### PR TITLE
periodically recheck socket validity/connectivity for sockets that lo…

### DIFF
--- a/lib/SimpleHttpClient/GeneralClientConnection.h
+++ b/lib/SimpleHttpClient/GeneralClientConnection.h
@@ -170,7 +170,7 @@ class GeneralClientConnection {
   /// @brief prepare connection for read/write I/O
   //////////////////////////////////////////////////////////////////////////////
 
-  bool prepare(TRI_socket_t socket, double timeout, bool isWrite) const;
+  bool prepare(TRI_socket_t socket, double timeout, bool isWrite);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief check whether the socket is still alive


### PR DESCRIPTION
…op around poll() every 20s

that way we can earlier detect sockets that became invalid, e.g. because the connection was closed
