### PR TITLE
make arangosh automatically reconnect if the server closes the connection

### DIFF
--- a/3rdParty/fuerte/src/HttpConnection.cpp
+++ b/3rdParty/fuerte/src/HttpConnection.cpp
@@ -269,7 +269,7 @@ std::string HttpConnection<ST>::buildRequestBody(Request const& req) {
 
   // construct request path ("/_db/<name>/" prefix)
   if (!req.header.database.empty()) {
-    header.append("/_db/");
+    header.append("/_db/", 5);
     http::urlEncode(header, req.header.database);
   }
   // must start with /, also turns /_db/abc into /_db/abc/

--- a/3rdParty/fuerte/src/connection.cpp
+++ b/3rdParty/fuerte/src/connection.cpp
@@ -32,12 +32,11 @@ Connection::~Connection() {
 }
 
 // sendRequest and wait for it to finished.
-std::unique_ptr<Response> Connection::sendRequest(
-    std::unique_ptr<Request> request) {
+std::unique_ptr<Response> Connection::sendRequest(std::unique_ptr<Request> request) {
   FUERTE_LOG_TRACE << "sendRequest (sync): before send" << std::endl;
 
   WaitGroup wg;
-  auto rv = std::unique_ptr<Response>(nullptr);
+  std::unique_ptr<Response> rv;
   ::arangodb::fuerte::v1::Error error = Error::NoError;
 
   auto cb = [&](::arangodb::fuerte::v1::Error e,
@@ -69,11 +68,14 @@ std::unique_ptr<Response> Connection::sendRequest(
   
 std::string Connection::endpoint() const {
   std::string endpoint;
-  endpoint.reserve(16);
+  endpoint.reserve(32);
+  // http/vst 
   endpoint.append(fuerte::to_string(_config._protocolType));
   endpoint.push_back('+');
+  // tcp/ssl/unix
   endpoint.append(fuerte::to_string(_config._socketType));
   endpoint.append("://");
+  // domain name or IP (xxx.xxx.xxx.xxx)
   endpoint.append(_config._host);
   if (_config._socketType != SocketType::Unix) {
     endpoint.push_back(':');


### PR DESCRIPTION
### Scope & Purpose

This masks the ugly "Connection reset by peer" errors that occur if a user operation is carried out in arangosh on a connection that was already closed by the peer.
Instead of throwing the error in the user's face, the shell will silently try to reconnect and execute the operation once again. If that still fails, the error is propagated.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7003/