### PR TITLE
Update .gitattributes: Force LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,8 @@
 *.sh eol=lf 
+VERSION eol=lf
+VERSIONS eol=lf
+scripts/unittest eol=lf
+*.groovy eol=lf
+*.csv binary
+*.json eol=lf
+Documentation/Books/SummaryBlacklist.txt eol=lf


### PR DESCRIPTION
Force LF line endings for certain files to avoid build errors on Windows in Cygwin