### PR TITLE
Shutdown Bug

### DIFF
--- a/lib/ApplicationFeatures/ApplicationServer.h
+++ b/lib/ApplicationFeatures/ApplicationServer.h
@@ -132,7 +132,7 @@ class ApplicationServer {
   static ApplicationServer* server;
 
   static bool isStopping() {
-    return server != nullptr && server->_stopping.load();
+    return server != nullptr && server->_beginShutdown.load();
   }
 
   // Today this static function is a duplicate of isStopping().  The

--- a/lib/ApplicationFeatures/ApplicationServer.h
+++ b/lib/ApplicationFeatures/ApplicationServer.h
@@ -232,7 +232,7 @@ class ApplicationServer {
   // out specific options. the filter function is expected to return true
   // for any options that should become part of the result
   VPackBuilder options(std::function<bool(std::string const&)> const& filter) const;
-  
+
   // return the program options object
   std::shared_ptr<options::ProgramOptions> options() const { return _options; }
 
@@ -344,6 +344,7 @@ class ApplicationServer {
 
   // stop flag. this is being changed by calling beginShutdown
   std::atomic<bool> _stopping;
+  std::atomic<bool> _beginShutdown;
 
   // whether or not privileges have been dropped permanently
   bool _privilegesDropped = false;


### PR DESCRIPTION

### Scope & Purpose

Prevent parallel or wrong order execution of beginShutdown and stop handlers of features.

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.
