### PR TITLE
restrict database length to 64 characters again

### DIFF
--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -339,13 +339,13 @@ Result Collections::create(TRI_vocbase_t& vocbase,
     VPackBuilder merged =
         VPackCollection::merge(info.properties, helper.slice(), false, true);
 
-    if (haveShardingFeature && !info.properties.get("shardingStrategy").isString()) {
+    if (haveShardingFeature && !info.properties.get(StaticStrings::ShardingStrategy).isString()) {
       // NOTE: We need to do this in a second merge as the geature call requires to have the
       // DataSourceType set in the JSON, which has just been done by the call above.
       helper.clear();
       helper.openObject();
       TRI_ASSERT(ServerState::instance()->isCoordinator());
-      helper.add("shardingStrategy",
+      helper.add(StaticStrings::ShardingStrategy,
                  VPackValue(vocbase.server().getFeature<ShardingFeature>().getDefaultShardingStrategyForNewCollection(
                      merged.slice())));
       helper.close();

--- a/arangod/VocBase/VocbaseInfo.cpp
+++ b/arangod/VocBase/VocbaseInfo.cpp
@@ -287,8 +287,12 @@ Result CreateDatabaseInfo::checkOptions() {
     _validId = false;
   }
 
+  // we cannot use IsAllowedName for database name length validation alone, because
+  // IsAllowedName allows up to 256 characters. Database names are just up to 64
+  // chars long, as their names are also used as filesystem directories (for Foxx apps)
   if (_name.empty() ||
-      !TRI_vocbase_t::IsAllowedName(_isSystemDB, arangodb::velocypack::StringRef(_name))) {
+      !TRI_vocbase_t::IsAllowedName(_isSystemDB, arangodb::velocypack::StringRef(_name)) ||
+      _name.size() > 64) {
     return Result(TRI_ERROR_ARANGO_DATABASE_NAME_INVALID);
   }
 

--- a/tests/js/common/shell/01_shell-database.js
+++ b/tests/js/common/shell/01_shell-database.js
@@ -86,6 +86,29 @@ function DatabaseSuite () {
     },
 
 ////////////////////////////////////////////////////////////////////////////////
+/// @brief test create with too long names function
+////////////////////////////////////////////////////////////////////////////////
+
+    testLongName : function () {
+      const prefix = "UnitTestsDatabase";
+      let name = prefix + Array(64 + 1 - prefix.length).join("x");
+      assertEqual(64, name.length);
+          
+      assertTrue(internal.db._createDatabase(name));
+      assertTrue(internal.db._dropDatabase(name));
+
+      name += 'x';
+      assertEqual(65, name.length);
+
+      try {
+        internal.db._createDatabase(name);
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_DATABASE_NAME_INVALID.code, err.errorNum);
+      }
+    },
+
+////////////////////////////////////////////////////////////////////////////////
 /// @brief test _name function
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
### Scope & Purpose

Restrict _database_ name to 64 characters again, as it has been the case in 3.5 and ever before.
A previous PR for devel/3.6 allowed collection name lengths of 256 characters (raised from 64 chars), and as an unintended side effect this also allowed database names of 256 chars length.
This PR fixes the side effect, so database names are again restricted to 64 chars, while collection names can be up to 256 chars.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [ ] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest shell_server --test database*.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7717/