### PR TITLE
fixed an issue with smart joins if both collections were restricted to a

### DIFF
--- a/arangod/Aql/EngineInfoContainerDBServer.cpp
+++ b/arangod/Aql/EngineInfoContainerDBServer.cpp
@@ -171,8 +171,7 @@ void EngineInfoContainerDBServer::EngineInfo::addNode(ExecutionNode* node) {
     TRI_ASSERT(sourceImpl);
 
     if (node->isRestricted()) {
-      TRI_ASSERT(sourceImpl->restrictedShard.empty());
-      sourceImpl->restrictedShard = node->restrictedShard();
+      sourceImpl->restrictedShards.emplace(node->restrictedShard());
     }
   };
 
@@ -315,10 +314,10 @@ void EngineInfoContainerDBServer::EngineInfo::serializeSnippet(
     bool isResponsibleForInitializeCursor) const {
   auto* collection = boost::get<CollectionSource>(&_source);
   TRI_ASSERT(collection);
-  auto& restrictedShard = collection->restrictedShard;
+  auto const& restrictedShards = collection->restrictedShards;
 
-  if (!restrictedShard.empty()) {
-    if (id != restrictedShard) {
+  if (!restrictedShards.empty()) {
+    if (restrictedShards.find(id) == restrictedShards.end()) {
       return;
     }
     // We only have one shard it has to be responsible!

--- a/arangod/Aql/EngineInfoContainerDBServer.h
+++ b/arangod/Aql/EngineInfoContainerDBServer.h
@@ -88,7 +88,6 @@ class EngineInfoContainerDBServer {
     explicit EngineInfo(size_t idOfRemoteNode) noexcept;
     EngineInfo(EngineInfo&& other) noexcept;
     ~EngineInfo();
-    EngineInfo(EngineInfo&) = delete;
     EngineInfo(EngineInfo const& other) = delete;
 
 #if (_MSC_VER != 0)
@@ -124,14 +123,11 @@ class EngineInfoContainerDBServer {
 
    private:
     struct CollectionSource {
-      explicit CollectionSource(aql::Collection* collection) noexcept
-        : collection(collection) {
-      }
-      CollectionSource(CollectionSource&&) = default;
-      CollectionSource& operator=(CollectionSource&&) = default;
+      explicit CollectionSource(aql::Collection* collection)
+        : collection(collection) {}
 
       aql::Collection* collection{};  // The collection used to connect to this engine
-      std::unordered_set<std::string> restrictedShards; // The shards this snippet is restricted to
+      std::unordered_set<std::string> restrictedShards{}; // The shards this snippet is restricted to
     };
 
     struct ViewSource {

--- a/arangod/Aql/EngineInfoContainerDBServer.h
+++ b/arangod/Aql/EngineInfoContainerDBServer.h
@@ -131,7 +131,7 @@ class EngineInfoContainerDBServer {
       CollectionSource& operator=(CollectionSource&&) = default;
 
       aql::Collection* collection{};  // The collection used to connect to this engine
-      std::string restrictedShard;    // The shard this snippet is restricted to
+      std::unordered_set<std::string> restrictedShards; // The shards this snippet is restricted to
     };
 
     struct ViewSource {


### PR DESCRIPTION
### Scope & Purpose

Fixed a query abort error for smart joins if both collections were restricted to a single shard using the "restrict-to-single-shard" optimizer rule.

- [x] Bug-Fix for *devel-branch* 
- [x] The behaviour change can only be verified via automatic tests

#### Related Information

Related enterprise PR: https://github.com/arangodb/enterprise/pull/275

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added **Regression Tests** (Only for bug-fixes) 
- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/5348/