### PR TITLE
Fixed a race between a new request and the keepAlive timeout.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
+* Fixed a race between a new request and the keepAlive timeout.
+
 * Fixed a rare race in Agents, if the leader is rebooted quickly there is a
   chance that it is still assumed to be the leader, but delivers a state shortly
   in the past.

--- a/arangod/GeneralServer/CommTask.h
+++ b/arangod/GeneralServer/CommTask.h
@@ -89,9 +89,14 @@ class CommTask : public std::enable_shared_from_this<CommTask> {
   // callable from any thread
   virtual void start() = 0;
   virtual void stop() = 0;
-  
-protected:
-  
+
+  // returns the number of scheduled requests
+  std::size_t getRequestCount() const { return _requestCount; }
+
+  void setKeepAliveTimeoutReached() { _keepAliveTimeoutReached = true; }
+
+ protected:
+
   virtual std::unique_ptr<GeneralResponse> createResponse(rest::ResponseCode,
                                                           uint64_t messageId) = 0;
 
@@ -158,6 +163,8 @@ protected:
   
   ConnectionStatistics::Item _connectionStatistics;
   std::chrono::milliseconds _keepAliveTimeout;
+  std::size_t _requestCount = 0;
+  bool _keepAliveTimeoutReached = false;
   AuthenticationFeature* _auth;
 
   mutable std::mutex _statisticsMutex;

--- a/arangod/GeneralServer/H2CommTask.cpp
+++ b/arangod/GeneralServer/H2CommTask.cpp
@@ -428,6 +428,10 @@ void H2CommTask<T>::processStream(H2CommTask<T>::Stream* stream) {
   req->body().resetTo(req->body().size() - 1);
 
   this->_protocol->timer.cancel();
+  this->_requestCount += 1;
+  if (this->_keepAliveTimeoutReached) {
+    return;
+  }
 
   {
     LOG_TOPIC("924ce", INFO, Logger::REQUESTS)

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -364,6 +364,11 @@ void HttpCommTask<T>::processRequest() {
 
   TRI_ASSERT(_request);
   this->_protocol->timer.cancel();
+  this->_requestCount += 1;
+  if (this->_keepAliveTimeoutReached) {
+    return ;  // we have to ignore this request because the connection has already been closed
+  }
+
 
   // we may have gotten an H2 Upgrade request
   if (ADB_UNLIKELY(_parser.upgrade)) {


### PR DESCRIPTION
Backport of #12194.

https://jenkins.arangodb.biz/job/arangodb-matrix-pr/11057/