### PR TITLE
Fix windows path handling not to slip into UNC lookup (#10073)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.3.25 (2019-XX-XX)
 --------------------
 
+* Fix config directory handling, so we don't trap into UNC path lookups on windows
+
 * Fixed non-deterministic occurrences of "document not found" errors in sharded 
   collections with custom shard keys (i.e. non-`_key`) and multi-document lookups.
 

--- a/arangod/Aql/Graphs.cpp
+++ b/arangod/Aql/Graphs.cpp
@@ -40,7 +40,7 @@ EdgeConditionBuilder::EdgeConditionBuilder(AstNode* modCondition)
       _toCondition(nullptr),
       _modCondition(modCondition),
       _containsCondition(false) {
-#ifdef TRI_ENABLE_MAINTAINER_MODE
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if (_modCondition != nullptr) {
     TRI_ASSERT(_modCondition->type == NODE_TYPE_OPERATOR_NARY_AND);
   }
@@ -61,7 +61,7 @@ void EdgeConditionBuilder::swapSides(AstNode* cond) {
   TRI_ASSERT(cond == _fromCondition || cond == _toCondition);
   TRI_ASSERT(cond->type == NODE_TYPE_OPERATOR_BINARY_EQ);
   if (_containsCondition) {
-#ifdef TRI_ENABLE_MAINTAINER_MODE
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     // If used correctly this class guarantuees that the last element
     // of the nary-and is the _from or _to part and is exchangable.
     TRI_ASSERT(_modCondition->numMembers() > 0);

--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -135,7 +135,7 @@ TraversalNode::TraversalNode(ExecutionPlan* plan, size_t id, TRI_vocbase_t* vocb
                                      "_id string or an object with _id.");
   }
 
-#ifdef TRI_ENABLE_MAINTAINER_MODE
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   checkConditionsDefined();
 #endif
 }
@@ -239,7 +239,7 @@ TraversalNode::TraversalNode(ExecutionPlan* plan, arangodb::velocypack::Slice co
     }
   }
 
-#ifdef TRI_ENABLE_MAINTAINER_MODE
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   checkConditionsDefined();
 #endif
 }
@@ -416,7 +416,7 @@ ExecutionNode* TraversalNode::clone(ExecutionPlan* plan, bool withDependencies,
     c->_conditionVariables.emplace(it->clone());
   }
 
-#ifdef TRI_ENABLE_MAINTAINER_MODE
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   checkConditionsDefined();
 #endif
 
@@ -446,7 +446,7 @@ ExecutionNode* TraversalNode::clone(ExecutionPlan* plan, bool withDependencies,
     c->_vertexConditions.emplace(it.first, it.second->clone(_plan->getAst()));
   }
 
-#ifdef TRI_ENABLE_MAINTAINER_MODE
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   c->checkConditionsDefined();
 #endif
 
@@ -615,7 +615,7 @@ void TraversalNode::getConditionVariables(std::vector<Variable const*>& res) con
   }
 }
 
-#ifdef TRI_ENABLE_MAINTAINER_MODE
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 void TraversalNode::checkConditionsDefined() const {
   TRI_ASSERT(_tmpObjVariable != nullptr);
   TRI_ASSERT(_tmpObjVarNode != nullptr);

--- a/arangod/Aql/TraversalNode.h
+++ b/arangod/Aql/TraversalNode.h
@@ -198,7 +198,7 @@ class TraversalNode : public GraphNode {
   void prepareOptions() override;
 
  private:
-#ifdef TRI_ENABLE_MAINTAINER_MODE
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   void checkConditionsDefined() const;
 #endif
 

--- a/js/client/modules/@arangodb/testsuites/rspec.js
+++ b/js/client/modules/@arangodb/testsuites/rspec.js
@@ -355,8 +355,7 @@ function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
 
   if (opts.hasOwnProperty('ruby')) {
     let rx = new RegExp('ruby.exe$');
-    var rspec = opts.ruby.replace(rx, 'rspec');
-    opts['rspec'] = opts.ruby;
+    opts['rspec'] = opts.ruby.replace(rx, 'rspec');
   } else {
     if (platform.substr(0, 3) !== 'win') {
       opts['rspec'] = 'rspec';
@@ -366,6 +365,7 @@ function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
       opts['rspec'] = 'rspec.bat';
     }
   }
+  opts['ruby'] = '';
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }

--- a/js/client/modules/@arangodb/testsuites/rspec.js
+++ b/js/client/modules/@arangodb/testsuites/rspec.js
@@ -352,14 +352,20 @@ function setup (testFns, defaultFns, opts, fnDocs, optionsDoc) {
   defaultFns.push('ssl_server');
 
   opts['skipSsl'] = false;
-  if (platform.substr(0, 3) !== 'win') {
-    opts['rspec'] = 'rspec';
+
+  if (opts.hasOwnProperty('ruby')) {
+    let rx = new RegExp('ruby.exe$');
+    var rspec = opts.ruby.replace(rx, 'rspec');
+    opts['rspec'] = opts.ruby;
   } else {
-    // Windows process utilties would apply `.exe` to rspec.
-    // However the file is called .bat and .exe cannot be found.
-    opts['rspec'] = 'rspec.bat';
+    if (platform.substr(0, 3) !== 'win') {
+      opts['rspec'] = 'rspec';
+    } else {
+      // Windows process utilties would apply `.exe` to rspec.
+      // However the file is called .bat and .exe cannot be found.
+      opts['rspec'] = 'rspec.bat';
+    }
   }
-  opts['ruby'] = '';
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }

--- a/lib/ApplicationFeatures/RocksDBOptionFeature.cpp
+++ b/lib/ApplicationFeatures/RocksDBOptionFeature.cpp
@@ -84,7 +84,7 @@ RocksDBOptionFeature::RocksDBOptionFeature(application_features::ApplicationServ
   // setting the number of background jobs to
   _maxBackgroundJobs = static_cast<int32_t>(
       std::max((size_t)2, std::min(TRI_numberProcessors(), (size_t)8)));
-#ifdef WIN32
+#ifdef _WIN32
   // Windows code does not (yet) support lowering thread priority of
   //  compactions.  Therefore it is possible for rocksdb to use all
   //  CPU time on compactions.  Essential network communications can be lost.

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -112,7 +112,7 @@ std::string buildFilename(char const* path, char const* name) {
 
   if (!result.empty()) {
     result = removeTrailingSeparator(result);
-    if (result.length() == 1 && result[0] != TRI_DIR_SEPARATOR_CHAR) {
+    if (result.length() != 1 || result[0] != TRI_DIR_SEPARATOR_CHAR) {
       result += TRI_DIR_SEPARATOR_CHAR;
     }
   }
@@ -134,7 +134,7 @@ std::string buildFilename(std::string const& path, std::string const& name) {
 
   if (!result.empty()) {
     result = removeTrailingSeparator(result);
-    if (result.length() == 1 && result[0] != TRI_DIR_SEPARATOR_CHAR) {
+    if (result.length() != 1 || result[0] != TRI_DIR_SEPARATOR_CHAR) {
       result += TRI_DIR_SEPARATOR_CHAR;
     }
   }

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -111,7 +111,10 @@ std::string buildFilename(char const* path, char const* name) {
   std::string result(path);
 
   if (!result.empty()) {
-    result = removeTrailingSeparator(result) + TRI_DIR_SEPARATOR_CHAR;
+    result = removeTrailingSeparator(result);
+    if (result.length() == 1 && result[0] != TRI_DIR_SEPARATOR_CHAR) {
+      result += TRI_DIR_SEPARATOR_CHAR;
+    }
   }
 
   if (!result.empty() && *name == TRI_DIR_SEPARATOR_CHAR) {
@@ -130,7 +133,10 @@ std::string buildFilename(std::string const& path, std::string const& name) {
   std::string result(path);
 
   if (!result.empty()) {
-    result = removeTrailingSeparator(result) + TRI_DIR_SEPARATOR_CHAR;
+    result = removeTrailingSeparator(result);
+    if (result.length() == 1 && result[0] != TRI_DIR_SEPARATOR_CHAR) {
+      result += TRI_DIR_SEPARATOR_CHAR;
+    }
   }
 
   if (!result.empty() && !name.empty() && name[0] == TRI_DIR_SEPARATOR_CHAR) {

--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -2151,7 +2151,11 @@ int TRI_GetTempName(char const* directory, std::string& result, bool createFile,
 ////////////////////////////////////////////////////////////////////////////////
 std::string TRI_LocateInstallDirectory(char const* argv0, char const* binaryPath) {
   std::string thisPath = TRI_LocateBinaryPath(argv0);
-  return TRI_GetInstallRoot(thisPath, binaryPath) + std::string(1, TRI_DIR_SEPARATOR_CHAR);
+  std::string ret = TRI_GetInstallRoot(thisPath, binaryPath);
+  if (ret.length() != 1 || ret != TRI_DIR_SEPARATOR_STR) {
+    ret += TRI_DIR_SEPARATOR_CHAR;
+  }
+  return ret;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2170,8 +2174,14 @@ std::string TRI_LocateConfigDirectory(char const* binaryPath) {
   }
 
   std::string r = TRI_LocateInstallDirectory(nullptr, binaryPath);
-
-  r += _SYSCONFDIR_;
+  std::string scDir =  _SYSCONFDIR_;
+  if (r.length() == 1 &&
+      r == TRI_DIR_SEPARATOR_STR &&
+      scDir[0] == TRI_DIR_SEPARATOR_CHAR) {
+    r = scDir;
+  } else {
+    r += _SYSCONFDIR_;
+  }
   r += std::string(1, TRI_DIR_SEPARATOR_CHAR);
 
   return r;

--- a/lib/Basics/tri-zip.cpp
+++ b/lib/Basics/tri-zip.cpp
@@ -89,7 +89,7 @@ static int ExtractCurrentFile(unzFile uf, void* buffer, size_t const bufferSize,
   // adjust file name
   p = filenameInZip;
   while (*p != '\0') {
-#ifdef WIN32
+#ifdef _WIN32
     if (*p == '/') {
       *p = '\\';
     }


### PR DESCRIPTION
Backport of https://github.com/arangodb/arangodb/pull/10073

* make sure that we don't get more than one leading directory separator in front of the path, so windows doesn't mistakenly look it up as a UNC.
