### PR TITLE
fixed DEVSUP-554 and disabled "collect-in-cluster" when a LIMIT is found

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,22 @@
 v3.6.2 (XXXX-XX-XX)
 -------------------
 
+* Disable "collect-in-cluster" AQL optimizer rule in case a LIMIT node is between
+  the COLLECT and the source data. In this case it is not safe to apply the
+  distributed collect, as it may alter the results.
+
+* Fixed issue DEVSUP-554: COLLECT WITH COUNT together with FILTER yields zero.
+
+  This bugfix fixes an issue when skipping over documents in an index scan 
+  using a covering index and also at the same time using an early-pruning filter.
+
+  In this case wrong document data may have been injected into the filter 
+  condition for filtering, with the filter wrongfully deciding which documents
+  to filter out.
+
 * Fixed issue #11051: AQL query wrongfully returning no results on 3.6.1.
 
-  This change prevents the "late-document-materialization" optimizer rule from
+  This bugfix prevents the "late-document-materialization" optimizer rule from
   kicking in in cases when an index scan also uses early pruning of index
   entries. In this case, the late document materialization will lead to the
   filter condition used in early pruning not being applied correctly, potentially

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,11 +37,11 @@ v3.6.2 (XXXX-XX-XX)
 
 * Fix bug in collection creation with distributeShardsLike.
 
+* Fixed issue #10949: k shortest paths behaviour wrong with zero weights.
+
 
 v3.6.1 (2020-01-29)
 -------------------
-
-* Fixed issue #10949: k shortest paths behaviour wrong with zero weights.
 
 * Updated ArangoDB Starter to 0.14.13.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,8 @@ v3.6.2 (XXXX-XX-XX)
   the COLLECT and the source data. In this case it is not safe to apply the
   distributed collect, as it may alter the results.
 
-* Fixed issue: COLLECT WITH COUNT together with FILTER yields zero.
+* Fixed internal issue #4932: COLLECT WITH COUNT together with FILTER yields
+  zero.
 
   This bugfix fixes an issue when skipping over documents in an index scan 
   using a covering index and also at the same time using an early-pruning filter.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@ v3.6.2 (XXXX-XX-XX)
   the COLLECT and the source data. In this case it is not safe to apply the
   distributed collect, as it may alter the results.
 
-* Fixed issue DEVSUP-554: COLLECT WITH COUNT together with FILTER yields zero.
+* Fixed issue: COLLECT WITH COUNT together with FILTER yields zero.
 
   This bugfix fixes an issue when skipping over documents in an index scan 
   using a covering index and also at the same time using an early-pruning filter.

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -4043,7 +4043,9 @@ void arangodb::aql::collectInClusterRule(Optimizer* opt, std::unique_ptr<Executi
     auto current = node->getFirstDependency();
 
     while (current != nullptr) {
-      bool eligible = true;
+      if (current->getType() == EN::LIMIT) {
+        break;
+      }
 
       // check if any of the nodes we pass use a variable that will not be
       // available after we insert a new COLLECT on top of it (note: COLLECT
@@ -4053,6 +4055,7 @@ void arangodb::aql::collectInClusterRule(Optimizer* opt, std::unique_ptr<Executi
         current->getVariablesUsedHere(allUsed);
       }
 
+      bool eligible = true;
       for (auto const& it : current->getVariablesSetHere()) {
         if (std::find(used.begin(), used.end(), it) != used.end()) {
           eligible = false;


### PR DESCRIPTION
### Scope & Purpose

Fixes the issue reported in DEVSUP-554:
when there is a covering index scan and at the same time an early pruning filter is applied on the index data, the filter saw wrong document input in case there was either a LIMIT or a COLLECT WITH COUNT node pulling data from the IndexExecutor in "skipping" mode.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [ ] There is a *JIRA Ticket number*: https://arangodb.atlassian.net/browse/DEVSUP-554 

### Testing & Verification

This change is already covered by existing tests, such as *shell_server_aql*.

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8549/