### PR TITLE
fix all-numeric collection GUIDs on restore

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,16 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
+* Allow restoring collections from v3.3.0 with their all-numeric collection
+  GUID values, by creating a new, unambiguous collection GUID for them. 
+  v3.3.0 had a bug because it created all-numeric GUID values, which can be
+  confused with numeric collection ids in lookups. v3.3.1 already changed the
+  GUID routine to produce something non-numeric already, but collections
+  created with v3.3.0 can still have an ambiguous GUID. This fix adjusts
+  the restore routine to drop such GUID values, so it only changes something
+  if v3.3.0 collections are dumped, dropped on the server and then restored
+  with the flawed GUIDs.
+
 * Fixed hotbackup agency lock cleanup procedure.
 
 * The Web UI's replication view is now checking the replication state

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,15 +1,15 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
-* Allow restoring collections from v3.3.0 with their all-numeric collection
-  GUID values, by creating a new, unambiguous collection GUID for them. 
+* Allow restoring collections from v3.3.0 with their all-numeric collection GUID
+  values, by creating a new, unambiguous collection GUID for them.
   v3.3.0 had a bug because it created all-numeric GUID values, which can be
   confused with numeric collection ids in lookups. v3.3.1 already changed the
-  GUID routine to produce something non-numeric already, but collections
-  created with v3.3.0 can still have an ambiguous GUID. This fix adjusts
-  the restore routine to drop such GUID values, so it only changes something
-  if v3.3.0 collections are dumped, dropped on the server and then restored
-  with the flawed GUIDs.
+  GUID routine to produce something non-numeric already, but collections created
+  with v3.3.0 can still have an ambiguous GUID. This fix adjusts the restore
+  routine to drop such GUID values, so it only changes something if v3.3.0
+  collections are dumped, dropped on the server and then restored with the
+  flawed GUIDs.
 
 * Fixed hotbackup agency lock cleanup procedure.
 

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -27,6 +27,7 @@
 #include "Aql/Query.h"
 #include "Basics/ConditionLocker.h"
 #include "Basics/HybridLogicalClock.h"
+#include "Basics/NumberUtils.h"
 #include "Basics/ReadLocker.h"
 #include "Basics/Result.h"
 #include "Basics/RocksDBUtils.h"
@@ -1237,6 +1238,19 @@ Result RestReplicationHandler::processRestoreCollectionCoordinator(
       toMerge.add(StaticStrings::NumberOfShards, VPackValue(numberOfShards));
     } else {
       numberOfShards = numberOfShardsSlice.getUInt();
+    }
+  }
+
+  if (parameters.get(StaticStrings::DataSourceGuid).isString()) {
+    std::string const uuid = parameters.get(StaticStrings::DataSourceGuid).copyString();
+    bool valid = false;
+    NumberUtils::atoi_positive<uint64_t>(uuid.data(), uuid.data() + uuid.size(), valid);
+    if (valid) {
+      // globallyUniqueId is only numeric. This causes ambiguities later
+      // and can only happen for collections created with v3.3.0 (the GUID
+      // generation process was changed in v3.3.1 already to fix this issue).
+      // remove the globallyUniqueId so a new one will be generated server.side
+      toMerge.add(StaticStrings::DataSourceGuid, VPackSlice::nullSlice());
     }
   }
 
@@ -3343,6 +3357,17 @@ int RestReplicationHandler::createCollection(VPackSlice slice,
   patch.openObject();
   patch.add("version", VPackValue(static_cast<int>(LogicalCollection::currentVersion())));
   patch.add(StaticStrings::DataSourceSystem, VPackValue(TRI_vocbase_t::IsSystemName(name)));
+  if (!uuid.empty()) {
+    bool valid = false;
+    NumberUtils::atoi_positive<uint64_t>(uuid.data(), uuid.data() + uuid.size(), valid);
+    if (valid) {
+      // globallyUniqueId is only numeric. This causes ambiguities later
+      // and can only happen for collections created with v3.3.0 (the GUID
+      // generation process was changed in v3.3.1 already to fix this issue).
+      // remove the globallyUniqueId so a new one will be generated server.side
+      patch.add(StaticStrings::DataSourceGuid, VPackSlice::nullSlice());
+    }
+  }
   patch.add("objectId", VPackSlice::nullSlice());
   patch.add("cid", VPackSlice::nullSlice());
   patch.add("id", VPackSlice::nullSlice());


### PR DESCRIPTION
### Scope & Purpose

Allows restoring collections from v3.3.0 with their all-numeric collection GUID values, by creating a new, unambiguous collection GUID for them. 
v3.3.0 had a bug because it created all-numeric GUID values, which can be confused with numeric collection ids in lookups. v3.3.1 already changed the GUID routine to produce something non-numeric already, but collections created with v3.3.0 can still have an ambiguous GUID. This fix adjusts the restore routine to drop such GUID values, so it only changes something if v3.3.0 collections are dumped, dropped on the server and then restored with the flawed GUIDs.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

- [x] There is a *JIRA Ticket number*: https://arangodb.atlassian.net/browse/DEVSUP-572 

### Testing & Verification

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10635/