### PR TITLE
fixed AQL DOCUMENT lookup function for documents for shard collection…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.3.11 (2018-XX-XX)
 --------------------
 
-* fixed AQL DOCUMENT lookup function for documents for shard collections with
+* fixed AQL DOCUMENT lookup function for documents for sharded collections with
   more than a single shard and using a custom shard key (i.e. some shard
   key attribute other than `_key`).
   The previous implementation of DOCUMENT restricted to lookup to a single

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,20 @@
 v3.3.11 (2018-XX-XX)
 --------------------
 
+* fixed AQL DOCUMENT lookup function for documents for shard collections with
+  more than a single shard and using a custom shard key (i.e. some shard
+  key attribute other than `_key`).
+  The previous implementation of DOCUMENT restricted to lookup to a single
+  shard in all cases, though this restriction was invalid. That lead to 
+  `DOCUMENT` not finding documents in cases the wrong shard was contacted. The
+  fixed implementation in 3.3.11 will reach out to all shards to find the
+  document, meaning it will produce the correct result, but will cause more
+  cluster-internal traffic. This increase in traffic may be high if the number
+  of shards is also high, because each invocation of `DOCUMENT` will have to
+  contact all shards.
+  There will be no performance difference for non-sharded collections or
+  collections that are sharded by `_key` or that only have a single shard.
+
 * reimplemented replication view in web UI
 
 * fixed internal issue #2256: ui, document id not showing up when deleting a document

--- a/arangod/Cluster/ClusterMethods.h
+++ b/arangod/Cluster/ClusterMethods.h
@@ -120,7 +120,7 @@ int deleteDocumentOnCoordinator(
 
 int getDocumentOnCoordinator(
     std::string const& dbname, std::string const& collname,
-    VPackSlice const slice, OperationOptions const& options,
+    VPackSlice slice, OperationOptions const& options,
     std::unique_ptr<std::unordered_map<std::string, std::string>>& headers,
     arangodb::rest::ResponseCode& responseCode,
     std::unordered_map<int, size_t>& errorCounter,

--- a/js/server/tests/aql/aql-document.js
+++ b/js/server/tests/aql/aql-document.js
@@ -1,0 +1,193 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global assertEqual, AQL_EXECUTE */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief tests for DOCUMENT function
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+let internal = require("internal");
+let db = require("@arangodb").db;
+let jsunity = require("jsunity");
+
+function ahuacatlDocumentSuite () {
+  let cn = "UnitTestsAhuacatlDocument";
+
+  return {
+
+    setUp : function () {
+      db._drop(cn);
+    },
+
+    tearDown : function () {
+      db._drop(cn);
+    },
+
+    testDocumentSingleShard : function () {
+      let c = db._create(cn, {numberOfShards: 1});
+      for (let i = 0; i < 100; ++i) {
+        c.insert({ _key: "test" + i, value: i });
+      }
+
+      for (let i = 0; i < 100; ++i) {
+        let doc = c.document("test" + i);
+        assertEqual(i, doc.value);
+        assertEqual("test" + i, doc._key);
+
+        let res = AQL_EXECUTE("RETURN DOCUMENT('" + cn + "/test" + i + "')").json;
+        doc = res[0];
+        assertEqual(i, doc.value);
+        assertEqual("test" + i, doc._key);
+      }
+    },
+    
+    testDocumentMultipleShards : function () {
+      let c = db._create(cn, {numberOfShards: 5});
+      for (let i = 0; i < 100; ++i) {
+        c.insert({ _key: "test" + i, value: i });
+      }
+
+      for (let i = 0; i < 100; ++i) {
+        let doc = c.document("test" + i);
+        assertEqual(i, doc.value);
+        assertEqual("test" + i, doc._key);
+
+        let res = AQL_EXECUTE("RETURN DOCUMENT('" + cn + "/test" + i + "')").json;
+        doc = res[0];
+        assertEqual(i, doc.value);
+        assertEqual("test" + i, doc._key);
+      }
+    },
+    
+    testDocumentSingleShardNonDefaultShardKey : function () {
+      let c = db._create(cn, {numberOfShards: 1, shardKeys: ["value"]});
+      let keys = [];
+      for (let i = 0; i < 100; ++i) {
+        keys.push(c.insert({ value: i })._key);
+      }
+
+      keys.forEach(function(key, i) {
+        let doc = c.document(key);
+        assertEqual(i, doc.value);
+        assertEqual(key, doc._key);
+
+        let res = AQL_EXECUTE("RETURN DOCUMENT('" + cn + "/" + key + "')").json;
+        doc = res[0];
+        assertEqual(i, doc.value);
+        assertEqual(key, doc._key);
+      });
+    },
+    
+    testDocumentMultipleShardsNonDefaultShardKey : function () {
+      let c = db._create(cn, {numberOfShards: 5, shardKeys: ["value"]});
+      let keys = [];
+      for (let i = 0; i < 100; ++i) {
+        keys.push(c.insert({ value: i })._key);
+      }
+
+      keys.forEach(function(key, i) {
+        let doc = c.document(key);
+        assertEqual(i, doc.value);
+        assertEqual(key, doc._key);
+
+        let res = AQL_EXECUTE("RETURN DOCUMENT('" + cn + "/" + key + "')").json;
+        doc = res[0];
+        assertEqual(i, doc.value);
+        assertEqual(key, doc._key);
+      });
+    },
+    
+    testDocumentMultipleSingleShardDefaultShardKey : function () {
+      let c = db._create(cn, {numberOfShards: 1});
+      let ids = [];
+      for (let i = 0; i < 100; ++i) {
+        ids.push(c.insert({ value: i })._id);
+      }
+
+      let res = AQL_EXECUTE("RETURN DOCUMENT(" + JSON.stringify(ids) + ")").json[0];
+      ids.forEach(function(id, i) {
+        let doc = c.document(id);
+        assertEqual(i, doc.value);
+        assertEqual(id, doc._id);
+        assertEqual(i, res[i].value);
+        assertEqual(id, res[i]._id);
+      });
+    },
+    
+    testDocumentMultipleMultipleShardsDefaultShardKey : function () {
+      let c = db._create(cn, {numberOfShards: 5});
+      let ids = [];
+      for (let i = 0; i < 100; ++i) {
+        ids.push(c.insert({ value: i })._id);
+      }
+
+      let res = AQL_EXECUTE("RETURN DOCUMENT(" + JSON.stringify(ids) + ")").json[0];
+      ids.forEach(function(id, i) {
+        let doc = c.document(id);
+        assertEqual(i, doc.value);
+        assertEqual(id, doc._id);
+        assertEqual(i, res[i].value);
+        assertEqual(id, res[i]._id);
+      });
+    },
+    
+    testDocumentMultipleSingleShardNonDefaultShardKey : function () {
+      let c = db._create(cn, {numberOfShards: 1, shardKeys: ["value"]});
+      let ids = [];
+      for (let i = 0; i < 100; ++i) {
+        ids.push(c.insert({ value: i })._id);
+      }
+
+      let res = AQL_EXECUTE("RETURN DOCUMENT(" + JSON.stringify(ids) + ")").json[0];
+      ids.forEach(function(id, i) {
+        let doc = c.document(id);
+        assertEqual(i, doc.value);
+        assertEqual(id, doc._id);
+        assertEqual(i, res[i].value);
+        assertEqual(id, res[i]._id);
+      });
+    },
+    
+    testDocumentMultipleMultipleShardsNonDefaultShardKey : function () {
+      let c = db._create(cn, {numberOfShards: 5, shardKeys: ["value"]});
+      let ids = [];
+      for (let i = 0; i < 100; ++i) {
+        ids.push(c.insert({ value: i })._id);
+      }
+
+      let res = AQL_EXECUTE("RETURN DOCUMENT(" + JSON.stringify(ids) + ")").json[0];
+      ids.forEach(function(id, i) {
+        let doc = c.document(id);
+        assertEqual(i, doc.value);
+        assertEqual(id, doc._id);
+        assertEqual(i, res[i].value);
+        assertEqual(id, res[i]._id);
+      });
+    }
+
+  };
+}
+
+jsunity.run(ahuacatlDocumentSuite);
+
+return jsunity.done();


### PR DESCRIPTION
…s with more than a single shard and using a custom shard key (i.e. some shard key attribute other than `_key`).

  The previous implementation of DOCUMENT restricted to lookup to a single
  shard in all cases, though this restriction was invalid. That lead to
  `DOCUMENT` not finding documents in cases the wrong shard was contacted. The
  fixed implementation in 3.3.11 will reach out to all shards to find the
  document, meaning it will produce the correct result, but will cause more
  cluster-internal traffic. This increase in traffic may be high if the number
  of shards is also high, because each invocation of `DOCUMENT` will have to
  contact all shards.
  There will be no performance difference for non-sharded collections or
  collections that are sharded by `_key` or that only have a single shard.