### PR TITLE
added http_webif to oskar blacklist

### DIFF
--- a/UnitTests/OskarTestSuitesBlackList
+++ b/UnitTests/OskarTestSuitesBlackList
@@ -12,3 +12,4 @@ resilience_transactions
 paths_server
 wal_cleanup
 hot_backup
+http_webif


### PR DESCRIPTION
new `http_webif suite` added to oskar blacklist for 3.3 (as it does not exist there) 