### PR TITLE
BugFix 3.3:  Correct RocksDB NowNano() for overflow

### DIFF
--- a/3rdParty/rocksdb/v5.6.X/port/win/env_win.cc
+++ b/3rdParty/rocksdb/v5.6.X/port/win/env_win.cc
@@ -680,8 +680,11 @@ uint64_t WinEnvIO::NowNanos() {
   QueryPerformanceCounter(&li);
   // Convert to nanoseconds first to avoid loss of precision
   // and divide by frequency
-  li.QuadPart *= std::nano::den;
-  li.QuadPart /= perf_counter_frequency_;
+  if (perf_counter_frequency_ < std::nano::den) {
+    li.QuadPart *= (std::nano::den / perf_counter_frequency_);
+  } else {
+    li.QuadPart /= (perf_counter_frequency_ / std::nano::den);
+  } // else
   return li.QuadPart;
 }
 


### PR DESCRIPTION
This is same fix submitted to 3.4 and devel branches.

WinEnvIO::NowNanos() typically overflows its int64_t due to the way code "preserves" the nanoseconds.  This code actually preserves the accuracy.  The code includes a condition statement that will support future machines where clock frequency is sub-nanosecond.