### PR TITLE
automatically detect which variables to keep in AQL COLLECT

### DIFF
--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -387,6 +387,7 @@ class Ast {
   /// @brief determines the top-level attributes in an expression, grouped by
   /// variable
   static TopLevelAttributes getReferencedAttributes(AstNode const*, bool&);
+  static std::unordered_set<std::string> getReferencedAttributesForKeep(AstNode const*, Variable const* searchVariable, bool&);
   
   static bool populateSingleAttributeAccess(AstNode const* node,
                                             Variable const* variable,
@@ -503,16 +504,14 @@ public:
 
   /// @brief traverse the AST, using pre- and post-order visitors
   static void traverseReadOnly(AstNode const*,
-                               std::function<void(AstNode const*, void*)>,
-                               std::function<void(AstNode const*, void*)>,
-                               std::function<void(AstNode const*, void*)>,
-                               void*);
+                               std::function<bool(AstNode const*)> const&,
+                               std::function<void(AstNode const*)> const&);
 
   /// @brief traverse the AST using a depth-first visitor, with const nodes
   static void traverseReadOnly(AstNode const*,
-                               std::function<void(AstNode const*, void*)>,
-                               void*);
-private:
+                               std::function<void(AstNode const*)> const&);
+
+ private:
   /// @brief normalize a function name
   std::pair<std::string, bool> normalizeFunctionName(char const*);
 

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -1105,11 +1105,11 @@ void AstNode::toVelocyPack(VPackBuilder& builder, bool verbose) const {
 
     TRI_ASSERT(variable != nullptr);
     builder.add("name", VPackValue(variable->name));
-    builder.add("id", VPackValue(static_cast<double>(variable->id)));
+    builder.add("id", VPackValue(variable->id));
   }
 
   if (type == NODE_TYPE_EXPANSION) {
-    builder.add("levels", VPackValue(static_cast<double>(getIntValue(true))));
+    builder.add("levels", VPackValue(getIntValue(true)));
   }
 
   // dump sub-nodes

--- a/arangod/Aql/CollectNode.h
+++ b/arangod/Aql/CollectNode.h
@@ -172,6 +172,21 @@ class CollectNode : public ExecutionNode {
     TRI_ASSERT(!hasExpressionVariable());
     _expressionVariable = variable;
   }
+  
+  /// @brief return whether or not the collect has keep variables
+  bool hasKeepVariables() const {
+    return !_keepVariables.empty();
+  }
+  
+  /// @brief return the keep variables
+  std::vector<Variable const*> const& keepVariables() const {
+    return _keepVariables;
+  }
+  
+  /// @brief set list of variables to keep if INTO is used
+  void setKeepVariables(std::vector<Variable const*>&& variables) {
+    _keepVariables = std::move(variables);
+  }
 
   /// @brief return the variable map
   std::unordered_map<VariableId, std::string const> const& variableMap() const {

--- a/arangod/Aql/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode.h
@@ -439,6 +439,16 @@ class ExecutionNode {
     }
     return ids;
   }
+  
+  /// @brief tests whether the node sets one of the passed variables
+  bool setsVariable(std::unordered_set<Variable const*> const& which) const {
+    for (auto const& v : getVariablesSetHere()) {
+      if (which.find(v) != which.end()) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   /// @brief setVarsUsedLater
   void setVarsUsedLater(std::unordered_set<Variable const*>& v) {

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -1661,59 +1661,6 @@ void ExecutionPlan::findEndNodes(SmallVector<ExecutionNode*>& result,
   root()->walk(&finder);
 }
 
-/// @brief check linkage of execution plan
-#if 0
-class LinkChecker : public WalkerWorker<ExecutionNode> {
-
-  public:
-    LinkChecker () {
-    }
-
-    bool before (ExecutionNode* en) {
-      auto deps = en->getDependencies();
-      for (auto x : deps) {
-        auto parents = x->getParents();
-        bool ok = false;
-        for (auto it = parents.begin(); it != parents.end(); ++it) {
-          if (*it == en) {
-            ok = true;
-            break;
-          }
-        }
-        if (! ok) {
-          std::cout << "Found dependency which does not have us as a parent!"
-                    << std::endl;
-        }
-      }
-      auto parents = en->getParents();
-      if (parents.size() > 1) {
-        std::cout << "Found a node with more than one parent!" << std::endl;
-      }
-      for (auto x : parents) {
-        auto deps = x->getDependencies();
-        bool ok = false;
-        for (auto it = deps.begin(); it != deps.end(); ++it) {
-          if (*it == en) {
-            ok = true;
-            break;
-          }
-        }
-        if (! ok) {
-          std::cout << "Found parent which does not have us as a dependency!"
-                    << std::endl;
-        }
-      }
-      return false;
-    }
-};
-
-void ExecutionPlan::checkLinkage () {
-  LinkChecker checker;
-  root()->walk(&checker);
-}
-
-#endif
-
 /// @brief helper struct for findVarUsage
 struct VarUsageFinder final : public WalkerWorker<ExecutionNode> {
   std::unordered_set<Variable const*> _usedLater;

--- a/arangod/Aql/ExecutionPlan.h
+++ b/arangod/Aql/ExecutionPlan.h
@@ -166,11 +166,6 @@ class ExecutionPlan {
   void findEndNodes(SmallVector<ExecutionNode*>& result,
                     bool enterSubqueries) const;
 
-/// @brief check linkage
-#if 0
-  void checkLinkage();
-#endif
-
   /// @brief determine and set _varsUsedLater and _valid and _varSetBy
   void findVarUsage();
 

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -119,7 +119,7 @@ AqlValue Expression::execute(transaction::Methods* trx, ExpressionContext* ctx,
 
   TRI_ASSERT(_type != UNPROCESSED);
   _expressionContext = ctx;
-
+ 
   // and execute
   switch (_type) {
     case JSON: {

--- a/arangod/Aql/Expression.h
+++ b/arangod/Aql/Expression.h
@@ -70,7 +70,7 @@ class Expression {
   ~Expression();
  
   /// @brief replace the root node
-  void replaceNode (AstNode* node) {
+  void replaceNode(AstNode* node) {
     _node = node;
     invalidate();
   }


### PR DESCRIPTION
If a COLLECT INTO is used, then it is detected which sub-attributes
of the into variables are used later in the query, and automatic
KEEP instructions are added to the COLLECT if possible

Example query:

    FOR doc1 IN collection1
      FOR doc2 IN collection2
        COLLECT x = doc1.x INTO g
        RETURN { x, all: g[*].doc1.y }

would be turned into

    FOR doc1 IN collection1
      FOR doc2 IN collection2
        COLLECT x = doc1.x INTO g KEEP doc1
        RETURN { x, all: g[*].doc1.y }

and prevent `doc2` from being temporarily stored in the variable `g`