### PR TITLE
Added missing state rollback for failed attempt-based write locking of spin locks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.5.6 (XXXX-XX-XX)
 -------------------
 
-* Added missing state rollback for failed attempt-based write locking of
-  spin locks.
+* Added missing state rollback for failed attempt-based write locking of spin
+  locks.
 
 * Added vertex validation in case of a SmartGraph edge definition update.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.5.6 (XXXX-XX-XX)
 -------------------
 
+* Added missing state rollback for failed attempt-based write locking of
+  spin locks.
+
 * Added vertex validation in case of a SmartGraph edge definition update.
 
 * Internal issue BTS-71: Added a precondition to prevent creating a collection

--- a/lib/Basics/ReadWriteSpinLock.h
+++ b/lib/Basics/ReadWriteSpinLock.h
@@ -84,12 +84,17 @@ class ReadWriteSpinLock {
           return true;
         }
         if (++attempts > maxAttempts) {
+          // Undo the counting of us as queued writer:
+          _state.fetch_sub(QUEUED_WRITER_INC, std::memory_order_release);
           return false;
         }
       }
       cpu_relax();
       state = _state.load(std::memory_order_relaxed);
     }
+        
+    // Undo the counting of us as queued writer:
+    _state.fetch_sub(QUEUED_WRITER_INC, std::memory_order_release);
     return false;
   }
 


### PR DESCRIPTION
### Scope & Purpose

Add missing rollback of state changes when an attempt-based write operation on a spin lock fails.

- [x] Bug-Fix for a *released version*
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *all*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/10996/