### PR TITLE
Bug fix/simplify query object

### DIFF
--- a/arangod/Aql/AqlCallStack.cpp
+++ b/arangod/Aql/AqlCallStack.cpp
@@ -68,7 +68,7 @@ auto AqlCallStack::popCall() -> AqlCallList {
   TRI_ASSERT(_compatibilityMode3_6 || !_operations.empty());
   if (_compatibilityMode3_6 && _operations.empty()) {
     // This is only for compatibility with 3.6
-    // there we do not have the stack beeing passed-through
+    // there we do not have the stack being passed-through
     // in AQL, we only have a single call.
     // We can only get into this state in the abscence of
     // LIMIT => we always do an unlimted softLimit call
@@ -86,7 +86,7 @@ auto AqlCallStack::peek() const -> AqlCall const& {
   TRI_ASSERT(_compatibilityMode3_6 || !_operations.empty());
   if (is36Compatible() && _operations.empty()) {
     // This is only for compatibility with 3.6
-    // there we do not have the stack beeing passed-through
+    // there we do not have the stack being passed-through
     // in AQL, we only have a single call.
     // We can only get into this state in the abscence of
     // LIMIT => we always do an unlimted softLimit call

--- a/arangod/Aql/ExecutionEngine.cpp
+++ b/arangod/Aql/ExecutionEngine.cpp
@@ -701,12 +701,14 @@ std::pair<ExecutionState, Result> ExecutionEngine::shutdown(int errorCode) {
 }
 
 // @brief create an execution engine from a plan
-Result ExecutionEngine::instantiateFromPlan(Query& query,
-                                            ExecutionPlan& plan,
-                                            bool planRegisters,
-                                            SerializationFormat format,
-                                            SnippetList& snippets) {
-  auto role = arangodb::ServerState::instance()->getRole();
+void ExecutionEngine::instantiateFromPlan(Query& query,
+                                          ExecutionPlan& plan,
+                                          bool planRegisters,
+                                          SerializationFormat format,
+                                          SnippetList& snippets) {
+  auto const role = arangodb::ServerState::instance()->getRole();
+  
+  TRI_ASSERT(snippets.empty() || ServerState::instance()->isClusterRole(role));
 
   plan.findVarUsage();
   if (planRegisters) {
@@ -793,8 +795,8 @@ Result ExecutionEngine::instantiateFromPlan(Query& query,
   }
 
   engine->_root = root; // simon: otherwise it breaks
-
-  return {};
+      
+  TRI_ASSERT(snippets.size() == 1 || ServerState::instance()->isClusterRole(role));
 }
 
 /// @brief add a block to the engine

--- a/arangod/Aql/ExecutionEngine.h
+++ b/arangod/Aql/ExecutionEngine.h
@@ -66,11 +66,11 @@ class ExecutionEngine {
  public:
   
   // @brief create an execution engine from a plan
-  static Result instantiateFromPlan(Query& query,
-                                    ExecutionPlan& plan,
-                                    bool planRegisters,
-                                    SerializationFormat format,
-                                    SnippetList& list);
+  static void instantiateFromPlan(Query& query,
+                                  ExecutionPlan& plan,
+                                  bool planRegisters,
+                                  SerializationFormat format,
+                                  SnippetList& list);
   
   TEST_VIRTUAL Result createBlocks(std::vector<ExecutionNode*> const& nodes,
                                    MapRemoteToSnippet const& queryIds);

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -36,7 +36,6 @@
 #include "Aql/Parser.h"
 #include "Aql/PlanCache.h"
 #include "Aql/QueryCache.h"
-#include "Aql/QueryList.h"
 #include "Aql/QueryProfile.h"
 #include "Aql/QueryRegistry.h"
 #include "Aql/Timing.h"
@@ -44,7 +43,6 @@
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/fasthash.h"
-#include "Basics/system-functions.h"
 #include "Cluster/ServerState.h"
 #include "Cluster/TraverserEngine.h"
 #include "Graph/Graph.h"
@@ -94,7 +92,6 @@ Query::Query(std::shared_ptr<transaction::Context> const& ctx,
       _options(options),
       _queryOptions(_vocbase.server().getFeature<QueryRegistryFeature>()),
       _trx(nullptr),
-      _startTimeStamp(TRI_microtime()),
       _startTime(currentSteadyClockValue()),
       _queryHash(DontCache),
       _executionPhase(ExecutionPhase::INITIALIZE),
@@ -210,9 +207,6 @@ void Query::kill() {
     }
   }
 }
-  
-/// @brief return the start timestamp of the query (system clock value)
-double Query::startTimeStamp() const noexcept { return _startTimeStamp; }
   
 /// @brief return the start time of the query (steady clock value)
 double Query::startTime() const noexcept { return _startTime; }

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -44,6 +44,7 @@
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/fasthash.h"
+#include "Basics/system-functions.h"
 #include "Cluster/ServerState.h"
 #include "Cluster/TraverserEngine.h"
 #include "Graph/Graph.h"
@@ -93,6 +94,7 @@ Query::Query(std::shared_ptr<transaction::Context> const& ctx,
       _options(options),
       _queryOptions(_vocbase.server().getFeature<QueryRegistryFeature>()),
       _trx(nullptr),
+      _startTimeStamp(TRI_microtime()),
       _startTime(currentSteadyClockValue()),
       _queryHash(DontCache),
       _executionPhase(ExecutionPhase::INITIALIZE),
@@ -169,8 +171,14 @@ Query::~Query() {
   }
 
   // this will reset _trx, so _trx is invalid after here
-  ExecutionState state = cleanupPlanAndEngine(TRI_ERROR_INTERNAL, /*sync*/true);
-  TRI_ASSERT(state != ExecutionState::WAITING);
+  try {
+    ExecutionState state = cleanupPlanAndEngine(TRI_ERROR_INTERNAL, /*sync*/true);
+    TRI_ASSERT(state != ExecutionState::WAITING);
+  } catch (...) {
+    // unfortunately we cannot do anything here, as we are in 
+    // a destructor
+    _trx.reset();
+  }
 
   exitV8Context();
 
@@ -202,14 +210,15 @@ void Query::kill() {
     }
   }
 }
-
-void Query::injectTransaction(std::unique_ptr<transaction::Methods> trx) {
-  _trx = std::move(trx);
-  init();
-}
+  
+/// @brief return the start timestamp of the query (system clock value)
+double Query::startTimeStamp() const noexcept { return _startTimeStamp; }
+  
+/// @brief return the start time of the query (steady clock value)
+double Query::startTime() const noexcept { return _startTime; }
 
 void Query::prepareQuery(SerializationFormat format) {
-  init();
+  init(/*createProfile*/ true);
   enterState(QueryExecutionState::ValueType::PARSING);
 
   std::unique_ptr<ExecutionPlan> plan = preparePlan();
@@ -223,8 +232,8 @@ void Query::prepareQuery(SerializationFormat format) {
   // own _engine attribute (the instanciation procedure may modify us
   // by calling our engine(ExecutionEngine*) function
   // this is confusing and should be fixed!
-  auto res = ExecutionEngine::instantiateFromPlan(*this, *plan, /*planRegisters*/!_queryString.empty(),
-                                                  format, _snippets);
+  ExecutionEngine::instantiateFromPlan(*this, *plan, /*planRegisters*/!_queryString.empty(),
+                                       format, _snippets);
 
   _plans.push_back(std::move(plan));
 
@@ -314,9 +323,9 @@ ExecutionState Query::execute(QueryResult& queryResult) {
   LOG_TOPIC("e8ed7", DEBUG, Logger::QUERIES) << elapsedSince(_startTime)
                                              << " Query::execute"
                                              << " this: " << (uintptr_t)this;
-
+    
   try {
-    if (_killed) {
+    if (killed()) {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
     }
 
@@ -383,7 +392,7 @@ ExecutionState Query::execute(QueryResult& queryResult) {
         _resultBuilder->openArray();
         _executionPhase = ExecutionPhase::EXECUTE;
       }
-        [[fallthrough]];
+      [[fallthrough]];
       case ExecutionPhase::EXECUTE: {
         TRI_ASSERT(_resultBuilder != nullptr);
         TRI_ASSERT(_resultBuilder->isOpenArray());
@@ -466,7 +475,7 @@ ExecutionState Query::execute(QueryResult& queryResult) {
         _executionPhase = ExecutionPhase::FINALIZE;
       }
 
-        [[fallthrough]];
+      [[fallthrough]];
       case ExecutionPhase::FINALIZE: {
         // will set warnings, stats, profile and cleanup plan and engine
         return finalize(queryResult);
@@ -474,30 +483,27 @@ ExecutionState Query::execute(QueryResult& queryResult) {
     }
     // We should not be able to get here
     TRI_ASSERT(false);
-    return ExecutionState::DONE;
   } catch (arangodb::basics::Exception const& ex) {
-    cleanupPlanAndEngine(ex.code(), /*sync*/true);
     queryResult.reset(Result(ex.code(), "AQL: " + ex.message() +
                                             QueryExecutionState::toStringWithPrefix(_execState)));
-    return ExecutionState::DONE;
+    cleanupPlanAndEngine(ex.code(), /*sync*/true);
   } catch (std::bad_alloc const&) {
-    cleanupPlanAndEngine(TRI_ERROR_OUT_OF_MEMORY, /*sync*/true);
     queryResult.reset(Result(TRI_ERROR_OUT_OF_MEMORY,
                              TRI_errno_string(TRI_ERROR_OUT_OF_MEMORY) +
                                  QueryExecutionState::toStringWithPrefix(_execState)));
-    return ExecutionState::DONE;
+    cleanupPlanAndEngine(TRI_ERROR_OUT_OF_MEMORY, /*sync*/true);
   } catch (std::exception const& ex) {
-    cleanupPlanAndEngine(TRI_ERROR_INTERNAL, /*sync*/true);
     queryResult.reset(Result(TRI_ERROR_INTERNAL,
                              ex.what() + QueryExecutionState::toStringWithPrefix(_execState)));
-    return ExecutionState::DONE;
-  } catch (...) {
     cleanupPlanAndEngine(TRI_ERROR_INTERNAL, /*sync*/true);
+  } catch (...) {
     queryResult.reset(Result(TRI_ERROR_INTERNAL,
                              TRI_errno_string(TRI_ERROR_INTERNAL) +
                                  QueryExecutionState::toStringWithPrefix(_execState)));
-    return ExecutionState::DONE;
+    cleanupPlanAndEngine(TRI_ERROR_INTERNAL, /*sync*/true);
   }
+  
+  return ExecutionState::DONE;
 }
 
 /**
@@ -656,7 +662,7 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
           }
         }
 
-        if (_killed) {
+        if (killed()) {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
         }
       }
@@ -697,24 +703,25 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
       ss->waitForAsyncWakeup();
       state = finalize(queryResult);
     }
+    // fallthrough to returning queryResult below...
   } catch (arangodb::basics::Exception const& ex) {
-    cleanupPlanAndEngine(ex.code(), /*sync*/true);
     queryResult.reset(Result(ex.code(), "AQL: " + ex.message() +
                                             QueryExecutionState::toStringWithPrefix(_execState)));
+    cleanupPlanAndEngine(ex.code(), /*sync*/true);
   } catch (std::bad_alloc const&) {
-    cleanupPlanAndEngine(TRI_ERROR_OUT_OF_MEMORY, /*sync*/true);
     queryResult.reset(Result(TRI_ERROR_OUT_OF_MEMORY,
                              TRI_errno_string(TRI_ERROR_OUT_OF_MEMORY) +
                                  QueryExecutionState::toStringWithPrefix(_execState)));
+    cleanupPlanAndEngine(TRI_ERROR_OUT_OF_MEMORY, /*sync*/true);
   } catch (std::exception const& ex) {
-    cleanupPlanAndEngine(TRI_ERROR_INTERNAL, /*sync*/true);
     queryResult.reset(Result(TRI_ERROR_INTERNAL,
                              ex.what() + QueryExecutionState::toStringWithPrefix(_execState)));
-  } catch (...) {
     cleanupPlanAndEngine(TRI_ERROR_INTERNAL, /*sync*/true);
+  } catch (...) {
     queryResult.reset(Result(TRI_ERROR_INTERNAL,
                              TRI_errno_string(TRI_ERROR_INTERNAL) +
                                  QueryExecutionState::toStringWithPrefix(_execState)));
+    cleanupPlanAndEngine(TRI_ERROR_INTERNAL, /*sync*/true);
   }
 
   return queryResult;
@@ -780,30 +787,34 @@ ExecutionState Query::finalize(QueryResult& result) {
 
 /// @brief parse an AQL query
 QueryResult Query::parse() {
+  // only used in case case of failure
+  QueryResult result;
+
   try {
-    init();
+    init(/*createProfile*/ false);
     Parser parser(*this, *_ast, _queryString);
     return parser.parseWithDetails();
+
   } catch (arangodb::basics::Exception const& ex) {
-    return QueryResult(Result(ex.code(), ex.message()));
+    result.reset(Result(ex.code(), ex.message()));
   } catch (std::bad_alloc const&) {
-    cleanupPlanAndEngine(TRI_ERROR_OUT_OF_MEMORY, /*sync*/true);
-    return QueryResult(Result(TRI_ERROR_OUT_OF_MEMORY,
-                              TRI_errno_string(TRI_ERROR_OUT_OF_MEMORY)));
+    result.reset(Result(TRI_ERROR_OUT_OF_MEMORY));
   } catch (std::exception const& ex) {
-    cleanupPlanAndEngine(TRI_ERROR_INTERNAL, /*sync*/true);
-    return QueryResult(Result(TRI_ERROR_INTERNAL, ex.what()));
+    result.reset(Result(TRI_ERROR_INTERNAL, ex.what()));
   } catch (...) {
-    return QueryResult(
-        Result(TRI_ERROR_INTERNAL,
-               "an unknown error occurred while parsing the query"));
+    result.reset(Result(TRI_ERROR_INTERNAL, "an unknown error occurred while parsing the query"));
   }
+
+  TRI_ASSERT(result.fail());
+  return result;
 }
 
 /// @brief explain an AQL query
 QueryResult Query::explain() {
+  QueryResult result;
+
   try {
-    init();
+    init(/*createProfile*/ false);
     enterState(QueryExecutionState::ValueType::PARSING);
 
     Parser parser(*this, *_ast, _queryString);
@@ -840,8 +851,6 @@ QueryResult Query::explain() {
     opt.createPlans(std::move(plan), _queryOptions, true);
 
     enterState(QueryExecutionState::ValueType::FINALIZATION);
-
-    QueryResult result;
 
     auto preparePlanForSerialization = [&](std::unique_ptr<ExecutionPlan> const& plan) {
       plan->findVarUsage();
@@ -896,22 +905,20 @@ QueryResult Query::explain() {
       opt._stats.toVelocyPack(*result.extra);
     }
 
-    return result;
   } catch (arangodb::basics::Exception const& ex) {
-    return QueryResult(
-        Result(ex.code(), ex.message() + QueryExecutionState::toStringWithPrefix(_execState)));
+    result.reset(Result(ex.code(), ex.message() + QueryExecutionState::toStringWithPrefix(_execState)));
   } catch (std::bad_alloc const&) {
-    return QueryResult(Result(TRI_ERROR_OUT_OF_MEMORY,
-                              TRI_errno_string(TRI_ERROR_OUT_OF_MEMORY) +
-                                  QueryExecutionState::toStringWithPrefix(_execState)));
+    result.reset(Result(TRI_ERROR_OUT_OF_MEMORY,
+                        TRI_errno_string(TRI_ERROR_OUT_OF_MEMORY) +
+                        QueryExecutionState::toStringWithPrefix(_execState)));
   } catch (std::exception const& ex) {
-    return QueryResult(Result(TRI_ERROR_INTERNAL,
-                              ex.what() + QueryExecutionState::toStringWithPrefix(_execState)));
+    result.reset(Result(TRI_ERROR_INTERNAL, ex.what() + QueryExecutionState::toStringWithPrefix(_execState)));
   } catch (...) {
-    return QueryResult(Result(TRI_ERROR_INTERNAL,
-                              TRI_errno_string(TRI_ERROR_INTERNAL) +
-                                  QueryExecutionState::toStringWithPrefix(_execState)));
+    result.reset(Result(TRI_ERROR_INTERNAL, TRI_errno_string(TRI_ERROR_INTERNAL) + QueryExecutionState::toStringWithPrefix(_execState)));
   }
+
+  // will be returned in success or failure case
+  return result;
 }
 
 bool Query::isModificationQuery() const noexcept {
@@ -978,7 +985,7 @@ void Query::exitV8Context() {
 }
 
 /// @brief initializes the query
-void Query::init() {
+void Query::init(bool createProfile) {
   TRI_ASSERT(!_profile && !_ast);
   if (_profile || _ast) {
     // already called
@@ -987,7 +994,7 @@ void Query::init() {
 
   TRI_ASSERT(_profile == nullptr);
   // adds query to QueryList which is needed for /_api/query/current
-  if (!ServerState::instance()->isDBServer()) {
+  if (createProfile && !ServerState::instance()->isDBServer()) {
     _profile = std::make_unique<QueryProfile>(this);
   }
   enterState(QueryExecutionState::ValueType::INITIALIZATION);
@@ -1237,7 +1244,7 @@ transaction::Methods& Query::trxForOptimization() {
 
 #ifdef ARANGODB_USE_GOOGLE_TESTS
 void Query::initForTests() {
-  this->init();
+  this->init(/*createProfile*/ true);
   _trx = AqlTransaction::create(_transactionContext, _collections,
                                 _queryOptions.transactionOptions,
                                 std::unordered_set<std::string>{});
@@ -1285,7 +1292,7 @@ void ClusterQuery::prepareClusterQuery(SerializationFormat format,
                                              << " ClusterQuery::prepareClusterQuery"
                                              << " this: " << (uintptr_t)this;
 
-  init();
+  init(/*createProfile*/ true);
 
   VPackSlice val = querySlice.get("isModificationQuery");
   if (val.isBool() && val.getBool()) {
@@ -1333,12 +1340,8 @@ void ClusterQuery::prepareClusterQuery(SerializationFormat format,
 
     plan->findVarUsage();
 
-    res = ExecutionEngine::instantiateFromPlan(*this, *plan, /*planRegisters*/!_queryString.empty(),
-                                               format, _snippets);
-    if (res.fail()) {
-      THROW_ARANGO_EXCEPTION(res);
-    }
-
+    ExecutionEngine::instantiateFromPlan(*this, *plan, /*planRegisters*/!_queryString.empty(),
+                                         format, _snippets);
     _plans.push_back(std::move(plan));
   };
 

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -116,9 +116,6 @@ class Query : public QueryContext {
   
   TEST_VIRTUAL QueryOptions& queryOptions() { return _queryOptions; }
 
-  /// @brief return the start timestamp of the query (system clock value)
-  double startTimeStamp() const noexcept;
-  
   /// @brief return the start time of the query (steady clock value)
   double startTime() const noexcept;
 
@@ -289,9 +286,6 @@ class Query : public QueryContext {
   /// storing the cache entry in the query cache
   std::unique_ptr<QueryCacheResultEntry> _cacheEntry;
   
-  /// @brief query start timestamp (system clock value)
-  double const _startTimeStamp;
-
   /// @brief query start time (steady clock value)
   double const _startTime;
 

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -35,6 +35,7 @@
 #include "Aql/ResourceUsage.h"
 #include "Aql/SharedQueryState.h"
 #include "Basics/Common.h"
+#include "Basics/system-functions.h"
 #include "V8Server/V8Context.h"
 #include "Cluster/ClusterTypes.h"
 
@@ -109,17 +110,17 @@ class Query : public QueryContext {
 
   QueryString const& queryString() const { return _queryString; }
   
-  /// @brief Inject a transaction from outside. Use with care!
-  void injectTransaction(std::unique_ptr<transaction::Methods> trx);
-
   QueryProfile* profile() const { return _profile.get(); }
 
   velocypack::Slice optionsSlice() const { return _options->slice(); }
   
   TEST_VIRTUAL QueryOptions& queryOptions() { return _queryOptions; }
 
-  /// @brief return the start timestamp of the query
-  double startTime() const { return _startTime; }
+  /// @brief return the start timestamp of the query (system clock value)
+  double startTimeStamp() const noexcept;
+  
+  /// @brief return the start time of the query (steady clock value)
+  double startTime() const noexcept;
 
   void prepareQuery(SerializationFormat format);
   
@@ -208,7 +209,7 @@ class Query : public QueryContext {
 
  protected:
   /// @brief initializes the query
-  void init();
+  void init(bool createProfile);
 
   /// @brief calculate a hash for the query, once
   uint64_t hash();
@@ -287,9 +288,12 @@ class Query : public QueryContext {
   /// only populated when the query has generated its result(s) and before
   /// storing the cache entry in the query cache
   std::unique_ptr<QueryCacheResultEntry> _cacheEntry;
+  
+  /// @brief query start timestamp (system clock value)
+  double const _startTimeStamp;
 
-  /// @brief query start time
-  double _startTime;
+  /// @brief query start time (steady clock value)
+  double const _startTime;
 
   /// @brief hash for this query. will be calculated only once when needed
   mutable uint64_t _queryHash = DontCache;
@@ -300,7 +304,7 @@ class Query : public QueryContext {
   
   /// @brief whether or not someone else has acquired a V8 context for us
   bool const _contextOwnedByExterior;
-  
+
   bool _killed;
   
   /// @brief whether or not the hash was already calculated

--- a/arangod/Aql/QueryList.h
+++ b/arangod/Aql/QueryList.h
@@ -32,8 +32,6 @@
 #include "Basics/ReadWriteLock.h"
 #include "VocBase/voc-types.h"
 
-struct TRI_vocbase_t;
-
 namespace arangodb {
 namespace velocypack {
 class Builder;
@@ -66,7 +64,7 @@ struct QueryEntryCopy {
 class QueryList {
  public:
   /// @brief create a query list
-  explicit QueryList(QueryRegistryFeature&, TRI_vocbase_t*);
+  explicit QueryList(QueryRegistryFeature&);
 
   /// @brief destroy a query list
   ~QueryList() = default;
@@ -220,10 +218,10 @@ class QueryList {
   /// @brief r/w lock for the list
   arangodb::basics::ReadWriteLock _lock;
 
-  /// @brief list of current queries
+  /// @brief list of current queries, protected by _lock
   std::unordered_map<TRI_voc_tick_t, Query*> _current;
 
-  /// @brief list of slow queries
+  /// @brief list of slow queries, protected by _lock
   std::list<QueryEntryCopy> _slow;
 
   /// @brief whether or not queries are tracked

--- a/arangod/Aql/QueryResult.h
+++ b/arangod/Aql/QueryResult.h
@@ -43,8 +43,11 @@ class Context;
 namespace aql {
 
 struct QueryResult {
+  // no copying, but moving is allowed
+  QueryResult(QueryResult const& other) = delete;
   QueryResult& operator=(QueryResult const& other) = delete;
   QueryResult(QueryResult&& other) = default;
+  QueryResult& operator=(QueryResult&& other) = default;
 
   QueryResult()
       : result(),

--- a/arangod/Aql/QueryResultV8.h
+++ b/arangod/Aql/QueryResultV8.h
@@ -25,7 +25,6 @@
 #define ARANGOD_AQL_QUERY_RESULT_V8_H 1
 
 #include "Aql/QueryResult.h"
-#include "Basics/Common.h"
 
 #include <v8.h>
 
@@ -33,6 +32,7 @@ namespace arangodb {
 namespace aql {
 
 struct QueryResultV8 : public QueryResult {
+  QueryResultV8(QueryResultV8 const& other) = delete;
   QueryResultV8& operator=(QueryResultV8 const& other) = delete;
 
   QueryResultV8(QueryResultV8&& other) = default;

--- a/arangod/Aql/SingleRemoteModificationExecutor.cpp
+++ b/arangod/Aql/SingleRemoteModificationExecutor.cpp
@@ -146,7 +146,7 @@ auto SingleRemoteModificationExecutor<Modifier>::doSingleRemoteModificationOpera
     if (options.returnOld && !options.isOverwriteModeUpdateReplace()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_QUERY_VARIABLE_NAME_UNKNOWN,
-          "OLD is only available when using INSERT with the overwrite option");
+          "OLD is only available when using INSERT with overwriteModes 'update' or 'replace'");
     }
     result = _trx.insert(_info._aqlCollection->name(), inSlice, _info._options);
     possibleWrites = 1;

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -1640,7 +1640,7 @@ TRI_vocbase_t::TRI_vocbase_t(TRI_vocbase_type_e type,
   TRI_ASSERT(_info.valid());
 
   QueryRegistryFeature& feature = _info.server().getFeature<QueryRegistryFeature>();
-  _queries.reset(new arangodb::aql::QueryList(feature, this));
+  _queries.reset(new arangodb::aql::QueryList(feature));
   _cursorRepository.reset(new arangodb::CursorRepository(*this));
   _replicationClients.reset(new arangodb::ReplicationClientsProgressTracker());
 

--- a/tests/Aql/ExecutionBlockImplTest.cpp
+++ b/tests/Aql/ExecutionBlockImplTest.cpp
@@ -799,7 +799,7 @@ struct BaseCallAsserter {
  *        Assumes that we are always called once with an empty input.
  *        And once with a given input.
  *        Will expect to be called for skip and fullCount (4 counts)
- *        Does expect to not be called if skip and/or fullCount are ommited.
+ *        Does expect to not be called if skip and/or fullCount are omitted.
  */
 struct SkipCallAsserter : public BaseCallAsserter {
   explicit SkipCallAsserter(AqlCall const& expectedCall)

--- a/tests/Aql/SubqueryStartExecutorTest.cpp
+++ b/tests/Aql/SubqueryStartExecutorTest.cpp
@@ -169,7 +169,7 @@ TEST_P(SubqueryStartExecutorTest, adds_a_shadowrow_after_every_input_line) {
 }
 
 TEST_P(SubqueryStartExecutorTest, shadow_row_does_not_fit_in_current_block) {
-  // NOTE: This test relies on batchSizes beeing handled correctly and we do not over-allocate memory
+  // NOTE: This test relies on batchSizes being handled correctly and we do not over-allocate memory
   // Also it tests, that ShadowRows go into place accounting of the output block (count as 1 line)
 
   // NOTE: Reduce batch size to 1, to enforce a too small output block
@@ -298,7 +298,7 @@ TEST_P(SubqueryStartExecutorTest, shadow_row_forwarding_many_inputs_many_request
 }
 
 TEST_P(SubqueryStartExecutorTest, shadow_row_forwarding_many_inputs_not_enough_space) {
-  // NOTE: This test relies on batchSizes beeing handled correctly and we do not over-allocate memory
+  // NOTE: This test relies on batchSizes being handled correctly and we do not over-allocate memory
   // Also it tests, that ShadowRows go into place accounting of the output block (count as 1 line)
 
   // NOTE: Reduce batch size to 2, to enforce a too small output block, in between the shadow Rows

--- a/tests/IResearch/IResearchIndex-test.cpp
+++ b/tests/IResearch/IResearchIndex-test.cpp
@@ -825,7 +825,7 @@ TEST_F(IResearchIndexTest, test_async_index) {
   }
 }
 
-// test indexing selected fields will ommit non-indexed fields during query
+// test indexing selected fields will omit non-indexed fields during query
 TEST_F(IResearchIndexTest, test_fields) {
   auto createCollection0 = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testCollection0\" }");

--- a/tests/Transaction/Context-test.cpp
+++ b/tests/Transaction/Context-test.cpp
@@ -134,6 +134,7 @@ TEST_F(TransactionContextTest, StandaloneSmartContext) {
 
     auto qres = query.executeSync();
     ASSERT_TRUE(qres.ok());
+    ASSERT_NE(nullptr, qres.data);
     VPackSlice aqlSlice = qres.data->slice();
     ASSERT_TRUE(aqlSlice.isArray());
     ASSERT_EQ(aqlSlice.length(), 2);
@@ -149,6 +150,7 @@ TEST_F(TransactionContextTest, StandaloneSmartContext) {
 
     auto qres = query.executeSync();
     ASSERT_TRUE(qres.ok());
+    ASSERT_NE(nullptr, qres.data);
     VPackSlice aqlSlice = qres.data->slice();
     ASSERT_TRUE(aqlSlice.isArray());
     ASSERT_EQ(aqlSlice.length(), 1);

--- a/tests/Transaction/Manager-test.cpp
+++ b/tests/Transaction/Manager-test.cpp
@@ -394,6 +394,7 @@ TEST_F(TransactionManagerTest, aql_standalone_transaction) {
   auto qq = "FOR doc IN testCollection RETURN doc";
   arangodb::aql::QueryResult qres = executeQuery(vocbase, qq, ctx);
   ASSERT_TRUE(qres.ok());
+  ASSERT_NE(nullptr, qres.data);
   VPackSlice data = qres.data->slice();
   ASSERT_TRUE(data.isArray());
   ASSERT_EQ(data.length(), 1);

--- a/tests/js/common/shell/shell-query-spec.js
+++ b/tests/js/common/shell/shell-query-spec.js
@@ -161,7 +161,7 @@ describe('AQL query analyzer', function () {
     });
     
     it('should have proper running query descriptions', function () {
-      let now = (new Date).toISOString();
+      let now = (new Date()).toISOString();
       sendQuery(1, true);
       let q;
       let counter = 0;
@@ -187,7 +187,7 @@ describe('AQL query analyzer', function () {
     });
     
     it('should have proper running query descriptions, without bind vars', function () {
-      let now = (new Date).toISOString();
+      let now = (new Date()).toISOString();
       testee.properties({
         trackBindVars: false
       });
@@ -244,7 +244,7 @@ describe('AQL query analyzer', function () {
     });
 
     it('should track slow queries by threshold', function () {
-      let now = (new Date).toISOString();
+      let now = (new Date()).toISOString();
       sendQuery(1, false);
       expect(testee.current().filter(filterQueries).length).to.equal(0);
       expect(testee.slow().filter(filterQueries).length).to.equal(0);

--- a/tests/js/common/shell/shell-query-spec.js
+++ b/tests/js/common/shell/shell-query-spec.js
@@ -161,6 +161,7 @@ describe('AQL query analyzer', function () {
     });
     
     it('should have proper running query descriptions', function () {
+      let now = (new Date).toISOString();
       sendQuery(1, true);
       let q;
       let counter = 0;
@@ -177,12 +178,16 @@ describe('AQL query analyzer', function () {
       expect(q[0]).to.have.property('bindVars');
       expect(q[0].bindVars).to.eql({ value: 1 });
       expect(q[0]).to.have.property('started');
+      expect(q[0].started).to.be.greaterThan(now);
       expect(q[0]).to.have.property('runTime');
+      expect(q[0].runTime).to.be.greaterThan(0.0);
+      expect(q[0].runTime).to.be.lessThan(60.0);
       expect(q[0]).to.have.property('state', 'executing');
       expect(q[0]).to.have.property('stream', false);
     });
     
     it('should have proper running query descriptions, without bind vars', function () {
+      let now = (new Date).toISOString();
       testee.properties({
         trackBindVars: false
       });
@@ -202,7 +207,10 @@ describe('AQL query analyzer', function () {
       expect(q[0]).to.have.property('bindVars');
       expect(q[0].bindVars).to.eql({ });
       expect(q[0]).to.have.property('started');
+      expect(q[0].started).to.be.greaterThan(now);
       expect(q[0]).to.have.property('runTime');
+      expect(q[0].runTime).to.be.greaterThan(0.0);
+      expect(q[0].runTime).to.be.lessThan(60.0);
       expect(q[0]).to.have.property('state', 'executing');
       expect(q[0]).to.have.property('stream', false);
     });
@@ -236,6 +244,7 @@ describe('AQL query analyzer', function () {
     });
 
     it('should track slow queries by threshold', function () {
+      let now = (new Date).toISOString();
       sendQuery(1, false);
       expect(testee.current().filter(filterQueries).length).to.equal(0);
       expect(testee.slow().filter(filterQueries).length).to.equal(0);
@@ -253,7 +262,10 @@ describe('AQL query analyzer', function () {
       expect(queries[0]).to.have.property('bindVars');
       expect(queries[0].bindVars).to.eql({ value: 1 });
       expect(queries[0]).to.have.property('started');
+      expect(queries[0].started).to.be.greaterThan(now);
       expect(queries[0]).to.have.property('runTime');
+      expect(queries[0].runTime).to.be.greaterThan(0.0);
+      expect(queries[0].runTime).to.be.lessThan(60.0);
       expect(queries[0]).to.have.property('state', 'finished');
       expect(queries[0]).to.have.property('stream', false);
     });

--- a/tests/js/server/aql/aql-graph-k-shortest-path.js
+++ b/tests/js/server/aql/aql-graph-k-shortest-path.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, sub: true, maxlen: 500 */
-/*global assertEqual, assertTrue, assertFalse */
+/*global assertEqual, assertTrue, assertFalse, fail */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief tests for query language, graph functions
@@ -530,7 +530,8 @@ function kShortestPathsSyntaxTestSuite() {
       const query = `
         FOR a, b IN OUTBOUND K_SHORTEST_PATHS "x" TO "y" GRAPH "G" RETURN a`;
       try {
-        db._query(query).toArray();
+        db._query(query);
+        fail();
       } catch (e) {
         assertEqual(e.errorMessage, "AQL: k Shortest Paths only has one return variable near 'RETURN a' at position 2:68 (while parsing)");
       }


### PR DESCRIPTION
### Scope & Purpose

Clean up a bit in Query object and related parts.
The PR fixes wrong "started" values in QueryList.cpp (list of currently running queries), and fixes a few other small issues.
Additionally it avoids creating `_profile` objects for parse & explain operations and slightly simplifies the return value handling in error cases. 
I moved these changes out of another branch I currently have open, in order to keep the other branch smaller and to simplify reviews. 

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *shell_server_aql*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10802/