### PR TITLE
fix graph creation with min-replication-factor set

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fix creation of example graphs when `--cluster.min-replication-factor` is set
+  and no replication factor was specified for a graph. In this case, the new
+  graph will use the configured minimum replication factor.
+
 * Show some index details in index overview of the web interface, e.g. the 
   `minLength` attribute for fulltext indexes or the `expireAfter` attribute for
   TTL indexes.

--- a/arangod/Graph/Graph.cpp
+++ b/arangod/Graph/Graph.cpp
@@ -37,6 +37,7 @@
 #include "Basics/StaticStrings.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/WriteLocker.h"
+#include "Cluster/ClusterFeature.h"
 #include "Cluster/ServerState.h"
 #include "Transaction/Methods.h"
 #include "Transaction/StandaloneContext.h"
@@ -44,10 +45,20 @@
 #include "Utils/SingleCollectionTransaction.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/Methods/Collections.h"
+#include "VocBase/vocbase.h"
 
 using namespace arangodb;
 using namespace arangodb::graph;
 using Helper = arangodb::basics::VelocyPackHelper;
+
+namespace {
+size_t getWriteConcern(VPackSlice slice) {
+  if (slice.hasKey(StaticStrings::WriteConcern)) {
+    return Helper::getNumericValue<uint64_t>(slice, StaticStrings::WriteConcern, 1);
+  }
+  return Helper::getNumericValue<uint64_t>(slice, StaticStrings::MinReplicationFactor, 1);
+}
+}  // namespace
 
 #ifndef USE_ENTERPRISE
 // Factory methods
@@ -59,29 +70,20 @@ std::unique_ptr<Graph> Graph::fromPersistence(VPackSlice document, TRI_vocbase_t
   return result;
 }
 
-std::unique_ptr<Graph> Graph::fromUserInput(std::string&& name, VPackSlice document,
+std::unique_ptr<Graph> Graph::fromUserInput(TRI_vocbase_t& vocbase, std::string&& name, VPackSlice document,
                                             VPackSlice options) {
   if (document.isExternal()) {
     document = document.resolveExternal();
   }
-  std::unique_ptr<Graph> result{new Graph{std::move(name), document, options}};
+  std::unique_ptr<Graph> result{new Graph{vocbase, std::move(name), document, options}};
   return result;
 }
 #endif
 
-std::unique_ptr<Graph> Graph::fromUserInput(std::string const& name,
+std::unique_ptr<Graph> Graph::fromUserInput(TRI_vocbase_t& vocbase, std::string const& name,
                                             VPackSlice document, VPackSlice options) {
-  return Graph::fromUserInput(std::string{name}, document, options);
+  return Graph::fromUserInput(vocbase, std::string{name}, document, options);
 }
-
-namespace {
-size_t getWriteConcern(VPackSlice slice) {
-  if (slice.hasKey(StaticStrings::WriteConcern)) {
-    return Helper::getNumericValue<uint64_t>(slice, StaticStrings::WriteConcern, 1);
-  }
-  return Helper::getNumericValue<uint64_t>(slice, StaticStrings::MinReplicationFactor, 1);
-}
-}  // namespace
 
 // From persistence
 Graph::Graph(velocypack::Slice const& slice)
@@ -95,14 +97,14 @@ Graph::Graph(velocypack::Slice const& slice)
       _rev(Helper::getStringValue(slice, StaticStrings::RevString, "")),
       _isSatellite(Helper::getStringRef(slice, StaticStrings::ReplicationFactor,
                                         velocypack::StringRef("")) == StaticStrings::Satellite) {
-  // If this happens we have a document without an _key Attribute.
+  // If this happens we have a document without a _key attribute.
   if (_graphName.empty()) {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
                                    "Persisted graph is invalid. It does not "
                                    "have a _key set. Please contact support.");
   }
 
-  // If this happens we have a document without an _rev Attribute.
+  // If this happens we have a document without a _rev attribute.
   if (_rev.empty()) {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
                                    "Persisted graph is invalid. It does not "
@@ -128,12 +130,12 @@ Graph::Graph(velocypack::Slice const& slice)
 }
 
 // From user input
-Graph::Graph(std::string&& graphName, VPackSlice const& info, VPackSlice const& options)
-    : _graphName(graphName),
+Graph::Graph(TRI_vocbase_t& vocbase, std::string&& graphName, VPackSlice const& info, VPackSlice const& options)
+    : _graphName(std::move(graphName)),
       _vertexColls(),
       _edgeColls(),
       _numberOfShards(1),
-      _replicationFactor(1),
+      _replicationFactor(vocbase.replicationFactor()),
       _writeConcern(1),
       _rev("") {
   if (_graphName.empty()) {
@@ -156,7 +158,7 @@ Graph::Graph(std::string&& graphName, VPackSlice const& info, VPackSlice const& 
       setReplicationFactor(0);
     } else {
       _replicationFactor =
-          Helper::getNumericValue<uint64_t>(options, StaticStrings::ReplicationFactor, 1);
+          Helper::getNumericValue<uint64_t>(options, StaticStrings::ReplicationFactor, _replicationFactor);
       if (_replicationFactor < 1) {
         THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
                                        StaticStrings::ReplicationFactor +

--- a/arangod/Graph/Graph.cpp
+++ b/arangod/Graph/Graph.cpp
@@ -37,7 +37,6 @@
 #include "Basics/StaticStrings.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/WriteLocker.h"
-#include "Cluster/ClusterFeature.h"
 #include "Cluster/ServerState.h"
 #include "Transaction/Methods.h"
 #include "Transaction/StandaloneContext.h"

--- a/arangod/Graph/Graph.h
+++ b/arangod/Graph/Graph.h
@@ -24,7 +24,6 @@
 #define ARANGOD_GRAPH_GRAPH_H
 
 #include <velocypack/Buffer.h>
-#include <chrono>
 #include <utility>
 #include <set>
 
@@ -36,6 +35,8 @@
 #include "Transaction/Methods.h"
 #include "Transaction/StandaloneContext.h"
 #include "Utils/OperationResult.h"
+
+struct TRI_vocbase_t;
 
 namespace arangodb {
 namespace graph {
@@ -106,12 +107,14 @@ class Graph {
    *
    * @return A graph object corresponding to the user input
    */
-  static std::unique_ptr<Graph> fromUserInput(std::string&& name,
+  static std::unique_ptr<Graph> fromUserInput(TRI_vocbase_t& vocbase, 
+                                              std::string&& name,
                                               velocypack::Slice collectionInformation,
                                               velocypack::Slice options);
 
   // Wrapper for Move constructor
-  static std::unique_ptr<Graph> fromUserInput(std::string const& name,
+  static std::unique_ptr<Graph> fromUserInput(TRI_vocbase_t& vocbase,
+                                              std::string const& name,
                                               velocypack::Slice collectionInformation,
                                               velocypack::Slice options);
 
@@ -130,7 +133,7 @@ class Graph {
    * @param info Collection information, including relations and orphans
    * @param options The options to be used for collections
    */
-  Graph(std::string&& graphName, velocypack::Slice const& info,
+  Graph(TRI_vocbase_t& vocbase, std::string&& graphName, velocypack::Slice const& info,
         velocypack::Slice const& options);
 
   /**

--- a/arangod/Graph/GraphManager.cpp
+++ b/arangod/Graph/GraphManager.cpp
@@ -1021,7 +1021,7 @@ ResultT<std::unique_ptr<Graph>> GraphManager::buildGraphFromInput(std::string co
         return res;
       }
     }
-    return Graph::fromUserInput(graphName, input, input.get(StaticStrings::GraphOptions));
+    return Graph::fromUserInput(_vocbase, graphName, input, input.get(StaticStrings::GraphOptions));
   } catch (arangodb::basics::Exception const& e) {
     return Result{e.code(), e.message()};
   } catch (...) {

--- a/js/common/modules/@arangodb/general-graph-common.js
+++ b/js/common/modules/@arangodb/general-graph-common.js
@@ -1839,8 +1839,8 @@ exports._create = function (graphName, edgeDefinitions, orphanCollections, optio
     'orphanCollections': orphanCollections,
     'edgeDefinitions': edgeDefinitions,
     '_key': graphName,
-    'numberOfShards': options.numberOfShards || 1,
-    'replicationFactor': options.replicationFactor || 1,
+    'numberOfShards': options.numberOfShards || undefined,
+    'replicationFactor': options.replicationFactor || undefined,
   }, options);
   data.orphanCollections = orphanCollections;
   data.edgeDefinitions = edgeDefinitions;

--- a/tests/js/client/server_parameters/test-sharding-restrictions-cluster.js
+++ b/tests/js/client/server_parameters/test-sharding-restrictions-cluster.js
@@ -101,6 +101,51 @@ function testSuite() {
       let props = c.properties();
       assertEqual(4, props.replicationFactor);
     },
+
+    testCreateGraph : function() {
+      const graph = require("@arangodb/general-graph");
+      const vn = "UnitTestVertices";
+      const en = "UnitTestEdges";
+      const gn = "UnitTestGraph";
+      const edgeDef = [graph._relation(en, vn, vn)];
+      try {
+        graph._drop(gn, true);
+      } catch (err) {}
+
+      let myGraph = graph._create(gn, edgeDef, null, {});
+      try {
+        let props = db[vn].properties();
+        assertEqual(2, props.replicationFactor);
+        props = db[en].properties();
+        assertEqual(2, props.replicationFactor);
+      } finally {
+        graph._drop(gn, true);
+      }
+    },
+    
+    testCreateSmartGraph : function() {
+      if (!require("internal").isEnterprise()) {
+        return;
+      }
+      const smrt = require("@arangodb/smart-graph");
+      const vn = "UnitTestVertices";
+      const en = "UnitTestEdges";
+      const gn = "UnitTestGraph";
+      const edgeDef = [smrt._relation(en, vn, vn)];
+      try {
+        smrt._drop(gn, true);
+      } catch (err) {}
+
+      let myGraph = smrt._create(gn, edgeDef, null, {smartGraphAttribute: "value"});
+      try {
+        let props = db[vn].properties();
+        assertEqual(2, props.replicationFactor);
+        props = db[en].properties();
+        assertEqual(2, props.replicationFactor);
+      } finally {
+        smrt._drop(gn, true);
+      }
+    },
     
   };
 }


### PR DESCRIPTION
### Scope & Purpose

Fix example graph creation with `--cluster.min-replication-factor` set to > 1.
In case the startup option was used, example graphs were created with a replicationFactor value of 1, violating the requirements. Now, the default replication factor for the target database will be used.

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/434

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest server_parameters*.

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9460/