### PR TITLE
Minor documentation fixes

### DIFF
--- a/js/common/modules/org/arangodb/arango-collection-common.js
+++ b/js/common/modules/org/arangodb/arango-collection-common.js
@@ -311,7 +311,7 @@ ArangoCollection.prototype.byExample = function (example) {
 /// `collection.byExampleHash(index, example)`
 ///
 /// Selects all documents from the specified hash index that match the
-/// specified example example and returns a cursor.
+/// specified example and returns a cursor.
 ///
 /// You can use *toArray*, *next*, or *hasNext* to access the
 /// result. The result can be limited using the *skip* and *limit*
@@ -361,10 +361,10 @@ ArangoCollection.prototype.byExampleHash = function (index, example) {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief constructs a query-by-example using a skiplist index
 /// @startDocuBlock collectionByExampleSkiplist
-/// `collection}.byExampleSkiplist(index, example)
+/// `collection.byExampleSkiplist(index, example)`
 ///
 /// Selects all documents from the specified skiplist index that match the
-/// specified example example and returns a cursor.
+/// specified example and returns a cursor.
 ///
 /// You can use *toArray*, *next*, or *hasNext* to access the
 /// result. The result can be limited using the *skip* and *limit*
@@ -399,7 +399,7 @@ ArangoCollection.prototype.byExampleHash = function (index, example) {
 ///
 /// will match.
 ///
-/// `collection.byExampleHash(index-id, path1, value1, ...)`
+/// `collection.byExampleSkiplist(index, path1, value1, ...)`
 /// @endDocuBlock
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/js/server/modules/org/arangodb/arango-database.js
+++ b/js/server/modules/org/arangodb/arango-database.js
@@ -282,8 +282,8 @@ ArangoDatabase.prototype._truncate = function(name) {
 /// So you've created an index, and since its maintainance isn't for free,
 /// you definitely want to know whether your Query can utilize it.
 ///
-/// You can use explain to verify whether **skiplist** or **hash indices** are used:
-/// (if you ommit `colors: false` you will get nice colors on ArangoSH)
+/// You can use explain to verify whether **skiplist** or **hash indices** are used
+/// (if you ommit `colors: false` you will get nice colors in ArangoShell):
 ///
 /// @EXAMPLE_ARANGOSH_OUTPUT{IndexVerify}
 /// ~db._create("example");


### PR DESCRIPTION
Yet to be fixed:

1. `... has an attribute @LIT{c} of ... `:<br>
    `@LIT{c}` appears literally in documentation, is it resolved if used in .cpp/.h only?
2. `byExampleSkiplist()` and `byExampleHash()` list alternative signatures without further explanation, and do not actually implement it. They only pass the *example* argument on:

          var sq = this.byExample(example);

    Required change to support `.byExample*(index-id, "foo", 5, "bar", 1337)` as alternative to `(index-id, {foo: 5, bar: 1337})`:

        var sq = this.byExample.apply(this, Array.prototype.slice.call(arguments).slice(1))

    but better check arguments.length and don't apply/call if there are only 2 arguments, for better performance. But is it supposed to the implemented at all?