### PR TITLE
Fix potential data loss when leader come back at an unlucky time.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.5.6 (XXXX-XX-XX)
 -------------------
 
+* Fixed a problem with potentially lost updates because a failover could
+  happen at a wrong time or a restarted leader could come back at an
+  unlucky time.
+
 * Fixed bad behaviour in agency supervision in some corner cases involving
   already resigned leaders in Current.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,8 @@
 v3.5.6 (XXXX-XX-XX)
 -------------------
 
-* Fixed a problem with potentially lost updates because a failover could
-  happen at a wrong time or a restarted leader could come back at an
-  unlucky time.
+* Fixed a problem with potentially lost updates because a failover could happen
+  at a wrong time or a restarted leader could come back at an unlucky time.
 
 * Fixed bad behaviour in agency supervision in some corner cases involving
   already resigned leaders in Current.

--- a/arangod/Agency/FailedLeader.cpp
+++ b/arangod/Agency/FailedLeader.cpp
@@ -151,10 +151,9 @@ bool FailedLeader::start(bool& aborts) {
   using namespace std::chrono;
 
   // Current servers vector
-  auto const& current = _snapshot
-                            .hasAsSlice(curColPrefix + _database + "/" +
-                                        _collection + "/" + _shard + "/servers")
-                            .first;
+  std::string curPath = curColPrefix + _database + "/" + _collection + "/" + _shard;
+  auto const& current = _snapshot.hasAsSlice(curPath + "/servers").first;
+
   // Planned servers vector
   std::string planPath =
       planColPrefix + _database + "/" + _collection + "/shards/" + _shard;
@@ -258,6 +257,13 @@ bool FailedLeader::start(bool& aborts) {
         addPreconditionServerHealth(pending, _to, "GOOD");
         // Server list in plan still as before
         addPreconditionUnchanged(pending, planPath, planned);
+        // Server list in Current still as known
+        addPreconditionUnchanged(pending, curPath + "/servers", current);
+        // Failover candidates in Current still as known
+        auto const& failoverCandidates = _snapshot.hasAsSlice(curPath + "/failoverCandidates");
+        if (failoverCandidates.second) {
+          addPreconditionUnchanged(pending, curPath + "/failoverCandidates", failoverCandidates.first);
+        }
         // Destination server should not be blocked by another job
         addPreconditionServerNotBlocked(pending, _to);
         // Shard to be handled is block by another job

--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -30,6 +30,7 @@
 #include "Basics/Mutex.h"
 #include "Basics/ReadWriteLock.h"
 #include "Basics/Result.h"
+#include "Basics/StringUtils.h"
 #include "Basics/WriteLocker.h"
 #include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/StorageEngine.h"
@@ -199,12 +200,29 @@ class FollowerInfo {
       }
       READ_LOCKER(readLockerData, _dataLock);
       TRI_ASSERT(_docColl != nullptr);
+      if (!_theLeaderTouched) {
+        // prevent writes before `TakeoverShardLeadership` has run
+        LOG_TOPIC("7c1d4", INFO, Logger::REPLICATION)
+            << "Shard "
+            << _docColl->name() << " is temporarily in read-only mode, since we have not yet run TakeoverShardLeadership since the last restart.";
+        return false;
+      }
       if (_followers->size() + 1 < _docColl->minReplicationFactor()) {
         // We know that we still do not have enough followers
+        LOG_TOPIC("d7306", ERR, Logger::REPLICATION)
+            << "Shard " << _docColl->name() << " is temporarily in read-only mode, since we have less than minReplicationFactor ("
+            << basics::StringUtils::itoa(_docColl->minReplicationFactor())
+            << ") replicas in sync.";
         return false;
       }
     }
-    return updateFailoverCandidates();
+    bool res = updateFailoverCandidates();
+    if (!res) {
+      LOG_TOPIC("2e35a", ERR, Logger::REPLICATION)
+          << "Shard "
+          << _docColl->name() << " is temporarily in read-only mode, since we could not update the failover candidates in the agency.";
+    }
+    return res;
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -1752,11 +1752,6 @@ OperationResult transaction::Methods::insertLocal(std::string const& collectionN
       if (!followerInfo->allowedToWrite()) {
         // We cannot fulfill minimum replication Factor.
         // Reject write.
-        LOG_TOPIC("d7306", ERR, Logger::REPLICATION)
-            << "Less then minReplicationFactor "
-            << basics::StringUtils::itoa(collection->minReplicationFactor())
-            << " followers in sync. Shard  " << collection->name()
-            << " is temporarily in read-only mode.";
         return OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options);
       }
 
@@ -2082,11 +2077,6 @@ OperationResult transaction::Methods::modifyLocal(std::string const& collectionN
       if (!followerInfo->allowedToWrite()) {
         // We cannot fulfill minimum replication Factor.
         // Reject write.
-        LOG_TOPIC("2e35a", ERR, Logger::REPLICATION)
-            << "Less then minReplicationFactor "
-            << basics::StringUtils::itoa(collection->minReplicationFactor())
-            << " followers in sync. Shard  " << collection->name()
-            << " is temporarily in read-only mode.";
         return OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options);
       }
 
@@ -2362,11 +2352,6 @@ OperationResult transaction::Methods::removeLocal(std::string const& collectionN
       if (!followerInfo->allowedToWrite()) {
         // We cannot fulfill minimum replication Factor.
         // Reject write.
-        LOG_TOPIC("f1f8e", ERR, Logger::REPLICATION)
-            << "Less then minReplicationFactor "
-            << basics::StringUtils::itoa(collection->minReplicationFactor())
-            << " followers in sync. Shard  " << collection->name()
-            << " is temporarily in read-only mode.";
         return OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options);
       }
 
@@ -2597,11 +2582,6 @@ OperationResult transaction::Methods::truncateLocal(std::string const& collectio
       if (!followerInfo->allowedToWrite()) {
         // We cannot fulfill minimum replication Factor.
         // Reject write.
-        LOG_TOPIC("7c1d4", ERR, Logger::REPLICATION)
-            << "Less then minReplicationFactor "
-            << basics::StringUtils::itoa(collection->minReplicationFactor())
-            << " followers in sync. Shard  " << collection->name()
-            << " is temporarily in read-only mode.";
         return OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options);
       }
 


### PR DESCRIPTION
Only allow writes after TakeoverShardLeadership has happened.
On FailedLeader, add precondition for failoverCandidates.
Improve logging in case of temporary read-only shards.
CHANGELOG.

This is a backport of a fix for `devel` and `3.7`. Note that this bad behaviour has never been observed in 3.5 in chaos. However, theoretically, it could still happen and we probably have not seen it in chaos since the server restart timing is different between the different versions. Nevertheless, this fix should go into 3.5, too.