### PR TITLE
Documentation 3.1/force LF for certain files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,8 @@
 *.sh eol=lf 
-VERSION eolf=lf
+VERSION eol=lf
+VERSIONS eol=lf
 scripts/unittest eol=lf
+*.groovy eol=lf
 *.csv binary
 *.json eol=lf
 Documentation/Books/SummaryBlacklist.txt eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@ VERSION eolf=lf
 scripts/unittest eol=lf
 *.csv binary
 *.json eol=lf
+Documentation/Books/SummaryBlacklist.txt eol=lf


### PR DESCRIPTION
This should fix issues under Windows with Cygwin, which requires LF line endings for certain files.

The concrete error when building docs caused by CRLF line ending for file `Documentation/Books/SummaryBlacklist.txt` was:

```
not all files of HTTP are mapped to the summary!
 files found       |    files in summary
README.md
SUMMARY.md
```

@dothebart Do we need to add any more rules found in devel `.gitattributes`?

https://github.com/arangodb/arangodb/blob/devel/.gitattributes

Need to check if we need to port this to other branches as well.