### PR TITLE
Allow specifying Foxx manifest.json $schema value

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -207,6 +207,9 @@ devel
 
 * fixed internal #2215's failedleader timeout, when in todo
 
+* Foxx manifest.json files can now contain a $schema key with the value
+  of "http://json.schemastore.org/foxx-manifest" to improve tooling support.
+
 v3.3.4 (XXXX-XX-XX)
 -------------------
 

--- a/js/server/tests/shell/shell-foxx-manifest-spec.js
+++ b/js/server/tests/shell/shell-foxx-manifest-spec.js
@@ -1,0 +1,28 @@
+/*global describe, it */
+'use strict';
+const expect = require('chai').expect;
+const validateManifest = require('@arangodb/foxx/manifest').validateJson;
+const CANONICAL_SCHEMA = require('@arangodb/foxx/manifest').schemaUrl;
+const request = require('@arangodb/request');
+const db = require('@arangodb').db;
+
+describe('Foxx manifest $schema field', () => {
+  it(`defaults to "${CANONICAL_SCHEMA}"`, () => {
+    const manifest = validateManifest('fake', {}, '/fake');
+    expect(manifest).to.have.property('$schema', CANONICAL_SCHEMA);
+  });
+  it('warns (but does not fail validation) if invalid', () => {
+    const BAD_VALUE = 'http://badvalue.to/log';
+    try {
+      validateManifest('fake', { $schema: BAD_VALUE }, '/fake');
+    } catch (e) {
+      expect.fail();
+    }
+    const logs = request.get(`/_db/${db._name()}/_admin/log`, {json: true}).json;
+    expect(logs.text.filter(text => text.includes(BAD_VALUE))).not.to.be.empty;
+  });
+  it(`falls back to "${CANONICAL_SCHEMA}" if invalid`, () => {
+    const manifest = validateManifest('fake', { $schema: 'http://example.com' }, '/fake');
+    expect(manifest).to.have.property('$schema', CANONICAL_SCHEMA);
+  });
+});


### PR DESCRIPTION
This PR adds support for specifying a $schema value in the Foxx service manifest.

Foxx will now warn about (but ignore) invalid $schema values and default to the canonical JSON schema hosted at http://json.schemastore.org/foxx-manifest -- this aids tool based validation.