### PR TITLE
Force c++-17 usage in V8 where possible

### DIFF
--- a/3rdParty/V8/gypfiles/broken/standalone.gypi
+++ b/3rdParty/V8/gypfiles/broken/standalone.gypi
@@ -1080,7 +1080,7 @@
           ['clang==1', {
             'xcode_settings': {
               'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0',
-              'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',  # -std=c++11
+              'CLANG_CXX_LANGUAGE_STANDARD': 'c++17',  # -std=c++17
             },
             'conditions': [
               ['clang_xcode==0', {

--- a/3rdParty/V8/v7.9.317/third_party/icu/source/config/mh-solaris
+++ b/3rdParty/V8/v7.9.317/third_party/icu/source/config/mh-solaris
@@ -6,7 +6,7 @@
 ## others. All Rights Reserved.
 
 ## Flags for ICU 59+
-CXXFLAGS += -std=c++11
+CXXFLAGS += -std=c++17
 CFLAGS   += -std=c11
 
 ## Flags for position independent code

--- a/3rdParty/V8/v7.9.317/third_party/icu/source/configure
+++ b/3rdParty/V8/v7.9.317/third_party/icu/source/configure
@@ -6055,13 +6055,13 @@ $as_echo "no" >&6; }
 fi
 
 if [ "$GXX" = yes ]; then
-    # if CXXFLAGS does not have a "-std=" setting, set it now to -std=c++11,
+    # if CXXFLAGS does not have a "-std=" setting, set it now to -std=c++17,
     # and check that the compiler still works.
     if ! echo "$CXXFLAGS" | grep '\-std=' >/dev/null 2>&1; then
         OLD_CXXFLAGS="${CXXFLAGS}"
-        CXXFLAGS="$CXXFLAGS -std=c++11"
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we have a C++11 compiler" >&5
-$as_echo_n "checking if we have a C++11 compiler... " >&6; }
+        CXXFLAGS="$CXXFLAGS -std=c++17"
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we have a C++17 compiler" >&5
+$as_echo_n "checking if we have a C++17 compiler... " >&6; }
         cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -6074,17 +6074,17 @@ main ()
 }
 _ACEOF
 if ac_fn_cxx_try_compile "$LINENO"; then :
-  cxx11_okay=yes
+  cxx17_okay=yes
 else
-  cxx11_okay=no
+  cxx17_okay=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $cxx11_okay" >&5
-$as_echo "$cxx11_okay" >&6; }
-        if [ $cxx11_okay = yes ]; then
-            { $as_echo "$as_me:${as_lineno-$LINENO}: Adding CXXFLAGS option -std=c++11" >&5
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $cxx17_okay" >&5
+$as_echo "$cxx17_okay" >&6; }
+        if [ $cxx17_okay = yes ]; then
+            { $as_echo "$as_me:${as_lineno-$LINENO}: Adding CXXFLAGS option -std=c++17" >&5
 $as_echo "$as_me: Adding CXXFLAGS option -std=c++11" >&6;}
-            UCONFIG_CXXFLAGS="${UCONFIG_CXXFLAGS} -std=c++11"
+            UCONFIG_CXXFLAGS="${UCONFIG_CXXFLAGS} -std=c++17"
         else
             CXXFLAGS="$OLD_CXXFLAGS"
         fi

--- a/3rdParty/V8/v7.9.317/third_party/icu/source/configure.ac
+++ b/3rdParty/V8/v7.9.317/third_party/icu/source/configure.ac
@@ -513,17 +513,17 @@ else
 fi
 
 if [[ "$GXX" = yes ]]; then
-    # if CXXFLAGS does not have a "-std=" setting, set it now to -std=c++11,
+    # if CXXFLAGS does not have a "-std=" setting, set it now to -std=c++17,
     # and check that the compiler still works.
     if ! echo "$CXXFLAGS" | grep '\-std=' >/dev/null 2>&1; then
         OLD_CXXFLAGS="${CXXFLAGS}"
-        CXXFLAGS="$CXXFLAGS -std=c++11"
-        AC_MSG_CHECKING([[if we have a C++11 compiler]])
-        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]],[[]])],[cxx11_okay=yes],[cxx11_okay=no])
-        AC_MSG_RESULT($cxx11_okay)
-        if [[ $cxx11_okay = yes ]]; then
-            AC_MSG_NOTICE([Adding CXXFLAGS option -std=c++11])
-            UCONFIG_CXXFLAGS="${UCONFIG_CXXFLAGS} -std=c++11"
+        CXXFLAGS="$CXXFLAGS -std=c++17"
+        AC_MSG_CHECKING([[if we have a C++17 compiler]])
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]],[[]])],[cxx17_okay=yes],[cxx17_okay=no])
+        AC_MSG_RESULT($cxx17_okay)
+        if [[ $cxx17_okay = yes ]]; then
+            AC_MSG_NOTICE([Adding CXXFLAGS option -std=c++17])
+            UCONFIG_CXXFLAGS="${UCONFIG_CXXFLAGS} -std=c++17"
         else
             CXXFLAGS="$OLD_CXXFLAGS"
         fi

--- a/3rdParty/V8/v7.9.317/tools/gcmole/gcmole.lua
+++ b/3rdParty/V8/v7.9.317/tools/gcmole/gcmole.lua
@@ -102,7 +102,7 @@ local function MakeClangCommandLine(
      end
      plugin_args = " " .. table.concat(plugin_args, " ")
    end
-   return CLANG_BIN .. "/clang++ -std=c++14 -c"
+   return CLANG_BIN .. "/clang++ -std=c++17 -c"
       .. " -Xclang -load -Xclang " .. CLANG_PLUGINS .. "/libgcmole.so"
       .. " -Xclang -plugin -Xclang "  .. plugin
       .. (plugin_args or "")

--- a/3rdParty/V8/v7.9.317/tools/run-wasm-api-tests.py
+++ b/3rdParty/V8/v7.9.317/tools/run-wasm-api-tests.py
@@ -62,7 +62,7 @@ C = {
 CXX = {
   "name": "C++",
   "suffix": "cc",
-  "cflags": "-std=c++11",
+  "cflags": "-std=c++17",
 }
 
 MIN_ARGS = 3  # Script, outdir, tempdir


### PR DESCRIPTION
Probably will suppress the following on macOS:
```
14:57:49 ld: warning: direct access in function 'std::__1::__shared_ptr_pointer<icu_64::BreakIterator*, std::__1::default_delete<icu_64::BreakIterator>, std::__1::allocator<icu_64::BreakIterator> >::__get_deleter(std::type_info const&) const' from file '/Users/jenkins/vm08-mac/oskar/work/ArangoDB/build/3rdParty/V8/v7.9.317/x64.release/libv8_base_without_compiler.a(js-segmenter.o)' to global weak symbol 'typeinfo name for std::__1::default_delete<icu_64::BreakIterator>' from file '../bin/libanalyzer-text-s.a(text_token_stream.cpp.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
```

http://172.16.10.101:8080/job/arangodb-matrix-pr/10212/