### PR TITLE
don't force plan reload for analyzer revisions

### DIFF
--- a/arangod/ClusterEngine/ClusterTransactionState.cpp
+++ b/arangod/ClusterEngine/ClusterTransactionState.cpp
@@ -49,7 +49,7 @@ ClusterTransactionState::ClusterTransactionState(TRI_vocbase_t& vocbase,
   TRI_ASSERT(isCoordinator());
   acceptAnalyzersRevision(_vocbase.server()
     .getFeature< arangodb::iresearch::IResearchAnalyzerFeature>()
-    .getAnalyzersRevision(_vocbase, true)->getRevision());
+    .getAnalyzersRevision(_vocbase, false)->getRevision());
 }
 
 /// @brief start a transaction
@@ -95,12 +95,10 @@ Result ClusterTransactionState::commitTransaction(transaction::Methods* activeTr
     return Result(TRI_ERROR_DEBUG);
   }
 
-  arangodb::Result res;
-  
   updateStatus(transaction::Status::COMMITTED);
   _vocbase.server().getFeature<MetricsFeature>().serverStatistics()._transactionsStatistics._transactionsCommitted++;
 
-  return res;
+  return {};
 }
 
 /// @brief abort and rollback a transaction
@@ -111,5 +109,5 @@ Result ClusterTransactionState::abortTransaction(transaction::Methods* activeTrx
   updateStatus(transaction::Status::ABORTED);
   _vocbase.server().getFeature<MetricsFeature>().serverStatistics()._transactionsStatistics._transactionsAborted++;
   
-  return Result();
+  return {};
 }


### PR DESCRIPTION
### Scope & Purpose

Don't reload the plan forcefully to receive the latest revision of analyzers at the start of each cluster transaction.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *scripts/unittest gtests, scripts/unittest shell_server_aql --cluster true*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10313/
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10314/