### PR TITLE
Doc - Dump program options only if on Enterprise Edition

### DIFF
--- a/utils/generateExamples.sh
+++ b/utils/generateExamples.sh
@@ -16,8 +16,8 @@ DBDIR="out${PS}data-$PID"
 
 mkdir -p ${DBDIR}
 
-echo Database has its data in ${DBDIR}
-echo Logfile is in ${LOGFILE}
+echo "Database has its data in ${DBDIR}"
+echo "Logfile is in ${LOGFILE}"
 
 if [ $(uname -s) == "Darwin" ]; then
     EXEC_PATH="$(dirname "$(dirname "$0")")"
@@ -48,12 +48,15 @@ fi
 [ "$(uname -s)" != "Darwin" -a -x "${ARANGOSH}" ] && ARANGOSH="$(readlink -m "${ARANGOSH}")"
 [ "$(uname -s)" = "Darwin" -a -x "${ARANGOSH}" ] && ARANGOSH="$(cd -P -- "$(dirname -- "${ARANGOSH}")" && pwd -P)/$(basename -- "${ARANGOSH}")"
 
-
-ALLPROGRAMS="arangobench arangod arangodump arangoexport arangoimport arangoinspect arangorestore arangosh"
-
-for HELPPROGRAM in ${ALLPROGRAMS}; do
-    "${BIN_PATH}/${HELPPROGRAM}${EXT}" --dump-options > "Documentation/Examples/${HELPPROGRAM}.json"
-done
+# 
+if "${ARANGOSH}" --version | grep -q "^enterprise-version: enterprise$"; then
+    ALLPROGRAMS="arangobench arangod arangodump arangoexport arangoimport arangoinspect arangorestore arangosh"
+    for HELPPROGRAM in ${ALLPROGRAMS}; do
+        "${BIN_PATH}/${HELPPROGRAM}${EXT}" --dump-options > "Documentation/Examples/${HELPPROGRAM}.json"
+    done
+else
+    echo "skipping program option dump (requires Enterprise Edition binaries)"
+fi
 
 "${ARANGOSH}" \
     --configuration none \

--- a/utils/generateExamples.sh
+++ b/utils/generateExamples.sh
@@ -48,13 +48,13 @@ fi
 [ "$(uname -s)" != "Darwin" -a -x "${ARANGOSH}" ] && ARANGOSH="$(readlink -m "${ARANGOSH}")"
 [ "$(uname -s)" = "Darwin" -a -x "${ARANGOSH}" ] && ARANGOSH="$(cd -P -- "$(dirname -- "${ARANGOSH}")" && pwd -P)/$(basename -- "${ARANGOSH}")"
 
-# 
 if "${ARANGOSH}" --version | grep -q "^enterprise-version: enterprise$"; then
     ALLPROGRAMS="arangobench arangod arangodump arangoexport arangoimport arangoinspect arangorestore arangosh"
     for HELPPROGRAM in ${ALLPROGRAMS}; do
         "${BIN_PATH}/${HELPPROGRAM}${EXT}" --dump-options > "Documentation/Examples/${HELPPROGRAM}.json"
     done
 else
+    # should stop people from committing the JSON files without EE options
     echo "skipping program option dump (requires Enterprise Edition binaries)"
 fi
 

--- a/utils/generateExamples.sh
+++ b/utils/generateExamples.sh
@@ -51,11 +51,12 @@ fi
 if "${ARANGOSH}" --version | grep -q "^enterprise-version: enterprise$"; then
     ALLPROGRAMS="arangobench arangod arangodump arangoexport arangoimport arangoinspect arangorestore arangosh"
     for HELPPROGRAM in ${ALLPROGRAMS}; do
+        echo "Dumping program options of ${HELPPROGRAM}"
         "${BIN_PATH}/${HELPPROGRAM}${EXT}" --dump-options > "Documentation/Examples/${HELPPROGRAM}.json"
     done
 else
     # should stop people from committing the JSON files without EE options
-    echo "skipping program option dump (requires Enterprise Edition binaries)"
+    echo "Skipping program option dump (requires Enterprise Edition binaries)"
 fi
 
 "${ARANGOSH}" \


### PR DESCRIPTION
Skip Examples/*.json generation if the available build is a Community Edition version. This should avoid accidental commits to these files which remove Enterprise Edition only startup options.