### PR TITLE
Fix foxx github url

### DIFF
--- a/js/actions/_admin/foxx/app.js
+++ b/js/actions/_admin/foxx/app.js
@@ -68,7 +68,7 @@ function resolveAppInfo (appInfo) {
   }
   if (/^git:/i.test(appInfo)) {
     const splitted = appInfo.split(':');
-    const baseUrl = process.env.FOXX_BASE_URL || 'https://github.com';
+    const baseUrl = process.env.FOXX_BASE_URL || 'https://github.com/';
     return `${baseUrl}${splitted[1]}/archive/${splitted[2] || 'master'}.zip`;
   }
   if (/^https?:/i.test(appInfo)) {

--- a/js/apps/system/_admin/aardvark/APP/foxxes.js
+++ b/js/apps/system/_admin/aardvark/APP/foxxes.js
@@ -135,7 +135,7 @@ installer.put('/store', function (req) {
 `);
 
 installer.put('/git', function (req) {
-  const baseUrl = process.env.FOXX_BASE_URL || 'https://github.com';
+  const baseUrl = process.env.FOXX_BASE_URL || 'https://github.com/';
   req.body = `${baseUrl}${req.body.url}/archive/${req.body.version || 'master'}.zip`;
 })
 .body(joi.object({


### PR DESCRIPTION
fixed the following error when installing a foxx service via github

`via InternalServerError: Could not connect to 'http+ssl://github.comarangodb-foxx:443' 'getaddrinfo for host 'github.comarangodb-foxx': nodename nor servname provided, or not known'`