### PR TITLE
don't install aardvark source files into packages

### DIFF
--- a/cmake/InstallArangoDBJSClient.cmake
+++ b/cmake/InstallArangoDBJSClient.cmake
@@ -39,4 +39,9 @@ install(
   REGEX "^.*/.npmignore"                                   EXCLUDE
   REGEX "^.*/expect.js$"                                   EXCLUDE
   REGEX "^.*/.bin"                                         EXCLUDE
+  REGEX "^.*/_admin/aardvark/APP/frontend/html/"           EXCLUDE
+  REGEX "^.*/_admin/aardvark/APP/frontend/img/"            EXCLUDE
+  REGEX "^.*/_admin/aardvark/APP/frontend/js/"             EXCLUDE
+  REGEX "^.*/_admin/aardvark/APP/frontend/scss/"           EXCLUDE
+  REGEX "^.*/_admin/aardvark/APP/frontend/src/"            EXCLUDE
 )


### PR DESCRIPTION
after a discussion with @hkernbach yesterday we isolated source files for the aardvark UI which don't need to be delivered with the packages. 
This patch adds blacklist items to speed up the install process.