### PR TITLE
allow using `RANDOM_TOKEN` AQL function with an argument value of `0`.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Allow usage of AQL function `RANDOM_TOKEN` with an argument value of `0`. This
+  now produces an empty string, whereas in older versions this threw an invalid
+  value exception.
+
 * Add startup option `--rocksdb.exclusive-writes` to avoid write-write conflicts.
 
   This options allows for an easier transition from MMFiles to the RocksDB storage

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -4250,14 +4250,14 @@ AqlValue Functions::RandomToken(ExpressionContext*, transaction::Methods*,
   AqlValue const& value = extractFunctionParameterValue(parameters, 0);
 
   int64_t const length = value.toInt64();
-  if (length <= 0 || length > 65536) {
+  if (length < 0 || length > 65536) {
     THROW_ARANGO_EXCEPTION_PARAMS(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH,
                                   "RANDOM_TOKEN");
   }
 
-  UniformCharacter JSNumGenerator(
+  UniformCharacter generator(
       "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
-  return AqlValue(JSNumGenerator.random(static_cast<size_t>(length)));
+  return AqlValue(generator.random(static_cast<size_t>(length)));
 }
 
 /// @brief function MD5

--- a/tests/js/server/aql/aql-functions-string.js
+++ b/tests/js/server/aql/aql-functions-string.js
@@ -2566,15 +2566,15 @@ function ahuacatlStringFunctionsTestSuite () {
       assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, 'RETURN RANDOM_TOKEN(1, 2)');
       assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, 'RETURN RANDOM_TOKEN(-1)');
       assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, 'RETURN RANDOM_TOKEN(-10)');
-      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, 'RETURN RANDOM_TOKEN(0)');
       assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, 'RETURN RANDOM_TOKEN(65537)');
 
-      var actual = getQueryResults('FOR i IN [ 1, 10, 100, 1000 ] RETURN RANDOM_TOKEN(i)');
-      assertEqual(4, actual.length);
+      var actual = getQueryResults('FOR i IN [ 1, 10, 100, 1000, 0 ] RETURN RANDOM_TOKEN(i)');
+      assertEqual(5, actual.length);
       assertEqual(1, actual[0].length);
       assertEqual(10, actual[1].length);
       assertEqual(100, actual[2].length);
       assertEqual(1000, actual[3].length);
+      assertEqual(0, actual[4].length);
     }
 
   };


### PR DESCRIPTION
### Scope & Purpose

Allow usage of `RANDOM_TOKEN` AQL function with an argument value of `0`.
This produces an empty string now, whereas in previous versions of ArangoDB it threw an invalid value exception.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *shell_server_aql*.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7141/