### PR TITLE
don't create `arangosh_XXXXXX` directories

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.5.1 (XXXX-XX-XX)
 -------------------
 
+* Don't create temporary directories named "arangosh_XXXXXX" anymore.
+
 * Upgraded version of bundled curl library to 7.65.3.
 
 * Don't retry persisting follower information for collections/shards already

--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -2237,9 +2237,16 @@ std::string TRI_GetTempPath() {
         try {
           long systemError;
           std::string systemErrorStr;
-          TRI_CreateRecursiveDirectory(SystemTempPath.get(), systemError, systemErrorStr);
+          std::string baseDirectory = TRI_Dirname(SystemTempPath.get());
+          if (baseDirectory.size() <= 1) {
+            baseDirectory = SystemTempPath.get();
+          }
+          // create base directory if it does not yet exist
+          TRI_CreateRecursiveDirectory(baseDirectory.data(), systemError, systemErrorStr);
         } catch (...) {}
 
+        // fill template string (XXXXXX) with some pseudo-random value and create
+        // the directory
         res = mkDTemp(SystemTempPath.get(), system.size() + 1);
       }
 


### PR DESCRIPTION
### Scope & Purpose

Don't create `arangosh_XXXXXX` directories anymore.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/5872/