### PR TITLE
Handle extra args to db._query when using aql templates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* db._query now handles additional arguments correctly when passing an AQL
+  query object instead of a query string and separate bindVars
+
 * added req.auth property to Foxx
 
 * added collection.documentId method to derive document id from key

--- a/js/client/modules/@arangodb/arango-database.js
+++ b/js/client/modules/@arangodb/arango-database.js
@@ -933,7 +933,7 @@ ArangoDatabase.prototype._query = function (query, bindVars, cursorOptions, opti
     bindVars: bindVars || undefined
   };
 
-  if (query && typeof query === 'object') {
+  if (query && typeof query === 'object' && typeof query.toAQL !== 'function') {
     payload = query;
     options = cursorOptions;
     cursorOptions = bindVars;

--- a/js/client/modules/@arangodb/arango-database.js
+++ b/js/client/modules/@arangodb/arango-database.js
@@ -928,23 +928,30 @@ ArangoDatabase.prototype._createStatement = function (data) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._query = function (query, bindVars, cursorOptions, options) {
-  if (typeof query === 'object' && query !== null && arguments.length === 1) {
-    return new ArangoStatement(this, query).execute();
+  var payload = {
+    query,
+    bindVars: bindVars || undefined
+  };
+
+  if (query && typeof query === 'object') {
+    payload = query;
+    options = cursorOptions;
+    cursorOptions = bindVars;
   }
   if (options === undefined && cursorOptions !== undefined) {
     options = cursorOptions;
   }
 
-  var data = {
-    query: query,
-    bindVars: bindVars || undefined,
-    count: (cursorOptions && cursorOptions.count) || false,
-    batchSize: (cursorOptions && cursorOptions.batchSize) || undefined,
-    options: options || undefined,
-    cache: (options && options.cache) || undefined
-  };
+  if (options) {
+    payload.options = options || undefined;
+    payload.cache = (options && options.cache) || undefined;
+  }
+  if (cursorOptions) {
+    payload.count = (cursorOptions && cursorOptions.count) || false;
+    payload.batchSize = (cursorOptions && cursorOptions.batchSize) || undefined;
+  }
 
-  return new ArangoStatement(this, data).execute();
+  return new ArangoStatement(this, payload).execute();
 };
 
 // //////////////////////////////////////////////////////////////////////////////

--- a/js/server/modules/@arangodb/arango-database.js
+++ b/js/server/modules/@arangodb/arango-database.js
@@ -81,7 +81,7 @@ ArangoDatabase.prototype._query = function (query, bindVars, cursorOptions, opti
     bindVars: bindVars || undefined
   };
 
-  if (query && typeof query === 'object') {
+  if (query && typeof query === 'object' && typeof query.toAQL !== 'function') {
     payload = query;
     options = cursorOptions;
     cursorOptions = bindVars;

--- a/js/server/modules/@arangodb/arango-database.js
+++ b/js/server/modules/@arangodb/arango-database.js
@@ -76,21 +76,29 @@ ArangoDatabase.prototype._createStatement = function (data) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._query = function (query, bindVars, cursorOptions, options) {
-  if (typeof query === 'object' && query !== null && arguments.length === 1) {
-    return new ArangoStatement(this, query).execute();
+  var payload = {
+    query,
+    bindVars: bindVars || undefined
+  };
+
+  if (query && typeof query === 'object') {
+    payload = query;
+    options = cursorOptions;
+    cursorOptions = bindVars;
   }
   if (options === undefined && cursorOptions !== undefined) {
     options = cursorOptions;
   }
 
-  var payload = {
-    query: query,
-    bindVars: bindVars || undefined,
-    count: (cursorOptions && cursorOptions.count) || false,
-    batchSize: (cursorOptions && cursorOptions.batchSize) || undefined,
-    options: options || undefined,
-    cache: (options && options.cache) || undefined
-  };
+  if (options) {
+    payload.options = options || undefined;
+    payload.cache = (options && options.cache) || undefined;
+  }
+  if (cursorOptions) {
+    payload.count = (cursorOptions && cursorOptions.count) || false;
+    payload.batchSize = (cursorOptions && cursorOptions.batchSize) || undefined;
+  }
+
   return new ArangoStatement(this, payload).execute();
 };
 

--- a/tests/js/common/shell/shell-database.js
+++ b/tests/js/common/shell/shell-database.js
@@ -165,6 +165,20 @@ function DatabaseSuite () {
     },
 
 ////////////////////////////////////////////////////////////////////////////////
+/// @brief test AQL literal and options
+////////////////////////////////////////////////////////////////////////////////
+
+    testAQLWithLiteralAndOptions : function () {
+      var aql = require("@arangodb").aql;
+      var result = internal.db._query(
+        aql`${aql.literal('RETURN 1')}`,
+        {fullCount: true}
+      );
+      assertEqual([ 1 ], result.toArray());
+      assertEqual(1, result.getExtra().stats.fullCount);
+    },
+
+////////////////////////////////////////////////////////////////////////////////
 /// @brief test _executeTransaction
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -698,4 +712,3 @@ function DatabaseSuite () {
 jsunity.run(DatabaseSuite);
 
 return jsunity.done();
-


### PR DESCRIPTION
This corrects the behavior of `db._query` when using `aql` template strings so additional arguments no longer result in an error. An object as initial argument is now always assumed to contain at least the query and bindVars.