### PR TITLE
added missing fix for NowNanos from upstream RocksDB

### DIFF
--- a/3rdParty/rocksdb/6.0.fb/port/win/env_win.h
+++ b/3rdParty/rocksdb/6.0.fb/port/win/env_win.h
@@ -198,6 +198,7 @@ private:
   size_t          page_size_;
   size_t          allocation_granularity_;
   uint64_t        perf_counter_frequency_;
+  uint64_t        nano_seconds_per_period_;
   FnGetSystemTimePreciseAsFileTime GetSystemTimePreciseAsFileTime_;
 };
 


### PR DESCRIPTION
We updated our version of RocksDB to 6.0.fb. This obviously does not include the NowNanos fix done in latest RocksDB master.

This patch ports the following fix from facebook/rocksdb:
```
commit 88d85b6820453fc6d83ee699e33013eb6810472f
Author: Burton Li <pul@microsoft.com>
Date:   Thu Mar 21 15:10:38 2019 -0700

    fix NowNanos overflow (#5062)
    
    Summary:
    The original implementation of WinEnvIO::NowNanos() has a constant data overflow by:
    li.QuadPart *= std::nano::den;
    As a result, the api provides a incorrect result.
    e.g.:
    li.QuadPart=13477844301545
    std::nano::den=1e9
    
    The fix uses pre-computed nano_seconds_per_period_ to present the nano seconds per performance counter period, in the case if nano::den is divisible by perf_counter_frequency_. Otherwise it falls back to use high_resolution_clock.
```