### PR TITLE
Feature 3.4:  Implement list command for single server hot backup

### DIFF
--- a/arangod/RestHandler/RestHotBackupHandler.cpp
+++ b/arangod/RestHandler/RestHotBackupHandler.cpp
@@ -70,7 +70,7 @@ RestStatus RestHotBackupHandler::execute() {
       operation->execute();
 
       if (operation->success()) {
-        generateResult(rest::ResponseCode::OK, operation->resultSlice());
+        generateOk(rest::ResponseCode::OK, operation->resultSlice());
       } else {
         reportError();
       }

--- a/arangod/RocksDBEngine/RocksDBHotBackup.cpp
+++ b/arangod/RocksDBEngine/RocksDBHotBackup.cpp
@@ -837,10 +837,21 @@ void RocksDBHotBackupList::execute() {
     hotbackups.erase(found);
   }
 
-  // add two failsafe directory names
+  // add two failsafe directory name string variables (from different branch)
+  found = std::find(hotbackups.begin(), hotbackups.end(), "FAILSAFE");
+  if (hotbackups.end() != found) {
+    hotbackups.erase(found);
+  }
+
+  found = std::find(hotbackups.begin(), hotbackups.end(), "FAILSAFE.1");
+  if (hotbackups.end() != found) {
+    hotbackups.erase(found);
+  }
+
 
   try {
     _result.add(VPackValue(VPackValueType::Object));
+    _result.add("server", VPackValue(getPersistedId()));
     _result.add("hotbackups", VPackValue(VPackValueType::Array));  // open
     for (auto dir : hotbackups) {
       _result.add(VPackValue(dir.c_str()));

--- a/arangod/RocksDBEngine/RocksDBHotBackup.cpp
+++ b/arangod/RocksDBEngine/RocksDBHotBackup.cpp
@@ -860,7 +860,11 @@ void RocksDBHotBackupList::execute() {
     _result.close();
     _success = true;
   } catch (...) {
-  }
+    _respCode = rest::ResponseCode::BAD;
+    _respError = TRI_ERROR_HTTP_SERVER_ERROR;
+    LOG_TOPIC(ERR, arangodb::Logger::ENGINES)
+      << "RocksDBHotBackupList exception generating response.";
+  } // catch
 
   return;
 

--- a/arangod/RocksDBEngine/RocksDBHotBackup.h
+++ b/arangod/RocksDBEngine/RocksDBHotBackup.h
@@ -49,10 +49,10 @@ public:
   int restResponseError() const {return _respError;};
   std::string const& errorMessage() const {return _errorMessage;};
 
-  // @brief Validate and extract parameters appropriate to the operation type
+  /// @brief Validate and extract parameters appropriate to the operation type
   virtual void parseParameters(rest::RequestType const) {};
 
-  // @brief Execute the operation
+  /// @brief Execute the operation
   virtual void execute() {};
 
   VPackSlice resultSlice() {return _result.slice();};
@@ -60,6 +60,11 @@ public:
 
   std::string getRocksDBPath();
   unsigned getTimeout() const {return _timeoutSeconds;}
+
+  /// @brief Build "/user/database/path/hotbackups"
+  std::string rebuildPathPrefix();
+
+  /// @brief Build rebuildPathPrefix() + "/" + suffix
   std::string rebuildPath(const std::string & suffix);
 
 protected:
@@ -138,6 +143,10 @@ protected:
 };// class RocksDBHotBackupCreate
 
 
+////////////////////////////////////////////////////////////////////////////////
+/// @brief POST:  Creates copy of given hotbackup, stops server, moves copy into
+///               production position, restarts process
+////////////////////////////////////////////////////////////////////////////////
 class RocksDBHotBackupRestore : public RocksDBHotBackup {
 public:
 
@@ -172,10 +181,18 @@ protected:
 };// class RocksDBHotBackupRestore
 
 
+////////////////////////////////////////////////////////////////////////////////
+/// @brief POST:  Returns array of Hotbackup directory names
+////////////////////////////////////////////////////////////////////////////////
 class RocksDBHotBackupList : public RocksDBHotBackup {
 public:
 
-  void execute() override {};
+  RocksDBHotBackupList() = delete;
+  RocksDBHotBackupList(const VPackSlice body);
+  ~RocksDBHotBackupList();
+
+  void parseParameters(rest::RequestType const) override;
+  void execute() override;
 
 };// class RocksDBHotBackupList
 

--- a/arangod/RocksDBEngine/RocksDBHotBackupCoord.h
+++ b/arangod/RocksDBEngine/RocksDBHotBackupCoord.h
@@ -54,6 +54,10 @@ public:
 class RocksDBHotBackupListCoord : public RocksDBHotBackup {
 public:
 
+  RocksDBHotBackupListCoord() = delete;
+  RocksDBHotBackupListCoord(const VPackSlice body)
+    : RocksDBHotBackup(body) {};
+
   void execute() override {};
 
 };// class RocksDBHotBackupList


### PR DESCRIPTION
This implements /_admin/hotbackup/list POST method for single server / db server.  It returns a JSON object like {"server": "server_id_string", "hotbackups":["entry 1 of directory name array", "entry 2 of directory name array"]}.  Special directory names like CREATING and FAILSAFE are filtered from the list.

Sample:

{"error":false,"code":200,"result":{"server":"SNGL-9231534b-e1aa-4eb6-881a-0b6c798c6677","hotbackups":["SNGL-9231534b-e1aa-4eb6-881a-0b6c798c6677_2019-02-25T18.35.16Z_before_restore","SNGL-9231534b-e1aa-4eb6-881a-0b6c798c6677_2019-02-25T18.21.11Z","SNGL-9231534b-e1aa-4eb6-881a-0b6c798c6677_2019-02-25T18.55.02Z_before_restore","SNGL-9231534b-e1aa-4eb6-881a-0b6c798c6677_2019-02-25T18.32.58Z_bubba_backup","SNGL-9231534b-e1aa-4eb6-881a-0b6c798c6677_2019-03-05T20.35.58Z_before_restore","SNGL-9231534b-e1aa-4eb6-881a-0b6c798c6677_2019-02-15T20.50.12Z","SNGL-9231534b-e1aa-4eb6-881a-0b6c798c6677_2019-02-15T20.38.01Z","SNGL-9231534b-e1aa-4eb6-881a-0b6c798c6677_2019-02-25T19.18.00Z_before_restore","SNGL-9231534b-e1aa-4eb6-881a-0b6c798c6677_2019-02-15T20.58.23Z","SNGL-9231534b-e1aa-4eb6-881a-0b6c798c6677_2019-03-05T20.36.54Z_before_restore","SNGL-9231534b-e1aa-4eb6-881a-0b6c798c6677_2019-02-25T18.29.26Z_bubba_backup","SNGL-9231534b-e1aa-4eb6-881a-0b6c798c6677_2019-02-15T20.51.13Z"]}}