### PR TITLE
Bugfix 3.4:  revert recently added condition variable in ClusterCommThread stop

### DIFF
--- a/arangod/Cluster/ClusterComm.cpp
+++ b/arangod/Cluster/ClusterComm.cpp
@@ -1225,15 +1225,7 @@ void ClusterComm::disable() {
 }
 
 void ClusterComm::scheduleMe(std::function<void()> task) {
-  // Post to Scheduler for async execution, but only if
-  //  not heading into shutdown ... still a race condition
-  if (!application_features::ApplicationServer::isStopping()) {
-    arangodb::SchedulerFeature::SCHEDULER->queue(RequestPriority::HIGH, task);
-  } else {
-    // performance no longer a concern, execute on caller's thread because
-    //  Scheduler's state is uncertain ... Nov 6, 2018 matthewv
-    task();
-  } // else
+  arangodb::SchedulerFeature::SCHEDULER->queue(RequestPriority::HIGH, task);
 }
 
 ClusterCommThread::ClusterCommThread() : Thread("ClusterComm"), _cc(nullptr) {

--- a/arangod/Cluster/ClusterComm.h
+++ b/arangod/Cluster/ClusterComm.h
@@ -727,7 +727,6 @@ class ClusterComm {
 
   std::atomic_uint _roundRobin;
   std::vector<ClusterCommThread*> _backgroundThreads;
-  arangodb::basics::ConditionVariable _activeThreadsCondition;
 
   std::shared_ptr<communicator::Communicator> communicator();
 


### PR DESCRIPTION
Missed in previous PR that ClusterCommThread destructor was calling Thread::shutdown.  The new code created a deadlock waiting for slow STOPPED state.

The actual target bug, segfault during Agency shutdown, is still unresolved.