### PR TITLE
Use HTML comments and use indention 

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,35 +1,38 @@
-<!-- Please remove everything that does not apply -->
+## My Environment
 
-## My environment
+* __ArangoDB Version__:        <!-- e.g. 3.3.10 or self-compiled devel branch -->
+* __Storage Engine__:             <!-- MMFiles / RocksDB -->
+* __Deployment Mode__:       <!-- Single Server | Master/Slave | Active Failover | Cluster | DC2DC -->
+* __Configuration__:               <!-- cluster setup details, notable server settings, etc. -->
+* __Infrastructure__:               <!-- AWS | Azure | ... | own -->
+* __Operating System__:        <!-- Ubuntu 18.04 | Windows 10 | MacOS 10.13.4 | DCOS 1.10 | ... -->
+* __Used Package__:              <!-- Debian or Ubuntu .deb | SUSE or RedHat .rpm | Docker - official Docker library | other -->
 
-* __ArangoDB version__ _(e.g. 3.3.10 or self-compiled devel branch)_:
-* __Storage engine__ _(MMFiles / RocksDB)_:
-* __ArangoDB Deployment mode:__ _(Single Server / Master/Slave / Active Failover / Cluster / DC2DC)_: 
-* __Configuration__ _(cluster setup details, notable server settings, etc)_: 
-* __Infrastructure__ _(AWS / Azure / ... / own)_: 
-* __Operating system__ _(Ubuntu 18.04 / Windows 10 / MacOS 10.13.4 / DCOS 1.10 /...)_: 
-* __Used Package__ _(Debian or Ubuntu .deb / SUSE or RedHat .rpm / docker - official docker library / other)_:
+## Component, Query & Data
 
-## Component
+__Affected feature__:
+<!-- e.g. Installation | Foxx | AQL query using web interface | arangosh | with driver | ... -->
 
-__Affected feature__
-_(e.g. Installation, Foxx, AQL query using web interface / arangosh / with driver / ...)_:
 
-__AQL query (if applicable):__
+__AQL query (if applicable)__:
 
-__AQL explain (if applicable)__ _(output of `db._explain("<my aql query>")`)_:
 
-__Dataset__
- _(description, or if possible, please share an example dataset to reproduce the issue either by a gist with an arangodump, or `db.collection.save({my: "values"}) statements )_:
- 
+__AQL explain (if applicable)__:
+<!-- output of  db._explain("<my aql query>") -->
+
+
+__Dataset__:
+<!-- description, or if possible, please share an example dataset to reproduce the issue either as Gist with an arangodump, or an arangosh script with db.collection.save({my: "values"}) statements -->
+
 
 ## Steps to reproduce
 
-1.
-2.
-3.
+1. 
+2. 
+3. 
 
 __Problem__:
+
 
 __Expected result__:
 


### PR DESCRIPTION
…for better user and support experience

This this really necessary? `Docker - official Docker library`
Can't we simplify that, e.g. to _official Docker image/registry_? (what is a Docker library?)

Preview below:

---

## My Environment

* __ArangoDB Version__: 3.3.10       <!-- e.g. 3.3.10 or self-compiled devel branch -->
* __Storage Engine__: RocksDB            <!-- MMFiles / RocksDB -->
* __Deployment Mode__: Active Failover      <!-- Single Server | Master/Slave | Active Failover | Cluster | DC2DC -->
* __Configuration__: 3 agents              <!-- cluster setup details, notable server settings, etc. -->
* __Infrastructure__: AWS              <!-- AWS | Azure | ... | own -->
* __Operating System__: Debian 8       <!-- Ubuntu 18.04 | Windows 10 | MacOS 10.13.4 | DCOS 1.10 | ... -->
* __Used Package__: .deb             <!-- Debian or Ubuntu .deb | SUSE or RedHat .rpm | Docker - official Docker library | other -->

## Component, Query & Data

__Affected feature__:
<!-- e.g. Installation | Foxx | AQL query using web interface | arangosh | with driver | ... -->
arangodump while import script runs in arangosh

__AQL query (if applicable)__:
`db._query("FOR i IN 1..10000 INSERT { val: i } INTO test")`

__AQL explain (if applicable)__:
<!-- output of  db._explain("<my aql query>") -->
```
Query string:
 FOR i IN 1..10000 INSERT { val: i } INTO test

Execution plan:
 Id   NodeType             Est.   Comment
  1   SingletonNode           1   * ROOT
  2   CalculationNode         1     - LET #2 = 1 .. 10000   /* range */   /* simple expression */
  3   EnumerateListNode   10000     - FOR i IN #2   /* list iteration */
  4   CalculationNode     10000       - LET #4 = { "val" : i }   /* simple expression */
  5   InsertNode              0       - INSERT #4 IN test

Indexes used:
 none

Optimization rules applied:
 Id   RuleName
  1   remove-data-modification-out-variables

Write query options:
 Option                   Value
 ignoreErrors             false
 waitForSync              false
 nullMeansRemove          false
 mergeObjects             true
 ignoreDocumentNotFound   false
 readCompleteInput        false
 useIsRestore             false
 consultAqlWriteFilter    false
```

__Dataset__:
<!-- description, or if possible, please share an example dataset to reproduce the issue either as Gist with an arangodump, or an arangosh script with db.collection.save({my: "values"}) statements -->
Empty document collection "test".

## Steps to reproduce

1. Create a collection with name "test" via Arangosh
2. Run above command to execute an INSERT query for 10k docs
3. While it's busy, execute arangodump for this collection

__Problem__:
Query aborts with error 12345

__Expected result__:
Both operations to succeed eventually, even if one has to be paused until the other one has finished
