### PR TITLE
Fix bug in SubqueryEndExecutor

### DIFF
--- a/arangod/Aql/SubqueryEndExecutor.cpp
+++ b/arangod/Aql/SubqueryEndExecutor.cpp
@@ -112,6 +112,9 @@ std::pair<ExecutionState, NoStats> SubqueryEndExecutor::produceRows(OutputAqlIte
         }
         TRI_ASSERT(state == ExecutionState::DONE || state == ExecutionState::HASMORE);
 
+        // This case happens when there are no inputs from the enclosing query,
+        // hence our companion SubqueryStartExecutor has not produced any rows
+        // (in particular not a ShadowRow), so we are done.
         if (state == ExecutionState::DONE && !shadowRow.isInitialized()) {
           /* We had better not accumulated any results if we get here */
           TRI_ASSERT(_accumulator->slice().length() == 0);


### PR DESCRIPTION
If a subquery was spliced, and did not get any input rows, the SubqueryEnd
executor still expected a relevant ShadowRow to be handed through, and ran into
an assertion (or otherwise crashed the server) if it didn't get one.

### Scope & Purpose

*(Can you describe what functional change your PR is trying to effect?)*

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added **Regression Tests** (Only for bug-fixes) 
