### PR TITLE
Better logic for AddFollower/RemoveFollower scheduling.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -168,6 +168,12 @@ v3.4.5 (2019-03-27)
 
 * do not wait for replication after each job execution in Supervision
 
+* fix a blockage in MoveShard if a failover happens during the operation
+
+* check health of servers in Current before scheduling removeFollower jobs
+
+* wait for statistics collections to be created before running resilience
+  tests
 
 v3.4.4 (2019-03-12)
 -------------------

--- a/arangod/Agency/Job.cpp
+++ b/arangod/Agency/Job.cpp
@@ -249,6 +249,10 @@ size_t Job::countGoodOrBadServersInList(Node const& snap, VPackSlice const& serv
       if (serverName.isString()) {
         // serverName not a string? Then don't count
         std::string serverStr = serverName.copyString();
+        // Ignore a potential _ prefix, which can occur on leader resign:
+        if (serverStr.size() > 0 && serverStr[0] == '_') {
+          serverStr.erase(0, 1);  // remove trailing _
+        }
         // Now look up this server:
         auto it = healthData.find(serverStr);
         if (it != healthData.end()) {

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -218,10 +218,15 @@ bool MoveShard::start(bool&) {
   // Check that the toServer is in state "GOOD":
   std::string health = checkServerHealth(_snapshot, _to);
   if (health != "GOOD") {
-    LOG_TOPIC(DEBUG, Logger::SUPERVISION)
-        << "server " << _to << " is currently " << health
-        << ", not starting MoveShard job " << _jobId;
-    return false;
+    if (health == "BAD") {
+      LOG_TOPIC(DEBUG, Logger::SUPERVISION)
+          << "server " << _to << " is currently " << health
+          << ", not starting MoveShard job " << _jobId;
+      return false;
+    } else {   // FAILED
+      finish("", "", false, "toServer is FAILED");
+      return false;
+    }
   }
 
   // Check that _to is not in `Target/CleanedServers`:

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1460,8 +1460,10 @@ void Supervision::enforceReplication() {
             auto const& currentServers = currentDBs.hasAsArray(curPath);
             size_t inSyncReplicationFactor = actualReplicationFactor;
             if (currentServers.second) {
-              if (currentServers.first.length() < actualReplicationFactor) {
-                inSyncReplicationFactor = currentServers.first.length();
+              size_t nrGoodOrBad
+                = Job::countGoodOrBadServersInList(_snapshot, currentServers.first);
+              if (nrGoodOrBad < actualReplicationFactor) {
+                inSyncReplicationFactor = nrGoodOrBad;
               }
             }
 
@@ -1479,10 +1481,8 @@ void Supervision::enforceReplication() {
                 found = true;
                 LOG_TOPIC(DEBUG, Logger::SUPERVISION)
                     << "already found "
-                       "addFollower or removeFollower job in ToDo, not "
-                       "scheduling "
-                       "again for shard "
-                    << shard_.first;
+                       "addFollower, removeFollower or moveShard job in ToDo,"
+                       "not scheduling again for shard " << shard_.first;
                 break;
               }
             }

--- a/js/server/modules/@arangodb/cluster.js
+++ b/js/server/modules/@arangodb/cluster.js
@@ -532,7 +532,7 @@ function waitForStatisticsCollections() {
     wait(1.0);
   }
   console.topic('startup=info',
-                'waitForStatisticsCollections: timeout of 120s reached.);
+                'waitForStatisticsCollections: timeout of 120s reached.');
   return false;
 }
 

--- a/js/server/modules/@arangodb/cluster.js
+++ b/js/server/modules/@arangodb/cluster.js
@@ -519,6 +519,7 @@ function waitForStatisticsCollections() {
   // trigger failovers. We want to have these collections in place before
   // we start.
   let count = 0;
+  let db = require('internal').db;
   while (count++ < 120) {
     console.topic('startup=info',
                   'waitForStatisticsCollections: checking for collections...');

--- a/js/server/modules/@arangodb/cluster.js
+++ b/js/server/modules/@arangodb/cluster.js
@@ -513,6 +513,29 @@ function getLocalInfo () {
   return ret;
 }
 
+function waitForStatisticsCollections() {
+  // Waits until _statistics, _statistics15 and _statisticsRaw exist.
+  // This is used in unittests which do cleanOutServer, moveShard or
+  // trigger failovers. We want to have these collections in place before
+  // we start.
+  let count = 0;
+  while (count++ < 120) {
+    console.topic('startup=info',
+                  'waitForStatisticsCollections: checking for collections...');
+    if (db._collection('_statistics') !== null &&
+        db._collection('_statisticsRaw') !== null &&
+        db._collection('_statistics15') !== null) {
+      console.topic('startup=info',
+                    'waitForStatisticsCollections: all found');
+      return true;
+    }
+    wait(1.0);
+  }
+  console.topic('startup=info',
+                'waitForStatisticsCollections: timeout of 120s reached.);
+  return false;
+}
+
 exports.coordinatorId = coordinatorId;
 exports.isCluster = isCluster;
 exports.isCoordinator = isCoordinator;
@@ -530,3 +553,4 @@ exports.waitForSyncRepl = waitForSyncRepl;
 exports.endpoints = endpoints;
 exports.queryAgencyJob = queryAgencyJob;
 exports.getLocalInfo = getLocalInfo;
+exports.waitForStatisticsCollections = waitForStatisticsCollections;

--- a/tests/js/server/resilience/moving-shards-cluster.js
+++ b/tests/js/server/resilience/moving-shards-cluster.js
@@ -35,6 +35,7 @@ const _ = require("lodash");
 const wait = require("internal").wait;
 const supervisionState = require("@arangodb/cluster").supervisionState;
 const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
+const waitForStatisticsCollections = require('@arangodb/cluster').waitForStatisticsCollections;
 
 // in the `useData` case, use this many documents:
 const numDocuments = 1000;
@@ -805,6 +806,8 @@ function MovingShardsSuite ({useData}) {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief executes the test suite
 ////////////////////////////////////////////////////////////////////////////////
+
+waitForStatisticsCollections();
 
 jsunity.run(function MovingShardsSuite_nodata() {
   let derivedSuite = {};

--- a/tests/js/server/resilience/moving-shards-with-arangosearch-view-grey-cluster.js
+++ b/tests/js/server/resilience/moving-shards-with-arangosearch-view-grey-cluster.js
@@ -37,6 +37,7 @@ const request = require("@arangodb/request");
 const cluster = require("@arangodb/cluster");
 const supervisionState = cluster.supervisionState;
 const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
+const waitForStatisticsCollections = require('@arangodb/cluster').waitForStatisticsCollections;
 
 function getDBServers() {
   var tmp = global.ArangoClusterInfo.getDBServers();
@@ -1079,6 +1080,8 @@ function MovingShardsWithViewSuite (options) {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief executes the test suite
 ////////////////////////////////////////////////////////////////////////////////
+
+waitForStatisticsCollections();
 
 jsunity.run(function MovingShardsWithViewSuite_nodata() {
   let derivedSuite = {};

--- a/tests/js/server/resilience/repair-distribute-shards-like-spec-grey.js
+++ b/tests/js/server/resilience/repair-distribute-shards-like-spec-grey.js
@@ -27,6 +27,7 @@ const _ = require("lodash");
 const internal = require('internal');
 const wait = require('internal').wait;
 const request = require('@arangodb/request');
+const waitForStatisticsCollections = require('@arangodb/cluster').waitForStatisticsCollections;
 
 const colName = "repairDSLTestCollection";
 const protoColName = "repairDSLTestProtoCollection";
@@ -795,6 +796,7 @@ const distributeShardsLikeSuite = (options) => {
   };
 };
 
+waitForStatisticsCollections();
 
 describe('Collections with distributeShardsLike without data',
   distributeShardsLikeSuite({withData: false}));

--- a/tests/js/server/resilience/resilience-synchronous-repl-cluster.js
+++ b/tests/js/server/resilience/resilience-synchronous-repl-cluster.js
@@ -35,6 +35,7 @@ const _ = require("lodash");
 const wait = require("internal").wait;
 const suspendExternal = require("internal").suspendExternal;
 const continueExternal = require("internal").continueExternal;
+const waitForStatisticsCollections = require('@arangodb/cluster').waitForStatisticsCollections;
 
 function getDBServers() {
   var tmp = global.ArangoClusterInfo.getDBServers();
@@ -870,6 +871,8 @@ function SynchronousReplicationSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief executes the test suite
 ////////////////////////////////////////////////////////////////////////////////
+
+waitForStatisticsCollections();
 
 jsunity.run(SynchronousReplicationSuite);
 

--- a/tests/js/server/resilience/resilience-synchronous-repl-failureAt-cluster.js
+++ b/tests/js/server/resilience/resilience-synchronous-repl-failureAt-cluster.js
@@ -36,6 +36,7 @@ const wait = require("internal").wait;
 const request = require('@arangodb/request');
 const suspendExternal = require("internal").suspendExternal;
 const continueExternal = require("internal").continueExternal;
+const waitForStatisticsCollections = require('@arangodb/cluster').waitForStatisticsCollections;
 
 function getDBServers() {
   var tmp = global.ArangoClusterInfo.getDBServers();
@@ -695,6 +696,8 @@ function SynchronousReplicationSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief executes the test suite
 ////////////////////////////////////////////////////////////////////////////////
+
+waitForStatisticsCollections();
 
 jsunity.run(SynchronousReplicationSuite);
 

--- a/tests/js/server/resilience/resilience-synchronous-repl-with-arangosearch-view-cluster.js
+++ b/tests/js/server/resilience/resilience-synchronous-repl-with-arangosearch-view-cluster.js
@@ -36,6 +36,7 @@ const wait = require("internal").wait;
 const suspendExternal = require("internal").suspendExternal;
 const continueExternal = require("internal").continueExternal;
 const download = require('internal').download;
+const waitForStatisticsCollections = require('@arangodb/cluster').waitForStatisticsCollections;
 
 function getDBServers() {
   var tmp = global.ArangoClusterInfo.getDBServers();
@@ -981,6 +982,8 @@ function SynchronousReplicationWithViewSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief executes the test suite
 ////////////////////////////////////////////////////////////////////////////////
+
+waitForStatisticsCollections();
 
 jsunity.run(SynchronousReplicationWithViewSuite);
 

--- a/tests/js/server/resilience/shard-distribution-spec.js
+++ b/tests/js/server/resilience/shard-distribution-spec.js
@@ -33,6 +33,7 @@ const wait = require("internal").wait;
 const request = require('@arangodb/request');
 const endpointToURL = require("@arangodb/cluster").endpointToURL;
 const coordinatorName = "Coordinator0001";
+const waitForStatisticsCollections = require('@arangodb/cluster').waitForStatisticsCollections;
 
 let coordinator = instanceInfo.arangods.filter(arangod => {
   return arangod.role === 'coordinator';
@@ -41,6 +42,8 @@ let coordinator = instanceInfo.arangods.filter(arangod => {
 let dbServerCount = instanceInfo.arangods.filter(arangod => {
   return arangod.role === 'dbserver';
 }).length;
+
+waitForStatisticsCollections();
 
 describe('Shard distribution', function () {
 


### PR DESCRIPTION
This addresses a problem found in the k8s chaos tests: A MoveShard job could be confused by a failover happening. In this case the MoveShard job would essentially wait forever and lock the toServer.
As a consequence, the removeFollower logic would end up in a bad cycle of scheduling a removeFollower job only to abort it immediately.

Therefore, we now abort a MoveShard job, if any of the servers it has in the Plan for the shard becomes FAILED. Furthermore, we only schedule a removeFollower job, if enough replicas are actually in sync (in Current).

Finally, since the _statistics collections are only created after the bootstrap, a problem during resilience tests could arise, which can occur if collections are created during a cleanOutServer job. This problem will be solved eventually, but here we simply wait for the existence of the _statistics collections before each resilience test starts.