### PR TITLE
refresh properties after switching back to edit mode

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/viewView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/viewView.js
@@ -67,6 +67,7 @@
                 self.checkIfInProgress();
               }, self.refreshRate);
             } else {
+              self.getViewProperties(true);
               self.setInProgress(false);
             }
           }


### PR DESCRIPTION
finally reload the properties of a view if the view inside the ui is set back to readOnly: false.

