### PR TITLE
allow usage of `scripts/startLocalCluster.sh` with a single DBS

### DIFF
--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -52,7 +52,6 @@ if [ "$POOLSZ" == "" ] ; then
 fi
 
 STORAGE_ENGINE="--server.storage-engine=rocksdb"
-DEFAULT_REPLICATION=""
 
 if [ "$AUTOUPGRADE" == "1" ];then
   echo "-- Using autoupgrade procedure"
@@ -193,6 +192,11 @@ for aid in `seq 0 $(( $NRAGENTS - 1 ))`; do
 done
 
 start() {
+    if [ "$NRDBSERVERS" == "1" ]; then
+        SYSTEM_REPLICATION_FACTOR="--cluster.system-replication-factor=1"
+    else
+        SYSTEM_REPLICATION_FACTOR=""
+    fi
 
     if [ "$1" == "dbserver" ]; then
         ROLE="DBSERVER"
@@ -237,6 +241,7 @@ start() {
           --log.force-direct false \
           --log.level $LOG_LEVEL_CLUSTER \
           --javascript.allow-admin-execute true \
+          $SYSTEM_REPLICATION_FACTOR \
           $STORAGE_ENGINE \
           $AUTHENTICATION \
           $SSLKEYFILE \
@@ -262,6 +267,7 @@ start() {
         --log.thread true \
         --log.level $LOG_LEVEL_CLUSTER \
         --javascript.allow-admin-execute true \
+        $SYSTEM_REPLICATION_FACTOR \
         $STORAGE_ENGINE \
         $AUTHENTICATION \
         $SSLKEYFILE \


### PR DESCRIPTION
### Scope & Purpose

Fix usage of `scripts/startLocalCluster.sh` with a single DB-Server

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10481/