### PR TITLE
adjust log level for "closing stream" message

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.5.1 (XXXX-XX-XX)
 -------------------
 
+* Changed log level for message "keep alive timeout - closing stream!" from INFO to
+  DEBUG.
+
 * Don't create temporary directories named "arangosh_XXXXXX" anymore.
 
 * Add TransactionStatistics to ServerStatistics (transactions started /

--- a/arangod/GeneralServer/SocketTask.cpp
+++ b/arangod/GeneralServer/SocketTask.cpp
@@ -247,7 +247,7 @@ void SocketTask::resetKeepAlive() {
   _keepAliveTimer->async_wait([self](const asio_ns::error_code& ec) {
     if (!ec) {  // error will be true if timer was canceled
       if (auto s = self.lock()) {
-        LOG_TOPIC("f0948", INFO, Logger::COMMUNICATION)
+        LOG_TOPIC("f0948", DEBUG, Logger::COMMUNICATION)
           << "keep alive timeout - closing stream!";
         s->closeStream();
       }


### PR DESCRIPTION
### Scope & Purpose

Adjusted log level for message "keep alive timeout - closing stream!" from INFO to DEBUG.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5888/