### PR TITLE
Bugfix Devel: adjust SetThrottle() to only call GetDelayToken() first time.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* PR5857: rocksdb engine would frequently request a new DelayToken.  This caused
+  excessive write delay on the next Put() call.  Alternate approach taken.
+
 * changed the thread handling in the scheduler. `--server.threads` will be
   the maximum number of threads for the scheduler.
 

--- a/arangod/RocksDBEngine/RocksDBThrottle.cpp
+++ b/arangod/RocksDBEngine/RocksDBThrottle.cpp
@@ -418,10 +418,24 @@ void RocksDBThrottle::SetThrottle() {
         // hard casting away of "const" ...
         if (((WriteController&)_internalRocksDB->write_controller()).max_delayed_write_rate() < _throttleBps) {
           ((WriteController&)_internalRocksDB->write_controller()).set_max_delayed_write_rate(_throttleBps);
-        } //if
-        _delayToken=(((WriteController&)_internalRocksDB->write_controller()).GetDelayToken(_throttleBps));
+        } // if
+
+        // Only replace the token when absolutely necessary.  GetDelayToken()
+        //  also resets internal timers which can result in long pauses if
+        //  flushes/compactions are happening often.
+        if (nullptr == _delayToken.get()) {
+          _delayToken=(((WriteController&)_internalRocksDB->write_controller()).GetDelayToken(_throttleBps));
+          LOG_TOPIC(DEBUG, arangodb::Logger::ENGINES)
+            << "SetThrottle(): GetDelayTokey(" << _throttleBps << ")";
+        } else {
+          LOG_TOPIC(DEBUG, arangodb::Logger::ENGINES)
+            << "SetThrottle(): set_delayed_write_rate(" << _throttleBps << ")";
+          ((WriteController&)_internalRocksDB->write_controller()).set_delayed_write_rate(_throttleBps);
+        } // else
       } else {
         _delayToken.reset();
+        LOG_TOPIC(DEBUG, arangodb::Logger::ENGINES)
+          << "SetThrottle(): _delaytoken.reset()";
       } // else
     } // if
   } // lock


### PR DESCRIPTION
The SetThrottle() routine previously replaced its DelayToken every time called. This procedure was intended to keep our calculated bytes-per-second active instead of any other value that rocksdb's code might subsequently set. Unfortunately, The GetDelayToken() code within rocksdb also clears all timings currently in use and forces a big wait upon the very next write. This could happen multiple times a second under heavy load.

The code now retrieves a DelayToken only if one is not previously held. Subsequent rewrites of our bytes-per-second value now use a different API that does not clear current timings.