### PR TITLE
ignore files in .bin when copying js files

### DIFF
--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -505,8 +505,14 @@ void V8DealerFeature::copyInstallationFiles() {
     std::string const nodeModulesPathVersioned =
         basics::FileUtils::buildFilename("js", versionAppendix, "node",
                                          "node_modules");
-    auto filter = [&nodeModulesPath,
-                   &nodeModulesPathVersioned](std::string const& filename) -> bool {
+
+    std::regex const binRegex("[/\\\\]\\.bin[/\\\\]", std::regex::ECMAScript);
+
+    auto filter = [&nodeModulesPath, &nodeModulesPathVersioned, &binRegex](std::string const& filename) -> bool {
+      if (std::regex_search(filename, binRegex)) {
+        // don't copy files in .bin
+        return true;
+      }
       if (filename.size() >= nodeModulesPath.size()) {
         std::string normalized = filename;
         FileUtils::normalizePath(normalized);

--- a/arangosh/Shell/V8ShellFeature.cpp
+++ b/arangosh/Shell/V8ShellFeature.cpp
@@ -280,8 +280,14 @@ void V8ShellFeature::copyInstallationFiles() {
   std::string const nodeModulesPathVersioned =
       basics::FileUtils::buildFilename("js", versionAppendix, "node",
                                        "node_modules");
-  auto filter = [&nodeModulesPath,
-                 &nodeModulesPathVersioned](std::string const& filename) -> bool {
+  std::regex const binRegex("[/\\\\]\\.bin[/\\\\]", std::regex::ECMAScript);
+
+  auto filter = [&nodeModulesPath, &nodeModulesPathVersioned, &binRegex](std::string const& filename) -> bool {
+    if (std::regex_search(filename, binRegex)) {
+      // don't copy files in .bin
+      return true;
+    }
+
     if (filename.size() >= nodeModulesPath.size()) {
       std::string normalized = filename;
       FileUtils::normalizePath(normalized);

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -477,7 +477,7 @@ bool copyDirectoryRecursive(std::string const& source, std::string const& target
         if (isSubDirectory(src)) {
           long systemError;
           int rc = TRI_CreateDirectory(dst.c_str(), systemError, error);
-          if (rc != TRI_ERROR_NO_ERROR) {
+          if (rc != TRI_ERROR_NO_ERROR && rc != TRI_ERROR_FILE_EXISTS) {
             rc_bool = false;
             break;
           }

--- a/tests/js/client/permissions/copy-installation.js
+++ b/tests/js/client/permissions/copy-installation.js
@@ -1,0 +1,53 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertTrue, assertFalse, assertNotMatch, assertUndefined */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for copy-installation
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Wilfried Goesgens
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'javascript.copy-installation' : 'true'
+  };
+}
+
+var jsunity = require('jsunity');
+
+function testSuite() {
+  return {
+    setUp: function() {},
+    tearDown: function() {},
+    
+    testStarts : function() {
+      // the only relevant thing here is that the shell has started
+      // successfully when using the `--javascript.copy-installation true`
+      // setting
+      assertTrue(true);
+    }
+  };
+}
+jsunity.run(testSuite);
+return jsunity.done();

--- a/tests/js/client/server_permissions/test-copy-installation.js
+++ b/tests/js/client/server_permissions/test-copy-installation.js
@@ -1,0 +1,58 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for security-related server options
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'javascript.copy-installation': 'true',
+    'javascript.allow-admin-execute': 'true',
+  };
+}
+var jsunity = require('jsunity');
+
+function testSuite() {
+  const errors = require('@arangodb').errors;
+
+  return {
+    setUp: function() {},
+    tearDown: function() {},
+
+    testCanExecuteAction : function() {
+      // this test just does something, and it doesn't really matter
+      // the key thing in this test is to get the server started using
+      // the `--javascript.copy-installation true` setting without failing
+      let data = "return 'test!'";
+      let result = arango.POST("/_admin/execute", data);
+      assertEqual("test!", result);
+    },
+    
+  };
+}
+jsunity.run(testSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

When copying js files at startup, there can be problems when copying symlinks.
All these symlinks are in .bin subdirectories, and we can just ignore them while copying.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/6563/