### PR TITLE
fix return value when reboot id cannot be retrieved

### DIFF
--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -340,8 +340,7 @@ bool ServerState::unregister() {
   return r.successful();
 }
 
-ResultT<uint64_t> ServerState::readRebootIdFromAgency(AgencyComm& comm)
-{
+ResultT<uint64_t> ServerState::readRebootIdFromAgency(AgencyComm& comm) {
   TRI_ASSERT(!_id.empty());
   std::string rebootIdPath = "Current/ServersKnown/" + _id + "/rebootId";
   AgencyCommResult result = comm.getValues(rebootIdPath);
@@ -350,7 +349,7 @@ ResultT<uint64_t> ServerState::readRebootIdFromAgency(AgencyComm& comm)
     LOG_TOPIC("762ed", WARN, Logger::CLUSTER)
       << "Could not read back " << rebootIdPath;
 
-    ResultT<uint64_t>::error(TRI_ERROR_INTERNAL, "could not read rebootId from agency");
+    return ResultT<uint64_t>::error(TRI_ERROR_INTERNAL, "could not read rebootId from agency");
   }
 
   auto slicePath = AgencyCommManager::slicePath(rebootIdPath);


### PR DESCRIPTION
### Scope & Purpose

Fix handling of return value when reboot id cannot be retrieved from the agency

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/5946/