### PR TITLE
added missing mutex to ConnectionPool::cancelConnections()

### DIFF
--- a/3rdParty/fuerte/include/fuerte/connection.h
+++ b/3rdParty/fuerte/include/fuerte/connection.h
@@ -200,12 +200,6 @@ class ConnectionBuilder {
     _conf._jwtToken = t;
     return *this;
   }
-  // Set the maximum size for chunks (VST only)
-  /*inline std::size_t maxChunkSize() const { return _conf._maxChunkSize; }
-  ConnectionBuilder& maxChunkSize(std::size_t c) {
-    _conf._maxChunkSize = c;
-    return *this;
-  }*/
 
   /// @brief tcp, ssl or unix
   inline SocketType socketType() const { return _conf._socketType; }

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Added missing mutex to ConnectionPool::cancelConnections().  
+
 * Fix crash in execution of non-spliced subqueries if remainder of subquery is skipped.
 
 * Made modification subqueries non-passthrough. The passthrough logic only works

--- a/arangod/Network/ConnectionPool.cpp
+++ b/arangod/Network/ConnectionPool.cpp
@@ -66,6 +66,11 @@ network::ConnectionPtr ConnectionPool::leaseConnection(std::string const& endpoi
 /// @brief drain all connections
 void ConnectionPool::drainConnections() {
   WRITE_LOCKER(guard, _lock);
+  for (auto& pair : _connections) {
+    Bucket& buck = *(pair.second);
+    std::lock_guard<std::mutex> lock(buck.mutex);
+    buck.list.clear();
+  }
   _connections.clear();
 }
 

--- a/arangod/Network/ConnectionPool.h
+++ b/arangod/Network/ConnectionPool.h
@@ -70,7 +70,7 @@ class ConnectionPool final {
 
  public:
   explicit ConnectionPool(ConnectionPool::Config const& config);
-  virtual ~ConnectionPool();
+  TEST_VIRTUAL ~ConnectionPool();
 
   /// @brief request a connection for a specific endpoint
   /// note: it is the callers responsibility to ensure the endpoint
@@ -119,10 +119,8 @@ class ConnectionPool final {
   TEST_VIRTUAL ConnectionPtr createConnection(fuerte::ConnectionBuilder&);
   ConnectionPtr selectConnection(std::string const& endpoint, Bucket& bucket);
   
-  void removeBrokenConnections(Bucket&);
-
  private:
-  const Config _config;
+  Config _config;
 
   mutable basics::ReadWriteSpinLock _lock;
   std::unordered_map<std::string, std::unique_ptr<Bucket>> _connections;

--- a/arangod/Network/Utils.cpp
+++ b/arangod/Network/Utils.cpp
@@ -197,8 +197,11 @@ int toArangoErrorCodeInternal(fuerte::Error err) {
     case fuerte::Error::CouldNotConnect:
       return TRI_ERROR_CLUSTER_BACKEND_UNAVAILABLE;
 
-    case fuerte::Error::CloseRequested:
     case fuerte::Error::ConnectionClosed:
+      // only here temporarily...
+      TRI_ASSERT(false);
+      return TRI_ERROR_CLUSTER_CONNECTION_LOST;
+    case fuerte::Error::CloseRequested:
       return TRI_ERROR_CLUSTER_CONNECTION_LOST;
 
     case fuerte::Error::Timeout:  // No reply, we give up:


### PR DESCRIPTION
### Scope & Purpose

* Added missing mutex acquisition to ConnectionPool::cancelConnections().
* optimize ConnectionPool::pruneConnections() to make only a single pass over the connections.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *anything connection related*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10260/