### PR TITLE
fix smart join optimization when another optimizer rule (reduce-extra…

### DIFF
--- a/arangod/Aql/Optimizer.cpp
+++ b/arangod/Aql/Optimizer.cpp
@@ -45,6 +45,14 @@ void Optimizer::disableRule(int rule) {
   it->second.enabled = false;
 }
 
+bool Optimizer::isDisabled(int rule) const {
+  auto it = _rules.find(rule);
+  if (it == _rules.end()) {
+    return true;
+  }
+  return !it->second.enabled;
+}
+
 bool Optimizer::runOnlyRequiredRules(size_t extraPlans) const {
   return (_runOnlyRequiredRules ||
           (_newPlans.size() + _plans.size() + extraPlans >= _maxNumberOfPlans));

--- a/arangod/Aql/Optimizer.h
+++ b/arangod/Aql/Optimizer.h
@@ -134,6 +134,8 @@ class Optimizer {
   void addPlan(std::unique_ptr<ExecutionPlan>, OptimizerRule const*, bool, int newLevel = 0);
 
   void disableRule(int rule);
+  
+  bool isDisabled(int rule) const;
 
   /// @brief getPlans, ownership of the plans remains with the optimizer
   RollingVector<PlanList::Entry>& getPlans() { return _plans.list; }

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -3463,6 +3463,7 @@ void arangodb::aql::interchangeAdjacentEnumerationsRule(Optimizer* opt,
 
 /// @brief optimize queries in the cluster so that the entire query gets pushed
 /// to a single server
+#if 0
 void arangodb::aql::optimizeClusterSingleShardRule(Optimizer* opt,
                                                    std::unique_ptr<ExecutionPlan> plan,
                                                    OptimizerRule const* rule) {
@@ -3556,6 +3557,7 @@ void arangodb::aql::optimizeClusterSingleShardRule(Optimizer* opt,
 
   opt->addPlan(std::move(plan), rule, wasModified);
 }
+#endif
 
 /// @brief scatter operations in cluster
 /// this rule inserts scatter, gather and remote nodes so operations on sharded

--- a/arangod/RocksDBEngine/RocksDBOptimizerRules.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptimizerRules.cpp
@@ -230,6 +230,8 @@ void RocksDBOptimizerRules::reduceExtractionToProjectionRule(
               std::move(condition), opts);
           plan->registerNode(inode);
           plan->replaceNode(n, inode);
+          // copy over specialization data from smart-joins rule
+          inode->setPrototype(en->prototypeCollection(), en->prototypeOutVariable());
           n = inode;
           // need to update e, because it is used later
           e = dynamic_cast<DocumentProducingNode*>(n);


### PR DESCRIPTION
…ction-to-projection) turned full scans into index accesses

Related enterprise PR: https://github.com/arangodb/enterprise/pull/238