### PR TITLE
copy enterprise files too when starting with `--javascript.copy-insta…

### DIFF
--- a/lib/Basics/FileResultString.h
+++ b/lib/Basics/FileResultString.h
@@ -28,9 +28,9 @@
 namespace arangodb {
 class FileResultString : public FileResult {
  public:
-  FileResultString(std::string result) : FileResult(), _result(result) {}
+  FileResultString(std::string const& result) : FileResult(), _result(result) {}
 
-  FileResultString(int sysErrorNumber, std::string result)
+  FileResultString(int sysErrorNumber, std::string const& result)
       : FileResult(sysErrorNumber), _result(result) {}
 
   FileResultString(int sysErrorNumber)

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -379,7 +379,7 @@ bool copyDirectoryRecursive(std::string const& source,
     if (isSubDirectory(src)) {
       long systemError;
       int rc = TRI_CreateDirectory(dst.c_str(), systemError, error);
-      if (rc != TRI_ERROR_NO_ERROR) {
+      if (rc != TRI_ERROR_NO_ERROR && rc != TRI_ERROR_FILE_EXISTS) {
         break;
       }
       if (!copyDirectoryRecursive(src, dst, filter, error)) {


### PR DESCRIPTION
…llation`

this is not required for our packages, but it is needed when using `--javascript.copy-installation` with a locally checked out ArangoDB enterprise edition
