### PR TITLE
Bug fix 3.4/multi bugs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.4.8 (XXXX-XX-XX)
 -------------------
 
+* Don't retry persisting follower information for collections/shards already
+  dropped. The previous implementation retried (unsuccessfully in this case)
+  for up to 2 hours, occupying one scheduler thread.
+
 * Show query string length and cacheability information in query explain output.
 
 * Fixed internal issue #4378: fix bug in MoveShard::abort which causes a

--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -126,6 +126,11 @@ void FollowerInfo::add(ServerID const& sid) {
   double startTime = TRI_microtime();
   bool success = false;
   do {
+    if (_docColl->deleted() || _docColl->vocbase().isDropped()) {
+      LOG_TOPIC(WARN, Logger::CLUSTER) << "giving up persisting follower info for dropped collection"; 
+      return;
+    }
+
     AgencyReadTransaction trx(std::vector<std::string>(
         {AgencyCommManager::path(planPath), AgencyCommManager::path(curPath)}));
     AgencyCommResult res = ac.sendTransactionWithFailover(trx);
@@ -265,6 +270,10 @@ bool FollowerInfo::remove(ServerID const& sid) {
   double startTime = TRI_microtime();
   bool success = false;
   do {
+    if (_docColl->deleted() || _docColl->vocbase().isDropped()) {
+      LOG_TOPIC(WARN, Logger::CLUSTER) << "giving up persisting follower info for dropped collection"; 
+      return true;
+    }
     AgencyReadTransaction trx(std::vector<std::string>(
         {AgencyCommManager::path(planPath), AgencyCommManager::path(curPath)}));
     AgencyCommResult res = ac.sendTransactionWithFailover(trx);

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -958,7 +958,7 @@ bool SynchronizeShard::first() {
 
     } catch (std::exception const& e) {
       std::stringstream error;
-      error << "synchronization of";
+      error << "synchronization of ";
       AppendShardInformationToMessage(database, shard, planId, startTime, error);
       error << " failed: " << e.what();
       LOG_TOPIC(DEBUG, Logger::MAINTENANCE) << error.str();


### PR DESCRIPTION
### Scope & Purpose

Give up trying to persist follower info in agency for collections that have been dropped in the meantime. The previous implementation cycled forever, occupying one scheduler thread just with the retries.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest shell_client --cluster true*.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5843/