### PR TITLE
Create leader shards on agency cache events directly.

### DIFF
--- a/arangod/Cluster/DBServerAgencySync.cpp
+++ b/arangod/Cluster/DBServerAgencySync.cpp
@@ -61,7 +61,7 @@ DBServerAgencySync::DBServerAgencySync(ApplicationServer& server, HeartbeatThrea
   ClusterFeature& clusterFeature = server.getFeature<ClusterFeature>();
   if (ServerState::instance()->isDBServer()) {
     AgencyCache& agencyCache = clusterFeature.agencyCache();
-    auto cb = [serverState, &server, this](int64_t raftIndex, std::string const& key, VPackSlice value) {
+    auto cb = [serverState, &server](int64_t raftIndex, std::string const& key, VPackSlice value) {
       // Now let's detect a collection creation change under /arango/Plan/Collections,
       // we already know that the key has this prefix.
       auto serverId = serverState->getId();

--- a/arangod/Cluster/DBServerAgencySync.cpp
+++ b/arangod/Cluster/DBServerAgencySync.cpp
@@ -23,9 +23,15 @@
 
 #include "DBServerAgencySync.h"
 
+#include <velocypack/Collection.h>
+#include <velocypack/Slice.h>
+#include <velocypack/velocypack-aliases.h>
+
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/ScopeGuard.h"
 #include "Basics/StringUtils.h"
+#include "Cluster/ActionDescription.h"
+#include "Cluster/AgencyCache.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/FollowerInfo.h"
@@ -49,7 +55,71 @@ using namespace arangodb::methods;
 using namespace arangodb::rest;
 
 DBServerAgencySync::DBServerAgencySync(ApplicationServer& server, HeartbeatThread* heartbeat)
-    : _server(server), _heartbeat(heartbeat) {}
+    : _server(server), _heartbeat(heartbeat) {
+
+  auto* serverState = ServerState::instance();
+  ClusterFeature& clusterFeature = server.getFeature<ClusterFeature>();
+  if (ServerState::instance()->isDBServer()) {
+    AgencyCache& agencyCache = clusterFeature.agencyCache();
+    auto cb = [serverState, &server, this](int64_t raftIndex, std::string const& key, VPackSlice value) {
+      // Now let's detect a collection creation change under /arango/Plan/Collections,
+      // we already know that the key has this prefix.
+      auto serverId = serverState->getId();
+      MaintenanceFeature& mfeature = server.getFeature<MaintenanceFeature>();
+      std::vector<std::string> parts = arangodb::basics::StringUtils::split(key, '/');
+      TRI_ASSERT(parts.size() >= 4 && parts[0] == "" && parts[1] == "arango" &&
+                 parts[2] == "Plan" && parts[3] == "Collections");
+      if (parts.size() == 6) {
+        std::string dbName{parts[4]};
+        std::string collId{parts[5]};
+        if (value.isObject() && value.hasKey("op") && value.hasKey("new")) {
+          VPackSlice op = value.get("op");
+          if (op.isString() && op.stringView() == "set") {
+            VPackSlice newVal = value.get("new");
+            if (newVal.hasKey("isBuilding") && newVal.get("isBuilding").isTrue() &&
+                newVal.hasKey("shards") && newVal.hasKey("name")) {
+              VPackSlice shards = newVal.get("shards");
+              VPackSlice colName = newVal.get("name");
+              for (auto const& p : VPackObjectIterator(shards)) {
+                VPackSlice servers = p.value;
+                if (servers.isArray() && servers.length() > 0) {
+                  VPackSlice leader = servers[0];
+                  if (leader.isString() && leader.stringView() == serverId) {
+                    // This is a new shard for which we shall be the leader, let's create an action for it:
+                    LOG_DEVEL
+                        << "We need to quickly create a maintenance action for "
+                        << "database " << dbName << " collection "
+                        << colName.stringView() << " shard " << p.key;
+                    auto changes = std::make_shared<VPackBuilder>();
+                    {
+                      VPackObjectBuilder ob(changes.get());
+                      changes->add(maintenance::ID, VPackSlice::nullSlice());
+                      changes->add(maintenance::NAME, VPackSlice::nullSlice());
+                      changes->add(maintenance::PLAN_RAFT_INDEX, VPackValue(raftIndex));
+                    }
+                    auto properties = std::make_shared<VPackBuilder>();
+                    arangodb::velocypack::Collection::merge(*properties, newVal,
+                                                            changes->slice(), false, true);
+                    maintenance::ActionDescription ad(
+                        {{maintenance::NAME, maintenance::CREATE_COLLECTION},
+                         {maintenance::COLLECTION, collId},
+                         {maintenance::SHARD, p.key.copyString()},
+                         {maintenance::DATABASE, dbName},
+                         {maintenance::SERVER_ID, serverId},
+                         {maintenance::THE_LEADER, std::string()}},
+                        maintenance::LEADER_PRIORITY, properties);
+                    mfeature.addAction(std::make_shared<maintenance::ActionDescription>(ad));
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+    agencyCache.registerEventHandler("/arango/Plan/Collections", cb);
+  }
+}
 
 void DBServerAgencySync::work() {
   LOG_TOPIC("57898", TRACE, Logger::CLUSTER) << "starting plan update handler";
@@ -111,6 +181,7 @@ Result DBServerAgencySync::getLocalCollections(VPackBuilder& collections) {
         // after a restart we would implicitly be assumed to be the leader.
         collections.add("theLeader", VPackValue(theLeaderTouched ? theLeader : maintenance::LEADER_NOT_YET_KNOWN));
         collections.add("theLeaderTouched", VPackValue(theLeaderTouched));
+        collections.add(maintenance::RAFT_INDEX_AT_CREATION, VPackValue(collection->raftIndexAtCreation()));
 
         if (theLeader.empty() && theLeaderTouched) {
           // we are the leader ourselves

--- a/arangod/Cluster/MaintenanceStrings.h
+++ b/arangod/Cluster/MaintenanceStrings.h
@@ -54,6 +54,7 @@ constexpr char const* OP = "op";
 constexpr char const* PHASE_ONE = "phaseOne";
 constexpr char const* PHASE_TWO = "phaseTwo";
 constexpr char const* PLAN_RAFT_INDEX = "planRaftIndex";
+constexpr char const* RAFT_INDEX_AT_CREATION = "raftIndexAtCreation";
 constexpr char const* RESIGN_SHARD_LEADERSHIP = "ResignShardLeadership";
 constexpr char const* SCHEMA = "schema";
 constexpr char const* SELECTIVITY_ESTIMATE = "selectivityEstimate";

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -185,7 +185,8 @@ LogicalCollection::LogicalCollection(TRI_vocbase_t& vocbase, VPackSlice const& i
       _smartJoinAttribute(
           ::readStringValue(info, StaticStrings::SmartJoinAttribute, "")),
 #endif
-      _physical(EngineSelectorFeature::ENGINE->createPhysicalCollection(*this, info)) {
+      _physical(EngineSelectorFeature::ENGINE->createPhysicalCollection(*this, info)),
+      _raftIndexAtCreation(0) {
 
   TRI_ASSERT(info.isObject());
 

--- a/arangod/VocBase/LogicalCollection.h
+++ b/arangod/VocBase/LogicalCollection.h
@@ -110,6 +110,14 @@ class LogicalCollection : public LogicalDataSource {
 
   std::string globallyUniqueId() const;
 
+  int64_t raftIndexAtCreation() const {
+    return _raftIndexAtCreation;
+  }
+
+  void setRaftIndexAtCreation(int64_t raftIndex) {
+    _raftIndexAtCreation = raftIndex;
+  }
+
   // For normal collections the realNames is just a vector of length 1
   // with its name. For smart edge collections (Enterprise Edition only)
   // this is different.
@@ -421,6 +429,11 @@ class LogicalCollection : public LogicalDataSource {
   // `_validators` must be used with atomic accessors only!!
   // We use relaxed access (load/store) as we only care about atomicity.
   std::shared_ptr<ValidatorVec> _validators;
+
+  // The following is used only in the cluster for shards, one can tell the
+  // collection object which raft index lead to its creation. This is used to
+  // tell in the maintenance that a shard belongs to a future plan version.
+  int64_t _raftIndexAtCreation;
 };
 
 }  // namespace arangodb

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -376,7 +376,7 @@ std::pair<std::vector<consensus::apply_ret_t>, consensus::index_t> AgencyCache::
   {
     std::lock_guard g(_callbacksLock);
     for (auto const& trx : VPackArrayIterator(trxs->slice())) {
-      handleCallbacksNoLock(trx[0], uniq, toCall);
+      handleCallbacksNoLock(trx[0], normalizeAndSortKeys(trx[0]), uniq, toCall);
     }
   }
   invokeCallbacks(toCall);


### PR DESCRIPTION
This is a first try to use event-based methods to react to
Plan changes more quickly. So far, this is a proof of concept.
We may or may not adopt this approach in the future.