### PR TITLE
Do not create superfluous task to run processAll.

### DIFF
--- a/arangod/Scheduler/SocketTask.cpp
+++ b/arangod/Scheduler/SocketTask.cpp
@@ -146,15 +146,6 @@ void SocketTask::addWriteBuffer(WriteBuffer&& buffer) {
     return;
   }
 
-  {
-    auto self = shared_from_this();
-
-    _loop._scheduler->post([self, this]() {
-      MUTEX_LOCKER(locker, _lock);
-      processAll();
-    });
-  }
-
   if (!buffer.empty()) {
     if (!_writeBuffer.empty()) {
       _writeBuffers.emplace_back(std::move(buffer));


### PR DESCRIPTION
A profiling run with VTune showed that a lot of time is spent to acquire the lock in line 153 in `SocketTask::addWriteBuffer`. When the task is created and added to the job queue, a potentially waiting SchedulerThread immediately gets notified and starts executing the task - and immediately gets blocked when trying to aqcuire the lock, because the lock is actually held by the thread that created the task.

As far as I could see it is not necessary to create these tasks to execute `processAll` since `SocketTask::asyncReadSome` (which initially acquires that lock) implicitly calls `processAll` anyway (my tests all worked fine), but someone who is more familiar with this code should doublecheck this.

During the profiling run I just executed a bunch of requests using `arangobench` on my 4-core machine (Core i5). With the original code, a total of 15 `SchedulerThread` have been created. With this change only 5 `SchedulerThread` get created and the CPU utilization per thread is much higher.