### PR TITLE
Solve a deadlock problem in the cluster.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix a bad deadlock because transaction cleanup was pushed with too low
+  priority.
+
 * Allow specifying graph names as unquoted string in an AQL graph traversal
   query, e.g. `FOR ... IN ... GRAPH abc`. Previously, the graph name had
   to be a bind parameter or a string enclosed in quotes.

--- a/arangod/Transaction/ManagerFeature.cpp
+++ b/arangod/Transaction/ManagerFeature.cpp
@@ -49,7 +49,10 @@ void queueGarbageCollection(std::mutex& mutex, arangodb::Scheduler::WorkHandle& 
         arangodb::basics::function_utils::retryUntilTimeout<arangodb::Scheduler::WorkHandle>(
             [&gcfunc]() -> std::pair<bool, arangodb::Scheduler::WorkHandle> {
               auto off = std::chrono::seconds(1);
-              return arangodb::SchedulerFeature::SCHEDULER->queueDelay(arangodb::RequestLane::INTERNAL_LOW,
+              // The RequestLane needs to be something which is `HIGH` priority, otherwise
+              // all threads executing this might be blocking, waiting for a lock to be
+              // released.
+              return arangodb::SchedulerFeature::SCHEDULER->queueDelay(arangodb::RequestLane::CLUSTER_INTERNAL,
                                                                        off, gcfunc);
             },
             arangodb::Logger::TRANSACTIONS,


### PR DESCRIPTION
Transaction manager garbage collection was posted on the INTERNAL_LOW
lane, which is a very bad idea.
This can lead to deadlock if an exclusive lock from SynchronizeShard stays due to network failures. The cleanup after 5 minutes would be done by the transaction manager garbage collection. However, if all threads for the low prio queue are blocked on the lock, we have a deadlock.