### PR TITLE
Make ExecutionEngine respect the batch size.

### DIFF
--- a/arangod/Aql/ExecutionEngine.cpp
+++ b/arangod/Aql/ExecutionEngine.cpp
@@ -469,7 +469,7 @@ std::pair<ExecutionState, SharedAqlItemBlockPtr> ExecutionEngine::getSome(size_t
       return {res.first, nullptr};
     }
   }
-  return _root->getSome(atMost);
+  return _root->getSome((std::min)(atMost, ExecutionBlock::DefaultBatchSize()));
 }
 
 std::pair<ExecutionState, size_t> ExecutionEngine::skipSome(size_t atMost) {


### PR DESCRIPTION
Fixes a test failure in api-export-spec-timecritical-noncluster.rb
