### PR TITLE
Docs: Add missing isSmart and smartJoinAttribute options

### DIFF
--- a/Documentation/DocuBlocks/Rest/Collections/1_structs.md
+++ b/Documentation/DocuBlocks/Rest/Collections/1_structs.md
@@ -55,8 +55,8 @@ up-to-date copies will succeed at the same time however. The value of
 the sharding strategy selected for the collection.
 One of 'hash' or 'enterprise-hash-smart-edge'. _(cluster only)_
 
-@RESTSTRUCT{isSmart,collection_info,boolean,required,}
-Whether the graph is a SmartGraph. _(cluster only)_
+@RESTSTRUCT{isSmart,collection_info,boolean,optional,}
+Whether the collection is used in a SmartGraph. _(cluster only)_
 
 @RESTSTRUCT{smartGraphAttribute,collection_info,string,optional,}
 Attribute that is used in SmartGraphs. _(cluster only)_

--- a/Documentation/DocuBlocks/Rest/Collections/1_structs.md
+++ b/Documentation/DocuBlocks/Rest/Collections/1_structs.md
@@ -55,8 +55,15 @@ up-to-date copies will succeed at the same time however. The value of
 the sharding strategy selected for the collection.
 One of 'hash' or 'enterprise-hash-smart-edge'. _(cluster only)_
 
+@RESTSTRUCT{isSmart,collection_info,boolean,required,}
+Whether the graph is a SmartGraph. _(cluster only)_
+
 @RESTSTRUCT{smartGraphAttribute,collection_info,string,optional,}
 Attribute that is used in SmartGraphs. _(cluster only)_
+
+@RESTSTRUCT{smartJoinAttribute,collection_info,string,optional,}
+Determines an attribute of the collection that must contain the shard key value
+of the referred-to SmartJoin collection. _(cluster only)_
 
 @RESTSTRUCT{indexBuckets,collection_info,integer,optional,}
 the number of index buckets


### PR DESCRIPTION
https://arangodb.slack.com/archives/C1PJT16QP/p1590755388483700

The current API docs are not very specific about things like whether an attribute is returned only in Enterprise Edition. It's also unclear whether the server behavior is as intended (e.g. `isSmart` is present in Community Edition as well). I would like to defer improvements to this to the Swagger rewrite, and only add missing options for now.

https://jenkins01.arangodb.biz/view/Documentation/job/arangodb-ANY-examples/634/