### PR TITLE
Bug fix 3.5/fix parsing unterminated strings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+v3.5.2 (XXXX-XX-XX)
+-------------------
+
+* Properly report parse errors for extraneous unterminated string literals 
+  at the end of AQL query strings. For example, in the query `RETURN 1 "abc`, 
+  the `RETURN 1` part was parsed fully, and the `"abc` part at the end was 
+  parsed until the EOF and then forgotten. But as the fully parsed tokens
+  `RETURN 1` already form a proper query, the unterminated string literal 
+  at the end was not reported as a parse error. 
+  This is now fixed for unterminated string literals in double and single
+  quotes as well as unterminated multi-line comments at the end of the query
+  string.
+
+
 v3.5.1 (XXXX-XX-XX)
 -------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,19 +1,15 @@
-v3.5.2 (XXXX-XX-XX)
+v3.5.1 (XXXX-XX-XX)
 -------------------
 
-* Properly report parse errors for extraneous unterminated string literals 
-  at the end of AQL query strings. For example, in the query `RETURN 1 "abc`, 
-  the `RETURN 1` part was parsed fully, and the `"abc` part at the end was 
+* Properly report parse errors for extraneous unterminated string literals
+  at the end of AQL query strings. For example, in the query `RETURN 1 "abc`,
+  the `RETURN 1` part was parsed fully, and the `"abc` part at the end was
   parsed until the EOF and then forgotten. But as the fully parsed tokens
-  `RETURN 1` already form a proper query, the unterminated string literal 
-  at the end was not reported as a parse error. 
+  `RETURN 1` already form a proper query, the unterminated string literal
+  at the end was not reported as a parse error.
   This is now fixed for unterminated string literals in double and single
   quotes as well as unterminated multi-line comments at the end of the query
   string.
-
-
-v3.5.1 (XXXX-XX-XX)
--------------------
 
 * Fix config directory handling, so we don't trap into UNC path lookups on Windows.
 

--- a/arangod/Aql/tokens.cpp
+++ b/arangod/Aql/tokens.cpp
@@ -2036,6 +2036,12 @@ YY_RULE_SETUP
   /* newline character inside backtick */
 }
 	YY_BREAK
+case YY_STATE_EOF(BACKTICK):
+{
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated identifier", yylloc->first_line, yylloc->first_column);
+}
+	YY_BREAK
 case 68:
 YY_RULE_SETUP
 {
@@ -2072,6 +2078,12 @@ case 72:
 YY_RULE_SETUP
 {
   /* newline character inside forwardtick */
+}
+	YY_BREAK
+case YY_STATE_EOF(FORWARDTICK):
+{
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated identifier", yylloc->first_line, yylloc->first_column);
 }
 	YY_BREAK
 case 73:
@@ -2114,6 +2126,12 @@ YY_RULE_SETUP
   /* newline character inside quote */
 }
 	YY_BREAK
+case YY_STATE_EOF(DOUBLE_QUOTE):
+{
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated string literal", yylloc->first_line, yylloc->first_column);
+}
+	YY_BREAK
 case 78:
 YY_RULE_SETUP
 {
@@ -2149,6 +2167,12 @@ case 82:
 YY_RULE_SETUP
 {
   /* newline character inside quote */
+}
+	YY_BREAK
+case YY_STATE_EOF(SINGLE_QUOTE):
+{
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated string literal", yylloc->first_line, yylloc->first_column);
 }
 	YY_BREAK
 case 83:
@@ -2301,6 +2325,12 @@ YY_RULE_SETUP
   // eat the lone star
 }
 	YY_BREAK
+case YY_STATE_EOF(COMMENT_MULTI):
+{
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated multi-line comment", yylloc->first_line, yylloc->first_column);
+}
+	YY_BREAK
 case 97:
 /* rule 97 can match eol */
 YY_RULE_SETUP
@@ -2321,12 +2351,7 @@ YY_RULE_SETUP
 ECHO;
 	YY_BREAK
 case YY_STATE_EOF(INITIAL):
-case YY_STATE_EOF(BACKTICK):
-case YY_STATE_EOF(FORWARDTICK):
-case YY_STATE_EOF(SINGLE_QUOTE):
-case YY_STATE_EOF(DOUBLE_QUOTE):
 case YY_STATE_EOF(COMMENT_SINGLE):
-case YY_STATE_EOF(COMMENT_MULTI):
 	yyterminate();
 
 	case YY_END_OF_BUFFER:

--- a/arangod/Aql/tokens.ll
+++ b/arangod/Aql/tokens.ll
@@ -363,6 +363,11 @@ class Parser;
   /* newline character inside backtick */
 }
 
+<BACKTICK><<EOF>> {
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated identifier", yylloc->first_line, yylloc->first_column);
+}
+
 <BACKTICK>. {
   /* any character (except newline) inside backtick */
 }
@@ -389,6 +394,11 @@ class Parser;
 
 <FORWARDTICK>\n {
   /* newline character inside forwardtick */
+}
+
+<FORWARDTICK><<EOF>> {
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated identifier", yylloc->first_line, yylloc->first_column);
 }
 
 <FORWARDTICK>. {
@@ -421,6 +431,11 @@ class Parser;
   /* newline character inside quote */
 }
 
+<DOUBLE_QUOTE><<EOF>> {
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated string literal", yylloc->first_line, yylloc->first_column);
+}
+
 <DOUBLE_QUOTE>. {
   /* any character (except newline) inside quote */
 }
@@ -445,6 +460,11 @@ class Parser;
 
 <SINGLE_QUOTE>\n {
   /* newline character inside quote */
+}
+
+<SINGLE_QUOTE><<EOF>> {
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated string literal", yylloc->first_line, yylloc->first_column);
 }
 
 <SINGLE_QUOTE>. {
@@ -570,6 +590,11 @@ class Parser;
 
 <COMMENT_MULTI>"*" {
   // eat the lone star
+}
+
+<COMMENT_MULTI><<EOF>> {
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated multi-line comment", yylloc->first_line, yylloc->first_column);
 }
 
 <COMMENT_MULTI>\n {

--- a/tests/js/server/aql/aql-parse.js
+++ b/tests/js/server/aql/aql-parse.js
@@ -125,6 +125,11 @@ function ahuacatlParseTestSuite () {
       assertParseError(errors.ERROR_QUERY_PARSE.code, "return -");
       assertParseError(errors.ERROR_QUERY_PARSE.code, "return +");
       assertParseError(errors.ERROR_QUERY_PARSE.code, "return ."); 
+      assertParseError(errors.ERROR_QUERY_PARSE.code, "RETURN 1 /* "); 
+      assertParseError(errors.ERROR_QUERY_PARSE.code, "RETURN 1 \" foo "); 
+      assertParseError(errors.ERROR_QUERY_PARSE.code, "RETURN 1 ' foo "); 
+      assertParseError(errors.ERROR_QUERY_PARSE.code, "RETURN 1 `foo "); 
+      assertParseError(errors.ERROR_QUERY_PARSE.code, "RETURN 1 ´foo "); 
     },
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose

Properly report parse errors for extraneous unterminated string literals at the end of AQL query strings.
For example, in the query `RETURN 1 "abc`, the `RETURN 1` was parsed fully, and the `"abc` part is only parsed partly and then forgotten. But as the `RETURN 1` is already a proper query, the unterminated string literal at the end was not reported.
This PR fixes this, also for unterminated single quoted string literals and unterminated multi-line comments.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6578/