### PR TITLE
fix #7900 - null bind values do not change to empty string anymore

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* fix issue #7900: Bind values of `null` are not replaced by
+  empty string anymore, when toggling between json and table
+  view in the web-ui.
+
 * Use base64url to encode and decode JWT parts.
 
 * updated bundled curl library to version 7.63

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js
@@ -1154,6 +1154,8 @@
       _.each(foundBindParams, function (word) {
         if (self.bindParamTableObj[word]) {
           newObject[word] = self.bindParamTableObj[word];
+        } else if (self.bindParamTableObj[word] === null) {
+          newObject[word] = null;
         } else {
           newObject[word] = '';
         }


### PR DESCRIPTION
Please note that for legal reasons we require you to sign the 
[Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
