### PR TITLE
Add host id detection and show in /_admin/cluster/Health.

### DIFF
--- a/arangod/Agency/AgencyFeature.cpp
+++ b/arangod/Agency/AgencyFeature.cpp
@@ -208,6 +208,19 @@ void AgencyFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
                                        << "' specified for --agency.my-address";
       FATAL_ERROR_EXIT();
     }
+
+    std::string fallback = unified;
+    // Now extract the hostname/IP:
+    auto pos = fallback.find("://");
+    if (pos != std::string::npos) {
+      fallback = fallback.substr(pos+3);
+    }
+    pos = fallback.rfind(':');
+    if (pos != std::string::npos) {
+      fallback = fallback.substr(0, pos);
+    }
+    auto ss = ServerState::instance();
+    ss->findHost(fallback);
   }
 }
 

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -156,6 +156,8 @@ void ClusterFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
 
   if (!_enableCluster) {
     ServerState::instance()->setRole(ServerState::ROLE_SINGLE);
+    auto ss = ServerState::instance();
+    ss->findHost("localhost");
     return;
   }
 
@@ -185,6 +187,19 @@ void ClusterFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
     LOG_TOPIC(FATAL, arangodb::Logger::CLUSTER) << "system replication factor must be greater 0";
     FATAL_ERROR_EXIT();
   }
+
+  std::string fallback = _myAddress;
+  // Now extract the hostname/IP:
+  auto pos = fallback.find("://");
+  if (pos != std::string::npos) {
+    fallback = fallback.substr(pos+3);
+  }
+  pos = fallback.rfind(':');
+  if (pos != std::string::npos) {
+    fallback = fallback.substr(0, pos);
+  }
+  auto ss = ServerState::instance();
+  ss->findHost(fallback);
 
   if (!_myRole.empty()) {
     _requestedRole = ServerState::stringToRole(_myRole);
@@ -445,6 +460,7 @@ void ClusterFeature::start() {
     try {
       VPackObjectBuilder b(&builder);
       builder.add("endpoint", VPackValue(_myAddress));
+      builder.add("host", VPackValue(ServerState::instance()->getHost()));
     } catch (...) {
       LOG_TOPIC(FATAL, arangodb::Logger::CLUSTER) << "out of memory";
       FATAL_ERROR_EXIT();

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -66,6 +66,46 @@ ServerState::ServerState()
   storeRole(ROLE_UNDEFINED);
 }
 
+void ServerState::findHost(std::string const& fallback) {
+  // Compute a string identifying the host on which we are running, note
+  // that this is more complicated than immediately obvious, because we
+  // could sit in a container which is deployed by Kubernetes or Mesos or
+  // some other orchestration framework:
+
+  // the following is set by Mesos or by an administrator:
+  char* p = getenv("HOST");
+  if (p != NULL) {
+    _host = p;
+    return;
+  }
+
+  // the following is set by Kubernetes when using the downward API:
+  p = getenv("NODE_NAME");
+  if (p != NULL) {
+    _host = p;
+    return;
+  }
+
+  // Now look at the contents of the file /etc/machine-id, if it exists:
+  std::string name = "/etc/machine-id";
+  try {
+    _host = arangodb::basics::FileUtils::slurp(name);
+    while (!_host.empty() &&
+           (_host.back() == '\r' || _host.back() == '\n' ||
+            _host.back() == ' ')) {
+      _host.erase(_host.size() - 1);
+    }
+    if (!_host.empty()) {
+      return;
+    }
+  } catch (...) { }
+
+  // Finally, as a last resort, take the fallback, coming from
+  // the ClusterFeature with the value of --cluster.my-address
+  // or by the AgencyFeature with the value of --agency.my-address:
+  _host = fallback;
+}
+
 ServerState::~ServerState() {}
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/arangod/Cluster/ServerState.h
+++ b/arangod/Cluster/ServerState.h
@@ -184,6 +184,14 @@ class ServerState {
   /// @brief set the server address
   void setAddress(std::string const&);
 
+  /// @brief find a host identification string
+  void findHost(std::string const& fallback);
+
+  /// @brief get a string to identify the host we are running on
+  std::string getHost() {
+    return _host;
+  }
+
   /// @brief get the current state
   StateEnum getState();
 
@@ -282,6 +290,9 @@ class ServerState {
 
   /// @brief the server's own address, can be set just once
   std::string _address;
+
+  /// @brief an identification string for the host a server is running on
+  std::string _host;
 
   /// @brief r/w lock for state
   arangodb::basics::ReadWriteLock _lock;

--- a/arangod/RestHandler/RestVersionHandler.cpp
+++ b/arangod/RestHandler/RestVersionHandler.cpp
@@ -23,6 +23,7 @@
 
 #include "RestVersionHandler.h"
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Cluster/ServerState.h"
 #include "Rest/HttpRequest.h"
 #include "Rest/Version.h"
 #include "RestServer/ServerFeature.h"
@@ -68,6 +69,10 @@ RestStatus RestVersionHandler::execute() {
       auto server = application_features::ApplicationServer::server
                         ->getFeature<ServerFeature>("Server");
       result.add("mode", VPackValue(server->operationModeString()));
+    }
+    std::string host = ServerState::instance()->getHost();
+    if (!host.empty()) {
+      result.add("host", VPackValue(host));
     }
 
     result.close();


### PR DESCRIPTION
This is a mechanism to detect the host an `arangod` instance is running on, even if it has been started in a container. This is used to ensure data locality with the `arangosync` tool.