### PR TITLE
Bug fix/fix cluster tests for analyzers

### DIFF
--- a/arangod/RestHandler/RestAnalyzerHandler.cpp
+++ b/arangod/RestHandler/RestAnalyzerHandler.cpp
@@ -113,9 +113,15 @@ void RestAnalyzerHandler::createAnalyzer( // create
   }
 
   type = getStringRef(typeSlice);
-
-  auto const properties = body.get(StaticStrings::AnalyzerPropertiesField);
-
+  
+  std::shared_ptr<VPackBuilder> propertiesFromStringBuilder;
+  auto properties = body.get(StaticStrings::AnalyzerPropertiesField);
+  if(properties.isString()) { // string still could be parsed to an object
+    auto string_ref = getStringRef(properties);
+    propertiesFromStringBuilder = arangodb::velocypack::Parser::fromJson(string_ref);
+    properties = propertiesFromStringBuilder->slice();
+  }
+  
   if (!properties.isNone() && !properties.isObject()) { // optional parameter
     generateError(arangodb::Result( // generate error
       TRI_ERROR_BAD_PARAMETER, // code

--- a/arangod/RestHandler/RestAnalyzerHandler.cpp
+++ b/arangod/RestHandler/RestAnalyzerHandler.cpp
@@ -121,6 +121,7 @@ void RestAnalyzerHandler::createAnalyzer( // create
       TRI_ERROR_BAD_PARAMETER, // code
       "invalid 'properties', expecting body to be of the form { name: <string>, type: <string>[, properties: <object>[, features: <string-array>]] }"
     ));
+    return;
   }
 
   irs::flags features;

--- a/arangod/V8Server/v8-analyzers.cpp
+++ b/arangod/V8Server/v8-analyzers.cpp
@@ -320,6 +320,10 @@ void JS_Create(v8::FunctionCallbackInfo<v8::Value> const& args) {
       TRI_V8_THROW_TYPE_ERROR("<properties> must be an object");
     }
   }
+  // properties(if exists) at the end should be parsed into object 
+  if(properties.use_count() && !properties->slice().isObject()) {
+    TRI_V8_THROW_TYPE_ERROR("<properties> must be an object");
+  }
 
   irs::flags features;
 

--- a/tests/RestHandler/RestAnalyzerHandler-test.cpp
+++ b/tests/RestHandler/RestAnalyzerHandler-test.cpp
@@ -185,14 +185,14 @@ TEST_F(RestAnalyzerHandlerTest, test_create) {
   {
     const auto name = arangodb::StaticStrings::SystemDatabase + "::testAnalyzer1";
     ASSERT_TRUE(analyzers->emplace(result, name, "identity", 
-                                  VPackParser::fromJson("\"abc\"")->slice())
+                                  VPackParser::fromJson("{\"args\":\"abc\"}")->slice())
                            .ok());
   }
 
   {
     const auto name = arangodb::StaticStrings::SystemDatabase + "::emptyAnalyzer";
     ASSERT_TRUE(analyzers->emplace(result, name, "rest-analyzer-empty",
-                                  VPackParser::fromJson("\"en\"")->slice(),
+                                  VPackParser::fromJson("{\"args\":\"en\"}")->slice(),
                                   irs::flags{irs::frequency::type()})
                            .ok());
   }
@@ -438,7 +438,7 @@ TEST_F(RestAnalyzerHandlerTest, test_create) {
     request._payload.openObject();
     request._payload.add("name", arangodb::velocypack::Value("emptyAnalyzer"));
     request._payload.add("type", arangodb::velocypack::Value("rest-analyzer-empty"));
-    request._payload.add("properties", arangodb::velocypack::Value("abc"));
+    request._payload.add("properties", arangodb::velocypack::Value("{\"args\":\"abc\"}"));
     request._payload.close();
 
     arangodb::auth::UserMap userMap;  // empty map, no user -> no permissions
@@ -481,7 +481,7 @@ TEST_F(RestAnalyzerHandlerTest, test_create) {
     request._payload.openObject();
     request._payload.add("name", VPackValue("testAnalyzer1"));
     request._payload.add("type", VPackValue("identity"));
-    request._payload.add("properties", VPackValue(arangodb::velocypack::ValueType::Null));
+    request._payload.add("properties", VPackSlice::noneSlice());
     request._payload.close();
 
     arangodb::auth::UserMap userMap;  // empty map, no user -> no permissions
@@ -522,7 +522,7 @@ TEST_F(RestAnalyzerHandlerTest, test_create) {
     request._payload.openObject();
     request._payload.add("name", VPackValue("testAnalyzer2"));
     request._payload.add("type", VPackValue("identity"));
-    request._payload.add("properties", arangodb::velocypack::Value("abc"));
+    request._payload.add("properties", arangodb::velocypack::Value("{\"args\":\"abc\"}"));
     request._payload.close();
 
     arangodb::auth::UserMap userMap;  // empty map, no user -> no permissions
@@ -565,7 +565,7 @@ TEST_F(RestAnalyzerHandlerTest, test_create) {
     request._payload.openObject();
     request._payload.add("name", arangodb::velocypack::Value("testAnalyzer2"));
     request._payload.add("type", arangodb::velocypack::Value("identity"));
-    request._payload.add("properties", arangodb::velocypack::Value("abc"));
+    request._payload.add("properties", arangodb::velocypack::Value("{\"args\":\"abc\"}"));
     request._payload.close();
 
     arangodb::auth::UserMap userMap;  // empty map, no user -> no permissions

--- a/tests/V8Server/v8-analyzers-test.cpp
+++ b/tests/V8Server/v8-analyzers-test.cpp
@@ -717,7 +717,7 @@ TEST_F(V8AnalyzersTest, test_create) {
   {
     const auto name = arangodb::StaticStrings::SystemDatabase + "::emptyAnalyzer";
     ASSERT_TRUE(analyzers->emplace(result, name, "v8-analyzer-empty",
-                                   VPackParser::fromJson("\"en\"")->slice(), 
+                                   VPackParser::fromJson("{\"args\":\"12312\"}")->slice(), 
                                    irs::flags{irs::frequency::type()}).ok());
   }
 
@@ -1050,7 +1050,7 @@ TEST_F(V8AnalyzersTest, test_create) {
     std::vector<v8::Local<v8::Value>> args = {
         TRI_V8_STD_STRING(isolate.get(), "emptyAnalyzer"s),
         TRI_V8_ASCII_STRING(isolate.get(), "v8-analyzer-empty"),
-        TRI_V8_ASCII_STRING(isolate.get(), "\"abc\""),
+        TRI_V8_ASCII_STRING(isolate.get(), "{\"abc\":1}"),
     };
 
     arangodb::auth::UserMap userMap;  // empty map, no user -> no permissions
@@ -1168,7 +1168,7 @@ TEST_F(V8AnalyzersTest, test_create) {
     std::vector<v8::Local<v8::Value>> args = {
         TRI_V8_STD_STRING(isolate.get(), "testAnalyzer2"s),
         TRI_V8_ASCII_STRING(isolate.get(), "identity"),
-        TRI_V8_ASCII_STRING(isolate.get(), "\"abc\""),
+        TRI_V8_ASCII_STRING(isolate.get(), "{\"abc\":1}"),
     };
 
     arangodb::auth::UserMap userMap;  // empty map, no user -> no permissions
@@ -1226,7 +1226,7 @@ TEST_F(V8AnalyzersTest, test_create) {
     std::vector<v8::Local<v8::Value>> args = {
         TRI_V8_STD_STRING(isolate.get(), "testAnalyzer2"s),
         TRI_V8_ASCII_STRING(isolate.get(), "identity"),
-        TRI_V8_ASCII_STRING(isolate.get(), "\"abc\"")
+        TRI_V8_ASCII_STRING(isolate.get(), "{\"abc\":1}")
     };
 
     arangodb::auth::UserMap userMap;  // empty map, no user -> no permissions

--- a/tests/js/common/aql/aql-view-arangosearch-cluster.inc
+++ b/tests/js/common/aql/aql-view-arangosearch-cluster.inc
@@ -47,7 +47,7 @@
 
     return {
       setUp : function () {
-        analyzers.save("text_en", "text", { "locale": "en.UTF-8", "stopwords": [ ] }, [ "frequency", "norm", "position" ]);
+        analyzers.save("text_en", "text", "{ \"locale\": \"en.UTF-8\", \"stopwords\": [ ] }", [ "frequency", "norm", "position" ]);
         db._drop("UnitTestsCollection");
         c = db._create("UnitTestsCollection", args);
 

--- a/tests/js/common/aql/aql-view-arangosearch-cluster.inc
+++ b/tests/js/common/aql/aql-view-arangosearch-cluster.inc
@@ -47,7 +47,7 @@
 
     return {
       setUp : function () {
-        analyzers.save("text_en", "text", "{ \"locale\": \"en.UTF-8\", \"stopwords\": [ ] }", [ "frequency", "norm", "position" ]);
+        analyzers.save("text_en", "text", { "locale": "en.UTF-8", "stopwords": [ ] }, [ "frequency", "norm", "position" ]);
         db._drop("UnitTestsCollection");
         c = db._create("UnitTestsCollection", args);
 


### PR DESCRIPTION
Fixed parsing json object encoded as string (like ``` "{ \"locale\": \"en.UTF-8\", \"stopwords\": [ ] }"``` ).
Fixed generating proper error message if analyzer properties could not be parsed into  json object.

https://jenkins.arangodb.biz/job/arangodb-matrix-pr/5005/