### PR TITLE
issue #9654: make `--rocksdb.max-write-buffer-number` work

### DIFF
--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -581,9 +581,17 @@ void RocksDBEngine::start() {
     _options.db_write_buffer_size = opts->_totalWriteBufferSize;
   }
 
-  // this is cfFamilies.size() + 2 ... but _option needs to be set before
-  //  building cfFamilies
-  _options.max_write_buffer_number = 7 + 2;
+  if (!application_features::ApplicationServer::server->options()->processingResult().touched("rocksdb.max-write-buffer-number")) {
+    // user hasn't explicitly set the number of write buffers, so we use a default value based
+    // on the number of column families
+    // this is cfFamilies.size() + 2 ... but _option needs to be set before
+    //  building cfFamilies
+    // Update max_write_buffer_number above if you change number of families used
+    _options.max_write_buffer_number = 7 + 2;
+  } else if (_options.max_write_buffer_number < 7 + 2) {
+    // use set the value explicitly, and it is lower than recommended
+    LOG_TOPIC("d5c49", WARN, Logger::ENGINES) << "ignoring value for option `--rocksdb.max-write-buffer-number` because it is lower than recommended";
+  }
 
   // cf options for definitons (dbs, collections, views, ...)
   rocksdb::ColumnFamilyOptions definitionsCF(_options);
@@ -622,8 +630,8 @@ void RocksDBEngine::start() {
   cfFamilies.emplace_back("GeoIndex", fixedPrefCF);         // 5
   cfFamilies.emplace_back("FulltextIndex", fixedPrefCF);    // 6
 
-  // DO NOT FORGET TO DESTROY THE CFs ON CLOSE
-  //  Update max_write_buffer_number above if you change number of families used
+  TRI_ASSERT(static_cast<int>(_options.max_write_buffer_number) >= static_cast<int>(cfFamilies.size()));
+  // Update max_write_buffer_number above if you change number of families used
 
   std::vector<rocksdb::ColumnFamilyHandle*> cfHandles;
   size_t const numberOfColumnFamilies = RocksDBColumnFamily::minNumberOfColumnFamilies;

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -589,7 +589,8 @@ void RocksDBEngine::start() {
     // Update max_write_buffer_number above if you change number of families used
     _options.max_write_buffer_number = 7 + 2;
   } else if (_options.max_write_buffer_number < 7 + 2) {
-    // use set the value explicitly, and it is lower than recommended
+    // user set the value explicitly, and it is lower than recommended
+    _options.max_write_buffer_number = 7 + 2;
     LOG_TOPIC("d5c49", WARN, Logger::ENGINES) << "ignoring value for option `--rocksdb.max-write-buffer-number` because it is lower than recommended";
   }
 

--- a/lib/ApplicationFeatures/RocksDBOptionFeature.cpp
+++ b/lib/ApplicationFeatures/RocksDBOptionFeature.cpp
@@ -57,7 +57,7 @@ RocksDBOptionFeature::RocksDBOptionFeature(application_features::ApplicationServ
       _transactionLockTimeout(rocksDBTrxDefaults.transaction_lock_timeout),
       _totalWriteBufferSize(rocksDBDefaults.db_write_buffer_size),
       _writeBufferSize(rocksDBDefaults.write_buffer_size),
-      _maxWriteBufferNumber(rocksDBDefaults.max_write_buffer_number),
+      _maxWriteBufferNumber(7 + 2), // number of column families plus 2
       _maxTotalWalSize(80 << 20),
       _delayedWriteRate(rocksDBDefaults.delayed_write_rate),
       _minWriteBufferNumberToMerge(rocksDBDefaults.min_write_buffer_number_to_merge),

--- a/lib/ApplicationFeatures/RocksDBOptionFeature.h
+++ b/lib/ApplicationFeatures/RocksDBOptionFeature.h
@@ -58,6 +58,7 @@ class RocksDBOptionFeature final : public application_features::ApplicationFeatu
   std::string _walDirectory;
   uint64_t _totalWriteBufferSize;
   uint64_t _writeBufferSize;
+  // Update max_write_buffer_number above if you change number of families used
   uint64_t _maxWriteBufferNumber;
   uint64_t _maxTotalWalSize;
   uint64_t _delayedWriteRate;


### PR DESCRIPTION
### Scope & Purpose

Honor user-defined values for `--rocksdb.max-write-buffer-number` if within an acceptable range (i.e. 9 or greater). Ignore values that don't make sense.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

- [x] There is a GitHub Issue reported by a Community User: https://github.com/arangodb/arangodb/pull/9654

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5762/
