### PR TITLE
Bugfix: Calculate Write Amplification / Flag to disable StatisticsWorker

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* add --server.statistics-history flag to allow disabling of only the historical
+  statistics.  Also added rocksdbengine.write.amplification.x100 statistics
+  for measurement of compaction option impact.  Enabled non-historical
+  statistics for agents.
+
 * Fixed the removal (including a collection drop) of an orphanCollection from a
   graph definition when using the arango shell. The boolean
   flag whether to drop the collection or not was not transferred properly.
@@ -16,7 +21,7 @@ devel
   above inconsistencies. Also creation of databases are now secured against
   coordinator outages, they will either be fully created or not visible and
   eventually dropped. This does not require any change on the client code.
-  
+
 * Added UI support to create documents in a collection using smartGraphAttribute
   and/or smartJoinAttribute.
 
@@ -72,10 +77,10 @@ devel
 * Enforced the valid date range for working with date/time in AQL. The valid date
   ranges for any AQL date/time function are:
 
-  - for string date/time values: `"0000-01-01T00:00:00.000Z"` (including) up to 
+  - for string date/time values: `"0000-01-01T00:00:00.000Z"` (including) up to
     `"9999-12-31T23:59:59.999Z"` (including)
   - for numeric date/time values: -62167219200000 (including) up to 253402300799999
-    (including). These values are the numeric equivalents of 
+    (including). These values are the numeric equivalents of
     `"0000-01-01T00:00:00.000Z"` and `"9999-12-31T23:59:59.999Z"`.
 
   Any date/time values outside the given range that are passed into an AQL date
@@ -132,22 +137,22 @@ v3.5.0-rc.6 (2019-07-29)
 
 * Added startup error for bad temporary directory setting.
 
-  If the temporary directory (--temp.path) setting is identical to the database 
-  directory (`--database.directory`) this can eventually lead to data loss, as 
-  temporary files may be created inside the temporary directory, causing overwrites of 
+  If the temporary directory (--temp.path) setting is identical to the database
+  directory (`--database.directory`) this can eventually lead to data loss, as
+  temporary files may be created inside the temporary directory, causing overwrites of
   existing database files/directories with the same names.
-  Additionally the temporary directory may be cleaned at some point, and this would lead 
+  Additionally the temporary directory may be cleaned at some point, and this would lead
   to an unintended cleanup of the database files/directories as well.
-  Now, if the database directory and temporary directory are set to the same path, there 
-  will be a startup warning about potential data loss (though in ArangoDB 3.4 allowing to 
+  Now, if the database directory and temporary directory are set to the same path, there
+  will be a startup warning about potential data loss (though in ArangoDB 3.4 allowing to
   continue the startup - in 3.5 and higher we will abort the startup).
 
 * Make TTL indexes behave like other indexes on creation.
-    
+
   If a TTL index is already present on a collection, the previous behavior
   was to make subsequent calls to `ensureIndex` fail unconditionally with
   the error "there can only be one ttl index per collection".
-    
+
   Now we are comparing the attributes of the to-be-created index with the
   attributes of the existing TTL index and make it only fail when the
   attributes differ. If the attributes are identical, the `ensureIndex`
@@ -163,7 +168,7 @@ v3.5.0-rc.5 (2019-07-22)
   many insync followers. With this mechanism users can avoid to have collections diverge too much in case of failure scenarios.
   minReplicationFactor can have the values: 1 <= minReplicationFactor <= replicationFactor.
   Having minReplicationFactor == 1 ArangoDB behaves the same way as in any previous version.
-  
+
 * Fixed a query abort error with smart joins if both collections were restricted to a
   single shard using the "restrict-to-single-shard" optimizer rule.
 
@@ -171,7 +176,7 @@ v3.5.0-rc.5 (2019-07-22)
 
 * Fixed some races in cluster collection creation, which allowed collections with the
   same name to be created in parallel under some rare conditions.
- 
+
 * arangoimport would not stop, much less report, communications errors.  Add CSV reporting
   of line numbers that are impacted during such errors
 

--- a/arangod/Agency/AgencyFeature.cpp
+++ b/arangod/Agency/AgencyFeature.cpp
@@ -235,12 +235,11 @@ void AgencyFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
   // - ArangoSearch: not needed by agency even if MMFiles is the selected
   //   storage engine
   // - IResearchAnalyzer: analyzers are not needed by agency
-  // - Statistics: turn off statistics gathering for agency
   // - Action/Script/FoxxQueues/Frontend: Foxx and JavaScript APIs
 
   std::vector<std::string> disabledFeatures({
     "MMFilesPersistentIndex", "ArangoSearch", "ArangoSearchAnalyzer",
-    "Statistics", "Action", "Script", "FoxxQueues", "Frontend"});
+    "Action", "Script", "FoxxQueues", "Frontend"});
 
   if (!result.touched("console") || !*(options->get<BooleanParameter>("console")->ptr)) {
     // specifiying --console requires JavaScript, so we can only turn it off

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -112,7 +112,7 @@ using namespace arangodb::application_features;
 using namespace arangodb::options;
 
 namespace arangodb {
-  
+
 std::string const RocksDBEngine::EngineName("rocksdb");
 std::string const RocksDBEngine::FeatureName("RocksDBEngine");
 
@@ -314,7 +314,7 @@ void RocksDBEngine::collectOptions(std::shared_ptr<options::ProgramOptions> opti
                      "true to enable rocksdb debug logging",
                      new BooleanParameter(&_debugLogging),
                      arangodb::options::makeFlags(arangodb::options::Flags::Hidden));
-  
+
   options->addOption("--rocksdb.wal-archive-size-limit",
                      "maximum total size (in bytes) of archived WAL files (0 = unlimited)",
                      new UInt64Parameter(&_maxWalArchiveSizeLimit),
@@ -376,12 +376,12 @@ void RocksDBEngine::prepare() {
 void RocksDBEngine::start() {
   // it is already decided that rocksdb is used
   TRI_ASSERT(isEnabled());
-  
+
   if (ServerState::instance()->isAgent() &&
       !application_features::ApplicationServer::server->options()->processingResult().touched("rocksdb.wal-file-timeout-initial")) {
     // reduce --rocksb.wal-file-timeout-initial to 15 seconds for agency nodes
     // as we probably won't need the WAL for WAL tailing and replication here
-    _pruneWaitTimeInitial = 15; 
+    _pruneWaitTimeInitial = 15;
   }
 
   LOG_TOPIC("107fd", TRACE, arangodb::Logger::ENGINES)
@@ -601,7 +601,7 @@ void RocksDBEngine::start() {
   rocksdb::ColumnFamilyOptions fixedPrefCF(_options);
   fixedPrefCF.prefix_extractor = std::shared_ptr<rocksdb::SliceTransform const>(
       rocksdb::NewFixedPrefixTransform(RocksDBKey::objectIdSize()));
-  
+
   // construct column family options with prefix containing indexed value
   rocksdb::ColumnFamilyOptions dynamicPrefCF(_options);
   dynamicPrefCF.prefix_extractor = std::make_shared<RocksDBPrefixExtractor>();
@@ -755,7 +755,7 @@ void RocksDBEngine::start() {
   if (opts->_limitOpenFilesAtStartup) {
     _db->SetDBOptions({{"max_open_files", "-1"}});
   }
-    
+
   {
     auto feature = application_features::ApplicationServer::getFeature<FlushFeature>("Flush");
     TRI_ASSERT(feature);
@@ -809,7 +809,7 @@ void RocksDBEngine::beginShutdown() {
 
 void RocksDBEngine::stop() {
   TRI_ASSERT(isEnabled());
-  
+
   // in case we missed the beginShutdown somehow, call it again
   replicationManager()->beginShutdown();
   replicationManager()->dropAll();
@@ -1258,7 +1258,7 @@ std::string RocksDBEngine::createCollection(TRI_vocbase_t& vocbase,
   if (res != TRI_ERROR_NO_ERROR) {
     THROW_ARANGO_EXCEPTION(res);
   }
-  
+
   return std::string();  // no need to return a path
 }
 
@@ -1750,7 +1750,7 @@ void RocksDBEngine::determinePrunableWalFiles(TRI_voc_tick_t minTickExternal) {
     // we need to take its start tick into account as well, because the following
     // file's start tick can be assumed to be the end tick of the current file!
     if (f->StartSequence() < minTickToKeep &&
-        current < files.size() - 1) {      
+        current < files.size() - 1) {
       auto const& n = files[current + 1].get();
       if (n->StartSequence() < minTickToKeep) {
         // this file will be removed because it does not contain any data we
@@ -1764,7 +1764,7 @@ void RocksDBEngine::determinePrunableWalFiles(TRI_voc_tick_t minTickExternal) {
       }
     }
   }
-  
+
   if (_maxWalArchiveSizeLimit == 0) {
     // size of the archive is not restricted. done!
     return;
@@ -1772,7 +1772,7 @@ void RocksDBEngine::determinePrunableWalFiles(TRI_voc_tick_t minTickExternal) {
 
   // print current archive size
   LOG_TOPIC("8d71b", TRACE, Logger::ENGINES) << "total size of the RocksDB WAL file archive: " << totalArchiveSize;
-    
+
   if (totalArchiveSize <= _maxWalArchiveSizeLimit) {
     // archive is smaller than allowed. all good
     return;
@@ -2238,6 +2238,14 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
     for (auto const& stat : rocksdb::TickersNameMap) {
       builder.add(stat.second, VPackValue(_options.statistics->getTickerCount(stat.first)));
     }
+
+    uint64_t walWrite, flushWrite, compactionWrite, userWrite;
+    walWrite = _options.statistics->getTickerCount(rocksdb::WAL_FILE_BYTES);
+    flushWrite = _options.statistics->getTickerCount(rocksdb::FLUSH_WRITE_BYTES);
+    compactionWrite = _options.statistics->getTickerCount(rocksdb::COMPACT_WRITE_BYTES);
+    userWrite = _options.statistics->getTickerCount(rocksdb::BYTES_WRITTEN);
+    builder.add("rocksdbengine.write.amplification.x100",
+                VPackValue( (0 != userWrite) ? ((walWrite+flushWrite+compactionWrite)*100)/userWrite : 100));
   }
 
   cache::Manager* manager = CacheManagerFeature::MANAGER;
@@ -2307,7 +2315,7 @@ Result RocksDBEngine::createLoggerState(TRI_vocbase_t* vocbase, VPackBuilder& bu
 
   // "clients" part
   builder.add("clients", VPackValue(VPackValueType::Array));  // open
-  if (vocbase != nullptr) {    
+  if (vocbase != nullptr) {
     vocbase->replicationClients().toVelocyPack(builder);
   }
   builder.close();  // clients

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -23,6 +23,7 @@
 #include "StatisticsFeature.h"
 
 #include "Basics/application-exit.h"
+#include "Cluster/ServerState.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
@@ -131,6 +132,8 @@ StatisticsFeature* StatisticsFeature::STATISTICS = nullptr;
 StatisticsFeature::StatisticsFeature(application_features::ApplicationServer& server)
     : ApplicationFeature(server, "Statistics"),
       _statistics(true),
+      _statisticsHistory(true),
+      _statisticsHistoryTouched(false),
       _descriptions(new stats::Descriptions()) {
   startsAfter("AQLPhase");
   setOptional(true);
@@ -145,13 +148,22 @@ void StatisticsFeature::collectOptions(std::shared_ptr<ProgramOptions> options) 
                      "turn statistics gathering on or off",
                      new BooleanParameter(&_statistics),
                      arangodb::options::makeFlags(arangodb::options::Flags::Hidden));
+  options->addOption("--server.statistics-history",
+                     "turn storing statistics in database on or off",
+                     new BooleanParameter(&_statisticsHistory),
+                     arangodb::options::makeFlags(arangodb::options::Flags::Hidden))
+    .setIntroducedIn(30409)
+    .setIntroducedIn(30501);
 }
 
-void StatisticsFeature::validateOptions(std::shared_ptr<ProgramOptions>) {
+void StatisticsFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
   if (!_statistics) {
     // turn ourselves off
     disable();
   }
+
+  _statisticsHistoryTouched = options->processingResult().touched("--server.statistics-history");
+
 }
 
 void StatisticsFeature::prepare() {
@@ -185,7 +197,6 @@ void StatisticsFeature::start() {
   }
 
   _statisticsThread.reset(new StatisticsThread);
-  _statisticsWorker.reset(new StatisticsWorker(*vocbase));
 
   if (!_statisticsThread->start()) {
     LOG_TOPIC("46b0c", FATAL, arangodb::Logger::STATISTICS)
@@ -193,11 +204,20 @@ void StatisticsFeature::start() {
     FATAL_ERROR_EXIT();
   }
 
-  if (!_statisticsWorker->start()) {
-    LOG_TOPIC("6ecdc", FATAL, arangodb::Logger::STATISTICS)
+  // force history disable on Agents
+  if (arangodb::ServerState::instance()->isAgent() && !_statisticsHistoryTouched) {
+    _statisticsHistory = false;
+  } // if
+
+  if (_statisticsHistory) {
+    _statisticsWorker.reset(new StatisticsWorker(*vocbase));
+
+    if (!_statisticsWorker->start()) {
+      LOG_TOPIC("63cdc", FATAL, arangodb::Logger::STATISTICS)
         << "could not start statistics worker";
-    FATAL_ERROR_EXIT();
-  }
+      FATAL_ERROR_EXIT();
+    }
+  } // if
 }
 
 void StatisticsFeature::stop() {

--- a/arangod/Statistics/StatisticsFeature.h
+++ b/arangod/Statistics/StatisticsFeature.h
@@ -94,6 +94,8 @@ class StatisticsFeature final : public application_features::ApplicationFeature 
 
  private:
   bool _statistics;
+  bool _statisticsHistory;
+  bool _statisticsHistoryTouched;
 
   std::unique_ptr<stats::Descriptions> _descriptions;
   std::unique_ptr<StatisticsThread> _statisticsThread;


### PR DESCRIPTION
This PR adds three independent changes, and a related Agency change:

- rocksdb Write Amplification is now calculated and reported with existing rocksdb statistics. This is essential for judging impact of compactions (and changes to compaction options).

- StatisticsWorker has demonstrated a tendency to cause increased compactions which heavily impact throughput. The new --server.statistics-history option allows just the StatisticsWorker portion of statistics to be disabled.

- statistics are now active for Agency. Previously AgencyFeature.cpp completely disabled statistics for an agent daemon. The disabling code is removed. StatisticsFeature.cpp now notices if the daemon is for an agent and automatically disables statistics-history to avoid current performance issues.