### PR TITLE
Fix race bug in gtest.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
+* Always fetch data for /_api/cluster/agency-dump from leader of the agency.
+  Add option "redirectToLeader=true" to internal /_api/agency/state API.
+
 * Added startup option `--rocksdb.encryption-key-rotation` to
   activate/deactivate the encryption key rotation REST API. The API is disabled
   by default.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,6 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
-* Fix a race problem in the unit tests w.r.t. PlanSyncer.
-
 * Added startup option `--rocksdb.encryption-key-rotation` to
   activate/deactivate the encryption key rotation REST API. The API is disabled
   by default.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,7 @@
 v3.7.1-rc.1 (XXXX-XX-XX)
 ------------------------
 
-* Always fetch data for /_api/cluster/agency-dump from leader of the agency.
-  Add option "redirectToLeader=true" to internal /_api/agency/state API.
+* Fix a race problem in the unit tests w.r.t. PlanSyncer.
 
 * Added startup option `--rocksdb.encryption-key-rotation` to
   activate/deactivate the encryption key rotation REST API. The API is disabled

--- a/arangod/Cluster/AgencyCallback.cpp
+++ b/arangod/Cluster/AgencyCallback.cpp
@@ -28,7 +28,6 @@
 
 #include <velocypack/velocypack-aliases.h>
 
-#include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/ConditionLocker.h"
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"
@@ -44,7 +43,7 @@ AgencyCallback::AgencyCallback(application_features::ApplicationServer& server, 
                                std::function<bool(VPackSlice const&)> const& cb,
                                bool needsValue, bool needsInitialValue)
     : key(key),
-      _agency(server),
+      _server(server),
       _cb(cb),
       _needsValue(needsValue),
       _wasSignaled(false),
@@ -56,6 +55,9 @@ AgencyCallback::AgencyCallback(application_features::ApplicationServer& server, 
 
 void AgencyCallback::local(bool b) {
   _local = b;
+  if (!b) {
+    _agency = std::make_unique<AgencyComm>(_server);
+  }
 }
 
 bool AgencyCallback::local() const {
@@ -83,11 +85,11 @@ void AgencyCallback::refetchAndUpdate(bool needToAcquireMutex, bool forceCheck) 
     "Refetching and update for " << AgencyCommHelper::path(key);
   
   if (_local) {
-    auto& _cache = _agency.server().getFeature<ClusterFeature>().agencyCache();
+    auto& _cache = _server.getFeature<ClusterFeature>().agencyCache();
     std::tie(builder, idx) = _cache.read(std::vector<std::string>{AgencyCommHelper::path(key)});
     result = builder->slice();
     if (!result.isArray()) {
-      if (!_agency.server().isStopping()) {
+      if (!_server.isStopping()) {
         // only log errors if we are not already shutting down...
         // in case of shutdown this error is somewhat expected
         LOG_TOPIC("ec320", ERR, arangodb::Logger::CLUSTER)
@@ -96,9 +98,10 @@ void AgencyCallback::refetchAndUpdate(bool needToAcquireMutex, bool forceCheck) 
       return;
     }
   } else {
-    tmp = _agency.getValues(key);
+    TRI_ASSERT(_agency.get() != nullptr);
+    tmp = _agency->getValues(key);
     if (!tmp.successful()) {
-      if (!_agency.server().isStopping()) {
+      if (!_server.isStopping()) {
         // only log errors if we are not already shutting down...
         // in case of shutdown this error is somewhat expected
         LOG_TOPIC("fb402", ERR, arangodb::Logger::CLUSTER)
@@ -168,7 +171,7 @@ bool AgencyCallback::execute(std::shared_ptr<VPackBuilder> newData) {
 bool AgencyCallback::executeByCallbackOrTimeout(double maxTimeout) {
   // One needs to acquire the mutex of the condition variable
   // before entering this function!
-  if (!_agency.server().isStopping()) {
+  if (!_server.isStopping()) {
     if (_wasSignaled) {
       // ok, we have been signaled already, so there is no need to wait at all
       // directly refetch the values

--- a/arangod/Cluster/AgencyCallback.h
+++ b/arangod/Cluster/AgencyCallback.h
@@ -31,6 +31,7 @@
 #include <memory>
 
 #include "Agency/AgencyComm.h"
+#include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/ConditionVariable.h"
 
 namespace arangodb {
@@ -132,7 +133,8 @@ class AgencyCallback {
   //////////////////////////////////////////////////////////////////////////////
 
  private:
-  AgencyComm _agency;
+  application_features::ApplicationServer& _server;
+  std::unique_ptr<AgencyComm> _agency;
   std::function<bool(velocypack::Slice const&)> const _cb;
   std::shared_ptr<velocypack::Builder> _lastData;
   bool const _needsValue;

--- a/tests/IResearch/IResearchFeature-test.cpp
+++ b/tests/IResearch/IResearchFeature-test.cpp
@@ -850,7 +850,7 @@ class IResearchFeatureTestCoordinator
 TEST_F(IResearchFeatureTestCoordinator, test_upgrade0_1) {
   // test coordinator
   auto collectionJson = arangodb::velocypack::Parser::fromJson(
-      "{ \"id\": \"1\", \"name\": \"testCollection\", \"shards\":{} }");
+      "{ \"id\": \"41\", \"name\": \"testCollection\", \"shards\":{} }");
   auto linkJson = arangodb::velocypack::Parser::fromJson(
       "{ \"view\": \"testView\", \"type\": \"arangosearch\", "
       "\"includeAllFields\": true }");
@@ -859,7 +859,7 @@ TEST_F(IResearchFeatureTestCoordinator, test_upgrade0_1) {
       "\"version\": 0 }");
   auto versionJson = arangodb::velocypack::Parser::fromJson(
       "{ \"version\": 0, \"tasks\": {} }");
-  auto collectionId = std::to_string(1);
+  auto collectionId = std::to_string(41);
   auto viewId = std::to_string(42);
 
   // add the UpgradeFeature, but make sure it is not prepared


### PR DESCRIPTION
A local AgencyCallback object does not need an AgencyComm instance.