### PR TITLE
Docs: Improve Swagger presentation of example code

### DIFF
--- a/utils/generateSwagger.py
+++ b/utils/generateSwagger.py
@@ -1081,12 +1081,12 @@ def example_arangosh_run(cargo, r=Regexen()):
     except:
         print >> sys.stderr, "Failed to open example file:\n  '%s'" % fn
         raise
-    operation['x-examples'][currentExample]= '\n\n**Example:**\n ' + exampleHeader.strip('\n ') + '\n\n<pre><code class="json">'
+    operation['x-examples'][currentExample]= '\n\n**Example:**\n ' + exampleHeader.strip('\n ') + '\n\n<pre>'
     
     for line in examplefile.readlines():
-        operation['x-examples'][currentExample] += line
+        operation['x-examples'][currentExample] += '<code>' + line + '</code>'
     
-    operation['x-examples'][currentExample] += '</code></pre>\n\n\n'
+    operation['x-examples'][currentExample] += '</pre>\n\n\n'
 
     line = ""
 


### PR DESCRIPTION
Wrap each line in code tag. This will make all lines show in the proper style (mono-spaced etc.).

It does not seem to have any effect on doc generation, although the api-docs.json is used there too (`x-examples` is appended to `description` in generateSwagger.py and the description is actually used in generateMdFiles.py, but no `<code>` elements are visible in the final HTML?)