### PR TITLE
Restrict vertex collections in traversal

### DIFF
--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -180,6 +180,20 @@ std::unique_ptr<graph::BaseOptions> createTraversalOptions(aql::Query* query,
                 "due to unpredictable results. Use 'path' "
                 "or 'none' instead");
           }
+        } else if (name == "vertexCollections") {
+          if (value->isStringValue()) {
+            options->vertexCollections.emplace_back(value->getStringValue(),
+                                                    value->getStringLength());
+          } else if (value->isArray()) {
+            for (size_t j = 0; j < value->numMembers(); j++) {
+              AstNode const* member = value->getMember(j);
+              if (member->type == AstNodeType::NODE_TYPE_VALUE &&
+                  member->value.type == AstNodeValueType::VALUE_TYPE_STRING) {
+                options->vertexCollections.emplace_back(member->getStringValue(),
+                                                        member->getStringLength());
+              }
+            }
+          }
         }
       }
     }

--- a/arangod/Graph/BreadthFirstEnumerator.cpp
+++ b/arangod/Graph/BreadthFirstEnumerator.cpp
@@ -124,7 +124,7 @@ bool BreadthFirstEnumerator::next() {
 
       auto callback = [&](graph::EdgeDocumentToken&& eid, VPackSlice e,
                           size_t cursorIdx) -> void {
-        if (!keepEdge(eid, e, cursorIdx, _currentDepth, nextVertex)) {
+        if (!keepEdge(eid, e, nextVertex, _currentDepth, cursorIdx)) {
           return;
         }
 

--- a/arangod/Graph/BreadthFirstEnumerator.cpp
+++ b/arangod/Graph/BreadthFirstEnumerator.cpp
@@ -124,15 +124,10 @@ bool BreadthFirstEnumerator::next() {
 
       auto callback = [&](graph::EdgeDocumentToken&& eid, VPackSlice e,
                           size_t cursorIdx) -> void {
-        if (_opts->hasEdgeFilter(_currentDepth, cursorIdx)) {
-          VPackSlice edge = e;
-          if (edge.isString()) {
-            edge = _opts->cache()->lookupToken(eid);
-          }
-          if (!_traverser->edgeMatchesConditions(edge, nextVertex, _currentDepth, cursorIdx)) {
-            return;
-          }
+        if (!keepEdge(eid, e, cursorIdx, _currentDepth, nextVertex)) {
+          return;
         }
+
         if (_opts->uniqueEdges == TraverserOptions::UniquenessLevel::PATH) {
           if (pathContainsEdge(nextIdx, eid)) {
             // This edge is on the path.

--- a/arangod/Graph/NeighborsEnumerator.cpp
+++ b/arangod/Graph/NeighborsEnumerator.cpp
@@ -75,16 +75,8 @@ bool NeighborsEnumerator::next() {
       swapLastAndCurrentDepth();
       for (auto const& nextVertex : _lastDepth) {
         auto callback = [&](EdgeDocumentToken&& eid, VPackSlice other, size_t cursorId) {
-          if (_opts->hasEdgeFilter(_searchDepth, cursorId)) {
-            // execute edge filter
-            VPackSlice edge = other;
-            if (edge.isString()) {
-              edge = _opts->cache()->lookupToken(eid);
-            }
-            if (!_traverser->edgeMatchesConditions(edge, nextVertex, _searchDepth, cursorId)) {
-              // edge does not qualify
-              return;
-            }
+          if (!keepEdge(eid, other, cursorId, _searchDepth, nextVertex)) {
+            return;
           }
 
           // Counting should be done in readAll

--- a/arangod/Graph/NeighborsEnumerator.cpp
+++ b/arangod/Graph/NeighborsEnumerator.cpp
@@ -75,7 +75,7 @@ bool NeighborsEnumerator::next() {
       swapLastAndCurrentDepth();
       for (auto const& nextVertex : _lastDepth) {
         auto callback = [&](EdgeDocumentToken&& eid, VPackSlice other, size_t cursorId) {
-          if (!keepEdge(eid, other, cursorId, _searchDepth, nextVertex)) {
+          if (!keepEdge(eid, other, nextVertex, _searchDepth, cursorId)) {
             return;
           }
 

--- a/arangod/Graph/PathEnumerator.cpp
+++ b/arangod/Graph/PathEnumerator.cpp
@@ -53,7 +53,7 @@ void PathEnumerator::setStartVertex(arangodb::velocypack::StringRef startVertex)
 
 bool PathEnumerator::keepEdge(arangodb::graph::EdgeDocumentToken& eid,
                               arangodb::velocypack::Slice edge,
-                              velocypack::StringRef sourceVertex, size_t depth,
+                              arangodb::velocypack::StringRef sourceVertex, size_t depth,
                               size_t cursorId) {
   if (_opts->hasEdgeFilter(depth, cursorId)) {
     VPackSlice e = edge;

--- a/arangod/Graph/PathEnumerator.cpp
+++ b/arangod/Graph/PathEnumerator.cpp
@@ -52,23 +52,18 @@ void PathEnumerator::setStartVertex(arangodb::velocypack::StringRef startVertex)
 }
 
 bool PathEnumerator::keepEdge(arangodb::graph::EdgeDocumentToken& eid,
-                              arangodb::velocypack::slice edge,
+                              arangodb::velocypack::Slice edge,
                               velocypack::StringRef sourceVertex, size_t depth,
                               size_t cursorId) {
-  VPackSlice e = edge;
-  if (edge.isString()) {
-    e = _opts->cache()->lookupToken(eid);
-  }
-  return keepEdge(e, sourceVertex, depth, cursorId);
-}
-
-bool PathEnumerator::keepEdge(arangodb::velocypack::Slice edge,
-                              arangodb::velocypack::StringRef sourceVertex,
-                              size_t depth, size_t cursorId) {
-  if (_opts->hasEdgeFilter(depth, cursorId) &&
-      !_traverser->edgeMatchesConditions(edge, sourceVertex, depth, cursorId)) {
-    // This edge does not pass the filtering
-    return false;
+  if (_opts->hasEdgeFilter(depth, cursorId)) {
+    VPackSlice e = edge;
+    if (edge.isString()) {
+      e = _opts->cache()->lookupToken(eid);
+    }
+    if (!_traverser->edgeMatchesConditions(e, sourceVertex, depth, cursorId)) {
+      // This edge does not pass the filtering
+      return false;
+    }
   }
 
   return _opts->destinationCollectionAllowed(edge, sourceVertex);

--- a/arangod/Graph/PathEnumerator.cpp
+++ b/arangod/Graph/PathEnumerator.cpp
@@ -51,8 +51,10 @@ void PathEnumerator::setStartVertex(arangodb::velocypack::StringRef startVertex)
   TRI_ASSERT(_enumeratedPath.vertices.size() == 1);
 }
 
-bool PathEnumerator::keepEdge(graph::EdgeDocumentToken& eid, VPackSlice edge,
-                              velocypack::StringRef sourceVertex, size_t depth, size_t cursorId) {
+bool PathEnumerator::keepEdge(arangodb::graph::EdgeDocumentToken& eid,
+                              arangodb::velocypack::slice edge,
+                              velocypack::StringRef sourceVertex, size_t depth,
+                              size_t cursorId) {
   VPackSlice e = edge;
   if (edge.isString()) {
     e = _opts->cache()->lookupToken(eid);
@@ -60,8 +62,9 @@ bool PathEnumerator::keepEdge(graph::EdgeDocumentToken& eid, VPackSlice edge,
   return keepEdge(e, sourceVertex, depth, cursorId);
 }
 
-bool PathEnumerator::keepEdge(VPackSlice edge,
-                              arangodb::velocypack::StringRef sourceVertex, size_t depth, size_t cursorId) {
+bool PathEnumerator::keepEdge(arangodb::velocypack::Slice edge,
+                              arangodb::velocypack::StringRef sourceVertex,
+                              size_t depth, size_t cursorId) {
   if (_opts->hasEdgeFilter(depth, cursorId) &&
       !_traverser->edgeMatchesConditions(edge, sourceVertex, depth, cursorId)) {
     // This edge does not pass the filtering

--- a/arangod/Graph/PathEnumerator.cpp
+++ b/arangod/Graph/PathEnumerator.cpp
@@ -35,6 +35,25 @@ using DepthFirstEnumerator = arangodb::traverser::DepthFirstEnumerator;
 using Traverser = arangodb::traverser::Traverser;
 using TraverserOptions = arangodb::traverser::TraverserOptions;
 
+namespace {
+arangodb::velocypack::StringRef getDestination(arangodb::velocypack::Slice edge,
+                                               arangodb::velocypack::StringRef origin) {
+  if (edge.isString()) {
+    return edge.stringRef();
+  }
+
+  TRI_ASSERT(edge.isObject());
+  auto from = edge.get(arangodb::StaticStrings::FromString);
+  TRI_ASSERT(from.isString());
+  if (from.stringRef() == origin) {
+    auto to = edge.get(arangodb::StaticStrings::ToString);
+    TRI_ASSERT(to.isString());
+    return to.stringRef();
+  }
+  return from.stringRef();
+}
+}  // namespace
+
 PathEnumerator::PathEnumerator(Traverser* traverser, TraverserOptions* opts)
     : _traverser(traverser), 
       _isFirst(true), 
@@ -66,9 +85,8 @@ bool PathEnumerator::keepEdge(graph::EdgeDocumentToken& eid,
   }
 
   if (!_opts->vertexCollections.empty()) {
-    TRI_ASSERT(edge.isString());
-    auto idRef = edge.stringRef();
-    auto collection = transaction::helpers::extractCollectionFromId(idRef);
+    auto destination = ::getDestination(edge, sourceVertex);
+    auto collection = transaction::helpers::extractCollectionFromId(destination);
     if (std::find(_opts->vertexCollections.begin(), _opts->vertexCollections.end(),
                   std::string_view(collection.data(), collection.size())) ==
         _opts->vertexCollections.end()) {

--- a/arangod/Graph/PathEnumerator.h
+++ b/arangod/Graph/PathEnumerator.h
@@ -89,8 +89,14 @@ class PathEnumerator {
 
   size_t _httpRequests;
 
-  bool keepEdge(graph::EdgeDocumentToken& eid, velocypack::Slice const& edge,
-                size_t cursorId, size_t depth, velocypack::StringRef nextVertex);
+  bool keepEdge(graph::EdgeDocumentToken& eid, velocypack::Slice edge,
+                velocypack::StringRef sourceVertex, size_t depth, size_t cursorId);
+
+  bool keepEdge(velocypack::Slice edge,
+                velocypack::StringRef sourceVertex, size_t depth, size_t cursorId);
+
+  bool destinationCollectionAllowed(velocypack::Slice edge,
+                                    velocypack::StringRef sourceVertex);
 
  public:
   PathEnumerator(Traverser* traverser, TraverserOptions* opts);

--- a/arangod/Graph/PathEnumerator.h
+++ b/arangod/Graph/PathEnumerator.h
@@ -95,9 +95,6 @@ class PathEnumerator {
   bool keepEdge(velocypack::Slice edge,
                 velocypack::StringRef sourceVertex, size_t depth, size_t cursorId);
 
-  bool destinationCollectionAllowed(velocypack::Slice edge,
-                                    velocypack::StringRef sourceVertex);
-
  public:
   PathEnumerator(Traverser* traverser, TraverserOptions* opts);
 

--- a/arangod/Graph/PathEnumerator.h
+++ b/arangod/Graph/PathEnumerator.h
@@ -92,9 +92,6 @@ class PathEnumerator {
   bool keepEdge(graph::EdgeDocumentToken& eid, velocypack::Slice edge,
                 velocypack::StringRef sourceVertex, size_t depth, size_t cursorId);
 
-  bool keepEdge(velocypack::Slice edge,
-                velocypack::StringRef sourceVertex, size_t depth, size_t cursorId);
-
  public:
   PathEnumerator(Traverser* traverser, TraverserOptions* opts);
 

--- a/arangod/Graph/PathEnumerator.h
+++ b/arangod/Graph/PathEnumerator.h
@@ -88,7 +88,10 @@ class PathEnumerator {
   //////////////////////////////////////////////////////////////////////////////
 
   size_t _httpRequests;
-  
+
+  bool keepEdge(graph::EdgeDocumentToken& eid, velocypack::Slice const& edge,
+                size_t cursorId, size_t depth, velocypack::StringRef nextVertex);
+
  public:
   PathEnumerator(Traverser* traverser, TraverserOptions* opts);
 

--- a/arangod/Graph/TraverserOptions.h
+++ b/arangod/Graph/TraverserOptions.h
@@ -82,6 +82,8 @@ struct TraverserOptions : public graph::BaseOptions {
 
   UniquenessLevel uniqueEdges;
 
+  std::vector<std::string> vertexCollections;
+
   explicit TraverserOptions(aql::Query* query);
 
   TraverserOptions(aql::Query* query, arangodb::velocypack::Slice const& definition);
@@ -114,6 +116,8 @@ struct TraverserOptions : public graph::BaseOptions {
   bool vertexHasFilter(uint64_t) const;
 
   bool hasEdgeFilter(int64_t, size_t) const;
+
+  bool hasVertexCollectionRestrictions() const;
 
   bool evaluateEdgeExpression(arangodb::velocypack::Slice,
                               arangodb::velocypack::StringRef vertexId,

--- a/arangod/Graph/TraverserOptions.h
+++ b/arangod/Graph/TraverserOptions.h
@@ -125,6 +125,8 @@ struct TraverserOptions : public graph::BaseOptions {
 
   bool evaluateVertexExpression(arangodb::velocypack::Slice, uint64_t);
 
+  bool destinationCollectionAllowed(velocypack::Slice edge, velocypack::StringRef sourceVertex);
+
   graph::EdgeCursor* nextCursor(arangodb::velocypack::StringRef vid, uint64_t);
 
   void linkTraverser(arangodb::traverser::ClusterTraverser*);

--- a/arangod/Transaction/Helpers.cpp
+++ b/arangod/Transaction/Helpers.cpp
@@ -373,9 +373,8 @@ VPackSlice transaction::helpers::extractRevSliceFromDocument(VPackSlice slice) {
 }
 
 velocypack::StringRef transaction::helpers::extractCollectionFromId(velocypack::StringRef id) {
-  std::string_view view(id.data(), id.size());
-  auto index = view.find('/');
-  if (index == std::string_view::npos) {
+  std::size_t index = id.find('/');
+  if (index == std::string::npos) {
     // can't find the '/' to split, bail out with only logical response
     return id;
   }

--- a/arangod/Transaction/Helpers.cpp
+++ b/arangod/Transaction/Helpers.cpp
@@ -372,6 +372,16 @@ VPackSlice transaction::helpers::extractRevSliceFromDocument(VPackSlice slice) {
   return slice.get(StaticStrings::RevString);
 }
 
+velocypack::StringRef transaction::helpers::extractCollectionFromId(velocypack::StringRef id) {
+  std::string_view view(id.data(), id.size());
+  auto index = view.find('/');
+  if (index == std::string_view::npos) {
+    // can't find the '/' to split, bail out with only logical response
+    return id;
+  }
+  return velocypack::StringRef(id.data(), index);
+}
+
 OperationResult transaction::helpers::buildCountResult(
     std::vector<std::pair<std::string, uint64_t>> const& count,
     transaction::CountType type, uint64_t& total) {

--- a/arangod/Transaction/Helpers.h
+++ b/arangod/Transaction/Helpers.h
@@ -84,6 +84,8 @@ VPackSlice extractToFromDocument(VPackSlice);
 void extractKeyAndRevFromDocument(VPackSlice slice, VPackSlice& keySlice,
                                   TRI_voc_rid_t& revisionId);
 
+velocypack::StringRef extractCollectionFromId(velocypack::StringRef id);
+
 /// @brief extract _rev from a database document
 TRI_voc_rid_t extractRevFromDocument(VPackSlice slice);
 VPackSlice extractRevSliceFromDocument(VPackSlice slice);

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -506,6 +506,9 @@ function printTraversalDetails(traversals) {
       uniqueVertices: options.uniqueVertices,
       uniqueEdges: options.uniqueEdges
     };
+    if (options.vertexCollections !== undefined) {
+      opts.vertexCollections = options.vertexCollections;
+    }
 
     var result = '';
     for (var att in opts) {
@@ -701,7 +704,7 @@ function processQuery(query, explain, planIndex) {
   if (planIndex !== undefined) {
     plan = explain.plans[planIndex];
   }
-  
+
   /// mode with actual runtime stats per node
   let profileMode = stats && stats.hasOwnProperty('nodes');
 

--- a/tests/js/server/aql/aql-traversal-restrict-vertex-collections.js
+++ b/tests/js/server/aql/aql-traversal-restrict-vertex-collections.js
@@ -99,7 +99,7 @@ function vertexCollectionRestrictionSuite() {
       const query = `WITH @@vc1, @@vc2
                      FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec
                        SORT v._id
-                       RETURN DISTINCT v._id`
+                       RETURN DISTINCT v._id`;
 
       const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec': ecName}).toArray();
       const expected = [
@@ -119,7 +119,7 @@ function vertexCollectionRestrictionSuite() {
                      FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec
                        OPTIONS {vertexCollections: ["${vc1Name}", "${vc2Name}"]}
                        SORT v._id
-                       RETURN DISTINCT v._id`
+                       RETURN DISTINCT v._id`;
 
       const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec': ecName }).toArray();
       const expected = [
@@ -139,7 +139,7 @@ function vertexCollectionRestrictionSuite() {
                      FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec
                        OPTIONS {vertexCollections: ["${vc1Name}"]}
                        SORT v._id
-                       RETURN DISTINCT v._id`
+                       RETURN DISTINCT v._id`;
 
       const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec': ecName }).toArray();
       const expected = [
@@ -154,7 +154,7 @@ function vertexCollectionRestrictionSuite() {
                      FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec
                        OPTIONS {vertexCollections: ["${vc2Name}"]}
                        SORT v._id
-                       RETURN DISTINCT v._id`
+                       RETURN DISTINCT v._id`;
 
       const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec': ecName }).toArray();
       const expected = [
@@ -169,7 +169,7 @@ function vertexCollectionRestrictionSuite() {
                      FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec
                        OPTIONS {bfs: true}
                        SORT v._id
-                       RETURN DISTINCT v._id`
+                       RETURN DISTINCT v._id`;
 
       const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec': ecName}).toArray();
       const expected = [
@@ -189,7 +189,7 @@ function vertexCollectionRestrictionSuite() {
                      FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec
                        OPTIONS {bfs: true, vertexCollections: ["${vc1Name}", "${vc2Name}"]}
                        SORT v._id
-                       RETURN DISTINCT v._id`
+                       RETURN DISTINCT v._id`;
 
       const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec': ecName }).toArray();
       const expected = [
@@ -209,7 +209,7 @@ function vertexCollectionRestrictionSuite() {
                      FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec
                        OPTIONS {bfs: true, vertexCollections: ["${vc1Name}"]}
                        SORT v._id
-                       RETURN DISTINCT v._id`
+                       RETURN DISTINCT v._id`;
 
       const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec': ecName }).toArray();
       const expected = [
@@ -224,7 +224,7 @@ function vertexCollectionRestrictionSuite() {
                      FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec
                        OPTIONS {bfs: true, vertexCollections: ["${vc2Name}"]}
                        SORT v._id
-                       RETURN DISTINCT v._id`
+                       RETURN DISTINCT v._id`;
 
       const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec': ecName }).toArray();
       const expected = [

--- a/tests/js/server/aql/aql-traversal-restrict-vertex-collections.js
+++ b/tests/js/server/aql/aql-traversal-restrict-vertex-collections.js
@@ -24,7 +24,7 @@
 ///
 /// Copyright holder is triAGENS GmbH, Cologne, Germany
 ///
-/// @author Markus Pfeiffer
+/// @author Dan Larkin-York
 /// @author Copyright 2020, triAGENS GmbH, Cologne, Germany
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -153,6 +153,76 @@ function vertexCollectionRestrictionSuite() {
       const query = `WITH @@vc1, @@vc2
                      FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec
                        OPTIONS {vertexCollections: ["${vc2Name}"]}
+                       SORT v._id
+                       RETURN DISTINCT v._id`
+
+      const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec': ecName }).toArray();
+      const expected = [
+        vc2Name + "/node_3",
+      ];
+
+      assertEqual(actual, expected);
+    },
+
+    testNoRestrictionBfs : function () {
+      const query = `WITH @@vc1, @@vc2
+                     FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec
+                       OPTIONS {bfs: true}
+                       SORT v._id
+                       RETURN DISTINCT v._id`
+
+      const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec': ecName}).toArray();
+      const expected = [
+        vc1Name + "/node_4",
+        vc1Name + "/node_6",
+        vc1Name + "/node_8",
+        vc2Name + "/node_3",
+        vc2Name + "/node_5",
+        vc2Name + "/node_7",
+      ];
+
+      assertEqual(actual, expected);
+    },
+
+    testNoPracticalRestrictionBfs: function () {
+      const query = `WITH @@vc1, @@vc2
+                     FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec
+                       OPTIONS {bfs: true, vertexCollections: ["${vc1Name}", "${vc2Name}"]}
+                       SORT v._id
+                       RETURN DISTINCT v._id`
+
+      const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec': ecName }).toArray();
+      const expected = [
+        vc1Name + "/node_4",
+        vc1Name + "/node_6",
+        vc1Name + "/node_8",
+        vc2Name + "/node_3",
+        vc2Name + "/node_5",
+        vc2Name + "/node_7",
+      ];
+
+      assertEqual(actual, expected);
+    },
+
+    testRestrict1Bfs: function () {
+      const query = `WITH @@vc1, @@vc2
+                     FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec
+                       OPTIONS {bfs: true, vertexCollections: ["${vc1Name}"]}
+                       SORT v._id
+                       RETURN DISTINCT v._id`
+
+      const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec': ecName }).toArray();
+      const expected = [
+        vc1Name + "/node_8",
+      ];
+
+      assertEqual(actual, expected);
+    },
+
+    testRestrict2Bfs: function () {
+      const query = `WITH @@vc1, @@vc2
+                     FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec
+                       OPTIONS {bfs: true, vertexCollections: ["${vc2Name}"]}
                        SORT v._id
                        RETURN DISTINCT v._id`
 

--- a/tests/js/server/aql/aql-traversal-restrict-vertex-collections.js
+++ b/tests/js/server/aql/aql-traversal-restrict-vertex-collections.js
@@ -1,0 +1,177 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global assertEqual, AQL_EXECUTE, assertTrue, fail */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief tests for regression returning blocks to the manager
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2014 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+/// @author Copyright 2020, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+var jsunity = require("jsunity");
+var internal = require("internal");
+var errors = internal.errors;
+var db = require("@arangodb").db, indexId;
+
+const vc1Name = "v1";
+const vc2Name = "v2";
+const ecName = "edges";
+
+var cleanup = function() {
+  db._drop(vc1Name);
+  db._drop(vc2Name);
+  db._drop(ecName);
+};
+
+var createBaseGraph = function () {
+  const vc1 = db._create(vc1Name);
+  const vc2 = db._create(vc2Name);
+  const ec = db._createEdgeCollection(ecName);
+
+  for (let i = 0; i < 10; ++i) {
+    const doc = { _key: "node_" + i, value: i };
+    vc1.save(doc);
+    vc2.save(doc);
+  }
+
+  for (let i = 0; i < 10; ++i) {
+    ec.save({_from: vc1Name + "/node_" + i, _to: vc2Name + "/node_" + i});
+    ec.save({_from: vc2Name + "/node_" + i, _to: vc1Name + "/node_" + i});
+    if (i < 9) {
+      ec.save({_from: vc1Name + "/node_" + i, _to: vc1Name + "/node_" + (i + 1)});
+    }
+    if (i > 0) {
+      ec.save({_from: vc2Name + "/node_" + i, _to: vc2Name + "/node_" + (i - 1)});
+    }
+  }
+};
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test suite
+////////////////////////////////////////////////////////////////////////////////
+
+function vertexCollectionRestrictionSuite() {
+  return {
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief set up
+////////////////////////////////////////////////////////////////////////////////
+
+    setUpAll : function () {
+      cleanup();
+      createBaseGraph();
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief tear down
+////////////////////////////////////////////////////////////////////////////////
+
+    tearDownAll : function () {
+      cleanup();
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test object access for path object
+////////////////////////////////////////////////////////////////////////////////
+
+    testNoRestriction : function () {
+      const query = `WITH @@vc1, @@vc2
+                     FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec
+                       SORT v._id
+                       RETURN DISTINCT v._id`
+
+      const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec': ecName}).toArray();
+      const expected = [
+        vc1Name + "/node_4",
+        vc1Name + "/node_6",
+        vc1Name + "/node_8",
+        vc2Name + "/node_3",
+        vc2Name + "/node_5",
+        vc2Name + "/node_7",
+      ];
+
+      assertEqual(actual, expected);
+    },
+
+    testNoPracticalRestriction: function () {
+      const query = `WITH @@vc1, @@vc2
+                     FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec
+                       OPTIONS {vertexCollections: ["${vc1Name}", "${vc2Name}"]}
+                       SORT v._id
+                       RETURN DISTINCT v._id`
+
+      const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec': ecName }).toArray();
+      const expected = [
+        vc1Name + "/node_4",
+        vc1Name + "/node_6",
+        vc1Name + "/node_8",
+        vc2Name + "/node_3",
+        vc2Name + "/node_5",
+        vc2Name + "/node_7",
+      ];
+
+      assertEqual(actual, expected);
+    },
+
+    testRestrict1: function () {
+      const query = `WITH @@vc1, @@vc2
+                     FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec
+                       OPTIONS {vertexCollections: ["${vc1Name}"]}
+                       SORT v._id
+                       RETURN DISTINCT v._id`
+
+      const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec': ecName }).toArray();
+      const expected = [
+        vc1Name + "/node_8",
+      ];
+
+      assertEqual(actual, expected);
+    },
+
+    testRestrict2: function () {
+      const query = `WITH @@vc1, @@vc2
+                     FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec
+                       OPTIONS {vertexCollections: ["${vc2Name}"]}
+                       SORT v._id
+                       RETURN DISTINCT v._id`
+
+      const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec': ecName }).toArray();
+      const expected = [
+        vc2Name + "/node_3",
+      ];
+
+      assertEqual(actual, expected);
+    },
+
+  };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief executes the test suite
+////////////////////////////////////////////////////////////////////////////////
+
+jsunity.run(vertexCollectionRestrictionSuite);
+
+return jsunity.done();
+


### PR DESCRIPTION
### Scope & Purpose

Add a new query option to restrict a traversal to only visit certain vertex collections. The filtering can be done at the edge, and thus save additional query time to the storage engine or to other database servers to retrieve the vertex for post-filtering.

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

Enterprise component: https://github.com/arangodb/enterprise/pull/396

#### Related Information

*(Please reference tickets / specification etc )*

- [x] There is a *JIRA Ticket number* (In case a customer was affected / involved): https://arangodb.atlassian.net/browse/AR-15

### Testing & Verification

- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

Jenkins:
http://172.16.10.101:8080/job/arangodb-matrix-pr/8675/ (blue except for Windows)
http://172.16.10.101:8080/job/arangodb-matrix-pr-windows/2642/