### PR TITLE
Fix fuerte TLS connection breakages.

### DIFF
--- a/3rdParty/fuerte/include/fuerte/FuerteLogger.h
+++ b/3rdParty/fuerte/include/fuerte/FuerteLogger.h
@@ -20,6 +20,27 @@
 /// @author Frank Celler
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
+
+// Please leave the following debug code in for the next time we have to
+// debug fuerte.
+#if 0
+#include <sstream>
+#include <iostream>
+
+extern void LogHackWriter(char const* p);
+
+class LogHack {
+  std::stringstream _s;
+ public:
+  LogHack() {};
+  ~LogHack() { LogHackWriter(_s.str().c_str()); };
+  template<typename T> LogHack& operator<<(T const& o) { _s << o; return *this; }
+  typedef std::basic_ostream<char, std::char_traits<char> > CoutType;
+  typedef CoutType& (*StandardEndLine)(CoutType&);
+  LogHack& operator<<(StandardEndLine manip) { return *this; }
+};
+#endif
+
 #ifndef ARANGO_CXX_DRIVER_FUERTE_LOGGER
 #define ARANGO_CXX_DRIVER_FUERTE_LOGGER 1
 

--- a/3rdParty/fuerte/include/fuerte/connection.h
+++ b/3rdParty/fuerte/include/fuerte/connection.h
@@ -93,6 +93,9 @@ class Connection : public std::enable_shared_from_this<Connection> {
   /// @brief endpoint we are connected to
   std::string endpoint() const;
 
+  /// @brief lease a connection (prevent idle timeout)
+  virtual bool lease() = 0;
+
  protected:
   Connection(detail::ConnectionConfiguration const& conf) : _config(conf) {}
 

--- a/3rdParty/fuerte/src/GeneralConnection.cpp
+++ b/3rdParty/fuerte/src/GeneralConnection.cpp
@@ -49,6 +49,12 @@ void GeneralConnection<ST>::cancel() {
   });
 }
 
+// Lease this connection (cancel idle alarm)
+template <SocketType ST>
+bool GeneralConnection<ST>::lease() {
+  return true;   // this is a noop, derived classes can override
+}
+
 // Activate this connection.
 template <SocketType ST>
 void GeneralConnection<ST>::start() {

--- a/3rdParty/fuerte/src/GeneralConnection.h
+++ b/3rdParty/fuerte/src/GeneralConnection.h
@@ -53,6 +53,11 @@ class GeneralConnection : public fuerte::Connection {
   // Activate this connection
   void start() override;
 
+  // Switch off potential idle alarm (used by connection pool). Returns
+  // true if lease was successful and connection can be used afterwards.
+  // If false is retured the connection is broken beyond repair.
+  virtual bool lease() override;
+
   /// All protected or private methods below here must only be called on the
   /// IO thread.
  protected:
@@ -102,7 +107,7 @@ class GeneralConnection : public fuerte::Connection {
 
   /// @brief is the connection established
   std::atomic<Connection::State> _state;
-  
+
   std::atomic<uint32_t> _numQueued; /// queued items
 };
 

--- a/3rdParty/fuerte/src/H1Connection.cpp
+++ b/3rdParty/fuerte/src/H1Connection.cpp
@@ -431,7 +431,7 @@ void H1Connection<ST>::asyncWriteNextRequest() {
         int exp = 2;
         if (!_leased.compare_exchange_strong(exp, 0)) {
           FUERTE_ASSERT(exp != -1);
-        };
+        }
         setTimeout(this->_config._idleTimeout, TimeoutType::IDLE);
       } else {
         this->shutdownConnection(Error::CloseRequested);

--- a/3rdParty/fuerte/src/H1Connection.cpp
+++ b/3rdParty/fuerte/src/H1Connection.cpp
@@ -664,7 +664,7 @@ void H1Connection<ST>::setTimeout(std::chrono::milliseconds millis, TimeoutType 
               FUERTE_LOG_DEBUG << "HTTP-Request idle timeout"
                                << " this=" << me << "\n";
               me->shutdownConnection(Error::CloseRequested);
-              me->_leased = 0;
+              me->_leased.store(0, std::memory_order_seq_cst);
             }
           }
         }

--- a/3rdParty/fuerte/src/H1Connection.cpp
+++ b/3rdParty/fuerte/src/H1Connection.cpp
@@ -138,6 +138,7 @@ H1Connection<ST>::H1Connection(EventLoopService& loop,
       _reading(false),
       _writing(false),
       _writeStart(),
+      _leased(0),
       _lastHeaderWasValue(false),
       _shouldKeepAlive(false),
       _messageComplete(false),
@@ -662,7 +663,7 @@ void H1Connection<ST>::setTimeout(std::chrono::milliseconds millis, TimeoutType 
               // **before** we call `shutdownConnection` and actually kill the
               // connection. This is important, see below!
               FUERTE_LOG_DEBUG << "HTTP-Request idle timeout"
-                               << " this=" << me << "\n";
+                    << " this=" << me << "\n";
               me->shutdownConnection(Error::CloseRequested);
               me->_leased.store(0, std::memory_order_seq_cst);
             }

--- a/3rdParty/fuerte/src/H1Connection.h
+++ b/3rdParty/fuerte/src/H1Connection.h
@@ -151,10 +151,37 @@ class H1Connection final : public fuerte::GeneralConnection<ST> {
   // We use this to compute the timeout of the corresponding read if the
   // write was done.
 
-  std::atomic<int>
-      _leased;  // set to 1 by the `lease` method, prevents idle alarm if
-                // non-zero, set to 2 by `sendRequest` method, set back to 0
-                // when the idle alarm is set, provided it was 2
+  std::atomic<int> _leased;
+    // This member is used to allow to lease a connection from the connection
+    // pool without the idle alarm going off when we believe to have
+    // leased the connection successfully. Here is the workflow:
+    // Normally, the value is 0. If the idle alarm goes off, it first
+    // compare-exchanges this value from 0 to -1, then shuts down the
+    // connection (setting the _state to Failed in the TLS case). After
+    // that, the value is set back to 0.
+    // The lease operation tries to compare-exchange the value from 0 to 1,
+    // and if this has worked, it checks again that the _state is not Failed.
+    // This means, that if a lease has happened successfully, the idle alarm
+    // does no longer shut down the connection.
+    // If `sendRequest` is called on the connection (typically after a lease),
+    // a compare-exchange operation from 1 to 2 is tried. The value 2 indicates
+    // that the next time the idle alarm is set (after write/read activity
+    // finishes), a compare-exchange to 0 happens, such that the idle alarm
+    // can happen again.
+    // All this has the net effect that from the moment of a successful lease
+    // until the next call to `sendRequest`, we are sure that the idle alarm
+    // does not go off.
+    // Note that if one does not lease the connection, the idle alarm can
+    // go off at any time and the next `sendRequest` might fail because of
+    // this.
+    // Furthermore, note that if one leases the connection and does not call
+    // `sendRequest`, then the idle alarm does no longer go off and the
+    // connection stays open indefinitely. This is misusage.
+    // Finally, note that if the idle alarm goes off between a lease and
+    // the following call to `sendRequest`, the connection might stay open
+    // indefinitely, until activity on the connection has ceased again
+    // and a new idle alarm is set. However, this will automatically happen
+    // if that `sendRequest` and the corresponding request finishes.
 
   // parser state
   std::string _lastHeaderField;

--- a/3rdParty/fuerte/src/H1Connection.h
+++ b/3rdParty/fuerte/src/H1Connection.h
@@ -53,6 +53,11 @@ class H1Connection final : public fuerte::GeneralConnection<ST> {
   /// @brief Return the number of requests that have not yet finished.
   size_t requestsLeft() const override;
 
+  // Switch off potential idle alarm (used by connection pool). Returns
+  // true if lease was successful and connection can be used afterwards.
+  // If false is retured the connection is broken beyond repair.
+  bool lease() override;
+
   /// All methods below here must only be called from the IO thread.
  protected:
   /// This is posted by `sendRequest` to the _io_context thread, the `_active`
@@ -145,6 +150,11 @@ class H1Connection final : public fuerte::GeneralConnection<ST> {
   // This is the time when the latest write operation started.
   // We use this to compute the timeout of the corresponding read if the
   // write was done.
+
+  std::atomic<int>
+      _leased;  // set to 1 by the `lease` method, prevents idle alarm if
+                // non-zero, set to 2 by `sendRequest` method, set back to 0
+                // when the idle alarm is set, provided it was 2
 
   // parser state
   std::string _lastHeaderField;

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fixed a race in the ConnectionPool which could lease out a connection
+  that got its idle timeout after the lease was completed. This could lead
+  to sporadic network failures in TLS and to inefficiencies with TCP.
+
 * Keep the list of last-acknowledged entires in Agency more consistent.
   During leadership take-over it was possible to get into a situation that
   the new leader does not successfully report the agency config, which

--- a/arangod/Network/ConnectionPool.cpp
+++ b/arangod/Network/ConnectionPool.cpp
@@ -177,8 +177,7 @@ ConnectionPool::Context::Context(std::shared_ptr<fuerte::Connection> c,
     : fuerte(std::move(c)), lastLeased(t), leases(l) {}
 
 std::shared_ptr<fuerte::Connection> ConnectionPool::createConnection(fuerte::ConnectionBuilder& builder) {
-  //auto idle = std::chrono::milliseconds(_config.idleConnectionMilli);
-  auto idle = std::chrono::milliseconds(2);
+  auto idle = std::chrono::milliseconds(_config.idleConnectionMilli);
   builder.idleTimeout(idle);
   builder.verifyHost(_config.verifyHosts);
   builder.protocolType(_config.protocol); // always overwrite protocol

--- a/arangod/Network/ConnectionPool.cpp
+++ b/arangod/Network/ConnectionPool.cpp
@@ -177,7 +177,8 @@ ConnectionPool::Context::Context(std::shared_ptr<fuerte::Connection> c,
     : fuerte(std::move(c)), lastLeased(t), leases(l) {}
 
 std::shared_ptr<fuerte::Connection> ConnectionPool::createConnection(fuerte::ConnectionBuilder& builder) {
-  auto idle = std::chrono::milliseconds(_config.idleConnectionMilli);
+  //auto idle = std::chrono::milliseconds(_config.idleConnectionMilli);
+  auto idle = std::chrono::milliseconds(2);
   builder.idleTimeout(idle);
   builder.verifyHost(_config.verifyHosts);
   builder.protocolType(_config.protocol); // always overwrite protocol
@@ -206,7 +207,11 @@ ConnectionPtr ConnectionPool::selectConnection(std::string const& endpoint,
     if (state == fuerte::Connection::State::Failed) {
       continue;
     }
-    
+
+    if (!c->fuerte->lease()) {
+      continue;
+    }
+
     TRI_ASSERT(_config.protocol != fuerte::ProtocolType::Undefined);
 
     std::size_t limit = 0;

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -61,6 +61,13 @@
 using namespace arangodb::basics;
 using namespace arangodb::options;
 
+// Please leave this code in for the next time we have to debug fuerte.
+#if 0
+void LogHackWriter(char const* p) {
+  LOG_DEVEL << p;
+}
+#endif
+
 namespace arangodb {
 
 LoggerFeature::LoggerFeature(application_features::ApplicationServer& server, bool threaded)

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -29,7 +29,6 @@
 #endif
 
 #ifdef TRI_HAVE_UNISTD_H
-#include <fuerte/FuerteLogger.h>
 #include <unistd.h>
 #endif
 

--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -266,6 +266,7 @@ start() {
         --log.force-direct false \
         --log.thread true \
         --log.level $LOG_LEVEL_CLUSTER \
+        --log.time-format=timestamp-micros \
         --javascript.allow-admin-execute true \
         $SYSTEM_REPLICATION_FACTOR \
         $STORAGE_ENGINE \

--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -266,7 +266,6 @@ start() {
         --log.force-direct false \
         --log.thread true \
         --log.level $LOG_LEVEL_CLUSTER \
-        --log.time-format=timestamp-micros \
         --javascript.allow-admin-execute true \
         $SYSTEM_REPLICATION_FACTOR \
         $STORAGE_ENGINE \

--- a/tests/AsyncAgencyComm/AsyncAgencyCommTest.cpp
+++ b/tests/AsyncAgencyComm/AsyncAgencyCommTest.cpp
@@ -124,6 +124,9 @@ struct AsyncAgencyCommPoolMock final : public network::ConnectionPool {
 
     void cancel() override {}
     void start() override {}
+    bool lease() override {
+      return true;
+    }
 
     AsyncAgencyCommPoolMock* _mock;
     std::string _endpoint;

--- a/tests/IResearch/AgencyMock.cpp
+++ b/tests/IResearch/AgencyMock.cpp
@@ -109,6 +109,9 @@ struct AsyncAgencyStorePoolConnection final : public fuerte::Connection {
 
   void cancel() override {}
   void start() override {}
+  bool lease() override {
+    return true;
+  }
 
   AsyncAgencyStorePoolMock* _mock;
   std::string _endpoint;

--- a/tests/Network/MethodsTest.cpp
+++ b/tests/Network/MethodsTest.cpp
@@ -63,7 +63,10 @@ struct DummyConnection final : public fuerte::Connection {
   
   void cancel() override {}
   void start() override {}
-  
+  bool lease() override {
+    return true;
+  }
+
   fuerte::Connection::State _state = fuerte::Connection::State::Connected;
   
   fuerte::Error _err = fuerte::Error::NoError;


### PR DESCRIPTION
This ensures that a connection which has already been leased out of the
connection pool can no longer run into its idle timeout.

This has to be ported to 3.7 but not to older versions.