### PR TITLE
Bug fix/fix temp file usage

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix premature access to temporary path before a user-specified path was
+  read from the config options.
+
 * Rebuild UI and update swagger.
 
 * Added ability to store values in ArangoSearch views.

--- a/lib/ApplicationFeatures/TempFeature.cpp
+++ b/lib/ApplicationFeatures/TempFeature.cpp
@@ -23,6 +23,7 @@
 #include "ApplicationFeatures/TempFeature.h"
 #include "ApplicationFeatures/GreetingsFeaturePhase.h"
 #include "Basics/ArangoGlobalContext.h"
+#include "Basics/CrashHandler.h"
 #include "Basics/FileUtils.h"
 #include "Basics/files.h"
 #include "Logger/Logger.h"
@@ -59,6 +60,7 @@ void TempFeature::prepare() {
   TRI_SetApplicationName(_appname);
   if (!_path.empty()) {
     TRI_SetTempPath(_path);
+    CrashHandler::setTempFilename();
   }
 }
 

--- a/lib/Basics/CrashHandler.h
+++ b/lib/Basics/CrashHandler.h
@@ -27,6 +27,7 @@ namespace arangodb {
 class CrashHandler {
  public:
   static void installCrashHandler();
+  static void setTempFilename();
 };
 
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose

Prevent accessing the temporary path before a user-specified temporary path could be read via `--temp.path`.
This PR fixes a regression introduced in devel about 2 weeks ago.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest paths_server*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9072/