### PR TITLE
dont fill cache on truncate

### DIFF
--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -612,9 +612,12 @@ Result RocksDBCollection::truncate(transaction::Methods& trx, OperationOptions& 
   // normal transactional truncate
   RocksDBKeyBounds documentBounds = RocksDBKeyBounds::CollectionDocuments(_objectId);
   rocksdb::Comparator const* cmp = RocksDBColumnFamily::documents()->GetComparator();
+  // intentionally copy the read options so we can modify them
   rocksdb::ReadOptions ro = mthds->iteratorReadOptions();
   rocksdb::Slice const end = documentBounds.end();
   ro.iterate_upper_bound = &end;
+  // we are going to blow away all data anyway. no need to blow up the cache
+  ro.fill_cache = false;
   
   TRI_ASSERT(ro.snapshot);
   


### PR DESCRIPTION
### Scope & Purpose

Don't fill RocksDB caches on per-document truncate operation

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5706/