### PR TITLE
Make version more prominent in documentation

### DIFF
--- a/Documentation/Books/Makefile
+++ b/Documentation/Books/Makefile
@@ -58,8 +58,9 @@ build-book:
 	done
 	python generateMdFiles.py $(NAME) ppbooks/
 
-	cd ppbooks/$(NAME) && sed -ie 's/VERSION_NUMBER/$(newVersionNumber)/g' styles/header.js
-	cd ppbooks/$(NAME) && sed -ie 's/VERSION_NUMBER/$(newVersionNumber)/g' README.md
+	cd ppbooks/$(NAME) && sed -ie 's/VERSION_NUMBER/v$(newVersionNumber)/g' styles/header.js
+	cd ppbooks/$(NAME) && sed -ie 's/VERSION_NUMBER/v$(newVersionNumber)/g' README.md
+	cd ppbooks/$(NAME) && sed -ie 's/VERSION_NUMBER/v$(newVersionNumber)/g' book.json
 
 	test -d books/$(NAME) || mkdir -p books/$(NAME)
 

--- a/Documentation/Books/Users/README.mdpp
+++ b/Documentation/Books/Users/README.mdpp
@@ -1,6 +1,6 @@
-!BOOK ArangoDB Documentation
+!BOOK ArangoDB VERSION_NUMBER Documentation
 
-Welcome to the ArangoDB *VERSION_NUMBER* documentation!
+Welcome to the ArangoDB documentation!
 
 The documentation introduces ArangoDB for you as a user, developer and administrator and describes all of its functions in detail. 
 

--- a/Documentation/Books/Users/book.json
+++ b/Documentation/Books/Users/book.json
@@ -1,6 +1,6 @@
 {
   "gitbook": ">=2.0.0",
-  "title": "ArangoDB Documentation",
+  "title": "ArangoDB VERSION_NUMBER Documentation",
   "language": "en",
   "plugins":["expandable-chapters", "addcssjs"],
   "pdf": {


### PR DESCRIPTION
Many ebook readers (and reading apps) generate covers from metadata like the book title. Therefore it makes sense to place the version string there instead of the first paragraph.

![Imgur](http://i.imgur.com/LciZaqs.png?1)

Not sure what it tries to read from the book metadata below the title on the right side ("*Unknown*"), maybe it's the description?
http://help.gitbook.com/format/configuration.html#description