### PR TITLE
Leave isBuilding collections alone in the Supervision

### DIFF
--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -2209,9 +2209,15 @@ void Supervision::enforceReplication() {
         }
       }
 
-      bool clone = col.has(StaticStrings::DistributeShardsLike);
+      bool const clone = col.has(StaticStrings::DistributeShardsLike);
+      bool const isBuilding = std::invoke([&col] {
+        auto pair = col.hasAsBool(StaticStrings::AttrIsBuilding);
+        // Return true if the attribute exists, is a bool, and that bool is
+        // true. Return false otherwise.
+        return pair.first && pair.second;
+      });
 
-      if (!clone) {
+      if (!clone && !isBuilding) {
         for (auto const& shard_ : col.hasAsChildren("shards").first) {  // Pl shards
           auto const& shard = *(shard_.second);
           VPackBuilder onlyFollowers;


### PR DESCRIPTION
### Scope & Purpose

The Supervision must not try to enforce the replication factor for a collection during creation, i.e. while the `isBuilding` flag is set. Otherwise, if that happens and e.g. an `addFollower` job runs during creation, the collection creation will always fail.

- [X] Bug-Fix for *devel*
- [ ] Bug-Fix for *3.7*
- [ ] Bug-Fix for *3.6* ?
- [ ] Bug-Fix for *3.5* ?
- [X] The behavior in this PR can be (and was) *manually tested*
- [X] The behavior change can be verified via automatic tests

This was found while inspecting the failures in the resilience_repair test suite noted in BTS-59 and BTS-71.

#### Related Information

Relates to internal issues https://arangodb.atlassian.net/browse/BTS-59 and https://arangodb.atlassian.net/browse/BTS-71.

### Testing & Verification

This change is already covered by existing tests, such as the *resilience* tests.