### PR TITLE
Documents that arangorestore/arangodump threads option is from v3.4.0 on

### DIFF
--- a/Documentation/Examples/arangodump.json
+++ b/Documentation/Examples/arangodump.json
@@ -551,7 +551,7 @@
   "threads" : {
     "category" : "option",
     "default" : 2,
-    "description" : "maximum number of collections to process in parallel",
+    "description" : "maximum number of collections to process in parallel. From v3.4.0",
     "dynamic" : false,
     "enterpriseOnly" : false,
     "hidden" : false,

--- a/Documentation/Examples/arangorestore.json
+++ b/Documentation/Examples/arangorestore.json
@@ -611,7 +611,7 @@
   "threads" : {
     "category" : "option",
     "default" : 2,
-    "description" : "maximum number of collections to process in parallel",
+    "description" : "maximum number of collections to process in parallel. From v3.4.0",
     "dynamic" : false,
     "enterpriseOnly" : false,
     "hidden" : false,

--- a/arangosh/Dump/DumpFeature.cpp
+++ b/arangosh/Dump/DumpFeature.cpp
@@ -509,7 +509,7 @@ void DumpFeature::collectOptions(std::shared_ptr<options::ProgramOptions> option
                      new UInt64Parameter(&_options.maxChunkSize));
 
   options->addOption("--threads",
-                     "maximum number of collections to process in parallel",
+                     "maximum number of collections to process in parallel. From v3.4.0",
                      new UInt32Parameter(&_options.threadCount));
 
   options->addOption("--dump-data", "dump collection data",

--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -916,7 +916,7 @@ void RestoreFeature::collectOptions(std::shared_ptr<options::ProgramOptions> opt
                      new UInt64Parameter(&_options.chunkSize));
 
   options->addOption("--threads",
-                     "maximum number of collections to process in parallel",
+                     "maximum number of collections to process in parallel. From 3.4.0",
                      new UInt32Parameter(&_options.threadCount));
 
   options->addOption("--include-system-collections",

--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -916,7 +916,7 @@ void RestoreFeature::collectOptions(std::shared_ptr<options::ProgramOptions> opt
                      new UInt64Parameter(&_options.chunkSize));
 
   options->addOption("--threads",
-                     "maximum number of collections to process in parallel. From 3.4.0",
+                     "maximum number of collections to process in parallel. From v3.4.0",
                      new UInt32Parameter(&_options.threadCount));
 
   options->addOption("--include-system-collections",


### PR DESCRIPTION
(same as devel https://github.com/arangodb/arangodb/pull/7701) 