### PR TITLE
More sugary Foxx exports

### DIFF
--- a/js/server/modules/org/arangodb/foxx.js
+++ b/js/server/modules/org/arangodb/foxx.js
@@ -37,7 +37,7 @@ var Controller = require("org/arangodb/foxx/controller").Controller,
 exports.Controller = Controller;
 exports.Model = Model;
 exports.Repository = Repository;
-exports.app = function(path) {
+exports.requireApp = function(path) {
   return manager.mountedApp(arangodb.normalizeURL('/' + path));
 };
 


### PR DESCRIPTION
The current API for `require('org/arangodb/foxx/manager').mountedApp('/mount/point')` is a good start, but it could be friendlier. Foxx Apps don't normally mess with the `manager` module and the leading slash four mount paths can easily be missed (I can not think of a situation where it should not be provided).

This change allows using `require('org/arangodb/foxx').app('mount/point')` and cleans up missing/redundant slashes automagically, providing a more natural syntax.
