### PR TITLE
handle K_SHORTEST_PATHS where it was forgotten

### DIFF
--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -1659,7 +1659,8 @@ void Ast::injectBindParameters(BindParameters& parameters,
                                       node->getString().c_str());
       } else if (node->type == NODE_TYPE_TRAVERSAL) {
         extractCollectionsFromGraph(node->getMember(2));
-      } else if (node->type == NODE_TYPE_SHORTEST_PATH) {
+      } else if (node->type == NODE_TYPE_SHORTEST_PATH ||
+                 node->type == NODE_TYPE_K_SHORTEST_PATHS) {
         extractCollectionsFromGraph(node->getMember(3));
       }
 

--- a/arangod/Aql/ClusterNodes.cpp
+++ b/arangod/Aql/ClusterNodes.cpp
@@ -364,6 +364,7 @@ CostEstimate DistributeNode::estimateCost() const {
         return castTo<IndexNode const*>(node)->collection();
       case TRAVERSAL:
       case SHORTEST_PATH:
+      case K_SHORTEST_PATHS:
         return castTo<GraphNode const*>(node)->collection();
       case SCATTER:
         return nullptr;  // diamond boundary

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -2341,7 +2341,8 @@ bool ExecutionPlan::isDeadSimple() const {
 
     if (nodeType == ExecutionNode::SUBQUERY || nodeType == ExecutionNode::ENUMERATE_COLLECTION ||
         nodeType == ExecutionNode::ENUMERATE_LIST || nodeType == ExecutionNode::TRAVERSAL ||
-        nodeType == ExecutionNode::SHORTEST_PATH || nodeType == ExecutionNode::INDEX) {
+        nodeType == ExecutionNode::SHORTEST_PATH || nodeType == ExecutionNode::K_SHORTEST_PATHS ||
+        nodeType == ExecutionNode::INDEX) {
       // these node types are not simple
       return false;
     }

--- a/arangod/Aql/IResearchViewNode.cpp
+++ b/arangod/Aql/IResearchViewNode.cpp
@@ -389,6 +389,7 @@ bool hasDependencies(aql::ExecutionPlan const& plan, aql::AstNode const& node,
       case aql::ExecutionNode::TRAVERSAL:
       case aql::ExecutionNode::INDEX:
       case aql::ExecutionNode::SHORTEST_PATH:
+      case aql::ExecutionNode::K_SHORTEST_PATHS:
       case aql::ExecutionNode::ENUMERATE_IRESEARCH_VIEW:
         // we're in the loop with dependent context
         return true;
@@ -417,6 +418,7 @@ bool isInInnerLoopOrSubquery(aql::ExecutionNode const& node) {
       case aql::ExecutionNode::TRAVERSAL:
       case aql::ExecutionNode::ENUMERATE_LIST:
       case aql::ExecutionNode::SHORTEST_PATH:
+      case aql::ExecutionNode::K_SHORTEST_PATHS:
       case aql::ExecutionNode::ENUMERATE_IRESEARCH_VIEW:
         // we're in a loop
         return true;

--- a/arangod/Aql/IResearchViewOptimizerRules.cpp
+++ b/arangod/Aql/IResearchViewOptimizerRules.cpp
@@ -162,6 +162,7 @@ bool optimizeSort(IResearchViewNode& viewNode, ExecutionPlan* plan) {
         current->getType() == EN::ENUMERATE_COLLECTION ||
         current->getType() == EN::TRAVERSAL ||
         current->getType() == EN::SHORTEST_PATH ||
+        current->getType() == EN::K_SHORTEST_PATHS ||
         current->getType() == EN::INDEX ||
         current->getType() == EN::COLLECT) {
       // any of these node types will lead to more/less results in the output,
@@ -239,6 +240,7 @@ bool optimizeSort(IResearchViewNode& viewNode, ExecutionPlan* plan) {
           current->getType() == EN::ENUMERATE_COLLECTION ||
           current->getType() == EN::TRAVERSAL ||
           current->getType() == EN::SHORTEST_PATH ||
+          current->getType() == EN::K_SHORTEST_PATHS ||
           current->getType() == EN::INDEX ||
           current->getType() == EN::COLLECT ||
           current->getType() == EN::SORT) {


### PR DESCRIPTION
### Scope & Purpose

Handle K_SHORTEST_PATHS cases where it was forgotten.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/6139/