### PR TITLE
3.4.2 changelog - missing entries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,7 +37,32 @@ v3.4.2 (XXXX-XX-XX)
   "mycollection" and "test". 
 
   The `--replication-factor` option works similarly.
+  
+* validate uniqueness of attribute names in AQL in cases in which it was not
+  done before. When constructing AQL objects via object literals, there was
+  no validation about object attribute names being unique. For example, it was
+  possible to create objects with duplicate attribute names as follows:
 
+      INSERT { a: 1, a: 2 } INTO collection
+
+  This resulted in a document having two "a" attributes, which is obviously
+  undesired. Now, when an attribute value is used multiple times, only the first
+  assigned value will be used for that attribute in AQL. It is not possible to 
+  specify the same attribute multiple times and overwrite the attribute's value
+  with by that. That means in the above example, the value of "a" will be 1, 
+  and not 2.
+  This changes the behavior for overriding attribute values in AQL compared to
+  previous versions of ArangoDB, as previous versions in some cases allowed
+  duplicate attribute names in objects/documents (which is undesired) and in
+  other cases used the _last_ value assigned to an attribute instead of the _first_
+  value. In order to explicitly override a value in an existing object, use the
+  AQL MERGE function.
+
+  To avoid all these issues, users are encouraged to use unambiguous attribute 
+  names in objects/documents in AQL. Outside of AQL, specifying the same attribute
+  multiple times may even result in a parse error, e.g. when sending such data
+  to ArangoDB's HTTP REST API.
+  
 * fixed issue #7834: AQL Query crashes instance
 
 * Added --server.jwt-secret-keyfile option.


### PR DESCRIPTION
Jan, I have added a missed entry in the changelog - I took this from 3.3.22

I did not add other 2 entries that you added in 3.3.22 because I am not sure. You added them in PR 7827 (same PR I am taking the entry from), which was done for 3.4 as well

I will leave this to you - please review my commit and consider this additional entries, if appropriate for 3.4.2:

```
* when detecting parse errors in the JSON input sent to the restore API, now
  abort with a proper error containing the problem description instead of aborting
  but hiding there was a problem.

* remove Swagger map files from the build to reduce package sizes 

* do not respond with an internal error in case of JSON parse errors detected
  in incoming HTTP requests 
```

Thanks,