### PR TITLE
add missing generated examples

### DIFF
--- a/Documentation/Examples/10_workWithAQL_debugging1.generated
+++ b/Documentation/Examples/10_workWithAQL_debugging1.generated
@@ -1,0 +1,2 @@
+arangosh&gt; <span class="hljs-keyword">var</span> query = <span class="hljs-string">"FOR doc IN mycollection FILTER doc.value &gt; 42 RETURN doc"</span>;
+arangosh&gt; <span class="hljs-built_in">require</span>(<span class="hljs-string">"@arangodb/aql/explainer"</span>).debugDump(<span class="hljs-string">"/tmp/query-debug-info"</span>, query);

--- a/Documentation/Examples/10_workWithAQL_debugging2.generated
+++ b/Documentation/Examples/10_workWithAQL_debugging2.generated
@@ -1,0 +1,3 @@
+arangosh&gt; <span class="hljs-keyword">var</span> query = <span class="hljs-string">"FOR doc IN @@collection FILTER doc.value &gt; @value RETURN doc"</span>;
+arangosh&gt; <span class="hljs-keyword">var</span> bind = { <span class="hljs-attr">value</span>: <span class="hljs-number">42</span>, <span class="hljs-string">"@collection"</span>: <span class="hljs-string">"mycollection"</span> };
+arangosh&gt; <span class="hljs-built_in">require</span>(<span class="hljs-string">"@arangodb/aql/explainer"</span>).debugDump(<span class="hljs-string">"/tmp/query-debug-info"</span>, query, bind);

--- a/Documentation/Examples/10_workWithAQL_debugging3.generated
+++ b/Documentation/Examples/10_workWithAQL_debugging3.generated
@@ -1,0 +1,4 @@
+arangosh&gt; <span class="hljs-keyword">var</span> query = <span class="hljs-string">"FOR doc IN @@collection FILTER doc.value &gt; @value RETURN doc"</span>;
+arangosh&gt; <span class="hljs-keyword">var</span> bind = { <span class="hljs-attr">value</span>: <span class="hljs-number">42</span>, <span class="hljs-string">"@collection"</span>: <span class="hljs-string">"mycollection"</span> };
+arangosh&gt; <span class="hljs-keyword">var</span> options = { <span class="hljs-attr">examples</span>: <span class="hljs-number">10</span>, <span class="hljs-attr">anonymize</span>: <span class="hljs-literal">true</span> };
+arangosh&gt; <span class="hljs-built_in">require</span>(<span class="hljs-string">"@arangodb/aql/explainer"</span>).debugDump(<span class="hljs-string">"/tmp/query-debug-info"</span>, query, bind, options);


### PR DESCRIPTION
add missing examples that are required to build the documentation
