### PR TITLE
make test work with more than 2 db servers

### DIFF
--- a/tests/js/server/aql/aql-subquery.js
+++ b/tests/js/server/aql/aql-subquery.js
@@ -389,6 +389,12 @@ function ahuacatlSubqueryTestSuite () {
       const colName = "UnitTestSubqueryCollection";
       try {
         const col = db._create(colName, {numberOfShards: 9});
+        let dbServers = 0;
+        if (isCoordinator) {
+          dbServers = Object.values(col.shards(true)).filter((value, index, self) => {
+            return self.indexOf(value) === index;
+          }).length;
+        }
         const docs = [];
         const expected = new Map();
         for (let i = 0; i < 2000; ++i) {
@@ -418,7 +424,7 @@ function ahuacatlSubqueryTestSuite () {
           assertEqual(scannedIndex, 0);
           assertEqual(filtered, 3960000);
           if (isCoordinator) {
-            assertTrue(httpRequests <= 8007 + 1);
+            assertTrue(httpRequests <= 4003 * dbServers + 1, httpRequests);
           } else {
             assertEqual(httpRequests, 0);
           }
@@ -445,7 +451,7 @@ function ahuacatlSubqueryTestSuite () {
           assertEqual(scannedIndex, 40000);
           assertEqual(filtered, 0);
           if (isCoordinator) {
-            assertTrue(httpRequests <= 8007 + 1);
+            assertTrue(httpRequests <= 4003 * dbServers + 1, httpRequests);
           } else {
             assertEqual(httpRequests, 0);
           }


### PR DESCRIPTION
### Scope & Purpose

Make cluster AQL test work with a variable number of db servers

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

*(Please pick either of the following options)*

This change is already covered by existing tests, such as *scripts/unittest shell_server_aql --cluster true*.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7082/