### PR TITLE
Warn about Foxx manifest names

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -132,6 +132,7 @@ devel
       WARNING {memory} maximum number of memory mappings per process is 65530, which seems too low. it is recommended to set it to at least 512000
       WARNING {memory} execute 'sudo sysctl -w "vm.max_map_count=512000"'
 
+* Foxx now warns about malformed configuration/dependency names and aliases in the manifest.
 
 v3.2.7 (2017-11-13)
 -------------------

--- a/Documentation/Books/Manual/Foxx/Configuration.md
+++ b/Documentation/Books/Manual/Foxx/Configuration.md
@@ -5,10 +5,11 @@ Foxx services can define configuration parameters to make them more re-usable.
 
 The `configuration` object maps names to configuration parameters:
 
-* The key is the name under which the parameter will be available
-  on the [service context's](Context.md) `configuration` property.
+* The key is the name under which the parameter will be available on the [service context's](Context.md) `configuration` property.
 
 * The value is a parameter definition.
+
+The key should be a valid identifier following the case-insensitive format `/^[_$a-z][-_$a-z0-9]*$/`.
 
 The parameter definition can have the following properties:
 

--- a/Documentation/Books/Manual/Foxx/Dependencies.md
+++ b/Documentation/Books/Manual/Foxx/Dependencies.md
@@ -33,7 +33,8 @@ Foxx dependencies can be declared in a [service's manifest](Manifest.md) using t
 
 * `dependencies` lists the dependencies a given service uses, i.e. which APIs its dependencies need to be compatible with
 
-A dependency name should generally use the same format as a namespaced (org-scoped) NPM module, e.g. `@foxx/sessions`.
+A dependency name should generally use the same format as a namespaced (org-scoped) NPM module, e.g. `@foxx/sessions`. The dependency name should follow either the case-insensitive format
+  `/^@[_$a-z][-_$a-z0-9]*(\/[_$a-z][-_$a-z0-9]*)*$/` or `/^[_$a-z][-_$a-z0-9]*$/`.
 
 Dependency names refer to the external JavaScript API of a service rather than specific services implementing those APIs. Some dependency names defined by officially maintained services are:
 
@@ -74,6 +75,8 @@ A `dependencies` definition maps the local alias of a given dependency against i
 Dependencies can be configured from the web interface in a service's settings tab using the *Dependencies* button.
 
 <!-- TODO (Add link to relevant aardvark docs) -->
+
+The local alias should be a valid identifier following the case-insensitive format `/^[_$a-z][-_$a-z0-9]*$/`.
 
 The value for each dependency should be the database-relative mount path of the service (including the leading slash). In order to be usable as the dependency of another service both services need to be mounted in the same database. A service can be used to provide multiple dependencies for the same service (as long as the expected JavaScript APIs don't conflict).
 


### PR DESCRIPTION
Via #3818.

This does not change the current behaviour of Foxx but logs warnings so we can deprecate troublesome names/keys in the future. It also documents the expected constraints that were previously not clearly defined anywhere.