### PR TITLE
Deprecate foxx-manager

### DIFF
--- a/js/client/modules/@arangodb/foxx/manager.js
+++ b/js/client/modules/@arangodb/foxx/manager.js
@@ -27,6 +27,7 @@
 // / @author Dr. Frank Celler
 // //////////////////////////////////////////////////////////////////////////////
 
+var internal = require('internal');
 var arangodb = require('@arangodb');
 var arangosh = require('@arangodb/arangosh');
 var errors = arangodb.errors;
@@ -554,8 +555,9 @@ var tests = function (mount, options) {
 // //////////////////////////////////////////////////////////////////////////////
 
 var run = function (args) {
+  var version = internal.version.split('.').slice(0, 2).join('.');
   arangodb.print('NOTE: foxx-manager is deprecated and will be removed in ArangoDB 4.');
-  arangodb.print('Please use foxx-cli instead: https://www.npmjs.com/package/foxx-cli\n');
+  arangodb.print(`Please use foxx-cli instead: https://docs.arangodb.com/${version}/Manual/Foxx/Deployment/FoxxCLI/\n`);
 
   if (args === undefined || args.length === 0) {
     arangodb.print('Expecting a command, please try:\n');

--- a/js/client/modules/@arangodb/foxx/manager.js
+++ b/js/client/modules/@arangodb/foxx/manager.js
@@ -554,6 +554,9 @@ var tests = function (mount, options) {
 // //////////////////////////////////////////////////////////////////////////////
 
 var run = function (args) {
+  arangodb.print('NOTE: foxx-manager is deprecated and will be removed in ArangoDB 4.');
+  arangodb.print('Please use foxx-cli instead: https://www.npmjs.com/package/foxx-cli\n');
+
   if (args === undefined || args.length === 0) {
     arangodb.print('Expecting a command, please try:\n');
     cmdUsage();


### PR DESCRIPTION
The foxx-cli tool has been released and tested on Windows, Linux and Docker. Accordingly we will now warn users to switch from foxx-manager to foxx-cli starting with ArangoDB 3.4.0 and remove foxx-manager fully in ArangoDB 4.0.

@mpv1989 maybe we should replace the URL with a link to the Foxx CLI docs when they land in the ArangoDB tools documentation? Assuming this happens before 3.4. What do you think of a chapter on switching from foxx-manager to help users transition?