### PR TITLE
Break retry loops on shutdown

### DIFF
--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -408,7 +408,7 @@ std::string AgencyCommResult::errorMessage() const {
   try {
     std::shared_ptr<VPackBuilder> bodyBuilder =
         VPackParser::fromJson(_body);
-    
+
 
     VPackSlice body = bodyBuilder->slice();
     if (!body.isObject()) {
@@ -1155,8 +1155,8 @@ AgencyCommResult AgencyComm::sendTransactionWithFailover(
                                        << result._statusCode
                                        << ", incriminating body: "
                                        << result.bodyRef()
-                                       << ", url: " << url 
-                                       << ", timeout: " << timeout 
+                                       << ", url: " << url
+                                       << ", timeout: " << timeout
                                        << ", data sent: " << builder.toJson();
     result.clear();
   } catch (...) {
@@ -1456,8 +1456,8 @@ AgencyCommResult AgencyComm::sendWithFailover(
         continue;
       }
 
-      // got a result, we are done
-      if (result.successful()) {
+      // got a result or shutdown, we are done
+      if (result.successful() || application_features::ApplicationServer::isStopping()) {
         AgencyCommManager::MANAGER->release(std::move(connection), endpoint);
         break;
       }
@@ -1511,7 +1511,7 @@ AgencyCommResult AgencyComm::sendWithFailover(
         if (outer.isObject() && outer.hasKey("ongoing")) {
           continue;
         }
-        
+
         // If we get an answer, and it contains a "results" key,
         // we release the connection and break out of the loop letting the
         // inquiry result go to the client. Otherwise try again.
@@ -1660,7 +1660,7 @@ AgencyCommResult AgencyComm::send(
 
   basics::StringBuffer& sb = response->getBody();
   result._body = std::string(sb.c_str(), sb.length());
-  
+
   LOG_TOPIC(TRACE, Logger::AGENCYCOMM)
       << "request to agency returned status code " << result._statusCode
       << ", message: '" << result._message << "', body: '" << result._body
@@ -1675,7 +1675,7 @@ bool AgencyComm::tryInitializeStructure() {
   try {
     VPackObjectBuilder b(&builder);
 
-    
+
     builder.add(                       // Cluster Id --------------------------
       "Cluster", VPackValue(to_string(boost::uuids::random_generator()())));
 

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1321,7 +1321,7 @@ int ClusterInfo::createCollectionCoordinator(std::string const& databaseName,
           LOG_TOPIC(ERR, Logger::CLUSTER) << "Could not get agency dump!";
         }
       } else {
-        errorMsg += std::string("file: ") + __FILE__ + 
+        errorMsg += std::string("file: ") + __FILE__ +
                     " line: " + std::to_string(__LINE__);
         errorMsg += " HTTP code: " + std::to_string(res.httpCode());
         errorMsg += " error message: " + res.errorMessage();
@@ -1660,7 +1660,7 @@ Result ClusterInfo::setCollectionStatusCoordinator(
   if (res.successful()) {
     loadPlan();
     return Result();
-  } 
+  }
 
   return Result(TRI_ERROR_CLUSTER_AGENCY_COMMUNICATION_FAILED, res.errorMessage());
 }
@@ -1693,7 +1693,7 @@ int ClusterInfo::ensureIndexCoordinator(
   int errorCode = ensureIndexCoordinatorWithoutRollback(
     databaseName, collectionID, idString, slice, create, compare, resultBuilder, errorMsg, timeout);
 
-  if (errorCode == TRI_ERROR_NO_ERROR) {
+  if (errorCode == TRI_ERROR_NO_ERROR || application_features::ApplicationServer::isStopping()) {
     return errorCode;
   }
 


### PR DESCRIPTION
Have twice seen coordinator go into long loop on shutdown.  Added two tests for isStopping() to break the loops.

Both loops were part of ClusterInfo::ensureIndexCoordinator()'s call tree.  First is in AgencyComm::sendWithFailover().  It would loop for 50 seconds.  Second is within ClusterInfor::ensureIndexCoordinatorWithoutRollback() which would retry if lower layers failed.  Combined, the two retry loops could delay coordinator stop by 10 minutes or more.

The changes also help coordinators stop slightly quicker even when not caught in the ensureIndexCoordinator() retry operations.