### PR TITLE
Recent changes in the cmake setup broke static binaries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,10 +48,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
 option(SKIP_PACKAGING "" OFF)
-option(STATIC_EXECUTABLES "produce static executables" OFF)
-if (STATIC_EXECUTABLES)
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
-endif()
 
 # be verbose about flags used
 option(VERBOSE "be verbose about flags used" OFF)
@@ -81,6 +77,12 @@ if (WIN32)
 else ()
   project(arangodb3 LANGUAGES CXX C ASM VERSION ${ARANGODB_VERSION_MAJOR}.${ARANGODB_VERSION_MINOR})
 endif ()
+
+# Static executables:
+option(STATIC_EXECUTABLES "produce static executables" OFF)
+if (STATIC_EXECUTABLES)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+endif()
 
 # enable enterprise features
 set(ENTERPRISE_INCLUDE_DIR "enterprise")


### PR DESCRIPTION
This has to do with the order in which things happen in the CMakeLists.txt.
This PR should fix the problem, so that we have static executables again.

Please note that for legal reasons we require you to sign the 
[Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
