### PR TITLE
Replication: New startup options available from v3.5.3 on, not v3.5.4

### DIFF
--- a/arangod/Replication/ReplicationFeature.cpp
+++ b/arangod/Replication/ReplicationFeature.cpp
@@ -88,11 +88,11 @@ void ReplicationFeature::collectOptions(std::shared_ptr<ProgramOptions> options)
   options->addOption("--replication.connect-timeout",
                      "Default timeout value for replication connection attempts (in seconds)",
                      new DoubleParameter(&_connectTimeout))
-                     .setIntroducedIn(30409).setIntroducedIn(30504);
+                     .setIntroducedIn(30409).setIntroducedIn(30503);
   options->addOption("--replication.request-timeout",
                      "Default timeout value for replication requests (in seconds)",
                      new DoubleParameter(&_requestTimeout))
-                     .setIntroducedIn(30409).setIntroducedIn(30504);
+                     .setIntroducedIn(30409).setIntroducedIn(30503);
 }
 
 void ReplicationFeature::validateOptions(std::shared_ptr<options::ProgramOptions> options) {


### PR DESCRIPTION
From 3.5.3 release email:

> * Make the timeouts for replication requests (for active failover and master-slave replication) configurable via startup options:
>
>      --replication.connect-timeout
>      --replication.request-timeout

`--dump-options` reports them as being introduced in v3.5.4

Blocks update of online docs for 3.5.3