### PR TITLE
Move roundCost function to utilities

### DIFF
--- a/js/server/modules/@arangodb/aql-helper.js
+++ b/js/server/modules/@arangodb/aql-helper.js
@@ -381,6 +381,27 @@ function removeClusterNodesFromPlan (nodes) {
   });
 }
 
+function roundCost (obj) {
+  if (Array.isArray(obj)) {
+    return obj.map(roundCost);
+  } else if (typeof obj === 'object') {
+    var result = {};
+    for (var key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        if (key === "estimatedCost" ) {
+          result[key] = Math.round(obj[key]);
+        } else {
+          result[key] = roundCost(obj[key]);
+        }
+      }
+    }
+    return result;
+  } else {
+    return obj;
+  }
+}
+
+
 exports.getParseResults = getParseResults;
 exports.assertParseError = assertParseError;
 exports.getQueryExplanation = getQueryExplanation;
@@ -398,3 +419,4 @@ exports.getQueryMultiplePlansAndExecutions = getQueryMultiplePlansAndExecutions;
 exports.removeAlwaysOnClusterRules = removeAlwaysOnClusterRules;
 exports.removeClusterNodes = removeClusterNodes;
 exports.removeClusterNodesFromPlan = removeClusterNodesFromPlan;
+exports.roundCost = roundCost;

--- a/tests/js/server/aql/aql-graph-traverser.js
+++ b/tests/js/server/aql/aql-graph-traverser.js
@@ -39,33 +39,14 @@ const gm = require('@arangodb/general-graph');
 const vn = 'UnitTestVertexCollection';
 const en = 'UnitTestEdgeCollection';
 const isCluster = require('@arangodb/cluster').isCluster();
+const roundCost = require('@arangodb/aql-helper').roundCost;
+
 var _ = require('lodash');
 var vertex = {};
 var edge = {};
 var vc;
 var ec;
 var mmfilesEngine = (db._engine().name === 'mmfiles');
-
-
-let roundCost = function(obj) {
-  if (Array.isArray(obj)) {
-    return obj.map(roundCost);
-  } else if (typeof obj === 'object') {
-    var result = {};
-    for (var key in obj) {
-      if (obj.hasOwnProperty(key)) {
-        if (key === "estimatedCost" ) {
-          result[key] = Math.round(obj[key]);
-        } else {
-          result[key] = roundCost(obj[key]);
-        }
-      }
-    }
-    return result;
-  } else {
-    return obj;
-  }
-};
 
 var cleanup = function () {
   db._drop(vn);


### PR DESCRIPTION
This enables it to be used in other tests, most notably the enterprise traverser tests which show the same floating point fluctuation problems as the community edition traverser tests.

There will be a PR on the enterprise edition that depends on this PR.