### PR TITLE
fixed issue #11652: Error: AQL: missing variable #2 (1) for node #6 (FilterNode) while planning registers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.6.4 (XXXX-XX-XX)
 -------------------
 
+* Fixed issue #11652: Error: AQL: missing variable #2 (1) for node #6 
+  (FilterNode) while planning registers.
+
 * Update OpenLDAP to 2.4.50.
 
 * Fixed issue ES-545: failing modification operations led to random crashes with

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -7234,6 +7234,7 @@ void arangodb::aql::moveFiltersIntoEnumerateRule(Optimizer* opt, std::unique_ptr
         
         current = filterParent;
         modified = true;
+        continue;
       } else if (current->getType() == EN::CALCULATION) {
         // store all calculations we found
         auto calculationNode = ExecutionNode::castTo<CalculationNode*>(current);


### PR DESCRIPTION
### Scope & Purpose

Fixed issue #11652 

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is a GitHub Issue reported by a Community User: #11652  

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10064/