### PR TITLE
Bug fix 3.4:  verify communication thread has fully stopped in ClusterComm

### DIFF
--- a/arangod/Cluster/ClusterComm.h
+++ b/arangod/Cluster/ClusterComm.h
@@ -727,6 +727,7 @@ class ClusterComm {
 
   std::atomic_uint _roundRobin;
   std::vector<ClusterCommThread*> _backgroundThreads;
+  arangodb::basics::ConditionVariable _activeThreadsCondition;
 
   std::shared_ptr<communicator::Communicator> communicator();
 


### PR DESCRIPTION
This change is believed to address the segfault discussed here:

https://github.com/arangodb/release-3.4/issues/127

The original ClusterComm::stopBackgroundThreads() did not actually guarantee that the Communicator object on the background thread had stopped.  This appears to have allowed the background thread to continue posting response tasks to Supervisor after Supervisor was destroyed.  Segfaults happen.

Background thread stopping happens in two steps.  First tell all threads to stop.  This allows parallel shutdown activity.  Second, check each thread to see that it has stopped and wait until it does.