### PR TITLE
issue #157: check for readline and ncurses headers, not only libraries

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -5450,7 +5450,6 @@ Doxygen/js/server/modules/%.c: @srcdir@/js/server/modules/%.js Doxygen/.setup-di
 	@python @top_srcdir@/Doxygen/Scripts/js2doxy.py $< > $@
 
 Doxygen/xml/%.md: Doxygen/xml/%.xml
-	echo "CREATING XML FROM MD!!!"
 	@python @top_srcdir@/Doxygen/Scripts/xml2md.py $< > $@
 
 ################################################################################

--- a/configure
+++ b/configure
@@ -7653,8 +7653,46 @@ fi
 fi
 
 if test "x$tr_NCURSES" != xyes;  then
-  as_fn_error $? "Please install the ncurses library" "$LINENO" 5
+  as_fn_error $? "Please install the ncurses library and header files" "$LINENO" 5
 fi
+
+
+for ac_header in curses.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "curses.h" "ac_cv_header_curses_h" "$ac_includes_default"
+if test "x$ac_cv_header_curses_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_CURSES_H 1
+_ACEOF
+ tr_NCURSES="yes"
+else
+  tr_NCURSES="no"
+fi
+
+done
+
+if test "x$tr_NCURSES" != xyes;  then
+  as_fn_error $? "Please install the ncurses header files" "$LINENO" 5
+fi
+
+for ac_header in term.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "term.h" "ac_cv_header_term_h" "$ac_includes_default"
+if test "x$ac_cv_header_term_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_TERM_H 1
+_ACEOF
+ tr_NCURSES="yes"
+else
+  tr_NCURSES="no"
+fi
+
+done
+
+if test "x$tr_NCURSES" != xyes;  then
+  as_fn_error $? "Please install the ncurses header files" "$LINENO" 5
+fi
+
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking NCURSES version" >&5
 $as_echo_n "checking NCURSES version... " >&6; }
@@ -7937,6 +7975,10 @@ fi
   fi
 fi
 
+if test "x$tr_READLINE" = xno;  then
+  as_fn_error $? "Please install readline support" "$LINENO" 5
+fi
+
 
 if test "x$tr_READLINE" = xyes;  then
 
@@ -7957,6 +7999,11 @@ _ACEOF
 $as_echo_n "checking READLINE version... " >&6; }
 eval "$ac_cpp conftest.$ac_ext" | fgrep "long sdnhg36ed" | awk '{print $4 "." $5}' > conftest.output
 TRI_READLINE_VERSION=`cat conftest.output`
+
+if test -z "$TRI_READLINE_VERSION"; then
+  as_fn_error $? "Readline support is not working. Please re-install readline support" "$LINENO" 5
+fi
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $TRI_READLINE_VERSION" >&5
 $as_echo "$TRI_READLINE_VERSION" >&6; }
 rm -f conftest*

--- a/m4/external.ncurses
+++ b/m4/external.ncurses
@@ -55,8 +55,23 @@ if test "x$tr_NCURSES" = xyes;  then
 fi
 
 if test "x$tr_NCURSES" != xyes;  then
-  AC_MSG_ERROR([Please install the ncurses library])
+  AC_MSG_ERROR([Please install the ncurses library and header files])
 fi
+
+dnl -----------------------------------------------------------------------------------------
+dnl check if ncurses headers are present
+dnl -----------------------------------------------------------------------------------------
+    
+AC_CHECK_HEADERS(curses.h, [tr_NCURSES="yes"], [tr_NCURSES="no"])
+if test "x$tr_NCURSES" != xyes;  then
+  AC_MSG_ERROR([Please install the ncurses header files])
+fi
+
+AC_CHECK_HEADERS(term.h, [tr_NCURSES="yes"], [tr_NCURSES="no"])
+if test "x$tr_NCURSES" != xyes;  then
+  AC_MSG_ERROR([Please install the ncurses header files])
+fi
+
 
 AC_MSG_CHECKING([NCURSES version])
 AC_MSG_RESULT([$TRI_NCURSES_VERSION])

--- a/m4/external.readline
+++ b/m4/external.readline
@@ -74,6 +74,10 @@ if test "x$tr_READLINE" = xyes -o "x$tr_READLINE" = xmaybe;  then
   fi
 fi
 
+if test "x$tr_READLINE" = xno;  then
+  AC_MSG_ERROR([Please install readline support])
+fi
+
 dnl -----------------------------------------------------------------------------------------
 dnl grep readline version number
 dnl -----------------------------------------------------------------------------------------
@@ -96,6 +100,11 @@ _ACEOF
 AC_MSG_CHECKING([READLINE version])
 eval "$ac_cpp conftest.$ac_ext" | fgrep "long sdnhg36ed" | awk '{print $4 "." $5}' > conftest.output
 TRI_READLINE_VERSION=`cat conftest.output`
+
+if test -z "$TRI_READLINE_VERSION"; then
+  AC_MSG_ERROR([Readline support is not working. Please re-install readline support])
+fi
+
 AC_MSG_RESULT([$TRI_READLINE_VERSION])
 rm -f conftest*
 


### PR DESCRIPTION
Delegates the problem of missing headers from make to configure.
