### PR TITLE
added http_webif to oskar blacklist

### DIFF
--- a/UnitTests/OskarTestSuitesBlackList
+++ b/UnitTests/OskarTestSuitesBlackList
@@ -1,3 +1,4 @@
 upgrade_data_3.2.*
 upgrade_data_3.3.*
 audit
+http_webif


### PR DESCRIPTION
new `http_webif suite` added to oskar blacklist for 3.3 (as it does not exist there) 