### PR TITLE
opts.repeatTimes incorrect value types corrected

### DIFF
--- a/Documentation/Books/Manual/Foxx/Scripts.md
+++ b/Documentation/Books/Manual/Foxx/Scripts.md
@@ -283,7 +283,7 @@ Returns the job id.
 
     See *script.maxFailures*.
 
-  * **repeatTimes**: `number | Function` (Default: `0`)
+  * **repeatTimes**: `number` (Default: `0`)
 
     If set to a positive number, the job will be repeated this many times (not counting recovery when using *maxFailures*). If set to a negative number or `Infinity`, the job will be repeated indefinitely. If set to `0` the job will not be repeated.
 


### PR DESCRIPTION
repeatTimes can only be a number (or undefined), not a function. Tested it in 3.3.17

Please note that for legal reasons we require you to sign the 
[Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
