### PR TITLE
Adding dependencies by no v8_use_snapshot

### DIFF
--- a/3rdParty/V8/V8-5.0.71.39/tools/gyp/v8.gyp
+++ b/3rdParty/V8/V8-5.0.71.39/tools/gyp/v8.gyp
@@ -110,7 +110,7 @@
           # The dependency on v8_base should come from a transitive
           # dependency however the Android toolchain requires libv8_base.a
           # to appear before libv8_snapshot.a so it's listed explicitly.
-          'dependencies': ['v8_base', 'v8_nosnapshot'],
+          'dependencies': ['v8_base', 'v8_nosnapshot', 'v8_libbase', 'v8_libplatform'],
         }],
         ['v8_use_snapshot=="true" and v8_use_external_startup_data==0', {
           # The dependency on v8_base should come from a transitive


### PR DESCRIPTION
ArangoDB use no snapshot, but use v8_use_snapshot=true for creating  additinal libs (v8_libbase, 'v8_libplatform). Due this change can be used v8_use_snapshot=false.
Note: this works only with gyp and Unix make. Ninja don't work with v8_use_snapshot=false.