### PR TITLE
make sure error files get built when arangod is built

### DIFF
--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -962,11 +962,6 @@ if (USE_JEMALLOC)
   add_dependencies(arangod jemalloc)
 endif ()
   
-if (USE_MAINTAINER_MODE)
-  add_dependencies(arangod errorfiles)
-  add_dependencies(arangod exitcodefiles)
-endif ()
-
 foreach(TARGET
   arango_agency
   arango_aql

--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -961,6 +961,11 @@ endif ()
 if (USE_JEMALLOC)
   add_dependencies(arangod jemalloc)
 endif ()
+  
+if (USE_MAINTAINER_MODE)
+  add_dependencies(arangod errorfiles)
+  add_dependencies(arangod exitcodefiles)
+endif ()
 
 foreach(TARGET
   arango_agency

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -258,6 +258,14 @@ target_link_libraries(arango
   ${SYSTEM_LIBRARIES}
 )
 
+# Rebuild generated error files so they are up-to-date when all
+# dependent stuff is built
+if (USE_MAINTAINER_MODE)
+  add_dependencies(arango errorfiles)
+  add_dependencies(arango exitcodefiles)
+endif ()
+
+
 # Enterprise
 if (USE_ENTERPRISE)
   target_compile_definitions(arango PUBLIC "-DUSE_ENTERPRISE=1")


### PR DESCRIPTION
### Scope & Purpose

Add a depedency so error files get (re)built when arangod is built.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6790/