### PR TITLE
Fixed production check, removed assertion

### DIFF
--- a/arangod/Graph/Graph.cpp
+++ b/arangod/Graph/Graph.cpp
@@ -193,8 +193,7 @@ void Graph::insertOrphanCollections(VPackSlice const arr) {
         "'orphanCollections' are not an array in the graph definition");
   }
   for (auto const& c : VPackArrayIterator(arr)) {
-    TRI_ASSERT(c.isString());
-    validateOrphanCollection(c);
+    THROW_ARANGO_EXCEPTION_IF_FAIL(validateOrphanCollection(c));
     addOrphanCollection(c.copyString());
   }
 }

--- a/arangod/Graph/Graph.h
+++ b/arangod/Graph/Graph.h
@@ -141,7 +141,7 @@ class Graph {
  public:
   virtual ~Graph() = default;
 
-  static Result validateOrphanCollection(const velocypack::Slice& orphanDefinition);
+  [[nodiscard]] static Result validateOrphanCollection(velocypack::Slice const& orphanDefinition);
 
   virtual void createCollectionOptions(VPackBuilder& builder, bool waitForSync) const;
 

--- a/lib/Basics/Exceptions.h
+++ b/lib/Basics/Exceptions.h
@@ -59,12 +59,13 @@
   throw arangodb::basics::Exception(code, message, __FILE__, __LINE__)
 
 /// @brief throws an arango result if the result fails
-#define THROW_ARANGO_EXCEPTION_IF_FAIL(result)                         \
-  do {                                                                 \
-    if ((result).fail()) {                                             \
-      throw arangodb::basics::Exception((result), __FILE__, __LINE__); \
-    }                                                                  \
-  } while (0);
+#define THROW_ARANGO_EXCEPTION_IF_FAIL(expression)                                        \
+  do {                                                                                    \
+    auto&& expressionResult = (expression);                                               \
+    if (expressionResult.fail()) {                                                        \
+      throw arangodb::basics::Exception(std::move(expressionResult), __FILE__, __LINE__); \
+    }                                                                                     \
+  } while (0)
 
 namespace arangodb {
 namespace basics {


### PR DESCRIPTION
### Scope & Purpose

When orphan collections were provided to the gharial API as an array, but the elements weren't strings, in maintainer mode an assertion would trigger. The production check wasn't active, however, and would have led to a generic velocypack error.

This remove the assertion (because it can be triggered by using an external API wrongly), and fixed the production check that should have thrown a meaningful exception (but didn't).

- [X] Bug-Fix for *devel-branch*

### Testing & Verification

This change is trivial. It removes a maintainer-mode assertion, and adds a more helpful error message in production.
