### PR TITLE
revert a previous change that caused existing system collections on a…

### DIFF
--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -1128,9 +1128,10 @@ Result DatabaseInitialSyncer::handleCollection(VPackSlice const& parameters,
         if (col != nullptr) {
           bool truncate = false;
 
-          if (col->system()) {
-            // better not throw away system collections. otherwise they may be dropped
-            // and this can be a problem if the server crashes before they are recreated.
+          if (col->name() == TRI_COL_NAME_USERS) {
+            // better not throw away the _users collection. otherwise it is gone
+            // and this may be a problem if the
+            // server crashes in-between.
             truncate = true;
           }
 


### PR DESCRIPTION
… slave to be truncated instead of being deleted

truncating instead of deleting introduced the possibility of the collection's indexes continuing to exist with different ids on the slave than on the master, leading to potential follow-up problems
