### PR TITLE
remove obsolete options from recovery test

### DIFF
--- a/js/client/modules/@arangodb/testsuites/recovery.js
+++ b/js/client/modules/@arangodb/testsuites/recovery.js
@@ -83,7 +83,6 @@ function runArangodRecovery (params) {
     }
     args = Object.assign(args, params.options.extraArgs);
     args = Object.assign(args, {
-      'wal.reserve-logfiles': 1,
       'rocksdb.wal-file-timeout-initial': 10,
       'database.directory': fs.join(dataDir + 'db'),
       'server.rest-server': 'false',
@@ -121,7 +120,6 @@ function runArangodRecovery (params) {
       Object.assign(params.args,
                     {
                       'log.foreground-tty': 'true',
-                      'wal.ignore-logfile-errors': 'true',
                       'database.ignore-datafile-errors': 'false', // intentionally false!
                       'javascript.script-parameter': 'recovery'
                     }


### PR DESCRIPTION
### Scope & Purpose

Remove 2 obsolete options being set for recovery tests.
These options were useful with MMFiles only and in 3.7 only trigger obsoletion warnings at startup.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10016/