### PR TITLE
added extra assertions and checks for MMFiles index consistency

### DIFF
--- a/arangod/MMFiles/MMFilesCollection.cpp
+++ b/arangod/MMFiles/MMFilesCollection.cpp
@@ -4040,7 +4040,7 @@ Result MMFilesCollection::removeFastPath(transaction::Methods& trx, TRI_voc_rid_
     LOG_TOPIC("5110f", ERR, Logger::ENGINES) << "caught exception in removeFastPath: " << ex.what(); 
     res = Result(TRI_ERROR_INTERNAL, ex.what());
   } catch (...) {
-    LOG_TOPIC("c264c2", ERR, Logger::ENGINES) << "caught unknown exception in removeFastPath"; 
+    LOG_TOPIC("d3dd9", ERR, Logger::ENGINES) << "caught unknown exception in removeFastPath"; 
     res = Result(TRI_ERROR_INTERNAL);
   }
 

--- a/arangod/MMFiles/MMFilesCollection.h
+++ b/arangod/MMFiles/MMFilesCollection.h
@@ -252,6 +252,8 @@ class MMFilesCollection final : public PhysicalCollection {
   /// @brief Drop an index with the given iid.
   bool dropIndex(TRI_idx_iid_t iid) override;
 
+  void drop() override;
+
   ////////////////////////////////////
   // -- SECTION Locking --
   ///////////////////////////////////

--- a/arangod/MMFiles/MMFilesHashIndex.cpp
+++ b/arangod/MMFiles/MMFilesHashIndex.cpp
@@ -564,9 +564,17 @@ int MMFilesHashIndex::lookup(transaction::Methods* trx, VPackSlice key,
   documents.clear();
   try {
     _multiArray->_hashArray->lookupByKey(&context, &key, documents);
-  } catch (std::bad_alloc const&) {
+  } catch (std::bad_alloc const& ex) {
+    LOG_TOPIC("5c5b5", ERR, arangodb::Logger::ENGINES)
+      << "caught exception in lookup: " << ex.what();
     return TRI_ERROR_OUT_OF_MEMORY;
+  } catch (std::exception const& ex) {
+    LOG_TOPIC("15d36", ERR, arangodb::Logger::ENGINES)
+      << "caught exception in lookup: " << ex.what();
+    return TRI_ERROR_INTERNAL;
   } catch (...) {
+    LOG_TOPIC("0d79e", ERR, arangodb::Logger::ENGINES)
+      << "caught unknown exception in lookup";
     return TRI_ERROR_INTERNAL;
   }
   return TRI_ERROR_NO_ERROR;
@@ -727,10 +735,20 @@ Result MMFilesHashIndex::insertMulti(transaction::Methods* trx,
     try {
       work(hashElement, mode);
     } catch (arangodb::basics::Exception const& ex) {
+      LOG_TOPIC("f137e", ERR, arangodb::Logger::ENGINES)
+        << "caught exception in insertMulti: " << ex.what();
       r = ex.code();
-    } catch (std::bad_alloc const&) {
+    } catch (std::bad_alloc const& ex) {
+      LOG_TOPIC("f447f", ERR, arangodb::Logger::ENGINES)
+        << "caught exception in insertMulti: " << ex.what();
       r = TRI_ERROR_OUT_OF_MEMORY;
+    } catch (std::exception const& ex) {
+      LOG_TOPIC("9f987", ERR, arangodb::Logger::ENGINES)
+        << "caught exception in insertMulti: " << ex.what();
+      r = TRI_ERROR_INTERNAL;
     } catch (...) {
+      LOG_TOPIC("ceacd", ERR, arangodb::Logger::ENGINES)
+        << "caught unknown exception in insertMulti";
       r = TRI_ERROR_INTERNAL;
     }
 
@@ -821,6 +839,7 @@ int MMFilesHashIndex::removeUniqueElement(transaction::Methods* trx,
       return TRI_ERROR_NO_ERROR;
     }
 
+    LOG_TOPIC("e1a5e", ERR, arangodb::Logger::ENGINES) << "caught error in removeUniqueElement";
     return TRI_ERROR_INTERNAL;
   }
 
@@ -843,6 +862,7 @@ int MMFilesHashIndex::removeMultiElement(transaction::Methods* trx,
       return TRI_ERROR_NO_ERROR;
     }
 
+    LOG_TOPIC("f9036", ERR, arangodb::Logger::ENGINES) << "caught error in removeMultiElement";
     return TRI_ERROR_INTERNAL;
   }
 

--- a/arangod/MMFiles/MMFilesPathBasedIndex.cpp
+++ b/arangod/MMFiles/MMFilesPathBasedIndex.cpp
@@ -130,8 +130,21 @@ int MMFilesPathBasedIndex::fillElement(std::vector<T*>& elements,
     try {
       buildIndexValues(doc, 0, toInsert, sliceStack);
     } catch (basics::Exception const& ex) {
+      if (ex.code() != TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED) {
+        LOG_TOPIC("9c0f9", ERR, arangodb::Logger::ENGINES)
+          << "caught exception in fillElement: " << ex.what();
+      }
       return ex.code();
+    } catch (std::bad_alloc const& ex) {
+      LOG_TOPIC("bdfe3", ERR, arangodb::Logger::ENGINES)
+        << "caught exception in fillElement: " << ex.what();
+      return TRI_ERROR_OUT_OF_MEMORY;
+    } catch (std::exception const& ex) {
+      LOG_TOPIC("3fca6", ERR, arangodb::Logger::ENGINES)
+        << "caught exception in fillElement: " << ex.what();
     } catch (...) {
+      LOG_TOPIC("e60f5", ERR, arangodb::Logger::ENGINES)
+        << "caught unknown exception in fillElement";
       return TRI_ERROR_INTERNAL;
     }
 

--- a/arangod/MMFiles/MMFilesSkiplist.h
+++ b/arangod/MMFiles/MMFilesSkiplist.h
@@ -390,6 +390,7 @@ class MMFilesSkiplist {
 
   void appendToVelocyPack(VPackBuilder& builder) {
     builder.add("nrUsed", VPackValue(_nrUsed));
+    builder.add("totalUsed", VPackValue(_nrUsed));
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/arangod/StorageEngine/PhysicalCollection.h
+++ b/arangod/StorageEngine/PhysicalCollection.h
@@ -78,7 +78,7 @@ class PhysicalCollection {
   /// @brief opens an existing collection
   virtual void open(bool ignoreErrors) = 0;
 
-  void drop();
+  virtual void drop();
 
   ////////////////////////////////////
   // -- SECTION Indexes --

--- a/lib/Basics/AssocUnique.h
+++ b/lib/Basics/AssocUnique.h
@@ -332,9 +332,11 @@ class AssocUnique {
   //////////////////////////////////////////////////////////////////////////////
 
   void appendToVelocyPack(VPackBuilder& builder) {
+    size_t nrUsed = 0;
     TRI_ASSERT(builder.isOpenObject());
     builder.add("buckets", VPackValue(VPackValueType::Array));
     for (auto& b : _buckets) {
+      nrUsed += b._nrUsed;
       builder.openObject();
       builder.add("nrAlloc", VPackValue(b._nrAlloc));
       builder.add("nrUsed", VPackValue(b._nrUsed));
@@ -343,6 +345,9 @@ class AssocUnique {
     builder.close();  // buckets
     builder.add("nrBuckets", VPackValue(_buckets.size()));
     builder.add("totalUsed", VPackValue(size()));
+    
+    // sum of items in buckets should equal the total number of items
+    TRI_ASSERT(nrUsed == size());
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/lib/Basics/IndexBucket.h
+++ b/lib/Basics/IndexBucket.h
@@ -66,18 +66,19 @@ struct IndexBucket {
   }
 
   IndexBucket& operator=(IndexBucket&& other) {
-    deallocate();  // free own resources first
+    if (this != &other) {
+      deallocate();  // free own resources first
 
-    _nrAlloc = other._nrAlloc;
-    _nrUsed = other._nrUsed;
-    _nrCollisions = other._nrCollisions;
-    _table = other._table;
+      _nrAlloc = other._nrAlloc;
+      _nrUsed = other._nrUsed;
+      _nrCollisions = other._nrCollisions;
+      _table = other._table;
 
-    other._nrAlloc = 0;
-    other._nrUsed = 0;
-    other._nrCollisions = 0;
-    other._table = nullptr;
-
+      other._nrAlloc = 0;
+      other._nrUsed = 0;
+      other._nrCollisions = 0;
+      other._table = nullptr;
+    }
     return *this;
   }
 

--- a/tests/js/server/shell/shell-transactions-mmfiles.js
+++ b/tests/js/server/shell/shell-transactions-mmfiles.js
@@ -125,9 +125,12 @@ function transactionServerFailuresSuite () {
         assertEqual(0, c.count());
         let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
         assertEqual(2, indexes.length);
-        indexes.forEach(function(idx) {
-          assertEqual(0, idx.figures.totalUsed);
-        });
+
+        if (!isCluster) {
+          indexes.forEach(function(idx) {
+            assertEqual(0, idx.figures.totalUsed);
+          });
+        }
       });
     },
 
@@ -168,9 +171,12 @@ function transactionServerFailuresSuite () {
         assertEqual(1, c.count());
         let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
         assertEqual(2, indexes.length);
-        indexes.forEach(function(idx) {
-          assertEqual(1, idx.figures.totalUsed);
-        });
+
+        if (!isCluster) {
+          indexes.forEach(function(idx) {
+            assertEqual(1, idx.figures.totalUsed);
+          });
+        }
       });
     },
     
@@ -210,9 +216,12 @@ function transactionServerFailuresSuite () {
         assertEqual(0, c.count());
         let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
         assertEqual(2, indexes.length);
-        indexes.forEach(function(idx) {
-          assertEqual(0, idx.figures.totalUsed);
-        });
+
+        if (!isCluster) {
+          indexes.forEach(function(idx) {
+            assertEqual(0, idx.figures.totalUsed);
+          });
+        }
       });
     },
 
@@ -242,9 +251,12 @@ function transactionServerFailuresSuite () {
         assertEqual(0, c.count());
         let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
         assertEqual(2, indexes.length);
-        indexes.forEach(function(idx) {
-          assertEqual(0, idx.figures.totalUsed);
-        });
+
+        if (!isCluster) {
+          indexes.forEach(function(idx) {
+            assertEqual(0, idx.figures.totalUsed);
+          });
+        }
       });
     },
 
@@ -285,9 +297,12 @@ function transactionServerFailuresSuite () {
         assertEqual(1, c.count());
         let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
         assertEqual(2, indexes.length);
-        indexes.forEach(function(idx) {
-          assertEqual(1, idx.figures.totalUsed);
-        });
+
+        if (!isCluster) {
+          indexes.forEach(function(idx) {
+            assertEqual(1, idx.figures.totalUsed);
+          });
+        }
       });
     },
 
@@ -327,9 +342,12 @@ function transactionServerFailuresSuite () {
         assertEqual(0, c.count());
         let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
         assertEqual(2, indexes.length);
-        indexes.forEach(function(idx) {
-          assertEqual(0, idx.figures.totalUsed);
-        });
+
+        if (!isCluster) {
+          indexes.forEach(function(idx) {
+            assertEqual(0, idx.figures.totalUsed);
+          });
+        }
       });
     },
 
@@ -362,9 +380,12 @@ function transactionServerFailuresSuite () {
         assertEqual(1000, c.count());
         let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
         assertEqual(2, indexes.length);
-        indexes.forEach(function(idx) {
-          assertEqual(1000, idx.figures.totalUsed);
-        });
+
+        if (!isCluster) {
+          indexes.forEach(function(idx) {
+            assertEqual(1000, idx.figures.totalUsed);
+          });
+        }
       });
     },
 
@@ -397,9 +418,12 @@ function transactionServerFailuresSuite () {
         assertEqual(1000, c.count());
         let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
         assertEqual(2, indexes.length);
-        indexes.forEach(function(idx) {
-          assertEqual(1000, idx.figures.totalUsed);
-        });
+
+        if (!isCluster) {
+          indexes.forEach(function(idx) {
+            assertEqual(1000, idx.figures.totalUsed);
+          });
+        }
       });
     },
 
@@ -445,9 +469,12 @@ function transactionServerFailuresSuite () {
         assertEqual(990, c.count());
         let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
         assertEqual(2, indexes.length);
-        indexes.forEach(function(idx) {
-          assertEqual(990, idx.figures.totalUsed);
-        });
+
+        if (!isCluster) {
+          indexes.forEach(function(idx) {
+            assertEqual(990, idx.figures.totalUsed);
+          });
+        }
       });
     },
 
@@ -493,9 +520,12 @@ function transactionServerFailuresSuite () {
         assertEqual(1000, c.count());
         let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
         assertEqual(2, indexes.length);
-        indexes.forEach(function(idx) {
-          assertEqual(1000, idx.figures.totalUsed);
-        });
+
+        if (!isCluster) {
+          indexes.forEach(function(idx) {
+            assertEqual(1000, idx.figures.totalUsed);
+          });
+        }
       });
     },
 
@@ -528,9 +558,12 @@ function transactionServerFailuresSuite () {
         assertEqual(1000, c.count());
         let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'skiplist'; });
         assertEqual(2, indexes.length);
-        indexes.forEach(function(idx) {
-          assertEqual(1000, idx.figures.totalUsed);
-        });
+
+        if (!isCluster) {
+          indexes.forEach(function(idx) {
+            assertEqual(1000, idx.figures.totalUsed);
+          });
+        }
       });
     },
 
@@ -563,9 +596,12 @@ function transactionServerFailuresSuite () {
         assertEqual(1000, c.count());
         let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'skiplist'; });
         assertEqual(2, indexes.length);
-        indexes.forEach(function(idx) {
-          assertEqual(1000, idx.figures.totalUsed);
-        });
+
+        if (!isCluster) {
+          indexes.forEach(function(idx) {
+            assertEqual(1000, idx.figures.totalUsed);
+          });
+        }
       });
     },
 
@@ -599,9 +635,12 @@ function transactionServerFailuresSuite () {
         assertEqual(1000, c.count());
         let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash' || idx.type === 'skiplist'; });
         assertEqual(3, indexes.length);
-        indexes.forEach(function(idx) {
-          assertEqual(1000, idx.figures.totalUsed);
-        });
+
+        if (!isCluster) {
+          indexes.forEach(function(idx) {
+            assertEqual(1000, idx.figures.totalUsed);
+          });
+        }
       });
     },
 

--- a/tests/js/server/shell/shell-transactions-mmfiles.js
+++ b/tests/js/server/shell/shell-transactions-mmfiles.js
@@ -74,7 +74,7 @@ function transactionServerFailuresSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test: rollback in case of starting a transaction fails
 ////////////////////////////////////////////////////////////////////////////////
-
+    
     testBeginTransactionFailure : function () {
       internal.debugClearFailAt();
       db._drop(cn);
@@ -94,8 +94,7 @@ function transactionServerFailuresSuite () {
         });
 
         fail();
-      }
-      catch (err) {
+      } catch (err) {
         assertEqual(internal.errors.ERROR_OUT_OF_MEMORY.code, err.errorNum);
       }
     },
@@ -103,9 +102,9 @@ function transactionServerFailuresSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test: rollback in case of a server-side fail
 ////////////////////////////////////////////////////////////////////////////////
-
+    
     testInsertUniqueHashIndexServerFailures : function () {
-      var failures = [ "InsertPrimaryIndex", "InsertSecondaryIndexes", "InsertHashIndex" ];
+      var failures = ["InsertPrimaryIndex", "InsertSecondaryIndexes", "InsertHashIndex" ];
 
       failures.forEach (function (f) {
         internal.debugClearFailAt();
@@ -119,19 +118,23 @@ function transactionServerFailuresSuite () {
         try {
           c.save({ value: 1 });
           fail();
-        }
-        catch (err) {
+        } catch (err) {
           assertEqual(internal.errors.ERROR_DEBUG.code, err.errorNum);
         }
 
         assertEqual(0, c.count());
+        let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
+        assertEqual(2, indexes.length);
+        indexes.forEach(function(idx) {
+          assertEqual(0, idx.figures.totalUsed);
+        });
       });
     },
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test: rollback in case of a server-side fail
 ////////////////////////////////////////////////////////////////////////////////
-
+    
     testInsertUniqueHashIndexServerFailuresTrx : function () {
       var failures = [ "InsertPrimaryIndex", "InsertSecondaryIndexes", "InsertHashIndex" ];
 
@@ -153,8 +156,7 @@ function transactionServerFailuresSuite () {
             try {
               c.save({ value: 2 });
               fail();
-            }
-            catch (err) {
+            } catch (err) {
               assertEqual(internal.errors.ERROR_DEBUG.code, err.errorNum);
             }
 
@@ -162,9 +164,16 @@ function transactionServerFailuresSuite () {
             internal.debugClearFailAt();
           }
         });
+        
+        assertEqual(1, c.count());
+        let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
+        assertEqual(2, indexes.length);
+        indexes.forEach(function(idx) {
+          assertEqual(1, idx.figures.totalUsed);
+        });
       });
     },
-
+    
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test: rollback in case of a server-side fail
 ////////////////////////////////////////////////////////////////////////////////
@@ -192,13 +201,18 @@ function transactionServerFailuresSuite () {
             }
           });
           fail();
-        }
-        catch (err) {
+        } catch (err) {
           assertEqual(internal.errors.ERROR_DEBUG.code, err.errorNum);
         }
 
-        assertEqual(0, c.count());
         internal.debugClearFailAt();
+        
+        assertEqual(0, c.count());
+        let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
+        assertEqual(2, indexes.length);
+        indexes.forEach(function(idx) {
+          assertEqual(0, idx.figures.totalUsed);
+        });
       });
     },
 
@@ -221,12 +235,16 @@ function transactionServerFailuresSuite () {
         try {
           c.save({ value: 1 });
           fail();
-        }
-        catch (err) {
+        } catch (err) {
           assertEqual(internal.errors.ERROR_DEBUG.code, err.errorNum);
         }
 
         assertEqual(0, c.count());
+        let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
+        assertEqual(2, indexes.length);
+        indexes.forEach(function(idx) {
+          assertEqual(0, idx.figures.totalUsed);
+        });
       });
     },
 
@@ -255,14 +273,20 @@ function transactionServerFailuresSuite () {
             try {
               c.save({ value: 2 });
               fail();
-            }
-            catch (err) {
+            } catch (err) {
               assertEqual(internal.errors.ERROR_DEBUG.code, err.errorNum);
             }
 
             assertEqual(1, c.count());
             internal.debugClearFailAt();
           }
+        });
+        
+        assertEqual(1, c.count());
+        let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
+        assertEqual(2, indexes.length);
+        indexes.forEach(function(idx) {
+          assertEqual(1, idx.figures.totalUsed);
         });
       });
     },
@@ -294,13 +318,18 @@ function transactionServerFailuresSuite () {
             }
           });
           fail();
-        }
-        catch (err) {
+        } catch (err) {
           assertEqual(internal.errors.ERROR_DEBUG.code, err.errorNum);
         }
 
-        assertEqual(0, c.count());
         internal.debugClearFailAt();
+        
+        assertEqual(0, c.count());
+        let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
+        assertEqual(2, indexes.length);
+        indexes.forEach(function(idx) {
+          assertEqual(0, idx.figures.totalUsed);
+        });
       });
     },
 
@@ -326,12 +355,16 @@ function transactionServerFailuresSuite () {
         try {
           c.truncate();
           fail();
-        }
-        catch (err) {
+        } catch (err) {
           assertEqual(internal.errors.ERROR_DEBUG.code, err.errorNum);
         }
 
         assertEqual(1000, c.count());
+        let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
+        assertEqual(2, indexes.length);
+        indexes.forEach(function(idx) {
+          assertEqual(1000, idx.figures.totalUsed);
+        });
       });
     },
 
@@ -357,12 +390,16 @@ function transactionServerFailuresSuite () {
         try {
           c.truncate();
           fail();
-        }
-        catch (err) {
+        } catch (err) {
           assertEqual(internal.errors.ERROR_DEBUG.code, err.errorNum);
         }
 
         assertEqual(1000, c.count());
+        let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
+        assertEqual(2, indexes.length);
+        indexes.forEach(function(idx) {
+          assertEqual(1000, idx.figures.totalUsed);
+        });
       });
     },
 
@@ -397,15 +434,20 @@ function transactionServerFailuresSuite () {
             try {
               c.remove("test10");
               fail();
-            }
-            catch (err) {
+            } catch (err) {
               assertEqual(internal.errors.ERROR_DEBUG.code, err.errorNum);
             }
           }
         });
 
-        assertEqual(990, c.count());
         internal.debugClearFailAt();
+        
+        assertEqual(990, c.count());
+        let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
+        assertEqual(2, indexes.length);
+        indexes.forEach(function(idx) {
+          assertEqual(990, idx.figures.totalUsed);
+        });
       });
     },
 
@@ -442,13 +484,18 @@ function transactionServerFailuresSuite () {
             }
           });
           fail();
-        }
-        catch (err) {
+        } catch (err) {
           assertEqual(internal.errors.ERROR_DEBUG.code, err.errorNum);
         }
 
-        assertEqual(1000, c.count());
         internal.debugClearFailAt();
+        
+        assertEqual(1000, c.count());
+        let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash'; });
+        assertEqual(2, indexes.length);
+        indexes.forEach(function(idx) {
+          assertEqual(1000, idx.figures.totalUsed);
+        });
       });
     },
 
@@ -474,12 +521,16 @@ function transactionServerFailuresSuite () {
         try {
           c.truncate();
           fail();
-        }
-        catch (err) {
+        } catch (err) {
           assertEqual(internal.errors.ERROR_DEBUG.code, err.errorNum);
         }
 
         assertEqual(1000, c.count());
+        let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'skiplist'; });
+        assertEqual(2, indexes.length);
+        indexes.forEach(function(idx) {
+          assertEqual(1000, idx.figures.totalUsed);
+        });
       });
     },
 
@@ -505,12 +556,16 @@ function transactionServerFailuresSuite () {
         try {
           c.truncate();
           fail();
-        }
-        catch (err) {
+        } catch (err) {
           assertEqual(internal.errors.ERROR_DEBUG.code, err.errorNum);
         }
 
         assertEqual(1000, c.count());
+        let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'skiplist'; });
+        assertEqual(2, indexes.length);
+        indexes.forEach(function(idx) {
+          assertEqual(1000, idx.figures.totalUsed);
+        });
       });
     },
 
@@ -537,12 +592,16 @@ function transactionServerFailuresSuite () {
         try {
           c.truncate();
           fail();
-        }
-        catch (err) {
+        } catch (err) {
           assertEqual(internal.errors.ERROR_DEBUG.code, err.errorNum);
         }
 
         assertEqual(1000, c.count());
+        let indexes = c.indexes(true).filter(function(idx) { return idx.type === 'primary' || idx.type === 'hash' || idx.type === 'skiplist'; });
+        assertEqual(3, indexes.length);
+        indexes.forEach(function(idx) {
+          assertEqual(1000, idx.figures.totalUsed);
+        });
       });
     },
 


### PR DESCRIPTION
### Scope & Purpose

Added assertions and checks for MMFiles index consistency. These changes will have effect in maintainer mode only.
Additionally, add log messages in case MMFiles index operations go wrong.

### Testing & Verification

This change is already covered by existing tests, such as *(please describe tests)*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8431/