### PR TITLE
[3.5] Fix restore for smart collections 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,16 @@
 v3.5.5 (XXXX-XX-XX)
 -------------------
 
+* Fix arangorestore:
+  If a smartGraphAttribute value was changed after document creation,
+  the _key of the document becomes inconsistent with the smartGraphAttribute
+  entry. However, the sharding of documents stays intact.
+
+  When restoring data from a dump that contains a document with inconsistent
+  _key and smartGraphAttribute this would cause an error and the document
+  would not be inserted. This is fixed by ignoring this inconsistency in
+  the case of restore.
+
 * Disable "collect-in-cluster" AQL optimizer rule in case a LIMIT node is
   between the COLLECT and the source data. In this case it is not safe to apply
   the distributed collect, as it may alter the results.

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -658,6 +658,7 @@ function hotBackup (options) {
 
 exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
+
   testFns['dump'] = dump;
   defaultFns.push('dump');
 

--- a/tests/js/server/dump/dump-mmfiles-cluster.js
+++ b/tests/js/server/dump/dump-mmfiles-cluster.js
@@ -803,8 +803,17 @@ function dumpTestEnterpriseSuite () {
       assertEqual(props.cleanupIntervalStep, 456);
       assertTrue(Math.abs(props.consolidationPolicy.threshold - 0.3) < 0.001);
       assertEqual(props.consolidationPolicy.type, "bytes_accum");
-    }
+    },
 
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test whether the test collection has been restored
+////////////////////////////////////////////////////////////////////////////////
+    testSmartGraphAttribute : function () {
+      assertEqual(db.UnitTestRestoreSmartGraphRegressionVertices.toArray().length, 1);
+      let doc = db.UnitTestRestoreSmartGraphRegressionVertices.toArray()[0];
+      assertEqual(doc.cheesyness, "bread");
+      assertTrue(doc._key.startsWith("cheese:"));
+    },
   };
 
 }
@@ -815,4 +824,3 @@ if (isEnterprise) {
 }
 
 return jsunity.done();
-

--- a/tests/js/server/dump/dump-rocksdb-cluster.js
+++ b/tests/js/server/dump/dump-rocksdb-cluster.js
@@ -789,6 +789,16 @@ function dumpTestEnterpriseSuite () {
       assertEqual("test", db._jobs.document("test")._key);
       assertEqual("test", db._queues.document("test")._key);
     },
+  
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test whether the test collection has been restored
+////////////////////////////////////////////////////////////////////////////////
+    testSmartGraphAttribute : function () {
+      assertEqual(db.UnitTestRestoreSmartGraphRegressionVertices.toArray().length, 1);
+      let doc = db.UnitTestRestoreSmartGraphRegressionVertices.toArray()[0];
+      assertEqual(doc.cheesyness, "bread");
+      assertTrue(doc._key.startsWith("cheese:"));
+    },
   };
 }
 

--- a/tests/js/server/dump/dump-setup-cluster.js
+++ b/tests/js/server/dump/dump-setup-cluster.js
@@ -111,7 +111,6 @@ const setupSmartArangoSearch = function () {
   });
 };
 
-
 /**
  * @brief Only if enterprise mode:
  *        Creates a satellite collection with 100 documents
@@ -130,6 +129,43 @@ function setupSatelliteCollections() {
     vDocs.push({value: String(i)});
   }
   db[satelliteCollectionName].save(vDocs);
+}
+
+/**
+ * @brief Only if enterprise mode:
+ *        Creates a smart graph and changes the value of the smart
+ *        attribute to check that the graph can still be restored. 
+ *
+ *        This is a regression test for a bug in which a dumped
+ *        database containing a smart graph with edited smart attribute
+ *        value could not be restored.
+ */
+function setupSmartGraphRegressionTest() {
+  if (!isEnterprise) {
+    return;
+  }
+
+  const smartGraphName = "UnitTestRestoreSmartGraphRegressionTest";
+  const edges = "UnitTestRestoreSmartGraphRegressionEdges";
+  const vertices = "UnitTestRestoreSmartGraphRegressionVertices";
+  const gm = require("@arangodb/smart-graph");
+  if (gm._exists(smartGraphName)) {
+    gm._drop(smartGraphName, true);
+  }
+  db._drop(edges);
+  db._drop(vertices);
+
+  gm._create(smartGraphName, [gm._relation(edges, vertices, vertices)],
+    [], {numberOfShards: 5, smartGraphAttribute: "cheesyness"});
+
+  let vDocs = [{cheesyness: "cheese"}];
+  let saved = db[vertices].save(vDocs).map(v => v._id);
+  let eDocs = [];
+
+  // update smartGraphAttribute. This makes _key inconsistent
+  // and on dump/restore used to throw an error. We now ignore
+  // that error
+  db._update(saved[0], { cheesyness: "bread" });  
 }
 
 (function () {
@@ -302,6 +338,7 @@ function setupSatelliteCollections() {
   setupSmartGraph();
   setupSmartArangoSearch();
   setupSatelliteCollections();
+  setupSmartGraphRegressionTest();
 
   db._create("UnitTestsDumpReplicationFactor1", { replicationFactor: 1, numberOfShards: 7 });
   db._create("UnitTestsDumpReplicationFactor2", { replicationFactor: 2, numberOfShards: 6 });


### PR DESCRIPTION
Backport (maybe) of (#11095)

*Note* that the actual fix ~(if needed)~ is in the enterprise repository.

This only adds a regression test.