### PR TITLE
 Don't log stacktrace when fishbowl update fails (3.4)

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/foxxes.js
+++ b/js/apps/system/_admin/aardvark/APP/foxxes.js
@@ -353,7 +353,7 @@ router.get('/fishbowl', function (req, res) {
   try {
     FoxxManager.update();
   } catch (e) {
-    console.warnLines(`Failed to update Foxx store: ${e.stack}`);
+    console.warn('Failed to update Foxx store from GitHub.');
   }
   res.json(FoxxManager.availableJson());
 })


### PR DESCRIPTION
Port of #5086 to 3.4