### PR TITLE
fix condition where empty ID is ok

### DIFF
--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -2584,7 +2584,7 @@ arangodb::Result hotBackupList(network::ConnectionPool* pool,
   << futures.size() << " lists of local backups";
 
   // Any error if no id presented
-  if (!idSlice.isNone() && nrGood < futures.size()) {
+  if (idSlice.isNone() && nrGood < futures.size()) {
     return arangodb::Result(
       TRI_ERROR_HOT_BACKUP_DBSERVERS_AWOL,
       std::string("not all db servers could be reached for backup listing"));


### PR DESCRIPTION
The go driver tests searches for non-existing IDs; this will loop forever, until a timeout occurs. 
This condition was wrong corrosponding to the comment above its line, correcting it fixes this behaviour. 