### PR TITLE
fix spurious "lock timeout" errors when restoring collections

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fix spurious lock timeout errors when restoring collections.
+
 * Make sure cluster statistics in web UI work in case a coordinator is down.
 
 * Updated arangosync to 0.7.8.

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1071,7 +1071,7 @@ Result RestReplicationHandler::processRestoreCollection(VPackSlice const& collec
           return server().getFeature<iresearch::IResearchAnalyzerFeature>().removeAllAnalyzers(_vocbase);
         }
 
-        auto dropResult = methods::Collections::drop(*col, true, 0.0, true);
+        auto dropResult = methods::Collections::drop(*col, true, 300.0, true);
         if (dropResult.fail()) {
           if (dropResult.is(TRI_ERROR_FORBIDDEN) || dropResult.is(TRI_ERROR_CLUSTER_MUST_NOT_DROP_COLL_OTHER_DISTRIBUTESHARDSLIKE)) {
             // If we are not allowed to drop the collection.


### PR DESCRIPTION
### Scope & Purpose

Fix spurious "lock timeout" errors that were observed during dump/restore tests.
Affects 3.7 and devel only.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11115/