### PR TITLE
Bug fix/refactor query optimizer

### DIFF
--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -253,7 +253,7 @@ ExecutionPlan::~ExecutionPlan() {
 }
 
 /// @brief create an execution plan from an AST
-ExecutionPlan* ExecutionPlan::instantiateFromAst(Ast* ast) {
+std::unique_ptr<ExecutionPlan> ExecutionPlan::instantiateFromAst(Ast* ast) {
   TRI_ASSERT(ast != nullptr);
 
   auto root = ast->root();
@@ -277,7 +277,7 @@ ExecutionPlan* ExecutionPlan::instantiateFromAst(Ast* ast) {
 
   plan->findVarUsage();
 
-  return plan.release();
+  return plan;
 }
 
 /// @brief whether or not the plan contains at least one node of this type
@@ -2180,8 +2180,8 @@ struct VarUsageFinder final : public WalkerWorker<ExecutionNode> {
   void after(ExecutionNode* en) override final {
     // Add variables set here to _valid:
     for (auto const& v : en->getVariablesSetHere()) {
-      _valid.emplace(v);
-      _varSetBy->emplace(v->id, en);
+      _valid.insert(v);
+      _varSetBy->insert({v->id, en});
     }
 
     en->setVarsValid(_valid);

--- a/arangod/Aql/ExecutionPlan.h
+++ b/arangod/Aql/ExecutionPlan.h
@@ -56,7 +56,7 @@ class ExecutionPlan {
 
  public:
   /// @brief create an execution plan from an AST
-  static ExecutionPlan* instantiateFromAst(Ast*);
+  static std::unique_ptr<ExecutionPlan> instantiateFromAst(Ast*);
 
   /// @brief process the list of collections in a VelocyPack
   static void getCollectionsFromVelocyPack(Ast* ast,

--- a/arangod/Aql/Optimizer.h
+++ b/arangod/Aql/Optimizer.h
@@ -165,8 +165,13 @@ class Optimizer {
   /// @brief current list of plans (while applying optimizer rules)
   PlanList _newPlans;
   
-  // which optimizer rules are disabled?
-  std::unordered_set<int> _disabledIds;
+  struct Rule {
+    OptimizerRule& rule;
+    bool enabled;
+  };
+  
+  /// @brief list of optimizer rules to be applied
+  std::map<int, Rule> _rules;
 
   /// @brief maximal number of plans to produce
   size_t const _maxNumberOfPlans;

--- a/arangod/Aql/Optimizer.h
+++ b/arangod/Aql/Optimizer.h
@@ -57,33 +57,19 @@ class Optimizer {
   /// @brief the following struct keeps a list (deque) of ExecutionPlan*
   /// and has some automatic convenience functions.
   struct PlanList {
-    RollingVector<ExecutionPlan*> list;
-    RollingVector<int> levelDone;
+    using Entry = std::pair<std::unique_ptr<ExecutionPlan>, int>;
+
+    RollingVector<Entry> list;
 
     PlanList() {
       list.reserve(8);
-      levelDone.reserve(8);
     }
 
     /// @brief constructor with a plan
-    PlanList(ExecutionPlan* p, int level) { push_back(p, level); }
+    PlanList(std::unique_ptr<ExecutionPlan> p, int level) { push_back(std::move(p), level); }
 
     /// @brief destructor, deleting contents
-    ~PlanList() {
-      for (auto& p : list) {
-        delete p;
-      }
-    }
-
-    /// @brief check if a plan is contained in the list
-    bool isContained(ExecutionPlan* plan) const {
-      for (auto const& p : list) {
-        if (p == plan) {
-          return true;
-        }
-      }
-      return false;
-    }
+    ~PlanList() = default;
 
     /// @brief get number of plans contained
     size_t size() const { return list.size(); }
@@ -92,55 +78,35 @@ class Optimizer {
     bool empty() const { return list.empty(); }
 
     /// @brief pop the first one
-    ExecutionPlan* pop_front(int& levelDoneOut) {
-      auto p = list.front();
-      levelDoneOut = levelDone.front();
+    Entry pop_front() {
+      auto p = std::move(list.front());
       list.pop_front();
-      levelDone.pop_front();
       return p;
     }
 
     /// @brief push_back
-    void push_back(ExecutionPlan* p, int level) {
-      list.push_back(p);
-      try {
-        levelDone.push_back(level);
-      } catch (...) {
-        list.pop_back();
-        throw;
-      }
+    void push_back(std::unique_ptr<ExecutionPlan> p, int level) {
+      list.push_back({std::move(p), level});
     }
 
-    /// @brief steals all the plans in b and clears b at the same time
-    void steal(PlanList& b) {
-      list = std::move(b.list);
-      levelDone = std::move(b.levelDone);
+    /// @brief swaps the two lists
+    void swap(PlanList& b) {
+      list.swap(b.list);
     }
 
     /// @brief appends all the plans to the target and clears *this at the same
     /// time
     void appendTo(PlanList& target) {
       while (list.size() > 0) {
-        auto p = list.front();
-        int level = levelDone.front();
+        auto p = std::move(list.front());
         list.pop_front();
-        levelDone.pop_front();
-        try {
-          target.push_back(p, level);
-        } catch (...) {
-          delete p;
-          throw;
-        }
+        target.push_back(std::move(p.first), p.second);
       }
     }
 
     /// @brief clear, deletes all plans contained
     void clear() {
-      for (auto& p : list) {
-        delete p;
-      }
       list.clear();
-      levelDone.clear();
     }
   };
 
@@ -160,38 +126,25 @@ class Optimizer {
   /// newly created plans it recalls and will automatically delete them.
   /// If you need to extract the plans from the optimizer use stealBest or
   /// stealPlans.
-  int createPlans(ExecutionPlan* p, QueryOptions const& queryOptions, bool estimateAllPlans);
+  int createPlans(std::unique_ptr<ExecutionPlan> p, QueryOptions const& queryOptions, bool estimateAllPlans);
 
   /// @brief add a plan to the optimizer
   void addPlan(std::unique_ptr<ExecutionPlan>, OptimizerRule const*, bool, int newLevel = 0);
 
   void disableRule(int rule);
 
-  /// @brief getBest, ownership of the plan remains with the optimizer
-  ExecutionPlan* getBest() {
-    if (_plans.empty()) {
-      return nullptr;
-    }
-    return _plans.list.front();
-  }
-
   /// @brief getPlans, ownership of the plans remains with the optimizer
-  RollingVector<ExecutionPlan*>& getPlans() { return _plans.list; }
+  RollingVector<PlanList::Entry>& getPlans() { return _plans.list; }
 
   /// @brief stealBest, ownership of the plan is handed over to the caller,
   /// all other plans are deleted
-  ExecutionPlan* stealBest() {
+  std::unique_ptr<ExecutionPlan> stealBest() {
     if (_plans.empty()) {
       return nullptr;
     }
-    auto res = _plans.list.front();
-    for (size_t i = 1; i < _plans.size(); i++) {
-      delete _plans.list[i];
-    }
+    auto res = std::move(_plans.list.front());
     _plans.list.clear();
-    _plans.levelDone.clear();
-
-    return res;
+    return std::move(res.first);
   }
 
   bool runOnlyRequiredRules(size_t extraPlans) const;
@@ -200,14 +153,6 @@ class Optimizer {
   /// this should be called from rules, it will consider those that the
   /// current rules has already added
   size_t numberOfPlans() { return _plans.size() + _newPlans.size() + 1; }
-
-  /// @brief stealPlans, ownership of the plans is handed over to the caller,
-  /// the optimizer will forget about them!
-  RollingVector<ExecutionPlan*> stealPlans() {
-    RollingVector<ExecutionPlan*> res(std::move(_plans.list));
-    _plans.levelDone.clear();
-    return res;
-  }
 
  public:
   /// @brief optimizer statistics

--- a/lib/Basics/RollingVector.h
+++ b/lib/Basics/RollingVector.h
@@ -110,22 +110,25 @@ class RollingVector {
     _data.push_back(value);
   }
 
+  void push_back(T&& value) {
+    _data.push_back(std::move(value));
+  }
+
   void pop_front() {
     TRI_ASSERT(!empty());
     ++_start;
     if (_start == _data.size()) {
       // use the opportunity to reset the start value
-      _data.clear();
-      _start = 0;
+      clear();
     }
   }
   
   void pop_back() {
     TRI_ASSERT(!empty());
     _data.pop_back();
-    if (_data.empty()) {
+    if (_start == _data.size()) {
       // use the opportunity to reset the start value
-      _start = 0;
+      clear();
     }
   }
 
@@ -144,6 +147,7 @@ class RollingVector {
   }
 
   T& back() {
+    TRI_ASSERT(!empty());
     return _data.back();
   }
 
@@ -164,11 +168,13 @@ class RollingVector {
     _data.shrink_to_fit();
   }
 
+  void swap(RollingVector& other) {
+    std::swap(_data, other._data);
+    std::swap(_start, other._start);
+  }
  private:
   size_t _start;
   std::vector<T> _data;
-
-  static_assert(std::is_trivial<T>::value, "RollingVector is only safe for trivial types");
 };
 
 }

--- a/tests/IResearch/common.cpp
+++ b/tests/IResearch/common.cpp
@@ -258,9 +258,7 @@ std::unique_ptr<arangodb::aql::ExecutionPlan> planFromQuery(
     return nullptr;
   }
 
-  return std::unique_ptr<arangodb::aql::ExecutionPlan>(
-    arangodb::aql::ExecutionPlan::instantiateFromAst(query.ast())
-  );
+  return arangodb::aql::ExecutionPlan::instantiateFromAst(query.ast());
 }
 
 uint64_t getCurrentPlanVersion() {


### PR DESCRIPTION
As part of this PR I removed the limitation that `RollingVector` could only be used with trivial types, since I could not find any reason that justified it (please let me know if you disagree). That allowed me to use unique_ptrs instead of raw pointers for the execution plans.
Profiling runs showed that a highly significant portion of `createPlans` is spent in the lookups in `_disabledIds` - this should be improved by this PR. An even larger portion is spent in `upper_bound` to find the next rule to be applied. I have though about how to improve this as well, but this would require bigger changes so I will tackle this in a separate PR.

http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/1941/