### PR TITLE
Doc - Add some missing db and collection methods

### DIFF
--- a/Documentation/Books/AQL/Invocation/WithArangosh.md
+++ b/Documentation/Books/AQL/Invocation/WithArangosh.md
@@ -337,7 +337,7 @@ a client.
 ### Using cursors to obtain additional information on internal timings
 
 Cursors can also optionally provide statistics of the internal execution phases. By default, they do not. 
-To get to know how long parsing, otpimisation, instanciation and execution took,
+To get to know how long parsing, optimization, instantiation and execution took,
 make the server return that by setting the *profile* attribute to
 *true* when creating a statement:
 
@@ -359,3 +359,15 @@ produced statistics:
     c.getExtra();
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock 06_workWithAQL_statements12
+
+Query validation
+----------------
+
+The *_parse* method of the *db* object can be used to parse and validate a
+query syntactically, without actually executing it.
+
+    @startDocuBlockInline 06_workWithAQL_statements13
+    @EXAMPLE_ARANGOSH_OUTPUT{06_workWithAQL_statements13}
+    db._parse( { "query": "FOR i IN [ 1, 2 ] RETURN i" } );
+    @END_EXAMPLE_ARANGOSH_OUTPUT
+    @endDocuBlock 06_workWithAQL_statements13

--- a/Documentation/Books/Manual/Appendix/References/CollectionObject.md
+++ b/Documentation/Books/Manual/Appendix/References/CollectionObject.md
@@ -10,7 +10,7 @@ The following methods exist on the collection object (returned by *db.name*):
 * [collection.drop()](../../DataModeling/Collections/CollectionMethods.md#drop)
 * [collection.figures()](../../DataModeling/Collections/CollectionMethods.md#figures)
 * [collection.load()](../../DataModeling/Collections/CollectionMethods.md#load)
-* [collection.properties()](../../DataModeling/Collections/CollectionMethods.md#properties)
+* [collection.properties(options)](../../DataModeling/Collections/CollectionMethods.md#properties)
 * [collection.revision()](../../DataModeling/Collections/CollectionMethods.md#revision)
 * [collection.rotate()](../../DataModeling/Collections/CollectionMethods.md#rotate)
 * [collection.toArray()](../../DataModeling/Documents/DocumentMethods.md#toarray)

--- a/Documentation/Books/Manual/Appendix/References/CollectionObject.md
+++ b/Documentation/Books/Manual/Appendix/References/CollectionObject.md
@@ -29,6 +29,7 @@ The following methods exist on the collection object (returned by *db.name*):
 
 * [collection.all()](../../DataModeling/Documents/DocumentMethods.md#all)
 * [collection.any()](../../DataModeling/Documents/DocumentMethods.md#any)
+* [collection.byExample(example)](../../DataModeling/Documents/DocumentMethods.md#query-by-example)
 * [collection.closedRange(attribute, left, right)](../../DataModeling/Documents/DocumentMethods.md#closed-range)
 * [collection.document(object)](../../DataModeling/Documents/DocumentMethods.md#document)
 * [collection.documents(keys)](../../DataModeling/Documents/DocumentMethods.md#lookup-by-keys)
@@ -40,9 +41,9 @@ The following methods exist on the collection object (returned by *db.name*):
 * [collection.edges(vertices)](../../DataModeling/Documents/DocumentMethods.md#edges)
 * [collection.iterate(iterator,options)](../../DataModeling/Documents/DocumentMethods.md#misc)
 * [collection.outEdges(vertex-id)](../../DataModeling/Documents/DocumentMethods.md#edges)
-* [collection.queryByExample(example)](../../DataModeling/Documents/DocumentMethods.md#query-by-example)
 * [collection.range(attribute, left, right)](../../DataModeling/Documents/DocumentMethods.md#range)
 * [collection.remove(selector)](../../DataModeling/Documents/DocumentMethods.md#remove)
+* [collection.removeByExample(example)](../../DataModeling/Documents/DocumentMethods.md#remove-by-example)
 * [collection.removeByKeys(keys)](../../DataModeling/Documents/DocumentMethods.md#remove-by-keys)
 * [collection.rename()](../../DataModeling/Collections/CollectionMethods.md#rename)
 * [collection.replace(selector, data)](../../DataModeling/Documents/DocumentMethods.md#replace)

--- a/Documentation/Books/Manual/Appendix/References/DBObject.md
+++ b/Documentation/Books/Manual/Appendix/References/DBObject.md
@@ -31,6 +31,7 @@ The following methods exists on the *_db* object:
 *Collection*
 
 * [db._collection(name)](../../DataModeling/Collections/DatabaseMethods.md#collection)
+* [db._collections()](../../DataModeling/Collections/DatabaseMethods.md#all-collections)
 * [db._create(name)](../../DataModeling/Collections/DatabaseMethods.md#create)
 * [db._drop(name)](../../DataModeling/Collections/DatabaseMethods.md#drop)
 * [db._truncate(name)](../../DataModeling/Collections/DatabaseMethods.md#truncate)
@@ -40,6 +41,7 @@ The following methods exists on the *_db* object:
 * [db._createStatement(query)](../../../AQL/Invocation/WithArangosh.html#with-createstatement-arangostatement)
 * [db._query(query)](../../../AQL/Invocation/WithArangosh.html#with-dbquery)
 * [db._explain(query)](../../ReleaseNotes/NewFeatures28.md#miscellaneous-improvements)
+* [db._parse(query)](../../../AQL/Invocation/WithArangosh.html#query-validation)
 
 *Document*
 
@@ -48,3 +50,16 @@ The following methods exists on the *_db* object:
 * [db._remove(selector)](../../DataModeling/Documents/DatabaseMethods.md#remove)
 * [db._replace(selector,data)](../../DataModeling/Documents/DatabaseMethods.md#replace)
 * [db._update(selector,data)](../../DataModeling/Documents/DatabaseMethods.md#update)
+
+*Views*
+
+* [db._view(name)](../../DataModeling/Views/DatabaseMethods.md#view)
+* [db._views()](../../DataModeling/Views/DatabaseMethods.md#all-views)
+* [db._createView(name, type, properties)](../../DataModeling/Views/DatabaseMethods.md#create)
+* [db._dropView(name)](../../DataModeling/Views/DatabaseMethods.md#drop)
+
+*Global*
+
+* [db._engine()](../../DataModeling/Databases/WorkingWith.md#engine)
+* [db._engineStats()](../../DataModeling/Databases/WorkingWith.md#engine-statistics)
+* [db._executeTransaction()](../../Transactions/TransactionInvocation.md)

--- a/Documentation/Books/Manual/DataModeling/Collections/README.md
+++ b/Documentation/Books/Manual/DataModeling/Collections/README.md
@@ -58,7 +58,7 @@ altogether k copies of each shard are kept in the cluster on k different
 servers, and are kept in sync. That is, every write operation is automatically
 replicated on all copies.
 
-This is organised using a leader/follower model. At all times, one of the
+This is organized using a leader/follower model. At all times, one of the
 servers holding replicas for a shard is "the leader" and all others
 are "followers", this configuration is held in the Agency (see 
 [Scalability](../../Scalability/README.md) for details of the ArangoDB

--- a/Documentation/Books/Manual/DataModeling/Databases/WorkingWith.md
+++ b/Documentation/Books/Manual/DataModeling/Databases/WorkingWith.md
@@ -187,7 +187,7 @@ all clients have disconnected and references have been garbage-collected.
 
 ### Engine
 
-retrieve storage engine used by the server
+retrieve the storage engine used by the server
 `db._engine()`
 
 Returns the name of the storage engine in use (`mmfiles` or `rocksdb`), as well
@@ -199,7 +199,7 @@ as a list of supported features (types of indexes and
 retrieve statistics related to the storage engine (rocksdb)
 `db._engineStats()`
 
-Returns some statistics related to storage engine activity, including figures
+Returns some statistics related to the storage engine activity, including figures
 about data size, cache usage, etc.
 
 **Note**: Currently this only produces useful output for the RocksDB engine.

--- a/Documentation/Books/Manual/DataModeling/Databases/WorkingWith.md
+++ b/Documentation/Books/Manual/DataModeling/Databases/WorkingWith.md
@@ -185,9 +185,18 @@ database. The *_system* database itself cannot be dropped.
 Databases are dropped asynchronously, and will be physically removed if
 all clients have disconnected and references have been garbage-collected.
 
+### Engine
+
+retrieve storage engine used by the server
+`db._engine()`
+
+Returns the name of the storage engine in use (`mmfiles` or `rocksdb`), as well
+as a list of supported features (types of indexes and
+[dfdb](../../Troubleshooting/DatafileDebugger.md)).
+
 ### Engine statistics
 
-retrieve statistics related to the storage engine-rocksdb
+retrieve statistics related to the storage engine (rocksdb)
 `db._engineStats()`
 
 Returns some statistics related to storage engine activity, including figures

--- a/js/client/modules/@arangodb/arango-collection.js
+++ b/js/client/modules/@arangodb/arango-collection.js
@@ -260,6 +260,7 @@ var helpArangoCollection = arangosh.createHelpHeadline('ArangoCollection help') 
   '  type()                                type of the collection            ' + '\n' +
   '  truncate()                            delete all documents              ' + '\n' +
   '  properties()                          show collection properties        ' + '\n' +
+  '  properties(<data>)                    change collection properties      ' + '\n' +
   '  drop()                                delete a collection               ' + '\n' +
   '  load()                                load a collection                 ' + '\n' +
   '  unload()                              unload a collection               ' + '\n' +

--- a/js/client/modules/@arangodb/arango-database.js
+++ b/js/client/modules/@arangodb/arango-database.js
@@ -252,10 +252,11 @@ var helpArangoDatabase = arangosh.createHelpHeadline('ArangoDatabase (db) help')
   '  _createStatement(<data>)              create and return AQL query       ' + '\n' +
   '                                                                          ' + '\n' +
   'View Functions:                                                           ' + '\n' +
-  '  _views()                                  list all views                ' + '\n' +
-  '  _view(<name>)                             get view by name              ' + '\n' +
-  '  _createView(<name>, <type>, <properties>) creates a new view            ' + '\n' +
-  '  _dropView(<name>)                         delete a view                 ';
+  '  _views()                              list all views                    ' + '\n' +
+  '  _view(<name>)                         get view by name                  ' + '\n' +
+  '  _createView(<name>, <type>,           creates a new view                ' + '\n' +
+  '              <properties>)                                               ' + '\n' +
+  '  _dropView(<name>)                     delete a view                     ';
 
 ArangoDatabase.prototype._help = function () {
   internal.print(helpArangoDatabase);
@@ -283,7 +284,7 @@ ArangoDatabase.prototype._collections = function () {
     var result = [];
     var i;
 
-    // add all collentions to object
+    // add all collections to object
     for (i = 0;  i < collections.length;  ++i) {
       var collection = new this._collectionConstructor(this, collections[i]);
       this._registerCollection(collection._name, collection);


### PR DESCRIPTION
*url() methods are probably internal and should be ignored.

Missing:

- coll.shards(): cluster only
- more?

Open questions:

- what about deprecated methods?
  - ensureGeoConstraint only prints an error that tells to use ensureGeoIndex / ensureIndex
  - Other geo-related methods are superseeded by AQL queries
- what about some other oddball methods?
  - db._id(): where is this actually used?
  - _help(): does this work in Foxx too? It nothing but a string meant for arangosh however
  - _flushCache(), _refresh(): are these internal?