### PR TITLE
fix dirname behavior

### DIFF
--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -662,26 +662,28 @@ int TRI_RemoveDirectoryDeterministic(char const* filename) {
 
 std::string TRI_Dirname(std::string const& path) {
   size_t n = path.size();
-  size_t m = 0;
-
-  if (1 < n) {
-    if (path[n - 1] == TRI_DIR_SEPARATOR_CHAR) {
-      m = 1;
-    }
+  
+  if (n == 0) {
+    // "" => "."
+    return std::string(".");
   }
 
-  if (n == 0) {
-    return std::string(".");
-  } else if (n == 1 && path[0] == TRI_DIR_SEPARATOR_CHAR) {
+  if (n > 1 && path[n - 1] == TRI_DIR_SEPARATOR_CHAR) {
+    // .../ => ...
+    return path.substr(0, n - 1);
+  }
+
+  if (n == 1 && path[0] == TRI_DIR_SEPARATOR_CHAR) {
+    // "/" => "/"
     return std::string(TRI_DIR_SEPARATOR_STR);
-  } else if (n - m == 1 && path[0] == '.') {
+  } else if (n == 1 && path[0] == '.') {
     return std::string(".");
-  } else if (n - m == 2 && path[0] == '.' && path[1] == '.') {
+  } else if (n == 2 && path[0] == '.' && path[1] == '.') {
     return std::string("..");
   }
 
   char const* p;
-  for (p = path.data() + (n - m - 1); path.data() < p; --p) {
+  for (p = path.data() + (n - 1); path.data() < p; --p) {
     if (*p == TRI_DIR_SEPARATOR_CHAR) {
       break;
     }

--- a/tests/Basics/files-test.cpp
+++ b/tests/Basics/files-test.cpp
@@ -397,3 +397,29 @@ TEST_F(CFilesTest, tst_getfilename) {
   EXPECT_TRUE("haxxmann" == TRI_GetFilename("\\a\\haxxmann"));
   EXPECT_TRUE("haxxmann" == TRI_GetFilename("\\a\\b\\haxxmann"));
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test TRI_Dirname
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_F(CFilesTest, tst_dirname) {
+#ifdef _WIN32
+  EXPECT_EQ("C:\\Users\\abc def\\foobar", TRI_Dirname("C:\\Users\\abc def\\foobar\\"));
+  EXPECT_EQ("C:\\Users\\abc def\\foobar", TRI_Dirname("C:\\Users\\abc def\\foobar\\baz"));
+  EXPECT_EQ("C:\\Users\\abc def\\foobar", TRI_Dirname("C:\\Users\\abc def\\foobar\\baz.text"));
+  EXPECT_EQ("C:\\Users\\abc def\\foobar", TRI_Dirname("C:\\Users\\abc def\\foobar\\VERSION-1.tmp"));
+  EXPECT_EQ("\\Users\\abc def\\foobar", TRI_Dirname("\\Users\\abc def\\foobar\\VERSION-1.tmp"));
+#else 
+  EXPECT_EQ("/tmp/abc/def hihi", TRI_Dirname("/tmp/abc/def hihi/"));
+  EXPECT_EQ("/tmp/abc/def hihi", TRI_Dirname("/tmp/abc/def hihi/abc"));
+  EXPECT_EQ("/tmp/abc/def hihi", TRI_Dirname("/tmp/abc/def hihi/abc.txt"));
+  EXPECT_EQ("/tmp", TRI_Dirname("/tmp/"));
+  EXPECT_EQ("/tmp", TRI_Dirname("/tmp/1"));
+  EXPECT_EQ("/", TRI_Dirname("/tmp"));
+  EXPECT_EQ("/", TRI_Dirname("/"));
+  EXPECT_EQ(".", TRI_Dirname("./"));
+  EXPECT_EQ(".", TRI_Dirname(""));
+  EXPECT_EQ(".", TRI_Dirname("."));
+  EXPECT_EQ("..", TRI_Dirname(".."));
+#endif
+}


### PR DESCRIPTION
### Scope & Purpose

Attempt to fix the behavior of TRI_Dirname, which seems to do wrong things.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes: tests/Basics/files-test.cpp

- [x] Added **Regression Tests** (Only for bug-fixes) 

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/4707/
