### PR TITLE
[3.4] Move Shard Bug 4567124

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.4.8 (XXXX-XX-XX)
 -------------------
 
+* Fixed bug in MoveShard::abort which causes a duplicate entry in the follower list.
+
 * Refactor maintenance to use a TakeoverShardLeadership job. This fixes a bug
   that a shard follower could have set the wrong leader for the shard locally.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,8 @@
 v3.4.8 (XXXX-XX-XX)
 -------------------
 
-* Fixed bug in MoveShard::abort which causes a duplicate entry in the follower list. (Internal Bug #4378)
+* Fixed internal issue #4378: fix bug in MoveShard::abort which causes a
+  duplicate entry in the follower list.
 
 * Refactor maintenance to use a TakeoverShardLeadership job. This fixes a bug
   that a shard follower could have set the wrong leader for the shard locally.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.4.8 (XXXX-XX-XX)
 -------------------
 
-* Fixed bug in MoveShard::abort which causes a duplicate entry in the follower list.
+* Fixed bug in MoveShard::abort which causes a duplicate entry in the follower list. (Internal Bug #4378)
 
 * Refactor maintenance to use a TakeoverShardLeadership job. This fixes a bug
   that a shard follower could have set the wrong leader for the shard locally.

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -853,6 +853,7 @@ arangodb::Result MoveShard::abort(std::string const& reason) {
                             }
                             trx.add(srv);
                           }
+                          trx.add(VPackValue(_to));
                         }
                       });
       } else {

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -840,20 +840,21 @@ arangodb::Result MoveShard::abort(std::string const& reason) {
       if (_isLeader) {
         // All changes to Plan for all shards:
         doForAllShards(_snapshot, _database, shardsLikeMe,
-                       [this, &trx](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
-                         // Restore leader to be _from:
-                         trx.add(VPackValue(planPath));
-                         {
-                           VPackArrayBuilder guard(&trx);
-                           trx.add(VPackValue(_from));
-                           VPackArrayIterator iter(plan);
-                           ++iter;  // skip the first
-                           while (iter.valid()) {
-                             trx.add(iter.value());
-                             ++iter;
-                           }
-                         }
-                       });
+                      [this, &trx](Slice plan, Slice current, std::string& planPath, std::string& curPath) {
+                        // Restore leader to be _from:
+                        trx.add(VPackValue(planPath));
+                        {
+                          VPackArrayBuilder guard(&trx);
+                          trx.add(VPackValue(_from));
+                          for (auto const& srv : VPackArrayIterator(plan)) {
+                            // from could be in plan as <from> or <_from>. Exclude to server always.
+                            if (srv.isEqualString(_from) || srv.isEqualString("_" + _from) || srv.isEqualString(_to)) {
+                              continue ;
+                            }
+                            trx.add(srv);
+                          }
+                        }
+                      });
       } else {
         // All changes to Plan for all shards:
         doForAllShards(_snapshot, _database, shardsLikeMe,
@@ -863,7 +864,7 @@ arangodb::Result MoveShard::abort(std::string const& reason) {
                          {
                            VPackArrayBuilder guard(&trx);
                            for (auto const& srv : VPackArrayIterator(plan)) {
-                             if (srv.copyString() != _to) {
+                             if (false == srv.isEqualString(_to)) {
                                trx.add(srv);
                              }
                            }

--- a/tests/Agency/MoveShardTest.cpp
+++ b/tests/Agency/MoveShardTest.cpp
@@ -1919,9 +1919,10 @@ SECTION("aborting the job while the new leader is already in place should not br
     CHECK(writes.get("/arango/Supervision/Shards/" + SHARD).get("op").copyString() == "delete");
     CHECK(std::string(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD).typeName()) == "array");
     // well apparently this job is not responsible to cleanup its mess
-    CHECK(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD).length() >= 2);
+    CHECK(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD).length() >= 3);
     CHECK(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD)[0].copyString() == SHARD_LEADER);
     CHECK(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD)[1].copyString() == SHARD_FOLLOWER1);
+    CHECK(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD)[2].copyString() == FREE_SERVER);
     CHECK(std::string(writes.get("/arango/Target/Failed/1").typeName()) == "object");
 
     return fakeWriteResult;


### PR DESCRIPTION
### Scope & Purpose

Fixing bug in moveShard::abort. In the case the new leader has not confirmed in current, the from server is written back twice into the Plan.

- [x] Bug-Fix for a *released version*

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added **Regression Tests** (Only for bug-fixes) 
- [x] Added new C++ **Unit Tests** (Either GoogleTest or Catch-Test)

Additionally:

- [ ] There are tests in an external testing repository (i.e. node-resilience tests, chaos tests)
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

### Documentation

- [x] Added a *Changelog Entry* 
