### PR TITLE
Bug fix 3.6/always create fishbowl collections

### DIFF
--- a/arangod/VocBase/Methods/UpgradeTasks.cpp
+++ b/arangod/VocBase/Methods/UpgradeTasks.cpp
@@ -29,7 +29,6 @@
 #include "Basics/files.h"
 #include "ClusterEngine/ClusterEngine.h"
 #include "GeneralServer/AuthenticationFeature.h"
-#include "GeneralServer/ServerSecurityFeature.h"
 #include "Logger/Logger.h"
 #include "MMFiles/MMFilesEngine.h"
 #include "RestServer/SystemDatabaseFeature.h"

--- a/arangod/VocBase/Methods/UpgradeTasks.cpp
+++ b/arangod/VocBase/Methods/UpgradeTasks.cpp
@@ -188,6 +188,7 @@ Result createSystemCollections(TRI_vocbase_t& vocbase,
   systemCollections.push_back(StaticStrings::AppBundlesCollection);
   systemCollections.push_back(StaticStrings::FrontendCollection);
   systemCollections.push_back(StaticStrings::ModulesCollection);
+  systemCollections.push_back(StaticStrings::FishbowlCollection);
 
   TRI_IF_FAILURE("UpgradeTasks::CreateCollectionsExistsGraphAqlFunctions") {
     VPackBuilder testOptions;
@@ -211,12 +212,6 @@ Result createSystemCollections(TRI_vocbase_t& vocbase,
                                             colToDistributeShardsLike, cols);
     // capture created collection vector
     createdCollections.insert(std::end(createdCollections), std::begin(cols), std::end(cols));
-  }
-
-  // check wether we need fishbowl collection, or not.
-  ServerSecurityFeature& security = vocbase.server().getFeature<ServerSecurityFeature>();
-  if (!security.isFoxxStoreDisabled()) {
-    systemCollections.push_back(StaticStrings::FishbowlCollection);
   }
 
   std::vector<std::shared_ptr<VPackBuffer<uint8_t>>> buffers;


### PR DESCRIPTION
Addition to: 
- https://github.com/arangodb/arangodb/pull/10652

Also, the fishbowl collection needs to be created every time. 