### PR TITLE
fix an unstable test that depended on timing

### DIFF
--- a/tests/js/server/recovery/foxx-directories.js
+++ b/tests/js/server/recovery/foxx-directories.js
@@ -37,7 +37,7 @@ function runSetup () {
   'use strict';
   internal.debugClearFailAt();
 
-  var appPath = fs.join(FoxxService._appPath, '..');
+  let appPath = fs.join(FoxxService._appPath, '..');
 
   try {
     db._dropDatabase('UnitTestsRecovery1');
@@ -57,7 +57,16 @@ function runSetup () {
 
   db._dropDatabase('UnitTestsRecovery2');
 
-  internal.wait(1);
+  // we need to wait long enough for the DatabaseManagerThread to 
+  // physically carry out the deletion
+  let path = fs.join(appPath, 'UnitTestsRecovery2');
+  let tries = 0;
+  while (++tries < 10) {
+    if (!fs.isDirectory(path)) {
+      break;
+    }
+    internal.wait(1, false);
+  }
   internal.debugTerminate('crashing server');
 }
 
@@ -74,7 +83,7 @@ function recoverySuite () {
     tearDown: function () {},
 
     // //////////////////////////////////////////////////////////////////////////////
-    // / @brief test whether we the data are correct after restart
+    // / @brief test whether the data are correct after restart
     // //////////////////////////////////////////////////////////////////////////////
 
     testFoxxDirectories: function () {


### PR DESCRIPTION
### Scope & Purpose

Fix unstable recovery test that depended on timing.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest recovery*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9776/