### PR TITLE
disable building rocksdb tools when building arangodb

### DIFF
--- a/3rdParty/rocksdb/CMakeLists.txt
+++ b/3rdParty/rocksdb/CMakeLists.txt
@@ -34,6 +34,8 @@ endif ()
 set(PORTABLE On CACHE BOOL "enable portable rocksdb build (disabling might yield better performance but break portability)")
 
 set(ROCKSDB_BUILD_SHARED OFF CACHE BOOL "build shared libraries")
+set(WITH_TOOLS OFF CACHE BOOL "disable tools")
+set(WITH_CORE_TOOLS OFF CACHE BOOL "disable core tools")
 set(WITH_TESTS OFF CACHE BOOL "disable tests")
 set(WITH_SNAPPY ON CACHE BOOL "force enable snappy")
 set(SNAPPY_INCLUDE_DIR "${SNAPPY_SOURCE_DIR};${SNAPPY_BUILD_DIR}" CACHE PATH "relation to snappy")


### PR DESCRIPTION
### Scope & Purpose

Disable compiling RocksDB tools when building ArangoDB.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

Test plan: compilation must still work!

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/9992/