### PR TITLE
remove the need to call stealComputedValue for AstNodes

### DIFF
--- a/arangod/Aql/AstNode.h
+++ b/arangod/Aql/AstNode.h
@@ -557,9 +557,6 @@ struct AstNode {
   /// this creates an equivalent to what JSON.stringify() would do
   void appendValue(arangodb::basics::StringBuffer*) const;
 
-  /// @brief Steals the computed value and frees it.
-  void stealComputedValue();
-
   /// @brief If the node has not been marked finalized, mark its subtree so.
   /// If it runs into a finalized node, it assumes the whole subtree beneath
   /// it is marked already and exits early; otherwise it will finalize the node
@@ -583,6 +580,8 @@ struct AstNode {
                                                                Args... args);
 
   static std::underlying_type<AstNodeFlagType>::type makeFlags();
+
+  void freeComputedValue();
 
  private:
   /// @brief precomputed VPack value (used when executing expressions)

--- a/arangod/Graph/TraverserOptions.cpp
+++ b/arangod/Graph/TraverserOptions.cpp
@@ -621,7 +621,6 @@ bool TraverserOptions::evaluateEdgeExpression(arangodb::velocypack::Slice edge,
     auto idNode = dirCmp->getMemberUnchecked(1);
     TRI_ASSERT(idNode->type == aql::NODE_TYPE_VALUE);
     TRI_ASSERT(idNode->isValueType(aql::VALUE_TYPE_STRING));
-    idNode->stealComputedValue();
     idNode->setStringValue(vertexId.data(), vertexId.length());
   }
   if (edge.isExternal()) {


### PR DESCRIPTION
### Scope & Purpose

This frees uses of AstNode from having to remember to call `stealComputedValue()` on the AstNode before re-purposing it.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [ ] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *shell_server_aql, shell_client*.

Additionally:

- [x] I ensured this code runs with ASan / TSan or other static verification tools

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8856/