### PR TITLE
Made test tolerant to leftover links from previous test-runs

### DIFF
--- a/tests/js/server/aql/aql-view-arangosearch-server.js
+++ b/tests/js/server/aql/aql-view-arangosearch-server.js
@@ -371,7 +371,7 @@ function iResearchFeatureAqlServerSideTestSuite () {
           });
         }
         return linksCount;
-      }
+      };
 
       try {
         let beforeLinkCount = getLinksCount();


### PR DESCRIPTION
Made test testRemoveIndexOnCreationFail  tolerant to links present in test database before  test run.

https://jenkins01.arangodb.biz/view/PR/job/arangodb-matrix-pr/7263/