### PR TITLE
document `includeFoxxQueues` attribute and persist it

### DIFF
--- a/Documentation/Books/Manual/Administration/MasterSlave/DatabaseSetup.md
+++ b/Documentation/Books/Manual/Administration/MasterSlave/DatabaseSetup.md
@@ -176,7 +176,10 @@ An important consideration for replication is whether data from system collectio
 *true*, changes in system collections will be replicated. Otherwise, they will not be replicated. 
 It is often not necessary to replicate data from system collections, especially because it may 
 lead to confusion on the slave because the slave needs to have its own system collections in 
-order to start and keep operational. Please note that there is a seperate option 
+order to start and keep operational.
+
+{% hint 'warning' %}
+There is a separate option
 *includeFoxxQueues* for controlling whether Foxx queue jobs from the system collections `_jobs` 
 and `_queues` collections should be replicated. Documents from these collections are not replicated
 by default in order to avoid execution of Foxx queue jobs on the slave. 

--- a/Documentation/Books/Manual/Administration/MasterSlave/DatabaseSetup.md
+++ b/Documentation/Books/Manual/Administration/MasterSlave/DatabaseSetup.md
@@ -183,6 +183,7 @@ There is a separate option
 *includeFoxxQueues* for controlling whether Foxx queue jobs from the system collections `_jobs` 
 and `_queues` collections should be replicated. Documents from these collections are not replicated
 by default in order to avoid execution of Foxx queue jobs on the slave. 
+{% endhint %}
 
 The *requireFromPresent* attribute controls whether the applier will start synchronizing in case
 it detects that the master cannot provide data for the initial tick value provided by the slave. 

--- a/Documentation/Books/Manual/Administration/MasterSlave/DatabaseSetup.md
+++ b/Documentation/Books/Manual/Administration/MasterSlave/DatabaseSetup.md
@@ -176,7 +176,10 @@ An important consideration for replication is whether data from system collectio
 *true*, changes in system collections will be replicated. Otherwise, they will not be replicated. 
 It is often not necessary to replicate data from system collections, especially because it may 
 lead to confusion on the slave because the slave needs to have its own system collections in 
-order to start and keep operational.
+order to start and keep operational. Please note that there is a seperate option 
+*includeFoxxQueues* for controlling whether Foxx queue jobs from the system collections `_jobs` 
+and `_queues` collections should be replicated. Documents from these collections are not replicated
+by default in order to avoid execution of Foxx queue jobs on the slave. 
 
 The *requireFromPresent* attribute controls whether the applier will start synchronizing in case
 it detects that the master cannot provide data for the initial tick value provided by the slave. 

--- a/Documentation/Books/Manual/Administration/MasterSlave/ReplicationApplier.md
+++ b/Documentation/Books/Manual/Administration/MasterSlave/ReplicationApplier.md
@@ -175,7 +175,10 @@ The *includeSystem* attribute controls whether changes to system collections (su
 *_users*) should be applied. If set to *true*, changes in these collections will be replicated, 
 otherwise, they will not be replicated. It is often not necessary to replicate data from system
 collections, especially because it may lead to confusion on the slave because the slave needs to 
-have its own system collections in order to start and keep operational.
+have its own system collections in order to start and keep operational. Please note that there is 
+a seperate option *includeFoxxQueues* for controlling whether Foxx queue jobs from the system 
+collections `_jobs` and `_queues` collections should be replicated. Documents from these collections 
+are not replicated by default in order to avoid execution of Foxx queue jobs on the slave. 
 
 The *requireFromPresent* attribute controls whether the applier will start synchronizing in case
 it detects that the master cannot provide data for the initial tick value provided by the slave. 

--- a/Documentation/Books/Manual/Administration/MasterSlave/ReplicationApplier.md
+++ b/Documentation/Books/Manual/Administration/MasterSlave/ReplicationApplier.md
@@ -178,7 +178,7 @@ collections, especially because it may lead to confusion on the slave because th
 have its own system collections in order to start and keep operational.
 
 {% hint 'warning' %}
-a seperate option *includeFoxxQueues* for controlling whether Foxx queue jobs from the system 
+There is a separate option *includeFoxxQueues* for controlling whether Foxx queue jobs from the system 
 collections `_jobs` and `_queues` collections should be replicated. Documents from these collections 
 are not replicated by default in order to avoid execution of Foxx queue jobs on the slave. 
 

--- a/Documentation/Books/Manual/Administration/MasterSlave/ReplicationApplier.md
+++ b/Documentation/Books/Manual/Administration/MasterSlave/ReplicationApplier.md
@@ -175,7 +175,9 @@ The *includeSystem* attribute controls whether changes to system collections (su
 *_users*) should be applied. If set to *true*, changes in these collections will be replicated, 
 otherwise, they will not be replicated. It is often not necessary to replicate data from system
 collections, especially because it may lead to confusion on the slave because the slave needs to 
-have its own system collections in order to start and keep operational. Please note that there is 
+have its own system collections in order to start and keep operational.
+
+{% hint 'warning' %}
 a seperate option *includeFoxxQueues* for controlling whether Foxx queue jobs from the system 
 collections `_jobs` and `_queues` collections should be replicated. Documents from these collections 
 are not replicated by default in order to avoid execution of Foxx queue jobs on the slave. 

--- a/Documentation/Books/Manual/Administration/MasterSlave/ServerLevelSetup.md
+++ b/Documentation/Books/Manual/Administration/MasterSlave/ServerLevelSetup.md
@@ -175,7 +175,10 @@ An important consideration for replication is whether data from system collectio
 *true*, changes in system collections will be replicated. Otherwise, they will not be replicated. 
 It is often not necessary to replicate data from system collections, especially because it may 
 lead to confusion on the slave because the slave needs to have its own system collections in 
-order to start and keep operational.
+order to start and keep operational. Please note that there is a seperate option 
+*includeFoxxQueues* for controlling whether Foxx queue jobs from the system collections `_jobs` 
+and `_queues` collections should be replicated. Documents from these collections are not replicated
+by default in order to avoid execution of Foxx queue jobs on the slave. 
 
 The *requireFromPresent* attribute controls whether the applier will start synchronizing in case
 it detects that the master cannot provide data for the initial tick value provided by the slave. 

--- a/Documentation/Books/Manual/Administration/MasterSlave/ServerLevelSetup.md
+++ b/Documentation/Books/Manual/Administration/MasterSlave/ServerLevelSetup.md
@@ -175,7 +175,10 @@ An important consideration for replication is whether data from system collectio
 *true*, changes in system collections will be replicated. Otherwise, they will not be replicated. 
 It is often not necessary to replicate data from system collections, especially because it may 
 lead to confusion on the slave because the slave needs to have its own system collections in 
-order to start and keep operational. Please note that there is a seperate option 
+order to start and keep operational.
+
+{% hint 'warning' %}
+There is a separate option
 *includeFoxxQueues* for controlling whether Foxx queue jobs from the system collections `_jobs` 
 and `_queues` collections should be replicated. Documents from these collections are not replicated
 by default in order to avoid execution of Foxx queue jobs on the slave. 

--- a/Documentation/Books/Manual/Administration/MasterSlave/ServerLevelSetup.md
+++ b/Documentation/Books/Manual/Administration/MasterSlave/ServerLevelSetup.md
@@ -182,6 +182,7 @@ There is a separate option
 *includeFoxxQueues* for controlling whether Foxx queue jobs from the system collections `_jobs` 
 and `_queues` collections should be replicated. Documents from these collections are not replicated
 by default in order to avoid execution of Foxx queue jobs on the slave. 
+{% endhint %}
 
 The *requireFromPresent* attribute controls whether the applier will start synchronizing in case
 it detects that the master cannot provide data for the initial tick value provided by the slave. 

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -1126,10 +1126,9 @@ Result DatabaseInitialSyncer::handleCollection(VPackSlice const& parameters,
         if (col != nullptr) {
           bool truncate = false;
 
-          if (col->name() == TRI_COL_NAME_USERS) {
-            // better not throw away the _users collection. otherwise it is gone
-            // and this may be a problem if the
-            // server crashes in-between.
+          if (col->system()) {
+            // better not throw away system collections. otherwise they may be dropped
+            // and this can be a problem if the server crashes before they are recreated.
             truncate = true;
           }
 

--- a/arangod/Replication/GlobalInitialSyncer.cpp
+++ b/arangod/Replication/GlobalInitialSyncer.cpp
@@ -202,7 +202,7 @@ Result GlobalInitialSyncer::runInternal(bool incremental) {
                                _state.barrier.updateTime, _batch.id, _batch.updateTime);
 
       // run the syncer with the supplied inventory collections
-      Result r = syncer->runWithInventory(false, dbInventory);
+      Result r = syncer->runWithInventory(incremental, dbInventory);
       if (r.fail()) {
         return r;
       }
@@ -220,7 +220,7 @@ Result GlobalInitialSyncer::runInternal(bool incremental) {
     return Result(TRI_ERROR_INTERNAL, "caught an unexpected exception");
   }
 
-  return TRI_ERROR_NO_ERROR;
+  return Result();
 }
 
 /// @brief add or remove databases such that the local inventory
@@ -342,7 +342,7 @@ Result GlobalInitialSyncer::updateServerInventory(VPackSlice const& masterDataba
     }
   }
 
-  return TRI_ERROR_NO_ERROR;
+  return Result();
 }
 
 /// @brief fetch the server's inventory, public method for TailingSyncer

--- a/arangod/Replication/ReplicationApplierConfiguration.cpp
+++ b/arangod/Replication/ReplicationApplierConfiguration.cpp
@@ -59,12 +59,11 @@ ReplicationApplierConfiguration::ReplicationApplierConfiguration()
       _adaptivePolling(true),
       _autoResync(false),
       _includeSystem(true),
+      _includeFoxxQueues(false),
       _requireFromPresent(true),
       _incremental(false),
       _verbose(false),
-      _restrictType(RestrictType::None),
-      _restrictCollections(),
-      _includeFoxxQueues(false) {}
+      _restrictType(RestrictType::None) {}
 
 /// @brief reset the configuration to defaults
 void ReplicationApplierConfiguration::reset() {
@@ -91,12 +90,12 @@ void ReplicationApplierConfiguration::reset() {
   _adaptivePolling = true;
   _autoResync = false;
   _includeSystem = true;
+  _includeFoxxQueues = false;
   _requireFromPresent = true;
   _incremental = false;
   _verbose = false;
   _restrictType = RestrictType::None;
   _restrictCollections.clear();
-  _includeFoxxQueues = false;
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   _force32mode = false;
 #endif
@@ -140,6 +139,7 @@ void ReplicationApplierConfiguration::toVelocyPack(VPackBuilder& builder, bool i
   builder.add("autoResyncRetries", VPackValue(_autoResyncRetries));
   builder.add("maxPacketSize", VPackValue(_maxPacketSize));
   builder.add("includeSystem", VPackValue(_includeSystem));
+  builder.add("includeFoxxQueues", VPackValue(_includeFoxxQueues));
   builder.add("requireFromPresent", VPackValue(_requireFromPresent));
   builder.add("verbose", VPackValue(_verbose));
   builder.add("incremental", VPackValue(_incremental));
@@ -270,6 +270,11 @@ ReplicationApplierConfiguration ReplicationApplierConfiguration::fromVelocyPack(
   value = slice.get("includeSystem");
   if (value.isBoolean()) {
     configuration._includeSystem = value.getBoolean();
+  }
+  
+  value = slice.get("includeFoxxQueues");
+  if (value.isBoolean()) {
+    configuration._includeFoxxQueues = value.getBoolean();
   }
 
   value = slice.get("requireFromPresent");

--- a/arangod/Replication/ReplicationApplierConfiguration.h
+++ b/arangod/Replication/ReplicationApplierConfiguration.h
@@ -60,13 +60,13 @@ class ReplicationApplierConfiguration {
   bool _adaptivePolling;
   bool _autoResync;  /// resync completely if we miss updates
   bool _includeSystem;
+  bool _includeFoxxQueues; /// sync the _jobs and _queues collection
   bool _requireFromPresent;  /// while tailing WAL: master must have the clients
                              /// requested tick
   bool _incremental;         /// use incremental sync if we got local data
   bool _verbose;
   RestrictType _restrictType;
   std::set<std::string> _restrictCollections;
-  bool _includeFoxxQueues; /// sync the _jobs collection
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   bool _force32mode = false;  // force client to act like 3.2
 #endif

--- a/js/server/server.js
+++ b/js/server/server.js
@@ -65,7 +65,12 @@
       }
 
       // start the queue manager once
-      require('@arangodb/foxx/queues/manager').run();
+      try {
+        require('@arangodb/foxx/queues/manager').run();
+      } catch (err) {
+        require("console").warn("unable to start Foxx queues manager: " + String(err));
+        // continue with the startup!
+      }
     }
 
     // check available versions


### PR DESCRIPTION
Additionally, make active failover do an incremental sync instead of
a full sync. Finally, don't drop system collections when resyncing,
but only truncate them. This can avoid problems when a follower is
killed/stopped between having dropped a system collection and recreating
it.