### PR TITLE
try @graetzer's suggestion

### DIFF
--- a/arangod/Aql/AqlItemBlock.cpp
+++ b/arangod/Aql/AqlItemBlock.cpp
@@ -32,6 +32,7 @@
 #include "Aql/SharedAqlItemBlockPtr.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/VelocyPackHelper.h"
+#include "Containers/HashSet.h"
 #include "Transaction/Context.h"
 #include "Transaction/Methods.h"
 
@@ -44,21 +45,15 @@ using namespace arangodb::aql;
 
 using VelocyPackHelper = arangodb::basics::VelocyPackHelper;
 
-/// @brief an unordered_set with an optimized hash and compare function.
-/// can only be used for AqlValues with dynamic memory allocation.
-using AqlValueCache = std::unordered_set<AqlValue, AqlValue::SimpleHash, AqlValue::SimpleEqual>;
-
 namespace {
-// T will be std::unordered_set<AqlValue> with or without specialized comparators
-template<typename T>
-inline void copyValueOver(T& cache, 
+inline void copyValueOver(arangodb::containers::HashSet<void*>& cache, 
                           AqlValue const& a,
                           size_t rowNumber, 
                           RegisterId col, 
                           SharedAqlItemBlockPtr& res) {
   if (!a.isEmpty()) {
     if (a.requiresDestruction()) {
-      auto it = cache.find(a);
+      auto it = cache.find(a.data());
 
       if (it == cache.end()) {
         AqlValue b = a.clone();
@@ -68,9 +63,9 @@ inline void copyValueOver(T& cache,
           b.destroy();
           throw;
         }
-        cache.emplace(b);
+        cache.emplace(b.data());
       } else {
-        res->setValue(rowNumber, col, (*it));
+        res->setValue(rowNumber, col, AqlValue(a.type(), (*it)));
       }
     } else {
       res->setValue(rowNumber, col, a);
@@ -81,8 +76,7 @@ inline void copyValueOver(T& cache,
 
 /// @brief create the block
 AqlItemBlock::AqlItemBlock(AqlItemBlockManager& manager, size_t nrItems, RegisterCount nrRegs)
-    : _valueCount(0, AqlValue::SimpleHash(), AqlValue::SimpleEqual()),
-      _nrItems(nrItems), _nrRegs(nrRegs), _manager(manager), _refCount(0), _rowIndex(0) {
+    : _nrItems(nrItems), _nrRegs(nrRegs), _manager(manager), _refCount(0), _rowIndex(0) {
   TRI_ASSERT(nrItems > 0);  // empty AqlItemBlocks are not allowed!
   // check that the nrRegs value is somewhat sensible
   // this compare value is arbitrary, but having so many registers in a single
@@ -317,7 +311,7 @@ void AqlItemBlock::destroy() noexcept {
     for (size_t i = 0; i < n; i++) {
       auto& it = _data[i];
       if (it.requiresDestruction()) {
-        auto it2 = _valueCount.find(it);
+        auto it2 = _valueCount.find(it.data());
         if (it2 != _valueCount.end()) {  // if we know it, we are still responsible
           auto& valueInfo = (*it2).second;
           TRI_ASSERT(valueInfo.refCount > 0);
@@ -375,7 +369,7 @@ void AqlItemBlock::shrink(size_t nrItems) {
   for (size_t i = n; i < _data.size(); ++i) {
     AqlValue& a = _data[i];
     if (a.requiresDestruction()) {
-      auto it = _valueCount.find(a);
+      auto it = _valueCount.find(a.data());
 
       if (it != _valueCount.end()) {
         auto& valueInfo = (*it).second;
@@ -450,7 +444,7 @@ void AqlItemBlock::clearRegisters(RegIdFlatSet const& toClear) {
       AqlValue& a(_data[getAddress(i, reg)]);
 
       if (a.requiresDestruction()) {
-        auto it = _valueCount.find(a);
+        auto it = _valueCount.find(a.data());
 
         if (it != _valueCount.end()) {
           auto& valueInfo = (*it).second;
@@ -477,8 +471,11 @@ SharedAqlItemBlockPtr AqlItemBlock::cloneDataAndMoveShadow() {
   
   SharedAqlItemBlockPtr res{aqlItemBlockManager().requestBlock(numRows, numRegs)};
 
-  auto copyRows = [&](auto& cache) {
-    constexpr bool checkShadowRows = !std::is_same<decltype(cache), AqlValueCache>::value;
+  struct WithoutShadowRows {};
+  struct WithShadowRows {};
+
+  auto copyRows = [&](arangodb::containers::HashSet<void*>& cache, auto type) {
+    constexpr bool checkShadowRows = std::is_same<decltype(type),WithShadowRows>::value;
     cache.reserve(_valueCount.size());
 
     for (size_t row = 0; row < numRows; row++) {
@@ -486,8 +483,8 @@ SharedAqlItemBlockPtr AqlItemBlock::cloneDataAndMoveShadow() {
         for (RegisterId col = 0; col < numRegs; col++) {
           AqlValue a = stealAndEraseValue(row, col);
           AqlValueGuard guard{a, true};
-          auto [it, inserted] = cache.emplace(a);
-          res->setValue(row, col, *it);
+          auto [it, inserted] = cache.emplace(a.data());
+          res->setValue(row, col, AqlValue(a.type(), a.data()));
           if (inserted) {
             // otherwise, destroy this; we used a cached value.
             guard.steal();
@@ -505,16 +502,16 @@ SharedAqlItemBlockPtr AqlItemBlock::cloneDataAndMoveShadow() {
     }
   };
 
+  arangodb::containers::HashSet<void*> cache;
+
   if (!hasShadowRows()) {
     // optimized version for when no shadow rows exist
     // use a faster cache type
-    AqlValueCache cache;
-    copyRows(cache);
+    copyRows(cache, WithShadowRows{});
   } else {
     // at least one shadow row exists. this is the slow path
     // use a slower cache type
-    std::unordered_set<AqlValue> cache;
-    copyRows(cache);
+    copyRows(cache, WithoutShadowRows{});
   }
   TRI_ASSERT(res->size() == numRows);
 
@@ -560,7 +557,7 @@ auto AqlItemBlock::slice(std::vector<std::pair<size_t, size_t>> const& ranges) c
     numRows += to - from;
   }
 
-  AqlValueCache cache;
+  arangodb::containers::HashSet<void*> cache;
   cache.reserve(numRows * _nrRegs / 4 + 1);
 
   SharedAqlItemBlockPtr res{_manager.requestBlock(numRows, _nrRegs)};
@@ -586,8 +583,7 @@ SharedAqlItemBlockPtr AqlItemBlock::slice(size_t row,
                                           RegisterCount newNrRegs) const {
   TRI_ASSERT(_nrRegs <= newNrRegs);
 
-  AqlValueCache  cache;
-
+  arangodb::containers::HashSet<void*> cache;
   SharedAqlItemBlockPtr res{_manager.requestBlock(1, newNrRegs)};
   for (auto const& col : registers) {
     TRI_ASSERT(col < _nrRegs);
@@ -604,7 +600,7 @@ SharedAqlItemBlockPtr AqlItemBlock::slice(std::vector<size_t> const& chosen,
                                           size_t from, size_t to) const {
   TRI_ASSERT(from < to && to <= chosen.size());
 
-  AqlValueCache cache;
+  arangodb::containers::HashSet<void*> cache;
   cache.reserve((to - from) * internalNrRegs() / 4 + 1);
 
   SharedAqlItemBlockPtr res{_manager.requestBlock(to - from, _nrRegs)};
@@ -946,7 +942,8 @@ void AqlItemBlock::setValue(size_t index, RegisterId varNr, AqlValue const& valu
 
   // First update the reference count, if this fails, the value is empty
   if (value.requiresDestruction()) {
-    auto& valueInfo = _valueCount[value];
+    // note: this may create a new entry in _valueCount, which is fine
+    auto& valueInfo = _valueCount[value.data()];
     if (++valueInfo.refCount == 1) {
       // we just inserted the item
       size_t memoryUsage = value.memoryUsage();
@@ -962,7 +959,7 @@ void AqlItemBlock::destroyValue(size_t index, RegisterId varNr) {
   auto& element = _data[getAddress(index, varNr)];
 
   if (element.requiresDestruction()) {
-    auto it = _valueCount.find(element);
+    auto it = _valueCount.find(element.data());
 
     if (it != _valueCount.end()) {
       auto& valueInfo = (*it).second;
@@ -982,7 +979,7 @@ void AqlItemBlock::eraseValue(size_t index, RegisterId varNr) {
   auto& element = _data[getAddress(index, varNr)];
 
   if (element.requiresDestruction()) {
-    auto it = _valueCount.find(element);
+    auto it = _valueCount.find(element.data());
 
     if (it != _valueCount.end()) {
       auto& valueInfo = (*it).second;
@@ -1025,8 +1022,8 @@ void AqlItemBlock::referenceValuesFromRow(size_t currentRow,
       // First update the reference count, if this fails, the value is empty
       AqlValue const& a = getValueReference(fromRow, reg);
       if (a.requiresDestruction()) {
-        TRI_ASSERT(_valueCount.find(a) != _valueCount.end());
-        ++_valueCount[a].refCount;
+        TRI_ASSERT(_valueCount.find(a.data()) != _valueCount.end());
+        ++_valueCount[a.data()].refCount;
       }
       _data[getAddress(currentRow, reg)] = a;
     }
@@ -1037,7 +1034,7 @@ void AqlItemBlock::referenceValuesFromRow(size_t currentRow,
 
 void AqlItemBlock::steal(AqlValue const& value) {
   if (value.requiresDestruction()) {
-    auto it = _valueCount.find(value);
+    auto it = _valueCount.find(value.data());
     if (it != _valueCount.end()) {
       decreaseMemoryUsage((*it).second.memoryUsage);
       _valueCount.erase(it);

--- a/arangod/Aql/AqlItemBlock.h
+++ b/arangod/Aql/AqlItemBlock.h
@@ -321,9 +321,6 @@ class AqlItemBlock {
   /// The source block will be cleared after this.
   size_t moveOtherBlockHere(size_t targetRow, AqlItemBlock& source);
 
-  void copySubQueryDepthFromOtherBlock(size_t targetRow, AqlItemBlock const& source,
-                                       size_t sourceRow);
-
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 // MaintainerMode method to validate if ShadowRows organization are consistent.
 // e.g. If a block always follows this pattern:
@@ -338,6 +335,9 @@ class AqlItemBlock {
   size_t decrRefCount() const noexcept;
 
  private:
+  void copySubQueryDepthFromOtherBlock(size_t targetRow, AqlItemBlock const& source,
+                                       size_t sourceRow);
+
   // This includes the amount of internal registers that are not visible to the outside.
   RegisterCount internalNrRegs() const noexcept;
 

--- a/arangod/Aql/AqlItemBlock.h
+++ b/arangod/Aql/AqlItemBlock.h
@@ -336,7 +336,7 @@ class AqlItemBlock {
 
  private:
   void copySubQueryDepthFromOtherBlock(size_t targetRow, AqlItemBlock const& source,
-                                       size_t sourceRow);
+                                       size_t sourceRow, bool forceShadowRow);
 
   // This includes the amount of internal registers that are not visible to the outside.
   RegisterCount internalNrRegs() const noexcept;

--- a/arangod/Aql/AqlValue.cpp
+++ b/arangod/Aql/AqlValue.cpp
@@ -1378,12 +1378,6 @@ AqlValue::AqlValue(std::vector<arangodb::aql::SharedAqlItemBlockPtr>* docvec) no
   setType(AqlValueType::DOCVEC);
 }
 
-/// @brief return the item block at position
-AqlItemBlock* AqlValue::docvecAt(size_t position) const {
-  TRI_ASSERT(isDocvec());
-  return _data.docvec->at(position).get();
-}
-
 AqlValue::AqlValue() noexcept {
   // construct a slice of type None
   // we will simply zero-initialize the two 64 bit words
@@ -1407,6 +1401,13 @@ AqlValue::AqlValue(uint8_t const* pointer) {
     setPointer<false>(pointer);
   }
   TRI_ASSERT(!VPackSlice(_data.pointer).isExternal());
+}
+
+AqlValue::AqlValue(AqlValueType type, void* data) noexcept {
+  TRI_ASSERT(data != nullptr);
+  TRI_ASSERT(type != VPACK_INLINE);
+  _data.data = data;
+  setType(type);
 }
 
 AqlValue::AqlValue(AqlValueHintNone const&) noexcept {
@@ -1673,6 +1674,12 @@ void AqlValue::initFromSlice(arangodb::velocypack::Slice const& slice) {
 
 void AqlValue::setType(AqlValue::AqlValueType type) noexcept {
   _data.internal[sizeof(_data.internal) - 1] = type;
+}
+
+void* AqlValue::data() const noexcept {
+  TRI_ASSERT(type() != VPACK_INLINE);
+  TRI_ASSERT(_data.data != nullptr);
+  return _data.data;
 }
 
 template <bool isManagedDoc>

--- a/tests/js/common/shell/shell-cluster-collection.js
+++ b/tests/js/common/shell/shell-cluster-collection.js
@@ -905,9 +905,9 @@ function ClusterCollectionSuite () {
         {'@cn' : cn});
       assertEqual(1, c.toArray().length);
       var doc = c.any();
-      assertTrue(doc.super === "cat");
+      assertEqual(doc.super, "cat");
       doc = cursor.next();                // should be: cursor >>= id
-      assertTrue(doc[0].super === "cat");  // extra [] buy subquery return
+      assertEqual(doc[0].super, "cat");  // extra [] buy subquery return
 
       //remove
       cursor = db._query(`


### PR DESCRIPTION
## Scope & Purpose

Implement a simplification suggested by @graetzer in https://github.com/arangodb/arangodb/pull/12249#discussion_r458699618
This should use less memory and allow for slightly faster lookups in `_valueCount`.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *shell_server_aql*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11199/