### PR TITLE
don't exclude certain antiquated collections from replication

### DIFF
--- a/arangod/Replication/common-defines.cpp
+++ b/arangod/Replication/common-defines.cpp
@@ -24,7 +24,6 @@
 #include <time.h>
 
 #include "Basics/system-functions.h"
-#include "Basics/tri-strings.h"
 #include "Replication/common-defines.h"
 
 namespace arangodb {
@@ -64,13 +63,13 @@ bool TRI_ExcludeCollectionReplication(std::string const& name, bool includeSyste
     return true;
   }
 
-  if (TRI_IsPrefixString(name.c_str(), "_statistics") ||
-      name == "_configuration" || name == "_frontend" ||
-      name == "_cluster_kickstarter_plans" || name == "_routing" ||
-      name == "_fishbowl" || name == "_foxxlog" || name == "_sessions") {
+  if (name.compare(0, 11, "_statistics") == 0 ||
+      name == "_routing") {
     // these system collections will always be excluded
     return true;
-  } else if (!includeFoxxQueues && (name == "_jobs" || name == "_queues")) {
+  } 
+  
+  if (!includeFoxxQueues && (name == "_jobs" || name == "_queues")) {
     return true;
   }
 


### PR DESCRIPTION
### Scope & Purpose

Don't exclude certain system collections from replication. This is not necessary, and most of the previously excluded collections are antique and not in use anymore, or it simply does not make any difference if their changes get replicated.

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *replication tests*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9849/