### PR TITLE
Fix an arangod configuration bug (#11632)

### DIFF
--- a/lib/ApplicationFeatures/ConfigFeature.cpp
+++ b/lib/ApplicationFeatures/ConfigFeature.cpp
@@ -117,7 +117,7 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
 
     IniFileParser parser(options.get());
 
-    if (FileUtils::exists(local)) {
+    if (FileUtils::exists(local) && FileUtils::isRegularFile(local)) {
       LOG_TOPIC("9b20a", DEBUG, Logger::CONFIG) << "loading override '" << local << "'";
 
       if (!parser.parse(local, true)) {
@@ -207,7 +207,7 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
 
   LOG_TOPIC("f6420", TRACE, Logger::CONFIG) << "checking override '" << local << "'";
 
-  if (FileUtils::exists(local)) {
+  if (FileUtils::exists(local) && FileUtils::isRegularFile(local)) {
     LOG_TOPIC("3d2d0", DEBUG, Logger::CONFIG) << "loading override '" << local << "'";
 
     if (!parser.parse(local, true)) {


### PR DESCRIPTION
where the server tried to interpret
a directory as conf-file leading to
an early exit. Now the path is instead
ignored if it does not point to a
regular file.

This was especially a problem when
the original path was empty and
arangod tried to find a local
override. In this case the search
had '.local' as candidate witch is
a common directory in user homes.