### PR TITLE
show index type in not implemented exception

### DIFF
--- a/arangod/Indexes/Index.cpp
+++ b/arangod/Indexes/Index.cpp
@@ -688,7 +688,7 @@ arangodb::aql::AstNode* Index::specializeCondition(arangodb::aql::AstNode* /* no
                                                    arangodb::aql::Variable const* /* reference */) const {
   // the default implementation should never be called
   TRI_ASSERT(false); 
-  THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "no default implementation for specializeCondition");
+  THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, std::string("no default implementation for specializeCondition. index type: ") + typeName());
 }
 
 std::unique_ptr<IndexIterator> Index::iteratorForCondition(transaction::Methods* /* trx */,
@@ -697,7 +697,7 @@ std::unique_ptr<IndexIterator> Index::iteratorForCondition(transaction::Methods*
                                                            IndexIteratorOptions const& /* opts */) {
   // the default implementation should never be called
   TRI_ASSERT(false); 
-  THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "no default implementation for iteratorForCondition");
+  THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, std::string("no default implementation for iteratorForCondition. index type: ") + typeName());
 }
 
 /// @brief perform some base checks for an index condition part


### PR DESCRIPTION
### Scope & Purpose

Put index type name into exception error message for easier debugging.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7157/