### PR TITLE
switched the order of FoxxManager & Foxx for didactic reasons

### DIFF
--- a/Documentation/UserManual/UserManual.md
+++ b/Documentation/UserManual/UserManual.md
@@ -18,8 +18,8 @@ ArangoDB's User Manual (@VERSION) {#UserManual}
 @CHAPTER_REF{Graphs}
 @CHAPTER_REF{Transactions}
 @CHAPTER_REF{UserManualReplication}
-@CHAPTER_REF{UserManualFoxxManager}
 @CHAPTER_REF{UserManualFoxx}
+@CHAPTER_REF{UserManualFoxxManager}
 @CHAPTER_REF{HandlingEndpoints}
 @CHAPTER_REF{CommandLine}
 @CHAPTER_REF{Glossary}


### PR DESCRIPTION
From my experience it is easier to learn Foxx by following the hello world example first and then getting familiar with FoxxManager. I would like to change the order of both chapters (Foxx & FoxxManager) in the manual to lead newbies in the right direction.
