### PR TITLE
Bug fix/default stack size on osx too small

### DIFF
--- a/lib/Basics/threads-posix.cpp
+++ b/lib/Basics/threads-posix.cpp
@@ -125,7 +125,7 @@ bool TRI_StartThread(TRI_thread_t* thread, TRI_tid_t* threadId,
     }
   }
 
-  int rc = pthread_create(thread, nullptr, &ThreadStarter, d.get());
+  int rc = pthread_create(thread, &stackSizeAttribute, &ThreadStarter, d.get());
 
   if (rc != 0) {
     errno = rc;

--- a/lib/Basics/threads-posix.cpp
+++ b/lib/Basics/threads-posix.cpp
@@ -108,20 +108,23 @@ bool TRI_StartThread(TRI_thread_t* thread, TRI_tid_t* threadId,
 
   auto err = pthread_attr_init (&stackSizeAttribute);
   if (err) {
-    // We should never be here
-    TRI_ASSERT(false);
+    LOG_TOPIC(ERR, arangodb::Logger::FIXME)
+      << "could not initialise stack size attribute.";
+    return false;
   }
   err = pthread_attr_getstacksize(&stackSizeAttribute, &stackSize); 
   if (err) {
-    // We should never be here
-    TRI_ASSERT(false);
+    LOG_TOPIC(ERR, arangodb::Logger::FIXME)
+      << "could not acquire stack size from pthread.";
+    return false;
   }
 
   if (stackSize < 8388608) { // 8MB
     err = pthread_attr_setstacksize (&stackSizeAttribute, 8388608);
     if (err) {
-      // We should never be here
-      TRI_ASSERT(false);
+      LOG_TOPIC(ERR, arangodb::Logger::FIXME)
+        << "could not assign new stack size in pthread.";
+      return false;
     }
   }
 

--- a/lib/Basics/threads-posix.cpp
+++ b/lib/Basics/threads-posix.cpp
@@ -103,6 +103,28 @@ bool TRI_StartThread(TRI_thread_t* thread, TRI_tid_t* threadId,
 
   TRI_ASSERT(d != nullptr);
 
+  pthread_attr_t 	stackSizeAttribute;
+  size_t			stackSize = 0;
+
+  auto err = pthread_attr_init (&stackSizeAttribute);
+  if (err) {
+    // We should never be here
+    TRI_ASSERT(false);
+  }
+  err = pthread_attr_getstacksize(&stackSizeAttribute, &stackSize); 
+  if (err) {
+    // We should never be here
+    TRI_ASSERT(false);
+  }
+
+  if (stackSize < 8388608) { // 8MB
+    err = pthread_attr_setstacksize (&stackSizeAttribute, 8388608);
+    if (err) {
+      // We should never be here
+      TRI_ASSERT(false);
+    }
+  }
+
   int rc = pthread_create(thread, nullptr, &ThreadStarter, d.get());
 
   if (rc != 0) {

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -11,23 +11,23 @@
 
 #include <thread>
 
-template<class Function>
-class TestThread : public arangodb::Thread {
+template<class Function> class TestThread : public arangodb::Thread {
 public:
 
-  TestThread(Function&& f, int i, char** c) :
-    arangodb::Thread("catch"), f_(f), i_(i), c_(c) {
+  TestThread(Function&& f, int i, char* c[]) :
+    arangodb::Thread("catch"), _f(f), _i(i), _c(c) {
     run();
   }
   void run() {
-    result_ = f_(i_,c_);
+    _result = _f(_i,_c);
   }
-  int result() {return result_;}
+  int result() {return _result;}
+
 private:
-  Function f_;
-  int result_;
-  int i_;
-  char** c_;
+  Function _f;
+  int _result;
+  int _i;
+  char** _c;
 };
 
 char const* ARGV0 = "";

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -54,13 +54,10 @@ int main(int argc, char* argv[]) {
   // the stack size for subthreads has been reconfigured in the
   // ArangoGlobalContext above in the libmusl case:
   int result;
-  auto runTests =
-    [] (int argc, char* argv[]) -> int {
+  auto tests = [] (int argc, char* argv[]) -> int {
     return Catch::Session().run( argc, argv );
   };
-
-  TestThread<std::function<int(int, char**)>> t(
-    std::move(runTests), argc, argv);
+  TestThread<decltype(tests)> t(std::move(tests), argc, argv);
   result = t.result();
 
   arangodb::Logger::shutdown();


### PR DESCRIPTION
OSX default stack size for threads is at 512k, needs tweaking.
