### PR TITLE
Try improving error message

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -2100,13 +2100,17 @@ Result ClusterInfo::dropCollectionCoordinator(  // drop collection
 
   if (!clones.empty()) {
     std::string errorMsg(
-        "Collection must not be dropped while it is a sharding prototype for "
-        "collection(s)");
-
-    for (auto const& i : clones) {
-      errorMsg += std::string(" ") + i;
-    }
-
+      "Collection ");
+    errorMsg += coll->name();
+    errorMsg += " must not be dropped while ";
+    errorMsg += arangodb::basics::StringUtils::join(clones, ", ");
+    if(clones.size() == 1) {
+      errorMsg += " has ";
+    } else {
+      errorMsg += " have ";
+    };
+    errorMsg += "distributeShardsLike set to ";
+    errorMsg += coll->name();
     errorMsg += ".";
 
     events::DropCollection(dbName, collectionID,


### PR DESCRIPTION
When we try dropping a collection `A` for which there are other collections
that have distributeShardsLike set to `A`, mention this in the error message.