### PR TITLE
added REST API endpoint GET /_admin/server/availability

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.3.9 (xxxx-xx-xx)
 -------------------
 
+* added REST API endpoint /_admin/server/availability for monitoring purposes
+
 * UI: fixed an unreasonable event bug within the modal view engine
 
 * fixed issue #3811: gharial api is now checking existence of _from and _to vertices

--- a/Documentation/Books/HTTP/AdministrationAndMonitoring/README.md
+++ b/Documentation/Books/HTTP/AdministrationAndMonitoring/README.md
@@ -36,6 +36,8 @@ monitoring of the server.
 
 @startDocuBlock JSF_get_admin_server_id
 
+@startDocuBlock get_admin_server_availability
+
 ## Cluster
 
 <!-- js/actions/api-cluster.js -->

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_server_availability.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_server_availability.md
@@ -1,6 +1,6 @@
 
 @startDocuBlock get_admin_server_availability
-@brief Get to know whether this server is a Coordinator or DB-Server
+@brief Return whether or not a server is available
 
 @RESTHEADER{GET /_admin/server/availability, Return whether or not a server is available}
 
@@ -19,6 +19,6 @@ in case of an active failover setup.
 
 @RESTRETURNCODE{503}
 HTTP 503 will be returned in case the server is during startup or during shutdown,
-is set to read-only mode or is currently not a follower in an active failover setup.
+is set to read-only mode or is currently a follower in an active failover setup.
 @endDocuBlock
 

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_server_availability.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_server_availability.md
@@ -1,0 +1,24 @@
+
+@startDocuBlock get_admin_server_availability
+@brief Get to know whether this server is a Coordinator or DB-Server
+
+@RESTHEADER{GET /_admin/server/availability, Return whether or not a server is available}
+
+@RESTDESCRIPTION
+Return availability information about a server.
+
+This is a public API so it does *not* require authentication. It is meant to be
+used only in the context of server monitoring only.
+
+@RESTRETURNCODES
+
+@RESTRETURNCODE{200}
+This API will return HTTP 200 in case the server is up and running and usable for
+arbitrary operations, is not set to read-only mode and is currently not a follower 
+in case of an active failover setup.
+
+@RESTRETURNCODE{503}
+HTTP 503 will be returned in case the server is during startup or during shutdown,
+is set to read-only mode or is currently not a follower in an active failover setup.
+@endDocuBlock
+

--- a/arangod/GeneralServer/GeneralCommTask.cpp
+++ b/arangod/GeneralServer/GeneralCommTask.cpp
@@ -397,7 +397,8 @@ rest::ResponseCode GeneralCommTask::canAccessPath(
 
     if (result != rest::ResponseCode::OK) {
       if (path == "/" || StringUtils::isPrefix(path, Open) ||
-          StringUtils::isPrefix(path, AdminAardvark)) {
+          StringUtils::isPrefix(path, AdminAardvark) ||
+          path == "/_admin/server/availability") {
         // mop: these paths are always callable...they will be able to check
         // req.user when it could be validated
         result = rest::ResponseCode::OK;

--- a/arangod/GeneralServer/RestHandlerFactory.cpp
+++ b/arangod/GeneralServer/RestHandlerFactory.cpp
@@ -112,6 +112,7 @@ RestHandler* RestHandlerFactory::createHandler(
       if (path.find("/_admin/shutdown") == std::string::npos &&
           path.find("/_admin/cluster/health") == std::string::npos &&
           path.find("/_admin/server/role") == std::string::npos &&
+          path.find("/_admin/server/availability") == std::string::npos &&
           path.find("/_api/agency/agency-callbacks") == std::string::npos &&
           path.find("/_api/cluster/") == std::string::npos &&
           path.find("/_api/replication") == std::string::npos &&

--- a/arangod/RestHandler/RestAdminServerHandler.cpp
+++ b/arangod/RestHandler/RestAdminServerHandler.cpp
@@ -42,6 +42,8 @@ RestStatus RestAdminServerHandler::execute() {
     handleId();
   } else if (suffixes.size() == 1 && suffixes[0] == "role") {
     handleRole();
+  } else if (suffixes.size() == 1 && suffixes[0] == "availability") {
+    handleAvailability();
   } else {
     generateError(rest::ResponseCode::NOT_FOUND, 404);
   }
@@ -107,6 +109,42 @@ void RestAdminServerHandler::handleRole() {
     );
   }
   generateOk(rest::ResponseCode::OK, builder);
+}
+
+/// @brief simple availability check
+/// this handler does not require authentication
+/// it will return HTTP 200 in case the server is up and usable,
+/// and not in read-only mode (or a follower in case of active failover)
+/// will return HTTP 503 in case the server is starting, stopping, set
+/// to read-only or a follower in case of active failover
+void RestAdminServerHandler::handleAvailability() {
+  if (_request->requestType() != rest::RequestType::GET) {
+    generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
+      TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
+    return;
+  }
+  
+  bool available = false;
+  switch (ServerState::serverMode()) {
+    case ServerState::Mode::DEFAULT:
+      available = !application_features::ApplicationServer::isStopping();
+      break;
+    case ServerState::Mode::MAINTENANCE: 
+    case ServerState::Mode::REDIRECT:
+    case ServerState::Mode::TRYAGAIN: 
+    case ServerState::Mode::READ_ONLY:
+    case ServerState::Mode::INVALID:
+      TRI_ASSERT(!available);
+      break;
+  }
+ 
+  if (!available) {
+    // this will produce an HTTP 503 result
+    generateError(rest::ResponseCode::SERVICE_UNAVAILABLE, TRI_ERROR_HTTP_SERVICE_UNAVAILABLE);
+  } else {
+    // this will produce an HTTP 200 result
+    writeModeResult(ServerState::serverMode());
+  }
 }
 
 void RestAdminServerHandler::handleMode() {

--- a/arangod/RestHandler/RestAdminServerHandler.h
+++ b/arangod/RestHandler/RestAdminServerHandler.h
@@ -48,6 +48,7 @@ class RestAdminServerHandler : public RestBaseHandler {
   void handleMode();
   void handleId();
   void handleRole();
+  void handleAvailability();
   void writeModeResult(ServerState::Mode const&);
 };
 }


### PR DESCRIPTION
This a public API, which can be used without authentication.
It is meant to be used in the context of server monitoring only
