### PR TITLE
docupdate userfunctions

### DIFF
--- a/js/common/modules/org/arangodb/aql/functions.js
+++ b/js/common/modules/org/arangodb/aql/functions.js
@@ -264,7 +264,7 @@ var unregisterFunctionsGroup = function (group) {
 /// and are the same for repeated calls with the same input values). It is not
 /// used at the moment but may be used for optimizations later.
 ///
-/// The registered function is stored in the *_stystem* db's collection *_aqlfunctions*.
+/// The registered function is stored in the *_system* db's collection *_aqlfunctions*.
 ///
 /// @EXAMPLES
 ///


### PR DESCRIPTION
Thought the functions are temporary and dont survive a reboot of the server. 
So I clarified that user defined functions are store in _system:_aqlfunctions.
As consequence: persistence :)

feel free to change the doc text.

the context http://docs.arangodb.org/AqlExtending/Functions.html
