### PR TITLE
use struct instead of class

### DIFF
--- a/arangod/IResearch/IResearchOrderFactory.h
+++ b/arangod/IResearch/IResearchOrderFactory.h
@@ -31,8 +31,8 @@
 NS_BEGIN(arangodb)
 NS_BEGIN(aql)
 
-class AstNode;
-class Variable;
+struct AstNode;
+struct Variable;
 
 NS_END // aql
 


### PR DESCRIPTION
to fix those build warnings: 
```
In file included from /Users/hkernbach/Git/devel/arangod/IResearch/IResearchViewBlock.cpp:32:
/Users/hkernbach/Git/devel/arangod/IResearch/IResearchOrderFactory.h:34:1: warning: class 'AstNode' was previously declared as a struct [-Wmismatched-tags]
class AstNode;
^
/Users/hkernbach/Git/devel/arangod/Aql/AstNode.h:199:8: note: previous use is here
struct AstNode {
       ^
/Users/hkernbach/Git/devel/arangod/IResearch/IResearchOrderFactory.h:34:1: note: did you mean struct here?
class AstNode;
^~~~~
struct
/Users/hkernbach/Git/devel/arangod/IResearch/IResearchOrderFactory.h:35:1: warning: class 'Variable' was previously declared as a struct [-Wmismatched-tags]
class Variable;
^
/Users/hkernbach/Git/devel/arangod/Aql/Variable.h:39:8: note: previous use is here
struct Variable {
       ^
/Users/hkernbach/Git/devel/arangod/IResearch/IResearchOrderFactory.h:35:1: note: did you mean struct here?
class Variable;
^~~~~
struct
```