### PR TITLE
Feature/serialize writes

### DIFF
--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -691,9 +691,11 @@ Result RocksDBCollection::truncate(transaction::Methods& trx, OperationOptions& 
   // normal transactional truncate
   RocksDBKeyBounds documentBounds = RocksDBKeyBounds::CollectionDocuments(_objectId);
   rocksdb::Comparator const* cmp = RocksDBColumnFamily::documents()->GetComparator();
+  // take a copy of the options here, so we can modify them
   rocksdb::ReadOptions ro = mthds->iteratorReadOptions();
   rocksdb::Slice const end = documentBounds.end();
   ro.iterate_upper_bound = &end;
+  ro.fill_cache = false;
 
   TRI_ASSERT(ro.snapshot);
 

--- a/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
@@ -280,7 +280,7 @@ int RocksDBTransactionCollection::doLock(AccessMode::Type type, int nestingLevel
     return TRI_ERROR_NO_ERROR;
   }
   
-  TRI_ASSERT(!AccessMode::isWrite(type) || !_transaction->mustUpgradeWritesToExclusiveAccess());
+  TRI_ASSERT(!AccessMode::isWrite(type) || !_transaction->upgradeWritesToExclusiveAccess());
 
   TRI_ASSERT(_collection != nullptr);
   TRI_ASSERT(!isLocked());
@@ -303,7 +303,7 @@ int RocksDBTransactionCollection::doLock(AccessMode::Type type, int nestingLevel
   } else {
     // write locking means we'll be acquiring the collection's RW lock in read
     // mode
-    TRI_ASSERT(!_transaction->mustUpgradeWritesToExclusiveAccess());
+    TRI_ASSERT(!_transaction->upgradeWritesToExclusiveAccess());
     res = physical->lockRead(timeout);
   }
 
@@ -336,7 +336,7 @@ int RocksDBTransactionCollection::doUnlock(AccessMode::Type type, int nestingLev
     return TRI_ERROR_NO_ERROR;
   }
     
-  TRI_ASSERT(!AccessMode::isWrite(type) || !_transaction->mustUpgradeWritesToExclusiveAccess());
+  TRI_ASSERT(!AccessMode::isWrite(type) || !_transaction->upgradeWritesToExclusiveAccess());
 
   TRI_ASSERT(_collection != nullptr);
   TRI_ASSERT(isLocked());
@@ -371,7 +371,7 @@ int RocksDBTransactionCollection::doUnlock(AccessMode::Type type, int nestingLev
   } else {
     // write locking means we'll be releasing the collection's RW lock in read
     // mode
-    TRI_ASSERT(!_transaction->mustUpgradeWritesToExclusiveAccess());
+    TRI_ASSERT(!_transaction->upgradeWritesToExclusiveAccess());
     physical->unlockRead();
   }
 

--- a/arangod/RocksDBEngine/RocksDBTransactionState.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.cpp
@@ -430,6 +430,10 @@ Result RocksDBTransactionState::abortTransaction(transaction::Methods* activeTrx
   unuseCollections(nestingLevel());
   return result;
 }
+  
+bool RocksDBTransactionState::mustUpgradeWritesToExclusiveAccess() const {
+  return static_cast<RocksDBEngine*>(EngineSelectorFeature::ENGINE)->serializeWrites();
+}
 
 void RocksDBTransactionState::prepareOperation(TRI_voc_cid_t cid, TRI_voc_rid_t rid,
                                                TRI_voc_document_operation_e operationType) {

--- a/arangod/RocksDBEngine/RocksDBTransactionState.h
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.h
@@ -92,6 +92,8 @@ class RocksDBTransactionState final : public TransactionState {
   bool hasFailedOperations() const override {
     return (_status == transaction::Status::ABORTED) && hasOperations();
   }
+  
+  bool mustUpgradeWritesToExclusiveAccess() const override;
 
   void prepareOperation(TRI_voc_cid_t cid, TRI_voc_rid_t rid,
                         TRI_voc_document_operation_e operationType);

--- a/arangod/RocksDBEngine/RocksDBTransactionState.h
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.h
@@ -93,7 +93,7 @@ class RocksDBTransactionState final : public TransactionState {
     return (_status == transaction::Status::ABORTED) && hasOperations();
   }
   
-  bool mustUpgradeWritesToExclusiveAccess() const override;
+  bool upgradeWritesToExclusiveAccess() const override;
 
   void prepareOperation(TRI_voc_cid_t cid, TRI_voc_rid_t rid,
                         TRI_voc_document_operation_e operationType);

--- a/arangod/StorageEngine/TransactionState.cpp
+++ b/arangod/StorageEngine/TransactionState.cpp
@@ -104,7 +104,13 @@ Result TransactionState::addCollection(TRI_voc_cid_t cid, std::string const& cna
                                        AccessMode::Type accessType,
                                        int nestingLevel, bool force) {
   LOG_TRX("ad6d0", TRACE, this, nestingLevel) << "adding collection " << cid;
-  
+
+  if (accessType == AccessMode::Type::WRITE && 
+      mustUpgradeWritesToExclusiveAccess()) {
+    // upgrade from WRITE to EXCLUSIVE, automatically
+    accessType = AccessMode::Type::EXCLUSIVE;
+  }
+
   Result res;
 
   // upgrade transaction type if required
@@ -117,7 +123,7 @@ Result TransactionState::addCollection(TRI_voc_cid_t cid, std::string const& cna
         !AccessMode::isWriteOrExclusive(_type)) {
       // if one collection is written to, the whole transaction becomes a
       // write-transaction
-      _type = AccessMode::Type::WRITE;
+      _type = accessType;
     }
   }
 

--- a/arangod/StorageEngine/TransactionState.h
+++ b/arangod/StorageEngine/TransactionState.h
@@ -184,6 +184,11 @@ class TransactionState {
 
   virtual bool hasFailedOperations() const = 0;
 
+  /// @brief whether or not write operations shall be exclusive by default
+  /// (this serializes writes to the underlying collection, which avoids conflicts
+  /// but severly impairs write performance)
+  virtual bool mustUpgradeWritesToExclusiveAccess() const { return false; }
+
   TransactionCollection* findCollection(TRI_voc_cid_t cid) const;
 
   /// @brief make a exclusive transaction, only valid before begin

--- a/arangod/StorageEngine/TransactionState.h
+++ b/arangod/StorageEngine/TransactionState.h
@@ -36,6 +36,7 @@
 #include "VocBase/voc-types.h"
 
 #include <map>
+#include <memory>
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 
@@ -187,7 +188,7 @@ class TransactionState {
   /// @brief whether or not write operations shall be exclusive by default
   /// (this serializes writes to the underlying collection, which avoids conflicts
   /// but severly impairs write performance)
-  virtual bool mustUpgradeWritesToExclusiveAccess() const { return false; }
+  virtual bool upgradeWritesToExclusiveAccess() const { return false; }
 
   TransactionCollection* findCollection(TRI_voc_cid_t cid) const;
 
@@ -260,8 +261,8 @@ class TransactionState {
   /// @brief current status
   transaction::Status _status;
 
-  SmallVector<TransactionCollection*>::allocator_type::arena_type _arena;  // memory for collections
-  SmallVector<TransactionCollection*> _collections;  // list of participating collections
+  SmallVector<std::unique_ptr<TransactionCollection>>::allocator_type::arena_type _arena;  // memory for collections
+  SmallVector<std::unique_ptr<TransactionCollection>> _collections;  // list of participating collections
 
   ServerState::RoleEnum const _serverRole;  /// role of the server
 


### PR DESCRIPTION
### Scope & Purpose

Serialize writes to collections, by upgrade write locks to exclusive locks.
This allows applications to rely on the semantics provided by MMFiles (writes block other writes) even with the RocksDB storage engine.
Whether or not writes are serialized is configurable by a startup parameter `--rocksdb.serialize-writes`. The option is turned off by default.
It is only supported in single server and active failover mode.

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

We still need to add separate tests for this new option.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5659/