### PR TITLE
fix potential overflow in CRC marker check when a corrupted CRC marke…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.2.5 (2017-XX-XX)
 -------------------
 
+* fix potential overflow in CRC marker check when a corrupted CRC marker 
+  is found at the very beginning of an MMFiles datafile
+
 * UI: fixed unresponsive events in cluster shards view
 
 * Add statistics about the V8 context counts and number of available/active/busy

--- a/arangod/MMFiles/MMFilesDatafile.cpp
+++ b/arangod/MMFiles/MMFilesDatafile.cpp
@@ -82,7 +82,7 @@ static TRI_voc_crc_t Crc28(TRI_voc_crc_t crc, void const* data, size_t length) {
 }
 
 /// @brief check if a marker appears to be created by ArangoDB 2.8
-static bool IsMarker28(void const* marker) {
+static bool IsMarker28(void const* marker, size_t length) {
   struct Marker28 {
     TRI_voc_size_t       _size; 
     TRI_voc_crc_t        _crc;     
@@ -99,6 +99,10 @@ static bool IsMarker28(void const* marker) {
 
   char const* ptr = static_cast<char const*>(marker);
   Marker28 const* m = static_cast<Marker28 const*>(marker);
+  
+  if (m->_size < o + n || (m->_size - o - n > length)) {
+    return false;
+  }
 
   TRI_voc_crc_t crc = TRI_InitialCrc32();
 
@@ -1873,7 +1877,7 @@ MMFilesDatafile* MMFilesDatafile::openHelper(std::string const& filename, bool i
   ok = CheckCrcMarker(reinterpret_cast<MMFilesMarker const*>(ptr), end);
 
   if (!ok) {
-    if (IsMarker28(ptr)) {
+    if (IsMarker28(ptr, len)) {
       TRI_TRACKED_CLOSE_FILE(fd);
       LOG_TOPIC(ERR, arangodb::Logger::FIXME) << "datafile found from older version of ArangoDB. "
                << "Please dump data from that version with arangodump "


### PR DESCRIPTION
…r is found at the very beginning of an MMFiles datafile