### PR TITLE
make refcounts non-atomic again

### DIFF
--- a/arangod/Aql/AqlItemBlock.cpp
+++ b/arangod/Aql/AqlItemBlock.cpp
@@ -856,7 +856,7 @@ void AqlItemBlock::copySubQueryDepthFromOtherBlock(size_t const targetRow,
 }
 
 AqlItemBlock::~AqlItemBlock() {
-  TRI_ASSERT(_refCount.load(std::memory_order_relaxed) == 0);
+  TRI_ASSERT(_refCount == 0);
   destroy();
   decreaseMemoryUsage(sizeof(AqlValue) * _nrItems * internalNrRegs());
 }
@@ -1055,14 +1055,13 @@ AqlItemBlockManager& AqlItemBlock::aqlItemBlockManager() noexcept {
   return _manager;
 }
 
-size_t AqlItemBlock::getRefCount() const noexcept { return _refCount.load(std::memory_order_relaxed); }
+size_t AqlItemBlock::getRefCount() const noexcept { return _refCount; }
 
-void AqlItemBlock::incrRefCount() const noexcept { _refCount.fetch_add(1, std::memory_order_relaxed); }
+void AqlItemBlock::incrRefCount() const noexcept { ++_refCount; }
 
 size_t AqlItemBlock::decrRefCount() const noexcept {
-  size_t value = _refCount.fetch_sub(1, std::memory_order_release);
-  TRI_ASSERT(value > 0);
-  return value - 1;
+  TRI_ASSERT(_refCount > 0);
+  return --_refCount;
 }
 
 RegisterCount AqlItemBlock::internalNrRegs() const noexcept {

--- a/arangod/Aql/AqlItemBlock.h
+++ b/arangod/Aql/AqlItemBlock.h
@@ -27,7 +27,6 @@
 #include "Aql/AqlValue.h"
 #include "Aql/ResourceUsage.h"
 
-#include <atomic>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -327,7 +326,7 @@ class AqlItemBlock {
 
   /// @brief number of SharedAqlItemBlockPtr instances. shall be returned to
   /// the _manager when it reaches 0.
-  mutable std::atomic<size_t> _refCount = 0;
+  mutable size_t _refCount = 0;
 
   /// @brief A list of indexes with all shadowRows within
   /// this ItemBlock. Used to easier split data based on them.


### PR DESCRIPTION
### Scope & Purpose

Make AqlItemBlock's `_refCount` non-atomic again.
There should not be concurrent accesses of this variable, so making it atomic is a pessimization.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *shell_server_aql*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10067/