### PR TITLE
Cleanup ServerState.cpp

### DIFF
--- a/arangod/Agency/AgencyStrings.h
+++ b/arangod/Agency/AgencyStrings.h
@@ -21,6 +21,9 @@
 /// @author Kaveh Vahedipour
 ////////////////////////////////////////////////////////////////////////////////
 
+#if !defined(ARANGOD_AGENCY_AGENCY_STRINGS_H)
+#define ARANGOD_AGENCY_AGENCY_STRINGS_H
+
 #include <string>
 
 namespace arangodb {
@@ -45,3 +48,5 @@ constexpr char const* TARGET_HOTBACKUP = "Target/HotBackup";
 
 }  // namespace consensus
 }  // namespace arangodb
+
+#endif

--- a/arangod/Agency/AgencyStrings.h
+++ b/arangod/Agency/AgencyStrings.h
@@ -21,7 +21,7 @@
 /// @author Kaveh Vahedipour
 ////////////////////////////////////////////////////////////////////////////////
 
-#if !defined(ARANGOD_AGENCY_AGENCY_STRINGS_H)
+#ifndef ARANGOD_AGENCY_AGENCY_STRINGS_H
 #define ARANGOD_AGENCY_AGENCY_STRINGS_H
 
 #include <string>

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -454,8 +454,8 @@ bool ServerState::integrateIntoCluster(ServerState::RoleEnum role,
         auto it2 = endpoints.emplace(endpointSlice.copyString(), serverId);
         if (!it2.second && it2.first->first != serverId) {
           // duplicate entry!
-          LOG_TOPIC("9a134", WARN, Logger::CLUSTER) 
-            << "found duplicate server entry for endpoint '" 
+          LOG_TOPIC("9a134", WARN, Logger::CLUSTER)
+            << "found duplicate server entry for endpoint '"
             << endpointSlice.copyString() << "', already used by other server " << it2.first->second
             << ". it looks like this is a (mis)configuration issue";
           // anyway, continue with startup
@@ -466,7 +466,7 @@ bool ServerState::integrateIntoCluster(ServerState::RoleEnum role,
 
   return true;
 }
-        
+
 /// @brief whether or not "value" is a server UUID
 bool ServerState::isUuid(std::string const& value) const {
   // whenever the format of the generated UUIDs changes, please make sure to
@@ -629,9 +629,9 @@ bool ServerState::registerAtAgencyPhase1(AgencyComm& comm, ServerState::RoleEnum
   // ok to fail..if it failed we are already registered
   AgencyCommResult pregResult = comm.sendTransactionWithFailover(preg, 0.0);
   if (!pregResult.successful()) {
-    LOG_TOPIC("cd1d0", TRACE, Logger::CLUSTER) 
-      << "unable to initially register in agency. " 
-      << pregResult.errorMessage(); 
+    LOG_TOPIC("cd1d0", TRACE, Logger::CLUSTER)
+      << "unable to initially register in agency. "
+      << pregResult.errorMessage();
   }
 
   AgencyWriteTransaction creg(
@@ -641,9 +641,9 @@ bool ServerState::registerAtAgencyPhase1(AgencyComm& comm, ServerState::RoleEnum
   // ok to fail..if it failed we are already registered
   AgencyCommResult cregResult = comm.sendTransactionWithFailover(creg, 0.0);
   if (!cregResult.successful()) {
-    LOG_TOPIC("fe96a", TRACE, Logger::CLUSTER) 
-      << "unable to initially register in agency. " 
-      << cregResult.errorMessage(); 
+    LOG_TOPIC("fe96a", TRACE, Logger::CLUSTER)
+      << "unable to initially register in agency. "
+      << cregResult.errorMessage();
   }
 
   // coordinator is already/still registered from an previous unclean shutdown;
@@ -739,10 +739,10 @@ bool ServerState::registerAtAgencyPhase1(AgencyComm& comm, ServerState::RoleEnum
 
 bool ServerState::registerAtAgencyPhase2(AgencyComm& comm, bool const hadPersistedId) {
   TRI_ASSERT(!_id.empty() && !_myEndpoint.empty());
-    
+
   std::string const serverRegistrationPath = currentServersRegisteredPref + _id;
   std::string const rebootIdPath = "/Current/ServersKnown/" + _id + "/rebootId";
-  
+
   // If we generated a new UUID, this *must not* exist in the Agency, so we
   // should fail to register.
   std::vector<AgencyPrecondition> pre;
@@ -762,7 +762,7 @@ bool ServerState::registerAtAgencyPhase2(AgencyComm& comm, bool const hadPersist
       builder.add("engine", VPackValue(EngineSelectorFeature::engineName()));
       builder.add("timestamp", VPackValue(timepointToString(std::chrono::system_clock::now())));
     }
-    
+
     AgencyWriteTransaction trx(
         {AgencyOperation(serverRegistrationPath, AgencyValueOperationType::SET,
                          builder.slice()),

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -609,15 +609,17 @@ bool ServerState::checkIfAgencyInitialized(AgencyComm& comm,
 //////////////////////////////////////////////////////////////////////////////
 
 bool ServerState::registerAtAgencyPhase1(AgencyComm& comm, ServerState::RoleEnum const& role) {
+
+  // if the agency is not initialized, there is no point in continuing.
+  if(!checkIfAgencyInitialized(comm, role)) {
+    return false;
+  }
+
   std::string const agencyListKey = roleToAgencyListKey(role);
   std::string const latestIdKey = "Latest" + roleToAgencyKey(role) + "Id";
 
   VPackBuilder builder;
   builder.add(VPackValue("none"));
-
-  if(!checkIfAgencyInitialized(comm, role)) {
-    return false;
-  }
 
   std::string planUrl = "Plan/" + agencyListKey + "/" + _id;
   std::string currentUrl = "Current/" + agencyListKey + "/" + _id;

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -510,16 +510,6 @@ std::string ServerState::roleToAgencyKey(ServerState::RoleEnum role) {
   return "INVALID_CLUSTER_ROLE";
 }
 
-void mkdir(std::string const& path) {
-  if (!TRI_IsDirectory(path.c_str())) {
-    if (!arangodb::basics::FileUtils::createDirectory(path)) {
-      LOG_TOPIC("626e8", FATAL, arangodb::Logger::CLUSTER)
-          << "Couldn't create file directory " << path << " (UUID)";
-      FATAL_ERROR_EXIT();
-    }
-  }
-}
-
 std::string ServerState::getUuidFilename() const {
   auto dbpath = application_features::ApplicationServer::getFeature<DatabasePathFeature>(
       "DatabasePath");

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -397,18 +397,6 @@ bool ServerState::integrateIntoCluster(ServerState::RoleEnum role,
     return false;
   }
 
-  // if (have persisted id) {
-  //   use the persisted id
-  // } else {
-  //  if (myLocalId not empty) {
-  //    lookup in agency
-  //    if (found) {
-  //      persist id
-  //    }
-  //  }
-  //  if (id still not set) {
-  //    generate and persist new id
-  //  }
   std::string id;
   bool hadPersistedId = hasPersistedId();
   if (!hadPersistedId) {
@@ -490,7 +478,7 @@ bool ServerState::isUuid(std::string const& value) const {
 /// @brief get the key for a role in the agency
 //////////////////////////////////////////////////////////////////////////////
 std::string ServerState::roleToAgencyListKey(ServerState::RoleEnum role) {
-  return roleToAgencyKey(role) + "s";  // lol
+  return roleToAgencyKey(role) + "s";
 }
 
 std::string ServerState::roleToAgencyKey(ServerState::RoleEnum role) {

--- a/arangod/Cluster/ServerState.h
+++ b/arangod/Cluster/ServerState.h
@@ -277,6 +277,9 @@ class ServerState {
   /// @brief try to read the rebootID from the Agency
   ResultT<uint64_t> readRebootIdFromAgency(AgencyComm& comm);
 
+  /// @brief check whether the agency has been initalized
+  bool checkIfAgencyInitialized(AgencyComm&, RoleEnum const&);
+
   /// @brief register at agency, might already be done
   bool registerAtAgencyPhase1(AgencyComm&, RoleEnum const&);
 


### PR DESCRIPTION
This PR cleans up some bits in `arangod/ServerState.cpp`

 * remove unused function `mkdir`
 * remove some out of date (and out of place) comments
 * move a function that tests for agency initialisation into a separate functions. This is mainly for readability.

This change is a trivial rework / code cleanup without additional test coverage,
this change is already covered by existing tests, such as *(please describe tests)*.
