### PR TITLE
semver foxx plain func

### DIFF
--- a/js/server/modules/@arangodb/index.js
+++ b/js/server/modules/@arangodb/index.js
@@ -26,6 +26,7 @@
 module.isSystem = true;
 
 var common = require('@arangodb/common');
+const semver = require('semver');
 
 Object.keys(common).forEach(function (key) {
   exports[key] = common[key];
@@ -80,16 +81,20 @@ exports.db = internal.db;
 
 exports.plainServerVersion = function () {
   let version = internal.version;
-  let devel = version.match(/(.*)\.devel/);
 
-  if (devel !== null) {
-    version = devel[1] + '.0';
-  } else {
-    devel = version.match(/(.*)((milestone|alpha|beta|devel|rc)[0-9]*)$/);
-
+  if (semver.valid(version) === null) {
+    let devel = version.match(/(.*)\.devel/);
     if (devel !== null) {
-      version = devel[1] + '0';;
+      version = devel[1] + '.0';
+    } else {
+      devel = version.match(/(.*)((milestone|alpha|beta|devel|rc)[0-9]*)$/);
+
+      if (devel !== null) {
+        version = devel[1] + '0';
+      }
     }
+  } else {
+    version = semver.major(version) + '.' + semver.minor(version) + '.' + semver.patch(version);
   }
 
   return version;


### PR DESCRIPTION
This PR adds formatting of semversioned versions. 
Keeping the old mechanism if verion is not given in semver format. 
Please remove this check, if this is not needed anymore (keep backward compatibility in mind?) 