### PR TITLE
Use fixed-length encoding for revisions.

### DIFF
--- a/lib/Basics/HybridLogicalClock.h
+++ b/lib/Basics/HybridLogicalClock.h
@@ -107,7 +107,7 @@ class HybridLogicalClock {
   static std::string encodeTimeStamp(uint64_t t) {
     std::string r(11, '\x00');
     size_t pos = 11;
-    while (t > 0) {
+    while (pos > 0) {
       r[--pos] = encodeTable[static_cast<uint8_t>(t & 0x3ful)];
       t >>= 6;
     }
@@ -120,7 +120,7 @@ class HybridLogicalClock {
   /// the result buffer are returned
   static std::pair<size_t, size_t> encodeTimeStamp(uint64_t t, char* r) {
     size_t pos = 11;
-    while (t > 0) {
+    while (pos > 0) {
       r[--pos] = encodeTable[static_cast<uint8_t>(t & 0x3ful)];
       t >>= 6;
     }


### PR DESCRIPTION
### Scope & Purpose

We encode revision IDs using a base64 encoding to get around the 53-bit integer limitation in JS. The encoding has been variable-length, simply omitting any possible leading zero chunks (otherwise encoded as `-`). Among other irregularities, this causes a 0 revision to be encoded as an empty string, which can cause some odd behavior in clients. This PR changes the encoding to be fixed-length at 11 characters by including leading zeroes. The decoding algorithm handles both variants without any problems, so it should not cause any backwards-compatibility issues.

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)

### Testing & Verification

This change is already covered by existing tests.

Jenkins: 