### PR TITLE
Bug fix/assert on passthrough indexes (#11818)

### DIFF
--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -1049,9 +1049,7 @@ auto ExecutionBlockImpl<Executor>::shadowRowForwarding(AqlCallStack& stack) -> E
   auto&& [state, shadowRow] = _lastRange.nextShadowRow();
   TRI_ASSERT(shadowRow.isInitialized());
 
-  _outputItemRow->moveRow(shadowRow);
   countShadowRowProduced(stack, shadowRow.getDepth());
-
   if (shadowRow.isRelevant()) {
     LOG_QUERY("6d337", DEBUG) << printTypeInfo() << " init executor.";
     // We found a relevant shadow Row.
@@ -1059,6 +1057,7 @@ auto ExecutionBlockImpl<Executor>::shadowRowForwarding(AqlCallStack& stack) -> E
     resetExecutor();
   }
 
+  _outputItemRow->moveRow(shadowRow);
   TRI_ASSERT(_outputItemRow->produced());
   _outputItemRow->advanceRow();
   if (state == ExecutorState::DONE) {

--- a/arangod/Aql/InputAqlItemRow.cpp
+++ b/arangod/Aql/InputAqlItemRow.cpp
@@ -39,8 +39,8 @@ using namespace arangodb;
 using namespace arangodb::aql;
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-bool InputAqlItemRow::internalBlockIs(SharedAqlItemBlockPtr const& other) const {
-  return _block == other;
+bool InputAqlItemRow::internalBlockIs(SharedAqlItemBlockPtr const& other, size_t index) const {
+  return _block == other && _baseIndex == index;
 }
 #endif
 

--- a/arangod/Aql/InputAqlItemRow.h
+++ b/arangod/Aql/InputAqlItemRow.h
@@ -115,7 +115,7 @@ class InputAqlItemRow {
   /**
    * @brief Compare the underlying block. Only for assertions.
    */
-  bool internalBlockIs(SharedAqlItemBlockPtr const& other) const;
+  bool internalBlockIs(SharedAqlItemBlockPtr const& other, size_t index) const;
 #endif
 
   /**

--- a/arangod/Aql/OutputAqlItemRow.cpp
+++ b/arangod/Aql/OutputAqlItemRow.cpp
@@ -187,7 +187,7 @@ void OutputAqlItemRow::copyOrMoveRow(ItemRowType& sourceRow, bool ignoreMissing)
   if (_doNotCopyInputRow) {
     TRI_ASSERT(sourceRow.isInitialized());
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-    TRI_ASSERT(sourceRow.internalBlockIs(_block));
+    TRI_ASSERT(sourceRow.internalBlockIs(_block, _baseIndex));
 #endif
     _inputRowCopied = true;
     memorizeRow(sourceRow);
@@ -200,7 +200,7 @@ void OutputAqlItemRow::copyOrMoveRow(ItemRowType& sourceRow, bool ignoreMissing)
 auto OutputAqlItemRow::fastForwardAllRows(InputAqlItemRow const& sourceRow, size_t rows)
     -> void {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-  TRI_ASSERT(sourceRow.internalBlockIs(_block));
+  TRI_ASSERT(sourceRow.internalBlockIs(_block, _baseIndex));
 #endif
   TRI_ASSERT(_doNotCopyInputRow);
   TRI_ASSERT(_call.getLimit() >= rows);
@@ -226,7 +226,7 @@ void OutputAqlItemRow::copyBlockInternalRegister(InputAqlItemRow const& sourceRo
   // This method is only allowed if the block of the input row is the same as
   // the block of the output row!
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-  TRI_ASSERT(sourceRow.internalBlockIs(_block));
+  TRI_ASSERT(sourceRow.internalBlockIs(_block, _baseIndex));
 #endif
   TRI_ASSERT(isOutputRegister(output));
   // This is already implicitly asserted by isOutputRegister:
@@ -348,7 +348,7 @@ void OutputAqlItemRow::createShadowRow(InputAqlItemRow const& sourceRow) {
   TRI_ASSERT(sourceRow.isInitialized());
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // We can only add shadow rows if source and this are different blocks
-  TRI_ASSERT(!sourceRow.internalBlockIs(_block));
+  TRI_ASSERT(!sourceRow.internalBlockIs(_block, _baseIndex));
 #endif
   block().makeShadowRow(_baseIndex);
   doCopyOrMoveRow<InputAqlItemRow const, CopyOrMove::COPY, AdaptRowDepth::IncreaseDepth>(sourceRow, true);

--- a/arangod/Aql/ShadowAqlItemRow.cpp
+++ b/arangod/Aql/ShadowAqlItemRow.cpp
@@ -55,8 +55,8 @@ bool ShadowAqlItemRow::isInitialized() const {
 }
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-bool ShadowAqlItemRow::internalBlockIs(SharedAqlItemBlockPtr const& other) const {
-  return _block == other;
+bool ShadowAqlItemRow::internalBlockIs(SharedAqlItemBlockPtr const& other, size_t index) const {
+  return _block == other && _baseIndex == index;
 }
 #endif
 

--- a/arangod/Aql/ShadowAqlItemRow.h
+++ b/arangod/Aql/ShadowAqlItemRow.h
@@ -83,7 +83,7 @@ class ShadowAqlItemRow {
   /**
    * @brief Compare the underlying block. Only for assertions.
    */
-  [[nodiscard]] bool internalBlockIs(SharedAqlItemBlockPtr const& other) const;
+  [[nodiscard]] bool internalBlockIs(SharedAqlItemBlockPtr const& other, size_t index) const;
 #endif
 
   /**


### PR DESCRIPTION
Just PR adds an assertion around  passthrough blocks to make sure we actually pass through identical lines.

Also moves down a "move" operation.
I do not think that the earlier code is incorrect, as the only read value is copied instead of moved (because it it the meta information and only data is moved here) but it is more obvious that this is correct now.

Jenkins:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10561/