### PR TITLE
fix VERSION files on upgrade and database creation in cluster

### DIFF
--- a/arangod/RestServer/CheckVersionFeature.cpp
+++ b/arangod/RestServer/CheckVersionFeature.cpp
@@ -24,6 +24,7 @@
 
 #include "Basics/FileUtils.h"
 #include "Basics/exitcodes.h"
+#include "Cluster/ServerState.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerFeature.h"
 #include "ProgramOptions/ProgramOptions.h"
@@ -167,6 +168,12 @@ void CheckVersionFeature::checkVersion() {
             << "in order to automatically fix the VERSION file on startup, "
             << "please start the server with option "
                "`--database.ignore-datafile-errors true`";
+      }
+    } else if (res.status == methods::VersionResult::NO_VERSION_FILE) {
+      // try to install a fresh new, empty VERSION file instead
+      if (methods::Version::write(vocbase, std::map<std::string, bool>(), true).ok()) {
+        // give it another try
+        res = methods::Version::check(vocbase);
       }
     }
 

--- a/arangod/VocBase/Methods/Upgrade.cpp
+++ b/arangod/VocBase/Methods/Upgrade.cpp
@@ -298,7 +298,7 @@ UpgradeResult methods::Upgrade::runTasks(TRI_vocbase_t& vocbase, VersionResult& 
   // needs to run in superuser scope, otherwise we get errors
   ExecContextScope scope(ExecContext::superuser());
   // only local should actually write a VERSION file
-  bool isLocal = clusterFlag == CLUSTER_NONE || clusterFlag == CLUSTER_LOCAL;
+  bool isLocal = clusterFlag == CLUSTER_NONE || clusterFlag == CLUSTER_LOCAL || clusterFlag == CLUSTER_DB_SERVER_LOCAL;
 
   bool ranOnce = false;
   // execute all tasks


### PR DESCRIPTION
### Scope & Purpose

Fix creation of VERSION files for new databases in the cluster, and make sure that `--database.check-version` does not choke on existing databases with a VERSION file.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This needs a manual test!

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/4581/