### PR TITLE
don't run compact after collection truncation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,14 +5,15 @@ v3.5.5 (XXXX-XX-XX)
   operation on a RocksDB storage engine collection via the REST API's truncate
   endpoint.
 
-  The compaction was previously done to make RocksDB physically free data of 
-  key ranges that were supposed to be empty after the truncate, but it seems 
-  that the used version of RocksDB is struggling to achieve that goal. Although 
-  it does compact the ranges, it seems to read a lot of extra data from unrelated 
-  ranges as well, which blows up the overall time required to do the compactions. 
-  Most recent versions of RocksDB do not seem to have this problem anymore. 
+  The compaction was previously done to make RocksDB physically free data of key
+  ranges that were supposed to be empty after the truncate, but it seems that
+  the used version of RocksDB is struggling to achieve that goal. Although it
+  does compact the ranges, it seems to read a lot of extra data from unrelated
+  ranges as well, which blows up the overall time required to do the
+  compactions.
+  Most recent versions of RocksDB do not seem to have this problem anymore.
   But without upgrading RocksDB to the latest version the most sensible fix is
-  to turn off the manual compaction and rely on RocksDB eventually freeing the 
+  to turn off the manual compaction and rely on RocksDB eventually freeing the
   key ranges that are empty after a truncate.
 
 * Fixed issue #11275: indexes backward compatibility broken in 3.5+.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,20 @@
 v3.5.5 (XXXX-XX-XX)
 -------------------
 
+* Don't invoke collection key ranges compaction after performing a truncate
+  operation on a RocksDB storage engine collection via the REST API's truncate
+  endpoint.
+
+  The compaction was previously done to make RocksDB physically free data of 
+  key ranges that were supposed to be empty after the truncate, but it seems 
+  that the used version of RocksDB is struggling to achieve that goal. Although 
+  it does compact the ranges, it seems to read a lot of extra data from unrelated 
+  ranges as well, which blows up the overall time required to do the compactions. 
+  Most recent versions of RocksDB do not seem to have this problem anymore. 
+  But without upgrading RocksDB to the latest version the most sensible fix is
+  to turn off the manual compaction and rely on RocksDB eventually freeing the 
+  key ranges that are empty after a truncate.
+
 * Fixed issue #11275: indexes backward compatibility broken in 3.5+.
 
 * Fix an endless loop in FollowerInfo::persistInAgency which could trigger a

--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -441,11 +441,17 @@ void RestCollectionHandler::handleCommandPut() {
               res = trx->finish(result.result);
             }
           }
-          // wait for the transaction to finish first. only after that compact the
-          // data range(s) for the collection
-          // we shouldn't run compact() as part of the transaction, because the compact
-          // will be useless inside due to the snapshot the transaction has taken
-          coll->compact();
+
+          // note that previously we ran a compaction of the collection's key range
+          // and the collection's indexes key ranges directly after the truncate.
+          // this was done to make RocksDB physically free data of unused key ranges,
+          // but it seems that the used version of RocksDB is struggling to achieve
+          // that goal. although it does compact the range, it seems to read a lot
+          // of extra data from unrelated ranges as well, which blows up the overall
+          // time required to do the compactions. most recent versions of RocksDB
+          // do not seem to have this problem anymore. but for now, in this ArangoDb
+          // version we turn off the manual compaction and rely on RocksDB eventually
+          // freeing the now-unsed ranges.
 
           if (res.ok()) {
             if (ServerState::instance()->isCoordinator()) {  // ClusterInfo::loadPlan eventually


### PR DESCRIPTION
### Scope & Purpose

Don't invoke collection key ranges compaction after performing a truncate operation on a RocksDB storage engine collection via the REST API's truncate endpoint.

The compaction was previously done to make RocksDB physically free data of key ranges that were supposed to be empty after the truncate, but it seems that the used version of RocksDB is struggling to achieve that goal. Although it does compact the ranges, it seems to read a lot of extra data from unrelated ranges as well, which blows up the overall time required to do the compactions. 

Most recent versions of RocksDB do not seem to have this problem anymore. But without upgrading RocksDB to the latest version the most sensible fix is to turn off the manual compaction and rely on RocksDB eventually freeing the key ranges that are empty after a truncate.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is a *JIRA Ticket number* (In case a customer was affected / involved): https://arangodb.atlassian.net/browse/ES-531

### Testing & Verification

This change is already covered by existing tests, such as *shell_client, http_server*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9337/