### PR TITLE
fix return value checks

### DIFF
--- a/arangod/Cluster/ClusterComm.cpp
+++ b/arangod/Cluster/ClusterComm.cpp
@@ -1148,8 +1148,8 @@ void ClusterComm::disable() {
   }
 }
 
-void ClusterComm::scheduleMe(std::function<void()> task) {
-  arangodb::SchedulerFeature::SCHEDULER->queue(RequestLane::CLUSTER_INTERNAL, std::move(task));
+bool ClusterComm::scheduleMe(std::function<void()> task) {
+  return arangodb::SchedulerFeature::SCHEDULER->queue(RequestLane::CLUSTER_INTERNAL, std::move(task));
 }
 
 

--- a/arangod/Cluster/ClusterComm.h
+++ b/arangod/Cluster/ClusterComm.h
@@ -572,11 +572,10 @@ class ClusterComm {
   void disable();
 
   //////////////////////////////////////////////////////////////////////////////
-  /// @brief push all libcurl callback work to Scheduler threads.  It is a
-  ///  public static function that any object can use.
+  /// @brief push all libcurl callback work to Scheduler threads.
   //////////////////////////////////////////////////////////////////////////////
 
-  static void scheduleMe(std::function<void()> task);
+  static bool scheduleMe(std::function<void()> task);
 
  protected:  // protected members are for unit test purposes
   /// @brief Constructor for test cases.

--- a/arangod/MMFiles/MMFilesCollection.cpp
+++ b/arangod/MMFiles/MMFilesCollection.cpp
@@ -1704,8 +1704,8 @@ int MMFilesCollection::fillIndexes(transaction::Methods& trx,
       _logicalCollection.vocbase().name() + "/" + _logicalCollection.name() +
       " }, indexes: " + std::to_string(n - 1));
 
-  auto poster = [](std::function<void()> fn) -> void {
-    SchedulerFeature::SCHEDULER->queue(RequestLane::INTERNAL_LOW, fn);
+  auto poster = [](std::function<void()> fn) -> bool {
+    return SchedulerFeature::SCHEDULER->queue(RequestLane::INTERNAL_LOW, fn);
   };
   auto queue = std::make_shared<arangodb::basics::LocalTaskQueue>(poster);
 

--- a/arangod/Scheduler/SupervisedScheduler.h
+++ b/arangod/Scheduler/SupervisedScheduler.h
@@ -43,7 +43,7 @@ class SupervisedScheduler final : public Scheduler {
                       uint64_t fifo1Size, uint64_t fifo2Size);
   virtual ~SupervisedScheduler();
 
-  bool queue(RequestLane lane, std::function<void()>, bool allowDirectHandling = false) override;
+  bool queue(RequestLane lane, std::function<void()>, bool allowDirectHandling = false) override ADB_WARN_UNUSED_RESULT;
 
  private:
   std::atomic<size_t> _numWorkers;

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -727,12 +727,13 @@ Result Collections::warmup(TRI_vocbase_t& vocbase, LogicalCollection const& coll
     return res;
   }
 
-  auto idxs = coll.getIndexes();
-  auto poster = [](std::function<void()> fn) -> void {
-    SchedulerFeature::SCHEDULER->queue(RequestLane::INTERNAL_LOW, fn);
+  auto poster = [](std::function<void()> fn) -> bool {
+    return SchedulerFeature::SCHEDULER->queue(RequestLane::INTERNAL_LOW, fn);
   };
+  
   auto queue = std::make_shared<basics::LocalTaskQueue>(poster);
 
+  auto idxs = coll.getIndexes();
   for (auto& idx : idxs) {
     idx->warmup(&trx, queue);
   }

--- a/lib/Basics/LocalTaskQueue.h
+++ b/lib/Basics/LocalTaskQueue.h
@@ -87,7 +87,7 @@ class LocalCallbackTask : public std::enable_shared_from_this<LocalCallbackTask>
 
 class LocalTaskQueue {
  public:
-  typedef std::function<void(std::function<void()>)> PostFn;
+  typedef std::function<bool(std::function<void()>)> PostFn;
 
   LocalTaskQueue() = delete;
   LocalTaskQueue(LocalTaskQueue const&) = delete;
@@ -118,7 +118,7 @@ class LocalTaskQueue {
   /// by task dispatch.
   //////////////////////////////////////////////////////////////////////////////
 
-  void post(std::function<void()> fn);
+  void post(std::function<bool()> fn);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief join a single task. reduces the number of waiting tasks and wakes

--- a/lib/SimpleHttpClient/Callbacks.h
+++ b/lib/SimpleHttpClient/Callbacks.h
@@ -36,7 +36,7 @@ class Callbacks {
 
   typedef std::function<void(std::unique_ptr<GeneralResponse>)> OnSuccessCallback;
 
-  typedef std::function<void(std::function<void()>)> ScheduleMeCallback;
+  typedef std::function<bool(std::function<void()> const&)> ScheduleMeCallback;
 
   Callbacks() {}
   Callbacks(OnSuccessCallback const& onSuccess, OnErrorCallback const& onError)
@@ -51,7 +51,10 @@ class Callbacks {
   ScheduleMeCallback _scheduleMe;
 
  protected:
-  static void defaultScheduleMe(std::function<void()> task) { task(); }
+  static bool defaultScheduleMe(std::function<void()> const& task) { 
+    task(); 
+    return true; 
+  }
 };
 }  // namespace communicator
 }  // namespace arangodb

--- a/tests/Mocks/StorageEngineMock.cpp
+++ b/tests/Mocks/StorageEngineMock.cpp
@@ -497,8 +497,9 @@ std::shared_ptr<arangodb::Index> PhysicalCollectionMock::createIndex(
   }
 
   asio_ns::io_context ioContext;
-  auto poster = [&ioContext](std::function<void()> fn) -> void {
+  auto poster = [&ioContext](std::function<void()> fn) -> bool {
     ioContext.post(fn);
+    return true;
   };
   arangodb::basics::LocalTaskQueue taskQueue(poster);
   std::shared_ptr<arangodb::basics::LocalTaskQueue> taskQueuePtr(


### PR DESCRIPTION
### Scope & Purpose

Fix return value check for Scheduler::queue() and derived method

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/300

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it): compilation works on Linux without raising warnings
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *compilation*.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/5935/