### PR TITLE
obsolete option `--vst.maxsize` requires a value if specified

### DIFF
--- a/arangod/RestServer/ServerFeature.cpp
+++ b/arangod/RestServer/ServerFeature.cpp
@@ -96,7 +96,7 @@ void ServerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addSection("vst", "Configure the VelocyStream protocol");
 
   options->addObsoleteOption("--vst.maxsize", "maximal size (in bytes) "
-                             "for a VelocyPack chunk", false);
+                             "for a VelocyPack chunk", true);
 
 #if _WIN32
   options->addOption("--console.code-page",


### PR DESCRIPTION
### Scope & Purpose

Fix handling of obsolete option `--vst.maxsize`.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7388/