### PR TITLE
fixed optimizer rule `move-filters-into-enumerate`

### DIFF
--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -7249,12 +7249,13 @@ void arangodb::aql::moveFiltersIntoEnumerateRule(Optimizer* opt, std::unique_ptr
         ExecutionNode* filterParent = current->getFirstParent();
         TRI_ASSERT(filterParent != nullptr);
         plan->unlinkNode(current);
-        current = filterParent;
-
+          
         if (!current->isVarUsedLater(cn->outVariable())) {
           // also remove the calculation node
           plan->unlinkNode(cn);
         }
+        
+        current = filterParent;
         modified = true;
       } else if (current->getType() == EN::CALCULATION) {
         // store all calculations we found

--- a/tests/js/server/aql/aql-optimizer-rule-move-filters-into-enumerate.js
+++ b/tests/js/server/aql/aql-optimizer-rule-move-filters-into-enumerate.js
@@ -183,6 +183,19 @@ function optimizerRuleTestSuite () {
         assertEqual(query[1], result, query);
       });
     },
+
+    testVariableUsage : function () {
+      let queries = [ 
+        `FOR doc IN ${cn} FILTER doc.abc FOR inner IN doc.abc RETURN inner`,
+        `FOR doc IN ${cn} FILTER doc.abc FILTER doc.abc FOR inner IN doc.abc RETURN inner`,
+        `FOR doc IN ${cn} FILTER doc.abc FILTER doc.xyz FOR inner IN doc.xyz RETURN inner`,
+      ];
+
+      queries.forEach(function(query) {
+        let result = AQL_EXPLAIN(query);
+        assertNotEqual(-1, result.plan.rules.indexOf(ruleName), query);
+      });
+    }
     
   };
 }


### PR DESCRIPTION
### Scope & Purpose

Fixed queries having the following structure
```
      FOR doc IN collection
        FILTER doc.nonIndexedAttribute     // expression
        FOR sub IN doc.nonIndexedAttribute // same expression
```
For such queries, the FILTER was moved into the first FOR loop for early pruning. Afterwards, the leftover CalculationNode that evaluated `doc.nonIndexedAttribute` was removed. This was wrong however, because the same expression was reused in the second FOR loop. There was code considering this, but due to a bug it did not work if the expression in the FILTER was reused in t

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8578/