### PR TITLE
Allow passing plain JSON data for config/deps

### DIFF
--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_service_install.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_service_install.md
@@ -15,8 +15,8 @@ The request body can be any of the following formats:
 
 A service definition is an object or form with the following properties or fields:
 
-- *configuration*: a (stringified) JSON object describing configuration values
-- *dependencies*: a (stringified) JSON object describing dependency settings
+- *configuration*: a JSON object describing configuration values
+- *dependencies*: a JSON object describing dependency settings
 - *source*: a fully qualified URL or an absolute path on the server's file system
 
 When using multipart data, the *source* field can also alternatively be a file field

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_service_replace.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_service_replace.md
@@ -20,8 +20,8 @@ The request body can be any of the following formats:
 
 A service definition is an object or form with the following properties or fields:
 
-- *configuration*: a (stringified) JSON object describing configuration values
-- *dependencies*: a (stringified) JSON object describing dependency settings
+- *configuration*: a JSON object describing configuration values
+- *dependencies*: a JSON object describing dependency settings
 - *source*: a fully qualified URL or an absolute path on the server's file system
 
 When using multipart data, the *source* field can also alternatively be a file field

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_service_upgrade.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_service_upgrade.md
@@ -20,8 +20,8 @@ The request body can be any of the following formats:
 
 A service definition is an object or form with the following properties or fields:
 
-- *configuration*: a (stringified) JSON object describing configuration values
-- *dependencies*: a (stringified) JSON object describing dependency settings
+- *configuration*: a JSON object describing configuration values
+- *dependencies*: a JSON object describing dependency settings
 - *source*: a fully qualified URL or an absolute path on the server's file system
 
 When using multipart data, the *source* field can also alternatively be a file field

--- a/js/apps/system/_api/foxx/APP/index.js
+++ b/js/apps/system/_api/foxx/APP/index.js
@@ -100,6 +100,10 @@ router.use((req, res, next) => {
 router.get((req, res) => {
   res.json(
     FoxxManager.installedServices()
+    .filter((service) => (
+      !req.queryParams.excludeSystem ||
+      !service.mount.startsWith('/_')
+    ))
     .map((service) => (
       {
         mount: service.mount,
@@ -112,6 +116,7 @@ router.get((req, res) => {
     ))
   );
 })
+.queryParam('excludeSystem', schemas.flag.default(false))
 .response(200, joi.array().items(schemas.shortInfo).required());
 
 router.post(prepareServiceRequestBody, (req, res) => {

--- a/js/apps/system/_api/foxx/APP/multipart.js
+++ b/js/apps/system/_api/foxx/APP/multipart.js
@@ -27,16 +27,23 @@ module.exports = {
       if (disposition.type !== 'form-data' || !disposition.parameters.name) {
         continue;
       }
+      const name = disposition.parameters.name;
       const filename = disposition.parameters.filename;
       const type = headers['content-type'];
-      const value = (type || filename) ? part.data : part.data.toString('utf-8');
-      if (filename) {
-        value.filename = filename;
-      }
       if (type || filename) {
-        value.headers = _.omit(headers, ['content-disposition']);
+        parsedBody[name] = Object.assign(part.data, {
+          headers: _.omit(headers, ['content-disposition']),
+          filename
+        });
+      } else {
+        let value = part.data.toString('utf-8');
+        try {
+          value = JSON.parse(value);
+        } catch (e) {
+          // noop
+        }
+        parsedBody[name] = value;
       }
-      parsedBody[disposition.parameters.name] = value;
     }
     return parsedBody;
   }

--- a/js/apps/system/_api/foxx/APP/schemas.js
+++ b/js/apps/system/_api/foxx/APP/schemas.js
@@ -44,7 +44,7 @@ exports.service = joi.alternatives(
       joi.string(),
       joi.object().type(Buffer)
     ).required(),
-    configuration: joi.string().optional(),
-    dependencies: joi.string().optional()
+    configuration: joi.object().optional(),
+    dependencies: joi.object().optional()
   }).required()
 );


### PR DESCRIPTION
Some minor adjustments to the Foxx API:

* the list route now allows filtering system services, analogous to the ArangoDB API for listing collections

* the install/upgrade/replace routes now take options as JSON objects rather than JSON strings containing serialized JSON objects

This was initially done to allow passing the options via multipart uploads which can't contain objects, but I've adjusted the multipart handling to attempt to parse string values as JSON before giving up and treating them as plain strings. This shouldn't be a problem unless someone uses a valid JSON value as source, for example (e.g. `source=25` would parse to a Number) but that seems unlikely. We might want to write tests for this edge case behaviour however (are there any weird objects we can pass via source that might result in unintended behaviour?).

Also, serialising JSON values when passing them in JSON is awkward and inconsistent with the dependencies/configuration routes.

I would suggest we backport these changes to 3.1 for the next bugfix release to have parity on the 3.2.0 release.