### PR TITLE
Revive faster out-of-range comparator for secondary index scans

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Revive faster out-of-range comparator for secondary index scans that do a full 
+  collection index scan for index types "hash", "skiplist", "persistent". 
+
 * Fixed internal issue #733: Primary sort compression in views now used properly.
 
 * Fix spurious lock timeout errors when restoring collections.

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -181,6 +181,7 @@ class RocksDBVPackIndexIterator final : public IndexIterator {
         _index(index),
         _cmp(static_cast<RocksDBVPackComparator const*>(index->comparator())),
         _bounds(std::move(bounds)),
+        _fullEnumerationObjectId(0),
         _mustSeek(true) {
     TRI_ASSERT(index->columnFamily() == RocksDBColumnFamily::vpack());
 
@@ -191,9 +192,21 @@ class RocksDBVPackIndexIterator final : public IndexIterator {
     if constexpr (reverse) {
       _rangeBound = _bounds.start();
       options.iterate_lower_bound = &_rangeBound;
+      VPackSlice s = VPackSlice(reinterpret_cast<uint8_t const*>(_rangeBound.data() + sizeof(uint64_t)));
+      if (s.isArray() && s.length() == 1 && s.at(0).isMinKey()) {
+        // lower bound is the min key. that means we can get away with a
+        // cheap outOfBounds comparator
+        _fullEnumerationObjectId = _index->objectId();
+      }
     } else {
       _rangeBound = _bounds.end();
       options.iterate_upper_bound = &_rangeBound;
+      VPackSlice s = VPackSlice(reinterpret_cast<uint8_t const*>(_rangeBound.data() + sizeof(uint64_t)));
+      if (s.isArray() && s.length() == 1 && s.at(0).isMaxKey()) {
+        // upper bound is the max key. that means we can get away with a
+        // cheap outOfBounds comparator
+        _fullEnumerationObjectId = _index->objectId();
+      }
     }
 
     TRI_ASSERT(options.prefix_same_as_start);
@@ -306,7 +319,16 @@ class RocksDBVPackIndexIterator final : public IndexIterator {
 
  private:
   inline bool outOfRange() const {
-    // we are enumerating a subset of the index
+    if (_fullEnumerationObjectId) {
+      // we are enumerating the entire index range for a collection,
+      // so we can use a cheap comparator that only checks the index' objectId.
+      // there is no need to do a function call into the comparator here 
+      // (even though its type is know here), or to compare the 
+      // indexed velocypack values at all.
+      return (arangodb::rocksutils::uint64FromPersistent(_iterator->key().data()) != _fullEnumerationObjectId);
+    }
+
+    // we are enumerating a subset of the index values of a collection
     // so we really need to run the full-featured (read: expensive)
     // comparator
 
@@ -347,6 +369,7 @@ class RocksDBVPackIndexIterator final : public IndexIterator {
   RocksDBKeyBounds _bounds;
   // used for iterate_upper_bound iterate_lower_bound
   rocksdb::Slice _rangeBound;
+  uint64_t _fullEnumerationObjectId;
   bool _mustSeek;
 };
 


### PR DESCRIPTION
### Scope & Purpose

Revive faster out-of-range comparator for secondary index scans that do a full collection index scan for index types "hash", "skiplist", "persistent". There is a performance gain of a few percent when running a query on a local collection with 1M entries, e.g. `FOR doc IN collection RETURN doc.value` (where `value` is indexed).

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *shell_server_aql*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11167/