### PR TITLE
improve readability of queries in web UI's query view

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Improve readability of running and slow queries in web UI by properly left-  
+  aligning the query strings.
+
 * Allow changing collection properties for smart edge collections as well. 
   Previously, collection property changes for smart edge collections were not
   propagated.

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/templates/arangoTable.ejs
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/templates/arangoTable.ejs
@@ -15,9 +15,7 @@
             <% _.each(k, function(x) { %>
               <% if (type && type[counter] === 'pre') { %>
                 <td class="arango-table-td table-cell<%=counter%>">
-                  <pre class="tablePre"> 
-                    <%=(content.unescaped && content.unescaped[counter] ? x : _.escape(x))%>
-                  </pre>
+                  <pre class="tablePre"><%=(content.unescaped && content.unescaped[counter] ? x : _.escape(x))%></pre>
                 </td>
               <% } else { %>
                 <td class="arango-table-td table-cell<%=counter%>"><%=(content.unescaped && content.unescaped[counter] ? x : _.escape(x))%></td>

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryManagementView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryManagementView.js
@@ -57,7 +57,7 @@
 
     tableDescription: {
       id: 'arangoQueryManagementTable',
-      titles: ['ID', 'Query String', 'Bind parameter', 'Runtime', 'Started', ''],
+      titles: ['ID', 'Query String', 'Bind parameters', 'Runtime', 'Started', ''],
       rows: [],
       unescaped: [false, false, false, false, false, true]
     },

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js
@@ -150,7 +150,7 @@
         }
         this.setCachedQuery(this.aqlEditor.getValue(), JSON.stringify(this.bindParamTableObj));
       } else {
-        arangoHelper.arangoError('Bind parameter', 'Could not parse bind parameter');
+        arangoHelper.arangoError('Bind parameters', 'Could not parse bind parameters');
       }
       this.resize();
     },

--- a/js/apps/system/_admin/aardvark/APP/frontend/scss/_arangoTable.scss
+++ b/js/apps/system/_admin/aardvark/APP/frontend/scss/_arangoTable.scss
@@ -30,6 +30,9 @@
       pre {
         background: none;
         border: 0;
+        padding-left: 0px;
+        padding-top: inherit;
+        margin: 0px 0px 0px 0px;
       }
     }
   }


### PR DESCRIPTION
### Scope & Purpose

Fixes a bit of web UI layout for the currently running and slow queries.
Previously, the query string was not properly left-aligned, due to usage of an HTML `<pre>` element inside a template that had lots of whitespace around the to-be-inserted query string. This effectly left-padding the query string, because a `<pre>` is supposed to keep and render all surrounding whitepace.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10836/