### PR TITLE
correct-funny-fail-rotation-after-compaction-bugfix

### DIFF
--- a/arangod/Agency/Job.cpp
+++ b/arangod/Agency/Job.cpp
@@ -1,4 +1,4 @@
-////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
 /// Copyright 2014-2016 ArangoDB GmbH, Cologne, Germany
@@ -22,12 +22,14 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "Job.h"
+#include "Basics/StringUtils.h"
 #include "Random/RandomGenerator.h"
 
 #include <numeric>
 
 static std::string const DBServer = "DBServer";
 
+using namespace arangodb::basics;
 using namespace arangodb::consensus;
 
 Job::Job(JOB_STATUS status, Node const& snapshot, AgentInterface* agent,
@@ -232,7 +234,7 @@ std::vector<std::string> sortedShardList(Node const& shards) {
   std::vector<size_t> sids;
   auto const& shardMap = shards.children();
   for (const auto& shard : shardMap) {
-    sids.push_back(std::stoul(shard.first.substr(1)));
+    sids.push_back(StringUtils::uint64(shard.first.substr(1)));
   }
 
   std::vector<size_t> idx(idxsort(sids));

--- a/arangod/Agency/RestAgencyPrivHandler.h
+++ b/arangod/Agency/RestAgencyPrivHandler.h
@@ -56,7 +56,7 @@ class RestAgencyPrivHandler : public arangodb::RestBaseHandler {
       return false;
     } else {
       try {
-        val = std::stoull(val_str);
+        val = basics::StringUtils::uint64(val_str);
       } catch (std::invalid_argument const&) {
         LOG_TOPIC(WARN, Logger::AGENCY)
             << "Value for query string " << name


### PR DESCRIPTION
- Store to reset at `operator=`
- Clear both key value stores with rebuildDBs
- Fixed all agency std::sto[u]ll to use StringUtils
