### PR TITLE
stop printing `connection class corrupted` in arangosh

### DIFF
--- a/js/client/modules/@arangodb/index.js
+++ b/js/client/modules/@arangodb/index.js
@@ -96,7 +96,9 @@ if (typeof internal.arango !== 'undefined') {
       get(target, name) {
         if (!target.hasOwnProperty(name) && target[name] === undefined && typeof name === 'string') {
           // unknown collection, try re-populating the cache
-          db._collections();
+          try {
+            db._collections();
+          } catch (err) {}
         }
         return target[name];
       },


### PR DESCRIPTION
when just starting the arangosh without a connection to a server
and running code such as `require("internal")`, the shell always
printed "connection class corrupted", which is somewhat misleading.
just don't print this error here, as it is useless
