### PR TITLE
Feature/improve block prefetching in collect

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,7 +15,6 @@ devel
   '--server.jwt-secret-folder' but not both." from occurring when specifying the
   JWT secret keyfile option.
 
-
 * Honor `cacheEnabled` attribute when updating the properties of a collection
   in case of the cluster. Previously, this attribute was ignored in the cluster,
   but it shouldn't have been.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 devel
 -----
 
+* In some cases with a COLLECT LIMIT situation on a small limit the collect
+  does more calls to upstream then without a limit to provide the same
+  result. We improved this situation and made sure that LIMIT does
+  not cause the COLLECT to fetch too few input. There is a chance
+  that queries with a very small amount of data might suffer from this
+  modification, most queries will benefit however.  
+
 * Honor `cacheEnabled` attribute when updating the properties of a collection
   in case of the cluster. Previously, this attribute was ignored in the cluster,
   but it shouldn't have been.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ devel
 -----
 
 * In some cases with a COLLECT LIMIT situation on a small limit the collect
-  does more calls to upstream then without a limit to provide the same
+  does more calls to upstream than without a limit to provide the same
   result. We improved this situation and made sure that LIMIT does
   not cause the COLLECT to fetch too few input. There is a chance
   that queries with a very small amount of data might suffer from this

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ devel
 * In some cases with a COLLECT LIMIT situation on a small limit the collect
   does more calls to upstream than without a limit to provide the same
   result. We improved this situation and made sure that LIMIT does
-  not cause the COLLECT to fetch too few input. There is a chance
+  not cause the COLLECT to fetch too few input rows. There is a chance
   that queries with a very small amount of data might suffer from this
   modification, most queries will benefit however.  
 

--- a/arangod/Aql/HashedCollectExecutor.cpp
+++ b/arangod/Aql/HashedCollectExecutor.cpp
@@ -329,10 +329,11 @@ std::pair<ExecutionState, size_t> HashedCollectExecutor::expectedNumberOfRows(si
     // as it knows how many  groups is has created and not returned.
     rowsLeft = _allGroups.size() - _returnedGroups;
   }
-  if (rowsLeft > 0) {
-    return {ExecutionState::HASMORE, rowsLeft};
+  auto rowsAvailable = std::min(rowsLeft, atMost);
+  if (rowsAvailable > 0) {
+    return {ExecutionState::HASMORE, rowsAvailable};
   }
-  return {ExecutionState::DONE, rowsLeft};
+  return {ExecutionState::DONE, rowsAvailable};
 }
 
 const HashedCollectExecutor::Infos& HashedCollectExecutor::infos() const noexcept {

--- a/arangod/Aql/HashedCollectExecutor.cpp
+++ b/arangod/Aql/HashedCollectExecutor.cpp
@@ -301,7 +301,8 @@ decltype(HashedCollectExecutor::_allGroups)::iterator HashedCollectExecutor::fin
   }
 
   // note: aggregateValues may be a nullptr!
-  auto [result, emplaced] = _allGroups.try_emplace(std::move(_nextGroupValues), std::move(aggregateValues));
+  auto [result, emplaced] =
+      _allGroups.try_emplace(std::move(_nextGroupValues), std::move(aggregateValues));
   // emplace must not fail
   TRI_ASSERT(emplaced);
 
@@ -316,7 +317,8 @@ std::pair<ExecutionState, size_t> HashedCollectExecutor::expectedNumberOfRows(si
   size_t rowsLeft = 0;
   if (!_isInitialized) {
     ExecutionState state;
-    std::tie(state, rowsLeft) = _fetcher.preFetchNumberOfRows(atMost);
+    std::tie(state, rowsLeft) =
+        _fetcher.preFetchNumberOfRows(ExecutionBlock::DefaultBatchSize);
     if (state == ExecutionState::WAITING) {
       TRI_ASSERT(rowsLeft == 0);
       return {state, 0};

--- a/arangod/Aql/SortedCollectExecutor.cpp
+++ b/arangod/Aql/SortedCollectExecutor.cpp
@@ -369,7 +369,8 @@ std::pair<ExecutionState, size_t> SortedCollectExecutor::expectedNumberOfRows(si
   if (!_fetcherDone) {
     ExecutionState state;
     size_t expectedRows;
-    std::tie(state, expectedRows) = _fetcher.preFetchNumberOfRows(atMost);
+    std::tie(state, expectedRows) =
+        _fetcher.preFetchNumberOfRows(ExecutionBlock::DefaultBatchSize);
     if (state == ExecutionState::WAITING) {
       TRI_ASSERT(expectedRows == 0);
       return {state, 0};

--- a/arangod/Aql/SortedCollectExecutor.cpp
+++ b/arangod/Aql/SortedCollectExecutor.cpp
@@ -375,7 +375,8 @@ std::pair<ExecutionState, size_t> SortedCollectExecutor::expectedNumberOfRows(si
       TRI_ASSERT(expectedRows == 0);
       return {state, 0};
     }
-    return {ExecutionState::HASMORE, expectedRows + 1};
+    auto rowsAvailable = std::min(expectedRows + 1, atMost);
+    return {ExecutionState::HASMORE, rowsAvailable};
   }
   // The fetcher will NOT send anything any more
   // We will at most return the current oepn group

--- a/tests/js/server/aql/aql-profiler-noncluster.js
+++ b/tests/js/server/aql/aql-profiler-noncluster.js
@@ -410,6 +410,33 @@ function ahuacatlProfilerTestSuite () {
       );
     },
 
+    testLimitCollectCombination: function () {
+      const query = `
+            FOR x IN 1..@rows
+              COLLECT AGGREGATE total = SUM(x)
+              LIMIT 0, 1
+              RETURN total
+      `;
+      const prepare = () => {};
+      const bind = (rows) => ({rows});
+      const genNodeList = (rows, batches) => {
+        return [
+          {type: SingletonBlock, calls: 1, items: 1},
+          {type: CalculationBlock, calls: 1, items: 1},
+          {type: EnumerateListBlock, calls: batches, items: rows},
+          {type: SortedCollectBlock, calls: 1, items: 1},
+          {type: LimitBlock, calls: 1, items: 1},
+          {type: ReturnBlock, calls: 1, items: 1}
+        ];
+      };
+
+      profHelper.runDefaultChecks(
+        {query, genNodeList, prepare, bind}
+      );
+
+
+    }
+
   };
 }
 


### PR DESCRIPTION
Minor improvement in Collect nodes.
Nothing visible to the outside, it just might improve the speed of some queries slightly.

I have not written changeling, if we decide to use this imrpvoment I will add CHANGELOG to remove the DO_NOT_MERGE flag.

Jenkins:
http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/8692/