### PR TITLE
make arangobench return a proper error message

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Make arangobench return a proper error message when its initial attempt to 
+  create the test collection fails.
+
 * Added traversal options `vertexCollections` and `edgeCollections` to restrict
   traversal to certain vertex or edge collections.
 

--- a/arangosh/Benchmark/test-cases.h
+++ b/arangosh/Benchmark/test-cases.h
@@ -22,7 +22,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "Basics/Common.h"
-
+#include "Basics/StringUtils.h"
 #include "Random/RandomGenerator.h"
 
 static bool DeleteCollection(SimpleHttpClient*, std::string const&);
@@ -1549,13 +1549,28 @@ static bool CreateCollection(SimpleHttpClient* client, std::string const& name,
   std::unique_ptr<SimpleHttpResult> result(client->request(rest::RequestType::POST, "/_api/collection",
                            payload.c_str(), payload.size(), headerFields));
 
-  bool failed = true;
-
-  if (result != nullptr) {
-    int statusCode = result->getHttpReturnCode();
-    if (statusCode == 200 || statusCode == 201 || statusCode == 202) {
-      failed = false;
+  if (result == nullptr) {
+    LOG_TOPIC("03767", FATAL, Logger::FIXME) << "got no response from server when trying to create collection";
+    FATAL_ERROR_EXIT();
+  } 
+  int statusCode = result->getHttpReturnCode();
+  if (statusCode >= 400) {
+    std::string errorMsg = result->getHttpReturnMessage();
+    std::shared_ptr<arangodb::velocypack::Builder> bodyBuilder(result->getBodyVelocyPack());
+    arangodb::velocypack::Slice error = bodyBuilder->slice();
+    if (!error.isNone() && error.hasKey(arangodb::StaticStrings::ErrorMessage)) {
+      errorMsg = error.get(arangodb::StaticStrings::ErrorMessage).copyString();
     }
+    LOG_TOPIC("44810", FATAL, Logger::FIXME) 
+      << "got error message when trying to create collection: " 
+      << "HTTP " << arangodb::basics::StringUtils::itoa(result->getHttpReturnCode()) << ": " 
+      << errorMsg;
+    FATAL_ERROR_EXIT();
+  }
+
+  bool failed = true;
+  if (statusCode == 200 || statusCode == 201 || statusCode == 202) {
+    failed = false;
   }
 
   return !failed;


### PR DESCRIPTION
### Scope & Purpose

Make arangobench return a proper error message in case its initial collection creation attempt fails.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8774/