### PR TITLE
temporarily break flush thread feature in order to prevent some loss

### DIFF
--- a/arangod/MMFiles/MMFilesCollectorThread.cpp
+++ b/arangod/MMFiles/MMFilesCollectorThread.cpp
@@ -404,7 +404,7 @@ int MMFilesCollectorThread::collectLogfiles(bool& worked) {
 
   try {
     int res = collect(logfile);
-    // LOG_TOPIC(TRACE, Logger::COLLECTOR) << "collected logfile: " << logfile->id() << ". result: " << res;
+    LOG_TOPIC(TRACE, Logger::COLLECTOR) << "collected logfile: " << logfile->id() << ". result: " << res;
 
     if (res == TRI_ERROR_NO_ERROR) {
       // reset collector status

--- a/arangod/MMFiles/MMFilesLogfileManager.cpp
+++ b/arangod/MMFiles/MMFilesLogfileManager.cpp
@@ -1426,7 +1426,7 @@ MMFilesWalLogfile* MMFilesLogfileManager::getCollectableLogfile() {
         return logfile;
       }
 
-      if (logfile->id() > minId) {
+      if (logfile->id() > minId || !logfile->hasBeenReleased(released)) {
         // abort early
         break;
       }

--- a/arangod/MMFiles/MMFilesWalLogfile.h
+++ b/arangod/MMFiles/MMFilesWalLogfile.h
@@ -145,16 +145,17 @@ class MMFilesWalLogfile {
 
   /// @brief whether or not the logfile can be collected
   inline bool canBeCollected(TRI_voc_tick_t releasedTick) const {
-#if 0
-    // TODO: if this is reactivated, the recovery tests for MMFiles
-    // will show data loss in some tests
-    if (releasedTick <= df()->maxTick()) {
+    if (releasedTick < df()->maxTick()) {
       return false;
     }
-#endif
 
     return (_status == StatusType::SEALED ||
             _status == StatusType::COLLECTION_REQUESTED);
+  }
+
+  /// @brief whether or not the logfile can be collected
+  inline bool hasBeenReleased(TRI_voc_tick_t releasedTick) const {
+    return (releasedTick >= df()->maxTick());
   }
 
   /// @brief whether or not the logfile can be removed

--- a/arangod/MMFiles/MMFilesWalLogfile.h
+++ b/arangod/MMFiles/MMFilesWalLogfile.h
@@ -145,9 +145,13 @@ class MMFilesWalLogfile {
 
   /// @brief whether or not the logfile can be collected
   inline bool canBeCollected(TRI_voc_tick_t releasedTick) const {
+#if 0
+    // TODO: if this is reactivated, the recovery tests for MMFiles
+    // will show data loss in some tests
     if (releasedTick <= df()->maxTick()) {
       return false;
     }
+#endif
 
     return (_status == StatusType::SEALED ||
             _status == StatusType::COLLECTION_REQUESTED);

--- a/js/server/tests/recovery/documents.js
+++ b/js/server/tests/recovery/documents.js
@@ -1,0 +1,81 @@
+/* jshint globalstrict:false, strict:false, unused : false */
+/* global assertEqual, assertTrue */
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief tests for recovery
+// /
+// / @file
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2010-2012 triagens GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// / @author Copyright 2013, triAGENS GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+var db = require('@arangodb').db;
+var internal = require('internal');
+var jsunity = require('jsunity');
+
+function runSetup () {
+  'use strict';
+  internal.debugClearFailAt();
+
+  db._drop('UnitTestsRecovery');
+  var c = db._create('UnitTestsRecovery'), i;
+
+  for (i = 0; i < 1000; ++i) {
+    c.save({ _key: 'test' + i, value: i });
+  }
+  // shut down normally! no crashing!
+}
+
+function recoverySuite () {
+  'use strict';
+  jsunity.jsUnity.attachAssertions();
+
+  return {
+    setUp: function () {},
+    tearDown: function () {},
+
+    testDocuments: function () {
+      var i, c = db._collection('UnitTestsRecovery');
+
+      assertEqual(1000, c.count());
+      for (i = 0; i < 1000; ++i) {
+        assertTrue(c.exists('test' + i));
+        assertEqual(i, c.document('test' + i).value);
+      }
+    }
+
+  };
+}
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief executes the test suite
+// //////////////////////////////////////////////////////////////////////////////
+
+function main (argv) {
+  'use strict';
+  if (argv[1] === 'setup') {
+    runSetup();
+    return 0;
+  } else {
+    jsunity.run(recoverySuite);
+    return jsunity.done().status ? 0 : 1;
+  }
+}

--- a/js/server/tests/recovery/many-documents.js
+++ b/js/server/tests/recovery/many-documents.js
@@ -1,0 +1,80 @@
+/* jshint globalstrict:false, strict:false, unused : false */
+/* global assertEqual, assertTrue */
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief tests for recovery
+// /
+// / @file
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2010-2012 triagens GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// / @author Copyright 2013, triAGENS GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+var db = require('@arangodb').db;
+var internal = require('internal');
+var jsunity = require('jsunity');
+
+function runSetup () {
+  'use strict';
+  internal.debugClearFailAt();
+
+  db._drop('UnitTestsRecovery');
+  var c = db._create('UnitTestsRecovery'), i;
+
+  for (i = 0; i < 100000; ++i) {
+    c.save({ _key: 'test' + i, value: i });
+  }
+  // shut down normally! no crashing!
+}
+
+function recoverySuite () {
+  'use strict';
+  jsunity.jsUnity.attachAssertions();
+
+  return {
+    setUp: function () {},
+    tearDown: function () {},
+
+    testManyDocuments: function () {
+      var i, c = db._collection('UnitTestsRecovery');
+
+      assertEqual(100000, c.count());
+      for (i = 0; i < 100000; ++i) {
+        assertEqual(i, c.document('test' + i).value);
+      }
+    }
+
+  };
+}
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief executes the test suite
+// //////////////////////////////////////////////////////////////////////////////
+
+function main (argv) {
+  'use strict';
+  if (argv[1] === 'setup') {
+    runSetup();
+    return 0;
+  } else {
+    jsunity.run(recoverySuite);
+    return jsunity.done().status ? 0 : 1;
+  }
+}


### PR DESCRIPTION
I just found that in latest devel the WAL recovery for MMFiles does not always take place as expected. It seems to happen in some situations only.
I have added two recovery tests that should demonstrate the problem. In order to reproduce it, undo the `#if 0` change I made in `MMFilesWalLogfile.h` in this PR. Everything should work fine with the `#if 0` in place, but without it I sometimes do not see the WAL file recovery actually working after restart. So data that was in the WAL before shutdown does not make it in the collections after restart.

Run the recovery tests as follows: `scripts/unittest recovery --test documents.js`
For me at least one of the tests fails if the `#if 0` code part is changed back.

This needs proper investigation, and it needs a proper fix. The `#if 0` will definitely break the FlushThread functionality that was added for IResearch.