### PR TITLE
fix a misleading message during maintenance

### DIFF
--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -189,7 +189,8 @@ CommTask::Flow CommTask::prepareExecution(GeneralRequest& req) {
         LOG_TOPIC("63f47", TRACE, arangodb::Logger::FIXME)
             << "Maintenance mode: refused path: " << path;
         addErrorResponse(ResponseCode::SERVICE_UNAVAILABLE, req.contentTypeResponse(),
-                         req.messageId(), TRI_ERROR_FORBIDDEN);
+                         req.messageId(), TRI_ERROR_HTTP_SERVICE_UNAVAILABLE,
+                         "service unavailable due to startup or maintenance mode");
         return Flow::Abort;
       }
       break;
@@ -443,24 +444,23 @@ RequestStatistics* CommTask::stealStatistics(uint64_t id) {
 /// @brief send response including error response body
 
 void CommTask::addErrorResponse(rest::ResponseCode code,
-                                          rest::ContentType respType, uint64_t messageId,
-                                          int errorNum, std::string const& msg) {
+                                rest::ContentType respType, uint64_t messageId,
+                                int errorNum, char const* errorMessage /* = nullptr */) {
+  if (errorMessage == nullptr) {
+    errorMessage = TRI_errno_string(errorNum);
+  }
+  TRI_ASSERT(errorMessage != nullptr);
+
   VPackBuffer<uint8_t> buffer;
   VPackBuilder builder(buffer);
   builder.openObject();
   builder.add(StaticStrings::Error, VPackValue(errorNum != TRI_ERROR_NO_ERROR));
   builder.add(StaticStrings::ErrorNum, VPackValue(errorNum));
-  builder.add(StaticStrings::ErrorMessage, VPackValue(msg));
-  builder.add(StaticStrings::Code, VPackValue((int)code));
+  builder.add(StaticStrings::ErrorMessage, VPackValue(errorMessage));
+  builder.add(StaticStrings::Code, VPackValue(static_cast<int>(code)));
   builder.close();
 
   addSimpleResponse(code, respType, messageId, std::move(buffer));
-}
-
-
-void CommTask::addErrorResponse(rest::ResponseCode code, rest::ContentType respType,
-                                          uint64_t messageId, int errorNum) {
-  addErrorResponse(code, respType, messageId, errorNum, TRI_errno_string(errorNum));
 }
 
 // -----------------------------------------------------------------------------
@@ -472,7 +472,6 @@ void CommTask::addErrorResponse(rest::ResponseCode code, rest::ContentType respT
 // and scheduled later when the number of used threads decreases
 
 bool CommTask::handleRequestSync(std::shared_ptr<RestHandler> handler) {
-
   RequestStatistics::SET_QUEUE_START(handler->statistics(), SchedulerFeature::SCHEDULER->queueStatistics()._queued);
 
   RequestLane lane = handler->getRequestLane();

--- a/arangod/GeneralServer/CommTask.h
+++ b/arangod/GeneralServer/CommTask.h
@@ -123,9 +123,7 @@ protected:
 
   /// @brief send response including error response body
   void addErrorResponse(rest::ResponseCode, rest::ContentType,
-                        uint64_t messageId, int errorNum, std::string const&);
-  void addErrorResponse(rest::ResponseCode, rest::ContentType,
-                        uint64_t messageId, int errorNum);
+                        uint64_t messageId, int errorNum, char const* errorMessage = nullptr);
   
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief checks the access rights for a specified path, includes automatic


### PR DESCRIPTION
### Scope & Purpose

this changes the body of HTTP 503 errors during maintenance from
```
{"errorNum":403,"errorMessage":"forbidden"}
```
to
```
{"errorNum":503,"errorMessage":"service unavailable due to startup or maintenance mode"}
```

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [ ] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *scripts/startLocalCluster.sh, scripts/unittest ... --cluster true*.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7763/