### PR TITLE
Removed noexcept specifier on defaulted constructors etc.

### DIFF
--- a/arangod/Agency/TransactionBuilder.h
+++ b/arangod/Agency/TransactionBuilder.h
@@ -152,7 +152,7 @@ struct write_trx {
     _buffer.openObject();
     return std::move(_buffer);
   }
-  write_trx& operator=(write_trx&&) noexcept = default;
+  write_trx& operator=(write_trx&&) = default;
 
  private:
   friend T;

--- a/arangod/Aql/AqlValue.h
+++ b/arangod/Aql/AqlValue.h
@@ -220,10 +220,10 @@ struct AqlValue final {
   /// @brief AqlValues can be copied and moved as required
   /// memory management is not performed via AqlValue destructor but via
   /// explicit calls to destroy()
-  AqlValue(AqlValue const&) noexcept = default;
-  AqlValue& operator=(AqlValue const&) noexcept = default;
-  AqlValue(AqlValue&&) noexcept = default;
-  AqlValue& operator=(AqlValue&&) noexcept = default;
+  AqlValue(AqlValue const&) = default;
+  AqlValue& operator=(AqlValue const&) = default;
+  AqlValue(AqlValue&&) = default;
+  AqlValue& operator=(AqlValue&&) = default;
 
   ~AqlValue() = default;
 
@@ -375,6 +375,19 @@ struct AqlValue final {
   template <bool isManagedDoc>
   void setPointer(uint8_t const* pointer) noexcept;
 };
+
+// Check that the defaulted constructors, destructor and assignment
+// operators are all noexcept:
+// AqlValue(AqlValue&&)
+static_assert(noexcept(AqlValue(std::declval<AqlValue>())));
+// AqlValue(AqlValue const&)
+static_assert(noexcept(AqlValue(static_cast<AqlValue const&>(std::declval<AqlValue>()))));
+// AqlValue& operator=(AqlValue&&)
+static_assert(noexcept(std::declval<AqlValue>() = std::declval<AqlValue>()));
+// AqlValue& operator=(AqlValue const&)
+static_assert(noexcept(std::declval<AqlValue>() = static_cast<AqlValue const&>(std::declval<AqlValue>())));
+// ~AqlValue()
+static_assert(noexcept(std::declval<AqlValue>().~AqlValue()));
 
 class AqlValueGuard {
  public:

--- a/arangod/Aql/BlocksWithClients.h
+++ b/arangod/Aql/BlocksWithClients.h
@@ -55,7 +55,7 @@ class ClientsExecutorInfos {
  public:
   explicit ClientsExecutorInfos(std::vector<std::string> clientIds);
 
-  ClientsExecutorInfos(ClientsExecutorInfos&&) noexcept = default;
+  ClientsExecutorInfos(ClientsExecutorInfos&&) = default;
   ClientsExecutorInfos(ClientsExecutorInfos const&) = delete;
   ~ClientsExecutorInfos() = default;
 

--- a/arangod/Aql/KShortestPathsExecutor.h
+++ b/arangod/Aql/KShortestPathsExecutor.h
@@ -76,7 +76,7 @@ class KShortestPathsExecutorInfos {
 
   KShortestPathsExecutorInfos() = delete;
 
-  KShortestPathsExecutorInfos(KShortestPathsExecutorInfos&&) noexcept = default;
+  KShortestPathsExecutorInfos(KShortestPathsExecutorInfos&&) = default;
   KShortestPathsExecutorInfos(KShortestPathsExecutorInfos const&) = delete;
   ~KShortestPathsExecutorInfos() = default;
 

--- a/arangod/Aql/MaterializeExecutor.h
+++ b/arangod/Aql/MaterializeExecutor.h
@@ -55,7 +55,7 @@ class MaterializerExecutorInfos {
                             RegisterId outDocRegId, aql::QueryContext& query);
 
   MaterializerExecutorInfos() = delete;
-  MaterializerExecutorInfos(MaterializerExecutorInfos&&) noexcept = default;
+  MaterializerExecutorInfos(MaterializerExecutorInfos&&) = default;
   MaterializerExecutorInfos(MaterializerExecutorInfos const&) = delete;
   ~MaterializerExecutorInfos() = default;
 

--- a/arangod/Aql/ScatterExecutor.h
+++ b/arangod/Aql/ScatterExecutor.h
@@ -38,7 +38,7 @@ class ScatterNode;
 class ScatterExecutorInfos : public ClientsExecutorInfos {
  public:
   explicit ScatterExecutorInfos(std::vector<std::string> clientIds);
-  ScatterExecutorInfos(ScatterExecutorInfos&&) noexcept = default;
+  ScatterExecutorInfos(ScatterExecutorInfos&&) = default;
 };
 
 // The ScatterBlock is actually implemented by specializing ExecutionBlockImpl,

--- a/arangod/Aql/SortedCollectExecutor.h
+++ b/arangod/Aql/SortedCollectExecutor.h
@@ -61,7 +61,7 @@ class SortedCollectExecutorInfos {
                              velocypack::Options const*, bool count);
 
   SortedCollectExecutorInfos() = delete;
-  SortedCollectExecutorInfos(SortedCollectExecutorInfos&&) noexcept = default;
+  SortedCollectExecutorInfos(SortedCollectExecutorInfos&&) = default;
   SortedCollectExecutorInfos(SortedCollectExecutorInfos const&) = delete;
   ~SortedCollectExecutorInfos() = default;
 

--- a/arangod/Aql/SortingGatherExecutor.h
+++ b/arangod/Aql/SortingGatherExecutor.h
@@ -53,7 +53,7 @@ class SortingGatherExecutorInfos {
                              arangodb::aql::QueryContext& query, GatherNode::SortMode sortMode,
                              size_t limit, GatherNode::Parallelism p);
   SortingGatherExecutorInfos() = delete;
-  SortingGatherExecutorInfos(SortingGatherExecutorInfos&&) noexcept = default;
+  SortingGatherExecutorInfos(SortingGatherExecutorInfos&&) = default;
   SortingGatherExecutorInfos(SortingGatherExecutorInfos const&) = delete;
   ~SortingGatherExecutorInfos() = default;
 

--- a/arangod/Aql/SubqueryEndExecutor.h
+++ b/arangod/Aql/SubqueryEndExecutor.h
@@ -48,7 +48,7 @@ class SubqueryEndExecutorInfos {
                            RegisterId outReg, bool isModificationSubquery);
 
   SubqueryEndExecutorInfos() = delete;
-  SubqueryEndExecutorInfos(SubqueryEndExecutorInfos&&) noexcept = default;
+  SubqueryEndExecutorInfos(SubqueryEndExecutorInfos&&) = default;
   SubqueryEndExecutorInfos(SubqueryEndExecutorInfos const&) = delete;
   ~SubqueryEndExecutorInfos();
 

--- a/arangod/Aql/SubqueryExecutor.h
+++ b/arangod/Aql/SubqueryExecutor.h
@@ -44,7 +44,7 @@ class SubqueryExecutorInfos {
   SubqueryExecutorInfos(ExecutionBlock& subQuery, RegisterId outReg, bool subqueryIsConst);
 
   SubqueryExecutorInfos() = delete;
-  SubqueryExecutorInfos(SubqueryExecutorInfos&&) noexcept = default;
+  SubqueryExecutorInfos(SubqueryExecutorInfos&&) = default;
   SubqueryExecutorInfos(SubqueryExecutorInfos const&) = delete;
   ~SubqueryExecutorInfos() = default;
 

--- a/lib/Containers/Enumerate.h
+++ b/lib/Containers/Enumerate.h
@@ -56,12 +56,12 @@ struct enumerate_iterator {
 
   explicit enumerate_iterator(T iter, C c = C()) : _iter(iter), _c(c) {}
   enumerate_iterator(enumerate_iterator const&) = default;
-  enumerate_iterator(enumerate_iterator&&) noexcept = default;
+  enumerate_iterator(enumerate_iterator&&) = default;
 
   enumerate_iterator& operator=(enumerate_iterator const&) = default;
-  enumerate_iterator& operator=(enumerate_iterator&&) noexcept = default;
+  enumerate_iterator& operator=(enumerate_iterator&&) = default;
 
-  ~enumerate_iterator() noexcept = default;
+  ~enumerate_iterator() = default;
 
   friend void swap<>(enumerate_iterator<T, C>& a, enumerate_iterator<T, C>& b);
 

--- a/tests/Cache/Rebalancer.cpp
+++ b/tests/Cache/Rebalancer.cpp
@@ -47,8 +47,8 @@ using namespace arangodb;
 using namespace arangodb::cache;
 
 struct ThreadGuard {
-  ThreadGuard(ThreadGuard&&) noexcept = default;
-  ThreadGuard& operator=(ThreadGuard&&) noexcept = default; 
+  ThreadGuard(ThreadGuard&&) = default;
+  ThreadGuard& operator=(ThreadGuard&&) = default;
 
   ThreadGuard(std::unique_ptr<std::thread> thread)
       : thread(std::move(thread)) {}

--- a/tests/Containers/EnumerateTest.cpp
+++ b/tests/Containers/EnumerateTest.cpp
@@ -35,10 +35,10 @@ template<typename T>
 struct NonCopyableType {
   explicit NonCopyableType(T t) : t(std::move(t)) {}
   NonCopyableType(NonCopyableType const&) = delete;
-  NonCopyableType(NonCopyableType &&) noexcept = default;
+  NonCopyableType(NonCopyableType &&) = default;
 
   NonCopyableType& operator=(NonCopyableType const&) = delete;
-  NonCopyableType& operator=(NonCopyableType&&) noexcept = default;
+  NonCopyableType& operator=(NonCopyableType&&) = default;
 
   T t;
 };


### PR DESCRIPTION
### Scope & Purpose

Remove `noexcept` specifier on `= default`ed constructors, destructors or assignment operators.

Rationale: Those defaulted functions are automatically declared `noexcept` (or not), depending on the base and/or members. Adding the specifier explicitly overrides that (at least with recent compilers like GCC10).

- [X] Bug-Fix for *devel*