### PR TITLE
remove asio and ICU compile warnings spam

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -814,7 +814,7 @@ if (USE_JEMALLOC)
   add_dependencies(rocksdb jemalloc)
 endif ()
 
-include_directories(${ASIO_INCLUDES})
+include_directories(SYSTEM ${ASIO_INCLUDES})
 
 ################################################################################
 ## VELOCYPACK
@@ -831,7 +831,7 @@ endforeach()
 ## ICU
 ################################################################################
 
-include_directories(${ICU_INCLUDE_DIR})
+include_directories(SYSTEM ${ICU_INCLUDE_DIR})
 
 ################################################################################
 ## OPENSSL


### PR DESCRIPTION
Use SYSTEM declaration when including asio and ICU, in order to reduce the number of compile warnings.