### PR TITLE
Revive faster out-of-range comparator for secondary index scans

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
+* Revive faster out-of-range comparator for secondary index scans that do a full
+  collection index scan for index types "hash", "skiplist", "persistent".
+
 * Conflict error codes (1200) will now use the proper error message instead of a
   generic and misleading "precondition failed".
 


### PR DESCRIPTION
### Scope & Purpose

Revive faster out-of-range comparator for secondary index scans that do a full collection index scan for index types "hash", "skiplist", "persistent". There is a performance gain of a few percent when running a query on a local collection with 1M entries, e.g. `FOR doc IN collection RETURN doc.value` (where `value` is indexed).

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *shell_server_aql*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11168/