### PR TITLE
Bug fix 3.4/fix parsing unterminated strings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,16 @@
 v3.4.9 (XXX-XX-XX)
 -------------------
 
+* Properly report parse errors for extraneous unterminated string literals
+  at the end of AQL query strings. For example, in the query `RETURN 1 "abc`,
+  the `RETURN 1` part was parsed fully, and the `"abc` part at the end was
+  parsed until the EOF and then forgotten. But as the fully parsed tokens
+  `RETURN 1` already form a proper query, the unterminated string literal
+  at the end was not reported as a parse error.
+  This is now fixed for unterminated string literals in double and single
+  quotes as well as unterminated multi-line comments at the end of the query
+  string.
+
 * Fixed issue #10078: FULLTEXT with sort on same field not working.
 
 * Fixed issue #10062: AQL: Could not extract custom attribute.

--- a/arangod/Aql/tokens.cpp
+++ b/arangod/Aql/tokens.cpp
@@ -2021,6 +2021,12 @@ YY_RULE_SETUP
   /* newline character inside backtick */
 }
 	YY_BREAK
+case YY_STATE_EOF(BACKTICK):
+{
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated identifier", yylloc->first_line, yylloc->first_column);
+}
+	YY_BREAK
 case 67:
 YY_RULE_SETUP
 {
@@ -2057,6 +2063,12 @@ case 71:
 YY_RULE_SETUP
 {
   /* newline character inside forwardtick */
+}
+	YY_BREAK
+case YY_STATE_EOF(FORWARDTICK):
+{
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated identifier", yylloc->first_line, yylloc->first_column);
 }
 	YY_BREAK
 case 72:
@@ -2099,6 +2111,12 @@ YY_RULE_SETUP
   /* newline character inside quote */
 }
 	YY_BREAK
+case YY_STATE_EOF(DOUBLE_QUOTE):
+{
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated string literal", yylloc->first_line, yylloc->first_column);
+}
+	YY_BREAK
 case 77:
 YY_RULE_SETUP
 {
@@ -2134,6 +2152,12 @@ case 81:
 YY_RULE_SETUP
 {
   /* newline character inside quote */
+}
+	YY_BREAK
+case YY_STATE_EOF(SINGLE_QUOTE):
+{
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated string literal", yylloc->first_line, yylloc->first_column);
 }
 	YY_BREAK
 case 82:
@@ -2287,6 +2311,12 @@ YY_RULE_SETUP
   // eat the lone star
 }
 	YY_BREAK
+case YY_STATE_EOF(COMMENT_MULTI):
+{
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated multi-line comment", yylloc->first_line, yylloc->first_column);
+}
+	YY_BREAK
 case 96:
 /* rule 96 can match eol */
 YY_RULE_SETUP
@@ -2344,12 +2374,7 @@ YY_RULE_SETUP
 ECHO;
 	YY_BREAK
 case YY_STATE_EOF(INITIAL):
-case YY_STATE_EOF(BACKTICK):
-case YY_STATE_EOF(FORWARDTICK):
-case YY_STATE_EOF(SINGLE_QUOTE):
-case YY_STATE_EOF(DOUBLE_QUOTE):
 case YY_STATE_EOF(COMMENT_SINGLE):
-case YY_STATE_EOF(COMMENT_MULTI):
 	yyterminate();
 
 	case YY_END_OF_BUFFER:

--- a/arangod/Aql/tokens.ll
+++ b/arangod/Aql/tokens.ll
@@ -356,6 +356,11 @@ class Parser;
   /* newline character inside backtick */
 }
 
+<BACKTICK><<EOF>> {
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated identifier", yylloc->first_line, yylloc->first_column);
+}
+
 <BACKTICK>. {
   /* any character (except newline) inside backtick */
 }
@@ -382,6 +387,11 @@ class Parser;
 
 <FORWARDTICK>\n {
   /* newline character inside forwardtick */
+}
+
+<FORWARDTICK><<EOF>> {
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated identifier", yylloc->first_line, yylloc->first_column);
 }
 
 <FORWARDTICK>. {
@@ -414,6 +424,11 @@ class Parser;
   /* newline character inside quote */
 }
 
+<DOUBLE_QUOTE><<EOF>> {
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated string literal", yylloc->first_line, yylloc->first_column);
+}
+
 <DOUBLE_QUOTE>. {
   /* any character (except newline) inside quote */
 }
@@ -438,6 +453,11 @@ class Parser;
 
 <SINGLE_QUOTE>\n {
   /* newline character inside quote */
+}
+
+<SINGLE_QUOTE><<EOF>> {
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated string literal", yylloc->first_line, yylloc->first_column);
 }
 
 <SINGLE_QUOTE>. {
@@ -564,6 +584,11 @@ class Parser;
 
 <COMMENT_MULTI>"*" {
   // eat the lone star
+}
+
+<COMMENT_MULTI><<EOF>> {
+  auto parser = yyextra;
+  parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected unterminated multi-line comment", yylloc->first_line, yylloc->first_column);
 }
 
 <COMMENT_MULTI>\n {

--- a/tests/js/server/aql/aql-parse.js
+++ b/tests/js/server/aql/aql-parse.js
@@ -119,6 +119,17 @@ function ahuacatlParseTestSuite () {
       assertParseError(errors.ERROR_QUERY_PARSE.code, "return 1 + 1 +"); 
       assertParseError(errors.ERROR_QUERY_PARSE.code, "return (1"); 
       assertParseError(errors.ERROR_QUERY_PARSE.code, "for f1 in x1"); 
+      assertParseError(errors.ERROR_QUERY_PARSE.code, "return 00"); 
+      assertParseError(errors.ERROR_QUERY_PARSE.code, "return 01"); 
+      assertParseError(errors.ERROR_QUERY_PARSE.code, "return 1."); 
+      assertParseError(errors.ERROR_QUERY_PARSE.code, "return -");
+      assertParseError(errors.ERROR_QUERY_PARSE.code, "return +");
+      assertParseError(errors.ERROR_QUERY_PARSE.code, "return ."); 
+      assertParseError(errors.ERROR_QUERY_PARSE.code, "RETURN 1 /* "); 
+      assertParseError(errors.ERROR_QUERY_PARSE.code, "RETURN 1 \" foo "); 
+      assertParseError(errors.ERROR_QUERY_PARSE.code, "RETURN 1 ' foo "); 
+      assertParseError(errors.ERROR_QUERY_PARSE.code, "RETURN 1 `foo "); 
+      assertParseError(errors.ERROR_QUERY_PARSE.code, "RETURN 1 ´foo "); 
     },
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose

Properly report parse errors for extraneous unterminated string literals at the end of AQL query strings.
For example, in the query `RETURN 1 "abc`, the `RETURN 1` was parsed fully, and the `"abc` part is only parsed partly and then forgotten. But as the `RETURN 1` is already a proper query, the unterminated string literal at the end was not reported.
This PR fixes this, also for unterminated single quoted string literals and unterminated multi-line comments.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6579/