### PR TITLE
add a generic "StorageEngine" feature

### DIFF
--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -237,10 +237,10 @@ DatabaseFeature::DatabaseFeature(ApplicationServer* server)
   startsAfter("DatabasePath");
   startsAfter("EngineSelector");
   startsAfter("InitDatabase");
-  startsAfter("MMFilesEngine");
-  startsAfter("MMFilesPersistentIndex");
+  startsAfter("MMFilesPersistentIndex"); // TODO: remove from here!
   startsAfter("RocksDBEngine");
   startsAfter("Scheduler");
+  startsAfter("StorageEngine");
 }
 
 DatabaseFeature::~DatabaseFeature() {

--- a/arangod/RestServer/arangod.cpp
+++ b/arangod/RestServer/arangod.cpp
@@ -83,6 +83,7 @@
 #include "Ssl/SslServerFeature.h"
 #include "Statistics/StatisticsFeature.h"
 #include "StorageEngine/EngineSelectorFeature.h"
+#include "StorageEngine/StorageEngineFeature.h"
 #include "V8Server/FoxxQueuesFeature.h"
 #include "V8Server/V8DealerFeature.h"
 
@@ -172,6 +173,7 @@ static int runServer(int argc, char** argv, ArangoGlobalContext &context) {
     server.addFeature(new ShutdownFeature(&server, {"UnitTests", "Script"}));
     server.addFeature(new SslFeature(&server));
     server.addFeature(new StatisticsFeature(&server));
+    server.addFeature(new StorageEngineFeature(&server));
     server.addFeature(new TempFeature(&server, name));
     server.addFeature(new TransactionManagerFeature(&server));
     server.addFeature(new TraverserEngineRegistryFeature(&server));

--- a/arangod/StorageEngine/StorageEngine.h
+++ b/arangod/StorageEngine/StorageEngine.h
@@ -36,9 +36,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
 
-namespace v8 {
-class Isolate;
-}
 namespace arangodb {
 
 class LogicalCollection;
@@ -81,14 +78,11 @@ class StorageEngine : public application_features::ApplicationFeature {
 
     startsAfter("CacheManager");
     startsAfter("DatabasePath");
-    startsAfter("EngineSelector");
     startsAfter("FileDescriptors");
+    startsAfter("StorageEngine");
     startsAfter("Temp");
     startsAfter("TransactionManager");
   }
-
-  virtual void start() {}
-  virtual void stop() {}
 
   virtual bool supportsDfdb() const = 0;
 

--- a/arangod/StorageEngine/StorageEngineFeature.h
+++ b/arangod/StorageEngine/StorageEngineFeature.h
@@ -1,0 +1,57 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2016 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Jan Christoph Uhde
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef ARANGOD_STORAGE_ENGINE_STORAGE_ENGINE_FEATURE_H
+#define ARANGOD_STORAGE_ENGINE_STORAGE_ENGINE_FEATURE_H 1
+
+#include "Basics/Common.h"
+#include "ApplicationFeatures/ApplicationFeature.h"
+
+namespace arangodb {
+// a stub class that "real" storage engines can require as their predecessor
+// it should make sure that the most relevant other application features
+// are already loaded
+class StorageEngineFeature : public application_features::ApplicationFeature {
+
+ public:
+  StorageEngineFeature(application_features::ApplicationServer* server)
+      : application_features::ApplicationFeature(server, "StorageEngine") {
+    setOptional(false);
+    // storage engines must not use elevated privileges for files etc
+    requiresElevatedPrivileges(false);
+
+    // all the following features need to be present for a concrete storage engine
+    startsAfter("CacheManager");
+    startsAfter("DatabasePath");
+    startsAfter("EngineSelector");
+    startsAfter("FileDescriptors");
+    startsAfter("Temp");
+    startsAfter("TransactionManager");
+  }
+
+};
+
+}
+
+#endif


### PR DESCRIPTION
so that other features can indicate that they need a storage engine
but do not need to reference a concrete storage engine such as "mmfiles"
or "rocksdb"