### PR TITLE
speculative fix for multi-coordinator bootstrap

### DIFF
--- a/arangod/Auth/UserManager.cpp
+++ b/arangod/Auth/UserManager.cpp
@@ -375,6 +375,8 @@ void auth::UserManager::createRootUser() {
     // No action
     LOG_TOPIC("268eb", ERR, Logger::AUTHENTICATION) << "unable to create user \"root\"";
   }
+
+  triggerGlobalReload();
 }
 
 VPackBuilder auth::UserManager::allUsers() {


### PR DESCRIPTION
### Scope & Purpose

in case multiple coordinators were used, the one that won the cluster
bootstrap race created the "root" user and was fine afterwards. other
coordinators however were not notified of the new user, and were denying
all incoming requests with an HTTP 401 "not allowed to execute this
request" response.
the change in this PR triggers an increase of the UserVersion counter
in the agency, so that other coordinators eventually get aware of the
root user being added.

It looks like in 3.5 this change is actually not needed, as the coordinators
start fine. But the "fix" doesn't do any harm.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

- [x] There is an internal planning ticket: https://github.com/arangodb/release-3.6/issues/13

### Testing & Verification

Start a cluster with 2 coordinators and authentication, and poll `/_api/version` for both of them repeatedly, e.g.
```
while true; do curl --insecure --user "root:" -X GET http://127.0.0.1:8530/_api/version -v --dump - 2>&1; done
while true; do curl --insecure --user "root:" -X GET http://127.0.0.1:8531/_api/version -v --dump - 2>&1; done
```
With and without the fix, both should eventually return HTTP 200.
This can also be verified via the driver tests in our Jenkins.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7586/