### PR TITLE
use default destructors

### DIFF
--- a/arangod/RestServer/Metrics.h
+++ b/arangod/RestServer/Metrics.h
@@ -148,7 +148,7 @@ public:
     TRI_ASSERT(n > 1);
     _delim.resize(n-1);
   }
-  virtual ~scale_t() {}
+  virtual ~scale_t() = default;
   /**
    * @brief number of buckets
    */
@@ -236,7 +236,7 @@ public:
     TRI_ASSERT(_div > T(0));
     _lbase = log(_base);
   }
-  virtual ~log_scale_t() {}
+  virtual ~log_scale_t() = default;
   /**
    * @brief index for val
    * @param val value
@@ -286,7 +286,7 @@ public:
       i = le;
     }
   }
-  virtual ~lin_scale_t() {}
+  virtual ~lin_scale_t() = default;
   /**
    * @brief index for val
    * @param val value

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -150,7 +150,7 @@ StatisticsFeature::StatisticsFeature(application_features::ApplicationServer& se
   startsAfter<AqlFeaturePhase>();
 }
 
-StatisticsFeature::~StatisticsFeature() {} // required by unique_ptrs to incomplete types
+StatisticsFeature::~StatisticsFeature() = default;
 
 void StatisticsFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addOldOption("server.disable-statistics", "server.statistics");

--- a/lib/Basics/process-utils.h
+++ b/lib/Basics/process-utils.h
@@ -91,7 +91,7 @@ struct ExternalId {
   HANDLE _writePipe;
 
   ExternalId();
-  virtual ~ExternalId() {}
+  virtual ~ExternalId() = default;
 };
 #endif
 

--- a/lib/V8/v8-globals.cpp
+++ b/lib/V8/v8-globals.cpp
@@ -278,7 +278,7 @@ TRI_v8_global_t::SharedPtrPersistent::~SharedPtrPersistent() {
   );
 }
 
-TRI_v8_global_t::~TRI_v8_global_t() {}
+TRI_v8_global_t::~TRI_v8_global_t() = default;
 
 /// @brief creates a global context
 TRI_v8_global_t* TRI_CreateV8Globals(arangodb::application_features::ApplicationServer& server,


### PR DESCRIPTION
### Scope & Purpose

Use default destructors

- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10311/