### PR TITLE
Bugfix:  backport defensive Communicator change and revert constant change in Scheduler

### DIFF
--- a/arangod/Scheduler/Scheduler.cpp
+++ b/arangod/Scheduler/Scheduler.cpp
@@ -46,7 +46,7 @@ using namespace arangodb::basics;
 using namespace arangodb::rest;
 
 namespace {
-constexpr double MIN_SECONDS = 60.0;
+constexpr double MIN_SECONDS = 30.0;
 }
 
 // -----------------------------------------------------------------------------

--- a/lib/SimpleHttpClient/Communicator.cpp
+++ b/lib/SimpleHttpClient/Communicator.cpp
@@ -470,7 +470,10 @@ void Communicator::handleResult(CURL* handle, CURLcode rc) {
   }
 
   if (curlHandle) {
-    rip->_callbacks._scheduleMe([curlHandle, this, handle, rc, rip]
+    // defensive code:  intentionally not passing "this".  There is a
+    //   possibility that Scheduler will execute the code after Communicator
+    //   object destroyed.  use shared_from_this() if ever essential.
+    rip->_callbacks._scheduleMe([curlHandle, handle, rc, rip]
     {// lamda rewrite starts
       double connectTime = 0.0;
       LOG_TOPIC(TRACE, Logger::COMMUNICATION)
@@ -494,7 +497,7 @@ void Communicator::handleResult(CURL* handle, CURLcode rc) {
       if (5.0 <= namelookup) {
         LOG_TOPIC(WARN, arangodb::Logger::FIXME) << "libcurl DNS lookup took "
                                                  << namelookup << " seconds.  Consider using static IP addresses.";
-      } // if
+      }
 
       switch (rc) {
         case CURLE_OK: {

--- a/lib/SimpleHttpClient/Communicator.h
+++ b/lib/SimpleHttpClient/Communicator.h
@@ -247,15 +247,17 @@ class Communicator {
   std::vector<RequestInProgress const*> requestsInProgress();
   void createRequestInProgress(NewRequest&& newRequest);
   void handleResult(CURL*, CURLcode);
-  void transformResult(CURL*, HeadersInProgress&&,
-                       std::unique_ptr<basics::StringBuffer>, HttpResponse*);
   /// @brief curl will strip standalone ".". ArangoDB allows using . as a key
   /// so this thing will analyse the url and urlencode any unsafe .'s
   std::string createSafeDottedCurlUrl(std::string const& originalUrl);
 
-  void callErrorFn(RequestInProgress*, int const&, std::unique_ptr<GeneralResponse>);
-  void callErrorFn(Ticket const&, Destination const&, Callbacks const&, int const&, std::unique_ptr<GeneralResponse>);
-  void callSuccessFn(Ticket const&, Destination const&, Callbacks const&, std::unique_ptr<GeneralResponse>);
+  // these function are static because they are called by a lambda function
+  //  that could execute after Communicator object destroyed.
+  static void transformResult(CURL*, HeadersInProgress&&,
+                       std::unique_ptr<basics::StringBuffer>, HttpResponse*);
+  static void callErrorFn(RequestInProgress*, int const&, std::unique_ptr<GeneralResponse>);
+  static void callErrorFn(Ticket const&, Destination const&, Callbacks const&, int const&, std::unique_ptr<GeneralResponse>);
+  static void callSuccessFn(Ticket const&, Destination const&, Callbacks const&, std::unique_ptr<GeneralResponse>);
 
  private:
   static size_t readBody(void*, size_t, size_t, void*);


### PR DESCRIPTION
Two PRs from 3.4:

- add defensive coding to Communicator.cpp that removes Communicator object dependency from lambda function sent to Scheduler:  https://github.com/arangodb/arangodb/pull/7144

- revert accidental change to constant in Scheduler.cpp:  https://github.com/arangodb/arangodb/pull/7208