### PR TITLE
Avoid a race and a use-after-free bug in the RemoteExecutor

### DIFF
--- a/arangod/Aql/RemoteExecutor.cpp
+++ b/arangod/Aql/RemoteExecutor.cpp
@@ -449,19 +449,22 @@ Result ExecutionBlockImpl<RemoteExecutor>::sendAsyncRequest(fuerte::RestVerb typ
   auto ticket = generateNewTicket();
   std::shared_ptr<fuerte::Connection> conn = ref.connection();
   conn->sendRequest(std::move(req),
-                    [=, ref(std::move(ref))](fuerte::Error err,
-                                             std::unique_ptr<fuerte::Request>,
-                                             std::unique_ptr<fuerte::Response> res) {
-                      std::lock_guard<std::mutex> guard(_communicationMutex);
+                    [this, ticket, spec, sharedState = _query.sharedState(),
+                     ref(std::move(ref))](fuerte::Error err, std::unique_ptr<fuerte::Request>,
+                                          std::unique_ptr<fuerte::Response> res) {
+                      // `this` is only valid as long as sharedState is valid.
+                      // So we must execute this under sharedState's mutex.
+                      sharedState->execute([&] {
+                        std::lock_guard<std::mutex> guard(_communicationMutex);
 
-                      if (_lastTicket == ticket) {
-                        if (err != fuerte::Error::NoError || res->statusCode() >= 400) {
-                          _lastError = handleErrorResponse(spec, err, res.get());
-                        } else {
-                          _lastResponse = std::move(res);
+                        if (_lastTicket == ticket) {
+                          if (err != fuerte::Error::NoError || res->statusCode() >= 400) {
+                            _lastError = handleErrorResponse(spec, err, res.get());
+                          } else {
+                            _lastResponse = std::move(res);
+                          }
                         }
-                        _query.sharedState()->execute();
-                      }
+                      });
                     });
 
   ++_engine->_stats.requests;

--- a/arangod/Aql/SharedQueryState.cpp
+++ b/arangod/Aql/SharedQueryState.cpp
@@ -73,21 +73,3 @@ bool SharedQueryState::executeContinueCallback() const {
   //  then backs up libcurl callbacks to other objects
   return scheduler->queue(RequestLane::CLIENT_AQL, _continueCallback);
 }
-
-bool SharedQueryState::execute() {
-  std::lock_guard<std::mutex> guard(_mutex);
-  if (!_valid) {
-    return false;
-  }
-
-  if (_hasHandler) {
-    if (ADB_UNLIKELY(!executeContinueCallback())) {
-      return false;  // likely shutting down
-    }
-  } else {
-    _wasNotified = true;
-    // simon: bad experience on macOS guard.unlock();
-    _condition.notify_one();
-  }
-  return true;
-}


### PR DESCRIPTION
### Scope & Purpose

- [X] Bug-Fix for *devel-branch* (no need for backports)

Two bugs were introduced in devel (namely in #10077 and #10206):

- The `shared_ptr` to the SharedQueryState wasn't captured in the callback executed by fuerte
- The same callback's execution wasn't protected by the SharedQueryState any longer
