### PR TITLE
fix return codes for concurrent writes to same documents

### DIFF
--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -684,8 +684,11 @@ Result RocksDBVPackIndex::insert(transaction::Methods& trx, RocksDBMethods* mthd
     rocksdb::PinnableSlice existing(leased.get());
     for (RocksDBKey& key : elements) {
       s = mthds->GetForUpdate(_cf, key.string(), &existing);
-      if (s.ok() || s.IsBusy()) {  // detected conflicting index entry
+      if (s.ok()) {  // detected conflicting index entry
         res.reset(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED);
+        break;
+      } else if (!s.IsNotFound()) {
+        res.reset(rocksutils::convertStatus(s));
         break;
       }
       s = mthds->Put(_cf, key, value.string(), /*assume_tracked*/true);


### PR DESCRIPTION
### Scope & Purpose

Fixed error message "Invalid argument: assume_tracked is set but it is not tracked yet" when trying to write to the same keys in concurrent RocksDB transactions. This error will now be reported as a "Lock timeout" error, with error code 1200.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [ ] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *document tests*.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5661/