### PR TITLE
Removed ERROR_ARANGO_COLLECTION_NOT_FOUND

### DIFF
--- a/js/common/bootstrap/errors.js
+++ b/js/common/bootstrap/errors.js
@@ -109,7 +109,6 @@
     "ERROR_ARANGO_COLLECTION_TYPE_MISMATCH" : { "code" : 1237, "message" : "collection type mismatch" },
     "ERROR_ARANGO_COLLECTION_NOT_LOADED" : { "code" : 1238, "message" : "collection not loaded" },
     "ERROR_ARANGO_DOCUMENT_REV_BAD" : { "code" : 1239, "message" : "illegal document revision" },
-    "ERROR_ARANGO_COLLECTION_NOT_FOUND" : { "code" : 1240, "message" : "collection not found" },
     "ERROR_ARANGO_DATAFILE_FULL"   : { "code" : 1300, "message" : "datafile full" },
     "ERROR_ARANGO_EMPTY_DATADIR"   : { "code" : 1301, "message" : "server database directory is empty" },
     "ERROR_ARANGO_TRY_AGAIN"       : { "code" : 1302, "message" : "operation should be tried again" },

--- a/js/common/bootstrap/errors.js
+++ b/js/common/bootstrap/errors.js
@@ -329,5 +329,8 @@
     "ERROR_QUEUE_UNKNOWN"          : { "code" : 21002, "message" : "named queue does not exist" },
     "ERROR_QUEUE_FULL"             : { "code" : 21003, "message" : "named queue is full" }
   };
+
+  // For compatibility with <= 3.3
+  internal.errors.ERROR_ARANGO_COLLECTION_NOT_FOUND = internal.errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND;
 }());
 

--- a/js/common/modules/@arangodb/general-graph.js
+++ b/js/common/modules/@arangodb/general-graph.js
@@ -96,8 +96,8 @@ var findOrCreateCollectionByName = function (name, type, noCreate, options) {
     res = true;
   } else if (!(col instanceof ArangoCollection)) {
     var err = new ArangoError();
-    err.errorNum = arangodb.errors.ERROR_ARANGO_COLLECTION_NOT_FOUND.code;
-    err.errorMessage = name + arangodb.errors.ERROR_ARANGO_COLLECTION_NOT_FOUND.message;
+    err.errorNum = arangodb.errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code;
+    err.errorMessage = name + arangodb.errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.message;
     throw err;
   } else if (type === ArangoCollection.TYPE_EDGE && col.type() !== type) {
     var err2 = new ArangoError();

--- a/lib/Basics/errors.dat
+++ b/lib/Basics/errors.dat
@@ -131,6 +131,7 @@ ERROR_ARANGO_WRITE_THROTTLE_TIMEOUT,1236,"write-throttling timeout","Will be rai
 ERROR_ARANGO_COLLECTION_TYPE_MISMATCH,1237,"collection type mismatch","Will be raised when a collection has a different type from what has been expected."
 ERROR_ARANGO_COLLECTION_NOT_LOADED,1238,"collection not loaded","Will be raised when a collection is accessed that is not yet loaded."
 ERROR_ARANGO_DOCUMENT_REV_BAD,1239,"illegal document revision","Will be raised when a document revision is corrupt or is missing where needed."
+ERROR_ARANGO_COLLECTION_NOT_FOUND,1240,"collection not found","Will be raised when a collection with a given identifier or handle is unknown."
 
 ################################################################################
 ## Checked ArangoDB storage errors

--- a/lib/Basics/errors.dat
+++ b/lib/Basics/errors.dat
@@ -131,7 +131,6 @@ ERROR_ARANGO_WRITE_THROTTLE_TIMEOUT,1236,"write-throttling timeout","Will be rai
 ERROR_ARANGO_COLLECTION_TYPE_MISMATCH,1237,"collection type mismatch","Will be raised when a collection has a different type from what has been expected."
 ERROR_ARANGO_COLLECTION_NOT_LOADED,1238,"collection not loaded","Will be raised when a collection is accessed that is not yet loaded."
 ERROR_ARANGO_DOCUMENT_REV_BAD,1239,"illegal document revision","Will be raised when a document revision is corrupt or is missing where needed."
-ERROR_ARANGO_COLLECTION_NOT_FOUND,1240,"collection not found","Will be raised when a collection with a given identifier or handle is unknown."
 
 ################################################################################
 ## Checked ArangoDB storage errors

--- a/lib/Basics/voc-errors.cpp
+++ b/lib/Basics/voc-errors.cpp
@@ -108,7 +108,6 @@ void TRI_InitializeErrorMessages() {
   REG_ERROR(ERROR_ARANGO_COLLECTION_TYPE_MISMATCH, "collection type mismatch");
   REG_ERROR(ERROR_ARANGO_COLLECTION_NOT_LOADED, "collection not loaded");
   REG_ERROR(ERROR_ARANGO_DOCUMENT_REV_BAD, "illegal document revision");
-  REG_ERROR(ERROR_ARANGO_COLLECTION_NOT_FOUND, "collection not found");
   REG_ERROR(ERROR_ARANGO_DATAFILE_FULL, "datafile full");
   REG_ERROR(ERROR_ARANGO_EMPTY_DATADIR, "server database directory is empty");
   REG_ERROR(ERROR_ARANGO_TRY_AGAIN, "operation should be tried again");

--- a/lib/Basics/voc-errors.cpp
+++ b/lib/Basics/voc-errors.cpp
@@ -74,7 +74,6 @@ void TRI_InitializeErrorMessages() {
   REG_ERROR(ERROR_ARANGO_CONFLICT, "conflict");
   REG_ERROR(ERROR_ARANGO_DATADIR_INVALID, "invalid database directory");
   REG_ERROR(ERROR_ARANGO_DOCUMENT_NOT_FOUND, "document not found");
-  REG_ERROR(ERROR_ARANGO_COLLECTION_NOT_FOUND, "collection not found");
   REG_ERROR(ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, "collection or view not found");
   REG_ERROR(ERROR_ARANGO_COLLECTION_PARAMETER_MISSING, "parameter 'collection' not found");
   REG_ERROR(ERROR_ARANGO_DOCUMENT_HANDLE_BAD, "illegal document handle");
@@ -109,6 +108,7 @@ void TRI_InitializeErrorMessages() {
   REG_ERROR(ERROR_ARANGO_COLLECTION_TYPE_MISMATCH, "collection type mismatch");
   REG_ERROR(ERROR_ARANGO_COLLECTION_NOT_LOADED, "collection not loaded");
   REG_ERROR(ERROR_ARANGO_DOCUMENT_REV_BAD, "illegal document revision");
+  REG_ERROR(ERROR_ARANGO_COLLECTION_NOT_FOUND, "collection not found");
   REG_ERROR(ERROR_ARANGO_DATAFILE_FULL, "datafile full");
   REG_ERROR(ERROR_ARANGO_EMPTY_DATADIR, "server database directory is empty");
   REG_ERROR(ERROR_ARANGO_TRY_AGAIN, "operation should be tried again");

--- a/lib/Basics/voc-errors.h
+++ b/lib/Basics/voc-errors.h
@@ -539,8 +539,9 @@ constexpr int TRI_ERROR_ARANGO_DOCUMENT_REV_BAD                                 
 
 /// 1240: ERROR_ARANGO_COLLECTION_NOT_FOUND
 /// "collection not found"
-/// Will be raised when a collection with a given identifier or handle is unknown.
-constexpr int TRI_ERROR_ARANGO_COLLECTION_NOT_FOUND                               = 1240;
+/// Will be raised when a collection with a given identifier or handle is
+/// unknown.
+constexpr int TRI_ERROR_ARANGO_COLLECTION_NOT_FOUND                             = 1240;
 
 /// 1300: ERROR_ARANGO_DATAFILE_FULL
 /// "datafile full"

--- a/lib/Basics/voc-errors.h
+++ b/lib/Basics/voc-errors.h
@@ -537,12 +537,6 @@ constexpr int TRI_ERROR_ARANGO_COLLECTION_NOT_LOADED                            
 /// needed.
 constexpr int TRI_ERROR_ARANGO_DOCUMENT_REV_BAD                                 = 1239;
 
-/// 1240: ERROR_ARANGO_COLLECTION_NOT_FOUND
-/// "collection not found"
-/// Will be raised when a collection with a given identifier or handle is
-/// unknown.
-constexpr int TRI_ERROR_ARANGO_COLLECTION_NOT_FOUND                             = 1240;
-
 /// 1300: ERROR_ARANGO_DATAFILE_FULL
 /// "datafile full"
 /// Will be raised when the datafile reaches its limit.

--- a/utils/generateErrorfile.py
+++ b/utils/generateErrorfile.py
@@ -49,6 +49,9 @@ def genJsFile(errors):
 
   out = out\
       + "  };\n"\
+      + "\n"\
+      + "  // For compatibility with <= 3.3\n"\
+      + "  internal.errors.ERROR_ARANGO_COLLECTION_NOT_FOUND = internal.errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND;\n"\
       + "}());\n"\
       + "\n"
 


### PR DESCRIPTION
Removed `ERROR_ARANGO_COLLECTION_NOT_FOUND` and added it as an alias for `ERROR_ARANGO_DATA_SOURCE_NOT_FOUND` in JS for backwards compatibility.