### PR TITLE
Bug fix 3.6/make test insert idempotent

### DIFF
--- a/tests/js/client/communication/test-communication.js
+++ b/tests/js/client/communication/test-communication.js
@@ -119,7 +119,7 @@ function CommunicationSuite () {
 
       // broad cast stop signal
       assertFalse(db[cn].exists("stop"));
-      db[cn].insert({ _key: "stop" });
+      db[cn].insert({ _key: "stop" }, { overwriteMode: "ignore" });
       let tries = 0;
       let done = 0;
       while (++tries < 60) {

--- a/tests/js/client/communication/test-communication.js
+++ b/tests/js/client/communication/test-communication.js
@@ -119,7 +119,7 @@ function CommunicationSuite () {
 
       // broad cast stop signal
       assertFalse(db[cn].exists("stop"));
-      db[cn].insert({ _key: "stop" }, { overwriteMode: "ignore" });
+      db[cn].insert({ _key: "stop" }, { overwrite: true });
       let tries = 0;
       let done = 0;
       while (++tries < 60) {


### PR DESCRIPTION
### Scope & Purpose

Make an insert operation in a test case succeed even if it is automatically retried.
This should fix spurious "unique constraint violation" errors in the `communication` testsuite.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *communication*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11014/