### PR TITLE
Fixing supervision job id procedure.

### DIFF
--- a/arangod/Agency/Node.cpp
+++ b/arangod/Agency/Node.cpp
@@ -1269,11 +1269,6 @@ void Node::clear() {
 
 auto Node::getIntWithDefault(Slice slice, std::string_view key, std::int64_t def)
     -> std::int64_t {
-  if (slice.isObject()) {
-    Slice value = slice.get(key.data(), key.size());
-    if (value.isInt()) {
-      return value.getInt();
-    }
-  }
-  return def;
+  return arangodb::basics::VelocyPackHelper::getNumericValue<std::int64_t>(
+      slice, VPackStringRef(key.data(), key.size()), def);
 }

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -2446,7 +2446,7 @@ static std::string const syncLatest = "/Sync/LatestID";
 void Supervision::getUniqueIds() {
   _lock.assertLockedByCurrentThread();
 
-  size_t n = 10000;
+  int64_t n = 10000;
 
   std::string path = _agencyPrefix + "/Sync/LatestID";
   auto builder = std::make_shared<Builder>();


### PR DESCRIPTION
### Scope & Purpose

The agency could only handle signed int types encoded in velocypack. The supervision encoded the increment step for reserving unique ids as unsigned int. Thus the step parameter was ignored and `LatestID` was incremented by 1. The supervision assumed that it reserver 10000 unique ids and that the highest id was 1. Thus it initialized its first usable id with 18446744073709541628. (because ids are unsigned). In theory coordinators and the supervision could have created two different jobs with the same id.

### Testing & Verification

This was manually tested.