### PR TITLE
Make maximum query parallelism configurable.

### DIFF
--- a/arangod/Aql/ExecutionEngine.cpp
+++ b/arangod/Aql/ExecutionEngine.cpp
@@ -186,13 +186,14 @@ Result ExecutionEngine::createBlocks(std::vector<ExecutionNode*> const& nodes,
 }
 
 /// @brief create the engine
-ExecutionEngine::ExecutionEngine(QueryContext& query,
-                                 AqlItemBlockManager& itemBlockMgr,
+ExecutionEngine::ExecutionEngine(QueryContext& query, AqlItemBlockManager& itemBlockMgr,
                                  SerializationFormat format,
                                  std::shared_ptr<SharedQueryState> sqs)
     : _query(query),
       _itemBlockManager(itemBlockMgr),
-      _sharedState((sqs != nullptr) ? std::move(sqs) : std::make_shared<SharedQueryState>()),
+      _sharedState((sqs != nullptr)
+                       ? std::move(sqs)
+                       : std::make_shared<SharedQueryState>(query.vocbase().server())),
       _blocks(),
       _root(nullptr),
       _resultRegister(0),

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -154,10 +154,11 @@ Query::Query(std::shared_ptr<transaction::Context> const& ctx,
 }
 
 /// @brief public constructor, Used to construct a full query
-Query::Query(std::shared_ptr<transaction::Context> const& ctx,
-             QueryString const& queryString, std::shared_ptr<VPackBuilder> const& bindParameters,
+Query::Query(std::shared_ptr<transaction::Context> const& ctx, QueryString const& queryString,
+             std::shared_ptr<VPackBuilder> const& bindParameters,
              std::shared_ptr<VPackBuilder> const& options)
-    : Query(ctx, queryString, bindParameters, options, std::make_shared<SharedQueryState>()) {}
+    : Query(ctx, queryString, bindParameters, options,
+            std::make_shared<SharedQueryState>(ctx->vocbase().server())) {}
 
 /// @brief destroys a query
 Query::~Query() {
@@ -1293,8 +1294,10 @@ ExecutionEngine* Query::rootEngine() const {
 
 ClusterQuery::ClusterQuery(std::shared_ptr<transaction::Context> const& ctx,
                            std::shared_ptr<arangodb::velocypack::Builder> const& options)
-    : Query(ctx, aql::QueryString(), /*bindParams*/ nullptr, options, 
-            /*sharedState*/ ServerState::instance()->isDBServer() ? nullptr : std::make_shared<SharedQueryState>()) {}
+    : Query(ctx, aql::QueryString(), /*bindParams*/ nullptr, options,
+            /*sharedState*/ ServerState::instance()->isDBServer()
+                ? nullptr
+                : std::make_shared<SharedQueryState>(ctx->vocbase().server())) {}
 
 ClusterQuery::~ClusterQuery() {
   try {

--- a/arangod/Aql/SharedQueryState.cpp
+++ b/arangod/Aql/SharedQueryState.cpp
@@ -22,17 +22,26 @@
 
 #include "SharedQueryState.h"
 
+#include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/Exceptions.h"
 #include "Basics/ScopeGuard.h"
+#include "RestServer/QueryRegistryFeature.h"
 #include "Scheduler/Scheduler.h"
 #include "Scheduler/SchedulerFeature.h"
+#include "Transaction/Context.h"
+#include "VocBase/vocbase.h"
 
 using namespace arangodb;
 using namespace arangodb::aql;
 
-SharedQueryState::SharedQueryState()
-  : _wakeupCb(nullptr), _numWakeups(0),
-    _cbVersion(0), _numTasks(0), _valid(true) {}
+SharedQueryState::SharedQueryState(application_features::ApplicationServer& server)
+    : _server(server),
+      _wakeupCb(nullptr),
+      _numWakeups(0),
+      _cbVersion(0),
+      _maxTasks(_server.getFeature<QueryRegistryFeature>().maxParallelism()),
+      _numTasks(0),
+      _valid(true) {}
 
 void SharedQueryState::invalidate() {
   {

--- a/arangod/Aql/SharedQueryState.h
+++ b/arangod/Aql/SharedQueryState.h
@@ -28,6 +28,9 @@
 #include <function2.hpp>
 
 namespace arangodb {
+namespace application_features {
+class ApplicationServer;
+}
 namespace aql {
 
 class SharedQueryState final : public std::enable_shared_from_this<SharedQueryState> {
@@ -35,7 +38,8 @@ class SharedQueryState final : public std::enable_shared_from_this<SharedQuerySt
   SharedQueryState(SharedQueryState const&) = delete;
   SharedQueryState& operator=(SharedQueryState const&) = delete;
 
-  SharedQueryState();
+  explicit SharedQueryState(application_features::ApplicationServer& server);
+  SharedQueryState() = delete;
   ~SharedQueryState() = default;
 
   void invalidate();
@@ -129,6 +133,7 @@ class SharedQueryState final : public std::enable_shared_from_this<SharedQuerySt
   bool queueAsyncTask(fu2::unique_function<void()>);
 
  private:
+  application_features::ApplicationServer& _server;
   mutable std::mutex _mutex;
   std::condition_variable _cv;
 
@@ -141,7 +146,7 @@ class SharedQueryState final : public std::enable_shared_from_this<SharedQuerySt
   unsigned _cbVersion; // increased once callstack is done
   
   // TODO: make configurable
-  const unsigned _maxTasks = 4;
+  const unsigned _maxTasks;
   std::atomic<unsigned> _numTasks;
   std::atomic<bool> _valid;
 };

--- a/arangod/RestServer/QueryRegistryFeature.h
+++ b/arangod/RestServer/QueryRegistryFeature.h
@@ -56,6 +56,7 @@ class QueryRegistryFeature final : public application_features::ApplicationFeatu
   uint64_t queryMemoryLimit() const { return _queryMemoryLimit; }
   uint64_t maxQueryPlans() const { return _maxQueryPlans; }
   aql::QueryRegistry* queryRegistry() const { return _queryRegistry.get(); }
+  uint64_t maxParallelism() const { return _maxParallelism; }
 
  private:
   bool _trackSlowQueries;
@@ -69,6 +70,7 @@ class QueryRegistryFeature final : public application_features::ApplicationFeatu
   uint64_t _queryCacheMaxResultsCount;
   uint64_t _queryCacheMaxResultsSize;
   uint64_t _queryCacheMaxEntrySize;
+  uint64_t _maxParallelism;
   double _slowQueryThreshold;
   double _slowStreamingQueryThreshold;
   double _queryRegistryTTL;


### PR DESCRIPTION
### Scope & Purpose

Some queries can take advantage of internal structure (currently only traversals) to run portions of the query in parallel. Currently there is a hard limit of on the maximum number of threads per query (4). This PR makes this configurable at the server level with a hidden option (but does not change the default of 4).