### PR TITLE
Documentation should be expanded by default

### DIFF
--- a/js/server/assets/swagger/index-alt.html
+++ b/js/server/assets/swagger/index-alt.html
@@ -31,7 +31,6 @@
         dom_id: "swagger-ui-container",
         supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
         onComplete: function(swaggerApi, swaggerUi){
-          $('#resources').children().addClass('active').find('.endpoints').show();
           $('pre code').each(function(i, e) {
             hljs.highlightBlock(e)
           });
@@ -39,7 +38,7 @@
         onFailure: function(data) {
           log("Unable to Load SwaggerUI");
         },
-        docExpansion: "none",
+        docExpansion: "list",
         sorter : "alpha"
       });
 

--- a/js/server/assets/swagger/index.html
+++ b/js/server/assets/swagger/index.html
@@ -47,7 +47,7 @@
         onFailure: function(data) {
           log("Unable to Load SwaggerUI");
         },
-        docExpansion: "none",
+        docExpansion: "list",
         sorter : "alpha"
       });
 


### PR DESCRIPTION
https://github.com/swagger-api/swagger-ui#parameters

This was hacked in `onComplete` function for the admin documentation, but for the mounted documentation it was always unfolded. Swagger 2.0 has a configuration parameter for this.