### PR TITLE
Fix hotbackup agency lock cleanup.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.6.5 (XXXX-XX-XX)
 -------------------
 
+* Fixed hotbackup agency lock cleanup.
+
 * Web UI now shows correct permissions in case wildcard database level and
   wildcard collection level permissions are both set.
 

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -4445,7 +4445,7 @@ arangodb::Result ClusterInfo::agencyReplan(VPackSlice const plan) {
   return arangodb::Result();
 }
 
-std::string const backupKey = "/arango/Target/HotBackup/Create/";
+std::string const backupKey = "/arango/Target/HotBackup/Create";
 std::string const maintenanceKey = "/arango/Supervision/Maintenance";
 std::string const supervisionMode = "/arango/Supervision/State/Mode";
 std::string const toDoKey = "/arango/Target/ToDo";
@@ -4477,7 +4477,7 @@ arangodb::Result ClusterInfo::agencyHotBackupLock(std::string const& backupId,
       {
         VPackObjectBuilder o(&builder);
         builder.add(                                      // Backup lock
-          backupKey + backupId,
+          backupKey,
           VPackValue(
             timepointToString(
               std::chrono::system_clock::now() + std::chrono::seconds(timeouti))));
@@ -4521,7 +4521,7 @@ arangodb::Result ClusterInfo::agencyHotBackupLock(std::string const& backupId,
       {
         VPackObjectBuilder o(&builder);
         builder.add(                                      // Backup lock
-          backupKey + backupId,
+          backupKey,
           VPackValue(
             timepointToString(
               std::chrono::system_clock::now() + std::chrono::seconds(timeouti))));


### PR DESCRIPTION
In case that a coordinator organising a hotbackup crashes during the hotbackup a hotbackup lock in the agency is left behind. To fix this, there is already a cleanup routine in the agency supervision. Unfortunately, this cleanup routine did not fit to the actual way the lock was acquired. Therefore the lock does not work. This PR adjusts the way the lock is acquired to the cleanup routine, thereby enabling automatic cleanup of left over locks. This is important for Oasis, see https://arangodb.atlassian.net/browse/OASIS-252