### PR TITLE
[3.4] Disable New View/Service in UI

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/templates/applicationsView.ejs
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/templates/applicationsView.ejs
@@ -47,7 +47,7 @@
     <div id="installedList" class="tileList pure-u">
       <div class="tile pure-u-1-1 pure-u-sm-1-2 pure-u-md-1-3 pure-u-lg-1-4 pure-u-xl-1-5">
         <div class="fullBorderBox">
-          <a href="#" id="addApp" class="add"><span class="pull-left add-Icon"><i class="fa fa-plus-circle"></i>
+          <a id="addApp" class="add"><span class="pull-left add-Icon"><i class="fa fa-plus-circle"></i>
 </span> Add Service</a>
         </div>
       </div>

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/templates/viewsView.ejs
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/templates/viewsView.ejs
@@ -29,12 +29,12 @@
       </ul>
     </div>
   </div>
-  
+
   <div class="contentDiv" id="">
     <div id="viewsThumbnailsIn" class="tileList pure-u">
       <div class="tile pure-u-1-1 pure-u-sm-1-2 pure-u-md-1-3 pure-u-lg-1-4 pure-u-xl-1-6">
         <div class="fullBorderBox">
-          <a href="#" id="createView" class="add">
+          <a id="createView" class="add">
             <span id="newView" class="pull-left add-Icon"><i class="fa fa-plus-circle"></i></span>
             Add View
           </a>

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/applicationsView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/applicationsView.js
@@ -108,8 +108,10 @@
     },
 
     createInstallModal: function (event) {
-      event.preventDefault();
-      window.App.navigate('services/install', {trigger: true});
+      if (!this.readOnly) {
+        event.preventDefault();
+        window.App.navigate('services/install', {trigger: true});
+      }
     },
 
     setReadOnly: function () {

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js
@@ -2002,7 +2002,7 @@
               if (position === data.result.length) {
                 if (markers.length > 0) {
                   try {
-                    var show = new L.featureGroup(markers);
+                    var show = new L.FeatureGroup(markers);
                     self.maps[counter].fitBounds(show.getBounds());
                   } catch (ignore) {
                   }

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/viewsView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/viewsView.js
@@ -6,6 +6,7 @@
 
   window.ViewsView = Backbone.View.extend({
     el: '#content',
+    readOnly: false,
 
     template: templateEngine.createTemplate('viewsView.ejs'),
 
@@ -97,6 +98,13 @@
       var strLength = searchInput.val().length;
       searchInput.focus();
       searchInput[0].setSelectionRange(strLength, strLength);
+
+      arangoHelper.checkDatabasePermissions(this.setReadOnly.bind(this));
+    },
+
+    setReadOnly: function () {
+      this.readOnly = true;
+      $('#createView').parent().parent().addClass('disabled');
     },
 
     setSearchString: function (string) {
@@ -159,8 +167,10 @@
     },
 
     createView: function (e) {
-      e.preventDefault();
-      this.createViewModal();
+      if (!this.readOnly) {
+        e.preventDefault();
+        this.createViewModal();
+      }
     },
 
     createViewModal: function () {


### PR DESCRIPTION
In readonly mode disable the `New View/Service` Buttons. Fixed a stupid warning about lower case constructors.

Fixes arangodb/release-3.4#64