### PR TITLE
removed superfluous member from stringbuffer struct

### DIFF
--- a/BasicsC/string-buffer.c
+++ b/BasicsC/string-buffer.c
@@ -779,7 +779,6 @@ void TRI_AppendDoubleStringBuffer (TRI_string_buffer_t * self, double attr) {
   }
   else if (attr == 0.0) {
     AppendChar(self, '0');
-    *self->_bufferPtr = '\0';
     return;
   }
 
@@ -829,7 +828,6 @@ void TRI_AppendDoubleStringBuffer (TRI_string_buffer_t * self, double attr) {
         if (pos > 2) { AppendChar(self, a3); }
         if (pos > 3) { AppendChar(self, a4); }
 
-        *self->_bufferPtr = '\0';
       }
 
       return;
@@ -857,7 +855,6 @@ void TRI_AppendDoubleStringBuffer (TRI_string_buffer_t * self, double attr) {
       AppendChar(self, '0');
     }
 
-    *self->_bufferPtr = '\0';
     return;
   }
 

--- a/BasicsC/string-buffer.h
+++ b/BasicsC/string-buffer.h
@@ -49,7 +49,6 @@ extern "C" {
 
 typedef struct TRI_string_buffer_s {
   char * _buffer;
-  char * _bufferPtr;
   ptrdiff_t _off;
   size_t _len;
 }

--- a/UnitTests/string-buffer-test.c
+++ b/UnitTests/string-buffer-test.c
@@ -244,6 +244,12 @@ void tst_smpl_utils () {
   TRI_AppendInteger3StringBuffer(&sb, 1234);
   cmp_str("234", sb._buffer, 1024, "append int3");
 
+  
+  TRI_AppendDoubleStringBuffer(&sb, 12.0);
+  cmp_str("23412", sb._buffer, 1024, "append int3");
+
+  TRI_AppendDoubleStringBuffer(&sb, -12.125);
+  cmp_str("23412-12.125", sb._buffer, 1024, "append int3");
 }
 
 void tst_report () {


### PR DESCRIPTION
looks like I wasn't nearly as careful as I should have been with the last pull. The purpose of changing the stringbuffer struct was to remove the "moving parts"/absolute addresses and replace them with length and offset. 

I forgot _bufferPtr (and even worse, I didn't remove all code accessing it)

sorry.
