### PR TITLE
do allow input to /_api/aqlfunction choose between

### DIFF
--- a/arangod/RestHandler/RestAqlUserFunctionsHandler.cpp
+++ b/arangod/RestHandler/RestAqlUserFunctionsHandler.cpp
@@ -131,7 +131,7 @@ RestStatus RestAqlUserFunctionsHandler::execute() {
       extractStringParameter(StaticStrings::Prefix, functionNamespace);
       if (functionNamespace.empty()) {
         // compatibility mode
-        extractStringParameter("namespace", functionNamespace);
+        extractStringParameter(StaticStrings::Namespace, functionNamespace);
       }
     }
 

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -58,8 +58,9 @@ std::string const StaticStrings::WaitForSyncString("waitForSync");
 std::string const StaticStrings::IsSynchronousReplicationString(
     "isSynchronousReplication");
 std::string const StaticStrings::Group("group");
-std::string const StaticStrings::ReplaceExisting("replaceExisting");
+std::string const StaticStrings::Namespace("namespace");
 std::string const StaticStrings::Prefix("prefix");
+std::string const StaticStrings::ReplaceExisting("replaceExisting");
 
 // replication headers
 std::string const StaticStrings::ReplicationHeaderCheckMore("x-arango-replication-checkmore");

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -63,6 +63,7 @@ class StaticStrings {
   static std::string const WaitForSyncString;
   static std::string const IsSynchronousReplicationString;
   static std::string const Group;
+  static std::string const Namespace;
   static std::string const ReplaceExisting;
   static std::string const Prefix;;
 


### PR DESCRIPTION
do allow input to /_api/aqlfunction choose between

    /_api/aqlfunction/<name> (new style)

and

    /_api/aqlfunction?prefix=... (old style)

This provides more downwards-compatibility to existing API clients
Additionally look for "prefix" URL parameter as this used to be
the parameter we communicated for earlier versions of ArangoDB.

Please note that for legal reasons we require you to sign the 
[Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
