### PR TITLE
Allow ctrl.before to prevent further processing of the request

### DIFF
--- a/js/server/modules/org/arangodb/foxx/controller.js
+++ b/js/server/modules/org/arangodb/foxx/controller.js
@@ -371,8 +371,10 @@ extend(Controller.prototype, {
       url: {match: path},
       action: {
         callback: function (req, res, opts, next) {
-          func(req, res, opts);
-          next();
+          var result = func(req, res, opts);
+          if (result !== false) {
+            next();
+          }
         }
       }
     });


### PR DESCRIPTION
A useful (but apparently unintended) use of `ctrl.before` is to impose access restrictions.

Currently the only way to prevent further processing of a request in `ctrl.before` is to throw an exception. But this yields a route handling error, which results in a stacktrace returned as plaintext response. This is less than ideal.

This change allows `ctrl.before` callbacks to explicitly return `false` to prevent any further processing of the request. As the response body can be accessed in `ctrl.before` callbacks already, this also provides a workaround for use cases requiring intercepting all supported HTTP verbs in a single function.

Returning `false` to prevent further processing should be familiar to many JS devs from client-side event handling and libraries like `underscore`.

@moonglum, @fceller does this make any sense to you?
