### PR TITLE
Docs: Dump program options of arangobackup as well

### DIFF
--- a/utils/generateExamples.sh
+++ b/utils/generateExamples.sh
@@ -52,6 +52,10 @@ fi
 
 if "${ARANGOSH}" --version | grep -q "^enterprise-version: enterprise$"; then
     ALLPROGRAMS="arangobench arangod arangodump arangoexport arangoimport arangoinspect arangorestore arangosh"
+    # arangobackup not available in v3.5.0
+    if [ -x "${BIN_PATH}/arangobackup${EXT}" ]; then
+        ALLPROGRAMS="arangobackup ${ALLPROGRAMS}"
+    fi
     for HELPPROGRAM in ${ALLPROGRAMS}; do
         echo "Dumping program options of ${HELPPROGRAM}"
         "${BIN_PATH}/${HELPPROGRAM}${EXT}" --dump-options > "Documentation/Examples/${HELPPROGRAM}.json"

--- a/utils/generateExamples.sh
+++ b/utils/generateExamples.sh
@@ -51,11 +51,7 @@ fi
 [ "$(uname -s)" = "Darwin" -a -x "${ARANGOSH}" ] && ARANGOSH="$(cd -P -- "$(dirname -- "${ARANGOSH}")" && pwd -P)/$(basename -- "${ARANGOSH}")"
 
 if "${ARANGOSH}" --version | grep -q "^enterprise-version: enterprise$"; then
-    ALLPROGRAMS="arangobench arangod arangodump arangoexport arangoimport arangoinspect arangorestore arangosh"
-    # arangobackup not available in v3.5.0
-    if [ -x "${BIN_PATH}/arangobackup${EXT}" ]; then
-        ALLPROGRAMS="arangobackup ${ALLPROGRAMS}"
-    fi
+    ALLPROGRAMS="arangobackup arangobench arangod arangodump arangoexport arangoimport arangoinspect arangorestore arangosh"
     for HELPPROGRAM in ${ALLPROGRAMS}; do
         echo "Dumping program options of ${HELPPROGRAM}"
         "${BIN_PATH}/${HELPPROGRAM}${EXT}" --dump-options > "Documentation/Examples/${HELPPROGRAM}.json"


### PR DESCRIPTION
Backport of #9932 

An additional check if the binary exists (because it's not there in v3.5.0) shouldn't be necessary, as the v3.5.0 tag does not include this change.