### PR TITLE
make smart graphs transaction-aware

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 v3.5.1 (XXXX-XX-XX)
 -------------------
+
 * Fixed internal issue #633: made ArangoSearch functions BOOST, ANALYZER, MIN_MATCH
   callable with constant arguments. This will allow running queries where all arguments
   for these functions are deterministic and do not depend on loop variables.

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -178,7 +178,7 @@ RestStatus RestIndexHandler::getSelectivityEstimates() {
     return RestStatus::DONE;
   }
 
-  // transaction protects acces onto selectivity estimates
+  // transaction protects access onto selectivity estimates
   auto trx = createTransaction(cName, AccessMode::Type::READ);
 
   Result res = trx->begin();

--- a/arangod/RestHandler/RestVocbaseBaseHandler.cpp
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.cpp
@@ -579,7 +579,7 @@ std::unique_ptr<SingleCollectionTransaction> RestVocbaseBaseHandler::createTrans
     auto ctx = mgr->leaseManagedTrx(tid, type);
     if (!ctx) {
       LOG_TOPIC("e94ea", DEBUG, Logger::TRANSACTIONS) << "Transaction with id '" << tid << "' not found";
-      THROW_ARANGO_EXCEPTION(TRI_ERROR_TRANSACTION_NOT_FOUND);
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_TRANSACTION_NOT_FOUND, std::string("transaction '") + std::to_string(tid) + "' not found");
     }
     return std::make_unique<SingleCollectionTransaction>(ctx, collectionName, type);
   } else {
@@ -632,7 +632,7 @@ std::shared_ptr<transaction::Context> RestVocbaseBaseHandler::createTransactionC
   auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE);
   if (!ctx) {
     LOG_TOPIC("2cfed", DEBUG, Logger::TRANSACTIONS) << "Transaction with id '" << tid << "' not found";
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_TRANSACTION_NOT_FOUND);
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_TRANSACTION_NOT_FOUND, std::string("transaction '") + std::to_string(tid) + "' not found");
   }
   return ctx;
 }

--- a/arangod/StorageEngine/TransactionState.h
+++ b/arangod/StorageEngine/TransactionState.h
@@ -55,12 +55,10 @@ struct TRI_vocbase_t;
 namespace arangodb {
 
 namespace transaction {
-class Context;
 class Methods;
 struct Options;
 }  // namespace transaction
 
-class ExecContext;
 class TransactionCollection;
 
 /// @brief transaction type

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -40,6 +40,10 @@
 #include "Utils/CollectionNameResolver.h"
 #include "Utils/ExecContext.h"
 
+#ifdef USE_ENTERPRISE
+#include "Enterprise/VocBase/VirtualCollection.h"
+#endif
+
 #include <velocypack/Iterator.h>
 #include <velocypack/velocypack-aliases.h>
 
@@ -304,7 +308,7 @@ Result Manager::createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,
   }
 
   auto fillColls = [](VPackSlice const& slice, std::vector<std::string>& cols) {
-    if (slice.isNone()) {  // ignore nonexistant keys
+    if (slice.isNone()) {  // ignore nonexistent keys
       return true;
     } else if (slice.isString()) {
       cols.emplace_back(slice.copyString());
@@ -391,6 +395,29 @@ Result Manager::createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,
                   std::string(TRI_errno_string(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND)) +
                       ":" + cname);
       } else {
+#ifdef USE_ENTERPRISE
+        std::shared_ptr<LogicalCollection> col = resolver.getCollection(cname);
+        if (col->isSmart() && col->type() == TRI_COL_TYPE_EDGE) {
+          if (state->isCoordinator()) {
+            auto theEdge = dynamic_cast<arangodb::VirtualSmartEdgeCollection*>(col.get());
+            if (theEdge == nullptr) {
+              THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "cannot cast collection to smart edge collection");
+            }
+            res.reset(state->addCollection(theEdge->getLocalCid(), "_local_" + cname, mode, /*nestingLevel*/ 0, false));
+            if (res.fail()) {
+              return false;
+            }
+            res.reset(state->addCollection(theEdge->getFromCid(), "_from_" + cname, mode, /*nestingLevel*/ 0, false));
+            if (res.fail()) {
+              return false;
+            }
+            res.reset(state->addCollection(theEdge->getToCid(), "_to_" + cname, mode, /*nestingLevel*/ 0, false));
+            if (res.fail()) {
+              return false;
+            }
+          }
+        }
+#endif
         res.reset(state->addCollection(cid, cname, mode, /*nestingLevel*/ 0, false));
       }
 

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -396,9 +396,9 @@ Result Manager::createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,
                       ":" + cname);
       } else {
 #ifdef USE_ENTERPRISE
-        std::shared_ptr<LogicalCollection> col = resolver.getCollection(cname);
-        if (col->isSmart() && col->type() == TRI_COL_TYPE_EDGE) {
-          if (state->isCoordinator()) {
+        if (state->isCoordinator()) {
+          std::shared_ptr<LogicalCollection> col = resolver.getCollection(cname);
+          if (col->isSmart() && col->type() == TRI_COL_TYPE_EDGE) {
             auto theEdge = dynamic_cast<arangodb::VirtualSmartEdgeCollection*>(col.get());
             if (theEdge == nullptr) {
               THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "cannot cast collection to smart edge collection");
@@ -619,14 +619,14 @@ Result Manager::updateTransaction(TRI_voc_tid_t tid, transaction::Status status,
     auto& buck = _transactions[bucket];
     auto it = buck._managed.find(tid);
     if (it == buck._managed.end() || !::authorized(it->second.user)) {
-      return res.reset(TRI_ERROR_TRANSACTION_NOT_FOUND);
+      return res.reset(TRI_ERROR_TRANSACTION_NOT_FOUND, std::string("transaction '") + std::to_string(tid) + "' not found");
     }
 
     ManagedTrx& mtrx = it->second;
     TRY_WRITE_LOCKER(tryGuard, mtrx.rwlock);
     if (!tryGuard.isLocked()) {
       return res.reset(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION,
-                       "transaction is in use");
+                       std::string("transaction '") + std::to_string(tid) + "' is in use");
     }
 
     if (mtrx.type == MetaType::StandaloneAQL) {


### PR DESCRIPTION
### Scope & Purpose

Make smart graphs transaction-aware too.
Enterprise companion PR: https://github.com/arangodb/enterprise/pull/308

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/6053/