### PR TITLE
fix docublocks parameter naming

### DIFF
--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index_fulltext.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index_fulltext.md
@@ -6,7 +6,7 @@
 
 @RESTQUERYPARAMETERS
 
-@RESTQUERYPARAM{collection-name,string,required}
+@RESTQUERYPARAM{collection,string,required}
 The collection name.
 
 @RESTBODYPARAM{type,string,required,string}

--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index_hash.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index_hash.md
@@ -6,7 +6,7 @@
 
 @RESTQUERYPARAMETERS
 
-@RESTQUERYPARAM{collection-name,string,required}
+@RESTQUERYPARAM{collection,string,required}
 The collection name.
 
 @RESTBODYPARAM{type,string,required,string}

--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index_persistent.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index_persistent.md
@@ -6,7 +6,7 @@
 
 @RESTQUERYPARAMETERS
 
-@RESTQUERYPARAM{collection-name,string,required}
+@RESTQUERYPARAM{collection,string,required}
 The collection name.
 
 @RESTBODYPARAM{type,string,required,string}

--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index_skiplist.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index_skiplist.md
@@ -6,7 +6,7 @@
 
 @RESTQUERYPARAMETERS
 
-@RESTQUERYPARAM{collection-name,string,required}
+@RESTQUERYPARAM{collection,string,required}
 The collection name.
 
 @RESTBODYPARAM{type,string,required,string}

--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index_ttl.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index_ttl.md
@@ -6,7 +6,7 @@
 
 @RESTQUERYPARAMETERS
 
-@RESTQUERYPARAM{collection-name,string,required}
+@RESTQUERYPARAM{collection,string,required}
 The collection name.
 
 @RESTBODYPARAM{type,string,required,string}


### PR DESCRIPTION
### Scope & Purpose

Parameters are named wrong

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://jenkins01.arangodb.biz:8080/view/Documentation/job/arangodb-ANY-examples/402/
