### PR TITLE
fix broken LDAP tests

### DIFF
--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -143,7 +143,7 @@ arangodb::Result Databases::grantCurrentUser(CreateDatabaseInfo const& info, int
     // If the current user is empty (which happens if a Maintenance job
     // called us, or when authentication is off), granting rights
     // will fail. We hence ignore it here, but issue a warning below
-    if (!exec.isSuperuser()) {
+    if (!exec.isAdminUser()) {
       auto const endTime = std::chrono::steady_clock::now() + std::chrono::seconds(timeout);
       while (true) {
         res = um->updateUser(exec.user(), [&](auth::User& entry) {

--- a/tests/js/client/authentication/auth-analyzer.js
+++ b/tests/js/client/authentication/auth-analyzer.js
@@ -28,8 +28,9 @@ function testSuite() {
 
   const name = "TestAuthAnalyzer";
 
-  if(!users.exists('bob'))
+  if (!users.exists('bob')) {
     users.save(user, ''); // password must be empty otherwise switchUser will not work
+  }
 
   // analyzers can only be changed from the `_system` database
   // analyzer API does not support database selection via the usual `_db/<dbname>/_api/<api>`


### PR DESCRIPTION
### Scope & Purpose

Fix LDAP tests that were broken since atomic database creation feature merge.
All LDAP tests in devel were broken. 3.5 was not affected.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *all LDAP tests*.

https://jenkins01.arangodb.biz/view/3.devel/job/arangodb-devel-matrix-nightly/200/