### PR TITLE
Bug fix 3.4/fix races in collection creation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,12 @@
 v3.4.8 (XXXX-XX-XX)
 -------------------
 
+* Fixed some races in cluster collection creation, which allowed collections with the
+  same name to be created in parallel under some rare conditions.
+
 * Prevent rare cases of duplicate DDL actions being executed by Maintenance.
 
-* coordinator code was reporting rocksdb error codes, but not the associated detail message.
+* Coordinator code was reporting rocksdb error codes, but not the associated detail message.
   Corrected.
 
 * Fixed some error reporting and logging in Maintenance.

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -279,6 +279,7 @@ void ClusterInfo::cleanup() {
 
 /// @brief produces an agency dump and logs it
 void ClusterInfo::logAgencyDump() const {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   AgencyComm ac;
   AgencyCommResult ag = ac.getValues("/");
 
@@ -287,6 +288,7 @@ void ClusterInfo::logAgencyDump() const {
   } else {
     LOG_TOPIC(WARN, Logger::CLUSTER) << "Could not get agency dump!";
   }
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1606,9 +1606,14 @@ Result ClusterInfo::checkCollectionPreconditions(std::string const& databaseName
           return TRI_ERROR_ARANGO_DUPLICATE_NAME;
         }
       } else {
-        // no need to create a collection in a database that is not there (anymore)
-        events::CreateCollection(info.name, TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
-        return TRI_ERROR_ARANGO_DATABASE_NOT_FOUND;
+        // no collection in plan for this particular database... this may be true for
+        // the first collection created in a db
+        // now check if there is a planned database at least
+        if (_plannedDatabases.find(databaseName) == _plannedDatabases.end()) {
+          // no need to create a collection in a database that is not there (anymore)
+          events::CreateCollection(info.name, TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
+          return TRI_ERROR_ARANGO_DATABASE_NOT_FOUND;
+        }
       }
     }
   

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -270,6 +270,9 @@ class ClusterInfo {
   static void cleanup();
 
  public:
+  /// @brief produces an agency dump and logs it
+  void logAgencyDump() const;
+
   //////////////////////////////////////////////////////////////////////////////
   /// @brief get a number of cluster-wide unique IDs, returns the first
   /// one and guarantees that <number> are reserved for the caller.

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -395,19 +395,15 @@ class ClusterInfo {
                                       std::vector<ClusterCollectionCreationInfo> const& infos,
                                       uint64_t& planVersion);
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief create multiple collections in coordinator
   ///        If any one of these collections fails, all creations will be
   ///        rolled back.
-  //////////////////////////////////////////////////////////////////////////////
-
+  /// Note that in contrast to most other methods here, this method does not
+  /// get a timeout parameter, but an endTime parameter!!!
   Result createCollectionsCoordinator(std::string const& databaseName,
-                                      std::vector<ClusterCollectionCreationInfo>&, double timeout);
+                                      std::vector<ClusterCollectionCreationInfo>&, double endTime);
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief drop collection in coordinator
-  //////////////////////////////////////////////////////////////////////////////
-
   int dropCollectionCoordinator(std::string const& databaseName, std::string const& collectionID,
                                 std::string& errorMsg, double timeout);
 

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -388,6 +388,13 @@ class ClusterInfo {
                                   arangodb::velocypack::Slice const& json,
                                   std::string& errorMsg, double timeout);
 
+  /// @brief this method does an atomic check of the preconditions for the collections
+  /// to be created, using the currently loaded plan. it populates the plan version
+  /// used for the checks
+  Result checkCollectionPreconditions(std::string const& databaseName,
+                                      std::vector<ClusterCollectionCreationInfo> const& infos,
+                                      uint64_t& planVersion);
+
   //////////////////////////////////////////////////////////////////////////////
   /// @brief create multiple collections in coordinator
   ///        If any one of these collections fails, all creations will be
@@ -612,20 +619,20 @@ class ClusterInfo {
    * @return         List of DB servers serving the shard
    */
   arangodb::Result getShardServers(ShardID const& shardId, std::vector<ServerID>&);
-
- private:
-  void loadClusterId();
-
+  
   //////////////////////////////////////////////////////////////////////////////
   /// @brief get an operation timeout
   //////////////////////////////////////////////////////////////////////////////
 
-  double getTimeout(double timeout) const {
+  static double getTimeout(double timeout) {
     if (timeout == 0.0) {
       return 24.0 * 3600.0;
     }
     return timeout;
   }
+
+ private:
+  void loadClusterId();
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief get the poll interval

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -22,6 +22,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "ClusterMethods.h"
+#include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/NumberUtils.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/StringRef.h"
@@ -2567,107 +2568,146 @@ std::vector<std::shared_ptr<LogicalCollection>> ClusterMethods::persistCollectio
     std::vector<std::shared_ptr<LogicalCollection>>& collections,
     bool ignoreDistributeShardsLikeErrors, bool waitForSyncReplication,
     bool enforceReplicationFactor) {
+  
   TRI_ASSERT(!collections.empty());
   if (collections.empty()) {
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_INTERNAL,
         "Trying to create an empty list of collections on coordinator.");
   }
+  
+  double const realTimeout = ClusterInfo::getTimeout(240.0);
+  double const endTime = TRI_microtime() + realTimeout;
+
   // We have at least one, take this collections DB name
-  auto& dbName = collections[0]->vocbase().name();
+  auto const dbName = collections[0]->vocbase().name();
   ClusterInfo* ci = ClusterInfo::instance();
-  ci->loadCurrentDBServers();
-  std::vector<std::string> dbServers = ci->getCurrentDBServers();
+    
   std::vector<ClusterCollectionCreationInfo> infos;
-  std::vector<std::shared_ptr<VPackBuffer<uint8_t>>> vpackData;
-  infos.reserve(collections.size());
-  vpackData.reserve(collections.size());
-  for (auto& col : collections) {
-    // We can only serve on Database at a time with this call.
-    // We have the vocbase context around this calls anyways, so this is save.
-    TRI_ASSERT(col->vocbase().name() == dbName);
-    std::string distributeShardsLike = col->distributeShardsLike();
-    std::vector<std::string> avoid = col->avoidServers();
-    std::shared_ptr<std::unordered_map<std::string, std::vector<std::string>>> shards = nullptr;
 
-    if (!distributeShardsLike.empty()) {
-      CollectionNameResolver resolver(col->vocbase());
-      TRI_voc_cid_t otherCid = resolver.getCollectionIdCluster(distributeShardsLike);
+  while (true) {
+    infos.clear();
 
-      if (otherCid != 0) {
-        shards = CloneShardDistribution(ci, col.get(), otherCid);
+    ci->loadCurrentDBServers();
+    std::vector<std::string> dbServers = ci->getCurrentDBServers();
+    infos.reserve(collections.size());
+    
+    std::vector<std::shared_ptr<VPackBuffer<uint8_t>>> vpackData;
+    vpackData.reserve(collections.size());
+    for (auto& col : collections) {
+      // We can only serve on Database at a time with this call.
+      // We have the vocbase context around this calls anyways, so this is save.
+      TRI_ASSERT(col->vocbase().name() == dbName);
+      std::string distributeShardsLike = col->distributeShardsLike();
+      std::vector<std::string> avoid = col->avoidServers();
+      std::shared_ptr<std::unordered_map<std::string, std::vector<std::string>>> shards = nullptr;
+
+      if (!distributeShardsLike.empty()) {
+        CollectionNameResolver resolver(col->vocbase());
+        TRI_voc_cid_t otherCid = resolver.getCollectionIdCluster(distributeShardsLike);
+
+        if (otherCid != 0) {
+          shards = CloneShardDistribution(ci, col.get(), otherCid);
+        } else {
+          THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_CLUSTER_UNKNOWN_DISTRIBUTESHARDSLIKE,
+              "Could not find collection " + distributeShardsLike +
+              " to distribute shards like it.");
+        }
       } else {
-        THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_CLUSTER_UNKNOWN_DISTRIBUTESHARDSLIKE,
-                                       "Could not find collection " + distributeShardsLike +
-                                           " to distribute shards like it.");
-      }
-    } else {
-      // system collections should never enforce replicationfactor
-      // to allow them to come up with 1 dbserver
-      if (col->system()) {
-        enforceReplicationFactor = false;
-      }
+        // system collections should never enforce replicationfactor
+        // to allow them to come up with 1 dbserver
+        if (col->system()) {
+          enforceReplicationFactor = false;
+        }
 
-      size_t replicationFactor = col->replicationFactor();
-      size_t numberOfShards = col->numberOfShards();
+        size_t replicationFactor = col->replicationFactor();
+        size_t numberOfShards = col->numberOfShards();
 
-      // the default behaviour however is to bail out and inform the user
-      // that the requested replicationFactor is not possible right now
-      if (dbServers.size() < replicationFactor) {
-        LOG_TOPIC(DEBUG, Logger::CLUSTER)
+        // the default behaviour however is to bail out and inform the user
+        // that the requested replicationFactor is not possible right now
+        if (dbServers.size() < replicationFactor) {
+          LOG_TOPIC(DEBUG, Logger::CLUSTER)
             << "Do not have enough DBServers for requested replicationFactor,"
             << " nrDBServers: " << dbServers.size()
             << " replicationFactor: " << replicationFactor;
-        if (enforceReplicationFactor) {
-          THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_INSUFFICIENT_DBSERVERS);
+          if (enforceReplicationFactor) {
+            THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_INSUFFICIENT_DBSERVERS);
+          }
         }
-      }
 
-      if (!avoid.empty()) {
-        // We need to remove all servers that are in the avoid list
-        if (dbServers.size() - avoid.size() < replicationFactor) {
-          LOG_TOPIC(DEBUG, Logger::CLUSTER)
+        if (!avoid.empty()) {
+          // We need to remove all servers that are in the avoid list
+          if (dbServers.size() - avoid.size() < replicationFactor) {
+            LOG_TOPIC(DEBUG, Logger::CLUSTER)
               << "Do not have enough DBServers for requested replicationFactor,"
               << " (after considering avoid list),"
               << " nrDBServers: " << dbServers.size() << " replicationFactor: " << replicationFactor
               << " avoid list size: " << avoid.size();
-          // Not enough DBServers left
-          THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_INSUFFICIENT_DBSERVERS);
+            // Not enough DBServers left
+            THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_INSUFFICIENT_DBSERVERS);
+          }
+          dbServers.erase(std::remove_if(dbServers.begin(), dbServers.end(),
+                [&](const std::string& x) {
+                return std::find(avoid.begin(), avoid.end(),
+                    x) != avoid.end();
+                }),
+              dbServers.end());
         }
-        dbServers.erase(std::remove_if(dbServers.begin(), dbServers.end(),
-                                       [&](const std::string& x) {
-                                         return std::find(avoid.begin(), avoid.end(),
-                                                          x) != avoid.end();
-                                       }),
-                        dbServers.end());
+        std::random_shuffle(dbServers.begin(), dbServers.end());
+        shards = DistributeShardsEvenly(ci, numberOfShards, replicationFactor,
+            dbServers, !col->system());
       }
-      std::random_shuffle(dbServers.begin(), dbServers.end());
-      shards = DistributeShardsEvenly(ci, numberOfShards, replicationFactor,
-                                      dbServers, !col->system());
-    }
 
-    if (shards->empty() && !col->isSmart()) {
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
-                                     "no database servers found in cluster");
-    }
+      if (shards->empty() && !col->isSmart()) {
+        THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+            "no database servers found in cluster");
+      }
 
-    col->setShardMap(shards);
+      col->setShardMap(shards);
 
-    std::unordered_set<std::string> const ignoreKeys{
+      std::unordered_set<std::string> const ignoreKeys{
         "allowUserKeys", "cid",     "globallyUniqueId", "count",
-        "planId",        "version", "objectId"};
-    col->setStatus(TRI_VOC_COL_STATUS_LOADED);
-    VPackBuilder velocy = col->toVelocyPackIgnore(ignoreKeys, false, false);
+          "planId",        "version", "objectId"};
+      col->setStatus(TRI_VOC_COL_STATUS_LOADED);
+      VPackBuilder velocy = col->toVelocyPackIgnore(ignoreKeys, false, false);
 
-    infos.emplace_back(
-        ClusterCollectionCreationInfo{std::to_string(col->id()),
-                                      col->numberOfShards(), col->replicationFactor(),
-                                      waitForSyncReplication, velocy.slice()});
-    vpackData.emplace_back(velocy.steal());
-  }
-  Result res = ci->createCollectionsCoordinator(dbName, infos, 240.0);
-  if (res.fail()) {
-    THROW_ARANGO_EXCEPTION(res);
+      infos.emplace_back(
+          ClusterCollectionCreationInfo{std::to_string(col->id()),
+          col->numberOfShards(), col->replicationFactor(),
+          waitForSyncReplication, velocy.slice()});
+      vpackData.emplace_back(velocy.steal());
+    }
+
+    Result res = ci->createCollectionsCoordinator(dbName, infos, endTime);
+
+    if (res.ok()) {
+      // success! exit the loop and go on
+      break;
+    }
+
+    if (res.is(TRI_ERROR_REQUEST_CANCELED)) {
+      // special error code indicating that storing the updated plan in the agency
+      // didn't succeed, and that we should try again
+      
+      // sleep for a while
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      
+      if (TRI_microtime() > endTime) {
+        // timeout expired
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_TIMEOUT);
+      }
+  
+      if (arangodb::application_features::ApplicationServer::isStopping()) {
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+      }
+      
+      // try in next iteration with an adjusted plan change attempt
+      continue; 
+
+    } else {
+      // any other error
+      THROW_ARANGO_EXCEPTION(res);
+    }
   }
 
   // This is no longer necessary, since we load the Plan in

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -2678,6 +2678,7 @@ std::vector<std::shared_ptr<LogicalCollection>> ClusterMethods::persistCollectio
       vpackData.emplace_back(velocy.steal());
     }
 
+    // pass in the *endTime* here, not a timeout!
     Result res = ci->createCollectionsCoordinator(dbName, infos, endTime);
 
     if (res.ok()) {


### PR DESCRIPTION
### Scope & Purpose

Fix multiple possible races in cluster collection creation.
Before it was possible for concurrent operations to create a collection with the same name multiple times. The change now will acquire the current Plan and validate if a collection of the same name exists in it. It then tries to create the collection in the agency, using the retrieved plan version as a precondition. If a concurrent operation has updated the plan in between, the whole operation, including a new shard distribution, will be retried. The sleep time before a retry has been lower from 5 seconds to 100 milliseconds.
Additionally now two agency calls are saved for each collection creation.
Caveat: as we are using the previous plan version as a precondition when creating the collection, it is possible that this change reduces the throughput of operations that concurrently create collections. This will especially be the case when there are huge plans.

For collection deletion, misleading error codes could have been returned, e.g. "database not found" when it should have been "collection not found".

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

We should run parallel collection creation and also parallel create/drop tests to validate this fix.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5274/