### PR TITLE
Docs: Dump program options of arangobackup as well

### DIFF
--- a/utils/generateExamples.sh
+++ b/utils/generateExamples.sh
@@ -51,7 +51,7 @@ fi
 [ "$(uname -s)" = "Darwin" -a -x "${ARANGOSH}" ] && ARANGOSH="$(cd -P -- "$(dirname -- "${ARANGOSH}")" && pwd -P)/$(basename -- "${ARANGOSH}")"
 
 if "${ARANGOSH}" --version | grep -q "^enterprise-version: enterprise$"; then
-    ALLPROGRAMS="arangobench arangod arangodump arangoexport arangoimport arangoinspect arangorestore arangosh"
+    ALLPROGRAMS="arangobackup arangobench arangod arangodump arangoexport arangoimport arangoinspect arangorestore arangosh"
     for HELPPROGRAM in ${ALLPROGRAMS}; do
         echo "Dumping program options of ${HELPPROGRAM}"
         "${BIN_PATH}/${HELPPROGRAM}${EXT}" --dump-options > "Documentation/Examples/${HELPPROGRAM}.json"


### PR DESCRIPTION
Adds arangobackup to list of binaries to dump startup options for.

Related: https://github.com/arangodb/docs/pull/125/commits/740ad4fb3107ba34a8db4430ccbf8bf81dc17803