### PR TITLE
centralized more of the sharding strategies code

### DIFF
--- a/Documentation/Books/Manual/Administration/Cluster/README.md
+++ b/Documentation/Books/Manual/Administration/Cluster/README.md
@@ -112,6 +112,36 @@ included in the list of attribute paths for the index:
 | a, b, c   | a, b      | not allowed |
 | a, b, c   | a, b, c   |     allowed |
 
+Sharding strategy
+-----------------
+
+strategy to use for the collection. Since ArangoDB 3.4 there are
+different sharding strategies to select from when creating a new 
+collection. The selected *shardingStrategy* value will remain
+fixed for the collection and cannot be changed afterwards. This is
+important to make the collection keep its sharding settings and
+always find documents already distributed to shards using the same
+initial sharding algorithm.
+
+The available sharding strategies are:
+- `community-compat`: default sharding used by ArangoDB community
+  versions before ArangoDB 3.4
+- `enterprise-compat`: default sharding used by ArangoDB enterprise
+  versions before ArangoDB 3.4
+- `enterprise-smart-edge-compat`: default sharding used by smart edge
+  collections in ArangoDB enterprise versions before ArangoDB 3.4
+- `hash`: default sharding used by ArangoDB 3.4 for new collections
+  (excluding smart edge collections)
+- `enterprise-hash-smart-edge`: default sharding used by ArangoDB 3.4 
+  for new smart edge collections
+
+If no sharding strategy is specified, the default will be `hash` for
+all collections, and `enterprise-hash-smart-edge` for all smart edge
+collections (requires the *Enterprise Edition* of ArangoDB). 
+Manually overriding the sharding strategy does not yet provide a 
+benefit, but it may later in case other sharding strategies are added.
+
+
 Moving/Rebalancing _shards_
 ---------------------------
 

--- a/Documentation/Books/Manual/Administration/Configuration/Compaction.md
+++ b/Documentation/Books/Manual/Administration/Configuration/Compaction.md
@@ -20,7 +20,7 @@ these documents are marked as 'dead' with a deletion marker.
 
 Over time the number of dead documents may rise, and we don't want to use the previously mentioned
 resources, plus the disk space should be given back to the system.
-Thus several journal files can be combined to one, ommitting the dead documents.
+Thus several journal files can be combined to one, omitting the dead documents.
 
 Combining several of these data files into one is called compaction. The compaction process reads
 the alive documents from the original data files, and writes them into new data file.

--- a/Documentation/Books/Manual/DataModeling/Collections/DatabaseMethods.md
+++ b/Documentation/Books/Manual/DataModeling/Collections/DatabaseMethods.md
@@ -165,11 +165,39 @@ to the [naming conventions](../NamingConventions/README.md).
   performance on these collections.
 
 - *distributeShardsLike* distribute the shards of this collection
-  cloning the shard distribution of another. If this value is set
-  it will copy *replicationFactor* and *numberOfShards* from the
-  other collection, the attributes in this collection will be 
-  ignored and can be omitted.
+  cloning the shard distribution of another. If this value is set,
+  it will copy the attributes *replicationFactor*, *numberOfShards* and 
+  *shardingStrategy* from the other collection. 
 
+- *shardingStrategy* (optional): specifies the name of the sharding
+  strategy to use for the collection. Since ArangoDB 3.4 there are
+  different sharding strategies to select from when creating a new 
+  collection. The selected *shardingStrategy* value will remain
+  fixed for the collection and cannot be changed afterwards. This is
+  important to make the collection keep its sharding settings and
+  always find documents already distributed to shards using the same
+  initial sharding algorithm.
+
+  The available sharding strategies are:
+  - `community-compat`: default sharding used by ArangoDB community
+    versions before ArangoDB 3.4
+  - `enterprise-compat`: default sharding used by ArangoDB enterprise
+    versions before ArangoDB 3.4
+  - `enterprise-smart-edge-compat`: default sharding used by smart edge
+    collections in ArangoDB enterprise versions before ArangoDB 3.4
+  - `hash`: default sharding used by ArangoDB 3.4 for new collections
+    (excluding smart edge collections)
+  - `enterprise-hash-smart-edge`: default sharding used by ArangoDB 3.4 
+    for new smart edge collections
+
+  If no sharding strategy is specified, the default will be `hash` for
+  all collections, and `enterprise-hash-smart-edge` for all smart edge
+  collections (requires the *Enterprise Edition* of ArangoDB). 
+  Manually overriding the sharding strategy does not yet provide a 
+  benefit, but it may later in case other sharding strategies are added.
+  
+  In single-server mode, the *shardingStrategy* attribute is meaningless 
+  and will be ignored.
 
 `db._create(collection-name, properties, type)`
 

--- a/Documentation/Books/Manual/Graphs/Pregel/README.md
+++ b/Documentation/Books/Manual/Graphs/Pregel/README.md
@@ -39,22 +39,22 @@ For example you might create your collections like this:
 ```javascript
 // Create main vertex collection: 
 db._create("vertices", {
-    shardKeys:['_key'],
-    numberOfShards: 8
-  });
+  shardKeys: ['_key'],
+  numberOfShards: 8
+});
 
 // Optionally create arbitrary additional vertex collections 
 db._create("additonal", {
-    distributeShardsLike:"vertices", 
-    numberOfShards:8
-  });
+  distributeShardsLike: "vertices", 
+  numberOfShards: 8
+});
 
 // Create (one or more) edge-collections: 
 db._createEdgeCollection("edges", {
-    shardKeys:['vertex'],
-    distributeShardsLike:"vertices",
-    numberOfShards:8
-  });
+  shardKeys: ['vertex'],
+  distributeShardsLike: "vertices",
+  numberOfShards: 8
+});
 ```
 
 You will need to ensure that edge documents contain the proper values in their sharding attribute.
@@ -62,9 +62,9 @@ For a vertex document with the following content ```{_key:"A", value:0}```
 the corresponding edge documents would have look like this:
 
 ```
-  {_from:"vertices/A", _to: "vertices/B", vertex:"A"}
-  {_from:"vertices/A", _to: "vertices/C", vertex:"A"}
-  {_from:"vertices/A", _to: "vertices/D", vertex:"A"}
+  {"_from":"vertices/A", "_to": "vertices/B", vertex:"A"}
+  {"_from":"vertices/A", "_to": "vertices/C", vertex:"A"}
+  {"_from":"vertices/A", "_to": "vertices/D", vertex:"A"}
   ...
 ```
 

--- a/Documentation/Books/Manual/Indexing/IndexBasics.md
+++ b/Documentation/Books/Manual/Indexing/IndexBasics.md
@@ -179,7 +179,7 @@ the `SORT` clause of the query in the same order as they appear in the index def
 Skiplist indexes are always created in ascending order, but they can be used to access
 the indexed elements in both ascending or descending order. However, for a combined index
 (an index on multiple attributes) this requires that the sort orders in a single query
-as specified in the `SORT` clause must be either all ascending (optionally ommitted 
+as specified in the `SORT` clause must be either all ascending (optionally omitted 
 as ascending is the default) or all descending. 
 
 For example, if the skiplist index is created on attributes `value1` and `value2` 

--- a/Documentation/Books/Manual/ReleaseNotes/UpgradingChanges34.md
+++ b/Documentation/Books/Manual/ReleaseNotes/UpgradingChanges34.md
@@ -175,8 +175,16 @@ HTTP REST API
 The following incompatible changes were made in context of ArangoDB's HTTP REST
 APIs:
 
+- The following, partly undocumented REST APIs have been removed in ArangoDB 3.4:
+
+  - `GET /_admin/test`
+  - `GET /_admin/clusterCheckPort`
+  - `GET /_admin/cluster-test` 
+  - `GET /_admin/statistics/short`
+  - `GET /_admin/statistics/long`
+
 - `GET /_api/index` will now return type `geo` for geo indexes, not type `geo1`
-  or `geo2`.
+  or `geo2` as previous versions did.
 
   For geo indexes, the index API will not return the attributes `constraint` and
   `ignoreNull` anymore. These attributes were initially deprecated in ArangoDB 2.5
@@ -202,12 +210,6 @@ APIs:
   In previous versions, this REST API returned only the list of available
   AQL user functions on the top level of the response.
   Each AQL user function description now also contains the 'isDeterministic' attribute.
-
-- `GET /_admin/status` now returns the attribute `operationMode` in addition to
-  `mode`. The attribute `writeOpsEnabled` is now also represented by the new an
-  attribute `readOnly`, which is has an inverted value compared to the original
-  attribute. In future releases the old attributes will be deprecated in favor
-  of the new ones.
 
 - if authentication is turned on, requests to databases by users with insufficient 
   access rights will be answered with HTTP 401 (forbidden) instead of HTTP 404 (not found).
@@ -246,6 +248,44 @@ The following APIs have been added or augmented:
   }
   ```
 
+- `GET /_admin/status` now returns the attribute `operationMode` in addition to
+  `mode`. The attribute `writeOpsEnabled` is now also represented by the new an
+  attribute `readOnly`, which is has an inverted value compared to the original
+  attribute. In future releases the old attributes will be deprecated in favor
+  of the new ones.
+
+- `POST /_api/collection` now will process the optional `shardingStrategy` 
+  attribute in the response body in cluster mode. 
+
+  This attribute specifies the name of the sharding strategy to use for the 
+  collection. Since ArangoDB 3.4 there are different sharding strategies to 
+  select from when creating a new collection. The selected *shardingStrategy* 
+  value will remain fixed for the collection and cannot be changed afterwards. 
+  This is important to make the collection keep its sharding settings and 
+  always find documents already distributed to shards using the same initial 
+  sharding algorithm.
+
+  The available sharding strategies are:
+  - `community-compat`: default sharding used by ArangoDB community
+    versions before ArangoDB 3.4
+  - `enterprise-compat`: default sharding used by ArangoDB enterprise
+    versions before ArangoDB 3.4
+  - `enterprise-smart-edge-compat`: default sharding used by smart edge
+    collections in ArangoDB enterprise versions before ArangoDB 3.4
+  - `hash`: default sharding used by ArangoDB 3.4 for new collections
+    (excluding smart edge collections)
+  - `enterprise-hash-smart-edge`: default sharding used by ArangoDB 3.4 
+    for new smart edge collections
+
+  If no sharding strategy is specified, the default will be `hash` for
+  all collections, and `enterprise-hash-smart-edge` for all smart edge
+  collections (requires the *Enterprise Edition* of ArangoDB). 
+  Manually overriding the sharding strategy does not yet provide a 
+  benefit, but it may later in case other sharding strategies are added.
+
+  In single-server mode, the *shardingStrategy* attribute is meaningless and
+  will be ignored.
+
 - APIs for view management have been added at endpoint `/_api/view`.
 
 - The REST APIs for modifying graphs at endpoint `/_api/gharial` now support returning
@@ -261,14 +301,6 @@ The following APIs have been added or augmented:
 
   The exception from this is that the HTTP DELETE verb for these APIs does not
   support `returnOld` because that would make the existing API incompatible.
-
-The following, partly undocumented REST APIs have been removed in ArangoDB 3.4:
-
-- `GET /_admin/test`
-- `GET /_admin/clusterCheckPort`
-- `GET /_admin/cluster-test` 
-- `GET /_admin/statistics/short`
-- `GET /_admin/statistics/long`
 
 
 AQL

--- a/Documentation/DocuBlocks/Rest/Collections/get_api_collection_properties.md
+++ b/Documentation/DocuBlocks/Rest/Collections/get_api_collection_properties.md
@@ -48,6 +48,8 @@ In a cluster setup, the result will also contain the following attributes:
 
 - *replicationFactor*: contains how many copies of each shard are kept on different DBServers.
 
+- *shardingStrategy*: the sharding strategy selected for the collection.
+
 @RESTRETURNCODES
 
 @RESTRETURNCODE{400}

--- a/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
+++ b/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
@@ -83,7 +83,7 @@ Not used for other key generator types.
 The following values for *type* are valid:
 
 - *2*: document collection
-- *3*: edges collection
+- *3*: edge collection
 
 @RESTBODYPARAM{indexBuckets,integer,optional,int64}
 The number of buckets into which indexes using a hash
@@ -127,13 +127,40 @@ copies take over, usually without an error being reported.
 
 @RESTBODYPARAM{distributeShardsLike,string,optional,string}
 (The default is *""*): in an Enterprise Edition cluster, this attribute binds
-the specifics of sharding  for the newly created collection to follow that of a
+the specifics of sharding for the newly created collection to follow that of a
 specified existing collection.
 **Note**: Using this parameter has consequences for the prototype
-collection. It can no longer be dropped, before sharding imitating
+collection. It can no longer be dropped, before the sharding-imitating
 collections are dropped. Equally, backups and restores of imitating
-collections alone will generate warnings, which can be overridden,
+collections alone will generate warnings (which can be overridden)
 about missing sharding prototype.
+
+@RESTBODYPARAM{shardingStrategy,string,optional,string}
+This attribute specifies the name of the sharding strategy to use for 
+the collection. Since ArangoDB 3.4 there are different sharding strategies 
+to select from when creating a new collection. The selected *shardingStrategy* 
+value will remain fixed for the collection and cannot be changed afterwards. 
+This is important to make the collection keep its sharding settings and
+always find documents already distributed to shards using the same
+initial sharding algorithm.
+
+The available sharding strategies are:
+- *community-compat*: default sharding used by ArangoDB community
+  versions before ArangoDB 3.4
+- *enterprise-compat*: default sharding used by ArangoDB enterprise
+  versions before ArangoDB 3.4
+- *enterprise-smart-edge-compat*: default sharding used by smart edge
+  collections in ArangoDB enterprise versions before ArangoDB 3.4
+- *hash*: default sharding used by ArangoDB 3.4 for new collections
+  (excluding smart edge collections)
+- *enterprise-hash-smart-edge*: default sharding used by ArangoDB 3.4 
+  for new smart edge collections
+
+If no sharding strategy is specified, the default will be *hash* for
+all collections, and *enterprise-hash-smart-edge* for all smart edge
+collections (requires the *Enterprise Edition* of ArangoDB). 
+Manually overriding the sharding strategy does not yet provide a 
+benefit, but it may later in case other sharding strategies are added.
 
 @RESTQUERYPARAMETERS
 

--- a/Documentation/DocuBlocks/collectionProperties.md
+++ b/Documentation/DocuBlocks/collectionProperties.md
@@ -54,6 +54,10 @@ In a cluster setup, the result will also contain the following attributes:
 * *replicationFactor*: determines how many copies of each shard are kept 
   on different DBServers.
 
+* *shardingStrategy*: the sharding strategy selected for the collection.
+  This attribute will only be populated in cluster mode and is not populated
+  in single-server mode.
+
 `collection.properties(properties)`
 
 Changes the collection properties. *properties* must be an object with
@@ -73,13 +77,9 @@ one or more of the following attribute(s):
   different DBServers, valid values are  integer numbers
   in the range of 1-10 *(Cluster only)*
 
-*Note*: it is not possible to change the journal size after the journal or
-datafile has been created. Changing this parameter will only effect newly
-created journals. Also note that you cannot lower the journal size to less
-then size of the largest document already stored in the collection.
-
 **Note**: some other collection properties, such as *type*, *isVolatile*,
-or *keyOptions* cannot be changed once the collection is created.
+*keyOptions*, *numberOfShards* or *shardingStrategy* cannot be changed once 
+the collection is created.
 
 @EXAMPLES
 

--- a/arangod/Sharding/ShardingFeature.h
+++ b/arangod/Sharding/ShardingFeature.h
@@ -48,10 +48,14 @@ class ShardingFeature : public application_features::ApplicationFeature {
 
   std::unique_ptr<ShardingStrategy> create(std::string const& name, ShardingInfo* sharding);
 
+  /// @brief returns the name of the default sharding strategy for new
+  /// collections
   std::string getDefaultShardingStrategyForNewCollection(
       VPackSlice const& properties) const;
 
  private:
+  /// @brief returns the name of the default sharding strategy for existing
+  /// collections without a sharding strategy assigned
   std::string getDefaultShardingStrategy(ShardingInfo const* sharding) const;
 
  private:


### PR DESCRIPTION
in arangod/Sharding/ShardingStrategiesDefault.*
The sharding strategy "enterprise-compat" is now also available
in the community version so users can switch between enterprise
and community version and vice versa without incompatibilities.

There are mock sharding strategy implementations of the enterprise
sharding strategies for smart edge collections now in the community
edition too. These do not actually shard any data, but they allow
increase the compatibility between enterprise and community edition
in case a downgrade is done from enterprise to community while
using smart edge collections.
When doing that, the previous smart edge collection will now have
a mock smart-edge collection sharding strategy that will always
throw an exception when actually asked for the location of a document.
The exception will indicate that the sharding strategy is only
available in the enterprise edition. This effectively disables
accessing that particular smart edge collection in the community
edition, but this is unavoidable given the fact that there is no
smart edge collection code in that version at all.
As long as the collection is not used, this should at least allow
using the rest of the cluster.