### PR TITLE
Repair arangorestore.

### DIFF
--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -210,7 +210,12 @@ static void mergeResults(
         arr.get(StaticStrings::Error).isBoolean() && arr.get(StaticStrings::Error).getBoolean()) {
       // an error occurred, now rethrow the error
       int res = arr.get(StaticStrings::ErrorNum).getNumericValue<int>();
-      THROW_ARANGO_EXCEPTION(res);
+      VPackSlice msg = arr.get(StaticStrings::ErrorMessage);
+      if (msg.isString()) {
+        THROW_ARANGO_EXCEPTION(res, msg.copyString());
+      } else {
+        THROW_ARANGO_EXCEPTION(res);
+      }
     }
     resultBody->add(arr.at(pair.second));
   }

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -51,7 +51,13 @@
 using namespace arangodb::basics;
 using namespace arangodb::rest;
 
+// Timeout for read operations:
 static double const CL_DEFAULT_TIMEOUT = 120.0;
+
+// Timeout for write operations, note that these are used for communication
+// with a shard leader and we always have to assume that some follower has
+// stopped writes for some time to get in sync:
+static double const CL_DEFAULT_LONG_TIMEOUT = 900.0;
 
 namespace {
 template<typename T>
@@ -212,7 +218,7 @@ static void mergeResults(
       int res = arr.get(StaticStrings::ErrorNum).getNumericValue<int>();
       VPackSlice msg = arr.get(StaticStrings::ErrorMessage);
       if (msg.isString()) {
-        THROW_ARANGO_EXCEPTION(res, msg.copyString());
+        THROW_ARANGO_EXCEPTION_MESSAGE(res, msg.copyString());
       } else {
         THROW_ARANGO_EXCEPTION(res);
       }
@@ -1170,7 +1176,7 @@ int createDocumentOnCoordinator(
   
   // Perform the requests
   size_t nrDone = 0;
-  cc->performRequests(requests, CL_DEFAULT_TIMEOUT, nrDone, Logger::COMMUNICATION, true);
+  cc->performRequests(requests, CL_DEFAULT_LONG_TIMEOUT, nrDone, Logger::COMMUNICATION, true);
 
   // Now listen to the results:
   if (!useMultiple) {
@@ -1334,7 +1340,7 @@ int deleteDocumentOnCoordinator(
 
     // Perform the requests
     size_t nrDone = 0;
-    cc->performRequests(requests, CL_DEFAULT_TIMEOUT, nrDone, Logger::COMMUNICATION, true);
+    cc->performRequests(requests, CL_DEFAULT_LONG_TIMEOUT, nrDone, Logger::COMMUNICATION, true);
 
     // Now listen to the results:
     if (!useMultiple) {
@@ -1383,7 +1389,7 @@ int deleteDocumentOnCoordinator(
 
   // Perform the requests
   size_t nrDone = 0;
-  cc->performRequests(requests, CL_DEFAULT_TIMEOUT, nrDone, Logger::COMMUNICATION, true);
+  cc->performRequests(requests, CL_DEFAULT_LONG_TIMEOUT, nrDone, Logger::COMMUNICATION, true);
 
   // Now listen to the results:
   if (!useMultiple) {
@@ -2425,7 +2431,7 @@ int modifyDocumentOnCoordinator(
 
     // Perform the requests
     size_t nrDone = 0;
-    cc->performRequests(requests, CL_DEFAULT_TIMEOUT, nrDone, Logger::COMMUNICATION, true);
+    cc->performRequests(requests, CL_DEFAULT_LONG_TIMEOUT, nrDone, Logger::COMMUNICATION, true);
 
     // Now listen to the results:
     if (!useMultiple) {
@@ -2479,7 +2485,7 @@ int modifyDocumentOnCoordinator(
 
   // Perform the requests
   size_t nrDone = 0;
-  cc->performRequests(requests, CL_DEFAULT_TIMEOUT, nrDone, Logger::COMMUNICATION, true);
+  cc->performRequests(requests, CL_DEFAULT_LONG_TIMEOUT, nrDone, Logger::COMMUNICATION, true);
 
   // Now listen to the results:
   if (!useMultiple) {

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1410,7 +1410,7 @@ Result RestReplicationHandler::processRestoreDataBatch(
       return opRes.result;
     }
     if (duration > 30) {
-      LOG_TOPIC(INFO, Logger::PERFORMANCE) << << "Restored/deleted "
+      LOG_TOPIC(INFO, Logger::PERFORMANCE) << "Restored/deleted "
         << oldBuilder.slice().length() << " documents in time: " << duration
         << " seconds.";
     }
@@ -1508,7 +1508,7 @@ Result RestReplicationHandler::processRestoreDataBatch(
       return opRes.result;
     }
     if (duration > 30) {
-      LOG_TOPIC(INFO, Logger::PERFORMANCE) << << "Restored/inserted "
+      LOG_TOPIC(INFO, Logger::PERFORMANCE) << "Restored/inserted "
         << requestSlice.length() << " documents in time: " << duration
         << " seconds.";
     }
@@ -1576,7 +1576,7 @@ Result RestReplicationHandler::processRestoreDataBatch(
       return opRes.result;
     }
     if (duration > 30) {
-      LOG_TOPIC(INFO, Logger::PERFORMANCE) << << "Restored/inserted "
+      LOG_TOPIC(INFO, Logger::PERFORMANCE) << "Restored/inserted "
         << replBuilder.slice().length() << " documents in time: " << duration
         << " seconds.";
     }

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1398,16 +1398,35 @@ Result RestReplicationHandler::processRestoreDataBatch(
     options.ignoreRevs = true;
     options.isRestore = true;
     options.waitForSync = false;
+    double startTime = TRI_microtime();
     OperationResult opRes =
         trx.remove(collectionName, oldBuilder.slice(), options);
+    double duration = TRI_microtime() - startTime;
     if (opRes.fail()) {
+      LOG_TOPIC(WARN, Logger::CLUSTER)
+        << "Could not delete " << oldBuilder.slice().length()
+        << " documents for restore: "
+        << opRes.result.errorMessage();
       return opRes.result;
     }
+    if (duration > 30) {
+      LOG_TOPIC(INFO, Logger::PERFORMANCE) << << "Restored/deleted "
+        << oldBuilder.slice().length() << " documents in time: " << duration
+        << " seconds.";
+    }
   } catch (arangodb::basics::Exception const& ex) {
+    LOG_TOPIC(WARN, Logger::CLUSTER)
+      << "Could not delete documents for restore exception (1): "
+      << ex.what();
     return Result(ex.code(), ex.what());
   } catch (std::exception const& ex) {
+    LOG_TOPIC(WARN, Logger::CLUSTER)
+      << "Could not delete documents for restore exception (2): "
+      << ex.what();
     return Result(TRI_ERROR_INTERNAL, ex.what());
   } catch (...) {
+    LOG_TOPIC(WARN, Logger::CLUSTER)
+      << "Could not delete documents for restore exception (3).";
     return Result(TRI_ERROR_INTERNAL);
   }
 
@@ -1478,15 +1497,34 @@ Result RestReplicationHandler::processRestoreDataBatch(
     options.ignoreRevs = true;
     options.isRestore = true;
     options.waitForSync = false;
+    double startTime = TRI_microtime();
     opRes = trx.insert(collectionName, requestSlice, options);
+    double duration = TRI_microtime() - startTime;
     if (opRes.fail()) {
+      LOG_TOPIC(WARN, Logger::CLUSTER)
+        << "Could not insert " << requestSlice.length()
+        << " documents for restore: "
+        << opRes.result.errorMessage();
       return opRes.result;
     }
+    if (duration > 30) {
+      LOG_TOPIC(INFO, Logger::PERFORMANCE) << << "Restored/inserted "
+        << requestSlice.length() << " documents in time: " << duration
+        << " seconds.";
+    }
   } catch (arangodb::basics::Exception const& ex) {
+    LOG_TOPIC(WARN, Logger::CLUSTER)
+      << "Could not insert documents for restore exception (1): "
+      << ex.what();
     return Result(ex.code(), ex.what());
   } catch (std::exception const& ex) {
+    LOG_TOPIC(WARN, Logger::CLUSTER)
+      << "Could not insert documents for restore exception (2): "
+      << ex.what();
     return Result(TRI_ERROR_INTERNAL, ex.what());
   } catch (...) {
+    LOG_TOPIC(WARN, Logger::CLUSTER)
+      << "Could not insert documents for restore exception (3).";
     return Result(TRI_ERROR_INTERNAL);
   }
 
@@ -1527,15 +1565,34 @@ Result RestReplicationHandler::processRestoreDataBatch(
     options.ignoreRevs = true;
     options.isRestore = true;
     options.waitForSync = false;
+    double startTime = TRI_microtime();
     opRes = trx.replace(collectionName, replBuilder.slice(), options);
+    double duration = TRI_microtime() - startTime;
     if (opRes.fail()) {
+      LOG_TOPIC(WARN, Logger::CLUSTER)
+        << "Could not replace " << replBuilder.slice().length()
+        << " documents for restore: "
+        << opRes.result.errorMessage();
       return opRes.result;
     }
+    if (duration > 30) {
+      LOG_TOPIC(INFO, Logger::PERFORMANCE) << << "Restored/inserted "
+        << replBuilder.slice().length() << " documents in time: " << duration
+        << " seconds.";
+    }
   } catch (arangodb::basics::Exception const& ex) {
+    LOG_TOPIC(WARN, Logger::CLUSTER)
+      << "Could not replace documents for restore exception (1): "
+      << ex.what();
     return Result(ex.code(), ex.what());
   } catch (std::exception const& ex) {
+    LOG_TOPIC(WARN, Logger::CLUSTER)
+      << "Could not replace documents for restore exception (2): "
+      << ex.what();
     return Result(TRI_ERROR_INTERNAL, ex.what());
   } catch (...) {
+    LOG_TOPIC(WARN, Logger::CLUSTER)
+      << "Could not replace documents for restore exception (3).";
     return Result(TRI_ERROR_INTERNAL);
   }
 

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1576,7 +1576,7 @@ Result RestReplicationHandler::processRestoreDataBatch(
       return opRes.result;
     }
     if (duration > 30) {
-      LOG_TOPIC(INFO, Logger::PERFORMANCE) << "Restored/inserted "
+      LOG_TOPIC(INFO, Logger::PERFORMANCE) << "Restored/replaced "
         << replBuilder.slice().length() << " documents in time: " << duration
         << " seconds.";
     }

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1416,17 +1416,17 @@ Result RestReplicationHandler::processRestoreDataBatch(
     }
   } catch (arangodb::basics::Exception const& ex) {
     LOG_TOPIC(WARN, Logger::CLUSTER)
-      << "Could not delete documents for restore exception (1): "
+      << "Could not delete documents for restore exception: "
       << ex.what();
     return Result(ex.code(), ex.what());
   } catch (std::exception const& ex) {
     LOG_TOPIC(WARN, Logger::CLUSTER)
-      << "Could not delete documents for restore exception (2): "
+      << "Could not delete documents for restore exception: "
       << ex.what();
     return Result(TRI_ERROR_INTERNAL, ex.what());
   } catch (...) {
     LOG_TOPIC(WARN, Logger::CLUSTER)
-      << "Could not delete documents for restore exception (3).";
+      << "Could not delete documents for restore exception.";
     return Result(TRI_ERROR_INTERNAL);
   }
 
@@ -1514,17 +1514,17 @@ Result RestReplicationHandler::processRestoreDataBatch(
     }
   } catch (arangodb::basics::Exception const& ex) {
     LOG_TOPIC(WARN, Logger::CLUSTER)
-      << "Could not insert documents for restore exception (1): "
+      << "Could not insert documents for restore exception: "
       << ex.what();
     return Result(ex.code(), ex.what());
   } catch (std::exception const& ex) {
     LOG_TOPIC(WARN, Logger::CLUSTER)
-      << "Could not insert documents for restore exception (2): "
+      << "Could not insert documents for restore exception: "
       << ex.what();
     return Result(TRI_ERROR_INTERNAL, ex.what());
   } catch (...) {
     LOG_TOPIC(WARN, Logger::CLUSTER)
-      << "Could not insert documents for restore exception (3).";
+      << "Could not insert documents for restore exception.";
     return Result(TRI_ERROR_INTERNAL);
   }
 
@@ -1582,17 +1582,17 @@ Result RestReplicationHandler::processRestoreDataBatch(
     }
   } catch (arangodb::basics::Exception const& ex) {
     LOG_TOPIC(WARN, Logger::CLUSTER)
-      << "Could not replace documents for restore exception (1): "
+      << "Could not replace documents for restore exception: "
       << ex.what();
     return Result(ex.code(), ex.what());
   } catch (std::exception const& ex) {
     LOG_TOPIC(WARN, Logger::CLUSTER)
-      << "Could not replace documents for restore exception (2): "
+      << "Could not replace documents for restore exception: "
       << ex.what();
     return Result(TRI_ERROR_INTERNAL, ex.what());
   } catch (...) {
     LOG_TOPIC(WARN, Logger::CLUSTER)
-      << "Could not replace documents for restore exception (3).";
+      << "Could not replace documents for restore exception.";
     return Result(TRI_ERROR_INTERNAL);
   }
 


### PR DESCRIPTION
Write requests from coordinator to leaders now have a longer timeout
to allow for stopped writes by a follower trying to get in sync.

Also improve error logging in the `restore` REST handler.