### PR TITLE
url-encode and -decode in place

### DIFF
--- a/3rdParty/fuerte/src/HttpConnection.cpp
+++ b/3rdParty/fuerte/src/HttpConnection.cpp
@@ -276,23 +276,23 @@ std::string HttpConnection<ST>::buildRequestBody(Request const& req) {
   // construct request path ("/_db/<name>/" prefix)
   if (!req.header.database.empty()) {
     header.append("/_db/");
-    header.append(http::urlEncode(req.header.database));
+    http::urlEncode(header, req.header.database);
   }
   // must start with /, also turns /_db/abc into /_db/abc/
   if (req.header.path.empty() || req.header.path[0] != '/') {
     header.push_back('/');
   }
 
-  if (req.header.parameters.empty()) {
-    header.append(req.header.path);
-  } else {
-    header.append(req.header.path);
+  header.append(req.header.path);
+  if (!req.header.parameters.empty()) {
     header.push_back('?');
     for (auto const& p : req.header.parameters) {
       if (header.back() != '?') {
         header.push_back('&');
       }
-      header.append(http::urlEncode(p.first) + "=" + http::urlEncode(p.second));
+      http::urlEncode(header, p.first);
+      header.push_back('=');
+      http::urlEncode(header, p.second);
     }
   }
   header.append(" HTTP/1.1\r\n")

--- a/3rdParty/fuerte/src/http.h
+++ b/3rdParty/fuerte/src/http.h
@@ -46,12 +46,34 @@ struct RequestItem {
   }
 };
 
-std::string urlDecode(std::string const& str);
-std::string urlEncode(char const* src, size_t const len);
-std::string urlEncode(char const* src);
+/// url-decodes [src, src+len) into out
+void urlDecode(std::string& out, char const* src, size_t len);
 
+/// url-decodes str into out - convenience function
+inline void urlDecode(std::string& out, std::string const& str) {
+  return urlDecode(out, str.data(), str.size());
+}
+
+/// url-decodes str and returns it - convenience function
+inline std::string urlDecode(std::string const& str) {
+  std::string result;
+  urlDecode(result, str.c_str(), str.size());
+  return result;
+}
+
+/// url-encodes [src, src+len) into out
+void urlEncode(std::string& out, char const* src, size_t len);
+
+/// url-encodes str into out - convenience function
+inline void urlEncode(std::string& out, std::string const& str) {
+  return urlEncode(out, str.data(), str.size());
+}
+
+/// url-encodes str and returns it - convenience function
 inline std::string urlEncode(std::string const& str) {
-  return urlEncode(str.c_str(), str.size());
+  std::string result;
+  urlEncode(result, str.c_str(), str.size());
+  return result;
 }
 }}}}  // namespace arangodb::fuerte::v1::http
 #endif


### PR DESCRIPTION
### Scope & Purpose

Avoid temporary strings & copying when url-encoding and url-decoding parameters in fuerte.

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.
If fuerte request header parameters are used (soonish, will be introduced by PR https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/6826/), the url-encoding and decoding code in this PR will be tested implicitly.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6827/