### PR TITLE
Fixed wrong permissions for rebalanceShards.

### DIFF
--- a/js/actions/api-cluster.js
+++ b/js/actions/api-cluster.js
@@ -1365,9 +1365,10 @@ actions.defineHttp({
     }
 
     // simon: RO is sufficient to rebalance shards for current db
-    if (req.database !== '_system'/* || !req.isAdminUser*/) {
+    if (!req.isAdminUser &&
+        users.permission(req.user, req.database) !== 'rw') {
       actions.resultError(req, res, actions.HTTP_FORBIDDEN, 0,
-        'only allowed for admins on the _system database');
+        'only allowed for admins on the database');
       return;
     }
 


### PR DESCRIPTION
### Scope & Purpose

Permissions for `rebalanceShards` where messed. Previously only a rebalancing of the `_system` database was possible. And only for admin users.

