### PR TITLE
Fix crash in test for ConstantWeightShortestPathFinder

### DIFF
--- a/tests/Graph/ConstantWeightShortestPathFinder.cpp
+++ b/tests/Graph/ConstantWeightShortestPathFinder.cpp
@@ -145,11 +145,12 @@ struct MockGraphDatabase {
 
   ~MockGraphDatabase() {
     for (auto& q : queries) {
-      q->trx()->abort();
+      if (q->trx() != nullptr) {
+        q->trx()->abort();
+      }
       delete q;
     }
     for (auto& o : spos) {
-      o->trx()->abort();
       delete o;
     }
   }


### PR DESCRIPTION
The test tried to abort a transaction twice which made the testing process crash sometimes. This removes the symptom (crashing), but not the cause: 

The transaction is shared between the query and the `ShortestPathOptions` and deleting the query leaves the transaction in a state that causes it to crash when `abort()` is called.