### PR TITLE
Avoid useless erasure of AqlValues when a block is being destroyed

### DIFF
--- a/arangod/Aql/AqlItemBlock.cpp
+++ b/arangod/Aql/AqlItemBlock.cpp
@@ -296,9 +296,12 @@ void AqlItemBlock::destroy() noexcept {
     _shadowRowIndexes.clear();
 
     size_t totalUsed = 0;
-    for (auto const& it : _valueCount) {
-      if (ADB_LIKELY(it.second > 0)) {
-        totalUsed += it.first.memoryUsage();
+    for (auto& it : _valueCount) {
+      auto value = it.first;
+      auto const& count = it.second;
+      if (ADB_LIKELY(count > 0)) {
+        value.destroy();
+        totalUsed += value.memoryUsage();
       }
     }
     decreaseMemoryUsage(totalUsed);

--- a/arangod/Aql/AqlItemBlock.cpp
+++ b/arangod/Aql/AqlItemBlock.cpp
@@ -300,8 +300,8 @@ void AqlItemBlock::destroy() noexcept {
       auto const& count = it.second;
       if (ADB_LIKELY(count > 0)) {
         auto value = it.first;
-        value.destroy();
         totalUsed += value.memoryUsage();
+        value.destroy();
       }
     }
     decreaseMemoryUsage(totalUsed);

--- a/arangod/Aql/AqlItemBlock.cpp
+++ b/arangod/Aql/AqlItemBlock.cpp
@@ -297,9 +297,9 @@ void AqlItemBlock::destroy() noexcept {
 
     size_t totalUsed = 0;
     for (auto& it : _valueCount) {
-      auto value = it.first;
       auto const& count = it.second;
       if (ADB_LIKELY(count > 0)) {
+        auto value = it.first;
         value.destroy();
         totalUsed += value.memoryUsage();
       }


### PR DESCRIPTION
Minor change, avoid some useless work.