### PR TITLE
don't run compact() on a collection after a truncate() was done in th…

### DIFF
--- a/Documentation/Books/Manual/Appendix/References/CollectionObject.md
+++ b/Documentation/Books/Manual/Appendix/References/CollectionObject.md
@@ -6,7 +6,7 @@ The following methods exist on the collection object (returned by *db.name*):
 *Collection*
 
 * [collection.checksum()](../../DataModeling/Collections/CollectionMethods.md#checksum)
-* [collection.compact()](../../DataModeling/Documents/DocumentMethods.md#compact)
+* [collection.compact()](../../DataModeling/Collections/CollectionMethods.md#compact)
 * [collection.count()](../../DataModeling/Documents/DocumentMethods.md#count)
 * [collection.drop()](../../DataModeling/Collections/CollectionMethods.md#drop)
 * [collection.figures()](../../DataModeling/Collections/CollectionMethods.md#figures)

--- a/Documentation/Books/Manual/Appendix/References/CollectionObject.md
+++ b/Documentation/Books/Manual/Appendix/References/CollectionObject.md
@@ -6,6 +6,7 @@ The following methods exist on the collection object (returned by *db.name*):
 *Collection*
 
 * [collection.checksum()](../../DataModeling/Collections/CollectionMethods.md#checksum)
+* [collection.compact()](../../DataModeling/Documents/DocumentMethods.md#compact)
 * [collection.count()](../../DataModeling/Documents/DocumentMethods.md#count)
 * [collection.drop()](../../DataModeling/Collections/CollectionMethods.md#drop)
 * [collection.figures()](../../DataModeling/Collections/CollectionMethods.md#figures)

--- a/Documentation/Books/Manual/DataModeling/Collections/CollectionMethods.md
+++ b/Documentation/Books/Manual/DataModeling/Collections/CollectionMethods.md
@@ -73,6 +73,29 @@ Truncates a collection:
     @endDocuBlock collectionTruncate
 
 
+Compact
+-------
+
+<!-- js/server/modules/@arangodb/arango-collection.js-->
+
+Compacts the data of a collection
+`collection.compact()`
+
+Compacts the data of a collection in order to reclaim disk space. For the
+MMFiles storage engine, the operation will reset the collection's last
+compaction timestamp, so it will become a candidate for compaction. For the
+RocksDB storage engine, the operation will compact the document and index
+data by rewriting the underlying .sst files and only keeping the relevant
+entries.
+
+Under normal circumstances running a compact operation is not necessary,
+as the collection data will eventually get compacted anyway. However, in 
+some situations, e.g. after running lots of update/replace or remove 
+operations, the disk data for a collection may contain a lot of outdated data
+for which the space shall be reclaimed. In this case the compaction operation
+can be used.
+
+
 Properties
 ----------
 

--- a/arangod/ClusterEngine/ClusterCollection.cpp
+++ b/arangod/ClusterEngine/ClusterCollection.cpp
@@ -418,6 +418,11 @@ void ClusterCollection::invokeOnAllElements(transaction::Methods* trx,
 Result ClusterCollection::truncate(transaction::Methods& trx, OperationOptions& options) {
   return Result(TRI_ERROR_NOT_IMPLEMENTED);
 }
+  
+/// @brief compact-data operation
+Result ClusterCollection::compact() {
+  return {};
+}
 
 LocalDocumentId ClusterCollection::lookupKey(transaction::Methods* trx,
                                              VPackSlice const& key) const {

--- a/arangod/ClusterEngine/ClusterCollection.h
+++ b/arangod/ClusterEngine/ClusterCollection.h
@@ -120,6 +120,9 @@ class ClusterCollection final : public PhysicalCollection {
   ///////////////////////////////////
 
   Result truncate(transaction::Methods& trx, OperationOptions& options) override;
+  
+  /// @brief compact-data operation
+  Result compact() override;
 
   void deferDropCollection(std::function<bool(LogicalCollection&)> const& callback) override;
 

--- a/arangod/MMFiles/MMFilesCollection.cpp
+++ b/arangod/MMFiles/MMFilesCollection.cpp
@@ -2814,6 +2814,16 @@ Result MMFilesCollection::truncate(transaction::Methods& trx, OperationOptions& 
   return Result();
 }
 
+/// @brief compact-data operation
+Result MMFilesCollection::compact() {
+  // this will only reset the last compaction timestamp,
+  // so the collection becomes eligible for the next round of compactions
+  MUTEX_LOCKER(mutexLocker, _compactionStatusLock);
+  _lastCompactionStamp = 0.0;
+
+  return {};
+}
+
 LocalDocumentId MMFilesCollection::reuseOrCreateLocalDocumentId(OperationOptions const& options) const {
   if (options.recoveryData != nullptr) {
     auto marker = static_cast<MMFilesWalMarker*>(options.recoveryData);

--- a/arangod/MMFiles/MMFilesCollection.h
+++ b/arangod/MMFiles/MMFilesCollection.h
@@ -270,6 +270,9 @@ class MMFilesCollection final : public PhysicalCollection {
 
   Result truncate(transaction::Methods& trx, OperationOptions& options) override;
 
+  /// @brief compact-data operation
+  Result compact() override;
+
   /// @brief Defer a callback to be executed when the collection
   ///        can be dropped. The callback is supposed to drop
   ///        the collection and it is guaranteed that no one is using

--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -383,22 +383,37 @@ void RestCollectionHandler::handleCommandPut() {
                                  /*showFigures*/ false, /*showCount*/ false,
                                  /*detailedCount*/ true);
       }
-    } else if (sub == "truncate") {
-      OperationOptions opts;
-
-      opts.waitForSync = _request->parsedValue("waitForSync", false);
-      opts.isSynchronousReplicationFrom =
-          _request->value("isSynchronousReplication");
-
-      auto trx = createTransaction(coll->name(), AccessMode::Type::EXCLUSIVE);
-      trx->addHint(transaction::Hints::Hint::INTERMEDIATE_COMMITS);
-      trx->addHint(transaction::Hints::Hint::ALLOW_RANGE_DELETE);
-      res = trx->begin();
-
+    } else if (sub == "compact") {
+      res = coll->compact();
+      
       if (res.ok()) {
-        auto result = trx->truncate(coll->name(), opts);
-        res = trx->finish(result.result);
+        collectionRepresentation(builder, name, /*showProperties*/ false,
+                                 /*showFigures*/ false, /*showCount*/ false,
+                                 /*detailedCount*/ true);
       }
+    } else if (sub == "truncate") {
+      {
+        OperationOptions opts;
+
+        opts.waitForSync = _request->parsedValue("waitForSync", false);
+        opts.isSynchronousReplicationFrom =
+            _request->value("isSynchronousReplication");
+
+        auto trx = createTransaction(coll->name(), AccessMode::Type::EXCLUSIVE);
+        trx->addHint(transaction::Hints::Hint::INTERMEDIATE_COMMITS);
+        trx->addHint(transaction::Hints::Hint::ALLOW_RANGE_DELETE);
+        res = trx->begin();
+
+        if (res.ok()) {
+          auto result = trx->truncate(coll->name(), opts);
+          res = trx->finish(result.result);
+        }
+      }
+      // wait for the transaction to finish first. only after that compact the
+      // data range(s) for the collection
+      // we shouldn't run compact() as part of the transaction, because the compact
+      // will be useless inside due to the snapshot the transaction has taken
+      coll->compact();
 
       if (res.ok()) {
         if (ServerState::instance()->isCoordinator()) {  // ClusterInfo::loadPlan eventually
@@ -455,7 +470,7 @@ void RestCollectionHandler::handleCommandPut() {
       if (res.is(TRI_ERROR_NOT_IMPLEMENTED)) {
         res.reset(TRI_ERROR_HTTP_NOT_FOUND,
                   "expecting one of the actions 'load', 'unload', 'truncate',"
-                  " 'properties', 'rename', 'loadIndexesIntoMemory'");
+                  " 'properties', 'compact', 'rename', 'loadIndexesIntoMemory'");
       }
     }
   });

--- a/arangod/RocksDBEngine/RocksDBCollection.h
+++ b/arangod/RocksDBEngine/RocksDBCollection.h
@@ -108,6 +108,10 @@ class RocksDBCollection final : public PhysicalCollection {
   ///////////////////////////////////
 
   Result truncate(transaction::Methods& trx, OperationOptions& options) override;
+  
+  /// @brief compact-data operation
+  /// triggers rocksdb compaction for documentDB and indexes
+  Result compact() override;
 
   void deferDropCollection(std::function<bool(LogicalCollection&)> const& callback) override;
 
@@ -172,8 +176,6 @@ class RocksDBCollection final : public PhysicalCollection {
   /// recalculte counts for collection in case of failure
   uint64_t recalculateCounts();
 
-  /// trigger rocksdb compaction for documentDB and indexes
-  void compact();
   void estimateSize(velocypack::Builder& builder);
 
   inline bool cacheEnabled() const { return _cacheEnabled; }

--- a/arangod/StorageEngine/PhysicalCollection.h
+++ b/arangod/StorageEngine/PhysicalCollection.h
@@ -137,6 +137,9 @@ class PhysicalCollection {
   ///////////////////////////////////
 
   virtual Result truncate(transaction::Methods& trx, OperationOptions& options) = 0;
+  
+  /// @brief compact-data operation
+  virtual Result compact() = 0;
 
   /// @brief Defer a callback to be executed when the collection
   ///        can be dropped. The callback is supposed to drop

--- a/arangod/V8Server/v8-collection.cpp
+++ b/arangod/V8Server/v8-collection.cpp
@@ -2044,27 +2044,31 @@ static void JS_TruncateVocbaseCol(v8::FunctionCallbackInfo<v8::Value> const& arg
     TRI_V8_THROW_EXCEPTION_INTERNAL("cannot extract collection");
   }
 
-  auto ctx = transaction::V8Context::Create(collection->vocbase(), true);
-  SingleCollectionTransaction trx(ctx, *collection, AccessMode::Type::EXCLUSIVE);
-  trx.addHint(transaction::Hints::Hint::INTERMEDIATE_COMMITS);
-  trx.addHint(transaction::Hints::Hint::ALLOW_RANGE_DELETE);
-  Result res = trx.begin();
+  {
+    auto ctx = transaction::V8Context::Create(collection->vocbase(), true);
+    SingleCollectionTransaction trx(ctx, *collection, AccessMode::Type::EXCLUSIVE);
+    trx.addHint(transaction::Hints::Hint::INTERMEDIATE_COMMITS);
+    trx.addHint(transaction::Hints::Hint::ALLOW_RANGE_DELETE);
+    Result res = trx.begin();
 
-  if (!res.ok()) {
-    TRI_V8_THROW_EXCEPTION(res);
+    if (!res.ok()) {
+      TRI_V8_THROW_EXCEPTION(res);
+    }
+
+    auto result = trx.truncate(collection->name(), opOptions);
+
+    res = trx.finish(result.result);
+
+    if (!res.ok()) {
+      TRI_V8_THROW_EXCEPTION(res);
+    }
   }
 
-  auto result = trx.truncate(collection->name(), opOptions);
-
-  res = trx.finish(result.result);
-
-  if (result.fail()) {
-    TRI_V8_THROW_EXCEPTION(result.result);
-  }
-
-  if (!res.ok()) {
-    TRI_V8_THROW_EXCEPTION(res);
-  }
+  // wait for the transaction to finish first. only after that compact the
+  // data range(s) for the collection
+  // we shouldn't run compact() as part of the transaction, because the compact
+  // will be useless inside due to the snapshot the transaction has taken
+  collection->compact();
 
   TRI_V8_RETURN_UNDEFINED();
   TRI_V8_TRY_CATCH_END

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -885,6 +885,11 @@ Result LogicalCollection::truncate(transaction::Methods& trx, OperationOptions& 
   return getPhysical()->truncate(trx, options);
 }
 
+/// @brief compact-data operation
+Result LogicalCollection::compact() {
+  return getPhysical()->compact();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief inserts a document or edge into the collection
 ////////////////////////////////////////////////////////////////////////////////

--- a/arangod/VocBase/LogicalCollection.h
+++ b/arangod/VocBase/LogicalCollection.h
@@ -284,6 +284,9 @@ class LogicalCollection : public LogicalDataSource {
 
   /// @brief processes a truncate operation
   Result truncate(transaction::Methods& trx, OperationOptions& options);
+  
+  /// @brief compact-data operation
+  Result compact();
 
   // convenience function for downwards-compatibility
   Result insert(transaction::Methods* trx, velocypack::Slice const slice,

--- a/js/client/modules/@arangodb/arango-collection.js
+++ b/js/client/modules/@arangodb/arango-collection.js
@@ -517,6 +517,7 @@ ArangoCollection.prototype.truncate = function (options) {
   var requestResult = this._database._connection.PUT(this._baseurl('truncate') + append, null);
 
   arangosh.checkRequestResult(requestResult);
+  // invalidate cache
   this._status = null;
 
   if (!options.compact) {
@@ -545,6 +546,18 @@ ArangoCollection.prototype.truncate = function (options) {
 };
 
 // //////////////////////////////////////////////////////////////////////////////
+// / @brief compacts a collection
+// //////////////////////////////////////////////////////////////////////////////
+
+ArangoCollection.prototype.compact = function () {
+  let requestResult = this._database._connection.PUT(this._baseurl('compact'), null);
+
+  arangosh.checkRequestResult(requestResult);
+  // invalidate cache
+  this._status = null;
+};
+
+// //////////////////////////////////////////////////////////////////////////////
 // / @brief loads a collection
 // //////////////////////////////////////////////////////////////////////////////
 
@@ -560,6 +573,7 @@ ArangoCollection.prototype.load = function (count) {
 
   arangosh.checkRequestResult(requestResult);
 
+  // invalidate cache
   this._status = null;
 };
 

--- a/tests/Mocks/StorageEngineMock.cpp
+++ b/tests/Mocks/StorageEngineMock.cpp
@@ -878,6 +878,10 @@ arangodb::Result PhysicalCollectionMock::truncate(arangodb::transaction::Methods
   return arangodb::Result();
 }
 
+arangodb::Result PhysicalCollectionMock::compact() {
+  return arangodb::Result();
+}
+
 arangodb::Result PhysicalCollectionMock::update(
     arangodb::transaction::Methods* trx, arangodb::velocypack::Slice const newSlice,
     arangodb::ManagedDocumentResult& result, arangodb::OperationOptions& options,

--- a/tests/Mocks/StorageEngineMock.h
+++ b/tests/Mocks/StorageEngineMock.h
@@ -107,6 +107,7 @@ class PhysicalCollectionMock: public arangodb::PhysicalCollection {
     arangodb::transaction::Methods& trx,
     arangodb::OperationOptions& options
   ) override;
+  virtual arangodb::Result compact() override;
   virtual arangodb::Result update(
       arangodb::transaction::Methods* trx,
       arangodb::velocypack::Slice const newSlice,


### PR DESCRIPTION
…e same transaction

running compact() in the same transaction will only increase the data size on disk due to RocksDB not being able to remove
any documents physically due to the snapshot we take at transaction start.
Decoupling the truncate transaction from the compact operation allows finishing the truncate transaction first, so we can
get rid of the snapshot. Running compact afterwards is then free to physically remove all the data.
As a nice side effect this change will also speed up the truncation of larger collections, because the compact will run
faster.

This change also exposes db.<collection>.compact() in the arangosh, in order to manually run a compaction on the data
range of a collection should it be needed for maintenance.