### PR TITLE
fixes database.check-version

### DIFF
--- a/arangod/GeneralServer/AuthenticationFeature.cpp
+++ b/arangod/GeneralServer/AuthenticationFeature.cpp
@@ -128,6 +128,7 @@ void AuthenticationFeature::prepare() {
   TRI_ASSERT(_userManager == nullptr);
   
   ServerState::RoleEnum role = ServerState::instance()->getRole();
+  TRI_ASSERT(role != ServerState::RoleEnum::ROLE_UNDEFINED);
   if (ServerState::isSingleServer(role) || ServerState::isCoordinator(role)) {
 #if USE_ENTERPRISE
     if (application_features::ApplicationServer::getFeature<LdapFeature>("Ldap")
@@ -140,9 +141,7 @@ void AuthenticationFeature::prepare() {
     _userManager = new auth::UserManager();
 #endif
   } else {
-    // We always need a user manager, even if ROLE is undefined
-    // Happens with `database.check-version true`
-    _userManager = new auth::UserManager();
+    LOG_TOPIC(DEBUG, Logger::AUTHENTICATION) << "Not creating user manager";
   }
   
   TRI_ASSERT(_authCache == nullptr);

--- a/arangod/GeneralServer/AuthenticationFeature.cpp
+++ b/arangod/GeneralServer/AuthenticationFeature.cpp
@@ -128,7 +128,6 @@ void AuthenticationFeature::prepare() {
   TRI_ASSERT(_userManager == nullptr);
   
   ServerState::RoleEnum role = ServerState::instance()->getRole();
-  TRI_ASSERT(role != ServerState::RoleEnum::ROLE_UNDEFINED);
   if (ServerState::isSingleServer(role) || ServerState::isCoordinator(role)) {
 #if USE_ENTERPRISE
     if (application_features::ApplicationServer::getFeature<LdapFeature>("Ldap")
@@ -141,7 +140,9 @@ void AuthenticationFeature::prepare() {
     _userManager = new auth::UserManager();
 #endif
   } else {
-    LOG_TOPIC(DEBUG, Logger::AUTHENTICATION) << "Not creating user manager";
+    // We always need a user manager, even if ROLE is undefined
+    // Happens with `database.check-version true`
+    _userManager = new auth::UserManager();
   }
   
   TRI_ASSERT(_authCache == nullptr);

--- a/arangod/RestServer/CheckVersionFeature.h
+++ b/arangod/RestServer/CheckVersionFeature.h
@@ -25,9 +25,26 @@
 
 #include "ApplicationFeatures/ApplicationFeature.h"
 
+struct TRI_vocbase_t;
+
 namespace arangodb {
+
+class StorageEngine;
+
 class CheckVersionFeature final
     : public application_features::ApplicationFeature {
+ private: 
+  enum CheckVersionResult : int {
+    NO_SERVER_VERSION = -5,
+    NO_VERSION_FILE = -4,
+    CANNOT_READ_VERSION_FILE = -3,
+    CANNOT_PARSE_VERSION_FILE = -2,
+    IS_CLUSTER = -1,
+    VERSION_MATCH = 1,
+    DOWNGRADE_NEEDED = 2,
+    UPGRADE_NEEDED = 3,
+  };
+
  public:
   explicit CheckVersionFeature(
       application_features::ApplicationServer* server, int* result,
@@ -43,6 +60,10 @@ class CheckVersionFeature final
 
  private:
   void checkVersion();
+
+  CheckVersionResult checkVersionFileForDB(TRI_vocbase_t* vocbase,
+                                           StorageEngine* engine,
+                                           uint32_t currentVersion) const;
 
  private:
   int* _result;

--- a/arangod/RestServer/LockfileFeature.cpp
+++ b/arangod/RestServer/LockfileFeature.cpp
@@ -85,3 +85,7 @@ void LockfileFeature::start() {
 void LockfileFeature::unprepare() {
   TRI_DestroyLockFile(_lockFilename.c_str());
 }
+
+void LockfileFeature::beginShutdown() {
+  TRI_DestroyLockFile(_lockFilename.c_str());
+}

--- a/arangod/RestServer/LockfileFeature.h
+++ b/arangod/RestServer/LockfileFeature.h
@@ -33,6 +33,7 @@ class LockfileFeature final : public application_features::ApplicationFeature {
  public:
   void start() override final;
   void unprepare() override final;
+  void beginShutdown() override final;
 
  private:
   std::string _lockFilename;

--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -109,6 +109,7 @@ V8DealerFeature::V8DealerFeature(
   requiresElevatedPrivileges(false);
   startsAfter("Action");
   startsAfter("Authentication");
+  startsAfter("CheckVersion");
   startsAfter("Database");
   startsAfter("Random");
   startsAfter("Scheduler");


### PR DESCRIPTION
Fixed undefined behaviour when starting arangodb with --database.check-version true as done by our scripts.

This bug was never part of any official release so no need to bother for any installation out there.
