### PR TITLE
reenable "Aqlvalue optimization" PR by @graetzer

### DIFF
--- a/arangod/Aql/AqlItemBlock.cpp
+++ b/arangod/Aql/AqlItemBlock.cpp
@@ -812,7 +812,8 @@ void AqlItemBlock::toVelocyPack(size_t from, size_t to,
 
         if (it == table.end()) {
           currentState = Next;
-          a.toVelocyPack(trxOptions, raw, false);
+          a.toVelocyPack(trxOptions, raw, /*resolveExternals*/false,
+                         /*allowUnindexed*/true);
           table.try_emplace(a, pos++);
         } else {
           currentState = Positional;
@@ -877,7 +878,8 @@ void AqlItemBlock::rowToSimpleVPack(size_t const row, velocypack::Options const*
       if (ref.isEmpty()) {
         builder.add(VPackSlice::noneSlice());
       } else {
-        ref.toVelocyPack(options, builder, false);
+        ref.toVelocyPack(options, builder, /*resolveExternals*/false,
+                         /*allowUnindexed*/true);
       }
     }
   }

--- a/arangod/Aql/AqlItemBlock.cpp
+++ b/arangod/Aql/AqlItemBlock.cpp
@@ -55,25 +55,23 @@ inline void copyValueOver(arangodb::containers::HashSet<void*>& cache,
                           size_t rowNumber, 
                           RegisterId col, 
                           SharedAqlItemBlockPtr& res) {
-  if (!a.isEmpty()) {
-    if (a.requiresDestruction()) {
-      auto it = cache.find(a.data());
+  if (a.requiresDestruction()) {
+    auto it = cache.find(a.data());
 
-      if (it == cache.end()) {
-        AqlValue b = a.clone();
-        try {
-          res->setValue(rowNumber, col, b);
-        } catch (...) {
-          b.destroy();
-          throw;
-        }
-        cache.emplace(b.data());
-      } else {
-        res->setValue(rowNumber, col, AqlValue(a.type(), (*it)));
+    if (it == cache.end()) {
+      AqlValue b = a.clone();
+      try {
+        res->setValue(rowNumber, col, b);
+      } catch (...) {
+        b.destroy();
+        throw;
       }
+      cache.emplace(b.data());
     } else {
-      res->setValue(rowNumber, col, a);
+      res->setValue(rowNumber, col, AqlValue(a.type(), (*it)));
     }
+  } else {
+    res->setValue(rowNumber, col, a);
   }
 }
 }  // namespace
@@ -339,6 +337,8 @@ void AqlItemBlock::destroy() noexcept {
   } catch (...) {
   }
 
+  TRI_ASSERT(_valueCount.empty());
+
   rescale(0, 0);
   TRI_ASSERT(numEntries() == 0);
 }
@@ -380,9 +380,11 @@ void AqlItemBlock::shrink(size_t nrItems) {
 
         if (--valueInfo.refCount == 0) {
           totalUsed += valueInfo.memoryUsage;
+          // destroy calls erase() for AqlValues with dynamic memory,
+          // no need for an extra a.erase() here
           a.destroy();
           _valueCount.erase(it);
-          continue;  // no need for an extra a.erase() here
+          continue;  
         }
       }
     }
@@ -457,9 +459,11 @@ void AqlItemBlock::clearRegisters(RegIdFlatSet const& toClear) {
 
           if (--valueInfo.refCount == 0) {
             totalUsed += valueInfo.memoryUsage;
+            // destroy calls erase() for AqlValues with dynamic memory,
+            // no need for an extra a.erase() here
             a.destroy();
             _valueCount.erase(it);
-            continue;  // no need for an extra a.erase() here
+            continue;  
           }
         }
       }
@@ -998,7 +1002,9 @@ void AqlItemBlock::destroyValue(size_t index, RegisterId varNr) {
         decreaseMemoryUsage(valueInfo.memoryUsage);
         _valueCount.erase(it);
         element.destroy();
-        return;  // no need for an extra element.erase() in this case
+        // no need for an extra element.erase() in this case, as
+        // destroy() calls erase() for AqlValues with dynamic memory
+        return;  
       }
     }
   }
@@ -1028,9 +1034,7 @@ void AqlItemBlock::eraseAll() {
   size_t const n = numEntries();
   for (size_t i = 0; i < n; i++) {
     auto& it = _data[i];
-    if (!it.isEmpty()) {
-      it.erase();
-    }
+    it.erase();
   }
 
   size_t totalUsed = 0;

--- a/arangod/Aql/AqlItemBlock.cpp
+++ b/arangod/Aql/AqlItemBlock.cpp
@@ -68,7 +68,7 @@ inline void copyValueOver(arangodb::containers::HashSet<void*>& cache,
       }
       cache.emplace(b.data());
     } else {
-      res->setValue(rowNumber, col, AqlValue(a.type(), (*it)));
+      res->setValue(rowNumber, col, AqlValue(a, (*it)));
     }
   } else {
     res->setValue(rowNumber, col, a);
@@ -496,7 +496,7 @@ SharedAqlItemBlockPtr AqlItemBlock::cloneDataAndMoveShadow() {
           if (a.requiresDestruction()) {
             AqlValueGuard guard{a, true};
             auto [it, inserted] = cache.emplace(a.data());
-            res->setValue(row, col, AqlValue(a.type(), a.data()));
+            res->setValue(row, col, AqlValue(a, (*it)));
             if (inserted) {
               // otherwise, destroy this; we used a cached value.
               guard.steal();

--- a/arangod/Aql/AqlValue.cpp
+++ b/arangod/Aql/AqlValue.cpp
@@ -27,7 +27,7 @@
 #include "Aql/Arithmetic.h"
 #include "Aql/Range.h"
 #include "Aql/SharedAqlItemBlockPtr.h"
-#include "Basics/ConditionalDeleter.h"
+#include "Basics/Endian.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Transaction/Context.h"
 #include "Transaction/Helpers.h"
@@ -39,6 +39,10 @@
 #include <velocypack/Slice.h>
 #include <velocypack/StringRef.h>
 #include <velocypack/velocypack-aliases.h>
+
+#ifndef velocypack_malloc
+#error velocypack_malloc must be defined
+#endif
 
 using namespace arangodb;
 using namespace arangodb::aql;
@@ -945,7 +949,7 @@ size_t AqlValue::docvecLength() const {
   }
   return s;
 }
-  
+
 /// @brief return the memory origin type for values of type VPACK_MANAGED_SLICE
 AqlValue::MemoryOriginType AqlValue::memoryOriginType() const noexcept {
   TRI_ASSERT(type() == VPACK_MANAGED_SLICE);
@@ -954,11 +958,26 @@ AqlValue::MemoryOriginType AqlValue::memoryOriginType() const noexcept {
   return mot;
 }
   
-/// @brief set the memory origin type for values of type VPACK_MANAGED_SLICE
-void AqlValue::setMemoryOriginType(AqlValue::MemoryOriginType type) noexcept {
-  _data.internal[sizeof(_data.internal) - 2] = static_cast<uint8_t>(type);
+/// @brief store meta information for values of type VPACK_MANAGED_SLICE
+void AqlValue::setManagedSliceData(MemoryOriginType mot, arangodb::velocypack::ValueLength length) {
+  TRI_ASSERT(mot == MemoryOriginType::New || mot == MemoryOriginType::Malloc);
+  if (ADB_UNLIKELY(length > 0x0000ffffffffffffULL)) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_OUT_OF_MEMORY, "invalid AqlValue length");
+  }
+  // assemble a 64 bit value with meta information for this AqlValue:
+  // the first 6 bytes contain the byteSize
+  // the next byte contains the memoryOriginType (0 = new[], 1 = malloc)
+  // the last byte contains the AqlValueType (always VPACK_MANAGED_SLICE)
+  _data.words[1] = basics::hostToBig<uint64_t>(
+      ((length & 0x0000ffffffffffffULL) << 16U) | 
+      (static_cast<uint8_t>(mot) << 8) |
+      static_cast<uint8_t>(AqlValueType::VPACK_MANAGED_SLICE)
+  );
+  TRI_ASSERT(type() == VPACK_MANAGED_SLICE);
+  TRI_ASSERT(memoryOriginType() == mot);
+  TRI_ASSERT(memoryUsage() == length);
 }
-
+  
 /// @brief construct a V8 value as input for the expression execution in V8
 v8::Handle<v8::Value> AqlValue::toV8(v8::Isolate* isolate, velocypack::Options const* options) const {
   auto context = TRI_IGETC;
@@ -1096,7 +1115,11 @@ AqlValue AqlValue::clone() const {
   switch (t) {
     case VPACK_INLINE: {
       // copy internal data
-      return AqlValue(slice(t));
+      VPackSlice s(&_data.internal[0]);
+      if (!s.isExternal()) {
+        return AqlValue(*this);
+      }
+      return AqlValue(s.resolveExternal());
     }
     case VPACK_SLICE_POINTER: {
       if (isManagedDocument()) {
@@ -1107,7 +1130,9 @@ AqlValue AqlValue::clone() const {
       return AqlValue(_data.pointer);
     }
     case VPACK_MANAGED_SLICE: {
-      return AqlValue(AqlValueHintCopy(_data.slice));
+      // byte size is stored in the first 6 bytes of the second uint64_t value
+      VPackValueLength length = static_cast<VPackValueLength>((basics::bigToHost<uint64_t>(_data.words[1]) & 0xffffffffffff0000ULL) >> 16);
+      return AqlValue(VPackSlice(_data.slice), length);
     }
     case DOCVEC: {
       auto c = std::make_unique<std::vector<SharedAqlItemBlockPtr>>();
@@ -1137,7 +1162,7 @@ void AqlValue::destroy() noexcept {
       return;
     }
     case VPACK_MANAGED_SLICE: {
-      auto memoryType = memoryOriginType();
+      MemoryOriginType const memoryType = memoryOriginType();
       if (memoryType == MemoryOriginType::New) {
         delete[] _data.slice;
       } else {
@@ -1444,15 +1469,15 @@ AqlValue::AqlValue(char const* value, size_t length) {
   } else if (length <= 126) {
     // short string... cannot store inline, but we don't need to
     // create a full-featured Builder object here
+    setManagedSliceData(MemoryOriginType::New, length + 1);
     _data.slice = new uint8_t[length + 1];
     _data.slice[0] = static_cast<uint8_t>(0x40U + length);
     memcpy(&_data.slice[1], value, length);
-    setMemoryOriginType(MemoryOriginType::New);
-    setType(AqlValueType::VPACK_MANAGED_SLICE);
   } else {
     // long string
     // create a big enough uint8_t buffer
     size_t byteSize = length + 9;
+    setManagedSliceData(MemoryOriginType::New, byteSize);
     _data.slice = new uint8_t[byteSize];
     _data.slice[0] = static_cast<uint8_t>(0xbfU);
     uint64_t v = length;
@@ -1461,8 +1486,6 @@ AqlValue::AqlValue(char const* value, size_t length) {
       v >>= 8;
     }
     memcpy(&_data.slice[9], value, length);
-    setMemoryOriginType(MemoryOriginType::New);
-    setType(AqlValueType::VPACK_MANAGED_SLICE);
   }
 }
 
@@ -1481,27 +1504,24 @@ AqlValue::AqlValue(AqlValueHintEmptyObject const&) noexcept {
 
 AqlValue::AqlValue(arangodb::velocypack::Buffer<uint8_t>&& buffer) {
   // intentionally do not resolve externals here
-  // if (slice.isExternal()) {
-  //   // recursively resolve externals
-  //   slice = slice.resolveExternals();
-  // }
-  if (buffer.length() < sizeof(_data.internal)) {
+  VPackValueLength length = buffer.length();
+  if (length < sizeof(_data.internal)) {
     // Use inline value
-    memcpy(_data.internal, buffer.data(), static_cast<size_t>(buffer.length()));
-    buffer.clear(); // for move semantics
+    memcpy(_data.internal, buffer.data(), static_cast<size_t>(length));
     setType(AqlValueType::VPACK_INLINE);
+    buffer.clear(); // for move semantics
   } else {
     // Use managed slice
     if (buffer.usesLocalMemory()) {
-      _data.slice = new uint8_t[buffer.length()]();
-      setMemoryOriginType(MemoryOriginType::New);
-      memcpy(&_data.slice[0], buffer.data(), buffer.length());
+      setManagedSliceData(MemoryOriginType::New, length);
+      _data.slice = new uint8_t[length];
+      memcpy(&_data.slice[0], buffer.data(), length);
       buffer.clear(); // for move semantics
     } else {
+      // steal dynamic memory from the Buffer
+      setManagedSliceData(MemoryOriginType::Malloc, length);
       _data.slice = buffer.steal();
-      setMemoryOriginType(MemoryOriginType::Malloc);
     }
-    setType(AqlValueType::VPACK_MANAGED_SLICE);
   }
 }
 
@@ -1512,11 +1532,16 @@ AqlValue::AqlValue(AqlValueHintDocumentNoCopy const& v) noexcept {
 
 AqlValue::AqlValue(AqlValueHintCopy const& v) {
   TRI_ASSERT(v.ptr != nullptr);
-  initFromSlice(VPackSlice(v.ptr));
+  VPackSlice slice(v.ptr);
+  initFromSlice(slice, slice.byteSize());
 }
 
-AqlValue::AqlValue(arangodb::velocypack::Slice const& slice) {
-  initFromSlice(slice);
+AqlValue::AqlValue(arangodb::velocypack::Slice slice) {
+  initFromSlice(slice, slice.byteSize());
+}
+
+AqlValue::AqlValue(arangodb::velocypack::Slice slice, arangodb::velocypack::ValueLength length) {
+  initFromSlice(slice, length);
 }
 
 AqlValue::AqlValue(int64_t low, int64_t high) {
@@ -1543,15 +1568,18 @@ bool AqlValue::isManagedDocument() const noexcept {
 }
 
 bool AqlValue::isRange() const noexcept { return type() == RANGE; }
+
 bool AqlValue::isDocvec() const noexcept { return type() == DOCVEC; }
+
 Range const* AqlValue::range() const {
   TRI_ASSERT(isRange());
   return _data.range;
 }
 
 void AqlValue::erase() noexcept {
-  _data.internal[0] = '\x00';
-  setType(AqlValueType::VPACK_INLINE);
+  _data.words[0] = 0;
+  _data.words[1] = 0;
+  TRI_ASSERT(isEmpty());
 }
 
 size_t AqlValue::memoryUsage() const noexcept {
@@ -1561,11 +1589,8 @@ size_t AqlValue::memoryUsage() const noexcept {
     case VPACK_SLICE_POINTER:
       return 0;
     case VPACK_MANAGED_SLICE:
-      try {
-        return VPackSlice(_data.slice).byteSize();
-      } catch (...) {
-        return 0;
-      }
+      // byte size is stored in the first 6 bytes of the second uint64_t value
+      return static_cast<size_t>((basics::bigToHost<uint64_t>(_data.words[1]) & 0xffffffffffff0000ULL) >> 16);
     case DOCVEC:
       // no need to count the memory usage for the item blocks in docvec.
       // these have already been counted elsewhere (in ctors of AqlItemBlock
@@ -1581,23 +1606,22 @@ AqlValue::AqlValueType AqlValue::type() const noexcept {
   return static_cast<AqlValueType>(_data.internal[sizeof(_data.internal) - 1]);
 }
 
-void AqlValue::initFromSlice(arangodb::velocypack::Slice const& slice) {
+void AqlValue::initFromSlice(arangodb::velocypack::Slice slice, arangodb::velocypack::ValueLength length) {
   // intentionally do not resolve externals here
   // if (slice.isExternal()) {
   //   // recursively resolve externals
   //   slice = slice.resolveExternals();
   // }
-  arangodb::velocypack::ValueLength length = slice.byteSize();
+  TRI_ASSERT(slice.byteSize() == length);
   if (length < sizeof(_data.internal)) {
     // Use inline value
     memcpy(_data.internal, slice.begin(), static_cast<size_t>(length));
     setType(AqlValueType::VPACK_INLINE);
   } else {
     // Use managed slice
+    setManagedSliceData(MemoryOriginType::New, length);
     _data.slice = new uint8_t[length];
     memcpy(&_data.slice[0], slice.begin(), length);
-    setMemoryOriginType(MemoryOriginType::New);
-    setType(AqlValueType::VPACK_MANAGED_SLICE);
   }
 }
 

--- a/arangod/Aql/AqlValue.cpp
+++ b/arangod/Aql/AqlValue.cpp
@@ -75,14 +75,13 @@ static inline uint8_t intLength(int64_t value) noexcept {
 }
 }  // namespace
 
-/// @brief hashes the value
+/// @brief hashes the value, normalizes the values
 uint64_t AqlValue::hash(uint64_t seed) const {
   AqlValueType t = type();
   switch (t) {
     case VPACK_INLINE:
     case VPACK_SLICE_POINTER:
-    case VPACK_MANAGED_SLICE:
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       // we must use the slow hash function here, because a value may have
       // different representations in case it's an array/object/number
       return slice(t).normalizedHash(seed);
@@ -133,9 +132,6 @@ bool AqlValue::isNone() const noexcept {
     case VPACK_MANAGED_SLICE: {
       return VPackSlice(_data.slice).resolveExternal().isNone();
     }
-    case VPACK_MANAGED_BUFFER: {
-      return VPackSlice(_data.buffer->data()).resolveExternal().isNone();
-    }
     case DOCVEC:
     case RANGE: {
       break;
@@ -163,11 +159,6 @@ bool AqlValue::isNull(bool emptyIsNull) const noexcept {
       s = s.resolveExternal();
       return (s.isNull() || (emptyIsNull && s.isNone()));
     }
-    case VPACK_MANAGED_BUFFER: {
-      VPackSlice s(_data.buffer->data());
-      s = s.resolveExternal();
-      return (s.isNull() || (emptyIsNull && s.isNone()));
-    }
     case DOCVEC:
     case RANGE: {
       break;
@@ -189,9 +180,6 @@ bool AqlValue::isBoolean() const noexcept {
     }
     case VPACK_MANAGED_SLICE: {
       return VPackSlice(_data.slice).resolveExternal().isBoolean();
-    }
-    case VPACK_MANAGED_BUFFER: {
-      return VPackSlice(_data.buffer->data()).resolveExternal().isBoolean();
     }
     case DOCVEC:
     case RANGE: {
@@ -215,9 +203,6 @@ bool AqlValue::isNumber() const noexcept {
     case VPACK_MANAGED_SLICE: {
       return VPackSlice(_data.slice).resolveExternal().isNumber();
     }
-    case VPACK_MANAGED_BUFFER: {
-      return VPackSlice(_data.buffer->data()).resolveExternal().isNumber();
-    }
     case DOCVEC:
     case RANGE: {
       break;
@@ -239,9 +224,6 @@ bool AqlValue::isString() const noexcept {
     }
     case VPACK_MANAGED_SLICE: {
       return VPackSlice(_data.slice).resolveExternal().isString();
-    }
-    case VPACK_MANAGED_BUFFER: {
-      return VPackSlice(_data.buffer->data()).resolveExternal().isString();
     }
     case DOCVEC:
     case RANGE: {
@@ -265,9 +247,6 @@ bool AqlValue::isObject() const noexcept {
     case VPACK_MANAGED_SLICE: {
       return VPackSlice(_data.slice).resolveExternal().isObject();
     }
-    case VPACK_MANAGED_BUFFER: {
-      return VPackSlice(_data.buffer->data()).resolveExternal().isObject();
-    }
     case DOCVEC:
     case RANGE: {
       break;
@@ -290,9 +269,6 @@ bool AqlValue::isArray() const noexcept {
     }
     case VPACK_MANAGED_SLICE: {
       return VPackSlice(_data.slice).resolveExternal().isArray();
-    }
-    case VPACK_MANAGED_BUFFER: {
-      return VPackSlice(_data.buffer->data()).resolveExternal().isArray();
     }
     case DOCVEC:
     case RANGE: {
@@ -328,8 +304,7 @@ size_t AqlValue::length() const {
   switch (t) {
     case VPACK_INLINE:
     case VPACK_SLICE_POINTER:
-    case VPACK_MANAGED_SLICE:
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       return static_cast<size_t>(slice(t).length());
     }
     case DOCVEC: {
@@ -353,9 +328,7 @@ AqlValue AqlValue::at(int64_t position, bool& mustDestroy, bool doCopy) const {
     [[fallthrough]];
     case VPACK_INLINE:
     [[fallthrough]];
-    case VPACK_MANAGED_SLICE:
-    [[fallthrough]];
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       VPackSlice s(slice(t));
       if (s.isArray()) {
         int64_t const n = static_cast<int64_t>(s.length());
@@ -431,9 +404,7 @@ AqlValue AqlValue::at(int64_t position, size_t n, bool& mustDestroy, bool doCopy
     [[fallthrough]];
     case VPACK_INLINE:
     [[fallthrough]];
-    case VPACK_MANAGED_SLICE:
-    [[fallthrough]];
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       VPackSlice s(slice(t));
       if (s.isArray()) {
         if (position < 0) {
@@ -506,9 +477,7 @@ AqlValue AqlValue::getKeyAttribute(bool& mustDestroy, bool doCopy) const {
     [[fallthrough]];
     case VPACK_INLINE:
     [[fallthrough]];
-    case VPACK_MANAGED_SLICE:
-    [[fallthrough]];
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       VPackSlice s(slice(t));
       if (s.isObject()) {
         VPackSlice found = transaction::helpers::extractKeyFromDocument(s);
@@ -546,9 +515,7 @@ AqlValue AqlValue::getIdAttribute(CollectionNameResolver const& resolver,
     [[fallthrough]];
     case VPACK_INLINE:
     [[fallthrough]];
-    case VPACK_MANAGED_SLICE:
-    [[fallthrough]];
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       VPackSlice s(slice(t));
       if (s.isObject()) {
         VPackSlice found = transaction::helpers::extractIdFromDocument(s);
@@ -590,9 +557,7 @@ AqlValue AqlValue::getFromAttribute(bool& mustDestroy, bool doCopy) const {
     [[fallthrough]];
     case VPACK_INLINE:
     [[fallthrough]];
-    case VPACK_MANAGED_SLICE:
-    [[fallthrough]];
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       VPackSlice s(slice(t));
       if (s.isObject()) {
         VPackSlice found = transaction::helpers::extractFromFromDocument(s);
@@ -629,9 +594,7 @@ AqlValue AqlValue::getToAttribute(bool& mustDestroy, bool doCopy) const {
     [[fallthrough]];
     case VPACK_INLINE:
     [[fallthrough]];
-    case VPACK_MANAGED_SLICE:
-    [[fallthrough]];
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       VPackSlice s(slice(t));
       if (s.isObject()) {
         VPackSlice found = transaction::helpers::extractToFromDocument(s);
@@ -669,9 +632,7 @@ AqlValue AqlValue::get(CollectionNameResolver const& resolver,
     [[fallthrough]];
     case VPACK_INLINE:
     [[fallthrough]];
-    case VPACK_MANAGED_SLICE:
-    [[fallthrough]];
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       VPackSlice s(slice(t));
       if (s.isObject()) {
         VPackSlice found(s.get(name));
@@ -715,9 +676,7 @@ AqlValue AqlValue::get(CollectionNameResolver const& resolver,
     [[fallthrough]];
     case VPACK_INLINE:
     [[fallthrough]];
-    case VPACK_MANAGED_SLICE:
-    [[fallthrough]];
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       VPackSlice s(slice(t));
       if (s.isObject()) {
         VPackSlice found(s.get(name));
@@ -765,9 +724,7 @@ AqlValue AqlValue::get(CollectionNameResolver const& resolver,
     [[fallthrough]];
     case VPACK_INLINE:
     [[fallthrough]];
-    case VPACK_MANAGED_SLICE:
-    [[fallthrough]];
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       VPackSlice s(slice(t));
       if (s.isObject()) {
         s = s.resolveExternal();
@@ -825,8 +782,7 @@ bool AqlValue::hasKey(std::string const& name) const {
   switch (t) {
     case VPACK_INLINE:
     case VPACK_SLICE_POINTER:
-    case VPACK_MANAGED_SLICE:
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       VPackSlice s(slice(t));
       return (s.isObject() && s.hasKey(name));
     }
@@ -852,8 +808,7 @@ double AqlValue::toDouble(bool& failed) const {
   switch (t) {
     case VPACK_INLINE:
     case VPACK_SLICE_POINTER:
-    case VPACK_MANAGED_SLICE:
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       VPackSlice s(slice(t));
       if (s.isNull()) {
         return 0.0;
@@ -901,8 +856,7 @@ int64_t AqlValue::toInt64() const {
   switch (t) {
     case VPACK_INLINE:
     case VPACK_SLICE_POINTER:
-    case VPACK_MANAGED_SLICE:
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       VPackSlice s(slice(t));
       if (s.isNumber()) {
         return s.getNumber<int64_t>();
@@ -954,8 +908,7 @@ bool AqlValue::toBoolean() const {
   switch (t) {
     case VPACK_INLINE:
     case VPACK_SLICE_POINTER:
-    case VPACK_MANAGED_SLICE:
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       VPackSlice s(slice(t));
       if (s.isBoolean()) {
         return s.getBoolean();
@@ -992,6 +945,19 @@ size_t AqlValue::docvecLength() const {
   }
   return s;
 }
+  
+/// @brief return the memory origin type for values of type VPACK_MANAGED_SLICE
+AqlValue::MemoryOriginType AqlValue::memoryOriginType() const noexcept {
+  TRI_ASSERT(type() == VPACK_MANAGED_SLICE);
+  MemoryOriginType mot = static_cast<MemoryOriginType>(_data.internal[sizeof(_data.internal) - 2]);
+  TRI_ASSERT(mot == MemoryOriginType::New || mot == MemoryOriginType::Malloc);
+  return mot;
+}
+  
+/// @brief set the memory origin type for values of type VPACK_MANAGED_SLICE
+void AqlValue::setMemoryOriginType(AqlValue::MemoryOriginType type) noexcept {
+  _data.internal[sizeof(_data.internal) - 2] = static_cast<uint8_t>(type);
+}
 
 /// @brief construct a V8 value as input for the expression execution in V8
 v8::Handle<v8::Value> AqlValue::toV8(v8::Isolate* isolate, velocypack::Options const* options) const {
@@ -1000,8 +966,7 @@ v8::Handle<v8::Value> AqlValue::toV8(v8::Isolate* isolate, velocypack::Options c
   switch (t) {
     case VPACK_INLINE:
     case VPACK_SLICE_POINTER:
-    case VPACK_MANAGED_SLICE:
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       return TRI_VPackToV8(isolate, slice(t), options);
     }
     case DOCVEC: {
@@ -1051,8 +1016,8 @@ v8::Handle<v8::Value> AqlValue::toV8(v8::Isolate* isolate, velocypack::Options c
 }
 
 /// @brief materializes a value into the builder
-void AqlValue::toVelocyPack(VPackOptions const* options, arangodb::velocypack::Builder& builder,
-                            bool resolveExternals) const {
+void AqlValue::toVelocyPack(VPackOptions const* options, VPackBuilder& builder,
+                            bool resolveExternals, bool allowUnindexed) const {
   AqlValueType t = type();
   switch (t) {
     case VPACK_SLICE_POINTER:
@@ -1062,33 +1027,33 @@ void AqlValue::toVelocyPack(VPackOptions const* options, arangodb::velocypack::B
       }  
       [[fallthrough]];
     case VPACK_INLINE:
-    case VPACK_MANAGED_SLICE:
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       if (resolveExternals) {
         bool const sanitizeExternals = true;
         bool const sanitizeCustom = true;
         arangodb::basics::VelocyPackHelper::sanitizeNonClientTypes(
             slice(t), VPackSlice::noneSlice(), builder,
             options, sanitizeExternals,
-            sanitizeCustom);
+            sanitizeCustom, allowUnindexed);
       } else {
         builder.add(slice(t));
       }
       break;
     }
     case DOCVEC: {
-      builder.openArray();
+      builder.openArray(/*unindexed*/allowUnindexed);
       for (auto const& it : *_data.docvec) {
         size_t const n = it->size();
         for (size_t i = 0; i < n; ++i) {
-          it->getValueReference(i, 0).toVelocyPack(options, builder, resolveExternals);
+          it->getValueReference(i, 0).toVelocyPack(options, builder,
+                                                   resolveExternals, allowUnindexed);
         }
       }
       builder.close();
       break;
     }
     case RANGE: {
-      builder.openArray(/*unindexed*/true);
+      builder.openArray(/*unindexed*/allowUnindexed);
       size_t const n = _data.range->size();
       Range::throwIfTooBigForMaterialization(n);
       for (size_t i = 0; i < n; ++i) {
@@ -1106,20 +1071,17 @@ AqlValue AqlValue::materialize(VPackOptions const* options, bool& hasCopied,
   switch (type()) {
     case VPACK_INLINE:
     case VPACK_SLICE_POINTER:
-    case VPACK_MANAGED_SLICE:
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       hasCopied = false;
       return *this;
     }
     case DOCVEC:
     case RANGE: {
-      bool shouldDelete = true;
-      ConditionalDeleter<VPackBuffer<uint8_t>> deleter(shouldDelete);
-      std::shared_ptr<VPackBuffer<uint8_t>> buffer(new VPackBuffer<uint8_t>, deleter);
+      VPackBuffer<uint8_t> buffer;
       VPackBuilder builder(buffer);
-      toVelocyPack(options, builder, resolveExternals);
+      toVelocyPack(options, builder, resolveExternals, /*allowUnindexed*/true);
       hasCopied = true;
-      return AqlValue(buffer.get(), shouldDelete);
+      return AqlValue(std::move(buffer));
     }
   }
 
@@ -1146,10 +1108,6 @@ AqlValue AqlValue::clone() const {
     }
     case VPACK_MANAGED_SLICE: {
       return AqlValue(AqlValueHintCopy(_data.slice));
-    }
-    case VPACK_MANAGED_BUFFER: {
-      // copy buffer
-      return AqlValue(VPackSlice(_data.buffer->data()));
     }
     case DOCVEC: {
       auto c = std::make_unique<std::vector<SharedAqlItemBlockPtr>>();
@@ -1179,11 +1137,13 @@ void AqlValue::destroy() noexcept {
       return;
     }
     case VPACK_MANAGED_SLICE: {
-      delete[] _data.slice;
-      break;
-    }
-    case VPACK_MANAGED_BUFFER: {
-      delete _data.buffer;
+      auto memoryType = memoryOriginType();
+      if (memoryType == MemoryOriginType::New) {
+        delete[] _data.slice;
+      } else {
+        TRI_ASSERT(memoryType == MemoryOriginType::Malloc);
+        free(_data.slice);
+      }
       break;
     }
     case DOCVEC: {
@@ -1202,25 +1162,7 @@ void AqlValue::destroy() noexcept {
 
 /// @brief return the slice from the value
 VPackSlice AqlValue::slice() const {
-  switch (type()) {
-    case VPACK_INLINE: {
-      return VPackSlice(&_data.internal[0]).resolveExternal();
-    }
-    case VPACK_SLICE_POINTER: {
-      return VPackSlice(_data.pointer);
-    }
-    case VPACK_MANAGED_SLICE: {
-      return VPackSlice(_data.slice).resolveExternal();
-    }
-    case VPACK_MANAGED_BUFFER: {
-      return VPackSlice(_data.buffer->data()).resolveExternal();
-    }
-    case DOCVEC:
-    case RANGE: {
-    }
-  }
-
-  THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
+  return this->slice(type());
 }
 
 /// @brief return the slice from the value
@@ -1234,9 +1176,6 @@ VPackSlice AqlValue::slice(AqlValueType type) const {
     }
     case VPACK_MANAGED_SLICE: {
       return VPackSlice(_data.slice).resolveExternal();
-    }
-    case VPACK_MANAGED_BUFFER: {
-      return VPackSlice(_data.buffer->data()).resolveExternal();
     }
     case DOCVEC:
     case RANGE: {
@@ -1257,10 +1196,10 @@ int AqlValue::Compare(velocypack::Options const* options, AqlValue const& left,
     if (leftType == RANGE || rightType == RANGE || leftType == DOCVEC || rightType == DOCVEC) {
       // range|docvec against x
       VPackBuilder leftBuilder;
-      left.toVelocyPack(options, leftBuilder, false);
+      left.toVelocyPack(options, leftBuilder, /*resolveExternal*/false, /*allowUnindexed*/true);
 
       VPackBuilder rightBuilder;
-      right.toVelocyPack(options, rightBuilder, false);
+      right.toVelocyPack(options, rightBuilder, /*resolveExternal*/false, /*allowUnindexed*/true);
 
       return arangodb::basics::VelocyPackHelper::compare(leftBuilder.slice(),
                                                          rightBuilder.slice(),
@@ -1274,8 +1213,7 @@ int AqlValue::Compare(velocypack::Options const* options, AqlValue const& left,
   switch (leftType) {
     case VPACK_INLINE:
     case VPACK_SLICE_POINTER:
-    case VPACK_MANAGED_SLICE:
-    case VPACK_MANAGED_BUFFER: {
+    case VPACK_MANAGED_SLICE: {
       return arangodb::basics::VelocyPackHelper::compare(left.slice(leftType), right.slice(rightType),
                                                          compareUtf8, options);
     }
@@ -1509,11 +1447,13 @@ AqlValue::AqlValue(char const* value, size_t length) {
     _data.slice = new uint8_t[length + 1];
     _data.slice[0] = static_cast<uint8_t>(0x40U + length);
     memcpy(&_data.slice[1], value, length);
+    setMemoryOriginType(MemoryOriginType::New);
     setType(AqlValueType::VPACK_MANAGED_SLICE);
   } else {
     // long string
     // create a big enough uint8_t buffer
-    _data.slice = new uint8_t[length + 9];
+    size_t byteSize = length + 9;
+    _data.slice = new uint8_t[byteSize];
     _data.slice[0] = static_cast<uint8_t>(0xbfU);
     uint64_t v = length;
     for (uint64_t i = 0; i < 8; ++i) {
@@ -1521,6 +1461,7 @@ AqlValue::AqlValue(char const* value, size_t length) {
       v >>= 8;
     }
     memcpy(&_data.slice[9], value, length);
+    setMemoryOriginType(MemoryOriginType::New);
     setType(AqlValueType::VPACK_MANAGED_SLICE);
   }
 }
@@ -1538,25 +1479,29 @@ AqlValue::AqlValue(AqlValueHintEmptyObject const&) noexcept {
   setType(AqlValueType::VPACK_INLINE);
 }
 
-AqlValue::AqlValue(arangodb::velocypack::Buffer<uint8_t>* buffer, bool& shouldDelete) {
-  TRI_ASSERT(buffer != nullptr);
-  TRI_ASSERT(shouldDelete);  // here, the Buffer is still owned by the caller
-
+AqlValue::AqlValue(arangodb::velocypack::Buffer<uint8_t>&& buffer) {
   // intentionally do not resolve externals here
   // if (slice.isExternal()) {
   //   // recursively resolve externals
   //   slice = slice.resolveExternals();
   // }
-  if (buffer->length() < sizeof(_data.internal)) {
+  if (buffer.length() < sizeof(_data.internal)) {
     // Use inline value
-    memcpy(_data.internal, buffer->data(), static_cast<size_t>(buffer->length()));
+    memcpy(_data.internal, buffer.data(), static_cast<size_t>(buffer.length()));
+    buffer.clear(); // for move semantics
     setType(AqlValueType::VPACK_INLINE);
   } else {
-    // Use managed buffer, simply reuse the pointer and adjust the original
-    // Buffer's deleter
-    _data.buffer = buffer;
-    setType(AqlValueType::VPACK_MANAGED_BUFFER);
-    shouldDelete = false;  // adjust deletion control variable
+    // Use managed slice
+    if (buffer.usesLocalMemory()) {
+      _data.slice = new uint8_t[buffer.length()]();
+      setMemoryOriginType(MemoryOriginType::New);
+      memcpy(&_data.slice[0], buffer.data(), buffer.length());
+      buffer.clear(); // for move semantics
+    } else {
+      _data.slice = buffer.steal();
+      setMemoryOriginType(MemoryOriginType::Malloc);
+    }
+    setType(AqlValueType::VPACK_MANAGED_SLICE);
   }
 }
 
@@ -1621,8 +1566,6 @@ size_t AqlValue::memoryUsage() const noexcept {
       } catch (...) {
         return 0;
       }
-    case VPACK_MANAGED_BUFFER:
-      return _data.buffer->size();
     case DOCVEC:
       // no need to count the memory usage for the item blocks in docvec.
       // these have already been counted elsewhere (in ctors of AqlItemBlock
@@ -1653,6 +1596,7 @@ void AqlValue::initFromSlice(arangodb::velocypack::Slice const& slice) {
     // Use managed slice
     _data.slice = new uint8_t[length];
     memcpy(&_data.slice[0], slice.begin(), length);
+    setMemoryOriginType(MemoryOriginType::New);
     setType(AqlValueType::VPACK_MANAGED_SLICE);
   }
 }

--- a/arangod/Aql/AqlValue.h
+++ b/arangod/Aql/AqlValue.h
@@ -68,14 +68,14 @@ class AqlItemBlock;
 // no-op struct used only internally to indicate that we want
 // to copy the data behind the passed pointer
 struct AqlValueHintCopy {
-  explicit AqlValueHintCopy(uint8_t const* ptr);
+  explicit AqlValueHintCopy(uint8_t const* ptr) noexcept;
   uint8_t const* ptr;
 };
 
 // no-op struct used only internally to indicate that we want
 // to NOT copy the database document data behind the passed pointer
 struct AqlValueHintDocumentNoCopy {
-  explicit AqlValueHintDocumentNoCopy(uint8_t const* v);
+  explicit AqlValueHintDocumentNoCopy(uint8_t const* v) noexcept;
   uint8_t const* ptr;
 };
 
@@ -181,8 +181,8 @@ struct AqlValue final {
   // construct from pointer, not copying!
   explicit AqlValue(uint8_t const* pointer);
   
-  // construct from type and pointer, not copying!
-  explicit AqlValue(AqlValueType type, void* data) noexcept;
+  // construct from another AqlValue and a new data pointer, not copying!
+  explicit AqlValue(AqlValue const& other, void* data) noexcept;
 
   // construct from docvec, taking over its ownership
   explicit AqlValue(std::vector<arangodb::aql::SharedAqlItemBlockPtr>* docvec) noexcept;

--- a/arangod/Aql/AqlValue.h
+++ b/arangod/Aql/AqlValue.h
@@ -28,6 +28,7 @@
 #include "Aql/AqlValueFwd.h"
 #include "Aql/types.h"
 
+#include <velocypack/velocypack-common.h>
 #include <vector>
 
 namespace v8 {
@@ -223,7 +224,10 @@ struct AqlValue final {
   explicit AqlValue(AqlValueHintCopy const& v);
 
   // construct from Slice, copying contents
-  explicit AqlValue(arangodb::velocypack::Slice const& slice);
+  explicit AqlValue(arangodb::velocypack::Slice slice);
+  
+  // construct from Slice and length, copying contents
+  AqlValue(arangodb::velocypack::Slice slice, arangodb::velocypack::ValueLength length);
 
   // construct range type
   AqlValue(int64_t low, int64_t high);
@@ -231,12 +235,12 @@ struct AqlValue final {
   /// @brief AqlValues can be copied and moved as required
   /// memory management is not performed via AqlValue destructor but via
   /// explicit calls to destroy()
-  AqlValue(AqlValue const&) = default;
-  AqlValue& operator=(AqlValue const&) = default;
-  AqlValue(AqlValue&&) = default;
-  AqlValue& operator=(AqlValue&&) = default;
+  AqlValue(AqlValue const&) noexcept = default;
+  AqlValue& operator=(AqlValue const&) noexcept = default;
+  AqlValue(AqlValue&&) noexcept = default;
+  AqlValue& operator=(AqlValue&&) noexcept = default;
 
-  ~AqlValue() = default;
+  ~AqlValue() noexcept = default;
 
   /// @brief whether or not the value must be destroyed
   bool requiresDestruction() const noexcept;
@@ -370,7 +374,10 @@ struct AqlValue final {
 
  private:
   /// @brief initializes value from a slice
-  void initFromSlice(arangodb::velocypack::Slice const& slice);
+  void initFromSlice(arangodb::velocypack::Slice slice);
+  
+  /// @brief initializes value from a slice, when the length is already known
+  void initFromSlice(arangodb::velocypack::Slice slice, arangodb::velocypack::ValueLength length);
 
   /// @brief sets the value type
   void setType(AqlValueType type) noexcept;
@@ -384,8 +391,8 @@ struct AqlValue final {
   /// @brief return the memory origin type for values of type VPACK_MANAGED_SLICE
   MemoryOriginType memoryOriginType() const noexcept;
   
-  /// @brief set the memory origin type for values of type VPACK_MANAGED_SLICE
-  void setMemoryOriginType(MemoryOriginType type) noexcept;
+  /// @brief store meta information for values of type VPACK_MANAGED_SLICE
+  void setManagedSliceData(MemoryOriginType mot, arangodb::velocypack::ValueLength length);
 };
 
 // Check that the defaulted constructors, destructor and assignment

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -626,7 +626,7 @@ AqlValue Expression::executeSimpleExpressionArray(AstNode const* node,
 
   builder->close();
   mustDestroy = true;  // AqlValue contains builder contains dynamic data
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief execute an expression of type SIMPLE with OBJECT
@@ -740,7 +740,7 @@ AqlValue Expression::executeSimpleExpressionObject(AstNode const* node,
 
   mustDestroy = true;  // AqlValue contains builder contains dynamic data
 
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief execute an expression of type SIMPLE with VALUE
@@ -929,7 +929,7 @@ AqlValue Expression::invokeV8Function(ExpressionContext* expressionContext,
   }
 
   mustDestroy = true;  // builder = dynamic data
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief execute an expression of type SIMPLE, JavaScript variant

--- a/arangod/Aql/FixedVarExpressionContext.cpp
+++ b/arangod/Aql/FixedVarExpressionContext.cpp
@@ -62,7 +62,8 @@ void FixedVarExpressionContext::serializeAllVariables(velocypack::Options const&
   for (auto const& it : _vars) {
     builder.openArray();
     it.first->toVelocyPack(builder);
-    it.second.toVelocyPack(&opts, builder, true);
+    it.second.toVelocyPack(&opts, builder, /*resolveExternals*/true,
+                           /*allowUnindexed*/false);
     builder.close();
   }
 }

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -7514,8 +7514,8 @@ AqlValue Functions::PregelResult(ExpressionContext* expressionContext,
     return AqlValue(AqlValueHintEmptyArray());
   }
 
-  auto buffer = std::make_unique<VPackBuffer<uint8_t>>();
-  VPackBuilder builder(*buffer);
+  VPackBuffer<uint8_t> buffer;
+  VPackBuilder builder(buffer);
   if (ServerState::instance()->isCoordinator()) {
     std::shared_ptr<pregel::Conductor> c = feature->conductor(execNr);
     if (!c) {
@@ -7539,12 +7539,7 @@ AqlValue Functions::PregelResult(ExpressionContext* expressionContext,
   TRI_ASSERT(builder.slice().isArray());
 
   // move the buffer into
-  bool shouldDelete = true;
-  AqlValue val(buffer.get(), shouldDelete);
-  if (!shouldDelete) {
-    buffer.release();
-  }
-  return val;
+  return AqlValue(std::move(buffer));
 }
 
 AqlValue Functions::Assert(ExpressionContext* expressionContext, transaction::Methods* trx,

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -959,7 +959,7 @@ AqlValue mergeParameters(ExpressionContext* expressionContext, transaction::Meth
       builder = arangodb::basics::VelocyPackHelper::merge(builder.slice(), it,
                                                           false, recursive);
     }
-    return AqlValue(builder.slice());
+    return AqlValue(builder.slice(), builder.size());
   }
 
   if (!initial.isObject()) {
@@ -986,7 +986,7 @@ AqlValue mergeParameters(ExpressionContext* expressionContext, transaction::Meth
     // only one parameter. now add original document
     builder.add(initialSlice);
   }
-  return AqlValue(builder.slice());
+  return AqlValue(builder.slice(), builder.size());
 }
 
 /// @brief internal recursive flatten helper
@@ -1918,7 +1918,7 @@ AqlValue Functions::ToArray(ExpressionContext*, transaction::Methods* trx,
     }
   }
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function LENGTH
@@ -2117,7 +2117,7 @@ AqlValue Functions::Reverse(ExpressionContext* expressionContext, transaction::M
       builder->add(it);
     }
     builder->close();
-    return AqlValue(builder->slice());
+    return AqlValue(builder->slice(), builder->size());
   } else if (value.isString()) {
     std::string utf8;
     transaction::StringBufferLeaser buf1(trx);
@@ -3060,7 +3060,7 @@ AqlValue Functions::Split(ExpressionContext* expressionContext, transaction::Met
     builder->openArray();
     builder->add(aqlValueToSplit.slice());
     builder->close();
-    return AqlValue(builder->slice());
+    return AqlValue(builder->slice(), builder->size());
   }
 
   // Get ready for ICU
@@ -3088,7 +3088,7 @@ AqlValue Functions::Split(ExpressionContext* expressionContext, transaction::Met
     // empty string again.
     result->add(VPackValue(""));
     result->close();
-    return AqlValue(result->slice());
+    return AqlValue(result->slice(), result->size());
   }
 
   std::string utf8;
@@ -3147,7 +3147,7 @@ AqlValue Functions::Split(ExpressionContext* expressionContext, transaction::Met
   }
 
   result->close();
-  return AqlValue(result->slice());
+  return AqlValue(result->slice(), result->size());
 }
 
 /// @brief function REGEX_MATCHES
@@ -3163,7 +3163,7 @@ AqlValue Functions::RegexMatches(ExpressionContext* expressionContext,
     builder->openArray();
     builder->add(aqlValueToMatch.slice());
     builder->close();
-    return AqlValue(builder->slice());
+    return AqlValue(builder->slice(), builder->size());
   }
 
   bool const caseInsensitive = ::getBooleanParameter(trx, parameters, 2, false);
@@ -3199,7 +3199,7 @@ AqlValue Functions::RegexMatches(ExpressionContext* expressionContext,
     // empty string again.
     result->add(VPackValue(""));
     result->close();
-    return AqlValue(result->slice());
+    return AqlValue(result->slice(), result->size());
   }
 
   UErrorCode status = U_ZERO_ERROR;
@@ -3223,7 +3223,7 @@ AqlValue Functions::RegexMatches(ExpressionContext* expressionContext,
   }
 
   result->close();
-  return AqlValue(result->slice());
+  return AqlValue(result->slice(), result->size());
 }
 
 /// @brief function REGEX_SPLIT
@@ -3258,7 +3258,7 @@ AqlValue Functions::RegexSplit(ExpressionContext* expressionContext,
     builder->openArray();
     builder->add(aqlValueToSplit.slice());
     builder->close();
-    return AqlValue(builder->slice());
+    return AqlValue(builder->slice(), builder->size());
   }
 
   bool const caseInsensitive = ::getBooleanParameter(trx, parameters, 2, false);
@@ -3292,7 +3292,7 @@ AqlValue Functions::RegexSplit(ExpressionContext* expressionContext,
     // empty string again.
     result->add(VPackValue(""));
     result->close();
-    return AqlValue(result->slice());
+    return AqlValue(result->slice(), result->size());
   }
 
   std::string utf8;
@@ -3351,7 +3351,7 @@ AqlValue Functions::RegexSplit(ExpressionContext* expressionContext,
   }
 
   result->close();
-  return AqlValue(result->slice());
+  return AqlValue(result->slice(), result->size());
 }
 
 /// @brief function REGEX_TEST
@@ -4117,7 +4117,7 @@ AqlValue Functions::Unset(ExpressionContext* expressionContext, transaction::Met
   VPackSlice slice = materializer.slice(value, false);
   transaction::BuilderLeaser builder(trx);
   ::unsetOrKeep(trx, slice, names, true, false, *builder.get());
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function UNSET_RECURSIVE
@@ -4140,7 +4140,7 @@ AqlValue Functions::UnsetRecursive(ExpressionContext* expressionContext,
   VPackSlice slice = materializer.slice(value, false);
   transaction::BuilderLeaser builder(trx);
   ::unsetOrKeep(trx, slice, names, true, true, *builder.get());
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function KEEP
@@ -4162,7 +4162,7 @@ AqlValue Functions::Keep(ExpressionContext* expressionContext, transaction::Meth
   VPackSlice slice = materializer.slice(value, false);
   transaction::BuilderLeaser builder(trx);
   ::unsetOrKeep(trx, slice, names, false, false, *builder.get());
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function TRANSLATE
@@ -4295,7 +4295,7 @@ AqlValue Functions::Attributes(ExpressionContext* expressionContext,
     }
     builder->close();
 
-    return AqlValue(builder->slice());
+    return AqlValue(builder->slice(), builder->size());
   }
 
   std::unordered_set<std::string> keys;
@@ -4310,7 +4310,7 @@ AqlValue Functions::Attributes(ExpressionContext* expressionContext,
     builder->add(VPackValue(it));
   }
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function VALUES
@@ -4362,7 +4362,7 @@ AqlValue Functions::Values(ExpressionContext* expressionContext, transaction::Me
   }
   builder->close();
 
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function MIN
@@ -4593,7 +4593,7 @@ AqlValue Functions::Collections(ExpressionContext* expressionContext,
 
   builder->close();
 
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function RANDOM_TOKEN
@@ -4943,7 +4943,7 @@ AqlValue Functions::Unique(ExpressionContext* expressionContext, transaction::Me
   }
 
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function SORTED_UNIQUE
@@ -4979,7 +4979,7 @@ AqlValue Functions::SortedUnique(ExpressionContext* expressionContext,
     builder->add(it);
   }
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function SORTED
@@ -5019,7 +5019,7 @@ AqlValue Functions::Sorted(ExpressionContext* expressionContext, transaction::Me
     }
   }
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function UNION
@@ -5059,7 +5059,7 @@ AqlValue Functions::Union(ExpressionContext* expressionContext, transaction::Met
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function UNION_DISTINCT
@@ -5116,7 +5116,7 @@ AqlValue Functions::UnionDistinct(ExpressionContext* expressionContext,
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function INTERSECTION
@@ -5186,7 +5186,7 @@ AqlValue Functions::Intersection(ExpressionContext* expressionContext,
   TRI_IF_FAILURE("AqlFunctions::OutOfMemory3") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function JACCARD
@@ -5293,7 +5293,7 @@ AqlValue Functions::Outersection(ExpressionContext* expressionContext,
   TRI_IF_FAILURE("AqlFunctions::OutOfMemory3") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function DISTANCE
@@ -5540,7 +5540,7 @@ AqlValue Functions::GeoPoint(ExpressionContext* expressionContext, transaction::
   if (!lat1.isNumber() || !lon1.isNumber()) {
     registerWarning(expressionContext, "GEO_POINT",
                     TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
-    return AqlValue(arangodb::velocypack::Slice::nullSlice());
+    return AqlValue(AqlValueHintNull());
   }
 
   bool failed;
@@ -5553,7 +5553,7 @@ AqlValue Functions::GeoPoint(ExpressionContext* expressionContext, transaction::
   if (error) {
     registerWarning(expressionContext, "GEO_POINT",
                     TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
-    return AqlValue(arangodb::velocypack::Slice::nullSlice());
+    return AqlValue(AqlValueHintNull());
   }
 
   transaction::BuilderLeaser builder(trx);
@@ -5565,7 +5565,7 @@ AqlValue Functions::GeoPoint(ExpressionContext* expressionContext, transaction::
   builder->close();
   builder->close();
 
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function GEO_MULTIPOINT
@@ -5583,13 +5583,13 @@ AqlValue Functions::GeoMultiPoint(ExpressionContext* expressionContext,
 
   if (!geoArray.isArray()) {
     registerWarning(expressionContext, "GEO_MULTIPOINT", TRI_ERROR_QUERY_ARRAY_EXPECTED);
-    return AqlValue(arangodb::velocypack::Slice::nullSlice());
+    return AqlValue(AqlValueHintNull());
   }
   if (geoArray.length() < 2) {
     registerWarning(expressionContext, "GEO_MULTIPOINT",
                     Result(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH,
                            "a MultiPoint needs at least two positions"));
-    return AqlValue(arangodb::velocypack::Slice::nullSlice());
+    return AqlValue(AqlValueHintNull());
   }
 
   transaction::BuilderLeaser builder(trx);
@@ -5610,7 +5610,7 @@ AqlValue Functions::GeoMultiPoint(ExpressionContext* expressionContext,
           registerWarning(expressionContext, "GEO_MULTIPOINT",
                           Result(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH,
                                  "not a numeric value"));
-          return AqlValue(arangodb::velocypack::Slice::nullSlice());
+          return AqlValue(AqlValueHintNull());
         }
       }
       builder->close();
@@ -5618,14 +5618,14 @@ AqlValue Functions::GeoMultiPoint(ExpressionContext* expressionContext,
       registerWarning(expressionContext, "GEO_MULTIPOINT",
                       Result(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH,
                              "not an array containing positions"));
-      return AqlValue(arangodb::velocypack::Slice::nullSlice());
+      return AqlValue(AqlValueHintNull());
     }
   }
 
   builder->close();
   builder->close();
 
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function GEO_POLYGON
@@ -5643,7 +5643,7 @@ AqlValue Functions::GeoPolygon(ExpressionContext* expressionContext,
 
   if (!geoArray.isArray()) {
     registerWarning(expressionContext, "GEO_POLYGON", TRI_ERROR_QUERY_ARRAY_EXPECTED);
-    return AqlValue(arangodb::velocypack::Slice::nullSlice());
+    return AqlValue(AqlValueHintNull());
   }
 
   transaction::BuilderLeaser builder(trx);
@@ -5657,13 +5657,13 @@ AqlValue Functions::GeoPolygon(ExpressionContext* expressionContext,
   Result res = ::parseGeoPolygon(s, *builder.get());
   if (res.fail()) {
     registerWarning(expressionContext, "GEO_POLYGON", res);
-    return AqlValue(arangodb::velocypack::Slice::nullSlice());
+    return AqlValue(AqlValueHintNull());
   }
 
   builder->close();  // coordinates
   builder->close();  // object
 
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function GEO_MULTIPOLYGON
@@ -5681,7 +5681,7 @@ AqlValue Functions::GeoMultiPolygon(ExpressionContext* expressionContext,
 
   if (!geoArray.isArray()) {
     registerWarning(expressionContext, "GEO_MULTIPOLYGON", TRI_ERROR_QUERY_ARRAY_EXPECTED);
-    return AqlValue(arangodb::velocypack::Slice::nullSlice());
+    return AqlValue(AqlValueHintNull());
   }
 
   AqlValueMaterializer materializer(trx);
@@ -5705,7 +5705,7 @@ AqlValue Functions::GeoMultiPolygon(ExpressionContext* expressionContext,
         expressionContext, "GEO_MULTIPOLYGON",
         Result(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH,
                "a MultiPolygon needs at least two Polygons inside."));
-    return AqlValue(arangodb::velocypack::Slice::nullSlice());
+    return AqlValue(AqlValueHintNull());
   }
 
   transaction::BuilderLeaser builder(trx);
@@ -5719,14 +5719,14 @@ AqlValue Functions::GeoMultiPolygon(ExpressionContext* expressionContext,
           expressionContext, "GEO_MULTIPOLYGON",
           Result(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH,
                  "a MultiPolygon needs at least two Polygons inside."));
-      return AqlValue(arangodb::velocypack::Slice::nullSlice());
+      return AqlValue(AqlValueHintNull());
     }
     builder->openArray();  // arrayOfPolygons
     for (VPackSlice v : VPackArrayIterator(arrayOfPolygons)) {
       Result res = ::parseGeoPolygon(v, *builder.get());
       if (res.fail()) {
         registerWarning(expressionContext, "GEO_MULTIPOLYGON", res);
-        return AqlValue(arangodb::velocypack::Slice::nullSlice());
+        return AqlValue(AqlValueHintNull());
       }
     }
     builder->close();  // arrayOfPolygons close
@@ -5735,7 +5735,7 @@ AqlValue Functions::GeoMultiPolygon(ExpressionContext* expressionContext,
   builder->close();
   builder->close();
 
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function GEO_LINESTRING
@@ -5753,13 +5753,13 @@ AqlValue Functions::GeoLinestring(ExpressionContext* expressionContext,
 
   if (!geoArray.isArray()) {
     registerWarning(expressionContext, "GEO_LINESTRING", TRI_ERROR_QUERY_ARRAY_EXPECTED);
-    return AqlValue(arangodb::velocypack::Slice::nullSlice());
+    return AqlValue(AqlValueHintNull());
   }
   if (geoArray.length() < 2) {
     registerWarning(expressionContext, "GEO_LINESTRING",
                     Result(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH,
                            "a LineString needs at least two positions"));
-    return AqlValue(arangodb::velocypack::Slice::nullSlice());
+    return AqlValue(AqlValueHintNull());
   }
 
   transaction::BuilderLeaser builder(trx);
@@ -5780,7 +5780,7 @@ AqlValue Functions::GeoLinestring(ExpressionContext* expressionContext,
           registerWarning(expressionContext, "GEO_LINESTRING",
                           Result(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH,
                                  "not a numeric value"));
-          return AqlValue(arangodb::velocypack::Slice::nullSlice());
+          return AqlValue(AqlValueHintNull());
         }
       }
       builder->close();
@@ -5788,14 +5788,14 @@ AqlValue Functions::GeoLinestring(ExpressionContext* expressionContext,
       registerWarning(expressionContext, "GEO_LINESTRING",
                       Result(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH,
                              "not an array containing positions"));
-      return AqlValue(arangodb::velocypack::Slice::nullSlice());
+      return AqlValue(AqlValueHintNull());
     }
   }
 
   builder->close();
   builder->close();
 
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function GEO_MULTILINESTRING
@@ -5813,14 +5813,14 @@ AqlValue Functions::GeoMultiLinestring(ExpressionContext* expressionContext,
 
   if (!geoArray.isArray()) {
     registerWarning(expressionContext, "GEO_MULTILINESTRING", TRI_ERROR_QUERY_ARRAY_EXPECTED);
-    return AqlValue(arangodb::velocypack::Slice::nullSlice());
+    return AqlValue(AqlValueHintNull());
   }
   if (geoArray.length() < 1) {
     registerWarning(
         expressionContext, "GEO_MULTILINESTRING",
         Result(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH,
                "a MultiLineString needs at least one array of linestrings"));
-    return AqlValue(arangodb::velocypack::Slice::nullSlice());
+    return AqlValue(AqlValueHintNull());
   }
 
   transaction::BuilderLeaser builder(trx);
@@ -5845,7 +5845,7 @@ AqlValue Functions::GeoMultiLinestring(ExpressionContext* expressionContext,
                 registerWarning(expressionContext, "GEO_MULTILINESTRING",
                                 Result(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH,
                                        "not a numeric value"));
-                return AqlValue(arangodb::velocypack::Slice::nullSlice());
+                return AqlValue(AqlValueHintNull());
               }
             }
             builder->close();
@@ -5853,7 +5853,7 @@ AqlValue Functions::GeoMultiLinestring(ExpressionContext* expressionContext,
             registerWarning(expressionContext, "GEO_MULTILINESTRING",
                             Result(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH,
                                    "not an array containing positions"));
-            return AqlValue(arangodb::velocypack::Slice::nullSlice());
+            return AqlValue(AqlValueHintNull());
           }
         }
         builder->close();
@@ -5861,20 +5861,20 @@ AqlValue Functions::GeoMultiLinestring(ExpressionContext* expressionContext,
         registerWarning(expressionContext, "GEO_MULTILINESTRING",
                         Result(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH,
                                "not an array containing linestrings"));
-        return AqlValue(arangodb::velocypack::Slice::nullSlice());
+        return AqlValue(AqlValueHintNull());
       }
     } else {
       registerWarning(expressionContext, "GEO_MULTILINESTRING",
                       Result(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH,
                              "not an array containing positions"));
-      return AqlValue(arangodb::velocypack::Slice::nullSlice());
+      return AqlValue(AqlValueHintNull());
     }
   }
 
   builder->close();
   builder->close();
 
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function FLATTEN
@@ -5908,7 +5908,7 @@ AqlValue Functions::Flatten(ExpressionContext* expressionContext, transaction::M
   builder->openArray();
   ::flattenList(listSlice, maxDepth, 0, *builder.get());
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function ZIP
@@ -5962,7 +5962,7 @@ AqlValue Functions::Zip(ExpressionContext* expressionContext, transaction::Metho
 
   builder->close();
 
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function JSON_STRINGIFY
@@ -6001,7 +6001,7 @@ AqlValue Functions::JsonParse(ExpressionContext* expressionContext,
 
   try {
     std::shared_ptr<VPackBuilder> builder = VPackParser::fromJson(p, l);
-    return AqlValue(builder->slice());
+    return AqlValue(builder->slice(), builder->size());
   } catch (...) {
     registerWarning(expressionContext, AFN, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
     return AqlValue(AqlValueHintNull());
@@ -6048,7 +6048,7 @@ AqlValue Functions::ParseIdentifier(ExpressionContext* expressionContext,
   builder->add("key", VPackValuePair(identifier.data() + pos + 1,
                                      identifier.size() - pos - 1, VPackValueType::String));
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function Slice
@@ -6113,7 +6113,7 @@ AqlValue Functions::Slice(ExpressionContext* expressionContext, transaction::Met
   }
 
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function Minus
@@ -6172,7 +6172,7 @@ AqlValue Functions::Minus(ExpressionContext* expressionContext, transaction::Met
     builder->add(it.first);
   }
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function Document
@@ -6192,7 +6192,7 @@ AqlValue Functions::Document(ExpressionContext* expressionContext, transaction::
         // not found
         return AqlValue(AqlValueHintNull());
       }
-      return AqlValue(builder->slice());
+      return AqlValue(builder->slice(), builder->size());
     }
     if (id.isArray()) {
       AqlValueMaterializer materializer(trx);
@@ -6206,7 +6206,7 @@ AqlValue Functions::Document(ExpressionContext* expressionContext, transaction::
         }
       }
       builder->close();
-      return AqlValue(builder->slice());
+      return AqlValue(builder->slice(), builder->size());
     }
     return AqlValue(AqlValueHintNull());
   }
@@ -6226,7 +6226,7 @@ AqlValue Functions::Document(ExpressionContext* expressionContext, transaction::
     if (builder->isEmpty()) {
       return AqlValue(AqlValueHintNull());
     }
-    return AqlValue(builder->slice());
+    return AqlValue(builder->slice(), builder->size());
   }
 
   if (id.isArray()) {
@@ -6244,7 +6244,7 @@ AqlValue Functions::Document(ExpressionContext* expressionContext, transaction::
     }
 
     builder->close();
-    return AqlValue(builder->slice());
+    return AqlValue(builder->slice(), builder->size());
   }
 
   // Id has invalid format
@@ -6582,7 +6582,7 @@ AqlValue Functions::Push(ExpressionContext* expressionContext, transaction::Meth
     builder->openArray();
     builder->add(p);
     builder->close();
-    return AqlValue(builder->slice());
+    return AqlValue(builder->slice(), builder->size());
   }
 
   if (!list.isArray()) {
@@ -6608,7 +6608,7 @@ AqlValue Functions::Push(ExpressionContext* expressionContext, transaction::Meth
     builder->add(p);
   }
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function POP
@@ -6639,7 +6639,7 @@ AqlValue Functions::Pop(ExpressionContext* expressionContext, transaction::Metho
     iterator.next();
   }
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function APPEND
@@ -6709,7 +6709,7 @@ AqlValue Functions::Append(ExpressionContext* expressionContext, transaction::Me
     }
   }
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function UNSHIFT
@@ -6755,7 +6755,7 @@ AqlValue Functions::Unshift(ExpressionContext* expressionContext, transaction::M
     }
   }
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function SHIFT
@@ -6791,7 +6791,7 @@ AqlValue Functions::Shift(ExpressionContext* expressionContext, transaction::Met
   }
   builder->close();
 
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function REMOVE_VALUE
@@ -6847,7 +6847,7 @@ AqlValue Functions::RemoveValue(ExpressionContext* expressionContext,
     builder->add(it);
   }
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function REMOVE_VALUES
@@ -6888,7 +6888,7 @@ AqlValue Functions::RemoveValues(ExpressionContext* expressionContext,
     }
   }
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function REMOVE_NTH
@@ -6935,7 +6935,7 @@ AqlValue Functions::RemoveNth(ExpressionContext* expressionContext,
     cur++;
   }
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function ReplaceNth
@@ -7002,7 +7002,7 @@ AqlValue Functions::ReplaceNth(ExpressionContext* expressionContext,
     builder->add(replaceValue);
   }
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function NOT_NULL
@@ -7350,7 +7350,7 @@ AqlValue Functions::Range(ExpressionContext* expressionContext, transaction::Met
     }
   }
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 /// @brief function POSITION
@@ -7380,7 +7380,7 @@ AqlValue Functions::Position(ExpressionContext* expressionContext, transaction::
     if (::listContainsElement(trx, options, list, searchValue, index)) {
       if (!returnIndex) {
         // return true
-        return AqlValue(arangodb::velocypack::Slice::trueSlice());
+        return AqlValue(AqlValueHintBool(true));
       }
       // return position
       return AqlValue(AqlValueHintUInt(index));
@@ -7390,7 +7390,7 @@ AqlValue Functions::Position(ExpressionContext* expressionContext, transaction::
   // not found
   if (!returnIndex) {
     // return false
-    return AqlValue(arangodb::velocypack::Slice::falseSlice());
+    return AqlValue(AqlValueHintBool(false));
   }
 
   // return -1
@@ -7660,7 +7660,7 @@ AqlValue Functions::DecodeRev(ExpressionContext* expressionContext,
   builder->add("count", VPackValue(count));
   builder->close();
 
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 AqlValue Functions::SchemaGet(ExpressionContext* expressionContext,
@@ -7682,9 +7682,9 @@ AqlValue Functions::SchemaGet(ExpressionContext* expressionContext,
                                    "could not find collection: " + collectionName);
   }
 
-  VPackBuilder builder;
-  logicalCollection->validatorsToVelocyPack(builder);
-  auto slice = builder.slice();
+  transaction::BuilderLeaser builder(trx);
+  logicalCollection->validatorsToVelocyPack(*builder.get());
+  VPackSlice slice = builder->slice();
 
   if (!slice.isObject()) {
     return AqlValue(AqlValueHintNull{});
@@ -7698,7 +7698,7 @@ AqlValue Functions::SchemaGet(ExpressionContext* expressionContext,
                                        collectionName + " has no rule object");
   }
 
-  return AqlValue(slice);
+  return AqlValue(slice, builder->size());
 }
 
 AqlValue Functions::SchemaValidate(ExpressionContext* expressionContext,
@@ -7726,7 +7726,7 @@ AqlValue Functions::SchemaValidate(ExpressionContext* expressionContext,
       VPackObjectBuilder guard(resultBuilder.builder());
       resultBuilder->add("valid", VPackValue(true));
     }
-    return AqlValue(resultBuilder->slice());
+    return AqlValue(resultBuilder->slice(), resultBuilder->size());
   }
 
   if (!schemaValue.isObject()) {
@@ -7760,7 +7760,7 @@ AqlValue Functions::SchemaValidate(ExpressionContext* expressionContext,
     }
   }
 
-  return AqlValue(resultBuilder->slice());
+  return AqlValue(resultBuilder->slice(), resultBuilder->size());
 }
 
 AqlValue Functions::Interleave(arangodb::aql::ExpressionContext* expressionContext,
@@ -7811,7 +7811,7 @@ AqlValue Functions::Interleave(arangodb::aql::ExpressionContext* expressionConte
   }
 
   builder->close();
-  return AqlValue(builder->slice());
+  return AqlValue(builder->slice(), builder->size());
 }
 
 AqlValue Functions::NotImplemented(ExpressionContext* expressionContext,

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -363,19 +363,14 @@ ExecutionState Query::execute(QueryResult& queryResult) {
         }
 
         log();
-
-        _resultBuilderOptions = std::make_unique<VPackOptions>(VPackOptions::Defaults);
-        _resultBuilderOptions->buildUnindexedArrays = true;
-        _resultBuilderOptions->buildUnindexedObjects = true;
-
         // NOTE: If the options have a shorter lifetime than the builder, it
         // gets invalid (at least set() and close() are broken).
-        queryResult.data = std::make_shared<VPackBuilder>(_resultBuilderOptions.get());
+        queryResult.data = std::make_shared<VPackBuilder>(&vpackOptions());
 
         // reserve some space in Builder to avoid frequent reallocs
         queryResult.data->reserve(16 * 1024);
-
-        queryResult.data->openArray();
+        queryResult.data->openArray(/*unindexed*/true);
+        
         _executionPhase = ExecutionPhase::EXECUTE;
       }
       [[fallthrough]];
@@ -425,7 +420,9 @@ ExecutionState Query::execute(QueryResult& queryResult) {
               AqlValue const& val = block->getValueReference(i, resultRegister);
 
               if (!val.isEmpty()) {
-                val.toVelocyPack(&vpackOpts, resultBuilder, useQueryCache);
+                val.toVelocyPack(&vpackOpts, resultBuilder,
+                                 /*resolveExternals*/useQueryCache,
+                                 /*allowUnindexed*/true);
               }
             }
           }
@@ -621,6 +618,7 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
         if (!_queryOptions.silent) {
           size_t const n = value->size();
 
+          auto const& vpackOpts = vpackOptions();
           for (size_t i = 0; i < n; ++i) {
             AqlValue const& val = value->getValueReference(i, resultRegister);
 
@@ -628,7 +626,9 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
               resArray->Set(context, j++, val.toV8(isolate, &vpackOptions())).FromMaybe(false);
 
               if (useQueryCache) {
-                val.toVelocyPack(&vpackOptions(), *builder, true);
+                val.toVelocyPack(&vpackOpts, *builder,
+                                 /*resolveExternals*/true,
+                                 /*allowUnindexed*/true);
               }
 
               if (V8PlatformFeature::isOutOfMemory(isolate)) {

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -274,10 +274,6 @@ class Query : public QueryContext {
   /// plan serialized before instantiation, used for query profiling
   std::unique_ptr<velocypack::UInt8Buffer> _planSliceCopy;
 
-  /// Options for _resultBuilder. Optimally, its lifetime should be linked to
-  /// it, but this is hard to do.
-  std::unique_ptr<arangodb::velocypack::Options> _resultBuilderOptions;
-  
   /// @brief the transaction object, in a distributed query every part of
   /// the query has its own transaction object. The transaction object is
   /// created in the prepare method.

--- a/arangod/Aql/QueryCursor.cpp
+++ b/arangod/Aql/QueryCursor.cpp
@@ -319,17 +319,7 @@ void QueryStreamCursor::resetWakeupHandler() {
 }
 
 ExecutionState QueryStreamCursor::writeResult(VPackBuilder& builder) {
-  VPackOptions const* oldOptions = builder.options;
-  auto guard = scopeGuard([&] {
-    builder.options = oldOptions;
-  });
-  
-  VPackOptions options = VPackOptions::Defaults;
-  options.buildUnindexedArrays = true;
-  options.buildUnindexedObjects = true;
-  options.escapeUnicode = true;
-  builder.options = &options;
-  
+
   const bool isDone = _numBufferedRows <= batchSize();
   if (isDone) {  // only able to add 'extra' after all stats are collected
     TRI_ASSERT(_finalization);
@@ -361,7 +351,8 @@ ExecutionState QueryStreamCursor::writeResult(VPackBuilder& builder) {
     while (rowsWritten < batchSize() && _queryResultPos < block->size()) {
       AqlValue const& value = block->getValueReference(_queryResultPos, resultRegister);
       if (!value.isEmpty()) {  // ignore empty blocks (e.g. from UpdateBlock)
-        value.toVelocyPack(&vopts, builder, false);
+        value.toVelocyPack(&vopts, builder, /*resolveExternals*/false,
+                           /*allowUnindexed*/true);
         ++rowsWritten;
       }
       ++_queryResultPos;

--- a/arangod/Aql/SortedCollectExecutor.cpp
+++ b/arangod/Aql/SortedCollectExecutor.cpp
@@ -50,9 +50,9 @@ static const AqlValue EmptyValue;
 SortedCollectExecutor::CollectGroup::CollectGroup(bool count, Infos& infos)
     : groupLength(0),
       count(count),
-      _shouldDeleteBuilderBuffer(true),
       infos(infos),
-      _lastInputRow(InputAqlItemRow{CreateInvalidInputRowHint{}}) {
+      _lastInputRow(InputAqlItemRow{CreateInvalidInputRowHint{}}),
+      _builder(_buffer) {
   for (auto const& aggName : infos.getAggregateTypes()) {
     aggregators.emplace_back(Aggregator::fromTypeString(infos.getVPackOptions(), aggName));
   }
@@ -85,10 +85,7 @@ void SortedCollectExecutor::CollectGroup::initialize(size_t capacity) {
 }
 
 void SortedCollectExecutor::CollectGroup::reset(InputAqlItemRow const& input) {
-  _shouldDeleteBuilderBuffer = true;
-  ConditionalDeleter<VPackBuffer<uint8_t>> deleter(_shouldDeleteBuilderBuffer);
-  std::shared_ptr<VPackBuffer<uint8_t>> buffer(new VPackBuffer<uint8_t>, deleter);
-  _builder = VPackBuilder(buffer);
+  _builder.clear();
 
   if (!groupValues.empty()) {
     for (auto& it : groupValues) {
@@ -175,14 +172,18 @@ void SortedCollectExecutor::CollectGroup::addLine(InputAqlItemRow const& input) 
       groupLength++;
     } else if (infos.getExpressionVariable() != nullptr) {
       // compute the expression
-      input.getValue(infos.getExpressionRegister()).toVelocyPack(infos.getVPackOptions(), _builder, false);
+      input.getValue(infos.getExpressionRegister()).toVelocyPack(infos.getVPackOptions(), _builder,
+                                                                 /*resolveExternals*/false,
+                                                                 /*allowUnindexed*/false);
     } else {
       // copy variables / keep variables into result register
 
       _builder.openObject();
       for (auto const& pair : infos.getInputVariables()) {
         _builder.add(VPackValue(pair.first));
-        input.getValue(pair.second).toVelocyPack(infos.getVPackOptions(), _builder, false);
+        input.getValue(pair.second).toVelocyPack(infos.getVPackOptions(), _builder,
+                                                 /*resolveExternals*/false,
+                                                 /*allowUnindexed*/false);
       }
       _builder.close();
     }
@@ -227,7 +228,9 @@ bool SortedCollectExecutor::CollectGroup::isSameGroup(InputAqlItemRow const& inp
 void SortedCollectExecutor::CollectGroup::groupValuesToArray(VPackBuilder& builder) {
   builder.openArray();
   for (auto const& value : groupValues) {
-    value.toVelocyPack(infos.getVPackOptions(), builder, false);
+    value.toVelocyPack(infos.getVPackOptions(), builder,
+                       /*resolveExternals*/false,
+                       /*allowUnindexed*/false);
   }
 
   builder.close();
@@ -272,9 +275,10 @@ void SortedCollectExecutor::CollectGroup::writeToOutput(OutputAqlItemRow& output
       TRI_ASSERT(_builder.isOpenArray());
       _builder.close();
 
-      auto buffer = _builder.steal();
-      AqlValue val(buffer.get(), _shouldDeleteBuilderBuffer);
+      AqlValue val(std::move(_buffer)); // _buffer still usable after
       AqlValueGuard guard{val, true};
+      TRI_ASSERT(_buffer.size() == 0);
+      _builder.clear(); // necessary
 
       output.moveValueInto(infos.getCollectRegister(), _lastInputRow, guard);
     }

--- a/arangod/Aql/SortedCollectExecutor.h
+++ b/arangod/Aql/SortedCollectExecutor.h
@@ -137,9 +137,9 @@ class SortedCollectExecutor {
     AggregateValuesType aggregators;
     size_t groupLength;
     bool const count;
-    bool _shouldDeleteBuilderBuffer;
     Infos& infos;
     InputAqlItemRow _lastInputRow;
+    arangodb::velocypack::Buffer<uint8_t> _buffer;
     arangodb::velocypack::Builder _builder;
 
     CollectGroup() = delete;

--- a/arangod/Aql/SubqueryEndExecutor.cpp
+++ b/arangod/Aql/SubqueryEndExecutor.cpp
@@ -120,31 +120,23 @@ auto SubqueryEndExecutor::consumeShadowRow(ShadowAqlItemRow shadowRow,
 }
 
 void SubqueryEndExecutor::Accumulator::reset() {
-  if (_buffer == nullptr) {
-    // no Buffer present
-    _buffer = std::make_unique<arangodb::velocypack::Buffer<uint8_t>>();
-    // we need to recreate the builder even if the old one still exists.
-    // this is because the Builder points to the Buffer
-    _builder = std::make_unique<VPackBuilder>(*_buffer);
-  } else {
-    // Buffer still present. we can get away with reusing and clearing 
-    // the existing Builder, which points to the Buffer
-    TRI_ASSERT(_builder != nullptr);
-    _builder->clear();
-  }
-  TRI_ASSERT(_builder != nullptr);
-  _builder->openArray();
+  // Buffer present. we can get away with reusing and clearing
+  // the existing Builder, which points to the Buffer
+  _builder.clear();
+  _builder.openArray();
   _numValues = 0;
 }
 
 void SubqueryEndExecutor::Accumulator::addValue(AqlValue const& value) {
-  TRI_ASSERT(_builder->isOpenArray());
-  value.toVelocyPack(_options, *_builder, false);
+  TRI_ASSERT(_builder.isOpenArray());
+  value.toVelocyPack(_options, _builder,
+                     /*resolveExternals*/false,
+                     /*allowUnindexed*/false);
   ++_numValues;
 }
 
 SubqueryEndExecutor::Accumulator::Accumulator(VPackOptions const* const options)
-    : _options(options) {
+    : _options(options), _builder(_buffer) {
   reset();
 }
 
@@ -152,22 +144,15 @@ AqlValueGuard SubqueryEndExecutor::Accumulator::stealValue(AqlValue& result) {
   // Note that an AqlValueGuard holds an AqlValue&, so we cannot create it
   // from a local AqlValue and return the Guard!
 
-  TRI_ASSERT(_builder->isOpenArray());
-  _builder->close();
-  TRI_ASSERT(_builder->isClosed());
+  TRI_ASSERT(_builder.isOpenArray());
+  _builder.close();
+  TRI_ASSERT(_builder.isClosed());
 
   // Here we have all data *and* the relevant shadow row,
   // so we can now submit
-  bool shouldDelete = true;
-  result = AqlValue{_buffer.get(), shouldDelete};
-  if (shouldDelete) {
-    // resultDocVec told us to delete our data
-    _buffer->clear();
-  } else {
-    // relinquish ownership of _buffer, as it now belongs to
-    // resultDocVec
-    std::ignore = _buffer.release();
-  }
+  result = AqlValue{std::move(_buffer)};
+  TRI_ASSERT(_buffer.size() == 0);
+  _builder.clear();
 
   // Call reset *after* AqlValueGuard is constructed, so when an exception is
   // thrown, the ValueGuard can free the AqlValue.

--- a/arangod/Aql/SubqueryEndExecutor.h
+++ b/arangod/Aql/SubqueryEndExecutor.h
@@ -32,7 +32,6 @@
 #include "Aql/Stats.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 namespace aql {
@@ -112,7 +111,7 @@ class SubqueryEndExecutor {
   // control of it to hand over to an AqlValue
   class Accumulator {
    public:
-    explicit Accumulator(VPackOptions const* options);
+    explicit Accumulator(velocypack::Options const* options);
     void reset();
 
     void addValue(AqlValue const& value);
@@ -122,9 +121,9 @@ class SubqueryEndExecutor {
     size_t numValues() const noexcept;
 
    private:
-    VPackOptions const* const _options;
-    std::unique_ptr<arangodb::velocypack::Buffer<uint8_t>> _buffer{nullptr};
-    std::unique_ptr<VPackBuilder> _builder{nullptr};
+    velocypack::Options const* const _options;
+    arangodb::velocypack::Buffer<uint8_t> _buffer;
+    velocypack::Builder _builder;
     size_t _numValues{0};
   };
 

--- a/arangod/Graph/TraverserDocumentCache.cpp
+++ b/arangod/Graph/TraverserDocumentCache.cpp
@@ -107,8 +107,8 @@ aql::AqlValue TraverserDocumentCache::fetchVertexAqlResult(arangodb::velocypack:
   if (finding.found()) {
     auto val = finding.value();
     VPackSlice slice(val->value());
-    // finding makes sure that slice contant stays valid.
-    return aql::AqlValue(slice);
+    // finding makes sure that slice constant stays valid.
+    return aql::AqlValue(slice, val->size());
   }
   // Not in cache. Fetch and insert.
   return aql::AqlValue(lookupAndCache(idString));

--- a/arangod/IResearch/AqlHelper.h
+++ b/arangod/IResearch/AqlHelper.h
@@ -342,7 +342,8 @@ class ScopedAqlValue : private irs::util::noncopyable {
     _node->isConstant()
         ? _node->toVelocyPackValue(builder)
         : _value.toVelocyPack(static_cast<velocypack::Options const*>(nullptr),
-                              builder, false);
+                              builder, /*resoveExternals*/false,
+                              /*allowUnindexed*/false);
   }
 
  private:

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -546,8 +546,8 @@ arangodb::aql::AqlValue aqlFnTokens(arangodb::aql::ExpressionContext* /*expressi
 
   // to avoid copying Builder's default buffer when initializing AqlValue
   // create the buffer externally and pass ownership directly into AqlValue
-  auto buffer = std::make_unique<arangodb::velocypack::Buffer<uint8_t>>();
-  arangodb::velocypack::Builder builder(*buffer);
+  arangodb::velocypack::Buffer<uint8_t> buffer;
+  arangodb::velocypack::Builder builder(buffer);
   builder.openArray();
   std::vector<arangodb::velocypack::ArrayIterator> arrayIteratorStack;
   auto current = args[0].slice();
@@ -641,16 +641,7 @@ arangodb::aql::AqlValue aqlFnTokens(arangodb::aql::ExpressionContext* /*expressi
 
   builder.close();
 
-  bool bufOwner = true;  // out parameter from AqlValue denoting ownership
-                         // aquisition (must be true initially)
-  auto release = irs::make_finally([&buffer, &bufOwner]() -> void {
-    // cppcheck-suppress knownConditionTrueFalse
-    if (!bufOwner) {
-      buffer.release();
-    }
-  });
-
-  return arangodb::aql::AqlValue(buffer.get(), bufOwner);
+  return arangodb::aql::AqlValue(std::move(buffer));
 }
 
 void addFunctions(arangodb::aql::AqlFunctionFeature& functions) {

--- a/tests/IResearch/IResearchAnalyzerFeature-test.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeature-test.cpp
@@ -2872,17 +2872,13 @@ TEST_F(IResearchAnalyzerFeatureTest, test_tokens) {
   // empty nested array
   {
     VPackFunctionParametersWrapper args;
-    auto buffer = irs::memory::make_unique<arangodb::velocypack::Buffer<uint8_t>>();
-    VPackBuilder builder(*buffer);
+    arangodb::velocypack::Buffer<uint8_t> buffer;
+    VPackBuilder builder(buffer);
     builder.openArray();
     builder.openArray();
     builder.close();
     builder.close();
-    auto bufOwner = true;
-    auto aqlValue = arangodb::aql::AqlValue(buffer.get(), bufOwner);
-    if (!bufOwner) {
-      buffer.release();
-    }
+    auto aqlValue = arangodb::aql::AqlValue(std::move(buffer));
     args->push_back(std::move(aqlValue));
     auto result = AqlValueWrapper(impl(nullptr, &trx, *args));
     EXPECT_TRUE(result->isArray());
@@ -2898,8 +2894,8 @@ TEST_F(IResearchAnalyzerFeatureTest, test_tokens) {
   // non-empty nested array
   {
     VPackFunctionParametersWrapper args;
-    auto buffer = irs::memory::make_unique<arangodb::velocypack::Buffer<uint8_t>>();
-    VPackBuilder builder(*buffer);
+    arangodb::velocypack::Buffer<uint8_t> buffer;
+    VPackBuilder builder(buffer);
     builder.openArray();
     builder.openArray();
     builder.openArray();
@@ -2907,11 +2903,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_tokens) {
     builder.close();
     builder.close();
     builder.close();
-    auto bufOwner = true;
-    auto aqlValue = arangodb::aql::AqlValue(buffer.get(), bufOwner);
-    if (!bufOwner) {
-      buffer.release();
-    }
+    auto aqlValue = arangodb::aql::AqlValue(std::move(buffer));
     args->push_back(std::move(aqlValue));
     auto result = AqlValueWrapper(impl(nullptr, &trx, *args));
     EXPECT_TRUE(result->isArray());
@@ -2933,18 +2925,14 @@ TEST_F(IResearchAnalyzerFeatureTest, test_tokens) {
 
   // array of bools
   {
-    auto buffer = irs::memory::make_unique<arangodb::velocypack::Buffer<uint8_t>>();
-    VPackBuilder builder(*buffer);
+    arangodb::velocypack::Buffer<uint8_t> buffer;
+    VPackBuilder builder(buffer);
     builder.openArray();
     builder.add(arangodb::velocypack::Value(true));
     builder.add(arangodb::velocypack::Value(false));
     builder.add(arangodb::velocypack::Value(true));
     builder.close();
-    auto bufOwner = true;
-    auto aqlValue = arangodb::aql::AqlValue(buffer.get(), bufOwner);
-    if (!bufOwner) {
-      buffer.release();
-    }
+    auto aqlValue = arangodb::aql::AqlValue(std::move(buffer));
     VPackFunctionParametersWrapper args;
     args->push_back(std::move(aqlValue));
     irs::string_ref analyzer("text_en");
@@ -2985,8 +2973,8 @@ TEST_F(IResearchAnalyzerFeatureTest, test_tokens) {
   // [ [[]], [['test', 123.4, true]], 123, 123.4, true, null, false, 'jumps', ['quick', 'dog'] ]
   {
     VPackFunctionParametersWrapper args;
-    auto buffer = irs::memory::make_unique<arangodb::velocypack::Buffer<uint8_t>>();
-    VPackBuilder builder(*buffer);
+    arangodb::velocypack::Buffer<uint8_t> buffer;
+    VPackBuilder builder(buffer);
     builder.openArray();
     // [[]]
     builder.openArray();
@@ -3018,11 +3006,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_tokens) {
 
     builder.close();
 
-    auto bufOwner = true;
-    auto aqlValue = arangodb::aql::AqlValue(buffer.get(), bufOwner);
-    if (!bufOwner) {
-      buffer.release();
-    }
+    auto aqlValue = arangodb::aql::AqlValue(std::move(buffer));
     args->push_back(std::move(aqlValue));
     irs::string_ref analyzer("text_en");
     args->emplace_back(analyzer.c_str(), analyzer.size());


### PR DESCRIPTION
### Scope & Purpose

Reenable "Aqlvalue optimization" PR after temporarily reverting the changes.
There was a problem with the original PR which did not show up in our PR tests, but only when using ASan.
Memory was allocated in 3rdParty/velocypack/include/velocypack/Buffer.h using `malloc()` but deallocated in arangod/Aql/AqlValue.cpp using `delete[]`. ASan rightfully complained about this.
This PR should store the memory allocation type (new vs. malloc) inside the AqlValue for AqlValues of type `VPACK_MANAGED_SLICE`, so the correct deallocation method can be chosen at runtime.

- [x] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [x] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [x] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [x] The behavior change can be verified via automatic tests

### Testing & Verification

This change is already covered by existing tests, such as *shell_server_aql*.

- [x] I ensured this code runs with ASan / TSan or other static verification tools

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11467/