### PR TITLE
Docs: Mention GEO_MULTIPOLYGON() in 3.4 release notes

### DIFF
--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures34.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures34.md
@@ -28,8 +28,8 @@ complex geographical objects. The new implementation is much faster than the pre
 the RocksDB engine.
 
 Additionally, several AQL functions have been added to facilitate working with
-geographical data: `GEO_POINT`, `GEO_MULTIPOINT`, `GEO_POLYGON`, `GEO_LINESTRING` and
-`GEO_MULTILINESTRING`. These functions will produce GeoJSON objects.
+geographical data: `GEO_POINT`, `GEO_MULTIPOINT`, `GEO_LINESTRING`, `GEO_MULTILINESTRING`,
+`GEO_POLYGON` and `GEO_MULTIPOLYGON`. These functions will produce GeoJSON objects.
 
 Additionally there are new geo AQL functions `GEO_CONTAINS`, `GEO_INTERSECTS` and `GEO_EQUALS`
 for querying and comparing GeoJSON objects.


### PR DESCRIPTION
~~Will it be in 3.4.1 or already in 3.4.0? If it's 3.4.1, then we need to point that out somehow...~~

Looks to me like it's in the release though:
- https://github.com/arangodb/arangodb/pull/7634
- https://github.com/arangodb/arangodb/commits/v3.4.0

Also backport this to 3.4 branch.