### PR TITLE
BugFix:  Some error results have messages that are not reporting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* coordinator code was reporting rocksdb error codes, but not the associated detail message.
+  Corrected.
+
 * Replication requests on Document API are now on higher priority then client-triggered requests.
   This should help to keep in sync replication up and running even if the server is overloaded.
 

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -3038,6 +3038,9 @@ Result ClusterInfo::ensureIndexCoordinatorInner(  // create index
                   "rolling back index creation.");
             }
 
+            // The mutex in the condition variable protects the access to
+            // *errMsg:
+            CONDITION_LOCKER(locker, agencyCallback->_cv);
             return Result(tmpRes, *errMsg);
           }
 
@@ -3057,6 +3060,9 @@ Result ClusterInfo::ensureIndexCoordinatorInner(  // create index
                   "Timed out while trying to roll back index creation failure");
             }
 
+            // The mutex in the condition variable protects the access to
+            // *errMsg:
+            CONDITION_LOCKER(locker, agencyCallback->_cv);
             return Result(tmpRes, *errMsg);
           }
 

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -3038,7 +3038,7 @@ Result ClusterInfo::ensureIndexCoordinatorInner(  // create index
                   "rolling back index creation.");
             }
 
-            return Result(tmpRes);
+            return Result(tmpRes, *errMsg);
           }
 
           if (update._statusCode == TRI_ERROR_HTTP_PRECONDITION_FAILED) {
@@ -3057,7 +3057,7 @@ Result ClusterInfo::ensureIndexCoordinatorInner(  // create index
                   "Timed out while trying to roll back index creation failure");
             }
 
-            return Result(tmpRes);
+            return Result(tmpRes, *errMsg);
           }
 
           if (sleepFor <= 2500) {


### PR DESCRIPTION
Discovered that some rocksdb error messages were not getting copied all the way to the client.  The generic error number arrived, but not the specific error message.  This updates code at the coordinator level to always report error messages retrieved from the agency updates.

- [XX] Bug-Fix for at least devel and 3.4 ... considering 3.3
- [XX ] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [ ] The behaviour change can only be verified via automatic tests

This change is a trivial rework / code cleanup without any test coverage.
