### PR TITLE
fix a memleak that only happens in tests due to mocking

### DIFF
--- a/arangod/Transaction/Context.cpp
+++ b/arangod/Transaction/Context.cpp
@@ -92,18 +92,34 @@ transaction::Context::~Context() {
                                                                   _transaction.isReadOnlyTransaction);
   }
 
+  // call the actual cleanup routine which frees all
+  // hogged resources
+  cleanup();
+}
+  
+/// @brief destroys objects owned by the context,
+/// this can be called multiple times.
+/// currently called by dtor and by unit test mocks. 
+/// we cannot move this into the dtor (where it was before) because
+/// the mocked objects in unittests do not seem to call it and effectively leak.
+void transaction::Context::cleanup() noexcept {
   // free all VPackBuilders we handed out
   for (auto& it : _builders) {
     delete it;
   }
+  _builders.clear();
 
   // clear all strings handed out
   for (auto& it : _strings) {
     delete it;
   }
+  _strings.clear();
+
+  _stringBuffer.reset();
 
   if (_ownsResolver) {
     delete _resolver;
+    _resolver = nullptr;
   }
 }
 

--- a/arangod/Transaction/Context.h
+++ b/arangod/Transaction/Context.h
@@ -66,6 +66,13 @@ class Context {
  public:
   /// @brief destroy the context
   virtual ~Context();
+  
+  /// @brief destroys objects owned by the context,
+  /// this can be called multiple times.
+  /// currently called by dtor and by unit test mocks. 
+  /// we cannot move this into the dtor (where it was before) because
+  /// the mocked objects in unittests do not seem to call it and effectively leak.
+  void cleanup() noexcept;
 
   /// @brief factory to create a custom type handler, not managed
   static std::unique_ptr<arangodb::velocypack::CustomTypeHandler> createCustomTypeHandler(


### PR DESCRIPTION
### Scope & Purpose

Fixes the following memleak when executing the gtests:
``` 
Direct leak of 64 byte(s) in 2 object(s) allocated from:
    #0 0x7fb5eb5b3947 in operator new(unsigned long) (/lib/x86_64-linux-gnu/libasan.so.5+0x10f947)
    #1 0x55decd5b5640 in arangodb::transaction::Context::leaseStringBuffer(unsigned long) /home/jsteemann/ArangoAsan/arangod/Transaction/Context.cpp:135
    #2 0x55decd5d1e44 in arangodb::transaction::StringBufferLeaser::StringBufferLeaser(arangodb::transaction::Methods*) /home/jsteemann/ArangoAsan/arangod/Transaction/Helpers.cpp:429
    #3 0x55ded000060b in arangodb::aql::Functions::LevenshteinDistance(arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*, std::vector<arangodb::aql::AqlValue, short_alloc<arangodb::aql::AqlValue, 64ul, 8ul> > const&) /home/jsteemann/ArangoAsan/arangod/Aql/Functions.cpp:1548

Indirect leak of 84 byte(s) in 2 object(s) allocated from:
    #0 0x7fb5eb5b1bc8 in malloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10dbc8)
    #1 0x55ded4515f4b in TRI_Allocate(unsigned long) /home/jsteemann/ArangoAsan/lib/Basics/memory.cpp:40
    #2 0x55ded4515f4b in TRI_Reallocate(void*, unsigned long) /home/jsteemann/ArangoAsan/lib/Basics/memory.cpp:58
    #3 0x55ded43daebd in Reserve /home/jsteemann/ArangoAsan/lib/Basics/StringBuffer.cpp:52
    #4 0x55ded43daebd in TRI_InitSizedStringBuffer(TRI_string_buffer_t*, unsigned long, bool) /home/jsteemann/ArangoAsan/lib/Basics/StringBuffer.cpp:139
    #5 0x55decd5b5660 in arangodb::basics::StringBuffer::StringBuffer(unsigned long, bool) /home/jsteemann/ArangoAsan/lib/Basics/StringBuffer.h:267
    #6 0x55decd5b5660 in arangodb::transaction::Context::leaseStringBuffer(unsigned long) /home/jsteemann/ArangoAsan/arangod/Transaction/Context.cpp:135
    #7 0x55decd5d1e44 in arangodb::transaction::StringBufferLeaser::StringBufferLeaser(arangodb::transaction::Methods*) /home/jsteemann/ArangoAsan/arangod/Transaction/Helpers.cpp:429
    #8 0x55ded000060b in arangodb::aql::Functions::LevenshteinDistance(arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*, std::vector<arangodb::aql::AqlValue, short_alloc<arangodb::aql::AqlValue, 64ul, 8ul> > const&) /home/jsteemann/ArangoAsan/arangod/Aql/Functions.cpp:1548
```

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] The behavior change can be verified via automatic tests

### Testing & Verification

Test plan: run gtests with LSan - should produce no leaks by ArangoDB code

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10453/