### PR TITLE
tag dynamic options with Dynamic flags attribute

### DIFF
--- a/arangosh/Shell/ConsoleFeature.cpp
+++ b/arangosh/Shell/ConsoleFeature.cpp
@@ -114,7 +114,8 @@ void ConsoleFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addSection("console", "Configure the console");
 
   options->addOption("--console.colors", "enable color support",
-                     new BooleanParameter(&_colors));
+                     new BooleanParameter(&_colors),
+                     arangodb::options::makeFlags(arangodb::options::Flags::Dynamic));
 
   options->addOption("--console.auto-complete", "enable auto completion",
                      new BooleanParameter(&_autoComplete));

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -94,7 +94,8 @@ void LoggerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addSection("log", "Configure the logging");
 
   options->addOption("--log.color", "use colors for TTY logging",
-                     new BooleanParameter(&_useColor));
+                     new BooleanParameter(&_useColor),
+                     arangodb::options::makeFlags(arangodb::options::Flags::Dynamic));
 
   options->addOption("--log.escape", "escape characters when logging",
                      new BooleanParameter(&_useEscaped));
@@ -181,7 +182,8 @@ void LoggerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
 
   options->addOption("--log.foreground-tty", "also log to tty if backgrounded",
                      new BooleanParameter(&_foregroundTty),
-                     arangodb::options::makeFlags(arangodb::options::Flags::Hidden));
+                     arangodb::options::makeFlags(arangodb::options::Flags::Hidden,
+                                                  arangodb::options::Flags::Dynamic));
 
   options->addOption("--log.force-direct",
                      "do not start a seperate thread for logging",

--- a/lib/ProgramOptions/Option.cpp
+++ b/lib/ProgramOptions/Option.cpp
@@ -105,7 +105,10 @@ void Option::printHelp(std::string const& search, size_t tw, size_t ow, bool) co
         value.append(". ");
         value.append(description);
       }
-      value += " (default: " + parameter->valueString() + ")";
+
+      if (!hasFlag(arangodb::options::Flags::Command)) {
+        value += " (default: " + parameter->valueString() + ")";
+      }
       if (hasIntroducedIn()) {
         value += " (introduced in " + introducedInString() + ")";
       }

--- a/lib/ProgramOptions/ProgramOptions.cpp
+++ b/lib/ProgramOptions/ProgramOptions.cpp
@@ -178,8 +178,12 @@ VPackBuilder ProgramOptions::toVPack(bool onlyTouched, bool detailed,
           if (!values.empty()) {
             builder.add("values", VPackValue(values));
           }
-          builder.add(VPackValue("default"));
-          option.toVPack(builder);
+          if (!option.hasFlag(arangodb::options::Flags::Command)) {
+            // command-like options are commands, thus they shouldn't have
+            // a "default" value
+            builder.add(VPackValue("default"));
+            option.toVPack(builder);
+          }
           builder.add("dynamic",
                       VPackValue(option.hasFlag(arangodb::options::Flags::Dynamic)));
           builder.close();


### PR DESCRIPTION
### Scope & Purpose

As agreed with @Simran-B, tag a few dynamic options as "Dynamic", so it is clear that their default value depends on the runtime environment.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7533/