### PR TITLE
Fix potential data loss when leader come back at an unlucky time.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,8 @@
 v3.6.6 (XXXX-XX-XX)
 -------------------
 
-* Fixed a problem with potentially lost updates because a failover could
-  happen at a wrong time or a restarted leader could come back at an
-  unlucky time.
+* Fixed a problem with potentially lost updates because a failover could happen
+  at a wrong time or a restarted leader could come back at an unlucky time.
 
 * Fixed BTS-167: Lingering Queries - Canceled from the UI.
   This fixes queries not vanishing from the list of running queries in the web

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.6.6 (XXXX-XX-XX)
 -------------------
 
+* Fixed a problem with potentially lost updates because a failover could
+  happen at a wrong time or a restarted leader could come back at an
+  unlucky time.
+
 * Fixed bad behaviour in agency supervision in some corner cases involving
   already resigned leaders in Current.
 

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -1551,11 +1551,6 @@ Future<OperationResult> transaction::Methods::insertLocal(std::string const& cna
       if (!followerInfo->allowedToWrite()) {
         // We cannot fulfill minimum replication Factor.
         // Reject write.
-        LOG_TOPIC("d7306", ERR, Logger::REPLICATION)
-            << "Less than writeConcern ("
-            << basics::StringUtils::itoa(collection->writeConcern())
-            << ") followers in sync. Shard  " << collection->name()
-            << " is temporarily in read-only mode.";
         return OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options);
       }
 
@@ -1864,11 +1859,6 @@ Future<OperationResult> transaction::Methods::modifyLocal(std::string const& col
       if (!followerInfo->allowedToWrite()) {
         // We cannot fulfill minimum replication Factor.
         // Reject write.
-        LOG_TOPIC("2e35a", ERR, Logger::REPLICATION)
-            << "Less than writeConcern ("
-            << basics::StringUtils::itoa(collection->writeConcern())
-            << ") followers in sync. Shard  " << collection->name()
-            << " is temporarily in read-only mode.";
         return OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options);
       }
 
@@ -2150,11 +2140,6 @@ Future<OperationResult> transaction::Methods::removeLocal(std::string const& col
       if (!followerInfo->allowedToWrite()) {
         // We cannot fulfill minimum replication Factor.
         // Reject write.
-        LOG_TOPIC("f1f8e", ERR, Logger::REPLICATION)
-            << "Less than writeConcern ("
-            << basics::StringUtils::itoa(collection->writeConcern())
-            << ") followers in sync. Shard  " << collection->name()
-            << " is temporarily in read-only mode.";
         return OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options);
       }
 
@@ -2395,11 +2380,6 @@ Future<OperationResult> transaction::Methods::truncateLocal(std::string const& c
       if (!followerInfo->allowedToWrite()) {
         // We cannot fulfill minimum replication Factor.
         // Reject write.
-        LOG_TOPIC("7c1d4", ERR, Logger::REPLICATION)
-            << "Less than writeConcern ("
-            << basics::StringUtils::itoa(collection->writeConcern())
-            << ") followers in sync. Shard  " << collection->name()
-            << " is temporarily in read-only mode.";
         return futures::makeFuture(OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options));
       }
 


### PR DESCRIPTION
Only allow writes after TakeoverShardLeadership has happened.
On FailedLeader, add precondition for failoverCandidates.
Improve logging in case of temporary read-only shards.
CHANGELOG.

This is a port from a `devel`/`3.7` fix back to 3.6. This problem was never observed in 3.6, but could theoretically also happen in 3.6. Most likely, it was never observed in chaos, since the server restart timing is different. Nevertheless, this fix should go into 3.6, preferably 3.6.6.