### PR TITLE
Starting HTTP/2 with Prior Knowledge

### DIFF
--- a/3rdParty/fuerte/include/fuerte/connection.h
+++ b/3rdParty/fuerte/include/fuerte/connection.h
@@ -213,6 +213,12 @@ class ConnectionBuilder {
     _conf._vstVersion = c;
     return *this;
   }
+  
+  /// upgrade http1.1 to http2 connection (not necessary)
+  ConnectionBuilder& upgradeHttp1ToHttp2(bool c) {
+    _conf._upgradeH1ToH2 = c;
+    return *this;
+  }
 
   /// @brief should we verify the SSL host
   inline bool verifyHost() const { return _conf._verifyHost; }

--- a/3rdParty/fuerte/include/fuerte/types.h
+++ b/3rdParty/fuerte/include/fuerte/types.h
@@ -181,6 +181,7 @@ struct ConnectionConfiguration {
       : _socketType(SocketType::Tcp),
         _protocolType(ProtocolType::Vst),
         _vstVersion(vst::VST1_1),
+        _upgradeH1ToH2(false),
         _host("localhost"),
         _port("8529"),
         _verifyHost(false),
@@ -197,6 +198,7 @@ struct ConnectionConfiguration {
   SocketType _socketType;      // tcp, ssl or unix
   ProtocolType _protocolType;  // vst or http
   vst::VSTVersion _vstVersion;
+  bool _upgradeH1ToH2;
 
   std::string _host;
   std::string _port;

--- a/3rdParty/fuerte/src/H2Connection.h
+++ b/3rdParty/fuerte/src/H2Connection.h
@@ -115,6 +115,7 @@ class H2Connection final : public fuerte::GeneralConnection<T> {
 
   void initNgHttp2Session();
 
+  void sendHttp1UpgradeRequest();
   void readSwitchingProtocolsResponse();
 
   // adjust the timeouts (only call from IO-Thread)

--- a/arangod/GeneralServer/H2CommTask.cpp
+++ b/arangod/GeneralServer/H2CommTask.cpp
@@ -364,7 +364,7 @@ void H2CommTask<T>::start() {
     submitConnectionPreface(me._session);
 
     me.doWrite();  // write out preface
-    me.asyncReadSome();
+    me.asyncReadSome(); // start reading
   });
 }
 

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -297,10 +297,9 @@ namespace {
 static constexpr const char* vst10 = "VST/1.0\r\n\r\n";
 static constexpr const char* vst11 = "VST/1.1\r\n\r\n";
 static constexpr const char* h2Preface = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
-static size_t vstLen = 11;       // length of vst connection preface
-static size_t h2PrefaceLen = 24; // length of h2 connection preface
-static size_t minHttpRequestLen = 18; // min length of an http 1.0 request
-// simon: Technically http 1.1 requires 'Host' header i.e. 24 bytes minimum
+static constexpr size_t vstLen = 11;          // length of vst connection preface
+static constexpr size_t h2PrefaceLen = 24;    // length of h2 connection preface
+static constexpr size_t minHttpRequestLen = 18; // min length of http 1.0 request
 }  // namespace
 
 template <SocketType T>

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -296,43 +296,57 @@ bool HttpCommTask<T>::readCallback(asio_ns::error_code ec) {
 namespace {
 static constexpr const char* vst10 = "VST/1.0\r\n\r\n";
 static constexpr const char* vst11 = "VST/1.1\r\n\r\n";
+static constexpr const char* h2Preface = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+static size_t vstLen = 11;       // length of vst connection preface
+static size_t h2PrefaceLen = 24; // length of h2 connection preface
+static size_t minHttpRequestLen = 18; // min length of an http 1.0 request
+// simon: Technically http 1.1 requires 'Host' header i.e. 24 bytes minimum
 }  // namespace
 
 template <SocketType T>
 void HttpCommTask<T>::checkVSTPrefix() {
   auto cb = [self = this->shared_from_this()](asio_ns::error_code const& ec, size_t nread) {
-    auto* me = static_cast<HttpCommTask<T>*>(self.get());
-    if (ec || nread < 11) {
-      me->close(ec);
+    auto& me = static_cast<HttpCommTask<T>&>(*self);
+    if (ec || nread < vstLen) {
+      me.close(ec);
       return;
     }
-    me->_protocol->buffer.commit(nread);
+    me._protocol->buffer.commit(nread);
 
-    auto bg = asio_ns::buffers_begin(me->_protocol->buffer.data());
-    if (std::equal(::vst10, ::vst10 + 11, bg, bg + 11)) {
-      me->_protocol->buffer.consume(11);  // remove VST/1.0 prefix
-      auto commTask = std::make_unique<VstCommTask<T>>(me->_server, me->_connectionInfo,
-                                                       std::move(me->_protocol),
+    auto bg = asio_ns::buffers_begin(me._protocol->buffer.data());
+    if (std::equal(::vst10, ::vst10 + vstLen, bg, bg + ptrdiff_t(vstLen))) {
+      me._protocol->buffer.consume(vstLen);  // remove VST/1.0 prefix
+      auto commTask = std::make_unique<VstCommTask<T>>(me._server, me._connectionInfo,
+                                                       std::move(me._protocol),
                                                        fuerte::vst::VST1_0);
-      me->_server.registerTask(std::move(commTask));
-      me->close(ec);
+      me._server.registerTask(std::move(commTask));
+      me.close(ec);
       return;  // vst 1.0
 
-    } else if (std::equal(::vst11, ::vst11 + 11, bg, bg + 11)) {
-      me->_protocol->buffer.consume(11);  // remove VST/1.1 prefix
-      auto commTask = std::make_unique<VstCommTask<T>>(me->_server, me->_connectionInfo,
-                                                       std::move(me->_protocol),
+    } else if (std::equal(::vst11, ::vst11 + vstLen, bg, bg + ptrdiff_t(vstLen))) {
+      me._protocol->buffer.consume(vstLen);  // remove VST/1.1 prefix
+      auto commTask = std::make_unique<VstCommTask<T>>(me._server, me._connectionInfo,
+                                                       std::move(me._protocol),
                                                        fuerte::vst::VST1_1);
-      me->_server.registerTask(std::move(commTask));
-      me->close(ec);
+      me._server.registerTask(std::move(commTask));
+      me.close(ec);
       return;  // vst 1.1
+    } else if (nread >= h2PrefaceLen &&
+               std::equal(::h2Preface, ::h2Preface + h2PrefaceLen,
+                          bg, bg + ptrdiff_t(h2PrefaceLen))) {
+      // do not remove the preface here
+      auto commTask = std::make_unique<H2CommTask<T>>(me._server, me._connectionInfo,
+                                                      std::move(me._protocol));
+      me._server.registerTask(std::move(commTask));
+      me.close(ec);
+      return;  // http2 upgrade
     }
 
-    me->asyncReadSome();  // continue reading
+    me.asyncReadSome();  // continue reading
   };
   auto buffs = this->_protocol->buffer.prepare(GeneralCommTask<T>::ReadBlockSize);
   asio_ns::async_read(this->_protocol->socket, buffs,
-                      asio_ns::transfer_at_least(11), std::move(cb));
+                      asio_ns::transfer_at_least(minHttpRequestLen), std::move(cb));
 }
 
 #ifdef USE_DTRACE


### PR DESCRIPTION
Support starting a non TLS http2 connection without upgrading from http 1.1
https://tools.ietf.org/html/rfc7540#section-3.4

https://172.16.10.101/job/arangodb-matrix-pr/10871/