### PR TITLE
use isDirect for slightly different cases

### DIFF
--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -46,9 +46,17 @@ using namespace arangodb::rest;
 RestDocumentHandler::RestDocumentHandler(application_features::ApplicationServer& server,
                                          GeneralRequest* request, GeneralResponse* response)
     : RestVocbaseBaseHandler(server, request, response) {
-  if(request->requestType() == rest::RequestType::POST
-      && request->contentLength() <= 1024) {
-    _allowDirectExecution = true;
+  
+  if (!ServerState::instance()->isClusterRole()) {
+    auto const type = _request->requestType();
+    if ((type == rest::RequestType::GET ||
+         type == rest::RequestType::POST ||
+         type == rest::RequestType::PUT ||
+         type == rest::RequestType::PATCH ||
+         type == rest::RequestType::DELETE_REQ) &&
+        request->contentLength() <= 1024) {
+      _allowDirectExecution = true;
+    }
   }
 }
 

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -48,6 +48,8 @@ RestDocumentHandler::RestDocumentHandler(application_features::ApplicationServer
     : RestVocbaseBaseHandler(server, request, response) {
   
   if (!ServerState::instance()->isClusterRole()) {
+    // in the cluster we will have (blocking) communication, so we only
+    // want the request to be executed directly when we are on a single server.
     auto const type = _request->requestType();
     if ((type == rest::RequestType::GET ||
          type == rest::RequestType::POST ||
@@ -55,6 +57,7 @@ RestDocumentHandler::RestDocumentHandler(application_features::ApplicationServer
          type == rest::RequestType::PATCH ||
          type == rest::RequestType::DELETE_REQ) &&
         request->contentLength() <= 1024) {
+      // only allow direct execution if we don't have huge payload
       _allowDirectExecution = true;
     }
   }


### PR DESCRIPTION
### Scope & Purpose

Don't use *isDirect* in cluster, when we will very likely have blocking communication.
Additionally, allow usage of *isDirect* in more (single server) cases.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *shell_client, http_server*.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7440/
