### PR TITLE
fixed issue #11590

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,8 +5,8 @@ v3.5.6 (XXXX-XX-XX)
   seemingly random property on entity ("old", in this case).
 
   This fixes single-key document lookups in the cluster for simple by-key
-  AQL queries, such as `FOR doc IN collection FILTER doc._key == @key RETURN doc`
-  in case the document has either an "old" or a "new" attribute.
+  AQL queries, such as `FOR doc IN collection FILTER doc._key == @key RETURN
+  doc`in case the document has either an "old" or a "new" attribute.
 
 
 v3.5.5.1 (2020-05-08)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@ v3.5.6 (XXXX-XX-XX)
 
   This fixes single-key document lookups in the cluster for simple by-key
   AQL queries, such as `FOR doc IN collection FILTER doc._key == @key RETURN
-  doc`in case the document has either an "old" or a "new" attribute.
+  doc` in case the document has either an "old" or a "new" attribute.
 
 
 v3.5.5.1 (2020-05-08)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+v3.5.6 (XXXX-XX-XX)
+-------------------
+
+* Fixed issue #11590: Querying for document by _key returning only a single
+  seemingly random property on entity ("old", in this case).
+
+  This fixes single-key document lookups in the cluster for simple by-key
+  AQL queries, such as `FOR doc IN collection FILTER doc._key == @key RETURN doc`
+  in case the document has either an "old" or a "new" attribute.
+
+
 v3.5.5.1 (2020-05-08)
 ---------------------
 

--- a/arangod/Aql/SingleRemoteModificationExecutor.cpp
+++ b/arangod/Aql/SingleRemoteModificationExecutor.cpp
@@ -199,7 +199,7 @@ bool SingleRemoteModificationExecutor<Modifier>::doSingleRemoteModificationOpera
 
   VPackSlice oldDocument = VPackSlice::nullSlice();
   VPackSlice newDocument = VPackSlice::nullSlice();
-  if (outDocument.isObject()) {
+  if (!isIndex && outDocument.isObject()) {
     if (_info._outputNewRegisterId != ExecutionNode::MaxRegisterId &&
         outDocument.hasKey("new")) {
       newDocument = outDocument.get("new");

--- a/tests/js/server/aql/aql-optimizer-optimize-cluster-single-document-operations.js
+++ b/tests/js/server/aql/aql-optimizer-optimize-cluster-single-document-operations.js
@@ -163,6 +163,46 @@ function optimizerClusterSingleDocumentTestSuite () {
       db._drop(cn3);
     },
 
+    testFetchDocumentWithOldAttribute : function() {
+      let doc = c1.save({ _key: "oldDoc", old: "abc" });
+      
+      const queries = [
+        [ "FOR one IN @@cn1 FILTER one._key == 'oldDoc' RETURN one._id", cn1 + "/oldDoc" ],
+        [ "FOR one IN @@cn1 FILTER one._key == 'oldDoc' RETURN one._key", "oldDoc" ],
+        [ "FOR one IN @@cn1 FILTER one._key == 'oldDoc' RETURN one._rev", doc._rev ],
+        [ "FOR one IN @@cn1 FILTER one._key == 'oldDoc' RETURN one.old", "abc" ],
+        [ "FOR one IN @@cn1 FILTER one._key == 'oldDoc' RETURN one", { _key: "oldDoc", _rev: doc._rev, old: "abc", _id: cn1 + "/oldDoc" } ],
+      ];
+
+      queries.forEach(function(query) {
+        let result = AQL_EXPLAIN(query[0], { "@cn1" : cn1 });
+        assertNotEqual(-1, result.plan.rules.indexOf(ruleName));
+
+        result = AQL_EXECUTE(query[0], { "@cn1" : cn1 }).json;
+        assertEqual(query[1], result[0]);
+      });
+    },
+    
+    testFetchDocumentWithNewAttribute : function() {
+      let doc = c1.save({ _key: "newDoc", "new": "abc" });
+      
+      const queries = [
+        [ "FOR one IN @@cn1 FILTER one._key == 'newDoc' RETURN one._id", cn1 + "/newDoc" ],
+        [ "FOR one IN @@cn1 FILTER one._key == 'newDoc' RETURN one._key", "newDoc" ],
+        [ "FOR one IN @@cn1 FILTER one._key == 'newDoc' RETURN one._rev", doc._rev ],
+        [ "FOR one IN @@cn1 FILTER one._key == 'newDoc' RETURN one.`new`", "abc" ],
+        [ "FOR one IN @@cn1 FILTER one._key == 'newDoc' RETURN one", { _key: "newDoc", _rev: doc._rev, "new": "abc", _id: cn1 + "/newDoc" } ],
+      ];
+
+      queries.forEach(function(query) {
+        let result = AQL_EXPLAIN(query[0], { "@cn1" : cn1 });
+        assertNotEqual(-1, result.plan.rules.indexOf(ruleName));
+
+        result = AQL_EXECUTE(query[0], { "@cn1" : cn1 }).json;
+        assertEqual(query[1], result[0]);
+      });
+    },
+    
     ////////////////////////////////////////////////////////////////////////////////
     /// @brief test plans that should result
     ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose

Fix issue #11590.
There was an issue when in a cluster a SingleRemoteNode was used to retrieve a document and this document either had an "old" or a "new" attribute. In this case, the document was not correctly returned.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is a GitHub Issue reported by a Community User: https://github.com/arangodb/arangodb/issues/11590

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9877/