### PR TITLE
Doc - Add noindex, nofollow meta tag (3.2)

### DIFF
--- a/Documentation/Books/AQL/book.json
+++ b/Documentation/Books/AQL/book.json
@@ -16,6 +16,7 @@
     "ga",
     "callouts@git+https://github.com/Simran-B/gitbook-plugin-callouts.git",
     "arangodb-outdated@git+https://github.com/Simran-B/gitbook-plugin-arangodb-outdated.git",
+    "meta",
     "edit-link",
     "localized-footer"
   ],
@@ -35,6 +36,10 @@
   "pluginsConfig": {
     "arangodb-outdated": {
       "eolDate": "2019-03-31"
+    },
+    "meta": {
+      "name": "robots",
+      "content": "noindex, nofollow"
     },
     "addcssjs": {
       "js": ["styles/header.js", "styles/hs.js"],

--- a/Documentation/Books/Cookbook/book.json
+++ b/Documentation/Books/Cookbook/book.json
@@ -16,6 +16,7 @@
     "ga",
     "callouts@git+https://github.com/Simran-B/gitbook-plugin-callouts.git",
     "arangodb-outdated@git+https://github.com/Simran-B/gitbook-plugin-arangodb-outdated.git",
+    "meta",
     "edit-link",
     "localized-footer"
   ],
@@ -35,6 +36,10 @@
   "pluginsConfig": {
     "arangodb-outdated": {
       "eolDate": "2019-03-31"
+    },
+    "meta": {
+      "name": "robots",
+      "content": "noindex, nofollow"
     },
     "addcssjs": {
       "js": ["styles/header.js", "styles/hs.js"],

--- a/Documentation/Books/HTTP/book.json
+++ b/Documentation/Books/HTTP/book.json
@@ -16,6 +16,7 @@
     "ga",
     "callouts@git+https://github.com/Simran-B/gitbook-plugin-callouts.git",
     "arangodb-outdated@git+https://github.com/Simran-B/gitbook-plugin-arangodb-outdated.git",
+    "meta",
     "edit-link",
     "localized-footer"
   ],
@@ -35,6 +36,10 @@
   "pluginsConfig": {
     "arangodb-outdated": {
       "eolDate": "2019-03-31"
+    },
+    "meta": {
+      "name": "robots",
+      "content": "noindex, nofollow"
     },
     "addcssjs": {
       "js": ["styles/header.js", "styles/hs.js"],

--- a/Documentation/Books/Manual/book.json
+++ b/Documentation/Books/Manual/book.json
@@ -16,6 +16,7 @@
     "ga",
     "callouts@git+https://github.com/Simran-B/gitbook-plugin-callouts.git",
     "arangodb-outdated@git+https://github.com/Simran-B/gitbook-plugin-arangodb-outdated.git",
+    "meta",
     "edit-link",
     "localized-footer"
   ],
@@ -35,6 +36,10 @@
   "pluginsConfig": {
     "arangodb-outdated": {
       "eolDate": "2019-03-31"
+    },
+    "meta": {
+      "name": "robots",
+      "content": "noindex, nofollow"
     },
     "addcssjs": {
       "js": ["styles/header.js", "styles/hs.js"],


### PR DESCRIPTION
In order to remove obsolete docs from Google, pages actually have to be readable by Google (robots.txt) and it we need this meta tag to disallow indexing/showing it in their results.