### PR TITLE
Fix build on windows with DebugInformation

### DIFF
--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -270,6 +270,8 @@ SET(ARANGOD_SOURCES
   Pregel/Recovery.cpp
   Pregel/Utils.cpp
   Pregel/Worker.cpp
+  Pregel/Worker-templates-native-types.cpp
+  Pregel/Worker-templates-algorithms.cpp
   Pregel/WorkerConfig.cpp
   Replication/DatabaseReplicationApplier.cpp
   Replication/GlobalReplicationApplier.cpp

--- a/arangod/Pregel/Worker-templates-algorithms.cpp
+++ b/arangod/Pregel/Worker-templates-algorithms.cpp
@@ -1,0 +1,33 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2016 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Simon Grätzer
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Pregel/Worker.cpp"
+
+// custom algorihm types
+template class arangodb::pregel::Worker<SCCValue, int8_t,
+                                        SenderMessage<uint64_t>>;
+template class arangodb::pregel::Worker<HITSValue, int8_t,
+                                        SenderMessage<double>>;
+template class arangodb::pregel::Worker<ECValue, int8_t, HLLCounter>;
+template class arangodb::pregel::Worker<DMIDValue, float, DMIDMessage>;
+template class arangodb::pregel::Worker<LPValue, int8_t, uint64_t>;
+template class arangodb::pregel::Worker<SLPAValue, int8_t, uint64_t>;

--- a/arangod/Pregel/Worker-templates-native-types.cpp
+++ b/arangod/Pregel/Worker-templates-native-types.cpp
@@ -1,0 +1,28 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2016 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Simon Grätzer
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Pregel/Worker.cpp"
+
+// template types to create
+template class arangodb::pregel::Worker<int64_t, int64_t, int64_t>;
+template class arangodb::pregel::Worker<float, float, float>;
+template class arangodb::pregel::Worker<double, float, double>;

--- a/arangod/Pregel/Worker.cpp
+++ b/arangod/Pregel/Worker.cpp
@@ -777,17 +777,3 @@ void Worker<V, E, M>::_callConductorWithResponse(
     }
   }
 }
-
-// template types to create
-template class arangodb::pregel::Worker<int64_t, int64_t, int64_t>;
-template class arangodb::pregel::Worker<float, float, float>;
-template class arangodb::pregel::Worker<double, float, double>;
-// custom algorihm types
-template class arangodb::pregel::Worker<SCCValue, int8_t,
-                                        SenderMessage<uint64_t>>;
-template class arangodb::pregel::Worker<HITSValue, int8_t,
-                                        SenderMessage<double>>;
-template class arangodb::pregel::Worker<ECValue, int8_t, HLLCounter>;
-template class arangodb::pregel::Worker<DMIDValue, float, DMIDMessage>;
-template class arangodb::pregel::Worker<LPValue, int8_t, uint64_t>;
-template class arangodb::pregel::Worker<SLPAValue, int8_t, uint64_t>;


### PR DESCRIPTION
Split the template generation code of Pregel-Worker into separate files. It is too much going on for VS 2015 compiler