### PR TITLE
fix handling of initial `null` values in AQL function `MIN`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.4.6 (XXXX-XX-XX)
 -------------------
 
+* fixed an edge case of handling `null` values in the AQL function `MIN` for input
+  sequences that started with a `null` value. In this case, `null` was always returned as the
+  minimum value even though other non-null values may have followed, and `MIN` was supposed
+  to return `null` only if there are no input values or all input values are `null`.
+
 * fixed a crash when posting an async request to the server using the "x-arango-async"
   request header and the server's request queue was full
 

--- a/arangod/Aql/Aggregator.cpp
+++ b/arangod/Aql/Aggregator.cpp
@@ -172,8 +172,8 @@ struct AggregatorMin final : public Aggregator {
   void reset() override { value.erase(); }
 
   void reduce(AqlValue const& cmpValue) override {
-    if (value.isEmpty() || (!cmpValue.isNull(true) &&
-                            AqlValue::Compare(trx, value, cmpValue, true) > 0)) {
+    if (!cmpValue.isNull(true) && (value.isEmpty() || 
+                                   AqlValue::Compare(trx, value, cmpValue, true) > 0)) {
       // the value `null` itself will not be used in MIN() to compare lower than
       // e.g. value `false`
       value.destroy();

--- a/tests/js/server/aql/aql-optimizer-collect-aggregate.js
+++ b/tests/js/server/aql/aql-optimizer-collect-aggregate.js
@@ -907,6 +907,19 @@ function optimizerAggregateTestSuite () {
 /// @brief test min
 ////////////////////////////////////////////////////////////////////////////////
 
+    testMinNotOnlyNullButStartsWithNull : function () {
+      var query = "FOR i IN [ null, null, null, null, 35 ] COLLECT AGGREGATE m = MIN(i) RETURN m";
+
+      var results = AQL_EXECUTE(query);
+      assertEqual(1, results.json.length);
+      assertEqual(35, results.json[0]);
+      assertEqual(results.json[0], AQL_EXECUTE("RETURN MIN([ null, null, null, null, 35 ])").json[0]);
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test min
+////////////////////////////////////////////////////////////////////////////////
+
     testMinMixed : function () {
       var query = "FOR i IN [ 'foo', 'bar', 'baz', true, 'bachelor', null, [ ], false, { }, { zzz: 15 }, { zzz: 2 }, 9999, -9999 ] COLLECT AGGREGATE m = MIN(i) RETURN m";
 


### PR DESCRIPTION
### Scope & Purpose

Fixed an edge case of handling `null` values in the AQL function `MIN` for input sequences that started with a `null` value. 
In this case, `null` was always returned as the minimum value even though other non-null values may have followed, and `MIN`  was supposed to return `null` only if there are no input values or all input values are `null`.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behaviour change can only be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/4552/

### Documentation

- [x] Added a *Changelog Entry* 
