### PR TITLE
don't use alignas for these shared_ptrs, as it confuses Valgrind and is not necessary

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.6.1 (2020-XX-XX)
 -------------------
 
+* Fix "random" Valgrind "invalid free/delete" errors caused by usage of `alignas(64)`
+  for shared_ptrs in the SupervisedScheduler.
+
 * Fixed issue #10867: arangod based binaries lack product version info and icon
   on Windows
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.6.1 (2020-XX-XX)
 -------------------
 
-* Fix "random" Valgrind "invalid free/delete" errors caused by usage of `alignas(64)`
-  for shared_ptrs in the SupervisedScheduler.
+* Fix "random" Valgrind "invalid free/delete" errors caused by usage of
+  `alignas(64)` for shared_ptrs in the SupervisedScheduler.
 
 * Fixed issue #10867: arangod based binaries lack product version info and icon
   on Windows

--- a/arangod/Scheduler/SupervisedScheduler.cpp
+++ b/arangod/Scheduler/SupervisedScheduler.cpp
@@ -627,17 +627,7 @@ void SupervisedScheduler::startOneThread() {
     }
 
     // start a new thread
-
-    // wait for windows fix or implement operator new
-#if (_MSC_VER >= 1)
-#pragma warning(push)
-#pragma warning(disable : 4316)  // Object allocated on the heap may not be aligned for this type
-#endif
     _workerStates.emplace_back(std::make_shared<WorkerState>(*this));
-#if (_MSC_VER >= 1)
-#pragma warning(pop)
-#endif
-
     state = _workerStates.back();
   }
 

--- a/arangod/Scheduler/SupervisedScheduler.h
+++ b/arangod/Scheduler/SupervisedScheduler.h
@@ -114,7 +114,7 @@ class SupervisedScheduler final : public Scheduler {
   //    Hence if you want to know, if the thread has a long running job, test for
   //    _working && (now - _lastJobStarted) > eps
 
-  struct alignas(64) WorkerState {
+  struct WorkerState {
     uint64_t _queueRetryTime_us; // t1
     uint64_t _sleepTimeout_ms;  // t2
     std::atomic<bool> _stop, _working, _sleeping;


### PR DESCRIPTION
### Scope & Purpose

Don't use `alignas` for this shared_ptr, as it is not necessary but confuses Valgrind.
If the change is not made, Valgrind will report "invalid free/delete errors" in the Scheduler randomly.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8073/