### PR TITLE
Fix escaping of asterisks in AQL documentation.

### DIFF
--- a/Documentation/Books/Users/Aql/Advanced.mdpp
+++ b/Documentation/Books/Users/Aql/Advanced.mdpp
@@ -32,11 +32,11 @@ Subqueries may also include other subqueries themselves.
 !SUBSECTION Variable expansion
 
 In order to access a named attribute from all elements in a list easily, AQL
-offers the shortcut operator [*] for variable expansion.
+offers the shortcut operator \[\*\] for variable expansion.
 
-Using the [*] operator with a variable will iterate over all elements in the
+Using the \[\*\] operator with a variable will iterate over all elements in the
 variable thus allowing to access a particular attribute of each element.  It is
-required that the expanded variable is a list.  The result of the [*]
+required that the expanded variable is a list.  The result of the \[\*\]
 operator is again a list.
 
     FOR u IN users

--- a/Documentation/Books/Users/Aql/Functions.mdpp
+++ b/Documentation/Books/Users/Aql/Functions.mdpp
@@ -120,7 +120,7 @@ For string processing, AQL offers the following functions:
   *separator* string. *null* values are ignored
 
 - *CHAR_LENGTH(value)*: Return the number of characters in *value*. This is
-  a synonym for LENGTH(value)*
+  a synonym for *LENGTH(value)*
 
 - *LOWER(value)*: Lower-case *value*
 
@@ -503,7 +503,7 @@ AQL supports the following functions to operate on document values:
   This will return *2*, because the third example matches, and because the 
   *return-index* flag is set to *true*.
 
-- *MERGE(document1, document2, ... *documentn)*: Merges the documents
+- *MERGE(document1, document2, ... \*documentn)*: Merges the documents
   in *document1* to *documentn* into a single document. If document attribute
   keys are ambiguous, the merged result will contain the values of the documents 
   contained later in the argument list.

--- a/Documentation/Books/Users/Aql/GraphOperations.mdpp
+++ b/Documentation/Books/Users/Aql/GraphOperations.mdpp
@@ -9,7 +9,7 @@ A lot of the following functions accept a vertex (or edge) example as parameter.
 * {}                : Returns all possible vertices for this graph
 * *idString*        : Returns the vertex/edge with the id *idString*
 * {*key1* : *value1*, *key2* : *value2*} : Returns the vertices/edges that match this example, which means that both have *key1* and *key2* with the corresponding attributes
-* {*key1.key2* : *value1*, *key3* : *value2*} : It is possible to chain keys which means that a document *{ key1 : {key2 : value1}, key3 : value2}* would be a match
+* {*key1.key2* : *value1*, *key3* : *value2*} : It is possible to chain keys, which means that a document *{key1 : {key2 : value1}, key3 : value2}* would be a match
 * [{*key1* : *value1*}, {*key2* : *value2*}] : Returns the vertices/edges that match one of the examples, which means that either *key1* or *key2* are set with the corresponding value
 
 !SUBSECTION The complexity of the shortest path algorithms

--- a/Documentation/Books/Users/Aql/Operators.mdpp
+++ b/Documentation/Books/Users/Aql/Operators.mdpp
@@ -135,9 +135,9 @@ The operator precedence in AQL is similar as in other familiar languages (lowest
 - *<*, *<=*, *>=*, *>* less than, less equal,
   greater equal, greater than
 - *+*, *-* addition, subtraction
-- \*, */*, *%* multiplication, division, modulus
+- *\**, */*, *%* multiplication, division, modulus
 - *!*, *+*, *-* logical negation, unary plus, unary minus
-- *[\]* expansion
+- *\[\*\]* expansion
 - *()* function call
 - *.* member access
 - *[]* indexed value access

--- a/Documentation/Books/Users/AqlExamples/Grouping.mdpp
+++ b/Documentation/Books/Users/AqlExamples/Grouping.mdpp
@@ -61,14 +61,14 @@ result document per distinct *age* value (let aside the *LIMIT*). For each group
 we have access to the matching document via the *usersByAge* variable introduced in
 the *COLLECT* statement. 
 
-!SUBSECTION list expander
+!SUBSECTION List Expander
 
 
 The *usersByAge* variable contains the full documents found, and as we're only 
-interested in user names, we'll use the list expander (*[\*]*) to extract just the 
+interested in user names, we'll use the list expander (*\[\*\]*) to extract just the 
 *name* attribute of all user documents in each group.
 
-The *[\*]* expander is just a handy short-cut. Instead of *usersByAge[\*].u.name* we 
+The *\[\*\]* expander is just a handy short-cut. Instead of *usersByAge\[\*\].u.name* we 
 could also write:
 
 ```js
@@ -174,7 +174,7 @@ FOR u IN users
 ```
 
 We have used the function *LENGTH* (returns the length of a list) here. This is the
-equivalent to SQL's *SELECT g, COUNT(*) FROM ... GROUP BY g*.
+equivalent to SQL's *SELECT g, COUNT(\*) FROM ... GROUP BY g*.
 In addition to *LENGTH* AQL also provides *MAX*, *MIN*, *SUM* and *AVERAGE* as 
 basic aggregation functions.
 


### PR DESCRIPTION
Asterisks need to be escaped with backslashes, but if surrounded by square brackets, the brackets need to be escaped as well. (Please test, github's markdown parses seems to be unable to do this at all, unless html tags are used.)

An italic list expander <i>[*]</i> needs to be written as: `*\[\*\]*`

Does not apply to parentheses it seems, but maybe other characters with special markdown meaning.
