### PR TITLE
Bug fix/fix test muell

### DIFF
--- a/arangod/Agency/RestAgencyHandler.cpp
+++ b/arangod/Agency/RestAgencyHandler.cpp
@@ -34,6 +34,7 @@
 #include "Rest/HttpRequest.h"
 #include "Rest/Version.h"
 #include "StorageEngine/EngineSelectorFeature.h"
+#include "Transaction/StandaloneContext.h"
 
 using namespace arangodb;
 
@@ -47,7 +48,7 @@ using namespace arangodb::consensus;
 
 RestAgencyHandler::RestAgencyHandler(GeneralRequest* request,
                                      GeneralResponse* response, Agent* agent)
-    : RestBaseHandler(request, response), _agent(agent) {}
+    : RestVocbaseBaseHandler(request, response), _agent(agent) {}
 
 inline RestStatus RestAgencyHandler::reportErrorEmptyRequest() {
   LOG_TOPIC("46536", WARN, Logger::AGENCY)
@@ -566,7 +567,8 @@ RestStatus RestAgencyHandler::handleState() {
     VPackObjectBuilder o(&body);
     _agent->readDB(body);
   }
-  generateResult(rest::ResponseCode::OK, body.slice());
+  auto ctx = std::make_shared<transaction::StandaloneContext>(_vocbase);
+  generateResult(rest::ResponseCode::OK, body.slice(), ctx->getVPackOptionsForDump());
   return RestStatus::DONE;
 }
 

--- a/arangod/Agency/RestAgencyHandler.h
+++ b/arangod/Agency/RestAgencyHandler.h
@@ -25,7 +25,7 @@
 #define ARANGOD_REST_HANDLER_REST_AGENCY_HANDLER_H 1
 
 #include "Agency/Agent.h"
-#include "RestHandler/RestBaseHandler.h"
+#include "RestHandler/RestVocbaseBaseHandler.h"
 
 namespace arangodb {
 
@@ -33,7 +33,7 @@ namespace arangodb {
 /// @brief REST handler for outside calls to agency (write & read)
 ////////////////////////////////////////////////////////////////////////////////
 
-class RestAgencyHandler : public RestBaseHandler {
+class RestAgencyHandler : public RestVocbaseBaseHandler {
  public:
   RestAgencyHandler(GeneralRequest*, GeneralResponse*, consensus::Agent*);
 

--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -839,17 +839,16 @@ function dumpAgency(instanceInfo, options) {
     if (agencyReply.code === 200) {
       let agencyValue = JSON.parse(agencyReply.body);
       fs.write(fs.join(options.testOutputDirectory, fn + '_' + arangod.pid + ".json"), JSON.stringify(agencyValue, null, 2));
-    }
-    else {
+    } else {
       print(agencyReply);
     }
   }
   instanceInfo.arangods.forEach((arangod) => {
     if (arangod.role === "agent") {
       if (arangod.hasOwnProperty('exitStatus')) {
-        print(Date() + " this agent is already dead: " + arangod);
+        print(Date() + " this agent is already dead: " + JSON.stringify(arangod));
       } else {
-        print(Date() + " Attempting to dump Agent: " + arangod);
+        print(Date() + " Attempting to dump Agent: " + JSON.stringify(arangod));
         dumpAgent(arangod, '/_api/agency/config', 'GET', 'agencyConfig');
 
         dumpAgent(arangod, '/_api/agency/state', 'GET', 'agencyState');

--- a/js/client/modules/@arangodb/testing.js
+++ b/js/client/modules/@arangodb/testing.js
@@ -138,7 +138,7 @@ const optionsDefaults = {
   'extraArgs': {},
   'extremeVerbosity': false,
   'force': true,
-  'getSockStat': true,
+  'getSockStat': false,
   'arangosearch':true,
   'jsonReply': false,
   'loopEternal': false,


### PR DESCRIPTION
Fix test shutdown by:
* not making agency config/state/dump produce many many warnings about unknown CustomTypeHandler.
* not printing "[Object object]" for every agent whose data is dumped
* turning off useless sock stats