### PR TITLE
Bug fix 3.7/fix condition where empty list is ok

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
+* Fixed cluster behaviour with hot backup and non existing backups on db-servers
+
 * Fixed bad behavior that led to unnecessary additional revision tree rebuilding
   on server restart.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
-* Fixed cluster behaviour with hot backup and non existing backups on db-servers
+* Fixed cluster behavior with hot backup and non existing backups on db-servers.
 
 * Fixed bad behavior that led to unnecessary additional revision tree rebuilding
   on server restart.

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -2584,7 +2584,7 @@ arangodb::Result hotBackupList(network::ConnectionPool* pool,
   << futures.size() << " lists of local backups";
 
   // Any error if no id presented
-  if (!idSlice.isNone() && nrGood < futures.size()) {
+  if (idSlice.isNone() && nrGood < futures.size()) {
     return arangodb::Result(
       TRI_ERROR_HOT_BACKUP_DBSERVERS_AWOL,
       std::string("not all db servers could be reached for backup listing"));


### PR DESCRIPTION
### Scope & Purpose
fix go driver backup tests - searching for non-existing backups in clusters
- [x] Bug-Fix for *devel-branch* only applies devel & 3.7
- [x] Bug-Fix for a *released version* 
- [x] The behavior in this PR can be (and was) *manually tested* - search for non existing backup in cluster.
- [x] The behavior change can be verified via automatic tests by running go driver tests

#### Related Information
- [x] TBTS-41

### Testing & Verification
run go driver tests
- [x] There are tests in an external testing repository (i.e. node-resilience tests, chaos tests)

### Documentation

- [x] Added a *Changelog Entry* (referencing the corresponding public or internal issue number)
