### PR TITLE
Fix uninitialized value in V8ClientConnection.

### DIFF
--- a/arangosh/Shell/V8ClientConnection.cpp
+++ b/arangosh/Shell/V8ClientConnection.cpp
@@ -65,6 +65,7 @@ namespace fu = arangodb::fuerte;
 
 V8ClientConnection::V8ClientConnection(application_features::ApplicationServer& server)
     : _server(server),
+      _requestTimeout(1200.0),
       _lastHttpReturnCode(0),
       _lastErrorMessage(""),
       _version("arango"),


### PR DESCRIPTION
Note that contrary to 3.7 we have no easy access to the `ClientFeature` in the constructor of the `V8ClientConnection`. On the other hand, the `_requestTimeout` is set in the `connection` method in 3.6. Anyway, it seems that JS is querying the timeout before the connection has been established.