### PR TITLE
Foxx Controller dependency injection

### DIFF
--- a/js/server/modules/org/arangodb/foxx/controller.js
+++ b/js/server/modules/org/arangodb/foxx/controller.js
@@ -135,7 +135,7 @@ extend(Controller.prototype, {
     return this.applicationContext.collection(name);
   },
 
-  inject: function(name, factory) {
+  addInjector: function(name, factory) {
     if (factory === undefined) {
       _.extend(this.injectors, name);
     } else {

--- a/js/server/modules/org/arangodb/foxx/internals.js
+++ b/js/server/modules/org/arangodb/foxx/internals.js
@@ -89,7 +89,7 @@ constructRoute = function (method, route, callback, controller) {
   return {
     url: constructUrlObject(route, undefined, method),
     action: {
-      callback: function() {
+      callback: function(req, res) {
         Object.keys(controller.injectors).forEach(function(key) {
           if (Object.prototype.hasOwnProperty.call(controller.injected, key)) return;
           var injector = controller.injectors[key];
@@ -99,7 +99,7 @@ constructRoute = function (method, route, callback, controller) {
             controller.injected[key] = injector;
           }
         });
-        callback.apply(controller.injected, arguments);
+        callback(req, res, controller.injected);
       }
     },
     docs: {

--- a/js/server/tests/shell-foxx.js
+++ b/js/server/tests/shell-foxx.js
@@ -255,7 +255,7 @@ function ControllerInjectionSpec () {
         res = {},
         timesCalled = 0;
 
-      app.inject({thing: function() {timesCalled++;}});
+      app.addInjector({thing: function() {timesCalled++;}});
 
       app.get('/foxx', function () {});
 
@@ -270,7 +270,7 @@ function ControllerInjectionSpec () {
         res = {},
         timesCalled = 0;
 
-      app.inject('thing', function() {timesCalled++;});
+      app.addInjector('thing', function() {timesCalled++;});
 
       app.get('/foxx', function () {});
 
@@ -286,8 +286,8 @@ function ControllerInjectionSpec () {
         wrongFuncCalled = false,
         timesCalled = 0;
 
-      app.inject({thing: function() {wrongFuncCalled = true;}});
-      app.inject({thing: function() {timesCalled++;}});
+      app.addInjector({thing: function() {wrongFuncCalled = true;}});
+      app.addInjector({thing: function() {timesCalled++;}});
 
       app.get('/foxx', function () {});
 
@@ -305,10 +305,10 @@ function ControllerInjectionSpec () {
         calledB = false,
         calledC = false;
 
-      app.inject({thing: function() {calledA = true;}});
+      app.addInjector({thing: function() {calledA = true;}});
 
       app.get('/foxx', function () {
-        app.inject({
+        app.addInjector({
           thing: function() {calledB = true;},
           other: function() {calledC = true;}
         });
@@ -328,10 +328,10 @@ function ControllerInjectionSpec () {
         res = {},
         called = false;
 
-      app.inject({thing: function() {return 'value';}});
+      app.addInjector({thing: function() {return 'value';}});
 
-      app.get('/foxx', function () {
-        assertEqual(this.thing, 'value');
+      app.get('/foxx', function (req, res, injected) {
+        assertEqual(injected.thing, 'value');
         called = true;
       });
 
@@ -345,25 +345,25 @@ function ControllerInjectionSpec () {
         res = {},
         called = false;
 
-      var injectables = {
+      var injectors = {
         obj: {a: 0, b: 1},
         arr: ['one', 'two'],
         str: 'hello',
         num: 42
       };
 
-      app.inject(injectables);
+      app.addInjector(injectors);
 
-      app.get('/foxx', function () {
-        assertEqual(typeof this.obj, 'object');
-        assertEqual(typeof this.arr, 'object');
-        assertEqual(typeof this.str, 'string');
-        assertEqual(typeof this.num, 'number');
-        assertTrue(Array.isArray(this.arr));
-        assertEqual(this.obj, injectables.obj);
-        assertEqual(this.arr, injectables.arr);
-        assertEqual(this.str, injectables.str);
-        assertEqual(this.num, injectables.num);
+      app.get('/foxx', function (req, res, injected) {
+        assertEqual(typeof injected.obj, 'object');
+        assertEqual(typeof injected.arr, 'object');
+        assertEqual(typeof injected.str, 'string');
+        assertEqual(typeof injected.num, 'number');
+        assertTrue(Array.isArray(injected.arr));
+        assertEqual(injected.obj, injectors.obj);
+        assertEqual(injected.arr, injectors.arr);
+        assertEqual(injected.str, injectors.str);
+        assertEqual(injected.num, injectors.num);
         called = true;
       });
 


### PR DESCRIPTION
With the new Foxx exports we have a dependency problem when Foxx apps try to use (via `Foxx.requireApp` or `manager.mountedApp`) exports from apps before those are loaded.

The primary use case of requiring exports from other apps are controllers. Wrapping every reference to a `requireApp` import in a function adds unsightly clutter to otherwise perfectly readable route handling logic.

This PR adds an `inject` method to controllers to tidy things up a bit. Compare:

before:

``` js
function getUserStorage() {
  return Foxx.requireApp('users').userStorage;
}

controller.get('/users', function(req, res) {
  res.json(getUserStorage().list());
});
```

after:

``` js
controller.inject({
  users: function() {
    return Foxx.requireApp('users').userStorage;
  }
});

controller.get('/users', function(req, res) {
  res.json(this.users.list());
});
```

If the injected dependency is a function, its return value will be injected into the route's context ("`this`"), otherwise the dependency will be injected verbatim (if you really want to inject a function verbatim, just wrap it in another function).

The dependency factories (i.e. dependencies that are functions) are guaranteed not to be invoked until a route handler would be called (this solves the "app depending on other app to be mounted and ready" problem). Further, all dependency factories will have been invoked before that route handler itself is called (in other words: `this` is guaranteed to have all injected dependencies ready for use).

Also, each dependency factory will only be called exactly once. For consecutive requests, the result value is re-used. ~~**Note:** this could cause a race condition when two requests are served in two parallel threads at roughly the same time, calling the factory for each request seems wasteful but the proposed implementation is likely **not** thread-safe.~~ According to @fceller this shouldn't be a problem.
