### PR TITLE
Allow AQL queries on DB-Servers again

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
 * Allow AQL queries on DB-Servers again. This is not an official supported
-  feature, but is sometimes used for debugging. Previous changes made it 
+  feature, but is sometimes used for debugging. Previous changes made it
   impossible to run a query on a local shard.
 
 * Fix restoring old arangodumps from ArangoDB 3.3 and before, which had index

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
+* Allow AQL queries on DB-Servers again. This is not an official supported
+  feature, but is sometimes used for debugging. Previous changes made it 
+  impossible to run a query on a local shard.
+
 * Fix restoring old arangodumps from ArangoDB 3.3 and before, which had index
   information stored in slightly different places in the dump.
 

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -115,9 +115,13 @@ LogicalDataSource::Category const* injectDataSourceInQuery(
   if (dataSource->category() == LogicalCollection::category()) {
     // it's a collection!
     // add datasource to query
-    ast.query().collections().add(nameRef.toString(), accessType, aql::Collection::Hint::Collection);
+    aql::Collection::Hint hint = aql::Collection::Hint::Collection;
+    if (ServerState::instance()->isDBServer()) {
+      hint = aql::Collection::Hint::Shard;
+    }
+    ast.query().collections().add(nameRef.toString(), accessType, hint);
     if (nameRef != name) {
-      ast.query().collections().add(name, accessType, aql::Collection::Hint::Collection);  // Add collection by ID as well
+      ast.query().collections().add(name, accessType, hint);  // Add collection by ID as well
     }
   } else if (dataSource->category() == LogicalView::category()) {
     // it's a view!

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -77,8 +77,15 @@ class Query : public QueryContext {
   Query(Query const&) = delete;
   Query& operator=(Query const&) = delete;
 
+ protected:
+  /// @brief internal constructor, Used to construct a full query or a ClusterQuery
+  Query(std::shared_ptr<transaction::Context> const& ctx, QueryString const& queryString,
+        std::shared_ptr<arangodb::velocypack::Builder> const& bindParameters,
+        std::shared_ptr<arangodb::velocypack::Builder> const& options,
+        std::shared_ptr<SharedQueryState> sharedState);
+
  public:
-  /// Used to construct a full query
+  /// @brief public constructor, Used to construct a full query
   Query(std::shared_ptr<transaction::Context> const& ctx, QueryString const& queryString,
         std::shared_ptr<arangodb::velocypack::Builder> const& bindParameters,
         std::shared_ptr<arangodb::velocypack::Builder> const& options);

--- a/arangod/Aql/QueryCursor.cpp
+++ b/arangod/Aql/QueryCursor.cpp
@@ -203,6 +203,7 @@ QueryStreamCursor::~QueryStreamCursor() {
 
   // now remove the continue handler we may have registered in the query
   _query->sharedState()->invalidate();
+
   // Query destructor will cleanup plan and abort transaction
   _query.reset();
 }

--- a/arangod/Aql/SharedQueryState.cpp
+++ b/arangod/Aql/SharedQueryState.cpp
@@ -54,14 +54,6 @@ void SharedQueryState::waitForAsyncWakeup() {
   std::unique_lock<std::mutex> guard(_mutex);
   if (!_valid) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
-/*    f ((errorCode == TRI_ERROR_INTERNAL || errorCode == TRI_ERROR_SHUTTING_DOWN) &&
-+            !sharedState->isValid()) {
-+          // exit early here instead of looping (indefinitely)
-+          // this is supposed to fix hangers on shutdown, when there
-+          // is nobody there to wake up queries anymore
-+          return res.reset(errorCode);
-+        }
-*/
   }
   
   TRI_ASSERT(!_wakeupCb);

--- a/js/client/modules/@arangodb/test-utils.js
+++ b/js/client/modules/@arangodb/test-utils.js
@@ -876,6 +876,7 @@ function runInLocalArangosh (options, instanceInfo, file, addArgs) {
       'return runTest(' + JSON.stringify(file) + ', true' + mochaGrep + ');\n';
   }
 
+  require('internal').env.INSTANCEINFO = JSON.stringify(instanceInfo);
   let testFunc;
   eval('testFunc = function () { \nglobal.instanceInfo = ' + JSON.stringify(instanceInfo) + ';\n' + testCode + "}");
   

--- a/tests/js/client/shell/shell-query-dbserver-cluster.js
+++ b/tests/js/client/shell/shell-query-dbserver-cluster.js
@@ -1,0 +1,105 @@
+/* jshint globalstrict:true, strict:true, maxlen: 5000 */
+/* global assertTrue, assertFalse, assertEqual, arango, require*/
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2018 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2018, ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+
+const jsunity = require("jsunity");
+const db = require("internal").db;
+const url = require('url');
+const _ = require("lodash");
+        
+function getServers(role) {
+  const matchesRole = (d) => (_.toLower(d.role) === role);
+  const instanceInfo = JSON.parse(require('internal').env.INSTANCEINFO);
+  return instanceInfo.arangods.filter(matchesRole);
+}
+
+const cn = "UnitTestsQueries";
+const originalEndpoint = arango.getEndpoint();
+
+function queriesTestSuite () {
+  'use strict';
+  
+  return {
+    setUp: function() {
+      arango.reconnect(originalEndpoint, "_system", arango.connectedUser(), "");
+      db._drop(cn);
+      
+      let c = db._create(cn, { numberOfShards: 5 });
+      let docs = [];
+      for (let i = 0; i < 100; ++i) {
+        docs.push({ value : i });
+      }
+      c.insert(docs);
+    },
+
+    tearDown: function() {
+      arango.reconnect(originalEndpoint, "_system", arango.connectedUser(), "");
+      db._drop(cn);
+    },
+    
+    // test executing operations on the coordinator
+    testCoordinator: function() {
+      assertEqual(100, db[cn].count());
+      assertEqual(100, db[cn].toArray().length);
+      assertEqual(100, db._query("FOR doc IN " + cn + " RETURN doc").toArray().length);
+    },
+
+    // test executing operations on the DB-Server, on all individual shards
+    testDBServer: function() {
+      let shardMap = db[cn].shards(true);
+      assertEqual(5, Object.keys(shardMap).length, shardMap);
+      
+      const dbservers = getServers("dbserver");
+      assertTrue(dbservers.length > 0, "no dbservers found");
+        
+      let totalCount = 0, totalToArray = 0, totalQuery = 0;
+       
+      dbservers.forEach(function(dbserver, i) {
+        let id = dbserver.id;
+        require("console").warn("connecting to dbserver", dbserver.endpoint, id);
+        arango.reconnect(dbserver.endpoint, "_system", arango.connectedUser(), "");
+
+        let shards = Object.keys(shardMap).filter(function(shard) {
+          return shardMap[shard][0] === id;
+        });
+        shards.forEach(function(shard) {
+          totalCount += db[shard].count();
+          totalToArray += db[shard].toArray().length;
+          totalQuery += db._query("FOR doc IN " + shard + " RETURN doc").toArray().length;
+        });
+      });
+
+      assertEqual(100, totalCount);
+      assertEqual(100, totalToArray);
+      assertEqual(100, totalQuery);
+    },
+
+  };
+}
+
+jsunity.run(queriesTestSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Allow queries on DB-Servers again, for debugging purposes.
This is not an official supported feature, but is sometimes used for debugging. Previous changes made it impossible to run a query on a local shard.

This is the 3.7 backport of the devel PR: https://github.com/arangodb/arangodb/pull/11886

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_client)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10497/