### PR TITLE
[3.6] Bug fix/fix one shard traversal instantiation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.6.3 (XXXX-XX-XX)
 -------------------
 
+* Fixed internal issue ES-544: Instantiation of AQL queries with graph
+  traversals in a OneShard setting failed with 'direction can only be INBOUND,
+  OUTBOUND or ANY'.
+
 * Fixed a rare race condition in SmartGraphs where the graph is unblanced, but a successful
   result could be found by only on database server, where the other server is still
   searching. In this race the query could continue on the other server and hit

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,10 +5,10 @@ v3.6.3 (XXXX-XX-XX)
   traversals in a OneShard setting failed with 'direction can only be INBOUND,
   OUTBOUND or ANY'.
 
-* Fixed a rare race condition in SmartGraphs where the graph is unblanced, but a successful
-  result could be found by only on database server, where the other server is still
-  searching. In this race the query could continue on the other server and hit
-  a non-thread save object.
+* Fixed a rare race condition in SmartGraphs where the graph is unblanced, but a
+  successful result could be found by only on database server, where the other
+  server is still searching. In this race the query could continue on the other
+  server and hit a non-thread save object.
 
 * Fixed a bug in the agency supervision, which ignored the `failoverCandidates`
   field.

--- a/arangod/Aql/GraphNode.cpp
+++ b/arangod/Aql/GraphNode.cpp
@@ -75,18 +75,18 @@ GraphNode::GraphNode(ExecutionPlan* plan, size_t id, TRI_vocbase_t* vocbase,
       _tmpObjVariable(_plan->getAst()->variables()->createTemporaryVariable()),
       _tmpObjVarNode(_plan->getAst()->createNodeReference(_tmpObjVariable)),
       _tmpIdNode(_plan->getAst()->createNodeValueString("", 0)),
+      _defaultDirection(parseDirection(direction)),
       _options(std::move(options)),
       _optionsBuilt(false),
       _isSmart(false) {
+  // Direction is already the correct Integer.
+  // Is not inserted by user but by enum.
+
   TRI_ASSERT(_vocbase != nullptr);
   TRI_ASSERT(_options != nullptr);
 
   TRI_ASSERT(direction != nullptr);
   TRI_ASSERT(graph != nullptr);
-
-  // Direction is already the correct Integer.
-  // Is not inserted by user but by enum.
-  _defaultDirection = parseDirection(direction);
 
   std::unordered_map<std::string, TRI_edge_direction_e> seenCollections;
 
@@ -265,12 +265,11 @@ GraphNode::GraphNode(ExecutionPlan* plan, arangodb::velocypack::Slice const& bas
       _tmpObjVariable(nullptr),
       _tmpObjVarNode(nullptr),
       _tmpIdNode(nullptr),
+      _defaultDirection(uint64ToDirection(arangodb::basics::VelocyPackHelper::stringUInt64(
+              base.get("defaultDirection")))),
       _options(nullptr),
       _optionsBuilt(false),
       _isSmart(false) {
-  uint64_t dir = arangodb::basics::VelocyPackHelper::stringUInt64(
-      base.get("defaultDirection"));
-  _defaultDirection = uint64ToDirection(dir);
 
   // Directions
   VPackSlice dirList = base.get("directions");
@@ -383,6 +382,7 @@ GraphNode::GraphNode(ExecutionPlan* plan, arangodb::velocypack::Slice const& bas
 GraphNode::GraphNode(ExecutionPlan* plan, size_t id, TRI_vocbase_t* vocbase,
                      std::vector<std::unique_ptr<Collection>> const& edgeColls,
                      std::vector<std::unique_ptr<Collection>> const& vertexColls,
+                     TRI_edge_direction_e defaultDirection,
                      std::vector<TRI_edge_direction_e> const& directions,
                      std::unique_ptr<BaseOptions> options)
     : ExecutionNode(plan, id),
@@ -393,6 +393,7 @@ GraphNode::GraphNode(ExecutionPlan* plan, size_t id, TRI_vocbase_t* vocbase,
       _tmpObjVariable(_plan->getAst()->variables()->createTemporaryVariable()),
       _tmpObjVarNode(_plan->getAst()->createNodeReference(_tmpObjVariable)),
       _tmpIdNode(_plan->getAst()->createNodeValueString("", 0)),
+      _defaultDirection(defaultDirection),
       _directions(directions),
       _options(std::move(options)),
       _optionsBuilt(false),

--- a/arangod/Aql/GraphNode.h
+++ b/arangod/Aql/GraphNode.h
@@ -64,6 +64,7 @@ class GraphNode : public ExecutionNode {
   GraphNode(ExecutionPlan* plan, size_t id, TRI_vocbase_t* vocbase,
             std::vector<std::unique_ptr<Collection>> const& edgeColls,
             std::vector<std::unique_ptr<Collection>> const& vertexColls,
+            TRI_edge_direction_e defaultDirection,
             std::vector<TRI_edge_direction_e> const& directions,
             std::unique_ptr<graph::BaseOptions> options);
 

--- a/arangod/Aql/KShortestPathsNode.cpp
+++ b/arangod/Aql/KShortestPathsNode.cpp
@@ -144,10 +144,12 @@ KShortestPathsNode::KShortestPathsNode(
     ExecutionPlan* plan, size_t id, TRI_vocbase_t* vocbase,
     std::vector<std::unique_ptr<Collection>> const& edgeColls,
     std::vector<std::unique_ptr<Collection>> const& vertexColls,
+    TRI_edge_direction_e defaultDirection,
     std::vector<TRI_edge_direction_e> const& directions, Variable const* inStartVariable,
     std::string const& startVertexId, Variable const* inTargetVariable,
     std::string const& targetVertexId, std::unique_ptr<BaseOptions> options)
-    : GraphNode(plan, id, vocbase, edgeColls, vertexColls, directions, std::move(options)),
+    : GraphNode(plan, id, vocbase, edgeColls, vertexColls, defaultDirection,
+        directions, std::move(options)),
       _pathOutVariable(nullptr),
       _inStartVariable(inStartVariable),
       _startVertexId(startVertexId),
@@ -297,7 +299,8 @@ ExecutionNode* KShortestPathsNode::clone(ExecutionPlan* plan, bool withDependenc
   auto oldOpts = static_cast<ShortestPathOptions*>(options());
   std::unique_ptr<BaseOptions> tmp = std::make_unique<ShortestPathOptions>(*oldOpts);
   auto c = std::make_unique<KShortestPathsNode>(plan, _id, _vocbase, _edgeColls,
-                                                _vertexColls, _directions, _inStartVariable,
+                                                _vertexColls, _defaultDirection,
+                                                _directions, _inStartVariable,
                                                 _startVertexId, _inTargetVariable,
                                                 _targetVertexId, std::move(tmp));
   if (usesPathOutVariable()) {

--- a/arangod/Aql/KShortestPathsNode.h
+++ b/arangod/Aql/KShortestPathsNode.h
@@ -60,6 +60,7 @@ class KShortestPathsNode : public GraphNode {
   KShortestPathsNode(ExecutionPlan* plan, size_t id, TRI_vocbase_t* vocbase,
                      std::vector<std::unique_ptr<Collection>> const& edgeColls,
                      std::vector<std::unique_ptr<Collection>> const& vertexColls,
+                     TRI_edge_direction_e defaultDirection,
                      std::vector<TRI_edge_direction_e> const& directions,
                      Variable const* inStartVariable, std::string const& startVertexId,
                      Variable const* inTargetVariable, std::string const& targetVertexId,

--- a/arangod/Aql/ShortestPathNode.cpp
+++ b/arangod/Aql/ShortestPathNode.cpp
@@ -142,10 +142,12 @@ ShortestPathNode::ShortestPathNode(
     ExecutionPlan* plan, size_t id, TRI_vocbase_t* vocbase,
     std::vector<std::unique_ptr<Collection>> const& edgeColls,
     std::vector<std::unique_ptr<Collection>> const& vertexColls,
+    TRI_edge_direction_e defaultDirection,
     std::vector<TRI_edge_direction_e> const& directions, Variable const* inStartVariable,
     std::string const& startVertexId, Variable const* inTargetVariable,
     std::string const& targetVertexId, std::unique_ptr<BaseOptions> options)
-    : GraphNode(plan, id, vocbase, edgeColls, vertexColls, directions, std::move(options)),
+    : GraphNode(plan, id, vocbase, edgeColls, vertexColls, defaultDirection,
+        directions, std::move(options)),
       _inStartVariable(inStartVariable),
       _startVertexId(startVertexId),
       _inTargetVariable(inTargetVariable),
@@ -303,7 +305,8 @@ ExecutionNode* ShortestPathNode::clone(ExecutionPlan* plan, bool withDependencie
   auto oldOpts = static_cast<ShortestPathOptions*>(options());
   std::unique_ptr<BaseOptions> tmp = std::make_unique<ShortestPathOptions>(*oldOpts);
   auto c = std::make_unique<ShortestPathNode>(plan, _id, _vocbase, _edgeColls,
-                                              _vertexColls, _directions, _inStartVariable,
+                                              _vertexColls, _defaultDirection,
+                                              _directions, _inStartVariable,
                                               _startVertexId, _inTargetVariable,
                                               _targetVertexId, std::move(tmp));
   if (usesVertexOutVariable()) {

--- a/arangod/Aql/ShortestPathNode.h
+++ b/arangod/Aql/ShortestPathNode.h
@@ -58,6 +58,7 @@ class ShortestPathNode : public GraphNode {
   ShortestPathNode(ExecutionPlan* plan, size_t id, TRI_vocbase_t* vocbase,
                    std::vector<std::unique_ptr<Collection>> const& edgeColls,
                    std::vector<std::unique_ptr<Collection>> const& vertexColls,
+                   TRI_edge_direction_e defaultDirection,
                    std::vector<TRI_edge_direction_e> const& directions,
                    Variable const* inStartVariable, std::string const& startVertexId,
                    Variable const* inTargetVariable, std::string const& targetVertexId,

--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -164,9 +164,11 @@ TraversalNode::TraversalNode(ExecutionPlan* plan, size_t id, TRI_vocbase_t* vocb
                              std::vector<std::unique_ptr<Collection>> const& edgeColls,
                              std::vector<std::unique_ptr<Collection>> const& vertexColls,
                              Variable const* inVariable, std::string const& vertexId,
+                             TRI_edge_direction_e defaultDirection,
                              std::vector<TRI_edge_direction_e> const& directions,
                              std::unique_ptr<BaseOptions> options)
-    : GraphNode(plan, id, vocbase, edgeColls, vertexColls, directions, std::move(options)),
+    : GraphNode(plan, id, vocbase, edgeColls, vertexColls, defaultDirection,
+        directions, std::move(options)),
       _pathOutVariable(nullptr),
       _inVariable(inVariable),
       _vertexId(vertexId),
@@ -529,7 +531,7 @@ ExecutionNode* TraversalNode::clone(ExecutionPlan* plan, bool withDependencies,
   auto oldOpts = static_cast<TraverserOptions*>(options());
   std::unique_ptr<BaseOptions> tmp = std::make_unique<TraverserOptions>(*oldOpts);
   auto c = std::make_unique<TraversalNode>(plan, _id, _vocbase, _edgeColls,
-                                           _vertexColls, _inVariable, _vertexId,
+                                           _vertexColls, _inVariable, _vertexId, _defaultDirection,
                                            _directions, std::move(tmp));
 
   if (usesVertexOutVariable()) {

--- a/arangod/Aql/TraversalNode.h
+++ b/arangod/Aql/TraversalNode.h
@@ -90,6 +90,7 @@ class TraversalNode : public GraphNode {
                 std::vector<std::unique_ptr<aql::Collection>> const& edgeColls,
                 std::vector<std::unique_ptr<aql::Collection>> const& vertexColls,
                 Variable const* inVariable, std::string const& vertexId,
+                TRI_edge_direction_e defaultDirection,
                 std::vector<TRI_edge_direction_e> const& directions,
                 std::unique_ptr<graph::BaseOptions> options);
 


### PR DESCRIPTION
### Scope & Purpose

Instantiation of AQL queries with graph traversals in One-Shard would previously fail. This is already fixed in devel.

- [X] Bug-Fix for 3.6
- [X] The behavior in this PR can be (and was) *manually tested*

#### Related Information

- [X] There is a *JIRA Ticket number*: ES-544

### Testing & Verification

This change is trivial.

In devel there are a bunch of additional tests that cover this in conjunction with satellite graphs, which I will maybe backport separately with another bugfix.

### Documentation

- [X] Added a *Changelog Entry*
