### PR TITLE
Do not store query opts

### DIFF
--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -80,7 +80,7 @@ using namespace arangodb::aql;
 /// @brief internal constructor, Used to construct a full query or a ClusterQuery
 Query::Query(std::shared_ptr<transaction::Context> const& ctx,
              QueryString const& queryString, std::shared_ptr<VPackBuilder> const& bindParameters,
-             std::shared_ptr<VPackBuilder> const& options,
+             aql::QueryOptions&& options,
              std::shared_ptr<SharedQueryState> sharedState)
     : QueryContext(ctx->vocbase()),
       _itemBlockManager(&_resourceMonitor, SerializationFormat::SHADOWROWS),
@@ -89,8 +89,7 @@ Query::Query(std::shared_ptr<transaction::Context> const& ctx,
       _sharedState(std::move(sharedState)),
       _v8Context(nullptr),
       _bindParameters(bindParameters),
-      _options(options),
-      _queryOptions(_vocbase.server().getFeature<QueryRegistryFeature>()),
+      _queryOptions(std::move(options)),
       _trx(nullptr),
       _startTime(currentSteadyClockValue()),
       _queryHash(DontCache),
@@ -110,11 +109,6 @@ Query::Query(std::shared_ptr<transaction::Context> const& ctx,
     if (state != nullptr) {
       _queryOptions.transactionOptions = state->options();
     }
-  }
-
-  // populate query options
-  if (_options != nullptr) {
-    _queryOptions.fromVelocyPack(_options->slice());
   }
 
   ProfileLevel level = _queryOptions.profile;
@@ -139,15 +133,17 @@ Query::Query(std::shared_ptr<transaction::Context> const& ctx,
     }
   }
 
-  if (options != nullptr && !options->isEmpty() && !options->slice().isNone()) {
-    if (level >= PROFILE_LEVEL_TRACE_1) {
-      LOG_TOPIC("8979d", INFO, Logger::QUERIES)
-          << "options: " << options->slice().toJson();
-    } else {
-      LOG_TOPIC("0b7cb", DEBUG, Logger::QUERIES)
-          << "options: " << options->slice().toJson();
-    }
-  }
+        
+#warning FIx
+//  if (options != nullptr && !options->isEmpty() && !options->slice().isNone()) {
+//    if (level >= PROFILE_LEVEL_TRACE_1) {
+//      LOG_TOPIC("8979d", INFO, Logger::QUERIES)
+//          << "options: " << options->slice().toJson();
+//    } else {
+//      LOG_TOPIC("0b7cb", DEBUG, Logger::QUERIES)
+//          << "options: " << options->slice().toJson();
+//    }
+//  }
 
   _resourceMonitor.setMemoryLimit(_queryOptions.memoryLimit);
   _warnings.updateOptions(_queryOptions);
@@ -156,8 +152,13 @@ Query::Query(std::shared_ptr<transaction::Context> const& ctx,
 /// @brief public constructor, Used to construct a full query
 Query::Query(std::shared_ptr<transaction::Context> const& ctx,
              QueryString const& queryString, std::shared_ptr<VPackBuilder> const& bindParameters,
+             QueryOptions&& options)
+    : Query(ctx, queryString, bindParameters, std::move(options), std::make_shared<SharedQueryState>()) {}
+
+Query::Query(std::shared_ptr<transaction::Context> const& ctx,
+             QueryString const& queryString, std::shared_ptr<VPackBuilder> const& bindParameters,
              std::shared_ptr<VPackBuilder> const& options)
-    : Query(ctx, queryString, bindParameters, options, std::make_shared<SharedQueryState>()) {}
+    : Query(ctx, queryString, bindParameters, QueryOptions(options != nullptr ? options->slice() : VPackSlice()), std::make_shared<SharedQueryState>()) {}
 
 /// @brief destroys a query
 Query::~Query() {
@@ -1054,14 +1055,17 @@ uint64_t Query::calculateHash() const {
     hashval = fasthash64(TRI_CHAR_LENGTH_PAIR("count:false"), hashval);
   }
 
-  // also hash "optimizer" options
-  VPackSlice options = arangodb::velocypack::Slice::emptyObjectSlice();
-
-  if (_options != nullptr && _options->slice().isObject()) {
-    options = _options->slice().get("optimizer");
+  // handle "optimizer.inspectSimplePlans" option
+  if (_queryOptions.inspectSimplePlans) {
+    hashval = fasthash64(TRI_CHAR_LENGTH_PAIR("inspect:true"), hashval);
+  } else {
+    hashval = fasthash64(TRI_CHAR_LENGTH_PAIR("inspect:false"), hashval);
   }
-  hashval ^= options.hash();
-
+  
+  // also hash "optimizer.rules" options
+  for (auto const& rule : _queryOptions.optimizerRules) {
+    hashval = VELOCYPACK_HASH(rule.data(), rule.size(), hashval);
+  }
   // blend query hash with bind parameters
   return hashval ^ _bindParameters.hash();
 }
@@ -1292,8 +1296,8 @@ ExecutionEngine* Query::rootEngine() const {
 }
 
 ClusterQuery::ClusterQuery(std::shared_ptr<transaction::Context> const& ctx,
-                           std::shared_ptr<arangodb::velocypack::Builder> const& options)
-    : Query(ctx, aql::QueryString(), /*bindParams*/ nullptr, options, 
+                           QueryOptions&& options)
+    : Query(ctx, aql::QueryString(), /*bindParams*/ nullptr, std::move(options),
             /*sharedState*/ ServerState::instance()->isDBServer() ? nullptr : std::make_shared<SharedQueryState>()) {}
 
 ClusterQuery::~ClusterQuery() {

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -133,17 +133,11 @@ Query::Query(std::shared_ptr<transaction::Context> const& ctx,
     }
   }
 
-        
-#warning FIx
-//  if (options != nullptr && !options->isEmpty() && !options->slice().isNone()) {
-//    if (level >= PROFILE_LEVEL_TRACE_1) {
-//      LOG_TOPIC("8979d", INFO, Logger::QUERIES)
-//          << "options: " << options->slice().toJson();
-//    } else {
-//      LOG_TOPIC("0b7cb", DEBUG, Logger::QUERIES)
-//          << "options: " << options->slice().toJson();
-//    }
-//  }
+  if (level >= PROFILE_LEVEL_TRACE_1) {
+    VPackBuilder b;
+    _queryOptions.toVelocyPack(b, /*disableOptimizerRules*/ false);
+    LOG_TOPIC("8979d", INFO, Logger::QUERIES) << "options: " << b.toJson();
+  }
 
   _resourceMonitor.setMemoryLimit(_queryOptions.memoryLimit);
   _warnings.updateOptions(_queryOptions);

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -82,11 +82,13 @@ class Query : public QueryContext {
   /// @brief internal constructor, Used to construct a full query or a ClusterQuery
   Query(std::shared_ptr<transaction::Context> const& ctx, QueryString const& queryString,
         std::shared_ptr<arangodb::velocypack::Builder> const& bindParameters,
-        std::shared_ptr<arangodb::velocypack::Builder> const& options,
-        std::shared_ptr<SharedQueryState> sharedState);
+        aql::QueryOptions&& options, std::shared_ptr<SharedQueryState> sharedState);
 
  public:
   /// @brief public constructor, Used to construct a full query
+  Query(std::shared_ptr<transaction::Context> const& ctx, QueryString const& queryString,
+        std::shared_ptr<arangodb::velocypack::Builder> const& bindParameters,
+        aql::QueryOptions&& options);
   Query(std::shared_ptr<transaction::Context> const& ctx, QueryString const& queryString,
         std::shared_ptr<arangodb::velocypack::Builder> const& bindParameters,
         std::shared_ptr<arangodb::velocypack::Builder> const& options);
@@ -107,8 +109,6 @@ class Query : public QueryContext {
   QueryString const& queryString() const { return _queryString; }
   
   QueryProfile* profile() const { return _profile.get(); }
-
-  velocypack::Slice optionsSlice() const { return _options->slice(); }
   
   TEST_VIRTUAL QueryOptions& queryOptions() { return _queryOptions; }
 
@@ -250,9 +250,6 @@ class Query : public QueryContext {
 
   /// @brief bind parameters for the query
   BindParameters _bindParameters;
-
-  /// @brief raw query options
-  std::shared_ptr<arangodb::velocypack::Builder> _options;
   
   /// @brief parsed query options
   QueryOptions _queryOptions;
@@ -314,7 +311,7 @@ class ClusterQuery final : public Query {
   
   /// Used to construct a full query
   ClusterQuery(std::shared_ptr<transaction::Context> const& ctx,
-               std::shared_ptr<arangodb::velocypack::Builder> const& options);
+               QueryOptions&& options);
   ~ClusterQuery();
   
   traverser::GraphEngineList const& traversers() const {

--- a/arangod/Aql/QueryOptions.cpp
+++ b/arangod/Aql/QueryOptions.cpp
@@ -35,19 +35,24 @@
 
 using namespace arangodb::aql;
 
-QueryOptions::QueryOptions(arangodb::QueryRegistryFeature& feature)
+size_t QueryOptions::defaultMemoryLimit = 0;
+size_t QueryOptions::defaultMaxNumberOfPlans = 128;
+double QueryOptions::defaultTtl;
+bool QueryOptions::defaultFailOnWarning;
+
+QueryOptions::QueryOptions()
     : memoryLimit(0),
-      maxNumberOfPlans(0),
+      maxNumberOfPlans(QueryOptions::defaultMaxNumberOfPlans),
       maxWarningCount(10),
       maxRuntime(0),
       satelliteSyncWait(60.0),
-      ttl(0),
+      ttl(QueryOptions::defaultTtl), // get global default ttl
       profile(PROFILE_LEVEL_NONE),
       allPlans(false),
       verbosePlans(false),
       stream(false),
       silent(false),
-      failOnWarning(false),
+      failOnWarning(QueryOptions::defaultFailOnWarning), // use global "failOnWarning" value
       cache(false),
       fullCount(false),
       count(false),
@@ -57,26 +62,23 @@ QueryOptions::QueryOptions(arangodb::QueryRegistryFeature& feature)
 {
   // now set some default values from server configuration options
   // use global memory limit value
-  uint64_t globalLimit = feature.queryMemoryLimit();
+  uint64_t globalLimit = QueryOptions::defaultMemoryLimit;
   if (globalLimit > 0) {
     memoryLimit = globalLimit;
   }
-
-  // get global default ttl
-  ttl = feature.registry()->defaultTTL();
-
-  // use global "failOnWarning" value
-  failOnWarning = feature.failOnWarning();
-
+  
   // "cache" only defaults to true if query cache is turned on
   auto queryCacheMode = QueryCache::instance()->mode();
   cache = (queryCacheMode == CACHE_ALWAYS_ON);
 
-  maxNumberOfPlans = feature.maxQueryPlans();
   TRI_ASSERT(maxNumberOfPlans > 0);
 }
 
-void QueryOptions::fromVelocyPack(VPackSlice const& slice) {
+QueryOptions::QueryOptions(arangodb::velocypack::Slice const slice) : QueryOptions() {
+  this->fromVelocyPack(slice);
+}
+
+void QueryOptions::fromVelocyPack(VPackSlice const slice) {
   if (!slice.isObject()) {
     return;
   }

--- a/arangod/Aql/QueryOptions.h
+++ b/arangod/Aql/QueryOptions.h
@@ -55,10 +55,11 @@ enum ProfileLevel : uint16_t {
 };
 
 struct QueryOptions {
-  explicit QueryOptions(QueryRegistryFeature&);
+  explicit QueryOptions();
+  explicit QueryOptions(arangodb::velocypack::Slice const);
   TEST_VIRTUAL ~QueryOptions() = default;
 
-  void fromVelocyPack(arangodb::velocypack::Slice const& slice);
+  void fromVelocyPack(arangodb::velocypack::Slice const slice);
   void toVelocyPack(arangodb::velocypack::Builder&, bool disableOptimizerRules) const;
   TEST_VIRTUAL ProfileLevel getProfileLevel() const { return profile; }
 
@@ -99,6 +100,11 @@ struct QueryOptions {
 #endif
 
   transaction::Options transactionOptions;
+  
+  static size_t defaultMemoryLimit;
+  static size_t defaultMaxNumberOfPlans;
+  static double defaultTtl;
+  static bool defaultFailOnWarning;
 };
 
 }  // namespace aql

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -65,29 +65,6 @@ RestAqlHandler::RestAqlHandler(application_features::ApplicationServer& server,
   TRI_ASSERT(_queryRegistry != nullptr);
 }
 
-std::pair<double, std::shared_ptr<VPackBuilder>> RestAqlHandler::getPatchedOptionsWithTTL(
-    VPackSlice const& optionsSlice) const {
-  auto options = std::make_shared<VPackBuilder>();
-  double ttl = _queryRegistry->defaultTTL();
-  {
-    VPackObjectBuilder guard(options.get());
-    TRI_ASSERT(optionsSlice.isObject());
-    for (auto pair : VPackObjectIterator(optionsSlice)) {
-      if (pair.key.isEqualString("ttl")) {
-        ttl = VelocyPackHelper::getNumericValue<double>(optionsSlice, "ttl", ttl);
-        ttl = _request->parsedValue<double>("ttl", ttl);
-        if (ttl <= 0) {
-          ttl = _queryRegistry->defaultTTL();
-        }
-        options->add("ttl", VPackValue(ttl));
-      } else {
-        options->add(pair.key.stringRef(), pair.value);
-      }
-    }
-  }
-  return std::make_pair(ttl, options);
-}
-
 // POST method for /_api/aql/setup (internal)
 // Only available on DBServers in the Cluster.
 // This route sets-up all the query engines required
@@ -200,11 +177,13 @@ void RestAqlHandler::setupClusterQuery() {
   //   "WRITE"} ], initialize: false, nodes: <one of snippets[*].value>,
   //   variables: <variables slice>
   // }
+  
+  QueryOptions options(optionsSlice);
+  if (options.ttl <= 0) { // patch TTL value
+    options.ttl = _queryRegistry->defaultTTL();
+  }
 
-  std::shared_ptr<VPackBuilder> options;
-  double ttl;
-  std::tie(ttl, options) = getPatchedOptionsWithTTL(optionsSlice);
-
+  // TODO: technically we could change the code in
   // Build the collection information
   VPackBuilder collectionBuilder;
   collectionBuilder.openArray();
@@ -238,9 +217,11 @@ void RestAqlHandler::setupClusterQuery() {
   }
   collectionBuilder.close();
   
+  
   // simon: making this write breaks queries where DOCUMENT function
   // is used in a coordinator-snippet above a DBServer-snippet
   AccessMode::Type access = AccessMode::Type::READ;
+  const double ttl = options.ttl;
   // creates a StandaloneContext or a leased context
   auto q = std::make_unique<ClusterQuery>(createTransactionContext(access),
                                           std::move(options));

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -183,7 +183,8 @@ void RestAqlHandler::setupClusterQuery() {
     options.ttl = _queryRegistry->defaultTTL();
   }
 
-  // TODO: technically we could change the code in
+  // TODO: technically we could change the code in prepareClusterQuery to parse
+  //       the collection info directly
   // Build the collection information
   VPackBuilder collectionBuilder;
   collectionBuilder.openArray();

--- a/arangod/Aql/RestAqlHandler.h
+++ b/arangod/Aql/RestAqlHandler.h
@@ -140,9 +140,6 @@ class RestAqlHandler : public RestVocbaseBaseHandler {
   // dig out vocbase from context and query from ID, handle errors
   ExecutionEngine* findEngine(std::string const& idString);
 
-  // generate patched options with TTL extracted from request
-  std::pair<double, std::shared_ptr<VPackBuilder>> getPatchedOptionsWithTTL(VPackSlice const& optionsSlice) const;
-
   // our query registry
   QueryRegistry* _queryRegistry;
 

--- a/arangod/RestServer/QueryRegistryFeature.cpp
+++ b/arangod/RestServer/QueryRegistryFeature.cpp
@@ -161,6 +161,7 @@ void QueryRegistryFeature::validateOptions(std::shared_ptr<ProgramOptions> optio
   _maxQueryPlans = std::min(_maxQueryPlans, decltype(_maxQueryPlans)(1024));
   
   if (_queryRegistryTTL <= 0) {
+    TRI_ASSERT(ServerState::instance()->getRole() != ServerState::ROLE_UNDEFINED);
     // set to default value based on instance type
     _queryRegistryTTL = ServerState::instance()->isSingleServer() ? 30 : 600;
   }

--- a/arangod/RestServer/QueryRegistryFeature.cpp
+++ b/arangod/RestServer/QueryRegistryFeature.cpp
@@ -46,12 +46,12 @@ QueryRegistryFeature::QueryRegistryFeature(application_features::ApplicationServ
     : ApplicationFeature(server, "QueryRegistry"),
       _trackSlowQueries(true),
       _trackBindVars(true),
-      _failOnWarning(false),
+      _failOnWarning(aql::QueryOptions::defaultFailOnWarning),
       _queryCacheIncludeSystem(false),
       _smartJoins(true),
       _parallelizeTraversals(true),
-      _queryMemoryLimit(0),
-      _maxQueryPlans(128),
+      _queryMemoryLimit(aql::QueryOptions::defaultMemoryLimit),
+      _maxQueryPlans(aql::QueryOptions::defaultMaxNumberOfPlans),
       _queryCacheMaxResultsCount(0),
       _queryCacheMaxResultsSize(0),
       _queryCacheMaxEntrySize(0),
@@ -159,6 +159,16 @@ void QueryRegistryFeature::validateOptions(std::shared_ptr<ProgramOptions> optio
 
   // cap the value somehow. creating this many plans really does not make sense
   _maxQueryPlans = std::min(_maxQueryPlans, decltype(_maxQueryPlans)(1024));
+  
+  if (_queryRegistryTTL <= 0) {
+    // set to default value based on instance type
+    _queryRegistryTTL = ServerState::instance()->isSingleServer() ? 30 : 600;
+  }
+  
+  aql::QueryOptions::defaultMemoryLimit = _queryMemoryLimit;
+  aql::QueryOptions::defaultMaxNumberOfPlans = _maxQueryPlans;
+  aql::QueryOptions::defaultTtl = _queryRegistryTTL;
+  aql::QueryOptions::defaultFailOnWarning = _failOnWarning;
 }
 
 void QueryRegistryFeature::prepare() {
@@ -176,12 +186,6 @@ void QueryRegistryFeature::prepare() {
                                                  _queryCacheIncludeSystem,
                                                  _trackBindVars};
   arangodb::aql::QueryCache::instance()->properties(properties);
-
-  if (_queryRegistryTTL <= 0) {
-    // set to default value based on instance type
-    _queryRegistryTTL = ServerState::instance()->isSingleServer() ? 30 : 600;
-  }
-
   // create the query registery
   _queryRegistry.reset(new aql::QueryRegistry(_queryRegistryTTL));
   QUERY_REGISTRY.store(_queryRegistry.get(), std::memory_order_release);

--- a/arangod/V8Server/v8-vocbase.cpp
+++ b/arangod/V8Server/v8-vocbase.cpp
@@ -705,7 +705,8 @@ static void JS_ExecuteAqlJson(v8::FunctionCallbackInfo<v8::Value> const& args) {
     }
   }
 
-  arangodb::aql::ClusterQuery query(transaction::V8Context::Create(vocbase, true), options);
+  arangodb::aql::ClusterQuery query(transaction::V8Context::Create(vocbase, true),
+                                    aql::QueryOptions(options->slice()));
   
   VPackSlice collections = queryBuilder->slice().get("collections");
   VPackSlice variables = queryBuilder->slice().get("variables");


### PR DESCRIPTION
Do not store the query options redundantly in a builder object

http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/11090/