### PR TITLE
Fix returning blocks with shadow rows to the AqlItemBlockManager

### DIFF
--- a/arangod/Aql/AqlItemBlock.cpp
+++ b/arangod/Aql/AqlItemBlock.cpp
@@ -368,6 +368,10 @@ void AqlItemBlock::shrink(size_t nrItems) {
     a.erase();
   }
 
+  // remove the shadow row indices pointing to now invalid rows.
+  _shadowRowIndexes.erase(_shadowRowIndexes.lower_bound(nrItems),
+                          _shadowRowIndexes.end());
+
   // adjust the size of the block
   _nrItems = nrItems;
 }

--- a/arangod/Aql/AqlItemBlock.cpp
+++ b/arangod/Aql/AqlItemBlock.cpp
@@ -292,6 +292,8 @@ void AqlItemBlock::destroy() noexcept {
   // arbitrary types. so we put a global try...catch here to be on
   // the safe side
   try {
+    _shadowRowIndexes.clear();
+
     if (_valueCount.empty()) {
       eraseAll();
       rescale(0, 0);

--- a/arangod/Aql/AqlItemBlockManager.cpp
+++ b/arangod/Aql/AqlItemBlockManager.cpp
@@ -80,6 +80,7 @@ SharedAqlItemBlockPtr AqlItemBlockManager::requestBlock(size_t nrItems, Register
   TRI_ASSERT(block->getNrRegs() == nrRegs);
   TRI_ASSERT(block->numEntries() == targetSize);
   TRI_ASSERT(block->getRefCount() == 0);
+  TRI_ASSERT(block->hasShadowRows() == false);
 
   return SharedAqlItemBlockPtr{block};
 }

--- a/tests/js/server/aql/aql-shadowrow-block-return-regression.js
+++ b/tests/js/server/aql/aql-shadowrow-block-return-regression.js
@@ -1,0 +1,76 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global assertEqual, AQL_EXECUTE, assertTrue, fail */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief tests for regression returning blocks to the manager
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2014 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+/// @author Copyright 2020, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+var jsunity = require("jsunity");
+var internal = require("internal");
+var errors = internal.errors;
+var db = require("@arangodb").db, indexId;
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test suite
+////////////////////////////////////////////////////////////////////////////////
+
+function blockReturnRegressionSuite() {
+  return {
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief set up
+////////////////////////////////////////////////////////////////////////////////
+
+    setUpAll : function () {
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief tear down
+////////////////////////////////////////////////////////////////////////////////
+
+    tearDownAll : function () {
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test WITHIN_RECTANGLE as result
+////////////////////////////////////////////////////////////////////////////////
+
+    testBlockReuseOkWithSubquery : function () {
+      const query = `FOR c in 1..1000 LET su = (FOR d in 1..1000 SORT d RETURN d) RETURN LENGTH(su)`;
+      var actual = db._query(query);
+      assertEqual(actual.toArray().length , 1000);
+    },
+  };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief executes the test suite
+////////////////////////////////////////////////////////////////////////////////
+
+jsunity.run(blockReturnRegressionSuite);
+
+return jsunity.done();
+


### PR DESCRIPTION
If we don't reset shadow row indices, this set might contain shadow rows from
previous uses and lead to havoc.

This will need to be backported to 3.6, and a new test should be be added too before merging.

This should solve (at least) #10804 