### PR TITLE
remove archived RocksDB WAL files on agent servers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,12 @@
 v3.4.7 (2019-XX-XX)
 -------------------
-* allow pregel to select the shard key via `shardKeyAttribute` in pregel start parameters
 
+* eventually remove archived RocksDB WAL files from the "archive" directory on agency servers
+
+  Previously on agent servers the WAL files in the archive directory were retained due to an
+  error
+
+* allow pregel to select the shard key via `shardKeyAttribute` in pregel start parameters
 
 * Speed up collection creation process in cluster, if not all agency callbacks are
   delivered successfully.

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -44,6 +44,7 @@
 #include "Rest/Version.h"
 #include "RestHandler/RestHandlerCreator.h"
 #include "RestServer/DatabasePathFeature.h"
+#include "RestServer/FlushFeature.h"
 #include "RestServer/ServerIdFeature.h"
 #include "RocksDBEngine/RocksDBBackgroundErrorListener.h"
 #include "RocksDBEngine/RocksDBBackgroundThread.h"
@@ -98,6 +99,7 @@
 
 #include "IResearch/IResearchView.h"
 
+#include <limits>
 #include <regex>
 
 using namespace arangodb;
@@ -191,6 +193,7 @@ RocksDBEngine::RocksDBEngine(application_features::ApplicationServer& server)
       _syncInterval(100),
 #endif
       _useThrottle(true),
+      _useReleasedTick(false),
       _debugLogging(false) {
 
   startsAfter("BasicsPhase");
@@ -743,6 +746,15 @@ void RocksDBEngine::start() {
   if (opts->_limitOpenFilesAtStartup) {
     _db->SetDBOptions({{"max_open_files", "-1"}});
   }
+
+  {
+    auto feature = application_features::ApplicationServer::getFeature<FlushFeature>("Flush");
+    TRI_ASSERT(feature);
+    _useReleasedTick = feature->isEnabled();
+  }
+
+  // useReleasedTick should be true on DB servers and single servers
+  TRI_ASSERT((arangodb::ServerState::instance()->isCoordinator() || arangodb::ServerState::instance()->isAgent()) || _useReleasedTick);
 
   if (_syncInterval > 0) {
     _syncThread.reset(new RocksDBSyncThread(this, std::chrono::milliseconds(_syncInterval)));
@@ -1678,12 +1690,11 @@ std::vector<std::shared_ptr<RocksDBRecoveryHelper>> const& RocksDBEngine::recove
 }
 
 void RocksDBEngine::determinePrunableWalFiles(TRI_voc_tick_t minTickExternal) {
-  rocksdb::VectorLogPtr files;
-
   WRITE_LOCKER(lock, _walFileLock);
-  TRI_voc_tick_t minTickToKeep = std::min(_releasedTick, minTickExternal);
-
+  TRI_voc_tick_t minTickToKeep = std::min(_useReleasedTick ? _releasedTick : std::numeric_limits<TRI_voc_tick_t>::max(), minTickExternal);
+  
   // Retrieve the sorted list of all wal files with earliest file first
+  rocksdb::VectorLogPtr files;
   auto status = _db->GetSortedWalFiles(files);
   if (!status.ok()) {
     LOG_TOPIC(INFO, Logger::ENGINES) << "could not get WAL files " << status.ToString();

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -442,6 +442,9 @@ class RocksDBEngine final : public StorageEngine {
 
   // use write-throttling
   bool _useThrottle;
+  
+  /// @brief whether or not to use _releasedTick when determining the WAL files to prune
+  bool _useReleasedTick;
 
   // activate rocksdb's debug logging
   bool _debugLogging;

--- a/js/client/modules/@arangodb/testsuites/wal.js
+++ b/js/client/modules/@arangodb/testsuites/wal.js
@@ -1,0 +1,70 @@
+/* jshint strict: false, sub: true */
+/* global print */
+'use strict';
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2018 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2018, ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const functionsDocumentation = {
+  'wal_cleanup': 'wal file cleanup tests'
+};
+
+const tu = require('@arangodb/test-utils');
+
+// const BLUE = require('internal').COLORS.COLOR_BLUE;
+const CYAN = require('internal').COLORS.COLOR_CYAN;
+// const GREEN = require('internal').COLORS.COLOR_GREEN;
+const RED = require('internal').COLORS.COLOR_RED;
+const RESET = require('internal').COLORS.COLOR_RESET;
+// const YELLOW = require('internal').COLORS.COLOR_YELLOW;
+
+const download = require('internal').download;
+
+const testPaths = {
+  'walCleanup': [tu.pathForTesting('client/wal_cleanup')]
+};
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief TEST: wal cleanup
+////////////////////////////////////////////////////////////////////////////////
+
+function walCleanup (options) {
+  print(CYAN + 'WAL cleanup tests...' + RESET);
+  let testCases = tu.scanTestPaths(testPaths.walCleanup);
+
+  options.extraArgs['rocksdb.wal-file-timeout-initial'] = '3';
+
+  return tu.performTests(options, testCases, 'wal_cleanup', tu.runInArangosh, {
+    'server.authentication': 'false',
+    'rocksdb.wal-file-timeout-initial': '3'
+  });
+}
+
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
+  testFns['wal_cleanup'] = walCleanup;
+
+  defaultFns.push('wal_cleanup');
+
+  for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
+};

--- a/tests/js/client/wal_cleanup/wal-cluster-rocksdb.js
+++ b/tests/js/client/wal_cleanup/wal-cluster-rocksdb.js
@@ -1,0 +1,185 @@
+/* jshint globalstrict:true, strict:true, maxlen: 5000 */
+/* global assertTrue, assertFalse, arango, require*/
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2018 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2018, ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+
+const jsunity = require("jsunity");
+
+const db = require("internal").db;
+const url = require('url');
+const _ = require("lodash");
+        
+function getServers(role) {
+  const matchesRole = (d) => (_.toLower(d.role) === role);
+  const instanceInfo = JSON.parse(require('internal').env.INSTANCEINFO);
+  return instanceInfo.arangods.filter(matchesRole);
+}
+
+const cn = "UnitTestsWalCleanup";
+const originalEndpoint = arango.getEndpoint();
+
+function WalCleanupSuite () {
+  'use strict';
+  
+  let run = function(insertData, getRanges) {
+    let seenInitialDeletion = false;
+    let seenNewFileDeletion = false;
+    let seenNewFile = false;
+    let minArchivedLogNumber = null;
+    let maxArchivedLogNumber = null;
+
+    let time = require("internal").time;
+    const start = time();
+
+    while (true) {
+      insertData();
+    
+      let ranges = getRanges();
+      if (ranges.length) {
+        if (minArchivedLogNumber === null) {
+          minArchivedLogNumber = ranges[0];
+          maxArchivedLogNumber = ranges[ranges.length - 1];
+          require("console").warn("minimum logfile number found:", minArchivedLogNumber, "maximum logfile number found:", maxArchivedLogNumber);
+        }
+        if (!seenNewFile && ranges[ranges.length - 1] > maxArchivedLogNumber) {
+          // we have seen a new logfile in the archive
+          seenNewFile = true;
+          maxArchivedLogNumber = ranges[ranges.length - 1];
+        } else if (seenNewFile && ranges[0] > maxArchivedLogNumber) {
+          seenNewFileDeletion = true;
+        }
+        if (ranges[0] > minArchivedLogNumber) {
+          // we have seen the deletion of at least one logfile
+          seenInitialDeletion = true;
+        }
+      }
+
+      if (seenInitialDeletion && seenNewFileDeletion) {
+        break;
+      }
+
+      assertFalse(time() - start > 600, "time's up for this test!");
+    }
+  };
+
+  return {
+    setUp: function() {
+      arango.reconnect(originalEndpoint, "_system", "root", "");
+    },
+
+    tearDown: function() {
+      arango.reconnect(originalEndpoint, "_system", "root", "");
+    },
+
+    testAgent: function() {
+      const huge = Array(128).join("XYZ");
+      let docs = [];
+      for (let i = 0; i < 100; ++i) {
+        docs.push({ huge });
+      }
+    
+      let getRanges = function() {
+        return require("@arangodb/replication").logger.tickRanges().filter(function(r) {
+          return r.status === 'collected';
+        }).map(function(r) {
+          return parseInt(r.datafile.replace(/^.*?(\d+)\.log$/, "$1"));
+        });
+      };
+      
+      let insertData = function() {
+        let c = db._collection(cn);
+        // require("console").warn("inserting more data");
+        for (let i = 0; i < 200; ++i) {
+          c.insert(docs);
+        }
+      };
+
+      const agents = getServers('agent');
+      assertTrue(agents.length > 0, "no agents found");
+      const agent = agents[0].endpoint;
+      require("console").warn("connecting to agent", agent);
+      arango.reconnect(agent, "_system", "root", "");
+      try {
+        db._drop(cn);
+        db._create(cn);
+        run(insertData, getRanges);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testDBServer: function() {
+      const huge = Array(128).join("XYZ");
+      let docs = [];
+      for (let i = 0; i < 100; ++i) {
+        docs.push({ huge });
+      }
+        
+      const coordinators = getServers("coordinator");
+      assertTrue(coordinators.length > 0, "no coordinators found");
+      const coordinator = coordinators[0].endpoint;
+      
+      const dbservers = getServers("dbserver");
+      assertTrue(dbservers.length > 0, "no dbservers found");
+      const dbserver = dbservers[0].endpoint;
+        
+      require("console").warn("connecting to dbserver", dbserver);
+      
+      let insertData = function() {
+        arango.reconnect(coordinator, "_system", "root", "");
+        let c = db._collection(cn);
+        // require("console").warn("inserting more data");
+        for (let i = 0; i < 250; ++i) {
+          c.insert(docs);
+        }
+      };
+      
+      let getRanges = function() {
+        arango.reconnect(dbserver, "_system", "root", "");
+        return require("@arangodb/replication").logger.tickRanges().filter(function(r) {
+          return r.status === 'collected';
+        }).map(function(r) {
+          return parseInt(r.datafile.replace(/^.*?(\d+)\.log$/, "$1"));
+        });
+      };
+
+      try {
+        arango.reconnect(coordinator, "_system", "root", "");
+        db._drop(cn);
+        db._create(cn, { numberOfShards: dbservers.length }); // we must make sure that we insert data to each db server
+        run(insertData, getRanges);
+      } finally {
+        arango.reconnect(coordinator, "_system", "root", "");
+        db._drop(cn);
+      }
+    },
+
+  };
+}
+
+jsunity.run(WalCleanupSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Remove archived RocksDB WAL files from the archive on agent servers. Previously WAL files were retained even agent servers due to an error.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

Also added a test suite in this PR. The test suite needs separate activation in Jenkins so that it will run
`scripts/unittest wal_cleanup --storageEngine rocksdb --cluster true`

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/4821/