### PR TITLE
Fixed a potential agency crash if trace logging is on.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
+* Fixed a potential agency crash if trace logging is on.
+
 * Fixed a document parsing bug in the Web UI. This issue occured in the
   document list view in case a document had an attribute called `length`.
   The result was an incorrect representation of the document preview.


### PR DESCRIPTION
This is a rather trivial fix which needs porting to all branches.
This is the 3.7 port.

Manual test procedure:

 1. Switch log level of topic "agency" to TRACE in the agency.
 2. Kill -9 a dbserver.

If agency leader does not crash, the fix works.