### PR TITLE
fixing the agency comm issues detected with the go-driver tests

### DIFF
--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -1358,7 +1358,7 @@ AgencyCommResult AgencyComm::sendWithFailover(
         if (waitInterval.count() == 0.0) {
           waitInterval = std::chrono::duration<double>(0.25);
         } else if (waitInterval.count() < 5.0) { 
-          waitInterval *= 1.5;
+          waitInterval *= 1.0749292929292;
         }
       }
     } else {
@@ -1491,24 +1491,22 @@ AgencyCommResult AgencyComm::sendWithFailover(
       break;
     }
 
-    if (tries%50 == 0) {
-      LOG_TOPIC(WARN, Logger::AGENCYCOMM)
-        << "Bad agency communiction! Unsuccessful consecutive tries:"
-        << tries << " (" << elapsed << "s). Network checks needed!";
-    } else if (tries%15 == 0) {
+    if (tries > 20) {
       LOG_TOPIC(INFO, Logger::AGENCYCOMM)
-        << "Flaky agency communication. Unsuccessful consecutive tries: "
-        << tries << " (" << elapsed << "s). Network checks advised.";
+        << "Flaky agency communication to " << endpoint
+        << ". Unsuccessful consecutive tries: " << tries
+        << " (" << elapsed << "s). Network checks advised.";
     } 
     
     if (1 < tries) {
       LOG_TOPIC(DEBUG, Logger::AGENCYCOMM)
         << "Retrying agency communication at '" << endpoint
-        << "', tries: " << tries << " ("
-        << 1.e-2 * (
-          std::round(
-            1.e+2 * std::chrono::duration<double>(
-              std::chrono::steady_clock::now() - started).count())) << "s)";
+        << ". Unsuccessful consecutive tries: " << tries
+        << " (" << elapsed << "s). Network checks advised.";
+    }
+
+    if (conTimeout < 5.0) {
+      conTimeout *= 1.1;
     }
     
     // here we have failed and want to try next endpoint

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -1020,8 +1020,8 @@ void Agent::run() {
       sendAppendEntriesRPC();
 
       // Don't panic
-      _appendCV.wait(static_cast<uint64_t>(1.0e-1*_config.minPing()));
-
+      _appendCV.wait(static_cast<uint64_t>(4.e3*_config.minPing()));
+      
       // Detect faulty agent and replace
       // if possible and only if not already activating
       if (duration<double>(system_clock::now() - tp).count() > 10.0) {

--- a/scripts/startStandAloneAgency.sh
+++ b/scripts/startStandAloneAgency.sh
@@ -185,8 +185,8 @@ else
 fi
 
 SFRE=2.5
-COMP=200
-KEEP=1
+COMP=20000
+KEEP=10000
 BASE=$(( $PORT_OFFSET + 5000 ))
 
 if [ "$GOSSIP_MODE" = "0" ]; then


### PR DESCRIPTION
Agent.cpp busy waiting in run method. 
AgencyComm.cpp will grow connection timeout from 1.0 to maximal 5.0 in sendWithFailover.
1.0 often at very high loads too short in ssl context.