### PR TITLE
Increase Plan/Version if follower is removed in MoveShard.

### DIFF
--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -591,6 +591,9 @@ JOB_STATUS MoveShard::pendingLeader() {
               pre.add(plan);
             }
           });
+        if (!_remainsFollower) {
+          addIncreasePlanVersion(trx);
+        }
         addPreconditionCollectionStillThere(pre, _database, _collection);
         addRemoveJobFromSomewhere(trx, "Pending", _jobId);
         Builder job;


### PR DESCRIPTION
This was forgotten when we added the `remainsFollower` flag.