### PR TITLE
Optimized AstNode members removals while condition optimizing

### DIFF
--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -2771,6 +2771,12 @@ void AstNode::removeMemberUnchecked(size_t i) {
   members.erase(members.begin() + i);
 }
 
+void AstNode::removeMemberUncheckedUnordered(size_t i) {
+  TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_FINALIZED));
+  std::swap(members[i], members.back());
+  members.pop_back();
+}
+
 void AstNode::removeMembers() {
   TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_FINALIZED));
   members.clear();

--- a/arangod/Aql/AstNode.h
+++ b/arangod/Aql/AstNode.h
@@ -458,6 +458,9 @@ struct AstNode {
   /// @brief remove a member from the node
   void removeMemberUnchecked(size_t i);
 
+  /// @brief remove a member from the node while breaking members ordering. Faster than removeMemberUnchecked
+  void removeMemberUncheckedUnordered(size_t i);
+
   /// @brief remove all members from the node at once
   void removeMembers();
 

--- a/arangod/Aql/Condition.cpp
+++ b/arangod/Aql/Condition.cpp
@@ -754,12 +754,12 @@ void Condition::normalize(ExecutionPlan* plan, bool multivalued /*= false*/) {
   }
  
   _root = transformNodePreorder(_root);
-  _root = transformNodePostorder(_root, multivalued);
+  _root = transformNodePostorder(_root);
   _root = fixRoot(_root, 0);
   optimize(plan, multivalued);
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-  if (_root != nullptr && !multivalued) { // ArangoSearch view is fine without DNF
+  if (_root != nullptr) {
     // _root->dump(0);
     validateAst(_root, 0);
   }
@@ -1666,7 +1666,7 @@ AstNode* Condition::transformNodePreorder(AstNode* node) {
 }
 
 /// @brief converts from negation normal to disjunctive normal form
-AstNode* Condition::transformNodePostorder(AstNode* node, bool multivalued /*= false*/) {
+AstNode* Condition::transformNodePostorder(AstNode* node) {
   if (node == nullptr) {
     return node;
   }
@@ -1682,10 +1682,10 @@ AstNode* Condition::transformNodePostorder(AstNode* node, bool multivalued /*= f
 
     for (size_t i = 0; i < n; ++i) {
       // process subnodes first
-      auto sub = transformNodePostorder(node->getMemberUnchecked(i), multivalued);
+      auto sub = transformNodePostorder(node->getMemberUnchecked(i));
       node->changeMember(i, sub);
 
-      if (sub->type == NODE_TYPE_OPERATOR_NARY_OR && !multivalued) {
+      if (sub->type == NODE_TYPE_OPERATOR_NARY_OR) {
         distributeOverChildren = true;
       } else if (sub->type == NODE_TYPE_OPERATOR_NARY_AND) {
         mustCollapse = true;
@@ -1787,7 +1787,7 @@ AstNode* Condition::transformNodePostorder(AstNode* node, bool multivalued /*= f
     bool mustCollapse = false;
 
     for (size_t i = 0; i < n; ++i) {
-      auto sub = transformNodePostorder(node->getMemberUnchecked(i), multivalued);
+      auto sub = transformNodePostorder(node->getMemberUnchecked(i));
       node->changeMember(i, sub);
 
       if (sub->type == NODE_TYPE_OPERATOR_NARY_OR) {

--- a/arangod/Aql/Condition.cpp
+++ b/arangod/Aql/Condition.cpp
@@ -752,15 +752,14 @@ void Condition::normalize(ExecutionPlan* plan, bool multivalued /*= false*/) {
     // already normalized
     return;
   }
-
+ 
   _root = transformNodePreorder(_root);
-  _root = transformNodePostorder(_root);
+  _root = transformNodePostorder(_root, multivalued);
   _root = fixRoot(_root, 0);
-
   optimize(plan, multivalued);
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-  if (_root != nullptr) {
+  if (_root != nullptr && !multivalued) { // ArangoSearch view is fine without DNF
     // _root->dump(0);
     validateAst(_root, 0);
   }
@@ -1011,7 +1010,7 @@ bool Condition::removeInvalidVariables(::arangodb::containers::HashSet<Variable 
       }
 
       if (invalid) {
-        andNode->removeMemberUnchecked(j);
+        andNode->removeMemberUncheckedUnordered(j);
         // repeat with some member index
         TRI_ASSERT(nAnd > 0);
         --nAnd;
@@ -1221,7 +1220,7 @@ void Condition::optimize(ExecutionPlan* plan, bool multivalued) {
                   _ast->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_IN,
                                                  leftNode->getMemberUnchecked(0),
                                                  mergeInOperations(trx, leftNode, rightNode));
-              andNode->removeMemberUnchecked(rightPos);
+              andNode->removeMemberUncheckedUnordered(rightPos);
               andNode->changeMember(leftPos, merged);
               goto restartThisOrItem;
             } else if (rightNode->isSimpleComparisonOperator()) {
@@ -1248,7 +1247,7 @@ void Condition::optimize(ExecutionPlan* plan, bool multivalued) {
 
               if (inNode->numMembers() == 0) {
                 // no values left after merging -> IMPOSSIBLE
-                _root->removeMemberUnchecked(r);
+                _root->removeMemberUncheckedUnordered(r); 
                 retry = true;
                 goto fastForwardToNextOrItem;
               }
@@ -1257,7 +1256,7 @@ void Condition::optimize(ExecutionPlan* plan, bool multivalued) {
               leftNode->changeMember(1, inNode);
 
               // remove the other operator
-              andNode->removeMemberUnchecked(rightPos);
+              andNode->removeMemberUncheckedUnordered(rightPos);
               goto restartThisOrItem;
             }
           }
@@ -1273,25 +1272,26 @@ void Condition::optimize(ExecutionPlan* plan, bool multivalued) {
               // impossible condition
               // j = positions.size();
               // we remove this one, so fast forward the loops to their end:
-              _root->removeMemberUnchecked(r);
+              _root->removeMemberUncheckedUnordered(r);
               retry = true;
               goto fastForwardToNextOrItem;
             }
             case CompareResult::SELF_CONTAINED_IN_OTHER: {
               TRI_ASSERT(!positions.empty());
-              andNode->removeMemberUnchecked(positions.at(0).first);
+              andNode->removeMemberUncheckedUnordered(positions.at(0).first);
               goto restartThisOrItem;
             }
             case CompareResult::OTHER_CONTAINED_IN_SELF: {
               TRI_ASSERT(j < positions.size());
-              andNode->removeMemberUnchecked(positions.at(j).first);
+              andNode->removeMemberUncheckedUnordered(positions.at(j).first);
               goto restartThisOrItem;
             }
             case CompareResult::CONVERT_EQUAL: {  // both ok, now transform to a
                                                   // == x (== y)
               TRI_ASSERT(!positions.empty());
               TRI_ASSERT(j < positions.size());
-              andNode->removeMemberUnchecked(positions.at(j).first);
+              TRI_ASSERT(positions.at(j).first > positions.at(0).first); // in this case remove will not spoil members indexes
+              andNode->removeMemberUncheckedUnordered(positions.at(j).first);
               auto origNode = andNode->getMemberUnchecked(positions.at(0).first);
               auto newNode = plan->getAst()->createNode(NODE_TYPE_OPERATOR_BINARY_EQ);
               for (size_t iMemb = 0; iMemb < origNode->numMembers(); iMemb++) {
@@ -1666,7 +1666,7 @@ AstNode* Condition::transformNodePreorder(AstNode* node) {
 }
 
 /// @brief converts from negation normal to disjunctive normal form
-AstNode* Condition::transformNodePostorder(AstNode* node) {
+AstNode* Condition::transformNodePostorder(AstNode* node, bool multivalued /*= false*/) {
   if (node == nullptr) {
     return node;
   }
@@ -1682,10 +1682,10 @@ AstNode* Condition::transformNodePostorder(AstNode* node) {
 
     for (size_t i = 0; i < n; ++i) {
       // process subnodes first
-      auto sub = transformNodePostorder(node->getMemberUnchecked(i));
+      auto sub = transformNodePostorder(node->getMemberUnchecked(i), multivalued);
       node->changeMember(i, sub);
 
-      if (sub->type == NODE_TYPE_OPERATOR_NARY_OR) {
+      if (sub->type == NODE_TYPE_OPERATOR_NARY_OR && !multivalued) {
         distributeOverChildren = true;
       } else if (sub->type == NODE_TYPE_OPERATOR_NARY_AND) {
         mustCollapse = true;
@@ -1787,7 +1787,7 @@ AstNode* Condition::transformNodePostorder(AstNode* node) {
     bool mustCollapse = false;
 
     for (size_t i = 0; i < n; ++i) {
-      auto sub = transformNodePostorder(node->getMemberUnchecked(i));
+      auto sub = transformNodePostorder(node->getMemberUnchecked(i), multivalued);
       node->changeMember(i, sub);
 
       if (sub->type == NODE_TYPE_OPERATOR_NARY_OR) {

--- a/arangod/Aql/Condition.h
+++ b/arangod/Aql/Condition.h
@@ -212,7 +212,7 @@ class Condition {
   AstNode* transformNodePreorder(AstNode*);
 
   /// @brief converts from negation normal to disjunctive normal form
-  AstNode* transformNodePostorder(AstNode*, bool multivalued = false);
+  AstNode* transformNodePostorder(AstNode*);
 
   /// @brief Creates a top-level OR node if it does not already exist, and make
   /// sure that all second level nodes are AND nodes. Additionally, this step

--- a/arangod/Aql/Condition.h
+++ b/arangod/Aql/Condition.h
@@ -212,7 +212,7 @@ class Condition {
   AstNode* transformNodePreorder(AstNode*);
 
   /// @brief converts from negation normal to disjunctive normal form
-  AstNode* transformNodePostorder(AstNode*);
+  AstNode* transformNodePostorder(AstNode*, bool multivalued = false);
 
   /// @brief Creates a top-level OR node if it does not already exist, and make
   /// sure that all second level nodes are AND nodes. Additionally, this step

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -498,9 +498,7 @@ bool transaction::Methods::sortOrs(arangodb::aql::Ast* ast, arangodb::aql::AstNo
   TRI_ASSERT(parts.size() == conditionData.size());
 
   // clean up
-  while (root->numMembers()) {
-    root->removeMemberUnchecked(0);
-  }
+  root->clearMembers();
 
   usedIndexes.clear();
   std::unordered_set<std::string> seenIndexConditions;


### PR DESCRIPTION
Bug-fix for internal issue #9750 
As was discovered major performance penalty was in condition optimizations.
This PR optimizes AstNode operations by introducing fast version of removeMemberUnckecked function  - removeMemberUncheckedUnordered . This function achieves removal speedup by sacrificing node members order (swap + pop_back is used for removal ).

This fix is covered by existing AQL/AST tests

https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/7719/
