### PR TITLE
remove now-obsolete warning

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fixed internal issue #4407: remove storage engine warning
+
 * Agents to remove callback entries when responded to with code 404
 
 * Added AQL function DATE_ROUND to bin a date/time into a set of equal-distance

--- a/arangod/StorageEngine/EngineSelectorFeature.cpp
+++ b/arangod/StorageEngine/EngineSelectorFeature.cpp
@@ -94,13 +94,6 @@ void EngineSelectorFeature::prepare() {
 
   if (_engine == "auto") {
     _engine = defaultEngine();
-    LOG_TOPIC("18bb0", WARN, Logger::STARTUP)
-        << "using default storage engine '" << _engine
-        << "', as no storage engine was explicitly selected via the "
-           "`--server.storage-engine` option";
-    LOG_TOPIC("bdd59", INFO, Logger::STARTUP)
-        << "please note that default storage engine has changed from 'mmfiles' "
-           "to 'rocksdb' in ArangoDB 3.4";
   }
 
   TRI_ASSERT(_engine != "auto");


### PR DESCRIPTION
### Scope & Purpose

Remove storage engine warning, as requested in planning/#4407

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

- [x] There is an internal planning ticket: https://github.com/arangodb/planning/issues/4407

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/5861/