### PR TITLE
disable parallel AQL when there are traversals or shortest paths queries

### DIFF
--- a/arangod/Aql/ClusterNodes.cpp
+++ b/arangod/Aql/ClusterNodes.cpp
@@ -564,7 +564,10 @@ struct ParallelizableFinder final : public WalkerWorker<ExecutionNode> {
   bool before(ExecutionNode* node) override final {
     if (node->getType() == ExecutionNode::SCATTER ||
         node->getType() == ExecutionNode::GATHER ||
-        node->getType() == ExecutionNode::DISTRIBUTE) {
+        node->getType() == ExecutionNode::DISTRIBUTE ||
+        node->getType() == ExecutionNode::TRAVERSAL ||
+        node->getType() == ExecutionNode::SHORTEST_PATH ||
+        node->getType() == ExecutionNode::K_SHORTEST_PATHS) {
       _isParallelizable = false;
       return true;  // true to abort the whole walking process
     }

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -7304,7 +7304,12 @@ void arangodb::aql::parallelizeGatherRule(Optimizer* opt, std::unique_ptr<Execut
   ::arangodb::containers::SmallVector<ExecutionNode*> nodes{a};
   plan->findNodesOfType(nodes, EN::GATHER, true);
 
-  if (nodes.size() == 1 && !plan->contains(EN::DISTRIBUTE) && !plan->contains(EN::SCATTER)) {
+  if (nodes.size() == 1 && 
+      !plan->contains(EN::TRAVERSAL) && 
+      !plan->contains(EN::SHORTEST_PATH) && 
+      !plan->contains(EN::K_SHORTEST_PATHS) && 
+      !plan->contains(EN::DISTRIBUTE) && 
+      !plan->contains(EN::SCATTER)) {
     GatherNode* gn = ExecutionNode::castTo<GatherNode*>(nodes[0]);
 
     if (!gn->isInSubquery() && gn->isParallelizable()) {


### PR DESCRIPTION
### Scope & Purpose

Disable parallelization of GatherNodes when queries includes traversals, shortest_path or k_shortest_path components.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [ ] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [ ] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. shell_server_aql)

https://172.16.10.101/view/PR/job/arangodb-matrix-pr/7907/