### PR TITLE
Doc - Add missing deprecation note for traversal module

### DIFF
--- a/Documentation/Books/Manual/Graphs/Traversals/UsingTraversalObjects.md
+++ b/Documentation/Books/Manual/Graphs/Traversals/UsingTraversalObjects.md
@@ -1,5 +1,10 @@
-Getting started
-===============
+Using Traversal Objects
+=======================
+
+{% hint 'warning' %}
+The JavaScript module `@arangodb/graph/traversal` (*traversal module* for short)
+is deprecated from version 3.4.0 on. The preferred way to traverse graphs is with AQL.
+{% endhint %}
 
 To use a traversal object, we first need to require the *traversal* module:
 

--- a/Documentation/Books/Manual/ReleaseNotes/UpgradingChanges34.md
+++ b/Documentation/Books/Manual/ReleaseNotes/UpgradingChanges34.md
@@ -738,19 +738,17 @@ This change will be visible only on systems which allow assigning names to
 threads.
 
 
-
-
 Deprecated features
 ===================
 
 The following features and APIs are deprecated in ArangoDB 3.4, and will be 
 removed in future versions of ArangoDB:
 
-* the JavaScript-based traversal REST API at `/_api/traversal`:
+* the JavaScript-based traversal REST API at `/_api/traversal` and the
+  underlaying traversal module `@arangodb/graph/traversal`:
 
   This API has several limitations (including low result set sizes) and has 
-  effectively been unmaintained since the introduction of AQL's general 
-  *TRAVERSAL* clause.
+  effectively been unmaintained since the introduction of native AQL traversal.
 
   It is recommended to migrate client applications that use the REST API at
   `/_api/traversal` to use AQL-based traversal queries instead.


### PR DESCRIPTION
It is the (shared) implementation of /_api/traversal - which we deprecated in v3.4.0

Action/route: [js/actions/api-traversal.js](https://github.com/arangodb/arangodb/blob/devel/js/actions/api-traversal.js)
Traverser included from: [js/common/modules/@arangodb/graph/traversal.js](https://github.com/arangodb/arangodb/blob/devel/js/common/modules/%40arangodb/graph/traversal.js)