### PR TITLE
output setup failures to testfailures.txt

### DIFF
--- a/js/client/modules/@arangodb/testing.js
+++ b/js/client/modules/@arangodb/testing.js
@@ -781,7 +781,21 @@ function unitTest (cases, options) {
     };
   }
 
-  pu.setupBinaries(options.build, options.buildType, options.configDir);
+  try {
+    pu.setupBinaries(options.build, options.buildType, options.configDir);
+  }
+  catch (err) {
+    print(err);
+    return {
+      status: false,
+      crashed: true,
+      ALL: [{
+        status: false,
+        failed: 1,
+        message: err.message
+      }]
+    };
+  }
   const jsonReply = options.jsonReply;
   delete options.jsonReply;
 


### PR DESCRIPTION
- Reduce the impact to the other developer’s time and energy spent on defects in your code
### Scope & Purpose
 - [x] bug fix in test setup to make `testfailures.txt` contain the errors - so one doesn't have to look at the logs
### Testing & Verification
remove i.e. `bin/arangobench` and try to run `scripts/unittest shell_server` - you will now get:
```
Error: unable to locate build-deb/bin/arangobench
================================================================================
TEST RESULTS
================================================================================


* Test "ALL"
    [FAILED]  0

      "test" failed: unable to locate build-deb/bin/arangobench
* Overall state: Fail
Marking crashy!
   Suites failed: 1 Tests Failed: 1
2019-06-04T10:11:52Z [98874] ERROR [8a210] JavaScript exception in file 'UnitTests/unittest.js' at 337,3: peng!
2019-06-04T10:11:52Z [98874] ERROR [409ee] !  throw 'peng!';
2019-06-04T10:11:52Z [98874] ERROR [cb0bd] !  ^
```
superseedes https://github.com/arangodb/arangodb/pull/9186