### PR TITLE
Update CHANGELOG 3.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-v3.4.0-rc.4 (XXXX-XX-XX)
+v3.4.0-rc.3 (XXXX-XX-XX)
 ------------------------
 
 * The single database or single coordinator statistics in a cluster
@@ -14,10 +14,6 @@ v3.4.0-rc.4 (XXXX-XX-XX)
 * suppress warnings from statistics background threads such as 
   `WARNING caught exception during statistics processing: Expecting Object`
   during version upgrade
-
-
-v3.4.0-rc.3 (2018-10-13)
-------------------------
 
 * fix internal issue #486: immediate deletion (right after creation) of
   a view with a link to one collection and indexed data reports failure


### PR DESCRIPTION
Removed the headings for 3.4.0-RC.4 and "merged" what was there under the 3.4.0-RC.3

Since 3.4.0-RC.3 has not been released yet - to avoid possible confusion from users and customers

Thanks,