### PR TITLE
don't issue a warning when transaction log iterator reports more data

### DIFF
--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
@@ -498,9 +498,10 @@ Result catchup(RocksDBIndex& ridx, WriteBatchType& wb, AccessMode::Type mode,
   }
 
   s = iterator->status();
-  // we can ignore it if we get a try again when we have exclusive access,
-  // because that indicates a write to another collection
-  if (!s.ok() && res.ok() && !(haveExclusiveAccess && s.IsTryAgain())) {
+  // we can ignore it if we get a try again return value, because that either
+  // indicates a write to another collection, or a write to this collection if
+  // we are not in exclusive mode, in which case we will call catchup again
+  if (!s.ok() && res.ok() && !s.IsTryAgain()) {
     LOG_TOPIC("8e3a4", WARN, Logger::ENGINES) << "iterator error '" <<
       s.ToString() << "'";
     res = rocksutils::convertStatus(s);


### PR DESCRIPTION
### Scope & Purpose

Don't issue a warning when the RocksDB transaction log iterator indicates more data (TryAgain).

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *background indexing tests*.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/5973/