### PR TITLE
auto-flush more exotic column families from time to time

### DIFF
--- a/arangod/RocksDBEngine/RocksDBBackgroundThread.h
+++ b/arangod/RocksDBEngine/RocksDBBackgroundThread.h
@@ -33,19 +33,13 @@ class RocksDBEngine;
 
 class RocksDBBackgroundThread final : public Thread {
  public:
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief engine pointer
-  //////////////////////////////////////////////////////////////////////////////
   RocksDBEngine& _engine;
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief interval in which we will run
-  //////////////////////////////////////////////////////////////////////////////
   double const _interval;
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief condition variable for heartbeat
-  //////////////////////////////////////////////////////////////////////////////
   arangodb::basics::ConditionVariable _condition;
 
   RocksDBBackgroundThread(RocksDBEngine& eng, double interval);
@@ -55,6 +49,13 @@ class RocksDBBackgroundThread final : public Thread {
 
  protected:
   void run() override;
+  
+ private:
+  /// @brief next time point for flushing column families
+  /// note that we need to flush column families every now and then
+  /// to prevent data from exotic column families to only reside in
+  /// memtables and block WAL file collection
+  double _nextFlushTime;
 };
 }  // namespace arangodb
 

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2432,6 +2432,21 @@ void RocksDBEngine::releaseTick(TRI_voc_tick_t tick) {
   }
 }
 
+void RocksDBEngine::flushColumnFamilies(bool wait) {
+  // we are intentionally not flushing cfs "document" and "primary", as these
+  // are expected to be written to every now and then by statistics etc.
+  LOG_TOPIC("9354c", DEBUG, Logger::ENGINES) << "flushing column families";
+
+  rocksdb::FlushOptions options;
+  options.wait = wait;
+  
+  _db->Flush(options, RocksDBColumnFamily::definitions());
+  _db->Flush(options, RocksDBColumnFamily::edge());
+  _db->Flush(options, RocksDBColumnFamily::vpack());
+  _db->Flush(options, RocksDBColumnFamily::geo());
+  _db->Flush(options, RocksDBColumnFamily::fulltext());
+}
+
 }  // namespace arangodb
 
 // -----------------------------------------------------------------------------

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -395,6 +395,9 @@ public:
   /// note: returns a nullptr if automatic syncing is turned off!
   RocksDBSyncThread* syncThread() const { return _syncThread.get(); }
 
+  /// @brief flushes most of the column families
+  void flushColumnFamilies(bool wait);
+
   static arangodb::Result registerRecoveryHelper(std::shared_ptr<RocksDBRecoveryHelper> helper);
   static std::vector<std::shared_ptr<RocksDBRecoveryHelper>> const& recoveryHelpers();
 


### PR DESCRIPTION
In the RocksDB engine, automatically flush more exotic column families
10 minutes after server startup, plus every 12 hours while the server is
running. This should prevent data from more exotic column families to
stay only in WAL and memtables, which may block WAL journals collection.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7119/