### PR TITLE
fix compile warning in tests

### DIFF
--- a/tests/IResearch/IResearchViewCoordinator-test.cpp
+++ b/tests/IResearch/IResearchViewCoordinator-test.cpp
@@ -1269,8 +1269,6 @@ TEST_F(IResearchViewCoordinatorTest, test_primary_compression_properties) {
   EXPECT_TRUE(ci.createViewCoordinator(vocbase->name(), viewId, json->slice()).ok());
 
   // get current plan version
-  auto planVersion = arangodb::tests::getCurrentPlanVersion(server.server());
-
   auto view = ci.getView(vocbase->name(), viewId);
   EXPECT_NE(nullptr, view);
   EXPECT_NE(nullptr, std::dynamic_pointer_cast<arangodb::iresearch::IResearchViewCoordinator>(view));


### PR DESCRIPTION
### Scope & Purpose

Fix a compile warning when compiling arangodbtests.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11218/