### PR TITLE
Port changes to fix the keep alive timeout

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@ v3.5.0-rc.5 (2019-XX-XX)
 * coordinator code was reporting rocksdb error codes, but not the associated detail message.
   Corrected.
 
+* The keep alive timeout specified via --http.keep-alive-timeout is now being honored
+
 * Replication requests on Document API are now on higher priority then client-triggered requests.
   This should help to keep in sync replication up and running even if the server is overloaded.
 

--- a/arangod/GeneralServer/SocketTask.cpp
+++ b/arangod/GeneralServer/SocketTask.cpp
@@ -230,31 +230,36 @@ void SocketTask::addToReadBuffer(char const* data, std::size_t len) {
 
 // does not need lock
 void SocketTask::resetKeepAlive() {
-  if (_useKeepAliveTimer) {
-    asio_ns::error_code err;
-    _keepAliveTimer->expires_from_now(_keepAliveTimeout, err);
-    if (err) {
-      closeStream();
-      return;
-    }
-
-    _keepAliveTimerActive.store(true, std::memory_order_relaxed);
-    _keepAliveTimer->async_wait([self = shared_from_this()](asio_ns::error_code const& error) {
-      if (!error) {  // error will be true if timer was canceled
-        LOG_TOPIC("5c1e0", ERR, Logger::COMMUNICATION)
-            << "keep alive timout - closing stream!";
-        self->closeStream();
-      }
-    });
+  if (!_useKeepAliveTimer) {
+    return;
   }
+  
+  // expires_from_now cancels pending operations
+  asio_ns::error_code err;
+  _keepAliveTimer->expires_from_now(_keepAliveTimeout, err);
+  if (err) {
+    closeStream();
+    return;
+  }
+  _keepAliveTimerActive.store(true);
+  
+  std::weak_ptr<SocketTask> self = shared_from_this();
+  _keepAliveTimer->async_wait([self](const asio_ns::error_code& ec) {
+    if (!ec) {  // error will be true if timer was canceled
+      LOG_TOPIC("f0948", INFO, Logger::COMMUNICATION)
+      << "keep alive timout - closing stream!";
+      if (auto s = self.lock()) {
+        s->closeStream();
+      }
+    }
+  });
 }
 
 // caller must hold the _lock
 void SocketTask::cancelKeepAlive() {
-  if (_useKeepAliveTimer && _keepAliveTimerActive.load(std::memory_order_relaxed)) {
+  if (_keepAliveTimerActive.exchange(false)) {
     asio_ns::error_code err;
     _keepAliveTimer->cancel(err);
-    _keepAliveTimerActive.store(false, std::memory_order_relaxed);
   }
 }
 

--- a/arangod/GeneralServer/SocketTask.h
+++ b/arangod/GeneralServer/SocketTask.h
@@ -147,7 +147,7 @@ class SocketTask : public std::enable_shared_from_this<SocketTask> {
   // caller must run in _peer->strand()
   void closeStreamNoLock();
 
-  // starts the keep alive time, no need to run on strand
+  // starts the keep alive time
   void resetKeepAlive();
 
   // cancels the keep alive timer


### PR DESCRIPTION
### Scope & Purpose

This ports https://github.com/arangodb/arangodb/pull/9477/files to 3.5:
Actually use a keep-alive timeout in the documented way

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)


### Testing

http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/5221/

### Documentation

- [x] Added a *Changelog Entry* 
