### PR TITLE
Fix white swagger code

### DIFF
--- a/js/server/assets/swagger/index.html
+++ b/js/server/assets/swagger/index.html
@@ -44,6 +44,13 @@
         font-weight: 100 !important;
       }
 
+      /* This fixes what seems to be a bug in the swagger-ui stylesheet
+       * causing syntax-highlighted code to have random white-on-gray text.
+       */
+      .swagger-ui .opblock-body pre span{
+        color: #000 !important;
+      }
+
       /* The topbar lets the user pick arbitrary URLs.
        * We don't need this feature in ArangoDB.
        */


### PR DESCRIPTION
For some reason swagger-ui renders some text in code blocks in white on light background. This changes that text to be rendered in black instead.