### PR TITLE
Bug fix/tidy up statistics

### DIFF
--- a/arangod/Cluster/ClusterComm.cpp
+++ b/arangod/Cluster/ClusterComm.cpp
@@ -644,14 +644,14 @@ ClusterCommResult const ClusterComm::wait(
 
   do {
     CONDITION_LOCKER(locker, somethingReceived);
-    match_good=false;
-    status_ready=false;
+    match_good = false;
+    status_ready = false;
 
     if (ticketId == 0) {
       i_erase = responses.end();
       for (i = responses.begin(); i != responses.end() && !status_ready; i++) {
         if (match(clientTransactionID, coordTransactionID, shardID, i->second.result.get())) {
-          match_good=true;
+          match_good = true;
           return_result = *i->second.result.get();
           status_ready = (CL_COMM_SUBMITTED != return_result.status);
           if (status_ready) {
@@ -689,21 +689,20 @@ ClusterCommResult const ClusterComm::wait(
       ClusterCommTimeout now = TRI_microtime();
       if (now < endTime || 0.0 == timeout) {
         // convert to microseconds, use 10 second safety poll if no timeout
-        uint64_t micros=(0.0 != timeout ? ((endTime - now)*1000000.0) : 10000000);
+        uint64_t micros = static_cast<uint64_t>(0.0 != timeout ? ((endTime - now) * 1000000.0) : 10000000);
         somethingReceived.wait(micros);
       } else {
         // time is up, leave
         return_result.operationID = ticketId;
         // does res.coordTransactionID need to be set here too?
         return_result.status = CL_COMM_TIMEOUT;
-        match_good=false;
+        match_good = false;
       } // else
     } // if
 
   } while(!status_ready && match_good);
 
   return return_result;
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -21,13 +21,13 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "StatisticsFeature.h"
-
 #include "Logger/Logger.h"
 #include "ProgramOptions/ProgramOptions.h"
 #include "ProgramOptions/Section.h"
 #include "Statistics/ConnectionStatistics.h"
 #include "Statistics/RequestStatistics.h"
 #include "Statistics/ServerStatistics.h"
+#include "Statistics/StatisticsWorker.h"
 
 #include <thread>
 #include <chrono>
@@ -174,7 +174,6 @@ void StatisticsFeature::prepare() {
 }
 
 void StatisticsFeature::start() {
-
   if (!_statistics) {
     return;
   }

--- a/arangod/Statistics/StatisticsFeature.h
+++ b/arangod/Statistics/StatisticsFeature.h
@@ -26,7 +26,6 @@
 #include "ApplicationFeatures/ApplicationFeature.h"
 #include "Basics/Thread.h"
 #include "Statistics/figures.h"
-#include "StatisticsWorker.h"
 
 namespace arangodb {
 namespace basics {


### PR DESCRIPTION
This branch tidies up the statistics a bit.
* re-use VelocyPack builders in order to save memory allocations (statistics thread will be invoked very often while the server is running)
* put the AQL queries that are executed by the statistics thread into const static strings, so they can be reused and do not need to be rebuild every time the statistics thread is invoked
* increase the statistics calculation interval from 1 second to the 3.2/3.3 value of 10 seconds
* make statistics garbage collection less intrusive, but more evenly spread its work across multiple invocations
* also add try...catch around the thread main loop, because a thread should not be left with an exception (and if an exception happens, it should resume its work later)
* change statistics values from floats to double, to get better accuracy