### PR TITLE
don't perform unnecessary document lookups in incremental sync

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,16 +2,16 @@ v3.6.3 (XXXX-XX-XX)
 -------------------
 
 * Avoid some unnecessary internal calls to the storage engine during the
-  incremental sync protocol for the RocksDB storage engine. This change can 
-  help reduce the I/O load on the follower during incremental sync for the
-  RocksDB storage engine.
+  incremental sync protocol for the RocksDB storage engine. This change can help
+  reduce the I/O load on the follower during incremental sync for the RocksDB
+  storage engine.
 
 * Fixed internal issue ES-544: Instantiation of AQL queries with graph
   traversals in a OneShard setting failed with 'direction can only be INBOUND,
   OUTBOUND or ANY'.
 
-* Fixed a rare race condition in SmartGraphs where the graph is unbalanced, but a
-  successful result could be found by only on database server, where the other
+* Fixed a rare race condition in SmartGraphs where the graph is unbalanced, but
+  a successful result could be found by only on database server, where the other
   server is still searching. In this race the query could continue on the other
   server and hit a non-thread save object.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,16 @@
 v3.6.3 (XXXX-XX-XX)
 -------------------
 
+* Avoid some unnecessary internal calls to the storage engine during the
+  incremental sync protocol for the RocksDB storage engine. This change can 
+  help reduce the I/O load on the follower during incremental sync for the
+  RocksDB storage engine.
+
 * Fixed internal issue ES-544: Instantiation of AQL queries with graph
   traversals in a OneShard setting failed with 'direction can only be INBOUND,
   OUTBOUND or ANY'.
 
-* Fixed a rare race condition in SmartGraphs where the graph is unblanced, but a
+* Fixed a rare race condition in SmartGraphs where the graph is unbalanced, but a
   successful result could be found by only on database server, where the other
   server is still searching. In this race the query could continue on the other
   server and hit a non-thread save object.

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -721,13 +721,8 @@ bool RocksDBCollection::lookupRevision(transaction::Methods* trx, VPackSlice con
   // document found, but revisionId may not have been present in the primary
   // index. this can happen for "older" collections
   TRI_ASSERT(documentId.isSet());
-
-  // now look up the revision id in the actual document data
-
-  return readDocumentWithCallback(trx, documentId, [&revisionId](LocalDocumentId const&, VPackSlice doc) {
-    revisionId = transaction::helpers::extractRevFromDocument(doc);
-    return true;
-  });
+  TRI_ASSERT(revisionId != 0);
+  return true;
 }
 
 Result RocksDBCollection::read(transaction::Methods* trx,


### PR DESCRIPTION
### Scope & Purpose

Don't perform unnecessary document lookups on the follower during the incremental sync protocol when the RocksDB storage engine is used.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *replication_sync*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9331/