### PR TITLE
speed up AQL upsert unit tests

### DIFF
--- a/arangod/Aql/AllRowsFetcher.cpp
+++ b/arangod/Aql/AllRowsFetcher.cpp
@@ -170,7 +170,7 @@ std::pair<ExecutionState, SharedAqlItemBlockPtr> AllRowsFetcher::fetchBlock() {
 }
 
 std::pair<ExecutionState, SharedAqlItemBlockPtr> AllRowsFetcher::fetchBlockForModificationExecutor(
-    std::size_t limit = ExecutionBlock::DefaultBatchSize()) {
+    std::size_t limit = ExecutionBlock::DefaultBatchSize) {
   // TODO this method is considered obsolete.
   // It cannot yet be removed as we need modification on the calling Executors which is ongoing
   // However this method will not be fixed and updated for ShadowRows

--- a/arangod/Aql/AllRowsFetcher.h
+++ b/arangod/Aql/AllRowsFetcher.h
@@ -139,7 +139,7 @@ class AllRowsFetcher {
    */
   // This is only TEST_VIRTUAL, so we ignore this lint warning:
   // NOLINTNEXTLINE google-default-arguments
-  std::pair<ExecutionState, InputAqlItemRow> fetchRow(size_t atMost = ExecutionBlock::DefaultBatchSize());
+  std::pair<ExecutionState, InputAqlItemRow> fetchRow(size_t atMost = ExecutionBlock::DefaultBatchSize);
 
   /**
    * @brief Prefetch the number of rows that will be returned from upstream.
@@ -168,7 +168,7 @@ class AllRowsFetcher {
 
   // NOLINTNEXTLINE google-default-arguments
   std::pair<ExecutionState, ShadowAqlItemRow> fetchShadowRow(
-      size_t atMost = ExecutionBlock::DefaultBatchSize());
+      size_t atMost = ExecutionBlock::DefaultBatchSize);
 
  private:
   DependencyProxy<BlockPassthrough::Disable>* _dependencyProxy;

--- a/arangod/Aql/ConstrainedSortExecutor.cpp
+++ b/arangod/Aql/ConstrainedSortExecutor.cpp
@@ -245,7 +245,7 @@ std::pair<ExecutionState, size_t> ConstrainedSortExecutor::expectedNumberOfRows(
     ExecutionState state;
     size_t expectedRows;
     std::tie(state, expectedRows) =
-        _fetcher.preFetchNumberOfRows(ExecutionBlock::DefaultBatchSize());
+        _fetcher.preFetchNumberOfRows(ExecutionBlock::DefaultBatchSize);
     if (state == ExecutionState::WAITING) {
       TRI_ASSERT(expectedRows == 0);
       return {state, 0};

--- a/arangod/Aql/DependencyProxy.h
+++ b/arangod/Aql/DependencyProxy.h
@@ -76,7 +76,7 @@ class DependencyProxy {
   // This is only TEST_VIRTUAL, so we ignore this lint warning:
   // NOLINTNEXTLINE google-default-arguments
   [[nodiscard]] TEST_VIRTUAL std::pair<ExecutionState, SharedAqlItemBlockPtr> fetchBlock(
-      size_t atMost = ExecutionBlock::DefaultBatchSize());
+      size_t atMost = ExecutionBlock::DefaultBatchSize);
 
   // This fetches a block from the given dependency.
   // NOTE: It is not allowed to be used in conjunction with prefetching
@@ -84,7 +84,7 @@ class DependencyProxy {
   // This is only TEST_VIRTUAL, so we ignore this lint warning:
   // NOLINTNEXTLINE google-default-arguments
   [[nodiscard]] TEST_VIRTUAL std::pair<ExecutionState, SharedAqlItemBlockPtr> fetchBlockForDependency(
-      size_t dependency, size_t atMost = ExecutionBlock::DefaultBatchSize());
+      size_t dependency, size_t atMost = ExecutionBlock::DefaultBatchSize);
 
   // See comment on fetchBlockForDependency().
   [[nodiscard]] TEST_VIRTUAL std::pair<ExecutionState, size_t> skipSomeForDependency(
@@ -102,7 +102,7 @@ class DependencyProxy {
   // regards the _blockQueue). If it doesn't it's either because
   //  - upstream returned WAITING - then so does prefetchBlock().
   //  - or upstream returned a nullptr with DONE - then so does prefetchBlock().
-  [[nodiscard]] ExecutionState prefetchBlock(size_t atMost = ExecutionBlock::DefaultBatchSize());
+  [[nodiscard]] ExecutionState prefetchBlock(size_t atMost = ExecutionBlock::DefaultBatchSize);
 
   [[nodiscard]] TEST_VIRTUAL size_t numberDependencies() const;
 

--- a/arangod/Aql/ExecutionBlock.cpp
+++ b/arangod/Aql/ExecutionBlock.cpp
@@ -68,6 +68,10 @@ std::string const& stateToString(aql::ExecutionState state) {
 
 }  // namespace
 
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+size_t ExecutionBlock::DefaultBatchSize = ExecutionBlock::ProductionDefaultBatchSize;
+#endif
+
 ExecutionBlock::ExecutionBlock(ExecutionEngine* engine, ExecutionNode const* ep)
     : _engine(engine),
       _trxVpackOptions(engine->getQuery()->trx()->transactionContextPtr()->getVPackOptions()),

--- a/arangod/Aql/ExecutionBlock.h
+++ b/arangod/Aql/ExecutionBlock.h
@@ -55,7 +55,16 @@ class ExecutionBlock {
 
  public:
   /// @brief batch size value
-  [[nodiscard]] static constexpr inline size_t DefaultBatchSize() { return 1000; }
+  static constexpr size_t ProductionDefaultBatchSize = 1000;
+
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+  // when we compile the tests, we want to make the batch size adjustable
+  static size_t DefaultBatchSize;
+  static void setDefaultBatchSize(size_t value) { DefaultBatchSize = value; }
+#else
+  // batch size is hard-coded for release builds
+  static constexpr size_t DefaultBatchSize = ProductionDefaultBatchSize;
+#endif
 
   /// @brief Number to use when we skip all. Should really be inf, but don't
   /// use something near std::numeric_limits<size_t>::max() to avoid overflows

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -134,7 +134,7 @@ std::pair<ExecutionState, SharedAqlItemBlockPtr> ExecutionBlockImpl<Executor>::g
 
 template <class Executor>
 std::pair<ExecutionState, SharedAqlItemBlockPtr> ExecutionBlockImpl<Executor>::getSomeWithoutTrace(size_t atMost) {
-  TRI_ASSERT(atMost <= ExecutionBlock::DefaultBatchSize());
+  TRI_ASSERT(atMost <= ExecutionBlock::DefaultBatchSize);
   // silence tests -- we need to introduce new failure tests for fetchers
   TRI_IF_FAILURE("ExecutionBlock::getOrSkipSome1") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
@@ -435,7 +435,7 @@ std::pair<ExecutionState, size_t> ExecutionBlockImpl<Executor>::skipSomeOnceWith
   constexpr SkipVariants customSkipType = skipType<Executor>();
 
   if (customSkipType == SkipVariants::GET_SOME) {
-    atMost = std::min(atMost, DefaultBatchSize());
+    atMost = std::min(atMost, DefaultBatchSize);
     auto res = getSomeWithoutTrace(atMost);
 
     size_t skipped = 0;

--- a/arangod/Aql/ExecutionEngine.cpp
+++ b/arangod/Aql/ExecutionEngine.cpp
@@ -573,7 +573,7 @@ std::pair<ExecutionState, SharedAqlItemBlockPtr> ExecutionEngine::getSome(size_t
       return {res.first, nullptr};
     }
   }
-  return _root->getSome((std::min)(atMost, ExecutionBlock::DefaultBatchSize()));
+  return _root->getSome((std::min)(atMost, ExecutionBlock::DefaultBatchSize));
 }
 
 std::pair<ExecutionState, size_t> ExecutionEngine::skipSome(size_t atMost) {

--- a/arangod/Aql/MultiDependencySingleRowFetcher.cpp
+++ b/arangod/Aql/MultiDependencySingleRowFetcher.cpp
@@ -45,7 +45,7 @@ MultiDependencySingleRowFetcher::MultiDependencySingleRowFetcher(
 std::pair<ExecutionState, SharedAqlItemBlockPtr> MultiDependencySingleRowFetcher::fetchBlockForDependency(
     size_t dependency, size_t atMost) {
   TRI_ASSERT(!_dependencyInfos.empty());
-  atMost = (std::min)(atMost, ExecutionBlock::DefaultBatchSize());
+  atMost = (std::min)(atMost, ExecutionBlock::DefaultBatchSize);
   TRI_ASSERT(dependency < _dependencyInfos.size());
 
   auto& depInfo = _dependencyInfos[dependency];

--- a/arangod/Aql/MultiDependencySingleRowFetcher.h
+++ b/arangod/Aql/MultiDependencySingleRowFetcher.h
@@ -123,12 +123,12 @@ class MultiDependencySingleRowFetcher {
   // This is only TEST_VIRTUAL, so we ignore this lint warning:
   // NOLINTNEXTLINE google-default-arguments
   TEST_VIRTUAL std::pair<ExecutionState, InputAqlItemRow> fetchRowForDependency(
-      size_t dependency, size_t atMost = ExecutionBlock::DefaultBatchSize());
+      size_t dependency, size_t atMost = ExecutionBlock::DefaultBatchSize);
 
   std::pair<ExecutionState, size_t> skipRowsForDependency(size_t dependency, size_t atMost);
 
   std::pair<ExecutionState, ShadowAqlItemRow> fetchShadowRow(
-      size_t atMost = ExecutionBlock::DefaultBatchSize());
+      size_t atMost = ExecutionBlock::DefaultBatchSize);
 
  private:
   DependencyProxy<BlockPassthrough::Disable>* _dependencyProxy;

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -674,7 +674,7 @@ ExecutionState Query::execute(QueryRegistry* registry, QueryResult& queryResult)
         // In case of WAITING we return, this function is repeatable!
         // In case of HASMORE we loop
         while (true) {
-          auto res = _engine->getSome(ExecutionBlock::DefaultBatchSize());
+          auto res = _engine->getSome(ExecutionBlock::DefaultBatchSize);
           if (res.first == ExecutionState::WAITING) {
             return res.first;
           }
@@ -882,11 +882,11 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate, QueryRegistry* registry) {
       uint32_t j = 0;
       ExecutionState state = ExecutionState::HASMORE;
       while (state != ExecutionState::DONE) {
-        auto res = _engine->getSome(ExecutionBlock::DefaultBatchSize());
+        auto res = _engine->getSome(ExecutionBlock::DefaultBatchSize);
         state = res.first;
         while (state == ExecutionState::WAITING) {
           ss->waitForAsyncWakeup();
-          res = _engine->getSome(ExecutionBlock::DefaultBatchSize());
+          res = _engine->getSome(ExecutionBlock::DefaultBatchSize);
           state = res.first;
         }
         SharedAqlItemBlockPtr value = std::move(res.second);

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -672,7 +672,7 @@ RestStatus RestAqlHandler::handleUseQuery(std::string const& operation,
     }
     auto atMost =
         VelocyPackHelper::getNumericValue<size_t>(querySlice, "atMost",
-                                                  ExecutionBlock::DefaultBatchSize());
+                                                  ExecutionBlock::DefaultBatchSize);
     SharedAqlItemBlockPtr items;
     ExecutionState state;
     if (shardId.empty()) {
@@ -706,7 +706,7 @@ RestStatus RestAqlHandler::handleUseQuery(std::string const& operation,
   } else if (operation == "skipSome") {
     auto atMost =
         VelocyPackHelper::getNumericValue<size_t>(querySlice, "atMost",
-                                                  ExecutionBlock::DefaultBatchSize());
+                                                  ExecutionBlock::DefaultBatchSize);
     size_t skipped;
     if (shardId.empty()) {
       auto tmpRes = _query->engine()->skipSome(atMost);

--- a/arangod/Aql/SimpleModifier.h
+++ b/arangod/Aql/SimpleModifier.h
@@ -105,7 +105,7 @@ class SimpleModifier {
         _completion(infos),
         _accumulator(nullptr),
         _resultsIterator(VPackSlice::emptyArraySlice()),
-        _batchSize(ExecutionBlock::DefaultBatchSize()) {}
+        _batchSize(ExecutionBlock::DefaultBatchSize) {}
   ~SimpleModifier() = default;
 
   void reset();

--- a/arangod/Aql/SingleRowFetcher.cpp
+++ b/arangod/Aql/SingleRowFetcher.cpp
@@ -47,7 +47,7 @@ std::pair<ExecutionState, SharedAqlItemBlockPtr> SingleRowFetcher<passBlocksThro
   if (_upstreamState == ExecutionState::DONE) {
     return {_upstreamState, nullptr};
   }
-  atMost = (std::min)(atMost, ExecutionBlock::DefaultBatchSize());
+  atMost = (std::min)(atMost, ExecutionBlock::DefaultBatchSize);
   // There are still some blocks left that ask their parent even after they got
   // DONE the last time, and I don't currently have time to track them down.
   // Thus the following assert is commented out.

--- a/arangod/Aql/SingleRowFetcher.h
+++ b/arangod/Aql/SingleRowFetcher.h
@@ -82,11 +82,11 @@ class SingleRowFetcher {
   // This is only TEST_VIRTUAL, so we ignore this lint warning:
   // NOLINTNEXTLINE google-default-arguments
   [[nodiscard]] TEST_VIRTUAL std::pair<ExecutionState, InputAqlItemRow> fetchRow(
-      size_t atMost = ExecutionBlock::DefaultBatchSize());
+      size_t atMost = ExecutionBlock::DefaultBatchSize);
 
   // NOLINTNEXTLINE google-default-arguments
   [[nodiscard]] TEST_VIRTUAL std::pair<ExecutionState, ShadowAqlItemRow> fetchShadowRow(
-      size_t atMost = ExecutionBlock::DefaultBatchSize());
+      size_t atMost = ExecutionBlock::DefaultBatchSize);
 
   [[nodiscard]] TEST_VIRTUAL std::pair<ExecutionState, size_t> skipRows(size_t atMost);
 

--- a/arangod/Aql/SortingGatherExecutor.cpp
+++ b/arangod/Aql/SortingGatherExecutor.cpp
@@ -229,7 +229,7 @@ SortingGatherExecutor::~SortingGatherExecutor() = default;
 
 std::pair<ExecutionState, NoStats> SortingGatherExecutor::produceRows(OutputAqlItemRow& output) {
   size_t const atMost = constrainedSort() ? output.numRowsLeft()
-                                          : ExecutionBlock::DefaultBatchSize();
+                                          : ExecutionBlock::DefaultBatchSize;
   ExecutionState state;
   InputAqlItemRow row{CreateInvalidInputRowHint{}};
   std::tie(state, row) = produceNextRow(atMost);

--- a/arangod/Aql/SubqueryExecutor.cpp
+++ b/arangod/Aql/SubqueryExecutor.cpp
@@ -89,7 +89,7 @@ std::pair<ExecutionState, NoStats> SubqueryExecutor<isModificationSubquery>::pro
       }
 
       // Non const case, or first run in const
-      auto res = _subquery.getSome(ExecutionBlock::DefaultBatchSize());
+      auto res = _subquery.getSome(ExecutionBlock::DefaultBatchSize);
       if (res.first == ExecutionState::WAITING) {
         TRI_ASSERT(res.second == nullptr);
         return {res.first, NoStats{}};

--- a/arangod/Indexes/SortedIndexAttributeMatcher.cpp
+++ b/arangod/Indexes/SortedIndexAttributeMatcher.cpp
@@ -146,7 +146,7 @@ void SortedIndexAttributeMatcher::matchAttributes(
     std::unordered_map<size_t, std::vector<arangodb::aql::AstNode const*>>& found,
     size_t& postFilterConditions, size_t& values, 
     std::unordered_set<std::string>& nonNullAttributes, bool isExecution) {
-  // assert we have a proper formed conditions - nary conjunction
+  // assert we have a properly formed condition - nary conjunction
   TRI_ASSERT(node->type == arangodb::aql::NODE_TYPE_OPERATOR_NARY_AND);
 
   // inspect the the conjuncts - allowed are binary comparisons and a contains check

--- a/arangod/MMFiles/MMFilesPrimaryIndex.cpp
+++ b/arangod/MMFiles/MMFilesPrimaryIndex.cpp
@@ -164,7 +164,7 @@ bool MMFilesAllIndexIterator::next(LocalDocumentIdCallback const& cb, size_t lim
 
 bool MMFilesAllIndexIterator::nextDocument(DocumentCallback const& cb, size_t limit) {
   _documentIds.clear();
-  _documentIds.reserve((std::min)(limit, aql::ExecutionBlock::DefaultBatchSize()));
+  _documentIds.reserve((std::min)(limit, aql::ExecutionBlock::DefaultBatchSize));
 
   bool done = false;
   while (limit > 0) {

--- a/arangod/Transaction/Methods.h
+++ b/arangod/Transaction/Methods.h
@@ -152,9 +152,6 @@ class Methods {
   /// feature
   static void clearDataSourceRegistrationCallbacks();
 
-  /// @brief default batch size for index and other operations
-  static constexpr uint64_t defaultBatchSize() { return 1000; }
-
   /// @brief Type of cursor
   enum class CursorType { ALL = 0, ANY };
 

--- a/tests/Aql/DependencyProxyMock.h
+++ b/tests/Aql/DependencyProxyMock.h
@@ -46,7 +46,7 @@ class DependencyProxyMock : public ::arangodb::aql::DependencyProxy<passBlocksTh
   // mock methods
   // NOLINTNEXTLINE google-default-arguments
   std::pair<arangodb::aql::ExecutionState, arangodb::aql::SharedAqlItemBlockPtr> fetchBlock(
-      size_t atMost = arangodb::aql::ExecutionBlock::DefaultBatchSize()) override;
+      size_t atMost = arangodb::aql::ExecutionBlock::DefaultBatchSize) override;
   inline size_t numberDependencies() const override { return 1; }
 
   std::pair<arangodb::aql::ExecutionState, size_t> skipSome(size_t atMost) override;
@@ -89,7 +89,7 @@ class MultiDependencyProxyMock
   // mock methods
   // NOLINTNEXTLINE google-default-arguments
   std::pair<arangodb::aql::ExecutionState, arangodb::aql::SharedAqlItemBlockPtr> fetchBlock(
-      size_t atMost = arangodb::aql::ExecutionBlock::DefaultBatchSize()) override {
+      size_t atMost = arangodb::aql::ExecutionBlock::DefaultBatchSize) override {
     // This is never allowed to be called.
     TRI_ASSERT(false);
     return {::arangodb::aql::ExecutionState::DONE, nullptr};
@@ -98,7 +98,7 @@ class MultiDependencyProxyMock
   // NOLINTNEXTLINE google-default-arguments
   std::pair<arangodb::aql::ExecutionState, arangodb::aql::SharedAqlItemBlockPtr> fetchBlockForDependency(
       size_t dependency,
-      size_t atMost = arangodb::aql::ExecutionBlock::DefaultBatchSize()) override;
+      size_t atMost = arangodb::aql::ExecutionBlock::DefaultBatchSize) override;
 
   std::pair<arangodb::aql::ExecutionState, size_t> skipSomeForDependency(size_t dependency,
                                                                          size_t atMost) override;

--- a/tests/Aql/RowFetcherHelper.h
+++ b/tests/Aql/RowFetcherHelper.h
@@ -73,11 +73,11 @@ class SingleRowFetcherHelper
 
   // NOLINTNEXTLINE google-default-arguments
   std::pair<arangodb::aql::ExecutionState, arangodb::aql::InputAqlItemRow> fetchRow(
-      size_t atMost = arangodb::aql::ExecutionBlock::DefaultBatchSize()) override;
+      size_t atMost = arangodb::aql::ExecutionBlock::DefaultBatchSize) override;
 
   // NOLINTNEXTLINE google-default-arguments
   std::pair<arangodb::aql::ExecutionState, arangodb::aql::ShadowAqlItemRow> fetchShadowRow(
-      size_t atMost = arangodb::aql::ExecutionBlock::DefaultBatchSize()) override;
+      size_t atMost = arangodb::aql::ExecutionBlock::DefaultBatchSize) override;
 
   uint64_t nrCalled() { return _nrCalled; }
   uint64_t nrReturned() { return _nrReturned; }

--- a/tests/Aql/UpsertExecutorTest.cpp
+++ b/tests/Aql/UpsertExecutorTest.cpp
@@ -24,6 +24,7 @@
 #include "QueryHelper.h"
 #include "gtest/gtest.h"
 
+#include "Aql/ExecutionBlock.h"
 #include "Basics/StringUtils.h"
 
 using namespace arangodb;
@@ -336,6 +337,10 @@ class UpsertExecutorIntegrationTest
 
   void SetUp() override {
     SCOPED_TRACE("Setup");
+    ASSERT_EQ(ExecutionBlock::ProductionDefaultBatchSize, ExecutionBlock::DefaultBatchSize);
+
+    ExecutionBlock::setDefaultBatchSize(100);
+
     auto info = VPackParser::fromJson(R"({"name":"UnitTestCollection"})");
     auto collection = vocbase.createCollection(info->slice());
     ASSERT_NE(collection.get(), nullptr) << "Failed to create collection";
@@ -353,6 +358,10 @@ class UpsertExecutorIntegrationTest
       }
     }
     AssertQueryHasResult(vocbase, GetAllDocs, expected.slice());
+  }
+  
+  void TearDown() override {
+    ExecutionBlock::setDefaultBatchSize(ExecutionBlock::ProductionDefaultBatchSize);
   }
 
   size_t numDocs() const {
@@ -798,7 +807,7 @@ TEST_P(UpsertExecutorIntegrationTest, upsert_alternate_insert_upsert) {
 
 INSTANTIATE_TEST_CASE_P(UpsertExecutorIntegration, UpsertExecutorIntegrationTest,
                         ::testing::Combine(::testing::Values(UpsertType::UPDATE, UpsertType::REPLACE),
-                                           ::testing::Values(1, 1001)));
+                                           ::testing::Values(1, 101)));
 
 /* This works as well, but takes considerably more time to pass.
 INSTANTIATE_TEST_CASE_P(UpsertExecutorIntegration, UpsertExecutorIntegrationTest,


### PR DESCRIPTION
### Scope & Purpose

Speed up AQL upsert unit tests by using a smaller batch size value.
Additionally this makes the DefaultBatchSize value adjustable by unit tests.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest catch*.

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7869/