### PR TITLE
Completely export views dump restore

### DIFF
--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -71,6 +71,7 @@ if (USE_IRESEARCH)
     IResearch/IResearchViewNode.cpp IResearch/IResearchViewNode.h
     IResearch/IResearchViewBlock.cpp IResearch/IResearchViewBlock.h
     IResearch/IResearchViewMeta.cpp IResearch/IResearchViewMeta.h
+    IResearch/IResearchViewSingleServer.cpp IResearch/IResearchViewSingleServer.h
     IResearch/IResearchFeature.cpp IResearch/IResearchFeature.h
     IResearch/IResearchDocument.cpp IResearch/IResearchDocument.h
     IResearch/IResearchFilterFactory.cpp IResearch/IResearchFilterFactory.h

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -43,6 +43,7 @@
 #include "IResearchView.h"
 #include "IResearchViewCoordinator.h"
 #include "IResearchViewDBServer.h"
+#include "IResearchViewSingleServer.h"
 #include "Aql/AqlValue.h"
 #include "Aql/AqlFunctionFeature.h"
 #include "Aql/Function.h"
@@ -348,8 +349,8 @@ void registerViewFactory() {
     res = viewTypes->emplace(viewType, arangodb::iresearch::IResearchViewCoordinator::make);
   } else if (arangodb::ServerState::instance()->isDBServer()) {
     res = viewTypes->emplace(viewType, arangodb::iresearch::IResearchViewDBServer::make);
-  } else {
-    res = viewTypes->emplace(viewType, arangodb::iresearch::IResearchView::make);
+  } else if (arangodb::ServerState::instance()->isSingleServer()) {
+    res = viewTypes->emplace(viewType, arangodb::iresearch::IResearchViewSingleServer::make);
   }
 
   if (!res.ok()) {

--- a/arangod/IResearch/IResearchView.cpp
+++ b/arangod/IResearch/IResearchView.cpp
@@ -1660,6 +1660,7 @@ int IResearchView::insert(
     arangodb::DatabasePathFeature
   >("DatabasePath");
 
+
   if (!feature) {
     LOG_TOPIC(WARN, arangodb::iresearch::TOPIC)
       << "failure to find feature 'DatabasePath' while constructing IResearch View in database '" << vocbase.id() << "'";

--- a/arangod/IResearch/IResearchView.h
+++ b/arangod/IResearch/IResearchView.h
@@ -132,7 +132,7 @@ class PrimaryKeyIndexReader: public irs::index_reader {
 ///       which may be, but are not explicitly required to be, triggered via
 ///       the IResearchLink or IResearchViewBlock
 ///////////////////////////////////////////////////////////////////////////////
-class IResearchView final
+class IResearchView
   : public arangodb::LogicalViewStorageEngine,
     public arangodb::FlushTransaction {
  public:

--- a/arangod/IResearch/IResearchViewCoordinator.cpp
+++ b/arangod/IResearch/IResearchViewCoordinator.cpp
@@ -130,11 +130,54 @@ bool IResearchViewCoordinator::emplace(
     uint64_t planVersion,
     LogicalView::PreCommitCallback const& preCommit
 ) {
+  auto& properties = info.isObject() ? info : emptyObjectSlice(); // if no 'info' then assume defaults
+  std::string error;
+
+  bool hasLinks = properties.hasKey("links");
+
   auto view = std::shared_ptr<IResearchViewCoordinator>(
     new IResearchViewCoordinator(vocbase, info, planVersion)
   );
-  auto& properties = info.isObject() ? info : emptyObjectSlice(); // if no 'info' then assume defaults
-  std::string error;
+
+  if (hasLinks) {
+    auto* engine = arangodb::ClusterInfo::instance();
+
+    if (!engine) {
+      return nullptr;
+    }
+
+    // check link auth as per https://github.com/arangodb/backlog/issues/459
+    if (arangodb::ExecContext::CURRENT) {
+      // check existing links
+      for (auto& entry: view->_collections) {
+        auto collection =
+          engine->getCollection(vocbase.name(), std::to_string(entry.first));
+
+        if (collection
+            && !arangodb::ExecContext::CURRENT->canUseCollection(vocbase.name(), collection->name(), arangodb::auth::Level::RO)) {
+          return nullptr;
+        }
+      }
+
+      // check new links
+      if (info.hasKey(StaticStrings::LinksField)) {
+        for (arangodb::velocypack::ObjectIterator itr(info.get(StaticStrings::LinksField)); itr.valid(); ++itr) {
+          if (!itr.key().isString()) {
+            continue; // not a resolvable collection (invalid jSON)
+          }
+
+          auto collection =
+            engine->getCollection(vocbase.name(), itr.key().copyString());
+
+          if (collection
+              && !arangodb::ExecContext::CURRENT->canUseCollection(vocbase.name(), collection->name(), arangodb::auth::Level::RO)) {
+            return nullptr;
+          }
+        }
+      }
+    }
+  }
+
 
   if (!view->_meta.init(properties, error)) {
     TRI_set_errno(TRI_ERROR_BAD_PARAMETER);
@@ -186,6 +229,33 @@ bool IResearchViewCoordinator::emplace(
         << "Failure during commit of created view while constructing IResearch View in database '" << vocbase.id() << "', error: " << error;
 
       return nullptr;
+    }
+
+    // create links - "on a best-effort basis"
+    if (info.hasKey("links")) {
+      arangodb::velocypack::Builder viewNewProperties;
+      viewNewProperties.openObject();
+      bool modified = false;
+      std::unordered_set<TRI_voc_cid_t> newCids;
+
+      std::unordered_set<TRI_voc_cid_t> currentCids;
+
+      auto result = updateLinks(
+        info.get("links"),
+        emptyObjectSlice(),
+        *view.get(),
+        false,
+        currentCids,
+        modified,
+        viewNewProperties,
+        newCids
+      );
+
+      if (result.fail()) {
+        TRI_set_errno(result.errorNumber());
+        LOG_TOPIC(ERR, arangodb::iresearch::TOPIC)
+          << "Failure to construct links on new view in database '" << vocbase.id() << "', error: " << error;
+      }
     }
   }
 

--- a/arangod/IResearch/IResearchViewSingleServer.cpp
+++ b/arangod/IResearch/IResearchViewSingleServer.cpp
@@ -1,0 +1,111 @@
+//////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2017 EMC Corporation
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is EMC Corporation
+///
+/// @author Lars Maier
+////////////////////////////////////////////////////////////////////////////////
+
+#include "IResearchCommon.h"
+#include "IResearchDocument.h"
+#include "IResearchFeature.h"
+#include "IResearchFilterFactory.h"
+#include "IResearchLink.h"
+#include "IResearchLinkHelper.h"
+
+#include "StorageEngine/TransactionState.h"
+#include "StorageEngine/StorageEngine.h"
+#include "RestServer/DatabaseFeature.h"
+#include "RestServer/DatabasePathFeature.h"
+#include "RestServer/FlushFeature.h"
+#include "Transaction/Methods.h"
+#include "Transaction/StandaloneContext.h"
+#include "Utils/ExecContext.h"
+#include "velocypack/Iterator.h"
+#include "VocBase/LogicalCollection.h"
+#include "VocBase/vocbase.h"
+#include "VocBase/LogicalView.h"
+#include "Logger/LogMacros.h"
+
+#include "IResearchView.h"
+#include "IResearchViewSingleServer.h"
+
+namespace arangodb {
+namespace iresearch {
+
+/*static*/ std::shared_ptr<LogicalView> IResearchViewSingleServer::make(
+    TRI_vocbase_t& vocbase,
+    arangodb::velocypack::Slice const& info,
+    bool isNew,
+    uint64_t planVersion,
+    LogicalView::PreCommitCallback const& preCommit /*= {}*/
+) {
+  auto& properties = info.isObject() ? info : emptyObjectSlice(); // if no 'info' then assume defaults
+  std::string error;
+
+  LOG_TOPIC(ERR, Logger::VIEWS) << "IResearchViewCoordinator::make info: " << info.toJson() << ", new: " << isNew;
+
+  bool hasLinks = properties.hasKey("links");
+
+  if (hasLinks && isNew) {
+
+    // check link auth as per https://github.com/arangodb/backlog/issues/459
+    if (arangodb::ExecContext::CURRENT) {
+
+      // check new links
+      if (info.hasKey(StaticStrings::LinksField)) {
+        for (arangodb::velocypack::ObjectIterator itr(info.get(StaticStrings::LinksField)); itr.valid(); ++itr) {
+          if (!itr.key().isString()) {
+            continue; // not a resolvable collection (invalid jSON)
+          }
+
+          auto collection= vocbase.lookupCollection(itr.key().copyString());
+
+          if (collection
+              && !arangodb::ExecContext::CURRENT->canUseCollection(vocbase.name(), collection->name(), arangodb::auth::Level::RO)) {
+            return nullptr;
+          }
+        }
+      }
+    }
+  }
+
+  auto view = IResearchView::make(vocbase, info, isNew, planVersion, preCommit);
+
+  // create links - "on a best-effort basis"
+  if (properties.hasKey("links") && isNew) {
+
+      std::unordered_set<TRI_voc_cid_t> collections;
+      auto result = IResearchLinkHelper::updateLinks(
+        collections, vocbase, *view.get(), properties.get("links")
+      );
+
+      if (result.fail()) {
+        TRI_set_errno(result.errorNumber());
+        LOG_TOPIC(ERR, arangodb::iresearch::TOPIC)
+          << "Failure to construct links on new view in database '" << vocbase.id() << "', error: " << error;
+        return nullptr;
+      }
+  }
+
+  return view;
+}
+
+}
+}
+
+

--- a/arangod/IResearch/IResearchViewSingleServer.h
+++ b/arangod/IResearch/IResearchViewSingleServer.h
@@ -1,0 +1,57 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2018 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Lars Maier
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef ARANGODB_IRESEARCH__IRESEARCH_VIEW_SINGLE_SERVER_H
+#define ARANGODB_IRESEARCH__IRESEARCH_VIEW_SINGLE_SERVER_H 1
+
+#include "IResearchView.h"
+
+#include <velocypack/Builder.h>
+#include <velocypack/Slice.h>
+
+namespace arangodb {
+namespace iresearch {
+
+///////////////////////////////////////////////////////////////////////////////
+/// @class IResearchViewSingleServer
+/// @brief an abstraction over the distributed IResearch index implementing the
+///        LogicalView interface
+///////////////////////////////////////////////////////////////////////////////
+class IResearchViewSingleServer final {
+ public:
+  ///////////////////////////////////////////////////////////////////////////////
+  /// @brief view factory
+  /// @returns initialized view object
+  ///////////////////////////////////////////////////////////////////////////////
+  static std::shared_ptr<LogicalView> make(
+    TRI_vocbase_t& vocbase,
+    velocypack::Slice const& info,
+    bool isNew,
+    uint64_t planVersion,
+    LogicalView::PreCommitCallback const& preCommit
+  );
+};
+
+} // iresearch
+} // arangodb
+
+#endif // ARANGODB_IRESEARCH__IRESEARCH_VIEW_SINGLE_SERVER_H

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -357,7 +357,7 @@ RestStatus RestReplicationHandler::execute() {
       if (type != rest::RequestType::PUT) {
         goto BAD_CALL;
       }
-      
+
       handleCommandRestoreView();
     } else if (command == "sync") {
       if (type != rest::RequestType::PUT) {
@@ -680,7 +680,7 @@ void RestReplicationHandler::handleCommandClusterInventory() {
   ClusterInfo* ci = ClusterInfo::instance();
   std::vector<std::shared_ptr<LogicalCollection>> cols =
       ci->getCollections(dbName);
-  auto views = ci->getViews(dbName);
+  auto views = _vocbase.views();//ci->getViews(dbName);
 
   VPackBuilder resultBuilder;
   resultBuilder.openObject();
@@ -711,7 +711,7 @@ void RestReplicationHandler::handleCommandClusterInventory() {
   resultBuilder.add("views", VPackValue(VPackValueType::Array));
   for (auto const& view : views) {
     resultBuilder.openObject();
-    view->toVelocyPack(resultBuilder, /*details*/false, /*forPersistence*/true);
+    view->toVelocyPack(resultBuilder, /*details*/true, /*forPersistence*/false);
     resultBuilder.close();
   }
   resultBuilder.close();  // views
@@ -1371,7 +1371,7 @@ Result RestReplicationHandler::processRestoreDataBatch(
   } catch (...) {
     return Result(TRI_ERROR_INTERNAL);
   }
-  
+
   bool const isUsersOnCoordinator = (ServerState::instance()->isCoordinator() && collectionName == "_users");
 
   // Now try to insert all keys for which the last marker was a document
@@ -1728,7 +1728,7 @@ void RestReplicationHandler::handleCommandRestoreView() {
     generateError(ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER);
     return;
   }
-  
+
   LOG_TOPIC(TRACE, Logger::REPLICATION) << "restoring view: "
     << nameSlice.copyString();
   auto view = _vocbase.lookupView(nameSlice.copyString());
@@ -2170,7 +2170,7 @@ void RestReplicationHandler::handleCommandAddFollower() {
 
 void RestReplicationHandler::handleCommandRemoveFollower() {
   TRI_ASSERT(ServerState::instance()->isDBServer());
-  
+
   bool success = false;
   VPackSlice const body = this->parseVPackBody(success);
   if (!success) {

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -287,7 +287,7 @@ void LogicalCollection::setShardMap(std::shared_ptr<ShardMap> const& map) {
   TRI_ASSERT(_sharding != nullptr);
   _sharding->setShardMap(map);
 }
-  
+
 int LogicalCollection::getResponsibleShard(arangodb::velocypack::Slice slice,
                                            bool docComplete, std::string& shardID) {
   bool usesDefaultShardKeys;
@@ -608,7 +608,14 @@ void LogicalCollection::toVelocyPackForClusterInventory(VPackBuilder& result,
   }
 
   result.add(VPackValue("indexes"));
-  getIndexesVPack(result, Index::makeFlags());
+  getIndexesVPack(result, Index::makeFlags(), [](arangodb::Index const* idx) {
+    // we have to exclude the primary and the edge index here, because otherwise
+    // at least the MMFiles engine will try to create it
+    // AND exclude arangosearch indexes
+    return (idx->type() != arangodb::Index::TRI_IDX_TYPE_PRIMARY_INDEX &&
+            idx->type() != arangodb::Index::TRI_IDX_TYPE_EDGE_INDEX &&
+            idx->type() != arangodb::Index::TRI_IDX_TYPE_IRESEARCH_LINK);
+  });
   result.add("planVersion", VPackValue(planVersion()));
   result.add("isReady", VPackValue(isReady));
   result.add("allInSync", VPackValue(allInSync));
@@ -690,8 +697,8 @@ void LogicalCollection::toVelocyPackIgnore(VPackBuilder& result,
     bool forPersistence) const {
   TRI_ASSERT(result.isOpenObject());
   VPackBuilder b = toVelocyPackIgnore(ignoreKeys, translateCids, forPersistence);
-  result.add(VPackObjectIterator(b.slice())); 
-} 
+  result.add(VPackObjectIterator(b.slice()));
+}
 
 VPackBuilder LogicalCollection::toVelocyPackIgnore(
     std::unordered_set<std::string> const& ignoreKeys, bool translateCids,
@@ -721,7 +728,7 @@ arangodb::Result LogicalCollection::updateProperties(VPackSlice const& slice,
   // ... probably a few others missing here ...
 
   MUTEX_LOCKER(guard, _infoLock); // prevent simultanious updates
-  
+
   size_t rf = _sharding->replicationFactor();
   VPackSlice rfSl = slice.get("replicationFactor");
   if (!rfSl.isNone()) {
@@ -736,7 +743,7 @@ arangodb::Result LogicalCollection::updateProperties(VPackSlice const& slice,
       if ((!isSatellite() && rf == 0) || rf > 10) {
         return Result(TRI_ERROR_BAD_PARAMETER, "bad value for replicationFactor");
       }
-      
+
       if (!_isLocal && rf != _sharding->replicationFactor()) { // sanity checks
         if (!_sharding->distributeShardsLike().empty()) {
           return Result(TRI_ERROR_FORBIDDEN, "Cannot change replicationFactor, "
@@ -1023,7 +1030,7 @@ ChecksumResult LogicalCollection::checksum(bool withRevisions, bool withData) co
 
   trx.invokeOnAllElements(name(), [&hash, &withData, &withRevisions, &trx, &collection](LocalDocumentId const& token) {
     collection->readDocumentWithCallback(&trx, token, [&](LocalDocumentId const&, VPackSlice slice) {
-      uint64_t localHash = transaction::helpers::extractKeyFromDocument(slice).hashString(); 
+      uint64_t localHash = transaction::helpers::extractKeyFromDocument(slice).hashString();
 
       if (withRevisions) {
         localHash += transaction::helpers::extractRevSliceFromDocument(slice).hash();
@@ -1040,7 +1047,7 @@ ChecksumResult LogicalCollection::checksum(bool withRevisions, bool withData) co
           // was already handled before
           VPackValueLength keyLength;
           char const* key = it.key.getString(keyLength);
-          if (keyLength >= 3 && 
+          if (keyLength >= 3 &&
               key[0] == '_' &&
               ((keyLength == 3 && memcmp(key, "_id", 3) == 0) ||
               (keyLength == 4 && (memcmp(key, "_key", 4) == 0 || memcmp(key, "_rev", 4) == 0)))) {
@@ -1048,8 +1055,8 @@ ChecksumResult LogicalCollection::checksum(bool withRevisions, bool withData) co
             continue;
           }
 
-          localHash ^= it.key.hash(seed) ^ 0xba5befd00d; 
-          localHash += it.value.normalizedHash(seed) ^ 0xd4129f526421; 
+          localHash ^= it.key.hash(seed) ^ 0xba5befd00d;
+          localHash += it.value.normalizedHash(seed) ^ 0xd4129f526421;
         }
       }
 

--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -62,7 +62,7 @@ arangodb::Result checkHttpResponse(
   if (response == nullptr || !response->isComplete()) {
     return {TRI_ERROR_INTERNAL,
         "got invalid response from server: '" +
-        client.getErrorMessage() + 
+        client.getErrorMessage() +
         "' while executing '" +
         requestAction +
         "' with this payload: '" +
@@ -74,7 +74,7 @@ arangodb::Result checkHttpResponse(
     return {TRI_ERROR_INTERNAL,
         "got invalid response from server: HTTP " +
         itoa(response->getHttpReturnCode()) + ": '" +
-        response->getHttpReturnMessage() + 
+        response->getHttpReturnMessage() +
         "' while executing '" +
         requestAction +
         "' with this payload: '" +
@@ -440,7 +440,7 @@ arangodb::Result restoreData(arangodb::httpclient::SimpleHttpClient& httpClient,
       return result;
     }
   }
-  
+
   int64_t const fileSize =  TRI_SizeFile(datafile->path().c_str());
 
   if (jobData.options.progress) {
@@ -506,15 +506,15 @@ arangodb::Result restoreData(arangodb::httpclient::SimpleHttpClient& httpClient,
       }
 
       buffer.erase_front(length);
-      
-      if (jobData.options.progress && 
-          fileSize > 0 && 
+
+      if (jobData.options.progress &&
+          fileSize > 0 &&
           numReadSinceLastReport > 1024 * 1024 * 8) {
         // report every 8MB of transferred data
         LOG_TOPIC(INFO, Logger::RESTORE) << "# Still loading data into " << collectionType
-                                         << " collection '" << cname << "', " 
-                                         << numReadForThisCollection << " of " << fileSize 
-                                         << " byte(s) restored (" << int(100. * double(numReadForThisCollection) / double(fileSize)) << " %)"; 
+                                         << " collection '" << cname << "', "
+                                         << numReadForThisCollection << " of " << fileSize
+                                         << " byte(s) restored (" << int(100. * double(numReadForThisCollection) / double(fileSize)) << " %)";
         numReadSinceLastReport = 0;
       }
     }
@@ -532,7 +532,7 @@ arangodb::Result restoreView(arangodb::httpclient::SimpleHttpClient& httpClient,
                              arangodb::RestoreFeature::Options const& options,
                              VPackSlice const& viewDefinition) {
   using arangodb::httpclient::SimpleHttpResult;
-  
+
   std::string url = "/_api/replication/restore-view?overwrite=" +
     std::string(options.overwrite ? "true" : "false") +
     "&force=" + std::string(options.force ? "true" : "false");
@@ -548,10 +548,10 @@ arangodb::Result restoreView(arangodb::httpclient::SimpleHttpClient& httpClient,
   if (response->wasHttpError()) {
     return ::checkHttpResponse(httpClient, response, "restoring view", body);
   }
-  
+
   return {TRI_ERROR_NO_ERROR};
 }
-  
+
 arangodb::Result processInputDirectory(
     arangodb::httpclient::SimpleHttpClient& httpClient,
     arangodb::ClientTaskQueue<arangodb::RestoreFeature::JobData>& jobQueue,
@@ -581,7 +581,7 @@ arangodb::Result processInputDirectory(
       // files
       for (std::string const& file : files) {
         size_t const nameLength = file.size();
-        
+
         if (nameLength > viewsSuffix.size() &&
             file.substr(file.size() - viewsSuffix.size()) == viewsSuffix) {
           VPackBuilder fileContentBuilder = directory.vpackFromJsonFile(file);
@@ -662,19 +662,7 @@ arangodb::Result processInputDirectory(
       }
     }
     std::sort(collections.begin(), collections.end(), ::sortCollections);
-   
-    if (options.importStructure && !views.empty()) {
-      LOG_TOPIC(INFO, Logger::RESTORE) << "# Creating views...";
-      // Step 2: recreate all views
-      for (VPackBuilder const& viewDefinition : views) {
-        LOG_TOPIC(DEBUG, Logger::RESTORE) << "# Creating view: " << viewDefinition.toJson();
-        Result res = ::restoreView(httpClient, options, viewDefinition.slice());
-        if (res.fail()) {
-          return res;
-        }
-      }
-    }
-    
+
     // Step 3: run the actual import
     for (VPackBuilder const& b : collections) {
       VPackSlice const collection = b.slice();
@@ -697,6 +685,18 @@ arangodb::Result processInputDirectory(
       }
     }
 
+    if (options.importStructure && !views.empty()) {
+      LOG_TOPIC(INFO, Logger::RESTORE) << "# Creating views...";
+      // Step 2: recreate all views
+      for (VPackBuilder const& viewDefinition : views) {
+        LOG_TOPIC(DEBUG, Logger::RESTORE) << "# Creating view: " << viewDefinition.toJson();
+        Result res = ::restoreView(httpClient, options, viewDefinition.slice());
+        if (res.fail()) {
+          return res;
+        }
+      }
+    }
+
     // wait for all jobs to finish, then check for errors
     if (options.progress) {
       LOG_TOPIC(INFO, Logger::RESTORE) << "# Dispatched " << stats.totalCollections << " job(s) to " << options.threadCount << " worker(s)";
@@ -708,7 +708,7 @@ arangodb::Result processInputDirectory(
           // done
           break;
         }
-        
+
         double now = TRI_microtime();
         if (now - start >= 5.0) {
           // returns #queued jobs, #workers total, #workers busy
@@ -721,7 +721,7 @@ arangodb::Result processInputDirectory(
               << ", queued jobs: " << std::get<0>(queueStats) << ", workers: " << std::get<1>(queueStats);
           start = now;
         }
-       
+
         // don't sleep for too long, as we want to quickly terminate
         // when the gets empty
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
@@ -735,7 +735,7 @@ arangodb::Result processInputDirectory(
     if (firstError.fail()) {
       return firstError;
     }
-    
+
   } catch (std::exception const& ex) {
     return {TRI_ERROR_INTERNAL,
             std::string(
@@ -771,10 +771,10 @@ arangodb::Result processJob(arangodb::httpclient::SimpleHttpClient& httpClient,
       return result;
     }
   }
-    
+
   ++jobData.stats.restoredCollections;
- 
-  if (jobData.options.progress) {         
+
+  if (jobData.options.progress) {
     VPackSlice const parameters = jobData.collection.get("parameters");
     std::string const cname = arangodb::basics::VelocyPackHelper::getStringValue(
         parameters, "name", "");
@@ -1036,7 +1036,7 @@ void RestoreFeature::start() {
 
   // set up threads and workers
   _clientTaskQueue.spawnWorkers(_clientManager, _options.threadCount);
-      
+
   if (_options.progress) {
     LOG_TOPIC(INFO, Logger::RESTORE) << "Using " << _options.threadCount << " worker thread(s)";
   }

--- a/tests/IResearch/IResearchView-test.cpp
+++ b/tests/IResearch/IResearchView-test.cpp
@@ -336,8 +336,19 @@ SECTION("test_defaults") {
     REQUIRE((false == !logicalView));
     std::set<TRI_voc_cid_t> cids;
     logicalView->visitCollections([&cids](TRI_voc_cid_t cid)->bool { cids.emplace(cid); return true; });
-    CHECK((0 == cids.size()));
-    CHECK((true == logicalCollection->getIndexes().empty()));
+    CHECK((1 == cids.size()));
+    CHECK((false == logicalCollection->getIndexes().empty()));
+
+    arangodb::velocypack::Builder builder;
+
+    builder.openObject();
+    logicalView->toVelocyPack(builder, true, false);
+    builder.close();
+
+    auto slice = builder.slice();
+    auto tmpSlice = slice.get("links");
+    CHECK((true == tmpSlice.isObject() && 1 == tmpSlice.length()));
+    CHECK((true == tmpSlice.hasKey("testCollection")));
   }
 
   // view definition with links

--- a/tests/js/common/shell/shell-view-arangosearch-link-noncluster.js
+++ b/tests/js/common/shell/shell-view-arangosearch-link-noncluster.js
@@ -76,7 +76,7 @@ function IResearchLinkSuite () {
       var meta = { links: { 'testCollection' : { includeAllFields: true } } };
       var view = db._createView("badView", "arangosearch", meta);
       var links = view.properties().links;
-      assertEqual(links['testCollection'], undefined);
+      assertNotEqual(links['testCollection'], undefined);
       view.drop();
     },
 
@@ -98,11 +98,7 @@ function IResearchLinkSuite () {
       assertEqual(links['testCollection'], undefined);
 
       view.drop();
-      try {
-        view = db._view('testView');
-      } catch (err) {
-        assertEqual(ERRORS.ERROR_VIEW_NOT_FOUND.code, err.errorNum);
-      }
+      assertNull(db._view('testView'));
     }
 
   };

--- a/tests/js/common/shell/shell-view-arangosearch-noncluster.js
+++ b/tests/js/common/shell/shell-view-arangosearch-noncluster.js
@@ -180,16 +180,8 @@ function ViewSuite () {
       assertEqual(propD.consolidationIntervalMsec, 3);
       abc.drop();
       def.drop();
-      try {
-        abc = db._view("abc");
-      } catch (err) {
-        assertEqual(ERRORS.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, err.errorNum);
-      }
-      try {
-        def = db._view("def");
-      } catch (err) {
-        assertEqual(ERRORS.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, err.errorNum);
-      }
+      assertNull(db._view("abc"));
+      assertNull(db._view("def"));
     },
 
     ////////////////////////////////////////////////////////////////////////////

--- a/tests/js/server/dump/dump-mmfiles-cluster.js
+++ b/tests/js/server/dump/dump-mmfiles-cluster.js
@@ -60,7 +60,7 @@ function dumpTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test the empty collection
 ////////////////////////////////////////////////////////////////////////////////
-    
+
     testEmpty : function () {
       var c = db._collection("UnitTestsDumpEmpty");
       var p = c.properties();
@@ -78,7 +78,7 @@ function dumpTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test the collection with many documents
 ////////////////////////////////////////////////////////////////////////////////
-    
+
     testMany : function () {
       var c = db._collection("UnitTestsDumpMany");
       var p = c.properties();
@@ -108,7 +108,7 @@ function dumpTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test the edges collection
 ////////////////////////////////////////////////////////////////////////////////
-    
+
     testEdges : function () {
       var c = db._collection("UnitTestsDumpEdges");
       var p = c.properties();
@@ -135,7 +135,7 @@ function dumpTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test the order of documents
 ////////////////////////////////////////////////////////////////////////////////
-    
+
     testOrder : function () {
       var c = db._collection("UnitTestsDumpOrder");
       var p = c.properties();
@@ -153,7 +153,7 @@ function dumpTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test document removal & update
 ////////////////////////////////////////////////////////////////////////////////
-    
+
     testRemoved : function () {
       var c = db._collection("UnitTestsDumpRemoved");
       var p = c.properties();
@@ -185,7 +185,7 @@ function dumpTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test indexes
 ////////////////////////////////////////////////////////////////////////////////
-    
+
     testIndexes : function () {
       var c = db._collection("UnitTestsDumpIndexes");
       var p = c.properties();
@@ -195,7 +195,7 @@ function dumpTestSuite () {
       assertFalse(p.isVolatile);
       assertEqual(32, p.indexBuckets);
 
-      assertEqual(9, c.getIndexes().length); 
+      assertEqual(9, c.getIndexes().length);
       assertEqual("primary", c.getIndexes()[0].type);
 
       assertEqual("hash", c.getIndexes()[1].type);
@@ -227,12 +227,12 @@ function dumpTestSuite () {
       assertFalse(c.getIndexes()[6].unique);
       assertTrue(c.getIndexes()[6].sparse);
       assertEqual([ "a_ss1", "a_ss2" ], c.getIndexes()[6].fields);
-      
+
       if (db._engine().name !== "rocksdb") {
         assertFalse(c.getIndexes()[7].unique);
         assertEqual("fulltext", c.getIndexes()[7].type);
         assertEqual([ "a_f" ], c.getIndexes()[7].fields);
-        
+
         assertEqual("geo", c.getIndexes()[8].type);
         assertEqual([ "a_la", "a_lo" ], c.getIndexes()[8].fields);
         assertFalse(c.getIndexes()[8].unique);
@@ -244,7 +244,7 @@ function dumpTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test truncate
 ////////////////////////////////////////////////////////////////////////////////
-    
+
     testTruncated : function () {
       var c = db._collection("UnitTestsDumpTruncated");
       var p = c.properties();
@@ -261,7 +261,7 @@ function dumpTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test shards
 ////////////////////////////////////////////////////////////////////////////////
-    
+
     testShards : function () {
       var c = db._collection("UnitTestsDumpShards");
       var p = c.properties();
@@ -274,7 +274,7 @@ function dumpTestSuite () {
       assertEqual(1, c.getIndexes().length); // just primary index
       assertEqual("primary", c.getIndexes()[0].type);
       assertEqual(1000, c.count());
-  
+
       for (var i = 0; i < 1000; ++i) {
         var doc = c.document(String(7 + (i * 42)));
 
@@ -287,7 +287,7 @@ function dumpTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test strings
 ////////////////////////////////////////////////////////////////////////////////
-    
+
     testStrings : function () {
       var c = db._collection("UnitTestsDumpStrings");
       var p = c.properties();
@@ -302,18 +302,18 @@ function dumpTestSuite () {
 
       var texts = [
         "big. Really big. He moment. Magrathea! - insisted Arthur, - I do you can sense no further because it doesn't fit properly. In my the denies faith, and the atmosphere beneath You are not cheap He was was his satchel. He throughout Magrathea. - He pushed a tore the ecstatic crowd. Trillian sat down the time, the existence is it? And he said, - What they don't want this airtight hatchway. - it's we you shooting people would represent their Poet Master Grunthos is in his mind.",
-        "Ultimo cadere chi sedete uso chiuso voluto ora. Scotendosi portartela meraviglia ore eguagliare incessante allegrezza per. Pensava maestro pungeva un le tornano ah perduta. Fianco bearmi storia soffio prende udi poteva una. Cammino fascino elisire orecchi pollici mio cui sai sul. Chi egli sino sei dita ben. Audace agonie groppa afa vai ultima dentro scossa sii. Alcuni mia blocco cerchi eterno andare pagine poi. Ed migliore di sommesso oh ai angoscia vorresti.", 
+        "Ultimo cadere chi sedete uso chiuso voluto ora. Scotendosi portartela meraviglia ore eguagliare incessante allegrezza per. Pensava maestro pungeva un le tornano ah perduta. Fianco bearmi storia soffio prende udi poteva una. Cammino fascino elisire orecchi pollici mio cui sai sul. Chi egli sino sei dita ben. Audace agonie groppa afa vai ultima dentro scossa sii. Alcuni mia blocco cerchi eterno andare pagine poi. Ed migliore di sommesso oh ai angoscia vorresti.",
         "Νέο βάθος όλα δομές της χάσει. Μέτωπο εγώ συνάμα τρόπος και ότι όσο εφόδιο κόσμου. Προτίμηση όλη διάφορους του όλο εύθραυστη συγγραφής. Στα άρα ένα μία οποία άλλων νόημα. Ένα αποβαίνει ρεαλισμού μελετητές θεόσταλτο την. Ποντιακών και rites κοριτσάκι παπούτσια παραμύθια πει κυρ.",
         "Mody laty mnie ludu pole rury Białopiotrowiczowi. Domy puer szczypię jemy pragnął zacność czytając ojca lasy Nowa wewnątrz klasztoru. Chce nóg mego wami. Zamku stał nogą imion ludzi ustaw Białopiotrowiczem. Kwiat Niesiołowskiemu nierostrzygniony Staje brał Nauka dachu dumę Zamku Kościuszkowskie zagon. Jakowaś zapytać dwie mój sama polu uszakach obyczaje Mój. Niesiołowski książkowéj zimny mały dotychczasowa Stryj przestraszone Stolnikównie wdał śmiertelnego. Stanisława charty kapeluszach mięty bratem każda brząknął rydwan.",
-        "Мелких против летают хижину тмится. Чудесам возьмет звездна Взжигай. . Податель сельские мучитель сверкает очищаясь пламенем. Увы имя меч Мое сия. Устранюсь воздушных Им от До мысленные потушатся Ко Ея терпеньем.", 
+        "Мелких против летают хижину тмится. Чудесам возьмет звездна Взжигай. . Податель сельские мучитель сверкает очищаясь пламенем. Увы имя меч Мое сия. Устранюсь воздушных Им от До мысленные потушатся Ко Ея терпеньем.",
         "dotyku. Výdech spalin bude položen záplavový detekční kabely 1x UPS Newave Conceptpower DPA 5x 40kVA bude ukončen v samostatné strojovně. Samotné servery mají pouze lokalita Ústí nad zdvojenou podlahou budou zakončené GateWayí HiroLink - Monitoring rozvaděče RTN na jednotlivých záplavových zón na soustrojí resp. technologie jsou označeny SA-MKx.y. Jejich výstupem je zajištěn přestupem dat z jejich provoz. Na dveřích vylepené výstražné tabulky. Kabeláž z okruhů zálohovaných obvodů v R.MON-I. Monitoring EZS, EPS, ... možno zajistit funkčností FireWallů na strukturovanou kabeláží vedenou v měrných jímkách zapuštěných v každém racku budou zakončeny v R.MON-NrNN. Monitoring motorgenerátorů: řídící systém bude zakončena v modulu",
         "ramien mu zrejme vôbec niekto je už presne čo mám tendenciu prispôsobiť dych jej páčil, čo chce. Hmm... Včera sa mi pozdava, len dočkali, ale keďže som na uz boli u jej nezavrela. Hlava jej to ve městě nepotká, hodně mi to tí vedci pri hre, keď je tu pre Designiu. Pokiaľ viete o odbornejšie texty. Prvým z tmavých uličiek, každý to niekedy, zrovnávať krok s obrovským batohom na okraj vane a temné úmysly, tak rozmýšľam, aký som si hromady mailov, čo chcem a neraz sa pokúšal o filmovém klubu v budúcnosti rozhodne uniesť mladú maliarku (Linda Rybová), ktorú so",
         " 復讐者」. 復讐者」. 伯母さん 復讐者」. 復讐者」. 復讐者」. 復讐者」. 第九章 第五章 第六章 第七章 第八章. 復讐者」 伯母さん. 復讐者」 伯母さん. 第十一章 第十九章 第十四章 第十八章 第十三章 第十五章. 復讐者」 . 第十四章 第十一章 第十二章 第十五章 第十七章 手配書. 第十四章 手配書 第十八章 第十七章 第十六章 第十三章. 第十一章 第十三章 第十八章 第十四章 手配書. 復讐者」."
       ];
 
-      texts.forEach(function (t, i) { 
+      texts.forEach(function (t, i) {
         var doc = c.document("text" + i);
-        
+
         assertEqual(t, doc.value);
       });
 
@@ -342,6 +342,12 @@ function dumpTestSuite () {
       assertTrue(props.links.UnitTestsDumpViewCollection.hasOwnProperty("includeAllFields"));
       assertTrue(props.links.UnitTestsDumpViewCollection.hasOwnProperty("fields"));
       assertTrue(props.links.UnitTestsDumpViewCollection.includeAllFields);
+
+      assertEqual(props.consolidationIntervalMsec, 0);
+      assertEqual(props.cleanupIntervalStep, 456);
+      assertEqual(props.consolidationPolicy.segmentThreshold, 456);
+      assertTrue(Math.abs(props.consolidationPolicy.threshold - 0.3) < 0.001);
+      assertEqual(props.consolidationPolicy.type, "bytes_accum");
 
       var res = db._query("FOR doc IN " + view.name() + " SEARCH doc.value >= 0 RETURN doc").toArray();
       assertEqual(5000, res.length);

--- a/tests/js/server/dump/dump-mmfiles.js
+++ b/tests/js/server/dump/dump-mmfiles.js
@@ -188,7 +188,7 @@ function dumpTestSuite () {
       assertFalse(p.isVolatile);
       assertEqual(32, p.indexBuckets);
 
-      assertEqual(9, c.getIndexes().length); 
+      assertEqual(9, c.getIndexes().length);
       assertEqual("primary", c.getIndexes()[0].type);
 
       assertEqual("hash", c.getIndexes()[1].type);
@@ -459,6 +459,12 @@ function dumpTestSuite () {
       assertTrue(props.links.UnitTestsDumpViewCollection.hasOwnProperty("includeAllFields"));
       assertTrue(props.links.UnitTestsDumpViewCollection.hasOwnProperty("fields"));
       assertTrue(props.links.UnitTestsDumpViewCollection.includeAllFields);
+
+      assertEqual(props.consolidationIntervalMsec, 0);
+      assertEqual(props.cleanupIntervalStep, 456);
+      assertEqual(props.consolidationPolicy.segmentThreshold, 456);
+      assertTrue(Math.abs(props.consolidationPolicy.threshold - 0.3) < 0.001);
+      assertEqual(props.consolidationPolicy.type, "bytes_accum");
 
       var res = db._query("FOR doc IN " + view.name() + " SEARCH doc.value >= 0 RETURN doc").toArray();
       assertEqual(5000, res.length);

--- a/tests/js/server/dump/dump-rocksdb-cluster.js
+++ b/tests/js/server/dump/dump-rocksdb-cluster.js
@@ -305,7 +305,7 @@ function dumpTestSuite () {
     ////////////////////////////////////////////////////////////////////////////////
     /// @brief test view restoring
     ////////////////////////////////////////////////////////////////////////////////
-    
+
     testView : function () {
       try {
         db._createView("check", "arangosearch", {});
@@ -326,6 +326,12 @@ function dumpTestSuite () {
       assertTrue(props.links.UnitTestsDumpViewCollection.hasOwnProperty("fields"));
       assertTrue(props.links.UnitTestsDumpViewCollection.includeAllFields);
 
+      assertEqual(props.consolidationIntervalMsec, 0);
+      assertEqual(props.cleanupIntervalStep, 456);
+      assertEqual(props.consolidationPolicy.segmentThreshold, 456);
+      assertTrue(Math.abs(props.consolidationPolicy.threshold - 0.3) < 0.001);
+      assertEqual(props.consolidationPolicy.type, "bytes_accum");
+
       var res = db._query("FOR doc IN " + view.name() + " SEARCH doc.value >= 0 RETURN doc").toArray();
       assertEqual(5000, res.length);
 
@@ -334,7 +340,7 @@ function dumpTestSuite () {
 
       res = db._query("FOR doc IN " + view.name() + " SEARCH doc.value >= 5000 RETURN doc").toArray();
       assertEqual(0, res.length);
-      
+
       res = db._query("FOR doc IN UnitTestsDumpView SEARCH PHRASE(doc.text, 'foxx jumps over', 'text_en')  RETURN doc").toArray();
       assertEqual(1, res.length);
     }

--- a/tests/js/server/dump/dump-rocksdb.js
+++ b/tests/js/server/dump/dump-rocksdb.js
@@ -391,7 +391,7 @@ function dumpTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test view restoring
 ////////////////////////////////////////////////////////////////////////////////
-    
+
     testView : function () {
       try {
         db._createView("check", "arangosearch", {});
@@ -411,6 +411,12 @@ function dumpTestSuite () {
       assertTrue(props.links.UnitTestsDumpViewCollection.hasOwnProperty("includeAllFields"));
       assertTrue(props.links.UnitTestsDumpViewCollection.hasOwnProperty("fields"));
       assertTrue(props.links.UnitTestsDumpViewCollection.includeAllFields);
+
+      assertEqual(props.consolidationIntervalMsec, 0);
+      assertEqual(props.cleanupIntervalStep, 456);
+      assertEqual(props.consolidationPolicy.segmentThreshold, 456);
+      assertTrue(Math.abs(props.consolidationPolicy.threshold - 0.3) < 0.001);
+      assertEqual(props.consolidationPolicy.type, "bytes_accum");
 
       var res = db._query("FOR doc IN " + view.name() + " SEARCH doc.value >= 0 RETURN doc").toArray();
       assertEqual(5000, res.length);

--- a/tests/js/server/dump/dump-setup-cluster.js
+++ b/tests/js/server/dump/dump-setup-cluster.js
@@ -154,7 +154,7 @@ function setupSatelliteCollections() {
   c.update("two", { value: 2, value2: 456 });
   c.update("one", { value: 1, value2: 789 });
   c.remove("four");
-  
+
   // we apply a series of updates & removals here
   c = db._create("UnitTestsDumpRemoved");
   l = [];
@@ -170,7 +170,7 @@ function setupSatelliteCollections() {
     l.push("test" + i);
   }
   c.remove(l);
-  
+
   // we create a lot of (meaningless) indexes here
   c = db._create("UnitTestsDumpIndexes", { indexBuckets: 32 });
   c.ensureUniqueConstraint("a_uc");
@@ -180,7 +180,7 @@ function setupSatelliteCollections() {
   c.ensureUniqueSkiplist("a_su");
   c.ensureHashIndex("a_hs1", "a_hs2", { sparse: true });
   c.ensureSkiplist("a_ss1", "a_ss2", { sparse: true });
- 
+
   c.ensureFulltextIndex("a_f");
   if (db._engine().name !== "rocksdb") {
     c.ensureGeoIndex("a_la", "a_lo");
@@ -202,21 +202,21 @@ function setupSatelliteCollections() {
     l.push({ _key : String(7 + (i*42)), value: i, more: { value: [ i, i ] } });
   }
   c.save(l);
-  
+
   // strings
   c = db._create("UnitTestsDumpStrings");
   var texts = [
     "big. Really big. He moment. Magrathea! - insisted Arthur, - I do you can sense no further because it doesn't fit properly. In my the denies faith, and the atmosphere beneath You are not cheap He was was his satchel. He throughout Magrathea. - He pushed a tore the ecstatic crowd. Trillian sat down the time, the existence is it? And he said, - What they don't want this airtight hatchway. - it's we you shooting people would represent their Poet Master Grunthos is in his mind.",
-    "Ultimo cadere chi sedete uso chiuso voluto ora. Scotendosi portartela meraviglia ore eguagliare incessante allegrezza per. Pensava maestro pungeva un le tornano ah perduta. Fianco bearmi storia soffio prende udi poteva una. Cammino fascino elisire orecchi pollici mio cui sai sul. Chi egli sino sei dita ben. Audace agonie groppa afa vai ultima dentro scossa sii. Alcuni mia blocco cerchi eterno andare pagine poi. Ed migliore di sommesso oh ai angoscia vorresti.", 
+    "Ultimo cadere chi sedete uso chiuso voluto ora. Scotendosi portartela meraviglia ore eguagliare incessante allegrezza per. Pensava maestro pungeva un le tornano ah perduta. Fianco bearmi storia soffio prende udi poteva una. Cammino fascino elisire orecchi pollici mio cui sai sul. Chi egli sino sei dita ben. Audace agonie groppa afa vai ultima dentro scossa sii. Alcuni mia blocco cerchi eterno andare pagine poi. Ed migliore di sommesso oh ai angoscia vorresti.",
     "Νέο βάθος όλα δομές της χάσει. Μέτωπο εγώ συνάμα τρόπος και ότι όσο εφόδιο κόσμου. Προτίμηση όλη διάφορους του όλο εύθραυστη συγγραφής. Στα άρα ένα μία οποία άλλων νόημα. Ένα αποβαίνει ρεαλισμού μελετητές θεόσταλτο την. Ποντιακών και rites κοριτσάκι παπούτσια παραμύθια πει κυρ.",
     "Mody laty mnie ludu pole rury Białopiotrowiczowi. Domy puer szczypię jemy pragnął zacność czytając ojca lasy Nowa wewnątrz klasztoru. Chce nóg mego wami. Zamku stał nogą imion ludzi ustaw Białopiotrowiczem. Kwiat Niesiołowskiemu nierostrzygniony Staje brał Nauka dachu dumę Zamku Kościuszkowskie zagon. Jakowaś zapytać dwie mój sama polu uszakach obyczaje Mój. Niesiołowski książkowéj zimny mały dotychczasowa Stryj przestraszone Stolnikównie wdał śmiertelnego. Stanisława charty kapeluszach mięty bratem każda brząknął rydwan.",
-    "Мелких против летают хижину тмится. Чудесам возьмет звездна Взжигай. . Податель сельские мучитель сверкает очищаясь пламенем. Увы имя меч Мое сия. Устранюсь воздушных Им от До мысленные потушатся Ко Ея терпеньем.", 
+    "Мелких против летают хижину тмится. Чудесам возьмет звездна Взжигай. . Податель сельские мучитель сверкает очищаясь пламенем. Увы имя меч Мое сия. Устранюсь воздушных Им от До мысленные потушатся Ко Ея терпеньем.",
     "dotyku. Výdech spalin bude položen záplavový detekční kabely 1x UPS Newave Conceptpower DPA 5x 40kVA bude ukončen v samostatné strojovně. Samotné servery mají pouze lokalita Ústí nad zdvojenou podlahou budou zakončené GateWayí HiroLink - Monitoring rozvaděče RTN na jednotlivých záplavových zón na soustrojí resp. technologie jsou označeny SA-MKx.y. Jejich výstupem je zajištěn přestupem dat z jejich provoz. Na dveřích vylepené výstražné tabulky. Kabeláž z okruhů zálohovaných obvodů v R.MON-I. Monitoring EZS, EPS, ... možno zajistit funkčností FireWallů na strukturovanou kabeláží vedenou v měrných jímkách zapuštěných v každém racku budou zakončeny v R.MON-NrNN. Monitoring motorgenerátorů: řídící systém bude zakončena v modulu",
     "ramien mu zrejme vôbec niekto je už presne čo mám tendenciu prispôsobiť dych jej páčil, čo chce. Hmm... Včera sa mi pozdava, len dočkali, ale keďže som na uz boli u jej nezavrela. Hlava jej to ve městě nepotká, hodně mi to tí vedci pri hre, keď je tu pre Designiu. Pokiaľ viete o odbornejšie texty. Prvým z tmavých uličiek, každý to niekedy, zrovnávať krok s obrovským batohom na okraj vane a temné úmysly, tak rozmýšľam, aký som si hromady mailov, čo chcem a neraz sa pokúšal o filmovém klubu v budúcnosti rozhodne uniesť mladú maliarku (Linda Rybová), ktorú so",
     " 復讐者」. 復讐者」. 伯母さん 復讐者」. 復讐者」. 復讐者」. 復讐者」. 第九章 第五章 第六章 第七章 第八章. 復讐者」 伯母さん. 復讐者」 伯母さん. 第十一章 第十九章 第十四章 第十八章 第十三章 第十五章. 復讐者」 . 第十四章 第十一章 第十二章 第十五章 第十七章 手配書. 第十四章 手配書 第十八章 第十七章 第十六章 第十三章. 第十一章 第十三章 第十八章 第十四章 手配書. 復讐者」."
   ];
 
-  texts.forEach(function (t, i) { 
+  texts.forEach(function (t, i) {
     c.save({ _key: "text" + i, value: t });
   });
 
@@ -225,14 +225,24 @@ function setupSatelliteCollections() {
     c = db._create("UnitTestsDumpViewCollection");
 
     let view = db._createView("UnitTestsDumpView", "arangosearch", {});
-    view.properties({ links: {
-      "UnitTestsDumpViewCollection": { 
-        includeAllFields: true,
-        fields: {
-          text: { analyzers: [ "text_en" ] }
+    view.properties({
+      // choose non default values to check if they are corretly dumped and imported
+      cleanupIntervalStep: 456,
+      consolidationPolicy: {
+        segmentThreshold: 456,
+        threshold: 0.3,
+        type: "bytes_accum" // undocumented?
+      },
+      consolidationIntervalMsec: 0,
+      links: {
+        "UnitTestsDumpViewCollection": {
+          includeAllFields: true,
+          fields: {
+            text: { analyzers: [ "text_en" ] }
+          }
         }
       }
-    } });
+    });
 
     for (i = 0; i < 5000; ++i) {
       c.save({ _key: "test" + i, value: i});

--- a/tests/js/server/dump/dump-setup.js
+++ b/tests/js/server/dump/dump-setup.js
@@ -79,7 +79,7 @@
   c.update("two", { value: 2, value2: 456 });
   c.update("one", { value: 1, value2: 789 });
   c.remove("four");
-  
+
   // we apply a series of updates & removals here
   c = db._create("UnitTestsDumpRemoved");
   for (i = 0; i < 10000; ++i) {
@@ -91,7 +91,7 @@
   for (i = 0; i < 10000; i += 10) {
     c.remove("test" + i);
   }
-  
+
   // we create a lot of (meaningless) indexes here
   c = db._create("UnitTestsDumpIndexes", { indexBuckets: 32 });
   c.ensureUniqueConstraint("a_uc");
@@ -113,61 +113,61 @@
   c.truncate();
 
   // custom key options
-  c = db._create("UnitTestsDumpKeygen", { 
-    keyOptions: { 
-      type: "autoincrement", 
-      allowUserKeys: false, 
-      offset: 7, 
-      increment: 42 
+  c = db._create("UnitTestsDumpKeygen", {
+    keyOptions: {
+      type: "autoincrement",
+      allowUserKeys: false,
+      offset: 7,
+      increment: 42
     }
   });
   for (i = 0; i < 1000; ++i) {
     c.save({ value: i, more: { value: [ i, i ] } });
   }
-  
+
   // custom key options
-  c = db._create("UnitTestsDumpKeygenPadded", { 
-    keyOptions: { 
-      type: "padded", 
+  c = db._create("UnitTestsDumpKeygenPadded", {
+    keyOptions: {
+      type: "padded",
       allowUserKeys: false
-    } 
+    }
   });
   for (i = 0; i < 1000; ++i) {
     c.save({ value: i, more: { value: [ i, i ] } });
   }
-  
+
   // custom key options
-  c = db._create("UnitTestsDumpKeygenUuid", { 
-    keyOptions: { 
-      type: "uuid", 
+  c = db._create("UnitTestsDumpKeygenUuid", {
+    keyOptions: {
+      type: "uuid",
       allowUserKeys: false
-    } 
+    }
   });
   for (i = 0; i < 1000; ++i) {
     c.save({ value: i });
   }
-  
+
   // strings
   c = db._create("UnitTestsDumpStrings");
   var texts = [
     "big. Really big. He moment. Magrathea! - insisted Arthur, - I do you can sense no further because it doesn't fit properly. In my the denies faith, and the atmosphere beneath You are not cheap He was was his satchel. He throughout Magrathea. - He pushed a tore the ecstatic crowd. Trillian sat down the time, the existence is it? And he said, - What they don't want this airtight hatchway. - it's we you shooting people would represent their Poet Master Grunthos is in his mind.",
-    "Ultimo cadere chi sedete uso chiuso voluto ora. Scotendosi portartela meraviglia ore eguagliare incessante allegrezza per. Pensava maestro pungeva un le tornano ah perduta. Fianco bearmi storia soffio prende udi poteva una. Cammino fascino elisire orecchi pollici mio cui sai sul. Chi egli sino sei dita ben. Audace agonie groppa afa vai ultima dentro scossa sii. Alcuni mia blocco cerchi eterno andare pagine poi. Ed migliore di sommesso oh ai angoscia vorresti.", 
+    "Ultimo cadere chi sedete uso chiuso voluto ora. Scotendosi portartela meraviglia ore eguagliare incessante allegrezza per. Pensava maestro pungeva un le tornano ah perduta. Fianco bearmi storia soffio prende udi poteva una. Cammino fascino elisire orecchi pollici mio cui sai sul. Chi egli sino sei dita ben. Audace agonie groppa afa vai ultima dentro scossa sii. Alcuni mia blocco cerchi eterno andare pagine poi. Ed migliore di sommesso oh ai angoscia vorresti.",
     "Νέο βάθος όλα δομές της χάσει. Μέτωπο εγώ συνάμα τρόπος και ότι όσο εφόδιο κόσμου. Προτίμηση όλη διάφορους του όλο εύθραυστη συγγραφής. Στα άρα ένα μία οποία άλλων νόημα. Ένα αποβαίνει ρεαλισμού μελετητές θεόσταλτο την. Ποντιακών και rites κοριτσάκι παπούτσια παραμύθια πει κυρ.",
     "Mody laty mnie ludu pole rury Białopiotrowiczowi. Domy puer szczypię jemy pragnął zacność czytając ojca lasy Nowa wewnątrz klasztoru. Chce nóg mego wami. Zamku stał nogą imion ludzi ustaw Białopiotrowiczem. Kwiat Niesiołowskiemu nierostrzygniony Staje brał Nauka dachu dumę Zamku Kościuszkowskie zagon. Jakowaś zapytać dwie mój sama polu uszakach obyczaje Mój. Niesiołowski książkowéj zimny mały dotychczasowa Stryj przestraszone Stolnikównie wdał śmiertelnego. Stanisława charty kapeluszach mięty bratem każda brząknął rydwan.",
-    "Мелких против летают хижину тмится. Чудесам возьмет звездна Взжигай. . Податель сельские мучитель сверкает очищаясь пламенем. Увы имя меч Мое сия. Устранюсь воздушных Им от До мысленные потушатся Ко Ея терпеньем.", 
+    "Мелких против летают хижину тмится. Чудесам возьмет звездна Взжигай. . Податель сельские мучитель сверкает очищаясь пламенем. Увы имя меч Мое сия. Устранюсь воздушных Им от До мысленные потушатся Ко Ея терпеньем.",
     "dotyku. Výdech spalin bude položen záplavový detekční kabely 1x UPS Newave Conceptpower DPA 5x 40kVA bude ukončen v samostatné strojovně. Samotné servery mají pouze lokalita Ústí nad zdvojenou podlahou budou zakončené GateWayí HiroLink - Monitoring rozvaděče RTN na jednotlivých záplavových zón na soustrojí resp. technologie jsou označeny SA-MKx.y. Jejich výstupem je zajištěn přestupem dat z jejich provoz. Na dveřích vylepené výstražné tabulky. Kabeláž z okruhů zálohovaných obvodů v R.MON-I. Monitoring EZS, EPS, ... možno zajistit funkčností FireWallů na strukturovanou kabeláží vedenou v měrných jímkách zapuštěných v každém racku budou zakončeny v R.MON-NrNN. Monitoring motorgenerátorů: řídící systém bude zakončena v modulu",
     "ramien mu zrejme vôbec niekto je už presne čo mám tendenciu prispôsobiť dych jej páčil, čo chce. Hmm... Včera sa mi pozdava, len dočkali, ale keďže som na uz boli u jej nezavrela. Hlava jej to ve městě nepotká, hodně mi to tí vedci pri hre, keď je tu pre Designiu. Pokiaľ viete o odbornejšie texty. Prvým z tmavých uličiek, každý to niekedy, zrovnávať krok s obrovským batohom na okraj vane a temné úmysly, tak rozmýšľam, aký som si hromady mailov, čo chcem a neraz sa pokúšal o filmovém klubu v budúcnosti rozhodne uniesť mladú maliarku (Linda Rybová), ktorú so",
     " 復讐者」. 復讐者」. 伯母さん 復讐者」. 復讐者」. 復讐者」. 復讐者」. 第九章 第五章 第六章 第七章 第八章. 復讐者」 伯母さん. 復讐者」 伯母さん. 第十一章 第十九章 第十四章 第十八章 第十三章 第十五章. 復讐者」 . 第十四章 第十一章 第十二章 第十五章 第十七章 手配書. 第十四章 手配書 第十八章 第十七章 第十六章 第十三章. 第十一章 第十三章 第十八章 第十四章 手配書. 復讐者」."
   ];
 
-  texts.forEach(function (t, i) { 
+  texts.forEach(function (t, i) {
     c.save({ _key: "text" + i, value: t });
   });
 
 
   c = db._create("UnitTestsDumpTransactionCommit");
   db._executeTransaction({
-    collections: { 
+    collections: {
       write: "UnitTestsDumpTransactionCommit"
     },
     action: function (params) {
@@ -177,15 +177,15 @@
       }
     }
   });
- 
-  
+
+
   c = db._create("UnitTestsDumpTransactionUpdate");
   for (i = 0; i < 1000; ++i) {
     c.save({ _key: "test" + i, value1: i, value2: "this is a test", value3: "test" + i });
   }
 
   db._executeTransaction({
-    collections: { 
+    collections: {
       write: "UnitTestsDumpTransactionUpdate"
     },
     action: function (params) {
@@ -195,13 +195,13 @@
       }
     }
   });
- 
-  
+
+
   c = db._create("UnitTestsDumpTransactionAbort");
   c.save({ _key: "foo" });
   try {
     db._executeTransaction({
-      collections: { 
+      collections: {
         write: "UnitTestsDumpTransactionAbort"
       },
       action: function (params) {
@@ -217,7 +217,7 @@
   }
   catch (err) {
   }
-  
+
   c = db._create("UnitTestsDumpPersistent");
   c.ensureIndex({ type: "persistent", fields: ["value"], unique: true });
 
@@ -230,14 +230,24 @@
     c = db._create("UnitTestsDumpViewCollection");
 
     let view = db._createView("UnitTestsDumpView", "arangosearch", {});
-    view.properties({ links: {
-      "UnitTestsDumpViewCollection": { 
-        includeAllFields: true,
-        fields: {
-          text: { analyzers: [ "text_en" ] }
+    view.properties({
+      // choose non default values to check if they are corretly dumped and imported
+      cleanupIntervalStep: 456,
+      consolidationPolicy: {
+        segmentThreshold: 456,
+        threshold: 0.3,
+        type: "bytes_accum" // undocumented?
+      },
+      consolidationIntervalMsec: 0,
+      links: {
+        "UnitTestsDumpViewCollection": {
+          includeAllFields: true,
+          fields: {
+            text: { analyzers: [ "text_en" ] }
+          }
         }
       }
-    } });
+    });
 
     for (i = 0; i < 5000; ++i) {
       c.save({ _key: "test" + i, value: i});


### PR DESCRIPTION
This PR changes the following things:

1. When creating views one can specify links. Those links are created on a "best effort" basis as usual in arangosearch.
2. `_api/replication/inventory` and `_api/repliation/clusterInventory` no longer show indexes of type `arangosearch` per collection, but export view with more details and a complete list of links as expected by `POST /_api/view` and `PUT|PATCH /_api/view/<name>/properties`.
3. `arangorestore` creates and imports collections first, then restores views. (Previously views have been created before collections. This was done because adding links via indexes required existing views)

***Note:*** This is the devel branch. As soon as it is approved, I will cherry-pick the changes to 3.4.

TODO:

- [ ] Clean up
- [ ] Changelog entry
- [ ] Update documentation
- [ ] Cherry-pick into 3.4 branche