### PR TITLE
Create leader shards on agency cache events directly.

### DIFF
--- a/arangod/Cluster/MaintenanceStrings.h
+++ b/arangod/Cluster/MaintenanceStrings.h
@@ -54,6 +54,7 @@ constexpr char const* OP = "op";
 constexpr char const* PHASE_ONE = "phaseOne";
 constexpr char const* PHASE_TWO = "phaseTwo";
 constexpr char const* PLAN_RAFT_INDEX = "planRaftIndex";
+constexpr char const* RAFT_INDEX_AT_CREATION = "raftIndexAtCreation";
 constexpr char const* RESIGN_SHARD_LEADERSHIP = "ResignShardLeadership";
 constexpr char const* SCHEMA = "schema";
 constexpr char const* SELECTIVITY_ESTIMATE = "selectivityEstimate";

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -169,7 +169,8 @@ LogicalCollection::LogicalCollection(TRI_vocbase_t& vocbase, VPackSlice const& i
       _smartJoinAttribute(
           ::readStringValue(info, StaticStrings::SmartJoinAttribute, "")),
 #endif
-      _physical(EngineSelectorFeature::ENGINE->createPhysicalCollection(*this, info)) {
+      _physical(EngineSelectorFeature::ENGINE->createPhysicalCollection(*this, info)),
+      _raftIndexAtCreation(0) {
 
   TRI_ASSERT(info.isObject());
 

--- a/arangod/VocBase/LogicalCollection.h
+++ b/arangod/VocBase/LogicalCollection.h
@@ -107,6 +107,14 @@ class LogicalCollection : public LogicalDataSource {
 
   std::string globallyUniqueId() const;
 
+  int64_t raftIndexAtCreation() const {
+    return _raftIndexAtCreation;
+  }
+
+  void setRaftIndexAtCreation(int64_t raftIndex) {
+    _raftIndexAtCreation = raftIndex;
+  }
+
   // For normal collections the realNames is just a vector of length 1
   // with its name. For smart edge collections (Enterprise Edition only)
   // this is different.
@@ -414,6 +422,11 @@ class LogicalCollection : public LogicalDataSource {
   // `_validators` must be used with atomic accessors only!!
   // We use relaxed access (load/store) as we only care about atomicity.
   std::shared_ptr<ValidatorVec> _validators;
+
+  // The following is used only in the cluster for shards, one can tell the
+  // collection object which raft index lead to its creation. This is used to
+  // tell in the maintenance that a shard belongs to a future plan version.
+  int64_t _raftIndexAtCreation;
 };
 
 }  // namespace arangodb

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -376,7 +376,7 @@ std::pair<std::vector<consensus::apply_ret_t>, consensus::index_t> AgencyCache::
   {
     std::lock_guard g(_callbacksLock);
     for (auto const& trx : VPackArrayIterator(trxs->slice())) {
-      handleCallbacksNoLock(trx[0], uniq, toCall);
+      handleCallbacksNoLock(trx[0], normalizeAndSortKeys(trx[0]), uniq, toCall);
     }
   }
   invokeCallbacks(toCall);


### PR DESCRIPTION
This is a first try to use event-based methods to react to
Plan changes more quickly. So far, this is a proof of concept.
We may or may not adopt this approach in the future.