### PR TITLE
Feature/explain spliced subqueries

### DIFF
--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -7277,7 +7277,7 @@ void arangodb::aql::spliceSubqueriesRule(Optimizer* opt, std::unique_ptr<Executi
     auto sq = ExecutionNode::castTo<SubqueryNode*>(n);
 
     // insert a SubqueryStartNode before the SubqueryNode
-    SubqueryStartNode* start = new SubqueryStartNode(plan.get(), plan->nextId());
+    SubqueryStartNode* start = new SubqueryStartNode(plan.get(), plan->nextId(), sq->outVariable());
     plan->registerNode(start);
     plan->insertBefore(sq, start);
 

--- a/arangod/Aql/SubqueryStartExecutionNode.cpp
+++ b/arangod/Aql/SubqueryStartExecutionNode.cpp
@@ -41,7 +41,9 @@ namespace aql {
 
 SubqueryStartNode::SubqueryStartNode(ExecutionPlan* plan,
                                      arangodb::velocypack::Slice const& base)
-    : ExecutionNode(plan, base) {}
+    : ExecutionNode(plan, base) {
+  // On purpose exclude the _subqueryOutVariable
+}
 
 CostEstimate SubqueryStartNode::estimateCost() const {
   TRI_ASSERT(!_dependencies.empty());
@@ -53,6 +55,11 @@ CostEstimate SubqueryStartNode::estimateCost() const {
 void SubqueryStartNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
                                            std::unordered_set<ExecutionNode const*>& seen) const {
   ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
+  // We need this for the Explainer
+  if (_subqueryOutVariable != nullptr) {
+    nodes.add(VPackValue("subqueryOutVariable"));
+    _subqueryOutVariable->toVelocyPack(nodes);
+  }
   nodes.close();
 }
 
@@ -70,23 +77,30 @@ std::unique_ptr<ExecutionBlock> SubqueryStartNode::createBlock(
                       getRegisterPlan()->nrRegs[previousNode->getDepth()],
                       getRegisterPlan()->nrRegs[getDepth()], getRegsToClear(),
                       calcRegsToKeep());
+  // On purpose exclude the _subqueryOutVariable
   return std::make_unique<ExecutionBlockImpl<SubqueryStartExecutor>>(&engine, this,
                                                                      std::move(infos));
 }
 
 ExecutionNode* SubqueryStartNode::clone(ExecutionPlan* plan, bool withDependencies,
                                         bool withProperties) const {
-  auto c = std::make_unique<SubqueryStartNode>(plan, _id);
+  // On purpose exclude the _subqueryOutVariable
+  auto c = std::make_unique<SubqueryStartNode>(plan, _id, nullptr);
   return cloneHelper(std::move(c), withDependencies, withProperties);
 }
 
 bool SubqueryStartNode::isEqualTo(ExecutionNode const& other) const {
+  // On purpose exclude the _subqueryOutVariable
   try {
     SubqueryStartNode const& p = dynamic_cast<SubqueryStartNode const&>(other);
     return ExecutionNode::isEqualTo(p);
   } catch (const std::bad_cast&) {
     return false;
   }
+}
+
+Variable const* SubqueryStartNode::subqueryOutVariable() const {
+  return _subqueryOutVariable;
 }
 
 }  // namespace aql

--- a/arangod/Aql/SubqueryStartExecutionNode.cpp
+++ b/arangod/Aql/SubqueryStartExecutionNode.cpp
@@ -41,8 +41,9 @@ namespace aql {
 
 SubqueryStartNode::SubqueryStartNode(ExecutionPlan* plan,
                                      arangodb::velocypack::Slice const& base)
-    : ExecutionNode(plan, base) {
+    : ExecutionNode(plan, base), _subqueryOutVariable(nullptr) {
   // On purpose exclude the _subqueryOutVariable
+  // A query cannot be explained after nodes have been serialized and deserialized
 }
 
 CostEstimate SubqueryStartNode::estimateCost() const {
@@ -97,10 +98,6 @@ bool SubqueryStartNode::isEqualTo(ExecutionNode const& other) const {
   } catch (const std::bad_cast&) {
     return false;
   }
-}
-
-Variable const* SubqueryStartNode::subqueryOutVariable() const {
-  return _subqueryOutVariable;
 }
 
 }  // namespace aql

--- a/arangod/Aql/SubqueryStartExecutionNode.h
+++ b/arangod/Aql/SubqueryStartExecutionNode.h
@@ -30,13 +30,16 @@
 namespace arangodb {
 namespace aql {
 
+struct Variable;
+
 class SubqueryStartNode : public ExecutionNode {
   friend class ExecutionNode;
   friend class ExecutionBlock;
 
  public:
   SubqueryStartNode(ExecutionPlan*, arangodb::velocypack::Slice const& base);
-  SubqueryStartNode(ExecutionPlan* plan, size_t id) : ExecutionNode(plan, id) {}
+  SubqueryStartNode(ExecutionPlan* plan, size_t id, Variable const* subqueryOutVariable)
+      : ExecutionNode(plan, id), _subqueryOutVariable(subqueryOutVariable) {}
 
   CostEstimate estimateCost() const override final;
 
@@ -53,6 +56,13 @@ class SubqueryStartNode : public ExecutionNode {
                        bool withProperties) const override final;
 
   bool isEqualTo(ExecutionNode const& other) const override final;
+
+  /// @brief This is only required for Explain output.
+  ///        it has no practical usage other then to print this information during explain.
+  Variable const* subqueryOutVariable() const;
+
+ private:
+  Variable const* _subqueryOutVariable;
 };
 
 }  // namespace aql

--- a/arangod/Aql/SubqueryStartExecutionNode.h
+++ b/arangod/Aql/SubqueryStartExecutionNode.h
@@ -57,11 +57,9 @@ class SubqueryStartNode : public ExecutionNode {
 
   bool isEqualTo(ExecutionNode const& other) const override final;
 
+ private:
   /// @brief This is only required for Explain output.
   ///        it has no practical usage other then to print this information during explain.
-  Variable const* subqueryOutVariable() const;
-
- private:
   Variable const* _subqueryOutVariable;
 };
 

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -1464,6 +1464,12 @@ function processQuery(query, explain, planIndex) {
         return keyword('RETURN') + ' ' + variableName(node.inVariable);
       case 'SubqueryNode':
         return keyword('LET') + ' ' + variableName(node.outVariable) + ' = ...   ' + annotation('/* ' + (node.isConst ? 'const ' : '') + 'subquery */');
+      case 'SubqueryStartNode':
+        // TODO
+        return `${keyword('LET')}  = ... ` ;
+      case 'SubqueryEndNode':
+        // TODO
+        return `... end` ;
       case 'InsertNode': {
         modificationFlags = node.modificationFlags;
         let restrictString = '';
@@ -1662,8 +1668,11 @@ function processQuery(query, explain, planIndex) {
     usedVariables = {};
     currentNode = node.id;
     isConst = true;
-    if (node.type === 'SubqueryNode') {
+    if (node.type === 'SubqueryNode' || node.type === 'SubqueryStartNode') {
       subqueries.push(level);
+    }
+    if (node.type === 'SubqueryEndNode' && subqueries.length > 0) {
+      level = subqueries.pop();
     }
   };
 
@@ -1676,6 +1685,7 @@ function processQuery(query, explain, planIndex) {
       'IndexRangeNode',
       'IndexNode',
       'TraversalNode',
+      'SubqueryStartNode',
       'SubqueryNode'].indexOf(node.type) !== -1) {
       level++;
     } else if (isLeafNode && subqueries.length > 0) {

--- a/tests/Aql/ExecutionNodeTest.cpp
+++ b/tests/Aql/ExecutionNodeTest.cpp
@@ -59,7 +59,7 @@ TEST_F(ExecutionNodeTest, start_node_velocypack_roundtrip) {
   std::unique_ptr<SubqueryStartNode> node, nodeFromVPack;
   std::unordered_set<ExecutionNode const*> seen{};
 
-  node = std::make_unique<SubqueryStartNode>(&plan, 0);
+  node = std::make_unique<SubqueryStartNode>(&plan, 0, nullptr);
 
   builder.openArray();
   node->toVelocyPackHelper(builder, ExecutionNode::SERIALIZE_DETAILS, seen);
@@ -75,8 +75,8 @@ TEST_F(ExecutionNodeTest, start_node_velocypack_roundtrip) {
 TEST_F(ExecutionNodeTest, start_node_not_equal_different_id) {
   std::unique_ptr<SubqueryStartNode> node1, node2;
 
-  node1 = std::make_unique<SubqueryStartNode>(&plan, 0);
-  node2 = std::make_unique<SubqueryStartNode>(&plan, 1);
+  node1 = std::make_unique<SubqueryStartNode>(&plan, 0, nullptr);
+  node2 = std::make_unique<SubqueryStartNode>(&plan, 1, nullptr);
 
   ASSERT_FALSE(node1->isEqualTo(*node2));
 }


### PR DESCRIPTION
Modified Explain to be able to print spliced (optimized) subqueries within the Explain out.
Unfortunately I had to add an additional variable to the Subquery Start Node, this has potential to be dumped again later. The variable has no "Production" semantics.


Jenkins:
http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/6816/

Non-spliced subquery:


    Query String (94 chars, cacheable: true):
     FOR x IN 1..2 LET y = (FOR z IN 1..2 LET a = (FOR b IN 1..2 RETURN b) RETURN [x,z,a]) RETURN y
    
    Execution plan:
     Id   NodeType            Est.   Comment
      1   SingletonNode          1   * ROOT
      2   CalculationNode        1     - LET #9 = 1 .. 2   /* range */   /* simple expression */
      3   EnumerateListNode      2     - FOR x IN #9   /* list iteration */
     14   SubqueryNode           2       - LET y = ...   /* subquery */
      4   SingletonNode          1         * ROOT
      5   CalculationNode        1           - LET #11 = 1 .. 2   /* range */   /* simple expression */
      6   EnumerateListNode      2           - FOR z IN #11   /* list iteration */
     11   SubqueryNode           2             - LET a = ...   /* const subquery */
      7   SingletonNode          1               * ROOT
      8   CalculationNode        1                 - LET #13 = 1 .. 2   /* range */   /* simple expression */
      9   EnumerateListNode      2                 - FOR b IN #13   /* list iteration */
     10   ReturnNode             2                   - RETURN b
     12   CalculationNode        2             - LET #15 = [ x, z, a ]   /* simple expression */
     13   ReturnNode             2             - RETURN #15
     15   ReturnNode             2       - RETURN y
    
    Indexes used:
     none
    
    Optimization rules applied:
     none

Spliced subquery:

    Query String (94 chars, cacheable: true):
     FOR x IN 1..2 LET y = (FOR z IN 1..2 LET a = (FOR b IN 1..2 RETURN b) RETURN [x,z,a]) RETURN y
    
    Execution plan:
     Id   NodeType            Est.   Comment
      1   SingletonNode          1   * ROOT
      2   CalculationNode        1     - LET #9 = 1 .. 2   /* range */   /* simple expression */
      3   EnumerateListNode      2     - FOR x IN #9   /* list iteration */
     16   SubqueryStartNode      2       - LET y = ( /* subquery begin */
      5   CalculationNode        2         - LET #11 = 1 .. 2   /* range */   /* simple expression */
      6   EnumerateListNode      4         - FOR z IN #11   /* list iteration */
     18   SubqueryStartNode      4           - LET a = ( /* subquery begin */
      8   CalculationNode        4             - LET #13 = 1 .. 2   /* range */   /* simple expression */
      9   EnumerateListNode      8             - FOR b IN #13   /* list iteration */
     10   ReturnNode             8               - RETURN b
     19   SubqueryEndNode        8           - ) /* subquery end */
     12   CalculationNode        8           - LET #15 = [ x, z, a ]   /* simple expression */
     13   ReturnNode             8           - RETURN #15
     17   SubqueryEndNode        8       - ) /* subquery end */
     15   ReturnNode             8       - RETURN y
    
    Indexes used:
     none

    Optimization rules applied:
     Id   RuleName
      1   splice-subqueries

NOTE:
The estimated cost is different.
The non-optimized code prints cost within subqueries only for one round trip, and exposes only the total mount of executed subqueries to the following nodes
The optimized code prints cost assumptions accumulated for all subquery executions.

Need discussion if we want to adapt this or not.