### PR TITLE
don't scan the specified directory recursively 

### DIFF
--- a/arangosh/Utils/ManagedDirectory.cpp
+++ b/arangosh/Utils/ManagedDirectory.cpp
@@ -246,7 +246,7 @@ ManagedDirectory::ManagedDirectory(application_features::ApplicationServer& serv
     }
 
     std::vector<std::string> files(TRI_FilesDirectory(_path.c_str()));
-    bool isEmpty = (files.size() <= 1);
+    bool isEmpty = files.empty();
     // TODO: TRI_FullTreeDirectory always returns at least one element ("")
     // even if directory is empty?
 

--- a/arangosh/Utils/ManagedDirectory.cpp
+++ b/arangosh/Utils/ManagedDirectory.cpp
@@ -246,11 +246,7 @@ ManagedDirectory::ManagedDirectory(application_features::ApplicationServer& serv
     }
 
     std::vector<std::string> files(TRI_FilesDirectory(_path.c_str()));
-    bool isEmpty = files.empty();
-    // TODO: TRI_FullTreeDirectory always returns at least one element ("")
-    // even if directory is empty?
-
-    if (!isEmpty) {
+    if (!files.empty()) {
       // directory exists, has files, and we aren't allowed to overwrite
       if (requireEmpty) {
         _status.reset(TRI_ERROR_CANNOT_OVERWRITE_FILE,

--- a/arangosh/Utils/ManagedDirectory.cpp
+++ b/arangosh/Utils/ManagedDirectory.cpp
@@ -245,7 +245,7 @@ ManagedDirectory::ManagedDirectory(application_features::ApplicationServer& serv
       return;
     }
 
-    std::vector<std::string> files(TRI_FullTreeDirectory(_path.c_str()));
+    std::vector<std::string> files(TRI_FilesDirectory(_path.c_str()));
     bool isEmpty = (files.size() <= 1);
     // TODO: TRI_FullTreeDirectory always returns at least one element ("")
     // even if directory is empty?


### PR DESCRIPTION
the effect can be observed when using arangoimp for a file in i.e. `~`, it will then recurse through the whole home.