### PR TITLE
Harmonize /_admin/server/* api permission.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Harmonize /_admin/server/* API permissions:
+    GET always allowed
+    POST allowed when superuser and authentication on
+    POST allowed when authentication off
+
 * Keep the list of last-acknowledged entires in Agency more consistent.
   During leadership take-over it was possible to get into a situation that
   the new leader does not successfully report the agency config, which

--- a/arangod/RestHandler/RestAdminServerHandler.cpp
+++ b/arangod/RestHandler/RestAdminServerHandler.cpp
@@ -238,7 +238,9 @@ void RestAdminServerHandler::handleTLS() {
   } else if (requestType == rest::RequestType::POST) {
 
     // Only the superuser may reload TLS data:
-    if (!_request->authenticated() || !_request->user().empty()) {
+    AuthenticationFeature* af = AuthenticationFeature::instance();
+    if (af->isActive() &&
+        (!_request->authenticated() || !_request->user().empty())) {
       generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_FORBIDDEN,
                     "only superusers may reload TLS data");
       return;


### PR DESCRIPTION
GET always allowed
POST allowed when superuser and authentication on
POST allowed when authentication off

In the normal, authenticated case, this only changes that

  GET /_admin/server/jwt
  GET /_admin/server/encryption

are now allowed, similar to /_admin/server/tls and others.
Other than that, a few more APIs are allowed when authentication is off.