### PR TITLE
wait until restore task queue is idle before shutting down

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Wait until restore task queue is idle before shutting down.
+
 * Fix a race problem in the unit tests w.r.t. PlanSyncer.
 
 * Always fetch data for /_api/cluster/agency-dump from leader of the agency.


### PR DESCRIPTION
### Scope & Purpose

Attempt to fix spurious failures (crashes) in arangorestore integration tests.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *restore integration test*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11327/