### PR TITLE
Fix idiomatic Foxx testing reports for 3.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.6.5 (XXXX-XX-XX)
 -------------------
 
+* Foxx API now respects "idiomatic" flag being explicitly set to false.
+
 * Fixed a bug in the internal `recalculateCount()` method for adjusting
   collection counts. The bug could have led to count adjustments being
   applied with the wrong sign.

--- a/js/apps/system/_api/foxx/APP/index.js
+++ b/js/apps/system/_api/foxx/APP/index.js
@@ -381,16 +381,22 @@ instanceRouter.post('/tests', (req, res) => {
   const filter = req.queryParams.filter || null;
   const reporter = req.queryParams.reporter || null;
   const result = FoxxManager.runTests(service.mount, {filter, reporter});
-  if (reporter === 'stream' && (idiomatic || req.accepts(LDJSON, 'json') === LDJSON)) {
+  if (reporter === 'stream' && idiomatic !== false && (
+    idiomatic || req.accepts(LDJSON, 'json') === LDJSON
+  )) {
     res.type(LDJSON);
     for (const row of result) {
       res.write(JSON.stringify(row) + '\r\n');
     }
-  } else if (reporter === 'xunit' && (idiomatic || req.accepts('xml', 'json') === 'xml')) {
+  } else if (reporter === 'xunit' && idiomatic !== false && (
+    idiomatic || req.accepts('xml', 'json') === 'xml'
+  )) {
     res.type('xml');
     res.write('<?xml version="1.0" encoding="utf-8"?>\n');
     res.write(jsonml2xml(result) + '\n');
-  } else if (reporter === 'tap' && (idiomatic || req.accepts('text', 'json') === 'text')) {
+  } else if (reporter === 'tap' && idiomatic !== false && (
+    idiomatic || req.accepts('text', 'json') === 'text'
+  )) {
     res.type('text');
     for (const row of result) {
       res.write(row + '\n');
@@ -401,7 +407,7 @@ instanceRouter.post('/tests', (req, res) => {
 })
 .queryParam('filter', joi.string().allow("").optional())
 .queryParam('reporter', joi.only(...Object.keys(reporters)).optional())
-.queryParam('idiomatic', schemas.flag.default(false))
+.queryParam('idiomatic', schemas.flag.optional())
 .response(200, ['json', LDJSON, 'xml', 'text']);
 
 instanceRouter.post('/download', (req, res) => {

--- a/js/apps/system/_api/foxx/APP/schemas.js
+++ b/js/apps/system/_api/foxx/APP/schemas.js
@@ -7,7 +7,7 @@ exports.mount = joi.string().regex(/(?:\/[-_0-9a-z]+)+/i).required();
 exports.flag = joi.alternatives().try(
   joi.boolean(),
   joi.number().integer().min(0).max(1)
-).default(false);
+);
 
 exports.shortInfo = joi.object({
   mount: exports.mount,

--- a/tests/js/client/shell/shell-foxx-api-spec.js
+++ b/tests/js/client/shell/shell-foxx-api-spec.js
@@ -1056,6 +1056,21 @@ describe('Foxx service', () => {
     expect(resp).to.have.property('passes');
   });
 
+  it('idiomatic tests reporter should return string', () => {
+    const testPath = path.resolve(internal.pathForTesting('common'), 'test-data', 'apps', 'with-tests');
+    FoxxManager.install(testPath, mount);
+    const resp = arango.POST('/_api/foxx/tests?reporter=xunit&idiomatic=true&mount=' + mount, '');
+    expect(resp).to.be.instanceof(Buffer);
+    expect(resp.toString("utf-8").startsWith("<?xml")).to.equal(true);
+  });
+
+  it('non-idiomatic tests reporter should not return string', () => {
+    const testPath = path.resolve(internal.pathForTesting('common'), 'test-data', 'apps', 'with-tests');
+    FoxxManager.install(testPath, mount);
+    const resp = arango.POST('/_api/foxx/tests?reporter=xunit&idiomatic=false&mount=' + mount, '');
+    expect(resp).to.be.an("array");
+  });
+
   it('replace on invalid mount should not be installed', () => {
     const replaceResp = arango.PUT('/_api/foxx/service?mount=' + mount, {
         source: minimalWorkingZipPath


### PR DESCRIPTION
Backport of https://github.com/arangodb/arangodb/pull/10348.

http://jenkins.arangodb.biz:8080/job/arangodb-matrix-pr/10270/