### PR TITLE
fix over-eager shutdown messaging

### DIFF
--- a/arangod/Aql/AllRowsFetcher.h
+++ b/arangod/Aql/AllRowsFetcher.h
@@ -116,8 +116,6 @@ class AllRowsFetcher {
   ExecutionState _upstreamState;
   std::size_t _blockToReturnNext;
 
-  std::vector<AqlItemMatrix::RowIndex> _rowIndexes;
-
  private:
   /**
    * @brief Delegates to ExecutionBlock::getNrInputRegisters()

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -705,13 +705,13 @@ void ClusterFeature::shutdownHeartbeatThread() {
   _heartbeatThread->beginShutdown();
   auto start = std::chrono::steady_clock::now();
   size_t counter = 0;
-  while(_heartbeatThread->isRunning()) {
+  while (_heartbeatThread->isRunning()) {
     if (std::chrono::steady_clock::now() - start > std::chrono::seconds(65)) {
       LOG_TOPIC("b5a8d", FATAL, Logger::CLUSTER)
         << "exiting prematurely as we failed terminating the heartbeat thread";
       FATAL_ERROR_EXIT();
     }
-    if(++counter % 50 == 0) {
+    if (++counter % 50 == 0) {
       LOG_TOPIC("acaa9", WARN, arangodb::Logger::CLUSTER)
         << "waiting for heartbeat thread to finish";
     }
@@ -727,13 +727,13 @@ void ClusterFeature::shutdownAgencyCache() {
   _agencyCache->beginShutdown();
   auto start = std::chrono::steady_clock::now();
   size_t counter = 0;
-  while(_agencyCache != nullptr && _agencyCache->isRunning()) {
+  while (_agencyCache != nullptr && _agencyCache->isRunning()) {
     if (std::chrono::steady_clock::now() - start > std::chrono::seconds(65)) {
       LOG_TOPIC("d8a5b", FATAL, Logger::CLUSTER)
         << "exiting prematurely as we failed terminating the agency cache";
       FATAL_ERROR_EXIT();
     }
-    if(counter % 50 == 0) {
+    if (++counter % 50 == 0) {
       LOG_TOPIC("acab0", WARN, arangodb::Logger::CLUSTER)
         << "waiting for agency cache thread to finish";
     }


### PR DESCRIPTION
### Scope & Purpose

Fix over-eager reporting of agency cache shutdown (currently logs every 100ms, which is too frequent).
No need to backport this to 3.6, as the agency cache does not exist there. The fix is included in some other PR for devel.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11019/