### PR TITLE
Fixed removing outdated readers from cache

### DIFF
--- a/3rdParty/iresearch/core/index/index_writer.cpp
+++ b/3rdParty/iresearch/core/index/index_writer.cpp
@@ -1863,6 +1863,13 @@ index_writer::pending_context_t index_writer::flush_all() {
 
     // write non-empty document mask
     if (!docs_mask.empty()) {
+      if (!pending_consolidation) {
+        // if this is pending consolidation, 
+        // this segment is already in the mask (see assert below)
+        // new version will be created. Remove old version from cache!
+        ctx->segment_mask_.emplace(pending_segment.segment.meta);
+      }
+      assert(ctx->segment_mask_.find(pending_segment.segment.meta) != ctx->segment_mask_.end()); // this segment should be deleted from cache!
       write_document_mask(dir, pending_segment.segment.meta, docs_mask, !pending_consolidation);
       pending_consolidation = true; // force write new segment meta
     }

--- a/3rdParty/iresearch/core/index/index_writer.cpp
+++ b/3rdParty/iresearch/core/index/index_writer.cpp
@@ -1867,7 +1867,7 @@ index_writer::pending_context_t index_writer::flush_all() {
         // if this is pending consolidation, 
         // this segment is already in the mask (see assert below)
         // new version will be created. Remove old version from cache!
-        ctx->segment_mask_.emplace(pending_segment.segment.meta);
+        ctx->segment_mask_.emplace(pending_segment.segment.meta.name);
       }
       assert(ctx->segment_mask_.find(pending_segment.segment.meta) != ctx->segment_mask_.end()); // this segment should be deleted from cache!
       write_document_mask(dir, pending_segment.segment.meta, docs_mask, !pending_consolidation);

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.4.9 (XXXX-XX-XX)
 -------------------
 
+* Fixed internal issue #656: While executing large amount of concurrent
+  insert/removes iresearch seems to leak open file handles. This results in
+  error 32 in cleanup (observed only on Windows as Linux doesn`t have file
+  sharing locks).
+
 * The _users collection is now properly restored when using arangorestore.
 
 * Updated arangosync to 0.7.1.


### PR DESCRIPTION
Bug-fix for dangling readers in cache left by consolidation. Issue results in errors 32 in cleanup procedure on windows. Also old segments is not freed until server reboot leading to disk space consumption on all platforms.
Fixes internal issue #656 and ticket ES-483

Fix is verified by upstream project tests

https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/7814/
