### PR TITLE
fix lockfile-related messages

### DIFF
--- a/arangod/RestServer/LockfileFeature.cpp
+++ b/arangod/RestServer/LockfileFeature.cpp
@@ -51,10 +51,13 @@ void LockfileFeature::start() {
     std::string otherPID;
     try {
       otherPID = FileUtils::slurp(_lockFilename.c_str());
+    } catch (...) {}
+    if (otherPID.empty()) {
+      LOG_TOPIC(FATAL, arangodb::Logger::FIXME) << "failed to read/write lockfile, please check the file permissions of the lockfile '" << _lockFilename << "'";
+    } else {
+      LOG_TOPIC(FATAL, arangodb::Logger::FIXME) << "database is locked by process " <<
+        otherPID << "; please stop it first and check that the lockfile '" << _lockFilename << "' goes away. If you are sure no other arangod process is running, please remove the lockfile '" << _lockFilename << "' and try again";
     }
-    catch (...) {}
-    LOG_TOPIC(FATAL, arangodb::Logger::FIXME) << "database is locked by process " <<
-      otherPID << "; please stop it and remove the lock file '" << _lockFilename << "'";
     FATAL_ERROR_EXIT();
   }
   
@@ -63,7 +66,7 @@ void LockfileFeature::start() {
   
     if (res != TRI_ERROR_NO_ERROR) {
       LOG_TOPIC(FATAL, arangodb::Logger::FIXME)
-        << "failed to remove an abandoned lock file in the database directory, please check the file permissions on the lock file '"
+        << "failed to remove an abandoned lockfile in the database directory, please check the file permissions of the lockfile '"
         << _lockFilename << "': " << TRI_errno_string(res);
       FATAL_ERROR_EXIT();
     }
@@ -72,7 +75,7 @@ void LockfileFeature::start() {
 
   if (res != TRI_ERROR_NO_ERROR) {
     LOG_TOPIC(FATAL, arangodb::Logger::FIXME)
-      << "failed to lock the database directory using "
+      << "failed to lock the database directory using '"
       << _lockFilename << "': " << TRI_errno_string(res);
     FATAL_ERROR_EXIT();
   }


### PR DESCRIPTION
This fixes the error messages in several cases when the lockfile `LOCK` for the arangod database cannot be acquired using fcntl. The error messages are now much more sensible and not misleading.
This also fixes a wrong file-open mode for lockfiles.