### PR TITLE
Bugfix-3.3: establish unique function name & implementation for communication retry status

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,9 @@ v3.3.15 (XXXX-XX-XX)
 * Create a default pacing algorithm for arangoimport to avoid TimeoutErrors
   on VMs with limited disk throughput
 
+* backport pull request 6150: establish unique function to indicate when
+  application is terminating and therefore network retries should not occur
+
 
 v3.3.14 (2018-08-15)
 --------------------
@@ -29,11 +32,11 @@ v3.3.14 (2018-08-15)
 
 * fixed internal issue #2566: corrected web UI alignment of the nodes table
 
-* fixed internal issue #2869: when attaching a follower with global applier to an 
-  authenticated leader already existing users have not been replicated, all users 
+* fixed internal issue #2869: when attaching a follower with global applier to an
+  authenticated leader already existing users have not been replicated, all users
   created/modified later are replicated.
 
-* fixed internal issue #2865: dumping from an authenticated arangodb the users have 
+* fixed internal issue #2865: dumping from an authenticated arangodb the users have
   not been included
 
 * fixed issue #5943: misplaced database ui icon and wrong cursor type were used
@@ -52,8 +55,8 @@ v3.3.14 (2018-08-15)
 
 * fixed internal issue #2812: Cluster fails to create many indexes in parallel
 
-* intermediate commits in the RocksDB engine are now only enabled in standalone AQL 
-  queries (not within a JS transaction), standalone truncate as well as for the 
+* intermediate commits in the RocksDB engine are now only enabled in standalone AQL
+  queries (not within a JS transaction), standalone truncate as well as for the
   "import" API
 
 * Bug fix: race condition could request data from Agency registry that did not

--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -1359,7 +1359,8 @@ AgencyCommResult AgencyComm::sendWithFailover(
     auto serverFeature =
         application_features::ApplicationServer::getFeature<ServerFeature>(
         "Server");
-    if (serverFeature->isStopping()) {
+    if (serverFeature->isStopping()
+        || !application_features::ApplicationServer::isRetryOK()) {
       LOG_TOPIC(INFO, Logger::AGENCYCOMM)
         << "Unsuccessful AgencyComm: Timeout because of shutdown "
         << "errorCode: " << result.errorCode()

--- a/arangod/Cluster/AgencyCallback.cpp
+++ b/arangod/Cluster/AgencyCallback.cpp
@@ -30,6 +30,7 @@
 #include <velocypack/Parser.h>
 #include <velocypack/velocypack-aliases.h>
 
+#include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/ConditionLocker.h"
 #include "Basics/MutexLocker.h"
 #include "Logger/Logger.h"
@@ -123,7 +124,8 @@ bool AgencyCallback::execute(std::shared_ptr<VPackBuilder> newData) {
 void AgencyCallback::executeByCallbackOrTimeout(double maxTimeout) {
   // One needs to acquire the mutex of the condition variable
   // before entering this function!
-  if (!_cv.wait(static_cast<uint64_t>(maxTimeout * 1000000.0))) {
+  if (!_cv.wait(static_cast<uint64_t>(maxTimeout * 1000000.0))
+    && application_features::ApplicationServer::isRetryOK()) {
     LOG_TOPIC(DEBUG, Logger::CLUSTER)
         << "Waiting done and nothing happended. Refetching to be sure";
     // mop: watches have not triggered during our sleep...recheck to be sure

--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -264,7 +264,7 @@ bool FollowerInfo::remove(ServerID const& sid) {
           break;  //
         } else {
           LOG_TOPIC(WARN, Logger::CLUSTER)
-              << "FollowerInfo::remove, could not cas key " << path 
+              << "FollowerInfo::remove, could not cas key " << path
               << ". status code: " << res2._statusCode << ", incriminating body: " << res2.bodyRef();
         }
       }
@@ -273,7 +273,8 @@ bool FollowerInfo::remove(ServerID const& sid) {
                                       << path << " in agency.";
     }
     usleep(500000);
-  } while (TRI_microtime() < startTime + 30);
+  } while (TRI_microtime() < startTime + 30
+    && application_features::ApplicationServer::isRetryOK());
   if (!success) {
     _followers = _oldFollowers;
     LOG_TOPIC(ERR, Logger::CLUSTER)

--- a/lib/ApplicationFeatures/ApplicationServer.h
+++ b/lib/ApplicationFeatures/ApplicationServer.h
@@ -133,6 +133,16 @@ class ApplicationServer {
     return server != nullptr && server->_stopping.load();
   }
 
+  // Today this static function is a duplicate of isStopping().  The
+  //  function name 'isStopping()' is defined in other classes and
+  //  can cause scope confusion.  It also causes confusion as to when
+  //  the application versus an individual feature or thread has begun
+  //  stopping.  This function is intended to be used within communication
+  //  retry loops where infinite retries have previously blocked clean "stopping".
+  static bool isRetryOK() {
+    return !isStopping();
+  }
+
   static bool isPrepared() {
     if (server != nullptr) {
       ServerState tmp = server->_state.load(std::memory_order_relaxed);
@@ -226,9 +236,9 @@ class ApplicationServer {
 
   // look up a feature and return a pointer to it. may be nullptr
   static ApplicationFeature* lookupFeature(std::string const&);
-  
+
   char const* getBinaryPath() { return _binaryPath;}
-  
+
   void registerStartupCallback(std::function<void()> const& callback) {
     _startupCallbacks.emplace_back(callback);
   }
@@ -236,7 +246,7 @@ class ApplicationServer {
   void registerFailCallback(std::function<void(std::string const&)> const& callback) {
     fail = callback;
   }
-  
+
   // setup and validate all feature dependencies, determine feature order
   void setupDependencies(bool failOnMissing);
 
@@ -305,7 +315,7 @@ class ApplicationServer {
 
   // features order for prepare/start
   std::vector<ApplicationFeature*> _orderedFeatures;
-  
+
   // will be signalled when the application server is asked to shut down
   basics::ConditionVariable _shutdownCondition;
 
@@ -317,7 +327,7 @@ class ApplicationServer {
 
   // whether or not to dump dependencies
   bool _dumpDependencies = false;
-  
+
   // whether or not to dump configuration options
   bool _dumpOptions = false;
 


### PR DESCRIPTION
This PR adds ApplicationServer::isRetryOK(). Today this function merely calls ApplicationServer::isStopping(). This additional function exists because various classes, such as threads and features, also include an isStopping() call. This creates confusion about when various logic stops versus retry actions should or should not occur. The new function creates a single, distinctive name for deciding when communication retries are appropriate.

This PR also includes fixes that use isRetryOK() to address two recent scenarios where a coordinator refused to shutdown due to all agents having shutdown more quickly.

Other code identified manually that decides whether or not to retry is also updated to use isRetryOK().