### PR TITLE
Fixed wait for sync in mmfiles

### DIFF
--- a/arangod/MMFiles/MMFilesEngine.cpp
+++ b/arangod/MMFiles/MMFilesEngine.cpp
@@ -701,11 +701,18 @@ int MMFilesEngine::getViews(TRI_vocbase_t* vocbase,
   return TRI_ERROR_NO_ERROR;
 }
 
-void MMFilesEngine::waitForSync(double maxWait) {
+void MMFilesEngine::waitForSyncTick(TRI_voc_tick_t tick) {
   if (application_features::ApplicationServer::isStopping()) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
   }
+  
+  MMFilesLogfileManager::instance()->slots()->waitForTick(tick);
+}
 
+void MMFilesEngine::waitForSyncTimeout(double maxWait) {
+  if (application_features::ApplicationServer::isStopping()) {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+  }
   MMFilesLogfileManager::instance()->waitForSync(maxWait);
 }
 

--- a/arangod/MMFiles/MMFilesEngine.h
+++ b/arangod/MMFiles/MMFilesEngine.h
@@ -167,7 +167,9 @@ class MMFilesEngine final : public StorageEngine {
 
   std::string versionFilename(TRI_voc_tick_t id) const override;
 
-  void waitForSync(double maxWait) override;
+  void waitForSyncTick(TRI_voc_tick_t tick) override;
+  
+  void waitForSyncTimeout(double maxWait) override;
 
   virtual TRI_vocbase_t* openDatabase(
       arangodb::velocypack::Slice const& parameters, bool isUpgrade,

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1759,7 +1759,7 @@ void RestReplicationHandler::handleCommandSync() {
   // wait until all data in current logfile got synced
   StorageEngine* engine = EngineSelectorFeature::ENGINE;
   TRI_ASSERT(engine != nullptr);
-  engine->waitForSync(5.0);
+  engine->waitForSyncTimeout(5.0);
 
   TRI_ASSERT(!config._skipCreateDrop);
   std::unique_ptr<InitialSyncer> syncer;
@@ -2344,7 +2344,7 @@ void RestReplicationHandler::handleCommandLoggerState() {
   StorageEngine* engine = EngineSelectorFeature::ENGINE;
   TRI_ASSERT(engine);
   
-  engine->waitForSync(10.0); // only for mmfiles
+  engine->waitForSyncTimeout(10.0); // only for mmfiles
   
   VPackBuilder builder;
   auto res = engine->createLoggerState(_vocbase, builder);

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -156,10 +156,10 @@ class RocksDBEngine final : public StorageEngine {
   
   // database, collection and index management
   // -----------------------------------------
-
-  void waitForSync(double) override {
-    // intentionally empty, not useful for this type of engine
-  }
+  
+  // intentionally empty, not useful for this type of engine
+  void waitForSyncTick(TRI_voc_tick_t) override {}
+  void waitForSyncTimeout(double) override {}
 
   virtual TRI_vocbase_t* openDatabase(velocypack::Slice const& parameters,
                                       bool isUpgrade, int&) override;

--- a/arangod/StorageEngine/StorageEngine.h
+++ b/arangod/StorageEngine/StorageEngine.h
@@ -150,9 +150,9 @@ class StorageEngine : public application_features::ApplicationFeature {
   // if not stated other wise functions may throw and the caller has to take care of error handling
   // the return values will be the usual  TRI_ERROR_* codes.
 
-  // TODO add pre / post conditions for functions
-
-  virtual void waitForSync(double maxWait) = 0;
+  virtual void waitForSyncTick(TRI_voc_tick_t tick) = 0;
+  
+  virtual void waitForSyncTimeout(double maxWait) = 0;
 
   //// operations on databasea
 

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -1441,7 +1441,7 @@ OperationResult transaction::Methods::insertLocal(
   // wait for operation(s) to be synced to disk here. On rocksdb maxTick == 0
   if (res.ok() && options.waitForSync && maxTick > 0 &&
       isSingleOperationTransaction()) {
-    EngineSelectorFeature::ENGINE->waitForSync(maxTick);
+    EngineSelectorFeature::ENGINE->waitForSyncTick(maxTick);
   }
 
   if (res.ok() && _state->isDBServer()) {
@@ -1786,7 +1786,7 @@ OperationResult transaction::Methods::modifyLocal(
   // wait for operation(s) to be synced to disk here. On rocksdb maxTick == 0
   if (res.ok() && options.waitForSync && maxTick > 0 &&
       isSingleOperationTransaction()) {
-    EngineSelectorFeature::ENGINE->waitForSync(maxTick);
+    EngineSelectorFeature::ENGINE->waitForSyncTick(maxTick);
   }
 
   // Now see whether or not we have to do synchronous replication:
@@ -2067,7 +2067,7 @@ OperationResult transaction::Methods::removeLocal(
   // wait for operation(s) to be synced to disk here. On rocksdb maxTick == 0
   if (res.ok() && options.waitForSync && maxTick > 0 &&
       isSingleOperationTransaction()) {
-    EngineSelectorFeature::ENGINE->waitForSync(maxTick);
+    EngineSelectorFeature::ENGINE->waitForSyncTick(maxTick);
   }
 
   // Now see whether or not we have to do synchronous replication:


### PR DESCRIPTION
- We wrongly overwrote the original tick-based `waitForSync` method in mmfiles
- This reverses this mistake by adding `waitForSyncTick`
- Add another storage engine method for a timeout based `waitForSyncTimeout`