### PR TITLE
fix codeblock reader - keep newlines

### DIFF
--- a/Documentation/Scripts/codeBlockReader.py
+++ b/Documentation/Scripts/codeBlockReader.py
@@ -230,6 +230,8 @@ def fetch_comments(dirpath):
               elif ("@END_EXAMPLE_ARANGOSH_OUTPUT" in _text or \
                 "@END_EXAMPLE_ARANGOSH_RUN" in _text):
                 shouldIgnoreLine = False
+            else:
+              fh.write("\n")
   fh.close()
 
 if __name__ == "__main__":


### PR DESCRIPTION
We must keep newlines when copying the markdown blocks into the documentation; else it will destroy the structure of documents.
fixes #4716