### PR TITLE
wait for suicide to actually take place before we fail this

### DIFF
--- a/lib/Basics/debugging.cpp
+++ b/lib/Basics/debugging.cpp
@@ -109,6 +109,7 @@ void TRI_TerminateDebugging(char const* message) {
   WaitForSingleObject(hSelf, INFINITE);
 #else
   kill(getpid(), SIGKILL);  //to kill the complete process tree.
+  std::this_thread::sleep_for(std::chrono::seconds(5));
 #endif
 
   // ensure the process is terminated


### PR DESCRIPTION

It seems as if our macs need a little more time for the suicide.
```
2019-11-28T13:53:18Z [93394] S WARNING [d8a5f] activating intentional failure point 'FlushCrashAfterSyncingMinTick'. the server will misbehave!
2019-11-28T13:53:18Z [93394] S WARNING [bde58] crashing after syncing min tick: summon Baal!
2019-11-28T13:53:18Z [93394] S FATAL [36a91] assertion failed in /Users/jenkins/vm13-mac/oskar/work/ArangoDB/lib/Basics/debugging.cpp:115: false
Thu Nov 28 2019 14:53:41 GMT+0100 (Central European Standard Time) Finished: ABORTED Signal: 6 Time elapsed: 27.486166954040527 - 
```

http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/7476/