### PR TITLE
Bugfix/fix test arangod shutdown command

### DIFF
--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -758,6 +758,18 @@ function shutdownArangod (arangod, options, forceTerminate) {
     } else if (options.useKillExternal) {
       killExternal(arangod.pid);
     } else {
+      if (arango.isConnected) {
+        try {
+          arango.DELETE('/_admin/shutdown');
+          if (options.extremeVerbosity) {
+            print('Shutdown response: ' + JSON.stringify(reply));
+          }
+          return;
+        } catch (x) {
+          print('failed to shut down arangod via our connection!')
+          print(x);
+        }
+      }
       const requestOptions = makeAuthorizationHeaders(options);
       requestOptions.method = 'DELETE';
       print(arangod.url + '/_admin/shutdown');

--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -758,7 +758,7 @@ function shutdownArangod (arangod, options, forceTerminate) {
     } else if (options.useKillExternal) {
       killExternal(arangod.pid);
     } else {
-      if (arango.isConnected) {
+      if (arango.isConnected()) {
         try {
           arango.DELETE('/_admin/shutdown');
           if (options.extremeVerbosity) {

--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -766,7 +766,7 @@ function shutdownArangod (arangod, options, forceTerminate) {
           }
           return;
         } catch (x) {
-          print('failed to shut down arangod via our connection!')
+          print('failed to shut down arangod via our connection!');
           print(x);
         }
       }

--- a/js/client/modules/@arangodb/testsuites/endpoints.js
+++ b/js/client/modules/@arangodb/testsuites/endpoints.js
@@ -95,8 +95,8 @@ function endpoints (options) {
         let result = tu.runInArangosh(options, instanceInfo, 'js/client/tests/endpoint-spec.js');
 
         print(CYAN + 'Shutting down...' + RESET);
-        // mop: mehhh...when launched with a socket we can't use download :S
-        pu.shutdownInstance(instanceInfo, Object.assign(options, {useKillExternal: true}));
+
+        pu.shutdownInstance(instanceInfo, Object.assign(options));
         print(CYAN + 'done.' + RESET);
 
         if (!result.status) {


### PR DESCRIPTION
Windows may not wait long enough after using killExternal to shut down arangodb and tests may fail.