### PR TITLE
Rename Repository#modelPrototype, add Repository#modelSchema

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,8 @@ v2.4.0 (XXXX-XX-XX)
   fetched from upstream in the presence of a LIMIT clause. This should
   generally improve performance.
 
+* deprecated `Repository#modelPrototype`. Use `Repository#model` instead.
+
 
 v2.3.0 (2014-11-18)
 -------------------

--- a/Documentation/Books/Users/Foxx/FoxxRepository.mdpp
+++ b/Documentation/Books/Users/Foxx/FoxxRepository.mdpp
@@ -86,9 +86,13 @@ ctrl.get("/:id", function(req, res) {
 
 @startDocuBlock JSF_foxx_repository_collection
 
-!SUBSECTION ModelPrototype
+!SUBSECTION Model
 
-@startDocuBlock JSF_foxx_repository_modelPrototype
+@startDocuBlock JSF_foxx_repository_model
+
+!SUBSECTION Model schema
+
+@startDocuBlock JSF_foxx_repository_modelSchema
 
 !SUBSECTION Prefix
 

--- a/js/server/modules/org/arangodb/foxx/repository.js
+++ b/js/server/modules/org/arangodb/foxx/repository.js
@@ -78,12 +78,39 @@ Repository = function (collection, opts) {
   this.collection = collection;
 
 ////////////////////////////////////////////////////////////////////////////////
-/// @startDocuBlock JSF_foxx_repository_modelPrototype
-/// The prototype of the according model.
+/// @startDocuBlock JSF_foxx_repository_model
+/// The model of this repository. Formerly called "modelPrototype".
 /// @endDocuBlock
 ////////////////////////////////////////////////////////////////////////////////
 
-  this.modelPrototype = this.options.model || Model;
+  this.model = this.options.model || Model;
+  Object.defineProperty(this, 'modelPrototype', {
+    configurable: true,
+    enumerable: true,
+    get: function () {
+      require('console').log('Repository#modelPrototype is deprecated, use Repository#model instead');
+      return this.model;
+    },
+    set: function (val) {
+      require('console').log('Repository#modelPrototype is deprecated, use Repository#model instead');
+      this.model = val;
+      return this.model;
+    }
+  });
+
+////////////////////////////////////////////////////////////////////////////////
+/// @startDocuBlock JSF_foxx_repository_modelSchema
+/// The schema of this repository's model.
+/// @endDocuBlock
+////////////////////////////////////////////////////////////////////////////////
+
+  Object.defineProperty(this, 'modelSchema', {
+    configurable: false,
+    enumerable: true,
+    get: function () {
+      return this.model.prototype.schema;
+    }
+  });
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @startDocuBlock JSF_foxx_repository_prefix
@@ -160,7 +187,7 @@ _.extend(Repository.prototype, {
   byId: function (id) {
     'use strict';
     var data = this.collection.document(id);
-    return (new this.modelPrototype(data));
+    return (new this.model(data));
   },
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -181,7 +208,7 @@ _.extend(Repository.prototype, {
     'use strict';
     var rawDocuments = this.collection.byExample(example).toArray();
     return _.map(rawDocuments, function (rawDocument) {
-      return (new this.modelPrototype(rawDocument));
+      return (new this.model(rawDocument));
     }, this);
   },
 
@@ -202,7 +229,7 @@ _.extend(Repository.prototype, {
   firstExample: function (example) {
     'use strict';
     var rawDocument = this.collection.firstExample(example);
-    return (new this.modelPrototype(rawDocument));
+    return (new this.model(rawDocument));
   },
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -242,7 +269,7 @@ _.extend(Repository.prototype, {
       rawDocuments = rawDocuments.limit(options.limit);
     }
     return _.map(rawDocuments.toArray(), function (rawDocument) {
-      return (new this.modelPrototype(rawDocument));
+      return (new this.model(rawDocument));
     }, this);
   },
 
@@ -514,7 +541,7 @@ var indexPrototypes = {
       'use strict';
       var rawDocuments = this.collection.range(attribute, left, right).toArray();
       return _.map(rawDocuments, function (rawDocument) {
-        return (new this.modelPrototype(rawDocument));
+        return (new this.model(rawDocument));
       }, this);
     }
   },
@@ -567,7 +594,7 @@ var indexPrototypes = {
         rawDocuments = rawDocuments.limit(options.limit);
       }
       return _.map(rawDocuments.toArray(), function (rawDocument) {
-        var model = (new this.modelPrototype(rawDocument)),
+        var model = (new this.model(rawDocument)),
           distance;
         if (options.distance) {
           delete model.attributes._distance;
@@ -627,7 +654,7 @@ var indexPrototypes = {
         rawDocuments = rawDocuments.limit(options.limit);
       }
       return _.map(rawDocuments.toArray(), function (rawDocument) {
-        var model = (new this.modelPrototype(rawDocument)),
+        var model = (new this.model(rawDocument)),
           distance;
         if (options.distance) {
           delete model.attributes._distance;
@@ -676,7 +703,7 @@ var indexPrototypes = {
         rawDocuments = rawDocuments.limit(options.limit);
       }
       return _.map(rawDocuments.toArray(), function (rawDocument) {
-        return (new this.modelPrototype(rawDocument));
+        return (new this.model(rawDocument));
       }, this);
     }
   }


### PR DESCRIPTION
I don't know why `Repository#modelPrototype` is called the way it is, but it's clearly wrong as it's actually referring to the model itself (i.e. the constructor), not the model's prototype.

I took the liberty of renaming it to `Repository#model` and adding an accessor property that logs a deprecation warning. This allows maintaining backwards compatibility while discouraging the use of `Repository#modelPrototype` (so we can use it for something else in the future).

I also added a getter for the model's schema, as that is something one may want to use occasionally (e.g. for `queryParam` or `pathParam` validation) and currently you have to access it via the model's (actual) prototype, which can be unwieldy.

We should make sure nothing in Foxx (or the bundled apps) uses `modelPrototype` before we merge this.
