### PR TITLE
Bug fix/git enforce more lf line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 *.sh eol=lf 
 VERSION eol=lf
+VERSIONS eol=lf
 scripts/unittest eol=lf
 *.groovy eol=lf
 *.csv binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 *.sh eol=lf 
-VERSION eolf=lf
+VERSION eol=lf
 scripts/unittest eol=lf
+*.groovy eol=lf
 *.csv binary
 *.json eol=lf
 Documentation/Books/SummaryBlacklist.txt eol=lf


### PR DESCRIPTION
The files `VERSION` and `Installation\Pipeline\Jenkinsfile.groovy` keep showing as modified for me in Git under Windows.

Git converts the line endings to CRLF in the working copy, but shouldn't see this as a change - yet it does. 
 This should circumvent this problem without touching the global git settings.