### PR TITLE
if no tests were following the timouted tests, don't add that message

### DIFF
--- a/js/client/modules/@arangodb/result-processing.js
+++ b/js/client/modules/@arangodb/result-processing.js
@@ -442,15 +442,19 @@ function unitTestPrettyPrintResults (options, results) {
             continue;
           }
 
+          let isSkipped = true;
           if (name === 'SKIPPED') {
             m = '    [SKIPPED]  the following tests were skipped due to the server not being in a trustworthy state anymore.';
           } else {
             m = '    [FAILED]  ' + name;
           }
+          let details = failedCases[name];
+          if (isSkipped && details.test === "") {
+            continue;
+          }
+
           failedMessages += RED + m + RESET + '\n\n';
           onlyFailedMessages += m + '\n\n';
-
-          let details = failedCases[name];
 
           let count = 0;
           for (let one in details) {


### PR DESCRIPTION
if the SUT is aborted the `UNITTEST_RESULT.json` may look like this - 
```
{"resilience_failover":{"startupTime":5.142500638961792,"tests/js/server/resilience/failover/resilience-synchronous-repl-cluster-grey.js":{"status":false,"message":"server unavailable for testing: Error reading from: 'http+tcp://127.0.0.1:12324' 'timeout during read'"},"SKIPPED":{"status":false,"message":"failedtest"},"testDuration":1801.927895307541,"shutdownTime":483.58957076072693,"failed":2,"status":false},"status":false,"crashed":true}
```
if there was no test following the test in which the system aborted, message will be empty:
```
{"resilience_failover":{"startupTime":5.142500638961792,"tests/js/server/resilience/failover/resilience-synchronous-repl-cluster-grey.js":{"status":false,"message":"server unavailable for testing: Error reading from: 'http+tcp://127.0.0.1:12324' 'timeout during read'"},"SKIPPED":{"status":false,"message":""},"testDuration":1801.927895307541,"shutdownTime":483.58957076072693,"failed":2,"status":false},"status":false,"crashed":true}
```
the `testresults.txt` can be reproduced using this command:
`./scripts/examine_results.js unitTestPrettyPrintResults --  --readFile /tmp/UNITTEST_RESULT.json`

```
Analyzing: /tmp/UNITTEST_RESULT.json

================================================================================'
TEST RESULTS
================================================================================

* Test "resilience_failover"
    [FAILED]  tests/js/server/resilience/failover/resilience-synchronous-repl-cluster-grey.js

      "test" failed: server unavailable for testing: Error reading from: 'http+tcp://127.0.0.1:12324' 'timeout during read'

    [SKIPPED]  the following tests were skipped due to the server not being in a trustworthy state anymore.

      "test" failed: failedtest

 * Overall state: Fail
Marking crashy!
   Suites failed: 2 Tests Failed: 0
```
before this patch no following skipped tests will produce this output:
```
================================================================================'
TEST RESULTS
================================================================================

* Test "resilience_failover"
    [FAILED]  tests/js/server/resilience/failover/resilience-synchronous-repl-cluster-grey.js

      "test" failed: server unavailable for testing: Error reading from: 'http+tcp://127.0.0.1:12324' 'timeout during read'

    [SKIPPED]  the following tests were skipped due to the server not being in a trustworthy state anymore.

      "test" failed: 

 * Overall state: Fail
Marking crashy!
   Suites failed: 2 Tests Failed: 0
```
with this patch the fixed output will be:
````
================================================================================'
TEST RESULTS
================================================================================

* Test "resilience_failover"
    [FAILED]  tests/js/server/resilience/failover/resilience-synchronous-repl-cluster-grey.js

      "test" failed: server unavailable for testing: Error reading from: 'http+tcp://127.0.0.1:12324' 'timeout during read'

 * Overall state: Fail
Marking crashy!
   Suites failed: 2 Tests Failed: 0
```
