### PR TITLE
Explicitly return 204 status code on commit

### DIFF
--- a/js/apps/system/_api/foxx/APP/index.js
+++ b/js/apps/system/_api/foxx/APP/index.js
@@ -385,7 +385,9 @@ instanceRouter.get('/swagger', (req, res) => {
 
 router.post('/commit', (req, res) => {
   FoxxManager.commitLocalState(req.queryParams.replace);
-});
+  res.status(204);
+})
+.response(204, null);
 
 const localRouter = createRouter();
 router.use('/_local', localRouter);


### PR DESCRIPTION
This _should_ already behave correctly but having it explicit helps when reading the code.