### PR TITLE
added an assert

### DIFF
--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -1621,6 +1621,7 @@ bool Expression::canRunOnDBServer() {
   TRI_ASSERT(_node != nullptr);
   return _node->canRunOnDBServer();
 }
+
 bool Expression::isDeterministic() {
   if (_type == UNPROCESSED) {
     initExpression();

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -7253,10 +7253,12 @@ void arangodb::aql::moveFiltersIntoEnumerateRule(Optimizer* opt, std::unique_ptr
         if (!expr->isDeterministic() || !expr->canRunOnDBServer()) {
           break;
         }
+
         if (expr->node() == nullptr) {
           break;
         }
 
+        TRI_ASSERT(!expr->willUseV8());
         found.clear();
         Ast::getReferencedVariables(expr->node(), found);
         if (found.size() == 1 && found.find(outVariable) != found.end()) {


### PR DESCRIPTION
### Scope & Purpose

Added assert that verifies that no V8 stuff will be used when there is early-pruning.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7023/