### PR TITLE
Fixed removed dangling  readers from cache

### DIFF
--- a/3rdParty/iresearch/core/index/index_writer.cpp
+++ b/3rdParty/iresearch/core/index/index_writer.cpp
@@ -2085,6 +2085,13 @@ index_writer::pending_context_t index_writer::flush_all(const before_commit_f& b
 
     // write non-empty document mask
     if (!docs_mask.empty()) {
+      if (!pending_consolidation) {
+        // if this is pending consolidation, 
+        // this segment is already in the mask (see assert below)
+        // new version will be created. Remove old version from cache!
+        ctx->segment_mask_.emplace(pending_segment.segment.meta);
+      }
+      assert(ctx->segment_mask_.find(pending_segment.segment.meta) != ctx->segment_mask_.end()); // this segment should be deleted from cache!
       write_document_mask(dir, pending_segment.segment.meta, docs_mask, !pending_consolidation);
       pending_consolidation = true; // force write new segment meta
     }


### PR DESCRIPTION
Bug-fix for dangling readers in cache left by consolidation. Issue results in errors 32 in cleanup procedure on windows. Also old segments is not freed until server reboot leading to disk space consumption on all platforms.
Fixes internal issue #656 and ticket ES-483

Fix is verified by upstream project tests

https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/7813/
