### PR TITLE
reduce space waste

### DIFF
--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -155,11 +155,11 @@ LogicalCollection::LogicalCollection(TRI_vocbase_t& vocbase, VPackSlice const& i
       _isSmart(Helper::getBooleanValue(info, StaticStrings::IsSmart, false)),
       _isSmartChild(Helper::getBooleanValue(info, StaticStrings::IsSmartChild, false)),
 #endif
-      _usesRevisionsAsDocumentIds(
-          Helper::getBooleanValue(info, StaticStrings::UsesRevisionsAsDocumentIds, false)),
       _waitForSync(Helper::getBooleanValue(info, StaticStrings::WaitForSyncString, false)),
       _allowUserKeys(Helper::getBooleanValue(info, "allowUserKeys", true)),
       _syncByRevision(determineSyncByRevision()),
+      _usesRevisionsAsDocumentIds(
+          Helper::getBooleanValue(info, StaticStrings::UsesRevisionsAsDocumentIds, false)),
       _minRevision((system() || isSmartChild())
                        ? 0
                        : Helper::getNumericValue<TRI_voc_rid_t>(info, StaticStrings::MinRevision,

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -157,9 +157,9 @@ LogicalCollection::LogicalCollection(TRI_vocbase_t& vocbase, VPackSlice const& i
 #endif
       _waitForSync(Helper::getBooleanValue(info, StaticStrings::WaitForSyncString, false)),
       _allowUserKeys(Helper::getBooleanValue(info, "allowUserKeys", true)),
-      _syncByRevision(determineSyncByRevision()),
       _usesRevisionsAsDocumentIds(
           Helper::getBooleanValue(info, StaticStrings::UsesRevisionsAsDocumentIds, false)),
+      _syncByRevision(determineSyncByRevision()),
       _minRevision((system() || isSmartChild())
                        ? 0
                        : Helper::getNumericValue<TRI_voc_rid_t>(info, StaticStrings::MinRevision,

--- a/arangod/VocBase/LogicalCollection.h
+++ b/arangod/VocBase/LogicalCollection.h
@@ -379,9 +379,9 @@ class LogicalCollection : public LogicalDataSource {
 
   bool const _allowUserKeys;
 
-  std::atomic<bool> _syncByRevision;
-  
   std::atomic<bool> _usesRevisionsAsDocumentIds;
+  
+  std::atomic<bool> _syncByRevision;
 
   TRI_voc_rid_t const _minRevision;
 

--- a/arangod/VocBase/LogicalCollection.h
+++ b/arangod/VocBase/LogicalCollection.h
@@ -374,14 +374,14 @@ class LogicalCollection : public LogicalDataSource {
   bool const _isSmartChild;
 #endif
 
-  std::atomic<bool> _usesRevisionsAsDocumentIds;
-
   // SECTION: Properties
   bool _waitForSync;
 
   bool const _allowUserKeys;
 
   std::atomic<bool> _syncByRevision;
+  
+  std::atomic<bool> _usesRevisionsAsDocumentIds;
 
   TRI_voc_rid_t const _minRevision;
 


### PR DESCRIPTION
### Scope & Purpose

Move std::atomic<bool> out of a sequence of non-atomic bools to class layout space waste.
Moving the atomics close together should be fine because they are written to just once or twice during the lifetime of the server.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

Test plan: must compile without warnings

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9390/