### PR TITLE
Complete to __aarch64__ achritectur

### DIFF
--- a/cmake/TargetArch.cmake
+++ b/cmake/TargetArch.cmake
@@ -28,6 +28,8 @@ set(archdetect_c_code "
     #else
         #error cmake_ARCH arm
     #endif
+#elif defined(__aarch64__)
+    #error cmake_ARCH aarch64
 #elif defined(__i386) || defined(__i386__) || defined(_M_IX86)
     #error cmake_ARCH i386
 #elif defined(__x86_64) || defined(__x86_64__) || defined(__amd64) || defined(_M_X64)


### PR DESCRIPTION
Recognition of architecture by compiler (preprocessor) error
Runs as on ODROID C2, Pine A64 

Similar change:
https://github.com/anqixu/ueye_cam/blob/master/cmake_modules/TargetArch.cmake