### PR TITLE
refactor index APIs

### DIFF
--- a/arangod/ClusterEngine/ClusterIndex.cpp
+++ b/arangod/ClusterEngine/ClusterIndex.cpp
@@ -219,10 +219,10 @@ bool ClusterIndex::matchesDefinition(VPackSlice const& info) const {
   return Index::Compare(_info.slice(), info);
 }
 
-bool ClusterIndex::supportsFilterCondition(
+Index::UsageCosts ClusterIndex::supportsFilterCondition(
     std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
     arangodb::aql::AstNode const* node, arangodb::aql::Variable const* reference,
-    size_t itemsInIndex, size_t& estimatedItems, double& estimatedCost) const {
+    size_t itemsInIndex) const {
   switch (_indexType) {
     case TRI_IDX_TYPE_PRIMARY_INDEX: {
       if (_engineType == ClusterEngineType::RocksDBEngine) {
@@ -232,12 +232,15 @@ bool ClusterIndex::supportsFilterCondition(
         SortedIndexAttributeMatcher::matchAttributes(this, node, reference, found,
                                                      values, nonNullAttributes,
                                                      /*skip evaluation (during execution)*/ false);
-        estimatedItems = values;
-        return !found.empty();
+        Index::UsageCosts costs;
+        costs.estimatedItems = values;
+        /// TODO: estimatedCost?
+        costs.supportsCondition = !found.empty();
+        return costs;
       }
       // MMFiles et al
       SimpleAttributeEqualityMatcher matcher(PrimaryIndexAttributes);
-      return matcher.matchOne(this, node, reference, itemsInIndex, estimatedItems, estimatedCost);
+      return matcher.matchOne(this, node, reference, itemsInIndex);
     }
     case TRI_IDX_TYPE_GEO_INDEX:
     case TRI_IDX_TYPE_GEO1_INDEX:
@@ -246,66 +249,51 @@ bool ClusterIndex::supportsFilterCondition(
     case TRI_IDX_TYPE_IRESEARCH_LINK:
     case TRI_IDX_TYPE_NO_ACCESS_INDEX: {
       // should not be called for these indexes
-      return Index::supportsFilterCondition(allIndexes, node, reference, itemsInIndex,
-                                            estimatedItems, estimatedCost);
+      return Index::supportsFilterCondition(allIndexes, node, reference, itemsInIndex);
     }
     case TRI_IDX_TYPE_HASH_INDEX: {
       if (_engineType == ClusterEngineType::MMFilesEngine) {
         SimpleAttributeEqualityMatcher matcher(this->_fields);
-        return matcher.matchAll(this, node, reference, itemsInIndex,
-                                estimatedItems, estimatedCost);
+        return matcher.matchAll(this, node, reference, itemsInIndex);
       } else if (_engineType == ClusterEngineType::RocksDBEngine) {
         return SortedIndexAttributeMatcher::supportsFilterCondition(
-            allIndexes, this, node, reference, itemsInIndex, estimatedItems, estimatedCost);
+            allIndexes, this, node, reference, itemsInIndex);
       }
       break;
     }
     case TRI_IDX_TYPE_EDGE_INDEX: {
       // same for both engines
       SimpleAttributeEqualityMatcher matcher(this->_fields);
-      return matcher.matchOne(this, node, reference, itemsInIndex, estimatedItems, estimatedCost);
+      return matcher.matchOne(this, node, reference, itemsInIndex);
     }
 
     case TRI_IDX_TYPE_SKIPLIST_INDEX:
-    case TRI_IDX_TYPE_TTL_INDEX: {
-      return SortedIndexAttributeMatcher::supportsFilterCondition(allIndexes, this,
-                                                                  node, reference,
-                                                                  itemsInIndex, estimatedItems,
-                                                                  estimatedCost);
-    }
+    case TRI_IDX_TYPE_TTL_INDEX: 
     case TRI_IDX_TYPE_PERSISTENT_INDEX: {
       // same for both engines
       return SortedIndexAttributeMatcher::supportsFilterCondition(allIndexes, this,
-                                                                  node, reference,
-                                                                  itemsInIndex, estimatedItems,
-                                                                  estimatedCost);
+                                                                  node, reference, itemsInIndex);
     }
 
     case TRI_IDX_TYPE_UNKNOWN:
       break;
   }
-
-  if (_engineType == ClusterEngineType::MockEngine) {
-    return false;
-  }
-  TRI_ASSERT(false);
-  return false;
+    
+  TRI_ASSERT(_engineType == ClusterEngineType::MockEngine);
+  Index::UsageCosts costs;
+  return Index::UsageCosts();
 }
 
-bool ClusterIndex::supportsSortCondition(arangodb::aql::SortCondition const* sortCondition,
-                                         arangodb::aql::Variable const* reference,
-                                         size_t itemsInIndex, double& estimatedCost,
-                                         size_t& coveredAttributes) const {
+Index::UsageCosts ClusterIndex::supportsSortCondition(arangodb::aql::SortCondition const* sortCondition,
+                                                      arangodb::aql::Variable const* reference,
+                                                      size_t itemsInIndex) const {
   switch (_indexType) {
     case TRI_IDX_TYPE_PRIMARY_INDEX:
     case TRI_IDX_TYPE_HASH_INDEX: {
       if (_engineType == ClusterEngineType::MMFilesEngine) {
-        return Index::supportsSortCondition(sortCondition, reference, itemsInIndex,
-                                            estimatedCost, coveredAttributes);
+        return Index::supportsSortCondition(sortCondition, reference, itemsInIndex);
       } else if (_engineType == ClusterEngineType::RocksDBEngine) {
-        return SortedIndexAttributeMatcher::supportsSortCondition(this, sortCondition, reference,
-                                                                  itemsInIndex, estimatedCost,
-                                                                  coveredAttributes);
+        return SortedIndexAttributeMatcher::supportsSortCondition(this, sortCondition, reference, itemsInIndex);
       }
       break;
     }
@@ -316,8 +304,7 @@ bool ClusterIndex::supportsSortCondition(arangodb::aql::SortCondition const* sor
     case TRI_IDX_TYPE_IRESEARCH_LINK:
     case TRI_IDX_TYPE_NO_ACCESS_INDEX:
     case TRI_IDX_TYPE_EDGE_INDEX: {
-      return Index::supportsSortCondition(sortCondition, reference, itemsInIndex,
-                                          estimatedCost, coveredAttributes);
+      return Index::supportsSortCondition(sortCondition, reference, itemsInIndex);
     }
 
     case TRI_IDX_TYPE_SKIPLIST_INDEX:
@@ -325,9 +312,7 @@ bool ClusterIndex::supportsSortCondition(arangodb::aql::SortCondition const* sor
     case TRI_IDX_TYPE_PERSISTENT_INDEX: {
       if (_engineType == ClusterEngineType::MMFilesEngine ||
           _engineType == ClusterEngineType::RocksDBEngine) {
-        return SortedIndexAttributeMatcher::supportsSortCondition(this, sortCondition, reference,
-                                                                  itemsInIndex, estimatedCost,
-                                                                  coveredAttributes);
+        return SortedIndexAttributeMatcher::supportsSortCondition(this, sortCondition, reference, itemsInIndex);
       }
       break;
     }
@@ -336,11 +321,8 @@ bool ClusterIndex::supportsSortCondition(arangodb::aql::SortCondition const* sor
       break;
   }
 
-  if (_engineType == ClusterEngineType::MockEngine) {
-    return false;
-  }
-  TRI_ASSERT(false);
-  return false;
+  TRI_ASSERT(_engineType == ClusterEngineType::MockEngine);
+  return Index::UsageCosts::defaultsForSorting(itemsInIndex, false);
 }
 
 /// @brief specializes the condition for use with the index

--- a/arangod/ClusterEngine/ClusterIndex.h
+++ b/arangod/ClusterEngine/ClusterIndex.h
@@ -84,32 +84,18 @@ class ClusterIndex : public Index {
   /// @brief Checks if this index is identical to the given definition
   bool matchesDefinition(arangodb::velocypack::Slice const&) const override;
 
-  bool supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
-                               arangodb::aql::AstNode const*,
-                               arangodb::aql::Variable const*, size_t, size_t&,
-                               double&) const override;
+  Index::UsageCosts supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
+                                            arangodb::aql::AstNode const* node,
+                                            arangodb::aql::Variable const* reference, 
+                                            size_t itemsInIndex) const override;
 
-  bool supportsSortCondition(arangodb::aql::SortCondition const*,
-                             arangodb::aql::Variable const*, size_t, double&,
-                             size_t&) const override;
+  Index::UsageCosts supportsSortCondition(arangodb::aql::SortCondition const* sortCondition,
+                                          arangodb::aql::Variable const* reference, 
+                                          size_t itemsInIndex) const override;
 
   /// @brief specializes the condition for use with the index
-  arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode*,
-                                              arangodb::aql::Variable const*) const override;
-
-  virtual arangodb::IndexIterator* iteratorForCondition(
-      arangodb::transaction::Methods* trx, 
-      arangodb::aql::AstNode const* condNode, arangodb::aql::Variable const* var,
-      arangodb::IndexIteratorOptions const& opts) override {
-    TRI_ASSERT(false);  // should not be called
-    return nullptr;
-  }
-
-  /// @brief provides a size hint for the index
-  Result sizeHint(transaction::Methods& /*trx*/, size_t /*size*/
-                  ) override final {
-    return Result();  // nothing to do here
-  }
+  arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode* node,
+                                              arangodb::aql::Variable const* reference) const override;
 
   void updateProperties(velocypack::Slice const&);
 

--- a/arangod/IResearch/IResearchLinkCoordinator.h
+++ b/arangod/IResearch/IResearchLinkCoordinator.h
@@ -73,14 +73,6 @@ class IResearchLinkCoordinator final : public arangodb::ClusterIndex, public IRe
   // IResearch does not provide a fixed default sort order
   virtual bool isSorted() const override { return IResearchLink::isSorted(); }
 
-  virtual arangodb::IndexIterator* iteratorForCondition(
-      arangodb::transaction::Methods* trx, 
-      arangodb::aql::AstNode const* condNode, arangodb::aql::Variable const* var,
-      arangodb::IndexIteratorOptions const& opts) override {
-    TRI_ASSERT(false);  // should not be called
-    return nullptr;
-  }
-
   virtual void load() override { IResearchLink::load(); }
 
   virtual bool matchesDefinition(arangodb::velocypack::Slice const& slice) const override {

--- a/arangod/IResearch/IResearchMMFilesLink.h
+++ b/arangod/IResearch/IResearchMMFilesLink.h
@@ -42,29 +42,29 @@ class IResearchMMFilesLink final : public arangodb::MMFilesIndex, public IResear
     IResearchLink::afterTruncate();
   };
 
-  virtual void batchInsert(
+  void batchInsert(
       arangodb::transaction::Methods& trx,
       std::vector<std::pair<arangodb::LocalDocumentId, arangodb::velocypack::Slice>> const& documents,
       std::shared_ptr<arangodb::basics::LocalTaskQueue> queue) override {
     IResearchLink::batchInsert(trx, documents, queue);
   }
 
-  virtual bool canBeDropped() const override {
+  bool canBeDropped() const override {
     return IResearchLink::canBeDropped();
   }
 
-  virtual arangodb::Result drop() override { return IResearchLink::drop(); }
+  arangodb::Result drop() override { return IResearchLink::drop(); }
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief the factory for this type of index
   //////////////////////////////////////////////////////////////////////////////
   static arangodb::IndexTypeFactory const& factory();
 
-  virtual bool hasSelectivityEstimate() const override {
+  bool hasSelectivityEstimate() const override {
     return IResearchLink::hasSelectivityEstimate();
   }
 
-  virtual arangodb::Result insert(arangodb::transaction::Methods& trx,
+  arangodb::Result insert(arangodb::transaction::Methods& trx,
                                   arangodb::LocalDocumentId const& documentId,
                                   arangodb::velocypack::Slice const& doc,
                                   arangodb::Index::OperationMode mode) override {
@@ -73,25 +73,17 @@ class IResearchMMFilesLink final : public arangodb::MMFilesIndex, public IResear
 
   bool isPersistent() const override;
 
-  virtual bool isSorted() const override { return IResearchLink::isSorted(); }
+  bool isSorted() const override { return IResearchLink::isSorted(); }
 
   bool isHidden() const override { return IResearchLink::isHidden(); }
+  
+  void load() override { IResearchLink::load(); }
 
-  virtual arangodb::IndexIterator* iteratorForCondition(
-      arangodb::transaction::Methods* trx,
-      arangodb::aql::AstNode const* condNode, arangodb::aql::Variable const* var,
-      arangodb::IndexIteratorOptions const& opts) override {
-    TRI_ASSERT(false);  // should not be called
-    return nullptr;
-  }
-
-  virtual void load() override { IResearchLink::load(); }
-
-  virtual bool matchesDefinition(arangodb::velocypack::Slice const& slice) const override {
+  bool matchesDefinition(arangodb::velocypack::Slice const& slice) const override {
     return IResearchLink::matchesDefinition(slice);
   }
 
-  virtual size_t memory() const override { return IResearchLink::memory(); }
+  size_t memory() const override { return IResearchLink::memory(); }
 
   arangodb::Result remove(transaction::Methods& trx,
                           arangodb::LocalDocumentId const& documentId,
@@ -104,16 +96,16 @@ class IResearchMMFilesLink final : public arangodb::MMFilesIndex, public IResear
   /// @param withFigures output 'figures' section with e.g. memory size
   ////////////////////////////////////////////////////////////////////////////////
   using Index::toVelocyPack; // for std::shared_ptr<Builder> Index::toVelocyPack(bool, Index::Serialize)
-  virtual void toVelocyPack(arangodb::velocypack::Builder& builder,
-                            std::underlying_type<arangodb::Index::Serialize>::type) const override;
+  void toVelocyPack(arangodb::velocypack::Builder& builder,
+                    std::underlying_type<arangodb::Index::Serialize>::type) const override;
 
-  virtual IndexType type() const override { return IResearchLink::type(); }
+  IndexType type() const override { return IResearchLink::type(); }
 
-  virtual char const* typeName() const override {
+  char const* typeName() const override {
     return IResearchLink::typeName();
   }
 
-  virtual void unload() override {
+  void unload() override {
     auto res = IResearchLink::unload();
 
     if (!res.ok()) {

--- a/arangod/IResearch/IResearchRocksDBLink.h
+++ b/arangod/IResearch/IResearchRocksDBLink.h
@@ -38,54 +38,46 @@ namespace iresearch {
 
 class IResearchRocksDBLink final : public arangodb::RocksDBIndex, public IResearchLink {
  public:
-  virtual void afterTruncate(TRI_voc_tick_t /*tick*/) override {
+  void afterTruncate(TRI_voc_tick_t /*tick*/) override {
     IResearchLink::afterTruncate();
   }
 
-  virtual bool canBeDropped() const override {
+  bool canBeDropped() const override {
     return IResearchLink::canBeDropped();
   }
 
-  virtual arangodb::Result drop() override { return IResearchLink::drop(); }
+  arangodb::Result drop() override { return IResearchLink::drop(); }
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief the factory for this type of index
   //////////////////////////////////////////////////////////////////////////////
   static arangodb::IndexTypeFactory const& factory();
 
-  virtual bool hasSelectivityEstimate() const override {
+  bool hasSelectivityEstimate() const override {
     return IResearchLink::hasSelectivityEstimate();
   }
 
-  virtual arangodb::Result insert(arangodb::transaction::Methods& trx,
-                                  arangodb::RocksDBMethods* methods,
-                                  arangodb::LocalDocumentId const& documentId,
-                                  arangodb::velocypack::Slice const& doc,
-                                  arangodb::Index::OperationMode mode) override {
+  arangodb::Result insert(arangodb::transaction::Methods& trx,
+                          arangodb::RocksDBMethods* methods,
+                          arangodb::LocalDocumentId const& documentId,
+                          arangodb::velocypack::Slice const& doc,
+                          arangodb::Index::OperationMode mode) override {
     return IResearchLink::insert(trx, documentId, doc, mode);
   }
 
-  virtual bool isSorted() const override { return IResearchLink::isSorted(); }
+  bool isSorted() const override { return IResearchLink::isSorted(); }
 
   bool isHidden() const override { return IResearchLink::isHidden(); }
+  
+  void load() override { IResearchLink::load(); }
 
-  virtual arangodb::IndexIterator* iteratorForCondition(
-      arangodb::transaction::Methods* trx,
-      arangodb::aql::AstNode const* condNode, arangodb::aql::Variable const* var,
-      arangodb::IndexIteratorOptions const& opts) override {
-    TRI_ASSERT(false);  // should not be called
-    return nullptr;
-  }
-
-  virtual void load() override { IResearchLink::load(); }
-
-  virtual bool matchesDefinition(arangodb::velocypack::Slice const& slice) const override {
+  bool matchesDefinition(arangodb::velocypack::Slice const& slice) const override {
     return IResearchLink::matchesDefinition(slice);
   }
 
-  virtual size_t memory() const override { return IResearchLink::memory(); }
+  size_t memory() const override { return IResearchLink::memory(); }
 
-  virtual arangodb::Result remove(arangodb::transaction::Methods& trx,
+  arangodb::Result remove(arangodb::transaction::Methods& trx,
                                   arangodb::RocksDBMethods*,
                                   arangodb::LocalDocumentId const& documentId,
                                   arangodb::velocypack::Slice const& doc,
@@ -98,16 +90,16 @@ class IResearchRocksDBLink final : public arangodb::RocksDBIndex, public IResear
   /// @param withFigures output 'figures' section with e.g. memory size
   ////////////////////////////////////////////////////////////////////////////////
   using Index::toVelocyPack; // for std::shared_ptr<Builder> Index::toVelocyPack(bool, Index::Serialize)
-  virtual void toVelocyPack(arangodb::velocypack::Builder& builder,
-                            std::underlying_type<arangodb::Index::Serialize>::type flags) const override;
+  void toVelocyPack(arangodb::velocypack::Builder& builder,
+                    std::underlying_type<arangodb::Index::Serialize>::type flags) const override;
 
-  virtual IndexType type() const override { return IResearchLink::type(); }
+  IndexType type() const override { return IResearchLink::type(); }
 
-  virtual char const* typeName() const override {
+  char const* typeName() const override {
     return IResearchLink::typeName();
   }
 
-  virtual void unload() override {
+  void unload() override {
     auto res = IResearchLink::unload();
 
     if (!res.ok()) {

--- a/arangod/Indexes/Index.cpp
+++ b/arangod/Indexes/Index.cpp
@@ -623,40 +623,37 @@ Result Index::drop() {
   return Result();  // do nothing
 }
 
-/// @brief default implementation for sizeHint
-Result Index::sizeHint(transaction::Methods& trx, size_t size) {
-  return Result();  // do nothing
-}
-
 /// @brief default implementation for supportsFilterCondition
-bool Index::supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const&,
-                                    arangodb::aql::AstNode const*,
-                                    arangodb::aql::Variable const*, size_t itemsInIndex,
-                                    size_t& estimatedItems, double& estimatedCost) const {
+Index::UsageCosts Index::supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const&,
+                                                 arangodb::aql::AstNode const* /* node */,
+                                                 arangodb::aql::Variable const* /* reference */, 
+                                                 size_t itemsInIndex) const {
   // by default, no filter conditions are supported
-  estimatedItems = itemsInIndex;
-  estimatedCost = static_cast<double>(estimatedItems);
-  return false;
+  return Index::UsageCosts::defaultsForFiltering(itemsInIndex);
 }
 
 /// @brief default implementation for supportsSortCondition
-bool Index::supportsSortCondition(arangodb::aql::SortCondition const*,
-                                  arangodb::aql::Variable const*, size_t itemsInIndex,
-                                  double& estimatedCost, size_t& coveredAttributes) const {
+Index::UsageCosts Index::supportsSortCondition(arangodb::aql::SortCondition const* /* sortCondition */,
+                                               arangodb::aql::Variable const* /* node */, 
+                                               size_t itemsInIndex) const {
   // by default, no sort conditions are supported
-  coveredAttributes = 0;
-  if (itemsInIndex > 0) {
-    estimatedCost = itemsInIndex * std::log2(itemsInIndex);
-  } else {
-    estimatedCost = 0.0;
-  }
-  return false;
+  return Index::UsageCosts::defaultsForSorting(itemsInIndex, this->isPersistent());
+}
+  
+arangodb::aql::AstNode* Index::specializeCondition(arangodb::aql::AstNode* /* node */,
+                                                   arangodb::aql::Variable const* /* reference */) const {
+  // the default implementation should never be called
+  TRI_ASSERT(false); 
+  THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "no default implementation for specializeCondition");
 }
 
-/// @brief specializes the condition for use with the index
-arangodb::aql::AstNode* Index::specializeCondition(arangodb::aql::AstNode* node,
-                                                   arangodb::aql::Variable const*) const {
-  return node;
+std::unique_ptr<IndexIterator> Index::iteratorForCondition(transaction::Methods* /* trx */,
+                                                           aql::AstNode const* /* node */,
+                                                           aql::Variable const* /* reference */,
+                                                           IndexIteratorOptions const& /* opts */) {
+  // the default implementation should never be called
+  TRI_ASSERT(false); 
+  THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "no default implementation for iteratorForCondition");
 }
 
 /// @brief perform some base checks for an index condition part

--- a/arangod/Indexes/Index.h
+++ b/arangod/Indexes/Index.h
@@ -104,8 +104,53 @@ class Index {
     TRI_IDX_TYPE_NO_ACCESS_INDEX
   };
 
-  // mode to signal how operation should behave
+  /// @brief: mode to signal how operation should behave
   enum OperationMode { normal, internal, rollback };
+  
+  /// @brief: helper struct returned by index methods that determine the costs
+  /// of index usage
+  struct UsageCosts {
+    /// @brief whether or not the index supports the filter condition/sort clause
+    bool supportsCondition = false;
+
+    /// @brief number of attributes covered by this index
+    size_t coveredAttributes = 0;
+
+    /// @brief estimated items to be returned for this condition
+    size_t estimatedItems = 0;
+
+    /// @brief estimated costs for this filter condition/sort clause
+    double estimatedCosts = 0.0;
+    
+    static UsageCosts zeroCosts() {
+      UsageCosts costs;
+      costs.estimatedItems = 0;
+      costs.estimatedCosts = 0;
+      costs.supportsCondition = true;
+      return costs;
+    }
+
+    static UsageCosts defaultsForFiltering(size_t itemsInIndex) {
+      UsageCosts costs;
+      costs.estimatedItems = itemsInIndex;
+      costs.estimatedCosts = static_cast<double>(itemsInIndex);
+      TRI_ASSERT(!costs.supportsCondition);
+      return costs;
+    }
+    
+    static UsageCosts defaultsForSorting(size_t itemsInIndex, bool isPersistent) {
+      UsageCosts costs;
+      costs.estimatedItems = itemsInIndex;
+      costs.estimatedCosts = itemsInIndex > 0 ? (itemsInIndex * std::log2(static_cast<double>(itemsInIndex))) : 0.0;
+      if (isPersistent) {
+        // slightly penalize this type of index against other indexes which
+        // are in memory
+        costs.estimatedCosts *= 1.05;
+      }
+      TRI_ASSERT(!costs.supportsCondition);
+      return costs;
+    }
+  };
 
  public:
   /// @brief return the index id
@@ -334,27 +379,36 @@ class Index {
 
   /// @brief called after the collection was truncated
   /// @param tick at which truncate was applied
-  virtual void afterTruncate(TRI_voc_tick_t tick){};
+  virtual void afterTruncate(TRI_voc_tick_t tick) {}
 
-  // give index a hint about the expected size
-  virtual Result sizeHint(transaction::Methods& trx, size_t size);
+  /// @brief whether or not the filter condition is supported by the index
+  /// returns detailed information about the costs associated with using this index
+  virtual UsageCosts supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
+                                             arangodb::aql::AstNode const* node,
+                                             arangodb::aql::Variable const* reference, 
+                                             size_t itemsInIndex) const;
 
-  virtual bool supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
-                                       arangodb::aql::AstNode const*,
-                                       arangodb::aql::Variable const*, size_t,
-                                       size_t&, double&) const;
+  /// @brief whether or not the sort condition is supported by the index
+  /// returns detailed information about the costs associated with using this index
+  virtual UsageCosts supportsSortCondition(arangodb::aql::SortCondition const* sortCondition,
+                                           arangodb::aql::Variable const* reference, 
+                                           size_t itemsInIndex) const;
 
-  virtual bool supportsSortCondition(arangodb::aql::SortCondition const*,
-                                     arangodb::aql::Variable const*, size_t,
-                                     double&, size_t&) const;
+  /// @brief specialize the condition for use with this index. this will remove all 
+  /// elements from the condition that are not supported by the index.
+  /// for example, if the condition is `doc.value1 == 38 && doc.value2 > 9`, but the index is
+  /// only on `doc.value1`, this will return a new AstNode that points to just the condition
+  /// `doc.value1 == 38`.
+  /// must only be called if supportsFilterCondition has indicated that the index supports
+  /// at least a part of the filter condition
+  virtual arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode* node,
+                                                      arangodb::aql::Variable const* reference) const;
 
-  virtual arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode*,
-                                                      arangodb::aql::Variable const*) const;
-
-  virtual IndexIterator* iteratorForCondition(transaction::Methods* trx,
-                                              aql::AstNode const* condNode,
-                                              aql::Variable const* var,
-                                              IndexIteratorOptions const& opts) = 0;
+  /// @brief create a new index iterator for the (specialized) condition
+  virtual std::unique_ptr<IndexIterator> iteratorForCondition(transaction::Methods* trx,
+                                                              aql::AstNode const* node,
+                                                              aql::Variable const* reference,
+                                                              IndexIteratorOptions const& opts);
 
   bool canUseConditionPart(arangodb::aql::AstNode const* access,
                            arangodb::aql::AstNode const* other,

--- a/arangod/Indexes/IndexIterator.cpp
+++ b/arangod/Indexes/IndexIterator.cpp
@@ -98,7 +98,7 @@ bool MultiIndexIterator::next(LocalDocumentIdCallback const& callback, size_t li
         _current = nullptr;
         return false;
       } else {
-        _current = _iterators.at(_currentIdx);
+        _current = _iterators.at(_currentIdx).get();
       }
     }
   }
@@ -124,7 +124,7 @@ bool MultiIndexIterator::nextDocument(DocumentCallback const& callback, size_t l
         _current = nullptr;
         return false;
       } else {
-        _current = _iterators.at(_currentIdx);
+        _current = _iterators.at(_currentIdx).get();
       }
     }
   }
@@ -157,7 +157,7 @@ bool MultiIndexIterator::nextCovering(DocumentCallback const& callback, size_t l
         _current = nullptr;
         return false;
       } else {
-        _current = _iterators.at(_currentIdx);
+        _current = _iterators.at(_currentIdx).get();
       }
     }
   }
@@ -167,7 +167,7 @@ bool MultiIndexIterator::nextCovering(DocumentCallback const& callback, size_t l
 /// @brief Reset the cursor
 ///        This will reset ALL internal iterators and start all over again
 void MultiIndexIterator::reset() {
-  _current = _iterators[0];
+  _current = _iterators[0].get();
   _currentIdx = 0;
   for (auto& it : _iterators) {
     it->reset();

--- a/arangod/Indexes/SimpleAttributeEqualityMatcher.cpp
+++ b/arangod/Indexes/SimpleAttributeEqualityMatcher.cpp
@@ -38,14 +38,13 @@ SimpleAttributeEqualityMatcher::SimpleAttributeEqualityMatcher(
 
 /// @brief match a single of the attributes
 /// this is used for the primary index and the edge index
-bool SimpleAttributeEqualityMatcher::matchOne(arangodb::Index const* index,
-                                              arangodb::aql::AstNode const* node,
-                                              arangodb::aql::Variable const* reference,
-                                              size_t itemsInIndex, size_t& estimatedItems,
-                                              double& estimatedCost) {
+Index::UsageCosts SimpleAttributeEqualityMatcher::matchOne(arangodb::Index const* index,
+                                                           arangodb::aql::AstNode const* node,
+                                                           arangodb::aql::Variable const* reference,
+                                                           size_t itemsInIndex) {
   std::unordered_set<std::string> nonNullAttributes;
   _found.clear();
-
+  
   size_t const n = node->numMembers();
 
   for (size_t i = 0; i < n; ++i) {
@@ -64,9 +63,7 @@ bool SimpleAttributeEqualityMatcher::matchOne(arangodb::Index const* index,
       }
       if (which >= 0) {
         // we can use the index
-        calculateIndexCosts(index, op->getMember(which), itemsInIndex,
-                            estimatedItems, estimatedCost);
-        return true;
+        return calculateIndexCosts(index, op->getMember(which), itemsInIndex);
       }
     } else if (op->type == arangodb::aql::NODE_TYPE_OPERATOR_BINARY_IN) {
       TRI_ASSERT(op->numMembers() == 2);
@@ -74,32 +71,29 @@ bool SimpleAttributeEqualityMatcher::matchOne(arangodb::Index const* index,
                           reference, nonNullAttributes, false)) {
         // we can use the index
         // use slightly different cost calculation for IN than for EQ
-        calculateIndexCosts(index, op->getMember(0), itemsInIndex, estimatedItems, estimatedCost);
+        Index::UsageCosts costs = calculateIndexCosts(index, op->getMember(0), itemsInIndex);
         size_t values = estimateNumberOfArrayMembers(op->getMember(1));
-        estimatedItems *= values;
-        estimatedCost *= values;
-        return true;
+        costs.estimatedItems *= values;
+        costs.estimatedCosts *= values;
+        return costs;
       }
     }
   }
 
   // set to defaults
-  estimatedItems = itemsInIndex;
-  estimatedCost = static_cast<double>(estimatedItems);
-  return false;
+  return Index::UsageCosts::defaultsForFiltering(itemsInIndex);
 }
 
 /// @brief match all of the attributes, in any order
 /// this is used for the hash index
-bool SimpleAttributeEqualityMatcher::matchAll(arangodb::Index const* index,
-                                              arangodb::aql::AstNode const* node,
-                                              arangodb::aql::Variable const* reference,
-                                              size_t itemsInIndex, size_t& estimatedItems,
-                                              double& estimatedCost) {
+Index::UsageCosts SimpleAttributeEqualityMatcher::matchAll(arangodb::Index const* index,
+                                                           arangodb::aql::AstNode const* node,
+                                                           arangodb::aql::Variable const* reference,
+                                                           size_t itemsInIndex) {
   std::unordered_set<std::string> nonNullAttributes;
   _found.clear();
   arangodb::aql::AstNode const* which = nullptr;
-
+  
   size_t values = 1;
   size_t const n = node->numMembers();
 
@@ -157,16 +151,14 @@ bool SimpleAttributeEqualityMatcher::matchAll(arangodb::Index const* index,
       which = nullptr;
     }
 
-    calculateIndexCosts(index, which, itemsInIndex, estimatedItems, estimatedCost);
-    estimatedItems *= values;
-    estimatedCost *= static_cast<double>(values);
-    return true;
+    Index::UsageCosts costs = calculateIndexCosts(index, which, itemsInIndex);
+    costs.estimatedItems *= values;
+    costs.estimatedCosts *= static_cast<double>(values);
+    return costs;
   }
 
   // set to defaults
-  estimatedItems = itemsInIndex;
-  estimatedCost = static_cast<double>(estimatedItems);
-  return false;
+  return Index::UsageCosts::defaultsForFiltering(itemsInIndex);
 }
 
 /// @brief specialize the condition for the index
@@ -306,18 +298,20 @@ arangodb::aql::AstNode* SimpleAttributeEqualityMatcher::specializeAll(
 /// that will return in average
 /// cost values have no special meaning, except that multiple cost values are
 /// comparable, and lower values mean lower costs
-void SimpleAttributeEqualityMatcher::calculateIndexCosts(
+Index::UsageCosts SimpleAttributeEqualityMatcher::calculateIndexCosts(
     arangodb::Index const* index, arangodb::aql::AstNode const* attribute,
-    size_t itemsInIndex, size_t& estimatedItems, double& estimatedCost) const {
+    size_t itemsInIndex) const {
   // note: attribute will be set to the index attribute for single-attribute
   // indexes such as the primary and edge indexes, and is a nullptr for the
   // other indexes
+  Index::UsageCosts costs;
+  costs.supportsCondition = true;
 
   if (index->unique() || index->implicitlyUnique()) {
     // index is unique, and the condition covers all attributes
     // now use a low value for the costs
-    estimatedItems = 1;
-    estimatedCost = 0.95 - 0.05 * (index->fields().size() - 1);
+    costs.estimatedItems = 1;
+    costs.estimatedCosts = 0.95 - 0.05 * (index->fields().size() - 1);
   } else if (index->hasSelectivityEstimate()) {
     // use index selectivity estimate
     arangodb::velocypack::StringRef att;
@@ -327,12 +321,12 @@ void SimpleAttributeEqualityMatcher::calculateIndexCosts(
     double estimate = index->selectivityEstimate(att);
     if (estimate <= 0.0) {
       // prevent division by zero
-      estimatedItems = itemsInIndex;
+      costs.estimatedItems = itemsInIndex;
       // the more attributes are contained in the index, the more specific the
       // lookup will be
       double equalityReductionFactor = 20.0;
       for (size_t i = 0; i < index->fields().size(); ++i) {
-        estimatedItems /= static_cast<size_t>(equalityReductionFactor);
+        costs.estimatedItems /= static_cast<size_t>(equalityReductionFactor);
         // decrease the effect of the equality reduction factor
         equalityReductionFactor *= 0.25;
         if (equalityReductionFactor < 2.0) {
@@ -341,17 +335,19 @@ void SimpleAttributeEqualityMatcher::calculateIndexCosts(
         }
       }
     } else {
-      estimatedItems = static_cast<size_t>(1.0 / estimate);
+      costs.estimatedItems = static_cast<size_t>(1.0 / estimate);
     }
 
-    estimatedItems = (std::max)(estimatedItems, static_cast<size_t>(1));
+    costs.estimatedItems = (std::max)(costs.estimatedItems, static_cast<size_t>(1));
     // the more attributes are covered by an index, the more accurate it
     // is considered to be
-    estimatedCost = static_cast<double>(estimatedItems) - index->fields().size() * 0.01;
+    costs.estimatedCosts = static_cast<double>(costs.estimatedItems) - index->fields().size() * 0.01;
   } else {
     // no such index should exist
     TRI_ASSERT(false);
   }
+
+  return costs;
 }
 
 /// @brief whether or not the access fits

--- a/arangod/Indexes/SimpleAttributeEqualityMatcher.h
+++ b/arangod/Indexes/SimpleAttributeEqualityMatcher.h
@@ -26,6 +26,7 @@
 
 #include "Basics/AttributeNameParser.h"
 #include "Basics/Common.h"
+#include "Indexes/Index.h"
 
 namespace arangodb {
 namespace aql {
@@ -44,13 +45,17 @@ class SimpleAttributeEqualityMatcher {
  public:
   /// @brief match a single of the attributes
   /// this is used for the primary index and the edge index
-  bool matchOne(arangodb::Index const*, arangodb::aql::AstNode const*,
-                arangodb::aql::Variable const*, size_t, size_t&, double&);
+  Index::UsageCosts matchOne(arangodb::Index const* index, 
+                             arangodb::aql::AstNode const* node,
+                             arangodb::aql::Variable const* reference, 
+                             size_t itemsInIndex);
 
   /// @brief match all of the attributes, in any order
   /// this is used for the hash index
-  bool matchAll(arangodb::Index const*, arangodb::aql::AstNode const*,
-                arangodb::aql::Variable const*, size_t, size_t&, double&);
+  Index::UsageCosts matchAll(arangodb::Index const* index, 
+                             arangodb::aql::AstNode const* node,
+                             arangodb::aql::Variable const* reference, 
+                             size_t itemsInIndex);
 
   /// @brief get the condition parts that the index is responsible for
   /// this is used for the primary index and the edge index
@@ -79,9 +84,8 @@ class SimpleAttributeEqualityMatcher {
   /// that will return in average
   /// cost values have no special meaning, except that multiple cost values are
   /// comparable, and lower values mean lower costs
-  void calculateIndexCosts(arangodb::Index const* index,
-                           arangodb::aql::AstNode const* attribute, size_t itemsInIndex,
-                           size_t& estimatedItems, double& estimatedCost) const;
+  Index::UsageCosts calculateIndexCosts(arangodb::Index const* index,
+                                        arangodb::aql::AstNode const* attribute, size_t itemsInIndex) const;
 
   /// @brief whether or not the access fits
   bool accessFitsIndex(arangodb::Index const*, arangodb::aql::AstNode const*,

--- a/arangod/Indexes/SortedIndexAttributeMatcher.cpp
+++ b/arangod/Indexes/SortedIndexAttributeMatcher.cpp
@@ -187,17 +187,18 @@ void SortedIndexAttributeMatcher::matchAttributes(
   }
 }
 
-bool SortedIndexAttributeMatcher::supportsFilterCondition(
+Index::UsageCosts SortedIndexAttributeMatcher::supportsFilterCondition(
     std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
     arangodb::Index const* idx, arangodb::aql::AstNode const* node,
-    arangodb::aql::Variable const* reference, size_t itemsInIndex,
-    size_t& estimatedItems, double& estimatedCost) {
+    arangodb::aql::Variable const* reference, size_t itemsInIndex) {
   // mmfiles failure point compat
   if (idx->type() == Index::TRI_IDX_TYPE_HASH_INDEX) {
     TRI_IF_FAILURE("SimpleAttributeMatcher::accessFitsIndex") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
   }
+  
+  Index::UsageCosts costs;
 
   std::unordered_map<size_t, std::vector<arangodb::aql::AstNode const*>> found;
   std::unordered_set<std::string> nonNullAttributes;
@@ -208,7 +209,7 @@ bool SortedIndexAttributeMatcher::supportsFilterCondition(
   size_t attributesCovered = 0;
   size_t attributesCoveredByEquality = 0;
   double equalityReductionFactor = 20.0;
-  estimatedCost = static_cast<double>(itemsInIndex);
+  costs.estimatedCosts = static_cast<double>(itemsInIndex);
 
   for (size_t i = 0; i < idx->fields().size(); ++i) {
     auto it = found.find(i);
@@ -237,7 +238,7 @@ bool SortedIndexAttributeMatcher::supportsFilterCondition(
     ++attributesCovered;
     if (containsEquality) {
       ++attributesCoveredByEquality;
-      estimatedCost /= equalityReductionFactor;
+      costs.estimatedCosts /= equalityReductionFactor;
 
       // decrease the effect of the equality reduction factor
       equalityReductionFactor *= 0.25;
@@ -250,10 +251,10 @@ bool SortedIndexAttributeMatcher::supportsFilterCondition(
       if (nodes.size() >= 2) {
         // at least two (non-equality) conditions. probably a range with lower
         // and upper bound defined
-        estimatedCost /= 7.5;
+        costs.estimatedCosts /= 7.5;
       } else {
         // one (non-equality). this is either a lower or a higher bound
-        estimatedCost /= 2.0;
+        costs.estimatedCosts /= 2.0;
       }
     }
 
@@ -267,20 +268,23 @@ bool SortedIndexAttributeMatcher::supportsFilterCondition(
   if (attributesCoveredByEquality == idx->fields().size() &&
       (idx->unique() || idx->implicitlyUnique())) {
     // index is unique and condition covers all attributes by equality
+    costs.coveredAttributes = attributesCovered;
+    costs.supportsCondition = true;
+
     if (itemsInIndex == 0) {
-      estimatedItems = 0;
-      estimatedCost = 0.0;
-      return true;
+      costs.estimatedItems = 0;
+      costs.estimatedCosts = 0.0;
+      return costs;
     }
 
-    estimatedItems = values;
+    costs.estimatedItems = values;
     // ALTERNATIVE: estimatedCost = static_cast<double>(estimatedItems * values);
-    estimatedCost = (std::max)(static_cast<double>(1),
-                               std::log2(static_cast<double>(itemsInIndex)) * values);
+    costs.estimatedCosts = (std::max)(static_cast<double>(1),
+                                     std::log2(static_cast<double>(itemsInIndex)) * values);
 
     // cost is already low... now slightly prioritize unique indexes
-    estimatedCost *= 0.995 - 0.05 * (idx->fields().size() - 1);
-    return true;
+    costs.estimatedCosts *= 0.995 - 0.05 * (idx->fields().size() - 1);
+    return costs;
   }
 
   if (attributesCovered > 0 &&
@@ -289,15 +293,15 @@ bool SortedIndexAttributeMatcher::supportsFilterCondition(
     // or the index is sparse and all attributes are covered by the condition,
     // then it can be used (note: additional checks for condition parts in
     // sparse indexes are contained in Index::canUseConditionPart)
-    estimatedItems = static_cast<size_t>(
-        (std::max)(static_cast<size_t>(estimatedCost * values), static_cast<size_t>(1)));
+    costs.estimatedItems = static_cast<size_t>(
+        (std::max)(static_cast<size_t>(costs.estimatedCosts * values), static_cast<size_t>(1)));
 
     // check if the index has a selectivity estimate ready
     if (idx->hasSelectivityEstimate() &&
         attributesCoveredByEquality == idx->fields().size()) {
       double estimate = idx->selectivityEstimate();
       if (estimate > 0.0) {
-        estimatedItems = static_cast<size_t>(1.0 / estimate);
+        costs.estimatedItems = static_cast<size_t>(1.0 / estimate);
       }
     } else if (attributesCoveredByEquality > 0) {
       TRI_ASSERT(attributesCovered > 0);
@@ -337,7 +341,7 @@ bool SortedIndexAttributeMatcher::supportsFilterCondition(
           double estimate = other->selectivityEstimate();
           if (estimate > 0.0) {
             // reuse the estimate from the other index
-            estimatedItems = static_cast<size_t>(1.0 / estimate);
+            costs.estimatedItems = static_cast<size_t>(1.0 / estimate);
             break;
           }
         }
@@ -345,28 +349,29 @@ bool SortedIndexAttributeMatcher::supportsFilterCondition(
     }
 
     if (itemsInIndex == 0) {
-      estimatedCost = 0.0;
+      costs.estimatedCosts = 0.0;
     } else {
       // lookup cost is O(log(n))
-      estimatedCost = (std::max)(static_cast<double>(1),
+      costs.estimatedCosts = (std::max)(static_cast<double>(1),
                                  std::log2(static_cast<double>(itemsInIndex)) * values);
       // slightly prefer indexes that cover more attributes
-      estimatedCost -= (attributesCovered - 1) * 0.02;
+      costs.estimatedCosts -= (attributesCovered - 1) * 0.02;
     }
-    return true;
+    costs.coveredAttributes = attributesCovered;
+    costs.supportsCondition = true;
+    return costs;
   }
 
   // index does not help for this condition
-  estimatedItems = itemsInIndex;
-  estimatedCost = static_cast<double>(estimatedItems);
-  return false;
+  return Index::UsageCosts::defaultsForFiltering(itemsInIndex);
 }
 
-bool SortedIndexAttributeMatcher::supportsSortCondition(
+Index::UsageCosts SortedIndexAttributeMatcher::supportsSortCondition(
     arangodb::Index const* idx, arangodb::aql::SortCondition const* sortCondition,
-    arangodb::aql::Variable const* reference, size_t itemsInIndex,
-    double& estimatedCost, size_t& coveredAttributes) {
+    arangodb::aql::Variable const* reference, size_t itemsInIndex) {
   TRI_ASSERT(sortCondition != nullptr);
+
+  Index::UsageCosts costs;
 
   if (!idx->sparse() ||
       sortCondition->onlyUsesNonNullSortAttributes(idx->fields())) {
@@ -374,42 +379,32 @@ bool SortedIndexAttributeMatcher::supportsSortCondition(
     // used if we can prove that we only need to return non-null index attribute values
     if (!idx->hasExpansion() && sortCondition->isUnidirectional() &&
         sortCondition->isOnlyAttributeAccess()) {
-      coveredAttributes = sortCondition->coveredAttributes(reference, idx->fields());
+      costs.coveredAttributes = sortCondition->coveredAttributes(reference, idx->fields());
 
-      if (coveredAttributes >= sortCondition->numAttributes()) {
+      if (costs.coveredAttributes >= sortCondition->numAttributes()) {
         // sort is fully covered by index. no additional sort costs!
         // forward iteration does not have high costs
-        estimatedCost = itemsInIndex * 0.001;
+        costs.estimatedCosts = itemsInIndex * 0.001;
         if (idx->isPersistent() && sortCondition->isDescending()) {
           // reverse iteration has higher costs than forward iteration
-          estimatedCost *= 4;
+          costs.estimatedCosts *= 4;
         }
-        return true;
-      } else if (coveredAttributes > 0) {
-        estimatedCost = (itemsInIndex / coveredAttributes) *
-                        std::log2(static_cast<double>(itemsInIndex));
+        costs.supportsCondition = true;
+        return costs;
+      } else if (costs.coveredAttributes > 0) {
+        costs.estimatedCosts = (itemsInIndex / costs.coveredAttributes) *
+                               std::log2(static_cast<double>(itemsInIndex));
         if (idx->isPersistent() && sortCondition->isDescending()) {
           // reverse iteration is more expensive
-          estimatedCost *= 4;
+          costs.estimatedCosts *= 4;
         }
-        return true;
+        costs.supportsCondition = true;
+        return costs;
       }
     }
   }
 
-  coveredAttributes = 0;
-  // by default no sort conditions are supported
-  if (itemsInIndex > 0) {
-    estimatedCost = itemsInIndex * std::log2(static_cast<double>(itemsInIndex));
-    // slightly penalize this type of index against other indexes which
-    // are in memory
-    if (idx->isPersistent()) {
-      estimatedCost *= 1.05;
-    }
-  } else {
-    estimatedCost = 0.0;
-  }
-  return false;
+  return Index::UsageCosts::defaultsForSorting(itemsInIndex, idx->isPersistent());
 }
 
 /// @brief specializes the condition for use with the index

--- a/arangod/Indexes/SortedIndexAttributeMatcher.h
+++ b/arangod/Indexes/SortedIndexAttributeMatcher.h
@@ -25,6 +25,7 @@
 
 #include "Basics/Common.h"
 #include "Basics/HashSet.h"
+#include "Indexes/Index.h"
 
 namespace arangodb {
 namespace aql {
@@ -38,23 +39,23 @@ class Index;
 
 namespace SortedIndexAttributeMatcher {
 
-bool supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
-                             arangodb::Index const* index,
-                             arangodb::aql::AstNode const* node,
-                             arangodb::aql::Variable const* reference, size_t itemsInIndex,
-                             size_t& estimatedItems, double& estimatedCost);
+Index::UsageCosts supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
+                                          arangodb::Index const* index,
+                                          arangodb::aql::AstNode const* node,
+                                          arangodb::aql::Variable const* reference, 
+                                          size_t itemsInIndex);
 
-bool supportsSortCondition(arangodb::Index const*,
-                           arangodb::aql::SortCondition const* sortCondition,
-                           arangodb::aql::Variable const* reference, size_t itemsInIndex,
-                           double& estimatedCost, size_t& coveredAttributes);
+Index::UsageCosts supportsSortCondition(arangodb::Index const* index,
+                                        arangodb::aql::SortCondition const* sortCondition,
+                                        arangodb::aql::Variable const* reference, 
+                                        size_t itemsInIndex);
 
 /// @brief specializes the condition for use with the index
-arangodb::aql::AstNode* specializeCondition(arangodb::Index const*,
+arangodb::aql::AstNode* specializeCondition(arangodb::Index const* index,
                                             arangodb::aql::AstNode* node,
                                             arangodb::aql::Variable const* reference);
 
-void matchAttributes(arangodb::Index const*, arangodb::aql::AstNode const* node,
+void matchAttributes(arangodb::Index const* index, arangodb::aql::AstNode const* node,
                      arangodb::aql::Variable const* reference,
                      std::unordered_map<size_t, std::vector<arangodb::aql::AstNode const*>>& found,
                      size_t& values, std::unordered_set<std::string>& nonNullAttributes,

--- a/arangod/MMFiles/MMFilesCollection.cpp
+++ b/arangod/MMFiles/MMFilesCollection.cpp
@@ -1717,7 +1717,7 @@ int MMFilesCollection::fillIndexes(transaction::Methods& trx,
       if (idx->type() == Index::IndexType::TRI_IDX_TYPE_PRIMARY_INDEX) {
         continue;
       }
-      idx.get()->sizeHint(trx, nrUsed);
+      static_cast<MMFilesIndex*>(idx.get())->sizeHint(trx, nrUsed);
     }
 
     // process documents a million at a time

--- a/arangod/MMFiles/MMFilesEdgeIndex.cpp
+++ b/arangod/MMFiles/MMFilesEdgeIndex.cpp
@@ -384,16 +384,16 @@ Result MMFilesEdgeIndex::sizeHint(transaction::Methods& trx, size_t size) {
 }
 
 /// @brief checks whether the index supports the condition
-bool MMFilesEdgeIndex::supportsFilterCondition(
+Index::UsageCosts MMFilesEdgeIndex::supportsFilterCondition(
     std::vector<std::shared_ptr<arangodb::Index>> const&,
     arangodb::aql::AstNode const* node, arangodb::aql::Variable const* reference,
-    size_t itemsInIndex, size_t& estimatedItems, double& estimatedCost) const {
+    size_t itemsInIndex) const {
   SimpleAttributeEqualityMatcher matcher(IndexAttributes);
-  return matcher.matchOne(this, node, reference, itemsInIndex, estimatedItems, estimatedCost);
+  return matcher.matchOne(this, node, reference, itemsInIndex);
 }
 
 /// @brief creates an IndexIterator for the given Condition
-IndexIterator* MMFilesEdgeIndex::iteratorForCondition(
+std::unique_ptr<IndexIterator> MMFilesEdgeIndex::iteratorForCondition(
     transaction::Methods* trx, 
     arangodb::aql::AstNode const* node,
     arangodb::aql::Variable const* reference, IndexIteratorOptions const& opts) {
@@ -417,7 +417,7 @@ IndexIterator* MMFilesEdgeIndex::iteratorForCondition(
   }
     
   // operator type unsupported
-  return new EmptyIndexIterator(&_collection, trx);
+  return std::make_unique<EmptyIndexIterator>(&_collection, trx);
 }
 
 /// @brief specializes the condition for use with the index
@@ -428,9 +428,9 @@ arangodb::aql::AstNode* MMFilesEdgeIndex::specializeCondition(
 }
 
 /// @brief create the iterator
-IndexIterator* MMFilesEdgeIndex::createEqIterator(transaction::Methods* trx,
-                                                  arangodb::aql::AstNode const* attrNode,
-                                                  arangodb::aql::AstNode const* valNode) const {
+std::unique_ptr<IndexIterator> MMFilesEdgeIndex::createEqIterator(transaction::Methods* trx,
+                                                                  arangodb::aql::AstNode const* attrNode,
+                                                                  arangodb::aql::AstNode const* valNode) const {
   // lease builder, but immediately pass it to the unique_ptr so we don't leak
   transaction::BuilderLeaser builder(trx);
   std::unique_ptr<VPackBuilder> keys(builder.steal());
@@ -445,15 +445,15 @@ IndexIterator* MMFilesEdgeIndex::createEqIterator(transaction::Methods* trx,
   // _from or _to?
   bool const isFrom = (attrNode->stringEquals(StaticStrings::FromString));
 
-  return new MMFilesEdgeIndexIterator(&_collection, trx, this,
-                                      isFrom ? _edgesFrom.get() : _edgesTo.get(),
-                                      std::move(keys));
+  return std::make_unique<MMFilesEdgeIndexIterator>(&_collection, trx, this,
+                                                    isFrom ? _edgesFrom.get() : _edgesTo.get(),
+                                                    std::move(keys));
 }
 
 /// @brief create the iterator
-IndexIterator* MMFilesEdgeIndex::createInIterator(transaction::Methods* trx,
-                                                  arangodb::aql::AstNode const* attrNode,
-                                                  arangodb::aql::AstNode const* valNode) const {
+std::unique_ptr<IndexIterator> MMFilesEdgeIndex::createInIterator(transaction::Methods* trx,
+                                                                  arangodb::aql::AstNode const* attrNode,
+                                                                  arangodb::aql::AstNode const* valNode) const {
   // lease builder, but immediately pass it to the unique_ptr so we don't leak
   transaction::BuilderLeaser builder(trx);
   std::unique_ptr<VPackBuilder> keys(builder.steal());
@@ -475,9 +475,9 @@ IndexIterator* MMFilesEdgeIndex::createInIterator(transaction::Methods* trx,
   // _from or _to?
   bool const isFrom = (attrNode->stringEquals(StaticStrings::FromString));
 
-  return new MMFilesEdgeIndexIterator(&_collection, trx, this,
-                                      isFrom ? _edgesFrom.get() : _edgesTo.get(),
-                                      std::move(keys));
+  return std::make_unique<MMFilesEdgeIndexIterator>(&_collection, trx, this,
+                                                    isFrom ? _edgesFrom.get() : _edgesTo.get(),
+                                                    std::move(keys));
 }
 
 /// @brief add a single value node to the iterator's keys

--- a/arangod/MMFiles/MMFilesEdgeIndex.h
+++ b/arangod/MMFiles/MMFilesEdgeIndex.h
@@ -180,28 +180,28 @@ class MMFilesEdgeIndex final : public MMFilesIndex {
 
   TRI_MMFilesEdgeIndexHash_t* to() const { return _edgesTo.get(); }
 
-  bool supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
-                               arangodb::aql::AstNode const*,
-                               arangodb::aql::Variable const*, size_t, size_t&,
-                               double&) const override;
+  Index::UsageCosts supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
+                                            arangodb::aql::AstNode const* node,
+                                            arangodb::aql::Variable const* reference, 
+                                            size_t itemsInIndex) const override;
 
-  IndexIterator* iteratorForCondition(transaction::Methods*, 
-                                      arangodb::aql::AstNode const*,
-                                      arangodb::aql::Variable const*,
-                                      IndexIteratorOptions const&) override;
+  std::unique_ptr<IndexIterator> iteratorForCondition(transaction::Methods* trx, 
+                                                      arangodb::aql::AstNode const* node,
+                                                      arangodb::aql::Variable const* reference,
+                                                      IndexIteratorOptions const& opts) override;
 
-  arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode*,
-                                              arangodb::aql::Variable const*) const override;
+  arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode* node,
+                                              arangodb::aql::Variable const* reference) const override;
 
  private:
   /// @brief create the iterator
-  IndexIterator* createEqIterator(transaction::Methods*, 
-                                  arangodb::aql::AstNode const*,
-                                  arangodb::aql::AstNode const*) const;
+  std::unique_ptr<IndexIterator> createEqIterator(transaction::Methods*, 
+                                                  arangodb::aql::AstNode const*,
+                                                  arangodb::aql::AstNode const*) const;
 
-  IndexIterator* createInIterator(transaction::Methods*, 
-                                  arangodb::aql::AstNode const*,
-                                  arangodb::aql::AstNode const*) const;
+  std::unique_ptr<IndexIterator> createInIterator(transaction::Methods*, 
+                                                  arangodb::aql::AstNode const*,
+                                                  arangodb::aql::AstNode const*) const;
 
   /// @brief add a single value node to the iterator's keys
   void handleValNode(VPackBuilder* keys, arangodb::aql::AstNode const* valNode) const;

--- a/arangod/MMFiles/MMFilesFulltextIndex.cpp
+++ b/arangod/MMFiles/MMFilesFulltextIndex.cpp
@@ -238,7 +238,7 @@ void MMFilesFulltextIndex::unload() {
   TRI_TruncateMMFilesFulltextIndex(_fulltextIndex);
 }
 
-IndexIterator* MMFilesFulltextIndex::iteratorForCondition(
+std::unique_ptr<IndexIterator> MMFilesFulltextIndex::iteratorForCondition(
     transaction::Methods* trx, aql::AstNode const* condNode,
     aql::Variable const* var, IndexIteratorOptions const& opts) {
   TRI_ASSERT(!isSorted() || opts.sorted);
@@ -274,7 +274,7 @@ IndexIterator* MMFilesFulltextIndex::iteratorForCondition(
   // note: the following call will free "ft"!
   std::set<TRI_voc_rid_t> results = TRI_QueryMMFilesFulltextIndex(_fulltextIndex, ft);
 
-  return new MMFilesFulltextIndexIterator(&_collection, trx, std::move(results));
+  return std::make_unique<MMFilesFulltextIndexIterator>(&_collection, trx, std::move(results));
 }
 
 /// @brief callback function called by the fulltext index to determine the

--- a/arangod/MMFiles/MMFilesFulltextIndex.h
+++ b/arangod/MMFiles/MMFilesFulltextIndex.h
@@ -72,10 +72,10 @@ class MMFilesFulltextIndex final : public MMFilesIndex {
   void load() override {}
   void unload() override;
 
-  IndexIterator* iteratorForCondition(transaction::Methods*, 
-                                      arangodb::aql::AstNode const*,
-                                      arangodb::aql::Variable const*,
-                                      IndexIteratorOptions const&) override final;
+  std::unique_ptr<IndexIterator> iteratorForCondition(transaction::Methods* trx, 
+                                                      arangodb::aql::AstNode const* node,
+                                                      arangodb::aql::Variable const* reference,
+                                                      IndexIteratorOptions const& opts) override final;
 
   bool isSame(std::string const& field, int minWordLength) const {
     std::string fieldString;

--- a/arangod/MMFiles/MMFilesGeoIndex.cpp
+++ b/arangod/MMFiles/MMFilesGeoIndex.cpp
@@ -364,7 +364,7 @@ Result MMFilesGeoIndex::remove(transaction::Methods& trx, LocalDocumentId const&
 }
 
 /// @brief creates an IndexIterator for the given Condition
-IndexIterator* MMFilesGeoIndex::iteratorForCondition(
+std::unique_ptr<IndexIterator> MMFilesGeoIndex::iteratorForCondition(
     transaction::Methods* trx, arangodb::aql::AstNode const* node,
     arangodb::aql::Variable const* reference, IndexIteratorOptions const& opts) {
   TRI_ASSERT(!isSorted() || opts.sorted);
@@ -396,11 +396,9 @@ IndexIterator* MMFilesGeoIndex::iteratorForCondition(
 
   // why does this have to be shit?
   if (params.ascending) {
-    return new NearIterator<geo_index::DocumentsAscending>(&_collection, trx, this,
-                                                           std::move(params));
+    return std::make_unique<NearIterator<geo_index::DocumentsAscending>>(&_collection, trx, this, std::move(params));
   } else {
-    return new NearIterator<geo_index::DocumentsDescending>(&_collection, trx, this,
-                                                            std::move(params));
+    return std::make_unique<NearIterator<geo_index::DocumentsDescending>>(&_collection, trx, this, std::move(params));
   }
 }
 

--- a/arangod/MMFiles/MMFilesGeoIndex.h
+++ b/arangod/MMFiles/MMFilesGeoIndex.h
@@ -86,10 +86,10 @@ class MMFilesGeoIndex final : public MMFilesIndex, public geo_index::Index {
   Result remove(transaction::Methods& trx, LocalDocumentId const& documentId,
                 velocypack::Slice const& doc, arangodb::Index::OperationMode mode) override;
 
-  IndexIterator* iteratorForCondition(transaction::Methods*, 
-                                      arangodb::aql::AstNode const*,
-                                      arangodb::aql::Variable const*,
-                                      IndexIteratorOptions const&) override;
+  std::unique_ptr<IndexIterator> iteratorForCondition(transaction::Methods* trx, 
+                                                      arangodb::aql::AstNode const* node,
+                                                      arangodb::aql::Variable const* reference,
+                                                      IndexIteratorOptions const& opts) override;
 
   void load() override {}
   void unload() override;

--- a/arangod/MMFiles/MMFilesHashIndex.cpp
+++ b/arangod/MMFiles/MMFilesHashIndex.cpp
@@ -845,23 +845,23 @@ int MMFilesHashIndex::removeMultiElement(transaction::Methods* trx,
 }
 
 /// @brief checks whether the index supports the condition
-bool MMFilesHashIndex::supportsFilterCondition(
+Index::UsageCosts MMFilesHashIndex::supportsFilterCondition(
     std::vector<std::shared_ptr<arangodb::Index>> const&,
     arangodb::aql::AstNode const* node, arangodb::aql::Variable const* reference,
-    size_t itemsInIndex, size_t& estimatedItems, double& estimatedCost) const {
+    size_t itemsInIndex) const {
   SimpleAttributeEqualityMatcher matcher(_fields);
-  return matcher.matchAll(this, node, reference, itemsInIndex, estimatedItems, estimatedCost);
+  return matcher.matchAll(this, node, reference, itemsInIndex);
 }
 
 /// @brief creates an IndexIterator for the given Condition
-IndexIterator* MMFilesHashIndex::iteratorForCondition(
+std::unique_ptr<IndexIterator> MMFilesHashIndex::iteratorForCondition(
     transaction::Methods* trx, arangodb::aql::AstNode const* node,
     arangodb::aql::Variable const* reference, IndexIteratorOptions const& opts) {
   TRI_ASSERT(!isSorted() || opts.sorted);
   TRI_IF_FAILURE("HashIndex::noIterator") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
-  return new MMFilesHashIndexIterator(&_collection, trx, this, node, reference);
+  return std::make_unique<MMFilesHashIndexIterator>(&_collection, trx, this, node, reference);
 }
 
 /// @brief specializes the condition for use with the index

--- a/arangod/MMFiles/MMFilesHashIndex.h
+++ b/arangod/MMFiles/MMFilesHashIndex.h
@@ -268,18 +268,18 @@ class MMFilesHashIndex final : public MMFilesPathBasedIndex {
 
   Result sizeHint(transaction::Methods& trx, size_t size) override;
 
-  bool supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
-                               arangodb::aql::AstNode const*,
-                               arangodb::aql::Variable const*, size_t, size_t&,
-                               double&) const override;
+  Index::UsageCosts supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
+                                            arangodb::aql::AstNode const* node,
+                                            arangodb::aql::Variable const* reference, 
+                                            size_t itemsInIndex) const override;
 
-  IndexIterator* iteratorForCondition(transaction::Methods*, 
-                                      arangodb::aql::AstNode const*,
-                                      arangodb::aql::Variable const*,
-                                      IndexIteratorOptions const&) override;
+  std::unique_ptr<IndexIterator> iteratorForCondition(transaction::Methods* trx, 
+                                                      arangodb::aql::AstNode const* node,
+                                                      arangodb::aql::Variable const* reference,
+                                                      IndexIteratorOptions const& opts) override;
 
-  arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode*,
-                                              arangodb::aql::Variable const*) const override;
+  arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode* node,
+                                              arangodb::aql::Variable const* reference) const override;
 
  private:
   /// @brief locates entries in the hash index given a velocypack slice

--- a/arangod/MMFiles/MMFilesIndex.h
+++ b/arangod/MMFiles/MMFilesIndex.h
@@ -26,13 +26,15 @@
 
 #include "Basics/AttributeNameParser.h"
 #include "Basics/Common.h"
+#include "Basics/Result.h"
 #include "Indexes/Index.h"
-
-#include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 class LogicalCollection;
+
+namespace velocypack {
+class Slice;
+}
 
 class MMFilesIndex : public Index {
  public:
@@ -49,6 +51,8 @@ class MMFilesIndex : public Index {
   virtual bool isHidden() const override {
     return false;  // do not generally hide MMFiles indexes
   }
+
+  virtual Result sizeHint(transaction::Methods& trx, size_t size) { return Result(); }
 
   virtual bool isPersistent() const override { return false; };
 

--- a/arangod/MMFiles/MMFilesPersistentIndex.cpp
+++ b/arangod/MMFiles/MMFilesPersistentIndex.cpp
@@ -566,9 +566,9 @@ Result MMFilesPersistentIndex::drop() {
 /// @brief attempts to locate an entry in the index
 /// Warning: who ever calls this function is responsible for destroying
 /// the MMFilesPersistentIndexIterator* results
-MMFilesPersistentIndexIterator* MMFilesPersistentIndex::lookup(transaction::Methods* trx,
-                                                               VPackSlice const searchValues,
-                                                               bool reverse) const {
+std::unique_ptr<MMFilesPersistentIndexIterator> MMFilesPersistentIndex::lookup(transaction::Methods* trx,
+                                                                               VPackSlice const searchValues,
+                                                                               bool reverse) const {
   TRI_ASSERT(searchValues.isArray());
   TRI_ASSERT(searchValues.length() <= _fields.size());
 
@@ -665,27 +665,21 @@ MMFilesPersistentIndexIterator* MMFilesPersistentIndex::lookup(transaction::Meth
   auto physical = static_cast<MMFilesCollection*>(_collection.getPhysical());
   auto idx = physical->primaryIndex();
   auto db = MMFilesPersistentIndexFeature::instance()->db();
-  return new MMFilesPersistentIndexIterator(&_collection, trx, this, idx, db,
-                                            reverse, leftBorder, rightBorder);
+  return std::make_unique<MMFilesPersistentIndexIterator>(&_collection, trx, this, idx, db,
+                                                          reverse, leftBorder, rightBorder);
 }
 
-bool MMFilesPersistentIndex::supportsFilterCondition(
+Index::UsageCosts MMFilesPersistentIndex::supportsFilterCondition(
     std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
     arangodb::aql::AstNode const* node, arangodb::aql::Variable const* reference,
-    size_t itemsInIndex, size_t& estimatedItems, double& estimatedCost) const {
-  return SortedIndexAttributeMatcher::supportsFilterCondition(allIndexes, this,
-                                                                node, reference,
-                                                                itemsInIndex, estimatedItems,
-                                                                estimatedCost);
+    size_t itemsInIndex) const {
+  return SortedIndexAttributeMatcher::supportsFilterCondition(allIndexes, this, node, reference, itemsInIndex);
 }
 
-bool MMFilesPersistentIndex::supportsSortCondition(arangodb::aql::SortCondition const* sortCondition,
-                                                   arangodb::aql::Variable const* reference,
-                                                   size_t itemsInIndex, double& estimatedCost,
-                                                   size_t& coveredAttributes) const {
-  return SortedIndexAttributeMatcher::supportsSortCondition(this, sortCondition, reference,
-                                                              itemsInIndex, estimatedCost,
-                                                              coveredAttributes);
+Index::UsageCosts MMFilesPersistentIndex::supportsSortCondition(arangodb::aql::SortCondition const* sortCondition,
+                                                                arangodb::aql::Variable const* reference,
+                                                                size_t itemsInIndex) const {
+  return SortedIndexAttributeMatcher::supportsSortCondition(this, sortCondition, reference, itemsInIndex);
 }
 
 /// @brief specializes the condition for use with the index
@@ -694,7 +688,7 @@ arangodb::aql::AstNode* MMFilesPersistentIndex::specializeCondition(
   return SortedIndexAttributeMatcher::specializeCondition(this, node, reference);
 }
 
-IndexIterator* MMFilesPersistentIndex::iteratorForCondition(
+std::unique_ptr<IndexIterator> MMFilesPersistentIndex::iteratorForCondition(
     transaction::Methods* trx, arangodb::aql::AstNode const* node,
     arangodb::aql::Variable const* reference, IndexIteratorOptions const& opts) {
   TRI_ASSERT(!isSorted() || opts.sorted);
@@ -851,28 +845,14 @@ IndexIterator* MMFilesPersistentIndex::iteratorForCondition(
     VPackBuilder expandedSearchValues;
     expandInSearchValues(searchValues.slice(), expandedSearchValues);
     VPackSlice expandedSlice = expandedSearchValues.slice();
-    std::vector<IndexIterator*> iterators;
-    try {
-      for (VPackSlice val : VPackArrayIterator(expandedSlice)) {
-        auto iterator = lookup(trx, val, !opts.ascending);
-        try {
-          iterators.push_back(iterator);
-        } catch (...) {
-          // avoid leak
-          delete iterator;
-          throw;
-        }
-      }
-      if (!opts.ascending) {
-        std::reverse(iterators.begin(), iterators.end());
-      }
-    } catch (...) {
-      for (auto& it : iterators) {
-        delete it;
-      }
-      throw;
+    std::vector<std::unique_ptr<IndexIterator>> iterators;
+    for (VPackSlice val : VPackArrayIterator(expandedSlice)) {
+      iterators.push_back(lookup(trx, val, !opts.ascending));
     }
-    return new MultiIndexIterator(&_collection, trx, this, iterators);
+    if (!opts.ascending) {
+      std::reverse(iterators.begin(), iterators.end());
+    }
+    return std::make_unique<MultiIndexIterator>(&_collection, trx, this, std::move(iterators));
   }
 
   VPackSlice searchSlice = searchValues.slice();

--- a/arangod/MMFiles/MMFilesPersistentIndex.h
+++ b/arangod/MMFiles/MMFilesPersistentIndex.h
@@ -157,29 +157,26 @@ class MMFilesPersistentIndex final : public MMFilesPathBasedIndex {
   Result drop() override;
 
   /// @brief attempts to locate an entry in the index
-  ///
-  /// Warning: who ever calls this function is responsible for destroying
-  /// the velocypack::Slice and the MMFilesPersistentIndexIterator* results
-  MMFilesPersistentIndexIterator* lookup(transaction::Methods*,
-                                         arangodb::velocypack::Slice const,
-                                         bool reverse) const;
+  std::unique_ptr<MMFilesPersistentIndexIterator> lookup(transaction::Methods*,
+                                                         arangodb::velocypack::Slice const,
+                                                         bool reverse) const;
 
-  bool supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
-                               arangodb::aql::AstNode const*,
-                               arangodb::aql::Variable const*, size_t, size_t&,
-                               double&) const override;
+  Index::UsageCosts supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
+                                            arangodb::aql::AstNode const* node,
+                                            arangodb::aql::Variable const* reference, 
+                                            size_t itemsInIndex) const override;
 
-  bool supportsSortCondition(arangodb::aql::SortCondition const*,
-                             arangodb::aql::Variable const*, size_t, double&,
-                             size_t&) const override;
+  Index::UsageCosts supportsSortCondition(arangodb::aql::SortCondition const* sortCondition,
+                                          arangodb::aql::Variable const* reference, 
+                                          size_t itemsInIndex) const override;
 
-  IndexIterator* iteratorForCondition(transaction::Methods*, 
-                                      arangodb::aql::AstNode const*,
-                                      arangodb::aql::Variable const*,
-                                      IndexIteratorOptions const&) override;
+  std::unique_ptr<IndexIterator> iteratorForCondition(transaction::Methods* trx,  
+                                                      arangodb::aql::AstNode const* node,
+                                                      arangodb::aql::Variable const* reference,
+                                                      IndexIteratorOptions const& opts) override;
 
-  arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode*,
-                                              arangodb::aql::Variable const*) const override;
+  arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode* node,
+                                              arangodb::aql::Variable const* reference) const override;
 };
 
 }  // namespace arangodb

--- a/arangod/MMFiles/MMFilesPrimaryIndex.cpp
+++ b/arangod/MMFiles/MMFilesPrimaryIndex.cpp
@@ -449,16 +449,16 @@ void MMFilesPrimaryIndex::invokeOnAllElementsForRemoval(
 }
 
 /// @brief checks whether the index supports the condition
-bool MMFilesPrimaryIndex::supportsFilterCondition(
+Index::UsageCosts MMFilesPrimaryIndex::supportsFilterCondition(
     std::vector<std::shared_ptr<arangodb::Index>> const&,
     arangodb::aql::AstNode const* node, arangodb::aql::Variable const* reference,
-    size_t itemsInIndex, size_t& estimatedItems, double& estimatedCost) const {
+    size_t itemsInIndex) const {
   SimpleAttributeEqualityMatcher matcher(IndexAttributes);
-  return matcher.matchOne(this, node, reference, itemsInIndex, estimatedItems, estimatedCost);
+  return matcher.matchOne(this, node, reference, itemsInIndex);
 }
 
-/// @brief creates an IndexIterator for the given Condition
-IndexIterator* MMFilesPrimaryIndex::iteratorForCondition(
+/// @brief creates an IndexIterator for the given condition
+std::unique_ptr<IndexIterator> MMFilesPrimaryIndex::iteratorForCondition(
     transaction::Methods* trx, arangodb::aql::AstNode const* node,
     arangodb::aql::Variable const* reference, IndexIteratorOptions const& opts) {
   TRI_ASSERT(!isSorted() || opts.sorted);
@@ -483,7 +483,7 @@ IndexIterator* MMFilesPrimaryIndex::iteratorForCondition(
   }
 
   // operator type unsupported or IN used on non-array
-  return new EmptyIndexIterator(&_collection, trx);
+  return std::make_unique<EmptyIndexIterator>(&_collection, trx);
 }
 
 /// @brief specializes the condition for use with the index
@@ -494,9 +494,9 @@ arangodb::aql::AstNode* MMFilesPrimaryIndex::specializeCondition(
 }
 
 /// @brief create the iterator, for a single attribute, IN operator
-IndexIterator* MMFilesPrimaryIndex::createInIterator(transaction::Methods* trx,
-                                                     arangodb::aql::AstNode const* attrNode,
-                                                     arangodb::aql::AstNode const* valNode) const {
+std::unique_ptr<IndexIterator> MMFilesPrimaryIndex::createInIterator(transaction::Methods* trx,
+                                                                     arangodb::aql::AstNode const* attrNode,
+                                                                     arangodb::aql::AstNode const* valNode) const {
   // _key or _id?
   bool const isId = (attrNode->stringEquals(StaticStrings::IdString));
 
@@ -523,13 +523,13 @@ IndexIterator* MMFilesPrimaryIndex::createInIterator(transaction::Methods* trx,
 
   keys->close();
 
-  return new MMFilesPrimaryIndexInIterator(&_collection, trx, this, std::move(keys));
+  return std::make_unique<MMFilesPrimaryIndexInIterator>(&_collection, trx, this, std::move(keys));
 }
 
 /// @brief create the iterator, for a single attribute, EQ operator
-IndexIterator* MMFilesPrimaryIndex::createEqIterator(transaction::Methods* trx,
-                                                     arangodb::aql::AstNode const* attrNode,
-                                                     arangodb::aql::AstNode const* valNode) const {
+std::unique_ptr<IndexIterator> MMFilesPrimaryIndex::createEqIterator(transaction::Methods* trx,
+                                                                     arangodb::aql::AstNode const* attrNode,
+                                                                     arangodb::aql::AstNode const* valNode) const {
   // _key or _id?
   bool const isId = (attrNode->stringEquals(StaticStrings::IdString));
 
@@ -545,10 +545,10 @@ IndexIterator* MMFilesPrimaryIndex::createEqIterator(transaction::Methods* trx,
   }
 
   if (!key->isEmpty()) {
-    return new MMFilesPrimaryIndexEqIterator(&_collection, trx, this, std::move(key));
+    return std::make_unique<MMFilesPrimaryIndexEqIterator>(&_collection, trx, this, std::move(key));
   }
 
-  return new EmptyIndexIterator(&_collection, trx);
+  return std::make_unique<EmptyIndexIterator>(&_collection, trx);
 }
 
 /// @brief add a single value node to the iterator's keys

--- a/arangod/MMFiles/MMFilesPrimaryIndex.h
+++ b/arangod/MMFiles/MMFilesPrimaryIndex.h
@@ -269,27 +269,27 @@ class MMFilesPrimaryIndex final : public MMFilesIndex {
   void invokeOnAllElements(std::function<bool(LocalDocumentId const&)>);
   void invokeOnAllElementsForRemoval(std::function<bool(MMFilesSimpleIndexElement const&)>);
 
-  bool supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
-                               arangodb::aql::AstNode const*,
-                               arangodb::aql::Variable const*, size_t, size_t&,
-                               double&) const override;
+  Index::UsageCosts supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
+                                            arangodb::aql::AstNode const* node,
+                                            arangodb::aql::Variable const* reference, 
+                                            size_t itemsInIndex) const override;
 
-  IndexIterator* iteratorForCondition(transaction::Methods*, 
-                                      arangodb::aql::AstNode const*,
-                                      arangodb::aql::Variable const*,
-                                      IndexIteratorOptions const&) override;
+  std::unique_ptr<IndexIterator> iteratorForCondition(transaction::Methods* trx, 
+                                                      arangodb::aql::AstNode const* node,
+                                                      arangodb::aql::Variable const* reference,
+                                                      IndexIteratorOptions const& opts) override;
 
-  arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode*,
-                                              arangodb::aql::Variable const*) const override;
+  arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode* node,
+                                              arangodb::aql::Variable const* reference) const override;
 
  private:
   /// @brief create the iterator, for a single attribute, IN operator
-  IndexIterator* createInIterator(transaction::Methods*, arangodb::aql::AstNode const*,
-                                  arangodb::aql::AstNode const*) const;
+  std::unique_ptr<IndexIterator> createInIterator(transaction::Methods*, arangodb::aql::AstNode const*,
+                                                  arangodb::aql::AstNode const*) const;
 
   /// @brief create the iterator, for a single attribute, EQ operator
-  IndexIterator* createEqIterator(transaction::Methods*, arangodb::aql::AstNode const*,
-                                  arangodb::aql::AstNode const*) const;
+  std::unique_ptr<IndexIterator> createEqIterator(transaction::Methods*, arangodb::aql::AstNode const*,
+                                                  arangodb::aql::AstNode const*) const;
 
   /// @brief add a single value node to the iterator's keys
   void handleValNode(transaction::Methods* trx, VPackBuilder* keys,

--- a/arangod/MMFiles/MMFilesSkiplistIndex.cpp
+++ b/arangod/MMFiles/MMFilesSkiplistIndex.cpp
@@ -1136,7 +1136,7 @@ bool MMFilesSkiplistIndex::findMatchingConditions(
   return true;
 }
 
-IndexIterator* MMFilesSkiplistIndex::iteratorForCondition(
+std::unique_ptr<IndexIterator> MMFilesSkiplistIndex::iteratorForCondition(
     transaction::Methods* trx, 
     arangodb::aql::AstNode const* node,
     arangodb::aql::Variable const* reference, IndexIteratorOptions const& opts) {
@@ -1148,7 +1148,7 @@ IndexIterator* MMFilesSkiplistIndex::iteratorForCondition(
                                      // will have _fields many entries.
     TRI_ASSERT(mapping.size() == _fields.size());
     if (!findMatchingConditions(node, reference, mapping, usesIn)) {
-      return new EmptyIndexIterator(&_collection, trx);
+      return std::make_unique<EmptyIndexIterator>(&_collection, trx);
     }
   } else {
     TRI_IF_FAILURE("SkiplistIndex::noSortIterator") {
@@ -1164,7 +1164,7 @@ IndexIterator* MMFilesSkiplistIndex::iteratorForCondition(
     auto builder = std::make_unique<MMFilesSkiplistInLookupBuilder>(trx, mapping, reference,
                                                                     !opts.ascending);
 
-    return new MMFilesSkiplistIterator(&_collection, trx, this,
+    return std::make_unique<MMFilesSkiplistIterator>(&_collection, trx, this,
                                        _skiplistIndex, numPaths(), CmpElmElm,
                                        !opts.ascending, builder.release());
   }
@@ -1172,28 +1172,24 @@ IndexIterator* MMFilesSkiplistIndex::iteratorForCondition(
   auto builder = std::make_unique<MMFilesSkiplistLookupBuilder>(trx, mapping, reference,
                                                                 !opts.ascending);
 
-  return new MMFilesSkiplistIterator(&_collection, trx, this,
+  return std::make_unique<MMFilesSkiplistIterator>(&_collection, trx, this,
                                      _skiplistIndex, numPaths(), CmpElmElm,
                                      !opts.ascending, builder.release());
 }
 
-bool MMFilesSkiplistIndex::supportsFilterCondition(
+Index::UsageCosts MMFilesSkiplistIndex::supportsFilterCondition(
     std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
     arangodb::aql::AstNode const* node, arangodb::aql::Variable const* reference,
-    size_t itemsInIndex, size_t& estimatedItems, double& estimatedCost) const {
+    size_t itemsInIndex) const {
   return SortedIndexAttributeMatcher::supportsFilterCondition(allIndexes, this,
                                                                 node, reference,
-                                                                itemsInIndex, estimatedItems,
-                                                                estimatedCost);
+                                                                itemsInIndex);
 }
 
-bool MMFilesSkiplistIndex::supportsSortCondition(arangodb::aql::SortCondition const* sortCondition,
-                                                 arangodb::aql::Variable const* reference,
-                                                 size_t itemsInIndex, double& estimatedCost,
-                                                 size_t& coveredAttributes) const {
-  return SortedIndexAttributeMatcher::supportsSortCondition(this, sortCondition, reference,
-                                                              itemsInIndex, estimatedCost,
-                                                              coveredAttributes);
+Index::UsageCosts MMFilesSkiplistIndex::supportsSortCondition(arangodb::aql::SortCondition const* sortCondition,
+                                                              arangodb::aql::Variable const* reference,
+                                                              size_t itemsInIndex) const {
+  return SortedIndexAttributeMatcher::supportsSortCondition(this, sortCondition, reference, itemsInIndex);
 }
 
 /// @brief specializes the condition for use with the index

--- a/arangod/MMFiles/MMFilesSkiplistIndex.h
+++ b/arangod/MMFiles/MMFilesSkiplistIndex.h
@@ -285,22 +285,22 @@ class MMFilesSkiplistIndex : public MMFilesPathBasedIndex {
 
   void unload() override;
 
-  bool supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
-                               arangodb::aql::AstNode const*,
-                               arangodb::aql::Variable const*, size_t, size_t&,
-                               double&) const override;
+  Index::UsageCosts supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
+                                            arangodb::aql::AstNode const* node,
+                                            arangodb::aql::Variable const* reference, 
+                                            size_t itemsInIndex) const override;
 
-  bool supportsSortCondition(arangodb::aql::SortCondition const*,
-                             arangodb::aql::Variable const*, size_t, double&,
-                             size_t&) const override;
+  Index::UsageCosts supportsSortCondition(arangodb::aql::SortCondition const* sortCondition,
+                                          arangodb::aql::Variable const* reference, 
+                                          size_t itemsInindex) const override;
 
-  IndexIterator* iteratorForCondition(transaction::Methods*, 
-                                      arangodb::aql::AstNode const*,
-                                      arangodb::aql::Variable const*,
-                                      IndexIteratorOptions const&) override;
+  std::unique_ptr<IndexIterator> iteratorForCondition(transaction::Methods* trx, 
+                                                      arangodb::aql::AstNode const* node,
+                                                      arangodb::aql::Variable const* reference,
+                                                      IndexIteratorOptions const& opts) override;
 
-  arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode*,
-                                              arangodb::aql::Variable const*) const override;
+  arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode* node,
+                                              arangodb::aql::Variable const* reference) const override;
 
  private:
   bool accessFitsIndex(arangodb::aql::AstNode const*, arangodb::aql::AstNode const*,

--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.h
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.h
@@ -109,14 +109,6 @@ class RocksDBBuilderIndex final : public arangodb::RocksDBIndex {
   /// @param locker locks and unlocks the collection
   Result fillIndexBackground(Locker& locker);
 
-  virtual IndexIterator* iteratorForCondition(transaction::Methods* trx,
-                                              aql::AstNode const* condNode,
-                                              aql::Variable const* var,
-                                              IndexIteratorOptions const& opts) override {
-    TRI_ASSERT(false);
-    return nullptr;
-  }
-
  private:
   std::shared_ptr<arangodb::RocksDBIndex> _wrapped;
 };

--- a/arangod/RocksDBEngine/RocksDBComparator.cpp
+++ b/arangod/RocksDBEngine/RocksDBComparator.cpp
@@ -29,6 +29,7 @@
 #include "RocksDBEngine/RocksDBTypes.h"
 
 #include <velocypack/Iterator.h>
+#include <velocypack/Slice.h>
 #include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;

--- a/arangod/RocksDBEngine/RocksDBComparator.h
+++ b/arangod/RocksDBEngine/RocksDBComparator.h
@@ -34,7 +34,7 @@ namespace arangodb {
 
 class RocksDBVPackComparator final : public rocksdb::Comparator {
  public:
-  RocksDBVPackComparator();
+  RocksDBVPackComparator() = default;
   ~RocksDBVPackComparator() = default;
 
   /// @brief Compares any two RocksDB keys.

--- a/arangod/RocksDBEngine/RocksDBComparator.h
+++ b/arangod/RocksDBEngine/RocksDBComparator.h
@@ -30,14 +30,11 @@
 #include <rocksdb/comparator.h>
 #include <rocksdb/slice.h>
 
-#include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
-
 namespace arangodb {
 
 class RocksDBVPackComparator final : public rocksdb::Comparator {
  public:
-  RocksDBVPackComparator() = default;
+  RocksDBVPackComparator();
   ~RocksDBVPackComparator() = default;
 
   /// @brief Compares any two RocksDB keys.

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
@@ -519,16 +519,16 @@ Result RocksDBEdgeIndex::remove(transaction::Methods& trx, RocksDBMethods* mthd,
 }
 
 /// @brief checks whether the index supports the condition
-bool RocksDBEdgeIndex::supportsFilterCondition(
+Index::UsageCosts RocksDBEdgeIndex::supportsFilterCondition(
     std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
     arangodb::aql::AstNode const* node, arangodb::aql::Variable const* reference,
-    size_t itemsInIndex, size_t& estimatedItems, double& estimatedCost) const {
+    size_t itemsInIndex) const {
   SimpleAttributeEqualityMatcher matcher(this->_fields);
-  return matcher.matchOne(this, node, reference, itemsInIndex, estimatedItems, estimatedCost);
+  return matcher.matchOne(this, node, reference, itemsInIndex);
 }
 
 /// @brief creates an IndexIterator for the given Condition
-IndexIterator* RocksDBEdgeIndex::iteratorForCondition(
+std::unique_ptr<IndexIterator> RocksDBEdgeIndex::iteratorForCondition(
     transaction::Methods* trx, arangodb::aql::AstNode const* node,
     arangodb::aql::Variable const* reference, IndexIteratorOptions const& opts) {
   TRI_ASSERT(!isSorted() || opts.sorted);
@@ -554,7 +554,7 @@ IndexIterator* RocksDBEdgeIndex::iteratorForCondition(
   }
 
   // operator type unsupported
-  return new EmptyIndexIterator(&_collection, trx);
+  return std::make_unique<EmptyIndexIterator>(&_collection, trx);
 }
 
 /// @brief specializes the condition for use with the index
@@ -824,27 +824,27 @@ void RocksDBEdgeIndex::warmupInternal(transaction::Methods* trx, rocksdb::Slice 
 // ===================== Helpers ==================
 
 /// @brief create the iterator
-IndexIterator* RocksDBEdgeIndex::createEqIterator(transaction::Methods* trx,
-                                                  arangodb::aql::AstNode const* attrNode,
-                                                  arangodb::aql::AstNode const* valNode) const {
+std::unique_ptr<IndexIterator> RocksDBEdgeIndex::createEqIterator(transaction::Methods* trx,
+                                                                  arangodb::aql::AstNode const* attrNode,
+                                                                  arangodb::aql::AstNode const* valNode) const {
   // lease builder, but immediately pass it to the unique_ptr so we don't leak
   transaction::BuilderLeaser builder(trx);
   std::unique_ptr<VPackBuilder> keys(builder.steal());
 
   fillLookupValue(*(keys.get()), valNode);
-  return new RocksDBEdgeIndexLookupIterator(&_collection, trx, this, std::move(keys), _cache);
+  return std::make_unique<RocksDBEdgeIndexLookupIterator>(&_collection, trx, this, std::move(keys), _cache);
 }
 
 /// @brief create the iterator
-IndexIterator* RocksDBEdgeIndex::createInIterator(transaction::Methods* trx,
-                                                  arangodb::aql::AstNode const* attrNode,
-                                                  arangodb::aql::AstNode const* valNode) const {
+std::unique_ptr<IndexIterator> RocksDBEdgeIndex::createInIterator(transaction::Methods* trx,
+                                                                  arangodb::aql::AstNode const* attrNode,
+                                                                  arangodb::aql::AstNode const* valNode) const {
   // lease builder, but immediately pass it to the unique_ptr so we don't leak
   transaction::BuilderLeaser builder(trx);
   std::unique_ptr<VPackBuilder> keys(builder.steal());
 
   fillInLookupValues(trx, *(keys.get()), valNode);
-  return new RocksDBEdgeIndexLookupIterator(&_collection, trx, this, std::move(keys), _cache);
+  return std::make_unique<RocksDBEdgeIndexLookupIterator>(&_collection, trx, this, std::move(keys), _cache);
 }
 
 void RocksDBEdgeIndex::fillLookupValue(VPackBuilder& keys,

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.h
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.h
@@ -92,18 +92,18 @@ class RocksDBEdgeIndex final : public RocksDBIndex {
 
   void toVelocyPack(VPackBuilder&, std::underlying_type<Index::Serialize>::type) const override;
 
-  bool supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
-                               arangodb::aql::AstNode const*,
-                               arangodb::aql::Variable const*, size_t, size_t&,
-                               double&) const override;
+  Index::UsageCosts supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
+                                            arangodb::aql::AstNode const* node,
+                                            arangodb::aql::Variable const* reference,
+                                            size_t itemsInIndex) const override;
 
-  IndexIterator* iteratorForCondition(transaction::Methods*, 
-                                      arangodb::aql::AstNode const*,
-                                      arangodb::aql::Variable const*,
-                                      IndexIteratorOptions const&) override;
+  std::unique_ptr<IndexIterator> iteratorForCondition(transaction::Methods* trx, 
+                                                      arangodb::aql::AstNode const* node,
+                                                      arangodb::aql::Variable const* reference,
+                                                      IndexIteratorOptions const& opts) override;
 
-  arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode*,
-                                              arangodb::aql::Variable const*) const override;
+  arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode* node,
+                                              arangodb::aql::Variable const* reference) const override;
 
   /// @brief Warmup the index caches.
   void warmup(arangodb::transaction::Methods* trx,
@@ -121,11 +121,11 @@ class RocksDBEdgeIndex final : public RocksDBIndex {
 
  private:
   /// @brief create the iterator
-  IndexIterator* createEqIterator(transaction::Methods*, arangodb::aql::AstNode const*,
-                                  arangodb::aql::AstNode const*) const;
+  std::unique_ptr<IndexIterator> createEqIterator(transaction::Methods*, arangodb::aql::AstNode const*,
+                                                  arangodb::aql::AstNode const*) const;
 
-  IndexIterator* createInIterator(transaction::Methods*, arangodb::aql::AstNode const*,
-                                  arangodb::aql::AstNode const*) const;
+  std::unique_ptr<IndexIterator> createInIterator(transaction::Methods*, arangodb::aql::AstNode const*,
+                                                  arangodb::aql::AstNode const*) const;
 
   /// @brief populate the keys builder with a single (string) lookup value
   void fillLookupValue(arangodb::velocypack::Builder& keys,

--- a/arangod/RocksDBEngine/RocksDBFulltextIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBFulltextIndex.cpp
@@ -495,7 +495,7 @@ Result RocksDBFulltextIndex::applyQueryToken(transaction::Methods* trx,
   return Result();
 }
 
-IndexIterator* RocksDBFulltextIndex::iteratorForCondition(
+std::unique_ptr<IndexIterator> RocksDBFulltextIndex::iteratorForCondition(
     transaction::Methods* trx, aql::AstNode const* condNode,
     aql::Variable const* var, IndexIteratorOptions const& opts) {
   TRI_ASSERT(!isSorted() || opts.sorted);
@@ -527,5 +527,5 @@ IndexIterator* RocksDBFulltextIndex::iteratorForCondition(
     THROW_ARANGO_EXCEPTION(res);
   }
 
-  return new RocksDBFulltextIndexIterator(&_collection, trx, std::move(results));
+  return std::make_unique<RocksDBFulltextIndexIterator>(&_collection, trx, std::move(results));
 }

--- a/arangod/RocksDBEngine/RocksDBFulltextIndex.h
+++ b/arangod/RocksDBEngine/RocksDBFulltextIndex.h
@@ -81,9 +81,10 @@ class RocksDBFulltextIndex final : public RocksDBIndex {
     return (_minWordLength == minWordLength && fieldString == field);
   }
 
-  IndexIterator* iteratorForCondition(transaction::Methods* trx, 
-                                      aql::AstNode const* condNode, aql::Variable const* var,
-                                      IndexIteratorOptions const&) override;
+  std::unique_ptr<IndexIterator> iteratorForCondition(transaction::Methods* trx, 
+                                                      aql::AstNode const* node, 
+                                                      aql::Variable const* reference,
+                                                      IndexIteratorOptions const& opts) override;
 
   arangodb::Result parseQueryString(std::string const&, FulltextQuery&);
   Result executeQuery(transaction::Methods* trx, FulltextQuery const& query,

--- a/arangod/RocksDBEngine/RocksDBGeoIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBGeoIndex.cpp
@@ -332,7 +332,7 @@ bool RocksDBGeoIndex::matchesDefinition(VPackSlice const& info) const {
 }
 
 /// @brief creates an IndexIterator for the given Condition
-IndexIterator* RocksDBGeoIndex::iteratorForCondition(
+std::unique_ptr<IndexIterator> RocksDBGeoIndex::iteratorForCondition(
     transaction::Methods* trx, arangodb::aql::AstNode const* node,
     arangodb::aql::Variable const* reference, IndexIteratorOptions const& opts) {
   TRI_ASSERT(!isSorted() || opts.sorted);
@@ -363,11 +363,9 @@ IndexIterator* RocksDBGeoIndex::iteratorForCondition(
   }
 
   if (params.ascending) {
-    return new RDBNearIterator<geo_index::DocumentsAscending>(&_collection, trx, this,
-                                                              std::move(params));
+    return std::make_unique<RDBNearIterator<geo_index::DocumentsAscending>>(&_collection, trx, this, std::move(params));
   } else {
-    return new RDBNearIterator<geo_index::DocumentsDescending>(&_collection, trx, this,
-                                                               std::move(params));
+    return std::make_unique<RDBNearIterator<geo_index::DocumentsDescending>>(&_collection, trx, this, std::move(params));
   }
 }
 

--- a/arangod/RocksDBEngine/RocksDBGeoIndex.h
+++ b/arangod/RocksDBEngine/RocksDBGeoIndex.h
@@ -55,10 +55,10 @@ class RocksDBGeoIndex final : public RocksDBIndex, public geo_index::Index {
 
   char const* typeName() const override { return _typeName.c_str(); }
 
-  IndexIterator* iteratorForCondition(transaction::Methods*, 
-                                      arangodb::aql::AstNode const*,
-                                      arangodb::aql::Variable const*,
-                                      IndexIteratorOptions const&) override;
+  std::unique_ptr<IndexIterator> iteratorForCondition(transaction::Methods* trx, 
+                                                      arangodb::aql::AstNode const* node,
+                                                      arangodb::aql::Variable const* reference,
+                                                      IndexIteratorOptions const& opts) override;
 
   bool canBeDropped() const override { return true; }
 

--- a/arangod/RocksDBEngine/RocksDBIndex.h
+++ b/arangod/RocksDBEngine/RocksDBIndex.h
@@ -79,12 +79,6 @@ class RocksDBIndex : public Index {
   /// compact the index, should reduce read amplification
   void compact();
 
-  /// @brief provides a size hint for the index
-  Result sizeHint(transaction::Methods& /*trx*/, size_t /*size*/
-                  ) override final {
-    return Result();  // nothing to do here
-  }
-
   void setCacheEnabled(bool enable) {
     // allow disabling and enabling of caches for the primary index
     _cacheEnabled = enable;

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
@@ -669,10 +669,10 @@ Result RocksDBPrimaryIndex::remove(transaction::Methods& trx, RocksDBMethods* mt
 }
 
 /// @brief checks whether the index supports the condition
-bool RocksDBPrimaryIndex::supportsFilterCondition(
+Index::UsageCosts RocksDBPrimaryIndex::supportsFilterCondition(
     std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
     arangodb::aql::AstNode const* node, arangodb::aql::Variable const* reference,
-    size_t itemsInIndex, size_t& estimatedItems, double& estimatedCost) const {
+    size_t itemsInIndex) const {
   std::unordered_map<size_t, std::vector<arangodb::aql::AstNode const*>> found;
   std::unordered_set<std::string> nonNullAttributes;
 
@@ -680,28 +680,29 @@ bool RocksDBPrimaryIndex::supportsFilterCondition(
   SortedIndexAttributeMatcher::matchAttributes(this, node, reference, found,
                                                values, nonNullAttributes,
                                                /*skip evaluation (during execution)*/ false);
-  estimatedItems = values;
-  return !found.empty();
+
+  Index::UsageCosts costs;
+  costs.estimatedItems = values;
+  // TODO: estimatedCost??
+  costs.supportsCondition = !found.empty();
+  return costs;
 }
 
-bool RocksDBPrimaryIndex::supportsSortCondition(arangodb::aql::SortCondition const* sortCondition,
-                                                arangodb::aql::Variable const* reference,
-                                                size_t itemsInIndex, double& estimatedCost,
-                                                size_t& coveredAttributes) const {
-  return SortedIndexAttributeMatcher::supportsSortCondition(this, sortCondition, reference,
-                                                            itemsInIndex, estimatedCost,
-                                                            coveredAttributes);
+Index::UsageCosts RocksDBPrimaryIndex::supportsSortCondition(arangodb::aql::SortCondition const* sortCondition,
+                                                             arangodb::aql::Variable const* reference,
+                                                             size_t itemsInIndex) const {
+  return SortedIndexAttributeMatcher::supportsSortCondition(this, sortCondition, reference, itemsInIndex);
 }
 
 /// @brief creates an IndexIterator for the given Condition
-IndexIterator* RocksDBPrimaryIndex::iteratorForCondition(
+std::unique_ptr<IndexIterator> RocksDBPrimaryIndex::iteratorForCondition(
     transaction::Methods* trx, arangodb::aql::AstNode const* node,
     arangodb::aql::Variable const* reference, IndexIteratorOptions const& opts) {
 
   TRI_ASSERT(!isSorted() || opts.sorted);
   if (node == nullptr) {
     // full range scan
-    return new RocksDBPrimaryIndexRangeIterator(
+    return std::make_unique<RocksDBPrimaryIndexRangeIterator>(
         &_collection /*logical collection*/, trx, this, !opts.ascending /*reverse*/,
         RocksDBKeyBounds::PrimaryIndex(_objectId, ::lowest, ::highest), opts.forceProjection);
   }
@@ -775,7 +776,7 @@ IndexIterator* RocksDBPrimaryIndex::iteratorForCondition(
     if (!(type == aql::NODE_TYPE_OPERATOR_BINARY_LE || type == aql::NODE_TYPE_OPERATOR_BINARY_LT ||
           type == aql::NODE_TYPE_OPERATOR_BINARY_GE || type == aql::NODE_TYPE_OPERATOR_BINARY_GT ||
           type == aql::NODE_TYPE_OPERATOR_BINARY_EQ)) {
-      return new EmptyIndexIterator(&_collection, trx);
+      return std::make_unique<EmptyIndexIterator>(&_collection, trx);
     }
 
     TRI_ASSERT(aap.attribute->type == aql::NODE_TYPE_ATTRIBUTE_ACCESS);
@@ -804,7 +805,7 @@ IndexIterator* RocksDBPrimaryIndex::iteratorForCondition(
     if (type == aql::NODE_TYPE_OPERATOR_BINARY_EQ) {
       if (cmpResult != 0) {
         // doc._id == different collection
-        return new EmptyIndexIterator(&_collection, trx);
+        return std::make_unique<EmptyIndexIterator>(&_collection, trx);
       }
       if (!upperFound || value < upper) {
         upper = value;
@@ -822,7 +823,7 @@ IndexIterator* RocksDBPrimaryIndex::iteratorForCondition(
         upper = ::highest;
       } else if (cmpResult < 0) {
         // doc._id < collection with "lower" name
-        return new EmptyIndexIterator(&_collection, trx);
+        return std::make_unique<EmptyIndexIterator>(&_collection, trx);
       } else {
         if (type == aql::NODE_TYPE_OPERATOR_BINARY_LT && !value.empty()) {
           value.back() -= 0x01U;  // modify upper bound so that it is not included
@@ -840,7 +841,7 @@ IndexIterator* RocksDBPrimaryIndex::iteratorForCondition(
         lower = ::lowest;
       } else if (cmpResult > 0) {
         // doc._id > collection with "bigger" name
-        return new EmptyIndexIterator(&_collection, trx);
+        return std::make_unique<EmptyIndexIterator>(&_collection, trx);
       } else {
         if (type == aql::NODE_TYPE_OPERATOR_BINARY_GE && !value.empty()) {
           value.back() -= 0x01U;  // modify lower bound so it is included
@@ -863,13 +864,13 @@ IndexIterator* RocksDBPrimaryIndex::iteratorForCondition(
   }
 
   if (lowerFound && upperFound) {
-    return new RocksDBPrimaryIndexRangeIterator(
+    return std::make_unique<RocksDBPrimaryIndexRangeIterator>(
         &_collection /*logical collection*/, trx, this, !opts.ascending /*reverse*/,
         RocksDBKeyBounds::PrimaryIndex(_objectId, lower, upper), opts.forceProjection);
   }
 
   // operator type unsupported or IN used on non-array
-  return new EmptyIndexIterator(&_collection, trx);
+  return std::make_unique<EmptyIndexIterator>(&_collection, trx);
 }
 
 /// @brief specializes the condition for use with the index
@@ -879,10 +880,10 @@ arangodb::aql::AstNode* RocksDBPrimaryIndex::specializeCondition(
 }
 
 /// @brief create the iterator, for a single attribute, IN operator
-IndexIterator* RocksDBPrimaryIndex::createInIterator(transaction::Methods* trx,
-                                                     arangodb::aql::AstNode const* attrNode,
-                                                     arangodb::aql::AstNode const* valNode,
-                                                     bool ascending) {
+std::unique_ptr<IndexIterator> RocksDBPrimaryIndex::createInIterator(transaction::Methods* trx,
+                                                                     arangodb::aql::AstNode const* attrNode,
+                                                                     arangodb::aql::AstNode const* valNode,
+                                                                     bool ascending) {
   // _key or _id?
   bool const isId = (attrNode->stringEquals(StaticStrings::IdString));
 
@@ -893,13 +894,13 @@ IndexIterator* RocksDBPrimaryIndex::createInIterator(transaction::Methods* trx,
   std::unique_ptr<VPackBuilder> keys(builder.steal());
 
   fillInLookupValues(trx, *(keys.get()), valNode, ascending, isId);
-  return new RocksDBPrimaryIndexInIterator(&_collection, trx, this, std::move(keys), !isId);
+  return std::make_unique<RocksDBPrimaryIndexInIterator>(&_collection, trx, this, std::move(keys), !isId);
 }
 
 /// @brief create the iterator, for a single attribute, EQ operator
-IndexIterator* RocksDBPrimaryIndex::createEqIterator(transaction::Methods* trx,
-                                                     arangodb::aql::AstNode const* attrNode,
-                                                     arangodb::aql::AstNode const* valNode) {
+std::unique_ptr<IndexIterator> RocksDBPrimaryIndex::createEqIterator(transaction::Methods* trx,
+                                                                     arangodb::aql::AstNode const* attrNode,
+                                                                     arangodb::aql::AstNode const* valNode) {
   // _key or _id?
   bool const isId = (attrNode->stringEquals(StaticStrings::IdString));
 
@@ -915,10 +916,10 @@ IndexIterator* RocksDBPrimaryIndex::createEqIterator(transaction::Methods* trx,
   }
 
   if (!key->isEmpty()) {
-    return new RocksDBPrimaryIndexEqIterator(&_collection, trx, this, std::move(key), !isId);
+    return std::make_unique<RocksDBPrimaryIndexEqIterator>(&_collection, trx, this, std::move(key), !isId);
   }
 
-  return new EmptyIndexIterator(&_collection, trx);
+  return std::make_unique<EmptyIndexIterator>(&_collection, trx);
 }
 
 void RocksDBPrimaryIndex::fillInLookupValues(transaction::Methods* trx, VPackBuilder& keys,

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.h
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.h
@@ -90,22 +90,22 @@ class RocksDBPrimaryIndex final : public RocksDBIndex {
   bool lookupRevision(transaction::Methods* trx, arangodb::velocypack::StringRef key,
                       LocalDocumentId& id, TRI_voc_rid_t& revisionId) const;
 
-  bool supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
-                               arangodb::aql::AstNode const*,
-                               arangodb::aql::Variable const*, size_t, size_t&,
-                               double&) const override;
+  Index::UsageCosts supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
+                                            arangodb::aql::AstNode const* node,
+                                            arangodb::aql::Variable const* reference, 
+                                            size_t itemsInIndex) const override;
   
-  bool supportsSortCondition(arangodb::aql::SortCondition const*,
-                             arangodb::aql::Variable const*, size_t, double&,
-                             size_t&) const override;
+  Index::UsageCosts supportsSortCondition(arangodb::aql::SortCondition const* node,
+                                          arangodb::aql::Variable const* reference, 
+                                          size_t itemsInIndex) const override;
 
-  IndexIterator* iteratorForCondition(transaction::Methods*, 
-                                      arangodb::aql::AstNode const*,
-                                      arangodb::aql::Variable const*,
-                                      IndexIteratorOptions const&) override;
+  std::unique_ptr<IndexIterator> iteratorForCondition(transaction::Methods* trx, 
+                                                      arangodb::aql::AstNode const* node,
+                                                      arangodb::aql::Variable const* reference,
+                                                      IndexIteratorOptions const& opts) override;
 
-  arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode*,
-                                              arangodb::aql::Variable const*) const override;
+  arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode* node,
+                                              arangodb::aql::Variable const* reference) const override;
 
   void invokeOnAllElements(transaction::Methods* trx,
                            std::function<bool(LocalDocumentId const&)> callback) const;
@@ -127,12 +127,12 @@ class RocksDBPrimaryIndex final : public RocksDBIndex {
 
  private:
   /// @brief create the iterator, for a single attribute, IN operator
-  IndexIterator* createInIterator(transaction::Methods*, arangodb::aql::AstNode const*,
-                                  arangodb::aql::AstNode const*, bool ascending);
+  std::unique_ptr<IndexIterator> createInIterator(transaction::Methods*, arangodb::aql::AstNode const*,
+                                                  arangodb::aql::AstNode const*, bool ascending);
 
   /// @brief create the iterator, for a single attribute, EQ operator
-  IndexIterator* createEqIterator(transaction::Methods*, arangodb::aql::AstNode const*,
-                                  arangodb::aql::AstNode const*);
+  std::unique_ptr<IndexIterator> createEqIterator(transaction::Methods*, arangodb::aql::AstNode const*,
+                                                  arangodb::aql::AstNode const*);
   
   /// @brief populate the keys builder with the keys from the array, in either
   /// forward or backward order

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.h
@@ -94,28 +94,25 @@ class RocksDBVPackIndex : public RocksDBIndex {
   static constexpr size_t minimalPrefixSize() { return sizeof(TRI_voc_tick_t); }
 
   /// @brief attempts to locate an entry in the index
-  ///
-  /// Warning: who ever calls this function is responsible for destroying
-  /// the velocypack::Slice and the RocksDBVPackIndexIterator* results
-  IndexIterator* lookup(transaction::Methods*,
-                        arangodb::velocypack::Slice const, bool reverse) const;
+  std::unique_ptr<IndexIterator> lookup(transaction::Methods*,
+                                        arangodb::velocypack::Slice const, bool reverse) const;
 
-  bool supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
-                               arangodb::aql::AstNode const*,
-                               arangodb::aql::Variable const*, size_t, size_t&,
-                               double&) const override;
+  Index::UsageCosts supportsFilterCondition(std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
+                                            arangodb::aql::AstNode const* node,
+                                            arangodb::aql::Variable const* reference, 
+                                            size_t itemsInIndex) const override;
 
-  bool supportsSortCondition(arangodb::aql::SortCondition const*,
-                             arangodb::aql::Variable const*, size_t, double&,
-                             size_t&) const override;
+  Index::UsageCosts supportsSortCondition(arangodb::aql::SortCondition const* sortCondition,
+                                          arangodb::aql::Variable const* reference, 
+                                          size_t itemsInIndex) const override;
 
-  arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode*,
-                                              arangodb::aql::Variable const*) const override;
+  arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode* node,
+                                              arangodb::aql::Variable const* reference) const override;
 
-  IndexIterator* iteratorForCondition(transaction::Methods*, 
-                                      arangodb::aql::AstNode const*,
-                                      arangodb::aql::Variable const*,
-                                      IndexIteratorOptions const&) override;
+  std::unique_ptr<IndexIterator> iteratorForCondition(transaction::Methods* trx, 
+                                                      arangodb::aql::AstNode const* node,
+                                                      arangodb::aql::Variable const* reference,
+                                                      IndexIteratorOptions const& opts) override;
 
   void afterTruncate(TRI_voc_tick_t tick) override;
 

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -182,26 +182,6 @@ static void throwCollectionNotFound(char const* name) {
                                      ": " + name);
 }
 
-/// @brief tests if the given index supports the sort condition
-static bool indexSupportsSort(Index const* idx, arangodb::aql::Variable const* reference,
-                              arangodb::aql::SortCondition const* sortCondition,
-                              size_t itemsInIndex, double& estimatedCost,
-                              size_t& coveredAttributes) {
-  if (idx->isSorted() && idx->supportsSortCondition(sortCondition, reference, 
-                                                    itemsInIndex, estimatedCost, coveredAttributes)) {
-    // index supports the sort condition
-    return true;
-  }
-
-  // index does not support the sort condition
-  if (itemsInIndex > 0) {
-    estimatedCost = itemsInIndex * std::log2(static_cast<double>(itemsInIndex));
-  } else {
-    estimatedCost = 0.0;
-  }
-  return false;
-}
-
 /// @brief Insert an error reported instead of the new document
 static void createBabiesError(VPackBuilder& builder,
                               std::unordered_map<int, size_t>& countErrorCodes,
@@ -592,15 +572,14 @@ std::pair<bool, bool> transaction::Methods::findIndexHandleForAndNode(
     bool supportsFilter = false;
     bool supportsSort = false;
 
-    // check if the index supports the filter expression
-    double estimatedCost;
-    size_t estimatedItems;
-    if (idx->supportsFilterCondition(indexes, node, reference, itemsInIndex,
-                                     estimatedItems, estimatedCost)) {
+    // check if the index supports the filter condition
+    Index::UsageCosts costs = idx->supportsFilterCondition(indexes, node, reference, itemsInIndex);
+
+    if (costs.supportsCondition) {
       // index supports the filter condition
-      filterCost = estimatedCost;
+      filterCost = costs.estimatedCosts;
       // this reduces the number of items left
-      itemsInIndex = estimatedItems;
+      itemsInIndex = costs.estimatedItems;
       supportsFilter = true;
     } else {
       // index does not support the filter condition
@@ -611,15 +590,16 @@ std::pair<bool, bool> transaction::Methods::findIndexHandleForAndNode(
         (!sortCondition->isEmpty() && sortCondition->isOnlyAttributeAccess());
 
     if (sortCondition->isUnidirectional()) {
-      size_t coveredAttributes = 0;
       // only go in here if we actually have a sort condition and it can in
       // general be supported by an index. for this, a sort condition must not
       // be empty, must consist only of attribute access, and all attributes
       // must be sorted in the direction
-      if (indexSupportsSort(idx.get(), reference, sortCondition, 
-                            itemsInIndex, sortCost, coveredAttributes)) {
+      Index::UsageCosts costs = idx->supportsSortCondition(sortCondition, reference, itemsInIndex);
+      if (costs.supportsCondition) {
         supportsSort = true;
       }
+      sortCost = costs.estimatedCosts;
+      // TODO: fill coveredAttributes so we don't need to determine it later on
     }
 
     if (!supportsSort && isOnlyAttributeAccess && node->isOnlyEqualityMatch()) {
@@ -647,7 +627,7 @@ std::pair<bool, bool> transaction::Methods::findIndexHandleForAndNode(
       if (supportsSort) {
         totalCost += sortCost;
       } else {
-        totalCost += estimatedItems * std::log2(static_cast<double>(estimatedItems));
+        totalCost += Index::UsageCosts::defaultsForSorting(itemsInIndex, idx->isPersistent()).estimatedCosts;
       }
     }
 
@@ -722,38 +702,25 @@ bool transaction::Methods::findIndexHandleForAndNode(
 
   auto considerIndex = [&bestIndex, &bestCost, itemsInCollection, &indexes, &node,
                         reference](std::shared_ptr<Index> const& idx) -> void {
-    size_t itemsInIndex = itemsInCollection;
-
     // check if the index supports the filter expression
-    double estimatedCost;
-    size_t estimatedItems;
-    bool supportsFilter =
-        idx->supportsFilterCondition(indexes, node, reference, itemsInIndex,
-                                     estimatedItems, estimatedCost);
-
+    Index::UsageCosts costs = idx->supportsFilterCondition(indexes, node, reference, itemsInCollection);
+    
     // enable the following line to see index candidates considered with their
     // abilities and scores
     LOG_TOPIC("fdbeb", TRACE, Logger::FIXME)
         << "looking at index: " << idx.get() << ", isSorted: " << idx->isSorted()
         << ", isSparse: " << idx->sparse() << ", fields: " << idx->fields().size()
-        << ", supportsFilter: " << supportsFilter
-        << ", estimatedCost: " << estimatedCost << ", estimatedItems: " << estimatedItems
-        << ", itemsInIndex: " << itemsInIndex << ", selectivity: "
+        << ", supportsFilter: " << costs.supportsCondition
+        << ", estimatedCost: " << costs.estimatedCosts << ", estimatedItems: " << costs.estimatedItems
+        << ", itemsInIndex: " << itemsInCollection << ", selectivity: "
         << (idx->hasSelectivityEstimate() ? idx->selectivityEstimate() : -1.0)
         << ", node: " << node;
 
-    if (!supportsFilter) {
-      return;
-    }
-
     // index supports the filter condition
-
-    // this reduces the number of items left
-    itemsInIndex = estimatedItems;
-
-    if (bestIndex == nullptr || estimatedCost < bestCost) {
+    if (costs.supportsCondition && 
+        (bestIndex == nullptr || costs.estimatedCosts < bestCost)) {
       bestIndex = idx;
-      bestCost = estimatedCost;
+      bestCost = costs.estimatedCosts;
     }
   };
 
@@ -2938,24 +2905,6 @@ bool transaction::Methods::getBestIndexHandleForFilterCondition(
                                    hint, usedIndex);
 }
 
-/// @brief Checks if the index supports the filter condition.
-/// note: the caller must have read-locked the underlying collection when
-/// calling this method
-bool transaction::Methods::supportsFilterCondition(
-    IndexHandle const& indexHandle, arangodb::aql::AstNode const* condition,
-    arangodb::aql::Variable const* reference, size_t itemsInIndex,
-    size_t& estimatedItems, double& estimatedCost) {
-  auto idx = indexHandle.getIndex();
-  if (nullptr == idx) {
-    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
-                                   "The index id cannot be empty.");
-  }
-
-  return idx->supportsFilterCondition(std::vector<std::shared_ptr<Index>>(),
-                                      condition, reference, itemsInIndex,
-                                      estimatedItems, estimatedCost);
-}
-
 /// @brief Get the index features:
 ///        Returns the covered attributes, and sets the first bool value
 ///        to isSorted and the second bool value to isSparse
@@ -2989,15 +2938,12 @@ bool transaction::Methods::getIndexForSortCondition(
 
     auto considerIndex = [reference, sortCondition, itemsInIndex, &bestCost, &bestIndex,
                           &coveredAttributes](std::shared_ptr<Index> const& idx) -> void {
-      double sortCost = 0.0;
-      size_t covered = 0;
-      if (indexSupportsSort(idx.get(), reference, sortCondition, itemsInIndex,
-                            sortCost, covered)) {
-        if (bestIndex == nullptr || sortCost < bestCost) {
-          bestCost = sortCost;
-          bestIndex = idx;
-          coveredAttributes = covered;
-        }
+      Index::UsageCosts costs = idx->supportsSortCondition(sortCondition, reference, itemsInIndex);
+      if (costs.supportsCondition &&
+          (bestIndex == nullptr || costs.estimatedCosts < bestCost)) {
+        bestCost = costs.estimatedCosts;
+        bestIndex = idx;
+        coveredAttributes = costs.coveredAttributes;
       }
     };
 
@@ -3066,7 +3012,7 @@ std::unique_ptr<IndexIterator> transaction::Methods::indexScanForCondition(
   }
 
   // Now create the Iterator
-  return std::unique_ptr<IndexIterator>(idx->iteratorForCondition(this, condition, var, opts));
+  return idx->iteratorForCondition(this, condition, var, opts);
 }
 
 /// @brief factory for IndexIterator objects

--- a/arangod/Transaction/Methods.h
+++ b/arangod/Transaction/Methods.h
@@ -344,12 +344,6 @@ class Methods {
       std::string const&, arangodb::aql::AstNode*&,
       arangodb::aql::Variable const*, size_t, aql::IndexHint const&, IndexHandle&);
 
-  /// @brief Checks if the index supports the filter condition.
-  /// note: the caller must have read-locked the underlying collection when
-  /// calling this method
-  bool supportsFilterCondition(IndexHandle const&, arangodb::aql::AstNode const*,
-                               arangodb::aql::Variable const*, size_t, size_t&, double&);
-
   /// @brief Get the index features:
   ///        Returns the covered attributes, and sets the first bool value
   ///        to isSorted and the second bool value to isSparse

--- a/tests/IResearch/IResearchAnalyzerFeature-test.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeature-test.cpp
@@ -84,10 +84,11 @@ struct TestIndex : public arangodb::Index {
   bool isHidden() const override { return false; }
   bool isPersistent() const override { return false; }
   bool isSorted() const override { return false; }
-  arangodb::IndexIterator* iteratorForCondition(
-      arangodb::transaction::Methods* trx, arangodb::aql::AstNode const* node,
-      arangodb::aql::Variable const* variable,
-      arangodb::IndexIteratorOptions const& operations) override {
+  std::unique_ptr<arangodb::IndexIterator> iteratorForCondition(
+      arangodb::transaction::Methods* /* trx */, 
+      arangodb::aql::AstNode const* /* node */,
+      arangodb::aql::Variable const* /* reference */,
+      arangodb::IndexIteratorOptions const& /* opts */) override {
     return nullptr;
   }
   void load() override {}

--- a/tests/IResearch/IResearchOrder-test.cpp
+++ b/tests/IResearch/IResearchOrder-test.cpp
@@ -182,7 +182,7 @@ void assertOrderExecutionFail(std::string const& queryString,
   return assertOrder(true, false, queryString, expected, exprCtx, bindVars, refName);
 }
 
-void assertOrderParseFail(std::string const& queryString, size_t parseCode) {
+void assertOrderParseFail(std::string const& queryString, int parseCode) {
   TRI_vocbase_t vocbase(TRI_vocbase_type_e::TRI_VOCBASE_TYPE_NORMAL, 1,
                         "testVocbase");
 
@@ -190,7 +190,7 @@ void assertOrderParseFail(std::string const& queryString, size_t parseCode) {
                              nullptr, nullptr, arangodb::aql::PART_MAIN);
 
   auto const parseResult = query.parse();
-  ASSERT_TRUE(parseCode == parseResult.result.errorNumber());
+  ASSERT_EQ(parseCode, parseResult.result.errorNumber());
 }
 
 }  // namespace


### PR DESCRIPTION
### Scope & Purpose

This PR refactors the index APIs slightly:
* added documentation for virtual methods in Index.h
* make `Index::supportsFilterCondition` and `Index::supportsSortCondition` return a struct with details about the usage costs. This is much more flexible that passing in a number of out parameters by reference as function call arguments. 
* `Index::iteratorForCondition` now returns a unique_ptr instead of a raw pointer, making ownership for the iterator much clearer

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

Companion enterprise PR: https://github.com/arangodb/enterprise/pull/259

### Testing & Verification

This change is already covered by existing tests, especially all AQL tests.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/4684/