### PR TITLE
fix an assertion failure when plans are shut down in an invalid state

### DIFF
--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -213,6 +213,7 @@ std::unique_ptr<graph::BaseOptions> createShortestPathOptions(arangodb::aql::Que
 ExecutionPlan::ExecutionPlan(Ast* ast)
     : _ids(),
       _root(nullptr),
+      _planValid(true),
       _varUsageComputed(false),
       _isResponsibleForInitialize(true),
       _nestingLevel(0),
@@ -225,7 +226,7 @@ ExecutionPlan::ExecutionPlan(Ast* ast)
 /// @brief destroy the plan, frees all assigned nodes
 ExecutionPlan::~ExecutionPlan() {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-  if (_root != nullptr) {
+  if (_root != nullptr && _planValid) {
     try {
       // count the actual number of nodes in the plan
       ::NodeCounter counter;

--- a/arangod/Aql/ExecutionPlan.h
+++ b/arangod/Aql/ExecutionPlan.h
@@ -129,6 +129,10 @@ class ExecutionPlan {
     return _root->getCost();
   }
 
+  /// @brief this can be called by the optimizer to tell that the
+  /// plan is temporarily in an invalid state
+  inline void setValidity(bool value) { _planValid = value; }
+
   /// @brief returns true if a plan is so simple that optimizations would
   /// probably cost more than simply executing the plan
   bool isDeadSimple() const;
@@ -168,7 +172,7 @@ class ExecutionPlan {
   /// @brief find all end nodes in a plan
   void findEndNodes(SmallVector<ExecutionNode*>& result, bool enterSubqueries) const;
 
-  /// @brief determine and set _varsUsedLater and _valid and _varSetBy
+  /// @brief determine and set _varsUsedLater and _varSetBy
   void findVarUsage();
 
   /// @brief determine if the above are already set
@@ -335,6 +339,11 @@ class ExecutionPlan {
 
   /// @brief which optimizer rules were applied for a plan
   std::vector<int> _appliedRules;
+
+  /// @brief if the plan is supposed to be in a valid state
+  /// this will always be true, except while a plan is handed to
+  /// the optimizer while applying optimizer rules
+  bool _planValid;
 
   /// @brief flag to indicate whether the variable usage is computed
   bool _varUsageComputed;

--- a/arangod/Aql/Optimizer.cpp
+++ b/arangod/Aql/Optimizer.cpp
@@ -55,6 +55,8 @@ void Optimizer::addPlan(std::unique_ptr<ExecutionPlan> plan,
                         OptimizerRule const* rule, bool wasModified, int newLevel) {
   TRI_ASSERT(plan != nullptr);
   TRI_ASSERT(&_currentRule->second.rule == rule);
+        
+  plan->setValidity(true);
 
   auto it = _currentRule;
 
@@ -170,6 +172,7 @@ int Optimizer::createPlans(std::unique_ptr<ExecutionPlan> plan,
         // - if the rule throws, then the original plan will be deleted by the optimizer.
         //   thus the rule must not have deleted the plan itself or add it
         //   back to the optimizer
+        p->setValidity(false);
         rule.func(this, std::move(p), &rule);
 
         if (!rule.isHidden) {


### PR DESCRIPTION
Should fix the following assertion failures:
```
#0  a_crash () at ./arch/x86_64/atomic_arch.h:108
#1  abort () at src/exit/abort.c:11
#2  0x0000000000c8de70 in arangodb::aql::ExecutionPlan::~ExecutionPlan (this=0x7f7257075340, __in_chrg=<optimized out>)
    at /work/ArangoDB/arangod/Aql/ExecutionPlan.cpp:237
#3  0x000000000065cc68 in std::default_delete<arangodb::aql::ExecutionPlan>::operator() (this=<optimized out>, __ptr=0x7f7257075340)
    at /usr/include/c++/6.4.0/bits/unique_ptr.h:76
#4  std::unique_ptr<arangodb::aql::ExecutionPlan, std::default_delete<arangodb::aql::ExecutionPlan> >::~unique_ptr (
    this=0x7f7266d30958, __in_chrg=<optimized out>) at /usr/include/c++/6.4.0/bits/unique_ptr.h:239
```