### PR TITLE
Foxx API Documentation explorer doesn't show POST/PUT/PATCH bodies without bodyParam

### DIFF
--- a/js/server/modules/org/arangodb/foxx/controller.js
+++ b/js/server/modules/org/arangodb/foxx/controller.js
@@ -174,6 +174,11 @@ extend(Controller.prototype, {
 
     this.applicationContext.clearComments();
 
+    if (method === 'post' || method === 'put' || method === 'patch') {
+      var UndocumentedBody = require('org/arangodb/foxx').Model.extend();
+      requestContext.bodyParam("undocumented body", "Undocumented body param", UndocumentedBody);
+    }
+
     return requestContext;
   },
 

--- a/js/server/modules/org/arangodb/foxx/request_context.js
+++ b/js/server/modules/org/arangodb/foxx/request_context.js
@@ -144,12 +144,22 @@ extend(SwaggerDocs.prototype, {
     'use strict';
     this.models[jsonSchema.id] = jsonSchema;
 
-    this.docs.parameters.push({
-      name: paramName,
-      paramType: "body",
-      description: description,
-      dataType: jsonSchema.id
+    var param = _.find(this.docs.parameters, function (parameter) {
+      return parameter.name === 'undocumented body';
     });
+
+    if (_.isUndefined(param)) {
+      this.docs.parameters.push({
+        name: paramName,
+        paramType: "body",
+        description: description,
+        dataType: jsonSchema.id
+      });
+    } else {
+      param.name = paramName;
+      param.description = description;
+      param.dataType = jsonSchema.id;
+    }
   },
 
   addSummary: function (summary) {


### PR DESCRIPTION
If you define an app controller route for POST/PUT/PATCH and do not use `bodyParam`, the API Documentation explorer should provide a `textarea` (or the JSON builder widget) for the request body.
