### PR TITLE
Feature/aql performance improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,31 @@
 devel
 -----
 
+* Added traversal options `vertexCollections` and `edgeCollections` to restrict
+  traversal to certain vertex or edge collections.
+
+  The use case for `vertexCollections` is to not follow any edges that will point
+  to other than the specified vertex collections, e.g.
+
+      FOR v, e, p IN 1..3 OUTBOUND 'products/123' components 
+        OPTIONS { vertexCollections: [ "bolts", "screws" ] }
+
+  The traversal's start vertex is always considered valid, regardless of whether
+  it is present in the `vertexCollections` option.
+
+  The use case for `edgeCollections` is to not take into consideration any edges
+  from edge collections other than the specified ones, e.g.
+      
+      FOR v, e, p IN 1..3 OUTBOUND 'products/123' GRAPH 'components' 
+        OPTIONS { edgeCollections: [ "productsToBotls", "productsToScrews" ] }
+
+  This is mostly useful in the context of named graphs, when the named graph
+  contains many edge collections. Not restricting the edge collections for the
+  traversal will make the traversal search for edges in all edge collections of
+  the graph, which can be expensive. In case it is known that only certain edges
+  from the named graph are needed, the `edgeCollections` option can be a handy
+  performance optimization.
+
 * In some cases with a COLLECT LIMIT situation on a small limit the collect
   does more calls to upstream than without a limit to provide the same
   result. We improved this situation and made sure that LIMIT does

--- a/arangod/Aql/AqlItemBlockManager.h
+++ b/arangod/Aql/AqlItemBlockManager.h
@@ -29,7 +29,7 @@
 #include "Basics/Common.h"
 
 #include <array>
-#include <cstddef>
+#include <cstdint>
 
 namespace arangodb {
 
@@ -69,7 +69,7 @@ class AqlItemBlockManager {
   // SharedAqlItemBlockPtr which in turn call returnBlock()!
   static void deleteBlock(AqlItemBlock* block);
 
-  static size_t getBucketId(size_t targetSize) noexcept;
+  static uint32_t getBucketId(size_t targetSize) noexcept;
 #endif
 
 #ifndef ARANGODB_USE_GOOGLE_TESTS
@@ -86,7 +86,7 @@ class AqlItemBlockManager {
   ResourceMonitor* _resourceMonitor;
   SerializationFormat const _format;
 
-  static constexpr size_t numBuckets = 12;
+  static constexpr uint32_t numBuckets = 12;
   static constexpr size_t numBlocksPerBucket = 7;
 
   struct Bucket {
@@ -104,7 +104,7 @@ class AqlItemBlockManager {
 
     void push(AqlItemBlock* block) noexcept;
 
-    static size_t getId(size_t targetSize) noexcept;
+    static uint32_t getId(size_t targetSize) noexcept;
   };
 
   Bucket _buckets[numBuckets];

--- a/arangod/Aql/AqlItemBlockManager.h
+++ b/arangod/Aql/AqlItemBlockManager.h
@@ -68,6 +68,8 @@ class AqlItemBlockManager {
   // Only used for the mocks in the catch tests. Other code should always use
   // SharedAqlItemBlockPtr which in turn call returnBlock()!
   static void deleteBlock(AqlItemBlock* block);
+
+  static size_t getBucketId(size_t targetSize) noexcept;
 #endif
 
 #ifndef ARANGODB_USE_GOOGLE_TESTS

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -375,10 +375,20 @@ int arangodb::aql::CompareAstNodes(AstNode const* lhs, AstNode const* rhs, bool 
       // afford the inefficiency to convert the node to VPack
       // for comparison (this saves us from writing our own compare function
       // for array AstNodes)
-      auto l = lhs->toVelocyPackValue();
-      auto r = rhs->toVelocyPackValue();
+      VPackBuilder builder;
+      // add the first Slice to the Builder
+      lhs->toVelocyPackValue(builder);
 
-      return basics::VelocyPackHelper::compare(l->slice(), r->slice(), compareUtf8);
+      // note the length of the first Slice
+      VPackValueLength split = builder.size();
+
+      // add the second Slice to the same Builder
+      rhs->toVelocyPackValue(builder);
+
+      return basics::VelocyPackHelper::compare(
+          builder.slice() /*lhs*/, 
+          VPackSlice(builder.start() + split) /*rhs*/, 
+          compareUtf8);
     }
 
     default: {
@@ -862,7 +872,9 @@ std::ostream& AstNode::toStream(std::ostream& os, int level) const {
   os << "- " << getTypeString();
 
   if (type == NODE_TYPE_VALUE || type == NODE_TYPE_ARRAY) {
-    os << ": " << toVelocyPackValue().get()->toJson();
+    VPackBuilder b;
+    toVelocyPackValue(b);
+    os << ": " << b.toJson();
   } else if (type == NODE_TYPE_ATTRIBUTE_ACCESS) {
     os << ": " << getString();
   } else if (type == NODE_TYPE_REFERENCE) {
@@ -971,16 +983,6 @@ AstNodeType AstNode::getNodeTypeFromVPack(arangodb::velocypack::Slice const& sli
   return static_cast<AstNodeType>(type);
 }
 
-/// @brief return a VelocyPack representation of the node value
-std::shared_ptr<VPackBuilder> AstNode::toVelocyPackValue() const {
-  auto builder = std::make_shared<VPackBuilder>();
-  if (builder == nullptr) {
-    return nullptr;
-  }
-  toVelocyPackValue(*builder);
-  return builder;
-}
-
 /// @brief build a VelocyPack representation of the node value
 ///        Can throw Out of Memory Error
 void AstNode::toVelocyPackValue(VPackBuilder& builder) const {
@@ -1045,18 +1047,18 @@ void AstNode::toVelocyPackValue(VPackBuilder& builder) const {
 
   if (type == NODE_TYPE_ATTRIBUTE_ACCESS) {
     // TODO Could this be done more efficiently in the builder in place?
-    auto tmp = getMember(0)->toVelocyPackValue();
-    if (tmp != nullptr) {
-      VPackSlice slice = tmp->slice();
-      if (slice.isObject()) {
-        slice = slice.get(getString());
-        if (!slice.isNone()) {
-          builder.add(slice);
-          return;
-        }
+    VPackBuilder tmp;
+    getMember(0)->toVelocyPackValue(tmp);
+
+    VPackSlice slice = tmp.slice();
+    if (slice.isObject()) {
+      slice = slice.get(getString());
+      if (!slice.isNone()) {
+        builder.add(slice);
+        return;
       }
-      builder.add(VPackValue(VPackValueType::Null));
     }
+    builder.add(VPackValue(VPackValueType::Null));
   }
 
   // Do not add anything.

--- a/arangod/Aql/AstNode.h
+++ b/arangod/Aql/AstNode.h
@@ -285,9 +285,6 @@ struct AstNode {
   /// @brief fetch a node's type from VPack
   static AstNodeType getNodeTypeFromVPack(arangodb::velocypack::Slice const& slice);
 
-  /// @brief return a VelocyPack representation of the node value
-  std::shared_ptr<arangodb::velocypack::Builder> toVelocyPackValue() const;
-
   /// @brief build a VelocyPack representation of the node value
   ///        Can throw Out of Memory Error
   void toVelocyPackValue(arangodb::velocypack::Builder&) const;

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -118,6 +118,26 @@ uint64_t checkTraversalDepthValue(AstNode const* node) {
   return static_cast<uint64_t>(v);
 }
 
+void parseGraphCollectionRestriction(std::vector<std::string>& collections, AstNode const* src) {
+  if (src->isStringValue()) {
+    collections.emplace_back(src->getString());
+  } else if (src->type == NODE_TYPE_ARRAY) {
+    size_t const n = src->numMembers();
+    collections.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+      AstNode const* c = src->getMemberUnchecked(i);
+      if (!c->isStringValue()) {
+        THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
+            "collection restrictions option must be either a string or an array of collection names");
+      }
+      collections.emplace_back(c->getStringValue(), c->getStringLength());
+    }
+  } else {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
+        "collection restrictions option must be either a string or an array of collection names");
+  }
+}
+
 std::unique_ptr<graph::BaseOptions> createTraversalOptions(aql::Query* query,
                                                            AstNode const* direction,
                                                            AstNode const* optionsNode) {
@@ -180,20 +200,10 @@ std::unique_ptr<graph::BaseOptions> createTraversalOptions(aql::Query* query,
                 "due to unpredictable results. Use 'path' "
                 "or 'none' instead");
           }
+        } else if (name == "edgeCollections") {
+          parseGraphCollectionRestriction(options->edgeCollections, value);
         } else if (name == "vertexCollections") {
-          if (value->isStringValue()) {
-            options->vertexCollections.emplace_back(value->getStringValue(),
-                                                    value->getStringLength());
-          } else if (value->isArray()) {
-            for (size_t j = 0; j < value->numMembers(); j++) {
-              AstNode const* member = value->getMember(j);
-              if (member->type == AstNodeType::NODE_TYPE_VALUE &&
-                  member->value.type == AstNodeValueType::VALUE_TYPE_STRING) {
-                options->vertexCollections.emplace_back(member->getStringValue(),
-                                                        member->getStringLength());
-              }
-            }
-          }
+          parseGraphCollectionRestriction(options->vertexCollections, value);
         }
       }
     }

--- a/arangod/Aql/GraphNode.cpp
+++ b/arangod/Aql/GraphNode.cpp
@@ -142,6 +142,11 @@ GraphNode::GraphNode(ExecutionPlan* plan, size_t id, TRI_vocbase_t* vocbase,
 
       std::string eColName = col->getString();
 
+      if (_options->shouldExcludeEdgeCollection(eColName)) {
+        // excluded edge collection
+        continue;
+      }
+
       // now do some uniqueness checks for the specified collections
       auto [it, inserted] = seenCollections.try_emplace(eColName, dir);
       if (!inserted) {
@@ -197,7 +202,7 @@ GraphNode::GraphNode(ExecutionPlan* plan, size_t id, TRI_vocbase_t* vocbase,
     if (length == 0) {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_GRAPH_EMPTY);
     }
-
+      
     // First determine whether all edge collections are smart and sharded
     // like a common collection:
     auto& ci = _vocbase->server().getFeature<ClusterFeature>().clusterInfo();
@@ -220,6 +225,11 @@ GraphNode::GraphNode(ExecutionPlan* plan, size_t id, TRI_vocbase_t* vocbase,
     }
 
     for (const auto& n : eColls) {
+      if (_options->shouldExcludeEdgeCollection(n)) {
+        // excluded edge collection
+        continue;
+      }
+
       if (ServerState::instance()->isRunningInCluster()) {
         auto c = ci.getCollection(_vocbase->name(), n);
         if (!c->isSmart()) {

--- a/arangod/Aql/GraphNode.cpp
+++ b/arangod/Aql/GraphNode.cpp
@@ -627,7 +627,7 @@ Variable const* GraphNode::vertexOutVariable() const {
 }
 
 bool GraphNode::usesVertexOutVariable() const {
-  return _vertexOutVariable != nullptr;
+  return _vertexOutVariable != nullptr && _options->produceVertices();
 }
 
 void GraphNode::setVertexOutput(Variable const* outVar) {

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -5790,7 +5790,6 @@ void arangodb::aql::optimizeTraversalsRule(Optimizer* opt,
     // out variable can contain the "vertices" sub attribute)
     auto outVariable = traversal->vertexOutVariable();
 
-#ifdef USE_ENTERPRISE
     if (outVariable != nullptr && !n->isVarUsedLater(outVariable) &&
         std::find(pruneVars.begin(), pruneVars.end(), outVariable) == pruneVars.end()) {
       outVariable = traversal->pathOutVariable();
@@ -5802,7 +5801,6 @@ void arangodb::aql::optimizeTraversalsRule(Optimizer* opt,
         modified = true;
       }
     }
-#endif
 
     outVariable = traversal->edgeOutVariable();
     if (outVariable != nullptr && !n->isVarUsedLater(outVariable) &&

--- a/arangod/Aql/RegisterPlan.cpp
+++ b/arangod/Aql/RegisterPlan.cpp
@@ -113,12 +113,13 @@ void RegisterPlan::after(ExecutionNode* en) {
       totalNrRegs++;
       break;
     }
-    case ExecutionNode::INDEX: {
-        auto ep = ExecutionNode::castTo<IndexNode const*>(en);
-        TRI_ASSERT(ep);
 
-        ep->planNodeRegisters(nrRegsHere, nrRegs, varInfo, totalNrRegs, ++depth);
-        break;
+    case ExecutionNode::INDEX: {
+      auto ep = ExecutionNode::castTo<IndexNode const*>(en);
+      TRI_ASSERT(ep);
+
+      ep->planNodeRegisters(nrRegsHere, nrRegs, varInfo, totalNrRegs, ++depth);
+      break;
     }
 
     case ExecutionNode::ENUMERATE_LIST: {

--- a/arangod/Aql/RegisterPlan.h
+++ b/arangod/Aql/RegisterPlan.h
@@ -28,7 +28,6 @@
 #include "Aql/WalkerWorker.h"
 #include "Aql/types.h"
 #include "Basics/Common.h"
-#include "Basics/debugging.h"
 
 #include <memory>
 
@@ -102,10 +101,6 @@ struct RegisterPlan final : public WalkerWorker<ExecutionNode> {
   /// @brief maximum register id that can be assigned, plus one.
   /// this is used for assertions
   static constexpr RegisterId MaxRegisterId = 1000;
-
-  /// @brief reserved register id for subquery depth. Needs to
-  ///        be present in all AqlItemMatrixes.
-  static constexpr RegisterId SUBQUERY_DEPTH_REGISTER = 0;
 };
 
 }  // namespace aql

--- a/arangod/Graph/BaseOptions.h
+++ b/arangod/Graph/BaseOptions.h
@@ -132,6 +132,10 @@ struct BaseOptions {
   /// @brief Estimate the total cost for this operation
   virtual double estimateCost(size_t& nrItems) const = 0;
 
+  /// @brief whether or not an edge collection shall be excluded
+  /// this can be overridden in TraverserOptions
+  virtual bool shouldExcludeEdgeCollection(std::string const& name) const { return false; }
+
   TraverserCache* cache();
 
   void activateCache(bool enableDocumentCache,

--- a/arangod/Graph/TraverserOptions.h
+++ b/arangod/Graph/TraverserOptions.h
@@ -83,6 +83,8 @@ struct TraverserOptions : public graph::BaseOptions {
   UniquenessLevel uniqueEdges;
 
   std::vector<std::string> vertexCollections;
+  
+  std::vector<std::string> edgeCollections;
 
   explicit TraverserOptions(aql::Query* query);
 
@@ -107,6 +109,9 @@ struct TraverserOptions : public graph::BaseOptions {
   /// @brief Build a velocypack containing all relevant information
   ///        for DBServer traverser engines.
   void buildEngineInfo(arangodb::velocypack::Builder&) const override;
+  
+  /// @brief Whether or not the edge collection shall be excluded
+  bool shouldExcludeEdgeCollection(std::string const& name) const override;
 
   /// @brief Add a lookup info for specific depth
   void addDepthLookupInfo(aql::ExecutionPlan* plan, std::string const& collectionName,

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -1203,6 +1203,8 @@ function processQuery(query, explain, planIndex) {
           } else {
             parts.push(variableName(node.vertexOutVariable) + '  ' + annotation('/* vertex */'));
           }
+        } else {
+          parts.push(annotation('/* vertex optimized away */'));
         }
         if (node.hasOwnProperty('edgeOutVariable')) {
           parts.push(variableName(node.edgeOutVariable) + '  ' + annotation('/* edge */'));

--- a/lib/Basics/NumberUtils.cpp
+++ b/lib/Basics/NumberUtils.cpp
@@ -42,7 +42,7 @@ uint32_t log2(uint32_t value) noexcept {
   return (8 * sizeof(unsigned long)) - static_cast<uint32_t>(__builtin_clzl(static_cast<unsigned long>(value))) - 1;
 #elif defined(_MSC_VER)
   unsigned long index;
-  _BitScanReverse(&idx, static_cast<unsigned long>(value));
+  _BitScanReverse(&index, static_cast<unsigned long>(value));
   return static_cast<uint32_t>(index);
 #else
   static_assert(false, "no known way of computing log2");

--- a/lib/Basics/NumberUtils.cpp
+++ b/lib/Basics/NumberUtils.cpp
@@ -1,0 +1,53 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2016 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#include "NumberUtils.h"
+#include "Basics/debugging.h"
+
+#ifdef _MSC_VER
+#include <intrin.h>
+
+#pragma intrinsic(_BitScanReverse)
+#endif
+
+namespace arangodb {
+namespace NumberUtils {
+
+/// @brief calculate the integer log2 value for the given input
+/// the result is undefined when calling this with a value of 0!
+uint32_t log2(uint32_t value) noexcept {
+  TRI_ASSERT(value > 0);
+
+#if (defined(__GNUC__) || defined(__clang__))
+  return (8 * sizeof(unsigned long)) - static_cast<uint32_t>(__builtin_clzl(static_cast<unsigned long>(value))) - 1;
+#elif defined(_MSC_VER)
+  unsigned long index;
+  _BitScanReverse(&idx, static_cast<unsigned long>(value));
+  return static_cast<uint32_t>(index);
+#else
+  static_assert(false, "no known way of computing log2");
+#endif
+}
+
+}
+}

--- a/lib/Basics/NumberUtils.h
+++ b/lib/Basics/NumberUtils.h
@@ -27,6 +27,7 @@
 #include "Basics/Common.h"
 #include "Basics/system-compiler.h"
 
+#include <cstdint>
 #include <limits>
 #include <type_traits>
 
@@ -249,6 +250,10 @@ inline T atoi_zero(char const* p, char const* e) noexcept {
   T result = atoi<T>(p, e, valid);
   return valid ? result : 0;
 }
+
+/// @brief calculate the integer log2 value for the given input
+/// the result is undefined when calling this with a value of 0!
+uint32_t log2(uint32_t value) noexcept;
 
 }  // namespace NumberUtils
 }  // namespace arangodb

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -114,6 +114,7 @@ add_library(arango STATIC
   Basics/ConditionVariable.cpp
   Basics/CrashHandler.cpp
   Basics/DataProtector.cpp
+  Basics/EncodingUtils.cpp
   Basics/Exceptions.cpp
   Basics/FileUtils.cpp
   Basics/FunctionUtils.cpp
@@ -122,6 +123,7 @@ add_library(arango STATIC
   Basics/LocalTaskQueue.cpp
   Basics/Mutex.cpp
   Basics/Nonce.cpp
+  Basics/NumberUtils.cpp
   Basics/PageSize.cpp
   Basics/PhysicalMemory.cpp
   Basics/ReadWriteLock.cpp
@@ -145,7 +147,6 @@ add_library(arango STATIC
   Basics/csv.cpp
   Basics/datetime.cpp
   Basics/debugging.cpp
-  Basics/EncodingUtils.cpp
   Basics/error.cpp
   Basics/fasthash.cpp
   Basics/files.cpp

--- a/tests/Aql/AqlItemBlockTest.cpp
+++ b/tests/Aql/AqlItemBlockTest.cpp
@@ -95,6 +95,46 @@ class AqlItemBlockTest : public ::testing::Test {
   }
 };
 
+TEST_F(AqlItemBlockTest, test_get_block_id) {
+  EXPECT_EQ(itemBlockManager.getBucketId(0), 0);
+  EXPECT_EQ(itemBlockManager.getBucketId(1), 0);
+  EXPECT_EQ(itemBlockManager.getBucketId(2), 1);
+  EXPECT_EQ(itemBlockManager.getBucketId(3), 1);
+  EXPECT_EQ(itemBlockManager.getBucketId(4), 2);
+  EXPECT_EQ(itemBlockManager.getBucketId(5), 2);
+  EXPECT_EQ(itemBlockManager.getBucketId(6), 2);
+  EXPECT_EQ(itemBlockManager.getBucketId(7), 2);
+  EXPECT_EQ(itemBlockManager.getBucketId(8), 3);
+  EXPECT_EQ(itemBlockManager.getBucketId(9), 3);
+  EXPECT_EQ(itemBlockManager.getBucketId(10), 3);
+  EXPECT_EQ(itemBlockManager.getBucketId(15), 3);
+  EXPECT_EQ(itemBlockManager.getBucketId(16), 4);
+  EXPECT_EQ(itemBlockManager.getBucketId(31), 4);
+  EXPECT_EQ(itemBlockManager.getBucketId(32), 5);
+  EXPECT_EQ(itemBlockManager.getBucketId(63), 5);
+  EXPECT_EQ(itemBlockManager.getBucketId(64), 6);
+  EXPECT_EQ(itemBlockManager.getBucketId(100), 6);
+  EXPECT_EQ(itemBlockManager.getBucketId(127), 6);
+  EXPECT_EQ(itemBlockManager.getBucketId(128), 7);
+  EXPECT_EQ(itemBlockManager.getBucketId(255), 7);
+  EXPECT_EQ(itemBlockManager.getBucketId(256), 8);
+  EXPECT_EQ(itemBlockManager.getBucketId(511), 8);
+  EXPECT_EQ(itemBlockManager.getBucketId(512), 9);
+  EXPECT_EQ(itemBlockManager.getBucketId(1000), 9);
+  EXPECT_EQ(itemBlockManager.getBucketId(1023), 9);
+  EXPECT_EQ(itemBlockManager.getBucketId(1024), 10);
+  EXPECT_EQ(itemBlockManager.getBucketId(2048), 11);
+  EXPECT_EQ(itemBlockManager.getBucketId(4095), 11);
+  EXPECT_EQ(itemBlockManager.getBucketId(4096), 11);
+  EXPECT_EQ(itemBlockManager.getBucketId(4097), 11);
+  EXPECT_EQ(itemBlockManager.getBucketId(5000), 11);
+  EXPECT_EQ(itemBlockManager.getBucketId(8192), 11);
+  EXPECT_EQ(itemBlockManager.getBucketId(10000), 11);
+  EXPECT_EQ(itemBlockManager.getBucketId(100000), 11);
+  EXPECT_EQ(itemBlockManager.getBucketId(1000000), 11);
+  EXPECT_EQ(itemBlockManager.getBucketId(10000000), 11);
+}
+
 TEST_F(AqlItemBlockTest, test_read_values_reference) {
   auto block = buildBlock<2>(itemBlockManager, {{{{1}, {2}}}, {{{3}, {4}}}});
   EXPECT_EQ(block->getValueReference(0, 0).toInt64(), 1);

--- a/tests/js/server/aql/aql-optimizer-rule-optimize-traversals-spec.js
+++ b/tests/js/server/aql/aql-optimizer-rule-optimize-traversals-spec.js
@@ -114,12 +114,12 @@ describe('Rule optimize-traversals', () => {
 
   it('should remove unused variables', () => {
     const queries = [
-      [ `FOR v, e, p IN 1..5 OUTBOUND 'circles/A' GRAPH '${graphName}' RETURN 1`, true, [ true, false, false ] ],
+      [ `FOR v, e, p IN 1..5 OUTBOUND 'circles/A' GRAPH '${graphName}' RETURN 1`, true, [ false, false, false ] ],
       [ `FOR v, e, p IN 1..5 OUTBOUND 'circles/A' GRAPH '${graphName}' RETURN [v, e]`, true, [ true, true, false ] ],
       [ `FOR v, e, p IN 1..5 OUTBOUND 'circles/A' GRAPH '${graphName}' RETURN [v, p]`, true, [ true, false, true ] ],
       [ `FOR v, e, p IN 1..5 OUTBOUND 'circles/A' GRAPH '${graphName}' RETURN [e, p]`, false, [ true, true, true ] ],
       [ `FOR v, e, p IN 1..5 OUTBOUND 'circles/A' GRAPH '${graphName}' RETURN [v]`, true, [ true, false, false ] ],
-      [ `FOR v, e, p IN 1..5 OUTBOUND 'circles/A' GRAPH '${graphName}' RETURN [e]`, true, [ true, true, false ] ],
+      [ `FOR v, e, p IN 1..5 OUTBOUND 'circles/A' GRAPH '${graphName}' RETURN [e]`, true, [ false, true, false ] ],
       [ `FOR v, e, p IN 1..5 OUTBOUND 'circles/A' GRAPH '${graphName}' RETURN [p]`, true, [ true, false, true ] ],
       [ `FOR v, e IN 1..5 OUTBOUND 'circles/A' GRAPH '${graphName}' RETURN [v, e]`, false, [ true, true, false ] ],
       [ `FOR v, e IN 1..5 OUTBOUND 'circles/A' GRAPH '${graphName}' RETURN [v]`, true, [ true, false, false ] ],

--- a/tests/js/server/aql/aql-traversal-restrict-edge-collections.js
+++ b/tests/js/server/aql/aql-traversal-restrict-edge-collections.js
@@ -1,0 +1,234 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global AQL_EXPLAIN, assertEqual, assertNotEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief tests for regression returning blocks to the manager
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2014 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2020, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const internal = require("internal");
+const db = require("@arangodb").db;
+const isCoordinator = require('@arangodb/cluster').isCoordinator();
+const isEnterprise = require("internal").isEnterprise();
+
+function edgeCollectionRestrictionSuite() {
+  const vn = "UnitTestsVertex";
+  const en = "UnitTestsEdges";
+  const gn = "UnitTestsGraph";
+
+  let fillGraph = function () {
+    let keys = [];
+    let v = db._collection(vn);
+    for (let i = 0; i < 10; ++i) {
+      keys.push(v.insert({ value: i })._key);
+    }
+
+    let e1 = db._collection(en + "1");
+    e1.insert({ _from: vn + "/" + keys[0], _to: vn + "/" + keys[1] });
+    e1.insert({ _from: vn + "/" + keys[1], _to: vn + "/" + keys[2] });
+    e1.insert({ _from: vn + "/" + keys[2], _to: vn + "/" + keys[3] });
+    e1.insert({ _from: vn + "/" + keys[3], _to: vn + "/" + keys[4] });
+    e1.insert({ _from: vn + "/" + keys[4], _to: vn + "/" + keys[5] });
+    
+    let e2 = db._collection(en + "2");
+    e2.insert({ _from: vn + "/" + keys[0], _to: vn + "/" + keys[6] });
+    e2.insert({ _from: vn + "/" + keys[1], _to: vn + "/" + keys[7] });
+    e2.insert({ _from: vn + "/" + keys[7], _to: vn + "/" + keys[8] });
+    e2.insert({ _from: vn + "/" + keys[8], _to: vn + "/" + keys[9] });
+
+    return keys;
+  };
+
+  let runTests = function (checkOptimizerRule) {
+    let keys = fillGraph();
+
+    let queries = [
+      [ `WITH ${vn} FOR v IN 0..0 OUTBOUND "${vn}/${keys[0]}" ${en}1 SORT v._id RETURN DISTINCT v._id`, [ 0 ] ],
+      [ `WITH ${vn} FOR v IN 0..1 OUTBOUND "${vn}/${keys[0]}" ${en}1 SORT v._id RETURN DISTINCT v._id`, [ 0, 1 ] ],
+      [ `WITH ${vn} FOR v IN 1..1 OUTBOUND "${vn}/${keys[0]}" ${en}1 SORT v._id RETURN DISTINCT v._id`, [ 1 ] ],
+      [ `WITH ${vn} FOR v IN 1..2 OUTBOUND "${vn}/${keys[0]}" ${en}1 SORT v._id RETURN DISTINCT v._id`, [ 1, 2 ] ],
+      [ `WITH ${vn} FOR v IN 1..3 OUTBOUND "${vn}/${keys[0]}" ${en}1 SORT v._id RETURN DISTINCT v._id`, [ 1, 2, 3 ] ],
+      [ `WITH ${vn} FOR v IN 0..1 OUTBOUND "${vn}/${keys[0]}" ${en}2 SORT v._id RETURN DISTINCT v._id`, [ 0, 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..1 OUTBOUND "${vn}/${keys[0]}" ${en}2 SORT v._id RETURN DISTINCT v._id`, [ 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..2 OUTBOUND "${vn}/${keys[0]}" ${en}2 SORT v._id RETURN DISTINCT v._id`, [ 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..3 OUTBOUND "${vn}/${keys[0]}" ${en}2 SORT v._id RETURN DISTINCT v._id`, [ 6 ] ],
+      
+      [ `WITH ${vn} FOR v IN 0..0 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 SORT v._id RETURN DISTINCT v._id`, [ 0 ] ],
+      [ `WITH ${vn} FOR v IN 0..1 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 SORT v._id RETURN DISTINCT v._id`, [ 0, 1, 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..1 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 SORT v._id RETURN DISTINCT v._id`, [ 1, 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..2 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 SORT v._id RETURN DISTINCT v._id`, [ 1, 2, 6, 7 ] ],
+      [ `WITH ${vn} FOR v IN 1..3 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 SORT v._id RETURN DISTINCT v._id`, [ 1, 2, 3, 6, 7, 8 ] ],
+      
+      [ `WITH ${vn} FOR v IN 0..0 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" SORT v._id RETURN DISTINCT v._id`, [ 0 ] ],
+      [ `WITH ${vn} FOR v IN 0..1 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" SORT v._id RETURN DISTINCT v._id`, [ 0, 1, 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..1 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" SORT v._id RETURN DISTINCT v._id`, [ 1, 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..2 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" SORT v._id RETURN DISTINCT v._id`, [ 1, 2, 6, 7 ] ],
+      [ `WITH ${vn} FOR v IN 1..3 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" SORT v._id RETURN DISTINCT v._id`, [ 1, 2, 3, 6, 7, 8 ] ],
+      
+      [ `WITH ${vn} FOR v IN 0..0 OUTBOUND "${vn}/${keys[0]}" ${en}1 OPTIONS { edgeCollections: "${en}1" } SORT v._id RETURN DISTINCT v._id`, [ 0 ] ],
+      [ `WITH ${vn} FOR v IN 0..1 OUTBOUND "${vn}/${keys[0]}" ${en}1 OPTIONS { edgeCollections: "${en}1" } SORT v._id RETURN DISTINCT v._id`, [ 0, 1 ] ],
+      [ `WITH ${vn} FOR v IN 1..1 OUTBOUND "${vn}/${keys[0]}" ${en}1 OPTIONS { edgeCollections: "${en}1" } SORT v._id RETURN DISTINCT v._id`, [ 1 ] ],
+      [ `WITH ${vn} FOR v IN 1..2 OUTBOUND "${vn}/${keys[0]}" ${en}1 OPTIONS { edgeCollections: "${en}1" } SORT v._id RETURN DISTINCT v._id`, [ 1, 2 ] ],
+      [ `WITH ${vn} FOR v IN 1..3 OUTBOUND "${vn}/${keys[0]}" ${en}1 OPTIONS { edgeCollections: "${en}1" } SORT v._id RETURN DISTINCT v._id`, [ 1, 2, 3 ] ],
+      [ `WITH ${vn} FOR v IN 0..1 OUTBOUND "${vn}/${keys[0]}" ${en}2 OPTIONs { edgeCollections: "${en}2" } SORT v._id RETURN DISTINCT v._id`, [ 0, 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..1 OUTBOUND "${vn}/${keys[0]}" ${en}2 OPTIONS { edgeCollections: "${en}2" } SORT v._id RETURN DISTINCT v._id`, [ 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..2 OUTBOUND "${vn}/${keys[0]}" ${en}2 OPTIONS { edgeCollections: "${en}2" } SORT v._id RETURN DISTINCT v._id`, [ 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..3 OUTBOUND "${vn}/${keys[0]}" ${en}2 OPTIONS { edgeCollections: "${en}2" } SORT v._id RETURN DISTINCT v._id`, [ 6 ] ],
+      
+      [ `WITH ${vn} FOR v IN 0..0 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 OPTIONS { edgeCollections: [ "${en}1", "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 0 ] ],
+      [ `WITH ${vn} FOR v IN 0..1 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 OPTIONS { edgeCollections: [ "${en}1", "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 0, 1, 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..1 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 OPTIONS { edgeCollections: [ "${en}1", "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 1, 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..2 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 OPTIONS { edgeCollections: [ "${en}1", "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 1, 2, 6, 7 ] ],
+      [ `WITH ${vn} FOR v IN 1..3 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 OPTIONS { edgeCollections: [ "${en}1", "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 1, 2, 3, 6, 7, 8 ] ],
+      
+      [ `WITH ${vn} FOR v IN 0..0 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 OPTIONS { edgeCollections: [ "${en}1" ] } SORT v._id RETURN DISTINCT v._id`, [ 0 ] ],
+      [ `WITH ${vn} FOR v IN 0..0 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 OPTIONS { edgeCollections: [ "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 0 ] ],
+      [ `WITH ${vn} FOR v IN 0..1 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 OPTIONS { edgeCollections: [ "${en}1" ] } SORT v._id RETURN DISTINCT v._id`, [ 0, 1 ] ],
+      [ `WITH ${vn} FOR v IN 0..1 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 OPTIONS { edgeCollections: [ "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 0, 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..1 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 OPTIONS { edgeCollections: [ "${en}1" ] } SORT v._id RETURN DISTINCT v._id`, [ 1 ] ],
+      [ `WITH ${vn} FOR v IN 1..1 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 OPTIONS { edgeCollections: [ "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..2 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 OPTIONS { edgeCollections: [ "${en}1" ] } SORT v._id RETURN DISTINCT v._id`, [ 1, 2 ] ],
+      [ `WITH ${vn} FOR v IN 1..2 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 OPTIONS { edgeCollections: [ "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..3 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 OPTIONS { edgeCollections: [ "${en}1" ] } SORT v._id RETURN DISTINCT v._id`, [ 1, 2, 3 ] ],
+      [ `WITH ${vn} FOR v IN 1..3 OUTBOUND "${vn}/${keys[0]}" ${en}1, ${en}2 OPTIONS { edgeCollections: [ "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 6 ] ],
+      
+      [ `WITH ${vn} FOR v IN 0..0 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" OPTIONS { edgeCollections: [ "${en}1" ] } SORT v._id RETURN DISTINCT v._id`, [ 0 ] ],
+      [ `WITH ${vn} FOR v IN 0..0 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" OPTIONS { edgeCollections: [ "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 0 ] ],
+      [ `WITH ${vn} FOR v IN 0..1 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" OPTIONS { edgeCollections: [ "${en}1" ] } SORT v._id RETURN DISTINCT v._id`, [ 0, 1 ] ],
+      [ `WITH ${vn} FOR v IN 0..1 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" OPTIONS { edgeCollections: [ "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 0, 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..1 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" OPTIONS { edgeCollections: [ "${en}1" ] } SORT v._id RETURN DISTINCT v._id`, [ 1 ] ],
+      [ `WITH ${vn} FOR v IN 1..1 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" OPTIONS { edgeCollections: [ "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..2 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" OPTIONS { edgeCollections: [ "${en}1" ] } SORT v._id RETURN DISTINCT v._id`, [ 1, 2 ] ],
+      [ `WITH ${vn} FOR v IN 1..2 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" OPTIONS { edgeCollections: [ "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..3 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" OPTIONS { edgeCollections: [ "${en}1" ] } SORT v._id RETURN DISTINCT v._id`, [ 1, 2, 3 ] ],
+      [ `WITH ${vn} FOR v IN 1..3 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" OPTIONS { edgeCollections: [ "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 6 ] ],
+      
+      [ `WITH ${vn} FOR v IN 0..0 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" OPTIONS { edgeCollections: [ "${en}1", "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 0 ] ],
+      [ `WITH ${vn} FOR v IN 0..1 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" OPTIONS { edgeCollections: [ "${en}1", "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 0, 1, 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..1 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" OPTIONS { edgeCollections: [ "${en}1", "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 1, 6 ] ],
+      [ `WITH ${vn} FOR v IN 1..2 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" OPTIONS { edgeCollections: [ "${en}1", "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 1, 2, 6, 7 ] ],
+      [ `WITH ${vn} FOR v IN 1..3 OUTBOUND "${vn}/${keys[0]}" GRAPH "${gn}" OPTIONS { edgeCollections: [ "${en}1", "${en}2" ] } SORT v._id RETURN DISTINCT v._id`, [ 1, 2, 3, 6, 7, 8 ] ],
+    ];
+
+    queries.forEach(function(q) {
+      if (checkOptimizerRule !== undefined) {
+        assertNotEqual(-1, AQL_EXPLAIN(q[0]).plan.rules.indexOf(checkOptimizerRule));
+      }
+      const actual = db._query(q[0]).toArray();
+      let expected = [];
+      q[1].forEach(function(e) {
+        expected.push(vn + "/" + keys[e]);
+      });
+      assertEqual(actual, expected, q);
+    });
+  };
+
+  return {
+
+    testBasic : function () {
+      const graphs = require("@arangodb/general-graph");
+      let cleanup = function() {
+        try {
+          graphs._drop(gn, true);
+        } catch (err) {}
+        db._drop(vn);
+        db._drop(en + "1");
+        db._drop(en + "2");
+      };
+      cleanup();
+
+      try {
+        db._create(vn, { numberOfShards: 4 });
+        db._createEdgeCollection(en + "1", { numberOfShards: 4 });
+        db._createEdgeCollection(en + "2", { numberOfShards: 4 });
+
+        graphs._create(gn, [graphs._relation(en + "1", vn, vn), graphs._relation(en + "2", vn, vn)]);
+
+        runTests();
+      } finally {
+        cleanup();
+      }
+    },
+
+    testOneShard : function () {
+      if (!isEnterprise || !isCoordinator) {
+        return;
+      }
+
+      const graphs = require("@arangodb/general-graph");
+      let cleanup = function() {
+        try {
+          graphs._drop(gn, true);
+        } catch (err) {}
+        db._drop(vn);
+        db._drop(en + "1");
+        db._drop(en + "2");
+      };
+      cleanup();
+   
+      try {
+        db._create(vn, { numberOfShards: 1 });
+        db._createEdgeCollection(en + "1", { distributeShardsLike: vn, numberOfShards: 1 });
+        db._createEdgeCollection(en + "2", { distributeShardsLike: vn, numberOfShards: 1 });
+
+        graphs._create(gn, [graphs._relation(en + "1", vn, vn), graphs._relation(en + "2", vn, vn)]);
+
+        runTests("cluster-one-shard");
+      } finally {
+        cleanup();
+      }
+    },
+
+    testSmart : function () {
+      if (!isEnterprise || !isCoordinator) {
+        return;
+      }
+
+      const graphs = require("@arangodb/smart-graph");
+      let cleanup = function() {
+        try {
+          graphs._drop(gn, true);
+        } catch (err) {}
+        db._drop(vn);
+        db._drop(en + "1");
+        db._drop(en + "2");
+      };
+      cleanup();
+   
+      try {
+        graphs._create(gn, [graphs._relation(en + "1", vn, vn), graphs._relation(en + "2", vn, vn)], null, { numberOfShards: 4, smartGraphAttribute: "aha" });
+
+        runTests();
+      } finally {
+        cleanup();
+      }
+    },
+  };
+}
+
+jsunity.run(edgeCollectionRestrictionSuite);
+
+return jsunity.done();

--- a/tests/js/server/aql/aql-traversal-restrict-vertex-collections.js
+++ b/tests/js/server/aql/aql-traversal-restrict-vertex-collections.js
@@ -28,10 +28,9 @@
 /// @author Copyright 2020, triAGENS GmbH, Cologne, Germany
 ////////////////////////////////////////////////////////////////////////////////
 
-var jsunity = require("jsunity");
-var internal = require("internal");
-var errors = internal.errors;
-var db = require("@arangodb").db, indexId;
+const jsunity = require("jsunity");
+const internal = require("internal");
+const db = require("@arangodb").db;
 
 const vc1Name = "v1";
 const vc2Name = "v2";


### PR DESCRIPTION
### Scope & Purpose

Added traversal option `edgeCollections` to restrict the traversal to certain edge collections when using named graphs
Additionally, speed up internal selection of appropriate AqlItemBlock bucket by using clz. 
Plus, remove the traversal's vertex output register from the register plan in case it is not needed.

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8721/