### PR TITLE
Set host_arch by CROSS_COMPILING

### DIFF
--- a/3rdParty/V8/CMakeLists.txt
+++ b/3rdParty/V8/CMakeLists.txt
@@ -61,9 +61,10 @@ list(APPEND V8_GYP_ARGS
 )
 
 if (CROSS_COMPILING)
-  list(APPEND V8_GYP_ARGS -DGYP_CROSSCOMPILE=1)
+  list(APPEND V8_GYP_ARGS
+  -Dhost_arch=${V8_PROC_ARCH}
+  -DGYP_CROSSCOMPILE=1)
 endif()
-
 
 ################################################################################
 ## ICU EXPORTS


### PR DESCRIPTION
in  standalone.gypi is the target_arch derived from host_arch and host_arch is automatically detected. The cross-compiler is misconfigured and ICU is compiled with settings for x64. This change overrides host_arch.