### PR TITLE
Documentation/cleanups 2018 12 06

### DIFF
--- a/Documentation/Books/Cookbook/Administration/README.md
+++ b/Documentation/Books/Cookbook/Administration/README.md
@@ -7,4 +7,8 @@ Administration
 
 - [Replicating Data](ReplicatingData.md)
 
+- [Installing ArangoDB unattended under Windows](NSISSilentMode.md)
+
 - [Migrating 2.8 to 3.0](Migrate2.8to3.0.md)
+
+- [A function to show grants in Arangosh](ShowUsersGrants.md)

--- a/Documentation/Books/Cookbook/Compiling/README.md
+++ b/Documentation/Books/Cookbook/Compiling/README.md
@@ -9,19 +9,19 @@ You want to modify sources or add your own changes to ArangoDB.
 Solution
 --------
 
-Arangodb, as many other opensource projects nowadays is standing on the shoulder of giants.
+ArangoDB, as many other open source projects nowadays, is standing on the shoulder of giants.
 This gives us a solid foundation to bring you a unique feature set, but it introduces a lot of
-dependencies that need to be in place in order to compile arangodb.
+dependencies that need to be in place in order to compile ArangoDB.
 
 Since build infrastructures are very different depending on the target OS, choose your target
-from the recepies below.
+from the recipes below.
 
 - [Compile on Debian](Debian.md)
 
 - [Compile on Windows](Windows.md)
 
+- [OpenSSL](OpenSSL.md)
+
 - [Running Custom Build](RunningCustomBuild.md)
 
   - [Recompiling jemalloc](jemalloc.md)
-
-  - [OpenSSL 1.1](OpenSSL.md)

--- a/Documentation/Books/Cookbook/SUMMARY.md
+++ b/Documentation/Books/Cookbook/SUMMARY.md
@@ -28,7 +28,7 @@
   * [Replication](Administration/Replication/README.md)
     * [Replicating Data](Administration/ReplicatingData.md)
     * [Slave Initialization](Administration/Replication/ReplicationFromBackup.md)
-  * [Silent NSIS on Windows](Administration/NSISSilentMode.md)
+  * [Silent installation on Windows](Administration/NSISSilentMode.md)
   * [Migrating 2.8 to 3.0](Administration/Migrate2.8to3.0.md)
   * [Show grants function](Administration/ShowUsersGrants.md)
 * [Compiling / Build](Compiling/README.md)

--- a/Documentation/Books/Manual/Architecture/DeploymentModes/SingleInstance/README.md
+++ b/Documentation/Books/Manual/Architecture/DeploymentModes/SingleInstance/README.md
@@ -1,2 +1,20 @@
 Single Instance
 ===============
+
+Running a single instance of ArangoDB is the most simple way to get started.
+It means to run the ArangoDB Server binary `arangod` stand-alone, without
+replication, without failover opportunity and not as cluster together with
+other nodes. It can be sufficient for testing and development, even as portable
+installation, but it is not recommended to run a single instance in production.
+
+You may run multiple processes of `arangod` side-by-side on the same machine as
+single instances, as long as they are configured for different ports and data
+folders. The official installers may not support multiple installations
+side-by-side, but you can get archive packages and unpack them manually.
+
+The provided ArangoDB packages run as single instances out of the box.
+
+See also:
+
+- [Installation](Installation/README.md)
+- [Single Instance Deployment](Deployment/SingleInstance/README.md)

--- a/Documentation/Books/Manual/Deployment/SingleInstance/README.md
+++ b/Documentation/Books/Manual/Deployment/SingleInstance/README.md
@@ -5,12 +5,12 @@ Unlike other setups, like the _Active Failover_, _Cluster_, or _Multiple Datacen
 which require some specific procedure to be started once the ArangoDB package has
 been installed, deploying a single-instance is straightforward.
 
-Depending on your Operating System, after the installation the ArangoDB Server
+Depending on your operating system, after the installation the ArangoDB Server
 might be already up and running. _Start_, _stop_ and _restart_ operations can be
 handled directly using your _System and Service Manager_.
 
 The following are two additional ways that can be used to start the stand-alone
 instance:
 
-1. using the [_ArangoDB Starter_](UsingTheStarter.md), or 
-1. [manually](ManualStart.md).
+1. Using the [_ArangoDB Starter_](UsingTheStarter.md), or 
+2. [manually](ManualStart.md).

--- a/Documentation/Books/Manual/Monitoring/README.md
+++ b/Documentation/Books/Manual/Monitoring/README.md
@@ -1,1 +1,3 @@
 # Monitoring
+
+- [Datacenter to datacenter replication](DC2DC/README.md)

--- a/Documentation/Books/Manual/ReleaseNotes/21.md
+++ b/Documentation/Books/Manual/ReleaseNotes/21.md
@@ -1,2 +1,4 @@
 Version 2.1
 ===========
+
+- [What's New in 2.1](NewFeatures21.md)

--- a/Documentation/Books/Manual/ReleaseNotes/22.md
+++ b/Documentation/Books/Manual/ReleaseNotes/22.md
@@ -1,2 +1,4 @@
 Version 2.2
 ===========
+
+- [What's New in 2.2](NewFeatures22.md)

--- a/Documentation/Books/Manual/ReleaseNotes/23.md
+++ b/Documentation/Books/Manual/ReleaseNotes/23.md
@@ -1,2 +1,5 @@
 Version 2.3
 ===========
+
+- [What's New in 2.3](NewFeatures23.md)
+- [Incompatible changes in 2.3](UpgradingChanges23.md)

--- a/Documentation/Books/Manual/ReleaseNotes/24.md
+++ b/Documentation/Books/Manual/ReleaseNotes/24.md
@@ -1,2 +1,5 @@
 Version 2.4
 ===========
+
+- [What's New in 2.4](NewFeatures24.md)
+- [Incompatible changes in 2.4](UpgradingChanges24.md)

--- a/Documentation/Books/Manual/ReleaseNotes/25.md
+++ b/Documentation/Books/Manual/ReleaseNotes/25.md
@@ -1,2 +1,5 @@
 Version 2.5
 ===========
+
+- [What's New in 2.5](NewFeatures25.md)
+- [Incompatible changes in 2.5](UpgradingChanges25.md)

--- a/Documentation/Books/Manual/ReleaseNotes/26.md
+++ b/Documentation/Books/Manual/ReleaseNotes/26.md
@@ -1,2 +1,5 @@
 Version 2.6
 ===========
+
+- [What's New in 2.6](NewFeatures26.md)
+- [Incompatible changes in 2.6](UpgradingChanges26.md)

--- a/Documentation/Books/Manual/ReleaseNotes/27.md
+++ b/Documentation/Books/Manual/ReleaseNotes/27.md
@@ -1,2 +1,5 @@
 Version 2.7
 ===========
+
+- [What's New in 2.7](NewFeatures27.md)
+- [Incompatible changes in 2.7](UpgradingChanges27.md)

--- a/Documentation/Books/Manual/ReleaseNotes/28.md
+++ b/Documentation/Books/Manual/ReleaseNotes/28.md
@@ -1,2 +1,5 @@
 Version 2.8
 ===========
+
+- [What's New in 2.8](NewFeatures28.md)
+- [Incompatible changes in 2.8](UpgradingChanges28.md)

--- a/Documentation/Books/Manual/ReleaseNotes/30.md
+++ b/Documentation/Books/Manual/ReleaseNotes/30.md
@@ -1,2 +1,5 @@
 Version 3.0
 ===========
+
+- [What's New in 3.0](NewFeatures30.md)
+- [Incompatible changes in 3.0](UpgradingChanges30.md)

--- a/Documentation/Books/Manual/ReleaseNotes/31.md
+++ b/Documentation/Books/Manual/ReleaseNotes/31.md
@@ -1,2 +1,5 @@
 Version 3.1
 ===========
+
+- [What's New in 3.1](NewFeatures31.md)
+- [Incompatible changes in 3.1](UpgradingChanges31.md)

--- a/Documentation/Books/Manual/ReleaseNotes/32.md
+++ b/Documentation/Books/Manual/ReleaseNotes/32.md
@@ -1,2 +1,6 @@
 Version 3.2
 ===========
+
+- [What's New in 3.2](NewFeatures32.md)
+- [Known Issues in 3.2](KnownIssues32.md)
+- [Incompatible changes in 3.2](UpgradingChanges32.md)

--- a/Documentation/Books/Manual/ReleaseNotes/33.md
+++ b/Documentation/Books/Manual/ReleaseNotes/33.md
@@ -1,2 +1,6 @@
 Version 3.3
 ===========
+
+- [What's New in 3.3](NewFeatures33.md)
+- [Known Issues in 3.3](KnownIssues33.md)
+- [Incompatible changes in 3.3](UpgradingChanges33.md)

--- a/Documentation/Books/Manual/ReleaseNotes/34.md
+++ b/Documentation/Books/Manual/ReleaseNotes/34.md
@@ -1,2 +1,6 @@
 Version 3.4
 ===========
+
+- [What's New in 3.4](NewFeatures34.md)
+- [Known Issues in 3.4](KnownIssues34.md)
+- [Incompatible changes in 3.4](UpgradingChanges34.md)

--- a/Documentation/Books/Manual/ReleaseNotes/KnownIssues32.md
+++ b/Documentation/Books/Manual/ReleaseNotes/KnownIssues32.md
@@ -1,5 +1,5 @@
-Known Issues
-============
+Known Issues in ArangoDB 3.2
+============================
 
 The following known issues are present in this version of ArangoDB and will be fixed
 in follow-up releases:

--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures21.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures21.md
@@ -1,5 +1,5 @@
-Features and Improvements
-=========================
+Features and Improvements in ArangoDB 2.1
+=========================================
 
 The following list shows in detail which features have been added or improved in
 ArangoDB 2.1.  ArangoDB 2.1 also contains several bugfixes that are not listed

--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures22.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures22.md
@@ -1,5 +1,5 @@
-Features and Improvements
-=========================
+Features and Improvements in ArangoDB 2.2
+=========================================
 
 The following list shows in detail which features have been added or improved in
 ArangoDB 2.2.  ArangoDB 2.2 also contains several bugfixes that are not listed

--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures23.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures23.md
@@ -1,5 +1,5 @@
-Features and Improvements
-=========================
+Features and Improvements in ArangoDB 2.3
+=========================================
 
 The following list shows in detail which features have been added or improved in
 ArangoDB 2.3. ArangoDB 2.3 also contains several bugfixes that are not listed

--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures24.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures24.md
@@ -1,5 +1,5 @@
-Features and Improvements
-=========================
+Features and Improvements in ArangoDB 2.4
+=========================================
 
 The following list shows in detail which features have been added or improved in
 ArangoDB 2.4. ArangoDB 2.4 also contains several bugfixes that are not listed

--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures25.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures25.md
@@ -1,5 +1,5 @@
-Features and Improvements
-=========================
+Features and Improvements in ArangoDB 2.5
+=========================================
 
 The following list shows in detail which features have been added or improved in
 ArangoDB 2.5. ArangoDB 2.5 also contains several bugfixes that are not listed

--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures26.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures26.md
@@ -1,5 +1,5 @@
-Features and Improvements
-=========================
+Features and Improvements in ArangoDB 2.6
+=========================================
 
 The following list shows in detail which features have been added or improved in
 ArangoDB 2.6. ArangoDB 2.6 also contains several bugfixes that are not listed

--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures27.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures27.md
@@ -1,5 +1,5 @@
-Features and Improvements
-=========================
+Features and Improvements in ArangoDB 2.7
+=========================================
 
 The following list shows in detail which features have been added or improved in
 ArangoDB 2.7. ArangoDB 2.7 also contains several bugfixes that are not listed

--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures28.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures28.md
@@ -1,5 +1,5 @@
-Features and Improvements
-=========================
+Features and Improvements in ArangoDB 2.8
+=========================================
 
 The following list shows in detail which features have been added or improved in
 ArangoDB 2.8. ArangoDB 2.8 also contains several bugfixes that are not listed

--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures30.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures30.md
@@ -1,5 +1,5 @@
-Features and Improvements
-=========================
+Features and Improvements in ArangoDB 3.0
+=========================================
 
 The following list shows in detail which features have been added or improved in
 ArangoDB 3.0. ArangoDB 3.0 also contains several bugfixes that are not listed

--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures31.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures31.md
@@ -1,5 +1,5 @@
-Features and Improvements
-=========================
+Features and Improvements in ArangoDB 3.1
+=========================================
 
 The following list shows in detail which features have been added or improved in
 ArangoDB 3.1. ArangoDB 3.1 also contains several bugfixes that are not listed

--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures32.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures32.md
@@ -1,5 +1,5 @@
-Features and Improvements
-=========================
+Features and Improvements in ArangoDB 3.2
+=========================================
 
 The following list shows in detail which features have been added or improved in
 ArangoDB 3.2. ArangoDB 3.2 also contains several bugfixes that are not listed

--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures33.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures33.md
@@ -1,5 +1,5 @@
-Features and Improvements
-=========================
+Features and Improvements in ArangoDB 3.3
+=========================================
 
 The following list shows in detail which features have been added or improved in
 ArangoDB 3.3. ArangoDB 3.3 also contains several bugfixes that are not listed

--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures34.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures34.md
@@ -1,5 +1,5 @@
-Features and Improvements
-=========================
+Features and Improvements in ArangoDB 3.4
+=========================================
 
 The following list shows in detail which features have been added or improved in
 ArangoDB 3.4. ArangoDB 3.4 also contains several bug fixes that are not listed

--- a/Documentation/Books/Manual/Troubleshooting/README.md
+++ b/Documentation/Books/Manual/Troubleshooting/README.md
@@ -1,2 +1,10 @@
 Troubleshooting
 ===============
+
+- [ArangoDB Server (`arangod`)](Arangod.md)
+
+- [Emergency Console](EmergencyConsole.md)
+
+- [Cluster](Cluster/README.md)
+
+- [Datacenter to datacenter replication](DC2DC/README.md)


### PR DESCRIPTION
- Add content to Architecture Single Instance (to be revised later)
- Add missing links to sub-chapters on a few overview pages
- Make some headlines in ReleaseNotes more precise
- Typos

Review required mainly for content change: https://github.com/arangodb/arangodb/compare/documentation/cleanups-2018-12-06?expand=1#diff-9dafa570a93eb347e72228777cdeff0e