### PR TITLE
Specialize Identifier::empty() and related methods

### DIFF
--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -387,6 +387,8 @@ set(LIB_ARANGO_VOCBASE_SOURCES
   Utils/DatabaseGuard.cpp
   Utils/SingleCollectionTransaction.cpp
   VocBase/Identifiers/IndexId.cpp
+  VocBase/Identifiers/LocalDocumentId.cpp
+  VocBase/Identifiers/ServerId.cpp
   VocBase/Methods/AqlUserFunctions.cpp
   VocBase/Methods/Collections.cpp
   VocBase/Methods/Databases.cpp

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -2946,7 +2946,7 @@ Result ClusterInfo::ensureIndexCoordinator(LogicalCollection const& collection,
     iid = IndexId{arangodb::basics::StringUtils::uint64(idSlice.copyString())};
   }
 
-  if (iid.isNone()) {  // no id set, create a new one!
+  if (iid.empty()) {  // no id set, create a new one!
     iid = IndexId{uniqid()};
   }
 

--- a/arangod/ClusterEngine/ClusterCollection.cpp
+++ b/arangod/ClusterEngine/ClusterCollection.cpp
@@ -283,8 +283,7 @@ std::shared_ptr<Index> ClusterCollection::createIndex(arangodb::velocypack::Slic
 /// @brief Drop an index with the given iid.
 bool ClusterCollection::dropIndex(IndexId iid) {
   // usually always called when _exclusiveLock is held
-  if (iid.isPrimary() || iid.isNone()) {
-    // invalid index id or primary index
+  if (iid.empty() || iid.isPrimary()) {
     return true;
   }
 

--- a/arangod/Indexes/IndexFactory.cpp
+++ b/arangod/Indexes/IndexFactory.cpp
@@ -328,7 +328,7 @@ IndexId IndexFactory::validateSlice(arangodb::velocypack::Slice info,
         TRI_ERROR_INTERNAL, "cannot restore index without index identifier");
   }
 
-  if (iid.isNone() && !isClusterConstructor) {
+  if (iid.empty() && !isClusterConstructor) {
     // Restore is not allowed to generate an id
     VPackSlice type = info.get(StaticStrings::IndexType);
     // dont generate ids for indexes of type "primary"

--- a/arangod/Replication/Syncer.cpp
+++ b/arangod/Replication/Syncer.cpp
@@ -807,7 +807,7 @@ void Syncer::createIndexInternal(VPackSlice const& idxDef, LogicalCollection& co
     std::string name;  // placeholder for now
     CollectionNameResolver resolver(col.vocbase());
     Result res = methods::Indexes::extractHandle(&col, &resolver, idxDef, iid, name);
-    if (res.ok() && !iid.isNone()) {
+    if (res.ok() && iid.isSet()) {
       // lookup by id
       auto byId = physical->lookupIndex(iid);
       auto byDef = physical->lookupIndex(idxDef);

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -938,8 +938,7 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice const& info,
 /// @brief Drop an index with the given iid.
 bool RocksDBCollection::dropIndex(IndexId iid) {
   // usually always called when _exclusiveLock is held
-  if (iid.isPrimary() || iid.isNone()) {
-    // invalid index id or primary index
+  if (iid.empty() || iid.isPrimary()) {
     return true;
   }
 
@@ -1231,7 +1230,7 @@ Result RocksDBCollection::truncate(transaction::Methods& trx, OperationOptions& 
 Result RocksDBCollection::lookupKey(transaction::Methods* trx,
                                     VPackStringRef key,
                                     std::pair<LocalDocumentId, TRI_voc_rid_t>& result) const {
-  result.first.clear();
+  result.first = LocalDocumentId::none();
   result.second = 0;
   
   // lookup the revision id in the primary index

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
@@ -549,7 +549,7 @@ bool RocksDBPrimaryIndex::lookupRevision(transaction::Methods* trx,
                                          arangodb::velocypack::StringRef keyRef,
                                          LocalDocumentId& documentId,
                                          TRI_voc_rid_t& revisionId) const {
-  documentId.clear();
+  documentId = LocalDocumentId::none();
   revisionId = 0;
 
   RocksDBKeyLeaser key(trx);

--- a/arangod/VocBase/Identifiers/IndexId.cpp
+++ b/arangod/VocBase/Identifiers/IndexId.cpp
@@ -25,9 +25,13 @@
 
 namespace arangodb {
 
-bool IndexId::isNone() const {
-  return id() == std::numeric_limits<BaseType>::max();
+/// @brief whether or not the id is set (not none())
+bool IndexId::isSet() const noexcept {
+  return id() != std::numeric_limits<BaseType>::max();
 }
+
+/// @brief whether or not the identifier is unset (equal to none())
+bool IndexId::empty() const noexcept { return !isSet(); }
 
 bool IndexId::isPrimary() const { return id() == 0; }
 

--- a/arangod/VocBase/Identifiers/IndexId.h
+++ b/arangod/VocBase/Identifiers/IndexId.h
@@ -36,7 +36,12 @@ class IndexId : public arangodb::basics::Identifier {
   constexpr explicit IndexId(BaseType id) noexcept : Identifier(id) {}
 
  public:
-  bool isNone() const;
+  /// @brief whether or not the id is set (not none())
+  bool isSet() const noexcept;
+
+  /// @brief whether or not the identifier is unset (equal to none())
+  bool empty() const noexcept;
+
   bool isPrimary() const;
   bool isEdge() const;
 
@@ -49,14 +54,11 @@ class IndexId : public arangodb::basics::Identifier {
   /// @brief create an id for a primary index
   static constexpr IndexId primary() { return IndexId{0}; }
 
-  /// @brief create an id for an edge _from index (rocksdb)
+  /// @brief create an id for an edge _from index
   static constexpr IndexId edgeFrom() { return IndexId{1}; }
 
-  /// @brief create an id for an edge _to index (rocksdb)
+  /// @brief create an id for an edge _to index
   static constexpr IndexId edgeTo() { return IndexId{2}; }
-
-  /// @brief create an id for an edge index (mmfiles)
-  static constexpr IndexId edge() { return IndexId{1}; }
 };
 
 static_assert(sizeof(IndexId) == sizeof(IndexId::BaseType),

--- a/arangod/VocBase/Identifiers/LocalDocumentId.cpp
+++ b/arangod/VocBase/Identifiers/LocalDocumentId.cpp
@@ -21,34 +21,12 @@
 /// @author Dan Larkin-York
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef ARANGOD_VOCBASE_IDENTIFIERS_SERVER_ID_H
-#define ARANGOD_VOCBASE_IDENTIFIERS_SERVER_ID_H 1
-
-#include "Basics/Identifier.h"
+#include "VocBase/Identifiers/LocalDocumentId.h"
 
 namespace arangodb {
 
-/// @brief server id type
-class ServerId : public arangodb::basics::Identifier {
- public:
-  constexpr ServerId() noexcept : Identifier() {}
-  constexpr explicit ServerId(BaseType id) noexcept : Identifier(id) {}
+bool LocalDocumentId::isSet() const noexcept { return id() != 0; }
 
-  /// @brief whether or not the id is set (not 0)
-  bool isSet() const noexcept;
+bool LocalDocumentId::empty() const noexcept { return !isSet(); }
 
-  /// @brief whether or not the identifier is unset (equal to 0)
-  bool empty() const noexcept;
-
- public:
-  /// @brief create a not-set file id
-  static constexpr ServerId none() { return ServerId{0}; }
-};
-
-static_assert(sizeof(ServerId) == sizeof(ServerId::BaseType),
-              "invalid size of ServerId");
 }  // namespace arangodb
-
-DECLARE_HASH_FOR_IDENTIFIER(arangodb::ServerId)
-
-#endif

--- a/arangod/VocBase/Identifiers/LocalDocumentId.h
+++ b/arangod/VocBase/Identifiers/LocalDocumentId.h
@@ -36,6 +36,12 @@ class LocalDocumentId : public basics::Identifier {
   constexpr LocalDocumentId() noexcept : Identifier() {}
   constexpr explicit LocalDocumentId(BaseType id) noexcept : Identifier(id) {}
 
+  /// @brief whether or not the id is set (not 0)
+  bool isSet() const noexcept;
+
+  /// @brief whether or not the identifier is unset (equal to 0)
+  bool empty() const noexcept;
+
  public:
   /// @brief create a not-set document id
   static constexpr LocalDocumentId none() { return LocalDocumentId(0); }

--- a/arangod/VocBase/Identifiers/ServerId.cpp
+++ b/arangod/VocBase/Identifiers/ServerId.cpp
@@ -21,34 +21,12 @@
 /// @author Dan Larkin-York
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef ARANGOD_VOCBASE_IDENTIFIERS_SERVER_ID_H
-#define ARANGOD_VOCBASE_IDENTIFIERS_SERVER_ID_H 1
-
-#include "Basics/Identifier.h"
+#include "VocBase/Identifiers/ServerId.h"
 
 namespace arangodb {
 
-/// @brief server id type
-class ServerId : public arangodb::basics::Identifier {
- public:
-  constexpr ServerId() noexcept : Identifier() {}
-  constexpr explicit ServerId(BaseType id) noexcept : Identifier(id) {}
+bool ServerId::isSet() const noexcept { return id() != 0; }
 
-  /// @brief whether or not the id is set (not 0)
-  bool isSet() const noexcept;
+bool ServerId::empty() const noexcept { return !isSet(); }
 
-  /// @brief whether or not the identifier is unset (equal to 0)
-  bool empty() const noexcept;
-
- public:
-  /// @brief create a not-set file id
-  static constexpr ServerId none() { return ServerId{0}; }
-};
-
-static_assert(sizeof(ServerId) == sizeof(ServerId::BaseType),
-              "invalid size of ServerId");
 }  // namespace arangodb
-
-DECLARE_HASH_FOR_IDENTIFIER(arangodb::ServerId)
-
-#endif

--- a/arangod/VocBase/Methods/Indexes.cpp
+++ b/arangod/VocBase/Methods/Indexes.cpp
@@ -508,7 +508,7 @@ arangodb::Result Indexes::createIndex(LogicalCollection* coll, Index::IndexType 
 static bool ExtractIndexHandle(VPackSlice const& arg,
                                std::string& collectionName, IndexId& iid) {
   TRI_ASSERT(collectionName.empty());
-  TRI_ASSERT(iid.isNone());
+  TRI_ASSERT(iid.empty());
 
   if (arg.isNumber()) {
     // numeric index id
@@ -629,7 +629,7 @@ arangodb::Result Indexes::drop(LogicalCollection* collection, VPackSlice const& 
       return res;
     }
 
-    if (iid.isNone() && !name.empty()) {
+    if (iid.empty() && !name.empty()) {
       VPackBuilder builder;
       res = methods::Indexes::getIndex(collection, indexArg, builder, trx);
       if (!res.ok()) {
@@ -692,7 +692,7 @@ arangodb::Result Indexes::drop(LogicalCollection* collection, VPackSlice const& 
     }
 
     std::shared_ptr<Index> idx = collection->lookupIndex(iid);
-    if (!idx || idx->id().isNone() || idx->id().isPrimary()) {
+    if (!idx || idx->id().empty() || idx->id().isPrimary()) {
       events::DropIndex(collection->vocbase().name(), collection->name(),
                         std::to_string(iid.id()), TRI_ERROR_ARANGO_INDEX_NOT_FOUND);
       return Result(TRI_ERROR_ARANGO_INDEX_NOT_FOUND);

--- a/lib/Basics/Identifier.cpp
+++ b/lib/Basics/Identifier.cpp
@@ -28,10 +28,6 @@
 
 namespace arangodb::basics {
 
-bool Identifier::isSet() const noexcept { return _id != 0; }
-
-bool Identifier::empty() const noexcept { return !isSet(); }
-
 Identifier::BaseType Identifier::id() const noexcept { return _id; }
 
 Identifier::BaseType const* Identifier::data() const noexcept { return &_id; }
@@ -61,8 +57,6 @@ bool Identifier::operator>(Identifier const& other) const {
 bool Identifier::operator>=(Identifier const& other) const {
   return _id >= other._id;
 }
-
-void Identifier::clear() { _id = 0; }
 
 }  // namespace arangodb::basics
 

--- a/lib/Basics/Identifier.h
+++ b/lib/Basics/Identifier.h
@@ -44,12 +44,6 @@ class Identifier {
   Identifier(Identifier&& other) noexcept = default;
   Identifier& operator=(Identifier&& other) noexcept = default;
 
-  /// @brief whether or not the id is set (not 0)
-  bool isSet() const noexcept;
-
-  /// @brief whether or not the identifier is unset (equal to 0)
-  bool empty() const noexcept;
-
   /// @brief return the document id
   BaseType id() const noexcept;
 
@@ -76,9 +70,6 @@ class Identifier {
 
   /// @brief check if this identifier is at least another
   bool operator>=(Identifier const& other) const;
-
-  /// @brief unset the identifier (set to 0)
-  void clear();
 
  private:
   BaseType _id;

--- a/tests/IResearch/IResearchLinkCoordinator-test.cpp
+++ b/tests/IResearch/IResearchLinkCoordinator-test.cpp
@@ -134,7 +134,7 @@ TEST_F(IResearchLinkCoordinatorTest, test_create_drop) {
     auto json = arangodb::velocypack::Parser::fromJson("{}");
     try {
       factory.instantiate(*logicalCollection.get(), json->slice(),
-                          arangodb::IndexId::edge(), true);
+                          arangodb::IndexId::edgeFrom(), true);
       EXPECT_TRUE(false);
     } catch (arangodb::basics::Exception const& ex) {
       EXPECT_EQ(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, ex.code());

--- a/tests/Mocks/StorageEngineMock.cpp
+++ b/tests/Mocks/StorageEngineMock.cpp
@@ -1176,7 +1176,7 @@ arangodb::Result PhysicalCollectionMock::lookupKey(
     }
   }
 
-  result.first.clear();
+  result.first = arangodb::LocalDocumentId::none();
   result.second = 0;
   return arangodb::Result(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND);
 }


### PR DESCRIPTION
### Scope & Purpose

Currently the `Identifier` class has `isSet()` and `empty()` methods which assume that `0` is an invalid identifier for all derived types. At least `IndexId` uses `0` for primary indices, which causes some confusion and requires a weird workaround. This PR removes the `empty()` and `isSet()` methods from `Identifier` and moves them to the derived classes. It also removes the `clear()` method, as it also makes this assumption (replacing uses with `= [DerivedType]::none()` instead), and removes `IndexId::isNone()` as it is no longer necessary.

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)

Enterprise component: https://github.com/arangodb/enterprise/pull/432

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.