### PR TITLE
Don't listen to procdumps exit code

### DIFF
--- a/js/client/modules/@arangodb/crash-utils.js
+++ b/js/client/modules/@arangodb/crash-utils.js
@@ -148,10 +148,9 @@ Crash analysis of: ` + JSON.stringify(instanceInfo) + '\n';
 
 function analyzeCoreDumpWindows (instanceInfo) {
   let cdbOutputFile = fs.getTempFile();
-  const coreFN = instanceInfo.rootDir + '\\' + 'core.dmp';
 
-  if (!fs.exists(coreFN)) {
-    print('core file ' + coreFN + ' not found?');
+  if (!fs.exists(instanceInfo.coreFilePattern)) {
+    print('core file ' + instanceInfo.coreFilePattern + ' not found?');
     return;
   }
 
@@ -167,7 +166,7 @@ function analyzeCoreDumpWindows (instanceInfo) {
 
   const args = [
     '-z',
-    coreFN,
+    instanceInfo.coreFilePattern,
     '-lines',
     '-logo',
     cdbOutputFile,
@@ -193,9 +192,9 @@ function checkMonitorAlive (binary, arangod, options, res) {
       let rc = statusExternal(arangod.monitor.pid, false);
       if (rc.status !== 'RUNNING') {
         arangod.monitor = rc;
-        if (arangod.monitor.exit !== 0) {
-          // ok, procdump exited with a failure,
-          // this means it wrote an exception dump.
+        // procdump doesn't set propper exit codes, check for
+        // dumps that may exist:
+        if (fs.exists(arangod.coreFilePattern)) {
           print("checkMonitorAlive: marking crashy");
           arangod.monitor.monitorExited = true;
           arangod.monitor.pid = null;

--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -375,8 +375,13 @@ function makeArgsArangod (options, appDir, role, tmpDir) {
 }
 
 
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief check whether process does bad on the wintendo
+// //////////////////////////////////////////////////////////////////////////////
+
 function runProcdump (options, instanceInfo, rootDir, pid) {
   let procdumpArgs = [ ];
+  let dumpFile = fs.join(rootDir, 'core_'+pid + '.dmp');
   if (options.exceptionFilter != null) {
     procdumpArgs = [
       '-accepteula',
@@ -391,14 +396,14 @@ function runProcdump (options, instanceInfo, rootDir, pid) {
     }
     procdumpArgs.push('-ma');
     procdumpArgs.push(pid);
-    procdumpArgs.push(fs.join(rootDir, 'core.dmp'));
+    procdumpArgs.push(dumpFile);
   } else {
     procdumpArgs = [
       '-accepteula',
       '-e',
       '-ma',
       pid,
-      fs.join(rootDir, 'core.dmp')
+      dumpFile
     ];
   }
   try {
@@ -406,11 +411,11 @@ function runProcdump (options, instanceInfo, rootDir, pid) {
       print("Starting procdump: " + JSON.stringify(procdumpArgs));
     }
     instanceInfo.monitor = executeExternal('procdump', procdumpArgs);
+    instanceInfo.coreFilePattern = dumpFile;
   } catch (x) {
     print('failed to start procdump - is it installed?');
     // throw x;
   }
-
 }
 
 // //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Procdump doesn't indicate by exit code whether a dump occured or not.
it just does some random undocumented exit code.
Put in a propper coredump filename on the start, remember it on the
instance structure, and check for the files existence to find out
whether procdump took a dump.
