### PR TITLE
only execute requests directly if there is one client on the IoContext

### DIFF
--- a/arangod/GeneralServer/GeneralCommTask.cpp
+++ b/arangod/GeneralServer/GeneralCommTask.cpp
@@ -456,10 +456,13 @@ bool GeneralCommTask::handleRequestSync(std::shared_ptr<RestHandler> handler) {
     return false;
   }
 
+  // queue the operation in the scheduler, and make it eligible for direct execution
+  // only if the current CommTask type allows it (HttpCommTask: yes, VstCommTask: no)
+  // and there is currently only a single client handled by the IoContext
   bool ok = SchedulerFeature::SCHEDULER->queue(handler->getRequestLane(), [self = shared_from_this(), handler]() {
     auto thisPtr = static_cast<GeneralCommTask*>(self.get());
     thisPtr->handleRequestDirectly(basics::ConditionalLocking::DoLock, handler);
-  }, allowDirectHandling());
+  }, allowDirectHandling() && _context._clients == 1);
 
   if (!ok) {
     addErrorResponse(rest::ResponseCode::SERVICE_UNAVAILABLE,


### PR DESCRIPTION
### Scope & Purpose

Only execute requests directly in the scheduler if there is a single client for an IoContext.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/4602/