### PR TITLE
remove unused bloat from the packages

### DIFF
--- a/cmake/ArangoDBInstall.cmake
+++ b/cmake/ArangoDBInstall.cmake
@@ -78,6 +78,8 @@ install(
     ${PROJECT_SOURCE_DIR}/js/server
   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR_ARANGO}/${ARANGODB_JS_VERSION}
   REGEX       "^.*/aardvark/APP/node_modules$"             EXCLUDE
+  REGEX       "^.*/aardvark/APP/frontend/js/lib"           EXCLUDE
+  REGEX       "^.*/js/server/assets/swagger/*.map$"        EXCLUDE
   REGEX       "^.*/.bin"                                   EXCLUDE
 )
 

--- a/cmake/InstallArangoDBJSClient.cmake
+++ b/cmake/InstallArangoDBJSClient.cmake
@@ -29,9 +29,4 @@ install(
   REGEX "^.*/eslint"                                       EXCLUDE
   REGEX "^.*/.npmignore"                                   EXCLUDE
   REGEX "^.*/.bin"                                         EXCLUDE
-  REGEX "^.*/_admin/aardvark/APP/frontend/html/"           EXCLUDE
-  REGEX "^.*/_admin/aardvark/APP/frontend/img/"            EXCLUDE
-  REGEX "^.*/_admin/aardvark/APP/frontend/js/"             EXCLUDE
-  REGEX "^.*/_admin/aardvark/APP/frontend/scss/"           EXCLUDE
-  REGEX "^.*/_admin/aardvark/APP/frontend/src/"            EXCLUDE
 )


### PR DESCRIPTION
- removes Swagger .map files from packages
- removes js/apps/system/_admin/aardvark/APP/frontend/js/lib from packages
This saves packaging 4.5+ MB uncompressed data.