### PR TITLE
added option `--rocksdb.total-write-buffer-size`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.3.20 (XXXX-XX-XX)
 --------------------
 
+* added option `--rocksdb.total-write-buffer-size` to limit total memory usage
+  across all RocksDB in-memory write buffers
+
 * Fixed an AQL bug where the optimize-traversals rule was falsely applied to
   extensions with inline expressions and thereby ignoring them
 

--- a/Documentation/Books/Manual/Administration/Configuration/RocksDB.md
+++ b/Documentation/Books/Manual/Administration/Configuration/RocksDB.md
@@ -33,6 +33,13 @@ The maximum number of write buffers that built up in memory. If this number is
 reached before the buffers can be flushed, writes will be slowed or stalled.
 Default: 2.
 
+`--rocksdb.total-write-buffer-size` (Hidden)
+
+The total amount of data to build up in all in-memory buffers (backed by log
+files). This option, together with the block cache size configuration option,
+can be used to limit memory usage. If set to 0, the memory usage is not limited.
+Default: 0 (disabled).
+
 `--rocksdb.min-write-buffer-number-to-merge`
 
 Minimum number of write buffers that will be merged together when flushing to

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -430,6 +430,10 @@ void RocksDBEngine::start() {
     _listener.reset(new RocksDBThrottle);
     _options.listeners.push_back(_listener);
   }
+  
+  if (opts->_totalWriteBufferSize > 0) {
+    _options.db_write_buffer_size = opts->_totalWriteBufferSize;
+  }
 
   // this is cfFamilies.size() + 2 ... but _option needs to be set before
   //  building cfFamilies
@@ -538,6 +542,7 @@ void RocksDBEngine::start() {
       }
     }
   }
+  
 
   rocksdb::Status status = rocksdb::TransactionDB::Open(
       _options, transactionOptions, _path, cfFamilies, &cfHandles, &_db);

--- a/lib/ApplicationFeatures/RocksDBOptionFeature.h
+++ b/lib/ApplicationFeatures/RocksDBOptionFeature.h
@@ -49,6 +49,7 @@ class RocksDBOptionFeature final
 
   int64_t _transactionLockTimeout;
   std::string _walDirectory;
+  uint64_t _totalWriteBufferSize;
   uint64_t _writeBufferSize;
   uint64_t _maxWriteBufferNumber;
   uint64_t _maxTotalWalSize;


### PR DESCRIPTION
Backport from 3.4/devel