### PR TITLE
[3.3] Bugfix: Creating a graph failed erroneously

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.3.12 (XXXX-XX-XX)
 --------------------
 
+* fixed graph creation under some circumstances failing with 'edge collection
+  already used in edge def' despite the edge definitions being identical
+
 * fixed issue #5727: Edge document with user provided key is inserted as many
   times as the number of shards, violating the primary index
 

--- a/js/common/modules/@arangodb/general-graph.js
+++ b/js/common/modules/@arangodb/general-graph.js
@@ -728,6 +728,11 @@ var checkIfMayBeDropped = function (colName, graphName, graphs) {
   return result;
 };
 
+const edgeDefinitionsEqual = function (leftEdgeDef, rightEdgeDef) {
+  const stringify = obj => JSON.stringify(obj, Object.keys(obj).sort());
+  return stringify(leftEdgeDef) === stringify(rightEdgeDef);
+};
+
 // @brief Class Graph. Defines a graph in the Database.
 class Graph {
   constructor (info) {
@@ -1573,7 +1578,7 @@ class Graph {
           function (sGED) {
             var col = sGED.collection;
             if (col === eC) {
-              if (JSON.stringify(sGED) !== JSON.stringify(edgeDefinition)) {
+              if (!edgeDefinitionsEqual(sGED, edgeDefinition)) {
                 err = new ArangoError();
                 err.errorNum = arangodb.errors.ERROR_GRAPH_COLLECTION_USE_IN_MULTI_GRAPHS.code;
                 err.errorMessage = col + ' ' +
@@ -2036,7 +2041,7 @@ exports._create = function (graphName, edgeDefinitions, orphanCollections, optio
         (sGED) => {
           var col = sGED.collection;
           if (tmpCollections.indexOf(col) !== -1) {
-            if (JSON.stringify(sGED) !== JSON.stringify(tmpEdgeDefinitions[col])) {
+            if (!edgeDefinitionsEqual(sGED, tmpEdgeDefinitions[col])) {
               let err = new ArangoError();
               err.errorNum = arangodb.errors.ERROR_GRAPH_COLLECTION_USE_IN_MULTI_GRAPHS.code;
               err.errorMessage = col + ' ' +

--- a/js/common/tests/shell/shell-general-graph.js
+++ b/js/common/tests/shell/shell-general-graph.js
@@ -57,6 +57,8 @@ function GeneralGraphCreationSuite() {
   var vn3 = "UnitTestVertices3";
   var vn4 = "UnitTestVertices4";
   var gn = "UnitTestGraph";
+  var gn1 = "UnitTestGraph1";
+  var gn2 = "UnitTestGraph2";
   var edgeDef = graph._edgeDefinitions(
     graph._relation(rn, [vn1], [vn1]),
     graph._relation(rn1,
@@ -110,6 +112,12 @@ function GeneralGraphCreationSuite() {
       try {
         graph._drop(gN2, true);
       } catch(ignore) {
+      }
+      if (db._collection("_graphs").exists(gn1)) {
+        db._collection("_graphs").remove(gn1);
+      }
+      if (db._collection("_graphs").exists(gn2)) {
+        db._collection("_graphs").remove(gn2);
       }
     },
 
@@ -465,6 +473,32 @@ function GeneralGraphCreationSuite() {
         assertEqual(err.errorNum, ERRORS.ERROR_GRAPH_DUPLICATE.code);
         assertEqual(err.errorMessage, ERRORS.ERROR_GRAPH_DUPLICATE.message);
       }
+    },
+
+    // Graphs may have overlapping edge collections, as long as their
+    // definitions are equal.
+    // This is also a regression test for a broken comparison of edge
+    // definitions, which did rely on the edge definition object's key order
+    // and thus sometimes reported spurious inequality.
+    test_createGraphsWithOverlappingEdgeDefinitions: function () {
+      // try to provoke differently ordered keys in
+      // edge definitions that are actually equal.
+      const edgeDefs1 = [
+        {
+          collection: rn,
+          from: [vn1],
+          to: [vn1],
+        },
+      ];
+      const edgeDefs2 = [
+        {
+          to: [vn1],
+          from: [vn1],
+          collection: rn,
+        },
+      ];
+      graph._create(gn1, edgeDefs1);
+      graph._create(gn2, edgeDefs2);
     },
 
     test_get_graph : function () {


### PR DESCRIPTION
The edge definition comparison relied on the object's key order and therefore sometimes failed when the edge definitions where actually equal.