### PR TITLE
Documentation/typos 2020 01 24

### DIFF
--- a/Documentation/DocuBlocks/Rest/Administration/JSF_get_admin_status.md
+++ b/Documentation/DocuBlocks/Rest/Administration/JSF_get_admin_status.md
@@ -27,15 +27,15 @@ The call returns an object with the following attributes:
 
 - *serverInfo.writeOpsEnabled*: boolean, true if writes are enabled.
 
-- *serverInfo.maintenance*: boolean, true if maintenace mode is enabled.
+- *serverInfo.maintenance*: boolean, true if maintenance mode is enabled.
 
-- *agency.endpoints*: a list of possible agency endpoints.
+- *agency.endpoints*: a list of possible Agency endpoints.
 
-An agent, coordinator or primary will also have
+An Agent, Coordinator or primary will also have
 
 - *serverInfo.persistedId*: the persisted ide, e. g. *"CRDN-e427b441-5087-4a9a-9983-2fb1682f3e2a"*.
 
-A coordinator or primary will also have
+A Coordinator or primary will also have
 
 - *serverInfo.state*: *SERVING*
 
@@ -43,21 +43,21 @@ A coordinator or primary will also have
 
 - *serverInfo.serverId*: the server ide, e. g. *"CRDN-e427b441-5087-4a9a-9983-2fb1682f3e2a"*.
 
-A coordinator will also have
+A Coordinator will also have
 
 - *coordinator.foxxmaster*: the server id of the foxx master.
 
 - *coordinator.isFoxxmaster*: boolean, true if the server is the foxx master.
 
-An agent will also have
+An Agent will also have
 
-- *agent.id*: server id of this agent.
+- *agent.id*: server id of this Agent.
 
 - *agent.leaderId*: server id of the leader.
 
 - *agent.leading*: boolean, true if leading.
 
-- *agent.endpoint*: the endpoint of this agent.
+- *agent.endpoint*: the endpoint of this Agent.
 
 - *agent.term*: current term number.
 

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_server_role.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_server_role.md
@@ -10,7 +10,7 @@ The role is returned in the *role* attribute of the result.
 Possible return values for *role* are:
 - *SINGLE*: the server is a standalone server without clustering
 - *COORDINATOR*: the server is a Coordinator in a cluster
-- *PRIMARY*: the server is a DBServer in a cluster
+- *PRIMARY*: the server is a DB-Server in a cluster
 - *SECONDARY*: this role is not used anymore
 - *AGENT*: the server is an Agency node in a cluster
 - *UNDEFINED*: in a cluster, *UNDEFINED* is returned if the server role cannot be

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_statistics.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_statistics.md
@@ -21,10 +21,10 @@ transactions as well as intermediate commits done for the server queried. The
 intermediate commit count will only take non zero values for the RocksDB
 storage engine. Coordinators do almost no local transactions themselves in
 their local databases, therefor cluster transactions (transactions started on a
-coordinator that require DBServers to finish before the transactions is
+Coordinator that require DB-Servers to finish before the transactions is
 committed cluster wide) are just added to their local statistics. This means
 that the statistics you would see for a single server is roughly what you can
-expect in a cluster setup using a single coordinator querying this coordinator.
+expect in a cluster setup using a single Coordinator querying this Coordinator.
 Just with the difference that cluster transactions have no notion of
 intermediate commits and will not increase the value.
 

--- a/Documentation/DocuBlocks/Rest/Administration/get_api_cluster_endpoints.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_api_cluster_endpoints.md
@@ -1,13 +1,13 @@
 @startDocuBlock get_api_cluster_endpoints
-@brief This API call returns information about all coordinator endpoints (cluster only).
+@brief This API call returns information about all Coordinator endpoints (cluster only).
 
-@RESTHEADER{GET /_api/cluster/endpoints, Get information about all coordinator endpoints, handleCommandEndpoints:listClusterEndpoints}
+@RESTHEADER{GET /_api/cluster/endpoints, Get information about all Coordinator endpoints, handleCommandEndpoints:listClusterEndpoints}
 
 @RESTDESCRIPTION
 Returns an object with an attribute `endpoints`, which contains an
 array of objects, which each have the attribute `endpoint`, whose value
 is a string with the endpoint description. There is an entry for each
-coordinator in the cluster. This method only works on coordinators in
+Coordinator in the cluster. This method only works on Coordinators in
 cluster mode. In case of an error the `error` attribute is set to
 `true`.
 
@@ -25,8 +25,8 @@ the HTTP status code - 200
 A list of active cluster endpoints.
 
 @RESTSTRUCT{endpoint,cluster_endpoints_struct,string,required,}
-The bind of the coordinator, like `tcp://[::1]:8530`
+The bind of the Coordinator, like `tcp://[::1]:8530`
 
-@RESTRETURNCODE{501} server is not a coordinator or method was not GET.
+@RESTRETURNCODE{501} server is not a Coordinator or method was not GET.
 
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Bulk/post_api_export.md
+++ b/Documentation/DocuBlocks/Rest/Bulk/post_api_export.md
@@ -127,7 +127,7 @@ compacted or unloaded. By default, unused cursors will be deleted automatically
 after a server-defined idle time, and clients can adjust this idle time by setting
 the *ttl* value.
 
-Note: this API is currently not supported on cluster coordinators.
+Note: this API is currently not supported on cluster Coordinators.
 
 @RESTRETURNCODES
 
@@ -147,6 +147,6 @@ The server will respond with *HTTP 405* if an unsupported HTTP method is used.
 
 @RESTRETURNCODE{501}
 The server will respond with *HTTP 501* if this API is called on a cluster
-coordinator.
+Coordinator.
 
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Cluster/get_cluster_health.md
+++ b/Documentation/DocuBlocks/Rest/Cluster/get_cluster_health.md
@@ -1,6 +1,6 @@
 
 @startDocuBlock get_cluster_health
-@brief Returns the health of the cluster as assessed by the supervision (agency)
+@brief Returns the health of the cluster as assessed by the supervision (Agency)
 
 @RESTHEADER{GET /_admin/cluster/health, Queries the health of cluster for monitoring}
 
@@ -15,11 +15,11 @@ Queries the health of the cluster for monitoring purposes. The response is a JSO
     - `CanBeDeleted`: Boolean representing whether the node can safely be removed from the cluster.
     - `Version`: Version String of ArangoDB used by that node.
     - `Engine`: Storage Engine used by that node.
-    - `Status`: A string indicating the health of the node as assessed by the supervision (agency). This should be considered primary source of truth for coordinator and dbservers node health. If the node is responding normally to requests, it is `"GOOD"`. If it has missed one heartbeat, it is `"BAD"`. If it has been declared failed by the supervision, which occurs after missing heartbeats for about 15 seconds, it will be marked `"FAILED"`.
+    - `Status`: A string indicating the health of the node as assessed by the supervision (Agency). This should be considered primary source of truth for Coordinator and DB-Servers node health. If the node is responding normally to requests, it is `"GOOD"`. If it has missed one heartbeat, it is `"BAD"`. If it has been declared failed by the supervision, which occurs after missing heartbeats for about 15 seconds, it will be marked `"FAILED"`.
 
     Additionally it will also have the following attributes for:
 
-    **Coordinators** and **DBServers**
+    **Coordinators** and **DB-Servers**
     - `SyncStatus`: The last sync status reported by the node. This value is primarily used to determine the value of `Status`. Possible values include `"UNKNOWN"`, `"UNDEFINED"`, `"STARTUP"`, `"STOPPING"`, `"STOPPED"`, `"SERVING"`, `"SHUTDOWN"`.
     - `LastAckedTime`: ISO 8601 timestamp specifying the last heartbeat received.
     - `ShortName`: A string representing the shortname of the server, e.g. `"Coordinator0001"`.
@@ -30,8 +30,8 @@ Queries the health of the cluster for monitoring purposes. The response is a JSO
     - `AdvertisedEndpoint`: A string representing the advertised endpoint, if set. (e.g. external IP address or load balancer, optional)
 
     **Agents**
-    - `Leader`: ID of the agent this node regards as leader.
-    - `Leading`: Whether this agent is the leader (true) or not (false).
+    - `Leader`: ID of the Agent this node regards as leader.
+    - `Leading`: Whether this Agent is the leader (true) or not (false).
     - `LastAckedTime`: Time since last `acked` in seconds.
 
 @RESTRETURNCODES

--- a/Documentation/DocuBlocks/Rest/Cluster/get_cluster_statistics.md
+++ b/Documentation/DocuBlocks/Rest/Cluster/get_cluster_statistics.md
@@ -1,22 +1,22 @@
 
 @startDocuBlock get_cluster_statistics
-@brief allows to query the statistics of a DBserver in the cluster
+@brief allows to query the statistics of a DB-Server in the cluster
 
-@RESTHEADER{GET /_admin/clusterStatistics, Queries statistics of DBserver}
+@RESTHEADER{GET /_admin/clusterStatistics, Queries statistics of a DB-Server}
 
 @RESTQUERYPARAMETERS
 
 @RESTQUERYPARAM{DBserver,string,required}
 
 @RESTDESCRIPTION
-Queries the statistics of the given DBserver
+Queries the statistics of the given DB-Server
 
 @RESTRETURNCODES
 
 @RESTRETURNCODE{200} is returned when everything went well.
 
 @RESTRETURNCODE{400} the parameter DBserver was not given or is not the
-ID of a DBserver
+ID of a DB-Server
 
-@RESTRETURNCODE{403} server is not a coordinator.
+@RESTRETURNCODE{403} server is not a Coordinator.
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Cluster/put_cluster_maintenance.md
+++ b/Documentation/DocuBlocks/Rest/Cluster/put_cluster_maintenance.md
@@ -1,6 +1,6 @@
 
 @startDocuBlock put_cluster_maintenance
-@brief Enable or disable the cluster supervision (agency) maintenance mode
+@brief Enable or disable the cluster supervision (Agency) maintenance mode
 
 @RESTHEADER{PUT /_admin/cluster/maintenance, Enable or disable the supervision maintenance mode}
 
@@ -18,7 +18,7 @@ To enable the maintenance mode the request body must contain the string `"on"`. 
 
 @RESTRETURNCODE{400} if the request contained an invalid body
 
-@RESTRETURNCODE{501} if the request was sent to a node other than a coordinator or single-server
+@RESTRETURNCODE{501} if the request was sent to a node other than a Coordinator or single-server
 
 @RESTRETURNCODE{504} if the request timed out while enabling the maintenance mode
 

--- a/Documentation/DocuBlocks/Rest/Collections/1_structs.md
+++ b/Documentation/DocuBlocks/Rest/Collections/1_structs.md
@@ -40,12 +40,12 @@ contains the names of document attributes that are used to
 determine the target shard for documents. _(cluster only)_
 
 @RESTSTRUCT{replicationFactor,collection_info,integer,optional,}
-contains how many copies of each shard are kept on different DBServers.
+contains how many copies of each shard are kept on different DB-Servers.
 _(cluster only)_
 
 @RESTSTRUCT{writeConcern,collection_info,integer,optional,}
 determines how many copies of each shard are required to be
-in sync on the different DBServers. If there are less then these many copies
+in sync on the different DB-Servers. If there are less then these many copies
 in the cluster a shard will refuse to write. Writes to shards with enough
 up-to-date copies will succeed at the same time however. The value of
 *writeConcern* can not be larger than *replicationFactor*. _(cluster only)_

--- a/Documentation/DocuBlocks/Rest/Collections/1_structs.md
+++ b/Documentation/DocuBlocks/Rest/Collections/1_structs.md
@@ -55,7 +55,7 @@ the sharding strategy selected for the collection.
 One of 'hash' or 'enterprise-hash-smart-edge'. _(cluster only)_
 
 @RESTSTRUCT{smartGraphAttribute,collection_info,string,optional,}
-Attribute that is used in smart graphs. _(cluster only)_
+Attribute that is used in SmartGraphs. _(cluster only)_
 
 @RESTSTRUCT{indexBuckets,collection_info,integer,optional,}
 the number of index buckets

--- a/Documentation/DocuBlocks/Rest/Collections/get_api_collection_getResponsibleShard.md
+++ b/Documentation/DocuBlocks/Rest/Collections/get_api_collection_getResponsibleShard.md
@@ -24,7 +24,7 @@ collection's shard key attributes set to some values.
 The response is a JSON object with a *shardId* attribute, which will
 contain the ID of the responsible shard.
 
-**Note** : This method is only available in a cluster coordinator.
+**Note** : This method is only available in a cluster Coordinator.
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Collections/get_api_collection_shards.md
+++ b/Documentation/DocuBlocks/Rest/Collections/get_api_collection_shards.md
@@ -21,7 +21,7 @@ If the `details` parameter is set to `true`, it will return a JSON object with t
 shard IDs as object attribute keys, and the responsible servers for each shard mapped to them.
 In the detailed response, the leader shards will be first in the arrays.
 
-**Note** : This method is only available in a cluster coordinator.
+**Note** : This method is only available in a cluster Coordinator.
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
+++ b/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
@@ -177,7 +177,7 @@ benefit, but it may later in case other sharding strategies are added.
 @RESTBODYPARAM{smartJoinAttribute,string,optional,string}
 In an *Enterprise Edition* cluster, this attribute determines an attribute
 of the collection that must contain the shard key value of the referred-to
-smart join collection. Additionally, the shard key for a document in this
+SmartJoin collection. Additionally, the shard key for a document in this
 collection must contain the value of this attribute, followed by a colon,
 followed by the actual primary key of the document.
 

--- a/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
+++ b/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
@@ -120,9 +120,9 @@ and the hash value is used to determine the target shard.
 
 @RESTBODYPARAM{replicationFactor,integer,optional,int64}
 (The default is *1*): in a cluster, this attribute determines how many copies
-of each shard are kept on different DBServers. The value 1 means that only one
+of each shard are kept on different DB-Servers. The value 1 means that only one
 copy (no synchronous replication) is kept. A value of k means that k-1 replicas
-are kept. Any two copies reside on different DBServers. Replication between them is
+are kept. Any two copies reside on different DB-Servers. Replication between them is
 synchronous, that is, every write operation to the "leader" copy will be replicated
 to all "follower" replicas, before the write operation is reported successful.
 
@@ -132,7 +132,7 @@ copies take over, usually without an error being reported.
 @RESTBODYPARAM{writeConcern,integer,optional,int64}
 Write concern for this collection (default: 1).
 It determines how many copies of each shard are required to be
-in sync on the different DBServers. If there are less then these many copies
+in sync on the different DB-Servers. If there are less then these many copies
 in the cluster a shard will refuse to write. Writes to shards with enough
 up-to-date copies will succeed at the same time however. The value of
 *writeConcern* can not be larger than *replicationFactor*. _(cluster only)_

--- a/Documentation/DocuBlocks/Rest/Cursors/post_api_cursor.md
+++ b/Documentation/DocuBlocks/Rest/Cursors/post_api_cursor.md
@@ -106,7 +106,7 @@ Additionally the query plan is returned in the sub-attribute *extra.plan*.
 
 @RESTSTRUCT{satelliteSyncWait,post_api_cursor_opts,boolean,optional,}
 This *Enterprise Edition* parameter allows to configure how long a DB-Server will have time
-to bring the satellite collections involved in the query into sync.
+to bring the Satellite Collections involved in the query into sync.
 The default value is *60.0* (seconds). When the max time has been reached the query
 will be stopped.
 

--- a/Documentation/DocuBlocks/Rest/Cursors/post_api_cursor.md
+++ b/Documentation/DocuBlocks/Rest/Cursors/post_api_cursor.md
@@ -105,7 +105,7 @@ per query plan node in sub-attribute *stats.nodes* of the *extra* return attribu
 Additionally the query plan is returned in the sub-attribute *extra.plan*.
 
 @RESTSTRUCT{satelliteSyncWait,post_api_cursor_opts,boolean,optional,}
-This *Enterprise Edition* parameter allows to configure how long a DBServer will have time
+This *Enterprise Edition* parameter allows to configure how long a DB-Server will have time
 to bring the satellite collections involved in the query into sync.
 The default value is *60.0* (seconds). When the max time has been reached the query
 will be stopped.

--- a/Documentation/DocuBlocks/Rest/Database/get_api_database_new.md
+++ b/Documentation/DocuBlocks/Rest/Database/get_api_database_new.md
@@ -17,12 +17,12 @@ are: "", "flexible", or "single". The first two are equivalent. _(cluster only)_
 @RESTSTRUCT{replicationFactor,get_api_database_new_USERS,string,optional,}
 Default replication factor for new collections created in this database.
 Special values include "satellite", which will replicate the collection to
-every DB-server, and 1, which disables replication. _(cluster only)_
+every DB-Server, and 1, which disables replication. _(cluster only)_
 
 @RESTSTRUCT{writeConcern,get_api_database_new_USERS,number,optional,}
 Default write concern for new collections created in this database.
 It determines how many copies of each shard are required to be
-in sync on the different DBServers. If there are less then these many copies
+in sync on the different DB-Servers. If there are less then these many copies
 in the cluster a shard will refuse to write. Writes to shards with enough
 up-to-date copies will succeed at the same time however. The value of
 *writeConcern* can not be larger than *replicationFactor*. _(cluster only)_

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_commit.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_commit.md
@@ -4,9 +4,9 @@
 @RESTHEADER{POST /_api/foxx/commit, Commit local service state}
 
 @RESTDESCRIPTION
-Commits the local service state of the coordinator to the database.
+Commits the local service state of the Coordinator to the database.
 
-This can be used to resolve service conflicts between coordinators that can not be fixed automatically due to missing data.
+This can be used to resolve service conflicts between Coordinators that can not be fixed automatically due to missing data.
 
 @RESTQUERYPARAMETERS
 

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_development_disable.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_development_disable.md
@@ -6,9 +6,9 @@
 @RESTDESCRIPTION
 Puts the service at the given mount path into production mode.
 
-When running ArangoDB in a cluster with multiple coordinators this will
-replace the service on all other coordinators with the version on this
-coordinator.
+When running ArangoDB in a cluster with multiple Coordinators this will
+replace the service on all other Coordinators with the version on this
+Coordinator.
 
 @RESTQUERYPARAMETERS
 

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_development_enable.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_development_enable.md
@@ -10,9 +10,9 @@ While the service is running in development mode the service will be reloaded
 from the filesystem and its setup script (if any) will be re-executed every
 time the service handles a request.
 
-When running ArangoDB in a cluster with multiple coordinators note that changes
-to the filesystem on one coordinator will not be reflected across the other
-coordinators. This means you should treat your coordinators as inconsistent
+When running ArangoDB in a cluster with multiple Coordinators note that changes
+to the filesystem on one Coordinator will not be reflected across the other
+Coordinators. This means you should treat your Coordinators as inconsistent
 as long as any service is running in development mode.
 
 @RESTQUERYPARAMETERS

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_service_install.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_service_install.md
@@ -31,8 +31,8 @@ If *source* is a file system path, the path will be resolved on the server.
 In either case the path or URL is expected to resolve to a zip bundle,
 JavaScript file or (in case of a file system path) directory.
 
-Note that when using file system paths in a cluster with multiple coordinators
-the file system path must resolve to equivalent files on every coordinator.
+Note that when using file system paths in a cluster with multiple Coordinators
+the file system path must resolve to equivalent files on every Coordinator.
 
 @RESTQUERYPARAMETERS
 

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_service_replace.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_service_replace.md
@@ -36,8 +36,8 @@ If *source* is a file system path, the path will be resolved on the server.
 In either case the path or URL is expected to resolve to a zip bundle,
 JavaScript file or (in case of a file system path) directory.
 
-Note that when using file system paths in a cluster with multiple coordinators
-the file system path must resolve to equivalent files on every coordinator.
+Note that when using file system paths in a cluster with multiple Coordinators
+the file system path must resolve to equivalent files on every Coordinator.
 
 @RESTQUERYPARAMETERS
 

--- a/Documentation/DocuBlocks/Rest/Foxx/api_foxx_service_upgrade.md
+++ b/Documentation/DocuBlocks/Rest/Foxx/api_foxx_service_upgrade.md
@@ -36,8 +36,8 @@ If *source* is a file system path, the path will be resolved on the server.
 In either case the path or URL is expected to resolve to a zip bundle,
 JavaScript file or (in case of a file system path) directory.
 
-Note that when using file system paths in a cluster with multiple coordinators
-the file system path must resolve to equivalent files on every coordinator.
+Note that when using file system paths in a cluster with multiple Coordinators
+the file system path must resolve to equivalent files on every Coordinator.
 
 @RESTQUERYPARAMETERS
 

--- a/Documentation/DocuBlocks/Rest/Graph/1_structs.md
+++ b/Documentation/DocuBlocks/Rest/Graph/1_structs.md
@@ -25,7 +25,7 @@ The replication factor used for every new collection in the graph.
 @RESTSTRUCT{writeConcern,graph_representation,integer,optional,}
 Default write concern for new collections in the graph.
 It determines how many copies of each shard are required to be
-in sync on the different DBServers. If there are less then these many copies
+in sync on the different DB-Servers. If there are less then these many copies
 in the cluster a shard will refuse to write. Writes to shards with enough
 up-to-date copies will succeed at the same time however. The value of
 *writeConcern* can not be larger than *replicationFactor*. _(cluster only)_

--- a/Documentation/DocuBlocks/Rest/Graph/1_structs.md
+++ b/Documentation/DocuBlocks/Rest/Graph/1_structs.md
@@ -34,7 +34,7 @@ up-to-date copies will succeed at the same time however. The value of
 Flag if the graph is a SmartGraph (Enterprise Edition only) or not.
 
 @RESTSTRUCT{smartGraphAttribute,graph_representation,string,optional,}
-The name of the sharding attribute in smart graph case (Enterprise Edition only)
+The name of the sharding attribute in SmartGraph case (Enterprise Edition only)
 
 @RESTSTRUCT{_id,vertex_representation,string,required,}
 The _id value of the stored data.

--- a/Documentation/DocuBlocks/Rest/Graph/general_graph_create_http_examples.md
+++ b/Documentation/DocuBlocks/Rest/Graph/general_graph_create_http_examples.md
@@ -49,7 +49,7 @@ The replication factor used when initially creating collections for this graph.
 @RESTSTRUCT{writeConcern,post_api_gharial_create_opts,integer,optional,}
 Write concern for new collections in the graph.
 It determines how many copies of each shard are required to be
-in sync on the different DBServers. If there are less then these many copies
+in sync on the different DB-Servers. If there are less then these many copies
 in the cluster a shard will refuse to write. Writes to shards with enough
 up-to-date copies will succeed at the same time however. The value of
 *writeConcern* can not be larger than *replicationFactor*. _(cluster only)_

--- a/Documentation/DocuBlocks/Rest/Graph/general_graph_list_http_examples.md
+++ b/Documentation/DocuBlocks/Rest/Graph/general_graph_list_http_examples.md
@@ -52,7 +52,7 @@ The replication factor used for every new collection in the graph.
 Flag if the graph is a SmartGraph (Enterprise Edition only) or not.
 
 @RESTSTRUCT{smartGraphAttribute,graph_representation,string,optional,}
-The name of the sharding attribute in smart graph case (Enterprise Edition only)
+The name of the sharding attribute in SmartGraph case (Enterprise Edition only)
 
 @EXAMPLES
 

--- a/Documentation/DocuBlocks/Rest/Replication/delete_batch_replication.md
+++ b/Documentation/DocuBlocks/Rest/Replication/delete_batch_replication.md
@@ -14,10 +14,10 @@ The id of the batch.
 @RESTDESCRIPTION
 Deletes the existing dump batch, allowing compaction and cleanup to resume.
 
-**Note**: on a coordinator, this request must have the query parameter
-*DBserver* which must be an ID of a DBserver.
-The very same request is forwarded synchronously to that DBserver.
-It is an error if this attribute is not bound in the coordinator case.
+**Note**: on a Coordinator, this request must have the query parameter
+*DBserver* which must be an ID of a DB-Server.
+The very same request is forwarded synchronously to that DB-Server.
+It is an error if this attribute is not bound in the Coordinator case.
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Replication/get_api_replication_cluster_inventory.md
+++ b/Documentation/DocuBlocks/Rest/Replication/get_api_replication_cluster_inventory.md
@@ -15,7 +15,7 @@ Returns the array of collections and indexes available on the cluster.
 The response will be an array of JSON objects, one for each collection.
 Each collection containscontains exactly two keys "parameters" and
 "indexes". This
-information comes from Plan/Collections/{DB-Name}/* in the agency,
+information comes from Plan/Collections/{DB-Name}/* in the Agency,
 just that the *indexes* attribute there is relocated to adjust it to
 the data format of arangodump.
 

--- a/Documentation/DocuBlocks/Rest/Replication/get_api_replication_logger_first_tick.md
+++ b/Documentation/DocuBlocks/Rest/Replication/get_api_replication_logger_first_tick.md
@@ -15,7 +15,7 @@ attribute contains the minimum tick value available in the server's
 replication
 log.
 
-**Note**: this method is not supported on a coordinator in a cluster.
+**Note**: this method is not supported on a Coordinator in a cluster.
 
 @RESTRETURNCODES
 
@@ -29,7 +29,7 @@ is returned when an invalid HTTP method is used.
 is returned if an error occurred while assembling the response.
 
 @RESTRETURNCODE{501}
-is returned when this operation is called on a coordinator in a cluster.
+is returned when this operation is called on a Coordinator in a cluster.
 
 @EXAMPLES
 

--- a/Documentation/DocuBlocks/Rest/Replication/get_api_replication_logger_follow.md
+++ b/Documentation/DocuBlocks/Rest/Replication/get_api_replication_logger_follow.md
@@ -114,7 +114,7 @@ The response will also contain the following HTTP headers:
   If there isn't any more log data to fetch, the client might decide to go
   to sleep for a while before calling the logger again.
 
-**Note**: this method is not supported on a coordinator in a cluster.
+**Note**: this method is not supported on a Coordinator in a cluster.
 
 @RESTRETURNCODES
 
@@ -138,7 +138,7 @@ is returned when an invalid HTTP method is used.
 is returned if an error occurred while assembling the response.
 
 @RESTRETURNCODE{501}
-is returned when this operation is called on a coordinator in a cluster.
+is returned when this operation is called on a Coordinator in a cluster.
 
 @EXAMPLES
 

--- a/Documentation/DocuBlocks/Rest/Replication/get_api_replication_logger_tick_ranges.md
+++ b/Documentation/DocuBlocks/Rest/Replication/get_api_replication_logger_tick_ranges.md
@@ -33,7 +33,7 @@ is returned when an invalid HTTP method is used.
 is returned if the logger state could not be determined.
 
 @RESTRETURNCODE{501}
-is returned when this operation is called on a coordinator in a cluster.
+is returned when this operation is called on a Coordinator in a cluster.
 
 @EXAMPLES
 

--- a/Documentation/DocuBlocks/Rest/Replication/get_api_wal_access_last_tick.md
+++ b/Documentation/DocuBlocks/Rest/Replication/get_api_wal_access_last_tick.md
@@ -13,7 +13,7 @@ The result is a JSON object containing the attributes *tick*, *time* and *server
 * *time*: the server time as string in format "YYYY-MM-DDTHH:MM:SSZ"
 * *server*: An object with fields *version* and *serverId*
 
-**Note**: this method is not supported on a coordinator in a cluster.
+**Note**: this method is not supported on a Coordinator in a cluster.
 
 @RESTRETURNCODES
 
@@ -27,7 +27,7 @@ is returned when an invalid HTTP method is used.
 is returned if an error occurred while assembling the response.
 
 @RESTRETURNCODE{501}
-is returned when this operation is called on a coordinator in a cluster.
+is returned when this operation is called on a Coordinator in a cluster.
 
 @EXAMPLES
 

--- a/Documentation/DocuBlocks/Rest/Replication/get_api_wal_access_range.md
+++ b/Documentation/DocuBlocks/Rest/Replication/get_api_wal_access_range.md
@@ -27,7 +27,7 @@ is returned when an invalid HTTP method is used.
 is returned if the server operations state could not be determined.
 
 @RESTRETURNCODE{501}
-is returned when this operation is called on a coordinator in a cluster.
+is returned when this operation is called on a Coordinator in a cluster.
 
 @EXAMPLES
 

--- a/Documentation/DocuBlocks/Rest/Replication/get_api_wal_access_tail.md
+++ b/Documentation/DocuBlocks/Rest/Replication/get_api_wal_access_tail.md
@@ -151,7 +151,7 @@ The response will also contain the following HTTP headers:
   If there isn't any more log data to fetch, the client might decide to go
   to sleep for a while before calling the logger again.
 
-**Note**: this method is not supported on a coordinator in a cluster.
+**Note**: this method is not supported on a Coordinator in a cluster.
 
 @RESTRETURNCODES
 
@@ -175,7 +175,7 @@ is returned when an invalid HTTP method is used.
 is returned if an error occurred while assembling the response.
 
 @RESTRETURNCODE{501}
-is returned when this operation is called on a coordinator in a cluster.
+is returned when this operation is called on a Coordinator in a cluster.
 
 @EXAMPLES
 

--- a/Documentation/DocuBlocks/Rest/Replication/post_batch_replication.md
+++ b/Documentation/DocuBlocks/Rest/Replication/post_batch_replication.md
@@ -17,10 +17,10 @@ The response is a JSON object with the following attributes:
 
 - *id*: the id of the batch
 
-**Note**: on a coordinator, this request must have the query parameter
-*DBserver* which must be an ID of a DBserver.
-The very same request is forwarded synchronously to that DBserver.
-It is an error if this attribute is not bound in the coordinator case.
+**Note**: on a Coordinator, this request must have the query parameter
+*DBserver* which must be an ID of a DB-Server.
+The very same request is forwarded synchronously to that DB-Server.
+It is an error if this attribute is not bound in the Coordinator case.
 
 @RESTRETURNCODES
 
@@ -29,7 +29,7 @@ is returned if the batch was created successfully.
 
 @RESTRETURNCODE{400}
 is returned if the ttl value is invalid or if *DBserver* attribute
-is not specified or illegal on a coordinator.
+is not specified or illegal on a Coordinator.
 
 @RESTRETURNCODE{405}
 is returned when an invalid HTTP method is used.

--- a/Documentation/DocuBlocks/Rest/Replication/put_api_replication_inventory.md
+++ b/Documentation/DocuBlocks/Rest/Replication/put_api_replication_inventory.md
@@ -75,13 +75,13 @@ server, the following additional steps need to be carried out:
   response will be empty and clients can go to sleep for a while and try again
   later.
 
-**Note**: on a coordinator, this request must have the query parameter
-*DBserver* which must be an ID of a DBserver.
-The very same request is forwarded synchronously to that DBserver.
-It is an error if this attribute is not bound in the coordinator case.
+**Note**: on a Coordinator, this request must have the query parameter
+*DBserver* which must be an ID of a DB-Server.
+The very same request is forwarded synchronously to that DB-Server.
+It is an error if this attribute is not bound in the Coordinator case.
 
-**Note:**: Using the `global` parameter the top-level object contains a key `databases`
-under which each key represents a datbase name, and the value conforms to the above describtion.
+**Note**: Using the `global` parameter the top-level object contains a key `databases`
+under which each key represents a database name, and the value conforms to the above description.
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Replication/put_api_replication_makeSlave.md
+++ b/Documentation/DocuBlocks/Rest/Replication/put_api_replication_makeSlave.md
@@ -219,7 +219,7 @@ Please also keep in mind that this command may take a long time to complete
 and return. This is because it will first do a full data synchronization with
 the master, which will take time roughly proportional to the amount of data.
 
-**Note**: this method is not supported on a coordinator in a cluster.
+**Note**: this method is not supported on a Coordinator in a cluster.
 
 @RESTRETURNCODES
 
@@ -237,5 +237,5 @@ is returned if an error occurred during synchronization or when starting the
 continuous replication.
 
 @RESTRETURNCODE{501}
-is returned when this operation is called on a coordinator in a cluster.
+is returned when this operation is called on a Coordinator in a cluster.
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Replication/put_api_replication_synchronize.md
+++ b/Documentation/DocuBlocks/Rest/Replication/put_api_replication_synchronize.md
@@ -76,7 +76,7 @@ collections will be purged and replaced with data from the endpoint.
 
 Use with caution!
 
-**Note**: this method is not supported on a coordinator in a cluster.
+**Note**: this method is not supported on a Coordinator in a cluster.
 
 @RESTRETURNCODES
 
@@ -93,5 +93,5 @@ is returned when an invalid HTTP method is used.
 is returned if an error occurred during synchronization.
 
 @RESTRETURNCODE{501}
-is returned when this operation is called on a coordinator in a cluster.
+is returned when this operation is called on a Coordinator in a cluster.
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Replication/put_batch_replication.md
+++ b/Documentation/DocuBlocks/Rest/Replication/put_batch_replication.md
@@ -20,10 +20,10 @@ the provided ttl value.
 
 If the batch's ttl can be extended successfully, the response is empty.
 
-**Note**: on a coordinator, this request must have the query parameter
-*DBserver* which must be an ID of a DBserver.
-The very same request is forwarded synchronously to that DBserver.
-It is an error if this attribute is not bound in the coordinator case.
+**Note**: on a Coordinator, this request must have the query parameter
+*DBserver* which must be an ID of a DB-Server.
+The very same request is forwarded synchronously to that DB-Server.
+It is an error if this attribute is not bound in the Coordinator case.
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Transactions/get_api_transactions.md
+++ b/Documentation/DocuBlocks/Rest/Transactions/get_api_transactions.md
@@ -7,7 +7,7 @@
 @RESTDESCRIPTION
 The result is an object describing with the attribute *transactions*, which contains
 an array of transactions.
-In a cluster the array will contain the transactions from all coordinators.
+In a cluster the array will contain the transactions from all Coordinators.
 
 Each array entry contains an object with the following attributes:
 

--- a/Documentation/DocuBlocks/clusterAgencyEndpoint.md
+++ b/Documentation/DocuBlocks/clusterAgencyEndpoint.md
@@ -1,10 +1,10 @@
 
 
-@brief list of agency endpoints
+@brief list of Agency endpoints
 `--cluster.agency-endpoint endpoint`
 
-An agency endpoint the server can connect to. The option can be specified
-multiple times so the server can use a cluster of agency servers.
+An Agency endpoint the server can connect to. The option can be specified
+multiple times so the server can use a cluster of Agency servers.
 Endpoints
 have the following pattern:
 

--- a/Documentation/DocuBlocks/clusterAgencyPrefix.md
+++ b/Documentation/DocuBlocks/clusterAgencyPrefix.md
@@ -1,11 +1,11 @@
 
 
-@brief global agency prefix
+@brief global Agency prefix
 `--cluster.agency-prefix prefix`
 
-The global key prefix used in all requests to the agency. The specified
-prefix will become part of each agency key. Specifying the key prefix
-allows managing multiple ArangoDB clusters with the same agency
+The global key prefix used in all requests to the Agency. The specified
+prefix will become part of each Agency key. Specifying the key prefix
+allows managing multiple ArangoDB clusters with the same Agency
 server(s).
 
 *prefix* must consist of the letters *a-z*, *A-Z* and the digits *0-9*

--- a/Documentation/DocuBlocks/clusterMyAddress.md
+++ b/Documentation/DocuBlocks/clusterMyAddress.md
@@ -11,7 +11,7 @@ must have the following pattern:
 - ssl://[ipv6-address]:port - TCP/IP endpoint, using IPv6, SSL encryption
 
 If no *endpoint* is specified, the server will look up its internal
-endpoint address in the agency. If no endpoint can be found in the agency
+endpoint address in the Agency. If no endpoint can be found in the Agency
 for the server's id, ArangoDB will refuse to start.
 
 @EXAMPLES

--- a/Documentation/DocuBlocks/clusterPassword.md
+++ b/Documentation/DocuBlocks/clusterPassword.md
@@ -6,14 +6,14 @@
 The password used for authorization of cluster-internal requests.
 This password will be used to authenticate all requests and responses in
 cluster-internal communication, i.e. requests exchanged between
-coordinators and individual database servers.
+Coordinators and individual database servers.
 
 This option is used for cluster-internal requests only. Regular requests
 to
-coordinators are authenticated normally using the data in the `_users`
+Coordinators are authenticated normally using the data in the `_users`
 collection.
 
-If coordinators and database servers are run with authentication turned
+If Coordinators and database servers are run with authentication turned
 off, (e.g. by setting the *--server.authentication* option to *false*),
 the cluster-internal communication will also be unauthenticated.
 

--- a/Documentation/DocuBlocks/clusterUsername.md
+++ b/Documentation/DocuBlocks/clusterUsername.md
@@ -6,13 +6,13 @@
 The username used for authorization of cluster-internal requests.
 This username will be used to authenticate all requests and responses in
 cluster-internal communication, i.e. requests exchanged between
-coordinators and individual database servers.
+Coordinators and individual database servers.
 
 This option is used for cluster-internal requests only. Regular requests
-to coordinators are authenticated normally using the data in the *_users*
+to Coordinators are authenticated normally using the data in the *_users*
 collection.
 
-If coordinators and database servers are run with authentication turned
+If Coordinators and database servers are run with authentication turned
 off, (e.g. by setting the *--server.authentication* option to *false*),
 the cluster-internal communication will also be unauthenticated.
 

--- a/Documentation/DocuBlocks/collectionFigures.md
+++ b/Documentation/DocuBlocks/collectionFigures.md
@@ -65,7 +65,7 @@ memory.
 not reported in the results. When the write-ahead log is collected, documents
 might be added to journals and datafiles of the collection, which may modify 
 the figures of the collection. Also note that `waitingFor` and `compactionStatus` 
-may be empty when called on a coordinator in a cluster.
+may be empty when called on a Coordinator in a cluster.
 
 Additionally, the filesizes of collection and index parameter JSON files are
 not reported. These files should normally have a size of a few bytes

--- a/Documentation/DocuBlocks/collectionProperties.md
+++ b/Documentation/DocuBlocks/collectionProperties.md
@@ -52,10 +52,10 @@ In a cluster setup, the result will also contain the following attributes:
   determine the target shard for documents.
 
 * *replicationFactor*: determines how many copies of each shard are kept 
-  on different DBServers. Has to be in the range of 1-10. _(cluster only)_
+  on different DB-Servers. Has to be in the range of 1-10. _(cluster only)_
 
 * *writeConcern*: determines how many copies of each shard are required to be
-  in sync on the different DBServers. If there are less then these many copies
+  in sync on the different DB-Servers. If there are less then these many copies
   in the cluster a shard will refuse to write. Writes to shards with enough
   up-to-date copies will succeed at the same time however. The value of
   *writeConcern* can not be larger than *replicationFactor*. _(cluster only)_
@@ -80,11 +80,11 @@ one or more of the following attribute(s):
   This option is meaningful for the MMFiles storage engine only.
 
 * *replicationFactor*: Change the number of shard copies kept on 
-  different DBServers, valid values are  integer numbers
+  different DB-Servers, valid values are  integer numbers
   in the range of 1-10. _(cluster only)_
 
 * *writeConcern*: change how many copies of each shard are required to be
-  in sync on the different DBServers. If there are less then these many copies
+  in sync on the different DB-Servers. If there are less then these many copies
   in the cluster a shard will refuse to write. Writes to shards with enough
   up-to-date copies will succeed at the same time however. The value of
   *writeConcern* can not be larger than *replicationFactor*. _(cluster only)_

--- a/README_maintainers.md
+++ b/README_maintainers.md
@@ -275,13 +275,13 @@ cluster on your local machine. `scripts/stopLocalCluster` stops it again.
 
 `scripts/startLocalCluster [numDBServers numCoordinators [mode]]`
 
-Without arguments it starts 2 DBServers and 1 Coordinator in the background,
-running on ports 8629, 8630 and 8530 respectively. The agency runs on port 4001.
+Without arguments it starts 2 DB-Servers and 1 Coordinator in the background,
+running on ports 8629, 8630 and 8530 respectively. The Agency runs on port 4001.
 
 Mode:
 - `C`: Starts the first Coordinator with `--console` in a separate window
   (using an `xterm`).
-- `D`: Starts all DBServers in the GNU debugger in separate windows
+- `D`: Starts all DB-Servers in the GNU debugger in separate windows
   (using `xterm`s). Hit *ENTER* in the original terminal where the script
   runs to continue once all processes have been started up in the debugger.
 

--- a/arangod/Pregel/README.md
+++ b/arangod/Pregel/README.md
@@ -5,7 +5,7 @@ this readme is more intended for internal use.
 
 ## Protocol
 
-Message format between DBServers:
+Message format between DB-Servers:
 
 ```json
 {

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -380,7 +380,7 @@ int dropDBCoordinator(std::string const& dbName) {
   return TRI_ERROR_NO_ERROR;
 }
 
-const std::string dropError = "Error when dropping Datbase";
+const std::string dropError = "Error when dropping database";
 }  // namespace
 
 arangodb::Result Databases::drop(TRI_vocbase_t* systemVocbase, std::string const& dbName) {


### PR DESCRIPTION
### Scope & Purpose

Unify spelling of DB-Server, Coordinator, Agent and Agency further.

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

Touches one line of code (error message only), but I don't expect this to break anything.
https://github.com/arangodb/arangodb/pull/10975/commits/a24b3d6079adec60da068e7d515be0662ffa6a11#diff-37f56f701220a0a005b9ff1ff3d9bb2a