### PR TITLE
Fix shebangs in scripts so that they work on non-linuxey systems

### DIFF
--- a/scripts/analyzeNetworkSocketUsage.sh
+++ b/scripts/analyzeNetworkSocketUsage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # we first count open sockets in total on the system:
 echo "open sockets: "
 F="/tmp/$$_netstat.log"

--- a/scripts/build-bundle.sh
+++ b/scripts/build-bundle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/build-dbg-deb.sh
+++ b/scripts/build-dbg-deb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # To install the build libraries needed by this script run:
 # `sudo apt-get install cmake libjemalloc-dev libssl-dev libreadline-dev`
 # After the packages are built you will find them in /var/tmp

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # To install the build libraries needed by this script run:
 # `sudo apt-get install cmake libjemalloc-dev libssl-dev libreadline-dev`
 # After the packages are built you will find them in /var/tmp

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/build-nsis.sh
+++ b/scripts/build-nsis.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/build-snap.sh
+++ b/scripts/build-snap.sh
@@ -1,5 +1,5 @@
 
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/build-xc-deb.sh
+++ b/scripts/build-xc-deb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/build-xc64-deb.sh
+++ b/scripts/build-xc64-deb.sh
@@ -1,5 +1,5 @@
 
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/buildCompletionsBash.sh
+++ b/scripts/buildCompletionsBash.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ "$1" == "" ]]; then
   echo "usage $0 outfile"

--- a/scripts/buildCompletionsFish.sh
+++ b/scripts/buildCompletionsFish.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ "$1" == "" ]]; then
   echo "usage $0 outfile"

--- a/scripts/cluster-run-common.sh
+++ b/scripts/cluster-run-common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function help() {
   echo "USAGE: $0 [options]"

--- a/scripts/dumpAgency.sh
+++ b/scripts/dumpAgency.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$*" == "" ] ; then
     curl -Ls http://localhost:4001/_api/agency/read -d '[["/"]]' | jq .
 else

--- a/scripts/encryptionTest.sh
+++ b/scripts/encryptionTest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script runs the go-driver tests against an ArangoDB enterprise 
 # docker image that has encryption turned on.

--- a/scripts/generateDocumentation.sh
+++ b/scripts/generateDocumentation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ##python-setuptools
 ##

--- a/scripts/generateMaintenanceTestData.sh
+++ b/scripts/generateMaintenanceTestData.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Generate test data for maintenance unit tests
 #

--- a/scripts/killLocalCluster.sh
+++ b/scripts/killLocalCluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 killall arangod
 sleep 2

--- a/scripts/limitMemory.sh
+++ b/scripts/limitMemory.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # limit memory useage for process
 # using control groups https://en.wikipedia.org/wiki/Cgroups
 

--- a/scripts/quickieTest.sh
+++ b/scripts/quickieTest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 JSLINTOUT=/tmp/jslintout.$$
 trap "rm -rf ${JSLINTOUT}" EXIT
 

--- a/scripts/setupPerfEvents.sh
+++ b/scripts/setupPerfEvents.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This requires the perf utility to be installed and the OS must be linux.
 # Compile with CMAKE_BUILD_TYPE=RelWithDebInfo in the subdirectory "build".

--- a/scripts/setupPerfEvents_onlyCriticalWrite.sh
+++ b/scripts/setupPerfEvents_onlyCriticalWrite.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This requires the perf utility to be installed and the OS must be linux.
 # Compile with CMAKE_BUILD_TYPE=RelWithDebInfo in the subdirectory "build".

--- a/scripts/shutdownLocalCluster.sh
+++ b/scripts/shutdownLocalCluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 params=("$@")
 
 case $OSTYPE in

--- a/scripts/startArangoDBClusterLocal.sh
+++ b/scripts/startArangoDBClusterLocal.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ -z "$XTERM" ] ; then
     XTERM=x-terminal-emulator
 fi

--- a/scripts/startLeaderFollower.sh
+++ b/scripts/startLeaderFollower.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 params=("$@")
 
 rm -rf active

--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 params=("$@")
 
 rm -rf cluster

--- a/scripts/startLocalDockerCluster.sh
+++ b/scripts/startLocalDockerCluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 DOCKERIMAGE=arangodb/arangodb:3.0.0-p4
 if [ -z "$XTERM" ] ; then
     XTERM=x-terminal-emulator

--- a/scripts/startStandAloneAgency.sh
+++ b/scripts/startStandAloneAgency.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function help() {
   echo "USAGE: scripts/startStandAloneAgency.sh [options]"

--- a/scripts/tmux_starter
+++ b/scripts/tmux_starter
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author Jan Christoph Uhde
 
 main(){

--- a/scripts/unittest
+++ b/scripts/unittest
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 export PID=$$
 export GLIBCXX_FORCE_NEW=1
 

--- a/scripts/unpackInspectorReport.sh
+++ b/scripts/unpackInspectorReport.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 filename=arango-inspector.json
 outdir=arango-inspector

--- a/utils/cppcheck.sh
+++ b/utils/cppcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 rm -f cppcheck.log cppcheck.tmp
 trap "rm -rf cppcheck.tmp" EXIT
 touch cppcheck.tmp

--- a/utils/generateExamples.sh
+++ b/utils/generateExamples.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 export PID=$$
 
 if test -n "$ORIGINAL_PATH"; then

--- a/utils/generateREADME.sh
+++ b/utils/generateREADME.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 IN=${1:-README.md}

--- a/utils/generateSwagger.sh
+++ b/utils/generateSwagger.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 exec python \
   `pwd`/utils/generateSwagger.py \

--- a/utils/gitjslint.sh
+++ b/utils/gitjslint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if test "`git status --short | grep '^\(.[MAU]\|[MAU].\) .*js$' | wc -l`" -eq 0; then
   exit 0;

--- a/utils/manPages.sh
+++ b/utils/manPages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 IN="$1"
 OUT="$2"

--- a/utils/reformat.sh
+++ b/utils/reformat.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 find arangod arangosh lib enterprise \
      -name Zip -prune -o \

--- a/utils/replace_string.sh
+++ b/utils/replace_string.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 while read file; do
     echo "$file: $1 -> $2"


### PR DESCRIPTION
This has bitten me a few times now when running ArangoDB on non-linux platforms.

Kept my fingers off the `3rdparty` directory, because I do not know how much in there is directly imported and hence broken upstream. 