### PR TITLE
Harden database creation against spurious "duplicate name" errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.5.1 (XXXX-XX-XX)
 -------------------
 
+* Harden database creation against spurious "duplicate name" errors that
+  were caused by other parallel operations lazily creating required
+  system collections in the same database.
+
 * Fixed internal issue #633: made ArangoSearch functions BOOST, ANALYZER, MIN_MATCH
   callable with constant arguments. This will allow running queries where all arguments
   for these functions are deterministic and do not depend on loop variables.

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1469,7 +1469,7 @@ Result ClusterInfo::createDatabaseCoordinator(  // create database
 
   if (!res.successful()) {
     if (res._statusCode == (int)arangodb::rest::ResponseCode::PRECONDITION_FAILED) {
-      return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME);
+      return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME, std::string("duplicate database name '") + name + "'");
     }
 
     return Result(TRI_ERROR_CLUSTER_COULD_NOT_CREATE_DATABASE_IN_PLAN);
@@ -1654,7 +1654,7 @@ Result ClusterInfo::checkCollectionPreconditions(std::string const& databaseName
         if (it2 != (*it).second.end()) {
           // collection already exists!
           events::CreateCollection(databaseName, info.name, TRI_ERROR_ARANGO_DUPLICATE_NAME);
-          return TRI_ERROR_ARANGO_DUPLICATE_NAME;
+          return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME, std::string("duplicate collection name '") + info.name + "'");
         }
       } else {
         // no collection in plan for this particular database... this may be true for
@@ -1678,7 +1678,7 @@ Result ClusterInfo::checkCollectionPreconditions(std::string const& databaseName
         if (it2 != (*it).second.end()) {
           // view already exists!
           events::CreateCollection(databaseName, info.name, TRI_ERROR_ARANGO_DUPLICATE_NAME);
-          return TRI_ERROR_ARANGO_DUPLICATE_NAME;
+          return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME, std::string("duplicate collection name '") + info.name + "'");
         }
       }
     }
@@ -2346,7 +2346,7 @@ Result ClusterInfo::createViewCoordinator(  // create view
         if (it2 != (*it).second.end()) {
           // view already exists!
           events::CreateView(databaseName, name, TRI_ERROR_ARANGO_DUPLICATE_NAME);
-          return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME);
+          return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME, std::string("duplicate view name '") + name + "'");
         }
       }
     }
@@ -2359,7 +2359,7 @@ Result ClusterInfo::createViewCoordinator(  // create view
         if (it2 != (*it).second.end()) {
           // collection already exists!
           events::CreateCollection(databaseName, name, TRI_ERROR_ARANGO_DUPLICATE_NAME);
-          return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME);
+          return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME, std::string("duplicate view name '") + name + "'");
         }
       }
     }

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -1171,12 +1171,12 @@ bool HeartbeatThread::handlePlanChangeCoordinator(uint64_t currentPlanVersion) {
         // database does not yet exist, create it now
 
         // create a local database object...
-        int res = databaseFeature->createDatabase(id, name, vocbase);
+        Result res = databaseFeature->createDatabase(id, name, vocbase);
 
-        if (res != TRI_ERROR_NO_ERROR) {
+        if (res.fail()) {
           LOG_TOPIC("ca877", ERR, arangodb::Logger::HEARTBEAT)
               << "creating local database '" << name
-              << "' failed: " << TRI_errno_string(res);
+              << "' failed: " << res.errorMessage();
         } else {
           HasRunOnce.store(true, std::memory_order_release);
         }

--- a/arangod/MMFiles/MMFilesWalRecoverState.cpp
+++ b/arangod/MMFiles/MMFilesWalRecoverState.cpp
@@ -1222,12 +1222,12 @@ bool MMFilesWalRecoverState::ReplayMarker(MMFilesMarker const* marker,
         MMFilesPersistentIndexFeature::dropDatabase(databaseId);
 
         vocbase = nullptr;
-        int res = state->databaseFeature->createDatabase(databaseId, nameString, vocbase);
+        Result res = state->databaseFeature->createDatabase(databaseId, nameString, vocbase);
 
-        if (res != TRI_ERROR_NO_ERROR) {
+        if (res.fail()) {
           LOG_TOPIC("9c045", WARN, arangodb::Logger::ENGINES)
               << "cannot create database " << databaseId << ": "
-              << TRI_errno_string(res);
+              << res.errorMessage();
           ++state->errorCount;
           return state->canContinue();
         }

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1964,8 +1964,10 @@ void RestReplicationHandler::handleCommandRestoreView() {
 
     if (view) {
       if (!overwrite) {
-        generateError(TRI_ERROR_ARANGO_DUPLICATE_NAME);
-
+        generateError(GeneralResponse::responseCode(TRI_ERROR_ARANGO_DUPLICATE_NAME),
+                      TRI_ERROR_ARANGO_DUPLICATE_NAME, 
+                      std::string("unable to restore view '") + nameSlice.copyString() + ": " + 
+                      TRI_errno_string(TRI_ERROR_ARANGO_DUPLICATE_NAME));
         return;
       }
 
@@ -1973,7 +1975,6 @@ void RestReplicationHandler::handleCommandRestoreView() {
 
       if (!res.ok()) {
         generateError(res);
-
         return;
       }
     }

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -586,13 +586,13 @@ Result DatabaseFeature::registerPostRecoveryCallback(std::function<Result()>&& c
 }
 
 /// @brief create a new database
-int DatabaseFeature::createDatabase(TRI_voc_tick_t id, std::string const& name,
-                                    TRI_vocbase_t*& result) {
+Result DatabaseFeature::createDatabase(TRI_voc_tick_t id, std::string const& name,
+                                       TRI_vocbase_t*& result) {
   result = nullptr;
 
   if (!TRI_vocbase_t::IsAllowedName(false, arangodb::velocypack::StringRef(name))) {
     events::CreateDatabase(name, TRI_ERROR_ARANGO_DATABASE_NAME_INVALID);
-    return TRI_ERROR_ARANGO_DATABASE_NAME_INVALID;
+    return {TRI_ERROR_ARANGO_DATABASE_NAME_INVALID};
   }
 
   if (id == 0) {
@@ -620,7 +620,7 @@ int DatabaseFeature::createDatabase(TRI_voc_tick_t id, std::string const& name,
       if (it != theLists->_databases.end()) {
         // name already in use
         events::CreateDatabase(name, TRI_ERROR_ARANGO_DUPLICATE_NAME);
-        return TRI_ERROR_ARANGO_DUPLICATE_NAME;
+        return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME, std::string("duplicate database name '") + name + "'");
       }
     }
 
@@ -640,17 +640,17 @@ int DatabaseFeature::createDatabase(TRI_voc_tick_t id, std::string const& name,
       try {
         vocbase->addReplicationApplier();
       } catch (basics::Exception const& ex) {
-        LOG_TOPIC("e7444", ERR, arangodb::Logger::FIXME)
-            << "initializing replication applier for database '"
-            << vocbase->name() << "' failed: " << ex.what();
+        std::string msg = "initializing replication applier for database '" + 
+            vocbase->name() + "' failed: " + ex.what();
+        LOG_TOPIC("e7444", ERR, arangodb::Logger::FIXME) << msg;
         events::CreateDatabase(name, ex.code());
-        return ex.code();
+        return Result(ex.code(), std::move(msg));
       } catch (std::exception const& ex) {
-        LOG_TOPIC("56c41", ERR, arangodb::Logger::FIXME)
-            << "initializing replication applier for database '"
-            << vocbase->name() << "' failed: " << ex.what();
+        std::string msg = "initializing replication applier for database '" + 
+            vocbase->name() + "' failed: " + ex.what();
+        LOG_TOPIC("56c41", ERR, arangodb::Logger::FIXME) << msg;
         events::CreateDatabase(name, TRI_ERROR_INTERNAL);
-        return TRI_ERROR_INTERNAL;
+        return Result(TRI_ERROR_INTERNAL, std::move(msg));
       }
 
       // enable deadlock detection

--- a/arangod/RestServer/DatabaseFeature.h
+++ b/arangod/RestServer/DatabaseFeature.h
@@ -110,7 +110,7 @@ class DatabaseFeature : public application_features::ApplicationFeature {
   std::vector<std::string> getDatabaseNames();
   std::vector<std::string> getDatabaseNamesForUser(std::string const& user);
 
-  int createDatabase(TRI_voc_tick_t id, std::string const& name, TRI_vocbase_t*& result);
+  Result createDatabase(TRI_voc_tick_t id, std::string const& name, TRI_vocbase_t*& result);
   int dropDatabase(std::string const& name, bool waitForDeletion, bool removeAppsDirectory);
   int dropDatabase(TRI_voc_tick_t id, bool waitForDeletion, bool removeAppsDirectory);
 

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -271,9 +271,9 @@ arangodb::Result Databases::create(std::string const& dbName, VPackSlice const& 
     }
 
     TRI_vocbase_t* vocbase = nullptr;
-    int res = databaseFeature->createDatabase(id, dbName, vocbase);
-    if (res != TRI_ERROR_NO_ERROR) {
-      return Result(res);
+    Result res = databaseFeature->createDatabase(id, dbName, vocbase);
+    if (res.fail()) {
+      return res;
     }
 
     TRI_ASSERT(vocbase != nullptr);

--- a/arangod/VocBase/Methods/UpgradeTasks.cpp
+++ b/arangod/VocBase/Methods/UpgradeTasks.cpp
@@ -65,7 +65,7 @@ namespace {
 void createSystemCollection(TRI_vocbase_t& vocbase, std::string const& name) {
   auto const res = methods::Collections::createSystem(vocbase, name);
 
-  if (res.fail()) {
+  if (res.fail() && !res.is(TRI_ERROR_ARANGO_DUPLICATE_NAME)) {
     THROW_ARANGO_EXCEPTION(res);
   }
 }

--- a/tests/Cluster/ClusterInfo-test.cpp
+++ b/tests/Cluster/ClusterInfo-test.cpp
@@ -249,9 +249,8 @@ TEST_F(ClusterInfoTest, test_drop_database) {
         "{ \"name\": \"testView\", \"type\": \"testViewType\" }");
     TRI_vocbase_t* vocbase;  // will be owned by DatabaseFeature
     // create database
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 database->createDatabase(1, "testDatabase", vocbase)));
-    ASSERT_TRUE((nullptr != vocbase));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
+    ASSERT_NE(nullptr, vocbase);
 
     // simulate heartbeat thread
     ASSERT_TRUE(arangodb::AgencyComm().setValue("Current/Databases/testDatabase", arangodb::velocypack::Slice::emptyObjectSlice(), 0.0).successful());

--- a/tests/IResearch/IResearchAnalyzerFeature-test.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeature-test.cpp
@@ -985,8 +985,7 @@ class IResearchAnalyzerFeatureGetTest : public IResearchAnalyzerFeatureTest {
     ASSERT_NE(_sysVocbase, nullptr);
 
     _vocbase = nullptr;
-    auto res = _dbFeature->createDatabase(1, dbName, _vocbase);
-    ASSERT_EQ(res, TRI_ERROR_NO_ERROR);
+    ASSERT_TRUE(_dbFeature->createDatabase(1, dbName, _vocbase).ok());
     ASSERT_NE(_vocbase, nullptr);
     arangodb::methods::Collections::createSystem(*_vocbase, arangodb::tests::AnalyzerCollectionName);
     // Prepare analyzers
@@ -1377,8 +1376,7 @@ class IResearchAnalyzerFeatureCoordinatorTest : public ::testing::Test {
     }
 
     _vocbase = nullptr;
-    auto res = dbFeature->createDatabase(1, _dbName, _vocbase);
-    ASSERT_EQ(res, TRI_ERROR_NO_ERROR);
+    ASSERT_TRUE(dbFeature->createDatabase(1, _dbName, _vocbase).ok());
     ASSERT_NE(_vocbase, nullptr);
 
     // Prepare analyzers
@@ -2471,8 +2469,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_remove) {
   {
     arangodb::iresearch::IResearchAnalyzerFeature feature(server);
     TRI_vocbase_t* vocbase;
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 dbFeature->createDatabase(1, "testVocbase", vocbase)));
+    ASSERT_TRUE(dbFeature->createDatabase(1, "testVocbase", vocbase).ok());
     ASSERT_TRUE((nullptr != dbFeature->lookupDatabase("testVocbase")));
 
     EXPECT_TRUE((true == !feature.get("testVocbase::test_analyzer")));
@@ -2972,8 +2969,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_upgrade_static_legacy) {
         StorageEngineMock::versionFilenameResult, versionJson->slice(), false)));
 
     TRI_vocbase_t* vocbase;
-    EXPECT_TRUE((TRI_ERROR_NO_ERROR ==
-                 dbFeature->createDatabase(1, "testVocbase", vocbase)));
+    EXPECT_TRUE(dbFeature->createDatabase(1, "testVocbase", vocbase).ok());
     sysDatabase->unprepare();  // unset system vocbase
     EXPECT_TRUE((arangodb::methods::Upgrade::startup(*vocbase, true, false).ok()));  // run upgrade
     EXPECT_TRUE((false == !vocbase->lookupCollection(arangodb::tests::AnalyzerCollectionName)));
@@ -3030,8 +3026,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_upgrade_static_legacy) {
 
     std::unordered_set<std::string> expected{"abc"};
     TRI_vocbase_t* vocbase;
-    EXPECT_TRUE((TRI_ERROR_NO_ERROR ==
-                 dbFeature->createDatabase(1, "testVocbase", vocbase)));
+    EXPECT_TRUE(dbFeature->createDatabase(1, "testVocbase", vocbase).ok());
     EXPECT_TRUE((false == !vocbase->createCollection(createCollectionJson->slice())));
 
     // add document to collection
@@ -3117,8 +3112,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_upgrade_static_legacy) {
         StorageEngineMock::versionFilenameResult, versionJson->slice(), false)));
 
     TRI_vocbase_t* vocbase;
-    EXPECT_TRUE((TRI_ERROR_NO_ERROR ==
-                 dbFeature->createDatabase(1, "testVocbase", vocbase)));
+    EXPECT_TRUE(dbFeature->createDatabase(1, "testVocbase", vocbase).ok());
     EXPECT_TRUE((arangodb::methods::Upgrade::startup(*vocbase, true, false).ok()));  // run upgrade
     EXPECT_TRUE((false == !vocbase->lookupCollection(arangodb::tests::AnalyzerCollectionName)));
     auto result = arangodb::tests::executeQuery(*vocbase, ANALYZER_COLLECTION_QUERY);
@@ -3180,8 +3174,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_upgrade_static_legacy) {
 
     std::unordered_set<std::string> expected{"abc"};
     TRI_vocbase_t* vocbase;
-    EXPECT_TRUE((TRI_ERROR_NO_ERROR ==
-                 dbFeature->createDatabase(1, "testVocbase", vocbase)));
+    EXPECT_TRUE(dbFeature->createDatabase(1, "testVocbase", vocbase).ok());
     EXPECT_TRUE((false == !vocbase->createCollection(createCollectionJson->slice())));
 
     // add document to collection
@@ -3281,8 +3274,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_upgrade_static_legacy) {
         StorageEngineMock::versionFilenameResult, versionJson->slice(), false)));
 
     TRI_vocbase_t* vocbase;
-    EXPECT_TRUE((TRI_ERROR_NO_ERROR ==
-                 dbFeature->createDatabase(1, "testVocbase", vocbase)));
+    EXPECT_TRUE(dbFeature->createDatabase(1, "testVocbase", vocbase).ok());
     EXPECT_TRUE((arangodb::methods::Upgrade::startup(*vocbase, true, false).ok()));  // run upgrade
     EXPECT_TRUE((false == !vocbase->lookupCollection(arangodb::tests::AnalyzerCollectionName)));
     auto result = arangodb::tests::executeQuery(*vocbase, ANALYZER_COLLECTION_QUERY);
@@ -3344,8 +3336,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_upgrade_static_legacy) {
 
     std::set<std::string> expected{"abc"};
     TRI_vocbase_t* vocbase;
-    EXPECT_TRUE((TRI_ERROR_NO_ERROR ==
-                 dbFeature->createDatabase(1, "testVocbase", vocbase)));
+    EXPECT_TRUE(dbFeature->createDatabase(1, "testVocbase", vocbase).ok());
     EXPECT_TRUE((false == !vocbase->createCollection(createCollectionJson->slice())));
 
     // add document to collection
@@ -3567,9 +3558,9 @@ TEST_F(IResearchAnalyzerFeatureTest, test_visit) {
   TRI_vocbase_t* vocbase0;
   TRI_vocbase_t* vocbase1;
   TRI_vocbase_t* vocbase2;
-  EXPECT_TRUE((TRI_ERROR_NO_ERROR == dbFeature->createDatabase(1, "vocbase0", vocbase0)));
-  EXPECT_TRUE((TRI_ERROR_NO_ERROR == dbFeature->createDatabase(1, "vocbase1", vocbase1)));
-  EXPECT_TRUE((TRI_ERROR_NO_ERROR == dbFeature->createDatabase(1, "vocbase2", vocbase2)));
+  EXPECT_TRUE(dbFeature->createDatabase(1, "vocbase0", vocbase0).ok());
+  EXPECT_TRUE(dbFeature->createDatabase(1, "vocbase1", vocbase1).ok());
+  EXPECT_TRUE(dbFeature->createDatabase(1, "vocbase2", vocbase2).ok());
   arangodb::methods::Collections::createSystem(*vocbase0, arangodb::tests::AnalyzerCollectionName);
   arangodb::methods::Collections::createSystem(*vocbase1, arangodb::tests::AnalyzerCollectionName);
   arangodb::methods::Collections::createSystem(*vocbase2, arangodb::tests::AnalyzerCollectionName);

--- a/tests/IResearch/IResearchFeature-test.cpp
+++ b/tests/IResearch/IResearchFeature-test.cpp
@@ -457,7 +457,7 @@ TEST_F(IResearchFeatureTest, test_upgrade0_1) {
     ASSERT_TRUE((nullptr != ci));
     TRI_vocbase_t* vocbase; // will be owned by DatabaseFeature
 
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR == database->createDatabase(1, "testDatabase", vocbase)));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
     ASSERT_TRUE(arangodb::AgencyComm().setValue(std::string("Current/Databases/") + vocbase->name(), arangodb::velocypack::Slice::emptyObjectSlice(), 0.0).successful());    
     ASSERT_TRUE((ci->createDatabaseCoordinator(vocbase->name(), arangodb::velocypack::Slice::emptyObjectSlice(), 0.0).ok()));
     ASSERT_TRUE((ci->createCollectionCoordinator(vocbase->name(), collectionId, 0, 1, 1, false, collectionJson->slice(), 0.0).ok()));

--- a/tests/IResearch/IResearchLinkCoordinator-test.cpp
+++ b/tests/IResearch/IResearchLinkCoordinator-test.cpp
@@ -273,9 +273,9 @@ TEST_F(IResearchLinkCoordinatorTest, test_create_drop) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_TRUE(TRI_ERROR_NO_ERROR == database->createDatabase(1, "testDatabase", vocbase));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
-    ASSERT_TRUE(nullptr != vocbase);
+    ASSERT_NE(nullptr, vocbase);
     EXPECT_TRUE("testDatabase" == vocbase->name());
     EXPECT_TRUE(TRI_vocbase_type_e::TRI_VOCBASE_TYPE_COORDINATOR == vocbase->type());
     EXPECT_TRUE(1 == vocbase->id());

--- a/tests/IResearch/IResearchLinkHelper-test.cpp
+++ b/tests/IResearch/IResearchLinkHelper-test.cpp
@@ -533,8 +533,8 @@ TEST_F(IResearchLinkHelperTest, test_updateLinks) {
             "Database");
     TRI_vocbase_t* vocbase;
     ASSERT_TRUE(
-        (TRI_ERROR_NO_ERROR == dbFeature->createDatabase(1, "testVocbase", vocbase)));  // required for IResearchAnalyzerFeature::emplace(...)
-    ASSERT_TRUE((nullptr != vocbase));
+        dbFeature->createDatabase(1, "testVocbase", vocbase).ok());  // required for IResearchAnalyzerFeature::emplace(...)
+    ASSERT_NE(nullptr, vocbase);
     arangodb::methods::Collections::createSystem(
         *vocbase, 
         arangodb::tests::AnalyzerCollectionName);

--- a/tests/IResearch/IResearchView-test.cpp
+++ b/tests/IResearch/IResearchView-test.cpp
@@ -1081,8 +1081,8 @@ TEST_F(IResearchViewTest, test_drop_database) {
   StorageEngineMock::before = [&beforeCount]()->void { ++beforeCount; };
 
   TRI_vocbase_t* vocbase; // will be owned by DatabaseFeature
-  ASSERT_TRUE((TRI_ERROR_NO_ERROR == databaseFeature->createDatabase(0, "testDatabase" TOSTRING(__LINE__), vocbase)));
-  ASSERT_TRUE((nullptr != vocbase));
+  ASSERT_TRUE(databaseFeature->createDatabase(0, "testDatabase" TOSTRING(__LINE__), vocbase).ok());
+  ASSERT_NE(nullptr, vocbase);
 
   beforeCount = 0; // reset before call to StorageEngine::createView(...)
   auto logicalView = vocbase->createView(viewCreateJson->slice());

--- a/tests/IResearch/IResearchViewCoordinator-test.cpp
+++ b/tests/IResearch/IResearchViewCoordinator-test.cpp
@@ -314,8 +314,8 @@ TEST_F(IResearchViewCoordinatorTest, visit_collections) {
   {
     auto* database = arangodb::DatabaseFeature::DATABASE;
     ASSERT_TRUE((nullptr != database));
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR == database->createDatabase(1, "testVocbase", vocbase)));
-    ASSERT_TRUE((nullptr != vocbase));
+    ASSERT_TRUE(database->createDatabase(1, "testVocbase", vocbase).ok());
+    ASSERT_NE(nullptr, vocbase);
     ASSERT_TRUE(arangodb::AgencyComm().setValue(std::string("Current/Databases/") + vocbase->name(), arangodb::velocypack::Slice::emptyObjectSlice(), 0.0).successful());
     ASSERT_TRUE((ci->createDatabaseCoordinator(vocbase->name(),
                                                arangodb::velocypack::Slice::emptyObjectSlice(), 0.0)
@@ -393,10 +393,9 @@ TEST_F(IResearchViewCoordinatorTest, test_defaults) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 database->createDatabase(1, "testDatabase", vocbase)));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
-    ASSERT_TRUE((nullptr != vocbase));
+    ASSERT_NE(nullptr, vocbase);
     EXPECT_TRUE(("testDatabase" == vocbase->name()));
     EXPECT_TRUE((TRI_vocbase_type_e::TRI_VOCBASE_TYPE_COORDINATOR == vocbase->type()));
     EXPECT_TRUE((1 == vocbase->id()));
@@ -688,9 +687,9 @@ TEST_F(IResearchViewCoordinatorTest, test_create_drop_view) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_TRUE(TRI_ERROR_NO_ERROR == database->createDatabase(1, "testDatabase", vocbase));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
-    ASSERT_TRUE(nullptr != vocbase);
+    ASSERT_NE(nullptr, vocbase);
     EXPECT_TRUE("testDatabase" == vocbase->name());
     EXPECT_TRUE(TRI_vocbase_type_e::TRI_VOCBASE_TYPE_COORDINATOR == vocbase->type());
     EXPECT_TRUE(1 == vocbase->id());
@@ -836,7 +835,7 @@ TEST_F(IResearchViewCoordinatorTest, test_create_link_in_background) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_EQ(TRI_ERROR_NO_ERROR, database->createDatabase(1, "testDatabase", vocbase));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
     ASSERT_NE(nullptr, vocbase);
     ASSERT_EQ("testDatabase", vocbase->name());
@@ -953,10 +952,9 @@ TEST_F(IResearchViewCoordinatorTest, test_drop_with_link) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 database->createDatabase(1, "testDatabase", vocbase)));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
-    ASSERT_TRUE((nullptr != vocbase));
+    ASSERT_NE(nullptr, vocbase);
     EXPECT_TRUE(("testDatabase" == vocbase->name()));
     EXPECT_TRUE((TRI_vocbase_type_e::TRI_VOCBASE_TYPE_COORDINATOR == vocbase->type()));
     EXPECT_TRUE((1 == vocbase->id()));
@@ -1084,9 +1082,9 @@ TEST_F(IResearchViewCoordinatorTest, test_update_properties) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_TRUE(TRI_ERROR_NO_ERROR == database->createDatabase(1, "testDatabase", vocbase));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
-    ASSERT_TRUE(nullptr != vocbase);
+    ASSERT_NE(nullptr, vocbase);
     EXPECT_TRUE("testDatabase" == vocbase->name());
     EXPECT_TRUE(TRI_vocbase_type_e::TRI_VOCBASE_TYPE_COORDINATOR == vocbase->type());
     EXPECT_TRUE(1 == vocbase->id());
@@ -1255,7 +1253,7 @@ TEST_F(IResearchViewCoordinatorTest, test_overwrite_immutable_properties) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_EQ(TRI_ERROR_NO_ERROR, database->createDatabase(1, "testDatabase", vocbase));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
     ASSERT_NE(nullptr, vocbase);
     EXPECT_EQ("testDatabase", vocbase->name());
@@ -1455,9 +1453,9 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_remove) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_TRUE(TRI_ERROR_NO_ERROR == database->createDatabase(1, "testDatabase", vocbase));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
-    ASSERT_TRUE(nullptr != vocbase);
+    ASSERT_NE(nullptr, vocbase);
     EXPECT_TRUE("testDatabase" == vocbase->name());
     EXPECT_TRUE(TRI_vocbase_type_e::TRI_VOCBASE_TYPE_COORDINATOR == vocbase->type());
     EXPECT_TRUE(1 == vocbase->id());
@@ -2047,9 +2045,9 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_add) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_TRUE(TRI_ERROR_NO_ERROR == database->createDatabase(1, "testDatabase", vocbase));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
-    ASSERT_TRUE(nullptr != vocbase);
+    ASSERT_NE(nullptr, vocbase);
     EXPECT_TRUE("testDatabase" == vocbase->name());
     EXPECT_TRUE(TRI_vocbase_type_e::TRI_VOCBASE_TYPE_COORDINATOR == vocbase->type());
     EXPECT_TRUE(1 == vocbase->id());
@@ -2690,9 +2688,9 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_replace) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_TRUE(TRI_ERROR_NO_ERROR == database->createDatabase(1, "testDatabase", vocbase));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
-    ASSERT_TRUE(nullptr != vocbase);
+    ASSERT_NE(nullptr, vocbase);
     EXPECT_TRUE("testDatabase" == vocbase->name());
     EXPECT_TRUE(TRI_vocbase_type_e::TRI_VOCBASE_TYPE_COORDINATOR == vocbase->type());
     EXPECT_TRUE(1 == vocbase->id());
@@ -3291,9 +3289,9 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_clear) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_TRUE(TRI_ERROR_NO_ERROR == database->createDatabase(1, "testDatabase", vocbase));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
-    ASSERT_TRUE(nullptr != vocbase);
+    ASSERT_NE(nullptr, vocbase);
     EXPECT_TRUE("testDatabase" == vocbase->name());
     EXPECT_TRUE(TRI_vocbase_type_e::TRI_VOCBASE_TYPE_COORDINATOR == vocbase->type());
     EXPECT_TRUE(1 == vocbase->id());
@@ -3756,9 +3754,9 @@ TEST_F(IResearchViewCoordinatorTest, test_drop_link) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_TRUE(TRI_ERROR_NO_ERROR == database->createDatabase(1, "testDatabase", vocbase));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
-    ASSERT_TRUE(nullptr != vocbase);
+    ASSERT_NE(nullptr, vocbase);
     EXPECT_TRUE("testDatabase" == vocbase->name());
     EXPECT_TRUE(TRI_vocbase_type_e::TRI_VOCBASE_TYPE_COORDINATOR == vocbase->type());
     EXPECT_TRUE(1 == vocbase->id());
@@ -4064,10 +4062,9 @@ TEST_F(IResearchViewCoordinatorTest, test_update_overwrite) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 database->createDatabase(1, "testDatabase", vocbase)));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
-    ASSERT_TRUE((nullptr != vocbase));
+    ASSERT_NE(nullptr, vocbase);
     EXPECT_TRUE(("testDatabase" == vocbase->name()));
     EXPECT_TRUE((TRI_vocbase_type_e::TRI_VOCBASE_TYPE_COORDINATOR == vocbase->type()));
     EXPECT_TRUE((1 == vocbase->id()));
@@ -4829,10 +4826,9 @@ TEST_F(IResearchViewCoordinatorTest, test_update_partial) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 database->createDatabase(1, "testDatabase", vocbase)));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
-    ASSERT_TRUE((nullptr != vocbase));
+    ASSERT_NE(nullptr, vocbase);
     EXPECT_TRUE(("testDatabase" == vocbase->name()));
     EXPECT_TRUE((TRI_vocbase_type_e::TRI_VOCBASE_TYPE_COORDINATOR == vocbase->type()));
     EXPECT_TRUE((1 == vocbase->id()));
@@ -5601,9 +5597,9 @@ TEST_F(IResearchViewCoordinatorTest, IResearchViewNode_createBlock) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_TRUE(TRI_ERROR_NO_ERROR == database->createDatabase(1, "testDatabase", vocbase));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
-    ASSERT_TRUE(nullptr != vocbase);
+    ASSERT_NE(nullptr, vocbase);
     EXPECT_TRUE("testDatabase" == vocbase->name());
     EXPECT_TRUE(TRI_vocbase_type_e::TRI_VOCBASE_TYPE_COORDINATOR == vocbase->type());
     EXPECT_TRUE(1 == vocbase->id());

--- a/tests/IResearch/IResearchViewDBServer-test.cpp
+++ b/tests/IResearch/IResearchViewDBServer-test.cpp
@@ -237,9 +237,9 @@ TEST_F(IResearchViewDBServerTest, test_drop) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_TRUE(TRI_ERROR_NO_ERROR == database->createDatabase(1, "testDatabase", vocbase));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
-    ASSERT_TRUE(nullptr != vocbase);
+    ASSERT_NE(nullptr, vocbase);
     EXPECT_TRUE("testDatabase" == vocbase->name());
     EXPECT_TRUE(TRI_vocbase_type_e::TRI_VOCBASE_TYPE_NORMAL == vocbase->type());
     EXPECT_TRUE(1 == vocbase->id());
@@ -354,9 +354,9 @@ TEST_F(IResearchViewDBServerTest, test_drop_cid) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_TRUE(TRI_ERROR_NO_ERROR == database->createDatabase(1, "testDatabase", vocbase));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
-    ASSERT_TRUE(nullptr != vocbase);
+    ASSERT_NE(nullptr, vocbase);
     EXPECT_TRUE("testDatabase" == vocbase->name());
     EXPECT_TRUE(TRI_vocbase_type_e::TRI_VOCBASE_TYPE_NORMAL == vocbase->type());
     EXPECT_TRUE(1 == vocbase->id());
@@ -422,9 +422,8 @@ TEST_F(IResearchViewDBServerTest, test_drop_database) {
   PhysicalCollectionMock::before = [&beforeCount]() -> void { ++beforeCount; };
 
   TRI_vocbase_t* vocbase;  // will be owned by DatabaseFeature
-  ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-               databaseFeature->createDatabase(0, "testDatabase" TOSTRING(__LINE__), vocbase)));
-  ASSERT_TRUE((nullptr != vocbase));
+  ASSERT_TRUE(databaseFeature->createDatabase(0, "testDatabase" TOSTRING(__LINE__), vocbase).ok());
+  ASSERT_NE(nullptr, vocbase);
   ASSERT_TRUE(arangodb::AgencyComm().setValue(std::string("Current/Databases/") + vocbase->name(), arangodb::velocypack::Slice::emptyObjectSlice(), 0.0).successful());  
   ASSERT_TRUE((ci->createDatabaseCoordinator(vocbase->name(),
                                              arangodb::velocypack::Slice::emptyObjectSlice(), 0.)
@@ -458,9 +457,9 @@ TEST_F(IResearchViewDBServerTest, test_ensure) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_TRUE(TRI_ERROR_NO_ERROR == database->createDatabase(1, "testDatabase", vocbase));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
-    ASSERT_TRUE(nullptr != vocbase);
+    ASSERT_NE(nullptr, vocbase);
     EXPECT_TRUE("testDatabase" == vocbase->name());
     EXPECT_TRUE(TRI_vocbase_type_e::TRI_VOCBASE_TYPE_NORMAL == vocbase->type());
     EXPECT_TRUE(1 == vocbase->id());
@@ -620,8 +619,7 @@ TEST_F(IResearchViewDBServerTest, test_query) {
         "{ \"view\": \"testView\", \"type\": \"arangosearch\", "
         "\"includeAllFields\": true }");
     TRI_vocbase_t* vocbase;  // will be owned by DatabaseFeature
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 database->createDatabase(1, "testDatabase0", vocbase)));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase0", vocbase).ok());
     EXPECT_TRUE(arangodb::AgencyComm().setValue(std::string("Current/Databases/") + vocbase->name(), arangodb::velocypack::Slice::emptyObjectSlice(), 0.0).successful());
     EXPECT_TRUE((ci->createDatabaseCoordinator(vocbase->name(), VPackSlice::emptyObjectSlice(), 0.0)
                      .ok()));
@@ -664,8 +662,7 @@ TEST_F(IResearchViewDBServerTest, test_query) {
         "{ \"view\": \"testView\", \"type\": \"arangosearch\", "
         "\"includeAllFields\": true }");
     TRI_vocbase_t* vocbase;  // will be owned by DatabaseFeature
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 database->createDatabase(1, "testDatabase1", vocbase)));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase1", vocbase).ok());
     EXPECT_TRUE(arangodb::AgencyComm().setValue(std::string("Current/Databases/") + vocbase->name(), arangodb::velocypack::Slice::emptyObjectSlice(), 0.0).successful());
     EXPECT_TRUE((ci->createDatabaseCoordinator(vocbase->name(), VPackSlice::emptyObjectSlice(), 0.0)
                      .ok()));
@@ -731,9 +728,8 @@ TEST_F(IResearchViewDBServerTest, test_query) {
         "{ \"name\": \"testCollection\", \"id\":442 }");
 
     TRI_vocbase_t* vocbase;  // will be owned by DatabaseFeature
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 databaseFeature->createDatabase(0, "testDatabase" TOSTRING(__LINE__), vocbase)));
-    ASSERT_TRUE((nullptr != vocbase));
+    ASSERT_TRUE(databaseFeature->createDatabase(0, "testDatabase" TOSTRING(__LINE__), vocbase).ok());
+    ASSERT_NE(nullptr, vocbase);
     ASSERT_TRUE(arangodb::AgencyComm().setValue(std::string("Current/Databases/") + vocbase->name(), arangodb::velocypack::Slice::emptyObjectSlice(), 0.0).successful());
     ASSERT_TRUE((ci->createDatabaseCoordinator(vocbase->name(),
                                                arangodb::velocypack::Slice::emptyObjectSlice(), 0.)
@@ -832,9 +828,8 @@ TEST_F(IResearchViewDBServerTest, test_query) {
             "Flush");
     ASSERT_TRUE(feature);
     TRI_vocbase_t* vocbase;  // will be owned by DatabaseFeature
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 databaseFeature->createDatabase(0, "testDatabase" TOSTRING(__LINE__), vocbase)));
-    ASSERT_TRUE((nullptr != vocbase));
+    ASSERT_TRUE(databaseFeature->createDatabase(0, "testDatabase" TOSTRING(__LINE__), vocbase).ok());
+    ASSERT_NE(nullptr, vocbase);
     ASSERT_TRUE(arangodb::AgencyComm().setValue(std::string("Current/Databases/") + vocbase->name(), arangodb::velocypack::Slice::emptyObjectSlice(), 0.0).successful());
     EXPECT_TRUE((ci->createDatabaseCoordinator(
                    vocbase->name(),
@@ -1121,9 +1116,9 @@ TEST_F(IResearchViewDBServerTest, test_transaction_snapshot) {
   // create database
   {
     // simulate heartbeat thread
-    ASSERT_TRUE(TRI_ERROR_NO_ERROR == database->createDatabase(1, "testDatabase", vocbase));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
-    ASSERT_TRUE(nullptr != vocbase);
+    ASSERT_NE(nullptr, vocbase);
     EXPECT_TRUE("testDatabase" == vocbase->name());
     EXPECT_TRUE(TRI_vocbase_type_e::TRI_VOCBASE_TYPE_NORMAL == vocbase->type());
     EXPECT_TRUE(1 == vocbase->id());
@@ -1267,9 +1262,8 @@ TEST_F(IResearchViewDBServerTest, test_updateProperties) {
         "\"collections\": [ 3, 4, 5 ], \"cleanupIntervalStep\": 24, "
         "\"consolidationIntervalMsec\": 42 }");
     TRI_vocbase_t* vocbase;  // will be owned by DatabaseFeature
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 databaseFeature->createDatabase(0, "testDatabase" TOSTRING(__LINE__), vocbase)));
-    ASSERT_TRUE((nullptr != vocbase));
+    ASSERT_TRUE(databaseFeature->createDatabase(0, "testDatabase" TOSTRING(__LINE__), vocbase).ok());
+    ASSERT_NE(nullptr, vocbase);
     ASSERT_TRUE(arangodb::AgencyComm().setValue(std::string("Current/Databases/") + vocbase->name(), arangodb::velocypack::Slice::emptyObjectSlice(), 0.0).successful());
     ASSERT_TRUE((ci->createDatabaseCoordinator(vocbase->name(),
                                                arangodb::velocypack::Slice::emptyObjectSlice(), 0.)
@@ -1393,9 +1387,8 @@ TEST_F(IResearchViewDBServerTest, test_updateProperties) {
         "\"collections\": [ 3, 4, 5 ], \"cleanupIntervalStep\": 24, "
         "\"consolidationIntervalMsec\": 42 }");
     TRI_vocbase_t* vocbase;  // will be owned by DatabaseFeature
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 databaseFeature->createDatabase(0, "testDatabase" TOSTRING(__LINE__), vocbase)));
-    ASSERT_TRUE((nullptr != vocbase));
+    ASSERT_TRUE(databaseFeature->createDatabase(0, "testDatabase" TOSTRING(__LINE__), vocbase).ok());
+    ASSERT_NE(nullptr, vocbase);
     ASSERT_TRUE(arangodb::AgencyComm().setValue(std::string("Current/Databases/") + vocbase->name(), arangodb::velocypack::Slice::emptyObjectSlice(), 0.0).successful());
     ASSERT_TRUE((ci->createDatabaseCoordinator(vocbase->name(),
                                                arangodb::velocypack::Slice::emptyObjectSlice(), 0.)
@@ -1522,9 +1515,8 @@ TEST_F(IResearchViewDBServerTest, test_updateProperties) {
         "\"collections\": [ 3, 4, 5 ], \"cleanupIntervalStep\": 24, "
         "\"consolidationIntervalMsec\": 42 }");
     TRI_vocbase_t* vocbase;  // will be owned by DatabaseFeature
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 databaseFeature->createDatabase(0, "testDatabase" TOSTRING(__LINE__), vocbase)));
-    ASSERT_TRUE((nullptr != vocbase));
+    ASSERT_TRUE(databaseFeature->createDatabase(0, "testDatabase" TOSTRING(__LINE__), vocbase).ok());
+    ASSERT_NE(nullptr, vocbase);
     ASSERT_TRUE(arangodb::AgencyComm().setValue(std::string("Current/Databases/") + vocbase->name(), arangodb::velocypack::Slice::emptyObjectSlice(), 0.0).successful());
     ASSERT_TRUE((ci->createDatabaseCoordinator(vocbase->name(),
                                                arangodb::velocypack::Slice::emptyObjectSlice(), 0.)
@@ -1656,9 +1648,8 @@ TEST_F(IResearchViewDBServerTest, test_updateProperties) {
         "\"collections\": [ 3, 4, 5 ], \"cleanupIntervalStep\": 24, "
         "\"consolidationIntervalMsec\": 42 }");
     TRI_vocbase_t* vocbase;  // will be owned by DatabaseFeature
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 databaseFeature->createDatabase(0, "testDatabase" TOSTRING(__LINE__), vocbase)));
-    ASSERT_TRUE((nullptr != vocbase));
+    ASSERT_TRUE(databaseFeature->createDatabase(0, "testDatabase" TOSTRING(__LINE__), vocbase).ok());
+    ASSERT_NE(nullptr, vocbase);
     ASSERT_TRUE(arangodb::AgencyComm().setValue(std::string("Current/Databases/") + vocbase->name(), arangodb::velocypack::Slice::emptyObjectSlice(), 0.0).successful());
     ASSERT_TRUE((ci->createDatabaseCoordinator(vocbase->name(),
                                                arangodb::velocypack::Slice::emptyObjectSlice(), 0.)

--- a/tests/RestHandler/RestAnalyzerHandler-test.cpp
+++ b/tests/RestHandler/RestAnalyzerHandler-test.cpp
@@ -1102,8 +1102,7 @@ TEST_F(RestAnalyzerHandlerTest, test_list) {
         arangodb::StaticStrings::SystemDatabase + "\" } ]");
     ASSERT_TRUE((TRI_ERROR_NO_ERROR == dbFeature->loadDatabases(databases->slice())));
     TRI_vocbase_t* vocbase;
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 dbFeature->createDatabase(1, "testVocbase", vocbase)));
+    ASSERT_TRUE(dbFeature->createDatabase(1, "testVocbase", vocbase).ok());
     sysDatabase->start();  // get system database from DatabaseFeature
     arangodb::methods::Collections::createSystem(
         *vocbase, 

--- a/tests/RestHandler/RestUsersHandler-test.cpp
+++ b/tests/RestHandler/RestUsersHandler-test.cpp
@@ -196,8 +196,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
       arangodb::application_features::ApplicationServer::getFeature<arangodb::DatabaseFeature>(
           "Database");
   TRI_vocbase_t* vocbase;  // will be owned by DatabaseFeature
-  ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-               databaseFeature->createDatabase(1, "testDatabase", vocbase)));
+  ASSERT_TRUE(databaseFeature->createDatabase(1, "testDatabase", vocbase).ok());
   auto grantRequestPtr = std::make_unique<GeneralRequestMock>(*vocbase);
   auto& grantRequest = *grantRequestPtr;
   auto grantResponcePtr = std::make_unique<GeneralResponseMock>();

--- a/tests/RestServer/FlushFeature-test.cpp
+++ b/tests/RestServer/FlushFeature-test.cpp
@@ -145,7 +145,7 @@ TEST_F(FlushFeatureTest, test_subscription_retention) {
           "Database");
   ASSERT_TRUE((dbFeature));
   TRI_vocbase_t* vocbase;
-  ASSERT_TRUE((TRI_ERROR_NO_ERROR == dbFeature->createDatabase(1, "testDatabase", vocbase)));
+  ASSERT_TRUE(dbFeature->createDatabase(1, "testDatabase", vocbase).ok());
   ASSERT_NE(nullptr, vocbase);
 
   arangodb::FlushFeature feature(server);

--- a/tests/V8Server/v8-analyzers-test.cpp
+++ b/tests/V8Server/v8-analyzers-test.cpp
@@ -2081,8 +2081,7 @@ TEST_F(V8AnalyzersTest, test_list) {
         arangodb::StaticStrings::SystemDatabase + "\" } ]");
     ASSERT_TRUE((TRI_ERROR_NO_ERROR == dbFeature->loadDatabases(databases->slice())));
     TRI_vocbase_t* vocbase;
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 dbFeature->createDatabase(1, "testVocbase", vocbase)));
+    ASSERT_TRUE(dbFeature->createDatabase(1, "testVocbase", vocbase).ok());
     sysDatabase->start();  // get system database from DatabaseFeature
     arangodb::methods::Collections::createSystem(
         *vocbase, 

--- a/tests/V8Server/v8-users-test.cpp
+++ b/tests/V8Server/v8-users-test.cpp
@@ -224,8 +224,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
       arangodb::application_features::ApplicationServer::getFeature<arangodb::DatabaseFeature>(
           "Database");
   TRI_vocbase_t* vocbase;  // will be owned by DatabaseFeature
-  ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-               databaseFeature->createDatabase(1, "testDatabase", vocbase)));
+  ASSERT_TRUE(databaseFeature->createDatabase(1, "testDatabase", vocbase).ok());
   v8::Isolate::CreateParams isolateParams;
   ArrayBufferAllocator arrayBufferAllocator;
   isolateParams.array_buffer_allocator = &arrayBufferAllocator;


### PR DESCRIPTION
### Scope & Purpose

Harden database creation against spurious "duplicate name" errors
that were caused by other parallel operations lazily creating required
system collections in the same database.

Problems can occur when during database creation some JS code runs
that attempts to create the same system collection that the "create database"
operation tries to create concurrently. There is a small window of overlap
here in which this can make database creation fail.

Additionally improve error messages in case an attempt of creating a database
object (database, collection, view) fails due to a "duplicate name" error.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6126/