### PR TITLE
RFC:  Prefix compactions

### DIFF
--- a/3rdParty/rocksdb/v5.16.X/db/builder.h
+++ b/3rdParty/rocksdb/v5.16.X/db/builder.h
@@ -35,6 +35,7 @@ class VersionEdit;
 class TableBuilder;
 class WritableFileWriter;
 class InternalStats;
+class VersionSet;
 
 // @param column_family_name Name of the column family that is also identified
 //    by column_family_id, or empty string if unknown. It must outlive the
@@ -79,6 +80,7 @@ extern Status BuildTable(
     const Env::IOPriority io_priority = Env::IO_HIGH,
     TableProperties* table_properties = nullptr, int level = -1,
     const uint64_t creation_time = 0, const uint64_t oldest_key_time = 0,
-    Env::WriteLifeTimeHint write_hint = Env::WLTH_NOT_SET);
+    Env::WriteLifeTimeHint write_hint = Env::WLTH_NOT_SET, VersionSet * version_set = nullptr,
+    std::vector<FileMetaData *> * meta_vec = nullptr);
 
 }  // namespace rocksdb

--- a/3rdParty/rocksdb/v5.16.X/db/compaction_picker.cc
+++ b/3rdParty/rocksdb/v5.16.X/db/compaction_picker.cc
@@ -227,7 +227,7 @@ bool CompactionPicker::ExpandInputsToCleanCut(const std::string& /*cf_name*/,
   // GetOverlappingInputs will always do the right thing for level-0.
   // So we don't need to do any expansion if level == 0.
   if (level == 0) {
-    return true;
+//    return true;
   }
 
   InternalKey smallest, largest;
@@ -1218,11 +1218,13 @@ void LevelCompactionBuilder::SetupInitialFiles() {
           // In these cases, to reduce L0 file count and thus reduce likelihood
           // of write stalls, we can attempt compacting a span of files within
           // L0.
+#if 0
           if (PickIntraL0Compaction()) {
             output_level_ = 0;
             compaction_reason_ = CompactionReason::kLevelL0FilesNum;
             break;
           }
+#endif
         }
       }
     }


### PR DESCRIPTION
This PR is for inter-company discussions only.  IT IS NOT FOR MERGE.  The code is NOT production quality.  And the code might not compile on all RocksDB support compilers.

## Summary

Propose adding Prefix oriented compaction to RocksDB's core feature set.  The new code would either use the existing PrefixTransform or another construct of same type.  Memory buffer flushes would segregate keys into multiple level zero .sst files by prefix.  This technique has shown to decrease total ingest time and reduce write amplification in the example case from 5.82 to 3.74.

## Example case 

ArangoDB has several column families that currently use the Prefix Seek API because it naturally fits our key designs and search needs.  An example key in one column family looks like this:

struct {
    int64_t collection_id;   // big endian binary format
    int64_t document_id;  // big endian binary format
}; 

An ArangoDB collection is the equivalent of an SQL table.  Similarly a document could be lightly compared to an SQL row.  Each write to our "document" column family RocksDB uses the above key along its data (a JSON document).

Both our internal code and user code may write to several different collection_id keys.  The example case is where our internal code writes to its statistics collection every ten seconds while the user's code is busy importing 303 million documents (records) into another collection.  The user's collection has a collection_id that is greater than the statistics collection_id.  Assume the document_id portion of the key is being incremented with each write.

The current RocksDB implementation, as well as the original Google leveldb implementation, writes all keys from a memory buffer into a single level 0 .sst file.  The example case therefore will often have both a new statistics key and many user keys within one level 0 .sst file.  The current compaction logic for level 0 will gather all available level 0 .sst files, find the containing range of all those files, then compact against all level 1 .sst files that overlap the same range.  The one statistics key compares to being below every user key.  And the level 0 user's keys compare above all or almost all user key in level 1 since the document_id of the user's key is incrementing.  The result is that often all .sst files in level 1 become part of the compaction with level 0.  What was really needed was for the statistics key to compact with the sole level 1 .sst file containing the statistics keys (or simply move to level 1 by trivial move).  And the user's keys in the level 0 .sst files only needed to merge with the level 1 .sst file containing the highest keys (or simply moved to level 1 by trivial move).

Note:  our import code has a multithreaded source so user keys do often overlap several document_id keys toward the end of the already imported key space.  This is why there are some necessary compactions with the last level 1 .sst file in the example case.  A single threaded import might achieve zero compactions between level 0 and level 1 for the user's documents when using prefix compactions.

## Example case execution

### Existing RocksDB code

The example case was executed on a 32 core server with 64G ram and a physical Raid 10 with 4 SATA drives.  The existing RocksDB code had many compactions like:

- Compacting 18@0 + 70@1 
- Compacting 12@0 + 37@1
- Compacting 21@0 + 22@1
- Compacting 12@0 + 10@1
- Compacting 14@0 + 51@1

- 9 x "trivial_move" (destination level: 1)
- 465 x "trivial_move" (across all compaction levels)

The import utility measured 7 stalls of 10 seconds or more.  The worst stall was 132.8 seconds.  The entire import ran for 78 minutes 15 seconds.  Write amplification was 5.82.

### Proof of concept code

The proof of concept code executed the same import in 62 minutes 30 seconds.  Write amplification was 3.74.  The worst stall 5.25 seconds.  The single worst compaction was:

- Compacting 4@0 + 1@1 files

The remaining were:

- 38 x Compacting 3@0 + ?@1 files
- 649 x Compacting 2@0 + ?@1 files
- 3,982 x Compacting 1@0 + ?@1 files

- 1,440 x "trivial_move" (destination level: 1)
- 2,810 x "trivial_move" (across all compaction levels)

## File change discussion

### db/builder.cc & .h

The BuildTable function in builder.cc currently creates a single level 0 .sst file from the one or more memory buffers passed to it.  The function returns the characteristic of that new .sst within the FileMetaData pointer object.  

The modification to BuildTable() is to ignore the current single FileMetaData point and switch to a std::vector<FileMetaData *> object for returning many files.  

I then wrapped the existing code that opens the new file within a lambda construct to ease executing the new file steps multiple times from two locations.  The production version should use a real function to easy compiler dependencies on c++14.

Line 231 contains "0 != memcmp(prev_user.c_str(), key.data(), 8)".  This is a hack substitute for a PrefixTransform type parameter.  Production code would pull the PrefixTransform or equivalent from the column family parameters.  

Maybe even better would be to write an equivalent to compaction_job.cc's ShouldStopBefore() that both uses both the PrefixTransform (or equivalent) and knowledge of the current level 1 files (grandparents) to decide when to split files.  But I suspect the optimization would only help early in a dataset's life cycle.

### db/compaction_picker.cc

I comment out line 230 to make sure individual files get reviewed for level 0 compaction instead of the entire level.

I removed the call to PickIntraL0Compaction() because it alone completely removed all benefits of this proposal.  For prefix compaction, this is a horrible function.  It could be made conditional by looking at the column family's options in a production release.  But it also brings up a larger point that I discuss in the conclusion.

Note:  I suspect PickIntraL0Compaction() is likely bad for almost all execution cases.  This would be a good project for an intern to investigate.  The function activates when level zero cannot compact right now because level 1 is busy against the disk.  So this function fires off another compaction that will add to the current disk activity and likely add to the delay of getting data out of level zero to higher levels.  Its advertised benefit is to ease the level zero throttle which is trying to help manage disk activity.  But it is actually hiding pending work by creating more disk activity and letting the user add more writes to further increase the disk activity backlog.

### db/flush_job.cc

The majority of the changes in this file are to move from having only one output file, one level 0 .sst file, too many.

## Conclusion

I am asking Facebook and other interested parties to comment on this PR.  The goal is to write a new PR that would be merged into the core RocksDB repository based upon comments here.

I noticed while dealing with PickIntraL0Compaction() that prefix compaction could dramatically increase the file count at level 0, while not changing the total file size of level zero.  The original Google code managed level 0 by file count and all other levels by total file size.  RocksDB continues this tradition.  I believe an additional change is needed to have level 0 managed by total file size as well.  To keep existing level 0 file count settings useful, the internal code for managing level 0 would use the file count settings multiplied by the write buffer size setting to set the various level 0 thresholds for total file size.