### PR TITLE
Bug fix 3.4/improve arangorestore

### DIFF
--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1137,6 +1137,16 @@ Result RestReplicationHandler::processRestoreCollectionCoordinator(
     changes.push_back("changed 'shardingStrategy' attribute value to 'hash'");
   }
 
+  s = parameters.get(StaticStrings::ReplicationFactor);
+  if (s.isString() && s.copyString() == "satellite") {
+    // set "satellite" replicationFactor to the default replication factor
+    ClusterFeature* cl = application_features::ApplicationServer::getFeature<ClusterFeature>("Cluster");
+    
+    uint32_t replicationFactor = cl->systemReplicationFactor();
+    toMerge.add(StaticStrings::ReplicationFactor, VPackValue(replicationFactor));
+    changes.push_back(std::string("changed 'replicationFactor' attribute value to ") + std::to_string(replicationFactor));;
+  }
+
   if (!changes.empty()) {
     LOG_TOPIC(INFO, Logger::CLUSTER) << "rewrote info for collection '" << name << "' on restore for usage with the community version. the following changes were applied: " << basics::StringUtils::join(changes, ". ");
   }

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -776,12 +776,13 @@ void RestReplicationHandler::handleCommandRestoreCollection() {
   if (res.is(TRI_ERROR_ARANGO_DUPLICATE_NAME)) {
     VPackSlice name = slice.get("parameters");
     if (name.isObject()) {
-      name = slice.get("name");
-    }
-    if (name.isString() && !name.copyString().empty() && name.copyString()[0] == '_') {
-      // system collection, may have been created in the meantime by a background action
-      // collection should be there now
-      res.reset();
+      name = name.get("name");
+      if (name.isString() && !name.copyString().empty() && name.copyString()[0] == '_') {
+        // system collection... it may have been created in the meantime by a background action
+        // collection should be there now - as long as the collection is there in the end
+        // we are satisfied
+        res.reset();
+      }
     }
   }
 


### PR DESCRIPTION
### Scope & Purpose

* reorder collections when restoring them, so that system collections are restored first. This should fix potential issues when the restore operation stops in the middle due to other errors, which may leave a database around with some important system collections missing
* additionally turn off some enterprise functionality (replicationFactor "satellite", smartGraphAttribute, smartJoinAttribute, enterprise sharding strategies)

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is already covered by existing tests, such as dump/restore tests.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/4696/