### PR TITLE
Bug fix/internal issue #650

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 devel
 -----
+* Fixed internal issue #650: Added analyzer cache update before ArangoSearch View
+  creation/update
 
 * Fixed issue ES-554: failed to build filter while querying ArangoSearch view.
 

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -1908,6 +1908,12 @@ Result IResearchAnalyzerFeature::cleanupAnalyzersCollection(irs::string_ref cons
 }
 
 Result IResearchAnalyzerFeature::loadAvailableAnalyzers(irs::string_ref const& dbName) {
+  if (!ServerState::instance()->isCoordinator()) {
+    // single-servers will load anythign they need in regular get
+    // dbserver receives analyzers definitions from coordinators in ddl requests
+    // and dbservers never should start ddl by themselves. 
+    return {};
+  }
   auto res = loadAnalyzers(dbName);
   if (res.fail()) {
     return res;

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -1909,8 +1909,8 @@ Result IResearchAnalyzerFeature::cleanupAnalyzersCollection(irs::string_ref cons
 
 Result IResearchAnalyzerFeature::loadAvailableAnalyzers(irs::string_ref const& dbName) {
   if (!ServerState::instance()->isCoordinator()) {
-    // single-servers will load anythign they need in regular get
-    // dbserver receives analyzers definitions from coordinators in ddl requests
+    // Single-servers will load analyzers they need in regular get call.
+    // DbServer receives analyzers definitions from coordinators in ddl requests
     // and dbservers never should start ddl by themselves.
     return {};
   }

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -1907,6 +1907,19 @@ Result IResearchAnalyzerFeature::cleanupAnalyzersCollection(irs::string_ref cons
   return {};
 }
 
+Result IResearchAnalyzerFeature::loadAvailableAnalyzers(irs::string_ref const& dbName) {
+  auto res = loadAnalyzers(dbName);
+  if (res.fail()) {
+    return res;
+  }
+  if (dbName != arangodb::StaticStrings::SystemDatabase) {
+    // System is available for all other databases. So reload it`s analyzers too
+    res = loadAnalyzers(arangodb::StaticStrings::SystemDatabase);
+  }
+  return res;
+}
+
+
 Result IResearchAnalyzerFeature::loadAnalyzers(
     irs::string_ref const& database /*= irs::string_ref::NIL*/) {
   if (!server().hasFeature<DatabaseFeature>()) {

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -1911,7 +1911,7 @@ Result IResearchAnalyzerFeature::loadAvailableAnalyzers(irs::string_ref const& d
   if (!ServerState::instance()->isCoordinator()) {
     // single-servers will load anythign they need in regular get
     // dbserver receives analyzers definitions from coordinators in ddl requests
-    // and dbservers never should start ddl by themselves. 
+    // and dbservers never should start ddl by themselves.
     return {};
   }
   auto res = loadAnalyzers(dbName);

--- a/arangod/IResearch/IResearchAnalyzerFeature.h
+++ b/arangod/IResearch/IResearchAnalyzerFeature.h
@@ -213,6 +213,14 @@ class IResearchAnalyzerFeature final
   }
 
   //////////////////////////////////////////////////////////////////////////////
+  /// @brief Loads (or reloads if necessary) analyzers available for use in context
+  /// of specified database.
+  /// @param dbName database name
+  /// @return overall load result
+  //////////////////////////////////////////////////////////////////////////////
+  Result loadAvailableAnalyzers(irs::string_ref const& dbName);
+
+  //////////////////////////////////////////////////////////////////////////////
   /// Checks if analyzer db (identified by db name prefix extracted from analyzer 
   /// name) could be reached from specified db.
   /// Properly handles special cases (e.g. NIL and EMPTY)       
@@ -313,11 +321,11 @@ class IResearchAnalyzerFeature final
   AnalyzersRevision::Ptr getAnalyzersRevision(const TRI_vocbase_t& vocbase, bool forceLoadPlan = false) const;
 
   ///////////////////////////////////////////////////////////////////////////////
-/// @brief return current known analyzers revision
-/// @param vocbase name to get revision for
-/// @param forceLoadPlan force request to get latest available revision
-/// @return revision number. always 0 for single server and before plan is loaded
-///////////////////////////////////////////////////////////////////////////////
+  /// @brief return current known analyzers revision
+  /// @param vocbase name to get revision for
+  /// @param forceLoadPlan force request to get latest available revision
+  /// @return revision number. always 0 for single server and before plan is loaded
+  ///////////////////////////////////////////////////////////////////////////////
   AnalyzersRevision::Ptr getAnalyzersRevision(const irs::string_ref& vocbaseName, bool forceLoadPlan = false) const;
 
   virtual void prepare() override;

--- a/arangod/IResearch/IResearchAnalyzerFeature.h
+++ b/arangod/IResearch/IResearchAnalyzerFeature.h
@@ -221,9 +221,9 @@ class IResearchAnalyzerFeature final
   Result loadAvailableAnalyzers(irs::string_ref const& dbName);
 
   //////////////////////////////////////////////////////////////////////////////
-  /// Checks if analyzer db (identified by db name prefix extracted from analyzer 
+  /// Checks if analyzer db (identified by db name prefix extracted from analyzer
   /// name) could be reached from specified db.
-  /// Properly handles special cases (e.g. NIL and EMPTY)       
+  /// Properly handles special cases (e.g. NIL and EMPTY)
   /// @param dbNameFromAnalyzer database name extracted from analyzer name
   /// @param currentDbName database name to check against (should not be empty!)
   /// @param forGetters check special case for getting analyzer (not creating/removing)
@@ -361,8 +361,7 @@ class IResearchAnalyzerFeature final
     irs::string_ref const& type, // analyzer type
     VPackSlice const properties, // analyzer properties
     irs::flags const& features, // analyzer features
-    AnalyzersRevision::Revision revision // analyzer revision
-  );
+    AnalyzersRevision::Revision revision); // analyzer revision
 
   AnalyzerPool::ptr get(irs::string_ref const& normalizedName,
                         AnalyzerName const& name, AnalyzersRevision::Revision const revision,
@@ -380,7 +379,7 @@ class IResearchAnalyzerFeature final
   ////////////////////////////////////////////////////////////////////////////////
   /// removes analyzers for database from feature cache
   /// Write lock must be acquired by caller
-  /// @param database the database to cleanup analyzers for 
+  /// @param database the database to cleanup analyzers for
   void cleanupAnalyzers(irs::string_ref const& database);
 
   //////////////////////////////////////////////////////////////////////////////

--- a/arangod/RestHandler/RestViewHandler.cpp
+++ b/arangod/RestHandler/RestViewHandler.cpp
@@ -207,7 +207,7 @@ void RestViewHandler::createView() {
   try {
     // First refresh our analyzers cache to see all latest changes in analyzers
     auto res = server().getFeature<arangodb::iresearch::IResearchAnalyzerFeature>()
-                         .loadAvailableAnalyzers(_vocbase.name());
+                       .loadAvailableAnalyzers(_vocbase.name());
 
     if (res.fail()) {
       generateError(res);
@@ -287,7 +287,7 @@ void RestViewHandler::modifyView(bool partialUpdate) {
 
     // First refresh our analyzers cache to see all latest changes in analyzers
     auto const analyzersRes = server().getFeature<arangodb::iresearch::IResearchAnalyzerFeature>()
-      .loadAvailableAnalyzers(_vocbase.name());
+                                      .loadAvailableAnalyzers(_vocbase.name());
     if (analyzersRes.fail()) {
       generateError(analyzersRes);
       return;

--- a/arangod/RestHandler/RestViewHandler.cpp
+++ b/arangod/RestHandler/RestViewHandler.cpp
@@ -27,6 +27,7 @@
 #include "Basics/Exceptions.h"
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"
+#include "IResearch/IResearchAnalyzerFeature.h"
 #include "Rest/GeneralResponse.h"
 #include "RestServer/DatabaseFeature.h"
 #include "Utils/CollectionNameResolver.h"
@@ -204,8 +205,18 @@ void RestViewHandler::createView() {
   }
 
   try {
+    // First refresh our analyzers cache to see all latest changes in analyzers
+    auto res = server().getFeature<arangodb::iresearch::IResearchAnalyzerFeature>()
+                         .loadAvailableAnalyzers(_vocbase.name());
+
+    if (res.fail()) {
+      generateError(res);
+      events::CreateView(_vocbase.name(), nameSlice.copyString(), res.errorNumber());
+      return;
+    }
+
     LogicalView::ptr view;
-    auto res = LogicalView::create(view, _vocbase, body);
+    res = LogicalView::create(view, _vocbase, body);
 
     if (!res.ok()) {
       generateError(res);
@@ -271,6 +282,14 @@ void RestViewHandler::modifyView(bool partialUpdate) {
     VPackSlice const body = this->parseVPackBody(parseSuccess);
 
     if (!parseSuccess) {
+      return;
+    }
+
+    // First refresh our analyzers cache to see all latest changes in analyzers
+    auto const analyzersRes = server().getFeature<arangodb::iresearch::IResearchAnalyzerFeature>()
+      .loadAvailableAnalyzers(_vocbase.name());
+    if (analyzersRes.fail()) {
+      generateError(analyzersRes);
       return;
     }
 

--- a/arangod/V8Server/v8-views.cpp
+++ b/arangod/V8Server/v8-views.cpp
@@ -26,6 +26,7 @@
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/conversions.h"
+#include "IResearch/IResearchAnalyzerFeature.h"
 #include "Logger/Logger.h"
 #include "RestServer/DatabaseFeature.h"
 #include "Transaction/V8Context.h"
@@ -186,8 +187,18 @@ static void JS_CreateViewVocbase(v8::FunctionCallbackInfo<v8::Value> const& args
                                                            header.slice(), false, true);
 
   try {
+
+    // First refresh our analyzers cache to see all latest changes in analyzers
+    TRI_GET_GLOBALS();
+    auto res = v8g->_server.getFeature<arangodb::iresearch::IResearchAnalyzerFeature>()
+      .loadAvailableAnalyzers(vocbase.name());
+
+    if (res.fail()) {
+      TRI_V8_THROW_EXCEPTION_MESSAGE(res.errorNumber(), res.errorMessage());
+    }
+
     LogicalView::ptr view;
-    auto res = LogicalView::create(view, vocbase, builder.slice());
+    res = LogicalView::create(view, vocbase, builder.slice());
 
     if (!res.ok()) {
       // events::CreateView(vocbase.name(), name, res.errorNumber());
@@ -579,7 +590,16 @@ static void JS_PropertiesViewVocbase(v8::FunctionCallbackInfo<v8::Value> const& 
       TRI_V8_THROW_EXCEPTION(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
     }
 
-    auto res = view->properties(builder.slice(), partialUpdate);
+    auto& vocbase = GetContextVocBase(isolate);
+    TRI_GET_GLOBALS();
+    auto res = v8g->_server.getFeature<arangodb::iresearch::IResearchAnalyzerFeature>()
+      .loadAvailableAnalyzers(vocbase.name());
+
+    if (res.fail()) {
+      TRI_V8_THROW_EXCEPTION_MESSAGE(res.errorNumber(), res.errorMessage());
+    }
+
+    res = view->properties(builder.slice(), partialUpdate);
 
     if (!res.ok()) {
       TRI_V8_THROW_EXCEPTION_MESSAGE(res.errorNumber(), res.errorMessage());

--- a/arangod/V8Server/v8-views.cpp
+++ b/arangod/V8Server/v8-views.cpp
@@ -191,7 +191,7 @@ static void JS_CreateViewVocbase(v8::FunctionCallbackInfo<v8::Value> const& args
     // First refresh our analyzers cache to see all latest changes in analyzers
     TRI_GET_GLOBALS();
     auto res = v8g->_server.getFeature<arangodb::iresearch::IResearchAnalyzerFeature>()
-      .loadAvailableAnalyzers(vocbase.name());
+                           .loadAvailableAnalyzers(vocbase.name());
 
     if (res.fail()) {
       TRI_V8_THROW_EXCEPTION_MESSAGE(res.errorNumber(), res.errorMessage());
@@ -593,7 +593,7 @@ static void JS_PropertiesViewVocbase(v8::FunctionCallbackInfo<v8::Value> const& 
     auto& vocbase = GetContextVocBase(isolate);
     TRI_GET_GLOBALS();
     auto res = v8g->_server.getFeature<arangodb::iresearch::IResearchAnalyzerFeature>()
-      .loadAvailableAnalyzers(vocbase.name());
+                           .loadAvailableAnalyzers(vocbase.name());
 
     if (res.fail()) {
       TRI_V8_THROW_EXCEPTION_MESSAGE(res.errorNumber(), res.errorMessage());

--- a/tests/js/common/aql/aql-view-arangosearch-ddl-cluster.js
+++ b/tests/js/common/aql/aql-view-arangosearch-ddl-cluster.js
@@ -1289,8 +1289,35 @@ function IResearchFeatureDDLTestSuite () {
 
       db._useDatabase("_system");
       db._dropDatabase(dbName);
+    },
+    testAutoLoadAnalyzerOnViewCreation : function() {
+      const dbName = "TestNameDroppedDB";
+      const analyzerName = "TestAnalyzer";
+      db._useDatabase("_system");
+      assertNotEqual(null, db._collection("_analyzers"));
+      try { db._dropDatabase(dbName); } catch (e) {}
+      try { analyzers.remove(analyzerName, true); } catch (e) {}
+      try {
+        db._analyzers.save({type:"identity", name: analyzerName});
+        db._createDatabase(dbName);
+        db._useDatabase(dbName);
+        db._analyzers.save({type:"identity", name: analyzerName});
+        var view = db._createView("analyzersView", "arangosearch", {
+          links: {
+            _analyzers : {
+              includeAllFields:true,
+              analyzers: [ analyzerName] // test only new database access. Load from _system is checked in gtest
+            }
+          }
+        });
+        var res = db._query("FOR d IN analyzersView OPTIONS {waitForSync:true} RETURN d").toArray();
+        assertEqual(1, res.length);
+      } finally {
+        db._useDatabase("_system");
+        db._dropDatabase(dbName);
+        try { analyzers.remove(analyzerName, true); } catch (e) {}
+      }
     }
-
   };
 }
 

--- a/tests/js/common/aql/aql-view-arangosearch-ddl-cluster.js
+++ b/tests/js/common/aql/aql-view-arangosearch-ddl-cluster.js
@@ -1296,9 +1296,7 @@ function IResearchFeatureDDLTestSuite () {
       db._useDatabase("_system");
       assertNotEqual(null, db._collection("_analyzers"));
       try { db._dropDatabase(dbName); } catch (e) {}
-      try { analyzers.remove(analyzerName, true); } catch (e) {}
       try {
-        db._analyzers.save({type:"identity", name: analyzerName});
         db._createDatabase(dbName);
         db._useDatabase(dbName);
         db._analyzers.save({type:"identity", name: analyzerName});
@@ -1315,7 +1313,6 @@ function IResearchFeatureDDLTestSuite () {
       } finally {
         db._useDatabase("_system");
         db._dropDatabase(dbName);
-        try { analyzers.remove(analyzerName, true); } catch (e) {}
       }
     },
     testAutoLoadAnalyzerOnViewUpdate : function() {
@@ -1324,9 +1321,7 @@ function IResearchFeatureDDLTestSuite () {
       db._useDatabase("_system");
       assertNotEqual(null, db._collection("_analyzers"));
       try { db._dropDatabase(dbName); } catch (e) {}
-      try { analyzers.remove(analyzerName, true); } catch (e) {}
       try {
-        db._analyzers.save({type:"identity", name: analyzerName});
         db._createDatabase(dbName);
         db._useDatabase(dbName);
         db._analyzers.save({type:"identity", name: analyzerName});
@@ -1345,7 +1340,6 @@ function IResearchFeatureDDLTestSuite () {
       } finally {
         db._useDatabase("_system");
         db._dropDatabase(dbName);
-        try { analyzers.remove(analyzerName, true); } catch (e) {}
       }
     }
   };


### PR DESCRIPTION
Added analyzer cache update on coordinator befor view create/update.
If cluster is just started analyzers cache is empty on coordinator. And attempt to create/update ArangoSearch view will fail due to not found analyzers. Now cache is reread for current database and system database (as analyzers from system database could be used also in other databases).

Fix is verified by js tests

https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/10054/

