### PR TITLE
Fix AR-60: memory leak in recovery

### DIFF
--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -537,7 +537,7 @@ Result RocksDBMetaCollection::rebuildRevisionTree() {
 
     std::vector<std::size_t> revisions;
     auto* db = rocksutils::globalRocksDB();
-    auto iter = db->NewIterator(ro, documentBounds.columnFamily());
+    std::unique_ptr<rocksdb::Iterator> iter(db->NewIterator(ro, documentBounds.columnFamily()));
     for (iter->Seek(documentBounds.start());
          iter->Valid() && cmp->Compare(iter->key(), end) < 0; iter->Next()) {
       LocalDocumentId const docId = RocksDBKey::documentId(iter->key());


### PR DESCRIPTION
### Scope & Purpose

Under certain circumstances, we leak a RocksDB iterator during recovery, which can under some circumstances, leak a great deal of data accessed by that iterator.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)

#### Related Information

- [ ] There is an internal planning ticket: AR-60

### Testing & Verification

Covered by recovery tests with ASAN.

Jenkins: https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/10834/ (blue)
http://jenkins.arangodb.biz:8080/job/arangodb-ANY-linux-asan/314/
