### PR TITLE
Bug fix/invalid memory access in gather test

### DIFF
--- a/tests/Aql/GatherExecutorCommonTest.cpp
+++ b/tests/Aql/GatherExecutorCommonTest.cpp
@@ -553,7 +553,7 @@ class CommonGatherExecutorTest
   auto sortedExecutor(RegisterInfos&& regInfos, GatherNode::SortMode sortMode)
       -> std::unique_ptr<ExecutionBlock> {
     std::vector<SortRegister> sortRegister;
-    sortRegister.emplace_back(SortRegister{0, SortElement{nullptr, true}});
+    sortRegister.emplace_back(SortRegister{0, _sortElement});
 
     auto executorInfos =
         SortingGatherExecutorInfos(std::move(sortRegister), *fakedQuery.get(),
@@ -662,6 +662,10 @@ class CommonGatherExecutorTest
   std::vector<std::unique_ptr<ExecutionBlock>> _blockLake;
   // Activate result logging
   bool _useLogging{false};
+
+  // We need to retain the memory of this SortElement. Otherwise we have invalid memory access,
+  // for sorting nodes.
+  SortElement _sortElement{nullptr, true};
 
 };  // namespace arangodb::tests::aql
 


### PR DESCRIPTION
Test only fix.

There is an invalid memory access, where a Referenced vector can go out of scope.
No change for Production code.
On Purpose no changelog.

Jenkins:
http://jenkins.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/10856/