### PR TITLE
License key documentation in starter.

### DIFF
--- a/Documentation/Books/Manual/Deployment/ActiveFailover/UsingTheStarter.md
+++ b/Documentation/Books/Manual/Deployment/ActiveFailover/UsingTheStarter.md
@@ -68,3 +68,20 @@ The _Starter_ will decide on which 2 machines to run a single server instance.
 To override this decision (only valid while bootstrapping), add a
 `--cluster.start-single=false` to the machine where the single server
 instance should _not_ be started.
+
+If you use an ArangoDB version of 3.4 or above and use the Enterprise
+Edition Docker image, you have to set the license key in an environment
+variable by adding this option to the above `docker` command:
+
+```
+    -e ARANGO_LICENSE_KEY=<thekey>
+```
+
+You can get a free evaluation license key by visiting
+
+     https://www.arangodb.com/download-arangodb-enterprise/
+
+Then replace `<thekey>` above with the actual license key. The start
+will then hand on the license key to the Docker containers it launches
+for ArangoDB.
+

--- a/Documentation/Books/Manual/Deployment/Cluster/UsingTheStarter.md
+++ b/Documentation/Books/Manual/Deployment/Cluster/UsingTheStarter.md
@@ -54,6 +54,22 @@ docker run -it --name=adb --rm -p 8528:8528 \
 
 Run the above command on machine A, B & C.
 
+If you use an ArangoDB version of 3.4 or above and use the Enterprise
+Edition Docker image, you have to set the license key in an environment
+variable by adding this option to the above `docker` command:
+
+```
+    -e ARANGO_LICENSE_KEY=<thekey>
+```
+
+You can get a free evaluation license key by visiting
+
+     https://www.arangodb.com/download-arangodb-enterprise/
+
+Then replace `<thekey>` above with the actual license key. The start
+will then hand on the license key to the Docker containers it launches
+for ArangoDB.
+
 Under the Hood
 --------------
 The first `arangodb` you ran will become the _master_ of your _Starter_

--- a/Documentation/Books/Manual/Deployment/SingleInstance/UsingTheStarter.md
+++ b/Documentation/Books/Manual/Deployment/SingleInstance/UsingTheStarter.md
@@ -31,3 +31,19 @@ docker run -it --name=adb --rm -p 8528:8528 \
     --starter.address=$IP \
     --starter.mode=single 
 ```
+
+If you use an ArangoDB version of 3.4 or above and use the Enterprise
+Edition Docker image, you have to set the license key in an environment
+variable by adding this option to the above `docker` command:
+
+```
+    -e ARANGO_LICENSE_KEY=<thekey>
+```
+
+You can get a free evaluation license key by visiting
+
+     https://www.arangodb.com/download-arangodb-enterprise/
+
+Then replace `<thekey>` above with the actual license key. The start
+will then hand on the license key to the Docker container it launches
+for ArangoDB.


### PR DESCRIPTION
This copies over a last minute change in the starter documentation
to 3.4.

Build:
- http://jenkins01.arangodb.biz:8080/job/arangodb-documentation/164/

Branch in the starter repo (changes needs to be ported there as well, fyi @Simran-B ) https://github.com/arangodb-helper/arangodb/tree/documentation/starter-license-key

Needs to be forward ported to devel