### PR TITLE
improve graph error messages in the UI

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/aardvark.js
+++ b/js/apps/system/_admin/aardvark/APP/aardvark.js
@@ -31,12 +31,15 @@ const joi = require('joi');
 const dd = require('dedent');
 const internal = require('internal');
 const db = require('@arangodb').db;
+const actions = require('@arangodb/actions');
 const errors = require('@arangodb').errors;
+const ArangoError = require('@arangodb').ArangoError;
 const notifications = require('@arangodb/configuration').notifications;
 const examples = require('@arangodb/graph-examples/example-graph');
 const createRouter = require('@arangodb/foxx/router');
 const users = require('@arangodb/users');
 const cluster = require('@arangodb/cluster');
+const generalGraph = require('@arangodb/general-graph');
 const request = require('@arangodb/request');
 const isEnterprise = require('internal').isEnterprise();
 const explainer = require('@arangodb/aql/explainer');
@@ -311,8 +314,17 @@ authRouter.post('/graph-examples/create/:name', function (req, res) {
   if (['knows_graph', 'social', 'routeplanner'].indexOf(name) === -1) {
     res.throw('not found');
   }
-
-  const g = examples.loadGraph(name);
+  if (generalGraph._list().indexOf(name) !== -1) {
+    const error = new ArangoError({errorNum: errors.ERROR_GRAPH_DUPLICATE.code, errorMessage: errors.ERROR_GRAPH_DUPLICATE.message});
+    res.throw(409, error);
+  }
+  let g = false;
+  try {
+    g = examples.loadGraph(name);
+  } catch (e) {
+    const error = new ArangoError({errorNum: e.errorNum, errorMessage: e.errorMessage});
+    res.throw(actions.arangoErrorToHttpCode(e.errorNum), error);
+  }
   res.json({error: !g});
 })
 .pathParam('name', joi.string().required(), 'Name of the example graph.')


### PR DESCRIPTION
creating a duplicate graph now results in in the error message:
`Example Graphs: graph already exists`

creating a graph with with already existing collections now results in the error message:
`Example Graphs: the collection: ["array","of", "collections"] already exists. Please clean up and try again.`