### PR TITLE
fix handling of `geometry` attributes

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js
@@ -2589,12 +2589,16 @@
                   geojson++;
                 }
               } else if (obj.hasOwnProperty('geometry')) {
-                if (obj.geometry.hasOwnProperty('coordinates') && obj.geometry.hasOwnProperty('type')) {
-                  if (obj.geometry.type === 'Point' || obj.geometry.type === 'MultiPoint' ||
-                    obj.geometry.type === 'Polygon' || obj.geometry.type === 'MultiPolygon' ||
-                    obj.geometry.type === 'LineString' || obj.geometry.type === 'MultiLineString') {
-                    geojson++;
+                try {
+                  if (obj.geometry.hasOwnProperty('coordinates') && obj.geometry.hasOwnProperty('type')) {
+                    if (obj.geometry.type === 'Point' || obj.geometry.type === 'MultiPoint' ||
+                      obj.geometry.type === 'Polygon' || obj.geometry.type === 'MultiPolygon' ||
+                      obj.geometry.type === 'LineString' || obj.geometry.type === 'MultiLineString') {
+                      geojson++;
+                    }
                   }
+                } catch (err) {
+                 // happens e.g. if doc.geomotry === null
                 }
               }
             }


### PR DESCRIPTION
### Scope & Purpose

Fixed handling of `geometry` attributes in query editor of the web UI.

Previously, document attributes named `geometry` were treated in a special way, assuming they were JSON objects. In case a document contained a `geometry` attribute that had a non-object value (e.g. `null`) the web UI threw a JavaScript exception and would not display AQL query results properly.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8546/