### PR TITLE
Graph.drop should check if vertices are used more than once

### DIFF
--- a/js/common/tests/shell-graph.js
+++ b/js/common/tests/shell-graph.js
@@ -68,6 +68,21 @@ function GraphCreationSuite() {
       graph.drop();
     },
 
+    testDroppingIfVertexCollectionIsUsedTwice : function () {
+      var Graph = require("org/arangodb/graph").Graph,
+        graph_name = "UnitTestsCollectionGraph",
+        other_graph_name = "UnitTestsCollectionOtherGraph",
+        vertex = "UnitTestsCollectionVertex",
+        edges = "UnitTestsCollectionEdge",
+        other_edges = "UnitTestsCollectionOtherEdges",
+        graph = new Graph(graph_name, vertex, edges),
+        other_graph = new Graph(other_graph_name, vertex, other_edges);
+
+      graph.drop();
+      assertTrue(arangodb.db._collection("UnitTestsCollectionVertex") !== null);
+      other_graph.drop();
+    },
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test: Find Graph
 ////////////////////////////////////////////////////////////////////////////////

--- a/js/server/modules/org/arangodb/graph.js
+++ b/js/server/modules/org/arangodb/graph.js
@@ -555,7 +555,10 @@ Graph.prototype.drop = function (waitForSync) {
 
   gdb.remove(this._properties, true, waitForSync);
 
-  this._vertices.drop();
+  if (gdb.byExample({vertices: this._vertices.name()}).count() === 0) {
+    this._vertices.drop();
+  }
+
   this._edges.drop();
 };
 


### PR DESCRIPTION
Graph.drop() should remove the vertex collection only, if it is not used in any other graph in "_graphs".
