### PR TITLE
Fix potential divide-by-zero in cache and fix non-deterministic test

### DIFF
--- a/arangod/Cache/Cache.cpp
+++ b/arangod/Cache/Cache.cpp
@@ -299,7 +299,7 @@ bool Cache::reportInsert(bool hadEviction) {
   if ((basics::SharedPRNG::rand() & _evictionMask) == 0) {
     std::uint64_t total = _insertsTotal.value(std::memory_order_relaxed);
     std::uint64_t evictions = _insertEvictions.value(std::memory_order_relaxed);
-    if ((static_cast<double>(evictions) / static_cast<double>(total)) > _evictionRateThreshold) {
+    if ((evictions > 0 && total > 0) && ((static_cast<double>(evictions) / static_cast<double>(total)) > _evictionRateThreshold)) {
       shouldMigrate = true;
       cache::Table* table = _table.load(std::memory_order_relaxed);
       TRI_ASSERT(table != nullptr);

--- a/arangod/Cache/Cache.cpp
+++ b/arangod/Cache/Cache.cpp
@@ -299,7 +299,8 @@ bool Cache::reportInsert(bool hadEviction) {
   if ((basics::SharedPRNG::rand() & _evictionMask) == 0) {
     std::uint64_t total = _insertsTotal.value(std::memory_order_relaxed);
     std::uint64_t evictions = _insertEvictions.value(std::memory_order_relaxed);
-    if ((evictions > 0 && total > 0) && ((static_cast<double>(evictions) / static_cast<double>(total)) > _evictionRateThreshold)) {
+    if (total > 0 && total > evictions &&
+        ((static_cast<double>(evictions) / static_cast<double>(total)) > _evictionRateThreshold)) {
       shouldMigrate = true;
       cache::Table* table = _table.load(std::memory_order_relaxed);
       TRI_ASSERT(table != nullptr);

--- a/tests/Cache/TransactionsWithBackingStore.cpp
+++ b/tests/Cache/TransactionsWithBackingStore.cpp
@@ -225,8 +225,8 @@ TEST(CacheWithBackingStoreTest, test_hit_rate_for_mixed_workload_LongRunning) {
   if (expected < 0.0) {
     expected = 0.01;
   }
-  EXPECT_GE(hitRates.first, 0.1);
-  EXPECT_GE(hitRates.second, 2.5);
+  EXPECT_GE(hitRates.first, expected);
+  EXPECT_GE(hitRates.second, expected);
 
   RandomGenerator::shutdown();
 }

--- a/tests/Cache/TransactionsWithBackingStore.cpp
+++ b/tests/Cache/TransactionsWithBackingStore.cpp
@@ -35,6 +35,7 @@
 
 #include "Cache/Manager.h"
 #include "Cache/Rebalancer.h"
+#include "Logger/LogMacros.h"
 #include "Random/RandomGenerator.h"
 
 #include "MockScheduler.h"
@@ -137,8 +138,8 @@ TEST(CacheWithBackingStoreTest, test_hit_rate_for_readonly_hotset_workload_LongR
   threads.clear();
 
   auto hitRates = manager.globalHitRates();
-  EXPECT_TRUE(hitRates.first >= 15.0);
-  EXPECT_TRUE(hitRates.second >= 30.0);
+  EXPECT_GE(hitRates.first, 15.0);
+  EXPECT_GE(hitRates.second, 30.0);
 
   RandomGenerator::shutdown();
 }
@@ -156,6 +157,7 @@ TEST(CacheWithBackingStoreTest, test_hit_rate_for_mixed_workload_LongRunning) {
   std::uint64_t batchSize = 1000;
   std::size_t readerCount = 4;
   std::size_t writerCount = 2;
+  std::atomic<std::size_t> documentsRead(0);
   std::atomic<std::size_t> writersDone(0);
   auto writeWaitInterval = std::chrono::milliseconds(10);
 
@@ -164,7 +166,9 @@ TEST(CacheWithBackingStoreTest, test_hit_rate_for_mixed_workload_LongRunning) {
     store.insert(nullptr, TransactionalStore::Document(i));
   }
 
-  auto readWorker = [&store, &writersDone, writerCount, totalDocuments]() -> void {
+  auto readWorker = [&store, &writersDone, &documentsRead, writerCount,
+                     totalDocuments]() -> void {
+    std::size_t localRead = 0;
     while (writersDone.load() < writerCount) {
       std::uint64_t choice = RandomGenerator::interval(totalDocuments);
       if (choice == 0) {
@@ -172,8 +176,10 @@ TEST(CacheWithBackingStoreTest, test_hit_rate_for_mixed_workload_LongRunning) {
       }
 
       auto d = store.lookup(nullptr, choice);
+      ++localRead;
       TRI_ASSERT(!d.empty());
     }
+    documentsRead += localRead;
   };
 
   auto writeWorker = [&store, &writersDone, batchSize,
@@ -214,8 +220,13 @@ TEST(CacheWithBackingStoreTest, test_hit_rate_for_mixed_workload_LongRunning) {
   threads.clear();
 
   auto hitRates = manager.globalHitRates();
-  EXPECT_TRUE(hitRates.first >= 0.1);
-  EXPECT_TRUE(hitRates.second >= 2.5);
+  double expected =
+      (static_cast<double>(documentsRead.load()) / static_cast<double>(totalDocuments)) - 2.0;
+  if (expected < 0.0) {
+    expected = 0.01;
+  }
+  EXPECT_GE(hitRates.first, 0.1);
+  EXPECT_GE(hitRates.second, 2.5);
 
   RandomGenerator::shutdown();
 }


### PR DESCRIPTION
# Scope & Purpose

Fixes a potential divide-by-zero error in the cache that was discovered by the undefined behavior sanitizer. Also adjusts a non-deterministic test which had an arbitrary success threshold to use a less-arbitrary threshold which should actually reveal something wrong (rather than just bad luck) if it isn't met.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

Jenkins: https://jenkins.arangodb.biz/job/arangodb-matrix-pr/9579/