### PR TITLE
do not run storage engine equality check too early

### DIFF
--- a/lib/ApplicationFeatures/ClusterPhase.cpp
+++ b/lib/ApplicationFeatures/ClusterPhase.cpp
@@ -31,7 +31,5 @@ ClusterFeaturePhase::ClusterFeaturePhase(ApplicationServer* server)
   startsAfter("DatabasePhase");
 
   startsAfter("Cluster");
-  startsAfter("EngineEqualityCheck");
   startsAfter("ReplicationTimeout");
-
 }


### PR DESCRIPTION
  deferring the engine check to after the coordinator is fully
  bootstrapped reduces the number of bogus startup errors when
  firing up a new cluster