### PR TITLE
Add support for AARCH64 architecture

### DIFF
--- a/3rdParty/jemalloc/CMakeLists.txt
+++ b/3rdParty/jemalloc/CMakeLists.txt
@@ -4,7 +4,12 @@ project(jemalloc C)
 include(ExternalProject)
 
 # set version and paths
-set(JEMALLOC_VERSION "5.0.1")
+if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
+  set(JEMALLOC_VERSION "5.1.0")
+else ()
+  set(JEMALLOC_VERSION "5.0.1")
+endif ()
+
 set(JEMALLOC_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/v${JEMALLOC_VERSION}")
 set(JEMALLOC_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/v${JEMALLOC_VERSION}")
 


### PR DESCRIPTION
This PR is raised in accordance with the ongoing discussion at https://github.com/arangodb/arangodb-docker/issues/53

By referring to these changes anybody can start/progress in the work related to ```ArangoDB``` over ```arm64v8``` architecture.
I would be happy to support in any kind of work whether is related to development/validation or update to provide support for ARM64.

In addition, I have made a conditional check so as to ensure that provided changes do not interfere with support for ongoing ```AMD64``` architecture.

Regards,