### PR TITLE
drop views on test teardown

### DIFF
--- a/lib/SimpleHttpClient/Communicator.cpp
+++ b/lib/SimpleHttpClient/Communicator.cpp
@@ -112,31 +112,46 @@ static int dumb_socketpair(SOCKET socks[2], int make_overlapped) {
 
   for (;;) {
     if (setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, (char*)&reuse,
-                   (socklen_t)sizeof(reuse)) == -1)
+                   (socklen_t)sizeof(reuse)) == -1) {
       break;
-    if (bind(listener, &a.addr, sizeof(a.inaddr)) == SOCKET_ERROR) break;
+    }
+    if (bind(listener, &a.addr, sizeof(a.inaddr)) == SOCKET_ERROR) {
+      break;
+    }
 
     memset(&a, 0, sizeof(a));
-    if (getsockname(listener, &a.addr, &addrlen) == SOCKET_ERROR) break;
+    if (getsockname(listener, &a.addr, &addrlen) == SOCKET_ERROR) {
+      break;
+    }
     // win32 getsockname may only set the port number, p=0.0005.
     // ( http://msdn.microsoft.com/library/ms738543.aspx ):
     a.inaddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
     a.inaddr.sin_family = AF_INET;
 
-    if (listen(listener, 1) == SOCKET_ERROR) break;
+    if (listen(listener, 1) == SOCKET_ERROR) {
+      break;
+    }
 
     socks[0] = WSASocketW(AF_INET, SOCK_STREAM, 0, NULL, 0, flags);
-    if (socks[0] == -1) break;
-    if (connect(socks[0], &a.addr, sizeof(a.inaddr)) == SOCKET_ERROR) break;
+    if (socks[0] == -1) {
+      break;
+    }
+    if (connect(socks[0], &a.addr, sizeof(a.inaddr)) == SOCKET_ERROR) {
+      break;
+    }
 
     socks[1] = accept(listener, NULL, NULL);
-    if (socks[1] == -1) break;
+    if (socks[1] == -1) {
+      break;
+    }
 
     closesocket(listener);
 
     u_long mode = 1;
     int res = ioctlsocket(socks[0], FIONBIO, &mode);
-    if (res != NO_ERROR) break;
+    if (res != NO_ERROR) {
+      break;
+    }
 
     return 0;
   }

--- a/lib/V8/v8-utils.cpp
+++ b/lib/V8/v8-utils.cpp
@@ -4494,7 +4494,7 @@ static void JS_ExecuteAndWaitExternal(v8::FunctionCallbackInfo<v8::Value> const&
   // extract the arguments
   if (5 < args.Length() || args.Length() < 1) {
     TRI_V8_THROW_EXCEPTION_USAGE(
-        "executeAndWaitExternal(<filename>[, <arguments> [,<usePipes>, [, <timoutms> [,<env>] ] ] ])");
+        "executeExternalAndWait(<filename>[, <arguments> [,<usePipes>, [, <timeoutms> [, <env>] ] ] ])");
   }
 
   TRI_Utf8ValueNFC name(isolate, args[0]);

--- a/tests/js/server/replication/ongoing/replication-ongoing.js
+++ b/tests/js/server/replication/ongoing/replication-ongoing.js
@@ -1342,6 +1342,7 @@ function ReplicationSuite () {
 
       db._dropView('UnitTestsSyncView');
       db._dropView('UnitTestsSyncViewRenamed');
+      db._dropView(cn + 'View');
       db._drop(cn);
       db._drop(cn2);
 
@@ -1351,6 +1352,7 @@ function ReplicationSuite () {
 
       db._dropView('UnitTestsSyncView');
       db._dropView('UnitTestsSyncViewRenamed');
+      db._dropView(cn + 'View');
       db._drop(cn);
       db._drop(cn2);
       db._drop(cn + 'Renamed');

--- a/tests/js/server/replication/static/replication-static.js
+++ b/tests/js/server/replication/static/replication-static.js
@@ -2228,6 +2228,7 @@ function ReplicationSuite () {
       db._drop(cn);
       db._drop(cn2);
       db._drop(systemCn, { isSystem: true });
+      db._dropView("UnitTestsSyncView");
 
       connectToSlave();
       replication.applier.stop();
@@ -2235,6 +2236,7 @@ function ReplicationSuite () {
       db._drop(cn);
       db._drop(cn2);
       db._drop(systemCn, { isSystem: true });
+      db._dropView("UnitTestsSyncView");
     }
   };
   deriveTestSuite(BaseTestConfig(), suite, '_Repl');

--- a/tests/js/server/replication/sync/replication-sync.js
+++ b/tests/js/server/replication/sync/replication-sync.js
@@ -1765,6 +1765,9 @@ function ReplicationSuite () {
       db._drop(sysCn, {isSystem: true});
 
       connectToSlave();
+      try {
+        db._dropView(cn + 'View');
+      } catch (ignored) {}
       db._drop(cn);
       db._drop(sysCn, {isSystem: true});
     }


### PR DESCRIPTION
#### Scope & Purpose

Clean up views in tests that forgot to.
Also set up the views in tests that require them, so that individual tests don't implicitly depend on their predecessors.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *the tests changed by this PR*.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6074/