### PR TITLE
bug-fix JSExposed cluster internal networking methods (#12202)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,14 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
-* Fixed a rare race in Agents, if the leader is rebooted quickly there is a
-  chance that it is still assumed to be the leader, but delivers a state shortly
-  in the past.
+* The internally used JS-based ClusterComm send request function can now again use JSON, and does
+  not require VelocyPack anymore. This fixes an issue with Foxx-App management (install, updated, remove)
+  got delayed in a sharded environment, all servers do get all apps eventually, now the fast-path
+  will work again.
+
+* Fixed a rare race in Agents, if the leader is rebooted quickly there is a chance
+  that it is still assumed to be the leader, but delivers a state shortly in the
+  past.
 
 * Keep the list of last-acknowledged entires in Agency more consistent.
   During leadership take-over it was possible to get into a situation that the

--- a/arangod/Cluster/v8-cluster.cpp
+++ b/arangod/Cluster/v8-cluster.cpp
@@ -1492,18 +1492,22 @@ static void Return_PrepareClusterCommResultForJS(v8::FunctionCallbackInfo<v8::Va
     network::Response const& response = res.response;
 
     if (response.ok()) {
-      // The headers:
-      v8::Handle<v8::Object> h = v8::Object::New(isolate);
-      TRI_GET_GLOBAL_STRING(StatusKey);
-      r->Set(context, StatusKey, TRI_V8_ASCII_STRING(isolate, "RECEIVED")).FromMaybe(false);
+      {
+        // The headers:
+        v8::Handle<v8::Object> h = v8::Object::New(isolate);
+        TRI_GET_GLOBAL_STRING(StatusKey);
+        r->Set(context, StatusKey, TRI_V8_ASCII_STRING(isolate, "RECEIVED")).FromMaybe(false);
 
-      auto headers = response.response->header.meta();
-      headers[StaticStrings::ContentLength] = StringUtils::itoa(response.response->payloadSize());
-      for (auto& it : headers) {
-        h->Set(context, TRI_V8_STD_STRING(isolate, it.first), TRI_V8_STD_STRING(isolate, it.second)).FromMaybe(false);
+        auto headers = response.response->header.meta();
+        headers[StaticStrings::ContentLength] = StringUtils::itoa(response.response->payloadSize());
+        for (auto& it : headers) {
+          h->Set(context, TRI_V8_STD_STRING(isolate, it.first), TRI_V8_STD_STRING(isolate, it.second)).FromMaybe(false);
+        }
+        r->Set(context, TRI_V8_ASCII_STRING(isolate, "headers"), h).FromMaybe(false);
       }
-      r->Set(context, TRI_V8_ASCII_STRING(isolate, "headers"), h).FromMaybe(false);
-
+      TRI_GET_GLOBAL_STRING(CodeKey);
+      r->Set(context, CodeKey, v8::Number::New(isolate, response.statusCode())).FromMaybe(false);
+    
       std::string json;
       if (response.response->isContentTypeVPack()) {
         json = response.response->slice().toJson();
@@ -1586,6 +1590,7 @@ static void JS_AsyncRequest(v8::FunctionCallbackInfo<v8::Value> const& args) {
   reqOpts.retryNotFound = false;
   reqOpts.timeout = network::Timeout(timeout);
   reqOpts.skipScheduler = true;
+  reqOpts.contentType = StaticStrings::MimeTypeJsonNoEncoding;
   
   OperationID opId = TRI_NewTickServer();
   auto ar = std::make_shared<::AsyncRequest>();

--- a/arangod/V8Server/v8-actions.cpp
+++ b/arangod/V8Server/v8-actions.cpp
@@ -1478,8 +1478,10 @@ static int clusterSendToAllServers(v8::Isolate* isolate, std::string const& dbna
   fuerte::RestVerb verb = network::arangoRestVerbToFuerte(method);
 
   network::RequestOptions reqOpts;
+
   reqOpts.database = dbname;
   reqOpts.timeout = network::Timeout(3600);
+  reqOpts.contentType = StaticStrings::MimeTypeJsonNoEncoding;
 
   std::vector<futures::Future<network::Response>> futures;
   futures.reserve(DBServers.size());

--- a/tests/js/server/shell/shell-communication-methods-cluster.js
+++ b/tests/js/server/shell/shell-communication-methods-cluster.js
@@ -1,0 +1,109 @@
+/*jshint globalstrict:false, strict:true */
+/*global global */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief tests for client-specific functionality
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2016 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Michael Hackstein
+/// @author Copyright 2020, ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const { asyncRequest, getId, wait, drop } = global.ArangoClusterComm;
+const { id } = global.ArangoServerState;
+const { db } = require("@arangodb");
+const { assertEqual } = jsunity.jsUnity.assertions;
+
+function clusterCommAsyncRequestSuite() {
+    // We use this URL as it accepts a POST, but does
+    // not care at all for the body.
+    // We can easily modify this.
+    const url = '/_api/foxx/_local/heal';
+    const method = "POST";
+
+    // Just send request to ourself
+    const target = `server:${id()}`;
+    const dbName = db._name();
+
+    const sendRequest = (body) => {
+      const identifier = {coordTransactionID: getId()};
+      asyncRequest(
+        method,
+        target,
+        dbName,
+        url,
+        body,
+        {},
+        identifier
+      );
+      return identifier;
+    };
+
+    const awaitResponse = (identifier) => {
+      try {
+        return wait(identifier);
+      } finally {
+        drop(identifier);
+      }
+    };
+
+    const Test = {};
+
+    const bodies = [
+      undefined,
+      {},
+      {a:1},
+      [],
+      [1],
+      123,
+      "foo",
+      9.5,
+      true
+    ];
+
+    for (const body of bodies) {
+      // Plain
+      Test[`testSend${JSON.stringify(body)}`] = function () {
+        const ident = sendRequest(body);
+        const result = awaitResponse(ident);
+        assertEqual(result.code, 204);
+      };
+
+      Test[`testSendStringified${JSON.stringify(body)}`] = function () {
+        const ident = sendRequest(JSON.stringify(body));
+        const result = awaitResponse(ident);
+        assertEqual(result.code, 204);
+      };
+    }
+
+
+    return Test;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief executes the test suite
+////////////////////////////////////////////////////////////////////////////////
+
+jsunity.run(clusterCommAsyncRequestSuite);
+
+return jsunity.done();


### PR DESCRIPTION
These will be called with JSON bodies, but the default content type is VPack. This will cause trouble and basically break those APIs for cluster internal usage.

Jenkins:
http://jenkins.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/11048/

Fixes:
https://arangodb.atlassian.net/projects/BTS/issues/BTS-128

Backport of:
https://github.com/arangodb/arangodb/pull/12202/

tests:
Included in this PR.
Also there is indirect tests for this code in resilience tests, Foxx part.