### PR TITLE
Actually use the given format to execute a query

### DIFF
--- a/arangod/Aql/ExecutionEngine.h
+++ b/arangod/Aql/ExecutionEngine.h
@@ -58,7 +58,9 @@ class ExecutionEngine {
 
  public:
   // @brief create an execution engine from a plan
-  static ExecutionEngine* instantiateFromPlan(QueryRegistry&, Query&, ExecutionPlan&, bool);
+  static ExecutionEngine* instantiateFromPlan(QueryRegistry& queryRegistry, Query& query,
+                                              ExecutionPlan& plan, bool planRegisters,
+                                              SerializationFormat format);
 
   TEST_VIRTUAL Result createBlocks(std::vector<ExecutionNode*> const& nodes,
                                    std::unordered_set<std::string> const& restrictToShards,
@@ -72,14 +74,14 @@ class ExecutionEngine {
 
   /// @brief get the query
   TEST_VIRTUAL Query* getQuery() const;
-    
+
   /// @brief server to snippet mapping
   void snippetMapping(MapRemoteToSnippet&& dbServerMapping,
-                      std::vector<uint64_t>&& coordinatorQueryIds) { 
-    _dbServerMapping = std::move(dbServerMapping); 
-    _coordinatorQueryIds = std::move(coordinatorQueryIds); 
+                      std::vector<uint64_t>&& coordinatorQueryIds) {
+    _dbServerMapping = std::move(dbServerMapping);
+    _coordinatorQueryIds = std::move(coordinatorQueryIds);
   }
-  
+
   /// @brief kill the query
   void kill();
 
@@ -142,10 +144,10 @@ class ExecutionEngine {
 
   /// @brief whether or not shutdown() was executed
   bool _wasShutdown;
-  
+
   /// @brief server to snippet mapping
   MapRemoteToSnippet _dbServerMapping;
-  
+
   /// @brief ids of all coordinator query snippets
   std::vector<uint64_t> _coordinatorQueryIds;
 };

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -276,8 +276,8 @@ Query* Query::clone(QueryPart part, bool withPlan) {
 }
 
 bool Query::killed() const {
-  if(_queryOptions.timeout > std::numeric_limits<double>::epsilon()) {
-    if(TRI_microtime() > (_startTime + _queryOptions.timeout)) {
+  if (_queryOptions.timeout > std::numeric_limits<double>::epsilon()) {
+    if (TRI_microtime() > (_startTime + _queryOptions.timeout)) {
       return true;
     }
   }
@@ -451,7 +451,7 @@ void Query::prepare(QueryRegistry* registry, SerializationFormat format) {
   // this is confusing and should be fixed!
   std::unique_ptr<ExecutionEngine> engine(
       ExecutionEngine::instantiateFromPlan(*registry, *this, *plan,
-                                           !_queryString.empty()));
+                                           !_queryString.empty(), format));
 
   if (_engine == nullptr) {
     _engine = std::move(engine);
@@ -655,7 +655,7 @@ ExecutionState Query::execute(QueryRegistry* registry, QueryResult& queryResult)
         _resultBuilder->openArray();
         _executionPhase = ExecutionPhase::EXECUTE;
       }
-      [[fallthrough]];
+        [[fallthrough]];
       case ExecutionPhase::EXECUTE: {
         TRI_ASSERT(_resultBuilder != nullptr);
         TRI_ASSERT(_resultBuilder->isOpenArray());
@@ -734,7 +734,7 @@ ExecutionState Query::execute(QueryRegistry* registry, QueryResult& queryResult)
         _executionPhase = ExecutionPhase::FINALIZE;
       }
 
-      [[fallthrough]];
+        [[fallthrough]];
       case ExecutionPhase::FINALIZE: {
         // will set warnings, stats, profile and cleanup plan and engine
         return finalize(queryResult);
@@ -784,7 +784,7 @@ ExecutionState Query::execute(QueryRegistry* registry, QueryResult& queryResult)
 QueryResult Query::executeSync(QueryRegistry* registry) {
   std::shared_ptr<SharedQueryState> ss = sharedState();
   ss->resetWakeupHandler();
-  
+
   QueryResult queryResult;
   while (true) {
     auto state = execute(registry, queryResult);
@@ -872,7 +872,7 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate, QueryRegistry* registry) {
     options.buildUnindexedArrays = true;
     options.buildUnindexedObjects = true;
     auto builder = std::make_shared<VPackBuilder>(&options);
-    
+
     try {
       ss->resetWakeupHandler();
 

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -189,9 +189,8 @@ void RestAqlHandler::setupClusterQuery() {
   // If we have a new format then it has to be included here.
   // If not default to classic (old coordinator will not send it)
   SerializationFormat format = static_cast<SerializationFormat>(
-      VelocyPackHelper::getNumericValue<int>(querySlice, "serializationFormat",
+      VelocyPackHelper::getNumericValue<int>(querySlice, StaticStrings::SerializationFormat,
                                              static_cast<int>(SerializationFormat::CLASSIC)));
-
   // Now we need to create shared_ptr<VPackBuilder>
   // That contains the old-style cluster snippet in order
   // to prepare create a Query object.
@@ -315,7 +314,6 @@ bool RestAqlHandler::registerSnippets(
     }
 
     try {
-
       if (needToLock) {
         // Directly try to lock only the first snippet is required to be locked.
         // For all others locking is pointless
@@ -340,7 +338,7 @@ bool RestAqlHandler::registerSnippets(
         // No need to cleanup...
       }
 
-      QueryId qId = query->id(); // not true in general
+      QueryId qId = query->id();  // not true in general
       TRI_ASSERT(qId > 0);
       _queryRegistry->insert(qId, query.get(), ttl, true, false);
       query.release();
@@ -443,17 +441,16 @@ RestStatus RestAqlHandler::useQuery(std::string const& operation, std::string co
     return RestStatus::DONE;
   }
 
-  if (!_query) { // the PUT verb
+  if (!_query) {  // the PUT verb
     TRI_ASSERT(this->state() == RestHandler::HandlerState::EXECUTE);
-    
+
     _query = findQuery(idString);
     if (!_query) {
       return RestStatus::DONE;
     }
     std::shared_ptr<SharedQueryState> ss = _query->sharedState();
-    ss->setWakeupHandler([self = shared_from_this()] {
-      return self->wakeupHandler();
-    });
+    ss->setWakeupHandler(
+        [self = shared_from_this()] { return self->wakeupHandler(); });
   }
 
   TRI_ASSERT(_qId > 0);
@@ -545,7 +542,7 @@ RestStatus RestAqlHandler::execute() {
       }
       break;
     }
-    
+
     default: {
       generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                     TRI_ERROR_NOT_IMPLEMENTED, "illegal method for /_api/aql");
@@ -628,7 +625,6 @@ Query* RestAqlHandler::findQuery(std::string const& idString) {
 // handle for useQuery
 RestStatus RestAqlHandler::handleUseQuery(std::string const& operation,
                                           VPackSlice const querySlice) {
-
   std::string const& shardId = _request->header("shard-id");
 
   // upon first usage, the "initializeCursor" method must be called
@@ -656,7 +652,7 @@ RestStatus RestAqlHandler::handleUseQuery(std::string const& operation,
 
   VPackBuffer<uint8_t> answerBuffer;
   VPackBuilder answerBuilder(answerBuffer);
-  answerBuilder.openObject(/*unindexed*/true);
+  answerBuilder.openObject(/*unindexed*/ true);
 
   if (operation == "getSome") {
     TRI_IF_FAILURE("RestAqlHandler::getSome") {
@@ -744,9 +740,9 @@ RestStatus RestAqlHandler::handleUseQuery(std::string const& operation,
     answerBuilder.add(StaticStrings::Error, VPackValue(res.fail()));
     answerBuilder.add(StaticStrings::Code, VPackValue(res.errorNumber()));
   } else if (operation == "shutdown") {
-    int errorCode =
-        VelocyPackHelper::getNumericValue<int>(querySlice, StaticStrings::Code, TRI_ERROR_INTERNAL);
-    
+    int errorCode = VelocyPackHelper::getNumericValue<int>(querySlice, StaticStrings::Code,
+                                                           TRI_ERROR_INTERNAL);
+
     ExecutionState state;
     Result res;
     std::tie(state, res) = _query->engine()->shutdown(errorCode);
@@ -775,10 +771,9 @@ RestStatus RestAqlHandler::handleUseQuery(std::string const& operation,
     generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND);
     return RestStatus::DONE;
   }
-  
+
   answerBuilder.close();
-  generateResult(rest::ResponseCode::OK, std::move(answerBuffer),
-                 transactionContext);
-  
+  generateResult(rest::ResponseCode::OK, std::move(answerBuffer), transactionContext);
+
   return RestStatus::DONE;
 }

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -217,8 +217,7 @@ std::string const StaticStrings::MimeTypeDump(
 std::string const StaticStrings::MimeTypeHtml("text/html; charset=utf-8");
 std::string const StaticStrings::MimeTypeJson(
     "application/json; charset=utf-8");
-std::string const StaticStrings::MimeTypeJsonNoEncoding(
-    "application/json");
+std::string const StaticStrings::MimeTypeJsonNoEncoding("application/json");
 std::string const StaticStrings::MimeTypeText("text/plain; charset=utf-8");
 std::string const StaticStrings::MimeTypeVPack("application/x-velocypack");
 std::string const StaticStrings::MultiPartContentType("multipart/form-data");
@@ -278,4 +277,6 @@ std::string const StaticStrings::Old("old");
 std::string const StaticStrings::UpgradeEnvName(
     "ARANGODB_UPGRADE_DURING_RESTORE");
 std::string const StaticStrings::BackupToDeleteName("DIRECTORY_TO_DELETE");
-std::string const StaticStrings::BackupSearchToDeleteName("DIRECTORY_TO_DELETE_SEARCH");
+std::string const StaticStrings::BackupSearchToDeleteName(
+    "DIRECTORY_TO_DELETE_SEARCH");
+std::string const StaticStrings::SerializationFormat("serializationFormat");

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -254,6 +254,7 @@ class StaticStrings {
   static std::string const UpgradeEnvName;
   static std::string const BackupToDeleteName;
   static std::string const BackupSearchToDeleteName;
+  static std::string const SerializationFormat;
 };
 }  // namespace arangodb
 


### PR DESCRIPTION
This fixes a rolling upgrade issue 3.5.* -> devel

During upgrade the AQL should be performed in 3.5 format, this has not been forwarded correctly inside the DBServers.

Jenkins:
http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/7282/