### PR TITLE
added wrapper for fdopen

### DIFF
--- a/lib/Basics/operating-system.h
+++ b/lib/Basics/operating-system.h
@@ -178,6 +178,7 @@
 #define TRI_STAT_MTIME_SEC(statbuf) statbuf.st_mtim.tv_sec
 #define TRI_UNLINK ::unlink
 #define TRI_WRITE ::write
+#define TRI_FDOPEN(a, b) ::fdopen((a), (b))
 
 #define TRI_usleep_t useconds_t
 #define TRI_lseek_t off_t
@@ -335,6 +336,7 @@
 #define TRI_STAT_MTIME_SEC(statbuf) statbuf.st_mtimespec.tv_sec
 #define TRI_UNLINK ::unlink
 #define TRI_WRITE ::write
+#define TRI_FDOPEN(a, b) ::fdopen((a), (b))
 
 #define TRI_usleep_t useconds_t
 #define TRI_lseek_t off_t
@@ -479,6 +481,7 @@
 #define TRI_STAT_MTIME_SEC(statbuf) statbuf.st_mtimespec.tv_sec
 #define TRI_UNLINK ::unlink
 #define TRI_WRITE ::write
+#define TRI_FDOPEN(a, b) ::fdopen((a), (b))
 
 #define TRI_usleep_t useconds_t
 #define TRI_lseek_t off_t
@@ -642,6 +645,7 @@
 #define TRI_STAT_MTIME_SEC(statbuf) statbuf.st_mtim.tv_sec
 #define TRI_UNLINK ::unlink
 #define TRI_WRITE ::write
+#define TRI_FDOPEN(a, b) ::fdopen((a), (b))
 
 #define TRI_usleep_t useconds_t
 #define TRI_lseek_t off_t
@@ -838,6 +842,7 @@ typedef unsigned char bool;
 #define TRI_STAT ::_stat64
 #define TRI_UNLINK ::_unlink
 #define TRI_WRITE ::_write
+#define TRI_FDOPEN(a, b) ::_fdopen((a), (b))
 
 #define TRI_usleep_t unsigned long
 #define TRI_lseek_t __int64


### PR DESCRIPTION
This should fix the following warning on MSVC:

C:\b\willi_arangodb\lib\Logger\LogAppenderFile.cpp(227): warning C4996: 'fdopen': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _fdopen. See online help for details. [C:\b\y\lib\arango.vcxproj]
 C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\ucrt\stdio.h(2448): note: see declaration of 'fdopen'