### PR TITLE
don't sleep so long while waiting for the result of /_api/replication…

### DIFF
--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -63,6 +63,23 @@ namespace {
 
 /// @brief maximum internal value for chunkSize
 size_t const MaxChunkSize = 10 * 1024 * 1024;
+        
+std::chrono::milliseconds sleepTimeFromWaitTime(double waitTime) {
+  if (waitTime < 1.0) {
+    return std::chrono::milliseconds(100);
+  }
+  if (waitTime < 5.0) {
+    return std::chrono::milliseconds(200);
+  } 
+  if (waitTime < 20.0) {
+    return std::chrono::milliseconds(500);
+  }
+  if (waitTime < 60.0) {
+    return std::chrono::seconds(1);
+  }
+   
+  return std::chrono::seconds(2);
+}
 
 }  // namespace
 
@@ -561,20 +578,11 @@ Result DatabaseInitialSyncer::fetchCollectionDump(
                   _config.master.endpoint);
         }
 
-        std::chrono::milliseconds sleepTime;
-        if (waitTime < 5.0) {
-          sleepTime = std::chrono::milliseconds(250);
-        } else if (waitTime < 20.0) {
-          sleepTime = std::chrono::milliseconds(500);
-        } else if (waitTime < 60.0) {
-          sleepTime = std::chrono::seconds(1);
-        } else {
-          sleepTime = std::chrono::seconds(2);
-        }
-
         if (isAborted()) {
           return Result(TRI_ERROR_REPLICATION_APPLIER_STOPPED);
         }
+        
+        std::chrono::milliseconds sleepTime = ::sleepTimeFromWaitTime(waitTime);
         std::this_thread::sleep_for(sleepTime);
       }
       // fallthrough here in case everything went well
@@ -789,20 +797,11 @@ Result DatabaseInitialSyncer::fetchCollectionSync(
               _config.master.endpoint);
     }
 
-    std::chrono::milliseconds sleepTime;
-    if (waitTime < 5.0) {
-      sleepTime = std::chrono::milliseconds(250);
-    } else if (waitTime < 20.0) {
-      sleepTime = std::chrono::milliseconds(500);
-    } else if (waitTime < 60.0) {
-      sleepTime = std::chrono::seconds(1);
-    } else {
-      sleepTime = std::chrono::seconds(2);
-    }
-
     if (isAborted()) {
       return Result(TRI_ERROR_REPLICATION_APPLIER_STOPPED);
     }
+    
+    std::chrono::milliseconds sleepTime = ::sleepTimeFromWaitTime(waitTime);
     std::this_thread::sleep_for(sleepTime);
   }
 

--- a/arangod/Replication/Syncer.cpp
+++ b/arangod/Replication/Syncer.cpp
@@ -403,6 +403,7 @@ Result Syncer::applyCollectionDumpMarker(transaction::Methods& trx,
         return res;
       }
 
+      LOG_TOPIC(DEBUG, Logger::REPLICATION) << "got lock timeout while waiting for lock on collection '" << coll->name() << "', retrying...";
       std::this_thread::sleep_for(std::chrono::microseconds(50000));
       // retry
     }


### PR DESCRIPTION
…/dump and /_api/replication/keys

Sleeping for shorter periods increases the chances that we can continue faster...
This will speed up the initial synchronization when collections contain only few or no documents,
but there are lots of collections to sync