### PR TITLE
don't make inline-subqueries optimizer rule pull out COLLECTs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.6.6 (XXXX-XX-XX)
 -------------------
 
+* Fixed issue ES-664: the optimizer rule `inline-subqueries` must pull out a
+  subqueries that contains a COLLECT statement if the subquery is itself
+  called from within a loop. Otherwise the COLLECT will be applied to the
+  values in the outer FOR loop, which can produce a different result.
+
 * Updated arangosync to 0.7.9.
 
 * Fixed hotbackup S3 credentials validation and error reporting for upload

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-v3.6.7 (XXXX-XX-XX)
+v3.6.6 (XXXX-XX-XX)
 -------------------
 
 * Fixed issue ES-664: the optimizer rule `inline-subqueries` must not pull out

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-v3.6.6 (XXXX-XX-XX)
+v3.6.7 (XXXX-XX-XX)
 -------------------
 
 * Fixed issue ES-664: the optimizer rule `inline-subqueries` must not pull out

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,9 +2,9 @@ v3.6.6 (XXXX-XX-XX)
 -------------------
 
 * Fixed issue ES-664: the optimizer rule `inline-subqueries` must not pull out
-  subqueries that contain a COLLECT statement if the subquery is itself
-  called from within a loop. Otherwise the COLLECT will be applied to the
-  values in the outer FOR loop, which can produce a different result.
+  subqueries that contain a COLLECT statement if the subquery is itself called
+  from within a loop. Otherwise the COLLECT will be applied to the values in the
+  outer FOR loop, which can produce a different result.
 
 * Updated arangosync to 0.7.9.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.6.6 (XXXX-XX-XX)
 -------------------
 
-* Fixed issue ES-664: the optimizer rule `inline-subqueries` must pull out a
+* Fixed issue ES-664: the optimizer rule `inline-subqueries` must not pull out
   subqueries that contains a COLLECT statement if the subquery is itself
   called from within a loop. Otherwise the COLLECT will be applied to the
   values in the outer FOR loop, which can produce a different result.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ v3.6.6 (XXXX-XX-XX)
 -------------------
 
 * Fixed issue ES-664: the optimizer rule `inline-subqueries` must not pull out
-  subqueries that contains a COLLECT statement if the subquery is itself
+  subqueries that contain a COLLECT statement if the subquery is itself
   called from within a loop. Otherwise the COLLECT will be applied to the
   values in the outer FOR loop, which can produce a different result.
 

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -6025,7 +6025,15 @@ void arangodb::aql::inlineSubqueriesRule(Optimizer* opt, std::unique_ptr<Executi
 
     while (current != nullptr) {
       if (current->getType() == EN::COLLECT) {
+        if (subqueryNode->isInInnerLoop()) {
+          eligible = false;
+          break;
+        }
         if (ExecutionNode::castTo<CollectNode const*>(current)->hasOutVariable()) {
+          // COLLECT ... INTO captures all existing variables in the scope.
+          // if we move the subquery from one scope into another, we will end up with
+          // different variables captured, so we must not apply the optimization in
+          // this case.
           eligible = false;
           break;
         }

--- a/tests/js/server/aql/aql-optimizer-rule-inline-subqueries.js
+++ b/tests/js/server/aql/aql-optimizer-rule-inline-subqueries.js
@@ -69,8 +69,15 @@ function optimizerRuleTestSuite () {
         "LET a = [1,2,3] FOR i IN a RETURN i",
         "FOR i IN [1,2,3] LET x = (FOR j IN [1,2,3] RETURN j) RETURN x",
         "FOR i IN (FOR j IN [1,2,3] COLLECT v = j INTO g RETURN [v, g]) RETURN i",
+        "FOR i IN [1,2,3] LET sub = (FOR j IN [1,2,3] COLLECT v = j INTO g RETURN [v, g]) FOR x IN sub RETURN [i, x]",
         "FOR i IN [1,2,3] LET x = (FOR j IN [1,2,3] LIMIT 1 RETURN j) FOR k IN x RETURN k",
-        "FOR i IN [1,2,3] LET x = (FOR j IN [1,2,3] SORT j RETURN j) FOR k IN x RETURN k"
+        "FOR i IN [1,2,3] LET x = (FOR j IN [1,2,3] SORT j RETURN j) FOR k IN x RETURN k",
+        "FOR i IN [3,2,1] SORT i LET sub = (FOR j IN [1,2,3] SORT j DESC RETURN j) FOR k IN sub RETURN [i, k]",
+        "FOR i IN [1,2,3] LET sub = (FOR j IN [1,1,1] RETURN DISTINCT j) FOR k IN sub RETURN [i, k]",
+        "FOR i IN [1,2,3] LET sub = (FOR j IN [1,1,1] COLLECT x = j RETURN x) FOR k IN sub RETURN [i, k]",
+        "FOR i IN [1,2,3] LET sub = (FOR j IN [1,1,1] COLLECT x = j OPTIONS { method: 'hash' } RETURN x) FOR k IN sub RETURN [i, k]",
+        "FOR i IN [1,2,3] LET sub = (FOR j IN [1,1,1] COLLECT x = j OPTIONS { method: 'sorted' } RETURN x) FOR k IN sub RETURN [i, k]",
+        "FOR i IN [1,2,3] LET sub = (FOR j IN [1,1,2,3,3] RETURN DISTINCT j) FOR x IN sub RETURN [i, x]",
       ];
 
       queries.forEach(function(query) {
@@ -147,7 +154,10 @@ function optimizerRuleTestSuite () {
         [ "LET x = (FOR j IN [1,2,3,4] RETURN j) FOR k IN x LIMIT 1, 1 RETURN k", [ 2 ] ],
         [ "LET x = (FOR j IN [1,2,3,4] SORT j DESC RETURN j) FOR k IN x RETURN k", [ 4, 3, 2, 1 ] ],
         [ "LET x = (FOR j IN [1,2,3,4] SORT j DESC LIMIT 2 RETURN j) FOR k IN x RETURN k", [ 4, 3 ] ],
-        [ "LET x = (FOR j IN [1,2,3,4] SORT j DESC LIMIT 2 RETURN j) FOR k IN x LIMIT 1 RETURN k", [ 4 ] ]
+        [ "LET x = (FOR j IN [1,2,3,4] SORT j DESC LIMIT 2 RETURN j) FOR k IN x LIMIT 1 RETURN k", [ 4 ] ],
+        
+        [ "FOR i IN [3,2,1] SORT i LET sub = (FOR j IN [1,2,3] RETURN j) FOR k IN sub RETURN [i, k]", [ [1, 1], [1, 2], [1, 3], [2, 1], [2, 2], [2, 3], [3, 1], [3, 2], [3, 3] ] ],
+        [ "FOR i IN [3,2,1] SORT i DESC LET sub = (FOR j IN [1,2,3] RETURN j) FOR k IN sub RETURN [i, k]", [ [3, 1], [3, 2], [3, 3], [2, 1], [2, 2], [2, 3], [1, 1], [1, 2], [1, 3] ] ],
       ];
       queries.forEach(function(query) {
         var result = AQL_EXPLAIN(query[0]);
@@ -168,20 +178,12 @@ function optimizerRuleCollectionTestSuite () {
 
   return {
 
-    ////////////////////////////////////////////////////////////////////////////////
-    /// @brief set up
-    ////////////////////////////////////////////////////////////////////////////////
-
-    setUp : function () {
+    setUpAll : function () {
       db._drop(cn);
       c = db._create(cn);
     },
 
-    ////////////////////////////////////////////////////////////////////////////////
-    /// @brief tear down
-    ////////////////////////////////////////////////////////////////////////////////
-
-    tearDown : function () {
+    tearDownAll : function () {
       db._drop(cn);
       c = null;
     },
@@ -240,14 +242,14 @@ function optimizerRuleViewTestSuite () {
 
   return {
 
-    setUp : function () {
+    setUpAll : function () {
       db._dropView(cn + "View");
       db._drop(cn);
       db._create(cn);
       db._createView(cn + "View", "arangosearch", { links: { "UnitTestsOptimizer" : { includeAllFields: true } } });
     },
 
-    tearDown : function () {
+    tearDownAll : function () {
       db._dropView(cn + "View");
       db._drop(cn);
     },


### PR DESCRIPTION
### Scope & Purpose

Don't apply optimizer rule `inline-subqueries` for subqueries that contain a COLLECT statement if the subquery itself is called from a FOR loop. Otherwise the COLLECT will be pulled out to caller level and be applied there, which may produce different results than when applied inside the subquery.

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

#### Related Information

- [x] There is a *JIRA Ticket number*: https://arangodb.atlassian.net/browse/ES-664

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11464/