### PR TITLE
Bugfix 3.4: Make ClusterComm start after Scheduler

### DIFF
--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -54,6 +54,7 @@ ClusterFeature::ClusterFeature(application_features::ApplicationServer& server)
     _requestedRole(ServerState::RoleEnum::ROLE_UNDEFINED) {
   setOptional(true);
   startsAfter("DatabasePhase");
+  startsAfter("Scheduler");
 }
 
 ClusterFeature::~ClusterFeature() {


### PR DESCRIPTION
3.4 adds code that pushes ClusterComm response processing into Scheduler tasks.  There have been crashes during shutdown recently.  The logs and such suggest that Scheduler's io_context is destroyed but ClusterComm is sending final messages to it.  This should keep the io_context alive until ClusterComm's responses have completed.