### PR TITLE
fix edge case with padding in VelocyPack arrays

### DIFF
--- a/3rdParty/velocypack/include/velocypack/Slice.h
+++ b/3rdParty/velocypack/include/velocypack/Slice.h
@@ -146,11 +146,6 @@ class Slice {
     return SliceStaticData::TypeMap[head()];
   }
   
-  // get the type for the slice
-  constexpr inline ValueType type(uint8_t h) const noexcept {
-    return SliceStaticData::TypeMap[h];
-  }
-
   char const* typeName() const { return valueTypeName(type()); }
 
   // Set new memory position
@@ -980,6 +975,11 @@ class Slice {
   int64_t getSmallIntUnchecked() const noexcept;
   
  private:
+  // get the type for the slice (including tags)
+  static constexpr inline ValueType type(uint8_t h) {
+    return SliceStaticData::TypeMap[h];
+  }
+
   // return the number of members for an Array
   // must only be called for Slices that have been validated to be of type Array
   ValueLength arrayLength() const {

--- a/3rdParty/velocypack/src/Builder.cpp
+++ b/3rdParty/velocypack/src/Builder.cpp
@@ -37,7 +37,45 @@
 using namespace arangodb::velocypack;
 
 namespace {
-  
+
+// checks whether a memmove operation is allowed to get rid of the padding
+bool isAllowedToMemmove(Options const* options, uint8_t const* start, 
+                        std::vector<ValueLength> const& index, ValueLength offsetSize) {
+  VELOCYPACK_ASSERT(offsetSize == 1 || offsetSize == 2);
+
+  if (options->paddingBehavior == Options::PaddingBehavior::NoPadding || 
+      (offsetSize == 1 && options->paddingBehavior == Options::PaddingBehavior::Flexible)) {
+    std::size_t const n = (std::min)(std::size_t(8 - 2 * offsetSize), index.size());
+    for (std::size_t i = 0; i < n; i++) {
+      if (start[index[i]] == 0x00) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  return false;
+}
+
+uint8_t determineArrayType(bool needIndexTable, ValueLength offsetSize) {
+  uint8_t type;
+  // Now build the table:
+  if (needIndexTable) {
+    type = 0x06;
+  } else {  // no index table
+    type = 0x02;
+  }
+  // Finally fix the byte width in the type byte:
+  if (offsetSize == 2) {
+    type += 1;
+  } else if (offsetSize == 4) {
+    type += 2;
+  } else if (offsetSize == 8) {
+    type += 3;
+  }
+  return type;
+}
+
 constexpr ValueLength LinearAttributeUniquenessCutoff = 4;
   
 // struct used when sorting index tables for objects:
@@ -414,9 +452,6 @@ bool Builder::closeCompactArrayOrObject(ValueLength tos, bool isArray,
 Builder& Builder::closeArray(ValueLength tos, std::vector<ValueLength>& index) {
   VELOCYPACK_ASSERT(!index.empty());
 
-  // fix head byte in case a compact Array was originally requested:
-  _start[tos] = 0x06;
-
   bool needIndexTable = true;
   bool needNrSubs = true;
 
@@ -447,25 +482,40 @@ Builder& Builder::closeArray(ValueLength tos, std::vector<ValueLength>& index) {
     }
   }
 
+  VELOCYPACK_ASSERT(needIndexTable == needNrSubs);
+  
   // First determine byte length and its format:
   unsigned int offsetSize;
   // can be 1, 2, 4 or 8 for the byte width of the offsets,
   // the byte length and the number of subvalues:
-  if (_pos - tos + (needIndexTable ? index.size() : 0) - (needNrSubs ? 6 : 7) <=
-      0xff) {
+  bool allowMemmove = ::isAllowedToMemmove(options, _start + tos, index, 1);
+  if (_pos - tos + 
+      (needIndexTable ? index.size() : 0) - 
+      (allowMemmove ? (needNrSubs ? 6 : 7) : 0) <= 0xff) {
     // We have so far used _pos - tos bytes, including the reserved 8
     // bytes for byte length and number of subvalues. In the 1-byte number
     // case we would win back 6 bytes but would need one byte per subvalue
     // for the index table
     offsetSize = 1;
-  } else if (_pos - tos + (needIndexTable ? 2 * index.size() : 0) <= 0xffff) {
-    offsetSize = 2;
-  } else if (_pos - tos + (needIndexTable ? 4 * index.size() : 0) <=
-             0xffffffffu) {
-    offsetSize = 4;
   } else {
-    offsetSize = 8;
+    allowMemmove = ::isAllowedToMemmove(options, _start + tos, index, 2);
+    if (_pos - tos + 
+        (needIndexTable ? 2 * index.size() : 0) - 
+        (allowMemmove ? (needNrSubs ? 4 : 6) : 0) <= 0xffff) {
+      offsetSize = 2;
+    } else {
+      allowMemmove = false;
+      if (_pos - tos + 
+          (needIndexTable ? 4 * index.size() : 0) <= 0xffffffffu) {
+        offsetSize = 4;
+      } else {
+        offsetSize = 8;
+      }
+    }
   }
+
+  VELOCYPACK_ASSERT(offsetSize == 1 || offsetSize == 2 || offsetSize == 4 || offsetSize == 8); 
+  VELOCYPACK_ASSERT(!allowMemmove || offsetSize == 1 || offsetSize == 2);
 
   if (offsetSize < 8 &&
       !needIndexTable && 
@@ -474,49 +524,39 @@ Builder& Builder::closeArray(ValueLength tos, std::vector<ValueLength>& index) {
     // using an index table, we can also use type 0x05 for all Arrays without making
     // things worse space-wise
     offsetSize = 8;
+    allowMemmove = false;
   }
 
+  // fix head byte
+  _start[tos] = ::determineArrayType(needIndexTable, offsetSize);
+  
   // Maybe we need to move down data:
-  if (offsetSize == 1 || offsetSize == 2) {
+  if (allowMemmove) {
     // check if one of the first entries in the array is ValueType::None 
     // (0x00). in this case, we could not distinguish between a None (0x00) 
     // and the optional padding. so we must prevent the memmove here
-    bool allowMemMove = options->paddingBehavior == Options::PaddingBehavior::NoPadding ||
-                        (offsetSize == 1 && options->paddingBehavior == Options::PaddingBehavior::Flexible);
-    if (allowMemMove) {
-      std::size_t const n = (std::min)(std::size_t(8 - 2 * offsetSize), index.size());
-      for (std::size_t i = 0; i < n; i++) {
-        if (_start[tos + index[i]] == 0x00) {
-          allowMemMove = false;
-          break;
-        }
-      }
-      if (allowMemMove) {
-        ValueLength targetPos = 1 + 2 * offsetSize;
-        if (!needIndexTable) {
-          targetPos -= offsetSize;
-        }
-        if (_pos > (tos + 9)) {
-          ValueLength len = _pos - (tos + 9);
-          memmove(_start + tos + targetPos, _start + tos + 9, checkOverflow(len));
-        }
-        ValueLength const diff = 9 - targetPos;
-        rollback(diff);
-        if (needIndexTable) {
-          std::size_t const n = index.size();
-          for (std::size_t i = 0; i < n; i++) {
-            index[i] -= diff;
-          }
-        }  // Note: if !needIndexTable the index array is now wrong!
-      }
+    ValueLength targetPos = 1 + 2 * offsetSize;
+    if (!needIndexTable) {
+      targetPos -= offsetSize;
     }
+    if (_pos > (tos + 9)) {
+      ValueLength len = _pos - (tos + 9);
+      memmove(_start + tos + targetPos, _start + tos + 9, checkOverflow(len));
+    }
+    ValueLength const diff = 9 - targetPos;
+    rollback(diff);
+    if (needIndexTable) {
+      std::size_t const n = index.size();
+      for (std::size_t i = 0; i < n; i++) {
+        index[i] -= diff;
+      }
+    }  // Note: if !needIndexTable the index array is now wrong!
   }
 
   // Now build the table:
   if (needIndexTable) {
-    ValueLength tableBase;
     reserve(offsetSize * index.size() + (offsetSize == 8 ? 8 : 0));
-    tableBase = _pos;
+    ValueLength tableBase = _pos;
     advance(offsetSize * index.size());
     for (std::size_t i = 0; i < index.size(); i++) {
       uint64_t x = index[i];
@@ -525,21 +565,12 @@ Builder& Builder::closeArray(ValueLength tos, std::vector<ValueLength>& index) {
         x >>= 8;
       }
     }
-  } else {  // no index table
-    _start[tos] = 0x02;
   }
-  // Finally fix the byte width in the type byte:
-  if (offsetSize > 1) {
-    if (offsetSize == 2) {
-      _start[tos] += 1;
-    } else if (offsetSize == 4) {
-      _start[tos] += 2;
-    } else {  // offsetSize == 8
-      _start[tos] += 3;
-      if (needNrSubs) {
-        appendLength<8>(index.size());
-      }
-    }
+
+  // Finally fix the byte width at tthe end:
+  if (offsetSize == 8 && needNrSubs) {
+    reserve(8);
+    appendLengthUnchecked<8>(index.size());
   }
 
   // Fix the byte length in the beginning:
@@ -702,6 +733,7 @@ Builder& Builder::close() {
   // off the _stack:
   _stack.pop_back();
   // Intentionally leave _index[depth] intact to avoid future allocs!
+      
   return *this;
 }
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.6.1 (2020-XX-XX)
 -------------------
 
+* Fixed an edge case in VelocyPack when the padding of a 1-byte offsetSize array 
+  is removed but the first few entries of the array contain a Slice of type None.
+
 * Fixed issue #10867: arangod based binaries lack product version info and icon
   on Windows
 


### PR DESCRIPTION
### Scope & Purpose

Fix edge case in VelocyPack when the padding of a 1-byte offsetSize array is removed but the first few entries of the array contain a Slice of type None.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

- [x] There are tests in an external testing repository: arangodb/velocypack
- [x] I ensured this code runs with ASan / TSan or other static verification tools

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8076/