### PR TITLE
Fix potential data loss when leader come back at an unlucky time.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fixed a problem with potentially lost updates because a failover could
+  happen at a wrong time or a restarted leader could come back at an
+  unlucky time.
+
 * Fixed issue ES-664: the optimizer rule `inline-subqueries` must pull out a
   subqueries that contains a COLLECT statement if the subquery is itself
   called from within a loop. Otherwise the COLLECT will be applied to the

--- a/arangod/Agency/FailedLeader.cpp
+++ b/arangod/Agency/FailedLeader.cpp
@@ -203,10 +203,9 @@ bool FailedLeader::start(bool& aborts) {
   using namespace std::chrono;
 
   // Current servers vector
-  auto const& current = _snapshot
-                            .hasAsSlice(curColPrefix + _database + "/" +
-                                        _collection + "/" + _shard + "/servers")
-                            .first;
+  std::string curPath = curColPrefix + _database + "/" + _collection + "/" + _shard;
+  auto const& current = _snapshot.hasAsSlice(curPath + "/servers").first;
+
   // Planned servers vector
   std::string planPath =
       planColPrefix + _database + "/" + _collection + "/shards/" + _shard;
@@ -302,6 +301,13 @@ bool FailedLeader::start(bool& aborts) {
         addPreconditionServerHealth(pending, _to, "GOOD");
         // Server list in plan still as before
         addPreconditionUnchanged(pending, planPath, planned);
+        // Server list in Current still as known
+        addPreconditionUnchanged(pending, curPath + "/servers", current);
+        // Failover candidates in Current still as known
+        auto const& failoverCandidates = _snapshot.hasAsSlice(curPath + "/failoverCandidates");
+        if (failoverCandidates.second) {
+          addPreconditionUnchanged(pending, curPath + "/failoverCandidates", failoverCandidates.first);
+        }
         // Destination server should not be blocked by another job
         addPreconditionServerNotBlocked(pending, _to);
         // Shard to be handled is block by another job

--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -30,6 +30,7 @@
 #include "Basics/Mutex.h"
 #include "Basics/ReadWriteLock.h"
 #include "Basics/Result.h"
+#include "Basics/StringUtils.h"
 #include "Basics/WriteLocker.h"
 #include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/StorageEngine.h"
@@ -198,17 +199,31 @@ class FollowerInfo {
         return _canWrite;
       }
       if (!_theLeaderTouched) {
+        READ_LOCKER(readLockerData, _dataLock);
         // prevent writes before `TakeoverShardLeadership` has run
+        LOG_TOPIC("7c1d4", INFO, Logger::REPLICATION)
+            << "Shard "
+            << _docColl->name() << " is temporarily in read-only mode, since we have not yet run TakeoverShardLeadership since the last restart.";
         return false;
       }
       READ_LOCKER(readLockerData, _dataLock);
       TRI_ASSERT(_docColl != nullptr);
       if (_followers->size() + 1 < _docColl->writeConcern()) {
         // We know that we still do not have enough followers
+        LOG_TOPIC("d7306", ERR, Logger::REPLICATION)
+            << "Shard " << _docColl->name() << " is temporarily in read-only mode, since we have less than writeConcern ("
+            << basics::StringUtils::itoa(_docColl->writeConcern())
+            << ") replicas in sync.";
         return false;
       }
     }
-    return updateFailoverCandidates();
+    bool res = updateFailoverCandidates();
+    if (!res) {
+      LOG_TOPIC("2e35a", ERR, Logger::REPLICATION)
+          << "Shard "
+          << _docColl->name() << " is temporarily in read-only mode, since we could not update the failover candidates in the agency.";
+    }
+    return res;
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -198,6 +198,8 @@ class FollowerInfo {
 #endif
         return _canWrite;
       }
+      READ_LOCKER(readLockerData, _dataLock);
+      TRI_ASSERT(_docColl != nullptr);
       if (!_theLeaderTouched) {
         READ_LOCKER(readLockerData, _dataLock);
         // prevent writes before `TakeoverShardLeadership` has run
@@ -206,8 +208,6 @@ class FollowerInfo {
             << _docColl->name() << " is temporarily in read-only mode, since we have not yet run TakeoverShardLeadership since the last restart.";
         return false;
       }
-      READ_LOCKER(readLockerData, _dataLock);
-      TRI_ASSERT(_docColl != nullptr);
       if (_followers->size() + 1 < _docColl->writeConcern()) {
         // We know that we still do not have enough followers
         LOG_TOPIC("d7306", ERR, Logger::REPLICATION)

--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -201,7 +201,6 @@ class FollowerInfo {
       READ_LOCKER(readLockerData, _dataLock);
       TRI_ASSERT(_docColl != nullptr);
       if (!_theLeaderTouched) {
-        READ_LOCKER(readLockerData, _dataLock);
         // prevent writes before `TakeoverShardLeadership` has run
         LOG_TOPIC("7c1d4", INFO, Logger::REPLICATION)
             << "Shard "

--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -197,6 +197,10 @@ class FollowerInfo {
 #endif
         return _canWrite;
       }
+      if (!_theLeaderTouched) {
+        // prevent writes before `TakeoverShardLeadership` has run
+        return false;
+      }
       READ_LOCKER(readLockerData, _dataLock);
       TRI_ASSERT(_docColl != nullptr);
       if (_followers->size() + 1 < _docColl->writeConcern()) {

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -997,11 +997,6 @@ Future<OperationResult> transaction::Methods::insertLocal(std::string const& cna
       if (!followerInfo->allowedToWrite()) {
         // We cannot fulfill minimum replication Factor.
         // Reject write.
-        LOG_TOPIC("d7306", ERR, Logger::REPLICATION)
-            << "Less than writeConcern ("
-            << basics::StringUtils::itoa(collection->writeConcern())
-            << ") followers in sync. Shard  " << collection->name()
-            << " is temporarily in read-only mode.";
         return OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options);
       }
 
@@ -1300,11 +1295,6 @@ Future<OperationResult> transaction::Methods::modifyLocal(std::string const& col
       if (!followerInfo->allowedToWrite()) {
         // We cannot fulfill minimum replication Factor.
         // Reject write.
-        LOG_TOPIC("2e35a", ERR, Logger::REPLICATION)
-            << "Less than writeConcern ("
-            << basics::StringUtils::itoa(collection->writeConcern())
-            << ") followers in sync. Shard  " << collection->name()
-            << " is temporarily in read-only mode.";
         return OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options);
       }
 
@@ -1525,11 +1515,6 @@ Future<OperationResult> transaction::Methods::removeLocal(std::string const& col
       if (!followerInfo->allowedToWrite()) {
         // We cannot fulfill minimum replication Factor.
         // Reject write.
-        LOG_TOPIC("f1f8e", ERR, Logger::REPLICATION)
-            << "Less than writeConcern ("
-            << basics::StringUtils::itoa(collection->writeConcern())
-            << ") followers in sync. Shard  " << collection->name()
-            << " is temporarily in read-only mode.";
         return OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options);
       }
 
@@ -1752,11 +1737,6 @@ Future<OperationResult> transaction::Methods::truncateLocal(std::string const& c
       if (!followerInfo->allowedToWrite()) {
         // We cannot fulfill minimum replication Factor.
         // Reject write.
-        LOG_TOPIC("7c1d4", ERR, Logger::REPLICATION)
-            << "Less than writeConcern ("
-            << basics::StringUtils::itoa(collection->writeConcern())
-            << ") followers in sync. Shard  " << collection->name()
-            << " is temporarily in read-only mode.";
         return futures::makeFuture(OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options));
       }
 


### PR DESCRIPTION
The fear is that a leader comes back exactly when the failover to
a different leader is happening, it could accept writes too early,
report success to the coordinator and then the client, and the failover
leads then to the writes being lost.

Measures taken:

 1. After a restart, only accept writes once TakeoverShardLeadership has
    run.
 2. In FailedServer (failover code), add precondition that the chosen
    failover candidate has not been deleted in the meantime.

Some of these problems have been observed in chaos runs but are not
easily reproducible.