### PR TITLE
Error when job retried: Cannot convert object to primitive value

### DIFF
--- a/js/common/bootstrap/modules/internal.js
+++ b/js/common/bootstrap/modules/internal.js
@@ -1473,7 +1473,7 @@ global.DEFINE_MODULE('internal', (function () {
         if (typeof src !== 'function' || (
           key !== 'arguments' && key !== 'caller' && key !== 'callee'
           )) {
-          if (key.charAt(0) !== '_' && !hasOwnProperty(result, key)) {
+          if (key.charAt(0) !== '_' && !hasOwnProperty.call(result, key)) {
             val = obj[key];
             if (seen.indexOf(val) !== -1 && (
               typeof val === 'object' || typeof val === 'function'
@@ -1491,7 +1491,7 @@ global.DEFINE_MODULE('internal', (function () {
     if (obj.constructor && obj.constructor.name) {
       if (obj instanceof Error && obj.name === Error.name) {
         result.name = obj.constructor.name;
-      } else if (!hasOwnProperty(result, 'constructor')) {
+      } else if (!hasOwnProperty.call(result, 'constructor')) {
         result.constructor = {
           name: obj.constructor.name
         };


### PR DESCRIPTION
If queue job return error, it never retry execute because stuck when check variable result.

error detail:
```
TypeError: Cannot convert object to primitive value at hasOwnProperty (native)
at global.DEFINE_MODULE.exports.flatten (/usr/share/arangodb3/js/common/bootstrap/modules/internal.js:1493:39)    
at Object.exports.work (/usr/share/arangodb3/js/server/modules/@arangodb/foxx/queues/worker.js:121:13)    
at eval (eval at undefined, <anonymous>:8:59)
at eval (eval at undefined, <anonymous>:11:17)    
at eval (eval at undefined, <anonymous>:11:29)
```