### PR TITLE
fixed issue #11590

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,13 @@
 devel
 -----
+
+* Fixed issue #11590: Querying for document by _key returning only a single 
+  seemingly random property on entity ("old", in this case).
+  
+  This fixes single-key document lookups in the cluster for simple by-key
+  AQL queries, such as `FOR doc IN collection FILTER doc._key == @key RETURN doc`
+  in case the document has either an "old" or a "new" attribute. 
+
 * Moved calculation of registers to keep into the register planning. It can be
   calculated more efficiently there.
 

--- a/arangod/Aql/SingleRemoteModificationExecutor.cpp
+++ b/arangod/Aql/SingleRemoteModificationExecutor.cpp
@@ -214,16 +214,18 @@ auto SingleRemoteModificationExecutor<Modifier>::doSingleRemoteModificationOutpu
   if (result.buffer) {
     outDocument = result.slice().resolveExternal();
   }
-
+  
+  const bool isIndex = std::is_same<Modifier, IndexTag>::value;
+    
   VPackSlice oldDocument = VPackSlice::nullSlice();
   VPackSlice newDocument = VPackSlice::nullSlice();
-  if (outDocument.isObject()) {
+  if (!isIndex && outDocument.isObject()) {
     if (_info._outputNewRegisterId != RegisterPlan::MaxRegisterId &&
-        outDocument.hasKey("new")) {
-      newDocument = outDocument.get("new");
+        outDocument.hasKey(StaticStrings::New)) {
+      newDocument = outDocument.get(StaticStrings::New);
     }
-    if (outDocument.hasKey("old")) {
-      outDocument = outDocument.get("old");
+    if (outDocument.hasKey(StaticStrings::Old)) {
+      outDocument = outDocument.get(StaticStrings::Old);
       if (_info._outputOldRegisterId != RegisterPlan::MaxRegisterId) {
         oldDocument = outDocument;
       }


### PR DESCRIPTION
### Scope & Purpose

Fix issue #11590.
There was an issue when in a cluster a SingleRemoteNode was used to retrieve a document and this document either had an "old" or a "new" attribute. In this case, the document was not correctly returned.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is a GitHub Issue reported by a Community User: https://github.com/arangodb/arangodb/issues/11590

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9876/