### PR TITLE
preserve smart-join attribute in DC2DC as well

### DIFF
--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -183,7 +183,8 @@ LogicalCollection::LogicalCollection(TRI_vocbase_t& vocbase, VPackSlice const& i
   _sharding = std::make_unique<ShardingInfo>(info, this);
 
 #ifdef USE_ENTERPRISE
-  if (ServerState::instance()->isCoordinator()) {
+  if (ServerState::instance()->isCoordinator() ||
+      ServerState::instance()->isDBServer()) {
     if (!info.get(StaticStrings::SmartJoinAttribute).isNone() &&
         !hasSmartJoinAttribute()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INVALID_SMART_JOIN_ATTRIBUTE,


### PR DESCRIPTION
Potential fix for DC2DC losing the smartJoinAttribute propery of a collection

I need some help testing this is in an actual DC2DC setup.