### PR TITLE
fix nullptr dereference

### DIFF
--- a/arangod/Aql/DocumentProducingHelper.cpp
+++ b/arangod/Aql/DocumentProducingHelper.cpp
@@ -95,10 +95,6 @@ IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVarian
       return true;
     }
 
-    InputAqlItemRow const& input = context.getInputRow();
-    OutputAqlItemRow& output = context.getOutputRow();
-    RegisterId registerId = context.getOutputRegister();
-
     transaction::BuilderLeaser b(context.getTrxPtr());
     b->openObject(true);
 
@@ -106,6 +102,10 @@ IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVarian
                       *b.get(), context.getUseRawDocumentPointers());
 
     b->close();
+    
+    InputAqlItemRow const& input = context.getInputRow();
+    OutputAqlItemRow& output = context.getOutputRow();
+    RegisterId registerId = context.getOutputRegister();
 
     AqlValue v(b.get());
     AqlValueGuard guard{v, true};
@@ -423,9 +423,6 @@ IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVarian
       checkFilter = false;
     }
 
-    InputAqlItemRow const& input = context.getInputRow();
-    OutputAqlItemRow& output = context.getOutputRow();
-
     transaction::BuilderLeaser b(context.getTrxPtr());
     b->openObject(true);
 
@@ -473,8 +470,10 @@ IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVarian
       context.incrFiltered();
       return false;
     }
-
+    
     if constexpr (!skip) {
+      InputAqlItemRow const& input = context.getInputRow();
+      OutputAqlItemRow& output = context.getOutputRow();
       RegisterId registerId = context.getOutputRegister();
       AqlValue v(b.get());
       AqlValueGuard guard{v, true};


### PR DESCRIPTION
### Scope & Purpose

Fix a nullptr dereference uncovered by ASan tests in `scripts/unittest shell_server_aql --test tests/js/server/aql/aql-optimizer-collect-count.js`

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *shell_server_aql*.

- [x] I ensured this code runs with ASan / TSan or other static verification tools

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8788/