### PR TITLE
Allow _admin/server prefix on followers

### DIFF
--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -185,11 +185,11 @@ CommTask::Flow CommTask::prepareExecution(auth::TokenCache::Entry const& authTok
     }
     [[fallthrough]];
     case ServerState::Mode::TRYAGAIN: {
+      // the following paths are whitelisted on followers
       if (!::startsWith(path, "/_admin/shutdown") &&
           !::startsWith(path, "/_admin/cluster/health") &&
           !::startsWith(path, "/_admin/log") &&
-          !::startsWith(path, "/_admin/server/role") &&
-          !::startsWith(path, "/_admin/server/availability") &&
+          !::startsWith(path, "/_admin/server/") &&
           !::startsWith(path, "/_admin/status") &&
           !::startsWith(path, "/_admin/statistics") &&
           !::startsWith(path, "/_api/agency/agency-callbacks") &&

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -185,7 +185,7 @@ CommTask::Flow CommTask::prepareExecution(auth::TokenCache::Entry const& authTok
     }
     [[fallthrough]];
     case ServerState::Mode::TRYAGAIN: {
-      // the following paths are whitelisted on followers
+      // the following paths are allowed on followers
       if (!::startsWith(path, "/_admin/shutdown") &&
           !::startsWith(path, "/_admin/cluster/health") &&
           !::startsWith(path, "/_admin/log") &&


### PR DESCRIPTION
always allow access to `_admin/server` APIs on active failover