### PR TITLE
Add missing * to *tickMax

### DIFF
--- a/Documentation/DocuBlocks/Rest/Replication/get_api_wal_access_range.md
+++ b/Documentation/DocuBlocks/Rest/Replication/get_api_wal_access_range.md
@@ -11,7 +11,7 @@ data (identified by tick value) are still available for replication.
 
 The body of the response contains a JSON object.
 * *tickMin*: minimum tick available
-* *tickMax: maximum tick available
+* *tickMax*: maximum tick available
 * *time*: the server time as string in format "YYYY-MM-DDTHH:MM:SSZ"
 * *server*: An object with fields *version* and *serverId*
 


### PR DESCRIPTION
Only missing in 3.6 by the look of things