### PR TITLE
fix it!

### DIFF
--- a/arangod/RestHandler/RestVocbaseBaseHandler.cpp
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.cpp
@@ -381,6 +381,7 @@ void RestVocbaseBaseHandler::generatePreconditionFailed(VPackSlice const& slice)
                 VPackValue(static_cast<int32_t>(rest::ResponseCode::PRECONDITION_FAILED)));
     builder.add(StaticStrings::ErrorNum, VPackValue(TRI_ERROR_ARANGO_CONFLICT));
     builder.add(StaticStrings::ErrorMessage, VPackValue("precondition failed"));
+
     if (slice.isObject()) {
       builder.add(StaticStrings::IdString, slice.get(StaticStrings::IdString));
       builder.add(StaticStrings::KeyString, slice.get(StaticStrings::KeyString));
@@ -487,7 +488,7 @@ void RestVocbaseBaseHandler::generateTransactionError(std::string const& collect
       return;
 
     case TRI_ERROR_ARANGO_CONFLICT:
-      if (result.buffer != nullptr) {
+      if (result.buffer != nullptr && !result.slice().isNone()) {
         // This case happens if we come via the generateTransactionError that
         // has a proper OperationResult with a slice:
         generatePreconditionFailed(result.slice());


### PR DESCRIPTION
### Scope & Purpose

This bug is about:
```js
conspire = function() {
  let theories = [
    "docker", "ubuntu", "k8s", "json", "vst", "c#", "javascript", "collectd", 
    "sleep", "satellite collections", "gyp", "lto", "macos", "smart joins",  
    "el cheapo", "v8", "salat", "windows", "transactions", "oskar", "fuerte",
    "ccache", "libmusl"
  ];
  let conspiracy = {};
  while (Object.keys(conspiracy).length < 3) {
    conspiracy[theories[Math.floor(Math.random() * theories.length)]] = true;
  }
  return Object.keys(conspiracy);
};
print("It is caused by:", conspire().join(" + "));
```
 
- [x] Bug-Fix for devel
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6647/