### PR TITLE
do not report figures for an index by default

### DIFF
--- a/tests/js/server/tests/replication/replication-ongoing-global-spec.js
+++ b/tests/js/server/tests/replication/replication-ongoing-global-spec.js
@@ -68,11 +68,9 @@ const compareIndexes = function(l, r, eq) {
   for (let x of l) {
     delete x.id;
     delete x.selectivityEstimate;
-    delete x.figures;
   }
   for (let x of r) {
     delete x.id;
-    delete x.figures;
     delete x.selectivityEstimate;
   }
   if (eq) {


### PR DESCRIPTION
the change in behavior crept in unintentionally due to my last
change of the index API. this PR reverts the unintended change
here so figures are only returned when explicitly requested
