### PR TITLE
fixed issue #12297

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 devel
 -----
 
+* Fixed issue #12297: ArangoDB 3.6.5 Swagger Error?
+  This issue caused the Swagger UI for displaying the APIs of user-defined Foxx
+  services to remain invisible in the web UI, because of a JavaScript exception.
+  This PR fixes the JavaScript exception, so the services API is displayed
+  again properly.
+
 * Slightly improved the performance of some k-shortest-path queries.
 
 * Added startup option `--rocksdb.encryption-key-rotation` to activate/deactivate

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/applicationDetailView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/applicationDetailView.js
@@ -81,18 +81,17 @@
         this.resize();
         $('#swagger').show();
         $('#swaggerIframe').remove();
+        
         // load swagger iframe
         var path = window.location.pathname.split('/');
         var urlswag = window.location.protocol + '//' + window.location.hostname + ':' + window.location.port + '/' + path[1] + '/' + path[2] + '/_admin/aardvark/foxxes/docs/index.html?mount=' + this.model.get('mount');
 
-        var ifr = $('<iframe/>', {
+        $('<iframe/>', {
           id: 'swaggerIframe',
-          src: urlswag,
-          load: function () {
-            $('#swagger').height($('.centralRow').height() - 150);
-          }
+          src: urlswag
+        }).appendTo('#swagger').on('load', function () {
+          $('#swagger').height($('.centralRow').height() - 150);
         });
-        $('#swagger').append(ifr);
       } else if (e.currentTarget.id === 'service-info') {
         this.resize(true);
         this.render();


### PR DESCRIPTION
### Scope & Purpose

Fix the display of the Swagger UI of user-defined Foxx services in the web UI.
The display was broken after a recent update of jquery, so that trying to load the swagger UI with the service description into an iframe caused a JavaScript exception. This prevented the proper display of the services API UI.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [ ] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)

#### Related Information

- [x] There is a GitHub Issue reported by a Community User: https://github.com/arangodb/arangodb/issues/12297

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11294/