### PR TITLE
always create the statistics collections

### DIFF
--- a/arangod/VocBase/Methods/UpgradeTasks.cpp
+++ b/arangod/VocBase/Methods/UpgradeTasks.cpp
@@ -29,7 +29,6 @@
 #include "Basics/files.h"
 #include "ClusterEngine/ClusterEngine.h"
 #include "GeneralServer/AuthenticationFeature.h"
-#include "GeneralServer/ServerSecurityFeature.h"
 #include "Logger/Logger.h"
 #include "MMFiles/MMFilesEngine.h"
 #include "RestServer/SystemDatabaseFeature.h"

--- a/arangod/VocBase/Methods/UpgradeTasks.cpp
+++ b/arangod/VocBase/Methods/UpgradeTasks.cpp
@@ -188,6 +188,7 @@ Result createSystemCollections(TRI_vocbase_t& vocbase,
   systemCollections.push_back(StaticStrings::AppBundlesCollection);
   systemCollections.push_back(StaticStrings::FrontendCollection);
   systemCollections.push_back(StaticStrings::ModulesCollection);
+  systemCollections.push_back(StaticStrings::FishbowlCollection);
 
   TRI_IF_FAILURE("UpgradeTasks::CreateCollectionsExistsGraphAqlFunctions") {
     VPackBuilder testOptions;
@@ -211,12 +212,6 @@ Result createSystemCollections(TRI_vocbase_t& vocbase,
                                             colToDistributeShardsLike, cols);
     // capture created collection vector
     createdCollections.insert(std::end(createdCollections), std::begin(cols), std::end(cols));
-  }
-
-  // check wether we need fishbowl collection, or not.
-  ServerSecurityFeature& security = vocbase.server().getFeature<ServerSecurityFeature>();
-  if (!security.isFoxxStoreDisabled()) {
-    systemCollections.push_back(StaticStrings::FishbowlCollection);
   }
 
   std::vector<std::shared_ptr<VPackBuffer<uint8_t>>> buffers;


### PR DESCRIPTION
### Scope & Purpose

unconditionally create statistics collections when the database is created
it is not advisable to not create them when the statistics are turned off, because the server may later be restarted with statistics turn on. and then the collections will be missing

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7599/