### PR TITLE
do not log Foxx store updates with log level info, as the message doe…

### DIFF
--- a/js/common/modules/@arangodb/foxx/store.js
+++ b/js/common/modules/@arangodb/foxx/store.js
@@ -160,7 +160,7 @@ var updateFishbowlFromZip = function (filename) {
         }
       });
 
-      require('console').log('Updated local foxx repository with ' + toSave.length + ' service(s)');
+      require('console').debug('Updated local foxx repository with ' + toSave.length + ' service(s)');
     }
   } catch (err) {
     if (tempPath !== undefined && tempPath !== '') {
@@ -328,7 +328,7 @@ var update = function () {
     var result = download(url, '', {
       method: 'get',
       followRedirects: true,
-      timeout: 30
+      timeout: 15
     }, filename);
 
     if (result.code < 200 || result.code > 299) {


### PR DESCRIPTION
…s not provide any value to the end user

  additionally, decrease the timeout for fetching data from the Foxx Github store from 30 to 15 seconds so in case the outgoing request is blocked by a firewall etc, it will not be blocked for so long
