### PR TITLE
Fix configuration file reader in the presence of @include.

### DIFF
--- a/lib/ApplicationFeatures/ConfigFeature.cpp
+++ b/lib/ApplicationFeatures/ConfigFeature.cpp
@@ -115,7 +115,7 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
     if (FileUtils::exists(local)) {
       LOG_TOPIC(DEBUG, Logger::CONFIG) << "loading override '" << local << "'";
 
-      if (!parser.parse(local)) {
+      if (!parser.parse(local, true)) {
         FATAL_ERROR_EXIT();
       }
     }
@@ -123,7 +123,7 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
     LOG_TOPIC(DEBUG, Logger::CONFIG) << "using user supplied config file '"
                                      << _file << "'";
 
-    if (!parser.parse(_file)) {
+    if (!parser.parse(_file, true)) {
       FATAL_ERROR_EXIT();
     }
 
@@ -192,7 +192,7 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
   if (FileUtils::exists(local)) {
     LOG_TOPIC(DEBUG, Logger::CONFIG) << "loading override '" << local << "'";
 
-    if (!parser.parse(local)) {
+    if (!parser.parse(local, true)) {
       FATAL_ERROR_EXIT();
     }
   } else {
@@ -219,7 +219,7 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
     }
   }
 
-  if (!parser.parse(filename)) {
+  if (!parser.parse(filename, true)) {
     exit(EXIT_FAILURE);
   }
 }

--- a/lib/ProgramOptions/IniFileParser.h
+++ b/lib/ProgramOptions/IniFileParser.h
@@ -62,7 +62,7 @@ class IniFileParser {
 
   // parse a config file. returns true if all is well, false otherwise
   // errors that occur during parse are reported to _options
-  bool parse(std::string const& filename) {
+  bool parse(std::string const& filename, bool endPassAfterwards) {
     if (filename.empty()) {
       return _options->fail(
           "unable to open configuration file: no configuration file specified");
@@ -134,7 +134,7 @@ class IniFileParser {
         LOG_TOPIC(DEBUG, Logger::CONFIG) << "reading include file '" << include
                                          << "'";
 
-        parse(include);
+        parse(include, false);
       } else if (std::regex_match(line, match, _matchers.assignment)) {
         // found assignment
         std::string option;
@@ -170,7 +170,9 @@ class IniFileParser {
     isCommunity ^= isEnterprise;
 
     // all is well
-    _options->endPass();
+    if (endPassAfterwards) {
+      _options->endPass();
+    }
     return true;
   }
 


### PR DESCRIPTION
Vector options in configuration files including others which set
them as well had been ignored. This patch fixes this behaviour.