### PR TITLE
In `mergeHistory` we check for valid coordinators.map replies as bein…

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/statistics.js
+++ b/js/apps/system/_admin/aardvark/APP/statistics.js
@@ -515,7 +515,7 @@ router.get("/coordshort", function(req, res) {
           }
         }
       }
-      return {};
+      return false;
     });
 
     mergeHistory(coordinatorStats);


### PR DESCRIPTION
…g an object. If we don't have a proper reply, rather return false, than an empty object twhich mergeHistory would trip over.

This removes exceptions from the log when DBServers aren't reachable.