### PR TITLE
[3.3] Fix broken validation of tick range in arangodump.

### DIFF
--- a/arangosh/Dump/DumpFeature.cpp
+++ b/arangosh/Dump/DumpFeature.cpp
@@ -154,7 +154,7 @@ void DumpFeature::validateOptions(std::shared_ptr<options::ProgramOptions> optio
     _maxChunkSize = _chunkSize;
   }
 
-  if (_tickStart < _tickEnd) {
+  if (_tickEnd < _tickStart) {
     LOG_TOPIC(FATAL, arangodb::Logger::FIXME)
         << "invalid values for --tick-start or --tick-end";
     FATAL_ERROR_EXIT();


### PR DESCRIPTION
Should address bug in #8031.