### PR TITLE
Agency Restart Bug

### DIFF
--- a/arangod/Agency/Inception.cpp
+++ b/arangod/Agency/Inception.cpp
@@ -346,6 +346,10 @@ bool Inception::restartingActiveAgent() {
               auto const theirLeaderEp =
                   tcc.get(std::vector<std::string>({"pool", theirLeaderId})).copyString();
 
+              if (theirLeaderId == myConfig.id()) {
+                continue;
+              }
+
               // Contact leader to update endpoint
               if (theirLeaderId != theirId) {
                 if (this->isStopping() || _agent.isStopping()) {


### PR DESCRIPTION
### Scope & Purpose

Do not assume leadership when restarted and cluster did not react to leader change yet. In particular to not server wrong data.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [ ] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [ ] Added **Regression Tests** (Only for bug-fixes) 
- [ ] Added new C++ **Unit Tests** (Either GoogleTest or Catch-Test)
   - Did you add tests for a new *RestHandler* subclass ?
   - Did you add new mocks of underlying code layers to be able to verify your functionality ? 
   - ...
- [ ] Added new **integration tests** (i.e. in shell_server / shell_server_aql)
- [ ] Added new **resilience tests** (only if the feature is impacted by failovers)

Additionally:

- [x] There are tests in an external testing repository (i.e. node-resilience tests, chaos tests)
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

