### PR TITLE
Make foxx queue tests more stable

### DIFF
--- a/js/client/tests/shell/shell-foxx-queue-spec.js
+++ b/js/client/tests/shell/shell-foxx-queue-spec.js
@@ -98,11 +98,17 @@ describe('Foxx service', () => {
     });
     expect(res.code).to.equal(204);
     expect(waitForJob()).to.equal(true);
-    const jobResult = db._query(aql`
-      FOR i IN foxx_queue_test
-        FILTER i.job == true
-        RETURN 1
-    `).toArray();
+
+    let retryCount = 0;
+    var jobResult = [];
+    while ((jobResult.length !== 1) && (retryCount < 50)) {
+      jobResult = db._query(aql`
+                            FOR i IN foxx_queue_test
+                            FILTER i.job == true
+                            RETURN 1
+                            `).toArray();
+      retryCount++;
+    }
     expect(jobResult.length).to.equal(1);
   });
   const waitForJob = () => {

--- a/js/common/test-data/apps/queue/job.js
+++ b/js/common/test-data/apps/queue/job.js
@@ -1,4 +1,5 @@
 'use strict';
 
 const db = require('@arangodb').db;
+db['foxx_queue_test'].truncate();
 db['foxx_queue_test'].save({job: true});


### PR DESCRIPTION
 - flush the test-collection before we add our tested entry
 - retry 50 times before we make the test failed