### PR TITLE
Fix Foxx Queues infinite maxFailures

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* fixed Foxx queues not retrying jobs with infinite `maxFailures`
+
 * force connection timeout to be 7 seconds to allow libcurl time to retry lost DNS
   queries.
 

--- a/js/server/modules/@arangodb/foxx/queues/worker.js
+++ b/js/server/modules/@arangodb/foxx/queues/worker.js
@@ -89,12 +89,12 @@ function getBackOffDelay(job) {
 
 exports.work = function (job) {
   var maxFailures = (
-  typeof job.maxFailures === 'number' || job.maxFailures === false
+    typeof job.maxFailures === 'number'
     ? job.maxFailures
     : (
-    typeof job.type.maxFailures === 'number' || job.type.maxFailures === false
+      typeof job.type.maxFailures === 'number'
       ? job.type.maxFailures
-      : false
+      : 0
     )
   );
 
@@ -150,7 +150,7 @@ exports.work = function (job) {
         callback = job.success;
         data.status = 'complete';
         data.runs += 1;
-      } else if (maxFailures === false || job.runFailures > maxFailures) {
+      } else if (maxFailures !== -1 && job.runFailures > maxFailures) {
         // mark failed
         callback = job.failure;
         data.status = 'failed';


### PR DESCRIPTION
This fixes a bug where `maxFailures` would be ignored if set to `-1` or `Infinity` and removes a useless check for `false` (which is not supported by the API).