### PR TITLE
Fix endquote of example string literal.

### DIFF
--- a/Documentation/Books/AQL/Fundamentals/DataTypes.md
+++ b/Documentation/Books/AQL/Fundamentals/DataTypes.md
@@ -51,7 +51,7 @@ a backslash.
 
 'yikes!'
 'don\'t know'
-'this is a longer string."
+'this is a longer string.'
 'the path separator on Windows is \\'
 ```
 


### PR DESCRIPTION
String was opened by `'` and should be closed with `'` not `"`.