### PR TITLE
add suppression for rocksdb leak

### DIFF
--- a/lsan_arangodb_suppressions.txt
+++ b/lsan_arangodb_suppressions.txt
@@ -1,3 +1,5 @@
 leak:create_conn
 leak:CRYPTO_zalloc
 leak:snowball
+leak:rocksdb::Arena::AllocateNewBlock
+leak:AllocateNewBlock


### PR DESCRIPTION
### Scope & Purpose

Adds a RocksDB-internal function to the leak sanitzer suppressions.
We found a one-time leak on startup inside RocksDB, which does not seem to have great effect and looks tolerable.
This PR adds the function name to the suppressions file, so we can ignore this leak in our tests.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *ASan tests in Jenkins*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10631/