### PR TITLE
git ignore /bin correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,7 @@ arangod/Aql/grammar.output
 
 UnitTests/HttpInterface/logs/
 
-bin/
+/bin
 logs/
 out/
 


### PR DESCRIPTION
This fixes `/bin` showing up when created as a symlink and avoids accidentally ignoring unrelated folders called "bin" elsewhere in the repository.

This eliminates the current workaround which is symlinking *from* `build/bin` *to* `bin`, which routinely results in problems when trashing `build` and forgetting to manually set up the symlink again.

This needs review because we might be intentionally ignoring artefact folders called "bin" elsewhere in the tree. Those should be blacklisted explicitly (i.e. `/path/to/bin`). If that's not possible the PR should fail review and we probably need to ignore both `/bin` and `bin/`.