### PR TITLE
add debug output for AQL failures

### DIFF
--- a/arangod/Aql/InsertModifier.cpp
+++ b/arangod/Aql/InsertModifier.cpp
@@ -43,7 +43,7 @@ using namespace arangodb::aql;
 using namespace arangodb::aql::ModificationExecutorHelpers;
 
 ModifierOperationType InsertModifierCompletion::accumulate(ModificationExecutorAccumulator& accu,
-                                                           InputAqlItemRow& row) {
+                                                           InputAqlItemRow& row) try {
   RegisterId const inDocReg = _infos._input1RegisterId;
 
   // The document to be INSERTed
@@ -55,8 +55,16 @@ ModifierOperationType InsertModifierCompletion::accumulate(ModificationExecutorA
   } else {
     return ModifierOperationType::CopyRow;
   }
+} catch (std::exception const& ex) {
+  LOG_TOPIC("def14", WARN, Logger::DEVEL)
+    << "InsertModifierCompletion::accumulate failed: " << ex.what();
+  throw;
 }
 
-OperationResult InsertModifierCompletion::transact(VPackSlice const& data) {
+OperationResult InsertModifierCompletion::transact(VPackSlice const& data) try {
   return _infos._trx->insert(_infos._aqlCollection->name(), data, _infos._options);
+} catch (std::exception const& ex) {
+  LOG_TOPIC("def13", WARN, Logger::DEVEL)
+    << "InsertModifierCompletion::transact failed: " << ex.what();
+  throw;
 }

--- a/arangod/Aql/ModificationExecutorHelpers.cpp
+++ b/arangod/Aql/ModificationExecutorHelpers.cpp
@@ -168,6 +168,10 @@ void ModificationExecutorHelpers::throwOperationResultException(
     auto const errorCode = p.first;
     if (!(infos._ignoreDocumentNotFound && errorCode == TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND)) {
       // Find the first error and throw with message.
+      if (!result.slice().isArray()) {
+        LOG_TOPIC("def0b", WARN, Logger::DEVEL)
+          << "throwOperationResultException will fail: " << result.slice().typeName();
+      }
       for (auto doc : VPackArrayIterator(result.slice())) {
         if (doc.isObject() && doc.hasKey(StaticStrings::ErrorNum) &&
             doc.get(StaticStrings::ErrorNum).getInt() == errorCode) {

--- a/arangod/Aql/UpdateReplaceModifier.cpp
+++ b/arangod/Aql/UpdateReplaceModifier.cpp
@@ -44,7 +44,7 @@ using namespace arangodb::aql;
 using namespace arangodb::aql::ModificationExecutorHelpers;
 
 ModifierOperationType UpdateReplaceModifierCompletion::accumulate(
-    ModificationExecutorAccumulator& accu, InputAqlItemRow& row) {
+    ModificationExecutorAccumulator& accu, InputAqlItemRow& row) try {
   RegisterId const inDocReg = _infos._input1RegisterId;
   RegisterId const keyReg = _infos._input2RegisterId;
   bool const hasKeyVariable = keyReg != RegisterPlan::MaxRegisterId;
@@ -105,12 +105,20 @@ ModifierOperationType UpdateReplaceModifierCompletion::accumulate(
   } else {
     return ModifierOperationType::CopyRow;
   }
+} catch (std::exception const& ex) {
+  LOG_TOPIC("def12", WARN, Logger::DEVEL)
+      << "UpdateReplaceModifierCompletion::accumulate failed: " << ex.what();
+  throw;
 }
 
-OperationResult UpdateReplaceModifierCompletion::transact(VPackSlice const& data) {
+OperationResult UpdateReplaceModifierCompletion::transact(VPackSlice const& data) try {
   if (_infos._isReplace) {
     return _infos._trx->replace(_infos._aqlCollection->name(), data, _infos._options);
   } else {
     return _infos._trx->update(_infos._aqlCollection->name(), data, _infos._options);
   }
+} catch (std::exception const& ex) {
+  LOG_TOPIC("def11", WARN, Logger::DEVEL)
+      << "UpdateReplaceModifierCompletion::transact failed: " << ex.what();
+  throw;
 }

--- a/arangod/Aql/UpsertModifier.cpp
+++ b/arangod/Aql/UpsertModifier.cpp
@@ -51,7 +51,7 @@ UpsertModifier::OutputIterator::OutputIterator(UpsertModifier const& modifier)
       _insertResultsIterator(modifier.getInsertResultsIterator()),
       _updateResultsIterator(modifier.getUpdateResultsIterator()) {}
 
-UpsertModifier::OutputIterator& UpsertModifier::OutputIterator::next() {
+UpsertModifier::OutputIterator& UpsertModifier::OutputIterator::next() try {
   if (_operationsIterator->first == UpsertModifier::OperationType::UpdateReturnIfAvailable) {
     ++_updateResultsIterator;
   } else if (_operationsIterator->first == UpsertModifier::OperationType::InsertReturnIfAvailable) {
@@ -59,6 +59,10 @@ UpsertModifier::OutputIterator& UpsertModifier::OutputIterator::next() {
   }
   ++_operationsIterator;
   return *this;
+} catch (std::exception const& ex) {
+  LOG_TOPIC("def10", WARN, Logger::DEVEL)
+      << "UpsertModifier::OutputIterator::next failed: " << ex.what();
+  throw;
 }
 
 UpsertModifier::OutputIterator& UpsertModifier::OutputIterator::operator++() {
@@ -70,7 +74,7 @@ bool UpsertModifier::OutputIterator::operator!=(UpsertModifier::OutputIterator c
   return _operationsIterator != other._operationsIterator;
 }
 
-ModifierOutput UpsertModifier::OutputIterator::operator*() const {
+ModifierOutput UpsertModifier::OutputIterator::operator*() const try {
   // When we get the output of our iterator, we have to check whether the
   // operation in question was APPLY_UPDATE or APPLY_INSERT to determine which
   // of the results slices (UpdateReplace or Insert) we have to look in and
@@ -114,6 +118,10 @@ ModifierOutput UpsertModifier::OutputIterator::operator*() const {
   // shut up compiler
   TRI_ASSERT(false);
   return ModifierOutput{_operationsIterator->second, ModifierOutput::Type::SkipRow};
+} catch (std::exception const& ex) {
+  LOG_TOPIC("def15", WARN, Logger::DEVEL)
+      << "UpsertModifier::OutputIterator::operator* failed: " << ex.what();
+  throw;
 }
 
 typename UpsertModifier::OutputIterator UpsertModifier::OutputIterator::begin() const {
@@ -138,7 +146,7 @@ void UpsertModifier::reset() {
 }
 
 UpsertModifier::OperationType UpsertModifier::updateReplaceCase(
-    ModificationExecutorAccumulator& accu, AqlValue const& inDoc, AqlValue const& updateDoc) {
+    ModificationExecutorAccumulator& accu, AqlValue const& inDoc, AqlValue const& updateDoc) try {
   std::string key;
   Result result;
 
@@ -174,10 +182,14 @@ UpsertModifier::OperationType UpsertModifier::updateReplaceCase(
   } else {
     return UpsertModifier::OperationType::CopyRow;
   }
+} catch (std::exception const& ex) {
+  LOG_TOPIC("def0e", WARN, Logger::DEVEL)
+      << "UpsertModifier::updateReplaceCase failed: " << ex.what();
+  throw;
 }
 
 UpsertModifier::OperationType UpsertModifier::insertCase(ModificationExecutorAccumulator& accu,
-                                                         AqlValue const& insertDoc) {
+                                                         AqlValue const& insertDoc) try {
   if (insertDoc.isObject()) {
     auto const& toInsert = insertDoc.slice();
     if (writeRequired(_infos, toInsert, StaticStrings::Empty)) {
@@ -195,6 +207,10 @@ UpsertModifier::OperationType UpsertModifier::insertCase(ModificationExecutorAcc
     }
     return UpsertModifier::OperationType::SkipRow;
   }
+} catch (std::exception const& ex) {
+  LOG_TOPIC("def0f", WARN, Logger::DEVEL)
+      << "UpsertModifier::insertCase failed: " << ex.what();
+  throw;
 }
 
 bool UpsertModifier::resultAvailable() const {
@@ -215,7 +231,7 @@ VPackArrayIterator UpsertModifier::getInsertResultsIterator() const {
   return VPackArrayIterator(VPackSlice::emptyArraySlice());
 }
 
-Result UpsertModifier::accumulate(InputAqlItemRow& row) {
+Result UpsertModifier::accumulate(InputAqlItemRow& row) try {
   RegisterId const inDocReg = _infos._input1RegisterId;
   RegisterId const insertReg = _infos._input2RegisterId;
   RegisterId const updateReg = _infos._input3RegisterId;
@@ -236,9 +252,13 @@ Result UpsertModifier::accumulate(InputAqlItemRow& row) {
   }
   _operations.push_back({result, row});
   return Result{};
+} catch (std::exception const& ex) {
+  LOG_TOPIC("def0c", WARN, Logger::DEVEL)
+      << "UpsertModifier::accumulate failed: " << ex.what();
+  throw;
 }
 
-Result UpsertModifier::transact() {
+Result UpsertModifier::transact() try {
   auto toInsert = _insertAccumulator->closeAndGetContents();
   if (toInsert.isArray() && toInsert.length() > 0) {
     _insertResults =
@@ -259,6 +279,10 @@ Result UpsertModifier::transact() {
   }
 
   return Result{};
+} catch (std::exception const& ex) {
+  LOG_TOPIC("def0d", WARN, Logger::DEVEL)
+      << "UpsertModifier::transact failed: " << ex.what();
+  throw;
 }
 
 size_t UpsertModifier::nrOfDocuments() const {


### PR DESCRIPTION
### Scope & Purpose

Debug AQL exceptions.
Under normal conditions, this PR should not Otherwise this not cause any visible change in behavior. However, when the log level for log topic `development` is set to `warning`, exceptions in certain operations (insert, update, replace, upsert, sync replication) are caught and logged.
The only purpose of this PR is to aid debugging, and it is only a temporary solution.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10002/