### PR TITLE
Bugfix 3.4: Calculate Write Amplification / Flag to disable StatisticsWorker

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+v3.4.9 (xxxx-xx-xx)
+-------------------
+* add --server.statistics-history flag to allow disable of only the historical
+  statistics.  Also added rocksdbengine.write.amplification.x100 statistics
+  for measurement of compaction option impact.  Enabled non-historical
+  statistics for agents.
+
 v3.4.8 (2019-08-29)
 -------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 v3.4.9 (xxxx-xx-xx)
 -------------------
-* add --server.statistics-history flag to allow disable of only the historical
+* add --server.statistics-history flag to allow disabling of only the historical
   statistics.  Also added rocksdbengine.write.amplification.x100 statistics
   for measurement of compaction option impact.  Enabled non-historical
   statistics for agents.

--- a/arangod/Agency/AgencyFeature.cpp
+++ b/arangod/Agency/AgencyFeature.cpp
@@ -233,11 +233,10 @@ void AgencyFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
   //   the selected storage engine
   // - ArangoSearch: not needed by agency even if MMFiles is the selected
   //   storage engine
-  // - Statistics: turn off statistics gathering for agency
   // - Action/Script/FoxxQueues/Frontend: Foxx and JavaScript APIs
 
   std::vector<std::string> disabledFeatures(
-      {"MMFilesPersistentIndex", "ArangoSearch", "Statistics", "Action",
+      {"MMFilesPersistentIndex", "ArangoSearch", "Action",
        "Script", "FoxxQueues", "Frontend"});
   if (!result.touched("console") || !*(options->get<BooleanParameter>("console")->ptr)) {
     // specifiying --console requires JavaScript, so we can only turn it off

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -31,11 +31,13 @@
 
 #include "Agency/AgentCallback.h"
 #include "Agency/GossipCallback.h"
+#include "Agency/AgencyFeature.h"
 #include "Basics/ConditionLocker.h"
 #include "Basics/ReadLocker.h"
 #include "Basics/WriteLocker.h"
 #include "RestServer/QueryRegistryFeature.h"
 #include "RestServer/SystemDatabaseFeature.h"
+#include "Scheduler/SchedulerFeature.h"
 #include "VocBase/vocbase.h"
 
 using namespace arangodb::application_features;
@@ -1960,10 +1962,19 @@ void Agent::emptyCbTrashBin() {
     _callbackLastPurged = std::chrono::steady_clock::now();
   }
 
-  LOG_TOPIC(DEBUG, Logger::AGENCY) << "unobserving: " << envelope->toJson();
-
-  // Best effort. Will be retried anyway
-  auto wres = write(envelope);
+  // Best effort. Will be retried otherwise.
+  LOG_TOPIC(DEBUG, Logger::AGENCY) << "scheduling unobserve: " << envelope->toJson();
+  auto* scheduler = SchedulerFeature::SCHEDULER;
+  
+  if (scheduler != nullptr) {
+    scheduler->queue(
+      RequestPriority::LOW, [envelope](bool) {
+                              auto* agent = AgencyFeature::AGENT;
+                              if (!application_features::ApplicationServer::isStopping() && agent) {
+                                agent->write(envelope);
+                              }
+                            });
+  }
 
 }
 

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2229,13 +2229,13 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
       builder.add(stat.second, VPackValue(_options.statistics->getTickerCount(stat.first)));
     }
 
-    uint64_t wal_write, flush_write, compaction_write, user_write;
-    wal_write = _options.statistics->getTickerCount(rocksdb::WAL_FILE_BYTES);
-    flush_write = _options.statistics->getTickerCount(rocksdb::FLUSH_WRITE_BYTES);
-    compaction_write = _options.statistics->getTickerCount(rocksdb::COMPACT_WRITE_BYTES);
-    user_write = _options.statistics->getTickerCount(rocksdb::BYTES_WRITTEN);
+    uint64_t walWrite, flushWrite, compactionWrite, userWrite;
+    walWrite = _options.statistics->getTickerCount(rocksdb::WAL_FILE_BYTES);
+    flushWrite = _options.statistics->getTickerCount(rocksdb::FLUSH_WRITE_BYTES);
+    compactionWrite = _options.statistics->getTickerCount(rocksdb::COMPACT_WRITE_BYTES);
+    userWrite = _options.statistics->getTickerCount(rocksdb::BYTES_WRITTEN);
     builder.add("rocksdbengine.write.amplification.x100",
-                VPackValue( (0 != user_write) ? ((wal_write+flush_write+compaction_write)*100)/user_write : 100));
+                VPackValue( (0 != userWrite) ? ((walWrite+flushWrite+compactionWrite)*100)/userWrite : 100));
   }
 
   cache::Manager* manager = CacheManagerFeature::MANAGER;

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2228,6 +2228,14 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
     for (auto const& stat : rocksdb::TickersNameMap) {
       builder.add(stat.second, VPackValue(_options.statistics->getTickerCount(stat.first)));
     }
+
+    uint64_t wal_write, flush_write, compaction_write, user_write;
+    wal_write = _options.statistics->getTickerCount(rocksdb::WAL_FILE_BYTES);
+    flush_write = _options.statistics->getTickerCount(rocksdb::FLUSH_WRITE_BYTES);
+    compaction_write = _options.statistics->getTickerCount(rocksdb::COMPACT_WRITE_BYTES);
+    user_write = _options.statistics->getTickerCount(rocksdb::BYTES_WRITTEN);
+    builder.add("rocksdbengine.write.amplification.x100",
+                VPackValue( (0 != user_write) ? ((wal_write+flush_write+compaction_write)*100)/user_write : 100));
   }
 
   cache::Manager* manager = CacheManagerFeature::MANAGER;

--- a/arangod/Statistics/StatisticsFeature.h
+++ b/arangod/Statistics/StatisticsFeature.h
@@ -86,6 +86,7 @@ class StatisticsFeature final : public application_features::ApplicationFeature 
  private:
   bool _statistics;
   bool _statisticsHistory;
+  bool _statisticsHistoryTouched;
 
   std::unique_ptr<stats::Descriptions> _descriptions;
   std::unique_ptr<StatisticsThread> _statisticsThread;

--- a/arangod/Statistics/StatisticsFeature.h
+++ b/arangod/Statistics/StatisticsFeature.h
@@ -85,6 +85,7 @@ class StatisticsFeature final : public application_features::ApplicationFeature 
 
  private:
   bool _statistics;
+  bool _statisticsHistory;
 
   std::unique_ptr<stats::Descriptions> _descriptions;
   std::unique_ptr<StatisticsThread> _statisticsThread;


### PR DESCRIPTION
This PR adds two independent changes, and a related Agency change:

- rocksdb Write Amplification is now calculated and reported with existing rocksdb statistics.  This is essential for judging impact of compactions (and changes to compaction options).

- StatisticsWorker has demonstrated a tendency to cause increased compactions which heavily impact throughput.  The new --server.statistics-history option allows just the StatisticsWorker portion of statistics to be disabled.  

- statistics are now active for Agency.  Previously AgencyFeature.cpp completely disabled statistics for an agent daemon.  The disabling code is removed.  StatisticsFeature.cpp now notices if the daemon is for an agent and automatically disables statistics-history to avoid current performance issues.