### PR TITLE
test for USE_FAIL_ON_WARNINGS cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ option(VERBOSE "be verbose about flags used" OFF)
 
 # treat warnings as errors on some platforms
 option(USE_FAIL_ON_WARNINGS "treat warnings as errors (MSVC and MacOS only)" ON)
+message(STATUS "USE_FAIL_ON_WARNINGS IS SET TO: ${USE_FAIL_ON_WARNINGS}")
 
 # use strictly required OpenSSL version (from ./VERSIONS file)
 option(USE_STRICT_OPENSSL_VERSION "use strictly required OpenSSL version (from ./VERSIONS file)" ON)

--- a/arangod/RestServer/arangod.cpp
+++ b/arangod/RestServer/arangod.cpp
@@ -371,6 +371,8 @@ static void f() {
 #endif
 
 int main(int argc, char* argv[]) {
+  // variable intentionally not used. we only want to see if this makes the build fail
+  bool unused = true;
 #ifdef __linux__
   // Do not delete this! See above for an explanation.
   if (argc >= 1 && strcmp(argv[0], "not a/valid name") == 0) { f(); }


### PR DESCRIPTION
**Don't merge this - this is just for testing**

This is a test case for the `USE_FAIL_ON_WARNINGS` in Jenkins.

The PR intentionally adds an unused variable to a file, and it is expected that building ArangoDB triggers a compile warning which should be escalated to an error, and thus abort the build.

The value of `USE_FAIL_ON_WARNINGS` effectively used by cmake should be printed in the cmake output.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7323/