### PR TITLE
Catch exceptions in noexcept methods

### DIFF
--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -575,13 +575,25 @@ RestStatus RestAqlHandler::continueExecute() {
 }
 
 void RestAqlHandler::shutdownExecute(bool isFinalized) noexcept {
-  if (isFinalized) {
-    if (_query) {
-      _query->sharedState()->resetWakeupHandler();
+  try {
+    if (isFinalized) {
+      if (_query) {
+        _query->sharedState()->resetWakeupHandler();
+      }
+      if (_qId != 0) {
+        _queryRegistry->close(&_vocbase, _qId);
+      }
     }
-    if (_qId != 0) {
-      _queryRegistry->close(&_vocbase, _qId);
-    }
+  } catch (arangodb::basics::Exception const& ex) {
+    LOG_TOPIC("f73b8", INFO, Logger::FIXME)
+        << "Ignoring exception during rest handler shutdown: "
+        << "[" << ex.code() << "] " << ex.message();
+  } catch (std::exception const& ex) {
+    LOG_TOPIC("b7335", INFO, Logger::FIXME)
+        << "Ignoring exception during rest handler shutdown: " << ex.what();
+  } catch (...) {
+    LOG_TOPIC("c4db4", INFO, Logger::FIXME)
+        << "Ignoring unknown exception during rest handler shutdown.";
   }
 }
 


### PR DESCRIPTION
### Scope & Purpose

We observed the following crash occasionally in devel:

```
[Current thread is 1 (LWP 16044)]
#0  a_crash () at ./arch/x86_64/atomic_arch.h:108
#1  abort () at src/exit/abort.c:29
#2  0x00007f5dc7b433b9 in __gnu_cxx::__verbose_terminate_handler () at /home/buildozer/aports/main/gcc/src/gcc-9.2.0/libstdc++-v3/libsupc++/vterminate.cc:95
#3  0x00007f5dc7af6195 in __cxxabiv1::__terminate (handler=<optimized out>) at /home/buildozer/aports/main/gcc/src/gcc-9.2.0/libstdc++-v3/libsupc++/eh_terminate.cc:47
#4  0x00007f5dc7b43087 in __cxa_call_terminate (ue_header=ue_header@entry=0x7f5d8f62b4a0) at /home/buildozer/aports/main/gcc/src/gcc-9.2.0/libstdc++-v3/libsupc++/eh_call.cc:54
#5  0x00007f5dc7af5dd6 in __cxxabiv1::__gxx_personality_v0 (version=<optimized out>, actions=6, exception_class=5138137972254386944, ue_header=0x7f5d8f62b4a0, context=0x7f5db95f8100)
    at /home/buildozer/aports/main/gcc/src/gcc-9.2.0/libstdc++-v3/libsupc++/eh_personality.cc:677
#6  0x00007f5dc7b45dda in _Unwind_RaiseException_Phase2 (exc=exc@entry=0x7f5d8f62b4a0, context=context@entry=0x7f5db95f8100, frames_p=frames_p@entry=0x7f5db95f8008)
    at /home/buildozer/aports/main/gcc/src/gcc-9.2.0/libgcc/unwind.inc:64
#7  0x00007f5dc7b46324 in _Unwind_Resume (exc=exc@entry=0x7f5d8f62b4a0) at /home/buildozer/aports/main/gcc/src/gcc-9.2.0/libgcc/unwind.inc:241
#8  0x00007f5dc539b088 in arangodb::basics::WriteLocker<arangodb::basics::ReadWriteLock>::~WriteLocker (this=<optimized out>, __in_chrg=<optimized out>)
    at /work/ArangoDB/lib/Basics/WriteLocker.h:106
#9  arangodb::aql::QueryRegistry::close (this=<optimized out>, vocbase=<optimized out>, id=<optimized out>, ttl=<optimized out>) at /work/ArangoDB/arangod/Aql/QueryRegistry.cpp:169
#10 0x00007f5dc5a40933 in arangodb::aql::RestAqlHandler::shutdownExecute (isFinalized=true, this=0x7f5dade2dbc0) at /work/ArangoDB/arangod/Aql/RestAqlHandler.cpp:583
#11 arangodb::aql::RestAqlHandler::shutdownExecute (this=0x7f5dade2dbc0, isFinalized=<optimized out>) at /work/ArangoDB/arangod/Aql/RestAqlHandler.cpp:577
#12 0x00007f5dc56c0682 in arangodb::rest::RestHandler::runHandlerStateMachine() () at /work/ArangoDB/arangod/GeneralServer/RestHandler.cpp:273
#13 0x00007f5dc5933118 in arangodb::rest::RestHandler::runHandler(std::function<void (arangodb::rest::RestHandler*)>) (cb=..., this=<optimized out>)
    at /work/ArangoDB/arangod/GeneralServer/RestHandler.h:92
#14 arangodb::rest::CommTask::<lambda()>::operator() (__closure=0x7f5d91e40500) at /work/ArangoDB/arangod/GeneralServer/CommTask.cpp:490
#15 std::_Function_handler<void (), arangodb::rest::CommTask::handleRequestSync(std::shared_ptr<arangodb::rest::RestHandler>)::{lambda()#1}>::_M_invoke(std::_Any_data const&) ()
    at /usr/include/c++/9.2.0/bits/std_function.h:300
#16 0x00007f5dc57bb42b in std::function<void ()>::operator()() const (this=<optimized out>) at /usr/include/c++/9.2.0/bits/std_function.h:685
#17 arangodb::SupervisedScheduler::runWorker() () at /work/ArangoDB/arangod/Scheduler/SupervisedScheduler.cpp:377
#18 0x00007f5dc695be8d in arangodb::Thread::runMe() () at /work/ArangoDB/lib/Basics/Thread.cpp:323
#19 0x00007f5dc695bf60 in arangodb::Thread::startThread(void*) () at /work/ArangoDB/lib/Basics/Thread.cpp:103
#20 0x00007f5dc6a030f7 in ThreadStarter(void*) () at /work/ArangoDB/lib/Basics/threads-posix.cpp:85
#21 0x00007f5dc7b5981b in start (p=0x7f5db95f8ea0) at src/thread/pthread_create.c:192
#22 0x00007f5dc7b5afa7 in __clone () at src/thread/x86_64/clone.s:22
```

Maybe it's unrelated, but there definitely is an exception thrown inside a `noexcept` method that isn't caught. This PR fixes that.

- [X] Bug-Fix for *devel-branch* (introduced in #10408)

