### PR TITLE
reduce wait timeouts as a mitigation for notifying waiters without ho…

### DIFF
--- a/tests/IResearch/Containers-test.cpp
+++ b/tests/IResearch/Containers-test.cpp
@@ -84,16 +84,16 @@ TEST(ContainersTest, testResourceMutex) {
       cond.notify_all();
     });
 
-    auto result0 = cond.wait_for(cond_lock, std::chrono::milliseconds(100));
+    auto result0 = cond.wait_for(cond_lock, std::chrono::milliseconds(50));
 
     // MSVC 2015/2017 seems to sporadically notify condition variables without explicit request
     MSVC2015_ONLY(while (!reset && result0 == std::cv_status::no_timeout) result0 =
-                      cond.wait_for(cond_lock, std::chrono::milliseconds(100)));
+                      cond.wait_for(cond_lock, std::chrono::milliseconds(50)));
     MSVC2017_ONLY(while (!reset && result0 == std::cv_status::no_timeout) result0 =
-                      cond.wait_for(cond_lock, std::chrono::milliseconds(100)));
+                      cond.wait_for(cond_lock, std::chrono::milliseconds(50)));
 
     lock.unlock();
-    auto result1 = cond.wait_for(cond_lock, std::chrono::milliseconds(100));
+    auto result1 = cond.wait_for(cond_lock, std::chrono::milliseconds(50));
     cond_lock.unlock();
     thread.join();
     EXPECT_TRUE((std::cv_status::timeout == result0));  // check only after joining with thread to avoid early exit


### PR DESCRIPTION
### Scope & Purpose

this is a quick mitigation only, which reduces maximum wait time from 1
second to 100 milliseconds without changing other behavior.

the main problem of notifying pending writers without successfully
acquiring the required mutex still needs proper addressing.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5524/