### PR TITLE
fixed devsup-554

### DIFF
--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -4045,7 +4045,9 @@ void arangodb::aql::collectInClusterRule(Optimizer* opt, std::unique_ptr<Executi
     auto current = node->getFirstDependency();
 
     while (current != nullptr) {
-      bool eligible = true;
+      if (current->getType() == EN::LIMIT) {
+        break;
+      }
 
       // check if any of the nodes we pass use a variable that will not be
       // available after we insert a new COLLECT on top of it (note: COLLECT
@@ -4055,6 +4057,7 @@ void arangodb::aql::collectInClusterRule(Optimizer* opt, std::unique_ptr<Executi
         current->getVariablesUsedHere(allUsed);
       }
 
+      bool eligible = true;
       for (auto const& it : current->getVariablesSetHere()) {
         if (std::find(used.begin(), used.end(), it) != used.end()) {
           eligible = false;


### PR DESCRIPTION
### Scope & Purpose

Fixes the issue reported in DEVSUP-554:
when there is a covering index scan and at the same time an early pruning filter is applied on the index data, the filter saw wrong document input in case there was either a LIMIT or a COLLECT WITH COUNT node pulling data from the IndexExecutor in "skipping" mode.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [ ] There is a *JIRA Ticket number*: https://arangodb.atlassian.net/browse/DEVSUP-554 

### Testing & Verification

This change is already covered by existing tests, such as *shell_server_aql*.

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8550/