### PR TITLE
disable the creation of TTL indexes on sub-attributes

### DIFF
--- a/arangod/Indexes/IndexFactory.h
+++ b/arangod/Indexes/IndexFactory.h
@@ -111,13 +111,14 @@ class IndexFactory {
                               std::vector<std::shared_ptr<arangodb::Index>>& indexes) const = 0;
 
   static Result validateFieldsDefinition(arangodb::velocypack::Slice definition, 
-                                         size_t minFields, size_t maxFields);
+                                         size_t minFields, size_t maxFields,
+                                         bool allowSubAttributes = true);
 
   /// @brief process the fields list, deduplicate it, and add it to the json
   static Result processIndexFields(arangodb::velocypack::Slice definition, 
                                    arangodb::velocypack::Builder& builder,
                                    size_t minFields, size_t maxFields, bool create,
-                                   bool allowExpansion);
+                                   bool allowExpansion, bool allowSubAttributes = true);
 
   /// @brief process the unique flag and add it to the json
   static void processIndexUniqueFlag(arangodb::velocypack::Slice definition,

--- a/tests/Basics/VelocyPackHelper-test.cpp
+++ b/tests/Basics/VelocyPackHelper-test.cpp
@@ -162,3 +162,26 @@ TEST(VPackHelperTest, tst_compare_values_unequal) {
   VPACK_EXPECT_TRUE(-1, arangodb::basics::VelocyPackHelper::compare, "1", "[true]");
   VPACK_EXPECT_TRUE(-1, arangodb::basics::VelocyPackHelper::compare, "1", "{}");
 }
+
+TEST(VPackHelperTest, testHashString) {
+  auto compare = [](std::string const& input, uint64_t seed = arangodb::velocypack::Slice::defaultSeed) {
+    VPackBuilder builder;
+    builder.add(VPackValue(input));
+
+    VPackSlice slice = builder.slice();
+    uint64_t expected = slice.hash(seed);
+
+    ASSERT_EQ(expected, arangodb::basics::VelocyPackHelper::hashString(input, seed));
+  };
+
+  compare("");
+  /*
+  compare(" ");
+  compare("1");
+  compare("FOO");
+  compare("fuppes12");
+  compare("der hund");
+  compare("this is a test string");
+  compare("this is a long string, and it must be longer than 126 bytes, so we really need to fill this string up with some random text");
+  */
+}

--- a/tests/js/common/shell/shell-ttl.js
+++ b/tests/js/common/shell/shell-ttl.js
@@ -204,6 +204,16 @@ function TtlSuite () {
       // number of runs must not have changed
       assertEqual(stats.runs, oldRuns);
     },
+    
+    testCreateIndexSubAttribute : function () {
+      let c = db._create(cn, { numberOfShards: 2 });
+      try {
+        c.ensureIndex({ type: "ttl", fields: ["date.created"], expireAfter: 10, unique: true });
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_BAD_PARAMETER.code, err.errorNum);
+      }
+    },
 
     testCreateIndexUnique : function () {
       let c = db._create(cn, { numberOfShards: 2 });


### PR DESCRIPTION
### Scope & Purpose

Don't allow creation of TTL indexes on sub-attributes.
Creating indexes on sub-attributes was allowed before, but did not work.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/6205/