### PR TITLE
don't keep the memory stats in the collections to save disk space

### DIFF
--- a/arangod/Statistics/StatisticsWorker.cpp
+++ b/arangod/Statistics/StatisticsWorker.cpp
@@ -937,6 +937,7 @@ void StatisticsWorker::generateRawStatistics(VPackBuilder& builder, double const
   builder.add("dirty", VPackValue(v8Counters.dirty));
   builder.add("free", VPackValue(v8Counters.free));
   builder.add("max", VPackValue(v8Counters.max));
+  /* at the time being we don't want to write this into the database so the data volume doesn't increase.
   {
     builder.add("memory", VPackValue(VPackValueType::Array));
     for (auto memStatistic : memoryStatistics) {
@@ -950,6 +951,7 @@ void StatisticsWorker::generateRawStatistics(VPackBuilder& builder, double const
     }
     builder.close();
   }
+  */
   builder.close();
 
   // export threads statistics


### PR DESCRIPTION
backport of https://github.com/arangodb/arangodb/pull/9581