### PR TITLE
Bugfix devel: dynamic management of libcurl's open connections

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 devel
 -----
+* dynamically manage libcurl's number of open connections to increase performance
+  by reducing the number of socket close and then reopen cycles
 
 * disable in-memory cache for edge and traversal data on agency nodes, as it
   is not needed there
@@ -20,7 +22,7 @@ v3.4.0-rc.3 (XXXX-XX-XX)
 
 * include forward-ported diagnostic options for debugging LDAP connections
 
-* fix internal issue #3065: fix variable replacements by the AQL query 
+* fix internal issue #3065: fix variable replacements by the AQL query
   optimizer in arangosearch view search conditions
 
   The consequence of the missing replacements was that some queries using view
@@ -56,10 +58,10 @@ v3.4.0-rc.2 (XXXX-XX-XX)
 
 * upgraded arangodb starter version to 0.13.3
 
-* fixed issue #6611: Properly display JSON properties of user defined foxx services 
-  configuration within the web UI 
+* fixed issue #6611: Properly display JSON properties of user defined foxx services
+  configuration within the web UI
 
-* improved shards display in web UI: included arrows to better visualize that 
+* improved shards display in web UI: included arrows to better visualize that
   collection name sections can be expanded and collapsed
 
 * added nesting support for `aql` template strings
@@ -68,7 +70,7 @@ v3.4.0-rc.2 (XXXX-XX-XX)
 
 * added `aql.join` function
 
-* fixed issue #6583: Agency node segfaults if sent an authenticated HTTP 
+* fixed issue #6583: Agency node segfaults if sent an authenticated HTTP
   request is sent to its port
 
 * fixed issue #6601: Context cancelled (never ending query)
@@ -84,27 +86,27 @@ v3.4.0-rc.2 (XXXX-XX-XX)
 
 * added startup parameter `--cluster.advertised-endpoints`
 
-* AQL query optimizer now makes better choices regarding indexes to use in a 
+* AQL query optimizer now makes better choices regarding indexes to use in a
   query when there are multiple competing indexes and some of them are prefixes
   of others
-  
+
   In this case, the optimizer could have preferred indexes that covered less
   attributes, but it should rather pick the indexes that covered more attributes.
-  
+
   For example, if there was an index on ["a"] and another index on ["a", "b"], then
   previously the optimizer may have picked the index on just ["a"] instead the
   index on ["a", "b"] for queries that used all index attributes but did range
   queries on them (e.g. `FILTER doc.a == @val1 && doc.b >= @val2`).
 
-* Added compression for the AQL intermediate results transfer in the cluster, 
+* Added compression for the AQL intermediate results transfer in the cluster,
   leading to less data being transferred between coordinator and database servers
   in many cases
 
 * forward-ported a bugfix from RocksDB (https://github.com/facebook/rocksdb/pull/4386)
-  that fixes range deletions (used internally in ArangoDB when dropping or truncating 
+  that fixes range deletions (used internally in ArangoDB when dropping or truncating
   collections)
 
-  The non-working range deletes could have triggered errors such as 
+  The non-working range deletes could have triggered errors such as
   `deletion check in index drop failed - not all documents in the index have been deleted.`
   when dropping or truncating collections
 
@@ -132,9 +134,9 @@ v3.4.0-rc.2 (XXXX-XX-XX)
 
 * fixed some TLS errors that occurred when combining HTTPS/TLS transport with the
   VelocyStream protocol (VST)
-  
+
   That combination could have led to spurious errors such as "TLS padding error"
-  or "Tag mismatch" and connections being closed 
+  or "Tag mismatch" and connections being closed
 
 * make synchronous replication detect more error cases when followers cannot
   apply the changes from the leader
@@ -143,7 +145,7 @@ v3.4.0-rc.2 (XXXX-XX-XX)
 
 * fixed issue #6495: Document not found when removing records
 
-* fixed undefined behavior is cluster plan-loading procedure that may have 
+* fixed undefined behavior is cluster plan-loading procedure that may have
   unintentionally modified a shared structure
 
 * reduce overhead of function initialization in AQL COLLECT aggregate functions,
@@ -725,18 +727,18 @@ v3.3.15 (XXXX-XX-XX)
 
 * added startup option `--query.optimizer-max-plans value`
 
-  This option allows limiting the number of query execution plans created by the 
+  This option allows limiting the number of query execution plans created by the
   AQL optimizer for any incoming queries. The default value is `128`.
 
-  By adjusting this value it can be controlled how many different query execution 
-  plans the AQL query optimizer will generate at most for any given AQL query. 
-  Normally the AQL query optimizer will generate a single execution plan per AQL query, 
+  By adjusting this value it can be controlled how many different query execution
+  plans the AQL query optimizer will generate at most for any given AQL query.
+  Normally the AQL query optimizer will generate a single execution plan per AQL query,
   but there are some cases in which it creates multiple competing plans. More plans
   can lead to better optimized queries, however, plan creation has its costs. The
-  more plans are created and shipped through the optimization pipeline, the more time 
+  more plans are created and shipped through the optimization pipeline, the more time
   will be spent in the optimizer.
 
-  Lowering this option's value will make the optimizer stop creating additional plans 
+  Lowering this option's value will make the optimizer stop creating additional plans
   when it has already created enough plans.
 
   Note that this setting controls the default maximum number of plans to create. The

--- a/arangod/Aql/SharedQueryState.cpp
+++ b/arangod/Aql/SharedQueryState.cpp
@@ -69,6 +69,8 @@ bool SharedQueryState::executeContinueCallback() const {
     // We are shutting down
     return false;
   }
-  scheduler->post(_continueCallback, false);
+  // do NOT use scheduler->post(), can have high latency that
+  //  then backs up libcurl callbacks to other objects
+  scheduler->queue(RequestPriority::HIGH, _continueCallback);
   return true;
 }

--- a/arangod/Cluster/ClusterComm.cpp
+++ b/arangod/Cluster/ClusterComm.cpp
@@ -417,7 +417,7 @@ OperationID ClusterComm::asyncRequest(
   bool doLogConnectionErrors = logConnectionErrors();
 
   if (callback) {
-    callbacks._onError = [callback, result, doLogConnectionErrors, this](int errorCode, std::unique_ptr<GeneralResponse> response) {
+    callbacks._onError = [callback, result, doLogConnectionErrors, this, connectTimeout](int errorCode, std::unique_ptr<GeneralResponse> response) {
       {
         CONDITION_LOCKER(locker, somethingReceived);
         responses.erase(result->operationID);
@@ -426,12 +426,12 @@ OperationID ClusterComm::asyncRequest(
       if (result->status == CL_COMM_BACKEND_UNAVAILABLE) {
         if (doLogConnectionErrors) {
           LOG_TOPIC(ERR, Logger::CLUSTER)
-            << "cannot create connection to server '" << result->serverID
-            << "' at endpoint '" << result->endpoint << "'";
+            << "cannot create connection to server (1) '" << result->serverID
+            << "' at endpoint '" << result->endpoint << "'" << connectTimeout;
         } else {
           LOG_TOPIC(INFO, Logger::CLUSTER)
-            << "cannot create connection to server '" << result->serverID
-            << "' at endpoint '" << result->endpoint << "'";
+            << "cannot create connection to server (2)'" << result->serverID
+            << "' at endpoint '" << result->endpoint << "'" << connectTimeout;
         }
       }
       /*bool ret =*/ ((*callback.get())(result.get()));
@@ -448,18 +448,18 @@ OperationID ClusterComm::asyncRequest(
       //TRI_ASSERT(ret == true);
     };
   } else {
-    callbacks._onError = [result, doLogConnectionErrors, this](int errorCode, std::unique_ptr<GeneralResponse> response) {
+    callbacks._onError = [result, doLogConnectionErrors, this, connectTimeout](int errorCode, std::unique_ptr<GeneralResponse> response) {
       CONDITION_LOCKER(locker, somethingReceived);
       result->fromError(errorCode, std::move(response));
       if (result->status == CL_COMM_BACKEND_UNAVAILABLE) {
         if (doLogConnectionErrors) {
           LOG_TOPIC(ERR, Logger::CLUSTER)
-            << "cannot create connection to server '" << result->serverID
-            << "' at endpoint '" << result->endpoint << "'";
+            << "cannot create connection to server (3)'" << result->serverID
+            << "' at endpoint '" << result->endpoint << "'" << connectTimeout;
         } else {
           LOG_TOPIC(INFO, Logger::CLUSTER)
-            << "cannot create connection to server '" << result->serverID
-            << "' at endpoint '" << result->endpoint << "'";
+            << "cannot create connection to server (4)'" << result->serverID
+            << "' at endpoint '" << result->endpoint << "'" << connectTimeout;
         }
       }
       somethingReceived.broadcast();
@@ -534,11 +534,11 @@ std::unique_ptr<ClusterCommResult> ClusterComm::syncRequest(
       if (result->status == CL_COMM_BACKEND_UNAVAILABLE) {
         if (doLogConnectionErrors) {
           LOG_TOPIC(ERR, Logger::CLUSTER)
-            << "cannot create connection to server '" << result->serverID
+            << "cannot create connection to server (5)'" << result->serverID
             << "' at endpoint '" << result->endpoint << "'";
         } else {
           LOG_TOPIC(INFO, Logger::CLUSTER)
-            << "cannot create connection to server '" << result->serverID
+            << "cannot create connection to server (6)'" << result->serverID
             << "' at endpoint '" << result->endpoint << "'";
         }
       }

--- a/lib/SimpleHttpClient/Communicator.cpp
+++ b/lib/SimpleHttpClient/Communicator.cpp
@@ -137,10 +137,14 @@ Communicator::Communicator() : _curl(nullptr), _mc(CURLM_OK), _enabled(true) {
   curl_global_init(CURL_GLOBAL_ALL);
   _curl = curl_multi_init();
 
+  /// start with unlimited, non-closing connection count.  ConnectionCount object will
+  ///  moderate once requests start
+  curl_multi_setopt(_curl, CURLMOPT_MAXCONNECTS, 0);  //default is -1, want unlimited
+
   if (_curl == nullptr) {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_OUT_OF_MEMORY, "unable to initialize curl");
   }
-  
+
 #ifdef _WIN32
   int err = dumb_socketpair(_socks, 0);
   if (err != 0) {
@@ -174,7 +178,7 @@ Ticket Communicator::addRequest(Destination&& destination,
                                 Callbacks callbacks, Options options) {
   uint64_t id = NEXT_TICKET_ID.fetch_add(1, std::memory_order_seq_cst);
   TRI_ASSERT(request != nullptr);
-  
+
   {
     MUTEX_LOCKER(guard, _newRequestsLock);
     _newRequests.emplace_back(
@@ -199,11 +203,17 @@ Ticket Communicator::addRequest(Destination&& destination,
 
 int Communicator::work_once() {
   std::vector<NewRequest> newRequests;
+  int connections;
 
   {
     MUTEX_LOCKER(guard, _newRequestsLock);
     newRequests.swap(_newRequests);
   }
+
+  /// make sure there is enough room for every new request to get
+  ///  an independent connection
+  connections = connectionCount.newMaxConnections(newRequests.size());
+  curl_multi_setopt(_curl, CURLMOPT_MAXCONNECTS, connections);
 
   for (auto& newRequest : newRequests) {
     createRequestInProgress(std::move(newRequest));
@@ -216,6 +226,11 @@ int Communicator::work_once() {
         "Invalid curl multi result while performing! Result was " +
         std::to_string(_mc));
   }
+
+  /// use stillRunning as high water mark for open connections needed.
+  ///  curl/lib/multi.c uses stillRunning * 4 to estimate connections retained,
+  ///  starting with *2
+  connectionCount.updateMaxConnections(stillRunning * 2);
 
   // handle all messages received
   CURLMsg* msg = nullptr;
@@ -271,7 +286,7 @@ void Communicator::createRequestInProgress(NewRequest&& newRequest) {
       newRequest._options, std::move(newRequest._request));
 
   auto handleInProgress = std::make_unique<CurlHandle>(rip);
-  
+
   auto request = (HttpRequest*)handleInProgress->_rip->_request.get();
 
   CURL* handle = handleInProgress->_handle;
@@ -316,7 +331,7 @@ void Communicator::createRequestInProgress(NewRequest&& newRequest) {
     thisHeader.append(": ", 2);
     thisHeader.append(header.second);
     requestHeaders = curl_slist_append(requestHeaders, thisHeader.c_str());
-    
+
     thisHeader.clear();
   }
 
@@ -337,7 +352,7 @@ void Communicator::createRequestInProgress(NewRequest&& newRequest) {
   curl_easy_setopt(handle, CURLOPT_HEADERDATA, handleInProgress->_rip.get());
   curl_easy_setopt(handle, CURLOPT_ERRORBUFFER,
                    handleInProgress->_rip.get()->_errorBuffer);
-  
+
   // mop: XXX :S CURLE 51 and 60...
   curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0L);
   curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 0L);
@@ -358,7 +373,7 @@ void Communicator::createRequestInProgress(NewRequest&& newRequest) {
   // the requests immediately fail
   // if not this hack can go away
   if (connectTimeout <= 0) {
-    connectTimeout = 1;
+    connectTimeout = 5;
   }
 
   curl_easy_setopt(
@@ -416,7 +431,6 @@ void Communicator::createRequestInProgress(NewRequest&& newRequest) {
 }
 
 void Communicator::handleResult(CURL* handle, CURLcode rc) {
-  // remove request in progress
   double connectTime = 0.0;
   curl_multi_remove_handle(_curl, handle);
 
@@ -429,11 +443,11 @@ void Communicator::handleResult(CURL* handle, CURLcode rc) {
   if (rip->_options._curlRcFn) {
     (*rip->_options._curlRcFn)(rc);
   }
-  
+
   LOG_TOPIC(TRACE, Logger::COMMUNICATION)
       << ::buildPrefix(rip->_ticketId) << "curl rc is : " << rc << " after "
       << Logger::FIXED(TRI_microtime() - rip->_startTime) << " s";
-  
+
   if (CURLE_OPERATION_TIMEDOUT == rc) {
     curl_easy_getinfo(handle, CURLINFO_CONNECT_TIME, &connectTime);
     LOG_TOPIC(TRACE, Logger::COMMUNICATION)
@@ -668,8 +682,8 @@ std::vector<RequestInProgress const*> Communicator::requestsInProgress() {
   }
   return vec;
 }
-      
-// needs _handlesLock! 
+
+// needs _handlesLock!
 void Communicator::abortRequestInternal(Ticket ticketId) {
   _handlesLock.assertLockedByCurrentThread();
 
@@ -678,8 +692,8 @@ void Communicator::abortRequestInternal(Ticket ticketId) {
     return;
   }
 
-  LOG_TOPIC(WARN, Logger::REQUESTS) 
-      << ::buildPrefix(handle->second->_rip->_ticketId) 
+  LOG_TOPIC(WARN, Logger::REQUESTS)
+      << ::buildPrefix(handle->second->_rip->_ticketId)
       << "aborting request to " << handle->second->_rip->_destination.url();
   handle->second->_rip->_aborted = true;
 }
@@ -698,7 +712,7 @@ void Communicator::callErrorFn(Ticket const& ticketId, Destination const& destin
   auto total = TRI_microtime() - start;
 
   if (total > CALLBACK_WARN_TIME) {
-    LOG_TOPIC(WARN, Logger::COMMUNICATION) 
+    LOG_TOPIC(WARN, Logger::COMMUNICATION)
         << ::buildPrefix(ticketId) << "error callback for request to " << destination.url() << " took " << total << "s";
   }
 }
@@ -714,7 +728,7 @@ void Communicator::callSuccessFn(Ticket const& ticketId, Destination const& dest
   auto total = TRI_microtime() - start;
 
   if (total > CALLBACK_WARN_TIME) {
-    LOG_TOPIC(WARN, Logger::COMMUNICATION) 
+    LOG_TOPIC(WARN, Logger::COMMUNICATION)
         << ::buildPrefix(ticketId) << "success callback for request to " << destination.url() << " took " << (total) << "s";
   }
 }

--- a/tests/SimpleHttpClient/CommunicatorTest.cpp
+++ b/tests/SimpleHttpClient/CommunicatorTest.cpp
@@ -42,7 +42,7 @@ TEST_CASE("requests are properly aborted", "[communicator]" ) {
   Communicator communicator;
 
   bool callbacksCalled = false;
-  
+
   communicator::Callbacks callbacks([&callbacksCalled](std::unique_ptr<GeneralResponse> response) {
     WARN("RESULT: " << GeneralResponse::responseString(response->responseCode()));
     REQUIRE(false); // it should be aborted?!
@@ -81,7 +81,7 @@ TEST_CASE("requests will call the progress callback", "[communicator]") {
   opt._curlRcFn = std::make_shared<std::function<void(CURLcode)>>([&curlRc](CURLcode rc) {
     curlRc = rc;
   });
-  
+
   auto destination = Destination("http://www.example.com");
   communicator.addRequest(std::move(destination), std::move(request), callbacks, opt);
   communicator.work_once();
@@ -90,4 +90,79 @@ TEST_CASE("requests will call the progress callback", "[communicator]") {
     std::this_thread::sleep_for(std::chrono::microseconds(1));
   }
   REQUIRE(curlRc == CURLE_ABORTED_BY_CALLBACK); // curlRcFn was called
+}
+
+
+class ConnectionCountTester : public ConnectionCount {
+public:
+
+  /// this allows testing of time bucket rotation
+    void moveCursor() {advanceCursor();}
+
+
+};// class ConnectionCountTester
+
+
+TEST_CASE("ConnectionCount:", "[communicator]" ) {
+  ConnectionCountTester tester;
+  int loop;
+
+  // loop through the coverage minutes, see if minimum is consistent
+  for (loop=0; loop<=ConnectionCount::eMinutesTracked; ++loop) {
+    REQUIRE(ConnectionCount::eMinOpenConnects == tester.newMaxConnections(0));
+    tester.moveCursor();
+  } // for
+
+  // parameter to newMaxConnections() does NOT change history
+  REQUIRE(ConnectionCount::eMinOpenConnects+10 == tester.newMaxConnections(10));
+  REQUIRE(ConnectionCount::eMinOpenConnects == tester.newMaxConnections(0));
+  REQUIRE(ConnectionCount::eMinOpenConnects+2 == tester.newMaxConnections(2));
+  REQUIRE(ConnectionCount::eMinOpenConnects == tester.newMaxConnections(0));
+
+  // parameter to updateMaxConnections() DOES change history if bigger
+  tester.updateMaxConnections(10);
+  REQUIRE(10 == tester.newMaxConnections(0));
+  REQUIRE(16 == tester.newMaxConnections(6));
+  tester.updateMaxConnections(7);
+  REQUIRE(10 == tester.newMaxConnections(0));
+  REQUIRE(13 == tester.newMaxConnections(3));
+
+  // simulate time passing and returned max changing ... assumes 6 min history
+  //  "10" is still in current minute
+  REQUIRE(6 == ConnectionCount::eMinutesTracked);
+  REQUIRE(10 == tester.newMaxConnections(0));
+  tester.updateMaxConnections(17);
+  REQUIRE(17 == tester.newMaxConnections(0));
+  tester.moveCursor();
+  tester.updateMaxConnections(13);
+  REQUIRE(17 == tester.newMaxConnections(0));
+  tester.moveCursor();
+  tester.updateMaxConnections(11);
+  REQUIRE(17 == tester.newMaxConnections(0));
+  tester.moveCursor();
+  tester.updateMaxConnections(9);
+  REQUIRE(17 == tester.newMaxConnections(0));
+  tester.moveCursor();
+  tester.updateMaxConnections(10);
+  REQUIRE(17 == tester.newMaxConnections(0));
+  tester.moveCursor();
+  tester.updateMaxConnections(7);
+  REQUIRE(17 == tester.newMaxConnections(0));
+  tester.moveCursor();
+
+  // minute history now full ... should see sliding window now
+  REQUIRE(13 == tester.newMaxConnections(0));
+  tester.moveCursor();
+  REQUIRE(11 == tester.newMaxConnections(0));
+  tester.moveCursor();
+  REQUIRE(10 == tester.newMaxConnections(0)); // 9 smaller than 10
+  tester.moveCursor();
+  REQUIRE(10 == tester.newMaxConnections(0));
+  tester.moveCursor();
+  REQUIRE(7 == tester.newMaxConnections(0));
+  tester.moveCursor();
+  REQUIRE(ConnectionCount::eMinOpenConnects == tester.newMaxConnections(0));
+  tester.moveCursor();
+  REQUIRE(ConnectionCount::eMinOpenConnects == tester.newMaxConnections(0));
+
 }


### PR DESCRIPTION
java-benchmark using 64 threads on aql_get test encountered errors. The errors coincided with the coordinator experiencing time outs when connecting to database servers. Detail study of logs, code, and packet traces revealed that libcurl was aggressive closing connections, sometimes 20 at a time, during periods when those connections were going to be needed real soon.

Disabling all connection closing worked immediately. However, that leaves the possibility having a large number of open connections that never get used again after a burst.

The fix is to dynamical adjust libcurl's maximum connection size. The code watches for the maximum number of actions over 5 minutes (using one minute intervals). The code then sets the maximum connection number based upon history and new requests.