### PR TITLE
Reduce test leftovers on disk

### DIFF
--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -1137,7 +1137,7 @@ function shutdownInstance (instanceInfo, options, forceTerminate) {
     timeout *= 2;
   }
 
-  if ((toShutdown.length > 0) && (options.cluster === true)) {
+  if ((toShutdown.length > 0) && (options.cluster === true) && (options.dumpAgencyOnError === true)) {
     dumpAgency(instanceInfo, options);
   }
   var shutdownTime = internal.time();

--- a/js/client/modules/@arangodb/testing.js
+++ b/js/client/modules/@arangodb/testing.js
@@ -83,6 +83,7 @@ let optionsDocumentation = [
   '   - `configDir`: the directory containing the config files, defaults to',
   '                  etc/testing',
   '   - `writeXmlReport`:  Write junit xml report files',
+  '   - `dumpAgencyOnError`: if we should create an agency dump if an error occurs',
   '   - `prefix`:    prefix for the tests in the xml reports',
   '',
   '   - `disableMonitor`: if set to true on windows, procdump will not be attached.',
@@ -119,6 +120,7 @@ let optionsDocumentation = [
 ];
 
 const optionsDefaults = {
+  'dumpAgencyOnError': false,
   'agencySize': 3,
   'agencyWaitForSync': false,
   'agencySupervision': true,
@@ -172,7 +174,7 @@ const optionsDefaults = {
   'valgrindHosts': false,
   'verbose': false,
   'walFlushTimeout': 30000,
-  'writeXmlReport': true,
+  'writeXmlReport': false,
   'testFailureText': 'testfailures.txt',
   'testCase': undefined,
   'disableMonitor': false

--- a/js/client/modules/@arangodb/testing.js
+++ b/js/client/modules/@arangodb/testing.js
@@ -120,7 +120,7 @@ let optionsDocumentation = [
 ];
 
 const optionsDefaults = {
-  'dumpAgencyOnError': false,
+  'dumpAgencyOnError': true,
   'agencySize': 3,
   'agencyWaitForSync': false,
   'agencySupervision': true,


### PR DESCRIPTION
- don't dump agency by default on all errors
- don't write junit xml reports by default
