### PR TITLE
Fix explainer output when restricting collections

### DIFF
--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -507,9 +507,6 @@ function printTraversalDetails(traversals) {
       uniqueVertices: options.uniqueVertices,
       uniqueEdges: options.uniqueEdges
     };
-    if (options.vertexCollections !== undefined) {
-      opts.vertexCollections = options.vertexCollections;
-    }
 
     var result = '';
     for (var att in opts) {
@@ -1103,7 +1100,7 @@ function processQuery(query, explain, planIndex) {
   };
 
   var label = function (node) {
-    var rc, v, e, edgeCols, i, d, directions, isLast;
+    var rc, v, vNames, e, eNames, edgeCols, i, d, directions, isLast;
     var parts = [];
     var types = [];
     var filter = '';
@@ -1298,25 +1295,59 @@ function processQuery(query, explain, planIndex) {
         e = [];
         if (node.hasOwnProperty('graphDefinition')) {
           v = [];
-          node.graphDefinition.vertexCollectionNames.forEach(function (vcn) {
-            v.push(collection(vcn));
-          });
+          vNames = [];
+          if (node.hasOwnProperty('options') && node.options.hasOwnProperty('vertexCollections')) {
+            node.options.vertexCollections.forEach(function (vcn) {
+              v.push(collection(vcn));
+              vNames.push(vcn);
+            });
+          } else {
+            node.graphDefinition.vertexCollectionNames.forEach(function (vcn) {
+              v.push(collection(vcn));
+              vNames.push(vcn);
+            });
+          }
           node.vertexCollectionNameStr = v.join(', ');
-          node.vertexCollectionNameStrLen = node.graphDefinition.vertexCollectionNames.join(', ').length;
+          node.vertexCollectionNameStrLen = vNames.join(', ').length;
 
-          node.graphDefinition.edgeCollectionNames.forEach(function (ecn) {
-            e.push(collection(ecn));
-          });
+          if (node.hasOwnProperty('options') && node.options.hasOwnProperty('edgeCollections')) {
+            node.options.edgeCollections.forEach(function (ecn) {
+              e.push(collection(ecn));
+              eNames.push(ecn);
+            });
+          } else {
+            node.graphDefinition.edgeCollectionNames.forEach(function (ecn) {
+              e.push(collection(ecn));
+              eNames.push(ecn);
+            });
+          }
           node.edgeCollectionNameStr = e.join(', ');
-          node.edgeCollectionNameStrLen = node.graphDefinition.edgeCollectionNames.join(', ').length;
+          node.edgeCollectionNameStrLen = eNames.join(', ').length;
         } else {
-          edgeCols = node.graph || [];
-          edgeCols.forEach(function (ecn) {
-            e.push(collection(ecn));
-          });
+          if (node.hasOwnProperty('options') && node.options.hasOwnProperty('edgeCollections')) {
+            node.options.edgeCollections.forEach(function (ecn) {
+              e.push(collection(ecn));
+              eNames.push(ecn);
+            });
+          } else {
+            edgeCols = node.graph || [];
+            edgeCols.forEach(function (ecn) {
+              e.push(collection(ecn));
+              eNames.push(ecn);
+            });
+          }
           node.edgeCollectionNameStr = e.join(', ');
-          node.edgeCollectionNameStrLen = edgeCols.join(', ').length;
+          node.edgeCollectionNameStrLen = eNames.join(', ').length;
           node.graph = '<anonymous>';
+
+          if (node.hasOwnProperty('options') && node.options.hasOwnProperty('vertexCollections')) {
+            v = [];
+            node.options.vertexCollections.forEach(function (vcn) {
+              v.push(collection(vcn));
+            });
+            node.vertexCollectionNameStr = v.join(', ');
+            node.vertexCollectionNameStrLen = node.options.vertexCollections.join(', ').length;
+          }
         }
 
         allIndexes.forEach(function (idx) {
@@ -1376,25 +1407,58 @@ function processQuery(query, explain, planIndex) {
         e = [];
         if (node.hasOwnProperty('graphDefinition')) {
           v = [];
-          node.graphDefinition.vertexCollectionNames.forEach(function (vcn) {
-            v.push(collection(vcn));
-          });
+          vNames = [];
+          if (node.hasOwnProperty('options') && node.options.hasOwnProperty('vertexCollections')) {
+            node.options.vertexCollections.forEach(function (vcn) {
+              v.push(collection(vcn));
+              vNames.push(vcn);
+            });
+          } else {            
+            node.graphDefinition.vertexCollectionNames.forEach(function (vcn) {
+              v.push(collection(vcn));
+              vNames.push(vcn);
+            });
+          }
           node.vertexCollectionNameStr = v.join(', ');
-          node.vertexCollectionNameStrLen = node.graphDefinition.vertexCollectionNames.join(', ').length;
+          node.vertexCollectionNameStrLen = vNames.join(', ').length;
 
-          node.graphDefinition.edgeCollectionNames.forEach(function (ecn) {
-            e.push(collection(ecn));
-          });
+          if (node.hasOwnProperty('options') && node.options.hasOwnProperty('edgeCollections')) {
+            node.options.edgeCollections.forEach(function (ecn) {
+              e.push(collection(ecn));
+              eNames.push(ecn);
+            });
+          } else {
+            node.graphDefinition.edgeCollectionNames.forEach(function (ecn) {
+              e.push(collection(ecn));
+              eNames.push(ecn);
+            });
+          }
           node.edgeCollectionNameStr = e.join(', ');
-          node.edgeCollectionNameStrLen = node.graphDefinition.edgeCollectionNames.join(', ').length;
+          node.edgeCollectionNameStrLen = eNames.join(', ').length;
         } else {
-          edgeCols = node.graph || [];
-          edgeCols.forEach(function (ecn) {
-            e.push(collection(ecn));
-          });
+          if (node.hasOwnProperty('options') && node.options.hasOwnProperty('edgeCollections')) {
+            node.options.edgeCollections.forEach(function (ecn) {
+              e.push(collection(ecn));
+              eNames.push(ecn);
+            });
+          } else {
+            edgeCols = node.graph || [];
+            edgeCols.forEach(function (ecn) {
+              e.push(collection(ecn));
+              eNames.push(ecn);
+            });
+          }
           node.edgeCollectionNameStr = e.join(', ');
-          node.edgeCollectionNameStrLen = edgeCols.join(', ').length;
+          node.edgeCollectionNameStrLen = eNames.join(', ').length;
           node.graph = '<anonymous>';
+          if (node.hasOwnProperty('options') && node.options.hasOwnProperty('vertexCollections')) {
+            v = [];
+            node.options.vertexCollections.forEach(function (vcn) {
+              v.push(collection(vcn));
+            });
+            node.vertexCollectionNameStr = v.join(', ');
+            node.vertexCollectionNameStrLen = node.options.vertexCollections.join(', ').length;
+          }
         }
         return rc;
       }
@@ -1445,27 +1509,61 @@ function processQuery(query, explain, planIndex) {
 
         kShortestPathsDetails.push(node);
         e = [];
+        eNames = [];
         if (node.hasOwnProperty('graphDefinition')) {
           v = [];
-          node.graphDefinition.vertexCollectionNames.forEach(function (vcn) {
-            v.push(collection(vcn));
-          });
+          vNames = [];
+          if (node.hasOwnProperty('options') && node.options.hasOwnProperty('vertexCollections')) {
+            node.options.vertexCollections.forEach(function (vcn) {
+              v.push(collection(vcn));
+              vNames.push(vcn);
+            });
+          } else {
+            node.graphDefinition.vertexCollectionNames.forEach(function (vcn) {
+              v.push(collection(vcn));
+              vNames.push(vcn);
+            });
+          }
           node.vertexCollectionNameStr = v.join(', ');
-          node.vertexCollectionNameStrLen = node.graphDefinition.vertexCollectionNames.join(', ').length;
+          node.vertexCollectionNameStrLen = vNames.join(', ').length;
 
-          node.graphDefinition.edgeCollectionNames.forEach(function (ecn) {
-            e.push(collection(ecn));
-          });
+          if (node.hasOwnProperty('options') && node.options.hasOwnProperty('edgeCollections')) {
+            node.options.edgeCollections.forEach(function (ecn) {
+              e.push(collection(ecn));
+              eNames.push(ecn);
+            });
+          } else {
+            node.graphDefinition.edgeCollectionNames.forEach(function (ecn) {
+              e.push(collection(ecn));
+              eNames.push(ecn);
+            });
+          }
           node.edgeCollectionNameStr = e.join(', ');
-          node.edgeCollectionNameStrLen = node.graphDefinition.edgeCollectionNames.join(', ').length;
+          node.edgeCollectionNameStrLen = eNames.join(', ').length;
         } else {
-          edgeCols = node.graph || [];
-          edgeCols.forEach(function (ecn) {
-            e.push(collection(ecn));
-          });
+          if (node.hasOwnProperty('options') && node.options.hasOwnProperty('edgeCollections')) {
+            node.options.edgeCollections.forEach(function (ecn) {
+              e.push(collection(ecn));
+              eNames.push(ecn);
+            });
+          } else {
+            edgeCols = node.graph || [];
+            edgeCols.forEach(function (ecn) {
+              e.push(collection(ecn));
+              eNames.push(ecn);
+            });
+          }
           node.edgeCollectionNameStr = e.join(', ');
-          node.edgeCollectionNameStrLen = edgeCols.join(', ').length;
+          node.edgeCollectionNameStrLen = eNames.join(', ').length;
           node.graph = '<anonymous>';
+          if (node.hasOwnProperty('options') && node.options.hasOwnProperty('vertexCollections')) {
+            v = [];
+            node.options.vertexCollections.forEach(function (vcn) {
+              v.push(collection(vcn));
+            });
+            node.vertexCollectionNameStr = v.join(', ');
+            node.vertexCollectionNameStrLen = node.options.vertexCollections.join(', ').length;
+          }
         }
         return rc;
       }

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -1293,6 +1293,7 @@ function processQuery(query, explain, planIndex) {
         }
 
         e = [];
+        eNames = [];
         if (node.hasOwnProperty('graphDefinition')) {
           v = [];
           vNames = [];
@@ -1405,6 +1406,7 @@ function processQuery(query, explain, planIndex) {
 
         shortestPathDetails.push(node);
         e = [];
+        eNames = [];
         if (node.hasOwnProperty('graphDefinition')) {
           v = [];
           vNames = [];


### PR DESCRIPTION
### Scope & Purpose

Properly display vertex and edge collections for traversals when using the `OPTIONS` restrictions.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)

#### Related Information

Description of bad behavior: https://github.com/arangodb/docs/pull/345#issuecomment-592108113

### Testing & Verification

Jenkins: http://jenkins01.arangodb.biz:8080/job/arangodb-matrix-pr/9169/