### PR TITLE
use --forceVersionNightly to set the bugfix part of the version to 'nightly'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,9 @@ endif ()
 
 set(ARANGODB_VERSION_MAJOR      "3")
 set(ARANGODB_VERSION_MINOR      "3")
-set(ARANGODB_VERSION_REVISION   "devel")
+if (NOT DEFINED ARANGODB_VERSION_REVISION)
+  set(ARANGODB_VERSION_REVISION   "devel")
+endif()
 set(ARANGODB_PACKAGE_REVISION   "1")
 # version for the windows rc file needs to be numeric:
 if (ARANGODB_VERSION_REVISION GREATER -1)

--- a/Installation/Jenkins/build.sh
+++ b/Installation/Jenkins/build.sh
@@ -413,6 +413,10 @@ while [ $# -gt 0 ];  do
             RETRY_N_TIMES=$1
             shift
             ;;
+        --forceVersionNightly)
+            shift
+            CONFIGURE_OPTIONS+=(-DARANGODB_VERSION_REVISION=nightly)
+            ;;
         *)
             echo "Unknown option: $1"
             exit 1


### PR DESCRIPTION

We need this in order to not have misleading versions on nightly builds from stable branches.