### PR TITLE
when changing between leader and follower re-attempt connecting to circumvent OS resource shortages

### DIFF
--- a/js/common/modules/@arangodb/replication-common.js
+++ b/js/common/modules/@arangodb/replication-common.js
@@ -1,3 +1,4 @@
+/* global arango, print */
 'use strict';
 
 // //////////////////////////////////////////////////////////////////////////////
@@ -26,6 +27,11 @@
 // / @author Simon Grätzer
 // //////////////////////////////////////////////////////////////////////////////
 
+const RED = require('internal').COLORS.COLOR_RED;
+const RESET = require('internal').COLORS.COLOR_RESET;
+
+const sleep = require('internal').sleep;
+
 exports.compareTicks = function(l, r) {
   var i;
   if (l === null) {
@@ -46,4 +52,21 @@ exports.compareTicks = function(l, r) {
   }
 
   return 0;
+};
+
+exports.reconnectRetry = function(endpoint, databaseName, user, password) {
+  let sleepTime = 0.1;
+  let ex;
+  do {
+    try {
+      arango.reconnect(endpoint, databaseName, user, password);
+      return;
+    } catch (ex) {
+      print(RED + "connecting " + endpoint + " failed - retrying (" + ex.message + ")" + RESET);
+    }
+    sleepTime *= 2;
+    sleep(sleepTime);
+  } while (sleepTime < 5);
+  print(RED + "giving up!" + RESET);
+  throw ex;
 };

--- a/tests/js/server/replication/aql/replication-aql.js
+++ b/tests/js/server/replication/aql/replication-aql.js
@@ -34,6 +34,7 @@ var db = arangodb.db;
 
 const replication = require("@arangodb/replication");
 const compareTicks = replication.compareTicks;
+const reconnectRetry = require('@arangodb/replication-common').reconnectRetry;
 const console = require("console");
 const internal = require("internal");
 const masterEndpoint = arango.getEndpoint();
@@ -48,12 +49,12 @@ function ReplicationSuite() {
   var cn = "UnitTestsReplication";
 
   var connectToMaster = function() {
-    arango.reconnect(masterEndpoint, db._name(), "root", "");
+    reconnectRetry(masterEndpoint, db._name(), "root", "");
     db._flushCache();
   };
 
   var connectToSlave = function() {
-    arango.reconnect(slaveEndpoint, db._name(), "root", "");
+    reconnectRetry(slaveEndpoint, db._name(), "root", "");
     db._flushCache();
   };
 

--- a/tests/js/server/replication/fuzz/replication-fuzz-global.js
+++ b/tests/js/server/replication/fuzz/replication-fuzz-global.js
@@ -32,6 +32,7 @@ var jsunity = require("jsunity");
 var arangodb = require("@arangodb");
 var db = arangodb.db;
 
+const reconnectRetry = require('@arangodb/replication-common').reconnectRetry;
 var replication = require("@arangodb/replication");
 let compareTicks = replication.compareTicks;
 var console = require("console");
@@ -48,12 +49,12 @@ function ReplicationSuite() {
   var cn = "UnitTestsReplication";
 
   var connectToMaster = function() {
-    arango.reconnect(masterEndpoint, db._name(), "root", "");
+    reconnectRetry(masterEndpoint, db._name(), "root", "");
     db._flushCache();
   };
 
   var connectToSlave = function() {
-    arango.reconnect(slaveEndpoint, db._name(), "root", "");
+    reconnectRetry(slaveEndpoint, db._name(), "root", "");
     db._flushCache();
   };
 

--- a/tests/js/server/replication/fuzz/replication-fuzz.js
+++ b/tests/js/server/replication/fuzz/replication-fuzz.js
@@ -32,6 +32,7 @@ var jsunity = require("jsunity");
 var arangodb = require("@arangodb");
 var db = arangodb.db;
 
+const reconnectRetry = require('@arangodb/replication-common').reconnectRetry;
 var replication = require("@arangodb/replication");
 let compareTicks = replication.compareTicks;
 var console = require("console");
@@ -53,12 +54,12 @@ function ReplicationSuite() {
   var cn = "UnitTestsReplication";
 
   var connectToMaster = function() {
-    arango.reconnect(masterEndpoint, db._name(), "root", "");
+    reconnectRetry(masterEndpoint, db._name(), "root", "");
     db._flushCache();
   };
 
   var connectToSlave = function() {
-    arango.reconnect(slaveEndpoint, db._name(), "root", "");
+    reconnectRetry(slaveEndpoint, db._name(), "root", "");
     db._flushCache();
   };
 

--- a/tests/js/server/replication/ongoing/32/replication-ongoing-32.js
+++ b/tests/js/server/replication/ongoing/32/replication-ongoing-32.js
@@ -30,6 +30,7 @@ var arangodb = require('@arangodb');
 var db = arangodb.db;
 
 var replication = require('@arangodb/replication');
+const reconnectRetry = require('@arangodb/replication-common').reconnectRetry;
 var deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
 let compareTicks = replication.compareTicks;
 var console = require('console');
@@ -41,12 +42,12 @@ const cn = 'UnitTestsReplication';
 const cn2 = 'UnitTestsReplication2';
 
 const connectToMaster = function () {
-  arango.reconnect(masterEndpoint, db._name(), 'root', '');
+  reconnectRetry(masterEndpoint, db._name(), 'root', '');
   db._flushCache();
 };
 
 const connectToSlave = function () {
-  arango.reconnect(slaveEndpoint, db._name(), 'root', '');
+  reconnectRetry(slaveEndpoint, db._name(), 'root', '');
   db._flushCache();
 };
 

--- a/tests/js/server/replication/ongoing/frompresent/32/replication-ongoing-frompresent-32.js
+++ b/tests/js/server/replication/ongoing/frompresent/32/replication-ongoing-frompresent-32.js
@@ -33,6 +33,7 @@ var arangodb = require('@arangodb');
 var db = arangodb.db;
 
 var replication = require('@arangodb/replication');
+const reconnectRetry = require('@arangodb/replication-common').reconnectRetry;
 var deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
 let compareTicks = replication.compareTicks;
 var console = require('console');
@@ -44,12 +45,12 @@ var cn = 'UnitTestsReplication';
 var cn2 = 'UnitTestsReplication2';
 
 var connectToMaster = function () {
-  arango.reconnect(masterEndpoint, db._name(), 'root', '');
+  reconnectRetry(masterEndpoint, db._name(), 'root', '');
   db._flushCache();
 };
 
 var connectToSlave = function () {
-  arango.reconnect(slaveEndpoint, db._name(), 'root', '');
+  reconnectRetry(slaveEndpoint, db._name(), 'root', '');
   db._flushCache();
 };
 

--- a/tests/js/server/replication/ongoing/frompresent/replication-ongoing-frompresent.js
+++ b/tests/js/server/replication/ongoing/frompresent/replication-ongoing-frompresent.js
@@ -33,6 +33,7 @@ var arangodb = require('@arangodb');
 var db = arangodb.db;
 
 var replication = require('@arangodb/replication');
+const reconnectRetry = require('@arangodb/replication-common').reconnectRetry;
 var deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
 let compareTicks = replication.compareTicks;
 var console = require('console');
@@ -44,12 +45,12 @@ var cn = 'UnitTestsReplication';
 var cn2 = 'UnitTestsReplication2';
 
 var connectToMaster = function () {
-  arango.reconnect(masterEndpoint, db._name(), 'root', '');
+  reconnectRetry(masterEndpoint, db._name(), 'root', '');
   db._flushCache();
 };
 
 var connectToSlave = function () {
-  arango.reconnect(slaveEndpoint, db._name(), 'root', '');
+  reconnectRetry(slaveEndpoint, db._name(), 'root', '');
   db._flushCache();
 };
 

--- a/tests/js/server/replication/ongoing/global/replication-ongoing-global.js
+++ b/tests/js/server/replication/ongoing/global/replication-ongoing-global.js
@@ -34,6 +34,7 @@ const db = arangodb.db;
 
 const replication = require('@arangodb/replication');
 var deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
+const reconnectRetry = require('@arangodb/replication-common').reconnectRetry;
 const compareTicks = replication.compareTicks;
 const console = require('console');
 const internal = require('internal');
@@ -45,12 +46,12 @@ const cn = 'UnitTestsReplication';
 const cn2 = 'UnitTestsReplication2';
 
 const connectToMaster = function () {
-  arango.reconnect(masterEndpoint, db._name(), 'root', '');
+  reconnectRetry(masterEndpoint, db._name(), 'root', '');
   db._flushCache();
 };
 
 const connectToSlave = function () {
-  arango.reconnect(slaveEndpoint, db._name(), 'root', '');
+  reconnectRetry(slaveEndpoint, db._name(), 'root', '');
   db._flushCache();
 };
 

--- a/tests/js/server/replication/ongoing/global/spec/replication-ongoing-global-spec.js
+++ b/tests/js/server/replication/ongoing/global/spec/replication-ongoing-global-spec.js
@@ -32,6 +32,7 @@
 const expect = require('chai').expect;
 const arangodb = require("@arangodb");
 const replication = require("@arangodb/replication");
+const reconnectRetry = require('@arangodb/replication-common').reconnectRetry;
 const compareTicks = replication.compareTicks;
 const errors = arangodb.errors;
 const db = arangodb.db;
@@ -122,7 +123,7 @@ const waitForReplication = function() {
 // You do not need to monitor any state.
 const connectToMaster = function() {
   if (!onMaster) {
-    arango.reconnect(masterEndpoint, "_system", username, password);
+    reconnectRetry(masterEndpoint, "_system", username, password);
     db._flushCache();
     onMaster = true;
   } else {
@@ -132,7 +133,7 @@ const connectToMaster = function() {
 
 const connectToSlave = function() {
   if (onMaster) {
-    arango.reconnect(slaveEndpoint, "_system", username, password);
+    reconnectRetry(slaveEndpoint, "_system", username, password);
     db._flushCache();
     onMaster = false;
   } else {

--- a/tests/js/server/replication/ongoing/replication-ongoing.js
+++ b/tests/js/server/replication/ongoing/replication-ongoing.js
@@ -34,6 +34,7 @@ var analyzers = require("@arangodb/analyzers");
 const db = arangodb.db;
 
 const replication = require('@arangodb/replication');
+const reconnectRetry = require('@arangodb/replication-common').reconnectRetry;
 const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
 const compareTicks = replication.compareTicks;
 const console = require('console');
@@ -45,12 +46,12 @@ const cn = 'UnitTestsReplication';
 const cn2 = 'UnitTestsReplication2';
 
 const connectToMaster = function () {
-  arango.reconnect(masterEndpoint, db._name(), 'root', '');
+  reconnectRetry(masterEndpoint, db._name(), 'root', '');
   db._flushCache();
 };
 
 const connectToSlave = function () {
-  arango.reconnect(slaveEndpoint, db._name(), 'root', '');
+  reconnectRetry(slaveEndpoint, db._name(), 'root', '');
   db._flushCache();
 };
 

--- a/tests/js/server/replication/random/replication-random.js
+++ b/tests/js/server/replication/random/replication-random.js
@@ -32,6 +32,7 @@ const jsunity = require("jsunity");
 const arangodb = require("@arangodb");
 const db = arangodb.db;
 
+const reconnectRetry = require('@arangodb/replication-common').reconnectRetry;
 const replication = require("@arangodb/replication");
 const compareTicks = replication.compareTicks;
 const console = require("console");
@@ -50,12 +51,12 @@ function ReplicationSuite() {
   var cn3 = "UnitTestsReplication3";
 
   var connectToMaster = function() {
-    arango.reconnect(masterEndpoint, db._name(), "root", "");
+    reconnectRetry(masterEndpoint, db._name(), "root", "");
     db._flushCache();
   };
 
   var connectToSlave = function() {
-    arango.reconnect(slaveEndpoint, db._name(), "root", "");
+    reconnectRetry(slaveEndpoint, db._name(), "root", "");
     db._flushCache();
   };
 

--- a/tests/js/server/replication/static/replication-static.js
+++ b/tests/js/server/replication/static/replication-static.js
@@ -38,6 +38,7 @@ const _ = require('lodash');
 
 const replication = require('@arangodb/replication');
 const compareTicks = require('@arangodb/replication-common').compareTicks;
+const reconnectRetry = require('@arangodb/replication-common').reconnectRetry;
 const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
 const console = require('console');
 const internal = require('internal');
@@ -55,11 +56,11 @@ const replicatorUser = 'replicator-user';
 const replicatorPassword = 'replicator-password';
 
 const connectToMaster = function () {
-  arango.reconnect(masterEndpoint, db._name(), replicatorUser, replicatorPassword);
+  reconnectRetry(masterEndpoint, db._name(), replicatorUser, replicatorPassword);
 };
 
 const connectToSlave = function () {
-  arango.reconnect(slaveEndpoint, db._name(), 'root', '');
+  reconnectRetry(slaveEndpoint, db._name(), 'root', '');
 };
 
 const collectionChecksum = function (name) {

--- a/tests/js/server/replication/sync/replication-sync.js
+++ b/tests/js/server/replication/sync/replication-sync.js
@@ -32,6 +32,7 @@ const jsunity = require('jsunity');
 const arangodb = require('@arangodb');
 var analyzers = require("@arangodb/analyzers");
 const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
+const reconnectRetry = require('@arangodb/replication-common').reconnectRetry;
 const db = arangodb.db;
 const _ = require('lodash');
 
@@ -49,12 +50,12 @@ const cn = 'UnitTestsReplication';
 const sysCn = '_UnitTestsReplication';
 
 const connectToMaster = function () {
-  arango.reconnect(masterEndpoint, db._name(), 'root', '');
+  reconnectRetry(masterEndpoint, db._name(), 'root', '');
   db._flushCache();
 };
 
 const connectToSlave = function () {
-  arango.reconnect(slaveEndpoint, db._name(), 'root', '');
+  reconnectRetry(slaveEndpoint, db._name(), 'root', '');
   db._flushCache();
 };
 


### PR DESCRIPTION
The resilient testsuites family frequently disconnects from leader / follower to work out test states. 
This may lead to instability in tests if the system fails to connect in one of these reconnects.
Known popular reasons for failing connects are IP-Port shortages. 
To circumvent testfailure this PR will re-attempt connecting to the SUT after an increasing grace period several times. 

Example of such a failed testrun:
```
2019-10-11T14:45:18.866Z [ RUN        ] testChangeCollection1_Repl
2019-10-11T14:45:20.653Z [     PASSED ] testChangeCollection1_Repl (setUp: 7ms, test: 1515ms, tearDown: 265ms)
2019-10-11T14:45:20.654Z [ RUN        ] testChangeCollection2_Repl
2019-10-11T14:45:52Z [10128] ERROR [9d7ea] Could not connect to endpoint 'tcp://127.0.0.1:10033', username: 'replicator-user'
2019-10-11T14:45:52.180Z [   FAILED   ] testChangeCollection2_Repl (setUp: 5ms, test: 1516ms, tearDown: 30005ms)
ArangoError: could not connect
    at connectToMaster (c:\vm02-windows\oskar\work\ArangoDB\tests\js\server\replication\static\replication-static.js:58:10)
    at Object.tearDown (c:\vm02-windows\oskar\work\ArangoDB\tests\js\server\replication\static\replication-static.js:2226:7)
    at c:\vm02-windows\oskar\work\ArangoDB\js\common\modules\jsunity\jsunity.js:484:16
    at Object.run (c:\vm02-windows\oskar\work\ArangoDB\js\common\modules\jsunity\jsunity.js:556:19)
    at Object.Run [as run] (c:\vm02-windows\oskar\work\ArangoDB\js\common\modules\jsunity.js:275:24)
    at c:\vm02-windows\oskar\work\ArangoDB\tests\js\server\replication\static\replication-static.js:2325:9
    at c:\vm02-windows\oskar\work\ArangoDB\tests\js\server\replication\static\replication-static.js:2329:3
    at RunTest (c:\vm02-windows\oskar\work\ArangoDB\js\common\modules\jsunity.js:389:12)
    at c:\vm02-windows\oskar\work\ArangoDB\js\common\modules\@arangodb\testrunner.js:66:13
    at arrayEach (c:\vm02-windows\oskar\work\ArangoDB\js\node\node_modules\lodash\lodash.js:516:11) - tearDown failed
2019-10-11T14:45:52.180Z [ RUN        ] testChangeCollectionIndexBuckets_Repl
2019-10-11T14:45:52.399Z [     PASSED ] testChangeCollectionIndexBuckets_Repl (setUp: 211ms, test: 0ms, tearDown: 8ms)


```
