### PR TITLE
try to make shell-ttl less time-dependent

### DIFF
--- a/tests/js/common/shell/shell-ttl.js
+++ b/tests/js/common/shell/shell-ttl.js
@@ -47,6 +47,16 @@ function TtlSuite () {
       numServers = Object.values(collection.shards(true)).filter(function(value, index, self) {
         return self.indexOf(value) === index;
       }).length;
+      // if there are multiple servers involved, we increase by 3, in order to avoid continuing
+      // in case the the *same* server reports multiple times. this would break the simple
+      // "how many times did it run check" in case the jobs are executed in the following order:
+      // - job run on server 1
+      // - job run on server 2
+      // - job run on server 1 (3 executions, but not from 3 different servers!)
+      // - job run on server 3
+      // - job run on server 2
+      // - job run on server 3
+      numServers *= 3;
     } catch (err) {
       // collection.shards() will throw when not running in cluster mode
       numServers = 1;
@@ -508,7 +518,7 @@ function TtlSuite () {
 
       // both number of runs and deletions must have changed
       assertNotEqual(stats.runs, oldStats.runs);
-      assertEqual(stats.documentsRemoved, oldStats.documentsRemoved + 1000);
+      assertEqual(stats.documentsRemoved, oldStats.documentsRemoved + 1000); 
 
       assertEqual(1, db._collection(cn).count());
       assertEqual(dt, db._collection(cn).any().dateCreated);


### PR DESCRIPTION
### Scope & Purpose

Try to make `shell-ttl` test in cluster less timing-dependent.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is an internal planning ticket: https://github.com/arangodb/release-3.6/issues/17

### Testing & Verification

This change is already covered by existing tests, such as `scripts/unittest shell_client --test shell-ttl --cluster true`.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7581/