### PR TITLE
fix read-only tests

### DIFF
--- a/js/client/modules/@arangodb/testsuites/readOnly.js
+++ b/js/client/modules/@arangodb/testsuites/readOnly.js
@@ -120,12 +120,12 @@ function readOnly (options) {
 
     // database with only collection access
     [200, 'get', '/_db/testdb2/_api/document/testcol2/one', 'test', {}],
-    [403, 'get', '/_db/testdb2/_api/document/testcol3/one', 'test', {}],
+    [200, 'get', '/_db/testdb2/_api/document/testcol3/one', 'test', {}],
     [403, 'post', '/_db/testdb2/_api/document/testcol2', 'test', {_key: 'wxyz'}],
     [403, 'post', '/_db/testdb2/_api/document/testcol3', 'test', {_key: 'wxyz'}],
 
     [200, 'get', '/_db/testdb2/_api/document/testcol2/one', 'test2', {}],
-    [403, 'get', '/_db/testdb2/_api/document/testcol3/one', 'test2', {}],
+    [200, 'get', '/_db/testdb2/_api/document/testcol3/one', 'test2', {}],
     [202, 'post', '/_db/testdb2/_api/document/testcol2', 'test2', {_key: 'wxyz'}],
     [403, 'post', '/_db/testdb2/_api/document/testcol3', 'test2', {_key: 'wxyz'}],
 

--- a/js/client/modules/@arangodb/testsuites/readOnly.js
+++ b/js/client/modules/@arangodb/testsuites/readOnly.js
@@ -197,7 +197,8 @@ function readOnly (options) {
 
 exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc) {
   testFns['readOnly'] = readOnly;
-
+  defaultFns.push('readOnly');
+  
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
 };


### PR DESCRIPTION
According to the CHANGELOG, the permission resolution has been changed in devel as follows:

  The new fallback rule for collections for which an access level is not explicitly specified:
  Choose the higher access level of:
    * Any wildcard access grant in the same database, or on "*/*"
    * The access level for the current database
    * The access level for the `_system` database

Please note that for legal reasons we require you to sign the 
[Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
