### PR TITLE
[3.5.1] Fast Controlled Leaderchange

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+v3.5.1 (XXXX-XX-XX)
+-------------------
+
+* Keep followers in sync if the old leader resigned and stopped writes.
+
 v3.5.0-rc.7 (2019-08-01)
 ------------------------
 

--- a/arangod/Cluster/CreateCollection.cpp
+++ b/arangod/Cluster/CreateCollection.cpp
@@ -160,7 +160,7 @@ bool CreateCollection::first() {
 
                               if (leader.empty()) {
                                 std::vector<std::string> noFollowers;
-                                col->followers()->takeOverLeadership(noFollowers);
+                                col->followers()->takeOverLeadership(noFollowers, nullptr);
                               } else {
                                 col->followers()->setTheLeader(leader);
                               }

--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -247,13 +247,14 @@ bool FollowerInfo::contains(ServerID const& sid) const {
 ///        before a failover to this server has happened
 ////////////////////////////////////////////////////////////////////////////////
 
-void FollowerInfo::takeOverLeadership(std::vector<std::string> const& previousInsyncFollowers) {
+void FollowerInfo::takeOverLeadership(std::vector<ServerID> const& previousInsyncFollowers,
+                                      std::shared_ptr<std::vector<ServerID>> realInsyncFollowers) {
   // This function copies over the information taken from the last CURRENT into a local vector.
   // Where we remove the old leader and ourself from the list of followers
   WRITE_LOCKER(canWriteLocker, _canWriteLock);
   WRITE_LOCKER(writeLocker, _dataLock);
   // Reset local structures, if we take over leadership we do not know anything!
-  _followers = std::make_shared<std::vector<ServerID>>();
+  _followers = realInsyncFollowers ? realInsyncFollowers : std::make_shared<std::vector<ServerID>>();
   _failoverCandidates = std::make_shared<std::vector<ServerID>>();
   // We disallow writes until the first write.
   _canWrite = false;

--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -106,9 +106,13 @@ class FollowerInfo {
   /// @brief Take over leadership for this shard.
   ///        Also inject information of a insync followers that we knew about
   ///        before a failover to this server has happened
+  ///        The second parameter may be nullptr. It is an additional list
+  ///        of declared to be insync followers. If it is nullptr the follower
+  ///        list is initialised empty.
   ////////////////////////////////////////////////////////////////////////////////
 
-  void takeOverLeadership(std::vector<std::string> const& previousInsyncFollowers);
+  void takeOverLeadership(std::vector<ServerID> const& previousInsyncFollowers,
+                          std::shared_ptr<std::vector<ServerID>> realInsyncFollowers);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief add a follower to a shard, this is only done by the server side

--- a/arangod/Cluster/ResignShardLeadership.cpp
+++ b/arangod/Cluster/ResignShardLeadership.cpp
@@ -119,9 +119,9 @@ bool ResignShardLeadership::first() {
     // for now but we will not accept any replication operation from any
     // leader, until we have negotiated a deal with it. Then the actual
     // name of the leader will be set.
-    col->followers()->setTheLeader("LEADER_NOT_YET_KNOWN");  // resign
+    col->followers()->setTheLeader(LeaderNotYetKnownString);  // resign
     trx.abort(); // unlock
-    
+
     transaction::cluster::abortLeaderTransactionsOnShard(col->id());
 
   } catch (std::exception const& e) {
@@ -135,3 +135,5 @@ bool ResignShardLeadership::first() {
   notify();
   return false;
 }
+
+std::string const ResignShardLeadership::LeaderNotYetKnownString = "LEADER_NOT_YET_KNOWN";

--- a/arangod/Cluster/ResignShardLeadership.h
+++ b/arangod/Cluster/ResignShardLeadership.h
@@ -40,6 +40,8 @@ class ResignShardLeadership : public ActionBase {
   virtual ~ResignShardLeadership();
 
   virtual bool first() override final;
+
+  static std::string const LeaderNotYetKnownString;
 };
 
 }  // namespace maintenance

--- a/arangod/Cluster/UpdateCollection.cpp
+++ b/arangod/Cluster/UpdateCollection.cpp
@@ -89,7 +89,7 @@ UpdateCollection::UpdateCollection(MaintenanceFeature& feature, ActionDescriptio
 
 void sendLeaderChangeRequests(std::vector<ServerID> const& currentServers,
                               std::shared_ptr<std::vector<ServerID>>& realInsyncFollowers,
-                              ShardID const& shardID) {
+                              std::string const& databaseName, ShardID const& shardID) {
 
   auto cc = ClusterComm::instance();
   if (cc == nullptr) {
@@ -107,7 +107,7 @@ void sendLeaderChangeRequests(std::vector<ServerID> const& currentServers,
     bodyBuilder.add("shard", VPackValue(shardID));
   }
 
-  std::string const url = "/_api/replication/set-the-leader";
+  std::string const url = "/_db/" + databaseName + "/_api/replication/set-the-leader";
 
   std::vector<ClusterCommRequest> requests;
   auto body = std::make_shared<std::string>(bodyBuilder.toJson());
@@ -163,7 +163,7 @@ void handleLeadership(LogicalCollection& collection, std::string const& localLea
           oldLeader = oldLeader.substr(1);
 
           // Update all follower and tell them that we are the leader now
-          sendLeaderChangeRequests(currentServers, realInsyncFollowers, collection.name());
+          sendLeaderChangeRequests(currentServers, realInsyncFollowers, databaseName, collection.name());
         }
       }
 

--- a/arangod/Cluster/UpdateCollection.cpp
+++ b/arangod/Cluster/UpdateCollection.cpp
@@ -29,6 +29,7 @@
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/FollowerInfo.h"
 #include "Cluster/MaintenanceFeature.h"
+#include "Cluster/ClusterComm.h"
 #include "Transaction/ClusterUtils.h"
 #include "Utils/DatabaseGuard.h"
 #include "VocBase/LogicalCollection.h"
@@ -86,6 +87,52 @@ UpdateCollection::UpdateCollection(MaintenanceFeature& feature, ActionDescriptio
   }
 }
 
+void sendLeaderChangeRequests(std::vector<ServerID> const& currentServers,
+                              std::shared_ptr<std::vector<ServerID>>& realInsyncFollowers,
+                              ShardID const& shardID) {
+
+  auto cc = ClusterComm::instance();
+  if (cc == nullptr) {
+    // nullptr happens only during controlled shutdown
+    return;
+  }
+
+  std::string const& sid = ServerState::instance()->getId();
+
+
+  VPackBuilder bodyBuilder;
+  {
+    VPackObjectBuilder ob(&bodyBuilder);
+    bodyBuilder.add("leaderId", VPackValue(sid));
+    bodyBuilder.add("shard", VPackValue(shardID));
+  }
+
+  std::string const url = "/_api/replication/set-the-leader";
+
+  std::vector<ClusterCommRequest> requests;
+  auto body = std::make_shared<std::string>(bodyBuilder.toJson());
+  for (auto const& srv : currentServers) {
+    if (srv == sid) {
+      continue; // ignore ourself
+    }
+    LOG_DEVEL << "Sending " << bodyBuilder.toJson() << " to " << srv;
+    requests.emplace_back("server:" + srv, RequestType::PUT, url, body);
+  }
+
+  cc->performRequests(requests, 3.0, Logger::COMMUNICATION, false);
+
+  // This code intentionally ignores all errors
+  realInsyncFollowers = std::make_shared<std::vector<ServerID>>();
+  for (auto const& req : requests) {
+    ClusterCommResult const& result = req.result;
+    if (result.errorCode == TRI_ERROR_NO_ERROR) {
+      if (result.result && result.result->getHttpReturnCode() == 200) {
+        realInsyncFollowers->push_back(result.serverID);
+      }
+    }
+  }
+}
+
 void handleLeadership(LogicalCollection& collection, std::string const& localLeader,
                       std::string const& plannedLeader,
                       std::string const& followersToDrop, std::string const& databaseName,
@@ -104,8 +151,24 @@ void handleLeadership(LogicalCollection& collection, std::string const& localLea
         return;
       }
       TRI_ASSERT(currentInfo != nullptr);
-      auto failoverCandidates = currentInfo->failoverCandidates(collection.name());
-      followers->takeOverLeadership(failoverCandidates);
+      std::vector<ServerID> currentServers = currentInfo->servers(collection.name());
+      std::shared_ptr<std::vector<ServerID>> realInsyncFollowers;
+
+      if (currentServers.size() > 0) {
+        std::string& oldLeader = currentServers.at(0);
+        // Check if the old leader has resigned and stopped all write
+        // (if so, we can assume that all servers are still in sync)
+        if (oldLeader.at(0) == '_') {
+          // remove the underscore from the list as it is useless anyway
+          oldLeader = oldLeader.substr(1);
+
+          // Update all follower and tell them that we are the leader now
+          sendLeaderChangeRequests(currentServers, realInsyncFollowers, collection.name());
+        }
+      }
+
+      std::vector<ServerID> failoverCandidates = currentInfo->failoverCandidates(collection.name());
+      followers->takeOverLeadership(failoverCandidates, realInsyncFollowers);
       transaction::cluster::abortFollowerTransactionsOnShard(collection.id());
     } else {
       // If someone (the Supervision most likely) has thrown

--- a/arangod/Cluster/UpdateCollection.cpp
+++ b/arangod/Cluster/UpdateCollection.cpp
@@ -89,7 +89,8 @@ UpdateCollection::UpdateCollection(MaintenanceFeature& feature, ActionDescriptio
 
 void sendLeaderChangeRequests(std::vector<ServerID> const& currentServers,
                               std::shared_ptr<std::vector<ServerID>>& realInsyncFollowers,
-                              std::string const& databaseName, ShardID const& shardID) {
+                              std::string const& databaseName, ShardID const& shardID,
+                              std::string const& oldLeader) {
 
   auto cc = ClusterComm::instance();
   if (cc == nullptr) {
@@ -104,6 +105,7 @@ void sendLeaderChangeRequests(std::vector<ServerID> const& currentServers,
   {
     VPackObjectBuilder ob(&bodyBuilder);
     bodyBuilder.add("leaderId", VPackValue(sid));
+    bodyBuilder.add("oldLeaderId", VPackValue(oldLeader));
     bodyBuilder.add("shard", VPackValue(shardID));
   }
 
@@ -163,7 +165,7 @@ void handleLeadership(LogicalCollection& collection, std::string const& localLea
           oldLeader = oldLeader.substr(1);
 
           // Update all follower and tell them that we are the leader now
-          sendLeaderChangeRequests(currentServers, realInsyncFollowers, databaseName, collection.name());
+          sendLeaderChangeRequests(currentServers, realInsyncFollowers, databaseName, collection.name(), oldLeader);
         }
       }
 

--- a/arangod/Cluster/UpdateCollection.cpp
+++ b/arangod/Cluster/UpdateCollection.cpp
@@ -127,7 +127,7 @@ void sendLeaderChangeRequests(std::vector<ServerID> const& currentServers,
   realInsyncFollowers = std::make_shared<std::vector<ServerID>>();
   for (auto const& req : requests) {
     ClusterCommResult const& result = req.result;
-    if (result.errorCode == TRI_ERROR_NO_ERROR) {
+    if (result.status == CL_COMM_RECEIVED && result.errorCode == TRI_ERROR_NO_ERROR) {
       if (result.result && result.result->getHttpReturnCode() == 200) {
         realInsyncFollowers->push_back(result.serverID);
       }

--- a/arangod/Cluster/UpdateCollection.cpp
+++ b/arangod/Cluster/UpdateCollection.cpp
@@ -117,7 +117,6 @@ void sendLeaderChangeRequests(std::vector<ServerID> const& currentServers,
     if (srv == sid) {
       continue; // ignore ourself
     }
-    LOG_DEVEL << "Sending " << bodyBuilder.toJson() << " to " << srv;
     requests.emplace_back("server:" + srv, RequestType::PUT, url, body);
   }
 

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -121,19 +121,14 @@ static Result checkPlanLeaderDirect(std::shared_ptr<LogicalCollection> const& co
 
   std::string shardAgencyPathString = StringUtils::join(agencyPath, '/');
 
-  LOG_DEVEL << shardAgencyPathString;
-
   AgencyComm ac;
   AgencyCommResult res = ac.getValues(shardAgencyPathString);
 
   if (res.successful()) {
-
-  LOG_DEVEL << "Agency Transaction: " << res.slice().toJson();
     // This is bullshit. Why does the *fancy* AgencyComm Manager
     // prepend the agency url with `arango` but in the end returns an object
     // that is prepended by `arango`! WTF!?
     VPackSlice plan = res.slice().at(0).get(AgencyCommManager::path()).get(agencyPath);
-    LOG_DEVEL << plan.toJson();
     TRI_ASSERT(plan.isArray() && plan.length() > 0);
 
     VPackSlice leaderSlice = plan.at(0);
@@ -2544,8 +2539,6 @@ void RestReplicationHandler::handleCommandSetTheLeader() {
   }
 
   col->followers()->setTheLeader(leaderId);
-  LOG_DEVEL << "Set leader for " << shard.copyString() << " to " << leaderId;
-
   VPackBuilder b;
   {
     VPackObjectBuilder bb(&b);

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -545,7 +545,7 @@ RestStatus RestReplicationHandler::execute() {
       } else {
         handleCommandRemoveFollower();
       }
-    }else if (command == SetTheLeader) {
+    } else if (command == SetTheLeader) {
       if (type != rest::RequestType::PUT) {
         goto BAD_CALL;
       }

--- a/arangod/RestHandler/RestReplicationHandler.h
+++ b/arangod/RestHandler/RestReplicationHandler.h
@@ -101,6 +101,7 @@ class RestReplicationHandler : public RestVocbaseBaseHandler {
   static std::string const ClusterInventory;
   static std::string const AddFollower;
   static std::string const RemoveFollower;
+  static std::string const SetTheLeader;
   static std::string const HoldReadLockCollection;
 
  protected:
@@ -217,6 +218,12 @@ class RestReplicationHandler : public RestVocbaseBaseHandler {
   //////////////////////////////////////////////////////////////////////////////
 
   void handleCommandRemoveFollower();
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// @brief update the leader of a shard
+  //////////////////////////////////////////////////////////////////////////////
+
+  void handleCommandSetTheLeader();
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief hold a read lock on a collection to stop writes temporarily


### PR DESCRIPTION
### Scope & Purpose

During a controlled leader change (i.e. when the leader has stopped writes) the new leader can make assumptions about the state of other followers. In that case the new leader can assume that the old followers are in sync and directly place them into Current. 

However, the new leader has to inform the other followers that it has taken over leadership.

### Testing & Verification

This PR adds tests that were used to verify all changes:
- [x]  Manual testing.

### Documentation

- [x] Added a *Changelog Entry* 
