### PR TITLE
Doc - Arangosh: server.endpoint must start with http+ssl:// if server uses SSL

### DIFF
--- a/Documentation/Books/Manual/Programs/Arangod/Server.md
+++ b/Documentation/Books/Manual/Programs/Arangod/Server.md
@@ -5,7 +5,7 @@
 The ArangoDB server can listen for incoming requests on multiple *endpoints*.
 
 The endpoints are normally specified either in ArangoDB's configuration file or
-on the command-line, using the `--server.endpoint`.  ArangoDB supports different
+on the command-line like `--server.endpoint`. ArangoDB supports different
 types of endpoints:
 
 - tcp://ipv4-address:port - TCP/IP endpoint, using IPv4
@@ -15,7 +15,7 @@ types of endpoints:
 - unix:///path/to/socket - Unix domain socket endpoint
 
 If a TCP/IP endpoint is specified without a port number, then the default port
-(8529) will be used.  If multiple endpoints need to be used, the option can be
+(8529) will be used. If multiple endpoints need to be used, the option can be
 repeated multiple times.
 
 The default endpoint for ArangoDB is *tcp://127.0.0.1:8529* or
@@ -27,11 +27,15 @@ The default endpoint for ArangoDB is *tcp://127.0.0.1:8529* or
 unix> ./arangod --server.endpoint tcp://127.0.0.1:8529
                 --server.endpoint ssl://127.0.0.1:8530
                 --ssl.keyfile server.pem /tmp/vocbase
-2012-07-26T07:07:47Z [8161] INFO using SSL protocol version 'TLSv1'
-2012-07-26T07:07:48Z [8161] INFO using endpoint 'ssl://127.0.0.1:8530' for http ssl requests
-2012-07-26T07:07:48Z [8161] INFO using endpoint 'tcp://127.0.0.1:8529' for http tcp requests
-2012-07-26T07:07:49Z [8161] INFO ArangoDB (version 1.1.alpha) is ready for business
-2012-07-26T07:07:49Z [8161] INFO Have Fun!
+2019-05-06T07:30:42Z [9228] INFO ArangoDB 3.4.5 [linux] 64bit, using jemalloc, build tags/v3.4.5-0-g648fbb8191, VPack 0.1.33, RocksDB 5.16.0, ICU 58.1, V8 5.7.492.77, OpenSSL 1.1.0j  20 Nov 2018
+2019-05-06T07:30:43Z [9228] INFO {authentication} Jwt secret not specified, generating...
+2019-05-06T07:30:43Z [9228] INFO using storage engine rocksdb
+2019-05-06T07:30:43Z [9228] INFO {cluster} Starting up with role SINGLE
+2019-05-06T07:50:53Z [9228] INFO {syscall} file-descriptors (nofiles) hard limit is 1048576, soft limit is 1048576
+2019-05-06T07:50:53Z [9228] INFO {authentication} Authentication is turned on (system only), authentication for unix sockets is turned on
+2019-05-06T07:30:43Z [9228] INFO using endpoint 'http+tcp://127.0.0.1:8529' for non-encrypted requests
+2019-05-06T07:30:43Z [9228] INFO using endpoint 'http+ssl://127.0.0.1:8530' for ssl-encrypted requests
+2019-05-06T07:30:44Z [9228] INFO ArangoDB (version 3.4.5 [linux]) is ready for business. Have fun!
 ```
 
 Given a hostname:

--- a/Documentation/Books/Manual/Programs/Arangosh/Examples.md
+++ b/Documentation/Books/Manual/Programs/Arangosh/Examples.md
@@ -1,17 +1,20 @@
 Arangosh Examples
 =================
 
+Connecting to a server
+----------------------
+
 By default _arangosh_ will try to connect to an ArangoDB server running on
 server *localhost* on port *8529*. It will use the username *root* and an
 empty password by default. Additionally it will connect to the default database
 (*_system*). All these defaults can be changed using the following 
 command-line options:
 
-- *--server.database <string>*: name of the database to connect to
-- *--server.endpoint <string>*: endpoint to connect to
-- *--server.username <string>*: database username
-- *--server.password <string>*: password to use when connecting 
-- *--server.authentication <bool>*: whether or not to use authentication
+- `--server.database <string>`: name of the database to connect to
+- `--server.endpoint <string>`: endpoint to connect to
+- `--server.username <string>`: database username
+- `--server.password <string>`: password to use when connecting 
+- `--server.authentication <bool>`: whether or not to use authentication
 
 For example, to connect to an ArangoDB server on IP *192.168.173.13* on port
 8530 with the user *foo* and using the database *test*, use:
@@ -23,6 +26,28 @@ server after the password was entered.
 
 The shell will print its own version number and if successfully connected
 to a server the version number of the ArangoDB server.
+
+{% hint 'tip' %}
+If the server endpoint is configured for SSL then clients such as _arangosh_
+need to connect to it using an SSL socket as well. For example, use `http+ssl://`
+as schema in `--server.endpoint` for an SSL-secured HTTP connection.
+{% endhint %}
+
+The schema of an endpoint is comprised of a protocol and a socket in the format
+`protocol+socket://`. There are alternatives and shorthands for some combinations,
+`ssl://` is equivalent to `http+ssl://` and `https://` for instance:
+
+Protocol     | Socket           | Schema
+-------------|------------------|-----------
+HTTP         | TCP              | `http+tcp`, `http+srv`, `http`, `tcp`
+HTTP         | TCP with SSL/TLS | `http+ssl`, `https`, `ssl`
+HTTP         | Unix             | `http+unix`, `unix`
+VelocyStream | TCP              | `vst+tcp`, `vst+srv`, `vst`
+VelocyStream | TCP with SSL/TLS | `vst+ssl`, `vsts`
+VelocyStream | Unix             | `vst+unix`
+
+Using Arangosh
+--------------
 
 To change the current database after the connection has been made, you
 can use the `db._useDatabase()` command in Arangosh:

--- a/Documentation/Examples/arangosh.json
+++ b/Documentation/Examples/arangosh.json
@@ -825,7 +825,7 @@
     "category" : "option",
     "default" : "http+tcp://127.0.0.1:8529",
     "deprecatedIn" : null,
-    "description" : "endpoint to connect to, use 'none' to start without a server",
+    "description" : "endpoint to connect to, use 'none' to start without a server. Use http+ssl:// or vst+ssl:// as schema to connect to an SSL-secured server endpoint, otherwise http+tcp://, vst+tcp:// or unix://",
     "dynamic" : false,
     "enterpriseOnly" : false,
     "hidden" : false,

--- a/arangosh/Shell/ClientFeature.cpp
+++ b/arangosh/Shell/ClientFeature.cpp
@@ -84,7 +84,9 @@ void ClientFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
 
   options->addOption(
       "--server.endpoint",
-      "endpoint to connect to, use 'none' to start without a server",
+      "endpoint to connect to. Use 'none' to start without a server. "
+      "Use http+ssl:// or vst+ssl:// as schema to connect to an SSL-secured "
+      "server endpoint, otherwise http+tcp://, vst+tcp:// or unix://",
       new StringParameter(&_endpoint));
 
   options->addOption("--server.password",


### PR DESCRIPTION
Backport of https://github.com/arangodb/arangodb/pull/7329