### PR TITLE
Add lock on unload

### DIFF
--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -202,11 +202,12 @@ void RocksDBCollection::load() {
 }
 
 void RocksDBCollection::unload() {
+  WRITE_LOCKER(guard, _exclusiveLock);
   if (useCache()) {
     destroyCache();
     TRI_ASSERT(!_cachePresent);
   }
-  READ_LOCKER(guard, _indexesLock);
+  READ_LOCKER(indexGuard, _indexesLock);
   for (auto it : _indexes) {
     it->unload();
   }


### PR DESCRIPTION
# Scope & Purpose

Prevent a race when unloading the collection while using it

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)

#### Related Information

- [x] There is a GitHub Issue reported by a Community User: https://github.com/arangodb/arangodb/issues/9302
### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr-linux/6616/