### PR TITLE
fix-iresearch-doc

### DIFF
--- a/Documentation/Books/HTTP/SUMMARY.md
+++ b/Documentation/Books/HTTP/SUMMARY.md
@@ -44,6 +44,7 @@
   * [Fulltext](Indexes/Fulltext.md)
 * [Views](Views/README.md)
   * [Creating](Views/Creating.md)
+  * [Deleting](Views/Dropping.md)
   * [Modifying](Views/Modifying.md)
   * [Retrieving](Views/Getting.md)
   * [ArangoSearch Views](Views/ArangoSearch.md)

--- a/Documentation/DocuBlocks/Rest/Views/delete_api_view.md
+++ b/Documentation/DocuBlocks/Rest/Views/delete_api_view.md
@@ -5,7 +5,7 @@
 
 @RESTURLPARAMETERS
 
-@RESTURLPARAM{view-name, string, required}
+@RESTURLPARAM{view-name,string,required}
 The name of the view to drop.
 
 @RESTDESCRIPTION

--- a/Documentation/DocuBlocks/Rest/Views/get_api_view_name.md
+++ b/Documentation/DocuBlocks/Rest/Views/get_api_view_name.md
@@ -5,7 +5,7 @@
 
 @RESTURLPARAMETERS
 
-@RESTURLPARAM{view-name, string, required}
+@RESTURLPARAM{view-name,string,required}
 The name of the view.
 
 @RESTDESCRIPTION

--- a/Documentation/DocuBlocks/Rest/Views/patch_api_view_properties.md
+++ b/Documentation/DocuBlocks/Rest/Views/patch_api_view_properties.md
@@ -1,11 +1,11 @@
 @startDocuBlock patch_api_view_properties
 @brief partially changes properties of an ArangoDB view
 
-@RESTHEADER{PATCH /_api/view/{view-name}/properties#<view-type>, Partially changes properties of an ArangoDB view}
+@RESTHEADER{PATCH /_api/view/{view-name}/properties#arangosearch, Partially changes properties of an ArangoDB view}
 
 @RESTURLPARAMETERS
 
-@RESTURLPARAM{view-name, string, required}
+@RESTURLPARAM{view-name,string,required}
 The name of the view.
 
 @RESTDESCRIPTION

--- a/Documentation/DocuBlocks/Rest/Views/patch_api_view_properties_iresearch.md
+++ b/Documentation/DocuBlocks/Rest/Views/patch_api_view_properties_iresearch.md
@@ -5,18 +5,18 @@
 
 @RESTURLPARAMETERS
 
-@RESTURLPARAM{view-name, string, required}
+@RESTURLPARAM{view-name,string,required}
 The name of the view.
 
-@RESTBODYPARAM{properties, object, optional, post_api_view_props}
+@RESTBODYPARAM{properties,object,optional,post_api_view_props}
 The view properties. If specified, then *properties* should be a JSON object
 containing the following attributes:
 
 
-@RESTSTRUCT{commit, post_api_view_props, object, optional, post_api_view_props_commit}
+@RESTSTRUCT{commit,post_api_view_props,object,optional,post_api_view_props_commit}
 Commit options for regular operations.
 
-@RESTSTRUCT{commitIntervalMsec, post_api_view_props_commit, integer, optional, uint64}
+@RESTSTRUCT{commitIntervalMsec,post_api_view_props_commit,integer,optional,uint64}
 Wait at least this many milliseconds between committing index data changes and
 making them visible to queries (default: 60000, to disable use: 0).
 For the case where there are a lot of inserts/updates, a lower value, until
@@ -26,7 +26,7 @@ For the case where there are a few inserts/updates, a higher value will impact
 performance and waste disk space for each commit call without any added
 benefits.
 
-@RESTSTRUCT{cleanupIntervalStep, post_api_view_props_commit, integer, optional, uint64}
+@RESTSTRUCT{cleanupIntervalStep,post_api_view_props_commit,integer,optional,uint64}
 Wait at least this many commits between removing unused files in data
 directory (default: 10, to disable use: 0).
 For the case where the consolidation policies merge segments often (i.e. a lot
@@ -37,82 +37,82 @@ inserts/deletes), a higher value will impact performance without any added
 benefits.
 
 
-@RESTSTRUCT{consolidate, post_api_view_props_commit, object,optional, post_api_view_props_consolidation}
+@RESTSTRUCT{consolidate,post_api_view_props_commit,object,optional,post_api_view_props_consolidation}
 
 
-@RESTSTRUCT{bytes, post_api_view_props_consolidation, object, optional, post_api_view_props_consolidation_bytes}
+@RESTSTRUCT{bytes,post_api_view_props_consolidation,object,optional,post_api_view_props_consolidation_bytes}
 Use empty object for default values, i.e. {}
 
-@RESTSTRUCT{segmentThreshold, post_api_view_props_consolidation_bytes, integer, optional,uint64}
+@RESTSTRUCT{segmentThreshold,post_api_view_props_consolidation_bytes,integer,optional,uint64}
 Apply consolidation policy IFF {segmentThreshold} >= #segments (default: 300, to disable use: 0)
 
-@RESTSTRUCT{threshold, post_api_view_props_consolidation_bytes, integer, optional,uint64}
+@RESTSTRUCT{threshold,post_api_view_props_consolidation_bytes,integer,optional,uint64}
 Consolidate IFF {threshold} > segment_bytes / (all_segment_bytes / #segments) (default: 0.85)
 
 
-@RESTSTRUCT{bytes_accum, post_api_view_props_consolidation, object, optional, post_api_view_props_consolidation_bytes_accum}
+@RESTSTRUCT{bytes_accum,post_api_view_props_consolidation,object,optional,post_api_view_props_consolidation_bytes_accum}
 Use empty object for default values, i.e. {}
 
-@RESTSTRUCT{segmentThreshold, post_api_view_props_consolidation_bytes_accum, integer, optional, uint64}
+@RESTSTRUCT{segmentThreshold,post_api_view_props_consolidation_bytes_accum,integer,optional,uint64}
 Apply consolidation policy IFF {segmentThreshold} >= #segments (default: 300, to disable use: 0)
 
-@RESTSTRUCT{threshold, post_api_view_props_consolidation_bytes_accum, integer, optional, uint64}
+@RESTSTRUCT{threshold,post_api_view_props_consolidation_bytes_accum,integer,optional,uint64}
 Consolidate IFF {threshold} > (segment_bytes + sum_of_merge_candidate_segment_bytes) / all_segment_bytes (default: 0.85)
 
 
-@RESTSTRUCT{count, post_api_view_props_consolidation, object, optional, post_api_view_props_consolidation_count}
+@RESTSTRUCT{count,post_api_view_props_consolidation,object,optional,post_api_view_props_consolidation_count}
 Use empty object for default values, i.e. {}
 
-@RESTSTRUCT{segmentThreshold, post_api_view_props_consolidation_count, integer, optional, uint64}
+@RESTSTRUCT{segmentThreshold,post_api_view_props_consolidation_count,integer,optional,uint64}
 Apply consolidation policy IFF {segmentThreshold} >= #segments (default: 300, to disable use: 0)
 
-@RESTSTRUCT{threshold, post_api_view_props_consolidation_count, integer, optional, uint64}
+@RESTSTRUCT{threshold,post_api_view_props_consolidation_count,integer,optional,uint64}
 Consolidate IFF {threshold} > segment_docs{valid} / (all_segment_docs{valid} / #segments) (default: 0.85)
 
 
-@RESTSTRUCT{fill, post_api_view_props_consolidation, object, optional,post_api_view_props_consolidation_fill}
+@RESTSTRUCT{fill,post_api_view_props_consolidation,object,optional,post_api_view_props_consolidation_fill}
 Use empty object for default values, i.e. {}
 
-@RESTSTRUCT{segmentThreshold, post_api_view_props_consolidation_fill, integer, optional, uint64}
+@RESTSTRUCT{segmentThreshold,post_api_view_props_consolidation_fill,integer,optional,uint64}
 Apply consolidation policy IFF {segmentThreshold} >= #segments (default: 300, to disable use: 0)
 
-@RESTSTRUCT{threshold, post_api_view_props_consolidation_fill, integer, optional, uint64}
+@RESTSTRUCT{threshold,post_api_view_props_consolidation_fill,integer,optional,uint64}
 Consolidate IFF {threshold} > #segment_docs{valid} / (#segment_docs{valid} + #segment_docs{removed}) (default: 0.85)
 
 
-@RESTSTRUCT{links, post_api_view_props, object, optional, post_api_view_links}
+@RESTSTRUCT{links,post_api_view_props,object,optional,post_api_view_links}
 The set of collection names associated with the properties.
 
 
-@RESTSTRUCT{[collection-name], post_api_view_links, object, optional, post_api_view_link_props}
+@RESTSTRUCT{[collection-name],post_api_view_links,object,optional,post_api_view_link_props}
 The link properties. If specified, then *properties* should be a JSON object
 containing the following attributes:
 
-@RESTSTRUCT{analyzers, post_api_view_link_props, array, optional, string}
+@RESTSTRUCT{analyzers,post_api_view_link_props,array,optional,string}
 The list of analyzers to be used for indexing of string values
 (default: ["identity"]).
 
 
-@RESTSTRUCT{fields, post_api_view_link_props, object, optional, post_api_view_fields}
+@RESTSTRUCT{fields,post_api_view_link_props,object,optional,post_api_view_fields}
 The field properties. If specified, then *properties* should be a JSON object
 containing the following attributes:
 
-@RESTSTRUCT{[field-name], post_api_view_fields, array, optional, post_api_view_field_props}
+@RESTSTRUCT{[field-name],post_api_view_fields,,optional,post_api_view_field_props}
 This is a recursive structure for the specific attribute path, potentially
 containing any of the following attributes:
 *analyzers*, *includeAllFields*, *trackListPositions*, *trackValues*
 Any attributes not specified are inherited from the parent.
 
 
-@RESTSTRUCT{includeAllFields, post_api_view_link_props, boolean, optional, bool}
+@RESTSTRUCT{includeAllFields,post_api_view_link_props,boolean,optional,bool}
 The flag determines whether or not to index all fields on a particular level of
 depth (default: false).
 
-@RESTSTRUCT{trackListPositions, post_api_view_link_props, boolean, optional, bool}
+@RESTSTRUCT{trackListPositions,post_api_view_link_props,boolean,optional,bool}
 The flag determines whether or not values in a lists should be treated separate
 (default: false).
 
-@RESTSTRUCT{trackValues, post_api_view_link_props, string, optional, string}
+@RESTSTRUCT{trackValues,post_api_view_link_props,string,optional,string}
 How should the view track the attribute values, this setting allows for
 additional value retrieval optimizations, one of:
 - *none*: Do not track values by the view
@@ -120,7 +120,7 @@ additional value retrieval optimizations, one of:
 (default "none").
 
 
-@RESTSTRUCT{locale, post_api_view_props, string, optional, string}
+@RESTSTRUCT{locale,post_api_view_props,string,optional,string}
 The default locale used for queries on analyzed string values (default: *C*).
 
 

--- a/Documentation/DocuBlocks/Rest/Views/post_api_view.md
+++ b/Documentation/DocuBlocks/Rest/Views/post_api_view.md
@@ -1,16 +1,16 @@
 @startDocuBlock post_api_view
 @brief creates an ArangoDB view
 
-@RESTHEADER{POST /_api/view#<view-type>, Create an ArangoDB view}
+@RESTHEADER{POST /_api/view#arangosearch, Create an ArangoDB view}
 
-@RESTBODYPARAM{name, string, required, string}
+@RESTBODYPARAM{name,string,required,string}
 The name of the view.
 
-@RESTBODYPARAM{type, string, required, string}
+@RESTBODYPARAM{type,string,required,string}
 The type of the view. must be equal to one of the supported ArangoDB view
 types.
 
-@RESTBODYPARAM{properties, object, optional, post_api_view_props}
+@RESTBODYPARAM{properties,object,optional,post_api_view_props}
 The view properties. If specified, then *properties* should be a JSON object
 containing the attributes supported by the specific view type.
 

--- a/Documentation/DocuBlocks/Rest/Views/post_api_view_iresearch.md
+++ b/Documentation/DocuBlocks/Rest/Views/post_api_view_iresearch.md
@@ -3,21 +3,21 @@
 
 @RESTHEADER{POST /_api/view#ArangoSearch, Create an ArangoSearch view}
 
-@RESTBODYPARAM{name, string, required, string}
+@RESTBODYPARAM{name,string,required,string}
 The name of the view.
 
-@RESTBODYPARAM{type, string, required, string}
+@RESTBODYPARAM{type,string,required,string}
 The type of the view. must be equal to *"arangosearch"*
 
-@RESTBODYPARAM{properties, object, optional, post_api_view_props}
+@RESTBODYPARAM{properties,object,optional,post_api_view_props}
 The view properties. If specified, then *properties* should be a JSON object
 containing the following attributes:
 
 
-@RESTSTRUCT{commit, post_api_view_props, object, optional, post_api_view_props_commit}
+@RESTSTRUCT{commit,post_api_view_props,object,optional,post_api_view_props_commit}
 Commit options for regular operations.
 
-@RESTSTRUCT{commitIntervalMsec, post_api_view_props_commit, integer, optional, uint64}
+@RESTSTRUCT{commitIntervalMsec,post_api_view_props_commit,integer,optional,uint64}
 Wait at least this many milliseconds between committing index data changes and
 making them visible to queries (default: 60000, to disable use: 0).
 For the case where there are a lot of inserts/updates, a lower value, until
@@ -27,7 +27,7 @@ For the case where there are a few inserts/updates, a higher value will impact
 performance and waste disk space for each commit call without any added
 benefits.
 
-@RESTSTRUCT{cleanupIntervalStep, post_api_view_props_commit, integer, optional, uint64}
+@RESTSTRUCT{cleanupIntervalStep,post_api_view_props_commit,integer,optional,uint64}
 Wait at least this many commits between removing unused files in data
 directory (default: 10, to disable use: 0).
 For the case where the consolidation policies merge segments often (i.e. a lot
@@ -38,50 +38,50 @@ inserts/deletes), a higher value will impact performance without any added
 benefits.
 
 
-@RESTSTRUCT{consolidate, post_api_view_props_commit, object,optional, post_api_view_props_consolidation}
+@RESTSTRUCT{consolidate,post_api_view_props_commit,object,optional,post_api_view_props_consolidation}
 
 
-@RESTSTRUCT{bytes, post_api_view_props_consolidation, object, optional, post_api_view_props_consolidation_bytes}
+@RESTSTRUCT{bytes,post_api_view_props_consolidation,object,optional,post_api_view_props_consolidation_bytes}
 Use empty object for default values, i.e. {}
 
-@RESTSTRUCT{segmentThreshold, post_api_view_props_consolidation_bytes, integer, optional, uint64}
+@RESTSTRUCT{segmentThreshold,post_api_view_props_consolidation_bytes,integer,optional,uint64}
 Apply consolidation policy IFF {segmentThreshold} >= #segments (default: 300, to disable use: 0)
 
-@RESTSTRUCT{threshold, post_api_view_props_consolidation_bytes, integer, optional,uint64}
+@RESTSTRUCT{threshold,post_api_view_props_consolidation_bytes,integer,optional,uint64}
 Consolidate IFF {threshold} > segment_bytes / (all_segment_bytes / #segments) (default: 0.85)
 
 
-@RESTSTRUCT{bytes_accum, post_api_view_props_consolidation, object, optional, post_api_view_props_consolidation_bytes_accum}
+@RESTSTRUCT{bytes_accum,post_api_view_props_consolidation,object,optional,post_api_view_props_consolidation_bytes_accum}
 Use empty object for default values, i.e. {}
 
-@RESTSTRUCT{segmentThreshold, post_api_view_props_consolidation_bytes_accum, integer, optional, uint64}
+@RESTSTRUCT{segmentThreshold,post_api_view_props_consolidation_bytes_accum,integer,optional,uint64}
 Apply consolidation policy IFF {segmentThreshold} >= #segments (default: 300, to disable use: 0)
 
-@RESTSTRUCT{threshold, post_api_view_props_consolidation_bytes_accum, integer, optional, uint64}
+@RESTSTRUCT{threshold,post_api_view_props_consolidation_bytes_accum,integer,optional,uint64}
 Consolidate IFF {threshold} > (segment_bytes + sum_of_merge_candidate_segment_bytes) / all_segment_bytes (default: 0.85)
 
 
-@RESTSTRUCT{count, post_api_view_props_consolidation, object, optional, post_api_view_props_consolidation_count}
+@RESTSTRUCT{count,post_api_view_props_consolidation,object,optional,post_api_view_props_consolidation_count}
 Use empty object for default values, i.e. {}
 
-@RESTSTRUCT{segmentThreshold, post_api_view_props_consolidation_count, integer, optional, uint64}
+@RESTSTRUCT{segmentThreshold,post_api_view_props_consolidation_count,integer,optional,uint64}
 Apply consolidation policy IFF {segmentThreshold} >= #segments (default: 300, to disable use: 0)
 
-@RESTSTRUCT{threshold, post_api_view_props_consolidation_count, integer, optional, uint64}
+@RESTSTRUCT{threshold,post_api_view_props_consolidation_count,integer,optional,uint64}
 Consolidate IFF {threshold} > segment_docs{valid} / (all_segment_docs{valid} / #segments) (default: 0.85)
 
 
-@RESTSTRUCT{fill, post_api_view_props_consolidation, object, optional,post_api_view_props_consolidation_fill}
+@RESTSTRUCT{fill,post_api_view_props_consolidation,object,optional,post_api_view_props_consolidation_fill}
 Use empty object for default values, i.e. {}
 
-@RESTSTRUCT{segmentThreshold, post_api_view_props_consolidation_fill, integer, optional, uint64}
+@RESTSTRUCT{segmentThreshold,post_api_view_props_consolidation_fill,integer,optional,uint64}
 Apply consolidation policy IFF {segmentThreshold} >= #segments (default: 300, to disable use: 0)
 
-@RESTSTRUCT{threshold, post_api_view_props_consolidation_fill, integer, optional, uint64}
+@RESTSTRUCT{threshold,post_api_view_props_consolidation_fill,integer,optional,uint64}
 Consolidate IFF {threshold} > #segment_docs{valid} / (#segment_docs{valid} + #segment_docs{removed}) (default: 0.85)
 
 
-@RESTSTRUCT{locale, post_api_view_props, string, optional, string}
+@RESTSTRUCT{locale,post_api_view_props,string,optional,string}
 The default locale used for queries on analyzed string values (default: *C*).
 
 

--- a/Documentation/DocuBlocks/Rest/Views/put_api_view_properties.md
+++ b/Documentation/DocuBlocks/Rest/Views/put_api_view_properties.md
@@ -1,11 +1,11 @@
 @startDocuBlock put_api_view_properties
 @brief changes properties of an ArangoDB view
 
-@RESTHEADER{PUT /_api/view/{view-name}/properties#<view-type>, Change properties of an ArangoDB view}
+@RESTHEADER{PUT /_api/view/{view-name}/properties#arangosearch, Change properties of an ArangoDB view}
 
 @RESTURLPARAMETERS
 
-@RESTURLPARAM{view-name, string, required}
+@RESTURLPARAM{view-name,string,required}
 The name of the view.
 
 @RESTDESCRIPTION

--- a/Documentation/DocuBlocks/Rest/Views/put_api_view_properties_iresearch.md
+++ b/Documentation/DocuBlocks/Rest/Views/put_api_view_properties_iresearch.md
@@ -5,18 +5,18 @@
 
 @RESTURLPARAMETERS
 
-@RESTURLPARAM{view-name, string, required}
+@RESTURLPARAM{view-name,string,required}
 The name of the view.
 
-@RESTBODYPARAM{properties, object, optional, post_api_view_props}
+@RESTBODYPARAM{properties,object,optional,post_api_view_props}
 The view properties. If specified, then *properties* should be a JSON object
 containing the following attributes:
 
 
-@RESTSTRUCT{commit, post_api_view_props, object, optional, post_api_view_props_commit}
+@RESTSTRUCT{commit,post_api_view_props,object,optional,post_api_view_props_commit}
 Commit options for regular operations.
 
-@RESTSTRUCT{commitIntervalMsec, post_api_view_props_commit, integer, optional, uint64}
+@RESTSTRUCT{commitIntervalMsec,post_api_view_props_commit,integer,optional,uint64}
 Wait at least this many milliseconds between committing index data changes and
 making them visible to queries (default: 60000, to disable use: 0).
 For the case where there are a lot of inserts/updates, a lower value, until
@@ -26,7 +26,7 @@ For the case where there are a few inserts/updates, a higher value will impact
 performance and waste disk space for each commit call without any added
 benefits.
 
-@RESTSTRUCT{cleanupIntervalStep, post_api_view_props_commit, integer, optional, uint64}
+@RESTSTRUCT{cleanupIntervalStep,post_api_view_props_commit,integer,optional,uint64}
 Wait at least this many commits between removing unused files in data
 directory (default: 10, to disable use: 0).
 For the case where the consolidation policies merge segments often (i.e. a lot
@@ -37,82 +37,80 @@ inserts/deletes), a higher value will impact performance without any added
 benefits.
 
 
-@RESTSTRUCT{consolidate, post_api_view_props_commit, object,optional, post_api_view_props_consolidation}
+@RESTSTRUCT{consolidate,post_api_view_props_commit,object,optional,post_api_view_props_consolidation}
 
 
-@RESTSTRUCT{bytes, post_api_view_props_consolidation, object, optional, post_api_view_props_consolidation_bytes}
+@RESTSTRUCT{bytes,post_api_view_props_consolidation,object,optional,post_api_view_props_consolidation_bytes}
 Use empty object for default values, i.e. {}
 
-@RESTSTRUCT{segmentThreshold, post_api_view_props_consolidation_bytes, integer, optional, uint64}
+@RESTSTRUCT{segmentThreshold,post_api_view_props_consolidation_bytes,integer,optional,uint64}
 Apply consolidation policy IFF {segmentThreshold} >= #segments (default: 300, to disable use: 0)
 
-@RESTSTRUCT{threshold, post_api_view_props_consolidation_bytes, integer, optional,uint64}
+@RESTSTRUCT{threshold,post_api_view_props_consolidation_bytes,integer,optional,uint64}
 Consolidate IFF {threshold} > segment_bytes / (all_segment_bytes / #segments) (default: 0.85)
 
 
-@RESTSTRUCT{bytes_accum, post_api_view_props_consolidation, object, optional, post_api_view_props_consolidation_bytes_accum}
+@RESTSTRUCT{bytes_accum,post_api_view_props_consolidation,object,optional,post_api_view_props_consolidation_bytes_accum}
 Use empty object for default values, i.e. {}
 
-@RESTSTRUCT{segmentThreshold, post_api_view_props_consolidation_bytes_accum, integer, optional, uint64}
+@RESTSTRUCT{segmentThreshold,post_api_view_props_consolidation_bytes_accum,integer,optional,uint64}
 Apply consolidation policy IFF {segmentThreshold} >= #segments (default: 300, to disable use: 0)
 
-@RESTSTRUCT{threshold, post_api_view_props_consolidation_bytes_accum, integer, optional, uint64}
+@RESTSTRUCT{threshold,post_api_view_props_consolidation_bytes_accum,integer,optional,uint64}
 Consolidate IFF {threshold} > (segment_bytes + sum_of_merge_candidate_segment_bytes) / all_segment_bytes (default: 0.85)
 
 
-@RESTSTRUCT{count, post_api_view_props_consolidation, object, optional, post_api_view_props_consolidation_count}
+@RESTSTRUCT{count,post_api_view_props_consolidation,object,optional,post_api_view_props_consolidation_count}
 Use empty object for default values, i.e. {}
 
-@RESTSTRUCT{segmentThreshold, post_api_view_props_consolidation_count, integer, optional, uint64}
+@RESTSTRUCT{segmentThreshold,post_api_view_props_consolidation_count,integer,optional,uint64}
 Apply consolidation policy IFF {segmentThreshold} >= #segments (default: 300, to disable use: 0)
 
-@RESTSTRUCT{threshold, post_api_view_props_consolidation_count, integer, optional, uint64}
+@RESTSTRUCT{threshold,post_api_view_props_consolidation_count,integer,optional,uint64}
 Consolidate IFF {threshold} > segment_docs{valid} / (all_segment_docs{valid} / #segments) (default: 0.85)
 
 
-@RESTSTRUCT{fill, post_api_view_props_consolidation, object, optional,post_api_view_props_consolidation_fill}
+@RESTSTRUCT{fill,post_api_view_props_consolidation,object,optional,post_api_view_props_consolidation_fill}
 Use empty object for default values, i.e. {}
 
-@RESTSTRUCT{segmentThreshold, post_api_view_props_consolidation_fill, integer, optional, uint64}
+@RESTSTRUCT{segmentThreshold,post_api_view_props_consolidation_fill,integer,optional,uint64}
 Apply consolidation policy IFF {segmentThreshold} >= #segments (default: 300, to disable use: 0)
 
-@RESTSTRUCT{threshold, post_api_view_props_consolidation_fill, integer, optional, uint64}
+@RESTSTRUCT{threshold,post_api_view_props_consolidation_fill,integer,optional,uint64}
 Consolidate IFF {threshold} > #segment_docs{valid} / (#segment_docs{valid} + #segment_docs{removed}) (default: 0.85)
 
 
-@RESTSTRUCT{links, post_api_view_props, object, optional, post_api_view_links}
+@RESTSTRUCT{links,post_api_view_props,object,optional,post_api_view_links}
 The set of collection names associated with the properties.
 
 
-@RESTSTRUCT{[collection-name], post_api_view_links, object, optional, post_api_view_link_props}
+@RESTSTRUCT{[collection-name],post_api_view_links,object,optional,post_api_view_link_props}
 The link properties. If specified, then *properties* should be a JSON object
 containing the following attributes:
 
-@RESTSTRUCT{analyzers, post_api_view_link_props, array, optional, string}
+@RESTSTRUCT{analyzers,post_api_view_link_props,array,optional,string}
 The list of analyzers to be used for indexing of string values
 (default: ["identity"]).
 
-
-@RESTSTRUCT{fields, post_api_view_link_props, object, optional, post_api_view_fields}
+@RESTSTRUCT{fields,post_api_view_link_props,object,optional,post_api_view_fields}
 The field properties. If specified, then *properties* should be a JSON object
 containing the following attributes:
 
-@RESTSTRUCT{[field-name], post_api_view_fields, array, optional, post_api_view_field_props}
+@RESTSTRUCT{[field-name],post_api_view_fields,,optional,post_api_view_field_props}
 This is a recursive structure for the specific attribute path, potentially
 containing any of the following attributes:
 *analyzers*, *includeAllFields*, *trackListPositions*, *trackValues*
 Any attributes not specified are inherited from the parent.
 
-
-@RESTSTRUCT{includeAllFields, post_api_view_link_props, boolean, optional, bool}
+@RESTSTRUCT{includeAllFields,post_api_view_link_props,boolean,optional,bool}
 The flag determines whether or not to index all fields on a particular level of
 depth (default: false).
 
-@RESTSTRUCT{trackListPositions, post_api_view_link_props, boolean, optional, bool}
+@RESTSTRUCT{trackListPositions,post_api_view_link_props,boolean,optional,bool}
 The flag determines whether or not values in a lists should be treated separate
 (default: false).
 
-@RESTSTRUCT{trackValues, post_api_view_link_props, string, optional, string}
+@RESTSTRUCT{trackValues,post_api_view_link_props,string,optional,string}
 How should the view track the attribute values, this setting allows for
 additional value retrieval optimizations, one of:
 - *none*: Do not track values by the view
@@ -120,7 +118,7 @@ additional value retrieval optimizations, one of:
 (default "none").
 
 
-@RESTSTRUCT{locale, post_api_view_props, string, optional, string}
+@RESTSTRUCT{locale,post_api_view_props,string,optional,string}
 The default locale used for queries on analyzed string values (default: *C*).
 
 


### PR DESCRIPTION
- remove blank spaces in REST-blocks
- add missing link
- remove type from "@RESTSTRUCT{[field-name],post_api_view_fields,,optional,post_api_view_field_props}"
- replace in @RESTHEADER `#<view-type>` with `#arangosearch`