### PR TITLE
fix UPSERT behavior with collection bind parameter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,23 @@
 devel
 -----
 
+* Make UPSERT statement with collection bind parameter behave identical to its
+  non-bind parameter counterpart.
+
+  For example, the query 
+
+      FOR d IN ["key_1", "key_2", "key_3", "key_1"] 
+        UPSERT d INSERT d UPDATE d IN @@collection
+
+  would fail with "unique constraint violation" when used with a collection
+  bind parameter, but the equivalent query
+      
+      FOR d IN ["key_1", "key_2", "key_3", "key_1"] 
+        UPSERT d INSERT d UPDATE d IN collectionName
+
+  with a hard-coded collection name would succeed. This is now fixed so both
+  queries have the same behavior (no failure).
+
 * Fixed that dropping a vanished follower works again. An exception response
   to the replication request is now handled properly.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,23 @@
 devel
 -----
+
+* Make UPSERT statement with collection bind parameter behave identical to its
+  non-bind parameter counterpart.
+
+  For example, the query 
+
+      FOR d IN ["key_1", "key_2", "key_3", "key_1"] 
+        UPSERT d INSERT d UPDATE d IN @@collection
+
+  would fail with "unique constraint violation" when used with a collection
+  bind parameter, but the equivalent query
+      
+      FOR d IN ["key_1", "key_2", "key_3", "key_1"] 
+        UPSERT d INSERT d UPDATE d IN collectionName
+
+  with a hard-coded collection name would succeed. This is now fixed so both
+  queries have the same behavior (no failure) in single server. 
+
 * Fix internal issue #742: Add tick storage in index meta payload after 
   truncate operation
 
@@ -20,23 +38,6 @@ devel
   to the correct HTTP 400 "Bad parameter".
 
 * Show optimizer rules with highest execution times in explain output.
-
-* Make UPSERT statement with collection bind parameter behave identical to its
-  non-bind parameter counterpart.
-
-  For example, the query 
-
-      FOR d IN ["key_1", "key_2", "key_3", "key_1"] 
-        UPSERT d INSERT d UPDATE d IN @@collection
-
-  would fail with "unique constraint violation" when used with a collection
-  bind parameter, but the equivalent query
-      
-      FOR d IN ["key_1", "key_2", "key_3", "key_1"] 
-        UPSERT d INSERT d UPDATE d IN collectionName
-
-  with a hard-coded collection name would succeed. This is now fixed so both
-  queries have the same behavior (no failure).
 
 * Fixed that dropping a vanished follower works again. An exception response
   to the replication request is now handled properly.

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -1636,36 +1636,56 @@ void Ast::injectBindParameters(BindParameters& parameters,
           bool isWriteCollection = false;
 
           arangodb::velocypack::StringRef paramRef(param);
+          arangodb::velocypack::StringRef nameRef(name, l);
+
+          AstNode* newNode = nullptr;
           for (auto const& it : _writeCollections) {
             auto const& c = it.first;
 
             if (c->type == NODE_TYPE_PARAMETER_DATASOURCE &&
                 paramRef == arangodb::velocypack::StringRef(c->getStringValue(),
                                                             c->getStringLength())) {
+              // bind parameter still present in _writeCollections
+              TRI_ASSERT(newNode == nullptr);
               isWriteCollection = true;
+              break;
+            } else if (c->type == NODE_TYPE_COLLECTION &&
+                nameRef == arangodb::velocypack::StringRef(c->getStringValue(),
+                                                           c->getStringLength())) {
+              // bind parameter was already replaced with a proper collection node 
+              // in _writeCollections
+              TRI_ASSERT(newNode == nullptr);
+              isWriteCollection = true;
+              newNode = const_cast<AstNode*>(c);
               break;
             }
           }
 
-          node = createNodeDataSource(resolver, name, l,
-                                      isWriteCollection ? AccessMode::Type::WRITE
-                                                        : AccessMode::Type::READ,
-                                      false, true);
+          TRI_ASSERT(newNode == nullptr || isWriteCollection);
 
-          if (isWriteCollection) {
-            // must update AST info now for all nodes that contained this
-            // parameter
-            for (size_t i = 0; i < _writeCollections.size(); ++i) {
-              auto& c = _writeCollections[i].first;
+          if (newNode == nullptr) {
+            newNode = createNodeDataSource(resolver, name, l,
+                                           isWriteCollection ? AccessMode::Type::WRITE
+                                                             : AccessMode::Type::READ,
+                                        false, true);
+            TRI_ASSERT(newNode != nullptr);
 
-              if (c->type == NODE_TYPE_PARAMETER_DATASOURCE &&
-                  paramRef == arangodb::velocypack::StringRef(c->getStringValue(),
-                                                              c->getStringLength())) {
-                c = node;
-                // no break here. replace all occurrences
+            if (isWriteCollection) {
+              // must update AST info now for all nodes that contained this
+              // parameter
+              for (auto& it : _writeCollections) {
+                auto& c = it.first;
+
+                if (c->type == NODE_TYPE_PARAMETER_DATASOURCE &&
+                    paramRef == arangodb::velocypack::StringRef(c->getStringValue(),
+                                                                c->getStringLength())) {
+                  c = newNode;
+                  // no break here. replace all occurrences
+                }
               }
             }
           }
+          node = newNode;
         }
       } else if (node->type == NODE_TYPE_BOUND_ATTRIBUTE_ACCESS) {
         // look at second sub-node. this is the (replaced) bind parameter

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -586,6 +586,8 @@ class Ast {
   std::vector<AstNode*> _queries;
 
   /// @brief which collection is going to be modified in the query
+  /// maps from NODE_TYPE_COLLECTION/NODE_TYPE_PARAMETER_DATASOURCE to 
+  /// whether the collection is used in exclusive mode
   std::vector<std::pair<AstNode const*, bool>> _writeCollections;
 
   /// @brief whether or not function calls may access collection data

--- a/tests/js/server/aql/aql-modify.js
+++ b/tests/js/server/aql/aql-modify.js
@@ -1350,6 +1350,8 @@ function aqlUpsertReadCompleteInputSuite() {
 
       let result = db._query(query1).toArray();
       assertEqual(expected, result);
+
+      db[collectionName].truncate();
       
       const query2 = 'FOR d IN [ {_key: "key_1", value: 1}, {_key: "key_2", value: 2}, {_key: "key_3", value: 3}, {_key: "key_1", value: 1} ] UPSERT { _key: d._key } INSERT d UPDATE d IN @@collection RETURN NEW._id';
       result = db._query(query2, { "@collection": collectionName }).toArray();

--- a/tests/js/server/aql/aql-modify.js
+++ b/tests/js/server/aql/aql-modify.js
@@ -1325,10 +1325,39 @@ function aqlUpsertOptionsSuite() {
   };
 };
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief executes the test suites
-////////////////////////////////////////////////////////////////////////////////
+function aqlUpsertReadCompleteInputSuite() {
 
+  return {
+    setUp: function () {
+      db._drop(collectionName);
+      db._create(collectionName, { numberOfShards: 3 });
+    },
+
+    tearDown: function () {
+      db._drop(collectionName);
+    },
+
+    testReadCompleteInput: function () {
+      const expected = [
+        collectionName + "/key_1",
+        collectionName + "/key_2",
+        collectionName + "/key_3",
+        collectionName + "/key_1",
+      ];
+      
+      const query1 = 'FOR d IN [ {_key: "key_1", value: 1}, {_key: "key_2", value: 2}, {_key: "key_3", value: 3}, {_key: "key_1", value: 1} ] UPSERT { _key: d._key } INSERT d UPDATE d IN ' + collectionName + ' RETURN NEW._id';
+
+      let result = db._query(query1).toArray();
+      assertEqual(expected, result);
+      
+      const query2 = 'FOR d IN [ {_key: "key_1", value: 1}, {_key: "key_2", value: 2}, {_key: "key_3", value: 3}, {_key: "key_1", value: 1} ] UPSERT { _key: d._key } INSERT d UPDATE d IN @@collection RETURN NEW._id';
+      result = db._query(query2, { "@collection": collectionName }).toArray();
+      assertEqual(expected, result);
+    },
+
+  };
+};
+    
 jsunity.run(aqlUpdateOptionsSuite);
 jsunity.run(aqlUpdateWithOptionsSuite);
 jsunity.run(aqlUpdateWithRevOptionsSuite);
@@ -1337,4 +1366,5 @@ jsunity.run(aqlReplaceWithOptionsSuite);
 jsunity.run(aqlReplaceWithRevOptionsSuite);
 jsunity.run(aqlRemoveOptionsSuite);
 jsunity.run(aqlUpsertOptionsSuite);
+jsunity.run(aqlUpsertReadCompleteInputSuite);
 return jsunity.done();

--- a/tests/js/server/aql/aql-modify.js
+++ b/tests/js/server/aql/aql-modify.js
@@ -33,6 +33,7 @@ const db = require("@arangodb").db;
 const jsunity = require("jsunity");
 const helper = require("@arangodb/aql-helper");
 const errors = internal.errors;
+const isCluster = require('@arangodb/cluster').isCluster();
 
 const collectionName = "UnitTestAqlModify";
 let col;
@@ -1366,5 +1367,8 @@ jsunity.run(aqlReplaceWithOptionsSuite);
 jsunity.run(aqlReplaceWithRevOptionsSuite);
 jsunity.run(aqlRemoveOptionsSuite);
 jsunity.run(aqlUpsertOptionsSuite);
-jsunity.run(aqlUpsertReadCompleteInputSuite);
+if (!isCluster) {
+  // TODO: remove the !isCluster() once it has been made working in cluster
+  jsunity.run(aqlUpsertReadCompleteInputSuite);
+}
 return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Try to fix UPSERT behavior when fed with the same key, and a collection bind parameter.

Make UPSERT statement with collection bind parameter behave identical to its non-bind parameter counterpart.
For example, the query 
```
FOR d IN ["key_1", "key_2", "key_3", "key_1"] 
  UPSERT d INSERT d UPDATE d IN @@collection
```
would fail with "unique constraint violation" when used with a collection bind parameter, but the equivalent query
```
FOR d IN ["key_1", "key_2", "key_3", "key_1"] 
  UPSERT d INSERT d UPDATE d IN collectionName
```
with a hard-coded collection name would succeed. This is now fixed so both queries have the same behavior (no failure) in single server.

The fix does not yet work in the cluster. That will be addressed separately.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

Potentially related issues:
https://github.com/arangodb/arangodb/issues?q=is%3Aissue+is%3Aopen+AQL%3A+unique+constraint+violated+-+in+index+primary+of+type+primary+over+%27_key%27
https://arangodb.atlassian.net/browse/DEVSUP-636

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.7 (https://github.com/arangodb/arangodb/pull/12486) , 3.6 (https://github.com/arangodb/arangodb/pull/12487), 3.5 (https://github.com/arangodb/arangodb/pull/12488)

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11571/