### PR TITLE
Remove loadPlan call and verbose logging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 devel
 -----
+* Removed triggering loadPlan from analyzers revisions loading for queries.
+
+* Removed verbose logging in case of vocbase missing for collections/views
+  during plan loading
 
 * Fixed that dropping a vanished follower works again. An exception response
   to the replication request is now handled properly.


### PR DESCRIPTION
Removed call for loadPlan in getQueryAnalyzersRevision as this will introduce cycling dependency for cluster and database features.
If plan is not loaded  - no revisions is assumed. 

Removed verbose logging of missing vocbase case (for views/collections)  from ClusterInfo. That was proven useless for debugging and was just bloating logs

Backports required for: 3.7

This change is already covered by existing tests, such as arangosearch feature tests and cluster resilience tests

https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/11532/

