### PR TITLE
Bugfix-3.4:  correct omissions from recent scheduler thread PR

### DIFF
--- a/arangod/Scheduler/Scheduler.cpp
+++ b/arangod/Scheduler/Scheduler.cpp
@@ -426,12 +426,12 @@ bool Scheduler::canPostDirectly(RequestPriority prio) const noexcept {
   switch (prio) {
     case RequestPriority::HIGH:
 //      return nrWorking + nrQueued <= _maxQueuedHighPrio;
-      return nrWorking + nrQueued <= _maxThreads;
+      return nrWorking + nrQueued < _maxThreads;
 
     case RequestPriority::LOW:
     case RequestPriority::V8:
 //      return nrWorking + nrQueued <= _maxQueuedLowPrio;
-      return nrWorking + nrQueued <= _maxThreads - _minThreads;
+      return nrWorking + nrQueued < _maxThreads - _minThreads;
   }
 
   return false;
@@ -737,10 +737,13 @@ bool Scheduler::threadShouldStop(double now) {
   // I reactivated the following at the last hour before 3.4.RC3 without
   // being able to consult with Matthew. If this breaks things, we find
   // out in due course. 12.10.2018 Max.
-
+#if 0
   // decrement nrRunning by one already in here while holding the lock
   decRunning();
   return true;
+#else
+  return false;
+#endif
 }
 
 void Scheduler::startNewThread() {

--- a/arangod/Scheduler/SchedulerFeature.h
+++ b/arangod/Scheduler/SchedulerFeature.h
@@ -53,7 +53,7 @@ class SchedulerFeature final : public application_features::ApplicationFeature {
   uint64_t queueSize() const { return _queueSize; }
 
  private:
-  uint64_t _nrMinimalThreads = 2;
+  uint64_t _nrMinimalThreads = 0;
   uint64_t _nrMaximalThreads = 0;
   uint64_t _queueSize = 128;
   uint64_t _fifo1Size = 1024 * 1024;


### PR DESCRIPTION
Addressing three critical omissions from recent PR:

1. _nrMinimalThreads was defaulting to 2, which therefore caused auto sizing of this value to be skipped.  Now defaults to zero so code will autosize based upon cpu core count.  The autosize creates execution environment that does NOT block critical tasks (that end up causing all schedulers to lock for 120 seconds).

2. canPostDirectly() used "<=" when "<" needed.  Creates opportunity to post one more task than count of threads.  Posting extra tasks to boost io_context can cause delays on poster's thread.

3. threadShouldStop() now returns only false.  This needs extensive testing and discussions about performance impact if original code restored.  Performance goes down in case where function returns true.

I intentionally did NOT create a CHANGELOG entry since this PR simply corrects item already in 3.4 CHANGELOG.  Let me know if entry required anyway.