### PR TITLE
Stop AgencyRequests on Shutdown

### DIFF
--- a/lib/SimpleHttpClient/GeneralClientConnection.cpp
+++ b/lib/SimpleHttpClient/GeneralClientConnection.cpp
@@ -158,10 +158,9 @@ bool GeneralClientConnection::connect() {
 void GeneralClientConnection::disconnect() {
   if (isConnected()) {
     disconnectSocket();
+    _numConnectRetries = 0;
+    _isConnected = false;
   }
-
-  _isConnected = false;
-  _numConnectRetries = 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/SimpleHttpClient/SimpleHttpClient.cpp
+++ b/lib/SimpleHttpClient/SimpleHttpClient.cpp
@@ -179,7 +179,7 @@ SimpleHttpResult* SimpleHttpClient::retryRequest(
           << "" << _params._retryMessage << " - no retries left";
       break;
     }
-    
+
     if (application_features::ApplicationServer::isStopping()) {
       // abort this client, will also lead to exiting this loop next
       setAborted(true);
@@ -402,6 +402,11 @@ SimpleHttpResult* SimpleHttpClient::doRequest(
 
       default:
         break;
+    }
+
+    if ( application_features::ApplicationServer::isStopping()) {
+      setErrorMessage("Command locally aborted");
+      return nullptr;
     }
 
     remainingTime = endTime - TRI_microtime();


### PR DESCRIPTION
Reset retry counter only when previously connected in order to not disable the retry check.

Abort the `doRequest` loop when on shutdown.

