### PR TITLE
Update arangorestore.conf.in

### DIFF
--- a/etc/arangodb/arangorestore.conf.in
+++ b/etc/arangodb/arangorestore.conf.in
@@ -2,4 +2,4 @@ progress = true
 
 [server]
 endpoint = tcp://localhost:8529
-disable-authentcation = true
+disable-authentication = true


### PR DESCRIPTION
Fixed typo causing:
`2013-11-29T10:58:40Z [2929] FATAL cannot parse config file '/etc/arangodb/arangorestore.conf': illegal option`
