### PR TITLE
fix error message when database creation fails for `--create-database` option

### DIFF
--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -323,8 +323,10 @@ arangodb::Result tryCreateDatabase(arangodb::application_features::ApplicationSe
           uint64_t replicationFactor = getReplicationFactor(options, properties, isSatellite);
           if (!isSatellite) {
             object->add(key, VPackValue(replicationFactor));
+            continue;
           }
-        } else  if (!slice.isNone()) {
+        }
+        if (!slice.isNone()) {
           object->add(key, slice);
         }
       }

--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -273,7 +273,8 @@ void makeAttributesUnique(arangodb::velocypack::Builder& builder,
 /// @brief Create the database to restore to, connecting manually
 arangodb::Result tryCreateDatabase(arangodb::application_features::ApplicationServer& server,
                                    std::string const& name,
-                                   VPackSlice properties) {
+                                   VPackSlice properties,
+                                   arangodb::RestoreFeature::Options const& options) {
   using arangodb::httpclient::SimpleHttpClient;
   using arangodb::httpclient::SimpleHttpResult;
   using arangodb::rest::RequestType;
@@ -284,6 +285,8 @@ arangodb::Result tryCreateDatabase(arangodb::application_features::ApplicationSe
   // get client feature for configuration info
   arangodb::ClientFeature& client =
       server.getFeature<arangodb::HttpEndpointProvider, arangodb::ClientFeature>();
+         
+  client.setDatabaseName(arangodb::StaticStrings::SystemDatabase);
 
   // get httpclient by hand rather than using manager, to bypass any built-in
   // checks which will fail if the database doesn't exist
@@ -293,6 +296,7 @@ arangodb::Result tryCreateDatabase(arangodb::application_features::ApplicationSe
     httpClient->params().setLocationRewriter(static_cast<void*>(&client),
                                              arangodb::ClientManager::rewriteLocation);
     httpClient->params().setUserNamePassword("/", client.username(), client.password());
+
   } catch (...) {
     LOG_TOPIC("832ef", FATAL, arangodb::Logger::RESTORE)
         << "cannot create server connection, giving up!";
@@ -307,13 +311,20 @@ arangodb::Result tryCreateDatabase(arangodb::application_features::ApplicationSe
     // add replication factor write concern etc
     if (properties.isObject()) {
       ObjectBuilder guard(&builder, "options");
-      for(auto const& key : std::vector<std::string>{
+      for (auto const& key : std::vector<std::string>{
         arangodb::StaticStrings::ReplicationFactor,
         arangodb::StaticStrings::Sharding,
         arangodb::StaticStrings::WriteConcern
       }) {
         VPackSlice slice = properties.get(key);
-        if (!slice.isNone()) {
+        if (key == arangodb::StaticStrings::ReplicationFactor) {
+          // overwrite replicationFactor if set
+          bool isSatellite = false;
+          uint64_t replicationFactor = getReplicationFactor(options, properties, isSatellite);
+          if (!isSatellite) {
+            object->add(key, VPackValue(replicationFactor));
+          }
+        } else  if (!slice.isNone()) {
           object->add(key, slice);
         }
       }
@@ -328,8 +339,9 @@ arangodb::Result tryCreateDatabase(arangodb::application_features::ApplicationSe
       }
     }
   }
-  std::string const body = builder.slice().toJson();
 
+  std::string const body = builder.slice().toJson();
+      
   std::unique_ptr<SimpleHttpResult> response(
       httpClient->request(RequestType::POST, "/_api/database", body.c_str(), body.size()));
   if (response == nullptr || !response->isComplete()) {
@@ -1309,7 +1321,7 @@ void RestoreFeature::collectOptions(std::shared_ptr<options::ProgramOptions> opt
       ->addOption(
           "--number-of-shards",
           "override value for numberOfShards (can be specified multiple times, "
-          "e.g. --numberOfShards 2 --numberOfShards myCollection=3)",
+          "e.g. --number-of-shards 2 --number-of-shards myCollection=3)",
           new VectorParameter<StringParameter>(&_options.numberOfShards))
       .setIntroducedIn(30322)
       .setIntroducedIn(30402);
@@ -1317,8 +1329,8 @@ void RestoreFeature::collectOptions(std::shared_ptr<options::ProgramOptions> opt
   options
       ->addOption("--replication-factor",
                   "override value for replicationFactor (can be specified "
-                  "multiple times, e.g. --replicationFactor 2 "
-                  "--replicationFactor myCollection=3)",
+                  "multiple times, e.g. --replication-factor 2 "
+                  "--replication-factor myCollection=3)",
                   new VectorParameter<StringParameter>(&_options.replicationFactor))
       .setIntroducedIn(30322)
       .setIntroducedIn(30402);
@@ -1484,12 +1496,12 @@ void RestoreFeature::start() {
 
   // enumerate all databases present in the dump directory (in case of
   // --all-databases=true, or use just the flat files in case of --all-databases=false)
-  std::vector<std::pair<std::string,VPackBuilder>> databases;
+  std::vector<std::pair<std::string, VPackBuilder>> databases;
   if (_options.allDatabases) {
     for (auto const& it : basics::FileUtils::listFiles(_options.inputPath)) {
       std::string path = basics::FileUtils::buildFilename(_options.inputPath, it);
       if (basics::FileUtils::isDirectory(path)) {
-        databases.push_back(std::pair(it,VPackBuilder{}));
+        databases.push_back(std::pair(it, VPackBuilder{}));
       }
     }
 
@@ -1499,9 +1511,9 @@ void RestoreFeature::start() {
     // credentials for the user which users the current arangorestore connection, and
     // this will make subsequent arangorestore calls to the server fail with "unauthorized"
     std::sort(databases.begin(), databases.end(), [](auto const& lhs, auto const& rhs) {
-      if (lhs.first == "_system" && rhs.first != "_system") {
+      if (lhs.first == StaticStrings::SystemDatabase && rhs.first != StaticStrings::SystemDatabase) {
         return false;
-      } else if (rhs.first == "_system" && lhs.first != "_system") {
+      } else if (rhs.first == StaticStrings::SystemDatabase && lhs.first != StaticStrings::SystemDatabase) {
         return true;
       }
       return lhs.first < rhs.first;
@@ -1511,15 +1523,13 @@ void RestoreFeature::start() {
       FATAL_ERROR_EXIT();
     }
   } else {
-    databases.push_back(std::pair(client.databaseName(),VPackBuilder{}));
+    databases.push_back(std::pair(client.databaseName(), VPackBuilder{}));
   }
 
   std::unique_ptr<SimpleHttpClient> httpClient;
 
   // final result
-  Result result;
-
-  result = _clientManager.getConnectedClient(httpClient, _options.force,
+  Result result = _clientManager.getConnectedClient(httpClient, _options.force,
                                              true, !_options.createDatabase, false);
   if (result.is(TRI_ERROR_SIMPLE_CLIENT_COULD_NOT_CONNECT)) {
     LOG_TOPIC("c23bf", FATAL, Logger::RESTORE)
@@ -1532,13 +1542,11 @@ void RestoreFeature::start() {
       // database not found, but database creation requested
       LOG_TOPIC("9b5a6", INFO, Logger::RESTORE) << "Creating database '" << dbName << "'";
 
-      client.setDatabaseName("_system");
-
       VPackBuilder properties;
       getDBProperties(*_directory, properties);
-      Result res = ::tryCreateDatabase(server(), dbName, properties.slice());
+      Result res = ::tryCreateDatabase(server(), dbName, properties.slice(), _options);
       if (res.fail()) {
-        LOG_TOPIC("b19db", FATAL, Logger::RESTORE) << "Could not create database '" << dbName << "': " << httpClient->getErrorMessage();
+        LOG_TOPIC("b19db", FATAL, Logger::RESTORE) << "Could not create database '" << dbName << "': " << res.errorMessage();
         FATAL_ERROR_EXIT();
       }
 
@@ -1595,7 +1603,7 @@ void RestoreFeature::start() {
 
   if (_options.allDatabases) {
     std::vector<std::string> dbs;
-    std::transform(databases.begin(), databases.end(),std::back_inserter(dbs), [](auto const& pair) { return pair.first; } );
+    std::transform(databases.begin(), databases.end(), std::back_inserter(dbs), [](auto const& pair) { return pair.first; } );
     LOG_TOPIC("7c10a", INFO, Logger::RESTORE)
       << "About to restore databases '"
       << basics::StringUtils::join(dbs, "', '") << "' from dump directory '" << _options.inputPath << "'...";
@@ -1626,11 +1634,9 @@ void RestoreFeature::start() {
           // database not found, but database creation requested
           LOG_TOPIC("080f3", INFO, Logger::RESTORE) << "Creating database '" << db.first << "'";
 
-          client.setDatabaseName("_system");
-
-          result = ::tryCreateDatabase(server(), db.first, db.second.slice());
+          result = ::tryCreateDatabase(server(), db.first, db.second.slice(), _options);
           if (result.fail()) {
-            LOG_TOPIC("7a35f", ERR, Logger::RESTORE) << "Could not create database '" << db.first << "': " << httpClient->getErrorMessage();
+            LOG_TOPIC("7a35f", ERR, Logger::RESTORE) << "Could not create database '" << db.first << "': " << result.errorMessage();
             break;
           }
 

--- a/arangosh/Shell/ClientFeature.cpp
+++ b/arangosh/Shell/ClientFeature.cpp
@@ -26,6 +26,7 @@
 #include "ApplicationFeatures/CommunicationFeaturePhase.h"
 #include "ApplicationFeatures/GreetingsFeaturePhase.h"
 #include "Basics/FileUtils.h"
+#include "Basics/StaticStrings.h"
 #include "Basics/application-exit.h"
 #include "Endpoint/Endpoint.h"
 #include "Logger/Logger.h"
@@ -49,7 +50,7 @@ namespace arangodb {
 ClientFeature::ClientFeature(application_features::ApplicationServer& server,
                              bool allowJwtSecret, double connectionTimeout, double requestTimeout)
     : HttpEndpointProvider(server, "Client"),
-      _databaseName("_system"),
+      _databaseName(StaticStrings::SystemDatabase),
       _endpoint(Endpoint::defaultEndpoint(Endpoint::TransportType::HTTP)),
       _username("root"),
       _password(""),


### PR DESCRIPTION
### Scope & Purpose

Fix error message when database creation fails for `--create-database` option
additionally, pass the specified replication factor from `--replication-factor` option when creating a database.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8516/