### PR TITLE
fix path length checks when copying js files

### DIFF
--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -488,11 +488,12 @@ void V8DealerFeature::copyInstallationFiles() {
       if (filename.size() >= nodeModulesPath.size()) {
         std::string normalized = filename;
         FileUtils::normalizePath(normalized);
-        TRI_ASSERT(filename.size() == normalized.size());
-        if (normalized.substr(normalized.size() - nodeModulesPath.size(),
-                              nodeModulesPath.size()) == nodeModulesPath ||
-            normalized.substr(normalized.size() - nodeModulesPathVersioned.size(),
-                              nodeModulesPathVersioned.size()) == nodeModulesPathVersioned) {
+        if ((!nodeModulesPath.empty() && 
+             normalized.size() >= nodeModulesPath.size() &&
+             normalized.substr(normalized.size() - nodeModulesPath.size(), nodeModulesPath.size()) == nodeModulesPath) ||
+            (!nodeModulesPathVersioned.empty() &&
+             normalized.size() >= nodeModulesPathVersioned.size() &&
+             normalized.substr(normalized.size() - nodeModulesPathVersioned.size(), nodeModulesPathVersioned.size()) == nodeModulesPathVersioned)) {
           // filter it out!
           return true;
         }


### PR DESCRIPTION
### Scope & Purpose

Fix invalid & improperly checked string accesses when copying JS files at startup

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/4742/