### PR TITLE
added http_webif to oskar blacklist

### DIFF
--- a/UnitTests/OskarTestSuitesBlackList
+++ b/UnitTests/OskarTestSuitesBlackList
@@ -7,3 +7,4 @@ audit_server
 resilience_transactions
 paths_server
 hot_backup
+http_webif


### PR DESCRIPTION
new `http_webif suite` added to oskar blacklist for 3.3 (as it does not exist there) 