### PR TITLE
Forward port changelog changes and typo fixes from #6303

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,9 +12,13 @@ devel
 
 * upgraded bundled Snappy compression library to 1.1.7
 
-* fixed issue #5941 if using breath first search in traversals uniqueness checks
+* fixed issue #5941 if using breadth first search in traversals uniqueness checks
   on path (vertices and edges) have not been applied. In SmartGraphs the checks
   have been executed properly.
+
+* added more detailed progress output to arangorestore, showing the percentage of
+  how much data is restored for bigger collections plus a set of overview statistics
+  after each processed collection
 
 * added option `--rocksdb.use-file-logging` to enable writing of RocksDB's own
   informational LOG files into RocksDB's database directory.

--- a/arangod/Graph/BreadthFirstEnumerator.cpp
+++ b/arangod/Graph/BreadthFirstEnumerator.cpp
@@ -239,14 +239,14 @@ bool BreadthFirstEnumerator::pathContainsVertex(size_t index, StringRef vertex) 
   while (true) {
     TRI_ASSERT(index < _schreier.size());
     auto const& step = _schreier[index];
-    // Massive logic error, only valid pointers should inserted in _schreier
+    // Massive logic error, only valid pointers should be inserted into _schreier
     TRI_ASSERT(step != nullptr);
     if (step->vertex == vertex) {
       // We have the given vertex on this path
       return true;
     }
     if (index == 0) {
-      //We have checked the compelte path
+      // We have checked the complete path
       return false;
     }
     index = step->sourceIdx;
@@ -258,7 +258,7 @@ bool BreadthFirstEnumerator::pathContainsEdge(size_t index, graph::EdgeDocumentT
   while (index != 0) {
     TRI_ASSERT(index < _schreier.size());
     auto const& step = _schreier[index];
-    // Massive logic error, only valid pointers should inserted in _schreier
+    // Massive logic error, only valid pointers should be inserted into _schreier
     TRI_ASSERT(step != nullptr);
     if (step->edge.equals(edge)) {
       // We have the given vertex on this path


### PR DESCRIPTION
The following changes did not make into 3.4 apparently:

https://github.com/arangodb/arangodb/pull/6303/commits/1e725646d343871b031b9fd48676f8965c3fd3b1#diff-d6a329b541cdda9e5ddff2c3e96e637d