### PR TITLE
Weighted Traversals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1358,4 +1358,4 @@ message(STATUS "building for git revision: ${ARANGODB_BUILD_REPOSITORY}")
 # endif ()
 
 add_custom_target(arangodb
-        DEPENDS arangod arangosh arangodump arangoexport arangobackup arangoimport arangorestore)
+        DEPENDS arangod arangosh arangodump arangoexport arangoimport arangorestore)

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -5843,18 +5843,18 @@ void arangodb::aql::optimizeTraversalsRule(Optimizer* opt,
       traversal->setPathOutput(nullptr);
       modified = true;
     }
-  
+
     // check if we can make use of the optimized neighbors enumerator
     if (!ServerState::instance()->isCoordinator()) {
       if (traversal->vertexOutVariable() != nullptr &&
           traversal->edgeOutVariable() == nullptr &&
           traversal->pathOutVariable() == nullptr &&
-          options->useBreadthFirst &&
+          options->isUseBreadthFirst() &&
           options->uniqueVertices == arangodb::traverser::TraverserOptions::GLOBAL &&
           !options->usesPrune() &&
           !options->hasDepthLookupInfo()) {
         // this is possible in case *only* vertices are produced (no edges, no path),
-        // the traversal is breadth-first, the vertex uniqueness level is set to "global", 
+        // the traversal is breadth-first, the vertex uniqueness level is set to "global",
         // there is no pruning and there are no depth-specific filters
         options->useNeighbors = true;
         modified = true;

--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -177,6 +177,7 @@ set(LIB_ARANGO_GRAPH_SOURCES
   Graph/TraverserCacheFactory.cpp
   Graph/TraverserDocumentCache.cpp
   Graph/TraverserOptions.cpp
+  Graph/WeightedEnumerator.cpp
   InternalRestHandler/InternalRestTraverserHandler.cpp
   RestHandler/RestGraphHandler.cpp
   RestServer/TraverserEngineRegistryFeature.cpp
@@ -1026,7 +1027,7 @@ endif ()
 if (USE_JEMALLOC)
   add_dependencies(arangod jemalloc_build)
 endif ()
-  
+
 foreach(TARGET
   arango_agency
   arango_aql

--- a/arangod/Cluster/ClusterTraverser.cpp
+++ b/arangod/Cluster/ClusterTraverser.cpp
@@ -35,6 +35,7 @@
 #include "Graph/EdgeCursor.h"
 #include "Graph/PathEnumerator.h"
 #include "Graph/TraverserCache.h"
+#include "Graph/WeightedEnumerator.h"
 #include "Logger/LogMacros.h"
 #include "Network/Methods.h"
 #include "Network/NetworkFeature.h"
@@ -49,11 +50,9 @@ using ClusterTraverser = arangodb::traverser::ClusterTraverser;
 ClusterTraverser::ClusterTraverser(arangodb::traverser::TraverserOptions* opts,
                                    std::unordered_map<ServerID, traverser::TraverserEngineID> const* engines,
                                    std::string const& dbname, transaction::Methods* trx)
-    : Traverser(opts, trx), 
-      _dbname(dbname), 
-      _engines(engines) { 
+    : Traverser(opts, trx), _dbname(dbname), _engines(engines) {
   _opts->linkTraverser(this);
-  
+
   createEnumerator();
   TRI_ASSERT(_enumerator != nullptr);
 }
@@ -78,7 +77,7 @@ void ClusterTraverser::setStartVertex(std::string const& vid) {
     _done = true;
     return;
   }
-  
+
   arangodb::velocypack::StringRef persId = traverserCache()->persistString(s);
   _vertexGetter->reset(persId);
   _enumerator->setStartVertex(persId);
@@ -92,7 +91,8 @@ void ClusterTraverser::clear() {
   _verticesToFetch.clear();
 }
 
-bool ClusterTraverser::getVertex(VPackSlice edge, std::vector<arangodb::velocypack::StringRef>& result) {
+bool ClusterTraverser::getVertex(VPackSlice edge,
+                                 std::vector<arangodb::velocypack::StringRef>& result) {
   bool res = _vertexGetter->getVertex(edge, result);
   if (res) {
     arangodb::velocypack::StringRef const& other = result.back();
@@ -106,7 +106,8 @@ bool ClusterTraverser::getVertex(VPackSlice edge, std::vector<arangodb::velocypa
 
 bool ClusterTraverser::getSingleVertex(arangodb::velocypack::Slice edge,
                                        arangodb::velocypack::StringRef sourceVertexId,
-                                       uint64_t depth, arangodb::velocypack::StringRef& targetVertexId) {
+                                       uint64_t depth,
+                                       arangodb::velocypack::StringRef& targetVertexId) {
   bool res = _vertexGetter->getSingleVertex(edge, sourceVertexId, depth, targetVertexId);
   if (res) {
     if (_vertices.find(targetVertexId) == _vertices.end()) {
@@ -124,7 +125,7 @@ void ClusterTraverser::fetchVertices() {
     fetchVerticesFromEngines(*_trx, _engines, _verticesToFetch, _vertices, ch->datalake(),
                              /*forShortestPath*/ false);
 
-    _enumerator->incHttpRequests(_engines->size()); 
+    _enumerator->incHttpRequests(_engines->size());
   } else {
     for (auto const& it : _verticesToFetch) {
       _vertices.emplace(it, VPackSlice::nullSlice());
@@ -138,7 +139,7 @@ aql::AqlValue ClusterTraverser::fetchVertexData(arangodb::velocypack::StringRef 
   auto cached = _vertices.find(idString);
   if (cached == _vertices.end()) {
     // Vertex not yet cached. Prepare for load.
-    
+
     // we need to make sure the idString remains valid afterwards
     idString = _opts->cache()->persistString(idString);
     _verticesToFetch.emplace(idString);
@@ -148,14 +149,15 @@ aql::AqlValue ClusterTraverser::fetchVertexData(arangodb::velocypack::StringRef 
   // Now all vertices are cached!!
   TRI_ASSERT(cached != _vertices.end());
   uint8_t const* ptr = cached->second.begin();
-  return aql::AqlValue(ptr); // no copy constructor
+  return aql::AqlValue(ptr);  // no copy constructor
 }
 
 //////////////////////////////////////////////////////////////////////////////
 /// @brief Function to add the real data of a vertex into a velocypack builder
 //////////////////////////////////////////////////////////////////////////////
 
-void ClusterTraverser::addVertexToVelocyPack(arangodb::velocypack::StringRef vid, VPackBuilder& result) {
+void ClusterTraverser::addVertexToVelocyPack(arangodb::velocypack::StringRef vid,
+                                             VPackBuilder& result) {
   auto cached = _vertices.find(vid);
   if (cached == _vertices.end()) {
     // Vertex not yet cached. Prepare for load.
@@ -180,18 +182,18 @@ void ClusterTraverser::destroyEngines() {
   _enumerator->incHttpRequests(_engines->size());
 
   VPackBuffer<uint8_t> body;
-  
+
   network::RequestOptions options;
   options.database = _trx->vocbase().name();
   options.timeout = network::Timeout(30.0);
-  options.skipScheduler = true; // hack to speed up future.get()
+  options.skipScheduler = true;  // hack to speed up future.get()
 
   // TODO: use collectAll to parallelize shutdown ?
   for (auto const& it : *_engines) {
-    auto res =
-        network::sendRequest(pool, "server:" + it.first, fuerte::RestVerb::Delete,
-                             "/_internal/traverser/" + arangodb::basics::StringUtils::itoa(it.second),
-                             body, options);
+    auto res = network::sendRequest(pool, "server:" + it.first, fuerte::RestVerb::Delete,
+                                    "/_internal/traverser/" +
+                                        arangodb::basics::StringUtils::itoa(it.second),
+                                    body, options);
     res.wait();
 
     if (!res.hasValue() || res.get().fail()) {
@@ -207,10 +209,29 @@ void ClusterTraverser::destroyEngines() {
 
 void ClusterTraverser::createEnumerator() {
   TRI_ASSERT(_enumerator == nullptr);
-
-  if (_opts->useBreadthFirst) {
-    _enumerator.reset(new arangodb::graph::BreadthFirstEnumerator(this, _opts));
-  } else {
-    _enumerator.reset(new arangodb::traverser::DepthFirstEnumerator(this, _opts));
+  switch (_opts->mode) {
+    case TraverserOptions::Mode::DFS:
+      // normal, depth-first enumerator
+      _enumerator = std::make_unique<DepthFirstEnumerator>(this, _opts);
+      break;
+    case TraverserOptions::Mode::BFS:
+      // default breadth-first enumerator
+      _enumerator = std::make_unique<BreadthFirstEnumerator>(this, _opts);
+      break;
+    case TraverserOptions::Mode::WEIGHTED:
+      _enumerator = std::make_unique<WeightedEnumerator>(this, _opts);
+      break;
   }
+}
+
+bool traverser::ClusterTraverser::getVertex(arangodb::velocypack::StringRef vertex,
+                                            size_t depth) {
+  bool res = _vertexGetter->getVertex(vertex, depth);
+  if (res) {
+    if (_vertices.find(vertex) == _vertices.end()) {
+      // Vertex not yet cached. Prepare it.
+      _verticesToFetch.emplace(vertex);
+    }
+  }
+  return res;
 }

--- a/arangod/Cluster/ClusterTraverser.h
+++ b/arangod/Cluster/ClusterTraverser.h
@@ -51,7 +51,7 @@ class ClusterTraverser final : public Traverser {
   ~ClusterTraverser() = default;
 
   void setStartVertex(std::string const& id) override;
-  
+
  protected:
   /// @brief Function to load the other sides vertex of an edge
   ///        Returns true if the vertex passes filtering conditions
@@ -63,6 +63,8 @@ class ClusterTraverser final : public Traverser {
   ///        Returns true if the vertex passes filtering conditions
   bool getSingleVertex(arangodb::velocypack::Slice edge, arangodb::velocypack::StringRef sourceVertexId,
                        uint64_t depth, arangodb::velocypack::StringRef& targetVertexId) override;
+
+  bool getVertex(arangodb::velocypack::StringRef vertex, size_t depth) override;
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Function to fetch the real data of a vertex into an AQLValue

--- a/arangod/Graph/NeighborsEnumerator.cpp
+++ b/arangod/Graph/NeighborsEnumerator.cpp
@@ -35,10 +35,10 @@ using namespace arangodb::graph;
 using namespace arangodb::traverser;
 
 NeighborsEnumerator::NeighborsEnumerator(Traverser* traverser, TraverserOptions* opts)
-    : PathEnumerator(traverser, opts), 
+    : PathEnumerator(traverser, opts),
       _searchDepth(0) {
-      
-  TRI_ASSERT(opts->useBreadthFirst);
+
+  TRI_ASSERT(opts->isUseBreadthFirst());
   TRI_ASSERT(opts->uniqueVertices == arangodb::traverser::TraverserOptions::GLOBAL);
   TRI_ASSERT(!opts->hasDepthLookupInfo());
 }
@@ -95,12 +95,12 @@ bool NeighborsEnumerator::next() {
             TRI_ASSERT(tmp.isString());
             vertex = tmp;
           }
-          
+
           arangodb::velocypack::StringRef v(vertex);
 
           if (_allFound.find(v) == _allFound.end()) {
             v = _opts->cache()->persistString(v);
-            
+
             if (_traverser->vertexMatchesConditions(v, _searchDepth + 1)) {
               _allFound.emplace(v);
               if (shouldPrune(v)) {
@@ -171,7 +171,7 @@ bool NeighborsEnumerator::shouldPrune(arangodb::velocypack::StringRef v) {
     vertex = _traverser->fetchVertexData(v);
     evaluator->injectVertex(vertex.slice());
   }
-  
+
   // We cannot support these two here
   TRI_ASSERT(!evaluator->needsEdge());
   TRI_ASSERT(!evaluator->needsPath());

--- a/arangod/Graph/SingleServerTraverser.cpp
+++ b/arangod/Graph/SingleServerTraverser.cpp
@@ -29,9 +29,12 @@
 #include "Graph/PathEnumerator.h"
 #include "Graph/TraverserCache.h"
 #include "Graph/TraverserOptions.h"
+#include "Graph/WeightedEnumerator.h"
 #include "Transaction/Methods.h"
 
 #include <velocypack/StringRef.h>
+
+#include <memory>
 
 using namespace arangodb;
 using namespace arangodb::traverser;
@@ -44,7 +47,8 @@ SingleServerTraverser::SingleServerTraverser(TraverserOptions* opts, transaction
 
 SingleServerTraverser::~SingleServerTraverser() = default;
 
-void SingleServerTraverser::addVertexToVelocyPack(arangodb::velocypack::StringRef vid, VPackBuilder& result) {
+void SingleServerTraverser::addVertexToVelocyPack(arangodb::velocypack::StringRef vid,
+                                                  VPackBuilder& result) {
   _opts->cache()->insertVertexIntoResult(vid, result);
 }
 
@@ -59,40 +63,50 @@ void SingleServerTraverser::setStartVertex(std::string const& vid) {
     _done = true;
     return;
   }
-  
+
   arangodb::velocypack::StringRef persId = _opts->cache()->persistString(s);
   _vertexGetter->reset(persId);
   _enumerator->setStartVertex(persId);
   _done = false;
 }
 
-void SingleServerTraverser::clear() {
-  traverserCache()->clear();
-}
+void SingleServerTraverser::clear() { traverserCache()->clear(); }
 
-bool SingleServerTraverser::getVertex(VPackSlice edge, std::vector<arangodb::velocypack::StringRef>& result) {
+bool SingleServerTraverser::getVertex(VPackSlice edge,
+                                      std::vector<arangodb::velocypack::StringRef>& result) {
   return _vertexGetter->getVertex(edge, result);
 }
 
-bool SingleServerTraverser::getSingleVertex(VPackSlice edge, arangodb::velocypack::StringRef sourceVertexId,
-                                            uint64_t depth, arangodb::velocypack::StringRef& targetVertexId) {
+bool SingleServerTraverser::getSingleVertex(VPackSlice edge,
+                                            arangodb::velocypack::StringRef sourceVertexId,
+                                            uint64_t depth,
+                                            arangodb::velocypack::StringRef& targetVertexId) {
   return _vertexGetter->getSingleVertex(edge, sourceVertexId, depth, targetVertexId);
 }
 
 void SingleServerTraverser::createEnumerator() {
   TRI_ASSERT(_enumerator == nullptr);
 
-  if (_opts->useBreadthFirst) {
-    // breadth-first enumerator
-    if (_opts->useNeighbors) {
-      // optimized neighbors enumerator
-      _enumerator.reset(new NeighborsEnumerator(this, _opts));
-    } else {
-      // default breadth-first enumerator
-      _enumerator.reset(new BreadthFirstEnumerator(this, _opts));
-    }
-  } else {
-    // normal, depth-first enumerator
-    _enumerator.reset(new DepthFirstEnumerator(this, _opts));
+  switch (_opts->mode) {
+    case TraverserOptions::Mode::DFS:
+      // normal, depth-first enumerator
+      _enumerator = std::make_unique<DepthFirstEnumerator>(this, _opts);
+      break;
+    case TraverserOptions::Mode::BFS:
+      if (_opts->useNeighbors) {
+        // optimized neighbors enumerator
+        _enumerator = std::make_unique<NeighborsEnumerator>(this, _opts);
+      } else {
+        // default breadth-first enumerator
+        _enumerator = std::make_unique<BreadthFirstEnumerator>(this, _opts);
+      }
+      break;
+    case TraverserOptions::Mode::WEIGHTED:
+      _enumerator = std::make_unique<WeightedEnumerator>(this, _opts);
+      break;
   }
+}
+
+bool SingleServerTraverser::getVertex(arangodb::velocypack::StringRef vertex, size_t depth) {
+  return _vertexGetter->getVertex(vertex, depth);
 }

--- a/arangod/Graph/SingleServerTraverser.h
+++ b/arangod/Graph/SingleServerTraverser.h
@@ -69,6 +69,9 @@ class SingleServerTraverser final : public Traverser {
                        arangodb::velocypack::StringRef const sourceVertexId, uint64_t depth,
                        arangodb::velocypack::StringRef& targetVertexId) override;
 
+
+  bool getVertex(arangodb::velocypack::StringRef vertex, size_t depth) override;
+
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Function to fetch the real data of a vertex into an AQLValue
   //////////////////////////////////////////////////////////////////////////////

--- a/arangod/Graph/Traverser.cpp
+++ b/arangod/Graph/Traverser.cpp
@@ -40,8 +40,8 @@ using namespace arangodb::graph;
 bool Traverser::VertexGetter::getVertex(VPackSlice edge,
                                         std::vector<arangodb::velocypack::StringRef>& result) {
   TRI_ASSERT(!result.empty());
-  
-  // getSingleVertex will populate s and register the underlying character data 
+
+  // getSingleVertex will populate s and register the underlying character data
   // if the vertex is found.
   arangodb::velocypack::StringRef s;
   if (!getSingleVertex(edge, result.back(), result.size(), s)) {
@@ -64,7 +64,7 @@ bool Traverser::VertexGetter::getSingleVertex(arangodb::velocypack::Slice edge,
     }
   }
   TRI_ASSERT(resSlice.isString());
-  
+
   arangodb::velocypack::StringRef s(resSlice);
   if (!_traverser->vertexMatchesConditions(s, depth)) {
     return false;
@@ -76,11 +76,15 @@ bool Traverser::VertexGetter::getSingleVertex(arangodb::velocypack::Slice edge,
 
 void Traverser::VertexGetter::reset(arangodb::velocypack::StringRef const&) {}
 
+bool Traverser::VertexGetter::getVertex(arangodb::velocypack::StringRef vertex, size_t depth) {
+  return _traverser->vertexMatchesConditions(vertex, depth);
+}
+
 bool Traverser::UniqueVertexGetter::getVertex(VPackSlice edge,
                                               std::vector<arangodb::velocypack::StringRef>& result) {
   TRI_ASSERT(!result.empty());
-  
-  // getSingleVertex will populate s and register the underlying character data 
+
+  // getSingleVertex will populate s and register the underlying character data
   // if the vertex is found.
   arangodb::velocypack::StringRef s;
   if (!getSingleVertex(edge, result.back(), result.size(), s)) {
@@ -88,6 +92,21 @@ bool Traverser::UniqueVertexGetter::getVertex(VPackSlice edge,
   }
 
   result.emplace_back(s);
+  return true;
+}
+
+bool Traverser::UniqueVertexGetter::getVertex(arangodb::velocypack::StringRef vertex, size_t depth) {
+  if (_returnedVertices.find(vertex) != _returnedVertices.end()) {
+    // This vertex is not unique.
+    _traverser->traverserCache()->increaseFilterCounter();
+    return false;
+  }
+
+  if(!_traverser->vertexMatchesConditions(vertex, depth)) {
+    return false;
+  }
+
+  _returnedVertices.emplace(vertex);
   return true;
 }
 
@@ -103,7 +122,7 @@ bool Traverser::UniqueVertexGetter::getSingleVertex(arangodb::velocypack::Slice 
     }
     TRI_ASSERT(resSlice.isString());
   }
-  
+
   arangodb::velocypack::StringRef s(resSlice);
 
   // First check if we visited it. If not, then mark
@@ -116,7 +135,7 @@ bool Traverser::UniqueVertexGetter::getSingleVertex(arangodb::velocypack::Slice 
   if (!_traverser->vertexMatchesConditions(s, depth)) {
     return false;
   }
-  
+
   result = _traverser->traverserCache()->persistString(s);
   _returnedVertices.emplace(result);
   return true;

--- a/arangod/Graph/Traverser.h
+++ b/arangod/Graph/Traverser.h
@@ -56,6 +56,7 @@ class Query;
 }  // namespace aql
 
 namespace graph {
+class WeightedEnumerator;
 class BreadthFirstEnumerator;
 class NeighborsEnumerator;
 class TraverserCache;
@@ -115,6 +116,7 @@ class TraversalPath {
 
 class Traverser {
   friend class arangodb::graph::BreadthFirstEnumerator;
+  friend class arangodb::graph::WeightedEnumerator;
   friend class DepthFirstEnumerator;
   friend class arangodb::graph::NeighborsEnumerator;
 #ifdef USE_ENTERPRISE
@@ -139,6 +141,8 @@ class Traverser {
     virtual bool getSingleVertex(arangodb::velocypack::Slice, arangodb::velocypack::StringRef,
                                  uint64_t, arangodb::velocypack::StringRef&);
 
+    virtual bool getVertex(arangodb::velocypack::StringRef vertex, size_t depth);
+
     virtual void reset(arangodb::velocypack::StringRef const&);
 
    protected:
@@ -161,6 +165,8 @@ class Traverser {
 
     bool getSingleVertex(arangodb::velocypack::Slice, arangodb::velocypack::StringRef,
                          uint64_t, arangodb::velocypack::StringRef&) override;
+
+    bool getVertex(arangodb::velocypack::StringRef vertex, size_t depth) override;
 
     void reset(arangodb::velocypack::StringRef const&) override;
 
@@ -227,6 +233,8 @@ class Traverser {
                                uint64_t depth,
                                arangodb::velocypack::StringRef& targetVertexId) = 0;
 
+  virtual bool getVertex(arangodb::velocypack::StringRef vertex, size_t depth) = 0;
+
  public:
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Builds only the last vertex as AQLValue
@@ -269,11 +277,11 @@ class Traverser {
   //////////////////////////////////////////////////////////////////////////////
 
   size_t getAndResetReadDocuments();
-  
+
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Get the number of HTTP requests made
   //////////////////////////////////////////////////////////////////////////////
-  
+
   size_t getAndResetHttpRequests();
 
   TraverserOptions* options() { return _opts; }

--- a/arangod/Graph/TraverserOptions.cpp
+++ b/arangod/Graph/TraverserOptions.cpp
@@ -74,9 +74,7 @@ TraverserOptions::TraverserOptions(aql::Query* query)
       uniqueVertices(UniquenessLevel::NONE),
       uniqueEdges(UniquenessLevel::PATH),
       mode(Mode::DFS),
-      defaultWeight(1.0) {
-  LOG_DEVEL << "TraverserOptions::TraverserOptions(aql::Query* query)";
-}
+      defaultWeight(1.0) {}
 
 TraverserOptions::TraverserOptions(aql::Query* query, VPackSlice const& obj)
     : BaseOptions(query),
@@ -89,8 +87,6 @@ TraverserOptions::TraverserOptions(aql::Query* query, VPackSlice const& obj)
       uniqueEdges(UniquenessLevel::PATH),
       mode(Mode::DFS),
       defaultWeight(1.0) {
-  LOG_DEVEL << "TraverserOptions::TraverserOptions(aql::Query* query, "
-               "VPackSlice const& obj)";
   TRI_ASSERT(obj.isObject());
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
@@ -104,7 +100,6 @@ TraverserOptions::TraverserOptions(aql::Query* query, VPackSlice const& obj)
   TRI_ASSERT(minDepth <= maxDepth);
 
   std::string tmp = VPackHelper::getStringValue(obj, "mode", "");
-  LOG_DEVEL << "mode = " << tmp << " obj = " << obj.toJson();
   if (!tmp.empty()) {
     if (tmp == "bfs") {
       mode = Mode::BFS;
@@ -210,8 +205,6 @@ TraverserOptions::TraverserOptions(arangodb::aql::Query* query, VPackSlice info,
       uniqueVertices(UniquenessLevel::NONE),
       uniqueEdges(UniquenessLevel::PATH),
       mode(Mode::DFS) {
-  LOG_DEVEL << "TraverserOptions::TraverserOptions(arangodb::aql::Query* "
-               "query, VPackSlice info, VPackSlice collections)";
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   VPackSlice type = info.get("type");
@@ -235,7 +228,6 @@ TraverserOptions::TraverserOptions(arangodb::aql::Query* query, VPackSlice info,
   maxDepth = read.getNumber<uint64_t>();
 
   read = info.get("mode");
-  LOG_DEVEL << "mode = " << read << " obj = " << info.toJson();
   if (!read.isInteger()) {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
                                    "The options require a mode");
@@ -432,8 +424,6 @@ TraverserOptions::TraverserOptions(TraverserOptions const& other, bool const all
       defaultWeight(1.0),
       vertexCollections(other.vertexCollections),
       edgeCollections(other.edgeCollections) {
-  LOG_DEVEL << "TraverserOptions::TraverserOptions(TraverserOptions const& "
-               "other, bool const allowAlreadyBuiltCopy)";
   if (!allowAlreadyBuiltCopy) {
     TRI_ASSERT(other._baseLookupInfos.empty());
     TRI_ASSERT(other._depthLookupInfo.empty());
@@ -836,8 +826,6 @@ void TraverserOptions::activatePrune(std::vector<aql::Variable const*> const&& v
 
 double TraverserOptions::weightEdge(VPackSlice edge) const {
   TRI_ASSERT(mode == Mode::WEIGHTED);
-  LOG_DEVEL << "TraverserOptions::weightEdge attr = " << weightAttribute
-            << " edge = " << edge.toJson();
   return arangodb::basics::VelocyPackHelper::getNumericValue<double>(edge, weightAttribute,
                                                                      defaultWeight);
 }

--- a/arangod/Graph/WeightedEnumerator.cpp
+++ b/arangod/Graph/WeightedEnumerator.cpp
@@ -68,8 +68,12 @@ bool WeightedEnumerator::expandEdge(NextEdge nextEdge) {
                            toVertex, nextEdge.accumWeight);
     LOG_DEVEL << "found vertex " << toVertex << " depth = " << nextEdge.depth
               << " weight = " << nextEdge.accumWeight;
-    // expand all edges on this vertex
-    expandVertex(_schreierIndex++, nextEdge.depth);
+
+    if (!shouldPrune()) {
+      // expand all edges on this vertex
+      expandVertex(_schreierIndex, nextEdge.depth);
+    }
+    _schreierIndex++;
     return true;
   } else {
     LOG_DEVEL << "vertex " << toVertex << " does not match conditions";
@@ -110,12 +114,12 @@ bool WeightedEnumerator::expandVertex(size_t vertexIndex, size_t depth) {
     VPackStringRef toVertex = _opts->cache()->persistString(getToVertex(e, vertex));
 
     if (depth < _opts->maxDepth - 1) {
-      // Prune here
-      if (!shouldPrune()) {
+      // Dont Prune here
+      //if (!shouldPrune()) {
         LOG_DEVEL << "new edge: "
                   << " weight = " << forwardWeight;
         _queue.emplace(vertexIndex, forwardWeight, depth + 1, std::move(eid), toVertex);
-      }
+      //}
     }
   });
 

--- a/arangod/Graph/WeightedEnumerator.cpp
+++ b/arangod/Graph/WeightedEnumerator.cpp
@@ -1,0 +1,337 @@
+#include "WeightedEnumerator.h"
+
+#include "Aql/PruneExpressionEvaluator.h"
+#include "Graph/EdgeCursor.h"
+#include "Graph/EdgeDocumentToken.h"
+#include "Graph/Traverser.h"
+#include "Graph/TraverserCache.h"
+#include "Graph/TraverserOptions.h"
+
+#include <velocypack/Slice.h>
+#include <velocypack/velocypack-aliases.h>
+
+#include <utility>
+
+using namespace arangodb;
+using namespace arangodb::graph;
+using namespace arangodb::traverser;
+
+WeightedEnumerator::PathStep::PathStep(arangodb::velocypack::StringRef vertex)
+    : fromIndex(0),
+      fromEdgeToken(EdgeDocumentToken()),
+      currentVertexId(std::move(vertex)),
+      accumWeight(0.0) {}
+
+WeightedEnumerator::PathStep::PathStep(size_t sourceIdx, EdgeDocumentToken&& edge,
+                                       arangodb::velocypack::StringRef vertex, double weight)
+    : fromIndex(sourceIdx),
+      fromEdgeToken(edge),
+      currentVertexId(std::move(vertex)),
+      accumWeight(weight) {}
+
+WeightedEnumerator::WeightedEnumerator(Traverser* traverser, TraverserOptions* opts)
+    : PathEnumerator(traverser, opts), _schreierIndex(0), _lastReturned(0) {
+  _schreier.reserve(32);
+}
+
+void WeightedEnumerator::setStartVertex(arangodb::velocypack::StringRef startVertex) {
+  PathEnumerator::setStartVertex(startVertex);
+
+  _schreier.clear();
+  _schreierIndex = 0;
+  _lastReturned = 0;
+  _queue.clear();
+
+  _schreier.emplace_back(startVertex);
+}
+
+bool WeightedEnumerator::expandEdge(NextEdge nextEdge) {
+
+  LOG_DEVEL << "expanding edge "
+            << " forward weight = " << nextEdge.accumWeight;
+
+  VPackStringRef const toVertex = nextEdge.forwardVertexId;
+
+  // we already have the toVertex, so we don't need to load the edge again
+  // getSingleVertex does nothing but that and checking conditions
+  // However, for global unique vertexes, we need the vertex getter.
+  if (_traverser->getVertex(toVertex, nextEdge.depth)) {
+    if (_opts->uniqueVertices == TraverserOptions::UniquenessLevel::PATH) {
+      if (pathContainsVertex(nextEdge.fromIndex, toVertex)) {
+        // This vertex is on the path.
+        return false;
+      } else {
+        LOG_DEVEL << "vertex " << toVertex << " is contained in path";
+      }
+    }
+    _schreier.emplace_back(nextEdge.fromIndex, std::move(nextEdge.forwardEdgeToken),
+                           toVertex, nextEdge.accumWeight);
+    LOG_DEVEL << "found vertex " << toVertex << " depth = " << nextEdge.depth
+              << " weight = " << nextEdge.accumWeight;
+    // expand all edges on this vertex
+    expandVertex(_schreierIndex++, nextEdge.depth);
+    return true;
+  } else {
+    LOG_DEVEL << "vertex " << toVertex << " does not match conditions";
+  }
+
+  return false;
+}
+
+bool WeightedEnumerator::expandVertex(size_t vertexIndex, size_t depth) {
+  PathStep const& currentStep = _schreier[vertexIndex];
+  VPackStringRef vertex = currentStep.currentVertexId;
+  EdgeCursor* cursor = getCursor(vertex, depth);
+  bool didInsert = false;
+
+  LOG_DEVEL << "expanding vertex " << vertex << " weight = " << currentStep.accumWeight;
+
+  cursor->readAll([&](graph::EdgeDocumentToken&& eid, VPackSlice e, size_t cursorIdx) -> void {
+    // transform edge if required
+    if (e.isString()) {
+      // this will result in a document request.
+      // however, shortest path has to do it as well, so I think this is ok.
+      e = _opts->cache()->lookupToken(eid);
+      // keep will eventually translate the edge if there is condition
+    }
+
+    if (!keepEdge(eid, e, vertex, depth, cursorIdx)) {
+      return;
+    }
+
+    if (_opts->uniqueEdges == TraverserOptions::UniquenessLevel::PATH) {
+      if (pathContainsEdge(vertexIndex, eid)) {
+        // This edge is on the path.
+        return;
+      }
+    }
+
+    double forwardWeight = currentStep.accumWeight + weightEdge(e);
+    VPackStringRef toVertex = _opts->cache()->persistString(getToVertex(e, vertex));
+
+    if (depth < _opts->maxDepth - 1) {
+      // Prune here
+      if (!shouldPrune()) {
+        LOG_DEVEL << "new edge: "
+                  << " weight = " << forwardWeight;
+        _queue.emplace(vertexIndex, forwardWeight, depth + 1, std::move(eid), toVertex);
+      }
+    }
+  });
+
+  incHttpRequests(cursor->httpRequests());
+
+  return didInsert;
+}
+
+bool WeightedEnumerator::expand() {
+  while (true) {
+    LOG_DEVEL << "Entering loop";
+    if (_queue.empty()) {
+      LOG_DEVEL << "Queue is empty, done";
+      // That's it. we are done.
+      return false;
+    }
+
+    // This access is always safe.
+    // If not it should have bailed out before.
+    TRI_ASSERT(!_queue.empty());
+    NextEdge nextEdge = _queue.popTop();
+
+    auto const nextIdx = nextEdge.fromIndex;
+    auto const nextVertex = _schreier[nextIdx].currentVertexId;
+
+    LOG_DEVEL << "Queue top: weight = " << nextEdge.accumWeight
+              << ", depth = " << nextEdge.depth << " vertex = " << nextVertex;
+
+    bool shouldReturnPath = nextEdge.depth + 1 >= _opts->minDepth;
+
+    bool didInsert = expandEdge(std::move(nextEdge));
+
+    if (!shouldReturnPath) {
+      _lastReturned = _schreierIndex;
+      didInsert = false;
+    }
+    if (didInsert) {
+      // We exit the loop here.
+      // _schreierIndex is moved forward
+      return true;
+    }
+  }
+}
+
+bool WeightedEnumerator::next() {
+  if (_isFirst) {
+    _isFirst = false;
+
+    if (!shouldPrune()) {
+      expandVertex(0, 0);
+    }
+    // We have faked the 0 position in schreier for pruning
+    _schreierIndex++;
+    if (_opts->minDepth == 0) {
+      return true;
+    }
+  }
+  _lastReturned++;
+
+  if (_lastReturned < _schreierIndex) {
+    // We still have something on our stack.
+    // Paths have been read but not returned.
+    return true;
+  }
+
+  if (_opts->maxDepth == 0) {
+    // Short circuit.
+    // We cannot find any path of length 0 or less
+    return false;
+  }
+
+  // otherwise expand "schreier" vector
+  return expand();
+}
+
+arangodb::aql::AqlValue WeightedEnumerator::lastVertexToAqlValue() {
+  return vertexToAqlValue(_lastReturned);
+}
+
+arangodb::aql::AqlValue WeightedEnumerator::lastEdgeToAqlValue() {
+  return edgeToAqlValue(_lastReturned);
+}
+
+arangodb::aql::AqlValue WeightedEnumerator::pathToAqlValue(arangodb::velocypack::Builder& result) {
+  return pathToIndexToAqlValue(result, _lastReturned);
+}
+
+arangodb::aql::AqlValue WeightedEnumerator::vertexToAqlValue(size_t index) {
+  TRI_ASSERT(index < _schreier.size());
+  return _traverser->fetchVertexData(_schreier[index].currentVertexId);
+}
+
+arangodb::aql::AqlValue WeightedEnumerator::edgeToAqlValue(size_t index) {
+  TRI_ASSERT(index < _schreier.size());
+  if (index == 0) {
+    // This is the first Vertex. No Edge Pointing to it
+    return arangodb::aql::AqlValue(arangodb::aql::AqlValueHintNull());
+  }
+  return _opts->cache()->fetchEdgeAqlResult(_schreier[index].fromEdgeToken);
+}
+
+VPackSlice WeightedEnumerator::pathToIndexToSlice(VPackBuilder& result, size_t index) {
+  for (_tempPathHelper.clear(); index != 0; index = _schreier[index].fromIndex) {
+    _tempPathHelper.emplace_back(index);
+  }
+
+  result.clear();
+  {
+    VPackObjectBuilder ob(&result);
+    {  // edges
+      VPackArrayBuilder ab(&result, StaticStrings::GraphQueryEdges);
+      std::for_each(_tempPathHelper.rbegin(), _tempPathHelper.rend(), [&](size_t idx) {
+        _opts->cache()->insertEdgeIntoResult(_schreier[idx].fromEdgeToken, result);
+      });
+    }
+    {  // vertices
+      VPackArrayBuilder ab(&result, StaticStrings::GraphQueryVertices);
+      _traverser->addVertexToVelocyPack(_schreier[0].currentVertexId, result);
+      std::for_each(_tempPathHelper.rbegin(), _tempPathHelper.rend(), [&](size_t idx) {
+        _traverser->addVertexToVelocyPack(_schreier[idx].currentVertexId, result);
+      });
+    }
+    {  // weights
+      VPackArrayBuilder ab(&result, "weights");
+      result.add(VPackValue(_schreier[0].accumWeight));
+      std::for_each(_tempPathHelper.rbegin(), _tempPathHelper.rend(), [&](size_t idx) {
+        result.add(VPackValue(_schreier[idx].accumWeight));
+      });
+    }
+  }
+  TRI_ASSERT(result.isClosed());
+  return result.slice();
+}
+
+arangodb::aql::AqlValue WeightedEnumerator::pathToIndexToAqlValue(arangodb::velocypack::Builder& result,
+                                                                  size_t index) {
+  return arangodb::aql::AqlValue(pathToIndexToSlice(result, index));
+}
+
+bool WeightedEnumerator::pathContainsVertex(size_t index,
+                                            arangodb::velocypack::StringRef vertex) const {
+  while (true) {
+    TRI_ASSERT(index < _schreier.size());
+    auto const& step = _schreier[index];
+    if (step.currentVertexId == vertex) {
+      // We have the given vertex on this path
+      return true;
+    }
+    if (index == 0) {
+      // We have checked the complete path
+      return false;
+    }
+    index = step.fromIndex;
+  }
+}
+
+bool WeightedEnumerator::pathContainsEdge(size_t index,
+                                          graph::EdgeDocumentToken const& edge) const {
+  while (index != 0) {
+    TRI_ASSERT(index < _schreier.size());
+    auto const& step = _schreier[index];
+    if (step.fromEdgeToken.equals(edge)) {
+      // We have the given edge on this path
+      return true;
+    }
+    index = step.fromIndex;
+  }
+  // We have checked the complete path
+  return false;
+}
+
+bool WeightedEnumerator::shouldPrune() {
+  if (!_opts->usesPrune()) {
+    return false;
+  }
+
+  transaction::BuilderLeaser pathBuilder(_opts->trx());
+
+  // evaluator->evaluate() might access these, so they have to live long enough.
+  aql::AqlValue vertex, edge;
+  aql::AqlValueGuard vertexGuard{vertex, true}, edgeGuard{edge, true};
+
+  auto* evaluator = _opts->getPruneEvaluator();
+  TRI_ASSERT(evaluator != nullptr);
+
+  if (evaluator->needsVertex()) {
+    // Note: vertexToAqlValue() copies the original vertex into the AqlValue.
+    // This could be avoided with a function that just returns the slice,
+    // as it will stay valid long enough.
+    vertex = vertexToAqlValue(_schreierIndex);
+    evaluator->injectVertex(vertex.slice());
+  }
+  if (evaluator->needsEdge()) {
+    // Note: edgeToAqlValue() copies the original edge into the AqlValue.
+    // This could be avoided with a function that just returns the slice,
+    // as it will stay valid long enough.
+    edge = edgeToAqlValue(_schreierIndex);
+    evaluator->injectEdge(edge.slice());
+  }
+  if (evaluator->needsPath()) {
+    VPackSlice path = pathToIndexToSlice(*pathBuilder.get(), _schreierIndex);
+    evaluator->injectPath(path);
+  }
+  return evaluator->evaluate();
+}
+
+double WeightedEnumerator::weightEdge(VPackSlice edge) const {
+  return _opts->weightEdge(edge);
+}
+
+velocypack::StringRef WeightedEnumerator::getToVertex(velocypack::Slice edge,
+                                                      velocypack::StringRef from) {
+  TRI_ASSERT(edge.isObject());
+  VPackSlice resSlice = transaction::helpers::extractToFromDocument(edge);
+  if (resSlice.isEqualString(from)) {
+    resSlice = transaction::helpers::extractFromFromDocument(edge);
+  }
+  return resSlice.stringRef();
+}

--- a/arangod/Graph/WeightedEnumerator.h
+++ b/arangod/Graph/WeightedEnumerator.h
@@ -1,0 +1,138 @@
+#ifndef ARANGODB_GRAPH_WEIGHTEDENUMERATOR_H
+#define ARANGODB_GRAPH_WEIGHTEDENUMERATOR_H 1
+
+#include "Basics/Common.h"
+#include "Graph/PathEnumerator.h"
+
+#include <memory>
+#include <queue>
+#include <vector>
+
+namespace arangodb {
+
+namespace traverser {
+class Traverser;
+struct TraverserOptions;
+}  // namespace traverser
+
+namespace graph {
+class EdgeCursor;
+
+class WeightedEnumerator final : public arangodb::traverser::PathEnumerator {
+ private:
+  struct PathStep {
+    size_t fromIndex;
+    graph::EdgeDocumentToken fromEdgeToken;
+    arangodb::velocypack::StringRef currentVertexId;
+    double accumWeight;
+
+   public:
+    explicit PathStep(arangodb::velocypack::StringRef vertex);
+
+    PathStep(size_t sourceIdx, graph::EdgeDocumentToken&& edge,
+             arangodb::velocypack::StringRef vertex, double weight);
+
+    ~PathStep() = default;
+
+    PathStep(PathStep const& other) = default;
+    PathStep& operator=(PathStep const& other) = delete;
+  };
+
+  /// @brief Struct to hold all information required to get the list of
+  ///        connected edges
+  struct NextEdge {
+    size_t fromIndex;
+    double accumWeight;
+    size_t depth;
+
+    graph::EdgeDocumentToken forwardEdgeToken;
+    arangodb::velocypack::StringRef forwardVertexId;
+
+   private:
+    NextEdge() = delete;
+
+   public:
+    explicit NextEdge(size_t fromIndex, double accumWeight, size_t depth, graph::EdgeDocumentToken forwardEdgeToken,
+                      arangodb::velocypack::StringRef forwardVertexId)
+        : fromIndex(fromIndex),
+          accumWeight(accumWeight),
+          depth(depth),
+          forwardEdgeToken(std::move(forwardEdgeToken)),
+          forwardVertexId(std::move(forwardVertexId)) {}
+
+    bool operator<(NextEdge const& other) const {
+      return accumWeight < other.accumWeight;
+    }
+    bool operator>(NextEdge const& other) const {
+      return accumWeight > other.accumWeight;
+    }
+  };
+
+  /// @brief schreier vector to store the visited vertices
+  std::vector<PathStep> _schreier;
+
+  /// @brief Next free index in schreier vector.
+  size_t _schreierIndex;
+
+  /// @brief Position of the last returned value in the schreier vector
+  size_t _lastReturned;
+
+  template <typename T>
+  using min_heap = std::priority_queue<T, std::vector<T>, std::greater<T>>;
+
+  template <typename T>
+  struct clearable_min_heap : min_heap<T> {
+    using min_heap<T>::min_heap;
+
+    void clear() { this->c.clear(); }
+    T popTop() {
+      T top = std::move(this->top());
+      this->pop();
+      return top;
+    }
+  };
+
+  /// @brief Queue to store where to continue search on next depth
+  clearable_min_heap<NextEdge> _queue;
+
+  /// @brief helper vector that is used temporarily when building the path
+  /// output. We hold this as member to keep underlying memory.
+  std::vector<size_t> _tempPathHelper;
+
+ public:
+  WeightedEnumerator(arangodb::traverser::Traverser* traverser,
+                     arangodb::traverser::TraverserOptions* opts);
+
+  ~WeightedEnumerator() = default;
+
+  void setStartVertex(arangodb::velocypack::StringRef startVertex) override;
+
+  /// @brief Get the next Path element from the traversal.
+  bool next() override;
+
+  aql::AqlValue lastVertexToAqlValue() override;
+  aql::AqlValue lastEdgeToAqlValue() override;
+  aql::AqlValue pathToAqlValue(arangodb::velocypack::Builder& result) override;
+
+ private:
+  bool pathContainsVertex(size_t index, arangodb::velocypack::StringRef vertex) const;
+  bool pathContainsEdge(size_t index, graph::EdgeDocumentToken const& edge) const;
+
+  aql::AqlValue vertexToAqlValue(size_t index);
+  aql::AqlValue edgeToAqlValue(size_t index);
+  aql::AqlValue pathToIndexToAqlValue(arangodb::velocypack::Builder& result, size_t index);
+  velocypack::Slice pathToIndexToSlice(arangodb::velocypack::Builder& result, size_t index);
+
+  bool shouldPrune();
+  double weightEdge(arangodb::velocypack::Slice edge) const;
+
+  bool expand();
+  bool expandVertex(size_t vertexIndex, size_t depth);
+  bool expandEdge(NextEdge edge);
+
+  static velocypack::StringRef getToVertex(velocypack::Slice edge, velocypack::StringRef from);
+};
+}  // namespace graph
+}  // namespace arangodb
+
+#endif

--- a/tests/js/server/aql/aql-graph-weighted-traversal.js
+++ b/tests/js/server/aql/aql-graph-weighted-traversal.js
@@ -1,0 +1,161 @@
+/*jshint globalstrict:false, strict:false, sub: true, maxlen: 500 */
+/*global assertEqual, assertTrue, assertFalse */
+
+const jsunity = require("jsunity");
+const db = require("@arangodb").db;
+const gm = require("@arangodb/general-graph");
+const _ = require("underscore");
+
+/*
+
+  1 - 1 > 2 - 10 > 3 -> 5
+   \       /
+     4 -> 6
+
+ */
+function WeightedTraveralsTestSuite() {
+
+  const graphName = "UnitTestGraph";
+  const vName = "UnitTestVertices";
+  const eName = "UnitTestEdges";
+
+  function createGraph () {
+    gm._create(graphName, [gm._relation(eName, vName, vName)], [], {});
+
+    const vertexes = [
+      { _key: "1", value: 1 },
+      { _key: "2", value: 1 },
+      { _key: "3", value: 1 },
+      { _key: "4", value: 1 },
+      { _key: "5", value: 1 },
+      { _key: "6", value: 0 },
+    ];
+
+    const edges = [
+      { _from: `${vName}/1`, _to: `${vName}/2`, weight: 1 },
+      { _from: `${vName}/2`, _to: `${vName}/3`, weight: 10 },
+      { _from: `${vName}/1`, _to: `${vName}/4`, weight: 1.5 },
+      { _from: `${vName}/4`, _to: `${vName}/6`, weight: 2 },
+      { _from: `${vName}/6`, _to: `${vName}/3`, weight: 0.5 },
+      { _from: `${vName}/3`, _to: `${vName}/5`, weight: 1 },
+    ];
+
+    db[vName].insert(vertexes);
+    db[eName].insert(edges);
+  }
+
+
+  return {
+    setUpAll : function () {
+      createGraph();
+    },
+
+    tearDownAll : function () {
+      gm._drop(graphName, true);
+    },
+
+    testSimpleTraversal : function () {
+      const query = `
+        FOR v, e, p IN 1..10 OUTBOUND "${vName}/1" GRAPH "${graphName}"
+          OPTIONS {mode: "weighted", weightAttribute: "weight"}
+          LIMIT 3
+          RETURN {path: p.vertices[*]._key, weight: p.weights[-1]}
+      `;
+
+      const expectedResult = [
+        { "path" : [ "1", "2" ], "weight" : 1 },
+        { "path" : [ "1", "4" ], "weight" : 1.5 },
+        { "path" : [ "1", "4", "6" ], "weight" : 3.5 }
+      ];
+
+      const result = db._query(query).toArray();
+      assertEqual(expectedResult, result);
+    },
+
+    testShortestPath : function () {
+      const target = `${vName}/5`;
+
+      const query = `
+        FOR v, e, p IN 0..10 OUTBOUND "${vName}/1" GRAPH "${graphName}"
+          PRUNE v._id == "${target}"
+          OPTIONS {mode: "weighted", weightAttribute: "weight", uniqueVertices: "global"}
+          FILTER v._id == "${target}"
+          LIMIT 1
+          RETURN {path: p.vertices[*]._key, weight: p.weights[-1]}
+      `;
+
+      const expectedResult = [
+        { "path" : [ "1", "4", "6", "3", "5" ], "weight" : 5 }
+      ];
+
+      const result = db._query(query).toArray();
+      assertEqual(expectedResult, result);
+    },
+
+    testShortestPathWithVertexCondition : function () {
+      const target = `${vName}/5`;
+
+      const query = `
+        FOR v, e, p IN 1..10 OUTBOUND "${vName}/1" GRAPH "${graphName}"
+          PRUNE v._id == "${target}"
+          OPTIONS {mode: "weighted", weightAttribute: "weight", uniqueVertices: "global"}
+          FILTER p.vertices[*].value ALL > 0
+          FILTER v._id == "${target}"
+          LIMIT 1
+          RETURN {path: p.vertices[*]._key, weight: p.weights[-1]}
+      `;
+
+      const expectedResult = [
+        { "path" : [ "1", "2", "3", "5" ], "weight" : 12 }
+      ];
+
+      const result = db._query(query).toArray();
+      assertEqual(expectedResult, result);
+    },
+
+    testShortestPathWithEdgeCondition : function () {
+      const target = `${vName}/5`;
+
+      const query = `
+        FOR v, e, p IN 1..10 OUTBOUND "${vName}/1" GRAPH "${graphName}"
+          PRUNE v._id == "${target}"
+          OPTIONS {mode: "weighted", weightAttribute: "weight", uniqueVertices: "global"}
+          FILTER p.edges[*].weight ALL >= 1
+          FILTER v._id == "${target}"
+          LIMIT 1
+          RETURN {path: p.vertices[*]._key, weight: p.weights[-1]}
+      `;
+
+      const expectedResult = [
+        { "path" : [ "1", "2", "3", "5" ], "weight" : 12 }
+      ];
+
+      const result = db._query(query).toArray();
+      assertEqual(expectedResult, result);
+    },
+
+    testKShortestPaths : function () {  // slow version :D
+      const target = `${vName}/5`;
+
+      const query = `
+        FOR v, e, p IN 1..10 OUTBOUND "${vName}/1" GRAPH "${graphName}"
+          PRUNE v._id == "${target}"
+          OPTIONS {mode: "weighted", weightAttribute: "weight", uniqueVertices: "path"}
+          FILTER v._id == "${target}"
+          LIMIT 3
+          RETURN {path: p.vertices[*]._key, weight: p.weights[-1]}
+      `;
+
+      const expectedResult = [
+        { "path" : [ "1", "4", "6", "3", "5" ], "weight" : 5 },
+        { "path" : [ "1", "2", "3", "5" ], "weight" : 12 }
+      ];
+
+      const result = db._query(query).toArray();
+      assertEqual(expectedResult, result);
+    }
+  };
+}
+
+jsunity.run(WeightedTraveralsTestSuite);
+return jsunity.done();


### PR DESCRIPTION
Hay guys <3 this is my corona open source output! :P

### Scope & Purpose


PR adds a `mode` field to traversal options (deprecating old `bfs: true`) now allowing following value: `dfs` (default), `bfs` and `weighted`. In weighted mode there is now a `weightAttribute` and `defaultWeight` attribute with same semantics as for shortest path traversals. Paths are enumerate by increasing length. Furthermore returned path has a new attribute `weights` that contains the weights at each individual step.

For example:
```
for x, v, p in 0..10 outbound "places/York" graph "kShortestPathsGraph" options {mode: "weighted", weightAttribute: "travelTime", uniqueVertices: "path"}
    FILTER p.edges[*].travelTime ALL < 3
    let totalTime = LAST(p.weights)
    FILTER totalTime < 6
    SORT totalTime DESC
    return {path: p.vertices[*]._key, weight: LAST(p.weights), weights: p.edges[*].travelTime}
```

returns
path | weight | weights
-- | -- | --
["York","London","Birmingham","Carlisle"] | 5.3 | [1.8,2.5,1]
["York","London","Birmingham"] | 4.3 | [1.8,2.5]
["York","London","Brussels"] | 4.3 | [1.8,2.5]
["York","London"] | 1.8 | [1.8]
["York"] | 0 | []

I'd like to ask for your feed back on this. Of course I will add tests later. It should work with all other options like `uniqueVertices` and `uniqueEdges`. Important case `uniqueVertices: "global"` <3

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [ ] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

Additionally:
- [x] I ensured this code runs with ASan / TSan or other static verification tools

### Documentation

Will add if you like the change.

- [ ] Added a *Changelog Entry* (referencing the corresponding public or internal issue number)
- [ ] Added a new section in the *Manual* 
