### PR TITLE
disable warning about `--server.jwt-secret`

### DIFF
--- a/arangod/GeneralServer/AuthenticationFeature.cpp
+++ b/arangod/GeneralServer/AuthenticationFeature.cpp
@@ -129,7 +129,7 @@ void AuthenticationFeature::collectOptions(std::shared_ptr<ProgramOptions> optio
       .setIntroducedIn(30700);
 }
 
-void AuthenticationFeature::validateOptions(std::shared_ptr<ProgramOptions>) {
+void AuthenticationFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
   if (!_jwtSecretKeyfileProgramOption.empty() && !_jwtSecretKeyfileProgramOption.empty()) {
     LOG_TOPIC("d3515", FATAL, Logger::STARTUP)
         << "specifiy either '--server.jwt-"
@@ -150,6 +150,12 @@ void AuthenticationFeature::validateOptions(std::shared_ptr<ProgramOptions>) {
           << "Given JWT secret too long. Max length is " << _maxSecretLength;
       FATAL_ERROR_EXIT();
     }
+  }
+
+  if (options->processingResult().touched("server.jwt-secret")) {
+    LOG_TOPIC("1aaae", WARN, arangodb::Logger::AUTHENTICATION)
+        << "--server.jwt-secret is insecure. Use --server.jwt-secret-keyfile "
+           "instead.";
   }
 }
 
@@ -199,15 +205,6 @@ void AuthenticationFeature::prepare() {
 
 void AuthenticationFeature::start() {
   TRI_ASSERT(isEnabled());
-
-  // If this is empty here, --server.jwt-secret was used
-  if (!_jwtSecretProgramOption.empty() && _jwtSecretKeyfileProgramOption.empty() &&
-      _jwtSecretFolderProgramOption.empty()) {
-    LOG_TOPIC("1aaae", WARN, arangodb::Logger::AUTHENTICATION)
-        << "--server.jwt-secret is insecure. Use --server.jwt-secret-keyfile "
-           "instead.";
-  }
-
   std::ostringstream out;
 
   out << "Authentication is turned " << (_active ? "on" : "off");


### PR DESCRIPTION
### Scope & Purpose

this change hides the warning message about `--server.jwt-secret` being
insecure in case the end user has not set the option at all.
previously the warning was displayed also when not specifying the
option.
the problem was caused by not checking whether the end user had set the
option, but by checking an internal string that was filled also in other
cases then when using the `--server.jwt-secret` option.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8376/