### PR TITLE
Fix undistributeRemoveAfterEnumColl rule.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 devel
 -----
+* Fix undistribute-remove-after-enum-coll which would allow calculations
+  to be pushed to a DBServer which are not allowed to run there.
 
 * Allow restoring collections from v3.3.0 with their all-numeric collection
   GUID values, by creating a new, unambiguous collection GUID for them. 

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -5301,7 +5301,8 @@ class RemoveToEnumCollFinder final : public WalkerWorker<ExecutionNode> {
         auto calculationNode = ExecutionNode::castTo<CalculationNode*>(en);
         auto expr = calculationNode->expression();
 
-        // Nein.
+        // If we find an expression that is not allowed to run on a DBServer,
+        // we cannot undistribute (as then the expression *would* run on a dbserver)
         if (!expr->canRunOnDBServer()) {
           break;
         }

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -5298,6 +5298,13 @@ class RemoveToEnumCollFinder final : public WalkerWorker<ExecutionNode> {
         return false;  // continue . . .
       }
       case EN::CALCULATION: {
+        auto calculationNode = ExecutionNode::castTo<CalculationNode*>(en);
+        auto expr = calculationNode->expression();
+
+        // Nein.
+        if (!expr->canRunOnDBServer()) {
+          break;
+        }
         return false;  // continue . . .
       }
       case EN::ENUMERATE_COLLECTION:

--- a/tests/js/server/aql/aql-optimizer-undistribute-remove-regression.js
+++ b/tests/js/server/aql/aql-optimizer-undistribute-remove-regression.js
@@ -35,19 +35,6 @@ var db = require("@arangodb").db,
 const collectionName1 = "collection1";
 const collectionName2 = "collection2";
 
-const expectedResult = [
-  {
-    name: "Adam",
-    lastname: "Smith",
-    number: 294,
-  },
-  {
-    name: "Matt",
-    lastname: "Smith",
-    number: 34,
-  },
-];
-
 var cleanup = function () {
   db._drop(collectionName2);
   db._drop(collectionName1);

--- a/tests/js/server/aql/aql-optimizer-undistribute-remove-regression.js
+++ b/tests/js/server/aql/aql-optimizer-undistribute-remove-regression.js
@@ -76,9 +76,10 @@ function undistributeAfterEnumCollRegressionSuite() {
     },
 
     ////////////////////////////////////////////////////////////////////////////////
-    /// @brief test object access for path object
+    /// @brief test whether the undistribute-remove-after-enum-coll rule
+    /// messes up the execution plan badly.
     ////////////////////////////////////////////////////////////////////////////////
-    testTraversalResetCrashes: function () {
+    testUndistributeRule: function () {
       const query = `
         FOR x IN @@c1
           LET gl = DOCUMENT(@c2, x._key)

--- a/tests/js/server/aql/aql-optimizer-undistribute-remove-regression.js
+++ b/tests/js/server/aql/aql-optimizer-undistribute-remove-regression.js
@@ -1,0 +1,122 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global assertEqual, AQL_EXECUTE, assertTrue, fail */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2020 ArangDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+/// @author Copyright 2020, ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+var jsunity = require("jsunity");
+var internal = require("internal");
+var errors = internal.errors;
+var db = require("@arangodb").db,
+  indexId;
+
+// This example was produced by Jan Steeman to reproduce a
+// crash in the TraversalExecutor code
+const collectionName1 = "collection1";
+const collectionName2 = "collection2";
+
+const expectedResult = [
+  {
+    name: "Adam",
+    lastname: "Smith",
+    number: 294,
+  },
+  {
+    name: "Matt",
+    lastname: "Smith",
+    number: 34,
+  },
+];
+
+var cleanup = function () {
+  db._drop(collectionName2);
+  db._drop(collectionName1);
+};
+
+var setupData = function () {
+  const c1 = internal.db._createDocumentCollection(collectionName1);
+  const c2 = internal.db._createDocumentCollection(collectionName2);
+
+  c1.save([{ _key: 1 }, { _key: 2 }, { _key: 3 }]);
+  c2.save([
+    { _key: 1, value: "testValue1" },
+    { _key: 2, value: "testValue2" },
+    { _key: 3, value: "testValue3" },
+  ]);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test suite
+////////////////////////////////////////////////////////////////////////////////
+
+function undistributeAfterEnumCollRegressionSuite() {
+  return {
+    ////////////////////////////////////////////////////////////////////////////////
+    /// @brief set up
+    ////////////////////////////////////////////////////////////////////////////////
+
+    setUpAll: function () {
+      cleanup();
+      setupData();
+    },
+
+    ////////////////////////////////////////////////////////////////////////////////
+    /// @brief tear down
+    ////////////////////////////////////////////////////////////////////////////////
+
+    tearDownAll: function () {
+      cleanup();
+    },
+
+    ////////////////////////////////////////////////////////////////////////////////
+    /// @brief test object access for path object
+    ////////////////////////////////////////////////////////////////////////////////
+    testTraversalResetCrashes: function () {
+      const query = `
+        FOR x IN @@c1
+          LET gl = DOCUMENT(@c2, x._key)
+          LET short = gl.value
+          UPDATE x WITH { value: short } IN @@c1
+          RETURN NEW.value`;
+      const bindVars = {
+        "@c1": collectionName1,
+        c2: collectionName2,
+      };
+
+      var withRule = db._query(query, bindVars);
+      var withoutRule = db._query(query, bindVars, {
+        optimizer: { rules: ["-undistribute-remove-after-enum-coll"] },
+      });
+
+      assertEqual(withoutRule.toArray().sort(), withRule.toArray().sort());
+    },
+  };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief executes the test suite
+////////////////////////////////////////////////////////////////////////////////
+
+jsunity.run(undistributeAfterEnumCollRegressionSuite);
+
+return jsunity.done();


### PR DESCRIPTION
The `undistribute-remove-after-enum-coll` optimizer rule was a bit too eager and accidentally moved a call to `DOCUMENT` to a DBServer.

Fixes #11858