### PR TITLE
🚨 Fix struct vs class warning

### DIFF
--- a/arangod/IResearch/IResearchAnalyzerFeature.h
+++ b/arangod/IResearch/IResearchAnalyzerFeature.h
@@ -33,7 +33,7 @@
 #include "Auth/Common.h"
 #include "VocBase/voc-types.h"
 
-class TRI_vocbase_t; // forward declaration
+struct TRI_vocbase_t; // forward declaration
 
 namespace arangodb {
 namespace transaction {


### PR DESCRIPTION
In file included from /home/mop/projects/arangodb/tests/IResearch/IResearchQueryNumericTerm-test.cpp:47:
/home/mop/projects/arangodb/arangod/IResearch/IResearchAnalyzerFeature.h:36:1: warning: class 'TRI_vocbase_t' was previously declared as a struct [-Wmismatched-tags]
class TRI_vocbase_t; // forward declaration
^
/home/mop/projects/arangodb/arangod/VocBase/vocbase.h:121:8: note: previous use is here
struct TRI_vocbase_t {
       ^
/home/mop/projects/arangodb/arangod/IResearch/IResearchAnalyzerFeature.h:36:1: note: did you mean struct here?
class TRI_vocbase_t; // forward declaration
^~~~~

