### PR TITLE
Bugfix 3.4: Defensive code for recent lambda function in Communicator

### DIFF
--- a/lib/SimpleHttpClient/Communicator.cpp
+++ b/lib/SimpleHttpClient/Communicator.cpp
@@ -467,7 +467,10 @@ void Communicator::handleResult(CURL* handle, CURLcode rc) {
   }
 
   if (curlHandle) {
-    rip->_callbacks._scheduleMe([curlHandle, this, handle, rc, rip]
+    // defensive code:  intentionally not passing "this".  There is a
+    //   possibility that Scheduler will execute the code after Communicator
+    //   object destroyed.  use shared_from_this() if ever essential.
+    rip->_callbacks._scheduleMe([curlHandle, handle, rc, rip]
     {// lamda rewrite starts
       double connectTime = 0.0;
       LOG_TOPIC(TRACE, Logger::COMMUNICATION)

--- a/lib/SimpleHttpClient/Communicator.h
+++ b/lib/SimpleHttpClient/Communicator.h
@@ -247,15 +247,17 @@ class Communicator {
   std::vector<RequestInProgress const*> requestsInProgress();
   void createRequestInProgress(NewRequest&& newRequest);
   void handleResult(CURL*, CURLcode);
-  void transformResult(CURL*, HeadersInProgress&&,
-                       std::unique_ptr<basics::StringBuffer>, HttpResponse*);
   /// @brief curl will strip standalone ".". ArangoDB allows using . as a key
   /// so this thing will analyse the url and urlencode any unsafe .'s
   std::string createSafeDottedCurlUrl(std::string const& originalUrl);
 
-  void callErrorFn(RequestInProgress*, int const&, std::unique_ptr<GeneralResponse>);
-  void callErrorFn(Ticket const&, Destination const&, Callbacks const&, int const&, std::unique_ptr<GeneralResponse>);
-  void callSuccessFn(Ticket const&, Destination const&, Callbacks const&, std::unique_ptr<GeneralResponse>);
+  // these function are static because they are called by a lambda function
+  //  that could execute after Communicator object destroyed.
+  static void transformResult(CURL*, HeadersInProgress&&,
+                       std::unique_ptr<basics::StringBuffer>, HttpResponse*);
+  static void callErrorFn(RequestInProgress*, int const&, std::unique_ptr<GeneralResponse>);
+  static void callErrorFn(Ticket const&, Destination const&, Callbacks const&, int const&, std::unique_ptr<GeneralResponse>);
+  static void callSuccessFn(Ticket const&, Destination const&, Callbacks const&, std::unique_ptr<GeneralResponse>);
 
  private:
   static size_t readBody(void*, size_t, size_t, void*);


### PR DESCRIPTION
handleResults() recently changed.  It now creates a lambda function for Scheduler to execute instead of performing the work in-line.  This code defends against the possibility (though not proven to exist) that the lambda function executes after the Communicator object is destroyed.
