### PR TITLE
log level lowered for consolidation warnings

### DIFF
--- a/3rdParty/iresearch/core/index/index_writer.cpp
+++ b/3rdParty/iresearch/core/index/index_writer.cpp
@@ -1480,7 +1480,7 @@ bool index_writer::consolidate(
 
     if (found != candidates.size()) {
       // not all candidates are valid
-      IR_FRMT_WARN(
+      IR_FRMT_DEBUG(
         "Failed to start consolidation for index generation '" IR_UINT64_T_SPECIFIER "', found only '" IR_SIZE_T_SPECIFIER "' out of '" IR_SIZE_T_SPECIFIER "' candidates",
         committed_meta->generation(),
         found,
@@ -1606,7 +1606,7 @@ bool index_writer::consolidate(
       if (res.second != candidates.size()) {
         // at least one candidate is missing
         // can't finish consolidation
-        IR_FRMT_WARN(
+        IR_FRMT_DEBUG(
           "Failed to finish consolidation id='" IR_SIZE_T_SPECIFIER "' for segment '%s', found only '" IR_SIZE_T_SPECIFIER "' out of '" IR_SIZE_T_SPECIFIER "' candidates",
           run_id,
           consolidation_segment.meta.name.c_str(),
@@ -1623,7 +1623,7 @@ bool index_writer::consolidate(
 
         if (!map_removals(mappings, merger, cached_readers_, docs_mask)) {
           // consolidated segment has docs missing from current_committed_meta->segments()
-          IR_FRMT_WARN(
+          IR_FRMT_DEBUG(
             "Failed to finish consolidation id='" IR_SIZE_T_SPECIFIER "' for segment '%s', due removed documents still present the consolidation candidates",
             run_id,
             consolidation_segment.meta.name.c_str()
@@ -1989,7 +1989,7 @@ index_writer::pending_context_t index_writer::flush_all(const before_commit_f& b
       if (res.second != candidates.size()) {
         // at least one candidate is missing
         // in pending meta can't finish consolidation
-        IR_FRMT_WARN(
+        IR_FRMT_DEBUG(
           "Failed to finish merge for segment '%s', found only '" IR_SIZE_T_SPECIFIER "' out of '" IR_SIZE_T_SPECIFIER "' candidates",
           pending_segment.segment.meta.name.c_str(),
           res.second,
@@ -2024,7 +2024,7 @@ index_writer::pending_context_t index_writer::flush_all(const before_commit_f& b
 
         if (!success) {
           // consolidated segment has docs missing from 'segments'
-          IR_FRMT_WARN(
+          IR_FRMT_DEBUG(
             "Failed to finish merge for segment '%s', due removed documents still present the consolidation candidates",
             pending_segment.segment.meta.name.c_str()
           );


### PR DESCRIPTION
warning log level was to high as consolidation interruptions are totally normal on highly loaded systems. This is expected situation, so lowered messages to DEBUG.
  
This change is a trivial rework / code cleanup without any test coverage.

https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/9709/