### PR TITLE
Explain now prints the RETURN of a spliced subquery again

### DIFF
--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -1489,7 +1489,7 @@ function processQuery(query, explain, planIndex) {
       case 'SubqueryStartNode':
         return `${keyword('LET')} ${variableName(node.subqueryOutVariable)} = ( ${annotation(`/* subquery begin */`)}` ;
       case 'SubqueryEndNode':
-        return `) ${annotation(`/* subquery end */`)}`;
+        return `${keyword('RETURN')}  ${variableName(node.inVariable)} ) ${annotation(`/* subquery end */`)}`;
       case 'InsertNode': {
         modificationFlags = node.modificationFlags;
         let restrictString = '';


### PR DESCRIPTION
Bugfix for Explain only.

No critical change, data is all correct.
It helps a user to better read the Explain output.

http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/7552/