### PR TITLE
fix truncate operation in synchronous replication

### DIFF
--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2457,6 +2457,8 @@ Future<OperationResult> transaction::Methods::truncateLocal(std::string const& c
           "/_api/collection/" + arangodb::basics::StringUtils::urlEncode(collectionName) +
           "/truncate";
       VPackBuffer<uint8_t> body;
+      VPackSlice s = VPackSlice::emptyObjectSlice();
+      body.append(s.start(), s.byteSize());
 
       // Now prepare the requests:
       std::vector<network::FutureRes> futures;


### PR DESCRIPTION
### Scope & Purpose

Fix truncate operation in synchronous replication.
Previously, when sending the HTTP PUT /_api/collection/<collection>/truncate, an empty body was sent with the request.
This lead to a parse error on the follower, which was then always dropped.
This PR sends an empty object instead of a completely empty body, so the followers can parse the request and subsequently can carry out the truncate operation.
This doesn't affect 3.5.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *many tests, e.g. dump*.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7303/