### PR TITLE
fix failing non-deterministic query-stream test

### DIFF
--- a/Documentation/Books/Manual/Appendix/JavaScriptModules/Queries.md
+++ b/Documentation/Books/Manual/Appendix/JavaScriptModules/Queries.md
@@ -15,6 +15,7 @@ Properties
     var queries = require("@arangodb/aql/queries");
     queries.properties();
     queries.properties({slowQueryThreshold: 1});
+    queries.properties({slowStreamingQueryThreshold: 1});
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock QUERY_01_properyOfQueries
 

--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures34.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures34.md
@@ -955,6 +955,10 @@ However, streaming cursors are enabled automatically for the following parts of 
 * when exporting data from collections using the arangoexport binary
 * when using `db.<collection>.toArray()` from the Arango shell
 
+Please note that AQL queries consumed in a streaming fashion have their own, adjustable
+"slow query" threshold. That means the "slow query" threshold can be configured seperately for 
+regular queries and streaming queries.
+
 Native implementations
 ----------------------
 

--- a/arangod/RestHandler/RestQueryHandler.cpp
+++ b/arangod/RestHandler/RestQueryHandler.cpp
@@ -85,6 +85,8 @@ bool RestQueryHandler::readQueryProperties() {
   result.add("maxSlowQueries", VPackValue(queryList->maxSlowQueries()));
   result.add("slowQueryThreshold",
               VPackValue(queryList->slowQueryThreshold()));
+  result.add("slowStreamingQueryThreshold",
+              VPackValue(queryList->slowStreamingQueryThreshold()));
   result.add("maxQueryStringLength",
               VPackValue(queryList->maxQueryStringLength()));
   result.close();
@@ -241,6 +243,7 @@ bool RestQueryHandler::replaceProperties() {
   bool trackBindVars = queryList->trackBindVars();
   size_t maxSlowQueries = queryList->maxSlowQueries();
   double slowQueryThreshold = queryList->slowQueryThreshold();
+  double slowStreamingQueryThreshold = queryList->slowStreamingQueryThreshold();
   size_t maxQueryStringLength = queryList->maxQueryStringLength();
 
   VPackSlice attribute;
@@ -268,6 +271,11 @@ bool RestQueryHandler::replaceProperties() {
   if (attribute.isNumber()) {
     slowQueryThreshold = attribute.getNumber<double>();
   }
+  
+  attribute = body.get("slowStreamingQueryThreshold");
+  if (attribute.isNumber()) {
+    slowStreamingQueryThreshold = attribute.getNumber<double>();
+  }
 
   attribute = body.get("maxQueryStringLength");
   if (attribute.isInteger()) {
@@ -279,6 +287,7 @@ bool RestQueryHandler::replaceProperties() {
   queryList->trackBindVars(trackBindVars);
   queryList->maxSlowQueries(maxSlowQueries);
   queryList->slowQueryThreshold(slowQueryThreshold);
+  queryList->slowStreamingQueryThreshold(slowStreamingQueryThreshold);
   queryList->maxQueryStringLength(maxQueryStringLength);
 
   return readQueryProperties();

--- a/arangod/V8Server/v8-vocbase.cpp
+++ b/arangod/V8Server/v8-vocbase.cpp
@@ -919,6 +919,10 @@ static void JS_QueriesPropertiesAql(
       queryList->slowQueryThreshold(TRI_ObjectToDouble(
           obj->Get(TRI_V8_ASCII_STRING(isolate, "slowQueryThreshold"))));
     }
+    if (obj->Has(TRI_V8_ASCII_STRING(isolate, "slowStreamingQueryThreshold"))) {
+      queryList->slowStreamingQueryThreshold(TRI_ObjectToDouble(
+          obj->Get(TRI_V8_ASCII_STRING(isolate, "slowStreamingQueryThreshold"))));
+    }
     if (obj->Has(TRI_V8_ASCII_STRING(isolate, "maxQueryStringLength"))) {
       queryList->maxQueryStringLength(static_cast<size_t>(TRI_ObjectToInt64(
           obj->Get(TRI_V8_ASCII_STRING(isolate, "maxQueryStringLength")))));
@@ -940,6 +944,8 @@ static void JS_QueriesPropertiesAql(
                   isolate, static_cast<double>(queryList->maxSlowQueries())));
   result->Set(TRI_V8_ASCII_STRING(isolate, "slowQueryThreshold"),
               v8::Number::New(isolate, queryList->slowQueryThreshold()));
+  result->Set(TRI_V8_ASCII_STRING(isolate, "slowStreamingQueryThreshold"),
+              v8::Number::New(isolate, queryList->slowStreamingQueryThreshold()));
   result->Set(TRI_V8_ASCII_STRING(isolate, "maxQueryStringLength"),
               v8::Number::New(isolate, static_cast<double>(
                                            queryList->maxQueryStringLength())));

--- a/tests/js/common/shell/shell-query-stream-timecritical-spec.js
+++ b/tests/js/common/shell/shell-query-stream-timecritical-spec.js
@@ -39,6 +39,7 @@ function restoreDefaults (testee) {
     trackBindVars: true,
     maxSlowQueries: 64,
     slowQueryThreshold: 10,
+    slowStreamingQueryThreshold: 10,
     maxQueryStringLength: 8192
   });
 }
@@ -76,6 +77,7 @@ describe('AQL query analyzer', function () {
       trackBindVars: false,
       maxSlowQueries: 42,
       slowQueryThreshold: 2.5,
+      slowStreamingQueryThreshold: 2.5,
       maxQueryStringLength: 117
     });
     expect(testee.properties().enabled).to.be.ok;
@@ -83,6 +85,7 @@ describe('AQL query analyzer', function () {
     expect(testee.properties().trackBindVars).not.to.be.ok;
     expect(testee.properties().maxSlowQueries).to.equal(42);
     expect(testee.properties().slowQueryThreshold).to.equal(2.5);
+    expect(testee.properties().slowStreamingQueryThreshold).to.equal(2.5);
     expect(testee.properties().maxQueryStringLength).to.equal(117);
   });
 
@@ -93,7 +96,8 @@ describe('AQL query analyzer', function () {
       }
       testee.properties({
         enabled: true,
-        slowQueryThreshold: 20
+        slowQueryThreshold: 20,
+        slowStreamingQueryThreshold: 20
       });
       testee.clearSlow();
     });
@@ -199,7 +203,8 @@ describe('AQL query analyzer', function () {
       expect(testee.slow().filter(filterQueries).length).to.equal(0);
 
       testee.properties({
-        slowQueryThreshold: 2
+        slowQueryThreshold: 2,
+        slowStreamingQueryThreshold: 2
       });
 
       sendQuery(1, false);
@@ -218,7 +223,8 @@ describe('AQL query analyzer', function () {
 
     it('should be able to clear the list of slow queries', function () {
       testee.properties({
-        slowQueryThreshold: 2
+        slowQueryThreshold: 2,
+        slowStreamingQueryThreshold: 2
       });
       sendQuery(1, false);
       expect(testee.slow().filter(filterQueries).length).to.equal(1);
@@ -230,6 +236,7 @@ describe('AQL query analyzer', function () {
       const max = 2;
       testee.properties({
         slowQueryThreshold: 2,
+        slowStreamingQueryThreshold: 2,
         maxSlowQueries: max
       });
       sendQuery(3, false);
@@ -242,7 +249,8 @@ describe('AQL query analyzer', function () {
         internal.debugSetFailAt('QueryList::remove');
 
         testee.properties({
-          slowQueryThreshold: 2
+          slowQueryThreshold: 2,
+          slowStreamingQueryThreshold: 2
         });
         sendQuery(3, false);
 
@@ -254,6 +262,7 @@ describe('AQL query analyzer', function () {
     it('should not track slow queries if turned off', function () {
       testee.properties({
         slowQueryThreshold: 2,
+        slowStreamingQueryThreshold: 2,
         trackSlowQueries: false
       });
       sendQuery(1, false);
@@ -264,6 +273,7 @@ describe('AQL query analyzer', function () {
     it('should not track slow queries if turned off but bind vars tracking is on', function () {
       testee.properties({
         slowQueryThreshold: 2,
+        slowStreamingQueryThreshold: 2,
         trackSlowQueries: false,
         trackBindVars: false
       });
@@ -275,6 +285,7 @@ describe('AQL query analyzer', function () {
     it('should track slow queries if only bind vars tracking is turned off', function () {
       testee.properties({
         slowQueryThreshold: 2,
+        slowStreamingQueryThreshold: 2,
         trackSlowQueries: true,
         trackBindVars: false
       });


### PR DESCRIPTION
Seems I broke this test with some prior changes, and this went unnoticed because of the `timecritical` appendix.