### PR TITLE
Increase the width of the new node modal

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/css/bootstrap.css
+++ b/js/apps/system/_admin/aardvark/APP/frontend/css/bootstrap.css
@@ -4904,8 +4904,8 @@ input[type="submit"].btn::-moz-focus-inner {
   top: 10%;
   left: 50%;
   z-index: 1050;
-  width: 560px;
-  margin-left: -280px;
+  width: 640px;
+  margin-left: -320px;
   background-color: #ffffff;
   border: 1px solid rgba(0, 0, 0, 0.3);
   -webkit-border-radius: 6px;


### PR DESCRIPTION
I made the "new node" modal dialog a little wider. It is now wide enough that scrolling is no longer
necessary when adding attributes to new nodes.
It does not seem to have messed up any of the other modals and seems fine in FF/Chrome.

