### PR TITLE
Allow controller-free Foxx apps

### DIFF
--- a/js/server/modules/org/arangodb/foxx/manager.js
+++ b/js/server/modules/org/arangodb/foxx/manager.js
@@ -121,7 +121,7 @@ function checkManifest (filename, mf) {
     "assets":             [ false, "object" ],
     "author":             [ false, "string" ],
     "contributors":       [ false, "array" ],
-    "controllers":        [ true, "object" ],
+    "controllers":        [ false, "object" ],
     "defaultDocument":    [ false, "string" ],
     "description":        [ true, "string" ],
     "engines":            [ false, "object" ],


### PR DESCRIPTION
Now that we have `exports` we should no longer require apps to have controllers.
