### PR TITLE
reenable crash handler

### DIFF
--- a/arangod/RestServer/arangod.cpp
+++ b/arangod/RestServer/arangod.cpp
@@ -21,7 +21,6 @@
 /// @author Dr. Frank Celler
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <fuerte/FuerteLogger.h>
 #include "Basics/Common.h"
 
 #include "Basics/directories.h"
@@ -138,7 +137,7 @@ using namespace arangodb::application_features;
 
 static int runServer(int argc, char** argv, ArangoGlobalContext& context) {
   try {
-    //CrashHandler::installCrashHandler();
+    CrashHandler::installCrashHandler();
     std::string name = context.binaryName();
 
     auto options = std::make_shared<arangodb::options::ProgramOptions>(


### PR DESCRIPTION
### Scope & Purpose

Reenable previously disabled crash handler.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9850/