### PR TITLE
Add docublocks for Merkle tree-based replication APIs

### DIFF
--- a/Documentation/DocuBlocks/Rest/Replication/get_api_replication_revisions_tree.md
+++ b/Documentation/DocuBlocks/Rest/Replication/get_api_replication_revisions_tree.md
@@ -1,0 +1,66 @@
+
+@startDocuBlock get_api_replication_revisions_tree
+@brief retrieves the Merkle tree associated with the collection
+
+@RESTHEADER{GET /_api/replication/revisions/tree, Return Merkle tree for a collection,handleCommandRevisionTree}
+
+@RESTQUERYPARAMETERS
+
+@RESTQUERYPARAM{collection,string,required}
+The name or id of the collection to query.
+
+@RESTQUERYPARAM{batchId,number,required}
+The id of the snapshot to use
+
+@RESTDESCRIPTION
+Returns the Merkle tree from the collection.
+
+The result will be JSON/VelocyPack in the following format:
+```
+{
+  version: <Number>
+  maxDepth: <Number>,
+  rangeMin: <String, revision>,
+  rangeMax: <String, revision>,
+  nodes: [
+    { count: <Number>, hash: <String, revision> },
+    { count: <Number>, hash: <String, revision> },
+    ...
+    { count: <Number>, hash: <String, revision> }
+  ]
+}
+```
+
+At the moment, there is only one version, 1, so this can safely be ignored for
+now.
+
+Each `<String, revision>` value type is a 64-bit value encoded as a string of
+11 characters, using the same encoding as our document `_rev` values. The
+reason for this is that 64-bit values cannot necessarily be represented in full
+in JavaScript, as it handles all numbers as floating point, and can only
+represent up to `2^53-1` faithfully.
+
+The node count should correspond to a full tree with the given `maxDepth`.
+
+@RESTRETURNCODES
+
+@RESTRETURNCODE{200}
+is returned if the request was executed successfully and data was returned.
+
+@RESTRETURNCODE{401}
+is returned if necessary parameters are missing
+
+@RESTRETURNCODE{404}
+is returned when the collection or snapshot could not be found.
+
+@RESTRETURNCODE{405}
+is returned when an invalid HTTP method is used.
+
+@RESTRETURNCODE{500}
+is returned if an error occurred while assembling the response.
+
+@RESTRETURNCODE{501}
+is returned if called with mmfiles or on a collection which doesn't support
+sync-by-revision
+
+@endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Replication/get_api_replication_revisions_tree.md
+++ b/Documentation/DocuBlocks/Rest/Replication/get_api_replication_revisions_tree.md
@@ -18,7 +18,8 @@ Returns the Merkle tree from the collection.
 The result will be JSON/VelocyPack in the following format:
 ```
 {
-  version: <Number>
+  version: <Number>,
+  branchingFactor: <Number>
   maxDepth: <Number>,
   rangeMin: <String, revision>,
   rangeMax: <String, revision>,
@@ -40,7 +41,10 @@ reason for this is that 64-bit values cannot necessarily be represented in full
 in JavaScript, as it handles all numbers as floating point, and can only
 represent up to `2^53-1` faithfully.
 
-The node count should correspond to a full tree with the given `maxDepth`.
+The node count should correspond to a full tree with the given `maxDepth` and
+`branchingFactor`. The nodes are laid out in level-order tree traversal, so the
+root is at index `0`, its children at indices `[1, branchingFactor]`, and so
+on.
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Replication/post_api_replication_revisions_tree.md
+++ b/Documentation/DocuBlocks/Rest/Replication/post_api_replication_revisions_tree.md
@@ -1,0 +1,38 @@
+
+@startDocuBlock post_api_replication_revisions_tree
+@brief rebuilds the Merkle tree associated with the collection
+
+@RESTHEADER{POST /_api/replication/revisions/tree, Rebuild Merkle tree for a collection,handleCommandRebuildRevisionTree}
+
+@RESTQUERYPARAMETERS
+
+@RESTQUERYPARAM{collection,string,required}
+The name or id of the collection to query.
+
+@RESTDESCRIPTION
+Rebuilds the Merkle tree for the collection.
+
+If successful, there will be no return body.
+
+@RESTRETURNCODES
+
+@RESTRETURNCODE{204}
+is returned if the request was executed successfully.
+
+@RESTRETURNCODE{401}
+is returned if necessary parameters are missing
+
+@RESTRETURNCODE{404}
+is returned when the collection or could not be found.
+
+@RESTRETURNCODE{405}
+is returned when an invalid HTTP method is used.
+
+@RESTRETURNCODE{500}
+is returned if an error occurred while assembling the response.
+
+@RESTRETURNCODE{501}
+is returned if called with mmfiles or on a collection which doesn't support
+sync-by-revision
+
+@endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Replication/put_api_replication_revisions_documents.md
+++ b/Documentation/DocuBlocks/Rest/Replication/put_api_replication_revisions_documents.md
@@ -2,7 +2,7 @@
 @startDocuBlock put_api_replication_revisions_documents
 @brief retrieves documents by revision
 
-@RESTHEADER{GET /_api/replication/revisions/documents, Return documents by revision,handleCommandRevisionDocuments}
+@RESTHEADER{PUT /_api/replication/revisions/documents, Return documents by revision,handleCommandRevisionDocuments}
 
 @RESTQUERYPARAMETERS
 

--- a/Documentation/DocuBlocks/Rest/Replication/put_api_replication_revisions_documents.md
+++ b/Documentation/DocuBlocks/Rest/Replication/put_api_replication_revisions_documents.md
@@ -1,0 +1,68 @@
+
+@startDocuBlock put_api_replication_revisions_documents
+@brief retrieves documents by revision
+
+@RESTHEADER{GET /_api/replication/revisions/documents, Return documents by revision,handleCommandRevisionDocuments}
+
+@RESTQUERYPARAMETERS
+
+@RESTQUERYPARAM{collection,string,required}
+The name or id of the collection to query.
+
+@RESTQUERYPARAM{batchId,number,required}
+The id of the snapshot to use
+
+@RESTDESCRIPTION
+Returns documents by revision
+
+The body of the request should be JSON/VelocyPack and should consist of an
+array of string-encoded revision IDs:
+
+```
+[
+  <String, revision>,
+  <String, revision>,
+  ...
+  <String, revision>
+]
+```
+
+In particular, the revisions should be sorted in ascending order of their
+decoded values.
+
+The result will be a JSON/VelocyPack array of document objects. If there is no
+document corresponding to a particular requested revision, an empty object will
+be returned in its place.
+
+The response may be truncated if it would be very long. In this case, the
+response array length will be less than the request array length, and
+subsequent requests can be made for the omitted documents.
+
+Each `<String, revision>` value type is a 64-bit value encoded as a string of
+11 characters, using the same encoding as our document `_rev` values. The
+reason for this is that 64-bit values cannot necessarily be represented in full
+in JavaScript, as it handles all numbers as floating point, and can only
+represent up to `2^53-1` faithfully.
+
+@RESTRETURNCODES
+
+@RESTRETURNCODE{200}
+is returned if the request was executed successfully and data was returned.
+
+@RESTRETURNCODE{401}
+is returned if necessary parameters are missing or incorrect
+
+@RESTRETURNCODE{404}
+is returned when the collection or snapshot could not be found.
+
+@RESTRETURNCODE{405}
+is returned when an invalid HTTP method is used.
+
+@RESTRETURNCODE{500}
+is returned if an error occurred while assembling the response.
+
+@RESTRETURNCODE{501}
+is returned if called with mmfiles or on a collection which doesn't support
+sync-by-revision
+
+@endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Replication/put_api_replication_revisions_ranges.md
+++ b/Documentation/DocuBlocks/Rest/Replication/put_api_replication_revisions_ranges.md
@@ -2,7 +2,7 @@
 @startDocuBlock put_api_replication_revisions_ranges
 @brief retrieves the revision IDs of documents within requested ranges
 
-@RESTHEADER{GET /_api/replication/revisions/ranges, Return revision IDs within requested ranges,handleCommandRevisionRanges}
+@RESTHEADER{PUT /_api/replication/revisions/ranges, Return revision IDs within requested ranges,handleCommandRevisionRanges}
 
 @RESTQUERYPARAMETERS
 
@@ -56,8 +56,8 @@ string-encoding for a moment), if ranges `[1, 3], [5, 9], [12, 15]` are
 requested, then a first response may return `[], [5, 6]` with a resume point of
 `7` and a subsequent response might be `[8], [12, 13]`.
 
-If a requested range contains no revisions, then an empty array may be
-returned. Empty ranges will not be omitted.
+If a requested range contains no revisions, then an empty array is returned.
+Empty ranges will not be omitted.
 
 Each `<String, revision>` value type is a 64-bit value encoded as a string of
 11 characters, using the same encoding as our document `_rev` values. The

--- a/Documentation/DocuBlocks/Rest/Replication/put_api_replication_revisions_ranges.md
+++ b/Documentation/DocuBlocks/Rest/Replication/put_api_replication_revisions_ranges.md
@@ -1,0 +1,89 @@
+
+@startDocuBlock put_api_replication_revisions_ranges
+@brief retrieves the revision IDs of documents within requested ranges
+
+@RESTHEADER{GET /_api/replication/revisions/ranges, Return revision IDs within requested ranges,handleCommandRevisionRanges}
+
+@RESTQUERYPARAMETERS
+
+@RESTQUERYPARAM{collection,string,required}
+The name or id of the collection to query.
+
+@RESTQUERYPARAM{batchId,number,required}
+The id of the snapshot to use
+
+@RESTQUERYPARAM{resume,string,optional}
+The revision at which to resume, if a previous request was truncated
+
+@RESTDESCRIPTION
+Returns the revision IDs of documents within requested ranges
+
+The body of the request should be JSON/VelocyPack and should consist of an
+array of pairs of string-encoded revision IDs:
+
+```
+[
+  [<String, revision>, <String, revision>],
+  [<String, revision>, <String, revision>],
+  ...
+  [<String, revision>, <String, revision>]
+]
+```
+
+In particular, the pairs should be non-overlapping, and sorted in ascending
+order of their decoded values.
+
+The result will be JSON/VelocyPack in the following format:
+```
+{
+  ranges: [
+    [<String, revision>, <String, revision>, ... <String, revision>],
+    [<String, revision>, <String, revision>, ... <String, revision>],
+    ...,
+    [<String, revision>, <String, revision>, ... <String, revision>]
+  ]
+  resume: <String, revision>
+}
+```
+
+The `resume` field is optional. If specified, then the response is to be
+considered partial, only valid through the revision specified. A subsequent
+request should be made with the same request body, but specifying the `resume`
+URL parameter with the value specified. The subsequent response will pick up
+from the appropriate request pair, and omit any complete ranges or revisions
+which are less than the requested resume revision. As an example (ignoring the
+string-encoding for a moment), if ranges `[1, 3], [5, 9], [12, 15]` are
+requested, then a first response may return `[], [5, 6]` with a resume point of
+`7` and a subsequent response might be `[8], [12, 13]`.
+
+If a requested range contains no revisions, then an empty array may be
+returned. Empty ranges will not be omitted.
+
+Each `<String, revision>` value type is a 64-bit value encoded as a string of
+11 characters, using the same encoding as our document `_rev` values. The
+reason for this is that 64-bit values cannot necessarily be represented in full
+in JavaScript, as it handles all numbers as floating point, and can only
+represent up to `2^53-1` faithfully.
+
+@RESTRETURNCODES
+
+@RESTRETURNCODE{200}
+is returned if the request was executed successfully and data was returned.
+
+@RESTRETURNCODE{401}
+is returned if necessary parameters are missing or incorrect
+
+@RESTRETURNCODE{404}
+is returned when the collection or snapshot could not be found.
+
+@RESTRETURNCODE{405}
+is returned when an invalid HTTP method is used.
+
+@RESTRETURNCODE{500}
+is returned if an error occurred while assembling the response.
+
+@RESTRETURNCODE{501}
+is returned if called with mmfiles or on a collection which doesn't support
+sync-by-revision
+
+@endDocuBlock

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -3001,13 +3001,6 @@ bool RestReplicationHandler::prepareRevisionOperation(RevisionOperationContext& 
     return false;
   }
 
-  // determine end tick for dump
-  ctx.tickEnd = std::numeric_limits<TRI_voc_tick_t>::max();
-  std::string const& value2 = _request->value("to", found);
-  if (found) {
-    ctx.tickEnd = static_cast<TRI_voc_tick_t>(StringUtils::uint64(value2));
-  }
-
   ctx.iter =
       ctx.collection->getPhysical()->getReplicationIterator(ReplicationIterator::Ordering::Revision,
                                                             ctx.batchId);
@@ -3048,12 +3041,6 @@ void RestReplicationHandler::handleCommandRevisionTree() {
 void RestReplicationHandler::handleCommandRebuildRevisionTree() {
   RevisionOperationContext ctx;
   if (!prepareRevisionOperation(ctx)) {
-    return;
-  }
-
-  if (!ctx.collection->syncByRevision()) {
-    generateError(Result(TRI_ERROR_BAD_PARAMETER,
-                         "collection does not support revision tree commands"));
     return;
   }
 

--- a/arangod/RestHandler/RestReplicationHandler.h
+++ b/arangod/RestHandler/RestReplicationHandler.h
@@ -342,7 +342,6 @@ class RestReplicationHandler : public RestVocbaseBaseHandler {
   struct RevisionOperationContext {
     uint64_t batchId;
     TRI_voc_rid_t resume;
-    TRI_voc_tick_t tickEnd;
     std::string cname;
     std::shared_ptr<LogicalCollection> collection;
     std::unique_ptr<ReplicationIterator> iter;

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -280,6 +280,7 @@ std::string const StaticStrings::GraphCreateCollection("createCollection");
 // Replication
 std::string const StaticStrings::ReplicationSoftLockOnly("doSoftLockOnly");
 std::string const StaticStrings::FailoverCandidates("failoverCandidates");
+std::string const StaticStrings::RevisionTreeBranchingFactor("branchingFactor");
 std::string const StaticStrings::RevisionTreeCount("count");
 std::string const StaticStrings::RevisionTreeHash("hash");
 std::string const StaticStrings::RevisionTreeMaxDepth("maxDepth");

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -259,6 +259,7 @@ class StaticStrings {
   // Replication
   static std::string const ReplicationSoftLockOnly;
   static std::string const FailoverCandidates;
+  static std::string const RevisionTreeBranchingFactor;
   static std::string const RevisionTreeCount;
   static std::string const RevisionTreeHash;
   static std::string const RevisionTreeMaxDepth;

--- a/lib/Containers/MerkleTree.cpp
+++ b/lib/Containers/MerkleTree.cpp
@@ -220,6 +220,11 @@ MerkleTree<BranchingBits, LockStripes>::deserialize(velocypack::Slice slice) {
     return tree;
   }
 
+  read = slice.get(StaticStrings::RevisionTreeBranchingFactor);
+  if (!read.isNumber() || read.getNumber<std::size_t>() != BranchingFactor) {
+    return tree;
+  }
+
   read = slice.get(StaticStrings::RevisionTreeMaxDepth);
   if (!read.isNumber()) {
     return tree;
@@ -567,6 +572,7 @@ void MerkleTree<BranchingBits, LockStripes>::serialize(velocypack::Builder& outp
   velocypack::ObjectBuilder topLevelGuard(&output);
   output.add(StaticStrings::RevisionTreeVersion, velocypack::Value(::CurrentVersion));
   output.add(StaticStrings::RevisionTreeMaxDepth, velocypack::Value(depth));
+  output.add(StaticStrings::RevisionTreeBranchingFactor, velocypack::Value(BranchingFactor));
   output.add(StaticStrings::RevisionTreeRangeMax,
              basics::HybridLogicalClock::encodeTimeStampToValuePair(meta().rangeMax, ridBuffer));
   output.add(StaticStrings::RevisionTreeRangeMin,


### PR DESCRIPTION
### Scope & Purpose

Add DocuBlocks for the new Merkle tree-based replication APIs and do a tiny bit of handler cleanup.

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

Jenkins, just in case: http://172.16.10.101:8080/job/arangodb-matrix-pr/8977/ (all blue)