### PR TITLE
set `_pos` when creating a Builder using a shared_ptr<Buffer>

### DIFF
--- a/3rdParty/velocypack/src/Builder.cpp
+++ b/3rdParty/velocypack/src/Builder.cpp
@@ -152,6 +152,7 @@ Builder::Builder(std::shared_ptr<Buffer<uint8_t>> const& buffer, Options const* 
     throw Exception(Exception::InternalError, "Buffer cannot be a nullptr");
   }
   _start = _bufferPtr->data();
+  _pos = _bufferPtr->size();
 
   if (VELOCYPACK_UNLIKELY(options == nullptr)) {
     throw Exception(Exception::InternalError, "Options cannot be a nullptr");


### PR DESCRIPTION
### Scope & Purpose

Set `_pos` properly when creating a Builder from a shared_ptr<Buffer>

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

- [x] There are tests in an external testing repository (i.e. node-resilience tests, chaos tests): arangodb/velocypack
- [x] I ensured this code runs with ASan / TSan or other static verification tools

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6895/