### PR TITLE
Bug fix 3.2:  Break retry loops on shutdown

### DIFF
--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -1472,8 +1472,8 @@ AgencyCommResult AgencyComm::sendWithFailover(
         continue;
       }
 
-      // got a result, we are done
-      if (result.successful()) {
+      // got a result or shutdown, we are done
+      if (result.successful() || application_features::ApplicationServer::isStopping()) {
         AgencyCommManager::MANAGER->release(std::move(connection), endpoint);
         break;
       }
@@ -1691,7 +1691,7 @@ bool AgencyComm::tryInitializeStructure(std::string const& jwtSecret) {
   try {
     VPackObjectBuilder b(&builder);
 
-    
+
     builder.add(                       // Cluster Id --------------------------
       "Cluster", VPackValue(to_string(boost::uuids::random_generator()())));
 

--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -1472,8 +1472,8 @@ AgencyCommResult AgencyComm::sendWithFailover(
         continue;
       }
 
-      // got a result or shutdown, we are done
-      if (result.successful() || application_features::ApplicationServer::isStopping()) {
+      // got a result, we are done
+      if (result.successful()) {
         AgencyCommManager::MANAGER->release(std::move(connection), endpoint);
         break;
       }
@@ -1691,7 +1691,7 @@ bool AgencyComm::tryInitializeStructure(std::string const& jwtSecret) {
   try {
     VPackObjectBuilder b(&builder);
 
-
+    
     builder.add(                       // Cluster Id --------------------------
       "Cluster", VPackValue(to_string(boost::uuids::random_generator()())));
 

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1697,7 +1697,7 @@ int ClusterInfo::ensureIndexCoordinator(
   int errorCode = ensureIndexCoordinatorWithoutRollback(
     databaseName, collectionID, idString, slice, create, compare, resultBuilder, errorMsg, timeout);
 
-  if (errorCode == TRI_ERROR_NO_ERROR) {
+  if (errorCode == TRI_ERROR_NO_ERROR || application_features::ApplicationServer::isStopping()) {
     return errorCode;
   }
 

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1697,7 +1697,7 @@ int ClusterInfo::ensureIndexCoordinator(
   int errorCode = ensureIndexCoordinatorWithoutRollback(
     databaseName, collectionID, idString, slice, create, compare, resultBuilder, errorMsg, timeout);
 
-  if (errorCode == TRI_ERROR_NO_ERROR || application_features::ApplicationServer::isStopping()) {
+  if (errorCode == TRI_ERROR_NO_ERROR) {
     return errorCode;
   }
 


### PR DESCRIPTION
Have twice seen coordinator go into long loop on shutdown. Added two tests for isStopping() to break the loops.

Both loops were part of ClusterInfo::ensureIndexCoordinator()'s call tree. First is in AgencyComm::sendWithFailover(). It would loop for 50 seconds. Second is within ClusterInfor::ensureIndexCoordinatorWithoutRollback() which would retry if lower layers failed. Combined, the two retry loops could delay coordinator stop by 10 minutes or more.

The changes also help coordinators stop slightly quicker even when not caught in the ensureIndexCoordinator() retry operations.