### PR TITLE
Simplify code and avoid duplicate lookups where possible.

### DIFF
--- a/arangod/Aql/Condition.cpp
+++ b/arangod/Aql/Condition.cpp
@@ -1141,25 +1141,10 @@ void Condition::storeAttributeAccess(
   auto variable = varAccess.first;
 
   if (variable != nullptr) {
-    auto it = variableUsage.find(variable);
-
-    if (it == variableUsage.end()) {
-      // nothing recorded yet for variable
-      it = variableUsage.emplace(variable, AttributeUsageType()).first;
-    }
-
     std::string attributeName;
     TRI_AttributeNamesToString(varAccess.second, attributeName, false);
 
-    auto it2 = (*it).second.find(attributeName);
-
-    if (it2 == (*it).second.end()) {
-      // nothing recorded yet for attribute name in this variable
-      it2 = (*it).second.emplace(attributeName, UsagePositionType()).first;
-    }
-
-    auto& dst = (*it2).second;
-
+    auto& dst = variableUsage[variable][attributeName];
     if (!dst.empty() && dst.back().first == position) {
       // already have this attribute for this variable. can happen in case a
       // condition refers to itself (e.g. a.x == a.x)

--- a/arangod/Aql/EngineInfoContainerDBServer.cpp
+++ b/arangod/Aql/EngineInfoContainerDBServer.cpp
@@ -890,12 +890,8 @@ void EngineInfoContainerDBServer::injectGraphNodesToMapping(
       // Thanks to fanout...
       for (auto const& collection : (*cs)) {
         for (auto& entry : mappingServerToCollections) {
-          auto it =
-              entry.second.vertexCollections.find(collection.second->name());
-          if (it == entry.second.vertexCollections.end()) {
-            entry.second.vertexCollections.emplace(collection.second->name(),
-                                                   std::vector<ShardID>());
-          }
+          // implicity creates the map entry in case it does not exist
+          entry.second.vertexCollections[collection.second->name()];
         }
       }
     } else {
@@ -921,11 +917,8 @@ void EngineInfoContainerDBServer::injectGraphNodesToMapping(
       // Thanks to fanout...
       for (auto const& it : vertices) {
         for (auto& entry : mappingServerToCollections) {
-          auto vIt = entry.second.vertexCollections.find(it->name());
-          if (vIt == entry.second.vertexCollections.end()) {
-            entry.second.vertexCollections.emplace(it->name(),
-                                                   std::vector<ShardID>());
-          }
+          // implicitly creates the map entry in case it does not exist.
+          entry.second.vertexCollections[it->name()];
         }
       }
     }

--- a/arangod/Aql/ExecutionStats.cpp
+++ b/arangod/Aql/ExecutionStats.cpp
@@ -83,11 +83,9 @@ void ExecutionStats::add(ExecutionStats const& summand) {
   // intentionally no modification of executionTime
   
   for(auto const& pair : summand.nodes) {
-    auto it = nodes.find(pair.first);
-    if (it != nodes.end()) {
-      it->second += pair.second;
-    } else {
-      nodes.emplace(pair);
+    auto result = nodes.insert(pair);
+    if (!result.second) {
+      result.first->second += pair.second;
     }
   }
 }

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -656,14 +656,10 @@ AqlValue Expression::executeSimpleExpressionObject(
         std::string key(buffer->begin(), buffer->length());
 
         // note each individual object key name with latest value position
-        auto it = uniqueKeyValues.find(key);
-
-        if (it == uniqueKeyValues.end()) {
-          // unique key
-          uniqueKeyValues.emplace(std::move(key), i);
-        } else {
+        auto it = uniqueKeyValues.insert({std::move(key), i});
+        if (!it.second) {
           // duplicate key
-          (*it).second = i;
+          it.first->second = i;
           isUnique = false;
         }
       }
@@ -679,14 +675,10 @@ AqlValue Expression::executeSimpleExpressionObject(
         std::string key(member->getString());
 
         // note each individual object key name with latest value position
-        auto it = uniqueKeyValues.find(key);
-
-        if (it == uniqueKeyValues.end()) {
-          // unique key
-          uniqueKeyValues.emplace(std::move(key), i);
-        } else {
+        auto it = uniqueKeyValues.insert({std::move(key), i});
+        if (!it.second) {
           // duplicate key
-          (*it).second = i;
+          it.first->second = i;
           isUnique = false;
         }
       }

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -4874,13 +4874,11 @@ AqlValue Functions::Outersection(ExpressionContext* expressionContext,
 
     for (auto const& it : VPackArrayIterator(slice)) {
       // check if we have seen the same element before
-      auto found = values.find(it);
-      if (found != values.end()) {
+      auto result = values.insert({it, 1});
+      if (!result.second) {
         // already seen
-        TRI_ASSERT((*found).second > 0);
-        ++(found->second);
-      } else {
-        values.emplace(it, 1);
+        TRI_ASSERT(result.first->second > 0);
+        ++(result.first->second);
       }
     }
   }
@@ -6304,12 +6302,7 @@ AqlValue Functions::Append(ExpressionContext* expressionContext,
   builder->openArray();
 
   for (auto const& it : VPackArrayIterator(l)) {
-    if (unique) {
-      if (added.find(it) == added.end()) {
-        builder->add(it);
-        added.emplace(it);
-      }
-    } else {
+    if (!unique || added.insert(it).second) {
       builder->add(it);
     }
   }
@@ -6323,12 +6316,7 @@ AqlValue Functions::Append(ExpressionContext* expressionContext,
     }
   } else {
     for (auto const& it : VPackArrayIterator(slice)) {
-      if (unique) {
-        if (added.find(it) == added.end()) {
-          builder->add(it);
-          added.emplace(it);
-        }
-      } else {
+      if (!unique || added.insert(it).second) {
         builder->add(it);
       }
     }

--- a/arangod/Aql/IndexBlock.cpp
+++ b/arangod/Aql/IndexBlock.cpp
@@ -613,7 +613,7 @@ std::pair<ExecutionState, std::unique_ptr<AqlItemBlock>> IndexBlock::getSome(
       TRI_ASSERT(_resultInFlight != nullptr);
       if (!_isLastIndex) {
         // insert & check for duplicates in one go
-        if (!_alreadyReturned.emplace(token.id()).second) {
+        if (!_alreadyReturned.insert(token.id()).second) {
           // Document already in list. Skip this
           return;
         }

--- a/arangod/Aql/PlanCache.cpp
+++ b/arangod/Aql/PlanCache.cpp
@@ -75,16 +75,9 @@ void PlanCache::store(
   auto entry = std::make_unique<PlanCacheEntry>(queryString.extract(SIZE_MAX), plan->toVelocyPack(plan->getAst(), true)); 
 
   WRITE_LOCKER(writeLocker, _lock);
-
-  auto it = _plans.find(vocbase);
-
-  if (it == _plans.end()) {
-    // create entry for the current database
-    it = _plans.emplace(vocbase, std::unordered_map<uint64_t, std::shared_ptr<PlanCacheEntry>>()).first;
-  }
-
+  
   // store cache entry
-  (*it).second.emplace(hash, std::move(entry));
+  _plans[vocbase].insert({hash, std::move(entry)});
 }
 
 /// @brief invalidate all queries for a particular database

--- a/arangod/Aql/QueryList.cpp
+++ b/arangod/Aql/QueryList.cpp
@@ -78,7 +78,7 @@ bool QueryList::insert(Query* query) {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
 
-    auto it = _current.emplace(query->id(), query);
+    auto it = _current.insert({query->id(), query});
     if (it.second) {
       return true;
     }

--- a/arangod/Aql/QueryRegistry.cpp
+++ b/arangod/Aql/QueryRegistry.cpp
@@ -80,22 +80,11 @@ void QueryRegistry::insert(QueryId id, Query* query, double ttl, bool isPrepared
   {
     WRITE_LOCKER(writeLocker, _lock);
 
-    auto m = _queries.find(vocbase.name());
-    if (m == _queries.end()) {
-      m = _queries.emplace(vocbase.name(),
-                           std::unordered_map<QueryId, std::unique_ptr<QueryInfo>>()).first;
-
-      TRI_ASSERT(_queries.find(vocbase.name()) != _queries.end());
-    }
-
-    auto q = m->second.find(id);
-
-    if (q != m->second.end()) {
+    auto result = _queries[vocbase.name()].insert({id, std::move(p)});
+    if (!result.second) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_INTERNAL, "query with given vocbase and id already there");
     }
-
-    m->second.emplace(id, std::move(p));
   }
 }
 

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -1864,14 +1864,13 @@ int fetchEdgesFromEngines(
         continue;
       }
       StringRef idRef(id);
-      auto resE = cache.find(idRef);
-      if (resE == cache.end()) {
+      auto resE = cache.insert({idRef, e});
+      if (resE.second) {
         // This edge is not yet cached.
         allCached = false;
-        cache.emplace(idRef, e);
         result.emplace_back(e);
       } else {
-        result.emplace_back(resE->second);
+        result.emplace_back(resE.first->second);
       }
     }
     if (!allCached) {
@@ -2753,14 +2752,13 @@ int fetchEdgesFromEngines(
         continue;
       }
       StringRef idRef(id);
-      auto resE = cache.find(idRef);
-      if (resE == cache.end()) {
+      auto resE = cache.insert({idRef, e});
+      if (resE.second) {
         // This edge is not yet cached.
         allCached = false;
-        cache.emplace(idRef, e);
         result.emplace_back(e);
       } else {
-        result.emplace_back(resE->second);
+        result.emplace_back(resE.first->second);
       }
     }
     if (!allCached) {

--- a/arangod/GeneralServer/GeneralCommTask.cpp
+++ b/arangod/GeneralServer/GeneralCommTask.cpp
@@ -358,19 +358,17 @@ void GeneralCommTask::executeRequest(
 void GeneralCommTask::setStatistics(uint64_t id, RequestStatistics* stat) {
   MUTEX_LOCKER(locker, _statisticsMutex);
 
-  auto iter = _statisticsMap.find(id);
-
-  if (iter == _statisticsMap.end()) {
-    if (stat != nullptr) {
-      _statisticsMap.emplace(std::make_pair(id, stat));
+  if (stat == nullptr) {
+    auto it = _statisticsMap.find(id);
+    if (it != _statisticsMap.end()) {
+      it->second->release();
+      _statisticsMap.erase(it);
     }
   } else {
-    iter->second->release();
-
-    if (stat != nullptr) {
-      iter->second = stat;
-    } else {
-      _statisticsMap.erase(iter);
+    auto result = _statisticsMap.insert({id, stat});
+    if (!result.second) {
+      result.first->second->release();
+      result.first->second = stat;
     }
   }
 }

--- a/arangod/GeoIndex/Near.cpp
+++ b/arangod/GeoIndex/Near.cpp
@@ -262,12 +262,11 @@ void NearUtils<CMP>::reportFound(LocalDocumentId lid,
   }
 
   if (!_params.pointsOnly) {
-    auto const& it = _seenDocs.find(lid.id());
-    if (it != _seenDocs.end()) {
+    auto result = _seenDocs.insert(lid.id());
+    if (!result.second) {
       _rejection++;
       return;  // ignore repeated documents
     }
-    _seenDocs.emplace(lid.id());
   }
 
   // possibly expensive point rejection, but saves parsing of document

--- a/arangod/Graph/Graph.cpp
+++ b/arangod/Graph/Graph.cpp
@@ -242,12 +242,11 @@ Result Graph::removeOrphanCollection(std::string&& name) {
 }
 
 Result Graph::addOrphanCollection(std::string&& name) {
-  if (_vertexColls.find(name) != _vertexColls.end()) {
+  if (!_vertexColls.insert(name).second) {
     return TRI_ERROR_GRAPH_COLLECTION_USED_IN_EDGE_DEF;
   }
   TRI_ASSERT(_orphanColls.find(name) == _orphanColls.end());
-  _vertexColls.emplace(name);
-  _orphanColls.emplace(std::move(name));
+  _orphanColls.insert(std::move(name));
   return TRI_ERROR_NO_ERROR;
 }
 

--- a/arangod/Graph/GraphCache.cpp
+++ b/arangod/Graph/GraphCache.cpp
@@ -165,7 +165,7 @@ const std::shared_ptr<const Graph> GraphCache::getGraph(
     CacheType::iterator it;
     bool insertSuccess;
     std::tie(it, insertSuccess) =
-        _cache.emplace(name, std::make_pair(now, graph));
+        _cache.insert({name, std::make_pair(now, graph)});
 
     if (!insertSuccess) {
       it->second.first = now;

--- a/arangod/Indexes/SkiplistIndexAttributeMatcher.cpp
+++ b/arangod/Indexes/SkiplistIndexAttributeMatcher.cpp
@@ -109,13 +109,7 @@ bool SkiplistIndexAttributeMatcher::accessFitsIndex(
     
     if (match) {
       // mark ith attribute as being covered
-      auto it = found.find(i);
-      
-      if (it == found.end()) {
-        found.emplace(i, std::vector<arangodb::aql::AstNode const*>{op});
-      } else {
-        (*it).second.emplace_back(op);
-      }
+      found[i].emplace_back(op);
       TRI_IF_FAILURE("PersistentIndex::accessFitsIndex") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }

--- a/arangod/MMFiles/MMFilesCollectorCache.h
+++ b/arangod/MMFiles/MMFilesCollectorCache.h
@@ -87,14 +87,7 @@ struct MMFilesCollectorCache {
   /// @brief return a reference to an existing datafile statistics struct,
   /// create it if it does not exist
   MMFilesDatafileStatisticsContainer& createDfi(TRI_voc_fid_t fid) {
-    auto it = dfi.find(fid);
-
-    if (it != dfi.end()) {
-      return (*it).second;
-    }
-
-    dfi.emplace(fid, MMFilesDatafileStatisticsContainer());
-
+    // implicitly creates the entry if it does not exist yet
     return dfi[fid];
   }
 

--- a/arangod/MMFiles/MMFilesEngine.cpp
+++ b/arangod/MMFiles/MMFilesEngine.cpp
@@ -2264,16 +2264,7 @@ void MMFilesEngine::registerCollectionPath(TRI_voc_tick_t databaseId,
                                            TRI_voc_cid_t id,
                                            std::string const& path) {
   WRITE_LOCKER(locker, _pathsLock);
-
-  auto it = _collectionPaths.find(databaseId);
-
-  if (it == _collectionPaths.end()) {
-    it = _collectionPaths
-             .emplace(databaseId,
-                      std::unordered_map<TRI_voc_cid_t, std::string>())
-             .first;
-  }
-  (*it).second[id] = path;
+  _collectionPaths[databaseId][id] = path;
 }
 
 void MMFilesEngine::unregisterCollectionPath(TRI_voc_tick_t databaseId,
@@ -2294,16 +2285,7 @@ void MMFilesEngine::registerViewPath(TRI_voc_tick_t databaseId,
                                      TRI_voc_cid_t id,
                                      std::string const& path) {
   WRITE_LOCKER(locker, _pathsLock);
-
-  auto it = _viewPaths.find(databaseId);
-
-  if (it == _viewPaths.end()) {
-    it = _viewPaths
-             .emplace(databaseId,
-                      std::unordered_map<TRI_voc_cid_t, std::string>())
-             .first;
-  }
-  (*it).second[id] = path;
+  _viewPaths[databaseId][id] = path;
 }
 
 void MMFilesEngine::saveCollectionInfo(
@@ -2556,16 +2538,7 @@ int MMFilesEngine::insertCompactionBlocker(TRI_vocbase_t* vocbase, double ttl,
 
   {
     WRITE_LOCKER_EVENTUAL(locker, _compactionBlockersLock);
-
-    auto it = _compactionBlockers.find(vocbase);
-
-    if (it == _compactionBlockers.end()) {
-      it =
-          _compactionBlockers.emplace(vocbase, std::vector<CompactionBlocker>())
-              .first;
-    }
-
-    (*it).second.emplace_back(blocker);
+    _compactionBlockers[vocbase].emplace_back(blocker);
   }
 
   id = blocker._id;

--- a/arangod/Pregel/AggregatorHandler.cpp
+++ b/arangod/Pregel/AggregatorHandler.cpp
@@ -49,11 +49,11 @@ IAggregator* AggregatorHandler::getAggregator(AggregatorID const& name) {
   std::unique_ptr<IAggregator> agg(_algorithm->aggregator(name));
   if (agg) {
     WRITE_LOCKER(guard, _lock);
-    if (_values.find(name) == _values.end()) {
-      _values.emplace(name, agg.get());
+    auto result = _values.insert({name, agg.get()});
+    if (result.second) {
       return agg.release();
     }
-    return _values[name];
+    return result.first->second;
   } else {
     return nullptr;
   }

--- a/arangod/Pregel/Algos/SLPA.cpp
+++ b/arangod/Pregel/Algos/SLPA.cpp
@@ -102,11 +102,9 @@ struct SLPAComputation : public VertexComputation<SLPAValue, int8_t, uint64_t> {
     if (messages.size() > 0 && shouldListen) {
       // listen to our neighbours
       uint64_t newCommunity = mostFrequent(messages);
-      auto it = val->memory.find(newCommunity);
-      if (it == val->memory.end()) {
-        val->memory.emplace(newCommunity, 1);
-      } else {
-        it->second++;
+      auto it = val->memory.insert({newCommunity, 1});
+      if (!it.second) {
+        it.first->second++;
       }
       val->numCommunities++;
     }

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1218,13 +1218,7 @@ Result RestReplicationHandler::parseBatch(
 
         // Put into array of all parsed markers:
         allMarkers.add(builder.slice());
-        auto it = latest.find(key);
-        if (it != latest.end()) {
-          // Already found, overwrite:
-          it->second = currentPos;
-        } else {
-          latest.emplace(std::make_pair(key, currentPos));
-        }
+        latest[key] = currentPos;
         ++currentPos;
       }
 


### PR DESCRIPTION
Replace calls to `find` followed by `emplace` with a single `insert` where possible without adding additional overhead. Use `insert` instead of `emplace` in some cases where it is expected that the operation can fail. `insert` is more efficient than `emplace` because `emplace` always has to create the internal node before checking if another entry with the same key already exists.