### PR TITLE
Bug fix/some future massaging

### DIFF
--- a/3rdParty/fuerte/include/fuerte/connection.h
+++ b/3rdParty/fuerte/include/fuerte/connection.h
@@ -61,7 +61,7 @@ class Connection : public std::enable_shared_from_this<Connection> {
   /// @brief Send a request to the server and wait into a response it received.
   /// @param r request that is copied
   std::unique_ptr<Response> sendRequest(Request const& r) {
-    std::unique_ptr<Request> copy(new Request(r));
+    auto copy = std::make_unique<Request>(r);
     return sendRequest(std::move(copy));
   }
 
@@ -77,7 +77,7 @@ class Connection : public std::enable_shared_from_this<Connection> {
   /// callbackis called. The callback is executed on a specific
   /// IO-Thread for this connection.
   MessageID sendRequest(Request const& r, RequestCallback cb) {
-    std::unique_ptr<Request> copy(new Request(r));
+    auto copy = std::make_unique<Request>(r);
     return sendRequest(std::move(copy), cb);
   }
 

--- a/3rdParty/fuerte/src/HttpConnection.cpp
+++ b/3rdParty/fuerte/src/HttpConnection.cpp
@@ -201,7 +201,7 @@ MessageID HttpConnection<ST>::sendRequest(std::unique_ptr<Request> req,
   static std::atomic<uint64_t> ticketId(1);
 
   // construct RequestItem
-  std::unique_ptr<RequestItem> item(new RequestItem());
+  auto item = std::make_unique<RequestItem>();
   // requestItem->_response later
   uint64_t mid = ticketId.fetch_add(1, std::memory_order_relaxed);
   item->requestHeader = buildRequestBody(*req);

--- a/3rdParty/fuerte/src/VstConnection.cpp
+++ b/3rdParty/fuerte/src/VstConnection.cpp
@@ -60,7 +60,7 @@ MessageID VstConnection<ST>::sendRequest(std::unique_ptr<Request> req,
   // it does not matter if IDs are reused on different connections
   uint64_t mid = vstMessageId.fetch_add(1, std::memory_order_relaxed);
   // Create RequestItem from parameters
-  std::unique_ptr<RequestItem> item(new RequestItem());
+  auto item = std::make_unique<RequestItem>();
   item->_messageID = mid;
   item->_request = std::move(req);
   item->_callback = cb;
@@ -485,7 +485,7 @@ std::unique_ptr<fu::Response> VstConnection<ST>::createResponse(
 
   ResponseHeader header =
       parser::responseHeaderFromSlice(VPackSlice(itemCursor));
-  std::unique_ptr<Response> response(new Response(std::move(header)));
+  auto response = std::make_unique<Response>(std::move(header));
   response->setPayload(std::move(*responseBuffer), /*offset*/ headerLength);
 
   return response;

--- a/3rdParty/fuerte/src/requests.cpp
+++ b/3rdParty/fuerte/src/requests.cpp
@@ -27,8 +27,7 @@ namespace arangodb { namespace fuerte { inline namespace v1 {
   
 std::unique_ptr<Request> createRequest(RestVerb verb,
                                        ContentType contentType) {
-  std::unique_ptr<Request> request(new Request());
-  
+  auto request = std::make_unique<Request>();
   request->header.restVerb = verb;
   request->header.contentType(contentType);
   request->header.acceptType(contentType);

--- a/3rdParty/fuerte/src/vst.cpp
+++ b/3rdParty/fuerte/src/vst.cpp
@@ -623,8 +623,7 @@ std::unique_ptr<VPackBuffer<uint8_t>> RequestItem::assemble() {
   if (!reject) {
     FUERTE_LOG_VSTCHUNKTRACE
         << "RequestItem::assemble: fast-path, chunks are in order" << std::endl;
-    return std::unique_ptr<VPackBuffer<uint8_t>>(
-        new VPackBuffer<uint8_t>(std::move(_buffer)));
+    return std::make_unique<VPackBuffer<uint8_t>>(std::move(_buffer));
   }
 
   // We now have all chunks. Sort them by index.

--- a/lib/Futures/Future.h
+++ b/lib/Futures/Future.h
@@ -141,9 +141,9 @@ void waitImpl(Future<T>& f) {
   
   Promise<T> p;
   Future<T> ret = p.getFuture();
-  f.thenFinal([&p, &cv, &m](Try<T>&& t) {
-    p.setTry(std::move(t));
+  f.thenFinal([p(std::move(p)), &cv, &m](Try<T>&& t) mutable {
     std::lock_guard<std::mutex> guard(m);
+    p.setTry(std::move(t));
     cv.notify_one();
   });
   std::unique_lock<std::mutex> lock(m);

--- a/lib/Futures/Promise.h
+++ b/lib/Futures/Promise.h
@@ -62,6 +62,7 @@ class Promise {
       detach();
       _state = std::move(o._state);
       _retrieved = o._retrieved;
+      o._retrieved = false;
       o._state = nullptr;
     }
     return *this;

--- a/lib/Futures/SharedState.h
+++ b/lib/Futures/SharedState.h
@@ -130,11 +130,11 @@ class SharedState {
   ///   but the referenced result may or may not have been modified, including
   ///   possibly moved-out, depending on what the callback did; some but not
   ///   all callbacks modify (possibly move-out) the result.)
-  Try<T>& getTry() {
+  Try<T>& getTry() noexcept {
     TRI_ASSERT(hasResult());
     return _result;
   }
-  Try<T> const& getTry() const {
+  Try<T> const& getTry() const noexcept {
     TRI_ASSERT(hasResult());
     return _result;
   }
@@ -163,18 +163,14 @@ class SharedState {
             return;
           }
           TRI_ASSERT(state == State::OnlyResult);  // race with setResult
-#ifndef _MSC_VER
           [[fallthrough]];
-#endif
 
         case State::OnlyResult:
-          if (_state.compare_exchange_strong(state, State::Done, std::memory_order_acquire)) {
+          if (_state.compare_exchange_strong(state, State::Done, std::memory_order_release)) {
             doCallback();
             return;
           }
-#ifndef _MSC_VER
           [[fallthrough]];
-#endif
 
         default:
           TRI_ASSERT(false);  // unexpected state
@@ -203,18 +199,14 @@ class SharedState {
             return;
           }
           TRI_ASSERT(state == State::OnlyCallback);  // race with setCallback
-#ifndef _MSC_VER
           [[fallthrough]];
-#endif
 
         case State::OnlyCallback:
-          if (_state.compare_exchange_strong(state, State::Done, std::memory_order_acquire)) {
+          if (_state.compare_exchange_strong(state, State::Done, std::memory_order_release)) {
             doCallback();
             return;
           }
-#ifndef _MSC_VER
           [[fallthrough]];
-#endif
 
         default:
           TRI_ASSERT(false);  // unexpected state


### PR DESCRIPTION
### Scope & Purpose

Move move operation under critical section, to avoid undefined behavior when spurious wakeups occur and the waiting thread may continue with a half-ready, half-uninitialized object.

:crossed_fingers: 

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest shell_server_aql --cluster true*.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6791/