### PR TITLE
Do not abuse TRI_ERROR_REQUEST_CANCELED in Cluster code (#11882)

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -2472,7 +2472,7 @@ Result ClusterInfo::createCollectionsCoordinator(
         if (res.httpCode() == (int)arangodb::rest::ResponseCode::PRECONDITION_FAILED) {
           // use this special error code to signal that we got a precondition failure
           // in this case the caller can try again with an updated version of the plan change
-          return {TRI_ERROR_REQUEST_CANCELED,
+          return {TRI_ERROR_CLUSTER_CREATE_COLLECTION_PRECONDITION_FAILED,
                   "operation aborted due to precondition failure"};
         }
         std::string errorMsg = "HTTP code: " + std::to_string(res.httpCode());

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -2482,7 +2482,7 @@ std::vector<std::shared_ptr<LogicalCollection>> ClusterMethods::persistCollectio
       break;
     }
 
-    if (res.is(TRI_ERROR_REQUEST_CANCELED)) {
+    if (res.is(TRI_ERROR_CLUSTER_CREATE_COLLECTION_PRECONDITION_FAILED)) {
       // special error code indicating that storing the updated plan in the
       // agency didn't succeed, and that we should try again
 

--- a/js/common/bootstrap/errors.js
+++ b/js/common/bootstrap/errors.js
@@ -131,6 +131,7 @@
     "ERROR_REPLICATION_START_TICK_NOT_PRESENT" : { "code" : 1414, "message" : "start tick not present" },
     "ERROR_REPLICATION_WRONG_CHECKSUM" : { "code" : 1416, "message" : "wrong checksum" },
     "ERROR_REPLICATION_SHARD_NONEMPTY" : { "code" : 1417, "message" : "shard not empty" },
+    "ERROR_CLUSTER_CREATE_COLLECTION_PRECONDITION_FAILED" : { "code" : 1448, "message" : "creating collection failed due to precondition" },
     "ERROR_CLUSTER_SERVER_UNKNOWN" : { "code" : 1449, "message" : "got a request from an unkown server" },
     "ERROR_CLUSTER_TOO_MANY_SHARDS" : { "code" : 1450, "message" : "too many shards" },
     "ERROR_CLUSTER_COLLECTION_ID_EXISTS" : { "code" : 1453, "message" : "collection ID already exists" },

--- a/lib/Basics/errors.dat
+++ b/lib/Basics/errors.dat
@@ -169,6 +169,7 @@ ERROR_REPLICATION_SHARD_NONEMPTY,1417,"shard not empty","Will be raised when a s
 ## ArangoDB cluster errors
 ################################################################################
 
+ERROR_CLUSTER_CREATE_COLLECTION_PRECONDITION_FAILED,1448,"creating collection failed due to precondition","Will be raised when updating the plan on collection creatio failed."
 ERROR_CLUSTER_SERVER_UNKNOWN,1449,"got a request from an unkown server","Will be raised on some occasions when one server gets a request from another, which has not (yet?) been made known via the Agency."
 ERROR_CLUSTER_TOO_MANY_SHARDS,1450,"too many shards","Will be raised when the number of shards for a collection is higher than allowed."
 ERROR_CLUSTER_COLLECTION_ID_EXISTS,1453,"collection ID already exists","Will be raised when a Coordinator in a cluster tries to create a collection and the collection ID already exists."

--- a/lib/Basics/voc-errors.cpp
+++ b/lib/Basics/voc-errors.cpp
@@ -131,6 +131,7 @@ void TRI_InitializeErrorMessages() {
   REG_ERROR(ERROR_REPLICATION_START_TICK_NOT_PRESENT, "start tick not present");
   REG_ERROR(ERROR_REPLICATION_WRONG_CHECKSUM, "wrong checksum");
   REG_ERROR(ERROR_REPLICATION_SHARD_NONEMPTY, "shard not empty");
+  REG_ERROR(ERROR_CLUSTER_CREATE_COLLECTION_PRECONDITION_FAILED, "creating collection failed due to precondition");
   REG_ERROR(ERROR_CLUSTER_SERVER_UNKNOWN, "got a request from an unkown server");
   REG_ERROR(ERROR_CLUSTER_TOO_MANY_SHARDS, "too many shards");
   REG_ERROR(ERROR_CLUSTER_COLLECTION_ID_EXISTS, "collection ID already exists");

--- a/lib/Basics/voc-errors.h
+++ b/lib/Basics/voc-errors.h
@@ -658,6 +658,11 @@ constexpr int TRI_ERROR_REPLICATION_WRONG_CHECKSUM                              
 /// Will be raised when a shard is not empty and the follower tries a shortcut
 constexpr int TRI_ERROR_REPLICATION_SHARD_NONEMPTY                              = 1417;
 
+/// 1448: ERROR_CLUSTER_CREATE_COLLECTION_PRECONDITION_FAILED
+/// "creating collection failed due to precondition"
+/// Will be raised when updating the plan on collection creatio failed.
+constexpr int TRI_ERROR_CLUSTER_CREATE_COLLECTION_PRECONDITION_FAILED           = 1448;
+
 /// 1449: ERROR_CLUSTER_SERVER_UNKNOWN
 /// "got a request from an unkown server"
 /// Will be raised on some occasions when one server gets a request from

--- a/lib/Rest/GeneralResponse.cpp
+++ b/lib/Rest/GeneralResponse.cpp
@@ -419,6 +419,9 @@ rest::ResponseCode GeneralResponse::responseCode(int code) {
     case TRI_ERROR_TASK_DUPLICATE_ID:
     case TRI_ERROR_GRAPH_DUPLICATE:
       return ResponseCode::CONFLICT;
+    
+    case TRI_ERROR_CLUSTER_CREATE_COLLECTION_PRECONDITION_FAILED:
+      return ResponseCode::PRECONDITION_FAILED;
 
     case TRI_ERROR_DEADLOCK:
     case TRI_ERROR_ARANGO_OUT_OF_KEYS:


### PR DESCRIPTION
Introduce a special error code to signal that updating the plan on
creating a collection had a failed precondition, and maybe the
surrounding code should try again.

In particular stop abusing a pre-existing error code that has no
relation to this context.

Backport of https://github.com/arangodb/arangodb/pull/11882

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10554/