### PR TITLE
Bug fix 3.2/agency loop wrong credentials

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.2.17 (2018-10-24)
 --------------------
 
+* in a cluster environment, the arangod process now exits if wrong credentials
+  are used during the startup process.
+
 * upgraded arangodb starter version to 0.13.7
 
 * when returning memory to the OS, use the same memory protection flags as 

--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -1198,6 +1198,12 @@ bool AgencyComm::ensureStructureInitialized() {
         LOG_TOPIC(TRACE, Logger::AGENCYCOMM) << "Found an initialized agency";
         break;
       }
+    } else {
+      if (result.httpCode() == 401) {
+        // unauthorized
+        LOG_TOPIC(FATAL, Logger::STARTUP) << "Unauthorized. Wrong credentials.";
+        FATAL_ERROR_EXIT();
+      }
     }
 
     LOG_TOPIC(TRACE, Logger::AGENCYCOMM)


### PR DESCRIPTION
During an arangod startup loop, the error checking was missing. If e.g. a database arangod instance tried to connect to the agency, it tried for an unlimited time. This pull request is now checking if we got an 401 http error code (unauthorized) and exists if true.