### PR TITLE
add caching for validation

### DIFF
--- a/arangod/Aql/AqlFunctionsInternalCache.cpp
+++ b/arangod/Aql/AqlFunctionsInternalCache.cpp
@@ -38,7 +38,7 @@ using namespace arangodb::aql;
 AqlFunctionsInternalCache::~AqlFunctionsInternalCache() { clear(); }
 
 void AqlFunctionsInternalCache::clear() noexcept {
-  _regexCache.clear();
+  _aqlFunctionsInternalCache.clear();
   _likeCache.clear();
 }
 
@@ -46,7 +46,7 @@ icu::RegexMatcher* AqlFunctionsInternalCache::buildRegexMatcher(char const* ptr,
                                                  bool caseInsensitive) {
   buildRegexPattern(_temp, ptr, length, caseInsensitive);
 
-  return fromCache(_temp, _regexCache);
+  return fromCache(_temp, _aqlFunctionsInternalCache);
 }
 
 icu::RegexMatcher* AqlFunctionsInternalCache::buildLikeMatcher(char const* ptr, size_t length,
@@ -93,8 +93,6 @@ icu::RegexMatcher* AqlFunctionsInternalCache::buildSplitMatcher(AqlValue const& 
 }
 
 arangodb::ValidatorBase* AqlFunctionsInternalCache::buildValidator(VPackSlice const& validatorParams) {
-
-  // insert into cache, no matter if pattern is valid or not
   auto matcherIter = _schemaCache.try_emplace(
         validatorParams.hash(),
         arangodb::lazyConstruct([&]{
@@ -103,7 +101,6 @@ arangodb::ValidatorBase* AqlFunctionsInternalCache::buildValidator(VPackSlice co
       ).first;
 
   return matcherIter->second.get();
-
 };
 
 /// @brief get matcher from cache, or insert a new matcher for the specified

--- a/arangod/Aql/AqlFunctionsInternalCache.cpp
+++ b/arangod/Aql/AqlFunctionsInternalCache.cpp
@@ -38,15 +38,16 @@ using namespace arangodb::aql;
 AqlFunctionsInternalCache::~AqlFunctionsInternalCache() { clear(); }
 
 void AqlFunctionsInternalCache::clear() noexcept {
-  _aqlFunctionsInternalCache.clear();
+  _regexCache.clear();
   _likeCache.clear();
+  _validatorCache.clear();
 }
 
 icu::RegexMatcher* AqlFunctionsInternalCache::buildRegexMatcher(char const* ptr, size_t length,
                                                  bool caseInsensitive) {
   buildRegexPattern(_temp, ptr, length, caseInsensitive);
 
-  return fromCache(_temp, _aqlFunctionsInternalCache);
+  return fromCache(_temp, _regexCache);
 }
 
 icu::RegexMatcher* AqlFunctionsInternalCache::buildLikeMatcher(char const* ptr, size_t length,
@@ -93,7 +94,7 @@ icu::RegexMatcher* AqlFunctionsInternalCache::buildSplitMatcher(AqlValue const& 
 }
 
 arangodb::ValidatorBase* AqlFunctionsInternalCache::buildValidator(VPackSlice const& validatorParams) {
-  auto matcherIter = _schemaCache.try_emplace(
+  auto matcherIter = _validatorCache.try_emplace(
         validatorParams.hash(),
         arangodb::lazyConstruct([&]{
           return std::unique_ptr<arangodb::ValidatorBase>(new arangodb::ValidatorJsonSchema(validatorParams));

--- a/arangod/Aql/AqlFunctionsInternalCache.h
+++ b/arangod/Aql/AqlFunctionsInternalCache.h
@@ -84,7 +84,7 @@ class AqlFunctionsInternalCache final {
 
  private:
   /// @brief cache for compiled regexes (REGEX function)
-  std::unordered_map<std::string, std::unique_ptr<icu::RegexMatcher>> _regexCache;
+  std::unordered_map<std::string, std::unique_ptr<icu::RegexMatcher>> _aqlFunctionsInternalCache;
   /// @brief cache for compiled regexes (LIKE function)
   std::unordered_map<std::string, std::unique_ptr<icu::RegexMatcher>> _likeCache;
   /// @brief a reusable string object for pattern generation

--- a/arangod/Aql/AqlFunctionsInternalCache.h
+++ b/arangod/Aql/AqlFunctionsInternalCache.h
@@ -58,6 +58,8 @@ class AqlFunctionsInternalCache final {
                                        velocypack::Options const* opts,
                                        bool& isEmptyExpression);
 
+  /// @brief return validators -- This is currently only used for JSONSchema validation.
+  //                              But it is able to handle other validation types without change.
   arangodb::ValidatorBase* buildValidator(VPackSlice const& validatorDescription);
 
   /// @brief inspect a LIKE pattern from a string, and remove all
@@ -84,11 +86,12 @@ class AqlFunctionsInternalCache final {
 
  private:
   /// @brief cache for compiled regexes (REGEX function)
-  std::unordered_map<std::string, std::unique_ptr<icu::RegexMatcher>> _aqlFunctionsInternalCache;
+  std::unordered_map<std::string, std::unique_ptr<icu::RegexMatcher>> _regexCache;
   /// @brief cache for compiled regexes (LIKE function)
   std::unordered_map<std::string, std::unique_ptr<icu::RegexMatcher>> _likeCache;
-  /// @brief a reusable string object for pattern generation
-  std::unordered_map<std::size_t, std::unique_ptr<arangodb::ValidatorBase>> _schemaCache;
+  /// @brief cache for validators -- This is currently only used for JSONSchema validation.
+  //                                 But it is able to handle other validation types without change.
+  std::unordered_map<std::size_t, std::unique_ptr<arangodb::ValidatorBase>> _validatorCache;
   /// @brief a reusable string object for pattern generation
   std::string _temp;
 };

--- a/arangod/Aql/AqlFunctionsInternalCache.h
+++ b/arangod/Aql/AqlFunctionsInternalCache.h
@@ -26,9 +26,12 @@
 
 #include "Aql/AqlValue.h"
 #include "Basics/Common.h"
+#include <VocBase/Validators.h>
 
 #include <unicode/regex.h>
 #include <memory>
+
+
 
 namespace arangodb {
 
@@ -39,13 +42,13 @@ class Methods;
 namespace aql {
 
 /// cache for parsed regexes, not thread safe
-class RegexCache final {
+class AqlFunctionsInternalCache final {
  public:
-  RegexCache(RegexCache const&) = delete;
-  RegexCache& operator=(RegexCache const&) = delete;
+  AqlFunctionsInternalCache(AqlFunctionsInternalCache const&) = delete;
+  AqlFunctionsInternalCache& operator=(AqlFunctionsInternalCache const&) = delete;
 
-  RegexCache() = default;
-  ~RegexCache();
+  AqlFunctionsInternalCache() = default;
+  ~AqlFunctionsInternalCache();
 
   void clear() noexcept;
 
@@ -54,6 +57,8 @@ class RegexCache final {
   icu::RegexMatcher* buildSplitMatcher(AqlValue const& splitExpression,
                                        velocypack::Options const* opts,
                                        bool& isEmptyExpression);
+
+  arangodb::ValidatorBase* buildValidator(VPackSlice const& validatorDescription);
 
   /// @brief inspect a LIKE pattern from a string, and remove all
   /// of its escape characters. will stop at the first wildcards found.
@@ -82,6 +87,8 @@ class RegexCache final {
   std::unordered_map<std::string, std::unique_ptr<icu::RegexMatcher>> _regexCache;
   /// @brief cache for compiled regexes (LIKE function)
   std::unordered_map<std::string, std::unique_ptr<icu::RegexMatcher>> _likeCache;
+  /// @brief a reusable string object for pattern generation
+  std::unordered_map<std::size_t, std::unique_ptr<arangodb::ValidatorBase>> _schemaCache;
   /// @brief a reusable string object for pattern generation
   std::string _temp;
 };

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -1912,7 +1912,7 @@ void Ast::validateAndOptimize(transaction::Methods& trx) {
     std::unordered_set<std::string> writeCollectionsSeen;
     std::unordered_map<std::string, int64_t> collectionsFirstSeen;
     std::unordered_map<Variable const*, AstNode const*> variableDefinitions;
-    AqlFunctionsInternalCache regexCache;
+    AqlFunctionsInternalCache aqlFunctionsInternalCache;
     transaction::Methods& trx;
     int64_t stopOptimizationRequests = 0;
     int64_t nestingLevel = 0;
@@ -2075,7 +2075,7 @@ void Ast::validateAndOptimize(transaction::Methods& trx) {
         node->type == NODE_TYPE_OPERATOR_BINARY_LE || node->type == NODE_TYPE_OPERATOR_BINARY_GT ||
         node->type == NODE_TYPE_OPERATOR_BINARY_GE || node->type == NODE_TYPE_OPERATOR_BINARY_IN ||
         node->type == NODE_TYPE_OPERATOR_BINARY_NIN) {
-      return this->optimizeBinaryOperatorRelational(ctx->trx, ctx->regexCache, node);
+      return this->optimizeBinaryOperatorRelational(ctx->trx, ctx->aqlFunctionsInternalCache, node);
     }
 
     if (node->type == NODE_TYPE_OPERATOR_BINARY_PLUS ||
@@ -2117,7 +2117,7 @@ void Ast::validateAndOptimize(transaction::Methods& trx) {
 
       if (ctx->stopOptimizationRequests == 0) {
         // optimization allowed
-        return this->optimizeFunctionCall(ctx->trx, ctx->regexCache, node);
+        return this->optimizeFunctionCall(ctx->trx, ctx->aqlFunctionsInternalCache, node);
       }
       // optimization not allowed
       return node;

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -2945,7 +2945,7 @@ AstNode* Ast::optimizeBinaryOperatorLogical(AstNode* node, bool canModifyResultT
 
 /// @brief optimizes the binary relational operators <, <=, >, >=, ==, != and IN
 AstNode* Ast::optimizeBinaryOperatorRelational(transaction::Methods& trx,
-                                               AqlFunctionsInternalCache& regex,
+                                               AqlFunctionsInternalCache& aqlFunctionsInternalCache,
                                                AstNode* node) {
   TRI_ASSERT(node != nullptr);
   TRI_ASSERT(node->numMembers() == 2);
@@ -2975,7 +2975,7 @@ AstNode* Ast::optimizeBinaryOperatorRelational(transaction::Methods& trx,
                                         rhs->getMember(0));
       }
       // and optimize ourselves...
-      return optimizeBinaryOperatorRelational(trx, regex, node);
+      return optimizeBinaryOperatorRelational(trx, aqlFunctionsInternalCache, node);
     }
     // intentionally falls through
   }
@@ -3018,7 +3018,7 @@ AstNode* Ast::optimizeBinaryOperatorRelational(transaction::Methods& trx,
   TRI_ASSERT(lhs->isConstant() && rhs->isConstant());
 
   Expression exp(this, node);
-  FixedVarExpressionContext context(trx, _query, regex);
+  FixedVarExpressionContext context(trx, _query, aqlFunctionsInternalCache);
   bool mustDestroy;
 
   AqlValue a = exp.execute(&context, mustDestroy);
@@ -3244,7 +3244,7 @@ AstNode* Ast::optimizeAttributeAccess(
 
 /// @brief optimizes a call to a built-in function
 AstNode* Ast::optimizeFunctionCall(transaction::Methods& trx,
-                                   AqlFunctionsInternalCache& regex, AstNode* node) {
+                                   AqlFunctionsInternalCache& aqlFunctionsInternalCache, AstNode* node) {
   TRI_ASSERT(node != nullptr);
   TRI_ASSERT(node->type == NODE_TYPE_FCALL);
   TRI_ASSERT(node->numMembers() == 1);
@@ -3360,7 +3360,7 @@ AstNode* Ast::optimizeFunctionCall(transaction::Methods& trx,
   }
 
   Expression exp(this, node);
-  FixedVarExpressionContext context(trx, _query, regex);
+  FixedVarExpressionContext context(trx, _query, aqlFunctionsInternalCache);
   bool mustDestroy;
 
   AqlValue a = exp.execute(&context, mustDestroy);

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -40,7 +40,7 @@
 #include "Aql/Graphs.h"
 #include "Aql/ModificationOptions.h"
 #include "Aql/QueryContext.h"
-#include "Aql/RegexCache.h"
+#include "Aql/AqlFunctionsInternalCache.h"
 #include "Basics/Exceptions.h"
 #include "Basics/StringUtils.h"
 #include "Basics/tri-strings.h"
@@ -1912,7 +1912,7 @@ void Ast::validateAndOptimize(transaction::Methods& trx) {
     std::unordered_set<std::string> writeCollectionsSeen;
     std::unordered_map<std::string, int64_t> collectionsFirstSeen;
     std::unordered_map<Variable const*, AstNode const*> variableDefinitions;
-    RegexCache regexCache;
+    AqlFunctionsInternalCache regexCache;
     transaction::Methods& trx;
     int64_t stopOptimizationRequests = 0;
     int64_t nestingLevel = 0;
@@ -2945,7 +2945,7 @@ AstNode* Ast::optimizeBinaryOperatorLogical(AstNode* node, bool canModifyResultT
 
 /// @brief optimizes the binary relational operators <, <=, >, >=, ==, != and IN
 AstNode* Ast::optimizeBinaryOperatorRelational(transaction::Methods& trx,
-                                               RegexCache& regex,
+                                               AqlFunctionsInternalCache& regex,
                                                AstNode* node) {
   TRI_ASSERT(node != nullptr);
   TRI_ASSERT(node->numMembers() == 2);
@@ -3244,7 +3244,7 @@ AstNode* Ast::optimizeAttributeAccess(
 
 /// @brief optimizes a call to a built-in function
 AstNode* Ast::optimizeFunctionCall(transaction::Methods& trx,
-                                   RegexCache& regex, AstNode* node) {
+                                   AqlFunctionsInternalCache& regex, AstNode* node) {
   TRI_ASSERT(node != nullptr);
   TRI_ASSERT(node->type == NODE_TYPE_FCALL);
   TRI_ASSERT(node->numMembers() == 1);
@@ -3308,7 +3308,7 @@ AstNode* Ast::optimizeFunctionCall(transaction::Methods& trx,
       std::string unescapedPattern;
       bool wildcardFound;
       bool wildcardIsLastChar;
-      std::tie(wildcardFound, wildcardIsLastChar) = RegexCache::inspectLikePattern(unescapedPattern, patternArg->getStringValue(), patternArg->getStringLength());
+      std::tie(wildcardFound, wildcardIsLastChar) = AqlFunctionsInternalCache::inspectLikePattern(unescapedPattern, patternArg->getStringValue(), patternArg->getStringLength());
 
       if (!wildcardFound) {
         TRI_ASSERT(!wildcardIsLastChar);

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -59,7 +59,7 @@ namespace aql {
 
 class BindParameters;
 class QueryContext;
-class RegexCache;
+class AqlFunctionsInternalCache;
 struct Variable;
 
 typedef std::unordered_map<Variable const*, std::unordered_set<std::string>> TopLevelAttributes;
@@ -479,7 +479,7 @@ class Ast {
 
   /// @brief optimizes the binary relational operators <, <=, >, >=, ==, != and IN
   AstNode* optimizeBinaryOperatorRelational(transaction::Methods&,
-                                            RegexCache&, AstNode*);
+                                            AqlFunctionsInternalCache&, AstNode*);
 
   /// @brief optimizes the binary arithmetic operators +, -, *, / and %
   AstNode* optimizeBinaryOperatorArithmetic(AstNode*);
@@ -493,7 +493,7 @@ class Ast {
 
   /// @brief optimizes a call to a built-in function
   AstNode* optimizeFunctionCall(transaction::Methods&,
-                                RegexCache&, AstNode*);
+                                AqlFunctionsInternalCache&, AstNode*);
 
   /// @brief optimizes a reference to a variable
   AstNode* optimizeReference(AstNode*);

--- a/arangod/Aql/CalculationExecutor.cpp
+++ b/arangod/Aql/CalculationExecutor.cpp
@@ -169,7 +169,7 @@ template <>
 void CalculationExecutor<CalculationType::Condition>::doEvaluation(InputAqlItemRow& input,
                                                                    OutputAqlItemRow& output) {
   // execute the expression
-  ExecutorExpressionContext ctx(_trx, _infos.getQuery(), _regexCache, input,
+  ExecutorExpressionContext ctx(_trx, _infos.getQuery(), _aqlFunctionsInternalCache, input,
                                 _infos.getExpInVars(), _infos.getExpInRegs());
 
   bool mustDestroy;  // will get filled by execution
@@ -202,7 +202,7 @@ void CalculationExecutor<CalculationType::V8Condition>::doEvaluation(InputAqlIte
   ISOLATE;
   v8::HandleScope scope(isolate);  // do not delete this!
   // execute the expression
-  ExecutorExpressionContext ctx(_trx, _infos.getQuery(), _regexCache, input,
+  ExecutorExpressionContext ctx(_trx, _infos.getQuery(), _aqlFunctionsInternalCache, input,
                                 _infos.getExpInVars(), _infos.getExpInRegs());
 
   bool mustDestroy;  // will get filled by execution

--- a/arangod/Aql/CalculationExecutor.h
+++ b/arangod/Aql/CalculationExecutor.h
@@ -123,7 +123,7 @@ class CalculationExecutor {
 
  private:
   transaction::Methods _trx;
-  aql::AqlFunctionsInternalCache _regexCache;
+  aql::AqlFunctionsInternalCache _aqlFunctionsInternalCache;
   CalculationExecutorInfos& _infos;
 
   Fetcher& _fetcher;

--- a/arangod/Aql/CalculationExecutor.h
+++ b/arangod/Aql/CalculationExecutor.h
@@ -25,7 +25,7 @@
 
 #include "Aql/ExecutionState.h"
 #include "Aql/InputAqlItemRow.h"
-#include "Aql/RegexCache.h"
+#include "Aql/AqlFunctionsInternalCache.h"
 #include "Aql/RegisterInfos.h"
 #include "Aql/SharedAqlItemBlockPtr.h"
 #include "Aql/Stats.h"
@@ -123,7 +123,7 @@ class CalculationExecutor {
 
  private:
   transaction::Methods _trx;
-  aql::RegexCache _regexCache;
+  aql::AqlFunctionsInternalCache _regexCache;
   CalculationExecutorInfos& _infos;
 
   Fetcher& _fetcher;

--- a/arangod/Aql/DocumentExpressionContext.cpp
+++ b/arangod/Aql/DocumentExpressionContext.cpp
@@ -29,7 +29,7 @@ using namespace arangodb::aql;
 
 DocumentExpressionContext::DocumentExpressionContext(arangodb::transaction::Methods& trx,
                                                      QueryContext& query,
-                                                     RegexCache& cache,
+                                                     AqlFunctionsInternalCache& cache,
                                                      arangodb::velocypack::Slice document)
     : QueryExpressionContext(trx, query, cache), _document(document) {}
 

--- a/arangod/Aql/DocumentExpressionContext.h
+++ b/arangod/Aql/DocumentExpressionContext.h
@@ -34,7 +34,7 @@ namespace aql {
 class DocumentExpressionContext final : public QueryExpressionContext {
  public:
   DocumentExpressionContext(transaction::Methods& trx, QueryContext& query,
-                            RegexCache& cache, arangodb::velocypack::Slice document);
+                            AqlFunctionsInternalCache& cache, arangodb::velocypack::Slice document);
 
   ~DocumentExpressionContext() = default;
 

--- a/arangod/Aql/DocumentIndexExpressionContext.cpp
+++ b/arangod/Aql/DocumentIndexExpressionContext.cpp
@@ -28,7 +28,7 @@ using namespace arangodb::aql;
 DocumentIndexExpressionContext::DocumentIndexExpressionContext(
     arangodb::transaction::Methods& trx,
     QueryContext& query,
-    RegexCache& cache, AqlValue (*getValue)(void const* ctx, Variable const* var, bool doCopy),
+    AqlFunctionsInternalCache& cache, AqlValue (*getValue)(void const* ctx, Variable const* var, bool doCopy),
     void const* ctx)
   : QueryExpressionContext(trx, query, cache), _getValue(getValue), _ctx(ctx) {}
 

--- a/arangod/Aql/DocumentIndexExpressionContext.h
+++ b/arangod/Aql/DocumentIndexExpressionContext.h
@@ -33,7 +33,7 @@ class DocumentIndexExpressionContext final : public QueryExpressionContext {
  public:
   DocumentIndexExpressionContext(transaction::Methods& trx,
                                  QueryContext& query,
-                                 RegexCache& cache,
+                                 AqlFunctionsInternalCache& cache,
                                  AqlValue (*getValue)(void const* ctx, Variable const* var, bool doCopy),
                                  void const* ctx);
 

--- a/arangod/Aql/DocumentProducingHelper.cpp
+++ b/arangod/Aql/DocumentProducingHelper.cpp
@@ -318,14 +318,14 @@ bool DocumentProducingFunctionContext::checkUniqueness(LocalDocumentId const& to
 }
 
 bool DocumentProducingFunctionContext::checkFilter(velocypack::Slice slice) {
-  DocumentExpressionContext ctx(_trx, _query, _regexCache, slice);
+  DocumentExpressionContext ctx(_trx, _query, _aqlFunctionsInternalCache, slice);
   return checkFilter(ctx);
 }
 
 bool DocumentProducingFunctionContext::checkFilter(
     AqlValue (*getValue)(void const* ctx, Variable const* var, bool doCopy),
     void const* filterContext) {
-  DocumentIndexExpressionContext ctx(_trx, _query, _regexCache, getValue, filterContext);
+  DocumentIndexExpressionContext ctx(_trx, _query, _aqlFunctionsInternalCache, getValue, filterContext);
   return checkFilter(ctx);
 }
 

--- a/arangod/Aql/DocumentProducingHelper.h
+++ b/arangod/Aql/DocumentProducingHelper.h
@@ -117,7 +117,7 @@ struct DocumentProducingFunctionContext {
   
   bool hasFilter() const noexcept;
   
-  aql::AqlFunctionsInternalCache& regexCache() { return _aqlFunctionsInternalCache; }
+  aql::AqlFunctionsInternalCache& aqlFunctionsInternalCache() { return _aqlFunctionsInternalCache; }
 
  private:
   aql::AqlFunctionsInternalCache _aqlFunctionsInternalCache;

--- a/arangod/Aql/DocumentProducingHelper.h
+++ b/arangod/Aql/DocumentProducingHelper.h
@@ -117,10 +117,10 @@ struct DocumentProducingFunctionContext {
   
   bool hasFilter() const noexcept;
   
-  aql::AqlFunctionsInternalCache& regexCache() { return _regexCache; }
+  aql::AqlFunctionsInternalCache& regexCache() { return _aqlFunctionsInternalCache; }
 
  private:
-  aql::AqlFunctionsInternalCache _regexCache;
+  aql::AqlFunctionsInternalCache _aqlFunctionsInternalCache;
 
   bool checkFilter(ExpressionContext& ctx);
 

--- a/arangod/Aql/DocumentProducingHelper.h
+++ b/arangod/Aql/DocumentProducingHelper.h
@@ -25,7 +25,7 @@
 #define ARANGOD_AQL_DOCUMENT_PRODUCING_HELPER_H 1
 
 #include "Aql/types.h"
-#include "Aql/RegexCache.h"
+#include "Aql/AqlFunctionsInternalCache.h"
 #include "Indexes/IndexIterator.h"
 #include "VocBase/voc-types.h"
 
@@ -117,10 +117,10 @@ struct DocumentProducingFunctionContext {
   
   bool hasFilter() const noexcept;
   
-  aql::RegexCache& regexCache() { return _regexCache; }
+  aql::AqlFunctionsInternalCache& regexCache() { return _regexCache; }
 
  private:
-  aql::RegexCache _regexCache;
+  aql::AqlFunctionsInternalCache _regexCache;
 
   bool checkFilter(ExpressionContext& ctx);
 

--- a/arangod/Aql/ExecutorExpressionContext.cpp
+++ b/arangod/Aql/ExecutorExpressionContext.cpp
@@ -57,7 +57,7 @@ AqlValue ExecutorExpressionContext::getVariableValue(Variable const* variable, b
 
 ExecutorExpressionContext::ExecutorExpressionContext(arangodb::transaction::Methods& trx,
                                                      QueryContext& context,
-                                                     RegexCache& cache,
+                                                     AqlFunctionsInternalCache& cache,
                                                      InputAqlItemRow const& inputRow,
                                                      std::vector<Variable const*> const& vars,
                                                      std::vector<RegisterId> const& regs)

--- a/arangod/Aql/ExecutorExpressionContext.h
+++ b/arangod/Aql/ExecutorExpressionContext.h
@@ -40,7 +40,7 @@ class ExecutorExpressionContext final : public QueryExpressionContext {
  public:
   ExecutorExpressionContext(transaction::Methods& trx,
                             QueryContext& context,
-                            RegexCache& cache, InputAqlItemRow const& inputRow,
+                            AqlFunctionsInternalCache& cache, InputAqlItemRow const& inputRow,
                             std::vector<Variable const*> const& vars,
                             std::vector<RegisterId> const& regs);
 

--- a/arangod/Aql/ExpressionContext.h
+++ b/arangod/Aql/ExpressionContext.h
@@ -29,12 +29,14 @@
 struct TRI_vocbase_t;
 
 namespace arangodb {
+class ValidatorBase;
 namespace transaction {
 class BufferCache ;
 class Methods;
 }
 namespace velocypack {
 struct Options;
+struct Slice;
 }
 
 namespace aql {
@@ -64,6 +66,7 @@ class ExpressionContext {
   virtual icu::RegexMatcher* buildSplitMatcher(AqlValue splitExpression,
                                                velocypack::Options const* opts,
                                                bool& isEmptyExpression) = 0;
+  virtual arangodb::ValidatorBase* buildValidator(arangodb::velocypack::Slice const&) = 0;
 
   virtual TRI_vocbase_t& vocbase() const = 0;
   virtual transaction::Methods& trx() const = 0;

--- a/arangod/Aql/ExpressionContext.h
+++ b/arangod/Aql/ExpressionContext.h
@@ -29,14 +29,14 @@
 struct TRI_vocbase_t;
 
 namespace arangodb {
-class ValidatorBase;
+struct ValidatorBase;
 namespace transaction {
 class BufferCache ;
 class Methods;
 }
 namespace velocypack {
 struct Options;
-struct Slice;
+class Slice;
 }
 
 namespace aql {
@@ -58,7 +58,7 @@ class ExpressionContext {
 
   virtual void registerWarning(int errorCode, char const* msg) = 0;
   virtual void registerError(int errorCode, char const* msg) = 0;
-  
+
   virtual icu::RegexMatcher* buildRegexMatcher(char const* ptr, size_t length,
                                                bool caseInsensitive) = 0;
   virtual icu::RegexMatcher* buildLikeMatcher(char const* ptr, size_t length,

--- a/arangod/Aql/FixedVarExpressionContext.cpp
+++ b/arangod/Aql/FixedVarExpressionContext.cpp
@@ -69,5 +69,5 @@ void FixedVarExpressionContext::serializeAllVariables(velocypack::Options const&
 
 FixedVarExpressionContext::FixedVarExpressionContext(transaction::Methods& trx,
                                                      QueryContext& context,
-                                                     RegexCache& cache)
+                                                     AqlFunctionsInternalCache& cache)
     : QueryExpressionContext(trx, context, cache) {}

--- a/arangod/Aql/FixedVarExpressionContext.h
+++ b/arangod/Aql/FixedVarExpressionContext.h
@@ -41,7 +41,7 @@ class FixedVarExpressionContext final : public QueryExpressionContext {
  public:
   explicit FixedVarExpressionContext(transaction::Methods& trx,
                                      QueryContext& query,
-                                     RegexCache& cache);
+                                     AqlFunctionsInternalCache& cache);
 
   ~FixedVarExpressionContext() override = default;
 

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -7569,16 +7569,19 @@ AqlValue Functions::SchemaValidate(ExpressionContext* expressionContext,
   }
   auto* validator = expressionContext->buildValidator(schemaValue.slice());
 
-  //store and restore validatin level this is cheaper than modifying the vpack
-  auto storedLevel =  validator->level();
-  validator->setLevel(ValidationLevel::Strict); //override level so the validation will be executed no matter what
+  //store and restore validation level this is cheaper than modifying the VPack
+  auto storedLevel = validator->level();
+
+  //override level so the validation will be executed no matter what
+  validator->setLevel(ValidationLevel::Strict);
 
   Result res;
   {
     arangodb::ScopeGuard guardi([storedLevel, &validator]{
         validator->setLevel(storedLevel);
     });
-    auto res = validator->validateOne(docValue.slice(), vpackOptions);
+
+    res = validator->validateOne(docValue.slice(), vpackOptions);
   }
 
   transaction::BuilderLeaser resultBuilder(trx);

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -1705,7 +1705,7 @@ AqlValue Functions::NgramMatch(ExpressionContext* ctx, transaction::Methods* trx
     arangodb::aql::registerWarning(ctx, AFN, TRI_ERROR_INTERNAL);
     return arangodb::aql::AqlValue{arangodb::aql::AqlValueHintNull{}};
   }
-  auto analyzer = analyzerFeature.get(analyzerId, trx->vocbase(), *sysVocbase, 
+  auto analyzer = analyzerFeature.get(analyzerId, trx->vocbase(), *sysVocbase,
                                       trx->state()->analyzersRevision());
   if (!analyzer) {
     arangodb::aql::registerWarning(
@@ -3056,7 +3056,7 @@ AqlValue Functions::Split(ExpressionContext* expressionContext, transaction::Met
   Stringify(trx, adapter, aqlValueToSplit.slice());
   icu::UnicodeString valueToSplit(buffer->c_str(), static_cast<int32_t>(buffer->length()));
   bool isEmptyExpression = false;
-  
+
   // the matcher is owned by the context!
   icu::RegexMatcher* matcher =
       expressionContext->buildSplitMatcher(aqlSeparatorExpression,
@@ -7567,10 +7567,19 @@ AqlValue Functions::SchemaValidate(ExpressionContext* expressionContext,
         TRI_ERROR_BAD_PARAMETER, "second parameter is not a schema object: " +
                                      schemaValue.slice().toJson());
   }
+  auto* validator = expressionContext->buildValidator(schemaValue.slice());
 
-  arangodb::ValidatorJsonSchema validator(schemaValue.slice());
-  validator.setLevel(ValidationLevel::Strict); //override level so the validation will be executed no matter what
-  auto res = validator.validateOne(docValue.slice(), vpackOptions);
+  //store and restore validatin level this is cheaper than modifying the vpack
+  auto storedLevel =  validator->level();
+  validator->setLevel(ValidationLevel::Strict); //override level so the validation will be executed no matter what
+
+  Result res;
+  {
+    arangodb::ScopeGuard guardi([storedLevel, &validator]{
+        validator->setLevel(storedLevel);
+    });
+    auto res = validator->validateOne(docValue.slice(), vpackOptions);
+  }
 
   transaction::BuilderLeaser resultBuilder(trx);
   {

--- a/arangod/Aql/IResearchViewExecutor.cpp
+++ b/arangod/Aql/IResearchViewExecutor.cpp
@@ -396,7 +396,7 @@ IResearchViewExecutorBase<Impl, Traits>::IResearchViewExecutorBase(
       _infos(infos),
       _inputRow(CreateInvalidInputRowHint{}),  // TODO: Remove me after refactor
       _indexReadBuffer(_infos.getScoreRegisters().size()),
-      _ctx(_trx, infos.getQuery(), _regexCache,
+      _ctx(_trx, infos.getQuery(), _aqlFunctionsInternalCache,
            infos.outVariable(), infos.varInfoMap(), infos.getDepth()),
       _filterCtx(_ctx),  // arangodb::iresearch::ExpressionExecutionContext
       _reader(infos.getReader()),

--- a/arangod/Aql/IResearchViewExecutor.h
+++ b/arangod/Aql/IResearchViewExecutor.h
@@ -27,7 +27,7 @@
 #include "Aql/ExecutionState.h"
 #include "Aql/IResearchViewNode.h"
 #include "Aql/InputAqlItemRow.h"
-#include "Aql/RegexCache.h"
+#include "Aql/AqlFunctionsInternalCache.h"
 #include "Aql/RegisterInfos.h"
 #include "IResearch/ExpressionFilter.h"
 #include "IResearch/IResearchExpressionContext.h"
@@ -382,7 +382,7 @@ class IResearchViewExecutorBase {
 
  protected:
   transaction::Methods _trx;
-  RegexCache _regexCache;
+  AqlFunctionsInternalCache _regexCache;
   Infos& _infos;
   InputAqlItemRow _inputRow;
   IndexReadBuffer<typename Traits::IndexBufferValueType> _indexReadBuffer;

--- a/arangod/Aql/IResearchViewExecutor.h
+++ b/arangod/Aql/IResearchViewExecutor.h
@@ -382,7 +382,7 @@ class IResearchViewExecutorBase {
 
  protected:
   transaction::Methods _trx;
-  AqlFunctionsInternalCache _regexCache;
+  AqlFunctionsInternalCache _aqlFunctionsInternalCache;
   Infos& _infos;
   InputAqlItemRow _inputRow;
   IndexReadBuffer<typename Traits::IndexBufferValueType> _indexReadBuffer;

--- a/arangod/Aql/InAndOutRowExpressionContext.cpp
+++ b/arangod/Aql/InAndOutRowExpressionContext.cpp
@@ -43,7 +43,7 @@ static bool testInternalIdValid(size_t id, std::vector<RegisterId> const& regs) 
 InAndOutRowExpressionContext::InAndOutRowExpressionContext(
     transaction::Methods& trx,
     QueryContext& context,
-    RegexCache& cache,
+    AqlFunctionsInternalCache& cache,
     std::vector<Variable const*> vars,
     std::vector<RegisterId> regs, size_t vertexVarIdx,
     size_t edgeVarIdx, size_t pathVarIdx)

--- a/arangod/Aql/InAndOutRowExpressionContext.h
+++ b/arangod/Aql/InAndOutRowExpressionContext.h
@@ -43,7 +43,7 @@ class InAndOutRowExpressionContext final : public QueryExpressionContext {
  public:
   InAndOutRowExpressionContext(transaction::Methods& trx,
                                QueryContext& query,
-                               RegexCache& cache,
+                               AqlFunctionsInternalCache& cache,
                                std::vector<Variable const*> vars,
                                std::vector<RegisterId> regs, size_t vertexVarIdx,
                                size_t edgeVarIdx, size_t pathVarIdx);

--- a/arangod/Aql/IndexExecutor.cpp
+++ b/arangod/Aql/IndexExecutor.cpp
@@ -593,7 +593,7 @@ void IndexExecutor::executeExpressions(InputAqlItemRow& input) {
         _infos.getNonConstExpressions()[posInExpressions].get();
     auto exp = toReplace->expression.get();
 
-    auto& regex = _documentProducingFunctionContext.regexCache();
+    auto& regex = _documentProducingFunctionContext.aqlFunctionsInternalCache();
 
     ExecutorExpressionContext ctx(_trx, query, regex,
                                   input, _infos.getExpInVars(),

--- a/arangod/Aql/PruneExpressionEvaluator.cpp
+++ b/arangod/Aql/PruneExpressionEvaluator.cpp
@@ -32,7 +32,7 @@ using namespace arangodb::aql;
 PruneExpressionEvaluator::PruneExpressionEvaluator(
     transaction::Methods& trx,
     QueryContext& query,
-    RegexCache& cache,
+    AqlFunctionsInternalCache& cache,
     std::vector<Variable const*> vars, std::vector<RegisterId> regs,
     size_t vertexVarIdx, size_t edgeVarIdx, size_t pathVarIdx, Expression* expr)
     : _pruneExpression(expr),

--- a/arangod/Aql/PruneExpressionEvaluator.h
+++ b/arangod/Aql/PruneExpressionEvaluator.h
@@ -43,7 +43,7 @@ class PruneExpressionEvaluator {
  public:
   PruneExpressionEvaluator(transaction::Methods& trx,
                            QueryContext& query,
-                           RegexCache& cache,
+                           AqlFunctionsInternalCache& cache,
                            std::vector<Variable const*> vars,
                            std::vector<RegisterId> regs, size_t vertexVarIdx,
                            size_t edgeVarIdx, size_t pathVarIdx, Expression* expr);

--- a/arangod/Aql/QueryExpressionContext.cpp
+++ b/arangod/Aql/QueryExpressionContext.cpp
@@ -55,6 +55,10 @@ icu::RegexMatcher* QueryExpressionContext::buildSplitMatcher(AqlValue splitExpre
   return _regexCache.buildSplitMatcher(splitExpression, opts, isEmptyExpression);
 }
 
+arangodb::ValidatorBase* QueryExpressionContext::buildValidator(arangodb::velocypack::Slice const& params) {
+  return _regexCache.buildValidator(params);
+}
+
 TRI_vocbase_t& QueryExpressionContext::vocbase() const {
   return _trx.vocbase();
 }

--- a/arangod/Aql/QueryExpressionContext.cpp
+++ b/arangod/Aql/QueryExpressionContext.cpp
@@ -41,22 +41,22 @@ void QueryExpressionContext::registerError(int errorCode, char const* msg) {
 
 icu::RegexMatcher* QueryExpressionContext::buildRegexMatcher(char const* ptr, size_t length,
                                                              bool caseInsensitive) {
-  return _regexCache.buildRegexMatcher(ptr, length, caseInsensitive);
+  return _aqlFunctionsInternalCache.buildRegexMatcher(ptr, length, caseInsensitive);
 }
 
 icu::RegexMatcher* QueryExpressionContext::buildLikeMatcher(char const* ptr, size_t length,
                                                             bool caseInsensitive) {
-  return _regexCache.buildLikeMatcher(ptr, length, caseInsensitive);
+  return _aqlFunctionsInternalCache.buildLikeMatcher(ptr, length, caseInsensitive);
 }
 
 icu::RegexMatcher* QueryExpressionContext::buildSplitMatcher(AqlValue splitExpression,
                                                              velocypack::Options const* opts,
                                                              bool& isEmptyExpression) {
-  return _regexCache.buildSplitMatcher(splitExpression, opts, isEmptyExpression);
+  return _aqlFunctionsInternalCache.buildSplitMatcher(splitExpression, opts, isEmptyExpression);
 }
 
 arangodb::ValidatorBase* QueryExpressionContext::buildValidator(arangodb::velocypack::Slice const& params) {
-  return _regexCache.buildValidator(params);
+  return _aqlFunctionsInternalCache.buildValidator(params);
 }
 
 TRI_vocbase_t& QueryExpressionContext::vocbase() const {

--- a/arangod/Aql/QueryExpressionContext.cpp
+++ b/arangod/Aql/QueryExpressionContext.cpp
@@ -25,7 +25,7 @@
 
 #include "Aql/AqlValue.h"
 #include "Aql/QueryContext.h"
-#include "Aql/RegexCache.h"
+#include "Aql/AqlFunctionsInternalCache.h"
 #include "Transaction/Methods.h"
 
 using namespace arangodb;

--- a/arangod/Aql/QueryExpressionContext.h
+++ b/arangod/Aql/QueryExpressionContext.h
@@ -38,7 +38,7 @@ class QueryExpressionContext : public ExpressionContext {
                                   QueryContext& query,
                                   AqlFunctionsInternalCache& cache)
       : ExpressionContext(),
-        _trx(trx), _query(query), _regexCache(cache) {}
+        _trx(trx), _query(query), _aqlFunctionsInternalCache(cache) {}
 
   void registerWarning(int errorCode, char const* msg) override final;
   void registerError(int errorCode, char const* msg) override final;
@@ -60,7 +60,7 @@ class QueryExpressionContext : public ExpressionContext {
  private:
   transaction::Methods& _trx;
   QueryContext& _query;
-  AqlFunctionsInternalCache& _regexCache;
+  AqlFunctionsInternalCache& _aqlFunctionsInternalCache;
 };
 }  // namespace aql
 }  // namespace arangodb

--- a/arangod/Aql/QueryExpressionContext.h
+++ b/arangod/Aql/QueryExpressionContext.h
@@ -29,13 +29,13 @@
 namespace arangodb {
 namespace aql {
 class QueryContext;
-class RegexCache;
+class AqlFunctionsInternalCache;
 
 class QueryExpressionContext : public ExpressionContext {
  public:
   explicit QueryExpressionContext(transaction::Methods& trx,
                                   QueryContext& query,
-                                  RegexCache& cache)
+                                  AqlFunctionsInternalCache& cache)
       : ExpressionContext(),
         _trx(trx), _query(query), _regexCache(cache) {}
 
@@ -57,7 +57,7 @@ class QueryExpressionContext : public ExpressionContext {
  private:
   transaction::Methods& _trx;
   QueryContext& _query;
-  RegexCache& _regexCache;
+  AqlFunctionsInternalCache& _regexCache;
 };
 }  // namespace aql
 }  // namespace arangodb

--- a/arangod/Aql/QueryExpressionContext.h
+++ b/arangod/Aql/QueryExpressionContext.h
@@ -27,7 +27,7 @@
 #include "ExpressionContext.h"
 
 namespace arangodb {
-class ValidatorBase;
+struct ValidatorBase;
 namespace aql {
 class QueryContext;
 class AqlFunctionsInternalCache;
@@ -42,7 +42,7 @@ class QueryExpressionContext : public ExpressionContext {
 
   void registerWarning(int errorCode, char const* msg) override final;
   void registerError(int errorCode, char const* msg) override final;
-  
+
   icu::RegexMatcher* buildRegexMatcher(char const* ptr, size_t length,
                                        bool caseInsensitive) override final;
   icu::RegexMatcher* buildLikeMatcher(char const* ptr, size_t length,

--- a/arangod/Aql/QueryExpressionContext.h
+++ b/arangod/Aql/QueryExpressionContext.h
@@ -27,6 +27,7 @@
 #include "ExpressionContext.h"
 
 namespace arangodb {
+class ValidatorBase;
 namespace aql {
 class QueryContext;
 class AqlFunctionsInternalCache;
@@ -48,6 +49,8 @@ class QueryExpressionContext : public ExpressionContext {
                                       bool caseInsensitive) override final;
   icu::RegexMatcher* buildSplitMatcher(AqlValue splitExpression, velocypack::Options const* opts,
                                        bool& isEmptyExpression) override final;
+
+  arangodb::ValidatorBase* buildValidator(arangodb::velocypack::Slice const&) override final;
 
   TRI_vocbase_t& vocbase() const override final;
   /// may be inaccessible on some platforms

--- a/arangod/Aql/TraversalConditionFinder.cpp
+++ b/arangod/Aql/TraversalConditionFinder.cpp
@@ -757,7 +757,7 @@ bool TraversalConditionFinder::isTrueOnNull(AstNode* node, Variable const* pathV
   bool mustDestroy = false;
   Expression tmpExp(_plan->getAst(), node);
 
-  RegexCache rcache;
+  AqlFunctionsInternalCache rcache;
   FixedVarExpressionContext ctxt(_plan->getAst()->query().trxForOptimization(),
                                  _plan->getAst()->query(),
                                  rcache);

--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -340,7 +340,7 @@ set(LIB_ARANGO_AQL_SOURCES
   Aql/QueryWarnings.cpp
   Aql/Range.cpp
   Aql/RemoveModifier.cpp
-  Aql/RegexCache.cpp
+  Aql/AqlFunctionsInternalCache.cpp
   Aql/RegisterPlan.cpp
   Aql/RemoteExecutor.cpp
   Aql/RestAqlHandler.cpp

--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -50,34 +50,34 @@ find_package(IResearch REQUIRED)
 add_library(arango_iresearch
   STATIC
   IResearch/ApplicationServerHelper.h IResearch/ApplicationServerHelper.cpp
+  IResearch/AqlHelper.cpp IResearch/AqlHelper.h
   IResearch/Containers.cpp IResearch/Containers.h
+  IResearch/ExpressionFilter.cpp IResearch/ExpressionFilter.h
   IResearch/IResearchAnalyzerFeature.cpp IResearch/IResearchAnalyzerFeature.h
   IResearch/IResearchCommon.cpp IResearch/IResearchCommon.h
   IResearch/IResearchCompression.cpp IResearch/IResearchCompression.h
+  IResearch/IResearchDocument.cpp IResearch/IResearchDocument.h
+  IResearch/IResearchExpressionContext.cpp IResearch/IResearchExpressionContext.h
+  IResearch/IResearchFeature.cpp IResearch/IResearchFeature.h
+  IResearch/IResearchFilterFactory.cpp IResearch/IResearchFilterFactory.h
   IResearch/IResearchKludge.cpp IResearch/IResearchKludge.h
   IResearch/IResearchLink.cpp IResearch/IResearchLink.h
   IResearch/IResearchLinkCoordinator.cpp IResearch/IResearchLinkCoordinator.h
   IResearch/IResearchLinkHelper.cpp IResearch/IResearchLinkHelper.h
   IResearch/IResearchLinkMeta.cpp IResearch/IResearchLinkMeta.h
+  IResearch/IResearchOrderFactory.cpp IResearch/IResearchOrderFactory.h
+  IResearch/IResearchPDP.cpp IResearch/IResearchPDP.h
+  IResearch/IResearchPrimaryKeyFilter.cpp IResearch/IResearchPrimaryKeyFilter.h
   IResearch/IResearchRocksDBLink.cpp IResearch/IResearchRocksDBLink.h
   IResearch/IResearchRocksDBRecoveryHelper.cpp
   IResearch/IResearchRocksDBRecoveryHelper.h
-  IResearch/IResearchView.cpp IResearch/IResearchView.h
   IResearch/IResearchVPackComparer.cpp IResearch/IResearchVPackComparer.h
+  IResearch/IResearchView.cpp IResearch/IResearchView.h
+  IResearch/IResearchViewCoordinator.cpp IResearch/IResearchViewCoordinator.h
+  IResearch/IResearchViewMeta.cpp IResearch/IResearchViewMeta.h
   IResearch/IResearchViewSort.cpp IResearch/IResearchViewSort.h
   IResearch/IResearchViewStoredValues.cpp IResearch/IResearchViewStoredValues.h
-  IResearch/IResearchViewCoordinator.cpp IResearch/IResearchViewCoordinator.h
-  IResearch/IResearchExpressionContext.cpp IResearch/IResearchExpressionContext.h
-  IResearch/IResearchViewMeta.cpp IResearch/IResearchViewMeta.h
-  IResearch/IResearchFeature.cpp IResearch/IResearchFeature.h
-  IResearch/IResearchPDP.cpp IResearch/IResearchPDP.h
-  IResearch/IResearchDocument.cpp IResearch/IResearchDocument.h
-  IResearch/IResearchPrimaryKeyFilter.cpp IResearch/IResearchPrimaryKeyFilter.h
-  IResearch/IResearchFilterFactory.cpp IResearch/IResearchFilterFactory.h
-  IResearch/IResearchOrderFactory.cpp IResearch/IResearchOrderFactory.h
   IResearch/VelocyPackHelper.cpp IResearch/VelocyPackHelper.h
-  IResearch/ExpressionFilter.cpp IResearch/ExpressionFilter.h
-  IResearch/AqlHelper.cpp IResearch/AqlHelper.h
   RestHandler/RestAnalyzerHandler.cpp RestHandler/RestAnalyzerHandler.h
 )
 
@@ -225,6 +225,7 @@ set(LIB_ARANGO_AQL_SOURCES
   Aql/AqlCallStack.cpp
   Aql/AqlExecuteResult.cpp
   Aql/AqlFunctionFeature.cpp
+  Aql/AqlFunctionsInternalCache.cpp
   Aql/AqlItemBlock.cpp
   Aql/AqlItemBlockInputMatrix.cpp
   Aql/AqlItemBlockInputRange.cpp
@@ -280,7 +281,6 @@ set(LIB_ARANGO_AQL_SOURCES
   Aql/ExecutionState.cpp
   Aql/ExecutionStats.cpp
   Aql/ExecutorExpressionContext.cpp
-  Aql/RegisterInfos.cpp
   Aql/Expression.cpp
   Aql/FilterExecutor.cpp
   Aql/FixedVarExpressionContext.cpp
@@ -324,6 +324,7 @@ set(LIB_ARANGO_AQL_SOURCES
   Aql/OptimizerRulesReplaceFunctions.cpp
   Aql/OptimizerUtils.cpp
   Aql/OutputAqlItemRow.cpp
+  Aql/ParallelUnsortedGatherExecutor.cpp
   Aql/Parser.cpp
   Aql/Quantifier.cpp
   Aql/Query.cpp
@@ -339,10 +340,10 @@ set(LIB_ARANGO_AQL_SOURCES
   Aql/QueryString.cpp
   Aql/QueryWarnings.cpp
   Aql/Range.cpp
-  Aql/RemoveModifier.cpp
-  Aql/AqlFunctionsInternalCache.cpp
+  Aql/RegisterInfos.cpp
   Aql/RegisterPlan.cpp
   Aql/RemoteExecutor.cpp
+  Aql/RemoveModifier.cpp
   Aql/RestAqlHandler.cpp
   Aql/ReturnExecutor.cpp
   Aql/ScatterExecutor.cpp
@@ -365,23 +366,23 @@ set(LIB_ARANGO_AQL_SOURCES
   Aql/SortedCollectExecutor.cpp
   Aql/SortingGatherExecutor.cpp
   Aql/SubqueryEndExecutionNode.cpp
-  Aql/SubqueryExecutor.cpp
   Aql/SubqueryEndExecutor.cpp
+  Aql/SubqueryExecutor.cpp
   Aql/SubqueryStartExecutionNode.cpp
   Aql/SubqueryStartExecutor.cpp
   Aql/TraversalConditionFinder.cpp
   Aql/TraversalExecutor.cpp
   Aql/TraversalNode.cpp
-  Aql/ParallelUnsortedGatherExecutor.cpp
   Aql/UnsortedGatherExecutor.cpp
   Aql/UpdateReplaceModifier.cpp
   Aql/UpsertModifier.cpp
   Aql/V8Executor.cpp
+  Aql/VarUsageFinder.cpp
   Aql/Variable.cpp
   Aql/VariableGenerator.cpp
   Aql/grammar.cpp
   Aql/tokens.cpp
-        Aql/VarUsageFinder.cpp)
+)
 
 set(LIB_ARANGO_VOCBASE_SOURCES
   Aql/PlanCache.cpp
@@ -394,6 +395,11 @@ set(LIB_ARANGO_VOCBASE_SOURCES
   VocBase/Identifiers/IndexId.cpp
   VocBase/Identifiers/LocalDocumentId.cpp
   VocBase/Identifiers/ServerId.cpp
+  VocBase/KeyGenerator.cpp
+  VocBase/LogicalCollection.cpp
+  VocBase/LogicalDataSource.cpp
+  VocBase/LogicalView.cpp
+  VocBase/ManagedDocumentResult.cpp
   VocBase/Methods/AqlUserFunctions.cpp
   VocBase/Methods/Collections.cpp
   VocBase/Methods/Databases.cpp
@@ -405,15 +411,10 @@ set(LIB_ARANGO_VOCBASE_SOURCES
   VocBase/Methods/Upgrade.cpp
   VocBase/Methods/UpgradeTasks.cpp
   VocBase/Methods/Version.cpp
-  VocBase/KeyGenerator.cpp
-  VocBase/LogicalCollection.cpp
-  VocBase/LogicalDataSource.cpp
-  VocBase/LogicalView.cpp
-  VocBase/ManagedDocumentResult.cpp
-  VocBase/ticks.cpp
   VocBase/Validators.cpp
-  VocBase/vocbase.cpp
   VocBase/VocbaseInfo.cpp
+  VocBase/ticks.cpp
+  VocBase/vocbase.cpp
 )
 
 set(LIB_ARANGO_UTILS_SOURCES
@@ -505,7 +506,6 @@ set(LIB_ARANGO_AGENCY_SOURCES
   Agency/CleanOutServer.cpp
   Agency/Compactor.cpp
   Agency/Constituent.cpp
-  Agency/ResignLeadership.cpp
   Agency/FailedFollower.cpp
   Agency/FailedLeader.cpp
   Agency/FailedServer.cpp
@@ -515,6 +515,7 @@ set(LIB_ARANGO_AGENCY_SOURCES
   Agency/MoveShard.cpp
   Agency/Node.cpp
   Agency/RemoveFollower.cpp
+  Agency/ResignLeadership.cpp
   Agency/RestAgencyHandler.cpp
   Agency/RestAgencyPrivHandler.cpp
   Agency/State.cpp
@@ -577,9 +578,9 @@ set(LIB_ARANGOSERVER_SOURCES
   Cluster/ClusterInfo.cpp
   Cluster/ClusterRepairDistributeShardsLike.cpp
   Cluster/ClusterRepairOperations.cpp
-  Cluster/ClusterUpgradeFeature.cpp
   Cluster/ClusterTrxMethods.cpp
   Cluster/ClusterTypes.cpp
+  Cluster/ClusterUpgradeFeature.cpp
   Cluster/CreateCollection.cpp
   Cluster/CreateDatabase.cpp
   Cluster/CriticalThread.cpp

--- a/arangod/Graph/BaseOptions.cpp
+++ b/arangod/Graph/BaseOptions.cpp
@@ -175,7 +175,7 @@ std::unique_ptr<BaseOptions> BaseOptions::createOptionsFromSlice(arangodb::aql::
 
 BaseOptions::BaseOptions(arangodb::aql::QueryContext& query)
     : _trx(query.newTrxContext()),
-      _expressionCtx(_trx, query, _regexCache),
+      _expressionCtx(_trx, query, _aqlFunctionsInternalCache),
       _query(query),
       _tmpVar(nullptr),
       _parallelism(1),
@@ -184,7 +184,7 @@ BaseOptions::BaseOptions(arangodb::aql::QueryContext& query)
 
 BaseOptions::BaseOptions(BaseOptions const& other, bool allowAlreadyBuiltCopy)
     : _trx(other._query.newTrxContext()),
-      _expressionCtx(_trx, other._query, _regexCache),
+      _expressionCtx(_trx, other._query, _aqlFunctionsInternalCache),
       _query(other._query),
       _tmpVar(nullptr),
       _collectionToShard(other._collectionToShard),

--- a/arangod/Graph/BaseOptions.h
+++ b/arangod/Graph/BaseOptions.h
@@ -158,7 +158,7 @@ struct BaseOptions {
 
   std::map<std::string, std::string> const& collectionToShard() const { return _collectionToShard; }
   
-  aql::AqlFunctionsInternalCache& regexCache() { return _aqlFunctionsInternalCache; }
+  aql::AqlFunctionsInternalCache& aqlFunctionsInternalCache() { return _aqlFunctionsInternalCache; }
 
   virtual auto estimateDepth() const noexcept -> uint64_t = 0;
   

--- a/arangod/Graph/BaseOptions.h
+++ b/arangod/Graph/BaseOptions.h
@@ -25,7 +25,7 @@
 #define ARANGOD_GRAPH_BASE_OPTIONS_H 1
 
 #include "Aql/FixedVarExpressionContext.h"
-#include "Aql/RegexCache.h"
+#include "Aql/AqlFunctionsInternalCache.h"
 #include "Basics/Common.h"
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
@@ -158,7 +158,7 @@ struct BaseOptions {
 
   std::map<std::string, std::string> const& collectionToShard() const { return _collectionToShard; }
   
-  aql::RegexCache& regexCache() { return _regexCache; }
+  aql::AqlFunctionsInternalCache& regexCache() { return _regexCache; }
 
   virtual auto estimateDepth() const noexcept -> uint64_t = 0;
   
@@ -189,7 +189,7 @@ struct BaseOptions {
  protected:
   
   mutable arangodb::transaction::Methods _trx;
-  arangodb::aql::RegexCache _regexCache; // needed for expression evaluation
+  arangodb::aql::AqlFunctionsInternalCache _regexCache; // needed for expression evaluation
   arangodb::aql::FixedVarExpressionContext _expressionCtx;
 
   /// @brief Lookup info to find all edges fulfilling the base conditions

--- a/arangod/Graph/BaseOptions.h
+++ b/arangod/Graph/BaseOptions.h
@@ -158,7 +158,7 @@ struct BaseOptions {
 
   std::map<std::string, std::string> const& collectionToShard() const { return _collectionToShard; }
   
-  aql::AqlFunctionsInternalCache& regexCache() { return _regexCache; }
+  aql::AqlFunctionsInternalCache& regexCache() { return _aqlFunctionsInternalCache; }
 
   virtual auto estimateDepth() const noexcept -> uint64_t = 0;
   
@@ -189,7 +189,7 @@ struct BaseOptions {
  protected:
   
   mutable arangodb::transaction::Methods _trx;
-  arangodb::aql::AqlFunctionsInternalCache _regexCache; // needed for expression evaluation
+  arangodb::aql::AqlFunctionsInternalCache _aqlFunctionsInternalCache; // needed for expression evaluation
   arangodb::aql::FixedVarExpressionContext _expressionCtx;
 
   /// @brief Lookup info to find all edges fulfilling the base conditions

--- a/arangod/Graph/TraverserOptions.cpp
+++ b/arangod/Graph/TraverserOptions.cpp
@@ -733,7 +733,7 @@ void TraverserOptions::activatePrune(std::vector<aql::Variable const*> vars,
                                      size_t vertexVarIdx, size_t edgeVarIdx,
                                      size_t pathVarIdx, aql::Expression* expr) {
   _pruneExpression =
-      std::make_unique<aql::PruneExpressionEvaluator>(_trx, _query, _regexCache,
+      std::make_unique<aql::PruneExpressionEvaluator>(_trx, _query, _aqlFunctionsInternalCache,
                                                       std::move(vars),
                                                       std::move(regs), vertexVarIdx,
                                                       edgeVarIdx, pathVarIdx, expr);

--- a/arangod/IResearch/IResearchExpressionContext.cpp
+++ b/arangod/IResearch/IResearchExpressionContext.cpp
@@ -24,7 +24,7 @@
 #include "IResearchExpressionContext.h"
 
 #include "Aql/AqlItemBlock.h"
-#include "Aql/RegexCache.h"
+#include "Aql/AqlFunctionsInternalCache.h"
 #include "Aql/QueryContext.h"
 #include "Aql/IResearchViewNode.h"
 #include "Basics/StaticStrings.h"

--- a/arangod/IResearch/IResearchExpressionContext.cpp
+++ b/arangod/IResearch/IResearchExpressionContext.cpp
@@ -50,22 +50,22 @@ void ViewExpressionContextBase::registerError(int errorCode, char const* msg) {
 
 icu::RegexMatcher* ViewExpressionContextBase::buildRegexMatcher(char const* ptr, size_t length,
                                                              bool caseInsensitive) {
-  return _regexCache->buildRegexMatcher(ptr, length, caseInsensitive);
+  return _aqlFunctionsInternalCache->buildRegexMatcher(ptr, length, caseInsensitive);
 }
 
 icu::RegexMatcher* ViewExpressionContextBase::buildLikeMatcher(char const* ptr, size_t length,
                                                             bool caseInsensitive) {
-  return _regexCache->buildLikeMatcher(ptr, length, caseInsensitive);
+  return _aqlFunctionsInternalCache->buildLikeMatcher(ptr, length, caseInsensitive);
 }
 
 icu::RegexMatcher* ViewExpressionContextBase::buildSplitMatcher(AqlValue splitExpression,
                                                              velocypack::Options const* opts,
                                                              bool& isEmptyExpression) {
-  return _regexCache->buildSplitMatcher(splitExpression, opts, isEmptyExpression);
+  return _aqlFunctionsInternalCache->buildSplitMatcher(splitExpression, opts, isEmptyExpression);
 }
 
 arangodb::ValidatorBase* ViewExpressionContextBase::buildValidator(arangodb::velocypack::Slice const& params) {
-  return _regexCache->buildValidator(params);
+  return _aqlFunctionsInternalCache->buildValidator(params);
 }
 
 TRI_vocbase_t& ViewExpressionContextBase::vocbase() const {

--- a/arangod/IResearch/IResearchExpressionContext.cpp
+++ b/arangod/IResearch/IResearchExpressionContext.cpp
@@ -64,6 +64,10 @@ icu::RegexMatcher* ViewExpressionContextBase::buildSplitMatcher(AqlValue splitEx
   return _regexCache->buildSplitMatcher(splitExpression, opts, isEmptyExpression);
 }
 
+arangodb::ValidatorBase* ViewExpressionContextBase::buildValidator(arangodb::velocypack::Slice const& params) {
+  return _regexCache->buildValidator(params);
+}
+
 TRI_vocbase_t& ViewExpressionContextBase::vocbase() const {
   return _trx->vocbase();
 }

--- a/arangod/IResearch/IResearchExpressionContext.h
+++ b/arangod/IResearch/IResearchExpressionContext.h
@@ -37,7 +37,7 @@ class AqlItemBlock;
 struct AstNode;
 class ExecutionEngine;
 class QueryContext;
-class RegexCache;
+class AqlFunctionsInternalCache;
 }  // namespace aql
 
 namespace iresearch {
@@ -53,7 +53,7 @@ class IResearchViewNode;
 struct ViewExpressionContextBase : public arangodb::aql::ExpressionContext {
   explicit ViewExpressionContextBase(arangodb::transaction::Methods* trx,
                                      aql::QueryContext* query,
-                                     aql::RegexCache* cache)
+                                     aql::AqlFunctionsInternalCache* cache)
   : ExpressionContext(), _trx(trx), _query(query), _regexCache(cache)  {}
   
   void registerWarning(int errorCode, char const* msg) override final;
@@ -76,7 +76,7 @@ struct ViewExpressionContextBase : public arangodb::aql::ExpressionContext {
 protected:
   arangodb::transaction::Methods* _trx;
   arangodb::aql::QueryContext* _query;
-  arangodb::aql::RegexCache* _regexCache;
+  arangodb::aql::AqlFunctionsInternalCache* _regexCache;
 };                              // ViewExpressionContextBase
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -87,7 +87,7 @@ struct ViewExpressionContext final : public ViewExpressionContextBase {
 
   ViewExpressionContext(arangodb::transaction::Methods& trx,
                         aql::QueryContext& query,
-                        aql::RegexCache& cache, aql::Variable const& outVar,
+                        aql::AqlFunctionsInternalCache& cache, aql::Variable const& outVar,
                         VarInfoMap const& varInfoMap, int nodeDepth)
       : ViewExpressionContextBase(&trx, &query, &cache),
         _outVar(outVar),

--- a/arangod/IResearch/IResearchExpressionContext.h
+++ b/arangod/IResearch/IResearchExpressionContext.h
@@ -54,7 +54,7 @@ struct ViewExpressionContextBase : public arangodb::aql::ExpressionContext {
   explicit ViewExpressionContextBase(arangodb::transaction::Methods* trx,
                                      aql::QueryContext* query,
                                      aql::AqlFunctionsInternalCache* cache)
-  : ExpressionContext(), _trx(trx), _query(query), _regexCache(cache)  {}
+  : ExpressionContext(), _trx(trx), _query(query), _aqlFunctionsInternalCache(cache)  {}
   
   void registerWarning(int errorCode, char const* msg) override final;
   void registerError(int errorCode, char const* msg) override final;
@@ -78,7 +78,7 @@ struct ViewExpressionContextBase : public arangodb::aql::ExpressionContext {
 protected:
   arangodb::transaction::Methods* _trx;
   arangodb::aql::QueryContext* _query;
-  arangodb::aql::AqlFunctionsInternalCache* _regexCache;
+  arangodb::aql::AqlFunctionsInternalCache* _aqlFunctionsInternalCache;
 };                              // ViewExpressionContextBase
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/arangod/IResearch/IResearchExpressionContext.h
+++ b/arangod/IResearch/IResearchExpressionContext.h
@@ -66,6 +66,8 @@ struct ViewExpressionContextBase : public arangodb::aql::ExpressionContext {
   icu::RegexMatcher* buildSplitMatcher(aql::AqlValue splitExpression, velocypack::Options const* opts,
                                        bool& isEmptyExpression) override final;
 
+  arangodb::ValidatorBase* buildValidator(arangodb::velocypack::Slice const&) override final;
+
   TRI_vocbase_t& vocbase() const override final;
   /// may be inaccessible on some platforms
   transaction::Methods& trx() const override final;

--- a/arangod/VocBase/Validators.h
+++ b/arangod/VocBase/Validators.h
@@ -65,6 +65,7 @@ struct ValidatorBase {
   std::string const& message() const { return this->_message; }
   std::string const& specialProperties() const;
   void setLevel(ValidationLevel level) { _level = level; }
+  ValidationLevel level() { return _level; }
 
  protected:
   virtual void toVelocyPackDerived(VPackBuilder&) const = 0;

--- a/tests/IResearch/ExpressionContextMock.h
+++ b/tests/IResearch/ExpressionContextMock.h
@@ -25,7 +25,7 @@
 #define ARANGODB_IRESEARCH__IRESEARCH_EXPRESSION_CONTEXT 1
 
 #include "Aql/QueryContext.h"
-#include "Aql/RegexCache.h"
+#include "Aql/AqlFunctionsInternalCache.h"
 #include "IResearch/IResearchExpressionContext.h"
 #include "Transaction/Methods.h"
 
@@ -44,7 +44,7 @@ struct Variable; // forward decl
 struct ExpressionContextMock final : public arangodb::iresearch::ViewExpressionContextBase {
 
   static ExpressionContextMock EMPTY;
-  
+
   ExpressionContextMock() : ViewExpressionContextBase(nullptr, nullptr, nullptr) {}
 
   virtual ~ExpressionContextMock();
@@ -62,8 +62,8 @@ struct ExpressionContextMock final : public arangodb::iresearch::ViewExpressionC
   void setTrx(arangodb::transaction::Methods* trx) {
     this->_trx = trx;
   }
-  
-  arangodb::aql::RegexCache _regexCache;
+
+  arangodb::aql::AqlFunctionsInternalCache _regexCache;
   std::unordered_map<std::string, arangodb::aql::AqlValue> vars;
 }; // ExpressionContextMock
 


### PR DESCRIPTION
Withe the test-setup, that can be found in this ticket, a speedup of 400% was observed when validating all documents in a collection. 

- strictly new
- no documentation required
- covered by existing tests as the cache is always used.