### PR TITLE
suppress a warning message about non-optimal MMFiles collection data …

### DIFF
--- a/arangod/MMFiles/MMFilesCollection.cpp
+++ b/arangod/MMFiles/MMFilesCollection.cpp
@@ -2004,7 +2004,7 @@ int MMFilesCollection::iterateMarkersOnLoad(transaction::Methods* trx) {
   _hasAllPersistentLocalIds.store(openState._hasAllPersistentLocalIds);
   auto engine = static_cast<MMFilesEngine*>(EngineSelectorFeature::ENGINE);
   LOG_TOPIC_IF(WARN, arangodb::Logger::ENGINES,
-               !openState._hasAllPersistentLocalIds && !engine->upgrading())
+               !openState._hasAllPersistentLocalIds && !engine->upgrading() && !engine->inRecovery())
      << "collection '" << _logicalCollection.name() << "' does not have all "
      << "persistent LocalDocumentIds; cannot be linked to an arangosearch view";
 


### PR DESCRIPTION
…structures while doing WAL recovery, not just while upgrading.

otherwise this message may pop up even when starting the server with `--database.auto-upgrade true` before actually starting the upgrade procedure