### PR TITLE
Fixed repeatable seek to the same document

### DIFF
--- a/3rdParty/iresearch/core/search/conjunction.hpp
+++ b/3rdParty/iresearch/core/search/conjunction.hpp
@@ -178,7 +178,7 @@ class conjunction : public doc_iterator_base {
 
     for (auto rest = seek_rest(target); target != rest; rest = seek_rest(target)) {
       target = front_->seek(rest);
-      if (target == rest || doc_limits::eof(target)) {
+      if (doc_limits::eof(target)) {
         break;
       }
     }

--- a/3rdParty/iresearch/core/search/conjunction.hpp
+++ b/3rdParty/iresearch/core/search/conjunction.hpp
@@ -164,7 +164,7 @@ class conjunction : public doc_iterator_base {
 
   virtual doc_id_t seek(doc_id_t target) override {
     if (doc_limits::eof(target = front_->seek(target))) {
-      return target;
+      return doc_limits::eof();
     }
 
     return converge(target);
@@ -174,9 +174,13 @@ class conjunction : public doc_iterator_base {
   // tries to converge front_ and other iterators to the specified target.
   // if it impossible tries to find first convergence place
   doc_id_t converge(doc_id_t target) {
-    for (auto rest = seek_rest(target); target != rest;) {
+    assert(!doc_limits::eof(target));
+
+    for (auto rest = seek_rest(target); target != rest; rest = seek_rest(target)) {
       target = front_->seek(rest);
-      rest = seek_rest(target);
+      if (target == rest || doc_limits::eof(target)) {
+        break;
+      }
     }
 
     return target;
@@ -185,9 +189,7 @@ class conjunction : public doc_iterator_base {
   // seeks all iterators except the
   // first to the specified target
   doc_id_t seek_rest(doc_id_t target) {
-    if (doc_limits::eof(target)) {
-      return target;
-    }
+    assert(!doc_limits::eof(target));
 
     for (auto it = itrs_.begin()+1, end = itrs_.end(); it != end; ++it) {
       const auto doc = (*it)->seek(target);
@@ -208,7 +210,7 @@ class conjunction : public doc_iterator_base {
 }; // conjunction
 
 //////////////////////////////////////////////////////////////////////////////
-/// @returns conjunction iterator created from the specified sub iterators 
+/// @returns conjunction iterator created from the specified sub iterators
 //////////////////////////////////////////////////////////////////////////////
 template<typename Conjunction, typename... Args>
 doc_iterator::ptr make_conjunction(

--- a/3rdParty/iresearch/core/search/phrase_iterator.hpp
+++ b/3rdParty/iresearch/core/search/phrase_iterator.hpp
@@ -82,7 +82,9 @@ class phrase_iterator final : public basic_doc_iterator_base {
   }
 
   virtual doc_id_t seek(doc_id_t target) override {
-    approx_.seek(target);
+    if (approx_.seek(target) == target) {
+      return target;
+    }
 
     if (doc_limits::eof(value()) || (phrase_freq_.value = phrase_freq())) {
       return value();


### PR DESCRIPTION
IResearch. Do not seek again if you did it (an iterator has already been moved).

Issue: https://github.com/arangodb/arangodb/issues/10090
phrase_iterator.hpp contains the issue fix.
conjunction.hpp contains optimizations.

http://jenkins01.arangodb.biz:8080/job/arangodb-matrix-pr-linux/8270/