### PR TITLE
catch 501 (not implemented) in the query editor (ui)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,13 @@
+v3.3.17 (XXXX-XX-XX)
+--------------------
+
+* the query editor within the web ui is now catching http 501 responses
+  propertly.
+
+
 v3.3.16 (2018-09-17)
 --------------------
+
 
 * fixed issue #6495 (Document not found when removing records)
 

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js
@@ -2153,7 +2153,7 @@
               if (error.code === 409) {
                 return;
               }
-              if (error.code !== 400 && error.code !== 404 && error.code !== 500 && error.code !== 403) {
+              if (error.code !== 400 && error.code !== 404 && error.code !== 500 && error.code !== 403 && error.code !== 501) {
                 arangoHelper.arangoNotification('Query', 'Successfully aborted.');
               }
             }


### PR DESCRIPTION
catch 501 (not implemented) in the query editor (ui)
