### PR TITLE
Fix restoring old arangodumps from ArangoDB 3.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,10 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
-* Fix internal test helper function `removeCost` to really remove costs.
+* Fix restoring old arangodumps from ArangoDB 3.3 and before, which had index
+  information stored in slightly different places in the dump.
 
-* Fix restoring old arangodumps from ArangoDB 3.3 and before, which had 
-  index information stored in slightly different places in the dump.
+* Fix internal test helper function `removeCost` to really remove costs.
 
 * Fix invalid calls to `AgencyCommResult::slice()` method, which must only be
   made in case of an agency result was retrieved successfully. In case the call

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,9 @@ v3.7.1-rc.1 (XXXX-XX-XX)
 
 * Fix internal test helper function `removeCost` to really remove costs.
 
+* Fix restoring old arangodumps from ArangoDB 3.3 and before, which had 
+  index information stored in slightly different places in the dump.
+
 * Fix invalid calls to `AgencyCommResult::slice()` method, which must only be
   made in case of an agency result was retrieved successfully. In case the call
   to the agency was not successful, `slice()` must not be called on it. This

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -3417,6 +3417,13 @@ Result ClusterInfo::ensureIndexCoordinator(LogicalCollection const& collection,
   }
 
   std::string const idString = arangodb::basics::StringUtils::itoa(iid.id());
+
+  VPackSlice const typeSlice = slice.get(StaticStrings::IndexType);
+  if (!typeSlice.isString() || (typeSlice.isEqualString("geo1") || typeSlice.isEqualString("geo2"))) {
+    // geo1 and geo2 are disallowed here. Only "geo" should be used
+    return Result(TRI_ERROR_BAD_PARAMETER, "invalid index type");
+  }
+
   Result res;
 
   try {

--- a/arangod/Indexes/IndexFactory.cpp
+++ b/arangod/Indexes/IndexFactory.cpp
@@ -325,7 +325,7 @@ IndexId IndexFactory::validateSlice(arangodb::velocypack::Slice info,
   } else if (!generateKey) {
     // In the restore case it is forbidden to NOT have id
     THROW_ARANGO_EXCEPTION_MESSAGE(
-        TRI_ERROR_INTERNAL, "cannot restore index without index identifier");
+        TRI_ERROR_BAD_PARAMETER, "cannot restore index without index identifier");
   }
 
   if (iid.empty() && !isClusterConstructor) {

--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -909,7 +909,8 @@ arangodb::Result processInputDirectory(
     std::vector<std::string> const files = listFiles(directory.path());
     std::string const collectionSuffix = std::string(".structure.json");
     std::string const viewsSuffix = std::string(".view.json");
-    std::vector<VPackBuilder> collections, views;
+    std::vector<VPackBuilder> collections;
+    std::vector<VPackBuilder> views;
 
     // Step 1 determine all collections to process
     {
@@ -1004,7 +1005,26 @@ arangodb::Result processInputDirectory(
           // TODO: we have a JSON object with sub-object "parameters" with
           // attribute "name". we only want to replace this. how?
         } else {
-          collections.emplace_back(std::move(fileContentBuilder));
+          VPackSlice s = fileContentBuilder.slice();
+          VPackSlice indexes = s.get("indexes");
+          VPackSlice parameters = s.get("parameters");
+          if ((indexes.isNone() || indexes.isEmptyArray()) &&
+              parameters.get("indexes").isArray()) {
+            // old format
+            VPackBuilder const parametersWithoutIndexes =
+              VPackCollection::remove(parameters, std::vector<std::string>{"indexes"});
+
+            VPackBuilder rewritten;
+            rewritten.openObject();
+            rewritten.add("indexes", parameters.get("indexes"));
+            rewritten.add("parameters", parametersWithoutIndexes.slice());
+            rewritten.close();
+          
+            collections.emplace_back(std::move(rewritten));
+          } else {
+            // new format
+            collections.emplace_back(std::move(fileContentBuilder));
+          }
         }
       }
     }
@@ -1064,8 +1084,8 @@ arangodb::Result processInputDirectory(
       if (params.isObject()) {
         name = params.get("name");
         // Only these two are relevant for FOXX.
-        if (name.isString() && (name.isEqualString("_apps") ||
-                                name.isEqualString("_appbundles"))) {
+        if (name.isString() && (name.isEqualString(arangodb::StaticStrings::AppsCollection) ||
+                                name.isEqualString(arangodb::StaticStrings::AppBundlesCollection))) {
           didModifyFoxxCollection = true;
         }
       }
@@ -1082,7 +1102,7 @@ arangodb::Result processInputDirectory(
         }
       }
 
-      if (name.isString() && name.stringRef() == "_users") {
+      if (name.isString() && name.stringRef() == arangodb::StaticStrings::UsersCollection) {
         // special treatment for _users collection - this must be the very last,
         // and run isolated from all previous data loading operations - the
         // reason is that loading into the users collection may change the
@@ -1224,7 +1244,7 @@ arangodb::Result processJob(arangodb::httpclient::SimpleHttpClient& httpClient,
   std::string const cname =
       arangodb::basics::VelocyPackHelper::getStringValue(parameters, "name", "");
 
-  if (cname == "_users") {
+  if (cname == arangodb::StaticStrings::UsersCollection) {
     // special case: never restore data in the _users collection first as it could
     // potentially change user permissions. In that case index creation will fail.
     result = ::restoreIndexes(httpClient, jobData);

--- a/tests/js/client/shell/shell-restore-integration.js
+++ b/tests/js/client/shell/shell-restore-integration.js
@@ -1,0 +1,398 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global fail, assertTrue, assertFalse, assertEqual, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief ArangoTransaction sTests
+// /
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2018 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// //////////////////////////////////////////////////////////////////////////////
+
+let jsunity = require('jsunity');
+let internal = require('internal');
+let arangodb = require('@arangodb');
+let fs = require('fs');
+let pu = require('@arangodb/process-utils');
+let db = arangodb.db;
+
+function restoreIntegrationSuite () {
+  'use strict';
+  const cn = 'UnitTestsRestore';
+  // detect the path of arangorestore. quite hacky, but works
+  const arangorestore = fs.join(global.ARANGOSH_PATH, 'arangorestore' + pu.executableExt);
+
+  assertTrue(fs.isFile(arangorestore), "arangorestore not found!");
+
+  let addConnectionArgs = function(args) {
+    let endpoint = arango.getEndpoint().replace(/\+vpp/, '').replace(/^http:/, 'tcp:').replace(/^https:/, 'ssl:').replace(/^vst:/, 'tcp:').replace(/^h2:/, 'tcp:');
+    args.push('--server.endpoint');
+    args.push(endpoint);
+    args.push('--server.database');
+    args.push(arango.getDatabaseName());
+    args.push('--server.username');
+    args.push(arango.connectedUser());
+  };
+
+  let runRestore = function(path, args, rc) {
+    args.push('--input-directory');
+    args.push(path);
+    addConnectionArgs(args);
+
+    let actualRc = internal.executeExternalAndWait(arangorestore, args);
+    assertTrue(actualRc.hasOwnProperty("exit"));
+    assertEqual(rc, actualRc.exit);
+  };
+
+  return {
+
+    setUp: function () {
+      db._drop(cn);
+    },
+
+    tearDown: function () {
+      db._drop(cn);
+    },
+    
+    testRestoreIndexesOldFormat: function () {
+      let path = fs.getTempFile();
+      try {
+        fs.makeDirectory(path);
+        let fn = fs.join(path, cn + ".structure.json");
+
+        fs.write(fn, JSON.stringify({
+          indexes: [],
+          parameters: {
+            indexes: [
+              { id: "0", fields: ["_key"], type: "primary", unique: true },
+              { id: "95", fields: ["loc"], type: "geo", geoJson: false },
+              { id: "295", fields: ["value"], type: "skiplist", sparse: true },
+            ],
+            name: cn,
+            numberOfShards: 3,
+            type: 2
+          }
+        }));
+
+        let args = ['--collection', cn, '--import-data', 'false'];
+        runRestore(path, args, 0); 
+
+        let c = db._collection(cn);
+        let indexes = c.indexes();
+        assertEqual(3, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(["_key"], indexes[0].fields);
+        assertEqual("geo", indexes[1].type);
+        assertEqual(["loc"], indexes[1].fields);
+        assertFalse(indexes[1].geoJson);
+        assertEqual("skiplist", indexes[2].type);
+        assertEqual(["value"], indexes[2].fields);
+
+        // test if the indexes work
+        for (let i = 0; i < 100; ++i) {
+          c.insert({ _key: "test" + i, value: 42 });
+        }
+        for (let i = 0; i < 100; ++i) {
+          assertEqual("test" + i, c.document("test" + i)._key);
+        }
+        let result = db._query("FOR doc IN " + cn + " FILTER doc.value == 42 RETURN doc").toArray();
+        assertEqual(100, result.length);
+      } finally {
+        try {
+          fs.removeDirectory(path);
+        } catch (err) {}
+      }
+    },
+    
+    testRestoreIndexesOldFormatGeo1: function () {
+      let path = fs.getTempFile();
+      try {
+        fs.makeDirectory(path);
+        let fn = fs.join(path, cn + ".structure.json");
+
+        fs.write(fn, JSON.stringify({
+          indexes: [],
+          parameters: {
+            indexes: [
+              { id: "95", fields: ["loc"], type: "geo1", geoJson: false },
+            ],
+            name: cn,
+            numberOfShards: 3,
+            type: 2
+          }
+        }));
+
+        let args = ['--collection', cn, '--import-data', 'false'];
+        runRestore(path, args, 0); 
+
+        let c = db._collection(cn);
+        let indexes = c.indexes();
+        assertEqual(2, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(["_key"], indexes[0].fields);
+        assertEqual("geo", indexes[1].type);
+        assertEqual(["loc"], indexes[1].fields);
+        assertFalse(indexes[1].geoJson);
+      } finally {
+        try {
+          fs.removeDirectory(path);
+        } catch (err) {}
+      }
+    },
+    
+    testRestoreIndexesOldFormatGeo2: function () {
+      let path = fs.getTempFile();
+      try {
+        fs.makeDirectory(path);
+        let fn = fs.join(path, cn + ".structure.json");
+
+        fs.write(fn, JSON.stringify({
+          indexes: [],
+          parameters: {
+            indexes: [
+              { id: "95", fields: ["a", "b"], type: "geo2", geoJson: false },
+            ],
+            name: cn,
+            numberOfShards: 3,
+            type: 2
+          }
+        }));
+
+        let args = ['--collection', cn, '--import-data', 'false'];
+        runRestore(path, args, 0); 
+
+        let c = db._collection(cn);
+        let indexes = c.indexes();
+        assertEqual(2, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(["_key"], indexes[0].fields);
+        assertEqual("geo", indexes[1].type);
+        assertEqual(["a", "b"], indexes[1].fields);
+        assertFalse(indexes[1].geoJson);
+      } finally {
+        try {
+          fs.removeDirectory(path);
+        } catch (err) {}
+      }
+    },
+    
+    testRestoreIndexesNewFormat: function () {
+      let path = fs.getTempFile();
+      try {
+        fs.makeDirectory(path);
+        let fn = fs.join(path, cn + ".structure.json");
+
+        fs.write(fn, JSON.stringify({
+          indexes: [
+            { id: "95", fields: ["loc"], type: "geo", geoJson: false },
+            { id: "295", fields: ["value"], type: "skiplist", sparse: true },
+          ],
+          parameters: {
+            name: cn,
+            numberOfShards: 3,
+            type: 2
+          }
+        }));
+
+        let args = ['--collection', cn, '--import-data', 'false'];
+        runRestore(path, args, 0); 
+
+        let c = db._collection(cn);
+        let indexes = c.indexes();
+        assertEqual(3, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(["_key"], indexes[0].fields);
+        assertEqual("geo", indexes[1].type);
+        assertEqual(["loc"], indexes[1].fields);
+        assertFalse(indexes[1].geoJson);
+        assertEqual("skiplist", indexes[2].type);
+        assertEqual(["value"], indexes[2].fields);
+
+        // test if the indexes work
+        for (let i = 0; i < 100; ++i) {
+          c.insert({ _key: "test" + i, value: 42 });
+        }
+        for (let i = 0; i < 100; ++i) {
+          assertEqual("test" + i, c.document("test" + i)._key);
+        }
+        let result = db._query("FOR doc IN " + cn + " FILTER doc.value == 42 RETURN doc").toArray();
+        assertEqual(100, result.length);
+      } finally {
+        try {
+          fs.removeDirectory(path);
+        } catch (err) {}
+      }
+    },
+
+    testRestoreEdgeIndexOldFormat: function () {
+      let path = fs.getTempFile();
+      try {
+        fs.makeDirectory(path);
+        let fn = fs.join(path, cn + ".structure.json");
+
+        fs.write(fn, JSON.stringify({
+          indexes: [],
+          parameters: {
+            indexes: [
+              { id: "0", fields: ["_key"], type: "primary", unique: true },
+              { id: "1", fields: ["_from", "_to"], type: "edge" },
+              { id: "95", fields: ["value"], type: "hash" },
+            ],
+            name: cn,
+            numberOfShards: 3,
+            type: 3 // edge collection
+          }
+        }));
+
+        let args = ['--collection', cn, '--import-data', 'false'];
+        runRestore(path, args, 0); 
+
+        let c = db._collection(cn);
+        let indexes = c.indexes();
+        assertEqual(3, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(["_key"], indexes[0].fields);
+        assertEqual("edge", indexes[1].type);
+        assertEqual(["_from", "_to"], indexes[1].fields);
+        assertEqual("hash", indexes[2].type);
+        assertEqual(["value"], indexes[2].fields);
+
+        // test if the indexes work
+        for (let i = 0; i < 100; ++i) {
+          c.insert({ _key: "test" + i, _from: "v/" + i, _to: "v/" + i, value: 42 });
+        }
+        for (let i = 0; i < 100; ++i) {
+          assertEqual("test" + i, c.document("test" + i)._key);
+        }
+        for (let i = 0; i < 100; ++i) {
+          let inEdges = c.inEdges("v/" + i);
+          assertEqual(1, inEdges.length);
+          assertEqual("test" + i, inEdges[0]._key);
+          
+          let outEdges = c.outEdges("v/" + i);
+          assertEqual(1, outEdges.length);
+          assertEqual("test" + i, outEdges[0]._key);
+        }
+        let result = db._query("FOR doc IN " + cn + " FILTER doc.value == 42 RETURN doc").toArray();
+        assertEqual(100, result.length);
+      } finally {
+        try {
+          fs.removeDirectory(path);
+        } catch (err) {}
+      }
+    },
+    
+    testRestoreEdgeIndexWrongCollectionType: function () {
+      let path = fs.getTempFile();
+      try {
+        fs.makeDirectory(path);
+        let fn = fs.join(path, cn + ".structure.json");
+
+        fs.write(fn, JSON.stringify({
+          indexes: [],
+          parameters: {
+            indexes: [
+              { id: "0", fields: ["_key"], type: "primary", unique: true },
+              { id: "1", fields: ["_from", "_to"], type: "edge" },
+            ],
+            name: cn,
+            numberOfShards: 3,
+            type: 2 // document collection
+          }
+        }));
+
+        let args = ['--collection', cn, '--import-data', 'false'];
+        runRestore(path, args, 0); 
+
+        let c = db._collection(cn);
+        let indexes = c.indexes();
+        assertEqual(1, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(["_key"], indexes[0].fields);
+
+        // test if the index works
+        for (let i = 0; i < 100; ++i) {
+          c.insert({ _key: "test" + i });
+        }
+        for (let i = 0; i < 100; ++i) {
+          assertEqual("test" + i, c.document("test" + i)._key);
+        }
+      } finally {
+        try {
+          fs.removeDirectory(path);
+        } catch (err) {}
+      }
+    },
+    
+    testRestoreEdgeIndexNewFormat: function () {
+      let path = fs.getTempFile();
+      try {
+        fs.makeDirectory(path);
+        let fn = fs.join(path, cn + ".structure.json");
+
+        fs.write(fn, JSON.stringify({
+          indexes: [], // no edge index here, as it is an automatic index!
+          parameters: {
+            name: cn,
+            numberOfShards: 3,
+            type: 3 // edge collection
+          }
+        }));
+
+        let args = ['--collection', cn, '--import-data', 'false'];
+        runRestore(path, args, 0); 
+
+        let c = db._collection(cn);
+        let indexes = c.indexes();
+        assertEqual(2, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(["_key"], indexes[0].fields);
+        assertEqual("edge", indexes[1].type);
+        assertEqual(["_from", "_to"], indexes[1].fields);
+
+        // test if the indexes work
+        for (let i = 0; i < 100; ++i) {
+          c.insert({ _key: "test" + i, _from: "v/" + i, _to: "v/" + i, value: 42 });
+        }
+        for (let i = 0; i < 100; ++i) {
+          assertEqual("test" + i, c.document("test" + i)._key);
+        }
+        for (let i = 0; i < 100; ++i) {
+          let inEdges = c.inEdges("v/" + i);
+          assertEqual(1, inEdges.length);
+          assertEqual("test" + i, inEdges[0]._key);
+          
+          let outEdges = c.outEdges("v/" + i);
+          assertEqual(1, outEdges.length);
+          assertEqual("test" + i, outEdges[0]._key);
+        }
+      } finally {
+        try {
+          fs.removeDirectory(path);
+        } catch (err) {}
+      }
+    },
+    
+  };
+}
+
+jsunity.run(restoreIntegrationSuite);
+
+return jsunity.done();

--- a/tests/js/common/shell/shell-index-geo.js
+++ b/tests/js/common/shell/shell-index-geo.js
@@ -30,8 +30,6 @@
 
 var jsunity = require("jsunity");
 var internal = require("internal");
-var console = require("console");
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test suite: Creation
@@ -50,7 +48,7 @@ function GeoIndexCreationSuite() {
 
     setUp : function () {
       internal.db._drop(cn);
-      collection = internal.db._create(cn, { waitForSync : false });
+      collection = internal.db._create(cn);
     },
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -58,9 +56,37 @@ function GeoIndexCreationSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     tearDown : function () {
-      collection.unload();
-      collection.drop();
-      internal.wait(0.0);
+      internal.db._drop(cn);
+    },
+    
+    testGeo1 : function () {
+      collection.ensureIndex({ type: "geo1", fields: ["loc"], geoJson: false });
+      let indexes = collection.indexes();
+      assertTrue(2, indexes.length);
+      assertEqual("primary", indexes[0].type);
+      assertEqual("geo", indexes[1].type);
+      assertEqual(["loc"], indexes[1].fields);
+      assertFalse(indexes[1].geoJson);
+    },
+    
+    testGeo1GeoJson : function () {
+      collection.ensureIndex({ type: "geo1", fields: ["loc"], geoJson: true });
+      let indexes = collection.indexes();
+      assertTrue(2, indexes.length);
+      assertEqual("primary", indexes[0].type);
+      assertEqual("geo", indexes[1].type);
+      assertEqual(["loc"], indexes[1].fields);
+      assertTrue(indexes[1].geoJson);
+    },
+    
+    testGeo2 : function () {
+      collection.ensureIndex({ type: "geo2", fields: ["a", "b"] });
+      let indexes = collection.indexes();
+      assertTrue(2, indexes.length);
+      assertEqual("primary", indexes[0].type);
+      assertEqual("geo", indexes[1].type);
+      assertEqual(["a", "b"], indexes[1].fields);
+      assertFalse(indexes[1].geoJson);
     },
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -68,8 +94,6 @@ function GeoIndexCreationSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testUpdates : function () {
-      collection.truncate();
-
       collection.ensureGeoIndex("coordinates", true);
 
       [


### PR DESCRIPTION
### Scope & Purpose

Allow restoring arangodumps from ArangoDB 3.3 and before, taken with MMFiles, into a current version of ArangoDB.
Related ticket: https://arangodb.atlassian.net/browse/BTS-84 

This PR supersedes https://github.com/arangodb/arangodb/pull/11787

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is a *JIRA Ticket number* (In case a customer was affected / involved): https://arangodb.atlassian.net/browse/BTS-84

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_client)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10471/