### PR TITLE
fix some UI issues for database defaults

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/collectionsView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/collectionsView.js
@@ -472,7 +472,7 @@
             // if we are in the cluster and are not using distribute shards like
             // then we want to make use of the replication factor
             tmpObj.replicationFactor = replicationFactor === "satellite" ? replicationFactor : Number(replicationFactor);
-            tmpObj.minReplicationFactor = Number(writeConcern);
+            tmpObj.writeConcern = Number(writeConcern);
           }
 
           if (!abort) {
@@ -578,7 +578,7 @@
                 window.modalView.createTextEntry(
                   'new-replication-factor',
                   'Replication factor',
-                  ['', 'flexible'].indexOf(properties.sharding) !== -1 ? properties.replicationFactor : '',
+                  properties.replicationFactor ? properties.replicationFactor : '',
                   'Numeric value. Must be between ' + 
                   (this.minReplicationFactor ? this.minReplicationFactor : 1) + 
                   ' and ' + 
@@ -647,7 +647,7 @@
               window.modalView.createTextEntry(
                 'new-write-concern',
                 'Write concern',
-                ['', 'flexible'].indexOf(properties.sharding) !== -1 ? properties.minReplicationFactor : '',
+                properties.writeConcern ? properties.writeConcern : '',
                 'Numeric value. Must be at least 1. Must be smaller or equal compared to the replication factor. Total number of copies of the data in the cluster that are required for each write operation. If we get below this value the collection will be read-only until enough copies are created.',
                 '',
                 false,

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/databaseView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/databaseView.js
@@ -436,7 +436,7 @@
             'newSharding',
             'Sharding',
             'flexible',
-            'some nice description TODO',
+            'Selects the default sharding setup for new collections in this database. *flexible* means that shards of different collections by default will be randomly distributed to database servers. *single* means that collections by default will use the same sharding setup (number of shards and shard distribution) as one of the system collections.',
             sharding
           )
         );


### PR DESCRIPTION
### Scope & Purpose

Fixes several web UI glitches:
* adds missing description for "Sharding" attribute when creating a new database
* fixes setting of default values for new collections in databases created with "sharding" = "single" attribute. In this case, the attributes "Replication factor" and "Write concern" were not populated with default values

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7690/