### PR TITLE
increase the timeouts for replication, in order to increase the chanc…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+v3.3.18 (XXXX-XX-XX)
+--------------------
+
+* increased default timeouts in replication
+
+  this decreases the chances of followers not getting in sync with leaders because
+  of replication operations timing out
+
+
 v3.3.17 (2018-10-04)
 --------------------
 

--- a/arangod/MMFiles/MMFilesRestReplicationHandler.cpp
+++ b/arangod/MMFiles/MMFilesRestReplicationHandler.cpp
@@ -683,7 +683,7 @@ void MMFilesRestReplicationHandler::handleCommandCreateKeys() {
   
   // initialize a container with the keys
   auto keys =
-      std::make_unique<MMFilesCollectionKeys>(_vocbase, std::move(guard), id, 300.0);
+      std::make_unique<MMFilesCollectionKeys>(_vocbase, std::move(guard), id, 900.0);
 
   std::string const idString(std::to_string(keys->id()));
 

--- a/arangod/Replication/InitialSyncer.h
+++ b/arangod/Replication/InitialSyncer.h
@@ -61,7 +61,7 @@ struct IncrementalSyncStats {
 
 class InitialSyncer : public Syncer {
  public:
-  static constexpr double defaultBatchTimeout = 1800.0; // half an hour
+  static constexpr double defaultBatchTimeout = 7200.0; // two hours
 
  public:
   explicit InitialSyncer(ReplicationApplierConfiguration const&);

--- a/arangod/Replication/InitialSyncer.h
+++ b/arangod/Replication/InitialSyncer.h
@@ -61,7 +61,7 @@ struct IncrementalSyncStats {
 
 class InitialSyncer : public Syncer {
  public:
-  static constexpr double defaultBatchTimeout = 300.0;
+  static constexpr double defaultBatchTimeout = 1800.0; // half an hour
 
  public:
   explicit InitialSyncer(ReplicationApplierConfiguration const&);

--- a/arangod/Replication/Syncer.cpp
+++ b/arangod/Replication/Syncer.cpp
@@ -66,7 +66,7 @@ Syncer::Syncer(ReplicationApplierConfiguration const& configuration)
       _connection(nullptr),
       _client(nullptr),
       _barrierId(0),
-      _barrierTtl(600),
+      _barrierTtl(900),
       _barrierUpdateTime(0),
       _isChildSyncer(false) {
   


### PR DESCRIPTION
…es of followers getting in sync with leaders

This is a quick fix that increases the likelihood of getting in sync and should not do too much damage should a replication client abort hard without signing off from the leader.
Please note that for the RocksDB engine only the /_api/replication/batch timeout is relevant, as the /_api/replication/barrier API is simply a stub there.
The issue will be fixed differently for 3.4 and devel.