### PR TITLE
lib/SimpleHttpClient: don't reset timeout after EINTR

### DIFF
--- a/lib/SimpleHttpClient/ClientConnection.cpp
+++ b/lib/SimpleHttpClient/ClientConnection.cpp
@@ -173,10 +173,10 @@ bool ClientConnection::prepare (double timeout, bool isWrite) const {
     return false;
   }
 
-  do {
-    tv.tv_sec = (long) timeout;
-    tv.tv_usec = (long) ((timeout - (double) tv.tv_sec) * 1000000.0);
+  tv.tv_sec = (long) timeout;
+  tv.tv_usec = (long) ((timeout - (double) tv.tv_sec) * 1000000.0);
 
+  do {
     FD_ZERO(&fdset);
     FD_SET(TRI_get_fd_or_handle_of_socket(_socket), &fdset);
 

--- a/lib/SimpleHttpClient/SslClientConnection.cpp
+++ b/lib/SimpleHttpClient/SslClientConnection.cpp
@@ -269,10 +269,10 @@ bool SslClientConnection::prepare (double timeout, bool isWrite) const {
   fd_set fdset;
   int res;
 
-  do {
-    tv.tv_sec = (long) timeout;
-    tv.tv_usec = (long) ((timeout - (double) tv.tv_sec) * 1000000.0);
+  tv.tv_sec = (long) timeout;
+  tv.tv_usec = (long) ((timeout - (double) tv.tv_sec) * 1000000.0);
 
+  do {
     FD_ZERO(&fdset);
     FD_SET(TRI_get_fd_or_handle_of_socket(_socket), &fdset);
 


### PR DESCRIPTION
select() modifies the given timeout variable.  Calling select() again
will run with the remaining timeout.  However, method prepare()
overwrote the reduced timeout in each iteration.