### PR TITLE
Fix edge cases in RocksDB primary index range lookups for operators >= and <.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.5.6 (XXXX-XX-XX)
 -------------------
 
+* Fix edge cases in RocksDB primary index range lookups for operators >= and <.
+
 * Fixed issue #11525: Address security vulnerability by updating Swagger-UI
   dependency (upgraded Swagger UI to 3.25.1).
 


### PR DESCRIPTION
### Scope & Purpose

Fix edge cases in RocksDB primary index range lookups for operators >= and <.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10026/