### PR TITLE
Fix isAqlQuery with empty query

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* fixed JS AQL query objects with empty query strings not being recognized as AQL queries
+
 * report run-time openssl version (for dynamically linked executables)
 
 * added greeting warning about maintainer mode

--- a/js/common/modules/@arangodb/common.js
+++ b/js/common/modules/@arangodb/common.js
@@ -39,7 +39,7 @@ Object.keys(internal.errors).forEach(function(key) {
 });
 
 function isAqlQuery(query) {
-  return Boolean(query && query.query && query.bindVars);
+  return Boolean(query && typeof query.query === "string" && query.bindVars);
 }
 
 function isGeneratedAqlQuery(query) {


### PR DESCRIPTION
This fixes a bug where the following would result in garbage:
```js
aql`
  something
  ${aql.join([])}
  something
`;
```
The expected result would be that the `aql.join` is omitted entirely, the observed result was that an empty query object is added as a `bindVar`. The cause was that `aql.join` generates a query object with an empty query string and the `isAqlQuery` function checks for truthiness (empty strings are false).