### PR TITLE
Bugfix:  Correct rocksdb statistics to report column family sums.

### DIFF
--- a/arangod/Aql/ShortStringStorage.h
+++ b/arangod/Aql/ShortStringStorage.h
@@ -24,6 +24,7 @@
 #ifndef ARANGOD_AQL_SHORT_STRING_STORAGE_H
 #define ARANGOD_AQL_SHORT_STRING_STORAGE_H 1
 
+#include <cstddef>
 #include <vector>
 
 #include "Basics/Common.h"

--- a/arangod/RocksDBEngine/RocksDBThrottle.h
+++ b/arangod/RocksDBEngine/RocksDBThrottle.h
@@ -87,6 +87,8 @@ class RocksDBThrottle : public rocksdb::EventListener {
 
   void StopThread();
 
+  uint64_t GetThrottle() const {return _throttleBps;};
+
  protected:
   void Startup(rocksdb::DB* db);
 
@@ -139,7 +141,7 @@ class RocksDBThrottle : public rocksdb::EventListener {
   ThrottleData_t _throttleData[THROTTLE_INTERVALS];
   size_t _replaceIdx;
 
-  uint64_t _throttleBps;
+  std::atomic<uint64_t> _throttleBps;
   bool _firstThrottle;
 
   std::unique_ptr<WriteControllerToken> _delayToken;


### PR DESCRIPTION
The statistics from rocksdb were unknowingly focused upon "default" column family and therefore excluding values from the seven column families used by ArangoDB. This PR updates several values such that they report the sum across the seven column families. The corrected statistics are essential to performance measurement.

The current value of the RocksDBThrottle is a new statistic added in this PR.

From 3.4 branch.