### PR TITLE
remove AqlValue(VPackBuilder) ctor, as it is just redundant

### DIFF
--- a/arangod/Aql/AqlValue.cpp
+++ b/arangod/Aql/AqlValue.cpp
@@ -1068,7 +1068,8 @@ void AqlValue::toVelocyPack(VPackOptions const* options, arangodb::velocypack::B
       if (!resolveExternals && isManagedDocument()) {
         builder.addExternal(_data.pointer);
         break;
-      }  [[fallthrough]];
+      }  
+      [[fallthrough]];
     case VPACK_INLINE:
     case VPACK_MANAGED_SLICE:
     case VPACK_MANAGED_BUFFER: {
@@ -1181,10 +1182,10 @@ AqlValue AqlValue::clone() const {
 /// @brief destroy the value's internals
 void AqlValue::destroy() noexcept {
   switch (type()) {
-    case VPACK_INLINE: {
-      case VPACK_SLICE_POINTER:
-        // nothing to do
-        return;
+    case VPACK_INLINE: 
+    case VPACK_SLICE_POINTER: {
+      // nothing to do
+      return;
     }
     case VPACK_MANAGED_SLICE: {
       delete[] _data.slice;
@@ -1506,9 +1507,7 @@ AqlValue::AqlValue(char const* value, size_t length) {
     // empty string
     _data.internal[0] = 0x40;
     setType(AqlValueType::VPACK_INLINE);
-    return;
-  }
-  if (length < sizeof(_data.internal) - 1) {
+  } else if (length < sizeof(_data.internal) - 1) {
     // short string... can store it inline
     _data.internal[0] = static_cast<uint8_t>(0x40 + length);
     memcpy(_data.internal + 1, value, length);
@@ -1536,7 +1535,7 @@ AqlValue::AqlValue(char const* value, size_t length) {
 }
 
 AqlValue::AqlValue(std::string const& value)
-    : AqlValue(value.c_str(), value.size()) {}
+    : AqlValue(value.data(), value.size()) {}
 
 AqlValue::AqlValue(AqlValueHintEmptyArray const&) noexcept {
   _data.internal[0] = 0x01;  // empty array in VPack
@@ -1578,11 +1577,6 @@ AqlValue::AqlValue(AqlValueHintDocumentNoCopy const& v) noexcept {
 AqlValue::AqlValue(AqlValueHintCopy const& v) {
   TRI_ASSERT(v.ptr != nullptr);
   initFromSlice(VPackSlice(v.ptr));
-}
-
-AqlValue::AqlValue(arangodb::velocypack::Builder const& builder) {
-  TRI_ASSERT(builder.isClosed());
-  initFromSlice(builder.slice());
 }
 
 AqlValue::AqlValue(arangodb::velocypack::Slice const& slice) {
@@ -1702,9 +1696,11 @@ AqlValueHintDouble::AqlValueHintDouble(double v) noexcept : value(v) {}
 AqlValueHintInt::AqlValueHintInt(int64_t v) noexcept : value(v) {}
 AqlValueHintInt::AqlValueHintInt(int v) noexcept : value(int64_t(v)) {}
 AqlValueHintUInt::AqlValueHintUInt(uint64_t v) noexcept : value(v) {}
+
 AqlValueGuard::AqlValueGuard(AqlValue& value, bool destroy) noexcept
     : _value(value), _destroy(destroy) {}
-AqlValueGuard::~AqlValueGuard() {
+
+AqlValueGuard::~AqlValueGuard() noexcept {
   if (_destroy) {
     _value.destroy();
   }

--- a/arangod/Aql/AqlValue.h
+++ b/arangod/Aql/AqlValue.h
@@ -218,9 +218,6 @@ struct AqlValue final {
   // construct from pointer, copying the data behind the pointer
   explicit AqlValue(AqlValueHintCopy const& v);
 
-  // construct from Builder, copying contents
-  explicit AqlValue(arangodb::velocypack::Builder const& builder);
-
   // construct from Slice, copying contents
   explicit AqlValue(arangodb::velocypack::Slice const& slice);
 
@@ -405,7 +402,7 @@ class AqlValueGuard {
   AqlValueGuard& operator=(AqlValueGuard&&) = delete;
 
   AqlValueGuard(AqlValue& value, bool destroy) noexcept;
-  ~AqlValueGuard();
+  ~AqlValueGuard() noexcept;
 
   void steal() noexcept;
   AqlValue& value() noexcept;

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -2883,6 +2883,7 @@ void AstNode::setDoubleValue(double v) {
 }
 
 char const* AstNode::getStringValue() const { return value.value._string; }
+
 size_t AstNode::getStringLength() const {
   return static_cast<size_t>(value.length);
 }

--- a/arangod/Aql/DocumentExpressionContext.cpp
+++ b/arangod/Aql/DocumentExpressionContext.cpp
@@ -30,7 +30,7 @@ using namespace arangodb::aql;
 DocumentExpressionContext::DocumentExpressionContext(arangodb::transaction::Methods& trx,
                                                      QueryContext& query,
                                                      AqlFunctionsInternalCache& cache,
-                                                     arangodb::velocypack::Slice document)
+                                                     arangodb::velocypack::Slice document) noexcept
     : QueryExpressionContext(trx, query, cache), _document(document) {}
 
 AqlValue DocumentExpressionContext::getVariableValue(Variable const*, bool doCopy,

--- a/arangod/Aql/DocumentExpressionContext.h
+++ b/arangod/Aql/DocumentExpressionContext.h
@@ -34,7 +34,7 @@ namespace aql {
 class DocumentExpressionContext final : public QueryExpressionContext {
  public:
   DocumentExpressionContext(transaction::Methods& trx, QueryContext& query,
-                            AqlFunctionsInternalCache& cache, arangodb::velocypack::Slice document);
+                            AqlFunctionsInternalCache& cache, arangodb::velocypack::Slice document) noexcept;
 
   ~DocumentExpressionContext() = default;
 

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -738,7 +738,7 @@ AqlValue Expression::executeSimpleExpressionObject(AstNode const* node,
 
   mustDestroy = true;  // AqlValue contains builder contains dynamic data
 
-  return AqlValue(*builder.get());
+  return AqlValue(builder->slice());
 }
 
 /// @brief execute an expression of type SIMPLE with VALUE
@@ -1502,7 +1502,7 @@ AqlValue Expression::executeSimpleExpressionExpansion(AstNode const* node,
     builder.close();
 
     mustDestroy = true;  // builder = dynamic data
-    value = AqlValue(builder);
+    value = AqlValue(builder.slice());
   } else {
     bool localMustDestroy;
     AqlValue a = executeSimpleExpression(node->getMember(0), trx, localMustDestroy, false);
@@ -1594,7 +1594,7 @@ AqlValue Expression::executeSimpleExpressionExpansion(AstNode const* node,
 
   builder.close();
   mustDestroy = true;
-  return AqlValue(builder);  // builder = dynamic data
+  return AqlValue(builder.slice());  // builder = dynamic data
 }
 
 /// @brief execute an expression of type SIMPLE with ITERATOR

--- a/arangod/Aql/ExpressionContext.h
+++ b/arangod/Aql/ExpressionContext.h
@@ -31,7 +31,6 @@ struct TRI_vocbase_t;
 namespace arangodb {
 struct ValidatorBase;
 namespace transaction {
-class BufferCache ;
 class Methods;
 }
 namespace velocypack {

--- a/arangod/Aql/KShortestPathsExecutor.cpp
+++ b/arangod/Aql/KShortestPathsExecutor.cpp
@@ -209,11 +209,11 @@ auto KShortestPathsExecutor::fetchPaths(AqlItemBlockInputRange& input) -> bool {
 }
 
 auto KShortestPathsExecutor::doOutputPath(OutputAqlItemRow& output) -> void {
-  auto tmp = transaction::BuilderLeaser{_finder.options().trx()};
+  transaction::BuilderLeaser tmp{_finder.options().trx()};
   tmp->clear();
 
   if (_finder.getNextPathAql(*tmp.builder())) {
-    AqlValue path{*tmp.builder()};
+    AqlValue path{tmp->slice()};
     AqlValueGuard guard{path, true};
     output.moveValueInto(_infos.getOutputRegister(), _inputRow, guard);
     output.advanceRow();

--- a/arangod/Aql/QueryExpressionContext.h
+++ b/arangod/Aql/QueryExpressionContext.h
@@ -36,7 +36,7 @@ class QueryExpressionContext : public ExpressionContext {
  public:
   explicit QueryExpressionContext(transaction::Methods& trx,
                                   QueryContext& query,
-                                  AqlFunctionsInternalCache& cache)
+                                  AqlFunctionsInternalCache& cache) noexcept
       : ExpressionContext(),
         _trx(trx), _query(query), _aqlFunctionsInternalCache(cache) {}
 

--- a/arangod/Transaction/Context.h
+++ b/arangod/Transaction/Context.h
@@ -95,10 +95,10 @@ class Context {
   void returnString(std::string* str) noexcept;
 
   /// @brief temporarily lease a Builder object
-  arangodb::velocypack::Builder* leaseBuilder();
+  TEST_VIRTUAL arangodb::velocypack::Builder* leaseBuilder();
 
   /// @brief return a temporary Builder object
-  void returnBuilder(arangodb::velocypack::Builder*) noexcept;
+  TEST_VIRTUAL void returnBuilder(arangodb::velocypack::Builder*) noexcept;
 
   /// @brief get velocypack options with a custom type handler
   TEST_VIRTUAL arangodb::velocypack::Options* getVPackOptions();

--- a/tests/Aql/DateFunctionsTest.cpp
+++ b/tests/Aql/DateFunctionsTest.cpp
@@ -117,7 +117,7 @@ struct TestDate {
   }
 
   void buildParams(VPackFunctionParameters& input) const {
-    input.emplace_back(*_date);
+    input.emplace_back(_date->slice());
   }
 
   void validateResult(AqlValue const& result) const {

--- a/tests/Geo/GeoConstructorTest.cpp
+++ b/tests/Geo/GeoConstructorTest.cpp
@@ -71,6 +71,8 @@ class GeoConstructorTest : public ::testing::Test {
         params{arena} {
     fakeit::When(Method(trxMock, transactionContextPtr)).AlwaysReturn(&context);
     fakeit::When(Method(contextMock, getVPackOptions)).AlwaysReturn(&velocypack::Options::Defaults);
+    fakeit::When(Method(contextMock, leaseBuilder)).AlwaysDo([]() { return new arangodb::velocypack::Builder(); });
+    fakeit::When(Method(contextMock, returnBuilder)).AlwaysDo([](arangodb::velocypack::Builder* b) { delete b; });
   }
 };
 

--- a/tests/Geo/GeoFunctionsTest.cpp
+++ b/tests/Geo/GeoFunctionsTest.cpp
@@ -59,7 +59,7 @@ auto clearVector = [](SmallVector<AqlValue>& v) {
 };
 
 class GeoEqualsTest : public ::testing::Test {
-protected:
+ protected:
   fakeit::Mock<ExpressionContext> expressionContextMock;
   ExpressionContext& expressionContext;
 
@@ -82,6 +82,8 @@ protected:
           paramsC{arena} {
       fakeit::When(Method(trxMock, transactionContextPtr)).AlwaysReturn(&context);
       fakeit::When(Method(contextMock, getVPackOptions)).AlwaysReturn(&velocypack::Options::Defaults);
+      fakeit::When(Method(contextMock, leaseBuilder)).AlwaysDo([]() { return new arangodb::velocypack::Builder(); });
+      fakeit::When(Method(contextMock, returnBuilder)).AlwaysDo([](arangodb::velocypack::Builder* b) { delete b; });
     }
 
     ~GeoEqualsTest() {
@@ -95,469 +97,473 @@ protected:
 namespace geo_equals_point {
 class GeoEqualsPointTest : public GeoEqualsTest {};
 
-    TEST_F(GeoEqualsPointTest, checking_two_equal_points) {
-      VPackBuilder foo;
-      foo.openArray();
-      foo.add(VPackValue(1));
-      foo.add(VPackValue(-2.2));
-      foo.close();
-      paramsA.emplace_back(foo.slice().at(0));
-      paramsA.emplace_back(foo.slice().at(1));
-      AqlValue pointA = Functions::GeoPoint(&expressionContext, &trx, paramsA);
+TEST_F(GeoEqualsPointTest, checking_two_equal_points) {
+  VPackBuilder foo;
+  foo.openArray();
+  foo.add(VPackValue(1));
+  foo.add(VPackValue(-2.2));
+  foo.close();
+  paramsA.emplace_back(foo.slice().at(0));
+  paramsA.emplace_back(foo.slice().at(1));
+  AqlValue pointA = Functions::GeoPoint(&expressionContext, &trx, paramsA);
 
-      paramsC.emplace_back(pointA.clone());
-      paramsC.emplace_back(pointA.clone());
-      pointA.destroy();
+  paramsC.emplace_back(pointA.clone());
+  paramsC.emplace_back(pointA.clone());
+  pointA.destroy();
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      EXPECT_TRUE(resC.slice().isBoolean());
-      EXPECT_TRUE(resC.slice().getBool());
-    }
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  EXPECT_TRUE(resC.slice().isBoolean());
+  EXPECT_TRUE(resC.slice().getBool());
+}
 
-    TEST_F(GeoEqualsPointTest, checking_two_unequal_points) {
-      VPackBuilder foo;
-      foo.openArray();
-      foo.add(VPackValue(1));
-      foo.add(VPackValue(-2.2));
-      foo.close();
-      paramsA.emplace_back(foo.slice().at(0));
-      paramsA.emplace_back(foo.slice().at(1));
-      AqlValue pointA = Functions::GeoPoint(&expressionContext, &trx, paramsA);
-      paramsC.emplace_back(pointA.clone());
-      pointA.destroy();
-      
-      VPackBuilder bar;
-      bar.openArray();
-      bar.add(VPackValue(-2.2));
-      bar.add(VPackValue(-1));
-      bar.close();
-      paramsB.emplace_back(bar.slice().at(0));
-      paramsB.emplace_back(bar.slice().at(1));
-      AqlValue pointB = Functions::GeoPoint(&expressionContext, &trx, paramsB);
-      paramsC.emplace_back(pointB.clone());
-      pointB.destroy();
+TEST_F(GeoEqualsPointTest, checking_two_unequal_points) {
+  VPackBuilder foo;
+  foo.openArray();
+  foo.add(VPackValue(1));
+  foo.add(VPackValue(-2.2));
+  foo.close();
+  paramsA.emplace_back(foo.slice().at(0));
+  paramsA.emplace_back(foo.slice().at(1));
+  AqlValue pointA = Functions::GeoPoint(&expressionContext, &trx, paramsA);
+  paramsC.emplace_back(pointA.clone());
+  pointA.destroy();
+  
+  VPackBuilder bar;
+  bar.openArray();
+  bar.add(VPackValue(-2.2));
+  bar.add(VPackValue(-1));
+  bar.close();
+  paramsB.emplace_back(bar.slice().at(0));
+  paramsB.emplace_back(bar.slice().at(1));
+  AqlValue pointB = Functions::GeoPoint(&expressionContext, &trx, paramsB);
+  paramsC.emplace_back(pointB.clone());
+  pointB.destroy();
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      EXPECT_TRUE(resC.slice().isBoolean());
-      EXPECT_FALSE(resC.slice().getBool());
-    }
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  EXPECT_TRUE(resC.slice().isBoolean());
+  EXPECT_FALSE(resC.slice().getBool());
+}
 
 } // geo_equals_point
 
 namespace geo_equals_multipoint {
-class GeoEqualsMultipointTest : public GeoEqualsTest {  };
+class GeoEqualsMultipointTest : public GeoEqualsTest {};
 
-    TEST_F(GeoEqualsMultipointTest, checking_two_equal_multipoints) {
-      char const* polyA = "[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]";
-      size_t lA = strlen(polyA);
+TEST_F(GeoEqualsMultipointTest, checking_two_equal_multipoints) {
+  char const* polyA = "[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]";
+  size_t lA = strlen(polyA);
 
-      std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
-      VPackSlice jsonA = builderA->slice();
+  std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
+  VPackSlice jsonA = builderA->slice();
 
-      paramsA.emplace_back(jsonA);
+  paramsA.emplace_back(jsonA);
 
-      AqlValue resA = Functions::GeoMultiPoint(&expressionContext, &trx, paramsA);
-      paramsC.emplace_back(resA.clone());
-      paramsC.emplace_back(resA.clone());
-      resA.destroy();
+  AqlValue resA = Functions::GeoMultiPoint(&expressionContext, &trx, paramsA);
+  paramsC.emplace_back(resA.clone());
+  paramsC.emplace_back(resA.clone());
+  resA.destroy();
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      EXPECT_TRUE(resC.slice().isBoolean());
-      EXPECT_TRUE(resC.slice().getBool());
-    }
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  EXPECT_TRUE(resC.slice().isBoolean());
+  EXPECT_TRUE(resC.slice().getBool());
+}
 
-    TEST_F(GeoEqualsMultipointTest, checking_two_unequal_multipoints) {
-      char const* polyA = "[[0.5, 1.5], [3.0, 4.0], [5.0, 6.0], [0.5, 1.5]]";
-      size_t lA = strlen(polyA);
-      char const* polyB = "[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]";
-      size_t lB = strlen(polyB);
+TEST_F(GeoEqualsMultipointTest, checking_two_unequal_multipoints) {
+  char const* polyA = "[[0.5, 1.5], [3.0, 4.0], [5.0, 6.0], [0.5, 1.5]]";
+  size_t lA = strlen(polyA);
+  char const* polyB = "[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]";
+  size_t lB = strlen(polyB);
 
-      std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
-      VPackSlice jsonA = builderA->slice();
-      std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(polyB, lB);
-      VPackSlice jsonB = builderB->slice();
+  std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
+  VPackSlice jsonA = builderA->slice();
+  std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(polyB, lB);
+  VPackSlice jsonB = builderB->slice();
 
-      paramsA.emplace_back(jsonA);
-      paramsB.emplace_back(jsonB);
+  paramsA.emplace_back(jsonA);
+  paramsB.emplace_back(jsonB);
 
-      AqlValue resA = Functions::GeoMultiPoint(&expressionContext, &trx, paramsA);
-      paramsC.emplace_back(resA);
-      AqlValue resB = Functions::GeoMultiPoint(&expressionContext, &trx, paramsB);
-      paramsC.emplace_back(resB);
+  AqlValue resA = Functions::GeoMultiPoint(&expressionContext, &trx, paramsA);
+  paramsC.emplace_back(resA);
+  AqlValue resB = Functions::GeoMultiPoint(&expressionContext, &trx, paramsB);
+  paramsC.emplace_back(resB);
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      EXPECT_TRUE(resC.slice().isBoolean());
-      EXPECT_FALSE(resC.slice().getBool());
-    }
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  EXPECT_TRUE(resC.slice().isBoolean());
+  EXPECT_FALSE(resC.slice().getBool());
+}
 
 
 } // geo_equals_multipoint
 
 namespace geo_equals_polygon {
-  class GeoEqualsPolygonTest : public GeoEqualsTest {  };
-    TEST_F(GeoEqualsPolygonTest, checking_two_equal_polygons) {
-      char const* polyA = "[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]";
-      size_t lA = strlen(polyA);
+class GeoEqualsPolygonTest : public GeoEqualsTest {};
 
-      std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
-      VPackSlice jsonA = builderA->slice();
+TEST_F(GeoEqualsPolygonTest, checking_two_equal_polygons) {
+  char const* polyA = "[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]";
+  size_t lA = strlen(polyA);
 
-      paramsA.emplace_back(jsonA);
+  std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
+  VPackSlice jsonA = builderA->slice();
 
-      AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
-      paramsC.emplace_back(resA.clone());
-      paramsC.emplace_back(resA.clone());
-      resA.destroy();
+  paramsA.emplace_back(jsonA);
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      resC.destroy();
-      EXPECT_TRUE(resC.slice().isBoolean());
-      EXPECT_TRUE(resC.slice().getBool());
-    }
+  AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
+  paramsC.emplace_back(resA.clone());
+  paramsC.emplace_back(resA.clone());
+  resA.destroy();
 
-    TEST_F(GeoEqualsPolygonTest, checking_two_equal_more_detailed_polygons) {
-      char const* polyA = "[[6.888427734375,50.91602169392645],[6.9632720947265625,50.87921050161489],[7.013397216796875,50.89480467658874],[7.0731353759765625,50.92424609910128],[7.093048095703125,50.94804539355076],[7.03948974609375,50.9709677364145],[6.985244750976562,51.000360974529464],[6.8891143798828125,50.996471761616284],[6.867828369140624,50.95669666276118],[6.888427734375,50.91602169392645]]";
-      size_t lA = strlen(polyA);
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  resC.destroy();
+  EXPECT_TRUE(resC.slice().isBoolean());
+  EXPECT_TRUE(resC.slice().getBool());
+}
 
-      std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
-      VPackSlice jsonA = builderA->slice();
+TEST_F(GeoEqualsPolygonTest, checking_two_equal_more_detailed_polygons) {
+  char const* polyA = "[[6.888427734375,50.91602169392645],[6.9632720947265625,50.87921050161489],[7.013397216796875,50.89480467658874],[7.0731353759765625,50.92424609910128],[7.093048095703125,50.94804539355076],[7.03948974609375,50.9709677364145],[6.985244750976562,51.000360974529464],[6.8891143798828125,50.996471761616284],[6.867828369140624,50.95669666276118],[6.888427734375,50.91602169392645]]";
+  size_t lA = strlen(polyA);
 
-      paramsA.emplace_back(jsonA);
+  std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
+  VPackSlice jsonA = builderA->slice();
 
-      AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
-      paramsC.emplace_back(resA.clone());
-      paramsC.emplace_back(resA.clone());
-      resA.destroy();
+  paramsA.emplace_back(jsonA);
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      EXPECT_TRUE(resC.slice().isBoolean());
-      EXPECT_TRUE(resC.slice().getBool());
-    }
+  AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
+  paramsC.emplace_back(resA.clone());
+  paramsC.emplace_back(resA.clone());
+  resA.destroy();
 
-    TEST_F(GeoEqualsPolygonTest, checking_two_unequal_polygons) {
-      char const* polyA = "[[0.5, 1.5], [3.0, 4.0], [5.0, 6.0], [0.5, 1.5]]";
-      size_t lA = strlen(polyA);
-      char const* polyB = "[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]";
-      size_t lB = strlen(polyB);
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  EXPECT_TRUE(resC.slice().isBoolean());
+  EXPECT_TRUE(resC.slice().getBool());
+}
 
-      std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
-      VPackSlice jsonA = builderA->slice();
-      std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(polyB, lB);
-      VPackSlice jsonB = builderB->slice();
+TEST_F(GeoEqualsPolygonTest, checking_two_unequal_polygons) {
+  char const* polyA = "[[0.5, 1.5], [3.0, 4.0], [5.0, 6.0], [0.5, 1.5]]";
+  size_t lA = strlen(polyA);
+  char const* polyB = "[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]";
+  size_t lB = strlen(polyB);
 
-      paramsA.emplace_back(jsonA);
-      paramsB.emplace_back(jsonB);
+  std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
+  VPackSlice jsonA = builderA->slice();
+  std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(polyB, lB);
+  VPackSlice jsonB = builderB->slice();
 
-      AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
-      paramsC.emplace_back(resA);
-      AqlValue resB = Functions::GeoPolygon(&expressionContext, &trx, paramsB);
-      paramsC.emplace_back(resB);
+  paramsA.emplace_back(jsonA);
+  paramsB.emplace_back(jsonB);
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      EXPECT_TRUE(resC.slice().isBoolean());
-      EXPECT_FALSE(resC.slice().getBool());
-    }
+  AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
+  paramsC.emplace_back(resA);
+  AqlValue resB = Functions::GeoPolygon(&expressionContext, &trx, paramsB);
+  paramsC.emplace_back(resB);
 
-    TEST_F(GeoEqualsPolygonTest, checking_two_nested_equal_polygons) {
-      char const* polyA = "[[[35, 10], [45, 45], [15, 40], [10, 20], [35, 10]],[[20, 30], [35, 35], [30, 20], [20, 30]]]";
-      size_t lA = strlen(polyA);
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  EXPECT_TRUE(resC.slice().isBoolean());
+  EXPECT_FALSE(resC.slice().getBool());
+}
 
-      std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
-      VPackSlice jsonA = builderA->slice();
+TEST_F(GeoEqualsPolygonTest, checking_two_nested_equal_polygons) {
+  char const* polyA = "[[[35, 10], [45, 45], [15, 40], [10, 20], [35, 10]],[[20, 30], [35, 35], [30, 20], [20, 30]]]";
+  size_t lA = strlen(polyA);
 
-      paramsA.emplace_back(jsonA);
+  std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
+  VPackSlice jsonA = builderA->slice();
 
-      AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
-      paramsC.emplace_back(resA.clone());
-      paramsC.emplace_back(resA.clone());
-      resA.destroy();
+  paramsA.emplace_back(jsonA);
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      EXPECT_TRUE(resC.slice().isBoolean());
-      EXPECT_TRUE(resC.slice().getBool());
-    }
+  AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
+  paramsC.emplace_back(resA.clone());
+  paramsC.emplace_back(resA.clone());
+  resA.destroy();
 
-    TEST_F(GeoEqualsPolygonTest, checking_two_unequal_nested_polygons_outer_loop_difference) {
-      char const* polyA = "[[[30, 10], [45, 45], [15, 40], [10, 20], [30, 10]],[[20, 30], [35, 35], [30, 20], [20, 30]]]";
-      size_t lA = strlen(polyA);
-      char const* polyB = "[[[35, 10], [45, 45], [15, 40], [10, 20], [35, 10]],[[20, 30], [35, 35], [30, 20], [20, 30]]]";
-      size_t lB = strlen(polyB);
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  EXPECT_TRUE(resC.slice().isBoolean());
+  EXPECT_TRUE(resC.slice().getBool());
+}
 
-      std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
-      VPackSlice jsonA = builderA->slice();
-      std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(polyB, lB);
-      VPackSlice jsonB = builderB->slice();
+TEST_F(GeoEqualsPolygonTest, checking_two_unequal_nested_polygons_outer_loop_difference) {
+  char const* polyA = "[[[30, 10], [45, 45], [15, 40], [10, 20], [30, 10]],[[20, 30], [35, 35], [30, 20], [20, 30]]]";
+  size_t lA = strlen(polyA);
+  char const* polyB = "[[[35, 10], [45, 45], [15, 40], [10, 20], [35, 10]],[[20, 30], [35, 35], [30, 20], [20, 30]]]";
+  size_t lB = strlen(polyB);
 
-      paramsA.emplace_back(jsonA);
-      paramsB.emplace_back(jsonB);
+  std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
+  VPackSlice jsonA = builderA->slice();
+  std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(polyB, lB);
+  VPackSlice jsonB = builderB->slice();
 
-      AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
-      paramsC.emplace_back(resA);
-      AqlValue resB = Functions::GeoPolygon(&expressionContext, &trx, paramsB);
-      paramsC.emplace_back(resB);
+  paramsA.emplace_back(jsonA);
+  paramsB.emplace_back(jsonB);
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      EXPECT_TRUE(resC.slice().isBoolean());
-      EXPECT_FALSE(resC.slice().getBool());
-    }
+  AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
+  paramsC.emplace_back(resA);
+  AqlValue resB = Functions::GeoPolygon(&expressionContext, &trx, paramsB);
+  paramsC.emplace_back(resB);
 
-    TEST_F(GeoEqualsPolygonTest, checking_two_unequal_nested_polygons_inner_loop_difference) {
-      char const* polyA = "[[[35, 10], [45, 45], [15, 40], [10, 20], [35, 10]],[[15, 30], [35, 35], [30, 20], [15, 30]]]";
-      size_t lA = strlen(polyA);
-      char const* polyB = "[[[35, 10], [45, 45], [15, 40], [10, 20], [35, 10]],[[20, 30], [35, 35], [30, 20], [20, 30]]]";
-      size_t lB = strlen(polyB);
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  EXPECT_TRUE(resC.slice().isBoolean());
+  EXPECT_FALSE(resC.slice().getBool());
+}
 
-      std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
-      VPackSlice jsonA = builderA->slice();
-      std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(polyB, lB);
-      VPackSlice jsonB = builderB->slice();
+TEST_F(GeoEqualsPolygonTest, checking_two_unequal_nested_polygons_inner_loop_difference) {
+  char const* polyA = "[[[35, 10], [45, 45], [15, 40], [10, 20], [35, 10]],[[15, 30], [35, 35], [30, 20], [15, 30]]]";
+  size_t lA = strlen(polyA);
+  char const* polyB = "[[[35, 10], [45, 45], [15, 40], [10, 20], [35, 10]],[[20, 30], [35, 35], [30, 20], [20, 30]]]";
+  size_t lB = strlen(polyB);
 
-      paramsA.emplace_back(jsonA);
-      paramsB.emplace_back(jsonB);
+  std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
+  VPackSlice jsonA = builderA->slice();
+  std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(polyB, lB);
+  VPackSlice jsonB = builderB->slice();
 
-      AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
-      paramsC.emplace_back(resA);
-      AqlValue resB = Functions::GeoPolygon(&expressionContext, &trx, paramsB);
-      paramsC.emplace_back(resB);
+  paramsA.emplace_back(jsonA);
+  paramsB.emplace_back(jsonB);
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      EXPECT_TRUE(resC.slice().isBoolean());
-      EXPECT_FALSE(resC.slice().getBool());
-    }
+  AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
+  paramsC.emplace_back(resA);
+  AqlValue resB = Functions::GeoPolygon(&expressionContext, &trx, paramsB);
+  paramsC.emplace_back(resB);
 
-    TEST_F(GeoEqualsPolygonTest, checking_two_unequal_nested_polygons_inner_and_outer_polygons) {
-      char const* polyA = "[[[30, 10], [45, 45], [15, 40], [10, 20], [30, 10]],[[20, 30], [35, 35], [30, 20], [20, 30]]]";
-      size_t lA = strlen(polyA);
-      char const* polyB = "[[[35, 10], [45, 45], [15, 40], [10, 20], [35, 10]],[[15, 30], [35, 35], [30, 20], [15, 30]]]";
-      size_t lB = strlen(polyB);
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  EXPECT_TRUE(resC.slice().isBoolean());
+  EXPECT_FALSE(resC.slice().getBool());
+}
 
-      std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
-      VPackSlice jsonA = builderA->slice();
-      std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(polyB, lB);
-      VPackSlice jsonB = builderB->slice();
+TEST_F(GeoEqualsPolygonTest, checking_two_unequal_nested_polygons_inner_and_outer_polygons) {
+  char const* polyA = "[[[30, 10], [45, 45], [15, 40], [10, 20], [30, 10]],[[20, 30], [35, 35], [30, 20], [20, 30]]]";
+  size_t lA = strlen(polyA);
+  char const* polyB = "[[[35, 10], [45, 45], [15, 40], [10, 20], [35, 10]],[[15, 30], [35, 35], [30, 20], [15, 30]]]";
+  size_t lB = strlen(polyB);
 
-      paramsA.emplace_back(jsonA);
-      paramsB.emplace_back(jsonB);
+  std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
+  VPackSlice jsonA = builderA->slice();
+  std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(polyB, lB);
+  VPackSlice jsonB = builderB->slice();
 
-      AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
-      paramsC.emplace_back(resA);
-      AqlValue resB = Functions::GeoPolygon(&expressionContext, &trx, paramsB);
-      paramsC.emplace_back(resB);
+  paramsA.emplace_back(jsonA);
+  paramsB.emplace_back(jsonB);
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      EXPECT_TRUE(resC.slice().isBoolean());
-      EXPECT_FALSE(resC.slice().getBool());
-    }
+  AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
+  paramsC.emplace_back(resA);
+  AqlValue resB = Functions::GeoPolygon(&expressionContext, &trx, paramsB);
+  paramsC.emplace_back(resB);
 
-    TEST_F(GeoEqualsPolygonTest, checking_only_one_polygon_first_parameter) {
-      fakeit::When(Method(expressionContextMock, registerWarning)).Do([&](int code, char const* msg) -> void {
-        ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
-      });
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  EXPECT_TRUE(resC.slice().isBoolean());
+  EXPECT_FALSE(resC.slice().getBool());
+}
 
-      char const* polyA = "[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]";
-      size_t lA = strlen(polyA);
-      char const* nullValue = "null";
-      size_t lB = strlen(nullValue);
+TEST_F(GeoEqualsPolygonTest, checking_only_one_polygon_first_parameter) {
+  fakeit::When(Method(expressionContextMock, registerWarning)).Do([&](int code, char const* msg) -> void {
+    ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
+  });
 
-      std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
-      VPackSlice jsonA = builderA->slice();
-      
-      std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(nullValue, lB);
-      VPackSlice jsonB = builderB->slice();
+  char const* polyA = "[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]";
+  size_t lA = strlen(polyA);
+  char const* nullValue = "null";
+  size_t lB = strlen(nullValue);
 
-      paramsA.emplace_back(jsonA);
+  std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
+  VPackSlice jsonA = builderA->slice();
+  
+  std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(nullValue, lB);
+  VPackSlice jsonB = builderB->slice();
 
-      AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
-      paramsC.emplace_back(resA);
-      paramsC.emplace_back(jsonB);
+  paramsA.emplace_back(jsonA);
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      EXPECT_TRUE(resC.slice().isNull());
-    }
+  AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
+  paramsC.emplace_back(resA);
+  paramsC.emplace_back(jsonB);
 
-    TEST_F(GeoEqualsPolygonTest, checking_only_one_polygon_second_parameter) {
-      fakeit::When(Method(expressionContextMock, registerWarning)).Do([&](int code, char const* msg) -> void {
-        ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
-      });
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  EXPECT_TRUE(resC.slice().isNull());
+}
 
-      char const* polyA = "[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]";
-      size_t lA = strlen(polyA);
-      char const* nullValue = "null";
-      size_t lB = strlen(nullValue);
+TEST_F(GeoEqualsPolygonTest, checking_only_one_polygon_second_parameter) {
+  fakeit::When(Method(expressionContextMock, registerWarning)).Do([&](int code, char const* msg) -> void {
+    ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
+  });
 
-      std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
-      VPackSlice jsonA = builderA->slice();
-      
-      std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(nullValue, lB);
-      VPackSlice jsonB = builderB->slice();
+  char const* polyA = "[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]";
+  size_t lA = strlen(polyA);
+  char const* nullValue = "null";
+  size_t lB = strlen(nullValue);
 
-      paramsA.emplace_back(jsonA);
+  std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
+  VPackSlice jsonA = builderA->slice();
+  
+  std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(nullValue, lB);
+  VPackSlice jsonB = builderB->slice();
 
-      AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
-      paramsC.emplace_back(jsonB);
-      paramsC.emplace_back(resA);
+  paramsA.emplace_back(jsonA);
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      EXPECT_TRUE(resC.slice().isNull());
-    }
+  AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
+  paramsC.emplace_back(jsonB);
+  paramsC.emplace_back(resA);
+
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  EXPECT_TRUE(resC.slice().isNull());
+}
 } // geo_equals_polygon
 
 namespace geo_equals_linestring {
-  class GeoEqualsLinestringTest : public GeoEqualsTest {  };
+class GeoEqualsLinestringTest : public GeoEqualsTest {};
 
-    TEST_F(GeoEqualsLinestringTest, checking_two_equal_linestrings) {
-      char const* polyA = "[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]";
-      size_t lA = strlen(polyA);
+TEST_F(GeoEqualsLinestringTest, checking_two_equal_linestrings) {
+  char const* polyA = "[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]";
+  size_t lA = strlen(polyA);
 
-      std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
-      VPackSlice jsonA = builderA->slice();
+  std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
+  VPackSlice jsonA = builderA->slice();
 
-      paramsA.emplace_back(jsonA);
+  paramsA.emplace_back(jsonA);
 
-      AqlValue resA = Functions::GeoLinestring(&expressionContext, &trx, paramsA);
+  AqlValue resA = Functions::GeoLinestring(&expressionContext, &trx, paramsA);
 
-      paramsC.emplace_back(resA.clone());
-      paramsC.emplace_back(resA.clone());
-      resA.destroy();
+  paramsC.emplace_back(resA.clone());
+  paramsC.emplace_back(resA.clone());
+  resA.destroy();
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      EXPECT_TRUE(resC.slice().isBoolean());
-      EXPECT_TRUE(resC.slice().getBool());
-    }
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  EXPECT_TRUE(resC.slice().isBoolean());
+  EXPECT_TRUE(resC.slice().getBool());
+}
 
-    TEST_F(GeoEqualsLinestringTest, checking_two_unequal_linestrings) {
-      char const* polyA = "[[0.5, 1.5], [3.0, 4.0], [5.0, 6.0], [0.5, 1.5]]";
-      size_t lA = strlen(polyA);
-      char const* polyB = "[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]";
-      size_t lB = strlen(polyB);
+TEST_F(GeoEqualsLinestringTest, checking_two_unequal_linestrings) {
+  char const* polyA = "[[0.5, 1.5], [3.0, 4.0], [5.0, 6.0], [0.5, 1.5]]";
+  size_t lA = strlen(polyA);
+  char const* polyB = "[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]";
+  size_t lB = strlen(polyB);
 
-      std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
-      VPackSlice jsonA = builderA->slice();
-      std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(polyB, lB);
-      VPackSlice jsonB = builderB->slice();
+  std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
+  VPackSlice jsonA = builderA->slice();
+  std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(polyB, lB);
+  VPackSlice jsonB = builderB->slice();
 
-      paramsA.emplace_back(jsonA);
-      paramsB.emplace_back(jsonB);
+  paramsA.emplace_back(jsonA);
+  paramsB.emplace_back(jsonB);
 
-      AqlValue resA = Functions::GeoLinestring(&expressionContext, &trx, paramsA);
-      AqlValue resB = Functions::GeoLinestring(&expressionContext, &trx, paramsB);
+  AqlValue resA = Functions::GeoLinestring(&expressionContext, &trx, paramsA);
+  AqlValue resB = Functions::GeoLinestring(&expressionContext, &trx, paramsB);
 
-      paramsC.emplace_back(resA);
-      paramsC.emplace_back(resB);
+  paramsC.emplace_back(resA);
+  paramsC.emplace_back(resB);
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      EXPECT_TRUE(resC.slice().isBoolean());
-      EXPECT_FALSE(resC.slice().getBool());
-    }
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  EXPECT_TRUE(resC.slice().isBoolean());
+  EXPECT_FALSE(resC.slice().getBool());
+}
+
 } // geo_equals_linestring
 
 namespace geo_equals_multilinestring {
-  class GeoEqualsMultilinestringTest : public GeoEqualsTest {  };
+class GeoEqualsMultilinestringTest : public GeoEqualsTest {};
 
-    TEST_F(GeoEqualsMultilinestringTest, checking_two_equal_multilinestrings) {
-      char const* polyA = "[ [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]] ]";
-      size_t lA = strlen(polyA);
+TEST_F(GeoEqualsMultilinestringTest, checking_two_equal_multilinestrings) {
+  char const* polyA = "[ [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]] ]";
+  size_t lA = strlen(polyA);
 
-      std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
-      VPackSlice jsonA = builderA->slice();
+  std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
+  VPackSlice jsonA = builderA->slice();
 
-      paramsA.emplace_back(jsonA);
+  paramsA.emplace_back(jsonA);
 
-      AqlValue resA = Functions::GeoMultiLinestring(&expressionContext, &trx, paramsA);
-      paramsC.emplace_back(resA.clone());
-      paramsC.emplace_back(resA.clone());
-      resA.destroy();
+  AqlValue resA = Functions::GeoMultiLinestring(&expressionContext, &trx, paramsA);
+  paramsC.emplace_back(resA.clone());
+  paramsC.emplace_back(resA.clone());
+  resA.destroy();
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      EXPECT_TRUE(resC.slice().isBoolean());
-      EXPECT_TRUE(resC.slice().getBool());
-    }
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  EXPECT_TRUE(resC.slice().isBoolean());
+  EXPECT_TRUE(resC.slice().getBool());
+}
 
-    TEST_F(GeoEqualsMultilinestringTest, checking_two_unequal_multilinestrings) {
-      char const* polyA = "[ [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [5.0, 6.0]] ]";
-      size_t lA = strlen(polyA);
-      char const* polyB = "[ [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]] ]";
-      size_t lB = strlen(polyB);
+TEST_F(GeoEqualsMultilinestringTest, checking_two_unequal_multilinestrings) {
+  char const* polyA = "[ [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [5.0, 6.0]] ]";
+  size_t lA = strlen(polyA);
+  char const* polyB = "[ [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]] ]";
+  size_t lB = strlen(polyB);
 
-      std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
-      VPackSlice jsonA = builderA->slice();
-      std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(polyB, lB);
-      VPackSlice jsonB = builderB->slice();
+  std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
+  VPackSlice jsonA = builderA->slice();
+  std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(polyB, lB);
+  VPackSlice jsonB = builderB->slice();
 
-      paramsA.emplace_back(jsonA);
-      paramsB.emplace_back(jsonB);
+  paramsA.emplace_back(jsonA);
+  paramsB.emplace_back(jsonB);
 
-      AqlValue resA = Functions::GeoMultiLinestring(&expressionContext, &trx, paramsA);
-      AqlValue resB = Functions::GeoMultiLinestring(&expressionContext, &trx, paramsB);
+  AqlValue resA = Functions::GeoMultiLinestring(&expressionContext, &trx, paramsA);
+  AqlValue resB = Functions::GeoMultiLinestring(&expressionContext, &trx, paramsB);
 
-      paramsC.emplace_back(resA);
-      paramsC.emplace_back(resB);
+  paramsC.emplace_back(resA);
+  paramsC.emplace_back(resB);
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      EXPECT_TRUE(resC.slice().isBoolean());
-      EXPECT_FALSE(resC.slice().getBool());
-    }
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  EXPECT_TRUE(resC.slice().isBoolean());
+  EXPECT_FALSE(resC.slice().getBool());
+}
+
 }  // geo_equals_multilinestring
 
 namespace geo_equals_mixings {
-  class GeoEqualsMixedTypeTest : public GeoEqualsTest {  };
+class GeoEqualsMixedTypeTest : public GeoEqualsTest {};
 
-    TEST_F(GeoEqualsMixedTypeTest, checking_polygon_with_multilinestring) {
-      fakeit::When(Method(expressionContextMock, registerWarning)).Do([&](int code, char const* msg) -> void {
-        ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
-      });
+TEST_F(GeoEqualsMixedTypeTest, checking_polygon_with_multilinestring) {
+  fakeit::When(Method(expressionContextMock, registerWarning)).Do([&](int code, char const* msg) -> void {
+    ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
+  });
 
-      char const* polyA = "[ [[1.0, 2.0], [3.0, 4.0], [3.3, 4.4], [1.0, 2.0]] ]";
-      size_t lA = strlen(polyA);
-      char const* lineB = "[ [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]] ]";
-      size_t lB = strlen(lineB);
+  char const* polyA = "[ [[1.0, 2.0], [3.0, 4.0], [3.3, 4.4], [1.0, 2.0]] ]";
+  size_t lA = strlen(polyA);
+  char const* lineB = "[ [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]] ]";
+  size_t lB = strlen(lineB);
 
-      std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
-      VPackSlice jsonA = builderA->slice();
-      std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(lineB, lB);
-      VPackSlice jsonB = builderB->slice();
+  std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
+  VPackSlice jsonA = builderA->slice();
+  std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(lineB, lB);
+  VPackSlice jsonB = builderB->slice();
 
-      paramsA.emplace_back(jsonA);
-      paramsB.emplace_back(jsonB);
+  paramsA.emplace_back(jsonA);
+  paramsB.emplace_back(jsonB);
 
-      AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
-      AqlValue resB = Functions::GeoMultiLinestring(&expressionContext, &trx, paramsB);
+  AqlValue resA = Functions::GeoPolygon(&expressionContext, &trx, paramsA);
+  AqlValue resB = Functions::GeoMultiLinestring(&expressionContext, &trx, paramsB);
 
-      paramsC.emplace_back(resA);
-      paramsC.emplace_back(resB);
+  paramsC.emplace_back(resA);
+  paramsC.emplace_back(resB);
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      EXPECT_TRUE(resC.slice().isBoolean());
-      EXPECT_FALSE(resC.slice().getBool());
-    }
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  EXPECT_TRUE(resC.slice().isBoolean());
+  EXPECT_FALSE(resC.slice().getBool());
+}
 
-    TEST_F(GeoEqualsMixedTypeTest, checking_multipoint_with_multilinestring) {
-      fakeit::When(Method(expressionContextMock, registerWarning)).Do([&](int code, char const* msg) -> void {
-        ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
-      });
+TEST_F(GeoEqualsMixedTypeTest, checking_multipoint_with_multilinestring) {
+  fakeit::When(Method(expressionContextMock, registerWarning)).Do([&](int code, char const* msg) -> void {
+    ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
+  });
 
-      char const* polyA = "[ [1.0, 2.0], [3.0, 4.0], [1.0, 2.0], [5.0, 6.0] ]";
-      size_t lA = strlen(polyA);
-      char const* lineB = "[ [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]] ]";
-      size_t lB = strlen(lineB);
+  char const* polyA = "[ [1.0, 2.0], [3.0, 4.0], [1.0, 2.0], [5.0, 6.0] ]";
+  size_t lA = strlen(polyA);
+  char const* lineB = "[ [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]] ]";
+  size_t lB = strlen(lineB);
 
-      std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
-      VPackSlice jsonA = builderA->slice();
-      std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(lineB, lB);
-      VPackSlice jsonB = builderB->slice();
+  std::shared_ptr<VPackBuilder> builderA = VPackParser::fromJson(polyA, lA);
+  VPackSlice jsonA = builderA->slice();
+  std::shared_ptr<VPackBuilder> builderB = VPackParser::fromJson(lineB, lB);
+  VPackSlice jsonB = builderB->slice();
 
-      paramsA.emplace_back(jsonA);
-      paramsB.emplace_back(jsonB);
+  paramsA.emplace_back(jsonA);
+  paramsB.emplace_back(jsonB);
 
-      AqlValue resA = Functions::GeoMultiPoint(&expressionContext, &trx, paramsA);
-      paramsC.emplace_back(resA);
-      AqlValue resB = Functions::GeoMultiLinestring(&expressionContext, &trx, paramsB);
-      paramsC.emplace_back(resB);
+  AqlValue resA = Functions::GeoMultiPoint(&expressionContext, &trx, paramsA);
+  paramsC.emplace_back(resA);
+  AqlValue resB = Functions::GeoMultiLinestring(&expressionContext, &trx, paramsB);
+  paramsC.emplace_back(resB);
 
-      AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
-      EXPECT_TRUE(resC.slice().isBoolean());
-      EXPECT_FALSE(resC.slice().getBool());
-    }
+  AqlValue resC = Functions::GeoEquals(&expressionContext, &trx, paramsC);
+  EXPECT_TRUE(resC.slice().isBoolean());
+  EXPECT_FALSE(resC.slice().getBool());
+}
+
 }  // geo_equals_mixings
 
 }  // geo_functions_aql


### PR DESCRIPTION
### Scope & Purpose

Remove `AqlValue(VPackBuilder)` constructor, as it is simply redundant to `AqlValue(VPackSlice)`.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *all AQL tests*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11323/