### PR TITLE
use EVP interface

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Use OpenSSL's EVP interface for SHA256 instead of the deprecated low-level
+  API.
+
 * Honor `cacheEnabled` attribute when updating the properties of a collection
   in case of the cluster. Previously, this attribute was ignored in the cluster,
   but it shouldn't have been.

--- a/arangod/GeneralServer/SslServerFeature.cpp
+++ b/arangod/GeneralServer/SslServerFeature.cpp
@@ -654,7 +654,7 @@ static void dumpPEM(std::string const& pem, VPackBuilder& builder, std::string a
   // Now dump the certs and the hash of the key:
   {
     VPackObjectBuilder guard2(&builder, attrName);
-    builder.add("SHA256", VPackValue(func.final()));
+    builder.add("SHA256", VPackValue(func.finalize()));
     {
       VPackArrayBuilder guard3(&builder, "certificates");
       for (auto const& c : certs) {
@@ -664,7 +664,7 @@ static void dumpPEM(std::string const& pem, VPackBuilder& builder, std::string a
     if (!keys.empty()) {
       TRI_SHA256Functor func2;
       func2(keys[0].c_str(), keys[0].size());
-      builder.add("privateKeySHA256", VPackValue(func2.final()));
+      builder.add("privateKeySHA256", VPackValue(func2.finalize()));
     }
   }
 }

--- a/arangod/RocksDBEngine/RocksDBEventListener.cpp
+++ b/arangod/RocksDBEngine/RocksDBEventListener.cpp
@@ -130,7 +130,7 @@ bool RocksDBEventListenerThread::shaCalcFile(std::string const& filename) {
     if (good) {
       std::string newfile = filename.substr(0, filename.size() - 4);
       newfile += ".sha.";
-      newfile += sha.final();
+      newfile += sha.finalize();
       newfile += ".hash";
       LOG_TOPIC("80257", DEBUG, arangodb::Logger::ENGINES) << "shaCalcFile: done "
         << filename << " result: " << newfile;

--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -2687,7 +2687,11 @@ TRI_SHA256Functor::TRI_SHA256Functor()
 }
 
 TRI_SHA256Functor::~TRI_SHA256Functor() {
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
   EVP_MD_CTX_free(_context);
+#else
+    EVP_MD_CTX_destroy(_context);
+#endif
 }
 
 bool TRI_SHA256Functor::operator()(char const* data, size_t size) noexcept {

--- a/lib/Basics/files.h
+++ b/lib/Basics/files.h
@@ -33,7 +33,7 @@
 #include <string>
 #include <vector>
 
-#include <openssl/sha.h>
+#include <openssl/evp.h>
 
 #include "Basics/Common.h"
 #include "Basics/StringUtils.h"
@@ -427,28 +427,14 @@ bool TRI_GETENV(char const* which, std::string& value);
 ///        you need to wrap your TRI_SHA256Functor object within std::ref().
 ////////////////////////////////////////////////////////////////////////////////
 struct TRI_SHA256Functor {
-  SHA256_CTX _context;
-  unsigned char _digest[SHA256_DIGEST_LENGTH];
+  TRI_SHA256Functor();
+  ~TRI_SHA256Functor();
 
-  TRI_SHA256Functor() {
-    int ret_val = SHA256_Init(&_context);
-    if (1 != ret_val) {
-      TRI_ASSERT(false);
-    } // if
-  }
-
-  bool operator()(char const* data, size_t size) {
-    int ret_val = SHA256_Update(&_context, static_cast<void const*>(data), size);
-    return 1 == ret_val;
-  }
-
-  std::string final() {
-    int ret_val = SHA256_Final(_digest, &_context);
-    if (1 != ret_val) {
-      TRI_ASSERT(false);
-    } // if
-    return arangodb::basics::StringUtils::encodeHex((char const *)_digest, SHA256_DIGEST_LENGTH);
-  }
+  bool operator()(char const* data, size_t size) noexcept;
+  
+  std::string finalize();
+  
+  EVP_MD_CTX* _context;
 };// struct TRI_SHA256Functor
 
 #endif

--- a/tests/Basics/files-test.cpp
+++ b/tests/Basics/files-test.cpp
@@ -462,7 +462,7 @@ TEST_F(CFilesTest, tst_processFile) {
   good = TRI_ProcessFile(filename->c_str(), shaReader);
 
   EXPECT_TRUE(good);
-  EXPECT_TRUE(sha.final().compare("9ecb36561341d18eb65484e833efea61edc74b84cf5e6ae1b81c63533e25fc8f")==0);
+  EXPECT_TRUE(sha.finalize().compare("9ecb36561341d18eb65484e833efea61edc74b84cf5e6ae1b81c63533e25fc8f") == 0);
 
   TRI_UnlinkFile(filename->c_str());
   delete filename;


### PR DESCRIPTION
### Scope & Purpose

Use OpenSSL's EVP interface instead of the deprecated low-level APIs
Enterprise companion PR: https://github.com/arangodb/enterprise/pull/398

From https://www.openssl.org/docs/man1.1.0/man3/SHA256_Final.html:
> Applications should use the higher level functions EVP_DigestInit(3) etc. instead of calling the hash functions directly.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest catch*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8690/