### PR TITLE
Adapting to 64 bit ARM architecture (aarch64)

### DIFF
--- a/lib/Basics/operating-system.h
+++ b/lib/Basics/operating-system.h
@@ -41,7 +41,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #if defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || \
-    defined(__x86_64) || defined(_M_X64) || defined(_M_AMD64)
+    defined(__x86_64) || defined(_M_X64) || defined(_M_AMD64) || defined(__aarch64__)
 #undef TRI_PADDING_32
 #else
 #define TRI_PADDING_32 1


### PR DESCRIPTION
Adapting to a new 64 bit architecture (aarch64) at the exceptions for TRI_PADDING_32