### PR TITLE
Feature/out of search in range

### DIFF
--- a/arangod/Aql/AqlFunctionFeature.cpp
+++ b/arangod/Aql/AqlFunctionFeature.cpp
@@ -223,7 +223,7 @@ void AqlFunctionFeature::addStringFunctions() {
   add({"NGRAM_MATCH", ".,.|.,.", flags, &Functions::NgramMatch}); // (attribute, target, [threshold, analyzer]) OR (attribute, target, [analyzer])
   add({"NGRAM_SIMILARITY", ".,.,.", flags, &Functions::NgramSimilarity}); // (attribute, target, ngram size)
   add({"NGRAM_POSITIONAL_SIMILARITY", ".,.,.", flags, &Functions::NgramPositionalSimilarity}); // (attribute, target, ngram size)
-  add({"IN_RANGE", ".,.,.,.,.", flags, &Functions::InRange });
+  add({"IN_RANGE", ".,.,.,.,.", flags, &Functions::InRange }); // (attribute, lower, upper, include lower, include upper)
   // special flags:
   add({"RANDOM_TOKEN", ".", Function::makeFlags(FF::CanRunOnDBServer),
        &Functions::RandomToken});  // not deterministic and not cacheable

--- a/arangod/Aql/AqlFunctionFeature.cpp
+++ b/arangod/Aql/AqlFunctionFeature.cpp
@@ -223,6 +223,7 @@ void AqlFunctionFeature::addStringFunctions() {
   add({"NGRAM_MATCH", ".,.|.,.", flags, &Functions::NgramMatch}); // (attribute, target, [threshold, analyzer]) OR (attribute, target, [analyzer])
   add({"NGRAM_SIMILARITY", ".,.,.", flags, &Functions::NgramSimilarity}); // (attribute, target, ngram size)
   add({"NGRAM_POSITIONAL_SIMILARITY", ".,.,.", flags, &Functions::NgramPositionalSimilarity}); // (attribute, target, ngram size)
+  add({"IN_RANGE", ".,.,.,.,.", flags, &Functions::InRange });
   // special flags:
   add({"RANDOM_TOKEN", ".", Function::makeFlags(FF::CanRunOnDBServer),
        &Functions::RandomToken});  // not deterministic and not cacheable

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -1845,7 +1845,7 @@ AqlValue Functions::InRange(ExpressionContext* ctx, transaction::Methods* trx,
     registerWarning(
       ctx, AFN,
       arangodb::Result{ TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH,
-                        "4 arguments are expected." });
+                        "5 arguments are expected." });
     return AqlValue(AqlValueHintNull());
   }
 

--- a/arangod/Aql/Functions.h
+++ b/arangod/Aql/Functions.h
@@ -157,6 +157,8 @@ struct Functions {
                                             VPackFunctionParameters const&);
   static AqlValue NgramMatch(ExpressionContext*, transaction::Methods*,
                              VPackFunctionParameters const&);
+  static AqlValue InRange(ExpressionContext*, transaction::Methods*,
+                          VPackFunctionParameters const&);
   // Date
   static AqlValue DateNow(arangodb::aql::ExpressionContext*,
                           transaction::Methods*, VPackFunctionParameters const&);

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -403,7 +403,6 @@ void registerFilters(arangodb::aql::AqlFunctionFeature& functions) {
   addFunction(functions, { "EXISTS", ".|.,.", flags, &dummyFilterFunc });  // (attribute, [ // "analyzer"|"type"|"string"|"numeric"|"bool"|"null" // ])
   addFunction(functions, { "STARTS_WITH", ".,.|.", flags, &startsWithFunc });  // (attribute, prefix, scoring-limit)
   addFunction(functions, { "PHRASE", ".,.|.+", flags, &dummyFilterFunc });  // (attribute, input [, offset, input... ] [, analyzer])
-//!!!!!!  addFunction(functions, { "IN_RANGE", ".,.,.,.,.", flags, &dummyFilterFunc });  // (attribute, lower, upper, include lower, include upper)
   addFunction(functions, { "MIN_MATCH", ".,.|.+", flags, &minMatchFunc });  // (filter expression [, filter expression, ... ], min match count)
   addFunction(functions, { "BOOST", ".,.", flags, &contextFunc });  // (filter expression, boost)
   addFunction(functions, { "ANALYZER", ".,.", flags, &contextFunc });  // (filter expression, analyzer)

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -96,7 +96,7 @@ arangodb::aql::AqlValue dummyFilterFunc(arangodb::aql::ExpressionContext*,
                                         arangodb::containers::SmallVector<arangodb::aql::AqlValue> const&) {
   THROW_ARANGO_EXCEPTION_MESSAGE(
       TRI_ERROR_NOT_IMPLEMENTED,
-      "ArangoSearch filter functions EXISTS, IN_RANGE, PHRASE "
+      "ArangoSearch filter functions EXISTS, PHRASE "
       " are designed to be used only within a corresponding SEARCH statement "
       "of ArangoSearch view."
       " Please ensure function signature is correct.");
@@ -403,7 +403,7 @@ void registerFilters(arangodb::aql::AqlFunctionFeature& functions) {
   addFunction(functions, { "EXISTS", ".|.,.", flags, &dummyFilterFunc });  // (attribute, [ // "analyzer"|"type"|"string"|"numeric"|"bool"|"null" // ])
   addFunction(functions, { "STARTS_WITH", ".,.|.", flags, &startsWithFunc });  // (attribute, prefix, scoring-limit)
   addFunction(functions, { "PHRASE", ".,.|.+", flags, &dummyFilterFunc });  // (attribute, input [, offset, input... ] [, analyzer])
-  addFunction(functions, { "IN_RANGE", ".,.,.,.,.", flags, &dummyFilterFunc });  // (attribute, lower, upper, include lower, include upper)
+//!!!!!!  addFunction(functions, { "IN_RANGE", ".,.,.,.,.", flags, &dummyFilterFunc });  // (attribute, lower, upper, include lower, include upper)
   addFunction(functions, { "MIN_MATCH", ".,.|.+", flags, &minMatchFunc });  // (filter expression [, filter expression, ... ], min match count)
   addFunction(functions, { "BOOST", ".,.", flags, &contextFunc });  // (filter expression, boost)
   addFunction(functions, { "ANALYZER", ".,.", flags, &contextFunc });  // (filter expression, analyzer)
@@ -584,7 +584,8 @@ bool isFilter(arangodb::aql::Function const& func) noexcept {
          func.implementation == &startsWithFunc ||
          func.implementation == &aql::Functions::LevenshteinMatch ||
          func.implementation == &aql::Functions::Like ||
-         func.implementation == &aql::Functions::NgramMatch;
+         func.implementation == &aql::Functions::NgramMatch ||
+         func.implementation == &aql::Functions::InRange;
 }
 
 bool isScorer(arangodb::aql::Function const& func) noexcept {

--- a/tests/Aql/InRangeFunctionTest.cpp
+++ b/tests/Aql/InRangeFunctionTest.cpp
@@ -1,0 +1,159 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Andrey Abramov
+////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "fakeit.hpp"
+
+#include "Aql/ExpressionContext.h"
+#include "Aql/Functions.h"
+#include "Containers/SmallVector.h"
+#include "Transaction/Context.h"
+#include "Transaction/Methods.h"
+
+#include <velocypack/Builder.h>
+#include <velocypack/Iterator.h>
+#include <velocypack/Parser.h>
+#include <velocypack/Slice.h>
+#include <velocypack/velocypack-aliases.h>
+
+using namespace arangodb;
+using namespace arangodb::aql;
+using namespace arangodb::containers;
+
+namespace {
+
+AqlValue evaluate(AqlValue const& lhs,
+                  AqlValue const& rhs,
+                  AqlValue const& distance,
+                  AqlValue const* transpositions = nullptr) {
+  fakeit::Mock<ExpressionContext> expressionContextMock;
+  ExpressionContext& expressionContext = expressionContextMock.get();
+  fakeit::When(Method(expressionContextMock, registerWarning)).AlwaysDo([](int, char const*){ });
+
+  fakeit::Mock<transaction::Context> trxCtxMock;
+  fakeit::When(Method(trxCtxMock, getVPackOptions)).AlwaysDo([](){
+    static VPackOptions options;
+    return &options;
+  });
+  transaction::Context& trxCtx = trxCtxMock.get();
+
+  fakeit::Mock<transaction::Methods> trxMock;
+  fakeit::When(Method(trxMock, transactionContextPtr)).AlwaysDo([&trxCtx](){ return &trxCtx; });
+  transaction::Methods& trx = trxMock.get();
+
+  SmallVector<AqlValue>::allocator_type::arena_type arena;
+  SmallVector<AqlValue> params{arena};
+  params.emplace_back(lhs);
+  params.emplace_back(rhs);
+  params.emplace_back(distance);
+  if (transpositions) {
+    params.emplace_back(*transpositions);
+    params.emplace_back(VPackSlice::nullSlice()); // redundant argument
+  }
+
+  return Functions::LevenshteinMatch(&expressionContext, &trx, params);
+}
+
+void assertLevenshteinMatchFail(AqlValue const& lhs,
+                                AqlValue const& rhs,
+                                AqlValue const& distance,
+                                AqlValue const* transpositions = nullptr) {
+  ASSERT_TRUE(evaluate(lhs, rhs, distance, transpositions).isNull(false));
+  ASSERT_TRUE(evaluate(rhs, lhs, distance, transpositions).isNull(false));
+}
+
+void assertLevenshteinMatch(bool expectedValue,
+                            AqlValue const& lhs,
+                            AqlValue const& rhs,
+                            AqlValue const& distance,
+                            AqlValue const* transpositions = nullptr) {
+  auto assertLevenshteinMatchValue = [](
+      bool expectedValue,
+      AqlValue const& lhs,
+      AqlValue const& rhs,
+      AqlValue const& distance,
+      AqlValue const* transpositions = nullptr) {
+    auto const value = evaluate(lhs, rhs, distance, transpositions);
+    ASSERT_TRUE(value.isBoolean());
+    ASSERT_EQ(expectedValue, value.toBoolean());
+  };
+
+  assertLevenshteinMatchValue(expectedValue, lhs, rhs, distance, transpositions);
+  assertLevenshteinMatchValue(expectedValue, rhs, lhs, distance, transpositions);
+}
+
+}
+
+TEST(LevenshteinMatchFunctionTest, test) {
+  AqlValue const Damerau{AqlValueHintBool{true}};
+  AqlValue const Levenshtein{AqlValueHintBool{false}};
+  AqlValue const InvalidNull{AqlValueHintNull{}};
+  AqlValue const InvalidInt{AqlValueHintInt{1}};
+  AqlValue const InvalidArray{AqlValueHintEmptyArray{}};
+  AqlValue const InvalidObject{AqlValueHintEmptyObject{}};
+
+  assertLevenshteinMatch(false, AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{0}), &Levenshtein);
+  assertLevenshteinMatch(false, AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{0}));
+  assertLevenshteinMatch(false, AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{0}), &Damerau);
+  assertLevenshteinMatch(false, AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{1}), &Levenshtein);
+  assertLevenshteinMatch(false, AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{1}));
+  assertLevenshteinMatch(false, AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{1}), &Damerau);
+  assertLevenshteinMatch(true,  AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{2}), &Levenshtein);
+  assertLevenshteinMatch(true,  AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{2}));
+  assertLevenshteinMatch(true,  AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{2}), &Damerau);
+  assertLevenshteinMatch(true,  AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintDouble{2}), &Damerau);
+  assertLevenshteinMatch(true,  AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintDouble{2.5}), &Damerau);
+  assertLevenshteinMatch(true,  AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{3}), &Levenshtein);
+  assertLevenshteinMatch(true,  AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{3}));
+  assertLevenshteinMatch(true,  AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{3}), &Damerau);
+  assertLevenshteinMatch(true,  AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{4}), &Levenshtein);
+  assertLevenshteinMatch(true,  AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{4}));
+  assertLevenshteinMatch(true,  AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{5}), &Levenshtein);
+  assertLevenshteinMatch(true, AqlValue(AqlValueHintNull{}), AqlValue("aa"), AqlValue(AqlValueHintInt{2}), &Levenshtein);
+  assertLevenshteinMatch(false, AqlValue(AqlValueHintEmptyArray{}), AqlValue("aa"), AqlValue(AqlValueHintInt{1}), &Levenshtein);
+  assertLevenshteinMatch(true, AqlValue(AqlValueHintEmptyObject{}), AqlValue("aa"), AqlValue(AqlValueHintInt{2}), &Levenshtein);
+  assertLevenshteinMatch(true, AqlValue(AqlValueHintInt{1}), AqlValue("aa"), AqlValue(AqlValueHintInt{2}), &Levenshtein);
+  assertLevenshteinMatch(true, AqlValue(AqlValueHintDouble{1.}), AqlValue("aa"), AqlValue(AqlValueHintInt{2}), &Levenshtein);
+  assertLevenshteinMatch(true, AqlValue(AqlValueHintBool{false}), AqlValue("aa"), AqlValue(AqlValueHintInt{2}), &Levenshtein);
+  assertLevenshteinMatch(false, AqlValue(AqlValueHintNull{}), AqlValue("aa"), AqlValue(AqlValueHintInt{1}), &Damerau);
+  assertLevenshteinMatch(true, AqlValue(AqlValueHintEmptyArray{}), AqlValue("aa"), AqlValue(AqlValueHintInt{2}), &Damerau);
+  assertLevenshteinMatch(true, AqlValue(AqlValueHintEmptyObject{}), AqlValue("aa"), AqlValue(AqlValueHintInt{2}), &Damerau);
+  assertLevenshteinMatch(true, AqlValue(AqlValueHintInt{1}), AqlValue("aa"), AqlValue(AqlValueHintInt{2}), &Damerau);
+  assertLevenshteinMatch(true, AqlValue(AqlValueHintDouble{1.}), AqlValue("aa"), AqlValue(AqlValueHintInt{2}), &Damerau);
+  assertLevenshteinMatch(true, AqlValue(AqlValueHintBool{false}), AqlValue("aa"), AqlValue(AqlValueHintInt{2}), &Damerau);
+  assertLevenshteinMatch(false, AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{1}), &Levenshtein);
+  assertLevenshteinMatch(false, AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintDouble{1.}), &Levenshtein);
+  assertLevenshteinMatchFail(AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintNull{}), &Levenshtein);
+  assertLevenshteinMatchFail(AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintEmptyArray{}), &Levenshtein);
+  assertLevenshteinMatchFail(AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintEmptyObject{}), &Levenshtein);
+  assertLevenshteinMatchFail(AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintBool{false}), &Levenshtein);
+  assertLevenshteinMatchFail(AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{5}), &InvalidNull);
+  assertLevenshteinMatchFail(AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{5}), &InvalidInt);
+  assertLevenshteinMatchFail(AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{5}), &InvalidArray);
+  assertLevenshteinMatchFail(AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{5}), &InvalidObject);
+  assertLevenshteinMatchFail(AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{-1}));
+  assertLevenshteinMatchFail(AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{-1}), &Damerau);
+  assertLevenshteinMatchFail(AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{-1}), &Levenshtein);
+  assertLevenshteinMatchFail(AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{4}), &Damerau);
+  assertLevenshteinMatchFail(AqlValue("aa"), AqlValue("aaaa"), AqlValue(AqlValueHintInt{5}), &Damerau);
+}

--- a/tests/Aql/InRangeFunctionTest.cpp
+++ b/tests/Aql/InRangeFunctionTest.cpp
@@ -111,9 +111,11 @@ class InRangeFunctionTest : public ::testing::Test {
     bool includeUpper) {
     SCOPED_TRACE(testing::Message("assertInRange failed on line:") << line);
     std::set<int> warnings;
+    AqlValue includeLowerAql{ AqlValueHintBool(includeLower) };
+    AqlValue includeUpperAql{ AqlValueHintBool(includeUpper) };
     auto value = evaluate(attribute, lower, upper,
-      &AqlValue(AqlValueHintBool(includeLower)),
-      &AqlValue(AqlValueHintBool(includeUpper)), &warnings);
+      &includeLowerAql,
+      &includeUpperAql, &warnings);
     ASSERT_TRUE(warnings.empty());
     ASSERT_TRUE(value.isBoolean());
     ASSERT_EQ(expectedValue, value.toBoolean());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(ARANGODB_TESTS_SOURCES
   Aql/CalculationExecutorTest.cpp
   Aql/CountCollectExecutorTest.cpp
   Aql/DateFunctionsTest.cpp
+  Aql/InRangeFunctionTest.cpp
   Aql/JaccardFunctionTest.cpp
   Aql/LevenshteinMatchFunctionTest.cpp
   Aql/DependencyProxyMock.cpp

--- a/tests/js/server/aql/aql-functions.js
+++ b/tests/js/server/aql/aql-functions.js
@@ -4124,6 +4124,64 @@ function ahuacatlFunctionsTestSuite () {
     },
 
 ////////////////////////////////////////////////////////////////////////////////
+/// @brief test IN_RANGE function
+////////////////////////////////////////////////////////////////////////////////
+    testInRange: function () {
+      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN IN_RANGE()");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, 
+        "RETURN IN_RANGE(123, 0, 500, null, true)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, 
+        "RETURN IN_RANGE(123, 0, 500, false, null)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, 
+        "RETURN IN_RANGE(123, 0, 500, 1, true)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, 
+        "RETURN IN_RANGE(123, 0, 500, false, 0)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, 
+        "RETURN IN_RANGE(123, 0, 500, [1, 2, 3], true)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, 
+        "RETURN IN_RANGE(123, 0, 500, false, [1,2,3])");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, 
+        "RETURN IN_RANGE(123, 0, 500, 'true', true)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, 
+        "RETURN IN_RANGE(123, 0, 500, false, 'false')");
+      {
+        let res = getQueryResults("RETURN IN_RANGE(5, 1, 10, false, false)");
+        assertEqual(1, res.length);  
+        assertTrue(res[0]);
+      }     
+      {
+        let res = getQueryResults("RETURN IN_RANGE(5+1, 1+1, 10-1, false, false)");
+        assertEqual(1, res.length);  
+        assertTrue(res[0]);
+      }
+      {
+        let res = getQueryResults("RETURN IN_RANGE(MAX([5,6]), MIN([1,0]), MAX([0,6]), false, true)");
+        assertEqual(1, res.length);  
+        assertTrue(res[0]);
+      }
+      {
+        let res = getQueryResults("RETURN IN_RANGE(MAX([5,6]), MIN([1,0]), MAX([0,6]), false, false)");
+        assertEqual(1, res.length);  
+        assertFalse(res[0]);
+      }
+      {
+        let res = getQueryResults("RETURN IN_RANGE(NOOPT(MAX([5,6])), MIN([1,0]), MAX([0,6]), false, false)");
+        assertEqual(1, res.length);  
+        assertFalse(res[0]);
+      }
+      {
+        let res = getQueryResults("RETURN IN_RANGE('foo', MIN([1,0]), 'poo', false, false)");
+        assertEqual(1, res.length);  
+        assertTrue(res[0]);
+      }
+      {
+        let res = getQueryResults("RETURN IN_RANGE('foo', null, 'poo', false, false)");
+        assertEqual(1, res.length);  
+        assertTrue(res[0]);
+      }
+    },
+
+////////////////////////////////////////////////////////////////////////////////
 /// @brief test non-existing functions
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/tests/js/server/aql/aql-functions.js
+++ b/tests/js/server/aql/aql-functions.js
@@ -4179,6 +4179,21 @@ function ahuacatlFunctionsTestSuite () {
         assertEqual(1, res.length);  
         assertTrue(res[0]);
       }
+      {
+        let res = getQueryResults("RETURN IN_RANGE(123, null, 'poo', false, false)");
+        assertEqual(1, res.length);  
+        assertTrue(res[0]);
+      }
+      {
+        let res = getQueryResults("RETURN IN_RANGE({a:1}, null, 'poo', false, false)");
+        assertEqual(1, res.length);  
+        assertFalse(res[0]);
+      }
+      {
+        let res = getQueryResults("RETURN IN_RANGE('foo', 'boo', 'poo', false, false)");
+        assertEqual(1, res.length);  
+        assertTrue(res[0]);
+      }
     },
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Added implementation for IN_RANGE fuction for execution out of SEARCH context.
This implementation uses standart ArangoDB comparison rules.
Internal issue  https://github.com/arangodb/backlog/issues/692

Verified by GTEST and js tests

https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/9137/