### PR TITLE
delete obsolete stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,6 @@ out/
 
 etc/arangodb/*.conf
 
-Installation/epm/arangodb.sublist
 Installation/MacOSX/Bundle/Info.plist
 
 nbproject/

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,1 +1,0 @@
-make gitjslint


### PR DESCRIPTION
### Scope & Purpose

Delete obsolete `.hooks` directory with obsolete command
Delete line from `.gitignore` that points to non-existing directory

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9365/