### PR TITLE
ui, document id not showing up when deleting a document

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.2.16 (XXXX-XX-XX)
 --------------------
 
+* fixed internal issue #2256: ui, document id not showing up when deleting a document
+
 * fixed issue #5400: Unexpected AQL Result
 
 * Fixed issue #5035: fixed a vulnerability issue within the web ui's index view

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/documentView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/documentView.js
@@ -117,7 +117,7 @@
           window.modalView.createReadOnlyEntry(
             'doc-delete-button',
             'Confirm delete, document id is',
-            this.type._id,
+            this.type._id || this.docid,
             undefined,
             undefined,
             false,


### PR DESCRIPTION
fixed internal issue https://github.com/arangodb/planning/issues/2256: ui, document id not showing up when deleting a document