### PR TITLE
hide a method by default that is only used from within tests

### DIFF
--- a/arangod/Auth/UserManager.cpp
+++ b/arangod/Auth/UserManager.cpp
@@ -414,7 +414,8 @@ void auth::UserManager::triggerGlobalReload() {
   while (maxTries-- > 0) {
     AgencyCommResult result = agency.sendTransactionWithFailover(incrementVersion);
     if (result.successful()) {
-      _globalVersion.fetch_add(1, std::memory_order_release);
+      uint64_t aha = _globalVersion.fetch_add(1, std::memory_order_release);
+      LOG_DEVEL << "INCREMENTED GLOBAL VERSION TO " << (aha + 1);
       _internalVersion.fetch_add(1, std::memory_order_release);
       return;
     }
@@ -797,6 +798,7 @@ auth::Level auth::UserManager::collectionAuthLevel(std::string const& user,
   return level;
 }
 
+#ifdef ARANGODB_USE_GOOGLE_TESTS
 /// Only used for testing
 void auth::UserManager::setAuthInfo(auth::UserMap const& newMap) {
   MUTEX_LOCKER(guard, _loadFromDBLock);      // must be first
@@ -804,3 +806,4 @@ void auth::UserManager::setAuthInfo(auth::UserMap const& newMap) {
   _userCache = newMap;
   _internalVersion.store(_globalVersion.load());
 }
+#endif

--- a/arangod/Auth/UserManager.cpp
+++ b/arangod/Auth/UserManager.cpp
@@ -414,8 +414,7 @@ void auth::UserManager::triggerGlobalReload() {
   while (maxTries-- > 0) {
     AgencyCommResult result = agency.sendTransactionWithFailover(incrementVersion);
     if (result.successful()) {
-      uint64_t aha = _globalVersion.fetch_add(1, std::memory_order_release);
-      LOG_DEVEL << "INCREMENTED GLOBAL VERSION TO " << (aha + 1);
+      _globalVersion.fetch_add(1, std::memory_order_release);
       _internalVersion.fetch_add(1, std::memory_order_release);
       return;
     }

--- a/arangod/Auth/UserManager.h
+++ b/arangod/Auth/UserManager.h
@@ -84,7 +84,7 @@ class UserManager {
   }
 
   /// @brief used for caching
-  uint64_t globalVersion() {
+  uint64_t globalVersion() const {
     return _globalVersion.load(std::memory_order_acquire);
   }
 
@@ -134,10 +134,12 @@ class UserManager {
                                 std::string const& dbname, bool configured = false);
   auth::Level collectionAuthLevel(std::string const& username, std::string const& dbname,
                                   std::string const& coll, bool configured = false);
-
+  
+#ifdef ARANGODB_USE_GOOGLE_TESTS
   /// Overwrite internally cached permissions, only use
   /// for testing purposes
   void setAuthInfo(auth::UserMap const& userEntryMap);
+#endif
 
 #ifdef USE_ENTERPRISE
 


### PR DESCRIPTION
### Scope & Purpose

Don't include a method by default that is only used from within tests.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

Simply needs to compile after the change.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11027/