### PR TITLE
iterate through all vertexCollections of a graph to find a vertex to …

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* The graph viewer of the web interface now tries to find a vertex document of
+  all available vertex collections before it aborts.
+
 * Upgraded bundled jemalloc library to version 5.2.1.
 
 * Fixed internal issue #4407: remove storage engine warning.

--- a/js/apps/system/_admin/aardvark/APP/aardvark.js
+++ b/js/apps/system/_admin/aardvark/APP/aardvark.js
@@ -568,14 +568,9 @@ authRouter.get('/graph/:name', function (req, res) {
   if (!verticesCollections || verticesCollections.length === 0) {
     res.throw('bad request', 'no vertex collections found for graph');
   }
-  var vertexName;
-  try {
-    vertexName = verticesCollections[Math.floor(Math.random() * verticesCollections.length)].name();
-  } catch (err) {
-    res.throw('bad request', 'vertex collection of graph not found');
-  }
 
   var vertexCollections = [];
+
   _.each(graph._vertexCollections(), function (vertex) {
     vertexCollections.push({
       name: vertex.name(),
@@ -583,7 +578,6 @@ authRouter.get('/graph/:name', function (req, res) {
     });
   });
 
-  var startVertex;
   var config;
 
   try {
@@ -592,25 +586,40 @@ authRouter.get('/graph/:name', function (req, res) {
     res.throw('bad request', e.message, {cause: e});
   }
 
-  var getPseudoRandomStartVertex = function (collName) {
-    let maxDoc = db[collName].count();
-    if (maxDoc === 0) {
-      return null;
-    }
-    if (maxDoc > 1000) {
-      maxDoc = 1000;
-    }
-    let randDoc = Math.floor(Math.random() * maxDoc);
+  var getPseudoRandomStartVertex = function () {
+    for (var i = 0; i < graph._vertexCollections().length; i++) {
+      var vertexCollection = graph._vertexCollections()[i];
+      let maxDoc = db[vertexCollection.name()].count();
 
-    return db._query(
-      'FOR vertex IN @@vertexCollection LIMIT @skipN, 1 RETURN vertex',
-      {
-        '@vertexCollection': collName,
-        'skipN': randDoc
+      if (maxDoc === 0) {
+        continue;
       }
-    ).toArray()[0];
+
+      if (maxDoc > 1000) {
+        maxDoc = 1000;
+      }
+
+      let randDoc = Math.floor(Math.random() * maxDoc);
+
+      let potentialVertex = db._query(
+        'FOR vertex IN @@vertexCollection LIMIT @skipN, 1 RETURN vertex',
+        {
+          '@vertexCollection': vertexCollection.name(),
+          'skipN': randDoc
+        }
+      ).toArray()[0];
+
+      if (potentialVertex) {
+        return potentialVertex;
+      }
+    }
+
+    return null;
   };
+
   var multipleIds;
+  var startVertex; // will be "randomly" choosen if no start vertex is specified
+
   if (config.nodeStart) {
     if (config.nodeStart.indexOf(' ') > -1) {
       multipleIds = config.nodeStart.split(' ');
@@ -621,11 +630,11 @@ authRouter.get('/graph/:name', function (req, res) {
         res.throw('bad request', e.message, {cause: e});
       }
       if (!startVertex) {
-        startVertex = getPseudoRandomStartVertex(vertexName);
+        startVertex = getPseudoRandomStartVertex();
       }
     }
   } else {
-    startVertex = getPseudoRandomStartVertex(vertexName);
+    startVertex = getPseudoRandomStartVertex();
   }
 
   var limit = 0;
@@ -639,7 +648,7 @@ authRouter.get('/graph/:name', function (req, res) {
   if (startVertex === null) {
     toReturn = {
       empty: true,
-      msg: 'Your graph is empty',
+      msg: 'Your graph is empty. We did not find a document in any available vertex collection.',
       settings: {
         vertexCollections: vertexCollections
       }


### PR DESCRIPTION
…display

### Scope & Purpose

The Graph Viewer will not iterate through all available vertexCollections (which are defined in the graph definition) to find a possible vertex document to start with. Before just a single random vertex was chosen. Now all vertex collections will be checked before inform the user that the graph does not have any available vertices to draw/render.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)

Yes we need backports for all supported branches. Will create after the review is done. 

- [ ] Bug-Fix for a *released version* 
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

- No ticket available (Slack)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

Additionally:

- [x] I ensured this code runs with ASan / TSan or other static verification tools
No C++ modification is done here. Only JavaScript Aardvark modifications
So, no Jenkins run is needed as well. 

### Documentation

No documentation is available. 

> All new Features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the changelog so that
> developers and users have a concise overview. 

- [x] Added a *Changelog Entry* (referencing the corresponding public or internal issue number)
