### PR TITLE
Remove "lazyLoading"

### DIFF
--- a/arangod/Pregel/Algorithm.h
+++ b/arangod/Pregel/Algorithm.h
@@ -60,8 +60,6 @@ struct IAlgorithm {
 
   virtual bool supportsCompensation() const { return false; }
 
-  virtual bool supportsLazyLoading() const { return false; }
-
   virtual IAggregator* aggregator(std::string const& name) const {
     return nullptr;
   }

--- a/arangod/Pregel/Algos/ShortestPath.h
+++ b/arangod/Pregel/Algos/ShortestPath.h
@@ -42,7 +42,6 @@ struct ShortestPathAlgorithm : public Algorithm<int64_t, int64_t, int64_t> {
                                  VPackSlice userParams);
 
   bool supportsAsyncMode() const override { return true; }
-  bool supportsLazyLoading() const override { return true; }
 
   GraphFormat<int64_t, int64_t>* inputFormat() const override;
   MessageFormat<int64_t>* messageFormat() const override {

--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -88,12 +88,6 @@ Conductor::Conductor(uint64_t executionNumber, TRI_vocbase_t& vocbase,
   if (_asyncMode) {
     LOG_TOPIC("1b1c2", DEBUG, Logger::PREGEL) << "Running in async mode";
   }
-  VPackSlice lazy = _userParams.slice().get(Utils::lazyLoadingKey);
-  _lazyLoading = _algorithm->supportsLazyLoading();
-  _lazyLoading = _lazyLoading && (lazy.isNone() || lazy.getBoolean());
-  if (_lazyLoading) {
-    LOG_TOPIC("464dd", DEBUG, Logger::PREGEL) << "Enabled lazy loading";
-  }
   _useMemoryMaps = VelocyPackHelper::getBooleanValue(_userParams.slice(),
                                                       Utils::useMemoryMaps, _useMemoryMaps);
   VPackSlice storeSlice = config.get("store");
@@ -576,7 +570,6 @@ int Conductor::_initializeWorkers(std::string const& suffix, VPackSlice addition
     b.add(Utils::userParametersKey, _userParams.slice());
     b.add(Utils::coordinatorIdKey, VPackValue(coordinatorId));
     b.add(Utils::asyncModeKey, VPackValue(_asyncMode));
-    b.add(Utils::lazyLoadingKey, VPackValue(_lazyLoading));
     b.add(Utils::useMemoryMaps, VPackValue(_useMemoryMaps));
     if (additional.isObject()) {
       for (auto pair : VPackObjectIterator(additional)) {

--- a/arangod/Pregel/Conductor.h
+++ b/arangod/Pregel/Conductor.h
@@ -81,7 +81,6 @@ class Conductor {
   uint64_t _maxSuperstep = 500;
   /// determines whether we support async execution
   bool _asyncMode = false;
-  bool _lazyLoading = false;
   bool _useMemoryMaps = false;
   bool _storeResults = false;
 

--- a/arangod/Pregel/GraphStore.cpp
+++ b/arangod/Pregel/GraphStore.cpp
@@ -180,6 +180,8 @@ void GraphStore<V, E>::loadDocument(WorkerConfig* config, std::string const& doc
 template <typename V, typename E>
 void GraphStore<V, E>::loadDocument(WorkerConfig* config, PregelShard sourceShard,
                                     VPackStringRef const& _key) {
+  // Apparently this code has not been implemented yet; find out whether it's
+  // needed at all or remove
   TRI_ASSERT(false);
 }
 

--- a/arangod/Pregel/Utils.cpp
+++ b/arangod/Pregel/Utils.cpp
@@ -60,7 +60,6 @@ std::string const Utils::edgeShardsKey = "edgeShards";
 std::string const Utils::globalShardListKey = "globalShardList";
 std::string const Utils::userParametersKey = "userparams";
 std::string const Utils::asyncModeKey = "asyncMode";
-std::string const Utils::lazyLoadingKey = "lazyloading";
 std::string const Utils::useMemoryMaps = "useMemoryMaps";
 std::string const Utils::parallelismKey = "parallelism";
 

--- a/arangod/Pregel/Utils.h
+++ b/arangod/Pregel/Utils.h
@@ -70,7 +70,6 @@ class Utils {
   static std::string const globalShardListKey;
   static std::string const userParametersKey;
   static std::string const asyncModeKey;
-  static std::string const lazyLoadingKey;
   static std::string const useMemoryMaps;
   static std::string const parallelismKey;
 

--- a/arangod/Pregel/WorkerConfig.cpp
+++ b/arangod/Pregel/WorkerConfig.cpp
@@ -52,7 +52,6 @@ void WorkerConfig::updateConfig(VPackSlice params) {
   _executionNumber = execNum.getUInt();
   _coordinatorId = coordID.copyString();
   _asynchronousMode = async.getBool();
-  _lazyLoading = params.get(Utils::lazyLoadingKey).getBool();
   _useMemoryMaps = params.get(Utils::useMemoryMaps).getBool();
 
   VPackSlice userParams = params.get(Utils::userParametersKey);

--- a/arangod/Pregel/WorkerConfig.h
+++ b/arangod/Pregel/WorkerConfig.h
@@ -58,8 +58,6 @@ class WorkerConfig {
 
   inline bool asynchronousMode() const { return _asynchronousMode; }
 
-  inline bool lazyLoading() const { return _lazyLoading; }
-
   inline bool useMemoryMaps() const { return _useMemoryMaps; }
 
   inline uint64_t parallelism() const { return _parallelism; }
@@ -134,8 +132,6 @@ class WorkerConfig {
 
   /// Let async
   bool _asynchronousMode = false;
-  /// load vertices on a lazy basis
-  bool _lazyLoading = false;
   bool _useMemoryMaps = false; /// always use mmaps
 
   size_t _parallelism = 1;


### PR DESCRIPTION
according to Michael Hackstein this was put in to optimize how many
documents were loaded when using MMFiles; since we don't use MMFiles anymore
this is not needed anymore.

The code where it was attempted to be used was the ShortestPath algorithm
which crashed anyway (because of an unimplemented loadDocument function).
