### PR TITLE
added missing description of "global" query parameter in replication

### DIFF
--- a/Documentation/DocuBlocks/Rest/Replication/get_api_replication_applier_state.md
+++ b/Documentation/DocuBlocks/Rest/Replication/get_api_replication_applier_state.md
@@ -4,6 +4,13 @@
 
 @RESTHEADER{GET /_api/replication/applier-state, State of the replication applier,handleCommandApplierGetState}
 
+@RESTQUERYPARAMETERS
+
+@RESTQUERYPARAM{global,boolean,optional}
+If set to *true*, returns the state of the global replication applier for all
+database. If set to *false*, returns the state of the replication applier in the
+selected database.
+
 @RESTDESCRIPTION
 Returns the state of the replication applier, regardless of whether the
 applier is currently running or not.

--- a/Documentation/DocuBlocks/Rest/Replication/get_api_wal_access_tail.md
+++ b/Documentation/DocuBlocks/Rest/Replication/get_api_wal_access_tail.md
@@ -6,6 +6,10 @@
 
 @RESTQUERYPARAMETERS
 
+@RESTQUERYPARAM{global,boolean,optional}
+If set to *true*, tails the WAL for all databases. If set to *false*, tails the 
+WAL for the selected database.
+
 @RESTQUERYPARAM{from,number,optional}
 Exclusive lower bound tick value for results. On successive calls
 to this API you should set this to the value returned

--- a/Documentation/DocuBlocks/Rest/Replication/put_api_replication_applier.md
+++ b/Documentation/DocuBlocks/Rest/Replication/put_api_replication_applier.md
@@ -4,6 +4,13 @@
 
 @RESTHEADER{GET /_api/replication/applier-config, Return configuration of replication applier, handleCommandApplierGetConfig}
 
+@RESTQUERYPARAMETERS
+
+@RESTQUERYPARAM{global,boolean,optional}
+If set to *true*, returns the configuration of the global replication applier for all
+database. If set to *false*, returns the configuration of the replication applier in the
+selected database.
+
 @RESTDESCRIPTION
 Returns the configuration of the replication applier.
 

--- a/Documentation/DocuBlocks/Rest/Replication/put_api_replication_applier_adjust.md
+++ b/Documentation/DocuBlocks/Rest/Replication/put_api_replication_applier_adjust.md
@@ -4,6 +4,13 @@
 
 @RESTHEADER{PUT /_api/replication/applier-config, Adjust configuration of replication applier,handleCommandApplierSetConfig}
 
+@RESTQUERYPARAMETERS
+
+@RESTQUERYPARAM{global,boolean,optional}
+If set to *true*, adjusts the configuration of the global replication applier for all
+database. If set to *false*, adjusts the configuration of the replication applier in the
+selected database.
+
 @RESTBODYPARAM{endpoint,string,required,string}
 the logger server to connect to (e.g. "tcp://192.168.173.13:8529"). The endpoint must be specified.
 

--- a/Documentation/DocuBlocks/Rest/Replication/put_api_replication_applier_start.md
+++ b/Documentation/DocuBlocks/Rest/Replication/put_api_replication_applier_start.md
@@ -6,6 +6,11 @@
 
 @RESTQUERYPARAMETERS
 
+@RESTQUERYPARAM{global,boolean,optional}
+If set to *true*, starts the global replication applier for all
+database. If set to *false*, starts the replication applier in the
+selected database.
+
 @RESTQUERYPARAM{from,string,optional}
 The remote *lastLogTick* value from which to start applying. If not specified,
 the last saved tick from the previous applier run is used. If there is no

--- a/Documentation/DocuBlocks/Rest/Replication/put_api_replication_applier_stop.md
+++ b/Documentation/DocuBlocks/Rest/Replication/put_api_replication_applier_stop.md
@@ -4,6 +4,13 @@
 
 @RESTHEADER{PUT /_api/replication/applier-stop, Stop replication applier,handleCommandApplierStop}
 
+@RESTQUERYPARAMETERS
+
+@RESTQUERYPARAM{global,boolean,optional}
+If set to *true*, stops the global replication applier for all
+database. If set to *false*, stops the replication applier in the
+selected database.
+
 @RESTDESCRIPTION
 Stops the replication applier. This will return immediately if the
 replication applier is not running.


### PR DESCRIPTION
### Scope & Purpose

Add missing "global" query parameter to replication API documentation

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

