### PR TITLE
SSL Vst CommTask

### DIFF
--- a/arangod/GeneralServer/VstCommTask.cpp
+++ b/arangod/GeneralServer/VstCommTask.cpp
@@ -220,7 +220,7 @@ bool VstCommTask<T>::processMessage(velocypack::Buffer<uint8_t> buffer,
   RequestStatistics* stat = this->statistics(messageId);
   RequestStatistics::SET_READ_END(stat);
   RequestStatistics::ADD_RECEIVED_BYTES(stat, buffer.size());
-  
+
   // handle request types
   if (mt == MessageType::Authentication) {  // auth
     handleAuthHeader(VPackSlice(buffer.data()), messageId);
@@ -246,7 +246,7 @@ bool VstCommTask<T>::processMessage(velocypack::Buffer<uint8_t> buffer,
       // if we don't call checkAuthentication we need to refresh
       this->_auth->userManager()->refreshUser(this->_authToken._username);
     }
-    
+
     // Separate superuser traffic:
     // Note that currently, velocystream traffic will never come from
     // a forwarding, since we always forward with HTTP.
@@ -297,7 +297,7 @@ void VstCommTask<T>::sendResponse(std::unique_ptr<GeneralResponse> baseRes, Requ
   resItem->response = std::move(baseRes);
   RequestStatistics::SET_WRITE_START(stat);
   resItem->stat = stat;
-  
+
   asio_ns::const_buffer payload;
   if (response.generateBody()) {
     payload = asio_ns::buffer(response.payload().data(),
@@ -334,7 +334,9 @@ void VstCommTask<T>::sendResponse(std::unique_ptr<GeneralResponse> baseRes, Requ
   bool expected = _writing.load();
   if (false == expected) {
     if (_writing.compare_exchange_strong(expected, true)) {
-      doWrite(); // we managed to start writing
+      this->_protocol->context.io_context.post([this, self = this->shared_from_this()]{
+        this->doWrite(); // we managed to start writing
+      });
     }
   }
 }


### PR DESCRIPTION
When using OpenSSL reading and writing are concurrent operations as both call into OpenSSL and one might need to write before one can read and vice versa. Thus this needs to be synchronized.