### PR TITLE
Bug fix/debug rocksdb mapping error

### DIFF
--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -1584,7 +1584,7 @@ void RocksDBEngine::addCollectionMapping(uint64_t objectId, TRI_voc_tick_t did,
         LOG_TOPIC("80e81", ERR, Logger::FIXME) 
             << "trying to add objectId: " << objectId << ", did: " << did << ", cid: " << cid 
             << ", found in map: did: " << it->second.first << ", cid: " << it->second.second
-            << ", map contains " << collectionMap.size() << " entries";
+            << ", map contains " << _collectionMap.size() << " entries";
         for (auto const& it : _collectionMap) {
           LOG_TOPIC("77de9", ERR, Logger::FIXME) 
               << "- objectId: " << it.first << " => (did: " << it.second.first << ", cid: " << it.second.second << ")";

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -1580,6 +1580,16 @@ void RocksDBEngine::addCollectionMapping(uint64_t objectId, TRI_voc_tick_t did,
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     auto it = _collectionMap.find(objectId);
     if (it != _collectionMap.end()) {
+      if (it->second.first != did || it->second.second != cid) {
+        LOG_TOPIC("80e81", ERR, Logger::FIXME) 
+            << "trying to add objectId: " << objectId << ", did: " << did << ", cid: " << cid 
+            << ", found in map: did: " << it->second.first << ", cid: " << it->second.second
+            << ", map contains " << collectionMap.size() << " entries";
+        for (auto const& it : _collectionMap) {
+          LOG_TOPIC("77de9", ERR, Logger::FIXME) 
+              << "- objectId: " << it.first << " => (did: " << it.second.first << ", cid: " << it.second.second << ")";
+        }
+      }
       TRI_ASSERT(it->second.first == did);
       TRI_ASSERT(it->second.second == cid);
     }


### PR DESCRIPTION
### Scope & Purpose

Add error output (in maintainer mode only) when some certain assertions fails.
This prints the collections map of the RocksDB storage engine in case a collection is reinserted into it but the slot is already used for a different collection.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9314/