### PR TITLE
Feature/log timestamp on test start

### DIFF
--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -805,10 +805,10 @@ function shutdownArangod (arangod, options, forceTerminate) {
     } else {
       const requestOptions = makeAuthorizationHeaders(options);
       requestOptions.method = 'DELETE';
-      print(arangod.url + '/_admin/shutdown');
+      print(Date() + ' ' + arangod.url + '/_admin/shutdown');
       const reply = download(arangod.url + '/_admin/shutdown', '', requestOptions);
       if (options.extremeVerbosity) {
-        print('Shutdown response: ' + JSON.stringify(reply));
+        print(Date() + ' Shutdown response: ' + JSON.stringify(reply));
       }
     }
   } else {

--- a/js/client/modules/@arangodb/test-utils.js
+++ b/js/client/modules/@arangodb/test-utils.js
@@ -292,7 +292,7 @@ function performTests (options, testList, testname, runFn, serverOptions, startS
     print(RED + 'No testcase matched the filter.' + RESET);
   }
 
-  print('Shutting down...');
+  print(Date() + ' Shutting down...');
   if (startStopHandlers !== undefined && startStopHandlers.hasOwnProperty('preStop')) {
     customInstanceInfos['preStop'] = startStopHandlers.preStop(options,
                                                                serverOptions,

--- a/js/common/modules/jsunity.js
+++ b/js/common/modules/jsunity.js
@@ -47,7 +47,7 @@ function setTestFilter(filter) {
 }
 
 jsUnity.results.begin = function (total, suiteName) {
-  print('Running ' + (suiteName || 'unnamed test suite'));
+  print(Date() + ' Running ' + (suiteName || 'unnamed test suite'));
   print(' ' + total + ' test(s) found');
   print();
   RESULTS = {};

--- a/js/common/modules/jsunity/jsunity.js
+++ b/js/common/modules/jsunity/jsunity.js
@@ -367,7 +367,7 @@ var jsUnity = exports.jsUnity = (function () {
       jsUnity.tap.write("# " + suiteName);
       jsUnity.tap.write("1.." + total);
 
-      jsUnity.log.info("Running "
+      jsUnity.log.info(Date() + " Running "
                        + (suiteName || "unnamed test suite"));
       jsUnity.log.info(plural(total, "test") + " found");
     },


### PR DESCRIPTION
Since tests may run longer, this PR will also print a timestamp in front of `Running...` 
```
Mon Oct 08 2018 09:50:39 GMT+0000 (UTC) runThere: Trying tests/js/common/shell/shell-index.js ...
Running indexSuite
 8 test(s) found
....
 8 test(s) passed
 0 test(s) failed
 5064 millisecond(s) elapsed

Running getIndexesSuite
 26 test(s) found
```
like this:
`Mon Oct 08 2018 14:15:46 GMT+0200 (CEST) Running getIndexesSuite`
so one can better identify the actual time where errors happened.