### PR TITLE
Better Foxx.Model attribute handling (fixes #877 and #878)

### DIFF
--- a/js/server/tests/shell-foxx-model.js
+++ b/js/server/tests/shell-foxx-model.js
@@ -90,9 +90,80 @@ function ModelSpec () {
       };
 
       instance = new FoxxModel(raw);
+      var dbData = instance.forDB();
+      var clientData = instance.forClient();
 
-      assertEqual(instance.forDB(), raw);
-      assertEqual(instance.forClient(), raw);
+      Object.keys(raw).forEach(function(key) {
+        assertEqual(raw[key], dbData[key]);
+        assertEqual(raw[key], clientData[key]);
+      });
+    },
+
+    testFilterUnknownProperties: function () {
+      var Model = FoxxModel.extend({}, {
+        attributes: {
+          a: {type: 'integer'}
+        }
+      });
+
+      var raw = {
+        a: 1,
+        b: 2
+      };
+
+      instance = new Model(raw);
+      var dbData = instance.forDB();
+      var clientData = instance.forClient();
+
+      assertEqual(Object.keys(dbData).length, 1);
+      assertEqual(Object.keys(clientData).length, 1);
+      assertEqual(dbData.a, raw.a);
+      assertEqual(clientData.a, raw.a);
+    },
+
+    testFilterMetadata: function () {
+      var Model = FoxxModel.extend({}, {
+        attributes: {
+          a: {type: 'integer'}
+        }
+      });
+
+      var raw = {
+        a: 1,
+        _key: 2
+      };
+
+      instance = new Model(raw);
+      var dbData = instance.forDB();
+      var clientData = instance.forClient();
+
+      assertEqual(Object.keys(dbData).length, 2);
+      assertEqual(Object.keys(clientData).length, 1);
+      assertEqual(dbData.a, raw.a);
+      assertEqual(dbData._key, raw._key);
+      assertEqual(clientData.a, raw.a);
+    },
+
+    testFromClient: function () {
+      var Model = FoxxModel.extend({}, {
+        attributes: {
+          a: {type: 'integer'}
+        }
+      });
+
+      var raw = {
+        a: 1,
+        _key: 2
+      };
+
+      instance = Model.fromClient(raw);
+      var dbData = instance.forDB();
+      var clientData = instance.forClient();
+
+      assertEqual(Object.keys(dbData).length, 1);
+      assertEqual(Object.keys(clientData).length, 1);
+      assertEqual(dbData.a, raw.a);
+      assertEqual(clientData.a, raw.a);
     }
   };
 }


### PR DESCRIPTION
I've adjusted the whitelist logic in `Foxx.Model` to whitelist the metadata attributes by default. I have also added a `fromClient` static method that allows stripping the metadata when loading a model from an untrusted source and adjusted `forClient` so it also strips the metadata.

If any metadata attributes are defined on the constructor, they will be processed as normal.

I've also made sure `Model` and `Model.fromClient` _always_ set the `attributes` property to a fresh object to avoid the bug in #878.

The tests in `shell-foxx-model.js` have been adjusted accordingly.

This change introduces behaviour that may be break code relying on `forDB` not returning metadata attributes passed to the constructor when the model has attributes defined that do not include the metadata attributes. This seems like an edge case.
