### PR TITLE
Fix pathForTesting -> startupPath

### DIFF
--- a/js/server/tests/shell/shell-foxx-queues.js
+++ b/js/server/tests/shell/shell-foxx-queues.js
@@ -35,7 +35,7 @@ var db = require("internal").db;
 var queues = require('@arangodb/foxx/queues');
 var FoxxManager = require('org/arangodb/foxx/manager');
 var fs = require('fs');
-var basePath = fs.makeAbsolute(fs.join(internal.pathForTesting('common'), 'test-data', 'apps'));
+var basePath = fs.makeAbsolute(fs.join(internal.startupPath, 'common', 'test-data', 'apps'));
 
 function foxxQueuesSuite () {
   var cn = "UnitTestsFoxx";


### PR DESCRIPTION
This fixes a bug introduced in #7225 due to a bad cherry-pick.