### PR TITLE
Bugfix 3.4:  Clean up rocksdb getStatistics()

### DIFF
--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2122,7 +2122,7 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
   };
 
   // get string property from each column family and return sum;
-  auto addStrAllCf = [&](std::string const& s) {
+  auto addIntAllCf = [&](std::string const& s) {
     int64_t sum = 0;
     for (auto cfh : RocksDBColumnFamily::_allHandles) {
       std::string v;
@@ -2165,43 +2165,43 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
 
   builder.openObject();
   for (int i = 0; i < _options.num_levels; ++i) {
-    addStrAllCf(rocksdb::DB::Properties::kNumFilesAtLevelPrefix + std::to_string(i));
+    addIntAllCf(rocksdb::DB::Properties::kNumFilesAtLevelPrefix + std::to_string(i));
     // ratio needs new calculation with all cf, not a simple add operation
-    addStrAllCf(rocksdb::DB::Properties::kCompressionRatioAtLevelPrefix + std::to_string(i));
+    addIntAllCf(rocksdb::DB::Properties::kCompressionRatioAtLevelPrefix + std::to_string(i));
   }
   // caution:  you must read rocksdb/db/interal_stats.cc carefully to
   //           determine if a property is for whole database or one column family
-  addStrAllCf(rocksdb::DB::Properties::kNumImmutableMemTable);
-  addStrAllCf(rocksdb::DB::Properties::kNumImmutableMemTableFlushed);
-  addStrAllCf(rocksdb::DB::Properties::kMemTableFlushPending);
-  addStrAllCf(rocksdb::DB::Properties::kCompactionPending);
+  addIntAllCf(rocksdb::DB::Properties::kNumImmutableMemTable);
+  addIntAllCf(rocksdb::DB::Properties::kNumImmutableMemTableFlushed);
+  addIntAllCf(rocksdb::DB::Properties::kMemTableFlushPending);
+  addIntAllCf(rocksdb::DB::Properties::kCompactionPending);
   addInt(rocksdb::DB::Properties::kBackgroundErrors);
-  addStrAllCf(rocksdb::DB::Properties::kCurSizeActiveMemTable);
-  addStrAllCf(rocksdb::DB::Properties::kCurSizeAllMemTables);
-  addStrAllCf(rocksdb::DB::Properties::kSizeAllMemTables);
-  addStrAllCf(rocksdb::DB::Properties::kNumEntriesActiveMemTable);
-  addStrAllCf(rocksdb::DB::Properties::kNumEntriesImmMemTables);
-  addStrAllCf(rocksdb::DB::Properties::kNumDeletesActiveMemTable);
-  addStrAllCf(rocksdb::DB::Properties::kNumDeletesImmMemTables);
-  addStrAllCf(rocksdb::DB::Properties::kEstimateNumKeys);
-  addStrAllCf(rocksdb::DB::Properties::kEstimateTableReadersMem);
+  addIntAllCf(rocksdb::DB::Properties::kCurSizeActiveMemTable);
+  addIntAllCf(rocksdb::DB::Properties::kCurSizeAllMemTables);
+  addIntAllCf(rocksdb::DB::Properties::kSizeAllMemTables);
+  addIntAllCf(rocksdb::DB::Properties::kNumEntriesActiveMemTable);
+  addIntAllCf(rocksdb::DB::Properties::kNumEntriesImmMemTables);
+  addIntAllCf(rocksdb::DB::Properties::kNumDeletesActiveMemTable);
+  addIntAllCf(rocksdb::DB::Properties::kNumDeletesImmMemTables);
+  addIntAllCf(rocksdb::DB::Properties::kEstimateNumKeys);
+  addIntAllCf(rocksdb::DB::Properties::kEstimateTableReadersMem);
   addInt(rocksdb::DB::Properties::kNumSnapshots);
   addInt(rocksdb::DB::Properties::kOldestSnapshotTime);
-  addStrAllCf(rocksdb::DB::Properties::kNumLiveVersions);
+  addIntAllCf(rocksdb::DB::Properties::kNumLiveVersions);
   addInt(rocksdb::DB::Properties::kMinLogNumberToKeep);
-  addStrAllCf(rocksdb::DB::Properties::kEstimateLiveDataSize);
-  addStrAllCf(rocksdb::DB::Properties::kLiveSstFilesSize);
+  addIntAllCf(rocksdb::DB::Properties::kEstimateLiveDataSize);
+  addIntAllCf(rocksdb::DB::Properties::kLiveSstFilesSize);
   addStr(rocksdb::DB::Properties::kDBStats);
   addStr(rocksdb::DB::Properties::kSSTables);
   addInt(rocksdb::DB::Properties::kNumRunningCompactions);
   addInt(rocksdb::DB::Properties::kNumRunningFlushes);
   addInt(rocksdb::DB::Properties::kIsFileDeletionsEnabled);
-  addStrAllCf(rocksdb::DB::Properties::kEstimatePendingCompactionBytes);
+  addIntAllCf(rocksdb::DB::Properties::kEstimatePendingCompactionBytes);
   addInt(rocksdb::DB::Properties::kBaseLevel);
   addInt(rocksdb::DB::Properties::kBlockCacheCapacity);
   addInt(rocksdb::DB::Properties::kBlockCacheUsage);
   addInt(rocksdb::DB::Properties::kBlockCachePinnedUsage);
-  addStrAllCf(rocksdb::DB::Properties::kTotalSstFilesSize);
+  addIntAllCf(rocksdb::DB::Properties::kTotalSstFilesSize);
   addInt(rocksdb::DB::Properties::kActualDelayedWriteRate);
   addInt(rocksdb::DB::Properties::kIsWriteStopped);
 

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2228,6 +2228,10 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
   addCf("fulltext", RocksDBColumnFamily::fulltext());
   builder.close();
 
+  if (_listener) {
+    builder.add("rocksdbengine.throttle.bps", VPackValue(_listener->GetThrottle()));
+  } // if
+
   builder.close();
 }
 

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2169,11 +2169,13 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
     // ratio needs new calculation with all cf, not a simple add operation
     addStrAllCf(rocksdb::DB::Properties::kCompressionRatioAtLevelPrefix + std::to_string(i));
   }
+  // caution:  you must read rocksdb/db/interal_stats.cc carefully to
+  //           determine if a property is for whole database or one column family
   addStrAllCf(rocksdb::DB::Properties::kNumImmutableMemTable);
   addStrAllCf(rocksdb::DB::Properties::kNumImmutableMemTableFlushed);
   addStrAllCf(rocksdb::DB::Properties::kMemTableFlushPending);
   addStrAllCf(rocksdb::DB::Properties::kCompactionPending);
-  addInt(rocksdb::DB::Properties::kBackgroundErrors); //db
+  addInt(rocksdb::DB::Properties::kBackgroundErrors);
   addStrAllCf(rocksdb::DB::Properties::kCurSizeActiveMemTable);
   addStrAllCf(rocksdb::DB::Properties::kCurSizeAllMemTables);
   addStrAllCf(rocksdb::DB::Properties::kSizeAllMemTables);
@@ -2183,25 +2185,25 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
   addStrAllCf(rocksdb::DB::Properties::kNumDeletesImmMemTables);
   addStrAllCf(rocksdb::DB::Properties::kEstimateNumKeys);
   addStrAllCf(rocksdb::DB::Properties::kEstimateTableReadersMem);
-  addInt(rocksdb::DB::Properties::kNumSnapshots);//db
-  addInt(rocksdb::DB::Properties::kOldestSnapshotTime);//db
+  addInt(rocksdb::DB::Properties::kNumSnapshots);
+  addInt(rocksdb::DB::Properties::kOldestSnapshotTime);
   addStrAllCf(rocksdb::DB::Properties::kNumLiveVersions);
-  addInt(rocksdb::DB::Properties::kMinLogNumberToKeep);//db
+  addInt(rocksdb::DB::Properties::kMinLogNumberToKeep);
   addStrAllCf(rocksdb::DB::Properties::kEstimateLiveDataSize);
   addStrAllCf(rocksdb::DB::Properties::kLiveSstFilesSize);
   addStr(rocksdb::DB::Properties::kDBStats);
   addStr(rocksdb::DB::Properties::kSSTables);
-  addInt(rocksdb::DB::Properties::kNumRunningCompactions);//db
-  addInt(rocksdb::DB::Properties::kNumRunningFlushes); //db
-  addInt(rocksdb::DB::Properties::kIsFileDeletionsEnabled);//db
+  addInt(rocksdb::DB::Properties::kNumRunningCompactions);
+  addInt(rocksdb::DB::Properties::kNumRunningFlushes);
+  addInt(rocksdb::DB::Properties::kIsFileDeletionsEnabled);
   addStrAllCf(rocksdb::DB::Properties::kEstimatePendingCompactionBytes);
-  addInt(rocksdb::DB::Properties::kBaseLevel);//cf
-  addInt(rocksdb::DB::Properties::kBlockCacheCapacity);//db
-  addInt(rocksdb::DB::Properties::kBlockCacheUsage);//db
-  addInt(rocksdb::DB::Properties::kBlockCachePinnedUsage);//db
+  addInt(rocksdb::DB::Properties::kBaseLevel);
+  addInt(rocksdb::DB::Properties::kBlockCacheCapacity);
+  addInt(rocksdb::DB::Properties::kBlockCacheUsage);
+  addInt(rocksdb::DB::Properties::kBlockCachePinnedUsage);
   addStrAllCf(rocksdb::DB::Properties::kTotalSstFilesSize);
-  addInt(rocksdb::DB::Properties::kActualDelayedWriteRate);//db
-  addInt(rocksdb::DB::Properties::kIsWriteStopped);//db
+  addInt(rocksdb::DB::Properties::kActualDelayedWriteRate);
+  addInt(rocksdb::DB::Properties::kIsWriteStopped);
 
   if (_options.statistics) {
     for (auto const& stat : rocksdb::TickersNameMap) {
@@ -2218,6 +2220,7 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
   builder.add("cache.hit-rate-recent", VPackValue(rates.second >= 0.0 ? rates.second : 0.0));
 
   // print column family statistics
+  //  warning: output format limits numbers to 3 digits of precision or less.
   builder.add("columnFamilies", VPackValue(VPackValueType::Object));
   addCf("definitions", RocksDBColumnFamily::definitions());
   addCf("documents", RocksDBColumnFamily::documents());

--- a/arangod/RocksDBEngine/RocksDBThrottle.h
+++ b/arangod/RocksDBEngine/RocksDBThrottle.h
@@ -85,6 +85,8 @@ class RocksDBThrottle : public rocksdb::EventListener {
 
   void StopThread();
 
+  uint64_t GetThrottle() const {return _throttleBps;};
+
  protected:
   void Startup(rocksdb::DB* db);
 
@@ -137,7 +139,7 @@ class RocksDBThrottle : public rocksdb::EventListener {
   ThrottleData_t _throttleData[THROTTLE_INTERVALS];
   size_t _replaceIdx;
 
-  uint64_t _throttleBps;
+  std::atomic<uint64_t> _throttleBps;
   bool _firstThrottle;
 
   std::unique_ptr<WriteControllerToken> _delayToken;


### PR DESCRIPTION
The statistics from rocksdb were unknowingly focused upon "default" column family and therefore excluding values from the seven column families used by ArangoDB.  This PR updates several values such that they report the sum across the seven column families.  The corrected statistics are essential to performance measurement.

The current value of the RocksDBThrottle is a new statistic added in this PR.

Upon merge, the same code will go to devel, 3.5.x, and maybe 3.3 branches.  