### PR TITLE
Documentation/sync 2018 10 02 (rename arangodbjs to arangojs)

### DIFF
--- a/Documentation/Books/Drivers/JS/GettingStarted/README.md
+++ b/Documentation/Books/Drivers/JS/GettingStarted/README.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # ArangoDB JavaScript Driver - Getting Started
 
 ## Compatibility

--- a/Documentation/Books/Drivers/JS/README.md
+++ b/Documentation/Books/Drivers/JS/README.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # ArangoDB JavaScript Driver
 
 The official ArangoDB low-level JavaScript client.

--- a/Documentation/Books/Drivers/JS/Reference/Collection/BulkImport.md
+++ b/Documentation/Books/Drivers/JS/Reference/Collection/BulkImport.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Bulk importing documents
 
 This function implements the

--- a/Documentation/Books/Drivers/JS/Reference/Collection/CollectionManipulation.md
+++ b/Documentation/Books/Drivers/JS/Reference/Collection/CollectionManipulation.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Manipulating the collection
 
 These functions implement the

--- a/Documentation/Books/Drivers/JS/Reference/Collection/DocumentCollection.md
+++ b/Documentation/Books/Drivers/JS/Reference/Collection/DocumentCollection.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # DocumentCollection API
 
 The _DocumentCollection API_ extends the

--- a/Documentation/Books/Drivers/JS/Reference/Collection/DocumentManipulation.md
+++ b/Documentation/Books/Drivers/JS/Reference/Collection/DocumentManipulation.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Manipulating documents
 
 These functions implement the

--- a/Documentation/Books/Drivers/JS/Reference/Collection/EdgeCollection.md
+++ b/Documentation/Books/Drivers/JS/Reference/Collection/EdgeCollection.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # EdgeCollection API
 
 The _EdgeCollection API_ extends the

--- a/Documentation/Books/Drivers/JS/Reference/Collection/Indexes.md
+++ b/Documentation/Books/Drivers/JS/Reference/Collection/Indexes.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Manipulating indexes
 
 These functions implement the

--- a/Documentation/Books/Drivers/JS/Reference/Collection/README.md
+++ b/Documentation/Books/Drivers/JS/Reference/Collection/README.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Collection API
 
 These functions implement the

--- a/Documentation/Books/Drivers/JS/Reference/Collection/SimpleQueries.md
+++ b/Documentation/Books/Drivers/JS/Reference/Collection/SimpleQueries.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Simple queries
 
 These functions implement the

--- a/Documentation/Books/Drivers/JS/Reference/Cursor.md
+++ b/Documentation/Books/Drivers/JS/Reference/Cursor.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Cursor API
 
 _Cursor_ instances provide an abstraction over the HTTP API's limitations.

--- a/Documentation/Books/Drivers/JS/Reference/Database/AqlUserFunctions.md
+++ b/Documentation/Books/Drivers/JS/Reference/Database/AqlUserFunctions.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Managing AQL user functions
 
 These functions implement the

--- a/Documentation/Books/Drivers/JS/Reference/Database/CollectionAccess.md
+++ b/Documentation/Books/Drivers/JS/Reference/Database/CollectionAccess.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Accessing collections
 
 These functions implement the

--- a/Documentation/Books/Drivers/JS/Reference/Database/DatabaseManipulation.md
+++ b/Documentation/Books/Drivers/JS/Reference/Database/DatabaseManipulation.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Manipulating databases
 
 These functions implement the

--- a/Documentation/Books/Drivers/JS/Reference/Database/FoxxServices.md
+++ b/Documentation/Books/Drivers/JS/Reference/Database/FoxxServices.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Managing Foxx services
 
 ## database.listServices

--- a/Documentation/Books/Drivers/JS/Reference/Database/GraphAccess.md
+++ b/Documentation/Books/Drivers/JS/Reference/Database/GraphAccess.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Accessing graphs
 
 These functions implement the

--- a/Documentation/Books/Drivers/JS/Reference/Database/HttpRoutes.md
+++ b/Documentation/Books/Drivers/JS/Reference/Database/HttpRoutes.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Arbitrary HTTP routes
 
 ## database.route

--- a/Documentation/Books/Drivers/JS/Reference/Database/Queries.md
+++ b/Documentation/Books/Drivers/JS/Reference/Database/Queries.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Queries
 
 This function implements the

--- a/Documentation/Books/Drivers/JS/Reference/Database/README.md
+++ b/Documentation/Books/Drivers/JS/Reference/Database/README.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Database API
 
 ## new Database

--- a/Documentation/Books/Drivers/JS/Reference/Database/Transactions.md
+++ b/Documentation/Books/Drivers/JS/Reference/Database/Transactions.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Transactions
 
 This function implements the

--- a/Documentation/Books/Drivers/JS/Reference/Database/ViewAccess.md
+++ b/Documentation/Books/Drivers/JS/Reference/Database/ViewAccess.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Accessing views
 
 These functions implement the

--- a/Documentation/Books/Drivers/JS/Reference/Graph/EdgeCollection.md
+++ b/Documentation/Books/Drivers/JS/Reference/Graph/EdgeCollection.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # GraphEdgeCollection API
 
 The _GraphEdgeCollection API_ extends the

--- a/Documentation/Books/Drivers/JS/Reference/Graph/Edges.md
+++ b/Documentation/Books/Drivers/JS/Reference/Graph/Edges.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Manipulating edges
 
 ## graph.edgeCollection

--- a/Documentation/Books/Drivers/JS/Reference/Graph/README.md
+++ b/Documentation/Books/Drivers/JS/Reference/Graph/README.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Graph API
 
 These functions implement the

--- a/Documentation/Books/Drivers/JS/Reference/Graph/VertexCollection.md
+++ b/Documentation/Books/Drivers/JS/Reference/Graph/VertexCollection.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # GraphVertexCollection API
 
 The _GraphVertexCollection API_ extends the

--- a/Documentation/Books/Drivers/JS/Reference/Graph/Vertices.md
+++ b/Documentation/Books/Drivers/JS/Reference/Graph/Vertices.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Manipulating vertices
 
 ## graph.vertexCollection

--- a/Documentation/Books/Drivers/JS/Reference/README.md
+++ b/Documentation/Books/Drivers/JS/Reference/README.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # ArangoDB JavaScript Driver - Reference
 
 - [Database](Database/README.md)

--- a/Documentation/Books/Drivers/JS/Reference/Route.md
+++ b/Documentation/Books/Drivers/JS/Reference/Route.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # Route API
 
 _Route_ instances provide access for arbitrary HTTP requests. This allows easy

--- a/Documentation/Books/Drivers/JS/Reference/ViewManipulation.md
+++ b/Documentation/Books/Drivers/JS/Reference/ViewManipulation.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, it's from https://@github.com/arangodb/arangodbjs.git / docs/Drivers/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb/arangojs.git / docs/Drivers/ -->
 # View API
 
 These functions implement the

--- a/Documentation/Books/Drivers/SUMMARY.md
+++ b/Documentation/Books/Drivers/SUMMARY.md
@@ -35,7 +35,7 @@
       * [Edges Manipulation](Java/Reference/Graph/Edges.md)
     * [Route](Java/Reference/Route.md)
     * [Serialization](Java/Reference/Serialization.md)
-<!-- SYNC: https://@github.com/arangodb/arangodbjs.git;arangodbjs;docs/Drivers;;/ -->
+<!-- SYNC: https://@github.com/arangodb/arangojs.git;arangojs;docs/Drivers;;/ -->
 * [ArangoJS - JavaScript Driver](JS/README.md)
   * [Getting Started](JS/GettingStarted/README.md)
   * [Reference](JS/Reference/README.md)

--- a/Documentation/Books/Manual/Upgrading/Starter/README.md
+++ b/Documentation/Books/Manual/Upgrading/Starter/README.md
@@ -1,4 +1,4 @@
-<!-- don't edit here, its from https://@github.com/arangodb-helper/arangodb.git / docs/Manual/ -->
+<!-- don't edit here, it's from https://@github.com/arangodb-helper/arangodb.git / docs/Manual/ -->
 # Upgrading _Starter_ Deployments
 
 Starting from versions 3.2.15 and 3.3.8, the ArangoDB [_Starter_](../../Programs/Starter/README.md)

--- a/VERSIONS
+++ b/VERSIONS
@@ -9,7 +9,7 @@ GCHANGE_FREQ "daily"
 GPRIORITY "0.3"
 BROWSEABLE_VERSIONS "'devel', '3.4', '3.3', '3.2', '3.1', '3.0', '2.8'"
 EXTERNAL_DOC_arangodb-java-driver=master
-EXTERNAL_DOC_arangodbjs=master
+EXTERNAL_DOC_arangojs=master
 EXTERNAL_DOC_arangosync=master
 EXTERNAL_DOC_arangodb=master
 EXTERNAL_DOC_spring-data=master


### PR DESCRIPTION
No content changes taken over from external repos (see https://github.com/arangodb/arangodb/pull/6476/commits/7a1c20c0c7e17fe6c9a66d36c67800c9b12aa11b), only renamed arangodbjs to arangojs.