### PR TITLE
fix logger issues

### DIFF
--- a/lib/Logger/LogAppender.cpp
+++ b/lib/Logger/LogAppender.cpp
@@ -48,7 +48,7 @@ std::vector<std::shared_ptr<LogAppender>> LogAppender::_globalAppenders;
 
 std::map<size_t, std::vector<std::shared_ptr<LogAppender>>> LogAppender::_topics2appenders;
 
-std::map<std::pair<std::string, std::string>, std::shared_ptr<LogAppender>> LogAppender::_definition2appenders;
+std::map<std::string, std::shared_ptr<LogAppender>> LogAppender::_definition2appenders;
 
 bool LogAppender::_allowStdLogging = true;
 
@@ -57,85 +57,60 @@ void LogAppender::addGlobalAppender(std::shared_ptr<LogAppender> appender) {
   _globalAppenders.emplace_back(std::move(appender));
 }
   
-void LogAppender::addAppender(std::string const& definition, std::string const& filter) {
-  MUTEX_LOCKER(guard, _appendersLock);
-  std::pair<std::shared_ptr<LogAppender>, LogTopic*> appender(
-      buildAppender(definition, filter));
-
-  if (appender.first == nullptr) {
-    return;
-  }
-
-  LogTopic* topic = appender.second;
-  size_t n = (topic == nullptr) ? LogTopic::MAX_LOG_TOPICS : topic->id();
-  if (std::find(_topics2appenders[n].begin(), _topics2appenders[n].end(),
-                appender.first) == _topics2appenders[n].end()) {
-    _topics2appenders[n].emplace_back(appender.first);
-  }
-}
-
-std::pair<std::shared_ptr<LogAppender>, LogTopic*> LogAppender::buildAppender(
-    std::string const& definition, std::string const& filter) {
-  std::vector<std::string> v = StringUtils::split(definition, '=');
+void LogAppender::addAppender(std::string const& definition) {
   std::string topicName;
   std::string output;
-  std::string contentFilter;
-
-  if (v.size() == 1) {
-    output = v[0];
-    contentFilter = filter;
-  } else if (v.size() == 2) {
-    topicName = StringUtils::tolower(v[0]);
-
-    if (topicName.empty()) {
-      output = v[0];
-      contentFilter = filter;
-    } else {
-      output = v[1];
-    }
-  } else {
-    LOG_TOPIC("32068", ERR, arangodb::Logger::FIXME)
-        << "strange output definition '" << definition << "' ignored";
-    return {nullptr, nullptr};
-  }
-
   LogTopic* topic = nullptr;
+  Result res = parseDefinition(definition, topicName, output, topic);
 
-  if (!topicName.empty()) {
-    topic = LogTopic::lookup(topicName);
-
-    if (topic == nullptr) {
-      LOG_TOPIC("a1098", ERR, arangodb::Logger::FIXME)
-          << "strange topic '" << topicName << "', ignoring whole defintion";
-      return {nullptr, nullptr};
-    }
+  if (res.fail()) {
+    LOG_TOPIC("658e0", ERR, Logger::FIXME) << res.errorMessage();
+    return;
   }
-
-  auto key = std::make_pair(output, contentFilter);
+  
+  auto key = output;
 
 #ifdef ARANGODB_ENABLE_SYSLOG
   if (StringUtils::isPrefix(output, "syslog://")) {
-    key = std::make_pair("syslog://", "");
+    key = "syslog://";
   }
 #endif
 
+  std::shared_ptr<LogAppender> appender;
+
+  MUTEX_LOCKER(guard, _appendersLock);
+  
   auto it = _definition2appenders.find(key);
 
   if (it != _definition2appenders.end()) {
-    return {it->second, topic};
+    // found an existing appender
+    appender = it->second;
+  } else {
+    // build a new appender from the definition. note: this may modify _definition2appenders
+    appender = buildAppender(output);
   }
 
+  if (appender != nullptr) {
+    try {
+      _definition2appenders[key] = appender;
+    } catch (...) {
+      // cannot open file for logging?
+      return;
+    }
+
+    size_t n = (topic == nullptr) ? LogTopic::MAX_LOG_TOPICS : topic->id();
+    if (std::find(_topics2appenders[n].begin(), _topics2appenders[n].end(), appender) == _topics2appenders[n].end()) {
+      _topics2appenders[n].emplace_back(appender);
+    }
+  }
+}
+
+std::shared_ptr<LogAppender> LogAppender::buildAppender(std::string const& output) {
 #ifdef ARANGODB_ENABLE_SYSLOG
   // first handle syslog-logging
   if (StringUtils::isPrefix(output, "syslog://")) {
     auto s = StringUtils::split(output.substr(9), '/');
-
-    if (s.size() < 1 || s.size() > 2) {
-      LOG_TOPIC("70194", ERR, arangodb::Logger::FIXME)
-          << "unknown syslog definition '" << output << "', expecting "
-          << "'syslog://facility/identifier'";
-      return {nullptr, nullptr};
-    }
+    TRI_ASSERT(s.size() == 1 || s.size() == 2);
 
     std::string identifier;
 
@@ -143,18 +118,15 @@ std::pair<std::shared_ptr<LogAppender>, LogTopic*> LogAppender::buildAppender(
       identifier = s[1];
     }
 
-    auto result = std::make_shared<LogAppenderSyslog>(s[0], identifier, contentFilter);
-    _definition2appenders[key] = result;
-
-    return {result, topic};
+    return std::make_shared<LogAppenderSyslog>(s[0], identifier);
   }
 #endif
 
   if (output == "+" || output == "-") {
     for (auto const& it : _definition2appenders) {
-      if (it.first.first == "+" || it.first.first == "-") {
+      if (it.first == "+" || it.first == "-") {
         // alreay got a logger for stderr/stdout
-        return {nullptr, nullptr};
+        return nullptr;
       }
     }
   }
@@ -163,25 +135,14 @@ std::pair<std::shared_ptr<LogAppender>, LogTopic*> LogAppender::buildAppender(
   std::shared_ptr<LogAppenderStream> result;
 
   if (output == "+") {
-    result.reset(new LogAppenderStderr(contentFilter));
+    result = std::make_shared<LogAppenderStderr>();
   } else if (output == "-") {
-    result.reset(new LogAppenderStdout(contentFilter));
+    result = std::make_shared<LogAppenderStdout>();
   } else if (StringUtils::isPrefix(output, "file://")) {
-    result.reset(new LogAppenderFile(output.substr(7), contentFilter));
-  } else {
-    LOG_TOPIC("ca950", ERR, arangodb::Logger::FIXME)
-        << "unknown output definition '" << output << "'";
-    return {nullptr, nullptr};
+    result = std::make_shared<LogAppenderFile>(output.substr(7));
   }
-
-  try {
-    _definition2appenders[key] = result;
-
-    return {result, topic};
-  } catch (...) {
-    // cannot open file for logging
-    return {nullptr, nullptr};
-  }
+  
+  return result;
 }
 
 void LogAppender::logGlobal(LogMessage const& message) {
@@ -203,12 +164,9 @@ void LogAppender::log(LogMessage const& message) {
       auto const& appenders = it->second;
 
       for (auto const& appender : appenders) {
-        if (appender->checkContent(message._message)) {
-          appender->logMessage(message);
-        }
-
-        shown = true;
+        appender->logMessage(message);
       }
+      shown = true;
     }
 
     return shown;
@@ -234,7 +192,9 @@ void LogAppender::log(LogMessage const& message) {
 void LogAppender::shutdown() {
   MUTEX_LOCKER(guard, _appendersLock);
 
+#ifdef ARANGODB_ENABLE_SYSLOG
   LogAppenderSyslog::close();
+#endif
   LogAppenderFile::closeAll();
 
   _globalAppenders.clear();
@@ -246,4 +206,59 @@ void LogAppender::reopen() {
   MUTEX_LOCKER(guard, _appendersLock);
 
   LogAppenderFile::reopenAll();
+}
+
+Result LogAppender::parseDefinition(std::string const& definition, 
+                                    std::string& topicName,
+                                    std::string& output,
+                                    LogTopic*& topic) {
+  topicName.clear();
+  output.clear();
+  topic = nullptr;
+
+  // split into parts and do some basic validation
+  std::vector<std::string> v = StringUtils::split(definition, '=');
+
+  if (v.size() == 1) {
+    output = v[0];
+  } else if (v.size() == 2) {
+    topicName = StringUtils::tolower(v[0]);
+
+    if (topicName.empty()) {
+      output = v[0];
+    } else {
+      output = v[1];
+    }
+  } else {
+    return Result(TRI_ERROR_BAD_PARAMETER, std::string("strange output definition '") + definition + "' ignored");
+  }
+
+  if (!topicName.empty()) {
+    topic = LogTopic::lookup(topicName);
+
+    if (topic == nullptr) {
+      return Result(TRI_ERROR_BAD_PARAMETER, std::string("strange topic '") + topicName + "', ignoring whole defintion");
+    }
+  }
+
+  bool handled = false;
+#ifdef ARANGODB_ENABLE_SYSLOG
+  if (StringUtils::isPrefix(output, "syslog://")) {
+    handled = true;
+    auto s = StringUtils::split(output.substr(9), '/');
+
+    if (s.size() < 1 || s.size() > 2) {
+      return Result(TRI_ERROR_BAD_PARAMETER, std::string("unknown syslog definition '") + output + "', expecting 'syslog://facility/identifier'");
+    }
+  }
+#endif
+
+  if (!handled) {
+    // not yet handled. must be a file-based logger now.
+    if (output != "+" && output != "-" && !StringUtils::isPrefix(output, "file://")) {
+      return Result(TRI_ERROR_BAD_PARAMETER, std::string("unknown output definition '") + output + "'");
+    }
+  }
+ 
+  return Result();
 }

--- a/lib/Logger/LogAppenderFile.h
+++ b/lib/Logger/LogAppenderFile.h
@@ -26,6 +26,7 @@
 
 #include <stddef.h>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -35,10 +36,10 @@
 
 namespace arangodb {
 struct LogMessage;
-
+  
 class LogAppenderStream : public LogAppender {
  public:
-  LogAppenderStream(std::string const& filename, std::string const& filter, int fd);
+  LogAppenderStream(std::string const& filename, int fd);
   ~LogAppenderStream() = default;
 
   void logMessage(LogMessage const& message) override final;
@@ -83,37 +84,43 @@ class LogAppenderStream : public LogAppender {
 
 class LogAppenderFile : public LogAppenderStream {
  public:
-  LogAppenderFile(std::string const& filename, std::string const& filter);
+  explicit LogAppenderFile(std::string const& filename);
+  ~LogAppenderFile();
 
   void writeLogMessage(LogLevel level, size_t topicId, char const* buffer, size_t len) override final;
 
   std::string details() const override final;
 
+  std::string const& filename() const { return _filename; }
+
  public:
   static void reopenAll();
   static void closeAll();
-  static std::vector<std::tuple<int, std::string, LogAppenderFile*>> getFds() {
-    return _fds;
-  }
-  static void setFds(std::vector<std::tuple<int, std::string, LogAppenderFile*>> const& fds) {
-    _fds = fds;
-  }
+
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+  static std::vector<std::tuple<int, std::string, LogAppenderFile*>> getAppenders();
+
+  static void setAppenders(std::vector<std::tuple<int, std::string, LogAppenderFile*>> const& fds);
+  
   static void clear();
+#endif
 
   static void setFileMode(int mode) { _fileMode = mode; }
   static void setFileGroup(int group) { _fileGroup = group; }
 
  private:
-  static std::vector<std::tuple<int, std::string, LogAppenderFile*>> _fds;
+  std::string const _filename;
+
+  static std::mutex _openAppendersMutex;
+  static std::vector<LogAppenderFile*> _openAppenders;
+
   static int _fileMode;
   static int _fileGroup;
-
-  std::string _filename;
 };
 
 class LogAppenderStdStream : public LogAppenderStream {
  public:
-  LogAppenderStdStream(std::string const& filename, std::string const& filter, int fd);
+  LogAppenderStdStream(std::string const& filename, int fd);
   ~LogAppenderStdStream();
 
   std::string details() const override final { return std::string(); }
@@ -127,12 +134,12 @@ class LogAppenderStdStream : public LogAppenderStream {
 
 class LogAppenderStderr final : public LogAppenderStdStream {
  public:
-  explicit LogAppenderStderr(std::string const& filter);
+  LogAppenderStderr();
 };
 
 class LogAppenderStdout final : public LogAppenderStdStream {
  public:
-  explicit LogAppenderStdout(std::string const& filter);
+  LogAppenderStdout();
 };
 
 }  // namespace arangodb

--- a/lib/Logger/LogAppenderFile.h
+++ b/lib/Logger/LogAppenderFile.h
@@ -101,8 +101,6 @@ class LogAppenderFile : public LogAppenderStream {
   static std::vector<std::tuple<int, std::string, LogAppenderFile*>> getAppenders();
 
   static void setAppenders(std::vector<std::tuple<int, std::string, LogAppenderFile*>> const& fds);
-  
-  static void clear();
 #endif
 
   static void setFileMode(int mode) { _fileMode = mode; }

--- a/lib/Logger/LogAppenderSyslog.cpp
+++ b/lib/Logger/LogAppenderSyslog.cpp
@@ -36,7 +36,6 @@ using namespace arangodb;
 #endif
 
 #include <cstring>
-#include "Basics/MutexLocker.h"
 #include "Basics/StringUtils.h"
 #include "Logger/Logger.h"
 
@@ -51,11 +50,9 @@ void LogAppenderSyslog::close() {
   }
 }
 
-LogAppenderSyslog::LogAppenderSyslog(std::string const& facility,
-                                     std::string const& name, std::string const& filter)
-    : LogAppender(filter) {
-  // no logging
-  std::string sysname = name.empty() ? "[arangod]" : name;
+LogAppenderSyslog::LogAppenderSyslog(std::string const& facility, std::string const& name)
+    : LogAppender(),
+      _sysname(name.empty() ? "[arangod]" : name) {
 
   // find facility
   int value = LOG_LOCAL0;
@@ -75,8 +72,13 @@ LogAppenderSyslog::LogAppenderSyslog(std::string const& facility,
     }
   }
 
+  // from man 3 syslog:
+  //   The argument ident in the call of openlog() is probably stored as-is.  
+  //   Thus, if the string it points to is changed, syslog() may start prepending the changed string, and  if
+  //    the string it points to ceases to exist, the results are undefined.  Most portable is to use a string constant.
+  
   // and open logging, openlog does not have a return value...
-  ::openlog(sysname.c_str(), LOG_CONS | LOG_PID, value);
+  ::openlog(_sysname.c_str(), LOG_CONS | LOG_PID, value);
   _opened = true;
 }
 
@@ -113,15 +115,5 @@ void LogAppenderSyslog::logMessage(LogMessage const& message) {
 std::string LogAppenderSyslog::details() const {
   return "More error details may be provided in the syslog";
 }
-
-#else
-
-LogAppenderSyslog::LogAppenderSyslog(std::string const& facility,
-                                     std::string const& name, std::string const& filter)
-    : LogAppender(filter) {
-  std::abort();
-}
-
-void LogAppenderSyslog::close() {}
 
 #endif

--- a/lib/Logger/LogAppenderSyslog.h
+++ b/lib/Logger/LogAppenderSyslog.h
@@ -34,28 +34,17 @@ class LogAppenderSyslog final : public LogAppender {
   static void close();
 
  public:
-  LogAppenderSyslog(std::string const& facility, std::string const& name,
-                    std::string const& filter);
+  LogAppenderSyslog(std::string const& facility, std::string const& name);
 
   void logMessage(LogMessage const& message) override final;
 
   std::string details() const override final;
 
  private:
+  std::string const _sysname;
+
   static bool _opened;
 };
-
-#else
-
-class LogAppenderSyslog : public LogAppender {
- public:
-  static void close();
-
- public:
-  LogAppenderSyslog(std::string const& facility, std::string const& name,
-                    std::string const& filter);
-};
-
 #endif
 }  // namespace arangodb
 

--- a/tests/Agency/NodeTest.cpp
+++ b/tests/Agency/NodeTest.cpp
@@ -153,7 +153,7 @@ TEST_F(NodeTest, node_applyOp_set) {
 
   ret = n(path).applyOp(b->slice());
   EXPECT_EQ(ret.ok(), false);
-  std::cout << ret.errorMessage() << std::endl;
+  // std::cout << ret.errorMessage() << std::endl;
 
   b = std::make_shared<VPackBuilder>();
   { VPackObjectBuilder a(b.get());
@@ -161,7 +161,7 @@ TEST_F(NodeTest, node_applyOp_set) {
 
   ret = n(path).applyOp(b->slice());
   EXPECT_EQ(ret.ok(), false);
-  std::cout << ret.errorMessage() << std::endl;
+  // std::cout << ret.errorMessage() << std::endl;
 }
 
 TEST_F(NodeTest, node_applyOp_delete) {

--- a/tests/Basics/LoggerTest.cpp
+++ b/tests/Basics/LoggerTest.cpp
@@ -54,7 +54,7 @@ class LoggerTest : public ::testing::Test {
   std::string const logfile2;
 
   LoggerTest()
-      : backup(LogAppenderFile::getFds()),
+      : backup(LogAppenderFile::getAppenders()),
         path(TRI_GetTempPath()),
         logfile1(path + "logfile1"),
         logfile2(path + "logfile2") {
@@ -66,7 +66,7 @@ class LoggerTest : public ::testing::Test {
 
   ~LoggerTest() {
     // restore old state
-    LogAppenderFile::setFds(backup);
+    LogAppenderFile::setAppenders(backup);
     LogAppenderFile::reopenAll();
 
     FileUtils::remove(logfile1);
@@ -75,10 +75,10 @@ class LoggerTest : public ::testing::Test {
 };
 
 TEST_F(LoggerTest, test_fds) {
-  LogAppenderFile logger1(logfile1, "");
-  LogAppenderFile logger2(logfile2, "");
+  LogAppenderFile logger1(logfile1);
+  LogAppenderFile logger2(logfile2);
 
-  auto fds = LogAppenderFile::getFds();
+  auto fds = LogAppenderFile::getAppenders();
   EXPECT_EQ(fds.size(), 2);
 
   EXPECT_EQ(std::get<1>(fds[0]), logfile1);
@@ -99,10 +99,10 @@ TEST_F(LoggerTest, test_fds) {
 }
 
 TEST_F(LoggerTest, test_fds_after_reopen) {
-  LogAppenderFile logger1(logfile1, "");
-  LogAppenderFile logger2(logfile2, "");
+  LogAppenderFile logger1(logfile1);
+  LogAppenderFile logger2(logfile2);
 
-  auto fds = LogAppenderFile::getFds();
+  auto fds = LogAppenderFile::getAppenders();
   EXPECT_EQ(fds.size(), 2);
 
   EXPECT_EQ(std::get<1>(fds[0]), logfile1);
@@ -122,7 +122,7 @@ TEST_F(LoggerTest, test_fds_after_reopen) {
 
   LogAppenderFile::reopenAll();
 
-  fds = LogAppenderFile::getFds();
+  fds = LogAppenderFile::getAppenders();
   EXPECT_EQ(fds.size(), 2);
 
   EXPECT_TRUE(std::get<0>(fds[0]) > STDERR_FILENO);

--- a/tests/Basics/LoggerTest.cpp
+++ b/tests/Basics/LoggerTest.cpp
@@ -61,7 +61,7 @@ class LoggerTest : public ::testing::Test {
     FileUtils::remove(logfile1);
     FileUtils::remove(logfile2);
     // remove any previous loggers
-    LogAppenderFile::clear();
+    LogAppenderFile::closeAll();
   }
 
   ~LoggerTest() {
@@ -95,7 +95,7 @@ TEST_F(LoggerTest, test_fds) {
   EXPECT_EQ(content.find("some error message"), std::string::npos);
   EXPECT_NE(content.find("some warning message"), std::string::npos);
 
-  LogAppenderFile::clear();
+  LogAppenderFile::closeAll();
 }
 
 TEST_F(LoggerTest, test_fds_after_reopen) {
@@ -142,5 +142,5 @@ TEST_F(LoggerTest, test_fds_after_reopen) {
   EXPECT_EQ(content.find("some warning message"), std::string::npos);
   EXPECT_NE(content.find("some other warning message"), std::string::npos);
 
-  LogAppenderFile::clear();
+  LogAppenderFile::closeAll();
 }

--- a/tests/Geo/ShapeContainerTest.cpp
+++ b/tests/Geo/ShapeContainerTest.cpp
@@ -62,9 +62,9 @@ namespace {
 bool pointsEqual(S2Point const& a, S2Point const& b) {
   bool equal = (a.Angle(b) * arangodb::geo::kEarthRadiusInMeters) <= AcceptableDistanceError;
   if (!equal) {
-    std::cout << "EXPECTING EQUAL POINTS, GOT " << S2LatLng(a).ToStringInDegrees()
-              << " AND " << S2LatLng(b).ToStringInDegrees() << " AT DISTANCE "
-              << (a.Angle(b) * arangodb::geo::kEarthRadiusInMeters);
+    // std::cout << "EXPECTING EQUAL POINTS, GOT " << S2LatLng(a).ToStringInDegrees()
+    //           << " AND " << S2LatLng(b).ToStringInDegrees() << " AT DISTANCE "
+    //           << (a.Angle(b) * arangodb::geo::kEarthRadiusInMeters);
   }
   return equal;
 }


### PR DESCRIPTION
### Scope & Purpose

* fix UB in syslog logger, with ident string going out of scope after `openlog` was called.
* fix infinite recursion when printing error messages about invalid logger configuration.
* fix sporadic use-after-free issue in logger shutdown 

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/498

Likely supersedes PR https://github.com/arangodb/arangodb/pull/12109.
Likely fixes https://arangodb.atlassian.net/browse/AR-60.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

- [x] There is a *JIRA Ticket number*: https://arangodb.atlassian.net/browse/AR-60

### Testing & Verification

Unfortunately this needs manual testing.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10926/
ASan run: http://172.16.10.101:8080/job/arangodb-ANY-linux-asan/329/