### PR TITLE
only offer indexes of type "persistent" in the web UI for the RocksDB engine

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 devel
 -----
 
+* disable selection of index types "hash" and "skiplist" in the web interface when 
+  using the RocksDB engine. The index types "hash", "skiplist" and "persistent" are 
+  just aliases of each other with the RocksDB engine, so there is no need to offer all 
+  of them. After initially only offering "hash" indexes, we decided to only offer
+  indexes of type "persistent", as it is technically the most appropriate description.
+
 * removed bug during start up with a single agent, that leads to dbserver crash.
 
 * fixed issue #7011: description when replacing a foxx application was misleading

--- a/arangod/RocksDBEngine/RocksDBIndexFactory.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndexFactory.cpp
@@ -377,8 +377,8 @@ RocksDBIndexFactory::RocksDBIndexFactory() {
 /// "hash") used to display storage engine capabilities
 std::unordered_map<std::string, std::string> RocksDBIndexFactory::indexAliases() const {
   return std::unordered_map<std::string, std::string>{
-      {"skiplist", "hash"},
-      {"persistent", "hash"},
+      {"hash", "persistent"},
+      {"skiplist", "persistent"},
   };
 }
 

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/templates/indicesView.ejs
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/templates/indicesView.ejs
@@ -62,7 +62,7 @@
                 </th>
                 <th class="tooltipInfoTh">
                   <div class="tooltipDiv">
-                    <a class="index-tooltip" data-toggle="tooltip" data-placement="left" title="Type of index to create. <% if (supported.indexOf('persistent') <= -1) { %>Please note that for the RocksDB engine the index types hash, skiplist and persistent are identical, so that they are not offered seperately here.<% } %>">
+                    <a class="index-tooltip" data-toggle="tooltip" data-placement="left" title="Type of index to create. <% if (supported.indexOf('hash') <= -1) { %>Please note that for the RocksDB engine the index types hash, skiplist and persistent are identical, so that they are not offered seperately here.<% } %>">
                       <span rel="tooltip" class="arangoicon icon_arangodb_info"></span>
                     </a>
                   </div>


### PR DESCRIPTION
### Scope & Purpose

Only offer indexes of type "persistent" in the web UI when creating a new index with the RocksDB storage engine, and hide the previously shown index types "hash" and "skiplist".
This is because the implementation of the 3 index types is absolutely identical for the RocksDB engine, and offering 3 types with different names but identical implementation confuses end users.
In a previous iteration we only offered the "hash" index type in the web UI for RocksDB, but it turns out that this description wasn't a good choice, because the index is actually no hash index. "skiplist" doesn't match either, only "persistent" somehow adequately describes the index.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behaviour change can only be verified via automatic tests

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

*(Include link to Jenkins run etc)*

### Documentation

- [x] Added a *Changelog Entry* 
- [x] Added entry to *Release Notes* (upgrading-changes35)

Additional documentation PR: https://github.com/arangodb/docs/pull/35