### PR TITLE
Port agency crash fixes to 3.3.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,8 @@ v3.3.23 (XXXX-XX-XX)
 
 * fix shrinkCluster for satellite collections
 
+* fix an agency crash in case of a leader change
+
 v3.3.22 (2019-02-01)
 --------------------
 

--- a/arangod/Agency/FailedFollower.cpp
+++ b/arangod/Agency/FailedFollower.cpp
@@ -273,12 +273,16 @@ bool FailedFollower::start(bool& aborts) {
       JobContext(PENDING, jobId.first, _snapshot, _agent).abort();
       return false;
     }
-  } 
+  }
 
   LOG_TOPIC(DEBUG, Logger::SUPERVISION)
       << "FailedFollower start transaction: " << job.toJson();
 
   auto res = generalTransaction(_agent, job);
+  if (!res.accepted) {  // lost leadership
+    LOG_TOPIC(INFO, Logger::SUPERVISION) << "Leadership lost! Job " << _jobId << " handed off.";
+    return false;
+  }
 
   LOG_TOPIC(DEBUG, Logger::SUPERVISION)
       << "FailedFollower start result: " << res.result->toJson();

--- a/arangod/Agency/FailedLeader.cpp
+++ b/arangod/Agency/FailedLeader.cpp
@@ -320,9 +320,8 @@ bool FailedLeader::start(bool& aborts) {
 
   trans_ret_t res = generalTransaction(_agent, pending);
 
-  if (!res.accepted) {
-    LOG_TOPIC(INFO, Logger::SUPERVISION)
-      << "Agency transaction not successful";
+  if (!res.accepted) {  // lost leadership
+    LOG_TOPIC(INFO, Logger::SUPERVISION) << "Leadership lost! Job " << _jobId << " handed off.";
     return false;
   }
 
@@ -332,15 +331,11 @@ bool FailedLeader::start(bool& aborts) {
   // Something went south. Let's see
   auto result = res.result->slice()[0];
 
-  if (res.accepted && result.isNumber()) {
+  if (result.isNumber()) {
     return true;
   }
 
   TRI_ASSERT(result.isObject());
-
-  if (!res.accepted) {  // lost leadership
-    LOG_TOPIC(INFO, Logger::SUPERVISION) << "Leadership lost! Job " << _jobId << " handed off.";
-  }
 
   if (result.isObject()) {
     // Still failing _from?

--- a/arangod/Agency/FailedLeader.cpp
+++ b/arangod/Agency/FailedLeader.cpp
@@ -320,6 +320,12 @@ bool FailedLeader::start(bool& aborts) {
 
   trans_ret_t res = generalTransaction(_agent, pending);
 
+  if (!res.accepted) {
+    LOG_TOPIC(INFO, Logger::SUPERVISION)
+      << "Agency transaction not successful";
+    return false;
+  }
+
   LOG_TOPIC(DEBUG, Logger::SUPERVISION)
       << "FailedLeader result: " << res.result->toJson();
 


### PR DESCRIPTION
- Check if transaction failed before accessing the result.
 - FailedFollower has the same bug.