### PR TITLE
less copying in ClusterInfo::loadPlan()

### DIFF
--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -366,6 +366,38 @@ AgencyCommResult::AgencyCommResult(int code, std::string const& message,
       _statusCode(code),
       _connected(false),
       _sent(false) {}
+  
+AgencyCommResult::AgencyCommResult(AgencyCommResult&& other) noexcept
+    : _location(std::move(other._location)),
+      _message(std::move(other._message)),
+      _body(std::move(other._body)),
+      _values(std::move(other._values)),
+      _statusCode(other._statusCode),
+      _connected(other._connected),
+      _sent(other._sent),
+      _vpack(std::move(other._vpack)) {
+  other._statusCode = 0;
+  other._connected = false;
+  other._sent = false;
+}
+
+AgencyCommResult& AgencyCommResult::operator=(AgencyCommResult&& other) noexcept {
+  if (this != &other) {
+    _location = std::move(other._location);
+    _message = std::move(other._message);
+    _body = std::move(other._body);
+    _values = std::move(other._values);
+    _statusCode = other._statusCode;
+    _connected = other._connected;
+    _sent = other._sent;
+    _vpack = std::move(other._vpack);
+    
+    other._statusCode = 0;
+    other._connected = false;
+    other._sent = false;
+  }
+  return *this;
+}
 
 void AgencyCommResult::set(int code, std::string const& message) {
   _message = message;

--- a/arangod/Agency/AgencyComm.h
+++ b/arangod/Agency/AgencyComm.h
@@ -236,6 +236,12 @@ class AgencyCommResult {
   AgencyCommResult(int code, std::string const& message,
                    std::string const& transactionId = std::string());
 
+  AgencyCommResult(AgencyCommResult const& other) = delete;
+  AgencyCommResult& operator=(AgencyCommResult const& other) = delete;
+  
+  AgencyCommResult(AgencyCommResult&& other) noexcept;
+  AgencyCommResult& operator=(AgencyCommResult&& other) noexcept;
+
   ~AgencyCommResult() = default;
 
  public:

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -867,8 +867,8 @@ void ClusterInfo::loadPlan() {
               // inside the IF
               if (!isBuilding) {
                 // register with name as well as with id:
-                databaseCollections.emplace(std::make_pair(collectionName, newCollection));
-                databaseCollections.emplace(std::make_pair(collectionId, newCollection));
+                databaseCollections.emplace(collectionName, newCollection);
+                databaseCollections.emplace(collectionId, newCollection);
               }
 
               auto shardKeys =

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -522,8 +522,7 @@ void ClusterInfo::loadPlan() {
   if (result.successful()) {
     VPackSlice slice = result.slice()[0].get(
         std::vector<std::string>({AgencyCommManager::path(), "Plan"}));
-    auto planBuilder = std::make_shared<VPackBuilder>();
-    planBuilder->add(slice);
+    auto planBuilder = std::make_shared<VPackBuilder>(slice);
 
     VPackSlice planSlice = planBuilder->slice();
 
@@ -874,7 +873,7 @@ void ClusterInfo::loadPlan() {
 
               auto shardKeys =
                   std::make_shared<std::vector<std::string>>(newCollection->shardKeys());
-              newShardKeys.insert(make_pair(collectionId, shardKeys));
+              newShardKeys.emplace(collectionId, std::move(shardKeys));
 
               auto shardIDs = newCollection->shardIds();
               auto shards = std::make_shared<std::vector<std::string>>();
@@ -888,7 +887,7 @@ void ClusterInfo::loadPlan() {
                           return std::strtol(a.c_str() + 1, nullptr, 10) <
                                  std::strtol(b.c_str() + 1, nullptr, 10);
                         });
-              newShards.emplace(std::make_pair(collectionId, shards));
+              newShards.emplace(collectionId, std::move(shards));
 
             } catch (std::exception const& ex) {
               // The plan contains invalid collection information.
@@ -923,12 +922,12 @@ void ClusterInfo::loadPlan() {
             }
           }
 
-          newCollections.emplace(std::make_pair(databaseName, databaseCollections));
+          newCollections.emplace(databaseName, std::move(databaseCollections));
         }
       }
 
       WRITE_LOCKER(writeLocker, _planProt.lock);
-      _plan = planBuilder;
+      _plan = std::move(planBuilder);
       _planVersion = newPlanVersion;
       if (swapDatabases) {
         _plannedDatabases.swap(newDatabases);


### PR DESCRIPTION
### Scope & Purpose

Less copying of vpack & other data in ClusterInfo::loadPlan()

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *all cluster tests*.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5584/