### PR TITLE
Doc Fix: typos and modify link

### DIFF
--- a/Documentation/Books/Cookbook/Compiling/Windows.md
+++ b/Documentation/Books/Cookbook/Compiling/Windows.md
@@ -7,17 +7,17 @@ Problem
 I want to compile ArangoDB 3.0 and onwards under Windows.
 
 **Note:** For this recipe you need at least ArangoDB 3.0;
-For ArangoDB version before 3.0 look at the [old Compiling ArangoDB under Windows](Windows.md).
+For ArangoDB version before 3.0 look at the [old Compiling ArangoDB under Windows](https://docs.arangodb.com/2.8/Cookbook/CompilingUnderWindows.html).
 
 Solution
 --------
 
 With ArangoDB 3.0 a complete cmake environment was introduced. This also streamlines the dependencies on windows.
-We sugest to use [chocolatey.org](https://chocolatey.org/) to install most of the dependencies. For sure
+We suggest to use [chocolatey.org](https://chocolatey.org/) to install most of the dependencies. For sure
 most projects offer their own setup & install packages, chocolatey offers a simplified way to install them
-with less userinteractions. You can even use chocolatey via the brand new
+with less user interactions. You can even use chocolatey via the brand new
 [ansibles 2.0 winrm facility](http://docs.ansible.com/ansible/intro_windows.html)
-to do unattended installions of some software on windows - the cool thing linux guys always told you about.
+to do unattended installations of some software on windows - the cool thing linux guys always told you about.
 
 ### Ingredients
 
@@ -47,7 +47,7 @@ Then we fetch the [OpenSSL](https://openssl.org) library via the nuget commandli
 
 #### Optional
 
-If you intend to run the unittests or compile from git, you also need *(needs to be run with Administrator privileges again)*:
+If you intend to run the unit tests or compile from git, you also need *(needs to be run with Administrator privileges again)*:
 
     choco install -y git winflexbison ruby
 
@@ -89,10 +89,10 @@ You can now load these in the Visual Studio IDE or use cmake to start the build:
 The binaries need the ICU datafile `icudt54l.dat`, which is automatically copied into the directory containing the
 executable.
 
-For development, unittests and documentation: Cygwin (Optional)
+For development, unit tests and documentation: Cygwin (Optional)
 ===============================================================
 
-The documentation and unittests still require a [cygwin](https://www.cygwin.com/) environment. Here the hints how to get it properly installed:
+The documentation and unit tests still require a [cygwin](https://www.cygwin.com/) environment. Here are the hints how to get it properly installed:
 
 You need at least `make` from cygwin. Cygwin also offers a `cmake`. Do **not** install the cygwin cmake.
 
@@ -156,10 +156,10 @@ And variable name: `ICU_DATA` to the value: `c:\\Windows`
 
 ![HowtoSetEnv](/assets/CompilingUnderWindows/SetEnvironmentVar.png)
 
-Running Unitests (Optional)
+Running Unit tests (Optional)
 ---------------------------
 
-You can then run the unittests in the cygwin shell like that:
+You can then run the unit tests in the cygwin shell like that:
 
     build64/bin/RelWithDebInfo/arangosh.exe \
     -c etc/relative/arangosh.conf \


### PR DESCRIPTION
- For compiling ArangoDB version below 3.0, fix the link by pointing to 2.8 documentation.
- Typos
