### PR TITLE
Wait 2s after switching server mode before answering.

### DIFF
--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -875,6 +875,10 @@ Result ServerState::propagateClusterServerMode(Mode mode) {
       if (!r.successful()) {
         return Result(TRI_ERROR_CLUSTER_AGENCY_COMMUNICATION_FAILED, r.errorMessage());
       }
+      // This is propagated to all servers via the heartbeat, which happens
+      // once per second. So to ensure that every server has taken note of
+      // the change, we delay here for 2 seconds.
+      std::this_thread::sleep_for(std::chrono::seconds(2));
     }
     setServerMode(mode);
   }


### PR DESCRIPTION
This is needed because the change is propagated via the agency and the
heartbeat, which only happens once per second.