### PR TITLE
Fix: Save (Update) on AQL query editor will now persist changes

### DIFF
--- a/js/apps/system/aardvark/frontend/js/views/queryView.js
+++ b/js/apps/system/aardvark/frontend/js/views/queryView.js
@@ -326,6 +326,7 @@
       e.stopPropagation();
       var inputEditor = ace.edit("aqlEditor");
       var saveName = $('#new-query-name').val();
+      var isUpdate = $('#modalButton1').text() === 'Update';
 
       if ($('#new-query-name').hasClass('invalid-input')) {
         return;
@@ -343,7 +344,7 @@
       $.each(this.customQueries, function (k, v) {
           if (v.name === saveName) {
             v.value = content;
-            quit = true;
+            quit = !isUpdate;
             return;
           }
         });
@@ -354,10 +355,12 @@
         return;
       }
 
-      this.customQueries.push({
-        name: saveName,
-        value: content
-      });
+      if (!isUpdate) {
+        this.customQueries.push({
+          name: saveName,
+          value: content
+        });
+      }
 
       window.modalView.hide();
 


### PR DESCRIPTION
In AQL Editor (web interface) if you make a change to an _existing_ AQL query the 'Save Query' dialog correctly shows 'Update' on the button but does not actually persist the change to local storage.  Well, now it does...
