### PR TITLE
  fix buffer overflow

### DIFF
--- a/3rdParty/iresearch/core/utils/log.hpp
+++ b/3rdParty/iresearch/core/utils/log.hpp
@@ -87,7 +87,7 @@ NS_END
 #if defined(_MSC_VER)
   #define IR_LOG_FORMATED(level, prefix, format, ...) \
     if (::iresearch::logger::enabled(level)) \
-      std::fprintf(::iresearch::logger::output(level), "%s: %s:%u " format "\n", prefix, __FILE__, __LINE__, __VA_ARGS__)
+      std::fprintf(::iresearch::logger::output(level), "%s: %s:%d " format "\n", prefix, __FILE__, __LINE__, __VA_ARGS__)
 
   #define IR_FRMT_FATAL(format, ...) IR_LOG_FORMATED(::iresearch::logger::IRL_FATAL, "FATAL", format, __VA_ARGS__)
   #define IR_FRMT_ERROR(format, ...) IR_LOG_FORMATED(::iresearch::logger::IRL_ERROR, "ERROR", format, __VA_ARGS__)
@@ -98,7 +98,7 @@ NS_END
 #else // use a GNU extension for ignoring the trailing comma: ', ##__VA_ARGS__'
   #define IR_LOG_FORMATED(level, prefix, format, ...) \
     if (::iresearch::logger::enabled(level)) \
-      std::fprintf(::iresearch::logger::output(level), "%s: %s:%u " format "\n", prefix, __FILE__, __LINE__, ##__VA_ARGS__)
+      std::fprintf(::iresearch::logger::output(level), "%s: %s:%d " format "\n", prefix, __FILE__, __LINE__, ##__VA_ARGS__)
 
   #define IR_FRMT_FATAL(format, ...) IR_LOG_FORMATED(::iresearch::logger::IRL_FATAL, "FATAL", format, ##__VA_ARGS__)
   #define IR_FRMT_ERROR(format, ...) IR_LOG_FORMATED(::iresearch::logger::IRL_ERROR, "ERROR", format, ##__VA_ARGS__)

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -120,7 +120,7 @@ class IdentityAnalyzer final : public irs::analysis::analyzer {
  public:
   DECLARE_ANALYZER_TYPE();
 
-  static bool normalize(const irs::string_ref& /*args*/, std::string& out) noexcept {
+  static bool normalize(const irs::string_ref& /*args*/, std::string& out) {
     out.resize(VPackSlice::emptyObjectSlice().byteSize());
     std::memcpy(&out[0], VPackSlice::emptyObjectSlice().begin(), out.size());
     return true;
@@ -194,7 +194,7 @@ bool parse_delimiter_vpack_config(const irs::string_ref& args, std::string& deli
   return false;
 }
 
-irs::analysis::analyzer::ptr delimiter_vpack_builder(irs::string_ref const& args) noexcept {
+irs::analysis::analyzer::ptr delimiter_vpack_builder(irs::string_ref const& args) {
   std::string delimiter;
   if (parse_delimiter_vpack_config(args, delimiter)) {
     return irs::analysis::delimited_token_stream::make(delimiter);
@@ -202,7 +202,7 @@ irs::analysis::analyzer::ptr delimiter_vpack_builder(irs::string_ref const& args
   return nullptr;
 }
 
-bool delimiter_vpack_normalizer(const irs::string_ref& args, std::string& out) noexcept {
+bool delimiter_vpack_normalizer(const irs::string_ref& args, std::string& out) {
   std::string tmp;
   if (parse_delimiter_vpack_config(args, tmp)) {
     VPackBuilder vpack;
@@ -280,10 +280,11 @@ bool parse_ngram_vpack_config(const irs::string_ref& args, irs::analysis::ngram_
       options.start_marker = irs::ref_cast<irs::byte_type>(
         arangodb::iresearch::getStringRef(start_marker_json));
     } else {
+      std::string argString = slice.toJson();
       IR_FRMT_ERROR(
           "Failed to read '%s' attribute as string while constructing "
           "ngram_token_stream from jSON arguments: %s",
-          START_MARKER_PARAM_NAME.c_str(), args.c_str());
+          START_MARKER_PARAM_NAME.c_str(), argString.c_str());
       return false;
     }
   }
@@ -294,10 +295,11 @@ bool parse_ngram_vpack_config(const irs::string_ref& args, irs::analysis::ngram_
       options.end_marker = irs::ref_cast<irs::byte_type>(
         arangodb::iresearch::getStringRef(end_marker_json));
     } else {
+      std::string argString = slice.toJson();
       IR_FRMT_ERROR(
           "Failed to read '%s' attribute as string while constructing "
           "ngram_token_stream from jSON arguments: %s",
-          END_MARKER_PARAM_NAME.c_str(), args.c_str());
+          END_MARKER_PARAM_NAME.c_str(), argString.c_str());
       return false;
     }
   }
@@ -395,7 +397,7 @@ REGISTER_ANALYZER_VPACK(irs::analysis::ngram_token_stream_base,
 
 namespace text_vpack {
 // FIXME implement proper vpack parsing
-irs::analysis::analyzer::ptr text_vpack_builder(irs::string_ref const& args) noexcept {
+irs::analysis::analyzer::ptr text_vpack_builder(irs::string_ref const& args) {
   auto slice = arangodb::iresearch::slice<char>(args);
   if (!slice.isNone()) {
     return irs::analysis::analyzers::get("text", irs::text_format::json,
@@ -405,7 +407,7 @@ irs::analysis::analyzer::ptr text_vpack_builder(irs::string_ref const& args) noe
   return nullptr;
 }
 
-bool text_vpack_normalizer(const irs::string_ref& args, std::string& out) noexcept {
+bool text_vpack_normalizer(const irs::string_ref& args, std::string& out) {
   std::string tmp;
   auto slice = arangodb::iresearch::slice<char>(args);
 
@@ -426,7 +428,7 @@ REGISTER_ANALYZER_VPACK(irs::analysis::text_token_stream, text_vpack_builder,
 
 namespace stem_vpack {
   // FIXME implement proper vpack parsing
-  irs::analysis::analyzer::ptr stem_vpack_builder(irs::string_ref const& args) noexcept {
+  irs::analysis::analyzer::ptr stem_vpack_builder(irs::string_ref const& args) {
     auto slice = arangodb::iresearch::slice<char>(args);
     if (!slice.isNone()) {
       return irs::analysis::analyzers::get("stem", irs::text_format::json,
@@ -436,7 +438,7 @@ namespace stem_vpack {
     return nullptr;
   }
 
-  bool stem_vpack_normalizer(const irs::string_ref& args, std::string& out) noexcept {
+  bool stem_vpack_normalizer(const irs::string_ref& args, std::string& out) {
     std::string tmp;
     auto slice = arangodb::iresearch::slice<char>(args);
     if (!slice.isNone() &&
@@ -455,7 +457,7 @@ namespace stem_vpack {
 
 namespace norm_vpack {
   // FIXME implement proper vpack parsing
-  irs::analysis::analyzer::ptr norm_vpack_builder(irs::string_ref const& args) noexcept {
+  irs::analysis::analyzer::ptr norm_vpack_builder(irs::string_ref const& args) {
     auto slice = arangodb::iresearch::slice<char>(args);
     if (!slice.isNone()) {//cannot be created without properties
       return irs::analysis::analyzers::get("norm", irs::text_format::json,
@@ -465,7 +467,7 @@ namespace norm_vpack {
     return nullptr;
   }
 
-  bool norm_vpack_normalizer(const irs::string_ref& args, std::string& out) noexcept {
+  bool norm_vpack_normalizer(const irs::string_ref& args, std::string& out) {
     std::string tmp;
     auto slice = arangodb::iresearch::slice<char>(args);
     if (!slice.isNone() && //cannot be created without properties

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -306,18 +306,20 @@ bool parse_ngram_vpack_config(const irs::string_ref& args, irs::analysis::ngram_
       auto stream_type_json = slice.get(STREAM_TYPE_PARAM_NAME.c_str());
 
       if (!stream_type_json.isString()) {
+        std::string argString = slice.toJson();
         IR_FRMT_WARN(
             "Non-string value in '%s' while constructing ngram_token_stream "
             "from jSON arguments: %s",
-            STREAM_TYPE_PARAM_NAME.c_str(), args.c_str());
+            STREAM_TYPE_PARAM_NAME.c_str(), argString.c_str());
         return false;
       }
       auto itr = STREAM_TYPE_CONVERT_MAP.find(arangodb::iresearch::getStringRef(stream_type_json));
       if (itr == STREAM_TYPE_CONVERT_MAP.end()) {
+        std::string argString = slice.toJson();
         IR_FRMT_WARN(
             "Invalid value in '%s' while constructing ngram_token_stream from "
             "jSON arguments: %s",
-            STREAM_TYPE_PARAM_NAME.c_str(), args.c_str());
+            STREAM_TYPE_PARAM_NAME.c_str(), argString.c_str());
         return false;
       }
       options.stream_bytes_type = itr->second;
@@ -334,7 +336,7 @@ bool parse_ngram_vpack_config(const irs::string_ref& args, irs::analysis::ngram_
 }
 
 
-irs::analysis::analyzer::ptr ngram_vpack_builder(irs::string_ref const& args) noexcept {
+irs::analysis::analyzer::ptr ngram_vpack_builder(irs::string_ref const& args) {
   irs::analysis::ngram_token_stream_base::Options tmp;
   if (parse_ngram_vpack_config(args, tmp)) {
     switch (tmp.stream_bytes_type) {
@@ -349,7 +351,7 @@ irs::analysis::analyzer::ptr ngram_vpack_builder(irs::string_ref const& args) no
 }
 
 
-bool ngram_vpack_normalizer(const irs::string_ref& args, std::string& out) noexcept {
+bool ngram_vpack_normalizer(const irs::string_ref& args, std::string& out) {
   irs::analysis::ngram_token_stream_base::Options tmp;
   if (parse_ngram_vpack_config(args, tmp)) {
     VPackBuilder vpack;


### PR DESCRIPTION
### Scope & Purpose

Fix a potential buffer overflow when stringfying arbitrary vpack objects

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as `scripts/unittest shell_server_aql --test tests/js/common/aql/aql-view-arangosearch-feature.js`.

Additionally:

- [x] I ensured this code runs with ASan / TSan or other static verification tools

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7521/