### PR TITLE
do not create empty useless transaction data objects

### DIFF
--- a/arangod/ClusterEngine/ClusterTransactionManager.h
+++ b/arangod/ClusterEngine/ClusterTransactionManager.h
@@ -51,6 +51,7 @@ class ClusterTransactionManager final : public TransactionManager {
   // register a transaction
   void registerTransaction(TRI_voc_tid_t transactionId,
                            std::unique_ptr<TransactionData> data) override {
+    TRI_ASSERT(data == nullptr);
     ++_nrRunning;
   }
 

--- a/arangod/ClusterEngine/ClusterTransactionState.cpp
+++ b/arangod/ClusterEngine/ClusterTransactionState.cpp
@@ -81,9 +81,7 @@ Result ClusterTransactionState::beginTransaction(transaction::Hints hints) {
 
   if (_nestingLevel == 0) {
     // register a protector (intentionally empty)
-    auto data = std::make_unique<ClusterTransactionData>();
-    TransactionManagerFeature::manager()->registerTransaction(_id, std::move(data));
-    
+    TransactionManagerFeature::manager()->registerTransaction(_id, std::unique_ptr<ClusterTransactionData>());
   } else {
     TRI_ASSERT(_status == transaction::Status::RUNNING);
   }

--- a/arangod/MMFiles/MMFilesTransactionManager.cpp
+++ b/arangod/MMFiles/MMFilesTransactionManager.cpp
@@ -69,7 +69,7 @@ void MMFilesTransactionManager::registerTransaction(TRI_voc_tid_t transactionId,
 
 // unregisters a transaction
 void MMFilesTransactionManager::unregisterTransaction(TRI_voc_tid_t transactionId,
-                                               bool markAsFailed) {
+                                                      bool markAsFailed) {
   size_t bucket = getBucket(transactionId);
   READ_LOCKER(allTransactionsLocker, _allTransactionsLock);
     
@@ -109,6 +109,7 @@ void MMFilesTransactionManager::iterateActiveTransactions(std::function<void(TRI
     READ_LOCKER(locker, _transactions[bucket]._lock);
 
     for (auto const& it : _transactions[bucket]._activeTransactions) {
+      TRI_ASSERT(it.second != nullptr);
       callback(it.first, it.second.get());
     }
   }

--- a/arangod/RocksDBEngine/RocksDBTransactionManager.h
+++ b/arangod/RocksDBEngine/RocksDBTransactionManager.h
@@ -52,6 +52,7 @@ class RocksDBTransactionManager final : public TransactionManager {
   // register a transaction
   void registerTransaction(TRI_voc_tid_t transactionId,
                            std::unique_ptr<TransactionData> data) override {
+    TRI_ASSERT(data == nullptr);
     ++_nrRunning;
   }
 

--- a/arangod/RocksDBEngine/RocksDBTransactionState.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.cpp
@@ -114,11 +114,8 @@ Result RocksDBTransactionState::beginTransaction(transaction::Hints hints) {
   }
 
   if (_nestingLevel == 0) {
-
     // register a protector (intentionally empty)
-    auto data = std::make_unique<RocksDBTransactionData>();
-    TransactionManagerFeature::manager()->registerTransaction(_id,
-                                                              std::move(data));
+    TransactionManagerFeature::manager()->registerTransaction(_id, std::unique_ptr<RocksDBTransactionData>());
 
     TRI_ASSERT(_rocksTransaction == nullptr);
     TRI_ASSERT(_cacheTx == nullptr);


### PR DESCRIPTION
  in the storage engines that do not need them
  the only engine using these objects is MMFiles. the other engines
  can get away with not creating these objects
