### PR TITLE
remove debug logging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+v3.5.2 (XXXX-XX-XX)
+-------------------
+
+* Removed debug log messages "found comm task ..." that could be logged
+  on server shutdown.
+
+
 v3.5.1 (2019-10-07)
 -------------------
 

--- a/arangod/GeneralServer/GeneralServer.cpp
+++ b/arangod/GeneralServer/GeneralServer.cpp
@@ -135,14 +135,19 @@ void GeneralServer::stopWorking() {
       }
     }
 
-    LOG_TOPIC("f1749", DEBUG, Logger::FIXME) << "waiting for " << _commTasks.size() << " comm tasks to shut down";
+    if (i % 40 == 0) {
+      // don't spam too much
+      LOG_TOPIC("f1749", DEBUG, Logger::FIXME) << "waiting for " << _commTasks.size() << " comm tasks to shut down";
+    }
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
 
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     // this is a debugging facility that we can hopefully remove soon
     MUTEX_LOCKER(lock, _tasksLock);
     for (auto const& it : _commTasks) {
       LOG_TOPIC("9c8ac", INFO, Logger::FIXME) << "- found comm task with id " << it.first << " -> " << it.second.get();
     }
+#endif
   }
   
   for (auto& context : _contexts) {

--- a/arangod/GeneralServer/GeneralServer.cpp
+++ b/arangod/GeneralServer/GeneralServer.cpp
@@ -154,6 +154,7 @@ void GeneralServer::stopWorking() {
     context.stop();
   }
 
+  size_t i = 0;
   while (true) {
     {
       MUTEX_LOCKER(lock, _tasksLock);
@@ -162,14 +163,18 @@ void GeneralServer::stopWorking() {
       }
     }
 
-    LOG_TOPIC("f1549", DEBUG, Logger::FIXME) << "waiting for " << _commTasks.size() << " comm tasks to shut down";
+    if (i++ % 100 == 0) {
+      LOG_TOPIC("f1549", DEBUG, Logger::FIXME) << "waiting for " << _commTasks.size() << " comm tasks to shut down";
+    }
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
 
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     // this is a debugging facility that we can hopefully remove soon
     MUTEX_LOCKER(lock, _tasksLock);
     for (auto const& it : _commTasks) {
       LOG_TOPIC("9b8ac", INFO, Logger::FIXME) << "- found comm task with id " << it.first << " -> " << it.second.get();
     }
+#endif
   }
   
   for (auto& context : _contexts) {


### PR DESCRIPTION
### Scope & Purpose

Remove debug log messages "found comm task... " that could occur on server shutdown.
This only applies to 3.5. The log message is not present in devel or 3.4.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6640/