### PR TITLE
Remove shell_client_aql suite from blacklist

### DIFF
--- a/UnitTests/OskarTestSuitesBlackList
+++ b/UnitTests/OskarTestSuitesBlackList
@@ -1,1 +1,1 @@
-shell_client_aql
+


### PR DESCRIPTION
Removed shell_client_aql suite from blacklist (OskarBlackList). Now ArangoSearch tests from `js/common/tests/aql` should execute on both server and client sides.