### PR TITLE
don't include the Logger in header files if it's not necessary

### DIFF
--- a/arangod/Aql/AqlItemMatrix.h
+++ b/arangod/Aql/AqlItemMatrix.h
@@ -23,7 +23,6 @@
 #ifndef ARANGOD_AQL_AQL_ITEM_MATRIX_H
 #define ARANGOD_AQL_AQL_ITEM_MATRIX_H 1
 
-#include <lib/Logger/Logger.h>
 #include "Aql/AqlItemBlock.h"
 #include "Aql/InputAqlItemRow.h"
 #include "Aql/types.h"

--- a/arangod/Aql/ClusterNodes.h
+++ b/arangod/Aql/ClusterNodes.h
@@ -32,7 +32,6 @@
 #include "Aql/types.h"
 #include "Basics/Common.h"
 #include "Basics/StringUtils.h"
-#include "Logger/Logger.h"
 #include "VocBase/voc-types.h"
 #include "VocBase/vocbase.h"
 

--- a/arangod/Cluster/ClusterComm.h
+++ b/arangod/Cluster/ClusterComm.h
@@ -34,7 +34,7 @@
 #include "Basics/ReadWriteLock.h"
 #include "Basics/Thread.h"
 #include "Cluster/ClusterInfo.h"
-#include "Logger/Logger.h"
+#include "Logger/LogTopic.h"
 #include "Rest/GeneralRequest.h"
 #include "Rest/GeneralResponse.h"
 #include "Rest/HttpRequest.h"

--- a/arangod/Cluster/CriticalThread.h
+++ b/arangod/Cluster/CriticalThread.h
@@ -24,7 +24,6 @@
 #define ARANGOD_CLUSTER_CRITICAL_THREAD_H 1
 
 #include "Basics/Thread.h"
-#include "Logger/Logger.h"
 
 namespace arangodb {
 

--- a/arangod/Cluster/HeartbeatThread.h
+++ b/arangod/Cluster/HeartbeatThread.h
@@ -31,7 +31,6 @@
 #include "Basics/Mutex.h"
 #include "Cluster/CriticalThread.h"
 #include "Cluster/DBServerAgencySync.h"
-#include "Logger/Logger.h"
 
 #include <velocypack/Slice.h>
 #include <chrono>

--- a/arangod/Scheduler/Scheduler.h
+++ b/arangod/Scheduler/Scheduler.h
@@ -30,7 +30,6 @@
 #include <queue>
 
 #include "GeneralServer/RequestLane.h"
-#include "Logger/Logger.h"
 
 namespace arangodb {
 

--- a/arangod/Utils/VersionTracker.h
+++ b/arangod/Utils/VersionTracker.h
@@ -25,7 +25,6 @@
 #define ARANGOD_UTILS_VERSION_TRACKER_H 1
 
 #include "Basics/Common.h"
-#include "Logger/Logger.h"
 
 namespace arangodb {
 

--- a/arangod/VocBase/LogicalView.h
+++ b/arangod/VocBase/LogicalView.h
@@ -30,8 +30,8 @@
 #include "Basics/Result.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
-#include "LogicalDataSource.h"
 #include "Meta/utility.h"
+#include "VocBase/LogicalDataSource.h"
 #include "VocBase/voc-types.h"
 
 #include <velocypack/Buffer.h>


### PR DESCRIPTION
### Scope & Purpose

don't include Logger.h in header files in case we don't need it.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behaviour change can only be verified via automatic tests: compilation!

### Testing & Verification

This change is already covered by existing tests: compilation on all platforms

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/4788/