### PR TITLE
Fix a hangup in VST.

### DIFF
--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -294,7 +294,7 @@ bool HttpCommTask::processRead(double startTime) {
                                 _readBuffer.length() - 11);
       {
         MUTEX_LOCKER(locker, commTask->_lock);
-        commTask->processRead(startTime);
+        commTask->processAll();
       }
       commTask->start();
       return false;


### PR DESCRIPTION
The problem happened when the two first chunks of a VST message arrived
together on a connection that was newly switched to VST.