### PR TITLE
added overwriteMode "ignore"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,43 @@
+v3.7.0-preview.2 (XXXX-XX-XX)
+-----------------------------
+
+* Added overwrite mode "ignore" for document inserts. This mode allows
+  ignoring primary key conflicts on insert when the target document already
+  exists.
+
+  The following overwrite modes now exist:
+
+  * "ignore": if a document with the specified `_key` value already exists,
+    nothing will be done, and no write operation will be carried out. The
+    insert operation will return success in this case. This mode does not
+    support returning the old or new document versions using the `returnOld`
+    and `returnNew` attributes.
+  * "replace": if a document with the specified `_key` value already exists,
+    it will be overwritten with the specified document value. This mode will
+    also be used when no overwrite mode is specified but the `overwrite`
+    flag is set to `true`.
+  * "update": if a document with the specified `_key` value already exists,
+    it will be patched (partially updated) with the specified document value.
+
+  The overwrite mode "ignore" can also be used from AQL INSERT operations
+  by specifying it in the INSERT's `OPTIONS`, e.g.
+
+      INSERT { _key: ..., .... } INTO collection OPTIONS { overwriteMode: "ignore" }
+
+  Again, when the overwrite mode "ignore" is used from AQL, it does not
+  support returning the old or new document versions. Using "RETURN OLD" in
+  an INSERT operation that uses the "ignore" overwrite mode will trigger
+  a parse error, as there will be no old version returned, and "RETURN NEW"
+  will only return the document in case it was inserted. In case the document
+  already existed, "RETURN NEW" will return "null".
+
+  The main use case of inserting documents with overwrite mode "ignore" is
+  to make sure that certain documents exist in the cheapest possible way.
+  In case the target document already exists, the "ignore" mode is most
+  efficient, as it will not retrieve the existing document from storage and
+  not write any updates to it.
+
+
 v3.7.0-preview.1 (2020-03-27)
 -----------------------------
 

--- a/arangod/Agency/RestAgencyHandler.cpp
+++ b/arangod/Agency/RestAgencyHandler.cpp
@@ -529,7 +529,6 @@ RestStatus RestAgencyHandler::handleRead() {
         return reportMessage(rest::ResponseCode::SERVICE_UNAVAILABLE,
                              "No leader");
       } else {
-        TRI_ASSERT(ret.redirect != _agent->id());
         redirectRequest(ret.redirect);
       }
     }

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -433,18 +433,22 @@ AstNode* Ast::createNodeInsert(AstNode const* expression,
     options = &NopNode;
   }
 
-  bool overwrite = false;
+  bool returnOld = false;
   if (options->type == NODE_TYPE_OBJECT) {
     auto ops = ExecutionPlan::parseModificationOptions(options);
-    overwrite = ops.overwrite;
+    if (ops.overwrite && 
+        (ops.overwriteMode == OperationOptions::OverwriteMode::Update ||
+         ops.overwriteMode == OperationOptions::OverwriteMode::Replace)) {
+      returnOld = true;
+    }
   }
 
-  node->reserve(overwrite ? 5 : 4);
+  node->reserve(returnOld ? 5 : 4);
   node->addMember(options);
   node->addMember(collection);
   node->addMember(expression);
   node->addMember(createNodeVariable(TRI_CHAR_LENGTH_PAIR(Variable::NAME_NEW), false));
-  if (overwrite) {
+  if (returnOld) {
     node->addMember(createNodeVariable(TRI_CHAR_LENGTH_PAIR(Variable::NAME_OLD), false));
   }
 

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -731,7 +731,6 @@ bool ExecutionPlan::hasExclusiveAccessOption(AstNode const* node) {
 ModificationOptions ExecutionPlan::parseModificationOptions(AstNode const* node) {
   ModificationOptions options;
 
-
   // parse the modification options we got
   if (node != nullptr && node->type == NODE_TYPE_OBJECT) {
     size_t n = node->numMembers();
@@ -759,16 +758,23 @@ ModificationOptions ExecutionPlan::parseModificationOptions(AstNode const* node)
         } else if (name == "exclusive") {
           options.exclusive = value->isTrue();
         } else if (name == "overwrite") {
-          if(value->isTrue()) {
+          if (value->isTrue()) {
             options.overwrite = true;
+            if (options.overwriteMode == OperationOptions::OverwriteMode::Unknown) {
+              options.overwriteMode = OperationOptions::OverwriteMode::Replace;
+            }
           }
         } else if (name == "overwriteMode" && value->isStringValue()) {
           auto ref = value->getStringRef();
-          if(ref == "update") {
+          if (ref == "update") {
             options.overwrite = true;
-            options.overwriteModeUpdate = true;
-          } else if(ref == "replace") {
+            options.overwriteMode = OperationOptions::OverwriteMode::Update;
+          } else if (ref == "replace") {
             options.overwrite = true;
+            options.overwriteMode = OperationOptions::OverwriteMode::Replace;
+          } else if (ref == "ignore") {
+            options.overwrite = true;
+            options.overwriteMode = OperationOptions::OverwriteMode::Ignore;
           }
         } else if (name == "ignoreRevs") {
           options.ignoreRevs = value->isTrue();

--- a/arangod/Aql/ModificationExecutorHelpers.cpp
+++ b/arangod/Aql/ModificationExecutorHelpers.cpp
@@ -206,7 +206,7 @@ OperationOptions ModificationExecutorHelpers::convertOptions(ModificationOptions
   // in.exclusive;
   out.overwrite = in.overwrite;
   out.ignoreRevs = in.ignoreRevs;
-  out.overwriteModeUpdate = in.overwriteModeUpdate;
+  out.overwriteMode = in.overwriteMode;
 
   out.returnNew = (outVariableNew != nullptr);
   out.returnOld = (outVariableOld != nullptr);

--- a/arangod/Aql/ModificationOptions.cpp
+++ b/arangod/Aql/ModificationOptions.cpp
@@ -25,6 +25,7 @@
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/StaticStrings.h"
 
+#include <velocypack/StringRef.h>
 #include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb::aql;
@@ -47,8 +48,9 @@ ModificationOptions::ModificationOptions(VPackSlice const& slice) {
       basics::VelocyPackHelper::getBooleanValue(obj, "consultAqlWriteFilter", false);
   exclusive = basics::VelocyPackHelper::getBooleanValue(obj, "exclusive", false);
   overwrite = basics::VelocyPackHelper::getBooleanValue(obj, StaticStrings::OverWrite, false);
-  overwriteModeUpdate = basics::VelocyPackHelper::getBooleanValue(obj, "overwriteModeUpdate", false);
   ignoreRevs = basics::VelocyPackHelper::getBooleanValue(obj, StaticStrings::IgnoreRevsString , true);
+  
+  overwriteMode = OperationOptions::determineOverwriteMode(VPackStringRef(basics::VelocyPackHelper::getStringValue(obj, "overwriteMode", "")));
 }
 
 void ModificationOptions::toVelocyPack(VPackBuilder& builder) const {
@@ -64,6 +66,6 @@ void ModificationOptions::toVelocyPack(VPackBuilder& builder) const {
   builder.add("consultAqlWriteFilter", VPackValue(consultAqlWriteFilter));
   builder.add("exclusive", VPackValue(exclusive));
   builder.add(StaticStrings::OverWrite, VPackValue(overwrite));
-  builder.add("overwriteModeUpdate", VPackValue(overwriteModeUpdate));
   builder.add(StaticStrings::IgnoreRevsString, VPackValue(ignoreRevs));
+  builder.add("overwriteMode", VPackValue(OperationOptions::stringifyOverwriteMode(overwriteMode)));
 }

--- a/arangod/Aql/ModificationOptions.h
+++ b/arangod/Aql/ModificationOptions.h
@@ -25,6 +25,7 @@
 #define ARANGOD_AQL_MODIFICATION_OPTIONS_H 1
 
 #include "Basics/Common.h"
+#include "Utils/OperationOptions.h"
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
@@ -38,7 +39,8 @@ struct ModificationOptions {
   explicit ModificationOptions(arangodb::velocypack::Slice const&);
 
   ModificationOptions()
-      : ignoreErrors(false),
+      : overwriteMode(OperationOptions::OverwriteMode::Replace),
+        ignoreErrors(false),
         waitForSync(false),
         validate(true),
         nullMeansRemove(false),
@@ -49,11 +51,11 @@ struct ModificationOptions {
         consultAqlWriteFilter(false),
         exclusive(false),
         overwrite(false),
-        overwriteModeUpdate(false),
         ignoreRevs(true) {}
 
   void toVelocyPack(arangodb::velocypack::Builder&) const;
 
+  OperationOptions::OverwriteMode overwriteMode;
   bool ignoreErrors;
   bool waitForSync;
   bool validate;
@@ -65,7 +67,6 @@ struct ModificationOptions {
   bool consultAqlWriteFilter;
   bool exclusive;
   bool overwrite;
-  bool overwriteModeUpdate;
   bool ignoreRevs;
 };
 

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -1351,10 +1351,9 @@ Future<OperationResult> createDocumentOnCoordinator(transaction::Methods const& 
            .param(StaticStrings::MergeObjectsString, (options.mergeObjects ? "true" : "false"))
            .param(StaticStrings::OverWrite, (options.overwrite ? "true" : "false"))
            .param(StaticStrings::SkipDocumentValidation, (options.validate ? "false" : "true"));
-    if(options.overwriteModeUpdate) {
-      reqOpts.parameters.insert_or_assign(StaticStrings::OverWriteMode,  "update" );
+    if (options.overwrite && options.overwriteMode != OperationOptions::OverwriteMode::Unknown) {
+      reqOpts.parameters.insert_or_assign(StaticStrings::OverWriteMode, OperationOptions::stringifyOverwriteMode(options.overwriteMode));
     }
-
 
     // Now prepare the requests:
     auto* pool = trx.vocbase().server().getFeature<NetworkFeature>().pool();

--- a/arangod/ClusterEngine/ClusterCollection.cpp
+++ b/arangod/ClusterEngine/ClusterCollection.cpp
@@ -418,6 +418,11 @@ Result ClusterCollection::truncate(transaction::Methods& trx, OperationOptions& 
 Result ClusterCollection::compact() {
   return {};
 }
+  
+Result ClusterCollection::lookupKey(transaction::Methods* trx, velocypack::StringRef key,
+                                    std::pair<LocalDocumentId, TRI_voc_rid_t>& result) const {
+  THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
+}
 
 LocalDocumentId ClusterCollection::lookupKey(transaction::Methods* trx,
                                              VPackSlice const& key) const {

--- a/arangod/ClusterEngine/ClusterCollection.h
+++ b/arangod/ClusterEngine/ClusterCollection.h
@@ -120,6 +120,9 @@ class ClusterCollection final : public PhysicalCollection {
   
   /// @brief compact-data operation
   Result compact() override;
+  
+  Result lookupKey(transaction::Methods* trx, velocypack::StringRef key,
+                   std::pair<LocalDocumentId, TRI_voc_rid_t>& result) const override;
 
   void deferDropCollection(std::function<bool(LogicalCollection&)> const& callback) override;
 

--- a/arangod/MMFiles/MMFilesCollection.cpp
+++ b/arangod/MMFiles/MMFilesCollection.cpp
@@ -2827,6 +2827,11 @@ Result MMFilesCollection::compact() {
 
   return {};
 }
+  
+Result MMFilesCollection::lookupKey(transaction::Methods* trx, velocypack::StringRef key,
+                                    std::pair<LocalDocumentId, TRI_voc_rid_t>& result) const {
+  THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_NOT_IMPLEMENTED, "not implemented for this storage engine");
+}
 
 LocalDocumentId MMFilesCollection::reuseOrCreateLocalDocumentId(OperationOptions const& options) const {
   if (options.recoveryData != nullptr) {

--- a/arangod/MMFiles/MMFilesCollection.h
+++ b/arangod/MMFiles/MMFilesCollection.h
@@ -272,6 +272,9 @@ class MMFilesCollection final : public PhysicalCollection {
 
   /// @brief compact-data operation
   Result compact() override;
+  
+  Result lookupKey(transaction::Methods* trx, velocypack::StringRef key,
+                   std::pair<LocalDocumentId, TRI_voc_rid_t>& result) const override;
 
   /// @brief Defer a callback to be executed when the collection
   ///        can be dropped. The callback is supposed to drop

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -175,14 +175,21 @@ RestStatus RestDocumentHandler::insertDocument() {
   using namespace std::literals::string_literals;
   if (mode == "update"s) {
     opOptions.overwrite = true;
-    opOptions.overwriteModeUpdate = true;
+    opOptions.overwriteMode = OperationOptions::OverwriteMode::Update;
     opOptions.mergeObjects = _request->parsedValue(StaticStrings::MergeObjectsString, true);
     opOptions.keepNull = _request->parsedValue(StaticStrings::KeepNullString, false);
   } else if (mode == "replace"s) {
     opOptions.overwrite = true;
+    opOptions.overwriteMode = OperationOptions::OverwriteMode::Replace;
+  } else if (mode == "ignore"s) {
+    opOptions.overwrite = true;
+    opOptions.overwriteMode = OperationOptions::OverwriteMode::Ignore;
   }
   if (!opOptions.overwrite) {
     opOptions.overwrite = _request->parsedValue(StaticStrings::OverWrite, false);
+    if (opOptions.overwrite) {
+      opOptions.overwriteMode = OperationOptions::OverwriteMode::Replace;
+    }
   }
 
   opOptions.returnOld = _request->parsedValue(StaticStrings::ReturnOldString, false) &&

--- a/arangod/RocksDBEngine/RocksDBCollection.h
+++ b/arangod/RocksDBEngine/RocksDBCollection.h
@@ -93,6 +93,9 @@ class RocksDBCollection final : public RocksDBMetaCollection {
   ///////////////////////////////////
 
   Result truncate(transaction::Methods& trx, OperationOptions& options) override;
+  
+  Result lookupKey(transaction::Methods* trx, velocypack::StringRef key,
+                   std::pair<LocalDocumentId, TRI_voc_rid_t>& result) const override;
 
   LocalDocumentId lookupKey(transaction::Methods* trx, velocypack::Slice const& key) const override;
 

--- a/arangod/StorageEngine/PhysicalCollection.h
+++ b/arangod/StorageEngine/PhysicalCollection.h
@@ -159,6 +159,9 @@ class PhysicalCollection {
 
   /// @brief compact-data operation
   virtual Result compact() = 0;
+  
+  virtual Result lookupKey(transaction::Methods* trx, velocypack::StringRef key,
+                           std::pair<LocalDocumentId, TRI_voc_rid_t>& result) const = 0;
 
   /// @brief Defer a callback to be executed when the collection
   ///        can be dropped. The callback is supposed to drop

--- a/arangod/V8Server/v8-collection.cpp
+++ b/arangod/V8Server/v8-collection.cpp
@@ -1910,14 +1910,15 @@ static void InsertVocbaseCol(v8::Isolate* isolate,
     TRI_GET_GLOBAL_STRING(OverwriteKey);
     if (!options.overwrite && TRI_HasProperty(context, isolate, optionsObject, OverwriteKey)) {
       options.overwrite = TRI_ObjectToBoolean(isolate, optionsObject->Get(context, OverwriteKey).FromMaybe(v8::Local<v8::Value>()));
+      options.overwriteMode = OperationOptions::OverwriteMode::Replace;
     }
 
     TRI_GET_GLOBAL_STRING(OverwriteModeKey);
     if (TRI_HasProperty(context, isolate, optionsObject, OverwriteModeKey)) {
       auto mode = TRI_ObjectToString(isolate, optionsObject->Get(context, OverwriteModeKey).FromMaybe(v8::Local<v8::Value>()));
       if (mode == "update" ) {
-        options.overwriteModeUpdate = true;
         options.overwrite = true;
+        options.overwriteMode = OperationOptions::OverwriteMode::Update;
 
         TRI_GET_GLOBAL_STRING(KeepNullKey);
         if (TRI_HasProperty(context, isolate, optionsObject, KeepNullKey)) {
@@ -1930,6 +1931,10 @@ static void InsertVocbaseCol(v8::Isolate* isolate,
         }
       } else if (mode == "replace") {
         options.overwrite = true;
+        options.overwriteMode = OperationOptions::OverwriteMode::Replace;
+      } else if (mode == "ignore") {
+        options.overwrite = true;
+        options.overwriteMode = OperationOptions::OverwriteMode::Ignore;
       }
     }
 

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -1062,6 +1062,11 @@ Result LogicalCollection::truncate(transaction::Methods& trx, OperationOptions& 
 /// @brief compact-data operation
 Result LogicalCollection::compact() { return getPhysical()->compact(); }
 
+Result LogicalCollection::lookupKey(transaction::Methods* trx, VPackStringRef key,
+                                    std::pair<LocalDocumentId, TRI_voc_rid_t>& result) const { 
+  return getPhysical()->lookupKey(trx, key, result);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief inserts a document or edge into the collection
 ////////////////////////////////////////////////////////////////////////////////

--- a/arangod/VocBase/LogicalCollection.h
+++ b/arangod/VocBase/LogicalCollection.h
@@ -278,6 +278,9 @@ class LogicalCollection : public LogicalDataSource {
 
   /// @brief compact-data operation
   Result compact();
+  
+  Result lookupKey(transaction::Methods* trx, velocypack::StringRef key,
+                   std::pair<LocalDocumentId, TRI_voc_rid_t>& result) const;
 
   // convenience function for downwards-compatibility
   Result insert(transaction::Methods* trx, velocypack::Slice const slice,

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -821,7 +821,8 @@ function processQuery(query, explain, planIndex) {
         return variable('#' + node.name);
       }
     } catch (x) {
-      print(node);
+      require('console').warn("got unexpected invalid variable struct in explainer");
+      require("console").trace();
       throw x;
     }
 
@@ -1619,7 +1620,11 @@ function processQuery(query, explain, planIndex) {
       case 'SubqueryStartNode':
         return `${keyword('LET')} ${variableName(node.subqueryOutVariable)} = ( ${annotation(`/* subquery begin */`)}` ;
       case 'SubqueryEndNode':
-        return `${keyword('RETURN')}  ${variableName(node.inVariable)} ) ${annotation(`/* subquery end */`)}`;
+        if (node.inVariable) {
+          return `${keyword('RETURN')}  ${variableName(node.inVariable)} ) ${annotation(`/* subquery end */`)}`;
+        }
+        // special hack for spliced subqueries that do not return any data
+        return `) ${annotation(`/* subquery end */`)}`;
       case 'InsertNode': {
         modificationFlags = node.modificationFlags;
         let restrictString = '';
@@ -1828,6 +1833,10 @@ function processQuery(query, explain, planIndex) {
     isConst = true;
     if (node.type === 'SubqueryNode' || node.type === 'SubqueryStartNode') {
       subqueries.push(level);
+    }
+    if (node.type === 'SubqueryEndNode' && !node.inVariable && subqueries.length > 0) {
+      // special hack for spliced subqueries that do not return any data
+      --level;
     }
   };
 
@@ -2227,6 +2236,9 @@ function inspectDump(filename, outfile) {
   }
 
   let data = JSON.parse(require('fs').read(filename));
+  if (data.version && data.version) {
+    print("/* original data is from " + data.version["server-version"] + ", " + data.version.license + " */");
+  }
   if (data.database) {
     print("/* original data gathered from database '" + data.database + "' */");
   }
@@ -2290,7 +2302,7 @@ function inspectDump(filename, outfile) {
     let details = data.collections[collection];
     if (details.examples) {
       details.examples.forEach(function (example) {
-        print("db[" + JSON.stringify(collection) + "].insert(" + JSON.stringify(example) + ");");
+        print("db[" + JSON.stringify(collection) + "].insert(" + JSON.stringify(example) + ", { isRestore: true });");
       });
     }
     let missing = details.count;

--- a/tests/Mocks/StorageEngineMock.cpp
+++ b/tests/Mocks/StorageEngineMock.cpp
@@ -1166,6 +1166,21 @@ arangodb::Result PhysicalCollectionMock::insert(
 
   return arangodb::Result();
 }
+  
+arangodb::Result PhysicalCollectionMock::lookupKey(
+    arangodb::transaction::Methods* trx, arangodb::velocypack::StringRef key,
+    std::pair<arangodb::LocalDocumentId, TRI_voc_rid_t>& result) const {
+  before();
+  TRI_ASSERT(false);
+  return arangodb::Result();
+}
+
+arangodb::LocalDocumentId PhysicalCollectionMock::lookupKey(
+    arangodb::transaction::Methods*, arangodb::velocypack::Slice const&) const {
+  before();
+  TRI_ASSERT(false);
+  return arangodb::LocalDocumentId();
+}
 
 arangodb::LocalDocumentId PhysicalCollectionMock::lookupKey(
     arangodb::transaction::Methods*, arangodb::velocypack::Slice const&) const {

--- a/tests/Mocks/StorageEngineMock.cpp
+++ b/tests/Mocks/StorageEngineMock.cpp
@@ -1171,15 +1171,18 @@ arangodb::Result PhysicalCollectionMock::lookupKey(
     arangodb::transaction::Methods* trx, arangodb::velocypack::StringRef key,
     std::pair<arangodb::LocalDocumentId, TRI_voc_rid_t>& result) const {
   before();
-  TRI_ASSERT(false);
-  return arangodb::Result();
-}
+  auto it = _documents.find(arangodb::velocypack::StringRef{key});
+  if (it != _documents.end()) {
+    if (_documents.find(arangodb::velocypack::StringRef{key}) != _documents.end()) {
+      result.first = it->second.docId();
+      result.second = result.first.id();
+      return arangodb::Result();
+    }
+  }
 
-arangodb::LocalDocumentId PhysicalCollectionMock::lookupKey(
-    arangodb::transaction::Methods*, arangodb::velocypack::Slice const&) const {
-  before();
-  TRI_ASSERT(false);
-  return arangodb::LocalDocumentId();
+  result.first.clear();
+  result.second = 0;
+  return arangodb::Result(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND);
 }
 
 arangodb::LocalDocumentId PhysicalCollectionMock::lookupKey(

--- a/tests/Mocks/StorageEngineMock.h
+++ b/tests/Mocks/StorageEngineMock.h
@@ -90,6 +90,9 @@ class PhysicalCollectionMock : public arangodb::PhysicalCollection {
                                   arangodb::OperationOptions& options, bool lock,
                                   arangodb::KeyLockInfo* /*keyLockInfo*/,
                                   std::function<void()> const& callbackDuringLock) override;
+  
+  virtual arangodb::Result lookupKey(arangodb::transaction::Methods* trx, arangodb::velocypack::StringRef key,
+                                     std::pair<arangodb::LocalDocumentId, TRI_voc_rid_t>& result) const override;
 
   virtual arangodb::LocalDocumentId lookupKey(arangodb::transaction::Methods*,
                                               arangodb::velocypack::Slice const&) const override;

--- a/tests/js/common/shell/shell-insert-overwrite.js
+++ b/tests/js/common/shell/shell-insert-overwrite.js
@@ -1,0 +1,713 @@
+/*jshint globalstrict:false, strict:false, maxlen: 5000 */
+/*global fail, assertNull, assertTrue, assertEqual, assertUndefined, assertNotUndefined */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test the insert/overwrite behavior
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+let jsunity = require("jsunity");
+let arangodb = require("@arangodb");
+let ERRORS = arangodb.errors;
+let db = arangodb.db;
+
+function InsertOverwriteSuite () {
+  'use strict';
+  let cn = "UnitTestsCollection";
+
+  return {
+
+    setUp : function () {
+      db._drop(cn);
+      db._create(cn);
+    },
+
+    tearDown : function () {
+      db._drop(cn);
+    },
+
+    testInsertNoOverwrite : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      try {
+        c.insert({ _key: "test", value: 2 });
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code, err.errorNum);
+      }
+
+      assertEqual(1, c.count());
+      assertEqual(1, c.document("test").value);
+    },
+    
+    testInsertWithOverwrite : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      c.insert({ _key: "test", value: 2 }, { overwrite: true });
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+    },
+    
+    testInsertWithOverwriteNewDocument : function () {
+      let c = db._collection(cn);
+      
+      assertEqual(0, c.count());
+
+      c.insert({ _key: "test", value: 2 }, { overwrite: true });
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+    },
+
+    testInsertWithOverwriteReplace : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      c.insert({ _key: "test", value: 2 }, { overwrite: true, overwriteMode: "replace" });
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+    },
+    
+    testInsertWithOverwriteOnlyReplace : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      c.insert({ _key: "test", value: 2 }, { overwriteMode: "replace" });
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+    },
+    
+    testInsertWithOverwriteReplaceNewDocument : function () {
+      let c = db._collection(cn);
+      
+      assertEqual(0, c.count());
+
+      c.insert({ _key: "test", value: 2 }, { overwrite: true, overwriteMode: "replace" });
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+    },
+    
+    testInsertWithOverwriteReplaceReturnOld : function () {
+      let c = db._collection(cn);
+
+      assertEqual(0, c.count());
+
+      let result = c.insert({ _key: "test", value: 2 }, { overwrite: true, overwriteMode: "replace", returnOld: true });
+      assertUndefined(result.old);
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+      
+      result = c.insert({ _key: "test", value: 3 }, { overwrite: true, overwriteMode: "replace", returnOld: true });
+      assertNotUndefined(result.old);
+      assertEqual("test", result.old._key);
+      assertEqual(2, result.old.value);
+      assertEqual(1, c.count());
+      assertEqual(3, c.document("test").value);
+    },
+    
+    testInsertWithOverwriteUpdate : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      c.insert({ _key: "test", value: 2 }, { overwrite: true, overwriteMode: "update" });
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+      
+      c.insert({ _key: "test", foo: "bar" }, { overwrite: true, overwriteMode: "update" });
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+      assertEqual("bar", c.document("test").foo);
+      
+      c.insert({ _key: "test", bar: "baz" }, { overwrite: true, overwriteMode: "update" });
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+      assertEqual("bar", c.document("test").foo);
+      assertEqual("baz", c.document("test").bar);
+      
+      c.insert({ _key: "test", value: 7 }, { overwrite: true, overwriteMode: "replace" });
+      assertEqual(1, c.count());
+      assertEqual(7, c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      assertUndefined(c.document("test").bar);
+    },
+    
+    testInsertWithOverwriteOnlyUpdate : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      c.insert({ _key: "test", value: 2 }, { overwriteMode: "update" });
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+      
+      c.insert({ _key: "test", foo: "bar" }, { overwriteMode: "update" });
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+      assertEqual("bar", c.document("test").foo);
+      
+      c.insert({ _key: "test", bar: "baz" }, { overwriteMode: "update" });
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+      assertEqual("bar", c.document("test").foo);
+      assertEqual("baz", c.document("test").bar);
+      
+      c.insert({ _key: "test", value: 7 }, { overwriteMode: "replace" });
+      assertEqual(1, c.count());
+      assertEqual(7, c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      assertUndefined(c.document("test").bar);
+    },
+    
+    testInsertWithOverwriteUpdateNewDocument : function () {
+      let c = db._collection(cn);
+      
+      assertEqual(0, c.count());
+
+      c.insert({ _key: "test", value: 2 }, { overwrite: true, overwriteMode: "update" });
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+    },
+    
+    testInsertWithOverwriteIgnore : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      c.insert({ _key: "test", value: 2 }, { overwrite: true, overwriteMode: "ignore" });
+      assertEqual(1, c.count());
+      assertEqual(1, c.document("test").value);
+      
+      c.insert({ _key: "test", foo: "bar" }, { overwrite: true, overwriteMode: "ignore" });
+      assertEqual(1, c.count());
+      assertEqual(1, c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      
+      c.insert({ _key: "test", bar: "baz" }, { overwrite: true, overwriteMode: "ignore" });
+      assertEqual(1, c.count());
+      assertEqual(1, c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      assertUndefined(c.document("test").bar);
+      
+      c.insert({ _key: "test", value: 7 }, { overwrite: true, overwriteMode: "replace" });
+      assertEqual(1, c.count());
+      assertEqual(7, c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      assertUndefined(c.document("test").bar);
+    },
+    
+    testInsertWithOverwriteOnlyIgnore : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      c.insert({ _key: "test", value: 2 }, { overwriteMode: "ignore" });
+      assertEqual(1, c.count());
+      assertEqual(1, c.document("test").value);
+      
+      c.insert({ _key: "test", foo: "bar" }, { overwriteMode: "ignore" });
+      assertEqual(1, c.count());
+      assertEqual(1, c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      
+      c.insert({ _key: "test", bar: "baz" }, { overwriteMode: "ignore" });
+      assertEqual(1, c.count());
+      assertEqual(1, c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      assertUndefined(c.document("test").bar);
+      
+      c.insert({ _key: "test", value: 7 }, { overwriteMode: "replace" });
+      assertEqual(1, c.count());
+      assertEqual(7, c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      assertUndefined(c.document("test").bar);
+    },
+    
+    testInsertWithOverwriteIgnoreNewDocument : function () {
+      let c = db._collection(cn);
+
+      assertEqual(0, c.count());
+
+      c.insert({ _key: "test", value: 2 }, { overwrite: true, overwriteMode: "ignore" });
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+    },
+    
+    testInsertWithOverwriteIgnoreNoKey : function () {
+      let c = db._collection(cn);
+
+      assertEqual(0, c.count());
+
+      c.insert({ value: 2 }, { overwrite: true, overwriteMode: "ignore" });
+      assertEqual(1, c.count());
+    },
+    
+    testInsertWithOverwriteIgnoreReturnOld : function () {
+      let c = db._collection(cn);
+
+      assertEqual(0, c.count());
+
+      let result = c.insert({ _key: "test", value: 2 }, { overwrite: true, overwriteMode: "ignore", returnOld: true });
+      assertUndefined(result.old);
+      assertEqual("test", result._key);
+      let oldRev = result._rev;
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+      
+      result = c.insert({ _key: "test", value: 3 }, { overwrite: true, overwriteMode: "ignore", returnOld: true });
+      assertUndefined(result.old);
+      assertEqual("test", result._key);
+      assertEqual(oldRev, result._rev);
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+    },
+    
+    testInsertWithOverwriteIgnoreReturnNew : function () {
+      let c = db._collection(cn);
+
+      assertEqual(0, c.count());
+
+      let result = c.insert({ _key: "test", value: 2 }, { overwrite: true, overwriteMode: "ignore", returnNew: true });
+      assertEqual("test", result.new._key);
+      assertEqual(2, result.new.value);
+      assertEqual("test", result._key);
+      let oldRev = result._rev;
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+      
+      result = c.insert({ _key: "test", value: 3 }, { overwrite: true, overwriteMode: "ignore", returnNew: true });
+      assertUndefined(result.new);
+      assertEqual("test", result._key);
+      assertEqual(oldRev, result._rev);
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+    },
+    
+    testInsertInvalidOverwriteMode : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      c.insert({ _key: "test", value: 2 }, { overwrite: true, overwriteMode: "fleisch" });
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+      
+      c.insert({ _key: "test", value: 3 }, { overwrite: true, overwriteMode: "" });
+      assertEqual(1, c.count());
+      assertEqual(3, c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      
+      c.insert({ _key: "test", rats: true }, { overwrite: true, overwriteMode: false });
+      assertEqual(1, c.count());
+      assertUndefined(c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      assertTrue(c.document("test").rats);
+    },
+    
+    testInsertOnlyInvalidOverwriteMode : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      try {
+        c.insert({ _key: "test", value: 2, foo: "bar" }, { overwriteMode: "hundmann" });
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code, err.errorNum);
+      }
+     
+      try {
+        c.insert({ _key: "test", value: 3 }, { overwriteMode: "" });
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code, err.errorNum);
+      }
+      
+      try {
+        c.insert({ _key: "test", rats: true }, { overwriteMode: false });
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code, err.errorNum);
+      }
+    },
+
+  };
+}
+
+function InsertOverwriteAqlSuite () {
+  'use strict';
+  let cn = "UnitTestsCollection";
+
+  return {
+
+    setUp : function () {
+      db._drop(cn);
+      db._create(cn);
+    },
+
+    tearDown : function () {
+      db._drop(cn);
+    },
+
+    testInsertNoOverwriteAql : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      try {
+        db._query("INSERT { _key: 'test', value: 2 } INTO " + cn);
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code, err.errorNum);
+      }
+
+      assertEqual(1, c.count());
+      assertEqual(1, c.document("test").value);
+    },
+    
+    testInsertWithOverwriteAql : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      db._query("INSERT { _key: 'test', value: 2 } INTO " + cn + " OPTIONS { overwrite: true }");
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+    },
+    
+    testInsertWithOverwriteNewDocumentAql : function () {
+      let c = db._collection(cn);
+      
+      assertEqual(0, c.count());
+
+      db._query("INSERT { _key: 'test', value: 2 } INTO " + cn + " OPTIONS { overwrite: true }");
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+    },
+
+    testInsertWithOverwriteReplaceAql : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      db._query("INSERT { _key: 'test', value: 2 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'replace' }");
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+    },
+    
+    testInsertWithOverwriteOnlyReplaceAql : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      db._query("INSERT { _key: 'test', value: 2 } INTO " + cn + " OPTIONS { overwriteMode: 'replace' }");
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+    },
+    
+    testInsertWithOverwriteReplaceNewDocumentAql : function () {
+      let c = db._collection(cn);
+      
+      assertEqual(0, c.count());
+
+      db._query("INSERT { _key: 'test', value: 2 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'replace' }");
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+    },
+    
+    testInsertWithOverwriteUpdateAql : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      db._query("INSERT { _key: 'test', value: 2 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'update' }");
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+      
+      db._query("INSERT { _key: 'test', foo: 'bar' } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'update' }");
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+      assertEqual("bar", c.document("test").foo);
+      
+      db._query("INSERT { _key: 'test', bar: 'baz' } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'update' }");
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+      assertEqual("bar", c.document("test").foo);
+      assertEqual("baz", c.document("test").bar);
+      
+      db._query("INSERT { _key: 'test', value: 7 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'replace' }");
+      assertEqual(1, c.count());
+      assertEqual(7, c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      assertUndefined(c.document("test").bar);
+    },
+    
+    testInsertWithOverwriteOnlyUpdateAql : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      db._query("INSERT { _key: 'test', value: 2 } INTO " + cn + " OPTIONS { overwriteMode: 'update' }");
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+      
+      db._query("INSERT { _key: 'test', foo: 'bar' } INTO " + cn + " OPTIONS { overwriteMode: 'update' }");
+      assertEqual(1, c.count());
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+      assertEqual("bar", c.document("test").foo);
+      
+      db._query("INSERT { _key: 'test', bar: 'baz' } INTO " + cn + " OPTIONS { overwriteMode: 'update' }");
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+      assertEqual("bar", c.document("test").foo);
+      assertEqual("baz", c.document("test").bar);
+      
+      db._query("INSERT { _key: 'test', value: 7 } INTO " + cn + " OPTIONS { overwriteMode: 'replace' }");
+      assertEqual(1, c.count());
+      assertEqual(7, c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      assertUndefined(c.document("test").bar);
+    },
+    
+    testInsertWithOverwriteUpdateNewDocumentAql : function () {
+      let c = db._collection(cn);
+      
+      assertEqual(0, c.count());
+
+      db._query("INSERT { _key: 'test', value: 2 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'update' }");
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+    },
+    
+    testInsertWithOverwriteIgnoreAql : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      db._query("INSERT { _key: 'test', value: 2 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'ignore' }");
+      assertEqual(1, c.count());
+      assertEqual(1, c.document("test").value);
+      
+      db._query("INSERT { _key: 'test', foo: 'bar' } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'ignore' }");
+      assertEqual(1, c.count());
+      assertEqual(1, c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      
+      db._query("INSERT { _key: 'test', bar: 'baz' } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'ignore' }");
+      assertEqual(1, c.count());
+      assertEqual(1, c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      assertUndefined(c.document("test").bar);
+      
+      db._query("INSERT { _key: 'test', value: 7 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'replace' }");
+      assertEqual(1, c.count());
+      assertEqual(7, c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      assertUndefined(c.document("test").bar);
+    },
+    
+    testInsertWithOverwriteOnlyIgnoreAql : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      db._query("INSERT { _key: 'test', value: 2 } INTO " + cn + " OPTIONS { overwriteMode: 'ignore' }");
+      assertEqual(1, c.count());
+      assertEqual(1, c.document("test").value);
+      
+      db._query("INSERT { _key: 'test', foo: 'bar' } INTO " + cn + " OPTIONS { overwriteMode: 'ignore' }");
+      assertEqual(1, c.count());
+      assertEqual(1, c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      
+      db._query("INSERT { _key: 'test', bar: 'baz' } INTO " + cn + " OPTIONS { overwriteMode: 'ignore' }");
+      assertEqual(1, c.count());
+      assertEqual(1, c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      assertUndefined(c.document("test").bar);
+      
+      db._query("INSERT { _key: 'test', value: 7 } INTO " + cn + " OPTIONS { overwriteMode: 'replace' }");
+      assertEqual(1, c.count());
+      assertEqual(7, c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      assertUndefined(c.document("test").bar);
+    },
+    
+    testInsertWithOverwriteIgnoreNewDocumentAql : function () {
+      let c = db._collection(cn);
+
+      assertEqual(0, c.count());
+
+      db._query("INSERT { _key: 'test', value: 2 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'ignore' }");
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+    },
+    
+    testInsertWithOverwriteIgnoreNoKeyAql : function () {
+      let c = db._collection(cn);
+
+      assertEqual(0, c.count());
+
+      db._query("INSERT { value: 2 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'ignore' }");
+      assertEqual(1, c.count());
+    },
+    
+    testInsertWithOverwriteIgnoreReturnOldAql : function () {
+      let c = db._collection(cn);
+
+      try {
+        db._query("INSERT { _key: 'test', value: 2 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'ignore' } RETURN OLD");
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, err.errorNum);
+      }
+      
+      assertEqual(0, c.count());
+
+      c.insert({ _key: "test", value: 2 });
+
+      try {
+        db._query("INSERT { _key: 'test', value: 3 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'ignore' } RETURN OLD");
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, err.errorNum);
+      }
+      
+      assertEqual(2, c.document("test").value);
+      assertEqual(1, c.count());
+    },
+    
+    testInsertWithOverwriteIgnoreReturnOldAqlNoSingleOperation : function () {
+      let disableRule = { optimizer: { rules: ["-optimize-cluster-single-document-operations"] } };
+      let c = db._collection(cn);
+
+      try {
+        db._query("INSERT { _key: 'test', value: 2 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'ignore' } RETURN OLD", null, disableRule);
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, err.errorNum);
+      }
+      
+      assertEqual(0, c.count());
+
+      c.insert({ _key: "test", value: 2 });
+
+      try {
+        db._query("INSERT { _key: 'test', value: 3 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'ignore' } RETURN OLD", null, disableRule);
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, err.errorNum);
+      }
+      
+      assertEqual(2, c.document("test").value);
+      assertEqual(1, c.count());
+    },
+    
+    testInsertWithOverwriteIgnoreReturnNewAql : function () {
+      let c = db._collection(cn);
+        
+      let result = db._query("INSERT { _key: 'test', value: 2 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'ignore' } RETURN NEW").toArray();
+      assertEqual("test", result[0]._key);
+      assertEqual(2, result[0].value);
+
+      result = db._query("INSERT { _key: 'test', value: 3 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'ignore' } RETURN NEW").toArray();
+      assertNull(result[0]);
+      
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+    },
+
+    testInsertWithOverwriteIgnoreReturnNewAqlNoSingleOperation : function () {
+      let disableRule = { optimizer: { rules: ["-optimize-cluster-single-document-operations"] } };
+      let c = db._collection(cn);
+        
+      let result = db._query("INSERT { _key: 'test', value: 2 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'ignore' } RETURN NEW", null, disableRule).toArray();
+      assertEqual("test", result[0]._key);
+      assertEqual(2, result[0].value);
+
+      result = db._query("INSERT { _key: 'test', value: 3 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'ignore' } RETURN NEW", null, disableRule).toArray();
+      assertNull(result[0]);
+      
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+    },
+    
+    testInsertInvalidOverwriteModeAql : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      db._query("INSERT { _key: 'test', value: 2 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: 'fleisch' }");
+      assertEqual(1, c.count());
+      assertEqual(2, c.document("test").value);
+      
+      db._query("INSERT { _key: 'test', value: 3 } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: '' }");
+      assertEqual(1, c.count());
+      assertEqual(3, c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      
+      db._query("INSERT { _key: 'test', rats: true } INTO " + cn + " OPTIONS { overwrite: true, overwriteMode: false }");
+      assertEqual(1, c.count());
+      assertUndefined(c.document("test").value);
+      assertUndefined(c.document("test").foo);
+      assertTrue(c.document("test").rats);
+    },
+    
+    testInsertOnlyInvalidOverwriteModeAql : function () {
+      let c = db._collection(cn);
+
+      c.insert({ _key: "test", value: 1 });
+
+      try {
+        db._query("INSERT { _key: 'test', value: 2, foo: 'bar' } INTO " + cn + " OPTIONS { overwriteMode: 'hundmann' }");
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code, err.errorNum);
+      }
+     
+      try {
+        db._query("INSERT { _key: 'test', value: 3 } INTO " + cn + " OPTIONS { overwriteMode: '' }");
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code, err.errorNum);
+      }
+      
+      try {
+        db._query("INSERT { _key: 'test', rats: true } INTO " + cn + " OPTIONS { overwriteMode: false }");
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code, err.errorNum);
+      }
+    },
+
+  };
+}
+
+jsunity.run(InsertOverwriteSuite);
+jsunity.run(InsertOverwriteAqlSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

* added overwriteMode "ignore" for AQL INSERT and non-AQL inserts.
* added tests for overwriteModes.
* fix a splice-subquery related bug in explainer for subqueries that don't return any data.
* fix an incorrect assertion in the agency.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server, shell_client)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9310/