### PR TITLE
Fix a minor typo in docs: "a" should be "as"

### DIFF
--- a/Documentation/Books/AQL/Functions/Document.md
+++ b/Documentation/Books/AQL/Functions/Document.md
@@ -307,7 +307,7 @@ MERGE_RECURSIVE(
 `PARSE_IDENTIFIER(documentHandle) → parts`
 
 Parse a [document handle](../../Manual/Appendix/Glossary.html#document-handle) and return its
-individual parts a separate attributes.
+individual parts as separate attributes.
 
 This function can be used to easily determine the
 [collection name](../../Manual/Appendix/Glossary.html#collection-name) and key of a given document.


### PR DESCRIPTION
Please note that for legal reasons we require you to sign the 
[Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
