### PR TITLE
Bug fix/agency compactor deadlock

### DIFF
--- a/arangod/Agency/Compactor.cpp
+++ b/arangod/Agency/Compactor.cpp
@@ -91,9 +91,6 @@ void Compactor::beginShutdown() {
     
   Thread::beginShutdown();
 
-  {
-    CONDITION_LOCKER(guard, _cv);
-    guard.broadcast();
-  }
-  
+  wakeUp();
+
 }

--- a/arangod/Agency/Compactor.cpp
+++ b/arangod/Agency/Compactor.cpp
@@ -32,7 +32,7 @@ using namespace arangodb::consensus;
 
 // @brief Construct with agent
 Compactor::Compactor(Agent* agent) :
-  Thread("Compactor"), _agent(agent), _waitInterval(1000000) {
+  Thread("Compactor"), _agent(agent), _wakeupCompactor(false), _waitInterval(1000000) {
 }
 
 
@@ -49,10 +49,14 @@ void Compactor::run() {
 
   LOG_TOPIC(DEBUG, Logger::AGENCY) << "Starting compactor personality";
 
-  CONDITION_LOCKER(guard, _cv);
-      
   while (true) {
-    _cv.wait();
+    {
+      CONDITION_LOCKER(guard, _cv);
+      if (!_wakeupCompactor) {
+        _cv.wait();
+      }
+    }
+    _wakeupCompactor = false;
     
     if (this->isStopping()) {
       break;
@@ -74,8 +78,9 @@ void Compactor::run() {
 void Compactor::wakeUp () {
   {
     CONDITION_LOCKER(guard, _cv);
-    guard.broadcast();
+    _wakeupCompactor = true;
   }
+  _cv.broadcast();
 }
 
 

--- a/arangod/Agency/Compactor.h
+++ b/arangod/Agency/Compactor.h
@@ -60,6 +60,7 @@ private:
   
   Agent* _agent; //< @brief Agent
   basics::ConditionVariable _cv;
+  bool _wakeupCompactor;
   long _waitInterval; //< @brief Wait interval 
   
 };

--- a/arangod/Agency/Compactor.h
+++ b/arangod/Agency/Compactor.h
@@ -59,6 +59,10 @@ public:
 private:
   
   Agent* _agent; //< @brief Agent
+  // This condition variable is used for the compactor thread to go to
+  // sleep. One has to set _wakeupCompactor to true under the Mutex of _cv
+  // and then broadcast on the _cv to wake up the compactor thread.
+  // Note that the Mutex is not held during the actual compaction!
   basics::ConditionVariable _cv;
   bool _wakeupCompactor;
   long _waitInterval; //< @brief Wait interval 


### PR DESCRIPTION
This fixes a possible deadlock between the compactor thread and the agent thread. Furthermore, the agent main thread now waits for all its agency subthreads to terminate at shutdown.