### PR TITLE
Fix result value from queue worker

### DIFF
--- a/js/server/modules/@arangodb/foxx/queues/worker.js
+++ b/js/server/modules/@arangodb/foxx/queues/worker.js
@@ -122,7 +122,7 @@ exports.work = function (job) {
   }
 
   try {
-    fm.runScript(job.type.name, job.type.mount, [].concat(job.data, job._id));
+    result = fm.runScript(job.type.name, job.type.mount, [].concat(job.data, job._id));
   } catch (e) {
     console.errorLines('Job %s failed:\n%s', job._key, e.stack || String(e));
     job.runFailures += 1;

--- a/js/server/modules/@arangodb/foxx/queues/worker.js
+++ b/js/server/modules/@arangodb/foxx/queues/worker.js
@@ -122,6 +122,7 @@ exports.work = function (job) {
   }
 
   try {
+    // assign output to "result" variable
     result = fm.runScript(job.type.name, job.type.mount, [].concat(job.data, job._id));
   } catch (e) {
     console.errorLines('Job %s failed:\n%s', job._key, e.stack || String(e));


### PR DESCRIPTION
On queue.push method, success callback always give empty result, because result variable never assigned as output.
```
queue.push(
  {mount: 'some path', name: 'some queue'},
  {data},
  {
    success: function(result, jobData, job){
      //result always empty
      console.log(result);
    }
  }
)
```