### PR TITLE
ignore files in .bin when copying js files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+v3.5.2 (XXXX-XX-XX)
+-------------------
+
+* Ignore symlinks when copying JavaScript files at startup via the option
+  `--javascript.copy-installation`. This potentially fixes the following
+  error message at startup:
+
+      Error copying JS installation files to '...': failed to open source file ...: No such file or directory
+
+
 v3.5.1 (XXXX-XX-XX)
 -------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,15 +1,12 @@
-v3.5.2 (XXXX-XX-XX)
+v3.5.1 (XXXX-XX-XX)
 -------------------
 
 * Ignore symlinks when copying JavaScript files at startup via the option
   `--javascript.copy-installation`. This potentially fixes the following
   error message at startup:
 
-      Error copying JS installation files to '...': failed to open source file ...: No such file or directory
-
-
-v3.5.1 (XXXX-XX-XX)
--------------------
+      Error copying JS installation files to '...': 
+      failed to open source file ...: No such file or directory
 
 * Added startup option `--cluster.max-number-of-shards` for restricting the 
   maximum number of shards when creating new collections. The default

--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -499,8 +499,14 @@ void V8DealerFeature::copyInstallationFiles() {
     std::string const nodeModulesPathVersioned =
         basics::FileUtils::buildFilename("js", versionAppendix, "node",
                                          "node_modules");
-    auto filter = [&nodeModulesPath,
-                   &nodeModulesPathVersioned](std::string const& filename) -> bool {
+
+    std::regex const binRegex("[/\\\\]\\.bin[/\\\\]", std::regex::ECMAScript);
+
+    auto filter = [&nodeModulesPath, &nodeModulesPathVersioned, &binRegex](std::string const& filename) -> bool {
+      if (std::regex_search(filename, binRegex)) {
+        // don't copy files in .bin
+        return true;
+      }
       if (filename.size() >= nodeModulesPath.size()) {
         std::string normalized = filename;
         FileUtils::normalizePath(normalized);

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -464,7 +464,7 @@ bool copyDirectoryRecursive(std::string const& source, std::string const& target
         if (isSubDirectory(src)) {
           long systemError;
           int rc = TRI_CreateDirectory(dst.c_str(), systemError, error);
-          if (rc != TRI_ERROR_NO_ERROR) {
+          if (rc != TRI_ERROR_NO_ERROR && rc != TRI_ERROR_FILE_EXISTS) {
             rc_bool = false;
             break;
           }


### PR DESCRIPTION
### Scope & Purpose

When copying js files at startup, there can be problems when copying symlinks.
All these symlinks are in .bin subdirectories, and we can simply ignore them.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/6564/