### PR TITLE
fix internal issue #1848

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 v3.2.12 (XXXX-XX-XX)
 --------------------
 
+* fix internal issue #1848
+    
+  AQL optimizer was trying to resolve attribute accesses
+  to attributes of constant object values at query compile time, but only did so far
+  the very first attribute in each object
+    
+  this fixes https://stackoverflow.com/questions/48648737/beginner-bug-in-for-loops-from-objects
 
 * fix inconvenience: If we want to start server with a non-existing
   --javascript.app-path it will now be created (if possible)

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -2913,7 +2913,7 @@ AstNode* Ast::optimizeAttributeAccess(AstNode* node, std::unordered_map<Variable
     size_t const n = what->numMembers();
 
     for (size_t i = 0; i < n; ++i) {
-      AstNode const* member = what->getMember(0);
+      AstNode const* member = what->getMember(i);
 
       if (member->type == NODE_TYPE_OBJECT_ELEMENT &&
           member->getStringLength() == length &&

--- a/js/server/tests/aql/aql-queries-optimizer.js
+++ b/js/server/tests/aql/aql-queries-optimizer.js
@@ -53,6 +53,20 @@ function ahuacatlOptimizerTestSuite () {
     tearDown : function () {
     },
 
+    testAttributeAccessOptimization : function () {
+      let query = "LET what = { a: [ 'foo' ], b: [ 'bar' ] } FOR doc IN what.a RETURN doc";
+      let actual = getQueryResults(query);
+      assertEqual([ 'foo' ], actual);
+      
+      query = "LET what = { a: [ 'foo' ], b: [ 'bar' ] } FOR doc IN what.b RETURN doc";
+      actual = getQueryResults(query);
+      assertEqual([ 'bar' ], actual);
+      
+      query = "LET what = { a: [ 'foo' ], b: [ 'bar' ], c: [ 'baz' ] } FOR doc IN what.c RETURN doc";
+      actual = getQueryResults(query);
+      assertEqual([ 'baz' ], actual);
+    },
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test special case "empty for loop"
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
AQL optimizer was trying to resolve attribute accesses
to attributes of constant object values at query compile time, but only did so far
the very first attribute in each object

this fixes https://stackoverflow.com/questions/48648737/beginner-bug-in-for-loops-from-objects

