### PR TITLE
Feature 3.4:  Hot backup delete API (single server)

### DIFF
--- a/arangod/RestHandler/RestHotBackupHandler.cpp
+++ b/arangod/RestHandler/RestHotBackupHandler.cpp
@@ -53,7 +53,11 @@ RestStatus RestHotBackupHandler::execute() {
 
       // if !valid() then !success() already set
       if (operation->success()) {
-        generateOk(rest::ResponseCode::OK, operation->resultSlice());
+        if (operation->result().isEmpty()) {
+          generateOk(rest::ResponseCode::OK, velocypack::Slice::emptyObjectSlice());
+        } else {
+          generateOk(rest::ResponseCode::OK, operation->resultSlice());
+        } // else
       } else {
         if (!operation->result().isEmpty()) {
           std::string msg = "Error, details: ";

--- a/arangod/RestHandler/RestHotBackupHandler.h
+++ b/arangod/RestHandler/RestHotBackupHandler.h
@@ -46,6 +46,8 @@ class RestHotBackupHandler : public RestBaseHandler {
   //////////////////////////////////////////////////////////////////////////////
 
  protected:
+  bool verifyPermitted();
+
   std::shared_ptr<RocksDBHotBackup> parseHotBackupParams(RequestType const,
                                                          std::vector<std::string> const &);
  private:

--- a/arangod/RocksDBEngine/RocksDBHotBackup.h
+++ b/arangod/RocksDBEngine/RocksDBHotBackup.h
@@ -133,12 +133,13 @@ protected:
   void executeCreate();
 
   // @brief Execute the delete operation
-  void executeDelete() {};
+  void executeDelete();
 
   bool _isCreate;
   bool _forceBackup;
-  std::string _timestamp;
+  std::string _timestamp;   // required for Create from Coordinator
   std::string _userString;
+  std::string _directory;   // required for Delete
 
 };// class RocksDBHotBackupCreate
 
@@ -194,6 +195,26 @@ public:
   void execute() override;
 
 };// class RocksDBHotBackupList
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief POST:  Set lock on rocksdb transactions
+///       DELETE:  Remove lock on rocksdb transactions
+////////////////////////////////////////////////////////////////////////////////
+class RocksDBHotBackupLock : public RocksDBHotBackup {
+public:
+
+  RocksDBHotBackupLock() = delete;
+  RocksDBHotBackupLock(const VPackSlice body);
+  ~RocksDBHotBackupLock();
+
+  void parseParameters(rest::RequestType const) override;
+  void execute() override;
+
+protected:
+  bool _isLock;
+
+};// class RocksDBHotBackupLock
 
 
 class RocksDBHotBackupPolicy : public RocksDBHotBackup {

--- a/arangod/RocksDBEngine/RocksDBHotBackupCoord.h
+++ b/arangod/RocksDBEngine/RocksDBHotBackupCoord.h
@@ -63,6 +63,18 @@ public:
 };// class RocksDBHotBackupList
 
 
+class RocksDBHotBackupLockCoord : public RocksDBHotBackup {
+public:
+
+  RocksDBHotBackupLockCoord() = delete;
+  RocksDBHotBackupLockCoord(const VPackSlice body)
+    : RocksDBHotBackup(body) {};
+
+  void execute() override {};
+
+};// class RocksDBHotBackupLock
+
+
 class RocksDBHotBackupPolicyCoord : public RocksDBHotBackup {
 public:
 


### PR DESCRIPTION
This implements the delete operation.  A sample API call to delete the FAILSAFE directory is:

<pre>
wget --body-data '{"directory": "FAILSAFE"}'  --method DELETE http://192.168.42.72:8529/_admin/hotbackup/create
</pre>

The lock api is stubbed out and available, though not functional:

<pre>

wget --post-data '' http://192.168.42.72:8529/_admin/hotbackup/lock

 wget --body-data '' --method DELETE  http://192.168.42.72:8529/_admin/hotbackup/lock

</pre>
