### PR TITLE
Bug fix/input row serialization

### DIFF
--- a/arangod/Aql/AqlItemBlock.cpp
+++ b/arangod/Aql/AqlItemBlock.cpp
@@ -535,6 +535,13 @@ SharedAqlItemBlockPtr AqlItemBlock::steal(std::vector<size_t> const& chosen,
   return res;
 }
 
+/// @brief toJson, transfer all rows of this AqlItemBlock to Json, the result
+/// can be used to recreate the AqlItemBlock via the Json constructor
+void AqlItemBlock::toVelocyPack(velocypack::Options const* const trxOptions,
+                                VPackBuilder& result) const {
+  return toVelocyPack(0, size(), trxOptions, result);
+}
+
 /// @brief toJson, transfer a whole AqlItemBlock to Json, the result can
 /// be used to recreate the AqlItemBlock via the Json constructor
 /// Here is a description of the data format: The resulting Json has
@@ -568,7 +575,15 @@ SharedAqlItemBlockPtr AqlItemBlock::steal(std::vector<size_t> const& chosen,
 ///                  corresponding position
 ///  "raw":     List of actual values, positions 0 and 1 are always null
 ///                  such that actual indices start at 2
-void AqlItemBlock::toVelocyPack(velocypack::Options const* const trxOptions, VPackBuilder& result) const {
+void AqlItemBlock::toVelocyPack(size_t from, size_t to,
+                                velocypack::Options const* const trxOptions,
+                                VPackBuilder& result) const {
+  // Can only have positive slice size
+  TRI_ASSERT(from < to);
+  // We cannot slice over the upper bound.
+  // The lower bound (0) is protected by unsigned number type
+  TRI_ASSERT(to <= _nrItems);
+
   TRI_ASSERT(result.isOpenObject());
   VPackOptions options(VPackOptions::Defaults);
   options.buildUnindexedArrays = true;
@@ -580,7 +595,7 @@ void AqlItemBlock::toVelocyPack(velocypack::Options const* const trxOptions, VPa
   raw.add(VPackValue(VPackValueType::Null));
   raw.add(VPackValue(VPackValueType::Null));
 
-  result.add("nrItems", VPackValue(_nrItems));
+  result.add("nrItems", VPackValue(to - from));
   result.add("nrRegs", VPackValue(_nrRegs));
   result.add(StaticStrings::Error, VPackValue(false));
 
@@ -639,7 +654,7 @@ void AqlItemBlock::toVelocyPack(velocypack::Options const* const trxOptions, VPa
     startRegister = 1;
   }
   for (RegisterId column = startRegister; column < internalNrRegs(); column++) {
-    for (size_t i = 0; i < _nrItems; i++) {
+    for (size_t i = from; i < to; i++) {
       AqlValue const& a(_data[i * internalNrRegs() + column]);
 
       // determine current state
@@ -701,7 +716,8 @@ void AqlItemBlock::toVelocyPack(velocypack::Options const* const trxOptions, VPa
   result.add("raw", raw.slice());
 }
 
-void AqlItemBlock::rowToSimpleVPack(size_t const row, velocypack::Options const* options, arangodb::velocypack::Builder& builder) const {
+void AqlItemBlock::rowToSimpleVPack(size_t const row, velocypack::Options const* options,
+                                    arangodb::velocypack::Builder& builder) const {
   VPackArrayBuilder rowBuilder{&builder};
 
   if (isShadowRow(row)) {

--- a/arangod/Aql/AqlItemBlock.h
+++ b/arangod/Aql/AqlItemBlock.h
@@ -206,9 +206,17 @@ class AqlItemBlock {
   /// to which our AqlValues point will vanish.
   SharedAqlItemBlockPtr steal(std::vector<size_t> const& chosen, size_t from, size_t to);
 
-  /// @brief toJson, transfer a whole AqlItemBlock to Json, the result can
-  /// be used to recreate the AqlItemBlock via the Json constructor
+  /// @brief toJson, transfer all rows of this AqlItemBlock to Json, the result
+  /// can be used to recreate the AqlItemBlock via the Json constructor
   void toVelocyPack(velocypack::Options const*, arangodb::velocypack::Builder&) const;
+
+  /// @brief toJson, transfer a slice of this AqlItemBlock to Json, the result can
+  /// be used to recreate the AqlItemBlock via the Json constructor
+  /// The slice will be starting at line `from` (including) and end at line `to` (excluding).
+  /// Only calls with 0 <= from < to <= this.size() are allowed.
+  /// If you want to transfer the full block, use from == 0, to == this.size()
+  void toVelocyPack(size_t from, size_t to, velocypack::Options const*,
+                    arangodb::velocypack::Builder&) const;
 
   /// @brief Creates a human-readable velocypack of the block. Adds an object
   /// `{nrItems, nrRegs, matrix}` to the builder.

--- a/arangod/Aql/InputAqlItemRow.cpp
+++ b/arangod/Aql/InputAqlItemRow.cpp
@@ -119,135 +119,17 @@ SharedAqlItemBlockPtr InputAqlItemRow::cloneToBlock(AqlItemBlockManager& manager
 ///                  corresponding position
 ///  "raw":     List of actual values, positions 0 and 1 are always null
 ///                  such that actual indices start at 2
-void InputAqlItemRow::toVelocyPack(velocypack::Options const* const trxOptions, VPackBuilder& result) const {
+void InputAqlItemRow::toVelocyPack(velocypack::Options const* const trxOptions,
+                                   VPackBuilder& result) const {
   TRI_ASSERT(isInitialized());
   TRI_ASSERT(result.isOpenObject());
-  VPackOptions options(VPackOptions::Defaults);
-  options.buildUnindexedArrays = true;
-  options.buildUnindexedObjects = true;
+  _block->toVelocyPack(_baseIndex, _baseIndex + 1, trxOptions, result);
+}
 
-  VPackBuilder raw(&options);
-  raw.openArray();
-  // Two nulls in the beginning such that indices start with 2
-  raw.add(VPackValue(VPackValueType::Null));
-  raw.add(VPackValue(VPackValueType::Null));
-
-  result.add("nrItems", VPackValue(1));
-  result.add("nrRegs", VPackValue(getNrRegisters()));
-  result.add(StaticStrings::Error, VPackValue(false));
-
-  enum State {
-    Empty,       // saw an empty value
-    Range,       // saw a range value
-    Next,        // saw a previously unknown value
-    Positional,  // saw a value previously encountered
-  };
-
-  std::unordered_map<AqlValue, size_t> table;  // remember duplicates
-  size_t lastTablePos = 0;
-  State lastState = Positional;
-
-  State currentState = Positional;
-  size_t runLength = 0;
-  size_t tablePos = 0;
-
-  result.add("data", VPackValue(VPackValueType::Array));
-
-  // write out data buffered for repeated "empty" or "next" values
-  auto writeBuffered = [](State lastState, size_t lastTablePos,
-                          VPackBuilder& result, size_t runLength) {
-    if (lastState == Range) {
-      return;
-    }
-
-    if (lastState == Positional) {
-      if (lastTablePos >= 2) {
-        if (runLength == 1) {
-          result.add(VPackValue(lastTablePos));
-        } else {
-          result.add(VPackValue(-4));
-          result.add(VPackValue(runLength));
-          result.add(VPackValue(lastTablePos));
-        }
-      }
-    } else {
-      TRI_ASSERT(lastState == Empty || lastState == Next);
-      if (runLength == 1) {
-        // saw exactly one value
-        result.add(VPackValue(lastState == Empty ? 0 : 1));
-      } else {
-        // saw multiple values
-        result.add(VPackValue(lastState == Empty ? -1 : -3));
-        result.add(VPackValue(runLength));
-      }
-    }
-  };
-
-  size_t pos = 2;  // write position in raw
-  // We use column == 0 to simulate a shadowRow
-  // this is only relevant if all participants can use shadow rows
-  RegisterId startRegister = 0;
-  if (block().getFormatType() == SerializationFormat::CLASSIC) {
-    // Skip over the shadowRows
-    startRegister = 1;
-  }
-  for (RegisterId column = startRegister; column < getNrRegisters() + 1; column++) {
-    AqlValue const& a = column == 0 ? AqlValue{} : getValue(column - 1);
-    // determine current state
-    if (a.isEmpty()) {
-      currentState = Empty;
-    } else if (a.isRange()) {
-      currentState = Range;
-    } else {
-      auto it = table.find(a);
-
-      if (it == table.end()) {
-        currentState = Next;
-        a.toVelocyPack(trxOptions, raw, false);
-        table.try_emplace(a, pos++);
-      } else {
-        currentState = Positional;
-        tablePos = it->second;
-        TRI_ASSERT(tablePos >= 2);
-        if (lastState != Positional) {
-          lastTablePos = tablePos;
-        }
-      }
-    }
-
-    // handle state change
-    if (currentState != lastState || (currentState == Positional && tablePos != lastTablePos)) {
-      // write out remaining buffered data in case of a state change
-      writeBuffered(lastState, lastTablePos, result, runLength);
-
-      lastTablePos = 0;
-      lastState = currentState;
-      runLength = 0;
-    }
-
-    switch (currentState) {
-      case Empty:
-      case Next:
-      case Positional:
-        ++runLength;
-        lastTablePos = tablePos;
-        break;
-
-      case Range:
-        result.add(VPackValue(-2));
-        result.add(VPackValue(a.range()->_low));
-        result.add(VPackValue(a.range()->_high));
-        break;
-    }
-  }
-
-  // write out any remaining buffered data
-  writeBuffered(lastState, lastTablePos, result, runLength);
-
-  result.close();  // closes "data"
-
-  raw.close();
-  result.add("raw", raw.slice());
+void InputAqlItemRow::toSimpleVelocyPack(velocypack::Options const* trxOpts,
+                                         arangodb::velocypack::Builder& result) const {
+  TRI_ASSERT(_block != nullptr);
+  _block->rowToSimpleVPack(_baseIndex, trxOpts, result);
 }
 
 InputAqlItemRow::InputAqlItemRow(SharedAqlItemBlockPtr const& block, size_t baseIndex)
@@ -280,7 +162,9 @@ AqlValue InputAqlItemRow::stealValue(RegisterId registerId) {
   return a;
 }
 
-RegisterCount InputAqlItemRow::getNrRegisters() const noexcept { return block().getNrRegs(); }
+RegisterCount InputAqlItemRow::getNrRegisters() const noexcept {
+  return block().getNrRegs();
+}
 
 bool InputAqlItemRow::operator==(InputAqlItemRow const& other) const noexcept {
   return this->_block == other._block && this->_baseIndex == other._baseIndex;

--- a/arangod/Aql/InputAqlItemRow.h
+++ b/arangod/Aql/InputAqlItemRow.h
@@ -36,7 +36,7 @@ namespace arangodb {
 namespace velocypack {
 class Builder;
 struct Options;
-}
+}  // namespace velocypack
 namespace aql {
 
 class AqlItemBlock;
@@ -132,6 +132,8 @@ class InputAqlItemRow {
   /// be used to recreate the AqlItemBlock via the Json constructor
   /// Uses the same API as an AqlItemBlock with only a single row
   void toVelocyPack(velocypack::Options const*, arangodb::velocypack::Builder&) const;
+
+  void toSimpleVelocyPack(velocypack::Options const*, arangodb::velocypack::Builder&) const;
 
  private:
   AqlItemBlock& block() noexcept;


### PR DESCRIPTION
Fixes another bug found by rolling upgrade tests.
Now an upgrade DBServer complies with the old format of initialize cursor again.

As a side effect there is a generalized toVelocyPack() method on AqlItemBlocks to serialize any slice out of them.
Right now we only use 0->end aka ALL
And x -> x+1 aka initializeCursor

Added c++ test.
Only internal API.

Jenkins:
http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/7319/