### PR TITLE
fixed issue #10183: Arangoimport imports on _system when you try to create a new database

### DIFF
--- a/arangosh/Import/ImportFeature.cpp
+++ b/arangosh/Import/ImportFeature.cpp
@@ -344,7 +344,13 @@ void ImportFeature::start() {
 
     // restore old database name
     client.setDatabaseName(dbName);
-    versionString = _httpClient->getServerVersion(nullptr);
+    err = TRI_ERROR_NO_ERROR;
+    versionString = _httpClient->getServerVersion(&err);
+  
+    if (err != TRI_ERROR_NO_ERROR) {
+      // disconnecting here will abort arangoimport a few lines below
+      _httpClient->disconnect();
+    }
   }
 
   if (!_httpClient->isConnected()) {

--- a/arangosh/Import/ImportFeature.cpp
+++ b/arangosh/Import/ImportFeature.cpp
@@ -289,8 +289,7 @@ void ImportFeature::start() {
 
   int err = TRI_ERROR_NO_ERROR;
   auto versionString = _httpClient->getServerVersion(&err);
-  auto dbName = client.databaseName();
-  bool createdDatabase = false;
+  auto const dbName = client.databaseName();
 
   auto successfulConnection = [&]() {
     std::cout << ClientFeature::buildConnectedMessage(_httpClient->getEndpointSpecification(),
@@ -343,12 +342,9 @@ void ImportFeature::start() {
       FATAL_ERROR_EXIT();
     }
 
-    successfulConnection();
-
     // restore old database name
     client.setDatabaseName(dbName);
     versionString = _httpClient->getServerVersion(nullptr);
-    createdDatabase = true;
   }
 
   if (!_httpClient->isConnected()) {
@@ -359,10 +355,12 @@ void ImportFeature::start() {
     FATAL_ERROR_EXIT();
   }
 
+  TRI_ASSERT(client.databaseName() == dbName);
+    
   // successfully connected
-  if (!createdDatabase) {
-    successfulConnection();
-  }
+  // print out connection info
+  successfulConnection();
+
   _httpClient->disconnect();  // we do not reuse this anymore
 
   SimpleHttpClientParams params = _httpClient->params();


### PR DESCRIPTION
### Scope & Purpose

Fix an arangoimport output issue reported in #10183. The other problem reported (data is imported into the wrong database) is not fixed by this PR, as I wasn't able to reproduce.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is a GitHub Issue reported by a Community User: #10183

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest importing*.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6629/