### PR TITLE
catch is dead

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -301,12 +301,8 @@ target_include_directories(arangodbtests SYSTEM PRIVATE
 )
 
 if (USE_JEMALLOC)
-   add_dependencies(arangodbtests jemalloc_build)
+  add_dependencies(arangodbtests jemalloc_build)
 endif ()
-# older macos has no uncaught exceptions
-if (DARWIN)
-  target_compile_definitions(arangodbtests PUBLIC CATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS)
-endif()
 
 find_package(OpenSSL REQUIRED)
 list(APPEND IRESEARCH_LIB_RESOURCES


### PR DESCRIPTION
### Scope & Purpose

remove compile definition that is only relevant for removed catch testing framework

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)


### Testing & Verification

Just needs to compile & execute the tests fine

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8331/