### PR TITLE
fix schema validation test errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,14 +1,14 @@
 devel
 -----
 
-* Allow removal of existing schemas by saving a schema of either `null`
-  or `{}` (empty object) . Using an empty string as schema will produce
-  an error in the web interface and will not remove the schema.
+* Allow removal of existing schemas by saving a schema of either `null` or `{}`
+  (empty object). Using an empty string as schema will produce  an error in the
+  web interface and will not remove the schema.
 
-  The PR also adjusts the behavior for the SCHEMA_VALIDATE AQL function
-  in case the first parameter was no document/object. In this case, the
-  function will now return nulland register a warning in the query, so
-  the user can handle it.
+  The change also adjusts the behavior for the SCHEMA_VALIDATE AQL function in
+  case the first parameter was no document/object. In this case, the function
+  will now return nulland register a warning in the query, so the user can
+  handle it.
 
 * Allow restoring collections from v3.3.0 with their all-numeric collection
   GUID values, by creating a new, unambiguous collection GUID for them. 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,15 @@
 devel
 -----
 
+* Allow removal of existing schemas by saving a schema of either `null`
+  or `{}` (empty object) . Using an empty string as schema will produce
+  an error in the web interface and will not remove the schema.
+
+  The PR also adjusts the behavior for the SCHEMA_VALIDATE AQL function
+  in case the first parameter was no document/object. In this case, the
+  function will now return nulland register a warning in the query, so
+  the user can handle it.
+
 * Fixed bug in IResearchViewExecutor that lead to only up to 1000 rows being
   produced.
 

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -7500,12 +7500,6 @@ AqlValue Functions::SchemaGet(ExpressionContext* expressionContext,
                               transaction::Methods* trx,
                               VPackFunctionParameters const& parameters) {
   // SCHEMA_GET(collectionName) -> schema object
-  static char const* AFN = "SCHEMA_GET";
-
-  if (parameters.size() != 1) {
-    THROW_ARANGO_EXCEPTION_PARAMS(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH, AFN);
-  }
-
   std::string const collectionName = ::extractCollectionName(trx, parameters, 0);
 
   if (collectionName.empty()) {
@@ -7533,7 +7527,7 @@ AqlValue Functions::SchemaGet(ExpressionContext* expressionContext,
 
   if (!ruleSlice.isObject()) {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
-                                   "validation object of collection " +
+                                   "schema definition for collection " +
                                        collectionName + " has no rule object");
   }
 
@@ -7547,14 +7541,19 @@ AqlValue Functions::SchemaValidate(ExpressionContext* expressionContext,
   static char const* AFN = "SCHEMA_VALIDATE";
   auto const* vpackOptions = trx->transactionContext()->getVPackOptions();
 
-  if (parameters.size() != 2) {
-    THROW_ARANGO_EXCEPTION_PARAMS(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH, AFN);
-  }
-
   AqlValue const& docValue = extractFunctionParameterValue(parameters, 0);
   AqlValue const& schemaValue = extractFunctionParameterValue(parameters, 1);
 
-  if (schemaValue.isNull(false)) {
+  if (!docValue.isObject()) {
+    registerWarning(expressionContext, AFN,
+                    Result(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH,
+                           "expecting document object"));
+    return AqlValue(AqlValueHintNull());
+  }
+
+  if (schemaValue.isNull(false) || 
+      (schemaValue.isObject() && schemaValue.length() == 0)) {
+    // schema is null or {}
     transaction::BuilderLeaser resultBuilder(trx);
     {
       VPackObjectBuilder guard(resultBuilder.builder());
@@ -7570,10 +7569,10 @@ AqlValue Functions::SchemaValidate(ExpressionContext* expressionContext,
   }
   auto* validator = expressionContext->buildValidator(schemaValue.slice());
 
-  //store and restore validation level this is cheaper than modifying the VPack
+  // store and restore validation level this is cheaper than modifying the VPack
   auto storedLevel = validator->level();
 
-  //override level so the validation will be executed no matter what
+  // override level so the validation will be executed no matter what
   validator->setLevel(ValidationLevel::Strict);
 
   Result res;

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -240,8 +240,8 @@ void handlePlanShard(uint64_t planIndex, VPackSlice const& cprops, VPackSlice co
     }
 
     // If comparison has brought any updates
-    if (!properties->slice().isObject() || properties->slice().length() > 0 ||
-        !followersToDropString.empty()) {
+    TRI_ASSERT(properties->slice().isObject());
+    if (properties->slice().length() > 0 || !followersToDropString.empty()) {
       if (errors.shards.find(fullShardLabel) == errors.shards.end()) {
         actions.emplace_back(ActionDescription(
             std::map<std::string, std::string>{{NAME, UPDATE_COLLECTION},

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -277,15 +277,19 @@ LogicalCollection::LogicalCollection(TRI_vocbase_t& vocbase, VPackSlice const& i
 
 Result LogicalCollection::updateValidators(VPackSlice validatorSlice) {
   using namespace std::literals::string_literals;
-  if (validatorSlice.isNone() || validatorSlice.isNull()) {
+  if (validatorSlice.isNone()) {
     return { TRI_ERROR_NO_ERROR };
-  } else if (!validatorSlice.isObject()) {
+  } 
+  if (validatorSlice.isNull()) {
+    validatorSlice = VPackSlice::emptyObjectSlice();
+  }
+  if (!validatorSlice.isObject()) {
     return {TRI_ERROR_VALIDATION_BAD_PARAMETER, "Schema description is not an object."};
   }
 
   TRI_ASSERT(validatorSlice.isObject());
 
-  std::shared_ptr<ValidatorVec> newVec = std::make_shared<ValidatorVec>();
+  auto newVec = std::make_shared<ValidatorVec>();
 
   // delete validators if empty object is given
   if (!validatorSlice.isEmptyObject()) {
@@ -817,7 +821,7 @@ arangodb::Result LogicalCollection::properties(velocypack::Slice const& slice, b
   // - _isSystem
   // - _isVolatile
   // ... probably a few others missing here ...
-
+      
   if (!vocbase().server().hasFeature<DatabaseFeature>()) {
     return Result(
         TRI_ERROR_INTERNAL,

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/validationView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/validationView.js
@@ -25,6 +25,7 @@
       $(this.el).html(this.template.render({}));
       this.renderValidationEditor();
       this.getValidationProperties();
+      this.editor.focus();
     },
 
     resize: function () {
@@ -72,7 +73,7 @@
         if (error) {
           arangoHelper.arangoError('Error', 'Could not save schema.');
         } else {
-          var newprops;
+          var newprops = null;
           try {
             newprops = this.editor.get();
           } catch (ex) {
@@ -86,6 +87,7 @@
             } else {
               arangoHelper.arangoNotification('Saved schema for collection ' + this.model.get('name') + '.');
             }
+            this.editor.focus();
           });
 
         } // if error


### PR DESCRIPTION
### Scope & Purpose

This PR should fix the error that a schema once set for a collection could not easily be removed.

Now schemas can be removed easily by saving a schema of either null or {} . Using an empty string a schema will produce an error in the web interface and will not remove the schema.

The PR also fixes the behavior for the SCHEMA_VALIDATE AQL function in case the first parameter was no document/object. In this case, the function will now return nulland register a warning in the query, so the user can handle it. 

Additional docs PR: https://github.com/arangodb/docs/pull/481

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is a *JIRA Ticket number*: https://arangodb.atlassian.net/browse/QA-22

### Testing & Verification

This change is already covered by existing tests, such as *shell_client / shell_server*.

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server / shell_client)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10665/