### PR TITLE
Do not assume leadership when restarted and cluster did not react to …

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
+* Fixed a rare race in Agents, if the leader is rebooted quickly there is a chance
+  that it is still assumed to be the leader, but delivers a state shortly in the
+  past.
+
 * Fixed a race in the ConnectionPool which could lease out a connection that got
   its idle timeout after the lease was completed. This could lead to sporadic
   network failures in TLS and to inefficiencies with TCP.

--- a/arangod/Agency/Inception.cpp
+++ b/arangod/Agency/Inception.cpp
@@ -346,6 +346,10 @@ bool Inception::restartingActiveAgent() {
               auto const theirLeaderEp =
                   tcc.get(std::vector<std::string>({"pool", theirLeaderId})).copyString();
 
+              if (theirLeaderId == myConfig.id()) {
+                continue;
+              }
+
               // Contact leader to update endpoint
               if (theirLeaderId != theirId) {
                 if (this->isStopping() || _agent.isStopping()) {


### PR DESCRIPTION
Backport of: https://github.com/arangodb/arangodb/pull/12198