### PR TITLE
Remove unneeded upsert of system services to _app.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* No longer put system services in _app on single server. On cluster, this
+  has never worked. This was unnecessary.
+
 * Fixed available flag for hotbackup.
 
 * Fixed list with id for partially available hotbackups.


### PR DESCRIPTION
This never worked in the cluster and is not used in single server.