### PR TITLE
show function name in log output

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* show C++ function name of call site in ArangoDB log output
+
+  This requires option `--log.line-number` to be set to *true*
+
 * fixed issue #3408: Hard crash in query for pagination
 
 * UI: fixed unresponsive events in cluster shards view

--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -350,7 +350,7 @@ void Logger::log(char const* function, char const* file, long int line,
         filename = shortened + 1;
       }
     }
-    out << '[' << filename << ':' << line << "] ";
+    out << '[' << function << "@" << filename << ':' << line << "] ";
   }
 
   // generate the complete message


### PR DESCRIPTION
this requires `--log.line-number` option to be set to true