### PR TITLE
get rid of _resolvedNames and _nameLock

### DIFF
--- a/arangod/Utils/CollectionNameResolver.cpp
+++ b/arangod/Utils/CollectionNameResolver.cpp
@@ -75,7 +75,7 @@ TRI_voc_cid_t CollectionNameResolver::getCollectionIdLocal(std::string const& na
     return NumberUtils::atoi_zero<TRI_voc_cid_t>(name.data(), name.data() + name.size());
   }
 
-  auto collection = getCollectionStruct(name);
+  auto collection = _vocbase.lookupCollection(name);
 
   if (collection != nullptr) {
     return collection->id();
@@ -143,7 +143,7 @@ TRI_voc_cid_t CollectionNameResolver::getCollectionIdCluster(std::string const& 
 std::shared_ptr<LogicalCollection> CollectionNameResolver::getCollectionStructCluster(
     std::string const& name) const {
   if (!ServerState::isRunningInCluster(_serverRole)) {
-    return getCollectionStruct(name);
+    return _vocbase.lookupCollection(name);
   }
 
   // We have to look up the collection info:
@@ -163,31 +163,6 @@ TRI_voc_cid_t CollectionNameResolver::getCollectionId(std::string const& name) c
     return getCollectionIdLocal(name);
   }
   return getCollectionIdCluster(name);
-}
-
-//////////////////////////////////////////////////////////////////////////////
-/// @brief look up a collection struct for a collection name
-//////////////////////////////////////////////////////////////////////////////
-
-std::shared_ptr<arangodb::LogicalCollection> CollectionNameResolver::getCollectionStruct(
-    std::string const& name) const {
-  {
-    READ_LOCKER(locker, _nameLock);
-    auto it = _resolvedNames.find(name);
-
-    if (it != _resolvedNames.end()) {
-      return (*it).second;
-    }
-  }
-
-  auto collection = _vocbase.lookupCollection(name);
-
-  if (collection != nullptr) {
-    WRITE_LOCKER(locker, _nameLock);
-    _resolvedNames.emplace(name, collection);
-  }
-
-  return collection;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -221,6 +196,11 @@ std::string CollectionNameResolver::getCollectionName(TRI_voc_cid_t cid) const {
 //////////////////////////////////////////////////////////////////////////////
 
 std::string CollectionNameResolver::getCollectionNameCluster(TRI_voc_cid_t cid) const {
+  if (!ServerState::isClusterRole(_serverRole)) {
+    // This handles the case of a standalone server
+    return getCollectionName(cid);
+  }
+
   // First check the cache:
   {
     READ_LOCKER(locker, _idLock);
@@ -229,11 +209,6 @@ std::string CollectionNameResolver::getCollectionNameCluster(TRI_voc_cid_t cid) 
     if (it != _resolvedIds.end()) {
       return (*it).second;
     }
-  }
-
-  if (!ServerState::isClusterRole(_serverRole)) {
-    // This handles the case of a standalone server
-    return getCollectionName(cid);
   }
 
   std::string name;
@@ -270,7 +245,7 @@ std::string CollectionNameResolver::getCollectionNameCluster(TRI_voc_cid_t cid) 
 
   LOG_TOPIC("817e8", DEBUG, arangodb::Logger::FIXME)
       << "CollectionNameResolver: was not able to resolve id " << cid;
-  return "_unknown";
+  return ::UNKNOWN;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -286,29 +261,6 @@ std::string CollectionNameResolver::getCollectionName(std::string const& nameOrI
   return getCollectionName(
       NumberUtils::atoi_zero<TRI_voc_cid_t>(nameOrId.data(),
                                             nameOrId.data() + nameOrId.size()));
-}
-
-std::string CollectionNameResolver::lookupName(TRI_voc_cid_t cid) const {
-  auto collection = _vocbase.lookupCollection(cid);
-
-  // exactly as in the non-cluster case
-  if (!ServerState::isDBServer(_serverRole)) {
-    return collection ? collection->name() : ::UNKNOWN;
-  }
-
-  // DBserver case of a shard:
-  if (collection && collection->planId() != collection->id()) {
-    collection =
-        ClusterInfo::instance()->getCollectionNT(collection->vocbase().name(),
-                                                 std::to_string(collection->planId()));
-  }
-
-  // can be empty, if collection unknown
-  if (collection != nullptr && !collection->name().empty()) {
-    return collection->name();
-  }
-  
-  return ::UNKNOWN;
 }
 
 std::shared_ptr<LogicalDataSource> CollectionNameResolver::getDataSource(TRI_voc_cid_t id) const {
@@ -427,6 +379,30 @@ bool CollectionNameResolver::visitCollections(std::function<bool(LogicalCollecti
   }
 
   return false;  // no way to determine what to visit
+}
+
+/// PRIVATE ---------------
+std::string CollectionNameResolver::lookupName(TRI_voc_cid_t cid) const {
+  auto collection = _vocbase.lookupCollection(cid);
+
+  // exactly as in the non-cluster case
+  if (!ServerState::isDBServer(_serverRole)) {
+    return collection ? collection->name() : ::UNKNOWN;
+  }
+
+  // DBserver case of a shard:
+  if (collection && collection->planId() != collection->id()) {
+    collection =
+        ClusterInfo::instance()->getCollectionNT(collection->vocbase().name(),
+                                                 std::to_string(collection->planId()));
+  }
+
+  // can be empty, if collection unknown
+  if (collection != nullptr && !collection->name().empty()) {
+    return collection->name();
+  }
+  
+  return ::UNKNOWN;
 }
 
 }  // namespace arangodb

--- a/arangod/Utils/CollectionNameResolver.h
+++ b/arangod/Utils/CollectionNameResolver.h
@@ -157,38 +157,22 @@ class CollectionNameResolver {
                         TRI_voc_cid_t id) const;
 
  private:
-  //////////////////////////////////////////////////////////////////////////////
-  /// @brief look up a collection struct for a collection name
-  //////////////////////////////////////////////////////////////////////////////
-  std::shared_ptr<arangodb::LogicalCollection> getCollectionStruct(std::string const& name) const;
-
   mutable std::unordered_map<TRI_voc_cid_t, std::shared_ptr<LogicalDataSource>> _dataSourceById;  // cached data-source by id
   mutable std::unordered_map<std::string, std::shared_ptr<LogicalDataSource>> _dataSourceByName;  // cached data-source by name
 
   std::string lookupName(TRI_voc_cid_t cid) const;
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief vocbase base pointer
-  //////////////////////////////////////////////////////////////////////////////
   TRI_vocbase_t& _vocbase;
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief role of server in cluster
-  //////////////////////////////////////////////////////////////////////////////
-  ServerState::RoleEnum _serverRole;
+  ServerState::RoleEnum const _serverRole;
 
-  //////////////////////////////////////////////////////////////////////////////
-  /// @brief collection id => collection struct map
-  //////////////////////////////////////////////////////////////////////////////
-  mutable std::unordered_map<std::string, std::shared_ptr<arangodb::LogicalCollection>> _resolvedNames;
-
-  //////////////////////////////////////////////////////////////////////////////
-  /// @brief collection id => collection name map
-  //////////////////////////////////////////////////////////////////////////////
-  mutable std::unordered_map<TRI_voc_cid_t, std::string> _resolvedIds;
-
-  mutable basics::ReadWriteLock _nameLock;
+  /// @brief lock protecting _resolvedIds
   mutable basics::ReadWriteLock _idLock;
+
+  /// @brief collection id => collection name map
+  mutable std::unordered_map<TRI_voc_cid_t, std::string> _resolvedIds;
 };
 
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose

Simplify CollectionNameResolver a little bit

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *all*.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5582/