### PR TITLE
forward-port changes from 3.7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Slightly improved the performance of some k-shortest-path queries.
+
 * Added startup option `--rocksdb.encryption-key-rotation` to activate/deactivate
   the encryption key rotation REST API. The API is disabled by default.
 

--- a/arangod/Graph/KShortestPathsFinder.cpp
+++ b/arangod/Graph/KShortestPathsFinder.cpp
@@ -42,7 +42,9 @@ using namespace arangodb;
 using namespace arangodb::graph;
 
 KShortestPathsFinder::KShortestPathsFinder(ShortestPathOptions& options)
-    : ShortestPathFinder(options) {
+    : ShortestPathFinder(options),
+      _left(FORWARD),
+      _right(BACKWARD) {
   // cppcheck-suppress *
   _forwardCursor = options.buildCursor(false);
   // cppcheck-suppress *
@@ -78,11 +80,11 @@ bool KShortestPathsFinder::startKShortestPathsTraversal(
 }
 
 bool KShortestPathsFinder::computeShortestPath(VertexRef const& start, VertexRef const& end,
-                                               std::unordered_set<VertexRef> const& forbiddenVertices,
-                                               std::unordered_set<Edge> const& forbiddenEdges,
+                                               VertexSet const& forbiddenVertices,
+                                               EdgeSet const& forbiddenEdges,
                                                Path& result) {
-  Ball left(start, FORWARD);
-  Ball right(end, BACKWARD);
+  _left.reset(start);
+  _right.reset(end);
   VertexRef join;
 
   result.clear();
@@ -91,24 +93,23 @@ bool KShortestPathsFinder::computeShortestPath(VertexRef const& start, VertexRef
 
   // We will not improve anymore if we have found a best path and the smallest
   // combined distance between left and right is bigger than that path
-  while (!left.done(currentBest) && !right.done(currentBest)) {
+  while (!_left.done(currentBest) && !_right.done(currentBest)) {
     _options.isQueryKilledCallback();
 
     // Choose the smaller frontier to expand.
-    if (!left.done(currentBest) && (left._frontier.size() < right._frontier.size())) {
-      advanceFrontier(left, right, forbiddenVertices, forbiddenEdges, join, currentBest);
+    if (!_left.done(currentBest) && (_left._frontier.size() < _right._frontier.size())) {
+      advanceFrontier(_left, _right, forbiddenVertices, forbiddenEdges, join, currentBest);
     } else {
-      advanceFrontier(right, left, forbiddenVertices, forbiddenEdges, join, currentBest);
+      advanceFrontier(_right, _left, forbiddenVertices, forbiddenEdges, join, currentBest);
     }
   }
 
   if (currentBest.has_value()) {
-    reconstructPath(left, right, join, result);
+    reconstructPath(_left, _right, join, result);
     return true;
-  } else {
-    // No path found
-    return false;
   }
+  // No path found
+  return false;
 }
 
 void KShortestPathsFinder::computeNeighbourhoodOfVertexCache(VertexRef vertex,
@@ -118,7 +119,7 @@ void KShortestPathsFinder::computeNeighbourhoodOfVertexCache(VertexRef vertex,
   auto& cache = lookup->second;  // want to update the cached vertex in place
 
   switch (direction) {
-    case BACKWARD:
+    case BACKWARD: 
       if (!cache._hasCachedInNeighbours) {
         computeNeighbourhoodOfVertex(vertex, direction, cache._inNeighbours);
         cache._hasCachedInNeighbours = true;
@@ -145,7 +146,7 @@ void KShortestPathsFinder::computeNeighbourhoodOfVertex(VertexRef vertex, Direct
 
   // TODO: This is a bit of a hack
   if (_options.useWeight()) {
-    cursor->readAll([&](EdgeDocumentToken&& eid, VPackSlice edge, size_t cursorIdx) -> void {
+    cursor->readAll([&](EdgeDocumentToken&& eid, VPackSlice edge, size_t /*cursorIdx*/) -> void {
       if (edge.isString()) {
         VPackSlice doc = _options.cache()->lookupToken(eid);
         double weight = _options.weightEdge(doc);
@@ -165,7 +166,7 @@ void KShortestPathsFinder::computeNeighbourhoodOfVertex(VertexRef vertex, Direct
       }
     });
   } else {
-    cursor->readAll([&](EdgeDocumentToken&& eid, VPackSlice edge, size_t cursorIdx) -> void {
+    cursor->readAll([&](EdgeDocumentToken&& eid, VPackSlice edge, size_t /*cursorIdx*/) -> void {
       if (edge.isString()) {
         if (edge.compareString(vertex.data(), vertex.length()) != 0) {
           VertexRef id = _options.cache()->persistString(VertexRef(edge));
@@ -186,13 +187,12 @@ void KShortestPathsFinder::computeNeighbourhoodOfVertex(VertexRef vertex, Direct
 }
 
 void KShortestPathsFinder::advanceFrontier(Ball& source, Ball const& target,
-                                           std::unordered_set<VertexRef> const& forbiddenVertices,
-                                           std::unordered_set<Edge> const& forbiddenEdges,
+                                           VertexSet const& forbiddenVertices,
+                                           EdgeSet const& forbiddenEdges,
                                            VertexRef& join,
                                            std::optional<double>& currentBest) {
   VertexRef vr;
   DijkstraInfo *v, *w;
-  std::vector<Step>* neighbours;
 
   bool success = source._frontier.popMinimal(vr, v);
   TRI_ASSERT(v != nullptr);
@@ -201,10 +201,11 @@ void KShortestPathsFinder::advanceFrontier(Ball& source, Ball const& target,
     return;
   }
 
+  std::vector<Step>* neighbours;
   computeNeighbourhoodOfVertexCache(vr, source._direction, neighbours);
   TRI_ASSERT(neighbours != nullptr);
 
-  for (auto& s : *neighbours) {
+  for (auto const& s : *neighbours) {
     if (forbiddenEdges.find(s._edge) == forbiddenEdges.end() &&
         forbiddenVertices.find(s._vertex) == forbiddenVertices.end()) {
       double weight = v->_weight + s._weight;
@@ -244,8 +245,7 @@ void KShortestPathsFinder::reconstructPath(Ball const& left, Ball const& right,
   TRI_ASSERT(!join.empty());
   result._vertices.emplace_back(join);
 
-  DijkstraInfo* it;
-  it = left._frontier.find(join);
+  DijkstraInfo* it = left._frontier.find(join);
   TRI_ASSERT(it != nullptr);
   double startToJoin = it->weight();
   result._weight = startToJoin;
@@ -276,15 +276,14 @@ void KShortestPathsFinder::reconstructPath(Ball const& left, Ball const& right,
 }
 
 bool KShortestPathsFinder::computeNextShortestPath(Path& result) {
-  std::unordered_set<VertexRef> forbiddenVertices;
-  std::unordered_set<Edge> forbiddenEdges;
-  Path tmpPath, candidate;
+  VertexSet forbiddenVertices;
+  EdgeSet forbiddenEdges;
   TRI_ASSERT(!_shortestPaths.empty());
   auto& lastShortestPath = _shortestPaths.back();
   bool available = false;
 
   for (size_t i = lastShortestPath._branchpoint; i + 1 < lastShortestPath.length(); ++i) {
-    auto& spur = lastShortestPath._vertices.at(i);
+    auto& spur = lastShortestPath._vertices[i];
 
     forbiddenVertices.clear();
     forbiddenEdges.clear();
@@ -298,37 +297,44 @@ bool KShortestPathsFinder::computeNextShortestPath(Path& result) {
     //       paths in a prefix/postfix tree
     // previous paths with same prefix must not be
     for (auto const& p : _shortestPaths) {
+      if (i >= p._edges.size()) {
+        continue;
+      }
       bool eq = true;
       for (size_t e = 0; e < i; ++e) {
-        if (!p._edges.at(e).equals(lastShortestPath._edges.at(e))) {
+        if (!p._edges[e].equals(lastShortestPath._edges.at(e))) {
           eq = false;
           break;
         }
       }
-      if (eq && (i < p._edges.size())) {
-        forbiddenEdges.emplace(p._edges.at(i));
+      if (eq) {
+        forbiddenEdges.emplace(p._edges[i]);
       }
     }
 
-    if (computeShortestPath(spur, _end, forbiddenVertices, forbiddenEdges, tmpPath)) {
-      candidate.clear();
-      candidate.append(lastShortestPath, 0, i);
-      candidate.append(tmpPath, 0, tmpPath.length() - 1);
-      candidate._branchpoint = i;
+    // abuse result variable for some intermediate calculations here...
+    // the "real" result is only calculated at the very end of this method
+    result.clear();
+    if (computeShortestPath(spur, _end, forbiddenVertices, forbiddenEdges, result)) {
+      _candidate.clear();
+      _candidate.append(lastShortestPath, 0, i);
+      _candidate.append(result, 0, result.length() - 1);
+      _candidate._branchpoint = i;
 
       auto it = find_if(_candidatePaths.begin(), _candidatePaths.end(),
-                        [candidate](Path const& v) {
-                          return v._weight >= candidate._weight;
+                        [this](Path const& v) {
+                          return v._weight >= _candidate._weight;
                         });
-      if (it == _candidatePaths.end() || !(*it == candidate)) {
-        _candidatePaths.emplace(it, candidate);
+      if (it == _candidatePaths.end() || !(*it == _candidate)) {
+        _candidatePaths.emplace(it, std::move(_candidate));
       }
     }
   }
+    
+  result.clear();
 
   if (!_candidatePaths.empty()) {
     auto const& p = _candidatePaths.front();
-    result.clear();
     result.append(p, 0, p.length() - 1);
     result._branchpoint = p._branchpoint;
     _candidatePaths.pop_front();
@@ -371,54 +377,54 @@ bool KShortestPathsFinder::getNextPath(Path& result) {
   return !_traversalDone;
 }
 
+#ifdef ARANGODB_USE_GOOGLE_TESTS
 bool KShortestPathsFinder::getNextPathShortestPathResult(ShortestPathResult& result) {
-  Path path;
+  _tempPath.clear();
 
   result.clear();
-  if (getNextPath(path)) {
-    result._vertices = path._vertices;
-    result._edges = path._edges;
+  if (getNextPath(_tempPath)) {
+    result._vertices = _tempPath._vertices;
+    result._edges = _tempPath._edges;
     return true;
-  } else {
-    return false;
   }
+
+  return false;
 }
+#endif
 
 bool KShortestPathsFinder::getNextPathAql(arangodb::velocypack::Builder& result) {
-  Path path;
+  _tempPath.clear();
 
-  if (getNextPath(path)) {
+  if (getNextPath(_tempPath)) {
     result.clear();
     result.openObject();
 
-    result.add(VPackValue("edges"));
-    result.openArray();
-    for (auto const& it : path._edges) {
+    result.add("edges", VPackValue(VPackValueType::Array));
+    for (auto const& it : _tempPath._edges) {
       _options.cache()->insertEdgeIntoResult(it, result);
     }
     result.close();  // Array
 
-    result.add(VPackValue("vertices"));
-    result.openArray();
-    for (auto const& it : path._vertices) {
+    result.add("vertices", VPackValue(VPackValueType::Array));
+    for (auto const& it : _tempPath._vertices) {
       _options.cache()->insertVertexIntoResult(it, result);
     }
     result.close();  // Array
     if (_options.useWeight()) {
-      result.add("weight", VPackValue(path._weight));
+      result.add("weight", VPackValue(_tempPath._weight));
     } else {
       // If not using weight, weight is defined as 1 per edge
-      result.add("weight", VPackValue(path._edges.size()));
+      result.add("weight", VPackValue(_tempPath._edges.size()));
     }
     result.close();  // Object
     TRI_ASSERT(result.isClosed());
     return true;
-  } else {
-    return false;
   }
+  
+  return false;
 }
 
 bool KShortestPathsFinder::skipPath() {
-  Path path;
-  return getNextPath(path);
+  _tempPath.clear();
+  return getNextPath(_tempPath);
 }

--- a/arangod/Graph/KShortestPathsFinder.h
+++ b/arangod/Graph/KShortestPathsFinder.h
@@ -25,7 +25,7 @@
 #define ARANGODB_GRAPH_CONSTANT_WEIGHT_K_SHORTEST_PATHS_FINDER_H 1
 
 #include "Aql/AqlValue.h"
-#include "Basics/VelocyPackHelper.h"
+#include "Containers/HashSet.h"
 #include "Graph/EdgeDocumentToken.h"
 #include "Graph/ShortestPathFinder.h"
 #include "Graph/ShortestPathPriorityQueue.h"
@@ -55,6 +55,9 @@ class KShortestPathsFinder : public ShortestPathFinder {
   // Mainly for readability
   typedef arangodb::velocypack::StringRef VertexRef;
   typedef arangodb::graph::EdgeDocumentToken Edge;
+
+  typedef arangodb::containers::HashSet<VertexRef, std::hash<VertexRef>, std::equal_to<VertexRef>> VertexSet;
+  typedef arangodb::containers::HashSet<Edge, std::hash<Edge>, std::equal_to<Edge>> EdgeSet;
   enum Direction { FORWARD, BACKWARD };
 
   // TODO: This could be merged with ShortestPathResult
@@ -153,23 +156,28 @@ class KShortestPathsFinder : public ShortestPathFinder {
   // Dijkstra is run using two Balls, one around the start vertex, one around
   // the end vertex
   struct Ball {
+    Direction const _direction;
     VertexRef _center;
-    Direction _direction;
     Frontier _frontier;
     // The distance of the last node that has been fully expanded
     // from _center
     double _closest;
 
-    Ball() {}
-    Ball(VertexRef const& center, Direction direction)
-        : _center(center), _direction(direction), _closest(0) {
+    explicit Ball(Direction direction) 
+        : _direction(direction), _closest(0) {}
+ 
+    void reset(VertexRef center) { 
+      _center = center; 
+      _frontier.clear();
       _frontier.insert(center, std::make_unique<DijkstraInfo>(center));
+      _closest = 0;
     }
-    ~Ball() = default;
-    const VertexRef center() const { return _center; };
-    bool done(std::optional<double> const currentBest) {
+
+    VertexRef center() const { return _center; }
+    
+    bool done(std::optional<double> const& currentBest) {
       return _frontier.empty() || (currentBest.has_value() && currentBest.value() < _closest);
-    };
+    }
   };
 
   //
@@ -198,8 +206,6 @@ class KShortestPathsFinder : public ShortestPathFinder {
     bool _hasCachedInNeighbours;
     std::vector<Step> _outNeighbours;
     std::vector<Step> _inNeighbours;
-
-    std::vector<size_t> _paths;
 
     explicit FoundVertex(VertexRef const& vertex)
         : _vertex(vertex), _hasCachedOutNeighbours(false), _hasCachedInNeighbours(false) {}
@@ -237,7 +243,9 @@ class KShortestPathsFinder : public ShortestPathFinder {
   // get the next available path as a ShortestPathResult
   // TODO: this is only here to not break catch-tests and needs a cleaner solution.
   //       probably by making ShortestPathResult versatile enough and using that
+#ifdef ARANGODB_USE_GOOGLE_TESTS
   bool getNextPathShortestPathResult(ShortestPathResult& path);
+#endif
   // get the next available path as a Path
   bool getNextPath(Path& path);
   TEST_VIRTUAL bool skipPath();
@@ -246,8 +254,9 @@ class KShortestPathsFinder : public ShortestPathFinder {
  private:
   // Compute the first shortest path
   bool computeShortestPath(VertexRef const& start, VertexRef const& end,
-                           std::unordered_set<VertexRef> const& forbiddenVertices,
-                           std::unordered_set<Edge> const& forbiddenEdges, Path& result);
+                           VertexSet const& forbiddenVertices,
+                           EdgeSet const& forbiddenEdges, 
+                           Path& result);
   bool computeNextShortestPath(Path& result);
 
   void reconstructPath(Ball const& left, Ball const& right,
@@ -262,8 +271,8 @@ class KShortestPathsFinder : public ShortestPathFinder {
                                     std::vector<Step>& steps);
 
   void advanceFrontier(Ball& source, Ball const& target,
-                       std::unordered_set<VertexRef> const& forbiddenVertices,
-                       std::unordered_set<Edge> const& forbiddenEdges,
+                       VertexSet const& forbiddenVertices,
+                       EdgeSet const& forbiddenEdges,
                        VertexRef& join, std::optional<double>& currentBest);
 
  private:
@@ -271,6 +280,9 @@ class KShortestPathsFinder : public ShortestPathFinder {
 
   VertexRef _start;
   VertexRef _end;
+    
+  Ball _left;
+  Ball _right;
 
   FoundVertexCache _vertexCache;
 
@@ -280,6 +292,12 @@ class KShortestPathsFinder : public ShortestPathFinder {
 
   std::unique_ptr<EdgeCursor> _forwardCursor;
   std::unique_ptr<EdgeCursor> _backwardCursor;
+
+  // a temporary object that is reused for building results
+  Path _tempPath;
+
+  // a temporary object that is reused for building candidate results
+  Path _candidate;
 };
 
 }  // namespace graph

--- a/arangod/Graph/ShortestPathPriorityQueue.h
+++ b/arangod/Graph/ShortestPathPriorityQueue.h
@@ -69,8 +69,15 @@ class ShortestPathPriorityQueue {
  public:
   ShortestPathPriorityQueue() : _popped(0), _isHeap(false), _maxWeight(0) {}
 
-  ~ShortestPathPriorityQueue() {
+  ~ShortestPathPriorityQueue() = default;
+
+  /// @brief clear the priority queue, so it can be reused
+  void clear() {
+    _popped = 0;
+    _lookup.clear();
+    _isHeap = false;
     _heap.clear();
+    _maxWeight = 0;
     _history.clear();
   }
 
@@ -92,43 +99,34 @@ class ShortestPathPriorityQueue {
   //////////////////////////////////////////////////////////////////////////////
 
   bool insert(Key const& k, std::unique_ptr<Value>&& v) {
-    auto it = _lookup.find(k);
-    if (it != _lookup.end()) {
+    auto it = _lookup.emplace(k, static_cast<ssize_t>(_heap.size() + _popped));
+    if (!it.second) {
+      // value already exists in the lookup table
       return false;
     }
 
     // Are we still in the simple case of a deque?
     if (!_isHeap) {
       Weight w = v->weight();
-      if (w < _maxWeight) {
+      if (w >= _maxWeight) {
+        _maxWeight = w;
+      } else {
         // Oh dear, we have to upgrade to heap:
         _isHeap = true;
-        // fall through intentionally
-      } else {
-        if (w > _maxWeight) {
-          _maxWeight = w;
-        }
-        _heap.push_back(std::move(v));
-        try {
-          _lookup.insert(std::make_pair(k, static_cast<ssize_t>(_heap.size() - 1 + _popped)));
-        } catch (...) {
-          _heap.pop_back();
-          throw;
-        }
-        return true;
       }
     }
-    // If we get here, we have to insert into a proper binary heap:
-    _heap.push_back(std::move(v));
+
     try {
-      size_t newpos = _heap.size() - 1;
-      _lookup.insert(std::make_pair(k, static_cast<ssize_t>(newpos + _popped)));
-      repairUp(newpos);
+      _heap.push_back(std::move(v));
+      if (_isHeap) {
+        // If we get here, we have to insert into a proper binary heap:
+        repairUp(_heap.size() - 1);
+      }
+      return true;
     } catch (...) {
-      _heap.pop_back();
+      _lookup.erase(it.first);
       throw;
     }
-    return true;
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -157,9 +155,7 @@ class ShortestPathPriorityQueue {
   //////////////////////////////////////////////////////////////////////////////
 
   bool lowerWeight(Key const& k, Weight newWeight) {
-    if (!_isHeap) {
-      _isHeap = true;
-    }
+    _isHeap = true;
     auto it = _lookup.find(k);
     if (it == _lookup.end()) {
       return false;
@@ -236,9 +232,8 @@ class ShortestPathPriorityQueue {
     }
     k = _heap[0]->getKey();
 
-    auto it = _lookup.find(k);
-    TRI_ASSERT(it != _lookup.end());
-    _lookup.erase(it);
+    size_t erased = _lookup.erase(k);
+    TRI_ASSERT(erased > 0);
 
     // Responsibility handed over to v
     // Note: _heap[0] is nullptr now.

--- a/arangod/Graph/ShortestPathResult.h
+++ b/arangod/Graph/ShortestPathResult.h
@@ -35,14 +35,6 @@ namespace aql {
 struct AqlValue;
 }
 
-namespace transaction {
-class Methods;
-}
-
-namespace velocypack {
-class Builder;
-}
-
 namespace graph {
 
 class AttributeWeightShortestPathFinder;
@@ -87,7 +79,7 @@ class ShortestPathResult {
 
   /// @brief Gets the length of the path. (Number of vertices)
 
-  size_t length() { return _vertices.size(); };
+  size_t length() { return _vertices.size(); }
 
   void addVertex(arangodb::velocypack::StringRef v);
   void addEdge(arangodb::graph::EdgeDocumentToken e);


### PR DESCRIPTION
### Scope & Purpose

Slightly improve performance of k-shortest-path queries, by reusing expensive objects

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *AQL tests*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11280/