### PR TITLE
Fix logrotate configuration

### DIFF
--- a/Installation/logrotate.d/arangod.systemd
+++ b/Installation/logrotate.d/arangod.systemd
@@ -3,8 +3,8 @@
      weekly
      compress
      delaycompress
-     create 640  arangodb adm
+     create 640  arangodb @LOGROTATE_GROUP@
      postrotate
-     systemctl -q is-active @SERVICE_NAME@ && systemctl kill --signal=SIGHUP arangodb3
+     systemctl -q is-active @SERVICE_NAME@ && systemctl kill --signal=SIGHUP @SERVICE_NAME@
      endscript
      }

--- a/cmake/ArangoDBInstall.cmake
+++ b/cmake/ArangoDBInstall.cmake
@@ -178,27 +178,8 @@ if (UNIX)
         DESTINATION ${SYSTEMD_UNIT_DIR}/
         RENAME ${SERVICE_NAME}.service
       )
-
-      # configure and install logrotate file
-      configure_file (
-        ${ARANGODB_SOURCE_DIR}/Installation/logrotate.d/arangod.systemd
-        ${PROJECT_BINARY_DIR}/arangod.systemd
-        NEWLINE_STYLE UNIX
-      )
-      install(
-        FILES ${PROJECT_BINARY_DIR}/arangod.systemd
-        PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
-        DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/logrotate.d
-        RENAME ${SERVICE_NAME}
-      )
-
     else ()
       message(STATUS "-- systemd not found")
-      configure_file (
-        ${ARANGODB_SOURCE_DIR}/Installation/logrotate.d/arangod.sysv
-        ${PROJECT_BINARY_DIR}/arangod.sysv
-        NEWLINE_STYLE UNIX
-      )
     endif(SYSTEMD_FOUND)
   endif(NOT PKG_CONFIG_FOUND) 
 endif(UNIX)

--- a/cmake/packages/deb.cmake
+++ b/cmake/packages/deb.cmake
@@ -24,6 +24,8 @@ else()
   set(CPACK_SYSTEMD_FOUND "0")
 endif()
 
+set(LOGROTATE_GROUP "adm")
+
 # substitute the package name so debconf works:
 configure_file (
   "${PROJECT_SOURCE_DIR}/Installation/debian/templates.in"

--- a/cmake/packages/packages.cmake
+++ b/cmake/packages/packages.cmake
@@ -28,6 +28,7 @@ endif ()
 set(ARANGODB_PACKAGE_ARCHITECTURE ${CMAKE_SYSTEM_PROCESSOR})
 # eventually the package string will be modified later on:
 
+set(LOGROTATE_GROUP "arangodb")
 if ("${PACKAGING}" STREQUAL "DEB")
   if(CMAKE_TARGET_ARCHITECTURES MATCHES ".*x86_64.*")
     set(ARANGODB_PACKAGE_ARCHITECTURE "amd64")
@@ -75,6 +76,29 @@ elseif (MSVC)
 else ()
   set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${ARANGODB_PACKAGE_REVISION}_${ARANGODB_PACKAGE_ARCHITECTURE}")
   include(packages/tar)
+endif ()
+
+if (UNIX)
+  if (SYSTEMD_FOUND)
+    # configure and install logrotate file
+    configure_file (
+      ${ARANGODB_SOURCE_DIR}/Installation/logrotate.d/arangod.systemd
+      ${PROJECT_BINARY_DIR}/arangod.systemd
+      NEWLINE_STYLE UNIX
+      )
+    install(
+      FILES ${PROJECT_BINARY_DIR}/arangod.systemd
+      PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+      DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/logrotate.d
+      RENAME ${SERVICE_NAME}
+      )
+  else ()
+    configure_file (
+      ${ARANGODB_SOURCE_DIR}/Installation/logrotate.d/arangod.sysv
+      ${PROJECT_BINARY_DIR}/arangod.sysv
+      NEWLINE_STYLE UNIX
+      )
+  endif ()
 endif ()
 
 


### PR DESCRIPTION
- we have to be able to configure a usergroup per distro target.
  ArangoDBInstall is invoked before the distro specific stuff.
  -> moving install into packages.cmake
- default to the user group of the file to be "arangodb"
- on debian systems logfiles are written with the "adm" group - overriding the default.
- fix the name of the service for enterprise packages