### PR TITLE
Docs: Make use of new per-page settings for page-toc plugin

### DIFF
--- a/Documentation/Books/Drivers/README.md
+++ b/Documentation/Books/Drivers/README.md
@@ -1,7 +1,12 @@
+---
+page-toc:
+  disable: true
+---
 ArangoDB VERSION_NUMBER Drivers Documentation
 =============================================
 
-**Official drivers**
+Official drivers
+----------------
 
 Name | Language | Repository | &nbsp;
 -----|----------|------------|-------
@@ -11,14 +16,16 @@ Name | Language | Repository | &nbsp;
 [ArangoDB-PHP](PHP/README.md) | PHP | https://github.com/arangodb/arangodb-php | [Changelog](https://github.com/arangodb/arangodb-php/blob/devel/CHANGELOG.md#readme)
 [Go-Driver](GO/README.md) | Go | https://github.com/arangodb/go-driver | [Changelog](https://github.com/arangodb/go-driver/blob/master/CHANGELOG.md#readme)
 
-**Integrations**
+Integrations
+------------
 
 Name | Language | Repository | &nbsp;
 -----|----------|------------|-------
 [Spring Data](SpringData/README.md) | Java | https://github.com/arangodb/spring-data | [Changelog](https://github.com/arangodb/spring-data/blob/master/ChangeLog.md#readme)
 [ArangoDB-Spark-Connector](SparkConnector/README.md) | Scala, Java | https://github.com/arangodb/arangodb-spark-connector | [Changelog](https://github.com/arangodb/arangodb-spark-connector/blob/master/ChangeLog.md#readme)
 
-**Community drivers**
+Community drivers
+-----------------
 
 Please note that this list is not exhaustive.
 

--- a/Documentation/Books/Manual/README.md
+++ b/Documentation/Books/Manual/README.md
@@ -1,3 +1,7 @@
+---
+page-toc:
+  disable: true
+---
 ArangoDB VERSION_NUMBER Documentation
 =====================================
 
@@ -8,7 +12,8 @@ New and eager to try out ArangoDB? Start right away with our beginner's guide:
 [**Getting Started**](GettingStarted/README.md)
 {% endhint %}
 
-**Structure**
+Structure
+---------
 
 The documentation is organized in five handbooks:
 
@@ -33,7 +38,8 @@ their own examples based on these .js based examples to improve understandabilit
 for their respective users, i.e. for the [java driver](https://github.com/arangodb/arangodb-java-driver#learn-more)
 some of the samples are re-implemented.
 
-**Key Features**
+Key Features
+------------
  
 ArangoDB is a native multi-model, open-source database with flexible data models for documents, graphs, and key-values. Build high performance applications using a convenient SQL-like query language or JavaScript extensions. Use ACID transactions if you require them. Scale horizontally and vertically with a few mouse clicks.
 
@@ -51,7 +57,8 @@ Key features include:
 * ArangoDB can be easily deployed as a [**fault-tolerant distributed state machine**](Deployment/StandaloneAgency/README.md), which can serve as the animal brain of distributed appliances
 * It is **open source** (Apache License 2.0)
 
-**Community**
+Community
+---------
  
 If you have questions regarding ArangoDB, Foxx, drivers, or this documentation don't hesitate to contact us on:
 


### PR DESCRIPTION
Disable page-toc, use headlines again on first pages of Manual and Drivers book
