### PR TITLE
Bug fix/fix invalid cast

### DIFF
--- a/arangod/IResearch/IResearchLinkCoordinator.cpp
+++ b/arangod/IResearch/IResearchLinkCoordinator.cpp
@@ -44,6 +44,7 @@
 namespace {
 
 arangodb::ClusterEngineType getEngineType() {
+#ifdef ARANGODB_USE_GOOGLE_TESTS
   // during the unit tests there is a mock storage engine which cannot be casted
   // to a ClusterEngine at all. the only sensible way to find out the engine type is 
   // to try a dynamic_cast here and assume the MockEngine if the cast goes wrong
@@ -52,6 +53,9 @@ arangodb::ClusterEngineType getEngineType() {
     return engine->engineType();
   }
   return arangodb::ClusterEngineType::MockEngine;
+#else
+  return static_cast<arangodb::ClusterEngine*>(arangodb::EngineSelectorFeature::ENGINE)->engineType();
+#endif
 }
 
 } // namespace


### PR DESCRIPTION
### Scope & Purpose

Fix an invalid static_cast during gtest execution.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *arangosearch gtests*.

Additionally:

- [x] I ensured this code runs with ASan / TSan or other static verification tools

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5768/
