### PR TITLE
use malloc/realloc/free in velocypack::Buffer

### DIFF
--- a/3rdParty/velocypack/include/velocypack/Buffer.h
+++ b/3rdParty/velocypack/include/velocypack/Buffer.h
@@ -28,7 +28,9 @@
 #define VELOCYPACK_BUFFER_H 1
 
 #include <cstring>
+#include <cstdlib>
 #include <string>
+#include <new>
 
 #include "velocypack/velocypack-common.h"
 #include "velocypack/Exception.h"
@@ -38,6 +40,8 @@ namespace velocypack {
 
 template <typename T>
 class Buffer {
+  static_assert(sizeof(T) == 1, "expecting sizeof(T) to be 1");
+
  public:
   Buffer() noexcept : _buffer(_local), _capacity(sizeof(_local)), _size(0) {
     poison(_buffer, _capacity);
@@ -52,10 +56,10 @@ class Buffer {
   Buffer(Buffer const& that) : Buffer() {
     if (that._size > 0) {
       if (that._size > sizeof(_local)) {
-        _buffer = new T[checkOverflow(that._size)];
+        _buffer = static_cast<T*>(malloc(checkOverflow(sizeof(T) * that._size)));
+        ensureValidPointer(_buffer);
         _capacity = that._size;
-      }
-      else {
+      } else {
         _capacity = sizeof(_local);
       }
       memcpy(_buffer, that._buffer, checkOverflow(that._size));
@@ -72,12 +76,13 @@ class Buffer {
       }
       else {
         // our own buffer is not big enough to hold the data
-        auto buffer = new T[checkOverflow(that._size)];
-        initWithNone();
+        T* buffer = static_cast<T*>(malloc(checkOverflow(sizeof(T) * that._size)));
+        ensureValidPointer(buffer);
+        buffer[0] = '\x00';
         memcpy(buffer, that._buffer, checkOverflow(that._size));
 
         if (_buffer != _local) {
-          delete[] _buffer;
+          free(_buffer);
         }
         _buffer = buffer;
         _capacity = that._size;
@@ -107,7 +112,7 @@ class Buffer {
         memcpy(_buffer, that._buffer, static_cast<std::size_t>(that._size));
       } else {
         if (_buffer != _local) {
-          delete[] _buffer;
+          free(_buffer);
         }
         _buffer = that._buffer;
         _capacity = that._capacity;
@@ -122,7 +127,7 @@ class Buffer {
 
   ~Buffer() { 
     if (_buffer != _local) {
-      delete[] _buffer;
+      free(_buffer);
     }
   }
 
@@ -174,7 +179,7 @@ class Buffer {
   void clear() noexcept {
     _size = 0;
     if (_buffer != _local) {
-      delete[] _buffer;
+      free(_buffer);
       _buffer = _local;
       _capacity = sizeof(_local);
       poison(_buffer, _capacity);
@@ -242,6 +247,12 @@ class Buffer {
  private:
   // initialize Buffer with a None value
   inline void initWithNone() noexcept { _buffer[0] = '\x00'; }
+
+  inline void ensureValidPointer(T* ptr) const {
+    if (VELOCYPACK_UNLIKELY(ptr == nullptr)) {
+      throw std::bad_alloc();
+    }
+  }
   
   // poison buffer memory, used only for debugging
 #ifdef VELOCYPACK_DEBUG
@@ -265,13 +276,22 @@ class Buffer {
     VELOCYPACK_ASSERT(newLen > _size);
 
     // intentionally do not initialize memory here
-    T* p = new T[checkOverflow(newLen)];
-    poison(p, newLen);
-    // copy old data
-    memcpy(p, _buffer, checkOverflow(_size));
+    // intentionally also do not care about alignments here, as we
+    // expect T to be 1-byte-aignable
+    VELOCYPACK_ASSERT(newLen > 0);
+    T* p;
     if (_buffer != _local) {
-      delete[] _buffer;
+      p = static_cast<T*>(realloc(_buffer, checkOverflow(sizeof(T) * newLen)));
+      ensureValidPointer(p);
+      // realloc will have copied the old data
+    } else {
+      p = static_cast<T*>(malloc(checkOverflow(sizeof(T) * newLen)));
+      ensureValidPointer(p);
+      // copy existing data into buffer
+      memcpy(p, _buffer, checkOverflow(_size));
     }
+    poison(p + _capacity, newLen - _capacity);
+
     _buffer = p;
     _capacity = newLen;
     


### PR DESCRIPTION
### Scope & Purpose

Use malloc/realloc/free instead of new/delete.
This is a test to see if using realloc upon increasing the size of a Buffer will help us avoid many reallocations (and copying data) for larger Buffers.

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

Additionally:

- [x] There are tests in an external testing repository (i.e. arangodb/velocypack)
- [x] I ensured this code runs with ASan / TSan or other static verification tools

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6496/