### PR TITLE
fix pasting from the documentation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 devel
 -----
 
-* fix cut'n'pasting code from the documentation into arangosh
+* Fixed cut'n'pasting code from the documentation into arangosh.
 
 * Added initial support for wgs84 reference ellipsoid in GEO_DISTANCE through third
   optional parameter to AQL function

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* fix cut'n'pasting code from the documentation into arangosh
+
 * Added initial support for wgs84 reference ellipsoid in GEO_DISTANCE through third
   optional parameter to AQL function
 
@@ -15,7 +17,7 @@ devel
 * Removed content from Documentation/Books, but keeping the subfolders.
   The documentation is in a separate repository (except DocuBlocks and Scripts):
   https://github.com/arangodb/docs.git
-  
+
 * Updated TOKENS function to deal with primitive types and arrays.
 
 * Fixed agency nodes to not create bogus keys on delete / observe / unobserve

--- a/lib/Utilities/ShellBase.cpp
+++ b/lib/Utilities/ShellBase.cpp
@@ -125,6 +125,9 @@ std::string ShellBase::prompt(std::string const& prompt,
 
     if (StringUtils::isPrefix(line, plain)) {
       pos = line.find('>');
+      // The documentation has this, so we ignore it:
+    } else if (StringUtils::isPrefix(line, "arangosh>")) {
+      pos = line.find('>');
     } else if (StringUtils::isPrefix(line, "...")) {
       pos = line.find('>');
     }


### PR DESCRIPTION
### Scope & Purpose
In ArangoDB 2.8 one could cut'n'paste code snippets including their `arangosh>` prefixes as seen here: 
https://www.arangodb.com/docs/stable/graphs.html#example-graphs
This wasn't possible anymore. This PR fixes that.
- [x] Bug-Fix for 3.0 - present
- [x] The behavior in this PR can be *manually tested* 
- [ ] The behavior change can be verified via automatic tests

#### Related Information
This change is a trivial rework / code cleanup without any test coverage.
http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/5750/
### Documentation
- [x] Added a *Changelog Entry* 
