### PR TITLE
added ArangoShell helper function for packaging all information about…

### DIFF
--- a/Documentation/Books/AQL/ExecutionAndPerformance/ExplainingQueries.md
+++ b/Documentation/Books/AQL/ExecutionAndPerformance/ExplainingQueries.md
@@ -122,3 +122,51 @@ The above command prints the query's execution plan in the ArangoShell directly,
 on the most important information.
 
 
+### Gathering debug information about a query
+
+If an explain provides no suitable insight into why a query does not perform as
+expected, it may be reported to the ArangoDB support. In order to make this as easy
+as possible, there is a built-in command in ArangoShell for packaging the query, its
+bind parameters and all data required to execute the query elsewhere.
+
+The command will store all data in a file with a configurable filename:
+
+    @startDocuBlockInline 10_workWithAQL_debugging1
+    @EXAMPLE_ARANGOSH_OUTPUT{10_workWithAQL_debugging1}
+    var query = "FOR doc IN mycollection FILTER doc.value > 42 RETURN doc";
+    require("@arangodb/aql/explainer").debugDump("/tmp/query-debug-info", query);
+    @END_EXAMPLE_ARANGOSH_OUTPUT
+    @endDocuBlock 10_workWithAQL_debugging1
+
+Entitled users can send the generated file to the ArangoDB support to facilitate 
+reproduction and debugging.
+
+If a query contains bind parameters, they will need to specified along with the query
+string:
+    
+    @startDocuBlockInline 10_workWithAQL_debugging2
+    @EXAMPLE_ARANGOSH_OUTPUT{10_workWithAQL_debugging2}
+    var query = "FOR doc IN @@collection FILTER doc.value > @value RETURN doc";
+    var bind = { value: 42, "@collection": "mycollection" };
+    require("@arangodb/aql/explainer").debugDump("/tmp/query-debug-info", query, bind);
+    @END_EXAMPLE_ARANGOSH_OUTPUT
+    @endDocuBlock 10_workWithAQL_debugging2
+
+It is also possible to include example documents from the underlying collection in
+order to make reproduction even easier. Example documents can be sent as they are, or
+in an anonymized form. The number of example documents can be specified in the *examples*
+options attribute, and should generally be kept low. The *anonymize* option will replace
+the contents of string attributes in the examples with "XXX". It will however not 
+replace any other types of data (e.g. numeric values) or attribute names. Attribute
+names in the examples will always be preserved because they may be indexed and used in
+queries:
+    
+    @startDocuBlockInline 10_workWithAQL_debugging3
+    @EXAMPLE_ARANGOSH_OUTPUT{10_workWithAQL_debugging3}
+    var query = "FOR doc IN @@collection FILTER doc.value > @value RETURN doc";
+    var bind = { value: 42, "@collection": "mycollection" };
+    var options = { examples: 10, anonymize: true };
+    require("@arangodb/aql/explainer").debugDump("/tmp/query-debug-info", query, bind, options);
+    @END_EXAMPLE_ARANGOSH_OUTPUT
+    @endDocuBlock 10_workWithAQL_debugging3
+


### PR DESCRIPTION
… an AQL query so it can be run and analyzed elsewhere:

    query = "FOR doc IN @@collection FILTER doc.value > @value RETURN doc";
    bind = { value: 42, "@collection": "mycollection" };
    options = { examples: 10, anonymize: true };
    require("@arangodb/aql/explainer").debugDump("/tmp/query-debug-info", query, bind, options);

Entitled users can send the generated file to the ArangoDB support to facilitate
reproduction and debugging.

The data from the generated file can be restored and analyzed via the *inspectDump*
function:

    require("@arangodb/aql/explainer").inspectDump("/tmp/query-debug-info");