### PR TITLE
bugfix-3.4:  Revert decrypt

### DIFF
--- a/js/client/modules/@arangodb/testsuites/export.js
+++ b/js/client/modules/@arangodb/testsuites/export.js
@@ -173,6 +173,9 @@ function exportTest (options) {
   if (!skipEncrypt) {
     print(CYAN + Date() + ': Export data (json encrypt)' + RESET);
     args['encryption.keyfile'] = keyfile;
+    if (fs.exists(fs.join(tmpPath, 'ENCRYPTION'))) {
+      fs.remove(fs.join(tmpPath, 'ENCRYPTION'));
+    }
     results.exportJsonEncrypt = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), options, 'arangosh', tmpPath, false, options.coreCheck);
     results.exportJsonEncrypt.failed = results.exportJsonGz.status ? 0 : 1;
 
@@ -192,6 +195,9 @@ function exportTest (options) {
       };
     }
     delete args['encryption.keyfile'];
+    if (fs.exists(fs.join(tmpPath, 'ENCRYPTION'))) {
+      fs.remove(fs.join(tmpPath, 'ENCRYPTION'));
+    }
   }
 
   print(CYAN + Date() + ': Export data (jsonl)' + RESET);


### PR DESCRIPTION
AES_set_encrypt_key() was changed to AES_set_decrypt_key() during debug.  It was not reverted before check-in and merge.  Change in enterprise branch reverts.

Change in this branch cleans up unit test that would periodically fail depending up on how often executed.

