### PR TITLE
mark AQL functions FULLTEXT, NEAR, WITHIN, WITHIN_RECTANGLE as cacheable

### DIFF
--- a/arangod/Aql/AqlFunctionFeature.cpp
+++ b/arangod/Aql/AqlFunctionFeature.cpp
@@ -443,14 +443,13 @@ void AqlFunctionFeature::addMiscFunctions() {
   add({"WARN", ".,.", Function::makeFlags(FF::CanRunOnDBServer), &Functions::Warn});  // not deterministic and not cacheable
 
   // NEAR, WITHIN, WITHIN_RECTANGLE and FULLTEXT are replaced by the AQL
-  // optimizer with collection-based subqueries they are all not marked as
-  // non-deterministic and non-cacheable here as they refer to documents
-  // note further that all of these function call will be replaced by equivalent
-  // subqueries by the optimizer
-  add({"NEAR", ".h,.,.|.,.", Function::makeFlags(), &Functions::NotImplemented});
-  add({"WITHIN", ".h,.,.,.|.", Function::makeFlags(), &Functions::NotImplemented});
-  add({"WITHIN_RECTANGLE", "h.,.,.,.,.", Function::makeFlags(), &Functions::NotImplemented});
-  add({"FULLTEXT", ".h,.,.|.", Function::makeFlags(), &Functions::NotImplemented});
+  // optimizer with collection-/index-based subqueries. they are all
+  // marked as deterministic and cacheable here as they are just
+  // placeholders for collection/index accesses nowaways.
+  add({"NEAR", ".h,.,.|.,.", Function::makeFlags(FF::Cacheable), &Functions::NotImplemented});
+  add({"WITHIN", ".h,.,.,.|.", Function::makeFlags(FF::Cacheable), &Functions::NotImplemented});
+  add({"WITHIN_RECTANGLE", "h.,.,.,.,.", Function::makeFlags(FF::Cacheable), &Functions::NotImplemented});
+  add({"FULLTEXT", ".h,.,.|.", Function::makeFlags(FF::Cacheable), &Functions::NotImplemented});
 }
 
 }  // namespace aql


### PR DESCRIPTION
### Scope & Purpose

Mark the AQL functions `FULLTEXT`, `NEAR`, `WITHIN` and `WITHIN_RECTANGLE` as cacheable, so they can be used in conjunction with the AQL query results cache (at least on single server).

Previously, these functions were marked as non-cacheable, because they accepted somewhat dynamic collection input which could not be tracked by the optimizer. However, this was changed with 3.4.0, and all these functions require the collection name to be specified unambiguously and for the optimizer to detect easily. Additionally, all of these functions are replaced at query planning time with appropriate index-accessing subqueries, whose results are cacheable normally.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5808/