### PR TITLE
issue #9794: Limit with offset results in an infinite query that can't be cancelled

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.4.8 (XXXX-XX-XX)
 -------------------
 
+* Issue #9798: Limit with offset results in an infinite query that can't be cancelled.
+
 * Agents to remove callback entries when responded to with code 404
 
 * Show query string length and cacheability information in query explain output.

--- a/arangod/Aql/IndexBlock.cpp
+++ b/arangod/Aql/IndexBlock.cpp
@@ -796,6 +796,10 @@ std::pair<ExecutionState, size_t> IndexBlock::skipSome(size_t atMost) {
     // At least one of them is prepared and ready to read.
     TRI_ASSERT(!_indexesExhausted);
     _indexesExhausted = !skipIndex(atMost);
+
+    if (_indexesExhausted) {
+      break;
+    }
   }
 
   size_t returned = _returned;


### PR DESCRIPTION
### Scope & Purpose

Fix issue #9794 
Affects only 3.4. 3.5 and devel work already due to a different implementation of the ExecutionBlocks.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5894/