### PR TITLE
fixed issue #11652: Error: AQL: missing variable #2 (1) for node #6 (FilterNode) while planning registers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fixed issue #11652: Error: AQL: missing variable #2 (1) for node #6 
+  (FilterNode) while planning registers.
+
 * Fixed internal issue #650: Added analyzer cache update before ArangoSearch
   view creation/update.
 

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -1671,16 +1671,27 @@ AqlValue Expression::executeSimpleExpressionArithmetic(AstNode const* node,
 }
 
 void Expression::replaceNode(AstNode* node) {
+  TRI_ASSERT(node != nullptr);
   if (node != _node) {
     _node = node;
     invalidateAfterReplacements();
   }
 }
 
-Ast* Expression::ast() const noexcept { return _ast; }
+Ast* Expression::ast() const noexcept { 
+  TRI_ASSERT(_ast != nullptr);
+  return _ast; 
+}
 
-AstNode const* Expression::node() const { return _node; }
-AstNode* Expression::nodeForModification() const { return _node; }
+AstNode const* Expression::node() const {
+  TRI_ASSERT(_node != nullptr);
+  return _node; 
+}
+
+AstNode* Expression::nodeForModification() const { 
+  TRI_ASSERT(_node != nullptr);
+  return _node; 
+}
 
 bool Expression::canRunOnDBServer() {
   TRI_ASSERT(_type != UNPROCESSED);

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -7479,15 +7479,12 @@ void arangodb::aql::moveFiltersIntoEnumerateRule(Optimizer* opt,
 
         current = filterParent;
         modified = true;
+        continue;
       } else if (current->getType() == EN::CALCULATION) {
         // store all calculations we found
         auto calculationNode = ExecutionNode::castTo<CalculationNode*>(current);
         auto expr = calculationNode->expression();
         if (!expr->isDeterministic() || !expr->canRunOnDBServer()) {
-          break;
-        }
-
-        if (expr->node() == nullptr) {
           break;
         }
 


### PR DESCRIPTION
### Scope & Purpose

Fixed issue #11652 

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is a GitHub Issue reported by a Community User: #11652  

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10063/