### PR TITLE
Docs: Remove Cookbook placeholder file

### DIFF
--- a/Documentation/Books/Cookbook/.gitkeep
+++ b/Documentation/Books/Cookbook/.gitkeep
@@ -1,5 +1,0 @@
-Git can not track empty repositories.
-This file ensures that the directory is kept.
-
-Some of the old documentation building scripts are still
-used by the new system which copy files into this folder.


### PR DESCRIPTION
Jenkins job `arangodb-ANY-examples` checks if the folder exists, so we have to remove it from the versions where there is no Cookbook in docs repo anymore (3.5, 3.6).