### PR TITLE
Fixing error reporting in arangoimp

### DIFF
--- a/arangosh/Import/ImportFeature.cpp
+++ b/arangosh/Import/ImportFeature.cpp
@@ -462,7 +462,7 @@ void ImportFeature::start() {
       }
 
     } else {
-      LOG_TOPIC(ERR, arangodb::Logger::FIXME) << "error message:";
+      LOG_TOPIC(ERR, arangodb::Logger::FIXME) << "error message(s):";
       for (std::string const& msg : ih.getErrorMessages()) {
         LOG_TOPIC(ERR, arangodb::Logger::FIXME) << msg;
       }

--- a/arangosh/Import/ImportHelper.cpp
+++ b/arangosh/Import/ImportHelper.cpp
@@ -846,13 +846,17 @@ void ImportHelper::waitForSenders() {
     uint32_t numIdle = 0;
     for (auto const& t : _senderThreads) {
       if (t->isDone()) {
+        if (t->hasError()) {
+          _hasError = true;
+          _errorMessages.push_back(t->errorMessage());
+        }
         numIdle++;
       }
     }
     if (numIdle == _senderThreads.size()) {
       return;
     }
-    usleep(100000);
+    usleep(10000);
   }
 }
 }


### PR DESCRIPTION
- When arangoimp has parsed the input file already, errors from the `arangod` server are not reported to the user anymore
- Arangoimp does not properly wait for all sender threads to finish, if the _hasError path is set too early