### PR TITLE
use "steady_clock" for profiling and not "system_clock"

### DIFF
--- a/arangod/Aql/ExecutionBlock.cpp
+++ b/arangod/Aql/ExecutionBlock.cpp
@@ -30,9 +30,9 @@
 #include "Aql/ExecutionEngine.h"
 #include "Aql/ExecutionNode.h"
 #include "Aql/InputAqlItemRow.h"
+#include "Aql/Timing.h"
 #include "Aql/Query.h"
 #include "Basics/Exceptions.h"
-#include "Basics/system-functions.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Transaction/Context.h"
@@ -171,7 +171,7 @@ bool ExecutionBlock::isInSplicedSubquery() const noexcept {
 void ExecutionBlock::traceExecuteBegin(AqlCallStack const& stack, std::string const& clientId) {
   if (_profile >= PROFILE_LEVEL_BLOCKS) {
     if (_execNodeStats.runtime >= 0.0) {
-      _execNodeStats.runtime -= TRI_microtime();
+      _execNodeStats.runtime -= currentSteadyClockValue();
       TRI_ASSERT(_execNodeStats.runtime < 0.0);
     }
     
@@ -198,8 +198,8 @@ void ExecutionBlock::traceExecuteEnd(std::tuple<ExecutionState, SkipResult, Shar
     _execNodeStats.items += skipped.getSkipCount() + items;
     if (state != ExecutionState::WAITING) {
       TRI_ASSERT(_execNodeStats.runtime < 0.0);
-      _execNodeStats.runtime += TRI_microtime();
-      TRI_ASSERT(_execNodeStats.runtime > 0.0);
+      _execNodeStats.runtime += currentSteadyClockValue();
+      TRI_ASSERT(_execNodeStats.runtime >= 0.0);
     }
 
     if (_profile >= PROFILE_LEVEL_TRACE_1) {

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -37,11 +37,11 @@
 #include "Aql/QueryList.h"
 #include "Aql/QueryProfile.h"
 #include "Aql/QueryRegistry.h"
+#include "Aql/Timing.h"
 #include "Basics/Exceptions.h"
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/fasthash.h"
-#include "Basics/system-functions.h"
 #include "Cluster/ServerState.h"
 #include "Cluster/TraverserEngine.h"
 #include "Graph/Graph.h"
@@ -89,7 +89,7 @@ Query::Query(std::shared_ptr<transaction::Context> const& ctx,
       _options(options),
       _queryOptions(_vocbase.server().getFeature<QueryRegistryFeature>()),
       _trx(nullptr),
-      _startTime(TRI_microtime()),
+      _startTime(currentSteadyClockValue()),
       _queryHash(DontCache),
       _executionPhase(ExecutionPhase::INITIALIZE),
       _contextOwnedByExterior(ctx->isV8Context() && v8::Isolate::GetCurrent() != nullptr),
@@ -116,13 +116,13 @@ Query::Query(std::shared_ptr<transaction::Context> const& ctx,
 
   ProfileLevel level = _queryOptions.profile;
   if (level >= PROFILE_LEVEL_TRACE_1) {
-    LOG_TOPIC("22a70", INFO, Logger::QUERIES) << TRI_microtime() - _startTime << " "
-                                              << "Query::Query queryString: " << _queryString
+    LOG_TOPIC("22a70", INFO, Logger::QUERIES) << elapsedSince(_startTime)
+                                              << " Query::Query queryString: " << _queryString
                                               << " this: " << (uintptr_t)this;
   } else {
     LOG_TOPIC("11160", DEBUG, Logger::QUERIES)
-        << TRI_microtime() - _startTime << " "
-        << "Query::Query queryString: " << _queryString << " this: " << (uintptr_t)this;
+        << elapsedSince(_startTime)
+        << " Query::Query queryString: " << _queryString << " this: " << (uintptr_t)this;
   }
 
   if (bindParameters != nullptr && !bindParameters->isEmpty() &&
@@ -159,8 +159,8 @@ Query::Query(std::shared_ptr<transaction::Context> const& ctx,
 /// @brief destroys a query
 Query::~Query() {
   if (_queryOptions.profile >= PROFILE_LEVEL_TRACE_1) {
-    LOG_TOPIC("36a75", INFO, Logger::QUERIES) << TRI_microtime() - _startTime << " "
-                                              << "Query::~Query queryString: "
+    LOG_TOPIC("36a75", INFO, Logger::QUERIES) << elapsedSince(_startTime)
+                                              << " Query::~Query queryString: "
                                               << " this: " << (uintptr_t)this;
   }
 
@@ -174,13 +174,13 @@ Query::~Query() {
   _ast.reset();
 
   LOG_TOPIC("f5cee", DEBUG, Logger::QUERIES)
-      << TRI_microtime() - _startTime << " "
-      << "Query::~Query this: " << (uintptr_t)this;
+      << elapsedSince(_startTime)
+      << " Query::~Query this: " << (uintptr_t)this;
 }
 
 bool Query::killed() const {
   if (_queryOptions.maxRuntime > std::numeric_limits<double>::epsilon() &&
-      TRI_microtime() > (_startTime + _queryOptions.maxRuntime)) {
+      elapsedSince(_startTime) > _queryOptions.maxRuntime) {
     return true;
   }
   return _killed;
@@ -242,8 +242,8 @@ void Query::prepareQuery(SerializationFormat format) {
 /// QueryRegistry.
 std::unique_ptr<ExecutionPlan> Query::preparePlan() {
   TRI_ASSERT(!_queryString.empty());
-  LOG_TOPIC("9625e", DEBUG, Logger::QUERIES) << TRI_microtime() - _startTime << " "
-                                             << "Query::prepare"
+  LOG_TOPIC("9625e", DEBUG, Logger::QUERIES) << elapsedSince(_startTime)
+                                             << " Query::prepare"
                                              << " this: " << (uintptr_t)this;
 
   TRI_ASSERT(_ast != nullptr);
@@ -307,8 +307,8 @@ std::unique_ptr<ExecutionPlan> Query::preparePlan() {
 
 /// @brief execute an AQL query
 ExecutionState Query::execute(QueryResult& queryResult) {
-  LOG_TOPIC("e8ed7", DEBUG, Logger::QUERIES) << TRI_microtime() - _startTime << " "
-                                             << "Query::execute"
+  LOG_TOPIC("e8ed7", DEBUG, Logger::QUERIES) << elapsedSince(_startTime)
+                                             << " Query::execute"
                                              << " this: " << (uintptr_t)this;
 
   try {
@@ -526,8 +526,8 @@ QueryResult Query::executeSync() {
 
 // execute an AQL query: may only be called with an active V8 handle scope
 QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
-  LOG_TOPIC("6cac7", DEBUG, Logger::QUERIES) << TRI_microtime() - _startTime << " "
-                                             << "Query::executeV8"
+  LOG_TOPIC("6cac7", DEBUG, Logger::QUERIES) << elapsedSince(_startTime)
+                                             << " Query::executeV8"
                                              << " this: " << (uintptr_t)this;
 
   aql::QueryResultV8 queryResult;
@@ -659,8 +659,8 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
       builder->close();
     } catch (...) {
       LOG_TOPIC("8a6bf", DEBUG, Logger::QUERIES)
-          << TRI_microtime() - _startTime << " "
-          << "got an exception executing "
+          << elapsedSince(_startTime)
+          << " got an exception executing "
           << " this: " << (uintptr_t)this;
       throw;
     }
@@ -719,8 +719,8 @@ ExecutionState Query::finalize(QueryResult& result) {
   if (result.extra == nullptr || !result.extra->isOpenObject()) {
     // The above condition is not true if we have already waited.
     LOG_TOPIC("fc22c", DEBUG, Logger::QUERIES)
-        << TRI_microtime() - _startTime << " "
-        << "Query::finalize: before _trx->commit"
+        << elapsedSince(_startTime)
+        << " Query::finalize: before _trx->commit"
         << " this: " << (uintptr_t)this;
 
     Result commitResult = _trx->commit();
@@ -729,8 +729,8 @@ ExecutionState Query::finalize(QueryResult& result) {
     }
 
     LOG_TOPIC("7ef18", DEBUG, Logger::QUERIES)
-        << TRI_microtime() - _startTime << " "
-        << "Query::finalize: before cleanupPlanAndEngine"
+        << elapsedSince(_startTime)
+        << " Query::finalize: before cleanupPlanAndEngine"
         << " this: " << (uintptr_t)this;
 
     enterState(QueryExecutionState::ValueType::FINALIZATION);
@@ -748,7 +748,7 @@ ExecutionState Query::finalize(QueryResult& result) {
 
   _warnings.toVelocyPack(*result.extra);
 
-  double now = TRI_microtime();
+  double now = currentSteadyClockValue();
   if (_profile != nullptr && _queryOptions.profile >= PROFILE_LEVEL_BASIC) {
     _profile->setStateEnd(QueryExecutionState::ValueType::FINALIZATION, now);
     _profile->toVelocyPack(*(result.extra));
@@ -767,8 +767,8 @@ ExecutionState Query::finalize(QueryResult& result) {
   basics::VelocyPackHelper::patchDouble(result.extra->slice().get("stats").get("executionTime"),
                                         rt);
 
-  LOG_TOPIC("95996", DEBUG, Logger::QUERIES) << rt << " "
-                                             << "Query::finalize:returning"
+  LOG_TOPIC("95996", DEBUG, Logger::QUERIES) << rt 
+                                             << " Query::finalize:returning"
                                              << " this: " << (uintptr_t)this;
   return ExecutionState::DONE;
 }
@@ -1065,8 +1065,8 @@ bool Query::canUseQueryCache() const {
 /// @brief enter a new state
 void Query::enterState(QueryExecutionState::ValueType state) {
   LOG_TOPIC("d8767", DEBUG, Logger::QUERIES)
-      << TRI_microtime() - _startTime << " "
-      << "Query::enterState: " << state << " this: " << (uintptr_t)this;
+      << elapsedSince(_startTime)
+      << " Query::enterState: " << state << " this: " << (uintptr_t)this;
   if (_profile != nullptr) {
     // record timing for previous state
     _profile->setStateDone(_execState);
@@ -1109,7 +1109,7 @@ ExecutionState Query::cleanupPlanAndEngine(int errorCode, bool sync,
     ExecutionStats stats;
     stats.requests += _numRequests.load(std::memory_order_relaxed);
     stats.setPeakMemoryUsage(_resourceMonitor.peakMemoryUsage());
-    stats.setExecutionTime(TRI_microtime() - _startTime);
+    stats.setExecutionTime(elapsedSince(_startTime));
     
     for (auto& [eId, engine] : _snippets) {
       engine->collectExecutionStats(stats);
@@ -1275,8 +1275,8 @@ void ClusterQuery::prepareClusterQuery(SerializationFormat format,
                                        VPackSlice traverserSlice,
                                        VPackBuilder& answerBuilder,
                                        arangodb::AnalyzersRevision::Revision analyzersRevision) {
-  LOG_TOPIC("9636f", DEBUG, Logger::QUERIES) << TRI_microtime() - _startTime << " "
-                                             << "ClusterQuery::prepareClusterQuery"
+  LOG_TOPIC("9636f", DEBUG, Logger::QUERIES) << elapsedSince(_startTime)
+                                             << " ClusterQuery::prepareClusterQuery"
                                              << " this: " << (uintptr_t)this;
   
   init();
@@ -1386,8 +1386,8 @@ Result ClusterQuery::finalizeClusterQuery(ExecutionStats& stats, int errorCode) 
   TRI_ASSERT(ServerState::instance()->isDBServer());
   
   LOG_TOPIC("fc33c", DEBUG, Logger::QUERIES)
-       << TRI_microtime() - _startTime << " "
-       << "Query::finalizeSnippets: before _trx->commit, errorCode: "
+       << elapsedSince(_startTime)
+       << " Query::finalizeSnippets: before _trx->commit, errorCode: "
        << errorCode << ", this: " << (uintptr_t)this;
   
   for (auto& [eId, engine] : _snippets) {
@@ -1409,22 +1409,22 @@ Result ClusterQuery::finalizeClusterQuery(ExecutionStats& stats, int errorCode) 
   }
 
   LOG_TOPIC("8ea28", DEBUG, Logger::QUERIES)
-       << TRI_microtime() - _startTime << " "
-       << "Query::finalizeSnippets: before cleanupPlanAndEngine"
+       << elapsedSince(_startTime)
+       << " Query::finalizeSnippets: before cleanupPlanAndEngine"
        << " this: " << (uintptr_t)this;
 
   enterState(QueryExecutionState::ValueType::FINALIZATION);
   
   stats.requests += _numRequests.load(std::memory_order_relaxed);
   stats.setPeakMemoryUsage(_resourceMonitor.peakMemoryUsage());
-  stats.setExecutionTime(TRI_microtime() - _startTime);
+  stats.setExecutionTime(elapsedSince(_startTime));
   
   _snippets.clear();
   _traversers.clear();
   
   LOG_TOPIC("5fde0", DEBUG, Logger::QUERIES)
-      << TRI_microtime() - _startTime << " "
-      << "ClusterQuery::finalizeClusterQuery: done"
+      << elapsedSince(_startTime)
+      << " ClusterQuery::finalizeClusterQuery: done"
       << " this: " << (uintptr_t)this;
   
   return finishResult;

--- a/arangod/Aql/QueryCache.cpp
+++ b/arangod/Aql/QueryCache.cpp
@@ -636,7 +636,7 @@ void QueryCache::store(TRI_vocbase_t* vocbase, std::shared_ptr<QueryCacheResultE
     return;
   }
 
-  // set insertion time
+  // set insertion time (wall-clock time, only used for displaying it later)
   e->_stamp = TRI_microtime();
 
   // get the right part of the cache to store the result in

--- a/arangod/Aql/QueryList.cpp
+++ b/arangod/Aql/QueryList.cpp
@@ -25,13 +25,13 @@
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/Query.h"
 #include "Aql/QueryProfile.h"
+#include "Aql/Timing.h"
 #include "Basics/Exceptions.h"
 #include "Basics/ReadLocker.h"
 #include "Basics/Result.h"
 #include "Basics/StringUtils.h"
 #include "Basics/WriteLocker.h"
 #include "Basics/conversions.h"
-#include "Basics/system-functions.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
@@ -136,7 +136,7 @@ void QueryList::remove(Query* query) {
   }
 
   double const started = query->startTime();
-  double const now = TRI_microtime();
+  double const now = arangodb::aql::currentSteadyClockValue();
 
   query->vocbase().server().getFeature<arangodb::MetricsFeature>().counter(
       StaticStrings::AqlQueryRuntimeMs) += static_cast<uint64_t>(1000 * (now - started));
@@ -262,7 +262,7 @@ uint64_t QueryList::kill(std::function<bool(Query&)> const& filter, bool silent)
 
 /// @brief get the list of currently running queries
 std::vector<QueryEntryCopy> QueryList::listCurrent() {
-  double const now = TRI_microtime();
+  double const now = arangodb::aql::currentSteadyClockValue();
   size_t const maxLength = _maxQueryStringLength;
 
   std::vector<QueryEntryCopy> result;

--- a/arangod/Aql/QueryProfile.cpp
+++ b/arangod/Aql/QueryProfile.cpp
@@ -25,8 +25,8 @@
 
 #include "Aql/Query.h"
 #include "Aql/QueryList.h"
+#include "Aql/Timing.h"
 #include "Basics/EnumIterator.h"
-#include "Basics/system-functions.h"
 #include "VocBase/vocbase.h"
 
 #include <velocypack/Builder.h>
@@ -73,7 +73,7 @@ void QueryProfile::unregisterFromQueryList() noexcept {
 
 /// @brief sets a state to done
 double QueryProfile::setStateDone(QueryExecutionState::ValueType state) {
-  double const now = TRI_microtime();
+  double const now = arangodb::aql::currentSteadyClockValue();
 
   if (state != QueryExecutionState::ValueType::INVALID_STATE &&
       state != QueryExecutionState::ValueType::KILLED) {

--- a/arangod/Aql/Timing.cpp
+++ b/arangod/Aql/Timing.cpp
@@ -1,0 +1,54 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2016 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Aql/Timing.h"
+#include "Basics/debugging.h"
+
+#include <chrono>
+
+namespace arangodb {
+namespace aql {
+
+/// @brief returns the current value of the steady clock.
+/// note that values produced by this function are not necessarily
+/// identical to unix timestamps, and are thus not meaningful by themselves. 
+/// they are only meaningful to measure time differences, i.e. when 
+/// subtracting two of this function's return values from another.
+/// the values returned by this function are monotonically increasing,
+/// but not necessarily strictly monotonically increasing.
+double currentSteadyClockValue() {
+  return std::chrono::duration<double>(  // time since "start of clock" in seconds
+             std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+/// @brief returns the elapsed time (in seconds) since the previous
+/// value, which must have been produced by a call to currentSteadyClockValue().
+double elapsedSince(double previous) {
+  double diff = currentSteadyClockValue() - previous;
+  // the clock values must be monotonically increasing
+  TRI_ASSERT(diff >= 0.0);
+  return diff;
+}
+
+} // namespace aql
+} // namespace arangodb

--- a/arangod/Aql/Timing.h
+++ b/arangod/Aql/Timing.h
@@ -1,0 +1,46 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2018 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef ARANGOD_AQL_EXECUTION_TIMING_H
+#define ARANGOD_AQL_EXECUTION_TIMING_H 1
+
+namespace arangodb {
+namespace aql {
+
+/// @brief returns the current value of the steady clock.
+/// note that values produced by this function are not necessarily
+/// identical to unix timestamps, and are thus not meaningful by themselves. 
+/// they are only meaningful to measure time differences, i.e. when 
+/// subtracting two of this function's return values from another.
+/// the values returned by this function are monotonically increasing,
+/// but not necessarily strictly monotonically increasing.
+double currentSteadyClockValue();
+
+/// @brief returns the elapsed time (in seconds) since the previous
+/// value, which must have been produced by a call to currentSteadyClockValue().
+double elapsedSince(double previous);
+
+}  // namespace aql
+}  // namespace arangodb
+
+#endif

--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -372,6 +372,7 @@ set(LIB_ARANGO_AQL_SOURCES
   Aql/SubqueryExecutor.cpp
   Aql/SubqueryStartExecutionNode.cpp
   Aql/SubqueryStartExecutor.cpp
+  Aql/Timing.cpp
   Aql/TraversalConditionFinder.cpp
   Aql/TraversalExecutor.cpp
   Aql/TraversalNode.cpp


### PR DESCRIPTION
### Scope & Purpose

Use the `steady_clock` for AQL query profiling and not the `system_clock`.
The system_clock is not guaranteed to be monotonically increasing, and it may jump forward or backward anytime upon user or OS interaction.
The steady_clock however is monotonically increasing and thus can be used for measuring time differences between two timepoints without being affected by leaps forward or backward.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10538/