### PR TITLE
fix a compile warning about different signedness

### DIFF
--- a/3rdParty/iresearch/core/iql/parser_context.cpp
+++ b/3rdParty/iresearch/core/iql/parser_context.cpp
@@ -111,7 +111,7 @@ parser::semantic_type parser_context::sequence(
   parser::location_type const& location
 ) {
   if (location.end.column < location.begin.column ||
-      m_sData.size() < location.end.column) {
+      m_sData.size() < static_cast<size_t>(location.end.column)) {
     return *const_cast<parser::semantic_type*>(&UNKNOWN); // index out of bounds
   }
 


### PR DESCRIPTION
### Scope & Purpose

Fixes compile warning
``` 
./3rdParty/iresearch/core/iql/parser_context.cpp: In member function ‘virtual iresearch::iql::parser::semantic_type iresearch::iql::parser_context::sequence(const location_type&)’:
./3rdParty/iresearch/core/iql/parser_context.cpp:114:22: warning: comparison of integer expressions of different signedness: ‘std::__cxx11::basic_string<char>::size_type’ {aka ‘long unsigned int’} and ‘const counter_type’ {aka ‘const int’} [-Wsign-compare]
  114 |       m_sData.size() < location.end.column) {
      |       ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
``` 

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10309/