### PR TITLE
fix underflow in copying code

### DIFF
--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -507,18 +507,16 @@ void V8DealerFeature::copyInstallationFiles() {
         // don't copy files in .bin
         return true;
       }
-      if (filename.size() >= nodeModulesPath.size()) {
-        std::string normalized = filename;
-        FileUtils::normalizePath(normalized);
-        if ((!nodeModulesPath.empty() && 
-             normalized.size() >= nodeModulesPath.size() &&
-             normalized.substr(normalized.size() - nodeModulesPath.size(), nodeModulesPath.size()) == nodeModulesPath) ||
-            (!nodeModulesPathVersioned.empty() &&
-             normalized.size() >= nodeModulesPathVersioned.size() &&
-             normalized.substr(normalized.size() - nodeModulesPathVersioned.size(), nodeModulesPathVersioned.size()) == nodeModulesPathVersioned)) {
-          // filter it out!
-          return true;
-        }
+      std::string normalized = filename;
+      FileUtils::normalizePath(normalized);
+      if ((!nodeModulesPath.empty() && 
+           normalized.size() >= nodeModulesPath.size() &&
+           normalized.substr(normalized.size() - nodeModulesPath.size(), nodeModulesPath.size()) == nodeModulesPath) ||
+          (!nodeModulesPathVersioned.empty() &&
+           normalized.size() >= nodeModulesPathVersioned.size() &&
+           normalized.substr(normalized.size() - nodeModulesPathVersioned.size(), nodeModulesPathVersioned.size()) == nodeModulesPathVersioned)) {
+        // filter it out!
+        return true;
       }
       // let the file/directory pass through
       return false;


### PR DESCRIPTION
### Scope & Purpose

Fix possible string length underflow when `--javascript.copy-installation` was used for arangosh

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest permissions --test copy-installation*.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6761/