### PR TITLE
Bug fix/jenkins ee checkout 3.3

### DIFF
--- a/Installation/Pipeline/Jenkinsfile.groovy
+++ b/Installation/Pipeline/Jenkinsfile.groovy
@@ -474,14 +474,14 @@ def checkoutEnterprise() {
                 userRemoteConfigs: [[credentialsId: credentials, url: enterpriseRepo]]])
     }
     catch (exc) {
-        echo "Failed ${sourceBranchLabel}, trying enterprise branch devel"
+        echo "Failed ${sourceBranchLabel}, trying enterprise branch 3.3"
 
         checkout(
             changelog: false,
             poll: false,
             scm: [
                 $class: 'GitSCM',
-                branches: [[name: "*/devel"]],
+                branches: [[name: "*/3.3"]],
                 doGenerateSubmoduleConfigurations: false,
                 extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'enterprise']],
                 submoduleCfg: [],


### PR DESCRIPTION
Fixes the groovy jenkins file to default checkout 3.3 enterprise of no special branch exists.