### PR TITLE
don't re-use connection objects on windows and mac either

### DIFF
--- a/3rdParty/fuerte/src/GeneralConnection.cpp
+++ b/3rdParty/fuerte/src/GeneralConnection.cpp
@@ -76,7 +76,7 @@ void GeneralConnection<ST>::shutdownConnection(const Error err,
   if (state != Connection::State::Failed) {
     state = Connection::State::Disconnected;
     // hack to fix SSL streams
-    if (_config._socketType == SocketType::Ssl) {
+    if constexpr (ST == SocketType::Ssl) {
       state = Connection::State::Failed;
     }
     _state.store(state);

--- a/3rdParty/fuerte/src/GeneralConnection.cpp
+++ b/3rdParty/fuerte/src/GeneralConnection.cpp
@@ -75,12 +75,10 @@ void GeneralConnection<ST>::shutdownConnection(const Error err,
   auto state = _state.load();
   if (state != Connection::State::Failed) {
     state = Connection::State::Disconnected;
-#ifdef __linux__
-    // hack to fix SSL streams on linux
+    // hack to fix SSL streams
     if (_config._socketType == SocketType::Ssl) {
       state = Connection::State::Failed;
     }
-#endif
     _state.store(state);
   }
 


### PR DESCRIPTION
This fixes `ssl_server` cluster tests failing on mac & windows. 