### PR TITLE
properly convert the JS object to VPack for transactions

### DIFF
--- a/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
@@ -295,7 +295,7 @@ void RocksDBTransactionCollection::commitCounts() {
     ridx->applyCommitedEstimates(pair.second.first, pair.second.second);
   }
 
-  _initialNumberDocuments = _numInserts - _numRemoves;
+  _initialNumberDocuments += _numInserts - _numRemoves;
   _operationSize = 0;
   _numInserts = 0;
   _numUpdates = 0;

--- a/arangod/VocBase/Methods/Transactions.cpp
+++ b/arangod/VocBase/Methods/Transactions.cpp
@@ -146,7 +146,9 @@ Result executeTransactionJS(
     // parse all other options. `allowImplicitCollections` will
     // be overwritten later if is contained in `object`
     VPackBuilder builder;
-    TRI_V8ToVPack(isolate, builder, object, false);
+    // we must use "convertFunctionsToNull" here, because "action" is most
+    // likey a JavaScript function
+    TRI_V8ToVPack(isolate, builder, object, false, /*convertFunctionsToNull*/ true);
     if (!builder.isClosed()) {
       builder.close();
     }

--- a/lib/V8/v8-vpack.cpp
+++ b/lib/V8/v8-vpack.cpp
@@ -282,8 +282,11 @@ static inline void AddValue(BuilderContext& context,
 template <bool performAllChecks, bool inObject>
 static int V8ToVPack(BuilderContext& context,
                      v8::Handle<v8::Value> const parameter,
-                     arangodb::StringRef const& attributeName) {
-  if (parameter->IsNull() || parameter->IsUndefined()) {
+                     arangodb::StringRef const& attributeName,
+                     bool convertFunctionsToNull) {
+  if (parameter->IsNull() || 
+      parameter->IsUndefined() || 
+      (convertFunctionsToNull && parameter->IsFunction())) {
     AddValue<VPackValue, inObject>(context, attributeName,
                                    VPackValue(VPackValueType::Null));
     return TRI_ERROR_NO_ERROR;
@@ -346,7 +349,7 @@ static int V8ToVPack(BuilderContext& context,
       }
 
       int res = V8ToVPack<performAllChecks, false>(context, value,
-                                                   arangodb::StringRef());
+                                                   arangodb::StringRef(), convertFunctionsToNull);
 
       --context.level;
 
@@ -416,7 +419,7 @@ static int V8ToVPack(BuilderContext& context,
 
           if (!converted.IsEmpty()) {
             // return whatever toJSON returned
-            return V8ToVPack<performAllChecks, inObject>(context, converted, attributeName);
+            return V8ToVPack<performAllChecks, inObject>(context, converted, attributeName, convertFunctionsToNull);
           }
         }
 
@@ -451,7 +454,7 @@ static int V8ToVPack(BuilderContext& context,
       }
 
       int res = V8ToVPack<performAllChecks, true>(
-          context, value, arangodb::StringRef(*str, str.length()));
+          context, value, arangodb::StringRef(*str, str.length()), convertFunctionsToNull);
 
       --context.level;
 
@@ -474,13 +477,14 @@ static int V8ToVPack(BuilderContext& context,
 ////////////////////////////////////////////////////////////////////////////////
 
 int TRI_V8ToVPack(v8::Isolate* isolate, VPackBuilder& builder,
-                  v8::Handle<v8::Value> const value, bool keepTopLevelOpen) {
+                  v8::Handle<v8::Value> const value, bool keepTopLevelOpen,
+                  bool convertFunctionsToNull) {
   v8::HandleScope scope(isolate);
   BuilderContext context(isolate, builder, keepTopLevelOpen);
   TRI_GET_GLOBALS();
   TRI_GET_GLOBAL_STRING(ToJsonKey);
   context.toJsonKey = ToJsonKey;
-  return V8ToVPack<true, false>(context, value, arangodb::StringRef());
+  return V8ToVPack<true, false>(context, value, arangodb::StringRef(), convertFunctionsToNull);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -494,5 +498,5 @@ int TRI_V8ToVPackSimple(v8::Isolate* isolate,
                         v8::Handle<v8::Value> const value) {
   // a HandleScope must have been created by the caller already
   BuilderContext context(isolate, builder, false);
-  return V8ToVPack<false, false>(context, value, arangodb::StringRef());
+  return V8ToVPack<false, false>(context, value, arangodb::StringRef(), false);
 }

--- a/lib/V8/v8-vpack.h
+++ b/lib/V8/v8-vpack.h
@@ -46,7 +46,8 @@ v8::Handle<v8::Value> TRI_VPackToV8(
 ////////////////////////////////////////////////////////////////////////////////
 
 int TRI_V8ToVPack(v8::Isolate* isolate, arangodb::velocypack::Builder& builder,
-                  v8::Handle<v8::Value> const value, bool keepTopLevelOpen);
+                  v8::Handle<v8::Value> const value, bool keepTopLevelOpen,
+                  bool convertFunctionsToNull = false);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief convert a V8 value to VPack value, simplified version


### PR DESCRIPTION
previously this did not work when the "action" attribute was a JavaScript function