### PR TITLE
Allow defining common properties shared by all routes handled by a controller

### DIFF
--- a/Documentation/Books/Users/Foxx/FoxxController.mdpp
+++ b/Documentation/Books/Users/Foxx/FoxxController.mdpp
@@ -78,6 +78,10 @@ API by chaining the following methods onto your path definition:
 <!-- js/server/modules/org/arangodb/foxx/request_context.js -->
 @startDocuBlock JSF_foxx_RequestContext_onlyIfAuthenticated
 
+!SUBSECTION Defining common properties
+<!-- js/server/modules/org/arangodb/foxx/controller.js -->
+@startDocuBlock JSF_foxx_controller_common
+
 !SECTION Documenting and constraining all routes
 
 In addition to documenting a specific route, you can also

--- a/js/server/modules/org/arangodb/foxx/controller.js
+++ b/js/server/modules/org/arangodb/foxx/controller.js
@@ -414,6 +414,43 @@ extend(Controller.prototype, {
   },
 
 ////////////////////////////////////////////////////////////////////////////////
+/// @startDocuBlock JSF_foxx_controller_common
+///
+/// `FoxxController#common(callback)`
+///
+/// Lets you define common properties shared by all route handlers of this
+/// controller. You can use this to define common error responses shared by all
+/// routes this controller defines.
+///
+/// @EXAMPLES
+///
+/// ```js
+/// app.common(function(routeHandler) {
+///   routeHandler.errorResponse(Unauthorized, 401, 'Not authenticated.');
+///   routeHandler.errorResponse(NotFound, 404, 'Document could not be found.');
+///   routeHandler.errorResponse(ServerError, 500, 'Something went wrong.');
+/// });
+/// ```
+///
+/// @endDocuBlock
+////////////////////////////////////////////////////////////////////////////////
+
+  common: function (callback) {
+    'use strict';
+    _.each(
+      ['head', 'get', 'post', 'put', 'patch', 'delete', 'del'],
+      function (method) {
+        var defineRouteHandler = this[method];
+        this[method] = function () {
+          var routeHandler = defineRouteHandler.apply(this, arguments);
+          callback(routeHandler);
+        };
+      },
+      this
+    );
+  },
+
+////////////////////////////////////////////////////////////////////////////////
 /// @startDocuBlock JSF_foxx_controller_around
 ///
 /// `FoxxController#around(path, callback)`


### PR DESCRIPTION
Currently there's no easy way to define error responses for errors shared by all route handlers of a controller, such as `DocumentNotFound` style errors, without specifying the `errorResponse` for each and every route.

In practice this discourages using `errorResponse` and leads to exceptions bubbling up all the way to ArangoDB's route handler which generates an ugly (but informative) stack trace plaintext response.

This proposed change would allow the following syntax:

``` js
var err = require('./my/api/errors');
ctrl.common(function (routeHandler) {
  routeHandler.errorResponse(err.Unauthorized, 401, 'Not authenticated.');
  routeHandler.errorResponse(err.NotFound, 404, 'Document not found.');
  routeHandler.errorResponse(err.ImATeapot, 418, 'I\'m a teapot.');
});

ctrl.get('/some/route', function (req, res) {
  // ...
  throw new err.NotFound('The document does not exist');
  // ...
}); // no errorResponse needed here

ctrl.get('/another/route', function (req, res) {
  // ...
  throw new err.NotFound('I made you a cookie but I ated it');
  // ...
}); // no errorResponse needed here either!
```

@fceller, @moonglum I'd welcome any input on this. I'm not sure about the name of this method but I think the functionality would seriously help avoiding redundancy in defining route handlers without breaking swagger.
