### PR TITLE
truncate displayed collection names in web UI at 64 chars

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/collectionsItemView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/collectionsItemView.js
@@ -497,7 +497,7 @@
           };
           window.modalView.show(
             'modalCollectionInfo.ejs',
-            'Collection: ' + this.model.get('name'),
+            'Collection: ' + (this.model.get('name').length > 64 ? this.model.get('name').substr(0, 64) + "..." : this.model.get('name')),
             buttons,
             tableContent
           );

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/documentView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/documentView.js
@@ -384,7 +384,7 @@
     breadcrumb: function () {
       var name = window.location.hash.split('/');
       $('#subNavigationBar .breadcrumb').html(
-        '<a href="#collection/' + name[1] + '/documents/1">Collection: ' + name[1] + '</a>' +
+        '<a href="#collection/' + name[1] + '/documents/1">Collection: ' + (name[1].length > 64 ? name[1].substr(0, 64) + "..." : name[1]) + '</a>' +
         '<i class="fa fa-chevron-right"></i>' +
         this.type.charAt(0).toUpperCase() + this.type.slice(1) + ': ' + name[2]
       );

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/documentsView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/documentsView.js
@@ -1178,7 +1178,7 @@
 
       if (window.App.naviView && $('#subNavigationBar .breadcrumb').html() !== undefined) {
         $('#subNavigationBar .breadcrumb').html(
-          'Collection: ' + arangoHelper.escapeHtml(this.collectionName)
+          'Collection: ' + arangoHelper.escapeHtml(this.collectionName.length > 64 ? this.collectionName.substr(0, 64) + "..." : this.collectionName)
         );
         arangoHelper.buildCollectionSubNav(this.collectionName, 'Content');
       } else {

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/indicesView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/indicesView.js
@@ -103,7 +103,7 @@
 
     breadcrumb: function () {
       $('#subNavigationBar .breadcrumb').html(
-        'Collection: ' + this.collectionName
+        'Collection: ' + (this.collectionName.length > 64 ? this.collectionName.substr(0, 64) + "..." : this.collectionName)
       );
     },
 

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/infoView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/infoView.js
@@ -31,7 +31,7 @@
 
     breadcrumb: function () {
       $('#subNavigationBar .breadcrumb').html(
-        'Collection: ' + this.collectionName
+        'Collection: ' + (this.collectionName.length > 64 ? this.collectionName.substr(0, 64) + "..." : this.collectionName)
       );
     },
 
@@ -66,7 +66,7 @@
           };
           window.modalView.show(
             'modalCollectionInfo.ejs',
-            'Collection: ' + this.model.get('name'),
+            'Collection: ' + (this.model.get('name').length > 64 ? this.model.get('name').substr(0, 64) + "..." : this.model.get('name')),
             buttons,
             tableContent, null, null,
             null, null,

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/settingsView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/settingsView.js
@@ -26,7 +26,7 @@
 
     breadcrumb: function () {
       $('#subNavigationBar .breadcrumb').html(
-        'Collection: ' + this.collectionName
+        'Collection: ' + (this.collectionName.length > 64 ? this.collectionName.substr(0, 64) + "..." : this.collectionName)
       );
     },
 

--- a/js/apps/system/_admin/aardvark/APP/frontend/scss/_tiles.scss
+++ b/js/apps/system/_admin/aardvark/APP/frontend/scss/_tiles.scss
@@ -236,7 +236,7 @@ $iconsize: 50px;
     margin-left: 5px;
     margin-right: 5px;
     overflow: hidden !important;
-    padding: 4px 8px;
+    padding: 4px 55px 4px 8px;
     text-overflow: ellipsis !important;
     white-space: nowrap !important;
 


### PR DESCRIPTION
### Scope & Purpose

We do allow very long collection names, but they cannot be displayed properly in the web UI's navigation. So truncate the display at 64 characters. Collection names are ASCII-only, so it is ok to truncate at an arbitrary byte offset.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7035/