### PR TITLE
Fix issue with hot backup and new replication protocol

### DIFF
--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -506,7 +506,7 @@ rocksdb::SequenceNumber RocksDBMetaCollection::lastSerializedRevisionTree(rocksd
 }
 
 rocksdb::SequenceNumber RocksDBMetaCollection::serializeRevisionTree(
-    std::string& output, rocksdb::SequenceNumber commitSeq) {
+    std::string& output, rocksdb::SequenceNumber commitSeq, bool force) {
   std::unique_lock<std::mutex> guard(_revisionTreeLock);
   if (_logicalCollection.useSyncByRevision()) {
     if (!_revisionTree) {
@@ -519,7 +519,7 @@ rocksdb::SequenceNumber RocksDBMetaCollection::serializeRevisionTree(
     bool beenTooLong = 30 < std::chrono::duration_cast<std::chrono::seconds>(
                                 std::chrono::steady_clock::now() - _revisionTreeSerializedTime)
                                 .count();
-    if (neverDone || coinFlip || beenTooLong) {  // ...but only write the tree out sometimes
+    if (force || neverDone || coinFlip || beenTooLong) {  // ...but only write the tree out sometimes
       _revisionTree->serializeBinary(output, true);
       _revisionTreeSerializedSeq = commitSeq;
       _revisionTreeSerializedTime = std::chrono::steady_clock::now();

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.h
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.h
@@ -78,7 +78,8 @@ class RocksDBMetaCollection : public PhysicalCollection {
   bool needToPersistRevisionTree(rocksdb::SequenceNumber maxCommitSeq) const;
   rocksdb::SequenceNumber lastSerializedRevisionTree(rocksdb::SequenceNumber maxCommitSeq);
   rocksdb::SequenceNumber serializeRevisionTree(std::string& output,
-                                                rocksdb::SequenceNumber commitSeq);
+                                                rocksdb::SequenceNumber commitSeq,
+                                                bool force);
 
   Result rebuildRevisionTree() override;
 

--- a/arangod/RocksDBEngine/RocksDBMetadata.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetadata.cpp
@@ -327,7 +327,8 @@ Result RocksDBMetadata::serializeMeta(rocksdb::WriteBatch& batch,
   if (rcoll->needToPersistRevisionTree(maxCommitSeq)) {
     if (coll.useSyncByRevision()) {
       output.clear();
-      rocksdb::SequenceNumber seq = rcoll->serializeRevisionTree(output, maxCommitSeq);
+      rocksdb::SequenceNumber seq =
+          rcoll->serializeRevisionTree(output, maxCommitSeq, force);
       appliedSeq = std::min(appliedSeq, seq);
       if (!output.empty()) {
         rocksutils::uint64ToPersistent(output, seq);
@@ -344,7 +345,8 @@ Result RocksDBMetadata::serializeMeta(rocksdb::WriteBatch& batch,
       }
     } else {
       output.clear();
-      rocksdb::SequenceNumber seq = rcoll->serializeRevisionTree(output, maxCommitSeq);
+      rocksdb::SequenceNumber seq =
+          rcoll->serializeRevisionTree(output, maxCommitSeq, force);
       appliedSeq = std::min(appliedSeq, seq);
       TRI_ASSERT(output.empty());
       key.constructRevisionTreeValue(rcoll->objectId());


### PR DESCRIPTION
### Scope & Purpose

This is a partial fix for an issue with the new replication protocol. The new revision trees do not appear to be persisted fully correctly. One symptom has been failures when used in conjunction with hot backup. This PR fixes this particular symptom, but may not fix all issue with the persistence/recovery of the revision trees.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)

#### Related Information

- [x] There is an internal planning ticket: BTS-48

### Testing & Verification

Jenkins: https://jenkins.arangodb.biz/job/arangodb-matrix-pr/10240/