### PR TITLE
Direct Execution RestHandler

### DIFF
--- a/arangod/Cluster/RestClusterHandler.cpp
+++ b/arangod/Cluster/RestClusterHandler.cpp
@@ -41,7 +41,8 @@ using namespace arangodb::rest;
 RestClusterHandler::RestClusterHandler(application_features::ApplicationServer& server,
                                        GeneralRequest* request, GeneralResponse* response)
     : RestBaseHandler(server, request, response) {
-  _allowDirectExecution = true;
+  std::vector<std::string> const& suffixes = _request->suffixes();
+  _allowDirectExecution = !suffixes.empty() && suffixes[0] == "endpoints";
 }
 
 RestStatus RestClusterHandler::execute() {

--- a/arangod/Cluster/RestClusterHandler.cpp
+++ b/arangod/Cluster/RestClusterHandler.cpp
@@ -40,7 +40,9 @@ using namespace arangodb::rest;
 
 RestClusterHandler::RestClusterHandler(application_features::ApplicationServer& server,
                                        GeneralRequest* request, GeneralResponse* response)
-    : RestBaseHandler(server, request, response) {}
+    : RestBaseHandler(server, request, response) {
+  _allowDirectExecution = true;
+}
 
 RestStatus RestClusterHandler::execute() {
   if (_request->requestType() != RequestType::GET) {
@@ -58,8 +60,8 @@ RestStatus RestClusterHandler::execute() {
       handleAgencyDump();
       return RestStatus::DONE;
     }
-  } 
-  
+  }
+
   generateError(
     Result(TRI_ERROR_FORBIDDEN, "expecting _api/cluster/[endpoints,agency-dump]"));
 

--- a/arangod/Cluster/RestClusterHandler.h
+++ b/arangod/Cluster/RestClusterHandler.h
@@ -40,9 +40,6 @@ class RestClusterHandler : public arangodb::RestBaseHandler {
   /// _api/cluster/endpoints
   void handleCommandEndpoints();
 
-  /// _api/cluster/serverInfo
-  void handleCommandServerInfo();
-
   /// _api/cluster/agency-dump
   void handleAgencyDump();
 };

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -481,6 +481,7 @@ bool CommTask::handleRequestSync(std::shared_ptr<RestHandler> handler) {
   RequestLane lane = handler->getRequestLane();
   ContentType respType = handler->request()->contentTypeResponse();
   uint64_t mid = handler->messageId();
+  bool handlerAllowDirectExecution = handler->allowDirectExecution();
 
   // queue the operation in the scheduler, and make it eligible for direct execution
   // only if the current CommTask type allows it (HttpCommTask: yes, CommTask: no)
@@ -492,7 +493,7 @@ bool CommTask::handleRequestSync(std::shared_ptr<RestHandler> handler) {
       self->sendResponse(handler->stealResponse(), handler->stealStatistics());
     });
   };
-  bool ok = SchedulerFeature::SCHEDULER->queue(lane, std::move(cb), allowDirectHandling() && handler->allowDirectExecution());
+  bool ok = SchedulerFeature::SCHEDULER->queue(lane, std::move(cb), allowDirectHandling() && handlerAllowDirectExecution);
 
   if (!ok) {
     addErrorResponse(rest::ResponseCode::SERVICE_UNAVAILABLE,

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -486,7 +486,7 @@ bool CommTask::handleRequestSync(std::shared_ptr<RestHandler> handler) {
   // queue the operation in the scheduler, and make it eligible for direct execution
   // only if the current CommTask type allows it (HttpCommTask: yes, CommTask: no)
   // and there is currently only a single client handled by the IoContext
-  auto cb = [self = shared_from_this(), handler = std::move(handler)]() {
+  auto cb = [self = shared_from_this(), handler = std::move(handler)]() mutable {
     RequestStatistics::SET_QUEUE_END(handler->statistics());
     handler->runHandler([self = std::move(self)](rest::RestHandler* handler) {
       // Pass the response the io context

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -492,7 +492,7 @@ bool CommTask::handleRequestSync(std::shared_ptr<RestHandler> handler) {
       self->sendResponse(handler->stealResponse(), handler->stealStatistics());
     });
   };
-  bool ok = SchedulerFeature::SCHEDULER->queue(lane, std::move(cb), allowDirectHandling());
+  bool ok = SchedulerFeature::SCHEDULER->queue(lane, std::move(cb), allowDirectHandling() && handler->allowDirectExecution());
 
   if (!ok) {
     addErrorResponse(rest::ResponseCode::SERVICE_UNAVAILABLE,

--- a/arangod/GeneralServer/RestHandler.h
+++ b/arangod/GeneralServer/RestHandler.h
@@ -108,6 +108,9 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
   // what lane to use for this request
   virtual RequestLane lane() const = 0;
 
+  // return true if direct handler execution is allowed
+  bool allowDirectExecution() const { return _allowDirectExecution; }
+
   RequestLane getRequestLane() {
     bool found;
     _request->header(StaticStrings::XArangoFrontend, found);
@@ -204,20 +207,22 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
   RequestStatistics* _statistics;
 
  private:
-  
+
   mutable Mutex _executionMutex;
 
   std::function<void(rest::RestHandler*)> _callback;
-  
+
   uint64_t _handlerId;
 
   std::atomic<std::thread::id> _executionMutexOwner;
-  
+
   HandlerState _state;
-  
+
  protected:
-  
+
   std::atomic<bool> _canceled;
+
+  bool _allowDirectExecution = false;
 };
 
 }  // namespace rest

--- a/arangod/RestHandler/RestAdminLogHandler.cpp
+++ b/arangod/RestHandler/RestAdminLogHandler.cpp
@@ -38,7 +38,9 @@ using namespace arangodb::rest;
 
 RestAdminLogHandler::RestAdminLogHandler(application_features::ApplicationServer& server,
                                          GeneralRequest* request, GeneralResponse* response)
-    : RestBaseHandler(server, request, response) {}
+    : RestBaseHandler(server, request, response) {
+  _allowDirectExecution = true;
+}
 
 RestStatus RestAdminLogHandler::execute() {
   auto& server = application_features::ApplicationServer::server();

--- a/arangod/RestHandler/RestAdminServerHandler.cpp
+++ b/arangod/RestHandler/RestAdminServerHandler.cpp
@@ -39,7 +39,9 @@ using namespace arangodb::rest;
 RestAdminServerHandler::RestAdminServerHandler(application_features::ApplicationServer& server,
                                                GeneralRequest* request,
                                                GeneralResponse* response)
-    : RestBaseHandler(server, request, response) {}
+    : RestBaseHandler(server, request, response) {
+  _allowDirectExecution = true;
+}
 
 RestStatus RestAdminServerHandler::execute() {
   std::vector<std::string> const& suffixes = _request->suffixes();

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -47,7 +47,7 @@ RestDocumentHandler::RestDocumentHandler(application_features::ApplicationServer
                                          GeneralRequest* request, GeneralResponse* response)
     : RestVocbaseBaseHandler(server, request, response) {
   if(request->requestType() == rest::RequestType::POST
-      && request->contentLength() > 120) {
+      && request->contentLength() <= 1024) {
     _allowDirectExecution = true;
   }
 }

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -45,7 +45,12 @@ using namespace arangodb::rest;
 
 RestDocumentHandler::RestDocumentHandler(application_features::ApplicationServer& server,
                                          GeneralRequest* request, GeneralResponse* response)
-    : RestVocbaseBaseHandler(server, request, response) {}
+    : RestVocbaseBaseHandler(server, request, response) {
+  if(request->requestType() == rest::RequestType::POST
+      && request->contentLength() > 120) {
+    _allowDirectExecution = true;
+  }
+}
 
 RestDocumentHandler::~RestDocumentHandler() = default;
 

--- a/arangod/RestHandler/RestEngineHandler.cpp
+++ b/arangod/RestHandler/RestEngineHandler.cpp
@@ -35,17 +35,19 @@ using namespace arangodb::rest;
 
 RestEngineHandler::RestEngineHandler(application_features::ApplicationServer& server,
                                      GeneralRequest* request, GeneralResponse* response)
-    : RestBaseHandler(server, request, response) {}
+    : RestBaseHandler(server, request, response) {
+  _allowDirectExecution = true;
+}
 
 RestStatus RestEngineHandler::execute() {
   // extract the sub-request type
   auto const type = _request->requestType();
-  
+
   if (type != rest::RequestType::GET) {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED, TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
     return RestStatus::DONE;
   }
-  
+
   handleGet();
   return RestStatus::DONE;
 }
@@ -70,7 +72,7 @@ void RestEngineHandler::handleGet() {
   if (!security.canAccessHardenedApi()) {
     // dont leak information about server internals here
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_FORBIDDEN);
-    return; 
+    return;
   }
 
   // access to engine stats is disallowed in hardened mode

--- a/arangod/RestHandler/RestJobHandler.cpp
+++ b/arangod/RestHandler/RestJobHandler.cpp
@@ -43,6 +43,7 @@ RestJobHandler::RestJobHandler(application_features::ApplicationServer& server,
                                AsyncJobManager* jobManager)
     : RestBaseHandler(server, request, response), _jobManager(jobManager) {
   TRI_ASSERT(jobManager != nullptr);
+  _allowDirectExecution = true;
 }
 
 RestStatus RestJobHandler::execute() {

--- a/arangod/RestHandler/RestPleaseUpgradeHandler.cpp
+++ b/arangod/RestHandler/RestPleaseUpgradeHandler.cpp
@@ -31,11 +31,13 @@ using velocypack::StringRef;
 RestPleaseUpgradeHandler::RestPleaseUpgradeHandler(application_features::ApplicationServer& server,
                                                    GeneralRequest* request,
                                                    GeneralResponse* response)
-    : RestHandler(server, request, response) {}
+    : RestHandler(server, request, response) {
+  _allowDirectExecution = true;
+}
 
 RestStatus RestPleaseUpgradeHandler::execute() {
   resetResponse(rest::ResponseCode::OK);
-  
+
   _response->setContentType(rest::ContentType::TEXT);
   _response->addRawPayload(StringRef("Database: "));
   _response->addRawPayload(StringRef(_request->databaseName()));

--- a/arangod/RestHandler/RestShutdownHandler.cpp
+++ b/arangod/RestHandler/RestShutdownHandler.cpp
@@ -39,7 +39,9 @@ using namespace arangodb::rest;
 
 RestShutdownHandler::RestShutdownHandler(application_features::ApplicationServer& server,
                                          GeneralRequest* request, GeneralResponse* response)
-    : RestBaseHandler(server, request, response) {}
+    : RestBaseHandler(server, request, response) {
+  _allowDirectExecution = true;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief was docuBlock JSF_get_api_initiate

--- a/arangod/RestHandler/RestStatusHandler.cpp
+++ b/arangod/RestHandler/RestStatusHandler.cpp
@@ -49,7 +49,9 @@ using namespace arangodb::rest;
 
 RestStatusHandler::RestStatusHandler(application_features::ApplicationServer& server,
                                      GeneralRequest* request, GeneralResponse* response)
-    : RestBaseHandler(server, request, response) {}
+    : RestBaseHandler(server, request, response) {
+  _allowDirectExecution = true;
+}
 
 RestStatus RestStatusHandler::execute() {
   auto& server = application_features::ApplicationServer::server();
@@ -57,7 +59,7 @@ RestStatus RestStatusHandler::execute() {
 
   if (!security.canAccessHardenedApi()) {
     // dont leak information about server internals here
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_FORBIDDEN); 
+    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_FORBIDDEN);
     return RestStatus::DONE;
   }
 

--- a/arangod/RestHandler/RestVersionHandler.cpp
+++ b/arangod/RestHandler/RestVersionHandler.cpp
@@ -41,7 +41,9 @@ using namespace arangodb::rest;
 
 RestVersionHandler::RestVersionHandler(application_features::ApplicationServer& server,
                                        GeneralRequest* request, GeneralResponse* response)
-    : RestBaseHandler(server, request, response) {}
+    : RestBaseHandler(server, request, response) {
+  _allowDirectExecution = true;
+}
 
 RestStatus RestVersionHandler::execute() {
   VPackBuilder result;


### PR DESCRIPTION
Ask the handler for direct execution instead of just looking at the RequestLane. This became necessary because in some cases the IOContext executed long running tasks and the server became unresponsive.