### PR TITLE
Add CHANGELOG entry for failover graph not found error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 devel
 -----
 
+* Fixed that, when performing a graph AQL query while a (graceful) failover for
+  the leader of the system collections is in progress, ArangoDB would report a 
+  "Graph not found error".
+  The real error, namely that an agency transaction failed, was swallowed in 
+  the graph lookup code due to a wrong error code being used from Fuerte. 
+  We now generate a more appropriate 503 - Service Unavailable error
+
 * added option `--log.use-json-format` to switch log output to JSON format.
   Each log message then produces a seperate line with JSON-encoded log data,
   which can be consumed by applications.


### PR DESCRIPTION
This is a missing changelog entry pertaining to #11880 and #11882 (and #11857)