### PR TITLE
Enforce Unix line endings for SummaryBlacklist.txt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@ VERSION eolf=lf
 scripts/unittest eol=lf
 *.csv binary
 *.json eol=lf
+Documentation/Books/SummaryBlacklist.txt eol=lf
 Documentation/Examples/*.generated merge=ours
 VERSION merge=ours
 STARTER_REV merge=ours


### PR DESCRIPTION
With Windows line breaks in a Cygwin environment, the docu build checker breaks (reports README.md and SUMMARY.md not being mapped to SUMMARY.md)