### PR TITLE
improve timeout behaviour of test utils

### DIFF
--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -342,7 +342,7 @@ function cleanupLastDirectory (options) {
     while (cleanupDirectories.length) {
       const cleanupDirectory = cleanupDirectories.shift();
       if (options.extremeVerbosity === true) {
-        print("Cleaning up: " + cleanupDirectory);
+        print(Date() + " Cleaning up: " + cleanupDirectory);
       }
       // Avoid attempting to remove the same directory multiple times
       if ((cleanupDirectories.indexOf(cleanupDirectory) === -1) &&
@@ -353,13 +353,13 @@ function cleanupLastDirectory (options) {
             fs.removeDirectoryRecursive(cleanupDirectory, true);
             return;
           } catch (x) {
-            print('failed to delete directory "' + cleanupDirectory + '" - "' +
+            print(Date() + ' failed to delete directory "' + cleanupDirectory + '" - "' +
                   x + '" - Will retry in 5 seconds"');
             sleep(5);
           }
           i += 1;
         }
-        print('failed to delete directory "' + cleanupDirectory + '" - "' +
+        print(Date() + ' failed to delete directory "' + cleanupDirectory + '" - "' +
               '" - Deferring cleanup for test run end."');
         cleanupDirectories.unshift(cleanupDirectory);
       }
@@ -400,7 +400,7 @@ function makeAuthorizationHeaders (options) {
                              {'server_id': 'none',
                               'iss': 'arangodb'}, 'HS256');
     if (options.extremeVerbosity) {
-      print('Using jwt token:     ' + jwt);
+      print(Date() + ' Using jwt token:     ' + jwt);
     }
     return {
       'headers': {
@@ -505,12 +505,12 @@ function runProcdump (options, instanceInfo, rootDir, pid) {
   }
   try {
     if (options.extremeVerbosity) {
-      print("Starting procdump: " + JSON.stringify(procdumpArgs));
+      print(Date() + " Starting procdump: " + JSON.stringify(procdumpArgs));
     }
     instanceInfo.monitor = executeExternal('procdump', procdumpArgs);
     instanceInfo.coreFilePattern = dumpFile;
   } catch (x) {
-    print('failed to start procdump - is it installed?');
+    print(Date() + ' failed to start procdump - is it installed?');
     // throw x;
   }
 }
@@ -518,7 +518,7 @@ function runProcdump (options, instanceInfo, rootDir, pid) {
 function stopProcdump (options, instanceInfo) {
   if (instanceInfo.hasOwnProperty('monitor') &&
       instanceInfo.monitor.pid !== null) {
-    print("wating for procdump to exit");
+    print(Date() + " wating for procdump to exit");
     statusExternal(instanceInfo.monitor.pid, true);
     instanceInfo.monitor.pid = null;
   }
@@ -562,7 +562,7 @@ function executeAndWait (cmd, args, options, valgrindTest, rootDir, circumventCo
   }
   
   if (options.extremeVerbosity) {
-    print('executeAndWait: cmd =', cmd, 'args =', args);
+    print(Date() + ' executeAndWait: cmd =', cmd, 'args =', args);
   }
 
   const startTime = time();
@@ -605,7 +605,7 @@ function executeAndWait (cmd, args, options, valgrindTest, rootDir, circumventCo
        (platform.substr(0, 3) === 'win')
       )
      ) {
-    print("executeAndWait: Marking crashy - " + JSON.stringify(instanceInfo));
+    print(Date() + " executeAndWait: Marking crashy - " + JSON.stringify(instanceInfo));
     crashUtils.analyzeCrash(cmd,
                             instanceInfo,
                             options,
@@ -619,7 +619,7 @@ function executeAndWait (cmd, args, options, valgrindTest, rootDir, circumventCo
   if (instanceInfo.exitStatus.status === 'TERMINATED') {
     const color = (instanceInfo.exitStatus.exit === 0 ? GREEN : RED);
 
-    print(color + 'Finished: ' + instanceInfo.exitStatus.status +
+    print(color + Date() + ' Finished: ' + instanceInfo.exitStatus.status +
       ' exit code: ' + instanceInfo.exitStatus.exit +
       ' Time elapsed: ' + deltaTime + RESET);
 
@@ -641,7 +641,7 @@ function executeAndWait (cmd, args, options, valgrindTest, rootDir, circumventCo
       errorMessage += instanceInfo.exitStatus.errorMessage;
     }
 
-    print('Finished: ' + instanceInfo.exitStatus.status +
+    print(Date() + ' Finished: ' + instanceInfo.exitStatus.status +
       ' Signal: ' + instanceInfo.exitStatus.signal +
       ' Time elapsed: ' + deltaTime + errorMessage);
 
@@ -656,7 +656,7 @@ function executeAndWait (cmd, args, options, valgrindTest, rootDir, circumventCo
       errorMessage += instanceInfo.exitStatus.errorMessage;
     }
 
-    print('Finished: ' + instanceInfo.exitStatus.status +
+    print(Date() + ' Finished: ' + instanceInfo.exitStatus.status +
       ' exit code: ' + instanceInfo.exitStatus.signal +
       ' Time elapsed: ' + deltaTime + errorMessage);
 
@@ -826,6 +826,27 @@ function runArangoBenchmark (options, instanceInfo, cmds, rootDir, coreCheck = f
 // //////////////////////////////////////////////////////////////////////////////
 
 // //////////////////////////////////////////////////////////////////////////////
+// / @brief dump the state of the agency to disk. if we still can get one.
+// //////////////////////////////////////////////////////////////////////////////
+function dumpAgency(instanceInfo, options) {
+  instanceInfo.arangods.forEach((arangod) => {
+    if (arangod.role === "agent") {
+      if (arangod.hasOwnProperty('exitStatus')) {
+        print(Date() + " this agent is already dead: " + arangod);
+      } else {
+        print(Date() + " Attempting to dump Agent: " + arangod);
+        let agencyConfig = arangod.GET('_api/agency/config');
+        let agencyState = arangod.GET('_api/agency/state');
+        print(JSON.stringify(agencyConfig));
+        print(JSON.stringify(agencyState));
+        fs.write(fs.join(options.testOutputDirectory, "agencyConfig_" + arangod.pid + ".json"), agencyConfig);
+        fs.write(fs.join(options.testOutputDirectory, "agencyState_" + arangod.pid + ".json"), agencyState);
+      }
+    }
+  });
+}
+
+// //////////////////////////////////////////////////////////////////////////////
 // / @brief the bad has happened, tell it the user and try to gather more
 // /        information about the incident. (arangod wrapper for the crash-utils)
 // //////////////////////////////////////////////////////////////////////////////
@@ -841,7 +862,7 @@ function checkArangoAlive (arangod, options) {
   const ret = res.status === 'RUNNING' && crashUtils.checkMonitorAlive(ARANGOD_BIN, arangod, options, res);
 
   if (!ret) {
-    print('ArangoD with PID ' + arangod.pid + ' gone:');
+    print(Date() + ' ArangoD with PID ' + arangod.pid + ' gone:');
     if (!arangod.hasOwnProperty('exitStatus')) {
       arangod.exitStatus = res;
     }
@@ -857,26 +878,43 @@ function checkArangoAlive (arangod, options) {
       arangod.exitStatus = res;
       analyzeServerCrash(arangod, options, 'health Check  - ' + res.signal);
       serverCrashedLocal = true;
-      print("checkArangoAlive: Marking crashy - " + JSON.stringify(arangod));
+      print(Date() + " checkArangoAlive: Marking crashy - " + JSON.stringify(arangod));
     }
   }
 
   return ret;
 }
 
+function abortSurviviours(arangod, options) {
+  print(Date() + " Killing in the name of: ");
+  print(arangod);
+  if (!arangod.hasOwnProperty('exitStatus')) {
+    arangod.exitStatus = killExternal(arangod.pid, abortSignal);
+  }
+}
+
 function checkInstanceAlive (instanceInfo, options) {
   if (options.activefailover && instanceInfo.hasOwnProperty('authOpts')) {
     let d = detectCurrentLeader(instanceInfo);
     if (instanceInfo.endpoint !== d.endpoint) {
-      print('failover has happened, leader is no more! Marking Crashy!');
+      print(Date() + ' failover has happened, leader is no more! Marking Crashy!');
       serverCrashedLocal = true;
+      dumpAgency(instanceInfo, options);
       return false;
     }
   }
   
-  return instanceInfo.arangods.reduce((previous, arangod) => {
+  let rc = instanceInfo.arangods.reduce((previous, arangod) => {
     return previous && checkArangoAlive(arangod, options);
   }, true);
+  if (!rc) {
+    dumpAgency(instanceInfo, options);
+    print(Date() + ' If cluster - will now start killing the rest.');
+    instanceInfo.arangods.forEach((arangod) => {
+      abortSurviviours(arangod, options);
+    });
+  }
+  return rc;
 }
 
 // //////////////////////////////////////////////////////////////////////////////
@@ -885,7 +923,7 @@ function checkInstanceAlive (instanceInfo, options) {
 
 function waitOnServerForGC (instanceInfo, options, waitTime) {
   try {
-    print('waiting ' + waitTime + ' for server GC');
+    print(Date() + ' waiting ' + waitTime + ' for server GC');
     const remoteCommand = 'require("internal").wait(' + waitTime + ', true);';
 
     const requestOptions = makeAuthorizationHeaders(options);
@@ -898,7 +936,7 @@ function waitOnServerForGC (instanceInfo, options, waitTime) {
       remoteCommand,
       requestOptions);
 
-    print('waiting ' + waitTime + ' for server GC - done.');
+    print(Date() + ' waiting ' + waitTime + ' for server GC - done.');
 
     if (!reply.error && reply.code === 200) {
       return JSON.parse(reply.body);
@@ -949,7 +987,7 @@ function executeArangod (cmd, args, options) {
   }
 
   if (options.extremeVerbosity) {
-    print('starting process ' + cmd + ' with arguments: ' + JSON.stringify(args));
+    print(Date() + ' starting process ' + cmd + ' with arguments: ' + JSON.stringify(args));
   }
   return executeExternal(cmd, args);
 }
@@ -979,7 +1017,7 @@ function shutdownArangod (arangod, options, forceTerminate) {
     forceTerminate = false;
   }
   if (options.hasOwnProperty('server')) {
-    print('running with external server');
+    print(Date() + ' running with external server');
     return;
   }
 
@@ -1020,7 +1058,7 @@ function shutdownArangod (arangod, options, forceTerminate) {
       }
     }
   } else {
-    print('Server already dead, doing nothing.');
+    print(Date() + ' Server already dead, doing nothing.');
   }
 }
 
@@ -1037,14 +1075,14 @@ function shutdownInstance (instanceInfo, options, forceTerminate) {
   if (options.activefailover) {
     let d = detectCurrentLeader(instanceInfo);
     if (instanceInfo.endpoint !== d.endpoint) {
-      print('failover has happened, leader is no more! Marking Crashy!');
+      print(Date() + ' failover has happened, leader is no more! Marking Crashy!');
       serverCrashedLocal = true;
       forceTerminate = true;
     }
   }
 
   if (!checkInstanceAlive(instanceInfo, options)) {
-    print('Server already dead, doing nothing. This shouldn\'t happen?');
+    print(Date() + ' Server already dead, doing nothing. This shouldn\'t happen?');
   }
 
   if (!forceTerminate) {
@@ -1062,7 +1100,7 @@ function shutdownInstance (instanceInfo, options, forceTerminate) {
         download(coords[0].url + "/_admin/cluster/maintenance", JSON.stringify("on"), requestOptions);
       }
     } catch (err) {
-      print("error while setting cluster maintenance mode:", err);
+      print(Date() + " error while setting cluster maintenance mode:", err);
     }
   }
 
@@ -1080,7 +1118,7 @@ function shutdownInstance (instanceInfo, options, forceTerminate) {
     if (b.role === 'agent') return -1;
     return 0;
   });
-  print('Shutdown order ' + JSON.stringify(toShutdown));
+  print(Date() + ' Shutdown order ' + JSON.stringify(toShutdown));
 
   let nonAgenciesCount = instanceInfo.arangods
       .filter(arangod => {
@@ -1108,12 +1146,12 @@ function shutdownInstance (instanceInfo, options, forceTerminate) {
         }
         shutdownArangod(arangod, options, forceTerminate);
         if (forceTerminate) {
-          print("FORCED shut down: " + JSON.stringify(arangod));
+          print(Date() + " FORCED shut down: " + JSON.stringify(arangod));
         } else {
           arangod.exitStatus = {
             status: 'RUNNING'
           };
-          print("Commanded shut down: " + JSON.stringify(arangod));
+          print(Date() + " Commanded shut down: " + JSON.stringify(arangod));
         }
         return true;
       }
@@ -1127,7 +1165,8 @@ function shutdownInstance (instanceInfo, options, forceTerminate) {
           localTimeout = localTimeout + 60;
         }
         if ((internal.time() - shutdownTime) > localTimeout) {
-          print('forcefully terminating ' + yaml.safeDump(arangod) +
+          dumpAgency(instanceInfo, options);
+          print(Date() + ' forcefully terminating ' + yaml.safeDump(arangod) +
                 ' after ' + timeout + 's grace period; marking crashy.');
           serverCrashedLocal = true;
           arangod.exitStatus = killExternal(arangod.pid, abortSignal);
@@ -1150,7 +1189,7 @@ function shutdownInstance (instanceInfo, options, forceTerminate) {
         }
         if (arangod.exitStatus.hasOwnProperty('signal') || arangod.exitStatus.hasOwnProperty('monitor')) {
           analyzeServerCrash(arangod, options, 'instance "' + arangod.role + '" Shutdown - ' + arangod.exitStatus.signal);
-          print("shutdownInstance: Marking crashy - " + JSON.stringify(arangod));
+          print(Date() + " shutdownInstance: Marking crashy - " + JSON.stringify(arangod));
           serverCrashedLocal = true;
         }
         stopProcdump(options, arangod);
@@ -1158,7 +1197,7 @@ function shutdownInstance (instanceInfo, options, forceTerminate) {
         if (arangod.role !== 'agent') {
           nonAgenciesCount --;
         }
-        print('Server "' + arangod.role + '" shutdown: Success: pid', arangod.pid);
+        print(Date() + ' Server "' + arangod.role + '" shutdown: Success: pid', arangod.pid);
         stopProcdump(options, arangod);
         return false;
       }
@@ -1185,7 +1224,7 @@ function shutdownInstance (instanceInfo, options, forceTerminate) {
     instanceInfo.arangods.forEach(arangod => {
       let errorEntries = readImportantLogLines(arangod.rootDir);
       if (Object.keys(errorEntries).length > 0) {
-        print('Found messages in the server logs: \n' +
+        print(Date() + ' Found messages in the server logs: \n' +
           yaml.safeDump(errorEntries));
       }
     });
@@ -1440,7 +1479,7 @@ function startArango (protocol, options, addArgs, rootDir, role) {
   try {
     instanceInfo.pid = executeArangod(ARANGOD_BIN, toArgv(args), options).pid;
   } catch (x) {
-    print('failed to run arangod - ' + JSON.stringify(x));
+    print(Date() + ' failed to run arangod - ' + JSON.stringify(x));
 
     throw x;
   }
@@ -1503,7 +1542,7 @@ function startInstanceAgency (instanceInfo, protocol, options, addArgs, rootDir)
     instanceInfo.endpoint = instanceInfo.arangods[instanceInfo.arangods.length - 1].endpoint;
     instanceInfo.url = instanceInfo.arangods[instanceInfo.arangods.length - 1].url;
     instanceInfo.role = 'agent';
-    print('Agency Endpoint: ' + instanceInfo.endpoint);
+    print(Date() + ' Agency Endpoint: ' + instanceInfo.endpoint);
   }
   return instanceInfo;
 }
@@ -1594,7 +1633,7 @@ function startInstance (protocol, options, addArgs, testname, tmpDir) {
         }
       });
     }
-    print(CYAN + 'up and running in ' + (time() - startTime) + ' seconds' + RESET);
+    print(CYAN + Date() + ' up and running in ' + (time() - startTime) + ' seconds' + RESET);
     var matchPort = /.*:.*:([0-9]*)/;
     var ports = [];
     var processInfo = [];
@@ -1608,7 +1647,7 @@ function startInstance (protocol, options, addArgs, testname, tmpDir) {
       processInfo.push('  [' + arangod.role + '] up with pid ' + arangod.pid + ' on port ' + port);
     });
 
-    print('sniffing template:\n  tcpdump -ni lo -s0 -w /tmp/out.pcap ' + ports.join(' or ') + '\n');
+    print(Date() + ' sniffing template:\n  tcpdump -ni lo -s0 -w /tmp/out.pcap ' + ports.join(' or ') + '\n');
     print(processInfo.join('\n') + '\n');
   } catch (e) {
     print(e, e.stack);

--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -836,11 +836,16 @@ function dumpAgency(instanceInfo, options) {
       } else {
         print(Date() + " Attempting to dump Agent: " + arangod);
         let agencyConfig = arangod.GET('_api/agency/config');
-        let agencyState = arangod.GET('_api/agency/state');
         print(JSON.stringify(agencyConfig));
-        print(JSON.stringify(agencyState));
         fs.write(fs.join(options.testOutputDirectory, "agencyConfig_" + arangod.pid + ".json"), agencyConfig);
+
+        let agencyState = arangod.GET('_api/agency/state');
+        print(JSON.stringify(agencyState));
         fs.write(fs.join(options.testOutputDirectory, "agencyState_" + arangod.pid + ".json"), agencyState);
+
+        let agencyPlan = arangod.GET('_api/agency/read');
+        print(JSON.stringify(agencyPlan));
+        fs.write(fs.join(options.testOutputDirectory, "agencyPlan_" + arangod.pid + ".json"), agencyPlan);
       }
     }
   });

--- a/js/client/modules/@arangodb/test-utils.js
+++ b/js/client/modules/@arangodb/test-utils.js
@@ -603,7 +603,12 @@ function runThere (options, instanceInfo, file) {
     } else {
       if ((reply.code === 500) &&
           reply.hasOwnProperty('message') &&
-          (reply.message === 'Request timeout reached')) {
+          (
+            (reply.message.search('Request timeout reached') >= 0 ) ||
+            (reply.message.search('timeout during read') >= 0 ) ||
+            (reply.message.search('Connection closed by remote') >= 0 )
+          )) {
+        print(RED + Date() + " request timeout reached, aborting test execution" + RESET);
         return {
           status: false,
           message: reply.message,


### PR DESCRIPTION
 - add timestamps in some prints
 - fix detection of `runThere` timeouts
 - add agency state dumper
 - add forcefull cluster killer, so we see what the whole cluster was doing.
