### PR TITLE
fixed iresearch analyzer NOT OR FALSE

### DIFF
--- a/3rdParty/iresearch/core/search/boolean_filter.hpp
+++ b/3rdParty/iresearch/core/search/boolean_filter.hpp
@@ -74,7 +74,7 @@ class IRESEARCH_API boolean_filter : public filter, private util::noncopyable {
   boolean_filter(const type_id& type) NOEXCEPT;
   virtual bool equals(const filter& rhs) const NOEXCEPT override;
 
-  virtual void optimize(
+  virtual void remove_excess(
       std::vector<const filter*>& /*incl*/,
       std::vector<const filter*>& /*excl*/,
       irs::boost::boost_t& /*boost*/) const {
@@ -114,7 +114,7 @@ class IRESEARCH_API And: public boolean_filter {
   using filter::prepare;
 
  protected:
-  virtual void optimize(
+  virtual void remove_excess(
     std::vector<const filter*>& incl,
     std::vector<const filter*>& excl,
     irs::boost::boost_t& boost
@@ -156,6 +156,12 @@ class IRESEARCH_API Or : public boolean_filter {
   }
 
  protected:
+  virtual void remove_excess(
+    std::vector<const filter*>& incl,
+    std::vector<const filter*>& excl,
+    boost_t& boost
+  ) const override;
+
   virtual filter::prepared::ptr prepare(
     const std::vector<const filter*>& incl,
     const std::vector<const filter*>& excl,

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.4.10 (XXXX-XX-XX)
 --------------------
 
+* Fixed issue #11104: `ANALYZER` function doesn't correctly process `!= OR`
+  queries.
+
 * Honor `cacheEnabled` attribute when updating the properties of a collection
   in case of the cluster. Previously, this attribute was ignored in the cluster,
   but it shouldn't have been.

--- a/tests/js/common/aql/aql-view-arangosearch-cluster.js
+++ b/tests/js/common/aql/aql-view-arangosearch-cluster.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global assertUndefined, assertEqual, assertTrue, assertFalse, fail*/
+/*global assertUndefined, assertEqual, assertNotEqual, assertTrue, assertFalse, fail*/
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief tests for iresearch usage
@@ -1089,6 +1089,11 @@ function IResearchAqlTestSuite(args) {
 
       docs.forEach(function(element, i) { assertEqual(res[i].length, 1); });
     },
+
+    testAnalyzerNotOrFalse : function () {
+      var result = db._query("FOR doc IN UnitTestsView SEARCH ANALYZER(doc.a != 'foo' OR FALSE, 'identity') OPTIONS { waitForSync : true } RETURN doc").toArray();
+      assertNotEqual(0, result.length);
+    }
   };
 }
 

--- a/tests/js/common/aql/aql-view-arangosearch-noncluster.js
+++ b/tests/js/common/aql/aql-view-arangosearch-noncluster.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global assertUndefined, assertEqual, assertTrue, assertFalse, fail*/
+/*global assertUndefined, assertEqual, assertNotEqual, assertTrue, assertFalse, fail*/
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief tests for iresearch usage
@@ -1116,6 +1116,10 @@ function iResearchAqlTestSuite () {
       docs.forEach(function(element, i) { assertEqual(res[i].length, 1); });
     },
 
+    testAnalyzerNotOrFalse : function () {
+      var result = db._query("FOR doc IN UnitTestsView SEARCH ANALYZER(doc.a != 'foo' OR FALSE, 'identity') OPTIONS { waitForSync : true } RETURN doc").toArray();
+      assertNotEqual(0, result.length);
+    }
   };
 }
 


### PR DESCRIPTION
fixed #11104

FOR s IN v-site
SEARCH ANALYZER(s.attributes.country.value != "w" OR false, "identity")
RETURN s.attributes.country.value

Empty result.

http://jenkins01.arangodb.biz:8080/job/arangodb-matrix-pr/9335/