### PR TITLE
Fixing agency pool update

### DIFF
--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -1308,7 +1308,7 @@ void AgencyComm::updateEndpoints(arangodb::velocypack::Slice const& current) {
   for (const auto& i : VPackObjectIterator(current)) {
     auto const endpoint = Endpoint::unifiedForm(i.value.copyString());
     if (std::find(stored.begin(), stored.end(), endpoint) == stored.end()) {
-      LOG_TOPIC(DEBUG, Logger::AGENCYCOMM)
+      LOG_TOPIC(INFO, Logger::AGENCYCOMM)
         << "Adding endpoint " << endpoint << " to agent pool";
       AgencyCommManager::MANAGER->addEndpoint(endpoint);
     }
@@ -1321,7 +1321,6 @@ void AgencyComm::updateEndpoints(arangodb::velocypack::Slice const& current) {
       << "Removing endpoint " << i << " from agent pool";
     AgencyCommManager::MANAGER->removeEndpoint(i);
   }
-
 }
 
 

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -333,9 +333,7 @@ void HeartbeatThread::runDBServer() {
               << "Heartbeat: Could not read from agency!";
         } else {
 
-          VPackSlice agentPool =
-            result.slice()[0].get(
-              std::vector<std::string>({".agency","pool"}));
+          VPackSlice agentPool = result.slice()[0].get(".agency");
           updateAgentPool(agentPool);
 
           VPackSlice shutdownSlice =
@@ -526,7 +524,7 @@ void HeartbeatThread::runSingleServer() {
       }
 
       VPackSlice response = result.slice()[0];
-      VPackSlice agentPool = response.get(std::vector<std::string>{".agency", "pool"});
+      VPackSlice agentPool = response.get(".agency");
       updateAgentPool(agentPool);
 
       VPackSlice shutdownSlice = response.get({AgencyCommManager::path(), "Shutdown"});
@@ -768,9 +766,7 @@ void HeartbeatThread::runCoordinator() {
             << result.bodyRef() << ", timeout: " << timeout;
       } else {
 
-        VPackSlice agentPool =
-          result.slice()[0].get(
-            std::vector<std::string>({".agency","pool"}));
+        VPackSlice agentPool = result.slice()[0].get(".agency");
         updateAgentPool(agentPool);
 
         VPackSlice shutdownSlice = result.slice()[0].get(
@@ -1264,11 +1260,11 @@ bool HeartbeatThread::sendServerState() {
 }
 
 void HeartbeatThread::updateAgentPool(VPackSlice const& agentPool) {
-  if (agentPool.isObject() && agentPool.hasKey("size") &&
-      agentPool.get("size").getUInt() > 1) {
-    _agency.updateEndpoints(agentPool);
+  if (agentPool.isObject() && agentPool.get("pool").isObject() &&
+      agentPool.hasKey("size") && agentPool.get("size").getUInt() > 1) {
+    _agency.updateEndpoints(agentPool.get("pool"));
   } else {
-    LOG_TOPIC(TRACE, arangodb::Logger::FIXME) << "Cannot find an agency persisted in RAFT 8|";
+    LOG_TOPIC(ERR, Logger::AGENCYCOMM) << "Cannot find an agency persisted in RAFT 8|";
   }
 }
 


### PR DESCRIPTION
Agency response for the path `/.agency` looked different from what the code expected, therefore `HeartbeatThread::updateAgentPool` was a no-op:
```
curl http://localhost:4002/_api/agency/read -v --data '[["/arango/Supervision"]]' | jq
[
  {
    ".agency": {
      "active": [
        "AGNT-8e571095-2bcb-4967-9f8f-8c8897c4c6b7",
        "AGNT-b5fc37f0-e677-4445-bb27-0f62ef6c07d8",
        "AGNT-362e7e17-d27a-442f-becc-55cd690a0dd7"
      ],
      "timeoutMult": 2,
      "id": "AGNT-362e7e17-d27a-442f-becc-55cd690a0dd7",
      "pool": {
        "AGNT-362e7e17-d27a-442f-becc-55cd690a0dd7": "tcp://[::1]:4002",
        "AGNT-8e571095-2bcb-4967-9f8f-8c8897c4c6b7": "tcp://[::1]:4003",
        "AGNT-b5fc37f0-e677-4445-bb27-0f62ef6c07d8": "tcp://[::1]:4001"
      },
      "size": 3,
      "term": 2
    }
  }
```