### PR TITLE
Bug fix/multi bugs

### DIFF
--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -344,6 +344,10 @@ Result FollowerInfo::persistInAgency(bool isRemove) const {
   std::string planPath = PlanShardPath(*_docColl);
   AgencyComm ac;
   do {
+    if (_docColl->deleted() || _docColl->vocbase().isDropped()) {
+      LOG_TOPIC("8972a", WARN, Logger::CLUSTER) << "giving up persisting follower info for dropped collection"; 
+      return TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND;
+    }
     AgencyReadTransaction trx(std::vector<std::string>(
         {AgencyCommManager::path(planPath), AgencyCommManager::path(curPath)}));
     AgencyCommResult res = ac.sendTransactionWithFailover(trx);

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -956,7 +956,7 @@ bool SynchronizeShard::first() {
 
     } catch (std::exception const& e) {
       std::stringstream error;
-      error << "synchronization of";
+      error << "synchronization of ";
       AppendShardInformationToMessage(database, shard, planId, startTime, error);
       error << " failed: " << e.what();
       LOG_TOPIC("1e576", ERR, Logger::MAINTENANCE) << error.str();

--- a/arangod/Scheduler/SupervisedScheduler.cpp
+++ b/arangod/Scheduler/SupervisedScheduler.cpp
@@ -338,14 +338,14 @@ void SupervisedScheduler::runWorker() {
   }
 
   while (true) {
-    std::unique_ptr<WorkItem> work = getWork(state);
-    if (work == nullptr) {
-      break;
-    }
-
-    _jobsDequeued++;
-
     try {
+      std::unique_ptr<WorkItem> work = getWork(state);
+      if (work == nullptr) {
+        break;
+      }
+    
+      _jobsDequeued++;
+
       state->_lastJobStarted = clock::now();
       state->_working = true;
       work->_handler();
@@ -397,23 +397,27 @@ void SupervisedScheduler::runSupervisor() {
     lastQueueLength = queueLength;
     lastJobsSubmitted = jobsSubmitted;
 
-    if (doStartOneThread && _numWorkers < _maxNumWorker) {
-      jobsStallingTick = 0;
-      startOneThread();
-    } else if (doStopOneThread && _numWorkers > _numIdleWorker) {
-      stopOneThread();
+    try {
+      if (doStartOneThread && _numWorkers < _maxNumWorker) {
+        jobsStallingTick = 0;
+        startOneThread();
+      } else if (doStopOneThread && _numWorkers > _numIdleWorker) {
+        stopOneThread();
+      }
+
+      cleanupAbandonedThreads();
+      sortoutLongRunningThreads();
+
+      std::unique_lock<std::mutex> guard(_mutexSupervisor);
+
+      if (_stopping) {
+        break;
+      }
+
+      _conditionSupervisor.wait_for(guard, std::chrono::milliseconds(100));
+    } catch (std::exception const& ex) {
+      LOG_TOPIC("3318c", WARN, Logger::THREADS) << "scheduler supervisor thread caught exception: " << ex.what();
     }
-
-    cleanupAbandonedThreads();
-    sortoutLongRunningThreads();
-
-    std::unique_lock<std::mutex> guard(_mutexSupervisor);
-
-    if (_stopping) {
-      break;
-    }
-
-    _conditionSupervisor.wait_for(guard, std::chrono::milliseconds(100));
   }
 }
 


### PR DESCRIPTION
### Scope & Purpose

Give up trying to persist follower info in agency for collections that have been dropped in the meantime. The previous implementation cycled forever, occupying one scheduler thread just with the retries.

Add try..catch for scheduler supervisor, and extend extend try..catch block scope for scheduler workers. Those threads should never be terminated with an exception failure but just continue running.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest shell_client --cluster true*.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5840/