### PR TITLE
fix internal test helper function `removeCost`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fix internal test helper function `removeCost` to really remove costs.
+
 * Use smarter default value preset in web UI for replication factor in case
   there are constraints established for the replication factor by the
   startup options `--cluster.min-replication-factor` and 

--- a/js/server/modules/@arangodb/aql-helper.js
+++ b/js/server/modules/@arangodb/aql-helper.js
@@ -388,12 +388,11 @@ function removeCost (obj) {
   if (Array.isArray(obj)) {
     return obj.map(removeCost);
   } else if (typeof obj === 'object') {
-    var result = {};
+    let result = {};
     for (var key in obj) {
-      if (obj.hasOwnProperty(key)) {
-        if (key !== "estimatedCost" || key !== "selectivityEstimate") {
-          result[key] = removeCost(obj[key]);
-        }
+      if (obj.hasOwnProperty(key) &&
+          key !== "estimatedCost" && key !== "selectivityEstimate") {
+        result[key] = removeCost(obj[key]);
       }
     }
     return result;
@@ -401,7 +400,6 @@ function removeCost (obj) {
     return obj;
   }
 }
-
 
 exports.getParseResults = getParseResults;
 exports.assertParseError = assertParseError;


### PR DESCRIPTION
### Scope & Purpose

Fix bug in internal test helper function `removeCost`. It was not excluding costs. This can help fix some spurious assertion failures in AQL tests.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10455/