### PR TITLE
Fetch data for /_api/cluster/agency-dump always from leader.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Always fetch data for /_api/cluster/agency-dump from leader of the agency.
+  Add option "redirectToLeader=true" to internal /_api/agency/state API.
+
 * Added startup option `--rocksdb.encryption-key-rotation` to activate/deactivate
   the encryption key rotation REST API. The API is disabled by default.
 

--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -771,7 +771,10 @@ AgencyCommResult AgencyComm::getValues(std::string const& key) {
 }
 
 AgencyCommResult AgencyComm::dump() {
-  std::string url = AgencyComm::AGENCY_URL_PREFIX + "/state";
+  // We only get the dump from the leader, else its snapshot might be wrong
+  // or at least outdated. If there is no leader, one has to contact the
+  // agency directly with `/_api/agency/state`.
+  std::string url = AgencyComm::AGENCY_URL_PREFIX + "/state?redirectToLeader=true";
 
   AgencyCommResult result =
       sendWithFailover(arangodb::rest::RequestType::GET,

--- a/arangod/Agency/RestAgencyHandler.cpp
+++ b/arangod/Agency/RestAgencyHandler.cpp
@@ -705,6 +705,25 @@ RestStatus RestAgencyHandler::handleConfig() {
 }
 
 RestStatus RestAgencyHandler::handleState() {
+  bool found;
+  std::string const& val_str = _request->value("redirectToLeader", found);
+  bool redirectToLeader = found && val_str == "true";
+
+  // Potentially look at leadership:
+  if (redirectToLeader) {
+    if (_agent->size() > 1) {
+      auto leader = _agent->leaderID();
+      if (leader == NO_LEADER) {
+        return reportMessage(rest::ResponseCode::SERVICE_UNAVAILABLE,
+                             "No leader");
+      }
+      if (leader != _agent->id()) {
+        redirectRequest(leader);
+        return RestStatus::DONE;
+      }
+    }
+  }
+  // Go ahead, either as leader or, if allowed, as follower.
 
   VPackBuilder body;
   {

--- a/arangod/Cluster/RestClusterHandler.cpp
+++ b/arangod/Cluster/RestClusterHandler.cpp
@@ -97,8 +97,12 @@ void RestClusterHandler::handleAgencyDump() {
 
   std::shared_ptr<VPackBuilder> body = std::make_shared<VPackBuilder>();
   auto& ci = server().getFeature<ClusterFeature>().clusterInfo();
-  ci.agencyDump(body);
-  generateResult(rest::ResponseCode::OK, body->slice());
+  Result res = ci.agencyDump(body);
+  if (res.ok()) {
+    generateResult(rest::ResponseCode::OK, body->slice());
+  } else {
+    generateError(rest::ResponseCode::SERVICE_UNAVAILABLE, res.errorNumber(), res.errorMessage());
+  }
 }
 
 void RestClusterHandler::handleAgencyCache() {


### PR DESCRIPTION
Add option "redirectToLeader" to /_api/agency/state. This is a strictly internal API which is currently not documented. Without the option, it does not change in behaviour. The actual change in `/_api/cluster/agency-dump` only repairs a bug which can happen in rare cases when the request to the agency leader times out. In that case, stale agency data can be reported in the `.agency` component (which our debug scripts look at).