### PR TITLE
Explain that <!-- these are HTML comments -->

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,3 +1,7 @@
+<!--
+You may remove points which do not apply, as well as the <!‐‐ examples in HTML comments ‐‐>
+-->
+
 ## My Environment
 
 * __ArangoDB Version__:        <!-- e.g. 3.3.14 or self-compiled devel branch -->


### PR DESCRIPTION
Note: This uses real hyphens for the example inside the actual HTML comment as opposed to the normally used hyphen-minus, which would end it too early (and we can't escape it nicely).

Reason for this addition:
A user filled in text, keeping the angled brackets

`* __Deployment Mode__:       <Single Server>`

This is interpreted as HTML element and will thus not display. I hope the proposed change makes it clearer what this is. Or should we explicitly tell not to write the answers in `<>`?