### PR TITLE
Remove std::move as it prevents copy elision

### DIFF
--- a/lib/Futures/Future.h
+++ b/lib/Futures/Future.h
@@ -326,7 +326,7 @@ class Future {
             }));
           }
         });
-    return std::move(future);
+    return future;
   }
 
   /// Variant: callable accepts T&&, returns future
@@ -358,7 +358,7 @@ class Future {
         }
       }
     });
-    return std::move(future);
+    return future;
   }
 
   /// Variant: callable accepts Try<T&&>, returns value
@@ -380,7 +380,7 @@ class Future {
         return futures::invoke(std::forward<DF>(fn), std::move(t));
       }));
     });
-    return std::move(future);
+    return future;
   }
 
   /// Variant: callable accepts Try<T&&>, returns future
@@ -404,7 +404,7 @@ class Future {
         pr.setException(std::current_exception());
       }
     });
-    return std::move(future);
+    return future;
   }
 
   /// Variant: function returns void and accepts Try<T>&&
@@ -442,7 +442,7 @@ class Future {
         pr.setTry(std::move(t));
       }
     });
-    return std::move(future);
+    return future;
   }
 
   /// Set an error continuation for this Future where the continuation can
@@ -476,7 +476,7 @@ class Future {
             pr.setTry(std::move(t));
           }
         });
-    return std::move(future);
+    return future;
   }
 
  private:


### PR DESCRIPTION
Following a warning I noticed when compiling with `gcc-9.1.0`.