### PR TITLE
disable a test that leaks memory

### DIFF
--- a/tests/IResearch/IResearchViewNode-test.cpp
+++ b/tests/IResearch/IResearchViewNode-test.cpp
@@ -359,7 +359,12 @@ SECTION("clone") {
     node.shards().emplace_back("abc");
     node.shards().emplace_back("def");
 
+/*
     // clone with properties into the same plan
+    // this is actually not a good idea... cloning the same variables into 
+    // the same plan will cause resource leaks, as this test exposes.
+    // if properties are cloned, the target plan must be a different one than 
+    // the source plan
     {
       auto const nextId = node.plan()->nextId();
       auto& cloned = dynamic_cast<arangodb::iresearch::IResearchViewNode&>(
@@ -385,6 +390,7 @@ SECTION("clone") {
       CHECK(node.estimateCost(lhsNrItems) == cloned.estimateCost(rhsNrItems));
       CHECK(lhsNrItems == rhsNrItems);
     }
+*/
 
     // clone without properties into the same plan
     {


### PR DESCRIPTION
This PR disables one sub-test that leaks memory.
The reason for the leak is that `ExecutionNode::clone()` called with the `withProperties` flag set, and the source and target plans are identical.
This will clone the plan's variables and register them in the same plan. Because variables are tracked by id, and the id will not change by cloning, this produces a leak.
The place that tracks the variables has no idea about what an ExecutionPlan is, so it cannot detect that source and target plan are identical.

There are two ways to go on from here:
- adjust the test so that the target plan is not the same as the source plan
- remove the test

I leave it up to you to decide what's best.