### PR TITLE
bug-fix/internal-issue-#609.1: properly handle removals during recovery

### DIFF
--- a/3rdParty/iresearch/core/index/index_writer.cpp
+++ b/3rdParty/iresearch/core/index/index_writer.cpp
@@ -722,6 +722,7 @@ index_writer::documents_context::~documents_context() NOEXCEPT {
 }
 
 void index_writer::documents_context::reset() NOEXCEPT {
+  tick_ = 0; // reset tick
   auto& ctx = segment_.ctx();
 
   if (!ctx) {

--- a/3rdParty/iresearch/core/index/index_writer.hpp
+++ b/3rdParty/iresearch/core/index/index_writer.hpp
@@ -190,7 +190,9 @@ class IRESEARCH_API index_writer:
     documents_context(documents_context&& other) NOEXCEPT
       : segment_(std::move(other.segment_)),
         segment_use_count_(std::move(other.segment_use_count_)),
+        tick_(other.tick_),
         writer_(other.writer_) {
+      other.tick_ = 0;
       other.segment_use_count_ = 0;
     }
 

--- a/3rdParty/iresearch/core/index/segment_writer.cpp
+++ b/3rdParty/iresearch/core/index/segment_writer.cpp
@@ -328,6 +328,7 @@ void segment_writer::flush(index_meta::index_segment_t& segment) {
 
 void segment_writer::reset() NOEXCEPT {
   initialized_ = false;
+  tick_ = 0;
   dir_.clear_tracked();
   docs_context_.clear();
   docs_mask_.clear();

--- a/arangod/IResearch/IResearchLink.cpp
+++ b/arangod/IResearch/IResearchLink.cpp
@@ -1074,6 +1074,13 @@ Result IResearchLink::initDataStore(InitCallback const& initCallback, bool sorte
           "failed to get last committed tick while initializing link '" + std::to_string(id()) + "'"
         };
       }
+
+      LOG_TOPIC("7e028", TRACE, iresearch::TOPIC)
+        << "successfully opened existing data store data store reader for link '" + std::to_string(id())
+        << "', docs count '" << _dataStore._reader->docs_count()
+        << "', live docs count '" << _dataStore._reader->live_docs_count()
+        << "', recovery tick '" << _dataStore._recoveryTick << "'";
+
     } catch (irs::index_not_found const&) {
       // NOOP
     }


### PR DESCRIPTION
Starting 806d56389cf rocksdb recovery helper for arangosearch doesn't handle removals correctly.