### PR TITLE
BugFix 3.4: Some error results have messages that are not reporting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.4.8 (XXXX-XX-XX)
 -------------------
 
+* coordinator code was reporting rocksdb error codes, but not the associated detail message.
+  Corrected.
+
 * Fixed some error reporting and logging in Maintenance.
 
 * Fixed an error condition in which an ex-leader for a short still believed
@@ -30,7 +33,7 @@ v3.4.7 (2019-07-02)
 
 * fixed internal issue #4172: on agent servers the RocksDB WAL files in the archive directory
   were retained due to an error. Now they are removed, eventually
-  
+
 * fix error reporting in arangorestore. previously, when the server returned an HTTP 404 error,
   arangorestore unconditionally translated this into a "collection not found" error, which may
   have masked an actually different server-side error. Instead, make arangorestore return the
@@ -43,13 +46,13 @@ v3.4.7 (2019-07-02)
 
 * Fixed parsing of ArangoDB config files with inlined comments. Previous versions didn't handle
   line comments properly if they were appended to an otherwise valid option value.
-  
+
   For example, the comment in the line
-  
+
       max-total-wal-size = 1024000 # 1M
 
   was not ignored and made part of the value. In the end, the value was interpreted as if
-      
+
       max-total-wal-size = 10240001000000
 
   was specified.
@@ -108,7 +111,7 @@ v3.4.6 (2019-05-21)
 
 * fixed internal issue #3912: improved the performance of graph creation with multiple
   relations. They do now create multiple collections within a single round-trip in the agency.
-  
+
 * fixed a crash when posting an async request to the server using the "x-arango-async"
   request header and the server's request queue was full
 
@@ -117,7 +120,7 @@ v3.4.6 (2019-05-21)
   and uncompressed data blocks not fitting into the block cache
 
   The error can only occur for collection or index scans with the RocksDB storage engine
-  when the RocksDB block cache is used and set to a very small size, plus its maximum size is 
+  when the RocksDB block cache is used and set to a very small size, plus its maximum size is
   enforced by setting the `--rocksdb.enforce-block-cache-size-limit` option to `true`.
 
   Previously these incomplete reads could have been ignored silently, making collection or
@@ -125,7 +128,7 @@ v3.4.6 (2019-05-21)
 
 * fixed internal issue #3918: added optional second parameter "withId" to AQL
   function PREGEL_RESULT
- 
+
   this parameter defaults to `false`. When set to `true` the results of the Pregel
   computation run will also contain the `_id` attribute for each vertex and not
   just `_key`. This allows distinguishing vertices from different vertex collections.

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -2913,7 +2913,10 @@ int ClusterInfo::ensureIndexCoordinatorInner(std::string const& databaseName,
         auto rollbackEndTime = steady_clock::now() + std::chrono::seconds(10);
         while (true) {
           AgencyCommResult update = _agency.sendTransactionWithFailover(trx, 0.0);
-          errorMsg = *errMsg;  // default is "", but errors not covered below can populate
+          {
+              CONDITION_LOCKER(locker, agencyCallback->_cv);
+              errorMsg = *errMsg; // default is "", but errors not covered below can populate
+          }
           if (update.successful()) {
             loadPlan();
             if (tmpRes < 0) {  // timeout

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -2913,6 +2913,7 @@ int ClusterInfo::ensureIndexCoordinatorInner(std::string const& databaseName,
         auto rollbackEndTime = steady_clock::now() + std::chrono::seconds(10);
         while (true) {
           AgencyCommResult update = _agency.sendTransactionWithFailover(trx, 0.0);
+          errorMsg = *errMsg;  // default is "", but errors not covered below can populate
           if (update.successful()) {
             loadPlan();
             if (tmpRes < 0) {  // timeout


### PR DESCRIPTION
Discovered that some rocksdb error messages were not getting copied all the way to the client. The generic error number arrived, but not the specific error message. This updates code at the coordinator level to always report error messages retrieved from the agency updates.

[XX] Bug-Fix for at least devel and 3.4 ... considering 3.3
[XX ] The behavior in this PR can be (and was) manually tested (support / qa / customers can test it)
 The behaviour change can only be verified via automatic tests
This change is a trivial rework / code cleanup without any test coverage.
