### PR TITLE
SmartBFS 2020 (#12079)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,16 +1,18 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
-* In rare cases SmartBFS could use a wrong index for looking up edges. This is fixed now.
+* In rare cases SmartBFS could use a wrong index for looking up edges. This is
+  fixed now.
 
-* The internally used JS-based ClusterComm send request function can now again use JSON, and does
-  not require VelocyPack anymore. This fixes an issue with Foxx-App management (install, updated, remove)
-  got delayed in a sharded environment, all servers do get all apps eventually, now the fast-path
-  will work again.
+* The internally used JS-based ClusterComm send request function can now again
+  use JSON, and does not require VelocyPack anymore. This fixes an issue with
+  Foxx-App management (install, updated, remove) got delayed in a sharded
+  environment, all servers do get all apps eventually, now the fast-path will
+  work again.
 
-* Fixed a rare race in Agents, if the leader is rebooted quickly there is a chance
-  that it is still assumed to be the leader, but delivers a state shortly in the
-  past.
+* Fixed a rare race in Agents, if the leader is rebooted quickly there is a
+  chance that it is still assumed to be the leader, but delivers a state shortly
+  in the past.
 
 * Keep the list of last-acknowledged entires in Agency more consistent.
   During leadership take-over it was possible to get into a situation that the

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
+* In rare cases SmartBFS could use a wrong index for looking up edges. This is fixed now.
+
+
 * Fixed a rare race in Agents, if the leader is rebooted quickly there is a
   chance that it is still assumed to be the leader, but delivers a state shortly
   in the past.

--- a/arangod/Aql/OptimizerUtils.cpp
+++ b/arangod/Aql/OptimizerUtils.cpp
@@ -457,19 +457,28 @@ std::pair<bool, bool> findIndexHandleForAndNode(
 ///        and the Condition stays unmodified. Also does not care for sorting
 ///        Returns false if no index could be found.
 
-bool getBestIndexHandleForFilterCondition(
-    aql::Collection const& collection,
-    arangodb::aql::AstNode*& node,
-    arangodb::aql::Variable const* reference, size_t itemsInCollection,
-    aql::IndexHint const& hint, std::shared_ptr<Index>& usedIndex) {
+bool getBestIndexHandleForFilterCondition(aql::Collection const& collection,
+                                          arangodb::aql::AstNode*& node,
+                                          arangodb::aql::Variable const* reference,
+                                          size_t itemsInCollection,
+                                          aql::IndexHint const& hint,
+                                          std::shared_ptr<Index>& usedIndex,
+                                          bool onlyEdgeIndexes) {
   // We can only start after DNF transformation and only a single AND
   TRI_ASSERT(node->type == arangodb::aql::AstNodeType::NODE_TYPE_OPERATOR_NARY_AND);
   if (node->numMembers() == 0) {
     // Well no index can serve no condition.
     return false;
   }
-  
+
   auto indexes = collection.indexes();
+  if (onlyEdgeIndexes) {
+    indexes.erase(std::remove_if(indexes.begin(), indexes.end(),
+                                 [](auto&& idx) {
+                                   return idx->type() != Index::IndexType::TRI_IDX_TYPE_EDGE_INDEX;
+                                 }),
+                  indexes.end());
+  }
 
   arangodb::aql::SortCondition sortCondition;    // always empty here
   arangodb::aql::AstNode* specializedCondition;  // unused

--- a/arangod/Aql/OptimizerUtils.h
+++ b/arangod/Aql/OptimizerUtils.h
@@ -54,10 +54,13 @@ std::pair<bool, bool> getBestIndexHandlesForFilterCondition(
 /// @brief Gets the best fitting index for an AQL condition.
 /// note: the caller must have read-locked the underlying collection when
 /// calling this method
-bool getBestIndexHandleForFilterCondition(
-aql::Collection const& collection, arangodb::aql::AstNode*& node,
-arangodb::aql::Variable const* reference, size_t itemsInCollection,
-aql::IndexHint const& hint, std::shared_ptr<Index>& usedIndex);
+bool getBestIndexHandleForFilterCondition(aql::Collection const& collection,
+                                          arangodb::aql::AstNode*& node,
+                                          arangodb::aql::Variable const* reference,
+                                          size_t itemsInCollection,
+                                          aql::IndexHint const& hint,
+                                          std::shared_ptr<Index>& usedIndex,
+                                          bool onlyEdgeIndexes = false);
 
 /// @brief Gets the best fitting index for an AQL sort condition
 /// note: the caller must have read-locked the underlying collection when

--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -699,16 +699,22 @@ void TraversalNode::prepareOptions() {
     }
   }
 
+
   TraverserOptions* opts = this->TraversalNode::options();
   TRI_ASSERT(opts != nullptr);
+  /*
+   * HACK: DO NOT use other indexes for smart BFS. Otherwise this will produce
+   * wrong results.
+   */
+  bool onlyEdgeIndexes = this->isSmart() && opts->useBreadthFirst;
   for (auto& it : _edgeConditions) {
     uint64_t depth = it.first;
     // We probably have to adopt minDepth. We cannot fulfill a condition of
     // larger depth anyway
     auto& builder = it.second;
 
-    for (auto& it : _globalEdgeConditions) {
-      builder->addConditionPart(it);
+    for (auto& it2 : _globalEdgeConditions) {
+      builder->addConditionPart(it2);
     }
 
     for (size_t i = 0; i < numEdgeColls; ++i) {
@@ -718,11 +724,11 @@ void TraversalNode::prepareOptions() {
       switch (dir) {
         case TRI_EDGE_IN:
           opts->addDepthLookupInfo(_plan, _edgeColls[i]->name(), StaticStrings::ToString,
-                                   builder->getInboundCondition()->clone(ast), depth);
+                                   builder->getInboundCondition()->clone(ast), depth, onlyEdgeIndexes);
           break;
         case TRI_EDGE_OUT:
           opts->addDepthLookupInfo(_plan, _edgeColls[i]->name(), StaticStrings::FromString,
-                                   builder->getOutboundCondition()->clone(ast), depth);
+                                   builder->getOutboundCondition()->clone(ast), depth, onlyEdgeIndexes);
           break;
         case TRI_EDGE_ANY:
           TRI_ASSERT(false);

--- a/arangod/Graph/BaseOptions.cpp
+++ b/arangod/Graph/BaseOptions.cpp
@@ -267,25 +267,26 @@ void BaseOptions::setVariable(aql::Variable const* variable) {
 }
 
 void BaseOptions::addLookupInfo(aql::ExecutionPlan* plan, std::string const& collectionName,
-                                std::string const& attributeName, aql::AstNode* condition) {
-  injectLookupInfoInList(_baseLookupInfos, plan, collectionName, attributeName, condition);
+                                std::string const& attributeName,
+                                aql::AstNode* condition, bool onlyEdgeIndexes) {
+  injectLookupInfoInList(_baseLookupInfos, plan, collectionName, attributeName, condition, onlyEdgeIndexes);
 }
 
 void BaseOptions::injectLookupInfoInList(std::vector<LookupInfo>& list,
                                          aql::ExecutionPlan* plan,
                                          std::string const& collectionName,
                                          std::string const& attributeName,
-                                         aql::AstNode* condition) {
+                                         aql::AstNode* condition, bool onlyEdgeIndexes) {
   LookupInfo info;
   info.indexCondition = condition->clone(plan->getAst());
   auto coll = _query.collections().get(collectionName);
   if (!coll) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
   }
-  
+
   bool res = aql::utils::getBestIndexHandleForFilterCondition(*coll, info.indexCondition,
                                                               _tmpVar, 1000, aql::IndexHint(),
-                                                              info.idxHandles[0]);
+                                                              info.idxHandles[0], onlyEdgeIndexes);
   // Right now we have an enforced edge index which should always fit.
   if (!res) {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,

--- a/arangod/Graph/BaseOptions.h
+++ b/arangod/Graph/BaseOptions.h
@@ -111,7 +111,8 @@ struct BaseOptions {
   void setVariable(aql::Variable const*);
 
   void addLookupInfo(aql::ExecutionPlan* plan, std::string const& collectionName,
-                     std::string const& attributeName, aql::AstNode* condition);
+                     std::string const& attributeName, aql::AstNode* condition,
+                     bool onlyEdgeIndexes = false);
 
   void clearVariableValues();
 
@@ -181,8 +182,8 @@ struct BaseOptions {
   bool evaluateExpression(aql::Expression*, arangodb::velocypack::Slice varValue);
 
   void injectLookupInfoInList(std::vector<LookupInfo>&, aql::ExecutionPlan* plan,
-                              std::string const& collectionName,
-                              std::string const& attributeName, aql::AstNode* condition);
+                              std::string const& collectionName, std::string const& attributeName,
+                              aql::AstNode* condition, bool onlyEdgeIndexes = false);
 
   void injectTestCache(std::unique_ptr<TraverserCache>&& cache);
 

--- a/arangod/Graph/TraverserOptions.cpp
+++ b/arangod/Graph/TraverserOptions.cpp
@@ -569,9 +569,10 @@ bool TraverserOptions::shouldExcludeEdgeCollection(std::string const& name) cons
 void TraverserOptions::addDepthLookupInfo(aql::ExecutionPlan* plan,
                                           std::string const& collectionName,
                                           std::string const& attributeName,
-                                          aql::AstNode* condition, uint64_t depth) {
+                                          aql::AstNode* condition, uint64_t depth,
+                                          bool onlyEdgeIndexes) {
   auto& list = _depthLookupInfo[depth];
-  injectLookupInfoInList(list, plan, collectionName, attributeName, condition);
+  injectLookupInfoInList(list, plan, collectionName, attributeName, condition, onlyEdgeIndexes);
 }
 
 bool TraverserOptions::vertexHasFilter(uint64_t depth) const {

--- a/arangod/Graph/TraverserOptions.h
+++ b/arangod/Graph/TraverserOptions.h
@@ -130,8 +130,8 @@ struct TraverserOptions : public graph::BaseOptions {
 
   /// @brief Add a lookup info for specific depth
   void addDepthLookupInfo(aql::ExecutionPlan* plan, std::string const& collectionName,
-                          std::string const& attributeName,
-                          aql::AstNode* condition, uint64_t depth);
+                          std::string const& attributeName, aql::AstNode* condition,
+                          uint64_t depth, bool onlyEdgeIndexes = false);
 
   bool hasDepthLookupInfo() const { return !_depthLookupInfo.empty(); }
 


### PR DESCRIPTION
Fixes a bug in BFS search over smart-graphs.
There was. a small chance that a different index was picked, which caused the result to be incomplete.

Jenkins:
http://jenkins.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/11054/

Has enterprise part:
https://github.com/arangodb/enterprise/pull/509

Backport of:
https://github.com/arangodb/arangodb/pull/12079/