### PR TITLE
Bug fix 3.5/invalid memory management in collect

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,18 @@
 v3.5.6 (XXXX-XX-XX)
 -------------------
 
+* Fixed undefined behaviour in AQL COLLECT with multiple group variables.
+  If you are grouping on "large" values that occur multiple times in different
+  groups, and two different groups with the same large value are written
+  to different batches in the output then the memory could be invalid.
+  e.g. the following query is affected:
+  ```
+  FOR d IN documents
+  FOR batchSizeFiller IN 1..1001
+  COLLECT largeVal = d.largeValue, t = batchSizeFiller
+  RETURN 1
+  ```
+
 * Updated arangosync to 0.7.8.
 
 * Added missing state rollback for failed attempt-based write locking of spin

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.5.6 (XXXX-XX-XX)
 -------------------
 
-* Fixed undefined behaviour in AQL COLLECT with multiple group variables.
+* Fixed undefined behavior in AQL COLLECT with multiple group variables.
   If you are grouping on "large" values that occur multiple times in different
   groups, and two different groups with the same large value are written
   to different batches in the output then the memory could be invalid.

--- a/arangod/Aql/HashedCollectExecutor.cpp
+++ b/arangod/Aql/HashedCollectExecutor.cpp
@@ -270,7 +270,10 @@ decltype(HashedCollectExecutor::_allGroups)::iterator HashedCollectExecutor::fin
       // On a single register there can be no duplicate value
       // inside the groupValues, so we cannot get into a situation
       // where it is unclear who is responsible for the data
+      AqlValue a = input.stealValue(reg.second);
+      AqlValueGuard guard{a, true};
       _nextGroupValues.emplace_back(input.stealValue(reg.second));
+      guard.steal();
     }
   } else {
     for (auto const& reg : _infos.getGroupRegisters()) {
@@ -283,7 +286,10 @@ decltype(HashedCollectExecutor::_allGroups)::iterator HashedCollectExecutor::fin
       // So this block is responsible for every grouped tuple, until it
       // is handed over to the output block. There is no overlapping
       // of responsibilities of tuples.
-      _nextGroupValues.emplace_back(input.getValue(reg.second).clone());
+      AqlValue a = input.getValue(reg.second).clone();
+      AqlValueGuard guard{a, true};
+      _nextGroupValues.emplace_back(a);
+      guard.steal();
     }
   }
 

--- a/arangod/Aql/HashedCollectExecutor.cpp
+++ b/arangod/Aql/HashedCollectExecutor.cpp
@@ -283,7 +283,7 @@ decltype(HashedCollectExecutor::_allGroups)::iterator HashedCollectExecutor::fin
       // So this block is responsible for every grouped tuple, until it
       // is handed over to the output block. There is no overlapping
       // of responsibilities of tuples.
-      _nextGroupValues.emplace_back(input.stealValue(reg.second).clone());
+      _nextGroupValues.emplace_back(input.getValue(reg.second).clone());
     }
   }
 

--- a/arangod/Aql/HashedCollectExecutor.cpp
+++ b/arangod/Aql/HashedCollectExecutor.cpp
@@ -272,7 +272,7 @@ decltype(HashedCollectExecutor::_allGroups)::iterator HashedCollectExecutor::fin
       // where it is unclear who is responsible for the data
       AqlValue a = input.stealValue(reg.second);
       AqlValueGuard guard{a, true};
-      _nextGroupValues.emplace_back(input.stealValue(reg.second));
+      _nextGroupValues.emplace_back(a);
       guard.steal();
     }
   } else {

--- a/tests/js/server/aql/aql-optimizer-collect-methods.js
+++ b/tests/js/server/aql/aql-optimizer-collect-methods.js
@@ -539,6 +539,49 @@ function optimizerCollectMethodsTestSuite () {
       
       var result = AQL_EXECUTE(query).json;
       assertEqual([ 1001, 1002 ], result);
+    },
+  
+////////////////////////////////////////////////////////////////////////////////
+/// @brief regression test external memory management
+////////////////////////////////////////////////////////////////////////////////
+ 
+    testRegressionMemoryManagementInHashedCollect : function () {
+      // This query triggers the following case:
+      // We have large input documents in `doc` which require
+      // non-inlined AQL values.
+      // Now we go above batch sizes with other values
+      // This way we have external management that needs
+      // to be manged accross different input and output blocks of AQL
+      const query = `
+        FOR doc IN ${c.name()}
+          LIMIT 2
+          FOR other IN 1..1001
+            COLLECT d = doc, o = other
+            RETURN 1`;
+      const res = db._query(query).toArray();
+      // We do not care for the result,
+      // ASAN would figure out invalid memory access here.
+      assertEqual(2002, res.length);
+    },
+
+    testRegressionMemoryManagementInSortedCollect : function () {
+      // This query triggers the following case:
+      // We have large input documents in `doc` which require
+      // non-inlined AQL values.
+      // Now we go above batch sizes with other values
+      // This way we have external management that needs
+      // to be manged accross different input and output blocks of AQL
+      const query = `
+        FOR doc IN ${c.name()}
+          LIMIT 2
+          FOR other IN 1..1001
+            SORT doc, other
+            COLLECT d = doc, o = other
+            RETURN 1`;
+      const res = db._query(query).toArray();
+      // We do not care for the result,
+      // ASAN would figure out invalid memory access here.
+      assertEqual(2002, res.length);
     }
   
   };


### PR DESCRIPTION
Backport of https://github.com/arangodb/arangodb/pull/12271
Fixes: https://github.com/arangodb/arangodb/issues/12267

In case of Large values collected in multiple groups the memory management was incorrect, and a value could be freed although it is still in use. Which causes undefined behavior.

Jenkins:
http://jenkins.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/11197/