### PR TITLE
minimum number of V8 contexts in console mode must be 2, not 1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* minimum number of V8 contexts in console mode must be 2, not 1. this is
+  required to ensure the console gets one dedicated V8 context and all other
+  operations have at least one extra context. This requirement was not enforced
+  anymore.
+
 * fix potential overflow in CRC marker check when a corrupted CRC marker 
   is found at the very beginning of an MMFiles datafile
 

--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -227,7 +227,11 @@ void V8DealerFeature::start() {
 
   // set singleton
   DEALER = this;
-
+  
+  if (_nrMinContexts < 1) {
+    _nrMinContexts = 1;
+  }
+  
   // try to guess a suitable number of contexts
   if (0 == _nrMaxContexts && 0 == _forceNrContexts) {
     SchedulerFeature* scheduler =
@@ -240,12 +244,9 @@ void V8DealerFeature::start() {
     _nrMaxContexts = _forceNrContexts;
   }
 
-  if (_nrMinContexts < 1) {
-    _nrMinContexts = 1;
-  }
-
   if (_nrMinContexts > _nrMaxContexts) {
-    _nrMinContexts = _nrMaxContexts;
+    // max contexts must not be lower than min contexts
+    _nrMaxContexts = _nrMinContexts;
   }
 
   LOG_TOPIC(DEBUG, Logger::V8) << "number of V8 contexts: min: " << _nrMinContexts << ", max: " << _nrMaxContexts;

--- a/arangod/V8Server/V8DealerFeature.h
+++ b/arangod/V8Server/V8DealerFeature.h
@@ -104,8 +104,10 @@ class V8DealerFeature final : public application_features::ApplicationFeature {
       TRI_vocbase_t*);
 
   void setMinimumContexts(size_t nr) { 
-    if (_nrMinContexts < nr) {
-      _nrMinContexts = nr;
+    _nrMinContexts = nr; 
+    // max contexts must not be lower than min contexts
+    if (_nrMinContexts > _nrMaxContexts) {
+      _nrMaxContexts = nr;
     }
   }
 


### PR DESCRIPTION
this is required to ensure the console gets one dedicated V8 context and all other
operations have at least one extra context. This requirement was not enforced
anymore.