### PR TITLE
[3.3] Bugfix: Add missing plan version increments in repair-distributeShardsLike

### DIFF
--- a/arangod/Cluster/ClusterRepairOperations.cpp
+++ b/arangod/Cluster/ClusterRepairOperations.cpp
@@ -435,6 +435,9 @@ RepairOperationToTransactionVisitor::operator()(
         protoReplicationFactorSlice});
   }
 
+  operations.emplace_back(AgencyOperation("Plan/Version",
+      AgencySimpleOperationType::INCREMENT_OP));
+
   return {AgencyWriteTransaction{operations, preconditions}, boost::none};
 }
 
@@ -502,6 +505,9 @@ RepairOperationToTransactionVisitor::operator()(
       AgencyOperation{newAttrPath, AgencyValueOperationType::SET,
                       protoCollectionIdSlice},
       AgencyOperation{oldAttrPath, AgencySimpleOperationType::DELETE_OP}};
+
+  operations.emplace_back(AgencyOperation("Plan/Version",
+      AgencySimpleOperationType::INCREMENT_OP));
 
   return {AgencyWriteTransaction{operations, preconditions}, boost::none};
 }

--- a/js/server/tests/resilience/repair-distribute-shards-like-spec.js
+++ b/js/server/tests/resilience/repair-distribute-shards-like-spec.js
@@ -354,6 +354,7 @@ const createBrokenClusterState = function ({failOnOperation = null} = {}) {
     `Plan/Collections/${internal.db._name()}/${collection._id}/distributeShardsLike`,
     protoCollection._id
   );
+  global.ArangoAgency.increaseVersion("Plan/Version");
 
   expect(waitForPlanEqualCurrent(collection)).to.be.true;
   return {collection, protoCollection, expectedCollections};

--- a/tests/Cluster/ClusterRepairsTest.cpp
+++ b/tests/Cluster/ClusterRepairsTest.cpp
@@ -525,7 +525,10 @@ SCENARIO("Cluster RepairOperations", "[cluster][shards][repairs]") {
                                 protoCollIdSlice},
                 AgencyOperation{
                     "Plan/Collections/myDbName/123456/replicationFactor",
-                    AgencyValueOperationType::SET, replicationFactorSlice}},
+                    AgencyValueOperationType::SET, replicationFactorSlice},
+                AgencyOperation{
+                    "Plan/Version",
+                    AgencySimpleOperationType::INCREMENT_OP}},
             std::vector<AgencyPrecondition>{
                 AgencyPrecondition{"Plan/Collections/myDbName/123456/"
                                    "repairingDistributeShardsLike",
@@ -597,7 +600,8 @@ SCENARIO("Cluster RepairOperations", "[cluster][shards][repairs]") {
         Slice replicationFactorSlice = Slice(replicationFactorVPack->data());
 
         AgencyWriteTransaction expectedTrx{
-            {},
+            {AgencyOperation{"Plan/Version",
+	                     AgencySimpleOperationType::INCREMENT_OP}},
             std::vector<AgencyPrecondition>{
                 AgencyPrecondition{
                     "Plan/Collections/myDbName/123456/distributeShardsLike",
@@ -658,7 +662,10 @@ SCENARIO("Cluster RepairOperations", "[cluster][shards][repairs]") {
                                 protoCollIdSlice},
                 AgencyOperation{
                     "Plan/Collections/myDbName/123456/replicationFactor",
-                    AgencyValueOperationType::SET, replicationFactorSlice}},
+                    AgencyValueOperationType::SET, replicationFactorSlice},
+                AgencyOperation{
+                    "Plan/Version",
+                    AgencySimpleOperationType::INCREMENT_OP}},
             std::vector<AgencyPrecondition>{
                 AgencyPrecondition{"Plan/Collections/myDbName/123456/"
                                    "repairingDistributeShardsLike",
@@ -719,7 +726,10 @@ SCENARIO("Cluster RepairOperations", "[cluster][shards][repairs]") {
                                 AgencySimpleOperationType::DELETE_OP},
                 AgencyOperation{
                     "Plan/Collections/myDbName/123456/distributeShardsLike",
-                    AgencyValueOperationType::SET, protoIdSlice}},
+                    AgencyValueOperationType::SET, protoIdSlice},
+                AgencyOperation{
+                    "Plan/Version",
+                    AgencySimpleOperationType::INCREMENT_OP}},
             std::vector<AgencyPrecondition>{
                 AgencyPrecondition{
                     "Plan/Collections/myDbName/123456/distributeShardsLike",


### PR DESCRIPTION
Changes backported from #5649, plus fix of `js/server/tests/resilience/repair-distribute-shards-like-spec.js`.