### PR TITLE
Make TransactionManager::begin/end lock-free.

### DIFF
--- a/arangod/Cache/TransactionManager.h
+++ b/arangod/Cache/TransactionManager.h
@@ -70,14 +70,19 @@ class TransactionManager {
   std::uint64_t term();
 
  private:
-  std::atomic<std::uint64_t> _openReads;
-  std::atomic<std::uint64_t> _openSensitive;
-  std::atomic<std::uint64_t> _openWrites;
-  std::atomic<std::uint64_t> _term;
-  std::atomic<bool> _lock;
+  struct Counters {
+    uint64_t openReads : 21;
+    uint64_t openWrites : 21;
+    uint64_t openSensitive : 21;
+  };
+  static_assert(sizeof(Counters) == sizeof(uint64_t), "unexpected size");
 
-  void lock();
-  void unlock();
+  struct alignas(16) Data {
+    Counters counters;
+    uint64_t term;
+  };
+
+  std::atomic<Data> _data;
 };
 
 };  // end namespace cache

--- a/arangod/Cache/TransactionManager.h
+++ b/arangod/Cache/TransactionManager.h
@@ -77,12 +77,12 @@ class TransactionManager {
   };
   static_assert(sizeof(Counters) == sizeof(uint64_t), "unexpected size");
 
-  struct alignas(16) Data {
+  struct alignas(16) State {
     Counters counters;
     uint64_t term;
   };
 
-  std::atomic<Data> _data;
+  std::atomic<State> _state;
 };
 
 };  // end namespace cache


### PR DESCRIPTION
### Scope & Purpose

In some profiling runs the TransactionManager begin/end methods showed up very significantly due to high contention on the lock. To improve that, I made them lock-free by putting all counters in a 128-bit struct that is updated in a CAS-loop.

- [x] Bug-Fix for *devel-branch*

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

