### PR TITLE
Avoid notifying condition variables while holding a lock.

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -5372,8 +5372,8 @@ void ClusterInfo::SyncerThread::beginShutdown() {
   {
     std::lock_guard<std::mutex> lck(_m);
     _news = false;
-    _cv.notify_one();
   }
+  _cv.notify_one();
 }
 
 void ClusterInfo::SyncerThread::start() {

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -95,8 +95,10 @@ class HeartbeatBackgroundJobThread : public Thread {
   /// @brief asks the thread to stop, but does not wait.
   //////////////////////////////////////////////////////////////////////////////
   void stop() {
-    std::unique_lock<std::mutex> guard(_mutex);
-    _stop = true;
+    {
+      std::unique_lock<std::mutex> guard(_mutex);
+      _stop = true;
+    }
     _condition.notify_one();
   }
 
@@ -108,6 +110,7 @@ class HeartbeatBackgroundJobThread : public Thread {
     std::unique_lock<std::mutex> guard(_mutex);
     _anotherRun.store(true, std::memory_order_release);
     if (_sleeping.load(std::memory_order_acquire)) {
+      guard.unlock();
       _condition.notify_one();
     }
   }

--- a/lib/Basics/ReadWriteLock.cpp
+++ b/lib/Basics/ReadWriteLock.cpp
@@ -91,7 +91,9 @@ bool ReadWriteLock::lockWrite(std::chrono::microseconds timeout) {
 
   // Undo the counting of us as queued writer:
   _state.fetch_sub(QUEUED_WRITER_INC, std::memory_order_relaxed);
-  std::unique_lock<std::mutex> guard(_reader_mutex);
+  {
+    std::lock_guard<std::mutex> guard(_reader_mutex);
+  }
   _readers_bell.notify_all();
 
   return false;
@@ -160,11 +162,15 @@ void ReadWriteLock::unlockWrite() noexcept {
   auto state = _state.fetch_sub(WRITE_LOCK, std::memory_order_release);
   if ((state & QUEUED_WRITER_MASK) != 0) {
     // there are other writers waiting -> wake up one of them
-    std::unique_lock<std::mutex> guard(_writer_mutex);
+    {
+      std::lock_guard<std::mutex> guard(_writer_mutex);
+    }
     _writers_bell.notify_one();
   } else {
     // no more writers -> wake up any waiting readings
-    std::unique_lock<std::mutex> guard(_reader_mutex);
+    {
+      std::lock_guard<std::mutex> guard(_reader_mutex);
+    }
     _readers_bell.notify_all();
   }
 }
@@ -178,7 +184,9 @@ void ReadWriteLock::unlockRead() noexcept {
   if (state != 0 && (state & ~QUEUED_WRITER_MASK) == 0) {
     // we were the last reader and there are other writers waiting
     // -> wake up one of them
-    std::unique_lock<std::mutex> guard(_writer_mutex);
+    {
+      std::lock_guard<std::mutex> guard(_writer_mutex);
+    }
     _writers_bell.notify_one();
   }
 }

--- a/lib/Futures/Future.h
+++ b/lib/Futures/Future.h
@@ -146,8 +146,10 @@ void waitImpl(Future<T>& f) {
   Promise<T> p;
   Future<T> ret = p.getFuture();
   f.thenFinal([p(std::move(p)), &cv, &m](Try<T>&& t) mutable {
-    std::lock_guard<std::mutex> guard(m);
-    p.setTry(std::move(t));
+    {
+      std::lock_guard<std::mutex> guard(m);
+      p.setTry(std::move(t));
+    }
     cv.notify_one();
   });
   std::unique_lock<std::mutex> lock(m);
@@ -168,8 +170,10 @@ void waitImpl(Future<T>& f, std::chrono::time_point<Clock, Duration> const& tp) 
   Promise<T> p;
   Future<T> ret = p.getFuture();
   f.thenFinal([p(std::move(p)), &cv, &m](Try<T>&& t) mutable {
-    std::lock_guard<std::mutex> guard(m);
-    p.setTry(std::move(t));
+    {
+      std::lock_guard<std::mutex> guard(m);
+      p.setTry(std::move(t));
+    }
     cv.notify_one();
   });
   std::unique_lock<std::mutex> lock(m);


### PR DESCRIPTION
The lock is only required to serialize operations on the data the CV wait operations depends on. In some cases (e.g., when using atomics like in the ReadWriteLock) it is sufficient to lock and immediately unlock the mutex (i.e., an "empty critical secion") before calling notify.

Notifying a CV while holding the lock is a pessimization, because the notified thread will immediately try to acquire that lock and therefore be blocked again if the notifying thread has not yet released the lock.

This change is a trivial rework / code cleanup without any test coverage.
