### PR TITLE
The big supervision fix. (#8243)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -217,6 +217,30 @@ devel
 
 * use `-std=c++14` for ArangoDB compilation
 
+* Supervision fix: abort MoveShard job does not leave a lock behind,
+
+* Supervision fix: abort MoveShard (leader) job moves forwards when point
+  of no return has been reached,
+
+* Supervision fix: abort CleanOutServer job does not leave server in
+  ToBeCleanedServers,
+
+* Supervision fix: move shard with data stopped to early due to wrong usage 
+  of compare function
+
+* Supervision fix: AddFollower only counts good followers, fixing a
+  situation after a FailedLeader job could not find a new working
+  follower
+
+* Supervision fix: FailedLeader now also considers temporarily BAD
+  servers as replacement followers and does not block servers which
+  currently receive a new shard
+
+* Supervision fix: Servers in ToBeCleanedServers are no longer considered
+  as replacement servers
+
+* Maintenance fix: added precondition of unchanged Plan in phase2
+
 
 v3.4.1 (XXXX-XX-XX)
 -------------------

--- a/arangod/Agency/CleanOutServer.cpp
+++ b/arangod/Agency/CleanOutServer.cpp
@@ -121,7 +121,7 @@ JOB_STATUS CleanOutServer::status() {
         reportTrx.add("op", VPackValue("push"));
         reportTrx.add("new", VPackValue(_server));
       }
-      reportTrx.add(VPackValue("/Target/ToBeCleanedServers"));
+      reportTrx.add(VPackValue(toBeCleanedPrefix));
       {
         VPackObjectBuilder guard4(&reportTrx);
         reportTrx.add("op", VPackValue("erase"));
@@ -318,7 +318,7 @@ bool CleanOutServer::start() {
       addBlockServer(*pending, _server, _jobId);
 
       // Put ourselves in list of servers to be cleaned:
-      pending->add(VPackValue("/Target/ToBeCleanedServers"));
+      pending->add(VPackValue(toBeCleanedPrefix));
       {
         VPackObjectBuilder guard4(pending.get());
         pending->add("op", VPackValue("push"));
@@ -509,7 +509,18 @@ arangodb::Result CleanOutServer::abort() {
     }
   }
 
-  finish(_server, "", false, "job aborted");
+  auto payload = std::make_shared<VPackBuilder>();
+  {
+    VPackObjectBuilder p(payload.get());
+    payload->add(VPackValue(toBeCleanedPrefix));
+    {
+      VPackObjectBuilder pp(payload.get());
+      payload->add("op", VPackValue("erase"));
+      payload->add("val", VPackValue(_server));
+    }
+  }
+
+  finish(_server, "", false, "job aborted", payload);
 
   return result;
 }

--- a/arangod/Agency/FailedFollower.cpp
+++ b/arangod/Agency/FailedFollower.cpp
@@ -86,7 +86,7 @@ bool FailedFollower::create(std::shared_ptr<VPackBuilder> envelope) {
       << "Create failedFollower for " + _shard + " from " + _from;
 
   _created = system_clock::now();
- 
+
   if (envelope == nullptr) {
     _jb = std::make_shared<Builder>();
     _jb->openArray();
@@ -117,7 +117,7 @@ bool FailedFollower::create(std::shared_ptr<VPackBuilder> envelope) {
   }
 
   return true;
-  
+
 }
 
 bool FailedFollower::start() {
@@ -149,7 +149,7 @@ bool FailedFollower::start() {
   }
 
   // Get proper replacement
-  _to = randomIdleGoodAvailableServer(_snapshot, planned);
+  _to = randomIdleAvailableServer(_snapshot, planned);
   if (_to.empty()) {
     // retry later
     return false;

--- a/arangod/Agency/FailedLeader.cpp
+++ b/arangod/Agency/FailedLeader.cpp
@@ -161,7 +161,7 @@ bool FailedLeader::create(std::shared_ptr<VPackBuilder> b) {
   }
 
   return true;
-  
+
 }
 
 bool FailedLeader::start() {
@@ -232,7 +232,7 @@ bool FailedLeader::start() {
   }
 
   // Additional follower, if applicable
-  auto additionalFollower = randomIdleGoodAvailableServer(_snapshot, planned);
+  auto additionalFollower = randomIdleAvailableServer(_snapshot, planned);
   if (!additionalFollower.empty()) {
     planv.push_back(additionalFollower);
   }

--- a/arangod/Agency/Job.cpp
+++ b/arangod/Agency/Job.cpp
@@ -38,6 +38,7 @@ std::string const failedPrefix = "/Target/Failed/";
 std::string const finishedPrefix = "/Target/Finished/";
 std::string const toDoPrefix = "/Target/ToDo/";
 std::string const cleanedPrefix = "/Target/CleanedServers";
+std::string const toBeCleanedPrefix = "/Target/ToBeCleanedServers";
 std::string const failedServersPrefix = "/Target/FailedServers";
 std::string const planColPrefix = "/Plan/Collections/";
 std::string const curColPrefix = "/Current/Collections/";
@@ -139,53 +140,56 @@ bool Job::finish(std::string const& server, std::string const& shard,
   return false;
 }
 
-std::string Job::randomIdleGoodAvailableServer(Node const& snap,
+std::string Job::randomIdleAvailableServer(Node const& snap,
                                                std::vector<std::string> const& exclude) {
   std::vector<std::string> as = availableServers(snap);
   std::string ret;
-  auto ex(exclude);
 
-  // ungood;
+  // Prefer good servers over bad servers
+  std::vector<std::string> good;
+  std::vector<std::string> bad;
+
+  // unfailed; - servers that have are just temporarily bad, should be considered
+  // as valid server.
   try {
     for (auto const& srv : snap.hasAsChildren(healthPrefix).first) {
-      if ((*srv.second).hasAsString("Status").first != "GOOD") {
-        ex.push_back(srv.first);
+      // ignore excluded servers
+      if (std::find(std::begin(exclude), std::end(exclude), srv.first) != std::end(exclude)) {
+        continue ;
+      }
+
+      std::string const& status = (*srv.second).hasAsString("Status").first;
+      if (status == "GOOD") {
+        good.push_back(srv.first);
+      } else if (status == "BAD") {
+        bad.push_back(srv.first);
       }
     }
   } catch (...) {
   }
 
-  // blocked;
-  try {
-    for (auto const& srv : snap.hasAsChildren(blockedServersPrefix).first) {
-      ex.push_back(srv.first);
+  if (good.empty()) {
+    if (bad.empty()) {
+      return ret;
     }
-  } catch (...) {
+    good = std::move(bad);
   }
 
-  // Remove excluded servers
-  std::sort(std::begin(ex), std::end(ex));
-  as.erase(std::remove_if(std::begin(as), std::end(as),
-                          [&](std::string const& s) {
-                            return std::binary_search(std::begin(ex), std::end(ex), s);
-                          }),
-           std::end(as));
-
   // Choose random server from rest
-  if (!as.empty()) {
-    if (as.size() == 1) {
-      ret = as[0];
+  if (!good.empty()) {
+    if (good.size() == 1) {
+      ret = good[0];
     } else {
-      uint16_t interval = static_cast<uint16_t>(as.size() - 1);
+      uint16_t interval = static_cast<uint16_t>(good.size() - 1);
       uint16_t random = RandomGenerator::interval(interval);
-      ret = as.at(random);
+      ret = good.at(random);
     }
   }
 
   return ret;
 }
 
-std::string Job::randomIdleGoodAvailableServer(Node const& snap, Slice const& exclude) {
+std::string Job::randomIdleAvailableServer(Node const& snap, Slice const& exclude) {
   std::vector<std::string> ev;
   if (exclude.isArray()) {
     for (const auto& s : VPackArrayIterator(exclude)) {
@@ -194,10 +198,42 @@ std::string Job::randomIdleGoodAvailableServer(Node const& snap, Slice const& ex
       }
     }
   }
-  return randomIdleGoodAvailableServer(snap, ev);
+  return randomIdleAvailableServer(snap, ev);
 }
 
-/// @brief Get servers from plan, which are not failed or cleaned out
+// The following counts in a given server list how many of the servers are
+// in Status "GOOD".
+size_t Job::countGoodServersInList(Node const& snap, VPackSlice const& serverList) {
+  size_t count = 0;
+  if (!serverList.isArray()) {
+    // No array, strange, return 0
+    return count;
+  }
+  for (VPackSlice const serverName : VPackArrayIterator(serverList)) {
+    if (serverName.isString()) {
+      // serverName not a string? Then don't count
+      std::string serverStr = serverName.copyString();
+      auto health = snap.hasAsChildren(healthPrefix);
+      // Do we have a Health substructure?
+      if (health.second) {
+        Node::Children& healthData = health.first; // List of servers in Health
+        // Now look up this server:
+        auto it = healthData.find(serverStr);
+        if (it != healthData.end()) {
+          // Only check if found
+          std::shared_ptr<Node> healthNode = it->second;
+          // Check its status:
+          if (healthNode->hasAsString("Status").first == "GOOD") {
+            ++count;
+          }
+        }
+      }
+    }
+  }
+  return count;
+}
+
+/// @brief Get servers from plan, which are not failed or (to be) cleaned out
 std::vector<std::string> Job::availableServers(Node const& snapshot) {
   std::vector<std::string> ret;
 
@@ -207,22 +243,31 @@ std::vector<std::string> Job::availableServers(Node const& snapshot) {
     ret.push_back(srv.first);
   }
 
-  // Remove cleaned servers from list (test first to avoid warning log
-  if (snapshot.has(cleanedPrefix)) try {
-      for (auto const& srv :
-           VPackArrayIterator(snapshot.hasAsSlice(cleanedPrefix).first)) {
-        ret.erase(std::remove(ret.begin(), ret.end(), srv.copyString()), ret.end());
-      }
-    } catch (...) {
-    }
+  auto excludePrefix = [&ret, &snapshot](std::string const& prefix, bool isArray) {
 
-  // Remove failed servers from list (test first to avoid warning log)
-  if (snapshot.has(failedServersPrefix)) try {
-      for (auto const& srv : snapshot.hasAsChildren(failedServersPrefix).first) {
+    bool has;
+    VPackSlice slice;
+    Node::Children children;
+
+    if (isArray) {
+      std::tie(slice, has) = snapshot.hasAsSlice(prefix);
+      if (has) {
+        for (auto const& srv : VPackArrayIterator(slice)) {
+          ret.erase(std::remove(ret.begin(), ret.end(), srv.copyString()), ret.end());
+        }
+      }
+    } else {
+      std::tie(children, has) = snapshot.hasAsChildren(prefix);
+      for (auto const& srv : children) {
         ret.erase(std::remove(ret.begin(), ret.end(), srv.first), ret.end());
       }
-    } catch (...) {
     }
+  };
+
+  // Remove (to be) cleaned and failed servers from the list
+  excludePrefix(cleanedPrefix, true);
+  excludePrefix(failedServersPrefix, false);
+  excludePrefix(toBeCleanedPrefix, true);
 
   return ret;
 }
@@ -419,7 +464,7 @@ bool Job::abortable(Node const& snapshot, std::string const& jobId) {
 
 void Job::doForAllShards(Node const& snapshot, std::string& database,
                          std::vector<shard_t>& shards,
-                         std::function<void(Slice plan, Slice current, std::string& planPath)> worker) {
+                         std::function<void(Slice plan, Slice current, std::string& planPath, std::string& curPath)> worker) {
   for (auto const& collShard : shards) {
     std::string shard = collShard.shard;
     std::string collection = collShard.collection;
@@ -432,7 +477,7 @@ void Job::doForAllShards(Node const& snapshot, std::string& database,
     Slice plan = snapshot.hasAsSlice(planPath).first;
     Slice current = snapshot.hasAsSlice(curPath).first;
 
-    worker(plan, current, planPath);
+    worker(plan, current, planPath, curPath);
   }
 }
 

--- a/arangod/Agency/Job.h
+++ b/arangod/Agency/Job.h
@@ -48,6 +48,7 @@ extern std::string const failedPrefix;
 extern std::string const finishedPrefix;
 extern std::string const toDoPrefix;
 extern std::string const cleanedPrefix;
+extern std::string const toBeCleanedPrefix;
 extern std::string const failedServersPrefix;
 extern std::string const planColPrefix;
 extern std::string const curColPrefix;
@@ -121,9 +122,10 @@ struct Job {
 
   /// @brief Get a random server, which is not blocked, in good condition and
   ///        excluding "exclude" vector
-  static std::string randomIdleGoodAvailableServer(Node const& snap,
+  static std::string randomIdleAvailableServer(Node const& snap,
                                                    std::vector<std::string> const& exclude);
-  static std::string randomIdleGoodAvailableServer(Node const& snap, VPackSlice const& exclude);
+  static size_t countGoodServersInList(Node const& snap, VPackSlice const& serverList);
+  static std::string randomIdleAvailableServer(Node const& snap, VPackSlice const& exclude);
 
   /// @brief Get servers from plan, which are not failed or cleaned out
   static std::vector<std::string> availableServers(const arangodb::consensus::Node&);
@@ -151,7 +153,7 @@ struct Job {
 
   static void doForAllShards(
       Node const& snapshot, std::string& database, std::vector<shard_t>& shards,
-      std::function<void(Slice plan, Slice current, std::string& planPath)> worker);
+      std::function<void(Slice plan, Slice current, std::string& planPath, std::string& curPath)> worker);
 
   // The following methods adds an operation to a transaction object or
   // a condition to a precondition object. In all cases, the builder trx

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -340,7 +340,7 @@ bool MoveShard::start() {
 
       // --- Plan changes
       doForAllShards(_snapshot, _database, shardsLikeMe,
-                     [this, &pending](Slice plan, Slice current, std::string& planPath) {
+                     [this, &pending](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                        pending.add(VPackValue(planPath));
                        {
                          VPackArrayBuilder serverList(&pending);
@@ -445,7 +445,7 @@ JOB_STATUS MoveShard::pendingLeader() {
     // Still the old leader, let's check that the toServer is insync:
     size_t done = 0;  // count the number of shards for which _to is in sync:
     doForAllShards(_snapshot, _database, shardsLikeMe,
-                   [this, &done](Slice plan, Slice current, std::string& planPath) {
+                   [this, &done](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                      for (auto const& s : VPackArrayIterator(current)) {
                        if (s.copyString() == _to) {
                          ++done;
@@ -469,7 +469,7 @@ JOB_STATUS MoveShard::pendingLeader() {
         VPackObjectBuilder trxObject(&trx);
         VPackObjectBuilder preObject(&pre);
         doForAllShards(_snapshot, _database, shardsLikeMe,
-                       [this, &trx, &pre](Slice plan, Slice current, std::string& planPath) {
+                       [this, &trx, &pre](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                          // Replace _from by "_" + _from
                          trx.add(VPackValue(planPath));
                          {
@@ -500,7 +500,7 @@ JOB_STATUS MoveShard::pendingLeader() {
     // Retired old leader, let's check that the fromServer has retired:
     size_t done = 0;  // count the number of shards for which leader has retired
     doForAllShards(_snapshot, _database, shardsLikeMe,
-                   [this, &done](Slice plan, Slice current, std::string& planPath) {
+                   [this, &done](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                      if (current.length() > 0 && current[0].copyString() == "_" + _from) {
                        ++done;
                      }
@@ -521,7 +521,7 @@ JOB_STATUS MoveShard::pendingLeader() {
         VPackObjectBuilder trxObject(&trx);
         VPackObjectBuilder preObject(&pre);
         doForAllShards(_snapshot, _database, shardsLikeMe,
-                       [this, &trx, &pre](Slice plan, Slice current, std::string& planPath) {
+                       [this, &trx, &pre](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                          // Replace "_" + _from by _to and leave _from out:
                          trx.add(VPackValue(planPath));
                          {
@@ -556,7 +556,7 @@ JOB_STATUS MoveShard::pendingLeader() {
     // all but except the old leader are in sync:
     size_t done = 0;
     doForAllShards(_snapshot, _database, shardsLikeMe,
-                   [this, &done](Slice plan, Slice current, std::string& planPath) {
+                   [this, &done](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                      if (current.length() > 0 && current[0].copyString() == _to) {
                        if (plan.length() < 3) {
                          // This only happens for replicationFactor == 1, in
@@ -571,7 +571,7 @@ JOB_STATUS MoveShard::pendingLeader() {
                          for (size_t i = 1; i < plan.length() - 1; ++i) {
                            VPackSlice p = plan[i];
                            for (auto const& c : VPackArrayIterator(current)) {
-                             if (arangodb::basics::VelocyPackHelper::compare(p, c, true)) {
+                             if (arangodb::basics::VelocyPackHelper::compare(p, c, true) == 0) {
                                ++found;
                                break;
                              }
@@ -599,7 +599,7 @@ JOB_STATUS MoveShard::pendingLeader() {
         VPackObjectBuilder trxObject(&trx);
         VPackObjectBuilder preObject(&pre);
         doForAllShards(_snapshot, _database, shardsLikeMe,
-                       [&trx, &pre, this](Slice plan, Slice current, std::string& planPath) {
+                       [&trx, &pre, this](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                          if (!_remainsFollower) {
                            // Remove _from from the list of follower
                            trx.add(VPackValue(planPath));
@@ -663,7 +663,7 @@ JOB_STATUS MoveShard::pendingFollower() {
 
   size_t done = 0;  // count the number of shards done
   doForAllShards(_snapshot, _database, shardsLikeMe,
-                 [&done](Slice plan, Slice current, std::string& planPath) {
+                 [&done](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                    if (ClusterHelpers::compareServerLists(plan, current)) {
                      ++done;
                    }
@@ -695,7 +695,7 @@ JOB_STATUS MoveShard::pendingFollower() {
 
       // All changes to Plan for all shards, with precondition:
       doForAllShards(_snapshot, _database, shardsLikeMe,
-                     [this, &trx, &precondition](Slice plan, Slice current, std::string& planPath) {
+                     [this, &trx, &precondition](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                        // Remove fromServer from Plan:
                        trx.add(VPackValue(planPath));
                        {
@@ -754,9 +754,26 @@ arangodb::Result MoveShard::abort() {
     return result;
   }
 
+  // Can now only be PENDING
   // Find the other shards in the same distributeShardsLike group:
   std::vector<Job::shard_t> shardsLikeMe =
-      clones(_snapshot, _database, _collection, _shard);
+    clones(_snapshot, _database, _collection, _shard);
+    
+  // We can no longer abort by reverting to where we started, if any of the
+  // shards of the distributeShardsLike group has already gone to new leader
+  if (_isLeader) {
+    for (auto const& i : shardsLikeMe) {
+      auto const& cur = _snapshot.hasAsArray(
+        curColPrefix + _database + "/" + i.collection + "/" + i.shard + "/" + "servers");
+      if (cur.second && cur.first[0].copyString() == _to) {
+        LOG_TOPIC(INFO, Logger::SUPERVISION) <<
+          "MoveShard can no longer abort through reversion to where it started. Flight forward";
+        finish(_to, _shard, true, "job aborted - new leader already in place");
+        return result;
+      }
+    }
+  }
+  
   Builder trx;  // to build the transaction
 
   // Now look after a PENDING job:
@@ -767,7 +784,7 @@ arangodb::Result MoveShard::abort() {
       if (_isLeader) {
         // All changes to Plan for all shards:
         doForAllShards(_snapshot, _database, shardsLikeMe,
-                       [this, &trx](Slice plan, Slice current, std::string& planPath) {
+                       [this, &trx](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                          // Restore leader to be _from:
                          trx.add(VPackValue(planPath));
                          {
@@ -784,7 +801,7 @@ arangodb::Result MoveShard::abort() {
       } else {
         // All changes to Plan for all shards:
         doForAllShards(_snapshot, _database, shardsLikeMe,
-                       [this, &trx](Slice plan, Slice current, std::string& planPath) {
+                       [this, &trx](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                          // Remove toServer from Plan:
                          trx.add(VPackValue(planPath));
                          {
@@ -805,8 +822,18 @@ arangodb::Result MoveShard::abort() {
       addReleaseServer(trx, _to);
       addIncreasePlanVersion(trx);
     }
+    if (_isLeader) { // Precondition, that current is still as in snapshot
+      VPackObjectBuilder preconditionObj(&trx);
+      // Current preconditions for all shards
+      doForAllShards(
+        _snapshot, _database, shardsLikeMe,
+        [this, &trx](
+          Slice plan, Slice current, std::string& planPath, std::string& curPath) {
+          // Current still as is 
+          trx.add(curPath, current);
+        });
+    }
   }
-
   write_ret_t res = singleWriteTransaction(_agent, trx);
 
   if (!res.accepted) {
@@ -814,10 +841,16 @@ arangodb::Result MoveShard::abort() {
                     std::string("Lost leadership"));
     return result;
   } else if (res.indices[0] == 0) {
+    if (_isLeader) {
+      // Tough luck. Things have changed. We'll move on
+      LOG_TOPIC(INFO, Logger::SUPERVISION) <<
+        "MoveShard can no longer abort through reversion to where it started. Flight forward";
+      finish(_to, _shard, true, "job aborted - new leader already in place");
+      return result;
+    }
     result = Result(
-        TRI_ERROR_SUPERVISION_GENERAL_FAILURE,
-        std::string("Precondition failed while aborting moveShard job ") + _jobId);
-    return result;
+    TRI_ERROR_SUPERVISION_GENERAL_FAILURE,
+    std::string("Precondition failed while aborting moveShard job ") + _jobId);
   }
 
   return result;

--- a/arangod/Agency/RemoveFollower.cpp
+++ b/arangod/Agency/RemoveFollower.cpp
@@ -187,7 +187,7 @@ bool RemoveFollower::start() {
   }
   doForAllShards(_snapshot, _database, shardsLikeMe,
                  [&planned, &overview, &leaderBad](Slice plan, Slice current,
-                                                   std::string& planPath) {
+                                                   std::string& planPath, std::string& curPath) {
                    if (current.length() > 0) {
                      if (current[0].copyString() != planned[0].copyString()) {
                        leaderBad = true;
@@ -347,7 +347,7 @@ bool RemoveFollower::start() {
 
       // --- Plan changes
       doForAllShards(_snapshot, _database, shardsLikeMe,
-                     [&trx, &chosenToRemove](Slice plan, Slice current, std::string& planPath) {
+                     [&trx, &chosenToRemove](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
                        trx.add(VPackValue(planPath));
                        {
                          VPackArrayBuilder serverList(&trx);

--- a/arangod/Cluster/DBServerAgencySync.cpp
+++ b/arangod/Cluster/DBServerAgencySync.cpp
@@ -254,7 +254,9 @@ DBServerAgencySyncResult DBServerAgencySync::execute() {
           }
           operations.push_back(AgencyOperation("Current/Version",
                                                AgencySimpleOperationType::INCREMENT_OP));
-          AgencyWriteTransaction currentTransaction(operations);
+          AgencyPrecondition precondition("Plan/Version",
+            AgencyPrecondition::Type::VALUE, plan->slice().get("Version"));
+          AgencyWriteTransaction currentTransaction(operations, precondition);
           AgencyCommResult r = comm.sendTransactionWithFailover(currentTransaction);
           if (!r.successful()) {
             LOG_TOPIC(ERR, Logger::MAINTENANCE) << "Error reporting to agency";

--- a/lib/Basics/StringUtils.h
+++ b/lib/Basics/StringUtils.h
@@ -66,7 +66,7 @@ std::vector<std::string> split(std::string const& source,
 
 /// @brief joins a string
 template <typename C>
-std::string join(C const& source, std::string const& delim = ",") {
+std::string join(C const& source, std::string const& delim) {
   std::string result;
   bool first = true;
 

--- a/tests/Agency/AddFollowerTest.json
+++ b/tests/Agency/AddFollowerTest.json
@@ -47,7 +47,7 @@ R"=(
           "Status": "GOOD"
         },
         "leader": {
-          "Status": "FAILED"
+          "Status": "GOOD"
         },
         "free": {
           "Status": "GOOD"

--- a/tests/Agency/CleanOutServerTest.json
+++ b/tests/Agency/CleanOutServerTest.json
@@ -58,6 +58,7 @@ R"=(
     },
     "Target": {
       "CleanedServers": [],
+      "ToBeCleanedServers": [],
       "FailedServers": {},
       "MapUniqueToShortID": {
         "follower1": {

--- a/tests/Agency/FailedLeaderTest.json
+++ b/tests/Agency/FailedLeaderTest.json
@@ -41,6 +41,12 @@ R"=(
     "Supervision": {
       "DBServers": {},
       "Health": {
+        "free2": {
+          "Status": "BAD"
+        },
+        "free": {
+          "Status": "GOOD"
+        },
         "follower1": {
           "Status": "GOOD"
         },

--- a/tests/Agency/MoveShardTest.cpp
+++ b/tests/Agency/MoveShardTest.cpp
@@ -1591,9 +1591,10 @@ SECTION("a pending moveshard job should also put the original server back into p
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write)).Do([&](query_t const& q, consensus::AgentInterface::WriteMode w) -> write_ret_t {
     INFO("WriteTransaction: " << q->slice().toJson());
+    LOG_DEVEL << q->slice().toJson() << " " << __LINE__;
     auto writes = q->slice()[0][0];
     CHECK(writes.get("/arango/Target/Pending/1").get("op").copyString() == "delete");
-    REQUIRE(q->slice()[0].length() == 1); // we always simply override! no preconditions...
+    REQUIRE(q->slice()[0].length() == 2); // Precondition: to Server not leader yet 
     CHECK(writes.get("/arango/Supervision/DBServers/" + FREE_SERVER).get("op").copyString() == "delete");
     CHECK(writes.get("/arango/Supervision/Shards/" + SHARD).get("op").copyString() == "delete");
     CHECK(std::string(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD).typeName()) == "array");
@@ -1819,9 +1820,11 @@ SECTION("aborting the job while a leader transition is in progress (for example 
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write)).Do([&](query_t const& q, consensus::AgentInterface::WriteMode w) -> write_ret_t {
     INFO("WriteTransaction: " << q->slice().toJson());
+    LOG_DEVEL << q->slice().toJson() << " " << __LINE__;
+
     auto writes = q->slice()[0][0];
     CHECK(writes.get("/arango/Target/Pending/1").get("op").copyString() == "delete");
-    REQUIRE(q->slice()[0].length() == 1); // we always simply override! no preconditions...
+    REQUIRE(q->slice()[0].length() == 2); // Precondition: to Server not leader yet 
     CHECK(writes.get("/arango/Supervision/DBServers/" + FREE_SERVER).get("op").copyString() == "delete");
     CHECK(writes.get("/arango/Supervision/Shards/" + SHARD).get("op").copyString() == "delete");
     CHECK(std::string(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD).typeName()) == "array");


### PR DESCRIPTION
* Updated CleanoutServerTests. Exclude servers in ToBeCleanedServers. Allow bad servers as new follower.
* Prefer good servers.
* Removed copy, sort and binary_search for a list of ~10 elements.
* Fix move shard bug with compare.
* MoveShard fixes, expansion of doForAllShards
* Count only GOOD servers in actualReplicationFactor.
* Make RemoveFollower remove broken servers.
* Precondition on Plan Version for updating Current as leader.
* CleanupServer to evict server from ToBeCleaned, when aborting
* cleanoutserver with payload in finish
* Use static string for ToBeCleanedOut.
* Fixed typo in log message.
* Change warning level. If a MoveShard job is aborted and we can no longer roll back, then we issue a WARNING rather than a DEBUG log message.
* Another typo and log level.
* Start to fix unit tests.
* Does not make sense for AddFollowerTest to have a FAILED leader.
* Only count GOOD followers in AddFollower.
* Fix AddFollowerTest.
* Report precondition failed in MoveShard follower case.
* Add CHANGELOG.