### PR TITLE
Added "Community integrations" section to Drivers docs

### DIFF
--- a/Documentation/Books/Drivers/README.md
+++ b/Documentation/Books/Drivers/README.md
@@ -40,3 +40,12 @@ pyArango | Python | http://www.github.com/tariqdaouda/pyArango
 python-arango | Python | https://github.com/Joowani/python-arango
 Scarango | Scala | https://github.com/outr/scarango
 ArangoRB | Ruby | https://github.com/StefanoMartin/ArangoRB
+
+Community integrations
+-----------------
+
+Please note that this list is not exhaustive.
+
+Name | Language | Repository
+-----|----------|-----------
+Kafka Connect ArangoDB | Java | https://github.com/jaredpetersen/kafka-connect-arangodb

--- a/Documentation/Books/Drivers/README.md
+++ b/Documentation/Books/Drivers/README.md
@@ -42,7 +42,7 @@ Scarango | Scala | https://github.com/outr/scarango
 ArangoRB | Ruby | https://github.com/StefanoMartin/ArangoRB
 
 Community integrations
------------------
+----------------------
 
 Please note that this list is not exhaustive.
 


### PR DESCRIPTION
Added a new "Community integrations" section to the Drivers docs. Included an entry in the section for [Kafka Connect ArangoDB](https://github.com/jaredpetersen/kafka-connect-arangodb), a [Kafka Connector](https://docs.confluent.io/current/connect/managing/index.html) that sinks data from Apache Kafka into ArangoDB.

I signed the Contributor License Agreement and sent it in via email.