### PR TITLE
fix leak in hot backup tests

### DIFF
--- a/tests/RocksDBEngine/ShaEventListener.cpp
+++ b/tests/RocksDBEngine/ShaEventListener.cpp
@@ -69,46 +69,40 @@ struct CFilesSetup {
     TRI_RemoveDirectory(_directory.c_str());
   }
 
-  StringBuffer* writeFile (const char* blob) {
-    StringBuffer* filename = new StringBuffer(true);
-    filename->appendText(_directory);
-    filename->appendChar(TRI_DIR_SEPARATOR_CHAR);
-    filename->appendText("tmp-");
-    filename->appendInteger(++counter);
-    filename->appendInteger(arangodb::RandomGenerator::interval(UINT32_MAX));
+  void writeFile(char const* blob) {
+    StringBuffer filename(true);
+    filename.appendText(_directory);
+    filename.appendChar(TRI_DIR_SEPARATOR_CHAR);
+    filename.appendText("tmp-");
+    filename.appendInteger(++counter);
+    filename.appendInteger(arangodb::RandomGenerator::interval(UINT32_MAX));
 
-    FILE* fd = fopen(filename->c_str(), "wb");
+    FILE* fd = fopen(filename.c_str(), "wb");
 
     if (fd) {
       size_t numWritten = fwrite(blob, strlen(blob), 1, fd);
       (void) numWritten;
       fclose(fd);
-    }
-    else {
+    } else {
       EXPECT_TRUE(false);
     }
-
-    return filename;
   }
 
-  StringBuffer * writeFile (const char * name, const char * blob) {
-    StringBuffer* filename = new StringBuffer(true);
-    filename->appendText(_directory);
-    filename->appendChar(TRI_DIR_SEPARATOR_CHAR);
-    filename->appendText(name);
+  void writeFile(char const* name, char const* blob) {
+    StringBuffer filename(true);
+    filename.appendText(_directory);
+    filename.appendChar(TRI_DIR_SEPARATOR_CHAR);
+    filename.appendText(name);
 
-    FILE* fd = fopen(filename->c_str(), "wb");
+    FILE* fd = fopen(filename.c_str(), "wb");
 
     if (fd) {
       size_t numWritten = fwrite(blob, strlen(blob), 1, fd);
       (void) numWritten;
       fclose(fd);
-    }
-    else {
+    } else {
       EXPECT_TRUE(false);
     }
-
-    return filename;
   }
 
   StringBuffer _directory;


### PR DESCRIPTION
### Scope & Purpose

Fix a leak in hot backup gtests. Backport of b6d1058eb059cdcc014583925a57d94b40e86d29

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest catch*.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6719/