### PR TITLE
make the default value of `--rocksdb.block-cache-shard-bits` use the …

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+v3.2.12 (XXXX-XX-XX)
+--------------------
+
+* make the default value of `--rocksdb.block-cache-shard-bits` use the RocksDB
+  default value. This will mostly mean the default number block cache shard
+  bits is lower than before, allowing each shard to store more data and cause
+  less evictions from block cache
+
+
 v3.2.11 (2018-01-17)
 --------------------
 

--- a/lib/ApplicationFeatures/RocksDBOptionFeature.cpp
+++ b/lib/ApplicationFeatures/RocksDBOptionFeature.cpp
@@ -70,7 +70,7 @@ RocksDBOptionFeature::RocksDBOptionFeature(
       _blockCacheSize((TRI_PhysicalMemory >= (static_cast<uint64_t>(4) << 30))
         ? static_cast<uint64_t>(((TRI_PhysicalMemory - (static_cast<uint64_t>(2) << 30)) * 0.3))
         : (256 << 20)),
-      _blockCacheShardBits(0),
+      _blockCacheShardBits(-1),
       _tableBlockSize(std::max(rocksDBTableOptionsDefaults.block_size, static_cast<decltype(rocksDBTableOptionsDefaults.block_size)>(16 * 1024))),
       _recycleLogFileNum(rocksDBDefaults.recycle_log_file_num),
       _compactionReadaheadSize(2 * 1024 * 1024),//rocksDBDefaults.compaction_readahead_size
@@ -85,11 +85,6 @@ RocksDBOptionFeature::RocksDBOptionFeature(
       _skipCorrupted(false),
       _dynamicLevelBytes(true),
       _enableStatistics(false) {
-  uint64_t testSize = _blockCacheSize >> 19;
-  while (testSize > 0) {
-    _blockCacheShardBits++;
-    testSize >>= 1;
-  }
   // setting the number of background jobs to
   _maxBackgroundJobs = static_cast<int32_t>(std::max((size_t)2,
                                 std::min(TRI_numberProcessors(), (size_t)8)));
@@ -251,8 +246,8 @@ void RocksDBOptionFeature::collectOptions(
                      new UInt64Parameter(&_blockCacheSize));
 
   options->addOption("--rocksdb.block-cache-shard-bits",
-                     "number of shard bits to use for block cache",
-                     new UInt64Parameter(&_blockCacheShardBits));
+                     "number of shard bits to use for block cache (use -1 for default value)",
+                     new Int64Parameter(&_blockCacheShardBits));
 
   options->addOption("--rocksdb.table-block-size",
                      "approximate size (in bytes) of user data packed per block",
@@ -313,7 +308,8 @@ void RocksDBOptionFeature::validateOptions(
   if (_maxSubcompactions > _numThreadsLow) {
     _maxSubcompactions = _numThreadsLow;
   }
-  if (_blockCacheShardBits > 32) {
+  if (_blockCacheShardBits >= 20 || _blockCacheShardBits < -1) {
+    // -1 is RocksDB default value, but anything less is invalid
     LOG_TOPIC(FATAL, arangodb::Logger::FIXME)
         << "invalid value for '--rocksdb.block-cache-shard-bits'";
     FATAL_ERROR_EXIT();

--- a/lib/ApplicationFeatures/RocksDBOptionFeature.h
+++ b/lib/ApplicationFeatures/RocksDBOptionFeature.h
@@ -63,7 +63,7 @@ class RocksDBOptionFeature final
   uint32_t _numThreadsHigh;
   uint32_t _numThreadsLow;
   uint64_t _blockCacheSize;
-  uint64_t _blockCacheShardBits;
+  int64_t _blockCacheShardBits;
   uint64_t _tableBlockSize;
   uint64_t _recycleLogFileNum;
   uint64_t _compactionReadaheadSize;


### PR DESCRIPTION
…RocksDB default value.

This will mostly mean the default number block cache shard bits is lower than before, allowing each shard to store more data and cause less evictions from block cache