### PR TITLE
WIP – aql current_user in cpp, test

### DIFF
--- a/arangod/Aql/AqlFunctionFeature.cpp
+++ b/arangod/Aql/AqlFunctionFeature.cpp
@@ -478,8 +478,7 @@ void AqlFunctionFeature::addMiscFunctions() {
        true, &Functions::ParseIdentifier});
   add({"IS_SAME_COLLECTION", ".h,.h", true,
        false, true, true, &Functions::IsSameCollection});
-  add({"CURRENT_USER", "", false, false, false,
-       true});
+  add({"CURRENT_USER", "", false, false, false, true, &Functions::CurrentUser});
   add({"CURRENT_DATABASE", "", false, false,
        false, true, &Functions::CurrentDatabase});
   add({"COLLECTION_COUNT", ".h", false, true,

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -3288,6 +3288,24 @@ AqlValue Functions::CurrentDatabase(
   return AqlValue(builder.get());
 }
 
+/// @brief function CURRENT_USER
+AqlValue Functions::CurrentUser(
+    arangodb::aql::Query* query, transaction::Methods* trx,
+    VPackFunctionParameters const& parameters) {
+
+  if (ExecContext::CURRENT == nullptr) {
+    return AqlValue(AqlValueHintNull());
+  }
+
+  std::string const& username = ExecContext::CURRENT->user();
+
+  if (username.size() == 0) {
+    return AqlValue(AqlValueHintNull());
+  }
+
+  return AqlValue(username);
+}
+
 /// @brief function COLLECTION_COUNT
 AqlValue Functions::CollectionCount(
     arangodb::aql::Query* query, transaction::Methods* trx,

--- a/arangod/Aql/Functions.h
+++ b/arangod/Aql/Functions.h
@@ -312,6 +312,9 @@ struct Functions {
    static AqlValue IsSameCollection(arangodb::aql::Query*,
                                     transaction::Methods*,
                                     VPackFunctionParameters const&);
+   static AqlValue CurrentUser(arangodb::aql::Query*,
+                                transaction::Methods*,
+                                VPackFunctionParameters const&);
 };
 }
 }

--- a/js/server/tests/aql/aql-functions-misc.js
+++ b/js/server/tests/aql/aql-functions-misc.js
@@ -520,9 +520,9 @@ function ahuacatlMiscFunctionsTestSuite () {
         }
       }
 
-      var actual = getQueryResults("RETURN CURRENT_USER()");
-      // there is no current user in the non-request context
-      assertEqual([ expected ], actual);
+       // there is no current user in the non-request context
+       assertEqual([ expected ], getQueryResults("RETURN NOOPT(CURRENT_USER())"));
+       assertEqual([ expected ], getQueryResults("RETURN NOOPT(V8(CURRENT_USER()))"));
     },
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
in js, getCurrentRequest() returns null when the action is a cpp action.

A async call to /_api/cursor with `return current_user()` returns null.
probably the currentrequest is not set by the cpp env.