### PR TITLE
Docs: Remove misleading statement

### DIFF
--- a/Documentation/DocuBlocks/Rest/Database/get_api_database_current.md
+++ b/Documentation/DocuBlocks/Rest/Database/get_api_database_current.md
@@ -1,11 +1,11 @@
 
 @startDocuBlock get_api_database_current
-@brief retrieves information about the current database (alias /_api/database/properties)
+@brief retrieves information about the current database
 
 @RESTHEADER{GET /_api/database/current, Information of the database, getDatabases:current}
 
 @RESTDESCRIPTION
-Retrieves information about the current database
+Retrieves the properties of the current database
 
 The response is a JSON object with the following attributes:
 


### PR DESCRIPTION
...about the non-existing API /_api/database/properties

Backport of https://github.com/arangodb/arangodb/commit/4ccfb073de32754e931282a6c93c71df5707d078