### PR TITLE
Add pacing logic to arangoimp

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 devel
 -----
+* PR #5238: Create a default pacing algorithm for arangoimport to avoid TimeoutErrors
+  on VMs with limited disk throughput
 
 * Fixed internal issue #2237: AQL queries on collections with replicationFactor:
   "satellite" crashed arangod in single server mode

--- a/Documentation/Books/Manual/Administration/Arangoimport.md
+++ b/Documentation/Books/Manual/Administration/Arangoimport.md
@@ -471,9 +471,9 @@ windows of non-import activity to allow the server extra time for meta
 operations.
 
 The pacing algorithm works successfully with mmfiles with disks
-limited to read and write throughput of 1 Mbyte per second. The
-algorithm works successfully with rocksdb with disks limited to read
-and write throughput of 3 Mbyte per second.
+limited to read and write throughput as small as 1 Mbyte per
+second. The algorithm works successfully with rocksdb with disks
+limited to read and write throughput as small as 3 Mbyte per second.
 
 This algorithm will slow import of an unlimited (really fast) disk
 array by almost 25%. Raising the number of threads via the "--threads

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -157,7 +157,8 @@ void HeartbeatThread::runBackgroundJob() {
       _launchAnotherBackgroundJob = false;
 
       // the JobGuard is in the operator() of HeartbeatBackgroundJob
-      SchedulerFeature::SCHEDULER->post(HeartbeatBackgroundJob(shared_from_this(), TRI_microtime()));
+      _lastSyncTime = TRI_microtime();
+      SchedulerFeature::SCHEDULER->post(HeartbeatBackgroundJob(shared_from_this(), _lastSyncTime));
     } else {
       _backgroundJobScheduledOrRunning = false;
       _launchAnotherBackgroundJob = false;

--- a/arangosh/CMakeLists.txt
+++ b/arangosh/CMakeLists.txt
@@ -174,6 +174,7 @@ endif ()
 add_executable(${BIN_ARANGOIMPORT}
   ${ProductVersionFiles_arangoimport}
   ${PROJECT_SOURCE_DIR}/lib/Basics/WorkMonitorDummy.cpp
+  Import/AutoTuneThread.cpp
   Import/ImportFeature.cpp
   Import/ImportHelper.cpp
   Import/SenderThread.cpp
@@ -283,6 +284,7 @@ endif ()
 add_executable(${BIN_ARANGOSH}
   ${ProductVersionFiles_arangosh}
   ${PROJECT_SOURCE_DIR}/lib/Basics/WorkMonitorDummy.cpp
+  Import/AutoTuneThread.cpp
   Import/ImportHelper.cpp
   Import/SenderThread.cpp
   Shell/ClientFeature.cpp

--- a/arangosh/Import/AutoTuneThread.cpp
+++ b/arangosh/Import/AutoTuneThread.cpp
@@ -1,0 +1,106 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2018 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Matthew Von-Maszewski
+////////////////////////////////////////////////////////////////////////////////
+
+#include <iostream>
+
+#include "AutoTuneThread.h"
+#include "Basics/ConditionLocker.h"
+#include "ImportHelper.h"
+
+using namespace arangodb;
+using namespace arangodb::import;
+
+AutoTuneThread::AutoTuneThread(ImportHelper & importHelper)
+    : Thread("AutoTuneThread"),
+      _importHelper(importHelper) {}
+
+AutoTuneThread::~AutoTuneThread() {
+  shutdown();
+}
+
+void AutoTuneThread::beginShutdown() {
+  Thread::beginShutdown();
+
+  // wake up the thread that may be waiting in run()
+  CONDITION_LOCKER(guard, _condition);
+  guard.broadcast();
+}
+
+
+void AutoTuneThread::run() {
+//  uint64_t total_time(0), total_bytes(0);
+
+  while (!isStopping()) {
+    {
+      CONDITION_LOCKER(guard, _condition);
+      guard.wait(std::chrono::seconds(10));
+    }
+    if (!isStopping()) {
+#if 1
+      // getMaxUploadSize() is per thread
+      uint64_t current_max = _importHelper.getMaxUploadSize();
+      current_max *= _importHelper.getThreadCount();
+      uint64_t ten_second_actual = _importHelper.rotatePeriodByteCount();
+      uint64_t new_max = current_max;
+
+      // is current_max way too big
+      if (ten_second_actual < current_max && 10 < ten_second_actual) {
+        new_max = ten_second_actual / 10;
+      } else if ( ten_second_actual <= 10 ) {
+        new_max = current_max / 10;
+      } else {
+        new_max = (current_max + ten_second_actual / 10) / 2;
+      }
+
+      // grow number slowly if possible (10%)
+//      new_max += new_max/10;
+      new_max += new_max/5;  //(20% growth)
+
+      // make "per thread"
+      new_max /= _importHelper.getThreadCount();
+
+      // notes in Import mention an internal limit of 768MBytes
+      if ((768 * 1024 * 1024) < new_max) {
+        new_max = 768 * 1024 * 1024;
+      }
+
+      std::cout << "Current: " << current_max
+                << ", ten_sec: " << ten_second_actual
+                << ", new_max: " << new_max
+                << std::endl;
+#else
+      total_time +=10;
+      total_bytes += _importHelper.rotatePeriodByteCount();
+
+      uint64_t new_max = total_bytes / total_time / _importHelper.getThreadCount();
+
+      new_max += new_max/10;
+
+      std::cout << "Total sec: " << total_time
+                << ", total byte: " << total_bytes
+                << ", new_max: " << new_max
+                << std::endl;
+#endif
+      _importHelper.setMaxUploadSize(new_max);
+    }
+  }
+}

--- a/arangosh/Import/AutoTuneThread.cpp
+++ b/arangosh/Import/AutoTuneThread.cpp
@@ -25,6 +25,7 @@
 
 #include "AutoTuneThread.h"
 #include "Basics/ConditionLocker.h"
+#include "ImportFeature.h"
 #include "ImportHelper.h"
 
 using namespace arangodb;
@@ -90,16 +91,15 @@ void AutoTuneThread::run() {
         new_max = (current_max + ten_second_actual / 10) / 2;
       }
 
-      // grow number slowly if possible (10%)
-//      new_max += new_max/10;
-      new_max += new_max/5;  //(20% growth)
+      // grow number slowly if possible (20%)
+      new_max += new_max/5;
 
       // make "per thread"
       new_max /= _importHelper.getThreadCount();
 
       // notes in Import mention an internal limit of 768MBytes
-      if ((768 * 1024 * 1024) < new_max) {
-        new_max = 768 * 1024 * 1024;
+      if ((arangodb::import::ImportHelper::MaxBatchSize) < new_max) {
+        new_max = arangodb::import::ImportHelper::MaxBatchSize;
       }
 
       LOG_TOPIC(DEBUG, arangodb::Logger::FIXME)

--- a/arangosh/Import/AutoTuneThread.cpp
+++ b/arangosh/Import/AutoTuneThread.cpp
@@ -102,7 +102,7 @@ void AutoTuneThread::run() {
         new_max = 768 * 1024 * 1024;
       }
 
-      LOG_TOPIC(INFO, arangodb::Logger::FIXME)
+      LOG_TOPIC(DEBUG, arangodb::Logger::FIXME)
         << "Current: " << current_max
         << ", ten_sec: " << ten_second_actual
         << ", new_max: " << new_max;

--- a/arangosh/Import/AutoTuneThread.cpp
+++ b/arangosh/Import/AutoTuneThread.cpp
@@ -31,11 +31,10 @@ using namespace arangodb;
 using namespace arangodb::import;
 
 ////////////////////////////////////////////////////////////////////////////////
-//
-// This auto tuning of output rate is based upon determining the actual rate
-//  arangodb is absorbing bytes per second, then dividing that total amount
-//  across the desired thread count.  The delivery is of bytes from each thread
-//  is also paced across a second.
+// Goals:
+//  1. compute current one second throughput of import
+//  2. spread byte count of one second throughput across sender threads
+//  3. create "space" between sender execution to give server time for other activities
 //
 // The code collects the total count of bytes absorbed for ten seconds, then averages
 //  that amount with the total from the previous 10 seconds.  The per second per thread pace

--- a/arangosh/Import/AutoTuneThread.h
+++ b/arangosh/Import/AutoTuneThread.h
@@ -45,12 +45,16 @@ class AutoTuneThread : public arangodb::Thread {
 
   void beginShutdown() override;
 
- protected:
+  void paceSends();
+
+protected:
   void run() override;
+
 
   ImportHelper & _importHelper;
   basics::ConditionVariable _condition;
-
+  std::chrono::steady_clock::time_point _nextSend;
+  std::chrono::microseconds _pace;
 };
 }
 }

--- a/arangosh/Import/AutoTuneThread.h
+++ b/arangosh/Import/AutoTuneThread.h
@@ -1,0 +1,57 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2018 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Matthew Von-Maszewski
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef ARANGODB_IMPORT_AUTOTUNE_THREAD_H
+#define ARANGODB_IMPORT_AUTOTUNE_THREAD_H 1
+
+#include "Basics/ConditionVariable.h"
+#include "Basics/Thread.h"
+#include "SimpleHttpClient/SimpleHttpClient.h"
+
+namespace arangodb {
+
+namespace import {
+
+  class ImportHelper;
+
+class AutoTuneThread : public arangodb::Thread {
+ private:
+  AutoTuneThread(AutoTuneThread const&) = delete;
+  AutoTuneThread& operator=(AutoTuneThread const&) = delete;
+
+ public:
+  explicit AutoTuneThread(ImportHelper & importHelper);
+
+  ~AutoTuneThread();
+
+  void beginShutdown() override;
+
+ protected:
+  void run() override;
+
+  ImportHelper & _importHelper;
+  basics::ConditionVariable _condition;
+
+};
+}
+}
+#endif

--- a/arangosh/Import/AutoTuneThread.h
+++ b/arangosh/Import/AutoTuneThread.h
@@ -25,7 +25,7 @@
 
 #include "Basics/ConditionVariable.h"
 #include "Basics/Thread.h"
-#include "SimpleHttpClient/SimpleHttpClient.h"
+#include "Logger/Logger.h"
 
 namespace arangodb {
 

--- a/arangosh/Import/ImportFeature.cpp
+++ b/arangosh/Import/ImportFeature.cpp
@@ -198,18 +198,16 @@ void ImportFeature::validateOptions(
     FATAL_ERROR_EXIT();
   }
 
-  static unsigned const MaxBatchSize = 768 * 1024 * 1024;
-
   // _chunkSize is dynamic ... unless user explicitly sets it
   _autoChunkSize = !options->processingResult().touched("--batch-size");
 
-  if (_chunkSize > MaxBatchSize) {
+  if (_chunkSize > arangodb::import::ImportHelper::MaxBatchSize) {
     // it's not sensible to raise the batch size beyond this value
     // because the server has a built-in limit for the batch size too
     // and will reject bigger HTTP request bodies
     LOG_TOPIC(WARN, arangodb::Logger::FIXME) << "capping --batch-size value to "
-                                             << MaxBatchSize;
-    _chunkSize = MaxBatchSize;
+                                             << arangodb::import::ImportHelper::MaxBatchSize;
+    _chunkSize = arangodb::import::ImportHelper::MaxBatchSize;
   }
 
   if (_threadCount < 1) {

--- a/arangosh/Import/ImportFeature.cpp
+++ b/arangosh/Import/ImportFeature.cpp
@@ -47,7 +47,8 @@ ImportFeature::ImportFeature(application_features::ApplicationServer* server,
       _filename(""),
       _useBackslash(false),
       _convert(true),
-      _chunkSize(1024 * 1024 * 16),
+      _autoChunkSize(true),
+      _chunkSize(1024 * 1024 * 1),
       _threadCount(2),
       _collectionName(""),
       _fromCollectionPrefix(""),
@@ -199,6 +200,9 @@ void ImportFeature::validateOptions(
 
   static unsigned const MaxBatchSize = 768 * 1024 * 1024;
 
+  // _chunkSize is dynamic ... unless user explicitly sets it
+  _autoChunkSize = !options->processingResult().touched("--batch-size");
+
   if (_chunkSize > MaxBatchSize) {
     // it's not sensible to raise the batch size beyond this value
     // because the server has a built-in limit for the batch size too
@@ -214,11 +218,12 @@ void ImportFeature::validateOptions(
                                              << 1;
     _threadCount = 1;
   }
-  if (_threadCount > TRI_numberProcessors()) {
-    // it's not sensible to use just one thread
+  if (_threadCount > TRI_numberProcessors()*2) {
+    // it's not sensible to use just one thread ...
+    //  and import's CPU usage is negligible, real limit is cluster cores
     LOG_TOPIC(WARN, arangodb::Logger::FIXME) << "capping --threads value to "
-                                             << TRI_numberProcessors();
-    _threadCount = (uint32_t)TRI_numberProcessors();
+                                             << TRI_numberProcessors()*2;
+    _threadCount = (uint32_t)TRI_numberProcessors()*2;
   }
 
   for (auto const& it : _translations) {
@@ -295,7 +300,7 @@ void ImportFeature::start() {
   auto versionString = _httpClient->getServerVersion(&err);
   auto dbName = client->databaseName();
   bool createdDatabase = false;
-  
+
   auto successfulConnection = [&](){
     std::cout << "Connected to ArangoDB '"
               << _httpClient->getEndpointSpecification() << "', version "
@@ -379,7 +384,7 @@ void ImportFeature::start() {
 
   SimpleHttpClientParams params = _httpClient->params();
   arangodb::import::ImportHelper ih(client, client->endpoint(), params,
-                                    _chunkSize, _threadCount);
+                                    _chunkSize, _threadCount, _autoChunkSize);
 
   // create colletion
   if (_createCollection) {

--- a/arangosh/Import/ImportFeature.h
+++ b/arangosh/Import/ImportFeature.h
@@ -51,6 +51,7 @@ class ImportFeature final : public application_features::ApplicationFeature,
   std::string _filename;
   bool _useBackslash;
   bool _convert;
+  bool _autoChunkSize;
   uint64_t _chunkSize;
   uint32_t _threadCount;
   std::string _collectionName;

--- a/arangosh/Import/ImportHelper.h
+++ b/arangosh/Import/ImportHelper.h
@@ -249,13 +249,15 @@ class ImportHelper {
 
   std::vector<std::string> getErrorMessages() { return _errorMessages; }
 
-  uint64_t getMaxUploadSize() {return(_maxUploadSize.load());};
-  void setMaxUploadSize(uint64_t newSize) {_maxUploadSize.store(newSize);};
+  uint64_t getMaxUploadSize() {return(_maxUploadSize.load());}
+  void setMaxUploadSize(uint64_t newSize) {_maxUploadSize.store(newSize);}
 
-  uint64_t rotatePeriodByteCount() {return(_periodByteCount.exchange(0));};
-  void addPeriodByteCount(uint64_t add) {_periodByteCount.fetch_add(add);};
+  uint64_t rotatePeriodByteCount() {return(_periodByteCount.exchange(0));}
+  void addPeriodByteCount(uint64_t add) {_periodByteCount.fetch_add(add);}
 
-  uint32_t getThreadCount() const {return _threadCount;};
+  uint32_t getThreadCount() const {return _threadCount;}
+
+  static unsigned const MaxBatchSize;
 
  private:
   static void ProcessCsvBegin(TRI_csv_parser_t*, size_t);

--- a/arangosh/Import/ImportHelper.h
+++ b/arangosh/Import/ImportHelper.h
@@ -25,6 +25,10 @@
 #ifndef ARANGODB_IMPORT_IMPORT_HELPER_H
 #define ARANGODB_IMPORT_IMPORT_HELPER_H 1
 
+#include <atomic>
+
+#include "AutoTuneThread.h"
+
 #include "Basics/Common.h"
 #include "Basics/ConditionVariable.h"
 #include "Basics/Mutex.h"
@@ -77,7 +81,7 @@ class ImportHelper {
  public:
   ImportHelper(ClientFeature const* client, std::string const& endpoint,
                httpclient::SimpleHttpClientParams const& params,
-               uint64_t maxUploadSize, uint32_t threadCount);
+               uint64_t maxUploadSize, uint32_t threadCount, bool autoUploadSize=false);
 
   ~ImportHelper();
 
@@ -157,7 +161,7 @@ class ImportHelper {
       std::unordered_map<std::string, std::string> const& translations) {
     _translations = translations;
   }
-  
+
   void setRemoveAttributes(std::vector<std::string> const& attr) {
     for (std::string const& str : attr) {
       _removeAttributes.insert(str);
@@ -245,6 +249,14 @@ class ImportHelper {
 
   std::vector<std::string> getErrorMessages() { return _errorMessages; }
 
+  uint64_t getMaxUploadSize() {return(_maxUploadSize.load());};
+  void setMaxUploadSize(uint64_t newSize) {_maxUploadSize.store(newSize);};
+
+  uint64_t rotatePeriodByteCount() {return(_periodByteCount.exchange(0));};
+  void addPeriodByteCount(uint64_t add) {_periodByteCount.fetch_add(add);};
+
+  uint32_t getThreadCount() const {return _threadCount;};
+
  private:
   static void ProcessCsvBegin(TRI_csv_parser_t*, size_t);
   static void ProcessCsvAdd(TRI_csv_parser_t*, char const*, size_t, size_t,
@@ -270,9 +282,14 @@ class ImportHelper {
 
  private:
   std::unique_ptr<httpclient::SimpleHttpClient> _httpClient;
-  uint64_t const _maxUploadSize;
+  std::atomic<uint64_t> _maxUploadSize;
+  std::atomic<uint64_t> _periodByteCount;
+  bool const _autoUploadSize;
+  std::unique_ptr<AutoTuneThread> _autoTuneThread;
   std::vector<std::unique_ptr<SenderThread>> _senderThreads;
-  basics::ConditionVariable _threadsCondition; 
+  uint32_t const _threadCount;
+  basics::ConditionVariable _threadsCondition;
+
 
   std::string _separator;
   std::string _quote;

--- a/lib/Basics/Thread.cpp
+++ b/lib/Basics/Thread.cpp
@@ -82,7 +82,7 @@ void Thread::startThread(void* arg) {
   TRI_ASSERT(ptr != nullptr);
 
   ptr->_threadNumber = LOCAL_THREAD_NUMBER;
-  
+
   LOCAL_THREAD_NAME = ptr->name().c_str();
 
   if (0 <= ptr->_affinity) {
@@ -135,7 +135,7 @@ TRI_pid_t Thread::currentProcessId() {
 ////////////////////////////////////////////////////////////////////////////////
 
 uint64_t Thread::currentThreadNumber() { return LOCAL_THREAD_NUMBER; }
-  
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief returns the name of the current thread, if set
 /// note that this function may return a nullptr
@@ -222,7 +222,7 @@ Thread::~Thread() {
         << ". shutting down hard";
     FATAL_ERROR_ABORT();
   }
-  
+
   LOCAL_THREAD_NAME = nullptr;
 }
 
@@ -251,7 +251,7 @@ void Thread::beginShutdown() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// @brief called from the destructor
+/// @brief derived class MUST call from its destructor
 ////////////////////////////////////////////////////////////////////////////////
 
 void Thread::shutdown() {


### PR DESCRIPTION
Google Compute and other VM providers limit the throughput of disk devices.  Google's limit is more strict for smaller disk rentals, than for larger.  Specifically, a user could choose the smallest disk space and be limited to 3 Mbytes per second.

Arangodb's import previously defaulted to pushing data in blocks of 3 Mbytes per thread, as often as possible (default of 2 threads).  The data pushed would back-up on the server and result in a TimeoutError.  The TimeoutError is very frustrating to new users.  The users were required to learn how to lower the default block size and default thread count ... and the new parameters would still not be guaranteed to work.

This branch creates a default algorithm that adjusts the block size dynamically based upon the actual throughput of the server over the last 20 seconds.  Further, each thread now delivers its portion of the data in mostly non-overlapping chunks.  The thread timing creates intentional windows of non-import activity to allow the server extra time for meta operations.

The algorithm has tested successful with mmfiles with disks limited to read and write throughput of 1 Mbyte per second.  The algorithm has tested successful with rocksdb with disks limited to read and write throughput of 3 Mbyte per second.

This algorithm will slow import of an unlimited (really fast) disk array by almost 25%.  Raising the number of threads via the "--threads X" command line to any value of X greater than 2 resolves the performance loss.

The algorithm is disabled by manually specifying any "--batch-size".  16777216 is the previous default for --batch-size.