### PR TITLE
Bug fix/overfetch in filter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,15 @@
 devel
 -----
 
+* The filter executor will now overfetch data again if followed by a limit, same as in 3.6 series.
+  The following queries are effected:
+  ```
+  something
+  FILTER a == b
+  LIMIT 10
+  ```
+  something will now be asked for a full batch, instead of only 10 documents.
+
 * The internally used JS-based ClusterComm send request function can now again use JSON, and does
   not require VelocyPack anymore. This fixes an issue with Foxx-App management (install, updated, remove)
   got delayed in a sharded environment, all servers do get all apps eventually, now the fast-path

--- a/arangod/Aql/FilterExecutor.cpp
+++ b/arangod/Aql/FilterExecutor.cpp
@@ -67,14 +67,8 @@ auto FilterExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange, AqlCall& 
     }
   }
 
+  // Just fetch everything from above, allow overfetching
   AqlCall upstreamCall{};
-  if (call.needSkipMore() && call.getLimit() == 0) {
-    // FullCount case, we need to skip more, but limit is reached.
-    upstreamCall.softLimit = ExecutionBlock::SkipAllSize();
-  } else {
-    upstreamCall.softLimit = call.getOffset();
-  }
-
   return {inputRange.upstreamState(), stats, call.getSkipCount(), upstreamCall};
 }
 
@@ -96,12 +90,8 @@ auto FilterExecutor::produceRows(AqlItemBlockInputRange& inputRange, OutputAqlIt
     }
   }
 
+  // Just fetch everything from above, allow overfetching
   AqlCall upstreamCall{};
-  auto const& clientCall = output.getClientCall();
-  // This is a optimistic fetch. We do not do any overfetching here, only if we
-  // pass through all rows this fetch is correct, otherwise we have too few rows.
-  upstreamCall.softLimit = clientCall.getOffset() +
-                           (std::min)(clientCall.softLimit, clientCall.hardLimit);
   return {inputRange.upstreamState(), stats, upstreamCall};
 }
 

--- a/tests/js/server/aql/aql-profiler-noncluster-nightly.js
+++ b/tests/js/server/aql/aql-profiler-noncluster-nightly.js
@@ -266,8 +266,16 @@ function ahuacatlProfilerTestSuite () {
 
           const listBatches = Math.ceil(listRows / defaultBatchSize);
           const totalRows = listRows * collectionRows;
+          const calcOptBatches = () => {
+            const opt =  Math.ceil(totalRows / defaultBatchSize);
+            if (totalRows % defaultBatchSize === 0) {
+              // In this case the traversal may, or may not know that there is more data.
+              return [opt, opt + 1];
+            }
+            return opt;
+          };
 
-          const optimalBatches = Math.ceil(totalRows / defaultBatchSize);
+          const optimalBatches = calcOptBatches();
 
           const expected = [
             {type: SingletonBlock, calls: 1, items: 1},

--- a/tests/js/server/aql/aql-profiler.js
+++ b/tests/js/server/aql/aql-profiler.js
@@ -342,39 +342,19 @@ function ahuacatlProfilerTestSuite () {
 
     testFilterBlock2 : function () {
       const query = 'FOR i IN 1..@rows FILTER i % 13 != 0 RETURN i';
-      const genNodeList = (rows) => {
+      const genNodeList = (rows, batches) => {
         // This is an array 1..rows where true means it passes the filter
         const list = Array.from(Array(rows)).map((_, index ) => {
           return ((index + 1) % 13 !== 0);
         });
-
-        const recursiveFilterCallEstimator = (rowsToFetch) => {
-          if (rowsToFetch === 0 || list.length === 0) {
-            return 0;
-          }
-          if (rowsToFetch < 0) {
-            // We would have counted an overfetch!
-            assertTrue(false);
-          }
-          // We count one required call.
-          // We remove rowsToFetch elements from the beginning of the array.
-          // We count how many of those are true.
-          // We simulate an above call with rowsToFetch - the number of true counts.
-          // Redo until we have no more rows to fetch.
-          return 1 + recursiveFilterCallEstimator(rowsToFetch - list.splice(0, rowsToFetch).filter(e => e).length);
-        };
-        let batchesAboveFilter = 0;
-        while (list.length > 0) {
-          batchesAboveFilter += recursiveFilterCallEstimator(defaultBatchSize);
-        }
         const rowsAfterFilter = rows - Math.floor(rows / 13);
         const batchesAfterFilter = Math.ceil(rowsAfterFilter / defaultBatchSize);
 
         return [
           { type : SingletonBlock, calls : 1, items : 1 },
           { type : CalculationBlock, calls : 1, items : 1 },
-          { type : EnumerateListBlock, calls : batchesAboveFilter, items : rows },
-          { type : CalculationBlock, calls : batchesAboveFilter, items : rows },
+          { type : EnumerateListBlock, calls : batches, items : rows },
+          { type : CalculationBlock, calls : batches, items : rows },
           { type : FilterBlock, calls : batchesAfterFilter, items : rowsAfterFilter },
           { type : ReturnBlock, calls : batchesAfterFilter, items : rowsAfterFilter },
         ];
@@ -388,38 +368,19 @@ function ahuacatlProfilerTestSuite () {
 
     testFilterBlock3 : function () {
       const query = 'FOR i IN 1..@rows FILTER i % 13 == 0 RETURN i';
-      const genNodeList = (rows) => {
+      const genNodeList = (rows, batches) => {
         // This is an array 1..rows where true means it passes the filter
         const list = Array.from(Array(rows)).map((_, index ) => {
           return ((index + 1) % 13 === 0);
         });
-        const recursiveFilterCallEstimator = (rowsToFetch) => {
-          if (rowsToFetch === 0 || list.length === 0) {
-            return 0;
-          }
-          if (rowsToFetch < 0) {
-            // We would have counted an overfetch!
-            assertTrue(false);
-          }
-          // We count one required call.
-          // We remove rowsToFetch elements from the beginning of the array.
-          // We count how many of those are true.
-          // We simulate an above call with rowsToFetch - the number of true counts.
-          // Redo until we have no more rows to fetch.
-          return 1 + recursiveFilterCallEstimator(rowsToFetch - list.splice(0, rowsToFetch).filter(e => e).length);
-        };
-        let batchesAboveFilter = 0;
-        while (list.length > 0) {
-          batchesAboveFilter += recursiveFilterCallEstimator(defaultBatchSize);
-        }
         const rowsAfterFilter = Math.floor(rows / 13);
         const batchesAfterFilter = Math.max(1, Math.ceil(rowsAfterFilter / defaultBatchSize));
 
         return [
           { type : SingletonBlock, calls : 1, items : 1 },
           { type : CalculationBlock, calls : 1, items : 1 },
-          { type : EnumerateListBlock, calls : batchesAboveFilter, items : rows },
-          { type : CalculationBlock, calls : batchesAboveFilter, items : rows },
+          { type : EnumerateListBlock, calls : batches, items : rows },
+          { type : CalculationBlock, calls : batches, items : rows },
           { type : FilterBlock, calls : batchesAfterFilter, items : rowsAfterFilter },
           { type : ReturnBlock, calls : batchesAfterFilter, items : rowsAfterFilter },
         ];

--- a/tests/js/server/aql/aql-skipping.js
+++ b/tests/js/server/aql/aql-skipping.js
@@ -336,7 +336,15 @@ function aqlSkippingIndexTestsuite () {
 
       const result = AQL_EXECUTE(query, bindParams, queryOptions);
       assertEqual(100, result.json.length);
-      assertEqual(137, result.stats.scannedIndex);
+
+      if (internal.isCluster()) {
+        // In cluster we cannot identify how many documents
+        // are scanned as it depends on the ranomd distribution
+        // of data, if the first shard or server can fulfill
+        // this query, the other shard will never be asked
+        return;
+      }
+      assertEqual(637, result.stats.scannedIndex);
     },
 
     testOffsetLimitFullCountTwoIndexes: function () {
@@ -408,7 +416,14 @@ function aqlSkippingIndexTestsuite () {
 
       const result = AQL_EXECUTE(query, bindParams, queryOptions);
       assertEqual(100, result.json.length);
-      assertEqual(189, result.stats.scannedIndex);
+      if (internal.isCluster()) {
+        // In cluster we cannot identify how many documents
+        // are scanned as it depends on the ranomd distribution
+        // of data, if the first shard or server can fulfill
+        // this query, the other shard will never be asked
+        return;
+      }
+      assertEqual(889, result.stats.scannedIndex);
     },
 
     testOffsetLimitFullCountThreeIndexes: function () {


### PR DESCRIPTION
Reverts an unintended behavior change in Filter Executor in comparison to 3.6

It will now again fetch full batches of documents instead of taking into account the requested limit.

Jenkins:
http://jenkins.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/11052/