### PR TITLE
Update remark about per-database replication

### DIFF
--- a/Documentation/Books/HTTP/Replications/README.md
+++ b/Documentation/Books/HTTP/Replications/README.md
@@ -16,8 +16,6 @@ The HTTP replication interface serves four main purposes:
 - administer the replication applier (starting, stopping, configuring, querying state) on 
   a slave
 
-Please note that all replication operations work on a per-database level. If an 
-ArangoDB server contains more than one database, the replication system must be
-configured individually per database, and replicating the data of multiple
-databases will require multiple operations.
-
+Please note that if a per-database setup is used (as opposed to server-level replication,
+available since v3.3.0), then the replication system must be configured individually per
+database, and replicating the data of multiple databases will require multiple operations.

--- a/Documentation/Books/Manual/Administration/MasterSlave/ReplicationApplier.md
+++ b/Documentation/Books/Manual/Administration/MasterSlave/ReplicationApplier.md
@@ -7,7 +7,7 @@ Replication configuration
 The replication is turned off by default. In order to create a master-slave setup,
 the so-called _replication applier_ needs to be enabled on the _slave_ databases.
 
-Replication is configured on a per-database level, or, starting from 3.3.0 at server level.
+Replication is configured on a per-database level or (starting from v3.3.0) at server level.
 
 The _replication applier_ on the _slave_ can be used to perform a one-time synchronization
 with the _master_ (and then stop), or to perform an ongoing replication of changes. To
@@ -20,7 +20,7 @@ _setupReplication_ Command
 To copy the initial data from the _master_ to the _slave_ and start the
 continuous replication, there is an all-in-one command *setupReplication*.
 
-From _ArangoSH_:
+From _Arangosh_:
 
 ```js
 require("@arangodb/replication").setupReplication(configuration);
@@ -242,7 +242,7 @@ The initial synchronization for the current database is executed with the *sync*
 require("@arangodb/replication").sync({
   endpoint: "tcp://master.domain.org:8529",
   username: "root",
-  password: "secret,
+  password: "secret",
   includeSystem: true
 });
 ```
@@ -259,7 +259,7 @@ The following command only synchronizes collection *foo* and *bar*:
 require("@arangodb/replication").sync({
   endpoint: "tcp://master.domain.org:8529",
   username: "root",
-  password: "secret,
+  password: "secret",
   restrictType: "include",
   restrictCollections: [ "foo", "bar" ]
 });


### PR DESCRIPTION
There is also a global applier since 3.3.0

Needs to be backported to 3.3 and 3.4 docs.

http://jenkins01.arangodb.biz:8080/view/Documentation/job/arangodb-documentation/238/