### PR TITLE
Allowed empty arrays as PHRASE parameter

### DIFF
--- a/arangod/IResearch/IResearchFilterFactory.cpp
+++ b/arangod/IResearch/IResearchFilterFactory.cpp
@@ -1918,6 +1918,7 @@ arangodb::Result processPhraseArgs(
     if (currentArg->isArray() && (!expectingOffset || allowDefaultOffset)) {
       if (0 == currentArg->numMembers()) {
         expectingOffset = true;
+        // do not reset offset here as we should accumulate it
         continue; // just skip empty arrays. This is not error anymore as this case may arise while working with autocomplete
       }
       // array arg is processed with possible default 0 offsets - to be easily compatible with TOKENS function
@@ -1945,7 +1946,7 @@ arangodb::Result processPhraseArgs(
         return { TRI_ERROR_BAD_PARAMETER, message };
       }
       if (arangodb::iresearch::SCOPED_VALUE_TYPE_DOUBLE == currentValue.type() && expectingOffset) {
-        offset = static_cast<uint64_t>(currentValue.getInt64());
+        offset += static_cast<uint64_t>(currentValue.getInt64());
         expectingOffset = false;
         continue; // got offset let`s go search for value
       } else if ( (arangodb::iresearch::SCOPED_VALUE_TYPE_STRING != currentValue.type() || !currentValue.getString(value)) || // value is not a string at all

--- a/arangod/IResearch/IResearchFilterFactory.cpp
+++ b/arangod/IResearch/IResearchFilterFactory.cpp
@@ -1916,6 +1916,10 @@ arangodb::Result processPhraseArgs(
       return { TRI_ERROR_BAD_PARAMETER, message };
     }
     if (currentArg->isArray() && (!expectingOffset || allowDefaultOffset)) {
+      if (0 == currentArg->numMembers()) {
+        expectingOffset = true;
+        continue; // just skip empty arrays. This is not error anymore as this case may arise while working with autocomplete
+      }
       // array arg is processed with possible default 0 offsets - to be easily compatible with TOKENS function
       // No array recursion allowed. This could be allowed, but just looks tangled.
       // Anyone interested coud use FLATTEN  to explicitly require processing all recurring arrays as one array
@@ -1971,7 +1975,7 @@ arangodb::Result processPhraseArgs(
     expectingOffset = true;
   }
   if (!expectingOffset) { // that means last arg is numeric - this is error as no term to apply offset to
-    auto message = "'PHRASE' AQL function : Unable to parse argument on position " + std::to_string(valueArgsEnd - 1) +  "as a value"s;
+    auto message = "'PHRASE' AQL function : Unable to parse argument on position " + std::to_string(valueArgsEnd - 1) +  " as a value"s;
     LOG_TOPIC("5fafe", WARN, arangodb::iresearch::TOPIC) << message;
     return { TRI_ERROR_BAD_PARAMETER, message };
   }

--- a/tests/IResearch/IResearchFilterFunction-test.cpp
+++ b/tests/IResearch/IResearchFilterFunction-test.cpp
@@ -2123,14 +2123,36 @@ TEST_F(IResearchFilterFunctionTest, Phrase) {
                      "FOR d IN myView FILTER analYzER(phrase(false, 'quick'), "
                      "'test_analyzer') RETURN d");
 
+    // empty phrase
+    irs::Or expectedEmpty;
+    auto& phraseEmpty = expectedEmpty.add<irs::by_phrase>();
+    phraseEmpty.field(mangleString("name", "test_analyzer"));
+    assertFilterSuccess(
+      vocbase(),
+      "FOR d IN myView FILTER ANALYZER(phrase(d.name, [ ]), 'test_analyzer') "
+      "RETURN d",
+      expectedEmpty);
+    assertFilterSuccess(
+      vocbase(),
+      "FOR d IN myView FILTER ANALYZER(phrase(d['name'], [ ]), "
+      "'test_analyzer') RETURN d",
+      expectedEmpty);
+
+    // accumulating offsets
+    irs::Or expectedAccumulated;
+    auto& phraseAccumulated = expectedAccumulated.add<irs::by_phrase>();
+    phraseAccumulated.field(mangleString("name", "test_analyzer"));
+    phraseAccumulated.push_back("q").push_back("u", 7).push_back("i", 3).push_back("c", 4).push_back(
+      "k",5);
+    assertFilterSuccess(
+      vocbase(),
+      "FOR d IN myView FILTER ANALYZER(phrase(d.name, "
+      " 'q', 0, [], 3, [], 4, 'u', 3, [], 0, 'i', 0, [], 4, 'c', 1, [], 1, [], 2, [], 1, 'k'), "
+      " 'test_analyzer') "
+      "RETURN d",
+      expectedAccumulated);
+
     // invalid input
-    assertFilterFail(
-        vocbase(),
-        "FOR d IN myView FILTER ANALYZER(phrase(d.name, [ ]), 'test_analyzer') "
-        "RETURN d");
-    assertFilterFail(vocbase(),
-                     "FOR d IN myView FILTER ANALYZER(phrase(d['name'], [ ]), "
-                     "'test_analyzer') RETURN d");
     assertFilterFail(
         vocbase(),
         "FOR d IN myView FILTER ANALYZER(phrase(d.name, [ 1, \"abc\" ]), "


### PR DESCRIPTION
Allowed empty array as PHRASE function parameter. Empty arrays  just skipped without affecting resulting ArangoSearch filter while accumulating offsets ( 'a', 1, [], 2, 'b' is equal to 'a', 3, 'b'). If only empty array(s) given, search will yeld no results, but will be considered valid.

https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/8194/