### PR TITLE
Implement edgeCollection.save shorthand

### DIFF
--- a/arangod/V8Server/v8-collection.cpp
+++ b/arangod/V8Server/v8-collection.cpp
@@ -962,7 +962,7 @@ static void InsertVocbaseCol(TRI_vocbase_col_t* col, uint32_t argOffset,
   TRI_GET_GLOBALS();
 
   if (argLength < 1 || argLength > 2) {
-    TRI_V8_THROW_EXCEPTION_USAGE("insert(<data>, [<waitForSync>])");
+    TRI_V8_THROW_EXCEPTION_USAGE("save(<data>, [<waitForSync>])");
   }
 
   InsertOptions options;
@@ -1116,7 +1116,7 @@ static void InsertVocbaseVPack(
   TRI_GET_GLOBALS();
 
   if (argLength < 1 || argLength > 2) {
-    TRI_V8_THROW_EXCEPTION_USAGE("insert(<data>, [<waitForSync>])");
+    TRI_V8_THROW_EXCEPTION_USAGE("save(<data>, [<waitForSync>])");
   }
 
   InsertOptions options;
@@ -2716,7 +2716,7 @@ static void InsertVocbaseColCoordinator(
   // Now get the arguments
   uint32_t const argLength = args.Length() - argOffset;
   if (argLength < 1 || argLength > 2) {
-    TRI_V8_THROW_EXCEPTION_USAGE("insert(<data>, [<waitForSync>])");
+    TRI_V8_THROW_EXCEPTION_USAGE("save(<data>, [<waitForSync>])");
   }
 
   InsertOptions options;
@@ -2987,7 +2987,7 @@ static void InsertEdgeColCoordinator(
   uint32_t const argLength = args.Length() - argOffset;
   if (argLength < 3 || argLength > 4) {
     TRI_V8_THROW_EXCEPTION_USAGE(
-        "insert(<from>, <to>, <data>, [<waitForSync>])");
+        "save(<from>, <to>, <data>, [<waitForSync>])");
   }
 
   std::string _from = GetId(args, argOffset);
@@ -4080,7 +4080,7 @@ void TRI_InitV8collection(v8::Handle<v8::Context> context, TRI_server_t* server,
                        JS_ExistsVocbaseCol);
   TRI_AddMethodVocbase(isolate, rt, TRI_V8_ASCII_STRING("figures"),
                        JS_FiguresVocbaseCol);
-  TRI_AddMethodVocbase(isolate, rt, TRI_V8_ASCII_STRING("insert"),
+  TRI_AddMethodVocbase(isolate, rt, TRI_V8_ASCII_STRING("_insert"),
                        JS_InsertVocbaseCol);
   TRI_AddMethodVocbase(isolate, rt, TRI_V8_ASCII_STRING("insertv"),
                        JS_InsertVocbaseVPack);
@@ -4106,9 +4106,6 @@ void TRI_InitV8collection(v8::Handle<v8::Context> context, TRI_server_t* server,
                        JS_ReplaceVocbaseCol);
   TRI_AddMethodVocbase(isolate, rt, TRI_V8_ASCII_STRING("rotate"),
                        JS_RotateVocbaseCol);
-  TRI_AddMethodVocbase(
-      isolate, rt, TRI_V8_ASCII_STRING("save"),
-      JS_InsertVocbaseCol);  // note: save is now an alias for insert
   TRI_AddMethodVocbase(isolate, rt, TRI_V8_ASCII_STRING("status"),
                        JS_StatusVocbaseCol);
   TRI_AddMethodVocbase(isolate, rt, TRI_V8_ASCII_STRING("TRUNCATE"),

--- a/js/client/modules/@arangodb/arango-collection.js
+++ b/js/client/modules/@arangodb/arango-collection.js
@@ -962,6 +962,13 @@ ArangoCollection.prototype.insert = function (from, to, data, waitForSync) {
     url = "/_api/document?collection=" + encodeURIComponent(this.name());
   }
   else if (type === ArangoCollection.TYPE_EDGE) {
+    if (!data && from && typeof from === 'object' && from.hasOwnProperty("_from") && from.hasOwnProperty("_to")) {
+      data = from;
+      waitForSync = to;
+      from = data._from;
+      to = data._to;
+    }
+
     if (typeof from === 'object' && from.hasOwnProperty("_id")) {
       from = from._id;
     }

--- a/js/common/tests/shell/shell-edge.js
+++ b/js/common/tests/shell/shell-edge.js
@@ -303,6 +303,28 @@ function CollectionEdgeSuite () {
       assertTypeOf("string", doc._id);
       assertTypeOf("string", doc._rev);
       assertMatch(/^UnitTestsCollectionEdge\//, doc._id);
+
+      var saved = edge.document(doc._id);
+
+      assertEqual(v1._id, saved._from);
+      assertEqual(v2._id, saved._to);
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief create an edge using the shorthand
+////////////////////////////////////////////////////////////////////////////////
+
+    testSaveEdgeShorthand : function () {
+      var doc = edge.save({ "_from": v1._id, "_to": v2._id, "Hello" : "World" });
+
+      assertTypeOf("string", doc._id);
+      assertTypeOf("string", doc._rev);
+      assertMatch(/^UnitTestsCollectionEdge\//, doc._id);
+
+      var saved = edge.document(doc._id);
+
+      assertEqual(v1._id, saved._from);
+      assertEqual(v2._id, saved._to);
     },
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/js/server/modules/@arangodb/arango-collection.js
+++ b/js/server/modules/@arangodb/arango-collection.js
@@ -454,6 +454,47 @@ ArangoCollection.prototype.last = function (count) {
 };
 
 ////////////////////////////////////////////////////////////////////////////////
+/// @brief saves a document in the collection
+/// note: this method is used to save documents and edges, but save() has a
+/// different signature for both. For document collections, the signature is
+/// save(<data>, <waitForSync>), whereas for edge collections, the signature is
+/// save(<from>, <to>, <data>, <waitForSync>)
+////////////////////////////////////////////////////////////////////////////////
+
+ArangoCollection.prototype.save =
+ArangoCollection.prototype.insert = function (from, to, data, waitForSync) {
+  var type = this.type();
+
+  if (type === undefined) {
+    type = ArangoCollection.TYPE_DOCUMENT;
+  }
+
+  if (type === ArangoCollection.TYPE_DOCUMENT) {
+    data = from;
+    waitForSync = to;
+    return this._insert(data, waitForSync);
+  }
+  else if (type === ArangoCollection.TYPE_EDGE) {
+    if (!data && from && typeof from === 'object' && from.hasOwnProperty("_from") && from.hasOwnProperty("_to")) {
+      data = from;
+      waitForSync = to;
+      from = data._from;
+      to = data._to;
+    }
+
+    if (typeof from === 'object' && from.hasOwnProperty("_id")) {
+      from = from._id;
+    }
+
+    if (typeof to === 'object' && to.hasOwnProperty("_id")) {
+      to = to._id;
+    }
+  }
+
+  return this._insert(from, to, data, waitForSync);
+};
+
+////////////////////////////////////////////////////////////////////////////////
 /// @brief was docuBlock collectionFirstExample
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Fixes #1733.

This renames the C++ ArangoCollection `insert` method to `_insert` and replaces it (as well as the `save` alias) with a JavaScript wrapper for `_insert`.

@neunhoef Do you see any potential complications from this change? The changes are all in the API exposed to JS so I think this change shouldn't break anything and the "old" method signature is still fully supported (and used internally too). This is intended to be purely a quality of life improvement, not a breaking change.

As `edgeCollection.save({_from: a, _to: b})` is purely a syntactic shorthand for `edgeCollection.save(a, b, {})` there are intentionally no sanity checks for the values of `a` and `b` -- all the underlying argument handling (e.g. handling objects with `_id` properties) will still apply no matter whether this makes sense or not. This is an intentional limitation on the input validation -- the `_from` and `_to` keys of the data will be ignored by the underlying API anyway.

As this PR involves changes to C++ code and because the ArangoCollection API is extremely vital, I would like explicit signoff by somebody else before merging this.