### PR TITLE
Also throw if result is not ok()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix bug which caused failing modification operations to lead to random
+  crashes.
+
 * Fixed issue #11525: Address security vulnerability by updating Swagger-UI
   dependency (upgraded Swagger UI to 3.25.1).
 

--- a/arangod/Aql/ModificationExecutorHelpers.cpp
+++ b/arangod/Aql/ModificationExecutorHelpers.cpp
@@ -151,6 +151,14 @@ bool ModificationExecutorHelpers::writeRequired(ModificationExecutorInfos const&
 
 void ModificationExecutorHelpers::throwOperationResultException(
     ModificationExecutorInfos const& infos, OperationResult const& result) {
+
+  // A "higher level error" happened (such as the transaction being aborted,
+  // replication being refused, etc ), and we do not have errorCounter or
+  // similar so we throw.
+  if (!result.ok()) {
+    THROW_ARANGO_EXCEPTION(result);
+  }
+
   auto const& errorCounter = result.countErrorCodes;
 
   // Early escape if we are ignoring errors.

--- a/arangod/Aql/ModificationExecutorHelpers.cpp
+++ b/arangod/Aql/ModificationExecutorHelpers.cpp
@@ -150,16 +150,17 @@ bool ModificationExecutorHelpers::writeRequired(ModificationExecutorInfos const&
 }
 
 void ModificationExecutorHelpers::throwOperationResultException(
-    ModificationExecutorInfos const& infos, OperationResult const& result) {
+    ModificationExecutorInfos const& infos, OperationResult const& operationResult) {
 
   // A "higher level error" happened (such as the transaction being aborted,
   // replication being refused, etc ), and we do not have errorCounter or
   // similar so we throw.
-  if (!result.ok()) {
-    THROW_ARANGO_EXCEPTION(result);
+  if (!operationResult.ok()) {
+    // inside OperationResult hides a small result.
+    THROW_ARANGO_EXCEPTION(operationResult.result);
   }
 
-  auto const& errorCounter = result.countErrorCodes;
+  auto const& errorCounter = operationResult.countErrorCodes;
 
   // Early escape if we are ignoring errors.
   if (infos._ignoreErrors == true || errorCounter.empty()) {
@@ -176,7 +177,7 @@ void ModificationExecutorHelpers::throwOperationResultException(
     auto const errorCode = p.first;
     if (!(infos._ignoreDocumentNotFound && errorCode == TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND)) {
       // Find the first error and throw with message.
-      for (auto doc : VPackArrayIterator(result.slice())) {
+      for (auto doc : VPackArrayIterator(operationResult.slice())) {
         if (doc.isObject() && doc.hasKey(StaticStrings::ErrorNum) &&
             doc.get(StaticStrings::ErrorNum).getInt() == errorCode) {
           VPackSlice s = doc.get(StaticStrings::ErrorMessage);

--- a/arangod/Aql/ModificationExecutorHelpers.h
+++ b/arangod/Aql/ModificationExecutorHelpers.h
@@ -84,7 +84,7 @@ bool writeRequired(ModificationExecutorInfos const& infos,
 // which are needed in the cluster where a document not found error can happen
 // but not be fatal.
 void throwOperationResultException(ModificationExecutorInfos const& infos,
-                                   OperationResult const& result);
+                                   OperationResult const& operationResult);
 
 // Converts ModificationOptions to OperationOptions
 OperationOptions convertOptions(ModificationOptions const& in, Variable const* outVariableNew,


### PR DESCRIPTION
If a modification operation yields an `OperationResult` that is *not* `ok()` we need to throw, and not try to access an empty array of results (and then pretend everything is ok...)