### PR TITLE
make it possible to limit the number of parallel WAL tailing invocations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 devel
 -----
 
+* added option `--replication.max-parallel-tailing-invocations` to limit the maximum number
+  of concurrent WAL tailing invocations.
+
+  The option can be used to limit the usage of the WAL tailing APIs in order to control
+  server load
+
 * Speed up collection creation process in cluster, if not all agency callbacks are
   delivered successfully.
 

--- a/arangod/Replication/ReplicationFeature.h
+++ b/arangod/Replication/ReplicationFeature.h
@@ -63,6 +63,15 @@ class ReplicationFeature final : public application_features::ApplicationFeature
   /// @brief automatic failover of replication using the agency
   bool isActiveFailoverEnabled() const { return _enableActiveFailover; }
 
+  /// @brief track the number of (parallel) tailing operations
+  /// will throw an exception if the number of concurrently running operations
+  /// would exceed the configured maximum
+  void trackTailingStart();
+
+  /// @brief count down the number of parallel tailing operations
+  /// must only be called after a successful call to trackTailingstart
+  void trackTailingEnd() noexcept;
+
   /// @brief set the x-arango-endpoint header
   static void setEndpointHeader(GeneralResponse*, arangodb::ServerState::Mode);
 
@@ -76,6 +85,12 @@ class ReplicationFeature final : public application_features::ApplicationFeature
 
   /// Enable the active failover
   bool _enableActiveFailover;
+  
+  /// @brief number of currently operating tailing operations
+  std::atomic<uint64_t> _parallelTailingInvocations;
+
+  /// @brief maximum number of parallel tailing operations invocations
+  uint64_t _maxParallelTailingInvocations;
 
   std::unique_ptr<GlobalReplicationApplier> _globalReplicationApplier;
 };

--- a/arangod/RestHandler/RestWalAccessHandler.cpp
+++ b/arangod/RestHandler/RestWalAccessHandler.cpp
@@ -21,9 +21,11 @@
 /// @author Simon Grätzer
 ////////////////////////////////////////////////////////////////////////////////
 
+#include "Basics/ScopeGuard.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/VPackStringBufferAdapter.h"
 #include "Basics/VelocyPackHelper.h"
+#include "Replication/ReplicationFeature.h"
 #include "Replication/common-defines.h"
 #include "Replication/utilities.h"
 #include "Rest/HttpResponse.h"
@@ -228,6 +230,15 @@ void RestWalAccessHandler::handleCommandLastTick(WalAccess const* wal) {
 }
 
 void RestWalAccessHandler::handleCommandTail(WalAccess const* wal) {
+  // track the number of parallel invocations of the tailing API
+  auto* rf = application_features::ApplicationServer::getFeature<ReplicationFeature>("Replication");
+  // this may throw when too many threads are going into tailing
+  rf->trackTailingStart();
+  
+  auto guard = scopeGuard([rf]() {
+    rf->trackTailingEnd();
+  });
+      
   bool const useVst = (_request->transportType() == Endpoint::TransportType::VST);
 
   WalAccess::Filter filter;
@@ -405,9 +416,7 @@ void RestWalAccessHandler::handleCommandDetermineOpenTransactions(WalAccess cons
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 /// @brief Grant temporary restore rights
-//////////////////////////////////////////////////////////////////////////////
 void RestWalAccessHandler::grantTemporaryRights() {
   if (ExecContext::CURRENT != nullptr) {
     if (ExecContext::CURRENT->databaseAuthLevel() == auth::Level::RW) {

--- a/lib/Basics/ScopeGuard.h
+++ b/lib/Basics/ScopeGuard.h
@@ -25,6 +25,7 @@
 #define ARANGODB_BASICS_SCOPE_GUARD_H 1
 
 #include <type_traits>
+#include <utility>
 
 #define SCOPE_GUARD_TOKEN_PASTE_WRAPPED(x, y) x##y
 #define SCOPE_GUARD_TOKEN_PASTE(x, y) SCOPE_GUARD_TOKEN_PASTE_WRAPPED(x, y)

--- a/tests/rb/HttpReplication/api-replication-global-spec.rb
+++ b/tests/rb/HttpReplication/api-replication-global-spec.rb
@@ -333,6 +333,19 @@ describe ArangoDB do
           end
         end
       end
+      
+      it "tails the WAL with a tick far in the future" do
+        cmd = api + "/lastTick"
+        doc = ArangoDB.log_get("#{prefix}-lastTick", cmd, :body => "")
+        doc.code.should eq(200)
+        fromTick = doc.parsed_response["tick"].to_i * 10000000
+
+        cmd = api + "/tail?global=true&from=" + fromTick.to_s
+        doc = ArangoDB.log_get("#{prefix}-tail", cmd, :body => "", :format => :plain)
+
+        doc.code.should eq(204)
+        doc.headers["x-arango-replication-lastincluded"].should eq("0")
+      end
 
       it "fetches a create collection action from the follow log" do
         cid = 0


### PR DESCRIPTION
### Scope & Purpose

Make it possible to limit the number of concurrently running WAL tailing operations.
This option can be used as a last resort to reduce the load put on a server by concurrently running WAL tailing invocations, e.g. from arangosync.
By default, the number of parallel invocations is not limited.

The PR also fixes assertions failure when WAL tailing is called with a `from` tick in the future, i.e. a `from` value that is not yet in the database. 

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

- [x] There is a *JIRA Ticket number* (In case a customer was affected / involved): https://arangodb.atlassian.net/browse/ES-312

### Testing & Verification

The changes were manually tested.

This change is already covered by existing replication tests.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/4967/