### PR TITLE
Document storage engine choice

### DIFF
--- a/Documentation/Books/Manual/Administration/Configuration/GeneralArangod.md
+++ b/Documentation/Books/Manual/Administration/Configuration/GeneralArangod.md
@@ -28,6 +28,19 @@ Whether or not this option is specified, the server will always perform a
 version check on startup. Running the server with a non-matching version number
 in the VERSION file will make the server refuse to start.
 
+### Storage Engine
+As of ArangoDB 3.2 several storage engines are supported. The previously existing
+engine is called `MMFiles`, the newly created one is based on [RocksDB](http://rocksdb.org)
+and thus called the like.
+
+One storage engine type is supported per server per installation. 
+Live switching of storage engines on currently installed systems isn't supported.
+If you configure the wrong engine not matching the previously used one will result
+in the server refusing to start. You may however use `auto` to let ArangoDB choose 
+the previously used one. 
+
+
+`--server.storage-engine [auto|mmfiles|rocksdb]`
 
 ### Daemon
 

--- a/Documentation/Books/Manual/Administration/Configuration/GeneralArangod.md
+++ b/Documentation/Books/Manual/Administration/Configuration/GeneralArangod.md
@@ -29,13 +29,15 @@ version check on startup. Running the server with a non-matching version number
 in the VERSION file will make the server refuse to start.
 
 ### Storage Engine
-As of ArangoDB 3.2 several storage engines are supported. The previously existing
-engine is called `MMFiles`, the newly created one is based on [RocksDB](http://rocksdb.org)
-and thus called the like.
+As of ArangoDB 3.2 two storage engines are supported. The "traditional"
+engine is called `MMFiles`, which is also the default storage engine.
+
+An alternative engine based on [RocksDB](http://rocksdb.org) is also provided and
+can be turned on manually.
 
 One storage engine type is supported per server per installation. 
-Live switching of storage engines on currently installed systems isn't supported.
-If you configure the wrong engine not matching the previously used one will result
+Live switching of storage engines on already installed systems isn't supported.
+Configuring the wrong engine (not matching the previously used one) will result
 in the server refusing to start. You may however use `auto` to let ArangoDB choose 
 the previously used one. 
 

--- a/Documentation/Books/Manual/Administration/Configuration/RocksDB.md
+++ b/Documentation/Books/Manual/Administration/Configuration/RocksDB.md
@@ -8,8 +8,8 @@ underlying RocksDB instance, and we change very few of their default settings.
 Depending [on the storage engine you have chosen](GeneralArangod.md#storage-engine) the availability
 and the scope of these options changes. 
 
-In case you have chosen `mmfiles` some of the following options apply to persistent indices.
-In case of `rocksdb` it will apply to all data stored as well as indices.
+In case you have chosen `mmfiles` some of the following options apply to persistent indexes.
+In case of `rocksdb` it will apply to all data stored as well as indexes.
 
 ## Pass-through options
 

--- a/Documentation/Books/Manual/Administration/Configuration/RocksDB.md
+++ b/Documentation/Books/Manual/Administration/Configuration/RocksDB.md
@@ -5,6 +5,12 @@ RocksDB is a highly configurable key-value store used to power our RocksDB
 storage engine. Most of the options on this page are pass-through options to the
 underlying RocksDB instance, and we change very few of their default settings.
 
+Depending [on the storage engine you have chosen](GeneralArangod.md#storage-engine) the availability
+and the scope of these options changes. 
+
+In case you have chosen `mmfiles` some of the following options apply to persistent indices.
+In case of `rocksdb` it will apply to all data stored as well as indices.
+
 ## Pass-through options
 
 ### Write buffers

--- a/Documentation/Books/Manual/Administration/Configuration/Wal.md
+++ b/Documentation/Books/Manual/Administration/Configuration/Wal.md
@@ -1,8 +1,11 @@
-Write-ahead log options
-=======================
+MMFiles Write-ahead log options
+===============================
 
-Since ArangoDB 2.2, the server will write all data-modification operations into its
-write-ahead log.
+Since ArangoDB 2.2, the MMFiles storage engine will write all data-modification
+operations into its write-ahead log.
+
+With ArangoDB 3.2 another Storage engine option becomes available - [RocksDB](RocksDB.md).
+In case of using RocksDB most of the subsequent options don't have a usefull meaning.
 
 The write-ahead log is a sequence of logfiles that are written in an append-only
 fashion. Full logfiles will eventually be garbage-collected, and the relevant data

--- a/Documentation/Books/Manual/Administration/Configuration/Wal.md
+++ b/Documentation/Books/Manual/Administration/Configuration/Wal.md
@@ -5,7 +5,7 @@ Since ArangoDB 2.2, the MMFiles storage engine will write all data-modification
 operations into its write-ahead log.
 
 With ArangoDB 3.2 another Storage engine option becomes available - [RocksDB](RocksDB.md).
-In case of using RocksDB most of the subsequent options don't have a usefull meaning.
+In case of using RocksDB most of the subsequent options don't have a useful meaning.
 
 The write-ahead log is a sequence of logfiles that are written in an append-only
 fashion. Full logfiles will eventually be garbage-collected, and the relevant data

--- a/Documentation/Books/Manual/Appendix/JavaScriptModules/WAL.md
+++ b/Documentation/Books/Manual/Appendix/JavaScriptModules/WAL.md
@@ -4,7 +4,7 @@ Write-ahead log
 `const wal = require('internal').wal`
 
 This module provides functionality for administering the write-ahead logs.
-Most of these functions only return good values when invoked with the 
+Most of these functions only return sensible values when invoked with the 
 [mmfiles engine being active](../../Administration/Configuration/GeneralArangod.md#storage-engine).
 
 ### Configuration

--- a/Documentation/Books/Manual/Appendix/JavaScriptModules/WAL.md
+++ b/Documentation/Books/Manual/Appendix/JavaScriptModules/WAL.md
@@ -4,6 +4,8 @@ Write-ahead log
 `const wal = require('internal').wal`
 
 This module provides functionality for administering the write-ahead logs.
+Most of these functions only return good values when invoked with the 
+[mmfiles engine being active](../../Administration/Configuration/GeneralArangod.md#storage-engine).
 
 ### Configuration
 <!-- arangod/V8Server/v8-vocbase.h -->

--- a/Documentation/Books/Manual/Architecture/WriteAheadLog.md
+++ b/Documentation/Books/Manual/Architecture/WriteAheadLog.md
@@ -1,5 +1,7 @@
 Write-ahead log
 ===============
+The Write-ahead log is part of the MMFiles storage engine; This doesn't apply to your
+ArangoDB if you are running with [RocksDB](../../Administration/Configuration/RocksDB.md).
 
 Starting with version 2.2 ArangoDB stores all data-modification operation in
 its write-ahead log. The write-ahead log is sequence of append-only files containing

--- a/Documentation/Books/Manual/Architecture/WriteAheadLog.md
+++ b/Documentation/Books/Manual/Architecture/WriteAheadLog.md
@@ -1,7 +1,8 @@
 Write-ahead log
 ===============
 The Write-ahead log is part of the MMFiles storage engine; This doesn't apply to your
-ArangoDB if you are running with [RocksDB](../../Administration/Configuration/RocksDB.md).
+ArangoDB if you are running with the [RocksDB](../../Administration/Configuration/RocksDB.md)
+storage engine.
 
 Starting with version 2.2 ArangoDB stores all data-modification operation in
 its write-ahead log. The write-ahead log is sequence of append-only files containing


### PR DESCRIPTION
- WAL is not available with rocksdb
- WAL commands don't output usefull data for rocksdb
- have to manually migrate to rocksdb.