### PR TITLE
Cleanup ServerState.cpp

### DIFF
--- a/arangod/Agency/AgencyStrings.h
+++ b/arangod/Agency/AgencyStrings.h
@@ -25,9 +25,12 @@
 #define ARANGOD_AGENCY_STRINGS_H 1
 
 #include <string>
+#include "Basics/StringUtils.h"
 
 namespace arangodb {
 namespace consensus {
+
+constexpr char const* ARANGO = "arango";
 
 constexpr char const* DATABASES = "Databases";
 constexpr char const* COLLECTIONS = "Collections";
@@ -39,6 +42,8 @@ constexpr char const* CURRENT_VERSION = "Current/Version";
 constexpr char const* CURRENT_COLLECTIONS = "Current/Collections/";
 constexpr char const* CURRENT_DATABASES = "Current/Databases/";
 
+constexpr char const* SERVERS_REGISTERED =  "ServersRegistered";
+
 constexpr char const* PLAN = "Plan";
 constexpr char const* PLAN_VERSION = "Plan/Version";
 constexpr char const* PLAN_COLLECTIONS = "Plan/Collections/";
@@ -46,6 +51,16 @@ constexpr char const* PLAN_DATABASES = "Plan/Databases/";
 
 constexpr char const* TARGET = "Target";
 constexpr char const* MAP_UNIQUE_TO_SHORT_ID = "MapUniqueToShortId";
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief helper function to conveniently assemble paths from string constants
+///
+///        this should really be moved to a more appropriate place, and maybe
+///        do checks and/or trims on the strings that are passed in.
+////////////////////////////////////////////////////////////////////////////////
+static inline std::string concatPath(std::vector<std::string> const& components) {
+  return arangodb::basics::StringUtils::join(components, "/");
+}
 
 }  // namespace consensus
 }  // namespace arangodb

--- a/arangod/Agency/AgencyStrings.h
+++ b/arangod/Agency/AgencyStrings.h
@@ -21,6 +21,9 @@
 /// @author Kaveh Vahedipour
 ////////////////////////////////////////////////////////////////////////////////
 
+#ifndef ARANGOD_AGENCY_STRINGS_H
+#define ARANGOD_AGENCY_STRINGS_H 1
+
 #include <string>
 
 namespace arangodb {
@@ -41,5 +44,10 @@ constexpr char const* PLAN_VERSION = "Plan/Version";
 constexpr char const* PLAN_COLLECTIONS = "Plan/Collections/";
 constexpr char const* PLAN_DATABASES = "Plan/Databases/";
 
+constexpr char const* TARGET = "Target";
+constexpr char const* MAP_UNIQUE_TO_SHORT_ID = "MapUniqueToShortId";
+
 }  // namespace consensus
 }  // namespace arangodb
+
+#endif

--- a/arangod/Agency/AgencyStrings.h
+++ b/arangod/Agency/AgencyStrings.h
@@ -50,7 +50,7 @@ constexpr char const* PLAN_COLLECTIONS = "Plan/Collections/";
 constexpr char const* PLAN_DATABASES = "Plan/Databases/";
 
 constexpr char const* TARGET = "Target";
-constexpr char const* MAP_UNIQUE_TO_SHORT_ID = "MapUniqueToShortId";
+constexpr char const* MAP_UNIQUE_TO_SHORT_ID = "MapUniqueToShortID";
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief helper function to conveniently assemble paths from string constants

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -348,18 +348,6 @@ bool ServerState::integrateIntoCluster(ServerState::RoleEnum role,
     return false;
   }
 
-  // if (have persisted id) {
-  //   use the persisted id
-  // } else {
-  //  if (myLocalId not empty) {
-  //    lookup in agency
-  //    if (found) {
-  //      persist id
-  //    }
-  //  }
-  //  if (id still not set) {
-  //    generate and persist new id
-  //  }
   std::string id;
   if (!hasPersistedId()) {
     id = generatePersistedId(role);
@@ -392,7 +380,7 @@ bool ServerState::integrateIntoCluster(ServerState::RoleEnum role,
 /// @brief get the key for a role in the agency
 //////////////////////////////////////////////////////////////////////////////
 std::string ServerState::roleToAgencyListKey(ServerState::RoleEnum role) {
-  return roleToAgencyKey(role) + "s";  // lol
+  return roleToAgencyKey(role) + "s";
 }
 
 std::string ServerState::roleToAgencyKey(ServerState::RoleEnum role) {

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -412,16 +412,6 @@ std::string ServerState::roleToAgencyKey(ServerState::RoleEnum role) {
   return "INVALID_CLUSTER_ROLE";
 }
 
-void mkdir(std::string const& path) {
-  if (!TRI_IsDirectory(path.c_str())) {
-    if (!arangodb::basics::FileUtils::createDirectory(path)) {
-      LOG_TOPIC("626e8", FATAL, arangodb::Logger::CLUSTER)
-          << "Couldn't create file directory " << path << " (UUID)";
-      FATAL_ERROR_EXIT();
-    }
-  }
-}
-
 std::string ServerState::getUuidFilename() {
   auto dbpath = application_features::ApplicationServer::getFeature<DatabasePathFeature>(
       "DatabasePath");

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -531,7 +531,7 @@ bool ServerState::registerAtAgencyPhase1(AgencyComm& comm, const ServerState::Ro
        AgencyOperation(CURRENT_VERSION, AgencySimpleOperationType::INCREMENT_OP)},
       AgencyPrecondition(currentUrl, AgencyPrecondition::Type::EMPTY, true));
   // ok to fail..if it failed we are already registered
-  AgencyCommResult res = comm.sendTransactionWithFailover(creg, 0.0);
+  comm.sendTransactionWithFailover(creg, 0.0);
 
   // coordinator is already/still registered from an previous unclean shutdown;
   // must establish a new short ID

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -493,8 +493,6 @@ bool ServerState::registerAtAgencyPhase1(AgencyComm& comm, const ServerState::Ro
   VPackBuilder builder;
   builder.add(VPackValue("none"));
 
-  AgencyCommResult createResult;
-
   AgencyCommResult result = comm.getValues(concatPath({PLAN, agencyListKey}));
   if (!result.successful()) {
     LOG_TOPIC("0f327", FATAL, Logger::STARTUP)

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -482,16 +482,9 @@ bool ServerState::checkEngineEquality(AgencyComm& comm) {
   return true;
 }
 
-//////////////////////////////////////////////////////////////////////////////
-/// @brief create an id for a specified role
-//////////////////////////////////////////////////////////////////////////////
-
-bool ServerState::registerAtAgencyPhase1(AgencyComm& comm, const ServerState::RoleEnum& role) {
+bool ServerState::checkIfAgencyInitialized(AgencyComm& comm,
+                                           ServerState::RoleEnum const& role) {
   std::string const agencyListKey = roleToAgencyListKey(role);
-  std::string const latestIdKey = "Latest" + roleToAgencyKey(role) + "Id";
-
-  VPackBuilder builder;
-  builder.add(VPackValue("none"));
 
   AgencyCommResult result = comm.getValues(concatPath({PLAN, agencyListKey}));
   if (!result.successful()) {
@@ -509,6 +502,20 @@ bool ServerState::registerAtAgencyPhase1(AgencyComm& comm, const ServerState::Ro
         << "Agency not initialized?";
     return false;
   }
+
+  return true;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+/// @brief create an id for a specified role
+//////////////////////////////////////////////////////////////////////////////
+
+bool ServerState::registerAtAgencyPhase1(AgencyComm& comm, const ServerState::RoleEnum& role) {
+  std::string const agencyListKey = roleToAgencyListKey(role);
+  std::string const latestIdKey = "Latest" + roleToAgencyKey(role) + "Id";
+
+  VPackBuilder builder;
+  builder.add(VPackValue("none"));
 
   std::string planUrl = concatPath({PLAN, agencyListKey,  _id});
   std::string currentUrl = concatPath({CURRENT, agencyListKey, _id});

--- a/arangod/Cluster/ServerState.h
+++ b/arangod/Cluster/ServerState.h
@@ -271,6 +271,8 @@ class ServerState {
 
   bool checkIfAgencyInitialized(AgencyComm&, RoleEnum const&);
 
+  void enterServerIntoPlanAndCurrent(AgencyComm&, RoleEnum const&);
+
   /// @brief register at agency, might already be done
   bool registerAtAgencyPhase1(AgencyComm&, const RoleEnum&);
 

--- a/arangod/Cluster/ServerState.h
+++ b/arangod/Cluster/ServerState.h
@@ -269,6 +269,8 @@ class ServerState {
   /// @brief check equality of engines with other registered servers
   bool checkEngineEquality(AgencyComm&);
 
+  bool checkIfAgencyInitialized(AgencyComm&, RoleEnum const&);
+
   /// @brief register at agency, might already be done
   bool registerAtAgencyPhase1(AgencyComm&, const RoleEnum&);
 


### PR DESCRIPTION
This PR is a collection that does three (unrelated) cleanups that should not (indeed must not) impact fuctionality.

I could put in separate PRs but that would put load on jenkins and might not be desirable.

 * removes the unused function `mkdir`
 * removes some obsolete comments
 * replaces the use of string literals to access the agency by using string constants

### Scope & Purpose

*(Can you describe what functional change your PR is trying to effect?)*

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [ ] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [ ] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behaviour change can only be verified via automatic tests
 Testing & Verification

This change is a code cleanup without any (additional) test coverage.
