### PR TITLE
Updated paths to fit ArangoDB v3

### DIFF
--- a/Documentation/Books/Cookbook/Compiling/Debian.md
+++ b/Documentation/Books/Cookbook/Compiling/Debian.md
@@ -220,11 +220,11 @@ The server will by default be installed in
 
 The configuration file will be installed in
 
-    /usr/local/etc/arangodb/arangod.conf
+    /usr/local/etc/arangodb3/arangod.conf
 
 The database will be installed in
 
-    /usr/local/var/lib/arangodb
+    /usr/local/var/lib/arangodb3
 
 The ArangoShell will be installed in
 


### PR DESCRIPTION
Port from [3.3](https://github.com/arangodb/arangodb/pull/5442) to devel