### PR TITLE
don't make queries parallel if they are not eligible

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,14 @@
 v3.6.0-rc.2 (XXXX-XX-XX)
 ------------------------
 
+* Fixed bug that made AQL queries eligible for parallelization even in case
+  they couldn't be parallelized, leading to undefined behavior due to the
+  thread races.
+
 * Fixed bug in `--query.parallelize-gather-writes-behavior` which led to
   the option not working correctly.
 
-* Agency relational operators TTL fix
+* Agency relational operators TTL fix.
 
 * Improve latency in scheduler.
 

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -2591,27 +2591,6 @@ void AstNode::stealComputedValue() {
   }
 }
 
-/// @brief Removes all members from the current node that are also
-///        members of the other node (ignoring ording)
-///        Can only be applied if this and other are of type
-///        n-ary-and
-void AstNode::removeMembersInOtherAndNode(AstNode const* other) {
-  TRI_ASSERT(type == NODE_TYPE_OPERATOR_NARY_AND);
-  TRI_ASSERT(other->type == NODE_TYPE_OPERATOR_NARY_AND);
-  for (size_t i = 0; i < other->numMembers(); ++i) {
-    auto theirs = other->getMemberUnchecked(i);
-    for (size_t j = 0; j < numMembers(); ++j) {
-      auto ours = getMemberUnchecked(j);
-      // NOTE: Pointer comparison on purpose.
-      // We do not want to reduce equivalent but identical nodes
-      if (ours == theirs) {
-        removeMemberUnchecked(j);
-        break;
-      }
-    }
-  }
-}
-
 void AstNode::markFinalized(AstNode* subtreeRoot) {
   if ((nullptr == subtreeRoot) || subtreeRoot->hasFlag(AstNodeFlagType::FLAG_FINALIZED)) {
     return;
@@ -2769,11 +2748,6 @@ void AstNode::changeMember(size_t i, AstNode* node) {
 void AstNode::removeMemberUnchecked(size_t i) {
   TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_FINALIZED));
   members.erase(members.begin() + i);
-}
-
-void AstNode::removeMembers() {
-  TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_FINALIZED));
-  members.clear();
 }
 
 AstNode* AstNode::getMember(size_t i) const {

--- a/arangod/Aql/AstNode.h
+++ b/arangod/Aql/AstNode.h
@@ -458,9 +458,6 @@ struct AstNode {
   /// @brief remove a member from the node
   void removeMemberUnchecked(size_t i);
 
-  /// @brief remove all members from the node at once
-  void removeMembers();
-
   /// @brief return a member of the node
   AstNode* getMember(size_t i) const;
 
@@ -561,12 +558,6 @@ struct AstNode {
 
   /// @brief Steals the computed value and frees it.
   void stealComputedValue();
-
-  /// @brief Removes all members from the current node that are also
-  ///        members of the other node (ignoring ordering)
-  ///        Can only be applied if this and other are of type
-  ///        n-ary-and
-  void removeMembersInOtherAndNode(AstNode const* other);
 
   /// @brief If the node has not been marked finalized, mark its subtree so.
   /// If it runs into a finalized node, it assumes the whole subtree beneath

--- a/arangod/Aql/EngineInfoContainerCoordinator.h
+++ b/arangod/Aql/EngineInfoContainerCoordinator.h
@@ -107,7 +107,7 @@ class EngineInfoContainerCoordinator {
   // @brief List of EngineInfos to distribute accross the cluster
   std::vector<EngineInfo> _engines;
 
-  std::stack<size_t> _engineStack;
+  std::stack<size_t, std::vector<size_t>> _engineStack;
 };
 
 }  // namespace aql

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -276,10 +276,9 @@ Query* Query::clone(QueryPart part, bool withPlan) {
 }
 
 bool Query::killed() const {
-  if(_queryOptions.maxRuntime > std::numeric_limits<double>::epsilon()) {
-    if(TRI_microtime() > (_startTime + _queryOptions.maxRuntime)) {
-      return true;
-    }
+  if (_queryOptions.maxRuntime > std::numeric_limits<double>::epsilon() &&
+      TRI_microtime() > (_startTime + _queryOptions.maxRuntime)) {
+    return true;
   }
   return _killed;
 }

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1997,7 +1997,7 @@ Result ClusterInfo::createCollectionsCoordinator(
                     nrDone, isCleaned, shardServers, this](VPackSlice const& result) {
       // NOTE: This ordering here is important to cover against a race in cleanup.
       // a) The Guard get's the Mutex, sets isCleaned == true, then removes the callback
-      // b) If the callback is aquired it is saved in a shared_ptr, the Mutex will be aquired first, then it will check if it isCleaned
+      // b) If the callback is acquired it is saved in a shared_ptr, the Mutex will be acquired first, then it will check if it isCleaned
       RECURSIVE_MUTEX_LOCKER(*cacheMutex, *cacheMutexOwner);
       if (*isCleaned) {
         return true;

--- a/arangod/Indexes/SimpleAttributeEqualityMatcher.cpp
+++ b/arangod/Indexes/SimpleAttributeEqualityMatcher.cpp
@@ -208,7 +208,7 @@ arangodb::aql::AstNode* SimpleAttributeEqualityMatcher::specializeOne(
                           reference, nonNullAttributes, false)) {
         // we can use the index
         // now return only the child node we need
-        node->removeMembers();
+        node->clearMembers();
         node->addMember(op);
 
         return node;
@@ -220,7 +220,7 @@ arangodb::aql::AstNode* SimpleAttributeEqualityMatcher::specializeOne(
                           reference, nonNullAttributes, false)) {
         // we can use the index
         // now return only the child node we need
-        node->removeMembers();
+        node->clearMembers();
         node->addMember(op);
 
         return node;
@@ -292,7 +292,7 @@ arangodb::aql::AstNode* SimpleAttributeEqualityMatcher::specializeAll(
 
   if (_found.size() == _attributes.size()) {
     // remove node's existing members
-    node->removeMembers();
+    node->clearMembers();
 
     // found contains all nodes required for this condition sorted by
     // _attributes

--- a/arangod/Indexes/SortedIndexAttributeMatcher.cpp
+++ b/arangod/Indexes/SortedIndexAttributeMatcher.cpp
@@ -474,7 +474,7 @@ arangodb::aql::AstNode* SortedIndexAttributeMatcher::specializeCondition(
   // must edit in place, no access to AST; TODO change so we can replace with
   // copy
   TEMPORARILY_UNLOCK_NODE(node);
-  node->removeMembers();
+  node->clearMembers();
 
   for (auto& it : children) {
     TRI_ASSERT(it->type != arangodb::aql::NODE_TYPE_OPERATOR_BINARY_NE);

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -792,7 +792,7 @@ int DatabaseFeature::dropDatabase(std::string const& name, bool waitForDeletion,
         return true;  // try next DataSource
       };
 
-      vocbase->visitDataSources(visitor, true);  // aquire a write lock to avoid potential deadlocks
+      vocbase->visitDataSources(visitor, true);  // acquire a write lock to avoid potential deadlocks
 
       if (TRI_ERROR_NO_ERROR != res) {
         events::DropDatabase(name, res);

--- a/arangod/Sharding/ShardingInfo.cpp
+++ b/arangod/Sharding/ShardingInfo.cpp
@@ -275,7 +275,7 @@ LogicalCollection* ShardingInfo::collection() const {
   return _collection;
 }
 
-void ShardingInfo::toVelocyPack(VPackBuilder& result, bool translateCids) {
+void ShardingInfo::toVelocyPack(VPackBuilder& result, bool translateCids) const {
   result.add(StaticStrings::NumberOfShards, VPackValue(_numberOfShards));
 
   result.add(VPackValue("shards"));

--- a/arangod/Sharding/ShardingInfo.h
+++ b/arangod/Sharding/ShardingInfo.h
@@ -55,7 +55,7 @@ class ShardingInfo {
   std::string shardingStrategyName() const;
 
   LogicalCollection* collection() const;
-  void toVelocyPack(arangodb::velocypack::Builder& result, bool translateCids);
+  void toVelocyPack(arangodb::velocypack::Builder& result, bool translateCids) const;
 
   std::string distributeShardsLike() const;
   void distributeShardsLike(std::string const& cid, ShardingInfo const* other);

--- a/arangod/Sharding/ShardingStrategy.cpp
+++ b/arangod/Sharding/ShardingStrategy.cpp
@@ -33,7 +33,7 @@ bool ShardingStrategy::isCompatible(ShardingStrategy const* other) const {
   return name() == other->name();
 }
 
-void ShardingStrategy::toVelocyPack(VPackBuilder& result) {
+void ShardingStrategy::toVelocyPack(VPackBuilder& result) const {
   // only need to print sharding strategy if we are in a cluster
   if (ServerState::instance()->isRunningInCluster()) {
     result.add("shardingStrategy", VPackValue(name()));

--- a/arangod/Sharding/ShardingStrategy.h
+++ b/arangod/Sharding/ShardingStrategy.h
@@ -51,7 +51,7 @@ class ShardingStrategy {
 
   virtual bool usesDefaultShardKeys() = 0;
 
-  virtual void toVelocyPack(arangodb::velocypack::Builder& result);
+  virtual void toVelocyPack(arangodb::velocypack::Builder& result) const;
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief find the shard that is responsible for a document, which is given

--- a/arangod/VocBase/vocbase.h
+++ b/arangod/VocBase/vocbase.h
@@ -378,7 +378,7 @@ struct TRI_vocbase_t {
 
   /// @brief visit all DataSources registered with this vocbase
   /// @param visitor returns if visitation should continue
-  /// @param lockWrite aquire write lock (if 'visitor' will modify vocbase)
+  /// @param lockWrite acquire write lock (if 'visitor' will modify vocbase)
   /// @return visitation compleated successfully
   typedef std::function<bool(arangodb::LogicalDataSource& dataSource)> dataSourceVisitor;
   bool visitDataSources(dataSourceVisitor const& visitor, bool lockWrite = false);

--- a/arangosh/Backup/BackupFeature.cpp
+++ b/arangosh/Backup/BackupFeature.cpp
@@ -693,16 +693,13 @@ void BackupFeature::collectOptions(std::shared_ptr<options::ProgramOptions> opti
                      "(restore/upload/download operation)",
                      new StringParameter(&_options.identifier));
 
-  //  options->addOption("--include-search", "whether to include ArangoSearch data",
-  //                     new BooleanParameter(&_options.includeSearch));
-
   options->addOption(
       "--label",
       "an additional label to add to the backup identifier (create operation)",
       new StringParameter(&_options.label));
 
   options->addOption("--max-wait-for-lock",
-                     "maximum time to wait in seconds to aquire a lock on "
+                     "maximum time to wait in seconds to acquire a lock on "
                      "all necessary resources (create operation)",
                      new DoubleParameter(&_options.maxWaitForLock));
 

--- a/lib/Basics/RecursiveLocker.h
+++ b/lib/Basics/RecursiveLocker.h
@@ -40,7 +40,7 @@ class RecursiveMutexLocker {
       T& mutex, // mutex
       std::atomic<std::thread::id>& owner, // owner
       arangodb::basics::LockerType type, // locker type
-      bool acquire, // aquire flag
+      bool acquire, // acquire flag
       char const* file, // file
       int line // line
 ): _locker(&mutex, type, false, file, line), _owner(owner), _update(noop) {
@@ -116,7 +116,7 @@ class RecursiveWriteLocker {
       T& mutex, // mutex
       std::atomic<std::thread::id>& owner, // owner
       arangodb::basics::LockerType type, // locker type
-      bool acquire, // aquire flag
+      bool acquire, // acquire flag
       char const* file, // file
       int line // line
 ): _locked(false), // locked
@@ -151,7 +151,7 @@ class RecursiveWriteLocker {
   }
 
  private:
-  bool _locked;  // track locked state separately for recursive lock aquisition
+  bool _locked;  // track locked state separately for recursive lock acquisition
   arangodb::basics::WriteLocker<T> _locker;
   std::atomic<std::thread::id>& _owner;
   void (*_update)(RecursiveWriteLocker& locker);

--- a/tests/js/server/aql/aql-optimizer-rule-parallelize-gather-cluster.js
+++ b/tests/js/server/aql/aql-optimizer-rule-parallelize-gather-cluster.js
@@ -73,11 +73,15 @@ function optimizerRuleTestSuite () {
 
     testRuleNoEffect : function () {
       let queries = [  
-        "FOR i IN 1..1000 IN " + cn + " INSERT {} IN " + cn,
+        "FOR i IN 1..1000 INSERT {} IN " + cn,
+        "FOR doc1 IN " + cn + " FOR doc2 IN " + cn + " FILTER doc1._key == doc2._key RETURN doc1",
+        "FOR doc1 IN " + cn + " FOR doc2 IN " + cn + " FOR doc3 IN " + cn + " FILTER doc1._key == doc2._key FILTER doc2._key == doc3._key RETURN doc1",
+        "FOR i IN 1..1000 IN " + cn + " FOR doc IN " + cn + " FILTER doc.value == i RETURN doc",
+        "FOR i IN 1..100 LET sub = (FOR doc IN " + cn + " FILTER doc.value == i RETURN doc) RETURN sub",
       ];
 
       queries.forEach(function(query) {
-        let result = AQL_EXPLAIN(query);
+        let result = AQL_EXPLAIN(query, null, { optimizer: { rules: ["-smart-joins"] } });
         assertEqual(-1, result.plan.rules.indexOf(ruleName), query);
       });
     },


### PR DESCRIPTION
### Scope & Purpose

Fix an issue with parallel AQL making too many queries parallel even in case they were not eligible for parallelization.
Now, for a query to be eligible, it must have exactly one GatherNode, not multiple. In case there are multiple GatherNodes, it is not possible to prevent the query from using the same transaction object on the same database server from multiple threads.

```
  // for example consider the following query, joining the shards of two collections 
  // on 2 database servers:
  //
  //   (4)      DBS1                            DBS2               database
  //        users, shard 1                 users, shard 2          servers
  //       --------------------------------------------------------
  //   (3)                      Gather                             coordinator 
  //       -------------------------------------------------------- 
  //   (2)      DBS1            Scatter         DBS2               database
  //       orders, shard 1                orders, shard 2          servers
  //       -------------------------------------------------------- 
  //   (1)                      Gather                             coordinator
  //
  // the query starts with a GatherNode (1). if we make that parallel, then it will 
  // ask the shards of `orders` on the database servers in parallel (2). So there
  // can be 2 threads in (2), on different servers. all is fine until here.
  // however, if the thread for DBS1 fetches upstream data from the coordinator (3),
  // then the coordinator may reach out to DBS2 to get more data from the `users`
  // collection (4). so one thread will be on DBS2 and using the transaction. at
  // the very same time we already have another thread working on the same server on
  // (2). they are using the same transaction object, which currently is not 
  // thread-safe.
  // we need to avoid any such situation, and thus we cannot make any of the GatherNodes
  // thread-safe here. the only case in which we currently can employ parallelization
  // is when there is only a single GatherNode. all other restrictions for 
  // parallelization (e.g. no DistributeNodes around) still apply.
```

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [ ] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest shell_server_aql --cluster true*.

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (added cases in tests/js/server/aql/aql-optimizer-rule-parallelize-gather-cluster.js)

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7743/