### PR TITLE
Fixed rebalanceShards permission.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@ devel
 
 * Fixed uptime in _admin/statistics.
 
+* Fixed a permissions bug for /_admin/cluster/rebalanceShards.
+
 * Fixed a bug in smart graph bfs traversals that might violate path uniqueness
   requirements in rare cases.
 

--- a/js/actions/api-cluster.js
+++ b/js/actions/api-cluster.js
@@ -1368,9 +1368,10 @@ actions.defineHttp({
     }
 
     // simon: RO is sufficient to rebalance shards for current db
-    if (req.database !== '_system'/* || !req.isAdminUser*/) {
+    if (!req.isAdminUser &&
+        users.permission(req.user, req.database) !== 'rw') {
       actions.resultError(req, res, actions.HTTP_FORBIDDEN, 0,
-        'only allowed for admins on the _system database');
+          'only allowed for admins on the database');
       return;
     }
 


### PR DESCRIPTION
### Scope & Purpose

Fix permissions for rebalanceShards. Before that fix only the `_system` database could be rebalanced.

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.
