### PR TITLE
Doc - Known Issues - Adjust overview page…

### DIFF
--- a/Documentation/Books/Manual/ReleaseNotes/README.md
+++ b/Documentation/Books/Manual/ReleaseNotes/README.md
@@ -76,6 +76,8 @@ Known Issues
 
 For a list of known issues, please refer to one of the following sections:
 
-- [Known Issues in 3.4](KnownIssues34.md)
-- [Known Issues in 3.3](KnownIssues33.md)
-- [Known Issues in 3.2](KnownIssues32.md)
+- Known Issues in 3.x:
+  [3.5](KnownIssues35.md),
+  [3.4](KnownIssues34.md),
+  [3.3](KnownIssues33.md),
+  [3.2](KnownIssues32.md)


### PR DESCRIPTION
...so that the list follows the style of the other ones

---

_Old text:_
Jira Service Desk does not seem to support searching by IDs... Can we make a feature request? Or am I overlooking something? There does not seem to be any other persistent ID to reference a knowledge base article. So not sure how useful it is to have the ID in the link label if you can't really do anything with it.