### PR TITLE
remove unused define

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,10 +630,6 @@ endfunction()
 
 if (USE_JEMALLOC)
   add_definitions("-DARANGODB_HAVE_JEMALLOC=1")
-
-  if (LINUX OR DARWIN)
-    add_definitions("-DARANGODB_MMAP_JEMALLOC=1")
-  endif ()
 endif ()
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This option is totally unused in our build, so it doesn't need to be set.