### PR TITLE
Initialize the content of all condition variables in Traversals

### DIFF
--- a/arangod/Aql/TraversalExecutor.cpp
+++ b/arangod/Aql/TraversalExecutor.cpp
@@ -286,6 +286,10 @@ bool TraversalExecutor::initTraverser(AqlItemBlockInputRange& input) {
     std::tie(std::ignore, _inputRow) = input.nextDataRow(AqlItemBlockInputRange::HasDataRow{});
     TRI_ASSERT(_inputRow.isInitialized());
 
+    for (auto const& pair : _infos.filterConditionVariables()) {
+      opts->setVariableValue(pair.first, _inputRow.getValue(pair.second));
+    }
+
     if (opts->usesPrune()) {
       auto* evaluator = opts->getPruneEvaluator();
       // Replace by inputRow


### PR DESCRIPTION
During the movement of Aql 3.6 => 3.7 this little piece of code was not transported.
It was shadowed by a test not working as intended, where a combination of optimizer rules actually improved the situation so much that this code was not triggered.

I have test for this which also triggered another item that needs back porting  to older versions.
So I decided to do two PRs, this 3.7 only fix
And another one that can be backportet more easily with the test and the second bug-fix.

Jenkins:
http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/9988/