### PR TITLE
Fix potential segfault

### DIFF
--- a/arangod/Utils/CollectionNameResolver.cpp
+++ b/arangod/Utils/CollectionNameResolver.cpp
@@ -32,7 +32,7 @@
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/LogicalView.h"
 #include "VocBase/vocbase.h"
-  
+
 namespace {
 std::string const UNKNOWN("_unknown");
 }
@@ -140,7 +140,6 @@ TRI_voc_cid_t CollectionNameResolver::getCollectionIdCluster(std::string const& 
       return vinfo->id();
     }
   } catch (...) {
-    // TODO: ?
   }
 
   return 0;
@@ -406,7 +405,7 @@ std::string CollectionNameResolver::lookupName(TRI_voc_cid_t cid) const {
   if (collection != nullptr && !collection->name().empty()) {
     return collection->name();
   }
-  
+
   return ::UNKNOWN;
 }
 

--- a/arangod/Utils/CollectionNameResolver.cpp
+++ b/arangod/Utils/CollectionNameResolver.cpp
@@ -70,7 +70,11 @@ std::shared_ptr<LogicalCollection> CollectionNameResolver::getCollection(std::st
 //////////////////////////////////////////////////////////////////////////////
 
 TRI_voc_cid_t CollectionNameResolver::getCollectionIdLocal(std::string const& name) const {
-  if (name[0] >= '0' && name[0] <= '9') {
+  if (name.empty()) {
+    return 0;
+  }
+
+  if (isdigit(name[0])) {
     // name is a numeric id
     return NumberUtils::atoi_zero<TRI_voc_cid_t>(name.data(), name.data() + name.size());
   }
@@ -82,7 +86,6 @@ TRI_voc_cid_t CollectionNameResolver::getCollectionIdLocal(std::string const& na
   }
 
   auto view = _vocbase.lookupView(name);
-
   if (view) {
     return view->id();
   }
@@ -101,7 +104,10 @@ TRI_voc_cid_t CollectionNameResolver::getCollectionIdCluster(std::string const& 
   if (!ServerState::isRunningInCluster(_serverRole)) {
     return getCollectionIdLocal(name);
   }
-  if (name[0] >= '0' && name[0] <= '9') {
+  if (name.empty()) {
+    return 0;
+  }
+  if (isdigit(name[0])) {
     // name is a numeric id
     TRI_voc_cid_t cid =
         NumberUtils::atoi_zero<TRI_voc_cid_t>(name.data(), name.data() + name.size());
@@ -134,6 +140,7 @@ TRI_voc_cid_t CollectionNameResolver::getCollectionIdCluster(std::string const& 
       return vinfo->id();
     }
   } catch (...) {
+    // TODO: ?
   }
 
   return 0;


### PR DESCRIPTION
### Scope & Purpose

Check whether `name` is empty when resolving collection name before we access it.

While we're here, use `isdigit` instead of check whether character is between `0` and `9`.

This *might* relate to the crash seen in https://github.com/arangodb/arangodb/issues/9302#issuecomment-504027431 but is hard to verify.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [ ] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [ ] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [ ] The behaviour change can only be verified via automatic tests

#### Related Information

*(Please reference tickets / specification etc )*

- [x] There is a GitHub Issue reported by a Community User: https://github.com/arangodb/arangodb/issues/9302#issuecomment-504027431
- [ ] There is an internal planning ticket: 
- [ ] There is a *JIRA Ticket number* (In case a customer was affected / involved): 
- [ ] There is a design document: 

### Testing & Verification

I do not know whether there is a simple way to test these functions, in particular how an empty collection name can get through.
