### PR TITLE
Fixed BTS-110: Fulltext index with minLength <= 0 not allowed.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fixed BTS-110: Fulltext index with minLength <= 0 not allowed.
+
 * Fixed a misleading error message in AQL.
 
 * Fix undistribute-remove-after-enum-coll which would allow calculations

--- a/arangod/Indexes/IndexFactory.cpp
+++ b/arangod/Indexes/IndexFactory.cpp
@@ -565,6 +565,10 @@ Result IndexFactory::enhanceJsonIndexFulltext(VPackSlice definition,
       return Result(TRI_ERROR_BAD_PARAMETER);
     }
 
+    if (minWordLength <= 0) {
+      minWordLength = 1;
+    }
+
     builder.add("minLength", VPackValue(minWordLength));
 
     bool bck = basics::VelocyPackHelper::getBooleanValue(definition, StaticStrings::IndexInBackground,

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -2066,6 +2066,26 @@ Result RestReplicationHandler::processRestoreIndexesCoordinator(VPackSlice const
       idxDef = rebuilder.slice();
     }
 
+    if (type.isEqualString("fulltext")) {
+      VPackSlice minLength = idxDef.get("minLength");
+      if (minLength.isNumber()) {
+        int length = minLength.getNumericValue<int>();
+        if (length <= 0) {
+          rebuilder.clear();
+          rebuilder.openObject();
+          rebuilder.add("minLength", VPackValue(1));
+          for (auto const& it : VPackObjectIterator(idxDef)) {
+            if (!it.key.isEqualString("minLength")) {
+              rebuilder.add(it.key);
+              rebuilder.add(it.value);
+            }
+          }
+          rebuilder.close();
+          idxDef = rebuilder.slice();
+        }
+      }
+    }
+
     VPackBuilder tmp;
 
     res = ci.ensureIndexCoordinator(*col, idxDef, true, tmp, cluster.indexCreationTimeout());


### PR DESCRIPTION
### Scope & Purpose

Currently, there is a difference in how we handle fulltext index creation between the cluster and single server. In the single server, a `minLength <= 0` parameter is simply overwritten with 1. In the cluster, it is honored when writing to the Plan, but then overwritten on the DBServers. This creates a discrepancy and leads to maintenance churn constantly recreating the index. The simple fix is to also do the overwrite to 1 in the Plan. 

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)

#### Related Information

*(Please reference tickets / specification etc )*

- [x] There is an internal planning ticket: BTS-110

### Testing & Verification

Jenkins: 