### PR TITLE
Bugfix: port 3.4 change to stopBackgroundThreads.

### DIFF
--- a/arangod/Cluster/ClusterComm.cpp
+++ b/arangod/Cluster/ClusterComm.cpp
@@ -343,8 +343,14 @@ void ClusterComm::startBackgroundThreads() {
 }
 
 void ClusterComm::stopBackgroundThreads() {
+  // pass 1:  tell all background threads to stop
   for (ClusterCommThread * thread: _backgroundThreads) {
     thread->beginShutdown();
+  } // for
+
+  // pass 2:  verify each thread is stopped, wait if necessary
+  //          (happens in destructor)
+  for (ClusterCommThread * thread: _backgroundThreads) {
     delete thread;
   }
 
@@ -801,29 +807,6 @@ void ClusterComm::cleanupAllQueues() {
     receivedByOpID.clear();
     received.clear();
   }
-}
-
-ClusterCommThread::ClusterCommThread() : Thread("ClusterComm"), _cc(nullptr) {
-  _cc = ClusterComm::instance().get();
-  _communicator = std::make_shared<communicator::Communicator>();
-}
-
-ClusterCommThread::~ClusterCommThread() { shutdown(); }
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief begin shutdown sequence
-////////////////////////////////////////////////////////////////////////////////
-
-void ClusterCommThread::beginShutdown() {
-  // Note that this is called from the destructor of the ClusterComm singleton
-  // object. This means that our pointer _cc is still valid and the condition
-  // variable in it is still OK. However, this method is called from a
-  // different thread than the ClusterCommThread. Therefore we can still
-  // use the condition variable to wake up the ClusterCommThread.
-  Thread::beginShutdown();
-
-  CONDITION_LOCKER(guard, _cc->somethingToSend);
-  guard.signal();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1331,6 +1314,29 @@ void ClusterComm::disable() {
 
 void ClusterComm::scheduleMe(std::function<void()> task) {
   arangodb::SchedulerFeature::SCHEDULER->queue(RequestPriority::HIGH, task);
+}
+
+ClusterCommThread::ClusterCommThread() : Thread("ClusterComm"), _cc(nullptr) {
+  _cc = ClusterComm::instance().get();
+  _communicator = std::make_shared<communicator::Communicator>();
+}
+
+ClusterCommThread::~ClusterCommThread() { shutdown(); }
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief begin shutdown sequence
+////////////////////////////////////////////////////////////////////////////////
+
+void ClusterCommThread::beginShutdown() {
+  // Note that this is called from the destructor of the ClusterComm singleton
+  // object. This means that our pointer _cc is still valid and the condition
+  // variable in it is still OK. However, this method is called from a
+  // different thread than the ClusterCommThread. Therefore we can still
+  // use the condition variable to wake up the ClusterCommThread.
+  Thread::beginShutdown();
+
+  CONDITION_LOCKER(guard, _cc->somethingToSend);
+  guard.signal();
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR contains 3.4 PRs #7232 and 7239.  Basically two changes:

1.  This change is believed to address the segfault discussed here:

arangodb/release-3.4#127

The original ClusterComm::stopBackgroundThreads() did not actually guarantee that the Communicator object on the background thread had stopped. This appears to have allowed the background thread to continue posting response tasks to Supervisor after Supervisor was destroyed. Segfaults happen.

Background thread stopping happens in two steps. First tell all threads to stop. This allows parallel shutdown activity. Second, check each thread to see that it has stopped and wait until it does.

2.  Move two ClusterCommThread functions from the middle of the source file to location at end of source file to be next to all other ClusterCommThread functions.