### PR TITLE
Remove zombie HttpCommTasks

### DIFF
--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -315,6 +315,7 @@ void HttpCommTask<T>::checkVSTPrefix() {
                                                        std::move(me->_protocol),
                                                        fuerte::vst::VST1_0);
       me->_server.registerTask(std::move(commTask));
+      me->close(ec);
       return;  // vst 1.0
 
     } else if (std::equal(::vst11, ::vst11 + 11, bg, bg + 11)) {
@@ -323,6 +324,7 @@ void HttpCommTask<T>::checkVSTPrefix() {
                                                        std::move(me->_protocol),
                                                        fuerte::vst::VST1_1);
       me->_server.registerTask(std::move(commTask));
+      me->close(ec);
       return;  // vst 1.1
     }
 
@@ -360,6 +362,7 @@ void HttpCommTask<T>::processRequest() {
       auto task = std::make_shared<H2CommTask<T>>(this->_server, this->_connectionInfo,
                                                   std::move(this->_protocol));
       task->upgradeHttp1(std::move(_request));
+      this->close();
       return;
     }
   }


### PR DESCRIPTION
### Scope & Purpose

Currently, all incoming requests are treated as HTTP/1 requests initially, and an `HttpCommTask` is created. If this is actually an HTTP/2 or VST request, then a subsequent comm task is created and the old one is discarded. Previously, we did not actually close this old task, so we ended up with an ever-growing number of zombie tasks objects. It did not leave the actual connections open, as those were transferred to the new tasks; however, it is effectively a memory leak and leads to incorrect connection statistics reporting.

- [x] Bug-Fix for a *released version* (backports will happen after review)

#### Related Information

- [x] There is an internal planning ticket: https://arangodb.atlassian.net/browse/BTS-43
- [x] There is a *JIRA Ticket number* (In case a customer was affected / involved): ES-564

### Testing & Verification

Jenkins: https://jenkins.arangodb.biz/job/arangodb-matrix-pr/10167/ (blue except known unrelated failures)