### PR TITLE
Bug fix 3.7/remove sonderlocke

### DIFF
--- a/lib/Basics/VelocyPackHelper.cpp
+++ b/lib/Basics/VelocyPackHelper.cpp
@@ -850,14 +850,7 @@ void VelocyPackHelper::patchDouble(VPackSlice slice, double value) {
   uint8_t* p = const_cast<uint8_t*>(slice.begin());
   // skip one byte for the header and overwrite
   // some architectures do not support unaligned writes, so copy bytewise
-  static_assert(sizeof(uint64_t) == sizeof(double), "invalid type sizes");
-  uint64_t dv;
-  memcpy(&dv, &value, sizeof(double));
-  VPackValueLength vSize = sizeof(double);
-  for (uint64_t x = dv; vSize > 0; vSize--) {
-    *(++p) = x & 0xff;
-    x >>= 8;
-  }
+  memcpy(p + 1, &value, sizeof(double));
 }
 
 bool VelocyPackHelper::hasNonClientTypes(VPackSlice input, bool checkExternals, bool checkCustom) {

--- a/lib/Basics/VelocyPackHelper.cpp
+++ b/lib/Basics/VelocyPackHelper.cpp
@@ -849,8 +849,8 @@ void VelocyPackHelper::patchDouble(VPackSlice slice, double value) {
   // get pointer to the start of the value
   uint8_t* p = const_cast<uint8_t*>(slice.begin());
   // skip one byte for the header and overwrite
-#ifndef TRI_UNALIGNED_ACCESS
-  // some architectures do not support unaligned writes, then copy bytewise
+  // some architectures do not support unaligned writes, so copy bytewise
+  static_assert(sizeof(uint64_t) == sizeof(double), "invalid type sizes");
   uint64_t dv;
   memcpy(&dv, &value, sizeof(double));
   VPackValueLength vSize = sizeof(double);
@@ -858,11 +858,6 @@ void VelocyPackHelper::patchDouble(VPackSlice slice, double value) {
     *(++p) = x & 0xff;
     x >>= 8;
   }
-#else
-  // other platforms support unaligned writes
-  // cppcheck-suppress *
-  *reinterpret_cast<double*>(p + 1) = value;
-#endif
 }
 
 bool VelocyPackHelper::hasNonClientTypes(VPackSlice input, bool checkExternals, bool checkCustom) {

--- a/tests/Basics/VelocyPackHelper-test.cpp
+++ b/tests/Basics/VelocyPackHelper-test.cpp
@@ -44,15 +44,22 @@
   r = VPackParser::fromJson(rValue);  \
   EXPECT_EQ(expected, func(l->slice(), r->slice(), true)); \
 
-#define INIT_BUFFER  TRI_string_buffer_t* sb = TRI_CreateStringBuffer();
-#define FREE_BUFFER  TRI_FreeStringBuffer(sb);
-#define STRINGIFY    TRI_StringifyJson(sb, json);
-#define STRING_VALUE sb->_buffer
-#define FREE_JSON    TRI_FreeJson(json);
-
 // -----------------------------------------------------------------------------
 // --SECTION--                                                        test suite
 // -----------------------------------------------------------------------------
+
+TEST(VPackHelperTest, tst_patch_double) {
+  VPackBuilder b;
+  b.add(VPackValue(double(1.0)));
+  
+  EXPECT_DOUBLE_EQ(double(1.0), b.slice().getDouble());
+
+  arangodb::basics::VelocyPackHelper::patchDouble(b.slice(), double(2.0));
+  EXPECT_DOUBLE_EQ(double(2.0), b.slice().getDouble());
+  
+  arangodb::basics::VelocyPackHelper::patchDouble(b.slice(), double(-34.456));
+  EXPECT_DOUBLE_EQ(double(-34.456), b.slice().getDouble());
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test compare values with equal values


### PR DESCRIPTION
### Scope & Purpose

Remove a Sonderlocke for patching double value in existing VPack chunks.
There was a potential optimized code branch for platforms that allow unaligned writes, but this only made the code more complex and can cause false-positive warnings with UBSan. So let's simplify this and rely on compilers to properly optimize it. It is called rarely anway.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new C++ **Unit Tests** (Either GoogleTest or Catch-Test)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10846/