### PR TITLE
fix edge case with padding in VelocyPack arrays

### DIFF
--- a/3rdParty/velocypack/include/velocypack/Slice.h
+++ b/3rdParty/velocypack/include/velocypack/Slice.h
@@ -1009,7 +1009,7 @@ class Slice {
 
  private:
   // get the type for the slice (including tags)
-  constexpr inline ValueType type(uint8_t h) const noexcept {
+  static constexpr inline ValueType type(uint8_t h) {
     return SliceStaticData::TypeMap[h];
   }
 


### PR DESCRIPTION
### Scope & Purpose

Fix edge case in VelocyPack when the padding of a 1-byte offsetSize array is removed but the first few entries of the array contain a Slice of type None.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

- [x] There are tests in an external testing repository: arangodb/velocypack
- [x] I ensured this code runs with ASan / TSan or other static verification tools

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8072/