### PR TITLE
make replication timeouts configurable via startup options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-v3.5.4 (XXXX-XX-XX)
+v3.5.3 (XXXX-XX-XX)
 -------------------
 
 * Make the timeouts for replication requests (for active failover and master-slave 
@@ -6,10 +6,6 @@ v3.5.4 (XXXX-XX-XX)
 
       --replication.connect-timeout
       --replication.request-timeout
-
-
-v3.5.3 (XXXX-XX-XX)
--------------------
 
 * Fixed internal issue #4647: dead Coordinators are not removed for agency.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,8 @@
 v3.5.4 (XXXX-XX-XX)
 -------------------
 
-* Increased default timeout for replication requests from 10 minutes to 20
-  minutes.
-
-  Additionally, the timeouts for replication requests (for active failover
-  and master-slave replication) are now configurable via startup options
+* Make the timeouts for replication requests (for active failover and master-slave 
+  replication configurable via startup options:
 
       --replication.connect-timeout
       --replication.request-timeout

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,16 @@
+v3.5.4 (XXXX-XX-XX)
+-------------------
+
+* Increased default timeout for replication requests from 10 minutes to 20
+  minutes.
+
+  Additionally, the timeouts for replication requests (for active failover
+  and master-slave replication) are now configurable via startup options
+
+      --replication.connect-timeout
+      --replication.request-timeout
+
+
 v3.5.3 (XXXX-XX-XX)
 -------------------
 

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -772,7 +772,11 @@ void HeartbeatThread::runSingleServer() {
         config._idleMinWaitTime = 250 * 1000; // 250ms
         config._idleMaxWaitTime = 3 * 1000 * 1000; // 3s
         TRI_ASSERT(!config._skipCreateDrop);
-        config._includeFoxxQueues = true;  // sync _queues and _jobs
+        config._includeFoxxQueues = true; // sync _queues and _jobs
+    
+        auto feature = application_features::ApplicationServer::getFeature<ReplicationFeature>("Replication");
+        config._connectTimeout = feature->checkConnectTimeout(config._connectTimeout);
+        config._requestTimeout = feature->checkRequestTimeout(config._requestTimeout);
 
         applier->forget();  // forget about any existing configuration
         applier->reconfigure(config);

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -774,9 +774,11 @@ void HeartbeatThread::runSingleServer() {
         TRI_ASSERT(!config._skipCreateDrop);
         config._includeFoxxQueues = true; // sync _queues and _jobs
     
-        auto feature = application_features::ApplicationServer::getFeature<ReplicationFeature>("Replication");
-        config._connectTimeout = feature->checkConnectTimeout(config._connectTimeout);
-        config._requestTimeout = feature->checkRequestTimeout(config._requestTimeout);
+        auto* feature = application_features::ApplicationServer::lookupFeature<ReplicationFeature>("Replication");
+        if (feature != nullptr) {
+          config._connectTimeout = feature->checkConnectTimeout(config._connectTimeout);
+          config._requestTimeout = feature->checkRequestTimeout(config._requestTimeout);
+        }
 
         applier->forget();  // forget about any existing configuration
         applier->reconfigure(config);

--- a/arangod/Replication/ReplicationApplierConfiguration.cpp
+++ b/arangod/Replication/ReplicationApplierConfiguration.cpp
@@ -65,9 +65,11 @@ ReplicationApplierConfiguration::ReplicationApplierConfiguration()
       _incremental(false),
       _verbose(false),
       _restrictType(RestrictType::None) {
-  auto feature = application_features::ApplicationServer::getFeature<ReplicationFeature>("Replication");
-  _requestTimeout = feature->requestTimeout();
-  _connectTimeout = feature->connectTimeout();
+  auto* feature = application_features::ApplicationServer::lookupFeature<ReplicationFeature>("Replication");
+  if (feature != nullptr) {
+    _requestTimeout = feature->requestTimeout();
+    _connectTimeout = feature->connectTimeout();
+  }
 }
 
 /// @brief reset the configuration to defaults
@@ -105,9 +107,11 @@ void ReplicationApplierConfiguration::reset() {
   _force32mode = false;
 #endif
       
-  auto feature = application_features::ApplicationServer::getFeature<ReplicationFeature>("Replication");
-  _requestTimeout = feature->requestTimeout();
-  _connectTimeout = feature->connectTimeout();
+  auto* feature = application_features::ApplicationServer::lookupFeature<ReplicationFeature>("Replication");
+  if (feature != nullptr) {
+    _requestTimeout = feature->requestTimeout();
+    _connectTimeout = feature->connectTimeout();
+  }
 }
 
 /// @brief get a VelocyPack representation
@@ -228,14 +232,18 @@ ReplicationApplierConfiguration ReplicationApplierConfiguration::fromVelocyPack(
 
   value = slice.get("requestTimeout");
   if (value.isNumber()) {
-    auto feature = application_features::ApplicationServer::getFeature<ReplicationFeature>("Replication");
-    configuration._requestTimeout = feature->checkRequestTimeout(value.getNumber<double>());
+    auto* feature = application_features::ApplicationServer::lookupFeature<ReplicationFeature>("Replication");
+    if (feature != nullptr) {
+      configuration._requestTimeout = feature->checkRequestTimeout(value.getNumber<double>());
+    }
   }
 
   value = slice.get("connectTimeout");
   if (value.isNumber()) {
-    auto feature = application_features::ApplicationServer::getFeature<ReplicationFeature>("Replication");
-    configuration._connectTimeout = feature->checkConnectTimeout(value.getNumber<double>());
+    auto* feature = application_features::ApplicationServer::lookupFeature<ReplicationFeature>("Replication");
+    if (feature != nullptr) {
+      configuration._connectTimeout = feature->checkConnectTimeout(value.getNumber<double>());
+    }
   }
 
   value = slice.get("maxConnectRetries");

--- a/arangod/Replication/ReplicationApplierConfiguration.cpp
+++ b/arangod/Replication/ReplicationApplierConfiguration.cpp
@@ -42,7 +42,7 @@ ReplicationApplierConfiguration::ReplicationApplierConfiguration()
       _username(),
       _password(),
       _jwt(),
-      _requestTimeout(1200.0),
+      _requestTimeout(600.0),
       _connectTimeout(10.0),
       _ignoreErrors(0),
       _maxConnectRetries(100),
@@ -77,7 +77,7 @@ void ReplicationApplierConfiguration::reset() {
   _username.clear();
   _password.clear();
   _jwt.clear();
-  _requestTimeout = 1200.0;
+  _requestTimeout = 600.0;
   _connectTimeout = 10.0;
   _ignoreErrors = 0;
   _maxConnectRetries = 100;

--- a/arangod/Replication/ReplicationFeature.cpp
+++ b/arangod/Replication/ReplicationFeature.cpp
@@ -43,6 +43,10 @@ ReplicationFeature* ReplicationFeature::INSTANCE = nullptr;
 
 ReplicationFeature::ReplicationFeature(ApplicationServer& server)
     : ApplicationFeature(server, "Replication"),
+      _connectTimeout(10.0),
+      _requestTimeout(1200.0),
+      _forceConnectTimeout(false),
+      _forceRequestTimeout(false),
       _replicationApplierAutoStart(true),
       _enableActiveFailover(false),
       _parallelTailingInvocations(0),
@@ -74,11 +78,21 @@ void ReplicationFeature::collectOptions(std::shared_ptr<ProgramOptions> options)
   options->addOption("--replication.active-failover",
                      "Enable active-failover during asynchronous replication",
                      new BooleanParameter(&_enableActiveFailover));
+  
   options->addOption("--replication.max-parallel-tailing-invocations",
                      "Maximum number of concurrently allowed WAL tailing invocations (0 = unlimited)",
                      new UInt64Parameter(&_maxParallelTailingInvocations),
                      arangodb::options::makeFlags(arangodb::options::Flags::Hidden))
                      .setIntroducedIn(30500);
+  
+  options->addOption("--replication.connect-timeout",
+                     "Default timeout value for replication connection attempts (in seconds)",
+                     new DoubleParameter(&_connectTimeout))
+                     .setIntroducedIn(30409).setIntroducedIn(30504);
+  options->addOption("--replication.request-timeout",
+                     "Default timeout value for replication requests (in seconds)",
+                     new DoubleParameter(&_requestTimeout))
+                     .setIntroducedIn(30409).setIntroducedIn(30504);
 }
 
 void ReplicationFeature::validateOptions(std::shared_ptr<options::ProgramOptions> options) {
@@ -88,6 +102,20 @@ void ReplicationFeature::validateOptions(std::shared_ptr<options::ProgramOptions
         << "automatic failover needs to be started with agency endpoint "
            "configured";
     FATAL_ERROR_EXIT();
+  }
+
+  if (_connectTimeout < 1.0) {
+    _connectTimeout = 1.0;
+  }
+  if (options->processingResult().touched("--replication.connect-timeout")) {
+    _forceConnectTimeout = true;
+  }
+
+  if (_requestTimeout < 3.0) {
+    _requestTimeout = 3.0;
+  }
+  if (options->processingResult().touched("--replication.request-timeout")) {
+    _forceRequestTimeout = true;
   }
 }
 
@@ -164,6 +192,20 @@ void ReplicationFeature::trackTailingStart() {
 /// must only be called after a successful call to trackTailingstart
 void ReplicationFeature::trackTailingEnd() noexcept {
   --_parallelTailingInvocations;
+}
+  
+double ReplicationFeature::checkConnectTimeout(double value) const {
+  if (_forceConnectTimeout) {
+    return _connectTimeout;
+  }
+  return value;
+}
+
+double ReplicationFeature::checkRequestTimeout(double value) const {
+  if (_forceRequestTimeout) {
+    return _requestTimeout;
+  }
+  return value;
 }
 
 // start the replication applier for a single database

--- a/arangod/Replication/ReplicationFeature.cpp
+++ b/arangod/Replication/ReplicationFeature.cpp
@@ -44,7 +44,7 @@ ReplicationFeature* ReplicationFeature::INSTANCE = nullptr;
 ReplicationFeature::ReplicationFeature(ApplicationServer& server)
     : ApplicationFeature(server, "Replication"),
       _connectTimeout(10.0),
-      _requestTimeout(1200.0),
+      _requestTimeout(600.0),
       _forceConnectTimeout(false),
       _forceRequestTimeout(false),
       _replicationApplierAutoStart(true),

--- a/arangod/Replication/ReplicationFeature.h
+++ b/arangod/Replication/ReplicationFeature.h
@@ -60,6 +60,24 @@ class ReplicationFeature final : public application_features::ApplicationFeature
   /// @brief stop the replication applier for a single database
   void stopApplier(TRI_vocbase_t* vocbase);
 
+  /// @brief returns the connect timeout for replication requests
+  double connectTimeout() const { return _connectTimeout; }
+  
+  /// @brief returns the request timeout for replication requests
+  double requestTimeout() const { return _requestTimeout; }
+  
+  /// @brief returns the connect timeout for replication requests
+  /// this will return the provided value if the user has not adjusted the
+  /// timeout via configuration. otherwise it will return the configured
+  /// timeout value
+  double checkConnectTimeout(double value) const;
+  
+  /// @brief returns the request timeout for replication requests
+  /// this will return the provided value if the user has not adjusted the
+  /// timeout via configuration. otherwise it will return the configured
+  /// timeout value
+  double checkRequestTimeout(double value) const;
+
   /// @brief automatic failover of replication using the agency
   bool isActiveFailoverEnabled() const { return _enableActiveFailover; }
 
@@ -81,6 +99,20 @@ class ReplicationFeature final : public application_features::ApplicationFeature
   static ReplicationFeature* INSTANCE;
 
  private:
+  /// @brief connection timeout for replication requests
+  double _connectTimeout;
+  
+  /// @brief request timeout for replication requests
+  double _requestTimeout;
+
+  /// @brief whether or not the user-defined connect timeout is forced to be used
+  /// this is true only if the user set the connect timeout at startup
+  bool _forceConnectTimeout;
+  
+  /// @brief whether or not the user-defined request timeout is forced to be used
+  /// this is true only if the user set the request timeout at startup
+  bool _forceRequestTimeout;
+
   bool _replicationApplierAutoStart;
 
   /// Enable the active failover

--- a/tests/js/common/replication/replication.js
+++ b/tests/js/common/replication/replication.js
@@ -2231,7 +2231,7 @@ function ReplicationApplierSuite () {
     testApplierProperties : function () {
       var properties = replication.applier.properties();
 
-      assertEqual(1200, properties.requestTimeout);
+      assertEqual(600, properties.requestTimeout);
       assertEqual(10, properties.connectTimeout);
       assertEqual(100, properties.maxConnectRetries);
       assertEqual(0, properties.chunkSize);
@@ -2261,7 +2261,7 @@ function ReplicationApplierSuite () {
 
       properties = replication.applier.properties();
       assertEqual(properties.endpoint, "tcp://9.9.9.9:9999");
-      assertEqual(1200, properties.requestTimeout);
+      assertEqual(600, properties.requestTimeout);
       assertEqual(10, properties.connectTimeout);
       assertEqual(100, properties.maxConnectRetries);
       assertEqual(0, properties.chunkSize);
@@ -2482,7 +2482,8 @@ function ReplicationSyncSuite () {
           connectionRetryWaitTime: 1
         });
         fail();
-      } catch (err) {
+      }
+      catch (err) {
         assertTrue(err.errorNum === errors.ERROR_REPLICATION_INVALID_RESPONSE.code ||
                    err.errorNum === errors.ERROR_REPLICATION_MASTER_ERROR.code ||
                    err.errorNum === errors.ERROR_REPLICATION_NO_RESPONSE.code);

--- a/tests/js/common/replication/replication.js
+++ b/tests/js/common/replication/replication.js
@@ -2231,7 +2231,7 @@ function ReplicationApplierSuite () {
     testApplierProperties : function () {
       var properties = replication.applier.properties();
 
-      assertEqual(600, properties.requestTimeout);
+      assertEqual(1200, properties.requestTimeout);
       assertEqual(10, properties.connectTimeout);
       assertEqual(100, properties.maxConnectRetries);
       assertEqual(0, properties.chunkSize);
@@ -2261,7 +2261,7 @@ function ReplicationApplierSuite () {
 
       properties = replication.applier.properties();
       assertEqual(properties.endpoint, "tcp://9.9.9.9:9999");
-      assertEqual(600, properties.requestTimeout);
+      assertEqual(1200, properties.requestTimeout);
       assertEqual(10, properties.connectTimeout);
       assertEqual(100, properties.maxConnectRetries);
       assertEqual(0, properties.chunkSize);
@@ -2482,8 +2482,7 @@ function ReplicationSyncSuite () {
           connectionRetryWaitTime: 1
         });
         fail();
-      }
-      catch (err) {
+      } catch (err) {
         assertTrue(err.errorNum === errors.ERROR_REPLICATION_INVALID_RESPONSE.code ||
                    err.errorNum === errors.ERROR_REPLICATION_MASTER_ERROR.code ||
                    err.errorNum === errors.ERROR_REPLICATION_NO_RESPONSE.code);


### PR DESCRIPTION
### Scope & Purpose

This targets *3.5.4*.

Make replication timeouts configurable via startup options.
The following options are available (for active failover and master-slave replication):
```
    --replication.connect-timeout
    --replication.request-timeout
```
Values can be specified in seconds. If these options are used, they will be used for replication requests, overriding any hard-coded defaults or explicitly configured timeouts.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7250/