### PR TITLE
upgraded to 4.17.11 because of CVE-2018-16487

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* upgraded lodash to 4.17.11 because of CVE-2018-16487
+
 * `--query.registry-ttl` is now honored in single-server mode, and cursor TTLs
   are now honored on DBServers in cluster mode
   

--- a/js/node/package.json
+++ b/js/node/package.json
@@ -25,7 +25,7 @@
     "joi": "9.2.0",
     "joi-to-json-schema": "2.3.0",
     "js-yaml": "3.10.0",
-    "lodash": "4.17.5",
+    "lodash": "4.17.11",
     "marked": "0.3.9",
     "media-typer": "0.3.0",
     "mime-types": "2.1.12",


### PR DESCRIPTION
http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/3145/