### PR TITLE
Port bugfix from 3.6 to 3.4.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.4.10 (2020-04-24)
 --------------------
 
+* Do not always loadPlan from agency when collections of a database are
+  listed. This is particularly important for arangosync.
+
 * Don't invoke collection key ranges compaction after performing a truncate
   operation on a RocksDB storage engine collection via the REST API's truncate
   endpoint.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,12 @@
-v3.4.10 (2020-04-24)
+v3.4.11 (XXXX-XX-XX)
 --------------------
 
-* Do not always loadPlan from agency when collections of a database are
-  listed. This is particularly important for arangosync.
+* Do not always loadPlan from agency when collections of a database are listed.
+  This is particularly important for arangosync.
+
+
+v3.4.10 (2020-04-24)
+--------------------
 
 * Don't invoke collection key ranges compaction after performing a truncate
   operation on a RocksDB storage engine collection via the REST API's truncate

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1230,9 +1230,6 @@ std::string ClusterInfo::getCollectionNotFoundMsg(DatabaseID const& databaseID,
 std::vector<std::shared_ptr<LogicalCollection>> const ClusterInfo::getCollections(DatabaseID const& databaseID) {
   std::vector<std::shared_ptr<LogicalCollection>> result;
 
-  // always reload
-  loadPlan();
-
   READ_LOCKER(readLocker, _planProt.lock);
   // look up database by id
   AllCollections::const_iterator it = _plannedCollections.find(databaseID);


### PR DESCRIPTION
Do not always loadPlan from agency if collections of a database are listed.
This is important for arangosync.