### PR TITLE
[3.5] Fix document search (Ctrl+F/Cmd+F)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.5.2 (XXXX-XX-XX)
 -------------------
 
-* Fixed search not working in document view while in code mode
+* Fixed search not working in document view while in code mode.
 
 * Fixed issue #10090: fix repeatable seek to the same document in
   SEARCH operations for ArangoSearch views.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.5.2 (XXXX-XX-XX)
 -------------------
 
+* Fixed search not working in document view while in code mode
+
 * Fixed issue #10090: fix repeatable seek to the same document in
   SEARCH operations for ArangoSearch views.
 

--- a/js/apps/system/_admin/aardvark/APP/manifest.json
+++ b/js/apps/system/_admin/aardvark/APP/manifest.json
@@ -68,6 +68,7 @@
     "/img": "frontend/compressed-img",
     "/data": "frontend/data",
     "/js/arango/aqltemplates.json": "frontend/aqltemplates.json",
+    "/ext-searchbox.js": "frontend/src/ext-searchbox.js",
     "/worker-json.js": {
       "path": "frontend/src/worker-json.js",
       "gzip": true


### PR DESCRIPTION
### Scope & Purpose

This fixes a longstanding regression in 3.x that broke search in the document editor in code view. The browser search doesn't work in ACE and the JSON Editor uses a searchbox extension that for some reason needs to be loaded dynamically via a hardcoded path. This PR simply maps that path to the file it's looking for.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

I've reported this issue internally before.

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [x] Added a *Changelog Entry* (referencing the corresponding public or internal issue number)
- [ ] Added entry to *Release Notes* 
