### PR TITLE
Fix some uses of atomics

### DIFF
--- a/arangod/ClusterEngine/ClusterSelectivityEstimates.cpp
+++ b/arangod/ClusterEngine/ClusterSelectivityEstimates.cpp
@@ -43,7 +43,7 @@ void ClusterSelectivityEstimates::flush() {
     _updating.store(false, std::memory_order_release);
   });
   
-  std::atomic_store<InternalData>(&_data, std::shared_ptr<InternalData>());
+  std::atomic_store(&_data, std::shared_ptr<InternalData>());
 }
 
 IndexEstMap ClusterSelectivityEstimates::get(bool allowUpdating, TRI_voc_tid_t tid) {
@@ -116,5 +116,5 @@ void ClusterSelectivityEstimates::set(IndexEstMap const& estimates) {
   }
 
   // finally update the cache
-  std::atomic_store<ClusterSelectivityEstimates::InternalData>(&_data, std::make_shared<ClusterSelectivityEstimates::InternalData>(estimates, ttl));
+  std::atomic_store(&_data, std::make_shared<ClusterSelectivityEstimates::InternalData>(estimates, ttl));
 }

--- a/arangosh/Shell/V8ClientConnection.cpp
+++ b/arangosh/Shell/V8ClientConnection.cpp
@@ -98,7 +98,7 @@ void V8ClientConnection::createConnection() {
     }
 
     if (_lastHttpReturnCode == 200) {
-      std::atomic_store<fuerte::Connection>(&_connection, newConnection);
+      std::atomic_store(&_connection, newConnection);
 
       std::shared_ptr<VPackBuilder> parsedBody;
       VPackSlice body;
@@ -158,7 +158,7 @@ void V8ClientConnection::createConnection() {
 }
 
 void V8ClientConnection::setInterrupted(bool interrupted) {
-  auto connection = std::atomic_load<fuerte::Connection>(&_connection);
+  auto connection = std::atomic_load(&_connection);
   if (interrupted && connection != nullptr) {
     shutdownConnection();
   } else if (!interrupted && connection == nullptr) {
@@ -167,7 +167,7 @@ void V8ClientConnection::setInterrupted(bool interrupted) {
 }
 
 bool V8ClientConnection::isConnected() const {
-  auto connection = std::atomic_load<fuerte::Connection>(&_connection);
+  auto connection = std::atomic_load(&_connection);
   if (connection) {
     return connection->state() == fuerte::Connection::State::Connected;
   }
@@ -175,7 +175,7 @@ bool V8ClientConnection::isConnected() const {
 }
 
 std::string V8ClientConnection::endpointSpecification() const {
-  auto connection = std::atomic_load<fuerte::Connection>(&_connection);
+  auto connection = std::atomic_load(&_connection);
   if (connection) {
     return connection->endpoint();
   }
@@ -225,7 +225,7 @@ void V8ClientConnection::reconnect(ClientFeature* client) {
     _builder.authenticationType(fuerte::AuthenticationType::Basic);
   }
 
-  auto oldConnection = std::atomic_exchange<fuerte::Connection>(&_connection, std::shared_ptr<fuerte::Connection>());
+  auto oldConnection = std::atomic_exchange(&_connection, std::shared_ptr<fuerte::Connection>());
   if (oldConnection) {
     oldConnection->cancel();
   }
@@ -1481,7 +1481,7 @@ v8::Local<v8::Value> V8ClientConnection::requestData(
   }
   req->timeout(std::chrono::duration_cast<std::chrono::milliseconds>(_requestTimeout));
   
-  auto connection = std::atomic_load<fuerte::Connection>(&_connection);
+  auto connection = std::atomic_load(&_connection);
   if (!connection) {
     TRI_V8_SET_EXCEPTION_MESSAGE(TRI_SIMPLE_CLIENT_COULD_NOT_CONNECT,
                                  "not connected");
@@ -1540,7 +1540,7 @@ v8::Local<v8::Value> V8ClientConnection::requestDataRaw(
   }
   req->timeout(std::chrono::duration_cast<std::chrono::milliseconds>(_requestTimeout));
   
-  auto connection = std::atomic_load<fuerte::Connection>(&_connection);
+  auto connection = std::atomic_load(&_connection);
   if (!connection) {
     TRI_V8_SET_EXCEPTION_MESSAGE(TRI_SIMPLE_CLIENT_COULD_NOT_CONNECT,
                                  "not connected");
@@ -1823,9 +1823,9 @@ void V8ClientConnection::initServer(v8::Isolate* isolate, v8::Local<v8::Context>
 }
 
 void V8ClientConnection::shutdownConnection() {
-  auto connection = std::atomic_load<fuerte::Connection>(&_connection);
+  auto connection = std::atomic_load(&_connection);
   if (connection) {
     connection->cancel();
-    std::atomic_store<fuerte::Connection>(&_connection, std::shared_ptr<fuerte::Connection>());
+    std::atomic_store(&_connection, std::shared_ptr<fuerte::Connection>());
   }
 }


### PR DESCRIPTION
This is an attempt at fixing compilation errors when using `libstdc++` that comes with `gcc-9.1.0`; we just let GCC deduce the template parameter, which is a `std::shared_ptr` which is handled atomically (as opposed to the `fuerte::Connection` or `ClusterSelectivityEstimates::InternalData`).

If the intent is to handle the `Connection` or the `InternalData` atomically we need different changes, as the `atomic` operations require the type to be `TriviallyCopyable` which in particular means for it to not have any virtual members.

Disclaimer: I have no idea (tm) why this worked before (or, why it works now, if it did before).