### PR TITLE
fill in ARANGOD_CONF_DIR in the wrapper scripts as sugested by @laird…

### DIFF
--- a/Installation/MacOSX/Bundle/arangodb-cli.sh.in
+++ b/Installation/MacOSX/Bundle/arangodb-cli.sh.in
@@ -57,7 +57,7 @@ for script in $SCRIPTS; do
     echo "export ROOTDIR=\"${ROOTDIR}@CMAKE_INSTALL_PREFIX@\""
     echo
 
-    echo "exec \"\${ROOTDIR}/$script\" -c \"\${ARANGOD_CONF_DIR}/${base}.conf\" \$*"
+    echo "exec \"\${ROOTDIR}/$script\" -c \"${ARANGOD_CONF_DIR}/${base}.conf\" \$*"
   ) > "${ROOTDIR}/$base.$$"
 
   chmod 755 "${ROOTDIR}/$base.$$"


### PR DESCRIPTION
… in #3014 so the wrapper scripts properly locate their respective config