### PR TITLE
Bug fix/agency restart after compaction and holes in log

### DIFF
--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -383,12 +383,6 @@ void Agent::sendAppendEntriesRPC() {
         lastAcked = _lastAcked[followerId];
         earliestPackage = _earliestPackage[followerId];
       }
-      {
-        CONDITION_LOCKER(guard, _waitForCV);
-        if (lastConfirmed == 0) {
-          lastConfirmed =  _commitIndex;
-        }
-      }
 
       if (
         ((system_clock::now() - earliestPackage).count() < 0)) {

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -1262,6 +1262,7 @@ void Agent::lead() {
     // Any missing indices before _commitIndex were compacted.
     // DO NOT EDIT without understanding the consequences for sendAppendEntries!
     CONDITION_LOCKER(guard, _waitForCV);
+    MUTEX_LOCKER(tiLocker, _tiLock);
     for (auto& i : _confirmed) {
       if (i.first != id()) {
         i.second = _commitIndex;

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -383,6 +383,12 @@ void Agent::sendAppendEntriesRPC() {
         lastAcked = _lastAcked[followerId];
         earliestPackage = _earliestPackage[followerId];
       }
+      {
+        CONDITION_LOCKER(guard, _waitForCV);
+        if (lastConfirmed <  _commitIndex) {
+          lastConfirmed =  _commitIndex;
+        }
+      }
 
       if (
         ((system_clock::now() - earliestPackage).count() < 0)) {

--- a/arangod/Agency/Agent.h
+++ b/arangod/Agency/Agent.h
@@ -390,8 +390,8 @@ class Agent : public arangodb::Thread,
 
   /// Rules for the locks: This covers the following locks:
   ///    _ioLock (here)
-  ///    _logLock (in State)
-  ///    _tiLock (here)
+  ///    _logLock (in State)         _waiForCV (here)
+  ///    _tiLock (here)              _tiLock (here)
   /// One may never acquire a log in this list whilst holding another one
   /// that appears further down on this list. This is to prevent deadlock.
   /// For _logLock: This is local to State and we make sure that the few

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -865,7 +865,7 @@ bool State::loadRemaining() {
     
     TRI_ASSERT(_log.empty());  // was cleared in loadCompacted
     std::string clientId;
-    index_t lastIndex = 0;
+    index_t lastIndex = _cur;
     for (auto const& i : VPackArrayIterator(result)) {
 
       buffer_t tmp = std::make_shared<arangodb::velocypack::Buffer<uint8_t>>();


### PR DESCRIPTION
Fixing holes in State.
When an Agent takes over lead, we need to make sure that we do not start with index 0 with sendAppendEntries but with first uncompacted one.
