### PR TITLE
jenkins configuration files where erroneously pointing to 'testing'

### DIFF
--- a/etc/jenkins/arangod-agency.conf
+++ b/etc/jenkins/arangod-agency.conf
@@ -1,1 +1,1 @@
-@include etc/testing/arangod-common.conf
+@include etc/jenkins/arangod-common.conf

--- a/etc/jenkins/arangod-agent.conf
+++ b/etc/jenkins/arangod-agent.conf
@@ -1,1 +1,1 @@
-@include etc/testing/arangod-common.conf
+@include etc/jenkins/arangod-common.conf

--- a/etc/jenkins/arangod-coordinator.conf
+++ b/etc/jenkins/arangod-coordinator.conf
@@ -1,4 +1,4 @@
-@include etc/testing/arangod-common.conf
+@include etc/jenkins/arangod-common.conf
 
 [log]
 #level = agencycomm=trace

--- a/etc/jenkins/arangod-dbserver.conf
+++ b/etc/jenkins/arangod-dbserver.conf
@@ -1,3 +1,3 @@
-@include etc/testing/arangod-common.conf
+@include etc/jenkins/arangod-common.conf
 [log]
 level = replication=trace

--- a/etc/jenkins/arangod-single.conf
+++ b/etc/jenkins/arangod-single.conf
@@ -1,1 +1,1 @@
-@include etc/testing/arangod-common.conf
+@include etc/jenkins/arangod-common.conf

--- a/etc/jenkins/arangod.conf
+++ b/etc/jenkins/arangod.conf
@@ -1,1 +1,1 @@
-@include etc/testing/arangod-common.conf
+@include etc/jenkins/arangod-common.conf


### PR DESCRIPTION
fixed jenkins configuration files to point to the proper default include