### PR TITLE
Introduce templated constructor for AgencyOperation

### DIFF
--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -159,6 +159,17 @@ AgencyOperation::AgencyOperation(std::string const& key, AgencyValueOperationTyp
   _opType.value = opType;
 }
 
+template<typename T>
+AgencyOperation::AgencyOperation(std::string const& key, AgencyValueOperationType opType, T const& value)
+  : _key(AgencyCommManager::path(key)), _opType(), _holder(std::make_shared<VPackBuilder>()) {
+  _holder->add(VPackValue(value));
+  _value = _holder->slice();
+  _opType.type = AgencyOperationType::Type::VALUE;
+  _opType.value = opType;
+}
+
+
+
 AgencyOperationType AgencyOperation::type() const { return _opType; }
 
 void AgencyOperation::toVelocyPack(VPackBuilder& builder) const {

--- a/arangod/Agency/AgencyComm.h
+++ b/arangod/Agency/AgencyComm.h
@@ -212,6 +212,9 @@ class AgencyOperation {
   AgencyOperation(std::string const& key, AgencyValueOperationType opType,
                   velocypack::Slice const newValue, velocypack::Slice const oldValue);
 
+  template <typename T>
+  AgencyOperation(std::string const& key, AgencyValueOperationType opType, T const& value);
+
  public:
   void toVelocyPack(arangodb::velocypack::Builder& builder) const;
   void toGeneralBuilder(arangodb::velocypack::Builder& builder) const;


### PR DESCRIPTION
This constructor enables passing a value directly to AgencyOperations that
SET values, making it unnecessary to create a velocypack builder and value
first.

I believe this was written by @kvahed

