### PR TITLE
Adding note about configuration file and endpoint.

### DIFF
--- a/Documentation/Books/Manual/GettingStarted/Installing/MacOSX.mdpp
+++ b/Documentation/Books/Manual/GettingStarted/Installing/MacOSX.mdpp
@@ -22,6 +22,10 @@ installed as:
 
 You can start the server by running the command `/usr/local/sbin/arangod &`.
 
+Configuration file is located at
+
+    /usr/local/etc/arangodb3/arangod.conf
+
 The ArangoDB shell will be installed as:
 
     /usr/local/bin/arangosh
@@ -49,6 +53,11 @@ also need to update homebrew:
 - Performance - the LLVM delivered as of Mac OS X El Capitan builds slow binaries. Use GCC instead,
   until this issue has been fixed by Apple.
 - the Commandline argument parsing doesn't accept blanks in filenames; the CLI version below does.
+- if you need to change server endpoint while starting homebrew version, you can edit arangod.conf 
+  file and uncomment line with endpoint needed, e.g.:
+      
+      [server]
+      endpoint = tcp://0.0.0.0:8529
 
 Graphical App
 -------------


### PR DESCRIPTION
Took me a while to find how to change server.endpoint. When editing provided plist file and using `brew services start arangodb` `ProgramArguments` from plist are ignored for some reason. So the only way to switch from `127.0.0.1:8529` to `0.0.0.0:8529` was to edit `arangod.conf` file and restart services with brew. After that I was able to access web interface remotely.