### PR TITLE
Fix invalid value of isSystem attribute for non-system databases.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.6.4 (XXXX-XX-XX)
 -------------------
 
+* Fix invalid value of `isSystem` attribute for non-system databases.
+
 * Updated OpenSSL to 1.1.1g.
 
 * Fix creation of example graphs when `--cluster.min-replication-factor` is set

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.6.4 (XXXX-XX-XX)
 -------------------
 
-* Fix invalid value of `isSystem` attribute for non-system databases.
+* Fixed issue 11243: `db._isSystem()` returns true for a non-system DB.
 
 * Fixed issue #11303: The result data of filter operation on edge document with 
   _from or _to field ALWAYS miss some data on version 3.6.2.

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -1204,8 +1204,6 @@ bool HeartbeatThread::handlePlanChangeCoordinator(uint64_t currentPlanVersion) {
       arangodb::CreateDatabaseInfo info(_server);
       TRI_ASSERT(options.value.get("name").isString());
       // when loading we allow system database names
-      info.allowSystemDB(TRI_vocbase_t::IsSystemName(options.value.get("name").copyString()));
-
       auto infoResult =  info.load(options.value, VPackSlice::emptyArraySlice());
       if (infoResult.fail()) {
         LOG_TOPIC("3fa12", ERR, Logger::HEARTBEAT) << "In agency database plan" << infoResult.errorMessage();

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -2938,10 +2938,7 @@ int RestReplicationHandler::createCollection(VPackSlice slice,
   VPackBuilder patch;
   patch.openObject();
   patch.add("version", VPackValue(static_cast<int>(LogicalCollection::Version::v31)));
-  if (!name.empty() && name[0] == '_' && !slice.hasKey("isSystem")) {
-    // system collection?
-    patch.add("isSystem", VPackValue(true));
-  }
+  patch.add(StaticStrings::DataSourceSystem, VPackValue(TRI_vocbase_t::IsSystemName(name)));
   patch.add("objectId", VPackSlice::nullSlice());
   patch.add("cid", VPackSlice::nullSlice());
   patch.add("id", VPackSlice::nullSlice());

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -1276,7 +1276,6 @@ int DatabaseFeature::iterateDatabases(VPackSlice const& databases) {
 
       // try to open this database
       arangodb::CreateDatabaseInfo info(server());
-      info.allowSystemDB(true);
       auto res = info.load(it, VPackSlice::emptyArraySlice());
       if (res.fail()) {
         THROW_ARANGO_EXCEPTION(res);

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -104,30 +104,29 @@ arangodb::Result Databases::info(TRI_vocbase_t* vocbase, VPackBuilder& result) {
 
     VPackSlice value = commRes.slice()[0].get<std::string>(
         {AgencyCommManager::path(), "Plan", "Databases", vocbase->name()});
-    if (value.isObject() && value.hasKey("name")) {
-      VPackValueLength l = 0;
-      const char* name = value.get("name").getString(l);
-      TRI_ASSERT(l > 0);
+    if (value.isObject() && value.hasKey(StaticStrings::DataSourceName)) {
+      std::string name = value.get(StaticStrings::DataSourceName).copyString();
 
       VPackObjectBuilder b(&result);
-      result.add("name", value.get("name"));
-      if (value.get("id").isString()) {
-        result.add("id", value.get("id"));
-      } else if (value.get("id").isNumber()) {
-        result.add("id", VPackValue(std::to_string(value.get("id").getUInt())));
+      result.add(StaticStrings::DataSourceName, VPackValue(name));
+      VPackSlice s = value.get(StaticStrings::DataSourceId);
+      if (s.isString()) {
+        result.add(StaticStrings::DataSourceId, s);
+      } else if (s.isNumber()) {
+        result.add(StaticStrings::DataSourceId, VPackValue(std::to_string(s.getUInt())));
       } else {
         THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
                                        "unexpected type for 'id' attribute");
       }
+      result.add(StaticStrings::DataSourceSystem, VPackValue(TRI_vocbase_t::IsSystemName(name)));
       result.add("path", VPackValue("none"));
-      result.add("isSystem", VPackValue(name[0] == '_'));
     }
   } else {
     VPackObjectBuilder b(&result);
-    result.add("name", VPackValue(vocbase->name()));
-    result.add("id", VPackValue(std::to_string(vocbase->id())));
+    result.add(StaticStrings::DataSourceName, VPackValue(vocbase->name()));
+    result.add(StaticStrings::DataSourceId, VPackValue(std::to_string(vocbase->id())));
+    result.add(StaticStrings::DataSourceSystem, VPackValue(vocbase->isSystem()));
     result.add("path", VPackValue(vocbase->path()));
-    result.add("isSystem", VPackValue(vocbase->isSystem()));
   }
   return Result();
 }
@@ -216,8 +215,8 @@ Result Databases::createCoordinator(CreateDatabaseInfo const& info) {
 
   // This vocbase is needed for the call to methods::Upgrade::createDB, but
   // is just a placeholder
-  CreateDatabaseInfo tmp_info = info;
-  TRI_vocbase_t vocbase(TRI_vocbase_type_e::TRI_VOCBASE_TYPE_NORMAL, std::move(tmp_info));
+  CreateDatabaseInfo tempInfo = info;
+  TRI_vocbase_t vocbase(TRI_vocbase_type_e::TRI_VOCBASE_TYPE_NORMAL, std::move(tempInfo));
 
   // Now create *all* system collections for the database,
   // if any of these fail, database creation is considered unsuccessful
@@ -256,8 +255,8 @@ Result Databases::createOther(CreateDatabaseInfo const& info) {
   DatabaseFeature& databaseFeature = info.server().getFeature<DatabaseFeature>();
 
   TRI_vocbase_t* vocbase = nullptr;
-  auto tmp_info = info;
-  Result createResult = databaseFeature.createDatabase(std::move(tmp_info), vocbase);
+  auto tempInfo = info;
+  Result createResult = databaseFeature.createDatabase(std::move(tempInfo), vocbase);
   if (createResult.fail()) {
     return createResult;
   }

--- a/arangod/VocBase/VocbaseInfo.cpp
+++ b/arangod/VocBase/VocbaseInfo.cpp
@@ -290,8 +290,10 @@ Result CreateDatabaseInfo::checkOptions() {
   // we cannot use IsAllowedName for database name length validation alone, because
   // IsAllowedName allows up to 256 characters. Database names are just up to 64
   // chars long, as their names are also used as filesystem directories (for Foxx apps)
+  bool isSystem = _name == StaticStrings::SystemDatabase;
+
   if (_name.empty() ||
-      !TRI_vocbase_t::IsAllowedName(TRI_vocbase_t::IsSystemName(_name), arangodb::velocypack::StringRef(_name)) ||
+      !TRI_vocbase_t::IsAllowedName(isSystem, arangodb::velocypack::StringRef(_name)) ||
       _name.size() > 64) {
     return Result(TRI_ERROR_ARANGO_DATABASE_NAME_INVALID);
   }

--- a/arangod/VocBase/VocbaseInfo.cpp
+++ b/arangod/VocBase/VocbaseInfo.cpp
@@ -146,7 +146,7 @@ void CreateDatabaseInfo::toVelocyPack(VPackBuilder& builder, bool withUsers) con
   std::string const idString(basics::StringUtils::itoa(_id));
   builder.add(StaticStrings::DatabaseId, VPackValue(idString));
   builder.add(StaticStrings::DatabaseName, VPackValue(_name));
-  builder.add(StaticStrings::DataSourceSystem, VPackValue(_isSystemDB));
+  builder.add(StaticStrings::DataSourceSystem, VPackValue(TRI_vocbase_t::IsSystemName(_name)));
 
   if (ServerState::instance()->isCoordinator()) {
     addClusterOptions(builder, _sharding, _replicationFactor, _writeConcern);
@@ -291,7 +291,7 @@ Result CreateDatabaseInfo::checkOptions() {
   // IsAllowedName allows up to 256 characters. Database names are just up to 64
   // chars long, as their names are also used as filesystem directories (for Foxx apps)
   if (_name.empty() ||
-      !TRI_vocbase_t::IsAllowedName(_isSystemDB, arangodb::velocypack::StringRef(_name)) ||
+      !TRI_vocbase_t::IsAllowedName(TRI_vocbase_t::IsSystemName(_name), arangodb::velocypack::StringRef(_name)) ||
       _name.size() > 64) {
     return Result(TRI_ERROR_ARANGO_DATABASE_NAME_INVALID);
   }

--- a/arangod/VocBase/VocbaseInfo.h
+++ b/arangod/VocBase/VocbaseInfo.h
@@ -123,8 +123,6 @@ class CreateDatabaseInfo {
   ShardingPrototype shardingPrototype() const;
   void shardingPrototype(ShardingPrototype type);
 
-  void allowSystemDB(bool s) { _isSystemDB = s; }
-
  private:
   Result extractUsers(VPackSlice const& users);
   Result extractOptions(VPackSlice const& options, bool extactId = true,
@@ -145,7 +143,6 @@ class CreateDatabaseInfo {
 
   bool _validId = false;
   bool _valid = false;  // required because TRI_ASSERT needs variable in Release mode.
-  bool _isSystemDB = false;
 };
 
 struct VocbaseOptions {

--- a/tests/Aql/IndexNodeTest.cpp
+++ b/tests/Aql/IndexNodeTest.cpp
@@ -49,7 +49,6 @@ class IndexNodeTest
 
 arangodb::CreateDatabaseInfo createInfo(arangodb::application_features::ApplicationServer& server) {
   arangodb::CreateDatabaseInfo info(server);
-  info.allowSystemDB(false);
   auto rv = info.load("testVocbase", 2);
   if (rv.fail()) {
     throw std::runtime_error(rv.errorMessage());

--- a/tests/IResearch/common.cpp
+++ b/tests/IResearch/common.cpp
@@ -886,9 +886,8 @@ void assertFilterParseFail(TRI_vocbase_t& vocbase, std::string const& queryStrin
   ASSERT_TRUE(parseResult.result.fail());
 }
 
-arangodb::CreateDatabaseInfo createInfo(arangodb::application_features::ApplicationServer& server, std::string const& name, uint64_t id, bool allowSystem) {
+arangodb::CreateDatabaseInfo createInfo(arangodb::application_features::ApplicationServer& server, std::string const& name, uint64_t id, bool /*allowSystem*/) {
   arangodb::CreateDatabaseInfo info(server);
-  info.allowSystemDB(allowSystem);
   auto rv = info.load(name, id);
   if(rv.fail()) {
     throw std::runtime_error(rv.errorMessage());

--- a/tests/js/common/shell/01_shell-database.js
+++ b/tests/js/common/shell/01_shell-database.js
@@ -411,6 +411,7 @@ function DatabaseSuite () {
 
     testCreateDatabaseNonSystem : function () {
       assertEqual("_system", internal.db._name());
+      assertTrue(internal.db._isSystem());
 
       try {
         internal.db._dropDatabase("UnitTestsDatabase0");
@@ -420,6 +421,7 @@ function DatabaseSuite () {
       internal.db._createDatabase("UnitTestsDatabase0");
       internal.db._useDatabase("UnitTestsDatabase0");
       assertEqual("UnitTestsDatabase0", internal.db._name());
+      assertFalse(internal.db._isSystem());
 
       // creation of new databases should fail here
       try {
@@ -438,6 +440,7 @@ function DatabaseSuite () {
       }
 
       internal.db._useDatabase("_system");
+      assertTrue(internal.db._isSystem());
       internal.db._dropDatabase("UnitTestsDatabase0");
     },
 
@@ -547,6 +550,7 @@ function DatabaseSuite () {
 
     testUseDatabase : function () {
       assertEqual("_system", internal.db._name());
+      assertTrue(internal.db._isSystem());
 
       try {
         internal.db._dropDatabase("UnitTestsDatabase0");
@@ -556,12 +560,15 @@ function DatabaseSuite () {
       internal.db._createDatabase("UnitTestsDatabase0");
       internal.db._useDatabase("UnitTestsDatabase0");
       assertEqual("UnitTestsDatabase0", internal.db._name());
+      assertFalse(internal.db._isSystem());
 
       internal.db._useDatabase("UnitTestsDatabase0");
       assertEqual("UnitTestsDatabase0", internal.db._name());
+      assertFalse(internal.db._isSystem());
 
       internal.db._useDatabase("_system");
       assertEqual("_system", internal.db._name());
+      assertTrue(internal.db._isSystem());
 
       assertTrue(internal.db._dropDatabase("UnitTestsDatabase0"));
 


### PR DESCRIPTION
### Scope & Purpose

Fix invalid value of `isSystem` attribute for non-system databases.
Should fix https://github.com/arangodb/arangodb/issues/11243

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [ ] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is a GitHub Issue reported by a Community User: https://github.com/arangodb/arangodb/issues/11243

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9632/