### PR TITLE
Bug fix 3.4/fix smart graph issues

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+v3.4.9 (XXXX-XX-XX)
+-------------------
+
+* Fixed output of `_listObjects()` function of "general-graph" and "smart-graph" 
+  modules, which did not print the `_id` values of the return graphs correctly
+
+* Fixed undefined behavior in single server mode when trying to create a smart 
+  graph.
+
+
 v3.4.8 (2019-08-29)
 -------------------
 

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -31,11 +31,13 @@
 
 #include "Agency/AgentCallback.h"
 #include "Agency/GossipCallback.h"
+#include "Agency/AgencyFeature.h"
 #include "Basics/ConditionLocker.h"
 #include "Basics/ReadLocker.h"
 #include "Basics/WriteLocker.h"
 #include "RestServer/QueryRegistryFeature.h"
 #include "RestServer/SystemDatabaseFeature.h"
+#include "Scheduler/SchedulerFeature.h"
 #include "VocBase/vocbase.h"
 
 using namespace arangodb::application_features;
@@ -1960,10 +1962,19 @@ void Agent::emptyCbTrashBin() {
     _callbackLastPurged = std::chrono::steady_clock::now();
   }
 
-  LOG_TOPIC(DEBUG, Logger::AGENCY) << "unobserving: " << envelope->toJson();
-
-  // Best effort. Will be retried anyway
-  auto wres = write(envelope);
+  // Best effort. Will be retried otherwise.
+  LOG_TOPIC(DEBUG, Logger::AGENCY) << "scheduling unobserve: " << envelope->toJson();
+  auto* scheduler = SchedulerFeature::SCHEDULER;
+  
+  if (scheduler != nullptr) {
+    scheduler->queue(
+      RequestPriority::LOW, [envelope](bool) {
+                              auto* agent = AgencyFeature::AGENT;
+                              if (!application_features::ApplicationServer::isStopping() && agent) {
+                                agent->write(envelope);
+                              }
+                            });
+  }
 
 }
 

--- a/arangod/V8Server/v8-general-graph.cpp
+++ b/arangod/V8Server/v8-general-graph.cpp
@@ -170,6 +170,7 @@ static void JS_GetGraph(v8::FunctionCallbackInfo<v8::Value> const& args) {
   result.close();
   VPackSlice resSlice = result.slice().get("graph");
 
+
   TRI_V8_RETURN(TRI_VPackToV8(isolate, resSlice));
   TRI_V8_TRY_CATCH_END
 }
@@ -189,7 +190,8 @@ static void JS_GetGraphs(v8::FunctionCallbackInfo<v8::Value> const& args) {
   }
 
   if (!result.isEmpty()) {
-    TRI_V8_RETURN(TRI_VPackToV8(isolate, result.slice().get("graphs")));
+    auto ctx = std::make_shared<transaction::StandaloneContext>(vocbase);
+    TRI_V8_RETURN(TRI_VPackToV8(isolate, result.slice().get("graphs"), ctx->getVPackOptionsForDump()));
   }
 
   TRI_V8_RETURN_UNDEFINED();


### PR DESCRIPTION
### Scope & Purpose

Fixed undefined behavior when creating a smart graph in single server
Fixed output of `require("@arangodb/{smart|general}-graph")._listObjects()` function, which did not return the `_id` value of graphs correctly

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/303

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/5953/