### PR TITLE
elevate permissions for analyzers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@ devel
 
 * Added permissions check before trying to read data from `_analyzers` collection.
   If these permissions are not there, no load is performed (user can not use analyzers from 
-  database anyway)
+  database anyway).
 
 * Updated arangosync to 0.7.6.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,9 @@
 devel
 -----
 
-* Temporarily elevate permissions to read data from `_analyzers` collection.
-  If these permissions are not there, view creation can fail for users
-  that do not have read permissions in the `_system` database.
+* Added permissions chek before trying to read data from `_analyzers` collection.
+  If these permissions are not there, no load is performed (user can not use analyzers from 
+  database anyway)
 
 * Updated arangosync to 0.7.6.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,10 @@
 devel
 -----
 
-* Added permissions check before trying to read data from `_analyzers` collection.
-  If these permissions are not there, no load is performed (user can not use analyzers from 
-  database anyway).
+* Added permissions check before trying to read data from `_analyzers`
+  collection.
+  If these permissions are not there, no load is performed (user can not use
+  analyzers from database anyway).
 
 * Updated arangosync to 0.7.6.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 devel
 -----
 
-* Added permissions chek before trying to read data from `_analyzers` collection.
+* Added permissions check before trying to read data from `_analyzers` collection.
   If these permissions are not there, no load is performed (user can not use analyzers from 
   database anyway)
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Temporarily elevate permissions to read data from `_analyzers` collection.
+  If these permissions are not there, view creation can fail for users
+  that do not have read permissions in the `_system` database.
+
 * Updated arangosync to 0.7.6.
 
 * Make the reboot tracker catch a failed server and permanently removed

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -723,6 +723,11 @@ bool equalAnalyzer(
 arangodb::Result visitAnalyzers(
     TRI_vocbase_t& vocbase,
     std::function<arangodb::Result(VPackSlice const&)> const& visitor) {
+
+  // temporarily changes to superuser mode, in order to be able to enumerate
+  // all analyzers even from the _system database
+  arangodb::ExecContextSuperuserScope scope;
+
   static const auto resultVisitor = [](
       std::function<arangodb::Result(VPackSlice const&)> const& visitor,
       TRI_vocbase_t const& vocbase,

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -1930,7 +1930,7 @@ Result IResearchAnalyzerFeature::loadAvailableAnalyzers(irs::string_ref const& d
   }
   if (dbName != arangodb::StaticStrings::SystemDatabase &&
       canUseVocbase(arangodb::StaticStrings::SystemDatabase, auth::Level::RO)) {
-    // System is available for all other databases. So reload it`s analyzers too
+    // System is available for all other databases. So reload its analyzers too
     res = loadAnalyzers(arangodb::StaticStrings::SystemDatabase);
   }
   return res;

--- a/arangod/IResearch/IResearchAnalyzerFeature.h
+++ b/arangod/IResearch/IResearchAnalyzerFeature.h
@@ -160,6 +160,14 @@ class IResearchAnalyzerFeature final
   static bool canUse(TRI_vocbase_t const& vocbase, auth::Level const& level);
 
   //////////////////////////////////////////////////////////////////////////////
+  /// @brief check permissions for analyzer usage from vocbase by name
+  /// @param vocbaseName  vocbase name to check
+  /// @param level access level
+  /// @return analyzers in the specified vocbase are granted 'level' access
+  //////////////////////////////////////////////////////////////////////////////
+  static bool canUseVocbase(irs::string_ref const& vocbaseName, auth::Level const& level);
+
+  //////////////////////////////////////////////////////////////////////////////
   /// @brief check permissions
   /// @param name analyzer name (already normalized)
   /// @param level access level

--- a/tests/js/client/authentication/auth-analyzer-view-integration.js
+++ b/tests/js/client/authentication/auth-analyzer-view-integration.js
@@ -1,0 +1,62 @@
+/*jshint globalstrict:false, strict:false */
+/* global assertTrue, assertFalse, assertEqual, assertMatch, fail, arango */
+
+const jsunity = require('jsunity');
+const internal = require('internal');
+const error = internal.errors;
+const print = internal.print;
+const arango = internal.arango;
+
+const db = require("@arangodb").db;
+const users = require('@arangodb/users');
+const helper = require('@arangodb/user-helper');
+const endpoint = arango.getEndpoint();
+
+function testSuite() {
+  const user = 'bob';
+  const system = "_system";
+
+  const name = "TestAuthAnalyzer";
+
+  return {
+    setUp: function() {
+      helper.switchUser("root", system);
+      try {
+        users.remove(user);
+      } catch (err) {}
+      
+      try {
+        db._dropDatabase(name);
+      } catch (err) {}
+    },
+
+    tearDown: function() {
+      helper.switchUser("root", system);
+      try {
+        db._dropDatabase(name);
+      } catch (err) {}
+
+      try {
+        users.remove(user);
+      } catch (err) {}
+    },
+
+    testIntegration : function() {
+      db._createDatabase(name);
+    
+      users.save(user, "", true); 
+      users.grantDatabase(user, name, "rw"); 
+
+      helper.switchUser(user, name);
+    
+      db._createView("test", "arangosearch", {});
+    
+      let view = db._view("test");
+      view.properties({links:{}});
+    },
+
+  };
+} 
+
+jsunity.run(testSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Temporarily elevate permissions for analyzers.
This seems to be required in order to create views in other databases than `_system`, with users that do not have privileges to access the `_system` database.
When creating a new view, all analyzers a queried via an AQL qurery `FOR d IN _analyzers RETURN d`, which reads them from the `_analyzers` collection in the `_system` database. Without privileges to read from that collection, the query and thus the view creation fails.
This PR temporarily elevates the privileges for executing that query.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in scripts/unittest authentication)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10416/