### PR TITLE
Fix for 'docs out of order' error (internal issue #686)

### DIFF
--- a/3rdParty/iresearch/core/index/merge_writer.cpp
+++ b/3rdParty/iresearch/core/index/merge_writer.cpp
@@ -396,7 +396,14 @@ class sorting_compound_doc_iterator : public irs::doc_iterator {
     // advance
     bool operator()(const size_t i) const {
       assert(i < itrs_.get().size());
-      return itrs_.get()[i].first->next();
+      auto& doc_it = itrs_.get()[i];
+      auto const& map = *doc_it.second;
+      while (doc_it.first->next()) {
+        if (!irs::doc_limits::eof(map(doc_it.first->value()))) {
+          return true;
+        }
+      }
+      return false;
     }
 
     // compare

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.5.5 (XXXX-XX-XX)
 -------------------
 
+* Fixed issue #686 'docs out of order' error while ArangoSearch consolidation
+
 * Updated OpenSSL to 1.1.1f.
 
 * Don't invoke collection key ranges compaction after performing a truncate


### PR DESCRIPTION
Backport fix from upstream.
Verified by upstream tests.

https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/9481/