### PR TITLE
foxx manual: renamed titles

### DIFF
--- a/Documentation/UserManual/Foxx.md
+++ b/Documentation/UserManual/Foxx.md
@@ -19,7 +19,7 @@ please continue.
 So let's get started, shall we?
 
 Overview
---------
+========
 
 The typical request to a Foxx application will work as follows (only conceptually,
 a lot of the steps are cached in reality):
@@ -44,8 +44,8 @@ methods.
 
 Now let's get into the details.
 
-Creating the application files
-------------------------------
+Your first Foxx app in 5 minutes - a step-by-step tutorial 
+==========================================================
 
 An application built with Foxx is written in JavaScript and deployed to 
 ArangoDB directly. ArangoDB serves this application, you do not need a 


### PR DESCRIPTION
and made them 'h1' so that they appear in the table of content (context: people kind of asking in the Google user group for a getting-starting introduction to Foxx)
