### PR TITLE
Docs: EOL note for 3.1

### DIFF
--- a/Documentation/Books/AQL/book.json
+++ b/Documentation/Books/AQL/book.json
@@ -1,6 +1,7 @@
 {
   "gitbook": "^3.2.2",
   "title": "ArangoDB VERSION_NUMBER AQL Documentation",
+  "version": "VERSION_NUMBER",
   "author": "ArangoDB GmbH",
   "description": "Official AQL manual for ArangoDB - the native multi-model NoSQL database",
   "language": "en",
@@ -14,6 +15,7 @@
     "sitemap-general@git+https://github.com/Simran-B/gitbook-plugin-sitemap-general.git",
     "ga",
     "callouts@git+https://github.com/Simran-B/gitbook-plugin-callouts.git",
+    "arangodb-outdated@git+https://github.com/Simran-B/gitbook-plugin-arangodb-outdated.git",
     "edit-link",
     "localized-footer"
   ],

--- a/Documentation/Books/Cookbook/book.json
+++ b/Documentation/Books/Cookbook/book.json
@@ -1,6 +1,7 @@
 {
   "gitbook": "^3.2.2",
-  "title": "ArangoDB Cookbook",
+  "title": "ArangoDB VERSION_NUMBER Cookbook",
+  "version": "VERSION_NUMBER",
   "author": "ArangoDB GmbH",
   "description": "Recipes for ArangoDB - the native multi-model NoSQL database",
   "language": "en",
@@ -14,6 +15,7 @@
     "sitemap-general@git+https://github.com/Simran-B/gitbook-plugin-sitemap-general.git",
     "ga",
     "callouts@git+https://github.com/Simran-B/gitbook-plugin-callouts.git",
+    "arangodb-outdated@git+https://github.com/Simran-B/gitbook-plugin-arangodb-outdated.git",
     "edit-link",
     "localized-footer"
   ],

--- a/Documentation/Books/HTTP/book.json
+++ b/Documentation/Books/HTTP/book.json
@@ -1,6 +1,7 @@
 {
   "gitbook": "^3.2.2",
   "title": "ArangoDB VERSION_NUMBER HTTP API Documentation",
+  "version": "VERSION_NUMBER",
   "author": "ArangoDB GmbH",
   "description": "Official HTTP API manual for ArangoDB - the native multi-model NoSQL database",
   "language": "en",
@@ -14,6 +15,7 @@
     "sitemap-general@git+https://github.com/Simran-B/gitbook-plugin-sitemap-general.git",
     "ga",
     "callouts@git+https://github.com/Simran-B/gitbook-plugin-callouts.git",
+    "arangodb-outdated@git+https://github.com/Simran-B/gitbook-plugin-arangodb-outdated.git",
     "edit-link",
     "localized-footer"
   ],

--- a/Documentation/Books/Manual/book.json
+++ b/Documentation/Books/Manual/book.json
@@ -1,6 +1,7 @@
 {
   "gitbook": "^3.2.2",
   "title": "ArangoDB VERSION_NUMBER Documentation",
+  "version": "VERSION_NUMBER",
   "author": "ArangoDB GmbH",
   "description": "Official manual for ArangoDB - the native multi-model NoSQL database",
   "language": "en",
@@ -14,6 +15,7 @@
     "sitemap-general@git+https://github.com/Simran-B/gitbook-plugin-sitemap-general.git",
     "ga",
     "callouts@git+https://github.com/Simran-B/gitbook-plugin-callouts.git",
+    "arangodb-outdated@git+https://github.com/Simran-B/gitbook-plugin-arangodb-outdated.git",
     "edit-link",
     "localized-footer"
   ],


### PR DESCRIPTION
VERSION_NUMBER is automatically being substituted with the content of the `VERSION` file in book.json. This PR adds a new configuration field `"version"` with the ArangoDB version (VERSION_NUMBER), e.g. `v3.1.29` or `3.4.devel ...`.

This version string is then used by the [arangodb-outdated](https://github.com/Simran-B/gitbook-plugin-arangodb-outdated) plugin to add a sentence about EOL of v<i>X.X</i>. If no version could be determined (should never be the case), the entire sentence is left out as it would make little sense without a version. The second sentence about the docs being obsolete is shown regardless.

However, the updated plugin replaces the **Latest Manual** link to `https://docs.arangodb.com/latest/<path-the-user-is-looking-at>` with label **Try latest**. If the structure / file names didn't change between the viewed version and the latest version, then the user will get to the latest online docs with a single click. If it can't be found, he will be redirected to the latest Manual as before. The `node-documentation` routing could be later improved to try to redirect to the closest parent page instead of the Manual.

Related PR for building on Windows in Cygwin: https://github.com/arangodb/arangodb/pull/5684

There seem to be Swagger related build issues at the moment that need to be sorted out.