### PR TITLE
Fix and unify asterisks, tested with GitBook.

### DIFF
--- a/Documentation/Books/Users/Aql/Advanced.mdpp
+++ b/Documentation/Books/Users/Aql/Advanced.mdpp
@@ -6,7 +6,7 @@ Wherever an expression is allowed in AQL, a subquery can be placed. A subquery
 is a query part that can introduce its own local variables without affecting
 variables and values in its outer scope(s).
 
-It is required that subqueries be put inside parentheses `(` and `)` to
+It is required that subqueries be put inside parentheses *(* and *)* to
 explicitly mark their start and end points:
 
 ```js
@@ -35,11 +35,11 @@ Subqueries may also include other subqueries themselves.
 !SUBSECTION Variable expansion
 
 In order to access a named attribute from all elements in a list easily, AQL
-offers the shortcut operator `[*]` for variable expansion.
+offers the shortcut operator <i>[\*]</i> for variable expansion.
 
-Using the `[*]` operator with a variable will iterate over all elements in the
+Using the <i>[\*]</i> operator with a variable will iterate over all elements in the
 variable thus allowing to access a particular attribute of each element.  It is
-required that the expanded variable is a list.  The result of the `[*]`
+required that the expanded variable is a list.  The result of the <i>[\*]</i>
 operator is again a list.
 
 ```js

--- a/Documentation/Books/Users/Aql/Basics.mdpp
+++ b/Documentation/Books/Users/Aql/Basics.mdpp
@@ -9,7 +9,7 @@ parser will return an error if it detects more than one data-modification
 operation in the same query or if it cannot figure out if the query is meant
 to be a data retrieval or a modification operation.
 
-AQL only allows *one* query in a single query string; Thus semicolons to
+AQL only allows *one* query in a single query string; thus semicolons to
 indicate the end of one query and separate multiple queries (as seen in SQL) are
 not allowed.
 
@@ -24,8 +24,9 @@ in quotes in order to be preserved.
 
 Comments can be embedded at any position in a query. The text contained in the
 comment is ignored by the AQL parser.
-Multi-line Comments cannot be nested. -> Subsequent comment starts within
-comments are ignored, ends will end the comment.
+
+Multi-line comments cannot be nested, which means subsequent comment starts within
+comments are ignored, comment ends will end the comment.
 
 AQL supports two types of comments:
 - Single line comments: These start with a double forward slash and end at

--- a/Documentation/Books/Users/Aql/DataModification.mdpp
+++ b/Documentation/Books/Users/Aql/DataModification.mdpp
@@ -13,7 +13,7 @@ iterate over a given list of documents. They can optionally be combined with
 *FILTER* statements and the like.
 
 Let's start with an example that modifies existing documents in a collection
-"users" that match some condition:
+*users* that match some condition:
 
     FOR u IN users
       FILTER u.status == 'not active'
@@ -26,14 +26,14 @@ stripped-down *update* query will work, too. It will *update* one document
 
     UPDATE "foo" WITH { status: 'inactive' } IN users
 
-Now, let's copy the contents of the collection "users" into the collection
-"backup":
+Now, let's copy the contents of the collection *users* into the collection
+*backup*:
 
     FOR u IN users
       INSERT u IN backup
 
-As a final example, let's find some documents in collection "users" and
-remove them from collection "backup". The link between the documents in both
+As a final example, let's find some documents in collection *users* and
+remove them from collection *backup*. The link between the documents in both
 collections is establish via the documents' keys:
 
     FOR u IN users
@@ -43,7 +43,7 @@ collections is establish via the documents' keys:
 
 !SUBSECTION Restrictions
 
-The name of the modified collection ("users" and "backup" in the above cases) 
+The name of the modified collection (*users* and *backup* in the above cases) 
 must be known to the AQL executor at query-compile time and cannot change at 
 runtime. Using a bind parameter to specify the [collection name](../Glossary/README.html#collection_name) is allowed.
 

--- a/Documentation/Books/Users/Aql/Functions.mdpp
+++ b/Documentation/Books/Users/Aql/Functions.mdpp
@@ -694,7 +694,7 @@ will fail with an error.
 
 AQL has the following functions to traverse graphs:
 
-**Warning Deprecated**
+**Warning: Deprecated**
 
 This query is deprecated and will be removed soon.
 Please use [Graph operations](../Aql/GraphOperations.md) instead.
@@ -726,7 +726,7 @@ Please use [Graph operations](../Aql/GraphOperations.md) instead.
         FILTER p.source._id == "123456/123456" && LENGTH(p.edges) == 2
         RETURN p.vertices[*].name
 
-**Warning Deprecated**
+**Warning: Deprecated**
 
 This query is deprecated and will be removed soon.
 Please use [Graph operations](../Aql/GraphOperations.md) instead.
@@ -867,7 +867,7 @@ Please use [Graph operations](../Aql/GraphOperations.md) instead.
         return [ ]; // include everything else
       }, false);
 
-**Warning Deprecated**
+**Warning: Deprecated**
 
 This query is deprecated and will be removed soon.
 Please use [Graph operations](../Aql/GraphOperations.md) instead.
@@ -896,7 +896,7 @@ If no bounds are set, a traversal may run into an endless loop in a cyclic graph
 and even in a non-cyclic graph, traversing far into the graph may consume a lot of processing
 time and memory for the result set.
 
-**Warning Deprecated**
+**Warning: Deprecated**
 
 This query is deprecated and will be removed soon.
 Please use [Graph operations](../Aql/GraphOperations.md) instead.
@@ -1018,7 +1018,7 @@ Please use [Graph operations](../Aql/GraphOperations.md) instead.
       EDGES(friendrelations, "friends/john", "outbound")
       EDGES(friendrelations, "friends/john", "any", [ { "$label": "knows" } ])
 
-**Warning Deprecated**
+**Warning: Deprecated**
 
 This query is deprecated and will be removed soon.
 Please use [Graph operations](../Aql/GraphOperations.md) instead.

--- a/Documentation/Books/Users/Aql/Operators.mdpp
+++ b/Documentation/Books/Users/Aql/Operators.mdpp
@@ -16,9 +16,9 @@ The following comparison operators are supported:
 - *<=* less or equal
 - *>*  greater than
 - *>=* greater or equal
-- *in* test if a value is contained in a list
+- *IN* test if a value is contained in a list
 
-The *in* operator expects the second operand to be of type list. All other
+The *IN* operator expects the second operand to be of type list. All other
 operators accept any data types for the first and second operands.
 
 Each of the comparison operators returns a boolean value if the comparison can
@@ -73,7 +73,7 @@ AQL supports the following arithmetic operators:
 
 - *+* addition
 - *-* subtraction
-- *** multiplication
+- <i>\*</i> multiplication
 - */* division
 - *%* modulus
 
@@ -131,13 +131,13 @@ The operator precedence in AQL is similar as in other familiar languages (lowest
 - *||* logical or
 - *&&* logical and
 - *==*, *!=* equality and inequality
-- *in* in operator
+- *IN* in operator
 - *<*, *<=*, *>=*, *>* less than, less equal,
   greater equal, greater than
 - *+*, *-* addition, subtraction
-- *\**, */*, *%* multiplication, division, modulus
+- <i>\*</i>, */*, *%* multiplication, division, modulus
 - *!*, *+*, *-* logical negation, unary plus, unary minus
-- *\[\*\]* expansion
+- <i>[\*]</i> expansion
 - *()* function call
 - *.* member access
 - *[]* indexed value access

--- a/Documentation/Books/Users/AqlExamples/Grouping.mdpp
+++ b/Documentation/Books/Users/AqlExamples/Grouping.mdpp
@@ -65,10 +65,10 @@ the *COLLECT* statement.
 
 
 The *usersByAge* variable contains the full documents found, and as we're only 
-interested in user names, we'll use the expansion operator `[*]` to extract just the 
+interested in user names, we'll use the expansion operator <i>[\*]</i> to extract just the 
 *name* attribute of all user documents in each group.
 
-The `[*]` expansion operator is just a handy short-cut. Instead of `usersByAge[*].u.name`
+The <i>[\*]</i> expansion operator is just a handy short-cut. Instead of <i>usersByAge[\*].u.name</i>
 we could also write:
 
 ```js
@@ -173,7 +173,7 @@ FOR u IN users
 ]
 ```
 
-We have used the function *LENGTH* (returns the length of a list) here. This is the
+We have used the function *LENGTH* here (it returns the length of a list). This is the
 equivalent to SQL's `SELECT g, COUNT(*) FROM ... GROUP BY g`.
 In addition to *LENGTH* AQL also provides *MAX*, *MIN*, *SUM* and *AVERAGE* as 
 basic aggregation functions.

--- a/Documentation/Books/Users/AqlExtending/Conventions.mdpp
+++ b/Documentation/Books/Users/AqlExtending/Conventions.mdpp
@@ -1,6 +1,6 @@
 !CHAPTER Conventions
 
-The **::** symbol is used inside AQL as the namespace separator. Using 
+The *::* symbol is used inside AQL as the namespace separator. Using 
 the namespace separator, users can create a multi-level hierarchy of 
 function groups if required.
 


### PR DESCRIPTION
Italic asterisks should be done by escaping the asterisk and wrapping it with html i-tag. It seems to be the only safe technique (3 asterisks to display 1 italic asterisk in a list works, unless followed by more markup for italic text; 1 escaped asterisk wrapped by i-tag works regardless of the rest of the line).
