### PR TITLE
improve shutdown and feature reusability in tests

### DIFF
--- a/arangod/RestServer/FeatureCacheFeature.cpp
+++ b/arangod/RestServer/FeatureCacheFeature.cpp
@@ -37,6 +37,14 @@ FeatureCacheFeature::FeatureCacheFeature(application_features::ApplicationServer
       _databaseFeature(nullptr) {
   setOptional(false);
   requiresElevatedPrivileges(false);
+
+  // reset it so it can be used in multiple tests
+  Instance = nullptr;
+}
+
+FeatureCacheFeature::~FeatureCacheFeature() {
+  // reset it so it can be used in multiple tests
+  Instance = nullptr;
 }
 
 void FeatureCacheFeature::prepare() {

--- a/arangod/RestServer/FeatureCacheFeature.h
+++ b/arangod/RestServer/FeatureCacheFeature.h
@@ -32,6 +32,7 @@ class DatabaseFeature;
 class FeatureCacheFeature final : public application_features::ApplicationFeature {
  public:
   explicit FeatureCacheFeature(application_features::ApplicationServer*);
+  ~FeatureCacheFeature();
 
  public:
   void prepare() override final;

--- a/lib/ApplicationFeatures/ApplicationServer.cpp
+++ b/lib/ApplicationFeatures/ApplicationServer.cpp
@@ -611,6 +611,7 @@ void ApplicationServer::start() {
         if (feature->state() == FeatureState::STARTED) {
           LOG_TOPIC(TRACE, Logger::STARTUP) << "forcefully stopping feature '" << feature->name() << "'";
           try {
+            feature->beginShutdown();
             feature->stop();
             feature->state(FeatureState::STOPPED);
           } catch (...) {


### PR DESCRIPTION
Call beginShutdown() for all started features when there is a hard shutdown