### PR TITLE
when producing documents and using projections, recycle a velocypack::Builder

### DIFF
--- a/arangod/Aql/DocumentProducingHelper.cpp
+++ b/arangod/Aql/DocumentProducingHelper.cpp
@@ -101,7 +101,7 @@ IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVarian
     RegisterId registerId = context.getOutputRegister();
 
     TRI_ASSERT(!output.isFull());
-    output.copyValueInto(registerId, input, objectBuilder.slice());
+    output.moveValueInto<InputAqlItemRow, VPackSlice const>(registerId, input, objectBuilder.slice());
     TRI_ASSERT(output.produced());
     output.advanceRow();
 
@@ -112,7 +112,7 @@ IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVarian
 template <bool checkUniqueness, bool skip>
 IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVariant::DocumentCopy,
                                                  DocumentProducingFunctionContext& context) {
-  return [&context](LocalDocumentId const& token, VPackSlice slice) {
+  return [&context](LocalDocumentId const& token, VPackSlice const slice) {
     if constexpr (checkUniqueness) {
       if (!context.checkUniqueness(token)) {
         // Document already found, skip it
@@ -138,7 +138,7 @@ IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVarian
     RegisterId registerId = context.getOutputRegister();
 
     TRI_ASSERT(!output.isFull());
-    output.copyValueInto(registerId, input, slice);
+    output.moveValueInto(registerId, input, slice);
     TRI_ASSERT(output.produced());
     output.advanceRow();
 
@@ -424,7 +424,7 @@ IndexIterator::DocumentCallback aql::getCallback(DocumentProducingCallbackVarian
       OutputAqlItemRow& output = context.getOutputRow();
       RegisterId registerId = context.getOutputRegister();
       TRI_ASSERT(!output.isFull());
-      output.copyValueInto(registerId, input, objectBuilder.slice());
+      output.moveValueInto<InputAqlItemRow, VPackSlice const>(registerId, input, objectBuilder.slice());
       TRI_ASSERT(output.produced());
       output.advanceRow();
     }

--- a/arangod/Aql/DocumentProducingHelper.h
+++ b/arangod/Aql/DocumentProducingHelper.h
@@ -29,6 +29,8 @@
 #include "Indexes/IndexIterator.h"
 #include "VocBase/voc-types.h"
 
+#include <velocypack/Builder.h>
+
 #include <functional>
 #include <string>
 #include <unordered_set>
@@ -119,6 +121,8 @@ struct DocumentProducingFunctionContext {
   
   aql::AqlFunctionsInternalCache& aqlFunctionsInternalCache() { return _aqlFunctionsInternalCache; }
 
+  arangodb::velocypack::Builder& getBuilder() noexcept;
+
  private:
   aql::AqlFunctionsInternalCache _aqlFunctionsInternalCache;
 
@@ -134,6 +138,9 @@ struct DocumentProducingFunctionContext {
   std::vector<size_t> const& _coveringIndexAttributePositions;
   size_t _numScanned;
   size_t _numFiltered;
+
+  /// @brief Builder that is reused to generate projections 
+  arangodb::velocypack::Builder _objectBuilder;
 
   /// @brief set of already returned documents. Used to make the result distinct
   std::unordered_set<TRI_voc_rid_t> _alreadyReturned;

--- a/arangod/Aql/OutputAqlItemRow.cpp
+++ b/arangod/Aql/OutputAqlItemRow.cpp
@@ -128,6 +128,22 @@ void OutputAqlItemRow::moveValueInto(RegisterId registerId, ItemRowType const& s
   }
 }
 
+void OutputAqlItemRow::copyValueInto(RegisterId registerId, InputAqlItemRow const& sourceRow,
+                                     VPackSlice value) {
+  TRI_ASSERT(isOutputRegister(registerId));
+  // This is already implicitly asserted by isOutputRegister:
+  TRI_ASSERT(registerId < getNrRegisters());
+  TRI_ASSERT(_numValuesWritten < numRegistersToWrite());
+  TRI_ASSERT(block().getValueReference(_baseIndex, registerId).isNone());
+
+  block().emplaceValue(_baseIndex, registerId, value);
+  _numValuesWritten++;
+
+  if (allValuesWritten()) {
+    copyRow(sourceRow);
+  }
+}
+
 void OutputAqlItemRow::consumeShadowRow(RegisterId registerId, ShadowAqlItemRow& sourceRow,
                                         AqlValueGuard& guard) {
   TRI_ASSERT(sourceRow.isRelevant());

--- a/arangod/Aql/OutputAqlItemRow.h
+++ b/arangod/Aql/OutputAqlItemRow.h
@@ -79,6 +79,10 @@ class OutputAqlItemRow {
   template <class ItemRowType>
   void moveValueInto(RegisterId registerId, ItemRowType const& sourceRow,
                      AqlValueGuard& guard);
+  
+  // Copies the given VPackSlice, so that the data is owned by the block.
+  void copyValueInto(RegisterId registerId, InputAqlItemRow const& sourceRow,
+                     arangodb::velocypack::Slice value);
 
   // Consume the given shadow row and transform it into a InputAqlItemRow
   // for the next consumer of this block.

--- a/arangod/Aql/OutputAqlItemRow.h
+++ b/arangod/Aql/OutputAqlItemRow.h
@@ -76,13 +76,9 @@ class OutputAqlItemRow {
   // Note that there is no real move happening here, just a trivial copy of
   // the passed AqlValue. However, that means the output block will take
   // responsibility of possibly referenced external memory.
-  template <class ItemRowType>
+  template <class ItemRowType, class ValueType>
   void moveValueInto(RegisterId registerId, ItemRowType const& sourceRow,
-                     AqlValueGuard& guard);
-  
-  // Copies the given VPackSlice, so that the data is owned by the block.
-  void copyValueInto(RegisterId registerId, InputAqlItemRow const& sourceRow,
-                     arangodb::velocypack::Slice value);
+                     ValueType& value);
 
   // Consume the given shadow row and transform it into a InputAqlItemRow
   // for the next consumer of this block.
@@ -281,8 +277,8 @@ class OutputAqlItemRow {
 
   /// @brief move the value into the given output registers and count the value
   /// as written in _numValuesWritten.
-  template <class ItemRowType>
-  void moveValueWithoutRowCopy(RegisterId registerId, AqlValueGuard& guard);
+  template <class ItemRowType, class ValueType>
+  void moveValueWithoutRowCopy(RegisterId registerId, ValueType& value);
 
   template <class ItemRowType>
   void memorizeRow(ItemRowType const& sourceRow);


### PR DESCRIPTION
### Scope & Purpose

When producing documents and using projections, recycle a velocypack::Builder
Additionally, use an optimized method for storing data in the target AqlItemBlock 

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *shell_server_aql*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10284/