### PR TITLE
give the instance a second try if it resets our connection

### DIFF
--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -1693,7 +1693,7 @@ function startInstanceCluster (instanceInfo, protocol, options,
       internal.sleep(5);
       arango.reconnect(instanceInfo.endpoint, '_system', 'root', '');
     } else {
-      throw(e);
+      throw e;
     }
   }
   return true;

--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -1559,7 +1559,7 @@ function checkClusterAlive(options, instanceInfo, addArgs) {
       try {
         reply = download(arangod.url + '/_db/_system/_admin/server/id', '', makeAuthorizationHeaders(instanceInfo.authOpts));
       } catch (e) {
-        print(RED + Date() + " error requesting agent '" + JSON.stringify(arangod) + "' Error: " + JSON.stringify(e) + RESET);
+        print(RED + Date() + " error requesting server '" + JSON.stringify(arangod) + "' Error: " + JSON.stringify(e) + RESET);
         if (e instanceof ArangoError && e.message.search('Connection reset by peer') >= 0) {
           internal.sleep(5);
           reply = download(arangod.url + '/_db/_system/_admin/server/id', '', makeAuthorizationHeaders(instanceInfo.authOpts));

--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -1564,7 +1564,7 @@ function checkClusterAlive(options, instanceInfo, addArgs) {
           internal.sleep(5);
           reply = download(arangod.url + '/_db/_system/_admin/server/id', '', makeAuthorizationHeaders(instanceInfo.authOpts));
         } else {
-          throw(e);
+          throw e;
         }
       }
       if (reply.error || reply.code !== 200) {

--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -33,6 +33,7 @@ const yaml = require('js-yaml');
 const internal = require('internal');
 const crashUtils = require('@arangodb/crash-utils');
 const crypto = require('@arangodb/crypto');
+const ArangoError = require('@arangodb').ArangoError;
 
 /* Functions: */
 const toArgv = internal.toArgv;
@@ -1554,7 +1555,18 @@ function checkClusterAlive(options, instanceInfo, addArgs) {
   instanceInfo.arangods.forEach(arangod => {
     // agents don't support the ID call...
     if ((arangod.role !== "agent") && (arangod.role !== "single")) {
-      const reply = download(arangod.url + '/_db/_system/_admin/server/id', '', makeAuthorizationHeaders(instanceInfo.authOpts));
+      let reply;
+      try {
+        reply = download(arangod.url + '/_db/_system/_admin/server/id', '', makeAuthorizationHeaders(instanceInfo.authOpts));
+      } catch (e) {
+        print(RED + Date() + " error requesting agent '" + JSON.stringify(arangod) + "' Error: " + JSON.stringify(e) + RESET);
+        if (e instanceof ArangoError && e.message.search('Connection reset by peer') >= 0) {
+          internal.sleep(5);
+          reply = download(arangod.url + '/_db/_system/_admin/server/id', '', makeAuthorizationHeaders(instanceInfo.authOpts));
+        } else {
+          throw(e);
+        }
+      }
       if (reply.error || reply.code !== 200) {
         throw new Error("Server has no detectable ID! " + JSON.stringify(reply) + "\n" + JSON.stringify(arangod));
       }
@@ -1673,7 +1685,17 @@ function startInstanceCluster (instanceInfo, protocol, options,
     instanceInfo.url = d.url;
   }
 
-  arango.reconnect(instanceInfo.endpoint, '_system', 'root', '');
+  try {
+    arango.reconnect(instanceInfo.endpoint, '_system', 'root', '');
+  } catch (e) {
+    print(RED + Date() + " error connecting '" + instanceInfo.endpoint + "' Error: " + JSON.stringify(e) + RESET);
+    if (e instanceof ArangoError && e.message.search('Connection reset by peer') >= 0) {
+      internal.sleep(5);
+      arango.reconnect(instanceInfo.endpoint, '_system', 'root', '');
+    } else {
+      throw(e);
+    }
+  }
   return true;
 }
 


### PR DESCRIPTION
This patch should eventually give the server a second chance. Seen like this in a testrun:

```
Mon Jan 20 2020 01:25:45 GMT+0100 (Central European Standard Time) tickeling cluster node https://127.0.0.1:11497
Determining server IDs
queued request on failed connection
2020-01-20T00:25:46Z [6304] ERROR [9d7ea] Could not connect to endpoint 'ssl://127.0.0.1:11497', username: 'root' - Server message: Connection reset by peer
[ArangoError 10: Connection reset by peer] ArangoError: Connection reset by peer
    at startInstanceCluster (c:\vm02-windows\oskar\work\ArangoDB\js\client\modules\@arangodb\process-utils.js:1752:10)
    at Object.startInstance (c:\vm02-windows\oskar\work\ArangoDB\js\client\modules\@arangodb\process-utils.js:2038:7)
    at Object.performTests (c:\vm02-windows\oskar\work\ArangoDB\js\client\modules\@arangodb\test-utils.js:128:25)
    at Object.sslServer [as ssl_server] (c:\vm02-windows\oskar\work\ArangoDB\js\client\modules\@arangodb\testsuites\rspec.js:130:13)
    at iterateTests (c:\vm02-windows\oskar\work\ArangoDB\js\client\modules\@arangodb\testing.js:498:36)
    at unitTest (c:\vm02-windows\oskar\work\ArangoDB\js\client\modules\@arangodb\testing.js:584:12)
    at main (C:\vm02-windows\oskar\work\ArangoDB\UnitTests\unittest.js:67:14)
    at C:\vm02-windows\oskar\work\ArangoDB\UnitTests\unittest.js:118:14
not cleaning up as some tests weren't successful:
[] false - false - false

Killing remaining process & marking crashy: {"pid":6020,"status":"RUNNING","executable":"build\\bin\\RelWithDebInfo\\arangod.exe","arguments":["build\\bin\\RelWithDebInfo\\arangod.exe","--configuration","c:\\vm02-windows\\oskar\\work\\ArangoDB\\etc\\testing\\arangod-agency.conf","--define","TOP_DIR=c:\\vm02-windows\\oskar\\work\\ArangoDB","--wal.flush-timeout","30000","--javascript.app-path","c:\\vm02-windows\\oskar\\work\\tmp\\arangosh_a05396\\ssl_server\\agency\\app0","--javascript.copy-installation","false","--http.trusted-origin","http://was-erlauben-strunz.it","--cluster.create-waits-for-sync-replication","false","--temp.path","c:\\vm02-windows\\oskar\\work\\tmp\\arangosh_a05396\\ssl_server\\agency\\tmp","--server.storage-engine","mmfiles","--server.endpoint","ssl://127.0.0.1:11477","--database.directory","c:\\vm02-windows\\oskar\\work\\tmp\\arangosh_a05396\\ssl_server\\agency\\data0","--log.file","c:\\vm02-windows\\oskar\\work\\tmp\\arangosh_a05396\\ssl_server\\agency\\log0","--ssl.keyfile","UnitTests\\server.pem","--javascript.enabled","false","--agency.activate","true","--agency.size","3","--agency.pool-size","3","--agency.wait-for-sync","false","--agency.supervision","true","--agency.my-address","ssl://127.0.0.1:11477","--agency.supervision-grace-period","10.0","--agency.supervision-frequency","1.0"]}
```