### PR TITLE
fix some test memleaks, slightly optimize LEVENSHTEIN_DISTANCE function

### DIFF
--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -1558,19 +1558,22 @@ AqlValue Functions::LevenshteinDistance(ExpressionContext*, transaction::Methods
   AqlValue const& value1 = extractFunctionParameterValue(parameters, 0);
   AqlValue const& value2 = extractFunctionParameterValue(parameters, 1);
 
-  // FIXME: there is only one shared stringbuffer instance
-  transaction::StringBufferLeaser buffer1(trx);
-  transaction::StringBufferLeaser buffer2(trx);
+  // we use one buffer to stringify both arguments
+  transaction::StringBufferLeaser buffer(trx);
+  arangodb::basics::VPackStringBufferAdapter adapter(buffer->stringBuffer());
 
-  arangodb::basics::VPackStringBufferAdapter adapter1(buffer1->stringBuffer());
-  arangodb::basics::VPackStringBufferAdapter adapter2(buffer2->stringBuffer());
+  // stringify argument 1
+  ::appendAsString(trx, adapter, value1);
 
-  ::appendAsString(trx, adapter1, value1);
-  ::appendAsString(trx, adapter2, value2);
+  // note split position
+  size_t const split = buffer->length();
+
+  // stringify argument 2
+  ::appendAsString(trx, adapter, value2);
 
   int encoded = basics::StringUtils::levenshteinDistance(
-      std::string(buffer1->begin(), buffer1->length()),
-      std::string(buffer2->begin(), buffer2->length()));
+      buffer->begin(), split,
+      buffer->begin() + split, buffer->length() - split);
 
   return AqlValue(AqlValueHintInt(encoded));
 }

--- a/arangod/Transaction/Context.cpp
+++ b/arangod/Transaction/Context.cpp
@@ -141,7 +141,7 @@ basics::StringBuffer* transaction::Context::leaseStringBuffer(size_t initialSize
 }
 
 /// @brief return a temporary StringBuffer object
-void transaction::Context::returnStringBuffer(basics::StringBuffer* stringBuffer) {
+void transaction::Context::returnStringBuffer(basics::StringBuffer* stringBuffer) noexcept {
   _stringBuffer.reset(stringBuffer);
 }
 
@@ -160,7 +160,7 @@ std::string* transaction::Context::leaseString() {
 }
 
 /// @brief return a temporary std::string object
-void transaction::Context::returnString(std::string* str) {
+void transaction::Context::returnString(std::string* str) noexcept {
   try {  // put string back into our vector of strings
     _strings.push_back(str);
   } catch (...) {
@@ -185,7 +185,7 @@ VPackBuilder* transaction::Context::leaseBuilder() {
 }
 
 /// @brief return a temporary Builder object
-void transaction::Context::returnBuilder(VPackBuilder* builder) {
+void transaction::Context::returnBuilder(VPackBuilder* builder) noexcept {
   try {
     // put builder back into our vector of builders
     _builders.push_back(builder);

--- a/arangod/Transaction/Context.h
+++ b/arangod/Transaction/Context.h
@@ -84,19 +84,19 @@ class Context {
   basics::StringBuffer* leaseStringBuffer(size_t initialSize);
 
   /// @brief return a temporary StringBuffer object
-  void returnStringBuffer(basics::StringBuffer* stringBuffer);
+  void returnStringBuffer(basics::StringBuffer* stringBuffer) noexcept;
   
   /// @brief temporarily lease a std::string
   std::string* leaseString();
 
   /// @brief return a temporary std::string object
-  void returnString(std::string* str);
+  void returnString(std::string* str) noexcept;
 
   /// @brief temporarily lease a Builder object
   arangodb::velocypack::Builder* leaseBuilder();
 
   /// @brief return a temporary Builder object
-  void returnBuilder(arangodb::velocypack::Builder*);
+  void returnBuilder(arangodb::velocypack::Builder*) noexcept;
 
   /// @brief get velocypack options with a custom type handler
   TEST_VIRTUAL arangodb::velocypack::Options* getVPackOptions();

--- a/lib/Basics/StringUtils.cpp
+++ b/lib/Basics/StringUtils.cpp
@@ -989,24 +989,23 @@ std::string soundex(std::string const& str) {
   return soundex(str.data(), str.size());
 }
 
-unsigned int levenshteinDistance(std::string const& str1, std::string const& str2) {
+unsigned int levenshteinDistance(char const* s1, size_t l1, char const* s2, size_t l2) {
   // convert input strings to vectors of (multi-byte) character numbers
-  std::vector<uint32_t> vect1 = characterCodes(str1);
-  std::vector<uint32_t> vect2 = characterCodes(str2);
+  std::vector<uint32_t> vect1 = characterCodes(s1, l1);
+  std::vector<uint32_t> vect2 = characterCodes(s2, l2);
 
   // calculate levenshtein distance on vectors of character numbers
   return static_cast<unsigned int>(::levenshteinDistance(vect1, vect2));
 }
 
-std::vector<uint32_t> characterCodes(std::string const& str) {
-  char const* s = str.data();
-  char const* e = s + str.size();
+std::vector<uint32_t> characterCodes(char const* s, size_t length) {
+  char const* e = s + length;
 
   std::vector<uint32_t> charNums;
   // be conservative, and reserve space for one number of input
   // string byte. this may be too much, but it avoids later
   // reallocation of the vector
-  charNums.reserve(str.size());
+  charNums.reserve(length);
 
   while (s < e) {
     // note: consume advances the *s* pointer by one byte
@@ -1046,6 +1045,14 @@ std::vector<uint32_t> characterCodes(std::string const& str) {
   }
 
   return charNums;
+}
+
+std::vector<uint32_t> characterCodes(std::string const& str) {
+  return characterCodes(str.data(), str.size());
+}
+
+unsigned int levenshteinDistance(std::string const& str1, std::string const& str2) {
+  return levenshteinDistance(str1.data(), str1.size(), str2.data(), str2.size());
 }
 
 // .............................................................................

--- a/lib/Basics/StringUtils.h
+++ b/lib/Basics/StringUtils.h
@@ -215,9 +215,11 @@ std::string soundex(std::string const& str);
 std::string soundex(char const* src, size_t len);
 
 /// @brief converts input string to vector of character codes
+std::vector<uint32_t> characterCodes(char const* s, size_t length);
 std::vector<uint32_t> characterCodes(std::string const& str);
 
 /// @brief calculates the levenshtein distance between the input strings
+unsigned int levenshteinDistance(char const* s1, size_t l1, char const* s2, size_t l2);
 unsigned int levenshteinDistance(std::string const& str1, std::string const& str2);
 
 /// @brief calculates the levenshtein distance between the input strings

--- a/tests/Aql/JaccardFunctionTest.cpp
+++ b/tests/Aql/JaccardFunctionTest.cpp
@@ -71,7 +71,13 @@ AqlValue evaluate(char const* lhs, char const* rhs) {
   auto const lhsJson = arangodb::velocypack::Parser::fromJson(lhs);
   auto const rhsJson = arangodb::velocypack::Parser::fromJson(rhs);
 
-  return evaluate(AqlValue(lhsJson->slice()), AqlValue(rhsJson->slice()));
+  AqlValue lhsValue(lhsJson->slice());
+  AqlValueGuard lhsGuard(lhsValue, true);
+  
+  AqlValue rhsValue(rhsJson->slice());
+  AqlValueGuard rhsGuard(rhsValue, true);
+
+  return evaluate(lhsValue, rhsValue);
 }
 
 void assertJaccardFail(char const* lhs, char const* rhs) {


### PR DESCRIPTION
### Scope & Purpose

Fix memleaks in Jaccard function tests
Slightly optimize LEVENSHTEIN_DISTANCE function performance

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *shell_server_aql*, *catch*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8704/