### PR TITLE
make sure we don't build paths that start with two \'s

### DIFF
--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -128,7 +128,10 @@ std::string buildFilename(char const* path, char const* name) {
   std::string result(path);
 
   if (!result.empty()) {
-    result = removeTrailingSeparator(result) + TRI_DIR_SEPARATOR_CHAR;
+    result = removeTrailingSeparator(result);
+    if (result.length() == 1 && result[0] != TRI_DIR_SEPARATOR_CHAR) {
+      result += TRI_DIR_SEPARATOR_CHAR;
+    }
   }
 
   if (!result.empty() && *name == TRI_DIR_SEPARATOR_CHAR) {
@@ -147,7 +150,10 @@ std::string buildFilename(std::string const& path, std::string const& name) {
   std::string result(path);
 
   if (!result.empty()) {
-    result = removeTrailingSeparator(result) + TRI_DIR_SEPARATOR_CHAR;
+    result = removeTrailingSeparator(result);
+    if (result.length() == 1 && result[0] != TRI_DIR_SEPARATOR_CHAR) {
+      result += TRI_DIR_SEPARATOR_CHAR;
+    }
   }
 
   if (!result.empty() && !name.empty() && name[0] == TRI_DIR_SEPARATOR_CHAR) {


### PR DESCRIPTION
can be manually validated on windows using 

`arangosh --version  --log.level config=trace `