### PR TITLE
Heartbeat Agency Endpoint Update

### DIFF
--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -1302,16 +1302,17 @@ bool HeartbeatThread::sendServerState() {
 }
 
 void HeartbeatThread::updateAgentPool(VPackSlice const& agentPool) {
-  if (agentPool.isObject() && agentPool.get("pool").isObject() &&
-      agentPool.hasKey("size") && agentPool.get("size").getUInt() > 0) {
+  if (agentPool.isObject() && agentPool.get("pool").isObject() && agentPool.hasKey("size") &&
+      agentPool.get("size").getUInt() > 0 && agentPool.get("id").isString()) {
     try {
       std::vector<std::string> values;
       // we have to make sure that the leader is on the front
       auto leaderId = agentPool.get("id").stringRef();
       auto pool = agentPool.get("pool");
+      values.reserve(pool.length());
       values.emplace_back(pool.get(leaderId).copyString());
       // now add all non leaders
-      for (auto pair : VPackObjectIterator(agentPool.get("pool"))) {
+      for (auto pair : VPackObjectIterator(pool)) {
         if (!pair.key.isEqualString(leaderId)) {
           values.emplace_back(pair.value.copyString());
         }
@@ -1319,15 +1320,15 @@ void HeartbeatThread::updateAgentPool(VPackSlice const& agentPool) {
       AgencyCommManager::MANAGER->updateEndpoints(values);
     } catch (basics::Exception const& e) {
       LOG_TOPIC("1cec6", WARN, Logger::HEARTBEAT)
-          << "Error updating agency pool: " << e.message();
+        << "Error updating agency pool: " << e.message();
     } catch (std::exception const& e) {
       LOG_TOPIC("889d4", WARN, Logger::HEARTBEAT)
-          << "Error updating agency pool: " << e.what();
+        << "Error updating agency pool: " << e.what();
     } catch (...) {
     }
   } else {
     LOG_TOPIC("92522", ERR, Logger::AGENCYCOMM)
-        << "Cannot find an agency persisted in RAFT 8|";
+      << "Cannot find an agency persisted in RAFT 8|";
   }
 }
 


### PR DESCRIPTION
The heartbeat thread updates the agency endpoint once per second but did not put the leader in front, instead it put them in lexicographic order. Thus in case the leader is not the first server, each server in the cluster forgets every second which server was the actual leader and asked the first named follower, just to be redirected immediately.