### PR TITLE
[3.4] FollowerInfo Lock during AgencyTRX

### DIFF
--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -26,6 +26,9 @@
 #define ARANGOD_CLUSTER_FOLLOWER_INFO_H 1
 
 #include "ClusterInfo.h"
+#include "Basics/Mutex.h"
+#include "Basics/ReadWriteLock.h"
+#include "Basics/WriteLocker.h"
 
 namespace arangodb {
 
@@ -35,7 +38,12 @@ namespace arangodb {
 
 class FollowerInfo {
   std::shared_ptr<std::vector<ServerID> const> _followers;
-  mutable Mutex _mutex;
+
+  // The agencyMutex is used to synchronise access to the agency.
+  // the _dataLock is used to sync the access to local data.
+  // The agencyMutex is always locked before the _dataLock is locked.
+  mutable Mutex _agencyMutex;
+  mutable arangodb::basics::ReadWriteLock _dataLock;
   arangodb::LogicalCollection* _docColl;
   std::string _theLeader;
   // if the latter is empty, then we are leading
@@ -45,11 +53,14 @@ class FollowerInfo {
   explicit FollowerInfo(arangodb::LogicalCollection* d)
       : _followers(new std::vector<ServerID>()), _docColl(d), _theLeaderTouched(false) {}
 
-  //////////////////////////////////////////////////////////////////////////////
+  ////////////////////////////////////////////////////////////////////////////////
   /// @brief get information about current followers of a shard.
-  //////////////////////////////////////////////////////////////////////////////
+  ////////////////////////////////////////////////////////////////////////////////
 
-  std::shared_ptr<std::vector<ServerID> const> get() const;
+  std::shared_ptr<std::vector<ServerID> const> get() const {
+    READ_LOCKER(readLocker, _dataLock);
+    return _followers;
+  }
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief add a follower to a shard, this is only done by the server side
@@ -81,7 +92,7 @@ class FollowerInfo {
   //////////////////////////////////////////////////////////////////////////////
 
   void setTheLeader(std::string const& who) {
-    MUTEX_LOCKER(locker, _mutex);
+    WRITE_LOCKER(writeLocker, _dataLock);
     _theLeader = who;
     _theLeaderTouched = true;
   }
@@ -91,7 +102,7 @@ class FollowerInfo {
   //////////////////////////////////////////////////////////////////////////////
 
   std::string getLeader() const {
-    MUTEX_LOCKER(locker, _mutex);
+    READ_LOCKER(readLocker, _dataLock);
     return _theLeader;
   }
 
@@ -100,7 +111,7 @@ class FollowerInfo {
   //////////////////////////////////////////////////////////////////////////////
 
   bool getLeaderTouched() const {
-    MUTEX_LOCKER(locker, _mutex);
+    READ_LOCKER(readLocker, _dataLock);
     return _theLeaderTouched;
   }
 };


### PR DESCRIPTION
### Scope & Purpose

Added special lock for local data. Use read and write locking. Do not hold read lock during agency transactions.

### Testing & Verification
This change is already covered by existing tests.