### PR TITLE
fix example graph creation with `--cluster.min-replication-factor` set

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+v3.6.4 (XXXX-XX-XX)
+-------------------
+
+* Fix creation of example graphs when `--cluster.min-replication-factor` is set
+  and no replication factor was specified for a graph. In this case, the new
+  graph will use the configured minimum replication factor.
+
+
 v3.6.3 (2020-04-15)
 -------------------
 

--- a/arangod/Graph/Graph.h
+++ b/arangod/Graph/Graph.h
@@ -24,7 +24,6 @@
 #define ARANGOD_GRAPH_GRAPH_H
 
 #include <velocypack/Buffer.h>
-#include <chrono>
 #include <utility>
 #include <set>
 
@@ -36,6 +35,8 @@
 #include "Transaction/Methods.h"
 #include "Transaction/StandaloneContext.h"
 #include "Utils/OperationResult.h"
+
+struct TRI_vocbase_t;
 
 namespace arangodb {
 namespace graph {
@@ -106,12 +107,14 @@ class Graph {
    *
    * @return A graph object corresponding to the user input
    */
-  static std::unique_ptr<Graph> fromUserInput(std::string&& name,
+  static std::unique_ptr<Graph> fromUserInput(TRI_vocbase_t& vocbase, 
+                                              std::string&& name,
                                               velocypack::Slice collectionInformation,
                                               velocypack::Slice options);
 
   // Wrapper for Move constructor
-  static std::unique_ptr<Graph> fromUserInput(std::string const& name,
+  static std::unique_ptr<Graph> fromUserInput(TRI_vocbase_t& vocbase,
+                                              std::string const& name,
                                               velocypack::Slice collectionInformation,
                                               velocypack::Slice options);
 
@@ -130,7 +133,7 @@ class Graph {
    * @param info Collection information, including relations and orphans
    * @param options The options to be used for collections
    */
-  Graph(std::string&& graphName, velocypack::Slice const& info,
+  Graph(TRI_vocbase_t& vocbase, std::string&& graphName, velocypack::Slice const& info,
         velocypack::Slice const& options);
 
  public:

--- a/arangod/Graph/GraphManager.cpp
+++ b/arangod/Graph/GraphManager.cpp
@@ -996,7 +996,7 @@ ResultT<std::unique_ptr<Graph>> GraphManager::buildGraphFromInput(std::string co
         return res;
       }
     }
-    return Graph::fromUserInput(graphName, input, input.get(StaticStrings::GraphOptions));
+    return Graph::fromUserInput(_vocbase, graphName, input, input.get(StaticStrings::GraphOptions));
   } catch (arangodb::basics::Exception const& e) {
     return Result{e.code(), e.message()};
   } catch (...) {

--- a/js/common/modules/@arangodb/general-graph-common.js
+++ b/js/common/modules/@arangodb/general-graph-common.js
@@ -1835,8 +1835,8 @@ exports._create = function (graphName, edgeDefinitions, orphanCollections, optio
     'orphanCollections': orphanCollections,
     'edgeDefinitions': edgeDefinitions,
     '_key': graphName,
-    'numberOfShards': options.numberOfShards || 1,
-    'replicationFactor': options.replicationFactor || 1,
+    'numberOfShards': options.numberOfShards || undefined,
+    'replicationFactor': options.replicationFactor || undefined,
   }, options);
   data.orphanCollections = orphanCollections;
   data.edgeDefinitions = edgeDefinitions;

--- a/tests/js/client/server_permissions/test-sharding-restrictions-cluster.js
+++ b/tests/js/client/server_permissions/test-sharding-restrictions-cluster.js
@@ -101,6 +101,51 @@ function testSuite() {
       let props = c.properties();
       assertEqual(4, props.replicationFactor);
     },
+
+    testCreateGraph : function() {
+      const graph = require("@arangodb/general-graph");
+      const vn = "UnitTestVertices";
+      const en = "UnitTestEdges";
+      const gn = "UnitTestGraph";
+      const edgeDef = [graph._relation(en, vn, vn)];
+      try {
+        graph._drop(gn, true);
+      } catch (err) {}
+
+      let myGraph = graph._create(gn, edgeDef, null, {});
+      try {
+        let props = db[vn].properties();
+        assertEqual(2, props.replicationFactor);
+        props = db[en].properties();
+        assertEqual(2, props.replicationFactor);
+      } finally {
+        graph._drop(gn, true);
+      }
+    },
+    
+    testCreateSmartGraph : function() {
+      if (!require("internal").isEnterprise()) {
+        return;
+      }
+      const smrt = require("@arangodb/smart-graph");
+      const vn = "UnitTestVertices";
+      const en = "UnitTestEdges";
+      const gn = "UnitTestGraph";
+      const edgeDef = [smrt._relation(en, vn, vn)];
+      try {
+        smrt._drop(gn, true);
+      } catch (err) {}
+
+      let myGraph = smrt._create(gn, edgeDef, null, {smartGraphAttribute: "value"});
+      try {
+        let props = db[vn].properties();
+        assertEqual(2, props.replicationFactor);
+        props = db[en].properties();
+        assertEqual(2, props.replicationFactor);
+      } finally {
+        smrt._drop(gn, true);
+      }
+    },
     
   };
 }


### PR DESCRIPTION
### Scope & Purpose

Fix example graph creation with `--cluster.min-replication-factor` set to > 1.
In case the startup option was used, example graphs were created with a replicationFactor value of 1, violating the requirements. Now, the default replication factor for the target database will be used.

Backport of #11445.

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/440

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9573/