### PR TITLE
fixed issue #11590

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 v3.6.4 (XXXX-XX-XX)
 -------------------
 
+* Fixed issue #11590: Querying for document by _key returning only a single 
+  seemingly random property on entity ("old", in this case).
+  
+  This fixes single-key document lookups in the cluster for simple by-key
+  AQL queries, such as `FOR doc IN collection FILTER doc._key == @key RETURN doc`
+  in case the document has either an "old" or a "new" attribute. 
+
 * Fix a dead-lock situation in hot-backup case.
 
   If the cluster is under high write load, then a hot-backup is requested, and

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,12 @@
 v3.6.4 (XXXX-XX-XX)
 -------------------
 
-* Fixed issue #11590: Querying for document by _key returning only a single 
+* Fixed issue #11590: Querying for document by _key returning only a single
   seemingly random property on entity ("old", in this case).
-  
+
   This fixes single-key document lookups in the cluster for simple by-key
-  AQL queries, such as `FOR doc IN collection FILTER doc._key == @key RETURN doc`
-  in case the document has either an "old" or a "new" attribute. 
+  AQL queries, such as `FOR doc IN collection FILTER doc._key == @key RETURN
+  doc` in case the document has either an "old" or a "new" attribute.
 
 * Fix a bad deadlock because transaction cleanup was pushed with too low
   priority.

--- a/arangod/Aql/SingleRemoteModificationExecutor.cpp
+++ b/arangod/Aql/SingleRemoteModificationExecutor.cpp
@@ -195,10 +195,10 @@ bool SingleRemoteModificationExecutor<Modifier>::doSingleRemoteModificationOpera
   if (result.buffer) {
     outDocument = result.slice().resolveExternal();
   }
-
+    
   VPackSlice oldDocument = VPackSlice::nullSlice();
   VPackSlice newDocument = VPackSlice::nullSlice();
-  if (outDocument.isObject()) {
+  if (!isIndex && outDocument.isObject()) {
     if (_info._outputNewRegisterId != RegisterPlan::MaxRegisterId &&
         outDocument.hasKey("new")) {
       newDocument = outDocument.get("new");


### PR DESCRIPTION
### Scope & Purpose

Fix issue #11590.
There was an issue when in a cluster a SingleRemoteNode was used to retrieve a document and this document either had an "old" or a "new" attribute. In this case, the document was not correctly returned.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is a GitHub Issue reported by a Community User: https://github.com/arangodb/arangodb/issues/11590

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9875/