### PR TITLE
BugFix 3.3:  adjust SetThrottle() to only call GetDelayToken() first time.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.3.12 (2018-07-12)
 --------------------
 
+* PR5854: rocksdb engine would frequently request a new DelayToken.  This caused
+  excessive write delay on the next Put() call.  Alternate approach taken.
+
 * fixed graph creation under some circumstances failing with 'edge collection
   already used in edge def' despite the edge definitions being identical
 
@@ -43,7 +46,7 @@ v3.3.11 (2018-06-26)
   more than a single shard and using a custom shard key (i.e. some shard
   key attribute other than `_key`).
   The previous implementation of DOCUMENT restricted to lookup to a single
-  shard in all cases, though this restriction was invalid. That lead to 
+  shard in all cases, though this restriction was invalid. That lead to
   `DOCUMENT` not finding documents in cases the wrong shard was contacted. The
   fixed implementation in 3.3.11 will reach out to all shards to find the
   document, meaning it will produce the correct result, but will cause more
@@ -57,7 +60,7 @@ v3.3.11 (2018-06-26)
 
 * fixed internal issue #2256: ui, document id not showing up when deleting a document
 
-* fixed internal issue #2163: wrong labels within foxx validation of service 
+* fixed internal issue #2163: wrong labels within foxx validation of service
   input parameters
 
 * fixed internal issue #2160: fixed misplaced tooltips in indices view
@@ -233,7 +236,7 @@ v3.3.9 (2018-05-17)
   `COLLECT ...` (no options)                 => create a plan using sorted, and another plan using hash method
 
 * added bulk document lookups for MMFiles engine, which will improve the performance
-  of document lookups from an inside an index in case the index lookup produces many 
+  of document lookups from an inside an index in case the index lookup produces many
   documents
 
 


### PR DESCRIPTION
The SetThrottle() routine previously replaced its DelayToken every time called.  This procedure was intended to keep our calculated bytes-per-second active instead of any other value that rocksdb's code might subsequently set.  Unfortunately, The GetDelayToken() code within rocksdb also clears all timings currently in use and forces a big wait upon the very next write.  This could happen multiple times a second under heavy load.

The code now retrieves a DelayToken only if one is not previously held.  Subsequent rewrites of our bytes-per-second value now use a different API that does not clear current timings.