### PR TITLE
Add vertex filtering to AQL's TRAVERSAL[_TREE]() function

### DIFF
--- a/js/server/modules/org/arangodb/ahuacatl.js
+++ b/js/server/modules/org/arangodb/ahuacatl.js
@@ -3765,7 +3765,7 @@ function TRAVERSAL_VERTEX_FILTER (config, vertex, path) {
   "use strict";
   
   if (!MATCHES(vertex, config.filterVertexExamples)) {
-    return config.vertexFilterType;
+    return config.vertexFilterMethod;
   }
 }
 
@@ -3841,7 +3841,7 @@ function TRAVERSAL_FUNC (func, vertexCollection, edgeCollection, startVertex, di
   if (params.filterVertices) {
     config.filter = TRAVERSAL_VERTEX_FILTER;
     config.filterVertexExamples = params.filterVertices;
-    config.vertexFilterType = params.vertexFilterType || ["prune","exclude"];
+    config.vertexFilterMethod = params.vertexFilterMethod || ["prune","exclude"];
   }
 
   if (params._sort) {


### PR DESCRIPTION
Example: 

``` javascript
return TRAVERSAL_TREE(collection, edges, "collection/id", "outbound", "children", {
     filterVertices : [{isDeleted:false}]

    // representative of the default value, ignored if filterVertices not present.
    ,vertexFilterMethod : ["prune","exclude"]
});
```
