### PR TITLE
[3.6] Exclude system collections from supervision clean up.

### DIFF
--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1484,6 +1484,10 @@ void Supervision::checkBrokenCollections() {
     std::shared_ptr<Node> const& db = dbpair.second;
 
     for (auto const& collectionPair : db->children()) {
+      std::string const& collectionName = collectionPair.first;
+      if (collectionName.front() == '_') {
+        continue;
+      }
       ifResourceCreatorLost(collectionPair.second,
                             [&](ResourceCreatorLostEvent const& ev) {
                               LOG_TOPIC("fe523", INFO, Logger::SUPERVISION) << "checkBrokenCollections: removing broken collection with name "

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1044,7 +1044,7 @@ void Supervision::cleanupLostCollections(Node const& snapshot, AgentInterface* a
               {
                 VPackArrayBuilder trx(builder.get());
                 {
-                  VPackObjectBuilder update(builder.get());
+                  VPackObjectBuilder update(builder.get ());
                   // remove the shard in current
                   builder->add(VPackValue(currenturl));
                   {
@@ -1485,10 +1485,11 @@ void Supervision::checkBrokenCollections() {
 
     for (auto const& collectionPair : db->children()) {
       // collectionPair.first is collection id
-      std::pair<std::string, bool> collectionNamePair = collectionPair.second->hasAsString(StaticStrings::DatabaseName);
+      std::pair<std::string, bool> collectionNamePair = collectionPair.second->hasAsString(StaticStrings::DataSourceName);
       if (!collectionNamePair.second || collectionNamePair.first.front() == '_') {
         continue;
       }
+      LOG_DEVEL << collectionNamePair.first;
       ifResourceCreatorLost(collectionPair.second,
                             [&](ResourceCreatorLostEvent const& ev) {
                               LOG_TOPIC("fe523", INFO, Logger::SUPERVISION) << "checkBrokenCollections: removing broken collection with name "

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1044,7 +1044,7 @@ void Supervision::cleanupLostCollections(Node const& snapshot, AgentInterface* a
               {
                 VPackArrayBuilder trx(builder.get());
                 {
-                  VPackObjectBuilder update(builder.get ());
+                  VPackObjectBuilder update(builder.get());
                   // remove the shard in current
                   builder->add(VPackValue(currenturl));
                   {
@@ -1489,7 +1489,7 @@ void Supervision::checkBrokenCollections() {
       if (!collectionNamePair.second || collectionNamePair.first.front() == '_') {
         continue;
       }
-      LOG_DEVEL << collectionNamePair.first;
+
       ifResourceCreatorLost(collectionPair.second,
                             [&](ResourceCreatorLostEvent const& ev) {
                               LOG_TOPIC("fe523", INFO, Logger::SUPERVISION) << "checkBrokenCollections: removing broken collection with name "

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1486,7 +1486,8 @@ void Supervision::checkBrokenCollections() {
     for (auto const& collectionPair : db->children()) {
       // collectionPair.first is collection id
       std::pair<std::string, bool> collectionNamePair = collectionPair.second->hasAsString(StaticStrings::DataSourceName);
-      if (!collectionNamePair.second || collectionNamePair.first.front() == '_') {
+      std::string const& collectionName = collectionNamePair.first;
+      if (!collectionNamePair.second || collectionName.empty() || collectionName.front() == '_') {
         continue;
       }
 

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1484,8 +1484,9 @@ void Supervision::checkBrokenCollections() {
     std::shared_ptr<Node> const& db = dbpair.second;
 
     for (auto const& collectionPair : db->children()) {
-      std::string const& collectionName = collectionPair.first;
-      if (collectionName.front() == '_') {
+      // collectionPair.first is collection id
+      std::pair<std::string, bool> collectionNamePair = collectionPair.second->hasAsString(StaticStrings::DatabaseName);
+      if (!collectionNamePair.second || collectionNamePair.first.front() == '_') {
         continue;
       }
       ifResourceCreatorLost(collectionPair.second,


### PR DESCRIPTION
### Scope & Purpose
Fix a race that could prevent startup. Supervision now ignores system collections with `isBuilding`. Before that it deleted collections that have been created during bootstrap from a coordinator that was not listed in health.

### Testing & Verification
This was found by automated tests.
