### PR TITLE
add assertions for Cache memory usage not underflowing its minimal usage

### DIFF
--- a/arangod/Cache/Manager.cpp
+++ b/arangod/Cache/Manager.cpp
@@ -291,7 +291,7 @@ std::tuple<bool, Metadata, std::shared_ptr<Table>> Manager::registerCache(uint64
                                                                           uint64_t maxSize) {
   TRI_ASSERT(_lock.isWriteLocked());
   Metadata metadata;
-  std::shared_ptr<Table> table(nullptr);
+  std::shared_ptr<Table> table;
   bool ok = true;
 
   if ((_globalHighwaterMark / (_caches.size() + 1)) < Manager::minCacheAllocation) {
@@ -300,7 +300,7 @@ std::tuple<bool, Metadata, std::shared_ptr<Table>> Manager::registerCache(uint64
 
   if (ok) {
     table = leaseTable(Table::minLogSize);
-    ok = (table.get() != nullptr);
+    ok = (table != nullptr);
   }
 
   if (ok) {
@@ -308,10 +308,11 @@ std::tuple<bool, Metadata, std::shared_ptr<Table>> Manager::registerCache(uint64
     ok = increaseAllowed(metadata.allocatedSize - table->memoryUsage(), true);
     if (ok) {
       _globalAllocation += (metadata.allocatedSize - table->memoryUsage());
+      TRI_ASSERT(_globalAllocation >= _fixedAllocation);
     }
   }
 
-  if (!ok && (table.get() != nullptr)) {
+  if (!ok && (table != nullptr)) {
     reclaimTable(table, true);
     table.reset();
   }
@@ -331,6 +332,7 @@ void Manager::unregisterCache(uint64_t id) {
   Metadata* metadata = cache->metadata();
   metadata->readLock();
   _globalAllocation -= metadata->allocatedSize;
+  TRI_ASSERT(_globalAllocation >= _fixedAllocation);
   metadata->readUnlock();
   _caches.erase(id);
   _lock.writeUnlock();
@@ -602,6 +604,7 @@ void Manager::freeUnusedTables() {
     while (!_tables[i].empty()) {
       auto table = _tables[i].top();
       _globalAllocation -= table->memoryUsage();
+      TRI_ASSERT(_globalAllocation >= _fixedAllocation);
       _tables[i].pop();
     }
   }
@@ -633,6 +636,7 @@ void Manager::resizeCache(Manager::TaskEnvironment environment, Cache* cache, ui
     metadata->writeUnlock();
     _globalAllocation -= oldLimit;
     _globalAllocation += newLimit;
+    TRI_ASSERT(_globalAllocation >= _fixedAllocation);
     return;
   }
 
@@ -678,12 +682,13 @@ void Manager::migrateCache(Manager::TaskEnvironment environment, Cache* cache,
 std::shared_ptr<Table> Manager::leaseTable(uint32_t logSize) {
   TRI_ASSERT(_lock.isWriteLocked());
 
-  std::shared_ptr<Table> table(nullptr);
+  std::shared_ptr<Table> table;
   if (_tables[logSize].empty()) {
     if (increaseAllowed(Table::allocationSize(logSize), true)) {
       try {
         table = std::make_shared<Table>(logSize);
         _globalAllocation += table->memoryUsage();
+        TRI_ASSERT(_globalAllocation >= _fixedAllocation);
       } catch (std::bad_alloc const&) {
         table.reset();
       }
@@ -712,6 +717,7 @@ void Manager::reclaimTable(std::shared_ptr<Table> table, bool internal) {
     _spareTableAllocation += table->memoryUsage();
   } else {
     _globalAllocation -= table->memoryUsage();
+    TRI_ASSERT(_globalAllocation >= _fixedAllocation);
     table.reset();
   }
 


### PR DESCRIPTION
### Scope & Purpose

Added assertions to the cache manager, making sure the memory usage value it tracks internally does not go below the expected minimum allocation value.
There was a [bug in the memory accounting](https://github.com/arangodb/arangodb/pull/10028) previously that led to an underflow of the `_globalAllocation` value, which was fixed by @danielhlarkin. 
This PR makes sure the bug will not happen again.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *edge cache tests*.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/6328/