### PR TITLE
fixed issue #10193

### DIFF
--- a/arangosh/Export/ExportFeature.h
+++ b/arangosh/Export/ExportFeature.h
@@ -56,14 +56,14 @@ class ExportFeature final : public application_features::ApplicationFeature,
  private:
   void collectionExport(httpclient::SimpleHttpClient* httpClient);
   void queryExport(httpclient::SimpleHttpClient* httpClient);
-  void writeFirstLine(ManagedDirectory::File & fd, std::string const& fileName, std::string const& collection);
-  void writeBatch(ManagedDirectory::File & fd, VPackArrayIterator it, std::string const& fileName);
+  void writeFirstLine(ManagedDirectory::File& fd, std::string const& fileName, std::string const& collection);
+  void writeBatch(ManagedDirectory::File& fd, VPackArrayIterator it, std::string const& fileName);
   void graphExport(httpclient::SimpleHttpClient* httpClient);
-  void writeGraphBatch(ManagedDirectory::File &fd, VPackArrayIterator it, std::string const& fileName);
-  void xgmmlWriteOneAtt(ManagedDirectory::File & fd, std::string const& fileName, VPackSlice const& slice,
+  void writeGraphBatch(ManagedDirectory::File& fd, VPackArrayIterator it, std::string const& fileName);
+  void xgmmlWriteOneAtt(ManagedDirectory::File& fd, VPackSlice const& slice,
                         std::string const& name, int deep = 0);
 
-  void writeToFile(ManagedDirectory::File & fd, std::string const& string, std::string const& fileName);
+  void writeToFile(ManagedDirectory::File& fd, std::string const& string);
   std::shared_ptr<VPackBuilder> httpCall(httpclient::SimpleHttpClient* httpClient,
                                          std::string const& url, arangodb::rest::RequestType,
                                          std::string postBody = "");

--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -1125,7 +1125,7 @@ char* TRI_SlurpGzipFile(char const* filename, size_t* length) {
   TRI_set_errno(TRI_ERROR_NO_ERROR);
   gzFile gzFd(gzopen(filename,"rb"));
   auto fdGuard = arangodb::scopeGuard([&gzFd](){ if (nullptr != gzFd) gzclose(gzFd); });
-  char * retPtr = nullptr;
+  char* retPtr = nullptr;
 
   if (nullptr != gzFd) {
     TRI_string_buffer_t result;

--- a/tests/js/server/export/export-setup-cluster.js
+++ b/tests/js/server/export/export-setup-cluster.js
@@ -44,6 +44,7 @@
   for (let i = 0; i < 100; ++i) {
     col.save({ _key: "export" + i, value1: i, value2: "this is export", value3: "export" + i, value4: "%<>\"'" });
   }
+  col.save({ _key: "special", value1: "abc \"def\" ghi", value2: [1, 2], value3: { foo: "bar" }, value4: "abc\r\ncd" }); 
 }
 
 return {

--- a/tests/js/server/export/export-setup.js
+++ b/tests/js/server/export/export-setup.js
@@ -44,6 +44,7 @@
   for (let i = 0; i < 100; ++i) {
     col.save({ _key: "export" + i, value1: i, value2: "this is export", value3: "export" + i, value4: "%<>\"'" });
   }
+  col.save({ _key: "special", value1: "abc \"def\" ghi", value2: [1, 2], value3: { foo: "bar" }, value4: "abc\r\ncd" }); 
 }
 
 return {


### PR DESCRIPTION
### Scope & Purpose

Make arangoexport enclose CSV values that contain line breaks in `"`.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

- [x] There is a GitHub Issue reported by a Community User: #10193 

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest export*.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6644/