### PR TITLE
Bug fix 3.2:  Make chooseTimeout() dynamic

### DIFF
--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -204,6 +204,7 @@ SET(ARANGOD_SOURCES
   Cluster/FollowerInfo.cpp
   Cluster/DBServerAgencySync.cpp
   Cluster/HeartbeatThread.cpp
+  Cluster/ReplicationTimeoutFeature.cpp
   Cluster/RestAgencyCallbacksHandler.cpp
   Cluster/ServerState.cpp
   Cluster/ShardDistributionReporter.cpp

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -133,10 +133,6 @@ void ClusterFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                      "replication factor for system collections",
                      new UInt32Parameter(&_systemReplicationFactor));
 
-  options->addOption("--cluster.synchronous-replication-timeout-factor",
-                     "all synchronous replication timeouts are multiplied by this factor",
-                     new DoubleParameter(&_syncReplTimeoutFactor));
-
   options->addHiddenOption("--cluster.create-waits-for-sync-replication",
                      "active coordinator will wait for all replicas to create collection",
                      new BooleanParameter(&_createWaitsForSyncReplication));

--- a/arangod/Cluster/ClusterFeature.h
+++ b/arangod/Cluster/ClusterFeature.h
@@ -50,10 +50,6 @@ class ClusterFeature : public application_features::ApplicationFeature {
     return _agencyPrefix;
   }
 
-  double syncReplTimeoutFactor() {
-    return _syncReplTimeoutFactor;
-  }
-
  private:
   std::vector<std::string> _agencyEndpoints;
   std::string _agencyPrefix;
@@ -63,7 +59,6 @@ class ClusterFeature : public application_features::ApplicationFeature {
   std::string _myAddress;
   uint32_t _systemReplicationFactor = 2;
   bool _createWaitsForSyncReplication = true;
-  double _syncReplTimeoutFactor = 1.0;
 
  private:
   void reportRole(ServerState::RoleEnum);

--- a/arangod/Cluster/ReplicationTimeoutFeature.cpp
+++ b/arangod/Cluster/ReplicationTimeoutFeature.cpp
@@ -1,0 +1,58 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2016 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#include "ReplicationTimeoutFeature.h"
+#include "StorageEngine/EngineSelectorFeature.h"
+#include "StorageEngine/StorageEngine.h"
+
+using namespace arangodb;
+using namespace arangodb::options;
+  
+double ReplicationTimeoutFeature::timeoutFactor = 1.0;
+double ReplicationTimeoutFeature::timeoutPer4k = 0.1;
+double ReplicationTimeoutFeature::lowerLimit = 0.5;
+
+ReplicationTimeoutFeature::ReplicationTimeoutFeature(application_features::ApplicationServer* server)
+    : ApplicationFeature(server, "ReplicationTimeout") {
+  setOptional(true);
+  requiresElevatedPrivileges(false);
+  startsAfter("EngineSelector");
+  startsBefore("StorageEngine");
+}
+
+void ReplicationTimeoutFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
+  options->addSection("cluster", "Configure the cluster");
+
+  options->addOption("--cluster.synchronous-replication-timeout-factor",
+                     "all synchronous replication timeouts are multiplied by this factor",
+                     new DoubleParameter(&timeoutFactor));
+
+  options->addHiddenOption("--cluster.synchronous-replication-timeout-per-4k",
+                     "all synchronous replication timeouts are increased by this amount per 4096 bytes (in seconds)",
+                     new DoubleParameter(&timeoutPer4k));
+}
+
+void ReplicationTimeoutFeature::prepare() {
+  // set minimum timeout. this depends on the selected storage engine 
+  lowerLimit = EngineSelectorFeature::ENGINE->minimumSyncReplicationTimeout();
+}

--- a/arangod/Cluster/ReplicationTimeoutFeature.h
+++ b/arangod/Cluster/ReplicationTimeoutFeature.h
@@ -1,0 +1,49 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2016 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef ARANGOD_CLUSTER_REPLICATION_TIMEOUT_FEATURE_H
+#define ARANGOD_CLUSTER_REPLICATION_TIMEOUT_FEATURE_H 1
+
+#include "Basics/Common.h"
+
+#include "ApplicationFeatures/ApplicationFeature.h"
+
+namespace arangodb {
+
+class ReplicationTimeoutFeature : public application_features::ApplicationFeature {
+ public:
+  explicit ReplicationTimeoutFeature(application_features::ApplicationServer*);
+
+ public:
+  void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
+  void prepare() override final;
+  
+ public:
+  static double timeoutFactor;
+  static double timeoutPer4k;
+  static double lowerLimit;
+};
+
+}
+
+#endif

--- a/arangod/MMFiles/MMFilesEngine.h
+++ b/arangod/MMFiles/MMFilesEngine.h
@@ -85,6 +85,9 @@ class MMFilesEngine final : public StorageEngine {
   // flush wal wait for collector
   void stop() override;
   
+  // minimum timeout for the synchronous replication
+  double minimumSyncReplicationTimeout() const override { return 0.5; }
+  
   bool supportsDfdb() const override { return true; }
   
   bool useRawDocumentPointers() override { return true; }

--- a/arangod/RestServer/arangod.cpp
+++ b/arangod/RestServer/arangod.cpp
@@ -50,6 +50,7 @@
 #include "Basics/ArangoGlobalContext.h"
 #include "Cache/CacheManagerFeature.h"
 #include "Cluster/ClusterFeature.h"
+#include "Cluster/ReplicationTimeoutFeature.h"
 #include "GeneralServer/AuthenticationFeature.h"
 #include "GeneralServer/GeneralServerFeature.h"
 #include "Logger/LoggerBufferFeature.h"
@@ -110,7 +111,7 @@ static int runServer(int argc, char** argv, ArangoGlobalContext &context) {
   try {
     context.installSegv();
     context.runStartupChecks();
-    
+
     std::string name = context.binaryName();
 
     auto options = std::make_shared<options::ProgramOptions>(
@@ -122,7 +123,7 @@ static int runServer(int argc, char** argv, ArangoGlobalContext &context) {
     std::vector<std::string> nonServerFeatures = {
         "Action",        "Agency",
         "Cluster",       "Daemon",
-        "FoxxQueues",    "GeneralServer", 
+        "FoxxQueues",    "GeneralServer",
         "Greetings",     "LoggerBufferFeature",
         "Server",        "SslServer",
         "Statistics",    "Supervisor"};
@@ -165,6 +166,7 @@ static int runServer(int argc, char** argv, ArangoGlobalContext &context) {
     server.addFeature(new pregel::PregelFeature(&server));
     server.addFeature(new PrivilegeFeature(&server));
     server.addFeature(new RandomFeature(&server));
+    server.addFeature(new ReplicationTimeoutFeature(&server));
     server.addFeature(new QueryRegistryFeature(&server));
     server.addFeature(new SchedulerFeature(&server));
     server.addFeature(new ScriptFeature(&server, &ret));

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -82,6 +82,9 @@ class RocksDBEngine final : public StorageEngine {
   void stop() override;
   void unprepare() override;
 
+  // minimum timeout for the synchronous replication
+  double minimumSyncReplicationTimeout() const override { return 1.0; }
+
   bool supportsDfdb() const override { return false; }
   bool useRawDocumentPointers() override { return false; }
 

--- a/arangod/StorageEngine/StorageEngine.h
+++ b/arangod/StorageEngine/StorageEngine.h
@@ -106,6 +106,9 @@ class StorageEngine : public application_features::ApplicationFeature {
   // create storage-engine specific view
   virtual PhysicalView* createPhysicalView(LogicalView*, VPackSlice const&) = 0;
 
+  // minimum timeout for the synchronous replication
+  virtual double minimumSyncReplicationTimeout() const = 0;
+
   // status functionality
   // --------------------
 

--- a/arangod/Transaction/Methods.h
+++ b/arangod/Transaction/Methods.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2016 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2017 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,6 +37,12 @@
 #include "VocBase/voc-types.h"
 
 #include <velocypack/Slice.h>
+
+#ifdef USE_ENTERPRISE
+  #define ENTERPRISE_VIRT virtual
+#else
+  #define ENTERPRISE_VIRT
+#endif
 
 namespace arangodb {
 
@@ -81,11 +87,6 @@ class TransactionState;
 class TransactionCollection;
 
 namespace transaction {
-#ifdef USE_ENTERPRISE
-  #define ENTERPRISE_VIRT virtual
-#else
-  #define ENTERPRISE_VIRT
-#endif
 
 class Methods {
   friend class traverser::BaseEngine;


### PR DESCRIPTION
from PR 3996 on devel:

chooseTimeout() was setting the timeout too low for ClusterComm::processRequests() when data size was 500K. This update adds 100ms of timeout per 4096 of data body. So the routine now dynamically responds to message size.

The function is now chooseTimeout(size_t count, size_t total_bytes). A new hidden option variable exists call cluster.synchronous-replication-timeout-per-4k. This allows the default 100ms (0.1 seconds) to be changed at start-up.

The total_bytes parameter contains the sum of all messages in this batch. This assumes there might be shared resources along the communication and/or destination database path that have to process all the bytes, not just one message's data.