### PR TITLE
same behavior as java driver while parsing a queries bind parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 v3.2.13 (XXXX-XX-XX)
 --------------------
 
+* fix issue #4582: UI query editor now supports usage of empty string as bind parameter value
 
 * fix issue #4924: removeFollower now prefers to remove the last follower(s)
 

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js
@@ -1575,17 +1575,6 @@
         return quit;
       }
 
-      var keys = [];
-      _.each(this.bindParamTableObj, function (val, key) {
-        if (val === '') {
-          quit = true;
-          keys.push(key);
-        }
-      });
-      if (keys.length > 0) {
-        arangoHelper.arangoError('Bind Parameter', JSON.stringify(keys) + ' not defined.');
-      }
-
       return quit;
     },
 


### PR DESCRIPTION
ui query editor now has the same behavior as java driver while parsing a queries bind parameters