### PR TITLE
Fix for missing constant in older Windows versions (issue 3742)

### DIFF
--- a/lib/ApplicationFeatures/ShellColorsFeature.cpp
+++ b/lib/ApplicationFeatures/ShellColorsFeature.cpp
@@ -24,6 +24,9 @@
 
 #ifdef _WIN32
 #include "Basics/win-utils.h"
+#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#endif
 #endif
 
 using namespace arangodb;


### PR DESCRIPTION
Fix for #3753 

Confirmed to work on latest Windows 10 as well.