### PR TITLE
remove unnecessary parameter validation

### DIFF
--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -1412,8 +1412,10 @@ AstNode* Ast::createNodeFunctionCall(char const* functionName, size_t length,
     auto numExpectedArguments = func->numArguments();
 
     if (n < numExpectedArguments.first || n > numExpectedArguments.second) {
+      std::string const fname(functionName, length);
+
       THROW_ARANGO_EXCEPTION_PARAMS(
-          TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH, functionName,
+          TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH, fname.c_str(),
           static_cast<int>(numExpectedArguments.first),
           static_cast<int>(numExpectedArguments.second));
     }

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -968,7 +968,6 @@ AqlValue Expression::executeSimpleExpressionFCallJS(
   mustDestroy = false;
 
   {
-
     ISOLATE;
     TRI_ASSERT(isolate != nullptr);
     TRI_V8_CURRENT_GLOBALS_AND_SCOPE;

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -99,7 +99,6 @@ using namespace date;
     - ICU related errors: if (U_FAILURE(status)) { ::registerICUWarning(query, "MYFUNC", status); }
     - close with: return AqlValue(AqlValueHintNull());
 - specify the number of parameters you expect at least and at max using:
-  ValidateParameters(parameters, "MYFUNC", 1, 3); (min: 1, max: 3); Max is optional.
 - if you support optional parameters, first check whether the count is sufficient
   using parameters.size()
 - fetch the values using:
@@ -110,7 +109,7 @@ using namespace date;
   - ::extractKeys() if its an object and you need the keys
   - ::extractCollectionName() if you expect a collection
   - ::listContainsElement() search for a member
-  - ::parameterToTimePoint / DateFromParameters get a time string as date.
+  - ::parameterToTimePoint / ::dateFromParameters get a time string as date.
 - check the values whether they match your expectations i.e. using:
   - param.isNumber() then extract it using: param.toInt64(trx)
 - Available helper functions for working with parameters:
@@ -1277,6 +1276,179 @@ void flattenList(VPackSlice const& array, size_t maxDepth,
   }
 }
 
+/**
+ * @brief Parses 1 or 3-7 input parameters and creates a Date object out of it.
+ *        This object can either be a timestamp in milliseconds or an ISO_8601
+ * DATE
+ *
+ * @param query The AQL query
+ * @param trx The used transaction
+ * @param parameters list of parameters, only 1 or 3-7 are allowed
+ * @param asTimestamp If it should return a timestamp (true) or ISO_DATE (false)
+ *
+ * @return Returns a timestamp if asTimestamp is true, an ISO_DATE otherwise
+ */
+AqlValue dateFromParameters(
+    arangodb::aql::Query* query, transaction::Methods* trx,
+    VPackFunctionParameters const& parameters,
+    char const* AFN,
+    bool asTimestamp) {
+  tp_sys_clock_ms tp;
+  duration<int64_t, std::milli> time;
+
+  if (parameters.size() == 1) {
+    if (!parameterToTimePoint(query, trx, parameters, tp, AFN, 0)) {
+      return AqlValue(AqlValueHintNull());
+    }
+    time = tp.time_since_epoch();
+  } else {
+    if (parameters.size() < 3 || parameters.size() > 7) {
+      // YMD is a must
+      registerInvalidArgumentWarning(query, AFN);
+      return AqlValue(AqlValueHintNull());
+    }
+
+    for (uint8_t i = 0; i < parameters.size(); i++) {
+      AqlValue value = Functions::ExtractFunctionParameterValue(parameters, i);
+
+      // All Parameters have to be a number or a string
+      if (!value.isNumber() && !value.isString()) {
+        registerInvalidArgumentWarning(query, AFN);
+        return AqlValue(AqlValueHintNull());
+      }
+    }
+
+    years y{Functions::ExtractFunctionParameterValue(parameters, 0).toInt64(trx)};
+    months m{Functions::ExtractFunctionParameterValue(parameters, 1).toInt64(trx)};
+    days d{Functions::ExtractFunctionParameterValue(parameters, 2).toInt64(trx)};
+
+    if ( (y < years{0}) || (m < months{0}) || (d < days {0}) ) {
+      registerWarning(query, AFN, TRI_ERROR_QUERY_INVALID_DATE_VALUE);
+      return AqlValue(AqlValueHintNull());
+    }
+    year_month_day ymd = year{y.count()} / m.count() / d.count();
+
+    // Parse the time
+    hours h(0);
+    minutes min(0);
+    seconds s(0);
+    milliseconds ms(0);
+
+    if (parameters.size() >= 4) {
+      h = hours((Functions::ExtractFunctionParameterValue(parameters, 3).toInt64(trx)));
+    }
+    if (parameters.size() >= 5) {
+      min = minutes((Functions::ExtractFunctionParameterValue(parameters, 4).toInt64(trx)));
+    }
+    if (parameters.size() >= 6) {
+      s = seconds((Functions::ExtractFunctionParameterValue(parameters, 5).toInt64(trx)));
+    }
+    if (parameters.size() == 7) {
+      ms = milliseconds(
+          (Functions::ExtractFunctionParameterValue(parameters, 6).toInt64(trx)));
+    }
+
+    if ((h < hours{0}) ||
+        (min < minutes{0}) ||
+        (s < seconds{0}) ||
+        (ms < milliseconds{0})) {
+      registerWarning(query, AFN,
+                      TRI_ERROR_QUERY_INVALID_DATE_VALUE);
+      return AqlValue(AqlValueHintNull());
+    }
+
+    time = sys_days(ymd).time_since_epoch();
+    time += h;
+    time += min;
+    time += s;
+    time += ms;
+    tp = tp_sys_clock_ms(time);
+  }
+
+  if (asTimestamp) {
+    return AqlValue(AqlValueHintInt(time.count()));
+  }
+  return timeAqlValue(tp);
+}
+
+AqlValue callApplyBackend(arangodb::aql::Query* query,
+                          transaction::Methods* trx,
+                          char const* AFN,
+                          AqlValue const& invokeFN,
+                          VPackFunctionParameters const& invokeParams) {
+  std::string ucInvokeFN;
+  transaction::StringBufferLeaser buffer(trx);
+  arangodb::basics::VPackStringBufferAdapter adapter(buffer->stringBuffer());
+
+  ::appendAsString(trx, adapter, invokeFN);
+
+  UnicodeString unicodeStr(buffer->c_str(),
+                           static_cast<int32_t>(buffer->length()));
+  unicodeStr.toUpper(nullptr);
+  unicodeStr.toUTF8String(ucInvokeFN);
+
+  arangodb::aql::Function const* func = nullptr;
+  if (ucInvokeFN.find("::") == std::string::npos) {
+    // built-in C++ function
+    func = AqlFunctionFeature::getFunctionByName(ucInvokeFN);
+    if (func->implementation != nullptr) {
+      std::pair<size_t, size_t> numExpectedArguments = func->numArguments();
+     
+      if (invokeParams.size() < numExpectedArguments.first ||
+          invokeParams.size() > numExpectedArguments.second) {
+        THROW_ARANGO_EXCEPTION_PARAMS(
+            TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH, ucInvokeFN.c_str(),
+            static_cast<int>(numExpectedArguments.first),
+            static_cast<int>(numExpectedArguments.second));
+      }
+
+      return func->implementation(query, trx, invokeParams);
+    }
+  }
+
+  // JavaScript function (this includes user-defined functions)
+  {
+    ISOLATE;
+    TRI_V8_CURRENT_GLOBALS_AND_SCOPE;
+    query->prepareV8Context();
+
+    auto old = v8g->_query;
+    v8g->_query = query;
+    TRI_DEFER(v8g->_query = old);
+
+    std::string jsName;
+    int const n = static_cast<int>(invokeParams.size());
+    int const callArgs = (func == nullptr ? 3 : n);
+    auto args = std::make_unique<v8::Handle<v8::Value>[]>(callArgs);
+
+    if (func == nullptr) {
+      // a call to a user-defined function
+      jsName = "FCALL_USER";
+
+      // function name
+      args[0] = TRI_V8_STD_STRING(isolate, ucInvokeFN);
+      // call parameters
+      v8::Handle<v8::Array> params = v8::Array::New(isolate, static_cast<int>(n));
+
+      for (int i = 0; i < n; ++i) {
+        params->Set(static_cast<uint32_t>(i), invokeParams[i].toV8(isolate, trx));
+      }
+      args[1] = params;
+      args[2] = TRI_V8_ASCII_STRING(isolate, AFN);
+    } else {
+      // a call to a built-in V8 function
+      jsName = "AQL_" + func->name;
+      for (int i = 0; i < n; ++i) {
+        args[i] = invokeParams[i].toV8(isolate, trx);
+      }
+    }
+
+    bool dummy;
+    return Expression::invokeV8Function(query, trx, jsName, ucInvokeFN, AFN, false, callArgs, args.get(), dummy);
+  }
+}
+
+
 } // namespace
 
 void Functions::init() {
@@ -1288,24 +1460,6 @@ void Functions::init() {
     dateMap.insert(std::make_pair(p.first, p.second));
   });
   ::theDateFormatRegex = std::regex(myregex);
-}
-
-/// @brief validate the number of parameters
-void Functions::ValidateParameters(VPackFunctionParameters const& parameters,
-                                   char const* function, int minParams,
-                                   int maxParams) {
-  if (parameters.size() < static_cast<size_t>(minParams) ||
-      parameters.size() > static_cast<size_t>(maxParams)) {
-    THROW_ARANGO_EXCEPTION_PARAMS(
-        TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH, function, minParams,
-        maxParams);
-  }
-}
-
-void Functions::ValidateParameters(VPackFunctionParameters const& parameters,
-                                   char const* function, int minParams) {
-  return ValidateParameters(parameters, function, minParams,
-                            static_cast<int>(Function::maxArguments));
 }
 
 /// @brief extract a function parameter from the arguments
@@ -1435,7 +1589,6 @@ AqlValue Functions::ToString(arangodb::aql::Query*,
 AqlValue Functions::ToBase64(arangodb::aql::Query*,
                              transaction::Methods* trx,
                              VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "TO_BASE64", 1, 1);
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   transaction::StringBufferLeaser buffer(trx);
@@ -1452,7 +1605,6 @@ AqlValue Functions::ToBase64(arangodb::aql::Query*,
 AqlValue Functions::ToHex(arangodb::aql::Query*,
                              transaction::Methods* trx,
                              VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "TO_HEX", 1, 1);
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
     
   transaction::StringBufferLeaser buffer(trx);
@@ -1469,17 +1621,16 @@ AqlValue Functions::ToHex(arangodb::aql::Query*,
 AqlValue Functions::EncodeURIComponent(arangodb::aql::Query*,
                           transaction::Methods* trx,
                           VPackFunctionParameters const& parameters) {
-    ValidateParameters(parameters, "ENCODE_URI_COMPONENT", 1, 1);
-    AqlValue value = ExtractFunctionParameterValue(parameters, 0);
-    
-    transaction::StringBufferLeaser buffer(trx);
-    arangodb::basics::VPackStringBufferAdapter adapter(buffer->stringBuffer());
-    
-    ::appendAsString(trx, adapter, value);
-    
-    std::string encoded = basics::StringUtils::encodeURIComponent(std::string(buffer->begin(), buffer->length()));
-    
-    return AqlValue(encoded);
+  AqlValue value = ExtractFunctionParameterValue(parameters, 0);
+
+  transaction::StringBufferLeaser buffer(trx);
+  arangodb::basics::VPackStringBufferAdapter adapter(buffer->stringBuffer());
+
+  ::appendAsString(trx, adapter, value);
+
+  std::string encoded = basics::StringUtils::encodeURIComponent(std::string(buffer->begin(), buffer->length()));
+
+  return AqlValue(encoded);
 }
 
 /// @brief function UUID
@@ -1500,7 +1651,6 @@ AqlValue Functions::Uuid(arangodb::aql::Query*,
 AqlValue Functions::Soundex(arangodb::aql::Query*,
                                        transaction::Methods* trx,
                                        VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "SOUNDEX", 1, 1);
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   transaction::StringBufferLeaser buffer(trx);
@@ -1518,7 +1668,6 @@ AqlValue Functions::Soundex(arangodb::aql::Query*,
 AqlValue Functions::LevenshteinDistance(arangodb::aql::Query*,
                             transaction::Methods* trx,
                             VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "LEVENSHTEIN_DISTANCE", 2, 2);
   AqlValue value1 = ExtractFunctionParameterValue(parameters, 0);
   AqlValue value2 = ExtractFunctionParameterValue(parameters, 1);
 
@@ -1584,9 +1733,6 @@ AqlValue Functions::ToArray(arangodb::aql::Query*,
 AqlValue Functions::Length(arangodb::aql::Query*,
                            transaction::Methods* trx,
                            VPackFunctionParameters const& parameters) {
-  static char const* AFN = "LENGTH";
-  ValidateParameters(parameters, AFN, 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
   if (value.isArray()) {
     // shortcut!
@@ -1627,7 +1773,6 @@ AqlValue Functions::FindFirst(arangodb::aql::Query* query,
                               transaction::Methods* trx,
                               VPackFunctionParameters const& parameters) {
   static char const* AFN = "FIND_FIRST";
-  ValidateParameters(parameters, AFN, 2, 4);
 
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
   AqlValue searchValue = ExtractFunctionParameterValue(parameters, 1);
@@ -1696,7 +1841,6 @@ AqlValue Functions::FindLast(arangodb::aql::Query* query,
                              transaction::Methods* trx,
                              VPackFunctionParameters const& parameters) {
   static char const* AFN = "FIND_LAST";
-  ValidateParameters(parameters, AFN, 2, 4);
 
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
   AqlValue searchValue = ExtractFunctionParameterValue(parameters, 1);
@@ -1767,7 +1911,7 @@ AqlValue Functions::Reverse(arangodb::aql::Query* query,
                             transaction::Methods* trx,
                             VPackFunctionParameters const& parameters) {
   static char const* AFN = "REVERSE";
-  ValidateParameters(parameters, AFN, 1, 1);
+  
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   if (value.isArray()) {
@@ -1818,7 +1962,7 @@ AqlValue Functions::First(arangodb::aql::Query* query,
                           transaction::Methods* trx,
                           VPackFunctionParameters const& parameters) {
   static char const* AFN = "FIRST";
-  ValidateParameters(parameters, AFN, 1, 1);
+  
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   if (!value.isArray()) {
@@ -1840,7 +1984,7 @@ AqlValue Functions::Last(arangodb::aql::Query* query,
                          transaction::Methods* trx,
                          VPackFunctionParameters const& parameters) {
   static char const* AFN = "LAST";
-  ValidateParameters(parameters, AFN, 1, 1);
+  
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   if (!value.isArray()) {
@@ -1863,7 +2007,7 @@ AqlValue Functions::Last(arangodb::aql::Query* query,
 AqlValue Functions::Nth(arangodb::aql::Query* query, transaction::Methods* trx,
                         VPackFunctionParameters const& parameters) {
   static char const* AFN = "NTH";
-  ValidateParameters(parameters, AFN, 2, 2);
+  
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   if (!value.isArray()) {
@@ -1893,9 +2037,6 @@ AqlValue Functions::Nth(arangodb::aql::Query* query, transaction::Methods* trx,
 AqlValue Functions::Contains(arangodb::aql::Query*,
                              transaction::Methods* trx,
                              VPackFunctionParameters const& parameters) {
-  static char const* AFN = "CONTAINS";
-  ValidateParameters(parameters, AFN, 2, 3);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
   AqlValue search = ExtractFunctionParameterValue(parameters, 1);
   AqlValue returnIndex = ExtractFunctionParameterValue(parameters, 2);
@@ -2061,9 +2202,6 @@ AqlValue Functions::ConcatSeparator(arangodb::aql::Query*,
 AqlValue Functions::CharLength(arangodb::aql::Query*,
                                transaction::Methods* trx,
                                VPackFunctionParameters const& parameters) {
-  static char const* AFN = "CHAR_LENGTH";
-  ValidateParameters(parameters, AFN, 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
   size_t length = 0;
 
@@ -2112,9 +2250,6 @@ AqlValue Functions::CharLength(arangodb::aql::Query*,
 AqlValue Functions::Lower(arangodb::aql::Query*,
                           transaction::Methods* trx,
                           VPackFunctionParameters const& parameters) {
-  static char const* AFN = "LOWER";
-  ValidateParameters(parameters, AFN, 1, 1);
-
   std::string utf8;
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
@@ -2135,9 +2270,6 @@ AqlValue Functions::Lower(arangodb::aql::Query*,
 AqlValue Functions::Upper(arangodb::aql::Query*,
                           transaction::Methods* trx,
                           VPackFunctionParameters const& parameters) {
-  static char const* AFN = "UPPER";
-  ValidateParameters(parameters, AFN, 1, 1);
-
   std::string utf8;
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
@@ -2158,8 +2290,6 @@ AqlValue Functions::Upper(arangodb::aql::Query*,
 AqlValue Functions::Substring(arangodb::aql::Query*,
                               transaction::Methods* trx,
                               VPackFunctionParameters const& parameters) {
-  static char const* AFN = "SUBSTRING";
-  ValidateParameters(parameters, AFN, 2, 3);
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   int32_t length = INT32_MAX;
@@ -2200,7 +2330,6 @@ AqlValue Functions::Substitute(arangodb::aql::Query* query,
                                transaction::Methods* trx,
                                VPackFunctionParameters const& parameters) {
   static char const* AFN = "SUBSTITUTE";
-  ValidateParameters(parameters, AFN, 2, 4);
 
   AqlValue search = ExtractFunctionParameterValue(parameters, 1);
   int64_t limit = -1;
@@ -2442,9 +2571,6 @@ AqlValue Functions::Substitute(arangodb::aql::Query* query,
 /// @brief function LEFT str, length
 AqlValue Functions::Left(arangodb::aql::Query*, transaction::Methods* trx,
                          VPackFunctionParameters const& parameters) {
-  static char const* AFN = "LEFT";
-  ValidateParameters(parameters, AFN, 2, 2);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
   uint32_t length = static_cast<int32_t>(
       ExtractFunctionParameterValue(parameters, 1).toInt64(trx));
@@ -2468,8 +2594,6 @@ AqlValue Functions::Left(arangodb::aql::Query*, transaction::Methods* trx,
 AqlValue Functions::Right(arangodb::aql::Query*,
                           transaction::Methods* trx,
                           VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "RIGHT", 2, 2);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
   uint32_t length = static_cast<int32_t>(
       ExtractFunctionParameterValue(parameters, 1).toInt64(trx));
@@ -2536,7 +2660,6 @@ void rtrimInternal(uint32_t& startOffset, uint32_t& endOffset,
 AqlValue Functions::Trim(arangodb::aql::Query* query, transaction::Methods* trx,
                          VPackFunctionParameters const& parameters) {
   static char const* AFN = "TRIM";
-  ValidateParameters(parameters, AFN, 1, 2);
 
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
   transaction::StringBufferLeaser buffer(trx);
@@ -2599,7 +2722,6 @@ AqlValue Functions::LTrim(arangodb::aql::Query* query,
                           transaction::Methods* trx,
                           VPackFunctionParameters const& parameters) {
   static char const* AFN = "LTRIM";
-  ValidateParameters(parameters, AFN, 1, 2);
 
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
   transaction::StringBufferLeaser buffer(trx);
@@ -2644,7 +2766,6 @@ AqlValue Functions::RTrim(arangodb::aql::Query* query,
                           transaction::Methods* trx,
                           VPackFunctionParameters const& parameters) {
   static char const* AFN = "RTRIM";
-  ValidateParameters(parameters, AFN, 1, 2);
 
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
   transaction::StringBufferLeaser buffer(trx);
@@ -2688,7 +2809,7 @@ AqlValue Functions::RTrim(arangodb::aql::Query* query,
 AqlValue Functions::Like(arangodb::aql::Query* query, transaction::Methods* trx,
                          VPackFunctionParameters const& parameters) {
   static char const* AFN = "LIKE";
-  ValidateParameters(parameters, AFN, 2, 3);
+  
   bool const caseInsensitive = ::getBooleanParameter(trx, parameters, 2, false);
   transaction::StringBufferLeaser buffer(trx);
   arangodb::basics::VPackStringBufferAdapter adapter(buffer->stringBuffer());
@@ -2730,7 +2851,6 @@ AqlValue Functions::Split(arangodb::aql::Query* query,
                           transaction::Methods* trx,
                           VPackFunctionParameters const& parameters) {
   static char const* AFN = "SPLIT";
-  ValidateParameters(parameters, AFN, 1, 3);
 
   // cheapest parameter checks first:
   int64_t limitNumber = -1;
@@ -2863,7 +2983,6 @@ AqlValue Functions::RegexMatches(arangodb::aql::Query* query,
                                 transaction::Methods* trx,
                                 VPackFunctionParameters const& parameters) {
   static char const* AFN = "REGEX_MATCHES";
-  ValidateParameters(parameters, AFN, 2, 3);
 
   AqlValueMaterializer materializer(trx);
   AqlValue aqlValueToMatch = ExtractFunctionParameterValue(parameters, 0);
@@ -2938,7 +3057,6 @@ AqlValue Functions::RegexSplit(arangodb::aql::Query* query,
                                transaction::Methods* trx,
                                VPackFunctionParameters const& parameters) {
   static char const* AFN = "REGEX_SPLIT";
-  ValidateParameters(parameters, AFN, 2, 4);
 
   int64_t limitNumber = -1;
   if (parameters.size() == 4) {
@@ -3067,7 +3185,7 @@ AqlValue Functions::RegexTest(arangodb::aql::Query* query,
                               transaction::Methods* trx,
                               VPackFunctionParameters const& parameters) {
   static char const* AFN = "REGEX_TEST";
-  ValidateParameters(parameters, AFN, 2, 3);
+  
   bool const caseInsensitive = ::getBooleanParameter(trx, parameters, 2, false);
   transaction::StringBufferLeaser buffer(trx);
   arangodb::basics::VPackStringBufferAdapter adapter(buffer->stringBuffer());
@@ -3109,7 +3227,7 @@ AqlValue Functions::RegexReplace(arangodb::aql::Query* query,
                                  transaction::Methods* trx,
                                  VPackFunctionParameters const& parameters) {
   static char const* AFN = "REGEX_REPLACE";
-  ValidateParameters(parameters, AFN, 3, 4);
+  
   bool const caseInsensitive = ::getBooleanParameter(trx, parameters, 3, false);
   transaction::StringBufferLeaser buffer(trx);
   arangodb::basics::VPackStringBufferAdapter adapter(buffer->stringBuffer());
@@ -3160,107 +3278,12 @@ AqlValue Functions::DateNow(arangodb::aql::Query*, transaction::Methods*,
   return AqlValue(AqlValueHintUInt(dur));
 }
 
-/**
- * @brief Parses 1 or 3-7 input parameters and creates a Date object out of it.
- *        This object can either be a timestamp in milliseconds or an ISO_8601
- * DATE
- *
- * @param query The AQL query
- * @param trx The used transaction
- * @param parameters list of parameters, only 1 or 3-7 are allowed
- * @param asTimestamp If it should return a timestamp (true) or ISO_DATE (false)
- *
- * @return Returns a timestamp if asTimestamp is true, an ISO_DATE otherwise
- */
-AqlValue Functions::DateFromParameters(
-    arangodb::aql::Query* query, transaction::Methods* trx,
-    VPackFunctionParameters const& parameters,
-    char const* AFN,
-    bool asTimestamp) {
-  tp_sys_clock_ms tp;
-  duration<int64_t, std::milli> time;
-
-  if (parameters.size() == 1) {
-    if (!::parameterToTimePoint(query, trx, parameters, tp, AFN, 0)) {
-      return AqlValue(AqlValueHintNull());
-    }
-    time = tp.time_since_epoch();
-  } else {
-    if (parameters.size() < 3 || parameters.size() > 7) {
-      // YMD is a must
-      ::registerInvalidArgumentWarning(query, AFN);
-      return AqlValue(AqlValueHintNull());
-    }
-
-    for (uint8_t i = 0; i < parameters.size(); i++) {
-      AqlValue value = ExtractFunctionParameterValue(parameters, i);
-
-      // All Parameters have to be a number or a string
-      if (!value.isNumber() && !value.isString()) {
-        ::registerInvalidArgumentWarning(query, AFN);
-        return AqlValue(AqlValueHintNull());
-      }
-    }
-
-    years y{ExtractFunctionParameterValue(parameters, 0).toInt64(trx)};
-    months m{ExtractFunctionParameterValue(parameters, 1).toInt64(trx)};
-    days d{ExtractFunctionParameterValue(parameters, 2).toInt64(trx)};
-
-    if ( (y < years{0}) || (m < months{0}) || (d < days {0}) ) {
-      ::registerWarning(query, AFN, TRI_ERROR_QUERY_INVALID_DATE_VALUE);
-      return AqlValue(AqlValueHintNull());
-    }
-    year_month_day ymd = year{y.count()} / m.count() / d.count();
-
-    // Parse the time
-    hours h(0);
-    minutes min(0);
-    seconds s(0);
-    milliseconds ms(0);
-
-    if (parameters.size() >= 4) {
-      h = hours((ExtractFunctionParameterValue(parameters, 3).toInt64(trx)));
-    }
-    if (parameters.size() >= 5) {
-      min = minutes((ExtractFunctionParameterValue(parameters, 4).toInt64(trx)));
-    }
-    if (parameters.size() >= 6) {
-      s = seconds((ExtractFunctionParameterValue(parameters, 5).toInt64(trx)));
-    }
-    if (parameters.size() == 7) {
-      ms = milliseconds(
-          (ExtractFunctionParameterValue(parameters, 6).toInt64(trx)));
-    }
-
-    if ((h < hours{0}) ||
-        (min < minutes{0}) ||
-        (s < seconds{0}) ||
-        (ms < milliseconds{0})) {
-      ::registerWarning(query, AFN,
-                      TRI_ERROR_QUERY_INVALID_DATE_VALUE);
-      return AqlValue(AqlValueHintNull());
-    }
-
-    time = sys_days(ymd).time_since_epoch();
-    time += h;
-    time += min;
-    time += s;
-    time += ms;
-    tp = tp_sys_clock_ms(time);
-  }
-
-  if (asTimestamp) {
-    return AqlValue(AqlValueHintInt(time.count()));
-  }
-  return ::timeAqlValue(tp);
-}
-
 /// @brief function DATE_ISO8601
 AqlValue Functions::DateIso8601(arangodb::aql::Query* query,
                                 transaction::Methods* trx,
                                 VPackFunctionParameters const& parameters) {
   static char const* AFN = "DATE_ISO8601";
-  return DateFromParameters(query, trx, parameters, AFN, false);
+  return ::dateFromParameters(query, trx, parameters, AFN, false);
 }
 
 /// @brief function DATE_TIMESTAMP
@@ -3268,7 +3291,7 @@ AqlValue Functions::DateTimestamp(arangodb::aql::Query* query,
                                   transaction::Methods* trx,
                                   VPackFunctionParameters const& parameters) {
   static char const* AFN = "DATE_TIMESTAMP";
-  return DateFromParameters(query, trx, parameters, AFN, true);
+  return ::dateFromParameters(query, trx, parameters, AFN, true);
 }
 
 /// @brief function IS_DATESTRING
@@ -3867,7 +3890,7 @@ AqlValue Functions::Unset(arangodb::aql::Query* query,
                           transaction::Methods* trx,
                           VPackFunctionParameters const& parameters) {
   static char const* AFN = "UNSET";
-  ValidateParameters(parameters, AFN, 2);
+  
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   if (!value.isObject()) {
@@ -3890,7 +3913,7 @@ AqlValue Functions::UnsetRecursive(arangodb::aql::Query* query,
                                    transaction::Methods* trx,
                                    VPackFunctionParameters const& parameters) {
   static char const* AFN = "UNSET_RECURSIVE";
-  ValidateParameters(parameters, AFN, 2);
+  
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   if (!value.isObject()) {
@@ -3912,7 +3935,7 @@ AqlValue Functions::UnsetRecursive(arangodb::aql::Query* query,
 AqlValue Functions::Keep(arangodb::aql::Query* query, transaction::Methods* trx,
                          VPackFunctionParameters const& parameters) {
   static char const* AFN = "KEEP";
-  ValidateParameters(parameters, AFN, 2);
+  
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   if (!value.isObject()) {
@@ -3935,7 +3958,7 @@ AqlValue Functions::Translate(arangodb::aql::Query* query,
                               transaction::Methods* trx,
                               VPackFunctionParameters const& parameters) {
   static char const* AFN = "TRANSLATE";
-  ValidateParameters(parameters, AFN, 2, 3);
+  
   AqlValue key = ExtractFunctionParameterValue(parameters, 0);
   AqlValue lookupDocument = ExtractFunctionParameterValue(parameters, 1);
 
@@ -4482,7 +4505,6 @@ AqlValue Functions::CountDistinct(arangodb::aql::Query* query,
                                   transaction::Methods* trx,
                                   VPackFunctionParameters const& parameters) {
   static char const* AFN = "COUNT_DISTINCT";
-  ValidateParameters(parameters, AFN, 1, 1);
 
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
@@ -4515,7 +4537,6 @@ AqlValue Functions::Unique(arangodb::aql::Query* query,
                            transaction::Methods* trx,
                            VPackFunctionParameters const& parameters) {
   static char const* AFN = "UNIQUE";
-  ValidateParameters(parameters, AFN, 1, 1);
 
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
@@ -4554,7 +4575,7 @@ AqlValue Functions::SortedUnique(arangodb::aql::Query* query,
                                  transaction::Methods* trx,
                                  VPackFunctionParameters const& parameters) {
   static char const* AFN = "SORTED_UNIQUE";
-  ValidateParameters(parameters, AFN, 1, 1);
+  
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   if (!value.isArray()) {
@@ -4590,7 +4611,7 @@ AqlValue Functions::Sorted(arangodb::aql::Query* query,
                            transaction::Methods* trx,
                            VPackFunctionParameters const& parameters) {
   static char const* AFN = "SORTED";
-  ValidateParameters(parameters, AFN, 1, 1);
+  
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   if (!value.isArray()) {
@@ -4632,7 +4653,6 @@ AqlValue Functions::Union(arangodb::aql::Query* query,
                           transaction::Methods* trx,
                           VPackFunctionParameters const& parameters) {
   static char const* AFN = "UNION";
-  ValidateParameters(parameters, AFN, 2);
 
   transaction::BuilderLeaser builder(trx);
   builder->openArray();
@@ -4674,7 +4694,7 @@ AqlValue Functions::UnionDistinct(arangodb::aql::Query* query,
                                   transaction::Methods* trx,
                                   VPackFunctionParameters const& parameters) {
   static char const* AFN = "UNION_DISTINCT";
-  ValidateParameters(parameters, AFN, 2);
+  
   size_t const n = parameters.size();
 
   auto options = trx->transactionContextPtr()->getVPackOptions();
@@ -4732,7 +4752,6 @@ AqlValue Functions::Intersection(arangodb::aql::Query* query,
                                  transaction::Methods* trx,
                                  VPackFunctionParameters const& parameters) {
   static char const* AFN = "INTERSECTION";
-  ValidateParameters(parameters, AFN, 2);
 
   auto options = trx->transactionContextPtr()->getVPackOptions();
   std::unordered_map<VPackSlice, size_t,
@@ -4804,7 +4823,6 @@ AqlValue Functions::Outersection(arangodb::aql::Query* query,
                                  transaction::Methods* trx,
                                  VPackFunctionParameters const& parameters) {
   static char const* AFN = "OUTERSECTION";
-  ValidateParameters(parameters, AFN, 2);
 
   auto options = trx->transactionContextPtr()->getVPackOptions();
   std::unordered_map<VPackSlice, size_t,
@@ -4865,7 +4883,6 @@ AqlValue Functions::Distance(arangodb::aql::Query* query,
                              transaction::Methods* trx,
                              VPackFunctionParameters const& parameters) {
   static char const* AFN = "DISTANCE";
-  ValidateParameters(parameters, AFN, 4, 4);
 
   AqlValue lat1 = ExtractFunctionParameterValue(parameters, 0);
   AqlValue lon1 = ExtractFunctionParameterValue(parameters, 1);
@@ -4919,8 +4936,6 @@ AqlValue Functions::Distance(arangodb::aql::Query* query,
 AqlValue Functions::GeoDistance(arangodb::aql::Query* query,
                              transaction::Methods* trx,
                              VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "GEO_DISTANCE", 2, 2);
-
   AqlValue loc1 = ExtractFunctionParameterValue(parameters, 0);
   AqlValue loc2 = ExtractFunctionParameterValue(parameters, 1);
 
@@ -4956,7 +4971,6 @@ static AqlValue GeoContainsIntersect(arangodb::aql::Query* query,
                                      transaction::Methods* trx,
                                      VPackFunctionParameters const& parameters,
                                      char const* func, bool contains) {
-  Functions::ValidateParameters(parameters, func, 2, 2);
   AqlValue p1 = Functions::ExtractFunctionParameterValue(parameters, 0);
   AqlValue p2 = Functions::ExtractFunctionParameterValue(parameters, 1);
 
@@ -5013,8 +5027,6 @@ AqlValue Functions::GeoIntersects(arangodb::aql::Query* query,
 AqlValue Functions::GeoEquals(arangodb::aql::Query* query,
                              transaction::Methods* trx,
                              VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "GEO_EQUALS", 2, 2);
-
   AqlValue p1 = Functions::ExtractFunctionParameterValue(parameters, 0);
   AqlValue p2 = Functions::ExtractFunctionParameterValue(parameters, 1);
 
@@ -5049,8 +5061,6 @@ AqlValue Functions::GeoEquals(arangodb::aql::Query* query,
 AqlValue Functions::IsInPolygon(arangodb::aql::Query* query,
                                 transaction::Methods* trx,
                                 VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "IS_IN_POLYGON", 2, 3);
-
   AqlValue coords = ExtractFunctionParameterValue(parameters, 0);
   AqlValue p2 = ExtractFunctionParameterValue(parameters, 1);
   AqlValue p3 = ExtractFunctionParameterValue(parameters, 2);
@@ -5110,8 +5120,6 @@ AqlValue Functions::IsInPolygon(arangodb::aql::Query* query,
 AqlValue Functions::GeoPoint(arangodb::aql::Query* query,
                              transaction::Methods* trx,
                              VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "GEO_POINT", 2, 2);
-
   size_t const n = parameters.size();
 
   if (n < 2) {
@@ -5159,9 +5167,6 @@ AqlValue Functions::GeoPoint(arangodb::aql::Query* query,
 AqlValue Functions::GeoMultiPoint(arangodb::aql::Query* query,
                                   transaction::Methods* trx,
                                   VPackFunctionParameters const& parameters) {
-
-  ValidateParameters(parameters, "GEO_MULTIPOINT", 1, 1);
-
   size_t const n = parameters.size();
 
   if (n < 1) {
@@ -5223,8 +5228,6 @@ AqlValue Functions::GeoMultiPoint(arangodb::aql::Query* query,
 AqlValue Functions::GeoPolygon(arangodb::aql::Query* query,
                                transaction::Methods* trx,
                                VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "GEO_POLYGON", 1, 1);
-
   size_t const n = parameters.size();
 
   if (n < 1) {
@@ -5359,8 +5362,6 @@ AqlValue Functions::GeoPolygon(arangodb::aql::Query* query,
 AqlValue Functions::GeoLinestring(arangodb::aql::Query* query,
                                   transaction::Methods* trx,
                                   VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "GEO_LINESTRING", 1, 1);
-
   size_t const n = parameters.size();
 
   if (n < 1) {
@@ -5422,8 +5423,6 @@ AqlValue Functions::GeoLinestring(arangodb::aql::Query* query,
 AqlValue Functions::GeoMultiLinestring(arangodb::aql::Query* query,
                                        transaction::Methods* trx,
                                        VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "GEO_MULTILINESTRING", 1, 1);
-
   size_t const n = parameters.size();
 
   if (n < 1) {
@@ -5504,7 +5503,6 @@ AqlValue Functions::Flatten(arangodb::aql::Query* query,
                             transaction::Methods* trx,
                             VPackFunctionParameters const& parameters) {
   static char const* AFN = "FLATTEN";
-  ValidateParameters(parameters, AFN, 1, 2);
 
   AqlValue list = ExtractFunctionParameterValue(parameters, 0);
   if (!list.isArray()) {
@@ -5538,7 +5536,6 @@ AqlValue Functions::Flatten(arangodb::aql::Query* query,
 AqlValue Functions::Zip(arangodb::aql::Query* query, transaction::Methods* trx,
                         VPackFunctionParameters const& parameters) {
   static char const* AFN = "ZIP";
-  ValidateParameters(parameters, AFN, 2, 2);
 
   AqlValue keys = ExtractFunctionParameterValue(parameters, 0);
   AqlValue values = ExtractFunctionParameterValue(parameters, 1);
@@ -5594,8 +5591,6 @@ AqlValue Functions::Zip(arangodb::aql::Query* query, transaction::Methods* trx,
 AqlValue Functions::JsonStringify(arangodb::aql::Query*,
                                   transaction::Methods* trx,
                                   VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "JSON_STRINGIFY", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
   AqlValueMaterializer materializer(trx);
   VPackSlice slice = materializer.slice(value, false);
@@ -5614,7 +5609,6 @@ AqlValue Functions::JsonParse(arangodb::aql::Query* query,
                               transaction::Methods* trx,
                               VPackFunctionParameters const& parameters) {
   static char const* AFN = "JSON_PARSE";
-  ValidateParameters(parameters, AFN, 1, 1);
 
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
   AqlValueMaterializer materializer(trx);
@@ -5642,7 +5636,6 @@ AqlValue Functions::ParseIdentifier(arangodb::aql::Query* query,
                                     transaction::Methods* trx,
                                     VPackFunctionParameters const& parameters) {
   static char const* AFN = "PARSE_IDENTIFIER";
-  ValidateParameters(parameters, AFN, 1, 1);
 
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
   std::string identifier;
@@ -5685,7 +5678,6 @@ AqlValue Functions::Slice(arangodb::aql::Query* query,
                           transaction::Methods* trx,
                           VPackFunctionParameters const& parameters) {
   static char const* AFN = "SLICE";
-  ValidateParameters(parameters, AFN, 2, 3);
 
   AqlValue baseArray = ExtractFunctionParameterValue(parameters, 0);
 
@@ -5751,7 +5743,6 @@ AqlValue Functions::Minus(arangodb::aql::Query* query,
                           transaction::Methods* trx,
                           VPackFunctionParameters const& parameters) {
   static char const* AFN = "MINUS";
-  ValidateParameters(parameters, AFN, 2);
 
   AqlValue baseArray = ExtractFunctionParameterValue(parameters, 0);
 
@@ -5813,7 +5804,6 @@ AqlValue Functions::Document(arangodb::aql::Query* query,
                              transaction::Methods* trx,
                              VPackFunctionParameters const& parameters) {
   static char const* AFN = "DOCUMENT";
-  ValidateParameters(parameters, AFN, 1, 2);
 
   if (parameters.size() == 1) {
     AqlValue id = ExtractFunctionParameterValue(parameters, 0);
@@ -5892,7 +5882,6 @@ AqlValue Functions::Matches(arangodb::aql::Query* query,
                             transaction::Methods* trx,
                             VPackFunctionParameters const& parameters) {
   static char const* AFN = "MATCHES";
-  ValidateParameters(parameters, AFN, 2, 3);
 
   AqlValue docToFind = ExtractFunctionParameterValue(parameters, 0);
 
@@ -5972,8 +5961,6 @@ AqlValue Functions::Matches(arangodb::aql::Query* query,
 AqlValue Functions::Round(arangodb::aql::Query*,
                           transaction::Methods* trx,
                           VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "ROUND", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   double input = value.toDouble(trx);
@@ -5985,8 +5972,6 @@ AqlValue Functions::Round(arangodb::aql::Query*,
 /// @brief function ABS
 AqlValue Functions::Abs(arangodb::aql::Query*, transaction::Methods* trx,
                         VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "ABS", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   double input = value.toDouble(trx);
@@ -5996,8 +5981,6 @@ AqlValue Functions::Abs(arangodb::aql::Query*, transaction::Methods* trx,
 /// @brief function CEIL
 AqlValue Functions::Ceil(arangodb::aql::Query*, transaction::Methods* trx,
                          VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "CEIL", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   double input = value.toDouble(trx);
@@ -6008,8 +5991,6 @@ AqlValue Functions::Ceil(arangodb::aql::Query*, transaction::Methods* trx,
 AqlValue Functions::Floor(arangodb::aql::Query*,
                           transaction::Methods* trx,
                           VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "FLOOR", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   double input = value.toDouble(trx);
@@ -6019,8 +6000,6 @@ AqlValue Functions::Floor(arangodb::aql::Query*,
 /// @brief function SQRT
 AqlValue Functions::Sqrt(arangodb::aql::Query*, transaction::Methods* trx,
                          VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "SQRT", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   double input = value.toDouble(trx);
@@ -6030,8 +6009,6 @@ AqlValue Functions::Sqrt(arangodb::aql::Query*, transaction::Methods* trx,
 /// @brief function POW
 AqlValue Functions::Pow(arangodb::aql::Query*, transaction::Methods* trx,
                         VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "POW", 2, 2);
-
   AqlValue baseValue = ExtractFunctionParameterValue(parameters, 0);
   AqlValue expValue = ExtractFunctionParameterValue(parameters, 1);
 
@@ -6044,8 +6021,6 @@ AqlValue Functions::Pow(arangodb::aql::Query*, transaction::Methods* trx,
 /// @brief function LOG
 AqlValue Functions::Log(arangodb::aql::Query*, transaction::Methods* trx,
                         VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "LOG", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   double input = value.toDouble(trx);
@@ -6055,8 +6030,6 @@ AqlValue Functions::Log(arangodb::aql::Query*, transaction::Methods* trx,
 /// @brief function LOG2
 AqlValue Functions::Log2(arangodb::aql::Query*, transaction::Methods* trx,
                          VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "LOG2", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   double input = value.toDouble(trx);
@@ -6067,8 +6040,6 @@ AqlValue Functions::Log2(arangodb::aql::Query*, transaction::Methods* trx,
 AqlValue Functions::Log10(arangodb::aql::Query*,
                           transaction::Methods* trx,
                           VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "LOG10", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   double input = value.toDouble(trx);
@@ -6078,8 +6049,6 @@ AqlValue Functions::Log10(arangodb::aql::Query*,
 /// @brief function EXP
 AqlValue Functions::Exp(arangodb::aql::Query*, transaction::Methods* trx,
                         VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "EXP", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   double input = value.toDouble(trx);
@@ -6089,8 +6058,6 @@ AqlValue Functions::Exp(arangodb::aql::Query*, transaction::Methods* trx,
 /// @brief function EXP2
 AqlValue Functions::Exp2(arangodb::aql::Query*, transaction::Methods* trx,
                          VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "EXP2", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   double input = value.toDouble(trx);
@@ -6100,8 +6067,6 @@ AqlValue Functions::Exp2(arangodb::aql::Query*, transaction::Methods* trx,
 /// @brief function SIN
 AqlValue Functions::Sin(arangodb::aql::Query*, transaction::Methods* trx,
                         VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "SIN", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   double input = value.toDouble(trx);
@@ -6111,8 +6076,6 @@ AqlValue Functions::Sin(arangodb::aql::Query*, transaction::Methods* trx,
 /// @brief function COS
 AqlValue Functions::Cos(arangodb::aql::Query*, transaction::Methods* trx,
                         VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "COS", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   double input = value.toDouble(trx);
@@ -6122,8 +6085,6 @@ AqlValue Functions::Cos(arangodb::aql::Query*, transaction::Methods* trx,
 /// @brief function TAN
 AqlValue Functions::Tan(arangodb::aql::Query*, transaction::Methods* trx,
                         VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "TAN", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   double input = value.toDouble(trx);
@@ -6133,8 +6094,6 @@ AqlValue Functions::Tan(arangodb::aql::Query*, transaction::Methods* trx,
 /// @brief function ASIN
 AqlValue Functions::Asin(arangodb::aql::Query*, transaction::Methods* trx,
                          VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "ASIN", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   double input = value.toDouble(trx);
@@ -6144,8 +6103,6 @@ AqlValue Functions::Asin(arangodb::aql::Query*, transaction::Methods* trx,
 /// @brief function ACOS
 AqlValue Functions::Acos(arangodb::aql::Query*, transaction::Methods* trx,
                          VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "ACOS", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   double input = value.toDouble(trx);
@@ -6155,8 +6112,6 @@ AqlValue Functions::Acos(arangodb::aql::Query*, transaction::Methods* trx,
 /// @brief function ATAN
 AqlValue Functions::Atan(arangodb::aql::Query*, transaction::Methods* trx,
                          VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "ATAN", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   double input = value.toDouble(trx);
@@ -6167,8 +6122,6 @@ AqlValue Functions::Atan(arangodb::aql::Query*, transaction::Methods* trx,
 AqlValue Functions::Atan2(arangodb::aql::Query*,
                           transaction::Methods* trx,
                           VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "ATAN2", 2, 2);
-
   AqlValue value1 = ExtractFunctionParameterValue(parameters, 0);
   AqlValue value2 = ExtractFunctionParameterValue(parameters, 1);
 
@@ -6181,8 +6134,6 @@ AqlValue Functions::Atan2(arangodb::aql::Query*,
 AqlValue Functions::Radians(arangodb::aql::Query*,
                             transaction::Methods* trx,
                             VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "RADIANS", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   double degrees = value.toDouble(trx);
@@ -6194,8 +6145,6 @@ AqlValue Functions::Radians(arangodb::aql::Query*,
 AqlValue Functions::Degrees(arangodb::aql::Query*,
                             transaction::Methods* trx,
                             VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "DEGREES", 1, 1);
-
   AqlValue value = ExtractFunctionParameterValue(parameters, 0);
 
   double radians = value.toDouble(trx);
@@ -6206,8 +6155,6 @@ AqlValue Functions::Degrees(arangodb::aql::Query*,
 /// @brief function PI
 AqlValue Functions::Pi(arangodb::aql::Query*, transaction::Methods* trx,
                        VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "PI", 0, 0);
-
   // acos(-1) == PI
   return ::numberValue(trx, std::acos(-1.0), true);
 }
@@ -6215,8 +6162,6 @@ AqlValue Functions::Pi(arangodb::aql::Query*, transaction::Methods* trx,
 /// @brief function RAND
 AqlValue Functions::Rand(arangodb::aql::Query*, transaction::Methods* trx,
                          VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "RAND", 0, 0);
-
   // This random functionality is not too good yet...
   return ::numberValue(trx, static_cast<double>(std::rand()) / RAND_MAX, true);
 }
@@ -6255,7 +6200,6 @@ AqlValue Functions::FirstList(arangodb::aql::Query*,
 AqlValue Functions::Push(arangodb::aql::Query* query, transaction::Methods* trx,
                          VPackFunctionParameters const& parameters) {
   static char const* AFN = "PUSH";
-  ValidateParameters(parameters, AFN, 2, 3);
 
   AqlValue list = ExtractFunctionParameterValue(parameters, 0);
   AqlValue toPush = ExtractFunctionParameterValue(parameters, 1);
@@ -6301,7 +6245,7 @@ AqlValue Functions::Push(arangodb::aql::Query* query, transaction::Methods* trx,
 AqlValue Functions::Pop(arangodb::aql::Query* query, transaction::Methods* trx,
                         VPackFunctionParameters const& parameters) {
   static char const* AFN = "POP";
-  ValidateParameters(parameters, AFN, 1, 1);
+  
   AqlValue list = ExtractFunctionParameterValue(parameters, 0);
 
   if (list.isNull(true)) {
@@ -6332,7 +6276,7 @@ AqlValue Functions::Append(arangodb::aql::Query* query,
                            transaction::Methods* trx,
                            VPackFunctionParameters const& parameters) {
   static char const* AFN = "APPEND";
-  ValidateParameters(parameters, AFN, 2, 3);
+  
   AqlValue list = ExtractFunctionParameterValue(parameters, 0);
   AqlValue toAppend = ExtractFunctionParameterValue(parameters, 1);
 
@@ -6409,7 +6353,7 @@ AqlValue Functions::Unshift(arangodb::aql::Query* query,
                             transaction::Methods* trx,
                             VPackFunctionParameters const& parameters) {
   static char const* AFN = "UNSHIFT";
-  ValidateParameters(parameters, AFN, 2, 3);
+  
   AqlValue list = ExtractFunctionParameterValue(parameters, 0);
 
   if (!list.isNull(true) && !list.isArray()) {
@@ -6455,7 +6399,6 @@ AqlValue Functions::Shift(arangodb::aql::Query* query,
                           transaction::Methods* trx,
                           VPackFunctionParameters const& parameters) {
   static char const* AFN = "SHIFT";
-  ValidateParameters(parameters, AFN, 1, 1);
 
   AqlValue list = ExtractFunctionParameterValue(parameters, 0);
   if (list.isNull(true)) {
@@ -6492,7 +6435,6 @@ AqlValue Functions::RemoveValue(arangodb::aql::Query* query,
                                 transaction::Methods* trx,
                                 VPackFunctionParameters const& parameters) {
   static char const* AFN = "REMOVE_VALUE";
-  ValidateParameters(parameters, AFN, 2, 3);
 
   AqlValue list = ExtractFunctionParameterValue(parameters, 0);
 
@@ -6549,7 +6491,6 @@ AqlValue Functions::RemoveValues(arangodb::aql::Query* query,
                                  transaction::Methods* trx,
                                  VPackFunctionParameters const& parameters) {
   static char const* AFN = "REMOVE_VALUES";
-  ValidateParameters(parameters, AFN, 2, 2);
 
   AqlValue list = ExtractFunctionParameterValue(parameters, 0);
   AqlValue values = ExtractFunctionParameterValue(parameters, 1);
@@ -6590,7 +6531,6 @@ AqlValue Functions::RemoveNth(arangodb::aql::Query* query,
                               transaction::Methods* trx,
                               VPackFunctionParameters const& parameters) {
   static char const* AFN = "REMOVE_NTH";
-  ValidateParameters(parameters, AFN, 2, 2);
 
   AqlValue list = ExtractFunctionParameterValue(parameters, 0);
 
@@ -6650,8 +6590,6 @@ AqlValue Functions::NotNull(arangodb::aql::Query*,
 AqlValue Functions::CurrentDatabase(arangodb::aql::Query* query,
                                     transaction::Methods* trx,
                                     VPackFunctionParameters const& parameters) {
-  ValidateParameters(parameters, "CURRENT_DATABASE", 0, 0);
-
   return AqlValue(query->vocbase().name());
 }
 
@@ -6678,7 +6616,6 @@ AqlValue Functions::CollectionCount(arangodb::aql::Query*,
                                     transaction::Methods* trx,
                                     VPackFunctionParameters const& parameters) {
   static char const* AFN = "COLLECTION_COUNT";
-  ValidateParameters(parameters, AFN, 1, 1);
 
   AqlValue element = ExtractFunctionParameterValue(parameters, 0);
   if (!element.isString()) {
@@ -6701,7 +6638,6 @@ AqlValue Functions::VarianceSample(arangodb::aql::Query* query,
                                    transaction::Methods* trx,
                                    VPackFunctionParameters const& parameters) {
   static char const* AFN = "VARIANCE_SAMPLE";
-  ValidateParameters(parameters, AFN, 1, 1);
 
   AqlValue list = ExtractFunctionParameterValue(parameters, 0);
 
@@ -6730,7 +6666,6 @@ AqlValue Functions::VariancePopulation(
     arangodb::aql::Query* query, transaction::Methods* trx,
     VPackFunctionParameters const& parameters) {
   static char const* AFN = "VARIANCE_POPULATION";
-  ValidateParameters(parameters, AFN, 1, 1);
 
   AqlValue list = ExtractFunctionParameterValue(parameters, 0);
 
@@ -6759,7 +6694,6 @@ AqlValue Functions::StdDevSample(arangodb::aql::Query* query,
                                  transaction::Methods* trx,
                                  VPackFunctionParameters const& parameters) {
   static char const* AFN = "STDDEV_SAMPLE";
-  ValidateParameters(parameters, AFN, 1, 1);
 
   AqlValue list = ExtractFunctionParameterValue(parameters, 0);
 
@@ -6788,7 +6722,6 @@ AqlValue Functions::StdDevPopulation(
     arangodb::aql::Query* query, transaction::Methods* trx,
     VPackFunctionParameters const& parameters) {
   static char const* AFN = "STDDEV_POPULATION";
-  ValidateParameters(parameters, AFN, 1, 1);
 
   AqlValue list = ExtractFunctionParameterValue(parameters, 0);
 
@@ -6817,7 +6750,6 @@ AqlValue Functions::Median(arangodb::aql::Query* query,
                            transaction::Methods* trx,
                            VPackFunctionParameters const& parameters) {
   static char const* AFN = "MEDIAN";
-  ValidateParameters(parameters, AFN, 1, 1);
 
   AqlValue list = ExtractFunctionParameterValue(parameters, 0);
 
@@ -6850,8 +6782,7 @@ AqlValue Functions::Percentile(arangodb::aql::Query* query,
                                transaction::Methods* trx,
                                VPackFunctionParameters const& parameters) {
   static char const* AFN = "PERCENTILE";
-  ValidateParameters(parameters, AFN, 2, 3);
-
+  
   AqlValue list = ExtractFunctionParameterValue(parameters, 0);
 
   if (!list.isArray()) {
@@ -6944,7 +6875,6 @@ AqlValue Functions::Range(arangodb::aql::Query* query,
                           transaction::Methods* trx,
                           VPackFunctionParameters const& parameters) {
   static char const* AFN = "RANGE";
-  ValidateParameters(parameters, AFN, 2, 3);
 
   AqlValue left = ExtractFunctionParameterValue(parameters, 0);
   AqlValue right = ExtractFunctionParameterValue(parameters, 1);
@@ -6989,7 +6919,6 @@ AqlValue Functions::Position(arangodb::aql::Query* query,
                              transaction::Methods* trx,
                              VPackFunctionParameters const& parameters) {
   static char const* AFN = "POSITION";
-  ValidateParameters(parameters, AFN, 2, 3);
 
   AqlValue list = ExtractFunctionParameterValue(parameters, 0);
 
@@ -7033,78 +6962,11 @@ AqlValue Functions::Position(arangodb::aql::Query* query,
   return AqlValue(builder.get());
 }
 
-AqlValue Functions::CallApplyBackend(arangodb::aql::Query* query,
-                                     transaction::Methods* trx,
-                                     VPackFunctionParameters const& parameters,
-                                     char const* AFN,
-                                     AqlValue const& invokeFN,
-                                     VPackFunctionParameters const& invokeParams) {
-  std::string ucInvokeFN;
-  transaction::StringBufferLeaser buffer(trx);
-  arangodb::basics::VPackStringBufferAdapter adapter(buffer->stringBuffer());
-
-  ::appendAsString(trx, adapter, invokeFN);
-
-  UnicodeString unicodeStr(buffer->c_str(),
-                           static_cast<int32_t>(buffer->length()));
-  unicodeStr.toUpper(nullptr);
-  unicodeStr.toUTF8String(ucInvokeFN);
-
-  arangodb::aql::Function const* func = nullptr;
-  if (ucInvokeFN.find("::") == std::string::npos) {
-    func = AqlFunctionFeature::getFunctionByName(ucInvokeFN);
-    if (func->implementation != nullptr) {
-      return func->implementation(query, trx, invokeParams);
-    }
-  }
-
-  {
-    ISOLATE;
-    TRI_V8_CURRENT_GLOBALS_AND_SCOPE;
-    query->prepareV8Context();
-
-    auto old = v8g->_query;
-    v8g->_query = query;
-    TRI_DEFER(v8g->_query = old);
-
-    std::string jsName;
-    int const n = static_cast<int>(invokeParams.size());
-    int const callArgs = (func == nullptr ? 3 : n);
-    auto args = std::make_unique<v8::Handle<v8::Value>[]>(callArgs);
-
-    if (func == nullptr) {
-      // a call to a user-defined function
-      jsName = "FCALL_USER";
-
-      // function name
-      args[0] = TRI_V8_STD_STRING(isolate, ucInvokeFN);
-      // call parameters
-      v8::Handle<v8::Array> params = v8::Array::New(isolate, static_cast<int>(n));
-
-      for (int i = 0; i < n; ++i) {
-        params->Set(static_cast<uint32_t>(i), invokeParams[i].toV8(isolate, trx));
-      }
-      args[1] = params;
-      args[2] = TRI_V8_ASCII_STRING(isolate, AFN);
-    } else {
-      // a call to a built-in V8 function
-      jsName = "AQL_" + func->name;
-      for (int i = 0; i < n; ++i) {
-        args[i] = invokeParams[i].toV8(isolate, trx);
-      }
-    }
-
-    bool dummy;
-    return Expression::invokeV8Function(query, trx, jsName, ucInvokeFN, AFN, false, callArgs, args.get(), dummy);
-  }
-}
-
 /// @brief function CALL
 AqlValue Functions::Call(arangodb::aql::Query* query,
                          transaction::Methods* trx,
                          VPackFunctionParameters const& parameters) {
   static char const* AFN = "CALL";
-  ValidateParameters(parameters, AFN, 1);
 
   AqlValue invokeFN = ExtractFunctionParameterValue(parameters, 0);
   if (!invokeFN.isString()) {
@@ -7123,7 +6985,7 @@ AqlValue Functions::Call(arangodb::aql::Query* query,
     }
   }
 
-  return CallApplyBackend(query, trx, parameters, AFN, invokeFN, invokeParams);
+  return ::callApplyBackend(query, trx, AFN, invokeFN, invokeParams);
 }
 
 /// @brief function APPLY
@@ -7131,7 +6993,6 @@ AqlValue Functions::Apply(
     arangodb::aql::Query* query, transaction::Methods* trx,
     VPackFunctionParameters const& parameters) {
   static char const* AFN = "APPLY";
-  ValidateParameters(parameters, AFN, 1, 2);
 
   AqlValue invokeFN = ExtractFunctionParameterValue(parameters, 0);
   if (!invokeFN.isString()) {
@@ -7171,7 +7032,7 @@ AqlValue Functions::Apply(
     }
   }
 
-  return CallApplyBackend(query, trx, parameters, AFN, invokeFN, invokeParams);
+  return ::callApplyBackend(query, trx, AFN, invokeFN, invokeParams);
 }
 
 /// @brief function IS_SAME_COLLECTION
@@ -7179,7 +7040,6 @@ AqlValue Functions::IsSameCollection(
     arangodb::aql::Query* query, transaction::Methods* trx,
     VPackFunctionParameters const& parameters) {
   static char const* AFN = "IS_SAME_COLLECTION";
-  ValidateParameters(parameters, AFN, 2, 2);
 
   std::string const first = ::extractCollectionName(trx, parameters, 0);
   std::string const second = ::extractCollectionName(trx, parameters, 1);
@@ -7196,7 +7056,6 @@ AqlValue Functions::PregelResult(arangodb::aql::Query* query,
                                  transaction::Methods* trx,
                                  VPackFunctionParameters const& parameters) {
   static char const* AFN = "PREGEL_RESULT";
-  ValidateParameters(parameters, AFN, 1, 1);
 
   AqlValue arg1 = ExtractFunctionParameterValue(parameters, 0);
   if (!arg1.isNumber()) {
@@ -7247,7 +7106,7 @@ AqlValue Functions::Assert(arangodb::aql::Query* query,
                            transaction::Methods* trx,
                            VPackFunctionParameters const& parameters) {
   static char const* AFN = "ASSERT";
-  ValidateParameters(parameters, AFN, 2, 2);
+  
   auto const expr = ExtractFunctionParameterValue(parameters, 0);
   auto const message = ExtractFunctionParameterValue(parameters, 1);
 
@@ -7265,7 +7124,7 @@ AqlValue Functions::Assert(arangodb::aql::Query* query,
 AqlValue Functions::Warn(arangodb::aql::Query* query, transaction::Methods* trx,
                          VPackFunctionParameters const& parameters) {
   static char const* AFN = "WARN";
-  ValidateParameters(parameters, AFN, 2, 2);
+  
   auto const expr = ExtractFunctionParameterValue(parameters, 0);
   auto const message = ExtractFunctionParameterValue(parameters, 1);
 
@@ -7284,8 +7143,6 @@ AqlValue Functions::Warn(arangodb::aql::Query* query, transaction::Methods* trx,
 
 AqlValue Functions::Fail(arangodb::aql::Query*, transaction::Methods* trx,
                          VPackFunctionParameters const& parameters) {
-  static char const* AFN = "FAIL";
-  ValidateParameters(parameters, AFN, 0, 1);
   if (parameters.size() == 0) {
     THROW_ARANGO_EXCEPTION_PARAMS(TRI_ERROR_QUERY_FAIL_CALLED, "");
   }
@@ -7307,7 +7164,6 @@ AqlValue Functions::DateFormat(arangodb::aql::Query* query,
                                VPackFunctionParameters const& params) {
   static char const* AFN = "DATE_FORMAT";
   tp_sys_clock_ms tp;
-  ValidateParameters(params, AFN, 2, 2);
 
   if (!::parameterToTimePoint(query, trx, params, tp, AFN, 0)) {
     return AqlValue(AqlValueHintNull());

--- a/arangod/Aql/Functions.h
+++ b/arangod/Aql/Functions.h
@@ -51,20 +51,12 @@ typedef std::function<AqlValue(arangodb::aql::Query*, transaction::Methods*,
 struct Functions {
 
  public:
-  /// @brief validate the number of parameters
-   static void ValidateParameters(VPackFunctionParameters const& parameters,
-                                  char const* function, int minParams,
-                                  int maxParams);
-
-   static void ValidateParameters(VPackFunctionParameters const& parameters,
-                                  char const* function, int minParams);
+   static void init();
 
    /// @brief extract a function parameter from the arguments
    static AqlValue ExtractFunctionParameterValue(
        VPackFunctionParameters const& parameters, size_t position);
 
-  public:
-   static void init();
    /// @brief helper function. not callable as a "normal" AQL function
    static void Stringify(transaction::Methods* trx,
                          arangodb::basics::VPackStringBufferAdapter& buffer,
@@ -447,12 +439,6 @@ struct Functions {
                           VPackFunctionParameters const&);
     static AqlValue Position(arangodb::aql::Query*, transaction::Methods*,
                              VPackFunctionParameters const&);
-    static AqlValue CallApplyBackend(arangodb::aql::Query* query,
-                                     transaction::Methods* trx,
-                                     VPackFunctionParameters const& parameters,
-                                     char const* AFN,
-                                     AqlValue const& invokeFN,
-                                     VPackFunctionParameters const& invokeParams);
     static AqlValue Call(arangodb::aql::Query*, transaction::Methods*,
                          VPackFunctionParameters const&);
     static AqlValue Apply(arangodb::aql::Query*, transaction::Methods*,
@@ -474,13 +460,6 @@ struct Functions {
     /// @brief dummy function that will only throw an error when called
     static AqlValue NotImplemented(arangodb::aql::Query*, transaction::Methods*,
                                    VPackFunctionParameters const&);
-
-   private:
-    static AqlValue DateFromParameters(arangodb::aql::Query* query,
-                                       transaction::Methods* trx,
-                                       VPackFunctionParameters const& parameters,
-                                       char const* AFN,
-                                       bool asTimestamp);
 };
 
 }


### PR DESCRIPTION
the validation has already been done before, so it does not need
to be repeated for each function call invocation