### PR TITLE
possible implementation for issue #213

### DIFF
--- a/arangod/RestHandler/RestEdgeHandler.cpp
+++ b/arangod/RestHandler/RestEdgeHandler.cpp
@@ -108,11 +108,14 @@ bool RestEdgeHandler::createDocument () {
     return false;
   }
 
+  bool found;
+  char const* forceStr = _request->value("waitForSync", found);
+  bool forceSync = found ? StringUtils::boolean(forceStr) : false;
+
   // edge
   TRI_document_edge_t edge;
 
   // extract the from
-  bool found;
   char const* from = _request->value("from", found);
 
   if (! found || *from == '\0') {
@@ -198,7 +201,7 @@ bool RestEdgeHandler::createDocument () {
   
   WriteTransaction trx(&ca);
 
-  TRI_doc_mptr_t const mptr = trx.primary()->createJson(trx.primary(), TRI_DOC_MARKER_EDGE, json, &edge, reuseId, false);
+  TRI_doc_mptr_t const mptr = trx.primary()->createJson(trx.primary(), TRI_DOC_MARKER_EDGE, json, &edge, reuseId, false, forceSync);
 
   trx.end();
 

--- a/arangod/RestHandler/RestImportHandler.cpp
+++ b/arangod/RestHandler/RestImportHandler.cpp
@@ -172,6 +172,7 @@ bool RestImportHandler::createByArray () {
   size_t numCreated = 0;
   size_t numError = 0;
   size_t numEmpty = 0;
+  const bool forceSync = false;
   
   vector<string> const& suffix = _request->suffix();
 
@@ -243,7 +244,7 @@ bool RestImportHandler::createByArray () {
 
     if (values) {      
       // now save the document
-      TRI_doc_mptr_t const mptr = trx.primary()->createJson(trx.primary(), TRI_DOC_MARKER_DOCUMENT, values, 0, reuseId, false);
+      TRI_doc_mptr_t const mptr = trx.primary()->createJson(trx.primary(), TRI_DOC_MARKER_DOCUMENT, values, 0, reuseId, false, forceSync);
       if (mptr._did != 0) {
         ++numCreated;
       }
@@ -287,6 +288,7 @@ bool RestImportHandler::createByList () {
   size_t numCreated = 0;
   size_t numError = 0;
   size_t numEmpty = 0;
+  const bool forceSync = false;
   
   vector<string> const& suffix = _request->suffix();
 
@@ -426,7 +428,7 @@ bool RestImportHandler::createByList () {
       }
 
       // now save the document
-      TRI_doc_mptr_t const mptr = trx.primary()->createJson(trx.primary(), TRI_DOC_MARKER_DOCUMENT, json, 0, reuseId, false);
+      TRI_doc_mptr_t const mptr = trx.primary()->createJson(trx.primary(), TRI_DOC_MARKER_DOCUMENT, json, 0, reuseId, false, forceSync);
       if (mptr._did != 0) {
         ++numCreated;
       }

--- a/arangod/VocBase/primary-collection.c
+++ b/arangod/VocBase/primary-collection.c
@@ -82,9 +82,10 @@ static bool IsEqualKeyDocument (TRI_associative_pointer_t* array, void const* ke
 static TRI_voc_did_t CreateLock (TRI_primary_collection_t* document,
                                  TRI_df_marker_type_e type,
                                  TRI_shaped_json_t const* json,
-                                 void const* data) {
+                                 void const* data,
+                                 bool forceSync) {
   document->beginWrite(document);
-  return document->create(document, type, json, data, 0, 0, true)._did;
+  return document->create(document, type, json, data, 0, 0, true, forceSync)._did;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -96,7 +97,8 @@ static TRI_doc_mptr_t CreateJson (TRI_primary_collection_t* collection,
                                   TRI_json_t const* json,
                                   void const* data,
                                   bool reuseId,
-                                  bool release) {
+                                  bool release,
+                                  bool forceSync) {
   TRI_shaped_json_t* shaped;
   TRI_doc_mptr_t result;
   TRI_voc_did_t did = 0;
@@ -122,7 +124,7 @@ static TRI_doc_mptr_t CreateJson (TRI_primary_collection_t* collection,
     }
   }
 
-  result = collection->create(collection, type, shaped, data, did, rid, release);
+  result = collection->create(collection, type, shaped, data, did, rid, release, forceSync);
 
   TRI_FreeShapedJson(collection->_shaper, shaped);
 
@@ -138,11 +140,12 @@ static int UpdateLock (TRI_primary_collection_t* document,
                        TRI_voc_did_t did,
                        TRI_voc_rid_t rid,
                        TRI_voc_rid_t* oldRid,
-                       TRI_doc_update_policy_e policy) {
+                       TRI_doc_update_policy_e policy,
+                       bool forceSync) {
   TRI_doc_mptr_t result;
 
   document->beginWrite(document);
-  result = document->update(document, json, did, rid, oldRid, policy, true);
+  result = document->update(document, json, did, rid, oldRid, policy, true, forceSync);
 
   if (result._did == 0) {
     return TRI_errno();
@@ -162,7 +165,8 @@ static TRI_doc_mptr_t UpdateJson (TRI_primary_collection_t* collection,
                                   TRI_voc_rid_t rid,
                                   TRI_voc_rid_t* oldRid,
                                   TRI_doc_update_policy_e policy,
-                                  bool release) {
+                                  bool release,
+                                  bool forceSync) {
   TRI_shaped_json_t* shaped;
   TRI_doc_mptr_t result;
 
@@ -174,7 +178,7 @@ static TRI_doc_mptr_t UpdateJson (TRI_primary_collection_t* collection,
     return result;
   }
 
-  result = collection->update(collection, shaped, did, rid, oldRid, policy, release);
+  result = collection->update(collection, shaped, did, rid, oldRid, policy, release, forceSync);
 
   TRI_FreeShapedJson(collection->_shaper, shaped);
 
@@ -189,9 +193,10 @@ static int DestroyLock (TRI_primary_collection_t* document,
                         TRI_voc_did_t did,
                         TRI_voc_rid_t rid,
                         TRI_voc_rid_t* oldRid,
-                        TRI_doc_update_policy_e policy) {
+                        TRI_doc_update_policy_e policy,
+                        bool forceSync) {
   document->beginWrite(document);
-  return document->destroy(document, did, rid, oldRid, policy, true);
+  return document->destroy(document, did, rid, oldRid, policy, true, forceSync);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/arangod/VocBase/primary-collection.h
+++ b/arangod/VocBase/primary-collection.h
@@ -329,18 +329,18 @@ typedef struct TRI_primary_collection_s {
   void (*createHeader) (struct TRI_primary_collection_s*, TRI_datafile_t*, TRI_df_marker_t const*, size_t, TRI_doc_mptr_t*, void const* data);
   void (*updateHeader) (struct TRI_primary_collection_s*, TRI_datafile_t*, TRI_df_marker_t const*, size_t, TRI_doc_mptr_t const*, TRI_doc_mptr_t*);
 
-  TRI_doc_mptr_t (*create) (struct TRI_primary_collection_s*, TRI_df_marker_type_e, TRI_shaped_json_t const*, void const*, TRI_voc_did_t, TRI_voc_rid_t, bool);
-  TRI_doc_mptr_t (*createJson) (struct TRI_primary_collection_s*, TRI_df_marker_type_e, TRI_json_t const*, void const*, bool, bool);
-  TRI_voc_did_t (*createLock) (struct TRI_primary_collection_s*, TRI_df_marker_type_e, TRI_shaped_json_t const*, void const*);
+  TRI_doc_mptr_t (*create) (struct TRI_primary_collection_s*, TRI_df_marker_type_e, TRI_shaped_json_t const*, void const*, TRI_voc_did_t, TRI_voc_rid_t, bool, bool);
+  TRI_doc_mptr_t (*createJson) (struct TRI_primary_collection_s*, TRI_df_marker_type_e, TRI_json_t const*, void const*, bool, bool, bool);
+  TRI_voc_did_t (*createLock) (struct TRI_primary_collection_s*, TRI_df_marker_type_e, TRI_shaped_json_t const*, void const*, bool);
 
   TRI_doc_mptr_t (*read) (struct TRI_primary_collection_s*, TRI_voc_did_t);
 
-  TRI_doc_mptr_t (*update) (struct TRI_primary_collection_s*, TRI_shaped_json_t const*, TRI_voc_did_t, TRI_voc_rid_t, TRI_voc_rid_t*, TRI_doc_update_policy_e, bool);
-  TRI_doc_mptr_t (*updateJson) (struct TRI_primary_collection_s*, TRI_json_t const*, TRI_voc_did_t, TRI_voc_rid_t, TRI_voc_rid_t*, TRI_doc_update_policy_e, bool);
-  int (*updateLock) (struct TRI_primary_collection_s*, TRI_shaped_json_t const*, TRI_voc_did_t, TRI_voc_rid_t, TRI_voc_rid_t*, TRI_doc_update_policy_e);
+  TRI_doc_mptr_t (*update) (struct TRI_primary_collection_s*, TRI_shaped_json_t const*, TRI_voc_did_t, TRI_voc_rid_t, TRI_voc_rid_t*, TRI_doc_update_policy_e, bool, bool);
+  TRI_doc_mptr_t (*updateJson) (struct TRI_primary_collection_s*, TRI_json_t const*, TRI_voc_did_t, TRI_voc_rid_t, TRI_voc_rid_t*, TRI_doc_update_policy_e, bool, bool);
+  int (*updateLock) (struct TRI_primary_collection_s*, TRI_shaped_json_t const*, TRI_voc_did_t, TRI_voc_rid_t, TRI_voc_rid_t*, TRI_doc_update_policy_e, bool);
 
-  int (*destroy) (struct TRI_primary_collection_s* collection, TRI_voc_did_t, TRI_voc_rid_t, TRI_voc_rid_t*, TRI_doc_update_policy_e, bool);
-  int (*destroyLock) (struct TRI_primary_collection_s* collection, TRI_voc_did_t, TRI_voc_rid_t, TRI_voc_rid_t*, TRI_doc_update_policy_e);
+  int (*destroy) (struct TRI_primary_collection_s* collection, TRI_voc_did_t, TRI_voc_rid_t, TRI_voc_rid_t*, TRI_doc_update_policy_e, bool, bool);
+  int (*destroyLock) (struct TRI_primary_collection_s* collection, TRI_voc_did_t, TRI_voc_rid_t, TRI_voc_rid_t*, TRI_doc_update_policy_e, bool);
 
   TRI_doc_collection_info_t* (*figures) (struct TRI_primary_collection_s* collection);
   TRI_voc_size_t (*size) (struct TRI_primary_collection_s* collection);


### PR DESCRIPTION
the attached commit presents a possible solution for this:
when using the HTTP POST/PUT/DELETE methods, the waitForSync URL parameter can be used to force synchronisation. If it is ommitted or set to false, everything will work as before: there will be synchronisation if the flag was set for the collection that is modified during the operation. 
If the waitForSync URL parameter is set to true, then synchronisation is forced after the operation, even if the collection-level flag is set to false.

That means one can use the flag to force synchronisation of individual operations in case that waitForSync is set to false on collection level. It cannot be used to turn off synchronisation for certain operations when waitForSync is set to true on collection level.

If we want to go ahead with this implementation, please pull this into devel.

Documentation for the changes is still missing as I wanted to avoid unnecessary work in case we discard the pull request.
