### PR TITLE
Changelog: remove duplicate entry

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,8 +46,6 @@ v3.4.5 (2019-03-27)
 
 * fixed some escaping issues within the web ui.
 
-* fixed issue #8165: AQL optimizer does not pick up multiple Geo index
-
 * fixed issue #8359: How to update a document with unique index (constraints)?
 
 * when restarting a follower in active failover mode, try an incremental sync instead


### PR DESCRIPTION
There are 2 entrys for `fixed issue #8165: AQL optimizer` in v3.4.5 and v3.4.4.
Removing the v3.4.5 entry since the fix is already included in v.3.4.4.