### PR TITLE
fix use-after-free for HTTP 100 Continue case

### DIFF
--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -175,11 +175,11 @@ int HttpCommTask<T>::on_header_complete(llhttp_t* p) {
         << "received a 100-continue request";
     char const* response = "HTTP/1.1 100 Continue\r\n\r\n";
     auto buff = asio_ns::buffer(response, strlen(response));
-    asio_ns::async_write(self->_protocol->socket, buff,
-                         [self = self->shared_from_this()](asio_ns::error_code const& ec, std::size_t transferred) {
-                           HttpCommTask<T>* task = static_cast<HttpCommTask<T>*>(self.get());
-                           task->asyncReadSome();
-                         });
+    asio_ns::async_write(self->_protocol->socket, buff, [self = self->shared_from_this()](asio_ns::error_code const& ec, std::size_t) {
+      if (ec) {
+        static_cast<HttpCommTask<T>*>(self.get())->close();
+      }
+    }); 
     return HPE_OK;
   }
   if (self->_request->requestType() == RequestType::HEAD) {


### PR DESCRIPTION
### Scope & Purpose

Fix use-after-free error and wrong behavior for HTTP 100 Continue case.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7112/