### PR TITLE
Bug fix/rename iresearch analyzer feature

### DIFF
--- a/arangod/Agency/AgencyFeature.cpp
+++ b/arangod/Agency/AgencyFeature.cpp
@@ -238,7 +238,7 @@ void AgencyFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
   // - Action/Script/FoxxQueues/Frontend: Foxx and JavaScript APIs
 
   std::vector<std::string> disabledFeatures({
-    "MMFilesPersistentIndex", "ArangoSearch", "IResearchAnalyzer",
+    "MMFilesPersistentIndex", "ArangoSearch", "ArangoSearchAnalyzer",
     "Statistics", "Action", "Script", "FoxxQueues", "Frontend"});
 
   if (!result.touched("console") || !*(options->get<BooleanParameter>("console")->ptr)) {

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -87,7 +87,7 @@ static std::string const ANALYZER_COLLECTION_NAME("_analyzers");
 static char const ANALYZER_PREFIX_DELIM = ':'; // name prefix delimiter (2 chars)
 static size_t const ANALYZER_PROPERTIES_SIZE_MAX = 1024 * 1024; // arbitrary value
 static size_t const DEFAULT_POOL_SIZE = 8;  // arbitrary value
-static std::string const FEATURE_NAME("IResearchAnalyzer");
+static std::string const FEATURE_NAME("ArangoSearchAnalyzer");
 static irs::string_ref const IDENTITY_ANALYZER_NAME("identity");
 static auto const RELOAD_INTERVAL = std::chrono::seconds(60); // arbitrary value
 

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -954,8 +954,8 @@ IResearchFeature::IResearchFeature(arangodb::application_features::ApplicationSe
       _threadsLimit(0) {
   setOptional(true);
   startsAfter("V8Phase");
-  startsAfter("IResearchAnalyzer");  // used for retrieving IResearch analyzers
-                                     // for functions
+  startsAfter("ArangoSearchAnalyzer");  // used for retrieving IResearch analyzers
+                                        // for functions
   startsAfter("AQLFunctions");
 }
 

--- a/arangod/MMFiles/MMFilesLogfileManager.cpp
+++ b/arangod/MMFiles/MMFilesLogfileManager.cpp
@@ -62,7 +62,7 @@ using namespace arangodb::options;
 MMFilesLogfileManager* MMFilesLogfileManager::Instance = nullptr;
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-bool MMFilesLogfileManager::SafeToUseInstance = false;
+std::atomic<bool> MMFilesLogfileManager::SafeToUseInstance{ false };
 #endif
 
 // whether or not there was a SHUTDOWN file with a last tick at

--- a/arangod/MMFiles/MMFilesLogfileManager.h
+++ b/arangod/MMFiles/MMFilesLogfileManager.h
@@ -98,7 +98,7 @@ class MMFilesLogfileManager final : public application_features::ApplicationFeat
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // whether or not it is safe to retrieve the instance yet
-  static bool SafeToUseInstance;
+  static std::atomic<bool> SafeToUseInstance;
 #endif
 
   // status of whether the last tick value was found on startup

--- a/lib/ApplicationFeatures/AQLPhase.cpp
+++ b/lib/ApplicationFeatures/AQLPhase.cpp
@@ -33,7 +33,7 @@ AQLFeaturePhase::AQLFeaturePhase(ApplicationServer& server)
   startsAfter("CommunicationPhase");
   startsAfter("Aql");
   startsAfter("AQLFunctions");
-  startsAfter("IResearchAnalyzer");
+  startsAfter("ArangoSearchAnalyzer");
   startsAfter("ArangoSearch");
   startsAfter("OptimizerRules");
   startsAfter("Pregel");

--- a/tests/IResearch/IResearchAnalyzerFeature-test.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeature-test.cpp
@@ -1225,7 +1225,7 @@ class IResearchAnalyzerFeatureCoordinatorTest : public ::testing::Test {
     // We have added the feature above, so saave to dereference here
     _feature =
         arangodb::application_features::ApplicationServer::lookupFeature<arangodb::iresearch::IResearchAnalyzerFeature>(
-            "IResearchAnalyzer");
+            "ArangoSearchAnalyzer");
     TransactionStateMock::abortTransactionCount = 0;
     TransactionStateMock::beginTransactionCount = 0;
     TransactionStateMock::commitTransactionCount = 0;

--- a/tests/RestServer/FlushFeature-test.cpp
+++ b/tests/RestServer/FlushFeature-test.cpp
@@ -451,13 +451,13 @@ TEST_F(FlushFeatureTest, test_subscription_retention) {
     ASSERT_NE(nullptr, subscription);
 
     size_t removed = 42;
-    size_t tick = 0;
+    TRI_voc_tick_t tick = 0;
     feature.releaseUnusedTicks(removed, tick);
     ASSERT_EQ(0, removed); // reference is being held
   }
 
   size_t removed = 42;
-  size_t tick = 0;
+  TRI_voc_tick_t tick = 0;
   feature.releaseUnusedTicks(removed, tick);
   ASSERT_EQ(1, removed); // stale subscription was removed
 }


### PR DESCRIPTION
- rename iresearch analyzer feature
- ensure `MMFilesLogFileManager::SafeToUseInstance` is safe to use in multi-threaded context