### PR TITLE
Add explanatory comment to build-deb

### DIFF
--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# To install the build libraries needed by this script run:
+# `sudo apt-get install cmake libjemalloc-dev libssl-dev libreadline-dev`
+# After the packages are built you will find them in /var/tmp
 
 set -e
 


### PR DESCRIPTION
After @dothebart pointed this script out I used it to build a package for Ubuntu 16.10. To do so I needed to figure out which packages needed to be installed and where the packages go after they are built.
I thought capturing those things in a comment might be helpful for others.
Let me know if I got the deps wrong.
