### PR TITLE
Bug fix/harden database creation against duplicate name

### DIFF
--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -1384,8 +1384,8 @@ AgencyCommResult AgencyComm::sendWithFailover(arangodb::rest::RequestType method
   AgencyCommResult result;
   if (!AgencyCommManager::isEnabled()) {
     LOG_TOPIC("42fae", ERR, Logger::AGENCYCOMM)
-      << "No AgencyCommManager.  Inappropriate agent usage?";
-    result.set(503, "No AgencyCommManager. Inappropriate agent usage?");
+      << "No AgencyCommManager. Inappropriate agent usage?";
+    result.set(static_cast<int>(rest::ResponseCode::SERVICE_UNAVAILABLE), "No AgencyCommManager. Inappropriate agent usage?");
     return result;
   } // if
 
@@ -1511,7 +1511,7 @@ AgencyCommResult AgencyComm::sendWithFailover(arangodb::rest::RequestType method
           if (clientIds[0] == "INTEGRATION_TEST_INQUIRY_ERROR_0") {
             result._statusCode = 0;
           } else if (clientIds[0] == "INTEGRATION_TEST_INQUIRY_ERROR_503") {
-            result._statusCode = 503;
+            result._statusCode = static_cast<int>(rest::ResponseCode::SERVICE_UNAVAILABLE);
           }
         }
 #endif
@@ -1542,7 +1542,7 @@ AgencyCommResult AgencyComm::sendWithFailover(arangodb::rest::RequestType method
       // timeout is reached.
       // Also note that we only inquire about WriteTransactions.
       if (isWriteTrans && !clientIds.empty() && result._sent &&
-          (result._statusCode == 0 || result._statusCode == 503)) {
+          (result._statusCode == 0 || result._statusCode == static_cast<int>(rest::ResponseCode::SERVICE_UNAVAILABLE))) {
         isInquiry = true;
         conTimeout = 16.0;
       }
@@ -1624,7 +1624,7 @@ AgencyCommResult AgencyComm::sendWithFailover(arangodb::rest::RequestType method
       }
     }
 
-    if (result._statusCode == 0 || result._statusCode == 503) {
+    if (result._statusCode == 0 || result._statusCode == static_cast<int>(rest::ResponseCode::SERVICE_UNAVAILABLE)) {
       // Rotate to new agent endpoint:
       AgencyCommManager::MANAGER->failed(std::move(connection), endpoint);
       endpoint.clear();
@@ -1633,13 +1633,13 @@ AgencyCommResult AgencyComm::sendWithFailover(arangodb::rest::RequestType method
   }
 
   // Log error
-  if (!result.successful() && result.httpCode() != 412) {
+  if (!result.successful() && result.httpCode() != static_cast<int>(rest::ResponseCode::PRECONDITION_FAILED)) {
     LOG_TOPIC("78466", DEBUG, Logger::AGENCYCOMM)
-        << "Unsuccessful AgencyComm: "
-        << "errorCode: " << result.errorCode()
+        << "Unsuccessful AgencyComm:"
+        << " errorCode: " << result.errorCode()
         << " errorMessage: " << result.errorMessage()
         << " errorDetails: " << result.errorDetails();
-  }
+  } 
 
   return result;
 }

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1591,7 +1591,7 @@ Result ClusterInfo::waitForDatabaseInCurrent(methods::CreateDatabaseInfo const& 
       agencyCallback->executeByCallbackOrTimeout(getReloadServerListTimeout() / interval);
 
       if (application_features::ApplicationServer::isStopping()) {
-        return Result(TRI_ERROR_CLUSTER_TIMEOUT);
+        return Result(TRI_ERROR_SHUTTING_DOWN);
       }
     }
   }
@@ -1729,7 +1729,7 @@ Result ClusterInfo::cancelCreateDatabaseCoordinator(methods::CreateDatabaseInfo 
     }
 
     if (application_features::ApplicationServer::isStopping()) {
-      return Result(TRI_ERROR_CLUSTER_TIMEOUT);
+      return Result(TRI_ERROR_SHUTTING_DOWN);
     }
   } while(!res.successful());
 
@@ -1826,7 +1826,7 @@ Result ClusterInfo::dropDatabaseCoordinator(  // drop database
       agencyCallback->executeByCallbackOrTimeout(interval);
 
       if (application_features::ApplicationServer::isStopping()) {
-        return Result(TRI_ERROR_CLUSTER_TIMEOUT);
+        return Result(TRI_ERROR_SHUTTING_DOWN);
       }
     }
   }
@@ -2487,8 +2487,8 @@ Result ClusterInfo::dropCollectionCoordinator(  // drop collection
       agencyCallback->executeByCallbackOrTimeout(interval);
 
       if (application_features::ApplicationServer::isStopping()) {
-        events::DropCollection(dbName, collectionID, TRI_ERROR_CLUSTER_TIMEOUT);
-        return Result(TRI_ERROR_CLUSTER_TIMEOUT);
+        events::DropCollection(dbName, collectionID, TRI_ERROR_SHUTTING_DOWN);
+        return Result(TRI_ERROR_SHUTTING_DOWN);
       }
     }
   }
@@ -3458,7 +3458,7 @@ Result ClusterInfo::dropIndexCoordinator(  // drop index
       agencyCallback->executeByCallbackOrTimeout(interval);
 
       if (application_features::ApplicationServer::isStopping()) {
-        return Result(TRI_ERROR_CLUSTER_TIMEOUT);
+        return Result(TRI_ERROR_SHUTTING_DOWN);
       }
     }
   }

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -642,12 +642,12 @@ void ClusterInfo::loadPlan() {
               arangodb::basics::VelocyPackHelper::stringUInt64(database.value,
                                                                StaticStrings::DatabaseId);
           // create a local database object...
-          int res = databaseFeature->createDatabase(id, name, vocbase);
+          Result res = databaseFeature->createDatabase(id, name, vocbase);
 
-          if (res != TRI_ERROR_NO_ERROR) {
+          if (res.fail()) {
             LOG_TOPIC("91870", ERR, arangodb::Logger::AGENCY)
                 << "creating local database '" << name
-                << "' failed: " << TRI_errno_string(res);
+                << "' failed: " << res.errorMessage();
           }
         }
       }
@@ -1622,7 +1622,7 @@ Result ClusterInfo::createIsBuildingDatabaseCoordinator(methods::CreateDatabaseI
 
   if (!res.successful()) {
     if (res._statusCode == (int)arangodb::rest::ResponseCode::PRECONDITION_FAILED) {
-      return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME);
+      return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME, std::string("duplicate database name '") + database.getName() + "'");
     }
 
     return Result(TRI_ERROR_CLUSTER_COULD_NOT_CREATE_DATABASE_IN_PLAN);
@@ -1874,7 +1874,7 @@ Result ClusterInfo::checkCollectionPreconditions(std::string const& databaseName
         if (it2 != (*it).second.end()) {
           // collection already exists!
           events::CreateCollection(databaseName, info.name, TRI_ERROR_ARANGO_DUPLICATE_NAME);
-          return TRI_ERROR_ARANGO_DUPLICATE_NAME;
+          return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME, std::string("duplicate collection name '") + info.name + "'");
         }
       } else {
         // no collection in plan for this particular database... this may be true for
@@ -1898,7 +1898,7 @@ Result ClusterInfo::checkCollectionPreconditions(std::string const& databaseName
         if (it2 != (*it).second.end()) {
           // view already exists!
           events::CreateCollection(databaseName, info.name, TRI_ERROR_ARANGO_DUPLICATE_NAME);
-          return TRI_ERROR_ARANGO_DUPLICATE_NAME;
+          return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME, std::string("duplicate collection name '") + info.name + "'");
         }
       }
     }
@@ -2594,7 +2594,7 @@ Result ClusterInfo::createViewCoordinator(  // create view
         if (it2 != (*it).second.end()) {
           // view already exists!
           events::CreateView(databaseName, name, TRI_ERROR_ARANGO_DUPLICATE_NAME);
-          return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME);
+          return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME, std::string("duplicate view name '") + name + "'");
         }
       }
     }
@@ -2607,7 +2607,7 @@ Result ClusterInfo::createViewCoordinator(  // create view
         if (it2 != (*it).second.end()) {
           // collection already exists!
           events::CreateCollection(databaseName, name, TRI_ERROR_ARANGO_DUPLICATE_NAME);
-          return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME);
+          return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME, std::string("duplicate view name '") + name + "'");
         }
       }
     }

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -1168,12 +1168,12 @@ bool HeartbeatThread::handlePlanChangeCoordinator(uint64_t currentPlanVersion) {
         // database does not yet exist, create it now
 
         // create a local database object...
-        int res = databaseFeature->createDatabase(id, name, vocbase);
+        Result res = databaseFeature->createDatabase(id, name, vocbase);
 
-        if (res != TRI_ERROR_NO_ERROR) {
+        if (res.fail()) {
           LOG_TOPIC("ca877", ERR, arangodb::Logger::HEARTBEAT)
               << "creating local database '" << name
-              << "' failed: " << TRI_errno_string(res);
+              << "' failed: " << res.errorMessage();
         } else {
           HasRunOnce.store(true, std::memory_order_release);
         }

--- a/arangod/MMFiles/MMFilesWalRecoverState.cpp
+++ b/arangod/MMFiles/MMFilesWalRecoverState.cpp
@@ -1222,12 +1222,12 @@ bool MMFilesWalRecoverState::ReplayMarker(MMFilesMarker const* marker,
         MMFilesPersistentIndexFeature::dropDatabase(databaseId);
 
         vocbase = nullptr;
-        int res = state->databaseFeature->createDatabase(databaseId, nameString, vocbase);
+        Result res = state->databaseFeature->createDatabase(databaseId, nameString, vocbase);
 
-        if (res != TRI_ERROR_NO_ERROR) {
+        if (res.fail()) {
           LOG_TOPIC("9c045", WARN, arangodb::Logger::ENGINES)
               << "cannot create database " << databaseId << ": "
-              << TRI_errno_string(res);
+              << res.errorMessage();
           ++state->errorCount;
           return state->canContinue();
         }

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1961,8 +1961,10 @@ void RestReplicationHandler::handleCommandRestoreView() {
 
     if (view) {
       if (!overwrite) {
-        generateError(TRI_ERROR_ARANGO_DUPLICATE_NAME);
-
+        generateError(GeneralResponse::responseCode(TRI_ERROR_ARANGO_DUPLICATE_NAME),
+                      TRI_ERROR_ARANGO_DUPLICATE_NAME, 
+                      std::string("unable to restore view '") + nameSlice.copyString() + ": " + 
+                      TRI_errno_string(TRI_ERROR_ARANGO_DUPLICATE_NAME));
         return;
       }
 
@@ -1970,7 +1972,6 @@ void RestReplicationHandler::handleCommandRestoreView() {
 
       if (!res.ok()) {
         generateError(res);
-
         return;
       }
     }

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -594,13 +594,13 @@ Result DatabaseFeature::registerPostRecoveryCallback(std::function<Result()>&& c
 }
 
 /// @brief create a new database
-int DatabaseFeature::createDatabase(TRI_voc_tick_t id, std::string const& name,
-                                    TRI_vocbase_t*& result) {
+Result DatabaseFeature::createDatabase(TRI_voc_tick_t id, std::string const& name,
+                                       TRI_vocbase_t*& result) {
   result = nullptr;
 
   if (!TRI_vocbase_t::IsAllowedName(false, arangodb::velocypack::StringRef(name))) {
     events::CreateDatabase(name, TRI_ERROR_ARANGO_DATABASE_NAME_INVALID);
-    return TRI_ERROR_ARANGO_DATABASE_NAME_INVALID;
+    return {TRI_ERROR_ARANGO_DATABASE_NAME_INVALID};
   }
 
   if (id == 0) {
@@ -627,7 +627,7 @@ int DatabaseFeature::createDatabase(TRI_voc_tick_t id, std::string const& name,
       if (it != theLists->_databases.end()) {
         // name already in use
         events::CreateDatabase(name, TRI_ERROR_ARANGO_DUPLICATE_NAME);
-        return TRI_ERROR_ARANGO_DUPLICATE_NAME;
+        return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME, std::string("duplicate database name '") + name + "'");
       }
     }
 
@@ -647,17 +647,17 @@ int DatabaseFeature::createDatabase(TRI_voc_tick_t id, std::string const& name,
       try {
         vocbase->addReplicationApplier();
       } catch (basics::Exception const& ex) {
-        LOG_TOPIC("e7444", ERR, arangodb::Logger::FIXME)
-            << "initializing replication applier for database '"
-            << vocbase->name() << "' failed: " << ex.what();
+        std::string msg = "initializing replication applier for database '" + 
+            vocbase->name() + "' failed: " + ex.what();
+        LOG_TOPIC("e7444", ERR, arangodb::Logger::FIXME) << msg;
         events::CreateDatabase(name, ex.code());
-        return ex.code();
+        return Result(ex.code(), std::move(msg));
       } catch (std::exception const& ex) {
-        LOG_TOPIC("56c41", ERR, arangodb::Logger::FIXME)
-            << "initializing replication applier for database '"
-            << vocbase->name() << "' failed: " << ex.what();
+        std::string msg = "initializing replication applier for database '" + 
+            vocbase->name() + "' failed: " + ex.what();
+        LOG_TOPIC("56c41", ERR, arangodb::Logger::FIXME) << msg;
         events::CreateDatabase(name, TRI_ERROR_INTERNAL);
-        return TRI_ERROR_INTERNAL;
+        return Result(TRI_ERROR_INTERNAL, std::move(msg));
       }
 
       // enable deadlock detection

--- a/arangod/RestServer/DatabaseFeature.h
+++ b/arangod/RestServer/DatabaseFeature.h
@@ -110,7 +110,7 @@ class DatabaseFeature : public application_features::ApplicationFeature {
   std::vector<std::string> getDatabaseNames();
   std::vector<std::string> getDatabaseNamesForUser(std::string const& user);
 
-  int createDatabase(TRI_voc_tick_t id, std::string const& name, TRI_vocbase_t*& result);
+  Result createDatabase(TRI_voc_tick_t id, std::string const& name, TRI_vocbase_t*& result);
   int dropDatabase(std::string const& name, bool waitForDeletion, bool removeAppsDirectory);
   int dropDatabase(TRI_voc_tick_t id, bool waitForDeletion, bool removeAppsDirectory);
 

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -24,6 +24,7 @@
 #include "Basics/Common.h"
 
 #include "Agency/AgencyComm.h"
+#include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Cluster/ClusterInfo.h"
@@ -45,6 +46,9 @@
 #include "V8Server/v8-user-structures.h"
 #include "VocBase/Methods/Upgrade.h"
 #include "VocBase/vocbase.h"
+
+#include <chrono>
+#include <thread>
 
 #include <v8.h>
 #include <velocypack/Builder.h>
@@ -253,40 +257,54 @@ arangodb::Result Databases::info(TRI_vocbase_t* vocbase, VPackBuilder& result) {
 
 // Grant permissions on newly created database to current user
 // to be able to run the upgrade script
-arangodb::Result Databases::grantCurrentUser(CreateDatabaseInfo const& info) {
+arangodb::Result Databases::grantCurrentUser(CreateDatabaseInfo const& info, double timeout) {
   auth::UserManager* um = AuthenticationFeature::instance()->userManager();
 
-  ExecContext const& exec = ExecContext::current();
+  Result res;
+
   if (um != nullptr) {
+    ExecContext const& exec = ExecContext::current();
     // If the current user is empty (which happens if a Maintenance job
     // called us, or when authentication is off), granting rights
     // will fail. We hence ignore it here, but issue a warning below
     if (!exec.isSuperuser()) {
-      return um->updateUser(exec.user(), [&](auth::User& entry) {
-        entry.grantDatabase(info.getName(), auth::Level::RW);
-        entry.grantCollection(info.getName(), "*", auth::Level::RW);
-        return TRI_ERROR_NO_ERROR;
-      });
-    } else {
-      LOG_TOPIC("2a4dd", DEBUG, Logger::FIXME)
-        << "current ExecContext's user() is empty."
-        << "Database will be created without any user having permissions";
-     return Result();
-    }
+      double const endTime = TRI_microtime() + timeout;
+      while (true) {
+        res = um->updateUser(exec.user(), [&](auth::User& entry) {
+          entry.grantDatabase(info.getName(), auth::Level::RW);
+          entry.grantCollection(info.getName(), "*", auth::Level::RW);
+          return TRI_ERROR_NO_ERROR;
+        });
+        if (res.ok() || 
+            !res.is(TRI_ERROR_ARANGO_CONFLICT) ||
+            TRI_microtime() >= endTime) {
+          break;
+        }
+
+        if (application_features::ApplicationServer::isStopping()) {
+          res.reset(TRI_ERROR_SHUTTING_DOWN);
+          break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      }
+    } 
+
+    LOG_TOPIC("2a4dd", DEBUG, Logger::FIXME)
+      << "current ExecContext's user() is empty. "
+      << "Database will be created without any user having permissions";
   }
 
-  return Result();
+  return res;
 }
 
 // Create database on cluster;
 Result Databases::createCoordinator(CreateDatabaseInfo const& info) {
   TRI_ASSERT(ServerState::instance()->isCoordinator());
-  Result res;
 
   // This operation enters the database as isBuilding into the agency
   // while the database is still building it is not visible.
   ClusterInfo* ci = ClusterInfo::instance();
-  res = ci->createIsBuildingDatabaseCoordinator(info);
+  Result res = ci->createIsBuildingDatabaseCoordinator(info);
 
   // Even entering the database as building failed; This can happen
   // because a database with this name already exists, or because we could
@@ -297,21 +315,20 @@ Result Databases::createCoordinator(CreateDatabaseInfo const& info) {
   }
 
   auto failureGuard = scopeGuard([ci, info]() {
-    Result res;
     LOG_TOPIC("8cc61", ERR, Logger::FIXME)
-      << "Failed to create database " << info.getName() << " rolling back.";
-    res = ci->cancelCreateDatabaseCoordinator(info);
+      << "Failed to create database '" << info.getName() << "', rolling back.";
+    Result res = ci->cancelCreateDatabaseCoordinator(info);
     if (!res.ok()) {
       // this cannot happen since cancelCreateDatabaseCoordinator keeps retrying
       // indefinitely until the cancellation is either successful or the cluster
       // is shut down.
       LOG_TOPIC("92157", ERR, Logger::FIXME)
-        << "Failed to rollback creation of database " << info.getName() <<
-        ". This should never happen. Cleanup will happen through a supervision job.";
+        << "Failed to rollback creation of database '" << info.getName() <<
+        "'. Cleanup will happen through a supervision job.";
     }
   });
 
-  res = grantCurrentUser(info);
+  res = grantCurrentUser(info, 5.0); 
   if (!res.ok()) {
     return res;
   }
@@ -324,26 +341,25 @@ Result Databases::createCoordinator(CreateDatabaseInfo const& info) {
   // if any of these fail, database creation is considered unsuccessful
 
   UpgradeResult upgradeRes = methods::Upgrade::createDB(vocbase, info.getUsers());
+  failureGuard.cancel();
+
   // If the creation of system collections was successful,
   // make the database visible, otherwise clean up what we can.
   if (upgradeRes.ok()) {
-    failureGuard.cancel();
-    res = ci->createFinalizeDatabaseCoordinator(info);
+    return ci->createFinalizeDatabaseCoordinator(info);
+  } 
+    
+  // We leave this handling here to be able to capture
+  // error messages and return
+  // Cleanup entries in agency.
+  res = ci->cancelCreateDatabaseCoordinator(info);
+  if (!res.ok()) {
+    // this should never happen as cancelCreateDatabaseCoordinator keeps retrying
+    // until either cancellation is successful or the cluster is shut down.
     return res;
-  } else {
-    // We leave this handling here to be able to capture
-    // error messages and return
-    failureGuard.cancel();
-    // Cleanup entries in agency.
-    res = ci->cancelCreateDatabaseCoordinator(info);
-    if (!res.ok()) {
-      // this should never happen as cancelCreateDatabaseCoordinaotr keeps retrying
-      // until either cancellation is successful or the cluster is shut down.
-      return res;
-    } else {
-      return std::move(upgradeRes.result());
-    }
-  }
+  } 
+  
+  return std::move(upgradeRes.result());
 }
 
 // Create a database on SingleServer, DBServer,
@@ -366,7 +382,7 @@ Result Databases::createOther(CreateDatabaseInfo const& info) {
 
   TRI_DEFER(vocbase->release());
 
-  Result res = grantCurrentUser(info);
+  Result res = grantCurrentUser(info, 10.0);
   if (!res.ok()) {
     return res;
   }

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -352,13 +352,13 @@ Result Databases::createOther(CreateDatabaseInfo const& info) {
   DatabaseFeature* databaseFeature = DatabaseFeature::DATABASE;
   if (databaseFeature == nullptr) {
     events::CreateDatabase(info.getName(), TRI_ERROR_INTERNAL);
-    return Result(TRI_ERROR_INTERNAL);
+    return {TRI_ERROR_INTERNAL};
   }
 
   TRI_vocbase_t* vocbase = nullptr;
-  int createDBres = databaseFeature->createDatabase(info.getId(), info.getName(), vocbase);
-  if (createDBres != TRI_ERROR_NO_ERROR) {
-    return Result(createDBres);
+  Result createResult = databaseFeature->createDatabase(info.getId(), info.getName(), vocbase);
+  if (createResult.fail()) {
+    return createResult;
   }
 
   TRI_ASSERT(vocbase != nullptr);

--- a/arangod/VocBase/Methods/Databases.h
+++ b/arangod/VocBase/Methods/Databases.h
@@ -73,7 +73,9 @@ struct Databases {
   static arangodb::Result drop(TRI_vocbase_t* systemVocbase, std::string const& dbName);
 
  private:
-  static arangodb::Result grantCurrentUser(CreateDatabaseInfo const& info);
+  /// @brief will retry for at most <timeout> seconds
+  static arangodb::Result grantCurrentUser(CreateDatabaseInfo const& info, double timeout);
+
   static arangodb::Result createCoordinator(CreateDatabaseInfo const& info);
   static arangodb::Result createOther(CreateDatabaseInfo const& info);
 };

--- a/tests/IResearch/IResearchAnalyzerFeature-test.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeature-test.cpp
@@ -983,8 +983,7 @@ class IResearchAnalyzerFeatureGetTest : public IResearchAnalyzerFeatureTest {
     ASSERT_NE(_sysVocbase, nullptr);
 
     _vocbase = nullptr;
-    auto res = _dbFeature->createDatabase(1, dbName, _vocbase);
-    ASSERT_EQ(res, TRI_ERROR_NO_ERROR);
+    ASSERT_TRUE(_dbFeature->createDatabase(1, dbName, _vocbase).ok());
     ASSERT_NE(_vocbase, nullptr);
     arangodb::methods::Collections::createSystem(*_vocbase, arangodb::tests::AnalyzerCollectionName,
                                                  false);
@@ -1376,8 +1375,7 @@ class IResearchAnalyzerFeatureCoordinatorTest : public ::testing::Test {
     }
 
     _vocbase = nullptr;
-    auto res = dbFeature->createDatabase(1, _dbName, _vocbase);
-    ASSERT_EQ(res, TRI_ERROR_NO_ERROR);
+    ASSERT_TRUE(dbFeature->createDatabase(1, _dbName, _vocbase).ok());
     ASSERT_NE(_vocbase, nullptr);
 
     // Prepare analyzers
@@ -2470,8 +2468,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_remove) {
   {
     arangodb::iresearch::IResearchAnalyzerFeature feature(server);
     TRI_vocbase_t* vocbase;
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 dbFeature->createDatabase(1, "testVocbase", vocbase)));
+    ASSERT_TRUE(dbFeature->createDatabase(1, "testVocbase", vocbase).ok());
     ASSERT_TRUE((nullptr != dbFeature->lookupDatabase("testVocbase")));
 
     EXPECT_TRUE((true == !feature.get("testVocbase::test_analyzer")));
@@ -3366,13 +3363,12 @@ TEST_F(IResearchAnalyzerFeatureTest, test_upgrade_static_legacy) {
         StorageEngineMock::versionFilenameResult, versionJson->slice(), false)));
 
     TRI_vocbase_t* vocbase;
-    EXPECT_TRUE((TRI_ERROR_NO_ERROR ==
-                 dbFeature->createDatabase(1, "testVocbase", vocbase)));
+    EXPECT_TRUE(dbFeature->createDatabase(1, "testVocbase", vocbase).ok());
     sysDatabase->unprepare();  // unset system vocbase
     // EXPECT_TRUE((arangodb::methods::Upgrade::startup(*vocbase, true, false).ok())); // run upgrade
     // collections are not created in upgrade tasks within iresearch anymore. For that reason, we have
     // to create the collection here manually.
-    // TODO: We should use global system creation here instead of all the exissting manual stuff ...
+    // TODO: We should use global system creation here instead of all the existing manual stuff ...
     arangodb::methods::Collections::createSystem(*vocbase, arangodb::tests::AnalyzerCollectionName, false);
 
     EXPECT_TRUE((false == !vocbase->lookupCollection(arangodb::tests::AnalyzerCollectionName)));
@@ -3429,8 +3425,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_upgrade_static_legacy) {
 
     std::unordered_set<std::string> expected{"abc"};
     TRI_vocbase_t* vocbase;
-    EXPECT_TRUE((TRI_ERROR_NO_ERROR ==
-                 dbFeature->createDatabase(1, "testVocbase", vocbase)));
+    EXPECT_TRUE(dbFeature->createDatabase(1, "testVocbase", vocbase).ok());
     EXPECT_TRUE((false == !vocbase->createCollection(createCollectionJson->slice())));
 
     // add document to collection
@@ -3449,7 +3444,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_upgrade_static_legacy) {
 
     sysDatabase->unprepare();  // unset system vocbase
     // EXPECT_TRUE((arangodb::methods::Upgrade::startup(*vocbase, true, false).ok())); // run upgrade
-    // TODO: We should use global system creation here instead of all the exissting manual stuff ...
+    // TODO: We should use global system creation here instead of all the existing manual stuff ...
     arangodb::methods::Collections::createSystem(*vocbase, arangodb::tests::AnalyzerCollectionName, false);
     EXPECT_TRUE((false == !vocbase->lookupCollection(arangodb::tests::AnalyzerCollectionName)));
     auto result = arangodb::tests::executeQuery(*vocbase, ANALYZER_COLLECTION_QUERY);
@@ -3518,10 +3513,9 @@ TEST_F(IResearchAnalyzerFeatureTest, test_upgrade_static_legacy) {
         StorageEngineMock::versionFilenameResult, versionJson->slice(), false)));
 
     TRI_vocbase_t* vocbase;
-    EXPECT_TRUE((TRI_ERROR_NO_ERROR ==
-                 dbFeature->createDatabase(1, "testVocbase", vocbase)));
+    EXPECT_TRUE(dbFeature->createDatabase(1, "testVocbase", vocbase).ok());
     // EXPECT_TRUE((arangodb::methods::Upgrade::startup(*vocbase, true, false).ok())); // run upgrade
-    // TODO: We should use global system creation here instead of all the exissting manual stuff ...
+    // TODO: We should use global system creation here instead of all the existing manual stuff ...
     arangodb::methods::Collections::createSystem(*vocbase, arangodb::tests::AnalyzerCollectionName, false);
     EXPECT_TRUE((false == !vocbase->lookupCollection(arangodb::tests::AnalyzerCollectionName)));
     auto result = arangodb::tests::executeQuery(*vocbase, ANALYZER_COLLECTION_QUERY);
@@ -3583,8 +3577,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_upgrade_static_legacy) {
 
     std::unordered_set<std::string> expected{"abc"};
     TRI_vocbase_t* vocbase;
-    EXPECT_TRUE((TRI_ERROR_NO_ERROR ==
-                 dbFeature->createDatabase(1, "testVocbase", vocbase)));
+    EXPECT_TRUE(dbFeature->createDatabase(1, "testVocbase", vocbase).ok());
     EXPECT_TRUE((false == !vocbase->createCollection(createCollectionJson->slice())));
 
     // add document to collection
@@ -3602,7 +3595,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_upgrade_static_legacy) {
     }
 
     // EXPECT_TRUE((arangodb::methods::Upgrade::startup(*vocbase, true, false).ok())); // run upgrade
-    // TODO: We should use global system creation here instead of all the exissting manual stuff ...
+    // TODO: We should use global system creation here instead of all the existing manual stuff ...
     arangodb::methods::Collections::createSystem(*vocbase, arangodb::tests::AnalyzerCollectionName, false);
     EXPECT_TRUE((false == !vocbase->lookupCollection(arangodb::tests::AnalyzerCollectionName)));
     auto result = arangodb::tests::executeQuery(*vocbase, ANALYZER_COLLECTION_QUERY);
@@ -3686,10 +3679,9 @@ TEST_F(IResearchAnalyzerFeatureTest, test_upgrade_static_legacy) {
         StorageEngineMock::versionFilenameResult, versionJson->slice(), false)));
 
     TRI_vocbase_t* vocbase;
-    EXPECT_TRUE((TRI_ERROR_NO_ERROR ==
-                 dbFeature->createDatabase(1, "testVocbase", vocbase)));
+    EXPECT_TRUE(dbFeature->createDatabase(1, "testVocbase", vocbase).ok());
     // EXPECT_TRUE((arangodb::methods::Upgrade::startup(*vocbase, true, false).ok())); // run upgrade
-    // TODO: We should use global system creation here instead of all the exissting manual stuff ...
+    // TODO: We should use global system creation here instead of all the existing manual stuff ...
     arangodb::methods::Collections::createSystem(*vocbase, arangodb::tests::AnalyzerCollectionName, false);
     EXPECT_TRUE((false == !vocbase->lookupCollection(arangodb::tests::AnalyzerCollectionName)));
     auto result = arangodb::tests::executeQuery(*vocbase, ANALYZER_COLLECTION_QUERY);
@@ -3751,8 +3743,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_upgrade_static_legacy) {
 
     std::set<std::string> expected{"abc"};
     TRI_vocbase_t* vocbase;
-    EXPECT_TRUE((TRI_ERROR_NO_ERROR ==
-                 dbFeature->createDatabase(1, "testVocbase", vocbase)));
+    EXPECT_TRUE(dbFeature->createDatabase(1, "testVocbase", vocbase).ok());
     EXPECT_TRUE((false == !vocbase->createCollection(createCollectionJson->slice())));
 
     // add document to collection
@@ -3770,7 +3761,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_upgrade_static_legacy) {
     }
 
     // EXPECT_TRUE((arangodb::methods::Upgrade::startup(*vocbase, true, false).ok())); // run upgrade
-    // TODO: We should use global system creation here instead of all the exissting manual stuff ...
+    // TODO: We should use global system creation here instead of all the existing manual stuff ...
     arangodb::methods::Collections::createSystem(*vocbase, arangodb::tests::AnalyzerCollectionName, false);
     EXPECT_TRUE((false == !vocbase->lookupCollection(arangodb::tests::AnalyzerCollectionName)));
     auto result = arangodb::tests::executeQuery(*vocbase, ANALYZER_COLLECTION_QUERY);
@@ -3976,9 +3967,9 @@ TEST_F(IResearchAnalyzerFeatureTest, test_visit) {
   TRI_vocbase_t* vocbase0;
   TRI_vocbase_t* vocbase1;
   TRI_vocbase_t* vocbase2;
-  EXPECT_TRUE((TRI_ERROR_NO_ERROR == dbFeature->createDatabase(1, "vocbase0", vocbase0)));
-  EXPECT_TRUE((TRI_ERROR_NO_ERROR == dbFeature->createDatabase(1, "vocbase1", vocbase1)));
-  EXPECT_TRUE((TRI_ERROR_NO_ERROR == dbFeature->createDatabase(1, "vocbase2", vocbase2)));
+  EXPECT_TRUE(dbFeature->createDatabase(1, "vocbase0", vocbase0).ok());
+  EXPECT_TRUE(dbFeature->createDatabase(1, "vocbase1", vocbase1).ok());
+  EXPECT_TRUE(dbFeature->createDatabase(1, "vocbase2", vocbase2).ok());
   arangodb::methods::Collections::createSystem(*vocbase0, arangodb::tests::AnalyzerCollectionName, false);
   arangodb::methods::Collections::createSystem(*vocbase1, arangodb::tests::AnalyzerCollectionName, false);
   arangodb::methods::Collections::createSystem(*vocbase2, arangodb::tests::AnalyzerCollectionName, false);

--- a/tests/IResearch/IResearchFeature-test.cpp
+++ b/tests/IResearch/IResearchFeature-test.cpp
@@ -504,8 +504,7 @@ TEST_F(IResearchFeatureTest, test_upgrade0_1) {
     ASSERT_TRUE((nullptr != ci));
     TRI_vocbase_t* vocbase;  // will be owned by DatabaseFeature
 
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 database->createDatabase(1, "testDatabase", vocbase)));
+    ASSERT_TRUE(database->createDatabase(1, "testDatabase", vocbase).ok());
 
     // simulate heartbeat thread (create database in current)
     // this is stupid.

--- a/tests/IResearch/IResearchView-test.cpp
+++ b/tests/IResearch/IResearchView-test.cpp
@@ -1079,7 +1079,7 @@ TEST_F(IResearchViewTest, test_drop_database) {
   StorageEngineMock::before = [&beforeCount]()->void { ++beforeCount; };
 
   TRI_vocbase_t* vocbase; // will be owned by DatabaseFeature
-  ASSERT_TRUE((TRI_ERROR_NO_ERROR == databaseFeature->createDatabase(0, "testDatabase" TOSTRING(__LINE__), vocbase)));
+  ASSERT_TRUE(databaseFeature->createDatabase(0, "testDatabase" TOSTRING(__LINE__), vocbase).ok());
   ASSERT_TRUE((nullptr != vocbase));
 
   beforeCount = 0; // reset before call to StorageEngine::createView(...)

--- a/tests/RestHandler/RestUsersHandler-test.cpp
+++ b/tests/RestHandler/RestUsersHandler-test.cpp
@@ -196,8 +196,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
       arangodb::application_features::ApplicationServer::getFeature<arangodb::DatabaseFeature>(
           "Database");
   TRI_vocbase_t* vocbase;  // will be owned by DatabaseFeature
-  ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-               databaseFeature->createDatabase(1, "testDatabase", vocbase)));
+  ASSERT_TRUE(databaseFeature->createDatabase(1, "testDatabase", vocbase).ok());
   auto grantRequestPtr = std::make_unique<GeneralRequestMock>(*vocbase);
   auto& grantRequest = *grantRequestPtr;
   auto grantResponcePtr = std::make_unique<GeneralResponseMock>();

--- a/tests/RestServer/FlushFeature-test.cpp
+++ b/tests/RestServer/FlushFeature-test.cpp
@@ -145,7 +145,7 @@ TEST_F(FlushFeatureTest, test_subscription_retention) {
           "Database");
   ASSERT_TRUE((dbFeature));
   TRI_vocbase_t* vocbase;
-  ASSERT_TRUE((TRI_ERROR_NO_ERROR == dbFeature->createDatabase(1, "testDatabase", vocbase)));
+  ASSERT_TRUE(dbFeature->createDatabase(1, "testDatabase", vocbase).ok());
   ASSERT_NE(nullptr, vocbase);
 
   arangodb::FlushFeature feature(server);

--- a/tests/V8Server/v8-analyzers-test.cpp
+++ b/tests/V8Server/v8-analyzers-test.cpp
@@ -2081,8 +2081,7 @@ TEST_F(V8AnalyzersTest, test_list) {
         arangodb::StaticStrings::SystemDatabase + "\" } ]");
     ASSERT_TRUE((TRI_ERROR_NO_ERROR == dbFeature->loadDatabases(databases->slice())));
     TRI_vocbase_t* vocbase;
-    ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-                 dbFeature->createDatabase(1, "testVocbase", vocbase)));
+    ASSERT_TRUE(dbFeature->createDatabase(1, "testVocbase", vocbase).ok());
     sysDatabase->start();  // get system database from DatabaseFeature
     arangodb::methods::Collections::createSystem(
         *vocbase, 

--- a/tests/V8Server/v8-users-test.cpp
+++ b/tests/V8Server/v8-users-test.cpp
@@ -224,8 +224,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
       arangodb::application_features::ApplicationServer::getFeature<arangodb::DatabaseFeature>(
           "Database");
   TRI_vocbase_t* vocbase;  // will be owned by DatabaseFeature
-  ASSERT_TRUE((TRI_ERROR_NO_ERROR ==
-               databaseFeature->createDatabase(1, "testDatabase", vocbase)));
+  ASSERT_TRUE(databaseFeature->createDatabase(1, "testDatabase", vocbase).ok());
   v8::Isolate::CreateParams isolateParams;
   ArrayBufferAllocator arrayBufferAllocator;
   isolateParams.array_buffer_allocator = &arrayBufferAllocator;


### PR DESCRIPTION
### Scope & Purpose

In case of duplicate name errors, report the name and type of the duplicate object, e.g. "duplicate database name 'xyz'".
This should help analyzing duplicate name errors in the future.

However, I was not able to fabricate duplicate name errors in devel. I was able to fabricate them in 3.4 and 3.5, but since the "atomic database creation" feature has been merged into devel, I can't think of a way to produce them any more.

Still, in devel it is possible that when concurrently creating & dropping databases with the same user, there is a race for the user's permissions, which can lead to spurious write-write conflicts that turn into a "precondition failed" error on the client level. These should be fixed by this PR by just retrying the failed update on the user permissions until a timeout is reached.
 
- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6130/