### PR TITLE
do not go on happily in case of OOM but abort the operation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.1.27 (XXXX-XX-XX)
 --------------------
 
+* fixed revision cache cleanup behavior in out-of-memory situations
+
 * fixed issue #2889: Traversal query using incorrect collection id
 
 * fixed issue #2884: AQL traversal uniqueness constraints "propagating" to other traversals? Weird results

--- a/arangod/VocBase/RevisionCacheChunk.cpp
+++ b/arangod/VocBase/RevisionCacheChunk.cpp
@@ -153,7 +153,9 @@ bool RevisionCacheChunk::invalidate(std::vector<TRI_voc_rid_t>& revisions) {
   revisions.clear();
   revisions.reserve(8192);
 
-  findRevisions(revisions);
+  if (!findRevisions(revisions)) {
+    return false;
+  }
   invalidate();
   if (!revisions.empty()) {
     _collectionCache->removeRevisions(revisions);
@@ -163,7 +165,7 @@ bool RevisionCacheChunk::invalidate(std::vector<TRI_voc_rid_t>& revisions) {
   return true;
 }
 
-void RevisionCacheChunk::findRevisions(std::vector<TRI_voc_rid_t>& revisions) {
+bool RevisionCacheChunk::findRevisions(std::vector<TRI_voc_rid_t>& revisions) {
   // no need for write mutex here as the chunk is read-only once fully
   // written to
   uint8_t const* data = _data;
@@ -180,8 +182,10 @@ void RevisionCacheChunk::findRevisions(std::vector<TRI_voc_rid_t>& revisions) {
       revisions.emplace_back(rid);
     } catch (...) {
       // LOG(ERR) << "SLICE: " << slice.toJson();
+      return false;
     }
   }
+  return true;
 }
 
 void RevisionCacheChunk::invalidate() { 

--- a/arangod/VocBase/RevisionCacheChunk.h
+++ b/arangod/VocBase/RevisionCacheChunk.h
@@ -119,7 +119,7 @@ class RevisionCacheChunk {
   
  private:
   
-  void findRevisions(std::vector<TRI_voc_rid_t>& revisions);
+  bool findRevisions(std::vector<TRI_voc_rid_t>& revisions);
   void invalidate();
 
   static inline uint32_t versionPart(uint64_t value) {


### PR DESCRIPTION
going on will remove not all revisions from the revisions map, so they will still point to the chunk that is about to be removed