### PR TITLE
Feature devel/allowed paths jwt

### DIFF
--- a/arangod/Auth/TokenCache.cpp
+++ b/arangod/Auth/TokenCache.cpp
@@ -330,13 +330,18 @@ auth::TokenCache::Entry auth::TokenCache::validateJwtBody(std::string const& bod
   if (bodySlice.hasKey("allowed_paths")) {
     VPackSlice const paths = bodySlice.get("allowed_paths");
     if (!paths.isArray()) {
-      LOG_TOPIC(TRACE, arangodb::Logger::AUTHENTICATION)
+      LOG_TOPIC("89898", TRACE, arangodb::Logger::AUTHENTICATION)
         << "allowed_paths must be an array";
+      return auth::TokenCache::Entry::Unauthenticated();
+    }
+    if (paths.length() == 0) {
+      LOG_TOPIC("89893", TRACE, arangodb::Logger::AUTHENTICATION)
+        << "allowed_paths may not be empty";
       return auth::TokenCache::Entry::Unauthenticated();
     }
     for (auto const& path : VPackArrayIterator(paths)) {
       if (!path.isString()) {
-        LOG_TOPIC(TRACE, arangodb::Logger::AUTHENTICATION)
+        LOG_TOPIC("89891", TRACE, arangodb::Logger::AUTHENTICATION)
         << "allowed_paths may only contain strings";
       return auth::TokenCache::Entry::Unauthenticated();
       }

--- a/arangod/Auth/TokenCache.cpp
+++ b/arangod/Auth/TokenCache.cpp
@@ -342,7 +342,7 @@ auth::TokenCache::Entry auth::TokenCache::validateJwtBody(std::string const& bod
     for (auto const& path : VPackArrayIterator(paths)) {
       if (!path.isString()) {
         LOG_TOPIC("89891", TRACE, arangodb::Logger::AUTHENTICATION)
-        << "allowed_paths may only contain strings";
+          << "allowed_paths may only contain strings";
       return auth::TokenCache::Entry::Unauthenticated();
       }
       authResult._allowedPaths.push_back(path.copyString());

--- a/arangod/Auth/TokenCache.cpp
+++ b/arangod/Auth/TokenCache.cpp
@@ -327,6 +327,23 @@ auth::TokenCache::Entry auth::TokenCache::validateJwtBody(std::string const& bod
     return auth::TokenCache::Entry::Unauthenticated();
   }
 
+  if (bodySlice.hasKey("allowed_paths")) {
+    VPackSlice const paths = bodySlice.get("allowed_paths");
+    if (!paths.isArray()) {
+      LOG_TOPIC(TRACE, arangodb::Logger::AUTHENTICATION)
+        << "allowed_paths must be an array";
+      return auth::TokenCache::Entry::Unauthenticated();
+    }
+    for (auto const& path : VPackArrayIterator(paths)) {
+      if (!path.isString()) {
+        LOG_TOPIC(TRACE, arangodb::Logger::AUTHENTICATION)
+        << "allowed_paths may only contain strings";
+      return auth::TokenCache::Entry::Unauthenticated();
+      }
+      authResult._allowedPaths.push_back(path.copyString());
+    }
+  }
+
   // mop: optional exp (cluster currently uses non expiring jwts)
   if (bodySlice.hasKey("exp")) {
     VPackSlice const expSlice = bodySlice.get("exp");

--- a/arangod/Auth/TokenCache.h
+++ b/arangod/Auth/TokenCache.h
@@ -53,7 +53,7 @@ class TokenCache {
 
    public:
     explicit Entry(std::string const& username, bool a, double t)
-        : _username(username), _authenticated(a), _expiry(t) {}
+        : _username(username), _authenticated(a), _expiry(t), _allowedPaths() {}
 
     static Entry Unauthenticated() { return Entry("", false, 0); }
 
@@ -70,6 +70,8 @@ class TokenCache {
     bool _authenticated;
     /// expiration time (in seconds since epoch) of this entry
     double _expiry;
+    // paths that are valid for this token
+    std::vector<std::string> _allowedPaths;
   };
 
  public:

--- a/arangod/GeneralServer/GeneralCommTask.cpp
+++ b/arangod/GeneralServer/GeneralCommTask.cpp
@@ -78,7 +78,8 @@ GeneralCommTask::GeneralCommTask(GeneralServer& server, GeneralServer::IoContext
     : IoTask(server, context, "GeneralCommTask"),
       SocketTask(server, context, std::move(socket), std::move(info),
                  keepAliveTimeout, skipSocketInit),
-      _auth(AuthenticationFeature::instance()) {
+      _auth(AuthenticationFeature::instance()),
+      _authToken("", false, 0.) {
   TRI_ASSERT(_auth != nullptr);
 }
 
@@ -511,6 +512,13 @@ rest::ResponseCode GeneralCommTask::canAccessPath(GeneralRequest& req) const {
   std::string const& path = req.requestPath();
   std::string const& username = req.user();
   bool userAuthenticated = req.authenticated();
+
+  auto const& ap = _authToken._allowedPaths;
+  if (!ap.empty()) {
+    if (std::find(ap.begin(), ap.end(), path) == ap.end()) {
+      return rest::ResponseCode::UNAUTHORIZED;
+    }
+  }
 
   rest::ResponseCode result = userAuthenticated ? rest::ResponseCode::OK
                                                 : rest::ResponseCode::UNAUTHORIZED;

--- a/arangod/GeneralServer/GeneralCommTask.h
+++ b/arangod/GeneralServer/GeneralCommTask.h
@@ -34,6 +34,7 @@
 #include "Basics/MutexLocker.h"
 #include "Basics/StringBuffer.h"
 #include "GeneralServer/Socket.h"
+#include "Auth/TokenCache.h"
 
 namespace arangodb {
 class AuthenticationFeature;
@@ -137,6 +138,8 @@ class GeneralCommTask : public SocketTask {
 
   arangodb::Mutex _statisticsMutex;
   std::unordered_map<uint64_t, RequestStatistics*> _statisticsMap;
+
+  auth::TokenCache::Entry _authToken;
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief checks the access rights for a specified path, includes automatic

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -795,7 +795,7 @@ ResponseCode HttpCommTask::handleAuthHeader(HttpRequest* req) {
 
       req->setAuthenticationMethod(authMethod);
       if (authMethod != AuthenticationMethod::NONE) {
-        _authToken = std::move(_auth->tokenCache().checkAuthentication(authMethod, auth));
+        _authToken = _auth->tokenCache().checkAuthentication(authMethod, auth);
         req->setAuthenticated(_authToken.authenticated());
         req->setUser(std::move(_authToken._username));
       }

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -797,7 +797,7 @@ ResponseCode HttpCommTask::handleAuthHeader(HttpRequest* req) {
       if (authMethod != AuthenticationMethod::NONE) {
         _authToken = _auth->tokenCache().checkAuthentication(authMethod, auth);
         req->setAuthenticated(_authToken.authenticated());
-        req->setUser(std::move(_authToken._username));
+        req->setUser(_authToken._username); // do copy here, so that we do not invalidate the member
       }
 
       if (req->authenticated() || !_auth->isActive()) {

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -760,7 +760,7 @@ void HttpCommTask::resetState() {
   _readRequestBody = false;
 }
 
-ResponseCode HttpCommTask::handleAuthHeader(HttpRequest* req) const {
+ResponseCode HttpCommTask::handleAuthHeader(HttpRequest* req) {
   bool found;
   std::string const& authStr = req->header(StaticStrings::Authorization, found);
   if (!found) {
@@ -795,9 +795,9 @@ ResponseCode HttpCommTask::handleAuthHeader(HttpRequest* req) const {
 
       req->setAuthenticationMethod(authMethod);
       if (authMethod != AuthenticationMethod::NONE) {
-        auto entry = _auth->tokenCache().checkAuthentication(authMethod, auth);
-        req->setAuthenticated(entry.authenticated());
-        req->setUser(std::move(entry._username));
+        _authToken = std::move(_auth->tokenCache().checkAuthentication(authMethod, auth));
+        req->setAuthenticated(_authToken.authenticated());
+        req->setUser(std::move(_authToken._username));
       }
 
       if (req->authenticated() || !_auth->isActive()) {

--- a/arangod/GeneralServer/HttpCommTask.h
+++ b/arangod/GeneralServer/HttpCommTask.h
@@ -51,7 +51,7 @@ class HttpCommTask final : public GeneralCommTask {
 
   std::string authenticationRealm() const;
   ResponseCode authenticateRequest(HttpRequest*);
-  ResponseCode handleAuthHeader(HttpRequest* request) const;
+  ResponseCode handleAuthHeader(HttpRequest* request);
 
  private:
   size_t _readPosition;       // current read position

--- a/arangod/GeneralServer/VstCommTask.cpp
+++ b/arangod/GeneralServer/VstCommTask.cpp
@@ -290,11 +290,11 @@ void VstCommTask::handleAuthHeader(VPackSlice const& header, uint64_t messageId)
     LOG_TOPIC("01f44", ERR, Logger::REQUESTS) << "Unknown VST encryption type";
   }
 
-  auto entry = _auth->tokenCache().checkAuthentication(_authMethod, authString);
-  _authorized = entry.authenticated();
+  _authToken = _auth->tokenCache().checkAuthentication(_authMethod, authString);
+  _authorized = _authToken.authenticated();
 
   if (_authorized || !_auth->isActive()) {
-    _authenticatedUser = std::move(entry._username);
+    _authenticatedUser = std::move(_authToken._username);
     // simon: drivers expect a response for their auth request
     addErrorResponse(ResponseCode::OK, rest::ContentType::VPACK, messageId,
                      TRI_ERROR_NO_ERROR, "auth successful");

--- a/arangod/GeneralServer/VstCommTask.cpp
+++ b/arangod/GeneralServer/VstCommTask.cpp
@@ -86,7 +86,6 @@ VstCommTask::VstCommTask(GeneralServer& server, GeneralServer::IoContext& contex
       GeneralCommTask(server, context, std::move(socket), std::move(info), timeout, skipInit),
       _authorized(!_auth->isActive()),
       _authMethod(rest::AuthenticationMethod::NONE),
-      _authenticatedUser(),
       _protocolVersion(protocolVersion) {
   _protocol = "vst";
 
@@ -294,12 +293,11 @@ void VstCommTask::handleAuthHeader(VPackSlice const& header, uint64_t messageId)
   _authorized = _authToken.authenticated();
 
   if (_authorized || !_auth->isActive()) {
-    _authenticatedUser = std::move(_authToken._username);
     // simon: drivers expect a response for their auth request
     addErrorResponse(ResponseCode::OK, rest::ContentType::VPACK, messageId,
                      TRI_ERROR_NO_ERROR, "auth successful");
   } else {
-    _authenticatedUser.clear();
+    _authToken = auth::TokenCache::Entry::Unauthenticated();
     addErrorResponse(rest::ResponseCode::UNAUTHORIZED, rest::ContentType::VPACK,
                      messageId, TRI_ERROR_HTTP_UNAUTHORIZED);
   }
@@ -381,11 +379,11 @@ bool VstCommTask::processRead(double startTime) {
       auto req = std::make_unique<VstRequest>(_connectionInfo, std::move(message),
                                               chunkHeader._messageID);
       req->setAuthenticated(_authorized);
-      req->setUser(_authenticatedUser);
+      req->setUser(_authToken._username);
       req->setAuthenticationMethod(_authMethod);
       if (_authorized && _auth->userManager() != nullptr) {
         // if we don't call checkAuthentication we need to refresh
-        _auth->userManager()->refreshUser(_authenticatedUser);
+        _auth->userManager()->refreshUser(_authToken._username);
       }
 
       RequestFlow cont = prepareExecution(*req.get());

--- a/arangod/GeneralServer/VstCommTask.h
+++ b/arangod/GeneralServer/VstCommTask.h
@@ -132,7 +132,6 @@ class VstCommTask final : public GeneralCommTask {
   /// Is the current user authorized
   bool _authorized;
   rest::AuthenticationMethod _authMethod;
-  std::string _authenticatedUser;
   ProtocolVersion _protocolVersion;
   uint32_t _maxChunkSize;
 };


### PR DESCRIPTION
Allow the restriction to specific paths in a JWT. This best explained by an example:
```
{"server_id":"foo", "allowed_paths":["/_api/version"]}
```
```
{"server_id":"foo", "allowed_paths":["/_admin/statistics"]}
```
Currently most tools (operator, prometheus exporter) use the superuser token everywhere.

Older versions of arangodb will ignore this attribute and thus adding `allowed_paths` to a token, that allowed access in the first place, will remain valid.

This is a first step to a more evolved method of specifying permissions (including groups, collections, ...) via jwt.