### PR TITLE
make incremental sync replication API check if the client passed an "…

### DIFF
--- a/arangod/MMFiles/MMFilesCollectionKeys.cpp
+++ b/arangod/MMFiles/MMFilesCollectionKeys.cpp
@@ -43,8 +43,6 @@
 
 using namespace arangodb;
 
-static constexpr size_t maxChunkSize = 8 * 1024 * 1024; // 8 MB maximum size per documents transfer
-
 MMFilesCollectionKeys::MMFilesCollectionKeys(TRI_vocbase_t* vocbase, std::string const& name,
                                              TRI_voc_tick_t blockerId, double ttl)
     : CollectionKeys(vocbase, name, ttl),
@@ -192,7 +190,7 @@ void MMFilesCollectionKeys::dumpKeys(VPackBuilder& result, size_t chunk,
 ////////////////////////////////////////////////////////////////////////////////
 
 void MMFilesCollectionKeys::dumpDocs(arangodb::velocypack::Builder& result, size_t chunk,
-                                     size_t chunkSize, size_t offsetInChunk, 
+                                     size_t chunkSize, size_t offsetInChunk, size_t maxChunkSize, 
                                      VPackSlice const& ids) const {
   if (!ids.isArray()) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_BAD_PARAMETER);

--- a/arangod/MMFiles/MMFilesCollectionKeys.h
+++ b/arangod/MMFiles/MMFilesCollectionKeys.h
@@ -80,7 +80,7 @@ class MMFilesCollectionKeys final : public CollectionKeys {
   //////////////////////////////////////////////////////////////////////////////
 
   void dumpDocs(arangodb::velocypack::Builder& result, size_t chunk, size_t chunkSize,
-                size_t offsetInChunk, arangodb::velocypack::Slice const& ids) const override;
+                size_t offsetInChunk, size_t maxChunkSize, arangodb::velocypack::Slice const& ids) const override;
 
  private:
   std::unique_ptr<arangodb::CollectionGuard> _guard;

--- a/arangod/MMFiles/MMFilesRestReplicationHandler.cpp
+++ b/arangod/MMFiles/MMFilesRestReplicationHandler.cpp
@@ -804,9 +804,16 @@ void MMFilesRestReplicationHandler::handleCommandFetchKeys() {
   }
 
   size_t offsetInChunk = 0;
+  size_t maxChunkSize = SIZE_MAX;
   std::string const& value4 = _request->value("offset", found);
   if (found) {
     offsetInChunk = static_cast<size_t>(StringUtils::uint64(value4));
+    // "offset" was introduced with ArangoDB 3.3. if the client sends it,
+    // it means we can adapt the result size dynamically and the client
+    // may refetch data for the same chunk
+    maxChunkSize = 8 * 1024 * 1024; 
+    // if a client does not send an "offset" parameter at all, we are
+    // not sure if it supports this protocol (3.2 and before) or not
   }
 
   std::string const& id = suffixes[1];
@@ -843,7 +850,7 @@ void MMFilesRestReplicationHandler::handleCommandFetchKeys() {
       }
       collectionKeys->dumpDocs(resultBuilder, chunk,
                                static_cast<size_t>(chunkSize), offsetInChunk,
-                               parsedIds->slice());
+                               maxChunkSize, parsedIds->slice());
     }
 
     resultBuilder.close();

--- a/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
@@ -50,8 +50,6 @@ using namespace arangodb::velocypack;
 
 double const RocksDBReplicationContext::DefaultTTL = 300.0; // seconds
 
-static constexpr size_t maxChunkSize = 8 * 1024 * 1024; // 8 MB maximum size per documents transfer
-
 RocksDBReplicationContext::RocksDBReplicationContext()
     : RocksDBReplicationContext(DefaultTTL) {}
 
@@ -416,7 +414,7 @@ arangodb::Result RocksDBReplicationContext::dumpKeys(
 /// dump keys and document
 arangodb::Result RocksDBReplicationContext::dumpDocuments(
     VPackBuilder& b, size_t chunk, size_t chunkSize, size_t offsetInChunk,
-    std::string const& lowKey, VPackSlice const& ids) {
+    size_t maxChunkSize, std::string const& lowKey, VPackSlice const& ids) {
   Result rv;
 
   TRI_ASSERT(_trx);

--- a/arangod/RocksDBEngine/RocksDBReplicationContext.h
+++ b/arangod/RocksDBEngine/RocksDBReplicationContext.h
@@ -94,7 +94,7 @@ class RocksDBReplicationContext {
                             size_t chunkSize, std::string const& lowKey);
   /// dump keys and document
   arangodb::Result dumpDocuments(velocypack::Builder& b, size_t chunk,
-                                 size_t chunkSize, size_t offsetInChunk, 
+                                 size_t chunkSize, size_t offsetInChunk, size_t maxChunkSize, 
                                  std::string const& lowKey, velocypack::Slice const& ids);
 
   double expires() const;

--- a/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
@@ -562,10 +562,17 @@ void RocksDBRestReplicationHandler::handleCommandFetchKeys() {
   }
   
   size_t offsetInChunk = 0;
+  size_t maxChunkSize = SIZE_MAX;
   std::string const& value4 = _request->value("offset", found);
   if (found) {
     offsetInChunk = static_cast<size_t>(StringUtils::uint64(value4));
-  }
+    // "offset" was introduced with ArangoDB 3.3. if the client sends it,
+    // it means we can adapt the result size dynamically and the client
+    // may refetch data for the same chunk
+    maxChunkSize = 8 * 1024 * 1024; 
+    // if a client does not send an "offset" parameter at all, we are
+    // not sure if it supports this protocol (3.2 and before) or not
+  } 
 
   std::string const& id = suffixes[1];
 
@@ -605,7 +612,7 @@ void RocksDBRestReplicationHandler::handleCommandFetchKeys() {
       return;
     }
     
-    Result rv = ctx->dumpDocuments(builder, chunk, static_cast<size_t>(chunkSize), offsetInChunk, lowKey, parsedIds->slice());
+    Result rv = ctx->dumpDocuments(builder, chunk, static_cast<size_t>(chunkSize), offsetInChunk, maxChunkSize, lowKey, parsedIds->slice());
     if (rv.fail()) {
       generateError(rv);
       return;

--- a/arangod/Utils/CollectionKeys.h
+++ b/arangod/Utils/CollectionKeys.h
@@ -104,7 +104,7 @@ class CollectionKeys {
   //////////////////////////////////////////////////////////////////////////////
 
   virtual void dumpDocs(arangodb::velocypack::Builder& result, size_t chunk, 
-                        size_t chunkSize, size_t offsetInChunk,
+                        size_t chunkSize, size_t offsetInChunk, size_t maxChunkSize,
                         arangodb::velocypack::Slice const& ids) const = 0;
 
  protected:


### PR DESCRIPTION
…offset" request parameter

if yes, the server may dynamically adapt the size of the response, in order to ensure that
HTTP responses do not get out of hand size-wise. This is a new feature in devel, and this
commit now makes it optional so that older clients do not need to be changed.