### PR TITLE
Bug fix/fix jwt option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Prevent startup error "specifiy either '--server.jwt-secret-keyfile' or 
+  '--server.jwt-secret-folder' but not both." from occurring when specifying the
+  JWT secret keyfile option.
+
 * Honor `cacheEnabled` attribute when updating the properties of a collection
   in case of the cluster. Previously, this attribute was ignored in the cluster,
   but it shouldn't have been.

--- a/arangod/GeneralServer/AuthenticationFeature.cpp
+++ b/arangod/GeneralServer/AuthenticationFeature.cpp
@@ -130,9 +130,9 @@ void AuthenticationFeature::collectOptions(std::shared_ptr<ProgramOptions> optio
 }
 
 void AuthenticationFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
-  if (!_jwtSecretKeyfileProgramOption.empty() && !_jwtSecretKeyfileProgramOption.empty()) {
+  if (!_jwtSecretKeyfileProgramOption.empty() && !_jwtSecretFolderProgramOption.empty()) {
     LOG_TOPIC("d3515", FATAL, Logger::STARTUP)
-        << "specifiy either '--server.jwt-"
+        << "please specify either '--server.jwt-"
            "secret-keyfile' or '--server.jwt-secret-folder' but not both.";
     FATAL_ERROR_EXIT();
   }


### PR DESCRIPTION
### Scope & Purpose

Prevent startup error `specifiy either '--server.jwt-secret-keyfile' or  '--server.jwt-secret-folder' but not both.` from occurring when specifying the JWT secret keyfile option.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8693/