### PR TITLE
Fix behavior when restoring from a dump with an old format

### DIFF
--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -651,7 +651,9 @@ arangodb::Result restoreIndexes(arangodb::httpclient::SimpleHttpClient& httpClie
 
   arangodb::Result result{};
   VPackSlice const parameters = jobData.collection.get("parameters");
-  VPackSlice const indexes = jobData.collection.get("indexes");
+  VPackSlice const indexes = jobData.collection.get("indexes").isNone()
+                                 ? parameters.get("indexes")
+                                 : jobData.collection.get("indexes");
   // re-create indexes
   if (indexes.length() > 0) {
     // we actually have indexes


### PR DESCRIPTION
### Scope & Purpose

Fix an error in restore behavior when using an old dump format. Previously, index info was stored under the parameters object in the collection properties in the dump. This handles both the old format and the new one.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)

#### Related Information

- [ ] There is an internal planning ticket: BTS-84

### Testing & Verification

Jenkins: https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/10306/