### PR TITLE
Expose "filter" attribute for running Foxx tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* added `filter` option to Foxx HTTP API for running tests.
+
 * updated bundled version of jemalloc memory allocator to 5.2.0.
 
 * don't create per-database system collection `_frontend` automatically.

--- a/Documentation/Books/Manual/ReleaseNotes/NewFeatures35.md
+++ b/Documentation/Books/Manual/ReleaseNotes/NewFeatures35.md
@@ -263,6 +263,9 @@ The HTTP API for creating indexes at POST `/_api/index` has been extended two-fo
 
 * to create an index in background, the attribute `inBackground` can be set to `true`.
 
+The HTTP API for running Foxx service tests now supports a `filter` attribute,
+which can be used to limit which test cases should be executed.
+
 
 Web interface
 -------------

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_bundle.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_bundle.md
@@ -19,7 +19,7 @@ Mount path of the installed service.
 @RESTRETURNCODES
 
 @RESTRETURNCODE{200}
-Returned if the request was sucessful.
+Returned if the request was successful.
 
 @RESTRETURNCODE{400}
 Returned if the mount path is unknown.

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_commit.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_commit.md
@@ -14,6 +14,6 @@ This can be used to resolve service conflicts between coordinators that can not 
 Overwrite existing service files in database even if they already exist.
 
 @RESTRETURNCODE{204}
-Returned if the request was sucessful.
+Returned if the request was successful.
 
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_configuration_get.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_configuration_get.md
@@ -17,6 +17,6 @@ Mount path of the installed service.
 @RESTRETURNCODES
 
 @RESTRETURNCODE{200}
-Returned if the request was sucessful.
+Returned if the request was successful.
 
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_configuration_replace.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_configuration_replace.md
@@ -18,6 +18,6 @@ Any omitted options will be reset to their default values or marked as unconfigu
 Mount path of the installed service.
 
 @RESTRETURNCODE{200}
-Returned if the request was sucessful.
+Returned if the request was successful.
 
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_configuration_update.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_configuration_update.md
@@ -18,6 +18,6 @@ Any omitted options will be ignored.
 Mount path of the installed service.
 
 @RESTRETURNCODE{200}
-Returned if the request was sucessful.
+Returned if the request was successful.
 
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_dependencies_get.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_dependencies_get.md
@@ -17,6 +17,6 @@ Mount path of the installed service.
 @RESTRETURNCODES
 
 @RESTRETURNCODE{200}
-Returned if the request was sucessful.
+Returned if the request was successful.
 
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_dependencies_replace.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_dependencies_replace.md
@@ -18,6 +18,6 @@ Any omitted dependencies will be disabled.
 Mount path of the installed service.
 
 @RESTRETURNCODE{200}
-Returned if the request was sucessful.
+Returned if the request was successful.
 
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_dependencies_update.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_dependencies_update.md
@@ -18,6 +18,6 @@ Any omitted dependencies will be ignored.
 Mount path of the installed service.
 
 @RESTRETURNCODE{200}
-Returned if the request was sucessful.
+Returned if the request was successful.
 
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_development_disable.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_development_disable.md
@@ -18,6 +18,6 @@ Mount path of the installed service.
 @RESTRETURNCODES
 
 @RESTRETURNCODE{200}
-Returned if the request was sucessful.
+Returned if the request was successful.
 
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_development_enable.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_development_enable.md
@@ -23,6 +23,6 @@ Mount path of the installed service.
 @RESTRETURNCODES
 
 @RESTRETURNCODE{200}
-Returned if the request was sucessful.
+Returned if the request was successful.
 
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_readme.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_readme.md
@@ -14,7 +14,7 @@ Mount path of the installed service.
 @RESTRETURNCODES
 
 @RESTRETURNCODE{200}
-Returned if the request was sucessful.
+Returned if the request was successful.
 
 @RESTRETURNCODE{204}
 Returned if no README file was found.

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_scripts_list.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_scripts_list.md
@@ -16,6 +16,6 @@ Mount path of the installed service.
 @RESTRETURNCODES
 
 @RESTRETURNCODE{200}
-Returned if the request was sucessful.
+Returned if the request was successful.
 
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_scripts_run.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_scripts_run.md
@@ -25,6 +25,6 @@ Returns the exports of the script, if any.
 @RESTRETURNCODES
 
 @RESTRETURNCODE{200}
-Returned if the request was sucessful.
+Returned if the request was successful.
 
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_swagger.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_swagger.md
@@ -16,6 +16,6 @@ Mount path of the installed service.
 @RESTRETURNCODES
 
 @RESTRETURNCODE{200}
-Returned if the request was sucessful.
+Returned if the request was successful.
 
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_tests_run.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_tests_run.md
@@ -38,6 +38,10 @@ Test reporter to use.
 @RESTQUERYPARAM{idiomatic,boolean,optional}
 Use the matching format for the reporter, regardless of the *Accept* header.
 
+@RESTQUERYPARAM{filter,string,optional}
+Only run tests where the full name (including full test suites and test case)
+matches this string.
+
 @RESTRETURNCODES
 
 @RESTRETURNCODE{200}

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_tests_run.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_tests_run.md
@@ -45,6 +45,6 @@ matches this string.
 @RESTRETURNCODES
 
 @RESTRETURNCODE{200}
-Returned if the request was sucessful.
+Returned if the request was successful.
 
 @endDocuBlock

--- a/js/apps/system/_api/foxx/APP/index.js
+++ b/js/apps/system/_api/foxx/APP/index.js
@@ -367,8 +367,9 @@ scriptsRouter.post('/:name', (req, res) => {
 instanceRouter.post('/tests', (req, res) => {
   const service = req.service;
   const idiomatic = req.queryParams.idiomatic;
+  const filter = req.queryParams.filter || null;
   const reporter = req.queryParams.reporter || null;
-  const result = FoxxManager.runTests(service.mount, {reporter});
+  const result = FoxxManager.runTests(service.mount, {filter, reporter});
   if (reporter === 'stream' && (idiomatic || req.accepts(LDJSON, 'json') === LDJSON)) {
     res.type(LDJSON);
     for (const row of result) {
@@ -387,6 +388,7 @@ instanceRouter.post('/tests', (req, res) => {
     res.json(result);
   }
 })
+.queryParam('filter', joi.string().allow("").optional())
 .queryParam('reporter', joi.only(...reporters).optional())
 .queryParam('idiomatic', schemas.flag.default(false))
 .response(200, ['json', LDJSON, 'xml', 'text']);

--- a/js/server/modules/@arangodb/foxx/manager.js
+++ b/js/server/modules/@arangodb/foxx/manager.js
@@ -971,7 +971,7 @@ function runTests (mount, options = {}) {
     service = reloadInstalledService(mount, true);
   }
   ensureServiceLoaded(mount);
-  return require('@arangodb/foxx/mocha').run(service, options.reporter);
+  return require('@arangodb/foxx/mocha').run(service, options);
 }
 
 function enableDevelopmentMode (mount) {

--- a/js/server/modules/@arangodb/foxx/mocha.js
+++ b/js/server/modules/@arangodb/foxx/mocha.js
@@ -29,10 +29,10 @@ const mocha = require('@arangodb/mocha');
 
 const isNotPattern = (pattern) => pattern.indexOf('*') === -1;
 
-exports.run = function runFoxxTests (service, reporterName) {
-  const run = (file, context) => service.run(file, {context: context});
-  const result = mocha.run(run, exports.findTests(service), reporterName);
-  if (reporterName === 'xunit' && Array.isArray(result) && result[1]) {
+exports.run = function runFoxxTests (service, {filter, reporter}) {
+  const run = (file, context) => service.run(file, {context});
+  const result = mocha.run(run, exports.findTests(service), reporter, filter);
+  if (reporter === 'xunit' && Array.isArray(result) && result[1]) {
     result[1].name = service.mount;
   }
   return result;


### PR DESCRIPTION
This exposes the "mocha grep" option already implemented for test-utils as the "filter" attribute in the Foxx HTTP API so users can filter which tests to run. This is helpful for users who write a lot of tests and don't want to run all tests every time.