### PR TITLE
Fix crash in cleanup of parallel traversal query

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fixed crash in cleanup of parallel traversal queries (QA-28).
+
 * Fixed a rare race in Agents, if the leader is rebooted quickly there is a chance
   that it is still assumed to be the leader, but delivers a state shortly in the
   past.

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -683,11 +683,10 @@ CostEstimate ExecutionNode::getCost() const {
 
 /// @brief functionality to walk an execution plan recursively
 bool ExecutionNode::walk(WalkerWorkerBase<ExecutionNode>& worker) {
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if (worker.done(this)) {
     return false;
   }
-#endif
+
   if (worker.before(this)) {
     return true;
   }

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -1199,16 +1199,22 @@ ExecutionState Query::cleanupPlanAndEngine(int errorCode, bool sync,
         for (size_t i = 0; i < parents.size(); i++) {
           TRI_ASSERT(parents[i]->getType() == ExecutionNode::DISTRIBUTE_CONSUMER);
           ExecutionNode* graph = parents[i]->getFirstParent();
-          TRI_ASSERT(graph->getType() == ExecutionNode::TRAVERSAL);
-          plan->unlinkNode(parents[i]); // Dist-Consumer node does not like toVelocyPack
-          if (i > 0) {
-            // unlink additional ASYNC nodes, explainer does not handle cycles
-            ExecutionNode* async = graph->getFirstParent();
-            TRI_ASSERT(async->getType() == ExecutionNode::ASYNC);
-            ExecutionNode* gather = async->getFirstParent();
-            TRI_ASSERT(gather->getType() == ExecutionNode::GATHER);
-            gather->removeDependency(async);
-            plan->clearVarUsageComputed();
+          if (graph) {
+            TRI_ASSERT(graph->getType() == ExecutionNode::TRAVERSAL);
+            plan->unlinkNode(parents[i]); // Dist-Consumer node does not like toVelocyPack
+            if (i > 0) {
+              // unlink additional ASYNC nodes, explainer does not handle cycles
+              ExecutionNode* async = graph->getFirstParent();
+              if (async) {
+                TRI_ASSERT(async->getType() == ExecutionNode::ASYNC);
+                ExecutionNode* gather = async->getFirstParent();
+                if (gather) {
+                  TRI_ASSERT(gather->getType() == ExecutionNode::GATHER);
+                  gather->removeDependency(async);
+                  plan->clearVarUsageComputed();
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
### Scope & Purpose

Profiling a parallel traversal query with a non-maintainer build results in a crash by dereferencing a nullptr. This PR fixes this by checking for nullptrs.

- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)

#### Related Information

- [x] There is an internal planning ticket: QA-28

### Testing & Verification

Jenkins: https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/11069/