### PR TITLE
Fix the password dialog

### DIFF
--- a/arangod/RestServer/InitDatabaseFeature.cpp
+++ b/arangod/RestServer/InitDatabaseFeature.cpp
@@ -109,7 +109,6 @@ void InitDatabaseFeature::prepare() {
           _password = password1;
           break;
         }
-
         LOG_TOPIC(ERR, arangodb::Logger::FIXME) << "passwords do not match, please repeat";
       } else {
         LOG_TOPIC(FATAL, arangodb::Logger::FIXME) << "initialization aborted by user";
@@ -123,6 +122,9 @@ std::string InitDatabaseFeature::readPassword(std::string const& message) {
   std::string password;
 
   arangodb::Logger::flush();
+  // Wait for the logger thread to flush eventually existing output.
+  sleep(0.5);
+  std::cerr << std::flush;
   std::cout << message << ": " << std::flush;
 
 #ifdef TRI_HAVE_TERMIOS_H

--- a/arangod/RestServer/UpgradeFeature.cpp
+++ b/arangod/RestServer/UpgradeFeature.cpp
@@ -121,8 +121,8 @@ void UpgradeFeature::start() {
     
     Result res = ai->removeAllUsers();
     if (res.fail()) {
-      LOG_TOPIC(WARN, arangodb::Logger::FIXME) << "failed to create clear users: "
-                                               << res.errorMessage();
+      LOG_TOPIC(ERR, arangodb::Logger::FIXME) << "failed to clear users: "
+                                              << res.errorMessage();
       *_result = EXIT_FAILURE;
       return;
     }
@@ -133,11 +133,15 @@ void UpgradeFeature::start() {
     }
 
     if (res.fail()) {
-      LOG_TOPIC(WARN, arangodb::Logger::FIXME) << "failed to create root user: "
-                                               << res.errorMessage();
+      LOG_TOPIC(ERR, arangodb::Logger::FIXME) << "failed to create root user: "
+                                              << res.errorMessage();
       *_result = EXIT_FAILURE;
       return;
     }
+    auto oldLevel = arangodb::Logger::FIXME.level();
+    arangodb::Logger::FIXME.setLogLevel(arangodb::LogLevel::INFO);
+    LOG_TOPIC(INFO, arangodb::Logger::FIXME) << "Password changed.";
+    arangodb::Logger::FIXME.setLogLevel(oldLevel);
     *_result = EXIT_SUCCESS;
   }
 


### PR DESCRIPTION
- make sure the question is only output after log messages are sent to the console
- make sure error messages are sent before re-quoting for the next try
- inform the user whether the password has been sent