### PR TITLE
Bug fix 3.6/windows exe product info

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.6.1 (2020-XX-XX)
 -------------------
 
+* Fixed issue #10867:
+  Windows: arangod based binaries lack product version info and icon
+
 * Add ability to choose logging to file in Windows installer of ArangoDB server
   (enabled by default).
 

--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -782,7 +782,6 @@ add_library(arango_agency STATIC
 add_library(arangoserver STATIC 
   ${LIB_ARANGOSERVER_SOURCES}
   ${ADDITIONAL_LIB_ARANGOSERVER_SOURCES}
-  ${ProductVersionFiles}
 )
 
 add_library(arango_network STATIC
@@ -972,6 +971,7 @@ endif()
 
 add_executable(${BIN_ARANGOD}
   RestServer/arangod.cpp
+  ${ProductVersionFiles}
 )
 
 target_link_libraries(${BIN_ARANGOD}


### PR DESCRIPTION
### Scope & Purpose

The product version information (right-click on .exe in explorer, Properties, Details tab) as well as the application icon were missing for:

- arangod.exe
- arango-dfdb.exe
- arango-init-database.exe
- arango-secure-installation.exe

<!-- -->

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

Fixes #10867

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [x] Added a *Changelog Entry* (referencing the corresponding public or internal issue number)
