### PR TITLE
Unify isModificationNode and isModificationSubquery, delete some unnecessary code

### DIFF
--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -1946,7 +1946,7 @@ void SubqueryNode::invalidateCost() {
 }
 
 bool SubqueryNode::isConst() {
-  if (isModificationSubquery() || !isDeterministic()) {
+  if (isModificationNode() || !isDeterministic()) {
     return false;
   }
 
@@ -2039,7 +2039,7 @@ std::unique_ptr<ExecutionBlock> SubqueryNode::createBlock(
   // The const_cast has been taken from previous implementation.
   auto executorInfos =
       SubqueryExecutorInfos(*subquery, outReg, const_cast<SubqueryNode*>(this)->isConst());
-  if (isModificationSubquery()) {
+  if (isModificationNode()) {
     return std::make_unique<ExecutionBlockImpl<SubqueryExecutor<true>>>(
         &engine, this, std::move(registerInfos), std::move(executorInfos));
   } else {
@@ -2062,7 +2062,7 @@ ExecutionNode* SubqueryNode::clone(ExecutionPlan* plan, bool withDependencies,
 }
 
 /// @brief whether or not the subquery is a data-modification operation
-bool SubqueryNode::isModificationSubquery() const {
+bool SubqueryNode::isModificationNode() const {
   std::vector<ExecutionNode*> stack({_subquery});
 
   while (!stack.empty()) {

--- a/arangod/Aql/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode.h
@@ -833,8 +833,10 @@ class SubqueryNode : public ExecutionNode {
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
                        bool withProperties) const override final;
 
-  /// @brief whether or not the subquery is a data-modification operation
-  bool isModificationSubquery() const;
+  /// @brief this is true iff the subquery contains a data-modification operation
+  ///        NOTE that this is tested recursively, that is, if this subquery contains
+  ///        a subquery that contains a modification operation, this is true too.
+  bool isModificationNode() const override;
 
   /// @brief getter for subquery
   ExecutionNode* getSubquery() const;

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -2764,7 +2764,7 @@ void arangodb::aql::removeUnnecessaryCalculationsRule(Optimizer* opt,
         continue;
       }
 
-      if (nn->isModificationSubquery()) {
+      if (nn->isModificationNode()) {
         // subqueries that modify data must not be optimized away
         continue;
       }
@@ -6275,7 +6275,7 @@ void arangodb::aql::inlineSubqueriesRule(Optimizer* opt, std::unique_ptr<Executi
   for (auto const& n : nodes) {
     auto subqueryNode = ExecutionNode::castTo<SubqueryNode*>(n);
 
-    if (subqueryNode->isModificationSubquery()) {
+    if (subqueryNode->isModificationNode()) {
       // can't modify modifying subqueries
       continue;
     }
@@ -7352,7 +7352,7 @@ void arangodb::aql::optimizeSubqueriesRule(Optimizer* opt,
     TRI_ASSERT(node->getType() == EN::SUBQUERY);
     auto sn = ExecutionNode::castTo<SubqueryNode const*>(node);
 
-    if (sn->isModificationSubquery()) {
+    if (sn->isModificationNode()) {
       // cannot push a LIMIT into data-modification subqueries
       continue;
     }
@@ -7650,7 +7650,7 @@ void arangodb::aql::optimizeCountRule(Optimizer* opt,
             if (setter != nullptr && setter->getType() == EN::SUBQUERY) {
               // COUNT(subquery) / LENGTH(subquery)
               auto sn = ExecutionNode::castTo<SubqueryNode*>(setter);
-              if (sn->isModificationSubquery()) {
+              if (sn->isModificationNode()) {
                 // subquery modifies data
                 // cannot apply optimization for data-modification queries
                 return true;
@@ -8238,7 +8238,7 @@ void arangodb::aql::spliceSubqueriesRule(Optimizer* opt, std::unique_ptr<Executi
       // Create new end node
       auto end = plan->createNode<SubqueryEndNode>(plan.get(), plan->nextId(),
                                                    inVariable, sq->outVariable(),
-                                                   sq->isModificationSubquery());
+                                                   sq->isModificationNode());
       // start and end inherit this property from the subquery node
       end->setIsInSplicedSubquery(sq->isInSplicedSubquery());
       // insert a SubqueryEndNode after the SubqueryNode sq

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -8237,8 +8237,7 @@ void arangodb::aql::spliceSubqueriesRule(Optimizer* opt, std::unique_ptr<Executi
 
       // Create new end node
       auto end = plan->createNode<SubqueryEndNode>(plan.get(), plan->nextId(),
-                                                   inVariable, sq->outVariable(),
-                                                   sq->isModificationNode());
+                                                   inVariable, sq->outVariable());
       // start and end inherit this property from the subquery node
       end->setIsInSplicedSubquery(sq->isInSplicedSubquery());
       // insert a SubqueryEndNode after the SubqueryNode sq

--- a/arangod/Aql/SubqueryEndExecutionNode.cpp
+++ b/arangod/Aql/SubqueryEndExecutionNode.cpp
@@ -54,16 +54,13 @@ bool CompareVariables(Variable const* mine, Variable const* yours) {
 SubqueryEndNode::SubqueryEndNode(ExecutionPlan* plan, arangodb::velocypack::Slice const& base)
     : ExecutionNode(plan, base),
       _inVariable(Variable::varFromVPack(plan->getAst(), base, "inVariable", true)),
-      _outVariable(Variable::varFromVPack(plan->getAst(), base, "outVariable")),
-      _isModificationSubquery(basics::VelocyPackHelper::getBooleanValue(
-          base, "isModificationSubquery", false)) {}
+      _outVariable(Variable::varFromVPack(plan->getAst(), base, "outVariable")) {}
 
-SubqueryEndNode::SubqueryEndNode(ExecutionPlan* plan, ExecutionNodeId id, Variable const* inVariable,
-                                 Variable const* outVariable, bool isModificationSubquery)
+SubqueryEndNode::SubqueryEndNode(ExecutionPlan* plan, ExecutionNodeId id,
+                                 Variable const* inVariable, Variable const* outVariable)
     : ExecutionNode(plan, id),
       _inVariable(inVariable),
-      _outVariable(outVariable),
-      _isModificationSubquery(isModificationSubquery) {
+      _outVariable(outVariable) {
   // _inVariable might be nullptr
   TRI_ASSERT(_outVariable != nullptr);
 }
@@ -79,8 +76,6 @@ void SubqueryEndNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
     nodes.add(VPackValue("inVariable"));
     _inVariable->toVelocyPack(nodes);
   }
-
-  nodes.add("isModificationSubquery", VPackValue(isModificationNode()));
 
   nodes.close();
 }
@@ -106,7 +101,7 @@ std::unique_ptr<ExecutionBlock> SubqueryEndNode::createBlock(
 
   auto const& vpackOptions = engine.getQuery().vpackOptions();
   auto executorInfos =
-      SubqueryEndExecutorInfos(&vpackOptions, inReg, outReg, isModificationNode());
+      SubqueryEndExecutorInfos(&vpackOptions, inReg, outReg);
 
   return std::make_unique<ExecutionBlockImpl<SubqueryEndExecutor>>(
       &engine, this, std::move(registerInfos), std::move(executorInfos));
@@ -123,8 +118,7 @@ ExecutionNode* SubqueryEndNode::clone(ExecutionPlan* plan, bool withDependencies
       inVariable = plan->getAst()->variables()->createVariable(inVariable);
     }
   }
-  auto c = std::make_unique<SubqueryEndNode>(plan, _id, inVariable, outVariable,
-                                             isModificationNode());
+  auto c = std::make_unique<SubqueryEndNode>(plan, _id, inVariable, outVariable);
 
   return cloneHelper(std::move(c), withDependencies, withProperties);
 }
@@ -150,8 +144,7 @@ bool SubqueryEndNode::isEqualTo(ExecutionNode const& other) const {
     SubqueryEndNode const& p = dynamic_cast<SubqueryEndNode const&>(other);
     TRI_ASSERT(p._outVariable != nullptr);
     if (!CompareVariables(_outVariable, p._outVariable) ||
-        !CompareVariables(_inVariable, p._inVariable) ||
-        _isModificationSubquery != p._isModificationSubquery) {
+        !CompareVariables(_inVariable, p._inVariable)) {
       // One of the variables does not match
       return false;
     }
@@ -162,6 +155,14 @@ bool SubqueryEndNode::isEqualTo(ExecutionNode const& other) const {
   }
 }
 
+// NOTE: A SubqueryEndNode should never be asked whether its a modification
+//       node, as this information is supposed to be used in optimizer rules,
+//       and subquery splicing runs as the *last* optimizer rule in any case.
+//
+//       If this assumption is changed, you will need to make an implementation
+//       of this function that makes sense (for example by deriving the isModificationNode
+//       from the SubqueryNode).
 bool SubqueryEndNode::isModificationNode() const {
-  return _isModificationSubquery;
+  TRI_ASSERT(false);
+  return false;
 }

--- a/arangod/Aql/SubqueryEndExecutionNode.h
+++ b/arangod/Aql/SubqueryEndExecutionNode.h
@@ -38,7 +38,7 @@ class SubqueryEndNode : public ExecutionNode {
   SubqueryEndNode(ExecutionPlan*, arangodb::velocypack::Slice const& base);
 
   SubqueryEndNode(ExecutionPlan* plan, ExecutionNodeId id, Variable const* inVariable,
-                  Variable const* outVariable, bool isModificationSubquery);
+                  Variable const* outVariable);
 
   CostEstimate estimateCost() const override final;
 
@@ -71,12 +71,15 @@ class SubqueryEndNode : public ExecutionNode {
   }
 
   void replaceOutVariable(Variable const* var);
+
+  // We only override this to TRI_ASSERT(false), because
+  // noone should ever ask this node whether it is a modification
+  // node
   bool isModificationNode() const override;
 
  private:
   Variable const* _inVariable;
   Variable const* _outVariable;
-  bool _isModificationSubquery;
 };
 
 }  // namespace aql

--- a/arangod/Aql/SubqueryEndExecutor.cpp
+++ b/arangod/Aql/SubqueryEndExecutor.cpp
@@ -40,12 +40,10 @@ using namespace arangodb;
 using namespace arangodb::aql;
 
 SubqueryEndExecutorInfos::SubqueryEndExecutorInfos(velocypack::Options const* const options,
-                                                   RegisterId inReg, RegisterId outReg,
-                                                   bool isModificationSubquery)
+                                                   RegisterId inReg, RegisterId outReg)
     : _vpackOptions(options),
       _outReg(outReg),
-      _inReg(inReg),
-      _isModificationSubquery(isModificationSubquery) {}
+      _inReg(inReg) {}
 
 SubqueryEndExecutorInfos::~SubqueryEndExecutorInfos() = default;
 
@@ -63,10 +61,6 @@ RegisterId SubqueryEndExecutorInfos::getOutputRegister() const noexcept {
 
 RegisterId SubqueryEndExecutorInfos::getInputRegister() const noexcept {
   return _inReg;
-}
-
-bool SubqueryEndExecutorInfos::isModificationSubquery() const noexcept {
-  return _isModificationSubquery;
 }
 
 SubqueryEndExecutor::SubqueryEndExecutor(Fetcher&, SubqueryEndExecutorInfos& infos)
@@ -123,10 +117,6 @@ auto SubqueryEndExecutor::consumeShadowRow(ShadowAqlItemRow shadowRow,
   AqlValue value;
   AqlValueGuard guard = _accumulator.stealValue(value);
   output.consumeShadowRow(_infos.getOutputRegister(), shadowRow, guard);
-}
-
-auto SubqueryEndExecutor::isModificationSubquery() const noexcept -> bool {
-  return _infos.isModificationSubquery();
 }
 
 void SubqueryEndExecutor::Accumulator::reset() {

--- a/arangod/Aql/SubqueryEndExecutor.h
+++ b/arangod/Aql/SubqueryEndExecutor.h
@@ -45,7 +45,7 @@ class SingleRowFetcher;
 class SubqueryEndExecutorInfos {
  public:
   SubqueryEndExecutorInfos(velocypack::Options const* options, RegisterId inReg,
-                           RegisterId outReg, bool isModificationSubquery);
+                           RegisterId outReg);
 
   SubqueryEndExecutorInfos() = delete;
   SubqueryEndExecutorInfos(SubqueryEndExecutorInfos&&) = default;
@@ -56,13 +56,11 @@ class SubqueryEndExecutorInfos {
   [[nodiscard]] RegisterId getOutputRegister() const noexcept;
   [[nodiscard]] bool usesInputRegister() const noexcept;
   [[nodiscard]] RegisterId getInputRegister() const noexcept;
-  [[nodiscard]] bool isModificationSubquery() const noexcept;
 
  private:
   velocypack::Options const* _vpackOptions;
   RegisterId const _outReg;
   RegisterId const _inReg;
-  bool const _isModificationSubquery;
 };
 
 class SubqueryEndExecutor {
@@ -102,8 +100,6 @@ class SubqueryEndExecutor {
    * @param output Output block
    */
   auto consumeShadowRow(ShadowAqlItemRow shadowRow, OutputAqlItemRow& output) -> void;
-
-  [[nodiscard]] auto isModificationSubquery() const noexcept -> bool;
 
  private:
   enum class State {

--- a/arangod/Aql/SubqueryStartExecutionNode.h
+++ b/arangod/Aql/SubqueryStartExecutionNode.h
@@ -58,13 +58,10 @@ class SubqueryStartNode : public ExecutionNode {
 
   bool isEqualTo(ExecutionNode const& other) const override final;
 
-  bool isModificationSubqueryNode();
-
  private:
   /// @brief This is only required for Explain output.
   ///        it has no practical usage other then to print this information during explain.
   Variable const* _subqueryOutVariable;
-  bool _isModificationSubquery;
 };
 
 }  // namespace aql

--- a/tests/Aql/CountCollectExecutorTest.cpp
+++ b/tests/Aql/CountCollectExecutorTest.cpp
@@ -105,7 +105,7 @@ class CountCollectExecutorTest
   auto MakeSubqueryEndExecutorInfos(RegisterId inputRegister) -> SubqueryEndExecutor::Infos {
     auto const outputRegister = RegisterId{inputRegister + 1};
 
-    return SubqueryEndExecutor::Infos(nullptr, inputRegister, outputRegister, false);
+    return SubqueryEndExecutor::Infos(nullptr, inputRegister, outputRegister);
   }
 
   auto MakeRemoveAllLinesRegisterInfos() -> RegisterInfos {

--- a/tests/Aql/ExecutionNodeTest.cpp
+++ b/tests/Aql/ExecutionNodeTest.cpp
@@ -92,7 +92,7 @@ TEST_F(ExecutionNodeTest, end_node_velocypack_roundtrip_no_invariable) {
   std::unique_ptr<SubqueryEndNode> node, nodeFromVPack;
   std::unordered_set<ExecutionNode const*> seen{};
 
-  node = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{0}, nullptr, &outvar, false);
+  node = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{0}, nullptr, &outvar);
   node->setVarsUsedLater({{}});
   node->setVarsValid({{}});
   node->setRegsToKeep({{}});
@@ -118,7 +118,7 @@ TEST_F(ExecutionNodeTest, end_node_velocypack_roundtrip_invariable) {
   std::unique_ptr<SubqueryEndNode> node, nodeFromVPack;
   std::unordered_set<ExecutionNode const*> seen{};
 
-  node = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{0}, &invar, &outvar, false);
+  node = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{0}, &invar, &outvar);
   node->setVarsUsedLater({{}});
   node->setVarsValid({{}});
   node->setRegsToKeep({{}});
@@ -140,8 +140,8 @@ TEST_F(ExecutionNodeTest, end_node_not_equal_different_id) {
 
   Variable outvar("name", 1, false);
 
-  node1 = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{0}, nullptr, &outvar, false);
-  node2 = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{1}, nullptr, &outvar, false);
+  node1 = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{0}, nullptr, &outvar);
+  node2 = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{1}, nullptr, &outvar);
 
   ASSERT_FALSE(node1->isEqualTo(*node2));
 }
@@ -152,8 +152,8 @@ TEST_F(ExecutionNodeTest, end_node_not_equal_invariable_null_vs_non_null) {
   Variable outvar("name", 1, false);
   Variable invar("otherName", 2, false);
 
-  node1 = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{0}, &invar, &outvar, false);
-  node2 = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{1}, nullptr, &outvar, false);
+  node1 = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{0}, &invar, &outvar);
+  node2 = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{1}, nullptr, &outvar);
 
   ASSERT_FALSE(node1->isEqualTo(*node2));
   // Bidirectional nullptr check
@@ -167,8 +167,8 @@ TEST_F(ExecutionNodeTest, end_node_not_equal_invariable_differ) {
   Variable invar("otherName", 2, false);
   Variable otherInvar("invalidName", 3, false);
 
-  node1 = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{0}, &invar, &outvar, false);
-  node2 = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{1}, &otherInvar, &outvar, false);
+  node1 = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{0}, &invar, &outvar);
+  node2 = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{1}, &otherInvar, &outvar);
 
   ASSERT_FALSE(node1->isEqualTo(*node2));
   // Bidirectional check
@@ -181,8 +181,8 @@ TEST_F(ExecutionNodeTest, end_node_not_equal_outvariable_differ) {
   Variable outvar("name", 1, false);
   Variable otherOutvar("otherName", 2, false);
 
-  node1 = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{0}, nullptr, &outvar, false);
-  node2 = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{1}, nullptr, &otherOutvar, false);
+  node1 = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{0}, nullptr, &outvar);
+  node2 = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{1}, nullptr, &otherOutvar);
 
   ASSERT_FALSE(node1->isEqualTo(*node2));
   // Bidirectional check

--- a/tests/Aql/SplicedSubqueryIntegrationTest.cpp
+++ b/tests/Aql/SplicedSubqueryIntegrationTest.cpp
@@ -116,7 +116,7 @@ class SplicedSubqueryIntegrationTest
   auto makeSubqueryEndExecutorInfos(RegisterId inputRegister) -> SubqueryEndExecutor::Infos {
     auto const outputRegister = RegisterId{inputRegister + 1};
 
-    return SubqueryEndExecutor::Infos(nullptr, inputRegister, outputRegister, false);
+    return SubqueryEndExecutor::Infos(nullptr, inputRegister, outputRegister);
   }
 
   auto makeDoNothingRegisterInfos() -> RegisterInfos {

--- a/tests/Aql/SubqueryEndExecutorTest.cpp
+++ b/tests/Aql/SubqueryEndExecutorTest.cpp
@@ -46,7 +46,7 @@ using RegisterSet = std::unordered_set<RegisterId>;
 class SubqueryEndExecutorTest : public ::testing::Test {
  public:
   SubqueryEndExecutorTest()
-      : _infos(nullptr, RegisterId{0}, RegisterId{0}, false) {}
+      : _infos(nullptr, RegisterId{0}, RegisterId{0}) {}
 
  protected:
   ResourceMonitor monitor;


### PR DESCRIPTION
This PR merges the concepts of a "modification node" and a "modification subquery": a node is now a modification node (maybe a bit of a misnomer),  if

 * it is one of `InsertNode`, `UpdateNode`, `RemoveNode` or `UpsertNode` or
 * a `SubqueryNode` that contains a modification node

*NOTE* that this means that in the situation where we have `SubqueryNode1 -> SubqueryNode2 -> InsertNode`, this means that `SubqueryNode1` *and* `SubqueryNode2` are modification nodes. 

This is a change to the previous behaviour where `SubqueryNode1` would *not* have been a modification subquery, leading to wrong behaviouir of optimizer rules and executors.  