### PR TITLE
Carrotfix to only stop inception thread if it has been started

### DIFF
--- a/arangod/Agency/AgencyFeature.cpp
+++ b/arangod/Agency/AgencyFeature.cpp
@@ -289,7 +289,7 @@ void AgencyFeature::stop() {
     return;
   }
 
-  if (_agent->size() > 1 && _agent->inception() != nullptr) {
+  if (_agent->inception() != nullptr) { // can only exist in resilient agents
     int counter = 0;
     while (_agent->inception()->isRunning()) {
       usleep(100000);

--- a/arangod/Agency/AgencyFeature.cpp
+++ b/arangod/Agency/AgencyFeature.cpp
@@ -289,7 +289,7 @@ void AgencyFeature::stop() {
     return;
   }
 
-  if (_agent->inception() != nullptr) {
+  if (_agent->size() > 1 && _agent->inception() != nullptr) {
     int counter = 0;
     while (_agent->inception()->isRunning()) {
       usleep(100000);

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -1225,7 +1225,7 @@ void Agent::beginShutdown() {
   }
 
   // Stop inception process
-  if (_inception != nullptr) {
+  if (size() > 1 && _inception != nullptr) {
     _inception->beginShutdown();
   } 
 

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -52,13 +52,15 @@ Agent::Agent(config_t const& config)
     _readDB(this),
     _transient(this),
     _nextCompactionAfter(_config.compactionStepSize()),
-    _inception(std::make_unique<Inception>(this)),
     _activator(nullptr),
     _compactor(this),
     _ready(false),
     _preparing(false) {
   _state.configure(this);
   _constituent.configure(this);
+  if (size() > 1) {
+    _inception = std::make_unique<Inception>(this);
+  }
 }
 
 /// This agent's id
@@ -764,7 +766,7 @@ void Agent::load() {
     _supervision.start(this);
   }
 
-  if (size() > 1) {
+  if (_inception != nullptr) { // resilient agency only
     _inception->start();
   } else {
     _spearhead = _readDB;
@@ -1225,7 +1227,7 @@ void Agent::beginShutdown() {
   }
 
   // Stop inception process
-  if (size() > 1 && _inception != nullptr) {
+  if (_inception != nullptr) { // resilient agency only
     _inception->beginShutdown();
   } 
 
@@ -1579,7 +1581,7 @@ query_t Agent::gossip(query_t const& in, bool isCallback, size_t version) {
         20003, "Gossip message must contain string parameter 'endpoint'");
   }
   std::string endpoint = slice.get("endpoint").copyString();
-  if (isCallback) {
+  if ( _inception != nullptr && isCallback) {
     _inception->reportVersionForEp(endpoint, version);
   }
 


### PR DESCRIPTION
should really be done in the thread lib but that is a bit risky so
shortly before the release