### PR TITLE
fixed issue #10183: Arangoimport imports on _system when you try to create a new database

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+v3.5.2 (XXXX-XX-XX)
+-------------------
+
+* Fixed issue #10183: Arangoimport imports on _system when you try to 
+  create a new database.
+
+  This bugfix fixes the output of arangoimport, which could display a
+  wrong target database for the import if the option `--create-database`
+  was used.
+
+
 v3.5.1 (2019-10-07)
 -------------------
 


### PR DESCRIPTION
### Scope & Purpose

Fix an arangoimport output issue reported in #10183. The other problem reported (data is imported into the wrong database) is not fixed by this PR, as I wasn't able to reproduce.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is a GitHub Issue reported by a Community User: #10183

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest importing*.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6633/