### PR TITLE
add initializeCursor back to DistinctCollectExecutor

### DIFF
--- a/arangod/Aql/DistinctCollectExecutor.cpp
+++ b/arangod/Aql/DistinctCollectExecutor.cpp
@@ -64,12 +64,11 @@ DistinctCollectExecutor::DistinctCollectExecutor(Fetcher& fetcher, Infos& infos)
             AqlValueGroupEqual(_infos.getTransaction())) {}
 
 DistinctCollectExecutor::~DistinctCollectExecutor() {
-  // destroy all AqlValues captured
-  for (auto& it : _seen) {
-    for (auto& it2 : it) {
-      const_cast<AqlValue*>(&it2)->destroy();
-    }
-  }
+  destroyValues();
+}
+
+void DistinctCollectExecutor::initializeCursor() {
+  destroyValues();
 }
 
 std::pair<ExecutionState, NoStats> DistinctCollectExecutor::produceRows(OutputAqlItemRow& output) {
@@ -137,4 +136,14 @@ std::pair<ExecutionState, size_t> DistinctCollectExecutor::expectedNumberOfRows(
   // This block cannot know how many elements will be returned exactly.
   // but it is upper bounded by the input.
   return _fetcher.preFetchNumberOfRows(atMost);
+}
+
+void DistinctCollectExecutor::destroyValues() {
+  // destroy all AqlValues captured
+  for (auto& it : _seen) {
+    for (auto& it2 : it) {
+      const_cast<AqlValue*>(&it2)->destroy();
+    }
+  }
+  _seen.clear();
 }

--- a/arangod/Aql/DistinctCollectExecutor.h
+++ b/arangod/Aql/DistinctCollectExecutor.h
@@ -95,6 +95,8 @@ class DistinctCollectExecutor {
   DistinctCollectExecutor(DistinctCollectExecutor const&) = delete;
   DistinctCollectExecutor(Fetcher& fetcher, Infos&);
   ~DistinctCollectExecutor();
+  
+  void initializeCursor();
 
   /**
    * @brief produce the next Row of Aql Values.
@@ -107,6 +109,7 @@ class DistinctCollectExecutor {
 
  private:
   Infos const& infos() const noexcept { return _infos; };
+  void destroyValues();
 
  private:
   Infos const& _infos;

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -372,6 +372,9 @@ std::pair<ExecutionState, Result> ExecutionBlockImpl<Executor>::initializeCursor
   static_assert(!std::is_same<Executor, IndexExecutor>::value || customInit,
                 "IndexExecutor is expected to implement a custom "
                 "initializeCursor method!");
+  static_assert(!std::is_same<Executor, DistinctCollectExecutor>::value || customInit,
+                "DistinctCollectExecutor is expected to implement a custom "
+                "initializeCursor method!");
   InitializeCursor<customInit>::init(_executor, _rowFetcher, _infos);
 
   // // use this with c++17 instead of specialisation below


### PR DESCRIPTION
### Scope & Purpose

Add `initializeCursor` method back to `DistinctCollectExecutor`. It existed in 3.4 but was missing in devel. It may be handy to free some temporary results and reduce overall memory usage.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)

### Testing & Verification

This change is already covered by existing tests, such as *AQL collect tests*.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5028/