### PR TITLE
Added fallback to allow requiring submodules (fixes #789)

### DIFF
--- a/js/common/bootstrap/modules.js
+++ b/js/common/bootstrap/modules.js
@@ -834,6 +834,17 @@ function require (path) {
       }
     }
 
+    // check if there is a package containing this module
+    path = path.substr(1);
+    if (path.indexOf('/') !== -1) {
+      var p = path.split('/');
+      localModule = requirePackage(currentModule, '/' + p.shift());
+      if (localModule !== null) {
+        localModule = requirePackage(localModule, '/' + p.join('/'));
+        return localModule;
+      }
+    }
+
     // nothing found
     return null;
   }


### PR DESCRIPTION
I've added a fallback in the `requirePackage` function to allow requiring sub-modules (e.g. `require('some-dependency/subfolder/filename')`, see #789). This should improve compatibility with `npm` modules that are meant to be used this way.

I'm not sure how to test this properly but I have tried it successfully with a local fixture.
