### PR TITLE
Add "idiomatic" flag to Foxx tests

### DIFF
--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_tests_run.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_tests_run.md
@@ -14,7 +14,7 @@ Supported test reporters are:
 - *xunit*: an XUnit/JUnit compatible structure
 - *tap*: a raw TAP compatible stream
 
-The *Accept* request header can  be used to further control the response format:
+The *Accept* request header can be used to further control the response format:
 
 When using the *stream* reporter `application/x-ldjson` will result
 in the response body being formatted as a newline-delimited JSON stream.
@@ -34,6 +34,9 @@ Mount path of the installed service.
 
 @RESTQUERYPARAM{reporter,string,optional}
 Test reporter to use.
+
+@RESTQUERYPARAM{idiomatic,boolean,optional}
+Use the matching format for the reporter, regardless of the *Accept* header.
 
 @RESTRETURNCODES
 

--- a/js/apps/system/_api/foxx/APP/index.js
+++ b/js/apps/system/_api/foxx/APP/index.js
@@ -322,18 +322,19 @@ scriptsRouter.post('/:name', (req, res) => {
 
 instanceRouter.post('/tests', (req, res) => {
   const service = req.service;
+  const idiomatic = req.queryParams.idiomatic;
   const reporter = req.queryParams.reporter || null;
   const result = FoxxManager.runTests(service.mount, {reporter});
-  if (reporter === 'stream' && req.accepts(LDJSON, 'json') === LDJSON) {
+  if (reporter === 'stream' && (idiomatic || req.accepts(LDJSON, 'json') === LDJSON)) {
     res.type(LDJSON);
     for (const row of result) {
       res.write(JSON.stringify(row) + '\r\n');
     }
-  } else if (reporter === 'xunit' && req.accepts('xml', 'json') === 'xml') {
+  } else if (reporter === 'xunit' && (idiomatic || req.accepts('xml', 'json') === 'xml')) {
     res.type('xml');
     res.write('<?xml version="1.0" encoding="utf-8"?>\n');
     res.write(jsonml2xml(result) + '\n');
-  } else if (reporter === 'tap' && req.accepts('text', 'json') === 'text') {
+  } else if (reporter === 'tap' && (idiomatic || req.accepts('text', 'json') === 'text')) {
     res.type('text');
     for (const row of result) {
       res.write(row + '\n');
@@ -343,6 +344,7 @@ instanceRouter.post('/tests', (req, res) => {
   }
 })
 .queryParam('reporter', joi.only(...reporters).optional())
+.queryParam('idiomatic', schemas.flag.default(false))
 .response(200, ['json', LDJSON, 'xml', 'text']);
 
 instanceRouter.post('/download', (req, res) => {


### PR DESCRIPTION
Keeping track of the appropriate Accept headers is a bit cumbersome for drivers so having a catchall flag to opt in helps.