### PR TITLE
another attempt to please ASan

### DIFF
--- a/lib/Logger/LogAppender.cpp
+++ b/lib/Logger/LogAppender.cpp
@@ -86,22 +86,21 @@ void LogAppender::addAppender(std::string const& definition) {
     // found an existing appender
     appender = it->second;
   } else {
-    // build a new appender from the definition. note: this may modify _definition2appenders
+    // build a new appender from the definition
     appender = buildAppender(output);
-  }
-
-  if (appender != nullptr) {
-    try {
-      _definition2appenders[key] = appender;
-    } catch (...) {
-      // cannot open file for logging?
+    if (appender == nullptr) {
+      // cannot create appender, for whatever reason
       return;
     }
+  
+    _definition2appenders[key] = appender;
+  }
 
-    size_t n = (topic == nullptr) ? LogTopic::MAX_LOG_TOPICS : topic->id();
-    if (std::find(_topics2appenders[n].begin(), _topics2appenders[n].end(), appender) == _topics2appenders[n].end()) {
-      _topics2appenders[n].emplace_back(appender);
-    }
+  TRI_ASSERT(appender != nullptr);
+
+  size_t n = (topic == nullptr) ? LogTopic::MAX_LOG_TOPICS : topic->id();
+  if (std::find(_topics2appenders[n].begin(), _topics2appenders[n].end(), appender) == _topics2appenders[n].end()) {
+    _topics2appenders[n].emplace_back(appender);
   }
 }
 

--- a/lib/Logger/LogAppenderFile.cpp
+++ b/lib/Logger/LogAppenderFile.cpp
@@ -176,19 +176,7 @@ LogAppenderFile::LogAppenderFile(std::string const& filename)
   _useColors = ((isatty(_fd) == 1) && Logger::getUseColor());
 }
 
-LogAppenderFile::~LogAppenderFile() {
-  if (_filename != "+" && _filename != "-") {
-    // remove ourselves from the list of open appenders
-    std::unique_lock<std::mutex> guard(_openAppendersMutex);
-    for (auto it = _openAppenders.begin(); it != _openAppenders.end(); /* no hoisting */) {
-      if ((*it) == this) {
-        it = _openAppenders.erase(it);
-      } else {
-        ++it;
-      }
-    }
-  }
-}
+LogAppenderFile::~LogAppenderFile() = default;
 
 void LogAppenderFile::writeLogMessage(LogLevel level, size_t /*topicId*/, char const* buffer, size_t len) {
   bool giveUp = false;


### PR DESCRIPTION
### Scope & Purpose

Trying to fix use-after-free as found here:
http://172.16.10.101:8080/job/arangodb-ANY-mac-matrix/1063/EDITION=enterprise,STORAGE_ENGINE=rocksdb,TEST_SUITE=cluster,limit=mac/artifact/testfailures.txt

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/505

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

Should be covered by ASan runs and matrix tests.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11021/
http://172.16.10.101:8080/job/arangodb-ANY-linux-asan/333/