### PR TITLE
Doc - Deprecate --server.jwt-secret startup option (3.4)

### DIFF
--- a/Documentation/Examples/arangod.json
+++ b/Documentation/Examples/arangod.json
@@ -2542,7 +2542,10 @@
   "server.jwt-secret" : {
     "category" : "option",
     "default" : "",
-    "deprecatedIn" : null,
+    "deprecatedIn" : [
+      "v3.3.22",
+      "v3.4.2"
+    ],
     "description" : "secret to use when doing jwt authentication",
     "dynamic" : false,
     "enterpriseOnly" : false,

--- a/arangod/GeneralServer/AuthenticationFeature.cpp
+++ b/arangod/GeneralServer/AuthenticationFeature.cpp
@@ -106,7 +106,8 @@ void AuthenticationFeature::collectOptions(std::shared_ptr<ProgramOptions> optio
   // Maybe deprecate this option in devel
   options->addOption("--server.jwt-secret",
                      "secret to use when doing jwt authentication",
-                     new StringParameter(&_jwtSecretProgramOption));
+                     new StringParameter(&_jwtSecretProgramOption))
+                     .setDeprecatedIn(30322).setDeprecatedIn(30402);
 
   options->addOption("--server.jwt-secret-keyfile",
                      "file containing jwt secret to use when doing jwt authentication.",


### PR DESCRIPTION
Backport of https://github.com/arangodb/arangodb/pull/7947/