### PR TITLE
Bug fix 3.4/misc issues

### DIFF
--- a/arangod/RestHandler/RestQueryHandler.cpp
+++ b/arangod/RestHandler/RestQueryHandler.cpp
@@ -182,7 +182,7 @@ bool RestQueryHandler::deleteQuery(std::string const& name) {
 
     generateResult(rest::ResponseCode::OK, result.slice());
   } else {
-    generateError(rest::ResponseCode::BAD, res,
+    generateError(GeneralResponse::responseCode(res), res,
                   "cannot kill query '" + name + "'");
   }
 
@@ -227,7 +227,8 @@ bool RestQueryHandler::replaceProperties() {
   if (!body.isObject()) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "expecting a JSON object as body");
-  };
+    return true;
+  }
 
   auto queryList = _vocbase.queryList();
   bool enabled = queryList->enabled();
@@ -304,7 +305,8 @@ bool RestQueryHandler::parseQuery() {
   if (!body.isObject()) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "expecting a JSON object as body");
-  };
+    return true;
+  }
 
   std::string const queryString =
       VelocyPackHelper::checkAndGetStringValue(body, "query");

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -641,7 +641,11 @@ std::pair<bool, bool> transaction::Methods::findIndexHandleForAndNode(
     double totalCost = filterCost;
     if (!sortCondition->isEmpty()) {
       // only take into account the costs for sorting if there is actually something to sort
-      totalCost += sortCost;
+      if (supportsSort) {
+        totalCost += sortCost;
+      } else {
+        totalCost += estimatedItems * std::log2(static_cast<double>(estimatedItems));
+      }
     }
 
     LOG_TOPIC(TRACE, Logger::FIXME)

--- a/arangosh/Shell/ClientFeature.h
+++ b/arangosh/Shell/ClientFeature.h
@@ -67,6 +67,7 @@ class ClientFeature final : public application_features::ApplicationFeature,
   std::string const& jwtSecret() const { return _jwtSecret; }
   double connectionTimeout() const { return _connectionTimeout; }
   double requestTimeout() const { return _requestTimeout; }
+  void requestTimeout(double value) { _requestTimeout = value; }
   uint64_t maxPacketSize() const { return _maxPacketSize; }
   uint64_t sslProtocol() const { return _sslProtocol; }
 

--- a/arangosh/Shell/V8ClientConnection.cpp
+++ b/arangosh/Shell/V8ClientConnection.cpp
@@ -166,6 +166,14 @@ std::string V8ClientConnection::endpointSpecification() const {
   }
   return "";
 }
+    
+double V8ClientConnection::timeout() const {
+  return _requestTimeout.count();
+}
+
+void V8ClientConnection::timeout(double value) {
+  _requestTimeout = std::chrono::duration<double>(value);
+}
 
 void V8ClientConnection::connect(ClientFeature* client) {
   TRI_ASSERT(client);
@@ -1149,7 +1157,44 @@ static void ClientConnection_isConnected(v8::FunctionCallbackInfo<v8::Value> con
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// @brief ClientConnection method "isConnected"
+/// @brief ClientConnection method "timeout"
+////////////////////////////////////////////////////////////////////////////////
+
+static void ClientConnection_timeout(v8::FunctionCallbackInfo<v8::Value> const& args) {
+  TRI_V8_TRY_CATCH_BEGIN(isolate);
+  v8::HandleScope scope(isolate);
+
+  // get the connection
+  V8ClientConnection* v8connection =
+      TRI_UnwrapClass<V8ClientConnection>(args.Holder(), WRAP_TYPE_CONNECTION);
+
+  if (v8connection == nullptr) {
+    TRI_V8_THROW_EXCEPTION_INTERNAL("connection class corrupted");
+  }
+  
+  if (args.Length() == 0) {
+    TRI_V8_RETURN(v8::Number::New(isolate, v8connection->timeout()));
+  } else {
+    double value = TRI_ObjectToDouble(args[0]);
+    v8connection->timeout(value);
+
+    v8::Local<v8::External> wrap = v8::Local<v8::External>::Cast(args.Data());
+    ClientFeature* client = static_cast<ClientFeature*>(wrap->Value());
+
+    if (client == nullptr) {
+      TRI_V8_THROW_EXCEPTION_INTERNAL("connection class corrupted");
+    }
+    
+    client->requestTimeout(value);
+
+    TRI_V8_RETURN_UNDEFINED();
+  }
+    
+  TRI_V8_TRY_CATCH_END
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief ClientConnection method "toString"
 ////////////////////////////////////////////////////////////////////////////////
 
 static void ClientConnection_toString(v8::FunctionCallbackInfo<v8::Value> const& args) {
@@ -1694,6 +1739,9 @@ void V8ClientConnection::initServer(v8::Isolate* isolate, v8::Local<v8::Context>
                         v8::FunctionTemplate::New(isolate, ClientConnection_connectedUser,
                                                   v8client));
 
+  connection_proto->Set(isolate, "timeout",
+                        v8::FunctionTemplate::New(isolate, ClientConnection_timeout));
+  
   connection_proto->Set(isolate, "toString",
                         v8::FunctionTemplate::New(isolate, ClientConnection_toString));
 

--- a/arangosh/Shell/V8ClientConnection.h
+++ b/arangosh/Shell/V8ClientConnection.h
@@ -64,6 +64,10 @@ class V8ClientConnection {
 
   void connect(ClientFeature*);
   void reconnect(ClientFeature*);
+  
+  double timeout() const;
+  
+  void timeout(double value);
 
   std::string const& databaseName() const { return _databaseName; }
   void setDatabaseName(std::string const& value) { _databaseName = value; }


### PR DESCRIPTION
This PR contains two changes:

* if an index cannot be used for sorting, its sort cost was previously returned as 0. 
  this will in fact favor indexes that can be used for filtering but not for sorting over indexes that can be used for both.
  this change is to report the sort cost for indexes that cannot be used for sorting to n * log(n), where n is the number of documents that optimizer expects to come out of the index after filtering

* only spend up to 10 seconds for initially fetching the list of collections in arangosh
  fetching the list of collections is a blocking operation, and the default timeout for this is very high. if the server is blocked by whatever reason, then the shell is unusable until the collections list request returns. to avoid this, the initial request is limited to 10 seconds, so the shell can be used afterwards.

