### PR TITLE
don't show "NaN" in web interface for cluster RAM usage

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/clusterView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/clusterView.js
@@ -185,7 +185,8 @@
       if (typeof value === 'number') {
         $(id).html(value);
       } else if ($.isArray(value)) {
-        var a = value[0]; var b = value[1];
+        var a = value[0]; 
+        var b = value[1];
 
         var percent = 1 / (b / a) * 100;
         if (percent > 90) {
@@ -193,7 +194,11 @@
         } else if (percent > 70 && percent < 90) {
           warning = true;
         }
-        $(id).html(percent.toFixed(1) + ' %');
+        if (isNaN(percent)) {
+          $(id).html('n/a');
+        } else {
+          $(id).html(percent.toFixed(1) + ' %');
+        }
       } else if (typeof value === 'string') {
         $(id).html(value);
       }


### PR DESCRIPTION
### Scope & Purpose

Don't show "NaN" in web interface for cluster RAM usage if statistics are disabled or otherwise not available. Instead, display "n/a".

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6789/