### PR TITLE
vale, vamos a ver!

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Added AQL optimizer rule "move-filters-into-enumerate", to allow for
+  early pruning of non-matching documents while full-scanning or index-
+  scanning documents. This optimization can help to avoid a lot of
+  temporary document copies.
+
 * Allow collection names to be at most 256 characters long, instead of 64 characters
   in previous versions.
 

--- a/arangod/Aql/DocumentProducingHelper.cpp
+++ b/arangod/Aql/DocumentProducingHelper.cpp
@@ -71,14 +71,14 @@ void aql::handleProjections(std::vector<std::pair<ProjectionType, std::string>> 
   }
 }
 
-template <bool checkUniqueness>
-DocumentProducingFunction aql::getCallback(DocumentProducingCallbackVariant::WithProjectionsNotCoveredByIndex,
-                                           DocumentProducingFunctionContext& context) {
+template <bool checkUniqueness, bool skip>
+IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVariant::WithProjectionsNotCoveredByIndex,
+                                                 DocumentProducingFunctionContext& context) {
   return [&context](LocalDocumentId const& token, VPackSlice slice) {
     if (checkUniqueness) {
       if (!context.checkUniqueness(token)) {
         // Document already found, skip it
-        return;
+        return false;
       }
     }
     
@@ -87,8 +87,12 @@ DocumentProducingFunction aql::getCallback(DocumentProducingCallbackVariant::Wit
     if (context.hasFilter()) {
       if (!context.checkFilter(slice)) {
         context.incrFiltered();
-        return;
+        return false;
       }
+    }
+
+    if (skip) {
+      return true;
     }
 
     InputAqlItemRow const& input = context.getInputRow();
@@ -109,17 +113,19 @@ DocumentProducingFunction aql::getCallback(DocumentProducingCallbackVariant::Wit
     output.moveValueInto(registerId, input, guard);
     TRI_ASSERT(output.produced());
     output.advanceRow();
+
+    return true;
   };
 }
 
-template <bool checkUniqueness>
-DocumentProducingFunction aql::getCallback(DocumentProducingCallbackVariant::DocumentWithRawPointer,
-                                           DocumentProducingFunctionContext& context) {
+template <bool checkUniqueness, bool skip>
+IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVariant::DocumentWithRawPointer,
+                                                 DocumentProducingFunctionContext& context) {
   return [&context](LocalDocumentId const& token, VPackSlice slice) {
     if (checkUniqueness) {
       if (!context.checkUniqueness(token)) {
         // Document already found, skip it
-        return;
+        return false;
       }
     }
 
@@ -128,8 +134,12 @@ DocumentProducingFunction aql::getCallback(DocumentProducingCallbackVariant::Doc
     if (context.hasFilter()) {
       if (!context.checkFilter(slice)) {
         context.incrFiltered();
-        return;
+        return false;
       }
+    }
+    
+    if (skip) {
+      return true;
     }
 
     InputAqlItemRow const& input = context.getInputRow();
@@ -143,17 +153,19 @@ DocumentProducingFunction aql::getCallback(DocumentProducingCallbackVariant::Doc
     output.moveValueInto(registerId, input, guard);
     TRI_ASSERT(output.produced());
     output.advanceRow();
+
+    return true;
   };
 }
 
-template <bool checkUniqueness>
-DocumentProducingFunction aql::getCallback(DocumentProducingCallbackVariant::DocumentCopy,
-                                           DocumentProducingFunctionContext& context) {
+template <bool checkUniqueness, bool skip>
+IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVariant::DocumentCopy,
+                                                 DocumentProducingFunctionContext& context) {
   return [&context](LocalDocumentId const& token, VPackSlice slice) {
     if (checkUniqueness) {
       if (!context.checkUniqueness(token)) {
         // Document already found, skip it
-        return;
+        return false;
       }
     }
     
@@ -162,8 +174,12 @@ DocumentProducingFunction aql::getCallback(DocumentProducingCallbackVariant::Doc
     if (context.hasFilter()) {
       if (!context.checkFilter(slice)) {
         context.incrFiltered();
-        return;
+        return false;
       }
+    }
+    
+    if (skip) {
+      return true;
     }
 
     InputAqlItemRow const& input = context.getInputRow();
@@ -178,16 +194,18 @@ DocumentProducingFunction aql::getCallback(DocumentProducingCallbackVariant::Doc
     output.moveValueInto(registerId, input, guard);
     TRI_ASSERT(output.produced());
     output.advanceRow();
+
+    return true;
   };
 }
 
-template <bool checkUniqueness>
-DocumentProducingFunction aql::buildCallback(DocumentProducingFunctionContext& context) {
-  if (!context.getProduceResult()) {
+template <bool checkUniqueness, bool skip>
+IndexIterator::DocumentCallback aql::buildDocumentCallback(DocumentProducingFunctionContext& context) {
+  if (!skip && !context.getProduceResult()) {
     // This callback is disallowed use getNullCallback instead
     TRI_ASSERT(false);
-    return [](LocalDocumentId const&, VPackSlice slice) {
-      THROW_ARANGO_EXCEPTION(TRI_ERROR_INTERNAL);
+    return [](LocalDocumentId const&, VPackSlice slice) -> bool {
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "invalid callback");
     };
   }
     
@@ -195,33 +213,33 @@ DocumentProducingFunction aql::buildCallback(DocumentProducingFunctionContext& c
     // return a projection
     if (!context.getCoveringIndexAttributePositions().empty()) {
       // projections from an index value (covering index)
-      return getCallback<checkUniqueness>(DocumentProducingCallbackVariant::WithProjectionsCoveredByIndex{},
-                                          context);
+      return getCallback<checkUniqueness, skip>(DocumentProducingCallbackVariant::WithProjectionsCoveredByIndex{},
+                                                context);
     } else {
       // projections from a "real" document
-      return getCallback<checkUniqueness>(DocumentProducingCallbackVariant::WithProjectionsNotCoveredByIndex{},
-                                          context);
+      return getCallback<checkUniqueness, skip>(DocumentProducingCallbackVariant::WithProjectionsNotCoveredByIndex{},
+                                                context);
     }
   }
 
   // return the document as is
   if (context.getUseRawDocumentPointers()) {
-    return getCallback<checkUniqueness>(DocumentProducingCallbackVariant::DocumentWithRawPointer{},
-                                        context);
+    return getCallback<checkUniqueness, skip>(DocumentProducingCallbackVariant::DocumentWithRawPointer{},
+                                              context);
   } else {
-    return getCallback<checkUniqueness>(DocumentProducingCallbackVariant::DocumentCopy{}, context);
+    return getCallback<checkUniqueness, skip>(DocumentProducingCallbackVariant::DocumentCopy{}, context);
   }
 }
 
 template <bool checkUniqueness>
-std::function<void(LocalDocumentId const& token)> aql::getNullCallback(DocumentProducingFunctionContext& context) {
+std::function<bool(LocalDocumentId const& token)> aql::getNullCallback(DocumentProducingFunctionContext& context) {
   return [&context](LocalDocumentId const& token) {
     TRI_ASSERT(!context.hasFilter());
 
     if (checkUniqueness) {
       if (!context.checkUniqueness(token)) {
         // Document already found, skip it
-        return;
+        return false;
       }
     }
     
@@ -235,6 +253,8 @@ std::function<void(LocalDocumentId const& token)> aql::getNullCallback(DocumentP
     output.cloneValueInto(registerId, input, AqlValue(AqlValueHintNull()));
     TRI_ASSERT(output.produced());
     output.advanceRow();
+
+    return true;
   };
 }
 
@@ -378,14 +398,14 @@ bool DocumentProducingFunctionContext::hasFilter() const noexcept {
   return _filter != nullptr;
 }
 
-template <bool checkUniqueness>
-DocumentProducingFunction aql::getCallback(DocumentProducingCallbackVariant::WithProjectionsCoveredByIndex,
-                                           DocumentProducingFunctionContext& context) {
+template <bool checkUniqueness, bool skip>
+IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVariant::WithProjectionsCoveredByIndex,
+                                                 DocumentProducingFunctionContext& context) {
   return [&context](LocalDocumentId const& token, VPackSlice slice) {
     if (checkUniqueness) {
       if (!context.checkUniqueness(token)) {
         // Document already found, skip it
-        return;
+        return false;
       }
     }
    
@@ -393,7 +413,7 @@ DocumentProducingFunction aql::getCallback(DocumentProducingCallbackVariant::Wit
     if (checkFilter && !context.getAllowCoveringIndexOptimization()) {
       if (!context.checkFilter(slice)) {
         context.incrFiltered();
-        return;
+        return false;
       }
       // no need to check later again
       checkFilter = false;
@@ -448,7 +468,7 @@ DocumentProducingFunction aql::getCallback(DocumentProducingCallbackVariant::Wit
       
     if (checkFilter && !context.checkFilter(b->slice())) {
       context.incrFiltered();
-      return;
+      return false;
     }
 
     AqlValue v(b.get());
@@ -458,23 +478,35 @@ DocumentProducingFunction aql::getCallback(DocumentProducingCallbackVariant::Wit
     TRI_ASSERT(output.produced());
     output.advanceRow();
     context.incrScanned();
+
+    return true;
   };
 }
 
-template DocumentProducingFunction aql::getCallback<false>(DocumentProducingCallbackVariant::WithProjectionsCoveredByIndex, DocumentProducingFunctionContext& context);
-template DocumentProducingFunction aql::getCallback<true>(DocumentProducingCallbackVariant::WithProjectionsCoveredByIndex, DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::getCallback<false, false>(DocumentProducingCallbackVariant::WithProjectionsCoveredByIndex, DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::getCallback<true, false>(DocumentProducingCallbackVariant::WithProjectionsCoveredByIndex, DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::getCallback<false, true>(DocumentProducingCallbackVariant::WithProjectionsCoveredByIndex, DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::getCallback<true, true>(DocumentProducingCallbackVariant::WithProjectionsCoveredByIndex, DocumentProducingFunctionContext& context);
 
-template DocumentProducingFunction aql::getCallback<false>(DocumentProducingCallbackVariant::WithProjectionsNotCoveredByIndex, DocumentProducingFunctionContext& context);
-template DocumentProducingFunction aql::getCallback<true>(DocumentProducingCallbackVariant::WithProjectionsNotCoveredByIndex, DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::getCallback<false, false>(DocumentProducingCallbackVariant::WithProjectionsNotCoveredByIndex, DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::getCallback<true, false>(DocumentProducingCallbackVariant::WithProjectionsNotCoveredByIndex, DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::getCallback<false, true>(DocumentProducingCallbackVariant::WithProjectionsNotCoveredByIndex, DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::getCallback<true, true>(DocumentProducingCallbackVariant::WithProjectionsNotCoveredByIndex, DocumentProducingFunctionContext& context);
 
-template DocumentProducingFunction aql::getCallback<false>(DocumentProducingCallbackVariant::DocumentWithRawPointer, DocumentProducingFunctionContext& context);
-template DocumentProducingFunction aql::getCallback<true>(DocumentProducingCallbackVariant::DocumentWithRawPointer, DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::getCallback<false, false>(DocumentProducingCallbackVariant::DocumentWithRawPointer, DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::getCallback<true, false>(DocumentProducingCallbackVariant::DocumentWithRawPointer, DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::getCallback<false, true>(DocumentProducingCallbackVariant::DocumentWithRawPointer, DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::getCallback<true, true>(DocumentProducingCallbackVariant::DocumentWithRawPointer, DocumentProducingFunctionContext& context);
 
-template DocumentProducingFunction aql::getCallback<false>(DocumentProducingCallbackVariant::DocumentCopy, DocumentProducingFunctionContext& context);
-template DocumentProducingFunction aql::getCallback<true>(DocumentProducingCallbackVariant::DocumentCopy, DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::getCallback<false, false>(DocumentProducingCallbackVariant::DocumentCopy, DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::getCallback<true, false>(DocumentProducingCallbackVariant::DocumentCopy, DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::getCallback<false, true>(DocumentProducingCallbackVariant::DocumentCopy, DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::getCallback<true, true>(DocumentProducingCallbackVariant::DocumentCopy, DocumentProducingFunctionContext& context);
 
-template std::function<void(LocalDocumentId const& token)> aql::getNullCallback<false>(DocumentProducingFunctionContext& context);
-template std::function<void(LocalDocumentId const& token)> aql::getNullCallback<true>(DocumentProducingFunctionContext& context);
+template IndexIterator::LocalDocumentIdCallback aql::getNullCallback<false>(DocumentProducingFunctionContext& context);
+template IndexIterator::LocalDocumentIdCallback aql::getNullCallback<true>(DocumentProducingFunctionContext& context);
 
-template DocumentProducingFunction aql::buildCallback<false>(DocumentProducingFunctionContext& context);
-template DocumentProducingFunction aql::buildCallback<true>(DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::buildDocumentCallback<false, false>(DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::buildDocumentCallback<true, false>(DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::buildDocumentCallback<false, true>(DocumentProducingFunctionContext& context);
+template IndexIterator::DocumentCallback aql::buildDocumentCallback<true, true>(DocumentProducingFunctionContext& context);

--- a/arangod/Aql/EnumerateCollectionExecutor.cpp
+++ b/arangod/Aql/EnumerateCollectionExecutor.cpp
@@ -146,8 +146,9 @@ EnumerateCollectionExecutor::EnumerateCollectionExecutor(Fetcher& fetcher, Infos
                                        std::to_string(maxWait) + ")");
   }
   if (_infos.getProduceResult()) {
-    this->setProducingFunction(buildCallback<false>(_documentProducingFunctionContext));
+    _documentProducer = buildDocumentCallback<false, false>(_documentProducingFunctionContext);
   }
+  _documentSkipper = buildDocumentCallback<false, true>(_documentProducingFunctionContext);
 }
 
 EnumerateCollectionExecutor::~EnumerateCollectionExecutor() = default;
@@ -220,12 +221,12 @@ std::tuple<ExecutionState, EnumerateCollectionStats, size_t> EnumerateCollection
     std::tie(_state, _input) = _fetcher.fetchRow();
 
     if (_state == ExecutionState::WAITING) {
-      return std::make_tuple(_state, stats, 0);  // tupple, cannot use initializer list due to build failure
+      return std::make_tuple(_state, stats, 0);  // tuple, cannot use initializer list due to build failure
     }
 
     if (!_input) {
       TRI_ASSERT(_state == ExecutionState::DONE);
-      return std::make_tuple(_state, stats, 0);  // tupple, cannot use initializer list due to build failure
+      return std::make_tuple(_state, stats, 0);  // tuple, cannot use initializer list due to build failure
     }
 
     _cursor->reset();
@@ -233,18 +234,31 @@ std::tuple<ExecutionState, EnumerateCollectionStats, size_t> EnumerateCollection
   }
 
   TRI_ASSERT(_input.isInitialized());
+  TRI_ASSERT(_documentProducingFunctionContext.getAndResetNumScanned() == 0);
+  TRI_ASSERT(_documentProducingFunctionContext.getAndResetNumFiltered() == 0);
 
   uint64_t actuallySkipped = 0;
-  _cursor->skip(toSkip, actuallySkipped);
+  if (_infos.getFilter() == nullptr) {
+    _cursor->skip(toSkip, actuallySkipped);
+    stats.incrScanned(actuallySkipped);
+    _documentProducingFunctionContext.getAndResetNumScanned();
+  } else {
+    _cursor->nextDocument(_documentSkipper, toSkip);
+    size_t filtered = _documentProducingFunctionContext.getAndResetNumFiltered();
+    size_t scanned = _documentProducingFunctionContext.getAndResetNumScanned();
+    TRI_ASSERT(scanned >= filtered);
+    stats.incrFiltered(filtered);
+    stats.incrScanned(scanned);
+    actuallySkipped = scanned - filtered;
+  }
   _cursorHasMore = _cursor->hasMore();
-  stats.incrScanned(actuallySkipped);
 
   if (_state == ExecutionState::DONE && !_cursorHasMore) {
     return std::make_tuple(ExecutionState::DONE, stats,
-                           actuallySkipped);  // tupple, cannot use initializer list due to build failure
+                           actuallySkipped);  // tuple, cannot use initializer list due to build failure
   }
 
-  return std::make_tuple(ExecutionState::HASMORE, stats, actuallySkipped);  // tupple, cannot use initializer list due to build failure
+  return std::make_tuple(ExecutionState::HASMORE, stats, actuallySkipped);  // tuple, cannot use initializer list due to build failure
 }
 
 void EnumerateCollectionExecutor::initializeCursor() {
@@ -253,10 +267,6 @@ void EnumerateCollectionExecutor::initializeCursor() {
   setAllowCoveringIndexOptimization(true);
   _cursorHasMore = false;
   _cursor->reset();
-}
-
-void EnumerateCollectionExecutor::setProducingFunction(DocumentProducingFunction const& documentProducer) {
-  _documentProducer = documentProducer;
 }
 
 void EnumerateCollectionExecutor::setAllowCoveringIndexOptimization(bool const allowCoveringIndexOptimization) {

--- a/arangod/Aql/EnumerateCollectionExecutor.h
+++ b/arangod/Aql/EnumerateCollectionExecutor.h
@@ -129,8 +129,6 @@ class EnumerateCollectionExecutor {
   std::pair<ExecutionState, Stats> produceRows(OutputAqlItemRow& output);
   std::tuple<ExecutionState, EnumerateCollectionStats, size_t> skipRows(size_t atMost);
 
-  void setProducingFunction(DocumentProducingFunction const& documentProducer);
-
   void initializeCursor();
 
  private:
@@ -145,7 +143,8 @@ class EnumerateCollectionExecutor {
  private:
   Infos& _infos;
   Fetcher& _fetcher;
-  DocumentProducingFunction _documentProducer;
+  IndexIterator::DocumentCallback _documentProducer;
+  IndexIterator::DocumentCallback _documentSkipper;
   DocumentProducingFunctionContext _documentProducingFunctionContext;
   ExecutionState _state;
   bool _cursorHasMore;

--- a/arangod/Aql/IResearchViewExecutor.cpp
+++ b/arangod/Aql/IResearchViewExecutor.cpp
@@ -233,6 +233,7 @@ IndexIterator::DocumentCallback IResearchViewExecutorBase<Impl, Traits>::ReadCon
           bool mustDestroy = true;
           AqlValueGuard guard{a, mustDestroy};
           ctx.outputRow.moveValueInto(ctx.docOutReg, ctx.inputRow, guard);
+          return true;
         };
       },
 
@@ -243,6 +244,7 @@ IndexIterator::DocumentCallback IResearchViewExecutorBase<Impl, Traits>::ReadCon
           bool mustDestroy = true;
           AqlValueGuard guard{a, mustDestroy};
           ctx.outputRow.moveValueInto(ctx.docOutReg, ctx.inputRow, guard);
+          return true;
         };
       }};
 

--- a/arangod/Aql/IndexExecutor.cpp
+++ b/arangod/Aql/IndexExecutor.cpp
@@ -269,23 +269,19 @@ IndexExecutor::CursorReader::CursorReader(IndexExecutorInfos const& infos,
       _index(index),
       _cursor(std::make_unique<OperationCursor>(infos.getTrxPtr()->indexScanForCondition(
           index, condition, infos.getOutVariable(), infos.getOptions()))),
+      _context(context),
       _type(!infos.getProduceResult()
                 ? Type::NoResult
                 : _cursor->hasCovering() &&
                           !infos.getCoveringIndexAttributePositions().empty()
                       ? Type::Covering
-                      : Type::Document),
-      _noProduce(nullptr),
-      _produce(nullptr) {
-  auto getNullCallback_ = checkUniqueness ? getNullCallback<true> : getNullCallback<false>;
-  auto buildCallback_ = checkUniqueness ? buildCallback<true> : buildCallback<false>;
+                      : Type::Document) {
   if (_type == Type::NoResult) {
-    _noProduce = getNullCallback_(context);
-    _produce = nullptr;
+    _documentNonProducer = checkUniqueness ? getNullCallback<true>(context) : getNullCallback<false>(context);
   } else {
-    _produce = buildCallback_(context);
-    _noProduce = nullptr;
+    _documentProducer = checkUniqueness ? buildDocumentCallback<true, false>(context) : buildDocumentCallback<false, false>(context);
   }
+  _documentSkipper = checkUniqueness ? buildDocumentCallback<true, true>(context) : buildDocumentCallback<false, true>(context);
 }
 
 IndexExecutor::CursorReader::CursorReader(CursorReader&& other) noexcept
@@ -293,9 +289,11 @@ IndexExecutor::CursorReader::CursorReader(CursorReader&& other) noexcept
       _condition(other._condition),
       _index(other._index),
       _cursor(std::move(other._cursor)),
+      _context(other._context),
       _type(other._type),
-      _noProduce(std::move(other._noProduce)),
-      _produce(std::move(other._produce)) {}
+      _documentNonProducer(std::move(other._documentNonProducer)),
+      _documentProducer(std::move(other._documentProducer)),
+      _documentSkipper(std::move(other._documentSkipper)) {}
 
 bool IndexExecutor::CursorReader::hasMore() const {
   return _cursor != nullptr && _cursor->hasMore();
@@ -317,18 +315,18 @@ bool IndexExecutor::CursorReader::readIndex(OutputAqlItemRow& output) {
   }
   switch (_type) {
     case Type::NoResult:
-      TRI_ASSERT(_noProduce != nullptr);
-      return _cursor->next(_noProduce, output.numRowsLeft());
+      TRI_ASSERT(_documentNonProducer != nullptr);
+      return _cursor->next(_documentNonProducer, output.numRowsLeft());
     case Type::Covering:
-      TRI_ASSERT(_produce != nullptr);
-      return _cursor->nextCovering(_produce, output.numRowsLeft());
+      TRI_ASSERT(_documentProducer != nullptr);
+      return _cursor->nextCovering(_documentProducer, output.numRowsLeft());
     case Type::Document:
-      TRI_ASSERT(_produce != nullptr);
-      return _cursor->nextDocument(_produce, output.numRowsLeft());
+      TRI_ASSERT(_documentProducer != nullptr);
+      return _cursor->nextDocument(_documentProducer, output.numRowsLeft());
   }
   // The switch above is covering all values and this code
   // cannot be reached
-  TRI_ASSERT(false);
+  ADB_UNREACHABLE;
   return false;
 }
 
@@ -390,7 +388,12 @@ size_t IndexExecutor::CursorReader::skipIndex(size_t toSkip) {
   }
 
   uint64_t skipped = 0;
-  _cursor->skip(toSkip, skipped);
+  if (_infos.getFilter() != nullptr) {
+    _cursor->nextDocument(_documentSkipper, toSkip);
+    skipped = _context.getAndResetNumScanned() - _context.getAndResetNumFiltered();
+  } else {
+    _cursor->skip(toSkip, skipped);
+  }
 
   TRI_ASSERT(skipped <= toSkip);
   TRI_ASSERT(skipped == toSkip || !hasMore());
@@ -637,13 +640,13 @@ std::tuple<ExecutionState, IndexExecutor::Stats, size_t> IndexExecutor::skipRows
 
         _skipped = 0;
 
-        return std::make_tuple(_state, stats, skipped);  // tupple, cannot use initializer list due to build failure
+        return std::make_tuple(_state, stats, skipped);  // tuple, cannot use initializer list due to build failure
       }
 
       std::tie(_state, _input) = _fetcher.fetchRow();
 
       if (_state == ExecutionState::WAITING) {
-        return std::make_tuple(_state, stats, 0);  // tupple, cannot use initializer list due to build failure
+        return std::make_tuple(_state, stats, 0);  // tuple, cannot use initializer list due to build failure
       }
 
       if (!_input) {
@@ -652,7 +655,7 @@ std::tuple<ExecutionState, IndexExecutor::Stats, size_t> IndexExecutor::skipRows
 
         _skipped = 0;
 
-        return std::make_tuple(_state, stats, skipped);  // tupple, cannot use initializer list due to build failure
+        return std::make_tuple(_state, stats, skipped);  // tuple, cannot use initializer list due to build failure
       }
 
       initIndexes(_input);
@@ -683,11 +686,11 @@ std::tuple<ExecutionState, IndexExecutor::Stats, size_t> IndexExecutor::skipRows
 
   if (_state == ExecutionState::DONE && !_input) {
     return std::make_tuple(ExecutionState::DONE, stats,
-                           skipped);  // tupple, cannot use initializer list due to build failure
+                           skipped);  // tuple, cannot use initializer list due to build failure
   }
 
   return std::make_tuple(ExecutionState::HASMORE, stats,
-                         skipped);  // tupple, cannot use initializer list due to build failure
+                         skipped);  // tuple, cannot use initializer list due to build failure
 }
 
 IndexExecutor::CursorReader& IndexExecutor::getCursor() {

--- a/arangod/Aql/IndexExecutor.h
+++ b/arangod/Aql/IndexExecutor.h
@@ -179,13 +179,15 @@ class IndexExecutor {
     AstNode const* _condition;
     transaction::Methods::IndexHandle const& _index;
     std::unique_ptr<OperationCursor> _cursor;
+    DocumentProducingFunctionContext& _context;
     Type const _type;
 
-    // Only one of _produce and _noProduce is set at a time, depending on _type.
+    // Only one of _documentProducer and _documentNonProducer is set at a time, depending on _type.
     // As std::function is not trivially destructible, it's safer not to use a
     // union.
-    IndexIterator::LocalDocumentIdCallback _noProduce;
-    DocumentProducingFunction _produce;
+    IndexIterator::LocalDocumentIdCallback _documentNonProducer;
+    IndexIterator::DocumentCallback _documentProducer;
+    IndexIterator::DocumentCallback _documentSkipper;
   };
 
  public:

--- a/arangod/Aql/MaterializeExecutor.cpp
+++ b/arangod/Aql/MaterializeExecutor.cpp
@@ -47,6 +47,7 @@ arangodb::IndexIterator::DocumentCallback MaterializeExecutor::ReadContext::copy
       bool mustDestroy = true;
       arangodb::aql::AqlValueGuard guard{ a, mustDestroy };
       ctx._outputRow->moveValueInto(ctx._infos->outputMaterializedDocumentRegId(), *ctx._inputRow, guard);
+      return true;
     };
   },
 
@@ -61,6 +62,7 @@ arangodb::IndexIterator::DocumentCallback MaterializeExecutor::ReadContext::copy
       bool mustDestroy = true;
       arangodb::aql::AqlValueGuard guard{ a, mustDestroy };
       ctx._outputRow->moveValueInto(ctx._infos->outputMaterializedDocumentRegId(), *ctx._inputRow, guard);
+      return true;
     };
   } };
 

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -7208,12 +7208,6 @@ void arangodb::aql::moveFiltersIntoEnumerateRule(Optimizer* opt, std::unique_ptr
         if (calculations.empty()) {
           break;
         }
-        if (current->hasParentOfType(EN::LIMIT)) {
-          break;
-        }
-        if (current->hasParentOfType(EN::COLLECT)) {
-          break;
-        }
         
         auto filterNode = ExecutionNode::castTo<FilterNode*>(current);
         Variable const* inVariable = filterNode->inVariable();

--- a/arangod/Indexes/IndexIterator.cpp
+++ b/arangod/Indexes/IndexIterator.cpp
@@ -35,15 +35,6 @@ IndexIterator::IndexIterator(LogicalCollection* collection, transaction::Methods
   TRI_ASSERT(_trx != nullptr);
 }
 
-bool IndexIterator::nextDocument(DocumentCallback const& cb, size_t limit) {
-  TRI_ASSERT(_collection != nullptr);
-  return next(
-      [this, &cb](LocalDocumentId const& token) {
-        _collection->readDocumentWithCallback(_trx, token, cb);
-      },
-      limit);
-}
-  
 /// @brief default implementation for rearm
 /// specialized index iterators can implement this method with some
 /// sensible behavior
@@ -54,6 +45,15 @@ bool IndexIterator::rearm(arangodb::aql::AstNode const*,
   THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "requested rearming of an index iterator that does not support it");
 }
 
+bool IndexIterator::nextDocument(DocumentCallback const& cb, size_t limit) {
+  TRI_ASSERT(_collection != nullptr);
+  return next(
+      [this, &cb](LocalDocumentId const& token) {
+        return _collection->readDocumentWithCallback(_trx, token, cb);
+      },
+      limit);
+}
+  
 /// @brief default implementation for nextCovering
 /// specialized index iterators can implement this method with some
 /// sensible behavior
@@ -74,9 +74,10 @@ void IndexIterator::reset() {}
 /// @brief default implementation for skip
 void IndexIterator::skip(uint64_t count, uint64_t& skipped) {
   // Skip the first count-many entries
-  auto cb = [&skipped](LocalDocumentId const&) { ++skipped; };
-  // TODO: Can be improved
-  next(cb, count);
+  next([&skipped](LocalDocumentId const&) { 
+    ++skipped; 
+    return true; 
+  }, count);
 }
 
 /// @brief Get the next elements
@@ -85,8 +86,11 @@ void IndexIterator::skip(uint64_t count, uint64_t& skipped) {
 ///        all iterators are exhausted
 bool MultiIndexIterator::next(LocalDocumentIdCallback const& callback, size_t limit) {
   auto cb = [&limit, &callback](LocalDocumentId const& token) {
-    --limit;
-    callback(token);
+    if (callback(token)) {
+      --limit;
+      return true;
+    }
+    return false;
   };
   while (limit > 0) {
     if (_current == nullptr) {
@@ -111,8 +115,11 @@ bool MultiIndexIterator::next(LocalDocumentIdCallback const& callback, size_t li
 ///        all iterators are exhausted
 bool MultiIndexIterator::nextDocument(DocumentCallback const& callback, size_t limit) {
   auto cb = [&limit, &callback](LocalDocumentId const& token, arangodb::velocypack::Slice slice) {
-    --limit;
-    callback(token, slice);
+    if (callback(token, slice)) {
+      --limit;
+      return true;
+    }
+    return false;
   };
   while (limit > 0) {
     if (_current == nullptr) {
@@ -144,8 +151,11 @@ bool MultiIndexIterator::nextCovering(DocumentCallback const& callback, size_t l
   TRI_ASSERT(hasCovering());
   auto cb = [&limit, &callback](LocalDocumentId const& token,
                                 arangodb::velocypack::Slice slice) {
-    --limit;
-    callback(token, slice);
+    if (callback(token, slice)) {
+      --limit;
+      return true;
+    }
+    return false;
   };
   while (limit > 0) {
     if (_current == nullptr) {

--- a/arangod/Indexes/IndexIterator.h
+++ b/arangod/Indexes/IndexIterator.h
@@ -68,9 +68,9 @@ struct IndexIteratorOptions;
 /// at the index itself
 class IndexIterator {
  public:
-  typedef std::function<void(LocalDocumentId const& token)> LocalDocumentIdCallback;
-  typedef std::function<void(LocalDocumentId const& token, velocypack::Slice doc)> DocumentCallback;
-  typedef std::function<void(LocalDocumentId const& token, velocypack::Slice extra)> ExtraCallback;
+  typedef std::function<bool(LocalDocumentId const& token)> LocalDocumentIdCallback;
+  typedef std::function<bool(LocalDocumentId const& token, velocypack::Slice doc)> DocumentCallback;
+  typedef std::function<bool(LocalDocumentId const& token, velocypack::Slice extra)> ExtraCallback;
 
  public:
   IndexIterator(IndexIterator const&) = delete;

--- a/arangod/MMFiles/MMFilesCollectorThread.cpp
+++ b/arangod/MMFiles/MMFilesCollectorThread.cpp
@@ -665,6 +665,7 @@ void MMFilesCollectorThread::processCollectionMarker(
               wasAdjusted = physical->updateLocalDocumentIdConditional(
                   element.localDocumentId(), walMarker, newPosition, fid, false);
             }
+            return true;
           });
     }
 
@@ -703,6 +704,7 @@ void MMFilesCollectorThread::processCollectionMarker(
               dfi.numberDead++;
               dfi.sizeDead += encoding::alignedSize<int64_t>(datafileMarkerSize);
             }
+            return true;
           });
     }
   }

--- a/arangod/MMFiles/MMFilesGeoIndex.cpp
+++ b/arangod/MMFiles/MMFilesGeoIndex.cpp
@@ -94,11 +94,12 @@ struct NearIterator final : public IndexIterator {
                       (ft == geo::FilterType::CONTAINS && !filter.contains(&test)) ||
                       (ft == geo::FilterType::INTERSECTS && !filter.intersects(&test))) {
                     result = false;  // skip
-                    return;
+                    return false;
                   }
                 }
                 cb(gdoc.token, doc);  // return result
                 result = true;
+                return true;
               })) {
             return false;  // skip
           }
@@ -126,6 +127,7 @@ struct NearIterator final : public IndexIterator {
                   } else {
                     result = true;
                   }
+                  return result;
                 })) {
               return false;
             }

--- a/arangod/MMFiles/MMFilesHashIndex.cpp
+++ b/arangod/MMFiles/MMFilesHashIndex.cpp
@@ -608,6 +608,7 @@ Result MMFilesHashIndex::insertUnique(transaction::Methods* trx,
         _collection.getPhysical()->readDocumentWithCallback(
             trx, rev, [&existingId](LocalDocumentId const&, VPackSlice doc) {
               existingId = doc.get(StaticStrings::KeyString).copyString();
+              return true; // return value does not matter here
             });
 
         if (mode == OperationMode::internal) {

--- a/arangod/MMFiles/MMFilesSkiplistIndex.cpp
+++ b/arangod/MMFiles/MMFilesSkiplistIndex.cpp
@@ -820,8 +820,9 @@ Result MMFilesSkiplistIndex::insert(transaction::Methods& trx,
     std::string existingId;
 
     _collection.getPhysical()->readDocumentWithCallback(
-        &trx, rev, [&existingId](LocalDocumentId const&, velocypack::Slice doc) -> void {
+        &trx, rev, [&existingId](LocalDocumentId const&, velocypack::Slice doc) {
           existingId = doc.get(StaticStrings::KeyString).copyString();
+          return true; // return value does not matter here
         });
 
     if (mode == OperationMode::internal) {

--- a/arangod/Pregel/GraphStore.cpp
+++ b/arangod/Pregel/GraphStore.cpp
@@ -338,11 +338,12 @@ void GraphStore<V, E>::_loadVertices(ShardID const& vertexShard,
     for (ShardID const& edgeShard : edgeShards) {
       _loadEdges(trx, *ventry, edgeShard, documentId, edges, eKeys);
     }
+    return true;
   };
   
   _localVertexCount += numVertices;
   bool hasMore = true;
-  while(hasMore && numVertices > 0) {
+  while (hasMore && numVertices > 0) {
     TRI_ASSERT(segmentSize > 0);
     hasMore = cursor.nextDocument(cb, segmentSize);
     if (_destroyed) {
@@ -442,6 +443,7 @@ void GraphStore<V, E>::_loadEdges(transaction::Methods& trx, Vertex<V, E>& verte
       allocateSpace(toValue.size());
       Edge<E>* edge = edgeBuff->appendElement();
       buildEdge(edge, toValue);
+      return true;
     };
     while (cursor->nextWithExtra(cb, 1000)) {
       if (_destroyed) {
@@ -463,6 +465,7 @@ void GraphStore<V, E>::_loadEdges(transaction::Methods& trx, Vertex<V, E>& verte
       if (res == TRI_ERROR_NO_ERROR) {
         _graphFormat->copyEdgeData(slice, edge->data());
       }
+      return true;
     };
     while (cursor->nextDocument(cb, 1000)) {
       if (_destroyed) {

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -719,6 +719,7 @@ bool RocksDBCollection::lookupRevision(transaction::Methods* trx, VPackSlice con
 
   return readDocumentWithCallback(trx, documentId, [&revisionId](LocalDocumentId const&, VPackSlice doc) {
     revisionId = transaction::helpers::extractRevFromDocument(doc);
+    return true;
   });
 }
 

--- a/arangod/RocksDBEngine/RocksDBGeoIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBGeoIndex.cpp
@@ -100,11 +100,12 @@ class RDBNearIterator final : public IndexIterator {
                       (ft == geo::FilterType::CONTAINS && !filter.contains(&test)) ||
                       (ft == geo::FilterType::INTERSECTS && !filter.intersects(&test))) {
                     result = false;
-                    return;
+                    return false;
                   }
                 }
                 cb(gdoc.token, doc);  // return document
                 result = true;
+                return true;
               })) {
             return false;  // ignore document
           }
@@ -129,7 +130,9 @@ class RDBNearIterator final : public IndexIterator {
                       (ft == geo::FilterType::CONTAINS && !filter.contains(&test)) ||
                       (ft == geo::FilterType::INTERSECTS && !filter.intersects(&test))) {
                     result = false;
+                    return false;
                   }
+                  return true;
                 })) {
               return false;
             }

--- a/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
+++ b/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
@@ -826,6 +826,7 @@ Result handleSyncKeysRocksDB(DatabaseInitialSyncer& syncer,
             col->readDocumentWithCallback(&trx, documentId,
                                           [&docRev](LocalDocumentId const&, VPackSlice doc) {
                                             docRev = TRI_ExtractRevisionId(doc);
+                                            return true;
                                           });
           }
           compareChunk(docKey, docRev);

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -703,6 +703,7 @@ Result RocksDBVPackIndex::insert(transaction::Methods& trx, RocksDBMethods* mthd
         auto success = _collection.getPhysical()->readDocumentWithCallback(&trx, docId,
            [&](LocalDocumentId const&, VPackSlice doc) {
              existingKey = transaction::helpers::extractKeyFromDocument(doc).copyString();
+             return true; // return value does not matter here
            });
         TRI_ASSERT(success);
         

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -1082,6 +1082,7 @@ OperationResult transaction::Methods::anyLocal(std::string const& collectionName
   cursor.nextDocument(
       [&resultBuilder](LocalDocumentId const& token, VPackSlice slice) {
         resultBuilder.add(slice);
+        return true;
       },
       1);
 
@@ -2346,6 +2347,7 @@ OperationResult transaction::Methods::allLocal(std::string const& collectionName
 
   auto cb = [&resultBuilder](LocalDocumentId const& token, VPackSlice slice) {
     resultBuilder.add(slice);
+    return true;
   };
   cursor.allDocuments(cb, 1000);
 

--- a/arangod/V8Server/v8-query.cpp
+++ b/arangod/V8Server/v8-query.cpp
@@ -234,8 +234,9 @@ static void JS_AllQuery(v8::FunctionCallbackInfo<v8::Value> const& args) {
   resultBuilder.openArray();
 
   opCursor.allDocuments(
-      [&resultBuilder](LocalDocumentId const& token, VPackSlice slice) {
+      [&resultBuilder](LocalDocumentId const&, VPackSlice slice) {
         resultBuilder.add(slice);
+        return true;
       },
       1000);
 

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -902,9 +902,10 @@ futures::Future<OperationResult> Collections::revisionId(Context& ctxt) {
     // We directly read the entire cursor. so batchsize == limit
     OperationCursor opCursor(trx.indexScan(cname, transaction::Methods::CursorType::ALL));
 
-    opCursor.allDocuments([&](LocalDocumentId const& token,
-                              VPackSlice doc) { cb(doc.resolveExternal()); },
-                          1000);
+    opCursor.allDocuments([&](LocalDocumentId const&, VPackSlice doc) { 
+      cb(doc.resolveExternal()); 
+      return true;
+    }, 1000);
 
     return trx.finish(res);
   }
@@ -963,7 +964,7 @@ arangodb::Result Collections::checksum(LogicalCollection& collection,
     }
 
     checksum ^= localHash;
-
+    return true;
   }, 1000);
 
   return trx.finish(res);

--- a/arangod/VocBase/Methods/Indexes.cpp
+++ b/arangod/VocBase/Methods/Indexes.cpp
@@ -112,17 +112,18 @@ arangodb::Result Indexes::getAll(LogicalCollection const* collection,
     auto& databaseName = collection->vocbase().name();
     std::string const& cid = collection->name();
 
-    // add code for estimates here
     std::unordered_map<std::string, double> estimates;
 
-    auto& feature = collection->vocbase().server().getFeature<ClusterFeature>();
-    Result rv = selectivityEstimatesOnCoordinator(feature, databaseName, cid, estimates);
-    if (rv.fail()) {
-      return Result(rv.errorNumber(), "could not retrieve estimates" + rv.errorMessage());
-    }
+    if (Index::hasFlag(flags, Index::Serialize::Estimates)) {
+      auto& feature = collection->vocbase().server().getFeature<ClusterFeature>();
+      Result rv = selectivityEstimatesOnCoordinator(feature, databaseName, cid, estimates);
+      if (rv.fail()) {
+        return Result(rv.errorNumber(), "could not retrieve estimates" + rv.errorMessage());
+      }
 
-    // we will merge in the index estimates later
-    flags &= ~Index::makeFlags(Index::Serialize::Estimates);
+      // we will merge in the index estimates later
+      flags &= ~Index::makeFlags(Index::Serialize::Estimates);
+    }
 
     VPackBuilder tmpInner;
     auto& ci = collection->vocbase().server().getFeature<ClusterFeature>().clusterInfo();

--- a/tests/js/server/aql/aql-optimizer-geoindex.js
+++ b/tests/js/server/aql/aql-optimizer-geoindex.js
@@ -134,55 +134,49 @@ function legacyOptimizerRuleTestSuite() {
         geocol.ensureIndex({ type: "hash", fields: [ "y", "z" ], unique: false });
 
         var queries = [
-          { string  : "FOR d IN " + colName + " SORT distance(d.lat, d.lon, 0 ,0 ) ASC LIMIT 1 RETURN d",
+          { string  : "FOR d IN " + colName + " SORT distance(d.lat, d.lon, 0 ,0) ASC LIMIT 1 RETURN d",
             cluster : false,
             sort    : false,
             filter  : false,
             index   : true
           },
-          { string  : "FOR d IN " + colName + " SORT distance(d.loca.tion.lat, d.loca.tion.lon, 0 ,0 ) ASC LIMIT 1 RETURN d",
+          { string  : "FOR d IN " + colName + " SORT distance(d.loca.tion.lat, d.loca.tion.lon, 0 ,0) ASC LIMIT 1 RETURN d",
             cluster : false,
             sort    : false,
             filter  : false,
             index   : true
           },
-          { string  : "FOR d IN " + colName + " SORT distance(0, 0, d.lat,d.lon ) ASC LIMIT 1 RETURN d",
+          { string  : "FOR d IN " + colName + " SORT distance(0, 0, d.lat,d.lon) ASC LIMIT 1 RETURN d",
             cluster : false,
             sort    : false,
             filter  : false,
             index   : true
           },
-          { string  : "FOR d IN " + colName + " FILTER distance(0, 0, d.lat,d.lon ) < 1 LIMIT 1 RETURN d",
+          { string  : "FOR d IN " + colName + " FILTER distance(0, 0, d.lat,d.lon) < 1 LIMIT 1 RETURN d",
             cluster : false,
             sort    : false,
             filter  : false,
             index   : true
           },
-          { string  : "FOR d IN " + colName + " FILTER distance(0, 0, d.geo[0],d.geo[1] ) < 1 LIMIT 1 RETURN d",
+          { string  : "FOR d IN " + colName + " FILTER distance(0, 0, d.geo[0],d.geo[1]) < 1 LIMIT 1 RETURN d",
             cluster : false,
             sort    : false,
             filter  : false,
             index   : true
           },
-          { string  : "FOR d IN " + colName + " FILTER distance(0, 0, d.lat, d.geo[1] ) < 1 LIMIT 1 RETURN d",
+          { string  : "FOR d IN " + colName + " FILTER distance(0, 0, d.lat, d.geo[1]) < 1 LIMIT 1 RETURN d",
             cluster : false,
             sort    : false,
-            filter  : true,
+            filter  : false,
             index   : false
           },
-          { string  : "FOR d IN " + colName + " SORT distance(0, 0, d.lat, d.lon) FILTER distance(0, 0, d.lat,d.lon ) < 1 LIMIT 1 RETURN d",
+          { string  : "FOR d IN " + colName + " SORT distance(0, 0, d.lat, d.lon) FILTER distance(0, 0, d.lat, d.lon) < 1 LIMIT 1 RETURN d",
             cluster : false,
             sort    : false,
             filter  : false,
             index   : true
           },
-          { string  : "FOR d IN " + colName + " SORT distance(0, 0, d.lat, d.lon) FILTER distance(0, 0, d.lat,d.lon ) < 1 LIMIT 1 RETURN d",
-            cluster : false,
-            sort    : false,
-            filter  : false,
-            index   : true
-          },
-          { string  : "FOR i in 1..2 FOR d IN " + colName + " FILTER distance(0, 0, d.lat,d.lon ) < 1 && i > 1 LIMIT 1 RETURN d",
+          { string  : "FOR i in 1..2 FOR d IN " + colName + " FILTER distance(0, 0, d.lat, d.lon) < 1 && i > 1 LIMIT 1 RETURN d",
             cluster : false,
             sort    : false,
             filter  : true,
@@ -543,49 +537,42 @@ function optimizerRuleTestSuite() {
             index: true
           },
           {
-            string: "FOR d IN " + colName + " SORT distance(0, 0, d.lat,d.lon ) ASC LIMIT 1 RETURN d",
+            string: "FOR d IN " + colName + " SORT distance(0, 0, d.lat, d.lon) ASC LIMIT 1 RETURN d",
             cluster: false,
             sort: false,
             filter: false,
             index: true
           },
           {
-            string: "FOR d IN " + colName + " FILTER distance(0, 0, d.lat,d.lon ) < 1 LIMIT 1 RETURN d",
+            string: "FOR d IN " + colName + " FILTER distance(0, 0, d.lat, d.lon) < 1 LIMIT 1 RETURN d",
             cluster: false,
             sort: false,
             filter: false,
             index: true
           },
           {
-            string: "FOR d IN " + colName + " FILTER distance(0, 0, d.geo[0],d.geo[1] ) < 1 LIMIT 1 RETURN d",
+            string: "FOR d IN " + colName + " FILTER distance(0, 0, d.geo[0], d.geo[1]) < 1 LIMIT 1 RETURN d",
             cluster: false,
             sort: false,
             filter: false,
             index: true
           },
           {
-            string: "FOR d IN " + colName + " FILTER distance(0, 0, d.lat, d.geo[1] ) < 1 LIMIT 1 RETURN d",
+            string: "FOR d IN " + colName + " FILTER distance(0, 0, d.lat, d.geo[1]) < 1 LIMIT 1 RETURN d",
             cluster: false,
             sort: false,
-            filter: true,
+            filter: false,
             index: false
           },
           {
-            string: "FOR d IN " + colName + " SORT distance(0, 0, d.lat, d.lon) FILTER distance(0, 0, d.lat,d.lon ) < 1 LIMIT 1 RETURN d",
+            string: "FOR d IN " + colName + " SORT distance(0, 0, d.lat, d.lon) FILTER distance(0, 0, d.lat, d.lon) < 1 LIMIT 1 RETURN d",
             cluster: false,
             sort: false,
             filter: false,
             index: true
           },
           {
-            string: "FOR d IN " + colName + " SORT distance(0, 0, d.lat, d.lon) FILTER distance(0, 0, d.lat,d.lon ) < 1 LIMIT 1 RETURN d",
-            cluster: false,
-            sort: false,
-            filter: false,
-            index: true
-          },
-          {
-            string: "FOR i in 1..2 FOR d IN " + colName + " FILTER distance(0, 0, d.lat,d.lon ) < 1 && i > 1 LIMIT 1 RETURN d",
+            string: "FOR i in 1..2 FOR d IN " + colName + " FILTER distance(0, 0, d.lat, d.lon) < 1 && i > 1 LIMIT 1 RETURN d",
             cluster: false,
             sort: false,
             filter: true,

--- a/tests/js/server/aql/aql-optimizer-rule-move-filter-into-enumerate.js
+++ b/tests/js/server/aql/aql-optimizer-rule-move-filter-into-enumerate.js
@@ -58,6 +58,13 @@ function optimizerRuleTestSuite () {
         [ `FOR doc IN ${cn} FILTER doc.value1 >= 1995 RETURN doc`, 5 ],
         [ `FOR doc IN ${cn} FILTER doc.value1 >= 1995 && doc.value1 < 2000 RETURN doc`, 5 ],
         [ `FOR doc IN ${cn} FILTER doc.value1 >= 100 && doc.value1 < 200 RETURN doc`, 100 ],
+        [ `FOR doc IN ${cn} FILTER doc.value1 < 1000 LIMIT 10 RETURN doc`, 10 ],
+        [ `FOR doc IN ${cn} FILTER doc.value1 < 1000 LIMIT 10, 10 RETURN doc`, 10 ],
+        [ `FOR doc IN ${cn} FILTER doc.value1 >= 0 && doc.value1 < 1000 LIMIT 100 RETURN doc`, 100 ],
+        [ `FOR doc IN ${cn} FILTER doc.value1 >= 0 && doc.value1 < 1000 LIMIT 10, 100 RETURN doc`, 100 ],
+        [ `FOR doc IN ${cn} FILTER doc.value1 >= 990 && doc.value1 < 1000 LIMIT 10, 5 RETURN doc`, 0 ],
+        [ `FOR doc IN ${cn} FILTER doc.value1 >= 990 && doc.value1 < 1000 LIMIT 5, 5 RETURN doc`, 5 ],
+        [ `FOR doc IN ${cn} FILTER doc.value1 >= 990 && doc.value1 < 1000 LIMIT 5, 10 RETURN doc`, 5 ],
       ];
 
       queries.forEach(function(query) {
@@ -71,13 +78,6 @@ function optimizerRuleTestSuite () {
     
     testLimit : function () {
       let queries = [ 
-        [ `FOR doc IN ${cn} FILTER doc.value1 < 1000 LIMIT 10 RETURN doc`, 10 ],
-        [ `FOR doc IN ${cn} FILTER doc.value1 < 1000 LIMIT 10, 10 RETURN doc`, 10 ],
-        [ `FOR doc IN ${cn} FILTER doc.value1 >= 0 && doc.value1 < 1000 LIMIT 100 RETURN doc`, 100 ],
-        [ `FOR doc IN ${cn} FILTER doc.value1 >= 0 && doc.value1 < 1000 LIMIT 10, 100 RETURN doc`, 100 ],
-        [ `FOR doc IN ${cn} FILTER doc.value1 >= 990 && doc.value1 < 1000 LIMIT 10, 5 RETURN doc`, 0 ],
-        [ `FOR doc IN ${cn} FILTER doc.value1 >= 990 && doc.value1 < 1000 LIMIT 5, 5 RETURN doc`, 5 ],
-        [ `FOR doc IN ${cn} FILTER doc.value1 >= 990 && doc.value1 < 1000 LIMIT 5, 10 RETURN doc`, 5 ],
         [ `FOR doc IN ${cn} FILTER doc.value2 < 1000 LIMIT 10 RETURN doc`, 10 ],
         [ `FOR doc IN ${cn} FILTER doc.value2 < 1000 LIMIT 10, 10 RETURN doc`, 10 ],
         [ `FOR doc IN ${cn} FILTER doc.value2 >= 0 && doc.value2 < 1000 LIMIT 100 RETURN doc`, 100 ],
@@ -88,8 +88,14 @@ function optimizerRuleTestSuite () {
       ];
 
       queries.forEach(function(query) {
-        let result = AQL_EXPLAIN(query[0]);
+        let result = AQL_EXPLAIN(query[0], null, { optimizer: { rules: ["-" + ruleName] } });
         assertEqual(-1, result.plan.rules.indexOf(ruleName), query);
+        result = AQL_EXECUTE(query[0]).json.length;
+        assertEqual(query[1], result, query);
+        
+        result = AQL_EXPLAIN(query[0], null, { optimizer: { rules: ["+" + ruleName] } });
+        assertNotEqual(-1, result.plan.rules.indexOf(ruleName), query);
+        assertEqual(0, result.plan.nodes.filter(function(n) { return n.type === 'FilterNode'; }).length);
         result = AQL_EXECUTE(query[0]).json.length;
         assertEqual(query[1], result, query);
       });
@@ -97,13 +103,14 @@ function optimizerRuleTestSuite () {
     
     testCollect : function () {
       let queries = [ 
-        [ `FOR doc IN ${cn} FILTER doc.value1 < 1000 COLLECT g = doc.value1 % 100 RETURN g`, 100 ],
-        [ `FOR doc IN ${cn} FILTER doc.value1 < 1000 COLLECT WITH COUNT INTO l RETURN l`, 1 ],
+        [ `FOR doc IN ${cn} FILTER doc.value2 < 1000 COLLECT g = doc.value1 % 100 RETURN g`, 100 ],
+        [ `FOR doc IN ${cn} FILTER doc.value2 < 1000 COLLECT WITH COUNT INTO l RETURN l`, 1 ],
       ];
 
       queries.forEach(function(query) {
         let result = AQL_EXPLAIN(query[0]);
-        assertEqual(-1, result.plan.rules.indexOf(ruleName), query);
+        assertNotEqual(-1, result.plan.rules.indexOf(ruleName), query);
+        assertEqual(0, result.plan.nodes.filter(function(n) { return n.type === 'FilterNode'; }).length);
         result = AQL_EXECUTE(query[0]).json.length;
         assertEqual(query[1], result, query);
       });


### PR DESCRIPTION
### Scope & Purpose

Activar mover-filtros-en-enumerar tambien cuando omitimos documentos.

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *shell_server_aql*.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/6966/