### PR TITLE
Added support for error names instead of error types

### DIFF
--- a/js/server/modules/org/arangodb/foxx/request_context.js
+++ b/js/server/modules/org/arangodb/foxx/request_context.js
@@ -60,7 +60,7 @@ createErrorBubbleWrap = function (handler, errorClass, code, reason, errorHandle
     try {
       handler(req, res);
     } catch (e) {
-      if (e instanceof errorClass) {
+      if ((typeof errorClass === 'string' && e.name === errorClass) || e instanceof errorClass) {
         res.status(code);
         res.json(errorHandler(e));
       } else {


### PR DESCRIPTION
In JavaScript, `Error` is not a real constructor. Regular constructors directly modify `this`, whereas `Error` always returns a new object. This makes it [a bit tricky](https://github.com/Ralt/newError) to create "real" Error sub-types.

Because of this a lot of libraries allow distinguishing errors by their `name` (which is also used by `Error` in stacktraces) instead of `instanceof`.

I think `errorResponse` would be more useful if it also allowed catching errors by their name. This change would be backwards-compatible with the `instanceof` check because `instanceof` always expects a constructor.
