### PR TITLE
potential shutdown speedup (#11902)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
+* Allow for faster cluster shutdown. This should reduce the number of shutdown
+  hangers in case the agents are stopped already and then coordinators or
+  DB-Servers are shut down.
+
 * Fixed issue ES-598. Web UI now shows correct permissions in case wildcard
   database level and wildcard collection level permissions are both set.
 

--- a/arangod/Agency/AgencyComm.h
+++ b/arangod/Agency/AgencyComm.h
@@ -587,7 +587,7 @@ class AgencyComm {
  public:
   explicit AgencyComm(application_features::ApplicationServer&);
 
-  AgencyCommResult sendServerState();
+  AgencyCommResult sendServerState(double timeout);
 
   std::string version();
 
@@ -604,8 +604,9 @@ class AgencyComm {
 
   AgencyCommResult setValue(std::string const&, arangodb::velocypack::Slice const&, double);
 
-  AgencyCommResult setTransient(std::string const&,
-                                arangodb::velocypack::Slice const&, uint64_t);
+  AgencyCommResult setTransient(std::string const& key,
+                                arangodb::velocypack::Slice const& slice, 
+                                uint64_t ttl, double timeout);
 
   bool exists(std::string const&);
 

--- a/arangod/Agency/AsyncAgencyComm.cpp
+++ b/arangod/Agency/AsyncAgencyComm.cpp
@@ -48,8 +48,8 @@ using RequestType = arangodb::AsyncAgencyComm::RequestType;
 struct RequestMeta {
   network::Timeout timeout;
   fuerte::RestVerb method;
-  std::string url;
   RequestType type;
+  std::string url;
   std::vector<std::string> clientIds;
   network::Headers headers;
   clock::time_point startTime;
@@ -412,7 +412,7 @@ AsyncAgencyComm::FutureResult AsyncAgencyComm::sendWithFailover(
   uint64_t requestId = _manager.nextRequestId();
 
   return agencyAsyncSend(_manager,
-                         RequestMeta({timeout, method, url, type, std::move(clientIds),
+                         RequestMeta({timeout, method, type, url, std::move(clientIds),
                                       std::move(headers), clock::now(), requestId,
                                       _skipScheduler || _manager.getSkipScheduler(), 0}),
                          std::move(body))
@@ -572,7 +572,6 @@ AsyncAgencyComm::FutureResult AsyncAgencyComm::sendReadTransaction(
 
 AsyncAgencyComm::FutureResult AsyncAgencyComm::sendPollTransaction(
   network::Timeout timeout, uint64_t index) const {
-  std::vector<ClientId> clientIds;
 
   return sendWithFailover(
     fuerte::RestVerb::Get, AGENCY_URL_POLL, timeout, RequestType::READ, index);

--- a/arangod/Cluster/ClusterFeature.h
+++ b/arangod/Cluster/ClusterFeature.h
@@ -120,8 +120,8 @@ class ClusterFeature : public application_features::ApplicationFeature {
   bool _unregisterOnShutdown = false;
   bool _enableCluster = false;
   bool _requirePersistedId = false;
-  double _indexCreationTimeout = 3600.0;
   bool _allocated = false;
+  double _indexCreationTimeout = 3600.0;
   std::unique_ptr<ClusterInfo> _clusterInfo;
   std::shared_ptr<HeartbeatThread> _heartbeatThread;
   std::unique_ptr<AgencyCache> _agencyCache;

--- a/arangod/Cluster/ServerState.h
+++ b/arangod/Cluster/ServerState.h
@@ -194,8 +194,17 @@ class ServerState {
   bool integrateIntoCluster(RoleEnum role, std::string const& myAddr,
                             std::string const& myAdvEndpoint);
 
-  /// @brief unregister this server with the agency
-  bool unregister();
+  /// @brief unregister this server with the agency, removing it from
+  /// the cluster setup.
+  /// the timeout can be used as the max wait time for the agency to
+  /// acknowledge the unregister action.
+  bool unregister(double timeout);
+
+  /// @brief mark this server as shut down in the agency, without removing it
+  /// from the cluster setup.
+  /// the timeout can be used as the max wait time for the agency to
+  /// acknowledge the logoff action.
+  bool logoff(double timeout);
 
   /// @brief set the server role
   void setRole(RoleEnum);


### PR DESCRIPTION
### Scope & Purpose

Speed up the cluster shutdown by waiting for shorter periods for transient agency writes on shutdown and in heartbeat thread.

Potentially fixes https://arangodb.atlassian.net/browse/BTS-90 and https://arangodb.atlassian.net/browse/BTS-104.

Backport of https://github.com/arangodb/arangodb/pull/11902/

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

- [x] There is a *JIRA Ticket number*: https://arangodb.atlassian.net/browse/BTS-90 and https://arangodb.atlassian.net/browse/BTS-104

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10573/