### PR TITLE
Automatically convert log startup options

### DIFF
--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -222,6 +222,21 @@ void LoggerFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
         << "cannot combine `--log.time-format` with either `--log.use-microtime` or `--log.use-local-time`";
     FATAL_ERROR_EXIT();
   }
+       
+  // convert the deprecated options into the new timeformat
+  if (options->processingResult().touched("log.use-local-time")) {
+    _timeFormatString = "local-datestring";
+    // the following call ensures the string is actually valid.
+    // if not valid, the following call will throw an exception and
+    // abort the startup
+    LogTimeFormats::formatFromName(_timeFormatString);
+  } else if (options->processingResult().touched("log.use-microtime")) {
+    _timeFormatString = "timestamp-micros";
+    // the following call ensures the string is actually valid.
+    // if not valid, the following call will throw an exception and
+    // abort the startup
+    LogTimeFormats::formatFromName(_timeFormatString);
+  }
 
   if (!_fileMode.empty()) {
     try {


### PR DESCRIPTION
### Scope & Purpose

Automatically turn values for deprecated startup option parameters  `--log.use-microtime` and `--log.use-local-time` into equivalent option values of the new, preferred option `--log.time-format`.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/6058/