### PR TITLE
simplify register planning code, a bit

### DIFF
--- a/arangod/Aql/AqlItemBlock.cpp
+++ b/arangod/Aql/AqlItemBlock.cpp
@@ -909,25 +909,6 @@ void AqlItemBlock::eraseAll() {
   _valueCount.clear();
 }
 
-void AqlItemBlock::copyValuesFromRow(size_t currentRow, RegisterId curRegs, size_t fromRow) {
-  TRI_ASSERT(currentRow != fromRow);
-
-  for (RegisterId i = 0; i < curRegs; i++) {
-    auto currentAddress = getAddress(currentRow, i);
-    auto fromAddress = getAddress(fromRow, i);
-    if (_data[currentAddress].isEmpty()) {
-      // First update the reference count, if this fails, the value is empty
-      if (_data[fromAddress].requiresDestruction()) {
-        ++_valueCount[_data[fromAddress]];
-      }
-      TRI_ASSERT(_data[currentAddress].isEmpty());
-      _data[currentAddress] = _data[fromAddress];
-    }
-  }
-  // Copy over subqueryDepth
-  copySubqueryDepth(currentRow, fromRow);
-}
-
 void AqlItemBlock::copyValuesFromRow(size_t currentRow,
                                      std::unordered_set<RegisterId> const& regs,
                                      size_t fromRow) {

--- a/arangod/Aql/AqlItemBlock.h
+++ b/arangod/Aql/AqlItemBlock.h
@@ -149,8 +149,6 @@ class AqlItemBlock {
   /// elsewhere
   void eraseAll();
 
-  void copyValuesFromRow(size_t currentRow, RegisterId curRegs, size_t fromRow);
-
   void copyValuesFromRow(size_t currentRow,
                          std::unordered_set<RegisterId> const& regs, size_t fromRow);
 

--- a/arangod/Aql/AqlValue.cpp
+++ b/arangod/Aql/AqlValue.cpp
@@ -77,14 +77,15 @@ static inline uint8_t intLength(int64_t value) noexcept {
 
 /// @brief hashes the value
 uint64_t AqlValue::hash(transaction::Methods* trx, uint64_t seed) const {
-  switch (type()) {
+  AqlValueType t = type();
+  switch (t) {
     case VPACK_INLINE:
     case VPACK_SLICE_POINTER:
     case VPACK_MANAGED_SLICE:
     case VPACK_MANAGED_BUFFER: {
       // we must use the slow hash function here, because a value may have
       // different representations in case it's an array/object/number
-      return slice().normalizedHash(seed);
+      return slice(t).normalizedHash(seed);
     }
     case DOCVEC:
     case RANGE: {
@@ -101,97 +102,185 @@ uint64_t AqlValue::hash(transaction::Methods* trx, uint64_t seed) const {
 
 /// @brief whether or not the value contains a none value
 bool AqlValue::isNone() const noexcept {
-  AqlValueType t = type();
-  if (t == DOCVEC || t == RANGE) {
-    return false;
+  switch (type()) {
+    case VPACK_INLINE: {
+      return VPackSlice(&_data.internal[0]).resolveExternal().isNone();
+    }
+    case VPACK_SLICE_POINTER: {
+      // not resolving externals here
+      return VPackSlice(_data.pointer).isNone();
+    }
+    case VPACK_MANAGED_SLICE: {
+      return VPackSlice(_data.slice).resolveExternal().isNone();
+    }
+    case VPACK_MANAGED_BUFFER: {
+      return VPackSlice(_data.buffer->data()).resolveExternal().isNone();
+    }
+    case DOCVEC:
+    case RANGE: {
+      break;
+    }
   }
 
-  try {
-    return slice().isNone();
-  } catch (...) {
-    return false;
-  }
+  return false;
 }
 
 /// @brief whether or not the value is a null value
 bool AqlValue::isNull(bool emptyIsNull) const noexcept {
-  AqlValueType t = type();
-  if (t == DOCVEC || t == RANGE) {
-    return false;
+  switch (type()) {
+    case VPACK_INLINE: {
+      VPackSlice s(&_data.internal[0]);
+      s = s.resolveExternal();
+      return (s.isNull() || (emptyIsNull && s.isNone()));
+    }
+    case VPACK_SLICE_POINTER: {
+      // not resolving externals here
+      VPackSlice s(_data.pointer);
+      return (s.isNull() || (emptyIsNull && s.isNone()));
+    }
+    case VPACK_MANAGED_SLICE: {
+      VPackSlice s(_data.slice);
+      s = s.resolveExternal();
+      return (s.isNull() || (emptyIsNull && s.isNone()));
+    }
+    case VPACK_MANAGED_BUFFER: {
+      VPackSlice s(_data.buffer->data());
+      s = s.resolveExternal();
+      return (s.isNull() || (emptyIsNull && s.isNone()));
+    }
+    case DOCVEC:
+    case RANGE: {
+      break;
+    }
   }
 
-  try {
-    VPackSlice s(slice());
-    return (s.isNull() || (emptyIsNull && s.isNone()));
-  } catch (...) {
-    return false;
-  }
+  return false;
 }
 
 /// @brief whether or not the value is a boolean value
 bool AqlValue::isBoolean() const noexcept {
-  AqlValueType t = type();
-  if (t == DOCVEC || t == RANGE) {
-    return false;
+  switch (type()) {
+    case VPACK_INLINE: {
+      return VPackSlice(&_data.internal[0]).resolveExternal().isBoolean();
+    }
+    case VPACK_SLICE_POINTER: {
+      // not resolving externals here
+      return VPackSlice(_data.pointer).isBoolean();
+    }
+    case VPACK_MANAGED_SLICE: {
+      return VPackSlice(_data.slice).resolveExternal().isBoolean();
+    }
+    case VPACK_MANAGED_BUFFER: {
+      return VPackSlice(_data.buffer->data()).resolveExternal().isBoolean();
+    }
+    case DOCVEC:
+    case RANGE: {
+      break;
+    }
   }
-  try {
-    return slice().isBoolean();
-  } catch (...) {
-    return false;
-  }
+
+  return false;
 }
 
 /// @brief whether or not the value is a number
 bool AqlValue::isNumber() const noexcept {
-  AqlValueType t = type();
-  if (t == DOCVEC || t == RANGE) {
-    return false;
+  switch (type()) {
+    case VPACK_INLINE: {
+      return VPackSlice(&_data.internal[0]).resolveExternal().isNumber();
+    }
+    case VPACK_SLICE_POINTER: {
+      // not resolving externals here
+      return VPackSlice(_data.pointer).isNumber();
+    }
+    case VPACK_MANAGED_SLICE: {
+      return VPackSlice(_data.slice).resolveExternal().isNumber();
+    }
+    case VPACK_MANAGED_BUFFER: {
+      return VPackSlice(_data.buffer->data()).resolveExternal().isNumber();
+    }
+    case DOCVEC:
+    case RANGE: {
+      break;
+    }
   }
-  try {
-    return slice().isNumber();
-  } catch (...) {
-    return false;
-  }
+
+  return false;
 }
 
 /// @brief whether or not the value is a string
 bool AqlValue::isString() const noexcept {
-  AqlValueType t = type();
-  if (t == DOCVEC || t == RANGE) {
-    return false;
+  switch (type()) {
+    case VPACK_INLINE: {
+      return VPackSlice(&_data.internal[0]).resolveExternal().isString();
+    }
+    case VPACK_SLICE_POINTER: {
+      // not resolving externals here
+      return VPackSlice(_data.pointer).isString();
+    }
+    case VPACK_MANAGED_SLICE: {
+      return VPackSlice(_data.slice).resolveExternal().isString();
+    }
+    case VPACK_MANAGED_BUFFER: {
+      return VPackSlice(_data.buffer->data()).resolveExternal().isString();
+    }
+    case DOCVEC:
+    case RANGE: {
+      break;
+    }
   }
-  try {
-    return slice().isString();
-  } catch (...) {
-    return false;
-  }
+  
+  return false;
 }
 
 /// @brief whether or not the value is an object
 bool AqlValue::isObject() const noexcept {
-  AqlValueType t = type();
-  if (t == RANGE || t == DOCVEC) {
-    return false;
+  switch (type()) {
+    case VPACK_INLINE: {
+      return VPackSlice(&_data.internal[0]).resolveExternal().isObject();
+    }
+    case VPACK_SLICE_POINTER: {
+      // not resolving externals here
+      return VPackSlice(_data.pointer).isObject();
+    }
+    case VPACK_MANAGED_SLICE: {
+      return VPackSlice(_data.slice).resolveExternal().isObject();
+    }
+    case VPACK_MANAGED_BUFFER: {
+      return VPackSlice(_data.buffer->data()).resolveExternal().isObject();
+    }
+    case DOCVEC:
+    case RANGE: {
+      break;
+    }
   }
-  try {
-    return slice().isObject();
-  } catch (...) {
-    return false;
-  }
+  
+  return false;
 }
 
 /// @brief whether or not the value is an array (note: this treats ranges
 /// as arrays, too!)
 bool AqlValue::isArray() const noexcept {
-  AqlValueType t = type();
-  if (t == RANGE || t == DOCVEC) {
-    return true;
+  switch (type()) {
+    case VPACK_INLINE: {
+      return VPackSlice(&_data.internal[0]).resolveExternal().isArray();
+    }
+    case VPACK_SLICE_POINTER: {
+      // not resolving externals here
+      return VPackSlice(_data.pointer).isArray();
+    }
+    case VPACK_MANAGED_SLICE: {
+      return VPackSlice(_data.slice).resolveExternal().isArray();
+    }
+    case VPACK_MANAGED_BUFFER: {
+      return VPackSlice(_data.buffer->data()).resolveExternal().isArray();
+    }
+    case DOCVEC:
+    case RANGE: {
+      break;
+    }
   }
-  try {
-    return slice().isArray();
-  } catch (...) {
-    return false;
-  }
+  
+  return true;
 }
 
 char const* AqlValue::getTypeString() const noexcept {
@@ -215,12 +304,13 @@ char const* AqlValue::getTypeString() const noexcept {
 
 /// @brief get the (array) length (note: this treats ranges as arrays, too!)
 size_t AqlValue::length() const {
-  switch (type()) {
+  AqlValueType t = type();
+  switch (t) {
     case VPACK_INLINE:
     case VPACK_SLICE_POINTER:
     case VPACK_MANAGED_SLICE:
     case VPACK_MANAGED_BUFFER: {
-      return static_cast<size_t>(slice().length());
+      return static_cast<size_t>(slice(t).length());
     }
     case DOCVEC: {
       return docvecSize();
@@ -236,7 +326,8 @@ size_t AqlValue::length() const {
 /// @brief get the (array) element at position
 AqlValue AqlValue::at(int64_t position, bool& mustDestroy, bool doCopy) const {
   mustDestroy = false;
-  switch (type()) {
+  AqlValueType t = type();
+  switch (t) {
     case VPACK_SLICE_POINTER:
       doCopy = false;
     [[fallthrough]];
@@ -245,7 +336,7 @@ AqlValue AqlValue::at(int64_t position, bool& mustDestroy, bool doCopy) const {
     case VPACK_MANAGED_SLICE:
     [[fallthrough]];
     case VPACK_MANAGED_BUFFER: {
-      VPackSlice s(slice());
+      VPackSlice s(slice(t));
       if (s.isArray()) {
         int64_t const n = static_cast<int64_t>(s.length());
         if (position < 0) {
@@ -313,7 +404,8 @@ AqlValue AqlValue::at(int64_t position, bool& mustDestroy, bool doCopy) const {
 /// @brief get the (array) element at position
 AqlValue AqlValue::at(int64_t position, size_t n, bool& mustDestroy, bool doCopy) const {
   mustDestroy = false;
-  switch (type()) {
+  AqlValueType t = type();
+  switch (t) {
     case VPACK_SLICE_POINTER:
       doCopy = false;
     [[fallthrough]];
@@ -322,7 +414,7 @@ AqlValue AqlValue::at(int64_t position, size_t n, bool& mustDestroy, bool doCopy
     case VPACK_MANAGED_SLICE:
     [[fallthrough]];
     case VPACK_MANAGED_BUFFER: {
-      VPackSlice s(slice());
+      VPackSlice s(slice(t));
       if (s.isArray()) {
         if (position < 0) {
           // a negative position is allowed
@@ -387,7 +479,8 @@ AqlValue AqlValue::at(int64_t position, size_t n, bool& mustDestroy, bool doCopy
 /// @brief get the _key attribute from an object/document
 AqlValue AqlValue::getKeyAttribute(bool& mustDestroy, bool doCopy) const {
   mustDestroy = false;
-  switch (type()) {
+  AqlValueType t = type();
+  switch (t) {
     case VPACK_SLICE_POINTER:
       doCopy = false;
     [[fallthrough]];
@@ -396,7 +489,7 @@ AqlValue AqlValue::getKeyAttribute(bool& mustDestroy, bool doCopy) const {
     case VPACK_MANAGED_SLICE:
     [[fallthrough]];
     case VPACK_MANAGED_BUFFER: {
-      VPackSlice s(slice());
+      VPackSlice s(slice(t));
       if (s.isObject()) {
         VPackSlice found = transaction::helpers::extractKeyFromDocument(s);
         if (!found.isNone()) {
@@ -426,7 +519,8 @@ AqlValue AqlValue::getKeyAttribute(bool& mustDestroy, bool doCopy) const {
 AqlValue AqlValue::getIdAttribute(CollectionNameResolver const& resolver,
                                   bool& mustDestroy, bool doCopy) const {
   mustDestroy = false;
-  switch (type()) {
+  AqlValueType t = type();
+  switch (t) {
     case VPACK_SLICE_POINTER:
       doCopy = false;
     [[fallthrough]];
@@ -435,7 +529,7 @@ AqlValue AqlValue::getIdAttribute(CollectionNameResolver const& resolver,
     case VPACK_MANAGED_SLICE:
     [[fallthrough]];
     case VPACK_MANAGED_BUFFER: {
-      VPackSlice s(slice());
+      VPackSlice s(slice(t));
       if (s.isObject()) {
         VPackSlice found = transaction::helpers::extractIdFromDocument(s);
         if (found.isCustom()) {
@@ -469,7 +563,8 @@ AqlValue AqlValue::getIdAttribute(CollectionNameResolver const& resolver,
 /// @brief get the _from attribute from an object/document
 AqlValue AqlValue::getFromAttribute(bool& mustDestroy, bool doCopy) const {
   mustDestroy = false;
-  switch (type()) {
+  AqlValueType t = type();
+  switch (t) {
     case VPACK_SLICE_POINTER:
       doCopy = false;
     [[fallthrough]];
@@ -478,7 +573,7 @@ AqlValue AqlValue::getFromAttribute(bool& mustDestroy, bool doCopy) const {
     case VPACK_MANAGED_SLICE:
     [[fallthrough]];
     case VPACK_MANAGED_BUFFER: {
-      VPackSlice s(slice());
+      VPackSlice s(slice(t));
       if (s.isObject()) {
         VPackSlice found = transaction::helpers::extractFromFromDocument(s);
         if (!found.isNone()) {
@@ -507,7 +602,8 @@ AqlValue AqlValue::getFromAttribute(bool& mustDestroy, bool doCopy) const {
 /// @brief get the _to attribute from an object/document
 AqlValue AqlValue::getToAttribute(bool& mustDestroy, bool doCopy) const {
   mustDestroy = false;
-  switch (type()) {
+  AqlValueType t = type();
+  switch (t) {
     case VPACK_SLICE_POINTER:
       doCopy = false;
     [[fallthrough]];
@@ -516,7 +612,7 @@ AqlValue AqlValue::getToAttribute(bool& mustDestroy, bool doCopy) const {
     case VPACK_MANAGED_SLICE:
     [[fallthrough]];
     case VPACK_MANAGED_BUFFER: {
-      VPackSlice s(slice());
+      VPackSlice s(slice(t));
       if (s.isObject()) {
         VPackSlice found = transaction::helpers::extractToFromDocument(s);
         if (!found.isNone()) {
@@ -546,7 +642,8 @@ AqlValue AqlValue::getToAttribute(bool& mustDestroy, bool doCopy) const {
 AqlValue AqlValue::get(CollectionNameResolver const& resolver,
                        std::string const& name, bool& mustDestroy, bool doCopy) const {
   mustDestroy = false;
-  switch (type()) {
+  AqlValueType t = type();
+  switch (t) {
     case VPACK_SLICE_POINTER:
       doCopy = false;
     [[fallthrough]];
@@ -555,7 +652,7 @@ AqlValue AqlValue::get(CollectionNameResolver const& resolver,
     case VPACK_MANAGED_SLICE:
     [[fallthrough]];
     case VPACK_MANAGED_BUFFER: {
-      VPackSlice s(slice());
+      VPackSlice s(slice(t));
       if (s.isObject()) {
         VPackSlice found(s.get(name));
         if (found.isCustom()) {
@@ -591,7 +688,8 @@ AqlValue AqlValue::get(CollectionNameResolver const& resolver,
                        arangodb::velocypack::StringRef const& name,
                        bool& mustDestroy, bool doCopy) const {
   mustDestroy = false;
-  switch (type()) {
+  AqlValueType t = type();
+  switch (t) {
     case VPACK_SLICE_POINTER:
       doCopy = false;
     [[fallthrough]];
@@ -600,7 +698,7 @@ AqlValue AqlValue::get(CollectionNameResolver const& resolver,
     case VPACK_MANAGED_SLICE:
     [[fallthrough]];
     case VPACK_MANAGED_BUFFER: {
-      VPackSlice s(slice());
+      VPackSlice s(slice(t));
       if (s.isObject()) {
         VPackSlice found(s.get(name));
         if (found.isCustom()) {
@@ -640,7 +738,8 @@ AqlValue AqlValue::get(CollectionNameResolver const& resolver,
     return AqlValue(AqlValueHintNull());
   }
 
-  switch (type()) {
+  AqlValueType t = type();
+  switch (t) {
     case VPACK_SLICE_POINTER:
       doCopy = false;
     [[fallthrough]];
@@ -649,7 +748,7 @@ AqlValue AqlValue::get(CollectionNameResolver const& resolver,
     case VPACK_MANAGED_SLICE:
     [[fallthrough]];
     case VPACK_MANAGED_BUFFER: {
-      VPackSlice s(slice());
+      VPackSlice s(slice(t));
       if (s.isObject()) {
         if (s.isExternal()) {
           s = s.resolveExternal();
@@ -706,12 +805,13 @@ AqlValue AqlValue::get(CollectionNameResolver const& resolver,
 
 /// @brief check whether an object has a specific key
 bool AqlValue::hasKey(std::string const& name) const {
-  switch (type()) {
+  AqlValueType t = type();
+  switch (t) {
     case VPACK_INLINE:
     case VPACK_SLICE_POINTER:
     case VPACK_MANAGED_SLICE:
     case VPACK_MANAGED_BUFFER: {
-      VPackSlice s(slice());
+      VPackSlice s(slice(t));
       return (s.isObject() && s.hasKey(name));
     }
     case DOCVEC:
@@ -732,12 +832,13 @@ double AqlValue::toDouble() const {
 
 double AqlValue::toDouble(bool& failed) const {
   failed = false;
-  switch (type()) {
+  AqlValueType t = type();
+  switch (t) {
     case VPACK_INLINE:
     case VPACK_SLICE_POINTER:
     case VPACK_MANAGED_SLICE:
     case VPACK_MANAGED_BUFFER: {
-      VPackSlice s(slice());
+      VPackSlice s(slice(t));
       if (s.isNull()) {
         return 0.0;
       }
@@ -780,12 +881,13 @@ double AqlValue::toDouble(bool& failed) const {
 
 /// @brief get the numeric value of an AqlValue
 int64_t AqlValue::toInt64() const {
-  switch (type()) {
+  AqlValueType t = type();
+  switch (t) {
     case VPACK_INLINE:
     case VPACK_SLICE_POINTER:
     case VPACK_MANAGED_SLICE:
     case VPACK_MANAGED_BUFFER: {
-      VPackSlice s(slice());
+      VPackSlice s(slice(t));
       if (s.isNumber()) {
         return s.getNumber<int64_t>();
       }
@@ -832,12 +934,13 @@ int64_t AqlValue::toInt64() const {
 
 /// @brief whether or not the contained value evaluates to true
 bool AqlValue::toBoolean() const {
-  switch (type()) {
+  AqlValueType t = type();
+  switch (t) {
     case VPACK_INLINE:
     case VPACK_SLICE_POINTER:
     case VPACK_MANAGED_SLICE:
     case VPACK_MANAGED_BUFFER: {
-      VPackSlice s(slice());
+      VPackSlice s(slice(t));
       if (s.isBoolean()) {
         return s.getBoolean();
       }
@@ -881,13 +984,14 @@ size_t AqlValue::sizeofDocvec() const {
 /// @brief construct a V8 value as input for the expression execution in V8
 v8::Handle<v8::Value> AqlValue::toV8(v8::Isolate* isolate, transaction::Methods* trx) const {
   auto context = TRI_IGETC;
-  switch (type()) {
+  AqlValueType t = type();
+  switch (t) {
     case VPACK_INLINE:
     case VPACK_SLICE_POINTER:
     case VPACK_MANAGED_SLICE:
     case VPACK_MANAGED_BUFFER: {
       VPackOptions* options = trx->transactionContext()->getVPackOptions();
-      return TRI_VPackToV8(isolate, slice(), options);
+      return TRI_VPackToV8(isolate, slice(t), options);
     }
     case DOCVEC: {
       // calculate the result array length
@@ -938,7 +1042,8 @@ v8::Handle<v8::Value> AqlValue::toV8(v8::Isolate* isolate, transaction::Methods*
 /// @brief materializes a value into the builder
 void AqlValue::toVelocyPack(VPackOptions const* options, arangodb::velocypack::Builder& builder,
                             bool resolveExternals) const {
-  switch (type()) {
+  AqlValueType t = type();
+  switch (t) {
     case VPACK_SLICE_POINTER:
       if (!resolveExternals && isManagedDocument()) {
         builder.addExternal(_data.pointer);
@@ -951,11 +1056,11 @@ void AqlValue::toVelocyPack(VPackOptions const* options, arangodb::velocypack::B
         bool const sanitizeExternals = true;
         bool const sanitizeCustom = true;
         arangodb::basics::VelocyPackHelper::sanitizeNonClientTypes(
-            slice(), VPackSlice::noneSlice(), builder,
+            slice(t), VPackSlice::noneSlice(), builder,
             options, sanitizeExternals,
             sanitizeCustom);
       } else {
-        builder.add(slice());
+        builder.add(slice(t));
       }
       break;
     }
@@ -1023,10 +1128,11 @@ AqlValue AqlValue::materialize(transaction::Methods* trx, bool& hasCopied,
 
 /// @brief clone a value
 AqlValue AqlValue::clone() const {
-  switch (type()) {
+  AqlValueType t = type();
+  switch (t) {
     case VPACK_INLINE: {
       // copy internal data
-      return AqlValue(slice());
+      return AqlValue(slice(t));
     }
     case VPACK_SLICE_POINTER: {
       if (isManagedDocument()) {
@@ -1095,28 +1201,39 @@ void AqlValue::destroy() noexcept {
 VPackSlice AqlValue::slice() const {
   switch (type()) {
     case VPACK_INLINE: {
-      VPackSlice s(&_data.internal[0]);
-      if (s.isExternal()) {
-        s = s.resolveExternal();
-      }
-      return s;
+      return VPackSlice(&_data.internal[0]).resolveExternal();
     }
     case VPACK_SLICE_POINTER: {
       return VPackSlice(_data.pointer);
     }
     case VPACK_MANAGED_SLICE: {
-      VPackSlice s(_data.slice);
-      if (s.isExternal()) {
-        s = s.resolveExternal();
-      }
-      return s;
+      return VPackSlice(_data.slice).resolveExternal();
     }
     case VPACK_MANAGED_BUFFER: {
-      VPackSlice s(_data.buffer->data());
-      if (s.isExternal()) {
-        s = s.resolveExternal();
-      }
-      return s;
+      return VPackSlice(_data.buffer->data()).resolveExternal();
+    }
+    case DOCVEC:
+    case RANGE: {
+    }
+  }
+
+  THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
+}
+
+/// @brief return the slice from the value
+VPackSlice AqlValue::slice(AqlValueType type) const {
+  switch (type) {
+    case VPACK_INLINE: {
+      return VPackSlice(&_data.internal[0]).resolveExternal();
+    }
+    case VPACK_SLICE_POINTER: {
+      return VPackSlice(_data.pointer);
+    }
+    case VPACK_MANAGED_SLICE: {
+      return VPackSlice(_data.slice).resolveExternal();
+    }
+    case VPACK_MANAGED_BUFFER: {
+      return VPackSlice(_data.buffer->data()).resolveExternal();
     }
     case DOCVEC:
     case RANGE: {
@@ -1156,7 +1273,7 @@ int AqlValue::Compare(velocypack::Options const* options, AqlValue const& left,
     case VPACK_SLICE_POINTER:
     case VPACK_MANAGED_SLICE:
     case VPACK_MANAGED_BUFFER: {
-      return arangodb::basics::VelocyPackHelper::compare(left.slice(), right.slice(),
+      return arangodb::basics::VelocyPackHelper::compare(left.slice(leftType), right.slice(rightType),
                                                          compareUtf8, options);
     }
     case DOCVEC: {

--- a/arangod/Aql/AqlValue.h
+++ b/arangod/Aql/AqlValue.h
@@ -344,6 +344,8 @@ struct AqlValue final {
   /// this will throw if the value type is not VPACK_SLICE_POINTER,
   /// VPACK_INLINE, VPACK_MANAGED_SLICE or VPACK_MANAGED_BUFFER
   arangodb::velocypack::Slice slice() const;
+  
+  arangodb::velocypack::Slice slice(AqlValueType type) const;
 
   /// @brief clone a value
   AqlValue clone() const;

--- a/arangod/Aql/BlocksWithClients.cpp
+++ b/arangod/Aql/BlocksWithClients.cpp
@@ -100,9 +100,6 @@ BlocksWithClientsImpl<Executor>::BlocksWithClientsImpl(ExecutionEngine* engine,
 
   _clientBlockData.reserve(shardIds.size());
 
-  auto readAble = make_shared_unordered_set();
-  auto writeAble = make_shared_unordered_set();
-
   for (auto const& id : shardIds) {
     _clientBlockData.try_emplace(id, typename Executor::ClientBlockData{*engine, scatter, _infos});
   }

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -239,7 +239,7 @@ std::unique_ptr<OutputAqlItemRow> ExecutionBlockImpl<Executor>::createOutputRow(
   }
 #endif
 
-  if /* constexpr */ (Executor::Properties::allowsBlockPassthrough == BlockPassthrough::Enable) {
+  if constexpr (Executor::Properties::allowsBlockPassthrough == BlockPassthrough::Enable) {
     return std::make_unique<OutputAqlItemRow>(newBlock, infos().getOutputRegisters(),
                                               infos().registersToKeep(),
                                               infos().registersToClear(), call,

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -73,6 +73,8 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/velocypack-aliases.h>
 
+#include <algorithm>
+
 using namespace arangodb;
 using namespace arangodb::aql;
 using namespace arangodb::basics;
@@ -355,58 +357,11 @@ ExecutionNode::ExecutionNode(ExecutionPlan* plan, VPackSlice const& slice)
     : _id(slice.get("id").getNumericValue<size_t>()),
       _depth(slice.get("depth").getNumericValue<int>()),
       _varUsageValid(true),
-      _plan(plan),
-      _isInSplicedSubquery(false) {
-  TRI_ASSERT(_registerPlan.get() == nullptr);
-  _registerPlan.reset(new RegisterPlan());
-  _registerPlan->clear();
-  _registerPlan->depth = _depth;
-  _registerPlan->totalNrRegs = slice.get("totalNrRegs").getNumericValue<unsigned int>();
-
-  VPackSlice varInfoList = slice.get("varInfoList");
-  if (!varInfoList.isArray()) {
-    THROW_ARANGO_EXCEPTION_MESSAGE(
-        TRI_ERROR_BAD_PARAMETER,
-        "\"varInfoList\" attribute needs to be an array");
-  }
-
-  _registerPlan->varInfo.reserve(varInfoList.length());
-
-  for (VPackSlice it : VPackArrayIterator(varInfoList)) {
-    if (!it.isObject()) {
-      THROW_ARANGO_EXCEPTION_MESSAGE(
-          TRI_ERROR_NOT_IMPLEMENTED,
-          "\"varInfoList\" item needs to be an object");
-    }
-    VariableId variableId = it.get("VariableId").getNumericValue<VariableId>();
-    RegisterId registerId = it.get("RegisterId").getNumericValue<RegisterId>();
-    unsigned int depth = it.get("depth").getNumericValue<unsigned int>();
-
-    _registerPlan->varInfo.try_emplace(variableId, VarInfo(depth, registerId));
-  }
-
-  VPackSlice nrRegsList = slice.get("nrRegs");
-  if (!nrRegsList.isArray()) {
-    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
-                                   "\"nrRegs\" attribute needs to be an array");
-  }
-
-  _registerPlan->nrRegs.reserve(nrRegsList.length());
-  for (VPackSlice it : VPackArrayIterator(nrRegsList)) {
-    _registerPlan->nrRegs.emplace_back(it.getNumericValue<RegisterId>());
-  }
-
-  VPackSlice nrRegsHereList = slice.get("nrRegsHere");
-  if (!nrRegsHereList.isArray()) {
-    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_NOT_IMPLEMENTED,
-                                   "\"nrRegsHere\" needs to be an array");
-  }
-
-  _registerPlan->nrRegsHere.reserve(nrRegsHereList.length());
-  for (VPackSlice it : VPackArrayIterator(nrRegsHereList)) {
-    _registerPlan->nrRegsHere.emplace_back(it.getNumericValue<RegisterId>());
-  }
-
+      _isInSplicedSubquery(false),
+      _plan(plan) {
+  TRI_ASSERT(_registerPlan == nullptr);
+  _registerPlan = std::make_shared<RegisterPlan>(slice, _depth);
+  
   VPackSlice regsToClearList = slice.get("regsToClear");
   if (!regsToClearList.isArray()) {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_NOT_IMPLEMENTED,
@@ -539,10 +494,8 @@ void ExecutionNode::cloneWithoutRegisteringAndDependencies(ExecutionPlan& plan,
       other._varsValid.insert(var);
     }
 
-    if (_registerPlan.get() != nullptr) {
-      auto otherRegisterPlan =
-          std::shared_ptr<RegisterPlan>(_registerPlan->clone(&plan, _plan));
-      other._registerPlan = otherRegisterPlan;
+    if (_registerPlan != nullptr) {
+      other._registerPlan = _registerPlan->clone();
     }
   } else {
     // point to current AST -> don't do deep copies.
@@ -770,39 +723,9 @@ void ExecutionNode::toVelocyPackHelperGeneric(VPackBuilder& nodes, unsigned flag
     nodes.add("depth", VPackValue(_depth));
 
     if (_registerPlan) {
-      nodes.add(VPackValue("varInfoList"));
-      {
-        VPackArrayBuilder guard(&nodes);
-        for (auto const& oneVarInfo : _registerPlan->varInfo) {
-          VPackObjectBuilder guardInner(&nodes);
-          nodes.add("VariableId", VPackValue(oneVarInfo.first));
-          nodes.add("depth", VPackValue(oneVarInfo.second.depth));
-          nodes.add("RegisterId", VPackValue(oneVarInfo.second.registerId));
-        }
-      }
-      nodes.add(VPackValue("nrRegs"));
-      {
-        VPackArrayBuilder guard(&nodes);
-        for (auto const& oneRegisterID : _registerPlan->nrRegs) {
-          nodes.add(VPackValue(oneRegisterID));
-        }
-      }
-      nodes.add(VPackValue("nrRegsHere"));
-      {
-        VPackArrayBuilder guard(&nodes);
-        for (auto const& oneRegisterID : _registerPlan->nrRegsHere) {
-          nodes.add(VPackValue(oneRegisterID));
-        }
-      }
-      nodes.add("totalNrRegs", VPackValue(_registerPlan->totalNrRegs));
+      _registerPlan->toVelocyPack(nodes);
     } else {
-      nodes.add(VPackValue("varInfoList"));
-      { VPackArrayBuilder guard(&nodes); }
-      nodes.add(VPackValue("nrRegs"));
-      { VPackArrayBuilder guard(&nodes); }
-      nodes.add(VPackValue("nrRegsHere"));
-      { VPackArrayBuilder guard(&nodes); }
-      nodes.add("totalNrRegs", VPackValue(0));
+      RegisterPlan::toVelocyPackEmpty(nodes);
     }
 
     nodes.add(VPackValue("regsToClear"));
@@ -887,9 +810,9 @@ void ExecutionNode::planRegisters(ExecutionNode* super) {
   std::shared_ptr<RegisterPlan> v;
 
   if (super == nullptr) {
-    v.reset(new RegisterPlan());
+    v = std::make_shared<RegisterPlan>();
   } else {
-    v.reset(new RegisterPlan(*(super->_registerPlan), super->_depth));
+    v = std::make_shared<RegisterPlan>(*(super->_registerPlan), super->_depth);
   }
   v->setSharedPtr(&v);
 
@@ -1077,7 +1000,11 @@ RegisterId ExecutionNode::getNrOutputRegisters() const {
 }
 
 ExecutionNode::ExecutionNode(ExecutionPlan* plan, size_t id)
-    : _id(id), _depth(0), _varUsageValid(false), _plan(plan), _isInSplicedSubquery(false) {}
+    : _id(id), 
+      _depth(0), 
+      _varUsageValid(false), 
+      _isInSplicedSubquery(false),
+      _plan(plan) {} 
 
 size_t ExecutionNode::id() const { return _id; }
 
@@ -2100,9 +2027,7 @@ ExecutionNode* FilterNode::clone(ExecutionPlan* plan, bool withDependencies,
     inVariable = plan->getAst()->variables()->createVariable(inVariable);
   }
 
-  auto c = std::make_unique<FilterNode>(plan, _id, inVariable);
-
-  return cloneHelper(std::move(c), withDependencies, withProperties);
+  return cloneHelper(std::make_unique<FilterNode>(plan, _id, inVariable), withDependencies, withProperties);
 }
 
 /// @brief estimateCost

--- a/arangod/Aql/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode.h
@@ -493,6 +493,8 @@ class ExecutionNode {
 
   /// @brief whether or not _varsUsedLater and _varsValid are actually valid
   bool _varUsageValid;
+  
+  bool _isInSplicedSubquery;
 
   /// @brief _plan, the ExecutionPlan object
   ExecutionPlan* _plan;
@@ -504,8 +506,6 @@ class ExecutionNode {
   /// just before this node hands on results. This is computed during
   /// the static analysis for each node using the variable usage in the plan.
   std::unordered_set<RegisterId> _regsToClear;
-
-  bool _isInSplicedSubquery;
 
  public:
   /// @brief used as "type traits" for ExecutionNodes and derived classes

--- a/arangod/Aql/IResearchViewNode.h
+++ b/arangod/Aql/IResearchViewNode.h
@@ -40,6 +40,7 @@ namespace aql {
 struct Collection;
 class ExecutionBlock;
 class ExecutionEngine;
+struct RegisterPlan;
 struct VarInfo;
 }  // namespace aql
 
@@ -173,10 +174,7 @@ class IResearchViewNode final : public arangodb::aql::ExecutionNode {
   ///       sort condition
   std::pair<bool, bool> volatility(bool force = false) const;
 
-  void planNodeRegisters(std::vector<aql::RegisterId>& nrRegsHere,
-                         std::vector<aql::RegisterId>& nrRegs,
-                         std::unordered_map<aql::VariableId, aql::VarInfo>& varInfo,
-                         unsigned int& totalNrRegs, unsigned int depth) const;
+  void planNodeRegisters(aql::RegisterPlan& registerPlan) const;
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<aql::ExecutionBlock> createBlock(

--- a/arangod/Aql/IndexNode.cpp
+++ b/arangod/Aql/IndexNode.cpp
@@ -226,27 +226,15 @@ void IndexNode::initIndexCoversProjections() {
   _options.forceProjection = true;
 }
 
-void IndexNode::planNodeRegisters(
-    std::vector<aql::RegisterId>& nrRegsHere, std::vector<aql::RegisterId>& nrRegs,
-    std::unordered_map<aql::VariableId, aql::VarInfo>& varInfo,
-    unsigned int& totalNrRegs, unsigned int depth) const {
-  // create a copy of the last value here
-  // this is required because back returns a reference and emplace/push_back
-  // may invalidate all references
-  auto regsCount = nrRegs.back();
-  nrRegs.emplace_back(regsCount + 1);
-  nrRegsHere.emplace_back(1);
-
+void IndexNode::planNodeRegisters(RegisterPlan& registerPlan) const {
   if (isLateMaterialized()) {
-    varInfo.emplace(_outNonMaterializedDocId->id, aql::VarInfo(depth, totalNrRegs++));
+    registerPlan.registerVariable(_outNonMaterializedDocId);
     // plan registers for index references
     for (auto const& fieldVar : _outNonMaterializedIndVars.second) {
-      ++nrRegsHere[depth];
-      ++nrRegs[depth];
-      varInfo.emplace(fieldVar.second->id, aql::VarInfo(depth, totalNrRegs++));
+      registerPlan.registerVariable(fieldVar.second);
     }
   } else {
-    varInfo.emplace(_outVariable->id, aql::VarInfo(depth, totalNrRegs++));
+    registerPlan.registerVariable(_outVariable);
   }
 }
 

--- a/arangod/Aql/IndexNode.h
+++ b/arangod/Aql/IndexNode.h
@@ -46,6 +46,7 @@ class ExecutionBlock;
 class ExecutionEngine;
 class ExecutionPlan;
 class Expression;
+struct RegisterPlan;
 
 /// @brief struct to hold the member-indexes in the _condition node
 struct NonConstExpression {
@@ -117,10 +118,7 @@ class IndexNode : public ExecutionNode, public DocumentProducingNode, public Col
   /// the projection attributes (if any)
   void initIndexCoversProjections();
 
-  void planNodeRegisters(std::vector<aql::RegisterId>& nrRegsHere,
-                         std::vector<aql::RegisterId>& nrRegs,
-                         std::unordered_map<aql::VariableId, aql::VarInfo>& varInfo,
-                         unsigned int& totalNrRegs, unsigned int depth) const;
+  void planNodeRegisters(aql::RegisterPlan& registerPlan) const;
 
   bool isLateMaterialized() const noexcept {
     TRI_ASSERT((_outNonMaterializedDocId == nullptr && _outNonMaterializedIndVars.second.empty()) ||

--- a/arangod/Aql/OutputAqlItemRow.cpp
+++ b/arangod/Aql/OutputAqlItemRow.cpp
@@ -57,17 +57,17 @@ OutputAqlItemRow::OutputAqlItemRow(
       _baseIndex(0),
       _lastBaseIndex(0),
       _inputRowCopied(false),
-      _lastSourceRow{CreateInvalidInputRowHint{}},
-      _numValuesWritten(0),
-      _call(clientCall),
       _doNotCopyInputRow(copyRowBehavior == CopyRowBehavior::DoNotCopyInputRows),
-      _outputRegisters(std::move(outputRegisters)),
-      _registersToKeep(std::move(registersToKeep)),
-      _registersToClear(std::move(registersToClear)),
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
       _setBaseIndexNotUsed(true),
 #endif
-      _allowSourceRowUninitialized(false) {
+      _allowSourceRowUninitialized(false),
+      _lastSourceRow{CreateInvalidInputRowHint{}},
+      _numValuesWritten(0),
+      _call(clientCall),
+      _outputRegisters(std::move(outputRegisters)),
+      _registersToKeep(std::move(registersToKeep)),
+      _registersToClear(std::move(registersToClear)) {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if (_block != nullptr) {
     for (auto const& reg : *_outputRegisters) {

--- a/arangod/Aql/OutputAqlItemRow.h
+++ b/arangod/Aql/OutputAqlItemRow.h
@@ -251,6 +251,19 @@ class OutputAqlItemRow {
    * @brief Whether the input registers were copied from a source row.
    */
   bool _inputRowCopied;
+  
+  /**
+   * @brief Set if and only if the current ExecutionBlock passes the
+   * AqlItemBlocks through.
+   */
+  bool const _doNotCopyInputRow;
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  bool _setBaseIndexNotUsed;
+#endif
+  // Need this special bool for allowing an empty AqlValue inside the
+  // SortedCollectExecutor, CountCollectExecutor and ConstrainedSortExecutor.
+  bool _allowSourceRowUninitialized;
 
   /**
    * @brief The last source row seen. Note that this is invalid before the first
@@ -271,22 +284,9 @@ class OutputAqlItemRow {
    */
   AqlCall _call;
 
-  /**
-   * @brief Set if and only if the current ExecutionBlock passes the
-   * AqlItemBlocks through.
-   */
-  bool const _doNotCopyInputRow;
-
   std::shared_ptr<std::unordered_set<RegisterId> const> _outputRegisters;
   std::shared_ptr<std::unordered_set<RegisterId> const> _registersToKeep;
   std::shared_ptr<std::unordered_set<RegisterId> const> _registersToClear;
-
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-  bool _setBaseIndexNotUsed;
-#endif
-  // Need this special bool for allowing an empty AqlValue inside the
-  // SortedCollectExecutor, CountCollectExecutor and ConstrainedSortExecutor.
-  bool _allowSourceRowUninitialized;
 
  private:
   [[nodiscard]] size_t nextUnwrittenIndex() const noexcept {

--- a/arangod/Aql/RegisterPlan.cpp
+++ b/arangod/Aql/RegisterPlan.cpp
@@ -33,6 +33,11 @@
 #include "Aql/ModificationNodes.h"
 #include "Aql/SubqueryEndExecutionNode.h"
 
+#include <velocypack/Builder.h>
+#include <velocypack/Slice.h>
+#include <velocypack/Iterator.h>
+#include <velocypack/velocypack-aliases.h>
+
 using namespace arangodb;
 using namespace arangodb::aql;
 
@@ -41,11 +46,18 @@ VarInfo::VarInfo(int depth, RegisterId registerId)
     : depth(depth), registerId(registerId) {
   TRI_ASSERT(registerId < RegisterPlan::MaxRegisterId);
 }
+  
+RegisterPlan::RegisterPlan()
+    : depth(0), 
+      totalNrRegs(0), 
+      me(nullptr) {
+  nrRegs.reserve(8);
+  nrRegs.emplace_back(0);
+}
 
 // Copy constructor used for a subquery:
 RegisterPlan::RegisterPlan(RegisterPlan const& v, unsigned int newdepth)
     : varInfo(v.varInfo),
-      nrRegsHere(v.nrRegsHere),
       nrRegs(v.nrRegs),
       subQueryNodes(),
       depth(newdepth + 1),
@@ -53,11 +65,8 @@ RegisterPlan::RegisterPlan(RegisterPlan const& v, unsigned int newdepth)
       me(nullptr) {
   if (depth + 1 < 8) {
     // do a minium initial allocation to avoid frequent reallocations
-    nrRegsHere.reserve(8);
     nrRegs.reserve(8);
   }
-  nrRegsHere.resize(depth + 1);
-  nrRegsHere.back() = 0;
   // create a copy of the last value here
   // this is required because back returns a reference and emplace/push_back may
   // invalidate all references
@@ -66,19 +75,48 @@ RegisterPlan::RegisterPlan(RegisterPlan const& v, unsigned int newdepth)
   nrRegs.emplace_back(registerId);
 }
 
-void RegisterPlan::clear() {
-  varInfo.clear();
-  nrRegsHere.clear();
-  nrRegs.clear();
-  subQueryNodes.clear();
-  depth = 0;
-  totalNrRegs = 0;
+RegisterPlan::RegisterPlan(VPackSlice slice, unsigned int depth) 
+    : depth(depth),
+      totalNrRegs(slice.get("totalNrRegs").getNumericValue<unsigned int>()),
+      me(nullptr) {
+  
+  VPackSlice varInfoList = slice.get("varInfoList");
+  if (!varInfoList.isArray()) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_BAD_PARAMETER,
+        "\"varInfoList\" attribute needs to be an array");
+  }
+
+  varInfo.reserve(varInfoList.length());
+
+  for (VPackSlice it : VPackArrayIterator(varInfoList)) {
+    if (!it.isObject()) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_NOT_IMPLEMENTED,
+          "\"varInfoList\" item needs to be an object");
+    }
+    VariableId variableId = it.get("VariableId").getNumericValue<VariableId>();
+    RegisterId registerId = it.get("RegisterId").getNumericValue<RegisterId>();
+    unsigned int depth = it.get("depth").getNumericValue<unsigned int>();
+
+    varInfo.try_emplace(variableId, VarInfo(depth, registerId));
+  }
+
+  VPackSlice nrRegsList = slice.get("nrRegs");
+  if (!nrRegsList.isArray()) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
+                                   "\"nrRegs\" attribute needs to be an array");
+  }
+
+  nrRegs.reserve(nrRegsList.length());
+  for (VPackSlice it : VPackArrayIterator(nrRegsList)) {
+    nrRegs.emplace_back(it.getNumericValue<RegisterId>());
+  }
 }
 
-RegisterPlan* RegisterPlan::clone(ExecutionPlan* otherPlan, ExecutionPlan* plan) {
-  auto other = std::make_unique<RegisterPlan>();
+std::shared_ptr<RegisterPlan> RegisterPlan::clone() {
+  auto other = std::make_shared<RegisterPlan>();
 
-  other->nrRegsHere = nrRegsHere;
   other->nrRegs = nrRegs;
   other->depth = depth;
   other->totalNrRegs = totalNrRegs;
@@ -88,12 +126,11 @@ RegisterPlan* RegisterPlan::clone(ExecutionPlan* otherPlan, ExecutionPlan* plan)
   // No need to clone subQueryNodes because this was only used during
   // the buildup.
 
-  return other.release();
+  return other;
 }
 
 void RegisterPlan::increaseDepth() {
   depth++;
-  nrRegsHere.emplace_back(0);
   // create a copy of the last value here
   // this is required because back returns a reference and emplace/push_back
   // may invalidate all references
@@ -101,11 +138,61 @@ void RegisterPlan::increaseDepth() {
   nrRegs.emplace_back(registerId);
 }
 
-void RegisterPlan::registerVariable(Variable const* v) {
-  nrRegsHere[depth]++;
+void RegisterPlan::addRegister() {
   nrRegs[depth]++;
-  varInfo.try_emplace(v->id, VarInfo(depth, totalNrRegs));
   totalNrRegs++;
+}
+
+void RegisterPlan::registerVariable(Variable const* v) {
+  TRI_ASSERT(v != nullptr);
+
+  auto total = totalNrRegs;
+  addRegister();
+  varInfo.try_emplace(v->id, VarInfo(depth, total));
+}
+
+void RegisterPlan::toVelocyPackEmpty(VPackBuilder& builder) {
+  builder.add(VPackValue("varInfoList"));
+  { VPackArrayBuilder guard(&builder); }
+  builder.add(VPackValue("nrRegs"));
+  { VPackArrayBuilder guard(&builder); }
+  // nrRegsHere is not used anymore and is intentionally left empty
+  // can be removed in ArangoDB 3.8
+  builder.add(VPackValue("nrRegsHere"));
+  { VPackArrayBuilder guard(&builder); }
+  builder.add("totalNrRegs", VPackValue(0));
+}
+
+void RegisterPlan::toVelocyPack(VPackBuilder& builder) const {
+  TRI_ASSERT(builder.isOpenObject());
+      
+  builder.add(VPackValue("varInfoList"));
+  {
+    VPackArrayBuilder guard(&builder);
+    for (auto const& oneVarInfo : varInfo) {
+      VPackObjectBuilder guardInner(&builder);
+      builder.add("VariableId", VPackValue(oneVarInfo.first));
+      builder.add("depth", VPackValue(oneVarInfo.second.depth));
+      builder.add("RegisterId", VPackValue(oneVarInfo.second.registerId));
+    }
+  }
+
+  builder.add(VPackValue("nrRegs"));
+  {
+    VPackArrayBuilder guard(&builder);
+    for (auto const& oneRegisterID : nrRegs) {
+      builder.add(VPackValue(oneRegisterID));
+    }
+  }
+
+  // nrRegsHere is not used anymore and is intentionally left empty
+  // can be removed in ArangoDB 3.8
+  builder.add(VPackValue("nrRegsHere"));
+  {
+    VPackArrayBuilder guard(&builder);
+  }
+
+  builder.add("totalNrRegs", VPackValue(totalNrRegs));
 }
 
 void RegisterPlan::after(ExecutionNode* en) {
@@ -125,8 +212,9 @@ void RegisterPlan::after(ExecutionNode* en) {
     }
 
     case ExecutionNode::INDEX: {
+      increaseDepth();
       auto ep = ExecutionNode::castTo<IndexNode const*>(en);
-      ep->planNodeRegisters(nrRegsHere, nrRegs, varInfo, totalNrRegs, ++depth);
+      ep->planNodeRegisters(*this);
       break;
     }
 
@@ -178,13 +266,7 @@ void RegisterPlan::after(ExecutionNode* en) {
     case ExecutionNode::REPLACE:
     case ExecutionNode::REMOVE:
     case ExecutionNode::UPSERT: {
-      increaseDepth();
-
-      auto ep = dynamic_cast<ModificationNode const*>(en);
-      if (ep == nullptr) {
-        THROW_ARANGO_EXCEPTION_MESSAGE(
-            TRI_ERROR_INTERNAL, "unexpected cast result for ModificationNode");
-      }
+      auto ep = ExecutionNode::castTo<ModificationNode const*>(en);
       if (ep->getOutVariableOld() != nullptr) {
         registerVariable(ep->getOutVariableOld());
       }
@@ -244,8 +326,9 @@ void RegisterPlan::after(ExecutionNode* en) {
     }
 
     case ExecutionNode::ENUMERATE_IRESEARCH_VIEW: {
+      increaseDepth();
       auto ep = ExecutionNode::castTo<iresearch::IResearchViewNode const*>(en);
-      ep->planNodeRegisters(nrRegsHere, nrRegs, varInfo, totalNrRegs, ++depth);
+      ep->planNodeRegisters(*this);
       break;
     }
 
@@ -278,7 +361,7 @@ void RegisterPlan::after(ExecutionNode* en) {
   // Now find out which registers ought to be erased after this node:
   if (en->getType() != ExecutionNode::RETURN) {
     // ReturnNodes are special, since they return a single column anyway
-    ::arangodb::containers::HashSet<Variable const*> varsUsedLater =
+    ::arangodb::containers::HashSet<Variable const*> const& varsUsedLater =
         en->getVarsUsedLater();
     ::arangodb::containers::HashSet<Variable const*> varsUsedHere;
     en->getVariablesUsedHere(varsUsedHere);

--- a/arangod/Aql/RegisterPlan.h
+++ b/arangod/Aql/RegisterPlan.h
@@ -31,6 +31,15 @@
 #include "Basics/Common.h"
 
 #include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace arangodb {
+namespace velocypack {
+class Builder;
+class Slice;
+}
+}
 
 namespace arangodb::aql {
 
@@ -54,9 +63,6 @@ struct RegisterPlan final : public WalkerWorker<ExecutionNode> {
   // map VariableIds to their depth and registerId:
   std::unordered_map<VariableId, VarInfo> varInfo;
 
-  // number of variables in the frame of the current depth:
-  std::vector<RegisterId> nrRegsHere;
-
   // number of variables in this and all outer frames together,
   // the entry with index i here is always the sum of all values
   // in nrRegsHere from index 0 to i (inclusively) and the two
@@ -66,35 +72,35 @@ struct RegisterPlan final : public WalkerWorker<ExecutionNode> {
   // We collect the subquery nodes to deal with them at the end:
   std::vector<ExecutionNode*> subQueryNodes;
 
+ private:
   // Local for the walk:
   unsigned int depth;
+  
   unsigned int totalNrRegs;
 
- private:
   // This is used to tell all nodes and share a pointer to ourselves
   std::shared_ptr<RegisterPlan>* me;
 
  public:
-  RegisterPlan() : depth(0), totalNrRegs(0), me(nullptr) {
-    nrRegsHere.reserve(8);
-    nrRegsHere.emplace_back(0);
-    nrRegs.reserve(8);
-    nrRegs.emplace_back(0);
-  }
-  
+  RegisterPlan();
+  RegisterPlan(arangodb::velocypack::Slice slice, unsigned int depth);
   // Copy constructor used for a subquery:
   RegisterPlan(RegisterPlan const& v, unsigned int newdepth);
   ~RegisterPlan() = default;
   
   void setSharedPtr(std::shared_ptr<RegisterPlan>* shared) { me = shared; }
 
-  void clear();
-  
-  RegisterPlan* clone(ExecutionPlan* otherPlan, ExecutionPlan* plan);
+  std::shared_ptr<RegisterPlan> clone();
 
   void registerVariable(Variable const* v);
   
   void increaseDepth();
+  
+  void addRegister();
+
+  void toVelocyPack(arangodb::velocypack::Builder& builder) const;
+  
+  static void toVelocyPackEmpty(arangodb::velocypack::Builder& builder);
 
   virtual bool enterSubquery(ExecutionNode*, ExecutionNode*) override final {
     return false;  // do not walk into subquery

--- a/tests/IResearch/IResearchViewNode-test.cpp
+++ b/tests/IResearch/IResearchViewNode-test.cpp
@@ -46,6 +46,7 @@
 #include "Aql/NoResultsExecutor.h"
 #include "Aql/OptimizerRulesFeature.h"
 #include "Aql/Query.h"
+#include "Aql/RegisterPlan.h"
 #include "Aql/SingleRowFetcher.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Cluster/ClusterFeature.h"
@@ -2722,20 +2723,18 @@ TEST_F(IResearchViewNodeTest, registerPlanningLateMaterialized) {
                                               {});        // no sort condition
   node.addDependency(&singleton);
   node.setLateMaterialized(outNmColPtr, outNmDocId);
-  std::vector<arangodb::aql::RegisterId> nrRegsHere{ 0 };
-  std::vector<arangodb::aql::RegisterId> nrRegs{ 0 };
-  std::unordered_map<arangodb::aql::VariableId, arangodb::aql::VarInfo> varInfo;
-  unsigned int totalNrRegs = 0;
-  node.planNodeRegisters(nrRegsHere, nrRegs, varInfo, totalNrRegs, 1);
-  EXPECT_EQ(2, totalNrRegs);
-  EXPECT_EQ(2, nrRegs.size());
-  EXPECT_EQ(2, nrRegs[1]);
-  EXPECT_EQ(2, nrRegsHere.size());
-  EXPECT_EQ(2, nrRegsHere[1]);
-  EXPECT_EQ(2, varInfo.size());
-  EXPECT_NE(varInfo.end(), varInfo.find(outNmColPtr.id));
-  EXPECT_NE(varInfo.end(), varInfo.find(outNmDocId.id));
-  EXPECT_EQ(varInfo.end(), varInfo.find(outVariable.id));
+
+  arangodb::aql::RegisterPlan registerPlan;
+  EXPECT_EQ(1, registerPlan.nrRegs.size());
+  registerPlan.increaseDepth();
+  EXPECT_EQ(2, registerPlan.nrRegs.size());
+  node.planNodeRegisters(registerPlan);
+  EXPECT_EQ(2, registerPlan.nrRegs.size());
+  EXPECT_EQ(2, registerPlan.nrRegs[1]);
+  EXPECT_EQ(2, registerPlan.varInfo.size());
+  EXPECT_NE(registerPlan.varInfo.end(), registerPlan.varInfo.find(outNmColPtr.id));
+  EXPECT_NE(registerPlan.varInfo.end(), registerPlan.varInfo.find(outNmDocId.id));
+  EXPECT_EQ(registerPlan.varInfo.end(), registerPlan.varInfo.find(outVariable.id));
 }
 
 TEST_F(IResearchViewNodeTest, registerPlanningLateMaterializedWitScore) {
@@ -2744,7 +2743,7 @@ TEST_F(IResearchViewNodeTest, registerPlanningLateMaterializedWitScore) {
   auto createJson = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
   auto logicalView = vocbase.createView(createJson->slice());
-  ASSERT_TRUE((false == !logicalView));
+  ASSERT_NE(logicalView, nullptr);
 
   // dummy query
   arangodb::aql::Query query(false, vocbase, arangodb::aql::QueryString("RETURN 1"),
@@ -2772,21 +2771,17 @@ TEST_F(IResearchViewNodeTest, registerPlanningLateMaterializedWitScore) {
                                               std::vector<arangodb::iresearch::Scorer>{ {&scoreVariable, nullptr} });   //sort condition
   node.addDependency(&singleton);
   node.setLateMaterialized(outNmColPtr, outNmDocId);
-  std::vector<arangodb::aql::RegisterId> nrRegsHere{ 0 };
-  std::vector<arangodb::aql::RegisterId> nrRegs{ 0 };
-  std::unordered_map<arangodb::aql::VariableId, arangodb::aql::VarInfo> varInfo;
-  unsigned int totalNrRegs = 0;
-  node.planNodeRegisters(nrRegsHere, nrRegs, varInfo, totalNrRegs, 1);
-  EXPECT_EQ(3, totalNrRegs);
-  EXPECT_EQ(2, nrRegs.size());
-  EXPECT_EQ(3, nrRegs[1]);
-  EXPECT_EQ(2, nrRegsHere.size());
-  EXPECT_EQ(3, nrRegsHere[1]);
-  EXPECT_EQ(3, varInfo.size());
-  EXPECT_NE(varInfo.end(), varInfo.find(outNmColPtr.id));
-  EXPECT_NE(varInfo.end(), varInfo.find(outNmDocId.id));
-  EXPECT_EQ(varInfo.end(), varInfo.find(outVariable.id));
-  EXPECT_NE(varInfo.end(), varInfo.find(scoreVariable.id));
+  
+  arangodb::aql::RegisterPlan registerPlan;
+  registerPlan.increaseDepth();
+  node.planNodeRegisters(registerPlan);
+  EXPECT_EQ(2, registerPlan.nrRegs.size());
+  EXPECT_EQ(3, registerPlan.nrRegs[1]);
+  EXPECT_EQ(3, registerPlan.varInfo.size());
+  EXPECT_NE(registerPlan.varInfo.end(), registerPlan.varInfo.find(outNmColPtr.id));
+  EXPECT_NE(registerPlan.varInfo.end(), registerPlan.varInfo.find(outNmDocId.id));
+  EXPECT_EQ(registerPlan.varInfo.end(), registerPlan.varInfo.find(outVariable.id));
+  EXPECT_NE(registerPlan.varInfo.end(), registerPlan.varInfo.find(scoreVariable.id));
 }
 
 TEST_F(IResearchViewNodeTest, registerPlanning) {
@@ -2819,18 +2814,14 @@ TEST_F(IResearchViewNodeTest, registerPlanning) {
                                               nullptr,  // no options
                                               {});        // no sort condition
   node.addDependency(&singleton);
-  std::vector<arangodb::aql::RegisterId> nrRegsHere{ 0 };
-  std::vector<arangodb::aql::RegisterId> nrRegs{ 0 };
-  std::unordered_map<arangodb::aql::VariableId, arangodb::aql::VarInfo> varInfo;
-  unsigned int totalNrRegs = 0;
-  node.planNodeRegisters(nrRegsHere, nrRegs, varInfo, totalNrRegs, 1);
-  EXPECT_EQ(1, totalNrRegs);
-  EXPECT_EQ(2, nrRegs.size());
-  EXPECT_EQ(1, nrRegs[1]);
-  EXPECT_EQ(2, nrRegsHere.size());
-  EXPECT_EQ(1, nrRegsHere[1]);
-  EXPECT_EQ(1, varInfo.size());
-  EXPECT_NE(varInfo.end(), varInfo.find(outVariable.id));
+  
+  arangodb::aql::RegisterPlan registerPlan;
+  registerPlan.increaseDepth();
+  node.planNodeRegisters(registerPlan);
+  EXPECT_EQ(2, registerPlan.nrRegs.size());
+  EXPECT_EQ(1, registerPlan.nrRegs[1]);
+  EXPECT_EQ(1, registerPlan.varInfo.size());
+  EXPECT_NE(registerPlan.varInfo.end(), registerPlan.varInfo.find(outVariable.id));
 }
 
 TEST_F(IResearchViewNodeTest, registerPlanningWithScore) {
@@ -2864,19 +2855,15 @@ TEST_F(IResearchViewNodeTest, registerPlanningWithScore) {
                                               nullptr,  // no options
                                               std::vector<arangodb::iresearch::Scorer>{ {&scoreVariable, nullptr} });        //sort condition
   node.addDependency(&singleton);
-  std::vector<arangodb::aql::RegisterId> nrRegsHere{ 0 };
-  std::vector<arangodb::aql::RegisterId> nrRegs{ 0 };
-  std::unordered_map<arangodb::aql::VariableId, arangodb::aql::VarInfo> varInfo;
-  unsigned int totalNrRegs = 0;
-  node.planNodeRegisters(nrRegsHere, nrRegs, varInfo, totalNrRegs, 1);
-  EXPECT_EQ(2, totalNrRegs);
-  EXPECT_EQ(2, nrRegs.size());
-  EXPECT_EQ(2, nrRegs[1]);
-  EXPECT_EQ(2, nrRegsHere.size());
-  EXPECT_EQ(2, nrRegsHere[1]);
-  EXPECT_EQ(2, varInfo.size());
-  EXPECT_NE(varInfo.end(), varInfo.find(outVariable.id));
-  EXPECT_NE(varInfo.end(), varInfo.find(scoreVariable.id));
+  
+  arangodb::aql::RegisterPlan registerPlan;
+  registerPlan.increaseDepth();
+  node.planNodeRegisters(registerPlan);
+  EXPECT_EQ(2, registerPlan.nrRegs.size());
+  EXPECT_EQ(2, registerPlan.nrRegs[1]);
+  EXPECT_EQ(2, registerPlan.varInfo.size());
+  EXPECT_NE(registerPlan.varInfo.end(), registerPlan.varInfo.find(outVariable.id));
+  EXPECT_NE(registerPlan.varInfo.end(), registerPlan.varInfo.find(scoreVariable.id));
 }
 
 class IResearchViewBlockTest


### PR DESCRIPTION
### Scope & Purpose

Simplify register planning code a bit.
Keeps the inefficient and partially unused parameters in the Executor interfaces due to @goedderz request. Thus obsoletes https://github.com/arangodb/arangodb/pull/11336

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest catch, scripts/unittest shell_server_aql*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9313/