### PR TITLE
don't assert/crash when using an unknown collection/shard

### DIFF
--- a/arangod/Agency/AgencyComm.h
+++ b/arangod/Agency/AgencyComm.h
@@ -31,10 +31,6 @@
 #include <string>
 #include <unordered_map>
 
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
-
 #include <velocypack/Slice.h>
 #include <velocypack/Builder.h>
 #include <velocypack/velocypack-aliases.h>

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -839,7 +839,6 @@ AqlValue Expression::invokeV8Function(ExpressionContext* expressionContext,
 
   // actually call the V8 function
   v8::TryCatch tryCatch(isolate);
-  ;
   v8::Handle<v8::Value> result =
       v8::Handle<v8::Function>::Cast(function)->Call(current, static_cast<int>(callArgs), args);
 

--- a/arangod/Cluster/ClusterComm.cpp
+++ b/arangod/Cluster/ClusterComm.cpp
@@ -44,18 +44,17 @@
 using namespace arangodb;
 using namespace arangodb::communicator;
 
-
 namespace {
 std::stringstream createRequestInfo(NewRequest const& request) {
-  bool trace = Logger::CLUSTERCOMM.level() == LogLevel::TRACE;
   std::stringstream ss;
   ss << "id: " << std::setw(8) << std::setiosflags(std::ios::left)
                << request._ticketId << std::resetiosflags(std::ios::adjustfield)
      << " --> " << request._destination
      << " -- " << arangodb::GeneralRequest::translateMethod(request._request->requestType())
-     << ": " << ( request._request->fullUrl().empty() ? "url unknown" : request._request->fullUrl())
-     ;
-  if(trace){
+     << ": " << ( request._request->fullUrl().empty() ? "url unknown" : request._request->fullUrl());
+  
+  bool trace = Logger::CLUSTERCOMM.level() == LogLevel::TRACE;
+  if (trace) {
     try {
       ss << " -- payload: '" << request._request->payload().toJson() << "'";
     } catch (...) {
@@ -66,16 +65,16 @@ std::stringstream createRequestInfo(NewRequest const& request) {
 }
 
 std::stringstream createResponseInfo(ClusterCommResult const* result) {
-  bool trace = Logger::CLUSTERCOMM.level() == LogLevel::TRACE;
   std::stringstream ss;
   ss << "id: " << std::setw(8) << std::setiosflags(std::ios::left)
                << result->operationID << std::resetiosflags(std::ios::adjustfield)
      << " <-- " << result->endpoint
-     << " -- " << result->serverID << ":" << (result->shardID.empty() ? "unknown ShardID" : result->shardID)
-     ;
-  if(trace){
+     << " -- " << result->serverID << ":" << (result->shardID.empty() ? "unknown ShardID" : result->shardID);
+
+  bool trace = Logger::CLUSTERCOMM.level() == LogLevel::TRACE;
+  if (trace) {
     try {
-      if(result->result){
+      if (result->result) {
         ss << " -- payload: '" << result->result->getBody() << "'";
       } else {
         ss << " -- payload: no result";

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -890,7 +890,7 @@ void ClusterInfo::loadPlan() {
         try {
           std::shared_ptr<LogicalCollection> newCollection;
 
-#if defined(USE_ENTERPRISE)
+#ifdef USE_ENTERPRISE
           auto isSmart = collectionSlice.get(StaticStrings::IsSmart);
 
           if (isSmart.isTrue()) {

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -64,8 +64,12 @@
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include "velocypack/StringRef.h"
+#include <velocypack/velocypack-aliases.h>
+
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
 
 #include <algorithm>
 #include <numeric>

--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -187,7 +187,7 @@ class FollowerInfo {
       if (_canWrite) {
         // Someone has decided we can write, fastPath!
 
-#ifdef ARANGODB_USE_MAINTAINER_MODE
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
         // Invariant, we can only WRITE if we do not have other failover candidates
         READ_LOCKER(readLockerData, _dataLock);
         TRI_ASSERT(_followers->size() == _failoverCandidates->size());

--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -187,7 +187,10 @@ class FollowerInfo {
       if (_canWrite) {
         // Someone has decided we can write, fastPath!
 
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+        // the macro name use here is wrong. it must be ARANGODB_ENABLE_MAINTAINER_MODE
+        // and not ARANGODB_USE_MAINTAINER_MODE. @mchacki as original author of this code
+        // is informed
+#ifdef ARANGODB_USE_MAINTAINER_MODE
         // Invariant, we can only WRITE if we do not have other failover candidates
         READ_LOCKER(readLockerData, _dataLock);
         TRI_ASSERT(_followers->size() == _failoverCandidates->size());

--- a/arangod/Replication/ReplicationApplier.cpp
+++ b/arangod/Replication/ReplicationApplier.cpp
@@ -737,7 +737,6 @@ void ReplicationApplier::doStop(Result const& r, bool joinThread) {
             << "replication applier is not stopping";
         TRI_ASSERT(false);
         start = std::chrono::steady_clock::now();
-        ;
       }
       writeLocker.lock();
     }

--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -615,7 +615,22 @@ void RestCollectionHandler::collectionRepresentation(
     bool showProperties, bool showFigures, bool showCount, bool detailedCount) {
   if (showProperties || showCount) {
     // Here we need a transaction
-    auto trx = createTransaction(coll.name(), AccessMode::Type::READ);
+    std::unique_ptr<SingleCollectionTransaction> trx;
+    try {
+      trx = createTransaction(coll.name(), AccessMode::Type::READ);
+    } catch (basics::Exception const& ex) {
+      if (ex.code() == TRI_ERROR_TRANSACTION_NOT_FOUND) {
+      // this will happen if the tid of a managed transaction is passed in,
+      // but the transaction hasn't yet started on the DB server. in
+      // this case, we create an ad-hoc transaction on the underlying
+      // collection
+        trx = std::make_unique<SingleCollectionTransaction>(transaction::StandaloneContext::Create(_vocbase), coll.name(), AccessMode::Type::READ);
+      } else {
+        throw;
+      }
+    }
+
+    TRI_ASSERT(trx != nullptr);
     Result res = trx->begin();
 
     if (res.fail()) {

--- a/arangod/RestHandler/RestCursorHandler.cpp
+++ b/arangod/RestHandler/RestCursorHandler.cpp
@@ -630,7 +630,6 @@ RestStatus RestCursorHandler::modifyQueryCursor() {
   }
 
   return generateCursorResult(rest::ResponseCode::OK, cursor);
-  ;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -838,7 +838,6 @@ void RestReplicationHandler::handleCommandRestoreCollection() {
 
   bool overwrite = _request->parsedValue<bool>("overwrite", false);
   bool force = _request->parsedValue<bool>("force", false);
-  ;
   bool ignoreDistributeShardsLikeErrors =
       _request->parsedValue<bool>("ignoreDistributeShardsLikeErrors", false);
   uint64_t numberOfShards =
@@ -1258,7 +1257,6 @@ Result RestReplicationHandler::processRestoreCollectionCoordinator(
     changes.push_back(
         std::string("changed 'replicationFactor' attribute value to ") +
         std::to_string(replicationFactor));
-    ;
   }
 
   if (!changes.empty()) {

--- a/arangod/RestServer/ConsoleThread.cpp
+++ b/arangod/RestServer/ConsoleThread.cpp
@@ -204,7 +204,6 @@ start_color_print('arangodb', true);
 
       {
         v8::TryCatch tryCatch(isolate);
-        ;
         v8::HandleScope scope(isolate);
 
         console.setExecutingCommand(true);

--- a/arangod/RestServer/ScriptFeature.cpp
+++ b/arangod/RestServer/ScriptFeature.cpp
@@ -96,7 +96,6 @@ int ScriptFeature::runScript(std::vector<std::string> const& scripts) {
       }
 
       v8::TryCatch tryCatch(isolate);
-      ;
       // run the garbage collection for at most 30 seconds
       TRI_RunGarbageCollectionV8(isolate, 30.0);
 

--- a/arangod/RestServer/arangod.cpp
+++ b/arangod/RestServer/arangod.cpp
@@ -335,7 +335,7 @@ namespace arangodb {
 int main(int argc, char* argv[]) {
   std::string workdir(arangodb::basics::FileUtils::currentDirectory().result());
 #ifdef __linux__
-#if USE_ENTERPRISE
+#ifdef USE_ENTERPRISE
   arangodb::checkLicenseKey();
 #endif
 #endif

--- a/arangod/Utils/SingleCollectionTransaction.cpp
+++ b/arangod/Utils/SingleCollectionTransaction.cpp
@@ -92,6 +92,14 @@ LogicalCollection* SingleCollectionTransaction::documentCollection() {
   TRI_ASSERT(_documentCollection != nullptr);
   return _documentCollection;
 }
+  
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+TRI_voc_cid_t SingleCollectionTransaction::addCollectionAtRuntime(std::string const& name) {
+  // sanity check
+  TRI_ASSERT(name == resolveTrxCollection()->collectionName());
+  return _cid;
+}
+#endif
 
 /// @brief get the underlying collection's name
 std::string SingleCollectionTransaction::name() {

--- a/arangod/Utils/SingleCollectionTransaction.cpp
+++ b/arangod/Utils/SingleCollectionTransaction.cpp
@@ -29,6 +29,9 @@
 #include "Utils/CollectionNameResolver.h"
 #include "VocBase/LogicalDataSource.h"
 
+#include "Logger/Logger.h"
+#include "Logger/LogMacros.h"
+
 namespace arangodb {
 
 /// @brief create the transaction, using a data-source
@@ -96,7 +99,7 @@ LogicalCollection* SingleCollectionTransaction::documentCollection() {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 TRI_voc_cid_t SingleCollectionTransaction::addCollectionAtRuntime(std::string const& name) {
   // sanity check
-  TRI_ASSERT(name == resolveTrxCollection()->collectionName());
+  TRI_ASSERT((!name.empty() && name[0] >= '1' && name[0] <= '9') || name == resolveTrxCollection()->collectionName());
   return _cid;
 }
 #endif

--- a/arangod/Utils/SingleCollectionTransaction.h
+++ b/arangod/Utils/SingleCollectionTransaction.h
@@ -64,13 +64,11 @@ class SingleCollectionTransaction final : public transaction::Methods {
 #endif
   /// @brief add a collection to the transaction for read, at runtime
   /// note that this can only be ourselves
-  TRI_voc_cid_t addCollectionAtRuntime(std::string const& name) override final {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-    // sanity check
-    TRI_ASSERT(name == resolveTrxCollection()->collectionName());
+  TRI_voc_cid_t addCollectionAtRuntime(std::string const& name) override final;
+#else
+  TRI_voc_cid_t addCollectionAtRuntime(std::string const& name) override final { return _cid; }
 #endif
-    return _cid;
-  }
 
   /// @brief get the underlying collection's name
   std::string name();

--- a/arangod/V8Server/v8-vocbase.cpp
+++ b/arangod/V8Server/v8-vocbase.cpp
@@ -91,7 +91,7 @@
 #include "VocBase/Methods/Databases.h"
 #include "VocBase/Methods/Transactions.h"
 
-#if USE_ENTERPRISE
+#ifdef USE_ENTERPRISE
 #include "Enterprise/Ldap/LdapFeature.h"
 #endif
 
@@ -141,7 +141,6 @@ static void JS_Transaction(v8::FunctionCallbackInfo<v8::Value> const& args) {
   // filled by function
   v8::Handle<v8::Value> result;
   v8::TryCatch tryCatch(isolate);
-  ;
   Result rv = executeTransactionJS(isolate, args[0], result, tryCatch);
 
   // do not rethrow if already canceled

--- a/lib/Rest/VstResponse.h
+++ b/lib/Rest/VstResponse.h
@@ -27,8 +27,6 @@
 #include "Basics/StringBuffer.h"
 #include "Rest/GeneralResponse.h"
 
-#include <boost/asio/buffer.hpp>
-
 namespace arangodb {
 
 class VstResponse : public GeneralResponse {

--- a/tests/HotBackup/HotBackupCoordinatorTest.cpp
+++ b/tests/HotBackup/HotBackupCoordinatorTest.cpp
@@ -34,6 +34,10 @@
 #include <velocypack/Parser.h>
 #include <velocypack/velocypack-aliases.h>
 
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
 #include <fstream>
 #include <iterator>
 #include <iostream>
@@ -121,7 +125,7 @@ TEST_F(HotBackupOnCoordinators, test_first_dbserver_new) {
   }
 
   dbServers.front() = std::string("PRMR_")
-    + to_string(boost::uuids::random_generator()());
+    + boost::uuids::to_string(boost::uuids::random_generator()());
 
   arangodb::Result res = matchBackupServers(plan, dbServers, matches);
 
@@ -140,7 +144,7 @@ TEST_F(HotBackupOnCoordinators, test_last_dbserver_new) {
   }
 
   dbServers.back() = std::string("PRMR_")
-    + to_string(boost::uuids::random_generator()());
+    + boost::uuids::to_string(boost::uuids::random_generator()());
 
   arangodb::Result res = matchBackupServers(plan, dbServers, matches);
 
@@ -159,9 +163,9 @@ TEST_F(HotBackupOnCoordinators, test_first_and_last_dbserver_new) {
   }
 
   dbServers.front() = std::string("PRMR_")
-    + to_string(boost::uuids::random_generator()());
+    + boost::uuids::to_string(boost::uuids::random_generator()());
   dbServers.back() = std::string("PRMR_")
-    + to_string(boost::uuids::random_generator()());
+    + boost::uuids::to_string(boost::uuids::random_generator()());
 
   arangodb::Result res = matchBackupServers(plan, dbServers, matches);
 
@@ -177,7 +181,7 @@ TEST_F(HotBackupOnCoordinators, test_all_dbserver_new) {
 
   for (size_t i = 0; i < plan.get(dbsPath).length(); ++i) {
     dbServers.push_back(std::string("PRMR_")
-                        + to_string(boost::uuids::random_generator()()));
+                        + boost::uuids::to_string(boost::uuids::random_generator()()));
   }
 
   arangodb::Result res = matchBackupServers(plan, dbServers, matches);
@@ -196,7 +200,7 @@ TEST_F(HotBackupOnCoordinators, test_one_more_local_server_than_in_backup) {
     dbServers.push_back(i.key.copyString());
   }
   dbServers.push_back(std::string("PRMR_")
-                      + to_string(boost::uuids::random_generator()()));
+                      + boost::uuids::to_string(boost::uuids::random_generator()()));
 
   arangodb::Result res = matchBackupServers(plan, dbServers, matches);
 
@@ -231,7 +235,7 @@ TEST_F(HotBackupOnCoordinators, test_effect_of_first_dbserver_changed_on_new_pla
     dbServers.push_back(i.key.copyString());
   }
   dbServers.front() = std::string("PRMR_")
-    + to_string(boost::uuids::random_generator()());
+    + boost::uuids::to_string(boost::uuids::random_generator()());
 
   arangodb::Result res = matchBackupServers(plan, dbServers, matches);
 
@@ -259,9 +263,9 @@ TEST_F(HotBackupOnCoordinators, test_effect_of_first_and_last_dbservers_changed_
     dbServers.push_back(i.key.copyString());
   }
   dbServers.front() = std::string("PRMR_")
-    + to_string(boost::uuids::random_generator()());
+    + boost::uuids::to_string(boost::uuids::random_generator()());
   dbServers.back() = std::string("PRMR_")
-    + to_string(boost::uuids::random_generator()());
+    + boost::uuids::to_string(boost::uuids::random_generator()());
 
   arangodb::Result res = matchBackupServers(plan, dbServers, matches);
 
@@ -288,7 +292,7 @@ TEST_F(HotBackupOnCoordinators, test_effect_of_all_dbservers_changed_on_new_plan
 
   for (size_t i = 0; i < plan.get(dbsPath).length(); ++i) {
     dbServers.push_back(std::string("PRMR_")
-                        + to_string(boost::uuids::random_generator()()));
+                        + boost::uuids::to_string(boost::uuids::random_generator()()));
   }
 
   arangodb::Result res = matchBackupServers(plan, dbServers, matches);

--- a/tests/IResearch/IResearchAnalyzerFeature-test.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeature-test.cpp
@@ -3660,7 +3660,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_upgrade_static_legacy) {
           LEGACY_ANALYZER_COLLECTION_NAME, arangodb::AccessMode::Type::WRITE);
       EXPECT_TRUE((true == trx.begin().ok()));
       EXPECT_TRUE(
-          (true == trx.insert(arangodb::tests::AnalyzerCollectionName,
+          (true == trx.insert(LEGACY_ANALYZER_COLLECTION_NAME,
                               VPackParser::fromJson("{\"name\": \"legacy\"}")->slice(), options)
                        .ok()));
       EXPECT_TRUE((trx.commit().ok()));


### PR DESCRIPTION
### Scope & Purpose

Don't use assertion failures when an unknown collection/shard is used in a transaction, but throw an exception instead - so that issues can be investigated easier.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/6148/