### PR TITLE
fixed iresearch analyzer NOT OR FALSE

### DIFF
--- a/3rdParty/iresearch/core/search/boolean_filter.cpp
+++ b/3rdParty/iresearch/core/search/boolean_filter.cpp
@@ -384,7 +384,7 @@ filter::prepared::ptr boolean_filter::prepare(
   std::vector<const filter*> excl;
 
   group_filters(incl, excl);
-  optimize(incl, excl, boost);
+  remove_excess(incl, excl, boost);
 
   all all_docs;
   if (incl.empty() && !excl.empty()) {
@@ -449,7 +449,7 @@ And::And() NOEXCEPT
   : boolean_filter(And::type()) {
 }
 
-void And::optimize(
+void And::remove_excess(
     std::vector<const filter*>& incl,
     std::vector<const filter*>& /*excl*/,
     boost_t& boost) const {
@@ -478,6 +478,26 @@ void And::optimize(
   });
 
   // remove found `all` filters
+  incl.erase(it, incl.end());
+}
+
+void Or::remove_excess(
+    std::vector<const filter*>& incl,
+    std::vector<const filter*>& /*excl*/,
+    boost_t& /*boost*/) const {
+  if (incl.empty()) {
+    // nothing to do
+    return;
+  }
+
+  // find `empty` filters
+  auto it = std::remove_if(
+    incl.begin(), incl.end(),
+    [](const irs::filter* filter) {
+      return irs::empty::type() == filter->type();
+  });
+
+  // remove found `empty` filters
   incl.erase(it, incl.end());
 }
 

--- a/3rdParty/iresearch/core/search/boolean_filter.hpp
+++ b/3rdParty/iresearch/core/search/boolean_filter.hpp
@@ -74,7 +74,7 @@ class IRESEARCH_API boolean_filter : public filter, private util::noncopyable {
   boolean_filter(const type_id& type) NOEXCEPT;
   virtual bool equals(const filter& rhs) const NOEXCEPT override;
 
-  virtual void optimize(
+  virtual void remove_excess(
       std::vector<const filter*>& /*incl*/,
       std::vector<const filter*>& /*excl*/,
       boost_t& /*boost*/) const {
@@ -114,7 +114,7 @@ class IRESEARCH_API And: public boolean_filter {
   using filter::prepare;
 
  protected:
-  virtual void optimize(
+  virtual void remove_excess(
     std::vector<const filter*>& incl,
     std::vector<const filter*>& excl,
     boost_t& boost
@@ -156,6 +156,12 @@ class IRESEARCH_API Or : public boolean_filter {
   }
 
  protected:
+  virtual void remove_excess(
+    std::vector<const filter*>& incl,
+    std::vector<const filter*>& excl,
+    boost_t& boost
+  ) const override;
+
   virtual filter::prepared::ptr prepare(
     const std::vector<const filter*>& incl,
     const std::vector<const filter*>& excl,

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.6.3 (XXXX-XX-XX)
 -------------------
 
+* Fixed issue #11104: `ANALYZER` function doesn't correctly process `!= OR`
+  queries.
+
 * Fixed internal issue ES-544: Instantiation of AQL queries with graph
   traversals in a OneShard setting failed with 'direction can only be INBOUND,
   OUTBOUND or ANY'.

--- a/tests/js/common/aql/aql-view-arangosearch-cluster.inc
+++ b/tests/js/common/aql/aql-view-arangosearch-cluster.inc
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global assertUndefined, assertEqual, assertTrue, assertFalse*/
+/*global assertUndefined, assertEqual, assertNotEqual, assertTrue, assertFalse*/
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief tests for iresearch usage
@@ -1609,6 +1609,11 @@
           db._dropView(queryOptView);
         }
       },
+
+      testAnalyzerNotOrFalse : function () {
+        var result = db._query("FOR doc IN UnitTestsView SEARCH ANALYZER(doc.a != 'foo' OR FALSE, 'identity') OPTIONS { waitForSync : true } RETURN doc").toArray();
+        assertNotEqual(0, result.length);
+      }
     };
   };
 }());

--- a/tests/js/common/aql/aql-view-arangosearch-noncluster.js
+++ b/tests/js/common/aql/aql-view-arangosearch-noncluster.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global assertUndefined, assertEqual, assertTrue, assertFalse*/
+/*global assertUndefined, assertEqual, assertNotEqual, assertTrue, assertFalse*/
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief tests for iresearch usage
@@ -1655,6 +1655,11 @@ function iResearchAqlTestSuite () {
         db._dropView(queryOptView);
       }
     },
+
+    testAnalyzerNotOrFalse : function () {
+      var result = db._query("FOR doc IN UnitTestsView SEARCH ANALYZER(doc.a != 'foo' OR FALSE, 'identity') OPTIONS { waitForSync : true } RETURN doc").toArray();
+      assertNotEqual(0, result.length);
+    }
   };
 }
 


### PR DESCRIPTION
fixed https://github.com/arangodb/arangodb/issues/11104

FOR s IN `v-site`
    SEARCH ANALYZER(s.attributes.country.value != "w" OR false, "identity")
    RETURN s.attributes.country.value

Empty result.

http://jenkins01.arangodb.biz:8080/job/arangodb-matrix-pr/9332/