### PR TITLE
Fix uninitialized value _requestTimeout in V8ClientConnection.

### DIFF
--- a/arangosh/Shell/V8ClientConnection.cpp
+++ b/arangosh/Shell/V8ClientConnection.cpp
@@ -57,7 +57,8 @@ using namespace arangodb::httpclient;
 using namespace arangodb::import;
 
 V8ClientConnection::V8ClientConnection()
-    : _lastHttpReturnCode(0),
+    : _requestTimeout(1200.0),
+      _lastHttpReturnCode(0),
       _lastErrorMessage(""),
       _version("arango"),
       _mode("unknown mode"),


### PR DESCRIPTION
Same as for 3.6