### PR TITLE
Port connection pool fix from devel back to 3.7.

### DIFF
--- a/3rdParty/fuerte/include/fuerte/FuerteLogger.h
+++ b/3rdParty/fuerte/include/fuerte/FuerteLogger.h
@@ -20,6 +20,27 @@
 /// @author Frank Celler
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
+
+// Please leave the following debug code in for the next time we have to
+// debug fuerte.
+#if 0
+#include <sstream>
+#include <iostream>
+
+extern void LogHackWriter(char const* p);
+
+class LogHack {
+  std::stringstream _s;
+ public:
+  LogHack() {};
+  ~LogHack() { LogHackWriter(_s.str().c_str()); };
+  template<typename T> LogHack& operator<<(T const& o) { _s << o; return *this; }
+  typedef std::basic_ostream<char, std::char_traits<char> > CoutType;
+  typedef CoutType& (*StandardEndLine)(CoutType&);
+  LogHack& operator<<(StandardEndLine manip) { return *this; }
+};
+#endif
+
 #ifndef ARANGO_CXX_DRIVER_FUERTE_LOGGER
 #define ARANGO_CXX_DRIVER_FUERTE_LOGGER 1
 

--- a/3rdParty/fuerte/include/fuerte/connection.h
+++ b/3rdParty/fuerte/include/fuerte/connection.h
@@ -93,6 +93,9 @@ class Connection : public std::enable_shared_from_this<Connection> {
   /// @brief endpoint we are connected to
   std::string endpoint() const;
 
+  /// @brief lease a connection (prevent idle timeout)
+  virtual bool lease() = 0;
+
  protected:
   Connection(detail::ConnectionConfiguration const& conf) : _config(conf) {}
 

--- a/3rdParty/fuerte/src/GeneralConnection.cpp
+++ b/3rdParty/fuerte/src/GeneralConnection.cpp
@@ -49,6 +49,12 @@ void GeneralConnection<ST>::cancel() {
   });
 }
 
+// Lease this connection (cancel idle alarm)
+template <SocketType ST>
+bool GeneralConnection<ST>::lease() {
+  return true;   // this is a noop, derived classes can override
+}
+
 // Activate this connection.
 template <SocketType ST>
 void GeneralConnection<ST>::start() {

--- a/3rdParty/fuerte/src/GeneralConnection.h
+++ b/3rdParty/fuerte/src/GeneralConnection.h
@@ -53,6 +53,11 @@ class GeneralConnection : public fuerte::Connection {
   // Activate this connection
   void start() override;
 
+  // Switch off potential idle alarm (used by connection pool). Returns
+  // true if lease was successful and connection can be used afterwards.
+  // If false is retured the connection is broken beyond repair.
+  virtual bool lease() override;
+
   /// All protected or private methods below here must only be called on the
   /// IO thread.
  protected:
@@ -102,7 +107,7 @@ class GeneralConnection : public fuerte::Connection {
 
   /// @brief is the connection established
   std::atomic<Connection::State> _state;
-  
+
   std::atomic<uint32_t> _numQueued; /// queued items
 };
 

--- a/3rdParty/fuerte/src/H1Connection.cpp
+++ b/3rdParty/fuerte/src/H1Connection.cpp
@@ -431,7 +431,7 @@ void H1Connection<ST>::asyncWriteNextRequest() {
         int exp = 2;
         if (!_leased.compare_exchange_strong(exp, 0)) {
           FUERTE_ASSERT(exp != -1);
-        };
+        }
         setTimeout(this->_config._idleTimeout, TimeoutType::IDLE);
       } else {
         this->shutdownConnection(Error::CloseRequested);

--- a/3rdParty/fuerte/src/H1Connection.cpp
+++ b/3rdParty/fuerte/src/H1Connection.cpp
@@ -138,6 +138,7 @@ H1Connection<ST>::H1Connection(EventLoopService& loop,
       _reading(false),
       _writing(false),
       _writeStart(),
+      _leased(0),
       _lastHeaderWasValue(false),
       _shouldKeepAlive(false),
       _messageComplete(false),
@@ -210,6 +211,18 @@ void H1Connection<ST>::sendRequest(std::unique_ptr<Request> req,
   item.release();  // queue owns this now
 
   FUERTE_LOG_HTTPTRACE << "queued item: this=" << this << "\n";
+
+  // If the connection was leased explicitly, we set the _leased indicator
+  // to 2 here, such that it can be reset to 0 once the idle alarm is
+  // enabled explicitly later. We do not have to check if this has worked
+  // for the following reason: The value is only ever set to -1, 0, 1 or 2.
+  // If it is already 2, no action is needed. If it is still 0, then the
+  // connection was not leased and we do not have to mark it here to indicate
+  // that a `sendRequest` has happened. If it is currently -1, then the
+  // connection will be shut down anyway. In the TLS case, this will set
+  // the _state to Failed and the current operation will fail anyway.
+  int exp = 1;
+  _leased.compare_exchange_strong(exp, 2);
 
   // Note that we have first posted on the queue with std::memory_order_seq_cst
   // and now we check _active std::memory_order_seq_cst. This prevents a sleeping
@@ -405,6 +418,20 @@ void H1Connection<ST>::asyncWriteNextRequest() {
       if (_shouldKeepAlive && this->_config._idleTimeout.count() > 0) {
         FUERTE_LOG_HTTPTRACE << "setting idle keep alive timer, this=" << this
                              << "\n";
+        // We want to enable the idle timeout alarm here. However, if the
+        // connection object has been leased, but no `sendRequest` has been
+        // called on it yet, then the alarm must not go off. Therefore,
+        // if _leased is 2 (`sendRequest` has been called), we reset it to
+        // 0, if _leased is still 1 (`lease` has happened, but `sendRequest`
+        // has not yet been called), then we leave it untouched. Since
+        // this method here is only ever executed on the iothread and
+        // the value -1 only happens for a brief period in the iothread,
+        // it will never be observed here. Therefore, no actual need to check
+        // the result of the compare_exchange_strong.
+        int exp = 2;
+        if (!_leased.compare_exchange_strong(exp, 0)) {
+          FUERTE_ASSERT(exp != -1);
+        };
         setTimeout(this->_config._idleTimeout, TimeoutType::IDLE);
       } else {
         this->shutdownConnection(Error::CloseRequested);
@@ -604,9 +631,12 @@ void H1Connection<ST>::asyncReadCallback(asio_ns::error_code const& ec) {
 template <SocketType ST>
 void H1Connection<ST>::setTimeout(std::chrono::milliseconds millis, TimeoutType type) {
   if (millis.count() == 0) {
+    FUERTE_LOG_TRACE << "deleting timeout of type " << (int) type << " this=" << this << "\n";
     this->_proto.timer.cancel();
     return;
   }
+
+  FUERTE_LOG_TRACE << "setting timeout of type " << (int) type << " this=" << this << "\n";
 
   // expires_after cancels pending ops
   this->_proto.timer.expires_after(millis);
@@ -619,15 +649,24 @@ void H1Connection<ST>::setTimeout(std::chrono::milliseconds millis, TimeoutType 
         auto* me = static_cast<H1Connection<ST>*>(s.get());
         if ((type == TimeoutType::WRITE && me->_writing) ||
             (type == TimeoutType::READ && me->_reading)) {
-          FUERTE_LOG_DEBUG << "HTTP-Request timeout\n";
+          FUERTE_LOG_DEBUG << "HTTP-Request timeout" << " this=" << me << "\n";
           me->_proto.cancel();
           me->_timeoutOnReadWrite = true;
           // We simply cancel all ongoing asynchronous operations, the completion
           // handlers will do the rest.
           return;
-        } else if (type == TimeoutType::IDLE) {
+        } else if (type == TimeoutType::IDLE && !me->_writing & !me->_reading && me->_leased == 0) {
           if (!me->_active && me->_state == Connection::State::Connected) {
-            me->shutdownConnection(Error::CloseRequested);
+            int exp = 0;
+            if (me->_leased.compare_exchange_strong(exp, -1)) {
+              // Note that we check _leased here with std::memory_order_seq_cst
+              // **before** we call `shutdownConnection` and actually kill the
+              // connection. This is important, see below!
+              FUERTE_LOG_DEBUG << "HTTP-Request idle timeout"
+                    << " this=" << me << "\n";
+              me->shutdownConnection(Error::CloseRequested);
+              me->_leased.store(0, std::memory_order_seq_cst);
+            }
           }
         }
         // In all other cases we do nothing, since we have been posted to the
@@ -658,6 +697,30 @@ void H1Connection<ST>::drainQueue(const fuerte::Error ec) {
     FUERTE_ASSERT(q > 0);
     guard->invokeOnError(ec);
   }
+}
+
+// Lease this connection (cancel idle alarm)
+template <SocketType ST>
+bool H1Connection<ST>::lease() {
+  int exp = 0;
+  // We have to guard against data races here. Some other thread might call
+  // cancel() on the connection, but then it is OK that the next request
+  // runs into an error. Somebody was asking for trouble and gets it.
+  // The iothread itself can only set the state to Failed if a real
+  // error occurs (in which case it is again OK to run into an error with
+  // the next request), or if the idle timeout alarm goes off. This code
+  // guards against the idle alarm going off despite the fact that the
+  // connection was already leased, since we first compare exchange from
+  // 0 to 1 and then check again that the connection is not Failed. Both
+  // accesses happen with std::memory_order_seq_cst and the check for
+  // _leased in the idle alarm handler happens before shutdownConnection
+  // is called.
+  if (!this->_leased.compare_exchange_strong(exp, 1) ||
+      this->_state == Connection::State::Failed) {
+    return false;
+  }
+  FUERTE_LOG_TRACE << "Connection leased: this=" << this;
+  return true;   // this is a noop, derived classes can override
 }
 
 template class arangodb::fuerte::v1::http::H1Connection<SocketType::Tcp>;

--- a/3rdParty/fuerte/src/H1Connection.h
+++ b/3rdParty/fuerte/src/H1Connection.h
@@ -53,6 +53,11 @@ class H1Connection final : public fuerte::GeneralConnection<ST> {
   /// @brief Return the number of requests that have not yet finished.
   size_t requestsLeft() const override;
 
+  // Switch off potential idle alarm (used by connection pool). Returns
+  // true if lease was successful and connection can be used afterwards.
+  // If false is retured the connection is broken beyond repair.
+  bool lease() override;
+
   /// All methods below here must only be called from the IO thread.
  protected:
   /// This is posted by `sendRequest` to the _io_context thread, the `_active`
@@ -145,6 +150,38 @@ class H1Connection final : public fuerte::GeneralConnection<ST> {
   // This is the time when the latest write operation started.
   // We use this to compute the timeout of the corresponding read if the
   // write was done.
+
+  std::atomic<int> _leased;
+    // This member is used to allow to lease a connection from the connection
+    // pool without the idle alarm going off when we believe to have
+    // leased the connection successfully. Here is the workflow:
+    // Normally, the value is 0. If the idle alarm goes off, it first
+    // compare-exchanges this value from 0 to -1, then shuts down the
+    // connection (setting the _state to Failed in the TLS case). After
+    // that, the value is set back to 0.
+    // The lease operation tries to compare-exchange the value from 0 to 1,
+    // and if this has worked, it checks again that the _state is not Failed.
+    // This means, that if a lease has happened successfully, the idle alarm
+    // does no longer shut down the connection.
+    // If `sendRequest` is called on the connection (typically after a lease),
+    // a compare-exchange operation from 1 to 2 is tried. The value 2 indicates
+    // that the next time the idle alarm is set (after write/read activity
+    // finishes), a compare-exchange to 0 happens, such that the idle alarm
+    // can happen again.
+    // All this has the net effect that from the moment of a successful lease
+    // until the next call to `sendRequest`, we are sure that the idle alarm
+    // does not go off.
+    // Note that if one does not lease the connection, the idle alarm can
+    // go off at any time and the next `sendRequest` might fail because of
+    // this.
+    // Furthermore, note that if one leases the connection and does not call
+    // `sendRequest`, then the idle alarm does no longer go off and the
+    // connection stays open indefinitely. This is misusage.
+    // Finally, note that if the idle alarm goes off between a lease and
+    // the following call to `sendRequest`, the connection might stay open
+    // indefinitely, until activity on the connection has ceased again
+    // and a new idle alarm is set. However, this will automatically happen
+    // if that `sendRequest` and the corresponding request finishes.
 
   // parser state
   std::string _lastHeaderField;

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
+* Fixed a race in the ConnectionPool which could lease out a connection
+  that got its idle timeout after the lease was completed. This could lead
+  to sporadic network failures in TLS and to inefficiencies with TCP.
+
 * Added missing state rollback for failed attempt-based write locking of spin
   locks.
 

--- a/arangod/Network/ConnectionPool.cpp
+++ b/arangod/Network/ConnectionPool.cpp
@@ -206,7 +206,11 @@ ConnectionPtr ConnectionPool::selectConnection(std::string const& endpoint,
     if (state == fuerte::Connection::State::Failed) {
       continue;
     }
-    
+
+    if (!c->fuerte->lease()) {
+      continue;
+    }
+
     TRI_ASSERT(_config.protocol != fuerte::ProtocolType::Undefined);
 
     std::size_t limit = 0;

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -29,7 +29,6 @@
 #endif
 
 #ifdef TRI_HAVE_UNISTD_H
-#include <fuerte/FuerteLogger.h>
 #include <unistd.h>
 #endif
 
@@ -60,6 +59,13 @@
 
 using namespace arangodb::basics;
 using namespace arangodb::options;
+
+// Please leave this code in for the next time we have to debug fuerte.
+#if 0
+void LogHackWriter(char const* p) {
+  LOG_DEVEL << p;
+}
+#endif
 
 namespace arangodb {
 

--- a/tests/AsyncAgencyComm/AsyncAgencyCommTest.cpp
+++ b/tests/AsyncAgencyComm/AsyncAgencyCommTest.cpp
@@ -124,6 +124,9 @@ struct AsyncAgencyCommPoolMock final : public network::ConnectionPool {
 
     void cancel() override {}
     void start() override {}
+    bool lease() override {
+      return true;
+    }
 
     AsyncAgencyCommPoolMock* _mock;
     std::string _endpoint;

--- a/tests/IResearch/AgencyMock.cpp
+++ b/tests/IResearch/AgencyMock.cpp
@@ -108,6 +108,9 @@ struct AsyncAgencyStorePoolConnection final : public fuerte::Connection {
 
   void cancel() override {}
   void start() override {}
+  bool lease() override {
+    return true;
+  }
 
   AsyncAgencyStorePoolMock* _mock;
   std::string _endpoint;

--- a/tests/Network/MethodsTest.cpp
+++ b/tests/Network/MethodsTest.cpp
@@ -63,7 +63,10 @@ struct DummyConnection final : public fuerte::Connection {
   
   void cancel() override {}
   void start() override {}
-  
+  bool lease() override {
+    return true;
+  }
+
   fuerte::Connection::State _state = fuerte::Connection::State::Connected;
   
   fuerte::Error _err = fuerte::Error::NoError;


### PR DESCRIPTION
This fixes a race in the connection pool which could lead to a connection
being leased and then getting an idle timeout. This leads to sporadic network
request failures under TLS and inefficiencies under TCP.