### PR TITLE
fix a query abort error in smart joins if both collections were

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.4.8 (XXXX-XX-XX)
 -------------------
 
+* Fixed a query abort error in smart joins when both collections were
+  restricted to a single shard.
+
 * Fixed potential thread handle leak on thread shutdown on Windows.
 
 * Fixed recovery of arangosearch remove operations with the RocksDB storage engine.

--- a/arangod/Aql/EngineInfoContainerDBServer.cpp
+++ b/arangod/Aql/EngineInfoContainerDBServer.cpp
@@ -127,8 +127,7 @@ void EngineInfoContainerDBServer::EngineInfo::addNode(ExecutionNode* node) {
       TRI_ASSERT(_type == ExecutionNode::MAX_NODE_TYPE_VALUE);
       auto ecNode = ExecutionNode::castTo<EnumerateCollectionNode*>(node);
       if (ecNode->isRestricted()) {
-        TRI_ASSERT(_restrictedShard.empty());
-        _restrictedShard = ecNode->restrictedShard();
+        _restrictedShards.emplace(ecNode->restrictedShard());
       }
 
       // do not set '_type' of the engine here,
@@ -141,8 +140,7 @@ void EngineInfoContainerDBServer::EngineInfo::addNode(ExecutionNode* node) {
       TRI_ASSERT(_type == ExecutionNode::MAX_NODE_TYPE_VALUE);
       auto idxNode = ExecutionNode::castTo<IndexNode*>(node);
       if (idxNode->isRestricted()) {
-        TRI_ASSERT(_restrictedShard.empty());
-        _restrictedShard = idxNode->restrictedShard();
+        _restrictedShards.emplace(idxNode->restrictedShard());
       }
 
       // do not set '_type' of the engine here,
@@ -173,8 +171,7 @@ void EngineInfoContainerDBServer::EngineInfo::addNode(ExecutionNode* node) {
       TRI_ASSERT(_type == ExecutionNode::MAX_NODE_TYPE_VALUE);
       auto modNode = ExecutionNode::castTo<ModificationNode*>(node);
       if (modNode->isRestricted()) {
-        TRI_ASSERT(_restrictedShard.empty());
-        _restrictedShard = modNode->restrictedShard();
+        _restrictedShards.emplace(modNode->restrictedShard());
       }
       break;
     }
@@ -256,8 +253,8 @@ void EngineInfoContainerDBServer::EngineInfo::serializeSnippet(
 void EngineInfoContainerDBServer::EngineInfo::serializeSnippet(
     Query& query, const ShardID& id, VPackBuilder& infoBuilder,
     bool isResponsibleForInitializeCursor) const {
-  if (!_restrictedShard.empty()) {
-    if (id != _restrictedShard) {
+  if (!_restrictedShards.empty()) {
+    if (_restrictedShards.find(id) == _restrictedShards.end()) {
       return;
     }
     // We only have one shard it has to be responsible!

--- a/arangod/Aql/EngineInfoContainerDBServer.h
+++ b/arangod/Aql/EngineInfoContainerDBServer.h
@@ -149,7 +149,7 @@ class EngineInfoContainerDBServer {
       Collection* _collection;  // The collection used to connect to this engine
       LogicalView const* _view;  // The view used to connect to this engine
     };
-    ShardID _restrictedShard;  // The shard this snippet is restricted to
+    std::unordered_set<ShardID> _restrictedShards;  // The shards this snippet is restricted to
     ExecutionNode::NodeType _type{ExecutionNode::MAX_NODE_TYPE_VALUE};  // type of the "main node"
   };
 

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -4535,6 +4535,11 @@ void arangodb::aql::restrictToSingleShardRule(Optimizer* opt,
   // are used in a smart join (and use distributeShardsLike on each other)
   auto forwardRestrictionToPrototype = [&plan](ExecutionNode const* current, std::string const& shardId) {
     auto collectionNode = dynamic_cast<CollectionAccessingNode const*>(current);
+    
+    if (collectionNode == nullptr) {
+      return;
+    }
+
     auto prototypeOutVariable = collectionNode->prototypeOutVariable();
 
     if (prototypeOutVariable == nullptr) {


### PR DESCRIPTION
### Scope & Purpose

Fix a query abort error in case a smart join was used but both collections were restricted to a single shard using the "restrict-to-single-shard" optimizer rule.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behaviour change can only be verified via automatic tests

#### Related Information

Accompanying enterprise PR with test:
https://github.com/arangodb/enterprise/pull/274

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added **Regression Tests** (in the enterprise repository)
- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/5346/

### Documentation

- [x] Added a *Changelog Entry* 
