### PR TITLE
[3.4] Feature/advertised endpoints modifiable

### DIFF
--- a/arangod/Cluster/RestClusterHandler.cpp
+++ b/arangod/Cluster/RestClusterHandler.cpp
@@ -92,8 +92,7 @@ void RestClusterHandler::handleCommandPutAdvEndpoint() {
   AuthenticationFeature* af = AuthenticationFeature::instance();
   if (af->isEnabled() && !_request->user().empty()) {
     // error forbidden!
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                    "you need admin rights to modify the advertised endpoint");
+    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN);
     return ;
   }
 

--- a/arangod/Cluster/RestClusterHandler.h
+++ b/arangod/Cluster/RestClusterHandler.h
@@ -31,16 +31,21 @@ class RestClusterHandler : public arangodb::RestBaseHandler {
   RestClusterHandler(GeneralRequest*, GeneralResponse*);
 
  public:
-  
+
   virtual char const* name() const override { return "RestClusterHandler"; }
   RequestLane lane() const override final { return RequestLane::CLIENT_FAST; }
   RestStatus execute() override;
 
 private:
-  
-  /// _api/cluster/endpoints
+
+  /// GET _api/cluster/endpoints
   void handleCommandEndpoints();
-  
+
+  // PUT _api/cluster/endpoints
+  void handleCommandPutAdvEndpoint();
+  // GET _api/cluster/advertised-endpoint
+  void handleCommandGetAdvEndpoint();
+
   /// _api/cluster/serverInfo
   void handleCommandServerInfo();
 

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -482,16 +482,16 @@ static constexpr char const* currentServersRegisteredPref = "/Current/ServersReg
 /// @brief check equality of engines with other registered servers
 bool ServerState::checkEngineEquality(AgencyComm& comm) {
   std::string engineName = EngineSelectorFeature::engineName();
-  
+
   AgencyCommResult result = comm.getValues(currentServersRegisteredPref);
   if (result.successful()) { // no error if we cannot reach agency directly
-    
+
     auto slicePath = AgencyCommManager::slicePath(currentServersRegisteredPref);
     VPackSlice servers = result.slice()[0].get(slicePath);
     if (!servers.isObject()) {
       return true; // do not do anything harsh here
     }
-    
+
     for (VPackObjectIterator::ObjectPair pair : VPackObjectIterator(servers)) {
       if (pair.value.isObject()) {
         VPackSlice engineStr = pair.value.get("engine");
@@ -501,7 +501,7 @@ bool ServerState::checkEngineEquality(AgencyComm& comm) {
       }
     }
   }
-  
+
   return true;
 }
 
@@ -643,7 +643,7 @@ bool ServerState::registerAtAgencyPhase1(AgencyComm& comm,
 
 bool ServerState::registerAtAgencyPhase2(AgencyComm& comm) {
   TRI_ASSERT(!_id.empty() && !_myEndpoint.empty());
-  
+
   while (!application_features::ApplicationServer::isStopping()) {
     VPackBuilder builder;
     try {
@@ -657,9 +657,9 @@ bool ServerState::registerAtAgencyPhase2(AgencyComm& comm) {
       LOG_TOPIC(FATAL, arangodb::Logger::CLUSTER) << "out of memory";
       FATAL_ERROR_EXIT();
     }
-    
+
     auto result = comm.setValue(currentServersRegisteredPref + _id, builder.slice(), 0.0);
-    
+
     if (result.successful()) {
       return true;
     } else {
@@ -667,10 +667,10 @@ bool ServerState::registerAtAgencyPhase2(AgencyComm& comm) {
       << "failed to register server in agency: http code: "
       << result.httpCode() << ", body: '" << result.body() << "', retrying ...";
     }
-    
+
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
-  
+
   return false;
 }
 
@@ -732,15 +732,6 @@ void ServerState::setShortId(uint32_t id) {
 std::string ServerState::getEndpoint() {
   READ_LOCKER(readLocker, _lock);
   return _myEndpoint;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief get the server advertised endpoint
-////////////////////////////////////////////////////////////////////////////////
-
-std::string ServerState::getAdvertisedEndpoint() {
-  READ_LOCKER(readLocker, _lock);
-  return _advertisedEndpoint;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/arangod/Cluster/ServerState.h
+++ b/arangod/Cluster/ServerState.h
@@ -97,22 +97,22 @@ class ServerState {
 
   /// @brief convert a string representation to a mode
   static Mode stringToMode(std::string const&);
-  
+
   /// @brief atomically load current server mode
   static Mode mode();
-  
+
   /// @brief sets server mode, returns previously held
   /// value (performs atomic read-modify-write operation)
   static  Mode setServerMode(Mode mode);
-  
+
   /// @brief checks maintenance mode
   static bool isMaintenance() {
     return mode() == Mode::MAINTENANCE;
   }
-  
+
   /// @brief should not allow DDL operations / transactions
   static bool readOnly();
-  
+
   /// @brief set server read-only
   static bool setReadOnly(bool ro);
 
@@ -214,9 +214,6 @@ class ServerState {
   /// @brief get the server endpoint
   std::string getEndpoint();
 
-  /// @brief get the server advertised endpoint
-  std::string getAdvertisedEndpoint();
-
   /// @brief find a host identification string
   void findHost(std::string const& fallback);
 
@@ -269,24 +266,24 @@ class ServerState {
 
   /// @brief validate a state transition for a coordinator server
   bool checkCoordinatorState(StateEnum);
-  
+
   /// @brief check equality of engines with other registered servers
   bool checkEngineEquality(AgencyComm&);
 
   /// @brief register at agency, might already be done
   bool registerAtAgencyPhase1(AgencyComm&, const RoleEnum&);
-  
+
   /// @brief write the Current/ServersRegistered entry
   bool registerAtAgencyPhase2(AgencyComm&);
-  
+
   /// @brief register shortname for an id
   bool registerShortName(std::string const& id, const RoleEnum&);
-  
+
 private:
-  
+
   /// @brief server role
   std::atomic<RoleEnum> _role;
-  
+
   /// @brief r/w lock for state
   mutable arangodb::basics::ReadWriteSpinLock _lock;
 


### PR DESCRIPTION
Add a new endpoint `_api/cluster/advertised-endpoint` to modify the coordinator specific advertised endpoint.

- `GET` returns JSON object with `endpoint` set to the coordinator specific advertised endpoint.
- `PUT` expects a JSON object with `endpoint` set to a valid endpoint. Replaces the advertised endpoint of the given coordinator.

http://jenkins01.arangodb.biz:8080/job/arangodb-matrix-pr/2002/

Docs: arangodb/documents#25