### PR TITLE
downgrade WARN messages to INFO level

### DIFF
--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -399,7 +399,7 @@ void Conductor::cancelNoLock() {
   _callbackMutex.assertLockedByCurrentThread();
   _state = ExecutionState::CANCELED;
   bool ok = basics::function_utils::retryUntilTimeout(
-      [this]() -> bool { int(_finalizeWorkers() != TRI_ERROR_QUEUE_FULL); },
+      [this]() -> bool { return (_finalizeWorkers() != TRI_ERROR_QUEUE_FULL); },
       Logger::PREGEL, "cancel worker execution");
   if (!ok) {
     LOG_TOPIC("f8b3c", ERR, Logger::PREGEL)

--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -398,13 +398,8 @@ void Conductor::cancel() {
 void Conductor::cancelNoLock() {
   _callbackMutex.assertLockedByCurrentThread();
   _state = ExecutionState::CANCELED;
-  bool ok;
-  int res;
-  std::tie(ok, res) = basics::function_utils::retryUntilTimeout<int>(
-      [this]() -> std::pair<bool, int> {
-        int res = _finalizeWorkers();
-        return std::make_pair(res != TRI_ERROR_QUEUE_FULL, res);
-      },
+  bool ok = basics::function_utils::retryUntilTimeout(
+      [this]() -> bool { int(_finalizeWorkers() != TRI_ERROR_QUEUE_FULL); },
       Logger::PREGEL, "cancel worker execution");
   if (!ok) {
     LOG_TOPIC("f8b3c", ERR, Logger::PREGEL)

--- a/arangod/Replication/InitialSyncer.cpp
+++ b/arangod/Replication/InitialSyncer.cpp
@@ -82,9 +82,12 @@ void InitialSyncer::startRecurringBatchExtension() {
           },
           Logger::REPLICATION, "queue batch extension");
   if (!queued) {
-    LOG_TOPIC("f8b3e", FATAL, Logger::REPLICATION)
-        << "Failed to queue batch extension for 5 minutes, exiting.";
-    FATAL_ERROR_EXIT();
+    LOG_TOPIC("f8b3e", ERR, Logger::REPLICATION)
+        << "Failed to queue replication batch extension for 5 minutes, exiting.";
+    // don't abort, as this is not a critical error 
+    // if requeueing has failed here, the replication can still go on, but
+    // it _may_ fail later because the batch has expired on the leader.
+    // but there are still chances it can continue successfully
   }
 }
 

--- a/lib/Basics/FunctionUtils.cpp
+++ b/lib/Basics/FunctionUtils.cpp
@@ -48,7 +48,7 @@ bool retryUntilTimeout(std::function<bool()> fn, LogTopic& topic,
     if (success) {
       break;
     }
-    LOG_TOPIC("18d0b", WARN, topic) << "Failed to " << message << ", waiting to retry...";
+    LOG_TOPIC("18d0b", INFO, topic) << "Failed to " << message << ", waiting to retry...";
     std::this_thread::sleep_for(retryInterval);
   }
   return success;

--- a/lib/Basics/FunctionUtils.h
+++ b/lib/Basics/FunctionUtils.h
@@ -54,13 +54,13 @@ std::pair<bool, R> retryUntilTimeout(
     std::chrono::nanoseconds timeout = std::chrono::minutes(5)) {
   auto start = std::chrono::steady_clock::now();
   bool success = false;
-  R value;
+  R value{};
   while ((std::chrono::steady_clock::now() - start) < timeout) {
     std::tie(success, value) = fn();
     if (success) {
       break;
     }
-    LOG_TOPIC("18d0a", WARN, topic) << "Failed to " << message << ", waiting to retry...";
+    LOG_TOPIC("18d0a", INFO, topic) << "Failed to " << message << ", waiting to retry...";
     std::this_thread::sleep_for(retryInterval);
   }
   return std::make_pair(success, value);


### PR DESCRIPTION
### Scope & Purpose

Downgrade WARN messages to INFO level
because the failed operations will be retried and likely succeed later on.
Additionally, fix a compile warning for a potentially uninitialized
value in FunctionUtils.h. Finally, don't abort the server process if
the batch ping timer cannot be requeued in initial replication, as this
is not a critical error. Replication can still be retried, and even has
a chance to succeed without the batch ping timer being requeued.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5783/