### PR TITLE
avoid lookup plus sequent insert/emplace for the fast path

### DIFF
--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -244,19 +244,19 @@ void Manager::registerAQLTrx(TransactionState* state) {
   }
 
   TRI_ASSERT(state != nullptr);
-  const size_t bucket = getBucket(state->id());
+  auto const tid = state->id();
+  size_t const bucket = getBucket(tid);
   {
     READ_LOCKER(allTransactionsLocker, _allTransactionsLock);
     WRITE_LOCKER(writeLocker, _transactions[bucket]._lock);
 
-    auto const id = state->id();
     auto& buck = _transactions[bucket];
-    auto it = buck._managed.find(id);
+    auto it = buck._managed.find(tid);
     if (it != buck._managed.end()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_TRANSACTION_INTERNAL,
-                                     std::string("transaction ID ") + std::to_string(id) + "' already used in registerAQLTrx");
+                                     std::string("transaction ID ") + std::to_string(tid) + "' already used in registerAQLTrx");
     }
-    buck._managed.emplace(std::piecewise_construct, std::forward_as_tuple(id),
+    buck._managed.emplace(std::piecewise_construct, std::forward_as_tuple(tid),
                           std::forward_as_tuple(MetaType::StandaloneAQL, state));
   }
 }

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -249,13 +249,14 @@ void Manager::registerAQLTrx(TransactionState* state) {
     READ_LOCKER(allTransactionsLocker, _allTransactionsLock);
     WRITE_LOCKER(writeLocker, _transactions[bucket]._lock);
 
+    auto const id = state->id();
     auto& buck = _transactions[bucket];
-    auto it = buck._managed.find(state->id());
+    auto it = buck._managed.find(id);
     if (it != buck._managed.end()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_TRANSACTION_INTERNAL,
-                                     "transaction ID already used");
+                                     std::string("transaction ID ") + std::to_string(id) + "' already used in registerAQLTrx");
     }
-    buck._managed.emplace(std::piecewise_construct, std::forward_as_tuple(state->id()),
+    buck._managed.emplace(std::piecewise_construct, std::forward_as_tuple(id),
                           std::forward_as_tuple(MetaType::StandaloneAQL, state));
   }
 }
@@ -358,7 +359,7 @@ Result Manager::createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,
     auto it = buck._managed.find(tid);
     if (it != buck._managed.end()) {
       return res.reset(TRI_ERROR_TRANSACTION_INTERNAL,
-                       "transaction ID already used");
+                       std::string("transaction ID '") + std::to_string(tid) + "' already used in createManagedTrx lookup");
     }
   }
 
@@ -430,7 +431,7 @@ Result Manager::createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,
     auto it = _transactions[bucket]._managed.find(tid);
     if (it != _transactions[bucket]._managed.end()) {
       return res.reset(TRI_ERROR_TRANSACTION_INTERNAL,
-                       "transaction ID already used");
+                       std::string("transaction ID '") + std::to_string(tid) + "' already used in createManagedTrx insert");
     }
     TRI_ASSERT(state->id() == tid);
     _transactions[bucket]._managed.emplace(std::piecewise_construct,

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -236,27 +236,25 @@ Manager::ManagedTrx::~ManagedTrx() {
 using namespace arangodb;
 
 /// @brief register a transaction shard
-/// @brief tid global transaction shard
-/// @param cid the optional transaction ID (use 0 for a single shard trx)
 void Manager::registerAQLTrx(TransactionState* state) {
   if (_disallowInserts.load(std::memory_order_acquire)) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
   }
 
   TRI_ASSERT(state != nullptr);
-  const size_t bucket = getBucket(state->id());
+  auto const id = state->id();
+  size_t const bucket = getBucket(id);
   {
     READ_LOCKER(allTransactionsLocker, _allTransactionsLock);
     WRITE_LOCKER(writeLocker, _transactions[bucket]._lock);
 
     auto& buck = _transactions[bucket];
-    auto it = buck._managed.find(state->id());
-    if (it != buck._managed.end()) {
+    if (!buck._managed.emplace(std::piecewise_construct, std::forward_as_tuple(id),
+                               std::forward_as_tuple(MetaType::StandaloneAQL, state)).second) {
+      // if insertion fails because of a duplicate key, bail out!
       THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_TRANSACTION_INTERNAL,
-                                     "transaction ID already used");
+                                     std::string("transaction ID '") + std::to_string(id) + "' already used in registerAQLTrx");
     }
-    buck._managed.emplace(std::piecewise_construct, std::forward_as_tuple(state->id()),
-                          std::forward_as_tuple(MetaType::StandaloneAQL, state));
   }
 }
 
@@ -358,7 +356,7 @@ Result Manager::createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,
     auto it = buck._managed.find(tid);
     if (it != buck._managed.end()) {
       return res.reset(TRI_ERROR_TRANSACTION_INTERNAL,
-                       "transaction ID already used");
+                       std::string("transaction ID '") + std::to_string(tid) + "' already used in createManagedTrx check");
     }
   }
 
@@ -424,19 +422,20 @@ Result Manager::createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,
     return res;
   }
 
+  TRI_ASSERT(state->id() == tid);
+
   {  // add transaction to bucket
     READ_LOCKER(allTransactionsLocker, _allTransactionsLock);
     WRITE_LOCKER(writeLocker, _transactions[bucket]._lock);
-    auto it = _transactions[bucket]._managed.find(tid);
-    if (it != _transactions[bucket]._managed.end()) {
+    
+    if (!_transactions[bucket]._managed.emplace(std::piecewise_construct,
+                                                std::forward_as_tuple(tid),
+                                                std::forward_as_tuple(MetaType::Managed,
+                                                                      state.release())).second) {
+      // transaction with the same ID already present
       return res.reset(TRI_ERROR_TRANSACTION_INTERNAL,
-                       "transaction ID already used");
+                       std::string("transaction ID ") + std::to_string(tid) + "' already used in createManagedTrx insert");
     }
-    TRI_ASSERT(state->id() == tid);
-    _transactions[bucket]._managed.emplace(std::piecewise_construct,
-                                           std::forward_as_tuple(tid),
-                                           std::forward_as_tuple(MetaType::Managed,
-                                                                 state.release()));
   }
 
   LOG_TOPIC("d6806", DEBUG, Logger::TRANSACTIONS) << "created managed trx '" << tid << "'";


### PR DESCRIPTION
### Scope & Purpose

Avoid seperate lookup plus follow-up insert/emplace operations for transactions.
Additionally add the transaction id and more location information to error messages which were previously undistinguishable.

@graetzer: I don't know the reason why previously we had seperated the find from the following emplace operation. Maybe the transaction object must not be created if it already exists in the map. 
In this case my PR will cause damage. Can you please double-check?

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *cluster transaction tests*.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6034/