### PR TITLE
Change label from Download to Load full graph

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/templates/graphViewer2.ejs
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/templates/graphViewer2.ejs
@@ -27,7 +27,7 @@
           </li>
           <li class="enabled">
             <a id="loadFullGraph" class="headerButton">
-              <span title="Download full graph - use with caution">
+              <span title="Load full graph - use with caution">
                 <i class="fa fa-share-alt"></i>
               </span>
             </a>


### PR DESCRIPTION
"Download" is a bit confusing, one might expect it to start a JSON file download of the graph. Internally, it was called "loadFullGraph" anyway.