### PR TITLE
fix skipInaccessible

### DIFF
--- a/arangod/Aql/AqlTransaction.cpp
+++ b/arangod/Aql/AqlTransaction.cpp
@@ -46,7 +46,7 @@ std::shared_ptr<AqlTransaction> AqlTransaction::create(
   if (options.skipInaccessibleCollections) {
     return std::make_shared<transaction::IgnoreNoAccessAqlTransaction>(transactionContext, collections,
                                                                        options, isMainTransaction,
-                                                                       inaccessibleCollections);
+                                                                       std::move(inaccessibleCollections));
   }
 #endif
   return std::make_shared<AqlTransaction>(transactionContext, collections, options, isMainTransaction);

--- a/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
+++ b/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
@@ -92,9 +92,17 @@ EngineInfoContainerDBServerServerBased::TraverserEngineShardLists::TraverserEngi
   // It might in fact be empty, if we only have edge collections in a graph.
   // Or if we guarantee to never read vertex data.
   for (auto const& col : vertices) {
-    _vertexCollections.emplace(col->name(),
-                               getAllLocalShards(shardMapping, server,
-                                                 col->shardIds(restrictToShards)));
+    auto shards = getAllLocalShards(shardMapping, server,
+                                    col->shardIds(restrictToShards));
+#ifdef USE_ENTERPRISE
+    for (auto const& s : shards) {
+      if (query.trx()->isInaccessibleCollectionId(col->getPlanId())) {
+        _inaccessibleShards.insert(s);
+        _inaccessibleShards.insert(std::to_string(col->id()));
+      }
+    }
+#endif
+    _vertexCollections.emplace(col->name(), std::move(shards));
   }
 }
 

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -483,7 +483,7 @@ ExecutionPlan* Query::preparePlan() {
 
   auto trx = AqlTransaction::create(std::move(ctx), _collections.collections(),
                                     _queryOptions.transactionOptions,
-                                    _part == PART_MAIN, inaccessibleCollections);
+                                    _part == PART_MAIN, std::move(inaccessibleCollections));
   // create the transaction object, but do not start it yet
   _trx = trx;
   _trx->addHint(transaction::Hints::Hint::FROM_TOPLEVEL_AQL);  // only used on toplevel

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -254,8 +254,8 @@ class Query {
   TEST_VIRTUAL void setEngine(ExecutionEngine* engine);
 
   /// @brief return the transaction, if prepared
-  TEST_VIRTUAL inline transaction::Methods* trx() { return _trx.get(); }
-
+  TEST_VIRTUAL inline transaction::Methods* trx() const { return _trx.get(); }
+  
   /// @brief get the plan for the query
   ExecutionPlan* plan() const { return _plan.get(); }
 

--- a/arangod/Cluster/TraverserEngine.cpp
+++ b/arangod/Cluster/TraverserEngine.cpp
@@ -141,7 +141,7 @@ BaseEngine::BaseEngine(TRI_vocbase_t& vocbase,
       inaccessible.insert(shard.copyString());
     }
     _trx = aql::AqlTransaction::create(ctx, _collections.collections(), trxOpts,
-                                       true, inaccessible);
+                                       true, std::move(inaccessible));
   } else {
     _trx = aql::AqlTransaction::create(ctx, _collections.collections(), trxOpts, /*isMainTransaction*/true);
   }

--- a/arangod/Replication/ReplicationApplierConfiguration.cpp
+++ b/arangod/Replication/ReplicationApplierConfiguration.cpp
@@ -188,7 +188,6 @@ void ReplicationApplierConfiguration::toVelocyPack(VPackBuilder& builder, bool i
 
   builder.add("restrictCollections", VPackValue(VPackValueType::Array));
   for (std::string const& it : _restrictCollections) {
-    LOG_DEVEL << "printing '" << it << "'";
     builder.add(VPackValue(it));
   }
   builder.close();  // restrictCollections
@@ -355,7 +354,6 @@ ReplicationApplierConfiguration ReplicationApplierConfiguration::fromVelocyPack(
 
     for (auto const& it : VPackArrayIterator(value)) {
       if (it.isString()) {
-        LOG_DEVEL << "adding '" << it.copyString() << "'";
         configuration._restrictCollections.emplace(it.copyString());
       }
     }

--- a/arangod/Transaction/Methods.h
+++ b/arangod/Transaction/Methods.h
@@ -447,10 +447,10 @@ class Methods {
   /// @brief return the collection name resolver
   CollectionNameResolver const* resolver() const;
 
-  ENTERPRISE_VIRT bool isInaccessibleCollectionId(TRI_voc_cid_t /*cid*/) {
+  ENTERPRISE_VIRT bool isInaccessibleCollectionId(TRI_voc_cid_t /*cid*/) const {
     return false;
   }
-  ENTERPRISE_VIRT bool isInaccessibleCollection(std::string const& /*cid*/) {
+  ENTERPRISE_VIRT bool isInaccessibleCollection(std::string const& /*cid*/) const {
     return false;
   }
   


### PR DESCRIPTION
### Scope & Purpose

Fix `skipInaccessible` in AQL queries. This was broken due to new query snippet planning code.

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/327

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *authentication*.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/6443/