### PR TITLE
Bug fix 3.4/agency loop wrong credentials

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.4.0-rc.4 (XXXX-XX-XX)
 ------------------------
 
+* in a cluster environment, the arangod process now exits if wrong credentials
+  are used during the startup process.
+
 * suppress warnings from statistics background threads such as 
   `WARNING caught exception during statistics processing: Expecting Object`
   during version upgrade

--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -1221,6 +1221,12 @@ bool AgencyComm::ensureStructureInitialized() {
         LOG_TOPIC(TRACE, Logger::AGENCYCOMM) << "Found an initialized agency";
         break;
       }
+    } else {
+      if (result.httpCode() == 401) {
+        // unauthorized
+        LOG_TOPIC(FATAL, Logger::STARTUP) << "Unauthorized. Wrong credentials.";
+        FATAL_ERROR_EXIT();
+      }
     }
 
     LOG_TOPIC(TRACE, Logger::AGENCYCOMM)


### PR DESCRIPTION
During an arangod startup loop, the error checking was missing. If e.g. a database arangod instance tried to connect to the agency, it tried for an unlimited time. This pull request is now checking if we got an 401 http error code (unauthorized) and exists if true.