### PR TITLE
Improved query tracing, especially useful for cluster queries

### DIFF
--- a/arangod/Aql/RemoteExecutor.h
+++ b/arangod/Aql/RemoteExecutor.h
@@ -141,6 +141,10 @@ class ExecutionBlockImpl<RemoteExecutor> : public ExecutionBlock {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   bool _didSendShutdownRequest = false;
 #endif
+
+  void traceGetSomeRequest(std::shared_ptr<const std::string> const& sharedPtr, size_t atMost);
+  void traceSkipSomeRequest(std::shared_ptr<const std::string> const& body, size_t atMost);
+  void traceRequest(const char* rpc, std::shared_ptr<const std::string> const& sharedPtr, size_t atMost);
 };
 
 }  // namespace aql

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -446,7 +446,7 @@ RestStatus RestAqlHandler::useQuery(std::string const& operation, std::string co
   TRI_ASSERT(query->engine() != nullptr);
 
   if (query->queryOptions().profile >= PROFILE_LEVEL_TRACE_1) {
-    LOG_TOPIC("92c71", INFO, Logger::QUERIES)
+    LOG_TOPIC("1bf67", INFO, Logger::QUERIES)
         << "[query#" << query->id() << "] remote request received: " << operation
         << " registryId=" << idString;
   }


### PR DESCRIPTION
### Scope & Purpose

Add additional information to AQL query tracing, to make it easier to follow a query, especially in a cluster. This affects `profile >= 3` only: These levels are not documented and only used for debugging.

- [X] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

This change is already covered by existing tests, such as `shell_server_aql`.
