### PR TITLE
[3.4] Minimize unnecessary dropping of followers due to poorly set synchronous replication timeouts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.4.8 (XXXX-XX-XX)
 -------------------
 
+* Make minimum timeout for synchronous replication configurable via parameter
+  (--cluster.synchronous-replication-timeout-minimum) and increase default value
+  to prevent dropping followers unnecessarily.
+
 * Don't retry persisting follower information for collections/shards already
   dropped. The previous implementation retried (unsuccessfully in this case)
   for up to 2 hours, occupying one scheduler thread.

--- a/arangod/Cluster/ReplicationTimeoutFeature.cpp
+++ b/arangod/Cluster/ReplicationTimeoutFeature.cpp
@@ -31,7 +31,7 @@ namespace arangodb {
 
 double ReplicationTimeoutFeature::timeoutFactor = 1.0;
 double ReplicationTimeoutFeature::timeoutPer4k = 0.1;
-double ReplicationTimeoutFeature::lowerLimit = 0.5;
+double ReplicationTimeoutFeature::lowerLimit = 30.0;
 
 ReplicationTimeoutFeature::ReplicationTimeoutFeature(application_features::ApplicationServer& server)
     : ApplicationFeature(server, "ReplicationTimeout") {
@@ -41,6 +41,11 @@ ReplicationTimeoutFeature::ReplicationTimeoutFeature(application_features::Appli
 
 void ReplicationTimeoutFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addSection("cluster", "Configure the cluster");
+
+  options->addOption("--cluster.synchronous-replication-timeout-minimum",
+                     "all synchronous replication timeouts will be at least "
+                     "this value (in seconds)",
+                     new DoubleParameter(&lowerLimit));
 
   options->addOption(
       "--cluster.synchronous-replication-timeout-factor",
@@ -52,12 +57,6 @@ void ReplicationTimeoutFeature::collectOptions(std::shared_ptr<ProgramOptions> o
                      "this amount per 4096 bytes (in seconds)",
                      new DoubleParameter(&timeoutPer4k),
                      arangodb::options::makeFlags(arangodb::options::Flags::Hidden));
-}
-
-void ReplicationTimeoutFeature::prepare() {
-  // set minimum timeout. this depends on the selected storage engine
-  TRI_ASSERT(EngineSelectorFeature::ENGINE != nullptr);
-  lowerLimit = EngineSelectorFeature::ENGINE->minimumSyncReplicationTimeout();
 }
 
 }  // namespace arangodb

--- a/arangod/Cluster/ReplicationTimeoutFeature.cpp
+++ b/arangod/Cluster/ReplicationTimeoutFeature.cpp
@@ -42,10 +42,12 @@ ReplicationTimeoutFeature::ReplicationTimeoutFeature(application_features::Appli
 void ReplicationTimeoutFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addSection("cluster", "Configure the cluster");
 
-  options->addOption("--cluster.synchronous-replication-timeout-minimum",
-                     "all synchronous replication timeouts will be at least "
-                     "this value (in seconds)",
-                     new DoubleParameter(&lowerLimit));
+  options
+      ->addOption("--cluster.synchronous-replication-timeout-minimum",
+                  "all synchronous replication timeouts will be at least "
+                  "this value (in seconds)",
+                  new DoubleParameter(&lowerLimit))
+      .setIntroducedIn(30408);
 
   options->addOption(
       "--cluster.synchronous-replication-timeout-factor",

--- a/arangod/Cluster/ReplicationTimeoutFeature.h
+++ b/arangod/Cluster/ReplicationTimeoutFeature.h
@@ -35,7 +35,6 @@ class ReplicationTimeoutFeature : public application_features::ApplicationFeatur
   explicit ReplicationTimeoutFeature(application_features::ApplicationServer& server);
 
   void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
-  void prepare() override final;
 
   static double timeoutFactor;
   static double timeoutPer4k;

--- a/arangod/ClusterEngine/ClusterEngine.h
+++ b/arangod/ClusterEngine/ClusterEngine.h
@@ -76,9 +76,6 @@ class ClusterEngine final : public StorageEngine {
   void prepare() override;
   void start() override;
 
-  // minimum timeout for the synchronous replication
-  double minimumSyncReplicationTimeout() const override { return 1.0; }
-
   bool supportsDfdb() const override { return false; }
   bool useRawDocumentPointers() override { return false; }
 

--- a/arangod/MMFiles/MMFilesEngine.h
+++ b/arangod/MMFiles/MMFilesEngine.h
@@ -90,9 +90,6 @@ class MMFilesEngine final : public StorageEngine {
   // flush wal wait for collector
   void stop() override;
 
-  // minimum timeout for the synchronous replication
-  double minimumSyncReplicationTimeout() const override { return 0.5; }
-
   bool supportsDfdb() const override { return true; }
 
   bool useRawDocumentPointers() override { return true; }

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -142,9 +142,6 @@ class RocksDBEngine final : public StorageEngine {
   void stop() override;
   void unprepare() override;
 
-  // minimum timeout for the synchronous replication
-  double minimumSyncReplicationTimeout() const override { return 1.0; }
-
   bool supportsDfdb() const override { return false; }
   bool useRawDocumentPointers() override { return false; }
 

--- a/arangod/StorageEngine/StorageEngine.h
+++ b/arangod/StorageEngine/StorageEngine.h
@@ -103,9 +103,6 @@ class StorageEngine : public application_features::ApplicationFeature {
   virtual std::unique_ptr<PhysicalCollection> createPhysicalCollection(
       LogicalCollection& collection, velocypack::Slice const& info) = 0;
 
-  // minimum timeout for the synchronous replication
-  virtual double minimumSyncReplicationTimeout() const = 0;
-
   // status functionality
   // --------------------
 

--- a/tests/IResearch/StorageEngineMock.h
+++ b/tests/IResearch/StorageEngineMock.h
@@ -200,7 +200,6 @@ class StorageEngineMock: public arangodb::StorageEngine {
   virtual arangodb::Result handleSyncKeys(arangodb::DatabaseInitialSyncer& syncer, arangodb::LogicalCollection& col, std::string const& keysId) override;
   virtual bool inRecovery() override;
   virtual arangodb::Result lastLogger(TRI_vocbase_t& vocbase, std::shared_ptr<arangodb::transaction::Context> transactionContext, uint64_t tickStart, uint64_t tickEnd, std::shared_ptr<VPackBuilder>& builderSPtr) override;
-  virtual double minimumSyncReplicationTimeout() const override { return 1.0; }
   virtual std::unique_ptr<TRI_vocbase_t> openDatabase(arangodb::velocypack::Slice const& args, bool isUpgrade, int& status) override;
   virtual arangodb::Result persistCollection(TRI_vocbase_t& vocbase, arangodb::LogicalCollection const& collection) override;
   virtual void prepareDropDatabase(TRI_vocbase_t& vocbase, bool useWriteMarker, int& status) override;


### PR DESCRIPTION
### Scope & Purpose

- [x] Strictly *new functionality* (backport of https://github.com/arangodb/arangodb/pull/9798)
- [x] The behavior in this PR can be (and was) *manually tested*

#### Related Information

This PR makes the timeout for synchronous replication configurable, with a default considerably larger than the current one. In particular, it is chosen such that the normal failed-follower logic in the agency will kick in if the server stops responding (is actually dead) prior to the replication operation timing out on its own (in case the operation is just slow). Therefore, it is much less likely that we will react to a slow operation by considering the follower failed and triggering shard recovery.

### Testing & Verification

Jenkins: http://jenkins01.arangodb.biz:8080/job/arangodb-matrix-pr/5874/