### PR TITLE
[3.6] Guard  AqlValues properly in ModificationExecutor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.6.2 (XXXX-XX-XX)
 -------------------
 
-* Fixed a memory leak in ModificationExecutors
+* Fixed a memory leak in ModificationExecutors.
 
 * Updated rclone to 1.51.1.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.6.2 (XXXX-XX-XX)
 -------------------
 
+* Fixed a memory leak in ModificationExecutors
+
 * Updated rclone to 1.51.1.
 
 * Fixed queries having the following structure

--- a/arangod/Aql/ModificationExecutor.cpp
+++ b/arangod/Aql/ModificationExecutor.cpp
@@ -58,10 +58,21 @@ ModifierOutput::ModifierOutput(InputAqlItemRow&& inputRow, Type type)
 
 ModifierOutput::ModifierOutput(InputAqlItemRow const& inputRow, Type type,
                                AqlValue const& oldValue, AqlValue const& newValue)
-    : _inputRow(std::move(inputRow)), _type(type), _oldValue(oldValue), _newValue(newValue) {}
+    : _inputRow(std::move(inputRow)),
+      _type(type),
+      _oldValue(oldValue),
+      _oldValueGuard(std::in_place, _oldValue.value(), true),
+      _newValue(newValue),
+      _newValueGuard(std::in_place, _newValue.value(), true) {}
+
 ModifierOutput::ModifierOutput(InputAqlItemRow&& inputRow, Type type,
                                AqlValue const& oldValue, AqlValue const& newValue)
-    : _inputRow(std::move(inputRow)), _type(type), _oldValue(oldValue), _newValue(newValue) {}
+    : _inputRow(std::move(inputRow)),
+      _type(type),
+      _oldValue(oldValue),
+      _oldValueGuard(std::in_place, _oldValue.value(), true),
+      _newValue(newValue),
+      _newValueGuard(std::in_place, _newValue.value(), true) {}
 
 InputAqlItemRow ModifierOutput::getInputRow() const { return _inputRow; }
 ModifierOutput::Type ModifierOutput::getType() const { return _type; }

--- a/arangod/Aql/ModificationExecutor.h
+++ b/arangod/Aql/ModificationExecutor.h
@@ -140,8 +140,10 @@ class ModifierOutput {
  protected:
   InputAqlItemRow const _inputRow;
   Type const _type;
-  std::optional<AqlValue> const _oldValue;
-  std::optional<AqlValue> const _newValue;
+  std::optional<AqlValue> _oldValue;
+  std::optional<AqlValueGuard> _oldValueGuard;
+  std::optional<AqlValue> _newValue;
+  std::optional<AqlValueGuard> _newValueGuard;
 };
 
 template <typename FetcherType, typename ModifierType>


### PR DESCRIPTION
Backport of #11116