### PR TITLE
Bugfix 3.4:  update Scheduler thread logic based upon testing

### DIFF
--- a/arangod/Scheduler/Scheduler.cpp
+++ b/arangod/Scheduler/Scheduler.cpp
@@ -369,9 +369,11 @@ bool Scheduler::canPostDirectly(RequestPriority prio) const noexcept {
     case RequestPriority::HIGH:
       return nrWorking + nrQueued < _maxThreads;
 
+    // the "/ 2" is an assumption that HIGH is typically responses to our outbound messages
+    //  where MED & LOW are incoming requests.  Keep half the threads processing our work and half their work.
     case RequestPriority::MED:
     case RequestPriority::LOW:
-      return nrWorking + nrQueued < _maxThreads - _minThreads;
+      return nrWorking + nrQueued < _maxThreads / 2;
   }
 
   return false;
@@ -465,7 +467,7 @@ bool Scheduler::start() {
   TRI_ASSERT(0 < _minThreads);
   TRI_ASSERT(_minThreads <= _maxThreads);
 
-  for (uint64_t i = 0; i < _maxThreads; ++i) {
+  for (uint64_t i = 0; i < _minThreads; ++i) {
     {
       MUTEX_LOCKER(locker, _threadCreateLock);
       incRunning();
@@ -579,6 +581,11 @@ void Scheduler::stopRebalancer() noexcept {
   }
 }
 
+
+//
+// This routine tries to keep only the mostly likely needed count of threads running:
+//  - asio io_context runs less efficiently if it has too many threads, but
+//  - there is a latency hit to starting a new thread.
 void Scheduler::rebalanceThreads() {
   static uint64_t count = 0;
 
@@ -673,7 +680,7 @@ bool Scheduler::threadShouldStop(double now) {
   // I reactivated the following at the last hour before 3.4.RC3 without
   // being able to consult with Matthew. If this breaks things, we find
   // out in due course. 12.10.2018 Max.
-#if 0
+#if 1
   // decrement nrRunning by one already in here while holding the lock
   decRunning();
   return true;

--- a/arangod/Scheduler/Scheduler.cpp
+++ b/arangod/Scheduler/Scheduler.cpp
@@ -583,9 +583,10 @@ void Scheduler::stopRebalancer() noexcept {
 
 
 //
-// This routine tries to keep only the mostly likely needed count of threads running:
+// This routine tries to keep only the most likely needed count of threads running:
 //  - asio io_context runs less efficiently if it has too many threads, but
 //  - there is a latency hit to starting a new thread.
+//
 void Scheduler::rebalanceThreads() {
   static uint64_t count = 0;
 
@@ -677,16 +678,9 @@ bool Scheduler::threadShouldStop(double now) {
     return false;
   }
 
-  // I reactivated the following at the last hour before 3.4.RC3 without
-  // being able to consult with Matthew. If this breaks things, we find
-  // out in due course. 12.10.2018 Max.
-#if 1
   // decrement nrRunning by one already in here while holding the lock
   decRunning();
   return true;
-#else
-  return false;
-#endif
 }
 
 void Scheduler::startNewThread() {

--- a/arangod/Scheduler/SchedulerFeature.cpp
+++ b/arangod/Scheduler/SchedulerFeature.cpp
@@ -98,8 +98,8 @@ void SchedulerFeature::validateOptions(
   if (_nrMaximalThreads == 0) {
     _nrMaximalThreads = defaultNumberOfThreads();
   }
-  if (_nrMinimalThreads == 0) {
-    _nrMinimalThreads = _nrMaximalThreads / 2;
+  if (_nrMinimalThreads < 2) {
+    _nrMinimalThreads = 2;
   }
 
   if (_queueSize == 0) {
@@ -132,14 +132,14 @@ void SchedulerFeature::start() {
     LOG_TOPIC(WARN, arangodb::Logger::THREADS) << "--server.minimal-threads ("
                                                << _nrMinimalThreads
                                                << ") should be at least 2";
-    _nrMinimalThreads = _nrMaximalThreads / 2;
+    _nrMinimalThreads = 2;
   }
 
   if (_nrMinimalThreads >= _nrMaximalThreads) {
     LOG_TOPIC(WARN, arangodb::Logger::THREADS)
         << "--server.threads (" << _nrMaximalThreads << ") should be at least "
         << (_nrMinimalThreads + 1) << ", raising it";
-    _nrMaximalThreads = _nrMinimalThreads * 2;
+    _nrMaximalThreads = _nrMinimalThreads;
   }
 
   TRI_ASSERT(2 <= _nrMinimalThreads);

--- a/arangod/Scheduler/SchedulerFeature.h
+++ b/arangod/Scheduler/SchedulerFeature.h
@@ -53,7 +53,7 @@ class SchedulerFeature final : public application_features::ApplicationFeature {
   uint64_t queueSize() const { return _queueSize; }
 
  private:
-  uint64_t _nrMinimalThreads = 0;
+  uint64_t _nrMinimalThreads = 2;
   uint64_t _nrMaximalThreads = 0;
   uint64_t _queueSize = 128;
   uint64_t _fifo1Size = 1024 * 1024;


### PR DESCRIPTION
This PR restores some of the prior Scheduler logic that would delete "excess" threads.  The asio io_context object appears to have latency issues when too many threads are active but unused.  There is a similar latency problem when too few threads exist and the code tries to spawn new threads.  

Recently optimized for the latter case by always starting all threads and never deleting any.  Worked great for tests with using large number of clients.  Worked worse for tests with single client.

This branch returns to the previous code for number to start and when to delete.  It also adds a comment about why this is happening.

Original testing was based largely upon Coordinator throughput.  It ws the subsequent testing with the code also running on db servers that better demonstrated the loss under single client tests.