### PR TITLE
🚨 Fix clang warnings

### DIFF
--- a/arangod/RestHandler/RestRepairHandler.cpp
+++ b/arangod/RestHandler/RestRepairHandler.cpp
@@ -314,7 +314,7 @@ ResultT<bool> RestRepairHandler::jobFinished(std::string const& jobId) {
         << "Failed to get job status: "
         << "[" << jobStatus.errorNumber() << "] " << jobStatus.errorMessage();
 
-    return jobStatus;
+    return std::move(jobStatus);
   }
 
   return false;
@@ -375,7 +375,7 @@ Result RestRepairHandler::executeRepairOperations(DatabaseID const& databaseId,
       while (!previousJobFinished) {
         ResultT<bool> jobFinishedResult = jobFinished(jobId);
         if (jobFinishedResult.fail()) {
-          return jobFinishedResult;
+          return std::move(jobFinishedResult);
         }
         previousJobFinished = jobFinishedResult.get();
 
@@ -396,7 +396,7 @@ Result RestRepairHandler::executeRepairOperations(DatabaseID const& databaseId,
             checkReplicationFactor(databaseId, collectionId);
 
         if (checkReplicationFactorResult.fail()) {
-          return checkReplicationFactorResult;
+          return std::move(checkReplicationFactorResult);
         }
         replicationFactorMatches = checkReplicationFactorResult.get();
 

--- a/arangod/Scheduler/SupervisedScheduler.h
+++ b/arangod/Scheduler/SupervisedScheduler.h
@@ -81,6 +81,8 @@ class SupervisedScheduler : public Scheduler {
   // in a container class and store pointers. -- Maybe there is a better way?
   boost::lockfree::queue<WorkItem*> _queue[3];
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-private-field"
   char _padding1[64];
   std::atomic<uint64_t> _jobsSubmitted;
   char _padding2[64];
@@ -88,6 +90,7 @@ class SupervisedScheduler : public Scheduler {
   char _padding3[64];
   std::atomic<uint64_t> _jobsDone;
   char _padding5[64];
+#pragma clang diagnostic pop
 
   // During a queue operation there a two reasons to manually wake up a worker
   //  1. the queue length is bigger than _wakeupQueueLength and the last submit time

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -286,7 +286,7 @@ arangodb::Result Databases::create(std::string const& dbName, VPackSlice const& 
   if (upgradeRes.fail()) {
     LOG_TOPIC(ERR, Logger::FIXME)
         << "Could not create database: " << upgradeRes.errorMessage();
-    return upgradeRes;
+    return std::move(upgradeRes);
   }
 
   // Entirely Foxx related:


### PR DESCRIPTION
Assuming the padding is intended (disabled warnings via #pragma)

```
Scanning dependencies of target arangoserver
[ 60%] Building CXX object arangod/CMakeFiles/arangoserver.dir/RestHandler/RestRepairHandler.cpp.o
[ 60%] Building CXX object arangod/CMakeFiles/arangoserver.dir/Scheduler/SchedulerFeature.cpp.o
[ 60%] Building CXX object arangod/CMakeFiles/arangoserver.dir/Scheduler/SupervisedScheduler.cpp.o
[ 60%] Building CXX object arangod/CMakeFiles/arangoserver.dir/VocBase/Methods/Databases.cpp.o
/home/mop/projects/arangodb/arangod/VocBase/Methods/Databases.cpp:289:12: warning: local variable 'upgradeRes' will be copied despite being returned by name
      [-Wreturn-std-move]
    return upgradeRes;
           ^~~~~~~~~~
/home/mop/projects/arangodb/arangod/VocBase/Methods/Databases.cpp:289:12: note: call 'std::move' explicitly to avoid copying
    return upgradeRes;
           ^~~~~~~~~~
           std::move(upgradeRes)
1 warning generated.
In file included from /home/mop/projects/arangodb/arangod/Scheduler/SupervisedScheduler.cpp:25:
/home/mop/projects/arangodb/arangod/Scheduler/SupervisedScheduler.h:84:8: warning: private field '_padding1' is not used [-Wunused-private-field]
  char _padding1[64];
       ^
/home/mop/projects/arangodb/arangod/Scheduler/SupervisedScheduler.h:86:8: warning: private field '_padding2' is not used [-Wunused-private-field]
  char _padding2[64];
       ^
/home/mop/projects/arangodb/arangod/Scheduler/SupervisedScheduler.h:88:8: warning: private field '_padding3' is not used [-Wunused-private-field]
  char _padding3[64];
       ^
/home/mop/projects/arangodb/arangod/Scheduler/SupervisedScheduler.h:90:8: warning: private field '_padding5' is not used [-Wunused-private-field]
  char _padding5[64];
       ^
/home/mop/projects/arangodb/arangod/RestHandler/RestRepairHandler.cpp:317:12: warning: local variable 'jobStatus' will be copied despite being returned by name
      [-Wreturn-std-move]
    return jobStatus;
           ^~~~~~~~~
/home/mop/projects/arangodb/arangod/RestHandler/RestRepairHandler.cpp:317:12: note: call 'std::move' explicitly to avoid copying
    return jobStatus;
           ^~~~~~~~~
           std::move(jobStatus)
/home/mop/projects/arangodb/arangod/RestHandler/RestRepairHandler.cpp:378:18: warning: local variable 'jobFinishedResult' will be copied despite being returned by name
      [-Wreturn-std-move]
          return jobFinishedResult;
                 ^~~~~~~~~~~~~~~~~
/home/mop/projects/arangodb/arangod/RestHandler/RestRepairHandler.cpp:378:18: note: call 'std::move' explicitly to avoid copying
          return jobFinishedResult;
                 ^~~~~~~~~~~~~~~~~
                 std::move(jobFinishedResult)
4 warnings generated.
/home/mop/projects/arangodb/arangod/RestHandler/RestRepairHandler.cpp:399:18: warning: local variable 'checkReplicationFactorResult' will be copied despite being returned by
      name [-Wreturn-std-move]
          return checkReplicationFactorResult;
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/mop/projects/arangodb/arangod/RestHandler/RestRepairHandler.cpp:399:18: note: call 'std::move' explicitly to avoid copying
          return checkReplicationFactorResult;
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 std::move(checkReplicationFactorResult)

```