### PR TITLE
Feature/cleanup collect node registers

### DIFF
--- a/arangod/Aql/CollectNode.cpp
+++ b/arangod/Aql/CollectNode.cpp
@@ -552,6 +552,9 @@ namespace {
 // Get all variables that should be collected "INTO" the group variable.
 // Returns whether we are at the top level.
 // Gets passed whether we did encounter a loop "on the way" from the collect node.
+// TODO As this is now called in instantiateFromAst, thus earliest possible,
+//      the whole spliced subquery handling could be removed here to simplify
+//      the code.
 [[nodiscard]] auto calculateAccessibleUserVariables(ExecutionNode const& node,
                                                     std::vector<Variable const*>& userVariables,
                                                     bool const encounteredLoop,

--- a/arangod/Aql/CollectNode.cpp
+++ b/arangod/Aql/CollectNode.cpp
@@ -786,8 +786,16 @@ std::vector<Variable const*> const& CollectNode::keepVariables() const {
   return _keepVariables;
 }
 
-void CollectNode::setKeepVariables(std::vector<Variable const*>&& variables) {
-  _keepVariables = std::move(variables);
+void CollectNode::restrictKeepVariables(std::unordered_set<const Variable*> const& variables) {
+  auto remainingKeepVariables = decltype(this->_keepVariables){};
+  remainingKeepVariables.reserve(std::min(_keepVariables.size(), variables.size()));
+
+  std::copy_if(_keepVariables.begin(), _keepVariables.end(),
+               std::back_inserter(remainingKeepVariables), [&](auto const& var) {
+                 return variables.find(var) != variables.end();
+               });
+
+  _keepVariables = std::move(remainingKeepVariables);
 }
 
 std::unordered_map<VariableId, std::string const> const& CollectNode::variableMap() const {

--- a/arangod/Aql/CollectNode.h
+++ b/arangod/Aql/CollectNode.h
@@ -189,6 +189,9 @@ class CollectNode : public ExecutionNode {
 
   [[nodiscard]] auto getOutputVariables() const -> VariableIdSet final;
 
+  static void calculateAccessibleUserVariables(ExecutionNode const& node,
+                                               std::vector<Variable const*>& userVariables);
+
  private:
   /// @brief options for the aggregation
   CollectOptions _options;

--- a/arangod/Aql/CollectNode.h
+++ b/arangod/Aql/CollectNode.h
@@ -113,7 +113,8 @@ class CollectNode : public ExecutionNode {
                               std::unordered_set<RegisterId>& writeableOutputRegisters) const;
 
   void calcAggregateTypes(std::vector<std::unique_ptr<Aggregator>>& aggregateTypes) const;
-  void calcVariableNames(std::vector<std::pair<std::string, RegisterId>>& variableNames) const;
+
+  std::vector<std::pair<std::string, RegisterId>> calcInputVariableNames() const;
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
@@ -142,6 +143,9 @@ class CollectNode : public ExecutionNode {
 
   /// @brief clear the out variable
   void clearOutVariable();
+
+  /// @brief clear all keep variables
+  void clearKeepVariables();
 
   void setAggregateVariables(
       std::vector<std::pair<Variable const*, std::pair<Variable const*, std::string>>> const& aggregateVariables);

--- a/arangod/Aql/CollectNode.h
+++ b/arangod/Aql/CollectNode.h
@@ -163,8 +163,9 @@ class CollectNode : public ExecutionNode {
   /// @brief return the keep variables
   std::vector<Variable const*> const& keepVariables() const;
 
-  /// @brief set list of variables to keep if INTO is used
-  void setKeepVariables(std::vector<Variable const*>&& variables);
+  /// @brief restrict the KEEP variables (which may also be the auto-collected
+  /// variables of an unrestricted `INTO var`) to the passed `variables`.
+  void restrictKeepVariables(std::unordered_set<const Variable*> const& variables);
 
   /// @brief return the variable map
   std::unordered_map<VariableId, std::string const> const& variableMap() const;

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -1551,6 +1551,13 @@ ExecutionNode* ExecutionPlan::fromNodeCollect(ExecutionNode* previous, AstNode c
       TRI_ASSERT(ref->type == NODE_TYPE_REFERENCE);
       keepVariables.emplace_back(static_cast<Variable const*>(ref->getData()));
     }
+  } else if (into->type != NODE_TYPE_NOP && expression->type == NODE_TYPE_NOP) {
+    // `COLLECT ... INTO var ...` with neither an explicit expression
+    // (INTO var = <expr>), nor an explicit `KEEP`.
+    // In this case, we look for all previously defined user-defined variables
+    // , which are in our scope, and which aren't top-level variables in the
+    // (sub)query the COLLECT resides in.
+    CollectNode::calculateAccessibleUserVariables(*previous, keepVariables);
   }
 
   auto collectNode =

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -1250,6 +1250,7 @@ void arangodb::aql::removeCollectVariablesRule(Optimizer* opt,
       // outVariable not used later
       if (!collectNode->count()) {
         collectNode->clearOutVariable();
+        collectNode->clearKeepVariables();
       }
       modified = true;
     } else if (outVariable != nullptr && !collectNode->count() &&

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -1253,7 +1253,7 @@ void arangodb::aql::removeCollectVariablesRule(Optimizer* opt,
       }
       modified = true;
     } else if (outVariable != nullptr && !collectNode->count() &&
-               !collectNode->hasExpressionVariable() && !collectNode->hasKeepVariables()) {
+               !collectNode->hasExpressionVariable()) {
       // outVariable used later, no count, no INTO expression, no KEEP
       // e.g. COLLECT something INTO g
       // we will now check how many parts of "g" are used later
@@ -1313,7 +1313,7 @@ void arangodb::aql::removeCollectVariablesRule(Optimizer* opt,
       }  // end - inspection of nodes below the found collect node - while valid planNode
 
       if (doOptimize) {
-        std::vector<Variable const*> keepVariables;
+        auto keepVariables = std::unordered_set<Variable const*>{};
         // we are allowed to do the optimization
         auto current = n->getFirstDependency();
         while (current != nullptr) {
@@ -1321,7 +1321,7 @@ void arangodb::aql::removeCollectVariablesRule(Optimizer* opt,
             for (auto it = keepAttributes.begin(); it != keepAttributes.end();
                  /* no hoisting */) {
               if ((*it) == var->name) {
-                keepVariables.emplace_back(var);
+                keepVariables.emplace(var);
                 it = keepAttributes.erase(it);
               } else {
                 ++it;
@@ -1336,7 +1336,7 @@ void arangodb::aql::removeCollectVariablesRule(Optimizer* opt,
         }  // while current
 
         if (keepAttributes.empty() && !keepVariables.empty()) {
-          collectNode->setKeepVariables(std::move(keepVariables));
+          collectNode->restrictKeepVariables(keepVariables);
           modified = true;
         }
       }  // end - if doOptimize

--- a/tests/js/server/aql/aql-optimizer-keep.js
+++ b/tests/js/server/aql/aql-optimizer-keep.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global assertTrue, assertFalse, assertEqual, assertNotEqual, AQL_EXECUTE, AQL_EXPLAIN */
+/*global AQL_EXECUTE, AQL_EXPLAIN */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief tests for COLLECT w/ KEEP
@@ -29,6 +29,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 var jsunity = require("jsunity");
+const {assertTrue, assertFalse, assertEqual, assertNotEqual} = jsunity.jsUnity.assertions;
 var internal = require("internal");
 var errors = internal.errors;
 var db = require("@arangodb").db;
@@ -232,7 +233,8 @@ function optimizerKeepTestSuite () {
 
       assertEqual("x", collect.groups[0].outVariable.name);
       assertEqual("g", collect.outVariable.name);
-      assertFalse(collect.hasOwnProperty("keepVariables"));
+      assertTrue(collect.hasOwnProperty("keepVariables"));
+      assertEqual(["doc1", "doc2"], collect.keepVariables.map(v => v.variable.name).sort());
     }
 
   };


### PR DESCRIPTION
This PR removes all implicit register/variable calculations of COLLECT, so the register planning is able to plan register and variable usage correctly.