### PR TITLE
Bug fix/disable gdb coredumping

### DIFF
--- a/js/client/modules/@arangodb/crash-utils.js
+++ b/js/client/modules/@arangodb/crash-utils.js
@@ -69,13 +69,13 @@ let GDB_OUTPUT = '';
 function analyzeCoreDump (instanceInfo, options, storeArangodPath, pid) {
   let gdbOutputFile = fs.getTempFile();
 
-  let command;
-  command = '(';
+  let command = 'ulimit -c 0; (';
   command += 'printf \'' +
     'set logging file ' + gdbOutputFile + '\\n' +
     'set logging on\\n' +
-    'bt full\\n' +
+    'bt\\n' +
     'thread apply all bt\\n'+
+    'bt full\\n' +
     '\';';
 
   command += 'sleep 10;';

--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -568,17 +568,23 @@ function initProcessStats(instanceInfo) {
 }
 
 function getDeltaProcessStats(instanceInfo) {
-  let deltaStats = {};
-  instanceInfo.arangods.forEach((arangod) => {
-    let newStats = getProcessStats(arangod.pid);
-    let myDeltaStats = {};
-    for (let key in arangod.stats) {
-      myDeltaStats[key] = newStats[key] - arangod.stats[key];
-    }
-    deltaStats[arangod.pid + '_' + arangod.role] = myDeltaStats;
-    arangod.stats = newStats;
-  });
-  return deltaStats;
+  try {
+    let deltaStats = {};
+    instanceInfo.arangods.forEach((arangod) => {
+      let newStats = getProcessStats(arangod.pid);
+      let myDeltaStats = {};
+      for (let key in arangod.stats) {
+        myDeltaStats[key] = newStats[key] - arangod.stats[key];
+      }
+      deltaStats[arangod.pid + '_' + arangod.role] = myDeltaStats;
+      arangod.stats = newStats;
+    });
+    return deltaStats;
+  }
+  catch (x) {
+    print("aborting stats generation");
+    return {};
+  }
 }
 
 function summarizeStats(deltaStats) {


### PR DESCRIPTION
- when the process is gone we can't get any more stats from it - continue processing anyways since i.e. crash analysis may happen
- disable coredumping for gdb
- move 'bt full' to the end so we get as much information as possible before we enter the danger zone.

http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/8857/