### PR TITLE
fix tests that didn't properly use env variable to look for test

### DIFF
--- a/tests/IResearch/IResearchComparer-test.cpp
+++ b/tests/IResearch/IResearchComparer-test.cpp
@@ -32,8 +32,10 @@
 #include "velocypack/Iterator.h"
 
 TEST(IResearchComparerTest, test_comparer_single_entry) {
+  arangodb::tests::init(true);
+
   irs::utf8_path resource;
-  resource /= irs::string_ref(IResearch_test_resource_dir);
+  resource /= irs::string_ref(arangodb::tests::testResourceDir);
   resource /= irs::string_ref("simple_sequential.json");
 
   auto builder = arangodb::basics::VelocyPackHelper::velocyPackFromFile(resource.utf8());
@@ -75,8 +77,10 @@ TEST(IResearchComparerTest, test_comparer_single_entry) {
 }
 
 TEST(IResearchComparerTest, test_comparer_multiple_entries) {
+  arangodb::tests::init(true);
+
   irs::utf8_path resource;
-  resource /= irs::string_ref(IResearch_test_resource_dir);
+  resource /= irs::string_ref(arangodb::tests::testResourceDir);
   resource /= irs::string_ref("simple_sequential.json");
 
   auto builder = arangodb::basics::VelocyPackHelper::velocyPackFromFile(resource.utf8());

--- a/tests/IResearch/IResearchViewSorted-test.cpp
+++ b/tests/IResearch/IResearchViewSorted-test.cpp
@@ -294,7 +294,7 @@ TEST_F(IResearchViewSortedTest, SingleField) {
     // insert into collections
     {
       irs::utf8_path resource;
-      resource /= irs::string_ref(IResearch_test_resource_dir);
+      resource /= irs::string_ref(arangodb::tests::testResourceDir);
       resource /= irs::string_ref("simple_sequential.json");
 
       auto builder =
@@ -583,7 +583,7 @@ TEST_F(IResearchViewSortedTest, MultipleFields) {
     // insert into collections
     {
       irs::utf8_path resource;
-      resource /= irs::string_ref(IResearch_test_resource_dir);
+      resource /= irs::string_ref(arangodb::tests::testResourceDir);
       resource /= irs::string_ref("simple_sequential.json");
 
       auto builder =


### PR DESCRIPTION
### Scope & Purpose

Fix arangosearch tests that did not use env variable IRESEARCH_TEST_RESOURCE_DIR to determine the location for test files.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behaviour change can only be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *arangosearch catch tests*.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5047/