### PR TITLE
Fix an agency crash.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -284,6 +284,13 @@ devel
 
 * use `-std=c++14` for ArangoDB compilation
 
+* in case of resigned leader, set isReady=false in clusterInventory
+
+* abort RemoveFollower job if not enough in-sync followers or leader failure
+
+* fix shrinkCluster for satelliteCollections
+
+* fix crash in agency supervision when leadership is lost
 
 v3.4.1 (XXXX-XX-XX)
 -------------------

--- a/arangod/Agency/FailedFollower.cpp
+++ b/arangod/Agency/FailedFollower.cpp
@@ -276,12 +276,16 @@ bool FailedFollower::start(bool& aborts) {
       JobContext(PENDING, jobId.first, _snapshot, _agent).abort();
       return false;
     }
-  } 
+  }
 
   LOG_TOPIC(DEBUG, Logger::SUPERVISION)
       << "FailedFollower start transaction: " << job.toJson();
 
   auto res = generalTransaction(_agent, job);
+  if (!res.accepted) {  // lost leadership
+    LOG_TOPIC(INFO, Logger::SUPERVISION) << "Leadership lost! Job " << _jobId << " handed off.";
+    return false;
+  }
 
   LOG_TOPIC(DEBUG, Logger::SUPERVISION)
       << "FailedFollower start result: " << res.result->toJson();

--- a/arangod/Agency/FailedLeader.cpp
+++ b/arangod/Agency/FailedLeader.cpp
@@ -320,9 +320,8 @@ bool FailedLeader::start(bool& aborts) {
 
   trans_ret_t res = generalTransaction(_agent, pending);
 
-  if (!res.accepted) {
-    LOG_TOPIC(INFO, Logger::SUPERVISION)
-      << "Agency transaction not successful";
+  if (!res.accepted) {  // lost leadership
+    LOG_TOPIC(INFO, Logger::SUPERVISION) << "Leadership lost! Job " << _jobId << " handed off.";
     return false;
   }
 
@@ -332,15 +331,11 @@ bool FailedLeader::start(bool& aborts) {
   // Something went south. Let's see
   auto result = res.result->slice()[0];
 
-  if (res.accepted && result.isNumber()) {
+  if (result.isNumber()) {
     return true;
   }
 
   TRI_ASSERT(result.isObject());
-
-  if (!res.accepted) {  // lost leadership
-    LOG_TOPIC(INFO, Logger::SUPERVISION) << "Leadership lost! Job " << _jobId << " handed off.";
-  }
 
   if (result.isObject()) {
     // Still failing _from?

--- a/arangod/Agency/FailedLeader.cpp
+++ b/arangod/Agency/FailedLeader.cpp
@@ -320,6 +320,12 @@ bool FailedLeader::start(bool& aborts) {
 
   trans_ret_t res = generalTransaction(_agent, pending);
 
+  if (!res.accepted) {
+    LOG_TOPIC(INFO, Logger::SUPERVISION)
+      << "Agency transaction not successful";
+    return false;
+  }
+
   LOG_TOPIC(DEBUG, Logger::SUPERVISION)
       << "FailedLeader result: " << res.result->toJson();
 


### PR DESCRIPTION
- Check if transaction failed before accessing the result.
 - FailedFollower has the same bug.