### PR TITLE
fix context.incrScanned

### DIFF
--- a/arangod/Aql/DocumentProducingHelper.cpp
+++ b/arangod/Aql/DocumentProducingHelper.cpp
@@ -408,7 +408,9 @@ IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVarian
         return false;
       }
     }
-   
+
+    context.incrScanned();
+
     bool checkFilter = context.hasFilter();
     if (checkFilter && !context.getAllowCoveringIndexOptimization()) {
       if (!context.checkFilter(slice)) {
@@ -477,7 +479,6 @@ IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVarian
     output.moveValueInto(registerId, input, guard);
     TRI_ASSERT(output.produced());
     output.advanceRow();
-    context.incrScanned();
 
     return true;
   };

--- a/arangod/Aql/DocumentProducingHelper.cpp
+++ b/arangod/Aql/DocumentProducingHelper.cpp
@@ -75,7 +75,7 @@ template <bool checkUniqueness, bool skip>
 IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVariant::WithProjectionsNotCoveredByIndex,
                                                  DocumentProducingFunctionContext& context) {
   return [&context](LocalDocumentId const& token, VPackSlice slice) {
-    if (checkUniqueness) {
+    if constexpr (checkUniqueness) {
       if (!context.checkUniqueness(token)) {
         // Document already found, skip it
         return false;
@@ -122,7 +122,7 @@ template <bool checkUniqueness, bool skip>
 IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVariant::DocumentWithRawPointer,
                                                  DocumentProducingFunctionContext& context) {
   return [&context](LocalDocumentId const& token, VPackSlice slice) {
-    if (checkUniqueness) {
+    if constexpr (checkUniqueness) {
       if (!context.checkUniqueness(token)) {
         // Document already found, skip it
         return false;
@@ -162,7 +162,7 @@ template <bool checkUniqueness, bool skip>
 IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVariant::DocumentCopy,
                                                  DocumentProducingFunctionContext& context) {
   return [&context](LocalDocumentId const& token, VPackSlice slice) {
-    if (checkUniqueness) {
+    if constexpr (checkUniqueness) {
       if (!context.checkUniqueness(token)) {
         // Document already found, skip it
         return false;
@@ -201,12 +201,14 @@ IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVarian
 
 template <bool checkUniqueness, bool skip>
 IndexIterator::DocumentCallback aql::buildDocumentCallback(DocumentProducingFunctionContext& context) {
-  if (!skip && !context.getProduceResult()) {
-    // This callback is disallowed use getNullCallback instead
-    TRI_ASSERT(false);
-    return [](LocalDocumentId const&, VPackSlice slice) -> bool {
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "invalid callback");
-    };
+  if constexpr (!skip) {
+    if (!context.getProduceResult()) {
+      // This callback is disallowed use getNullCallback instead
+      TRI_ASSERT(false);
+      return [](LocalDocumentId const&, VPackSlice slice) -> bool {
+        THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "invalid callback");
+      };
+    }
   }
     
   if (!context.getProjections().empty()) {
@@ -236,13 +238,13 @@ std::function<bool(LocalDocumentId const& token)> aql::getNullCallback(DocumentP
   return [&context](LocalDocumentId const& token) {
     TRI_ASSERT(!context.hasFilter());
 
-    if (checkUniqueness) {
+    if constexpr (checkUniqueness) {
       if (!context.checkUniqueness(token)) {
         // Document already found, skip it
         return false;
       }
     }
-    
+
     context.incrScanned();
 
     InputAqlItemRow const& input = context.getInputRow();
@@ -402,7 +404,7 @@ template <bool checkUniqueness, bool skip>
 IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVariant::WithProjectionsCoveredByIndex,
                                                  DocumentProducingFunctionContext& context) {
   return [&context](LocalDocumentId const& token, VPackSlice slice) {
-    if (checkUniqueness) {
+    if constexpr (checkUniqueness) {
       if (!context.checkUniqueness(token)) {
         // Document already found, skip it
         return false;
@@ -467,10 +469,14 @@ IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVarian
     }
 
     b->close();
-      
+
     if (checkFilter && !context.checkFilter(b->slice())) {
       context.incrFiltered();
       return false;
+    }
+
+    if constexpr (skip) {
+      return true;
     }
 
     AqlValue v(b.get());

--- a/arangod/Aql/IndexExecutor.cpp
+++ b/arangod/Aql/IndexExecutor.cpp
@@ -133,7 +133,6 @@ IndexIterator::DocumentCallback getCallback(DocumentProducingFunctionContext& co
 
     TRI_ASSERT(output.produced());
     output.advanceRow();
-    context.incrScanned();
 
     return true;
   };


### PR DESCRIPTION
Fixed context.incrScanned() for index

1. WithProjectionsCoveredByIndex (was a wrong place)
2. Late materialization (was duplicated)