### PR TITLE
produce smaller output arrays when calculating the intersection of two IN lists

### DIFF
--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -1149,7 +1149,7 @@ AstNode* Ast::createNodeIntersectedArray(AstNode const* lhs, AstNode const* rhs)
     cache.try_emplace(slice, member);
   }
 
-  auto node = createNodeArray(cache.size() + nr);
+  auto node = createNodeArray(nl);
 
   for (size_t i = 0; i < nr; ++i) {
     auto member = rhs->getMemberUnchecked(i);
@@ -1157,8 +1157,12 @@ AstNode* Ast::createNodeIntersectedArray(AstNode const* lhs, AstNode const* rhs)
 
     auto it = cache.find(slice);
 
-    if (it != cache.end()) {
+    if (it != cache.end() &&
+        (*it).second != nullptr) {
+      // add to output
       node->addMember((*it).second);
+      // make sure we don't add the same value again
+      (*it).second = nullptr;
     }
   }
 


### PR DESCRIPTION
### Scope & Purpose

Produce smaller output arrays when calculating the intersection of two IN lists.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8861/