### PR TITLE
Systemd fix legacy path PID

### DIFF
--- a/Installation/systemd/arangodb3.service.in
+++ b/Installation/systemd/arangodb3.service.in
@@ -25,14 +25,14 @@ LimitNOFILE=131072
 LimitNPROC=131072
 TasksMax=131072
 
-PIDFile=/var/run/arangodb3/arangod.pid
+PIDFile=/run/arangodb3/arangod.pid
 Environment=GLIBCXX_FORCE_NEW=1
 
 # Protect users from making their installation unusable by
 # starting arangod with wrong permissions (e.g. as root).
 # This will reset the permissions to the working default.
 ExecStartPre=/usr/bin/install -g arangodb -o arangodb -d /var/tmp/arangodb3
-ExecStartPre=/usr/bin/install -g arangodb -o arangodb -d /var/run/arangodb3
+ExecStartPre=/usr/bin/install -g arangodb -o arangodb -d /run/arangodb3
 ExecStartPre=@CHOWN_EXECUTABLE@ -R arangodb:arangodb /var/log/arangodb3
 ExecStartPre=@CHMOD_EXECUTABLE@ 700 /var/log/arangodb3
 ExecStartPre=@CHOWN_EXECUTABLE@ -R arangodb:arangodb /var/lib/arangodb3
@@ -40,7 +40,7 @@ ExecStartPre=@CHMOD_EXECUTABLE@ 700 /var/lib/arangodb3
 ExecStartPre=@CHOWN_EXECUTABLE@ -R arangodb:arangodb /var/lib/arangodb3-apps
 ExecStartPre=@CHMOD_EXECUTABLE@ 700 /var/lib/arangodb3-apps
 
-ExecStart=/usr/sbin/arangod --uid arangodb --gid arangodb --pid-file /var/run/arangodb3/arangod.pid --temp.path /var/tmp/arangodb3 --log.foreground-tty true
+ExecStart=/usr/sbin/arangod --uid arangodb --gid arangodb --pid-file /run/arangodb3/arangod.pid --temp.path /var/tmp/arangodb3 --log.foreground-tty true
 
 TimeoutStopSec=3600
 TimeoutSec=3600


### PR DESCRIPTION
Hello :)

I just packaged arangodb for our distribution and I have this message in the logs after starting the service.

```
Mar 01 00:15:45 laptop systemd[1]: /usr/x86_64-pc-linux-gnu/lib/systemd/system/arangodb3.service:13: PIDFile= references a path below legacy directory /var/run/, updating /var/run/arangodb3/arangod.pid → /run/arangodb3/arangod.pid; please update the unit file accordingly.
Mar 01 00:15:45 laptop systemd[1]: /usr/x86_64-pc-linux-gnu/lib/systemd/system/arangodb3.service:13: PIDFile= references a path below legacy directory /var/run/, updating /var/run/arangodb3/arangod.pid → /run/arangodb3/arangod.pid; please update the unit file accordingly.
Mar 01 00:15:46 laptop systemd[1]: /usr/x86_64-pc-linux-gnu/lib/systemd/system/arangodb3.service:13: PIDFile= references a path below legacy directory /var/run/, updating /var/run/arangodb3/arangod.pid → /run/arangodb3/arangod.pid; please update the unit file accordingly.
```
