### PR TITLE
fix and extend cluster metrics

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,18 @@
 devel
 -----
 
+* Added cluster metrics `arangodb_load_plan_accum_runtime_msec` and
+  `arangodb_load_current_accum_runtime_msec` to track the total time spent
+  in `loadPlan()` and `loadCurrent()` operations.
+
+* Fixed wrong reporting of failures in all maintenace failure counter metrics
+  (`arangodb_maintenance_action_failure_counter`). Previously, each successful
+  maintenance operation was reported as a failure, so the failure counters
+  actually were counters for the number of successful maintenance actions.
+
+* Adjusted the scale of the `arangodb_maintenance_action_queue_time_msec` to
+  cover a more useful range.
+
 * Fixed restoring a SmartGraph into a database that already contains that same graph.
   The use case is restoring a SmartGraph from backup, apply some modifications, which are
   undesired, and then resetting it to the restored state, without dropping the database.

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -269,9 +269,13 @@ ClusterInfo::ClusterInfo(application_features::ApplicationServer& server,
     _lpTimer(_server.getFeature<MetricsFeature>().histogram(
                "arangodb_load_plan_runtime", log_scale_t(std::exp(1.f), 0.f, 2500.f, 10),
                "Plan loading runtimes [ms]")),
+    _lpTotal(_server.getFeature<MetricsFeature>().counter(
+               "arangodb_load_plan_accum_runtime_msec", 0, "Accumulated runtime of Plan loading [ms]")),
     _lcTimer(_server.getFeature<MetricsFeature>().histogram(
                "arangodb_load_current_runtime", log_scale_t(std::exp(1.f), 0.f, 2500.f, 10),
-               "Current loading runtimes [ms]")) {
+               "Current loading runtimes [ms]")),
+    _lcTotal(_server.getFeature<MetricsFeature>().counter(
+               "arangodb_load_current_accum_runtime_msec", 0, "Accumulated runtime of Current loading [ms]")) {
   _uniqid._currentValue = 1ULL;
   _uniqid._upperValue = 0ULL;
   _uniqid._nextBatchStart = 1ULL;
@@ -279,6 +283,7 @@ ClusterInfo::ClusterInfo(application_features::ApplicationServer& server,
   _uniqid._backgroundJobIsRunning = false;
   // Actual loading into caches is postponed until necessary
 }
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief destroys a cluster info object
 ////////////////////////////////////////////////////////////////////////////////
@@ -561,7 +566,6 @@ void ClusterInfo::loadClusterId() {
 static std::string const prefixPlan = "Plan";
 
 void ClusterInfo::loadPlan() {
-
   using namespace std::chrono;
   using clock = std::chrono::high_resolution_clock;
 
@@ -1196,9 +1200,9 @@ void ClusterInfo::loadPlan() {
     triggerWaiting(_waitPlanVersion, _planVersion);
   }
 
-  _lpTimer.count(duration<float,std::milli>(clock::now()-start).count());
-
-
+  auto diff = duration<float, std::milli>(clock::now() - start).count();
+  _lpTotal += diff;
+  _lpTimer.count(diff);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1380,8 +1384,9 @@ void ClusterInfo::loadCurrent() {
     triggerWaiting(_waitCurrentVersion, _currentVersion);
   }
 
-  _lcTimer.count(duration<float,std::milli>(clock::now()-start).count());
-
+  auto diff = duration<float, std::milli>(clock::now() - start).count();
+  _lcTotal += diff;
+  _lcTimer.count(diff);
 }
 
 /// @brief ask about a collection

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1201,7 +1201,7 @@ void ClusterInfo::loadPlan() {
   }
 
   auto diff = duration<float, std::milli>(clock::now() - start).count();
-  _lpTotal += diff;
+  _lpTotal += static_cast<uint64_t>(diff);
   _lpTimer.count(diff);
 }
 
@@ -1385,7 +1385,7 @@ void ClusterInfo::loadCurrent() {
   }
 
   auto diff = duration<float, std::milli>(clock::now() - start).count();
-  _lcTotal += diff;
+  _lcTotal += static_cast<uint64_t>(diff);
   _lcTimer.count(diff);
 }
 

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -1209,8 +1209,17 @@ public:
   mutable std::mutex _waitCurrentVersionLock;
   std::multimap<uint64_t, futures::Promise<arangodb::Result>> _waitCurrentVersion;
 
+  /// @brief histogram for loadPlan runtime
   Histogram<log_scale_t<float>>& _lpTimer;
+  
+  /// @brief total time for loadPlan runtime
+  Counter& _lpTotal;
+  
+  /// @brief histogram for loadCurrent runtime
   Histogram<log_scale_t<float>>& _lcTimer;
+  
+  /// @brief total time for loadCurrent runtime
+  Counter& _lcTotal;
     
 };
 

--- a/arangod/Cluster/MaintenanceFeature.cpp
+++ b/arangod/Cluster/MaintenanceFeature.cpp
@@ -168,13 +168,13 @@ void MaintenanceFeature::initializeMetrics() {
 
   _phase1_accum_runtime_msec =
       metricsFeature.counter(StaticStrings::MaintenancePhaseOneAccumRuntimeMs,
-                             0, "Accumulated runtime of phase one");
+                             0, "Accumulated runtime of phase one [ms]");
   _phase2_accum_runtime_msec =
       metricsFeature.counter(StaticStrings::MaintenancePhaseTwoAccumRuntimeMs,
-                             0, "Accumulated runtime of phase two");
+                             0, "Accumulated runtime of phase two [ms]");
   _agency_sync_total_accum_runtime_msec =
       metricsFeature.counter(StaticStrings::MaintenanceAgencySyncAccumRuntimeMs,
-                             0, "Accumulated runtime of agency sync phase");
+                             0, "Accumulated runtime of agency sync phase [ms]");
 
   _shards_out_of_sync = metricsFeature.gauge<uint64_t>(
       StaticStrings::ShardsOutOfSync, 0,
@@ -215,7 +215,7 @@ void MaintenanceFeature::initializeMetrics() {
                                  "Time spend execution the action [ms]"),
         metricsFeature.histogram(
             {StaticStrings::MaintenanceActionQueueTimeMs, action_label},
-            log_scale_t<uint64_t>(2, 82, 86400000, 12),
+            log_scale_t<uint64_t>(2, 82, 3600000, 12),
             "Time spend in the queue before execution [ms]"),
 
         metricsFeature.counter({StaticStrings::MaintenanceActionAccumRuntimeMs, action_label},

--- a/arangod/Cluster/MaintenanceWorker.cpp
+++ b/arangod/Cluster/MaintenanceWorker.cpp
@@ -160,7 +160,7 @@ void MaintenanceWorker::nextState(bool actionMore) {
       _curAction->endStats();
 
       bool ok = _curAction->result().ok() && FAILED != _curAction->getState();
-      recordJobStats(ok);
+      recordJobStats(/*failed*/ !ok);
 
       // if action's state not set, assume it succeeded when result ok
       if (ok) {

--- a/arangod/Cluster/MaintenanceWorker.cpp
+++ b/arangod/Cluster/MaintenanceWorker.cpp
@@ -159,11 +159,11 @@ void MaintenanceWorker::nextState(bool actionMore) {
       _lastResult = _curAction->result();
       _curAction->endStats();
 
-      bool failed = _curAction->result().ok() && FAILED != _curAction->getState();
-      recordJobStats(failed);
+      bool ok = _curAction->result().ok() && FAILED != _curAction->getState();
+      recordJobStats(ok);
 
       // if action's state not set, assume it succeeded when result ok
-      if (failed) {
+      if (ok) {
         _curAction->endStats();
         _curAction->setState(COMPLETE);
 

--- a/arangod/RestServer/MetricsFeature.cpp
+++ b/arangod/RestServer/MetricsFeature.cpp
@@ -101,13 +101,13 @@ void MetricsFeature::toPrometheus(std::string& result) const {
   }
 }
 
-Counter& MetricsFeature::counter (
+Counter& MetricsFeature::counter(
   std::initializer_list<std::string> const& key, uint64_t const& val,
   std::string const& help) {
   return counter(metrics_key(key), val, help);
 }
 
-Counter& MetricsFeature::counter (
+Counter& MetricsFeature::counter(
   metrics_key const& mk, uint64_t const& val,
   std::string const& help) {
 
@@ -128,12 +128,12 @@ Counter& MetricsFeature::counter (
   }
   if (!success) {
     THROW_ARANGO_EXCEPTION_MESSAGE(
-      TRI_ERROR_INTERNAL, std::string("counter ") + mk.name + " alredy exists");
+      TRI_ERROR_INTERNAL, std::string("counter ") + mk.name + " already exists");
   }
   return *metric;
 }
 
-Counter& MetricsFeature::counter (
+Counter& MetricsFeature::counter(
   std::string const& name, uint64_t const& val, std::string const& help) {
   return counter(metrics_key(name), val, help);
 }
@@ -142,7 +142,7 @@ ServerStatistics& MetricsFeature::serverStatistics() {
   return *_serverStatistics;
 }
 
-Counter& MetricsFeature::counter (std::initializer_list<std::string> const& key) {
+Counter& MetricsFeature::counter(std::initializer_list<std::string> const& key) {
   metrics_key mk(key);
   std::shared_ptr<Counter> metric = nullptr;
   std::string error;
@@ -174,7 +174,7 @@ Counter& MetricsFeature::counter (std::initializer_list<std::string> const& key)
   return *metric;
 }
 
-Counter& MetricsFeature::counter (std::string const& name) {
+Counter& MetricsFeature::counter(std::string const& name) {
   return counter({name});
 }
 


### PR DESCRIPTION
### Scope & Purpose

This PR provides 3 metrics-related changes:

* Added cluster metrics `arangodb_load_plan_accum_runtime_msec` and `arangodb_load_current_accum_runtime_msec` to track the total time spent in `loadPlan()` and `loadCurrent()` operations.
* Fixed wrong reporting of failures in all maintenace failure counter metrics (`arangodb_maintenance_action_failure_counter`). Previously, each successful maintenance operation was reported as a failure, so the failure counters actually were counters for the number of successful maintenance actions.
* Adjusted the scale of the `arangodb_maintenance_action_queue_time_msec` to cover a more useful range.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11033/