### PR TITLE
Activate CalculationExecutors

### DIFF
--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -137,10 +137,8 @@ template <typename Executor>
 constexpr bool isNewStyleExecutor =
     is_one_of_v<Executor, FilterExecutor, SortedCollectExecutor, IdExecutor<ConstFetcher>,
                 IdExecutor<SingleRowFetcher<BlockPassthrough::Enable>>, ReturnExecutor, IndexExecutor, EnumerateCollectionExecutor,
-                /*
-                                CalculationExecutor<CalculationType::Condition>, CalculationExecutor<CalculationType::Reference>,
-                                CalculationExecutor<CalculationType::V8Condition>,*/
-                HashedCollectExecutor,
+                CalculationExecutor<CalculationType::Condition>, CalculationExecutor<CalculationType::Reference>,
+                CalculationExecutor<CalculationType::V8Condition>, HashedCollectExecutor,
 #ifdef ARANGODB_USE_GOOGLE_TESTS
                 TestLambdaExecutor,
                 TestLambdaSkipExecutor,  // we need one after these to avoid compile errors in non-test mode


### PR DESCRIPTION
InternalTG PR.
Some tests have been red, however executors are implemented, the issue was in ShadowRow handling outside of the executors.