### PR TITLE
fix async request handling when server queue is full

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,11 @@
 v3.3.24 (XXXX-XX-XX)
 --------------------
 
+* fixed a crash when posting an async request to the server using the "x-arango-async"
+  request header and the server's request queue was full
+
 * upgraded arangodb starter version to 0.14.3
+
 
 v3.3.23 (2019-04-14)
 --------------------

--- a/arangod/GeneralServer/GeneralCommTask.cpp
+++ b/arangod/GeneralServer/GeneralCommTask.cpp
@@ -226,7 +226,7 @@ void GeneralCommTask::executeRequest(std::unique_ptr<GeneralRequest>&& request,
         << "could not find corresponding request/response";
   }
 
-  rest::ContentType respType = request->contentTypeResponse();
+  rest::ContentType const respType = request->contentTypeResponse();
   // create a handler, this takes ownership of request and response
   std::shared_ptr<RestHandler> handler(
       GeneralServerFeature::HANDLER_FACTORY->createHandler(std::move(request),
@@ -264,6 +264,11 @@ void GeneralCommTask::executeRequest(std::unique_ptr<GeneralRequest>&& request,
       ok = handleRequestAsync(std::move(handler));
     }
 
+    TRI_IF_FAILURE("queueFull") {
+      ok = false;
+      jobId = 0;
+    }
+
     if (ok) {
       std::unique_ptr<GeneralResponse> response =
           createResponse(rest::ResponseCode::ACCEPTED, messageId);
@@ -276,7 +281,7 @@ void GeneralCommTask::executeRequest(std::unique_ptr<GeneralRequest>&& request,
       addResponse(*response, nullptr);
     } else {
       addErrorResponse(rest::ResponseCode::SERVICE_UNAVAILABLE,
-                       request->contentTypeResponse(), messageId, TRI_ERROR_QUEUE_FULL,
+                       respType, messageId, TRI_ERROR_QUEUE_FULL,
                        TRI_errno_string(TRI_ERROR_QUEUE_FULL));
     }
   } else {

--- a/js/client/tests/shell/shell-async-request.js
+++ b/js/client/tests/shell/shell-async-request.js
@@ -1,0 +1,83 @@
+/*jshint globalstrict:false, strict:false */
+/*global arango, assertTrue, assertFalse, assertEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test async requests
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2015 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2015, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+let jsunity = require('jsunity');
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test suite
+////////////////////////////////////////////////////////////////////////////////
+
+function AsyncRequestSuite () {
+  'use strict';
+  return {
+    testAsyncRequest() {
+      let res = arango.GET_RAW("/_api/version", { "x-arango-async" : "true" });
+      assertEqual(202, res.code);
+      assertFalse(res.headers.hasOwnProperty("x-arango-async-id"));
+    },
+    
+    testAsyncRequestStore() {
+      let res = arango.GET_RAW("/_api/version", { "x-arango-async" : "store" });
+      assertEqual(202, res.code);
+      assertTrue(res.headers.hasOwnProperty("x-arango-async-id"));
+      const id = res.headers["x-arango-async-id"];
+     
+      let tries = 0;
+      while (++tries < 30) {
+        res = arango.PUT_RAW("/_api/job/" + id, "");
+        if (res.code === 200) {
+          break;
+        }
+        require("internal").sleep(0.5);
+      }
+
+      assertEqual(200, res.code);
+    },
+
+    testAsyncRequestQueueFull() {
+      let res = arango.PUT_RAW("/_admin/debug/failat/queueFull", "");
+      if (res.code !== 200) {
+        // abort test - failure mode is not activated on server
+        return;
+      }
+      try {
+        res = arango.GET_RAW("/_api/version", { "x-arango-async" : "true" });
+        assertEqual(503, res.code);
+      } finally {
+        arango.DELETE("/_admin/debug/failat/queueFull");
+      }
+    },
+  };
+}
+
+
+jsunity.run(AsyncRequestSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

* Fix a crash when using the "x-arango-async" header for sending an async request and the server's request queue was full.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added **Regression Tests** (Only for bug-fixes) 
- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/4520/

- [x] Added a *Changelog Entry* 