### PR TITLE
Allowed paths in JWT

### DIFF
--- a/arangod/Auth/TokenCache.h
+++ b/arangod/Auth/TokenCache.h
@@ -53,7 +53,7 @@ class TokenCache {
 
    public:
     explicit Entry(std::string const& username, bool a, double t)
-        : _username(username), _authenticated(a), _expiry(t) {}
+        : _username(username), _authenticated(a), _expiry(t), _allowedPaths() {}
 
     static Entry Unauthenticated() { return Entry("", false, 0); }
 
@@ -70,6 +70,8 @@ class TokenCache {
     bool _authenticated;
     /// expiration time (in seconds since epoch) of this entry
     double _expiry;
+    // paths that are valid for this token
+    std::vector<std::string> _allowedPaths;
   };
 
  public:

--- a/arangod/GeneralServer/GeneralCommTask.h
+++ b/arangod/GeneralServer/GeneralCommTask.h
@@ -33,6 +33,7 @@
 #include "Basics/MutexLocker.h"
 #include "Basics/StringBuffer.h"
 #include "Scheduler/Socket.h"
+#include "Auth/TokenCache.h"
 
 namespace arangodb {
 class AuthenticationFeature;
@@ -139,6 +140,8 @@ class GeneralCommTask : public SocketTask {
 
   arangodb::Mutex _statisticsMutex;
   std::unordered_map<uint64_t, RequestStatistics*> _statisticsMap;
+
+  auth::TokenCache::Entry _authToken;
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief checks the access rights for a specified path, includes automatic

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -759,7 +759,7 @@ void HttpCommTask::resetState() {
   _readRequestBody = false;
 }
 
-ResponseCode HttpCommTask::handleAuthHeader(HttpRequest* req) const {
+ResponseCode HttpCommTask::handleAuthHeader(HttpRequest* req) {
   bool found;
   std::string const& authStr = req->header(StaticStrings::Authorization, found);
   if (!found) {
@@ -794,9 +794,9 @@ ResponseCode HttpCommTask::handleAuthHeader(HttpRequest* req) const {
 
       req->setAuthenticationMethod(authMethod);
       if (authMethod != AuthenticationMethod::NONE) {
-        auto entry = _auth->tokenCache().checkAuthentication(authMethod, auth);
-        req->setAuthenticated(entry.authenticated());
-        req->setUser(std::move(entry._username));
+        _authToken = std::move(_auth->tokenCache().checkAuthentication(authMethod, auth));
+        req->setAuthenticated(_authToken.authenticated());
+        req->setUser(std::move(_authToken._username));
       }
 
       if (req->authenticated() || !_auth->isActive()) {

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -794,7 +794,7 @@ ResponseCode HttpCommTask::handleAuthHeader(HttpRequest* req) {
 
       req->setAuthenticationMethod(authMethod);
       if (authMethod != AuthenticationMethod::NONE) {
-        _authToken = std::move(_auth->tokenCache().checkAuthentication(authMethod, auth));
+        _authToken = _auth->tokenCache().checkAuthentication(authMethod, auth);
         req->setAuthenticated(_authToken.authenticated());
         req->setUser(std::move(_authToken._username));
       }

--- a/arangod/GeneralServer/HttpCommTask.h
+++ b/arangod/GeneralServer/HttpCommTask.h
@@ -53,7 +53,7 @@ class HttpCommTask final : public GeneralCommTask {
 
   std::string authenticationRealm() const;
   ResponseCode authenticateRequest(HttpRequest*);
-  ResponseCode handleAuthHeader(HttpRequest* request) const;
+  ResponseCode handleAuthHeader(HttpRequest* request);
 
  private:
   size_t _readPosition;       // current read position

--- a/arangod/GeneralServer/VstCommTask.cpp
+++ b/arangod/GeneralServer/VstCommTask.cpp
@@ -291,11 +291,11 @@ void VstCommTask::handleAuthHeader(VPackSlice const& header, uint64_t messageId)
     LOG_TOPIC(ERR, Logger::REQUESTS) << "Unknown VST encryption type";
   }
 
-  auto entry = _auth->tokenCache().checkAuthentication(_authMethod, authString);
-  _authorized = entry.authenticated();
+  _authToken = _auth->tokenCache().checkAuthentication(_authMethod, authString);
+  _authorized = _authToken.authenticated();
 
   if (_authorized || !_auth->isActive()) {
-    _authenticatedUser = std::move(entry._username);
+    _authenticatedUser = std::move(_authToken._username);
     // simon: drivers expect a response for their auth request
     addErrorResponse(ResponseCode::OK, rest::ContentType::VPACK, messageId,
                      TRI_ERROR_NO_ERROR, "auth successful");


### PR DESCRIPTION
Allow the restriction to specific paths in a JWT. This best explained by an example:
```
{"server_id":"foo", "allowed_paths":["/_api/version"]}
```
```
{"server_id":"foo", "allowed_paths":["/_admin/statistics"]}
```
Currently most tools (operator, prometheus exporter) use the superuser token everywhere. 