### PR TITLE
[3.5] Fix bug where early abort condition aborts too early 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,8 +2,8 @@ v3.5.6 (XXXX-XX-XX)
 -------------------
 
 * Fixed issue #10371: For k-shortest-paths queries on certain graphs a condition
-  to abort search was too eager and hence missed the shortest path between
-  two vertices and returned a longer one.
+  to abort search was too eager and hence missed the shortest path between two
+  vertices and returned a longer one.
 
 * Fixed issue #11590: Querying for document by _key returning only a single
   seemingly random property on entity ("old", in this case).

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.5.6 (XXXX-XX-XX)
 -------------------
 
+* Fixed issue #10371: For k-shortest-paths queries on certain graphs a condition
+  to abort search was too eager and hence missed the shortest path between
+  two vertices and returned a longer one.
+
 * Fixed issue #11590: Querying for document by _key returning only a single
   seemingly random property on entity ("old", in this case).
 

--- a/arangod/Graph/KShortestPathsFinder.cpp
+++ b/arangod/Graph/KShortestPathsFinder.cpp
@@ -80,13 +80,11 @@ bool KShortestPathsFinder::computeShortestPath(VertexRef const& start, VertexRef
 
   // We will not improve anymore if we have found a best path and the smallest
   // combined distance between left and right is bigger than that path
-  while (!left._frontier.empty() && !right._frontier.empty() &&
-         !(currentBest.has_value() &&
-           (left._closest + right._closest > currentBest.value()))) {
+  while (!left.done(currentBest) && !right.done(currentBest)) {
     _options.isQueryKilledCallback();
 
     // Choose the smaller frontier to expand.
-    if (left._frontier.size() < right._frontier.size()) {
+    if (!left.done(currentBest) && (left._frontier.size() < right._frontier.size())) {
       advanceFrontier(left, right, forbiddenVertices, forbiddenEdges, join, currentBest);
     } else {
       advanceFrontier(right, left, forbiddenVertices, forbiddenEdges, join, currentBest);

--- a/arangod/Graph/KShortestPathsFinder.h
+++ b/arangod/Graph/KShortestPathsFinder.h
@@ -166,7 +166,10 @@ class KShortestPathsFinder : public ShortestPathFinder {
       _frontier.insert(centre, std::make_unique<DijkstraInfo>(centre));
     }
     ~Ball() = default;
-    const VertexRef centre() const { return _centre; };
+    const VertexRef center() const { return _center; };
+    bool done(std::optional<double> const currentBest) {
+      return _frontier.empty() || (currentBest.has_value() && currentBest.value() < _closest);
+    };
   };
 
   //

--- a/arangod/Graph/KShortestPathsFinder.h
+++ b/arangod/Graph/KShortestPathsFinder.h
@@ -166,7 +166,7 @@ class KShortestPathsFinder : public ShortestPathFinder {
       _frontier.insert(centre, std::make_unique<DijkstraInfo>(centre));
     }
     ~Ball() = default;
-    const VertexRef center() const { return _center; };
+    const VertexRef centre() const { return _centre; };
     bool done(std::optional<double> const currentBest) {
       return _frontier.empty() || (currentBest.has_value() && currentBest.value() < _closest);
     };

--- a/arangod/Graph/KShortestPathsFinder.h
+++ b/arangod/Graph/KShortestPathsFinder.h
@@ -167,7 +167,7 @@ class KShortestPathsFinder : public ShortestPathFinder {
     }
     ~Ball() = default;
     const VertexRef centre() const { return _centre; };
-    bool done(std::optional<double> const currentBest) {
+    bool done(boost::optional<double> const currentBest) {
       return _frontier.empty() || (currentBest.has_value() && currentBest.value() < _closest);
     };
   };

--- a/tests/js/server/aql/aql-graph-k-shortest-path-early-abort-regression.js
+++ b/tests/js/server/aql/aql-graph-k-shortest-path-early-abort-regression.js
@@ -1,0 +1,119 @@
+/*jshint globalstrict:false, strict:false, sub: true, maxlen: 500 */
+/*global assertEqual, assertTrue, assertFalse */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief tests for query language, graph functions
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+/// @author Copyright 2020, ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const db = require("@arangodb").db;
+const gm = require("@arangodb/general-graph");
+const _ = require("underscore");
+
+const graphName = "UnitTestGraph";
+const vName = "UnitTestVertices";
+const eName = "UnitTestEdges";
+
+const tearDownAll = () => {
+  try {
+    gm._drop(graphName, true);
+  } catch (e) {
+    // Don't care for error, we might runinitially with no graph exist
+  }
+  db._drop(eName);
+  db._drop(vName);
+};
+
+const createGraph = () => {
+  gm._create(graphName, [gm._relation(eName, vName, vName)], [], {});
+
+  const vertices = [];
+  const edges = [];
+
+  for (var i = 0; i < 9; i++) {
+    vertices.push({
+      _key: i.toString(),
+    });
+  }
+
+  edges.push({ _from: `${vName}/0`, _to: `${vName}/1`, weight: 1000 });
+  edges.push({ _from: `${vName}/0`, _to: `${vName}/4`, weight: 500 });
+
+  edges.push({ _from: `${vName}/2`, _to: `${vName}/1`, weight: 500 });
+
+  edges.push({ _from: `${vName}/3`, _to: `${vName}/2`, weight: 50 });
+  edges.push({ _from: `${vName}/3`, _to: `${vName}/6`, weight: 200 });
+  edges.push({ _from: `${vName}/3`, _to: `${vName}/7`, weight: 300 });
+
+  edges.push({ _from: `${vName}/4`, _to: `${vName}/3`, weight: 50 });
+
+  edges.push({ _from: `${vName}/5`, _to: `${vName}/2`, weight: 100 });
+
+  db[vName].save(vertices);
+  db[eName].save(edges);
+};
+
+function kEarlyAbortRegressionTest() {
+  return {
+    setUpAll: function () {
+      tearDownAll();
+      createGraph();
+    },
+    tearDownAll,
+
+    testPathsExists: function () {
+      const query = `
+        FOR path IN OUTBOUND K_SHORTEST_PATHS "${vName}/0" TO "${vName}/1" GRAPH "${graphName}"
+          OPTIONS {weightAttribute: "weight"}
+          LIMIT 1
+          RETURN path`;
+      const result = db._query(query).toArray();
+      assertEqual(result.length, 1);
+      const path = result[0];
+      assertEqual(1000, path.weight);
+      assertEqual(
+        ["0", "1"],
+        path.vertices.map((v) => v._key)
+      );
+      assertEqual(
+        [[`${vName}/0`, `${vName}/1`]],
+        path.edges.map((e) => [e._from, e._to])
+      );
+    },
+
+    testPaths: function () {
+      const query = `
+        FOR path IN OUTBOUND K_SHORTEST_PATHS "${vName}/0" TO "${vName}/1" GRAPH "${graphName}"
+          OPTIONS {weightAttribute: "weight"}
+          RETURN path.weight`;
+      const result = db._query(query).toArray();
+      assertEqual([1000,1100], result);
+    },
+  };
+}
+
+jsunity.run(kEarlyAbortRegressionTest);
+return jsunity.done();


### PR DESCRIPTION
(Backport of #11602)

Before this path the k-shortest-paths algorithm kept a record
of the weight of the done vertex furthest away from the centre,
and a record of the weight of the currently best path found.

This was used to stop search if

start.furthest + end.furthest > currentBest

which is wrong, as (wlog) the start side can find a any vertex in the
target side, including the target vertex itself. vertex on the target side that is closer to the target than the current furthest away.

We now stop search for a neighbourhood, if the known highest weight
is higher than current best path weight, as we are not
going to find a shorter path originating in this neighbourhood.