### PR TITLE
add toggle for encryption key rotation API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Added startup option `--rocksdb.encryption-key-rotation` to activate/deactivate
+  the encryption key rotation REST API. The API is disabled by default.
+
 * Add internal caching for LogicalCollection objects inside ClusterInfo::loadPlan.
   This allows avoiding the recreation of LogicalCollection objects that did not
   change from one loadPlan run to the next. It reduces CPU usage considerably on

--- a/Documentation/DocuBlocks/Rest/Administration/post_admin_server_encryption.md
+++ b/Documentation/DocuBlocks/Rest/Administration/post_admin_server_encryption.md
@@ -13,6 +13,8 @@ new user key.
 This is a protected API and can only be executed with superuser rights.
 This API is not available on coordinator nodes.
 
+The API returns HTTP 404 in case encryption key rotation is disabled.
+
 @RESTRETURNCODES
 
 @RESTRETURNCODE{200}
@@ -34,4 +36,7 @@ Can be empty.
 @RESTRETURNCODE{403}
 This API will return HTTP 403 FORBIDDEN if it is not called with
 superuser rights.
+
+@RESTRETURNCODE{404}
+This API will return HTTP 404 in case encryption key rotation is disabled.
 @endDocuBlock

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -314,12 +314,14 @@ class RocksDBEngine final : public StorageEngine {
   void prepareEnterprise();
   void configureEnterpriseRocksDBOptions(rocksdb::Options& options, bool createdEngineDir);
   void validateJournalFiles() const;
-  
+ 
   Result readUserEncryptionSecrets(std::vector<enterprise::EncryptionSecret>& outlist) const;
 
   enterprise::RocksDBEngineEEData _eeData;
 
  public:
+  bool encryptionKeyRotationEnabled() const;
+
   bool isEncryptionEnabled() const;
   
   std::string const& getEncryptionKey();


### PR DESCRIPTION
### Scope & Purpose

Add startup option `--rocksdb.encryption-key-rotation` to enable/disable the HTTP REST API for encryption key rotation.
The rotation API is disabled by default.

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/522
Docs PR: https://github.com/arangodb/docs/pull/511

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in server_permissions)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11262/