### PR TITLE
Fixes compile issue on FreeBSD/clang

### DIFF
--- a/lib/Basics/logging.cpp
+++ b/lib/Basics/logging.cpp
@@ -1873,7 +1873,7 @@ TRI_log_appender_t* TRI_CreateLogAppenderSyslog (char const* name,
     value = atoi(facility);
   }
   else {
-    CODE * ptr = TRI_facilitynames;
+    CODE * ptr = (CODE *)TRI_facilitynames;
 
     while (ptr->c_name != 0) {
       if (strcmp(ptr->c_name, facility) == 0) {


### PR DESCRIPTION
```
lib/Basics/logging.cpp:1876:12: error: cannot initialize a variable of type 'CODE *' (aka '_code *') with an  value of type 'const CODE [25]'
    CODE * ptr = TRI_facilitynames;
           ^     ~~~~~~~~~~~~~~~~~
```

FreeBSD clang version 3.4.1 (tags/RELEASE_34/dot1-final 208032) 20140512
Target: x86_64-unknown-freebsd10.1
