### PR TITLE
Added missing state rollback for failed attempt-based write locking of spin locks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.6.5 (XXXX-XX-XX)
 -------------------
 
+* Added missing state rollback for failed attempt-based write locking of
+  spin locks.
+
 * Fixed a sleeping barber in Fuerte HTTPConnection. It was possible that
   sendRequest calls were started but never completed due to the fact that
   the idle connection close triggered at exactly the same time.

--- a/lib/Basics/ReadWriteSpinLock.h
+++ b/lib/Basics/ReadWriteSpinLock.h
@@ -83,12 +83,17 @@ class ReadWriteSpinLock {
           return true;
         }
         if (++attempts > maxAttempts) {
+          // Undo the counting of us as queued writer:
+          _state.fetch_sub(QUEUED_WRITER_INC, std::memory_order_release);
           return false;
         }
       }
       cpu_relax();
       state = _state.load(std::memory_order_relaxed);
     }
+        
+    // Undo the counting of us as queued writer:
+    _state.fetch_sub(QUEUED_WRITER_INC, std::memory_order_release);
     return false;
   }
 


### PR DESCRIPTION
### Scope & Purpose

Add missing rollback of state changes when an attempt-based write operation on a spin lock fails.

- [x] Bug-Fix for a *released version*
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *all*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10995/