### PR TITLE
Doc - setIntroducedIn for log.file-group/mode

### DIFF
--- a/Documentation/Examples/arangobench.json
+++ b/Documentation/Examples/arangobench.json
@@ -254,6 +254,40 @@
     "section" : "log",
     "type" : "string"
   },
+  "log.file-group" : {
+    "category" : "option",
+    "default" : "",
+    "deprecatedIn" : null,
+    "description" : "group to use for new log file, user must be a member of this group",
+    "dynamic" : false,
+    "enterpriseOnly" : false,
+    "hidden" : false,
+    "introducedIn" : [
+      "v3.4.5",
+      "v3.5.0"
+    ],
+    "obsolete" : false,
+    "requiresValue" : true,
+    "section" : "log",
+    "type" : "string"
+  },
+  "log.file-mode" : {
+    "category" : "option",
+    "default" : "",
+    "deprecatedIn" : null,
+    "description" : "mode to use for new log file, umask will be applied as well",
+    "dynamic" : false,
+    "enterpriseOnly" : false,
+    "hidden" : false,
+    "introducedIn" : [
+      "v3.4.5",
+      "v3.5.0"
+    ],
+    "obsolete" : false,
+    "requiresValue" : true,
+    "section" : "log",
+    "type" : "string"
+  },
   "log.force-direct" : {
     "category" : "option",
     "default" : false,

--- a/Documentation/Examples/arangod.json
+++ b/Documentation/Examples/arangod.json
@@ -1807,6 +1807,40 @@
     "section" : "log",
     "type" : "string"
   },
+  "log.file-group" : {
+    "category" : "option",
+    "default" : "",
+    "deprecatedIn" : null,
+    "description" : "group to use for new log file, user must be a member of this group",
+    "dynamic" : false,
+    "enterpriseOnly" : false,
+    "hidden" : false,
+    "introducedIn" : [
+      "v3.4.5",
+      "v3.5.0"
+    ],
+    "obsolete" : false,
+    "requiresValue" : true,
+    "section" : "log",
+    "type" : "string"
+  },
+  "log.file-mode" : {
+    "category" : "option",
+    "default" : "",
+    "deprecatedIn" : null,
+    "description" : "mode to use for new log file, umask will be applied as well",
+    "dynamic" : false,
+    "enterpriseOnly" : false,
+    "hidden" : false,
+    "introducedIn" : [
+      "v3.4.5",
+      "v3.5.0"
+    ],
+    "obsolete" : false,
+    "requiresValue" : true,
+    "section" : "log",
+    "type" : "string"
+  },
   "log.force-direct" : {
     "category" : "option",
     "default" : false,

--- a/Documentation/Examples/arangodump.json
+++ b/Documentation/Examples/arangodump.json
@@ -269,6 +269,40 @@
     "section" : "log",
     "type" : "string"
   },
+  "log.file-group" : {
+    "category" : "option",
+    "default" : "",
+    "deprecatedIn" : null,
+    "description" : "group to use for new log file, user must be a member of this group",
+    "dynamic" : false,
+    "enterpriseOnly" : false,
+    "hidden" : false,
+    "introducedIn" : [
+      "v3.4.5",
+      "v3.5.0"
+    ],
+    "obsolete" : false,
+    "requiresValue" : true,
+    "section" : "log",
+    "type" : "string"
+  },
+  "log.file-mode" : {
+    "category" : "option",
+    "default" : "",
+    "deprecatedIn" : null,
+    "description" : "mode to use for new log file, umask will be applied as well",
+    "dynamic" : false,
+    "enterpriseOnly" : false,
+    "hidden" : false,
+    "introducedIn" : [
+      "v3.4.5",
+      "v3.5.0"
+    ],
+    "obsolete" : false,
+    "requiresValue" : true,
+    "section" : "log",
+    "type" : "string"
+  },
   "log.force-direct" : {
     "category" : "option",
     "default" : false,

--- a/Documentation/Examples/arangoexport.json
+++ b/Documentation/Examples/arangoexport.json
@@ -185,6 +185,40 @@
     "section" : "log",
     "type" : "string"
   },
+  "log.file-group" : {
+    "category" : "option",
+    "default" : "",
+    "deprecatedIn" : null,
+    "description" : "group to use for new log file, user must be a member of this group",
+    "dynamic" : false,
+    "enterpriseOnly" : false,
+    "hidden" : false,
+    "introducedIn" : [
+      "v3.4.5",
+      "v3.5.0"
+    ],
+    "obsolete" : false,
+    "requiresValue" : true,
+    "section" : "log",
+    "type" : "string"
+  },
+  "log.file-mode" : {
+    "category" : "option",
+    "default" : "",
+    "deprecatedIn" : null,
+    "description" : "mode to use for new log file, umask will be applied as well",
+    "dynamic" : false,
+    "enterpriseOnly" : false,
+    "hidden" : false,
+    "introducedIn" : [
+      "v3.4.5",
+      "v3.5.0"
+    ],
+    "obsolete" : false,
+    "requiresValue" : true,
+    "section" : "log",
+    "type" : "string"
+  },
   "log.force-direct" : {
     "category" : "option",
     "default" : false,

--- a/Documentation/Examples/arangoimport.json
+++ b/Documentation/Examples/arangoimport.json
@@ -297,6 +297,40 @@
     "section" : "log",
     "type" : "string"
   },
+  "log.file-group" : {
+    "category" : "option",
+    "default" : "",
+    "deprecatedIn" : null,
+    "description" : "group to use for new log file, user must be a member of this group",
+    "dynamic" : false,
+    "enterpriseOnly" : false,
+    "hidden" : false,
+    "introducedIn" : [
+      "v3.4.5",
+      "v3.5.0"
+    ],
+    "obsolete" : false,
+    "requiresValue" : true,
+    "section" : "log",
+    "type" : "string"
+  },
+  "log.file-mode" : {
+    "category" : "option",
+    "default" : "",
+    "deprecatedIn" : null,
+    "description" : "mode to use for new log file, umask will be applied as well",
+    "dynamic" : false,
+    "enterpriseOnly" : false,
+    "hidden" : false,
+    "introducedIn" : [
+      "v3.4.5",
+      "v3.5.0"
+    ],
+    "obsolete" : false,
+    "requiresValue" : true,
+    "section" : "log",
+    "type" : "string"
+  },
   "log.force-direct" : {
     "category" : "option",
     "default" : false,

--- a/Documentation/Examples/arangoinspect.json
+++ b/Documentation/Examples/arangoinspect.json
@@ -488,6 +488,40 @@
     "section" : "log",
     "type" : "string"
   },
+  "log.file-group" : {
+    "category" : "option",
+    "default" : "",
+    "deprecatedIn" : null,
+    "description" : "group to use for new log file, user must be a member of this group",
+    "dynamic" : false,
+    "enterpriseOnly" : false,
+    "hidden" : false,
+    "introducedIn" : [
+      "v3.4.5",
+      "v3.5.0"
+    ],
+    "obsolete" : false,
+    "requiresValue" : true,
+    "section" : "log",
+    "type" : "string"
+  },
+  "log.file-mode" : {
+    "category" : "option",
+    "default" : "",
+    "deprecatedIn" : null,
+    "description" : "mode to use for new log file, umask will be applied as well",
+    "dynamic" : false,
+    "enterpriseOnly" : false,
+    "hidden" : false,
+    "introducedIn" : [
+      "v3.4.5",
+      "v3.5.0"
+    ],
+    "obsolete" : false,
+    "requiresValue" : true,
+    "section" : "log",
+    "type" : "string"
+  },
   "log.force-direct" : {
     "category" : "option",
     "default" : false,

--- a/Documentation/Examples/arangorestore.json
+++ b/Documentation/Examples/arangorestore.json
@@ -362,6 +362,40 @@
     "section" : "log",
     "type" : "string"
   },
+  "log.file-group" : {
+    "category" : "option",
+    "default" : "",
+    "deprecatedIn" : null,
+    "description" : "group to use for new log file, user must be a member of this group",
+    "dynamic" : false,
+    "enterpriseOnly" : false,
+    "hidden" : false,
+    "introducedIn" : [
+      "v3.4.5",
+      "v3.5.0"
+    ],
+    "obsolete" : false,
+    "requiresValue" : true,
+    "section" : "log",
+    "type" : "string"
+  },
+  "log.file-mode" : {
+    "category" : "option",
+    "default" : "",
+    "deprecatedIn" : null,
+    "description" : "mode to use for new log file, umask will be applied as well",
+    "dynamic" : false,
+    "enterpriseOnly" : false,
+    "hidden" : false,
+    "introducedIn" : [
+      "v3.4.5",
+      "v3.5.0"
+    ],
+    "obsolete" : false,
+    "requiresValue" : true,
+    "section" : "log",
+    "type" : "string"
+  },
   "log.force-direct" : {
     "category" : "option",
     "default" : false,

--- a/Documentation/Examples/arangosh.json
+++ b/Documentation/Examples/arangosh.json
@@ -489,6 +489,40 @@
     "section" : "log",
     "type" : "string"
   },
+  "log.file-group" : {
+    "category" : "option",
+    "default" : "",
+    "deprecatedIn" : null,
+    "description" : "group to use for new log file, user must be a member of this group",
+    "dynamic" : false,
+    "enterpriseOnly" : false,
+    "hidden" : false,
+    "introducedIn" : [
+      "v3.4.5",
+      "v3.5.0"
+    ],
+    "obsolete" : false,
+    "requiresValue" : true,
+    "section" : "log",
+    "type" : "string"
+  },
+  "log.file-mode" : {
+    "category" : "option",
+    "default" : "",
+    "deprecatedIn" : null,
+    "description" : "mode to use for new log file, umask will be applied as well",
+    "dynamic" : false,
+    "enterpriseOnly" : false,
+    "hidden" : false,
+    "introducedIn" : [
+      "v3.4.5",
+      "v3.5.0"
+    ],
+    "obsolete" : false,
+    "requiresValue" : true,
+    "section" : "log",
+    "type" : "string"
+  },
   "log.force-direct" : {
     "category" : "option",
     "default" : false,

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -93,12 +93,16 @@ void LoggerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
 
   options->addOption("--log.file-mode",
                      "mode to use for new log file, umask will be applied as well",
-                     new StringParameter(&_fileMode));
+                     new StringParameter(&_fileMode))
+                     .setIntroducedIn(30405)
+                     .setIntroducedIn(30500);
 
 #ifdef ARANGODB_HAVE_SETGID
   options->addOption("--log.file-group",
                      "group to use for new log file, user must be a member of this group",
-                     new StringParameter(&_fileGroup));
+                     new StringParameter(&_fileGroup))
+                     .setIntroducedIn(30405)
+                     .setIntroducedIn(30500);
 #endif
 
   options->addOption("--log.prefix", "prefix log message with this string",


### PR DESCRIPTION
The version information should be added for all new options, especially if they were introduced in a bugfix release for a GA version (here v3.4.5).

http://jenkins01.arangodb.biz:8080/view/Documentation/job/arangodb-documentation/383/