### PR TITLE
honor index hints in optimizer rule

### DIFF
--- a/tests/js/server/aql/aql-optimizer-rule-reduce-extraction-to-projection-rocksdb.js
+++ b/tests/js/server/aql/aql-optimizer-rule-reduce-extraction-to-projection-rocksdb.js
@@ -89,14 +89,14 @@ function optimizerRuleTestSuite () {
       // these queries may actually use projections, but they must not use the primary
       // index for scanning
       var queries = [
-        "FOR doc IN @@cn OPTIONS { indexHint: 'aha' } RETURN 1",
-        "FOR doc IN @@cn OPTIONS { indexHint: 'aha' } RETURN doc",
+        "FOR doc IN @@cn OPTIONS { indexHint: 'aha', forceIndexHint: true } RETURN 1",
+        "FOR doc IN @@cn OPTIONS { indexHint: 'aha', forceIndexHint: true } RETURN doc",
+        "FOR doc IN @@cn OPTIONS { indexHint: 'aha', forceIndexHint: true } RETURN doc.value1",
+        "FOR doc IN @@cn OPTIONS { indexHint: 'aha', forceIndexHint: true } RETURN doc.value2",
+        "FOR doc IN @@cn OPTIONS { indexHint: 'aha', forceIndexHint: true } RETURN doc._key",
         "FOR doc IN @@cn OPTIONS { indexHint: 'primary' } RETURN doc",
-        "FOR doc IN @@cn OPTIONS { indexHint: 'aha' } RETURN doc.value1",
         "FOR doc IN @@cn OPTIONS { indexHint: 'primary' } RETURN doc.value1",
-        "FOR doc IN @@cn OPTIONS { indexHint: 'aha' } RETURN doc.value2",
         "FOR doc IN @@cn OPTIONS { indexHint: 'primary' } RETURN doc.value2",
-        "FOR doc IN @@cn OPTIONS { indexHint: 'aha' } RETURN doc._key",
       ];
 
       queries.forEach(function(query) {


### PR DESCRIPTION
The optimizer rule "reduce-extraction-to-projection" may choose to turn a full scan into an index scan.
Make it honor any index hints given in the query.