### PR TITLE
Bug fix/internal issue #720

### DIFF
--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -783,6 +783,25 @@ arangodb::Result visitAnalyzers(
       }
 
       auto shards = collection->shardIds();
+      if (ADB_UNLIKELY(!shards)) {
+        TRI_ASSERT(FALSE);
+        return {};  // treat missing collection as if there are no analyzers
+      }
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+      LOG_TOPIC("e07d4", WARN, arangodb::iresearch::TOPIC)
+          << "OneShard optimization found " << shards->size() << " shards "
+          << " for server " << arangodb::ServerState::instance()->getId();
+      for (auto const& shard : *shards) {
+        LOG_TOPIC("31300", WARN, arangodb::iresearch::TOPIC)
+            << "Shard '" << shard.first << "' on servers:";
+        for (auto const& server : shard.second) {
+          LOG_TOPIC("ead22", WARN, arangodb::iresearch::TOPIC)
+              << "Shard server '" << server << "'";
+        }
+      }
+#endif
+
       if (shards->empty()) {
         return {}; // treat missing collection as if there are no analyzers
       }

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -789,14 +789,14 @@ arangodb::Result visitAnalyzers(
       }
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-      LOG_TOPIC("e07d4", WARN, arangodb::iresearch::TOPIC)
+      LOG_TOPIC("e07d4", TRACE, arangodb::iresearch::TOPIC)
           << "OneShard optimization found " << shards->size() << " shards "
           << " for server " << arangodb::ServerState::instance()->getId();
       for (auto const& shard : *shards) {
-        LOG_TOPIC("31300", WARN, arangodb::iresearch::TOPIC)
+        LOG_TOPIC("31300", TRACE, arangodb::iresearch::TOPIC)
             << "Shard '" << shard.first << "' on servers:";
         for (auto const& server : shard.second) {
-          LOG_TOPIC("ead22", WARN, arangodb::iresearch::TOPIC)
+          LOG_TOPIC("ead22", TRACE, arangodb::iresearch::TOPIC)
               << "Shard server '" << server << "'";
         }
       }


### PR DESCRIPTION
PR adds test case for loading analyzers in oneshard database.
Additional trace level logging added in maintainer mode to help debug oneshard optimization in future.

Suggest to not backport to 3.7 (as it contains no fixes in implementation) just leave in devel  to avoid same pitfall in future.
