### PR TITLE
Fix ArangoSearch consolidation results commit

### DIFF
--- a/3rdParty/iresearch/core/index/index_writer.cpp
+++ b/3rdParty/iresearch/core/index/index_writer.cpp
@@ -2038,6 +2038,11 @@ index_writer::pending_context_t index_writer::flush_all(const before_commit_f& b
       // pending consolidation request
       pending_candidates_count += candidates.size();
     } else {
+      // during consolidation doc_mask could be already populated even for just merged segment
+      if (pending_segment.segment.meta.docs_count != pending_segment.segment.meta.live_docs_count) {
+        index_utils::read_document_mask(docs_mask, dir, pending_segment.segment.meta);
+      }
+      bool docs_mask_modified = false;
       // pending already imported/consolidated segment, apply deletes
       // mask documents matching filters from segment_contexts (i.e. from new operations)
       for (auto& modifications: ctx->pending_segment_contexts_) {
@@ -2052,13 +2057,18 @@ index_writer::pending_context_t index_writer::flush_all(const before_commit_f& b
           modifications_end - modifications_begin
         );
 
-        add_document_mask_modified_records(
+        docs_mask_modified |= add_document_mask_modified_records(
           modification_queries,
           docs_mask,
           cached_readers_, // reader cache for segments
           pending_segment.segment.meta,
           pending_segment.generation
         );
+      }
+
+      // if mask left untouched, reset it, to prevent unnecessary writes
+      if (!docs_mask_modified) {
+        docs_mask.clear();
       }
     }
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 devel
 -----
+* Fixed ArangoSearch index removes being discarded on commiting consolidation results with
+  pending removes after some segments under consolidation were already committed 
 
 * Fixed available flag for hotbackup.
 


### PR DESCRIPTION
Fixed applying consolidation results with pending removals on commit.
Flush procedure checks existing removals for consolidated segments before applying pending removals

Fix is verified by IResearch unit-tests

https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/7039/