### PR TITLE
Do not translate Fuerte's Canceled into TRI_ERROR_REQUEST_CANCELED

### DIFF
--- a/arangod/Network/Utils.cpp
+++ b/arangod/Network/Utils.cpp
@@ -206,8 +206,6 @@ int toArangoErrorCodeInternal(fuerte::Error err) {
       return TRI_ERROR_CLUSTER_TIMEOUT;
 
     case fuerte::Error::Canceled:
-      return TRI_ERROR_REQUEST_CANCELED;
-
     case fuerte::Error::QueueCapacityExceeded:  // there is no result
     case fuerte::Error::ReadError:
     case fuerte::Error::WriteError:


### PR DESCRIPTION
These two errors mean something entirely different, so we just convert
Fuerte's Canceled into  TRI_ERROR_CLUSTER_CONNECTION_LOST.

Backport of https://github.com/arangodb/arangodb/pull/11880

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10553/