### PR TITLE
[3.4] MoveShard release Lock when collection dropped

### DIFF
--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -417,7 +417,7 @@ JOB_STATUS MoveShard::status() {
   std::string planPath = planColPrefix + _database + "/" + _collection;
   if (!_snapshot.has(planPath)) {
     // Oops, collection is gone, simple finish job:
-    finish("", _shard, true, "collection was dropped");
+    finish(_to, _shard, true, "collection was dropped");
     return FINISHED;
   }
 
@@ -661,7 +661,7 @@ JOB_STATUS MoveShard::pendingLeader() {
     finishedAfterTransaction = true;
   } else {
     // something seriously wrong here, fail job:
-    finish("", _shard, false, "something seriously wrong");
+    finish(_to, _shard, false, "something seriously wrong");
     return FAILED;
   }
 


### PR DESCRIPTION
### Scope & Purpose

If a MoveShard job is in `pending` state and the collection it refers to is dropped, the lock on the `toServer` was not released.

### Testing & Verification
This change is a trivial rework / code cleanup without any test coverage.

http://jenkins01.arangodb.biz:8080/job/arangodb-matrix-pr/4882/