### PR TITLE
Bugfix 3.5.1: Correct calculation of rocksdb statistics to be sum of column families

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.5.1 (XXXX-XX-XX)
 -------------------
 
+* Correct rocksdb statistics to report sums from column families instead of
+  single value from default column family
+
 * Fixed error message "Invalid argument: assume_tracked is set but it is not tracked yet" when
   trying to write to the same keys in concurrent RocksDB transactions. This error will now be
   reported as a "Lock timeout" error, with error code 1200.

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2117,6 +2117,23 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
     }
   };
 
+  // get string property from each column family and return sum;
+  auto addIntAllCf = [&](std::string const& s) {
+    int64_t sum = 0;
+    for (auto cfh : RocksDBColumnFamily::_allHandles) {
+      std::string v;
+      if (_db->GetProperty(cfh, s, &v)) {
+        int64_t temp=basics::StringUtils::int64(v);
+
+        // -1 returned for somethings that are valid property but no value
+        if (0 < temp) {
+          sum += temp;
+        } // if
+      } // if
+    } // for
+    builder.add(s, VPackValue(sum));
+  };
+
   // add column family properties
   auto addCf = [&](std::string const& name, rocksdb::ColumnFamilyHandle* c) {
     std::string v;
@@ -2144,40 +2161,43 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
 
   builder.openObject();
   for (int i = 0; i < _options.num_levels; ++i) {
-    addStr(rocksdb::DB::Properties::kNumFilesAtLevelPrefix + std::to_string(i));
-    addStr(rocksdb::DB::Properties::kCompressionRatioAtLevelPrefix + std::to_string(i));
+    addIntAllCf(rocksdb::DB::Properties::kNumFilesAtLevelPrefix + std::to_string(i));
+    // ratio needs new calculation with all cf, not a simple add operation
+    addIntAllCf(rocksdb::DB::Properties::kCompressionRatioAtLevelPrefix + std::to_string(i));
   }
-  addInt(rocksdb::DB::Properties::kNumImmutableMemTable);
-  addInt(rocksdb::DB::Properties::kNumImmutableMemTableFlushed);
-  addInt(rocksdb::DB::Properties::kMemTableFlushPending);
-  addInt(rocksdb::DB::Properties::kCompactionPending);
+  // caution:  you must read rocksdb/db/interal_stats.cc carefully to
+  //           determine if a property is for whole database or one column family
+  addIntAllCf(rocksdb::DB::Properties::kNumImmutableMemTable);
+  addIntAllCf(rocksdb::DB::Properties::kNumImmutableMemTableFlushed);
+  addIntAllCf(rocksdb::DB::Properties::kMemTableFlushPending);
+  addIntAllCf(rocksdb::DB::Properties::kCompactionPending);
   addInt(rocksdb::DB::Properties::kBackgroundErrors);
-  addInt(rocksdb::DB::Properties::kCurSizeActiveMemTable);
-  addInt(rocksdb::DB::Properties::kCurSizeAllMemTables);
-  addInt(rocksdb::DB::Properties::kSizeAllMemTables);
-  addInt(rocksdb::DB::Properties::kNumEntriesActiveMemTable);
-  addInt(rocksdb::DB::Properties::kNumEntriesImmMemTables);
-  addInt(rocksdb::DB::Properties::kNumDeletesActiveMemTable);
-  addInt(rocksdb::DB::Properties::kNumDeletesImmMemTables);
-  addInt(rocksdb::DB::Properties::kEstimateNumKeys);
-  addInt(rocksdb::DB::Properties::kEstimateTableReadersMem);
+  addIntAllCf(rocksdb::DB::Properties::kCurSizeActiveMemTable);
+  addIntAllCf(rocksdb::DB::Properties::kCurSizeAllMemTables);
+  addIntAllCf(rocksdb::DB::Properties::kSizeAllMemTables);
+  addIntAllCf(rocksdb::DB::Properties::kNumEntriesActiveMemTable);
+  addIntAllCf(rocksdb::DB::Properties::kNumEntriesImmMemTables);
+  addIntAllCf(rocksdb::DB::Properties::kNumDeletesActiveMemTable);
+  addIntAllCf(rocksdb::DB::Properties::kNumDeletesImmMemTables);
+  addIntAllCf(rocksdb::DB::Properties::kEstimateNumKeys);
+  addIntAllCf(rocksdb::DB::Properties::kEstimateTableReadersMem);
   addInt(rocksdb::DB::Properties::kNumSnapshots);
   addInt(rocksdb::DB::Properties::kOldestSnapshotTime);
-  addInt(rocksdb::DB::Properties::kNumLiveVersions);
+  addIntAllCf(rocksdb::DB::Properties::kNumLiveVersions);
   addInt(rocksdb::DB::Properties::kMinLogNumberToKeep);
-  addInt(rocksdb::DB::Properties::kEstimateLiveDataSize);
-  addInt(rocksdb::DB::Properties::kLiveSstFilesSize);
+  addIntAllCf(rocksdb::DB::Properties::kEstimateLiveDataSize);
+  addIntAllCf(rocksdb::DB::Properties::kLiveSstFilesSize);
   addStr(rocksdb::DB::Properties::kDBStats);
   addStr(rocksdb::DB::Properties::kSSTables);
   addInt(rocksdb::DB::Properties::kNumRunningCompactions);
   addInt(rocksdb::DB::Properties::kNumRunningFlushes);
   addInt(rocksdb::DB::Properties::kIsFileDeletionsEnabled);
-  addInt(rocksdb::DB::Properties::kEstimatePendingCompactionBytes);
+  addIntAllCf(rocksdb::DB::Properties::kEstimatePendingCompactionBytes);
   addInt(rocksdb::DB::Properties::kBaseLevel);
   addInt(rocksdb::DB::Properties::kBlockCacheCapacity);
   addInt(rocksdb::DB::Properties::kBlockCacheUsage);
   addInt(rocksdb::DB::Properties::kBlockCachePinnedUsage);
-  addInt(rocksdb::DB::Properties::kTotalSstFilesSize);
+  addIntAllCf(rocksdb::DB::Properties::kTotalSstFilesSize);
   addInt(rocksdb::DB::Properties::kActualDelayedWriteRate);
   addInt(rocksdb::DB::Properties::kIsWriteStopped);
 
@@ -2208,6 +2228,7 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
   }
 
   // print column family statistics
+  //  warning: output format limits numbers to 3 digits of precision or less.
   builder.add("columnFamilies", VPackValue(VPackValueType::Object));
   addCf("definitions", RocksDBColumnFamily::definitions());
   addCf("documents", RocksDBColumnFamily::documents());
@@ -2217,6 +2238,10 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
   addCf("geo", RocksDBColumnFamily::geo());
   addCf("fulltext", RocksDBColumnFamily::fulltext());
   builder.close();
+
+  if (_listener) {
+    builder.add("rocksdbengine.throttle.bps", VPackValue(_listener->GetThrottle()));
+  } // if
 
   builder.close();
 }

--- a/arangod/RocksDBEngine/RocksDBThrottle.h
+++ b/arangod/RocksDBEngine/RocksDBThrottle.h
@@ -87,6 +87,8 @@ class RocksDBThrottle : public rocksdb::EventListener {
 
   void StopThread();
 
+  uint64_t GetThrottle() const {return _throttleBps;};
+
  protected:
   void Startup(rocksdb::DB* db);
 
@@ -139,7 +141,7 @@ class RocksDBThrottle : public rocksdb::EventListener {
   ThrottleData_t _throttleData[THROTTLE_INTERVALS];
   size_t _replaceIdx;
 
-  uint64_t _throttleBps;
+  std::atomic<uint64_t> _throttleBps;
   bool _firstThrottle;
 
   std::unique_ptr<WriteControllerToken> _delayToken;


### PR DESCRIPTION
The statistics from rocksdb were unknowingly focused upon "default" column family and therefore excluding values from the seven column families used by ArangoDB. This PR updates several values such that they report the sum across the seven column families. The corrected statistics are essential to performance measurement.

The current value of the RocksDBThrottle is a new statistic added in this PR.

From 3.4 branch.