### PR TITLE
Fix windows path handling not to slip into UNC lookup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fix config directory handling, so we don't trap into UNC path lookups on windows
+
 * Fix compilation issue with clang 10
 
 * Fixed issue #10062: AQL: Could not extract custom attribute.

--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -2441,7 +2441,11 @@ int TRI_GetTempName(char const* directory, std::string& result, bool createFile,
 
 std::string TRI_LocateInstallDirectory(char const* argv0, char const* binaryPath) {
   std::string thisPath = TRI_LocateBinaryPath(argv0);
-  return TRI_GetInstallRoot(thisPath, binaryPath) + TRI_DIR_SEPARATOR_CHAR;
+  std::string ret = TRI_GetInstallRoot(thisPath, binaryPath);
+  if (ret.length() != 1 || ret != TRI_DIR_SEPARATOR_STR) {
+    ret += TRI_DIR_SEPARATOR_CHAR;
+  }
+  return ret;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2460,8 +2464,14 @@ std::string TRI_LocateConfigDirectory(char const* binaryPath) {
   }
 
   std::string r = TRI_LocateInstallDirectory(nullptr, binaryPath);
-
-  r += _SYSCONFDIR_;
+  std::string scDir =  _SYSCONFDIR_;
+  if (r.length() == 1 &&
+      r == TRI_DIR_SEPARATOR_STR &&
+      scDir[0] == TRI_DIR_SEPARATOR_CHAR) {
+    r = scDir;
+  } else {
+    r += _SYSCONFDIR_;
+  }
   r += std::string(1, TRI_DIR_SEPARATOR_CHAR);
 
   return r;


### PR DESCRIPTION
### Scope & Purpose

make sure that we don't get more than one leading directory separator in front of the path, so windows doesn't mistakenly look it up as a UNC.


- [x] Bug-Fix for *devel-branch*, needs backports
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information
- [x] There is a *JIRA Ticket number* https://arangodb.atlassian.net/browse/COP-165

### Testing & Verification
verify time used to run `arangosh --version` - if takes longer than a second, an UNC may be triggered and timed out.

- [x] Added a *Changelog Entry* (referencing the corresponding public or internal issue number)
