### PR TITLE
Docs: Improve program option / startup parameter description

### DIFF
--- a/Documentation/Books/Manual/Administration/Configuration/README.md
+++ b/Documentation/Books/Manual/Administration/Configuration/README.md
@@ -82,22 +82,24 @@ So you see in general `--section.param value` translates to
 param=value 
 ```
 
-{% hint 'warning' %}
-Whitespace around `=` is ignored in the configuration file. Do not put spaces
-around additional `=` in the parameter value however. The following example
-shows the correct way to specify a log level of `trace` for the topic `startup`:
+{% hint 'tip' %}
+Whitespace around `=` is ignored in the configuration file.
+This includes whitespace around equals signs in the parameter value:
 
 ```js
-log.level = startup=trace
+log.level = startup = trace
 ```
 
-Note that there is no whitespace between `startup` and `=`, and also not `=`
-and `trace`.
+It is the same as without whitespace:
+
+```js
+log.level=startup=trace
+```
 {% endhint %}
 
-Where one section may occur multiple times, and the last occurance of `param`
+Where one section may occur multiple times, and the last occurrence of `param`
 will become the final value. In case of parameters being vectors, multiple
-occurance adds another item to the vector. Vectors can be identified by the
+occurrence adds another item to the vector. Vectors can be identified by the
 `...` in the `--help` output of the binaries.
 
 Comments can be placed in the configuration file, only if the line begins with

--- a/Documentation/Books/Manual/Programs/Arangod/Options.md
+++ b/Documentation/Books/Manual/Programs/Arangod/Options.md
@@ -3,4 +3,22 @@ ArangoDB Server Options
 
 Usage: `arangod [<options>]`
 
+The database directory can be specified as positional (unnamed) first parameter:
+
+    arangod /path/to/datadir
+
+Or explicitly as named parameter:
+
+    arangod --database.directory /path/to/datadir
+
+All other parameters need to be passed as named parameters.
+That is two hyphens followed by the option name, an equals sign or a space and
+finally the parameter value. The value needs to be wrapped in double quote marks
+if the value contains whitespace. Extra whitespace around `=` is allowed:
+
+    arangod --database.directory = "/path with spaces/to/datadir"
+
+See [Configuration](../../Administration/Configuration/README.md#configuration-files)
+if you want to translate startup parameters to configuration files.
+
 @startDocuBlock program_options_arangod


### PR DESCRIPTION
Add brief description of startup parameter usage to Arangod Options page (which should close the gap between the General Options headline and the table caused by the ToC)

Changed hint regarding whitespace in parameter values in config files - I believe @jsteemann changed this at some point so that whitespace in parameter values does not matter anymore, but I'm not sure if this was shipped in 3.3.0 or later. The following works in 3.3.10 in arangod.conf:

```
[log]
level = info
	  level	 = 		threads 	     	=     	  trace		   
```