### PR TITLE
set merge strategy to binary for autogenerated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,15 @@
-js/apps/system/_admin/aardvark/APP/api-docs.json MERGE=binary
+*.sh eol=lf 
+VERSION eol=lf
+VERSIONS eol=lf
+scripts/unittest eol=lf
+*.groovy eol=lf
+*.csv binary
+*.json eol=lf
+Documentation/Books/SummaryBlacklist.txt eol=lf
+Documentation/Examples/*.generated merge=ours
+VERSION merge=ours
+STARTER_REV merge=ours
+lib/V8/v8-json.cpp merge=ours
+arangod/Aql/tokens.cpp merge=ours
+arangod/Aql/grammar.cpp merge=ours
+js/apps/system/_admin/aardvark/APP/api-docs.json merge=ours

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,14 +1,1 @@
-*.sh eol=lf 
-VERSION eol=lf
-VERSIONS eol=lf
-scripts/unittest eol=lf
-*.groovy eol=lf
-*.csv binary
-*.json eol=lf
-Documentation/Books/SummaryBlacklist.txt eol=lf
-Documentation/Examples/*.generated merge=ours
-VERSION merge=ours
-STARTER_REV merge=ours
-lib/V8/v8-json.cpp merge=ours
-arangod/Aql/tokens.cpp merge=ours
-arangod/Aql/grammar.cpp merge=ours
+js/apps/system/_admin/aardvark/APP/api-docs.json MERGE=binary

--- a/Documentation/Examples/.gitattributes
+++ b/Documentation/Examples/.gitattributes
@@ -1,0 +1,1 @@
+*.generated MERGE=binary

--- a/Documentation/Examples/.gitattributes
+++ b/Documentation/Examples/.gitattributes
@@ -1,1 +1,0 @@
-*.generated MERGE=binary

--- a/README_maintainers.md
+++ b/README_maintainers.md
@@ -7,7 +7,7 @@ Documentation readme can be found in directory [Documentation](https://github.co
 
 GIT
 ===
-Setting up git for automaticaly merging certain automatically generated files in the arangodb source tree:
+Setting up git for automatically merging certain automatically generated files in the arangodb source tree:
 
     git config --global merge.ours.driver true
 

--- a/README_maintainers.md
+++ b/README_maintainers.md
@@ -5,6 +5,13 @@ ArangoDB Maintainers manual
 This file contains documentation about the build process and unittests - put short - if you want to hack parts of arangod this could be interesting for you.
 Documentation readme can be found in directory [Documentation](https://github.com/arangodb/arangodb/blob/devel/Documentation/README_maintainers.md).
 
+GIT
+===
+Setting up git for automaticaly merging certain automatically generated files in the arangodb source tree:
+
+    git config --global merge.ours.driver true
+
+    
 CMake
 =====
 


### PR DESCRIPTION
This switches the swagger json merge strategy to 'ours';
As pointed out here, one needs to define that 'ours'-merge driver:
https://medium.com/@porteneuve/how-to-make-git-preserve-specific-files-while-merging-18c92343826b
It will always prefer your version over the devel version.