### PR TITLE
KShortestPathsExecutor must reset its KShortestPathFinder, including all caches.

### DIFF
--- a/arangod/Aql/KShortestPathsExecutor.cpp
+++ b/arangod/Aql/KShortestPathsExecutor.cpp
@@ -149,7 +149,7 @@ KShortestPathsExecutor::KShortestPathsExecutor(Fetcher& fetcher, Infos& infos)
   // Make sure the finder is in a defined state, because we could
   // get any old junk here, because infos are not recreated in between
   // initializeCursor calls.
-  _finder.reset();
+  _finder.clear();
 }
 
 // Shutdown query
@@ -215,6 +215,7 @@ auto KShortestPathsExecutor::skipRowsRange(AqlItemBlockInputRange& input, AqlCal
 
 auto KShortestPathsExecutor::fetchPaths(AqlItemBlockInputRange& input) -> bool {
   TRI_ASSERT(_finder.isDone());
+  _finder.clear();
   while (input.hasDataRow()) {
     auto source = VPackSlice{};
     auto target = VPackSlice{};

--- a/arangod/Aql/KShortestPathsExecutor.cpp
+++ b/arangod/Aql/KShortestPathsExecutor.cpp
@@ -146,6 +146,10 @@ KShortestPathsExecutor::KShortestPathsExecutor(Fetcher& fetcher, Infos& infos)
   if (!_infos.useRegisterForTargetInput()) {
     _targetBuilder.add(VPackValue(_infos.getTargetInputValue()));
   }
+  // Make sure the finder is in a defined state, because we could
+  // get any old junk here, because infos are not recreated in between
+  // initializeCursor calls.
+  _finder.reset();
 }
 
 // Shutdown query

--- a/arangod/Aql/ShortestPathExecutor.cpp
+++ b/arangod/Aql/ShortestPathExecutor.cpp
@@ -156,6 +156,9 @@ ShortestPathExecutor::ShortestPathExecutor(Fetcher&, Infos& infos)
   if (!_infos.useRegisterForTargetInput()) {
     _targetBuilder.add(VPackValue(_infos.getTargetInputValue()));
   }
+  // Make sure the finder does not contain any leftovers in case of
+  // the executor being reconstructed.
+  _finder.clear();
 }
 
 // Shutdown query
@@ -209,6 +212,7 @@ auto ShortestPathExecutor::doSkipPath(AqlCall& call) -> size_t {
 auto ShortestPathExecutor::fetchPath(AqlItemBlockInputRange& input) -> bool {
   // We only want to call fetchPath if we don't have a path currently available
   TRI_ASSERT(pathLengthAvailable() == 0);
+  _finder.clear();
   _path->clear();
   _posInPath = 0;
 

--- a/arangod/Graph/AttributeWeightShortestPathFinder.cpp
+++ b/arangod/Graph/AttributeWeightShortestPathFinder.cpp
@@ -166,6 +166,16 @@ AttributeWeightShortestPathFinder::AttributeWeightShortestPathFinder(ShortestPat
 
 AttributeWeightShortestPathFinder::~AttributeWeightShortestPathFinder() = default;
 
+void AttributeWeightShortestPathFinder::clear() {
+  options().cache()->clear();
+  _highscoreSet = false;
+  _highscore = 0;
+  _bingo = false;
+  _resultCode = TRI_ERROR_NO_ERROR;
+  _intermediateSet = false;
+  _intermediate = arangodb::velocypack::StringRef{};
+}
+
 bool AttributeWeightShortestPathFinder::shortestPath(arangodb::velocypack::Slice const& st,
                                                      arangodb::velocypack::Slice const& ta,
                                                      ShortestPathResult& result) {
@@ -275,18 +285,17 @@ bool AttributeWeightShortestPathFinder::shortestPath(arangodb::velocypack::Slice
 }
 
 void AttributeWeightShortestPathFinder::inserter(
-  std::unordered_map<arangodb::velocypack::StringRef, size_t>& candidates,
-  std::vector<std::unique_ptr<Step>>& result,
-  arangodb::velocypack::StringRef const& s, arangodb::velocypack::StringRef const& t,
-  double currentWeight, EdgeDocumentToken&& edge) {
-
-  auto [cand, emplaced] = candidates.try_emplace(
-    t,
-    arangodb::lazyConstruct([&]{
-    result.emplace_back(std::make_unique<Step>(t, s, currentWeight, std::move(edge)));
-      return result.size() - 1;
-    })
-  );
+    std::unordered_map<arangodb::velocypack::StringRef, size_t>& candidates,
+    std::vector<std::unique_ptr<Step>>& result,
+    arangodb::velocypack::StringRef const& s, arangodb::velocypack::StringRef const& t,
+    double currentWeight, EdgeDocumentToken&& edge) {
+  auto [cand, emplaced] =
+      candidates.try_emplace(t, arangodb::lazyConstruct([&] {
+                               result.emplace_back(
+                                   std::make_unique<Step>(t, s, currentWeight,
+                                                          std::move(edge)));
+                               return result.size() - 1;
+                             }));
 
   if (!emplaced) {
     // Compare weight

--- a/arangod/Graph/AttributeWeightShortestPathFinder.h
+++ b/arangod/Graph/AttributeWeightShortestPathFinder.h
@@ -200,6 +200,8 @@ class AttributeWeightShortestPathFinder : public ShortestPathFinder {
 
   ~AttributeWeightShortestPathFinder();
 
+  void clear() override;
+
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Find the shortest path between start and target.
   ///        Only edges having the given direction are followed.

--- a/arangod/Graph/ConstantWeightShortestPathFinder.cpp
+++ b/arangod/Graph/ConstantWeightShortestPathFinder.cpp
@@ -56,6 +56,11 @@ ConstantWeightShortestPathFinder::~ConstantWeightShortestPathFinder() {
   clearVisited();
 }
 
+void ConstantWeightShortestPathFinder::clear() {
+  clearVisited();
+  options().cache()->clear();
+}
+
 bool ConstantWeightShortestPathFinder::shortestPath(
     arangodb::velocypack::Slice const& s, arangodb::velocypack::Slice const& e,
     arangodb::graph::ShortestPathResult& result) {
@@ -102,10 +107,9 @@ bool ConstantWeightShortestPathFinder::shortestPath(
   return false;
 }
 
-bool ConstantWeightShortestPathFinder::expandClosure(Closure& sourceClosure,
-                                                     Snippets& sourceSnippets,
-                                                     Snippets& targetSnippets,
-                                                     bool isBackward, arangodb::velocypack::StringRef& result) {
+bool ConstantWeightShortestPathFinder::expandClosure(
+    Closure& sourceClosure, Snippets& sourceSnippets, Snippets& targetSnippets,
+    bool isBackward, arangodb::velocypack::StringRef& result) {
   _nextClosure.clear();
   for (auto& v : sourceClosure) {
     _edges.clear();
@@ -118,12 +122,10 @@ bool ConstantWeightShortestPathFinder::expandClosure(Closure& sourceClosure,
       auto const& n = _neighbors[i];
 
       bool emplaced = false;
-      std::tie(std::ignore, emplaced) = sourceSnippets.try_emplace(
-        _neighbors[i],
-        arangodb::lazyConstruct([&]{
-          return new PathSnippet(v, std::move(_edges[i]));
-        })
-      );
+      std::tie(std::ignore, emplaced) =
+          sourceSnippets.try_emplace(_neighbors[i], arangodb::lazyConstruct([&] {
+                                       return new PathSnippet(v, std::move(_edges[i]));
+                                     }));
 
       if (emplaced) {
         // NOTE: _edges[i] stays intact after move
@@ -174,21 +176,25 @@ void ConstantWeightShortestPathFinder::fillResult(arangodb::velocypack::StringRe
   clearVisited();
 }
 
-void ConstantWeightShortestPathFinder::expandVertex(bool backward, arangodb::velocypack::StringRef vertex) {
+void ConstantWeightShortestPathFinder::expandVertex(bool backward,
+                                                    arangodb::velocypack::StringRef vertex) {
   EdgeCursor* cursor = backward ? _backwardCursor.get() : _forwardCursor.get();
   cursor->rearm(vertex, 0);
 
   cursor->readAll([&](EdgeDocumentToken&& eid, VPackSlice edge, size_t cursorIdx) -> void {
     if (edge.isString()) {
       if (edge.compareString(vertex.data(), vertex.length()) != 0) {
-        arangodb::velocypack::StringRef id = _options.cache()->persistString(arangodb::velocypack::StringRef(edge));
+        arangodb::velocypack::StringRef id =
+            _options.cache()->persistString(arangodb::velocypack::StringRef(edge));
         _edges.emplace_back(std::move(eid));
         _neighbors.emplace_back(id);
       }
     } else {
-      arangodb::velocypack::StringRef other(transaction::helpers::extractFromFromDocument(edge));
+      arangodb::velocypack::StringRef other(
+          transaction::helpers::extractFromFromDocument(edge));
       if (other == vertex) {
-        other = arangodb::velocypack::StringRef(transaction::helpers::extractToFromDocument(edge));
+        other = arangodb::velocypack::StringRef(
+            transaction::helpers::extractToFromDocument(edge));
       }
       if (other != vertex) {
         arangodb::velocypack::StringRef id = _options.cache()->persistString(other);

--- a/arangod/Graph/ConstantWeightShortestPathFinder.h
+++ b/arangod/Graph/ConstantWeightShortestPathFinder.h
@@ -63,15 +63,18 @@ class ConstantWeightShortestPathFinder : public ShortestPathFinder {
                     arangodb::velocypack::Slice const& end,
                     arangodb::graph::ShortestPathResult& result) override;
 
+  void clear() override;
+
  private:
   void expandVertex(bool backward, arangodb::velocypack::StringRef vertex);
 
   void clearVisited();
 
-  bool expandClosure(Closure& sourceClosure, Snippets& sourceSnippets,
-                     Snippets& targetSnippets, bool direction, arangodb::velocypack::StringRef& result);
+  bool expandClosure(Closure& sourceClosure, Snippets& sourceSnippets, Snippets& targetSnippets,
+                     bool direction, arangodb::velocypack::StringRef& result);
 
-  void fillResult(arangodb::velocypack::StringRef& n, arangodb::graph::ShortestPathResult& result);
+  void fillResult(arangodb::velocypack::StringRef& n,
+                  arangodb::graph::ShortestPathResult& result);
 
  private:
   Snippets _leftFound;

--- a/arangod/Graph/KShortestPathsFinder.cpp
+++ b/arangod/Graph/KShortestPathsFinder.cpp
@@ -50,7 +50,7 @@ KShortestPathsFinder::KShortestPathsFinder(ShortestPathOptions& options)
 
 KShortestPathsFinder::~KShortestPathsFinder() = default;
 
-void KShortestPathsFinder::reset() {
+void KShortestPathsFinder::clear() {
   _shortestPaths.clear();
   _candidatePaths.clear();
   _vertexCache.clear();

--- a/arangod/Graph/KShortestPathsFinder.cpp
+++ b/arangod/Graph/KShortestPathsFinder.cpp
@@ -50,6 +50,13 @@ KShortestPathsFinder::KShortestPathsFinder(ShortestPathOptions& options)
 
 KShortestPathsFinder::~KShortestPathsFinder() = default;
 
+void KShortestPathsFinder::reset() {
+  _shortestPaths.clear();
+  _candidatePaths.clear();
+  _vertexCache.clear();
+  _traversalDone = true;
+}
+
 // Sets up k-shortest-paths traversal from start to end
 bool KShortestPathsFinder::startKShortestPathsTraversal(
     arangodb::velocypack::Slice const& start, arangodb::velocypack::Slice const& end) {
@@ -58,10 +65,11 @@ bool KShortestPathsFinder::startKShortestPathsTraversal(
   _start = arangodb::velocypack::StringRef(start);
   _end = arangodb::velocypack::StringRef(end);
 
-  _traversalDone = false;
-
+  _vertexCache.clear();
   _shortestPaths.clear();
   _candidatePaths.clear();
+
+  _traversalDone = false;
 
   TRI_IF_FAILURE("Travefalse") { THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG); }
 

--- a/arangod/Graph/KShortestPathsFinder.h
+++ b/arangod/Graph/KShortestPathsFinder.h
@@ -214,7 +214,7 @@ class KShortestPathsFinder : public ShortestPathFinder {
   // reset the traverser; this is mainly needed because the traverser is
   // part of the KShortestPathsExecutorInfos, and hence not recreated when
   // a cursor is initialised.
-  void reset();
+  void clear() override;
 
   // This is here because we inherit from ShortestPathFinder (to get the destroyEngines function)
   // TODO: Remove

--- a/arangod/Graph/KShortestPathsFinder.h
+++ b/arangod/Graph/KShortestPathsFinder.h
@@ -211,6 +211,11 @@ class KShortestPathsFinder : public ShortestPathFinder {
   explicit KShortestPathsFinder(ShortestPathOptions& options);
   ~KShortestPathsFinder();
 
+  // reset the traverser; this is mainly needed because the traverser is
+  // part of the KShortestPathsExecutorInfos, and hence not recreated when
+  // a cursor is initialised.
+  void reset();
+
   // This is here because we inherit from ShortestPathFinder (to get the destroyEngines function)
   // TODO: Remove
   bool shortestPath(arangodb::velocypack::Slice const& start,

--- a/arangod/Graph/ShortestPathFinder.cpp
+++ b/arangod/Graph/ShortestPathFinder.cpp
@@ -39,8 +39,7 @@ using namespace arangodb;
 using namespace arangodb::graph;
 
 ShortestPathFinder::ShortestPathFinder(ShortestPathOptions& options)
-    : _options(options),
-      _httpRequests(0) {}
+    : _options(options), _httpRequests(0) {}
 
 void ShortestPathFinder::destroyEngines() {
   if (!ServerState::instance()->isCoordinator()) {
@@ -54,22 +53,22 @@ void ShortestPathFinder::destroyEngines() {
     return;
   }
   // nullptr only happens on controlled server shutdown
-  
+
   auto ch = reinterpret_cast<ClusterTraverserCache*>(_options.cache());
-  
+
   network::RequestOptions options;
   options.database = _options.trx()->vocbase().name();
   options.timeout = network::Timeout(30.0);
-  options.skipScheduler = true; // hack to speed up future.get()
+  options.skipScheduler = true;  // hack to speed up future.get()
 
   for (auto const& it : *ch->engines()) {
     incHttpRequests(1);
 
-    auto res =
-        network::sendRequest(pool, "server:" + it.first, fuerte::RestVerb::Delete,
-                             "/_internal/traverser/" + arangodb::basics::StringUtils::itoa(it.second),
-                             VPackBuffer<uint8_t>(), options)
-            .get();
+    auto res = network::sendRequest(pool, "server:" + it.first, fuerte::RestVerb::Delete,
+                                    "/_internal/traverser/" +
+                                        arangodb::basics::StringUtils::itoa(it.second),
+                                    VPackBuffer<uint8_t>(), options)
+                   .get();
 
     if (res.error != fuerte::Error::NoError) {
       // Note If there was an error on server side we do not have

--- a/arangod/Graph/ShortestPathFinder.h
+++ b/arangod/Graph/ShortestPathFinder.h
@@ -48,13 +48,15 @@ class ShortestPathFinder {
 
   ShortestPathOptions& options() const;
 
+  virtual void clear() = 0;
+
   /// @brief return number of HTTP requests made, and reset it to 0
-  size_t getAndResetHttpRequests() { 
+  size_t getAndResetHttpRequests() {
     size_t value = _httpRequests;
     _httpRequests = 0;
     return value;
   }
-  
+
   void incHttpRequests(size_t requests) { _httpRequests += requests; }
 
  protected:
@@ -62,7 +64,7 @@ class ShortestPathFinder {
   /// @brief The options to modify this shortest path computation
   //////////////////////////////////////////////////////////////////////////////
   ShortestPathOptions& _options;
-  
+
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Number of HTTP requests made
   //////////////////////////////////////////////////////////////////////////////

--- a/tests/Aql/ShortestPathExecutorTest.cpp
+++ b/tests/Aql/ShortestPathExecutorTest.cpp
@@ -130,6 +130,8 @@ class FakePathFinder : public ShortestPathFinder {
 
   ~FakePathFinder() = default;
 
+  void clear() override{};
+
   void addPath(std::vector<std::string>&& path) {
     _paths.emplace_back(std::move(path));
   }


### PR DESCRIPTION
Make sure the KShortestPathsExecutor resets the KShortestPathFinder correctly, including all caches.

Unfortunately there is no easy way to reproduce failure, so no regression test.