### PR TITLE
allow specification of log topics with whitespace in the argument

### DIFF
--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -89,9 +89,12 @@ void Logger::setLogLevel(std::string const& levelName) {
     return;
   }
 
+  // if log level is "foo = bar", we better get rid of the whitespace
+  StringUtils::trimInPlace(v[0]);
   bool isGeneral = v.size() == 1;
 
   if (!isGeneral) {
+    StringUtils::trimInPlace(v[1]);
     l = v[1];
   }
 


### PR DESCRIPTION
For example, the following log level now does not cause a warning anymore

    v8 = trace

previously the log levels had to be specified without any whitespace around