### PR TITLE
remove dependency on trx object

### DIFF
--- a/arangod/Aql/AqlValue.cpp
+++ b/arangod/Aql/AqlValue.cpp
@@ -988,7 +988,7 @@ size_t AqlValue::sizeofDocvec() const {
 }
 
 /// @brief construct a V8 value as input for the expression execution in V8
-v8::Handle<v8::Value> AqlValue::toV8(v8::Isolate* isolate, transaction::Methods* trx) const {
+v8::Handle<v8::Value> AqlValue::toV8(v8::Isolate* isolate, velocypack::Options const* options) const {
   auto context = TRI_IGETC;
   AqlValueType t = type();
   switch (t) {
@@ -996,7 +996,6 @@ v8::Handle<v8::Value> AqlValue::toV8(v8::Isolate* isolate, transaction::Methods*
     case VPACK_SLICE_POINTER:
     case VPACK_MANAGED_SLICE:
     case VPACK_MANAGED_BUFFER: {
-      VPackOptions* options = trx->transactionContext()->getVPackOptions();
       return TRI_VPackToV8(isolate, slice(t), options);
     }
     case DOCVEC: {
@@ -1008,7 +1007,7 @@ v8::Handle<v8::Value> AqlValue::toV8(v8::Isolate* isolate, transaction::Methods*
       for (auto const& it : *_data.docvec) {
         size_t const n = it->size();
         for (size_t i = 0; i < n; ++i) {
-          result->Set(context, j++, it->getValueReference(i, 0).toV8(isolate, trx)).FromMaybe(false);
+          result->Set(context, j++, it->getValueReference(i, 0).toV8(isolate, options)).FromMaybe(false);
 
           if (V8PlatformFeature::isOutOfMemory(isolate)) {
             THROW_ARANGO_EXCEPTION(TRI_ERROR_OUT_OF_MEMORY);
@@ -1094,11 +1093,6 @@ void AqlValue::toVelocyPack(VPackOptions const* options, arangodb::velocypack::B
   }
 }
 
-//void AqlValue::toVelocyPack(transaction::Methods* trx, arangodb::velocypack::Builder& builder,
-//                            bool resolveExternals) const {
-//  toVelocyPack(trx->transactionContextPtr()->getVPackOptions(), builder, resolveExternals);
-//}
-
 /// @brief materializes a value into the builder
 AqlValue AqlValue::materialize(VPackOptions const* options, bool& hasCopied,
                                bool resolveExternals) const {
@@ -1125,11 +1119,6 @@ AqlValue AqlValue::materialize(VPackOptions const* options, bool& hasCopied,
   // we shouldn't get here
   hasCopied = false;
   return AqlValue();
-}
-
-AqlValue AqlValue::materialize(transaction::Methods* trx, bool& hasCopied,
-                               bool resolveExternals) const {
-  return materialize(trx->transactionContextPtr()->getVPackOptions(), hasCopied, resolveExternals);
 }
 
 /// @brief clone a value

--- a/arangod/Aql/AqlValue.h
+++ b/arangod/Aql/AqlValue.h
@@ -322,18 +322,14 @@ struct AqlValue final {
   AqlItemBlock* docvecAt(size_t position) const;
 
   /// @brief construct a V8 value as input for the expression execution in V8
-  v8::Handle<v8::Value> toV8(v8::Isolate* isolate, transaction::Methods*) const;
+  v8::Handle<v8::Value> toV8(v8::Isolate* isolate, arangodb::velocypack::Options const*) const;
 
   /// @brief materializes a value into the builder
   void toVelocyPack(velocypack::Options const*, arangodb::velocypack::Builder&, bool resolveExternals) const;
-//  [[deprecated("Pass VPackOptions instead of the transaction")]]
-//  void toVelocyPack(transaction::Methods*, arangodb::velocypack::Builder&, bool resolveExternals) const;
 
   /// @brief materialize a value into a new one. this expands docvecs and
   /// ranges
   AqlValue materialize(velocypack::Options const*, bool& hasCopied, bool resolveExternals) const;
-  [[deprecated("Pass VPackOptions instead of the transaction")]]
-  AqlValue materialize(transaction::Methods*, bool& hasCopied, bool resolveExternals) const;
 
   /// @brief return the slice for the value
   /// this will throw if the value type is not VPACK_SLICE_POINTER,

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -942,8 +942,10 @@ AqlValue Expression::executeSimpleExpressionFCallJS(AstNode const* node,
   {
     ISOLATE;
     TRI_ASSERT(isolate != nullptr);
-    v8::HandleScope scope(isolate);                                   \
+    v8::HandleScope scope(isolate);      
     auto context = TRI_IGETC;
+    
+    VPackOptions const* options = trx->transactionContext()->getVPackOptions();
 
     std::string jsName;
     size_t const n = member->numMembers();
@@ -962,7 +964,7 @@ AqlValue Expression::executeSimpleExpressionFCallJS(AstNode const* node,
         AqlValue a = executeSimpleExpression(arg, trx, localMustDestroy, false);
         AqlValueGuard guard(a, localMustDestroy);
 
-        params->Set(context, static_cast<uint32_t>(i), a.toV8(isolate, trx)).FromMaybe(false);
+        params->Set(context, static_cast<uint32_t>(i), a.toV8(isolate, options)).FromMaybe(false);
       }
 
       // function name
@@ -987,7 +989,7 @@ AqlValue Expression::executeSimpleExpressionFCallJS(AstNode const* node,
           AqlValue a = executeSimpleExpression(arg, trx, localMustDestroy, false);
           AqlValueGuard guard(a, localMustDestroy);
 
-          args[i] = a.toV8(isolate, trx);
+          args[i] = a.toV8(isolate, options);
         }
       }
     }

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -1127,6 +1127,7 @@ AqlValue callApplyBackend(ExpressionContext* expressionContext, transaction::Met
     v8::HandleScope scope(isolate);
     auto context = TRI_IGETC;
 
+    VPackOptions const* options = trx->transactionContext()->getVPackOptions();
     std::string jsName;
     int const n = static_cast<int>(invokeParams.size());
     int const callArgs = (func == nullptr ? 3 : n);
@@ -1143,7 +1144,7 @@ AqlValue callApplyBackend(ExpressionContext* expressionContext, transaction::Met
 
       for (int i = 0; i < n; ++i) {
         params
-            ->Set(context, static_cast<uint32_t>(i), invokeParams[i].toV8(isolate, trx))
+            ->Set(context, static_cast<uint32_t>(i), invokeParams[i].toV8(isolate, options))
             .FromMaybe(true);
       }
       args[1] = params;
@@ -1152,7 +1153,7 @@ AqlValue callApplyBackend(ExpressionContext* expressionContext, transaction::Met
       // a call to a built-in V8 function
       jsName = "AQL_" + func->name;
       for (int i = 0; i < n; ++i) {
-        args[i] = invokeParams[i].toV8(isolate, trx);
+        args[i] = invokeParams[i].toV8(isolate, options);
       }
     }
 

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -639,7 +639,8 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
             AqlValue const& val = value->getValueReference(i, resultRegister);
 
             if (!val.isEmpty()) {
-              resArray->Set(context, j++, val.toV8(isolate, _trx.get())).FromMaybe(false);
+              VPackOptions const* options = _trx->transactionContext()->getVPackOptions();
+              resArray->Set(context, j++, val.toV8(isolate, options)).FromMaybe(false);
 
               if (useQueryCache) {
                 val.toVelocyPack(&vpackOptions(), *builder, true);


### PR DESCRIPTION
### Scope & Purpose

Remove dependency on `trx` object in AqlValue::toV8(...)

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *shell_server_aql*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10283/