### PR TITLE
Something about `--agency.supervision-grace-period`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,20 @@
 devel
 -----
 
+* Changed default value for startup option `--agency.supervision-grace-period` from
+  `10` to `0`. The value of `0` will make the server automatically determine the
+  grace period based on the chosen deployment mode. 
+  
+  When `0` is used, a grace period of 10 seconds will be used for regular clusters, 
+  and a grace period of 30 seconds will be used for active failover setups.
+
+  That means the effective default value for regular clusters does not change, but
+  the supervision grace period for active failover setups is increased from 10 to
+  30 seconds by default. This is to avoid unnecessary failovers in active failover
+  setups. In active failover setups, the leader server needs to handle all the load 
+  and is thus expected to get overloaded and unresponsive more easily than a server 
+  in a regular cluster which needs handle only a part of the overall load.
+
 * Added limit for AQL range materialization to prevent out-of-memory errors.
 
   When materializing ranges created by either the AQL `RANGE` function or by using

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,20 +1,6 @@
 devel
 -----
 
-* Changed default value for startup option `--agency.supervision-grace-period` from
-  `10` to `0`. The value of `0` will make the server automatically determine the
-  grace period based on the chosen deployment mode. 
-  
-  When `0` is used, a grace period of 10 seconds will be used for regular clusters, 
-  and a grace period of 30 seconds will be used for active failover setups.
-
-  That means the effective default value for regular clusters does not change, but
-  the supervision grace period for active failover setups is increased from 10 to
-  30 seconds by default. This is to avoid unnecessary failovers in active failover
-  setups. In active failover setups, the leader server needs to handle all the load 
-  and is thus expected to get overloaded and unresponsive more easily than a server 
-  in a regular cluster which needs handle only a part of the overall load.
-
 * Added limit for AQL range materialization to prevent out-of-memory errors.
 
   When materializing ranges created by either the AQL `RANGE` function or by using

--- a/arangod/Agency/AgencyFeature.cpp
+++ b/arangod/Agency/AgencyFeature.cpp
@@ -38,7 +38,6 @@
 #include "MMFiles/MMFilesPersistentIndexFeature.h"
 #include "ProgramOptions/ProgramOptions.h"
 #include "ProgramOptions/Section.h"
-#include "Replication/ReplicationFeature.h"
 #include "RestServer/FrontendFeature.h"
 #include "RestServer/ScriptFeature.h"
 #include "Statistics/StatisticsFeature.h"
@@ -68,7 +67,7 @@ AgencyFeature::AgencyFeature(application_features::ApplicationServer& server)
       _compactionStepSize(1000),
       _compactionKeepSize(50000),
       _maxAppendSize(250),
-      _supervisionGracePeriod(0.0),
+      _supervisionGracePeriod(10.0),
       _cmdLineTimings(false) {
   setOptional(true);
   startsAfter<FoxxFeaturePhase>();
@@ -114,7 +113,7 @@ void AgencyFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
 
   options->addOption(
       "--agency.supervision-grace-period",
-      "supervision time, after which a server is considered to have failed (in seconds, 0 = auto-select grace period)",
+      "supervision time, after which a server is considered to have failed (in seconds)",
       new DoubleParameter(&_supervisionGracePeriod));
 
   options->addOption("--agency.compaction-step-size",
@@ -309,21 +308,6 @@ void AgencyFeature::prepare() {
   if (_waitForSync) {
     _maxAppendSize /= 10;
   }
-
-  // default value for supervision-grace-period was 10 seconds in 3.5 and before.
-  // 3.6 changes the default to 0.0, which means "determine grace period automatically"
-  if (_supervisionGracePeriod <= 0.00001) {
-    ReplicationFeature& replicationFeature = server().getFeature<ReplicationFeature>();
-    if (replicationFeature.isActiveFailoverEnabled()) {
-      // default value for active failover
-      _supervisionGracePeriod = 30.0;
-    } else {
-      // default value for regular cluster
-      _supervisionGracePeriod = 10.0;
-    }
-  }
-
-  TRI_ASSERT(_supervisionGracePeriod > 0.0);
 
   _agent.reset(new consensus::Agent(
       server(), consensus::config_t(_recoveryId, _size, _poolSize, _minElectionTimeout,

--- a/scripts/startLeaderFollower.sh
+++ b/scripts/startLeaderFollower.sh
@@ -142,7 +142,6 @@ for aid in `seq 0 $(( $NRAGENTS - 1 ))`; do
         --agency.size $NRAGENTS \
         --agency.supervision true \
         --agency.supervision-frequency $SFRE \
-        --agency.supervision-grace-period 5.0 \
         --agency.wait-for-sync false \
         --database.directory active/data$PORT \
         --javascript.enabled false \

--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -156,7 +156,6 @@ for aid in `seq 0 $(( $NRAGENTS - 1 ))`; do
           --agency.size $NRAGENTS \
           --agency.supervision true \
           --agency.supervision-frequency $SFRE \
-          --agency.supervision-grace-period 5.0 \
           --agency.wait-for-sync false \
           --database.directory cluster/data$PORT \
           --javascript.enabled false \
@@ -184,7 +183,6 @@ for aid in `seq 0 $(( $NRAGENTS - 1 ))`; do
         --agency.size $NRAGENTS \
         --agency.supervision true \
         --agency.supervision-frequency $SFRE \
-        --agency.supervision-grace-period 5.0 \
         --agency.wait-for-sync false \
         --database.directory cluster/data$PORT \
         --javascript.enabled false \


### PR DESCRIPTION
### Scope & Purpose

Originally this PR was intended to change the default value for `--agency.supervision-grace-period` for active failover setups.
However, it turned out not to be possible to set the grace period based on the deployment mode on agency startup, as the agency is not aware of the deployment mode.

So what's left in this PR is a bit of cleanup, and the actual relevant change is in the documentation PR: https://github.com/arangodb/docs/pull/215

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7109/