### PR TITLE
fixed issue #12304

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@ v3.6.6 (XXXX-XX-XX)
 
 * Fixed issue #12304: insert in transaction causing
   com.arangodb.ArangoDBException: Response: 500, Error: 4 - Builder value not
-  yet sealed 
+  yet sealed.
 
   This happened when too deeply-nested documents (more than 63 levels of
   nesting) were inserted. While indefinite nesting is still not supported, the

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 v3.6.6 (XXXX-XX-XX)
 -------------------
 
+* Fixed issue #12304: insert in transaction causing com.arangodb.ArangoDBException: 
+  Response: 500, Error: 4 - Builder value not yet sealed 
+
+  This happened when too deeply-nested documents (more than 63 levels of nesting)
+  were inserted. While indefinite nesting is still not supported, the error message
+  has been corrected from the internal HTTP 500 error "Builder value not yet sealed"
+  to the correct HTTP 400 "Bad parameter".
+
 * Fixed internal issue #748: Fixed reading of primary sort values for late
   materialization (of ArangoSearch views).
 

--- a/arangod/VocBase/Methods/Transactions.cpp
+++ b/arangod/VocBase/Methods/Transactions.cpp
@@ -137,7 +137,7 @@ Result executeTransactionJS(v8::Isolate* isolate, v8::Handle<v8::Value> const& a
     // be overwritten later if is contained in `object`
     VPackBuilder builder;
     // we must use "convertFunctionsToNull" here, because "action" is most
-    // likey a JavaScript function
+    // likely a JavaScript function
     TRI_V8ToVPack(isolate, builder, object, false,
                   /*convertFunctionsToNull*/ true);
     if (!builder.isClosed()) {

--- a/arangosh/Shell/V8ClientConnection.cpp
+++ b/arangosh/Shell/V8ClientConnection.cpp
@@ -1618,9 +1618,9 @@ again:
     VPackBuilder builder(buffer, &_vpackOptions);
     int res = TRI_V8ToVPack(isolate, builder, body, false);
     if (res != TRI_ERROR_NO_ERROR) {
-      LOG_TOPIC("46ae2", ERR, Logger::V8)
-          << "error converting request body: " << TRI_errno_string(res);
-      return v8::Null(isolate);
+      TRI_V8_SET_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
+                                   std::string("error converting request body: ") + TRI_errno_string(res));
+      return v8::Undefined(isolate);
     }
     if (_forceJson) {
       auto resultJson = builder.slice().toJson();

--- a/lib/V8/v8-vpack.cpp
+++ b/lib/V8/v8-vpack.cpp
@@ -36,8 +36,8 @@
 
 using VelocyPackHelper = arangodb::basics::VelocyPackHelper;
 
-/// @brief maximum object nesting depth
-static int const MaxLevels = 64;
+/// @brief maximum array/object nesting depth
+static int const MaxLevels = 80;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief converts a VelocyValueType::String into a V8 object
@@ -341,10 +341,18 @@ static int V8ToVPack(BuilderContext& context, v8::Handle<v8::Value> const parame
   if (parameter->IsArray()) {
     v8::Handle<v8::Array> array = v8::Handle<v8::Array>::Cast(parameter);
 
+    if (++context.level > MaxLevels) {
+      // too much recursion - roll back level increase and return null and an error instead
+      --context.level;
+      AddValue<VPackValue, inObject>(context, attributeName, VPackValue(VPackValueType::Null));
+      return TRI_ERROR_BAD_PARAMETER;
+    }
+
     AddValue<VPackValue, inObject>(context, attributeName,
                                    VPackValue(VPackValueType::Array));
     uint32_t const n = array->Length();
 
+    int res = TRI_ERROR_NO_ERROR;
     for (uint32_t i = 0; i < n; ++i) {
       v8::Handle<v8::Value> value = array->Get(i);
       if (value->IsUndefined()) {
@@ -352,25 +360,20 @@ static int V8ToVPack(BuilderContext& context, v8::Handle<v8::Value> const parame
         continue;
       }
 
-      if (++context.level > MaxLevels) {
-        // too much recursion
-        return TRI_ERROR_BAD_PARAMETER;
-      }
-
-      int res = V8ToVPack<performAllChecks, false>(context, value, arangodb::velocypack::StringRef(),
-                                                   convertFunctionsToNull);
-
-      --context.level;
+      res = V8ToVPack<performAllChecks, false>(context, value, arangodb::velocypack::StringRef(),
+                                               convertFunctionsToNull);
 
       if (res != TRI_ERROR_NO_ERROR) {
-        return res;
+        break;
       }
     }
+      
+    --context.level;
 
     if (!context.keepTopLevelOpen || context.level > 0) {
       context.builder.close();
     }
-    return TRI_ERROR_NO_ERROR;
+    return res;
   }
 
   if (parameter->IsObject()) {
@@ -444,9 +447,18 @@ static int V8ToVPack(BuilderContext& context, v8::Handle<v8::Value> const parame
 
     v8::Handle<v8::Array> names = o->GetOwnPropertyNames();
     uint32_t const n = names->Length();
+    
+    if (++context.level > MaxLevels) {
+      // too much recursion - roll back level increase and return null and an error instead
+      --context.level;
+      AddValue<VPackValue, inObject>(context, attributeName, VPackValue(VPackValueType::Null));
+      return TRI_ERROR_BAD_PARAMETER;
+    }
 
     AddValue<VPackValue, inObject>(context, attributeName,
                                    VPackValue(VPackValueType::Object));
+
+    int res = TRI_ERROR_NO_ERROR;
 
     for (uint32_t i = 0; i < n; ++i) {
       // process attribute name
@@ -455,7 +467,8 @@ static int V8ToVPack(BuilderContext& context, v8::Handle<v8::Value> const parame
       v8::String::Utf8Value str(context.isolate, key);
 
       if (*str == nullptr) {
-        return TRI_ERROR_OUT_OF_MEMORY;
+        res = TRI_ERROR_OUT_OF_MEMORY;
+        break;
       }
 
       v8::Handle<v8::Value> value = o->Get(key);
@@ -464,26 +477,21 @@ static int V8ToVPack(BuilderContext& context, v8::Handle<v8::Value> const parame
         continue;
       }
 
-      if (++context.level > MaxLevels) {
-        // too much recursion
-        return TRI_ERROR_BAD_PARAMETER;
-      }
-
-      int res = V8ToVPack<performAllChecks, true>(context, value,
-                                                  arangodb::velocypack::StringRef(*str, str.length()),
-                                                  convertFunctionsToNull);
-
-      --context.level;
+      res = V8ToVPack<performAllChecks, true>(context, value,
+                                              arangodb::velocypack::StringRef(*str, str.length()),
+                                              convertFunctionsToNull);
 
       if (res != TRI_ERROR_NO_ERROR) {
-        return res;
+        break;
       }
     }
+    
+    --context.level;
 
     if (!context.keepTopLevelOpen || context.level > 0) {
       context.builder.close();
     }
-    return TRI_ERROR_NO_ERROR;
+    return res;
   }
 
   return TRI_ERROR_BAD_PARAMETER;

--- a/tests/js/common/shell/shell-transactions.js
+++ b/tests/js/common/shell/shell-transactions.js
@@ -44,19 +44,162 @@ function TransactionsInvocationsSuite() {
 
   return {
 
-    ////////////////////////////////////////////////////////////////////////////////
-    /// @brief set up
-    ////////////////////////////////////////////////////////////////////////////////
-
-    setUp: function () {
-    },
-
-    ////////////////////////////////////////////////////////////////////////////////
-    /// @brief tear down
-    ////////////////////////////////////////////////////////////////////////////////
-
     tearDown: function () {
       internal.wait(0);
+    },
+    
+    testNestingLevelArrayOk: function () {
+      let params = { doc: [] };
+      let level = 0;
+      let start = params.doc;
+      while (level < 64) {
+        start.push([]);
+        start = start[0];
+        ++level;
+      }
+
+      let obj = {
+        collections: {},
+        action: function (params) {
+          return params.doc;
+        },
+        params
+      };
+
+      let result = db._executeTransaction(obj);
+      assertEqual(params.doc, result);
+    },
+    
+    testNestingLevelArrayBorderline: function () {
+      let params = { doc: [] };
+      let level = 0;
+      let start = params.doc;
+      while (level < 77) {
+        start.push([]);
+        start = start[0];
+        ++level;
+      }
+
+      let obj = {
+        collections: {},
+        action: function (params) {
+          return params.doc;
+        },
+        params
+      };
+
+      let result = db._executeTransaction(obj);
+      assertEqual(params.doc, result);
+    },
+    
+    testNestingLevelArrayTooDeep: function () {
+      if (!global.ARANGOSH_PATH) {
+        // we are arangod... in this case the JS -> JSON -> JS 
+        // conversion will not take place, and we will not run into
+        // an error here
+        return;
+      }
+
+      let params = { doc: [] };
+      let level = 0;
+      let start = params.doc;
+      while (level < 100) {
+        start.push([]);
+        start = start[0];
+        ++level;
+      }
+
+      let obj = {
+        collections: {},
+        action: function (params) {
+          return params.doc;
+        },
+        params
+      };
+
+      try {
+        db._executeTransaction(obj);
+        fail();
+      } catch (err) {
+        assertEqual(arangodb.errors.ERROR_BAD_PARAMETER.code, err.errorNum);
+      }
+    },
+    
+    testNestingLevelObjectOk: function () {
+      let params = { doc: {} };
+      let level = 0;
+      let start = params.doc;
+      while (level < 64) {
+        start.doc = {};
+        start = start.doc;
+        ++level;
+      }
+
+      let obj = {
+        collections: {},
+        action: function (params) {
+          return params.doc;
+        },
+        params
+      };
+
+      let result = db._executeTransaction(obj);
+      assertEqual(params.doc, result);
+    },
+    
+    testNestingLevelObjectBorderline: function () {
+      let params = { doc: {} };
+      let level = 0;
+      let start = params.doc;
+      while (level < 77) {
+        start.doc = {};
+        start = start.doc;
+        ++level;
+      }
+
+      let obj = {
+        collections: {},
+        action: function (params) {
+          return params.doc;
+        },
+        params
+      };
+
+      let result = db._executeTransaction(obj);
+      assertEqual(params.doc, result);
+    },
+    
+    testNestingLevelObjectTooDeep: function () {
+      if (!global.ARANGOSH_PATH) {
+        // we are arangod... in this case the JS -> JSON -> JS 
+        // conversion will not take place, and we will not run into
+        // an error here
+        return;
+      }
+
+      let params = { doc: {} };
+      let level = 0;
+      let start = params.doc;
+      while (level < 100) {
+        start.doc = {};
+        start = start.doc;
+        ++level;
+      }
+
+      let obj = {
+        collections: {},
+        action: function (params) {
+          return params.doc;
+        },
+        params
+      };
+
+      try {
+        db._executeTransaction(obj);
+        fail();
+      } catch (err) {
+        assertEqual(arangodb.errors.ERROR_BAD_PARAMETER.code, err.errorNum);
+      }
     },
 
     testErrorHandling: function () {
@@ -99,8 +242,7 @@ function TransactionsInvocationsSuite() {
         assertEqual(arangodb.ERROR_BAD_PARAMETER, err.errorNum);
       }
     },
-
-
+    
     ////////////////////////////////////////////////////////////////////////////////
     /// @brief execute a transaction with a string action
     ////////////////////////////////////////////////////////////////////////////////
@@ -151,8 +293,7 @@ function TransactionsInvocationsSuite() {
           action: null,
         });
         fail();
-      }
-      catch (err) {
+      } catch (err) {
         assertEqual(ERRORS.ERROR_BAD_PARAMETER.code, err.errorNum);
       }
     },
@@ -167,8 +308,7 @@ function TransactionsInvocationsSuite() {
           collections: {}
         });
         fail();
-      }
-      catch (err) {
+      } catch (err) {
         assertEqual(ERRORS.ERROR_BAD_PARAMETER.code, err.errorNum);
       }
     },
@@ -184,8 +324,7 @@ function TransactionsInvocationsSuite() {
           action: "return 11;"
         });
         fail();
-      }
-      catch (err) {
+      } catch (err) {
         assertEqual(ERRORS.ERROR_BAD_PARAMETER.code, err.errorNum);
       }
     },
@@ -201,8 +340,7 @@ function TransactionsInvocationsSuite() {
           action: "function () { "
         });
         fail();
-      }
-      catch (err) {
+      } catch (err) {
         assertEqual(ERRORS.ERROR_BAD_PARAMETER.code, err.errorNum);
       }
     },
@@ -218,8 +356,7 @@ function TransactionsInvocationsSuite() {
           action: null,
         });
         fail();
-      }
-      catch (err) {
+      } catch (err) {
         assertEqual(ERRORS.ERROR_BAD_PARAMETER.code, err.errorNum);
       }
     },


### PR DESCRIPTION
### Scope & Purpose

Fixed issue #12304: insert in transaction causing com.arangodb.ArangoDBException: Response: 500, Error: 4 - Builder value not yet sealed. 

This happened when too deeply-nested documents (more than 63 levels of nesting) were inserted via an API that required a VelocyPack-to-JavaScript coversion or vice versa. 
While indefinite nesting is still not supported, the error message has been corrected from the internal HTTP 500 error "Builder value not yet sealed" to the correct HTTP 400 "Bad parameter".

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.6, 3.7

#### Related Information

- [x] GitHub issue / Jira ticket number: #12304 

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11510/