### PR TITLE
Documentation/remove aql array example anchors

### DIFF
--- a/Documentation/Books/AQL/Functions/Array.md
+++ b/Documentation/Books/AQL/Functions/Array.md
@@ -31,7 +31,7 @@ array (right side).
   that are not already contained in *anyArray*. The default is *false*.
 - returns **newArray** (array): the modified array
 
-### Examples
+**Examples**
 
 @startDocuBlockInline aqlArrayAppend_1
 @EXAMPLE_AQL{aqlArrayAppend_1}
@@ -59,7 +59,7 @@ Get the first element of an array. It is the same as `anyArray[0]`.
 - returns **firstElement** (any|null): the first element of *anyArray*, or *null* if
   the array is empty.
 
-### Examples
+**Examples**
 
 @startDocuBlockInline aqlArrayFirst_1
 @EXAMPLE_AQL{aqlArrayFirst_1}
@@ -85,7 +85,7 @@ will recurse into sub-arrays up to the specified depth. Duplicates will not be r
 - **depth** (number, *optional*):  flatten up to this many levels, the default is 1
 - returns **flatArray** (array): a flattened array
 
-### Examples
+**Examples**
 
 @startDocuBlockInline aqlArrayFlatten_1
 @EXAMPLE_AQL{aqlArrayFlatten_1}
@@ -113,7 +113,7 @@ occur in all arguments.
 - returns **newArray** (array): a single array with only the elements, which exist in all
   provided arrays. The element order is random. Duplicates are removed.
 
-### Examples
+**Examples**
 
 @startDocuBlockInline aqlArrayIntersection_1
 @EXAMPLE_AQL{aqlArrayIntersection_1}
@@ -168,7 +168,7 @@ collection and the [character length](String.md#length) of a string.
 |false|0|
 |null|0|
 
-### Examples
+**Examples**
 
 @startDocuBlockInline aqlArrayLength_1
 @EXAMPLE_AQL{aqlArrayLength_1}
@@ -233,7 +233,7 @@ for positive positions, but does not support negative positions.
   If *position* is negative or beyond the upper bound of the array,
   then *null* will be returned.
 
-### Examples
+**Examples**
 
 @startDocuBlockInline aqlArrayNth_1
 @EXAMPLE_AQL{aqlArrayNth_1}
@@ -282,7 +282,7 @@ Remove the element at the end (right side) of *array*.
 - returns **newArray** (array): *anyArray* without the last element. If it's already
   empty or has only a single element left, an empty array is returned.
 
-### Examples
+**Examples**
 
 @startDocuBlockInline aqlArrayPop_1
 @EXAMPLE_AQL{aqlArrayPop_1}
@@ -313,7 +313,7 @@ Return whether *search* is contained in *array*. Optionally return the position.
 To determine if or at which position a string occurs in another string, see the
 [CONTAINS() string function](String.md#contains).
 
-### Examples
+**Examples**
 
 @startDocuBlockInline aqlArrayPosition_1
 @EXAMPLE_AQL{aqlArrayPosition_1}
@@ -344,7 +344,7 @@ Note: The *unique* flag only controls if *value* is added if it's already presen
 in *anyArray*. Duplicate elements that already exist in *anyArray* will not be
 removed. To make an array unique, use the [UNIQUE()](#unique) function.
 
-### Examples
+**Examples**
 
 @startDocuBlockInline aqlArrayPush_1
 @EXAMPLE_AQL{aqlArrayPush_1}
@@ -370,7 +370,7 @@ Remove the element at *position* from the *anyArray*.
   If *position* is out of bounds, the array is returned unmodified.
 - returns **newArray** (array): *anyArray* without the element at *position*
 
-### Examples
+**Examples**
 
 @startDocuBlockInline aqlArrayRemoveNth_1
 @EXAMPLE_AQL{aqlArrayRemoveNth_1}
@@ -396,7 +396,7 @@ to the number of removals.
 - **limit** (number, *optional*): cap the number of removals to this value
 - returns **newArray** (array): *anyArray* with *value* removed
 
-### Examples
+**Examples**
 
 @startDocuBlockInline aqlArrayRemoveValue_1
 @EXAMPLE_AQL{aqlArrayRemoveValue_1}
@@ -457,7 +457,7 @@ Remove the element at the start (left side) of *anyArray*.
 - returns **newArray** (array): *anyArray* without the left-most element. If *anyArray*
   is already empty or has only one element left, an empty array is returned.
 
-### Examples
+**Examples**
 
 @startDocuBlockInline aqlArrayShift_1
 @EXAMPLE_AQL{aqlArrayShift_1}
@@ -485,7 +485,7 @@ Extract a slice of *anyArray*.
 - returns **newArray** (array): the specified slice of *anyArray*. If *length*
   is not specified, all array elements starting at *start* will be returned.
 
-### Examples
+**Examples**
 
 @startDocuBlockInline aqlArraySlice_1
 @EXAMPLE_AQL{aqlArraySlice_1}
@@ -572,7 +572,7 @@ Return the union of all arrays specified.
 - returns **newArray** (array): all array elements combined in a single array,
   in any order
 
-### Examples
+**Examples**
 
 @startDocuBlockInline aqlArrayUnion_1
 @EXAMPLE_AQL{aqlArrayUnion_1}
@@ -655,7 +655,7 @@ Note: The *unique* flag only controls if *value* is added if it's already presen
 in *anyArray*. Duplicate elements that already exist in *anyArray* will not be
 removed. To make an array unique, use the [UNIQUE()](#unique) function.
 
-### Examples
+**Examples**
 
 @startDocuBlockInline aqlArrayUnshift_1
 @EXAMPLE_AQL{aqlArrayUnshift_1}

--- a/Documentation/Scripts/codeBlockReader.py
+++ b/Documentation/Scripts/codeBlockReader.py
@@ -45,7 +45,7 @@ def file_content(filepath):
           (not searchMDPaths[2] in filepath) and
           (not searchMDPaths[3] in filepath) and
           (not searchMDPaths[4] in filepath)):
-        print "next startDocuBlock found without endDocuBlock inbetween in file %s [%s]" %(filepath, line)
+        print "next startDocuBlock found without endDocuBlock in between in file %s [%s]" %(filepath, line)
         raise
       _start = line[0]
     if "@endDocuBlock" in line[1]:
@@ -95,9 +95,9 @@ def example_content(filepath, fh, tag, blockType, placeIntoFilePath):
   for line in infile:
     if first:
       if blockType == "arangosh" and not line.startswith("arangosh&gt;"):
-        raise Exception ("mismatching blocktype - expecting 'arangosh' to start with 'arangosh&gt' - in %s while inpecting %s - referenced via %s have '%s'" %(filepath, tag, placeIntoFilePath, line))
+        raise Exception ("mismatching blocktype - expecting 'arangosh' to start with 'arangosh&gt' - in %s while inspecting %s - referenced via %s have '%s'" %(filepath, tag, placeIntoFilePath, line))
       if blockType == "curl" and not line.startswith("shell> curl"):
-        raise Exception("mismatching blocktype - expecting 'curl' to start with 'shell > curl' in %s while inpecting %s - referenced via %s have '%s'" %(filepath, tag, placeIntoFilePath, line))
+        raise Exception("mismatching blocktype - expecting 'curl' to start with 'shell > curl' in %s while inspecting %s - referenced via %s have '%s'" %(filepath, tag, placeIntoFilePath, line))
       first = False
 
     if blockType == "arangosh":


### PR DESCRIPTION
Do not use headlines for Examples

This clutters the page-toc and anchors will all jump to the first one because the generated IDs are not unique

![image](https://user-images.githubusercontent.com/7819991/39301729-86845cd8-4950-11e8-8c29-985660d4b9b7.png)

Also see https://github.com/arangodb/planning/issues/406

CC @sleto-it @dothebart 