### PR TITLE
Bug fix 3.4/fix arangoexport error messages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 v3.4.7 (2019-XX-XX)
 -------------------
+
+* fix error reporting in arangorestore. previously, when the server returned an HTTP 404 error,
+  arangorestore unconditionally translated this into a "collection not found" error, which may
+  have masked an actually different server-side error. Instead, make arangorestore return the
+  server's actual error message as is.
+
 * allow pregel to select the shard key via `shardKeyAttribute` in pregel start parameters
 
 * Fixed parsing of ArangoDB config files with inlined comments. Previous versions didn't handle

--- a/arangosh/Export/ExportFeature.cpp
+++ b/arangosh/Export/ExportFeature.cpp
@@ -25,6 +25,7 @@
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/FileUtils.h"
 #include "Basics/OpenFilesTracker.h"
+#include "Basics/StaticStrings.h"
 #include "Basics/StringUtils.h"
 #include "Logger/Logger.h"
 #include "ProgramOptions/ProgramOptions.h"
@@ -42,6 +43,10 @@ using namespace arangodb::basics;
 using namespace arangodb::httpclient;
 using namespace arangodb::options;
 using namespace boost::property_tree::xml_parser;
+
+namespace {
+constexpr double ttlValue = 1200.;
+}
 
 namespace arangodb {
 
@@ -308,6 +313,7 @@ void ExportFeature::collectionExport(SimpleHttpClient* httpClient) {
     post.add("query", VPackValue("FOR doc IN @@collection RETURN doc"));
     post.add("bindVars", VPackValue(VPackValueType::Object));
     post.add("@collection", VPackValue(collection));
+    post.add("ttl", VPackValue(::ttlValue));
     post.close();
     post.add("options", VPackValue(VPackValueType::Object));
     post.add("stream", VPackSlice::trueSlice());
@@ -371,6 +377,7 @@ void ExportFeature::queryExport(SimpleHttpClient* httpClient) {
   post.add("query", VPackValue(_query));
   post.add("options", VPackValue(VPackValueType::Object));
   post.add("stream", VPackSlice::trueSlice());
+  post.add("ttl", VPackValue(::ttlValue));
   post.close();
   post.close();
 
@@ -531,50 +538,42 @@ std::shared_ptr<VPackBuilder> ExportFeature::httpCall(SimpleHttpClient* httpClie
                                                       std::string const& url,
                                                       rest::RequestType requestType,
                                                       std::string postBody) {
-  std::string errorMsg;
-
   std::unique_ptr<SimpleHttpResult> response(
       httpClient->request(requestType, url, postBody.c_str(), postBody.size()));
   _httpRequestsDone++;
 
   if (response == nullptr || !response->isComplete()) {
-    errorMsg = "got invalid response from server: " + httpClient->getErrorMessage();
-    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, errorMsg);
+    LOG_TOPIC(FATAL, Logger::CONFIG) << "got invalid response from server: " + httpClient->getErrorMessage();
+    FATAL_ERROR_EXIT();
   }
 
   std::shared_ptr<VPackBuilder> parsedBody;
 
   if (response->wasHttpError()) {
-    if (response->getHttpReturnCode() == 404) {
-      if (_currentGraph.size()) {
-        LOG_TOPIC(FATAL, Logger::CONFIG) << "Graph '" << _currentGraph << "' not found.";
-      } else if (_currentCollection.size()) {
-        LOG_TOPIC(FATAL, Logger::CONFIG) << "Collection " << _currentCollection << " not found.";
-      }
-
-      FATAL_ERROR_EXIT();
-    } else {
-      parsedBody = response->getBodyVelocyPack();
-      std::cout << parsedBody->toJson() << std::endl;
-      errorMsg = "got invalid response from server: HTTP " +
-                 StringUtils::itoa(response->getHttpReturnCode()) + ": " +
-                 response->getHttpReturnMessage();
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, errorMsg);
+    parsedBody = response->getBodyVelocyPack();
+    arangodb::velocypack::Slice error = parsedBody->slice();
+    std::string errorMsg;
+    if (!error.isNone() && error.hasKey(arangodb::StaticStrings::ErrorMessage)) {
+      errorMsg = " - " + error.get(arangodb::StaticStrings::ErrorMessage).copyString();
     }
+    //std::cout << parsedBody->toJson() << std::endl;
+    LOG_TOPIC(FATAL, Logger::CONFIG) << "got invalid response from server: HTTP " +
+               StringUtils::itoa(response->getHttpReturnCode()) + ": " << response->getHttpReturnMessage() << errorMsg;
+    FATAL_ERROR_EXIT();
   }
 
   try {
     parsedBody = response->getBodyVelocyPack();
   } catch (...) {
-    errorMsg = "got malformed JSON response from server";
-    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, errorMsg);
+    LOG_TOPIC(FATAL, Logger::CONFIG) << "got malformed JSON response from server";
+    FATAL_ERROR_EXIT();
   }
 
   VPackSlice body = parsedBody->slice();
 
   if (!body.isObject()) {
-    errorMsg = "got malformed JSON response from server";
-    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, errorMsg);
+    LOG_TOPIC(FATAL, Logger::CONFIG) << "got malformed JSON response from server";
+    FATAL_ERROR_EXIT();
   }
 
   return parsedBody;
@@ -661,6 +660,7 @@ directed="1">
     post.add("query", VPackValue("FOR doc IN @@collection RETURN doc"));
     post.add("bindVars", VPackValue(VPackValueType::Object));
     post.add("@collection", VPackValue(collection));
+    post.add("ttl", VPackValue(::ttlValue));
     post.close();
     post.add("options", VPackValue(VPackValueType::Object));
     post.add("stream", VPackSlice::trueSlice());

--- a/arangosh/Export/ExportFeature.cpp
+++ b/arangosh/Export/ExportFeature.cpp
@@ -313,8 +313,8 @@ void ExportFeature::collectionExport(SimpleHttpClient* httpClient) {
     post.add("query", VPackValue("FOR doc IN @@collection RETURN doc"));
     post.add("bindVars", VPackValue(VPackValueType::Object));
     post.add("@collection", VPackValue(collection));
-    post.add("ttl", VPackValue(::ttlValue));
     post.close();
+    post.add("ttl", VPackValue(::ttlValue));
     post.add("options", VPackValue(VPackValueType::Object));
     post.add("stream", VPackSlice::trueSlice());
     post.close();
@@ -375,9 +375,9 @@ void ExportFeature::queryExport(SimpleHttpClient* httpClient) {
   VPackBuilder post;
   post.openObject();
   post.add("query", VPackValue(_query));
+  post.add("ttl", VPackValue(::ttlValue));
   post.add("options", VPackValue(VPackValueType::Object));
   post.add("stream", VPackSlice::trueSlice());
-  post.add("ttl", VPackValue(::ttlValue));
   post.close();
   post.close();
 
@@ -660,8 +660,8 @@ directed="1">
     post.add("query", VPackValue("FOR doc IN @@collection RETURN doc"));
     post.add("bindVars", VPackValue(VPackValueType::Object));
     post.add("@collection", VPackValue(collection));
-    post.add("ttl", VPackValue(::ttlValue));
     post.close();
+    post.add("ttl", VPackValue(::ttlValue));
     post.add("options", VPackValue(VPackValueType::Object));
     post.add("stream", VPackSlice::trueSlice());
     post.close();


### PR DESCRIPTION
### Scope & Purpose

Fix error messages in arangoexport.
Previously, when the server returned an HTTP 404 error, arangoexport unconditionally turned this error into a "collection not found" error, which may or may not be appropriate.
Instead, make it return the server's actual error message.
Additionally, move away from TRI_ERROR_INTERNAL.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/4810/