### PR TITLE
reenable stack trace printing

### DIFF
--- a/lib/ApplicationFeatures/TempFeature.cpp
+++ b/lib/ApplicationFeatures/TempFeature.cpp
@@ -60,8 +60,8 @@ void TempFeature::prepare() {
   TRI_SetApplicationName(_appname);
   if (!_path.empty()) {
     TRI_SetTempPath(_path);
-    CrashHandler::setTempFilename();
   }
+  CrashHandler::setTempFilename();
 }
 
 void TempFeature::start() {

--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -64,6 +64,7 @@
 
 #include "files.h"
 
+#include "Basics/CrashHandler.h"
 #include "Basics/Exceptions.h"
 #include "Basics/FileUtils.h"
 #include "Basics/ReadWriteLock.h"
@@ -2365,6 +2366,7 @@ std::string TRI_GetTempPath() {
     }
 
     SystemTempPathSweeperInstance.init(SystemTempPath.get());
+    CrashHandler::setTempFilename();
   }
 
   return std::string(path);


### PR DESCRIPTION
### Scope & Purpose

One of the previous commits accidentially disabled stack trace printing for crashes.
This commit turns it back on.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9099/