### PR TITLE
remove remainders of libcurl

### DIFF
--- a/lsan_arangodb_suppressions.txt
+++ b/lsan_arangodb_suppressions.txt
@@ -1,4 +1,2 @@
 leak:create_conn
-leak:curl_multi_perform
-leak:curl_multi_init
 leak:CRYPTO_zalloc


### PR DESCRIPTION
### Scope & Purpose

Removes remainders of libcurl from lsan_suppressions

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10360/