### PR TITLE
disable circumventing of coredumps for windows

### DIFF
--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -407,7 +407,7 @@ function executeAndWait (cmd, args, options, valgrindTest, rootDir, circumventCo
     if (platform.substr(0, 3) !== 'win') {
       // this shellscript will prevent cores from being writen on macos and linux.
       args.unshift(cmd);
-      cmd = pu.TOP_DIR + '/scripts/disable-cores.sh';
+      cmd = TOP_DIR + '/scripts/disable-cores.sh';
     }
   }
   

--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -377,7 +377,7 @@ function makeArgsArangod (options, appDir, role, tmpDir) {
 // / @brief executes a command and waits for result
 // //////////////////////////////////////////////////////////////////////////////
 
-function executeAndWait (cmd, args, options, valgrindTest, rootDir, coreCheck = false) {
+function executeAndWait (cmd, args, options, valgrindTest, rootDir, circumventCores, coreCheck = false) {
   if (valgrindTest && options.valgrind) {
     let valgrindOpts = {};
 
@@ -403,6 +403,14 @@ function executeAndWait (cmd, args, options, valgrindTest, rootDir, coreCheck = 
     cmd = options.valgrind;
   }
 
+  if (circumventCores) {
+    if (platform.substr(0, 3) !== 'win') {
+      // this shellscript will prevent cores from being writen on macos and linux.
+      args.unshift(cmd);
+      cmd = pu.TOP_DIR + '/scripts/disable-cores.sh';
+    }
+  }
+  
   if (options.extremeVerbosity) {
     print('executeAndWait: cmd =', cmd, 'args =', args);
   }

--- a/js/client/modules/@arangodb/testsuites/catch.js
+++ b/js/client/modules/@arangodb/testsuites/catch.js
@@ -77,7 +77,7 @@ function catchRunner (options) {
         options.extremeVerbosity ? "true" : "false",
         '[exclude:longRunning][exclude:cache]'
       ];
-      results.basics = pu.executeAndWait(run, argv, options, 'all-catch', rootDir, options.coreCheck);
+      results.basics = pu.executeAndWait(run, argv, options, 'all-catch', rootDir, false, options.coreCheck);
       results.basics.failed = results.basics.status ? 0 : 1;
       if (!results.basics.status) {
         results.failed += 1;
@@ -104,7 +104,7 @@ function catchRunner (options) {
         fs.join(options.testOutputDirectory, 'catch-cache.xml')
       ];
       results.cache_suite = pu.executeAndWait(run, argv, options,
-                                              'cache_suite', rootDir, options.coreCheck);
+                                              'cache_suite', rootDir, false, options.coreCheck);
       results.cache_suite.failed = results.cache_suite.status ? 0 : 1;
       if (!results.cache_suite.status) {
         results.failed += 1;

--- a/js/client/modules/@arangodb/testsuites/config.js
+++ b/js/client/modules/@arangodb/testsuites/config.js
@@ -117,7 +117,7 @@ function config (options) {
 
     const run = fs.join(pu.BIN_DIR, test);
 
-    results.absolut[test] = pu.executeAndWait(run, toArgv(args), options, test, rootDir, options.coreCheck);
+    results.absolut[test] = pu.executeAndWait(run, toArgv(args), options, test, rootDir, false, options.coreCheck);
 
     if (!results.absolut[test].status) {
       results.absolut.status = false;
@@ -153,7 +153,7 @@ function config (options) {
 
     const run = fs.join(pu.BIN_DIR, test);
 
-    results.relative[test] = pu.executeAndWait(run, toArgv(args), options, test, rootDir, options.coreCheck);
+    results.relative[test] = pu.executeAndWait(run, toArgv(args), options, test, rootDir, false, options.coreCheck);
 
     if (!results.relative[test].status) {
       results.failed += 1;

--- a/js/client/modules/@arangodb/testsuites/dfdb.js
+++ b/js/client/modules/@arangodb/testsuites/dfdb.js
@@ -57,7 +57,7 @@ function dfdb (options) {
 
   let results = { failed: 0 };
 
-  results.dfdb = pu.executeAndWait(pu.ARANGOD_BIN, args, options, 'dfdb', dataDir, options.coreCheck);
+  results.dfdb = pu.executeAndWait(pu.ARANGOD_BIN, args, options, 'dfdb', dataDir, false, options.coreCheck);
 
   print();
   results.dfdb.failed = results.dfdb.status ? 0 : 1;

--- a/js/client/modules/@arangodb/testsuites/export.js
+++ b/js/client/modules/@arangodb/testsuites/export.js
@@ -118,7 +118,7 @@ function exportTest (options) {
   }
 
   print(CYAN + Date() + ': Export data (json)' + RESET);
-  results.exportJson = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), options, 'arangosh', tmpPath, options.coreCheck);
+  results.exportJson = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), options, 'arangosh', tmpPath, false, options.coreCheck);
   results.exportJson.failed = results.exportJson.status ? 0 : 1;
 
   try {
@@ -138,7 +138,7 @@ function exportTest (options) {
 
   print(CYAN + Date() + ': Export data (jsonl)' + RESET);
   args['type'] = 'jsonl';
-  results.exportJsonl = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), options, 'arangosh', tmpPath, options.coreCheck);
+  results.exportJsonl = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), options, 'arangosh', tmpPath, false, options.coreCheck);
   results.exportJsonl.failed = results.exportJsonl.status ? 0 : 1;
   try {
     fs.read(fs.join(tmpPath, 'UnitTestsExport.jsonl')).split('\n')
@@ -161,7 +161,7 @@ function exportTest (options) {
   print(CYAN + Date() + ': Export data (xgmml)' + RESET);
   args['type'] = 'xgmml';
   args['graph-name'] = 'UnitTestsExport';
-  results.exportXgmml = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), options, 'arangosh', tmpPath, options.coreCheck);
+  results.exportXgmml = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), options, 'arangosh', tmpPath, false, options.coreCheck);
   results.exportXgmml.failed = results.exportXgmml.status ? 0 : 1;
   try {
     const filesContent = fs.read(fs.join(tmpPath, 'UnitTestsExport.xgmml'));
@@ -192,7 +192,7 @@ function exportTest (options) {
   args['query'] = 'FOR doc IN UnitTestsExport RETURN doc';
   delete args['graph-name'];
   delete args['collection'];
-  results.exportQuery = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), options, 'arangosh', tmpPath, options.coreCheck);
+  results.exportQuery = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), options, 'arangosh', tmpPath, false, options.coreCheck);
   results.exportQuery.failed = results.exportQuery.status ? 0 : 1;
   try {
     fs.read(fs.join(tmpPath, 'query.jsonl')).split('\n')

--- a/js/client/modules/@arangodb/testsuites/recovery.js
+++ b/js/client/modules/@arangodb/testsuites/recovery.js
@@ -100,12 +100,8 @@ function runArangodRecovery (instanceInfo, options, script, setup, count) {
   ]);
 
   let binary = pu.ARANGOD_BIN;
-  if (setup) {
-    binary = pu.TOP_DIR + '/scripts/disable-cores.sh';
-    argv.unshift(pu.ARANGOD_BIN);
-  }
 
-  instanceInfo.pid = pu.executeAndWait(binary, argv, options, 'recovery', instanceInfo.rootDir, setup, !setup && options.coreCheck);
+  instanceInfo.pid = pu.executeAndWait(binary, argv, options, 'recovery', instanceInfo.rootDir, setup, setup, !setup && options.coreCheck);
 }
 
 function recovery (options) {

--- a/js/client/modules/@arangodb/testsuites/recovery.js
+++ b/js/client/modules/@arangodb/testsuites/recovery.js
@@ -101,7 +101,7 @@ function runArangodRecovery (instanceInfo, options, script, setup, count) {
 
   let binary = pu.ARANGOD_BIN;
 
-  instanceInfo.pid = pu.executeAndWait(binary, argv, options, 'recovery', instanceInfo.rootDir, setup, setup, !setup && options.coreCheck);
+  instanceInfo.pid = pu.executeAndWait(binary, argv, options, 'recovery', instanceInfo.rootDir, setup, !setup && options.coreCheck);
 }
 
 function recovery (options) {

--- a/js/client/modules/@arangodb/testsuites/upgrade.js
+++ b/js/client/modules/@arangodb/testsuites/upgrade.js
@@ -85,7 +85,7 @@ function upgrade (options) {
 
   const argv = toArgv(args);
 
-  result.upgrade.first = pu.executeAndWait(pu.ARANGOD_BIN, argv, options, 'upgrade', tmpDataDir, options.coreCheck);
+  result.upgrade.first = pu.executeAndWait(pu.ARANGOD_BIN, argv, options, 'upgrade', tmpDataDir, false, options.coreCheck);
 
   if (result.upgrade.first.status !== true) {
     result.upgrade.failed = 1;
@@ -95,7 +95,7 @@ function upgrade (options) {
 
   ++result.upgrade.total;
 
-  result.upgrade.second = pu.executeAndWait(pu.ARANGOD_BIN, argv, options, 'upgrade', tmpDataDir, options.coreCheck);
+  result.upgrade.second = pu.executeAndWait(pu.ARANGOD_BIN, argv, options, 'upgrade', tmpDataDir, false, options.coreCheck);
 
   if (result.upgrade.second.status !== true) {
     result.upgrade.failed = 1;


### PR DESCRIPTION
http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr-linux/780/  (failed because of error in linux code branch)

http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr-windows/65/ [success in terms that the restore tests ran]

http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr-linux/782/ [success]