### PR TITLE
Replace revision IDs on restore.

### DIFF
--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1712,24 +1712,23 @@ Result RestReplicationHandler::processRestoreDataBatch(transaction::Methods& trx
       if (type == REPLICATION_MARKER_DOCUMENT) {
         VPackSlice const doc = marker.get(::dataString);
         TRI_ASSERT(doc.isObject());
-        if (isUsersOnCoordinator) {
-          // In the _users case we silently remove the _key value.
-          VPackObjectBuilder guard(&builder);
-          for (auto it : VPackObjectIterator(doc)) {
-            if (isUsersOnCoordinator &&
-                (arangodb::velocypack::StringRef(it.key) == StaticStrings::KeyString &&
-                arangodb::velocypack::StringRef(it.key) == StaticStrings::IdString)) {
-              continue;
-            }
+        // In the _users case we silently remove the _key value.
+        VPackObjectBuilder guard(&builder);
+        for (auto it : VPackObjectIterator(doc)) {
+          if (isUsersOnCoordinator &&
+              (arangodb::velocypack::StringRef(it.key) == StaticStrings::KeyString &&
+               arangodb::velocypack::StringRef(it.key) == StaticStrings::IdString)) {
+            continue;
+          }
 
-            builder.add(it.key);
+          builder.add(it.key);
 
-            if (generateNewRevisionIds && arangodb::velocypack::StringRef(it.key) == StaticStrings::RevString) {
-              TRI_voc_rid_t newRid = physical->newRevisionId();
-              builder.add(TRI_RidToValuePair(newRid, ridBuffer));
-            } else {
-              builder.add(it.value);
-            }
+          if (generateNewRevisionIds && arangodb::velocypack::StringRef(it.key) ==
+                                            StaticStrings::RevString) {
+            TRI_voc_rid_t newRid = physical->newRevisionId();
+            builder.add(TRI_RidToValuePair(newRid, ridBuffer));
+          } else {
+            builder.add(it.value);
           }
         }
       }

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1424,7 +1424,8 @@ Result RestReplicationHandler::processRestoreData(std::string const& colName) {
   }
 #endif
 
-  bool generateNewRevisionIds = !_request->parsedValue("preserveRevisionIds", false);
+  bool generateNewRevisionIds =
+      !_request->parsedValue(StaticStrings::PreserveRevisionIds, false);
 
   ExecContextSuperuserScope escope(ExecContext::current().isAdminUser());
 
@@ -1716,7 +1717,7 @@ Result RestReplicationHandler::processRestoreDataBatch(transaction::Methods& trx
         VPackObjectBuilder guard(&builder);
         for (auto it : VPackObjectIterator(doc)) {
           if (isUsersOnCoordinator &&
-              (arangodb::velocypack::StringRef(it.key) == StaticStrings::KeyString &&
+              (arangodb::velocypack::StringRef(it.key) == StaticStrings::KeyString ||
                arangodb::velocypack::StringRef(it.key) == StaticStrings::IdString)) {
             continue;
           }

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1424,6 +1424,8 @@ Result RestReplicationHandler::processRestoreData(std::string const& colName) {
   }
 #endif
 
+  bool generateNewRevisionIds = !_request->parsedValue("preserveRevisionIds", false);
+
   ExecContextSuperuserScope escope(ExecContext::current().isAdminUser());
 
   if (colName == TRI_COL_NAME_USERS) {
@@ -1446,7 +1448,7 @@ Result RestReplicationHandler::processRestoreData(std::string const& colName) {
     return res;
   }
 
-  res = processRestoreDataBatch(trx, colName);
+  res = processRestoreDataBatch(trx, colName, generateNewRevisionIds);
   res = trx.finish(res);
 
   return res;
@@ -1600,7 +1602,8 @@ Result RestReplicationHandler::processRestoreUsersBatch(std::string const& colle
 ////////////////////////////////////////////////////////////////////////////////
 
 Result RestReplicationHandler::processRestoreDataBatch(transaction::Methods& trx,
-                                                       std::string const& collectionName) {
+                                                       std::string const& collectionName,
+                                                       bool generateNewRevisionIds) {
   std::unordered_map<std::string, VPackValueLength> latest;
   VPackBuilder allMarkers;
 
@@ -1678,6 +1681,16 @@ Result RestReplicationHandler::processRestoreDataBatch(transaction::Methods& trx
   bool const isUsersOnCoordinator = (ServerState::instance()->isCoordinator() &&
                                      collectionName == TRI_COL_NAME_USERS);
 
+  LogicalCollection* collection = trx.documentCollection(collectionName);
+  if (generateNewRevisionIds && !collection) {
+    return TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND;
+  }
+  PhysicalCollection* physical = collection->getPhysical();
+  if (!physical) {
+    return TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND;
+  }
+  char ridBuffer[11];
+
   // Now try to insert all keys for which the last marker was a document
   // marker, note that these could still be replace markers!
   VPackBuilder builder;
@@ -1701,17 +1714,23 @@ Result RestReplicationHandler::processRestoreDataBatch(transaction::Methods& trx
         TRI_ASSERT(doc.isObject());
         if (isUsersOnCoordinator) {
           // In the _users case we silently remove the _key value.
-          builder.openObject();
+          VPackObjectBuilder guard(&builder);
           for (auto it : VPackObjectIterator(doc)) {
-            if (arangodb::velocypack::StringRef(it.key) != StaticStrings::KeyString &&
-                arangodb::velocypack::StringRef(it.key) != StaticStrings::IdString) {
-              builder.add(it.key);
+            if (isUsersOnCoordinator &&
+                (arangodb::velocypack::StringRef(it.key) == StaticStrings::KeyString &&
+                arangodb::velocypack::StringRef(it.key) == StaticStrings::IdString)) {
+              continue;
+            }
+
+            builder.add(it.key);
+
+            if (generateNewRevisionIds && arangodb::velocypack::StringRef(it.key) == StaticStrings::RevString) {
+              TRI_voc_rid_t newRid = physical->newRevisionId();
+              builder.add(TRI_RidToValuePair(newRid, ridBuffer));
+            } else {
               builder.add(it.value);
             }
           }
-          builder.close();
-        } else {
-          builder.add(doc);
         }
       }
     }

--- a/arangod/RestHandler/RestReplicationHandler.h
+++ b/arangod/RestHandler/RestReplicationHandler.h
@@ -374,7 +374,7 @@ class RestReplicationHandler : public RestVocbaseBaseHandler {
   /// @brief restores the data of a collection
   //////////////////////////////////////////////////////////////////////////////
 
-  Result processRestoreDataBatch(transaction::Methods& trx, std::string const& colName);
+  Result processRestoreDataBatch(transaction::Methods& trx, std::string const& colName, bool generateNewRevisionIds);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief restores the indexes of a collection

--- a/arangod/StorageEngine/PhysicalCollection.h
+++ b/arangod/StorageEngine/PhysicalCollection.h
@@ -233,6 +233,8 @@ class PhysicalCollection {
   virtual void placeRevisionTreeBlocker(TRI_voc_tid_t transactionId);
   virtual void removeRevisionTreeBlocker(TRI_voc_tid_t transactionId);
 
+  TRI_voc_rid_t newRevisionId() const;
+
  protected:
   PhysicalCollection(LogicalCollection& collection, arangodb::velocypack::Slice const& info);
 
@@ -240,8 +242,6 @@ class PhysicalCollection {
   virtual void figuresSpecific(arangodb::velocypack::Builder&) = 0;
 
   // SECTION: Document pre commit preperation
-
-  TRI_voc_rid_t newRevisionId() const;
 
   bool isValidEdgeAttribute(velocypack::Slice const& slice) const;
 

--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -584,7 +584,8 @@ arangodb::Result sendRestoreData(arangodb::httpclient::SimpleHttpClient& httpCli
   }
 
   std::string const url = "/_api/replication/restore-data?collection=" + urlEncode(cname) +
-                          "&force=" + (options.force ? "true" : "false");
+                          "&force=" + (options.force ? "true" : "false") +
+                          (options.preserveRevisionIds ? "&preserveRevisionIds=true" : "");
   
   std::unordered_map<std::string, std::string> headers;
   headers.emplace(arangodb::StaticStrings::ContentTypeHeader,
@@ -1363,6 +1364,14 @@ void RestoreFeature::collectOptions(std::shared_ptr<options::ProgramOptions> opt
           arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden))
       .setDeprecatedIn(30322)
       .setDeprecatedIn(30402);
+
+  options
+      ->addOption(
+          "--preserve-revision-ids",
+          "preserve `_rev` values for the documents (potentially unsafe)",
+          new BooleanParameter(&_options.preserveRevisionIds),
+          arangodb::options::makeDefaultFlags(options::Flags::Hidden))
+      .setIntroducedIn(30700);
 }
 
 void RestoreFeature::validateOptions(std::shared_ptr<options::ProgramOptions> options) {

--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -586,7 +586,9 @@ arangodb::Result sendRestoreData(arangodb::httpclient::SimpleHttpClient& httpCli
   std::string const url =
       "/_api/replication/restore-data?collection=" + urlEncode(cname) +
       "&force=" + (options.force ? "true" : "false") +
-      (options.preserveRevisionIds ? ("&" + StaticStrings::PreserveRevisionIds + "=true") : "");
+      (options.preserveRevisionIds
+           ? ("&" + arangodb::StaticStrings::PreserveRevisionIds + "=true")
+           : "");
 
   std::unordered_map<std::string, std::string> headers;
   headers.emplace(arangodb::StaticStrings::ContentTypeHeader,

--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -583,10 +583,11 @@ arangodb::Result sendRestoreData(arangodb::httpclient::SimpleHttpClient& httpCli
     bufferSize = cleaned.length();
   }
 
-  std::string const url = "/_api/replication/restore-data?collection=" + urlEncode(cname) +
-                          "&force=" + (options.force ? "true" : "false") +
-                          (options.preserveRevisionIds ? "&preserveRevisionIds=true" : "");
-  
+  std::string const url =
+      "/_api/replication/restore-data?collection=" + urlEncode(cname) +
+      "&force=" + (options.force ? "true" : "false") +
+      (options.preserveRevisionIds ? ("&" + StaticStrings::PreserveRevisionIds + "=true") : "");
+
   std::unordered_map<std::string, std::string> headers;
   headers.emplace(arangodb::StaticStrings::ContentTypeHeader,
                   arangodb::StaticStrings::MimeTypeDump);

--- a/arangosh/Restore/RestoreFeature.h
+++ b/arangosh/Restore/RestoreFeature.h
@@ -92,6 +92,7 @@ class RestoreFeature final : public application_features::ApplicationFeature {
     bool overwrite{true};
     bool cleanupDuplicateAttributes{false};
     bool progress{true};
+    bool preserveRevisionIds{false};
   };
 
   /// @brief Stores stats about the overall restore progress

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -65,6 +65,7 @@ std::string const StaticStrings::Prefix("prefix");
 std::string const StaticStrings::ReplaceExisting("replaceExisting");
 std::string const StaticStrings::OverWrite("overwrite");
 std::string const StaticStrings::OverWriteMode("overwriteMode");
+std::string const StaticStrings::PreserveRevisionIds("preserveRevisionIds");
 
 // replication headers
 std::string const StaticStrings::ReplicationHeaderCheckMore(

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -70,6 +70,7 @@ class StaticStrings {
   static std::string const Prefix;
   static std::string const OverWrite;
   static std::string const OverWriteMode;
+  static std::string const PreserveRevisionIds;
 
   // replication headers
   static std::string const ReplicationHeaderCheckMore;


### PR DESCRIPTION
### Scope & Purpose

The goal of this PR is to automatically assign new revision IDs to restored documents. Previously, we would always preserve the `_rev` values when restoring documents. This prevents us from guaranteeing that different documents in the same collection have distinct `_rev` values when the number of shards is changed. There is a hidden option to force preservation of the IDs for certain special circumstances, but in general it should not be set.

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as dump.
