### PR TITLE
GET /_api/collection/{collection-name} returns also 'isSystem' attribute

### DIFF
--- a/js/actions/api-collection.js
+++ b/js/actions/api-collection.js
@@ -445,6 +445,8 @@ function get_api_collections (req, res) {
 ///   - 2: document collection (normal case)
 ///   - 3: edges collection
 ///
+/// - *isSystem*: If *true* then the collection is a system collection.
+///
 /// @RESTRETURNCODES
 ///
 /// @RESTRETURNCODE{404}


### PR DESCRIPTION
Add 'isSystem' attribute to result description of GET /_api/collection/{collection-name} operation.
