### PR TITLE
always create `_analyzers` collection if missing

### DIFF
--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(arango_iresearch
   IResearch/ApplicationServerHelper.h IResearch/ApplicationServerHelper.cpp
   IResearch/Containers.cpp IResearch/Containers.h
   IResearch/IResearchAnalyzerFeature.cpp IResearch/IResearchAnalyzerFeature.h
+  IResearch/IResearchAnalyzerCollectionFeature.cpp
   IResearch/IResearchCommon.cpp IResearch/IResearchCommon.h
   IResearch/IResearchKludge.cpp IResearch/IResearchKludge.h
   IResearch/IResearchLink.cpp IResearch/IResearchLink.h

--- a/arangod/IResearch/IResearchAnalyzerCollectionFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerCollectionFeature.cpp
@@ -21,6 +21,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "ApplicationServerHelper.h"
+#include "Basics/StaticStrings.h"
 #include "Cluster/ServerState.h"
 #include "FeaturePhases/ClusterFeaturePhase.h"
 #include "FeaturePhases/DatabaseFeaturePhase.h"
@@ -55,16 +56,16 @@ void IResearchAnalyzerCollectionFeature::start() {
   TRI_ASSERT(databaseFeature != nullptr);
 
   databaseFeature->enumerateDatabases([](TRI_vocbase_t& vocbase) {
-    Result res = methods::Collections::lookup(vocbase, "_analyzers", [](std::shared_ptr<LogicalCollection> const&) {
+    Result res = methods::Collections::lookup(vocbase, StaticStrings::AnalyzersCollection, [](std::shared_ptr<LogicalCollection> const&) {
     });
 
     if (res.is(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND)) {
       // collection does not yet exist, so let's create it now
-      auto res =  methods::Collections::createSystem(vocbase, "_analyzers", false);
+      auto res =  methods::Collections::createSystem(vocbase, StaticStrings::AnalyzersCollection, false);
       if (res.first.ok()) {
-        LOG_TOPIC("c2e33", DEBUG, arangodb::iresearch::TOPIC) << "successfully created '_analyzers' collection in database '" << vocbase.name() << "'";
+        LOG_TOPIC("c2e33", DEBUG, arangodb::iresearch::TOPIC) << "successfully created '" << StaticStrings::AnalyzersCollection << "' collection in database '" << vocbase.name() << "'";
       } else if (res.first.fail() && !res.first.is(TRI_ERROR_ARANGO_CONFLICT)) {
-        LOG_TOPIC("ecc23", WARN, arangodb::iresearch::TOPIC) << "unable to create '_analyzers' collection: " << res.first.errorMessage();
+        LOG_TOPIC("ecc23", WARN, arangodb::iresearch::TOPIC) << "unable to create '" << StaticStrings::AnalyzersCollection << "' collection: " << res.first.errorMessage();
         // don't abort startup here. the next startup may fix this
       }
     }

--- a/arangod/IResearch/IResearchAnalyzerCollectionFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerCollectionFeature.cpp
@@ -1,0 +1,72 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#include "ApplicationServerHelper.h"
+#include "Cluster/ServerState.h"
+#include "FeaturePhases/ClusterFeaturePhase.h"
+#include "FeaturePhases/DatabaseFeaturePhase.h"
+#include "FeaturePhases/ServerFeaturePhase.h"
+#include "IResearch/IResearchAnalyzerCollectionFeature.h"
+#include "IResearch/IResearchCommon.h"
+#include "Logger/Logger.h"
+#include "Logger/LogMacros.h"
+#include "RestServer/BootstrapFeature.h"
+#include "RestServer/DatabaseFeature.h"
+#include "VocBase/Methods/Collections.h"
+
+using namespace arangodb;
+
+IResearchAnalyzerCollectionFeature::IResearchAnalyzerCollectionFeature(application_features::ApplicationServer& server)
+    : ApplicationFeature(server, "ArangoSearchAnalyzerCollection") {
+  setOptional(true);
+  startsAfter<application_features::DatabaseFeaturePhase>();
+  // should be relatively late in startup sequence
+  startsAfter<application_features::ClusterFeaturePhase>();
+  startsAfter<application_features::ServerFeaturePhase>();
+  startsAfter<BootstrapFeature>();
+}
+
+void IResearchAnalyzerCollectionFeature::start() {
+  if (ServerState::instance()->isDBServer()) {
+    // no need to execute this in DB server
+    return;
+  }
+
+  DatabaseFeature* databaseFeature = DatabaseFeature::DATABASE;
+  TRI_ASSERT(databaseFeature != nullptr);
+
+  databaseFeature->enumerateDatabases([](TRI_vocbase_t& vocbase) {
+    Result res = methods::Collections::lookup(vocbase, "_analyzers", [](std::shared_ptr<LogicalCollection> const&) {
+    });
+
+    if (res.is(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND)) {
+      // collection does not yet exist, so let's create it now
+      auto res =  methods::Collections::createSystem(vocbase, "_analyzers", false);
+      if (res.first.ok()) {
+        LOG_TOPIC("c2e33", DEBUG, arangodb::iresearch::TOPIC) << "successfully created '_analyzers' collection in database '" << vocbase.name() << "'";
+      } else if (res.first.fail() && !res.first.is(TRI_ERROR_ARANGO_CONFLICT)) {
+        LOG_TOPIC("ecc23", WARN, arangodb::iresearch::TOPIC) << "unable to create '_analyzers' collection: " << res.first.errorMessage();
+        // don't abort startup here. the next startup may fix this
+      }
+    }
+  });
+}

--- a/arangod/IResearch/IResearchAnalyzerCollectionFeature.h
+++ b/arangod/IResearch/IResearchAnalyzerCollectionFeature.h
@@ -1,0 +1,42 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef ARANGOD_IRESEARCH__IRESEARCH_ANALYZER_COLLECTION_FEATURE_H
+#define ARANGOD_IRESEARCH__IRESEARCH_ANALYZER_COLLECTION_FEATURE_H 1
+
+#include "ApplicationFeatures/ApplicationFeature.h"
+
+namespace arangodb {
+
+/// @brief the sole purpose of this feature is to create potentially
+/// missing `_analyzers` collection after startup. It can be removed
+/// eventually once the entire upgrading logic has been revised
+class IResearchAnalyzerCollectionFeature final : public arangodb::application_features::ApplicationFeature {
+ public:
+  explicit IResearchAnalyzerCollectionFeature(arangodb::application_features::ApplicationServer& server);
+
+  void start() override;
+};
+
+}  // namespace arangodb
+
+#endif

--- a/arangod/RestServer/arangod.cpp
+++ b/arangod/RestServer/arangod.cpp
@@ -118,6 +118,7 @@
 #endif
 
 #include "IResearch/IResearchAnalyzerFeature.h"
+#include "IResearch/IResearchAnalyzerCollectionFeature.h"
 #include "IResearch/IResearchFeature.h"
 
 // storage engines
@@ -258,6 +259,7 @@ static int runServer(int argc, char** argv, ArangoGlobalContext& context) {
 
     server.addFeature<arangodb::iresearch::IResearchAnalyzerFeature>();
     server.addFeature<arangodb::iresearch::IResearchFeature>();
+    server.addFeature<arangodb::IResearchAnalyzerCollectionFeature>();
 
     // storage engines
     server.addFeature<ClusterEngine>();


### PR DESCRIPTION
### Scope & Purpose

Always create `_analyzers` collection after startup

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7018/