### PR TITLE
Fix unintentional attempt to serialize revision tree during collection upgrade

### DIFF
--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -366,6 +366,10 @@ std::unique_ptr<containers::RevisionTree> RocksDBMetaCollection::revisionTree(tr
   rocksdb::SequenceNumber safeSeq = meta().committableSeq(db->GetLatestSequenceNumber());
 
   std::unique_lock<std::mutex> guard(_revisionTreeLock);
+  if (!_revisionTree) {
+    return nullptr;
+  }
+
   applyUpdates(safeSeq);
 
   // now clone the tree so we can apply all updates consistent with our ongoing trx
@@ -409,6 +413,10 @@ std::unique_ptr<containers::RevisionTree> RocksDBMetaCollection::revisionTree(ui
   rocksdb::SequenceNumber safeSeq = meta().committableSeq(db->GetLatestSequenceNumber());
 
   std::unique_lock<std::mutex> guard(_revisionTreeLock);
+  if (!_revisionTree) {
+    return nullptr;
+  }
+
   applyUpdates(safeSeq);
 
   // now clone the tree so we can apply all updates consistent with our ongoing trx
@@ -501,6 +509,10 @@ rocksdb::SequenceNumber RocksDBMetaCollection::serializeRevisionTree(
     std::string& output, rocksdb::SequenceNumber commitSeq) {
   std::unique_lock<std::mutex> guard(_revisionTreeLock);
   if (_logicalCollection.useSyncByRevision()) {
+    if (!_revisionTree) {
+      // should only occur temporarily during upgrade, just return last number
+      return _revisionTreeSerializedSeq;
+    }
     applyUpdates(commitSeq);  // always apply updates...
     bool neverDone = _revisionTreeSerializedSeq == 0;
     bool coinFlip = RandomGenerator::interval(static_cast<uint32_t>(5)) == 0;
@@ -602,12 +614,13 @@ void RocksDBMetaCollection::revisionTreeSummary(VPackBuilder& builder) {
   if (!_logicalCollection.useSyncByRevision()) {
     return;
   }
-  TRI_ASSERT(_revisionTree);
 
   std::unique_lock<std::mutex> guard(_revisionTreeLock);
-  VPackObjectBuilder obj(&builder);
-  obj->add(StaticStrings::RevisionTreeCount, VPackValue(_revisionTree->count()));
-  obj->add(StaticStrings::RevisionTreeHash, VPackValue(_revisionTree->rootValue()));
+  if (_revisionTree) {
+    VPackObjectBuilder obj(&builder);
+    obj->add(StaticStrings::RevisionTreeCount, VPackValue(_revisionTree->count()));
+    obj->add(StaticStrings::RevisionTreeHash, VPackValue(_revisionTree->rootValue()));
+  }
 }
 
 void RocksDBMetaCollection::placeRevisionTreeBlocker(TRI_voc_tid_t transactionId) {


### PR DESCRIPTION
### Scope & Purpose

Prevent an unintentional attempt to serialize a revision tree before it is constructed during an intermediate step in the collection upgrade process.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)

#### Related Information

*(Please reference tickets / specification etc )*

- [x] There is an internal planning ticket: https://arangodb.atlassian.net/browse/BTS-76

### Testing & Verification

Jenkins: https://jenkins.arangodb.biz/job/arangodb-matrix-pr/10165/ (blue except unrelated known failures)