### PR TITLE
already reap lock bugfix

### DIFF
--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -362,10 +362,13 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice const& info,
     }
 
     // Step 4. fill index
-    const bool inBackground =
-    basics::VelocyPackHelper::getBooleanValue(info, StaticStrings::IndexInBackground, false);
+    bool const inBackground =
+        basics::VelocyPackHelper::getBooleanValue(info, StaticStrings::IndexInBackground, false);
     if (inBackground) {  // allow concurrent inserts into index
-      _indexes.emplace(buildIdx);
+      {
+        WRITE_LOCKER(guard, _indexesLock);
+        _indexes.emplace(buildIdx);
+      }
       res = buildIdx->fillIndexBackground(locker);
     } else {
       res = buildIdx->fillIndexForeground();


### PR DESCRIPTION
### Scope & Purpose

Create separate PR for locking bugfix, so it can be merged already, before https://github.com/arangodb/arangodb/pull/10621 is completely ready.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests:
* start single server
* connect with arangosh and run `while (require("jsunity").runTest("tests/js/common/shell/aql-index-usage-rocksdb.js"));` until it fails/crashes/succeeds

Additionally:

- [x] I ensured this code runs with ASan / TSan or other static verification tools

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7566/