### PR TITLE
fix a leak in hotbackup tests

### DIFF
--- a/tests/RocksDBEngine/ShaEventListener.cpp
+++ b/tests/RocksDBEngine/ShaEventListener.cpp
@@ -69,46 +69,40 @@ struct CFilesSetup {
     TRI_RemoveDirectory(_directory.c_str());
   }
 
-  StringBuffer* writeFile (const char* blob) {
-    StringBuffer* filename = new StringBuffer(true);
-    filename->appendText(_directory);
-    filename->appendChar(TRI_DIR_SEPARATOR_CHAR);
-    filename->appendText("tmp-");
-    filename->appendInteger(++counter);
-    filename->appendInteger(arangodb::RandomGenerator::interval(UINT32_MAX));
+  void writeFile(char const* blob) {
+    StringBuffer filename(true);
+    filename.appendText(_directory);
+    filename.appendChar(TRI_DIR_SEPARATOR_CHAR);
+    filename.appendText("tmp-");
+    filename.appendInteger(++counter);
+    filename.appendInteger(arangodb::RandomGenerator::interval(UINT32_MAX));
 
-    FILE* fd = fopen(filename->c_str(), "wb");
+    FILE* fd = fopen(filename.c_str(), "wb");
 
     if (fd) {
       size_t numWritten = fwrite(blob, strlen(blob), 1, fd);
       (void) numWritten;
       fclose(fd);
-    }
-    else {
+    } else {
       EXPECT_TRUE(false);
     }
-
-    return filename;
   }
 
-  StringBuffer * writeFile (const char * name, const char * blob) {
-    StringBuffer* filename = new StringBuffer(true);
-    filename->appendText(_directory);
-    filename->appendChar(TRI_DIR_SEPARATOR_CHAR);
-    filename->appendText(name);
+  void writeFile(char const* name, char const* blob) {
+    StringBuffer filename(true);
+    filename.appendText(_directory);
+    filename.appendChar(TRI_DIR_SEPARATOR_CHAR);
+    filename.appendText(name);
 
-    FILE* fd = fopen(filename->c_str(), "wb");
+    FILE* fd = fopen(filename.c_str(), "wb");
 
     if (fd) {
       size_t numWritten = fwrite(blob, strlen(blob), 1, fd);
       (void) numWritten;
       fclose(fd);
-    }
-    else {
+    } else {
       EXPECT_TRUE(false);
     }
-
-    return filename;
   }
 
   StringBuffer _directory;


### PR DESCRIPTION
### Scope & Purpose

Fix memory leaks in hotbackup tests

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *hotbackup gtest*.

Additionally:

- [x] I ensured this code runs with ASan / TSan or other static verification tools

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5698/