### PR TITLE
[3.6] Fix restore for smart collections

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,16 @@
 v3.6.2 (XXXX-XX-XX)
 -------------------
 
+* Fix arangorestore:
+  If a smartGraphAttribute value was changed after document creation,
+  the _key of the document becomes inconsistent with the smartGraphAttribute
+  entry. However, the sharding of documents stays intact.
+
+  When restoring data from a dump that contains a document with inconsistent
+  _key and smartGraphAttribute this would cause an error and the document
+  would not be inserted. This is fixed by ignoring this inconsistency in
+  the case of restore.
+
 * Honor `cacheEnabled` attribute when updating the properties of a collection
   in case of the cluster. Previously, this attribute was ignored in the cluster,
   but it shouldn't have been.

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -658,6 +658,7 @@ function hotBackup (options) {
 
 exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
+
   testFns['dump'] = dump;
   defaultFns.push('dump');
 

--- a/tests/js/server/dump/dump-mmfiles-cluster.js
+++ b/tests/js/server/dump/dump-mmfiles-cluster.js
@@ -803,8 +803,17 @@ function dumpTestEnterpriseSuite () {
       assertEqual(props.cleanupIntervalStep, 456);
       assertTrue(Math.abs(props.consolidationPolicy.threshold - 0.3) < 0.001);
       assertEqual(props.consolidationPolicy.type, "bytes_accum");
-    }
+    },
 
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test whether the test collection has been restored
+////////////////////////////////////////////////////////////////////////////////
+    testSmartGraphAttribute : function () {
+      assertEqual(db.UnitTestRestoreSmartGraphRegressionVertices.toArray().length, 1);
+      let doc = db.UnitTestRestoreSmartGraphRegressionVertices.toArray()[0];
+      assertEqual(doc.cheesyness, "bread");
+      assertTrue(doc._key.startsWith("cheese:"));
+    },
   };
 
 }
@@ -815,4 +824,3 @@ if (isEnterprise) {
 }
 
 return jsunity.done();
-

--- a/tests/js/server/dump/dump-rocksdb-cluster.js
+++ b/tests/js/server/dump/dump-rocksdb-cluster.js
@@ -808,6 +808,16 @@ function dumpTestEnterpriseSuite () {
       assertEqual("test", db._jobs.document("test")._key);
       assertEqual("test", db._queues.document("test")._key);
     },
+  
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test whether the test collection has been restored
+////////////////////////////////////////////////////////////////////////////////
+    testSmartGraphAttribute : function () {
+      assertEqual(db.UnitTestRestoreSmartGraphRegressionVertices.toArray().length, 1);
+      let doc = db.UnitTestRestoreSmartGraphRegressionVertices.toArray()[0];
+      assertEqual(doc.cheesyness, "bread");
+      assertTrue(doc._key.startsWith("cheese:"));
+    },
   };
 }
 


### PR DESCRIPTION
Backport of #11095.

Note that the actual fix is in the enterprise repository, this just adds a regression test.