### PR TITLE
Doc - fetchRefs.sh - Process every distinct SYNC marker once

### DIFF
--- a/Documentation/Scripts/fetchRefs.sh
+++ b/Documentation/Scripts/fetchRefs.sh
@@ -6,11 +6,12 @@ ALLBOOKS="HTTP AQL Manual Cookbook Drivers"
 
 GITAUTH="$1"
 
-for book in ${ALLBOOKS}; do 
+for book in ${ALLBOOKS}; do
 
     repos=$(grep '^ *<!-- SYNC: ' "../Books/${book}/SUMMARY.md" |sed -r 's;^ *<!-- SYNC: (.+) -->$;\1;')
+    reposUnique=$(awk '!seen[$0]++' <(for oneRepo in ${repos}; do echo ${oneRepo}; done))
 
-    for oneRepo in ${repos}; do
+    for oneRepo in ${reposUnique}; do
 
         REPO=$(echo     "$oneRepo" |cut -d ';' -f 1)
         CLONEDIR=$(echo "$oneRepo" |cut -d ';' -f 2)
@@ -18,31 +19,36 @@ for book in ${ALLBOOKS}; do
         SRC=$(echo      "$oneRepo" |cut -d ';' -f 4)
         DST=$(echo      "$oneRepo" |cut -d ';' -f 5)
 
-
         CODIR="../Books/repos/${CLONEDIR}"
         AUTHREPO="${REPO/@/${GITAUTH}@}"
-        if test -d "${CODIR}"; then
-            (
-                cd "${CODIR}"
-                git pull --all
-            )
-        else
-            if test "${GITAUTH}" == "git"; then
-                AUTHREPO=$(echo "${AUTHREPO}" | sed -e "s;github.com/;github.com:;" -e "s;https://;;" )
-            fi
-            git clone "${AUTHREPO}" "${CODIR}"
+
+        if test "${GITAUTH}" == "git"; then
+            AUTHREPO=$(echo "${AUTHREPO}" | sed -e "s;github.com/;github.com:;" -e "s;https://;;" )
         fi
+
+        echo
+        echo "Syncing ${AUTHREPO} -> ${CLONEDIR}"
 
         # extract branch/tag/... for checkout from VERSIONS file
         branch=$(grep "EXTERNAL_DOC_${CLONEDIR}=" "../../VERSIONS" | sed "s/^EXTERNAL_DOC_${CLONEDIR}=//")
 
         if [ -z "${branch}" ]; then
-            echo "no branch for ${CLONEDIR}, specify in VERSIONS file."
+            echo "Branch for ${CLONEDIR} needs to be specified in VERSIONS file!"
             exit 1
         fi
 
-        # checkout name from VERSIONS file and pull=merge origin
-        (cd "${CODIR}" && git checkout "${branch}" && git pull)
+        if test -d "${CODIR}"; then
+            # checkout branch as specified in VERSIONS file, update by pulling (ff or merge)
+            (
+                cd "${CODIR}"
+                git fetch
+                git checkout "${branch}"
+                git merge FETCH_HEAD # --ff-only ?
+            )
+        else
+            # clone the desired branch directly (but fetch everything)
+            git clone --branch "${branch}" "${AUTHREPO}" "${CODIR}"
+        fi
 
         for oneMD in $(cd "${CODIR}/${SUBDIR}"; find "./${SRC}" -type f |sed "s;\./;;"); do
             NAME=$(basename "${oneMD}")

--- a/Documentation/Scripts/fetchRefs.sh
+++ b/Documentation/Scripts/fetchRefs.sh
@@ -9,7 +9,7 @@ GITAUTH="$1"
 for book in ${ALLBOOKS}; do
 
     repos=$(grep '^ *<!-- SYNC: ' "../Books/${book}/SUMMARY.md" |sed -r 's;^ *<!-- SYNC: (.+) -->$;\1;')
-    reposUnique=$(awk '!seen[$0]++' <(for oneRepo in ${repos}; do echo ${oneRepo}; done))
+    reposUnique=$(awk '!seen[$0]++' <(for oneRepo in ${repos}; do echo "${oneRepo}"; done))
 
     for oneRepo in ${reposUnique}; do
 


### PR DESCRIPTION
Also avoid double-pull or hidden fetch, better logging

Internal ref:
- https://github.com/arangodb/planning/issues/3504