### PR TITLE
Doc - Deprecate --server.jwt-secret startup option

### DIFF
--- a/Documentation/Examples/arangod.json
+++ b/Documentation/Examples/arangod.json
@@ -3077,7 +3077,10 @@
   "server.jwt-secret" : {
     "category" : "option",
     "default" : "",
-    "deprecatedIn" : null,
+    "deprecatedIn" : [
+      "v3.3.22",
+      "v3.4.2"
+    ],
     "description" : "secret to use when doing jwt authentication",
     "dynamic" : false,
     "enterpriseOnly" : false,

--- a/arangod/GeneralServer/AuthenticationFeature.cpp
+++ b/arangod/GeneralServer/AuthenticationFeature.cpp
@@ -106,7 +106,8 @@ void AuthenticationFeature::collectOptions(std::shared_ptr<ProgramOptions> optio
   // Maybe deprecate this option in devel
   options->addOption("--server.jwt-secret",
                      "secret to use when doing jwt authentication",
-                     new StringParameter(&_jwtSecretProgramOption));
+                     new StringParameter(&_jwtSecretProgramOption))
+                     .setDeprecatedIn(30322).setDeprecatedIn(30402);
 
   options->addOption(
       "--server.jwt-secret-keyfile",


### PR DESCRIPTION
The option should no longer be used.

Ref: https://github.com/arangodb/arangodb/pull/7863/files#diff-830e1f420da6281d48b409dc935de9e3R136

> --server.jwt-secret is insecure. Use --server.jwt-secret-keyfile instead.

Therefore, we should mark it as deprecated. This PR will add "Deprecated in: v3.3.22, v3.4.2" to the documentation on this page:
https://docs.arangodb.com/3.4/Manual/Programs/Arangod/Options.html#server-options

![image](https://user-images.githubusercontent.com/7819991/51136791-a57cc500-183d-11e9-98c3-e1d716c89823.png)
