### PR TITLE
Handle invalid endpoints in AgencyComm

### DIFF
--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -734,11 +734,11 @@ AgencyCommManager::createNewConnection() {
     return nullptr;
   }
 
-  std::string str = _endpoints.front();
-  std::unique_ptr<Endpoint> endpoint(Endpoint::clientFactory(str));
+  std::string const& spec = _endpoints.front();
+  std::unique_ptr<Endpoint> endpoint(Endpoint::clientFactory(spec));
   if (endpoint.get() == nullptr) {
     LOG_TOPIC(ERR, arangodb::Logger::FIXME) << "invalid value for "
-      << "--server.endpoint ('" << str << "')";
+      << "--server.endpoint ('" << spec << "')";
     THROW_ARANGO_EXCEPTION(TRI_ERROR_BAD_PARAMETER);
   }
 

--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -734,8 +734,13 @@ AgencyCommManager::createNewConnection() {
     return nullptr;
   }
 
-  std::unique_ptr<Endpoint> endpoint(
-    Endpoint::clientFactory(_endpoints.front()));
+  std::string str = _endpoints.front();
+  std::unique_ptr<Endpoint> endpoint(Endpoint::clientFactory(str));
+  if (endpoint.get() == nullptr) {
+    LOG_TOPIC(ERR, arangodb::Logger::FIXME) << "invalid value for "
+      << "--server.endpoint ('" << str << "')";
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_BAD_PARAMETER);
+  }
 
   return std::unique_ptr<GeneralClientConnection>(
     GeneralClientConnection::factory(endpoint,


### PR DESCRIPTION
- Crashes nastily if you use an invalid port 