### PR TITLE
make AQL fast again 12

### DIFF
--- a/arangod/RocksDBEngine/RocksDBKeyBounds.h
+++ b/arangod/RocksDBEngine/RocksDBKeyBounds.h
@@ -128,20 +128,20 @@ class RocksDBKeyBounds {
   /// specified non-unique index (skiplist and permanent)
   //////////////////////////////////////////////////////////////////////////////
   static RocksDBKeyBounds VPackIndex(uint64_t indexId, VPackSlice const& left,
-                                     VPackSlice const& right);
+                                     VPackSlice const& right, bool isReverse);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Bounds for all documents within a value range belonging to a
   /// specified unique index
   //////////////////////////////////////////////////////////////////////////////
   static RocksDBKeyBounds UniqueVPackIndex(uint64_t indexId, VPackSlice const& left,
-                                           VPackSlice const& right);
+                                           VPackSlice const& right, bool isReverse);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Bounds for all documents within a value range belonging to a
   /// specified unique index. this method is used for point lookups
   //////////////////////////////////////////////////////////////////////////////
-  static RocksDBKeyBounds UniqueVPackIndex(uint64_t indexId, VPackSlice const& left);
+  static RocksDBKeyBounds UniqueVPackIndex(uint64_t indexId, VPackSlice const& value);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Bounds for all views belonging to a specified database
@@ -221,7 +221,7 @@ class RocksDBKeyBounds {
   RocksDBKeyBounds(RocksDBEntryType type, uint64_t first, arangodb::velocypack::StringRef const& second);
   RocksDBKeyBounds(RocksDBEntryType type, uint64_t first, VPackSlice const& second);
   RocksDBKeyBounds(RocksDBEntryType type, uint64_t first,
-                   VPackSlice const& second, VPackSlice const& third);
+                   VPackSlice const& second, VPackSlice const& third, bool isReverse);
   RocksDBKeyBounds(RocksDBEntryType type, uint64_t first, uint64_t second, uint64_t third);
   RocksDBKeyBounds(RocksDBEntryType type, uint64_t id, std::string const& lower,
                    std::string const& upper);

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -181,7 +181,6 @@ class RocksDBVPackIndexIterator final : public IndexIterator {
         _index(index),
         _cmp(static_cast<RocksDBVPackComparator const*>(index->comparator())),
         _bounds(std::move(bounds)),
-        _fullEnumerationObjectId(0),
         _mustSeek(true) {
     TRI_ASSERT(index->columnFamily() == RocksDBColumnFamily::vpack());
 
@@ -192,21 +191,9 @@ class RocksDBVPackIndexIterator final : public IndexIterator {
     if constexpr (reverse) {
       _rangeBound = _bounds.start();
       options.iterate_lower_bound = &_rangeBound;
-      VPackSlice s = VPackSlice(reinterpret_cast<uint8_t const*>(_rangeBound.data() + sizeof(uint64_t)));
-      if (s.isArray() && s.length() == 1 && s.at(0).isMinKey()) {
-        // lower bound is the min key. that means we can get away with a
-        // cheap outOfBounds comparator
-        _fullEnumerationObjectId = _index->objectId();
-      }
     } else {
       _rangeBound = _bounds.end();
       options.iterate_upper_bound = &_rangeBound;
-      VPackSlice s = VPackSlice(reinterpret_cast<uint8_t const*>(_rangeBound.data() + sizeof(uint64_t)));
-      if (s.isArray() && s.length() == 1 && s.at(0).isMaxKey()) {
-        // upper bound is the max key. that means we can get away with a
-        // cheap outOfBounds comparator
-        _fullEnumerationObjectId = _index->objectId();
-      }
     }
 
     TRI_ASSERT(options.prefix_same_as_start);
@@ -319,19 +306,6 @@ class RocksDBVPackIndexIterator final : public IndexIterator {
 
  private:
   inline bool outOfRange() const {
-    if (_fullEnumerationObjectId) {
-      // we are enumerating the entire index range for a collection,
-      // so we can use a cheap comparator that only checks the index' objectId.
-      // there is no need to do a function call into the comparator here 
-      // (even though its type is know here), or to compare the 
-      // indexed velocypack values at all.
-      return (arangodb::rocksutils::uint64FromPersistent(_iterator->key().data()) != _fullEnumerationObjectId);
-    }
-
-    // we are enumerating a subset of the index values of a collection
-    // so we really need to run the full-featured (read: expensive)
-    // comparator
-
     if constexpr (reverse) {
       return (_cmp->Compare(_iterator->key(), _rangeBound) < 0);
     } else {
@@ -369,7 +343,6 @@ class RocksDBVPackIndexIterator final : public IndexIterator {
   RocksDBKeyBounds _bounds;
   // used for iterate_upper_bound iterate_lower_bound
   rocksdb::Slice _rangeBound;
-  uint64_t _fullEnumerationObjectId;
   bool _mustSeek;
 };
 
@@ -1047,10 +1020,13 @@ std::unique_ptr<IndexIterator> RocksDBVPackIndex::lookup(transaction::Methods* t
       }
     }
   }
-
+ 
+  TRI_ASSERT(!leftBorder.isNone());
+  TRI_ASSERT(!rightBorder.isNone());
+      
   RocksDBKeyBounds bounds =
-      _unique ? RocksDBKeyBounds::UniqueVPackIndex(objectId(), leftBorder, rightBorder)
-              : RocksDBKeyBounds::VPackIndex(objectId(), leftBorder, rightBorder);
+      _unique ? RocksDBKeyBounds::UniqueVPackIndex(objectId(), leftBorder, rightBorder, reverse)
+              : RocksDBKeyBounds::VPackIndex(objectId(), leftBorder, rightBorder, reverse);
 
   if (reverse) {
     // reverse version

--- a/lib/VPackDeserializer/utilities.h
+++ b/lib/VPackDeserializer/utilities.h
@@ -33,7 +33,7 @@ namespace deserializer::utilities {
 template <typename T>
 struct identity_factory {
   using constructed_type = T;
-  T operator()(T t) const { return std::move(t); }
+  T operator()(T t) const { return t; }
 };
 
 template <typename P>

--- a/tests/RocksDBEngine/KeyTest.cpp
+++ b/tests/RocksDBEngine/KeyTest.cpp
@@ -590,7 +590,7 @@ TEST_F(RocksDBKeyBoundsTestLittleEndian, test_hash_index) {
   key6.constructVPackIndexValue(1, b.slice(), LocalDocumentId(90));
   key7.constructVPackIndexValue(1, c.slice(), LocalDocumentId(12));
 
-  bounds = RocksDBKeyBounds::VPackIndex(1, a.slice(), c.slice());
+  bounds = RocksDBKeyBounds::VPackIndex(1, a.slice(), c.slice(), false);
   EXPECT_TRUE(cmp->Compare(bounds.start(), key4.string()) < 0);
   EXPECT_TRUE(cmp->Compare(key4.string(), bounds.end()) < 0);
   EXPECT_TRUE(cmp->Compare(bounds.start(), key5.string()) < 0);
@@ -715,7 +715,7 @@ TEST_F(RocksDBKeyBoundsTestBigEndian, test_hash_index) {
   key6.constructVPackIndexValue(1, b.slice(), LocalDocumentId(90));
   key7.constructVPackIndexValue(1, c.slice(), LocalDocumentId(12));
 
-  bounds = RocksDBKeyBounds::VPackIndex(1, a.slice(), c.slice());
+  bounds = RocksDBKeyBounds::VPackIndex(1, a.slice(), c.slice(), false);
   EXPECT_TRUE(cmp->Compare(bounds.start(), key4.string()) < 0);
   EXPECT_TRUE(cmp->Compare(key4.string(), bounds.end()) < 0);
   EXPECT_TRUE(cmp->Compare(bounds.start(), key5.string()) < 0);


### PR DESCRIPTION
### Scope & Purpose

Try creating specialized key bounds for full collection index scanning.
This allows removing a special case and a branch for scanning all values in an index (though the branch will still be present in the VPackComparator, but the code there already existed).
Suggested by @graetzer via the comments in https://github.com/arangodb/arangodb/pull/12266

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *shell_server_aql*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11201/