### PR TITLE
Add 3.2 tests blacklist for Oskar

### DIFF
--- a/UnitTests/OskarTestSuitesBlackList
+++ b/UnitTests/OskarTestSuitesBlackList
@@ -1,0 +1,1 @@
+shell_client_aql


### PR DESCRIPTION
Added 3.2 tests blacklist for Oskar with "shell_client_aql" suite.
