### PR TITLE
Fixing documentation and timeout.

### DIFF
--- a/Documentation/DocuBlocks/Rest/BackupRestore/post_admin_backup_create.md
+++ b/Documentation/DocuBlocks/Rest/BackupRestore/post_admin_backup_create.md
@@ -31,12 +31,15 @@ a timeout results in an HTTP 408 error.
 @RESTBODYPARAM{force,boolean,optional,}
 If this flag is set to `true` and no global transaction lock can be acquired
 within the given timeout, all running transactions are forcefully aborted to
-ensure that a consistent backup can be created. This is almost certainly not
-what you want for your application. In the presence of intermediate commits
-it can even destroy the atomicity of your transactions. Use at your own risk,
-and only if you need a consistent backup at all costs. The default and
-recommended value is `false`. If both `allowInconsistent` and `force` are set
-to `true`, then the latter takes precedence and transactions are aborted.
+ensure that a consistent backup can be created. This does not include 
+JavaScript transactions. It waits for the transactions to be aborted at most 
+`timeout` seconds. Thus using `force` the request timeout is doubled.
+To abort transactions is almost certainly not what you want for your application. 
+In the presence of intermediate commits it can even destroy the atomicity of your
+transactions. Use at your own risk, and only if you need a consistent backup at 
+all costs. The default and recommended value is `false`. If both 
+`allowInconsistent` and `force` are set to `true`, then the latter takes 
+precedence and transactions are aborted. This is only available in the cluster.
 
 @RESTRETURNCODES
 

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -3773,7 +3773,7 @@ arangodb::Result hotBackupCoordinator(ClusterFeature& feature, VPackSlice const 
         ci.agencyHotBackupUnlock(backupId, timeout, supervisionOff);
       });
 
-      // we have to reset the timeout, otherwise the code below will exit to soon
+      // we have to reset the timeout, otherwise the code below will exit too soon
       end = steady_clock::now() + milliseconds(static_cast<uint64_t>(1000 * timeout));
 
       // send the locks

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -3773,6 +3773,9 @@ arangodb::Result hotBackupCoordinator(ClusterFeature& feature, VPackSlice const 
         ci.agencyHotBackupUnlock(backupId, timeout, supervisionOff);
       });
 
+      // we have to reset the timeout, otherwise the code below will exit to soon
+      end = steady_clock::now() + milliseconds(static_cast<uint64_t>(1000 * timeout));
+
       // send the locks
       result = hotbackupAsyncLockDBServersTransactions(backupId, dbServers, lockWait, lockJobIds);
       if (result.fail()) {
@@ -3782,6 +3785,11 @@ arangodb::Result hotBackupCoordinator(ClusterFeature& feature, VPackSlice const 
       transaction::Manager* mgr = transaction::ManagerFeature::manager();
 
       while (!lockJobIds.empty()) {
+        if (steady_clock::now() > end) {
+          return arangodb::Result(TRI_ERROR_CLUSTER_TIMEOUT,
+                                  "hot backup timeout before locking phase");
+        }
+
         // kill all transactions
         result = mgr->abortAllManagedWriteTrx(ExecContext::current().user(), true);
         if (result.fail()) {


### PR DESCRIPTION
### Scope & Purpose

Properly document and fix the timeout behavior when creating backups. see https://github.com/arangodb/planning/issues/4761

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [ ] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [ ] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [ ] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as https://github.com/arangodb/arangodb-java-driver/blob/b4cb92c058a044acd79bef7de6a30e51de1b2805/src/test/java/qa/ForceBackupTest.java#L237.