### PR TITLE
K_SHORTEST_PATHS queries only support one variable in FOR

### DIFF
--- a/arangod/Aql/grammar.cpp
+++ b/arangod/Aql/grammar.cpp
@@ -2671,8 +2671,8 @@ yyreduce:
       auto variableNamesNode = static_cast<AstNode*>((yyvsp[-2].node));
       TRI_ASSERT(variableNamesNode != nullptr);
       TRI_ASSERT(variableNamesNode->type == NODE_TYPE_ARRAY);
-      if (variableNamesNode->numMembers() > 2) {
-          parser->registerParseError(TRI_ERROR_QUERY_PARSE, "ShortestPath only has one or two return variables", yylloc.first_line, yylloc.first_column);
+      if (variableNamesNode->numMembers() > 1) {
+          parser->registerParseError(TRI_ERROR_QUERY_PARSE, "k Shortest Paths only has one return variable", yylloc.first_line, yylloc.first_column);
       }
       auto variablesNode = TransformOutputVariables(parser, variableNamesNode);
       auto graphInfoNode = static_cast<AstNode*>((yyvsp[0].node));

--- a/arangod/Aql/grammar.y
+++ b/arangod/Aql/grammar.y
@@ -739,8 +739,8 @@ for_statement:
       auto variableNamesNode = static_cast<AstNode*>($2);
       TRI_ASSERT(variableNamesNode != nullptr);
       TRI_ASSERT(variableNamesNode->type == NODE_TYPE_ARRAY);
-      if (variableNamesNode->numMembers() > 2) {
-          parser->registerParseError(TRI_ERROR_QUERY_PARSE, "ShortestPath only has one or two return variables", yylloc.first_line, yylloc.first_column);
+      if (variableNamesNode->numMembers() > 1) {
+          parser->registerParseError(TRI_ERROR_QUERY_PARSE, "k Shortest Paths only has one return variable", yylloc.first_line, yylloc.first_column);
       }
       auto variablesNode = TransformOutputVariables(parser, variableNamesNode);
       auto graphInfoNode = static_cast<AstNode*>($4);

--- a/tests/js/server/aql/aql-graph-k-shortest-path.js
+++ b/tests/js/server/aql/aql-graph-k-shortest-path.js
@@ -524,6 +524,22 @@ function kAttributeWeightShortestPathTestSuite() {
 
 }
 
+function kShortestPathsSyntaxTestSuite() {
+  return {
+    testTooManyVariables: function () {
+      const query = `
+        FOR a, b IN OUTBOUND K_SHORTEST_PATHS "x" TO "y" GRAPH "G" RETURN a`;
+      try {
+        db._query(query).toArray();
+      } catch (e) {
+	assertEqual(e.errorMessage, "AQL: k Shortest Paths only has one return variable near 'RETURN a' at position 2:68 (while parsing)");
+      }
+    }
+  };
+}
+
+
+jsunity.run(kShortestPathsSyntaxTestSuite);
 jsunity.run(kConstantWeightShortestPathTestSuite);
 jsunity.run(kAttributeWeightShortestPathTestSuite);
 


### PR DESCRIPTION
  * catch if the user gives more than one variable in grammar.y
  * also give a correct error message
