### PR TITLE
fix internal issue #1848

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.3.4 (XXXX-XX-XX)
 -------------------
 
+* fix internal issue #1848: AQL optimizer was trying to resolve attribute accesses
+  to attributes of constant object values at query compile time, but only did so far
+  the very first attribute in each object
+
+  this fixes https://stackoverflow.com/questions/48648737/beginner-bug-in-for-loops-from-objects
 
 * fix inconvenience: If we want to start server with a non-existing
   --javascript.app-path it will now be created (if possible)
@@ -20,7 +25,6 @@ v3.3.4 (XXXX-XX-XX)
 
 v3.3.3 (2018-01-16)
 -------------------
-
 
 * fix issue #4272: VERSION file keeps disappearing
 
@@ -81,6 +85,7 @@ v3.3.3 (2018-01-16)
 
 * fixed incorrect persistence of RAFT vote and term
 
+
 v3.3.2 (2018-01-04)
 -------------------
 
@@ -94,7 +99,8 @@ v3.3.2 (2018-01-04)
 
 * fixed issue #4197: AQL statement not working in 3.3.1 when upgraded from 3.2.10
 
-* do not reuse collection ids when restoring collections from a dump, but assign new collection ids, this should prevent collection id conflicts
+* do not reuse collection ids when restoring collections from a dump, but assign 
+  new collection ids, this should prevent collection id conflicts
 
 
 v3.3.1 (2017-12-28)

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -2916,7 +2916,7 @@ AstNode* Ast::optimizeAttributeAccess(AstNode* node, std::unordered_map<Variable
     size_t const n = what->numMembers();
 
     for (size_t i = 0; i < n; ++i) {
-      AstNode const* member = what->getMember(0);
+      AstNode const* member = what->getMember(i);
 
       if (member->type == NODE_TYPE_OBJECT_ELEMENT &&
           member->getStringLength() == length &&

--- a/js/server/tests/aql/aql-queries-optimizer.js
+++ b/js/server/tests/aql/aql-queries-optimizer.js
@@ -53,6 +53,20 @@ function ahuacatlOptimizerTestSuite () {
     tearDown : function () {
     },
 
+    testAttributeAccessOptimization : function () {
+      let query = "LET what = { a: [ 'foo' ], b: [ 'bar' ] } FOR doc IN what.a RETURN doc";
+      let actual = getQueryResults(query);
+      assertEqual([ 'foo' ], actual);
+      
+      query = "LET what = { a: [ 'foo' ], b: [ 'bar' ] } FOR doc IN what.b RETURN doc";
+      actual = getQueryResults(query);
+      assertEqual([ 'bar' ], actual);
+      
+      query = "LET what = { a: [ 'foo' ], b: [ 'bar' ], c: [ 'baz' ] } FOR doc IN what.c RETURN doc";
+      actual = getQueryResults(query);
+      assertEqual([ 'baz' ], actual);
+    },
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test special case "empty for loop"
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
AQL optimizer was trying to resolve attribute accesses
to attributes of constant object values at query compile time, but only did so far
the very first attribute in each object

this fixes https://stackoverflow.com/questions/48648737/beginner-bug-in-for-loops-from-objects