### PR TITLE
improve handling of FILTERs with constant expressions

### DIFF
--- a/tests/js/server/aql/aql-profiler.js
+++ b/tests/js/server/aql/aql-profiler.js
@@ -295,9 +295,7 @@ function ahuacatlProfilerTestSuite () {
       const genNodeList = (rows, batches) => [
         {type: SingletonBlock, calls: 1, items: 1},
         {type: CalculationBlock, calls: 1, items: 1},
-        {type: CalculationBlock, calls: 1, items: 1},
         {type: EnumerateListBlock, calls: batches, items: rows},
-        {type: FilterBlock, calls: batches, items: rows},
         {type: ReturnBlock, calls: batches, items: rows},
       ];
       profHelper.runDefaultChecks({query, genNodeList, options});
@@ -497,8 +495,8 @@ function ahuacatlProfilerTestSuite () {
       const genNodeList = () => [
         {type: SingletonBlock, calls: 0, items: 0},
         {type: CalculationBlock, calls: 0, items: 0},
+        {type: EnumerateListBlock, calls: 0, items: 0},
         {type: NoResultsBlock, calls: 1, items: 0},
-        {type: EnumerateListBlock, calls: 1, items: 0},
         {type: ReturnBlock, calls: 1, items: 0},
       ];
 


### PR DESCRIPTION
### Scope & Purpose

Don't produce FILTER nodes for filter conditions that are known to be always false. Instead, produce a NoResultsNode.
Don't produce FILTER nodes for filter conditions that are known to be always true.
As a side effect, this may optimize certain queries that will not produce any results.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is a GitHub Issue reported by a Community User: https://github.com/arangodb/arangodb/issues/9938

### Testing & Verification

This change is already covered by existing tests, such as *(please describe tests)*.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/6114/