### PR TITLE
Bugfix for recurring Jenkins error in api-simple-modify-example-cluster-spec.rb

### DIFF
--- a/arangod/Aql/DependencyProxy.cpp
+++ b/arangod/Aql/DependencyProxy.cpp
@@ -210,11 +210,12 @@ std::pair<ExecutionState, size_t> DependencyProxy<blockPassthrough>::skipSome(si
     _skipped += skippedNow;
 
     // When the current dependency is done, advance.
-    if (state == ExecutionState::DONE && !advanceDependency()) {
-      size_t skipped = _skipped;
-      _skipped = 0;
-      TRI_ASSERT(skipped <= toSkip);
-      return {state, skipped};
+    if (state == ExecutionState::DONE) {
+      if (!advanceDependency()) {
+        break;
+      } else {
+        state = ExecutionState::HASMORE;
+      }
     }
   }
 


### PR DESCRIPTION
### Scope & Purpose

Fix an error we've seen occasionally during PR tests in `api-simple-modify-example-cluster-spec.rb`. `DependencyProxy::skipSome` did not work correctly with multiple dependencies if `atMost` was reached, returning `DONE` early.

- [X] Bug-Fix for *devel-branch*
- [ ] Bug-Fix for *3.5* (**TODO** check whether this needs backporting)
- [X] The behavior in this PR can be (and was) *manually tested*
- [X] The behavior change can be verified via automatic tests

### Testing & Verification

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This PR adds tests that were used to verify all changes:

- [ ] Added **Regression Tests** (Only for bug-fixes) 
- [ ] Added new C++ **Unit Tests** (Either GoogleTest or Catch-Test)
   - Did you add tests for a new *RestHandler* subclass ?
   - Did you add new mocks of underlying code layers to be able to verify your functionality ? 
   - ...
- [ ] Added new **integration tests** (i.e. in shell_server / shell_server_aql)
- [ ] Added new **resilience tests** (only if the feature is impacted by failovers)


### Documentation

- [ ] Added a *Changelog Entry*
