### PR TITLE
fix RestCursorHandler::finalizeExecute in case /_api/cursor is called…

### DIFF
--- a/arangod/RestHandler/RestCursorHandler.cpp
+++ b/arangod/RestHandler/RestCursorHandler.cpp
@@ -48,7 +48,8 @@ RestCursorHandler::RestCursorHandler(
       _queryLock(),
       _query(nullptr),
       _hasStarted(false),
-      _queryKilled(false) {}
+      _queryKilled(false),
+      _isValidForFinalize(false) {}
 
 RestStatus RestCursorHandler::execute() {
   // extract the sub-request type
@@ -382,6 +383,11 @@ void RestCursorHandler::createQueryCursor() {
       // error message generated in parseVelocyPackBody
       return;
     }
+    
+    // tell RestCursorHandler::finalizeExecute that the request
+    // could be parsed successfully and that it may look at it
+    _isValidForFinalize = true;
+
     VPackSlice body = parsedBody.get()->slice();
 
     processQuery(body);

--- a/arangod/RestHandler/RestCursorHandler.h
+++ b/arangod/RestHandler/RestCursorHandler.h
@@ -158,6 +158,14 @@ class RestCursorHandler : public RestVocbaseBaseHandler {
   //////////////////////////////////////////////////////////////////////////////
 
   bool _queryKilled;
+  
+  //////////////////////////////////////////////////////////////////////////////
+  /// @brief whether or not the finalize operation is allowed to further process
+  /// the request data. this will not work if the original request cannot be
+  /// parsed successfully. this is used by RestCursorHandler::finalizeExecute
+  //////////////////////////////////////////////////////////////////////////////
+  
+  bool _isValidForFinalize;
 };
 }
 

--- a/lib/Rest/HttpResponse.cpp
+++ b/lib/Rest/HttpResponse.cpp
@@ -57,6 +57,8 @@ HttpResponse::HttpResponse(ResponseCode code,
   _generateBody = false;
   _contentType = ContentType::TEXT;
   _connectionType = rest::ConnectionType::C_KEEP_ALIVE;
+
+  TRI_ASSERT(_body != nullptr);
   if (_body->c_str() == nullptr) {
     // no buffer could be reserved. out of memory!
     THROW_ARANGO_EXCEPTION(TRI_ERROR_OUT_OF_MEMORY);
@@ -73,6 +75,7 @@ void HttpResponse::reset(ResponseCode code) {
   _connectionType = rest::ConnectionType::C_KEEP_ALIVE;
   _contentType = ContentType::TEXT;
   _isHeadResponse = false;
+  TRI_ASSERT(_body != nullptr);
   _body->clear();
   _bodySize = 0;
 }
@@ -134,6 +137,7 @@ void HttpResponse::setCookie(std::string const& name, std::string const& value,
 }
 
 void HttpResponse::headResponse(size_t size) {
+  TRI_ASSERT(_body != nullptr);
   _body->clear();
   _isHeadResponse = true;
   _bodySize = size;
@@ -143,6 +147,7 @@ size_t HttpResponse::bodySize() const {
   if (_isHeadResponse) {
     return _bodySize;
   }
+  TRI_ASSERT(_body != nullptr);
   return _body->length();
 }
 


### PR DESCRIPTION
… with invalid JSON input