### PR TITLE
ignore hidden files and symbolic links in JWT secrets folder

### DIFF
--- a/arangod/GeneralServer/AuthenticationFeature.cpp
+++ b/arangod/GeneralServer/AuthenticationFeature.cpp
@@ -282,6 +282,24 @@ Result AuthenticationFeature::loadJwtSecretFolder() try {
       << "loading JWT secrets from folder " << _jwtSecretFolderProgramOption;
 
   auto list = basics::FileUtils::listFiles(_jwtSecretFolderProgramOption);
+
+  // filter out empty filenames, hidden files, tmp files and symlinks
+  list.erase(std::remove_if(list.begin(), list.end(),
+      [this](std::string const& file) {
+        if (file.empty() || file[0] == '.') {
+          return true;
+        }
+        if (file.size() >= 4 && file.substr(file.size() - 4, 4) == ".tmp") {
+          return true;
+        }
+        auto p = basics::FileUtils::buildFilename(_jwtSecretFolderProgramOption, file);
+        if (basics::FileUtils::isSymbolicLink(p)) {
+          return true;
+        }
+        return false;
+      }),
+      list.end());
+
   if (list.empty()) {
     return Result(TRI_ERROR_BAD_PARAMETER, "empty JWT secrets directory");
   }


### PR DESCRIPTION
### Scope & Purpose

Ignore "hidden" files and symbolic links in jwt-secrets-folder and in encryption-key-folder.

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/475

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)

#### Related Information

- [x] There is a *JIRA Ticket number* (In case a customer was affected / involved): https://arangodb.atlassian.net/browse/BTS-83

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10209/