### PR TITLE
Fix content-type for JS APIs

### DIFF
--- a/3rdParty/fuerte/src/HttpConnection.cpp
+++ b/3rdParty/fuerte/src/HttpConnection.cpp
@@ -305,18 +305,20 @@ std::string HttpConnection<ST>::buildRequestBody(Request const& req) {
     header.append("Connection: Close\r\n");
   }
 
-  header.append("Content-Type: ")
-      .append(to_string(req.contentType()))
-      .append("\r\n")
-      .append("Accept: ")
-      .append(to_string(req.acceptType()))
-      .append("\r\n");
+  if (req.contentType() != ContentType::Custom) {
+    header.append("Content-Type: ")
+          .append(to_string(req.contentType()))
+          .append("\r\n");
+  }
+  if (req.acceptType() != ContentType::Custom) {
+    header.append("Accept: ")
+          .append(to_string(req.acceptType()))
+          .append("\r\n");
+  }
 
   bool haveAuth = false;
   for (auto const& pair : req.header.meta()) {
-    if (boost::iequals(fu_content_length_key, pair.first) ||
-        boost::iequals(fu_content_type_key, pair.first) ||
-        boost::iequals(fu_accept_key, pair.first)) {
+    if (boost::iequals(fu_content_length_key, pair.first)) {
       continue;  // skip content-length header
     }
 

--- a/3rdParty/fuerte/src/message.cpp
+++ b/3rdParty/fuerte/src/message.cpp
@@ -38,12 +38,17 @@ namespace arangodb { namespace fuerte { inline namespace v1 {
 
 void MessageHeader::addMeta(std::string key, std::string value) {
   if (boost::iequals(key, fu_accept_key)) {
-    this->_acceptType = to_ContentType(value);
+    _acceptType = to_ContentType(value);
+    if (_acceptType != ContentType::Custom) {
+      return;
+    }
   } else if (boost::iequals(key, fu_content_type_key)) {
-    this->_contentType = to_ContentType(value);
-  } else {
-    this->_meta.emplace(std::move(key), std::move(value));
+    _contentType = to_ContentType(value);
+    if (_contentType != ContentType::Custom) {
+      return;
+    }
   }
+  this->_meta.emplace(std::move(key), std::move(value));
 }
 
 void MessageHeader::addMeta(StringMap const& map) {

--- a/3rdParty/fuerte/src/vst.cpp
+++ b/3rdParty/fuerte/src/vst.cpp
@@ -152,9 +152,13 @@ void message::requestHeader(RequestHeader const& header,
   // 6 - meta
   {
     VPackObjectBuilder guard(&builder);
-    builder.add(fu_accept_key, VPackValue(to_string(header.acceptType())));
-    builder.add(fu_content_type_key,
-                VPackValue(to_string(header.contentType())));
+    if (header.acceptType() != ContentType::Custom) {
+      builder.add(fu_accept_key, VPackValue(to_string(header.acceptType())));
+    }
+    if (header.contentType() != ContentType::Custom) {
+      builder.add(fu_content_type_key,
+                  VPackValue(to_string(header.contentType())));
+    }
     for (auto const& pair : header.meta()) {
       if (boost::iequals(fu_content_type_key, pair.first) ||
           boost::iequals(fu_accept_key, pair.first)) {
@@ -163,7 +167,6 @@ void message::requestHeader(RequestHeader const& header,
       builder.add(pair.first, VPackValue(pair.second));
     }
   }
-
   builder.close();  // </array>
 }
 

--- a/lib/Rest/VstResponse.cpp
+++ b/lib/Rest/VstResponse.cpp
@@ -124,12 +124,9 @@ void VstResponse::writeMessageHeader(VPackBuffer<uint8_t>& buffer) const {
   builder.add(VPackValue(int(2)));  // 2 == response
   builder.add(VPackValue(static_cast<int>(meta::underlyingValue(_responseCode))));  // 3 == request - return code
   
-  std::string currentHeader;
-  builder.openObject();  // 4 == meta
-  for (auto& item : _headers) {
-    currentHeader.assign(item.first);
+  auto fixCase = [](std::string& tmp) {
     int capState = 1;
-    for (auto& it : currentHeader) {
+    for (auto& it : tmp) {
       if (capState == 1) {
         // upper case
         it = ::toupper(it);
@@ -144,7 +141,23 @@ void VstResponse::writeMessageHeader(VPackBuffer<uint8_t>& buffer) const {
         }
       }
     }
+  };
+  
+  std::string currentHeader;
+  builder.openObject();  // 4 == meta
+  for (auto& item : _headers) {
+    if (item.first.compare(0, StaticStrings::ContentTypeHeader.size(),
+                           StaticStrings::ContentTypeHeader) == 0) {
+      continue;
+    }
+    currentHeader.assign(item.first);
+    fixCase(currentHeader);
     builder.add(currentHeader, VPackValue(item.second));
+  }
+  if (_contentType != ContentType::VPACK) { // fuerte uses VPack as default
+    std::string currentHeader = StaticStrings::ContentTypeHeader;
+    fixCase(currentHeader);
+    builder.add(currentHeader, VPackValue(rest::contentTypeToString(_contentType)));
   }
   builder.close();
   builder.close();

--- a/lib/Rest/VstResponse.cpp
+++ b/lib/Rest/VstResponse.cpp
@@ -146,7 +146,8 @@ void VstResponse::writeMessageHeader(VPackBuffer<uint8_t>& buffer) const {
   std::string currentHeader;
   builder.openObject();  // 4 == meta
   for (auto& item : _headers) {
-    if (item.first.compare(0, StaticStrings::ContentTypeHeader.size(),
+    if (_contentType != ContentType::CUSTOM &&
+        item.first.compare(0, StaticStrings::ContentTypeHeader.size(),
                            StaticStrings::ContentTypeHeader) == 0) {
       continue;
     }
@@ -154,7 +155,8 @@ void VstResponse::writeMessageHeader(VPackBuffer<uint8_t>& buffer) const {
     fixCase(currentHeader);
     builder.add(currentHeader, VPackValue(item.second));
   }
-  if (_contentType != ContentType::VPACK) { // fuerte uses VPack as default
+  if (_contentType != ContentType::VPACK &&
+      _contentType != ContentType::CUSTOM) { // fuerte uses VPack as default
     std::string currentHeader = StaticStrings::ContentTypeHeader;
     fixCase(currentHeader);
     builder.add(currentHeader, VPackValue(rest::contentTypeToString(_contentType)));


### PR DESCRIPTION

### Scope & Purpose

Fix response content-type

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as the http_server suite

http://jenkins01.arangodb.biz:8080/job/arangodb-matrix-pr/6692/