### PR TITLE
disallow encryption rotation APIs on coordinators

### DIFF
--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -386,6 +386,7 @@ void RocksDBEngine::prepare() {
 void RocksDBEngine::start() {
   // it is already decided that rocksdb is used
   TRI_ASSERT(isEnabled());
+  TRI_ASSERT(!ServerState::instance()->isCoordinator());
 
   if (ServerState::instance()->isAgent() &&
       !server().options()->processingResult().touched(

--- a/arangod/StorageEngine/EngineSelectorFeature.h
+++ b/arangod/StorageEngine/EngineSelectorFeature.h
@@ -54,6 +54,8 @@ class EngineSelectorFeature final : public application_features::ApplicationFeat
 
   static std::string const& defaultEngine();
 
+  /// @brief note that this will return true for the ClusterEngine too, in case
+  /// the underlying engine is the RocksDB engine.
   static bool isRocksDB();
 
   // selected storage engine. this will contain a pointer to the storage engine


### PR DESCRIPTION
### Scope & Purpose

Disallow usage of the encryption key rotation APIs on coordinators. Calling the APIs on a coordinator exposed undefined behavior, as the API works on the RocksDB storage engine's internals, which is not present on a coordinator.
Instead, now a nicer HTTP 403 error message is returned.

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/470

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10104/