### PR TITLE
Git ignore for CMAKE generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,22 @@ core
 TAGS
 tags
 
+CMakeCache.txt
+CMakeFiles/
+CPackConfig.cmake
+CPackSourceConfig.cmake
+CTestTestfile.cmake
+UnitTests/CMakeFiles/
+UnitTests/CTestTestfile.cmake
+UnitTests/cmake_install.cmake
+arangod/CMakeFiles/
+arangod/cmake_install.cmake
+arangosh/CMakeFiles/
+arangosh/cmake_install.cmake
+cmake_install.cmake
+lib/CMakeFiles/
+lib/cmake_install.cmake
+
 Documentation/Examples/*.generated
 Documentation/Books/Users/book.json
 Documentation/Books/Users/manual.epub


### PR DESCRIPTION
If using cmake, same files are generated.
It would be easier to just `git add .` for new files and not checking for `Untracked files`