### PR TITLE
Reactivated the failover of the FoxxMaster

### DIFF
--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -245,18 +245,13 @@ void handleOnStatusCoordinator(
   Agent* agent, Node const& snapshot, HealthRecord& persisted,
   HealthRecord& transisted, std::string const& serverID) {
   
-  if (transisted.status == Supervision::HEALTH_STATUS_GOOD) {
+  if (transisted.status == Supervision::HEALTH_STATUS_FAILED) {
     
-    std::string currentFoxxmaster;
-    if (snapshot.has(foxxmaster)) {
-      currentFoxxmaster = snapshot(foxxmaster).getString();
-    }
-    
-    if (serverID == currentFoxxmaster) {
+    if (snapshot.has(foxxmaster) && snapshot(foxxmaster).getString() == serverID) {
       VPackBuilder create;
       { VPackArrayBuilder tx(&create);
         { VPackObjectBuilder d(&create);
-          create.add(foxxmaster, VPackValue(serverID)); }}
+          create.add(foxxmaster, VPackValue("")); }}
       singleWriteTransaction(agent, create);
     }
     

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -492,8 +492,21 @@ void HeartbeatThread::runCoordinator() {
             result.slice()[0].get(std::vector<std::string>(
                 {AgencyCommManager::path(), "Current", "Foxxmaster"}));
 
-        if (foxxmasterSlice.isString()) {
+        if (foxxmasterSlice.isString() && foxxmasterSlice.getStringLength() != 0) {
           ServerState::instance()->setFoxxmaster(foxxmasterSlice.copyString());
+        } else {
+          auto state = ServerState::instance();
+          VPackBuilder myIdBuilder;
+          myIdBuilder.add(VPackValue(state->getId()));
+
+          auto updateMaster =
+              _agency.casValue("/Current/Foxxmaster", foxxmasterSlice,
+                               myIdBuilder.slice(), 0, 1.0);
+          if (updateMaster.successful()) {
+            // We won the race we are the master
+            ServerState::instance()->setFoxxmaster(state->getId());
+          }
+
         }
 
         VPackSlice versionSlice =


### PR DESCRIPTION
This is a bug-fix where on coordinator crash any other coordinator tries to become the new Foxx-Master.
As it is a highlander position only one of them will succeed.
The Supervision is responsible to remove a FoxxMaster if it is killed in action