### PR TITLE
Bug fix 3.3/calculate js sha1 sum

### DIFF
--- a/Installation/release.sh
+++ b/Installation/release.sh
@@ -50,6 +50,13 @@ else
     exit 1
 fi
 
+if sha1sum --version; then
+    echo "sha1sum found."
+else
+    echo "sha1sum missing from your system"
+    exit 1
+fi
+
 if [ "$#" -lt 1 ];  then
     echo "usage: $0 <major>.<minor>.<revision>"
     exit 1
@@ -126,7 +133,7 @@ if [ ! -d "${ENTERPRISE_SRC_DIR}" ];  then
 fi
 
 if echo "${VERSION}" | grep -q -- '-'; then
-    echo "${VERSION} mustn't contain minuses! "
+    echo "${VERSION} mustn't contain minuses!"
     exit 1
 fi
 
@@ -207,7 +214,14 @@ else
 fi
 (cd enterprise; git checkout master; git fetch --tags; git pull --all; git checkout ${GITARGS})
 
-
+# recalculate SHA1 sum for JS files
+(
+  cd js 
+  rm -rf JS_FILES.txt JS_SHA1SUM.txt
+  find . -type f | sort | xargs sha1sum > JS_FILES.txt
+  sha1sum JS_FILES.txt > JS_SHA1SUM.txt
+  rm -f JS_FILES.txt
+)
 
 VERSION_MAJOR=$(echo "$VERSION" | awk -F. '{print $1}')
 VERSION_MINOR=$(echo "$VERSION" | awk -F. '{print $2}')
@@ -274,6 +288,7 @@ git add -f \
     lib/Basics/voc-errors.h \
     lib/Basics/voc-errors.cpp \
     js/common/bootstrap/errors.js \
+    js/JS_SHA1SUM.txt \
     CMakeLists.txt \
     VERSIONS
 

--- a/Installation/release.sh
+++ b/Installation/release.sh
@@ -215,13 +215,10 @@ fi
 (cd enterprise; git checkout master; git fetch --tags; git pull --all; git checkout ${GITARGS})
 
 # recalculate SHA1 sum for JS files
-(
-  cd js 
-  rm -rf JS_FILES.txt JS_SHA1SUM.txt
-  find . -type f | sort | xargs sha1sum > JS_FILES.txt
-  sha1sum JS_FILES.txt > JS_SHA1SUM.txt
-  rm -f JS_FILES.txt
-)
+rm -f js/JS_FILES.txt js/JS_SHA1SUM.txt
+find js enterprise/js -type f | sort | xargs sha1sum > js/JS_FILES.txt
+sha1sum js/JS_FILES.txt > js/JS_SHA1SUM.txt
+rm -f js/JS_FILES.txt
 
 VERSION_MAJOR=$(echo "$VERSION" | awk -F. '{print $1}')
 VERSION_MINOR=$(echo "$VERSION" | awk -F. '{print $2}')

--- a/cmake/ArangoDBInstall.cmake
+++ b/cmake/ArangoDBInstall.cmake
@@ -84,6 +84,13 @@ install(
   REGEX       "^.*/.bin"                                   EXCLUDE
 )
 
+install(
+  FILES
+    ${ARANGODB_SOURCE_DIR}/js/JS_SHA1SUM.txt
+  DESTINATION
+    ${CMAKE_INSTALL_DATAROOTDIR_ARANGO}/JS_SHA1SUM.txt
+)
+
 if (USE_ENTERPRISE)
   install(
     DIRECTORY   ${PROJECT_SOURCE_DIR}/enterprise/js/server

--- a/cmake/InstallArangoDBJSClient.cmake
+++ b/cmake/InstallArangoDBJSClient.cmake
@@ -18,6 +18,13 @@ install(
     "^.*/client/tests$" EXCLUDE
 )
 
+install(
+  FILES
+    ${ARANGODB_SOURCE_DIR}/js/JS_SHA1SUM.txt
+  DESTINATION
+    ${CMAKE_INSTALL_DATAROOTDIR_ARANGO}/JS_SHA1SUM.txt
+)
+
 if (USE_ENTERPRISE)
   install(
     DIRECTORY

--- a/js/JS_SHA1SUM.txt
+++ b/js/JS_SHA1SUM.txt
@@ -1,0 +1,1 @@
+29a9c6d79b10275ed7ab26281dddbe59decffe76  JS_FILES.txt


### PR DESCRIPTION
this calculates an SHA1 sum over all files in js and enterprise/js.
makes the presence of the `sha1sum` executable a requirement for running the release script.