### PR TITLE
The big supervision fix. (#8243)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,23 @@ v3.3.23 (XXXX-XX-XX)
 * fix supervision's failed server handling to transactionally create
   all failed leader/followers along
 
+* Supervision fix: abort MoveShard job does not leave a lock behind,
+
+* Supervision fix: abort MoveShard (leader) job moves forwards when point
+  of no return has been reached,
+
+* Supervision fix: move shard with data stopped to early due to wrong usage 
+  of compare function
+
+* Supervision fix: AddFollower only counts good followers, fixing a
+  situation after a FailedLeader job could not find a new working
+  follower
+
+* Supervision fix: FailedLeader now also considers temporarily BAD
+  servers as replacement followers and does not block servers which
+  currently receive a new shard
+
+* Maintenance fix: added precondition of unchanged Plan in phase2
 
 v3.3.22 (2019-02-01)
 --------------------

--- a/arangod/Agency/CleanOutServer.cpp
+++ b/arangod/Agency/CleanOutServer.cpp
@@ -495,7 +495,7 @@ arangodb::Result CleanOutServer::abort() {
     }
   }
 
-  finish(_server, "", false, "job aborted");
+  finish(_server, "", false, "job aborted", payload);
 
   return result;
 }

--- a/arangod/Agency/CleanOutServer.cpp
+++ b/arangod/Agency/CleanOutServer.cpp
@@ -495,7 +495,7 @@ arangodb::Result CleanOutServer::abort() {
     }
   }
 
-  finish(_server, "", false, "job aborted", payload);
+  finish(_server, "", false, "job aborted");
 
   return result;
 }

--- a/arangod/Agency/FailedFollower.cpp
+++ b/arangod/Agency/FailedFollower.cpp
@@ -86,7 +86,7 @@ bool FailedFollower::create(std::shared_ptr<VPackBuilder> envelope) {
       << "Create failedFollower for " + _shard + " from " + _from;
 
   _created = system_clock::now();
- 
+
   if (envelope == nullptr) {
     _jb = std::make_shared<Builder>();
     _jb->openArray();
@@ -114,7 +114,7 @@ bool FailedFollower::create(std::shared_ptr<VPackBuilder> envelope) {
   }
  
   return true;
-  
+
 }
 
 bool FailedFollower::start() {
@@ -146,7 +146,7 @@ bool FailedFollower::start() {
   }
 
   // Get proper replacement
-  _to = randomIdleGoodAvailableServer(_snapshot, planned);
+  _to = randomIdleAvailableServer(_snapshot, planned);
   if (_to.empty()) {
     // retry later
     return false;

--- a/arangod/Agency/FailedLeader.cpp
+++ b/arangod/Agency/FailedLeader.cpp
@@ -161,7 +161,7 @@ bool FailedLeader::create(std::shared_ptr<VPackBuilder> b) {
   }
 
   return true;
-  
+
 }
 
 bool FailedLeader::start() {
@@ -232,7 +232,7 @@ bool FailedLeader::start() {
   }
 
   // Additional follower, if applicable
-  auto additionalFollower = randomIdleGoodAvailableServer(_snapshot, planned);
+  auto additionalFollower = randomIdleAvailableServer(_snapshot, planned);
   if (!additionalFollower.empty()) {
     planv.push_back(additionalFollower);
   }

--- a/arangod/Agency/Job.h
+++ b/arangod/Agency/Job.h
@@ -121,9 +121,10 @@ struct Job {
 
   /// @brief Get a random server, which is not blocked, in good condition and
   ///        excluding "exclude" vector
-  static std::string randomIdleGoodAvailableServer(Node const& snap,
+  static std::string randomIdleAvailableServer(Node const& snap,
                                                    std::vector<std::string> const& exclude);
-  static std::string randomIdleGoodAvailableServer(Node const& snap, VPackSlice const& exclude);
+  static size_t countGoodServersInList(Node const& snap, VPackSlice const& serverList);
+  static std::string randomIdleAvailableServer(Node const& snap, VPackSlice const& exclude);
 
   /// @brief Get servers from plan, which are not failed or cleaned out
   static std::vector<std::string> availableServers(const arangodb::consensus::Node&);
@@ -151,7 +152,7 @@ struct Job {
 
   static void doForAllShards(
       Node const& snapshot, std::string& database, std::vector<shard_t>& shards,
-      std::function<void(Slice plan, Slice current, std::string& planPath)> worker);
+      std::function<void(Slice plan, Slice current, std::string& planPath, std::string& curPath)> worker);
 
   // The following methods adds an operation to a transaction object or
   // a condition to a precondition object. In all cases, the builder trx

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -340,7 +340,7 @@ bool MoveShard::start() {
 
       // --- Plan changes
       doForAllShards(_snapshot, _database, shardsLikeMe,
-                     [this, &pending](Slice plan, Slice current, std::string& planPath) {
+                     [this, &pending](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                        pending.add(VPackValue(planPath));
                        {
                          VPackArrayBuilder serverList(&pending);
@@ -445,7 +445,7 @@ JOB_STATUS MoveShard::pendingLeader() {
     // Still the old leader, let's check that the toServer is insync:
     size_t done = 0;  // count the number of shards for which _to is in sync:
     doForAllShards(_snapshot, _database, shardsLikeMe,
-                   [this, &done](Slice plan, Slice current, std::string& planPath) {
+                   [this, &done](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                      for (auto const& s : VPackArrayIterator(current)) {
                        if (s.copyString() == _to) {
                          ++done;
@@ -469,7 +469,7 @@ JOB_STATUS MoveShard::pendingLeader() {
         VPackObjectBuilder trxObject(&trx);
         VPackObjectBuilder preObject(&pre);
         doForAllShards(_snapshot, _database, shardsLikeMe,
-                       [this, &trx, &pre](Slice plan, Slice current, std::string& planPath) {
+                       [this, &trx, &pre](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                          // Replace _from by "_" + _from
                          trx.add(VPackValue(planPath));
                          {
@@ -500,7 +500,7 @@ JOB_STATUS MoveShard::pendingLeader() {
     // Retired old leader, let's check that the fromServer has retired:
     size_t done = 0;  // count the number of shards for which leader has retired
     doForAllShards(_snapshot, _database, shardsLikeMe,
-                   [this, &done](Slice plan, Slice current, std::string& planPath) {
+                   [this, &done](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                      if (current.length() > 0 && current[0].copyString() == "_" + _from) {
                        ++done;
                      }
@@ -521,7 +521,7 @@ JOB_STATUS MoveShard::pendingLeader() {
         VPackObjectBuilder trxObject(&trx);
         VPackObjectBuilder preObject(&pre);
         doForAllShards(_snapshot, _database, shardsLikeMe,
-                       [this, &trx, &pre](Slice plan, Slice current, std::string& planPath) {
+                       [this, &trx, &pre](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                          // Replace "_" + _from by _to and leave _from out:
                          trx.add(VPackValue(planPath));
                          {
@@ -555,7 +555,7 @@ JOB_STATUS MoveShard::pendingLeader() {
     // all but except the old leader are in sync:
     size_t done = 0;
     doForAllShards(_snapshot, _database, shardsLikeMe,
-                   [this, &done](Slice plan, Slice current, std::string& planPath) {
+                   [this, &done](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                      if (current.length() > 0 && current[0].copyString() == _to) {
                        if (plan.length() < 3) {
                          // This only happens for replicationFactor == 1, in which case
@@ -569,7 +569,7 @@ JOB_STATUS MoveShard::pendingLeader() {
                          for (size_t i = 1; i < plan.length() - 1; ++i) {
                            VPackSlice p = plan[i];
                            for (auto const& c : VPackArrayIterator(current)) {
-                             if (arangodb::basics::VelocyPackHelper::compare(p, c, true)) {
+                             if (arangodb::basics::VelocyPackHelper::compare(p, c, true) == 0) {
                                ++found;
                                break;
                              }
@@ -597,7 +597,7 @@ JOB_STATUS MoveShard::pendingLeader() {
         VPackObjectBuilder trxObject(&trx);
         VPackObjectBuilder preObject(&pre);
         doForAllShards(_snapshot, _database, shardsLikeMe,
-                       [&trx, &pre, this](Slice plan, Slice current, std::string& planPath) {
+                       [&trx, &pre, this](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                          if (!_remainsFollower) {
                            // Remove _from from the list of follower
                            trx.add(VPackValue(planPath));
@@ -658,7 +658,7 @@ JOB_STATUS MoveShard::pendingFollower() {
 
   size_t done = 0;  // count the number of shards done
   doForAllShards(_snapshot, _database, shardsLikeMe,
-                 [&done](Slice plan, Slice current, std::string& planPath) {
+                 [&done](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                    if (ClusterHelpers::compareServerLists(plan, current)) {
                      ++done;
                    }
@@ -690,7 +690,7 @@ JOB_STATUS MoveShard::pendingFollower() {
 
       // All changes to Plan for all shards, with precondition:
       doForAllShards(_snapshot, _database, shardsLikeMe,
-                     [this, &trx, &precondition](Slice plan, Slice current, std::string& planPath) {
+                     [this, &trx, &precondition](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                        // Remove fromServer from Plan:
                        trx.add(VPackValue(planPath));
                        {
@@ -749,9 +749,26 @@ arangodb::Result MoveShard::abort() {
     return result;
   }
 
+  // Can now only be PENDING
   // Find the other shards in the same distributeShardsLike group:
   std::vector<Job::shard_t> shardsLikeMe =
-      clones(_snapshot, _database, _collection, _shard);
+    clones(_snapshot, _database, _collection, _shard);
+    
+  // We can no longer abort by reverting to where we started, if any of the
+  // shards of the distributeShardsLike group has already gone to new leader
+  if (_isLeader) {
+    for (auto const& i : shardsLikeMe) {
+      auto const& cur = _snapshot.hasAsArray(
+        curColPrefix + _database + "/" + i.collection + "/" + i.shard + "/" + "servers");
+      if (cur.second && cur.first[0].copyString() == _to) {
+        LOG_TOPIC(INFO, Logger::SUPERVISION) <<
+          "MoveShard can no longer abort through reversion to where it started. Flight forward";
+        finish(_to, _shard, true, "job aborted - new leader already in place");
+        return result;
+      }
+    }
+  }
+  
   Builder trx;  // to build the transaction
 
   // Now look after a PENDING job:
@@ -762,7 +779,7 @@ arangodb::Result MoveShard::abort() {
       if (_isLeader) {
         // All changes to Plan for all shards:
         doForAllShards(_snapshot, _database, shardsLikeMe,
-                       [this, &trx](Slice plan, Slice current, std::string& planPath) {
+                       [this, &trx](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                          // Restore leader to be _from:
                          trx.add(VPackValue(planPath));
                          {
@@ -779,7 +796,7 @@ arangodb::Result MoveShard::abort() {
       } else {
         // All changes to Plan for all shards:
         doForAllShards(_snapshot, _database, shardsLikeMe,
-                       [this, &trx](Slice plan, Slice current, std::string& planPath) {
+                       [this, &trx](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                          // Remove toServer from Plan:
                          trx.add(VPackValue(planPath));
                          {
@@ -800,8 +817,18 @@ arangodb::Result MoveShard::abort() {
       addReleaseServer(trx, _to);
       addIncreasePlanVersion(trx);
     }
+    if (_isLeader) { // Precondition, that current is still as in snapshot
+      VPackObjectBuilder preconditionObj(&trx);
+      // Current preconditions for all shards
+      doForAllShards(
+        _snapshot, _database, shardsLikeMe,
+        [this, &trx](
+          Slice plan, Slice current, std::string& planPath, std::string& curPath) {
+          // Current still as is 
+          trx.add(curPath, current);
+        });
+    }
   }
-
   write_ret_t res = singleWriteTransaction(_agent, trx);
 
   if (!res.accepted) {
@@ -809,10 +836,16 @@ arangodb::Result MoveShard::abort() {
                     std::string("Lost leadership"));
     return result;
   } else if (res.indices[0] == 0) {
+    if (_isLeader) {
+      // Tough luck. Things have changed. We'll move on
+      LOG_TOPIC(INFO, Logger::SUPERVISION) <<
+        "MoveShard can no longer abort through reversion to where it started. Flight forward";
+      finish(_to, _shard, true, "job aborted - new leader already in place");
+      return result;
+    }
     result = Result(
-        TRI_ERROR_SUPERVISION_GENERAL_FAILURE,
-        std::string("Precondition failed while aborting moveShard job ") + _jobId);
-    return result;
+    TRI_ERROR_SUPERVISION_GENERAL_FAILURE,
+    std::string("Precondition failed while aborting moveShard job ") + _jobId);
   }
 
   return result;

--- a/arangod/Agency/RemoveFollower.cpp
+++ b/arangod/Agency/RemoveFollower.cpp
@@ -186,7 +186,7 @@ bool RemoveFollower::start() {
   }
   doForAllShards(_snapshot, _database, shardsLikeMe,
                  [&planned, &overview, &leaderBad](Slice plan, Slice current,
-                                                   std::string& planPath) {
+                                                   std::string& planPath, std::string& curPath) {
                    if (current.length() > 0) {
                      if (current[0].copyString() != planned[0].copyString()) {
                        leaderBad = true;
@@ -346,7 +346,7 @@ bool RemoveFollower::start() {
 
       // --- Plan changes
       doForAllShards(_snapshot, _database, shardsLikeMe,
-                     [&trx, &chosenToRemove](Slice plan, Slice current, std::string& planPath) {
+                     [&trx, &chosenToRemove](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                        trx.add(VPackValue(planPath));
                        {
                          VPackArrayBuilder serverList(&trx);

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1153,9 +1153,24 @@ void Supervision::enforceReplication() {
       if (!clone) {
         for (auto const& shard_ : col.hasAsChildren("shards").first) {  // Pl shards
           auto const& shard = *(shard_.second);
+          VPackBuilder onlyFollowers;
+          {
+            VPackArrayBuilder guard(&onlyFollowers);
+            bool first = true;
+            for (auto const& pp : VPackArrayIterator(shard.slice())) {
+              if (!first) {
+                onlyFollowers.add(pp);
+              }
+              first = false;
+            }
+          }
+          size_t actualReplicationFactor
+            = 1 + Job::countGoodServersInList(_snapshot, onlyFollowers.slice());
+            // leader plus GOOD followers
+          size_t apparentReplicationFactor = shard.slice().length();
 
-          size_t actualReplicationFactor = shard.slice().length();
-          if (actualReplicationFactor != replicationFactor) {
+          if (actualReplicationFactor != replicationFactor ||
+              apparentReplicationFactor != replicationFactor) {
             // Check that there is not yet an addFollower or removeFollower
             // or moveShard job in ToDo for this shard:
             auto const& todo = _snapshot.hasAsChildren(toDoPrefix).first;
@@ -1186,7 +1201,7 @@ void Supervision::enforceReplication() {
                 AddFollower(_snapshot, _agent, std::to_string(_jobId++),
                             "supervision", db_.first, col_.first, shard_.first)
                     .run();
-              } else {
+              } else if (apparentReplicationFactor > replicationFactor) {
                 RemoveFollower(_snapshot, _agent, std::to_string(_jobId++),
                                "supervision", db_.first, col_.first, shard_.first)
                     .run();

--- a/lib/Basics/StringUtils.h
+++ b/lib/Basics/StringUtils.h
@@ -166,7 +166,7 @@ std::vector<std::string> split(std::string const& source,
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename C>
-std::string join(C const& source, std::string const& delim = ",") {
+std::string join(C const& source, std::string const& delim) {
   std::string result;
   bool first = true;
 

--- a/tests/Agency/AddFollowerTest.json
+++ b/tests/Agency/AddFollowerTest.json
@@ -47,7 +47,7 @@ R"=(
           "Status": "GOOD"
         },
         "leader": {
-          "Status": "FAILED"
+          "Status": "GOOD"
         },
         "free": {
           "Status": "GOOD"

--- a/tests/Agency/CleanOutServerTest.json
+++ b/tests/Agency/CleanOutServerTest.json
@@ -58,6 +58,7 @@ R"=(
     },
     "Target": {
       "CleanedServers": [],
+      "ToBeCleanedServers": [],
       "FailedServers": {},
       "MapUniqueToShortID": {
         "follower1": {

--- a/tests/Agency/FailedLeaderTest.json
+++ b/tests/Agency/FailedLeaderTest.json
@@ -41,6 +41,12 @@ R"=(
     "Supervision": {
       "DBServers": {},
       "Health": {
+        "free2": {
+          "Status": "BAD"
+        },
+        "free": {
+          "Status": "GOOD"
+        },
         "follower1": {
           "Status": "GOOD"
         },

--- a/tests/Agency/MoveShardTest.cpp
+++ b/tests/Agency/MoveShardTest.cpp
@@ -1591,9 +1591,10 @@ SECTION("a pending moveshard job should also put the original server back into p
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write)).Do([&](query_t const& q, consensus::AgentInterface::WriteMode w) -> write_ret_t {
     INFO("WriteTransaction: " << q->slice().toJson());
+    LOG_DEVEL << q->slice().toJson() << " " << __LINE__;
     auto writes = q->slice()[0][0];
     CHECK(writes.get("/arango/Target/Pending/1").get("op").copyString() == "delete");
-    REQUIRE(q->slice()[0].length() == 1); // we always simply override! no preconditions...
+    REQUIRE(q->slice()[0].length() == 2); // Precondition: to Server not leader yet 
     CHECK(writes.get("/arango/Supervision/DBServers/" + FREE_SERVER).get("op").copyString() == "delete");
     CHECK(writes.get("/arango/Supervision/Shards/" + SHARD).get("op").copyString() == "delete");
     CHECK(std::string(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD).typeName()) == "array");
@@ -1819,9 +1820,11 @@ SECTION("aborting the job while a leader transition is in progress (for example 
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write)).Do([&](query_t const& q, consensus::AgentInterface::WriteMode w) -> write_ret_t {
     INFO("WriteTransaction: " << q->slice().toJson());
+    LOG_DEVEL << q->slice().toJson() << " " << __LINE__;
+
     auto writes = q->slice()[0][0];
     CHECK(writes.get("/arango/Target/Pending/1").get("op").copyString() == "delete");
-    REQUIRE(q->slice()[0].length() == 1); // we always simply override! no preconditions...
+    REQUIRE(q->slice()[0].length() == 2); // Precondition: to Server not leader yet 
     CHECK(writes.get("/arango/Supervision/DBServers/" + FREE_SERVER).get("op").copyString() == "delete");
     CHECK(writes.get("/arango/Supervision/Shards/" + SHARD).get("op").copyString() == "delete");
     CHECK(std::string(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD).typeName()) == "array");


### PR DESCRIPTION
* Updated CleanoutServerTests. Allow bad servers as new follower.
* Prefer good servers.
* Removed copy, sort and binary_search for a list of ~10 elements.
* Fix move shard bug with compare.
* MoveShard fixes, expansion of doForAllShards
* Count only GOOD servers in actualReplicationFactor.
* Make RemoveFollower remove broken servers.
* Precondition on Plan Version for updating Current as leader.
* Fixed typo in log message.
* Change warning level. If a MoveShard job is aborted and we can no longer roll back, then we issue a WARNING rather than a DEBUG log message.
* Another typo and log level.
* Start to fix unit tests.
* Does not make sense for AddFollowerTest to have a FAILED leader.
* Only count GOOD followers in AddFollower.
* Fix AddFollowerTest.
* Report precondition failed in MoveShard follower case.
* Add CHANGELOG.