### PR TITLE
fix crash

### DIFF
--- a/arangod/Aql/OptimizerRulesCluster.cpp
+++ b/arangod/Aql/OptimizerRulesCluster.cpp
@@ -223,12 +223,12 @@ bool substituteClusterSingleDocumentOperationsIndex(Optimizer* opt, ExecutionPla
         Variable const* update = nullptr;
         Variable const* keyVar = nullptr;
 
-        if (parentType == EN::REMOVE) {
-          keyVar = ExecutionNode::castTo<RemoveNode const*>(mod)->inVariable();
-        } else if (parentType == EN::INSERT) {
-          keyVar = ExecutionNode::castTo<InsertNode const*>(mod)->inVariable();
+        if (parentType == EN::INSERT) {
           continue;
+        } else if (parentType == EN::REMOVE) {
+          keyVar = ExecutionNode::castTo<RemoveNode const*>(mod)->inVariable();
         } else {
+          // update / replace
           auto updateReplaceNode = ExecutionNode::castTo<UpdateReplaceNode const*>(mod);
           update = updateReplaceNode->inDocVariable();
           if (updateReplaceNode->inKeyVariable() != nullptr) {

--- a/tests/js/server/aql/aql-optimizer-optimize-cluster-single-document-operations.js
+++ b/tests/js/server/aql/aql-optimizer-optimize-cluster-single-document-operations.js
@@ -431,6 +431,13 @@ function optimizerClusterSingleDocumentTestSuite () {
         "FOR one IN @@cn1 FILTER one._key == 'a' UPDATE one WITH { two: 1 } IN @@cn1",
         "FOR one IN @@cn1 FILTER one._key == 'a' REPLACE one WITH { two: 1 } IN @@cn1",
         "FOR one IN @@cn1 FILTER one._key == 'a' REMOVE one IN @@cn1",
+        "INSERT {} INTO @@cn1",
+        "INSERT { _key: 'abc' } INTO @@cn1",
+        "INSERT { two: 1 } INTO @@cn1",
+        "UPDATE 'foo' WITH { two: 1 } INTO @@cn1",
+        "UPDATE { _key: 'abc' } WITH { two: 1 } INTO @@cn1",
+        "REMOVE 'abc' INTO @@cn1",
+        "REMOVE { _key: 'abc' } INTO @@cn1",
       ];
 
       queries.forEach(function(query) {


### PR DESCRIPTION
### Scope & Purpose

Prevent an invalid optimization from happening in the "cluster-single-document-operation" optimizer rule.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

- [x] There is an internal planning ticket: https://github.com/arangodb/team-orco-planning/issues/129

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/4561/