### PR TITLE
Docs: Add version to Gitbook configs

### DIFF
--- a/Documentation/Books/Cookbook/book.json
+++ b/Documentation/Books/Cookbook/book.json
@@ -1,6 +1,7 @@
 {
   "gitbook": "^3.2.2",
-  "title": "ArangoDB Cookbook",
+  "title": "ArangoDB VERSION_NUMBER Cookbook",
+  "version": "VERSION_NUMBER",
   "author": "ArangoDB GmbH",
   "description": "Recipes for ArangoDB - the native multi-model NoSQL database",
   "language": "en",

--- a/Documentation/Books/Users/book.json
+++ b/Documentation/Books/Users/book.json
@@ -1,6 +1,7 @@
 {
   "gitbook": "^3.2.2",
   "title": "ArangoDB VERSION_NUMBER Documentation",
+  "version": "VERSION_NUMBER",
   "author": "ArangoDB GmbH",
   "description": "Official manual for ArangoDB - the native multi-model NoSQL database",
   "language": "en",


### PR DESCRIPTION
Add version field to book.json for arangodb-outdated plugin, add version number to Cookbook

This will add an EOL notice.