### PR TITLE
do not send '["_key"] by default'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.5.1 (XXXX-XX-XX)
 -------------------
 
+* Fixed creation of a smart join collection in the web ui.
+
 * Fixed issue #9795: fix AQL `NOT IN` clause in SEARCH operations for ArangoSearch
   views.
 

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/collectionsView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/collectionsView.js
@@ -390,9 +390,7 @@
               return 0;
             }
             shardKeys = _.pluck($('#new-collection-shardKeys').select2('data'), 'text');
-            if (shardKeys.length === 0) {
-              shardKeys.push('_key');
-            } else {
+            if (shardKeys.length !== 0) {
               _.each(shardKeys, function (element, index) { shardKeys[index] = arangoHelper.escapeHtml(element); });
             }
           }


### PR DESCRIPTION
Do not send a default key by default. Only send if the user enters things. 