### PR TITLE
introduce target to locate the testsuite for a given testcase filename

### DIFF
--- a/js/client/modules/@arangodb/test-utils.js
+++ b/js/client/modules/@arangodb/test-utils.js
@@ -469,7 +469,7 @@ function splitBuckets (options, cases) {
 function doOnePathInner (path) {
   return _.filter(fs.list(makePathUnix(path)),
                   function (p) {
-                    return (p.substr(-3) === '.js');
+                    return (p.substr(-3) === '.js') || (p.substr(-3) === '.rb');;
                   })
     .map(function (x) {
       return fs.join(makePathUnix(path), x);

--- a/js/client/modules/@arangodb/testing.js
+++ b/js/client/modules/@arangodb/testing.js
@@ -26,7 +26,11 @@
 // //////////////////////////////////////////////////////////////////////////////
 
 let functionsDocumentation = {
-  'all': 'run all tests (marked with [x])'
+  'all': 'run all tests (marked with [x])',
+  'find': 'searches all testcases, and eventually filters them by `--test`, ' +
+    'will dump testcases associated to testsuites.',
+  'auto': 'uses find; if the testsuite for the testcase is located, ' +
+    'runs the suite with the filter applied'
 };
 
 let optionsDocumentation = [
@@ -158,6 +162,7 @@ const yaml = require('js-yaml');
 
 const pu = require('@arangodb/process-utils');
 const cu = require('@arangodb/crash-utils');
+const tu = require('@arangodb/test-utils');
 
 const BLUE = require('internal').COLORS.COLOR_BLUE;
 const CYAN = require('internal').COLORS.COLOR_CYAN;
@@ -404,6 +409,115 @@ function printUsage () {
   }
 }
 
+
+
+let allTestPaths = {};
+
+function findTestCases(options) {
+  let filterTestcases = (options.hasOwnProperty('test') && (typeof (options.test) !== 'undefined'));
+  let found = !filterTestcases;
+  let allTestFiles = {};
+  for (let testSuiteName in allTestPaths) {
+    var myList = [];
+    for (let i = 0; i < allTestPaths[testSuiteName].length; i++) {
+      let files =  tu.scanTestPath(allTestPaths[testSuiteName][i]);
+      if (options.hasOwnProperty('test') && (typeof (options.test) !== 'undefined')) {
+        for (let j = 0; j < files.length; j++) {
+          let foo = {};
+          // print(files[j])
+          if (tu.filterTestcaseByOptions(files[j], options, foo)) {
+            myList.push(files[j]);
+            found = true;
+          }
+        }
+      } else {
+        myList = myList.concat(files);
+      }
+      if (!filterTestcases || (myList.length > 0)) {
+        allTestFiles[testSuiteName] = myList;
+      }
+    }
+  }
+  // print(allTestPaths)
+  return [found, allTestFiles];
+}
+
+function findTest(options) {
+  let rc = findTestCases(options);
+  if (rc[0]) {
+    print(rc[1]);
+    return {
+      findTest: {
+        status: true,
+        total: 1,
+        message: 'we have found a test. see above.',
+        duration: 2,
+        failed: [],
+        found: {
+          status: true,
+          duration: 1,
+          message: 'we have found a test.'
+        }
+      }
+    };
+  } else {
+    return {
+      findTest: {
+        status: false,
+        total: 1,
+        failed: 1,
+        message: 'we haven\'t found a test.',
+        duration: 2,
+        found: {
+          status: false,
+          duration: 1,
+          message: 'we haven\'t found a test.'
+        }
+      }
+    };
+  }
+}
+
+
+function autoTest(options) {
+  if (!options.hasOwnProperty('test') || (typeof (options.test) === 'undefined')) {
+    return {
+      findTest: {
+        status: false,
+        total: 1,
+        failed: 1,
+        message: 'you must specify a --test filter.',
+        duration: 2,
+        found: {
+          status: false,
+          duration: 1,
+          message: 'you must specify a --test filter.'
+        }
+      }
+    };
+  }
+  let rc = findTestCases(options);
+  if (rc[0]) {
+    let testSuites = Object.keys(rc[1]);
+    return iterateTests(testSuites, options, true);
+  } else {
+    return {
+      findTest: {
+        status: false,
+        total: 1,
+        failed: 1,
+        message: 'we haven\'t found a test.',
+        duration: 2,
+        found: {
+          status: false,
+          duration: 1,
+          message: 'we haven\'t found a test.'
+        }
+      }
+    };
+  }
+}
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief load the available testsuites
 // //////////////////////////////////////////////////////////////////////////////
@@ -419,45 +533,20 @@ function loadTestSuites () {
                                                              allTests,
                                                              optionsDefaults,
                                                              functionsDocumentation,
-                                                             optionsDocumentation);
+                                                             optionsDocumentation,
+                                                             allTestPaths);
     } catch (x) {
       print('failed to load module ' + testSuites[j]);
       throw x;
     }
   }
+  testFuncs['find'] = findTest;
+  testFuncs['auto'] = autoTest;
 }
 
-// //////////////////////////////////////////////////////////////////////////////
-// / @brief framework to perform unittests
-// /
-// / This function gets one or two arguments, the first describes which tests
-// / to perform and the second is an options object. For `which` the following
-// / values are allowed:
-// /  Empty will give you a complete list.
-// //////////////////////////////////////////////////////////////////////////////
+let globalStatus = true;
 
-function unitTest (cases, options) {
-  if (typeof options !== 'object') {
-    options = {};
-  }
-  loadTestSuites();
-  _.defaults(options, optionsDefaults);
-
-  if (cases === undefined || cases.length === 0) {
-    printUsage();
-
-    print('FATAL: "which" is undefined\n');
-
-    return {
-      status: false,
-      crashed: false
-    };
-  }
-
-  pu.setupBinaries(options.build, options.buildType, options.configDir);
-  const jsonReply = options.jsonReply;
-  delete options.jsonReply;
-
+function iterateTests(cases, options, jsonReply) {
   // tests to run
   let caselist = [];
 
@@ -481,7 +570,6 @@ function unitTest (cases, options) {
     }
   }
 
-  let globalStatus = true;
   let results = {};
   let cleanup = true;
     
@@ -556,7 +644,41 @@ function unitTest (cases, options) {
       print(RED + require('internal').inspect(results) + RESET);
     }
   }
+  return results;
+}
 
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief framework to perform unittests
+// /
+// / This function gets one or two arguments, the first describes which tests
+// / to perform and the second is an options object. For `which` the following
+// / values are allowed:
+// /  Empty will give you a complete list.
+// //////////////////////////////////////////////////////////////////////////////
+
+function unitTest (cases, options) {
+  if (typeof options !== 'object') {
+    options = {};
+  }
+  loadTestSuites();
+  _.defaults(options, optionsDefaults);
+
+  if (cases === undefined || cases.length === 0) {
+    printUsage();
+
+    print('FATAL: "which" is undefined\n');
+
+    return {
+      status: false,
+      crashed: false
+    };
+  }
+
+  pu.setupBinaries(options.build, options.buildType, options.configDir);
+  const jsonReply = options.jsonReply;
+  delete options.jsonReply;
+
+  let results = iterateTests(cases, options, jsonReply);
   if (jsonReply === true) {
     return results;
   } else {

--- a/js/client/modules/@arangodb/testsuites/agency.js
+++ b/js/client/modules/@arangodb/testsuites/agency.js
@@ -33,12 +33,16 @@ const optionsDocumentation = [
 
 const tu = require('@arangodb/test-utils');
 
+const testPaths = {
+  'agency': ['js/client/tests/agency']
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief agency tests
 // //////////////////////////////////////////////////////////////////////////////
 
 function agency (options) {
-  let testCases = tu.scanTestPath('js/client/tests/agency');
+  let testCases = tu.scanTestPath(testPaths.agency[0]);
 
   let saveAgency = options.agency;
   let saveCluster = options.cluster;
@@ -54,11 +58,10 @@ function agency (options) {
   return results;
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['agency'] = agency;
   defaultFns.push('agency');
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/aql.js
+++ b/js/client/modules/@arangodb/testsuites/aql.js
@@ -39,14 +39,21 @@ const optionsDocumentation = [
 const _ = require('lodash');
 const tu = require('@arangodb/test-utils');
 
+const testPaths = {
+  'shell_client': [ 'js/common/tests/shell', 'js/client/tests/http', 'js/client/tests/shell' ],
+  'shell_server': [ 'js/common/tests/shell', 'js/server/tests/shell' ],
+  'shell_server_only': [ 'js/server/tests/shell' ],
+  'shell_server_aql': [ 'js/server/tests/aql' ]
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: shell_client
 // //////////////////////////////////////////////////////////////////////////////
 
 function shellClient (options) {
-  let testCases = tu.scanTestPath('js/common/tests/shell');
-  testCases = testCases.concat(tu.scanTestPath('js/client/tests/http'));
-  testCases = testCases.concat(tu.scanTestPath('js/client/tests/shell'));
+  let testCases = tu.scanTestPath(testPaths.shell_client[0]);
+  testCases = testCases.concat(tu.scanTestPath(testPaths.shell_client[1]));
+  testCases = testCases.concat(tu.scanTestPath(testPaths.shell_client[2]));
 
   return tu.performTests(options, testCases, 'shell_client', tu.runInArangosh);
 }
@@ -58,8 +65,8 @@ function shellClient (options) {
 function shellServer (options) {
   options.propagateInstanceInfo = true;
 
-  let testCases = tu.scanTestPath('js/common/tests/shell');
-  testCases = testCases.concat(tu.scanTestPath('js/server/tests/shell'));
+  let testCases = tu.scanTestPath(testPaths.shell_server[0]);
+  testCases = testCases.concat(tu.scanTestPath(testPaths.shell_server[1]));
 
   return tu.performTests(options, testCases, 'shell_server', tu.runThere);
 }
@@ -69,7 +76,7 @@ function shellServer (options) {
 // //////////////////////////////////////////////////////////////////////////////
 
 function shellServerOnly (options) {
-  let testCases = tu.scanTestPath('js/server/tests/shell');
+  let testCases = tu.scanTestPath(testPaths.shell_server_only[0]);
 
   return tu.performTests(options, testCases, 'shell_server_only', tu.runThere);
 }
@@ -83,7 +90,7 @@ function shellServerAql (options) {
   let name = 'shell_server_aql';
 
   if (!options.skipAql) {
-    testCases = tu.scanTestPath('js/server/tests/aql');
+    testCases = tu.scanTestPath(testPaths.shell_server_aql[0]);
     if (options.skipRanges) {
       testCases = _.filter(testCases,
                            function (p) { return p.indexOf('ranges-combined') === -1; });
@@ -103,7 +110,8 @@ function shellServerAql (options) {
   };
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['shell_client'] = shellClient;
   testFns['shell_server'] = shellServer;
   testFns['shell_server_aql'] = shellServerAql;
@@ -118,6 +126,4 @@ function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/arangobench.js
+++ b/js/client/modules/@arangodb/testsuites/arangobench.js
@@ -45,6 +45,10 @@ const RED = require('internal').COLORS.COLOR_RED;
 const RESET = require('internal').COLORS.COLOR_RESET;
 // const YELLOW = require('internal').COLORS.COLOR_YELLOW;
 
+const testPaths = {
+  'arangobench': []
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: arangobench
 // //////////////////////////////////////////////////////////////////////////////
@@ -233,7 +237,8 @@ function arangobench (options) {
   return results;
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['arangobench'] = arangobench;
 
   defaultFns.push('arangobench');
@@ -243,6 +248,4 @@ function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/arangosh.js
+++ b/js/client/modules/@arangodb/testsuites/arangosh.js
@@ -50,6 +50,10 @@ const optionsDocumentation = [
   '   - `skipShebang`: if set, the shebang tests are skipped.'
 ];
 
+const testPaths = {
+  'arangosh': []
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: arangosh
 // //////////////////////////////////////////////////////////////////////////////
@@ -235,7 +239,8 @@ function arangosh (options) {
   return ret;
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['arangosh'] = arangosh;
 
   defaultFns.push('arangosh');
@@ -244,6 +249,4 @@ function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/authentication.js
+++ b/js/client/modules/@arangodb/testsuites/authentication.js
@@ -48,6 +48,12 @@ const RESET = require('internal').COLORS.COLOR_RESET;
 
 const download = require('internal').download;
 
+const testPaths = {
+  'authentication': ['js/client/tests/authentication'],
+  'authentication_server': ['js/client/tests/authentication'],
+  'authentication_parameters': []
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: authentication
 // //////////////////////////////////////////////////////////////////////////////
@@ -64,7 +70,7 @@ function authenticationClient (options) {
   }
 
   print(CYAN + 'Client Authentication tests...' + RESET);
-  let testCases = tu.scanTestPath('js/client/tests/authentication');
+  let testCases = tu.scanTestPath(testPaths.authentication[0]);
 
   return tu.performTests(options, testCases, 'authentication', tu.runInArangosh, {
     'server.authentication': 'true',
@@ -74,7 +80,7 @@ function authenticationClient (options) {
 }
 
 function authenticationServer (options) {
-  let testCases = tu.scanTestPath('js/server/tests/authentication');
+  let testCases = tu.scanTestPath(testPaths.authentication_server[0]);
   if ((testCases.length === 0) || (options.skipAuthentication === true)) {
     print('skipping Authentication tests!');
     return {
@@ -262,7 +268,8 @@ function authenticationParameters (options) {
   return results;
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['authentication'] = authenticationClient;
   testFns['authentication_server'] = authenticationServer;
   testFns['authentication_parameters'] = authenticationParameters;
@@ -275,6 +282,4 @@ function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/backup.js
+++ b/js/client/modules/@arangodb/testsuites/backup.js
@@ -59,6 +59,13 @@ const asRoot = {
 const syssys = 'systemsystem';
 const sysNoSys = 'systemnosystem';
 
+const testPaths = {
+  'BackupNoAuthSysTests': ['js/server/tests/backup/backup-system-incl-system.js'],
+  'BackupNoAuthNoSysTests': ['js/server/tests/backup/backup-system-excl-system.js'],
+  'BackupAuthSysTests': ['js/server/tests/backup/backup-system-incl-system.js'],
+  'BackupAuthNoSysTests': ['js/server/tests/backup/backup-system-excl-system.js']
+};
+
 const failPreStartMessage = (msg) => {
   return {
     state: false,
@@ -147,7 +154,6 @@ const setServerOptions = (options, serverOptions, customInstanceInfos, startStop
 
   startStopHandlers['path'] = path;
 
-  const auth = { };
   if (startStopHandlers.useAuth) {
     serverOptions['server.authentication'] = 'true';
     serverOptions['server.jwt-secret'] = 'haxxmann';
@@ -204,7 +210,7 @@ const BackupNoAuthSysTests = (options) => {
   };
 
   return tu.performTests(options,
-                         ['js/server/tests/backup/backup-system-incl-system.js'],
+                         testPaths.BackupNoAuthSysTests,
                          'BackupNoAuthSysTests',
                          tu.runInArangosh, {},
                          startStopHandlers);
@@ -226,7 +232,7 @@ const BackupNoAuthNoSysTests = (options) => {
   };
 
   return tu.performTests(options,
-                         ['js/server/tests/backup/backup-system-excl-system.js'],
+                         testPaths.BackupNoAuthNoSysTests,
                          'BackupNoAuthNoSysTests',
                          tu.runInArangosh, {},
                          startStopHandlers);
@@ -248,7 +254,7 @@ const BackupAuthSysTests = (options) => {
   };
 
   return tu.performTests(options,
-                         ['js/server/tests/backup/backup-system-incl-system.js'],
+                         testPaths.BackupAuthSysTests,
                          'BackupAuthSysTests',
                          tu.runInArangosh, {},
                          startStopHandlers);
@@ -270,13 +276,14 @@ const BackupAuthNoSysTests = (options) => {
   };
 
   return tu.performTests(options,
-                         ['js/server/tests/backup/backup-system-excl-system.js'],
+                         testPaths.BackupAuthNoSysTests,
                          'BackupAuthNoSysTests',
                          tu.runInArangosh, {},
                          startStopHandlers);
 };
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['BackupNoAuthSysTests'] = BackupNoAuthSysTests;
   testFns['BackupNoAuthNoSysTests'] = BackupNoAuthNoSysTests;
   testFns['BackupAuthSysTests'] = BackupAuthSysTests;

--- a/js/client/modules/@arangodb/testsuites/catch.js
+++ b/js/client/modules/@arangodb/testsuites/catch.js
@@ -37,6 +37,11 @@ const optionsDocumentation = [
 const fs = require('fs');
 const pu = require('@arangodb/process-utils');
 
+const testPaths = {
+  'catch': [],
+  'boost': []
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: Catch
 // //////////////////////////////////////////////////////////////////////////////
@@ -135,7 +140,8 @@ function catchRunner (options) {
   return results;
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['catch'] = catchRunner;
   testFns['boost'] = catchRunner;
 
@@ -147,6 +153,4 @@ function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/config.js
+++ b/js/client/modules/@arangodb/testsuites/config.js
@@ -46,6 +46,10 @@ const RESET = require('internal').COLORS.COLOR_RESET;
 const time = require('internal').time;
 const toArgv = require('internal').toArgv;
 
+const testPaths = {
+  'config': []
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: config
 // //////////////////////////////////////////////////////////////////////////////
@@ -173,11 +177,10 @@ function config (options) {
   return results;
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['config'] = config;
   defaultFns.push('config');
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/dfdb.js
+++ b/js/client/modules/@arangodb/testsuites/dfdb.js
@@ -34,6 +34,10 @@ const optionsDocumentation = [
 const fs = require('fs');
 const pu = require('@arangodb/process-utils');
 
+const testPaths = {
+  'dfdb': []
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: dfdb
 // //////////////////////////////////////////////////////////////////////////////
@@ -64,11 +68,10 @@ function dfdb (options) {
   return results;
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['dfdb'] = dfdb;
   defaultFns.push('dfdb');
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -41,6 +41,10 @@ const CYAN = require('internal').COLORS.COLOR_CYAN;
 const RESET = require('internal').COLORS.COLOR_RESET;
 // const YELLOW = require('internal').COLORS.COLOR_YELLOW;
 
+const testPaths = {
+  'dump': 'js/server/tests/dump/' // we have to be fuzzy here...
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: dump
 // //////////////////////////////////////////////////////////////////////////////
@@ -160,11 +164,10 @@ function dump (options) {
   return results;
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['dump'] = dump;
   defaultFns.push('dump');
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/dump_authentication.js
+++ b/js/client/modules/@arangodb/testsuites/dump_authentication.js
@@ -42,6 +42,14 @@ const CYAN = require('internal').COLORS.COLOR_CYAN;
 const RESET = require('internal').COLORS.COLOR_RESET;
 // const YELLOW = require('internal').COLORS.COLOR_YELLOW;
 
+const testPaths = {
+  'dump_authentication': [
+    'js/server/tests/dump/dump-authentication-setup.js',
+    'js/server/tests/dump/dump-authentication.js',
+    'js/server/tests/dump/dump-teardown.js'
+  ]
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: dump_authentication
 // //////////////////////////////////////////////////////////////////////////////
@@ -88,7 +96,7 @@ function dumpAuthentication (options) {
 
   let results = { failed: 1 };
   results.setup = tu.runInArangosh(options, instanceInfo,
-    tu.makePathUnix('js/server/tests/dump/dump-authentication-setup.js'),
+    tu.makePathUnix(testPaths.dump_authentication[0]),
     auth2);
   results.setup.failed = 1;
 
@@ -124,7 +132,7 @@ function dumpAuthentication (options) {
         print(CYAN + Date() + ': Dump and Restore - dump after restore' + RESET);
 
         results.test = tu.runInArangosh(authOpts, instanceInfo,
-          tu.makePathUnix('js/server/tests/dump/dump-authentication.js'), {
+          tu.makePathUnix(testPaths.dump_authentication[1]), {
             'server.database': 'UnitTestsDumpDst'
           });
         results.test.failed = 1;
@@ -135,7 +143,7 @@ function dumpAuthentication (options) {
           print(CYAN + Date() + ': Dump and Restore - teardown' + RESET);
 
           results.tearDown = tu.runInArangosh(options, instanceInfo,
-            tu.makePathUnix('js/server/tests/dump/dump-teardown.js'), auth2);
+            tu.makePathUnix(testPaths.dump_authentication[2]), auth2);
 
           results.tearDown.failed = 1;
           if (results.tearDown.status) {
@@ -156,12 +164,11 @@ function dumpAuthentication (options) {
   return results;
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['dump_authentication'] = dumpAuthentication;
   defaultFns.push('dump_authentication');
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/dump_encrypted.js
+++ b/js/client/modules/@arangodb/testsuites/dump_encrypted.js
@@ -29,7 +29,7 @@ const functionsDocumentation = {
   'dump_encrypted': 'encrypted dump tests'
 };
 const optionsDocumentation = [
-  '   - `skipEncrypted` : if set to true the encryption tests are skipped',
+  '   - `skipEncrypted` : if set to true the encryption tests are skipped'
 ];
 
 const pu = require('@arangodb/process-utils');
@@ -40,7 +40,11 @@ const _ = require('lodash');
 const CYAN = require('internal').COLORS.COLOR_CYAN;
 const RESET = require('internal').COLORS.COLOR_RESET;
 
-function dumpEncrypted(options) {
+const testPaths = {
+  'dump_encrypted': ['js/server/tests/dump/'] // we have to be fuzzy here...
+};
+
+function dumpEncrypted (options) {
   let cluster;
 
   if (options.cluster) {
@@ -48,7 +52,7 @@ function dumpEncrypted(options) {
   } else {
     cluster = '';
   }
-  
+
   if (options.skipEncrypted === true) {
     print('skipping encryption tests!');
     return {
@@ -145,7 +149,8 @@ function dumpEncrypted(options) {
   return results;
 }
 
-function setup(testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   // turn off encryption tests by default. only enable them in enterprise version
   opts['skipEncrypted'] = true;
   let version = {};
@@ -159,6 +164,4 @@ function setup(testFns, defaultFns, opts, fnDocs, optionsDoc) {
   defaultFns.push('dump_encrypted');
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/endpoints.js
+++ b/js/client/modules/@arangodb/testsuites/endpoints.js
@@ -45,6 +45,10 @@ const CYAN = require('internal').COLORS.COLOR_CYAN;
 const RESET = require('internal').COLORS.COLOR_RESET;
 // const YELLOW = require('internal').COLORS.COLOR_YELLOW;
 
+const testPaths = {
+  'endpoints': ['js/client/tests/endpoint-spec.js']
+};
+
 function endpoints (options) {
   print(CYAN + 'Endpoints tests...' + RESET);
 
@@ -92,7 +96,7 @@ function endpoints (options) {
           };
         }
 
-        let result = tu.runInArangosh(options, instanceInfo, 'js/client/tests/endpoint-spec.js');
+        let result = tu.runInArangosh(options, instanceInfo, testPaths.endpoints[0]);
 
         print(CYAN + 'Shutting down...' + RESET);
         // mop: mehhh...when launched with a socket we can't use download :S
@@ -111,7 +115,8 @@ function endpoints (options) {
   }, {});
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['endpoints'] = endpoints;
 
   opts['skipEndpoints'] = false;
@@ -120,6 +125,4 @@ function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/export.js
+++ b/js/client/modules/@arangodb/testsuites/export.js
@@ -45,6 +45,10 @@ const RESET = require('internal').COLORS.COLOR_RESET;
 
 const toArgv = require('internal').toArgv;
 
+const testPaths = {
+  'export': ['js/server/tests/export/'] // we have to be fuzzy...
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: export
 // //////////////////////////////////////////////////////////////////////////////
@@ -211,11 +215,10 @@ function exportTest (options) {
   return shutdown();
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['export'] = exportTest;
   defaultFns.push('export');
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/fail.js
+++ b/js/client/modules/@arangodb/testsuites/fail.js
@@ -35,6 +35,11 @@ const optionsDocumentation = [
 const fs = require('fs');
 const pu = require('@arangodb/process-utils');
 
+const testPaths = {
+  'fail': [],
+  'success': []
+};
+
 function fail (options) {
   const tmpDataDir = fs.getTempFile();
   fs.makeDirectoryRecursive(tmpDataDir);
@@ -114,12 +119,11 @@ function success (options) {
   };
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['fail'] = fail;
   testFns['success'] = success;
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/foxxmanager.js
+++ b/js/client/modules/@arangodb/testsuites/foxxmanager.js
@@ -35,6 +35,10 @@ const optionsDocumentation = [
 const pu = require('@arangodb/process-utils');
 const fs = require('fs');
 
+const testPaths = {
+  'foxx_manager': []
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: foxx manager
 // //////////////////////////////////////////////////////////////////////////////
@@ -71,10 +75,9 @@ function foxxManager (options) {
 
   return results;
 }
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['foxx_manager'] = foxxManager;
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/importing.js
+++ b/js/client/modules/@arangodb/testsuites/importing.js
@@ -35,6 +35,15 @@ const pu = require('@arangodb/process-utils');
 const tu = require('@arangodb/test-utils');
 const yaml = require('js-yaml');
 
+const testPaths = {
+  'importing': [
+    'js/server/tests/import/import-setup.js',
+    'js/server/tests/import/import.js',
+    'js/server/tests/import/import-teardown.js',
+    'js/common/test-data/import/' // our testdata...
+  ]
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: importing
 // //////////////////////////////////////////////////////////////////////////////
@@ -202,7 +211,7 @@ function importing (options) {
 
   try {
     result.setup = tu.runInArangosh(options, instanceInfo,
-      tu.makePathUnix('js/server/tests/import/import-setup.js'));
+      tu.makePathUnix(testPaths.import[0]));
 
     result.setup.failed = 0;
     if (result.setup.status !== true) {
@@ -227,13 +236,13 @@ function importing (options) {
     result.check = tu.runInArangosh(
       options,
       instanceInfo,
-      tu.makePathUnix('js/server/tests/import/import.js'));
+      tu.makePathUnix(testPaths.import[1]));
     result.check.failed = result.check.success ? 0 : 1;
 
     result.teardown = tu.runInArangosh(
       options,
       instanceInfo,
-      tu.makePathUnix('js/server/tests/import/import-teardown.js'));
+      tu.makePathUnix(testPaths.import[2]));
     result.teardown.failed = result.teardown.success ? 0 : 1;
   } catch (banana) {
     print('An exceptions of the following form was caught:',
@@ -247,11 +256,10 @@ function importing (options) {
   return result;
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['importing'] = importing;
   defaultFns.push('importing');
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/ldap.js
+++ b/js/client/modules/@arangodb/testsuites/ldap.js
@@ -45,6 +45,14 @@ const CYAN = require('internal').COLORS.COLOR_CYAN;
 const RESET = require('internal').COLORS.COLOR_RESET;
 // const YELLOW = require('internal').COLORS.COLOR_YELLOW;
 
+const testPaths = {
+  'ldap': ['js/client/tests/authentication'],
+  'ldaprole': ['js/client/tests/authentication'],
+  'ldapsearch': ['js/client/tests/authentication'],
+  'ldaprolesimple': ['js/client/tests/authentication'],
+  'ldapsearchsimple': ['js/client/tests/authentication']
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief Shared conf
 // //////////////////////////////////////////////////////////////////////////////
@@ -143,7 +151,7 @@ function authenticationLdapSearchModePrefixSuffix (options) {
   }
 
   print(CYAN + 'Client LDAP Search Mode Permission tests...' + RESET);
-  let testCases = tu.scanTestPath('js/client/tests/authentication');
+  let testCases = tu.scanTestPath(testPaths.ldapsearchsimple[0]);
 
   print('Performing #4 Test: Search Mode - Simple Login Mode');
   print(opts.ldapModeSearchPrefixSuffix.conf);
@@ -167,7 +175,7 @@ function authenticationLdapSearchMode (options) {
   }
 
   print(CYAN + 'Client LDAP Search Mode Permission tests...' + RESET);
-  let testCases = tu.scanTestPath('js/client/tests/authentication');
+  let testCases = tu.scanTestPath(testPaths.ldapsearch[0]);
 
   print('Performing #2 Test: Search Mode');
   print(opts.ldapModeSearch.conf);
@@ -191,7 +199,7 @@ function authenticationLdapRolesModePrefixSuffix (options) {
   }
 
   print(CYAN + 'Client LDAP Permission tests...' + RESET);
-  let testCases = tu.scanTestPath('js/client/tests/authentication');
+  let testCases = tu.scanTestPath(testPaths.ldaprolesimple[0]);
 
   print('Performing #3 Test: Role Mode - Simple Login Mode');
   print(opts.ldapModeRolesPrefixSuffix.conf);
@@ -215,14 +223,15 @@ function authenticationLdapRolesMode (options) {
   }
 
   print(CYAN + 'Client LDAP Permission tests...' + RESET);
-  let testCases = tu.scanTestPath('js/client/tests/authentication');
+  let testCases = tu.scanTestPath(testPaths.ldaprole[0]);
 
   print('Performing #1 Test: Role Mode');
   print(opts.ldapModeRoles.conf);
   return tu.performTests(options, testCases, 'ldap', tu.runInArangosh, opts.ldapModeRoles.conf);
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   // just a convenicen wrapper for the regular tests
   testFns['ldap'] = [ 'ldaprole', 'ldaprole', 'ldapsearch', 'ldaprolesimple', 'ldapsearchsimple' ];
 
@@ -245,6 +254,4 @@ function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/perf.js
+++ b/js/client/modules/@arangodb/testsuites/perf.js
@@ -33,19 +33,22 @@ const optionsDocumentation = [
 
 const tu = require('@arangodb/test-utils');
 
+const testPaths = {
+  'shell_server_perf': ['js/server/perftests']
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: shell_server_perf
 // //////////////////////////////////////////////////////////////////////////////
 
 function shellServerPerf (options) {
-  let testCases = tu.scanTestPath('js/server/perftests');
+  let testCases = tu.scanTestPath(testPaths.shell_server_perf[0]);
   return tu.performTests(options, testCases, 'shell_server_perf', tu.runThere);
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['shell_server_perf'] = shellServerPerf;
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/queryCacheAuthorization.js
+++ b/js/client/modules/@arangodb/testsuites/queryCacheAuthorization.js
@@ -42,6 +42,10 @@ const CYAN = require('internal').COLORS.COLOR_CYAN;
 const RESET = require('internal').COLORS.COLOR_RESET;
 // const YELLOW = require('internal').COLORS.COLOR_YELLOW;
 
+const testPaths = {
+  'queryCacheAuthorization': []
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: queryCacheAuthorization
 // //////////////////////////////////////////////////////////////////////////////
@@ -149,7 +153,8 @@ function queryCacheAuthorization (options) {
   return results;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['queryCacheAuthorization'] = queryCacheAuthorization;
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }

--- a/js/client/modules/@arangodb/testsuites/readOnly.js
+++ b/js/client/modules/@arangodb/testsuites/readOnly.js
@@ -42,6 +42,10 @@ const CYAN = require('internal').COLORS.COLOR_CYAN;
 const RESET = require('internal').COLORS.COLOR_RESET;
 // const YELLOW = require('internal').COLORS.COLOR_YELLOW;
 
+const testPaths = {
+  'readOnly': []
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: readOnly
 // //////////////////////////////////////////////////////////////////////////////
@@ -185,7 +189,24 @@ function readOnly (options) {
     /* let res = db._query("for u in _users filter u.user == 'test' return u").toArray();
        print(res); */`
   ]);
-
+  if (res.status !== true) {
+    pu.shutdownInstance(adbInstance, options);
+    return {
+      readOnly : {
+        status: false,
+        total: 1,
+        message: 'the readonly suite failed to setup the environment.',
+        duration: 2,
+        failed: 1,
+        failTest: {
+          status: false,
+          total: 1,
+          duration: 1,
+          message: 'the readonly suite failed to setup the environment.'
+        }
+      }
+    };
+  }
   let bodies = run(requests.splice(0, 4));
   requests[0][2] += bodies.pop().indexes.filter(idx => idx.type === 'hash')[0].id;
   run(requests);
@@ -195,7 +216,8 @@ function readOnly (options) {
   return results;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['readOnly'] = readOnly;
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }

--- a/js/client/modules/@arangodb/testsuites/recovery.js
+++ b/js/client/modules/@arangodb/testsuites/recovery.js
@@ -41,6 +41,10 @@ const toArgv = require('internal').toArgv;
 const RED = require('internal').COLORS.COLOR_RED;
 const RESET = require('internal').COLORS.COLOR_RESET;
 
+const testPaths = {
+  'recovery': ['js/server/tests/recovery']
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: recovery
 // //////////////////////////////////////////////////////////////////////////////
@@ -118,7 +122,7 @@ function recovery (options) {
 
   let status = true;
 
-  let recoveryTests = tu.scanTestPath('js/server/tests/recovery');
+  let recoveryTests = tu.scanTestPath(testPaths.recovery[0]);
 
   recoveryTests = tu.splitBuckets(options, recoveryTests);
 
@@ -172,10 +176,9 @@ function recovery (options) {
   };
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['recovery'] = recovery;
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/replication.js
+++ b/js/client/modules/@arangodb/testsuites/replication.js
@@ -1,5 +1,4 @@
 /* jshint strict: false, sub: true */
-/* global arango */
 'use strict';
 
 // //////////////////////////////////////////////////////////////////////////////
@@ -41,12 +40,22 @@ const _ = require('lodash');
 const pu = require('@arangodb/process-utils');
 const tu = require('@arangodb/test-utils');
 
+const testPaths = {
+  'shell_replication': ['js/common/tests/replication'],
+  'replication_aql': ['js/server/tests/replication/'],
+  'replication_fuzz': ['js/server/tests/replication/'],
+  'replication_random': ['js/server/tests/replication/'],
+  'replication_ongoing': ['js/server/tests/replication/'],
+  'replication_static': ['js/server/tests/replication/'],
+  'replication_sync': ['js/server/tests/replication/']
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: shell_replication
 // //////////////////////////////////////////////////////////////////////////////
 
 function shellReplication (options) {
-  let testCases = tu.scanTestPath('js/common/tests/replication');
+  let testCases = tu.scanTestPath(testPaths.shell_replication[0]);
 
   var opts = {
     'replication': true
@@ -61,7 +70,7 @@ function shellReplication (options) {
 // //////////////////////////////////////////////////////////////////////////////
 
 function replicationFuzz (options) {
-  let testCases = tu.scanTestPath('js/server/tests/replication/');
+  let testCases = tu.scanTestPath(testPaths.replication_fuzz[0]);
 
   options.replication = true;
   options.test = 'replication-fuzz';
@@ -120,7 +129,7 @@ function replicationFuzz (options) {
 // //////////////////////////////////////////////////////////////////////////////
 
 function replicationRandom (options) {
-  let testCases = tu.scanTestPath('js/server/tests/replication/');
+  let testCases = tu.scanTestPath(testPaths.replication_random[0]);
 
   options.replication = true;
   options.test = 'replication-random';
@@ -179,7 +188,7 @@ function replicationRandom (options) {
 // //////////////////////////////////////////////////////////////////////////////
 
 function replicationAql (options) {
-  let testCases = tu.scanTestPath('js/server/tests/replication/');
+  let testCases = tu.scanTestPath(testPaths.replication_aql[0]);
 
   options.replication = true;
   options.test = 'replication-aql';
@@ -238,7 +247,7 @@ function replicationAql (options) {
 // //////////////////////////////////////////////////////////////////////////////
 
 function replicationOngoing (options) {
-  let testCases = tu.scanTestPath('js/server/tests/replication/');
+  let testCases = tu.scanTestPath(testPaths.replication_ongoing[0]);
 
   options.replication = true;
   if (options.test === undefined) {
@@ -300,7 +309,7 @@ function replicationOngoing (options) {
 // //////////////////////////////////////////////////////////////////////////////
 
 function replicationStatic (options) {
-  let testCases = tu.scanTestPath('js/server/tests/replication/');
+  let testCases = tu.scanTestPath(testPaths.replication_static[0]);
 
   options.replication = true;
   if (options.test === undefined) {
@@ -386,7 +395,7 @@ function replicationStatic (options) {
 // //////////////////////////////////////////////////////////////////////////////
 
 function replicationSync (options) {
-  let testCases = tu.scanTestPath('js/server/tests/replication/');
+  let testCases = tu.scanTestPath(testPaths.replication_sync[0]);
 
   options.replication = true;
   if (options.test === undefined) {
@@ -458,7 +467,8 @@ function replicationSync (options) {
   return tu.performTests(options, testCases, 'replication_sync', tu.runInArangosh, {}, startStopHandlers);
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['shell_replication'] = shellReplication;
   testFns['replication_aql'] = replicationAql;
   testFns['replication_fuzz'] = replicationFuzz;
@@ -468,6 +478,4 @@ function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
   testFns['replication_sync'] = replicationSync;
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/resilience.js
+++ b/js/client/modules/@arangodb/testsuites/resilience.js
@@ -36,12 +36,19 @@ const optionsDocumentation = [
 
 const tu = require('@arangodb/test-utils');
 
+const testPaths = {
+  'resilience': ['js/server/tests/resilience'],
+  'client_resilience': ['js/client/tests/resilience'],
+  'cluster_sync': ['js/server/tests/cluster-sync'],
+  'active_failover': ['js/client/tests/active-failover']
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: resilience
 // //////////////////////////////////////////////////////////////////////////////
 
 function resilience (options) {
-  let testCases = tu.scanTestPath('js/server/tests/resilience');
+  let testCases = tu.scanTestPath(testPaths.resilience);
   options.cluster = true;
   options.propagateInstanceInfo = true;
   if (options.dbServers < 5) {
@@ -55,7 +62,7 @@ function resilience (options) {
 // //////////////////////////////////////////////////////////////////////////////
 
 function clientResilience (options) {
-  let testCases = tu.scanTestPath('js/client/tests/resilience');
+  let testCases = tu.scanTestPath(testPaths.cluster_sync[0]);
   options.cluster = true;
   if (options.coordinators < 2) {
     options.coordinators = 2;
@@ -80,12 +87,11 @@ function clusterSync (options) {
       }
     };
   }
-  let testCases = tu.scanTestPath('js/server/tests/cluster-sync');
+  let testCases = tu.scanTestPath(testPaths.cluster_sync[0]);
   options.propagateInstanceInfo = true;
 
   return tu.performTests(options, testCases, 'cluster_sync', tu.runThere);
 }
-
 
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: active failover
@@ -102,7 +108,7 @@ function activeFailover (options) {
     };
   }
 
-  let testCases = tu.scanTestPath('js/client/tests/active-failover');
+  let testCases = tu.scanTestPath(testPaths.active_failover[0]);
   options.activefailover = true;
   options.singles = 4;
   return tu.performTests(options, testCases, 'client_resilience', tu.runInArangosh, {
@@ -111,13 +117,12 @@ function activeFailover (options) {
   });
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['resilience'] = resilience;
   testFns['client_resilience'] = clientResilience;
   testFns['cluster_sync'] = clusterSync;
   testFns['active_failover'] = activeFailover;
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/rspec.js
+++ b/js/client/modules/@arangodb/testsuites/rspec.js
@@ -52,13 +52,20 @@ const RED = require('internal').COLORS.COLOR_RED;
 const RESET = require('internal').COLORS.COLOR_RESET;
 // const YELLOW = require('internal').COLORS.COLOR_YELLOW;
 
+const testPaths = {
+  'http_replication': [fs.join('UnitTests', 'HttpInterface')],
+  'http_server': [fs.join('UnitTests', 'HttpInterface')],
+  'server_http': ['js/common/tests/http'],
+  'ssl_server': [fs.join('UnitTests', 'HttpInterface')]
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: shell_http
 // //////////////////////////////////////////////////////////////////////////////
 
 function serverHttp (options) {
   // first starts to replace rspec:
-  let testCases = tu.scanTestPath('js/common/tests/http');
+  let testCases = tu.scanTestPath(testPaths.server_http[0]);
 
   return tu.performTests(options, testCases, 'server_http', tu.runThere);
 }
@@ -115,8 +122,14 @@ function rubyTests (options, ssl) {
     fs.makeDirectory(pu.LOGS_DIR);
   } catch (err) {}
 
-  let files = fs.list(fs.join('UnitTests', 'HttpInterface'));
-
+  let files = [];
+  if (ssl) {
+    print(testPaths.http_server[0])
+    files = tu.scanTestPath(testPaths.ssl_server[0]);
+  } else {
+    print(testPaths.http_server[0])
+    files = tu.scanTestPath(testPaths.http_server[0]);
+  }
   let continueTesting = true;
   let filtered = {};
   let results = {};
@@ -165,8 +178,8 @@ function rubyTests (options, ssl) {
   for (let i = 0; i < files.length; i++) {
     const te = files[i];
 
-    if (te.substr(0, 4) === 'api-' && te.substr(-3) === '.rb') {
-      let tfn = fs.join('UnitTests', 'HttpInterface', te);
+    if ((te.search('api-') !== -1) && te.substr(-3) === '.rb') {
+      let tfn = te;
       if (tu.filterTestcaseByOptions(tfn, options, filtered)) {
         count += 1;
         if (!continueTesting) {
@@ -245,7 +258,7 @@ function rubyTests (options, ssl) {
           db._collections().forEach(collection => {
             collectionsAfter.push(collection._name);
           });
-          let delta = tu.diffArray(collectionsBefore, collectionsAfter, _.isEqual).filter(function(name) {
+          let delta = tu.diffArray(collectionsBefore, collectionsAfter, _.isEqual).filter(function (name) {
             return (name[0] !== '_'); // exclude system collections from the comparison
           });
           if (delta.length !== 0) {
@@ -341,7 +354,8 @@ function sslServer (options) {
   return rubyTests(opts, true);
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['http_replication'] = httpReplication;
   testFns['http_server'] = httpServer;
   testFns['server_http'] = serverHttp;
@@ -363,6 +377,4 @@ function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/single.js
+++ b/js/client/modules/@arangodb/testsuites/single.js
@@ -37,6 +37,11 @@ const optionsDocumentation = [
 const pu = require('@arangodb/process-utils');
 const tu = require('@arangodb/test-utils');
 
+const testPaths = {
+  'single_server': [],
+  'single_client': []
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: single_client
 // //////////////////////////////////////////////////////////////////////////////
@@ -154,11 +159,10 @@ function singleServer (options) {
   return result;
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['single_server'] = singleServer;
   testFns['single_client'] = singleClient;
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/stress.js
+++ b/js/client/modules/@arangodb/testsuites/stress.js
@@ -40,6 +40,12 @@ const yaml = require('js-yaml');
 const download = require('internal').download;
 const wait = require('internal').wait;
 
+const testPaths = {
+  'stress_crud': [],
+  'stress_killing': [],
+  'stress_locks': []
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief runs a stress test on arangod
 // //////////////////////////////////////////////////////////////////////////////
@@ -194,13 +200,12 @@ function stressLocks (options) {
   return runStressTest(options, command, 'stress_lock');
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['stress_crud'] = stressCrud;
   testFns['stress_killing'] = stressKilling;
   testFns['stress_locks'] = stressLocks;
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};

--- a/js/client/modules/@arangodb/testsuites/upgrade.js
+++ b/js/client/modules/@arangodb/testsuites/upgrade.js
@@ -36,6 +36,10 @@ const toArgv = require('internal').toArgv;
 const fs = require('fs');
 const pu = require('@arangodb/process-utils');
 
+const testPaths = {
+  'upgrade': []
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief TEST: upgrade
 // //////////////////////////////////////////////////////////////////////////////
@@ -103,11 +107,10 @@ function upgrade (options) {
   return result;
 }
 
-function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
   testFns['upgrade'] = upgrade;
   defaultFns.push('upgrade');
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
-}
-
-exports.setup = setup;
+};


### PR DESCRIPTION
This PR introduces locating of testsuites for specific test files. This way the developer doesn't have to know which testcase belongs to which testsuite. 

Possible usecases: 

```
./scripts/unittest find --test UnitTests/HttpInterface/api-edges-spec.rb 
...
{ 
  "http_replication" : [ 
    "UnitTests/HttpInterface/api-edges-spec.rb" 
  ], 
  "http_server" : [ 
    "UnitTests/HttpInterface/api-edges-spec.rb" 
  ], 
  "ssl_server" : [ 
    "UnitTests/HttpInterface/api-edges-spec.rb" 
  ] 
}
```
this case shows, that we can't always have the reverse direction of usecase to valid testcase - `http_replication` won't run this test: 

```
 ./scripts/unittest auto --test UnitTests/HttpInterface/api-edges-spec.rb 
...
================================================================================
Executing test http_replication
================================================================================
...
No testcase matched the filter.
...
================================================================================
Executing test http_server
================================================================================
Tue May 29 2018 11:45:00 GMT+0200 (CEST) rspec trying UnitTests/HttpInterface/api-edges-spec.rb ...

ArangoDB
  querying edges:
    error handling:
      returns an error if vertex-handle is missing
      returns an error if vertex-handle is empty
      returns an error if collection does not exist
    known collection name:
      creating an edge
...
* Test "auto"
    [SUCCESS] http_server
    [SUCCESS] ssl_server
    [FAILED]  http_replication

      "ALLTESTS" failed: undefined
```
So while the developer has to live with some inaccuracies, this module brings him mostway there to pick a testfile and run it. 

