### PR TITLE
[3.3] Add drop-check for index creation in cluster

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.3.24 (XXXX-XX-XX)
 --------------------
 
+* fix timeout-response in case of simultaneous index create/drop in cluster
+
 * Fixed parsing of ArangoDB config files with inlined comments. Previous versions didn't handle
   line comments properly if they were appended to an otherwise valid option value.
   

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1999,8 +1999,8 @@ int ClusterInfo::ensureIndexCoordinatorInner(std::string const& databaseName,
           }
 
           if (!found) {
-            return Result(TRI_ERROR_ARANGO_INDEX_CREATION_FAILED,
-                          "index was dropped during creation");
+            errorMsg = "index was dropped during creation";
+            return TRI_ERROR_ARANGO_INDEX_CREATION_FAILED;
           }
         }
       }

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1847,10 +1847,11 @@ int ClusterInfo::ensureIndexCoordinatorInner(std::string const& databaseName,
   }
 
   // will contain the error number and message
-  auto dbServerResult = std::make_shared<std::atomic<int>>(-1);
+  std::atomic<int> dbServerResult(-1);
   std::shared_ptr<std::string> errMsg = std::make_shared<std::string>();
 
-  std::function<bool(VPackSlice const& result)> dbServerChanged = [=](VPackSlice const& result) {
+  std::function<bool(VPackSlice const& result)> dbServerChanged = [=, &dbServerResult](
+                                                                      VPackSlice const& result) {
     if (!result.isObject() || result.length() != numberOfShards) {
       return true;
     }
@@ -1881,7 +1882,7 @@ int ClusterInfo::ensureIndexCoordinatorInner(std::string const& databaseName,
             // error otherwise
             int errNum = arangodb::basics::VelocyPackHelper::readNumericValue<int>(
                 v, StaticStrings::ErrorNum, TRI_ERROR_ARANGO_INDEX_CREATION_FAILED);
-            dbServerResult->store(errNum, std::memory_order_release);
+            dbServerResult.store(errNum, std::memory_order_release);
             return true;
           }
 
@@ -1892,7 +1893,7 @@ int ClusterInfo::ensureIndexCoordinatorInner(std::string const& databaseName,
     }
 
     if (found == (size_t)numberOfShards) {
-      dbServerResult->store(setErrormsg(TRI_ERROR_NO_ERROR, *errMsg), std::memory_order_release);
+      dbServerResult.store(setErrormsg(TRI_ERROR_NO_ERROR, *errMsg), std::memory_order_release);
     }
 
     return true;
@@ -1923,7 +1924,6 @@ int ClusterInfo::ensureIndexCoordinatorInner(std::string const& databaseName,
   // by a mutex. We use the mutex of the condition variable in the
   // AgencyCallback for this.
   std::string where = "Current/Collections/" + databaseName + "/" + collectionID;
-
   auto agencyCallback =
       std::make_shared<AgencyCallback>(ac, where, dbServerChanged, true, false);
   _agencyCallbackRegistry->registerCallback(agencyCallback);
@@ -1970,7 +1970,41 @@ int ClusterInfo::ensureIndexCoordinatorInner(std::string const& databaseName,
 
   {
     while (!application_features::ApplicationServer::isStopping()) {
-      int tmpRes = dbServerResult->load(std::memory_order_acquire);
+      int tmpRes = dbServerResult.load(std::memory_order_acquire);
+
+      if (tmpRes < 0) {
+        // index has not shown up in Current yet,  follow up check to
+        // ensure it is still in plan (not dropped between iterations)
+
+        AgencyCommResult result = _agency.sendTransactionWithFailover(
+            AgencyReadTransaction(AgencyCommManager::path(planIndexesKey)));
+
+        if (result.successful()) {
+          auto indexes = result.slice()[0].get(
+              std::vector<std::string>{AgencyCommManager::path(), "Plan",
+                                       "Collections", databaseName,
+                                       collectionID, "indexes"});
+
+          bool found = false;
+          if (indexes.isArray()) {
+            for (size_t i = 0; i < indexes.length(); i++) {
+              VPackSlice v = indexes.at(i);
+              VPackSlice const k = v.get(StaticStrings::IndexId);
+              if (k.isString() && idString == k.copyString()) {
+                // index is still here
+                found = true;
+                break;
+              }
+            }
+          }
+
+          if (!found) {
+            return Result(TRI_ERROR_ARANGO_INDEX_CREATION_FAILED,
+                          "index was dropped during creation");
+          }
+        }
+      }
+
       if (tmpRes == 0) {
         // Finally, in case all is good, remove the `isBuilding` flag
         // check that the index has appeared. Note that we have to have

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1987,10 +1987,9 @@ int ClusterInfo::ensureIndexCoordinatorInner(std::string const& databaseName,
 
           bool found = false;
           if (indexes.isArray()) {
-            for (size_t i = 0; i < indexes.length(); i++) {
-              VPackSlice v = indexes.at(i);
+            for (auto const& v : VPackArrayIterator(indexes)) {
               VPackSlice const k = v.get("id");
-              if (k.isString() && idString == k.copyString()) {
+              if (k.isString() && k.isEqualString(idString)) {
                 // index is still here
                 found = true;
                 break;

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1989,7 +1989,7 @@ int ClusterInfo::ensureIndexCoordinatorInner(std::string const& databaseName,
           if (indexes.isArray()) {
             for (size_t i = 0; i < indexes.length(); i++) {
               VPackSlice v = indexes.at(i);
-              VPackSlice const k = v.get(StaticStrings::IndexId);
+              VPackSlice const k = v.get("id");
               if (k.isString() && idString == k.copyString()) {
                 // index is still here
                 found = true;

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1847,11 +1847,11 @@ int ClusterInfo::ensureIndexCoordinatorInner(std::string const& databaseName,
   }
 
   // will contain the error number and message
-  std::atomic<int> dbServerResult(-1);
+  std::shared_ptr<std::atomic<int>> dbServerResult =
+      std::make_shared<std::atomic<int>>(-1);
   std::shared_ptr<std::string> errMsg = std::make_shared<std::string>();
 
-  std::function<bool(VPackSlice const& result)> dbServerChanged = [=, &dbServerResult](
-                                                                      VPackSlice const& result) {
+  std::function<bool(VPackSlice const& result)> dbServerChanged = [=](VPackSlice const& result) {
     if (!result.isObject() || result.length() != numberOfShards) {
       return true;
     }
@@ -1882,7 +1882,7 @@ int ClusterInfo::ensureIndexCoordinatorInner(std::string const& databaseName,
             // error otherwise
             int errNum = arangodb::basics::VelocyPackHelper::readNumericValue<int>(
                 v, StaticStrings::ErrorNum, TRI_ERROR_ARANGO_INDEX_CREATION_FAILED);
-            dbServerResult.store(errNum, std::memory_order_release);
+            dbServerResult->store(errNum, std::memory_order_release);
             return true;
           }
 
@@ -1893,7 +1893,7 @@ int ClusterInfo::ensureIndexCoordinatorInner(std::string const& databaseName,
     }
 
     if (found == (size_t)numberOfShards) {
-      dbServerResult.store(setErrormsg(TRI_ERROR_NO_ERROR, *errMsg), std::memory_order_release);
+      dbServerResult->store(setErrormsg(TRI_ERROR_NO_ERROR, *errMsg), std::memory_order_release);
     }
 
     return true;
@@ -1970,7 +1970,7 @@ int ClusterInfo::ensureIndexCoordinatorInner(std::string const& databaseName,
 
   {
     while (!application_features::ApplicationServer::isStopping()) {
-      int tmpRes = dbServerResult.load(std::memory_order_acquire);
+      int tmpRes = dbServerResult->load(std::memory_order_acquire);
 
       if (tmpRes < 0) {
         // index has not shown up in Current yet,  follow up check to


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/9219

Add check in coordinator index creation process to verify that the index has not been dropped between polling attempts. Previously, this could result in the creation request hanging and timing out instead of recognizing that a simultaneous drop request had been made.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

- [x] There is an internal planning ticket: https://github.com/arangodb/release-3.5/issues/101

### Testing & Verification

http://jenkins01.arangodb.biz:8080/job/arangodb-matrix-pr/4802/

### Documentation

- [x] Added a *Changelog Entry* 
