### PR TITLE
travisci: fix where the support libraries can be found - we don't off…

### DIFF
--- a/Installation/travisCI/build.sh
+++ b/Installation/travisCI/build.sh
@@ -6,7 +6,7 @@ echo "$0: loading precompiled libraries"
 
 wget \
   -O 3rdParty.tar.gz \
-  "https://www.arangodb.com/support-files/travisCI/precompiled-libraries-4.3.61.tar.gz"
+  "https://docs.arangodb.com/support-files/travisCI/precompiled-libraries-4.3.61.tar.gz"
 
 tar xzf 3rdParty.tar.gz
 


### PR DESCRIPTION
…er downloads via www.arangodb.com anymore.