### PR TITLE
slightly move responsibility for recovery

### DIFF
--- a/arangod/MMFiles/MMFilesCollection.cpp
+++ b/arangod/MMFiles/MMFilesCollection.cpp
@@ -483,7 +483,7 @@ MMFilesCollection::MMFilesCollection(LogicalCollection* collection,
       _cleanupIndexes(0),
       _persistentIndexes(0),
       _indexBuckets(Helper::readNumericValue<uint32_t>(
-          info, "indexBuckets", DatabaseFeature::defaultIndexBuckets())),
+          info, "indexBuckets", defaultIndexBuckets)),
       _useSecondaryIndexes(true),
       _doCompact(Helper::readBooleanValue(info, "doCompact", true)),
       _maxTick(0) {

--- a/arangod/MMFiles/MMFilesCollection.h
+++ b/arangod/MMFiles/MMFilesCollection.h
@@ -128,8 +128,10 @@ class MMFilesCollection final : public PhysicalCollection {
                              PhysicalCollection*);  // use in cluster only!!!!!
 
   ~MMFilesCollection();
+  
+  static constexpr uint32_t defaultIndexBuckets = 8;
 
-  constexpr static double defaultLockTimeout = 10.0 * 60.0;
+  static constexpr double defaultLockTimeout = 10.0 * 60.0;
 
   std::string const& path() const override { return _path; };
 

--- a/arangod/MMFiles/MMFilesLogfileManager.cpp
+++ b/arangod/MMFiles/MMFilesLogfileManager.cpp
@@ -441,15 +441,6 @@ bool MMFilesLogfileManager::open() {
   // tell the allocator that the recovery is over now
   _allocatorThread->recoveryDone();
 
-  // start compactor threads etc.
-  auto databaseFeature = ApplicationServer::getFeature<DatabaseFeature>("Database");
-  res = databaseFeature->recoveryDone();
-
-  if (res != TRI_ERROR_NO_ERROR) {
-    LOG_TOPIC(FATAL, arangodb::Logger::FIXME) << "could not initialize databases: " << TRI_errno_string(res);
-    return false;
-  }
-
   return true;
 }
 

--- a/arangod/MMFiles/MMFilesWalRecoveryFeature.cpp
+++ b/arangod/MMFiles/MMFilesWalRecoveryFeature.cpp
@@ -28,6 +28,7 @@
 #include "ProgramOptions/ProgramOptions.h"
 #include "ProgramOptions/Section.h"
 #include "MMFiles/MMFilesLogfileManager.h"
+#include "RestServer/DatabaseFeature.h"
 
 using namespace arangodb;
 using namespace arangodb::application_features;
@@ -68,5 +69,9 @@ void MMFilesWalRecoveryFeature::start() {
     // if we got here, the MMFilesLogfileManager has already logged a fatal error and we can simply abort
     FATAL_ERROR_EXIT();
   }
+  
+  // notify everyone that recovery is now done
+  auto databaseFeature = ApplicationServer::getFeature<DatabaseFeature>("Database");
+  databaseFeature->recoveryDone();
 }
 

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -438,8 +438,10 @@ void DatabaseFeature::unprepare() {
 }
 
 /// @brief will be called when the recovery phase has run
-/// this will start the compactors and replication appliers for all databases
-int DatabaseFeature::recoveryDone() {
+/// this will call the engine-specific recoveryDone() procedures
+/// and will execute engine-unspecific operations (such as starting
+/// the replication appliers) for all databases
+void DatabaseFeature::recoveryDone() {
   StorageEngine* engine = EngineSelectorFeature::ENGINE;
 
   auto unuser(_databasesProtector.use());
@@ -451,10 +453,10 @@ int DatabaseFeature::recoveryDone() {
     TRI_ASSERT(vocbase != nullptr);
     TRI_ASSERT(vocbase->type() == TRI_VOCBASE_TYPE_NORMAL);
 
-    // start the compactor for the database
+    // execute the engine-specific callbacks on successful recovery
     engine->recoveryDone(vocbase);
 
-    // start the replication applier
+    // start the replication applier, which is engine-unspecific
     TRI_ASSERT(vocbase->replicationApplier() != nullptr);
 
     if (vocbase->replicationApplier()->_configuration._autoStart) {
@@ -471,8 +473,6 @@ int DatabaseFeature::recoveryDone() {
       }
     }
   }
-
-  return TRI_ERROR_NO_ERROR;
 }
 
 /// @brief create a new database

--- a/arangod/RestServer/DatabaseFeature.h
+++ b/arangod/RestServer/DatabaseFeature.h
@@ -76,11 +76,13 @@ class DatabaseFeature final : public application_features::ApplicationFeature {
   void stop() override final;
   void unprepare() override final;
 
-  int recoveryDone();
+  /// @brief will be called when the recovery phase has run
+  /// this will call the engine-specific recoveryDone() procedures
+  /// and will execute engine-unspecific operations (such as starting
+  /// the replication appliers) for all databases
+  void recoveryDone();
 
  public:
-
-  static constexpr uint32_t defaultIndexBuckets() { return 8; }
 
    /// @brief get the ids of all local coordinator databases
   std::vector<TRI_voc_tick_t> getDatabaseIdsCoordinator(bool includeSystem);

--- a/arangod/RocksDBEngine/RocksDBCounterManager.cpp
+++ b/arangod/RocksDBEngine/RocksDBCounterManager.cpp
@@ -86,11 +86,21 @@ RocksDBCounterManager::RocksDBCounterManager(rocksdb::DB* db)
   readIndexEstimates();
 
   readCounterValues();
+}
+
+/// parse recent RocksDB WAL entries and notify the
+/// DatabaseFeature about the successful recovery
+void RocksDBCounterManager::runRecovery() {
   if (!_counters.empty()) {
     if (parseRocksWAL()) {
+      // TODO: what do we do if parseRocksWAL returns false?
       sync(false);
     }
   }
+
+  // notify everyone that recovery is now done
+  auto databaseFeature = ApplicationServer::getFeature<DatabaseFeature>("Database");
+  databaseFeature->recoveryDone();
 }
 
 RocksDBCounterManager::CounterAdjustment RocksDBCounterManager::loadCounter(

--- a/arangod/RocksDBEngine/RocksDBCounterManager.h
+++ b/arangod/RocksDBEngine/RocksDBCounterManager.h
@@ -71,6 +71,8 @@ class RocksDBCounterManager {
     TRI_voc_rid_t revisionId() const { return _revisionId; }
   };
 
+  void runRecovery();
+
   /// Thread-Safe load a counter
   CounterAdjustment loadCounter(uint64_t objectId) const;
 

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -505,6 +505,8 @@ void RocksDBEngine::start() {
   _counterManager.reset(new RocksDBCounterManager(_db));
   _replicationManager.reset(new RocksDBReplicationManager());
 
+  _counterManager->runRecovery();
+
   double const counter_sync_seconds = 2.5;
   _backgroundThread.reset(
       new RocksDBBackgroundThread(this, counter_sync_seconds));


### PR DESCRIPTION
This patch slightly simplifies the `recoveryDone()` API and makes responsibility a bit clearer.
It also implements the call to `recoveryDone()` from within the RocksDB engine.