### PR TITLE
fix JSON statistics for Scheduler

### DIFF
--- a/arangod/Scheduler/Scheduler.h
+++ b/arangod/Scheduler/Scheduler.h
@@ -152,17 +152,15 @@ class Scheduler {
   // ---------------------------------------------------------------------------
  public:
   struct QueueStatistics {
-    uint64_t _running;
-    uint64_t _working;
+    uint64_t _running; // numWorkers
+    uint64_t _blocked; // obsolete, always 0 now
     uint64_t _queued;
-    uint64_t _fifo1;
-    uint64_t _fifo2;
-    uint64_t _fifo3;
+    uint64_t _working;
+    uint64_t _directExec;
   };
 
-  virtual void addQueueStatistics(velocypack::Builder&) const = 0;
+  virtual void toVelocyPack(velocypack::Builder&) const = 0;
   virtual QueueStatistics queueStatistics() const = 0;
-  virtual std::string infoStatus() const = 0;
 
   // ---------------------------------------------------------------------------
   // Start/Stop/IsRunning stuff

--- a/arangod/Scheduler/SupervisedScheduler.h
+++ b/arangod/Scheduler/SupervisedScheduler.h
@@ -46,7 +46,7 @@ class SupervisedScheduler final : public Scheduler {
   bool queue(RequestLane lane, std::function<void()>, bool allowDirectHandling = false) override;
 
  private:
-  std::atomic<size_t> _numWorker;
+  std::atomic<size_t> _numWorkers;
   std::atomic<bool> _stopping;
 
  protected:
@@ -56,9 +56,8 @@ class SupervisedScheduler final : public Scheduler {
   bool start() override;
   void shutdown() override;
 
-  void addQueueStatistics(velocypack::Builder&) const override;
+  void toVelocyPack(velocypack::Builder&) const override;
   Scheduler::QueueStatistics queueStatistics() const override;
-  std::string infoStatus() const override;
 
  private:
   friend class SupervisedSchedulerManagerThread;

--- a/arangod/Statistics/Descriptions.cpp
+++ b/arangod/Statistics/Descriptions.cpp
@@ -370,9 +370,7 @@ void stats::Descriptions::serverStatistics(velocypack::Builder& b) const {
   }
 
   b.add("threads", VPackValue(VPackValueType::Object, true));
-
-  SchedulerFeature::SCHEDULER->addQueueStatistics(b);
-
+  SchedulerFeature::SCHEDULER->toVelocyPack(b);
   b.close();
 }
 

--- a/arangod/Statistics/StatisticsWorker.cpp
+++ b/arangod/Statistics/StatisticsWorker.cpp
@@ -939,7 +939,7 @@ void StatisticsWorker::generateRawStatistics(VPackBuilder& builder, double const
 
   // export threads statistics
   builder.add("threads", VPackValue(VPackValueType::Object));
-  SchedulerFeature::SCHEDULER->addQueueStatistics(builder);
+  SchedulerFeature::SCHEDULER->toVelocyPack(builder);
   builder.close();
   
   // export ttl statistics


### PR DESCRIPTION
### Scope & Purpose

Some statistics were not populated in current devel because of the refactored Scheduler code.
They were reported as "non-representable type" instead. This PR tries to bring back the statistics that were available in 3.4, at least for the metrics that are still available.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behaviour change can only be verified via automatic tests

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5027/