### PR TITLE
Bug fix 3.4/re add overcommit memory 2 warning

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.4.8 (XXXX-XX-XX)
 -------------------
 
+* Re-added warning for kernel setting "overcommit_memory=2" if jemalloc is also enabled.
+
 * Significantly reduced "random" 1 second delays in some arangosearch DDL operations.
 
 * Decreased unnecessary wait times for agency callbacks in case they were

--- a/lib/ApplicationFeatures/EnvironmentFeature.cpp
+++ b/lib/ApplicationFeatures/EnvironmentFeature.cpp
@@ -81,6 +81,15 @@ void EnvironmentFeature::prepare() {
     uint64_t v = basics::StringUtils::uint64(value);
 
     if (v == 2) {
+#ifdef ARANGODB_HAVE_JEMALLOC
+      LOG_TOPIC(WARN, arangodb::Logger::MEMORY)
+          << "/proc/sys/vm/overcommit_memory is set to a value of 2. this "
+             "setting has been found to be problematic";
+      LOG_TOPIC(WARN, Logger::MEMORY)
+          << "execute 'sudo bash -c \"echo 0 > "
+          << "/proc/sys/vm/overcommit_memory\"'";
+#endif
+
       // from https://www.kernel.org/doc/Documentation/sysctl/vm.txt:
       //
       //   When this flag is 0, the kernel attempts to estimate the amount


### PR DESCRIPTION
### Scope & Purpose

It's time to re-add the check for `overcommit_memory=2`.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5565/