### PR TITLE
Add 'Save' and 'New' button for Query Editor #1906

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/templates/queryView.ejs
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/templates/queryView.ejs
@@ -6,7 +6,9 @@
       <div class="pull-left">
         <button id="toggleQueries1" class="button-primary"><i class="fa fa-star-o"></i>Queries</button>
         <button id="toggleQueries2" class="button-primary" style="display: none"><i class="fa fa-star"></i>Queries</button>
-        <button id="saveCurrentQuery" class="button-success"><i class="fa fa-save"></i>Save</button>
+        <button id="createNewQuery" class="button-warning">New</button>
+        <button id="updateCurrentQuery" class="button-success" style="display: none"><i class="fa fa-save"></i>Save</button>
+        <button id="saveCurrentQuery" class="button-success"><i class="fa fa-save"></i>Save as</button>
       </div>
 
       <div class="pull-right">


### PR DESCRIPTION
Add a Save button, New button and a Title to view the current Query.
Try to make this change with minimal impact on already existed behavior.
I'm really not a front-end person, soo I may need some help to make the modifications more "pretty" or adjust to fit some system standard.

![captura de tela 2016-07-03 as 14 50 06](https://cloud.githubusercontent.com/assets/1529658/16546827/a46b91bc-412d-11e6-84b7-97dbcdbf618a.png)
