### PR TITLE
Documentation/deprecate simple all keys

### DIFF
--- a/Documentation/Books/HTTP/Indexes/Fulltext.md
+++ b/Documentation/Books/HTTP/Indexes/Fulltext.md
@@ -2,7 +2,7 @@ Fulltext
 ========
 
 If a [fulltext index](../../Manual/Appendix/Glossary.html#fulltext-index) exists, then
-/_api/simple/fulltext will use this index to execute the specified fulltext query.
+`/_api/simple/fulltext` will use this index to execute the specified fulltext query.
 
 <!-- js/actions/api-index.js -->
 @startDocuBlock post_api_index_fulltext

--- a/Documentation/Books/HTTP/Indexes/Hash.md
+++ b/Documentation/Books/HTTP/Indexes/Hash.md
@@ -1,7 +1,8 @@
 Working with Hash Indexes
 =========================
 
-If a suitable hash index exists, then */_api/simple/by-example* will use this index to execute a query-by-example.
+If a suitable hash index exists, then `/_api/simple/by-example` will use this
+index to execute a query-by-example.
 
 <!-- js/actions/api-index.js -->
 @startDocuBlock post_api_index_hash

--- a/Documentation/Books/HTTP/Indexes/Persistent.md
+++ b/Documentation/Books/HTTP/Indexes/Persistent.md
@@ -1,7 +1,7 @@
 Working with Persistent Indexes
 ===============================
 
-If a suitable persistent index exists, then /_api/simple/range and other operations
+If a suitable persistent index exists, then `/_api/simple/range` and other operations
 will use this index to execute queries.
 
 <!-- js/actions/api-index.js -->

--- a/Documentation/Books/HTTP/Indexes/Skiplist.md
+++ b/Documentation/Books/HTTP/Indexes/Skiplist.md
@@ -1,7 +1,7 @@
 Working with Skiplist Indexes
 =============================
 
-If a suitable skip-list index exists, then /_api/simple/range and other operations
+If a suitable skip-list index exists, then `/_api/simple/range` and other operations
 will use this index to execute queries.
 
 <!-- js/actions/api-index.js -->

--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures26.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures26.md
@@ -3,7 +3,8 @@ Features and Improvements
 
 The following list shows in detail which features have been added or improved in
 ArangoDB 2.6. ArangoDB 2.6 also contains several bugfixes that are not listed
-here. For a list of bugfixes, please consult the [CHANGELOG](https://github.com/arangodb/arangodb/blob/devel/CHANGELOG).
+here. For a list of bugfixes, please consult the
+[CHANGELOG](https://github.com/arangodb/arangodb/blob/devel/CHANGELOG).
 
 APIs added
 ----------
@@ -12,16 +13,16 @@ APIs added
 
 The following commands have been added for `collection` objects:
 
-* collection.lookupByKeys(keys)
-* collection.removeByKeys(keys)
+* `collection.lookupByKeys(keys)`
+* `collection.removeByKeys(keys)`
 
 These commands can be used to perform multi-document lookup and removal operations efficiently
 from the ArangoShell. The argument to these operations is an array of document keys.
 
 These commands can also be used via the HTTP REST API. Their endpoints are:
 
-* PUT /\_api/simple/lookup-by-keys
-* PUT /\_api/simple/remove-by-keys
+* `PUT /_api/simple/lookup-by-keys`
+* `PUT /_api/simple/remove-by-keys`
 
 ### Collection export HTTP REST API
 

--- a/Documentation/Books/Manual/ReleaseNotes/UpgradingChanges26.md
+++ b/Documentation/Books/Manual/ReleaseNotes/UpgradingChanges26.md
@@ -249,19 +249,19 @@ Deprecated server functionality
 
 The following simple query functions are now deprecated:
 
-* collection.near
-* collection.within 
-* collection.geo 
-* collection.fulltext
-* collection.range 
-* collection.closedRange 
+* `collection.near`
+* `collection.within`
+* `collection.geo`
+* `collection.fulltex`
+* `collection.range`
+* `collection.closedRange`
 
 This also lead to the following REST API methods being deprecated from now on:
 
-* PUT /_api/simple/near
-* PUT /_api/simple/within
-* PUT /_api/simple/fulltext
-* PUT /_api/simple/range
+* `PUT /_api/simple/near`
+* `PUT /_api/simple/within`
+* `PUT /_api/simple/fulltext`
+* `PUT /_api/simple/range`
 
 It is recommended to replace calls to these functions or APIs with equivalent AQL queries, 
 which are more flexible because they can be combined with other operations:

--- a/Documentation/Books/Manual/ReleaseNotes/UpgradingChanges26.md
+++ b/Documentation/Books/Manual/ReleaseNotes/UpgradingChanges26.md
@@ -252,7 +252,7 @@ The following simple query functions are now deprecated:
 * `collection.near`
 * `collection.within`
 * `collection.geo`
-* `collection.fulltex`
+* `collection.fulltext`
 * `collection.range`
 * `collection.closedRange`
 

--- a/Documentation/DocuBlocks/Rest/Documents/put_read_all_documents.md
+++ b/Documentation/DocuBlocks/Rest/Documents/put_read_all_documents.md
@@ -41,11 +41,13 @@ not be relied on.
 
 Note: the *all-keys* simple query is **deprecated** as of ArangoDB 3.4.0.
 This API may get removed in future versions of ArangoDB. You can use the
-`/_api/cursor` endpoint instead with a 
+`/_api/cursor` endpoint instead with one of the below AQL queries depending
+on the desired result:
 
-FOR doc IN @@collection RETURN doc._id for type id,
-FOR doc IN @@collection RETURN doc._key for type key,
-FOR doc IN @@collection RETURN CONCAT("/_db/", CURRENT_DATABASE(), "/_api/document/", doc._id) for type path?
+- `FOR doc IN @@collection RETURN doc._id` to mimic *type: id*
+- `FOR doc IN @@collection RETURN doc._key` to mimic *type: key*
+- `FOR doc IN @@collection RETURN CONCAT("/_db/", CURRENT_DATABASE(), "/_api/document/", doc._id)`
+  to mimic *type: path*
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Documents/put_read_all_documents.md
+++ b/Documentation/DocuBlocks/Rest/Documents/put_read_all_documents.md
@@ -4,15 +4,22 @@
 
 @RESTHEADER{PUT /_api/simple/all-keys, Read all documents}
 
+@HINTS
+{% hint 'warning' %}
+This route should no longer be used.
+All endpoints for Simple Queries are deprecated from version 3.4.0 on.
+They are superseded by AQL queries.
+{% endhint %}
+
 @RESTQUERYPARAMETERS
 
 @RESTQUERYPARAM{collection,string,optional}
 The name of the collection.
 **This parameter is only for an easier migration path from old versions.**
-In ArangoDB versions < 3.0, the URL path was */_api/document* and
+In ArangoDB versions < 3.0, the URL path was `/_api/document` and
 this was passed in via the query parameter "collection".
 This combination was removed. The collection name can be passed to
-*/_api/simple/all-keys* as body parameter (preferred) or as query parameter.
+`/_api/simple/all-keys` as body parameter (preferred) or as query parameter.
 
 @RESTBODYPARAM{collection,string,required,}
 The collection that should be queried
@@ -31,6 +38,14 @@ determined by the *type* attribute.
 
 Note that the results have no defined order and thus the order should
 not be relied on.
+
+Note: the *all-keys* simple query is **deprecated** as of ArangoDB 3.4.0.
+This API may get removed in future versions of ArangoDB. You can use the
+`/_api/cursor` endpoint instead with a 
+
+FOR doc IN @@collection RETURN doc._id for type id,
+FOR doc IN @@collection RETURN doc._key for type key,
+FOR doc IN @@collection RETURN CONCAT("/_db/", CURRENT_DATABASE(), "/_api/document/", doc._id) for type path?
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Simple Queries/put_api_simple_all.md
+++ b/Documentation/DocuBlocks/Rest/Simple Queries/put_api_simple_all.md
@@ -33,7 +33,7 @@ as body with the following attributes:
 - *stream*: Create this cursor as a stream query (optional). 
 
 
-Returns a cursor containing the result, see [Http Cursor](../AqlQueryCursor/README.md) for details.
+Returns a cursor containing the result, see [HTTP Cursor](../AqlQueryCursor/README.md) for details.
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Simple Queries/put_api_simple_by_example.md
+++ b/Documentation/DocuBlocks/Rest/Simple Queries/put_api_simple_by_example.md
@@ -41,7 +41,7 @@ not set, a server-controlled default value will be used. A *batchSize* value of
 
 This will find all documents matching a given example.
 
-Returns a cursor containing the result, see [Http Cursor](../AqlQueryCursor/README.md) for details.
+Returns a cursor containing the result, see [HTTP Cursor](../AqlQueryCursor/README.md) for details.
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Simple Queries/put_api_simple_fulltext.md
+++ b/Documentation/DocuBlocks/Rest/Simple Queries/put_api_simple_fulltext.md
@@ -39,7 +39,7 @@ query specified in *query*.
 In order to use the *fulltext* operator, a fulltext index must be defined
 for the collection and the specified attribute.
 
-Returns a cursor containing the result, see [Http Cursor](../AqlQueryCursor/README.md) for details.
+Returns a cursor containing the result, see [HTTP Cursor](../AqlQueryCursor/README.md) for details.
 
 Note: the *fulltext* simple query is **deprecated** as of ArangoDB 2.6. 
 This API may be removed in future versions of ArangoDB. The preferred

--- a/Documentation/DocuBlocks/Rest/Simple Queries/put_api_simple_near.md
+++ b/Documentation/DocuBlocks/Rest/Simple Queries/put_api_simple_near.md
@@ -47,7 +47,7 @@ for the document.  If you have more than one geo-spatial index, you can use
 the *geo* field to select a particular index.
 
 
-Returns a cursor containing the result, see [Http Cursor](../AqlQueryCursor/README.md) for details.
+Returns a cursor containing the result, see [HTTP Cursor](../AqlQueryCursor/README.md) for details.
 
 Note: the *near* simple query is **deprecated** as of ArangoDB 2.6. 
 This API may be removed in future versions of ArangoDB. The preferred

--- a/Documentation/DocuBlocks/Rest/Simple Queries/put_api_simple_range.md
+++ b/Documentation/DocuBlocks/Rest/Simple Queries/put_api_simple_range.md
@@ -39,7 +39,7 @@ is applied before the *limit* restriction. (optional)
 This will find all documents within a given range. In order to execute a
 range query, a skip-list index on the queried attribute must be present.
 
-Returns a cursor containing the result, see [Http Cursor](../AqlQueryCursor/README.md) for details.
+Returns a cursor containing the result, see [HTTP Cursor](../AqlQueryCursor/README.md) for details.
 
 Note: the *range* simple query is **deprecated** as of ArangoDB 2.6. 
 The function may be removed in future versions of ArangoDB. The preferred

--- a/Documentation/DocuBlocks/Rest/Simple Queries/put_api_simple_within.md
+++ b/Documentation/DocuBlocks/Rest/Simple Queries/put_api_simple_within.md
@@ -48,7 +48,7 @@ coordinates for the document.  If you have more than one geo-spatial index,
 you can use the *geo* field to select a particular index.
 
 
-Returns a cursor containing the result, see [Http Cursor](../AqlQueryCursor/README.md) for details.
+Returns a cursor containing the result, see [HTTP Cursor](../AqlQueryCursor/README.md) for details.
 
 Note: the *within* simple query is **deprecated** as of ArangoDB 2.6. 
 This API may be removed in future versions of ArangoDB. The preferred

--- a/Documentation/DocuBlocks/Rest/Simple Queries/put_api_simple_within_rectangle.md
+++ b/Documentation/DocuBlocks/Rest/Simple Queries/put_api_simple_within_rectangle.md
@@ -46,7 +46,7 @@ the collection. This index also defines which attribute holds the
 coordinates for the document.  If you have more than one geo-spatial index,
 you can use the *geo* field to select a particular index.
 
-Returns a cursor containing the result, see [Http Cursor](../AqlQueryCursor/README.md) for details.
+Returns a cursor containing the result, see [HTTP Cursor](../AqlQueryCursor/README.md) for details.
 
 @RESTRETURNCODES
 


### PR DESCRIPTION
Needs to be backported to 3.4!
**//edit:** https://github.com/arangodb/arangodb/pull/7665

Main change:
https://github.com/arangodb/arangodb/compare/documentation/deprecate-simple-all-keys?expand=1#diff-77678f10b2e377308f70bcfe593fbf25

- Test build: http://jenkins01.arangodb.biz:8080/view/Documentation/job/arangodb-documentation/168/
- Preview: http://web01.arangodb.biz/documentation/deprecate-simple-all-keys/HTTP/Document/WorkingWithDocuments.html#read-all-documents
- Internal ref: https://github.com/arangodb/planning/issues/2932#issuecomment-442836329