### PR TITLE
Honor `cacheEnabled` attribute when updating the properties of a collection in case of the cluster

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.5.5 (XXXX-XX-XX)
 -------------------
 
+* Honor `cacheEnabled` attribute when updating the properties of a collection
+  in case of the cluster. Previously, this attribute was ignored in the cluster,
+  but it shouldn't have been.
+
 * Disable "collect-in-cluster" AQL optimizer rule in case a LIMIT node is
   between the COLLECT and the source data. In this case it is not safe to apply
   the distributed collect, as it may alter the results.

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -52,7 +52,7 @@ using namespace arangodb::maintenance;
 using namespace arangodb::methods;
 using namespace arangodb::basics::StringUtils;
 
-static std::vector<std::string> const cmp{JOURNAL_SIZE, WAIT_FOR_SYNC, DO_COMPACT, INDEX_BUCKETS};
+static std::vector<std::string> const cmp{JOURNAL_SIZE, WAIT_FOR_SYNC, DO_COMPACT, INDEX_BUCKETS, CACHE_ENABLED};
 
 static VPackValue const VP_DELETE("delete");
 static VPackValue const VP_SET("set");

--- a/arangod/Cluster/MaintenanceFeature.cpp
+++ b/arangod/Cluster/MaintenanceFeature.cpp
@@ -434,14 +434,12 @@ void MaintenanceFeature::registerAction(std::shared_ptr<Action> action, bool exe
 }
 
 std::shared_ptr<Action> MaintenanceFeature::createAction(std::shared_ptr<ActionDescription> const& description) {
-  // write lock via _actionRegistryLock is assumed held
-  std::shared_ptr<Action> newAction;
-
   // name should already be verified as existing ... but trust no one
   std::string name = description->get(NAME);
 
   // call factory
-  newAction = std::make_shared<Action>(*this, *description);
+  // write lock via _actionRegistryLock is assumed held
+  std::shared_ptr<Action> newAction = std::make_shared<Action>(*this, *description);
 
   // if a new action constructed successfully
   if (!newAction->ok()) {

--- a/arangod/Cluster/MaintenanceStrings.h
+++ b/arangod/Cluster/MaintenanceStrings.h
@@ -29,6 +29,7 @@ namespace maintenance {
 
 constexpr char const* ACTIONS = "actions";
 constexpr char const* AGENCY = "agency";
+constexpr char const* CACHE_ENABLED = "cacheEnabled";
 constexpr char const* COLLECTION = "collection";
 constexpr char const* CREATE_COLLECTION = "CreateCollection";
 constexpr char const* CREATE_DATABASE = "CreateDatabase";

--- a/arangod/Cluster/ResignShardLeadership.cpp
+++ b/arangod/Cluster/ResignShardLeadership.cpp
@@ -98,7 +98,7 @@ bool ResignShardLeadership::first() {
       std::stringstream error;
       error << "Failed to lookup local collection " << collection
             << " in database " + database;
-      LOG_TOPIC("e06ca", ERR, Logger::MAINTENANCE) << "EnsureIndex: " << error.str();
+      LOG_TOPIC("e06ca", ERR, Logger::MAINTENANCE) << "ResignLeadership: " << error.str();
       _result.reset(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, error.str());
       return false;
     }


### PR DESCRIPTION
### Scope & Purpose

When using `db.<collection>.properties({ cacheEnabled: true });` this didn't have any effect. The `cacheEnabled` attribute was ignored here, but it shouldn't have been.
This PR fixes the behavior.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8686/