### PR TITLE
fixed some rare assertion failures complaining about non-sealed dataf…

### DIFF
--- a/arangod/MMFiles/MMFilesCollection.cpp
+++ b/arangod/MMFiles/MMFilesCollection.cpp
@@ -683,11 +683,14 @@ int MMFilesCollection::sealDatafile(MMFilesDatafile* datafile,
     std::string dname("datafile-" + std::to_string(datafile->fid()) + ".db");
     std::string filename =
         arangodb::basics::FileUtils::buildFilename(path(), dname);
+      
+    LOG_TOPIC(TRACE, arangodb::Logger::DATAFILES) << "closing and renaming journal file '"
+                                                  << datafile->getName() << "'";
 
     res = datafile->rename(filename);
 
     if (res == TRI_ERROR_NO_ERROR) {
-      LOG_TOPIC(TRACE, arangodb::Logger::DATAFILES) << "closed file '"
+      LOG_TOPIC(TRACE, arangodb::Logger::DATAFILES) << "closed and renamed journal file '"
                                                     << datafile->getName() << "'";
     } else {
       LOG_TOPIC(ERR, arangodb::Logger::DATAFILES)

--- a/arangod/MMFiles/MMFilesDatafile.cpp
+++ b/arangod/MMFiles/MMFilesDatafile.cpp
@@ -181,7 +181,7 @@ static uint64_t GetNumericFilenamePart(char const* filename) {
 #ifdef TRI_HAVE_ANONYMOUS_MMAP
 
 static MMFilesDatafile* CreateAnonymousDatafile(TRI_voc_fid_t fid,
-                                               uint32_t maximalSize) {
+                                                uint32_t maximalSize) {
 #ifdef TRI_MMAP_ANONYMOUS
   // fd -1 is required for "real" anonymous regions
   int fd = -1;
@@ -952,7 +952,7 @@ static std::string DiagnoseMarker(MMFilesMarker const* marker,
 }
 
 MMFilesDatafile::MMFilesDatafile(std::string const& filename, int fd, void* mmHandle, uint32_t maximalSize,
-                               uint32_t currentSize, TRI_voc_fid_t fid, char* data)
+                                 uint32_t currentSize, TRI_voc_fid_t fid, char* data)
         : _filename(filename),
           _fid(fid),
           _state(TRI_DF_STATE_READ),
@@ -1233,10 +1233,10 @@ int MMFilesDatafile::truncateAndSeal(uint32_t position) {
 }
 
 /// @brief checks a datafile
-bool MMFilesDatafile::check(bool ignoreFailures) {
+bool MMFilesDatafile::check(bool ignoreFailures, bool autoSeal) {
   // this function must not be called for non-physical datafiles
   TRI_ASSERT(isPhysical());
-  LOG_TOPIC(TRACE, arangodb::Logger::DATAFILES) << "checking markers in datafile '" << getName() << "'";
+  LOG_TOPIC(TRACE, arangodb::Logger::DATAFILES) << "checking markers in datafile '" << getName() << "', autoSeal: " << autoSeal;
 
   char const* ptr = _data;
   char const* end = ptr + _currentSize;
@@ -1262,10 +1262,14 @@ bool MMFilesDatafile::check(bool ignoreFailures) {
 
     if (canRead) {
       if (size == 0) {
-        LOG_TOPIC(DEBUG, arangodb::Logger::DATAFILES) << "reached end of datafile '" << getName() << "' data, current size " << currentSize;
+        LOG_TOPIC(DEBUG, arangodb::Logger::DATAFILES) << "reached end of datafile '" << getName() << "' data, current size " << currentSize << ", autoSeal: " << autoSeal;
 
         _currentSize = currentSize;
         _next = _data + _currentSize;
+
+        if (autoSeal) {
+          _isSealed = true;
+        }
 
         return true;
       }
@@ -1772,7 +1776,7 @@ bool MMFilesDatafile::tryRepair() {
 
 /// @brief opens an existing datafile
 /// The datafile will be opened read-only if a footer is found
-MMFilesDatafile* MMFilesDatafile::open(std::string const& filename, bool ignoreFailures) {
+MMFilesDatafile* MMFilesDatafile::open(std::string const& filename, bool ignoreFailures, bool autoSeal) {
   // this function must not be called for non-physical datafiles
   TRI_ASSERT(!filename.empty());
 
@@ -1783,7 +1787,7 @@ MMFilesDatafile* MMFilesDatafile::open(std::string const& filename, bool ignoreF
   }
 
   // check the datafile by scanning markers
-  bool ok = datafile->check(ignoreFailures);
+  bool ok = datafile->check(ignoreFailures, autoSeal);
 
   if (!ok) {
     TRI_UNMMFile(const_cast<char*>(datafile->data()), datafile->initSize(), datafile->fd(), &datafile->_mmHandle);

--- a/arangod/MMFiles/MMFilesDatafile.h
+++ b/arangod/MMFiles/MMFilesDatafile.h
@@ -186,6 +186,9 @@ typedef uint32_t MMFilesDatafileVersionType;
 
 /// @brief datafile
 struct MMFilesDatafile {
+  MMFilesDatafile(MMFilesDatafile const&) = delete;
+  MMFilesDatafile& operator=(MMFilesDatafile const&) = delete;
+
   MMFilesDatafile(std::string const& filename, int fd, void* mmHandle, uint32_t maximalSize,
                  uint32_t currentsize, TRI_voc_fid_t fid, char* data);
   ~MMFilesDatafile();
@@ -228,7 +231,7 @@ struct MMFilesDatafile {
   static bool tryRepair(std::string const& path);
 
   /// @brief opens a datafile
-  static MMFilesDatafile* open(std::string const& filename, bool ignoreErrors);
+  static MMFilesDatafile* open(std::string const& filename, bool ignoreErrors, bool autoSeal);
 
   /// @brief writes a marker to the datafile
   /// this function will write the marker as-is, without any CRC or tick updates
@@ -285,7 +288,7 @@ struct MMFilesDatafile {
   int truncateAndSeal(uint32_t position);
 
   /// @brief checks a datafile
-  bool check(bool ignoreFailures);
+  bool check(bool ignoreFailures, bool autoSeal);
 
   /// @brief fixes a corrupted datafile
   bool fix(uint32_t currentSize);

--- a/arangod/MMFiles/MMFilesWalLogfile.cpp
+++ b/arangod/MMFiles/MMFilesWalLogfile.cpp
@@ -60,7 +60,7 @@ MMFilesWalLogfile* MMFilesWalLogfile::createNew(std::string const& filename, MMF
 /// @brief open an existing logfile
 MMFilesWalLogfile* MMFilesWalLogfile::openExisting(std::string const& filename, MMFilesWalLogfile::IdType id,
                                                    bool wasCollected, bool ignoreErrors) {
-  std::unique_ptr<MMFilesDatafile> df(MMFilesDatafile::open(filename, ignoreErrors));
+  std::unique_ptr<MMFilesDatafile> df(MMFilesDatafile::open(filename, ignoreErrors, false));
 
   if (df == nullptr) {
     int res = TRI_errno();


### PR DESCRIPTION
…iles

non-sealing of datafiles could actually happen when more than a single journal
was found at startup, and all but the last journals were converted into datafiles
automatically. these datafiles were not sealed, triggering the assertion failures
later in other places