### PR TITLE
Remove old code for rolling upgrades. Fixes BTS-87.

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -5243,18 +5243,6 @@ ClusterInfo::ServersKnown::ServersKnown(VPackSlice const serversKnownSlice,
       }
     }
   }
-
-  // For backwards compatibility / rolling upgrades, add servers that aren't in
-  // ServersKnown but in ServersRegistered with a reboot ID of 0 as a fallback.
-  // We should be able to remove this in 3.6.
-  for (auto const& serverId : serverIds) {
-    auto const rv = _serversKnown.try_emplace(serverId, RebootId{0});
-    LOG_TOPIC_IF("0acbd", INFO, Logger::CLUSTER, rv.second)
-        << "Server " << serverId
-        << " is in Current/ServersRegistered, but not in "
-           "Current/ServersKnown. This is expected to happen "
-           "during a rolling upgrade.";
-  }
 }
 
 std::unordered_map<ServerID, ClusterInfo::ServersKnown::KnownServer> const&


### PR DESCRIPTION
### Scope & Purpose

Removed code for rolling upgrades that's not needed anymore. Removing this also fixes rebootIds possibly not working correctly when a server is being shutdown with `remove_from_cluster=1`.

- [X] Bug-Fix for *devel*
- [ ] Bug-Fix for a *released version* (Probably backport necessary)
- [ ] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [ ] The behavior change can be verified via automatic tests