### PR TITLE
fix unprotected access to _computedValue

### DIFF
--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -143,24 +143,6 @@ LogicalDataSource::Category const* injectDataSourceInQuery(
 
 }  // namespace
 
-/// @brief initialize a singleton no-op node instance
-AstNode const Ast::NopNode{NODE_TYPE_NOP};
-
-/// @brief initialize a singleton null node instance
-AstNode const Ast::NullNode{AstNodeValue()};
-
-/// @brief initialize a singleton false node instance
-AstNode const Ast::FalseNode{AstNodeValue(false)};
-
-/// @brief initialize a singleton true node instance
-AstNode const Ast::TrueNode{AstNodeValue(true)};
-
-/// @brief initialize a singleton zero node instance
-AstNode const Ast::ZeroNode{AstNodeValue(int64_t(0))};
-
-/// @brief initialize a singleton empty string node instance
-AstNode const Ast::EmptyStringNode{AstNodeValue("", uint32_t(0))};
-
 /// @brief inverse comparison operators
 std::unordered_map<int, AstNodeType> const Ast::NegatedOperators{
     {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_EQ), NODE_TYPE_OPERATOR_BINARY_NE},
@@ -179,6 +161,37 @@ std::unordered_map<int, AstNodeType> const Ast::ReversedOperators{
     {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_GE), NODE_TYPE_OPERATOR_BINARY_LE},
     {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_LT), NODE_TYPE_OPERATOR_BINARY_GT},
     {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_LE), NODE_TYPE_OPERATOR_BINARY_GE}};
+
+Ast::SpecialNodes::SpecialNodes() 
+  : NopNode{NODE_TYPE_NOP},
+    NullNode{AstNodeValue()},
+    FalseNode{AstNodeValue(false)},
+    TrueNode{AstNodeValue(true)},
+    ZeroNode{AstNodeValue(int64_t(0))},
+    EmptyStringNode{AstNodeValue("", uint32_t(0))} {
+
+  NopNode.setFlag(AstNodeFlagType::FLAG_INTERNAL_CONST);
+  NullNode.setFlag(AstNodeFlagType::FLAG_INTERNAL_CONST);
+  FalseNode.setFlag(AstNodeFlagType::FLAG_INTERNAL_CONST);
+  TrueNode.setFlag(AstNodeFlagType::FLAG_INTERNAL_CONST);
+  ZeroNode.setFlag(AstNodeFlagType::FLAG_INTERNAL_CONST);
+  EmptyStringNode.setFlag(AstNodeFlagType::FLAG_INTERNAL_CONST);
+
+  // the const-away casts are necessary API-wise. however, we are never ever modifying
+  // the computed values for these special nodes.
+  NullNode.setComputedValue(const_cast<uint8_t*>(VPackSlice::nullSlice().begin()));
+  FalseNode.setComputedValue(const_cast<uint8_t*>(VPackSlice::falseSlice().begin()));
+  TrueNode.setComputedValue(const_cast<uint8_t*>(VPackSlice::trueSlice().begin()));
+  ZeroNode.setComputedValue(const_cast<uint8_t*>(VPackSlice::zeroSlice().begin()));
+  EmptyStringNode.setComputedValue(const_cast<uint8_t*>(VPackSlice::emptyStringSlice().begin()));
+  
+  TRI_ASSERT(NopNode.hasFlag(AstNodeFlagType::FLAG_INTERNAL_CONST));
+  TRI_ASSERT(NullNode.hasFlag(AstNodeFlagType::FLAG_INTERNAL_CONST));
+  TRI_ASSERT(FalseNode.hasFlag(AstNodeFlagType::FLAG_INTERNAL_CONST));
+  TRI_ASSERT(TrueNode.hasFlag(AstNodeFlagType::FLAG_INTERNAL_CONST));
+  TRI_ASSERT(ZeroNode.hasFlag(AstNodeFlagType::FLAG_INTERNAL_CONST));
+  TRI_ASSERT(EmptyStringNode.hasFlag(AstNodeFlagType::FLAG_INTERNAL_CONST));
+}
 
 /// @brief create the AST
 Ast::Ast(QueryContext& query)
@@ -272,7 +285,7 @@ AstNode* Ast::createNodeFor(char const* variableName, size_t nameLength,
   AstNode* variable = createNodeVariable(variableName, nameLength, isUserDefinedVariable);
   node->addMember(variable);
   node->addMember(expression);
-  node->addMember(&NopNode);
+  node->addMember(&_specialNodes.NopNode);
 
   return node;
 }
@@ -286,7 +299,7 @@ AstNode* Ast::createNodeFor(Variable* variable, AstNode const* expression,
 
   if (options == nullptr) {
     // no options given. now use default options
-    options = &NopNode;
+    options = &_specialNodes.NopNode;
   }
 
   AstNode* v = createNode(NODE_TYPE_VARIABLE);
@@ -313,7 +326,7 @@ AstNode* Ast::createNodeForView(Variable* variable, AstNode const* expression,
 
   if (options == nullptr) {
     // no options given. now use default options
-    options = &NopNode;
+    options = &_specialNodes.NopNode;
   }
 
   AstNode* variableNode = createNode(NODE_TYPE_VARIABLE);
@@ -414,7 +427,7 @@ AstNode* Ast::createNodeRemove(AstNode const* expression,
 
   if (options == nullptr) {
     // no options given. now use default options
-    options = &NopNode;
+    options = &_specialNodes.NopNode;
   }
 
   node->addMember(options);
@@ -432,7 +445,7 @@ AstNode* Ast::createNodeInsert(AstNode const* expression,
 
   if (options == nullptr) {
     // no options given. now use default options
-    options = &NopNode;
+    options = &_specialNodes.NopNode;
   }
 
   bool returnOld = false;
@@ -461,7 +474,7 @@ AstNode* Ast::createNodeUpdate(AstNode const* keyExpression, AstNode const* docE
 
   if (options == nullptr) {
     // no options given. now use default options
-    options = &NopNode;
+    options = &_specialNodes.NopNode;
   }
 
   node->addMember(options);
@@ -471,7 +484,7 @@ AstNode* Ast::createNodeUpdate(AstNode const* keyExpression, AstNode const* docE
   if (keyExpression != nullptr) {
     node->addMember(keyExpression);
   } else {
-    node->addMember(&NopNode);
+    node->addMember(&_specialNodes.NopNode);
   }
 
   node->addMember(createNodeVariable(TRI_CHAR_LENGTH_PAIR(Variable::NAME_OLD), false));
@@ -488,7 +501,7 @@ AstNode* Ast::createNodeReplace(AstNode const* keyExpression, AstNode const* doc
 
   if (options == nullptr) {
     // no options given. now use default options
-    options = &NopNode;
+    options = &_specialNodes.NopNode;
   }
 
   node->addMember(options);
@@ -498,7 +511,7 @@ AstNode* Ast::createNodeReplace(AstNode const* keyExpression, AstNode const* doc
   if (keyExpression != nullptr) {
     node->addMember(keyExpression);
   } else {
-    node->addMember(&NopNode);
+    node->addMember(&_specialNodes.NopNode);
   }
 
   node->addMember(createNodeVariable(TRI_CHAR_LENGTH_PAIR(Variable::NAME_OLD), false));
@@ -518,7 +531,7 @@ AstNode* Ast::createNodeUpsert(AstNodeType type, AstNode const* docVariable,
 
   if (options == nullptr) {
     // no options given. now use default options
-    options = &NopNode;
+    options = &_specialNodes.NopNode;
   }
 
   node->addMember(options);
@@ -551,7 +564,7 @@ AstNode* Ast::createNodeCollect(AstNode const* groups, AstNode const* aggregates
 
   if (options == nullptr) {
     // no options given. now use default options
-    options = &NopNode;
+    options = &_specialNodes.NopNode;
   }
 
   node->addMember(options);
@@ -562,9 +575,9 @@ AstNode* Ast::createNodeCollect(AstNode const* groups, AstNode const* aggregates
   agg->addMember(aggregates);  // may be an empty array
   node->addMember(agg);
 
-  node->addMember(into != nullptr ? into : &NopNode);
-  node->addMember(intoExpression != nullptr ? intoExpression : &NopNode);
-  node->addMember(keepVariables != nullptr ? keepVariables : &NopNode);
+  node->addMember(into != nullptr ? into : &_specialNodes.NopNode);
+  node->addMember(intoExpression != nullptr ? intoExpression : &_specialNodes.NopNode);
+  node->addMember(keepVariables != nullptr ? keepVariables : &_specialNodes.NopNode);
 
   return node;
 }
@@ -577,7 +590,7 @@ AstNode* Ast::createNodeCollectCount(AstNode const* list, char const* name,
 
   if (options == nullptr) {
     // no options given. now use default options
-    options = &NopNode;
+    options = &_specialNodes.NopNode;
   }
 
   node->addMember(options);
@@ -1039,7 +1052,7 @@ AstNode* Ast::createNodeValueNull() {
   // performance optimization:
   // return a pointer to the singleton null node
   // note: this node is never registered nor freed
-  return const_cast<AstNode*>(&NullNode);
+  return const_cast<AstNode*>(&_specialNodes.NullNode);
 }
 
 /// @brief create an AST bool value node
@@ -1048,10 +1061,10 @@ AstNode* Ast::createNodeValueBool(bool value) {
   // return a pointer to the singleton bool nodes
   // note: these nodes are never registered nor freed
   if (value) {
-    return const_cast<AstNode*>(&TrueNode);
+    return const_cast<AstNode*>(&_specialNodes.TrueNode);
   }
 
-  return const_cast<AstNode*>(&FalseNode);
+  return const_cast<AstNode*>(&_specialNodes.FalseNode);
 }
 
 /// @brief create an AST int value node
@@ -1060,7 +1073,7 @@ AstNode* Ast::createNodeValueInt(int64_t value) {
     // performance optimization:
     // return a pointer to the singleton zero node
     // note: these nodes are never registered nor freed
-    return const_cast<AstNode*>(&ZeroNode);
+    return const_cast<AstNode*>(&_specialNodes.ZeroNode);
   }
 
   AstNode* node = createNode(NODE_TYPE_VALUE);
@@ -1095,7 +1108,7 @@ AstNode* Ast::createNodeValueString(char const* value, size_t length) {
     // performance optimization:
     // return a pointer to the singleton empty string node
     // note: these nodes are never registered nor freed
-    return const_cast<AstNode*>(&EmptyStringNode);
+    return const_cast<AstNode*>(&_specialNodes.EmptyStringNode);
   }
 
   AstNode* node = createNode(NODE_TYPE_VALUE);
@@ -1470,7 +1483,7 @@ AstNode const* Ast::createNodeOptions(AstNode const* options) const {
   if (options != nullptr) {
     return options;
   }
-  return &NopNode;
+  return &_specialNodes.NopNode;
 }
 
 /// @brief create an AST function call node
@@ -1541,10 +1554,7 @@ AstNode* Ast::createNodeRange(AstNode const* start, AstNode const* end) {
 }
 
 /// @brief create an AST nop node
-AstNode* Ast::createNodeNop() { return const_cast<AstNode*>(&NopNode); }
-
-/// @brief get the AST nop node
-AstNode* Ast::getNodeNop() { return const_cast<AstNode*>(&NopNode); }
+AstNode* Ast::createNodeNop() { return const_cast<AstNode*>(&_specialNodes.NopNode); }
 
 /// @brief create an AST n-ary operator node
 AstNode* Ast::createNodeNaryOperator(AstNodeType type) {
@@ -1555,9 +1565,7 @@ AstNode* Ast::createNodeNaryOperator(AstNodeType type) {
 
 /// @brief create an AST n-ary operator node
 AstNode* Ast::createNodeNaryOperator(AstNodeType type, AstNode const* child) {
-  TRI_ASSERT(type == NODE_TYPE_OPERATOR_NARY_AND || type == NODE_TYPE_OPERATOR_NARY_OR);
-
-  AstNode* node = createNode(type);
+  AstNode* node = createNodeNaryOperator(type);
   node->addMember(child);
 
   return node;
@@ -2458,6 +2466,9 @@ bool Ast::getReferencedAttributes(AstNode const* node, Variable const* variable,
 /// @brief copies node payload from node into copy. this is *not* copying
 /// the subnodes
 void Ast::copyPayload(AstNode const* node, AstNode* copy) const {
+  TRI_ASSERT(!copy->hasFlag(AstNodeFlagType::FLAG_INTERNAL_CONST));
+  TRI_ASSERT(copy->computedValue() == nullptr);
+
   AstNodeType const type = node->type;
 
   if (type == NODE_TYPE_COLLECTION || type == NODE_TYPE_VIEW || type == NODE_TYPE_PARAMETER ||
@@ -2517,14 +2528,15 @@ AstNode* Ast::clone(AstNode const* node) {
     // nop node is a singleton
     return const_cast<AstNode*>(node);
   }
-
+  
   AstNode* copy = createNode(type);
   TRI_ASSERT(copy != nullptr);
 
-  // copy flags
+  // copy flags, but nothing const-related
   copy->flags = node->flags;
+  copy->removeFlag(AstNodeFlagType::FLAG_INTERNAL_CONST);
   TEMPORARILY_UNLOCK_NODE(copy);  // if locked, unlock to copy properly
-
+  
   // special handling for certain node types
   // copy payload...
   copyPayload(node, copy);
@@ -2550,7 +2562,9 @@ AstNode* Ast::shallowCopyForModify(AstNode const* node) {
   TRI_ASSERT(copy != nullptr);
 
   // copy flags
-  copy->flags = (node->flags & ~AstNodeFlagType::FLAG_FINALIZED);
+  copy->flags = node->flags;
+  copy->removeFlag(AstNodeFlagType::FLAG_FINALIZED);
+  copy->removeFlag(AstNodeFlagType::FLAG_INTERNAL_CONST);
 
   // special handling for certain node types
   // copy payload...
@@ -2757,7 +2771,7 @@ AstNode* Ast::createArithmeticResultNode(double value) {
     // if the architecture does not use IEEE754 values then this shouldn't do
     // any harm either
     _query.warnings().registerWarning(TRI_ERROR_QUERY_NUMBER_OUT_OF_RANGE);
-    return const_cast<AstNode*>(&NullNode);
+    return const_cast<AstNode*>(&_specialNodes.NullNode);
   }
 
   return createNodeValueDouble(value);
@@ -2783,7 +2797,7 @@ AstNode* Ast::optimizeUnaryOperatorArithmetic(AstNode* node) {
   AstNode const* converted = operand->castToNumber(this);
 
   if (converted->isNullValue()) {
-    return const_cast<AstNode*>(&ZeroNode);
+    return const_cast<AstNode*>(&_specialNodes.ZeroNode);
   }
 
   if (converted->value.type != VALUE_TYPE_INT && converted->value.type != VALUE_TYPE_DOUBLE) {
@@ -2810,7 +2824,7 @@ AstNode* Ast::optimizeUnaryOperatorArithmetic(AstNode* node) {
         // if the architecture does not use IEEE754 values then this shouldn't
         // do
         // any harm either
-        return const_cast<AstNode*>(&ZeroNode);
+        return const_cast<AstNode*>(&_specialNodes.ZeroNode);
       }
 
       return createNodeValueDouble(value);
@@ -3099,7 +3113,7 @@ AstNode* Ast::optimizeBinaryOperatorArithmetic(AstNode* node) {
 
         if (r == 0) {
           _query.warnings().registerWarning(TRI_ERROR_QUERY_DIVISION_BY_ZERO);
-          return const_cast<AstNode*>(&NullNode);
+          return const_cast<AstNode*>(&_specialNodes.NullNode);
         }
 
         // check if the result would overflow
@@ -3113,7 +3127,7 @@ AstNode* Ast::optimizeBinaryOperatorArithmetic(AstNode* node) {
 
       if (right->getDoubleValue() == 0.0) {
         _query.warnings().registerWarning(TRI_ERROR_QUERY_DIVISION_BY_ZERO);
-        return const_cast<AstNode*>(&NullNode);
+        return const_cast<AstNode*>(&_specialNodes.NullNode);
       }
 
       return createArithmeticResultNode(left->getDoubleValue() / right->getDoubleValue());
@@ -3128,7 +3142,7 @@ AstNode* Ast::optimizeBinaryOperatorArithmetic(AstNode* node) {
 
         if (r == 0) {
           _query.warnings().registerWarning(TRI_ERROR_QUERY_DIVISION_BY_ZERO);
-          return const_cast<AstNode*>(&NullNode);
+          return const_cast<AstNode*>(&_specialNodes.NullNode);
         }
 
         // check if the result would overflow
@@ -3142,7 +3156,7 @@ AstNode* Ast::optimizeBinaryOperatorArithmetic(AstNode* node) {
 
       if (right->getDoubleValue() == 0.0) {
         _query.warnings().registerWarning(TRI_ERROR_QUERY_DIVISION_BY_ZERO);
-        return const_cast<AstNode*>(&NullNode);
+        return const_cast<AstNode*>(&_specialNodes.NullNode);
       }
 
       return createArithmeticResultNode(
@@ -3621,7 +3635,7 @@ AstNode* Ast::nodeFromVPack(VPackSlice const& slice, bool copyStringValues) {
 }
 
 /// @brief resolve an attribute access
-AstNode const* Ast::resolveConstAttributeAccess(AstNode const* node) {
+AstNode const* Ast::resolveConstAttributeAccess(AstNode const* node, bool& isValid) {
   TRI_ASSERT(node != nullptr);
   TRI_ASSERT(node->type == NODE_TYPE_ATTRIBUTE_ACCESS);
   AstNode const* original = node;
@@ -3639,6 +3653,7 @@ AstNode const* Ast::resolveConstAttributeAccess(AstNode const* node) {
 
   while (which > 0) {
     if (node->type == NODE_TYPE_PARAMETER) {
+      isValid = true;
       return original;
     }
 
@@ -3663,6 +3678,7 @@ AstNode const* Ast::resolveConstAttributeAccess(AstNode const* node) {
           node = member->getMember(0);
           if (which == 0) {
             // we found what we looked for
+            isValid = true;
             return node;
           }
           // we found the correct attribute but there is now an attribute
@@ -3678,6 +3694,19 @@ AstNode const* Ast::resolveConstAttributeAccess(AstNode const* node) {
     }
   }
 
+  // attribute not found or non-array
+  isValid = false;
+  return nullptr;
+}
+
+AstNode const* Ast::resolveConstAttributeAccess(AstNode const* node) {
+  TRI_ASSERT(node != nullptr);
+
+  bool isValid;
+  node = resolveConstAttributeAccess(node, isValid);
+  if (isValid) {
+    return node;
+  }
   // attribute not found or non-array
   return createNodeValueNull();
 }

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -69,14 +69,15 @@ class Ast {
   friend class Condition;
 
  public:
+  Ast(Ast const&) = delete;
+  Ast& operator=(Ast const&) = delete;
+
   /// @brief create the AST
   explicit Ast(QueryContext&);
 
   /// @brief destroy the AST
   ~Ast();
 
- public:
-  
   /// @brief return the query
   QueryContext& query() const { return _query; }
   
@@ -292,10 +293,10 @@ class Ast {
   AstNode* createNodeIterator(char const*, size_t, AstNode const*);
 
   /// @brief create an AST null value node
-  static AstNode* createNodeValueNull();
+  AstNode* createNodeValueNull();
 
   /// @brief create an AST bool value node
-  static AstNode* createNodeValueBool(bool);
+  AstNode* createNodeValueBool(bool);
 
   /// @brief create an AST int value node
   AstNode* createNodeValueInt(int64_t);
@@ -368,9 +369,6 @@ class Ast {
 
   /// @brief create an AST nop node
   AstNode* createNodeNop();
-
-  /// @brief get the AST nop node
-  static AstNode* getNodeNop();
 
   /// @brief create an AST n-ary operator
   AstNode* createNodeNaryOperator(AstNodeType);
@@ -447,7 +445,13 @@ class Ast {
   AstNode* nodeFromVPack(arangodb::velocypack::Slice const&, bool copyStringValues);
 
   /// @brief resolve an attribute access
-  static AstNode const* resolveConstAttributeAccess(AstNode const*);
+  AstNode const* resolveConstAttributeAccess(AstNode const*);
+
+  /// @brief resolve an attribute access, static version
+  /// if isValid is set to true, then the returned value is to be trusted. if 
+  /// isValid is set to false, then the returned value is not to be trued and the
+  /// the result is equivalent to an AQL `null` value
+  static AstNode const* resolveConstAttributeAccess(AstNode const*, bool& isValid);
 
  private:
   /// @brief make condition from example
@@ -601,24 +605,35 @@ class Ast {
   
   /// @brief query makes use of V8 function(s)
   bool _willUseV8;
-  
-  /// @brief a singleton no-op node instance
-  static AstNode const NopNode;
 
-  /// @brief a singleton null node instance
-  static AstNode const NullNode;
+  /// @brief special node types that are used often and for which no memory
+  /// allocation will be needed. The node types are singletons in an AST,
+  /// so they may be referenced from multiple places.
+  struct SpecialNodes {
+    SpecialNodes();
 
-  /// @brief a singleton false node instance
-  static AstNode const FalseNode;
+    ~SpecialNodes() = default;
 
-  /// @brief a singleton true node instance
-  static AstNode const TrueNode;
+    /// @brief a singleton no-op node instance
+    AstNode NopNode;
 
-  /// @brief a singleton zero node instance
-  static AstNode const ZeroNode;
+    /// @brief a singleton null node instance
+    AstNode NullNode;
 
-  /// @brief a singleton empty string node instance
-  static AstNode const EmptyStringNode;
+    /// @brief a singleton false node instance
+    AstNode FalseNode;
+
+    /// @brief a singleton true node instance
+    AstNode TrueNode;
+
+    /// @brief a singleton zero node instance
+    AstNode ZeroNode;
+
+    /// @brief a singleton empty string node instance
+    AstNode EmptyStringNode;
+  };
+
+  SpecialNodes const _specialNodes;
 };
 
 }  // namespace aql

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -261,15 +261,17 @@ int arangodb::aql::CompareAstNodes(AstNode const* lhs, AstNode const* rhs, bool 
   TRI_ASSERT(lhs != nullptr);
   TRI_ASSERT(rhs != nullptr);
 
+  bool isValid = true;
   if (lhs->type == NODE_TYPE_ATTRIBUTE_ACCESS) {
-    lhs = Ast::resolveConstAttributeAccess(lhs);
+    lhs = Ast::resolveConstAttributeAccess(lhs, isValid);
   }
+  VPackValueType const lType = isValid ? getNodeCompareType(lhs) : VPackValueType::Null;
+  
+  isValid = true;
   if (rhs->type == NODE_TYPE_ATTRIBUTE_ACCESS) {
-    rhs = Ast::resolveConstAttributeAccess(rhs);
+    rhs = Ast::resolveConstAttributeAccess(rhs, isValid);
   }
-
-  auto lType = getNodeCompareType(lhs);
-  auto rType = getNodeCompareType(rhs);
+  VPackValueType const rType = isValid ? getNodeCompareType(rhs) : VPackValueType::Null;
 
   if (lType != rType) {
     if (lType == VPackValueType::Int && rType == VPackValueType::Double) {
@@ -602,7 +604,7 @@ AstNode::AstNode(Ast* ast, arangodb::velocypack::Slice const& slice)
         int t = it.get("typeID").getNumericValue<int>();
         if (static_cast<AstNodeType>(t) == NODE_TYPE_NOP) {
           // special handling for nop as it is a singleton
-          addMember(Ast::getNodeNop());
+          addMember(ast->createNodeNop());
         } else {
           addMember(new AstNode(ast, it));
         }
@@ -896,6 +898,8 @@ VPackSlice AstNode::computeValue(VPackBuilder* builder) const {
   TRI_ASSERT(isConstant());
 
   if (_computedValue == nullptr) {
+    TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_INTERNAL_CONST));
+
     if (builder == nullptr) {
       VPackBuilder b;
       computeValue(b);
@@ -910,10 +914,11 @@ VPackSlice AstNode::computeValue(VPackBuilder* builder) const {
   return VPackSlice(_computedValue);
 }
 
-/// @brief internal function for actual computing the constant value
+/// @brief internal function for actually computing the constant value
 /// and storing it
 void AstNode::computeValue(VPackBuilder& builder) const {
   TRI_ASSERT(builder.isEmpty());
+  TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_INTERNAL_CONST));
   toVelocyPackValue(builder);
 
   TRI_ASSERT(_computedValue == nullptr);
@@ -1181,7 +1186,7 @@ bool AstNode::containsNodeType(AstNodeType searchType) const {
 /// boolean value node
 AstNode const* AstNode::castToBool(Ast* ast) const {
   if (type == NODE_TYPE_ATTRIBUTE_ACCESS) {
-    return Ast::resolveConstAttributeAccess(this)->castToBool(ast);
+    return ast->resolveConstAttributeAccess(this)->castToBool(ast);
   }
 
   TRI_ASSERT(type == NODE_TYPE_VALUE || type == NODE_TYPE_ARRAY || type == NODE_TYPE_OBJECT);
@@ -1218,7 +1223,7 @@ AstNode const* AstNode::castToBool(Ast* ast) const {
 /// numeric value node
 AstNode const* AstNode::castToNumber(Ast* ast) const {
   if (type == NODE_TYPE_ATTRIBUTE_ACCESS) {
-    return Ast::resolveConstAttributeAccess(this)->castToNumber(ast);
+    return ast->resolveConstAttributeAccess(this)->castToNumber(ast);
   }
 
   TRI_ASSERT(type == NODE_TYPE_VALUE || type == NODE_TYPE_ARRAY || type == NODE_TYPE_OBJECT);
@@ -1305,8 +1310,10 @@ double AstNode::getDoubleValue() const {
 /// @brief whether or not the node value is trueish
 bool AstNode::isTrue() const {
   if (type == NODE_TYPE_ATTRIBUTE_ACCESS && isConstant()) {
-    AstNode const* resolved = Ast::resolveConstAttributeAccess(this);
-    return resolved->isTrue();
+    bool isValid;
+    AstNode const* resolved = Ast::resolveConstAttributeAccess(this, isValid);
+    // TO_BOOL(null) => false, so isTrue(false) => false
+    return isValid ? resolved->isTrue() : false;
   }
 
   if (type == NODE_TYPE_VALUE) {
@@ -1347,8 +1354,10 @@ bool AstNode::isTrue() const {
 /// @brief whether or not the node value is falsey
 bool AstNode::isFalse() const {
   if (type == NODE_TYPE_ATTRIBUTE_ACCESS && isConstant()) {
-    AstNode const* resolved = Ast::resolveConstAttributeAccess(this);
-    return resolved->isFalse();
+    bool isValid;
+    AstNode const* resolved = Ast::resolveConstAttributeAccess(this, isValid);
+    // TO_BOOL(null) => false, so isFalse(false) => true
+    return isValid ? resolved->isFalse() : true;
   }
 
   if (type == NODE_TYPE_VALUE) {
@@ -1437,7 +1446,7 @@ bool AstNode::isAttributeAccessForVariable(
 
       // check if the expansion uses a projection. if yes, we cannot use an
       // index for it
-      if (node->getMember(4) != Ast::getNodeNop()) {
+      if (node->getMember(4) != nullptr && node->getMember(4)->type != NODE_TYPE_NOP) {
         // [* RETURN projection]
         result.second.clear();
         return false;
@@ -2123,19 +2132,19 @@ void AstNode::stringify(arangodb::basics::StringBuffer* buffer, bool verbose,
     buffer->appendChar(',');
 
     auto filterNode = getMember(2);
-    if (filterNode != nullptr && filterNode != Ast::getNodeNop()) {
+    if (filterNode != nullptr && filterNode->type != NODE_TYPE_NOP) {
       buffer->appendText(TRI_CHAR_LENGTH_PAIR(" FILTER "));
       filterNode->getMember(0)->stringify(buffer, verbose, failIfLong);
     }
     auto limitNode = getMember(3);
-    if (limitNode != nullptr && limitNode != Ast::getNodeNop()) {
+    if (limitNode != nullptr && limitNode->type != NODE_TYPE_NOP) {
       buffer->appendText(TRI_CHAR_LENGTH_PAIR(" LIMIT "));
       limitNode->getMember(0)->stringify(buffer, verbose, failIfLong);
       buffer->appendChar(',');
       limitNode->getMember(1)->stringify(buffer, verbose, failIfLong);
     }
     auto returnNode = getMember(4);
-    if (returnNode != nullptr && returnNode != Ast::getNodeNop()) {
+    if (returnNode != nullptr && returnNode->type != NODE_TYPE_NOP) {
       buffer->appendText(TRI_CHAR_LENGTH_PAIR(" RETURN "));
       returnNode->stringify(buffer, verbose, failIfLong);
     }
@@ -2639,7 +2648,10 @@ bool AstNode::hasFlag(AstNodeFlagType flag) const {
   return ((flags & static_cast<decltype(flags)>(flag)) != 0);
 }
 
-void AstNode::clearFlags() { flags = 0; }
+void AstNode::clearFlags() { 
+  // clear all flags but this one
+  flags &= AstNodeFlagType::FLAG_INTERNAL_CONST; 
+}
 
 void AstNode::setFlag(AstNodeFlagType flag) const { flags |= flag; }
 
@@ -2809,6 +2821,7 @@ void AstNode::clearMembers() {
 void AstNode::setExcludesNull(bool v) {
   TRI_ASSERT(type == NODE_TYPE_OPERATOR_BINARY_LT || type == NODE_TYPE_OPERATOR_BINARY_LE ||
              type == NODE_TYPE_OPERATOR_BINARY_EQ);
+  TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_INTERNAL_CONST));
   value.value._bool = v;
 }
 
@@ -2820,6 +2833,7 @@ bool AstNode::getExcludesNull() const noexcept {
 
 void AstNode::setValueType(AstNodeValueType t) {
   TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_FINALIZED));
+  TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_INTERNAL_CONST));
   value.type = t;
 }
 
@@ -2831,19 +2845,25 @@ bool AstNode::getBoolValue() const noexcept { return value.value._bool; }
 
 void AstNode::setBoolValue(bool v) {
   TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_FINALIZED));
+  TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_INTERNAL_CONST));
+
   freeComputedValue();
   value.value._bool = v;
 }
 
 int64_t AstNode::getIntValue(bool) const noexcept { return value.value._int; }
+
 void AstNode::setIntValue(int64_t v) {
   TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_FINALIZED));
+  TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_INTERNAL_CONST));
   freeComputedValue();
   value.value._int = v;
 }
 
 void AstNode::setDoubleValue(double v) {
   TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_FINALIZED));
+  TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_INTERNAL_CONST));
+
   freeComputedValue();
   value.value._double = v;
 }
@@ -2855,6 +2875,7 @@ size_t AstNode::getStringLength() const {
 
 void AstNode::setStringValue(char const* v, size_t length) {
   TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_FINALIZED));
+  TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_INTERNAL_CONST));
 
   freeComputedValue();
   // note: v may contain the NUL byte and is not necessarily
@@ -2886,21 +2907,27 @@ void* AstNode::getData() const { return value.value._data; }
 
 void AstNode::setData(void* v) {
   TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_FINALIZED));
+  TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_INTERNAL_CONST));
+
   freeComputedValue();
   value.value._data = v;
 }
 
 void AstNode::setData(void const* v) {
-  TRI_ASSERT(!hasFlag(AstNodeFlagType::FLAG_FINALIZED));
-  freeComputedValue();
-  value.value._data = const_cast<void*>(v);
+  setData(const_cast<void*>(v));
 }
 
 void AstNode::freeComputedValue() {
-  if (_computedValue != nullptr) {
+  if (_computedValue != nullptr && !hasFlag(AstNodeFlagType::FLAG_INTERNAL_CONST)) {
     delete[] _computedValue;
     _computedValue = nullptr;
   }
+}
+
+void AstNode::setComputedValue(uint8_t* data) {
+  TRI_ASSERT(isConstant());
+  TRI_ASSERT(hasFlag(AstNodeFlagType::FLAG_INTERNAL_CONST));
+  _computedValue = data;
 }
 
 /// @brief append the AstNode to an output stream

--- a/arangod/Aql/AstNode.h
+++ b/arangod/Aql/AstNode.h
@@ -78,6 +78,8 @@ enum AstNodeFlagType : AstNodeFlagsType {
   FLAG_FINALIZED = 0x0040000,  // node has been finalized and should not be modified; only
                                // set and checked in maintainer mode
   FLAG_SUBQUERY_REFERENCE = 0x0080000,  // node references a subquery
+  
+  FLAG_INTERNAL_CONST = 0x0100000,  // internal, constant node
 };
 
 /// @brief enumeration of AST node value types
@@ -562,6 +564,9 @@ struct AstNode {
   /// it is marked already and exits early; otherwise it will finalize the node
   /// and recurse on its subtree.
   static void markFinalized(AstNode* subtreeRoot);
+
+  /// @brief sets the computed value pointer.
+  void setComputedValue(uint8_t* data);
 
  public:
   /// @brief the node type

--- a/arangod/Aql/Condition.cpp
+++ b/arangod/Aql/Condition.cpp
@@ -1092,13 +1092,13 @@ void Condition::deduplicateJunctionNode(AstNode* unlockedNode) {
 
         if (lhs->type == NODE_TYPE_ATTRIBUTE_ACCESS) {
           if (lhs->isConstant()) {
-            lhs = Ast::resolveConstAttributeAccess(lhs);
+            lhs = _ast->resolveConstAttributeAccess(lhs);
           }
           storeAttributeAccess(varAccess, variableUsage, lhs, j, ATTRIBUTE_LEFT);
         }
         if (rhs->type == NODE_TYPE_ATTRIBUTE_ACCESS || rhs->type == NODE_TYPE_EXPANSION) {
           if (rhs->type == NODE_TYPE_ATTRIBUTE_ACCESS && rhs->isConstant()) {
-            rhs = Ast::resolveConstAttributeAccess(rhs);
+            rhs = _ast->resolveConstAttributeAccess(rhs);
           }
           storeAttributeAccess(varAccess, variableUsage, rhs, j, ATTRIBUTE_RIGHT);
         }
@@ -1279,13 +1279,13 @@ void Condition::optimize(ExecutionPlan* plan, bool multivalued) {
 
         if (lhs->type == NODE_TYPE_ATTRIBUTE_ACCESS) {
           if (lhs->isConstant()) {
-            lhs = Ast::resolveConstAttributeAccess(lhs);
+            lhs = _ast->resolveConstAttributeAccess(lhs);
           }
           storeAttributeAccess(varAccess, variableUsage, lhs, j, ATTRIBUTE_LEFT);
         }
         if (rhs->type == NODE_TYPE_ATTRIBUTE_ACCESS || rhs->type == NODE_TYPE_EXPANSION) {
           if (rhs->type == NODE_TYPE_ATTRIBUTE_ACCESS && rhs->isConstant()) {
-            rhs = Ast::resolveConstAttributeAccess(rhs);
+            rhs = _ast->resolveConstAttributeAccess(rhs);
           }
           storeAttributeAccess(varAccess, variableUsage, rhs, j, ATTRIBUTE_RIGHT);
         }

--- a/arangod/Aql/IndexExecutor.cpp
+++ b/arangod/Aql/IndexExecutor.cpp
@@ -60,14 +60,14 @@ using namespace arangodb::aql;
 
 namespace {
 /// resolve constant attribute accesses
-static void resolveFCallConstAttributes(AstNode* fcall) {
+static void resolveFCallConstAttributes(Ast* ast, AstNode* fcall) {
   TRI_ASSERT(fcall->type == NODE_TYPE_FCALL);
   TRI_ASSERT(fcall->numMembers() == 1);
   AstNode* array = fcall->getMemberUnchecked(0);
   for (size_t x = 0; x < array->numMembers(); x++) {
     AstNode* child = array->getMemberUnchecked(x);
     if (child->type == NODE_TYPE_ATTRIBUTE_ACCESS && child->isConstant()) {
-      child = const_cast<AstNode*>(Ast::resolveConstAttributeAccess(child));
+      child = const_cast<AstNode*>(ast->resolveConstAttributeAccess(child));
       array->changeMember(x, child);
     }
   }
@@ -218,7 +218,7 @@ IndexExecutorInfos::IndexExecutorInfos(
 
         // geo index condition i.e. GEO_CONTAINS, GEO_INTERSECTS
         if (leaf->type == NODE_TYPE_FCALL) {
-          ::resolveFCallConstAttributes(leaf);
+          ::resolveFCallConstAttributes(_ast, leaf);
           continue;  //
         } else if (leaf->numMembers() != 2) {
           continue;  // Otherwise we only support binary conditions
@@ -228,16 +228,16 @@ IndexExecutorInfos::IndexExecutorInfos(
         AstNode* lhs = leaf->getMemberUnchecked(0);
         AstNode* rhs = leaf->getMemberUnchecked(1);
         if (lhs->type == NODE_TYPE_ATTRIBUTE_ACCESS && lhs->isConstant()) {
-          lhs = const_cast<AstNode*>(Ast::resolveConstAttributeAccess(lhs));
+          lhs = const_cast<AstNode*>(_ast->resolveConstAttributeAccess(lhs));
           leaf->changeMember(0, lhs);
         }
         if (rhs->type == NODE_TYPE_ATTRIBUTE_ACCESS && rhs->isConstant()) {
-          rhs = const_cast<AstNode*>(Ast::resolveConstAttributeAccess(rhs));
+          rhs = const_cast<AstNode*>(_ast->resolveConstAttributeAccess(rhs));
           leaf->changeMember(1, rhs);
         }
         // geo index condition i.e. `GEO_DISTANCE(x, y) <= d`
         if (lhs->type == NODE_TYPE_FCALL) {
-          ::resolveFCallConstAttributes(lhs);
+          ::resolveFCallConstAttributes(_ast, lhs);
         }
       }
     }

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -2345,7 +2345,7 @@ void arangodb::aql::simplifyConditionsRule(Optimizer* opt,
         // attribute not found
         if (!isDynamic) {
           modifiedNode = true;
-          return Ast::createNodeValueNull();
+          return p->getAst()->createNodeValueNull();
         }
       }
     } else if (node->type == NODE_TYPE_INDEXED_ACCESS) {
@@ -2420,7 +2420,7 @@ void arangodb::aql::simplifyConditionsRule(Optimizer* opt,
         // attribute not found
         if (!isDynamic) {
           modifiedNode = true;
-          return Ast::createNodeValueNull();
+          return p->getAst()->createNodeValueNull();
         }
       } else if (accessed->type == NODE_TYPE_ARRAY) {
         int64_t position;
@@ -2434,7 +2434,7 @@ void arangodb::aql::simplifyConditionsRule(Optimizer* opt,
           if (!valid) {
             // invalid index
             modifiedNode = true;
-            return Ast::createNodeValueNull();
+            return p->getAst()->createNodeValueNull();
           }
         } else {
           // numeric index, e.g. [123]
@@ -2461,7 +2461,7 @@ void arangodb::aql::simplifyConditionsRule(Optimizer* opt,
 
         // index out of bounds
         modifiedNode = true;
-        return Ast::createNodeValueNull();
+        return p->getAst()->createNodeValueNull();
       }
     }
 
@@ -7367,7 +7367,7 @@ void arangodb::aql::optimizeSubqueriesRule(Optimizer* opt,
       if (std::get<2>(sq)) {
         Ast* ast = plan->getAst();
         // generate a calculation node that only produces "true"
-        auto expr = std::make_unique<Expression>(ast, Ast::createNodeValueBool(true));
+        auto expr = std::make_unique<Expression>(ast, ast->createNodeValueBool(true));
         Variable* outVariable = ast->variables()->createTemporaryVariable();
         auto calcNode = new CalculationNode(plan.get(), plan->nextId(),
                                             std::move(expr), outVariable);


### PR DESCRIPTION
### Scope & Purpose

AstNodes have a member `_computedValue` which can contain a pointer to dynamically allocated memory. this memory is owned by the AstNode and is freed when the AstNode is destroyed. this works fine for AstNodes that are dynamically created and destroyed in a query.

However, there were some singleton AstNodes which were created just once for the entire server process and were shared between all queries:
* NullNode
* FalseNode
* TrueNode
* ZeroNode
* EmptyStringNode

The initialization of the `_computedValue` attribute for these singleton nodes was not thread-safe, so it multiple queries computed the value for the same singleton node simultaneously, this could have caused races and a (small) one-time memory leak .

The fix now makes nodes per-query singleton nodes, so they can be reused within the same query, but are not shared between queries. in addition, the singleton nodes are all initialized in a query before there is any parallelization. as a bonus, no dynamic memory allocation is now needed
for the `_computedValues` of these per-query singleton nodes.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

Test plan:
* run `scripts/unittest shell_server_aql` and `scripts/unittest shell_server_aql --cluster true` in loops with ASan to see if there are leaks or any memory errors.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10022/