### PR TITLE
Multiple fixes backported from devel

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
+* Fixed unintentional connection re-use for cluster-internal communications.
+
+* Fixed problem with newer replication protocol and ArangoSearch which could
+  lead to server crashes during normal operation.
+
+* Fixed bad behavior that led to unnecessary additional revision tree rebuilding
+  on server restart.
+  
 * Fix restoring old arangodumps from ArangoDB 3.3 and before, which had index
   information stored in slightly different places in the dump.
 

--- a/arangod/Network/ConnectionPool.h
+++ b/arangod/Network/ConnectionPool.h
@@ -45,7 +45,8 @@ class ClusterInfo;
 
 namespace network {
 
-using ConnectionPtr = std::shared_ptr<fuerte::Connection>;
+// using ConnectionPtr = std::shared_ptr<fuerte::Connection>;
+class ConnectionPtr;
 
 /// @brief simple connection pool managing fuerte connections
 #ifdef ARANGODB_USE_GOOGLE_TESTS
@@ -55,6 +56,7 @@ class ConnectionPool final {
 #endif
  protected:
   struct Connection;
+  friend class ConnectionPtr;
 
  public:
   struct Config {
@@ -101,8 +103,13 @@ class ConnectionPool final {
  protected:
 
   struct Context {
+    Context(std::shared_ptr<fuerte::Connection>,
+            std::chrono::steady_clock::time_point, std::size_t);
+
     std::shared_ptr<fuerte::Connection> fuerte;
-    std::chrono::steady_clock::time_point leased; /// last time leased
+    std::chrono::steady_clock::time_point lastLeased;  /// last time leased
+    std::atomic<std::size_t> leases;  // number of active users, including those
+                                      // who may not have sent a request yet
   };
 
   /// @brief endpoint bucket
@@ -112,11 +119,11 @@ class ConnectionPool final {
     //    uint64_t bytesSend;
     //    uint64_t bytesReceived;
     //    uint64_t numRequests;
-    containers::SmallVector<Context>::allocator_type::arena_type arena;
-    containers::SmallVector<Context> list{arena};
+    containers::SmallVector<std::shared_ptr<Context>>::allocator_type::arena_type arena;
+    containers::SmallVector<std::shared_ptr<Context>> list{arena};
   };
 
-  TEST_VIRTUAL ConnectionPtr createConnection(fuerte::ConnectionBuilder&);
+  TEST_VIRTUAL std::shared_ptr<fuerte::Connection> createConnection(fuerte::ConnectionBuilder&);
   ConnectionPtr selectConnection(std::string const& endpoint, Bucket& bucket);
   
  private:
@@ -127,6 +134,24 @@ class ConnectionPool final {
 
   /// @brief contains fuerte asio::io_context
   fuerte::EventLoopService _loop;
+};
+
+class ConnectionPtr {
+ public:
+  ConnectionPtr(std::shared_ptr<ConnectionPool::Context>&);
+  ConnectionPtr(ConnectionPtr&&);
+  ConnectionPtr(ConnectionPtr const&) = delete;
+  ~ConnectionPtr();
+
+  ConnectionPtr operator=(ConnectionPtr&&) = delete;
+  ConnectionPtr operator=(ConnectionPtr const&) = delete;
+
+  fuerte::Connection& operator*() const;
+  fuerte::Connection* operator->() const;
+  fuerte::Connection* get() const;
+
+ private:
+  std::shared_ptr<ConnectionPool::Context> _context;
 };
 
 }  // namespace network

--- a/arangod/Replication/GlobalInitialSyncer.cpp
+++ b/arangod/Replication/GlobalInitialSyncer.cpp
@@ -123,7 +123,7 @@ Result GlobalInitialSyncer::runInternal(bool incremental) {
   if (!_state.isChildSyncer) {
     // start batch is required for the inventory request
     LOG_TOPIC("0da14", DEBUG, Logger::REPLICATION) << "sending start batch";
-    r = _batch.start(_state.connection, _progress, _state.syncerId);
+    r = _batch.start(_state.connection, _progress, _state.master, _state.syncerId);
     if (r.fail()) {
       return r;
     }
@@ -360,7 +360,7 @@ Result GlobalInitialSyncer::getInventory(VPackBuilder& builder) {
     return Result(TRI_ERROR_SHUTTING_DOWN);
   }
 
-  auto r = _batch.start(_state.connection, _progress, _state.syncerId);
+  auto r = _batch.start(_state.connection, _progress, _state.master, _state.syncerId);
   if (r.fail()) {
     return r;
   }

--- a/arangod/Replication/Syncer.cpp
+++ b/arangod/Replication/Syncer.cpp
@@ -51,6 +51,7 @@
 #include "VocBase/Identifiers/LocalDocumentId.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/LogicalView.h"
+#include "VocBase/ManagedDocumentResult.h"
 #include "VocBase/Methods/Indexes.h"
 #include "VocBase/voc-types.h"
 #include "VocBase/vocbase.h"
@@ -150,6 +151,16 @@ arangodb::Result applyCollectionDumpMarkerInternal(
       if (keySlice.isString()) {
         std::pair<arangodb::LocalDocumentId, TRI_voc_rid_t> lookupResult;
         if (coll->getPhysical()->lookupKey(&trx, keySlice.stringRef(), lookupResult).ok()) {
+          // determine if we already have this revision or need to replace the
+          // one we have
+          TRI_voc_rid_t rid = arangodb::transaction::helpers::extractRevFromDocument(slice);
+          if (rid != 0 && rid == lookupResult.second) {
+            // we already have exactly this document, don't replace, just
+            // consider it already applied and bail
+            return {};
+          }
+
+          // need to replace the one we have
           useReplace = true;
           opRes.result.reset(TRI_ERROR_NO_ERROR, keySlice.copyString());
         }

--- a/arangod/Replication/utilities.h
+++ b/arangod/Replication/utilities.h
@@ -140,30 +140,6 @@ struct BarrierInfo {
   Result remove(Connection&) noexcept;
 };
 
-struct BatchInfo {
-  static constexpr double DefaultTimeout = 7200.0;
-
-  /// @brief dump batch id
-  uint64_t id{0};
-  /// @brief ttl for batches
-  int ttl{static_cast<int>(DefaultTimeout)};
-  /// @brief dump batch last update time
-  double updateTime{0};
-
-  /// @brief send a "start batch" command
-  /// @param patchCount try to patch count of this collection
-  ///        only effective with the incremental sync
-  Result start(Connection const& connection, ProgressInfo& progress,
-               SyncerId syncerId, std::string const& patchCount = "");
-
-  /// @brief send an "extend batch" command
-  Result extend(Connection const& connection, ProgressInfo& progress, SyncerId syncerId);
-
-  /// @brief send a "finish batch" command
-  // TODO worker-safety
-  Result finish(Connection const& connection, ProgressInfo& progress, SyncerId syncerId);
-};
-
 struct MasterInfo {
   std::string endpoint;
   std::string engine;  // storage engine (optional)
@@ -186,6 +162,30 @@ struct MasterInfo {
  private:
   bool _force32mode{false};  // force client to act like 3.2
 #endif
+};
+
+struct BatchInfo {
+  static constexpr double DefaultTimeout = 7200.0;
+
+  /// @brief dump batch id
+  uint64_t id{0};
+  /// @brief ttl for batches
+  int ttl{static_cast<int>(DefaultTimeout)};
+  /// @brief dump batch last update time
+  double updateTime{0};
+
+  /// @brief send a "start batch" command
+  /// @param patchCount try to patch count of this collection
+  ///        only effective with the incremental sync
+  Result start(Connection const& connection, ProgressInfo& progress, MasterInfo& master,
+               SyncerId syncerId, std::string const& patchCount = "");
+
+  /// @brief send an "extend batch" command
+  Result extend(Connection const& connection, ProgressInfo& progress, SyncerId syncerId);
+
+  /// @brief send a "finish batch" command
+  // TODO worker-safety
+  Result finish(Connection const& connection, ProgressInfo& progress, SyncerId syncerId);
 };
 
 /// @brief generates basic source headers for ClusterComm requests

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -366,8 +366,7 @@ std::unique_ptr<containers::RevisionTree> RocksDBMetaCollection::revisionTree(ui
       return nullptr;
     }
     auto guard = scopeGuard([manager, ctx]() -> void { manager->release(ctx); });
-    rocksdb::Snapshot const* snapshot = ctx->snapshot();
-    rocksdb::SequenceNumber trxSeq = snapshot->GetSequenceNumber();
+    rocksdb::SequenceNumber trxSeq = ctx->snapshotTick();
     TRI_ASSERT(trxSeq != 0);
     Result res = applyUpdatesForTransaction(*tree, trxSeq);
     if (res.fail()) {
@@ -385,23 +384,28 @@ bool RocksDBMetaCollection::needToPersistRevisionTree(rocksdb::SequenceNumber ma
 
   std::unique_lock<std::mutex> guard(_revisionBufferLock);
 
+  // have a truncate to apply
   if (!_revisionTruncateBuffer.empty() && *_revisionTruncateBuffer.begin() <= maxCommitSeq) {
     return true;
   }
 
+  // have insertions to apply
   if (!_revisionInsertBuffers.empty() && _revisionInsertBuffers.begin()->first <= maxCommitSeq) {
     return true;
   }
 
+  // have removals to apply
   if (!_revisionRemovalBuffers.empty() && _revisionRemovalBuffers.begin()->first <= maxCommitSeq) {
     return true;
   }
 
+  // have applied updates that we haven't persisted
   if (_revisionTreeSerializedSeq < _revisionTreeApplied.load()) {
     return true;
   }
 
-  if (_revisionTreeSerializedSeq == 0) {
+  // tree has never been persisted
+  if (_revisionTreeSerializedSeq <= _revisionTreeCreationSeq) {
     return true;
   }
 
@@ -412,6 +416,8 @@ rocksdb::SequenceNumber RocksDBMetaCollection::lastSerializedRevisionTree(rocksd
   // first update so we don't under-report
   std::unique_lock<std::mutex> guard(_revisionBufferLock);
   rocksdb::SequenceNumber seq = maxCommitSeq;
+
+  // limit to before any pending buffered updates
 
   if (!_revisionTruncateBuffer.empty() && *_revisionTruncateBuffer.begin() - 1 < seq) {
     seq = *_revisionTruncateBuffer.begin() - 1;
@@ -425,11 +431,13 @@ rocksdb::SequenceNumber RocksDBMetaCollection::lastSerializedRevisionTree(rocksd
     seq = _revisionRemovalBuffers.begin()->first - 1;
   }
 
+  // limit to before the last thing we applied, since we haven't persisted it
   rocksdb::SequenceNumber applied = _revisionTreeApplied.load();
   if (applied > _revisionTreeSerializedSeq && applied - 1 < seq) {
     seq = applied - 1;
   }
 
+  // now actually advance it if we can
   if (seq > _revisionTreeSerializedSeq) {
     _revisionTreeSerializedSeq = seq;
   }
@@ -461,6 +469,7 @@ rocksdb::SequenceNumber RocksDBMetaCollection::serializeRevisionTree(
     }
     return _revisionTreeSerializedSeq;
   }
+  // if we get here, we aren't using the trees;
   // mark as don't persist again, tree should be deleted now
   _revisionTreeApplied.store(std::numeric_limits<rocksdb::SequenceNumber>::max());
   return commitSeq;

--- a/tests/IResearch/AgencyMock.cpp
+++ b/tests/IResearch/AgencyMock.cpp
@@ -191,7 +191,8 @@ struct AsyncAgencyStorePoolConnection final : public fuerte::Connection {
   }
 };
 
-ConnectionPtr AsyncAgencyStorePoolMock::createConnection(fuerte::ConnectionBuilder& builder) {
+std::shared_ptr<fuerte::Connection> AsyncAgencyStorePoolMock::createConnection(
+    fuerte::ConnectionBuilder& builder) {
   return std::make_shared<AsyncAgencyStorePoolConnection>(this, builder.normalizedEndpoint());
 }
 

--- a/tests/IResearch/AgencyMock.h
+++ b/tests/IResearch/AgencyMock.h
@@ -44,9 +44,10 @@ struct AsyncAgencyStorePoolMock final : public arangodb::network::ConnectionPool
       explicit AsyncAgencyStorePoolMock(arangodb::consensus::Store* store)
       : ConnectionPool({}), _store(store) {}
 
-  arangodb::network::ConnectionPtr createConnection(arangodb::fuerte::ConnectionBuilder&) override;
+      std::shared_ptr<arangodb::fuerte::Connection> createConnection(
+          arangodb::fuerte::ConnectionBuilder&) override;
 
-  arangodb::consensus::Store* _store;
+      arangodb::consensus::Store* _store;
 };
 
 #endif


### PR DESCRIPTION
### Scope & Purpose

A recent PR (https://github.com/arangodb/arangodb/pull/11760) made some changes to how revision trees are serialized, and one line of code was not updated properly, leading to some nuisance logging on server startup.

Furthermore, there's an issue with the catch-up phase of replication overlapping with the initial phase, which creates problems for ArangoSearch now that the `_rev` values are used for `LocalDocumentId`. This should fix the overlap.

Backport of https://github.com/arangodb/arangodb/pull/11807

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)

### Testing & Verification

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10499/