### PR TITLE
Docs: Fix POST /_api/database request body parameters

### DIFF
--- a/Documentation/DocuBlocks/Rest/Database/get_api_database_new.md
+++ b/Documentation/DocuBlocks/Rest/Database/get_api_database_new.md
@@ -48,7 +48,8 @@ log into the database. The default is *true*.
 
 @RESTSTRUCT{extra,get_api_database_new_USERS,object,optional,}
 A JSON object with extra user information. It is used by the web interface
-to store graph viewer settings and saved queries.
+to store graph viewer settings and saved queries. Should not be set or
+modified by end users, as custom attributes will not be preserved.
 
 @RESTDESCRIPTION
 Creates a new database

--- a/Documentation/DocuBlocks/Rest/Database/get_api_database_new.md
+++ b/Documentation/DocuBlocks/Rest/Database/get_api_database_new.md
@@ -7,19 +7,19 @@
 @RESTBODYPARAM{name,string,required,string}
 Has to contain a valid database name.
 
-@RESTBODYPARAM{options,object,optional,get_api_database_new_USERS}
+@RESTBODYPARAM{options,object,optional,get_api_database_new_OPTIONS}
 Optional object which can contain the following attributes:
 
-@RESTSTRUCT{sharding,get_api_database_new_USERS,string,optional,string}
+@RESTSTRUCT{sharding,get_api_database_new_OPTIONS,string,optional,}
 The sharding method to use for new collections in this database. Valid values
 are: "", "flexible", or "single". The first two are equivalent. _(cluster only)_
 
-@RESTSTRUCT{replicationFactor,get_api_database_new_USERS,integer,optional,}
+@RESTSTRUCT{replicationFactor,get_api_database_new_OPTIONS,integer,optional,}
 Default replication factor for new collections created in this database.
 Special values include "satellite", which will replicate the collection to
 every DB-Server, and 1, which disables replication. _(cluster only)_
 
-@RESTSTRUCT{writeConcern,get_api_database_new_USERS,number,optional,}
+@RESTSTRUCT{writeConcern,get_api_database_new_OPTIONS,number,optional,}
 Default write concern for new collections created in this database.
 It determines how many copies of each shard are required to be
 in sync on the different DB-Servers. If there are less then these many copies
@@ -35,20 +35,20 @@ If *users* is not specified or does not contain any users, a default user
 new database will be accessible after it is created.
 Each user object can contain the following attributes:
 
-@RESTSTRUCT{username,get_api_database_new_USERS,string,required,string}
-Login name of the user to be created
+@RESTSTRUCT{username,get_api_database_new_USERS,string,required,}
+Login name of the user to be created.
 
-@RESTSTRUCT{passwd,get_api_database_new_USERS,string,required,string}
+@RESTSTRUCT{passwd,get_api_database_new_USERS,string,optional,password}
 The user password as a string. If not specified, it will default to an empty string.
 
-@RESTSTRUCT{active,get_api_database_new_USERS,boolean,required,}
+@RESTSTRUCT{active,get_api_database_new_USERS,boolean,optional,}
 A flag indicating whether the user account should be activated or not.
 The default value is *true*. If set to *false*, the user won't be able to
-log into the database.
+log into the database. The default is *true*.
 
 @RESTSTRUCT{extra,get_api_database_new_USERS,object,optional,}
-A JSON object with extra user information. The data contained in *extra*
-will be stored for the user but not be interpreted further by ArangoDB.
+A JSON object with extra user information. It is used by the web interface
+to store graph viewer settings and saved queries.
 
 @RESTDESCRIPTION
 Creates a new database


### PR DESCRIPTION
The HTTP API expects the following structure:

- name: "string"
- options: { ... }
- users: [ {...}, {...} ]

The DocuBlock used the same parent ID for both options and users, leading to duplicate entries in both property descriptions.

Also adjusting description to actual server behavior (passwd and active not required).

https://jenkins01.arangodb.biz/view/Documentation/job/arangodb-ANY-examples/653/