### PR TITLE
[3.4] Feature/arangosearch pk endianness (#7306)

### DIFF
--- a/3rdParty/CMakeLists.txt
+++ b/3rdParty/CMakeLists.txt
@@ -164,6 +164,7 @@ if (USE_IRESEARCH)
   set(LZ4_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/lz4")
   set(SNOWBALL_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/snowball")
   set(UNWIND_ROOT "invalid")
+  set(BFD_ROOT "invalid")
 
   if(MSVC)
     set(USE_IQL OFF CACHE BOOL "Use IQL" FORCE) # skip IQL on MSVC until IResearch upstream is updated

--- a/arangod/IResearch/IResearchDocument.h
+++ b/arangod/IResearch/IResearchDocument.h
@@ -60,28 +60,26 @@ NS_END // arangodb
 NS_BEGIN(arangodb)
 NS_BEGIN(iresearch)
 
-// FIXME move constants to proper place
-
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief the delimiter used to separate jSON nesting levels when generating
 ///        flat iResearch field names
 ////////////////////////////////////////////////////////////////////////////////
-char const NESTING_LEVEL_DELIMITER = '.';
+constexpr char const NESTING_LEVEL_DELIMITER = '.';
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief the prefix used to denote start of jSON list offset when generating
 ///        flat iResearch field names
 ////////////////////////////////////////////////////////////////////////////////
-char const NESTING_LIST_OFFSET_PREFIX = '[';
+constexpr char const NESTING_LIST_OFFSET_PREFIX = '[';
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief the suffix used to denote end of jSON list offset when generating
 ///        flat iResearch field names
 ////////////////////////////////////////////////////////////////////////////////
-char const NESTING_LIST_OFFSET_SUFFIX = ']';
+constexpr char const NESTING_LIST_OFFSET_SUFFIX = ']';
 
 struct IResearchViewMeta; // forward declaration
-class DocumentPrimaryKey; // forward declaration
+struct DocumentPrimaryKey; // forward declaration
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief indexed/stored document field adapter for IResearch
@@ -242,45 +240,43 @@ class FieldIterator : public std::iterator<std::forward_iterator_tag, Field cons
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief represents stored primary key of the ArangoDB document
 ////////////////////////////////////////////////////////////////////////////////
-class DocumentPrimaryKey {
- public:
-  static irs::string_ref const& PK(); // stored primary key column
-  static irs::string_ref const& CID(); // stored collection id column
+struct DocumentPrimaryKey : std::pair<TRI_voc_cid_t, TRI_voc_rid_t> {
+  typedef std::pair<TRI_voc_cid_t, TRI_voc_rid_t> type; // underlying PK type
+
+  static irs::string_ref const& PK() noexcept; // stored primary key column
+  static irs::string_ref const& CID() noexcept; // stored collection id column
 
   ////////////////////////////////////////////////////////////////////////////////
-  /// @brief decodes the specified value in a proper way into 'buf'
-  /// @return success
+  /// @brief creates a filter matching 'cid'
   ////////////////////////////////////////////////////////////////////////////////
-  static bool decode(uint64_t& buf, const irs::bytes_ref& value);
+  static irs::filter::ptr filter(TRI_voc_cid_t cid);
 
   ////////////////////////////////////////////////////////////////////////////////
-  /// @brief encodes the specified value in a proper way
-  /// @return retuns corresponding encoded representation
-  /// @note the provided value may be modified
+  /// @brief creates a filter matching 'cid' + 'rid' pair
   ////////////////////////////////////////////////////////////////////////////////
-  static irs::bytes_ref encode(uint64_t& value);
+  static irs::filter::ptr filter(TRI_voc_cid_t cid, TRI_voc_rid_t rid);
 
-  constexpr DocumentPrimaryKey() = default;
+  ////////////////////////////////////////////////////////////////////////////////
+  /// @brief reads and decodes PK from a specified buffer
+  /// @returns 'true' on success, 'false' otherwise
+  /// @note PLEASE NOTE that 'in.c_str()' MUST HAVE alignment >= alignof(uint64_t)
+  ////////////////////////////////////////////////////////////////////////////////
+  static bool read(type& value, irs::bytes_ref const& in) noexcept;
+
+  ////////////////////////////////////////////////////////////////////////////////
+  /// @brief creates PK with properly encoded cid & rid
+  ////////////////////////////////////////////////////////////////////////////////
   DocumentPrimaryKey(TRI_voc_cid_t cid, TRI_voc_rid_t rid) noexcept;
 
-  // returning reference is important
-  // (because of casting to 'irs::bytes_ref')
-  constexpr TRI_voc_cid_t const& cid() const noexcept { return _keys[0]; }
-  constexpr TRI_voc_rid_t const& rid() const noexcept { return _keys[1]; }
-
+  ////////////////////////////////////////////////////////////////////////////////
+  /// @brief coverts a PK to corresponding irs::bytes_ref
+  ////////////////////////////////////////////////////////////////////////////////
   explicit operator irs::bytes_ref() const noexcept {
-    return {
-      reinterpret_cast<irs::byte_type const*>(_keys),
-      sizeof _keys
-    };
+    return irs::bytes_ref(
+      reinterpret_cast<irs::byte_type const*>(this),
+      sizeof(*this)
+    );
   }
-
-  // PLEASE NOTE that 'in.c_str()' MUST HAVE alignment >= alignof(uint64_t)
-  bool read(irs::bytes_ref const& in) noexcept;
-
- private:
-  // FIXME: define storage format (LE or BE)
-  uint64_t _keys[2]{}; // TRI_voc_cid_t + TRI_voc_rid_t
 }; // DocumentPrimaryKey
 
 bool appendKnownCollections(

--- a/arangod/IResearch/IResearchFilterFactory.cpp
+++ b/arangod/IResearch/IResearchFilterFactory.cpp
@@ -2066,24 +2066,6 @@ namespace iresearch {
 // --SECTION--                                      FilerFactory implementation
 // ----------------------------------------------------------------------------
 
-/*static*/ irs::filter::ptr FilterFactory::filter(TRI_voc_cid_t cid) {
-  auto filter = irs::by_term::make();
-
-  // filter matching on cid
-  static_cast<irs::by_term&>(*filter)
-    .field(DocumentPrimaryKey::CID()) // set field
-    .term(DocumentPrimaryKey::encode(cid)); // set value
-
-  return filter;
-}
-
-/*static*/ irs::filter::ptr FilterFactory::filter(
-    TRI_voc_cid_t cid,
-    TRI_voc_rid_t rid
-) {
-  return std::make_unique<PrimaryKeyFilter>(cid, rid);
-}
-
 /*static*/ bool FilterFactory::filter(
     irs::boolean_filter* filter,
     QueryContext const& ctx,

--- a/arangod/IResearch/IResearchFilterFactory.h
+++ b/arangod/IResearch/IResearchFilterFactory.h
@@ -46,13 +46,6 @@ NS_BEGIN(iresearch)
 struct QueryContext;
 
 struct FilterFactory {
-  static irs::filter::ptr filter(TRI_voc_cid_t cid);
-
-  ////////////////////////////////////////////////////////////////////////////////
-  /// @brief create a filter matching 'cid' + 'rid' pair
-  ////////////////////////////////////////////////////////////////////////////////
-  static irs::filter::ptr filter(TRI_voc_cid_t cid, TRI_voc_rid_t rid);
-
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief determine if the 'node' can be converted into an iresearch filter
   ///        if 'filter' != nullptr then also append the iresearch filter there

--- a/arangod/IResearch/IResearchPrimaryKeyFilter.cpp
+++ b/arangod/IResearch/IResearchPrimaryKeyFilter.cpp
@@ -52,8 +52,8 @@ irs::doc_iterator::ptr PrimaryKeyFilter::execute(
 size_t PrimaryKeyFilter::hash() const noexcept {
   size_t seed = 0;
   irs::hash_combine(seed, filter::hash());
-  irs::hash_combine(seed, _pk.cid());
-  irs::hash_combine(seed, _pk.rid());
+  irs::hash_combine(seed, _pk.first);
+  irs::hash_combine(seed, _pk.second);
   return seed;
 }
 
@@ -95,8 +95,8 @@ bool PrimaryKeyFilter::equals(filter const& rhs) const noexcept {
   auto const& trhs = static_cast<PrimaryKeyFilter const&>(rhs);
 
   return filter::equals(rhs)
-    && _pk.cid() == trhs._pk.cid()
-    && _pk.rid() == trhs._pk.rid();
+    && _pk.first == trhs._pk.first
+    && _pk.second == trhs._pk.second;
 }
 
 DEFINE_FILTER_TYPE(PrimaryKeyFilter);

--- a/arangod/IResearch/IResearchPrimaryKeyFilter.h
+++ b/arangod/IResearch/IResearchPrimaryKeyFilter.h
@@ -44,7 +44,8 @@ class PrimaryKeyFilter final
   DECLARE_FILTER_TYPE();
 
   PrimaryKeyFilter(TRI_voc_cid_t cid, TRI_voc_rid_t id) noexcept
-    : irs::filter(PrimaryKeyFilter::type()), _pk(cid, id) {
+    : irs::filter(PrimaryKeyFilter::type()),
+      _pk(cid, id) { // ensure proper endianness
   }
 
 // ----------------------------------------------------------------------------

--- a/arangod/IResearch/IResearchView.cpp
+++ b/arangod/IResearch/IResearchView.cpp
@@ -182,7 +182,7 @@ inline void insertDocument(
   doc.insert(irs::action::index_store, field);
 
   // Indexed: CID
-  Field::setCidValue(field, primaryKey.cid());
+  Field::setCidValue(field, primaryKey.first);
   doc.insert(irs::action::index, field);
 }
 
@@ -1050,7 +1050,7 @@ arangodb::Result IResearchView::drop(
     TRI_voc_cid_t cid,
     bool unlink /*= true*/
 ) {
-  auto filter = iresearch::FilterFactory::filter(cid);
+  auto filter = iresearch::DocumentPrimaryKey::filter(cid);
 
   ReadMutex rmutex(_mutex); // '_meta' and '_storeByTid' can be asynchronously updated
   WriteMutex wmutex(_mutex); // '_meta' and '_storeByTid' can be asynchronously updated

--- a/arangod/IResearch/IResearchViewBlock.cpp
+++ b/arangod/IResearch/IResearchViewBlock.cpp
@@ -52,7 +52,7 @@
 
 namespace {
 
-typedef std::vector<arangodb::iresearch::DocumentPrimaryKey> pks_t;
+typedef std::vector<arangodb::iresearch::DocumentPrimaryKey::type> pks_t;
 
 constexpr size_t const BATCH_SIZE = 1024;
 
@@ -69,7 +69,7 @@ pks_t::iterator readPKs(
   auto end = keys.end();
 
   for (irs::bytes_ref key; begin != end && it.next(); ) {
-    if (values(it.value(), key) && begin->read(key)) {
+    if (values(it.value(), key) && arangodb::iresearch::DocumentPrimaryKey::read(*begin, key)) {
       ++begin;
     }
   }
@@ -219,21 +219,21 @@ void IResearchViewBlockBase::reset() {
 }
 
 bool IResearchViewBlockBase::readDocument(
-    DocumentPrimaryKey const& docPk,
+    DocumentPrimaryKey::type const& docPk,
     IndexIterator::DocumentCallback const& callback
 ) {
   TRI_ASSERT(_trx->state());
 
   // this is necessary for MMFiles
-  _trx->pinData(docPk.cid());
+  _trx->pinData(docPk.first);
 
   // `Methods::documentCollection(TRI_voc_cid_t)` may throw exception
-  auto* collection = _trx->state()->collection(docPk.cid(), arangodb::AccessMode::Type::READ);
+  auto* collection = _trx->state()->collection(docPk.first, arangodb::AccessMode::Type::READ);
 
   if (!collection) {
     LOG_TOPIC(WARN, arangodb::iresearch::TOPIC)
-      << "failed to find collection while reading document from arangosearch view, cid '" << docPk.cid()
-      << "', rid '" << docPk.rid() << "'";
+      << "failed to find collection while reading document from arangosearch view, cid '" << docPk.first
+      << "', rid '" << docPk.second << "'";
 
     return false; // not a valid collection reference
   }
@@ -241,7 +241,7 @@ bool IResearchViewBlockBase::readDocument(
   TRI_ASSERT(collection->collection());
 
   return collection->collection()->readDocumentWithCallback(
-    _trx, arangodb::LocalDocumentId(docPk.rid()), callback
+    _trx, arangodb::LocalDocumentId(docPk.second), callback
   );
 }
 
@@ -252,10 +252,10 @@ bool IResearchViewBlockBase::readDocument(
 ) {
   TRI_ASSERT(pkValues);
 
-  arangodb::iresearch::DocumentPrimaryKey docPk;
+  arangodb::iresearch::DocumentPrimaryKey::type docPk;
   irs::bytes_ref tmpRef;
 
-  if (!pkValues(docId, tmpRef) || !docPk.read(tmpRef)) {
+  if (!pkValues(docId, tmpRef) || !arangodb::iresearch::DocumentPrimaryKey::read(docPk, tmpRef)) {
     LOG_TOPIC(WARN, arangodb::iresearch::TOPIC)
       << "failed to read document primary key while reading document from arangosearch view, doc_id '" << docId << "'";
 
@@ -265,15 +265,15 @@ bool IResearchViewBlockBase::readDocument(
   TRI_ASSERT(_trx->state());
 
   // this is necessary for MMFiles
-  _trx->pinData(docPk.cid());
+  _trx->pinData(docPk.first);
 
   // `Methods::documentCollection(TRI_voc_cid_t)` may throw exception
-  auto* collection = _trx->state()->collection(docPk.cid(), arangodb::AccessMode::Type::READ);
+  auto* collection = _trx->state()->collection(docPk.first, arangodb::AccessMode::Type::READ);
 
   if (!collection) {
     LOG_TOPIC(WARN, arangodb::iresearch::TOPIC)
-      << "failed to find collection while reading document from arangosearch view, cid '" << docPk.cid()
-      << "', rid '" << docPk.rid() << "'";
+      << "failed to find collection while reading document from arangosearch view, cid '" << docPk.first
+      << "', rid '" << docPk.second << "'";
 
     return false; // not a valid collection reference
   }
@@ -281,7 +281,7 @@ bool IResearchViewBlockBase::readDocument(
   TRI_ASSERT(collection->collection());
 
   return collection->collection()->readDocumentWithCallback(
-    _trx, arangodb::LocalDocumentId(docPk.rid()), callback
+    _trx, arangodb::LocalDocumentId(docPk.second), callback
   );
 }
 

--- a/arangod/IResearch/IResearchViewBlock.h
+++ b/arangod/IResearch/IResearchViewBlock.h
@@ -89,7 +89,7 @@ class IResearchViewBlockBase : public aql::ExecutionBlock {
   );
 
   bool readDocument(
-    DocumentPrimaryKey const& key,
+    DocumentPrimaryKey::type const& key,
     IndexIterator::DocumentCallback const& callback
   );
 
@@ -102,7 +102,7 @@ class IResearchViewBlockBase : public aql::ExecutionBlock {
 
   virtual size_t skip(size_t count) = 0;
 
-  std::vector<DocumentPrimaryKey> _keys; // buffer for primary keys
+  std::vector<DocumentPrimaryKey::type> _keys; // buffer for primary keys
   irs::attribute_view _filterCtx; // filter context
   ViewExpressionContext _ctx;
   irs::index_reader const& _reader;


### PR DESCRIPTION
* refactor arangosearch pks

* minor refactoring

* store PK as BigEndian since it leads to more compact index representation

* force iresearch to not to use libbfd

* fix tests

Please note that for legal reasons we require you to sign the 
[Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
