### PR TITLE
don't taint hash set if insert/emplace fails for whatever reason

### DIFF
--- a/lib/Basics/HashSet.h
+++ b/lib/Basics/HashSet.h
@@ -299,8 +299,8 @@ class HashSet {
     if (_states[bucket] == State::FILLED) {
       return { iterator(this, bucket), false };
     } else {
-      _states[bucket] = State::FILLED;
       new(_keys + bucket) KeyT(key);
+      _states[bucket] = State::FILLED;
       _num_filled++;
       return { iterator(this, bucket), true };
     }
@@ -318,8 +318,8 @@ class HashSet {
     if (_states[bucket] == State::FILLED) {
       return { iterator(this, bucket), false };
     } else {
-      _states[bucket] = State::FILLED;
       new(_keys + bucket) KeyT(std::move(key));
+      _states[bucket] = State::FILLED;
       _num_filled++;
       return { iterator(this, bucket), true };
     }


### PR DESCRIPTION
### Scope & Purpose

Don't prematurely manipulate state in HashSet on insert/emplace.
Only modify the state after the insert/emplace operation has succeeded.
If insert/emplace threw an exception, the hash set was potentially broken beforehand. This PR should fix thas situation.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6619/