### PR TITLE
explicitly define section "server" where it is needed.

### DIFF
--- a/arangod/Scheduler/SchedulerFeature.cpp
+++ b/arangod/Scheduler/SchedulerFeature.cpp
@@ -62,6 +62,7 @@ SchedulerFeature::~SchedulerFeature() {}
 
 void SchedulerFeature::collectOptions(std::shared_ptr<options::ProgramOptions> options) {
   options->addSection("scheduler", "Configure the I/O scheduler");
+  options->addSection("server", "Server features");
 
   options->addOption("--server.threads", "number of threads",
                      new UInt64Parameter(&_nrServerThreads));


### PR DESCRIPTION
### Scope & Purpose

This fix can prevent the startup error

    arangod terminated because of an exception: no section defined for program option --server.threads

from happening

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.
