### PR TITLE
BugFix 3.3:  Some error results have messages that are not reporting

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -2081,6 +2081,10 @@ int ClusterInfo::ensureIndexCoordinatorInner(std::string const& databaseName,
         auto rollbackEndTime = steady_clock::now() + std::chrono::seconds(10);
         while (true) {
           AgencyCommResult update = _agency.sendTransactionWithFailover(trx, 0.0);
+          {
+              CONDITION_LOCKER(locker, agencyCallback->_cv);
+              errorMsg = *errMsg; // default is "", but errors not covered below can populate
+          }
           if (update.successful()) {
             loadPlan();
             if (tmpRes < 0) {  // timeout


### PR DESCRIPTION
Discovered that some rocksdb error messages were not getting copied all the way to the client. The generic error number arrived, but not the specific error message. This updates code at the coordinator level to always report error messages retrieved from the agency updates.

[XX] Bug-Fix for at least devel and 3.4 ... considering 3.3
[XX ] The behavior in this PR can be (and was) manually tested (support / qa / customers can test it)
The behaviour change can only be verified via automatic tests
This change is a trivial rework / code cleanup without any test coverage.