### PR TITLE
fix processing of AQL index hints when upgrading

### DIFF
--- a/arangod/Aql/IndexHint.h
+++ b/arangod/Aql/IndexHint.h
@@ -26,13 +26,14 @@
 
 #include <iosfwd>
 
-#include <velocypack/Builder.h>
-#include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
-
 #include "Aql/AstNode.h"
 
 namespace arangodb {
+namespace velocypack {
+class Builder;
+class Slice;
+}
+
 namespace aql {
 
 /// @brief container for index hint information
@@ -43,20 +44,20 @@ class IndexHint {
  public:
   explicit IndexHint();
   explicit IndexHint(AstNode const* node);
-  explicit IndexHint(VPackSlice const& slice);
+  explicit IndexHint(arangodb::velocypack::Slice const& slice);
 
  public:
   HintType type() const;
   bool isForced() const;
   std::vector<std::string> const& hint() const;
 
-  void toVelocyPack(VPackBuilder& builder) const;
+  void toVelocyPack(arangodb::velocypack::Builder& builder) const;
   std::string typeName() const;
   std::string toString() const;
 
  private:
   HintType _type;
-  bool const _forced;
+  bool _forced;
 
   // actual hint is a recursive structure, with the data type determined by the
   // _type above; in the case of a nested IndexHint, the value of isForced() is


### PR DESCRIPTION
### Scope & Purpose

Fix handling of AQL index hints on upgrading.
When upgrading a cluster from 3.4 to 3.5, the 3.5 DB server nodes will try to read index hint data from the AQL query plan snippets. They assume that the "hint" part of the snippet is an object, which is only guaranteed if the plan was generated by a 3.5 coordinator. 3.4 coordinators however don't populate the "hint" attribute in the plan at all, so it will not be an object here.
3.5 DB servers then can't find the attribute and crash with an assertion failure.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.