### PR TITLE
show query string length and cacheability in explain output

### DIFF
--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -162,17 +162,18 @@ function pad(n) {
 /* print functions */
 
 /* print query string */
-function printQuery(query) {
+function printQuery(query, cacheable) {
   'use strict';
   // restrict max length of printed query to avoid endless printing for
   // very long query strings
-  var maxLength = 4096;
+  var maxLength = 4096, headline = 'Query String (' + query.length + ' chars';
   if (query.length > maxLength) {
-    stringBuilder.appendLine(section('Query String (truncated):'));
+    headline += ' - truncated...';
     query = query.substr(0, maxLength / 2) + ' ... ' + query.substr(query.length - maxLength / 2);
-  } else {
-    stringBuilder.appendLine(section('Query String:'));
   }
+  headline += ', cacheable: ' + (cacheable ? 'true' : 'false');
+  headline += '):';
+  stringBuilder.appendLine(section(headline));
   stringBuilder.appendLine(' ' + value(stringBuilder.wrap(query, 100)));
   stringBuilder.appendLine();
 }
@@ -700,7 +701,7 @@ function processQuery(query, explain, planIndex) {
   if (planIndex !== undefined) {
     plan = explain.plans[planIndex];
   }
-
+  
   /// mode with actual runtime stats per node
   let profileMode = stats && stats.hasOwnProperty('nodes');
 
@@ -1718,7 +1719,7 @@ function processQuery(query, explain, planIndex) {
   };
 
   if (planIndex === undefined) {
-    printQuery(query);
+    printQuery(query, explain.cacheable);
   }
 
   stringBuilder.appendLine(section('Execution plan:'));


### PR DESCRIPTION
### Scope & Purpose

Show query string length and cacheability info in explainer

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5804/