### PR TITLE
Remove coord list hack

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -2707,7 +2707,9 @@ int ClusterInfo::getResponsibleShard(LogicalCollection* collInfo,
 std::vector<ServerID> ClusterInfo::getCurrentCoordinators() {
   std::vector<ServerID> result;
 
-  loadCurrentCoordinators();
+  if (!_coordinatorsProt.isValid) {
+    loadCurrentCoordinators();
+  }
 
   // return a consistent state of servers
   READ_LOCKER(readLocker, _coordinatorsProt.lock);


### PR DESCRIPTION
This removes the coord list hack introduced in #2479.

Right now this hack is used to ensure the coordinator list used when distributing services and self-healing coordinators is always fresh but these changes should no longer be necessary.

It seems this particular list is only used in JavaScript right now so this should not affect cluster logic outside of Foxx.