### PR TITLE
Docs: Fix revision based replication min version

### DIFF
--- a/Documentation/DocuBlocks/Rest/Replication/get_api_replication_revisions_tree.md
+++ b/Documentation/DocuBlocks/Rest/Replication/get_api_replication_revisions_tree.md
@@ -7,7 +7,7 @@
 @HINTS
 {% hint 'warning' %}
 This revision-based replication endpoint will only work with the RocksDB
-engine, and with collections created in ArangoDB v3.7.0 or later.
+engine, and with collections created in ArangoDB v3.8.0 or later.
 {% endhint %}
 
 @RESTQUERYPARAMETERS

--- a/Documentation/DocuBlocks/Rest/Replication/post_api_replication_revisions_tree.md
+++ b/Documentation/DocuBlocks/Rest/Replication/post_api_replication_revisions_tree.md
@@ -7,7 +7,7 @@
 @HINTS
 {% hint 'warning' %}
 This revision-based replication endpoint will only work with the RocksDB
-engine, and with collections created in ArangoDB v3.7.0 or later.
+engine, and with collections created in ArangoDB v3.8.0 or later.
 {% endhint %}
 
 @RESTQUERYPARAMETERS

--- a/Documentation/DocuBlocks/Rest/Replication/put_api_replication_revisions_documents.md
+++ b/Documentation/DocuBlocks/Rest/Replication/put_api_replication_revisions_documents.md
@@ -7,7 +7,7 @@
 @HINTS
 {% hint 'warning' %}
 This revision-based replication endpoint will only work with the RocksDB
-engine, and with collections created in ArangoDB v3.7.0 or later.
+engine, and with collections created in ArangoDB v3.8.0 or later.
 {% endhint %}
 
 @RESTQUERYPARAMETERS

--- a/Documentation/DocuBlocks/Rest/Replication/put_api_replication_revisions_ranges.md
+++ b/Documentation/DocuBlocks/Rest/Replication/put_api_replication_revisions_ranges.md
@@ -7,7 +7,7 @@
 @HINTS
 {% hint 'warning' %}
 This revision-based replication endpoint will only work with the RocksDB
-engine, and with collections created in ArangoDB v3.7.0 or later.
+engine, and with collections created in ArangoDB v3.8.0 or later.
 {% endhint %}
 
 @RESTQUERYPARAMETERS


### PR DESCRIPTION
Merkle tree replication is not in 3.7 GA, updating the minimum version number in which collections will be compatible in DocuBlock hint.

Note: it's not decided whether it will land in 3.8.0 or another release.