### PR TITLE
don't swallow error details in case there are some

### DIFF
--- a/arangod/Network/Utils.cpp
+++ b/arangod/Network/Utils.cpp
@@ -281,6 +281,16 @@ int fuerteToArangoErrorCode(fuerte::Error err) {
 }
 
 std::string fuerteToArangoErrorMessage(network::Response const& res) {
+  if (res.response) {
+    // check "errorMessage" attribute first
+    velocypack::Slice s = res.response->slice();
+    if (s.isObject()) {
+      s = s.get(StaticStrings::ErrorMessage);
+      if (s.isString() && s.getStringLength() > 0) {
+        return s.copyString();
+      }
+    }
+  }
   return TRI_errno_string(fuerteToArangoErrorCode(res));
 }
 


### PR DESCRIPTION
### Scope & Purpose

Don't swallow error details in network responses in case they are present.
Right now some errors are reported as "no error" even in case there is a more detailed error message.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9744/