### PR TITLE
documentation: point out the User Function is defined on the selected database

### DIFF
--- a/Documentation/Books/Users/AqlExtending/Conventions.mdpp
+++ b/Documentation/Books/Users/AqlExtending/Conventions.mdpp
@@ -82,7 +82,8 @@ to undefined behavior and should be avoided.
 !SECTION Miscellaneous
 
 Internally, user functions are stored in a system collection named
-*_aqlfunctions*. That means that by default they are excluded from dumps
+*_aqlfunctions*  of the selected database. 
+That means that by default they are excluded from dumps
 created with [arangodump](../HttpBulkImports/Arangodump.md).
 To include AQL user functions in a dump, the dump should be started
 with the option *--include-system-collections true*.

--- a/Documentation/Books/Users/AqlExtending/Functions.mdpp
+++ b/Documentation/Books/Users/AqlExtending/Functions.mdpp
@@ -1,7 +1,7 @@
 !CHAPTER Registering and Unregistering User Functions
 
-AQL user functions can be registered using the *aqlfunctions* object as
-follows:
+AQL user functions can be registered  in the selected database 
+using the *aqlfunctions* object as follows:
 
 ```js
 var aqlfunctions = require("@arangodb/aql/functions");

--- a/Documentation/Books/Users/AqlExtending/README.mdpp
+++ b/Documentation/Books/Users/AqlExtending/README.mdpp
@@ -4,9 +4,9 @@ AQL comes with a built-in set of functions, but it is not a
 fully-featured programming language.
 
 To add missing functionality or to simplify queries, users
-may add their own functions to AQL. These functions can be written
-in JavaScript, and must be registered via the API; 
-see [Registering Functions](../AqlExtending/Functions.md).
+may add their own functions to AQL in the selected database. 
+These functions can be written in JavaScript, and must be 
+registered via the API; see [Registering Functions](../AqlExtending/Functions.md).
 
 In order to avoid conflicts with existing or future built-in 
 function names, all user functions must be put into separate


### PR DESCRIPTION
documentation change: point out that  AQL User Functions are defined on the selected database (not globally)