### PR TITLE
make sure the input for responsibleShard is always an object

### DIFF
--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -368,12 +368,16 @@ void RestCollectionHandler::handleCommandPut() {
     return;
   }
 
-  if (!body.isObject()) {
+  std::string const& name = suffixes[0];
+  std::string const& sub = suffixes[1];
+
+  if (sub != "responsibleShard" && !body.isObject()) {
+    // if the caller has sent an empty body. for convenience, let's turn this into an object
+    // however, for the "responsibleShard" case we want to distinguish between string values,
+    // object values etc. - so we don't do the conversion here
     body = VPackSlice::emptyObjectSlice();
   }
 
-  std::string const& name = suffixes[0];
-  std::string const& sub = suffixes[1];
   Result res;
   VPackBuilder builder;
   auto found = methods::Collections::lookup(  // find collection
@@ -418,6 +422,22 @@ void RestCollectionHandler::handleCommandPut() {
           if (!ServerState::instance()->isCoordinator()) {
             res.reset(TRI_ERROR_CLUSTER_ONLY_ON_COORDINATOR);
           } else {
+            VPackBuilder temp;
+            if (body.isString()) {
+              temp.openObject();
+              temp.add(StaticStrings::KeyString, body);
+              temp.close();
+              body = temp.slice();
+            } else if (body.isNumber()) {
+              temp.openObject();
+              temp.add(StaticStrings::KeyString, VPackValue(std::to_string(body.getNumber<int64_t>())));
+              temp.close();
+              body = temp.slice();
+            }
+            if (!body.isObject()) {
+              THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER, "expecting object for responsibleShard");
+            }
+
             std::string shardId;
             res = coll->getResponsibleShard(body, false, shardId);
 

--- a/tests/js/common/shell/shell-responsibleshard-cluster.js
+++ b/tests/js/common/shell/shell-responsibleshard-cluster.js
@@ -71,6 +71,17 @@ function ResponsibleShardSuite() {
       assertNotEqual("", c.getResponsibleShard(12345));
     },
     
+    testCheckBrokenParameterArray : function () {
+      let c = db._create(cn, { numberOfShards: 5, shardKeys: ["_key"] });
+
+      try {
+        c.getResponsibleShard([]);
+        fail();
+      } catch (err) {
+        assertEqual(internal.errors.ERROR_BAD_PARAMETER.code, err.errorNum);
+      }
+    },
+    
     testCheckKeyNotGiven : function () {
       let c = db._create(cn, { numberOfShards: 5, shardKeys: ["_key"] });
 


### PR DESCRIPTION
### Scope & Purpose

Make sure that the user-accessible `db.<collection>.getResponsibleShard()` method always calls the internal `getResponsibleShard()` method with an object slice.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *shell-responsibleshard-cluster.js*.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/6204/