### PR TITLE
3.6: propagate js version variable into the client package

### DIFF
--- a/cmake/packages/client/nsis.txt
+++ b/cmake/packages/client/nsis.txt
@@ -66,6 +66,7 @@ set(SSL_EAY_RELEASE_DLL "@SSL_EAY_RELEASE_DLL@")
 set(ICU_DT "@ICU_DT@")
 set(ICU_DT_DEST "@ICU_DT_DEST@")
 set(INSTALL_ICU_DT_DEST "@INSTALL_ICU_DT_DEST@")
+set(ARANGODB_JS_VERSION "@ARANGODB_JS_VERSION@")
 
 ################################################################################
 # Get the final values for cpack:


### PR DESCRIPTION
backport of https://github.com/arangodb/arangodb/pull/10822