### PR TITLE
Feature3.4/improve edgeindex covered

### DIFF
--- a/arangod/Aql/IndexNode.cpp
+++ b/arangod/Aql/IndexNode.cpp
@@ -125,7 +125,7 @@ void IndexNode::initIndexCoversProjections() {
   // note that we made sure that if we have multiple index instances, they
   // are actually all of the same index
 
-  auto const& fields = idx->fields();
+  auto const& fields = idx->coveredFields();
 
   if (!idx->hasCoveringIterator()) {
     // index does not have a covering index iterator

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -426,8 +426,6 @@ void Query::prepare(QueryRegistry* registry) {
   TRI_ASSERT(plan != nullptr);
   plan->findVarUsage();
 
-  enterState(QueryExecutionState::ValueType::EXECUTION);
-
   TRI_ASSERT(_engine == nullptr);
   TRI_ASSERT(_trx != nullptr);
   // note that the engine returned here may already be present in our
@@ -443,6 +441,8 @@ void Query::prepare(QueryRegistry* registry) {
   }
 
   _plan = std::move(plan);
+
+  enterState(QueryExecutionState::ValueType::EXECUTION);
 }
 
 /// @brief prepare an AQL query, this is a preparation for execute, but

--- a/arangod/ClusterEngine/ClusterIndex.cpp
+++ b/arangod/ClusterEngine/ClusterIndex.cpp
@@ -64,6 +64,24 @@ ClusterIndex::ClusterIndex(
       _clusterSelectivity(/* default */0.1) {
   TRI_ASSERT(_info.slice().isObject());
   TRI_ASSERT(_info.isClosed());
+
+  // The Edge Index on RocksDB can serve _from and _to when beeing asked.
+  if (_engineType == ClusterEngineType::RocksDBEngine && _indexType == TRI_IDX_TYPE_EDGE_INDEX) {
+    std::string attr = "";
+    TRI_AttributeNamesToString(_fields[0], attr);
+    if (attr == StaticStrings::FromString) {
+      _coveredFields = {
+        {arangodb::basics::AttributeName{StaticStrings::FromString, false}},
+        {arangodb::basics::AttributeName{StaticStrings::ToString, false}}
+      };
+    } else {
+      TRI_ASSERT(attr == StaticStrings::ToString);
+      _coveredFields = {
+        {arangodb::basics::AttributeName{StaticStrings::ToString, false}},
+        {arangodb::basics::AttributeName{StaticStrings::FromString, false}}
+      };
+    }
+  }
 }
 
 ClusterIndex::~ClusterIndex() {}
@@ -390,4 +408,13 @@ aql::AstNode* ClusterIndex::specializeCondition(
   }
   TRI_ASSERT(false);
   return node;
+}
+
+
+std::vector<std::vector<arangodb::basics::AttributeName>> const& ClusterIndex::coveredFields() const {
+  if (_engineType == ClusterEngineType::RocksDBEngine && _indexType == TRI_IDX_TYPE_EDGE_INDEX) {
+    TRI_ASSERT(_coveredFields.size() == 2);
+    return _coveredFields;
+  }
+  return _fields;
 }

--- a/arangod/ClusterEngine/ClusterIndex.h
+++ b/arangod/ClusterEngine/ClusterIndex.h
@@ -115,11 +115,16 @@ class ClusterIndex : public Index {
 
   void updateProperties(velocypack::Slice const&);
 
+  std::vector<std::vector<arangodb::basics::AttributeName>> const& coveredFields() const override;
+
  protected:
   ClusterEngineType _engineType;
   Index::IndexType _indexType;
   velocypack::Builder _info;
   double _clusterSelectivity;
+  
+  // Only used in RocksDB edge index.
+  std::vector<std::vector<arangodb::basics::AttributeName>> _coveredFields;
 };
 }  // namespace arangodb
 

--- a/arangod/Indexes/Index.h
+++ b/arangod/Indexes/Index.h
@@ -117,6 +117,14 @@ class Index {
     return _fields;
   }
 
+  /// @brief return the fields covered by this index.
+  ///        Typically just the fields, but e.g. EdgeIndex on _from also covers _to
+  virtual std::vector<std::vector<arangodb::basics::AttributeName>> const& coveredFields() const {
+    return fields();
+  }
+
+
+
   /// @brief return the index fields names
   inline std::vector<std::vector<std::string>> fieldNames() const {
     std::vector<std::vector<std::string>> result;

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.h
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.h
@@ -61,7 +61,9 @@ class RocksDBEdgeIndexIterator final : public IndexIterator {
   bool nextCovering(DocumentCallback const& cb, size_t limit) override;
   bool nextExtra(ExtraCallback const& cb, size_t limit) override;
   void reset() override;
-  
+
+
+
   /// @brief we provide a method to provide the index attribute values
   /// while scanning the index
   bool hasCovering() const override { return true; }
@@ -138,6 +140,8 @@ class RocksDBEdgeIndex final : public RocksDBIndex {
 
   bool hasSelectivityEstimate() const override { return true; }
 
+  std::vector<std::vector<arangodb::basics::AttributeName>> const& coveredFields() const override;
+
   double selectivityEstimate(arangodb::StringRef const& = arangodb::StringRef()) const override;
 
   RocksDBCuckooIndexEstimator<uint64_t>* estimator() override;
@@ -210,6 +214,10 @@ class RocksDBEdgeIndex final : public RocksDBIndex {
   /// On insertion of a document we have to insert it into the estimator,
   /// On removal we have to remove it in the estimator as well.
   std::unique_ptr<RocksDBCuckooIndexEstimator<uint64_t>> _estimator;
+
+  /// @brief The list of attributes covered by this index.
+  ///        First is the actual index attribute (e.g. _from), second is the opposite (e.g. _to)
+  std::vector<std::vector<arangodb::basics::AttributeName>> const _coveredFields;
 };
 }  // namespace arangodb
 


### PR DESCRIPTION
Ported from devel.
Allow the RocksDB edge index to return the opposite vertex id from the index itself and not extract the document first.