### PR TITLE
Add Oskar suite blacklist.

### DIFF
--- a/UnitTests/OskarTestSuitesBlackList
+++ b/UnitTests/OskarTestSuitesBlackList
@@ -1,0 +1,2 @@
+load_balancing
+load_balancing_auth


### PR DESCRIPTION
Prevents Oskar from running these suites against 3.2 builds.
