### PR TITLE
Remove isNewStyleExecutor constexpr

### DIFF
--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -118,8 +118,6 @@ CREATE_HAS_MEMBER_CHECK(expectedNumberOfRowsNew, hasExpectedNumberOfRowsNew);
 // Forward declaration of Test Executors.
 // only used as long as isNewStyleExecutor is required.
 namespace arangodb::aql {
-class TestLambdaExecutor;
-
 class TestLambdaSkipExecutor;
 }  // namespace arangodb::aql
 #endif
@@ -140,58 +138,6 @@ constexpr bool executorHasSideEffects =
                 ModificationExecutor<SingleRowFetcher<BlockPassthrough::Disable>, UpdateReplaceModifier>,
                 ModificationExecutor<AllRowsFetcher, UpsertModifier>,
                 ModificationExecutor<SingleRowFetcher<BlockPassthrough::Disable>, UpsertModifier>>;
-
-/*
- * Determine whether we execute new style or old style skips, i.e. pre or post shadow row introduction
- * TODO: This should be removed once all executors and fetchers are ported to the new style.
- */
-template <typename Executor>
-constexpr bool isNewStyleExecutor = is_one_of_v<
-    Executor, FilterExecutor, SortedCollectExecutor, IdExecutor<ConstFetcher>, ParallelUnsortedGatherExecutor,
-    IdExecutor<SingleRowFetcher<BlockPassthrough::Enable>>, ReturnExecutor, DistinctCollectExecutor, IndexExecutor,
-    EnumerateCollectionExecutor, SubqueryExecutor<true>, SubqueryExecutor<false>, CountCollectExecutor,
-    CalculationExecutor<CalculationType::Condition>, CalculationExecutor<CalculationType::Reference>,
-    CalculationExecutor<CalculationType::V8Condition>, HashedCollectExecutor, ConstrainedSortExecutor,
-#ifdef ARANGODB_USE_GOOGLE_TESTS
-    TestLambdaExecutor,
-    TestLambdaSkipExecutor,  // we need one after these to avoid compile errors in non-test mode
-#endif
-    ModificationExecutor<AllRowsFetcher, InsertModifier>,
-    ModificationExecutor<SingleRowFetcher<BlockPassthrough::Disable>, InsertModifier>,
-    ModificationExecutor<AllRowsFetcher, RemoveModifier>,
-    ModificationExecutor<SingleRowFetcher<BlockPassthrough::Disable>, RemoveModifier>,
-    ModificationExecutor<AllRowsFetcher, UpdateReplaceModifier>,
-    ModificationExecutor<SingleRowFetcher<BlockPassthrough::Disable>, UpdateReplaceModifier>,
-    ModificationExecutor<AllRowsFetcher, UpsertModifier>,
-    ModificationExecutor<SingleRowFetcher<BlockPassthrough::Disable>, UpsertModifier>, SubqueryStartExecutor,
-    UnsortedGatherExecutor, SortingGatherExecutor, SubqueryEndExecutor, TraversalExecutor,
-    KShortestPathsExecutor, ShortestPathExecutor, EnumerateListExecutor, LimitExecutor, SortExecutor,
-    IResearchViewExecutor<false, arangodb::iresearch::MaterializeType::NotMaterialize>,
-    IResearchViewExecutor<false, arangodb::iresearch::MaterializeType::LateMaterialize>,
-    IResearchViewExecutor<false, arangodb::iresearch::MaterializeType::Materialize>,
-    IResearchViewExecutor<false, arangodb::iresearch::MaterializeType::NotMaterialize | arangodb::iresearch::MaterializeType::UseStoredValues>,
-    IResearchViewExecutor<false, arangodb::iresearch::MaterializeType::LateMaterialize | arangodb::iresearch::MaterializeType::UseStoredValues>,
-    IResearchViewExecutor<true, arangodb::iresearch::MaterializeType::NotMaterialize>,
-    IResearchViewExecutor<true, arangodb::iresearch::MaterializeType::LateMaterialize>,
-    IResearchViewExecutor<true, arangodb::iresearch::MaterializeType::Materialize>,
-    IResearchViewExecutor<true, arangodb::iresearch::MaterializeType::NotMaterialize | arangodb::iresearch::MaterializeType::UseStoredValues>,
-    IResearchViewExecutor<true, arangodb::iresearch::MaterializeType::LateMaterialize | arangodb::iresearch::MaterializeType::UseStoredValues>,
-    IResearchViewMergeExecutor<false, arangodb::iresearch::MaterializeType::NotMaterialize>,
-    IResearchViewMergeExecutor<false, arangodb::iresearch::MaterializeType::LateMaterialize>,
-    IResearchViewMergeExecutor<false, arangodb::iresearch::MaterializeType::Materialize>,
-    IResearchViewMergeExecutor<false, arangodb::iresearch::MaterializeType::NotMaterialize | arangodb::iresearch::MaterializeType::UseStoredValues>,
-    IResearchViewMergeExecutor<false, arangodb::iresearch::MaterializeType::LateMaterialize | arangodb::iresearch::MaterializeType::UseStoredValues>,
-    IResearchViewMergeExecutor<true, arangodb::iresearch::MaterializeType::NotMaterialize>,
-    IResearchViewMergeExecutor<true, arangodb::iresearch::MaterializeType::LateMaterialize>,
-    IResearchViewMergeExecutor<true, arangodb::iresearch::MaterializeType::Materialize>,
-    IResearchViewMergeExecutor<true, arangodb::iresearch::MaterializeType::NotMaterialize | arangodb::iresearch::MaterializeType::UseStoredValues>,
-    IResearchViewMergeExecutor<true, arangodb::iresearch::MaterializeType::LateMaterialize | arangodb::iresearch::MaterializeType::UseStoredValues>,
-    SubqueryStartExecutor, SubqueryEndExecutor, TraversalExecutor, KShortestPathsExecutor,
-    NoResultsExecutor, ShortestPathExecutor, EnumerateListExecutor, LimitExecutor,
-    SingleRemoteModificationExecutor<IndexTag>, SingleRemoteModificationExecutor<Insert>,
-    SingleRemoteModificationExecutor<Remove>, SingleRemoteModificationExecutor<Update>,
-    SingleRemoteModificationExecutor<Replace>, SingleRemoteModificationExecutor<Upsert>,
-    MaterializeExecutor<RegisterId>, MaterializeExecutor<std::string const&>>;
 
 template <class Executor>
 ExecutionBlockImpl<Executor>::ExecutionBlockImpl(ExecutionEngine* engine,
@@ -758,65 +704,60 @@ auto ExecutionBlockImpl<Executor>::executeFetcher(AqlCallStack& stack,
                                                   AqlCallType const& aqlCall,
                                                   ADB_IGNORE_UNUSED bool wasCalledWithContinueCall)
     -> std::tuple<ExecutionState, SkipResult, typename Fetcher::DataRange> {
-  if constexpr (isNewStyleExecutor<Executor>) {
-    // TODO The logic in the MultiDependencySingleRowFetcher branch should be
-    //      moved into the MultiDependencySingleRowFetcher.
-    static_assert(isMultiDepExecutor<Executor> ==
-                  std::is_same_v<Fetcher, MultiDependencySingleRowFetcher>);
-    if constexpr (std::is_same_v<Fetcher, MultiDependencySingleRowFetcher>) {
-      static_assert(
-          !executorHasSideEffects<Executor>,
-          "there is a special implementation for side-effect executors to "
-          "exchange the stack. For the MultiDependencyFetcher this special "
-          "case is not implemented. There is no reason to disallow this "
-          "case here however, it is just not needed thus far.");
-      // Note the aqlCall is an AqlCallSet in this case:
-      static_assert(std::is_same_v<AqlCallSet, std::decay_t<decltype(aqlCall)>>);
-      TRI_ASSERT(_lastRange.numberDependencies() == _dependencies.size());
-      auto const& [state, skipped, ranges] = _rowFetcher.execute(stack, aqlCall);
-      for (auto const& [dependency, range] : ranges) {
-        _lastRange.setDependency(dependency, range);
-      }
-      return {state, skipped, _lastRange};
-
-    } else if constexpr (executorHasSideEffects<Executor>) {
-      // If the executor has side effects, we cannot bypass any subqueries
-      // by skipping them. So we need to fetch all shadow rows in order to
-      // trigger this Executor with everthing from above.
-      // NOTE: The Executor needs to discard shadowRows, and do the accouting.
-      static_assert(std::is_same_v<AqlCall, std::decay_t<decltype(aqlCall)>>);
-      auto fetchAllStack = stack.createEquivalentFetchAllShadowRowsStack();
-      fetchAllStack.pushCall(createUpstreamCall(aqlCall, wasCalledWithContinueCall));
-      auto res = _rowFetcher.execute(fetchAllStack);
-      // Just make sure we did not Skip anything
-      TRI_ASSERT(std::get<SkipResult>(res).nothingSkipped());
-      return res;
-    } else {
-      // If we are SubqueryStart, we remove the top element of the stack
-      // which belongs to the subquery enclosed by this
-      // SubqueryStart and the partnered SubqueryEnd by *not*
-      // pushing the upstream request.
-      if constexpr (!std::is_same_v<Executor, SubqueryStartExecutor>) {
-        stack.pushCall(createUpstreamCall(std::move(aqlCall), wasCalledWithContinueCall));
-      }
-
-      auto const result = _rowFetcher.execute(stack);
-
-      if constexpr (!std::is_same_v<Executor, SubqueryStartExecutor>) {
-        // As the stack is copied into the fetcher, we need to pop off our call
-        // again. If we use other datastructures or moving we may hand over
-        // ownership of the stack here instead and no popCall is necessary.
-        std::ignore = stack.popCall();
-      } else {
-        // Do not pop the call, we did not put it on.
-        // However we need it for accounting later.
-      }
-
-      return result;
+  // TODO The logic in the MultiDependencySingleRowFetcher branch should be
+  //      moved into the MultiDependencySingleRowFetcher.
+  static_assert(isMultiDepExecutor<Executor> ==
+                std::is_same_v<Fetcher, MultiDependencySingleRowFetcher>);
+  if constexpr (std::is_same_v<Fetcher, MultiDependencySingleRowFetcher>) {
+    static_assert(
+        !executorHasSideEffects<Executor>,
+        "there is a special implementation for side-effect executors to "
+        "exchange the stack. For the MultiDependencyFetcher this special "
+        "case is not implemented. There is no reason to disallow this "
+        "case here however, it is just not needed thus far.");
+    // Note the aqlCall is an AqlCallSet in this case:
+    static_assert(std::is_same_v<AqlCallSet, std::decay_t<decltype(aqlCall)>>);
+    TRI_ASSERT(_lastRange.numberDependencies() == _dependencies.size());
+    auto const& [state, skipped, ranges] = _rowFetcher.execute(stack, aqlCall);
+    for (auto const& [dependency, range] : ranges) {
+      _lastRange.setDependency(dependency, range);
     }
+    return {state, skipped, _lastRange};
+
+  } else if constexpr (executorHasSideEffects<Executor>) {
+    // If the executor has side effects, we cannot bypass any subqueries
+    // by skipping them. So we need to fetch all shadow rows in order to
+    // trigger this Executor with everthing from above.
+    // NOTE: The Executor needs to discard shadowRows, and do the accouting.
+    static_assert(std::is_same_v<AqlCall, std::decay_t<decltype(aqlCall)>>);
+    auto fetchAllStack = stack.createEquivalentFetchAllShadowRowsStack();
+    fetchAllStack.pushCall(createUpstreamCall(aqlCall, wasCalledWithContinueCall));
+    auto res = _rowFetcher.execute(fetchAllStack);
+    // Just make sure we did not Skip anything
+    TRI_ASSERT(std::get<SkipResult>(res).nothingSkipped());
+    return res;
   } else {
-    TRI_ASSERT(false);
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
+    // If we are SubqueryStart, we remove the top element of the stack
+    // which belongs to the subquery enclosed by this
+    // SubqueryStart and the partnered SubqueryEnd by *not*
+    // pushing the upstream request.
+    if constexpr (!std::is_same_v<Executor, SubqueryStartExecutor>) {
+      stack.pushCall(createUpstreamCall(std::move(aqlCall), wasCalledWithContinueCall));
+    }
+
+    auto const result = _rowFetcher.execute(stack);
+
+    if constexpr (!std::is_same_v<Executor, SubqueryStartExecutor>) {
+      // As the stack is copied into the fetcher, we need to pop off our call
+      // again. If we use other datastructures or moving we may hand over
+      // ownership of the stack here instead and no popCall is necessary.
+      std::ignore = stack.popCall();
+    } else {
+      // Do not pop the call, we did not put it on.
+      // However we need it for accounting later.
+    }
+
+    return result;
   }
 }
 
@@ -824,21 +765,17 @@ template <class Executor>
 auto ExecutionBlockImpl<Executor>::executeProduceRows(typename Fetcher::DataRange& input,
                                                       OutputAqlItemRow& output)
     -> std::tuple<ExecutorState, typename Executor::Stats, AqlCallType> {
-  if constexpr (isNewStyleExecutor<Executor>) {
-    if constexpr (isMultiDepExecutor<Executor>) {
-      TRI_ASSERT(input.numberDependencies() == _dependencies.size());
-      return _executor.produceRows(input, output);
-    } else if constexpr (is_one_of_v<Executor, SubqueryExecutor<true>, SubqueryExecutor<false>>) {
-      // The SubqueryExecutor has it's own special handling outside.
-      // SO this code is in fact not reachable
-      TRI_ASSERT(false);
-      THROW_ARANGO_EXCEPTION(TRI_ERROR_INTERNAL_AQL);
-    } else {
-      auto [state, stats, call] = _executor.produceRows(input, output);
-      return {state, stats, call};
-    }
+  if constexpr (isMultiDepExecutor<Executor>) {
+    TRI_ASSERT(input.numberDependencies() == _dependencies.size());
+    return _executor.produceRows(input, output);
+  } else if constexpr (is_one_of_v<Executor, SubqueryExecutor<true>, SubqueryExecutor<false>>) {
+    // The SubqueryExecutor has it's own special handling outside.
+    // SO this code is in fact not reachable
+    TRI_ASSERT(false);
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_INTERNAL_AQL);
   } else {
-    return {ExecutorState::DONE, typename Executor::Stats{}, AqlCall{}};
+    auto [state, stats, call] = _executor.produceRows(input, output);
+    return {state, stats, call};
   }
 }
 
@@ -846,43 +783,38 @@ template <class Executor>
 auto ExecutionBlockImpl<Executor>::executeSkipRowsRange(typename Fetcher::DataRange& inputRange,
                                                         AqlCall& call)
     -> std::tuple<ExecutorState, typename Executor::Stats, size_t, AqlCallType> {
-  if constexpr (isNewStyleExecutor<Executor>) {
-    call.skippedRows = 0;
-    if constexpr (skipRowsType<Executor>() == SkipRowsRangeVariant::EXECUTOR) {
-      if constexpr (isMultiDepExecutor<Executor>) {
-        TRI_ASSERT(inputRange.numberDependencies() == _dependencies.size());
-        // If the executor has a method skipRowsRange, to skip outputs.
-        // Every non-passthrough executor needs to implement this.
-        auto res = _executor.skipRowsRange(inputRange, call);
-        _executorReturnedDone = std::get<ExecutorState>(res) == ExecutorState::DONE;
-        return res;
-      } else if constexpr (is_one_of_v<Executor, SubqueryExecutor<true>, SubqueryExecutor<false>>) {
-        // The SubqueryExecutor has it's own special handling outside.
-        // SO this code is in fact not reachable
-        TRI_ASSERT(false);
-        THROW_ARANGO_EXCEPTION(TRI_ERROR_INTERNAL_AQL);
-      } else {
-        auto [state, stats, skipped, localCall] =
-            _executor.skipRowsRange(inputRange, call);
-        _executorReturnedDone = state == ExecutorState::DONE;
-        return {state, stats, skipped, localCall};
-      }
-    } else if constexpr (skipRowsType<Executor>() == SkipRowsRangeVariant::FETCHER) {
-      // If we know that every input row produces exactly one output row (this
-      // is a property of the executor), then we can just let the fetcher skip
-      // the number of rows that we would like to skip.
-      // Returning this will trigger to end in upstream state now, with the
-      // call that was handed it.
-      static_assert(
-          std::is_same_v<typename Executor::Stats, NoStats>,
-          "Executors with custom statistics must implement skipRowsRange.");
-      return {inputRange.upstreamState(), NoStats{}, 0, call};
-    } else {
-      static_assert(dependent_false<Executor>::value,
-                    "This value of SkipRowsRangeVariant is not supported");
+  call.skippedRows = 0;
+  if constexpr (skipRowsType<Executor>() == SkipRowsRangeVariant::EXECUTOR) {
+    if constexpr (isMultiDepExecutor<Executor>) {
+      TRI_ASSERT(inputRange.numberDependencies() == _dependencies.size());
+      // If the executor has a method skipRowsRange, to skip outputs.
+      // Every non-passthrough executor needs to implement this.
+      auto res = _executor.skipRowsRange(inputRange, call);
+      _executorReturnedDone = std::get<ExecutorState>(res) == ExecutorState::DONE;
+      return res;
+    } else if constexpr (is_one_of_v<Executor, SubqueryExecutor<true>, SubqueryExecutor<false>>) {
+      // The SubqueryExecutor has it's own special handling outside.
+      // SO this code is in fact not reachable
       TRI_ASSERT(false);
+      THROW_ARANGO_EXCEPTION(TRI_ERROR_INTERNAL_AQL);
+    } else {
+      auto [state, stats, skipped, localCall] = _executor.skipRowsRange(inputRange, call);
+      _executorReturnedDone = state == ExecutorState::DONE;
+      return {state, stats, skipped, localCall};
     }
+  } else if constexpr (skipRowsType<Executor>() == SkipRowsRangeVariant::FETCHER) {
+    // If we know that every input row produces exactly one output row (this
+    // is a property of the executor), then we can just let the fetcher skip
+    // the number of rows that we would like to skip.
+    // Returning this will trigger to end in upstream state now, with the
+    // call that was handed it.
+    static_assert(
+        std::is_same_v<typename Executor::Stats, NoStats>,
+        "Executors with custom statistics must implement skipRowsRange.");
+    return {inputRange.upstreamState(), NoStats{}, 0, call};
   } else {
+    static_assert(dependent_false<Executor>::value,
+                  "This value of SkipRowsRangeVariant is not supported");
     TRI_ASSERT(false);
   }
   TRI_ASSERT(false);
@@ -1155,7 +1087,6 @@ template <class Executor>
 auto ExecutionBlockImpl<Executor>::executeFastForward(typename Fetcher::DataRange& inputRange,
                                                       AqlCall& clientCall)
     -> std::tuple<ExecutorState, typename Executor::Stats, size_t, AqlCallType> {
-  TRI_ASSERT(isNewStyleExecutor<Executor>);
   auto type = fastForwardType(clientCall, _executor);
 
   switch (type) {
@@ -1274,501 +1205,491 @@ auto ExecutionBlockImpl<Executor>::executeFastForward(typename Fetcher::DataRang
 template <class Executor>
 std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr>
 ExecutionBlockImpl<Executor>::executeWithoutTrace(AqlCallStack stack) {
-  if constexpr (isNewStyleExecutor<Executor>) {
-    // We can only work on a Stack that has valid calls for all levels.
-    TRI_ASSERT(stack.hasAllValidCalls());
-    AqlCallList clientCallList = stack.popCall();
-    AqlCall clientCall;
-    if constexpr (std::is_same_v<Executor, SubqueryEndExecutor>) {
-      // In subqeryEndExecutor we actually manage two calls.
-      // The clientCall defines what will go into the Executor.
-      // on SubqueryEnd this call is generated based on the call from downstream
+  // We can only work on a Stack that has valid calls for all levels.
+  TRI_ASSERT(stack.hasAllValidCalls());
+  AqlCallList clientCallList = stack.popCall();
+  AqlCall clientCall;
+  if constexpr (std::is_same_v<Executor, SubqueryEndExecutor>) {
+    // In subqeryEndExecutor we actually manage two calls.
+    // The clientCall defines what will go into the Executor.
+    // on SubqueryEnd this call is generated based on the call from downstream
 
-      if (_outputItemRow != nullptr && _outputItemRow->isInitialized()) {
-        // If we return with a waiting state, we need to report it to the
-        // subquery callList, but not pull it of.
-        auto& subQueryCall = clientCallList.modifyNextCall();
-        // Overwrite with old state.
-        subQueryCall = _outputItemRow->getClientCall();
-      }
-      stack.pushCall(std::move(clientCallList));
-      clientCallList = AqlCallList{AqlCall{}, AqlCall{}};
-      clientCall = clientCallList.popNextCall();
-    } else {
-      clientCall = clientCallList.popNextCall();
+    if (_outputItemRow != nullptr && _outputItemRow->isInitialized()) {
+      // If we return with a waiting state, we need to report it to the
+      // subquery callList, but not pull it of.
+      auto& subQueryCall = clientCallList.modifyNextCall();
+      // Overwrite with old state.
+      subQueryCall = _outputItemRow->getClientCall();
     }
+    stack.pushCall(std::move(clientCallList));
+    clientCallList = AqlCallList{AqlCall{}, AqlCall{}};
+    clientCall = clientCallList.popNextCall();
+  } else {
+    clientCall = clientCallList.popNextCall();
+  }
 
-    ExecutorState localExecutorState = ExecutorState::DONE;
+  ExecutorState localExecutorState = ExecutorState::DONE;
 
-    TRI_ASSERT(!(clientCall.getOffset() == 0 && clientCall.softLimit == AqlCall::Limit{0}));
-    TRI_ASSERT(!(clientCall.hasSoftLimit() && clientCall.fullCount));
-    TRI_ASSERT(!(clientCall.hasSoftLimit() && clientCall.hasHardLimit()));
-    if constexpr (is_one_of_v<Executor, SubqueryExecutor<true>, SubqueryExecutor<false>>) {
-      // The old subquery executor can in-fact return waiting on produce call.
-      // if it needs to wait for the subquery.
-      // So we need to allow the return state here as well.
-      TRI_ASSERT(_execState == ExecState::CHECKCALL ||
-                 _execState == ExecState::SHADOWROWS || _execState == ExecState::UPSTREAM ||
-                 _execState == ExecState::PRODUCE || _execState == ExecState::SKIP);
-    } else {
-      // We can only have returned the following internal states
-      TRI_ASSERT(_execState == ExecState::CHECKCALL || _execState == ExecState::SHADOWROWS ||
-                 _execState == ExecState::UPSTREAM);
+  TRI_ASSERT(!(clientCall.getOffset() == 0 && clientCall.softLimit == AqlCall::Limit{0}));
+  TRI_ASSERT(!(clientCall.hasSoftLimit() && clientCall.fullCount));
+  TRI_ASSERT(!(clientCall.hasSoftLimit() && clientCall.hasHardLimit()));
+  if constexpr (is_one_of_v<Executor, SubqueryExecutor<true>, SubqueryExecutor<false>>) {
+    // The old subquery executor can in-fact return waiting on produce call.
+    // if it needs to wait for the subquery.
+    // So we need to allow the return state here as well.
+    TRI_ASSERT(_execState == ExecState::CHECKCALL ||
+               _execState == ExecState::SHADOWROWS || _execState == ExecState::UPSTREAM ||
+               _execState == ExecState::PRODUCE || _execState == ExecState::SKIP);
+  } else {
+    // We can only have returned the following internal states
+    TRI_ASSERT(_execState == ExecState::CHECKCALL || _execState == ExecState::SHADOWROWS ||
+               _execState == ExecState::UPSTREAM);
+  }
+
+  // In some executors we may write something into the output, but then return
+  // waiting. In this case we are not allowed to lose the call we have been
+  // working on, we have noted down created or skipped rows in there. The client
+  // is disallowed to change her mind anyways so we simply continue to work on
+  // the call we already have The guarantee is, if we have returned the block,
+  // and modified our local call, then the outputItemRow is not initialized
+  if constexpr (!std::is_same_v<Executor, SubqueryEndExecutor>) {
+    // The subqueryEndeExecutor has handled it above
+    if (_outputItemRow != nullptr && _outputItemRow->isInitialized()) {
+      clientCall = _outputItemRow->getClientCall();
     }
+  }
 
-    // In some executors we may write something into the output, but then return waiting.
-    // In this case we are not allowed to lose the call we have been working on, we have
-    // noted down created or skipped rows in there.
-    // The client is disallowed to change her mind anyways
-    // so we simply continue to work on the call we already have
-    // The guarantee is, if we have returned the block, and modified
-    // our local call, then the outputItemRow is not initialized
-    if constexpr (!std::is_same_v<Executor, SubqueryEndExecutor>) {
-      // The subqueryEndeExecutor has handled it above
-      if (_outputItemRow != nullptr && _outputItemRow->isInitialized()) {
-        clientCall = _outputItemRow->getClientCall();
-      }
-    }
+  // Skip can only be > 0 if we are in upstream cases, or if we got injected a block
+  TRI_ASSERT(_skipped.nothingSkipped() || _execState == ExecState::UPSTREAM ||
+             (std::is_same_v<Executor, IdExecutor<ConstFetcher>>));
 
-    // Skip can only be > 0 if we are in upstream cases, or if we got injected a block
-    TRI_ASSERT(_skipped.nothingSkipped() || _execState == ExecState::UPSTREAM ||
-               (std::is_same_v<Executor, IdExecutor<ConstFetcher>>));
-
-    if constexpr (executorHasSideEffects<Executor>) {
-      if (!_skipped.nothingSkipped()) {
-        // We get woken up on upstream, but we have not reported our
-        // local skip value to downstream
-        // In the sideEffect executor we need to apply the skip values on the
-        // incomming stack, which has not been modified yet.
-        // NOTE: We only apply the skipping on subquery level.
-        TRI_ASSERT(_skipped.subqueryDepth() == stack.subqueryLevel() + 1);
-        for (size_t i = 0; i < stack.subqueryLevel(); ++i) {
-          auto skippedSub = _skipped.getSkipOnSubqueryLevel(i);
-          if (skippedSub > 0) {
-            auto& call = stack.modifyCallAtDepth(i);
-            call.didSkip(skippedSub);
-          }
+  if constexpr (executorHasSideEffects<Executor>) {
+    if (!_skipped.nothingSkipped()) {
+      // We get woken up on upstream, but we have not reported our
+      // local skip value to downstream
+      // In the sideEffect executor we need to apply the skip values on the
+      // incomming stack, which has not been modified yet.
+      // NOTE: We only apply the skipping on subquery level.
+      TRI_ASSERT(_skipped.subqueryDepth() == stack.subqueryLevel() + 1);
+      for (size_t i = 0; i < stack.subqueryLevel(); ++i) {
+        auto skippedSub = _skipped.getSkipOnSubqueryLevel(i);
+        if (skippedSub > 0) {
+          auto& call = stack.modifyCallAtDepth(i);
+          call.didSkip(skippedSub);
         }
       }
     }
+  }
 
-    if (_execState == ExecState::UPSTREAM) {
-      // We have been in waiting state.
-      // We may have local work on the original call.
-      // The client does not have the right to change her
-      // mind just because we told her to hold the line.
+  if (_execState == ExecState::UPSTREAM) {
+    // We have been in waiting state.
+    // We may have local work on the original call.
+    // The client does not have the right to change her
+    // mind just because we told her to hold the line.
 
-      // The client cannot request less data!
-      TRI_ASSERT(_clientRequest.requestLessDataThan(clientCall));
-      clientCall = _clientRequest;
+    // The client cannot request less data!
+    TRI_ASSERT(_clientRequest.requestLessDataThan(clientCall));
+    clientCall = _clientRequest;
 
-      TRI_ASSERT(_stackBeforeWaiting.requestLessDataThan(stack));
-      stack = _stackBeforeWaiting;
-    }
+    TRI_ASSERT(_stackBeforeWaiting.requestLessDataThan(stack));
+    stack = _stackBeforeWaiting;
+  }
 
-    auto returnToState = ExecState::CHECKCALL;
+  auto returnToState = ExecState::CHECKCALL;
 
-    LOG_QUERY("007ac", DEBUG) << "starting statemachine of executor " << printBlockInfo();
-    while (_execState != ExecState::DONE) {
-      switch (_execState) {
-        case ExecState::CHECKCALL: {
-          LOG_QUERY("cfe46", DEBUG)
-              << printTypeInfo() << " determine next action on call " << clientCall;
+  LOG_QUERY("007ac", DEBUG) << "starting statemachine of executor " << printBlockInfo();
+  while (_execState != ExecState::DONE) {
+    switch (_execState) {
+      case ExecState::CHECKCALL: {
+        LOG_QUERY("cfe46", DEBUG)
+            << printTypeInfo() << " determine next action on call " << clientCall;
 
-          if constexpr (executorHasSideEffects<Executor>) {
-            // If the executor has sideEffects, and we need to skip the results we would
-            // produce here because we actually skip the subquery, we instead do a
-            // hardLimit 0 (aka FastForward) call instead to the local Executor
-            if (stack.needToSkipSubquery()) {
-              _execState = ExecState::FASTFORWARD;
-              break;
-            }
-          }
-          _execState = nextState(clientCall);
-          break;
-        }
-        case ExecState::SKIP: {
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-          auto const offsetBefore = clientCall.getOffset();
-          TRI_ASSERT(offsetBefore > 0);
-          bool const canPassFullcount =
-              clientCall.getLimit() == 0 && clientCall.needsFullCount();
-#endif
-          LOG_QUERY("1f786", DEBUG) << printTypeInfo() << " call skipRows " << clientCall;
-
-          ExecutorState state = ExecutorState::HASMORE;
-          typename Executor::Stats stats;
-          size_t skippedLocal = 0;
-          AqlCallType call{};
-          if constexpr (is_one_of_v<Executor, SubqueryExecutor<true>>) {
-            // NOTE: The subquery Executor will by itself call EXECUTE on it's
-            // subquery. This can return waiting => we can get a WAITING state
-            // here. We can only get the waiting state for Subquery executors.
-            ExecutionState subqueryState = ExecutionState::HASMORE;
-            std::tie(subqueryState, stats, skippedLocal, call) =
-                _executor.skipRowsRange(_lastRange, clientCall);
-            if (subqueryState == ExecutionState::WAITING) {
-              TRI_ASSERT(skippedLocal == 0);
-              return {subqueryState, SkipResult{}, nullptr};
-            } else if (subqueryState == ExecutionState::DONE) {
-              state = ExecutorState::DONE;
-            } else {
-              state = ExecutorState::HASMORE;
-            }
-          } else {
-            // Execute skipSome
-            std::tie(state, stats, skippedLocal, call) =
-                executeSkipRowsRange(_lastRange, clientCall);
-          }
-
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-          // Assertion: We did skip 'skippedLocal' documents here.
-          // This means that they have to be removed from
-          // clientCall.getOffset() This has to be done by the Executor
-          // calling call.didSkip() accordingly. The LIMIT executor with a
-          // LIMIT of 0 can also bypass fullCount here, even if callLimit > 0
-          if (canPassFullcount || std::is_same_v<Executor, LimitExecutor>) {
-            // In this case we can first skip. But straight after continue with fullCount, so we might skip more
-            TRI_ASSERT(clientCall.getOffset() + skippedLocal >= offsetBefore);
-            if (clientCall.getOffset() + skippedLocal > offsetBefore) {
-              // First need to count down offset.
-              TRI_ASSERT(clientCall.getOffset() == 0);
-            }
-          } else {
-            TRI_ASSERT(clientCall.getOffset() + skippedLocal == offsetBefore);
-          }
-#endif
-          localExecutorState = state;
-          _skipped.didSkip(skippedLocal);
-          _engine->_stats += stats;
-          // The execute might have modified the client call.
-          if (state == ExecutorState::DONE) {
+        if constexpr (executorHasSideEffects<Executor>) {
+          // If the executor has sideEffects, and we need to skip the results we would
+          // produce here because we actually skip the subquery, we instead do a
+          // hardLimit 0 (aka FastForward) call instead to the local Executor
+          if (stack.needToSkipSubquery()) {
             _execState = ExecState::FASTFORWARD;
-          } else if (clientCall.getOffset() > 0) {
-            TRI_ASSERT(_upstreamState != ExecutionState::DONE);
-            // We need to request more
-            _upstreamRequest = call;
-            _execState = ExecState::UPSTREAM;
-          } else {
-            // We are done with skipping. Skip is not allowed to request more
-            _execState = ExecState::CHECKCALL;
-          }
-          break;
-        }
-        case ExecState::PRODUCE: {
-          // Make sure there's a block allocated and set
-          // the call
-          TRI_ASSERT(clientCall.getLimit() > 0);
-
-          LOG_QUERY("1f786", DEBUG) << printTypeInfo() << " call produceRows " << clientCall;
-          if (outputIsFull()) {
-            // We need to be able to write data
-            // But maybe the existing block is full here
-            // Then we need to wake up again.
-            // However the client might decide on a different
-            // call, so we do not record this position
-            _execState = ExecState::DONE;
             break;
           }
-          if constexpr (std::is_same_v<Executor, SubqueryEndExecutor>) {
-            TRI_ASSERT(!stack.empty());
-            AqlCall const& subqueryCall = stack.peek();
-            AqlCall copyCall = subqueryCall;
-            ensureOutputBlock(std::move(copyCall), _lastRange);
-          } else {
-            ensureOutputBlock(std::move(clientCall), _lastRange);
-          }
-          TRI_ASSERT(_outputItemRow);
-          TRI_ASSERT(!_executorReturnedDone);
-          ExecutorState state = ExecutorState::HASMORE;
-          typename Executor::Stats stats;
-          auto call = AqlCallType{};
-          if constexpr (is_one_of_v<Executor, SubqueryExecutor<true>, SubqueryExecutor<false>>) {
-            // NOTE: The subquery Executor will by itself call EXECUTE on it's
-            // subquery. This can return waiting => we can get a WAITING state
-            // here. We can only get the waiting state for SUbquery executors.
-            ExecutionState subqueryState = ExecutionState::HASMORE;
-            std::tie(subqueryState, stats, call) =
-                _executor.produceRows(_lastRange, *_outputItemRow);
-            if (subqueryState == ExecutionState::WAITING) {
-              return {subqueryState, SkipResult{}, nullptr};
-            } else if (subqueryState == ExecutionState::DONE) {
-              state = ExecutorState::DONE;
-            } else {
-              state = ExecutorState::HASMORE;
-            }
-          } else {
-            // Execute getSome
-            std::tie(state, stats, call) = executeProduceRows(_lastRange, *_outputItemRow);
-          }
-          _executorReturnedDone = state == ExecutorState::DONE;
-          _engine->_stats += stats;
-          localExecutorState = state;
+        }
+        _execState = nextState(clientCall);
+        break;
+      }
+      case ExecState::SKIP: {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+        auto const offsetBefore = clientCall.getOffset();
+        TRI_ASSERT(offsetBefore > 0);
+        bool const canPassFullcount =
+            clientCall.getLimit() == 0 && clientCall.needsFullCount();
+#endif
+        LOG_QUERY("1f786", DEBUG) << printTypeInfo() << " call skipRows " << clientCall;
 
-          if constexpr (!std::is_same_v<Executor, SubqueryEndExecutor>) {
-            // But only do this if we are not subquery.
-            clientCall = _outputItemRow->getClientCall();
-          }
-
-          if (state == ExecutorState::DONE) {
-            _execState = ExecState::FASTFORWARD;
-          } else if ((Executor::Properties::allowsBlockPassthrough == BlockPassthrough::Enable ||
-                      clientCall.getLimit() > 0) &&
-                     outputIsFull()) {
-            // In pass through variant we need to stop whenever the block is full.
-            // In all other branches only if the client Still needs more data.
-            _execState = ExecState::DONE;
-            break;
-          } else if (clientCall.getLimit() > 0 && executorNeedsCall(call)) {
-            TRI_ASSERT(_upstreamState != ExecutionState::DONE);
-            // We need to request more
-            _upstreamRequest = call;
-            _execState = ExecState::UPSTREAM;
+        ExecutorState state = ExecutorState::HASMORE;
+        typename Executor::Stats stats;
+        size_t skippedLocal = 0;
+        AqlCallType call{};
+        if constexpr (is_one_of_v<Executor, SubqueryExecutor<true>>) {
+          // NOTE: The subquery Executor will by itself call EXECUTE on it's
+          // subquery. This can return waiting => we can get a WAITING state
+          // here. We can only get the waiting state for Subquery executors.
+          ExecutionState subqueryState = ExecutionState::HASMORE;
+          std::tie(subqueryState, stats, skippedLocal, call) =
+              _executor.skipRowsRange(_lastRange, clientCall);
+          if (subqueryState == ExecutionState::WAITING) {
+            TRI_ASSERT(skippedLocal == 0);
+            return {subqueryState, SkipResult{}, nullptr};
+          } else if (subqueryState == ExecutionState::DONE) {
+            state = ExecutorState::DONE;
           } else {
-            // We are done with producing. Produce is not allowed to request more
-            _execState = ExecState::CHECKCALL;
+            state = ExecutorState::HASMORE;
           }
+        } else {
+          // Execute skipSome
+          std::tie(state, stats, skippedLocal, call) =
+              executeSkipRowsRange(_lastRange, clientCall);
+        }
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+        // Assertion: We did skip 'skippedLocal' documents here.
+        // This means that they have to be removed from
+        // clientCall.getOffset() This has to be done by the Executor
+        // calling call.didSkip() accordingly. The LIMIT executor with a
+        // LIMIT of 0 can also bypass fullCount here, even if callLimit > 0
+        if (canPassFullcount || std::is_same_v<Executor, LimitExecutor>) {
+          // In this case we can first skip. But straight after continue with fullCount, so we might skip more
+          TRI_ASSERT(clientCall.getOffset() + skippedLocal >= offsetBefore);
+          if (clientCall.getOffset() + skippedLocal > offsetBefore) {
+            // First need to count down offset.
+            TRI_ASSERT(clientCall.getOffset() == 0);
+          }
+        } else {
+          TRI_ASSERT(clientCall.getOffset() + skippedLocal == offsetBefore);
+        }
+#endif
+        localExecutorState = state;
+        _skipped.didSkip(skippedLocal);
+        _engine->_stats += stats;
+        // The execute might have modified the client call.
+        if (state == ExecutorState::DONE) {
+          _execState = ExecState::FASTFORWARD;
+        } else if (clientCall.getOffset() > 0) {
+          TRI_ASSERT(_upstreamState != ExecutionState::DONE);
+          // We need to request more
+          _upstreamRequest = call;
+          _execState = ExecState::UPSTREAM;
+        } else {
+          // We are done with skipping. Skip is not allowed to request more
+          _execState = ExecState::CHECKCALL;
+        }
+        break;
+      }
+      case ExecState::PRODUCE: {
+        // Make sure there's a block allocated and set
+        // the call
+        TRI_ASSERT(clientCall.getLimit() > 0);
+
+        LOG_QUERY("1f786", DEBUG) << printTypeInfo() << " call produceRows " << clientCall;
+        if (outputIsFull()) {
+          // We need to be able to write data
+          // But maybe the existing block is full here
+          // Then we need to wake up again.
+          // However the client might decide on a different
+          // call, so we do not record this position
+          _execState = ExecState::DONE;
           break;
         }
-        case ExecState::FASTFORWARD: {
-          LOG_QUERY("96e2c", DEBUG)
-              << printTypeInfo() << " all produced, fast forward to end up (sub-)query.";
-
-          AqlCall callCopy = clientCall;
-          if constexpr (executorHasSideEffects<Executor>) {
-            if (stack.needToSkipSubquery()) {
-              // Fast Forward call.
-              callCopy = AqlCall{0, false, 0, AqlCall::LimitType::HARD};
-            }
-          }
-
-          auto [state, stats, skippedLocal, call] =
-              executeFastForward(_lastRange, callCopy);
-
-          if constexpr (executorHasSideEffects<Executor>) {
-            if (!stack.needToSkipSubquery()) {
-              // We need to modify the original call.
-              clientCall = callCopy;
-            }
-            // else: We are bypassing the results.
-            // Do not count them here.
+        if constexpr (std::is_same_v<Executor, SubqueryEndExecutor>) {
+          TRI_ASSERT(!stack.empty());
+          AqlCall const& subqueryCall = stack.peek();
+          AqlCall copyCall = subqueryCall;
+          ensureOutputBlock(std::move(copyCall), _lastRange);
+        } else {
+          ensureOutputBlock(std::move(clientCall), _lastRange);
+        }
+        TRI_ASSERT(_outputItemRow);
+        TRI_ASSERT(!_executorReturnedDone);
+        ExecutorState state = ExecutorState::HASMORE;
+        typename Executor::Stats stats;
+        auto call = AqlCallType{};
+        if constexpr (is_one_of_v<Executor, SubqueryExecutor<true>, SubqueryExecutor<false>>) {
+          // NOTE: The subquery Executor will by itself call EXECUTE on it's
+          // subquery. This can return waiting => we can get a WAITING state
+          // here. We can only get the waiting state for SUbquery executors.
+          ExecutionState subqueryState = ExecutionState::HASMORE;
+          std::tie(subqueryState, stats, call) =
+              _executor.produceRows(_lastRange, *_outputItemRow);
+          if (subqueryState == ExecutionState::WAITING) {
+            return {subqueryState, SkipResult{}, nullptr};
+          } else if (subqueryState == ExecutionState::DONE) {
+            state = ExecutorState::DONE;
           } else {
+            state = ExecutorState::HASMORE;
+          }
+        } else {
+          // Execute getSome
+          std::tie(state, stats, call) = executeProduceRows(_lastRange, *_outputItemRow);
+        }
+        _executorReturnedDone = state == ExecutorState::DONE;
+        _engine->_stats += stats;
+        localExecutorState = state;
+
+        if constexpr (!std::is_same_v<Executor, SubqueryEndExecutor>) {
+          // But only do this if we are not subquery.
+          clientCall = _outputItemRow->getClientCall();
+        }
+
+        if (state == ExecutorState::DONE) {
+          _execState = ExecState::FASTFORWARD;
+        } else if ((Executor::Properties::allowsBlockPassthrough == BlockPassthrough::Enable ||
+                    clientCall.getLimit() > 0) &&
+                   outputIsFull()) {
+          // In pass through variant we need to stop whenever the block is full.
+          // In all other branches only if the client Still needs more data.
+          _execState = ExecState::DONE;
+          break;
+        } else if (clientCall.getLimit() > 0 && executorNeedsCall(call)) {
+          TRI_ASSERT(_upstreamState != ExecutionState::DONE);
+          // We need to request more
+          _upstreamRequest = call;
+          _execState = ExecState::UPSTREAM;
+        } else {
+          // We are done with producing. Produce is not allowed to request more
+          _execState = ExecState::CHECKCALL;
+        }
+        break;
+      }
+      case ExecState::FASTFORWARD: {
+        LOG_QUERY("96e2c", DEBUG)
+            << printTypeInfo() << " all produced, fast forward to end up (sub-)query.";
+
+        AqlCall callCopy = clientCall;
+        if constexpr (executorHasSideEffects<Executor>) {
+          if (stack.needToSkipSubquery()) {
+            // Fast Forward call.
+            callCopy = AqlCall{0, false, 0, AqlCall::LimitType::HARD};
+          }
+        }
+
+        auto [state, stats, skippedLocal, call] = executeFastForward(_lastRange, callCopy);
+
+        if constexpr (executorHasSideEffects<Executor>) {
+          if (!stack.needToSkipSubquery()) {
+            // We need to modify the original call.
             clientCall = callCopy;
           }
-
-          _skipped.didSkip(skippedLocal);
-          _engine->_stats += stats;
-          localExecutorState = state;
-
-          if (state == ExecutorState::DONE) {
-            if (!_lastRange.hasShadowRow() && !_lastRange.hasDataRow()) {
-              _execState = ExecState::DONE;
-            } else {
-              _execState = ExecState::SHADOWROWS;
-            }
-          } else {
-            // We need to request more
-            _upstreamRequest = call;
-            _execState = ExecState::UPSTREAM;
-          }
-          break;
+          // else: We are bypassing the results.
+          // Do not count them here.
+        } else {
+          clientCall = callCopy;
         }
-        case ExecState::UPSTREAM: {
-          LOG_QUERY("488de", DEBUG)
-              << printTypeInfo() << " request dependency " << _upstreamRequest;
-          // If this triggers the executors produceRows function has returned
-          // HASMORE even if it knew that upstream has no further rows.
-          TRI_ASSERT(_upstreamState != ExecutionState::DONE);
-          // We need to make sure _lastRange is all used for single-dependency
-          // executors.
-          TRI_ASSERT(isMultiDepExecutor<Executor> || !lastRangeHasDataRow());
-          TRI_ASSERT(!_lastRange.hasShadowRow());
-          SkipResult skippedLocal;
 
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-          auto subqueryLevelBefore = stack.subqueryLevel();
-#endif
-          std::tie(_upstreamState, skippedLocal, _lastRange) =
-              executeFetcher(stack, _upstreamRequest, clientCallList.hasMoreCalls());
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-          TRI_ASSERT(subqueryLevelBefore == stack.subqueryLevel());
-#endif
+        _skipped.didSkip(skippedLocal);
+        _engine->_stats += stats;
+        localExecutorState = state;
 
-          if (_upstreamState == ExecutionState::WAITING) {
-            // We need to persist the old call before we return.
-            // We might have some local accounting to this call.
-            _clientRequest = clientCall;
-            // We might also have some local accounting in this stack.
-            _stackBeforeWaiting = stack;
-            // We do not return anything in WAITING state, also NOT skipped.
-            return {_upstreamState, SkipResult{}, nullptr};
-          }
-          if constexpr (Executor::Properties::allowsBlockPassthrough ==
-                        BlockPassthrough::Enable) {
-            // We have a new range, passthrough can use this range.
-            _hasUsedDataRangeBlock = false;
-          }
-
-          if constexpr (std::is_same_v<Executor, SubqueryEndExecutor>) {
-            // We need to pop the last subquery from the returned skip
-            // We have not asked for a subquery skip.
-            TRI_ASSERT(skippedLocal.getSkipCount() == 0);
-            skippedLocal.decrementSubquery();
-          }
-          if constexpr (skipRowsType<Executor>() == SkipRowsRangeVariant::FETCHER) {
-            // We skipped through passthrough, so count that a skip was solved.
-            _skipped.merge(skippedLocal, false);
-            clientCall.didSkip(skippedLocal.getSkipCount());
-          } else if constexpr (is_one_of_v<Executor, SubqueryStartExecutor, SubqueryEndExecutor>) {
-            // Subquery needs to include the topLevel Skip.
-            // But does not need to apply the count to clientCall.
-            _skipped.merge(skippedLocal, false);
-            // This is what has been asked for by the SubqueryEnd
-
-            auto& subqueryCall = stack.modifyTopCall();
-            subqueryCall.didSkip(skippedLocal.getSkipCount());
+        if (state == ExecutorState::DONE) {
+          if (!_lastRange.hasShadowRow() && !_lastRange.hasDataRow()) {
+            _execState = ExecState::DONE;
           } else {
-            _skipped.merge(skippedLocal, true);
-          }
-          if constexpr (std::is_same_v<Executor, SubqueryStartExecutor>) {
-            // For the subqueryStart, we need to increment the SkipLevel by one
-            // as we may trigger this multiple times, check if we need to do it.
-            while (_skipped.subqueryDepth() < stack.subqueryLevel() + 1) {
-              // In fact, we only need to increase by 1
-              TRI_ASSERT(_skipped.subqueryDepth() == stack.subqueryLevel());
-              _skipped.incrementSubquery();
-            }
-          }
-
-          if (_lastRange.hasShadowRow() && !_lastRange.peekShadowRow().isRelevant()) {
             _execState = ExecState::SHADOWROWS;
-          } else {
-            _execState = ExecState::CHECKCALL;
           }
-          break;
+        } else {
+          // We need to request more
+          _upstreamRequest = call;
+          _execState = ExecState::UPSTREAM;
         }
-        case ExecState::SHADOWROWS: {
-          // We only get Called with something in the input.
-          TRI_ASSERT(_lastRange.hasShadowRow() || _lastRange.hasDataRow());
-          LOG_QUERY("7c63c", DEBUG)
-              << printTypeInfo() << " (sub-)query completed. Move ShadowRows.";
-
-          // TODO: Check if we can have the situation that we are between two shadow rows here.
-          // E.g. LastRow is relevant shadowRow. NextRow is non-relevant shadowRow.
-          // NOTE: I do not think this is an issue, as the Executor will always say that it cannot do anything with
-          // an empty input. Only exception might be COLLECT COUNT.
-
-          if (outputIsFull()) {
-            // We need to be able to write data
-            // But maybe the existing block is full here
-            // Then we need to wake up again here.
-            returnToState = ExecState::SHADOWROWS;
-            _execState = ExecState::DONE;
-            break;
-          }
-          if constexpr (std::is_same_v<Executor, SubqueryEndExecutor>) {
-            TRI_ASSERT(!stack.empty());
-            AqlCall const& subqueryCall = stack.peek();
-            AqlCall copyCall = subqueryCall;
-            ensureOutputBlock(std::move(copyCall), _lastRange);
-          } else {
-            ensureOutputBlock(std::move(clientCall), _lastRange);
-          }
-
-          TRI_ASSERT(!_outputItemRow->allRowsUsed());
-          if constexpr (executorHasSideEffects<Executor>) {
-            _execState = sideEffectShadowRowForwarding(stack, _skipped);
-          } else {
-            // This may write one or more rows.
-            _execState = shadowRowForwarding(stack);
-          }
-          if constexpr (!std::is_same_v<Executor, SubqueryEndExecutor>) {
-            // Produce might have modified the clientCall
-            // But only do this if we are not subquery.
-            clientCall = _outputItemRow->getClientCall();
-          }
-          break;
-        }
-        case ExecState::NEXTSUBQUERY: {
-          // This state will continue with the next run in the current subquery.
-          // For this executor the input of the next run will be injected and it can continue to work.
-          LOG_QUERY("0ca35", DEBUG)
-              << printTypeInfo() << " ShadowRows moved, continue with next subquery.";
-          if constexpr (std::is_same_v<Executor, SubqueryStartExecutor>) {
-            auto currentSubqueryCall = stack.peek();
-            if (currentSubqueryCall.getLimit() == 0 && currentSubqueryCall.hasSoftLimit()) {
-              // SoftLimitReached.
-              // We cannot continue.
-              _execState = ExecState::DONE;
-              break;
-            }
-            // Otherwise just check like the other blocks
-          }
-          if (!stack.hasAllValidCalls()) {
-            // We can only continue if we still have a valid call
-            // on all levels
-            _execState = ExecState::DONE;
-            break;
-          }
-
-          if (clientCallList.hasMoreCalls()) {
-            // Update to next call and start all over.
-            clientCall = clientCallList.popNextCall();
-            _execState = ExecState::CHECKCALL;
-          } else {
-            // We cannot continue, so we are done
-            _execState = ExecState::DONE;
-          }
-
-          break;
-        }
-        default:
-          // unreachable
-          TRI_ASSERT(false);
-          THROW_ARANGO_EXCEPTION(TRI_ERROR_INTERNAL_AQL);
+        break;
       }
-    }
-    LOG_QUERY("80c24", DEBUG) << printBlockInfo() << " local statemachine done. Return now.";
-    // If we do not have an output, we simply return a nullptr here.
-    auto outputBlock = _outputItemRow != nullptr ? _outputItemRow->stealBlock()
-                                                 : SharedAqlItemBlockPtr{nullptr};
-    // We are locally done with our output.
-    // Next time we need to check the client call again
-    _execState = returnToState;
-    // This is not strictly necessary here, as we shouldn't be called again
-    // after DONE.
-    _outputItemRow.reset();
+      case ExecState::UPSTREAM: {
+        LOG_QUERY("488de", DEBUG)
+            << printTypeInfo() << " request dependency " << _upstreamRequest;
+        // If this triggers the executors produceRows function has returned
+        // HASMORE even if it knew that upstream has no further rows.
+        TRI_ASSERT(_upstreamState != ExecutionState::DONE);
+        // We need to make sure _lastRange is all used for single-dependency
+        // executors.
+        TRI_ASSERT(isMultiDepExecutor<Executor> || !lastRangeHasDataRow());
+        TRI_ASSERT(!_lastRange.hasShadowRow());
+        SkipResult skippedLocal;
 
-    // We return skipped here, reset member
-    SkipResult skipped = _skipped;
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-    if (!stack.is36Compatible()) {
-      if constexpr (std::is_same_v<Executor, SubqueryEndExecutor>) {
-        TRI_ASSERT(skipped.subqueryDepth() == stack.subqueryLevel() /*we inected a call*/);
-      } else {
-        TRI_ASSERT(skipped.subqueryDepth() == stack.subqueryLevel() + 1 /*we took our call*/);
-      }
-    }
+        auto subqueryLevelBefore = stack.subqueryLevel();
 #endif
-    _skipped.reset();
-    if (localExecutorState == ExecutorState::HASMORE ||
-        _lastRange.hasDataRow() || _lastRange.hasShadowRow()) {
-      // We have skipped or/and return data, otherwise we cannot return HASMORE
-      TRI_ASSERT(!skipped.nothingSkipped() ||
-                 (outputBlock != nullptr && outputBlock->numEntries() > 0));
-      return {ExecutionState::HASMORE, skipped, std::move(outputBlock)};
+        std::tie(_upstreamState, skippedLocal, _lastRange) =
+            executeFetcher(stack, _upstreamRequest, clientCallList.hasMoreCalls());
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+        TRI_ASSERT(subqueryLevelBefore == stack.subqueryLevel());
+#endif
+
+        if (_upstreamState == ExecutionState::WAITING) {
+          // We need to persist the old call before we return.
+          // We might have some local accounting to this call.
+          _clientRequest = clientCall;
+          // We might also have some local accounting in this stack.
+          _stackBeforeWaiting = stack;
+          // We do not return anything in WAITING state, also NOT skipped.
+          return {_upstreamState, SkipResult{}, nullptr};
+        }
+        if constexpr (Executor::Properties::allowsBlockPassthrough == BlockPassthrough::Enable) {
+          // We have a new range, passthrough can use this range.
+          _hasUsedDataRangeBlock = false;
+        }
+
+        if constexpr (std::is_same_v<Executor, SubqueryEndExecutor>) {
+          // We need to pop the last subquery from the returned skip
+          // We have not asked for a subquery skip.
+          TRI_ASSERT(skippedLocal.getSkipCount() == 0);
+          skippedLocal.decrementSubquery();
+        }
+        if constexpr (skipRowsType<Executor>() == SkipRowsRangeVariant::FETCHER) {
+          // We skipped through passthrough, so count that a skip was solved.
+          _skipped.merge(skippedLocal, false);
+          clientCall.didSkip(skippedLocal.getSkipCount());
+        } else if constexpr (is_one_of_v<Executor, SubqueryStartExecutor, SubqueryEndExecutor>) {
+          // Subquery needs to include the topLevel Skip.
+          // But does not need to apply the count to clientCall.
+          _skipped.merge(skippedLocal, false);
+          // This is what has been asked for by the SubqueryEnd
+
+          auto& subqueryCall = stack.modifyTopCall();
+          subqueryCall.didSkip(skippedLocal.getSkipCount());
+        } else {
+          _skipped.merge(skippedLocal, true);
+        }
+        if constexpr (std::is_same_v<Executor, SubqueryStartExecutor>) {
+          // For the subqueryStart, we need to increment the SkipLevel by one
+          // as we may trigger this multiple times, check if we need to do it.
+          while (_skipped.subqueryDepth() < stack.subqueryLevel() + 1) {
+            // In fact, we only need to increase by 1
+            TRI_ASSERT(_skipped.subqueryDepth() == stack.subqueryLevel());
+            _skipped.incrementSubquery();
+          }
+        }
+
+        if (_lastRange.hasShadowRow() && !_lastRange.peekShadowRow().isRelevant()) {
+          _execState = ExecState::SHADOWROWS;
+        } else {
+          _execState = ExecState::CHECKCALL;
+        }
+        break;
+      }
+      case ExecState::SHADOWROWS: {
+        // We only get Called with something in the input.
+        TRI_ASSERT(_lastRange.hasShadowRow() || _lastRange.hasDataRow());
+        LOG_QUERY("7c63c", DEBUG)
+            << printTypeInfo() << " (sub-)query completed. Move ShadowRows.";
+
+        // TODO: Check if we can have the situation that we are between two shadow rows here.
+        // E.g. LastRow is relevant shadowRow. NextRow is non-relevant shadowRow.
+        // NOTE: I do not think this is an issue, as the Executor will always say that it cannot do anything with
+        // an empty input. Only exception might be COLLECT COUNT.
+
+        if (outputIsFull()) {
+          // We need to be able to write data
+          // But maybe the existing block is full here
+          // Then we need to wake up again here.
+          returnToState = ExecState::SHADOWROWS;
+          _execState = ExecState::DONE;
+          break;
+        }
+        if constexpr (std::is_same_v<Executor, SubqueryEndExecutor>) {
+          TRI_ASSERT(!stack.empty());
+          AqlCall const& subqueryCall = stack.peek();
+          AqlCall copyCall = subqueryCall;
+          ensureOutputBlock(std::move(copyCall), _lastRange);
+        } else {
+          ensureOutputBlock(std::move(clientCall), _lastRange);
+        }
+
+        TRI_ASSERT(!_outputItemRow->allRowsUsed());
+        if constexpr (executorHasSideEffects<Executor>) {
+          _execState = sideEffectShadowRowForwarding(stack, _skipped);
+        } else {
+          // This may write one or more rows.
+          _execState = shadowRowForwarding(stack);
+        }
+        if constexpr (!std::is_same_v<Executor, SubqueryEndExecutor>) {
+          // Produce might have modified the clientCall
+          // But only do this if we are not subquery.
+          clientCall = _outputItemRow->getClientCall();
+        }
+        break;
+      }
+      case ExecState::NEXTSUBQUERY: {
+        // This state will continue with the next run in the current subquery.
+        // For this executor the input of the next run will be injected and it can continue to work.
+        LOG_QUERY("0ca35", DEBUG)
+            << printTypeInfo() << " ShadowRows moved, continue with next subquery.";
+        if constexpr (std::is_same_v<Executor, SubqueryStartExecutor>) {
+          auto currentSubqueryCall = stack.peek();
+          if (currentSubqueryCall.getLimit() == 0 && currentSubqueryCall.hasSoftLimit()) {
+            // SoftLimitReached.
+            // We cannot continue.
+            _execState = ExecState::DONE;
+            break;
+          }
+          // Otherwise just check like the other blocks
+        }
+        if (!stack.hasAllValidCalls()) {
+          // We can only continue if we still have a valid call
+          // on all levels
+          _execState = ExecState::DONE;
+          break;
+        }
+
+        if (clientCallList.hasMoreCalls()) {
+          // Update to next call and start all over.
+          clientCall = clientCallList.popNextCall();
+          _execState = ExecState::CHECKCALL;
+        } else {
+          // We cannot continue, so we are done
+          _execState = ExecState::DONE;
+        }
+
+        break;
+      }
+      default:
+        // unreachable
+        TRI_ASSERT(false);
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_INTERNAL_AQL);
     }
-    // We must return skipped and/or data when reporting HASMORE
-    TRI_ASSERT(_upstreamState != ExecutionState::HASMORE ||
-               (!skipped.nothingSkipped() ||
-                (outputBlock != nullptr && outputBlock->numEntries() > 0)));
-    return {_upstreamState, skipped, std::move(outputBlock)};
-  } else {
-    // TODO this branch must never be taken with an executor that has not been
-    //      converted yet
-    TRI_ASSERT(false);
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
   }
+  LOG_QUERY("80c24", DEBUG) << printBlockInfo() << " local statemachine done. Return now.";
+  // If we do not have an output, we simply return a nullptr here.
+  auto outputBlock = _outputItemRow != nullptr ? _outputItemRow->stealBlock()
+                                               : SharedAqlItemBlockPtr{nullptr};
+  // We are locally done with our output.
+  // Next time we need to check the client call again
+  _execState = returnToState;
+  // This is not strictly necessary here, as we shouldn't be called again
+  // after DONE.
+  _outputItemRow.reset();
+
+  // We return skipped here, reset member
+  SkipResult skipped = _skipped;
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  if (!stack.is36Compatible()) {
+    if constexpr (std::is_same_v<Executor, SubqueryEndExecutor>) {
+      TRI_ASSERT(skipped.subqueryDepth() == stack.subqueryLevel() /*we inected a call*/);
+    } else {
+      TRI_ASSERT(skipped.subqueryDepth() == stack.subqueryLevel() + 1 /*we took our call*/);
+    }
+  }
+#endif
+  _skipped.reset();
+  if (localExecutorState == ExecutorState::HASMORE || _lastRange.hasDataRow() ||
+      _lastRange.hasShadowRow()) {
+    // We have skipped or/and return data, otherwise we cannot return HASMORE
+    TRI_ASSERT(!skipped.nothingSkipped() ||
+               (outputBlock != nullptr && outputBlock->numEntries() > 0));
+    return {ExecutionState::HASMORE, skipped, std::move(outputBlock)};
+  }
+  // We must return skipped and/or data when reporting HASMORE
+  TRI_ASSERT(_upstreamState != ExecutionState::HASMORE ||
+             (!skipped.nothingSkipped() ||
+              (outputBlock != nullptr && outputBlock->numEntries() > 0)));
+  return {_upstreamState, skipped, std::move(outputBlock)};
 }
 
 template <class Executor>

--- a/tests/Aql/ExecutionBlockImplTest.cpp
+++ b/tests/Aql/ExecutionBlockImplTest.cpp
@@ -28,7 +28,6 @@
 #include "AqlItemBlockHelper.h"
 #include "Mocks/Servers.h"
 #include "TestEmptyExecutorHelper.h"
-#include "TestExecutorHelper.h"
 #include "TestLambdaExecutor.h"
 #include "WaitingExecutionBlockMock.h"
 

--- a/tests/Aql/ExecutionBlockImplTestInstances.cpp
+++ b/tests/Aql/ExecutionBlockImplTestInstances.cpp
@@ -3,6 +3,5 @@
 #include "TestExecutorHelper.h"
 #include "TestLambdaExecutor.h"
 
-template class ::arangodb::aql::ExecutionBlockImpl<TestExecutorHelper>;
 template class ::arangodb::aql::ExecutionBlockImpl<TestLambdaExecutor>;
 template class ::arangodb::aql::ExecutionBlockImpl<TestLambdaSkipExecutor>;

--- a/tests/Aql/SplicedSubqueryIntegrationTest.cpp
+++ b/tests/Aql/SplicedSubqueryIntegrationTest.cpp
@@ -25,7 +25,6 @@
 #include "AqlItemBlockHelper.h"
 #include "Mocks/Servers.h"
 #include "TestEmptyExecutorHelper.h"
-#include "TestExecutorHelper.h"
 #include "TestLambdaExecutor.h"
 #include "WaitingExecutionBlockMock.h"
 #include "fakeit.hpp"


### PR DESCRIPTION
Removes the `constexpr` case distinction for new style vs old style executors