### PR TITLE
Updated names for  text and norm analyzer parameters. Added tests for…

### DIFF
--- a/3rdParty/iresearch/core/analysis/text_token_normalizing_stream.hpp
+++ b/3rdParty/iresearch/core/analysis/text_token_normalizing_stream.hpp
@@ -40,7 +40,7 @@ class text_token_normalizing_stream: public analyzer, util::noncopyable {
     enum case_convert_t { LOWER, NONE, UPPER };
     case_convert_t case_convert{case_convert_t::NONE}; // no extra normalization
     std::string locale;
-    bool no_accent{false}; // no extra normalization
+    bool accent{true}; // no extra normalization
   };
 
   struct state_t;

--- a/3rdParty/iresearch/core/analysis/text_token_stream.hpp
+++ b/3rdParty/iresearch/core/analysis/text_token_stream.hpp
@@ -43,8 +43,8 @@ class text_token_stream : public analyzer, util::noncopyable {
     // needed for mark empty explicit_stopwords as valid and prevent loading from defaults
     bool explicit_stopwords_set{ false }; 
     std::string locale;
-    bool no_accent{true}; // remove accents from letters, mach original implementation
-    bool no_stem{false}; // try to stem if possible, mach original implementation
+    bool accent{false}; // leave accents on letters, mach original implementation
+    bool stemming{true}; // try to stem if possible, mach original implementation
     std::string stopwordsPath{0}; // string with zero char indicates 'no value set'
   };
 

--- a/3rdParty/iresearch/tests/analysis/text_analyzer_tests.cpp
+++ b/3rdParty/iresearch/tests/analysis/text_analyzer_tests.cpp
@@ -191,7 +191,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_text_analyzer) {
     }
     {
       // stopwords  should be set to empty - or default values will interfere with test data
-      auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, "{\"locale\":\"en_US.UTF-8\", \"stopwords\":[], \"caseConvert\":\"lower\"}");
+      auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, "{\"locale\":\"en_US.UTF-8\", \"stopwords\":[], \"case\":\"lower\"}");
       ASSERT_NE(nullptr, stream);
       testFunc(data, stream.get());
     }
@@ -226,7 +226,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_text_analyzer) {
     }
     {
       // stopwords  should be set to empty - or default values will interfere with test data
-      auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, "{\"locale\":\"en_US.UTF-8\", \"stopwords\":[], \"caseConvert\":\"upper\"}");
+      auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, "{\"locale\":\"en_US.UTF-8\", \"stopwords\":[], \"case\":\"upper\"}");
       ASSERT_NE(nullptr, stream);
       testFunc(data, stream.get());
     }
@@ -262,7 +262,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_text_analyzer) {
     }
     {
       // stopwords  should be set to empty - or default values will interfere with test data
-      auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, "{\"locale\":\"en_US.UTF-8\", \"stopwords\":[], \"caseConvert\":\"none\"}");
+      auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, "{\"locale\":\"en_US.UTF-8\", \"stopwords\":[], \"case\":\"none\"}");
       ASSERT_NE(nullptr, stream);
       testFunc(data, stream.get());
     }
@@ -400,7 +400,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_text_analyzer) {
     }
     {
       // stopwords  should be set to empty - or default values will interfere with test data
-      auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, "{\"locale\":\"ru_RU.UTF-8\", \"stopwords\":[], \"noAccent\":false}");
+      auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, "{\"locale\":\"ru_RU.UTF-8\", \"stopwords\":[], \"accent\":true}");
       ASSERT_NE(nullptr, stream);
       testFunc(data, stream.get());
     }
@@ -447,7 +447,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_text_analyzer) {
     }
     {
       // stopwords  should be set to empty - or default values will interfere with test data
-      auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, "{\"locale\":\"ru_RU.UTF-8\", \"stopwords\":[], \"noStem\":true}");
+      auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, "{\"locale\":\"ru_RU.UTF-8\", \"stopwords\":[], \"stemming\":false}");
       ASSERT_NE(nullptr, stream);
       testFunc(data, stream.get());
     }
@@ -661,7 +661,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_load_stopwords_path_override_emptypath)
     oldCWD.chdir();
   });
 
-  std::string config = "{\"locale\":\"en_US.UTF-8\",\"caseConvert\":\"lower\",\"noAccent\":true,\"noStem\":false,\"stopwordsPath\":\"\"}";
+  std::string config = "{\"locale\":\"en_US.UTF-8\",\"case\":\"lower\",\"accent\":false,\"stemming\":true,\"stopwordsPath\":\"\"}";
   auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
   ASSERT_NE(nullptr, stream);
 
@@ -683,51 +683,51 @@ TEST_F(TextAnalyzerParserTestSuite, test_make_config_json) {
   
   //with unknown parameter
   {
-    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"invalid_parameter\":true,\"stopwords\":[],\"noAccent\":false,\"noStem\":true}";
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"case\":\"lower\",\"invalid_parameter\":true,\"stopwords\":[],\"accent\":true,\"stemming\":false}";
     auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config.c_str());
     ASSERT_NE(nullptr, stream);
 
     std::string actual;
     ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
-    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"stopwords\":[],\"noAccent\":false,\"noStem\":true}", actual);
+    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"case\":\"lower\",\"stopwords\":[],\"accent\":true,\"stemming\":false}", actual);
   }
 
   // no case convert in creation. Default value shown
   {
-    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"stopwords\":[],\"noAccent\":false,\"noStem\":true}";
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"stopwords\":[],\"accent\":true,\"stemming\":false}";
     auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
     ASSERT_NE(nullptr, stream);
 
     std::string actual;
     ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
-    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"stopwords\":[],\"noAccent\":false,\"noStem\":true}" , actual);
+    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"case\":\"lower\",\"stopwords\":[],\"accent\":true,\"stemming\":false}" , actual);
   }
 
   // no accent in creation. Default value shown
   {
-    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"stopwords\":[],\"noStem\":true}";
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"case\":\"lower\",\"stopwords\":[],\"stemming\":false}";
     auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
     ASSERT_NE(nullptr, stream);
 
     std::string actual;
     ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
-    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"stopwords\":[],\"noAccent\":true,\"noStem\":true}", actual);
+    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"case\":\"lower\",\"stopwords\":[],\"accent\":false,\"stemming\":false}", actual);
   }
 
   // no stem in creation. Default value shown
   {
-    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"stopwords\":[],\"noAccent\":false}";
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"case\":\"lower\",\"stopwords\":[],\"accent\":true}";
     auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
     ASSERT_NE(nullptr, stream);
 
     std::string actual;
     ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
-    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"stopwords\":[],\"noAccent\":false,\"noStem\":false}", actual);
+    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"case\":\"lower\",\"stopwords\":[],\"accent\":true,\"stemming\":true}", actual);
   }
 
   // non default values for stem, accent and case
   {
-    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"upper\",\"stopwords\":[],\"noAccent\":false,\"noStem\":true}";
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"case\":\"upper\",\"stopwords\":[],\"accent\":true,\"stemming\":false}";
     auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
     ASSERT_NE(nullptr, stream);
 
@@ -748,7 +748,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_make_config_json) {
 
     iresearch::setenv(text_token_stream::STOPWORD_PATH_ENV_VARIABLE, IResearch_test_resource_dir, true);
 
-    std::string config = "{\"locale\":\"en_US.UTF-8\",\"caseConvert\":\"lower\",\"noAccent\":true,\"noStem\":false}";
+    std::string config = "{\"locale\":\"en_US.UTF-8\",\"case\":\"lower\",\"accent\":false,\"stemming\":true}";
     auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
     ASSERT_NE(nullptr, stream);
 
@@ -759,7 +759,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_make_config_json) {
   
   // empty stopwords, but stopwords path
   {
-    std::string config = "{\"locale\":\"en_US.UTF-8\",\"caseConvert\":\"upper\",\"stopwords\":[],\"noAccent\":true,\"noStem\":false,\"stopwordsPath\":\"" IResearch_test_resource_dir "\"}";
+    std::string config = "{\"locale\":\"en_US.UTF-8\",\"case\":\"upper\",\"stopwords\":[],\"accent\":false,\"stemming\":true,\"stopwordsPath\":\"" IResearch_test_resource_dir "\"}";
     auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
     ASSERT_NE(nullptr, stream);
 
@@ -770,7 +770,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_make_config_json) {
 
   // no stopwords, but stopwords path
   {
-    std::string config = "{\"locale\":\"en_US.UTF-8\",\"caseConvert\":\"upper\",\"noAccent\":true,\"noStem\":false,\"stopwordsPath\":\"" IResearch_test_resource_dir "\"}";
+    std::string config = "{\"locale\":\"en_US.UTF-8\",\"case\":\"upper\",\"accent\":false,\"stemming\":true,\"stopwordsPath\":\"" IResearch_test_resource_dir "\"}";
     auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
     ASSERT_NE(nullptr, stream);
 
@@ -788,7 +788,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_make_config_json) {
       oldCWD.chdir();
     });
 
-    std::string config = "{\"locale\":\"en_US.UTF-8\",\"caseConvert\":\"lower\",\"noAccent\":true,\"noStem\":false,\"stopwordsPath\":\"\"}";
+    std::string config = "{\"locale\":\"en_US.UTF-8\",\"case\":\"lower\",\"accent\":false,\"stemming\":true,\"stopwordsPath\":\"\"}";
     auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
     ASSERT_NE(nullptr, stream);
 
@@ -800,7 +800,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_make_config_json) {
 
   // non-empty stopwords with duplicates
   {
-    std::string config = "{\"locale\":\"en_US.UTF-8\",\"caseConvert\":\"upper\",\"stopwords\":[\"z\",\"a\",\"b\",\"a\"],\"noAccent\":true,\"noStem\":false,\"stopwordsPath\":\"" IResearch_test_resource_dir "\"}";
+    std::string config = "{\"locale\":\"en_US.UTF-8\",\"case\":\"upper\",\"stopwords\":[\"z\",\"a\",\"b\",\"a\"],\"accent\":false,\"stemming\":true,\"stopwordsPath\":\"" IResearch_test_resource_dir "\"}";
     auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
     ASSERT_NE(nullptr, stream);
 
@@ -826,7 +826,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_make_config_json) {
 }
 
 TEST_F(TextAnalyzerParserTestSuite, test_make_config_text) {
-  std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"stopwords\":[],\"noAccent\":false}";
+  std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"case\":\"lower\",\"stopwords\":[],\"accent\":true}";
   auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config.c_str());
   ASSERT_NE(nullptr, stream);
 
@@ -836,7 +836,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_make_config_text) {
 }
 
 TEST_F(TextAnalyzerParserTestSuite, test_make_config_invalid_format) {
-  std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"stopwords\":[],\"noAccent\":false}";
+  std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"case\":\"lower\",\"stopwords\":[],\"accent\":true}";
   auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config.c_str());
   ASSERT_NE(nullptr, stream);
 

--- a/3rdParty/iresearch/tests/analysis/text_token_normalizing_stream_tests.cpp
+++ b/3rdParty/iresearch/tests/analysis/text_token_normalizing_stream_tests.cpp
@@ -193,7 +193,7 @@ TEST_F(text_token_normalizing_stream_tests, test_load) {
   // with UPPER case 
   {
     irs::string_ref data("ruNNing");
-    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"en\", \"caseConvert\":\"upper\"}");
+    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"en\", \"case\":\"upper\"}");
 
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data));
@@ -213,7 +213,7 @@ TEST_F(text_token_normalizing_stream_tests, test_load) {
   // with LOWER case 
   {
     irs::string_ref data("ruNNing");
-    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"en\", \"caseConvert\":\"lower\"}");
+    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"en\", \"case\":\"lower\"}");
 
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data));
@@ -233,7 +233,7 @@ TEST_F(text_token_normalizing_stream_tests, test_load) {
   // with NONE case 
   {
     irs::string_ref data("ruNNing");
-    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"en\", \"caseConvert\":\"none\"}");
+    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"en\", \"case\":\"none\"}");
 
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data));
@@ -258,7 +258,7 @@ TEST_F(text_token_normalizing_stream_tests, test_load) {
     auto locale = irs::locale_utils::locale(irs::string_ref::NIL, "utf8", true); 
     ASSERT_TRUE(irs::locale_utils::append_external<wchar_t>(data, unicodeData, locale));
     
-    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"de_DE.UTF8\", \"caseConvert\":\"lower\", \"noAccent\":true}");
+    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"de_DE.UTF8\", \"case\":\"lower\", \"accent\":false}");
    
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data));
@@ -286,8 +286,8 @@ TEST_F(text_token_normalizing_stream_tests, test_load) {
     ASSERT_EQ(nullptr, irs::analysis::analyzers::get("norm", irs::text_format::json, "[]"));
     ASSERT_EQ(nullptr, irs::analysis::analyzers::get("norm", irs::text_format::json, "{}"));
     ASSERT_EQ(nullptr, irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":1}"));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"en\", \"caseConvert\":42}"));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"en\", \"noAccent\":42}"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"en\", \"case\":42}"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"en\", \"accent\":42}"));
   }
 
   // load text
@@ -315,41 +315,41 @@ TEST_F(text_token_normalizing_stream_tests, test_make_config_json) {
 
   //with unknown parameter
   {
-    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"invalid_parameter\":true,\"noAccent\":false}";
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"case\":\"lower\",\"invalid_parameter\":true,\"accent\":true}";
     auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, config.c_str());
     ASSERT_NE(nullptr, stream);
 
     std::string actual;
     ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
-    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"noAccent\":false}", actual);
+    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"case\":\"lower\",\"accent\":true}", actual);
   }
 
   // no case convert in creation. Default value shown
   {
-    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"noAccent\":false}";
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"accent\":true}";
     auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, config);
     ASSERT_NE(nullptr, stream);
 
     std::string actual;
     ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
-    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"none\",\"noAccent\":false}", actual);
+    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"case\":\"none\",\"accent\":true}", actual);
   }
 
   // no accent in creation. Default value shown
   {
-    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\"}";
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"case\":\"lower\"}";
     auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, config);
     ASSERT_NE(nullptr, stream);
 
     std::string actual;
     ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
-    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"noAccent\":false}", actual);
+    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"case\":\"lower\",\"accent\":true}", actual);
   }
 
   
   // non default values for accent and case
   {
-    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"upper\",\"noAccent\":false}";
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"case\":\"upper\",\"accent\":true}";
     auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, config);
     ASSERT_NE(nullptr, stream);
 

--- a/tests/js/common/aql/aql-view-arangosearch-feature.js
+++ b/tests/js/common/aql/aql-view-arangosearch-feature.js
@@ -391,6 +391,171 @@ function iResearchFeatureAqlTestSuite () {
 
     },
 
+    testNormAnalyzer : function() {
+      let analyzerName = "normUnderTest";
+      // case upper
+      {
+        analyzers.save(analyzerName, "norm", " { \"locale\" : \"en\", \"case\": \"upper\" }");
+        let result = db._query(
+          "RETURN TOKENS('fOx', '" + analyzerName + "' )",
+          null,
+          { }
+        ).toArray();
+        assertEqual(1, result.length);
+        assertEqual(1, result[0].length);
+        assertEqual([ "FOX" ], result[0]);
+        analyzers.remove(analyzerName, true);
+      }
+      // case lower
+      {
+        analyzers.save(analyzerName, "norm", " {  \"locale\" : \"en\", \"case\": \"lower\" }");
+        let result = db._query(
+          "RETURN TOKENS('fOx', '" + analyzerName + "' )",
+          null,
+          { }
+        ).toArray();
+        assertEqual(1, result.length);
+        assertEqual(1, result[0].length);
+        assertEqual([ "fox" ], result[0]);
+        analyzers.remove(analyzerName, true);
+      }
+      // case none
+      {
+        analyzers.save(analyzerName, "norm", " {  \"locale\" : \"en\", \"case\": \"none\" }");
+        let result = db._query(
+          "RETURN TOKENS('fOx', '" + analyzerName + "' )",
+          null,
+          { }
+        ).toArray();
+        assertEqual(1, result.length);
+        assertEqual(1, result[0].length);
+        assertEqual([ "fOx" ], result[0]);
+        analyzers.remove(analyzerName, true);
+      }
+       // accent removal
+      {
+        analyzers.save(analyzerName, "norm", " {  \"locale\" : \"de_DE.UTF8\", \"case\": \"none\", \"accent\":false }");
+        let result = db._query(
+          "RETURN TOKENS('\u00F6\u00F5', '" + analyzerName + "' )",
+          null,
+          { }
+        ).toArray();
+        assertEqual(1, result.length);
+        assertEqual(1, result[0].length);
+        assertEqual([ "\u006F\u006F" ], result[0]);
+        analyzers.remove(analyzerName, true);
+      }
+       // accent leave
+      {
+        analyzers.save(analyzerName, "norm", " {  \"locale\" : \"de_DE.UTF8\", \"case\": \"none\", \"accent\":true }");
+        let result = db._query(
+          "RETURN TOKENS('\u00F6\u00F5', '" + analyzerName + "' )",
+          null,
+          { }
+        ).toArray();
+        assertEqual(1, result.length);
+        assertEqual(1, result[0].length);
+        assertEqual([ "\u00F6\u00F5" ], result[0]);
+        analyzers.remove(analyzerName, true);
+      }
+    },
+
+    testCustomTextAnalyzer : function() {
+      let analyzerName = "textUnderTest";
+      // case upper
+      {
+        analyzers.save(analyzerName, "text", " { \"locale\" : \"en\", \"case\": \"upper\", \"stopwords\": [] }");
+        let result = db._query(
+          "RETURN TOKENS('fOx', '" + analyzerName + "' )",
+          null,
+          { }
+        ).toArray();
+        assertEqual(1, result.length);
+        assertEqual(1, result[0].length);
+        assertEqual([ "FOX" ], result[0]);
+        analyzers.remove(analyzerName, true);
+      }
+      // case lower
+      {
+        analyzers.save(analyzerName, "text", " {  \"locale\" : \"en\", \"case\": \"lower\", \"stopwords\": [] }");
+        let result = db._query(
+          "RETURN TOKENS('fOx', '" + analyzerName + "' )",
+          null,
+          { }
+        ).toArray();
+        assertEqual(1, result.length);
+        assertEqual(1, result[0].length);
+        assertEqual([ "fox" ], result[0]);
+        analyzers.remove(analyzerName, true);
+      }
+      // case none
+      {
+        analyzers.save(analyzerName, "text", " {  \"locale\" : \"en\", \"case\": \"none\", \"stopwords\": [] }");
+        let result = db._query(
+          "RETURN TOKENS('fOx', '" + analyzerName + "' )",
+          null,
+          { }
+        ).toArray();
+        assertEqual(1, result.length);
+        assertEqual(1, result[0].length);
+        assertEqual([ "fOx" ], result[0]);
+        analyzers.remove(analyzerName, true);
+      }
+       // accent removal
+      {
+        analyzers.save(analyzerName, "text", " {  \"locale\" : \"de_DE.UTF8\", \"case\": \"none\", \"accent\":false, \"stopwords\": [], \"stemming\":false }");
+        let result = db._query(
+          "RETURN TOKENS('\u00F6\u00F5', '" + analyzerName + "' )",
+          null,
+          { }
+        ).toArray();
+        assertEqual(1, result.length);
+        assertEqual(1, result[0].length);
+        assertEqual([ "\u006F\u006F" ], result[0]);
+        analyzers.remove(analyzerName, true);
+      }
+       // accent leave
+      {
+        analyzers.save(analyzerName, "text", " {  \"locale\" : \"de_DE.UTF8\", \"case\": \"none\", \"accent\":true, \"stopwords\": [], \"stemming\":false}");
+        let result = db._query(
+          "RETURN TOKENS('\u00F6\u00F5', '" + analyzerName + "' )",
+          null,
+          { }
+        ).toArray();
+        assertEqual(1, result.length);
+        assertEqual(1, result[0].length);
+        assertEqual([ "\u00F6\u00F5" ], result[0]);
+        analyzers.remove(analyzerName, true);
+      }
+
+      // no stemming
+      {
+        analyzers.save(analyzerName, "text", " {  \"locale\" : \"en\", \"case\": \"none\", \"stemming\":false, \"stopwords\": [] }");
+        let result = db._query(
+          "RETURN TOKENS('jumps', '" + analyzerName + "' )",
+          null,
+          { }
+        ).toArray();
+        assertEqual(1, result.length);
+        assertEqual(1, result[0].length);
+        assertEqual([ "jumps" ], result[0]);
+        analyzers.remove(analyzerName, true);
+      }
+      // stemming
+      {
+        analyzers.save(analyzerName, "text", " {  \"locale\" : \"en\", \"case\": \"none\", \"stemming\":true, \"stopwords\": [] }");
+        let result = db._query(
+          "RETURN TOKENS('jumps', '" + analyzerName + "' )",
+          null,
+          { }
+        ).toArray();
+        assertEqual(1, result.length);
+        assertEqual(1, result[0].length);
+        assertEqual([ "jump" ], result[0]);
+        analyzers.remove(analyzerName, true);
+      }
+    }
+
   };
 }
 


### PR DESCRIPTION
… new parameter names.

Renaming parameters  to make them reflect the result and not to confuse user with inverted logic.

Affected analyzer types: norm, text
Parameters renamed:
`caseConvert` -> `case`
`noAccent` -> `accent`
`noStem` -> `stemming`

https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/4908/