### PR TITLE
a few usability fixes for minReplicationFactor/writeConcern

### DIFF
--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -312,7 +312,8 @@ Result Collections::create(TRI_vocbase_t& vocbase,
           auto distributeSlice = info.properties.get(StaticStrings::DistributeShardsLike);
           if (distributeSlice.isNone()) {
             helper.add(StaticStrings::DistributeShardsLike, VPackValue(vocbase.shardingPrototypeName()));
-          } else if (distributeSlice.isString() && distributeSlice.compareString("") == 0) {
+          } else if (distributeSlice.isNull() ||
+                     (distributeSlice.isString() && distributeSlice.compareString("") == 0)) {
             helper.add(StaticStrings::DistributeShardsLike, VPackSlice::nullSlice()); //delete empty string from info slice
           }
         }

--- a/tests/js/common/shell/shell-one-shard.js
+++ b/tests/js/common/shell/shell-one-shard.js
@@ -55,7 +55,7 @@ function OneShardPropertiesSuite () {
       } catch (ex) {
       }
     },
-    
+
     testDefaultValues : function () {
       assertTrue(db._createDatabase(dn));
       db._useDatabase(dn);
@@ -67,6 +67,70 @@ function OneShardPropertiesSuite () {
         assertEqual(props.sharding, undefined);
         assertEqual(props.replicationFactor, undefined);
       }
+    },
+    
+    testDefaultValuesOverridden : function () {
+      assertTrue(db._createDatabase(dn, { replicationFactor: 2, writeConcern: 2, sharding: "single" }));
+      db._useDatabase(dn);
+      let props = db._properties();
+      if (isCluster) {
+        assertEqual(props.sharding, "single");
+        assertEqual(props.replicationFactor, 2);
+        assertEqual(props.writeConcern, 2);
+
+        let c = db._create("test", { writeConcern: 1, replicationFactor: 1, numberOfShards: 1, distributeShardsLike: "" });
+        props = c.properties();
+        assertEqual(1, props.writeConcern);
+        assertEqual(1, props.replicationFactor);
+        assertEqual(1, props.numberOfShards);
+      } else {
+        assertEqual(props.sharding, undefined);
+        assertEqual(props.replicationFactor, undefined);
+        assertEqual(props.writeConcern, undefined);
+      }
+    },
+    
+    testShardingFlexible : function () {
+      assertTrue(db._createDatabase(dn, { sharding: "flexible" }));
+      db._useDatabase(dn);
+      let props = db._properties();
+      if (isCluster) {
+        assertEqual(props.sharding, "");
+        assertEqual(props.replicationFactor, 1);
+      } else {
+        assertEqual(props.sharding, undefined);
+        assertEqual(props.replicationFactor, undefined);
+      }
+    },
+
+    testDeviatingWriteConcernAndMinReplicationFactorForDatabase : function () {
+      if (!isCluster) {
+        return;
+      }
+      try {
+        db._createDatabase(dn, { replicationFactor: 2, minReplicationFactor: 1, writeConcern: 2, sharding: "flexible" });
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_BAD_PARAMETER.code, err.errorNum);
+      }
+        
+      assertTrue(db._createDatabase(dn, { replicationFactor: 2, minReplicationFactor: 2, writeConcern: 2, sharding: "flexible" }));
+    },
+    
+    testDeviatingWriteConcernAndMinReplicationFactorForCollection : function () {
+      if (!isCluster) {
+        return;
+      }
+      assertTrue(db._createDatabase(dn, { sharding: "flexible" }));
+      db._useDatabase(dn);
+      try {
+        db._create("test", { replicationFactor: 2, minReplicationFactor: 1, writeConcern: 2 });
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_BAD_PARAMETER.code, err.errorNum);
+      }
+        
+      db._create("test", { replicationFactor: 2, minReplicationFactor: 2, writeConcern: 2 });
     },
     
     testNormalDBAndTooManyServers : function () {


### PR DESCRIPTION
### Scope & Purpose

Fixes a few usability issues reported via https://github.com/arangodb/release-3.6/issues/41

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is an internal planning ticket: https://github.com/arangodb/release-3.6/issues/41

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (in shell_server / shell_client)

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7793/