### PR TITLE
Revert "make sure we don't build paths that start with two \'s"

### DIFF
--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -128,10 +128,7 @@ std::string buildFilename(char const* path, char const* name) {
   std::string result(path);
 
   if (!result.empty()) {
-    result = removeTrailingSeparator(result);
-    if (result.length() == 1 && result[0] != TRI_DIR_SEPARATOR_CHAR) {
-      result += TRI_DIR_SEPARATOR_CHAR;
-    }
+    result = removeTrailingSeparator(result) + TRI_DIR_SEPARATOR_CHAR;
   }
 
   if (!result.empty() && *name == TRI_DIR_SEPARATOR_CHAR) {
@@ -150,10 +147,7 @@ std::string buildFilename(std::string const& path, std::string const& name) {
   std::string result(path);
 
   if (!result.empty()) {
-    result = removeTrailingSeparator(result);
-    if (result.length() == 1 && result[0] != TRI_DIR_SEPARATOR_CHAR) {
-      result += TRI_DIR_SEPARATOR_CHAR;
-    }
+    result = removeTrailingSeparator(result) + TRI_DIR_SEPARATOR_CHAR;
   }
 
   if (!result.empty() && !name.empty() && name[0] == TRI_DIR_SEPARATOR_CHAR) {


### PR DESCRIPTION
Reverts arangodb/arangodb#10144
```
$ ./arangosh.exe --version --log.level config=trace
{config} checking root location '\'
{config} checking config file 'c:\Users\Вадим\Desktopetcrelativearangosh.conf'
{config} checking config file '\etc\arangodb3arangosh.conf'
{config} checking config file 'c:\Users\Вадим\Desktoparangosh.conf'
{config} checking config file 'C:\Users\Вадим.arangodbarangosh.conf'
{config} checking config file '\etc\arangodb3arangosh.conf'
{config} cannot find any config file
{config} checking override '.local'
{config} no override file found
{config} loading ''
```
Trace looks a little bit weird. It seems we removed too much.