### PR TITLE
use static_cast instead of dynamic_cast

### DIFF
--- a/arangod/Agency/AgencyFeature.h
+++ b/arangod/Agency/AgencyFeature.h
@@ -32,7 +32,7 @@ namespace consensus {
 class Agent;
 }
 
-class AgencyFeature : virtual public application_features::ApplicationFeature {
+class AgencyFeature : public application_features::ApplicationFeature {
  public:
   static consensus::Agent* AGENT;
 

--- a/lib/ApplicationFeatures/ApplicationServer.h
+++ b/lib/ApplicationFeatures/ApplicationServer.h
@@ -232,7 +232,13 @@ class ApplicationServer {
          _features.emplace(std::type_index(typeid(As)),
                            std::make_unique<Type>(*this, std::forward<Args>(args)...));
      TRI_ASSERT(result.second);
-     return *dynamic_cast<As*>(result.first->second.get());
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+     auto obj = dynamic_cast<As*>(result.first->second.get());
+     TRI_ASSERT(obj != nullptr);
+     return *obj;
+#else
+     return *static_cast<As*>(result.first->second.get());
+#endif
    }
 
    // checks for the existence of a feature by type. will not throw when used
@@ -256,7 +262,13 @@ class ApplicationServer {
      if (it == _features.end()) {
        throwFeatureNotFoundException(type.name());
      }
-     return *dynamic_cast<AsType*>(it->second.get());
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+     auto obj = dynamic_cast<AsType*>(it->second.get());
+     TRI_ASSERT(obj != nullptr);
+     return *obj;
+#else
+     return *static_cast<AsType*>(it->second.get());
+#endif
    }
 
    // returns a const reference to a feature. will throw when used for
@@ -269,7 +281,13 @@ class ApplicationServer {
      if (it == _features.end()) {
        throwFeatureNotFoundException(typeid(Type).name());
      }
-     return *dynamic_cast<AsType*>(it->second.get());
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+     auto obj = dynamic_cast<AsType*>(it->second.get());
+     TRI_ASSERT(obj != nullptr);
+     return *obj;
+#else
+     return *static_cast<AsType*>(it->second.get());
+#endif
    }
 
    // returns the feature with the given name if known and enabled


### PR DESCRIPTION
### Scope & Purpose

Use a static_cast instead of a dynamic_cast to save runtime performance in release mode

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *full test suite*.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/6449/