### PR TITLE
fix the option to specify a ruby executeable from the outside in instead of leaning on rspec.bat to do its job (3.4)

### DIFF
--- a/js/client/modules/@arangodb/test-utils.js
+++ b/js/client/modules/@arangodb/test-utils.js
@@ -36,6 +36,7 @@ const time = require('internal').time;
 const sleep = require('internal').sleep;
 const download = require('internal').download;
 const pathForTesting = require('internal').pathForTesting;
+const platform = require('internal').platform;
 
 /* Constants: */
 // const BLUE = require('internal').COLORS.COLOR_BLUE;
@@ -828,6 +829,19 @@ function runInRSpec (options, instanceInfo, file, addArgs) {
       'end\n';
 
   fs.write(tmpname, rspecConfig);
+  if (options.hasOwnProperty('ruby')) {
+    let rx = new RegExp('ruby.exe$');
+    rspec = options.ruby.replace(rx, 'rspec');
+    command = options.ruby;
+  } else {
+    if (platform.substr(0, 3) !== 'win') {
+      command = 'rspec';
+    } else {
+      // Windows process utilties would apply `.exe` to rspec.
+      // However the file is called .bat and .exe cannot be found.
+      command = 'rspec.bat';
+    }
+  }
 
   if (options.extremeVerbosity === true) {
     print('rspecConfig: \n' + rspecConfig);
@@ -836,14 +850,6 @@ function runInRSpec (options, instanceInfo, file, addArgs) {
   try {
     fs.makeDirectory(pu.LOGS_DIR);
   } catch (err) {}
-
-  if (options.ruby === '') {
-    command = options.rspec;
-    rspec = undefined;
-  } else {
-    command = options.ruby;
-    rspec = options.rspec;
-  }
 
   args = ['--color',
           '-I', fs.join('tests', 'arangodbRspecLib'),

--- a/js/client/modules/@arangodb/testsuites/rspec.js
+++ b/js/client/modules/@arangodb/testsuites/rspec.js
@@ -142,14 +142,6 @@ exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTest
   defaultFns.push('ssl_server');
 
   opts['skipSsl'] = false;
-  if (platform.substr(0, 3) !== 'win') {
-    opts['rspec'] = 'rspec';
-  } else {
-    // Windows process utilties would apply `.exe` to rspec.
-    // However the file is called .bat and .exe cannot be found.
-    opts['rspec'] = 'rspec.bat';
-  }
-  opts['ruby'] = '';
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }


### PR DESCRIPTION
http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/4943/

http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-windows-matrix/237/