### PR TITLE
Bug fix 3.4/enable ldap tests

### DIFF
--- a/UnitTests/OskarTestSuitesBlackList
+++ b/UnitTests/OskarTestSuitesBlackList
@@ -1,5 +1,0 @@
-ldap
-ldaprole
-ldaprolesimple
-ldapsearch
-ldapsearchsimple

--- a/js/client/modules/@arangodb/testsuites/ldap.js
+++ b/js/client/modules/@arangodb/testsuites/ldap.js
@@ -125,10 +125,10 @@ function parseOptions (options) {
 
   _.each(toReturn, function (opt) {
     if (options.ldapHost) {
-      opt.ldapHost = options.ldapHost;
+      opt.conf['ldap.server'] = options.ldapHost;
     }
     if (options.ldapPort) {
-      opt.ldapPort = options.ldapPort;
+      opt.conf['ldap.port'] = options.ldapPort;
     }
   });
   return toReturn;
@@ -232,8 +232,8 @@ function authenticationLdapRolesMode (options) {
 
 exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
-  // just a convenicen wrapper for the regular tests
-  testFns['ldap'] = [ 'ldaprole', 'ldaprole', 'ldapsearch', 'ldaprolesimple', 'ldapsearchsimple' ];
+  // just a convenience wrapper for the regular tests
+  testFns['ldap'] = [ 'ldaprole', 'ldapsearch', 'ldaprolesimple', 'ldapsearchsimple' ];
 
   testFns['ldaprole'] = authenticationLdapRolesMode;
   testFns['ldapsearch'] = authenticationLdapSearchMode;


### PR DESCRIPTION
Enable LDAP tests in Jenkins again.

removed ldap from blacklist.
Fixed logic error in testsuite to pipe through the Server and port.

jenkins:
http://jenkins01.arangodb.biz:8080/view/Nightlies/job/arangodb-3.4-linux-matrix-nightly/78/