### PR TITLE
Properly display JSON properties of user defined foxx services configuration within the web UI

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/applicationDetailView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/applicationDetailView.js
@@ -459,7 +459,7 @@
         } else if (obj.type === 'json') {
           methodName = 'createBlobEntry';
           defaultValue = obj.default === undefined ? '' : JSON.stringify(obj.default);
-          currentValue = obj.current === undefined ? '' : obj.current;
+          currentValue = obj.current === undefined ? '' : JSON.stringify(obj.current);
           checks.push({
             rule: function (v) {
               return v && JSON.parse(v);


### PR DESCRIPTION
Fix  the web UI to properly display JSON properties of foxx service configuration, without this, it was displaying `[Object object]` instead of the proper JSON "stringified" configuration (see the screenshot below).

![arangodb-webui-foxx-config-bug](http://www.oualid.net/temp/arangodb-webui-foxx-config-bug.png)

This PR does not include the grunt generated files, I guess they are generated automatically by your CD/CI before packaging a new version.