### PR TITLE
Let hotbackup only stop leader transactions.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.6.6 (XXXX-XX-XX)
 -------------------
 
+* Fixed a blockage on hotbackup when writes are happening concurrently, since
+  followers could no longer replicate leader transactions.
+
 * Fixed issue #12349: arangosh compact Arangoerror 404.
 
 * Always fetch data for /_api/cluster/agency-dump from leader of the agency.

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -121,7 +121,7 @@ void Manager::unregisterFailedTransactions(std::unordered_set<TRI_voc_tid_t> con
 void Manager::registerTransaction(TRI_voc_tid_t transactionId,
                                   std::unique_ptr<TransactionData> data,
                                   bool isReadOnlyTransaction) {
-  if (!isReadOnlyTransaction) {
+  if (!isReadOnlyTransaction && !isFollowerTransactionId(transactionId)) {
     _rwLock.readLock();
   }
 
@@ -150,8 +150,8 @@ void Manager::registerTransaction(TRI_voc_tid_t transactionId,
 void Manager::unregisterTransaction(TRI_voc_tid_t transactionId, bool markAsFailed,
                                     bool isReadOnlyTransaction) {
   // always perform an unlock when we leave this function
-  auto guard = scopeGuard([this, &isReadOnlyTransaction]() {
-    if (!isReadOnlyTransaction) {
+  auto guard = scopeGuard([this, transactionId, &isReadOnlyTransaction]() {
+    if (!isReadOnlyTransaction && !isFollowerTransactionId(transactionId)) {
       _rwLock.unlockRead();
     }
   });


### PR DESCRIPTION
This is the first part of a fix to not let hotbackup disturb imports. This allows a leader transaction to complete after the lockdown, since it can still start follower transactions to replicate the operations.