### PR TITLE
fix SORT RAND() LIMIT 1 optimizer rule

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,10 +2,11 @@ v3.6.3 (XXXX-XX-XX)
 -------------------
 
 * Fix SORT RAND() LIMIT 1 optimization for RocksDB when only a projection of the
-  attributes was used. When a projection was used and that projection was covered
-  by an index (e.g. `_key` via the primary index), then the access pattern was
-  transformed from random order collection seek to an index access, which always
-  resulted in the same index entry to be returned and not a random one.
+  attributes was used. When a projection was used and that projection was
+  covered by an index (e.g. `_key` via the primary index), then the access
+  pattern was transformed from random order collection seek to an index access,
+  which always resulted in the same index entry to be returned and not a random
+  one.
 
 
 v3.6.2 (2020-03-05)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,13 +1,17 @@
 v3.6.3 (XXXX-XX-XX)
 -------------------
 
-
+* Fix SORT RAND() LIMIT 1 optimization for RocksDB when only a projection of the
+  attributes was used. When a projection was used and that projection was covered
+  by an index (e.g. `_key` via the primary index), then the access pattern was
+  transformed from random order collection seek to an index access, which always
+  resulted in the same index entry to be returned and not a random one.
 
 
 v3.6.2 (2020-03-05)
 -------------------
 
-* Legacy behaviour for maintenance mode in supervision.
+* Legacy behavior for maintenance mode in supervision.
 
 * Fix the usage of the AQL functions `CALL` and `APPLY` for calling user-defined
   AQL functions when invoking an AQL query from the arangosh or a client application.

--- a/arangod/RocksDBEngine/RocksDBOptimizerRules.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptimizerRules.cpp
@@ -84,6 +84,11 @@ void RocksDBOptimizerRules::reduceExtractionToProjectionRule(
   std::unordered_set<std::string> attributes;
 
   for (auto& n : nodes) {
+    // isDeterministic is false for EnumerateCollectionNodes when the "random" flag is set.
+    bool const isRandomOrder = 
+      (n->getType() == EN::ENUMERATE_COLLECTION && 
+       !ExecutionNode::castTo<EnumerateCollectionNode*>(n)->isDeterministic());
+
     bool stop = false;
     bool optimize = false;
     attributes.clear();
@@ -194,6 +199,7 @@ void RocksDBOptimizerRules::reduceExtractionToProjectionRule(
     // projections are currently limited (arbitrarily to 5 attributes)
     if (optimize && !stop && !attributes.empty() && attributes.size() <= 5) {
       if (n->getType() == ExecutionNode::ENUMERATE_COLLECTION &&
+          !isRandomOrder &&
           std::find(attributes.begin(), attributes.end(), StaticStrings::IdString) ==
               attributes.end()) {
         // the node is still an EnumerateCollection... now check if we should
@@ -290,7 +296,10 @@ void RocksDBOptimizerRules::reduceExtractionToProjectionRule(
       }
 
       modified = true;
-    } else if (!stop && attributes.empty() && n->getType() == ExecutionNode::ENUMERATE_COLLECTION) {
+    } else if (!stop && 
+               attributes.empty() && 
+               n->getType() == ExecutionNode::ENUMERATE_COLLECTION && 
+               !isRandomOrder) {
       // replace collection access with primary index access (which can be
       // faster given the fact that keys and values are stored together in
       // RocksDB, but average values are much bigger in the documents column

--- a/tests/js/server/aql/aql-optimizer-rule-remove-sort-rand-limit-rocksdb.js
+++ b/tests/js/server/aql/aql-optimizer-rule-remove-sort-rand-limit-rocksdb.js
@@ -1,0 +1,115 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global assertEqual, assertTrue, assertFalse, assertNotEqual, assertUndefined, AQL_EXPLAIN, AQL_EXECUTE */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief tests for optimizer rules
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+var jsunity = require("jsunity");
+var helper = require("@arangodb/aql-helper");
+var db = require("@arangodb").db;
+var removeAlwaysOnClusterRules = helper.removeAlwaysOnClusterRules;
+var removeClusterNodes = helper.removeClusterNodes;
+
+function optimizerRuleTestSuite () {
+  const ruleName = "remove-sort-rand-limit-1";
+  let c;
+
+  return {
+
+    setUpAll : function () {
+      db._drop("UnitTestsCollection");
+      c = db._create("UnitTestsCollection");
+
+      for (let i = 0; i < 1000; ++i) {
+        c.insert({ value: i });
+      }
+    },
+
+    tearDownAll : function () {
+      db._drop("UnitTestsCollection");
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test that rule has no effect
+////////////////////////////////////////////////////////////////////////////////
+
+    testRuleNoEffect : function () {
+      let queries = [ 
+        "FOR i IN 1..10 SORT RAND() RETURN i",  // no collection
+        "FOR i IN 1..10 SORT RAND() LIMIT 1 RETURN i",  // no collection
+        "FOR i IN " + c.name() + " SORT RAND() LIMIT 2 RETURN i", 
+        "FOR i IN " + c.name() + " SORT RAND() LIMIT 10 RETURN i", 
+        "FOR i IN " + c.name() + " SORT RAND() LIMIT 0 RETURN i", 
+        "FOR i IN " + c.name() + " SORT i.value, RAND() LIMIT 1 RETURN i", 
+        "FOR i IN " + c.name() + " SORT RAND(), i.value RETURN i", // more than one sort criterion
+        "FOR i IN " + c.name() + " FOR j IN " + c.name() + " SORT RAND() RETURN i", // more than one collection
+        "FOR i IN " + c.name() + " FOR j IN " + c.name() + " SORT RAND() LIMIT 1 RETURN i", // more than one collection
+      ];
+
+      queries.forEach(function(query) {
+        let result = AQL_EXPLAIN(query);
+        assertEqual(-1, result.plan.rules.indexOf(ruleName), query);
+      });
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test that rule has an effect
+////////////////////////////////////////////////////////////////////////////////
+
+    testRuleHasEffect : function () {
+      let queries = [ 
+        "FOR i IN " + c.name() + " SORT RAND() LIMIT 1 RETURN i", 
+        "FOR i IN " + c.name() + " SORT RAND() LIMIT 1 RETURN i.value", 
+        "FOR i IN " + c.name() + " SORT RAND() LIMIT 1 RETURN i._key", 
+        "FOR i IN " + c.name() + " SORT RAND() LIMIT 1 RETURN i._id", 
+        "FOR i IN " + c.name() + " SORT RAND() ASC LIMIT 1 RETURN i", 
+        "FOR i IN " + c.name() + " SORT RAND() ASC LIMIT 1 RETURN i.value", 
+        "FOR i IN " + c.name() + " SORT RAND() ASC LIMIT 1 RETURN i._key", 
+        "FOR i IN " + c.name() + " SORT RAND() ASC LIMIT 1 RETURN i._id", 
+        "FOR i IN " + c.name() + " SORT RAND() DESC LIMIT 1 RETURN i", 
+        "FOR i IN " + c.name() + " SORT RAND() DESC LIMIT 1 RETURN i.value", 
+        "FOR i IN " + c.name() + " SORT RAND() DESC LIMIT 1 RETURN i._key", 
+        "FOR i IN " + c.name() + " SORT RAND() DESC LIMIT 1 RETURN i._id", 
+      ];
+
+      queries.forEach(function(query) {
+        let result = AQL_EXPLAIN(query);
+        assertNotEqual(-1, result.plan.rules.indexOf(ruleName), query);
+        assertEqual(-1, result.plan.nodes.map(function(node) { return node.type; }).indexOf("IndexNode"));
+        let collectionNode = result.plan.nodes.map(function(node) { return node.type; }).indexOf("EnumerateCollectionNode");
+        if (collectionNode !== -1) {
+          assertTrue(result.plan.nodes[collectionNode].random); // check for random iteration flag
+        }
+      });
+    },
+
+  };
+}
+
+jsunity.run(optimizerRuleTestSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Fix `SORT RAND() LIMIT 1` optimization for RocksDB when only a projection of the attributes was used. When a projection was used and that projection was covered by an index (e.g. `_key` via the primary index), then the access pattern was transformed from random order collection seek to an index access, which always resulted in the same index entry to be returned and not a random one.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [ ] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/8986/