### PR TITLE
Bugfix 3.5: Add object counts to arangoimport latency

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 v3.5.1 (XXXX-XX-XX)
 -------------------
-* Add count of objects to latency reporting in arangoimport
+* Add count of objects to latency reporting in arangoimport.
 
 * Fixed internal issue #633: made ArangoSearch functions BOOST, ANALYZER, MIN_MATCH
   callable with constant arguments. This will allow running queries where all arguments

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,12 @@
 v3.5.1 (XXXX-XX-XX)
 -------------------
+* Add count of objects to latency reporting in arangoimport
+
 * Fixed internal issue #633: made ArangoSearch functions BOOST, ANALYZER, MIN_MATCH
   callable with constant arguments. This will allow running queries where all arguments
   for these functions are deterministic and do not depend on loop variables.
 
-* Automatically turn values for deprecated startup option parameters 
+* Automatically turn values for deprecated startup option parameters
   `--log.use-microtime` and `--log.use-local-time` into equivalent option values
   of the new, preferred option `--log.time-format`.
 
@@ -19,18 +21,18 @@ v3.5.1 (XXXX-XX-XX)
 * Check for duplicate server endpoints registered in the agency in sub-keys of
   `/Current/ServersRegistered`.
 
-  Duplicate endpoints will be registered if more than one arangod instance is 
-  started with the same value for startup option `--cluster.my-address`. This can 
+  Duplicate endpoints will be registered if more than one arangod instance is
+  started with the same value for startup option `--cluster.my-address`. This can
   happen unintentionally due to typos in the configuration, copy&paste remainders etc.
 
-  In case a duplicate endpoint is detected on startup, a warning will be written 
+  In case a duplicate endpoint is detected on startup, a warning will be written
   to the log, indicating which other server has already "acquired" the same endpoint.
 
 * Make graph operations in general-graph transaction-aware.
 
 * Fixed adding an orphan collections as the first collection in a SmartGraph.
 
-* Fixed non-deterministic occurrences of "document not found" errors in sharded 
+* Fixed non-deterministic occurrences of "document not found" errors in sharded
   collections with custom shard keys (i.e. non-`_key`) and multi-document lookups.
 
 * Fixed issue #9862: ServerException: RestHandler/RestCursorHandler.cpp:279
@@ -56,7 +58,7 @@ v3.5.1 (XXXX-XX-XX)
   The default TLS protocol for the arangod server is still TLS 1.2 however, in order
   to keep compatibility with previous versions of ArangoDB.
 
-  The arangod server and any of the client tools can be started with option 
+  The arangod server and any of the client tools can be started with option
   `--ssl.protocol 6` to make use of TLS 1.3.
 
   To configure the TLS version for arangod instances started by the ArangoDB starter,
@@ -128,7 +130,7 @@ v3.5.1 (XXXX-XX-XX)
   is set to at least 9 (which is the recommended value). Ignore it if it is
   set to a lower value than 9, and warn the end user about it.
 
-  Previous versions of ArangoDB always silently ignored the value of this setting 
+  Previous versions of ArangoDB always silently ignored the value of this setting
   and effectively hard-coded the value to 9.
 
 * Fixed internal issue #4378: fix bug in MoveShard::abort which causes a

--- a/arangosh/Import/ImportHelper.cpp
+++ b/arangosh/Import/ImportHelper.cpp
@@ -294,7 +294,6 @@ bool ImportHelper::importDelimited(std::string const& collectionName,
   _rowsRead = 0;
 
   char buffer[32768];
-  // int64_t totalRead = 0;
 
   while (!_hasError) {
     ssize_t n = fd->read(buffer, sizeof(buffer));
@@ -313,7 +312,6 @@ bool ImportHelper::importDelimited(std::string const& collectionName,
       break;
     }
 
-    // totalRead += static_cast<int64_t>(n);
     reportProgress(totalLength, fd->offset(), nextProgress);
 
     TRI_ParseCsvString(&parser, buffer, n);
@@ -378,7 +376,6 @@ bool ImportHelper::importJson(std::string const& collectionName,
   }
 
   // progress display control variables
-  // int64_t totalRead = 0;
   double nextProgress = ProgressStep;
 
   static int const BUFFER_SIZE = 32768;
@@ -422,7 +419,6 @@ bool ImportHelper::importJson(std::string const& collectionName,
       checkedFront = true;
     }
 
-    // totalRead += static_cast<int64_t>(n);
     reportProgress(totalLength, fd->offset(), nextProgress);
 
     if (_outputBuffer.length() > _maxUploadSize) {

--- a/arangosh/Import/QuickHistogram.h
+++ b/arangosh/Import/QuickHistogram.h
@@ -23,6 +23,7 @@
 #ifndef ARANGODB_IMPORT_QUICK_HIST_H
 #define ARANGODB_IMPORT_QUICK_HIST_H 1
 
+#include <algorithm>
 #include <chrono>
 #include <ctime>
 #include <future>
@@ -34,7 +35,9 @@
 #include "Basics/ConditionLocker.h"
 #include "Basics/ConditionVariable.h"
 #include "Basics/Thread.h"
+#include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
+#include "Logger/LoggerStream.h"
 
 namespace arangodb {
 namespace import {
@@ -46,12 +49,14 @@ class QuickHistogram : public arangodb::Thread {
   QuickHistogram(QuickHistogram const&) = delete;
   QuickHistogram& operator=(QuickHistogram const&) = delete;
 
- public:
-  QuickHistogram()
-      : Thread("QuickHistogram"),
-        _writingLatencies(nullptr),
-        _readingLatencies(nullptr),
-        _threadRunning(false) {}
+public:
+QuickHistogram()
+  : Thread("QuickHistogram"),
+    _writingLatencies(nullptr),
+    _readingLatencies(nullptr),
+    _objectsWriting(0),
+    _objectsReading(0),
+    _threadRunning(false) {}
 
   ~QuickHistogram() { shutdown(); }
 
@@ -64,7 +69,7 @@ class QuickHistogram : public arangodb::Thread {
     guard.broadcast();
   }
 
-  void postLatency(std::chrono::microseconds latency) {
+  void postLatency(std::chrono::microseconds latency, uint64_t objects = 1) {
     if (_threadRunning.load()) {
       CONDITION_LOCKER(guard, _condvar);
 
@@ -76,6 +81,7 @@ class QuickHistogram : public arangodb::Thread {
             << "QuickHistogram::postLatency() had exception doing a push_back "
                "(out of ram)";
       }
+      _objectsWriting += objects;
     }
   }
 
@@ -84,7 +90,7 @@ class QuickHistogram : public arangodb::Thread {
     _intervalStart = std::chrono::steady_clock::now();
     _measuringStart = _intervalStart;
     LOG_TOPIC("f206c", INFO, arangodb::Logger::FIXME)
-        << R"("elapsed","window","n","min","mean","median","95th","99th","99.9th","max","unused1","clock")";
+        << R"("elapsed","window","n","min","mean","median","95th","99th","99.9th","max","objects","clock")";
 
     _writingLatencies = &_vectors[0];
     _readingLatencies = &_vectors[1];
@@ -100,6 +106,8 @@ class QuickHistogram : public arangodb::Thread {
       temp = _writingLatencies;
       _writingLatencies = _readingLatencies;
       _readingLatencies = temp;
+      _objectsReading = _objectsWriting.load();
+      _objectsWriting = 0;
 
       printInterval(!_threadRunning.load());
     }
@@ -114,6 +122,7 @@ class QuickHistogram : public arangodb::Thread {
   typedef std::vector<std::chrono::microseconds> LatencyVec_t;
   LatencyVec_t _vectors[2];
   LatencyVec_t *_writingLatencies, *_readingLatencies;
+  std::atomic<uint64_t> _objectsWriting, _objectsReading;
 
   basics::ConditionVariable _condvar;
   std::atomic<bool> _threadRunning;
@@ -179,18 +188,15 @@ class QuickHistogram : public arangodb::Thread {
         oss << std::put_time(&tm, "%m-%d-%Y %H:%M:%S");
         auto str = oss.str();
 
-        // old age string buffering & formatting
-        char buffer[133];
-        snprintf(buffer, sizeof(buffer),
-                 "%.3f,%.3f,%llu,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%d,%s",
-                 fp_measuring, fp_interval, static_cast<unsigned long long>(num),
-                 (0 != num) ? static_cast<long>(_readingLatencies->at(0).count()) : 0,
-                 static_cast<long>(mean.count()), static_cast<long>(median.count()),
-                 static_cast<long>(per95.count()), static_cast<long>(per99.count()),
-                 static_cast<long>(per99_9.count()),
-                 (0 != num) ? static_cast<long>(_readingLatencies->at(num - 1).count()) : 0,
-                 0, str.c_str());
-        LOG_TOPIC("8a76c", INFO, arangodb::Logger::FIXME) << buffer;
+        LOG_TOPIC("8a76c",INFO, arangodb::Logger::FIXME) << Logger::FIXED(fp_measuring,3) << ","
+                                                 << Logger::FIXED(fp_interval,3) << ","
+                                                 << num << ","
+                                                 << ((0 != num) ? _readingLatencies->at(0).count() : 0) << ","
+                                                 << mean.count() << "," << median.count() << ","
+                                                 << per95.count() << "," << per99.count() << ","
+                                                 << per99_9.count() << ","
+                                                 << ((0 != num) ? _readingLatencies->at(num - 1).count() : 0) << ","
+                                                 << _objectsReading.load() << "," << str.c_str();
 
         _readingLatencies->clear();
         _intervalStart = intervalEnd;
@@ -249,18 +255,24 @@ class QuickHistogram : public arangodb::Thread {
 class QuickHistogramTimer {
  public:
   explicit QuickHistogramTimer(QuickHistogram& histo)
-      : _intervalStart(std::chrono::steady_clock::now()), _histogram(histo) {}
+    : _intervalStart(std::chrono::steady_clock::now()), _histogram(histo),
+    _objects(1) {}
+
+  explicit QuickHistogramTimer(QuickHistogram& histo, uint64_t objects)
+    : _intervalStart(std::chrono::steady_clock::now()), _histogram(histo),
+    _objects(objects) {}
 
   ~QuickHistogramTimer() {
     std::chrono::microseconds latency;
 
     latency = std::chrono::duration_cast<std::chrono::microseconds>(
         std::chrono::steady_clock::now() - _intervalStart);
-    _histogram.postLatency(latency);
+    _histogram.postLatency(latency, _objects);
   }
 
   std::chrono::steady_clock::time_point _intervalStart;
   QuickHistogram& _histogram;
+  uint64_t _objects;
 };  // QuickHistogramTimer
 }  // namespace import
 }  // namespace arangodb

--- a/arangosh/Import/QuickHistogram.h
+++ b/arangosh/Import/QuickHistogram.h
@@ -50,8 +50,8 @@ class QuickHistogram : public arangodb::Thread {
   QuickHistogram& operator=(QuickHistogram const&) = delete;
 
 public:
-QuickHistogram()
-  : Thread("QuickHistogram"),
+  QuickHistogram()
+    : Thread("QuickHistogram"),
     _writingLatencies(nullptr),
     _readingLatencies(nullptr),
     _objectsWriting(0),

--- a/arangosh/Import/SenderThread.cpp
+++ b/arangosh/Import/SenderThread.cpp
@@ -126,7 +126,7 @@ void SenderThread::run() {
         TRI_ASSERT(!_idle && !_url.empty());
 
         {
-          QuickHistogramTimer timer(_stats->_histogram);
+          QuickHistogramTimer timer(_stats->_histogram, (_highLineNumber - _lowLineNumber) +1);
           std::unique_ptr<httpclient::SimpleHttpResult> result(
               _client->request(rest::RequestType::POST, _url, _data.c_str(),
                                _data.length()));
@@ -212,7 +212,6 @@ void SenderThread::handleResult(httpclient::SimpleHttpResult* result) {
       VPackSlice const errorMessage = body.get("errorMessage");
       if (errorMessage.isString()) {
         _errorMessage = errorMessage.copyString();
-
       }
 
       // will trigger the waiting ImportHelper thread to cancel the import


### PR DESCRIPTION
This is a back port of PR 9856 (3.4).

Existing latency report stated number of requests posted to db server. But there was not tracking of how many objects / records were contained in each request. This PR utilizes the unused statistic location and populates it with total count of objects within the requests.