### PR TITLE
Avoid overfetch in sorting gather executor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix a problem with AQL constrained sort in the cluster, which might abort
+  queries.
+
 * Fix strange shutdown hanger which came from the fact that currently
   libgcc/libmusl wrongly detect multi-threadedness in statically linked
   executables.

--- a/arangod/Aql/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode.h
@@ -817,6 +817,8 @@ class LimitNode : public ExecutionNode {
   /// @brief tell the node to fully count what it will limit
   void setFullCount() { _fullCount = true; }
 
+  bool fullCount() const noexcept { return _fullCount; }
+
   /// @brief return the offset value
   size_t offset() const { return _offset; }
 

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -2391,4 +2391,11 @@ void ExecutionPlan::show() {
   _root->walk(shower);
 }
 
+bool ExecutionPlan::fullCount() const noexcept {
+  LimitNode* lastLimitNode = _lastLimitNode == nullptr
+                                 ? nullptr
+                                 : ExecutionNode::castTo<LimitNode*>(_lastLimitNode);
+  return lastLimitNode != nullptr && lastLimitNode->fullCount();
+}
+
 #endif

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -2356,6 +2356,13 @@ bool ExecutionPlan::isDeadSimple() const {
   return true;
 }
 
+bool ExecutionPlan::fullCount() const noexcept {
+  LimitNode* lastLimitNode = _lastLimitNode == nullptr
+                             ? nullptr
+                             : ExecutionNode::castTo<LimitNode*>(_lastLimitNode);
+  return lastLimitNode != nullptr && lastLimitNode->fullCount();
+}
+
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 
 #include <iostream>
@@ -2389,13 +2396,6 @@ struct Shower final : public WalkerWorker<ExecutionNode> {
 void ExecutionPlan::show() {
   Shower shower;
   _root->walk(shower);
-}
-
-bool ExecutionPlan::fullCount() const noexcept {
-  LimitNode* lastLimitNode = _lastLimitNode == nullptr
-                                 ? nullptr
-                                 : ExecutionNode::castTo<LimitNode*>(_lastLimitNode);
-  return lastLimitNode != nullptr && lastLimitNode->fullCount();
 }
 
 #endif

--- a/arangod/Aql/ExecutionPlan.h
+++ b/arangod/Aql/ExecutionPlan.h
@@ -245,6 +245,8 @@ class ExecutionPlan {
   /// @brief increase the node counter for the type
   void increaseCounter(ExecutionNode::NodeType type) noexcept;
 
+  bool fullCount() const noexcept;
+
  private:
   /// @brief creates a calculation node
   ExecutionNode* createCalculation(Variable*, Variable const*, AstNode const*, ExecutionNode*);

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -6924,6 +6924,13 @@ static bool isInnerPassthroughNode(ExecutionNode* node) {
 
 void arangodb::aql::sortLimitRule(Optimizer* opt, std::unique_ptr<ExecutionPlan> plan,
                                   OptimizerRule const& rule) {
+  if (ServerState::instance()->isCoordinator() && plan->fullCount()) {
+    // Disable optimizer rule temporarily. SortingGather must be made aware of
+    // constrained sort for this to work.
+    opt->addPlan(std::move(plan), rule, false);
+    return;
+  }
+
   SmallVector<ExecutionNode*>::allocator_type::arena_type a;
   SmallVector<ExecutionNode*> nodes{a};
   bool mod = false;

--- a/arangod/Aql/SortingGatherExecutor.h
+++ b/arangod/Aql/SortingGatherExecutor.h
@@ -121,7 +121,7 @@ class SortingGatherExecutor {
   std::pair<ExecutionState, size_t> expectedNumberOfRows(size_t atMost) const;
 
  private:
-  ExecutionState init();
+  ExecutionState init(size_t atMost);
 
  private:
   Fetcher& _fetcher;

--- a/tests/js/server/aql/aql-profiler-cluster.js
+++ b/tests/js/server/aql/aql-profiler-cluster.js
@@ -193,6 +193,9 @@ function ahuacatlProfilerTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 
     testRemoteAndSortingGatherBlock : function () {
+      // TODO re-enable this again, after the SortingGather block is fixed for cluster & fullCount,
+      //      and sort-limit is re-enabled.
+      return;
       const query = `FOR doc IN ${cn} SORT doc.i RETURN doc`;
       // Number of local getSome calls that do not return WAITING.
       // This is at least 1.

--- a/tests/js/server/aql/aql-profiler.js
+++ b/tests/js/server/aql/aql-profiler.js
@@ -33,6 +33,7 @@ const db = require('@arangodb').db;
 const jsunity = require("jsunity");
 const assert = jsunity.jsUnity.assertions;
 const _ = require('lodash');
+const isCluster = require('@arangodb/cluster').isCluster();
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -664,6 +665,11 @@ function ahuacatlProfilerTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 
     testSortLimitBlock2 : function () {
+      // TODO re-enable this again, after the SortingGather block is fixed for cluster & fullCount,
+      //      and sort-limit is re-enabled.
+      if (isCluster) {
+        return;
+      }
       const query = 'FOR i IN 1..@rows SORT i DESC LIMIT @offset, @limit RETURN i';
       const remainder = rows => rows - limit(rows);
       const remainderBatches = rows => remainder(rows) === 0 ? 0 : 1;

--- a/tests/js/server/aql/aql-queries-optimizer-sort-limit-cluster.js
+++ b/tests/js/server/aql/aql-queries-optimizer-sort-limit-cluster.js
@@ -1,0 +1,116 @@
+/*jshint globalstrict:true, strict:true, esnext: true */
+
+"use strict";
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2019 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require('jsunity');
+const assert = jsunity.jsUnity.assertions;
+const internal = require('internal');
+const db = internal.db;
+const console = require('console');
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test suite
+////////////////////////////////////////////////////////////////////////////////
+
+function ahuacatlQueryOptimizerLimitClusterTestSuite() {
+  const cn = 'UnitTestsAhuacatlOptimizerLimitCluster';
+  const numberOfShards = 9;
+  const docCount = 20;
+  let col;
+
+  const runWithOneFilledShard = (fun) => {
+    try {
+      internal.db._drop(cn);
+      col = db._create(cn, {numberOfShards});
+      const shards = col.shards();
+      assert.assertEqual(numberOfShards, shards.length);
+      const aShard = shards[0];
+
+      for (let i = 0, inserted = 0; inserted < docCount; i++) {
+        const doc = {_key: "test" + i.toString(), value: inserted};
+
+        const shard = col.getResponsibleShard(doc);
+        if (shard === aShard) {
+          col.save(doc);
+          ++inserted;
+        }
+      }
+
+      for (const [k, v] of Object.entries(col.count(true))) {
+        if (k === aShard) {
+          assert.assertEqual(docCount, v);
+        } else {
+          assert.assertEqual(0, v);
+        }
+      }
+
+      fun();
+    } finally {
+      internal.db._drop(cn);
+    }
+  };
+
+  const getSorts = function (plan) {
+    return plan.nodes.filter(node => node.type === "SortNode");
+  };
+
+  return {
+    setUpAll: function () {
+    },
+    tearDownAll: function () {
+    },
+
+    testSortWithFullCountOnOneShard: function () {
+      runWithOneFilledShard(() => {
+        const query = `FOR c IN ${cn} SORT c.value LIMIT 5, 10 RETURN c`;
+
+        const queryResult = db._query(query, {}, {fullCount: true, profile: 2});
+        const extra = queryResult.getExtra();
+        const values = queryResult.toArray();
+
+        const fullCount = extra.stats.fullCount;
+
+        assertEqual(10, values.length);
+
+        assertEqual(fullCount, 20);
+
+        const sorts = getSorts(extra.plan);
+        assertEqual(sorts.length, 1);
+        // Temporarily disabled:
+        // assertEqual(15, sorts[0].limit);
+        // assertEqual('constrained-heap', sorts[0].strategy);
+        assertEqual('standard', sorts[0].strategy);
+      });
+    },
+  };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief executes the test suite
+////////////////////////////////////////////////////////////////////////////////
+
+jsunity.run(ahuacatlQueryOptimizerLimitClusterTestSuite);
+
+return jsunity.done();

--- a/tests/js/server/aql/aql-queries-optimizer-sort-limit-cluster.js
+++ b/tests/js/server/aql/aql-queries-optimizer-sort-limit-cluster.js
@@ -92,16 +92,16 @@ function ahuacatlQueryOptimizerLimitClusterTestSuite() {
 
         const fullCount = extra.stats.fullCount;
 
-        assertEqual(10, values.length);
+        assert.assertEqual(10, values.length);
 
-        assertEqual(fullCount, 20);
+        assert.assertEqual(fullCount, 20);
 
         const sorts = getSorts(extra.plan);
-        assertEqual(sorts.length, 1);
+        assert.assertEqual(sorts.length, 1);
         // Temporarily disabled:
         // assertEqual(15, sorts[0].limit);
         // assertEqual('constrained-heap', sorts[0].strategy);
-        assertEqual('standard', sorts[0].strategy);
+        assert.assertEqual('standard', sorts[0].strategy);
       });
     },
   };

--- a/tests/js/server/aql/aql-queries-optimizer-sort-limit.js
+++ b/tests/js/server/aql/aql-queries-optimizer-sort-limit.js
@@ -52,7 +52,7 @@ function ahuacatlQueryOptimizerLimitTestSuite () {
 /// @brief set up
 ////////////////////////////////////////////////////////////////////////////////
 
-    setUp : function () {
+    setUpAll : function () {
       internal.db._drop(cn);
       collection = internal.db._create(cn, {numberOfShards: 9});
 
@@ -65,7 +65,7 @@ function ahuacatlQueryOptimizerLimitTestSuite () {
 /// @brief tear down
 ////////////////////////////////////////////////////////////////////////////////
 
-    tearDown : function () {
+    tearDownAll : function () {
       internal.db._drop(cn);
     },
 


### PR DESCRIPTION
### Scope & Purpose

Avoid overfetch in SortingGather. Related to #9981. Error was noticed in a test in #9395.

Also disables the sort-limit, if both in cluster and fullCount is enabled for the query. This will be addressed in another PR, because the fix for SortingGather will be more complicated.

- [X] Bug-Fix for *devel-branch*
- [ ] Bug-Fix for *3.5* **(will be delayed until SortingGather is fixed, too)**

### Testing & Verification

This change is already covered by existing tests, such as `tests/js/server/aql/aql-queries-optimizer-sort-limit.js`.

### Documentation

- [X] Added a *Changelog Entry*
