### PR TITLE
Doc: fix build - add missing SUMMARY entries

### DIFF
--- a/Documentation/Books/Manual/SUMMARY.md
+++ b/Documentation/Books/Manual/SUMMARY.md
@@ -372,6 +372,8 @@
 * [Release Notes](ReleaseNotes/README.md)
   * [Version 3.5](ReleaseNotes/35.md)
     * [What's New in 3.5](ReleaseNotes/NewFeatures35.md)
+    * [Known Issues in 3.5](ReleaseNotes/KnownIssues35.md)
+    * [Incompatible changes in 3.5](ReleaseNotes/UpgradingChanges35.md)
   * [Version 3.4](ReleaseNotes/34.md)
     * [What's New in 3.4](ReleaseNotes/NewFeatures34.md)
     * [Known Issues in 3.4](ReleaseNotes/KnownIssues34.md)


### PR DESCRIPTION
The devel documentation build is broken, missing files in SUMMARY.md
see https://github.com/arangodb/arangodb/pull/7686/files
```
not all files of Manual are mapped to the summary!
 files found       |    files in summary
ReleaseNotes/KnownIssues35.md
ReleaseNotes/UpgradingChanges35.md
```
