### PR TITLE
Attempt to fix undefined behaviour under Mac Os

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Fixed issue BTS-168: Fixed undefined behaviour that did trigger
+  segfaults on cluster startups. It is only witnessed for
+  MacOS based builds. The issue could be triggered by any network connection.
+  This behaviour is not part of any released version.
+
 * Fixed issue ES-664: the optimizer rule `inline-subqueries` must pull out a
   subqueries that contains a COLLECT statement if the subquery is itself
   called from within a loop. Otherwise the COLLECT will be applied to the


### PR DESCRIPTION
### Scope & Purpose

This partially reverts an earlier commit:
https://github.com/arangodb/arangodb/pull/12206

After the above commit our clang compiled versions (mainly macOS) started to show undefined behavior.

I think in the case we have here, there is a race where a wait on the condition variable could trigger before the notify is send if the mutex is freed, which would cause the variable to be freed and causes undefined behavior
As @mpoeter has contributed the original version and has much more detail knowledge here I hope you have some time for a quick Review or comment here.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests (MacOS Jenkins)

#### Backports:

- [x] No backports required
- [ ] Backports required for: *(Please specify versions)*

#### Related Information

*(Please reference tickets / specification etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket number: BTS-168
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] This change is already covered by existing tests, such as *MacOs Cluster tests*. 
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added **Regression Tests**
  - [ ] Added new C++ **Unit Tests**
  - [ ] Added new **integration tests** (i.e. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)

Additionally:

- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

*(Include link to Jenkins run etc)*
http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/11492/

### Documentation

> All new Features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the changelog so that
> developers and users have a concise overview. 

- [x] Added a *Changelog Entry* (referencing the corresponding public or internal issue number)
- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
