### PR TITLE
StorageEngineMock: Prevent deadlock

### DIFF
--- a/tests/Mocks/StorageEngineMock.cpp
+++ b/tests/Mocks/StorageEngineMock.cpp
@@ -1569,7 +1569,9 @@ int TransactionCollectionMock::use(int nestingLevel) {
     }
   }
 
-  _collection = _transaction->vocbase().useCollection(_cid, status);
+  if (!_collection) {
+    _collection = _transaction->vocbase().useCollection(_cid, status);
+  }
 
   return _collection ? TRI_ERROR_NO_ERROR : TRI_ERROR_INTERNAL;
 }


### PR DESCRIPTION
This bug showed up while implementing some tests for path finding.

Thanks to Michael Hackstein <michael@arangodb.com> for debugging.