### PR TITLE
fix generating examples

### DIFF
--- a/3rdParty/fuerte/include/fuerte/types.h
+++ b/3rdParty/fuerte/include/fuerte/types.h
@@ -145,7 +145,7 @@ std::string to_string(ProtocolType type);
 // --SECTION--                                                       ContentType
 // -----------------------------------------------------------------------------
 
-enum class ContentType { Unset, Custom, VPack, Dump, Json, Html, Text };
+enum class ContentType { Unset, Custom, VPack, Dump, Json, Html, Text, BatchPart, FormData };
 ContentType to_ContentType(std::string const& val);
 std::string to_string(ContentType type);
 

--- a/3rdParty/fuerte/src/types.cpp
+++ b/3rdParty/fuerte/src/types.cpp
@@ -151,23 +151,28 @@ const std::string fu_content_type_json("application/json");
 const std::string fu_content_type_html("text/html");
 const std::string fu_content_type_text("text/plain");
 const std::string fu_content_type_dump("application/x-arango-dump");
+const std::string fu_content_type_batchpart("application/x-arango-batchpart");
+const std::string fu_content_type_formdata("multipart/form-data");
 
 ContentType to_ContentType(std::string const& val) {
-
   if (val.empty()) {
     return ContentType::Unset;
-  } else if (val.find(fu_content_type_unset) != std::string::npos) {
+  } else if (val.compare(0, fu_content_type_unset.size(), fu_content_type_unset) == 0) {
     return ContentType::Unset;
-  } else if (val.find(fu_content_type_vpack) != std::string::npos) {
+  } else if (val.compare(0, fu_content_type_vpack.size(), fu_content_type_vpack) == 0) {
     return ContentType::VPack;
-  } else if (val.find(fu_content_type_json) != std::string::npos) {
+  } else if (val.compare(0, fu_content_type_json.size(), fu_content_type_json) == 0) {
     return ContentType::Json;
-  } else if (val.find(fu_content_type_html) != std::string::npos) {
+  } else if (val.compare(0, fu_content_type_html.size(), fu_content_type_html) == 0) {
     return ContentType::Html;
-  } else if (val.find(fu_content_type_text) != std::string::npos) {
+  } else if (val.compare(0, fu_content_type_text.size(), fu_content_type_text) == 0) {
     return ContentType::Text;
-  } else if (val.find(fu_content_type_dump) != std::string::npos) {
+  } else if (val.compare(0, fu_content_type_dump.size(), fu_content_type_dump) == 0) {
     return ContentType::Dump;
+  } else if (val.compare(0, fu_content_type_batchpart.size(), fu_content_type_batchpart) == 0) {
+    return ContentType::BatchPart;
+  } else if (val.compare(0, fu_content_type_formdata.size(), fu_content_type_formdata) == 0) {
+    return ContentType::FormData;
   }
 
   return ContentType::Custom;
@@ -192,11 +197,17 @@ std::string to_string(ContentType type) {
 
     case ContentType::Dump:
       return fu_content_type_dump;
+    
+    case ContentType::BatchPart:
+      return fu_content_type_batchpart;
+    
+    case ContentType::FormData:
+      return fu_content_type_formdata;
 
     case ContentType::Custom:
       throw std::logic_error(
           "custom content type could take different "
-          "values and is therefor not convertible to string");
+          "values and is therefore not convertible to string");
   }
 
   throw std::logic_error("unknown content type");


### PR DESCRIPTION
### Scope & Purpose

Fix generating examples via `utils/generateExamples.sh`.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/6596/