### PR TITLE
Fix minor typo in docs under PARSE_IDENTIFIER

### DIFF
--- a/Documentation/Books/AQL/Functions/Document.md
+++ b/Documentation/Books/AQL/Functions/Document.md
@@ -317,7 +317,7 @@ PARSE_IDENTIFIER()
 `PARSE_IDENTIFIER(documentHandle) → parts`
 
 Parse a [document handle](../../Manual/Appendix/Glossary.html#document-handle) and return its
-individual parts a separate attributes.
+individual parts as separate attributes.
 
 This function can be used to easily determine the
 [collection name](../../Manual/Appendix/Glossary.html#collection-name) and key of a given document.


### PR DESCRIPTION
From "...return its individual parts a separate attributes" to "return its individual parts as separate attributes".
