### PR TITLE
Feature/cluster inventory version

### DIFF
--- a/arangod/Aql/ExecutionEngine.cpp
+++ b/arangod/Aql/ExecutionEngine.cpp
@@ -903,7 +903,9 @@ struct CoordinatorInstanciator : public WalkerWorker<ExecutionNode> {
     Serv2ColMap mappingServerToCollections;
     size_t length = edges.size();
     
+#ifdef USE_ENTERPRISE
     transaction::Methods* trx = query->trx();
+#endif
     
     auto findServerLists = [&] (ShardID const& shard) -> Serv2ColMap::iterator {
       auto serverList = clusterInfo->getResponsibleServer(shard);

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -56,22 +56,17 @@ class CollectionInfoCurrent {
   friend class ClusterInfo;
 
  public:
-  CollectionInfoCurrent();
+  CollectionInfoCurrent(uint64_t currentVersion);
 
-  CollectionInfoCurrent(ShardID const&, VPackSlice);
+  CollectionInfoCurrent(CollectionInfoCurrent const&) = delete;
 
-  CollectionInfoCurrent(CollectionInfoCurrent const&);
+  CollectionInfoCurrent(CollectionInfoCurrent&&) = delete;
 
-  CollectionInfoCurrent(CollectionInfoCurrent&&);
+  CollectionInfoCurrent& operator=(CollectionInfoCurrent const&) = delete;
 
-  CollectionInfoCurrent& operator=(CollectionInfoCurrent const&);
-
-  CollectionInfoCurrent& operator=(CollectionInfoCurrent&&);
+  CollectionInfoCurrent& operator=(CollectionInfoCurrent&&) = delete;
 
   ~CollectionInfoCurrent();
-
- private:
-  void copyAllVPacks();
 
  public:
   bool add(ShardID const& shardID, VPackSlice slice) {
@@ -178,6 +173,14 @@ class CollectionInfoCurrent {
   }
 
   //////////////////////////////////////////////////////////////////////////////
+  /// @brief get version that underlies this info in Current in the agency
+  //////////////////////////////////////////////////////////////////////////////
+
+  uint64_t getCurrentVersion() const {
+    return _currentVersion;
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
   /// @brief local helper to return boolean flags
   //////////////////////////////////////////////////////////////////////////////
 
@@ -206,6 +209,9 @@ class CollectionInfoCurrent {
 
  private:
   std::unordered_map<ShardID, std::shared_ptr<VPackBuilder>> _vpacks;
+
+  uint64_t _currentVersion;    // Version of Current in the agency that
+                               // underpins the data presented in this object
 };
 
 class ClusterInfo {
@@ -609,6 +615,12 @@ class ClusterInfo {
 
   ProtectionData _planProt;
 
+  uint64_t _planVersion;   // This is the version in the Plan which underlies
+                           // the data in _plannedCollections, _shards and
+                           // _shardKeys
+  uint64_t _currentVersion;  // This is the version in Current which underlies
+                             // the data in _currentDatabases,
+                             // _currentCollections and _shardsIds
   std::unordered_map<DatabaseID,
                      std::unordered_map<ServerID, VPackSlice>>
       _currentDatabases;  // from Current/Databases

--- a/arangod/Cluster/v8-cluster.cpp
+++ b/arangod/Cluster/v8-cluster.cpp
@@ -706,6 +706,8 @@ static void JS_GetCollectionInfoCurrentClusterInfo(
       ClusterInfo::instance()->getCollectionCurrent(TRI_ObjectToString(args[0]),
                                                     cid);
 
+  result->Set(TRI_V8_ASCII_STRING("currentVersion"),
+              v8::Number::New(isolate, (double) cic->getCurrentVersion()));
   result->Set(TRI_V8_ASCII_STRING("type"),
               v8::Number::New(isolate, (int)ci->type()));
 

--- a/arangod/VocBase/LogicalCollection.h
+++ b/arangod/VocBase/LogicalCollection.h
@@ -255,7 +255,8 @@ class LogicalCollection {
       bool forPersistence) const;
 
   virtual void toVelocyPackForClusterInventory(velocypack::Builder&,
-                                               bool useSystem) const;
+                                               bool useSystem,
+                                               bool isReady) const;
 
   inline TRI_vocbase_t* vocbase() const { return _vocbase; }
 
@@ -346,6 +347,14 @@ class LogicalCollection {
   // with the checksum provided in the reference checksum
   Result compareChecksums(velocypack::Slice checksumSlice, std::string const& referenceChecksum) const;
 
+  // Set and get _planVersion, this is only used if the object is used in
+  // ClusterInfo to represent a cluster wide collection in the agency.
+  void setPlanVersion(uint64_t v) {
+    _planVersion = v;
+  }
+  uint64_t getPlanVersion() const {
+    return _planVersion;
+  }
  private:
   void prepareIndexes(velocypack::Slice indexesSlice);
 
@@ -431,6 +440,12 @@ class LogicalCollection {
   std::unordered_map<std::string, double> _clusterEstimates;
   double _clusterEstimateTTL; //only valid if above vector is not empty
   basics::ReadWriteLock _clusterEstimatesLock;
+
+  uint64_t _planVersion;   // Only set if setPlanVersion was called. This only
+                           // happens in ClusterInfo when this object is used
+                           // to represent a cluster wide collection. This is
+                           // then the version in the agency Plan that underpins
+                           // the information in this object. Otherwise 0.
 };
 
 }  // namespace arangodb


### PR DESCRIPTION
Teach /_api/replication/clusterInventory to report Plan/Version and readiness.
    
This is first implemented in the ClusterInfo library. Then the clusterInventory code uses it and checks readiness. Readiness of a collection means that it is created and all shards and all replications have been created and are in sync.
