### PR TITLE
removing misleading upgrade instructions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 devel
 -----
 
+* Remove misleading error messages about upgrade commands to carry out in
+  case of a database upgrade. These commands are highly platform-dependent and
+  also depend on whether ArangoDB is started manually, via the ArangoDB starter
+  or as a service.
+  In order to not confuse end users, remove the potentially misleading instructions.
+
 * Clear backups from DB servers and agency, when plan unchanged not
   met and not allowing for inconsistency.
 

--- a/arangod/RestHandler/RestPleaseUpgradeHandler.cpp
+++ b/arangod/RestHandler/RestPleaseUpgradeHandler.cpp
@@ -41,10 +41,6 @@ RestStatus RestPleaseUpgradeHandler::execute() {
   _response->addRawPayload(StringRef(_request->databaseName()));
   _response->addRawPayload(StringRef("\r\n\r\n"));
   _response->addRawPayload(StringRef("It appears that your database must be upgraded. "));
-  _response->addRawPayload(StringRef("Normally this can be done using\r\n\r\n"));
-  _response->addRawPayload(StringRef("  /etc/init.d/arangodb3 stop\r\n"));
-  _response->addRawPayload(StringRef("  /etc/init.d/arangodb3 upgrade\r\n"));
-  _response->addRawPayload(StringRef("  /etc/init.d/arangodb3 start\r\n\r\n"));
   _response->addRawPayload(StringRef("Please check the log file for details.\r\n"));
 
   return RestStatus::DONE;

--- a/arangod/VocBase/Methods/Upgrade.cpp
+++ b/arangod/VocBase/Methods/Upgrade.cpp
@@ -160,7 +160,9 @@ UpgradeResult Upgrade::startup(TRI_vocbase_t& vocbase, bool isUpgrade, bool igno
             << "  --database.auto-upgrade true";
         LOG_TOPIC("13414", ERR, Logger::STARTUP)
             << "option to upgrade the data in the database directory.";
-
+        LOG_TOPIC("24bd1", ERR, Logger::STARTUP)	
+            << "---------------------------------------------------------------"	
+               "-------'";
         return UpgradeResult(TRI_ERROR_BAD_PARAMETER, vinfo.status);
       }
       // do perform the upgrade

--- a/arangod/VocBase/Methods/Upgrade.cpp
+++ b/arangod/VocBase/Methods/Upgrade.cpp
@@ -161,18 +161,6 @@ UpgradeResult Upgrade::startup(TRI_vocbase_t& vocbase, bool isUpgrade, bool igno
         LOG_TOPIC("13414", ERR, Logger::STARTUP)
             << "option to upgrade the data in the database directory.";
 
-        LOG_TOPIC("7421a", ERR, Logger::STARTUP)
-            << "Normally you can use the control "
-               "script to upgrade your database'";
-        LOG_TOPIC("fb665", ERR, Logger::STARTUP)
-            << "  /etc/init.d/arangodb stop";
-        LOG_TOPIC("6753e", ERR, Logger::STARTUP)
-            << "  /etc/init.d/arangodb upgrade";
-        LOG_TOPIC("f7b06", ERR, Logger::STARTUP)
-            << "  /etc/init.d/arangodb start";
-        LOG_TOPIC("24bd1", ERR, Logger::STARTUP)
-            << "---------------------------------------------------------------"
-               "-------'";
         return UpgradeResult(TRI_ERROR_BAD_PARAMETER, vinfo.status);
       }
       // do perform the upgrade


### PR DESCRIPTION
### Scope & Purpose

Remove misleading upgrade instructions

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8488/