### PR TITLE
Remove hasMore

### DIFF
--- a/arangod/Aql/BasicBlocks.h
+++ b/arangod/Aql/BasicBlocks.h
@@ -44,14 +44,6 @@ class SingletonBlock final : public ExecutionBlock {
   /// above
   std::pair<ExecutionState, Result> initializeCursor(AqlItemBlock* items, size_t pos) override;
 
-  ExecutionState hasMoreState() override final {
-    if (_done) {
-      return ExecutionState::DONE;
-    } else {
-      return ExecutionState::HASMORE;
-    }
-  }
-
   Type getType() const override final {
     return Type::SINGLETON;
   }
@@ -196,8 +188,6 @@ class NoResultsBlock final : public ExecutionBlock {
   /// @brief initializeCursor, store a copy of the register values coming from
   /// above
   std::pair<ExecutionState, Result> initializeCursor(AqlItemBlock* items, size_t pos) override;
-
-  ExecutionState hasMoreState() override final { return ExecutionState::DONE; }
 
   Type getType() const override final {
     return Type::NO_RESULTS;

--- a/arangod/Aql/ClusterBlocks.h
+++ b/arangod/Aql/ClusterBlocks.h
@@ -77,12 +77,6 @@ class BlockWithClients : public ExecutionBlock {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
   }
 
-  /// @brief hasMore
-  ExecutionState hasMoreState() override final {
-    TRI_ASSERT(false);
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
-  }
-
   /// @brief getSomeForShard
   std::pair<ExecutionState, std::unique_ptr<AqlItemBlock>> getSomeForShard(
       size_t atMost, std::string const& shardId);
@@ -252,9 +246,6 @@ class RemoteBlock final : public ExecutionBlock {
   /// @brief skipSome
   std::pair<ExecutionState, size_t> skipSome(size_t atMost) override final;
 
-  /// @brief hasMore
-  ExecutionState hasMoreState() override final;
-
   /// @brief handleAsyncResult
   bool handleAsyncResult(ClusterCommResult* result) override;
 
@@ -323,10 +314,6 @@ class UnsortingGatherBlock final : public ExecutionBlock {
   /// @brief initializeCursor
   std::pair<ExecutionState, arangodb::Result> initializeCursor(AqlItemBlock* items, size_t pos) override final;
 
-  /// @brief hasMore: true if any position of _buffer hasMore and false
-  /// otherwise.
-  ExecutionState hasMoreState() override final;
-
   /// @brief getSome
   std::pair<ExecutionState, std::unique_ptr<AqlItemBlock>> getSome(
       size_t atMost) override final;
@@ -377,10 +364,6 @@ class SortingGatherBlock final : public ExecutionBlock {
 
   /// @brief initializeCursor
   std::pair<ExecutionState, arangodb::Result> initializeCursor(AqlItemBlock* items, size_t pos) override final;
-
-  /// @brief hasMore: true if any position of _buffer hasMore and false
-  /// otherwise.
-  ExecutionState hasMoreState() override final;
 
   /// @brief getSome
   std::pair<ExecutionState, std::unique_ptr<AqlItemBlock>> getSome(

--- a/arangod/Aql/ExecutionBlock.cpp
+++ b/arangod/Aql/ExecutionBlock.cpp
@@ -435,28 +435,6 @@ std::pair<ExecutionState, size_t> ExecutionBlock::skipSome(size_t atMost) {
   return {res.first, skipped};
 }
 
-ExecutionState ExecutionBlock::hasMoreState() {
-  if (_done) {
-    return ExecutionState::DONE;
-  }
-  if (!_buffer.empty()) {
-    return ExecutionState::HASMORE;
-  }
-  ExecutionState state;
-  bool blockAppended;
-  std::tie(state, blockAppended) = getBlock(DefaultBatchSize());
-  if (state == ExecutionState::WAITING) {
-    TRI_ASSERT(!blockAppended);
-    return ExecutionState::WAITING;
-  }
-  if (blockAppended) {
-    _pos = 0;
-    return ExecutionState::HASMORE;
-  }
-  _done = true;
-  return ExecutionState::DONE;
-}
-
 ExecutionBlock::BufferState ExecutionBlock::getBlockIfNeeded(size_t atMost) {
   if (!_buffer.empty()) {
     return BufferState::HAS_BLOCKS;

--- a/arangod/Aql/ExecutionBlock.h
+++ b/arangod/Aql/ExecutionBlock.h
@@ -192,11 +192,6 @@ class ExecutionBlock {
   /// elements skipped is returned.
   virtual std::pair<ExecutionState, size_t> skipSome(size_t atMost);
 
-  // Used in aql rest handler hasMore
-  // Needs to be accurate
-  // TODO change the documentation of all hasMore implementations
-  virtual ExecutionState hasMoreState();
-  
   ExecutionNode const* getPlanNode() const { return _exeNode; }
   
   transaction::Methods* transaction() const { return _trx; }

--- a/arangod/Aql/ExecutionEngine.h
+++ b/arangod/Aql/ExecutionEngine.h
@@ -87,24 +87,6 @@ class ExecutionEngine {
   /// @brief hasMore
   inline ExecutionState hasMoreState() const { return _root->hasMoreState(); }
 
-  /// @brief hasMore - synchronous (cannot return WAITING, but blocks the
-  /// thread)
-  inline bool hasMoreSync() const {
-    getQuery()->setContinueCallback([&]() { getQuery()->tempSignalAsyncResponse(); });
-    ExecutionState state = _root->hasMoreState();
-
-    while (state == ExecutionState::WAITING) {
-      getQuery()->tempWaitForAsyncResponse();
-      state = _root->hasMoreState();
-    }
-
-    if (state == ExecutionState::DONE) {
-      return false;
-    }
-    TRI_ASSERT(state == ExecutionState::HASMORE);
-    return true;
-  }
-
   /// @brief whether or not initializeCursor was called
   bool initializeCursorCalled() const { return _initializeCursorCalled; }
 

--- a/arangod/Aql/ExecutionEngine.h
+++ b/arangod/Aql/ExecutionEngine.h
@@ -84,9 +84,6 @@ class ExecutionEngine {
   /// @brief skipSome
   std::pair<ExecutionState, size_t> skipSome(size_t atMost);
 
-  /// @brief hasMore
-  inline ExecutionState hasMoreState() const { return _root->hasMoreState(); }
-
   /// @brief whether or not initializeCursor was called
   bool initializeCursorCalled() const { return _initializeCursorCalled; }
 

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -576,39 +576,7 @@ RestStatus RestAqlHandler::getInfoQuery(std::string const& operation,
   try {
     VPackObjectBuilder guard(&answerBody);
 
-    if (operation == "hasMore") {
-      // asynchronous API
-      ExecutionState hasMoreState;
-      if (shardId.empty()) {
-        hasMoreState = query->engine()->hasMoreState();
-      } else {
-        auto block = dynamic_cast<BlockWithClients*>(query->engine()->root());
-        if (block->getPlanNode()->getType() != ExecutionNode::SCATTER &&
-            block->getPlanNode()->getType() != ExecutionNode::DISTRIBUTE) {
-          THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
-            "unexpected node type");
-        }
-        hasMoreState = block->getHasMoreStateForShard(shardId);
-      }
-      bool hasMore;
-      switch (hasMoreState) {
-        case ExecutionState::WAITING: {
-          auto self = shared_from_this();
-          query->setContinueHandler(
-              [this, self]() { continueHandlerExecution(); });
-        }
-          return RestStatus::WAITING;
-
-        case ExecutionState::DONE:
-          hasMore = false;
-          break;
-
-        case ExecutionState::HASMORE:
-          hasMore = true;
-          break;
-      }
-      answerBody.add("hasMore", VPackValue(hasMore));
-    } else {
+    if (true) {
       _queryRegistry->close(&_vocbase, _qId);
       LOG_TOPIC(ERR, arangodb::Logger::FIXME) << "referenced query not found";
       generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND);

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -548,72 +548,6 @@ RestStatus RestAqlHandler::useQuery(std::string const& operation,
   return RestStatus::DONE;
 }
 
-// GET method for /_api/aql/<operation>/<queryId>, (internal)
-// this is using the part of the cursor API without side effects. The operation
-// must be "hasMore".
-//
-// The result is a Json
-// with, depending on the operation, the following attributes:
-//   for "hasMore":
-//     the result has the attributes "error" (set to false)
-//     and "hasMore" set to a boolean value.
-//   for "hasMoreState":
-//     the result has the attributes "error" (set to false)
-//     and "hasMoreState" set to a string "DONE", "HASMORE" or "WAITING".
-RestStatus RestAqlHandler::getInfoQuery(std::string const& operation,
-                                        std::string const& idString) {
-  bool found;
-  std::string const& shardId = _request->header("shard-id", found);
-
-  Query* query = nullptr;
-  if (findQuery(idString, query)) {
-    return RestStatus::DONE;
-  }
-
-  TRI_ASSERT(_qId > 0);
-
-  VPackBuilder answerBody;
-  try {
-    VPackObjectBuilder guard(&answerBody);
-
-    if (true) {
-      _queryRegistry->close(&_vocbase, _qId);
-      LOG_TOPIC(ERR, arangodb::Logger::FIXME) << "referenced query not found";
-      generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND);
-      return RestStatus::DONE;
-    }
-
-    answerBody.add(StaticStrings::Error, VPackValue(false));
-  } catch (arangodb::basics::Exception const& ex) {
-    _queryRegistry->close(&_vocbase, _qId);
-    LOG_TOPIC(ERR, arangodb::Logger::FIXME) << "failed during use of query: " << ex.message();
-    generateError(rest::ResponseCode::SERVER_ERROR, ex.code(), ex.what());
-  } catch (std::exception const& ex) {
-    _queryRegistry->close(&_vocbase, _qId);
-
-    LOG_TOPIC(ERR, arangodb::Logger::FIXME) << "failed during use of query: "
-                                            << ex.what();
-
-    generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_HTTP_SERVER_ERROR,
-                  ex.what());
-  } catch (...) {
-    _queryRegistry->close(&_vocbase, _qId);
-
-    LOG_TOPIC(ERR, arangodb::Logger::FIXME)
-        << "failed during use of query: Unknown exception occurred";
-
-    generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_HTTP_SERVER_ERROR,
-                  "an unknown exception occurred");
-  }
-
-  _queryRegistry->close(&_vocbase, _qId);
-
-  sendResponse(rest::ResponseCode::OK, answerBody.slice(),
-               query->trx()->transactionContext().get());
-
-  return RestStatus::DONE;
-}
-
 // executes the handler
 RestStatus RestAqlHandler::execute() {
   // std::cout << "GOT INCOMING REQUEST: " <<
@@ -653,15 +587,9 @@ RestStatus RestAqlHandler::execute() {
       break;
     }
     case rest::RequestType::GET: {
-      if (suffixes.size() != 2) {
-        LOG_TOPIC(ERR, arangodb::Logger::FIXME) << "Unknown GET API";
-        generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND, "Unknown GET API");
-      } else {
-        auto status = getInfoQuery(suffixes[0], suffixes[1]);
-        if (status == RestStatus::WAITING) {
-          return status;
-        }
-      }
+      // Previously, the only GET API was /_api/aql/hasMore. Now, there is none.
+      LOG_TOPIC(ERR, arangodb::Logger::FIXME) << "Unknown GET API";
+      generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND, "Unknown GET API");
       break;
     }
     case rest::RequestType::DELETE_REQ:

--- a/arangod/Aql/RestAqlHandler.h
+++ b/arangod/Aql/RestAqlHandler.h
@@ -76,9 +76,6 @@ class RestAqlHandler : public RestVocbaseBaseHandler {
   //             "done" (boolean) [3.4.0 and later] to indicate whether or not the cursor is exhausted.
   RestStatus useQuery(std::string const& operation, std::string const& idString);
 
-  // GET method for /_api/aql/<queryId>
-  RestStatus getInfoQuery(std::string const &operation, std::string const &idString);
-
  private:
 
   // POST method for /_api/aql/setup (internal)

--- a/arangod/Aql/RestAqlHandler.h
+++ b/arangod/Aql/RestAqlHandler.h
@@ -77,7 +77,7 @@ class RestAqlHandler : public RestVocbaseBaseHandler {
   RestStatus useQuery(std::string const& operation, std::string const& idString);
 
   // GET method for /_api/aql/<queryId>
-  void getInfoQuery(std::string const& operation, std::string const& idString);
+  RestStatus getInfoQuery(std::string const &operation, std::string const &idString);
 
  private:
 


### PR DESCRIPTION
Removed `hasMore()` and `/_api/aql/hasMore` everywhere, respectively the just introduced variants `hasMoreState()` and `/_api/aql/hasMoreState`, as they are currently unused in devel and seem to have been unused at least in 3.2 and 3.3.