### PR TITLE
make API for POST /_api/aqlfunction downwards-compatible again

### DIFF
--- a/Documentation/DocuBlocks/Rest/AQL/post_api_aqlfunction.md
+++ b/Documentation/DocuBlocks/Rest/AQL/post_api_aqlfunction.md
@@ -34,6 +34,9 @@ boolean flag to indicate whether an error occurred (*false* in this case)
 @RESTREPLYBODY{code,integer,required,int64}
 the HTTP status code
 
+@RESTREPLYBODY{isNewlyCreated,boolean,required,}
+boolean flag to indicate whether the function was newly created (*false* in this case)
+
 @RESTRETURNCODE{201}
 If the function can be registered by the server, the server will respond with
 *HTTP 201*.
@@ -43,6 +46,9 @@ boolean flag to indicate whether an error occurred (*false* in this case)
 
 @RESTREPLYBODY{code,integer,required,int64}
 the HTTP status code
+
+@RESTREPLYBODY{isNewlyCreated,boolean,required,}
+boolean flag to indicate whether the function was newly created (*true* in this case)
 
 
 @RESTRETURNCODE{400}

--- a/UnitTests/HttpInterface/api-aqlfunction-spec.rb
+++ b/UnitTests/HttpInterface/api-aqlfunction-spec.rb
@@ -113,6 +113,7 @@ describe ArangoDB do
         doc.headers['content-type'].should eq("application/json; charset=utf-8")
         doc.parsed_response['error'].should eq(false)
         doc.parsed_response['code'].should eq(201)
+        doc.parsed_response['isNewlyCreated'].should eq(true)
       end
   
       it "add function, update" do
@@ -123,12 +124,14 @@ describe ArangoDB do
         doc.headers['content-type'].should eq("application/json; charset=utf-8")
         doc.parsed_response['error'].should eq(false)
         doc.parsed_response['code'].should eq(201)
+        doc.parsed_response['isNewlyCreated'].should eq(true)
         
         doc = ArangoDB.log_post("#{prefix}-add-function2", api, :body => body)
         doc.code.should eq(200)
         doc.headers['content-type'].should eq("application/json; charset=utf-8")
         doc.parsed_response['error'].should eq(false)
         doc.parsed_response['code'].should eq(200)
+        doc.parsed_response['isNewlyCreated'].should eq(false)
       end
       
       it "add function, delete" do
@@ -139,6 +142,7 @@ describe ArangoDB do
         doc.headers['content-type'].should eq("application/json; charset=utf-8")
         doc.parsed_response['error'].should eq(false)
         doc.parsed_response['code'].should eq(201)
+        doc.parsed_response['isNewlyCreated'].should eq(true)
         
         doc = ArangoDB.log_delete("#{prefix}-add-function3", api + "/UnitTests%3A%3Amytest")
         doc.code.should eq(200)
@@ -158,14 +162,17 @@ describe ArangoDB do
         body = "{ \"name\" : \"UnitTests::mytest::one\", \"code\": \"function () { return 1; }\" }"
         doc = ArangoDB.log_post("#{prefix}-add-function4", api, :body => body)
         doc.code.should eq(201)
+        doc.parsed_response['isNewlyCreated'].should eq(true)
         
         body = "{ \"name\" : \"UnitTests::mytest::two\", \"code\": \"function () { return 1; }\" }"
         doc = ArangoDB.log_post("#{prefix}-add-function4", api, :body => body)
         doc.code.should eq(201)
+        doc.parsed_response['isNewlyCreated'].should eq(true)
         
         body = "{ \"name\" : \"UnitTests::foo\", \"code\": \"function () { return 1; }\" }"
         doc = ArangoDB.log_post("#{prefix}-add-function4", api, :body => body)
         doc.code.should eq(201)
+        doc.parsed_response['isNewlyCreated'].should eq(true)
         
         doc = ArangoDB.log_delete("#{prefix}-add-function4", api + "/UnitTests%3A%3Amytest?group=true")
         doc.code.should eq(200)
@@ -200,6 +207,7 @@ describe ArangoDB do
       it "add function and retrieve the list" do
         body = "{ \"name\" : \"UnitTests::mytest\", \"code\": \"function () { return 1; }\" }"
         doc = ArangoDB.log_post("#{prefix}-list-functions1", api, :body => body)
+        doc.parsed_response['isNewlyCreated'].should eq(true)
 
         doc.code.should eq(201)
         doc.headers['content-type'].should eq("application/json; charset=utf-8")
@@ -219,6 +227,7 @@ describe ArangoDB do
         body = "{ \"name\" : \"UnitTests::mytest1\", \"code\": \"function () { return 1; }\" }"
         doc = ArangoDB.log_post("#{prefix}-list-functions2", api, :body => body)
         doc.code.should eq(201)
+        doc.parsed_response['isNewlyCreated'].should eq(true)
         
         doc = ArangoDB.log_get("#{prefix}-list-functions2", api + "?prefix=UnitTests")
         doc.code.should eq(200)

--- a/arangod/RestHandler/RestAqlUserFunctionsHandler.cpp
+++ b/arangod/RestHandler/RestAqlUserFunctionsHandler.cpp
@@ -63,11 +63,12 @@ RestStatus RestAqlUserFunctionsHandler::execute() {
     auto res = registerUserFunction(_vocbase, body, replacedExisting);
 
     if (res.ok()) {
-      auto code = (replacedExisting)? rest::ResponseCode::OK : rest::ResponseCode::CREATED;
+      auto code = replacedExisting ? rest::ResponseCode::OK : rest::ResponseCode::CREATED;
       VPackBuilder tmp;
       tmp.add(VPackValue(VPackValueType::Object));
       tmp.add("error", VPackValue(false));
       tmp.add("code", VPackValue(static_cast<int>(code)));
+      tmp.add("isNewlyCreated", VPackValue(!replacedExisting));
       tmp.close();
 
       generateResult(code, tmp.slice());

--- a/js/client/modules/@arangodb/aql/functions.js
+++ b/js/client/modules/@arangodb/aql/functions.js
@@ -83,7 +83,7 @@ var registerFunction = function (name, code, isDeterministic = false) {
                                           }));
 
   arangosh.checkRequestResult(requestResult);
-  return requestResult;
+  return !requestResult.isNewlyCreated;
 };
 
 // //////////////////////////////////////////////////////////////////////////////

--- a/js/common/tests/shell/shell-aqlfunctions.js
+++ b/js/common/tests/shell/shell-aqlfunctions.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 200, unused: false*/
-/*global assertEqual, fail */
+/*global assertEqual, assertTrue, assertFalse, fail */
 
 /* unused for functions with 'what' parameter.*/
 ////////////////////////////////////////////////////////////////////////////////
@@ -188,7 +188,6 @@ function AqlFunctionsSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 
     testToArray2 : function () {
-
       aqlfunctions.register("UnitTests::tryme::foo", function (what) { return what * 2; }, true);
       aqlfunctions.register("UnitTests::tryme::bar", function (what) { return what * 2; }, true);
       aqlfunctions.register("UnitTests58::tryme::bar", function (what) { return what * 2; }, true);
@@ -204,7 +203,6 @@ function AqlFunctionsSuite () {
 
       aqlfunctions.unregister("UnitTests58::tryme::bar");
       aqlfunctions.unregister("UnitTests58::whyme::bar");
-
     },
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -251,7 +249,7 @@ function AqlFunctionsSuite () {
 
     testRegisterString1 : function () {
       unregister("UnitTests::tryme");
-      aqlfunctions.register("UnitTests::tryme", "function (what) { return what * 2; }", true);
+      assertFalse(aqlfunctions.register("UnitTests::tryme", "function (what) { return what * 2; }", true));
     },
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -260,7 +258,7 @@ function AqlFunctionsSuite () {
 
     testRegisterString2 : function () {
       unregister("UnitTests::tryme::foo");
-      aqlfunctions.register("UnitTests::tryme::foo", "function (what) { return what * 2; }", true);
+      assertFalse(aqlfunctions.register("UnitTests::tryme::foo", "function (what) { return what * 2; }", true));
     },
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -269,7 +267,7 @@ function AqlFunctionsSuite () {
 
     testRegisterString3 : function () {
       unregister("UnitTests::tryme::foo");
-      aqlfunctions.register("UnitTests::tryme::foo", "/* this is a function! */ \n function (what) { return what * 2; }", true);
+      assertFalse(aqlfunctions.register("UnitTests::tryme::foo", "/* this is a function! */ \n function (what) { return what * 2; }", true));
     },
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -278,8 +276,8 @@ function AqlFunctionsSuite () {
 
     testReRegister : function () {
       unregister("UnitTests::tryme");
-      aqlfunctions.register("UnitTests::tryme", function (what) { return what * 2; }, true);
-      aqlfunctions.register("UnitTests::tryme", function (what) { return what * 2; }, true);
+      assertFalse(aqlfunctions.register("UnitTests::tryme", function (what) { return what * 2; }, true));
+      assertTrue(aqlfunctions.register("UnitTests::tryme", function (what) { return what * 2; }, true));
     },
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
add attribute "isNewlyCreated" to the response

Fixes issue #5629 