### PR TITLE
micro optimizations in velocypack

### DIFF
--- a/3rdParty/velocypack/include/velocypack/Value.h
+++ b/3rdParty/velocypack/include/velocypack/Value.h
@@ -65,59 +65,52 @@ class Value {
     uint64_t u;            // 4: uint64_t
     std::string const* s;  // 5: std::string
     char const* c;         // 6: char const*
-    void const* e;         // external
+    void const* e;         // 7: external
   } _value;
 
-  bool _unindexed;
-
  public:
-#ifdef SWIG
-  Value()
-      : _valueType(ValueType::None), _cType(CType::None), _unindexed(false) {}
-#else
   Value() = delete;
-#endif
 
   // creates a Value with the specified type Array or Object
   explicit Value(ValueType t, bool allowUnindexed = false);
 
   explicit Value(bool b, ValueType t = ValueType::Bool) noexcept
-      : _valueType(t), _cType(CType::Bool), _unindexed(false) {
+      : _valueType(t), _cType(CType::Bool) {
     _value.b = b;
   }
 
   explicit Value(double d, ValueType t = ValueType::Double) noexcept
-      : _valueType(t), _cType(CType::Double), _unindexed(false) {
+      : _valueType(t), _cType(CType::Double) {
     _value.d = d;
   }
 
   explicit Value(void const* e, ValueType t = ValueType::External) noexcept
-      : _valueType(t), _cType(CType::VoidPtr), _unindexed(false) {
+      : _valueType(t), _cType(CType::VoidPtr) {
     _value.e = e;
   }
 
   explicit Value(char const* c, ValueType t = ValueType::String) noexcept
-      : _valueType(t), _cType(CType::CharPtr), _unindexed(false) {
+      : _valueType(t), _cType(CType::CharPtr) {
     _value.c = c;
   }
 
   explicit Value(int32_t i, ValueType t = ValueType::Int) noexcept
-      : _valueType(t), _cType(CType::Int64), _unindexed(false) {
+      : _valueType(t), _cType(CType::Int64) {
     _value.i = static_cast<int64_t>(i);
   }
 
   explicit Value(uint32_t u, ValueType t = ValueType::UInt) noexcept
-      : _valueType(t), _cType(CType::UInt64), _unindexed(false) {
+      : _valueType(t), _cType(CType::UInt64) {
     _value.u = static_cast<uint64_t>(u);
   }
 
   explicit Value(int64_t i, ValueType t = ValueType::Int) noexcept
-      : _valueType(t), _cType(CType::Int64), _unindexed(false) {
+      : _valueType(t), _cType(CType::Int64) {
     _value.i = i;
   }
 
   explicit Value(uint64_t u, ValueType t = ValueType::UInt) noexcept
-      : _valueType(t), _cType(CType::UInt64), _unindexed(false) {
+      : _valueType(t), _cType(CType::UInt64) {
     _value.u = u;
   }
 
@@ -131,20 +124,24 @@ class Value {
 
   // however, defining the method on Linux and with MSVC will lead
   // to ambiguous overloads, so this is restricted to __APPLE__ only
-  explicit Value(unsigned long i, ValueType t = ValueType::Int) noexcept
-      : _valueType(t), _cType(CType::UInt64), _unindexed(false) {
+  explicit Value(unsigned long i, ValueType t = ValueType::UInt) noexcept
+      : _valueType(t), _cType(CType::UInt64) {
     _value.i = static_cast<uint64_t>(i);
   }
 #endif
 
   explicit Value(std::string const& s, ValueType t = ValueType::String) noexcept
-      : _valueType(t), _cType(CType::String), _unindexed(false) {
+      : _valueType(t), _cType(CType::String) {
     _value.s = &s;
   }
 
   ValueType valueType() const { return _valueType; }
 
   CType cType() const { return _cType; }
+
+  // whether or not the underlying Array/Object can be unindexed.
+  // it is only allowed to call this for Array/Object types!
+  bool unindexed() const;
 
   bool isString() const { return _valueType == ValueType::String; }
 

--- a/3rdParty/velocypack/src/Builder.cpp
+++ b/3rdParty/velocypack/src/Builder.cpp
@@ -872,24 +872,6 @@ uint8_t* Builder::set(uint64_t tag, Value const& item) {
       appendLengthUnchecked<sizeof(double)>(x);
       break;
     }
-    case ValueType::External: {
-      if (options->disallowExternals) {
-        // External values explicitly disallowed as a security
-        // precaution
-        throw Exception(Exception::BuilderExternalsDisallowed);
-      }
-      if (VELOCYPACK_UNLIKELY(ctype != Value::CType::VoidPtr)) {
-        throw Exception(Exception::BuilderUnexpectedValue,
-                        "Must give void pointer for ValueType::External");
-      }
-      reserve(1 + sizeof(void*));
-      // store pointer. this doesn't need to be portable
-      appendByteUnchecked(0x1d);
-      void const* value = item.getExternal();
-      memcpy(_start + _pos, &value, sizeof(void*));
-      advance(sizeof(void*));
-      break;
-    }
     case ValueType::SmallInt: {
       int64_t vv = 0;
       switch (ctype) {
@@ -1005,11 +987,11 @@ uint8_t* Builder::set(uint64_t tag, Value const& item) {
       break;
     }
     case ValueType::Array: {
-      addArray(item._unindexed);
+      addArray(item.unindexed());
       break;
     }
     case ValueType::Object: {
-      addObject(item._unindexed);
+      addObject(item.unindexed());
       break;
     }
     case ValueType::UTCDate: {
@@ -1050,6 +1032,24 @@ uint8_t* Builder::set(uint64_t tag, Value const& item) {
       reserve(size);
       memcpy(_start + _pos, p, checkOverflow(size));
       advance(size);
+      break;
+    }
+    case ValueType::External: {
+      if (options->disallowExternals) {
+        // External values explicitly disallowed as a security
+        // precaution
+        throw Exception(Exception::BuilderExternalsDisallowed);
+      }
+      if (VELOCYPACK_UNLIKELY(ctype != Value::CType::VoidPtr)) {
+        throw Exception(Exception::BuilderUnexpectedValue,
+                        "Must give void pointer for ValueType::External");
+      }
+      reserve(1 + sizeof(void*));
+      // store pointer. this doesn't need to be portable
+      appendByteUnchecked(0x1d);
+      void const* value = item.getExternal();
+      memcpy(_start + _pos, &value, sizeof(void*));
+      advance(sizeof(void*));
       break;
     }
     case ValueType::Illegal: {
@@ -1119,15 +1119,7 @@ uint8_t* Builder::set(uint64_t tag, ValuePair const& pair) {
     appendTag(tag);
   }
 
-  if (pair.valueType() == ValueType::Binary) {
-    uint64_t v = pair.getSize();
-    reserve(9 + v);
-    appendUInt(v, 0xbf);
-    VELOCYPACK_ASSERT(pair.getStart() != nullptr);
-    memcpy(_start + _pos, pair.getStart(), checkOverflow(v));
-    advance(v);
-    return _start + oldPos;
-  } else if (pair.valueType() == ValueType::String) {
+  if (pair.valueType() == ValueType::String) {
     uint64_t size = pair.getSize();
     if (size > 126) {
       // long string
@@ -1142,6 +1134,14 @@ uint8_t* Builder::set(uint64_t tag, ValuePair const& pair) {
     VELOCYPACK_ASSERT(pair.getStart() != nullptr);
     memcpy(_start + _pos, pair.getStart(), checkOverflow(size));
     advance(size);
+    return _start + oldPos;
+  } else if (pair.valueType() == ValueType::Binary) {
+    uint64_t v = pair.getSize();
+    reserve(9 + v);
+    appendUInt(v, 0xbf);
+    VELOCYPACK_ASSERT(pair.getStart() != nullptr);
+    memcpy(_start + _pos, pair.getStart(), checkOverflow(v));
+    advance(v);
     return _start + oldPos;
   } else if (pair.valueType() == ValueType::Custom) {
     if (options->disallowCustom) {

--- a/3rdParty/velocypack/src/Value.cpp
+++ b/3rdParty/velocypack/src/Value.cpp
@@ -32,11 +32,20 @@ using namespace arangodb::velocypack;
   
 // creates a Value with the specified type Array or Object
 Value::Value(ValueType t, bool allowUnindexed)
-      : _valueType(t), _cType(CType::None), _unindexed(allowUnindexed) {
+      : _valueType(t), _cType(CType::None) {
   if (allowUnindexed &&
       (_valueType != ValueType::Array && _valueType != ValueType::Object)) {
     throw Exception(Exception::InvalidValueType, "Expecting compound type");
   }
+  // we use the boolean part to store the allowUnindexed value
+  _value.b = allowUnindexed;
+}
+
+bool Value::unindexed() const {
+  if (_valueType != ValueType::Array && _valueType != ValueType::Object) {
+    throw Exception(Exception::InvalidValueType, "Expecting compound type");
+  }
+  return _value.b;
 }
   
 ValuePair::ValuePair(StringRef const& value, ValueType type) noexcept


### PR DESCRIPTION
### Scope & Purpose

Micro-optimize velocypack::Value by making its struct 16 bytes small instead of 24 bytes.
Additionally reorder cases in velocypack::Builder so the more frequent cases come first.

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *velocypack tests*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10277/