### PR TITLE
Fix broken validation of tick range in arangodump.

### DIFF
--- a/arangosh/Dump/DumpFeature.cpp
+++ b/arangosh/Dump/DumpFeature.cpp
@@ -610,7 +610,7 @@ void DumpFeature::validateOptions(std::shared_ptr<options::ProgramOptions> optio
   _options.maxChunkSize =
       boost::algorithm::clamp(_options.maxChunkSize, _options.initialChunkSize, ::MaxChunkSize);
 
-  if (_options.tickStart < _options.tickEnd) {
+  if (_options.tickEnd < _options.tickStart) {
     LOG_TOPIC(FATAL, arangodb::Logger::FIXME)
         << "invalid values for --tick-start or --tick-end";
     FATAL_ERROR_EXIT();


### PR DESCRIPTION
Should address bug in #8031.