### PR TITLE
Fix GeneralRequestMock constructor sequence

### DIFF
--- a/tests/IResearch/RestHandlerMock.cpp
+++ b/tests/IResearch/RestHandlerMock.cpp
@@ -25,11 +25,12 @@
 #include "RestServer/VocbaseContext.h"
 #include "VocBase/vocbase.h"
 
-GeneralRequestMock::GeneralRequestMock(TRI_vocbase_t& vocbase)
-  : _context(arangodb::VocbaseContext::create(*this, vocbase)) {
-  _context->vocbase().forceUse(); // must be called or ~VocbaseContext() will fail at '_vocbase.release()'
-  _requestContext = _context.get(); // do not use setRequestContext(...) since '_requestContext' has not been initialized and contains garbage
+GeneralRequestMock::GeneralRequestMock(TRI_vocbase_t& vocbase) {
+  _authenticated = false;
   _isRequestContextOwner = false;
+  _context.reset(arangodb::VocbaseContext::create(*this, vocbase));
+  _context->vocbase().forceUse(); // must be called or ~VocbaseContext() will fail at '_vocbase.release()'  
+  _requestContext = _context.get(); // do not use setRequestContext(...) since '_requestContext' has not been initialized and contains garbage
 }
 
 std::unordered_map<std::string, std::vector<std::string>> GeneralRequestMock::arrayValues() const {


### PR DESCRIPTION
Fix GeneralRequestMock constructor sequence to behave properly with `clang-900.0.39.2`.