### PR TITLE
Fixed exists function with stored values column

### DIFF
--- a/arangod/IResearch/IResearchViewStoredValues.cpp
+++ b/arangod/IResearch/IResearchViewStoredValues.cpp
@@ -143,11 +143,9 @@ bool IResearchViewStoredValues::fromVelocyPack(
         std::sort(fieldNames.begin(), fieldNames.end());
         std::string columnName;
         TRI_ASSERT(columnLength > 1);
-        columnName.reserve(columnLength - 1);
+        columnName.reserve(columnLength);
         for (auto const& fieldName : fieldNames) {
-          if (!columnName.empty()) {
-            columnName += FIELDS_DELIMITER;
-          }
+          columnName += FIELDS_DELIMITER; // a prefix for EXISTS()
           columnName += fieldName;
         }
         if (!uniqueColumns.emplace(columnName).second) {
@@ -173,9 +171,13 @@ bool IResearchViewStoredValues::fromVelocyPack(
         if (!uniqueColumns.emplace(fieldName).second) {
           continue;
         }
+        std::string columnName;
+        columnName.reserve(fieldName.size() + 1);
+        columnName += FIELDS_DELIMITER; // a prefix for EXISTS()
+        columnName += fieldName;
         StoredColumn sc;
         sc.fields.emplace_back(fieldName, std::move(field));
-        sc.name = std::move(fieldName);
+        sc.name = std::move(columnName);
         _storedColumns.emplace_back(std::move(sc));
       } else {
         clear();

--- a/tests/IResearch/IResearchView-test.cpp
+++ b/tests/IResearch/IResearchView-test.cpp
@@ -7482,14 +7482,16 @@ TEST_F(IResearchViewTest, create_view_with_stored_value) {
     EXPECT_TRUE(meta.init(slice, error));
     ASSERT_EQ(4, meta._storedValues.columns().size());
     EXPECT_EQ(1, meta._storedValues.columns()[0].fields.size());
-    EXPECT_EQ("obj.a", meta._storedValues.columns()[0].name);
+    EXPECT_EQ(arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + std::string("obj.a"), meta._storedValues.columns()[0].name);
     EXPECT_EQ(1, meta._storedValues.columns()[1].fields.size());
-    EXPECT_EQ("obj.b.b1", meta._storedValues.columns()[1].name);
+    EXPECT_EQ(arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + std::string("obj.b.b1"), meta._storedValues.columns()[1].name);
     EXPECT_EQ(2, meta._storedValues.columns()[2].fields.size());
-    EXPECT_EQ(std::string("obj.c") + arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + "obj.d",
+    EXPECT_EQ(arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + std::string("obj.c") +
+              arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + "obj.d",
               meta._storedValues.columns()[2].name);
     EXPECT_EQ(3, meta._storedValues.columns()[3].fields.size());
-    EXPECT_EQ(std::string("obj.e") + arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER +"obj.f.f1" +
+    EXPECT_EQ(arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + std::string("obj.e") +
+              arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + "obj.f.f1" +
               arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + "obj.g", meta._storedValues.columns()[3].name);
   }
 
@@ -7520,15 +7522,16 @@ TEST_F(IResearchViewTest, create_view_with_stored_value) {
     EXPECT_TRUE(meta.init(slice, error));
     ASSERT_EQ(5, meta._storedValues.columns().size());
     EXPECT_EQ(1, meta._storedValues.columns()[0].fields.size());
-    EXPECT_EQ("obj.a", meta._storedValues.columns()[0].name);
+    EXPECT_EQ(arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + std::string("obj.a"), meta._storedValues.columns()[0].name);
     EXPECT_EQ(1, meta._storedValues.columns()[1].fields.size());
-    EXPECT_EQ("obj.b", meta._storedValues.columns()[1].name);
+    EXPECT_EQ(arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + std::string("obj.b"), meta._storedValues.columns()[1].name);
     EXPECT_EQ(1, meta._storedValues.columns()[2].fields.size());
-    EXPECT_EQ("obj.c", meta._storedValues.columns()[2].name);
+    EXPECT_EQ(arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + std::string("obj.c"), meta._storedValues.columns()[2].name);
     EXPECT_EQ(1, meta._storedValues.columns()[3].fields.size());
-    EXPECT_EQ("obj.d", meta._storedValues.columns()[3].name);
+    EXPECT_EQ(arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + std::string("obj.d"), meta._storedValues.columns()[3].name);
     EXPECT_EQ(2, meta._storedValues.columns()[4].fields.size());
-    EXPECT_EQ(std::string("obj.c") + arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + "obj.d",
+    EXPECT_EQ(arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + std::string("obj.c") +
+              arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + "obj.d",
               meta._storedValues.columns()[4].name);
   }
 }


### PR DESCRIPTION
Wrong behavior: If a stored value column name prefix is equal to column name prefix then the exists function returns true.

Fixed. A stored value column name has a different prefix.

https://github.com/arangodb/backlog/issues/675