### PR TITLE
Fix error message when adding link to non-existent collection.

### DIFF
--- a/arangod/IResearch/IResearchLinkHelper.cpp
+++ b/arangod/IResearch/IResearchLinkHelper.cpp
@@ -555,7 +555,7 @@ namespace iresearch {
     if (!collection) {
       return arangodb::Result(
         TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
-        std::string("while validating arangosearch link definition, error: collection '") + collectionName.copyString() + "' not a string"
+        std::string("while validating arangosearch link definition, error: collection '") + collectionName.copyString() + "' not found"
       );
     }
 


### PR DESCRIPTION
Should address https://github.com/arangodb/release-3.4/issues/141.