### PR TITLE
Doc - Added "log-output" example

### DIFF
--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -99,7 +99,7 @@ void LoggerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addOption("--log.escape", "escape characters when logging",
                      new BooleanParameter(&_useEscaped));
 
-  options->addOption("--log.output,-o", "log destination(s)",
+  options->addOption("--log.output,-o", "log destination(s), e.g. file:///path-to-file",
                      new VectorParameter<StringParameter>(&_output));
 
   options->addOption("--log.level,-l", "the global or topic-specific log level",

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -99,7 +99,9 @@ void LoggerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addOption("--log.escape", "escape characters when logging",
                      new BooleanParameter(&_useEscaped));
 
-  options->addOption("--log.output,-o", "log destination(s), e.g. file:///path-to-file",
+  options->addOption("--log.output,-o",
+                     "log destination(s), e.g. file:///path/to/file (Linux, macOS) "
+                     "or file://C:\\path\\to\\file (Windows)",
                      new VectorParameter<StringParameter>(&_output));
 
   options->addOption("--log.level,-l", "the global or topic-specific log level",


### PR DESCRIPTION
As suggested by Omar: https://github.com/arangodb/docs/pull/177

To be backported to 3.5 at least.

Open questions:
- What other protocols aside from `file://` are supported?
- How do paths look like on Windows?
  - Linux seems to be `file://` + `/absolute/path/file.ext`
  - Windows `file://` + ???