### PR TITLE
bug-fix single-edge-definition-editing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fixed internal issue #4748: Editing a single edgeDefinition using the graph
+  API failed if it was not shared between all available graphs.
+
 * Fixed undefined behavior on node delete.
 
 * Fixed agency invalid operation

--- a/arangod/Graph/GraphOperations.cpp
+++ b/arangod/Graph/GraphOperations.cpp
@@ -267,10 +267,13 @@ OperationResult GraphOperations::editEdgeDefinition(VPackSlice edgeDefinitionSli
   for (auto singleGraph : VPackArrayIterator(graphs.get("graphs"))) {
     std::unique_ptr<Graph> graph =
         Graph::fromPersistence(singleGraph.resolveExternals(), _vocbase);
-    result = changeEdgeDefinitionForGraph(*(graph.get()), edgeDefinition, waitForSync, trx);
-  }
-  if (result.fail()) {
-    return result;
+    if (graph->hasEdgeCollection(edgeDefinition.getName())) {
+      // only try to modify the edgeDefinition if it's available.
+      result = changeEdgeDefinitionForGraph(*(graph.get()), edgeDefinition, waitForSync, trx);
+      if (result.fail()) {
+        return result;
+      }
+    }
   }
 
   res = trx.finish(TRI_ERROR_NO_ERROR);

--- a/tests/js/common/shell/shell-general-graph.js
+++ b/tests/js/common/shell/shell-general-graph.js
@@ -980,6 +980,22 @@ function GeneralGraphCreationSuite() {
       }
     },
 
+    test_editEdgeDefinitionFromExistingGraph4: function () {
+      // create two graphs, each of them has a "not-shared" edgeDefinition, then modify one of those.
+      // This is not allowed to fail.
+      var dr1 = graph._relation(ec1, _.cloneDeep([vc1]), _.cloneDeep([vc2])),
+        dr2 = graph._relation(ec2, _.cloneDeep([vc1]), _.cloneDeep([vc4])),
+        dr3 = graph._relation(ec1, _.cloneDeep([vc5]), _.cloneDeep([vc5])),
+        g1 = graph._create(gN1, _.cloneDeep([dr1])),
+        g2 = graph._create(gN2, _.cloneDeep([dr2]));
+
+      g1._editEdgeDefinitions(_.cloneDeep(dr3));
+      g1 = graph._graph(gN1);
+
+      assertEqual([dr3], g1.__edgeDefinitions);
+      assertEqual(g1._orphanCollections().sort(), [vc1, vc2].sort());
+    },
+
     test_createGraphAndDropAVertexCollectionAfterwards: function () {
       try {
         var gr = graph._create("gg",


### PR DESCRIPTION
### Scope & Purpose

Short: fixed editing single occurrence of an edge definition in case of multiple available graphs. 
e.g. Graph A has edge definition Z
e.g. Graph B has edge definition Y

Now we want to change edge definition Z. This will be tried for both graphs and will fail for Graph B. 
This PR fixed that behaviour.

*(Can you describe what functional change your PR is trying to effect?)*

- [x] Bug-Fix for *devel-branch* 
- [x] Bug-Fix for a *released version* (needed, yes, all supported versions)
- [x] The behavior in this PR can be (and was) *manually tested* 
- [x] The behavior change can be verified via automatic tests

#### Related Information

*(Please reference tickets / specification etc )*

- [x] There is a *JIRA Ticket number*: https://arangodb.atlassian.net/browse/DEVSUP-509
- [x] Internal planning ticket: https://github.com/arangodb/planning/issues/4748

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)
`./scripts/unittest shell_client --test tests/js/common/shell/shell-general-graph.js`
