### PR TITLE
Handle missing "shardingStrategy" in Plan agency entries for collections

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 devel
 -----
 
+* Handle missing "shardingStrategy" in Plan agency entries for collections.
+  "shardingStrategy" entries can be missing for collections created with
+  ArangoDB clusters in version 3.3 or earlier. A missing "shardingStrategy"
+  entry can cause issues for certain queries that need to check the shard
+  distribution on the DB-Servers.
+  This change transparently handles missing "shardingStrategy" entries.
+
 * Taken collection dropping from fast track in maintenance. This avoids
   blocking fast track maintenance threads when a shard cannot immediately
   be dropped because of some pending lock.

--- a/arangod/Sharding/ShardingFeature.cpp
+++ b/arangod/Sharding/ShardingFeature.cpp
@@ -152,11 +152,6 @@ std::string ShardingFeature::getDefaultShardingStrategy(ShardingInfo const* shar
   // TODO change these to use better algorithms when we no longer
   //      need to support collections created before 3.4
 
-  if (ServerState::instance()->isDBServer()) {
-    // on a DB server, we will not use sharding
-    return ShardingStrategyNone::NAME;
-  }
-
   // before 3.4, there were only hard-coded sharding strategies
 
   // no sharding strategy found in collection meta data


### PR DESCRIPTION
### Scope & Purpose

"shardingStrategy" entries can be missing for collections created with ArangoDB clusters in version 3.3 or earlier. A missing "shardingStrategy" entry can cause issues for certain queries that need to check the shard distribution on the DB-Servers.
This change transparently handles missing "shardingStrategy" entries.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [ ] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is a *JIRA Ticket number*: https://arangodb.atlassian.net/browse/ES-612 

### Testing & Verification

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10318/