### PR TITLE
Harden database creation against spurious "duplicate name" errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+v3.4.9 (XXXX-XX-XX)
+-------------------
+
+* Harden database creation against spurious "duplicate name" errors that
+  were caused by other parallel operations lazily creating required
+  system collections in the same database.
+
+
 v3.4.8 (2019-09-09)
 -------------------
 

--- a/arangod/VocBase/Methods/UpgradeTasks.cpp
+++ b/arangod/VocBase/Methods/UpgradeTasks.cpp
@@ -95,7 +95,9 @@ bool createSystemCollection(TRI_vocbase_t* vocbase, std::string const& name) {
                               [](std::shared_ptr<LogicalCollection> const&) -> void {});
   }
 
-  if (res.fail()) {
+  // if the system collection exists by now, then some other thread
+  // has just created it between the lookup and the create
+  if (res.fail() && !res.is(TRI_ERROR_ARANGO_DUPLICATE_NAME)) {
     THROW_ARANGO_EXCEPTION(res);
   }
 


### PR DESCRIPTION
### Scope & Purpose

Harden database creation against spurious "duplicate name" errors
that were caused by other parallel operations lazily creating required
system collections in the same database.

Problems can occur when during database creation some JS code runs
that attempts to create the same system collection that the "create database"
operation tries to create concurrently. There is a small window of overlap
here in which this can make database creation fail.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6125/