### PR TITLE
fix building with relative paths

### DIFF
--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -131,7 +131,11 @@ function setupBinaries (builddir, buildType, configDir) {
   ARANGOEXPORT_BIN = fs.join(BIN_DIR, 'arangoexport' + executableExt);
   ARANGOSH_BIN = fs.join(BIN_DIR, 'arangosh' + executableExt);
 
-  CONFIG_ARANGODB_DIR = fs.join(TOP_DIR, builddir, 'etc', 'arangodb3');
+  CONFIG_ARANGODB_DIR = fs.join(builddir, 'etc', 'arangodb3'); 
+  if(!fs.exists(CONFIG_ARANGODB_DIR)){
+    CONFIG_ARANGODB_DIR = fs.join(TOP_DIR, CONFIG_ARANGODB_DIR);
+  }
+
   CONFIG_RELATIVE_DIR = fs.join(TOP_DIR, 'etc', 'relative');
   CONFIG_DIR = fs.join(TOP_DIR, configDir);
 

--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -111,7 +111,11 @@ function setupBinaries (builddir, buildType, configDir) {
     }
   }
 
-  BIN_DIR = fs.join(TOP_DIR, builddir, 'bin');
+  BIN_DIR = fs.join(builddir, 'bin');
+  if(!fs.exists(BIN_DIR)){
+    BIN_DIR = fs.join(TOP_DIR, BIN_DIR);
+  }
+
   UNITTESTS_DIR = fs.join(TOP_DIR, fs.join(builddir, 'tests'));
 
   if (buildType !== '') {


### PR DESCRIPTION
The pull request was recated because tests fail to find the arangobench executable.

```
it: feature/js_to_cpp_transaction_handler $=
»  bash -x ./scripts/unittest all
+ export PID=17621
+ PID=17621
+ export GLIBCXX_FORCE_NEW=1
+ GLIBCXX_FORCE_NEW=1
+ test -n ''
+ export EXT=
+ EXT=
+ PS=/
++ expr 1024 + 15271
+ export PORT=16295
+ PORT=16295
+ NUMA=
++ which numactl
+ NUMA='numactl --interleave=all'
+ '[' -z '' ']'
+ '[' -x build/bin/arangosh ']'
+ ARANGOSH=build/bin/arangosh
+ declare -a EXTRA_ARGS
++ uname -s
+ '[' Linux == Darwin ']'
++++ readlink -m ./scripts/unittest
+++ dirname /mnt/c9/jan/arangodb2/scripts/unittest
++ dirname /mnt/c9/jan/arangodb2/scripts
+ EXEC_PATH=/mnt/c9/jan/arangodb2
+ '[' -x build/bin/arangosh ']'
++ readlink -m build/bin/arangosh
+ ARANGOSH=/mnt/c9/jan/arangodb2-build/Release-asan/bin/arangosh
+ [[  all  =~ --build ]]
+++ dirname /mnt/c9/jan/arangodb2-build/Release-asan/bin/arangosh
++ dirname /mnt/c9/jan/arangodb2-build/Release-asan/bin
+ BUILD_PATH=/mnt/c9/jan/arangodb2-build/Release-asan
+ BUILD_PATH=/mnt/c9/jan/arangodb2-build/Release-asan
+ EXTRA_ARGS=("--build" "${BUILD_PATH}")
+ cd /mnt/c9/jan/arangodb2
+ exec numactl --interleave=all /mnt/c9/jan/arangodb2-build/Release-asan/bin/arangosh -c etc/relative/arangosh.conf --log.level warning --server.endpoint tcp://127.0.0.1:16295 --javascript.execute UnitTests/unittest.js -- all --build /mnt/c9/jan/arangodb2-build/Release-asan
2017-08-08T05:55:52Z [17635] WARNING arangosh.rc: ReferenceError: test_massif is not defined
caught exception during test execution!
unable to locate /mnt/c9/jan/arangodb2/mnt/c9/jan/arangodb2-build/Release-asan/bin/arangobench
Error: unable to locate /mnt/c9/jan/arangodb2/mnt/c9/jan/arangodb2-build/Release-asan/bin/arangobench
    at Object.setupBinaries (/mnt/c9/jan/arangodb2/js/client/modules/@arangodb/process-utils.js:149:13)
    at Object.unitTest (/mnt/c9/jan/arangodb2/js/client/modules/@arangodb/testing.js:447:6)
    at main (UnitTests/unittest.js:205:18)
    at UnitTests/unittest.js:260:14
{}
================================================================================

TEST RESULTS

================================================================================
* Overall state: Fail BUT! - We had at least one unclean shutdown or crash during the testrun.
   Suites failed: 0 Tests Failed: 0
```

As you can see the full qualified path is passed in with the `--build` option. In the function that is modified in the pull request the build path was unconditionally prefixed with TOPDIR what lead to the creation of a faulty path. I assume that something in the calling script changed in a way that now full paths are passed in under some conditions.

The patch checks if the builddir is already a valid directory and if so forgoes further modification.