### PR TITLE
make more clear why a test was abortet

### DIFF
--- a/js/client/modules/@arangodb/result-processing.js
+++ b/js/client/modules/@arangodb/result-processing.js
@@ -411,7 +411,6 @@ function unitTestPrettyPrintResults (options, results) {
           }
 
           let details = successCases[name];
-
           if (details.skipped) {
             SuccessMessages += YELLOW + '    [SKIPPED] ' + name + RESET + '\n';
           } else {
@@ -443,7 +442,11 @@ function unitTestPrettyPrintResults (options, results) {
             continue;
           }
 
-          m = '    [FAILED]  ' + name;
+          if (name === 'SKIPPED') {
+            m = '    [SKIPPED]  the following tests were skipped due to the server not being in a trustworthy state anymore.';
+          } else {
+            m = '    [FAILED]  ' + name;
+          }
           failedMessages += RED + m + RESET + '\n\n';
           onlyFailedMessages += m + '\n\n';
 

--- a/js/client/modules/@arangodb/test-utils.js
+++ b/js/client/modules/@arangodb/test-utils.js
@@ -207,7 +207,7 @@ function performTests (options, testList, testname, runFn, serverOptions, startS
         if (!continueTesting) {
 
           if (!results.hasOwnProperty('SKIPPED')) {
-            print('oops! Skipping remaining tests, server is gone.');
+            print('oops! Skipping remaining tests, server is unavailable for testing.');
 
             results['SKIPPED'] = {
               status: false,
@@ -215,7 +215,7 @@ function performTests (options, testList, testname, runFn, serverOptions, startS
             };
             results[te] = {
               status: false,
-              message: 'server crashed'
+              message: 'server unavailable for testing: ' + results[te].message
             };
           } else {
             if (results['SKIPPED'].message !== '') {
@@ -233,6 +233,7 @@ function performTests (options, testList, testname, runFn, serverOptions, startS
         let reply = runFn(options, instanceInfo, te, env);
 
         if (reply.hasOwnProperty('forceTerminate')) {
+          results[te] = reply;
           continueTesting = false;
           forceTerminate = true;
           continue;
@@ -342,7 +343,7 @@ function performTests (options, testList, testname, runFn, serverOptions, startS
           continueTesting = false;
           results[te] = {
             status: false,
-            message: 'server is dead.'
+            message: 'server is dead: + ' + results[te].message
           };
         }
         


### PR DESCRIPTION
This PR improves the result representation in the test summary if the test was aborted due to a timeout.