### PR TITLE
improve handling of FILTERs that are known to always produce true or false

### DIFF
--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -1169,9 +1169,26 @@ ExecutionNode* ExecutionPlan::fromNodeFilter(ExecutionNode* previous, AstNode co
     en = registerNode(new FilterNode(this, nextId(), v));
   } else {
     // operand is some misc expression
-    auto calc = createTemporaryCalculation(expression, previous);
-    en = registerNode(new FilterNode(this, nextId(), getOutVariable(calc)));
-    previous = calc;
+    if (expression->isTrue()) {
+      // filter expression is known to be always true, so 
+      // remove the filter entirely
+      return previous;
+    }
+
+    // note: if isTrue() is false above, it is not necessarily the case that
+    // isFalse() is true next. The reason is that isTrue() and isFalse() only
+    // return true in case of absolulete certainty. this requires expressions
+    // to be based on query compile-time values only, but it will not work
+    // for expressions that need to be evaluated at query runtime
+    if (expression->isFalse()) {
+      // filter expression is known to be always false, so
+      // replace the FILTER with a NoResultsNode
+      en = registerNode(new NoResultsNode(this, nextId()));
+    } else {
+      auto calc = createTemporaryCalculation(expression, previous);
+      en = registerNode(new FilterNode(this, nextId(), getOutVariable(calc)));
+      previous = calc;
+    }
   }
 
   return addDependency(previous, en);

--- a/tests/js/server/aql/aql-profiler.js
+++ b/tests/js/server/aql/aql-profiler.js
@@ -295,9 +295,7 @@ function ahuacatlProfilerTestSuite () {
       const genNodeList = (rows, batches) => [
         {type: SingletonBlock, calls: 1, items: 1},
         {type: CalculationBlock, calls: 1, items: 1},
-        {type: CalculationBlock, calls: 1, items: 1},
         {type: EnumerateListBlock, calls: batches, items: rows},
-        {type: FilterBlock, calls: batches, items: rows},
         {type: ReturnBlock, calls: batches, items: rows},
       ];
       profHelper.runDefaultChecks({query, genNodeList, options});
@@ -497,8 +495,8 @@ function ahuacatlProfilerTestSuite () {
       const genNodeList = () => [
         {type: SingletonBlock, calls: 0, items: 0},
         {type: CalculationBlock, calls: 0, items: 0},
+        {type: EnumerateListBlock, calls: 0, items: 0},
         {type: NoResultsBlock, calls: 1, items: 0},
-        {type: EnumerateListBlock, calls: 1, items: 0},
         {type: ReturnBlock, calls: 1, items: 0},
       ];
 


### PR DESCRIPTION
### Scope & Purpose

Don't produce FILTER nodes for filter conditions that are known to be always false. Instead, produce a NoResultsNode.
Don't produce FILTER nodes for filter conditions that are known to be always true.
As a side effect, this may optimize certain queries that will not produce any results.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is a GitHub Issue reported by a Community User: https://github.com/arangodb/arangodb/issues/9938

### Testing & Verification

This change is already covered by existing tests, such as *(please describe tests)*.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/6112/