### PR TITLE
Bug fix 3.6/fuerte connection pool reuse

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.6.5 (XXXX-XX-XX)
 -------------------
 
+* Fixed unintentional connection re-use for cluster-internal communications.
+
 * Fixed internal issue #701: Dangling readers in ArangoSearch index_writer
   cache.
     

--- a/arangod/Network/ConnectionPool.cpp
+++ b/arangod/Network/ConnectionPool.cpp
@@ -68,10 +68,9 @@ void ConnectionPool::drainConnections() {
   for (auto& pair : _connections) {
     Bucket& buck = *(pair.second);
     std::lock_guard<std::mutex> lock(buck.mutex);
-    for (std::shared_ptr<Context>& c : buck.list) {
-      c->fuerte->cancel();
-    }
+    buck.list.clear();
   }
+  _connections.clear();
 }
 
 /// @brief shutdown all connections
@@ -80,6 +79,9 @@ void ConnectionPool::shutdown() {
   for (auto& pair : _connections) {
     Bucket& buck = *(pair.second);
     std::lock_guard<std::mutex> lock(buck.mutex);
+    for (std::shared_ptr<Context>& c : buck.list) {
+      c->fuerte->cancel();
+    }
     buck.list.clear();
   }
   _connections.clear();

--- a/arangod/Network/ConnectionPool.cpp
+++ b/arangod/Network/ConnectionPool.cpp
@@ -68,8 +68,8 @@ void ConnectionPool::drainConnections() {
   for (auto& pair : _connections) {
     Bucket& buck = *(pair.second);
     std::lock_guard<std::mutex> lock(buck.mutex);
-    for (Context& c : buck.list) {
-      c.fuerte->cancel();
+    for (std::shared_ptr<Context>& c : buck.list) {
+      c->fuerte->cancel();
     }
   }
 }
@@ -77,74 +77,65 @@ void ConnectionPool::drainConnections() {
 /// @brief shutdown all connections
 void ConnectionPool::shutdown() {
   WRITE_LOCKER(guard, _lock);
-  _connections.clear();
-}
-
-void ConnectionPool::removeBrokenConnections(Bucket& buck) {
-  auto it = buck.list.begin();
-  while (it != buck.list.end()) {
-    // lets not keep around disconnected fuerte connection objects
-    if (it->fuerte->state() == fuerte::Connection::State::Failed) {
-      it = buck.list.erase(it);
-    } else {
-      it++;
-    }
-  }
-}
-
-/// remove unsued and broken connections
-void ConnectionPool::pruneConnections() {
-  READ_LOCKER(guard, _lock);
-
-  const auto ttl = std::chrono::milliseconds(_config.idleConnectionMilli * 2);
   for (auto& pair : _connections) {
     Bucket& buck = *(pair.second);
     std::lock_guard<std::mutex> lock(buck.mutex);
+    buck.list.clear();
+  }
+  _connections.clear();
+}
 
+/// remove unused and broken connections
+void ConnectionPool::pruneConnections() {
+  const auto ttl = std::chrono::milliseconds(_config.idleConnectionMilli * 2);
+
+  READ_LOCKER(guard, _lock);
+  for (auto& pair : _connections) {
     auto now = std::chrono::steady_clock::now();
 
-    removeBrokenConnections(buck);
+    Bucket& buck = *(pair.second);
+    std::lock_guard<std::mutex> lock(buck.mutex);
 
-    // do not remove more connections than necessary
-    if (buck.list.size() <= _config.minOpenConnections) {
-      continue;
-    }
+    // this loop removes broken connections, and closes the ones we don't
+    // need anymore
+    size_t aliveCount = 0;
 
-    // first remove old connections
+    // make a single pass over the connections in this bucket
     auto it = buck.list.begin();
     while (it != buck.list.end()) {
-      std::shared_ptr<fuerte::Connection> const& c = it->fuerte;
+      bool remove = false;
 
-      if ((now - it->leased) > ttl) {
+      if ((*it)->fuerte->state() == fuerte::Connection::State::Failed) {
+        // lets not keep around disconnected fuerte connection objects
+        remove = true;
+      } else {
+        // connection has not yet failed
+        if ((*it)->leases.load() > 0 || (*it)->fuerte->requestsLeft() > 0) {  // continuously update lastUsed
+          (*it)->lastLeased = now;
+          // connection will be kept
+        } else if (aliveCount >= _config.minOpenConnections &&
+                   (now - (*it)->lastLeased) > ttl) {
+          // connection hasn't been used for a while, remove it
+          // if we still have enough others
+          remove = true;
+        } else if (aliveCount >= _config.maxOpenConnections) {
+          // remove superfluous connections
+          remove = true;
+        } // else keep the connection
+      }
+
+      if (remove) {
         it = buck.list.erase(it);
-        // do not remove more connections than necessary
-        if (buck.list.size() <= _config.minOpenConnections) {
-          break;
+      } else {
+        ++aliveCount;
+        ++it;
+        
+        if (aliveCount == _config.maxOpenConnections && 
+            it != buck.list.end()) {
+          LOG_TOPIC("2d59a", DEBUG, Logger::COMMUNICATION)
+            << "pruning extra connections to '" << pair.first
+            << "' (" << buck.list.size() << ")";
         }
-        continue;
-      }
-
-      if (c->requestsLeft() > 0) {  // continuously update lastUsed
-        it->leased = now;
-      }
-      it++;
-    }
-
-    // do not remove connections if there are less
-    if (buck.list.size() <= _config.maxOpenConnections) {
-      continue; // done
-    }
-
-    LOG_TOPIC("2d59a", DEBUG, Logger::COMMUNICATION)
-        << "pruning extra connections to '" << pair.first
-        << "' (" << buck.list.size() << ")";
-
-    // remove any remaining connections, they will be closed eventually
-    it = buck.list.begin();
-    while (it != buck.list.end()) {
-      it = buck.list.erase(it);
-      if (buck.list.size() <= _config.maxOpenConnections) {
-        break;
       }
     }
   }
@@ -158,8 +149,8 @@ size_t ConnectionPool::cancelConnections(std::string const& endpoint) {
     Bucket& buck = *(it->second);
     std::lock_guard<std::mutex> lock(buck.mutex);
     size_t n = buck.list.size();
-    for (auto& c : buck.list) {
-      c.fuerte->cancel();
+    for (std::shared_ptr<Context>& c : buck.list) {
+      c->fuerte->cancel();
     }
     _connections.erase(it);
     return n;
@@ -180,6 +171,10 @@ size_t ConnectionPool::numOpenConnections() const {
   return conns;
 }
 
+ConnectionPool::Context::Context(std::shared_ptr<fuerte::Connection> c,
+                                 std::chrono::steady_clock::time_point t, std::size_t l)
+    : fuerte(std::move(c)), lastLeased(t), leases(l) {}
+
 std::shared_ptr<fuerte::Connection> ConnectionPool::createConnection(fuerte::ConnectionBuilder& builder) {
   auto idle = std::chrono::milliseconds(_config.idleConnectionMilli);
   builder.idleTimeout(idle);
@@ -199,26 +194,36 @@ std::shared_ptr<fuerte::Connection> ConnectionPool::createConnection(fuerte::Con
 
 ConnectionPtr ConnectionPool::selectConnection(std::string const& endpoint,
                                                ConnectionPool::Bucket& bucket) {
+  std::size_t limit = 0;
+  if (_config.protocol == fuerte::ProtocolType::Vst) {
+    // VST allows up to 5 parallel threads to use the same connection,
+    // because requests and responses can be interleaved.
+    // HTTP allows just one, because it is strict request->response.
+    limit = 4;
+  }
+
   std::lock_guard<std::mutex> guard(bucket.mutex);
 
-  for (Context& c : bucket.list) {
-    const fuerte::Connection::State state = c.fuerte->state();
+  for (std::shared_ptr<Context>& c : bucket.list) {
+    const fuerte::Connection::State state = c->fuerte->state();
     if (state == fuerte::Connection::State::Failed) {
       continue;
     }
 
-    size_t num = c.fuerte->requestsLeft();
-    if (_config.protocol == fuerte::ProtocolType::Http && num == 0) {
-      auto now = std::chrono::steady_clock::now();
-      TRI_ASSERT(now >= c.leased);
-      // hack hack hack. Avoids reusing used connections
-      if ((now - c.leased) > std::chrono::milliseconds(25)) {
-        c.leased = now;
-        return c.fuerte;
+    // first check against number of active users
+    std::size_t num = c->leases.load();
+    while (num <= limit) {
+      bool const leased = c->leases.compare_exchange_strong(num, num + 1);
+      if (leased) {
+        // next check against the number of requests in flight
+        if (c->fuerte->requestsLeft() <= limit) {
+          c->lastLeased = std::chrono::steady_clock::now();
+          return {c};
+        } else {
+          --(c->leases);
+          break;
+        }
       }
-    } else if (_config.protocol == fuerte::ProtocolType::Vst && num <= 3) {
-      c.leased = std::chrono::steady_clock::now();
-      return c.fuerte; // TODO: make (num <= 3) configurable ?
     }
   }
 
@@ -231,11 +236,36 @@ ConnectionPtr ConnectionPool::selectConnection(std::string const& endpoint,
   TRI_ASSERT(builder.socketType() != SocketType::Undefined);
 
   std::shared_ptr<fuerte::Connection> fuerte = createConnection(builder);
-  bucket.list.push_back(Context{fuerte, std::chrono::steady_clock::now()});
-  return fuerte;
+  auto c = std::make_shared<Context>(fuerte, std::chrono::steady_clock::now(), 1 /* leases*/);
+  bucket.list.push_back(c);
+  return {c};
 }
 
 ConnectionPool::Config const& ConnectionPool::config() const { return _config; }
+
+ConnectionPtr::ConnectionPtr(std::shared_ptr<ConnectionPool::Context>& ctx)
+    : _context{ctx} {}
+
+ConnectionPtr::ConnectionPtr(ConnectionPtr&& other)
+    : _context(std::move(other._context)) {}
+
+ConnectionPtr::~ConnectionPtr() {
+  if (_context) {
+    --(_context->leases);
+  }
+}
+
+fuerte::Connection& ConnectionPtr::operator*() const {
+  return *(_context->fuerte);
+}
+
+fuerte::Connection* ConnectionPtr::operator->() const {
+  return _context->fuerte.get();
+}
+
+fuerte::Connection* ConnectionPtr::get() const {
+  return _context->fuerte.get();
+}
 
 }  // namespace network
 }  // namespace arangodb

--- a/arangod/Network/ConnectionPool.h
+++ b/arangod/Network/ConnectionPool.h
@@ -44,7 +44,8 @@ class ClusterInfo;
 
 namespace network {
 
-using ConnectionPtr = std::shared_ptr<fuerte::Connection>;
+// using ConnectionPtr = std::shared_ptr<fuerte::Connection>;
+class ConnectionPtr;
 
 /// @brief simple connection pool managing fuerte connections
 #ifdef ARANGODB_USE_GOOGLE_TESTS
@@ -54,6 +55,7 @@ class ConnectionPool final {
 #endif
  protected:
   struct Connection;
+  friend class ConnectionPtr;
 
  public:
   struct Config {
@@ -68,7 +70,7 @@ class ConnectionPool final {
 
  public:
   explicit ConnectionPool(ConnectionPool::Config const& config);
-  virtual ~ConnectionPool();
+  TEST_VIRTUAL ~ConnectionPool();
 
   /// @brief request a connection for a specific endpoint
   /// note: it is the callers responsibility to ensure the endpoint
@@ -99,34 +101,51 @@ class ConnectionPool final {
  protected:
 
   struct Context {
+    Context(std::shared_ptr<fuerte::Connection>,
+            std::chrono::steady_clock::time_point, std::size_t);
+
     std::shared_ptr<fuerte::Connection> fuerte;
-    std::chrono::steady_clock::time_point leased; /// last time leased
+    std::chrono::steady_clock::time_point lastLeased;  /// last time leased
+    std::atomic<std::size_t> leases;  // number of active users, including those
+                                      // who may not have sent a request yet
   };
 
   /// @brief endpoint bucket
   struct Bucket {
     std::mutex mutex;
-    // TODO statistics ?
-    //    uint64_t bytesSend;
-    //    uint64_t bytesReceived;
-    //    uint64_t numRequests;
-    containers::SmallVector<Context>::allocator_type::arena_type arena;
-    containers::SmallVector<Context> list{arena};
+    containers::SmallVector<std::shared_ptr<Context>>::allocator_type::arena_type arena;
+    containers::SmallVector<std::shared_ptr<Context>> list{arena};
   };
 
-  TEST_VIRTUAL ConnectionPtr createConnection(fuerte::ConnectionBuilder&);
+  TEST_VIRTUAL std::shared_ptr<fuerte::Connection> createConnection(fuerte::ConnectionBuilder&);
   ConnectionPtr selectConnection(std::string const& endpoint, Bucket& bucket);
   
-  void removeBrokenConnections(Bucket&);
-
  private:
-  const Config _config;
+  Config const _config;
 
   mutable basics::ReadWriteSpinLock _lock;
   std::unordered_map<std::string, std::unique_ptr<Bucket>> _connections;
 
   /// @brief contains fuerte asio::io_context
   fuerte::EventLoopService _loop;
+};
+
+class ConnectionPtr {
+ public:
+  ConnectionPtr(std::shared_ptr<ConnectionPool::Context>&);
+  ConnectionPtr(ConnectionPtr&&);
+  ConnectionPtr(ConnectionPtr const&) = delete;
+  ~ConnectionPtr();
+
+  ConnectionPtr operator=(ConnectionPtr&&) = delete;
+  ConnectionPtr operator=(ConnectionPtr const&) = delete;
+
+  fuerte::Connection& operator*() const;
+  fuerte::Connection* operator->() const;
+  fuerte::Connection* get() const;
+
+ private:
+  std::shared_ptr<ConnectionPool::Context> _context;
 };
 
 }  // namespace network


### PR DESCRIPTION
### Scope & Purpose

Fixed unintentional connection re-use for cluster-internal communications.
3.6 backport of https://github.com/arangodb/arangodb/pull/11890.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *all cluster, Network gtest*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10500/