### PR TITLE
[3.3] ActiveFailover Follower DB Not Found bug

### DIFF
--- a/arangod/GeneralServer/GeneralCommTask.cpp
+++ b/arangod/GeneralServer/GeneralCommTask.cpp
@@ -135,11 +135,11 @@ bool resolveRequestContext(GeneralRequest& req) {
   if (!guard) {
     return false;
   }
-  
+
   // the vocbase context is now responsible for releasing the vocbase
   req.setRequestContext(guard.get(), true);
   guard.release();
-  
+
   // the "true" means the request is the owner of the context
   return true;
 }
@@ -150,11 +150,26 @@ bool resolveRequestContext(GeneralRequest& req) {
 GeneralCommTask::RequestFlow GeneralCommTask::prepareExecution(
     GeneralRequest& req) {
   if (!::resolveRequestContext(req)) {
-    addErrorResponse(rest::ResponseCode::NOT_FOUND, req.contentTypeResponse(),
-                     req.messageId(), TRI_ERROR_ARANGO_DATABASE_NOT_FOUND,
-                     TRI_errno_string(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND));
 
-    return RequestFlow::Abort;
+    // BUG FIX - do not answer with DATABASE_NOT_FOUND, when follower in active failover
+    auto mode = ServerState::serverMode();
+    switch (mode) {
+      case ServerState::Mode::REDIRECT:
+        addErrorResponse(rest::ResponseCode::SERVICE_UNAVAILABLE, req.contentTypeResponse(),
+                     req.messageId(), TRI_ERROR_CLUSTER_NOT_LEADER,
+                     TRI_errno_string(TRI_ERROR_CLUSTER_NOT_LEADER));
+        return RequestFlow::Abort;
+      case ServerState::Mode::TRYAGAIN:
+        addErrorResponse(rest::ResponseCode::SERVICE_UNAVAILABLE, req.contentTypeResponse(),
+                     req.messageId(), TRI_ERROR_CLUSTER_LEADERSHIP_CHALLENGE_ONGOING,
+                     TRI_errno_string(TRI_ERROR_CLUSTER_LEADERSHIP_CHALLENGE_ONGOING));
+        return RequestFlow::Abort;
+      default:
+        addErrorResponse(rest::ResponseCode::NOT_FOUND, req.contentTypeResponse(),
+               req.messageId(), TRI_ERROR_ARANGO_DATABASE_NOT_FOUND,
+               TRI_errno_string(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND));
+        return RequestFlow::Abort;
+    }
   }
   TRI_ASSERT(req.requestContext() != nullptr);
 
@@ -489,7 +504,7 @@ rest::ResponseCode GeneralCommTask::canAccessPath(
     // no authentication required at all
     return rest::ResponseCode::OK;
   }
-    
+
   std::string const& path = request.requestPath();
   std::string const& username = request.user();
 


### PR DESCRIPTION
As follower in an active failover answer a request with not a leader, even if the database does not exist.