### PR TITLE
support db._explain with all plans

### DIFF
--- a/arangod/Indexes/Index.cpp
+++ b/arangod/Indexes/Index.cpp
@@ -51,6 +51,11 @@ using namespace arangodb;
 
 namespace {
 
+/// @brief the _key attribute, which, when used in an index, will implictly make it unique
+/// (note that we must not refer to StaticStrings::KeyString here to avoid an init-order-fiasco
+std::vector<arangodb::basics::AttributeName> const KeyAttribute{
+    arangodb::basics::AttributeName("_key", false)};
+
 bool hasExpansion(std::vector<std::vector<arangodb::basics::AttributeName>> const& fields) {
   for (auto const& it : fields) {
     if (TRI_AttributeNamesHaveExpansion(it)) {
@@ -521,11 +526,30 @@ double Index::selectivityEstimate(StringRef const&) const {
   THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
 }
 
-/// @brief default implementation for implicitlyUnique
+/// @brief whether or not the index is implicitly unique
+/// this can be the case if the index is not declared as unique, but contains a
+/// unique attribute such as _key
 bool Index::implicitlyUnique() const {
-  // simply return whether the index actually is unique
-  // in this base class, we cannot do anything else
-  return _unique;
+  if (_unique) {
+    // a unique index is always unique
+    return true;
+  }
+  if (_useExpansion) {
+    // when an expansion such as a[*] is used, the index may not be unique, even
+    // if it contains attributes that are guaranteed to be unique
+    return false;
+  }
+
+  for (auto const& it : _fields) {
+    // if _key is contained in the index fields definition, then the index is
+    // implicitly unique
+    if (it == KeyAttribute) {
+      return true;
+    }
+  }
+
+  // _key not contained
+  return false;
 }
 
 void Index::batchInsert(transaction::Methods& trx,

--- a/arangod/Indexes/Index.h
+++ b/arangod/Indexes/Index.h
@@ -252,7 +252,7 @@ class Index {
   /// @brief whether or not the index is implicitly unique
   /// this can be the case if the index is not declared as unique,
   /// but contains a unique attribute such as _key
-  virtual bool implicitlyUnique() const;
+  bool implicitlyUnique() const;
 
   virtual size_t memory() const = 0;
 

--- a/arangod/MMFiles/MMFilesPathBasedIndex.cpp
+++ b/arangod/MMFiles/MMFilesPathBasedIndex.cpp
@@ -35,11 +35,6 @@
 
 using namespace arangodb;
 
-/// @brief the _key attribute, which, when used in an index, will implictly make
-/// it unique
-static std::vector<arangodb::basics::AttributeName> const KeyAttribute{
-    arangodb::basics::AttributeName("_key", false)};
-
 /// @brief create the index
 MMFilesPathBasedIndex::MMFilesPathBasedIndex(TRI_idx_iid_t iid,
                                              arangodb::LogicalCollection& collection,
@@ -79,32 +74,6 @@ void MMFilesPathBasedIndex::toVelocyPack(VPackBuilder& builder,
   builder.add(arangodb::StaticStrings::IndexSparse, arangodb::velocypack::Value(_sparse));
   builder.add("deduplicate", VPackValue(_deduplicate));
   builder.close();
-}
-
-/// @brief whether or not the index is implicitly unique
-/// this can be the case if the index is not declared as unique, but contains a
-/// unique attribute such as _key
-bool MMFilesPathBasedIndex::implicitlyUnique() const {
-  if (_unique) {
-    // a unique index is always unique
-    return true;
-  }
-  if (_useExpansion) {
-    // when an expansion such as a[*] is used, the index may not be unique, even
-    // if it contains attributes that are guaranteed to be unique
-    return false;
-  }
-
-  for (auto const& it : _fields) {
-    // if _key is contained in the index fields definition, then the index is
-    // implicitly unique
-    if (it == KeyAttribute) {
-      return true;
-    }
-  }
-
-  // _key not contained
-  return false;
 }
 
 /// @brief helper function to insert a document into any index type

--- a/arangod/MMFiles/MMFilesPathBasedIndex.h
+++ b/arangod/MMFiles/MMFilesPathBasedIndex.h
@@ -58,7 +58,6 @@ class MMFilesPathBasedIndex : public MMFilesIndex {
   /// otherwise the non-negative number is the index of the expanding one.
   std::vector<int> const& expanding() const { return _expanding; }
 
-  bool implicitlyUnique() const override;
   void load() override {}
 
  protected:

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -54,11 +54,6 @@
 
 using namespace arangodb;
 
-/// @brief the _key attribute, which, when used in an index, will implictly make
-/// it unique
-static std::vector<arangodb::basics::AttributeName> const KeyAttribute{
-    arangodb::basics::AttributeName("_key", false)};
-
 // .............................................................................
 // recall for all of the following comparison functions:
 //
@@ -336,32 +331,6 @@ void RocksDBVPackIndex::toVelocyPack(VPackBuilder& builder,
   builder.add(arangodb::StaticStrings::IndexSparse, arangodb::velocypack::Value(_sparse));
   builder.add("deduplicate", VPackValue(_deduplicate));
   builder.close();
-}
-
-/// @brief whether or not the index is implicitly unique
-/// this can be the case if the index is not declared as unique,
-/// but contains a unique attribute such as _key
-bool RocksDBVPackIndex::implicitlyUnique() const {
-  if (_unique) {
-    // a unique index is always unique
-    return true;
-  }
-  if (_useExpansion) {
-    // when an expansion such as a[*] is used, the index may not be unique,
-    // even if it contains attributes that are guaranteed to be unique
-    return false;
-  }
-
-  for (auto const& it : _fields) {
-    // if _key is contained in the index fields definition, then the index is
-    // implicitly unique
-    if (it == KeyAttribute) {
-      return true;
-    }
-  }
-
-  // _key not contained
-  return false;
 }
 
 /// @brief helper function to insert a document into any index type

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.h
@@ -171,8 +171,6 @@ class RocksDBVPackIndex : public RocksDBIndex {
   /// otherwise the non-negative number is the index of the expanding one.
   std::vector<int> const& expanding() const { return _expanding; }
 
-  bool implicitlyUnique() const override;
-
   static constexpr size_t minimalPrefixSize() { return sizeof(TRI_voc_tick_t); }
 
   /// @brief attempts to locate an entry in the index

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -715,7 +715,6 @@ bool transaction::Methods::findIndexHandleForAndNode(
 }
 
 /// @brief Find out if any of the given requests has ended in a refusal
-
 static bool findRefusal(std::vector<ClusterCommRequest> const& requests) {
   for (auto const& it : requests) {
     if (it.done && it.result.status == CL_COMM_RECEIVED &&

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -40,15 +40,15 @@ const anonymize = function(doc) {
   return doc;
 };
 
-var stringBuilder = {
+let stringBuilder = {
   output: '',
+  prefix: '',
 
   appendLine: function (line) {
-    if (!line) {
-      this.output += '\n';
-    } else {
-      this.output += line + '\n';
+    if (line) {
+      this.output += this.prefix + line;
     }
+    this.output += '\n';
   },
 
   getOutput: function () {
@@ -57,6 +57,11 @@ var stringBuilder = {
 
   clearOutput: function () {
     this.output = '';
+  },
+
+  wrap: function (str, width) {
+    let re = '.{1,' + width + '}(\\s|$)|\\S+?(\\s|$)';
+    return str.match(new RegExp(re, 'g')).join('\n' + this.prefix).replace(/\n+/g, '\n ' + this.prefix);
   }
 
 };
@@ -154,12 +159,6 @@ function pad (n) {
   return new Array(n).join(' ');
 }
 
-function wrap (str, width) {
-  'use strict';
-  var re = '.{1,' + width + '}(\\s|$)|\\S+?(\\s|$)';
-  return str.match(new RegExp(re, 'g')).join('\n');
-}
-
 /* print functions */
 
 /* print query string */
@@ -174,7 +173,7 @@ function printQuery (query) {
   } else {
     stringBuilder.appendLine(section('Query String:'));
   }
-  stringBuilder.appendLine(' ' + value(wrap(query, 100).replace(/\n+/g, '\n ', query)));
+  stringBuilder.appendLine(' ' + value(stringBuilder.wrap(query, 100)));
   stringBuilder.appendLine();
 }
 
@@ -605,7 +604,7 @@ function printShortestPathDetails (shortestPaths) {
 }
 
 /* analyze and print execution plan */
-function processQuery (query, explain) {
+function processQuery (query, explain, planIndex) {
   'use strict';
   var nodes = { },
     parents = { },
@@ -617,8 +616,12 @@ function processQuery (query, explain) {
     maxCallsLen = String('Calls').length,
     maxItemsLen = String('Items').length,
     maxRuntimeLen = String('Runtime [s]').length,
-    plan = explain.plan,
     stats = explain.stats;
+    
+  let plan = explain.plan;
+  if (planIndex !== undefined) {
+    plan = explain.plans[planIndex];
+  }
 
   /// mode with actual runtime stats per node
   let profileMode = stats && stats.hasOwnProperty('nodes');
@@ -1601,8 +1604,23 @@ function explain(data, options, shouldPrint) {
 
   stringBuilder.clearOutput();
   let stmt = db._createStatement(data);
-  let result = stmt.explain(options); // TODO why is this there ?
-  processQuery(data.query, result);
+  let result = stmt.explain(options); 
+  if (options.allPlans) {
+    // multiple plans
+    for (let i = 0; i < result.plans.length; ++i) {
+      if (i > 0) {
+        stringBuilder.appendLine();
+      }
+      stringBuilder.appendLine(section("Plan #" + (i + 1) + " (estimated cost: " + result.plans[i].estimatedCost + ")"));
+      stringBuilder.prefix = ' ';
+      stringBuilder.appendLine();
+      processQuery(data.query, result, i);
+      stringBuilder.prefix = '';
+    }
+  } else {
+    // single plan
+    processQuery(data.query, result, undefined);
+  }
 
   if (shouldPrint === undefined || shouldPrint) {
     print(stringBuilder.getOutput());
@@ -1620,13 +1638,14 @@ function profileQuery(data, shouldPrint) {
   }
   let options =  data.options || { };
   options.silent = true;
+  options.allPlans = false; // always turn this off, as it will not work with profiling
   setColors(options.colors === undefined ? true : options.colors);
 
   stringBuilder.clearOutput();
   let stmt = db._createStatement(data);
   let cursor = stmt.execute();
   let extra = cursor.getExtra();
-  processQuery(data.query, extra);
+  processQuery(data.query, extra, undefined);
 
   if (shouldPrint === undefined || shouldPrint) {
     print(stringBuilder.getOutput());


### PR DESCRIPTION
This allows using
```
db._explain(query, bind, { allPlans: true });
```
showing all execution plans.