### PR TITLE
show index details in web UI

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Show some index details in index overview of the web interface, e.g. the 
+  `minLength` attribute for fulltext indexes or the `expireAfter` attribute for
+  TTL indexes.
+
 * Added startup option `--server.validate-utf8-strings`.
 
   This option controls whether strings in incoming JSON or VPack requests are

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/templates/indicesView.html
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/templates/indicesView.html
@@ -8,7 +8,7 @@
                 <th class="collectionInfoTh">Type</th>
                 <th class="collectionInfoTh">Unique</th>
                 <th class="collectionInfoTh">Sparse</th>
-                <th class="collectionInfoTh">Deduplicate</th>
+                <th class="collectionInfoTh">Extras</th>
                 <th class="collectionInfoTh">Selectivity Est.</th>
                 <th class="collectionInfoTh">Fields</th>
                 <th class="collectionInfoTh">Name</th>

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/indicesView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/indicesView.js
@@ -434,7 +434,12 @@
               : 'n/a'
           );
           var sparse = (v.hasOwnProperty('sparse') ? v.sparse : 'n/a');
-          var deduplicate = (v.hasOwnProperty('deduplicate') ? v.deduplicate : 'n/a');
+          var extras = [];
+          ["deduplicate", "expireAfter", "minLength"].forEach(function(k) {
+            if (v.hasOwnProperty(k)) {
+              extras.push(k + ": " + v[k]);
+            }
+          });
 
           $('#collectionEditIndexTable').append(
             '<tr>' +
@@ -442,7 +447,7 @@
             '<th class=' + JSON.stringify(cssClass) + '>' + arangoHelper.escapeHtml(v.type) + '</th>' +
             '<th class=' + JSON.stringify(cssClass) + '>' + arangoHelper.escapeHtml(v.unique) + '</th>' +
             '<th class=' + JSON.stringify(cssClass) + '>' + arangoHelper.escapeHtml(sparse) + '</th>' +
-            '<th class=' + JSON.stringify(cssClass) + '>' + arangoHelper.escapeHtml(deduplicate) + '</th>' +
+            '<th class=' + JSON.stringify(cssClass) + '>' + arangoHelper.escapeHtml(extras.join(", ")) + '</th>' +
             '<th class=' + JSON.stringify(cssClass) + '>' + arangoHelper.escapeHtml(selectivity) + '</th>' +
             '<th class=' + JSON.stringify(cssClass) + '>' + arangoHelper.escapeHtml(fieldString) + '</th>' +
             '<th class=' + JSON.stringify(cssClass) + '>' + arangoHelper.escapeHtml(v.name) + '</th>' +


### PR DESCRIPTION
### Scope & Purpose

Show index details in index overview of the web UI, e.g. the `expireAfter` attribute for TTL indexes or the `minLength` attribute for fulltext indexes

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9456/