### PR TITLE
Documentation formatting

### DIFF
--- a/Documentation/Books/Users/Advanced/Arangob.mdpp
+++ b/Documentation/Books/Users/Advanced/Arangob.mdpp
@@ -70,6 +70,7 @@ Related blog posts:
     - multitrx
     - multi-collection
     - aqlinsert
+    - aqlv8
 
 - *--verbose*: Print out replies if the HTTP header indicates DB errors.
   (default: false).

--- a/Documentation/Books/Users/Aql/Advanced.mdpp
+++ b/Documentation/Books/Users/Aql/Advanced.mdpp
@@ -48,7 +48,7 @@ operator is again an array.
 To demonstrate the array expansion operator, let's go on with the following three 
 example *users* documents:
 
-```
+```json
 [ 
   { 
     name: "john",
@@ -88,7 +88,7 @@ FOR u IN users
 
 This will produce:
 
-```
+```json
 [ 
   { "name" : "john", "friends" : [ "tina", "helga", "alfred" ] }, 
   { "name" : "yves", "friends" : [ "sergei", "tiffany" ] }, 
@@ -129,7 +129,7 @@ FOR u IN users
 
 The above will return:
 
-```
+```json
 [ 
   [ 
     "tina is a friend of john", 
@@ -162,7 +162,7 @@ FOR u IN users
 
 As we have multiple users, the overall result is a nested array:
 
-```
+```json
 [ 
   [ 
     "tina", 
@@ -194,13 +194,14 @@ RETURN (
 ```
 
 By now appending the <i>[\*\*]</i> operator the end of the query, the query result becomes:
+
 ```
 RETURN (
   FOR u IN users RETURN u.friends[*].name
 )[**]
 ```
 
-```
+```json
 [ 
   [ 
     "tina", 

--- a/Documentation/man1/arangob
+++ b/Documentation/man1/arangob
@@ -26,7 +26,7 @@ total number of requests to perform ENDOPTION
 OPTION "--test-case <string>"
 name of test case to perform (possible values: version, document, collection,
 import-document, hash, skiplist, edge, shapes, shapes-append, random-shapes, crud,
-crud-append, crud-write-read, aqltrx, counttrx, multitrx, multi-collection, aqlinsert) ENDOPTION
+crud-append, crud-write-read, aqltrx, counttrx, multitrx, multi-collection, aqlinsert, aqlv8) ENDOPTION
 OPTION "--complexity <int32>"
 complexity value for test case (meaning depends on test case) ENDOPTION
 OPTION "--server.endpoint <string>"

--- a/js/server/modules/org/arangodb/aql.js
+++ b/js/server/modules/org/arangodb/aql.js
@@ -6670,14 +6670,14 @@ function IS_EXAMPLE_SET (example) {
 ///   If no default is supplied the default would be positive Infinity so the path could
 ///   not be calculated.
 ///   * *stopAtFirstMatch*                 : Only useful if targetVertices is an example that matches 
-///                                          to more than one vertex. If so only the shortest path to
-///                                          the closest of these target vertices is returned.
-///                                          This flag is of special use if you have target pattern and
-///                                          you want to know which vertex with this pattern is matched first.
+///   to more than one vertex. If so only the shortest path to
+///   the closest of these target vertices is returned.
+///   This flag is of special use if you have target pattern and
+///   you want to know which vertex with this pattern is matched first.
 ///   * *includeData*                      : Triggers if only *_id*'s are returned (*false*, default)
-///                                          or if data is included for all objects as well (*true*)
-///                                          This will modify the content of *vertex*, *path.vertices*
-///                                          and *path.edges*. 
+///   or if data is included for all objects as well (*true*)
+///   This will modify the content of *vertex*, *path.vertices*
+///   and *path.edges*. 
 ///
 /// NOTE: Since version 2.6 we have included a new optional parameter *includeData*.
 /// This parameter triggers if the result contains the real data object *true* or
@@ -7402,7 +7402,7 @@ function AQL_NEIGHBORS (vertexCollection,
 ///
 /// * *graphName*          : The name of the graph as a string.
 /// * *vertexExample*      : An example for the desired
-///                          vertices (see [example](#short_explanation_of_the_example_parameter)).
+///   vertices (see [example](#short_explanation_of_the_example_parameter)).
 /// * *options*            : An object containing the following options:
 ///   * *direction*                        : The direction
 ///     of the edges. Possible values are *outbound*, *inbound* and *any* (default).
@@ -7859,8 +7859,8 @@ function AQL_GRAPH_VERTICES (graphName,
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @startDocuBlock JSF_aql_general_graph_common_neighbors
-/// *The GRAPH\_COMMON\_NEIGHBORS function returns all common neighbors of the vertices
-/// defined by the examples.*
+/// The GRAPH\_COMMON\_NEIGHBORS function returns all common neighbors of the vertices
+/// defined by the examples.
 ///
 /// `GRAPH_COMMON_NEIGHBORS (graphName, vertex1Example, vertex2Examples,
 /// optionsVertex1, optionsVertex2)`


### PR DESCRIPTION
8 or spaces of indentation create a code block in markdown, but wasn't intended