### PR TITLE
fix potential undefined behavior in syslog logging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.6.5 (XXXX-XX-XX)
 -------------------
 
+* Fixed potentially undefined behavior in syslog logger, with ident string going 
+  out of scope after `openlog` was called.
+
 * Fixed that the hotbackup agency lock is released under all circumstances using
   scope guards. This addresses a rare case in which the lock was left behind.
 

--- a/lib/Logger/LogAppenderSyslog.cpp
+++ b/lib/Logger/LogAppenderSyslog.cpp
@@ -52,9 +52,8 @@ void LogAppenderSyslog::close() {
 
 LogAppenderSyslog::LogAppenderSyslog(std::string const& facility,
                                      std::string const& name, std::string const& filter)
-    : LogAppender(filter) {
-  // no logging
-  std::string sysname = name.empty() ? "[arangod]" : name;
+    : LogAppender(filter),
+      _sysname(name.empty() ? "[arangod]" : name) {
 
   // find facility
   int value = LOG_LOCAL0;
@@ -74,8 +73,13 @@ LogAppenderSyslog::LogAppenderSyslog(std::string const& facility,
     }
   }
 
+  // from man 3 syslog:
+  //   The argument ident in the call of openlog() is probably stored as-is.
+  //   Thus, if the string it points to is changed, syslog() may start prepending the changed string, and  if
+  //   the string it points to ceases to exist, the results are undefined.  Most portable is to use a string constant.
+  
   // and open logging, openlog does not have a return value...
-  ::openlog(sysname.c_str(), LOG_CONS | LOG_PID, value);
+  ::openlog(_sysname.c_str(), LOG_CONS | LOG_PID, value);
   _opened = true;
 }
 

--- a/lib/Logger/LogAppenderSyslog.h
+++ b/lib/Logger/LogAppenderSyslog.h
@@ -42,6 +42,8 @@ class LogAppenderSyslog final : public LogAppender {
   std::string details() override final;
 
  private:
+  std::string const _sysname;
+
   static bool _opened;
 };
 


### PR DESCRIPTION
### Scope & Purpose

Fixed potential undefined behavior in syslog logging with ident string going out of scope after calling `openlog()`.
In 3.7 this is covered by PR https://github.com/arangodb/arangodb/pull/12141 and in devel by PR https://github.com/arangodb/arangodb/pull/12140.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10969/