### PR TITLE
disable health react request till we need it

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 devel
 -----
+
+* Removed an unnecessary and wrong request from within the Web UI to the
+  `/_admin/cluster/health` API. This lead to unauthorized network calls.
+
 * Fix issue #10897, using COLLECT in a subquery could lead to unexpected and
   confusing error messages
 

--- a/js/apps/system/_admin/aardvark/APP/react/src/store/cluster/middleware.tsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/store/cluster/middleware.tsx
@@ -20,7 +20,8 @@ const middleware : Middleware = (_ : MiddlewareAPI ) =>
       arango.triggerMoveShard(action.payload);
       break;
     case '@@cluster/checkHealth':
-      arango.clusterCheckHealth();
+      // TODO: enable me when switched to react
+      // arango.clusterCheckHealth();
       break;
     default:
   }


### PR DESCRIPTION
Disable a not needed health call. The function was only built for development as a POC. Only commented out as we need it in the future 