### PR TITLE
[3.6] Fix potential divide-by-zero in cache and fix non-deterministic test

### DIFF
--- a/arangod/Cache/Cache.cpp
+++ b/arangod/Cache/Cache.cpp
@@ -312,7 +312,8 @@ bool Cache::reportInsert(bool hadEviction) {
   if ((basics::SharedPRNG::rand() & _evictionMask) == 0) {
     uint64_t total = _insertsTotal.value(std::memory_order_relaxed);
     uint64_t evictions = _insertEvictions.value(std::memory_order_relaxed);
-    if ((static_cast<double>(evictions) / static_cast<double>(total)) > _evictionRateThreshold) {
+    if (total > 0 && total > evictions &&
+        (static_cast<double>(evictions) / static_cast<double>(total)) > _evictionRateThreshold) {
       shouldMigrate = true;
       cache::Table* table = _table.load(std::memory_order_relaxed);
       TRI_ASSERT(table != nullptr);


### PR DESCRIPTION
# Scope & Purpose

Fixes a potential divide-by-zero error in the cache that was discovered by the undefined behavior sanitizer. Also adjusts a non-deterministic test which had an arbitrary success threshold to use a less-arbitrary threshold which should actually reveal something wrong (rather than just bad luck) if it isn't met.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

Jenkins: https://jenkins.arangodb.biz/job/arangodb-matrix-pr/9580/ (blue except unrelated failures)