### PR TITLE
fix a few useless warnings

### DIFF
--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -411,6 +411,8 @@ void MockClusterServer::startFeatures() {
   AsyncAgencyCommManager::INSTANCE->updateEndpoints({"tcp://localhost:4000/"});
   arangodb::AgencyComm(server()).ensureStructureInitialized();
 
+  std::string st = "{\"" + arangodb::ServerState::instance()->getId() + "\":{\"rebootId\":1}}";
+  agencyTrx("/arango/Current/ServersKnown", st);
   arangodb::ServerState::instance()->setRebootId(arangodb::RebootId{1});
 
   // register factories & normalizers
@@ -436,7 +438,6 @@ void MockClusterServer::agencyTrx(std::string const& key, std::string const& val
 
 void MockClusterServer::agencyCreateDatabase(std::string const& name) {
   TemplateSpecializer ts(name);
-
 
   std::string st = ts.specialize(plan_dbs_string);
   agencyTrx("/arango/Plan/Databases/" + name, st);


### PR DESCRIPTION
### Scope & Purpose

Fix reboot tracker warnings in unit tests.
https://arangodb.atlassian.net/browse/AR-68

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is a *JIRA Ticket number*: https://arangodb.atlassian.net/browse/AR-68 

### Testing & Verification

This change is already covered by existing tests, such as *gtests*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10525/