### PR TITLE
Bug fix: do not mutate the offset in the LimitExecutor

### DIFF
--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -1439,16 +1439,12 @@ std::unique_ptr<ExecutionBlock> LimitNode::createBlock(
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 
-  // this is currently required to check weather we're in a subquery
-  // or not. We do not count fullCounts inside a subquery.
-  size_t queryDepth = 0;
-  if (isInSubQuery(this)) {
-    queryDepth = 1;
-  }
+  // Fullcount must only be enabled on the last limit node on the main level
+  TRI_ASSERT(!_fullCount || !isInSubQuery(this));
 
   LimitExecutorInfos infos(getRegisterPlan()->nrRegs[previousNode->getDepth()],
-                           getRegisterPlan()->nrRegs[getDepth()], getRegsToClear(),
-                           _offset, _limit, _fullCount, queryDepth);
+                           getRegisterPlan()->nrRegs[getDepth()],
+                           getRegsToClear(), _offset, _limit, _fullCount);
 
   return std::make_unique<ExecutionBlockImpl<LimitExecutor>>(&engine, this,
                                                              std::move(infos));

--- a/tests/Aql/LimitExecutorTest.cpp
+++ b/tests/Aql/LimitExecutorTest.cpp
@@ -59,7 +59,7 @@ SCENARIO("LimitExecutor", "[AQL][EXECUTOR][LIMITEXECUTOR]") {
   // 7th queryDepth
 
   GIVEN("there are no rows upstream") {
-    LimitExecutorInfos infos(1, 1, {}, 0, 1, true, 0);
+    LimitExecutorInfos infos(1, 1, {}, 0, 1, true);
     VPackBuilder input;
 
     WHEN("the producer does not wait") {
@@ -103,7 +103,7 @@ SCENARIO("LimitExecutor", "[AQL][EXECUTOR][LIMITEXECUTOR]") {
     WHEN("the producer does not wait: limit 1, offset 0, fullcount false") {
       auto input = VPackParser::fromJson(
               "[ [1], [2], [3], [4] ]");
-      LimitExecutorInfos infos(1, 1, {}, 0, 1, false, 0);
+      LimitExecutorInfos infos(1, 1, {}, 0, 1, false);
       SingleRowFetcherHelper<false> fetcher(input->steal(), false);
       LimitExecutor testee(fetcher, infos);
       LimitStats stats{};
@@ -126,7 +126,7 @@ SCENARIO("LimitExecutor", "[AQL][EXECUTOR][LIMITEXECUTOR]") {
     WHEN("the producer does not wait: limit 1, offset 0, fullcount true") {
       auto input = VPackParser::fromJson(
               "[ [1], [2], [3], [4] ]");
-      LimitExecutorInfos infos(1, 1, {}, 0, 1, true, 0);
+      LimitExecutorInfos infos(1, 1, {}, 0, 1, true);
       SingleRowFetcherHelper<false> fetcher(input->steal(), false);
       LimitExecutor testee(fetcher, infos);
       LimitStats stats{};
@@ -157,7 +157,7 @@ SCENARIO("LimitExecutor", "[AQL][EXECUTOR][LIMITEXECUTOR]") {
     WHEN("the producer does not wait: limit 1, offset 1, fullcount true") {
       auto input = VPackParser::fromJson(
               "[ [1], [2], [3], [4] ]");
-      LimitExecutorInfos infos(1, 1, {}, 1, 1, true, 0);
+      LimitExecutorInfos infos(1, 1, {}, 1, 1, true);
       SingleRowFetcherHelper<false> fetcher(input->steal(), false);
       LimitExecutor testee(fetcher, infos);
       LimitStats stats{};
@@ -188,7 +188,7 @@ SCENARIO("LimitExecutor", "[AQL][EXECUTOR][LIMITEXECUTOR]") {
     WHEN("the producer does wait: limit 1, offset 0, fullcount false") {
       auto input = VPackParser::fromJson(
               "[ [1], [2], [3], [4] ]");
-      LimitExecutorInfos infos(1, 1, {}, 0, 1, false, 0);
+      LimitExecutorInfos infos(1, 1, {}, 0, 1, false);
       SingleRowFetcherHelper<false> fetcher(input->steal(), true);
       LimitExecutor testee(fetcher, infos);
       LimitStats stats{};
@@ -222,7 +222,7 @@ SCENARIO("LimitExecutor", "[AQL][EXECUTOR][LIMITEXECUTOR]") {
     WHEN("the producer does wait: limit 1, offset 0, fullcount true") {
       auto input = VPackParser::fromJson(
               "[ [1], [2], [3], [4] ]");
-      LimitExecutorInfos infos(1, 1, {}, 0, 1, true, 0);
+      LimitExecutorInfos infos(1, 1, {}, 0, 1, true);
       SingleRowFetcherHelper<false> fetcher(input->steal(), true);
       LimitExecutor testee(fetcher, infos);
       LimitStats stats{};

--- a/tests/js/server/aql/aql-subquery.js
+++ b/tests/js/server/aql/aql-subquery.js
@@ -304,7 +304,25 @@ function ahuacatlSubqueryTestSuite () {
 
       var actual = getQueryResults("LET a = (FOR i IN 1..2000 RETURN i) FOR i IN 1..10000 FILTER i IN a RETURN i");
       assertEqual(expected, actual);
-    }
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test limit with offset in a subquery
+/// This test was introduced due to a bug (that never made it into devel) where
+/// the offset in the LimitBlock was mutated during a subquery run and not reset
+/// in between.
+////////////////////////////////////////////////////////////////////////////////
+
+    testSubqueriesWithLimitAndOffset: function () {
+      const query = `
+        FOR i IN 2..4
+        LET a = (FOR j IN [0, i, i+10] LIMIT 1, 1 RETURN j)
+        RETURN FIRST(a)`;
+      const expected = [ 2, 3, 4 ];
+
+      var actual = getQueryResults(query);
+      assertEqual(expected, actual);
+    },
 
   };
 }


### PR DESCRIPTION
The mutation could not be reset during initializeCursor, thus the offset was broken in subsequent iterations of a subquery.