### PR TITLE
don't create `arangosh_XXXXXX` directories

### DIFF
--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -2327,9 +2327,16 @@ std::string TRI_GetTempPath() {
         try {
           long systemError;
           std::string systemErrorStr;
-          TRI_CreateRecursiveDirectory(SystemTempPath.get(), systemError, systemErrorStr);
+          std::string baseDirectory = TRI_Dirname(SystemTempPath.get());
+          if (baseDirectory.size() <= 1) {
+            baseDirectory = SystemTempPath.get();
+          }
+          // create base directory if it does not yet exist
+          TRI_CreateRecursiveDirectory(baseDirectory.data(), systemError, systemErrorStr);
         } catch (...) {}
 
+        // fill template string (XXXXXX) with some pseudo-random value and create
+        // the directory
         res = mkDTemp(SystemTempPath.get(), system.size() + 1);
       }
 


### PR DESCRIPTION
### Scope & Purpose

Don't create `arangosh_XXXXXX` directories anymore.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/5871/