### PR TITLE
[3.4] Stop AgencyRequests on Shutdown

### DIFF
--- a/lib/SimpleHttpClient/GeneralClientConnection.cpp
+++ b/lib/SimpleHttpClient/GeneralClientConnection.cpp
@@ -157,10 +157,9 @@ bool GeneralClientConnection::connect() {
 void GeneralClientConnection::disconnect() {
   if (isConnected()) {
     disconnectSocket();
+    _numConnectRetries = 0;
+    _isConnected = false;
   }
-
-  _isConnected = false;
-  _numConnectRetries = 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Reset retry counter only when previously connected in order to not disable the retry check.

Abort the `doRequest` loop when in shutdown.
