### PR TITLE
Ngram-tests warnings fix

### DIFF
--- a/tests/Aql/NgramMatchFunctionTest.cpp
+++ b/tests/Aql/NgramMatchFunctionTest.cpp
@@ -66,7 +66,7 @@ class NgramMatchFunctionTest : public ::testing::Test {
   }
 
  protected:
-  constexpr const char* TwoGramAnalyzer() { return "_system::myngram"; }
+  constexpr char const* TwoGramAnalyzer() { return "_system::myngram"; }
 
   AqlValue evaluate(AqlValue const* &Attribute,
     AqlValue const* Target,

--- a/tests/Aql/NgramMatchFunctionTest.cpp
+++ b/tests/Aql/NgramMatchFunctionTest.cpp
@@ -66,7 +66,7 @@ class NgramMatchFunctionTest : public ::testing::Test {
   }
 
  protected:
-  constexpr char* TwoGramAnalyzer() { return "_system::myngram"; }
+  constexpr const char* TwoGramAnalyzer() { return "_system::myngram"; }
 
   AqlValue evaluate(AqlValue const* &Attribute,
     AqlValue const* Target,

--- a/tests/Aql/NgramPosSimilarityFunctionTest.cpp
+++ b/tests/Aql/NgramPosSimilarityFunctionTest.cpp
@@ -66,7 +66,6 @@ class NgramPosSimilarityFunctionTest : public ::testing::Test {
       static VPackOptions options;
       return &options;
       });
-    transaction::Context& trxCtx = trxCtxMock.get();
     TRI_vocbase_t mockVocbase(TRI_VOCBASE_TYPE_NORMAL, testDBInfo(server.server()));
     auto trx = server.createFakeTransaction();
     SmallVector<AqlValue>::allocator_type::arena_type arena;

--- a/tests/Aql/NgramSimilarityFunctionTest.cpp
+++ b/tests/Aql/NgramSimilarityFunctionTest.cpp
@@ -66,7 +66,6 @@ class NgramSimilarityFunctionTest : public ::testing::Test {
       static VPackOptions options;
       return &options;
       });
-    transaction::Context& trxCtx = trxCtxMock.get();
     TRI_vocbase_t mockVocbase(TRI_VOCBASE_TYPE_NORMAL, testDBInfo(server.server()));
     auto trx = server.createFakeTransaction();
     SmallVector<AqlValue>::allocator_type::arena_type arena;


### PR DESCRIPTION
Fixed g++9 generated warnings
This change is a trivial rework / code cleanup without any test coverage.

https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/9074/