### PR TITLE
add VelocyPackHelper::equal method

### DIFF
--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -594,7 +594,7 @@ JOB_STATUS MoveShard::pendingLeader() {
                          for (size_t i = 1; i < plan.length() - 1; ++i) {
                            VPackSlice p = plan[i];
                            for (auto const& c : VPackArrayIterator(current)) {
-                             if (arangodb::basics::VelocyPackHelper::compare(p, c, true) == 0) {
+                             if (arangodb::basics::VelocyPackHelper::equal(p, c, true)) {
                                ++found;
                                break;
                              }

--- a/arangod/Agency/Node.cpp
+++ b/arangod/Agency/Node.cpp
@@ -553,7 +553,7 @@ bool Node::handle<ERASE>(VPackSlice const& slice) {
       if (haveVal) {
         VPackSlice valToErase = slice.get("val");
         for (auto const& old : VPackArrayIterator(this->slice())) {
-          if (VelocyPackHelper::compare(old, valToErase, /*useUTF8*/ true) != 0) {
+          if (!VelocyPackHelper::equal(old, valToErase, /*useUTF8*/ true)) {
             tmp.add(old);
           }
         }
@@ -596,7 +596,7 @@ bool Node::handle<REPLACE>(VPackSlice const& slice) {
     if (this->slice().isArray()) {
       VPackSlice valToRepl = slice.get("val");
       for (auto const& old : VPackArrayIterator(this->slice())) {
-        if (VelocyPackHelper::compare(old, valToRepl, /*useUTF8*/ true) == 0) {
+        if (VelocyPackHelper::equal(old, valToRepl, /*useUTF8*/ true)) {
           tmp.add(slice.get("new"));
         } else {
           tmp.add(old);

--- a/arangod/Agency/Store.cpp
+++ b/arangod/Agency/Store.cpp
@@ -446,7 +446,7 @@ check_ret_t Store::check(VPackSlice const& slice, CheckMode mode) const {
             if (node->slice().isArray()) {
               bool found = false;
               for (auto const& i : VPackArrayIterator(node->slice())) {
-                if (basics::VelocyPackHelper::compare(i, op.value, false) == 0) {
+                if (basics::VelocyPackHelper::equal(i, op.value, false)) {
                   found = true;
                   break;
                 }
@@ -468,7 +468,7 @@ check_ret_t Store::check(VPackSlice const& slice, CheckMode mode) const {
           if (node->slice().isArray()) {
             bool found = false;
             for (auto const& i : VPackArrayIterator(node->slice())) {
-              if (basics::VelocyPackHelper::compare(i, op.value, false) == 0) {
+              if (basics::VelocyPackHelper::equal(i, op.value, false)) {
                 found = true;
                 break;
               }

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1318,7 +1318,7 @@ void Supervision::readyOrphanedIndexCreations() {
                           currentDBs(colPath + shname + "/indexes").slice();
                       for (auto const& curIndex : VPackArrayIterator(curIndexes)) {
                         auto const& curId = curIndex.get("id");
-                        if (basics::VelocyPackHelper::compare(planId, curId, false) == 0) {
+                        if (basics::VelocyPackHelper::equal(planId, curId, false)) {
                           ++nIndexes;
                         }
                       }

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -2542,7 +2542,7 @@ AstNode const* Ast::deduplicateArray(AstNode const* node) {
       auto member = node->getMemberUnchecked(i);
       VPackSlice rhs = member->computeValue();
 
-      if (arangodb::basics::VelocyPackHelper::compare(lhs, rhs, false, nullptr) == 0) {
+      if (arangodb::basics::VelocyPackHelper::equal(lhs, rhs, false, nullptr)) {
         unique = false;
         break;
       }

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -713,8 +713,7 @@ bool listContainsElement(transaction::Methods* trx, VPackOptions const* options,
 
   VPackArrayIterator it(slice);
   while (it.valid()) {
-    if (arangodb::basics::VelocyPackHelper::compare(testeeSlice, it.value(),
-                                                    false, options) == 0) {
+    if (arangodb::basics::VelocyPackHelper::equal(testeeSlice, it.value(), false, options)) {
       index = static_cast<size_t>(it.index());
       return true;
     }
@@ -729,7 +728,7 @@ bool listContainsElement(VPackOptions const* options, VPackSlice const& list,
                          VPackSlice const& testee, size_t& index) {
   TRI_ASSERT(list.isArray());
   for (size_t i = 0; i < static_cast<size_t>(list.length()); ++i) {
-    if (arangodb::basics::VelocyPackHelper::compare(testee, list.at(i), false, options) == 0) {
+    if (arangodb::basics::VelocyPackHelper::equal(testee, list.at(i), false, options)) {
       index = i;
       return true;
     }
@@ -5593,8 +5592,7 @@ AqlValue Functions::Matches(ExpressionContext* expressionContext, transaction::M
 
       if (keySlice.isNone() ||
           // compare inner content
-          basics::VelocyPackHelper::compare(keySlice, it.value, false, options,
-                                            &docSlice, &example) != 0) {
+          !basics::VelocyPackHelper::equal(keySlice, it.value, false, options, &docSlice, &example)) {
         foundMatch = false;
         break;
       }
@@ -6116,7 +6114,7 @@ AqlValue Functions::RemoveValue(ExpressionContext* expressionContext,
       builder->add(it);
       continue;
     }
-    if (arangodb::basics::VelocyPackHelper::compare(r, it, false, options) == 0) {
+    if (arangodb::basics::VelocyPackHelper::equal(r, it, false, options)) {
       --limit;
       continue;
     }

--- a/arangod/Aql/QueryCache.cpp
+++ b/arangod/Aql/QueryCache.cpp
@@ -222,7 +222,7 @@ std::shared_ptr<QueryCacheResultEntry> QueryCacheDatabaseEntry::lookup(
       return nullptr;
     }
 
-    if (basics::VelocyPackHelper::compare(entryBindVars, lookupBindVars, false) != 0) {
+    if (!basics::VelocyPackHelper::equal(entryBindVars, lookupBindVars, false)) {
       // different bind variables
       return nullptr;
     }

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -3647,7 +3647,7 @@ void ClusterInfo::loadCurrentDBServers() {
         bool found = false;
         if (failedDBServers.isObject()) {
           for (auto const& failedServer : VPackObjectIterator(failedDBServers)) {
-            if (basics::VelocyPackHelper::compare(dbserver.key, failedServer.key, false) == 0) {
+            if (basics::VelocyPackHelper::equal(dbserver.key, failedServer.key, false)) {
               found = true;
               break;
             }
@@ -3660,7 +3660,7 @@ void ClusterInfo::loadCurrentDBServers() {
         if (cleanedDBServers.isArray()) {
           bool found = false;
           for (auto const& cleanedServer : VPackArrayIterator(cleanedDBServers)) {
-            if (basics::VelocyPackHelper::compare(dbserver.key, cleanedServer, false) == 0) {
+            if (basics::VelocyPackHelper::equal(dbserver.key, cleanedServer, false)) {
               found = true;
               break;
             }
@@ -3673,7 +3673,7 @@ void ClusterInfo::loadCurrentDBServers() {
         if (toBeCleanedDBServers.isArray()) {
           bool found = false;
           for (auto const& toBeCleanedServer : VPackArrayIterator(toBeCleanedDBServers)) {
-            if (basics::VelocyPackHelper::compare(dbserver.key, toBeCleanedServer, false) == 0) {
+            if (basics::VelocyPackHelper::equal(dbserver.key, toBeCleanedServer, false)) {
               found = true;
               break;
             }

--- a/arangod/Indexes/Index.cpp
+++ b/arangod/Indexes/Index.cpp
@@ -455,14 +455,14 @@ bool Index::CompareIdentifiers(velocypack::Slice const& lhs, velocypack::Slice c
   VPackSlice lhsId = lhs.get(arangodb::StaticStrings::IndexId);
   VPackSlice rhsId = rhs.get(arangodb::StaticStrings::IndexId);
   if (lhsId.isString() && rhsId.isString() &&
-      arangodb::basics::VelocyPackHelper::compare(lhsId, rhsId, true) == 0) {
+      arangodb::basics::VelocyPackHelper::equal(lhsId, rhsId, true)) {
     return true;
   }
 
   VPackSlice lhsName = lhs.get(arangodb::StaticStrings::IndexName);
   VPackSlice rhsName = rhs.get(arangodb::StaticStrings::IndexName);
   if (lhsName.isString() && rhsName.isString() &&
-      arangodb::basics::VelocyPackHelper::compare(lhsName, rhsName, true) == 0) {
+      arangodb::basics::VelocyPackHelper::equal(lhsName, rhsName, true)) {
     return true;
   }
 
@@ -476,8 +476,7 @@ bool Index::Compare(VPackSlice const& lhs, VPackSlice const& rhs) {
   TRI_ASSERT(lhsType.isString());
 
   // type must be identical
-  if (arangodb::basics::VelocyPackHelper::compare(lhsType, rhs.get(arangodb::StaticStrings::IndexType),
-                                                  false) != 0) {
+  if (!arangodb::basics::VelocyPackHelper::equal(lhsType, rhs.get(arangodb::StaticStrings::IndexType), false)) {
     return false;
   }
 

--- a/arangod/Indexes/IndexFactory.cpp
+++ b/arangod/Indexes/IndexFactory.cpp
@@ -82,21 +82,17 @@ bool IndexTypeFactory::equal(arangodb::Index::IndexType type,
   // unique must be identical if present
   auto value = lhs.get(arangodb::StaticStrings::IndexUnique);
 
-  if (value.isBoolean()) {
-    if (arangodb::basics::VelocyPackHelper::compare(value, rhs.get(arangodb::StaticStrings::IndexUnique),
-                                                    false)) {
-      return false;
-    }
+  if (value.isBoolean() &&
+      !arangodb::basics::VelocyPackHelper::equal(value, rhs.get(arangodb::StaticStrings::IndexUnique), false)) {
+    return false;
   }
 
   // sparse must be identical if present
   value = lhs.get(arangodb::StaticStrings::IndexSparse);
 
-  if (value.isBoolean()) {
-    if (arangodb::basics::VelocyPackHelper::compare(value, rhs.get(arangodb::StaticStrings::IndexSparse),
-                                                    false)) {
-      return false;
-    }
+  if (value.isBoolean() &&
+      !arangodb::basics::VelocyPackHelper::equal(value, rhs.get(arangodb::StaticStrings::IndexSparse), false)) {
+    return false;
   }
 
   if (arangodb::Index::IndexType::TRI_IDX_TYPE_GEO1_INDEX == type ||
@@ -105,7 +101,7 @@ bool IndexTypeFactory::equal(arangodb::Index::IndexType type,
     value = lhs.get("geoJson");
 
     if (value.isBoolean() &&
-        arangodb::basics::VelocyPackHelper::compare(value, rhs.get("geoJson"), false)) {
+        !arangodb::basics::VelocyPackHelper::equal(value, rhs.get("geoJson"), false)) {
       return false;
     }
   } else if (arangodb::Index::IndexType::TRI_IDX_TYPE_FULLTEXT_INDEX == type) {
@@ -113,7 +109,7 @@ bool IndexTypeFactory::equal(arangodb::Index::IndexType type,
     value = lhs.get("minLength");
 
     if (value.isNumber() &&
-        arangodb::basics::VelocyPackHelper::compare(value, rhs.get("minLength"), false)) {
+        !arangodb::basics::VelocyPackHelper::equal(value, rhs.get("minLength"), false)) {
       return false;
     }
   }
@@ -139,7 +135,7 @@ bool IndexTypeFactory::equal(arangodb::Index::IndexType type,
         bool found = false;
 
         for (auto const& vr : VPackArrayIterator(r)) {
-          if (arangodb::basics::VelocyPackHelper::compare(v, vr, false) == 0) {
+          if (arangodb::basics::VelocyPackHelper::equal(v, vr, false)) {
             found = true;
             break;
           }
@@ -151,8 +147,8 @@ bool IndexTypeFactory::equal(arangodb::Index::IndexType type,
       }
     } else {
       // attribute order matters
-      if (arangodb::basics::VelocyPackHelper::compare(
-              value, rhs.get(arangodb::StaticStrings::IndexFields), false) != 0) {
+      if (!arangodb::basics::VelocyPackHelper::equal(
+              value, rhs.get(arangodb::StaticStrings::IndexFields), false)) {
         return false;
       }
     }

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -328,7 +328,7 @@ Result TailingSyncer::processDBMarker(TRI_replication_operation_e type,
           TRI_ERROR_REPLICATION_INVALID_RESPONSE,
           "create database marker did not contain data");
     }
-    TRI_ASSERT(basics::VelocyPackHelper::compare(data.get("name"), nameSlice, false) == 0);
+    TRI_ASSERT(basics::VelocyPackHelper::equal(data.get("name"), nameSlice, false));
 
     TRI_vocbase_t* vocbase = DatabaseFeature::DATABASE->lookupDatabase(name);
 

--- a/arangod/RestServer/BootstrapFeature.cpp
+++ b/arangod/RestServer/BootstrapFeature.cpp
@@ -250,7 +250,7 @@ void runActiveFailoverStart(std::string const& myId) {
 
       if (leader.isString() && leader.getStringLength() > 0) {
         ServerState::instance()->setFoxxmaster(leader.copyString());
-        if (basics::VelocyPackHelper::compare(leader, myIdBuilder.slice(), false) == 0) {
+        if (basics::VelocyPackHelper::equal(leader, myIdBuilder.slice(), false)) {
           LOG_TOPIC("95023", INFO, Logger::STARTUP)
               << "Became leader in active-failover setup";
         } else {

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -805,7 +805,7 @@ namespace {
       }
     }
     
-    return (basics::VelocyPackHelper::compare(first, second, true) == 0);
+    return basics::VelocyPackHelper::equal(first, second, true);
   }
 } // namespace
 

--- a/lib/Basics/VelocyPackHelper.cpp
+++ b/lib/Basics/VelocyPackHelper.cpp
@@ -300,7 +300,7 @@ size_t VelocyPackHelper::VPackStringHash::operator()(VPackSlice const& slice) co
 
 bool VelocyPackHelper::VPackEqual::operator()(VPackSlice const& lhs,
                                               VPackSlice const& rhs) const {
-  return VelocyPackHelper::compare(lhs, rhs, false, _options) == 0;
+  return VelocyPackHelper::equal(lhs, rhs, false, _options);
 }
 
 static inline int8_t TypeWeight(VPackSlice& slice) {

--- a/lib/Basics/VelocyPackHelper.h
+++ b/lib/Basics/VelocyPackHelper.h
@@ -323,11 +323,22 @@ class VelocyPackHelper {
                                  char const* right, VPackValueLength nr, bool useUTF8);
 
   /// @brief Compares two VelocyPack slices
+  /// returns 0 if the two slices are equal, < 0 if lhs < rhs, and > 0 if rhs > lhs
   static int compare(arangodb::velocypack::Slice lhs,
                      arangodb::velocypack::Slice rhs, bool useUTF8,
                      arangodb::velocypack::Options const* options = &arangodb::velocypack::Options::Defaults,
                      arangodb::velocypack::Slice const* lhsBase = nullptr,
-                     arangodb::velocypack::Slice const* rhsBase = nullptr);
+                     arangodb::velocypack::Slice const* rhsBase = nullptr) ADB_WARN_UNUSED_RESULT;
+  
+  /// @brief Compares two VelocyPack slices for equality
+  /// returns true if the slices are equal, false otherwise
+  static bool equal(arangodb::velocypack::Slice lhs,
+                    arangodb::velocypack::Slice rhs, bool useUTF8,
+                    arangodb::velocypack::Options const* options = &arangodb::velocypack::Options::Defaults,
+                    arangodb::velocypack::Slice const* lhsBase = nullptr,
+                    arangodb::velocypack::Slice const* rhsBase = nullptr) {
+    return compare(lhs, rhs, useUTF8, options, lhsBase, rhsBase) == 0;
+  }
 
   /// @brief Merges two VelocyPack Slices
   static arangodb::velocypack::Builder merge(arangodb::velocypack::Slice const&,

--- a/tests/Aql/AqlItemRowTest.cpp
+++ b/tests/Aql/AqlItemRowTest.cpp
@@ -61,7 +61,7 @@ class AqlItemRowsTest : public ::testing::Test {
           // If this should not be kept it has to be set to NONE!
           ASSERT_TRUE(v.slice().isNone());
         } else {
-          ASSERT_TRUE(basics::VelocyPackHelper::compare(row.at(regId), v.slice(), true) == 0);
+          ASSERT_TRUE(basics::VelocyPackHelper::equal(row.at(regId), v.slice(), true));
           // Work around test as we are unable to check the type via API.
           if (assertNotInline) {
             // If this object is not inlined it requires some memory

--- a/tests/Mocks/StorageEngineMock.cpp
+++ b/tests/Mocks/StorageEngineMock.cpp
@@ -832,7 +832,7 @@ arangodb::Result PhysicalCollectionMock::remove(
 
     arangodb::velocypack::Builder& doc = entry.first;
 
-    if (arangodb::basics::VelocyPackHelper::compare(key, doc.slice().get(arangodb::StaticStrings::KeyString), false) == 0) {
+    if (arangodb::basics::VelocyPackHelper::equal(key, doc.slice().get(arangodb::StaticStrings::KeyString), false)) {
       entry.second = false;
       previous.setUnmanaged(doc.data());
       TRI_ASSERT(previous.revisionId() == TRI_ExtractRevisionId(doc.slice()));
@@ -896,7 +896,7 @@ arangodb::Result PhysicalCollectionMock::update(
 
     auto& doc = entry.first;
 
-    if (arangodb::basics::VelocyPackHelper::compare(key, doc.slice().get(arangodb::StaticStrings::KeyString), false) == 0) {
+    if (arangodb::basics::VelocyPackHelper::equal(key, doc.slice().get(arangodb::StaticStrings::KeyString), false)) {
       if (!options.mergeObjects) {
         entry.second = false;
         previous.setUnmanaged(doc.data());


### PR DESCRIPTION
### Scope & Purpose

Add `VelocyPackHelper::equal` method as shortcut for `VelocyPackHelper::compare(...) == 0`.
Calls to `compare` that checked for equality move been changed to call `equal`.
The `compare` method has been tagged with attribute `warn_unused_result` as well.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behaviour change can only be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as most tests that used compare before.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5032/