### PR TITLE
removed posix_fadvise call from PosixSequentialFile::Read().

### DIFF
--- a/3rdParty/rocksdb/v5.6.X/env/io_posix.cc
+++ b/3rdParty/rocksdb/v5.6.X/env/io_posix.cc
@@ -172,9 +172,7 @@ Status PosixSequentialFile::Read(size_t n, Slice* result, char* scratch) {
       s = IOError(filename_, errno);
     }
   }
-  // we need to fadvise away the entire range of pages because
-  // we do not want readahead pages to be cached under buffered io
-  Fadvise(fd_, 0, 0, POSIX_FADV_DONTNEED);  // free OS pages
+  // matthewv:  removed Fadvise call here that was also removed by facebook in 5.7.1
   return s;
 }
 


### PR DESCRIPTION
this is consistent with facebook PR 2573: https://github.com/facebook/rocksdb/pull/2573

Fadvise() is a wrapper function for posix_fadvise().  It is only useful on Linux platforms.  The Fadvise() call was suggesting to the operating system that all cached data for the open file should be flushed.  When used with WAL tailing, this was causing all reads of WAL files to read from disk not from cache.  This was a performance hit for various ArangoDB activities that use the WAL tailing feature.

Issue was first spotted by @darkfrog26 and reported here:  https://github.com/arangodb/arangodb/issues/3291