### PR TITLE
Set thread's state to `STOPPED` when the thread function finishes.

### DIFF
--- a/lib/Basics/Thread.cpp
+++ b/lib/Basics/Thread.cpp
@@ -72,6 +72,7 @@ void Thread::startThread(void* arg) {
   // make sure we drop our reference when we are finished!
   auto guard = scopeGuard([ptr]() {
     LOCAL_THREAD_NAME = nullptr;
+    ptr->_state.store(ThreadState::STOPPED);
     ptr->releaseRef();
   });
 


### PR DESCRIPTION
This fixes a race condition where the thread function would return early when _state is already set to `STOPPING`. This was most likely the cause for the crash of the nightly tests.
