### PR TITLE
Bug fix 3.7/smarter ui default value for replication factor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,11 @@ v3.7.1-rc.1 (XXXX-XX-XX)
   If these permissions are not there, no load is performed (user can not use
   analyzers from database anyway).
 
+* Use smarter default value preset in web UI for replication factor in case
+  there are constraints established for the replication factor by the
+  startup options `--cluster.min-replication-factor` and 
+  `--cluster.max-replication-factor`.
+
 * Updated arangosync to 0.7.6.
 
 * Make the reboot tracker catch a failed server and permanently removed servers.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,15 +1,15 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
+* Use smarter default value preset in web UI for replication factor in case
+  there are constraints established for the replication factor by the startup
+  options `--cluster.min-replication-factor` and
+  `--cluster.max-replication-factor`.
+
 * Added permissions check before trying to read data from `_analyzers`
   collection.
   If these permissions are not there, no load is performed (user can not use
   analyzers from database anyway).
-
-* Use smarter default value preset in web UI for replication factor in case
-  there are constraints established for the replication factor by the
-  startup options `--cluster.min-replication-factor` and 
-  `--cluster.max-replication-factor`.
 
 * Updated arangosync to 0.7.6.
 

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/collectionsView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/collectionsView.js
@@ -592,25 +592,35 @@
             );
           
             if (window.App.isCluster) {
+              var minReplicationFactor = (this.minReplicationFactor ? this.minReplicationFactor : 1); 
+              var maxReplicationFactor = (this.maxReplicationFactor ? this.maxReplicationFactor : 10); 
+
+              // clamp replicationFactor between min & max allowed values
+              var replicationFactor = '';
+              if (properties.replicationFactor) {
+                replicationFactor = parseInt(properties.replicationFactor);
+                if (replicationFactor < minReplicationFactor) {
+                  replicationFactor = minReplicationFactor;
+                }
+                if (replicationFactor > maxReplicationFactor) {
+                  replicationFactor = maxReplicationFactor;
+                }
+              }
+
               tableContent.push(
                 window.modalView.createTextEntry(
                   'new-replication-factor',
                   'Replication factor',
-                  properties.replicationFactor ? properties.replicationFactor : '',
-                  'Numeric value. Must be between ' + 
-                  (this.minReplicationFactor ? this.minReplicationFactor : 1) + 
-                  ' and ' + 
-                  (this.maxReplicationFactor ? this.maxReplicationFactor : 10) +
-                  '. Total number of copies of the data in the cluster',
+                  String(replicationFactor),
+                  'Numeric value. Must be between ' + minReplicationFactor + ' and ' + 
+                  maxReplicationFactor + '. Total number of copies of the data in the cluster',
                   '',
                   false,
                   [
                     {
                       rule: Joi.string().allow('').optional().regex(/^[1-9][0-9]*$/),
-                      msg: 'Must be a number between ' + 
-                           (this.minReplicationFactor ? this.minReplicationFactor : 1) + 
-                           ' and ' + 
-                           (this.maxReplicationFactor ? this.maxReplicationFactor : 10) + '.'
+                      msg: 'Must be a number between ' + minReplicationFactor +  
+                           ' and ' + maxReplicationFactor + '.'
                     }
                   ]
                 )


### PR DESCRIPTION
### Scope & Purpose

Use smarter default value preset in web UI for replication factor in case there are constraints established for the replication factor by the startup options `--cluster.min-replication-factor` and `--cluster.max-replication-factor`.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10437/