### PR TITLE
made analyzers count check deterministic

### DIFF
--- a/tests/js/common/aql/aql-view-arangosearch-ddl-cluster.js
+++ b/tests/js/common/aql/aql-view-arangosearch-ddl-cluster.js
@@ -1258,16 +1258,16 @@ function IResearchFeatureDDLTestSuite () {
       assertNotEqual(null, db._collection("_analyzers"));
       try { db._dropDatabase(dbName); } catch (e) {}
       try { analyzers.remove(analyzerName); } catch (e) {}
-      assertEqual(0, db._analyzers.count());
       db._createDatabase(dbName);
       db._useDatabase(dbName);
+      assertEqual(0, db._analyzers.count());
       analyzers.save(analyzerName, "identity");
       // recreating database
       db._useDatabase("_system");
       db._dropDatabase(dbName);
       db._createDatabase(dbName);
       db._useDatabase(dbName);
-
+      assertEqual(0, db._analyzers.count());
       assertNull(analyzers.analyzer(analyzerName));
       // this should be no name conflict
       analyzers.save(analyzerName, "text", {"stopwords" : [], "locale":"en"});
@@ -1281,7 +1281,6 @@ function IResearchFeatureDDLTestSuite () {
           }
         }
       });
-
       var res = db._query("FOR d IN analyzersView OPTIONS {waitForSync:true} RETURN d").toArray();
       assertEqual(1, db._analyzers.count());
       assertEqual(1, res.length);

--- a/tests/js/common/aql/aql-view-arangosearch-ddl-noncluster.js
+++ b/tests/js/common/aql/aql-view-arangosearch-ddl-noncluster.js
@@ -1259,9 +1259,9 @@ function IResearchFeatureDDLTestSuite () {
       assertNotEqual(null, db._collection("_analyzers"));
       try { db._dropDatabase(dbName); } catch (e) {}
       try { analyzers.remove(analyzerName); } catch (e) {}
-      assertEqual(0, db._analyzers.count());
       db._createDatabase(dbName);
       db._useDatabase(dbName);
+      assertEqual(0, db._analyzers.count());
       analyzers.save(analyzerName, "identity");
       // recreating database
       db._useDatabase("_system");
@@ -1271,6 +1271,7 @@ function IResearchFeatureDDLTestSuite () {
 
       assertNull(analyzers.analyzer(analyzerName));
       // this should be no name conflict
+      assertEqual(0, db._analyzers.count());
       analyzers.save(analyzerName, "text", {"stopwords" : [], "locale":"en"});
       assertEqual(1, db._analyzers.count());
 

--- a/tests/js/common/aql/aql-view-arangosearch-feature.js
+++ b/tests/js/common/aql/aql-view-arangosearch-feature.js
@@ -59,63 +59,63 @@ function iResearchFeatureAqlTestSuite () {
     testAnalyzersInvalidPropertiesDiscarded : function() {
       {
         try {analyzers.remove("normPropAnalyzer"); } catch (e) {}
-        assertEqual(0, db._analyzers.count());
+        let oldCount = db._analyzers.count();
         let analyzer = analyzers.save("normPropAnalyzer", "norm", { "locale":"en", "invalid_param":true});
-        assertEqual(1, db._analyzers.count());
+        assertEqual(oldCount + 1, db._analyzers.count());
         assertTrue(null != analyzer);
         assertTrue(null == analyzer.properties.invalid_param);
         analyzers.remove("normPropAnalyzer", true);
-        assertEqual(0, db._analyzers.count());
+        assertEqual(oldCount, db._analyzers.count());
       }
       {
         try {analyzers.remove("textPropAnalyzer"); } catch (e) {}
-        assertEqual(0, db._analyzers.count());
+        let oldCount = db._analyzers.count();
         let analyzer = analyzers.save("textPropAnalyzer", "text", {"stopwords" : [], "locale":"en", "invalid_param":true});
-        assertEqual(1, db._analyzers.count());
+        assertEqual(oldCount + 1, db._analyzers.count());
         assertTrue(null != analyzer);
         assertTrue(null == analyzer.properties.invalid_param);
         analyzers.remove("textPropAnalyzer", true);
-        assertEqual(0, db._analyzers.count());
+        assertEqual(oldCount, db._analyzers.count());
       }
       {
         try {analyzers.remove("textPropAnalyzerWithNGram"); } catch (e) {}
-        assertEqual(0, db._analyzers.count());
+        let oldCount = db._analyzers.count();
         let analyzer = analyzers.save("textPropAnalyzerWithNgram", "text", {"stopwords" : [], "locale":"en", "edgeNgram" : { "min" : 2, "invalid_param":true}});
-        assertEqual(1, db._analyzers.count());
+        assertEqual(oldCount + 1, db._analyzers.count());
         assertTrue(null != analyzer);
         assertTrue(null == analyzer.properties.invalid_param);
         analyzers.remove("textPropAnalyzerWithNgram", true);
-        assertEqual(0, db._analyzers.count());
+        assertEqual(oldCount, db._analyzers.count());
       }
       {
         try {analyzers.remove("delimiterPropAnalyzer"); } catch (e) {}
-        assertEqual(0, db._analyzers.count());
+        let oldCount = db._analyzers.count();
         let analyzer = analyzers.save("delimiterPropAnalyzer", "delimiter", { "delimiter":"|", "invalid_param":true});
-        assertEqual(1, db._analyzers.count());
+        assertEqual(oldCount + 1, db._analyzers.count());
         assertTrue(null != analyzer);
         assertTrue(null == analyzer.properties.invalid_param);
         analyzers.remove("delimiterPropAnalyzer", true);
-        assertEqual(0, db._analyzers.count());
+        assertEqual(oldCount, db._analyzers.count());
       }
       {
         try {analyzers.remove("stemPropAnalyzer"); } catch (e) {}
-        assertEqual(0, db._analyzers.count());
+        let oldCount = db._analyzers.count();
         let analyzer = analyzers.save("stemPropAnalyzer", "stem", { "locale":"en", "invalid_param":true});
-        assertEqual(1, db._analyzers.count());
+        assertEqual(oldCount + 1, db._analyzers.count());
         assertTrue(null != analyzer);
         assertTrue(null == analyzer.properties.invalid_param);
         analyzers.remove("stemPropAnalyzer", true);
-        assertEqual(0, db._analyzers.count());
+        assertEqual(oldCount, db._analyzers.count());
       }
       {
         try {analyzers.remove("ngramPropAnalyzer"); } catch (e) {}
-        assertEqual(0, db._analyzers.count());
+        let oldCount = db._analyzers.count();
         let analyzer = analyzers.save("ngramPropAnalyzer", "ngram", { "min":1, "max":5, "preserveOriginal":true, "invalid_param":true});
-        assertEqual(1, db._analyzers.count());
+        assertEqual(oldCount + 1, db._analyzers.count());
         assertTrue(null != analyzer);
         assertTrue(null == analyzer.properties.invalid_param);
         analyzers.remove("ngramPropAnalyzer", true);
-        assertEqual(0, db._analyzers.count());
+        assertEqual(oldCount, db._analyzers.count());
       }
     },
     testAnalyzerRemovalWithDatabaseName_InSystem: function() {
@@ -284,8 +284,6 @@ function iResearchFeatureAqlTestSuite () {
       let oldListInCollection = db._analyzers.toArray();
       assertTrue(Array === oldList.constructor);
 
-      assertEqual(0, db._analyzers.count());
-
       // creation
       analyzers.save("testAnalyzer", "stem", { "locale":"en"}, [ "frequency" ]);
 
@@ -301,7 +299,6 @@ function iResearchFeatureAqlTestSuite () {
       assertEqual([ "frequency" ], analyzer.features());
 
       // check persisted analyzer
-      assertEqual(1, db._analyzers.count());
       let savedAnalyzer = db._analyzers.toArray()[0];
       assertTrue(null !== savedAnalyzer);
       assertEqual(8, Object.keys(savedAnalyzer).length);


### PR DESCRIPTION
Made ArangoSearch tests tolerate analyzers left in collection by other tests. Tests now checks explicit 0 only if db is newly created by test itself. Otherwise checks are made like "count before test" = "count after test"
This change is covered by existing tests.

https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/10734/