### PR TITLE
Don't log stacktrace when fishbowl update fails

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/foxxes.js
+++ b/js/apps/system/_admin/aardvark/APP/foxxes.js
@@ -362,7 +362,7 @@ router.get('/fishbowl', function (req, res) {
   try {
     store.update();
   } catch (e) {
-    console.warnLines(`Failed to update Foxx store: ${e.stack}`);
+    console.warn('Failed to update Foxx store from GitHub.');
   }
   res.json(store.availableJson());
 })


### PR DESCRIPTION
This implements the changes requested in #4860.