### PR TITLE
Aardvark: Add PRUNE to keyword list

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/src/mode-aql.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/src/mode-aql.js
@@ -88,7 +88,7 @@ var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
 var AqlHighlightRules = function() {
 
     var keywords = (
-        "for|return|filter|search|sort|limit|let|collect|asc|desc|in|into|insert|update|remove|replace|upsert|options|with|and|or|not|distinct|graph|shortest_path|outbound|inbound|any|all|none|aggregate|like|k_shortest_paths"
+        "for|return|filter|search|sort|limit|let|collect|asc|desc|in|into|insert|update|remove|replace|upsert|options|with|and|or|not|distinct|graph|shortest_path|outbound|inbound|any|all|none|aggregate|like|prune|k_shortest_paths"
     );
 
     var builtinFunctions = (


### PR DESCRIPTION
Frontend needs to be rebuilt. Should also be backported to 3.4.

Internal Ref: https://github.com/arangodb/planning/issues/3865