### PR TITLE
fix startup when using multiple coordinators.

### DIFF
--- a/arangod/Auth/UserManager.cpp
+++ b/arangod/Auth/UserManager.cpp
@@ -374,6 +374,8 @@ void auth::UserManager::createRootUser() {
     // No action
     LOG_TOPIC("268eb", ERR, Logger::AUTHENTICATION) << "unable to create user \"root\"";
   }
+
+  triggerGlobalReload();
 }
 
 VPackBuilder auth::UserManager::allUsers() {


### PR DESCRIPTION
### Scope & Purpose

in case multiple coordinators were used, the one that won the cluster
bootstrap race created the "root" user and was fine afterwards. other
coordinators however were not notified of the new user, and were denying
all incoming requests with an HTTP 401 "not allowed to execute this
request" response.
the change in this PR triggers an increase of the UserVersion counter
in the agency, so that other coordinators eventually get aware of the
root user being added.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

- [x] There is an internal planning ticket: https://github.com/arangodb/release-3.6/issues/13

### Testing & Verification

Start a cluster with 2 coordinators and authentication, and poll `/_api/version` for both of them repeatedly, e.g.
```
while true; do curl --insecure --user "root:" -X GET http://127.0.0.1:8530/_api/version -v --dump - 2>&1; done
while true; do curl --insecure --user "root:" -X GET http://127.0.0.1:8531/_api/version -v --dump - 2>&1; done
```
Without the fix, only one of the coordinators will eventually respond with HTTP 200, whereas the other will remain returning HTTP 401 responses.
With the fix, both should eventually return HTTP 200.
This can also be verified via the driver tests in our Jenkins.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7585/