### PR TITLE
'COALESCE' function

### DIFF
--- a/arangod/Aql/FunctionDefinitions.cpp
+++ b/arangod/Aql/FunctionDefinitions.cpp
@@ -434,6 +434,7 @@ struct FunctionDefiner {
                              true, false, true});
     add({"NOT_NULL", "AQL_NOT_NULL", ".|+", true, true, false,
                           true, true, &Functions::NotNull});
+    add({"COALESCE", "AQL_COALESCE", ".|+", true, true, false, true, true, &Functions::Coalesce });
     add({"FIRST_LIST", "AQL_FIRST_LIST", ".|+", true, true,
                             false, true, true, &Functions::FirstList});
     add({"FIRST_DOCUMENT", "AQL_FIRST_DOCUMENT", ".|+", true, true, false,

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -823,6 +823,21 @@ AqlValue Functions::IsNull(arangodb::aql::Query* query,
   return AqlValue(a.isNull(true));
 }
 
+/// @brief function COALESCE
+AqlValue Functions::Coalesce(arangodb::aql::Query* query,
+                           arangodb::AqlTransaction* trx,
+                           VPackFunctionParameters const& parameters) {
+  size_t const n = parameters.size();
+  for (size_t i=0;i<n;i++) {
+    AqlValue a = ExtractFunctionParameterValue(trx, parameters, i);
+    if (!a.isNull(false)) {
+      return a.clone();
+    }
+  }
+  return AqlValue(arangodb::basics::VelocyPackHelper::NullValue());
+}
+
+
 /// @brief function IS_BOOL
 AqlValue Functions::IsBool(arangodb::aql::Query* query,
                            arangodb::AqlTransaction* trx,

--- a/arangod/Aql/Functions.h
+++ b/arangod/Aql/Functions.h
@@ -61,6 +61,8 @@ struct Functions {
 
   static AqlValue IsNull(arangodb::aql::Query*, arangodb::AqlTransaction*,
                          VPackFunctionParameters const&);
+  static AqlValue Coalesce(arangodb::aql::Query*, arangodb::AqlTransaction*,
+                         VPackFunctionParameters const&);
   static AqlValue IsBool(arangodb::aql::Query*, arangodb::AqlTransaction*,
                          VPackFunctionParameters const&);
   static AqlValue IsNumber(arangodb::aql::Query*, arangodb::AqlTransaction*,


### PR DESCRIPTION
Implement the simple 'COALESCE' function which takes arbitrary number of parameters and returns the first non-null.

 It can be as substitution of 'IS_NULL(x)? a : x', which is equals to 'COALESCE(x,a)'