### PR TITLE
Bug fix/recalculate count

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fixed a bug in the internal `recalculateCount()` method for adjusting
+  collection counts. The bug could have led to count adjustments being
+  applied with the wrong sign.
+
 * Removed external file loading in a used 3rd party library (Web UI). 
 
 * More substantial metrics in agency.

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -288,12 +288,13 @@ uint64_t RocksDBMetaCollection::recalculateCounts() {
     ++count;
   }
   
-  int64_t adjustment = snapNumberOfDocuments - count;
+  int64_t adjustment = count - snapNumberOfDocuments;
   if (adjustment != 0) {
+    auto seq = snapshot->GetSequenceNumber();
     LOG_TOPIC("ad6d3", WARN, Logger::REPLICATION)
     << "inconsistent collection count detected, "
     << "an offet of " << adjustment << " will be applied";
-    _meta.adjustNumberDocuments(0, static_cast<TRI_voc_rid_t>(0), adjustment);
+    _meta.adjustNumberDocuments(seq, static_cast<TRI_voc_rid_t>(0), adjustment);
   }
   
   return _meta.numberDocuments();

--- a/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
@@ -205,6 +205,9 @@ void RocksDBTransactionCollection::abortCommit(uint64_t trxId) {
 }
 
 void RocksDBTransactionCollection::commitCounts(TRI_voc_tid_t trxId, uint64_t commitSeq) {
+  TRI_IF_FAILURE("DisableCommitCounts") {
+    return;
+  }
   TRI_ASSERT(_collection != nullptr);
   auto* rcoll = static_cast<RocksDBMetaCollection*>(_collection->getPhysical());
 

--- a/tests/js/server/recovery/recalculate-count-incremental.js
+++ b/tests/js/server/recovery/recalculate-count-incremental.js
@@ -1,0 +1,124 @@
+/* jshint globalstrict:false, strict:false, unused: false */
+/* global assertEqual, assertTrue */
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief tests for transactions
+// /
+// / @file
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2010-2012 triagens GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// / @author Copyright 2013, triAGENS GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+var db = require('@arangodb').db;
+var internal = require('internal');
+var jsunity = require('jsunity');
+
+function runSetup () {
+  'use strict';
+  
+  internal.debugSetFailAt('DisableCommitCounts');
+  
+  db._drop('UnitTestsRecovery1');
+  db._drop('UnitTestsRecovery2');
+  let c = db._create('UnitTestsRecovery1');
+  let control = db._create('UnitTestsRecovery2');
+
+  // count = 0
+  c.recalculateCount();
+  control.insert({ _key: "step1", expected: 0, actual: c.count() });
+
+  c.insert({ _key: "test1" });
+  // count = 1
+  c.recalculateCount();
+  control.insert({ _key: "step2", expected: 1, actual: c.count() });
+  
+  c.insert({ _key: "test2" });
+  // count = 2
+  c.recalculateCount();
+  control.insert({ _key: "step3", expected: 2, actual: c.count() });
+
+  c.insert({ _key: "test3" });
+  // count = 3
+  c.recalculateCount();
+  control.insert({ _key: "step4", expected: 3, actual: c.count() });
+  
+  c.remove("test2");
+  // count = 2
+  c.recalculateCount();
+  control.insert({ _key: "step5", expected: 2, actual: c.count() });
+
+  c.update("test1", { foo: "bar" });
+  // count = 2
+  c.recalculateCount();
+  control.insert({ _key: "step6", expected: 2, actual: c.count() });
+
+  c.truncate();
+  // count = 0;
+  c.recalculateCount();
+  control.insert({ _key: "step7", expected: 0, actual: c.count() }, { waitForSync: true });
+
+  internal.debugTerminate('crashing server');
+}
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief test suite
+// //////////////////////////////////////////////////////////////////////////////
+
+function recoverySuite () {
+  'use strict';
+  jsunity.jsUnity.attachAssertions();
+
+  return {
+    setUp: function () {},
+    tearDown: function () {},
+
+    testRecalculateCount: function () {
+      let c = db._collection('UnitTestsRecovery1');
+      assertEqual(0, c.count());
+      assertTrue([], c.toArray());
+      
+      let control = db._collection('UnitTestsRecovery2');
+      assertEqual(7, control.count());
+
+      for (let i = 1; i <= 7; ++i) {
+        let doc = control.document("step" + i);
+        assertEqual("step" + i, doc._key);
+        assertEqual(doc.expected, doc.actual);
+      }
+    }
+
+  };
+}
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief executes the test suite
+// //////////////////////////////////////////////////////////////////////////////
+
+function main (argv) {
+  'use strict';
+  if (argv[1] === 'setup') {
+    runSetup();
+    return 0;
+  } else {
+    jsunity.run(recoverySuite);
+    return jsunity.writeDone().status ? 0 : 1;
+  }
+}

--- a/tests/js/server/recovery/recalculate-count.js
+++ b/tests/js/server/recovery/recalculate-count.js
@@ -1,0 +1,94 @@
+/* jshint globalstrict:false, strict:false, unused: false */
+/* global assertEqual, assertFalse, assertNull, assertNotNull */
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief tests for transactions
+// /
+// / @file
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2010-2012 triagens GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// / @author Copyright 2013, triAGENS GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+var db = require('@arangodb').db;
+var internal = require('internal');
+var jsunity = require('jsunity');
+
+function runSetup () {
+  'use strict';
+  
+  internal.debugSetFailAt('DisableCommitCounts');
+  
+  db._drop('UnitTestsRecovery1');
+  let c = db._create('UnitTestsRecovery1');
+  let docs = [];
+  for (let i = 0; i < 100000; i++) {
+    docs.push({ _key: "test" + i, value: i });
+    if (docs.length === 10000) {
+      c.insert(docs);
+      docs = [];
+    }
+  }
+ 
+  c.recalculateCount();
+
+  // this is our marker that we got past the "recalculateCount()" call
+  c.insert({ _key: "done" }, { waitForSync: true });
+
+  internal.debugTerminate('crashing server');
+}
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief test suite
+// //////////////////////////////////////////////////////////////////////////////
+
+function recoverySuite () {
+  'use strict';
+  jsunity.jsUnity.attachAssertions();
+
+  return {
+    setUp: function () {},
+    tearDown: function () {},
+
+    testRecalculateCount: function () {
+      let c = db._collection('UnitTestsRecovery1');
+      assertEqual(100001, c.count());
+
+      // check that we got past the "recalculateCount()" call
+      assertEqual("done", c.document("done")._key);
+    }
+
+  };
+}
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief executes the test suite
+// //////////////////////////////////////////////////////////////////////////////
+
+function main (argv) {
+  'use strict';
+  if (argv[1] === 'setup') {
+    runSetup();
+    return 0;
+  } else {
+    jsunity.run(recoverySuite);
+    return jsunity.writeDone().status ? 0 : 1;
+  }
+}


### PR DESCRIPTION
### Scope & Purpose

Fixed a bug in the internal `recalculateCount()` method that could lead to count adjustments being applied with the wrong sign.
Added tests.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in `scripts/unittest recovery`)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10246/