### PR TITLE
More consistent config/deps output in Foxx API (devel)

### DIFF
--- a/js/apps/system/_api/foxx/APP/index.js
+++ b/js/apps/system/_api/foxx/APP/index.js
@@ -228,68 +228,74 @@ instanceRouter.use('/configuration', configRouter)
 .response(200, schemas.configs);
 
 configRouter.get((req, res) => {
-  res.json(req.service.getConfiguration());
-});
+  res.json(req.service.getConfiguration(req.queryParams.minimal));
+})
+.queryParam('minimal', joi.boolean().default(false));
 
 configRouter.patch((req, res) => {
   const warnings = FoxxManager.setConfiguration(req.service.mount, {
     configuration: req.body,
     replace: false
   });
-  const values = req.service.getConfiguration(true);
+  const values = req.service.getConfiguration(req.queryParams.minimal);
   res.json({
     values,
     warnings
   });
 })
-.body(joi.object().required());
+.body(joi.object().required())
+.queryParam('minimal', joi.boolean().default(true));
 
 configRouter.put((req, res) => {
   const warnings = FoxxManager.setConfiguration(req.service.mount, {
     configuration: req.body,
     replace: true
   });
-  const values = req.service.getConfiguration(true);
+  const values = req.service.getConfiguration(req.queryParams.minimal);
   res.json({
     values,
     warnings
   });
 })
-.body(joi.object().required());
+.body(joi.object().required())
+.queryParam('minimal', joi.boolean().default(true));
 
 const depsRouter = createRouter();
 instanceRouter.use('/dependencies', depsRouter)
 .response(200, schemas.deps);
 
 depsRouter.get((req, res) => {
-  res.json(req.service.getDependencies());
-});
+  res.json(req.service.getDependencies(req.queryParams.minimal));
+})
+.queryParam('minimal', joi.boolean().default(false));
 
 depsRouter.patch((req, res) => {
   const warnings = FoxxManager.setDependencies(req.service.mount, {
     dependencies: req.body,
     replace: true
   });
-  const values = req.service.getDependencies(true);
+  const values = req.service.getDependencies(req.queryParams.minimal);
   res.json({
     values,
     warnings
   });
 })
-.body(joi.object().required());
+.body(joi.object().required())
+.queryParam('minimal', joi.boolean().default(true));
 
 depsRouter.put((req, res) => {
   const warnings = FoxxManager.setDependencies(req.service.mount, {
     dependencies: req.body,
     replace: true
   });
-  const values = req.service.getDependencies(true);
+  const values = req.service.getDependencies(req.queryParams.minimal);
   res.json({
     values,
     warnings
   });
 })
-.body(joi.object().required());
+.body(joi.object().required())
+.queryParam('minimal', joi.boolean().default(true));
 
 const devRouter = createRouter();
 instanceRouter.use('/development', devRouter)

--- a/js/apps/system/_api/foxx/APP/index.js
+++ b/js/apps/system/_api/foxx/APP/index.js
@@ -238,10 +238,16 @@ configRouter.patch((req, res) => {
     replace: false
   });
   const values = req.service.getConfiguration(req.queryParams.minimal);
-  res.json({
-    values,
-    warnings
-  });
+  if (req.queryParams.minimal) {
+    res.json({values, warnings});
+  } else {
+    if (warnings) {
+      for (const key of Object.keys(warnings)) {
+        values[key].warning = warnings[key];
+      }
+    }
+    res.json(values);
+  }
 })
 .body(joi.object().required())
 .queryParam('minimal', joi.boolean().default(true));
@@ -252,10 +258,16 @@ configRouter.put((req, res) => {
     replace: true
   });
   const values = req.service.getConfiguration(req.queryParams.minimal);
-  res.json({
-    values,
-    warnings
-  });
+  if (req.queryParams.minimal) {
+    res.json({values, warnings});
+  } else {
+    if (warnings) {
+      for (const key of Object.keys(warnings)) {
+        values[key].warning = warnings[key];
+      }
+    }
+    res.json(values);
+  }
 })
 .body(joi.object().required())
 .queryParam('minimal', joi.boolean().default(true));
@@ -275,10 +287,16 @@ depsRouter.patch((req, res) => {
     replace: true
   });
   const values = req.service.getDependencies(req.queryParams.minimal);
-  res.json({
-    values,
-    warnings
-  });
+  if (req.queryParams.minimal) {
+    res.json({values, warnings});
+  } else {
+    if (warnings) {
+      for (const key of Object.keys(warnings)) {
+        values[key].warning = warnings[key];
+      }
+    }
+    res.json(values);
+  }
 })
 .body(joi.object().required())
 .queryParam('minimal', joi.boolean().default(true));
@@ -289,10 +307,16 @@ depsRouter.put((req, res) => {
     replace: true
   });
   const values = req.service.getDependencies(req.queryParams.minimal);
-  res.json({
-    values,
-    warnings
-  });
+  if (req.queryParams.minimal) {
+    res.json({values, warnings});
+  } else {
+    if (warnings) {
+      for (const key of Object.keys(warnings)) {
+        values[key].warning = warnings[key];
+      }
+    }
+    res.json(values);
+  }
 })
 .body(joi.object().required())
 .queryParam('minimal', joi.boolean().default(true));

--- a/js/server/modules/@arangodb/foxx/service.js
+++ b/js/server/modules/@arangodb/foxx/service.js
@@ -463,12 +463,13 @@ module.exports =
     getConfiguration (simple) {
       const config = {};
       const definitions = this.manifest.configuration;
-      const options = this._configuration;
+      const options = this.configuration;
       for (const name of Object.keys(definitions)) {
         const dfn = definitions[name];
         const value = options[name] === undefined ? dfn.default : options[name];
         config[name] = simple ? value : Object.assign({}, dfn, {
           title: getReadableName(name),
+          currentRaw: this._configuration[name],
           current: value
         });
       }


### PR DESCRIPTION
Having the option to get the same response format from the get/put/patch routes reduces the overhead for tools like foxx-cli. This should be backported to 3.2 and 3.1 after merging.