### PR TITLE
issue 485: ensure LogicalDataSource::drop() is called on vocbase drop…

### DIFF
--- a/arangod/IResearch/IResearchView.cpp
+++ b/arangod/IResearch/IResearchView.cpp
@@ -792,9 +792,6 @@ IResearchView::IResearchView(
         auto const runCleanupAfterConsolidation =
           state._cleanupIntervalCount > state._cleanupIntervalStep;
 
-        auto& viewMutex = self()->mutex();
-        SCOPED_LOCK(viewMutex); // ensure view does not get deallocated before call back finishes
-
         if (_storePersisted
             && consolidateCleanupStore(
                  *_storePersisted._directory,
@@ -1092,6 +1089,7 @@ arangodb::Result IResearchView::drop(
 }
 
 arangodb::Result IResearchView::dropImpl() {
+  std::unordered_set<TRI_voc_cid_t> collections;
   std::unordered_set<TRI_voc_cid_t> stale;
 
   // drop all known links
@@ -1101,41 +1099,42 @@ arangodb::Result IResearchView::dropImpl() {
     stale = _metaState._collections;
   }
 
-  // check link auth as per https://github.com/arangodb/backlog/issues/459
-  if (arangodb::ExecContext::CURRENT) {
-    for (auto& entry: stale) {
-      auto collection = vocbase().lookupCollection(entry);
+  if (!stale.empty()) {
+    // check link auth as per https://github.com/arangodb/backlog/issues/459
+    if (arangodb::ExecContext::CURRENT) {
+      for (auto& entry: stale) {
+        auto collection = vocbase().lookupCollection(entry);
 
-      if (collection
-          && !arangodb::ExecContext::CURRENT->canUseCollection(vocbase().name(), collection->name(), arangodb::auth::Level::RO)) {
-        return arangodb::Result(TRI_ERROR_FORBIDDEN);
+        if (collection
+            && !arangodb::ExecContext::CURRENT->canUseCollection(vocbase().name(), collection->name(), arangodb::auth::Level::RO)) {
+          return arangodb::Result(TRI_ERROR_FORBIDDEN);
+        }
       }
     }
-  }
 
-  std::unordered_set<TRI_voc_cid_t> collections;
-  arangodb::Result res;
+    arangodb::Result res;
 
-  {
-    if (!_updateLinksLock.try_lock()) {
-      return arangodb::Result(
-        TRI_ERROR_FAILED, // FIXME use specific error code
-        std::string("failed to remove arangosearch view '") + name()
+    {
+      if (!_updateLinksLock.try_lock()) {
+        return arangodb::Result(
+          TRI_ERROR_FAILED, // FIXME use specific error code
+          std::string("failed to remove arangosearch view '") + name()
+        );
+      }
+
+      ADOPT_SCOPED_LOCK_NAMED(_updateLinksLock, lock);
+
+      res = IResearchLinkHelper::updateLinks(
+        collections, vocbase(), *this, emptyObjectSlice(), stale
       );
     }
 
-    ADOPT_SCOPED_LOCK_NAMED(_updateLinksLock, lock);
-
-    res = IResearchLinkHelper::updateLinks(
-      collections, vocbase(), *this, emptyObjectSlice(), stale
-    );
-  }
-
-  if (!res.ok()) {
-    return arangodb::Result(
-      res.errorNumber(),
-      std::string("failed to remove links while removing arangosearch view '") + name() + "': " + res.errorMessage()
-    );
+    if (!res.ok()) {
+      return arangodb::Result(
+        res.errorNumber(),
+        std::string("failed to remove links while removing arangosearch view '") + name() + "': " + res.errorMessage()
+      );
+    }
   }
 
   _asyncTerminate.store(true); // mark long-running async jobs for terminatation
@@ -1173,6 +1172,7 @@ arangodb::Result IResearchView::dropImpl() {
   // ...........................................................................
   try {
     if (_storePersisted) {
+      _storePersisted._reader.reset(); // reset reader to release file handles
       _storePersisted._writer->close();
       _storePersisted._writer.reset();
       _storePersisted._directory->close();
@@ -1531,13 +1531,20 @@ int IResearchView::insert(
   auto& properties = info.isObject() ? info : emptyObjectSlice(); // if no 'info' then assume defaults
   std::string error;
 
-  if (!impl._meta->init(properties, error)
-      || !impl._metaState.init(properties, error)) {
-    TRI_set_errno(TRI_ERROR_BAD_PARAMETER);
-    LOG_TOPIC(WARN, arangodb::iresearch::TOPIC)
-      << "failed to initialize arangosearch view from definition, error: " << error;
+  {
+    WriteMutex mutex(impl._mutex); // '_meta' can be asynchronously read by async jobs started in constructor
+    SCOPED_LOCK(mutex);
 
-    return nullptr;
+    if (!impl._meta->init(properties, error)
+        || !impl._metaState.init(properties, error)) {
+      TRI_set_errno(TRI_ERROR_BAD_PARAMETER);
+      LOG_TOPIC(WARN, arangodb::iresearch::TOPIC)
+        << "failed to initialize arangosearch view from definition, error: " << error;
+
+      return nullptr;
+    }
+
+    impl.updateProperties(impl._meta); // trigger reload of settings for async jobs
   }
 
   auto links = properties.hasKey(StaticStrings::LinksField)
@@ -1629,6 +1636,7 @@ size_t IResearchView::memory() const {
   size += _metaState.memory();
 
   if (_storePersisted) {
+    // FIXME TODO this is incorrect since '_storePersisted' is on disk and not in memory
     size += directoryMemory(*(_storePersisted._directory), id());
     size += _storePersisted._path.native().size() * sizeof(irs::utf8_path::native_char_t);
   }

--- a/arangod/IResearch/IResearchView.h
+++ b/arangod/IResearch/IResearchView.h
@@ -318,7 +318,6 @@ class IResearchView final
     irs::directory::ptr _directory;
     irs::directory_reader _reader;
     irs::index_reader::ptr _readerImpl; // need this for 'std::atomic_exchange_strong'
-    std::atomic<size_t> _segmentCount{}; // FIXME remove total number of segments in the writer
     irs::index_writer::ptr _writer;
 
     DataStore() = default;

--- a/arangod/VocBase/LogicalView.cpp
+++ b/arangod/VocBase/LogicalView.cpp
@@ -289,12 +289,17 @@ arangodb::Result LogicalViewStorageEngine::appendVelocyPack(
 }
 
 arangodb::Result LogicalViewStorageEngine::drop() {
+  if (deleted()) {
+    return Result(); // view already dropped
+  }
+
   TRI_ASSERT(!ServerState::instance()->isCoordinator());
   StorageEngine* engine = EngineSelectorFeature::ENGINE;
   TRI_ASSERT(engine);
   auto res = dropImpl();
 
-  if (res.ok()) {
+  // skip on error or if already called by dropImpl()
+  if (res.ok() && !deleted()) {
     deleted(true);
     engine->dropView(vocbase(), *this);
   }

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -98,7 +98,10 @@ namespace {
         bool acquire,
         char const* file,
         int line
-    ): _locker(&mutex, type, false, file, line), _owner(owner), _update(noop) {
+    ): _locked(false),
+       _locker(&mutex, type, false, file, line),
+       _owner(owner),
+       _update(noop) {
       if (acquire) {
         lock();
       }
@@ -108,9 +111,7 @@ namespace {
       unlock();
     }
 
-    bool isLocked() {
-      return _locker.isLocked();
-    }
+    bool isLocked() { return _locked; }
 
     void lock() {
       // recursive locking of the same instance is not yet supported (create a new instance instead)
@@ -121,13 +122,17 @@ namespace {
         _owner.store(std::this_thread::get_id());
         _update = owned;
       }
+
+      _locked = true;
     }
 
     void unlock() {
       _update(*this);
+      _locked = false;
     }
 
    private:
+    bool _locked; // track locked state separately for recursive lock aquisition
     arangodb::basics::WriteLocker<T> _locker;
     std::atomic<std::thread::id>& _owner;
     void (*_update)(RecursiveWriteLocker& locker);
@@ -1842,6 +1847,10 @@ TRI_vocbase_t::~TRI_vocbase_t() {
   for (auto& it : _collections) {
     it->close(); // required to release indexes
   }
+
+  _dataSourceById.clear(); // clear map before deallocating TRI_vocbase_t members
+  _dataSourceByName.clear(); // clear map before deallocating TRI_vocbase_t members
+  _dataSourceByUuid.clear(); // clear map before deallocating TRI_vocbase_t members
 }
 
 std::string TRI_vocbase_t::path() const {
@@ -2110,6 +2119,43 @@ std::vector<arangodb::LogicalCollection*> TRI_vocbase_t::collections(
   }
 
   return collections;
+}
+
+bool TRI_vocbase_t::visitDataSources(
+    dataSourceVisitor const& visitor,
+    bool lockWrite /*= false*/
+) {
+  TRI_ASSERT(visitor);
+
+  if (!lockWrite) {
+    RECURSIVE_READ_LOCKER(_dataSourceLock, _dataSourceLockWriteOwner);
+
+    for (auto& entry: _dataSourceById) {
+      if (entry.second && !visitor(*(entry.second))) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  RECURSIVE_WRITE_LOCKER(_dataSourceLock, _dataSourceLockWriteOwner);
+  std::vector<std::shared_ptr<arangodb::LogicalDataSource>> dataSources;
+
+  dataSources.reserve(_dataSourceById.size());
+
+  // create a copy of all the datasource in case 'visitor' modifies '_dataSourceById'
+  for (auto& entry: _dataSourceById) {
+    dataSources.emplace_back(entry.second);
+  }
+
+  for (auto& dataSource: dataSources) {
+    if (dataSource && !visitor(*dataSource)) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 /// @brief extract the _rev attribute from a slice

--- a/arangod/VocBase/vocbase.h
+++ b/arangod/VocBase/vocbase.h
@@ -388,6 +388,16 @@ struct TRI_vocbase_t {
   /// @brief releases a collection from usage
   void releaseCollection(arangodb::LogicalCollection* collection);
 
+  /// @brief visit all DataSources registered with this vocbase
+  /// @param visitor returns if visitation should continue
+  /// @param lockWrite aquire write lock (if 'visitor' will modify vocbase)
+  /// @return visitation compleated successfully
+  typedef std::function<bool(arangodb::LogicalDataSource& dataSource)> dataSourceVisitor;
+  bool visitDataSources(
+    dataSourceVisitor const& visitor,
+    bool lockWrite = false
+  );
+
  private:
 
   /// @brief check some invariants on the various lists of collections

--- a/tests/IResearch/StorageEngineMock.cpp
+++ b/tests/IResearch/StorageEngineMock.cpp
@@ -1307,7 +1307,7 @@ void StorageEngineMock::prepareDropDatabase(
     bool useWriteMarker,
     int& status
 ) {
-  TRI_ASSERT(false);
+  // NOOP
 }
 
 TRI_voc_tick_t StorageEngineMock::releasedTick() const {
@@ -1401,7 +1401,7 @@ arangodb::Result StorageEngineMock::flushWal(bool waitForSync, bool waitForColle
 }
 
 void StorageEngineMock::waitUntilDeletion(TRI_voc_tick_t id, bool force, int& status) {
-  TRI_ASSERT(false);
+  // NOOP
 }
 
 int StorageEngineMock::writeCreateDatabaseMarker(TRI_voc_tick_t id, VPackSlice const& slice) {


### PR DESCRIPTION
… (#6895)

* issue 485: ensure LogicalDataSource::drop() is called on vocbase drop

* add missed change

* backport: address race between make(...) and async job

* add another missed change

* backport: ensure recursive lock reports itself as locked correctly

* backport: address test failure on mmfiles

* backport: remove redundant lock already held by async task

* backport: reset reader before unlinking directory

Please note that for legal reasons we require you to sign the 
[Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
