### PR TITLE
Remove superflous `%>` output in the UI modal dialog in case the JSON editor was embedded

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Remove superflous `%>` output in the UI modal dialog in case the JSON editor
+  was embedded.
+
 * Fixed a misleading error message in AQL.
 
 * Fix undistribute-remove-after-enum-coll which would allow calculations

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/templates/modalTable.ejs
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/templates/modalTable.ejs
@@ -65,7 +65,7 @@
           break;
         case "jsoneditor":
           %>
-          <div id="jsoneditor"/> %>
+          <div id="jsoneditor"/>
           <%
           break;
         }


### PR DESCRIPTION
### Scope & Purpose

Remove superflous `%>` output in the UI modal dialog in case the JSON editor was embedded
Reported via https://arangodb.atlassian.net/browse/QA-22?focusedCommentId=39910

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

- [x] There is a *JIRA Ticket number*: https://arangodb.atlassian.net/browse/QA-22?focusedCommentId=39910

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10773/