### PR TITLE
do not use a Builder object in every Aggregator

### DIFF
--- a/arangod/Aql/Aggregator.cpp
+++ b/arangod/Aql/Aggregator.cpp
@@ -106,11 +106,9 @@ void AggregatorLength::reduce(AqlValue const&) {
 }
 
 AqlValue AggregatorLength::stealValue() {
-  builder.clear();
-  builder.add(VPackValue(count));
-  AqlValue temp(builder.slice());
+  uint64_t value = count;
   reset();
-  return temp;
+  return AqlValue(AqlValueHintUInt(value));
 }
 
 AggregatorMin::~AggregatorMin() { value.destroy(); }
@@ -189,11 +187,9 @@ AqlValue AggregatorSum::stealValue() {
     return AqlValue(AqlValueHintNull());
   }
 
-  builder.clear();
-  builder.add(VPackValue(sum));
-  AqlValue temp(builder.slice());
+  double v = sum;
   reset();
-  return temp;
+  return AqlValue(AqlValueHintDouble(v));
 }
 
 void AggregatorAverage::reset() {
@@ -230,11 +226,9 @@ AqlValue AggregatorAverage::stealValue() {
 
   TRI_ASSERT(count > 0);
   
-  builder.clear();
-  builder.add(VPackValue(sum / count));
-  AqlValue temp(builder.slice());
+  double v = sum / count;
   reset();
-  return temp;
+  return AqlValue(AqlValueHintDouble(v));
 }
 
 void AggregatorVarianceBase::reset() {
@@ -273,19 +267,18 @@ AqlValue AggregatorVariance::stealValue() {
   }
 
   TRI_ASSERT(count > 0);
-  
-  builder.clear();
+ 
+  double v; 
   if (!population) {
     TRI_ASSERT(count > 1);
-    builder.add(VPackValue(sum / (count - 1)));
+    v = sum / (count - 1);
   }
   else {
-    builder.add(VPackValue(sum / count));
+    v = sum / count;
   }
   
-  AqlValue temp(builder.slice());
   reset();
-  return temp;
+  return AqlValue(AqlValueHintDouble(v));
 }
 
 AqlValue AggregatorStddev::stealValue() {
@@ -295,17 +288,16 @@ AqlValue AggregatorStddev::stealValue() {
   }
 
   TRI_ASSERT(count > 0);
-    
-  builder.clear();
+  
+  double v;  
   if (!population) {
     TRI_ASSERT(count > 1);
-    builder.add(VPackValue(sqrt(sum / (count - 1))));
+    v = sqrt(sum / (count - 1));
   }
   else {
-    builder.add(VPackValue(sqrt(sum / count)));
+    v = sqrt(sum / count);
   }
 
-  AqlValue temp(builder.slice());
   reset();
-  return temp;
+  return AqlValue(AqlValueHintDouble(v));
 }

--- a/arangod/Aql/Aggregator.h
+++ b/arangod/Aql/Aggregator.h
@@ -58,8 +58,6 @@ struct Aggregator {
   static bool requiresInput(std::string const&);
 
   transaction::Methods* trx;
-
-  arangodb::velocypack::Builder builder;
 };
 
 struct AggregatorLength final : public Aggregator {
@@ -90,6 +88,7 @@ struct AggregatorMin final : public Aggregator {
   AqlValue stealValue() override final;
 
   AqlValue value;
+  arangodb::velocypack::Builder builder;
 };
 
 struct AggregatorMax final : public Aggregator {
@@ -105,6 +104,7 @@ struct AggregatorMax final : public Aggregator {
   AqlValue stealValue() override final;
 
   AqlValue value;
+  arangodb::velocypack::Builder builder;
 };
 
 struct AggregatorSum final : public Aggregator {

--- a/arangod/Aql/CollectBlock.cpp
+++ b/arangod/Aql/CollectBlock.cpp
@@ -753,7 +753,6 @@ int HashedCollectBlock::getOrSkipSome(size_t atLeast, size_t atMost,
           }
         }
 
-        // note: aggregateValues may be a nullptr!
         allGroups.emplace(group, aggregateValues.get());
         aggregateValues.release();
       } else {


### PR DESCRIPTION
  Builder objects are only needed in few of them
  This saves allocates for the "hash" COLLECT variant when
  there are many distinct groups
