### PR TITLE
Unify regular and audit logging

### DIFF
--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -2524,7 +2524,7 @@ struct Shower final : public WalkerWorker<ExecutionNode, WalkerUniqueness::NonUn
     }
   }
 
-  static LoggerStream& logNode(LoggerStream& log, ExecutionNode const& node) {
+  static LoggerStreamBase& logNode(LoggerStreamBase& log, ExecutionNode const& node) {
     return log << "[" << node.id() << "]" << detailedNodeType(node);
   }
 

--- a/lib/Logger/LogAppender.cpp
+++ b/lib/Logger/LogAppender.cpp
@@ -34,6 +34,7 @@
 #include "Basics/operating-system.h"
 #include "Logger/LogAppenderFile.h"
 #include "Logger/LogAppenderSyslog.h"
+#include "Logger/LogGroup.h"
 #include "Logger/LogMacros.h"
 #include "Logger/LogTopic.h"
 #include "Logger/Logger.h"
@@ -43,21 +44,22 @@ using namespace arangodb;
 using namespace arangodb::basics;
 
 arangodb::Mutex LogAppender::_appendersLock;
-  
-std::vector<std::shared_ptr<LogAppender>> LogAppender::_globalAppenders;
 
-std::map<size_t, std::vector<std::shared_ptr<LogAppender>>> LogAppender::_topics2appenders;
+std::unordered_map<std::type_index, std::vector<std::shared_ptr<LogAppender>>> LogAppender::_globalAppenders;
 
-std::map<std::string, std::shared_ptr<LogAppender>> LogAppender::_definition2appenders;
+std::unordered_map<std::type_index, std::map<size_t, std::vector<std::shared_ptr<LogAppender>>>> LogAppender::_topics2appenders;
+
+std::unordered_map<std::type_index, std::map<std::string, std::shared_ptr<LogAppender>>> LogAppender::_definition2appenders;
 
 bool LogAppender::_allowStdLogging = true;
 
-void LogAppender::addGlobalAppender(std::shared_ptr<LogAppender> appender) {
+void LogAppender::addGlobalAppender(LogGroup const& group,
+                                    std::shared_ptr<LogAppender> appender) {
   MUTEX_LOCKER(guard, _appendersLock);
-  _globalAppenders.emplace_back(std::move(appender));
+  _globalAppenders[group.id()].emplace_back(std::move(appender));
 }
-  
-void LogAppender::addAppender(std::string const& definition) {
+
+void LogAppender::addAppender(LogGroup const& group, std::string const& definition) {
   std::string topicName;
   std::string output;
   LogTopic* topic = nullptr;
@@ -78,33 +80,38 @@ void LogAppender::addAppender(std::string const& definition) {
 
   std::shared_ptr<LogAppender> appender;
 
-  MUTEX_LOCKER(guard, _appendersLock);
-  
-  auto it = _definition2appenders.find(key);
+  auto& definitionsMap = _definition2appenders[group.id()];
 
-  if (it != _definition2appenders.end()) {
+  MUTEX_LOCKER(guard, _appendersLock);
+
+  auto it = definitionsMap.find(key);
+
+  if (it != definitionsMap.end()) {
     // found an existing appender
     appender = it->second;
   } else {
     // build a new appender from the definition
-    appender = buildAppender(output);
+    appender = buildAppender(group, output);
     if (appender == nullptr) {
       // cannot create appender, for whatever reason
       return;
     }
-  
-    _definition2appenders[key] = appender;
+
+    definitionsMap[key] = appender;
   }
 
   TRI_ASSERT(appender != nullptr);
 
+  auto& topicsMap = _topics2appenders[group.id()];
   size_t n = (topic == nullptr) ? LogTopic::MAX_LOG_TOPICS : topic->id();
-  if (std::find(_topics2appenders[n].begin(), _topics2appenders[n].end(), appender) == _topics2appenders[n].end()) {
-    _topics2appenders[n].emplace_back(appender);
+  if (std::find(topicsMap[n].begin(), topicsMap[n].end(), appender) ==
+      topicsMap[n].end()) {
+    topicsMap[n].emplace_back(appender);
   }
 }
 
-std::shared_ptr<LogAppender> LogAppender::buildAppender(std::string const& output) {
+std::shared_ptr<LogAppender> LogAppender::buildAppender(LogGroup const& group,
+                                                        std::string const& output) {
 #ifdef ARANGODB_ENABLE_SYSLOG
   // first handle syslog-logging
   if (StringUtils::isPrefix(output, "syslog://")) {
@@ -122,7 +129,7 @@ std::shared_ptr<LogAppender> LogAppender::buildAppender(std::string const& outpu
 #endif
 
   if (output == "+" || output == "-") {
-    for (auto const& it : _definition2appenders) {
+    for (auto const& it : _definition2appenders[group.id()]) {
       if (it.first == "+" || it.first == "-") {
         // alreay got a logger for stderr/stdout
         return nullptr;
@@ -144,22 +151,26 @@ std::shared_ptr<LogAppender> LogAppender::buildAppender(std::string const& outpu
   return result;
 }
 
-void LogAppender::logGlobal(LogMessage const& message) {
+void LogAppender::logGlobal(LogGroup const& group, LogMessage const& message) {
   MUTEX_LOCKER(guard, _appendersLock);
-  
+
+  auto& appenders = _globalAppenders[group.id()];
+
   // append to global appenders first
-  for (auto const& appender : _globalAppenders) {
+  for (auto const& appender : appenders) {
     appender->logMessage(message);
   }
 }
 
-void LogAppender::log(LogMessage const& message) {
+void LogAppender::log(LogGroup const& group, LogMessage const& message) {
   // output to appenders
-  auto output = [&message](size_t n) -> bool {
+  auto& topicsMap = _topics2appenders[group.id()];
+  auto output = [&topicsMap](LogGroup const& group, LogMessage const& message,
+                             size_t n) -> bool {
     bool shown = false;
 
-    auto const& it = _topics2appenders.find(n);
-    if (it != _topics2appenders.end()) {
+    auto const& it = topicsMap.find(n);
+    if (it != topicsMap.end() && !it->second.empty()) {
       auto const& appenders = it->second;
 
       for (auto const& appender : appenders) {
@@ -170,7 +181,7 @@ void LogAppender::log(LogMessage const& message) {
 
     return shown;
   };
-  
+
   bool shown = false;
 
   // try to find a topic-specific appender
@@ -179,12 +190,12 @@ void LogAppender::log(LogMessage const& message) {
   MUTEX_LOCKER(guard, _appendersLock);
  
   if (topicId < LogTopic::MAX_LOG_TOPICS) {
-    shown = output(topicId);
+    shown = output(group, message, topicId);
   }
 
   // otherwise use the general topic appender
   if (!shown) {
-    output(LogTopic::MAX_LOG_TOPICS);
+    output(group, message, LogTopic::MAX_LOG_TOPICS);
   }
 }
 
@@ -260,4 +271,21 @@ Result LogAppender::parseDefinition(std::string const& definition,
   }
  
   return Result();
+}
+
+bool LogAppender::haveAppenders(LogGroup const& group) {
+  auto& appenders = _topics2appenders[group.id()];
+  bool haveSome = false;
+  for (auto& list : appenders) {
+    if (!list.second.empty()) {
+      haveSome = true;
+      break;
+    }
+  }
+  return haveSome;
+}
+
+bool LogAppender::haveAppenders(LogGroup const& group, size_t topicId) {
+  return !_topics2appenders[group.id()][topicId].empty() ||
+         !_topics2appenders[group.id()][LogTopic::MAX_LOG_TOPICS].empty();
 }

--- a/lib/Logger/LogAppender.h
+++ b/lib/Logger/LogAppender.h
@@ -30,6 +30,7 @@
 #include <memory>
 #include <string>
 #include <typeindex>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/lib/Logger/LogAppender.h
+++ b/lib/Logger/LogAppender.h
@@ -25,12 +25,12 @@
 #define ARANGODB_LOGGER_LOG_APPENDER_H 1
 
 #include <stddef.h>
+#include <array>
 #include <functional>
 #include <map>
 #include <memory>
 #include <string>
 #include <typeindex>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/lib/Logger/LogAppender.h
+++ b/lib/Logger/LogAppender.h
@@ -36,10 +36,10 @@
 
 #include "Basics/Common.h"
 #include "Basics/Result.h"
+#include "Logger/LogGroup.h"
 #include "Logger/LogLevel.h"
 
 namespace arangodb {
-class LogGroup;
 class LogTopic;
 struct LogMessage;
 class Mutex;
@@ -59,7 +59,6 @@ class LogAppender {
   static void reopen();
   static void shutdown();
 
-  static bool haveAppenders(LogGroup const&);
   static bool haveAppenders(LogGroup const&, size_t topicId);
 
  public:
@@ -84,9 +83,9 @@ class LogAppender {
  
  private:
   static Mutex _appendersLock;
-  static std::unordered_map<std::type_index, std::vector<std::shared_ptr<LogAppender>>> _globalAppenders;
-  static std::unordered_map<std::type_index, std::map<size_t, std::vector<std::shared_ptr<LogAppender>>>> _topics2appenders;
-  static std::unordered_map<std::type_index, std::map<std::string, std::shared_ptr<LogAppender>>> _definition2appenders;
+  static std::array<std::vector<std::shared_ptr<LogAppender>>, LogGroup::Count> _globalAppenders;
+  static std::array<std::map<size_t, std::vector<std::shared_ptr<LogAppender>>>, LogGroup::Count> _topics2appenders;
+  static std::array<std::map<std::string, std::shared_ptr<LogAppender>>, LogGroup::Count> _definition2appenders;
   static bool _allowStdLogging;
 };
 }  // namespace arangodb

--- a/lib/Logger/LogBufferFeature.cpp
+++ b/lib/Logger/LogBufferFeature.cpp
@@ -207,7 +207,7 @@ void LogBufferFeature::prepare() {
     // in the ctor, we would waste a lot of memory in case we don't need the in-memory
     // appender. this is the case for simple command such as `--help` etc.
     _inMemoryAppender = std::make_shared<LogAppenderRingBuffer>();
-    LogAppender::addGlobalAppender(_inMemoryAppender);
+    LogAppender::addGlobalAppender(Logger::defaultLogGroup(), _inMemoryAppender);
   }
 }
 

--- a/lib/Logger/LogBufferFeature.cpp
+++ b/lib/Logger/LogBufferFeature.cpp
@@ -188,8 +188,10 @@ LogBufferFeature::LogBufferFeature(application_features::ApplicationServer& serv
   startsAfter<LoggerFeature>();
   
 #ifdef _WIN32
-  LogAppender::addGlobalAppender(std::make_shared<LogAppenderDebugOutput>());
-  LogAppender::addGlobalAppender(std::make_shared<LogAppenderEventLog>());
+  LogAppender::addGlobalAppender(Logger::defaultLogGroup(),
+                                 std::make_shared<LogAppenderDebugOutput>());
+  LogAppender::addGlobalAppender(Logger::defaultLogGroup(),
+                                 std::make_shared<LogAppenderEventLog>());
 #endif
 }
   

--- a/lib/Logger/LogGroup.h
+++ b/lib/Logger/LogGroup.h
@@ -1,0 +1,39 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2016 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2013 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Dan Larkin-York
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef ARANGODB_LOGGER_LOG_GROUP_H
+#define ARANGODB_LOGGER_LOG_GROUP_H 1
+
+#include <typeindex>
+
+namespace arangodb {
+
+class LogGroup {
+ public:
+  virtual ~LogGroup() = default;
+  virtual std::type_index id() const = 0;
+};
+
+}  // namespace arangodb
+
+#endif

--- a/lib/Logger/LogMacros.h
+++ b/lib/Logger/LogMacros.h
@@ -58,8 +58,9 @@
 #ifndef ARANGODB_LOGGER_LOG_MACROS_H
 #define ARANGODB_LOGGER_LOG_MACROS_H 1
 
-#include "Logger.h"
-#include "LoggerStream.h"
+#include "Logger/LogVoidify.h"
+#include "Logger/Logger.h"
+#include "Logger/LoggerStream.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief logs a message for a topic
@@ -106,21 +107,5 @@
 
 #define LOG_DEVEL_IF(cond) \
   LOG_TOPIC_IF("xxxxx", LOG_DEVEL_LEVEL, ::arangodb::Logger::FIXME, (cond)) << "###### "
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief helper class for macros
-////////////////////////////////////////////////////////////////////////////////
-
-namespace arangodb {
-
-class LoggerStream;
-
-class LogVoidify {
- public:
-  LogVoidify() {}
-  void operator&(LoggerStream const&) {}
-};
-
-}  // namespace arangodb
 
 #endif

--- a/lib/Logger/LogThread.cpp
+++ b/lib/Logger/LogThread.cpp
@@ -38,13 +38,13 @@ LogThread::~LogThread() {
   shutdown();
 }
 
-bool LogThread::log(std::unique_ptr<LogMessage>& message) {
+bool LogThread::log(LogGroup& group, std::unique_ptr<LogMessage>& message) {
   TRI_ASSERT(message != nullptr);
 
   bool const isDirectLogLevel =
              (message->_level == LogLevel::FATAL || message->_level == LogLevel::ERR || message->_level == LogLevel::WARN);
 
-  if (!_messages.push(message.get())) {
+  if (!_messages.push({&group, message.get()})) {
     return false;
   }
 
@@ -103,17 +103,18 @@ void LogThread::run() {
 
 bool LogThread::processPendingMessages() {
   bool worked = false;
-  LogMessage* msg = nullptr;
+  MessageEnvelope env{nullptr, nullptr};
 
-  while (_messages.pop(msg)) {
+  while (_messages.pop(env)) {
     worked = true;
-    TRI_ASSERT(msg != nullptr);
+    TRI_ASSERT(env.group != nullptr);
+    TRI_ASSERT(env.msg != nullptr);
     try {
-      LogAppender::log(*msg);
+      LogAppender::log(*env.group, *env.msg);
     } catch (...) {
     }
 
-    delete msg;
+    delete env.msg;
   }
   return worked;
 }

--- a/lib/Logger/LogThread.h
+++ b/lib/Logger/LogThread.h
@@ -30,6 +30,7 @@
 #include <boost/lockfree/queue.hpp>
 
 namespace arangodb {
+class LogGroup;
 namespace application_features {
 class ApplicationServer;
 }
@@ -40,6 +41,11 @@ class ConditionVariable;
 struct LogMessage;
 
 class LogThread final : public Thread {
+  struct MessageEnvelope {
+    LogGroup* group;
+    LogMessage* msg;
+  };
+
  public:
   explicit LogThread(application_features::ApplicationServer& server,
                      std::string const& name);
@@ -49,8 +55,8 @@ class LogThread final : public Thread {
   bool isSystem() const override { return true; }
   bool isSilent() const override { return true; }
   void run() override;
-  
-  bool log(std::unique_ptr<LogMessage>&);
+
+  bool log(LogGroup&, std::unique_ptr<LogMessage>&);
   // flush all pending log messages
   void flush() noexcept;
 
@@ -65,7 +71,7 @@ class LogThread final : public Thread {
 
  private:
   arangodb::basics::ConditionVariable _condition;
-  boost::lockfree::queue<LogMessage*> _messages;
+  boost::lockfree::queue<MessageEnvelope> _messages;
 };
 }  // namespace arangodb
 

--- a/lib/Logger/LogTopic.cpp
+++ b/lib/Logger/LogTopic.cpp
@@ -222,4 +222,5 @@ LogTopic::LogTopic(std::string const& name, LogLevel level)
   }
 
   Topics::instance().emplace(name, this);
+  TRI_ASSERT(_id < MAX_LOG_TOPICS);
 }

--- a/lib/Logger/LogTopic.h
+++ b/lib/Logger/LogTopic.h
@@ -37,7 +37,7 @@ class LogTopic {
   LogTopic& operator=(LogTopic const&) = delete;
 
  public:
-  static size_t const MAX_LOG_TOPICS = 64;
+  static constexpr size_t MAX_LOG_TOPICS = 64;
 
  public:
   static std::vector<std::pair<std::string, LogLevel>> logLevelTopics();

--- a/lib/Logger/LogVoidify.h
+++ b/lib/Logger/LogVoidify.h
@@ -18,25 +18,23 @@
 ///
 /// Copyright holder is ArangoDB GmbH, Cologne, Germany
 ///
-/// @author Dan Larkin-York
+/// @author Dr. Frank Celler
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef ARANGODB_LOGGER_LOG_GROUP_H
-#define ARANGODB_LOGGER_LOG_GROUP_H 1
+#ifndef ARANGODB_LOGGER_LOG_VOIDIFY_H
+#define ARANGODB_LOGGER_LOG_VOIDIFY_H 1
 
-#include <cstddef>
+////////////////////////////////////////////////////////////////////////////////
+/// @brief helper class for macros
+////////////////////////////////////////////////////////////////////////////////
 
 namespace arangodb {
+class LoggerStreamBase;
 
-class LogGroup {
+class LogVoidify {
  public:
-  // @brief Number of log groups; must increase this when a new group is added
-  static constexpr std::size_t Count = 2;
-  virtual ~LogGroup() = default;
-
-  /// @brief Must return a UNIQUE identifier amongst all LogGroup derivatives
-  /// and must be less than Count
-  virtual std::size_t id() const = 0;
+  LogVoidify() {}
+  void operator&(LoggerStreamBase const&) {}
 };
 
 }  // namespace arangodb

--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -571,7 +571,7 @@ void Logger::log(char const* logid, char const* function, char const* file, int 
 }
 
 void Logger::append(LogGroup& group, std::unique_ptr<LogMessage>& msg,
-                    std::function<void(std::unique_ptr<LogMessage>&)> inactive) {
+                    std::function<void(std::unique_ptr<LogMessage>&)> const& inactive) {
   // first log to all "global" appenders, which are the in-memory ring buffer logger plus
   // some Windows-specifc appenders for the debug output windows and the Windows event log.
   // note that these loggers do not require any configuration so we can always and safely invoke them.

--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -73,9 +73,7 @@ static std::string const UNKNOWN = "UNKNOWN";
 std::string const LogThreadName("Logging");
 
 class DefaultLogGroup : public LogGroup {
-  std::type_index id() const {
-    return std::type_index(typeid(DefaultLogGroup));
-  }
+  std::size_t id() const { return 0; }
 };
 DefaultLogGroup defaultLogGroupInstance;
 

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -284,7 +284,7 @@ class Logger {
                   LogLevel level, size_t topicId, std::string const& message);
 
   static void append(LogGroup&, std::unique_ptr<LogMessage>& msg,
-                     std::function<void(std::unique_ptr<LogMessage>&)> inactive =
+                     std::function<void(std::unique_ptr<LogMessage>&)> const& inactive =
                          [](std::unique_ptr<LogMessage>&) -> void {});
 
   static bool isEnabled(LogLevel level) {

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -61,6 +61,7 @@
 
 #include <stddef.h>
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
@@ -77,6 +78,7 @@ namespace arangodb {
 namespace application_features {
 class ApplicationServer;
 }
+class LogGroup;
 class LogThread;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -244,6 +246,7 @@ class Logger {
   };
 
  public:
+  static LogGroup& defaultLogGroup();
   static LogLevel logLevel();
   static std::vector<std::pair<std::string, LogLevel>> logLevelTopics();
   static void setLogLevel(LogLevel);
@@ -279,6 +282,10 @@ class Logger {
 
   static void log(char const* logid, char const* function, char const* file, int line,
                   LogLevel level, size_t topicId, std::string const& message);
+
+  static void append(LogGroup&, std::unique_ptr<LogMessage>& msg,
+                     std::function<void(std::unique_ptr<LogMessage>&)> inactive =
+                         [](std::unique_ptr<LogMessage>&) -> void {});
 
   static bool isEnabled(LogLevel level) {
     return (int)level <= (int)_level.load(std::memory_order_relaxed);

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -373,14 +373,15 @@ void LoggerFeature::prepare() {
 
   for (auto const& definition : _output) {
     if (_supervisor && StringUtils::isPrefix(definition, "file://")) {
-      LogAppender::addAppender(definition + ".supervisor");
+      LogAppender::addAppender(Logger::defaultLogGroup(),
+                               definition + ".supervisor");
     } else {
-      LogAppender::addAppender(definition);
+      LogAppender::addAppender(Logger::defaultLogGroup(), definition);
     }
   }
 
   if (_foregroundTty) {
-    LogAppender::addAppender("-");
+    LogAppender::addAppender(Logger::defaultLogGroup(), "-");
   }
 
   if (_forceDirect || _supervisor) {

--- a/lib/Logger/LoggerStream.h
+++ b/lib/Logger/LoggerStream.h
@@ -33,62 +33,37 @@
 #include "Logger/Logger.h"
 
 namespace arangodb {
-class LoggerStream {
+class LoggerStreamBase {
  public:
-  LoggerStream(LoggerStream const&) = delete;
-  LoggerStream& operator=(LoggerStream const&) = delete;
+  LoggerStreamBase(LoggerStreamBase const&) = delete;
+  LoggerStreamBase& operator=(LoggerStreamBase const&) = delete;
 
-  LoggerStream()
-      : _topicId(LogTopic::MAX_LOG_TOPICS),
-        _level(LogLevel::DEFAULT),
-        _line(0),
-        _logid(nullptr),
-        _file(nullptr),
-        _function(nullptr) {}
-
-  ~LoggerStream();
+  LoggerStreamBase();
+  virtual ~LoggerStreamBase() = default;
 
  public:
-  LoggerStream& operator<<(LogLevel const& level) noexcept {
-    _level = level;
-    return *this;
-  }
+  LoggerStreamBase& operator<<(LogLevel const& level) noexcept;
 
-  LoggerStream& operator<<(LogTopic const& topic) noexcept {
-    _topicId = topic.id();
-    return *this;
-  }
+  LoggerStreamBase& operator<<(LogTopic const& topic) noexcept;
 
-  LoggerStream& operator<<(Logger::BINARY const& binary);
+  LoggerStreamBase& operator<<(Logger::BINARY const& binary);
 
-  LoggerStream& operator<<(Logger::CHARS const& chars);
+  LoggerStreamBase& operator<<(Logger::CHARS const& chars);
 
-  LoggerStream& operator<<(Logger::RANGE const& range);
+  LoggerStreamBase& operator<<(Logger::RANGE const& range);
 
-  LoggerStream& operator<<(Logger::FIXED const& duration);
+  LoggerStreamBase& operator<<(Logger::FIXED const& duration);
 
-  LoggerStream& operator<<(Logger::LINE const& line) noexcept {
-    _line = line._line;
-    return *this;
-  }
+  LoggerStreamBase& operator<<(Logger::LINE const& line) noexcept;
 
-  LoggerStream& operator<<(Logger::FILE const& file) noexcept {
-    _file = file._file;
-    return *this;
-  }
+  LoggerStreamBase& operator<<(Logger::FILE const& file) noexcept;
 
-  LoggerStream& operator<<(Logger::FUNCTION const& function) noexcept {
-    _function = function._function;
-    return *this;
-  }
+  LoggerStreamBase& operator<<(Logger::FUNCTION const& function) noexcept;
 
-  LoggerStream& operator<<(Logger::LOGID const& logid) noexcept {
-    _logid = logid._logid;
-    return *this;
-  }
+  LoggerStreamBase& operator<<(Logger::LOGID const& logid) noexcept;
 
   template <typename T>
-  LoggerStream& operator<<(T const& obj) {
+  LoggerStreamBase& operator<<(T const& obj) {
     try {
       _out << obj;
     } catch (...) {
@@ -97,7 +72,7 @@ class LoggerStream {
     return *this;
   }
 
- private:
+ protected:
   std::stringstream _out;
   size_t _topicId;
   LogLevel _level;
@@ -106,6 +81,12 @@ class LoggerStream {
   char const* _file;
   char const* _function;
 };
+
+class LoggerStream : public LoggerStreamBase {
+ public:
+  ~LoggerStream();
+};
+
 }  // namespace arangodb
 
 #endif

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -102,7 +102,7 @@ int main(int argc, char* argv[]) {
 
   arangodb::Logger::setShowLineNumber(logLineNumbers);
   arangodb::Logger::initialize(server, false);
-  arangodb::LogAppender::addAppender("-");
+  arangodb::LogAppender::addAppender(arangodb::Logger::defaultLogGroup(), "-");
 
   sc.prepare();
 


### PR DESCRIPTION
### Scope & Purpose

Currently audit logging owns its own LogAppenders and directly logs to them in the calling thread. On the other hand, the regular logger will generally dispatch messages to a background thread and write them out to the LogAppenders from there. This PR moves the audit appenders into the regular logging framework, introducing the notion of LogGroups. It then refactors the logging code a bit so that the audit logger and regular logger can call the same append method to dispatch messages to the background thread.

- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)

Enterprise component: https://github.com/arangodb/enterprise/pull/524

### Testing & Verification

This change is a trivial rework / code cleanup without any test coverage.

Jenkins: https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/11309/