### PR TITLE
Fix drop collection hangers.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 devel
 -----
+
+* Fixed a lockup in dropCollection due to a mutex being held for too long.
+
 * Add an optimizer rule that enables execution of certain subqueries on a
   DB Server. For this optimization to work, the subquery must contain exactly
   one DISTRIBUTE/GATHER pair and only access at most one collection.

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -2662,13 +2662,8 @@ Result ClusterInfo::dropCollectionCoordinator(  // drop collection
         // ...remove the entire directory for the collection
         AgencyOperation delCurrentCollection("Current/Collections/" + dbName + "/" + collectionID,
                                              AgencySimpleOperationType::DELETE_OP);
-        AgencyOperation incrementCurrentVersion(
-          "Current/Version", AgencySimpleOperationType::INCREMENT_OP);
-        AgencyWriteTransaction cx({delCurrentCollection, incrementCurrentVersion});
+        AgencyWriteTransaction cx({delCurrentCollection});
         res = ac.sendTransactionWithFailover(cx);
-        if (res.slice().get("results").length()) {
-          waitForCurrent(res.slice().get("results")[0].getNumber<uint64_t>()).get();
-        }
         events::DropCollection(dbName, collectionID, *dbServerResult);
         return Result(*dbServerResult);
       }

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1655,8 +1655,6 @@ Result ClusterInfo::waitForDatabaseInCurrent(CreateDatabaseInfo const& database)
   {
     double const interval = getPollInterval();
 
-    CONDITION_LOCKER(locker, agencyCallback->_cv);
-
     int count = 0;  // this counts, when we have to reload the DBServers
     while (true) {
       if (++count >= static_cast<int>(getReloadServerListTimeout() / interval)) {
@@ -1679,7 +1677,10 @@ Result ClusterInfo::waitForDatabaseInCurrent(CreateDatabaseInfo const& database)
         return Result(tmpRes, *errMsg);
       }
 
-      agencyCallback->executeByCallbackOrTimeout(getReloadServerListTimeout() / interval);
+      {
+        CONDITION_LOCKER(locker, agencyCallback->_cv);
+        agencyCallback->executeByCallbackOrTimeout(getReloadServerListTimeout() / interval);
+      }
 
       if (_server.isStopping()) {
         return Result(TRI_ERROR_SHUTTING_DOWN);
@@ -1897,8 +1898,6 @@ Result ClusterInfo::dropDatabaseCoordinator(  // drop database
 
   // Now wait stuff in Current to disappear and thus be complete:
   {
-    CONDITION_LOCKER(locker, agencyCallback->_cv);
-
     while (true) {
       if (dbServerResult->load(std::memory_order_acquire) >= 0) {
         cbGuard.fire();  // unregister cb before calling ac.removeValues(...)
@@ -1918,7 +1917,10 @@ Result ClusterInfo::dropDatabaseCoordinator(  // drop database
               return Result(TRI_ERROR_CLUSTER_TIMEOUT);
       }
 
-      agencyCallback->executeByCallbackOrTimeout(interval);
+      {
+        CONDITION_LOCKER(locker, agencyCallback->_cv);
+        agencyCallback->executeByCallbackOrTimeout(interval);
+      }
 
       if (_server.isStopping()) {
               return Result(TRI_ERROR_SHUTTING_DOWN);
@@ -2654,8 +2656,6 @@ Result ClusterInfo::dropCollectionCoordinator(  // drop collection
   }
 
   {
-    CONDITION_LOCKER(locker, agencyCallback->_cv);
-
     while (true) {
       if (*dbServerResult >= 0) {
         cbGuard.fire();  // unregister cb before calling ac.removeValues(...)
@@ -2685,7 +2685,10 @@ Result ClusterInfo::dropCollectionCoordinator(  // drop collection
         return Result(TRI_ERROR_CLUSTER_TIMEOUT);
       }
 
-      agencyCallback->executeByCallbackOrTimeout(interval);
+      {
+        CONDITION_LOCKER(locker, agencyCallback->_cv);
+        agencyCallback->executeByCallbackOrTimeout(interval);
+      }
 
       if (_server.isStopping()) {
         events::DropCollection(dbName, collectionID, TRI_ERROR_SHUTTING_DOWN);
@@ -3668,8 +3671,6 @@ Result ClusterInfo::dropIndexCoordinator(  // drop index
   }
 
   {
-    CONDITION_LOCKER(locker, agencyCallback->_cv);
-
     while (true) {
       if (*dbServerResult >= 0) {
         cbGuard.fire();  // unregister cb
@@ -3685,7 +3686,10 @@ Result ClusterInfo::dropIndexCoordinator(  // drop index
         return Result(TRI_ERROR_CLUSTER_TIMEOUT);
       }
 
-      agencyCallback->executeByCallbackOrTimeout(interval);
+      {
+        CONDITION_LOCKER(locker, agencyCallback->_cv);
+        agencyCallback->executeByCallbackOrTimeout(interval);
+      }
 
       if (_server.isStopping()) {
         return Result(TRI_ERROR_SHUTTING_DOWN);

--- a/arangod/Cluster/v8-cluster.cpp
+++ b/arangod/Cluster/v8-cluster.cpp
@@ -630,7 +630,7 @@ static void JS_Databases(v8::FunctionCallbackInfo<v8::Value> const& args) {
 
   TRI_GET_GLOBALS();
   auto& ci = v8g->_server.getFeature<ClusterFeature>().clusterInfo();
-  std::vector<DatabaseID> res = ci.databases(true);
+  std::vector<DatabaseID> res = ci.databases(false);
   v8::Handle<v8::Array> a = v8::Array::New(isolate, (int)res.size());
   std::vector<DatabaseID>::iterator it;
   int count = 0;

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -81,7 +81,7 @@ std::vector<std::string> Databases::list(application_features::ApplicationServer
   if (user.empty()) {
     if (ServerState::instance()->isCoordinator()) {
       ClusterInfo& ci = server.getFeature<ClusterFeature>().clusterInfo();
-      return ci.databases(true);
+      return ci.databases(false);
     } else {
       // list of all databases
       return databaseFeature.getDatabaseNames();


### PR DESCRIPTION
A mutex was held for too long and therefore a deadlock could happen in dropCollection. This was introduced by the new regime for `loadPlan` and `loadCurrent`.