### PR TITLE
Fix usesRevisionAsDocumentId population and add syncByRevision flag

### DIFF
--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -742,7 +742,8 @@ arangodb::Result LogicalCollection::appendVelocyPack(arangodb::velocypack::Build
   result.add(StaticStrings::UsesRevisionsAsDocumentIds,
              VPackValue(usesRevisionsAsDocumentIds()));
   result.add(StaticStrings::MinRevision, VPackValue(minRevision()));
-             
+  result.add(StaticStrings::SyncByRevision, VPackValue(syncByRevision()));
+
   if (hasSmartJoinAttribute()) {
     result.add(StaticStrings::SmartJoinAttribute, VPackValue(_smartJoinAttribute));
   }

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -259,7 +259,8 @@ Result Collections::create(TRI_vocbase_t& vocbase,
                              vocbase.server().hasFeature<ShardingFeature>();
   bool addUseRevs = ServerState::instance()->isSingleServerOrCoordinator();
   bool useRevs =
-      vocbase.server().getFeature<arangodb::EngineSelectorFeature>().isRocksDB();
+      vocbase.server().getFeature<arangodb::EngineSelectorFeature>().isRocksDB() &&
+      LogicalCollection::currentVersion() >= LogicalCollection::Version::v37;
   VPackBuilder builder;
   VPackBuilder helper;
   builder.openArray();

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -242,6 +242,7 @@ std::string const StaticStrings::ShardingStrategy("shardingStrategy");
 std::string const StaticStrings::SmartJoinAttribute("smartJoinAttribute");
 std::string const StaticStrings::Sharding("sharding");
 std::string const StaticStrings::Satellite("satellite");
+std::string const StaticStrings::SyncByRevision("syncByRevision");
 std::string const StaticStrings::UsesRevisionsAsDocumentIds(
     "usesRevisionsAsDocumentIds");
 std::string const StaticStrings::Validation("validation");

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -224,6 +224,7 @@ class StaticStrings {
   static std::string const SmartJoinAttribute;
   static std::string const Sharding;
   static std::string const Satellite;
+  static std::string const SyncByRevision;
   static std::string const UsesRevisionsAsDocumentIds;
   static std::string const Validation;
   static std::string const WriteConcern;

--- a/tests/js/common/shell/shell-collection.js
+++ b/tests/js/common/shell/shell-collection.js
@@ -551,9 +551,8 @@ function CollectionSuite () {
 
       var p = c1.properties();
 
-      var isRocksDB = db._engine().name === "rocksdb";
       assertEqual(true, p.hasOwnProperty("usesRevisionsAsDocumentIds"));
-      assertEqual(isRocksDB, p.usesRevisionsAsDocumentIds);
+      assertEqual(false, p.usesRevisionsAsDocumentIds);
 
       db._drop(cn);
     },


### PR DESCRIPTION
### Scope & Purpose

Currently in devel, new collections will be created with the `usesRevisionAsDocumentId` flag set, which is wrong. This fixes it. This also adds a new flag `syncByRevision` to the collection properties so that clients can determine whether the collection supports the new replication protocol.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)

### Testing & Verification

Jenkins: https://jenkins01.arangodb.biz/job/arangodb-matrix-pr/9110/