### PR TITLE
use _exit instead of exit to prevent memory leaks

### DIFF
--- a/UnitTests/unittest.js
+++ b/UnitTests/unittest.js
@@ -335,6 +335,5 @@ let result = main(ARGUMENTS);
 if (!result) {
   // force an error in the console
   process.exit(1);
-  // throw 'peng!';
 }
 

--- a/arangosh/Shell/ShellFeature.cpp
+++ b/arangosh/Shell/ShellFeature.cpp
@@ -39,8 +39,7 @@ ShellFeature::ShellFeature(application_features::ApplicationServer& server, int*
     : ApplicationFeature(server, "Shell"),
       _jslint(),
       _result(result),
-      _runMode(RunMode::INTERACTIVE),
-      _unitTestFilter("") {
+      _runMode(RunMode::INTERACTIVE) {
   requiresElevatedPrivileges(false);
   setOptional(false);
   startsAfter("V8ShellPhase");
@@ -130,7 +129,7 @@ void ShellFeature::validateOptions(std::shared_ptr<options::ProgramOptions> opti
 }
 
 void ShellFeature::start() {
-  *_result = EXIT_FAILURE;
+  *_result = EXIT_SUCCESS;
 
   V8ShellFeature* shell =
       application_features::ApplicationServer::getFeature<V8ShellFeature>(
@@ -172,7 +171,9 @@ void ShellFeature::start() {
     ok = false;
   }
 
-  *_result = ok ? EXIT_SUCCESS : EXIT_FAILURE;
+  if (*_result == EXIT_SUCCESS && !ok) {
+    *_result = EXIT_FAILURE;
+  }
 }
 
 }  // namespace arangodb

--- a/arangosh/Shell/ShellFeature.h
+++ b/arangosh/Shell/ShellFeature.h
@@ -34,6 +34,8 @@ class ShellFeature final : public application_features::ApplicationFeature {
   void collectOptions(std::shared_ptr<options::ProgramOptions>) override;
   void validateOptions(std::shared_ptr<options::ProgramOptions> options) override;
   void start() override;
+  
+  void setExitCode(int code) { *_result = code; }
 
  private:
   std::vector<std::string> _jslint;

--- a/arangosh/Shell/V8ShellFeature.cpp
+++ b/arangosh/Shell/V8ShellFeature.cpp
@@ -968,7 +968,7 @@ static void JS_Exit(v8::FunctionCallbackInfo<v8::Value> const& args) {
     code = TRI_ObjectToInt64(isolate, args[0]);
   }
 
-  exit((int)code);
+  _exit((int)code);
 
   TRI_V8_TRY_CATCH_END
 }

--- a/arangosh/Shell/V8ShellFeature.cpp
+++ b/arangosh/Shell/V8ShellFeature.cpp
@@ -968,7 +968,13 @@ static void JS_Exit(v8::FunctionCallbackInfo<v8::Value> const& args) {
     code = TRI_ObjectToInt64(isolate, args[0]);
   }
 
-  _exit((int)code);
+  ShellFeature* shell =
+      application_features::ApplicationServer::getFeature<ShellFeature>(
+          "Shell");
+
+  shell->setExitCode(static_cast<int>(code));
+  
+  isolate->TerminateExecution();
 
   TRI_V8_TRY_CATCH_END
 }


### PR DESCRIPTION
### Scope & Purpose

When the arangosh is exited using the exit() JavaScript functions,
there is no memory cleanup, and ASan reports several leaks.
Instead of calling man 3 exit() use man 2 _exit(), which performs
some cleanup before killing the process.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as `scripts/unittest iihihhhf`.

Additionally:

- [x] I ensured this code runs with ASan / TSan or other static verification tools

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5699/