### PR TITLE
Bug fix/sorted collect reported null as undefined

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix: The 'sorted' COLLECT variant would return undefined instead of null when
+  grouping by a null value.
+
 * Hard-code returned "planVersion" attribute of collections to a value of 1.
   Before 3.7, the most recent Plan version from the agency was returned inside
   "planVersion".

--- a/arangod/Aql/SortedCollectExecutor.cpp
+++ b/arangod/Aql/SortedCollectExecutor.cpp
@@ -202,6 +202,12 @@ bool SortedCollectExecutor::CollectGroup::isSameGroup(InputAqlItemRow const& inp
     size_t i = 0;
 
     for (auto& it : infos.getGroupRegisters()) {
+      // Note that `None` and `null` are considered equal by AqlValue::Compare,
+      // which is a problem if we encounter `null` values on the very first row,
+      // when groupValues is still uninitialized and thus `None`.
+      if (this->groupValues[i].isNone()) {
+        return false;
+      }
       // we already had a group, check if the group has changed
       // compare values 1 1 by one
       int cmp = AqlValue::Compare(infos.getVPackOptions(), this->groupValues[i],

--- a/tests/js/server/aql/aql-optimizer-collect-methods.js
+++ b/tests/js/server/aql/aql-optimizer-collect-methods.js
@@ -533,7 +533,33 @@ function optimizerCollectMethodsTestSuite () {
       // We do not care for the result,
       // ASAN would figure out invalid memory access here.
       assertEqual(2002, res.length);
-    }
+    },
+
+    // Regression test. There was a bug where the sorted collect returned
+    // [ { "n" : undefined }, { "n" : "testi" } ]
+    // instead of
+    // [ { "n" : null }, { "n" : "testi" } ].
+    testNullVsUndefinedInSortedCollect : function () {
+      const query = `
+        FOR doc IN [ {_key:"foo"}, {_key:"bar", name:"testi"} ]
+        COLLECT n = doc.name OPTIONS { method: "sorted" }
+        RETURN { n }
+      `;
+      const res = db._query(query).toArray();
+      assertEqual([ { "n" : null }, { "n" : "testi" } ], res);
+    },
+
+    // Just for the sake of completeness, a version of the regression test above
+    // for the hashed collect variant.
+    testNullVsUndefinedInHashedCollect : function () {
+      const query = `
+        FOR doc IN [ {_key:"foo"}, {_key:"bar", name:"testi"} ]
+        COLLECT n = doc.name OPTIONS { method: "hash" }
+        RETURN { n }
+      `;
+      const res = db._query(query).toArray();
+      assertEqual([ { "n" : null }, { "n" : "testi" } ], res);
+    },
   
   };
 }


### PR DESCRIPTION
### Scope & Purpose

Fixed a bug where a `COLLECT` group, that should return `null`, would return `undefined` instead.

- [X] Bug-Fix for *devel*
- [X] Bug-Fix for *3.7*: https://github.com/arangodb/arangodb/pull/12401
- [X] Bug-Fix for *3.6*: https://github.com/arangodb/arangodb/pull/12402
- [X] Bug-Fix for *3.5*: https://github.com/arangodb/arangodb/pull/12403
- [X] The behavior in this PR can be (and was) *manually tested*
- [X] The behavior change can be verified via automatic tests

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [X] Added **Regression Tests**

### Documentation

- [x] Added a *Changelog Entry*
