### PR TITLE
Bug Fix 3.2:  connection timeout treated as "send complete"

### DIFF
--- a/lib/SimpleHttpClient/Communicator.cpp
+++ b/lib/SimpleHttpClient/Communicator.cpp
@@ -393,6 +393,7 @@ void Communicator::createRequestInProgress(NewRequest const& newRequest) {
 
 void Communicator::handleResult(CURL* handle, CURLcode rc) {
   // remove request in progress
+  double connectTime(0.0);
   curl_multi_remove_handle(_curl, handle);
 
   RequestInProgress* rip = nullptr;

--- a/lib/SimpleHttpClient/Communicator.cpp
+++ b/lib/SimpleHttpClient/Communicator.cpp
@@ -410,6 +410,11 @@ void Communicator::handleResult(CURL* handle, CURLcode rc) {
   LOG_TOPIC(TRACE, Logger::COMMUNICATION)
       << prefix << "Curl rc is : " << rc << " after "
       << Logger::FIXED(TRI_microtime() - rip->_startTime) << " s";
+  if (CURLE_OPERATION_TIMEDOUT == rc) {
+    curl_easy_getinfo(handle, CURLINFO_CONNECT_TIME, &connectTime);
+    LOG_TOPIC(TRACE, Logger::COMMUNICATION)
+      << prefix << "CURLINFO_CONNECT_TIME is " << connectTime;
+  } // if
   if (strlen(rip->_errorBuffer) != 0) {
     LOG_TOPIC(TRACE, Logger::COMMUNICATION)
         << prefix << "Curl error details: " << rip->_errorBuffer;


### PR DESCRIPTION
From PR 3866 on devel & 3.3:

Communicator::HandleResult() was returning an error message upon connection timeout that forced ClusterCommResult::fromError() to assume sendWasComplete should be marked true. This created a mild logging error during Agency gossip. But real fear is that some yet to be identified operation might assume the server received a message when in fact the server was not available.

CURL_OPERATION_TIMEOUT appears to be used both for connection timeout and overall operation timeout (such as awaiting a response). Added code detects the difference by retrieving the total time of connection. If zero, the connection never happened.