### PR TITLE
fix test timeout handling

### DIFF
--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -694,8 +694,8 @@ function executeAndWait (cmd, args, options, valgrindTest, rootDir, coreCheck = 
       instanceInfo.exitStatus = res;
     }
   } else {
-    // V8 executeExternalAndWait thinks that timeout is in ms, so *100
-    res = executeExternalAndWait(cmd, args, false, timeout*100, coverageEnvironment());
+    // V8 executeExternalAndWait thinks that timeout is in ms, so *1000
+    res = executeExternalAndWait(cmd, args, false, timeout*1000, coverageEnvironment());
     instanceInfo.pid = res.pid;
     instanceInfo.exitStatus = res;
     crashUtils.calculateMonitorValues(options, instanceInfo, res.pid, cmd);
@@ -759,6 +759,29 @@ function executeAndWait (cmd, args, options, valgrindTest, rootDir, coreCheck = 
       status: false,
       message: 'irregular termination: ' + instanceInfo.exitStatus.status +
         ' exit signal: ' + instanceInfo.exitStatus.signal + errorMessage,
+      duration: deltaTime
+    };
+  } else if (res.status === 'TIMEOUT') {
+    print('Killing ' + cmd + ' - ' + JSON.stringify(args));
+    let resKill = killExternal(res.pid, abortSignal);
+    if (coreCheck) {
+      print(Date() + " executeAndWait: Marking crashy because of timeout - " + JSON.stringify(instanceInfo));
+      crashUtils.analyzeCrash(cmd,
+                              instanceInfo,
+                              options,
+                              'execution of ' + cmd + ' - kill because of timeout');
+      if (options.coreCheck) {
+        print(instanceInfo.exitStatus.gdbHint);
+      }
+      serverCrashedLocal = true;
+    }
+    instanceInfo.pid = res.pid;
+    instanceInfo.exitStatus = res;
+    return {
+      timeout: true,
+      status: false,
+      message: 'termination by timeout: ' + instanceInfo.exitStatus.status +
+        ' killed by : ' + abortSignal + errorMessage,
       duration: deltaTime
     };
   } else {

--- a/js/client/modules/@arangodb/testing.js
+++ b/js/client/modules/@arangodb/testing.js
@@ -199,7 +199,7 @@ const optionsDefaults = {
   'skipNondeterministic': false,
   'skipGrey': false,
   'onlyGrey': false,
-  'oneTestTimeout': 2700,
+  'oneTestTimeout': 6000, // 10 minutes
   'isAsan': false,
   'skipTimeCritical': false,
   'storageEngine': 'rocksdb',

--- a/js/client/modules/@arangodb/testing.js
+++ b/js/client/modules/@arangodb/testing.js
@@ -199,7 +199,7 @@ const optionsDefaults = {
   'skipNondeterministic': false,
   'skipGrey': false,
   'onlyGrey': false,
-  'oneTestTimeout': 6000, // 10 minutes
+  'oneTestTimeout': 10 * 60,
   'isAsan': false,
   'skipTimeCritical': false,
   'storageEngine': 'rocksdb',

--- a/lib/Basics/process-utils.cpp
+++ b/lib/Basics/process-utils.cpp
@@ -1007,6 +1007,7 @@ ExternalProcessStatus TRI_CheckExternalProcess(ExternalId pid, bool wait, uint32
         if (endTime == 0.0) {
           endTime = now + timeout / 1000.0;
         } else if (now >= endTime) {
+          res = external->_pid;
           timeoutHappened = true;
           break;
         }
@@ -1052,7 +1053,10 @@ ExternalProcessStatus TRI_CheckExternalProcess(ExternalId pid, bool wait, uint32
                              arangodb::basics::StringUtils::itoa(external->_pid) +
                              std::string(": ") + std::string(TRI_last_error());
     } else if (static_cast<TRI_pid_t>(external->_pid) == static_cast<TRI_pid_t>(res)) {
-      if (WIFEXITED(loc)) {
+      if (timeoutHappened) {
+        external->_status = TRI_EXT_TIMEOUT;
+        external->_exitStatus = -1;
+      } else if (WIFEXITED(loc)) {
         external->_status = TRI_EXT_TERMINATED;
         external->_exitStatus = WEXITSTATUS(loc);
       } else if (WIFSIGNALED(loc)) {


### PR DESCRIPTION
This PR changes the test timeout from effectively 4.5 minutes to 10 minutes. 


http://jenkins.arangodb.biz:8080/job/arangodb-matrix-pr-linux/10354/EDITION=community,STORAGE_ENGINE=mmfiles,TEST_SUITE=single,limit=(linux&&test)%7C%7Cgce/ would show errnous timeout behaviour; rspec would continue running. 

running with a 15 seconds timeout will now do:
```
./scripts/unittest http_replication --test tests/rb/HttpReplication/api-replication-global-spec.rb --oneTestTimeout 3
...
      fetches the empty follow log
      tails the WAL with a tick far in the future
Killing rspec - ["--color","-I","tests/arangodbRspecLib","--format","d","--format","j","--out","/tmp/arangosh_Cso8Bt/http_replication/testresult.json","--require","/tmp/arangosh_Cso8Bt/http_replication/testconfig.rb","tests/rb/HttpReplication/api-replication-global-spec.rb"]
oops! Skipping remaining tests, server is gone.
Tue Feb 18 2020 14:21:04 GMT+0100 (Central European Standard Time) Shutting down...
...
\n  status: ABORTED\n  signal: 6\nmarking build as crashy."}}
done.
not cleaning up as some tests weren't successful:
["/tmp/arangosh_Cso8Bt/http_replication"] false - false - true


================================================================================'
TEST RESULTS
================================================================================

* Test "http_replication"
    [FAILED]  SKIPPED

      "test" failed: 

    [FAILED]  tests/rb/HttpReplication/api-replication-global-spec.rb

      "test" failed: server crashed

 * Overall state: Fail [http_replication] :     
    during: shutdown timeout; instance forcefully KILLED because of fatal timeout in testrun : Core dump written; Process facts :
    role: single
    port: 4630
    endpoint: 'tcp://127.0.0.1:4630'
    rootDir: /tmp/arangosh_Cso8Bt/http_replication
    url: 'http://127.0.0.1:4630'
    args:
      configuration: /home/willi/src/devel3/etc/testing/arangod-single.conf
      define: TOP_DIR=/home/willi/src/devel3
      wal.flush-timeout: 30000
      javascript.app-path: /tmp/arangosh_Cso8Bt/http_replication/apps
      javascript.copy-installation: false
      http.trusted-origin: all
      cluster.create-waits-for-sync-replication: false
      temp.path: /tmp/arangosh_Cso8Bt/http_replication/tmp
      server.storage-engine: rocksdb
      server.endpoint: 'tcp://127.0.0.1:4630'
      database.directory: /tmp/arangosh_Cso8Bt/http_replication/data
      log.file: /tmp/arangosh_Cso8Bt/http_replication/log
    pid: 3385988
    name: single - 4630
    stats:
      minorPageFaults: 8655
      majorPageFaults: 0
      userTime: 0.76
      systemTime: 0.07
      numberOfThreads: 57
      residentSize: 348999680
      residentSizePercent: 0.005172577284515001
      virtualSize: 1088315392
      rchar: 13044061
      wchar: 329269
      syscr: 2073
      syscw: 145
      read_bytes: 8192
      write_bytes: 466944
      cancelled_write_bytes: 4096
    exitStatus:
      pid: 3385988
      status: ABORTED
      signal: 6
    marking build as crashy.
Marking crashy!
   Suites failed: 2 Tests Failed: 0
```