### PR TITLE
make agency test less sensitive to timing

### DIFF
--- a/tests/js/client/agency/agency-test.js
+++ b/tests/js/client/agency/agency-test.js
@@ -905,21 +905,21 @@ function agencyTestSuite () {
       assertEqual(readAndCheck([["/a/y"]]), [{"a":{"y":12}}]);
       wait(1.1);
       assertEqual(readAndCheck([["/a/y"]]), [{a:{}}]);
-      writeAndCheck([[{"/a/y":{"op":"set","new":12, "ttl": 1}}]]);
+      writeAndCheck([[{"/a/y":{"op":"set","new":12, "ttl": 3}}]]);
       assertEqual(readAndCheck([["a/y"]]), [{"a":{"y":12}}]);
-      wait(1.1);
+      wait(3.1);
       assertEqual(readAndCheck([["/a/y"]]), [{a:{}}]);
       writeAndCheck([[{"foo/bar":{"op":"set","new":{"baz":12}}}]]);
       assertEqual(readAndCheck([["/foo/bar/baz"]]),
                   [{"foo":{"bar":{"baz":12}}}]);
       assertEqual(readAndCheck([["/foo/bar"]]), [{"foo":{"bar":{"baz":12}}}]);
       assertEqual(readAndCheck([["/foo"]]), [{"foo":{"bar":{"baz":12}}}]);
-      writeAndCheck([[{"foo/bar":{"op":"set","new":{"baz":12},"ttl":1}}]]);
-      wait(1.1);
+      writeAndCheck([[{"foo/bar":{"op":"set","new":{"baz":12},"ttl":3}}]]);
+      wait(3.1);
       assertEqual(readAndCheck([["/foo"]]), [{"foo":{}}]);
       assertEqual(readAndCheck([["/foo/bar"]]), [{"foo":{}}]);
       assertEqual(readAndCheck([["/foo/bar/baz"]]), [{"foo":{}}]);
-      writeAndCheck([[{"a/u":{"op":"set","new":25, "ttl": 2}}]]);
+      writeAndCheck([[{"a/u":{"op":"set","new":25, "ttl": 3}}]]);
       assertEqual(readAndCheck([["/a/u"]]), [{"a":{"u":25}}]);
       writeAndCheck([[{"a/u":{"op":"set","new":26}}]]);
       assertEqual(readAndCheck([["/a/u"]]), [{"a":{"u":26}}]);


### PR DESCRIPTION
### Scope & Purpose

Make one more agency test less sensitive to timing problems.
This should fix a spurious test failure that can happen in very slow/loaded environments.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest agency*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10294/