### PR TITLE
Port bug fix to 3.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.5.6 (XXXX-XX-XX)
 -------------------
 
+* Do not always loadPlan from agency whenever collections of a database
+  are listed. This is particularly important for arangosync.
+
 * Fixed issue #11590: Querying for document by _key returning only a single
   seemingly random property on entity ("old", in this case).
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.5.6 (XXXX-XX-XX)
 -------------------
 
-* Do not always loadPlan from agency whenever collections of a database
-  are listed. This is particularly important for arangosync.
+* Do not always loadPlan from agency when collections of a database are listed.
+  This is particularly important for arangosync.
 
 * Fixed issue #11590: Querying for document by _key returning only a single
   seemingly random property on entity ("old", in this case).

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1294,9 +1294,6 @@ std::string ClusterInfo::getCollectionNotFoundMsg(DatabaseID const& databaseID,
 std::vector<std::shared_ptr<LogicalCollection>> const ClusterInfo::getCollections(DatabaseID const& databaseID) {
   std::vector<std::shared_ptr<LogicalCollection>> result;
 
-  // always reload
-  loadPlan();
-
   READ_LOCKER(readLocker, _planProt.lock);
   // look up database by id
   AllCollections::const_iterator it = _plannedCollections.find(databaseID);


### PR DESCRIPTION
Port a bug fix to 3.5 from 3.6. Do not always loadPlan from agency when collections of a database are listed.