### PR TITLE
abort startup when using SSLv2 for a server endpoint

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 devel
 -----
 
+* abort startup when using SSLv2 for a server endpoint, or when connecting with
+  a client tool via an SSLv2 connection.
+  
+  SSLv2 has been disabled in the OpenSSL library by default in recent versions
+  because of security vulnerabilities inherent in this protocol. 
+
 * added startup option `--log.escape`
 
   This option toggles the escaping of log output. 

--- a/Documentation/Books/Manual/Administration/Configuration/SSL.md
+++ b/Documentation/Books/Manual/Administration/Configuration/SSL.md
@@ -89,13 +89,17 @@ The certificates in *filename* must be PEM formatted.
 Use this option to specify the default encryption protocol to be used.  The
 following variants are available:
 
-- 1: SSLv2
+- 1: SSLv2 (unsupported)
 - 2: SSLv2 or SSLv3 (negotiated)
 - 3: SSLv3
 - 4: TLSv1
 - 5: TLSv1.2
 
 The default *value* is 5 (TLSv1.2).
+
+Note that SSLv2 is unsupported as of ArangoDB 3.4, because of the inherent 
+security vulnerabilities in this protocol. Selecting SSLv2 as protocol will
+abort the startup.
 
 ### SSL cache
 

--- a/arangosh/Shell/ClientFeature.cpp
+++ b/arangosh/Shell/ClientFeature.cpp
@@ -129,6 +129,11 @@ void ClientFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
 }
 
 void ClientFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
+  if (_sslProtocol == 1) {
+    LOG_TOPIC(FATAL, arangodb::Logger::SSL) << "SSLv2 is not supported any longer because of security vulnerabilities in this protocol";
+    FATAL_ERROR_EXIT();
+  }
+
   // if a username is specified explicitly, assume authentication is desired
   if (options->processingResult().touched("server.username")) {
     _authentication = true;

--- a/lib/SimpleHttpClient/SslClientConnection.cpp
+++ b/lib/SimpleHttpClient/SslClientConnection.cpp
@@ -213,12 +213,6 @@ void SslClientConnection::init(uint64_t sslProtocol) {
   SSL_METHOD SSL_CONST* meth = nullptr;
 
   switch (SslProtocol(sslProtocol)) {
-#ifndef OPENSSL_NO_SSL2
-    case SSL_V2:
-      meth = SSLv2_method();
-      break;
-#endif
-
 #ifndef OPENSSL_NO_SSL3_METHOD
     case SSL_V3:
       meth = SSLv3_method();
@@ -235,7 +229,7 @@ void SslClientConnection::init(uint64_t sslProtocol) {
     case TLS_V12:
     case SSL_UNKNOWN:
     default:
-      // default is to use TLSv13
+      // default is to use TLSv12
       meth = TLS_method();
       break;
 #else

--- a/lib/Ssl/SslServerFeature.cpp
+++ b/lib/Ssl/SslServerFeature.cpp
@@ -92,6 +92,14 @@ void SslServerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
       new StringParameter(&_ecdhCurve));
 }
 
+void SslServerFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
+  // check for SSLv2
+  if (_sslProtocol == 1) {
+    LOG_TOPIC(FATAL, arangodb::Logger::SSL) << "SSLv2 is not supported any longer because of security vulnerabilities in this protocol";
+    FATAL_ERROR_EXIT();
+  }
+}
+
 void SslServerFeature::prepare() {
   LOG_TOPIC(INFO, arangodb::Logger::SSL) << "using SSL options: "
                                          << stringifySslOptions(_sslOptions);

--- a/lib/Ssl/SslServerFeature.h
+++ b/lib/Ssl/SslServerFeature.h
@@ -33,7 +33,7 @@
 #include <asio/ssl.hpp>
 
 namespace arangodb {
-class SslServerFeature final : public application_features::ApplicationFeature {
+class SslServerFeature : public application_features::ApplicationFeature {
  public:
   static SslServerFeature* SSL;
 
@@ -41,8 +41,8 @@ class SslServerFeature final : public application_features::ApplicationFeature {
   explicit SslServerFeature(application_features::ApplicationServer* server);
 
  public:
-  void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
-  void validateOptions(std::shared_ptr<options::ProgramOptions>) override final;
+  void collectOptions(std::shared_ptr<options::ProgramOptions>) override;
+  void validateOptions(std::shared_ptr<options::ProgramOptions>) override;
   void prepare() override final;
   void unprepare() override final;
 

--- a/lib/Ssl/SslServerFeature.h
+++ b/lib/Ssl/SslServerFeature.h
@@ -33,7 +33,7 @@
 #include <asio/ssl.hpp>
 
 namespace arangodb {
-class SslServerFeature : public application_features::ApplicationFeature {
+class SslServerFeature final : public application_features::ApplicationFeature {
  public:
   static SslServerFeature* SSL;
 
@@ -41,7 +41,8 @@ class SslServerFeature : public application_features::ApplicationFeature {
   explicit SslServerFeature(application_features::ApplicationServer* server);
 
  public:
-  void collectOptions(std::shared_ptr<options::ProgramOptions>) override;
+  void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
+  void validateOptions(std::shared_ptr<options::ProgramOptions>) override final;
   void prepare() override final;
   void unprepare() override final;
 

--- a/lib/Ssl/ssl-helper.cpp
+++ b/lib/Ssl/ssl-helper.cpp
@@ -46,11 +46,6 @@ asio::ssl::context arangodb::sslContext(
   context::method meth;
 
   switch (protocol) {
-#ifndef OPENSSL_NO_SSL2
-    case SSL_V2:
-      meth = context::method::sslv2;
-      break;
-#endif
 #ifndef OPENSSL_NO_SSL3_METHOD
     case SSL_V3:
       meth = context::method::sslv3;
@@ -107,9 +102,6 @@ asio::ssl::context arangodb::sslContext(
 
 std::string arangodb::protocolName(SslProtocol protocol) {
   switch (protocol) {
-    case SSL_V2:
-      return "SSLv2";
-
     case SSL_V23:
       return "SSLv23";
 

--- a/lib/Ssl/ssl-helper.h
+++ b/lib/Ssl/ssl-helper.h
@@ -36,7 +36,14 @@ namespace arangodb {
 // SSL protocol methods
 enum SslProtocol {
   SSL_UNKNOWN = 0,
-  SSL_V2 = 1,
+  // removed SSL_V2 here, because newer versions of OpenSSL do not
+  // include it by default.
+  // from https://www.openssl.org/news/cl110.txt:
+  //   Changes between 1.0.2f and 1.0.2g [1 Mar 2016]
+  //   * Disable SSLv2 default build, default negotiation and weak ciphers.  SSLv2
+  //     is by default disabled at build-time.  Builds that are not configured with
+  //     "enable-ssl2" will not support SSLv2.  
+  // SSL_V2 = 1,
   SSL_V23 = 2,
   SSL_V3 = 3,
   TLS_V1 = 4,


### PR DESCRIPTION
or when connecting with a client tool via an SSLv2 connection.

SSLv2 has been disabled in the OpenSSL library by default in recent versions
because of security vulnerabilities inherent in this protocol.

This also fixes a compile error when having installed a recent
version of OpenSSL on the system which does not provide SSLv2 at all.