### PR TITLE
port change from devel by @danielhlarkin

### DIFF
--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -398,13 +398,8 @@ void Conductor::cancel() {
 void Conductor::cancelNoLock() {
   _callbackMutex.assertLockedByCurrentThread();
   _state = ExecutionState::CANCELED;
-  bool ok;
-  int res;
-  std::tie(ok, res) = basics::function_utils::retryUntilTimeout<int>(
-      [this]() -> std::pair<bool, int> {
-        int res = _finalizeWorkers();
-        return std::make_pair(res != TRI_ERROR_QUEUE_FULL, res);
-      },
+  bool ok = basics::function_utils::retryUntilTimeout(
+      [this]() -> bool { return (_finalizeWorkers() != TRI_ERROR_QUEUE_FULL); },
       Logger::PREGEL, "cancel worker execution");
   if (!ok) {
     LOG_TOPIC("f8b3c", ERR, Logger::PREGEL)


### PR DESCRIPTION
### Scope & Purpose

Port a minor leftover change from devel to 3.5 that affects Pregel conductor.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5811/