### PR TITLE
Docs: Use relative links for cross references

### DIFF
--- a/Documentation/Books/Manual/Graphs/README.md
+++ b/Documentation/Books/Manual/Graphs/README.md
@@ -277,7 +277,7 @@ The above referenced chapters describe the various APIs of ArangoDBs graph engin
 
  - [Traversing a graph in full depth](../../Cookbook/Graph/FulldepthTraversal.html)
  - [Using an example vertex with the java driver](../../Cookbook/Graph/JavaDriverGraphExampleVertex.html)
- - [Retrieving documents from ArangoDB without knowing the structure](https://docs.arangodb.com/cookbook/Graph/JavaDriverBaseDocument.html)
+ - [Retrieving documents from ArangoDB without knowing the structure](../../Cookbook/UseCases/JavaDriverBaseDocument.html)
  - [Using a custom visitor from node.js](../../Cookbook/Graph/CustomVisitorFromNodeJs.html)
  - [AQL Example Queries on an Actors and Movies Database](../../Cookbook/Graph/ExampleActorsAndMovies.html)
 

--- a/Documentation/Books/Manual/README.md
+++ b/Documentation/Books/Manual/README.md
@@ -17,7 +17,7 @@ The documentation is organized in four handbooks:
   that is used to communicate with clients. In general, the HTTP handbook will be
   of interest to driver developers. If you use any of the existing drivers for
   the language of your choice, you can skip this handbook.
-- Our [cookbook](../cookbook/index.html) with recipes for specific problems and
+- Our [cookbook](../Cookbook/index.html) with recipes for specific problems and
   solutions.
 
 Features are illustrated with interactive usage examples; you can cut'n'paste them

--- a/Documentation/Books/Manual/ReleaseNotes/KnownIssues32.md
+++ b/Documentation/Books/Manual/ReleaseNotes/KnownIssues32.md
@@ -97,5 +97,5 @@ The following known issues will be resolved in future releases:
 
 ### OpenSSL 1.1
 
- * ArangoDB has been tested with OpenSSL 1.0 only and won't build against 1.1 when compiling on your own. See [here](../../cookbook/Compiling/OpenSSL.html)
+ * ArangoDB has been tested with OpenSSL 1.0 only and won't build against 1.1 when compiling on your own. See [here](../../Cookbook/Compiling/OpenSSL.html)
    for how to compile on systems that ship OpenSSL 1.1 by default.

--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures24.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures24.md
@@ -64,7 +64,7 @@ is here:
 * [part 2](https://www.arangodb.com/2014/12/02/building-hypermedia-apis-design)
 * [part 3](https://www.arangodb.com/2014/12/08/building-hypermedia-apis-foxxgenerator)
 
-A cookbook recipe for getting started with FoxxGenerator is [here](https://docs.arangodb.com/2.8/cookbook/FoxxGeneratorFirstSteps.html).
+A cookbook recipe for getting started with FoxxGenerator is [here](https://docs.arangodb.com/2.8/Cookbook/FoxxGeneratorFirstSteps.html).
 
 AQL improvements
 ----------------

--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures26.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures26.md
@@ -212,7 +212,7 @@ You can now write tests for your Foxx apps using the Mocha testing framework:
 https://www.arangodb.com/2015/04/testing-foxx-mocha/
 
 A recipe for writing tests for your Foxx apps can be found in the cookbook:
-https://docs.arangodb.com/2.8/cookbook/FoxxTesting.html
+https://docs.arangodb.com/2.8/Cookbook/FoxxTesting.html
 
 ### API Documentation
 

--- a/Documentation/Books/Manual/ReleaseNotes/UpgradingChanges27.md
+++ b/Documentation/Books/Manual/ReleaseNotes/UpgradingChanges27.md
@@ -64,7 +64,7 @@ The properties `setup` and `teardown` have been moved into the `scripts` propert
 
 ### Foxx Queues
 
-Function-based Foxx Queue job types are no longer supported. To learn about how you can use the new script-based job types [follow the updated recipe in the cookbook](https://docs.arangodb.com/2.8/cookbook/FoxxQueues.html).
+Function-based Foxx Queue job types are no longer supported. To learn about how you can use the new script-based job types [follow the updated recipe in the cookbook](https://docs.arangodb.com/2.8/Cookbook/FoxxQueues.html).
 
 ### Foxx Sessions
 

--- a/Documentation/Books/Manual/ReleaseNotes/UpgradingChanges30.md
+++ b/Documentation/Books/Manual/ReleaseNotes/UpgradingChanges30.md
@@ -149,7 +149,7 @@ The functions:
 * GRAPH_PATHS
 * GRAPH_VERTICES
 
-are covered in [Migrating GRAPH_* Functions from 2.8 or earlier to 3.0](https://docs.arangodb.com/cookbook/AQL/MigratingGraphFunctionsTo3.html)
+are covered in [Migrating GRAPH_* Functions from 2.8 or earlier to 3.0](../../Cookbook/AQL/MigratingGraphFunctionsTo3.html)
 
 * GRAPH_ABSOLUTE_BETWEENNESS
 * GRAPH_ABSOLUTE_CLOSENESS
@@ -160,7 +160,7 @@ are covered in [Migrating GRAPH_* Functions from 2.8 or earlier to 3.0](https://
 * GRAPH_ECCENTRICITY
 * GRAPH_RADIUS
 
-are covered in [Migrating GRAPH_* Measurements from 2.8 or earlier to 3.0](https://docs.arangodb.com/cookbook/AQL/MigratingMeasurementsTo3.html)
+are covered in [Migrating GRAPH_* Measurements from 2.8 or earlier to 3.0](../../Cookbook/AQL/MigratingMeasurementsTo3.html)
 
 * EDGES
 * NEIGHBORS
@@ -168,7 +168,7 @@ are covered in [Migrating GRAPH_* Measurements from 2.8 or earlier to 3.0](https
 * TRAVERSAL
 * TRAVERSAL_TREE
 
-are covered in [Migrating anonymous graph functions from 2.8 or earlier to 3.0](https://docs.arangodb.com/3/cookbook/AQL/MigratingEdgeFunctionsTo3.html)
+are covered in [Migrating anonymous graph functions from 2.8 or earlier to 3.0](../../Cookbook/AQL/MigratingEdgeFunctionsTo3.html)
 
 ### Typecasting functions
 


### PR DESCRIPTION
Fixes #4505 - Broken links to 2.8 -> 3.0 migration guides in release notes