### PR TITLE
fix handling of comments in config files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,20 @@
 v3.3.24 (XXXX-XX-XX)
 --------------------
 
+* Fixed parsing of ArangoDB config files with inlined comments. Previous versions didn't handle
+  line comments properly if they were appended to an otherwise valid option value.
+  
+  For example, the comment in the line
+  
+      max-total-wal-size = 1024000 # 1M
+
+  was not ignored and made part of the value. In the end, the value was interpreted as if
+      
+      max-total-wal-size = 10240001000000
+
+  was specified.
+  This version fixes the handling of comments in the config files so that they behave as intended.
+
 * fixed a crash when posting an async request to the server using the "x-arango-async"
   request header and the server's request queue was full
 
@@ -9,6 +23,7 @@ v3.3.24 (XXXX-XX-XX)
 * fix client id lookup table in agency
 
 * fix agency issue in abort of cleanOutServer job
+
 
 v3.3.23 (2019-04-14)
 --------------------

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -203,6 +203,7 @@ add_library(${LIB_ARANGO} STATIC
   Maskings/Path.cpp
   Maskings/RandomStringMask.cpp
   ProgramOptions/Option.cpp
+  ProgramOptions/Parameters.cpp
   ProgramOptions/ProgramOptions.cpp
   ProgramOptions/Section.cpp
   ProgramOptions/Translator.cpp

--- a/lib/ProgramOptions/IniFileParser.h
+++ b/lib/ProgramOptions/IniFileParser.h
@@ -36,6 +36,9 @@ namespace options {
 class IniFileParser {
  public:
   explicit IniFileParser(ProgramOptions* options) : _options(options) {
+    // a regex for removing all trailing comments
+    _matchers.removeComments =
+        std::regex("[ \t]?#.*$", std::regex::nosubs | std::regex::ECMAScript);
     // a line with just comments, e.g. #... or ;...
     _matchers.comment =
         std::regex("^[ \t]*([#;].*)?$", std::regex::nosubs | std::regex::ECMAScript);
@@ -72,6 +75,10 @@ class IniFileParser {
                             "'");
     }
 
+    return parseContent(filename, buf, endPassAfterwards);
+  }
+
+  bool parseContent(std::string const& filename, std::string const& buf, bool endPassAfterwards) {
     bool isCommunity = false;
     bool isEnterprise = false;
     std::string currentSection;
@@ -144,6 +151,8 @@ class IniFileParser {
           option = currentSection + "." + match[1].str();
         }
 
+        value = std::regex_replace(value, _matchers.removeComments, "");
+
 #ifdef USE_ENTERPRISE
         if (isCommunity) {
           continue;
@@ -177,6 +186,7 @@ class IniFileParser {
   std::set<std::string> _seen;
 
   struct {
+    std::regex removeComments;
     std::regex comment;
     std::regex section;
     std::regex enterpriseSection;

--- a/lib/ProgramOptions/IniFileParser.h
+++ b/lib/ProgramOptions/IniFileParser.h
@@ -72,10 +72,6 @@ class IniFileParser {
                             "'");
     }
 
-    return parseContent(filename, buf, endPassAfterwards);
-  }
-
-  bool parseContent(std::string const& filename, std::string const& buf, bool endPassAfterwards) {
     bool isCommunity = false;
     bool isEnterprise = false;
     std::string currentSection;

--- a/lib/ProgramOptions/IniFileParser.h
+++ b/lib/ProgramOptions/IniFileParser.h
@@ -36,9 +36,6 @@ namespace options {
 class IniFileParser {
  public:
   explicit IniFileParser(ProgramOptions* options) : _options(options) {
-    // a regex for removing all trailing comments
-    _matchers.removeComments =
-        std::regex("[ \t]?#.*$", std::regex::nosubs | std::regex::ECMAScript);
     // a line with just comments, e.g. #... or ;...
     _matchers.comment =
         std::regex("^[ \t]*([#;].*)?$", std::regex::nosubs | std::regex::ECMAScript);
@@ -151,8 +148,6 @@ class IniFileParser {
           option = currentSection + "." + match[1].str();
         }
 
-        value = std::regex_replace(value, _matchers.removeComments, "");
-
 #ifdef USE_ENTERPRISE
         if (isCommunity) {
           continue;
@@ -186,7 +181,6 @@ class IniFileParser {
   std::set<std::string> _seen;
 
   struct {
-    std::regex removeComments;
     std::regex comment;
     std::regex section;
     std::regex enterpriseSection;

--- a/lib/ProgramOptions/Parameters.cpp
+++ b/lib/ProgramOptions/Parameters.cpp
@@ -31,7 +31,7 @@ std::regex const removeComments("(^[ \t]+|[ \t]*(#.*)?$)", std::regex::nosubs | 
 namespace arangodb {
 namespace options {
 
-std::string stringToNumber(std::string const& value) {
+std::string removeCommentsFromNumber(std::string const& value) {
   // replace leading spaces, replace trailing spaces & comments
   return std::regex_replace(value, ::removeComments, "");
 }

--- a/lib/ProgramOptions/Parameters.cpp
+++ b/lib/ProgramOptions/Parameters.cpp
@@ -1,0 +1,40 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2016 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#include "ProgramOptions/Parameters.h"
+
+#include <regex>
+
+namespace {
+std::regex const removeComments("(^[ \t]+|[ \t]*(#.*)?$)", std::regex::nosubs | std::regex::ECMAScript);
+}
+
+namespace arangodb {
+namespace options {
+
+std::string stringToNumber(std::string const& value) {
+  // replace leading spaces, replace trailing spaces & comments
+  return std::regex_replace(value, ::removeComments, "");
+}
+
+}
+} 

--- a/lib/ProgramOptions/Parameters.h
+++ b/lib/ProgramOptions/Parameters.h
@@ -34,14 +34,22 @@
 #include <limits>
 #include <numeric>
 #include <type_traits>
+#include <iostream>
 
 namespace arangodb {
 namespace options {
+
+// helper functions to strip-non-numeric data from a string
+std::string stringToNumber(std::string const& value);
 
 // convert a string into a number, base version for signed integer types
 template <typename T>
 inline typename std::enable_if<std::is_signed<T>::value, T>::type toNumber(std::string value,
                                                                            T base) {
+
+  // replace leading spaces, replace trailing spaces & comments
+  value = stringToNumber(value);
+
   auto n = value.size();
   int64_t m = 1;
   int64_t d = 1;
@@ -51,15 +59,15 @@ inline typename std::enable_if<std::is_signed<T>::value, T>::type toNumber(std::
 
     if (suffix == "kib" || suffix == "KiB") {
       m = 1024;
-      value = value.substr(0, n - 2);
+      value = value.substr(0, n - 3);
       seen = true;
     } else if (suffix == "mib" || suffix == "MiB") {
       m = 1024 * 1024;
-      value = value.substr(0, n - 2);
+      value = value.substr(0, n - 3);
       seen = true;
     } else if (suffix == "gib" || suffix == "GiB") {
       m = 1024 * 1024 * 1024;
-      value = value.substr(0, n - 2);
+      value = value.substr(0, n - 3);
       seen = true;
     }
   }
@@ -98,6 +106,7 @@ inline typename std::enable_if<std::is_signed<T>::value, T>::type toNumber(std::
       value = value.substr(0, n - 1);
     }
   }
+  
   auto v = static_cast<int64_t>(std::stoll(value));
   if (v < static_cast<int64_t>((std::numeric_limits<T>::min)()) ||
       v > static_cast<int64_t>((std::numeric_limits<T>::max)())) {
@@ -110,6 +119,9 @@ inline typename std::enable_if<std::is_signed<T>::value, T>::type toNumber(std::
 template <typename T>
 inline typename std::enable_if<std::is_unsigned<T>::value, T>::type toNumber(std::string value,
                                                                              T base) {
+  // replace leading spaces, replace trailing spaces & comments
+  value = stringToNumber(value);
+
   auto n = value.size();
   uint64_t m = 1;
   uint64_t d = 1;
@@ -119,15 +131,15 @@ inline typename std::enable_if<std::is_unsigned<T>::value, T>::type toNumber(std
 
     if (suffix == "kib" || suffix == "KiB") {
       m = 1024;
-      value = value.substr(0, n - 2);
+      value = value.substr(0, n - 3);
       seen = true;
     } else if (suffix == "mib" || suffix == "MiB") {
       m = 1024 * 1024;
-      value = value.substr(0, n - 2);
+      value = value.substr(0, n - 3);
       seen = true;
     } else if (suffix == "gib" || suffix == "GiB") {
       m = 1024 * 1024 * 1024;
-      value = value.substr(0, n - 2);
+      value = value.substr(0, n - 3);
       seen = true;
     }
   }

--- a/lib/ProgramOptions/Parameters.h
+++ b/lib/ProgramOptions/Parameters.h
@@ -40,7 +40,7 @@ namespace arangodb {
 namespace options {
 
 // helper functions to strip-non-numeric data from a string
-std::string stringToNumber(std::string const& value);
+std::string removeCommentsFromNumber(std::string const& value);
 
 // convert a string into a number, base version for signed integer types
 template <typename T>
@@ -48,7 +48,7 @@ inline typename std::enable_if<std::is_signed<T>::value, T>::type toNumber(std::
                                                                            T base) {
 
   // replace leading spaces, replace trailing spaces & comments
-  value = stringToNumber(value);
+  value = removeCommentsFromNumber(value);
 
   auto n = value.size();
   int64_t m = 1;
@@ -120,7 +120,7 @@ template <typename T>
 inline typename std::enable_if<std::is_unsigned<T>::value, T>::type toNumber(std::string value,
                                                                              T base) {
   // replace leading spaces, replace trailing spaces & comments
-  value = stringToNumber(value);
+  value = removeCommentsFromNumber(value);
 
   auto n = value.size();
   uint64_t m = 1;
@@ -189,7 +189,7 @@ inline typename std::enable_if<std::is_unsigned<T>::value, T>::type toNumber(std
 // convert a string into a number, version for double values
 template <>
 inline double toNumber<double>(std::string value, double base) {
-  return std::stod(value);
+  return std::stod(removeCommentsFromNumber(value));
 }
 
 // convert a string into another type, specialized version for numbers

--- a/tests/Basics/InifileParserTest.cpp
+++ b/tests/Basics/InifileParserTest.cpp
@@ -58,6 +58,11 @@ SECTION("test_parsing") {
   bool enforceBlockCacheSizeLimit = false;
   uint64_t cacheSize = UINT64_MAX;
   uint64_t nonoSetOption = UINT64_MAX;
+  uint64_t someValueUsingSuffixes = UINT64_MAX;
+  uint64_t someOtherValueUsingSuffixes = UINT64_MAX;
+  uint64_t yetSomeOtherValueUsingSuffixes = UINT64_MAX;
+  uint64_t andAnotherValueUsingSuffixes = UINT64_MAX;
+  uint64_t andFinallySomeGb = UINT64_MAX;
   
   ProgramOptions options("testi", "testi [options]", "bla", "/tmp/bla");
   options.addSection("rocksdb", "bla");
@@ -71,6 +76,13 @@ SECTION("test_parsing") {
   options.addSection("cache", "bla");
   options.addOption("--cache.size", "bla", new UInt64Parameter(&cacheSize));
   options.addOption("--cache.nono-set-option", "bla", new UInt64Parameter(&nonoSetOption));
+
+  options.addSection("pork", "bla");
+  options.addOption("--pork.some-value-using-suffixes", "bla", new UInt64Parameter(&someValueUsingSuffixes));
+  options.addOption("--pork.some-other-value-using-suffixes", "bla", new UInt64Parameter(&someOtherValueUsingSuffixes));
+  options.addOption("--pork.yet-some-other-value-using-suffixes", "bla", new UInt64Parameter(&yetSomeOtherValueUsingSuffixes));
+  options.addOption("--pork.and-another-value-using-suffixes", "bla", new UInt64Parameter(&andAnotherValueUsingSuffixes));
+  options.addOption("--pork.and-finally-some-gb", "bla", new UInt64Parameter(&andFinallySomeGb));
 
   auto contents = R"data(
 [rocksdb]
@@ -86,6 +98,13 @@ enforce-block-cache-size-limit = true
 
 [cache]
 size = 268435456 # 256M
+
+[pork]
+some-value-using-suffixes = 1M
+some-other-value-using-suffixes = 1MiB
+yet-some-other-value-using-suffixes = 12MB  
+   and-another-value-using-suffixes = 256kb  
+   and-finally-some-gb = 256GB
 )data";
   
   IniFileParser parser(&options);
@@ -100,6 +119,11 @@ size = 268435456 # 256M
   CHECK(true == enforceBlockCacheSizeLimit);
   CHECK(268435456U == cacheSize);
   CHECK(UINT64_MAX == nonoSetOption);
+  CHECK(1000000U == someValueUsingSuffixes);
+  CHECK(1048576U == someOtherValueUsingSuffixes);
+  CHECK(12000000U == yetSomeOtherValueUsingSuffixes);
+  CHECK(256000U == andAnotherValueUsingSuffixes);
+  CHECK(256000000000U == andFinallySomeGb);
 }
 
 }

--- a/tests/Basics/InifileParserTest.cpp
+++ b/tests/Basics/InifileParserTest.cpp
@@ -1,0 +1,105 @@
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test suite for StringUtils class
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2004-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Dr. Frank Celler
+/// @author Copyright 2007-2012, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Basics/Common.h"
+
+#include "catch.hpp"
+
+#include <iomanip>
+#include <sstream>
+
+#include "Basics/StringUtils.h"
+#include "Logger/Logger.h"
+#include "ProgramOptions/IniFileParser.h"
+#include "ProgramOptions/Parameters.h"
+#include "ProgramOptions/ProgramOptions.h"
+
+using namespace arangodb;
+using namespace arangodb::basics;
+
+TEST_CASE("IniFileParserTest", "[ini]") {
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test_parsing
+////////////////////////////////////////////////////////////////////////////////
+
+SECTION("test_parsing") {
+  using namespace arangodb::options;
+
+  uint64_t writeBufferSize = UINT64_MAX;
+  uint64_t totalWriteBufferSize = UINT64_MAX;
+  uint64_t maxWriteBufferNumber = UINT64_MAX;
+  uint64_t maxTotalWalSize = UINT64_MAX;
+  uint64_t blockCacheSize = UINT64_MAX;
+  bool enforceBlockCacheSizeLimit = false;
+  uint64_t cacheSize = UINT64_MAX;
+  uint64_t nonoSetOption = UINT64_MAX;
+  
+  ProgramOptions options("testi", "testi [options]", "bla", "/tmp/bla");
+  options.addSection("rocksdb", "bla");
+  options.addOption("--rocksdb.write-buffer-size", "bla", new UInt64Parameter(&writeBufferSize));
+  options.addOption("--rocksdb.total-write-buffer-size", "bla", new UInt64Parameter(&totalWriteBufferSize));
+  options.addOption("--rocksdb.max-write-buffer-number", "bla", new UInt64Parameter(&maxWriteBufferNumber));
+  options.addOption("--rocksdb.max-total-wal-size", "bla", new UInt64Parameter(&maxTotalWalSize));
+  options.addOption("--rocksdb.block-cache-size", "bla", new UInt64Parameter(&blockCacheSize));
+  options.addOption("--rocksdb.enforce-block-cache-size-limit", "bla", new BooleanParameter(&enforceBlockCacheSizeLimit));
+  
+  options.addSection("cache", "bla");
+  options.addOption("--cache.size", "bla", new UInt64Parameter(&cacheSize));
+  options.addOption("--cache.nono-set-option", "bla", new UInt64Parameter(&nonoSetOption));
+
+  auto contents = R"data(
+[rocksdb]
+# Write buffers
+write-buffer-size = 2048000 # 2M
+total-write-buffer-size = 536870912
+max-write-buffer-number = 4
+max-total-wal-size = 1024000 # 1M
+
+# Read buffers
+block-cache-size = 268435456
+enforce-block-cache-size-limit = true
+
+[cache]
+size = 268435456 # 256M
+)data";
+  
+  IniFileParser parser(&options);
+
+  bool result = parser.parseContent("arangod.conf", contents, true);
+  CHECK(true == result);
+  CHECK(2048000U == writeBufferSize);;
+  CHECK(536870912U == totalWriteBufferSize);;
+  CHECK(4U == maxWriteBufferNumber);
+  CHECK(1024000U == maxTotalWalSize);
+  CHECK(268435456U == blockCacheSize);
+  CHECK(true == enforceBlockCacheSizeLimit);
+  CHECK(268435456U == cacheSize);
+  CHECK(UINT64_MAX == nonoSetOption);
+}
+
+}

--- a/tests/Basics/InifileParserTest.cpp
+++ b/tests/Basics/InifileParserTest.cpp
@@ -91,6 +91,10 @@ SECTION("test_parsing") {
   uint64_t yetSomeOtherValueUsingSuffixes = UINT64_MAX;
   uint64_t andAnotherValueUsingSuffixes = UINT64_MAX;
   uint64_t andFinallySomeGb = UINT64_MAX;
+  uint64_t aValueWithAnInlineComment = UINT64_MAX;
+  double aDouble = -2.0;
+  double aDoubleWithAComment = -2.0;
+  double aDoubleNotSet = -2.0;
   
   ProgramOptions options("testi", "testi [options]", "bla", "/tmp/bla");
   options.addSection("rocksdb", "bla");
@@ -111,6 +115,10 @@ SECTION("test_parsing") {
   options.addOption("--pork.yet-some-other-value-using-suffixes", "bla", new UInt64Parameter(&yetSomeOtherValueUsingSuffixes));
   options.addOption("--pork.and-another-value-using-suffixes", "bla", new UInt64Parameter(&andAnotherValueUsingSuffixes));
   options.addOption("--pork.and-finally-some-gb", "bla", new UInt64Parameter(&andFinallySomeGb));
+  options.addOption("--pork.a-value-with-an-inline-comment", "bla", new UInt64Parameter(&aValueWithAnInlineComment));
+  options.addOption("--pork.a-double", "bla", new DoubleParameter(&aDouble));
+  options.addOption("--pork.a-double-with-a-comment", "bla", new DoubleParameter(&aDoubleWithAComment));
+  options.addOption("--pork.a-double-not-set", "bla", new DoubleParameter(&aDoubleNotSet));
 
   auto contents = R"data(
 [rocksdb]
@@ -133,6 +141,9 @@ some-other-value-using-suffixes = 1MiB
 yet-some-other-value-using-suffixes = 12MB  
    and-another-value-using-suffixes = 256kb  
    and-finally-some-gb = 256GB
+a-value-with-an-inline-comment = 12345#1234M
+a-double = 335.25
+a-double-with-a-comment = 2948.434#343
 )data";
 
   // create a temp file with the above options
@@ -156,6 +167,10 @@ yet-some-other-value-using-suffixes = 12MB
   CHECK(12000000U == yetSomeOtherValueUsingSuffixes);
   CHECK(256000U == andAnotherValueUsingSuffixes);
   CHECK(256000000000U == andFinallySomeGb);
+  CHECK(12345U == aValueWithAnInlineComment);
+  CHECK(335.25 == aDouble);
+  CHECK(2948.434 == aDoubleWithAComment);
+  CHECK(-2.0 == aDoubleNotSet);
 }
 
 }

--- a/tests/Basics/InifileParserTest.cpp
+++ b/tests/Basics/InifileParserTest.cpp
@@ -92,9 +92,18 @@ SECTION("test_parsing") {
   uint64_t andAnotherValueUsingSuffixes = UINT64_MAX;
   uint64_t andFinallySomeGb = UINT64_MAX;
   uint64_t aValueWithAnInlineComment = UINT64_MAX;
+  bool aBoolean = false;
+  bool aBooleanTrue = false;
+  bool aBooleanFalse = true;
+  bool aBooleanNotSet = false;
   double aDouble = -2.0;
   double aDoubleWithAComment = -2.0;
   double aDoubleNotSet = -2.0;
+  std::string aStringValueEmpty = "snort";
+  std::string aStringValue = "purr";
+  std::string aStringValueWithAnInlineComment = "gaw";
+  std::string anotherStringValueWithAnInlineComment = "gaw";
+  std::string aStringValueNotSet = "meow";
   
   ProgramOptions options("testi", "testi [options]", "bla", "/tmp/bla");
   options.addSection("rocksdb", "bla");
@@ -110,6 +119,10 @@ SECTION("test_parsing") {
   options.addOption("--cache.nono-set-option", "bla", new UInt64Parameter(&nonoSetOption));
 
   options.addSection("pork", "bla");
+  options.addOption("--pork.a-boolean", "bla", new BooleanParameter(&aBoolean, true));
+  options.addOption("--pork.a-boolean-true", "bla", new BooleanParameter(&aBooleanTrue, true));
+  options.addOption("--pork.a-boolean-false", "bla", new BooleanParameter(&aBooleanFalse, true));
+  options.addOption("--pork.a-boolean-not-set", "bla", new BooleanParameter(&aBooleanNotSet, true));
   options.addOption("--pork.some-value-using-suffixes", "bla", new UInt64Parameter(&someValueUsingSuffixes));
   options.addOption("--pork.some-other-value-using-suffixes", "bla", new UInt64Parameter(&someOtherValueUsingSuffixes));
   options.addOption("--pork.yet-some-other-value-using-suffixes", "bla", new UInt64Parameter(&yetSomeOtherValueUsingSuffixes));
@@ -119,6 +132,11 @@ SECTION("test_parsing") {
   options.addOption("--pork.a-double", "bla", new DoubleParameter(&aDouble));
   options.addOption("--pork.a-double-with-a-comment", "bla", new DoubleParameter(&aDoubleWithAComment));
   options.addOption("--pork.a-double-not-set", "bla", new DoubleParameter(&aDoubleNotSet));
+  options.addOption("--pork.a-string-value-empty", "bla", new StringParameter(&aStringValueEmpty));
+  options.addOption("--pork.a-string-value", "bla", new StringParameter(&aStringValue));
+  options.addOption("--pork.a-string-value-with-an-inline-comment", "bla", new StringParameter(&aStringValueWithAnInlineComment));
+  options.addOption("--pork.another-string-value-with-an-inline-comment", "bla", new StringParameter(&anotherStringValueWithAnInlineComment));
+  options.addOption("--pork.a-string-value-not-set", "bla", new StringParameter(&aStringValueNotSet));
 
   auto contents = R"data(
 [rocksdb]
@@ -136,6 +154,9 @@ enforce-block-cache-size-limit = true
 size = 268435456 # 256M
 
 [pork]
+a-boolean = true
+a-boolean-true = true
+a-boolean-false = false
 some-value-using-suffixes = 1M
 some-other-value-using-suffixes = 1MiB
 yet-some-other-value-using-suffixes = 12MB  
@@ -144,6 +165,10 @@ yet-some-other-value-using-suffixes = 12MB
 a-value-with-an-inline-comment = 12345#1234M
 a-double = 335.25
 a-double-with-a-comment = 2948.434#343
+a-string-value-empty =      
+a-string-value = 486hbsbq,r
+a-string-value-with-an-inline-comment = abc#def h
+another-string-value-with-an-inline-comment = abc  #def h
 )data";
 
   // create a temp file with the above options
@@ -162,6 +187,10 @@ a-double-with-a-comment = 2948.434#343
   CHECK(true == enforceBlockCacheSizeLimit);
   CHECK(268435456U == cacheSize);
   CHECK(UINT64_MAX == nonoSetOption);
+  CHECK(true == aBoolean);
+  CHECK(true == aBooleanTrue);
+  CHECK(false == aBooleanFalse);
+  CHECK(false == aBooleanNotSet);
   CHECK(1000000U == someValueUsingSuffixes);
   CHECK(1048576U == someOtherValueUsingSuffixes);
   CHECK(12000000U == yetSomeOtherValueUsingSuffixes);
@@ -171,6 +200,11 @@ a-double-with-a-comment = 2948.434#343
   CHECK(335.25 == aDouble);
   CHECK(2948.434 == aDoubleWithAComment);
   CHECK(-2.0 == aDoubleNotSet);
+  CHECK("" == aStringValueEmpty);
+  CHECK("486hbsbq,r" == aStringValue);
+  CHECK("abc#def h" == aStringValueWithAnInlineComment);
+  CHECK("abc  #def h" == anotherStringValueWithAnInlineComment);
+  CHECK("meow" == aStringValueNotSet);
 }
 
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(
   Basics/vector-test.cpp
   Basics/structure-size-test.cpp
   Basics/EndpointTest.cpp
+  Basics/InifileParserTest.cpp
   Basics/StringBufferTest.cpp
   Basics/StringUtilsTest.cpp
   Basics/VelocyPackHelper-test.cpp


### PR DESCRIPTION
### Scope & Purpose

Fixed parsing of ArangoDB config files with inlined comments. Previous versions didn't handle line comments properly if they were appended to an otherwise valid option value.

For example, the comment in the line
```
max-total-wal-size = 1024000 # 1M
```
was not ignored and made part of the value. In the end, the value was interpreted as if
```
max-total-wal-size = 10240001000000
```
was specified.
This version fixes the handling of comments in the config files so that they behave as intended.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is a GitHub Issue reported by a Community User: 

Got aware of this problem while trying to reproduce https://github.com/arangodb/arangodb/issues/5414


### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added **Regression Tests** (Only for bug-fixes) 
- [x] Added new C++ **Unit Tests** (Either GoogleTest or Catch-Test)

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/4716/
