### PR TITLE
nicer log messages with stringified status value

### DIFF
--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -379,7 +379,7 @@ static arangodb::Result cancelBarrier(
     }
   } else {
     std::string error ("CancelBarrier: failed to send message to leader : status ");
-    error += comres->status;
+    error += ClusterCommResult::stringifyStatus(comres->status);
     LOG_TOPIC(ERR, Logger::MAINTENANCE) << error;
     return arangodb::Result(TRI_ERROR_INTERNAL, error);
   }


### PR DESCRIPTION
instead of
```
2018-12-05T15:43:16Z [14614] P ERROR {maintenance} CancelBarrier: failed to send message to leader : status \x06
```