### PR TITLE
Bugfix 3.4:  Null pointer defense in Scheduler::post(callback)

### DIFF
--- a/arangod/Scheduler/Scheduler.cpp
+++ b/arangod/Scheduler/Scheduler.cpp
@@ -519,6 +519,7 @@ void Scheduler::beginShutdown() {
   }
 
   stopRebalancer();
+#if 0
   _threadManager.reset();
 
   _managerGuard.reset();
@@ -526,7 +527,7 @@ void Scheduler::beginShutdown() {
 
   _serviceGuard.reset();
   _ioContext->stop();
-
+#endif
   // set the flag AFTER stopping the threads
   setStopping();
 }
@@ -554,6 +555,15 @@ void Scheduler::shutdown() {
   // One has to clean up the ioContext here, because there could a lambda
   // in its queue, that requires for it finalization some object (for example vocbase)
   // that would already be destroyed
+  _threadManager.reset();
+
+  _managerGuard.reset();
+  _managerContext->stop();
+
+  _serviceGuard.reset();
+  _ioContext->stop();
+
+
   _managerContext.reset();
   _ioContext.reset();
 }

--- a/arangod/Scheduler/Scheduler.cpp
+++ b/arangod/Scheduler/Scheduler.cpp
@@ -112,7 +112,7 @@ class arangodb::SchedulerThread : public Thread {
     size_t counter = 0;
     bool doDecrement = true;
 
-    while (!_scheduler->isStopping()) {
+    while (!_scheduler->isStopping() || 0 != _scheduler->numQueued()) {
       try {
         _service->run_one();
       } catch (std::exception const& ex) {
@@ -518,8 +518,6 @@ void Scheduler::beginShutdown() {
     return;
   }
 
-  stopRebalancer();
-
 #if 1
   setStopping();
 
@@ -539,6 +537,8 @@ void Scheduler::beginShutdown() {
   }
 
 #endif
+  stopRebalancer();
+
   _threadManager.reset();
 
   _managerGuard.reset();

--- a/arangod/Scheduler/Scheduler.cpp
+++ b/arangod/Scheduler/Scheduler.cpp
@@ -535,7 +535,8 @@ void Scheduler::shutdown() {
   while (true) {
     uint64_t const counters = _counters.load();
 
-    if (numRunning(counters) == 0 && numWorking(counters) == 0) {
+    if (numRunning(counters) == 0 && numWorking(counters) == 0
+        && numQueued(counters) == 0) {
       break;
     }
 

--- a/arangod/Scheduler/Scheduler.cpp
+++ b/arangod/Scheduler/Scheduler.cpp
@@ -232,6 +232,10 @@ void Scheduler::post(std::function<void()> const callback) {
     // no exception happened, cancel guard
     guardQueue.cancel();
   } else {
+    // increase number of working (must precede decQueue() to keep shutdown looping)
+    JobGuard jobGuard(this);
+    jobGuard.work();
+
     // reduce number of queued now
     decQueued();
 

--- a/arangod/Scheduler/Scheduler.cpp
+++ b/arangod/Scheduler/Scheduler.cpp
@@ -526,7 +526,7 @@ void Scheduler::beginShutdown() {
   while (true) {
     uint64_t const counters = _counters.load();
 
-    if (numRunning(counters) == 0 && numWorking(counters) == 0
+    if (/*numRunning(counters) == 0 && */numWorking(counters) == 0
         && numQueued(counters) == 0) {
       break;
     }

--- a/arangod/Scheduler/Scheduler.cpp
+++ b/arangod/Scheduler/Scheduler.cpp
@@ -384,57 +384,67 @@ std::string Scheduler::infoStatus() {
 }
 
 bool Scheduler::canPostDirectly(RequestPriority prio) const noexcept {
-  auto counters = getCounters();
-  auto nrWorking = numWorking(counters);
-  auto nrQueued = numQueued(counters);
+  if (!isStopping()) {
+    auto counters = getCounters();
+    auto nrWorking = numWorking(counters);
+    auto nrQueued = numQueued(counters);
 
-  switch (prio) {
-    case RequestPriority::HIGH:
-      return nrWorking + nrQueued < _maxThreads;
+    switch (prio) {
+      case RequestPriority::HIGH:
+        return nrWorking + nrQueued < _maxThreads;
 
-    // the "/ 2" is an assumption that HIGH is typically responses to our outbound messages
-    //  where MED & LOW are incoming requests.  Keep half the threads processing our work and half their work.
-    case RequestPriority::MED:
-    case RequestPriority::LOW:
-      return nrWorking + nrQueued < _maxThreads / 2;
-  }
+        // the "/ 2" is an assumption that HIGH is typically responses to our outbound messages
+        //  where MED & LOW are incoming requests.  Keep half the threads processing our work and half their work.
+      case RequestPriority::MED:
+      case RequestPriority::LOW:
+        return nrWorking + nrQueued < _maxThreads / 2;
+    }
 
-  return false;
+    return false;
+  } else {
+    // during shutdown, finesse is no longer needed.  post everything.
+    return true;
+  } // else
 }
 
 bool Scheduler::pushToFifo(int64_t fifo, std::function<void()> const& callback) {
   LOG_TOPIC(TRACE, Logger::THREADS) << "Push element on fifo: " << fifo;
   TRI_ASSERT(0 <= fifo && fifo < NUMBER_FIFOS);
 
-  size_t p = static_cast<size_t>(fifo);
-  auto job = std::make_unique<FifoJob>(callback);
+  if (!isStopping()) {
+    size_t p = static_cast<size_t>(fifo);
+    auto job = std::make_unique<FifoJob>(callback);
 
-  try {
-    if (0 < _maxFifoSize[p] && (int64_t)_maxFifoSize[p] <= _fifoSize[p]) {
+    try {
+      if (0 < _maxFifoSize[p] && (int64_t)_maxFifoSize[p] <= _fifoSize[p]) {
+        return false;
+      }
+
+      if (!_fifos[p]->push(job.get())) {
+        return false;
+      }
+
+      job.release();
+      ++_fifoSize[p];
+
+      // then check, otherwise we might miss to wake up a thread
+      auto counters = getCounters();
+      auto nrWorking = numRunning(counters);
+      auto nrQueued = numQueued(counters);
+
+      if (0 == nrWorking + nrQueued) {
+        post([] {
+            LOG_TOPIC(DEBUG, Logger::THREADS) << "Wakeup alarm";
+            /*wakeup call for scheduler thread*/
+          });
+      }
+    } catch (...) {
       return false;
     }
-
-    if (!_fifos[p]->push(job.get())) {
-      return false;
-    }
-
-    job.release();
-    ++_fifoSize[p];
-
-    // then check, otherwise we might miss to wake up a thread
-    auto counters = getCounters();
-    auto nrWorking = numRunning(counters);
-    auto nrQueued = numQueued(counters);
-
-    if (0 == nrWorking + nrQueued) {
-      post([] {
-          LOG_TOPIC(DEBUG, Logger::THREADS) << "Wakeup alarm";
-          /*wakeup call for scheduler thread*/
-      });
-    }
-  } catch (...) {
-    return false;
-  }
+  } else {
+    // hand this directly to post() so it can route it quickly
+    post(callback);
+  } // else
 
   return true;
 }
@@ -518,25 +528,26 @@ void Scheduler::beginShutdown() {
     return;
   }
 
-#if 1
+  // Scheduler::post() assumes atomic _counters is manipulated in a
+  //  sequentially-consistent manner so that state of _ioContext can be implied
+  //  via _counters.
   setStopping();
+
+  // push anything within fifo queues onto context queue
+  drain();
 
   while (true) {
     uint64_t const counters = _counters.load();
 
-    if (/*numRunning(counters) == 0 && */numWorking(counters) == 0
-        && numQueued(counters) == 0) {
+    if (numWorking(counters) == 0 && numQueued(counters) == 0) {
       break;
     }
 
     std::this_thread::yield();
-    // we can be quite generous here with waiting...
-    // as we are in the shutdown already, we do not care if we need to wait
-    // for a bit longer
-    std::this_thread::sleep_for(std::chrono::microseconds(20000));
+    std::this_thread::sleep_for(std::chrono::microseconds(2000));
   }
 
-#endif
+  // shutdown worker threads and control mechanisms
   stopRebalancer();
 
   _threadManager.reset();
@@ -546,17 +557,10 @@ void Scheduler::beginShutdown() {
 
   _serviceGuard.reset();
   _ioContext->stop();
-#if 0
-  // set the flag AFTER stopping the threads
-  setStopping();
-#endif
 }
 
 void Scheduler::shutdown() {
 
-  // Scheduler::post() assumes atomic _counters is manipulated in a
-  //  sequentially-consistent manner so that state of _ioContext can be implied
-  //  via _counters.
   while (true) {
     uint64_t const counters = _counters.load();
 

--- a/arangod/Scheduler/Scheduler.h
+++ b/arangod/Scheduler/Scheduler.h
@@ -105,8 +105,9 @@ class Scheduler {
 
   bool isRunning() const { return numRunning(_counters) > 0; }
   bool isStopping() const noexcept { return (_counters & (1ULL << 63)) != 0; }
+  size_t numQueued() const { return (_counters >> 32) & 0xFFFFULL; }
 
- private:
+private:
   void post(std::function<void()> const callback);
   void drain();
 

--- a/arangod/Scheduler/Scheduler.h
+++ b/arangod/Scheduler/Scheduler.h
@@ -169,6 +169,7 @@ class Scheduler {
   // the highest bytes (AA) are used only to encode a stopping bit. when this
   // bit is set, the scheduler is stopping (or already stopped)
 
+  // warning: _ioContext usage assumes _counters used in sequentially-consistent manner
   std::atomic<uint64_t> _counters;
 
   inline uint64_t getCounters() const noexcept { return _counters; }


### PR DESCRIPTION
A recent bug made a late call to Scheduler::post after the _ioContext had been reset.  The bug has been fixed.  But the bug demonstrated that post() is vulnerable to late calls that might creep into the codebase in the future.

This PR adds a test for NULL within _ioContext upon entry to the post() function.  When seen, the callback occurs immediately using the call's thread ... and logs a warning.  

This does NOT defend against race conditions with _ioContext clearing simultaneously to the post() call and/or clearing during the processing inside the post() function.