### PR TITLE
fix request forwarding with VST requests without Content-Type header set

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,18 +1,21 @@
 devel
 -----
 
+* Fix cluster-internal request forwarding for VST requests that do not have
+  any Content-Type header set. Such requests could have been caused by the Java
+  driver. 
+
 * Fixed issue OASIS-252: Hotbackup agency locks without clientId.
 
 * The `_from` and `_to` attributes of an edge document can now be edited from
   within the UI.
 
 * Added vertex collection validation in case of a SmartGraph edge definition update. 
+* Updated arangosync to 0.7.7.
 
 * Added support `db._engineStats()` API in coordinator. Previously calling this
   API always produced an empty result. Now it will return the engine statistics
   as an object, with an entry for each individual DB-Server.
-
-* Updated arangosync to 0.7.7.
 
 * Fixed a document parsing bug in the Web UI. This issue occured in the
   document list view in case a document had an attribute called `length`.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,9 @@
 devel
 -----
 
-* Fix cluster-internal request forwarding for VST requests that do not have
-  any Content-Type header set. Such requests could have been caused by the Java
-  driver. 
+* Fix cluster-internal request forwarding for VST requests that do not have any
+  Content-Type header set. Such requests could have been caused by the Java
+  driver (ES-635).
 
 * Fixed issue OASIS-252: Hotbackup agency locks without clientId.
 

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -168,8 +168,17 @@ futures::Future<Result> RestHandler::forwardRequest(bool& forwarded) {
   network::RequestOptions options;
   options.database = dbname;
   options.timeout = network::Timeout(900);
-  // if the type is unset JSON is used
-  options.contentType = rest::contentTypeToString(_request->contentType());
+  
+  if (useVst && _request->contentType() == rest::ContentType::UNSET) {
+    // request is using VST, but doesn't have a Content-Type header set.
+    // it is likely VelocyPack content, so let's assume that here.
+    // should fix issue BTS-133.
+    options.contentType = rest::contentTypeToString(rest::ContentType::VPACK);
+  } else {
+    // if the type is unset JSON is used
+    options.contentType = rest::contentTypeToString(_request->contentType());
+  }
+
   options.acceptType = rest::contentTypeToString(_request->contentTypeResponse());
     
   for (auto const& i : _request->values()) {
@@ -182,7 +191,7 @@ futures::Future<Result> RestHandler::forwardRequest(bool& forwarded) {
   VPackStringRef resPayload = _request->rawPayload();
   VPackBuffer<uint8_t> payload(resPayload.size());
   payload.append(resPayload.data(), resPayload.size());
-
+ 
   auto future = network::sendRequest(pool, "server:" + serverId, requestType,
                                      _request->requestPath(),
                                      std::move(payload), options, std::move(headers));

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -333,7 +333,7 @@ Result Manager::createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,
         // not found
         res.reset(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
                   std::string(TRI_errno_string(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND)) +
-                      ":" + cname);
+                      ": " + cname);
       } else {
 #ifdef USE_ENTERPRISE
         if (state->isCoordinator()) {


### PR DESCRIPTION
### Scope & Purpose

Properly set `Content-Type` to `application/x-velocypack` in case a VST request without Content-Type is being forwarded inside a load-balanced cluster from one coordinator to another.
Previously, if the incoming VST request did not have a proper content type set, `application/json` was assumed, which caused issues when parsing the forwarded request on the relayed-to coordinator.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is a *JIRA Ticket number*: https://arangodb.atlassian.net/browse/BTS-133, https://arangodb.atlassian.net/browse/ES-635 

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

Additionally:

- [x] There are tests in an external testing repository: for Java driver, as described in https://arangodb.atlassian.net/browse/BTS-133

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10963/