### PR TITLE
don't mangle AQL errors in web UI graph viewer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Pass through AQL query errors to UI graph viewer without turning them into
+  "Internal Server Error"s.
+
 * Fixed velocypack validator for proper check of keys.
 
 * Handle missing "shardingStrategy" in Plan agency entries for collections.

--- a/js/apps/system/_admin/aardvark/APP/aardvark.js
+++ b/js/apps/system/_admin/aardvark/APP/aardvark.js
@@ -590,7 +590,7 @@ authRouter.get('/graph/:name', function (req, res) {
   };
 
   var multipleIds;
-  var startVertex; // will be "randomly" choosen if no start vertex is specified
+  var startVertex; // will be "randomly" chosen if no start vertex is specified
 
   if (config.nodeStart) {
     if (config.nodeStart.indexOf(' ') > -1) {
@@ -612,7 +612,7 @@ authRouter.get('/graph/:name', function (req, res) {
   var limit = 0;
   if (config.limit !== undefined) {
     if (config.limit.length > 0 && config.limit !== '0') {
-      limit = config.limit;
+      limit = parseInt(config.limit);
     }
   }
 
@@ -635,6 +635,8 @@ authRouter.get('/graph/:name', function (req, res) {
     var aqlQuery;
     var aqlQueries = [];
 
+    let depth = parseInt(config.depth);
+
     if (config.query) {
       aqlQuery = config.query;
     } else {
@@ -642,11 +644,11 @@ authRouter.get('/graph/:name', function (req, res) {
         /* TODO: uncomment after #75 fix
           aqlQuery =
             'FOR x IN ' + JSON.stringify(multipleIds) + ' ' +
-            'FOR v, e, p IN 1..' + (config.depth || '2') + ' ANY x GRAPH "' + name + '"';
+            'FOR v, e, p IN 1..' + (depth || '2') + ' ANY x GRAPH "' + name + '"';
         */
         _.each(multipleIds, function (nodeid) {
           aqlQuery =
-            'FOR v, e, p IN 1..' + (config.depth || '2') + ' ANY "' + nodeid + '" GRAPH "' + name + '"';
+            'FOR v, e, p IN 1..' + (depth || '2') + ' ANY ' + JSON.stringify(nodeid) + ' GRAPH ' + JSON.stringify(name);
           if (limit !== 0) {
             aqlQuery += ' LIMIT ' + limit;
           }
@@ -655,7 +657,7 @@ authRouter.get('/graph/:name', function (req, res) {
         });
       } else {
         aqlQuery =
-          'FOR v, e, p IN 1..' + (config.depth || '2') + ' ANY "' + startVertex._id + '" GRAPH "' + name + '"';
+          'FOR v, e, p IN 1..' + (depth || '2') + ' ANY ' + JSON.stringify(startVertex._id) + ' GRAPH ' + JSON.stringify(name);
         if (limit !== 0) {
           aqlQuery += ' LIMIT ' + limit;
         }
@@ -714,18 +716,23 @@ authRouter.get('/graph/:name', function (req, res) {
         }
       });
     } else {
-    // get all nodes and edges which are connected to the given start node
-      if (aqlQueries.length === 0) {
-        cursor = AQL_EXECUTE(aqlQuery);
-      } else {
-        var x;
-        cursor = AQL_EXECUTE(aqlQueries[0]);
-        for (var k = 1; k < aqlQueries.length; k++) {
-          x = AQL_EXECUTE(aqlQueries[k]);
-          _.each(x.json, function (val) {
-            cursor.json.push(val);
-          });
+      // get all nodes and edges which are connected to the given start node
+      try {
+        if (aqlQueries.length === 0) {
+          cursor = AQL_EXECUTE(aqlQuery);
+        } else {
+          var x;
+          cursor = AQL_EXECUTE(aqlQueries[0]);
+          for (var k = 1; k < aqlQueries.length; k++) {
+            x = AQL_EXECUTE(aqlQueries[k]);
+            _.each(x.json, function (val) {
+              cursor.json.push(val);
+            });
+          }
         }
+      } catch (e) {
+        const error = new ArangoError({errorNum: e.errorNum, errorMessage: e.errorMessage});
+        res.throw(actions.arangoErrorToHttpCode(e.errorNum), error);
       }
     }
 


### PR DESCRIPTION
### Scope & Purpose

Pass through proper AQL errors to web UI graph viewer, instead of turning them into HTTP 500 "Internal Server Error"s.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

- [x] There is an internal planning ticket: https://github.com/arangodb/release-qa/issues/317#issuecomment-640894681

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10380/