### PR TITLE
Add updated JS deps to changelog (#8773)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -422,6 +422,39 @@ v3.5.0-rc.1 (2019-05-14)
 * Fixed JS AQL query objects with empty query strings not being recognized
   as AQL queries.
 
+* Updated JavaScript dependencies, including semver major updates to joi, mocha
+  and eslint. The eslint config modules were incompatible with the existing
+  coding style, so the old rules were inlined and the config dependencies removed.
+
+  Note that joi removed Joi.date().format() in v10.0.0. You can bundle your own
+  version of joi if you need to rely on version-dependent features.
+
+  - accepts: 1.3.4 -> 1.3.5
+  - ansi_up: 2.0.2 -> 4.0.3
+  - content-disposition: 0.5.2 -> 0.5.3
+  - dedent: 0.6.0 -> 0.7.0
+  - error-stack-parser: 1.3.6 -> 2.0.2
+  - eslint: 2.13.1 -> 5.16.0
+  - eslint-config-semistandard: 6.0.2 -> removed
+  - eslint-config-standard: 5.3.1 -> removed
+  - eslint-plugin-promise: 1.3.2 -> removed
+  - eslint-plugin-standard: 1.3.2 -> removed
+  - highlight.js: 9.12.0 -> 9.15.6
+  - http-errors: 1.6.2 -> 1.7.2
+  - iconv-lite: 0.4.19 -> 0.4.24
+  - joi: 9.2.0 -> 14.3.1
+  - joi-to-json-schema: 2.3.0 -> 4.0.1
+  - js-yaml: 3.10.0 -> 3.13.1
+  - marked: 0.3.9 -> 0.6.2
+  - mime-types: 2.1.12 -> 2.1.22
+  - mocha: 2.5.3 -> 6.1.3
+  - qs: 6.5.1 -> 6.7.0
+  - semver: 5.4.1 -> 6.0.0
+  - statuses: 1.4.0 -> 1.5.0
+  - timezone: 1.0.13 -> 1.0.22
+  - type-is: 1.6.15 -> 1.6.16
+  - underscore: 1.8.3 -> 1.9.1
+
 * Updated V8 to 7.1.302.28.
 
   New V8 behavior introduced herein:


### PR DESCRIPTION
### Scope & Purpose

Backport https://github.com/arangodb/arangodb/commit/85257fff271d18cb9a5a4c1b38178ee910625f3e to 3.5 to add info about the updated JavaScript dependencies (#8773).

- [x] Bug-Fix for *devel-branch*

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.
