### PR TITLE
added option `--rocksdb.use-file-logging`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.3.15 (XXXX-XX-XX)
 --------------------
 
+* added option `--rocksdb.use-file-logging` to enable writing of RocksDB's own
+  informational LOG files into RocksDB's database directory.
+
+  This option is turned off by default, but can be enabled for debugging RocksDB
+  internals and performance.
+
 * improved error messages when managing Foxx services
 
   Install/replace/upgrade will now provide additional information when an error

--- a/Documentation/Books/Manual/Administration/Configuration/RocksDB.md
+++ b/Documentation/Books/Manual/Administration/Configuration/RocksDB.md
@@ -230,3 +230,20 @@ milliseconds in ArangoDB 3.4 however.
 
 Note: this option is not supported on Windows platforms. Setting the option to
 a value greater 0 will produce a startup warning.
+
+`--rocksdb.use-file-logging`
+
+When set to *true*, enables writing of RocksDB's own informational LOG files into 
+RocksDB's database directory.
+
+This option is turned off by default, but can be enabled for debugging RocksDB
+internals and performance.
+
+`--rocksdb.debug-logging`
+
+When set to *true*, enables verbose logging of RocksDB's actions into the logfile
+written by ArangoDB (if option `--rocksdb.use-file-logging` is off) or RocksDB's
+own log (if option `--rocksdb.use-file-logging` is on).
+
+This option is turned off by default, but can be enabled for debugging RocksDB
+internals and performance.

--- a/lib/ApplicationFeatures/RocksDBOptionFeature.cpp
+++ b/lib/ApplicationFeatures/RocksDBOptionFeature.cpp
@@ -77,7 +77,8 @@ RocksDBOptionFeature::RocksDBOptionFeature(
       _useFSync(rocksDBDefaults.use_fsync),
       _skipCorrupted(false),
       _dynamicLevelBytes(true),
-      _enableStatistics(false) {
+      _enableStatistics(false),
+      _useFileLogging(false) {
   // setting the number of background jobs to
   _maxBackgroundJobs = static_cast<int32_t>(std::max((size_t)2,
                                                      std::min(TRI_numberProcessors(), (size_t)8)));
@@ -257,6 +258,10 @@ void RocksDBOptionFeature::collectOptions(
       "that way RocksDB's compaction is doing sequential instead of random "
       "reads.",
       new UInt64Parameter(&_compactionReadaheadSize));
+  
+  options->addHiddenOption("--rocksdb.use-file-logging",
+                           "use a file-base logger for RocksDB's own logs",
+                           new BooleanParameter(&_useFileLogging));
 
   options->addHiddenOption("--rocksdb.wal-recovery-skip-corrupted",
                            "skip corrupted records in WAL recovery",

--- a/lib/ApplicationFeatures/RocksDBOptionFeature.h
+++ b/lib/ApplicationFeatures/RocksDBOptionFeature.h
@@ -78,6 +78,7 @@ class RocksDBOptionFeature final
   bool _skipCorrupted;
   bool _dynamicLevelBytes;
   bool _enableStatistics;
+  bool _useFileLogging;
 };
 
 }  // namespace arangodb


### PR DESCRIPTION
Added option `--rocksdb.use-file-logging` to allow RocksDB write its own LOG files.