### PR TITLE
Compaction test fiddle

### DIFF
--- a/tests/js/server/shell/shell-compaction-mmfiles-noncluster.js
+++ b/tests/js/server/shell/shell-compaction-mmfiles-noncluster.js
@@ -830,19 +830,27 @@ function CompactionSuite () {
       internal.wait(0);
 
       c1.truncate();
+
+      // truncation should empty the collection
+      assertEqual(0, c1.count());
+
       internal.wal.flush(true, true);
       c1.rotate();
 
       waited = 0;
 
       maxWait = 10000;
-      console.log("Waiting for dead.deletion === 0 and dead.count === 0");
+      console.log("Waiting for alive.count === 0, dead.deletion === 0, dead.count === 0, journals.count === 0, and datafiles.count === 0");
       while (waited < maxWait) {
         internal.wait(2);
         waited += 2;
 
         fig = c1.figures();
-        if (fig['dead']['deletion'] === 0 && fig['dead']['count'] === 0) {
+        if (fig['alive']['count'] === 0 &&
+            fig['dead']['deletion'] === 0 &&
+	    fig['dead']['count'] === 0 &&
+            fig['journals']['count'] === 0 &&
+	    fig['datafiles']['count'] === 0) {
           break;
         }
       }


### PR DESCRIPTION
Try to make the compaction test more robust by waiting for the condition that is asserted later to be met.

Whether this works is dependent on whether mmfiles are supposed to delete all datafiles on an empty collection eventually (and when this eventually occurs).