### PR TITLE
disable internal protocol switch, and hard-code it to HTTP

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
+* Disable internal network protocol switch for cluster-internal communication,
+  and hard-code the internal communication protocol to HTTP.
+
 * Added vertex collection validation in case of a SmartGraph edge definition
   update.
 


### PR DESCRIPTION
### Scope & Purpose

Disable internal protocol switch for cluster-internal communication, and hard-code its value to "http".

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10977/