### PR TITLE
static cast to int to shutup compiler warning

### DIFF
--- a/tests/Aql/MultiDependencySingleRowFetcherTest.cpp
+++ b/tests/Aql/MultiDependencySingleRowFetcherTest.cpp
@@ -366,7 +366,7 @@ TEST_P(MultiDependencySingleRowFetcherTest, many_blocks_upstream_all_deps_equal)
 
 TEST_P(MultiDependencySingleRowFetcherTest, many_blocks_upstream_all_deps_differ) {
   std::vector<std::deque<SharedAqlItemBlockPtr>> data;
-  for (int i = 0; i < numberDependencies(); ++i) {
+  for (int i = 0; i < static_cast<int>(numberDependencies()); ++i) {
     std::deque<SharedAqlItemBlockPtr> blockDeque{};
     blockDeque.emplace_back(
         buildBlock<1>(itemBlockManager, {{1 * (i + 1)}, {2 * (i + 1)}, {3 * (i + 1)}}));
@@ -429,7 +429,7 @@ TEST_P(MultiDependencySingleRowFetcherTest, many_blocks_upstream_all_deps_differ
 TEST_P(MultiDependencySingleRowFetcherTest, many_blocks_upstream_all_deps_differ_sequentially) {
   // Difference to the test above is that we first fetch all from Dep1, then Dep2 then Dep3
   std::vector<std::deque<SharedAqlItemBlockPtr>> data;
-  for (int i = 0; i < numberDependencies(); ++i) {
+  for (int i = 0; i < static_cast<int>(numberDependencies()); ++i) {
     std::deque<SharedAqlItemBlockPtr> blockDeque{};
     blockDeque.emplace_back(
         buildBlock<1>(itemBlockManager, {{1 * (i + 1)}, {2 * (i + 1)}, {3 * (i + 1)}}));
@@ -504,7 +504,7 @@ TEST_P(MultiDependencySingleRowFetcherTest,
   // This has to be done by the InputRange hold externally.
   // It has seperate tests
   std::vector<std::deque<SharedAqlItemBlockPtr>> data;
-  for (int i = 0; i < numberDependencies(); ++i) {
+  for (int i = 0; i < static_cast<int>(numberDependencies()); ++i) {
     std::deque<SharedAqlItemBlockPtr> blockDeque{};
     blockDeque.emplace_back(
         buildBlock<1>(itemBlockManager,
@@ -608,7 +608,7 @@ TEST_P(MultiDependencySingleRowFetcherTest,
   // This has to be done by the InputRange hold externally.
   // It has seperate tests
   std::vector<std::deque<SharedAqlItemBlockPtr>> data;
-  for (int i = 0; i < numberDependencies(); ++i) {
+  for (int i = 0; i < static_cast<int>(numberDependencies()); ++i) {
     std::deque<SharedAqlItemBlockPtr> blockDeque{};
     blockDeque.emplace_back(
         buildBlock<1>(itemBlockManager,
@@ -714,7 +714,7 @@ TEST_P(MultiDependencySingleRowFetcherTest,
   // This has to be done by the InputRange hold externally.
   // It has seperate tests
   std::vector<std::deque<SharedAqlItemBlockPtr>> data;
-  for (int i = 0; i < numberDependencies(); ++i) {
+  for (int i = 0; i < static_cast<int>(numberDependencies()); ++i) {
     std::deque<SharedAqlItemBlockPtr> blockDeque{};
     blockDeque.emplace_back(
         buildBlock<1>(itemBlockManager,


### PR DESCRIPTION
Shuts up the compiler about comparing `int` to `size_t`.

Caused by  merging #11618