### PR TITLE
Allow printing any object recursively that doesn't override toString.

### DIFF
--- a/js/common/bootstrap/module-internal.js
+++ b/js/common/bootstrap/module-internal.js
@@ -1100,12 +1100,12 @@
       context.output += context.names[p];
     }
     else {
-      if (value instanceof Object) {
+      if (value instanceof Object || value.__proto__ === null) {
         context.seen.push(value);
         context.names.push(context.path);
       }
 
-      if (value instanceof Object) {
+      if (value instanceof Object || value.__proto__ === null) {
         if (customInspect && typeof value._PRINT === "function") {
           value._PRINT(context);
 
@@ -1117,7 +1117,7 @@
         else if (value instanceof Array) {
           printArray(value, context);
         }
-        else if (value.toString === Object.prototype.toString) {
+        else if (value.toString === Object.prototype.toString || value.__proto__ === null) {
           printObject(value, context);
 
           if (context.emit && context.output.length >= context.emit) {


### PR DESCRIPTION
The recursive console printing is currently useless for any object that doesn't specify its own `toString` method and doesn't have `Object.prototype` as its `[[Prototype]]`.

For example, the following will all print as `"[object Object]"`:

``` js
console.log(Object.create({some: 'other object'}));
console.log(new (function MyCtor() {}));
```

The following will even throw an exception:

``` js
console.log(Object.create(null)); // throws
// as will this:
var obj = Object.create(null);
obj.x = 'y';
console.log(obj); // throws
```

This PR changes the logic that decides whether to recursively print an object by looking at the object's `toString` method rather than its `__proto__` property (i.e. its `[[Prototype]]`). This means the print will still work as expected for built-in object types (`Date`, `RegExp`, etc) and any object that overrides its inherited `toString`. It also treats empty objects (i.e. objects that inherit from `null` rather than `Object.prototype`) as expected (i.e. the same way it treats regular objects).
