### PR TITLE
(mostly) restore pre-3.7 API behavior

### DIFF
--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -1320,7 +1320,7 @@ RestStatus RestAdminClusterHandler::handlePutNumberOfServers() {
     auto write = arangodb::agency::envelope<VPackBuilder>::create(builder).write();
 
     VPackSlice numberOfCoordinators = body.get("numberOfCoordinators");
-    if (numberOfCoordinators.isNumber()) {
+    if (numberOfCoordinators.isNumber() || numberOfCoordinators.isNull()) {
       write = std::move(write).set(targetPath->numberOfCoordinators()->str(),
                                    numberOfCoordinators);
       hasThingsToDo = true;
@@ -1331,7 +1331,7 @@ RestStatus RestAdminClusterHandler::handlePutNumberOfServers() {
     }
 
     VPackSlice numberOfDBServers = body.get("numberOfDBServers");
-    if (numberOfDBServers.isNumber()) {
+    if (numberOfDBServers.isNumber() || numberOfDBServers.isNull()) {
       write = std::move(write).set(targetPath->numberOfDBServers()->str(), numberOfDBServers);
       hasThingsToDo = true;
     } else if (!numberOfDBServers.isNone()) {
@@ -1368,8 +1368,12 @@ RestStatus RestAdminClusterHandler::handlePutNumberOfServers() {
   }
 
   if (!hasThingsToDo) {
-    generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
-                  "missing fields");
+    generateOk(rest::ResponseCode::OK, velocypack::Slice::noneSlice());
+    // TODO: the appropriate response would rather be
+    // generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
+    //               "missing fields");
+    // but that would break API compatibility. Introduce this behavior
+    // in 4.0!!
     return RestStatus::DONE;
   }
 

--- a/tests/js/client/shell/shell-numberof-servers-cluster.js
+++ b/tests/js/client/shell/shell-numberof-servers-cluster.js
@@ -1,0 +1,89 @@
+/*jshint globalstrict:false, strict:false, maxlen : 4000 */
+/* global arango, assertFalse, assertEqual, assertNull  */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief tests for inventory
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+const jsunity = require('jsunity');
+
+function numberOfServersSuite () {
+  return {
+    setUp : function () {
+      arango.PUT("/_admin/cluster/numberOfServers", { numberOfCoordinators: null, numberOfDBServers: null });
+    },
+
+    tearDown : function () {
+      arango.PUT("/_admin/cluster/numberOfServers", { numberOfCoordinators: null, numberOfDBServers: null });
+    },
+
+    testGet : function () {
+      let result = arango.GET("/_admin/cluster/numberOfServers");
+      assertFalse(result.error);
+      assertEqual(200, result.code);
+      assertNull(result.numberOfDBServers);
+      assertNull(result.numberOfCoordinators);
+      assertEqual([], result.cleanedServers);
+    },
+    
+    testPutEmptyBody : function () {
+      let result = arango.PUT("/_admin/cluster/numberOfServers", {});
+      assertFalse(result.error);
+      assertEqual(200, result.code);
+    }, 
+    
+    testPutNumberOfDBServers : function () {
+      let result = arango.PUT("/_admin/cluster/numberOfServers", { numberOfDBServers: 2 });
+      assertFalse(result.error);
+      assertEqual(200, result.code);
+      
+      result = arango.GET("/_admin/cluster/numberOfServers");
+      assertFalse(result.error);
+      assertEqual(200, result.code);
+      assertEqual(2, result.numberOfDBServers);
+      assertNull(result.numberOfCoordinators);
+      assertEqual([], result.cleanedServers);
+    }, 
+    
+    testPutNumberOfCoordinators : function () {
+      let result = arango.PUT("/_admin/cluster/numberOfServers", { numberOfCoordinators: 2 });
+      assertFalse(result.error);
+      assertEqual(200, result.code);
+      
+      result = arango.GET("/_admin/cluster/numberOfServers");
+      assertFalse(result.error);
+      assertEqual(200, result.code);
+      assertNull(result.numberOfDBServers);
+      assertEqual(2, result.numberOfCoordinators);
+      assertEqual([], result.cleanedServers);
+    },
+
+  };
+}
+
+jsunity.run(numberOfServersSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

The API `/_admin/cluster/numberOfServers` slightly changed in 3.7 compared to 3.6.
This PR reverts the change and also modifies the behavior in some other ways:
* allow sending HTTP PUT requests to the API with an empty JSON object `{}` as the request body. This was allowed in 3.6 as well. Sending such request does nothing, but it is allowed.
* allow using `null` values for setting the `numberOfDBServers` and `numberOfCoordinators` values. This is required for testing the API so the tests can reset the value each time.
* the return value of successful HTTP PUT requests in 3.6 was just `true`. In 3.7, we changed it to respond with `{"error":false,"code":200}`. This change is kept and will be documented as an API change.

Docs companion PR: https://github.com/arangodb/docs/pull/399

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_client)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9260/