### PR TITLE
Do not acquire snapshot for single read

### DIFF
--- a/arangod/RocksDBEngine/RocksDBMethods.cpp
+++ b/arangod/RocksDBEngine/RocksDBMethods.cpp
@@ -151,7 +151,8 @@ rocksdb::Status RocksDBReadOnlyMethods::Get(rocksdb::ColumnFamilyHandle* cf,
                                             rocksdb::Slice const& key, std::string* val) {
   TRI_ASSERT(cf != nullptr);
   rocksdb::ReadOptions const& ro = _state->_rocksReadOptions;
-  TRI_ASSERT(ro.snapshot != nullptr);
+  TRI_ASSERT(ro.snapshot != nullptr ||
+             _state->isReadOnlyTransaction() && _state->isSingleOperation());
   return _db->Get(ro, cf, key, val);
 }
 
@@ -160,7 +161,8 @@ rocksdb::Status RocksDBReadOnlyMethods::Get(rocksdb::ColumnFamilyHandle* cf,
                                             rocksdb::PinnableSlice* val) {
   TRI_ASSERT(cf != nullptr);
   rocksdb::ReadOptions const& ro = _state->_rocksReadOptions;
-  TRI_ASSERT(ro.snapshot != nullptr);
+  TRI_ASSERT(ro.snapshot != nullptr ||
+             _state->isReadOnlyTransaction() && _state->isSingleOperation());
   return _db->Get(ro, cf, key, val);
 }
 

--- a/arangod/RocksDBEngine/RocksDBTransactionState.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.cpp
@@ -127,14 +127,16 @@ Result RocksDBTransactionState::beginTransaction(transaction::Hints hints) {
     _rocksReadOptions.prefix_same_as_start = true;  // should always be true
 
     if (isReadOnlyTransaction()) {
-      if (_readSnapshot == nullptr) {       // replication may donate a snapshot
+      TRI_ASSERT(_readSnapshot == nullptr);
+      if (!isSingleOperation()) {
         _readSnapshot = db->GetSnapshot();  // must call ReleaseSnapshot later
+        TRI_ASSERT(_readSnapshot != nullptr);
+        _rocksReadOptions.snapshot = _readSnapshot;
+      } else {  // a single *trx.document(...)` does not need a snapshot
+        TRI_ASSERT(!hasHint(transaction::Hints::Hint::INTERMEDIATE_COMMITS));
       }
-      TRI_ASSERT(_readSnapshot != nullptr);
-      _rocksReadOptions.snapshot = _readSnapshot;
       _rocksMethods.reset(new RocksDBReadOnlyMethods(this));
     } else {
-      TRI_ASSERT(_readSnapshot == nullptr);
       createTransaction();
       _rocksReadOptions.snapshot = _rocksTransaction->GetSnapshot();
       if (hasHint(transaction::Hints::Hint::INTERMEDIATE_COMMITS)) {
@@ -371,17 +373,20 @@ arangodb::Result RocksDBTransactionState::internalCommit() {
                _rocksTransaction->GetNumPuts() == 0 &&
                _rocksTransaction->GetNumDeletes() == 0);
     // this is most likely the fill index case
-    rocksdb::SequenceNumber seq = _rocksTransaction->GetSnapshot()->GetSequenceNumber();
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+//    rocksdb::SequenceNumber seq = _rocksTransaction->GetSnapshot()->GetSequenceNumber();
     for (auto& trxColl : _collections) {
-      TRI_IF_FAILURE("RocksDBCommitCounts") { continue; }
+//      TRI_IF_FAILURE("RocksDBCommitCounts") { continue; }
       auto* rcoll = static_cast<RocksDBTransactionCollection*>(trxColl);
-      rcoll->prepareCommit(id(), seq);
-      // We get here if we have filled indexes. So let us commit counts and
-      // any buffered index estimator updates
-      rcoll->commitCounts(id(), seq + 1);
+      TRI_ASSERT(rcoll->stealTrackedOperations().empty());
+//      rcoll->prepareCommit(id(), seq);
+//      // We get here if we have filled indexes. So let us commit counts and
+//      // any buffered index estimator updates
+//      rcoll->commitCounts(id(), seq + 1);
     }
+#endif
     // don't write anything if the transaction is empty
-    result = rocksutils::convertStatus(_rocksTransaction->Rollback());
+//    result = rocksutils::convertStatus(_rocksTransaction->Rollback());
   }
 
   return result;
@@ -567,6 +572,8 @@ uint64_t RocksDBTransactionState::sequenceNumber() const {
     return static_cast<uint64_t>(_rocksTransaction->GetSnapshot()->GetSequenceNumber());
   } else if (_readSnapshot != nullptr) {
     return static_cast<uint64_t>(_readSnapshot->GetSequenceNumber());
+  } else if (isSingleOperation() && isReadOnlyTransaction()) {
+    return rocksutils::latestSequenceNumber();
   }
   TRI_ASSERT(false);
   THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "No snapshot set");

--- a/arangod/RocksDBEngine/RocksDBTransactionState.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.cpp
@@ -374,19 +374,11 @@ arangodb::Result RocksDBTransactionState::internalCommit() {
                _rocksTransaction->GetNumDeletes() == 0);
     // this is most likely the fill index case
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-//    rocksdb::SequenceNumber seq = _rocksTransaction->GetSnapshot()->GetSequenceNumber();
     for (auto& trxColl : _collections) {
-//      TRI_IF_FAILURE("RocksDBCommitCounts") { continue; }
       auto* rcoll = static_cast<RocksDBTransactionCollection*>(trxColl);
       TRI_ASSERT(rcoll->stealTrackedOperations().empty());
-//      rcoll->prepareCommit(id(), seq);
-//      // We get here if we have filled indexes. So let us commit counts and
-//      // any buffered index estimator updates
-//      rcoll->commitCounts(id(), seq + 1);
     }
 #endif
-    // don't write anything if the transaction is empty
-//    result = rocksutils::convertStatus(_rocksTransaction->Rollback());
   }
 
   return result;

--- a/lib/V8/v8-vpack.cpp
+++ b/lib/V8/v8-vpack.cpp
@@ -67,7 +67,7 @@ static v8::Handle<v8::Value> ObjectVPackObject(v8::Isolate* isolate, VPackSlice 
 
   TRI_GET_GLOBALS();
 
-  VPackObjectIterator it(slice, true);
+  VPackObjectIterator it(slice, false);
   while (it.valid()) {
     arangodb::velocypack::ValueLength l;
     VPackSlice k = it.key(false);


### PR DESCRIPTION
http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr-linux/4082/

A single read operation via `trx.document(...)` does not need any snapshot guarantees. In fact we probably only create unnecessary overhead by blocking compactions 