### PR TITLE
Fixed a bug to resolve externals in Traversal Condition checker.

### DIFF
--- a/arangod/VocBase/TraverserOptions.cpp
+++ b/arangod/VocBase/TraverserOptions.cpp
@@ -480,6 +480,9 @@ bool TraverserOptions::evaluateEdgeExpression(arangodb::velocypack::Slice edge,
     idNode->stealComputedValue();
     idNode->setStringValue(vertexId.data(), vertexId.length());
   }
+  if (edge.isExternal()) {
+    edge = edge.resolveExternal();
+  }
   return evaluateExpression(expression, edge);
 }
 
@@ -495,6 +498,9 @@ bool TraverserOptions::evaluateVertexExpression(
     expression = _baseVertexExpression;
   }
 
+  if (vertex.isExternal()) {
+    vertex = vertex.resolveExternal();
+  }
   return evaluateExpression(expression, vertex);
 }
 


### PR DESCRIPTION
In some cases the condition was checked against such in MMFiles.
This caused a ASSERTION to kick in.