### PR TITLE
Feature/enable tlsv13

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,32 @@
 devel
 -----
 
+* Added support for TLS 1.3 for the arangod server and the client tools. 
+
+  The default TLS protocol for the arangod server is now TLS 1.3 as well, in
+  contrast to TLS 1.2 in previous versions.
+
+  The arangod server can be started with option `--ssl.protocol 5` to make it use
+  TLS 1.2 again.
+  
+  All client tools also support TLS 1.3, by using the `--ssl.protocol 6` option when
+  invoking them. The client tools will use TLS 1.2 by default, in order to be
+  compatible with older versions of ArangoDB that may be contacted by these tools.
+
+  To configure the TLS version for arangod instances started by the ArangoDB starter,
+  one can use the `--all.ssl.protocol=VALUE` startup option for the ArangoDB starter,
+  where VALUE is one of the following:
+
+  - 4 = TLSv1
+  - 5 = TLSv1.2
+  - 6 = TLSv1.3
+
 * Fixed internal issue #4407: remove storage engine warning
 
 * Added TransactionStatistics to ServerStatistics (transactions started /
   aborted / committed and number of intermediate commits).
 
-* Agents to remove callback entries when responded to with code 404
+* Agents to remove callback entries when responded to with code 404.
 
 * Added AQL function DATE_ROUND to bin a date/time into a set of equal-distance
   buckets.

--- a/lib/SimpleHttpClient/SslClientConnection.cpp
+++ b/lib/SimpleHttpClient/SslClientConnection.cpp
@@ -255,18 +255,14 @@ void SslClientConnection::init(uint64_t sslProtocol) {
 #endif
       break;
 
-    case TLS_V13:
       // TLS 1.3, only supported from OpenSSL 1.1.1 onwards
 
       // openssl version number format is
       // MNNFFPPS: major minor fix patch status
 #if OPENSSL_VERSION_NUMBER >= 0x10101000L
+    case TLS_V13:
       meth = TLS_client_method();
       break;
-#else
-      // no TLS 1.3 support
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_NOT_IMPLEMENTED,
-                                     "TLS 1.3 is not supported in this build");
 #endif
 
     case SSL_UNKNOWN:
@@ -332,7 +328,9 @@ bool SslClientConnection::connectSocket() {
   switch (SslProtocol(_sslProtocol)) {
     case TLS_V1:
     case TLS_V12:
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
     case TLS_V13:
+#endif
     default:
       SSL_set_tlsext_host_name(_ssl, _endpoint->host().c_str());
   }

--- a/lib/Ssl/SslServerFeature.cpp
+++ b/lib/Ssl/SslServerFeature.cpp
@@ -66,7 +66,11 @@ SslServerFeature::SslServerFeature(application_features::ApplicationServer& serv
       _keyfile(),
       _sessionCache(false),
       _cipherList("HIGH:!EXPORT:!aNULL@STRENGTH"),
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+      _sslProtocol(TLS_V13),
+#else
       _sslProtocol(TLS_V12),
+#endif
       _sslOptions(asio_ns::ssl::context::default_workarounds | asio_ns::ssl::context::single_dh_use),
       _ecdhCurve("prime256v1") {
   setOptional(true);

--- a/lib/Ssl/ssl-helper.cpp
+++ b/lib/Ssl/ssl-helper.cpp
@@ -77,17 +77,13 @@ asio_ns::ssl::context arangodb::sslContext(SslProtocol protocol, std::string con
       meth = asio_ns::ssl::context::method::tlsv12_server;
       break;
     
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
     case TLS_V13: 
       // TLS 1.3, only supported from OpenSSL 1.1.1 onwards
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
       // openssl version number format is
       // MNNFFPPS: major minor fix patch status
       meth = asio_ns::ssl::context::method::tlsv13_server;
       break;
-#else
-      // no TLS 1.3 support
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_NOT_IMPLEMENTED,
-                                     "TLS 1.3 is not supported in this build");
 #endif
 
     default:
@@ -149,8 +145,10 @@ std::string arangodb::protocolName(SslProtocol protocol) {
     case TLS_V12:
       return "TLSv12";
     
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
     case TLS_V13:
       return "TLSv13";
+#endif
 
     default:
       return "unknown";
@@ -175,9 +173,15 @@ std::unordered_set<uint64_t> arangodb::availableSslProtocols() {
 }
 
 std::string arangodb::availableSslProtocolsDescription() {
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+  return "ssl protocol (1 = SSLv2 (unsupported), 2 = SSLv2 or SSLv3 "
+         "(negotiated), 3 = SSLv3, 4 = "
+         "TLSv1, 5 = TLSv1.2, 6 = TLSv1.3)";
+#else
   return "ssl protocol (1 = SSLv2 (unsupported), 2 = SSLv2 or SSLv3 "
          "(negotiated), 3 = SSLv3, 4 = "
          "TLSv1, 5 = TLSv1.2)";
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/Ssl/ssl-helper.h
+++ b/lib/Ssl/ssl-helper.h
@@ -50,7 +50,9 @@ enum SslProtocol {
   SSL_V3 = 3,
   TLS_V1 = 4,
   TLS_V12 = 5,
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
   TLS_V13 = 6,
+#endif
 
   SSL_LAST
 };


### PR DESCRIPTION
### Scope & Purpose

Enable TLS 1.3 in arangod and all client tools.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is already covered by existing tests, such as *ssl_server*.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5893/