### PR TITLE
[3.4] Removed erroneous noexcept specifier for rebootIds() accessor

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -3932,7 +3932,7 @@ ClusterInfo::ServersKnown::serversKnown() const noexcept {
   return _serversKnown;
 }
 
-std::unordered_map<ServerID, RebootId> ClusterInfo::ServersKnown::rebootIds() const noexcept {
+std::unordered_map<ServerID, RebootId> ClusterInfo::ServersKnown::rebootIds() const {
   std::unordered_map<ServerID, RebootId> rebootIds;
   for (auto const& it : _serversKnown) {
     rebootIds.emplace(it.first, it.second.rebootId());

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -253,7 +253,7 @@ class ClusterInfo {
 
     std::unordered_map<ServerID, KnownServer> const& serversKnown() const noexcept;
 
-    std::unordered_map<ServerID, RebootId> rebootIds() const noexcept;
+    std::unordered_map<ServerID, RebootId> rebootIds() const;
 
    private:
     std::unordered_map<ServerID, KnownServer> _serversKnown;


### PR DESCRIPTION
### Scope & Purpose

- [X] Bug-Fix for *3.4* (already fixed in devel)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.
