### PR TITLE
pick up write concern from UI

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Pick up selected "write concern" value entered in web UI when creating a
+  collection in the cluster. Previously, the "write concern" value was not 
+  picked up correctly and collections were created with the default write
+  concern.
+
 * Fixed velocypack validator for proper check of keys.
 
 * Handle missing "shardingStrategy" in Plan agency entries for collections.

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/collections/arangoCollections.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/collections/arangoCollections.js
@@ -179,11 +179,11 @@
         }
       }
 
-      if (object.minReplicationFactor) {
-        data.minReplicationFactor = object.minReplicationFactor;
-        if (pattern.test(object.minReplicationFactor)) {
+      if (object.writeConcern) {
+        data.writeConcern = object.writeConcern;
+        if (pattern.test(object.writeConcern)) {
           // looks like a number
-          data.minReplicationFactor = JSON.parse(object.minReplicationFactor);
+          data.writeConcern = JSON.parse(object.writeConcern);
         }
       }
 


### PR DESCRIPTION
### Scope & Purpose

Pick up selected "write concern" value entered in web UI when creating a collection in the cluster. Previously, the "write concern" value was not picked up correctly and collections were created with the default write concern.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

- [x] There is an internal planning ticket: https://github.com/arangodb/release-qa/issues/317#issuecomment-640830927

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10375/