### PR TITLE
Jenkins Pipeline Fix Undefined Variable

### DIFF
--- a/Installation/Pipeline/Jenkinsfile.groovy
+++ b/Installation/Pipeline/Jenkinsfile.groovy
@@ -626,7 +626,7 @@ def setBuildsAndTests() {
         runTests = params.RunTests
         runResilience = params.RunResilience
 
-        if (!useLinux && !userMac && !useWindows && !useDocker){
+        if (!useLinux && !useMac && !useWindows && !useDocker){
             throw("No build type selected for custom build!")
         }
 

--- a/Installation/Pipeline/Jenkinsfile.groovy.in
+++ b/Installation/Pipeline/Jenkinsfile.groovy.in
@@ -626,7 +626,7 @@ def setBuildsAndTests() {
         runTests = params.RunTests
         runResilience = params.RunResilience
 
-        if (!useLinux && !userMac && !useWindows && !useDocker){
+        if (!useLinux && !useMac && !useWindows && !useDocker){
             throw("No build type selected for custom build!")
         }
 


### PR DESCRIPTION
Fixed a type in VariableName of the pipeline script. This caused the Script to be unable to build custom combinations.
