### PR TITLE
Avoid unused warning in non-maintainer compile

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -701,6 +701,8 @@ void ClusterInfo::loadPlan() {
     if (diff > std::chrono::milliseconds(500)) {
       LOG_TOPIC("66666", WARN, Logger::CLUSTER) << "Loading the new plan took: " << std::chrono::duration<double>(diff).count() << "s";
     }
+#else
+    (void)start;
 #endif
   });
 


### PR DESCRIPTION
Fix compiler warning in non-maintainer mode.

http://jenkins.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/11348/
http://jenkins.arangodb.biz:8080/job/arangodb-ANY-mac-packages/1039/