### PR TITLE
make arangodump/restore fail with invalid collection names

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 devel
 -----
 
+* arangodump and arangorestore will now fail when using the `--collection`
+  option and none of the specified collections actually exist in the database
+  (on dump) or in the dump to restore (on restore). In case some of the specified
+  collections exist, arangodump/restore will issue warnings about the invalid
+  collections, but will continue to work for the valid collections.
+
 * Added multiple RocksDB configuration options to arangod:
   * `--rocksdb.cache-index-and-filter-blocks` to make the RocksDB block cache quota
     also include RocksDB memtable sizes

--- a/arangosh/Dump/DumpFeature.cpp
+++ b/arangosh/Dump/DumpFeature.cpp
@@ -841,6 +841,22 @@ Result DumpFeature::runDump(httpclient::SimpleHttpClient& client, std::string co
 
   // restrictList now contains all collections the user requested, or all collections
   // in case the user did not restrict the dump to any collections
+  
+  // now check if at least one of the specified collections was found
+  if (_options.collections.empty()) {
+    bool found = false;
+    for (auto const& [name, collection] : restrictList) {
+      if (!collection.isNone()) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      LOG_TOPIC("fdd87", FATAL, arangodb::Logger::DUMP)
+          << "None of the requested collections were found in the database";
+      FATAL_ERROR_EXIT();
+    }
+  }
 
   // Step 3. iterate over collections, queue dump jobs
   for (auto const& [name, collection] : restrictList) {

--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -1009,16 +1009,37 @@ arangodb::Result processInputDirectory(
       }
     }
 
-    for (auto const& it : restrictColls) {
-      if (!it.second) {
-        LOG_TOPIC("5163e", WARN, Logger::RESTORE)
-          << "Requested collection '" << it.first << "' not found in dump";
+    if (!options.collections.empty()) {
+      bool found = false;
+      for (auto const& it : restrictColls) {
+        if (!it.second) {
+          LOG_TOPIC("5163e", WARN, Logger::RESTORE)
+            << "Requested collection '" << it.first << "' not found in dump";
+        } else {
+          found = true;
+        }
+      }
+      if (!found) {
+        LOG_TOPIC("3ef18", FATAL, arangodb::Logger::RESTORE)
+            << "None of the requested collections were found in the dump";
+        FATAL_ERROR_EXIT();
       }
     }
-    for (auto const& it : restrictViews) {
-      if (!it.second) {
-        LOG_TOPIC("810df", WARN, Logger::RESTORE)
-          << "Requested view '" << it.first << "' not found in dump";
+    
+    if (!options.views.empty()) {
+      bool found = false;
+      for (auto const& it : restrictViews) {
+        if (!it.second) {
+          LOG_TOPIC("810df", WARN, Logger::RESTORE)
+            << "Requested view '" << it.first << "' not found in dump";
+        } else {
+          found = true;
+        }
+      }
+      if (!found) {
+        LOG_TOPIC("14051", FATAL, arangodb::Logger::RESTORE)
+            << "None of the requested Views were found in the dump";
+        FATAL_ERROR_EXIT();
       }
     }
 


### PR DESCRIPTION
### Scope & Purpose

arangodump and arangorestore will now fail when using the `--collection` option and none of the specified collections actually exist in the database (on dump) or in the dump to restore (on restore). In case some of the specified collections exist, arangodump/restore will issue warnings about the invalid collections, but will continue to work for the valid collections.

Documentation PR: https://github.com/arangodb/docs/pull/452

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (shell_client, for arangodump)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10217/