### PR TITLE
fix table validation

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js
@@ -2375,7 +2375,7 @@
         var check = true;
         var attributes = {};
 
-        if (result.length <= 1) {
+        if (result.length < 1) {
           check = false;
         }
 


### PR DESCRIPTION
include result with length = 1 to enable table view and csv download for a query with only 1 result