### PR TITLE
satellite collection coordinator crash

### DIFF
--- a/arangod/Aql/EngineInfoContainerCoordinator.cpp
+++ b/arangod/Aql/EngineInfoContainerCoordinator.cpp
@@ -75,6 +75,7 @@ Result EngineInfoContainerCoordinator::EngineInfo::buildEngine(
 
   auto engine = query.engine();
 
+  TRI_ASSERT(!dbServerQueryIds.empty());
   auto res = engine->createBlocks(_nodes, restrictToShards, dbServerQueryIds);
   if (!res.ok()) {
     return res;

--- a/arangod/Aql/ExecutionEngine.cpp
+++ b/arangod/Aql/ExecutionEngine.cpp
@@ -136,6 +136,10 @@ Result ExecutionEngine::createBlocks(std::vector<ExecutionNode*> const& nodes,
 
       // now we'll create a remote node for each shard and add it to the
       // gather node (eb->addDependency)
+      LOG_DEVEL << "------------------------------------------------";
+      LOG_DEVEL << "remote id" << remoteNode->id();
+      LOG_DEVEL << "queryIds"  << queryIds;
+
       auto serversForRemote = queryIds.find(remoteNode->id());
       // Planning gone terribly wrong. The RemoteNode does not have a
       // counter-part to fetch data from.
@@ -485,6 +489,8 @@ struct DistributedQueryInstanciator final : public WalkerWorker<ExecutionNode> {
     if (res.fail()) {
       return res;
     }
+
+    TRI_ASSERT(!queryIds.empty());
 
     // The coordinator engines cannot decide on lock issues later on,
     // however every engine gets injected the list of locked shards.

--- a/arangod/Aql/ShardLocking.cpp
+++ b/arangod/Aql/ShardLocking.cpp
@@ -201,7 +201,9 @@ std::vector<Collection const*> ShardLocking::getUsedCollections() const {
 }
 
 std::vector<ServerID> ShardLocking::getRelevantServers() {
+  LOG_DEVEL << "=== get relevant servers ===";
   if (_collectionLocking.empty()) {
+    LOG_DEVEL << "exit empty locking";
     // Nothing todo, there are no DBServers
     return {};
   }


### PR DESCRIPTION
Code to trigger the bug, should eventually be used to create a test.

```javascript
#!/usr/bin/env arangosh --javscript.execute



(() => {
  const internal = require("internal");
  const debug = true

  const print = (msg) => {
    if(debug){
      internal.print(msg)
    }
  }

  const getCurrent = (name) => {
    let distribution = db._connection.GET("/_admin/cluster/shardDistribution");
    return distribution.results[name].Current;
  }

  const getLeader = (name) => {
    let current = getCurrent(name);
    let leader =  Object.entries(current)[0][1].leader

    if(leader === undefined) {
      throw("leader not found");
    }
    return leader;
  }

  const sname = "satellite";
  const nname = "normal";

  try {
    db._drop(sname);
  } catch (ex) {}

  try {
    db._drop(nname);
  } catch (ex) {}

  let scol = db._create(sname, { numberOfShards: 1, replicationFactor: "satellite" });
  let ncol = db._create(nname, { numberOfShards: 1});

  while( getLeader(sname) === getLeader(nname)) {
    ncol.drop()
    ncol = db._create(nname, { numberOfShards: 1});
  }


  cols = [ sname, nname ]
  print('-- create cols --')
  cols.forEach((x) => {
    print(x + " leader on: " + getLeader(x));
  })

  print('-- add data --')
  cols.forEach((x) => {
    let c = db._collection(x);
    for(let i = 0; i < 100; i++) {
      c.insert({ "v" : i} );
    }
  })

  print('-- query --')
  q=`FOR n IN ${nname} 
       FOR s IN ${sname}
         RETURN { vn : n, vs : s}
    `
  db._explain(q);
  db._query(q);
  

})()
```