### PR TITLE
remove define that slows down Windows debug builds

### DIFF
--- a/lib/Basics/Common.h
+++ b/lib/Basics/Common.h
@@ -30,9 +30,6 @@
 #define WIN32_LEAN_AND_MEAN 1
 #endif
 
-// debug malloc for Windows (only used when DEBUG is set)
-#define _CRTDBG_MAP_ALLOC
-
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif


### PR DESCRIPTION
### Scope & Purpose

Remove a define that slows down Windows debug builds considerably.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behaviour change can only be verified via automatic tests

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/4598/