### PR TITLE
Bug fix/optimizations 210918

### DIFF
--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1423,6 +1423,7 @@ Result RestReplicationHandler::processRestoreDataBatch(
     options.ignoreRevs = true;
     options.isRestore = true;
     options.waitForSync = false;
+    options.overwrite = true;
     opRes = trx.insert(collectionName, requestSlice, options);
     if (opRes.fail()) {
       return opRes.result;

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -842,8 +842,7 @@ bool RocksDBCollection::readDocumentWithCallback(
     transaction::Methods* trx, LocalDocumentId const& documentId,
     IndexIterator::DocumentCallback const& cb) const {
   if (documentId.isSet()) {
-    auto res = lookupDocumentVPack(documentId, trx, cb, true);
-    return res.ok();
+    return lookupDocumentVPack(documentId, trx, cb, true).ok();
   }
   return false;
 }
@@ -869,6 +868,32 @@ Result RocksDBCollection::insert(arangodb::transaction::Methods* trx,
   }
 
   VPackSlice newSlice = builder->slice();
+ 
+  if (options.overwrite) { 
+    // special optimization for the overwrite case:
+    // in case the operation is a RepSert, we will first check if the specified
+    // primary key exists. we can abort this low-level insert early, before any
+    // modification to the data has been done. this saves us from creating a RocksDB
+    // transaction SavePoint.
+    // if we don't do the check here, we will always create a SavePoint first and
+    // insert the new document. when then inserting the key for the primary index and
+    // then detecting a unique constraint violation, the transaction would be rolled
+    // back to the SavePoint state, which will rebuild *all* data in the WriteBatch
+    // up to the SavePoint. this can be super-expensive for bigger transactions.
+    // to keep things simple, we are not checking for unique constraint violations
+    // in secondary indexes here, but defer it to the regular index insertion check
+    VPackSlice keySlice = newSlice.get(StaticStrings::KeyString);
+    if (keySlice.isString()) {
+      LocalDocumentId const documentId = primaryIndex()->lookupKey(trx, StringRef(keySlice));
+      if (documentId.isSet()) {
+        if (options.indexOperationMode == Index::OperationMode::internal) {
+          // need to return the key of the conflict document
+          return Result(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED, keySlice.copyString());
+        }
+        return Result(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED);
+      }
+    }
+  }
 
   auto state = RocksDBTransactionState::toState(trx);
   auto mthds = RocksDBTransactionState::toMethods(trx);

--- a/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
+++ b/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
@@ -500,8 +500,9 @@ Result syncChunkRocksDB(
                                       resultTick, false, revisionId);
         if (res.fail()) {
           if (res.is(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED) &&
-              res.errorMessage() > keySlice.copyString()) { // WTF ?!!
+              res.errorMessage() > keySlice.copyString()) { 
             // remove conflict and retry
+            // errorMessage() is this case contains the conflicting key
             auto inner = removeConflict(res.errorMessage());
             if (inner.fail()) {
               return res;
@@ -525,8 +526,9 @@ Result syncChunkRocksDB(
                                        false, prevRev, previous);
         if (res.fail()) {
           if (res.is(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED) &&
-              res.errorMessage() > keySlice.copyString()) { // WTF!?
+              res.errorMessage() > keySlice.copyString()) { 
             // remove conflict and retry
+            // errorMessage() is this case contains the conflicting key
             auto inner = removeConflict(res.errorMessage());
             if (inner.fail()) {
               return res;

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
@@ -290,11 +290,6 @@ Result RocksDBPrimaryIndex::insertInternal(transaction::Methods* trx,
   RocksDBKeyLeaser key(trx);
   key->constructPrimaryIndexValue(_objectId, StringRef(keySlice));
 
-
-
-  TRI_voc_rid_t revision = transaction::helpers::extractRevFromDocument(slice);
-  auto value = RocksDBValue::PrimaryIndexValue(documentId, revision);
-
   if (mthd->Exists(_cf, key.ref())) {
     std::string existingId(slice.get(StaticStrings::KeyString).copyString());
 
@@ -307,6 +302,9 @@ Result RocksDBPrimaryIndex::insertInternal(transaction::Methods* trx,
   }
 
   blackListKey(key->string().data(), static_cast<uint32_t>(key->string().size()));
+  
+  TRI_voc_rid_t revision = transaction::helpers::extractRevFromDocument(slice);
+  auto value = RocksDBValue::PrimaryIndexValue(documentId, revision);
 
   Result status = mthd->Put(_cf, key.ref(), value.string(), rocksutils::index);
   return IndexResult(status.errorNumber(), this);

--- a/arangod/VocBase/ManagedDocumentResult.cpp
+++ b/arangod/VocBase/ManagedDocumentResult.cpp
@@ -44,12 +44,6 @@ void ManagedDocumentResult::setManaged(uint8_t const* vpack, LocalDocumentId con
   _managed = true;
 }
 
-void ManagedDocumentResult::setManagedAfterStringUsage(LocalDocumentId const& documentId) {
-  _vpack = nullptr;
-  _localDocumentId = documentId;
-  _managed = true;
-}
-
 void ManagedDocumentResult::addToBuilder(velocypack::Builder& builder, bool allowExternals) const {
   uint8_t const* vpack;
   if (_managed) {

--- a/arangod/VocBase/ManagedDocumentResult.h
+++ b/arangod/VocBase/ManagedDocumentResult.h
@@ -64,8 +64,14 @@ class ManagedDocumentResult {
 
   void setManaged(uint8_t const* vpack, LocalDocumentId const& documentId);
   
-  void setManagedAfterStringUsage(LocalDocumentId const& documentId);
-
+  std::string* setManaged(LocalDocumentId const& documentId) {
+    _string.clear();
+    _vpack = nullptr;
+    _localDocumentId = documentId;
+    _managed = true;
+    return &_string; 
+  }
+  
   inline LocalDocumentId localDocumentId() const { return _localDocumentId; }
   
   void clear() noexcept {
@@ -73,10 +79,6 @@ class ManagedDocumentResult {
     _vpack = nullptr;
     _localDocumentId.clear();
     _managed = false;
-  }
-  
-  std::string* string() {
-    return &_string; 
   }
   
   inline uint8_t const* vpack() const {

--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -721,7 +721,7 @@ arangodb::Result processInputDirectory(
           auto queueStats = jobQueue.statistics();
           // periodically report current status, but do not spam user
           LOG_TOPIC(INFO, Logger::RESTORE)
-              << "# Worker progress summary: restored " << stats.restoredCollections
+              << "# Current restore progress: restored " << stats.restoredCollections
               << " of " << stats.totalCollections << " collection(s), read " << stats.totalRead << " byte(s) from datafiles, "
               << "sent " << stats.totalBatches << " data batch(es) of " << stats.totalSent << " byte(s) total size"
               << ", queued jobs: " << std::get<0>(queueStats) << ", workers: " << std::get<1>(queueStats);
@@ -1043,9 +1043,7 @@ void RestoreFeature::start() {
   // set up threads and workers
   _clientTaskQueue.spawnWorkers(_clientManager, _options.threadCount);
 
-  if (_options.progress) {
-    LOG_TOPIC(INFO, Logger::RESTORE) << "Using " << _options.threadCount << " worker thread(s)";
-  }
+  LOG_TOPIC(DEBUG, Logger::RESTORE) << "Using " << _options.threadCount << " worker thread(s)";
 
   // run the actual restore
   try {


### PR DESCRIPTION
* improve arangorestore progress reporting a bit
* rename MMFiles-specific test accordingly (test is not supposed to work with RocksDB at all)
* speed up restoring of documents with primary key conflicts (fixes issue #6379)
* changed some instances of `!res.ok()` to `res.fail()`
* reuse existing `ManagedDocumentResult` instances, simplify its API a bit