### PR TITLE
Add @arangodb/locals module

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -207,6 +207,9 @@ devel
 
 * fixed internal #2215's failedleader timeout, when in todo
 
+* added `@arangodb/locals` module to expose the Foxx service context as an
+  alternative to using `module.context` directly.
+
 v3.3.4 (XXXX-XX-XX)
 -------------------
 

--- a/js/common/bootstrap/modules.js
+++ b/js/common/bootstrap/modules.js
@@ -92,6 +92,9 @@
     function require (path) {
       assert(path, 'missing path');
       assert(typeof path === 'string', 'path must be a string');
+      if (path === '@arangodb/locals') {
+        return {context: module.context};
+      }
       return Module._load(path, module);
     }
 
@@ -631,6 +634,9 @@
   Module.Module = Module;
 
   global.require = function (request) {
+    if (request === '@arangodb/locals') {
+      return {};
+    }
     return Module._load(request);
   };
 }());

--- a/js/common/tests/shell/shell-locals-spec.js
+++ b/js/common/tests/shell/shell-locals-spec.js
@@ -1,0 +1,13 @@
+/*globals describe, it */
+'use strict';
+const expect = require('chai').expect;
+
+describe('@arangodb/locals', () => {
+  const context = {hello: 'world'};
+  it('should expose module.context', () => {
+    module.context = context;
+    const locals = require('@arangodb/locals');
+    expect(locals.context).to.equal(module.context);
+    expect(locals.context).to.equal(context);
+  });
+});


### PR DESCRIPTION
Extending Node's module object in TS is tricky so let's provide a fake module for compatibility.

This allows writing the following:
```typescript
import { createRouter } from "@arangodb/foxx";
import { context } from "@arangodb/locals";
const router = createRouter();
context.use(router);
```
instead of
```typescript
import { createRouter } from "@arangodb/foxx";
const context = (module as Foxx.Module).context;
const router = createRouter();
context.use(router);
```
or without typings
```typescript
import { createRouter } from "@arangodb/foxx";
const context = (module as any).context;
const router = createRouter();
context.use(router);
```

This should probably be backported to 3.3 and 3.2 if it passes review.