### PR TITLE
create _frontend collection lazily

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* don't create per-database system collection `_frontend` automatically.
+  This collection is only needed by the web UI, and it can be created lazily 
+  when needed.
+
 * added logging option `--log.time-format` to configure the time format used
   in log output. The possible values for this option are:
 

--- a/arangod/VocBase/Methods/Upgrade.cpp
+++ b/arangod/VocBase/Methods/Upgrade.cpp
@@ -240,11 +240,6 @@ void methods::Upgrade::registerTasks() {
           /*cluster*/ Flags::CLUSTER_NONE | Flags::CLUSTER_COORDINATOR_GLOBAL,
           /*database*/ DATABASE_INIT | DATABASE_UPGRADE | DATABASE_EXISTING,
           &UpgradeTasks::setupAqlFunctions);
-  addTask("createFrontend", "setup _frontend collection",
-          /*system*/ Flags::DATABASE_ALL,
-          /*cluster*/ Flags::CLUSTER_NONE | Flags::CLUSTER_COORDINATOR_GLOBAL,
-          /*database*/ DATABASE_INIT | DATABASE_UPGRADE | DATABASE_EXISTING,
-          &UpgradeTasks::createFrontend);
   addTask("setupQueues", "setup _queues collection",
           /*system*/ Flags::DATABASE_ALL,
           /*cluster*/ Flags::CLUSTER_NONE | Flags::CLUSTER_COORDINATOR_GLOBAL,

--- a/arangod/VocBase/Methods/UpgradeTasks.cpp
+++ b/arangod/VocBase/Methods/UpgradeTasks.cpp
@@ -281,11 +281,6 @@ bool UpgradeTasks::setupAqlFunctions(TRI_vocbase_t& vocbase,
   return ::createSystemCollection(vocbase, "_aqlfunctions");
 }
 
-bool UpgradeTasks::createFrontend(TRI_vocbase_t& vocbase,
-                                  arangodb::velocypack::Slice const& slice) {
-  return ::createSystemCollection(vocbase, "_frontend");
-}
-
 bool UpgradeTasks::setupQueues(TRI_vocbase_t& vocbase,
                                arangodb::velocypack::Slice const& slice) {
   return ::createSystemCollection(vocbase, "_queues");

--- a/arangod/VocBase/Methods/UpgradeTasks.h
+++ b/arangod/VocBase/Methods/UpgradeTasks.h
@@ -39,7 +39,6 @@ struct UpgradeTasks {
   static bool createUsersIndex(TRI_vocbase_t& vocbase, velocypack::Slice const& slice);
   static bool addDefaultUserOther(TRI_vocbase_t& vocbase, velocypack::Slice const& slice);
   static bool setupAqlFunctions(TRI_vocbase_t& vocbase, velocypack::Slice const& slice);
-  static bool createFrontend(TRI_vocbase_t& vocbase, velocypack::Slice const& slice);
   static bool setupQueues(TRI_vocbase_t& vocbase, velocypack::Slice const& slice);
   static bool setupJobs(TRI_vocbase_t& vocbase, velocypack::Slice const& slice);
   static bool createJobsIndex(TRI_vocbase_t& vocbase, velocypack::Slice const& slice);


### PR DESCRIPTION
This saves the creation of one collection per DB, which will sum up for installations with many databases and especially in the cluster.