### PR TITLE
ArangoImport Crash

### DIFF
--- a/arangosh/Import/ImportHelper.cpp
+++ b/arangosh/Import/ImportHelper.cpp
@@ -552,7 +552,7 @@ void ImportHelper::addField(char const* field, size_t fieldLength, size_t row,
     _columnNames.push_back(std::move(name));
   }
   // skip removable attributes
-  if (!_removeAttributes.empty() &&
+  if (!_removeAttributes.empty() && column < _columnNames.size() &&
       _removeAttributes.find(_columnNames[column]) != _removeAttributes.end()) {
     return;
   }


### PR DESCRIPTION
Do not access the array of field names to search for removed attributes if the index is out of bounds. (i.e. malformed input data)
