### PR TITLE
Supported STARTS_WITH with several prefixes

### DIFF
--- a/3rdParty/iresearch/tests/search/boolean_filter_tests.cpp
+++ b/3rdParty/iresearch/tests/search/boolean_filter_tests.cpp
@@ -7248,9 +7248,8 @@ TEST_P(boolean_filter_test_case, or_sequential) {
   // empty query
   {
     check_query(irs::Or(), docs_t{}, rdr);
-  }
+  } 
 
-  // name=V
   {
     irs::Or root;
     root.add<irs::by_term>().field("name").term("V"); // 22
@@ -7323,6 +7322,43 @@ TEST_P(boolean_filter_test_case, or_sequential) {
       docs_t{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32 },
       rdr
     );
+  }
+
+  // min match count == 0
+  {
+    irs::Or root;
+    root.min_match_count(0);
+    append<irs::by_term>(root, "name", "V"); // 22
+
+    check_query(
+      root,
+      docs_t{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32 },
+      rdr);
+  }
+
+  // min match count == 0
+  {
+    irs::Or root;
+    root.min_match_count(0);
+
+    check_query(
+      root,
+      docs_t{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32 },
+      rdr
+    );
+  }
+
+  // min match count is geater than a number of conditions
+  {
+    irs::Or root;
+    append<irs::by_term>(root, "name", "A"); // 1
+    append<irs::by_term>(root, "name", "Q"); // 17
+    append<irs::by_term>(root, "name", "Z"); // 26
+    append<irs::by_term>(root, "same", "xyz"); // 1..32
+    append<irs::by_term>(root, "same", "invalid_term");
+    root.min_match_count(root.size()+1);
+
+    check_query(root, docs_t{ }, rdr);
   }
 
   // name=A OR false
@@ -8302,7 +8338,3 @@ INSTANTIATE_TEST_CASE_P(
 );
 
 NS_END // tests
-
-// -----------------------------------------------------------------------------
-// --SECTION--                                                       END-OF-FILE
-// -----------------------------------------------------------------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Allow STARTS_WITH function to process several prefixes with min match count parameter.
+
 * Fix creation of example graphs when `--cluster.min-replication-factor` is set
   and no replication factor was specified for a graph. In this case, the new
   graph will use the configured minimum replication factor.

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -44,6 +44,7 @@
 #include "IResearch/Containers.h"
 #include "IResearch/IResearchCommon.h"
 #include "IResearch/IResearchFeature.h"
+#include "IResearch/IResearchFilterFactory.h"
 #include "IResearch/IResearchLinkCoordinator.h"
 #include "IResearch/IResearchLinkHelper.h"
 #include "IResearch/IResearchRocksDBLink.h"
@@ -109,6 +110,17 @@ arangodb::aql::AqlValue contextFunc(arangodb::aql::ExpressionContext*,
   return args[0];
 }
 
+/// Check whether prefix is a value prefix
+inline bool isPrefix(arangodb::velocypack::StringRef const& prefix, arangodb::velocypack::StringRef const& value) {
+  return prefix.size() <= value.size() && value.substr(0, prefix.size()) == prefix;
+}
+
+/// Register invalid argument warning
+inline arangodb::aql::AqlValue errorAqlValue(arangodb::aql::ExpressionContext* ctx, char const* afn) {
+  arangodb::aql::registerInvalidArgumentWarning(ctx, afn);
+  return arangodb::aql::AqlValue{arangodb::aql::AqlValueHintNull{}};
+}
+
 /// Executes STARTS_WITH function with const parameters locally the same way
 /// it will be done in ArangoSearch at runtime
 /// This will allow optimize out STARTS_WITH call if all arguments are const
@@ -117,27 +129,59 @@ arangodb::aql::AqlValue startsWithFunc(arangodb::aql::ExpressionContext* ctx,
                                        arangodb::containers::SmallVector<arangodb::aql::AqlValue> const& args) {
   static char const* AFN = "STARTS_WITH";
 
-  TRI_ASSERT(args.size() >= 2); // ensured by function signature
+  auto const argc = args.size();
+  TRI_ASSERT(argc >= 2 && argc <= 4); // ensured by function signature
   auto& value = args[0];
 
-  if (ADB_UNLIKELY(!value.isString())) {
-    arangodb::aql::registerInvalidArgumentWarning(ctx, AFN);
-    return arangodb::aql::AqlValue{arangodb::aql::AqlValueHintNull{}};
+  if (!value.isString()) {
+    return errorAqlValue(ctx, AFN);
   }
-
-  auto& prefix = args[1];
-
-  if (ADB_UNLIKELY(!prefix.isString())) {
-    arangodb::aql::registerInvalidArgumentWarning(ctx, AFN);
-    return arangodb::aql::AqlValue{arangodb::aql::AqlValueHintNull{}};
-  }
-
   auto const valueRef = value.slice().stringRef();
-  auto const prefixRef = prefix.slice().stringRef();
 
-  bool const result = prefixRef.size() <= valueRef.size() &&
-                      valueRef.substr(0, prefixRef.size()) == prefixRef;
+  auto result = false;
 
+  auto& prefixes = args[1];
+  if (prefixes.isArray()) {
+    auto const size = static_cast<int64_t>(prefixes.length());
+    if (0 == size) { // empty prefix
+      result = true;
+    } else {
+      int64_t minMatchCount = arangodb::iresearch::FilterConstants::DefaultStartsWithMinMatchCount;
+      if (argc > 2) {
+        auto& minMatchCountValue = args[2];
+        if (!minMatchCountValue.isNumber()) {
+          return errorAqlValue(ctx, AFN);
+        }
+        minMatchCount = minMatchCountValue.toInt64();
+        if (minMatchCount < 0) {
+          return errorAqlValue(ctx, AFN);
+        }
+        if (0 == minMatchCount) {
+          result = true;
+        }
+      }
+      if (minMatchCount > 0 && minMatchCount <= size) {
+        int64_t matchedCount = 0;
+        for (int64_t i = 0; i < size; ++i) {
+          auto mustDestroy = false;
+          auto prefix = prefixes.at(i, mustDestroy, false);
+          arangodb::aql::AqlValueGuard guard{prefix, mustDestroy};
+          if (!prefix.isString()) {
+            return errorAqlValue(ctx, AFN);
+          }
+          if (isPrefix(prefix.slice().stringRef(), valueRef) && ++matchedCount == minMatchCount) {
+            result = true;
+            break;
+          }
+        }
+      }
+    }
+  } else {
+    if (!prefixes.isString()) {
+      return errorAqlValue(ctx, AFN);
+    }
+    result = isPrefix(prefixes.slice().stringRef(), valueRef);
+  }
   return arangodb::aql::AqlValue{arangodb::aql::AqlValueHintBool{result}};
 }
 
@@ -152,8 +196,7 @@ arangodb::aql::AqlValue minMatchFunc(arangodb::aql::ExpressionContext* ctx,
   TRI_ASSERT(args.size() > 1); // ensured by function signature
   auto& minMatchValue = args.back();
   if (ADB_UNLIKELY(!minMatchValue.isNumber())) {
-    arangodb::aql::registerInvalidArgumentWarning(ctx, AFN);
-    return arangodb::aql::AqlValue{arangodb::aql::AqlValueHintNull{}};
+    return errorAqlValue(ctx, AFN);
   }
 
   auto matchesLeft = minMatchValue.toInt64();
@@ -398,7 +441,7 @@ void registerFilters(arangodb::aql::AqlFunctionFeature& functions) {
                                          arangodb::aql::Function::Flags::Cacheable,
                                          arangodb::aql::Function::Flags::CanRunOnDBServer);
   addFunction(functions, { "EXISTS", ".|.,.", flags, &dummyFilterFunc });  // (attribute, [ // "analyzer"|"type"|"string"|"numeric"|"bool"|"null" // ])
-  addFunction(functions, { "STARTS_WITH", ".,.|.", flags, &startsWithFunc });  // (attribute, prefix, scoring-limit)
+  addFunction(functions, { "STARTS_WITH", ".,.|.,.", flags, &startsWithFunc });  // (attribute, [ '[' ] prefix [, prefix, ... ']' ] [, scoring-limit|min-match-count ] [, scoring-limit ])
   addFunction(functions, { "PHRASE", ".,.|.+", flags, &dummyFilterFunc });  // (attribute, input [, offset, input... ] [, analyzer])
   addFunction(functions, { "MIN_MATCH", ".,.|.+", flags, &minMatchFunc });  // (filter expression [, filter expression, ... ], min match count)
   addFunction(functions, { "BOOST", ".,.", flags, &contextFunc });  // (filter expression, boost)

--- a/arangod/IResearch/IResearchFilterFactory.cpp
+++ b/arangod/IResearch/IResearchFilterFactory.cpp
@@ -2966,7 +2966,7 @@ arangodb::Result fromFuncStartsWith(
   auto minMatchCount = FilterConstants::DefaultStartsWithMinMatchCount;
   auto const* astPrefixes = args.getMemberUnchecked(currentArgNum);
   TRI_ASSERT(astPrefixes);
-  auto isMultiPrefix = astPrefixes->isArray();
+  auto const isMultiPrefix = astPrefixes->isArray();
   if (isMultiPrefix) {
     auto size = astPrefixes->numMembers();
     if (size > 0) {

--- a/arangod/IResearch/IResearchFilterFactory.cpp
+++ b/arangod/IResearch/IResearchFilterFactory.cpp
@@ -2929,7 +2929,7 @@ arangodb::Result fromFuncNgramMatch(
   return {};
 }
 
-// STARTS_WITH(<attribute>, <prefix>, [<scoring-limit>])
+// STARTS_WITH(<attribute>, [ '[' ] <prefix> [, <prefix>, ... ']' ], [ <scoring-limit>|<min-match-count> ] [, <scoring-limit> ])
 arangodb::Result fromFuncStartsWith(
     char const* funcName,
     irs::boolean_filter* filter,
@@ -2944,41 +2944,85 @@ arangodb::Result fromFuncStartsWith(
 
   auto const argc = args.numMembers();
 
-  if (argc < 2 || argc > 3) {
-    return error::invalidArgsCount<error::Range<2, 3>>(funcName);
+  if (argc < 2 || argc > 4) {
+    return error::invalidArgsCount<error::Range<2, 4>>(funcName);
   }
+
+  size_t currentArgNum = 0;
 
   // 1st argument defines a field
   auto const* field =
-      arangodb::iresearch::checkAttributeAccess(args.getMemberUnchecked(0), *ctx.ref);
+      arangodb::iresearch::checkAttributeAccess(args.getMemberUnchecked(currentArgNum), *ctx.ref);
 
   if (!field) {
-    return error::invalidAttribute(funcName, 1);
+    return error::invalidAttribute(funcName, currentArgNum + 1);
   }
+  ++currentArgNum;
 
-  // 2nd argument defines a value
-  ScopedAqlValue prefixValue;
-  irs::string_ref prefix;
-  auto rv = evaluateArg(prefix, prefixValue, funcName, args, 1, filter != nullptr, ctx);
+  // 2nd argument defines a value or array of values
+  std::vector<ScopedAqlValue> prefixValues;
+  std::vector<irs::string_ref> prefixes;
+  ScopedAqlValue minMatchCountValue;
+  auto minMatchCount = FilterConstants::DefaultStartsWithMinMatchCount;
+  auto const* astPrefixes = args.getMemberUnchecked(currentArgNum);
+  TRI_ASSERT(astPrefixes);
+  auto isMultiPrefix = astPrefixes->isArray();
+  if (isMultiPrefix) {
+    auto size = astPrefixes->numMembers();
+    if (size > 0) {
+      prefixValues.resize(size);
+      prefixes.resize(size);
+      for (size_t i = 0; i < size; ++i) {
+        auto rv = evaluateArg(prefixes[i], prefixValues[i], funcName, *astPrefixes, i, filter != nullptr, ctx);
+        if (rv.fail()) {
+          return rv;
+        }
+      }
+    }
+    ++currentArgNum;
 
-  if (rv.fail()) {
-    return rv;
+    if (argc > currentArgNum) {
+      // 3rd argument defines minimum match count
+      auto rv = evaluateArg<decltype(minMatchCount), true>(
+            minMatchCount, minMatchCountValue, funcName, args, currentArgNum, filter != nullptr, ctx);
+
+      if (rv.fail()) {
+        return rv;
+      }
+
+      if (minMatchCount < 0) {
+        return error::negativeNumber(funcName, currentArgNum + 1);
+      }
+    }
+  } else {
+    if (argc > 3) {
+      return error::invalidArgsCount<error::Range<2, 3>>(funcName);
+    }
+    size_t const size = 1;
+    prefixValues.resize(size);
+    prefixes.resize(size);
+    auto rv = evaluateArg(prefixes[0], prefixValues[0], funcName, args, currentArgNum, filter != nullptr, ctx);
+
+    if (rv.fail()) {
+      return rv;
+    }
   }
+  ++currentArgNum;
 
-  size_t scoringLimit = FilterConstants::DefaultScoringTermsLimit;
+  auto scoringLimit = FilterConstants::DefaultScoringTermsLimit;
 
-  if (argc > 2) {
-    // 3rd (optional) argument defines a number of scored terms
+  if (argc > currentArgNum) {
+    // 3rd or 4th (optional) argument defines a number of scored terms
     ScopedAqlValue scoringLimitValueBuf;
-    int64_t scoringLimitValue = static_cast<int64_t>(scoringLimit);
-    rv = evaluateArg(scoringLimitValue, scoringLimitValueBuf, funcName, args, 2, filter != nullptr, ctx);
+    auto scoringLimitValue = static_cast<int64_t>(scoringLimit);
+    auto rv = evaluateArg(scoringLimitValue, scoringLimitValueBuf, funcName, args, currentArgNum, filter != nullptr, ctx);
 
     if (rv.fail()) {
       return rv;
     }
 
     if (scoringLimitValue < 0) {
-      return error::negativeNumber(funcName, 3);
+      return error::negativeNumber(funcName, currentArgNum + 1);
     }
 
     scoringLimit = static_cast<size_t>(scoringLimitValue);
@@ -2993,12 +3037,25 @@ arangodb::Result fromFuncStartsWith(
 
     TRI_ASSERT(filterCtx.analyzer);
     kludge::mangleStringField(name, filterCtx.analyzer);
+    filter->boost(filterCtx.boost);
 
-    auto& prefixFilter = filter->add<irs::by_prefix>();
-    prefixFilter.scored_terms_limit(scoringLimit);
-    prefixFilter.field(std::move(name));
-    prefixFilter.boost(filterCtx.boost);
-    prefixFilter.term(prefix);
+    if (isMultiPrefix) {
+      auto& minMatchFilter = filter->add<irs::Or>();
+      minMatchFilter.min_match_count(static_cast<size_t>(minMatchCount));
+      // become a new root
+      filter = &minMatchFilter;
+    }
+
+    for (size_t i = 0, size = prefixes.size(); i < size; ++i) {
+      auto& prefixFilter = filter->add<irs::by_prefix>();
+      prefixFilter.scored_terms_limit(scoringLimit);
+      if (i + 1 < size) {
+        prefixFilter.field(name);
+      } else {
+        prefixFilter.field(std::move(name));
+      }
+      prefixFilter.term(prefixes[i]);
+    }
   }
 
   return {};

--- a/arangod/IResearch/IResearchFilterFactory.h
+++ b/arangod/IResearch/IResearchFilterFactory.h
@@ -61,6 +61,7 @@ struct FilterConstants {
   // Defaults
   static constexpr size_t DefaultScoringTermsLimit { 128 };
   static constexpr double_t DefaultNgramMatchThreshold { 0.7 };
+  static constexpr int64_t DefaultStartsWithMinMatchCount { 1 };
 };
 
 }  // namespace iresearch

--- a/tests/IResearch/IResearchFeature-test.cpp
+++ b/tests/IResearch/IResearchFeature-test.cpp
@@ -140,7 +140,7 @@ TEST_F(IResearchFeatureTest, test_start) {
     // filter functions
     { "EXISTS", { ".|.,.", FunctionType::FILTER } },
     { "PHRASE", { ".,.|.+", FunctionType::FILTER } },
-    { "STARTS_WITH", { ".,.|.", FunctionType::FILTER } },
+    { "STARTS_WITH", { ".,.|.,.", FunctionType::FILTER } },
     { "MIN_MATCH", { ".,.|.+", FunctionType::FILTER } },
 
     // context functions

--- a/tests/IResearch/IResearchFilterFunction-test.cpp
+++ b/tests/IResearch/IResearchFilterFunction-test.cpp
@@ -5234,6 +5234,20 @@ TEST_F(IResearchFilterFunctionTest, StartsWith) {
         &ctx);
   }
 
+  // empty array
+  {
+    irs::Or expected;
+    auto& orFilter = expected.add<irs::Or>();
+    orFilter.min_match_count(arangodb::iresearch::FilterConstants::DefaultStartsWithMinMatchCount);
+
+    assertFilterSuccess(
+        vocbase(),
+        "FOR d IN myView FILTER starts_with(d['name'], []) RETURN d", expected);
+    assertFilterSuccess(
+        vocbase(),
+        "FOR d IN myView FILTER starts_with(d.name, []) RETURN d", expected);
+  }
+
   // with scoring limit (int)
   {
     irs::Or expected;

--- a/tests/IResearch/IResearchQueryStartsWith-test.cpp
+++ b/tests/IResearch/IResearchQueryStartsWith-test.cpp
@@ -167,6 +167,22 @@ TEST_F(IResearchQueryStartsWithTest, test) {
     EXPECT_FALSE(resultIt.valid());
   }
 
+  // invalid field via []
+  {
+    auto queryResult = arangodb::tests::executeQuery(
+        vocbase,
+        "FOR d IN testView SEARCH STARTS_WITH(d.invalid_field, ['abc', 'def']) RETURN "
+        "d");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(0, resultIt.size());
+    EXPECT_FALSE(resultIt.valid());
+  }
+
   // invalid type
   {
     auto queryResult = arangodb::tests::executeQuery(
@@ -181,9 +197,65 @@ TEST_F(IResearchQueryStartsWithTest, test) {
     EXPECT_FALSE(resultIt.valid());
   }
 
+  // invalid type via []
+  {
+    auto queryResult = arangodb::tests::executeQuery(
+        vocbase, "FOR d IN testView SEARCH STARTS_WITH(d.seq, ['0', '1']) RETURN d");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(0, resultIt.size());
+    EXPECT_FALSE(resultIt.valid());
+  }
+
+  // execution outside arangosearch empty
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with()");
+    ASSERT_FALSE(queryResult.result.ok());
+  }
+
+  // execution outside arangosearch one parameter
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('abc')");
+    ASSERT_FALSE(queryResult.result.ok());
+  }
+
+  // execution outside arangosearch five parameters
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('abc', 'a', 1, 2, 3)");
+    ASSERT_FALSE(queryResult.result.ok());
+  }
+
+  // execution outside arangosearch five parameters via []
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('abc', ['a', 'ab'], 1, 2, 3)");
+    ASSERT_FALSE(queryResult.result.ok());
+  }
+
   // execution outside arangosearch (true)
   {
     auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('abc', 'a')");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(1, resultIt.size());
+
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      ASSERT_TRUE(resolved.isBool());
+      ASSERT_TRUE(resolved.getBool());
+    }
+  }
+
+  // execution outside arangosearch (true) via []
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('abc', ['a', 'ab'])");
     ASSERT_TRUE(queryResult.result.ok());
 
     auto result = queryResult.data->slice();
@@ -217,9 +289,189 @@ TEST_F(IResearchQueryStartsWithTest, test) {
     }
   }
 
+  // execution outside arangosearch (true) via []
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('abc', ['abc', 'def'])");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(1, resultIt.size());
+
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      ASSERT_TRUE(resolved.isBool());
+      ASSERT_TRUE(resolved.getBool());
+    }
+  }
+
   // execution outside arangosearch (false)
   {
     auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('a', 'abc')");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(1, resultIt.size());
+
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      ASSERT_TRUE(resolved.isBool());
+      ASSERT_FALSE(resolved.getBool());
+    }
+  }
+
+  // execution outside arangosearch (false) via []
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('a', ['abc', 'ab'])");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(1, resultIt.size());
+
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      ASSERT_TRUE(resolved.isBool());
+      ASSERT_FALSE(resolved.getBool());
+    }
+  }
+
+  // execution outside arangosearch (true) via [] min match count 0, 1 not success
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('abc', ['b', 'd'], 0)");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(1, resultIt.size());
+
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      ASSERT_TRUE(resolved.isBool());
+      ASSERT_TRUE(resolved.getBool());
+    }
+  }
+
+  // execution outside arangosearch (true) via [] min match count 1, 1 success
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('abc', ['a', 'd'], 0)");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(1, resultIt.size());
+
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      ASSERT_TRUE(resolved.isBool());
+      ASSERT_TRUE(resolved.getBool());
+    }
+  }
+
+  // execution outside arangosearch (true) via [] min match count 1
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('abc', ['a', 'd'], 1)");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(1, resultIt.size());
+
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      ASSERT_TRUE(resolved.isBool());
+      ASSERT_TRUE(resolved.getBool());
+    }
+  }
+
+  // execution outside arangosearch (false) via [] min match count 1
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('abc', ['b', 'd'], 1)");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(1, resultIt.size());
+
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      ASSERT_TRUE(resolved.isBool());
+      ASSERT_FALSE(resolved.getBool());
+    }
+  }
+
+  // execution outside arangosearch (true) via [] min match count = length
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('abc', ['a', 'ab'], 2)");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(1, resultIt.size());
+
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      ASSERT_TRUE(resolved.isBool());
+      ASSERT_TRUE(resolved.getBool());
+    }
+  }
+
+  // execution outside arangosearch (false) via [] min match count = length
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('abc', ['a', 'd'], 2)");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(1, resultIt.size());
+
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      ASSERT_TRUE(resolved.isBool());
+      ASSERT_FALSE(resolved.getBool());
+    }
+  }
+
+  // execution outside arangosearch (false) via [] min match count > length 2 not success
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('abc', ['b', 'd'], 3)");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(1, resultIt.size());
+
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      ASSERT_TRUE(resolved.isBool());
+      ASSERT_FALSE(resolved.getBool());
+    }
+  }
+
+  // execution outside arangosearch (false) via [] min match count > length 2 success
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('abc', ['a', 'ab'], 3)");
     ASSERT_TRUE(queryResult.result.ok());
 
     auto result = queryResult.data->slice();
@@ -249,9 +501,37 @@ TEST_F(IResearchQueryStartsWithTest, test) {
     }
   }
 
+  // execution outside arangosearch (wrong args) via []
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with(1, ['abc', 'def'])");
+    ASSERT_TRUE(queryResult.result.ok());
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(1, resultIt.size());
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      ASSERT_TRUE(resolved.isNull());
+    }
+  }
+
   // execution outside arangosearch (wrong args)
   {
     auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with(true, 'abc')");
+    ASSERT_TRUE(queryResult.result.ok());
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(1, resultIt.size());
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      ASSERT_TRUE(resolved.isNull());
+    }
+  }
+
+  // execution outside arangosearch (wrong args) via []
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with(true, ['abc', 'def'])");
     ASSERT_TRUE(queryResult.result.ok());
     auto result = queryResult.data->slice();
     EXPECT_TRUE(result.isArray());
@@ -277,9 +557,37 @@ TEST_F(IResearchQueryStartsWithTest, test) {
     }
   }
 
+  // execution outside arangosearch (wrong args) via []
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with(null, ['abc', 'def'])");
+    ASSERT_TRUE(queryResult.result.ok());
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(1, resultIt.size());
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      ASSERT_TRUE(resolved.isNull());
+    }
+  }
+
   // execution outside arangosearch (wrong args)
   {
     auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('a', 1)");
+    ASSERT_TRUE(queryResult.result.ok());
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(1, resultIt.size());
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      ASSERT_TRUE(resolved.isNull());
+    }
+  }
+
+  // execution outside arangosearch (wrong args) via []
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('a', [1, 2])");
     ASSERT_TRUE(queryResult.result.ok());
     auto result = queryResult.data->slice();
     EXPECT_TRUE(result.isArray());
@@ -305,9 +613,37 @@ TEST_F(IResearchQueryStartsWithTest, test) {
     }
   }
 
+  // execution outside arangosearch (wrong args) via []
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('a', [null])");
+    ASSERT_TRUE(queryResult.result.ok());
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(1, resultIt.size());
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      ASSERT_TRUE(resolved.isNull());
+    }
+  }
+
   // execution outside arangosearch (wrong args)
   {
     auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('a', true)");
+    ASSERT_TRUE(queryResult.result.ok());
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(1, resultIt.size());
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      ASSERT_TRUE(resolved.isNull());
+    }
+  }
+
+  // execution outside arangosearch (wrong args) via []
+  {
+    auto queryResult = arangodb::tests::executeQuery(vocbase, "RETURN starts_with('a', [true, false])");
     ASSERT_TRUE(queryResult.result.ok());
     auto result = queryResult.data->slice();
     EXPECT_TRUE(result.isArray());
@@ -349,6 +685,66 @@ TEST_F(IResearchQueryStartsWithTest, test) {
     EXPECT_TRUE(expectedDocs.empty());
   }
 
+  // exact term, unordered via []
+  {
+    std::map<irs::string_ref, arangodb::ManagedDocumentResult const*> expectedDocs{
+        {"A", &insertedDocs[0]}, {"B", &insertedDocs[1]}};
+
+    auto queryResult = arangodb::tests::executeQuery(
+        vocbase, "FOR d IN testView SEARCH starts_with(d.name, ['A', 'B']) RETURN d");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(expectedDocs.size(), resultIt.size());
+
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      auto const keySlice = resolved.get("name");
+      auto const key = arangodb::iresearch::getStringRef(keySlice);
+
+      auto expectedDoc = expectedDocs.find(key);
+      ASSERT_NE(expectedDoc, expectedDocs.end());
+      EXPECT_TRUE(0 == arangodb::basics::VelocyPackHelper::compare(
+                           arangodb::velocypack::Slice(expectedDoc->second->vpack()),
+                           resolved, true));
+      expectedDocs.erase(expectedDoc);
+    }
+    EXPECT_TRUE(expectedDocs.empty());
+  }
+
+  // exact term, unordered via [] min match count = 1
+  {
+    std::map<irs::string_ref, arangodb::ManagedDocumentResult const*> expectedDocs{
+        {"A", &insertedDocs[0]}, {"B", &insertedDocs[1]}};
+
+    auto queryResult = arangodb::tests::executeQuery(
+        vocbase, "FOR d IN testView SEARCH starts_with(d.name, ['A', 'B'], 1) RETURN d");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(expectedDocs.size(), resultIt.size());
+
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      auto const keySlice = resolved.get("name");
+      auto const key = arangodb::iresearch::getStringRef(keySlice);
+
+      auto expectedDoc = expectedDocs.find(key);
+      ASSERT_NE(expectedDoc, expectedDocs.end());
+      EXPECT_TRUE(0 == arangodb::basics::VelocyPackHelper::compare(
+                           arangodb::velocypack::Slice(expectedDoc->second->vpack()),
+                           resolved, true));
+      expectedDocs.erase(expectedDoc);
+    }
+    EXPECT_TRUE(expectedDocs.empty());
+  }
+
   // exact term, ordered
   {
     std::map<irs::string_ref, arangodb::ManagedDocumentResult const*> expectedDocs{
@@ -357,6 +753,38 @@ TEST_F(IResearchQueryStartsWithTest, test) {
     auto queryResult = arangodb::tests::executeQuery(
         vocbase,
         "FOR d IN testView SEARCH starts_with(d.name, 'A', 0) SORT TFIDF(d) "
+        "DESC RETURN d");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(expectedDocs.size(), resultIt.size());
+
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      auto const keySlice = resolved.get("name");
+      auto const key = arangodb::iresearch::getStringRef(keySlice);
+
+      auto expectedDoc = expectedDocs.find(key);
+      ASSERT_NE(expectedDoc, expectedDocs.end());
+      EXPECT_TRUE(0 == arangodb::basics::VelocyPackHelper::compare(
+                           arangodb::velocypack::Slice(expectedDoc->second->vpack()),
+                           resolved, true));
+      expectedDocs.erase(expectedDoc);
+    }
+    EXPECT_TRUE(expectedDocs.empty());
+  }
+
+  // exact term, ordered via []
+  {
+    std::map<irs::string_ref, arangodb::ManagedDocumentResult const*> expectedDocs{
+        {"A", &insertedDocs[0]}, {"B", &insertedDocs[1]}};
+
+    auto queryResult = arangodb::tests::executeQuery(
+        vocbase,
+        "FOR d IN testView SEARCH starts_with(d.name, ['A', 'B'], 1, 0) SORT TFIDF(d) "
         "DESC RETURN d");
     ASSERT_TRUE(queryResult.result.ok());
 
@@ -418,6 +846,243 @@ TEST_F(IResearchQueryStartsWithTest, test) {
     EXPECT_EQ(expectedDoc, expectedDocs.rend());
   }
 
+  // d.prefix = abc*|def*, d.seq DESC via []
+  {
+    std::map<ptrdiff_t, arangodb::ManagedDocumentResult const*> expectedDocs;
+    for (auto const& doc : insertedDocs) {
+      arangodb::velocypack::Slice docSlice(doc.vpack());
+      auto const prefixSlice = docSlice.get("prefix");
+      if (prefixSlice.isNone() ||
+          !irs::starts_with(arangodb::iresearch::getStringRef(prefixSlice),
+                            "abc")) {
+        continue;
+      }
+      expectedDocs.emplace(docSlice.get("seq").getNumber<ptrdiff_t>(), &doc);
+    }
+
+    auto queryResult = arangodb::tests::executeQuery(
+        vocbase,
+        "FOR d IN testView SEARCH starts_with(d.prefix, ['abc', 'def']) SORT d.seq DESC "
+        "RETURN d");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(expectedDocs.size(), resultIt.size());
+
+    auto expectedDoc = expectedDocs.rbegin();
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      EXPECT_TRUE(0 == arangodb::basics::VelocyPackHelper::compare(
+                           arangodb::velocypack::Slice(expectedDoc->second->vpack()),
+                           resolved, true));
+      ++expectedDoc;
+    }
+    EXPECT_EQ(expectedDoc, expectedDocs.rend());
+  }
+
+  // d.prefix = bca*|def*, d.seq DESC via [] min match count = 0 (true), 1 not success
+  {
+    std::map<ptrdiff_t, arangodb::ManagedDocumentResult const*> expectedDocs;
+    for (auto const& doc : insertedDocs) {
+      arangodb::velocypack::Slice docSlice(doc.vpack());
+      expectedDocs.emplace(docSlice.get("seq").getNumber<ptrdiff_t>(), &doc);
+    }
+
+    auto queryResult = arangodb::tests::executeQuery(
+        vocbase,
+        "FOR d IN testView SEARCH starts_with(d.prefix, ['bca', 'def'], 0) SORT d.seq DESC "
+        "RETURN d");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(expectedDocs.size(), resultIt.size());
+
+    auto expectedDoc = expectedDocs.rbegin();
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      EXPECT_TRUE(0 == arangodb::basics::VelocyPackHelper::compare(
+                           arangodb::velocypack::Slice(expectedDoc->second->vpack()),
+                           resolved, true));
+      ++expectedDoc;
+    }
+    EXPECT_EQ(expectedDoc, expectedDocs.rend());
+  }
+
+  // d.prefix = abc*|def*, d.seq DESC via [] min match count = 0 (true), 1 success
+  {
+    std::map<ptrdiff_t, arangodb::ManagedDocumentResult const*> expectedDocs;
+    for (auto const& doc : insertedDocs) {
+      arangodb::velocypack::Slice docSlice(doc.vpack());
+      expectedDocs.emplace(docSlice.get("seq").getNumber<ptrdiff_t>(), &doc);
+    }
+
+    auto queryResult = arangodb::tests::executeQuery(
+        vocbase,
+        "FOR d IN testView SEARCH starts_with(d.prefix, ['abc', 'def'], 0) SORT d.seq DESC "
+        "RETURN d");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(expectedDocs.size(), resultIt.size());
+
+    auto expectedDoc = expectedDocs.rbegin();
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      EXPECT_TRUE(0 == arangodb::basics::VelocyPackHelper::compare(
+                           arangodb::velocypack::Slice(expectedDoc->second->vpack()),
+                           resolved, true));
+      ++expectedDoc;
+    }
+    EXPECT_EQ(expectedDoc, expectedDocs.rend());
+  }
+
+  // d.prefix = abc*|def*, d.seq DESC via [] min match count = 1 (true)
+  {
+    std::map<ptrdiff_t, arangodb::ManagedDocumentResult const*> expectedDocs;
+    for (auto const& doc : insertedDocs) {
+      arangodb::velocypack::Slice docSlice(doc.vpack());
+      auto const prefixSlice = docSlice.get("prefix");
+      if (prefixSlice.isNone() ||
+          !irs::starts_with(arangodb::iresearch::getStringRef(prefixSlice),
+                            "abc")) {
+        continue;
+      }
+      expectedDocs.emplace(docSlice.get("seq").getNumber<ptrdiff_t>(), &doc);
+    }
+
+    auto queryResult = arangodb::tests::executeQuery(
+        vocbase,
+        "FOR d IN testView SEARCH starts_with(d.prefix, ['abc', 'def'], 1) SORT d.seq DESC "
+        "RETURN d");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(expectedDocs.size(), resultIt.size());
+
+    auto expectedDoc = expectedDocs.rbegin();
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      EXPECT_TRUE(0 == arangodb::basics::VelocyPackHelper::compare(
+                           arangodb::velocypack::Slice(expectedDoc->second->vpack()),
+                           resolved, true));
+      ++expectedDoc;
+    }
+    EXPECT_EQ(expectedDoc, expectedDocs.rend());
+  }
+
+  // d.prefix = dfg*|def*, d.seq DESC via [] min match count = 1 (false)
+  {
+    auto queryResult = arangodb::tests::executeQuery(
+        vocbase,
+        "FOR d IN testView SEARCH starts_with(d.prefix, ['dfg', 'def'], 1) SORT d.seq DESC "
+        "RETURN d");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(0, resultIt.size());
+    EXPECT_FALSE(resultIt.valid());
+  }
+
+  // d.prefix = abc*|ab*, d.seq DESC via [] min match count = 2 (true)
+  {
+    std::map<ptrdiff_t, arangodb::ManagedDocumentResult const*> expectedDocs;
+    for (auto const& doc : insertedDocs) {
+      arangodb::velocypack::Slice docSlice(doc.vpack());
+      auto const prefixSlice = docSlice.get("prefix");
+      if (prefixSlice.isNone() ||
+          !irs::starts_with(arangodb::iresearch::getStringRef(prefixSlice),
+                            "abc")) {
+        continue;
+      }
+      expectedDocs.emplace(docSlice.get("seq").getNumber<ptrdiff_t>(), &doc);
+    }
+
+    auto queryResult = arangodb::tests::executeQuery(
+        vocbase,
+        "FOR d IN testView SEARCH starts_with(d.prefix, ['abc', 'ab'], 2) SORT d.seq DESC "
+        "RETURN d");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(expectedDocs.size(), resultIt.size());
+
+    auto expectedDoc = expectedDocs.rbegin();
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+      EXPECT_TRUE(0 == arangodb::basics::VelocyPackHelper::compare(
+                           arangodb::velocypack::Slice(expectedDoc->second->vpack()),
+                           resolved, true));
+      ++expectedDoc;
+    }
+    EXPECT_EQ(expectedDoc, expectedDocs.rend());
+  }
+
+  // d.prefix = abc*|def*, d.seq DESC via [] min match count = 2 (false)
+  {
+    auto queryResult = arangodb::tests::executeQuery(
+        vocbase,
+        "FOR d IN testView SEARCH starts_with(d.prefix, ['abc', 'def'], 2) SORT d.seq DESC "
+        "RETURN d");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(0, resultIt.size());
+    EXPECT_FALSE(resultIt.valid());
+  }
+
+  // d.prefix = abc*|def*, d.seq DESC via [] min match count = 3 (false), 2 not success
+  {
+    auto queryResult = arangodb::tests::executeQuery(
+        vocbase,
+        "FOR d IN testView SEARCH starts_with(d.prefix, ['abc', 'def'], 3) SORT d.seq DESC "
+        "RETURN d");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(0, resultIt.size());
+    EXPECT_FALSE(resultIt.valid());
+  }
+
+  // d.prefix = abc*|ab*, d.seq DESC via [] min match count = 3 (false), 2 success
+  {
+    auto queryResult = arangodb::tests::executeQuery(
+        vocbase,
+        "FOR d IN testView SEARCH starts_with(d.prefix, ['abc', 'ab'], 3) SORT d.seq DESC "
+        "RETURN d");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(0, resultIt.size());
+    EXPECT_FALSE(resultIt.valid());
+  }
+
   // Empty prefix - return all docs: d.prefix = ''*, TFIDF(), BM25(), d.seq DESC
   {
     std::map<ptrdiff_t, arangodb::ManagedDocumentResult const*> expectedDocs;
@@ -454,11 +1119,63 @@ TEST_F(IResearchQueryStartsWithTest, test) {
     EXPECT_EQ(expectedDoc, expectedDocs.rend());
   }
 
+  // Empty prefix - return all docs: d.prefix = ''*, d.seq DESC via []
+  {
+    std::map<ptrdiff_t, arangodb::ManagedDocumentResult const*> expectedDocs;
+    for (auto const& doc : insertedDocs) {
+      arangodb::velocypack::Slice docSlice(doc.vpack());
+      auto const prefixSlice = docSlice.get("prefix");
+      if (prefixSlice.isNone()) {
+        continue;
+      }
+      expectedDocs.emplace(docSlice.get("seq").getNumber<ptrdiff_t>(), &doc);
+    }
+
+    auto queryResult = arangodb::tests::executeQuery(
+        vocbase,
+        "FOR d IN testView SEARCH starts_with(d.prefix, ['', 'ab']) SORT "
+        "d.seq DESC RETURN d");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(expectedDocs.size(), resultIt.size());
+
+    auto expectedDoc = expectedDocs.rbegin();
+    for (auto const actualDoc : resultIt) {
+      auto const resolved = actualDoc.resolveExternals();
+
+      EXPECT_TRUE(0 == arangodb::basics::VelocyPackHelper::compare(
+                           arangodb::velocypack::Slice(expectedDoc->second->vpack()),
+                           resolved, true));
+      ++expectedDoc;
+    }
+    EXPECT_EQ(expectedDoc, expectedDocs.rend());
+  }
+
   // invalid prefix
   {
     auto queryResult = arangodb::tests::executeQuery(
         vocbase,
         "FOR d IN testView SEARCH STARTS_WITH(d.prefix, 'abc_invalid_prefix') "
+        "RETURN d");
+    ASSERT_TRUE(queryResult.result.ok());
+
+    auto result = queryResult.data->slice();
+    EXPECT_TRUE(result.isArray());
+
+    arangodb::velocypack::ArrayIterator resultIt(result);
+    EXPECT_EQ(0, resultIt.size());
+    EXPECT_FALSE(resultIt.valid());
+  }
+
+  // invalid prefix via []
+  {
+    auto queryResult = arangodb::tests::executeQuery(
+        vocbase,
+        "FOR d IN testView SEARCH STARTS_WITH(d.prefix, ['abc_invalid_prefix', 'another_invalid_prefix']) "
         "RETURN d");
     ASSERT_TRUE(queryResult.result.ok());
 

--- a/tests/js/common/aql/aql-view-arangosearch-cluster.inc
+++ b/tests/js/common/aql/aql-view-arangosearch-cluster.inc
@@ -429,6 +429,48 @@
         assertEqual(result[1].c, 0);
       },
 
+      testStartsWithFilterArrayWithoutMinMatchCount : function () {
+        var result = db._query("FOR doc IN UnitTestsView SEARCH STARTS_WITH(doc.a, ['fo', 'g']) OPTIONS { waitForSync : true } RETURN doc").toArray();
+
+        assertEqual(result.length, 10);
+        result.forEach(function(res) {
+          assertEqual(res.a, 'foo');
+        });
+      },
+
+      testStartsWithFilterEmptyArray : function () {
+        var result = db._query("FOR doc IN UnitTestsView SEARCH STARTS_WITH(doc.a, []) OPTIONS { waitForSync : true } RETURN doc").toArray();
+
+        assertEqual(result.length, 0);
+      },
+
+      testStartsWithFilterEmptyArrayMinMatchCountZero : function () {
+        var result = db._query("FOR doc IN UnitTestsView SEARCH STARTS_WITH(doc.a, [], 0) OPTIONS { waitForSync : true } RETURN doc").toArray();
+
+        assertEqual(result.length, 28);
+      },
+
+      testStartsWithFilterArrayWithMinMatchCountZero : function () {
+        var result = db._query("FOR doc IN UnitTestsView SEARCH STARTS_WITH(doc.a, ['fo', 'g'], 0) OPTIONS { waitForSync : true } RETURN doc").toArray();
+
+        assertEqual(result.length, 28);
+      },
+
+      testStartsWithFilterArrayWithMinMatchCountTrue : function () {
+        var result = db._query("FOR doc IN UnitTestsView SEARCH STARTS_WITH(doc.a, ['fo', 'g'], 1) OPTIONS { waitForSync : true } RETURN doc").toArray();
+
+        assertEqual(result.length, 10);
+        result.forEach(function(res) {
+          assertEqual(res.a, 'foo');
+        });
+      },
+
+      testStartsWithFilterArrayWithMinMatchCountFalse : function () {
+        var result = db._query("FOR doc IN UnitTestsView SEARCH STARTS_WITH(doc.a, ['fo', 'g'], 2) OPTIONS { waitForSync : true } RETURN doc").toArray();
+
+        assertEqual(result.length, 0);
+      },
+
       testWildcardFilter : function() {
         {
           let result = db._query("FOR doc IN UnitTestsView SEARCH doc.a LIKE '_a_' OPTIONS { waitForSync:true } FILTER doc.c == 0 SORT doc.a RETURN doc").toArray();

--- a/tests/js/common/aql/aql-view-arangosearch-noncluster.js
+++ b/tests/js/common/aql/aql-view-arangosearch-noncluster.js
@@ -439,6 +439,48 @@ function iResearchAqlTestSuite () {
       assertEqual(result[1].c, 0);
     },
 
+    testStartsWithFilterArrayWithoutMinMatchCount : function () {
+      var result = db._query("FOR doc IN UnitTestsView SEARCH STARTS_WITH(doc.a, ['fo', 'g']) OPTIONS { waitForSync : true } RETURN doc").toArray();
+
+      assertEqual(result.length, 10);
+      result.forEach(function(res) {
+        assertEqual(res.a, 'foo');
+      });
+    },
+
+    testStartsWithFilterEmptyArray : function () {
+      var result = db._query("FOR doc IN UnitTestsView SEARCH STARTS_WITH(doc.a, []) OPTIONS { waitForSync : true } RETURN doc").toArray();
+
+      assertEqual(result.length, 0);
+    },
+
+    testStartsWithFilterEmptyArrayMinMatchCountZero : function () {
+      var result = db._query("FOR doc IN UnitTestsView SEARCH STARTS_WITH(doc.a, [], 0) OPTIONS { waitForSync : true } RETURN doc").toArray();
+
+      assertEqual(result.length, 28);
+    },
+
+    testStartsWithFilterArrayWithMinMatchCountZero : function () {
+      var result = db._query("FOR doc IN UnitTestsView SEARCH STARTS_WITH(doc.a, ['fo', 'g'], 0) OPTIONS { waitForSync : true } RETURN doc").toArray();
+
+      assertEqual(result.length, 28);
+    },
+
+    testStartsWithFilterArrayWithMinMatchCountTrue : function () {
+      var result = db._query("FOR doc IN UnitTestsView SEARCH STARTS_WITH(doc.a, ['fo', 'g'], 1) OPTIONS { waitForSync : true } RETURN doc").toArray();
+
+      assertEqual(result.length, 10);
+      result.forEach(function(res) {
+        assertEqual(res.a, 'foo');
+      });
+    },
+
+    testStartsWithFilterArrayWithMinMatchCountFalse : function () {
+      var result = db._query("FOR doc IN UnitTestsView SEARCH STARTS_WITH(doc.a, ['fo', 'g'], 2) OPTIONS { waitForSync : true } RETURN doc").toArray();
+
+      assertEqual(result.length, 0);
+    },
+
     testInTokensFilterSortTFIDF : function () {
       var result = db._query("FOR doc IN UnitTestsView SEARCH ANALYZER(doc.text IN TOKENS('the quick brown', 'text_en'), 'text_en') OPTIONS { waitForSync : true } SORT TFIDF(doc) LIMIT 4 RETURN doc").toArray();
 


### PR DESCRIPTION
Supported several prefixes in STARTS_WITH function with min match count.

https://github.com/arangodb/backlog/issues/694

http://jenkins01.arangodb.biz:8080/job/arangodb-matrix-pr/9498/