### PR TITLE
Doc - Correct AQL function examples

### DIFF
--- a/Documentation/Books/AQL/Functions/Document.md
+++ b/Documentation/Books/AQL/Functions/Document.md
@@ -10,8 +10,8 @@ ATTRIBUTES()
 
 `ATTRIBUTES(document, removeInternal, sort) → strArray`
 
-Return the attribute keys of the *document* as an array. Optionally omit
-system attributes.
+Return the top-level attribute keys of the *document* as an array.
+Optionally omit system attributes and sort the array.
 
 - **document** (object): an arbitrary document / object
 - **removeInternal** (bool, *optional*): whether all system attributes (*_key*, *_id* etc.,

--- a/Documentation/Books/AQL/Functions/Numeric.md
+++ b/Documentation/Books/AQL/Functions/Numeric.md
@@ -424,10 +424,11 @@ RANGE()
 `RANGE(start, stop, step) → numArray`
 
 Return an array of numbers in the specified range, optionally with increments
-other than 1.
+other than 1. The *start* and *stop* arguments are truncated to integers
+unless a *step* argument is provided.
 
-For integer ranges, use the [range operator](../Operators.md#range-operator)
-instead for better performance.
+Also see the [range operator](../Operators.md#range-operator) for ranges
+with integer bounds and a step size of 1.
 
 - **start** (number): the value to start the range at (inclusive)
 - **stop** (number): the value to end the range with (inclusive)
@@ -439,7 +440,8 @@ instead for better performance.
 RANGE(1, 4) // [ 1, 2, 3, 4 ]
 RANGE(1, 4, 2) // [ 1, 3 ]
 RANGE(1, 4, 3) // [ 1, 4 ]
-RANGE(1.5, 2.5) // [ 1.5, 2.5 ]
+RANGE(1.5, 2.5) // [ 1, 2 ]
+RANGE(1.5, 2.5, 1) // [ 1.5, 2.5 ]
 RANGE(1.5, 2.5, 0.5) // [ 1.5, 2, 2.5 ]
 RANGE(-0.75, 1.1, 0.5) // [ -0.75, -0.25, 0.25, 0.75 ]
 ```

--- a/Documentation/Books/AQL/Functions/String.md
+++ b/Documentation/Books/AQL/Functions/String.md
@@ -690,7 +690,7 @@ Split the given string *value* into a list of strings, using the *separator*.
 
 ```js
 SPLIT( "foo-bar-baz", "-" ) // [ "foo", "bar", "baz" ]
-SPLIT( "foo-bar-baz", "-", 1 ) // [ "foo", "bar-baz" ]
+SPLIT( "foo-bar-baz", "-", 1 ) // [ "foo" ]
 SPLIT( "foo, bar & baz", [ ", ", " & " ] ) // [ "foo", "bar", "baz" ]
 ```
 


### PR DESCRIPTION
- [x] SPLIT() with limit
- [x] RANGE() with default step size, see #8296
- [x] ATTRIBUTES() returns top-level attributes only!