### PR TITLE
Switch to std::shared_ptr<TRI_vocbase_t> then remove DataProtector from DatabaseFeature

### DIFF
--- a/arangod/RestServer/DatabaseFeature.h
+++ b/arangod/RestServer/DatabaseFeature.h
@@ -24,7 +24,6 @@
 #define APPLICATION_FEATURES_DATABASE_FEATURE_H 1
 
 #include "ApplicationFeatures/ApplicationFeature.h"
-#include "Basics/DataProtector.h"
 #include "Basics/Mutex.h"
 #include "Basics/Thread.h"
 #include "Utils/VersionTracker.h"
@@ -176,10 +175,8 @@ class DatabaseFeature : public application_features::ApplicationFeature {
 
   std::unique_ptr<DatabaseManagerThread> _databaseManager;
 
-  std::atomic<DatabasesLists*> _databasesLists;
-  // TODO: Make this again a template once everybody has gcc >= 4.9.2
-  // arangodb::basics::DataProtector<64>
-  arangodb::basics::DataProtector _databasesProtector;
+  // c++20 // std::atomic<std::shared_ptr<DatabasesLists>> _databasesLists;
+  std::shared_ptr<DatabasesLists> _databasesLists;
   arangodb::Mutex _databasesMutex;
 
   bool _isInitiallyEmpty;


### PR DESCRIPTION
I think it is not as easy as thought. I guess this is not 100% correct at the moment.

Update:
We need to change the internal vocbase pointers to be shared pointers as well, this would take too long and maybe cause deadlocks on devel, if we do not carefully use a combination of shared and weak pointers.
