### PR TITLE
allow concurrent synchronization of different shards per database

### DIFF
--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -300,6 +300,38 @@ arangodb::Result fetchRevisions(arangodb::transaction::Methods& trx,
 
 namespace arangodb {
 
+/// @brief helper struct to prevent multiple starts of the replication
+/// in the same database. used for single-server replication only.
+struct MultiStartPreventer {
+  MultiStartPreventer(MultiStartPreventer const&) = delete;
+  MultiStartPreventer& operator=(MultiStartPreventer const&) = delete;
+
+  MultiStartPreventer(TRI_vocbase_t& vocbase, bool preventStart)
+      : vocbase(vocbase), preventedStart(false) {
+    if (preventStart) {
+      TRI_ASSERT(!ServerState::instance()->isClusterRole());
+
+      auto res = vocbase.replicationApplier()->preventStart();
+      if (res.fail()) {
+        THROW_ARANGO_EXCEPTION(res);
+      }
+      preventedStart = true;
+    }
+  }
+
+  ~MultiStartPreventer() {
+    if (preventedStart) {
+      // reallow starting
+      TRI_ASSERT(!ServerState::instance()->isClusterRole());
+      vocbase.replicationApplier()->allowStart();
+    }
+  }
+
+  TRI_vocbase_t& vocbase;
+  bool preventedStart;
+};
+
+
 DatabaseInitialSyncer::Configuration::Configuration(
     ReplicationApplierConfiguration const& a, replutils::BarrierInfo& bar,
     replutils::BatchInfo& bat, replutils::Connection& c, bool f, replutils::MasterInfo& m,
@@ -316,7 +348,8 @@ DatabaseInitialSyncer::DatabaseInitialSyncer(TRI_vocbase_t& vocbase,
                     [this](std::string const& msg) -> void { setProgress(msg); }),
       _config{_state.applier,    _state.barrier, _batch,
               _state.connection, false,          _state.master,
-              _progress,         _state,         vocbase} {
+              _progress,         _state,         vocbase},
+      _isClusterRole(ServerState::instance()->isClusterRole()) {
   _state.vocbases.try_emplace(vocbase.name(), vocbase);
 
   if (configuration._database.empty()) {
@@ -330,26 +363,20 @@ Result DatabaseInitialSyncer::runWithInventory(bool incremental, VPackSlice dbIn
     return Result(TRI_ERROR_INTERNAL, "invalid endpoint");
   }
 
-  auto res = vocbase().replicationApplier()->preventStart();
-
-  if (res.fail()) {
-    return res;
-  }
-
-  TRI_DEFER(vocbase().replicationApplier()->allowStart());
-
-  setAborted(false);
-
   double const startTime = TRI_microtime();
 
   try {
+    bool const preventMultiStart = !_isClusterRole;
+    MultiStartPreventer p(vocbase(), preventMultiStart);
+      
+    setAborted(false);
+
     _config.progress.set("fetching master state");
 
     LOG_TOPIC("0a10d", DEBUG, Logger::REPLICATION)
         << "client: getting master state to dump " << vocbase().name();
-    Result r;
-    
-    r = sendFlush();
+
+    Result r = sendFlush();
     if (r.fail()) {
       return r;
     }
@@ -497,10 +524,12 @@ void DatabaseInitialSyncer::setProgress(std::string const& msg) {
     LOG_TOPIC("d15ed", DEBUG, Logger::REPLICATION) << msg;
   }
 
-  auto* applier = _config.vocbase.replicationApplier();
+  if (!_isClusterRole) {
+    auto* applier = _config.vocbase.replicationApplier();
 
-  if (applier != nullptr) {
-    applier->setProgress(msg);
+    if (applier != nullptr) {
+      applier->setProgress(msg);
+    }
   }
 }
 

--- a/arangod/Replication/DatabaseInitialSyncer.h
+++ b/arangod/Replication/DatabaseInitialSyncer.h
@@ -243,6 +243,9 @@ class DatabaseInitialSyncer final : public InitialSyncer {
   Result batchFinish();
 
   Configuration _config;
+
+  /// @brief whether or not we are a coordinator/dbserver
+  bool const _isClusterRole;
 };
 
 }  // namespace arangodb

--- a/arangod/Replication/GlobalInitialSyncer.cpp
+++ b/arangod/Replication/GlobalInitialSyncer.cpp
@@ -219,8 +219,12 @@ Result GlobalInitialSyncer::runInternal(bool incremental) {
         _state.barrier.extend(_state.connection);
       }
     }
+  } catch (arangodb::basics::Exception const& ex) {
+    return Result(ex.code(), std::string("syncer caught an unexpected exception: ") + ex.what());
+  } catch (std::exception const& ex) {
+    return Result(TRI_ERROR_INTERNAL, std::string("syncer caught an unexpected exception: ") + ex.what());
   } catch (...) {
-    return Result(TRI_ERROR_INTERNAL, "caught an unexpected exception");
+    return Result(TRI_ERROR_INTERNAL, "syncer caught an unexpected exception");
   }
 
   return Result();

--- a/arangod/Replication/ReplicationFeature.cpp
+++ b/arangod/Replication/ReplicationFeature.cpp
@@ -235,7 +235,8 @@ void ReplicationFeature::startApplier(TRI_vocbase_t* vocbase) {
   TRI_ASSERT(vocbase->type() == TRI_VOCBASE_TYPE_NORMAL);
   TRI_ASSERT(vocbase->replicationApplier() != nullptr);
 
-  if (vocbase->replicationApplier()->autoStart()) {
+  if (!ServerState::instance()->isClusterRole() &&
+      vocbase->replicationApplier()->autoStart()) {
     if (!_replicationApplierAutoStart) {
       LOG_TOPIC("c5378", INFO, arangodb::Logger::REPLICATION)
           << "replication applier explicitly deactivated for database '"
@@ -269,7 +270,8 @@ void ReplicationFeature::disableReplicationApplier() {
 void ReplicationFeature::stopApplier(TRI_vocbase_t* vocbase) {
   TRI_ASSERT(vocbase->type() == TRI_VOCBASE_TYPE_NORMAL);
 
-  if (vocbase->replicationApplier() != nullptr) {
+  if (!ServerState::instance()->isClusterRole() &&
+      vocbase->replicationApplier() != nullptr) {
     vocbase->replicationApplier()->stopAndJoin();
   }
 }


### PR DESCRIPTION
### Scope & Purpose

Enable concurrent synchronization of shards in the same database.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *replication tests, cluster tests, resilience tests*.

Started 2 runs:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11346/
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11347/