### PR TITLE
App requires should be module-relative by default. Fixes #721

### DIFF
--- a/js/common/bootstrap/modules.js
+++ b/js/common/bootstrap/modules.js
@@ -1258,7 +1258,7 @@ function require (path) {
       libpath = fs.join(this._root, this._path, this._manifest[type]);
     }
     else {
-      libpath = fs.join(this._root, this._path, type);
+      libpath = fs.join(this._root, this._path);
     }
 
     var pkg = new Package("application",


### PR DESCRIPTION
This probably needs discussion if there are any known Foxx apps that rely on the default being "lib" as it would break compatibility.
