### PR TITLE
remove directory first, so we don't copy it into a sub directory

### DIFF
--- a/Documentation/Books/build.sh
+++ b/Documentation/Books/build.sh
@@ -617,6 +617,7 @@ function build-dist-books()
 	mv books "ArangoDB-${newVersionNumber}"
         pwd
 	if test -n "${COOKBOOK_DIR}" ; then
+            rm -rf "ArangoDB-${newVersionNumber}/cookbook"
 	    cp -a "${COOKBOOK_DIR}" "ArangoDB-${newVersionNumber}/cookbook"
 	fi
 	tar -czf "${OUTPUT_DIR}/ArangoDB-${newVersionNumber}.tar.gz" "ArangoDB-${newVersionNumber}"


### PR DESCRIPTION
fix cookbook being an old version