### PR TITLE
fix dangling reference to AgencyComm in AgencyCallback ctor

### DIFF
--- a/arangod/Cluster/AgencyCallback.cpp
+++ b/arangod/Cluster/AgencyCallback.cpp
@@ -39,11 +39,11 @@
 using namespace arangodb;
 using namespace arangodb::application_features;
 
-AgencyCallback::AgencyCallback(AgencyComm& agency, std::string const& key,
+AgencyCallback::AgencyCallback(application_features::ApplicationServer& server, std::string const& key,
                                std::function<bool(VPackSlice const&)> const& cb,
                                bool needsValue, bool needsInitialValue)
     : key(key), 
-      _agency(agency), 
+      _agency(server), 
       _cb(cb), 
       _needsValue(needsValue),
       _wasSignaled(false) {

--- a/arangod/Cluster/AgencyCallback.h
+++ b/arangod/Cluster/AgencyCallback.h
@@ -34,6 +34,9 @@
 #include "Basics/ConditionVariable.h"
 
 namespace arangodb {
+namespace application_features {
+class ApplicationServer;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// class AgencyCallback
@@ -90,7 +93,7 @@ class AgencyCallback {
   //////////////////////////////////////////////////////////////////////////////
 
  public:
-  AgencyCallback(AgencyComm&, std::string const&,
+  AgencyCallback(application_features::ApplicationServer& server, std::string const&,
                  std::function<bool(velocypack::Slice const&)> const&, bool needsValue,
                  bool needsInitialValue = true);
 
@@ -122,7 +125,7 @@ class AgencyCallback {
   //////////////////////////////////////////////////////////////////////////////
 
  private:
-  AgencyComm& _agency;
+  AgencyComm _agency;
   std::function<bool(velocypack::Slice const&)> const _cb;
   std::shared_ptr<velocypack::Builder> _lastData;
   bool const _needsValue;

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -58,20 +58,18 @@ struct ClusterCollectionCreationInfo;
 // make sure a collection is still in Plan
 // we are only going from *assuming* that it is present
 // to it being changed to not present.
-class CollectionWatcher
-{
-public:
+class CollectionWatcher {
+ public:
   CollectionWatcher(CollectionWatcher const&) = delete;
-  CollectionWatcher(AgencyCallbackRegistry *agencyCallbackRegistry, LogicalCollection const& collection)
+  CollectionWatcher(AgencyCallbackRegistry* agencyCallbackRegistry, LogicalCollection const& collection)
     : _agencyCallbackRegistry(agencyCallbackRegistry), _present(true) {
-    AgencyComm ac(collection.vocbase().server());
 
     std::string databaseName = collection.vocbase().name();
     std::string collectionID = std::to_string(collection.id());
     std::string where = "Plan/Collections/" + databaseName + "/" + collectionID;
 
     _agencyCallback = std::make_shared<AgencyCallback>(
-        ac, where,
+        collection.vocbase().server(), where,
         [this](VPackSlice const& result) {
           if (result.isNone()) {
             _present.store(false);
@@ -80,7 +78,7 @@ public:
         },
         true, false);
     _agencyCallbackRegistry->registerCallback(_agencyCallback);
-  };
+  }
   ~CollectionWatcher();
 
   bool isPresent() {

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -341,10 +341,10 @@ void HeartbeatThread::runDBServer() {
   };
 
   auto planAgencyCallback =
-      std::make_shared<AgencyCallback>(_agency, "Plan/Version", updatePlan, true);
+      std::make_shared<AgencyCallback>(_server, "Plan/Version", updatePlan, true);
 
   auto currentAgencyCallback =
-      std::make_shared<AgencyCallback>(_agency, "Current/Version", updateCurrent, true);
+      std::make_shared<AgencyCallback>(_server, "Current/Version", updateCurrent, true);
 
   bool registered = false;
   while (!registered && !isStopping()) {


### PR DESCRIPTION
### Scope & Purpose

Fix a dangling reference to AgencyComm when creating an AgencyCallback from inside the CollectionWatcher object.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *all cluster tests - some crashed on Windows due to the issue*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8111/