### PR TITLE
Revert "avoid throwing exception in fuerte"

### DIFF
--- a/3rdParty/fuerte/src/AsioSockets.h
+++ b/3rdParty/fuerte/src/AsioSockets.h
@@ -125,22 +125,18 @@ struct Socket<fuerte::SocketType::Ssl> {
             return;
           }
 
-          try {
-            // Perform SSL handshake and verify the remote host's certificate.
-            socket.next_layer().set_option(asio_ns::ip::tcp::no_delay(true));
-            if (verify) {
-              socket.set_verify_mode(asio_ns::ssl::verify_peer);
-              socket.set_verify_callback(
-                  asio_ns::ssl::rfc2818_verification(config._host));
-            } else {
-              socket.set_verify_mode(asio_ns::ssl::verify_none);
-            }
-            socket.async_handshake(asio_ns::ssl::stream_base::client,
-                                   std::move(done));
-            
-          } catch(boost::system::system_error const& exc) {
-            done(exc.code());
+          // Perform SSL handshake and verify the remote host's certificate.
+          socket.next_layer().set_option(asio_ns::ip::tcp::no_delay(true));
+          if (verify) {
+            socket.set_verify_mode(asio_ns::ssl::verify_peer);
+            socket.set_verify_callback(
+                asio_ns::ssl::rfc2818_verification(config._host));
+          } else {
+            socket.set_verify_mode(asio_ns::ssl::verify_none);
           }
+
+          socket.async_handshake(asio_ns::ssl::stream_base::client,
+                                 std::move(done));
         });
   }
 


### PR DESCRIPTION
Reverts arangodb/arangodb#12259 as not safe.