### PR TITLE
honor crash handler override variable in tests

### DIFF
--- a/js/client/modules/@arangodb/testsuites/recovery.js
+++ b/js/client/modules/@arangodb/testsuites/recovery.js
@@ -75,6 +75,13 @@ function runArangodRecovery (params) {
       fs.remove(crashLog);
     } catch (err) {}
 
+
+    if (params.script.match(/crash-handler/)) {
+      // forcefully enable crash handler, even if turned off globally
+      // during testing
+      require('internal').env["ARANGODB_OVERRIDE_CRASH_HANDLER"] = "on";
+    }
+
     params.options.disableMonitor = true;
     params.testDir = fs.join(params.tempDir, `${params.count}`);
     pu.cleanupDBDirectoriesAppend(params.testDir);

--- a/tests/js/server/recovery/crash-handler-abort.js
+++ b/tests/js/server/recovery/crash-handler-abort.js
@@ -47,6 +47,15 @@ function recoverySuite () {
 
   return {
     testLogOutput: function () {
+      // check if crash handler is turned off
+      let envVariable = internal.env["ARANGODB_OVERRIDE_CRASH_HANDLER"];
+      if (typeof envVariable === 'string') {
+        envVariable = envVariable.trim().toLowerCase();
+        if (!(envVariable === 'true' || envVariable === 'yes' || envVariable === 'on' || envVariable === 'y')) {
+          return;
+        }
+      }
+
       let fs = require("fs");
       let crashFile = internal.env["crash-log"];
 

--- a/tests/js/server/recovery/crash-handler-assert.js
+++ b/tests/js/server/recovery/crash-handler-assert.js
@@ -47,6 +47,15 @@ function recoverySuite () {
 
   return {
     testLogOutput: function () {
+      // check if crash handler is turned off
+      let envVariable = internal.env["ARANGODB_OVERRIDE_CRASH_HANDLER"];
+      if (typeof envVariable === 'string') {
+        envVariable = envVariable.trim().toLowerCase();
+        if (!(envVariable === 'true' || envVariable === 'yes' || envVariable === 'on' || envVariable === 'y')) {
+          return;
+        }
+      }
+
       let fs = require("fs");
       let crashFile = internal.env["crash-log"];
 

--- a/tests/js/server/recovery/crash-handler-segfault.js
+++ b/tests/js/server/recovery/crash-handler-segfault.js
@@ -47,6 +47,15 @@ function recoverySuite () {
 
   return {
     testLogOutput: function () {
+      // check if crash handler is turned off
+      let envVariable = internal.env["ARANGODB_OVERRIDE_CRASH_HANDLER"];
+      if (typeof envVariable === 'string') {
+        envVariable = envVariable.trim().toLowerCase();
+        if (!(envVariable === 'true' || envVariable === 'yes' || envVariable === 'on' || envVariable === 'y')) {
+          return;
+        }
+      }
+
       let fs = require("fs");
       let crashFile = internal.env["crash-log"];
 

--- a/tests/js/server/recovery/crash-handler-terminate-active.js
+++ b/tests/js/server/recovery/crash-handler-terminate-active.js
@@ -47,6 +47,15 @@ function recoverySuite () {
 
   return {
     testLogOutput: function () {
+      // check if crash handler is turned off
+      let envVariable = internal.env["ARANGODB_OVERRIDE_CRASH_HANDLER"];
+      if (typeof envVariable === 'string') {
+        envVariable = envVariable.trim().toLowerCase();
+        if (!(envVariable === 'true' || envVariable === 'yes' || envVariable === 'on' || envVariable === 'y')) {
+          return;
+        }
+      }
+
       let fs = require("fs");
       let crashFile = internal.env["crash-log"];
 

--- a/tests/js/server/recovery/crash-handler-terminate.js
+++ b/tests/js/server/recovery/crash-handler-terminate.js
@@ -47,6 +47,15 @@ function recoverySuite () {
 
   return {
     testLogOutput: function () {
+      // check if crash handler is turned off
+      let envVariable = internal.env["ARANGODB_OVERRIDE_CRASH_HANDLER"];
+      if (typeof envVariable === 'string') {
+        envVariable = envVariable.trim().toLowerCase();
+        if (!(envVariable === 'true' || envVariable === 'yes' || envVariable === 'on' || envVariable === 'y')) {
+          return;
+        }
+      }
+
       let fs = require("fs");
       let crashFile = internal.env["crash-log"];
 


### PR DESCRIPTION
### Scope & Purpose

Honor value of variable `ARANGODB_OVERRIDE_CRASH_HANDLER` in our tests, too

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest recovery*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10201/