### PR TITLE
Bug fix 3.4/fix all numeric guids on restore

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,16 @@
 v3.4.11 (XXXX-XX-XX)
 --------------------
 
+* Allows restoring collections from v3.3.0 with their all-numeric collection
+  GUID values, by creating a new, unambiguous collection GUID for them. 
+  v3.3.0 had a bug because it created all-numeric GUID values, which can be
+  confused with numeric collection ids in lookups. v3.3.1 already changed the
+  GUID routine to produce something non-numeric already, but collections
+  created with v3.3.0 can still have an ambiguous GUID. This fix adjusts
+  the restore routine to drop such GUID values, so it only changes something
+  if v3.3.0 collections are dumped, dropped on the server and then restored
+  with the flawed GUIDs.
+
 * Fixed velocypack validator for proper check of keys.
 
 * Fixed issue ES-598. Web UI now shows correct permissions in case wildcard


### PR DESCRIPTION
### Scope & Purpose

Allows restoring collections from v3.3.0 with their all-numeric collection GUID values, by creating a new, unambiguous collection GUID for them. 
v3.3.0 had a bug because it created all-numeric GUID values, which can be confused with numeric collection ids in lookups. v3.3.1 already changed the GUID routine to produce something non-numeric already, but collections created with v3.3.0 can still have an ambiguous GUID. This fix adjusts the restore routine to drop such GUID values, so it only changes something if v3.3.0 collections are dumped, dropped on the server and then restored with the flawed GUIDs.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

- [x] There is a *JIRA Ticket number*: https://arangodb.atlassian.net/browse/DEVSUP-572 

### Testing & Verification

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10632/