### PR TITLE
Bug fix 3.7/invalid memory management in collect

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,18 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
+* Fixed undefined behaviour in AQL COLLECT with multiple group variables.
+  If you are grouping on "large" values that occur multiple times in different
+  groups, and two different groups with the same large value are written
+  to different batches in the output then the memory could be invalid.
+  e.g. the following query is affected:
+  ```
+  FOR d IN documents
+  FOR batchSizeFiller IN 1..1001
+  COLLECT largeVal = d.largeValue, t = batchSizeFiller
+  RETURN 1
+  ```
+
 * Revive faster out-of-range comparator for secondary index scans that do a full
   collection index scan for index types "hash", "skiplist", "persistent".
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
-* Fixed undefined behaviour in AQL COLLECT with multiple group variables.
+* Fixed undefined behavior in AQL COLLECT with multiple group variables.
   If you are grouping on "large" values that occur multiple times in different
   groups, and two different groups with the same large value are written
   to different batches in the output then the memory could be invalid.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,11 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
-* Fixed undefined behavior in AQL COLLECT with multiple group variables.
+* Fixed undefined behavior in AQL COLLECT with multiple group variables (issue
+  #12267).
   If you are grouping on "large" values that occur multiple times in different
-  groups, and two different groups with the same large value are written
-  to different batches in the output then the memory could be invalid.
+  groups, and two different groups with the same large value are written to
+  different batches in the output then the memory could be invalid.
   e.g. the following query is affected:
   ```
   FOR d IN documents

--- a/arangod/Aql/HashedCollectExecutor.cpp
+++ b/arangod/Aql/HashedCollectExecutor.cpp
@@ -333,7 +333,7 @@ decltype(HashedCollectExecutor::_allGroups)::iterator HashedCollectExecutor::fin
       // So this block is responsible for every grouped tuple, until it
       // is handed over to the output block. There is no overlapping
       // of responsibilities of tuples.
-      _nextGroupValues.emplace_back(input.stealValue(reg.second).clone());
+      _nextGroupValues.emplace_back(input.getValue(reg.second).clone());
     }
   }
 

--- a/arangod/Aql/HashedCollectExecutor.cpp
+++ b/arangod/Aql/HashedCollectExecutor.cpp
@@ -314,11 +314,29 @@ decltype(HashedCollectExecutor::_allGroups)::iterator HashedCollectExecutor::fin
   }
 
   _nextGroupValues.clear();
-  // for inserting into group we need to clone the values
-  // and take over ownership
-  for (auto const& reg : _infos.getGroupRegisters()) {
-    _nextGroupValues.emplace_back(input.stealValue(reg.second));
+
+  if (_infos.getGroupRegisters().size() == 1) {
+    for (auto const& reg : _infos.getGroupRegisters()) {
+      // On a single register there can be no duplicate value
+      // inside the groupValues, so we cannot get into a situation
+      // where it is unclear who is responsible for the data
+      _nextGroupValues.emplace_back(input.stealValue(reg.second));
+    }
+  } else {
+    for (auto const& reg : _infos.getGroupRegisters()) {
+      // With more then 1 register we cannot reliably figure out who
+      // is responsible for which value.
+      // E.g. for 2 registers we have two groups: A , 1 and A , 2
+      // Now A can be from different input blocks, and can be also
+      // be written to different output blocks, or even not handed over
+      // because of a limit. So we simply clone A here on every new group.
+      // So this block is responsible for every grouped tuple, until it
+      // is handed over to the output block. There is no overlapping
+      // of responsibilities of tuples.
+      _nextGroupValues.emplace_back(input.stealValue(reg.second).clone());
+    }
   }
+
   // this builds a new group with aggregate functions being prepared.
   auto aggregateValues = std::make_unique<AggregateValuesType>();
   aggregateValues->reserve(_aggregatorFactories.size());

--- a/arangod/Aql/HashedCollectExecutor.cpp
+++ b/arangod/Aql/HashedCollectExecutor.cpp
@@ -320,7 +320,10 @@ decltype(HashedCollectExecutor::_allGroups)::iterator HashedCollectExecutor::fin
       // On a single register there can be no duplicate value
       // inside the groupValues, so we cannot get into a situation
       // where it is unclear who is responsible for the data
+      AqlValue a = input.stealValue(reg.second);
+      AqlValueGuard guard{a, true};
       _nextGroupValues.emplace_back(input.stealValue(reg.second));
+      guard.steal();
     }
   } else {
     for (auto const& reg : _infos.getGroupRegisters()) {
@@ -333,7 +336,10 @@ decltype(HashedCollectExecutor::_allGroups)::iterator HashedCollectExecutor::fin
       // So this block is responsible for every grouped tuple, until it
       // is handed over to the output block. There is no overlapping
       // of responsibilities of tuples.
-      _nextGroupValues.emplace_back(input.getValue(reg.second).clone());
+      AqlValue a = input.getValue(reg.second).clone();
+      AqlValueGuard guard{a, true};
+      _nextGroupValues.emplace_back(a);
+      guard.steal();
     }
   }
 

--- a/arangod/Aql/HashedCollectExecutor.cpp
+++ b/arangod/Aql/HashedCollectExecutor.cpp
@@ -322,7 +322,7 @@ decltype(HashedCollectExecutor::_allGroups)::iterator HashedCollectExecutor::fin
       // where it is unclear who is responsible for the data
       AqlValue a = input.stealValue(reg.second);
       AqlValueGuard guard{a, true};
-      _nextGroupValues.emplace_back(input.stealValue(reg.second));
+      _nextGroupValues.emplace_back(a);
       guard.steal();
     }
   } else {


### PR DESCRIPTION
Backport of https://github.com/arangodb/arangodb/pull/12271
Fixes: https://github.com/arangodb/arangodb/issues/12267

In case of Large values collected in multiple groups the memory management was incorrect, and a value could be freed although it is still in use. Which causes undefined behavior.

Jenkins:
http://jenkins.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/11195/