### PR TITLE
Improve behaviour on dropping followers.

### DIFF
--- a/3rdParty/fuerte/src/H1Connection.cpp
+++ b/3rdParty/fuerte/src/H1Connection.cpp
@@ -140,7 +140,8 @@ H1Connection<ST>::H1Connection(EventLoopService& loop,
       _writeStart(),
       _lastHeaderWasValue(false),
       _shouldKeepAlive(false),
-      _messageComplete(false) {
+      _messageComplete(false),
+      _timeoutOnReadWrite(false) {
   // initialize http parsing code
   http_parser_settings_init(&_parserSettings);
   _parserSettings.on_message_begin = &on_message_begin;
@@ -424,6 +425,7 @@ void H1Connection<ST>::asyncWriteNextRequest() {
   _item.reset(ptr);
 
   setTimeout(_item->request->timeout(), TimeoutType::WRITE);
+  _timeoutOnReadWrite = false;
   _writeStart = std::chrono::steady_clock::now();
   _writing = true;
 
@@ -471,6 +473,9 @@ void H1Connection<ST>::asyncWriteCallback(asio_ns::error_code const& ec,
 
     // keepalive timeout may have expired
     auto err = translateError(ec, Error::WriteError);
+    if (this->_timeoutOnReadWrite && err == fuerte::Error::Canceled) {
+      err = fuerte::Error::Timeout;
+    }
     if (item) { // may be null if connection was canceled
       if (ec == asio_ns::error::broken_pipe && nwrite == 0) {  // re-queue
         // Note that this has the potential to change the order in which requests
@@ -507,6 +512,7 @@ void H1Connection<ST>::asyncWriteCallback(asio_ns::error_code const& ec,
   // Continue with a read, use the remaining part of the timeout as
   // timeout:
   setTimeout(_item->request->timeout() - timePassed, TimeoutType::READ);    // extend timeout
+  _timeoutOnReadWrite = false;
 
   _reading = true;
   this->asyncReadSome();  // listen for the response
@@ -530,7 +536,11 @@ void H1Connection<ST>::asyncReadCallback(asio_ns::error_code const& ec) {
     auto state = this->_state.load();
     if (state != Connection::State::Failed) {
       // Restart connection, will invoke _item cb
-      this->restartConnection(translateError(ec, Error::ReadError));
+      auto err = translateError(ec, Error::ReadError);
+      if (_timeoutOnReadWrite && err == fuerte::Error::Canceled) {
+        err = fuerte::Error::Timeout;
+      }
+      this->restartConnection(err);
     } else {
       drainQueue(Error::Canceled);
       abortOngoingRequests(Error::Canceled);
@@ -611,6 +621,7 @@ void H1Connection<ST>::setTimeout(std::chrono::milliseconds millis, TimeoutType 
             (type == TimeoutType::READ && me->_reading)) {
           FUERTE_LOG_DEBUG << "HTTP-Request timeout\n";
           me->_proto.cancel();
+          me->_timeoutOnReadWrite = true;
           // We simply cancel all ongoing asynchronous operations, the completion
           // handlers will do the rest.
           return;

--- a/3rdParty/fuerte/src/H1Connection.h
+++ b/3rdParty/fuerte/src/H1Connection.h
@@ -161,6 +161,7 @@ class H1Connection final : public fuerte::GeneralConnection<ST> {
   bool _lastHeaderWasValue = false;
   bool _shouldKeepAlive = false;
   bool _messageComplete = false;
+  bool _timeoutOnReadWrite = false;   // indicates that a timeout has happened
 };
 }}}}  // namespace arangodb::fuerte::v1::http
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 devel
 -----
 
-* Fixed bad behaviour when dropping followers. A follower should be dropped
+* Fixed bad behavior when dropping followers. A follower should be dropped
   immediately when it is officially FAILED, not only after a longish timeout.
 
 * Fixed a bug in CollectionNameResolver which could lead to an extended

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,15 @@
 devel
 -----
 
+* Fixed bad behaviour when dropping followers. A follower should be dropped
+  immediately when it is officially FAILED, not only after a longish timeout.
+
+* Fixed a bug in CollectionNameResolver which could lead to an extended
+  busy spin on a core when a collection was dropped, but documents of it
+  still remained in the WAL.
+
+* Fixed return value of fuerte::H1Connection in case of timeout.
+
 * Fixed traversal issue: If you have a traversal with different minDepth and maxDepth
   values and filter on path elements that are larger then minDepth, in a way that a
   shorter path would match the condition, the shorter paths would in some cases

--- a/arangod/Utils/CollectionNameResolver.cpp
+++ b/arangod/Utils/CollectionNameResolver.cpp
@@ -215,17 +215,18 @@ std::string CollectionNameResolver::getCollectionNameCluster(TRI_voc_cid_t cid) 
     }
   }
 
-  std::string name;
+  std::string name(::UNKNOWN);
 
   if (ServerState::isDBServer(_serverRole)) {
     // This might be a local system collection:
     name = lookupName(cid);
-    if (name == ::UNKNOWN) {
-      auto ci = _vocbase.server().getFeature<ClusterFeature>().clusterInfo().getCollectionNT(
-          _vocbase.name(), arangodb::basics::StringUtils::itoa(cid));
-      if (ci != nullptr) {
-        name = ci->name();
-      }
+  }
+
+  if (name == ::UNKNOWN) {
+    auto ci = _vocbase.server().getFeature<ClusterFeature>().clusterInfo().getCollectionNT(
+        _vocbase.name(), arangodb::basics::StringUtils::itoa(cid));
+    if (ci != nullptr) {
+      name = ci->name();
     }
   }
 
@@ -233,7 +234,7 @@ std::string CollectionNameResolver::getCollectionNameCluster(TRI_voc_cid_t cid) 
       << "CollectionNameResolver: was not able to resolve id " << cid;
   WRITE_LOCKER(locker, _lock);
   _resolvedIds.emplace(cid, name);
-  return ::UNKNOWN;
+  return name;
 }
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Do not retry requests to FAILED servers.
Cache _unknown result in CollectionNameResolver.
Return fuerte::Error::Timeout on timeout rather than Cancelled.

See https://arangodb.atlassian.net/browse/BTS-27

This is the `devel` version of the fix.