### PR TITLE
AQL Editor: Query only on selected text if a selection exists.

### DIFF
--- a/js/apps/system/aardvark/frontend/js/views/queryView.js
+++ b/js/apps/system/aardvark/frontend/js/views/queryView.js
@@ -453,12 +453,15 @@
       this.customQueries = _.sortBy(this.customQueries, 'name');
     },
     submitQuery: function () {
-      this.switchTab("result-switch");
       var self = this;
-      var sizeBox = $('#querySize');
       var inputEditor = ace.edit("aqlEditor");
+      var selectedText = inputEditor.session.getTextRange(inputEditor.getSelectionRange());
+      
+      this.switchTab("result-switch");
+      
+      var sizeBox = $('#querySize');
       var data = {
-        query: inputEditor.getValue(),
+        query: selectedText || inputEditor.getValue(),
         batchSize: parseInt(sizeBox.val(), 10)
       };
       var outputEditor = ace.edit("queryOutput");


### PR DESCRIPTION
I'm tired of commenting out query text I don't want to execute... With this PR if you have a selection in the AQL Editor (web interface) only the _selected_ text is use for the query.  If there is no selection then all the text in the editor is used for the query.
