### PR TITLE
Bug fix 3.4/restore feature collection order

### DIFF
--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -1037,6 +1037,7 @@ arangodb::Result processInputDirectory(
 
     // should instantly return
     jobQueue.waitForIdle();
+    jobs.clear();
 
     Result firstError = feature.getFirstError();
     if (firstError.fail()) {


### PR DESCRIPTION
As already implemented in 3.5 and newer versions, we need to restore the `_users` collection last! That change is missing in 3.4, and ported with that PR. 