### PR TITLE
use index projections when range-scanning the primary index and filtering on _key

### DIFF
--- a/arangod/Aql/IndexNode.cpp
+++ b/arangod/Aql/IndexNode.cpp
@@ -166,6 +166,7 @@ void IndexNode::initIndexCoversProjections() {
   }
 
   _coveringIndexAttributePositions = std::move(coveringAttributePositions);
+  _options.forceProjection = true;
 }
 
 /// @brief toVelocyPack, for IndexNode


### PR DESCRIPTION
### Scope & Purpose

Use `nextCovering` iterator method when range-scanning the RocksDB primary key.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behaviour change can only be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as AQL tests.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5010/