### PR TITLE
dont fail when restoring a cluster dump into a single server

### DIFF
--- a/arangod/Indexes/IndexFactory.cpp
+++ b/arangod/Indexes/IndexFactory.cpp
@@ -53,8 +53,13 @@ TRI_idx_iid_t IndexFactory::validateSlice(arangodb::velocypack::Slice info,
 
   if (iid == 0 && !isClusterConstructor) {
     // Restore is not allowed to generate an id
-    TRI_ASSERT(generateKey);
-    iid = arangodb::Index::generateId();
+    VPackSlice type = info.get("type");
+    // dont generate ids for indexes of type "primary"
+    // id 0 is expected for primary indexes
+    if (!type.isString() || !type.isEqualString("primary")) {
+      TRI_ASSERT(generateKey);
+      iid = arangodb::Index::generateId();
+    }
   }
 
   return iid;

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1672,6 +1672,13 @@ Result RestReplicationHandler::processRestoreIndexes(VPackSlice const& collectio
       std::shared_ptr<arangodb::Index> idx;
 
       // {"id":"229907440927234","type":"hash","unique":false,"fields":["x","Y"]}
+      if (idxDef.isObject() && idxDef.get("type").isString()) {
+        VPackSlice type = idxDef.get("type");
+        if (type.isEqualString("primary") || type.isEqualString("edge")) {
+          // don't try to create primary or edge indexes using restore
+          continue;
+        }
+      }
 
       res = physical->restoreIndex(&trx, idxDef, idx);
 


### PR DESCRIPTION
Fixes a problem with trying to restore indexes of type "primary" into a single server from a cluster dump.