### PR TITLE
fix upgrade/install foxx in cluster environment

### DIFF
--- a/js/server/modules/@arangodb/foxx/manager.js
+++ b/js/server/modules/@arangodb/foxx/manager.js
@@ -613,7 +613,7 @@ function uploadToPeerCoordinators (serviceInfo, coordinators) {
   let coordOptions = {
     coordTransactionID: ArangoClusterComm.getId()
   };
-  let req = fs.readBuffer(joinPath(fs.getTempPath(), serviceInfo));
+  let req = fs.readBuffer(serviceInfo);
   let httpOptions = {};
   let mapping = {};
   for (let i = 0; i < coordinators.length; ++i) {
@@ -1336,7 +1336,7 @@ function replace (serviceInfo, mount, options) {
         /* jshint -W075:true */
         let intReq = {appInfo: b.filename, mount, options: intOpts};
         /* jshint -W075:false */
-        ArangoClusterComm.asyncRequest('POST', 'server:' + mapping[res[i].coordinatorTransactionID], db._name(),
+        ArangoClusterComm.asyncRequest('POST', 'server:' + mapping[res[i].clientTransactionID], db._name(),
           '/_admin/foxx/replace', JSON.stringify(intReq), httpOptions, coordOptions);
       }
       cluster.wait(coordOptions, res.length);
@@ -1407,8 +1407,8 @@ function upgrade (serviceInfo, mount, options) {
         /* jshint -W075:true */
         let intReq = {appInfo: b.filename, mount, options: intOpts};
         /* jshint -W075:false */
-        ArangoClusterComm.asyncRequest('POST', 'server:' + mapping[res[i].coordinatorTransactionID], db._name(),
-          '/_admin/foxx/update', JSON.stringify(intReq), httpOptions, coordOptions);
+        ArangoClusterComm.asyncRequest('POST', 'server:' + mapping[res[i].clientTransactionID], db._name(),
+          '/_admin/foxx/upgrade', JSON.stringify(intReq), httpOptions, coordOptions);
       }
       cluster.wait(coordOptions, res.length);
     } else {
@@ -1425,7 +1425,7 @@ function upgrade (serviceInfo, mount, options) {
       req = JSON.stringify(req);
       for (let i = 0; i < coordinators.length; ++i) {
         ArangoClusterComm.asyncRequest('POST', 'server:' + coordinators[i], db._name(),
-          '/_admin/foxx/update', req, httpOptions, coordOptions);
+          '/_admin/foxx/upgrade', req, httpOptions, coordOptions);
       }
       cluster.wait(coordOptions, coordinators.length);
     }


### PR DESCRIPTION
When install/upgrade, arangodb response is "No such file or directory".
This is because serviveInfo path already join with temporary Path, and then
in "uploadToPeerCoordinators" it join twice with temporary path.
Another problem, arangodb upgrade url is "update" not "upgrade".
Last problem, when Sync foxx with another cluster, use "coordinatorTransactionID"
but there is no that key response from ArangoClusterComm.

Sample response from ArangoClusterComm

```
{
    "results": [
        {
            "clientTransactionID": "6100001",
            "coordTransactionID": "80",
            "operationID": "69",
            "endpoint": "tcp://0.0.0.0:8631",
            "singleRequest": false,
            "shardID": "",
            "status": "RECEIVED",
            "headers": {
                "content-length": "38",
                "x-arango-response-code": "201 Created"
            },
            "body": "{\"filename\":\"uploads/tmp-1-622403075\"}"
        }
    ],
    "mapping": {
        "6100001": "Coordinator002"
    }
}
```

This is relate with #2144 

/cc @pluma @kvahed 

maybe you can help me for this ..