### PR TITLE
Do not create superfluous task to run processAll. (#5139)

### DIFF
--- a/arangod/Scheduler/SocketTask.cpp
+++ b/arangod/Scheduler/SocketTask.cpp
@@ -146,15 +146,6 @@ void SocketTask::addWriteBuffer(WriteBuffer&& buffer) {
     return;
   }
 
-  {
-    auto self = shared_from_this();
-
-    _loop._scheduler->post([self, this]() {
-      MUTEX_LOCKER(locker, _lock);
-      processAll();
-    });
-  }
-
   if (!buffer.empty()) {
     if (!_writeBuffer.empty()) {
       _writeBuffers.emplace_back(std::move(buffer));


### PR DESCRIPTION
These tasks try to acquire the lock, but the lock is actually hold by the creator of the task. This causes unnecessary blockage of many SchedulerThreads.

Creating on behalf of @mpoeter :

 https://github.com/arangodb/arangodb/pull/5139

http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr-linux/299/