### PR TITLE
increase timeout for index creation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.3.5 (XXXX-XX-XX)
 -------------------
 
+* added hidden option `--cluster.index-create-timeout` for controlling the
+  default value of the index creation timeout in cluster
+  under normal circumstances, this option does not need to be adjusted
+
+* increase default timeout for index creation in cluster to 3600s
+
 * fixed issue #4843: Query-Result has more Docs than the Collection itself  
 
 * fixed the behavior of ClusterInfo when waiting for current to catch

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -133,6 +133,10 @@ void ClusterFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addHiddenOption("--cluster.create-waits-for-sync-replication",
                      "active coordinator will wait for all replicas to create collection",
                      new BooleanParameter(&_createWaitsForSyncReplication));
+  
+  options->addHiddenOption("--cluster.index-create-timeout",
+                     "amount of time (in seconds) the coordinator will wait for an index to be created before giving up",
+                     new DoubleParameter(&_indexCreationTimeout));
 }
 
 void ClusterFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {

--- a/arangod/Cluster/ClusterFeature.h
+++ b/arangod/Cluster/ClusterFeature.h
@@ -50,7 +50,7 @@ class ClusterFeature : public application_features::ApplicationFeature {
     return _agencyEndpoints;
   }
 
-  std::string agencyPrefix() {
+  std::string agencyPrefix() const {
     return _agencyPrefix;
   }
 
@@ -61,6 +61,7 @@ class ClusterFeature : public application_features::ApplicationFeature {
   std::string _myAddress;
   uint32_t _systemReplicationFactor = 2;
   bool _createWaitsForSyncReplication = true;
+  double _indexCreationTimeout = 3600.0;
 
  private:
   void reportRole(ServerState::RoleEnum);
@@ -79,7 +80,8 @@ class ClusterFeature : public application_features::ApplicationFeature {
   };
 
   void setUnregisterOnShutdown(bool);
-  bool createWaitsForSyncReplication() { return _createWaitsForSyncReplication; };
+  bool createWaitsForSyncReplication() const { return _createWaitsForSyncReplication; };
+  double indexCreationTimeout() const { return _indexCreationTimeout; }
 
   void stop() override final;
 

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1631,6 +1631,8 @@ int RestReplicationHandler::processRestoreIndexesCoordinator(
     return TRI_ERROR_ARANGO_COLLECTION_NOT_FOUND;
   }
   TRI_ASSERT(col != nullptr);
+  
+  auto cluster = application_features::ApplicationServer::getFeature<ClusterFeature>("Cluster");
 
   int res = TRI_ERROR_NO_ERROR;
   for (VPackSlice const& idxDef : VPackArrayIterator(indexes)) {
@@ -1644,7 +1646,7 @@ int RestReplicationHandler::processRestoreIndexesCoordinator(
     VPackBuilder tmp;
     res = ci->ensureIndexCoordinator(dbName, col->cid_as_string(), idxDef, true,
                                      arangodb::Index::Compare, tmp, errorMsg,
-                                     3600.0);
+                                     cluster->indexCreationTimeout());
     if (res != TRI_ERROR_NO_ERROR) {
       errorMsg =
           "could not create index: " + std::string(TRI_errno_string(res));

--- a/arangod/VocBase/Methods/Indexes.cpp
+++ b/arangod/VocBase/Methods/Indexes.cpp
@@ -309,7 +309,7 @@ Result Indexes::ensureIndexCoordinator(
   std::string errorMsg;
   int res = ClusterInfo::instance()->ensureIndexCoordinator(
       dbName, cid, indexDef, create, &arangodb::Index::Compare, resultBuilder,
-      errorMsg, 360.0);
+      errorMsg, 3600.0);
   return Result(res, errorMsg);
 }
 

--- a/arangod/VocBase/Methods/Indexes.cpp
+++ b/arangod/VocBase/Methods/Indexes.cpp
@@ -29,6 +29,7 @@
 #include "Basics/conversions.h"
 #include "Basics/tri-strings.h"
 #include "Cluster/ClusterComm.h"
+#include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ClusterMethods.h"
 #include "Cluster/ServerState.h"
@@ -307,9 +308,11 @@ Result Indexes::ensureIndexCoordinator(
   std::string const dbName = collection->dbName();
   std::string const cid = collection->cid_as_string();
   std::string errorMsg;
+
+  auto cluster = application_features::ApplicationServer::getFeature<ClusterFeature>("Cluster");
   int res = ClusterInfo::instance()->ensureIndexCoordinator(
       dbName, cid, indexDef, create, &arangodb::Index::Compare, resultBuilder,
-      errorMsg, 3600.0);
+      errorMsg, cluster->indexCreationTimeout());
   return Result(res, errorMsg);
 }
 


### PR DESCRIPTION
I actually did not fix it by adding (yet another) startup option, but by increasing the default timeout for index creation. The adjusted timeout (3600s) is now in line with the timeout used for index creation that was used already when restoring an index from a dump (3600s).