### PR TITLE
[3.4] Reload Foxx routes during startup

### DIFF
--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -686,7 +686,7 @@ void HeartbeatThread::runSingleServer() {
 
         // ensure everyone has server access
         ServerState::instance()->setFoxxmaster(_myId);
-        auto prv = ServerState::instance()->setServerMode(ServerState::Mode::DEFAULT);
+        auto prv = ServerState::setServerMode(ServerState::Mode::DEFAULT);
         if (prv == ServerState::Mode::REDIRECT) {
           LOG_TOPIC(INFO, Logger::HEARTBEAT) << "Successful leadership takeover: "
                                              << "All your base are belong to us";

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -851,7 +851,7 @@ bool ServerState::checkCoordinatorState(StateEnum state) {
   return false;
 }
 
-bool ServerState::isFoxxmaster() {
+bool ServerState::isFoxxmaster() const {
   return /*!isRunningInCluster() ||*/ _foxxmaster == getId();
 }
 
@@ -864,7 +864,9 @@ void ServerState::setFoxxmaster(std::string const& foxxmaster) {
   }
 }
 
-bool ServerState::getFoxxmasterQueueupdate() { return _foxxmasterQueueupdate; }
+bool ServerState::getFoxxmasterQueueupdate() const noexcept {
+  return _foxxmasterQueueupdate;
+}
 
 void ServerState::setFoxxmasterQueueupdate(bool value) {
   _foxxmasterQueueupdate = value;

--- a/arangod/Cluster/ServerState.h
+++ b/arangod/Cluster/ServerState.h
@@ -237,7 +237,7 @@ class ServerState {
   /// @brief sets the JavaScript startup path
   void setJavaScriptPath(std::string const&);
 
-  bool isFoxxmaster();
+  bool isFoxxmaster() const;
 
   std::string const& getFoxxmaster();
 
@@ -245,7 +245,7 @@ class ServerState {
 
   void setFoxxmasterQueueupdate(bool);
 
-  bool getFoxxmasterQueueupdate();
+  bool getFoxxmasterQueueupdate() const noexcept;
 
   std::string getPersistedId();
   bool hasPersistedId();
@@ -278,9 +278,6 @@ class ServerState {
   
   /// @brief write the Current/ServersRegistered entry
   bool registerAtAgencyPhase2(AgencyComm&);
-  
-  /// @brief register shortname for an id
-  bool registerShortName(std::string const& id, const RoleEnum&);
   
 private:
   

--- a/arangod/RestServer/BootstrapFeature.cpp
+++ b/arangod/RestServer/BootstrapFeature.cpp
@@ -320,10 +320,10 @@ void BootstrapFeature::start() {
 
   if (ServerState::isSingleServer(role) && AgencyCommManager::isEnabled()) {
     // simon: this is set to correct value in the heartbeat thread
-    ServerState::instance()->setServerMode(ServerState::Mode::TRYAGAIN);
+    ServerState::setServerMode(ServerState::Mode::TRYAGAIN);
   } else {
     // Start service properly:
-    ServerState::instance()->setServerMode(ServerState::Mode::DEFAULT);
+    ServerState::setServerMode(ServerState::Mode::DEFAULT);
   }
 
   LOG_TOPIC(INFO, arangodb::Logger::FIXME) << "ArangoDB (version " << ARANGODB_VERSION_FULL

--- a/js/server/modules/@arangodb/foxx/manager.js
+++ b/js/server/modules/@arangodb/foxx/manager.js
@@ -309,7 +309,7 @@ function startup () {
   if (global.ArangoServerState.role() === 'SINGLE') {
     commitLocalState(true);
   }
-  selfHealAll(true);
+  selfHealAll();
 }
 
 function upsertSystemServices () {


### PR DESCRIPTION
Fixes an error found with the node resilience tests. There, a coordinator is stopped, a foxx service is changed, then the coordinator is restarted. Sometimes the service isn't immediately available when the coordinator is up.

http://jenkins01.arangodb.biz:8080/job/arangodb-matrix-pr/2304/