### PR TITLE
Bug fix/do not reclaim shard ownership.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 v3.7.2 (XXXX-XX-XX)
 -------------------
 
+* Fixed: During a move-shard job which moves the leader there is a
+  situation in which the old owner of a shard can reclaim ownership
+  (after having resigned already), with a small race where it allows to
+  write documents only locally, but then continue the move-shard to a
+  server without those documents. An additional bug in the MoveShard
+  Supervision job would then leave the shard in a bad configuration
+  with a resigned leader permanently in charge.
+
 * Fixed a problem with potentially lost updates because a failover could happen
   at a wrong time or a restarted leader could come back at an unlucky time.
 

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -565,7 +565,7 @@ JOB_STATUS MoveShard::pendingLeader() {
 
     // We need to switch leaders:
     {
-      // First make sure that the server we want to go to is still a failoverCandidate
+      // First make sure that the server we want to go to is still in Current
       // for all shards. This is important, since some transaction which the leader
       // has still executed before its resignation might have dropped a follower
       // for some shard, and this could have been our new leader. In this case we

--- a/arangod/Agency/PathComponent.h
+++ b/arangod/Agency/PathComponent.h
@@ -52,10 +52,14 @@ class Path {
     return stream;
   }
 
-  std::vector<std::string> vec() const {
+  std::vector<std::string> vec(size_t skip = 0) const {
     std::vector<std::string> res;
-    forEach([&res](const char* component) {
-      res.emplace_back(std::string{component});
+    forEach([&res, &skip](const char* component) {
+      if (skip == 0) {
+        res.emplace_back(std::string{component});
+      } else {
+        skip--;
+      }
     });
     return res;
   }

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -38,6 +38,8 @@
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/Methods/Databases.h"
 
+#include "Cluster/ResignShardLeadership.h"
+
 #include <velocypack/Collection.h>
 #include <velocypack/Compare.h>
 #include <velocypack/Iterator.h>
@@ -184,6 +186,17 @@ static VPackBuilder compareIndexes(std::string const& dbname, std::string const&
   return builder;
 }
 
+static std::string CreateLeaderString(std::string const& leaderId, bool shouldBeLeading) {
+  if (shouldBeLeading) {
+    return std::string();
+  }
+  TRI_ASSERT(!leaderId.empty());
+  if (leaderId.front() == UNDERSCORE[0]) {
+    return leaderId.substr(1);
+  }
+  return leaderId;
+}
+
 void handlePlanShard(uint64_t planIndex, VPackSlice const& cprops, VPackSlice const& ldb,
                      std::string const& dbname, std::string const& colname,
                      std::string const& shname, std::string const& serverId,
@@ -192,7 +205,6 @@ void handlePlanShard(uint64_t planIndex, VPackSlice const& cprops, VPackSlice co
                      MaintenanceFeature::errors_t& errors, MaintenanceFeature& feature,
                      std::vector<std::shared_ptr<ActionDescription>>& actions) {
   bool shouldBeLeading = serverId == leaderId;
-  bool shouldResign = UNDERSCORE + serverId == leaderId;
 
   commonShrds.emplace(shname);
 
@@ -200,7 +212,6 @@ void handlePlanShard(uint64_t planIndex, VPackSlice const& cprops, VPackSlice co
   if (lcol.isObject()) {  // Have local collection with that name
 
     std::string_view const localLeader = lcol.get(THE_LEADER).stringView();
-    bool const leaderTouched = localLeader != LEADER_NOT_YET_KNOWN;
     bool leading = localLeader.empty();
     auto const properties = compareRelevantProps(cprops, lcol);
 
@@ -258,37 +269,25 @@ void handlePlanShard(uint64_t planIndex, VPackSlice const& cprops, VPackSlice co
             << "for central " << dbname << "/" << colname << "- skipping";
       }
     }
-
-    // Handle leadership change, this is mostly about taking over leadership,
-    // but it also handles the case that in a failover scenario we used to
-    // be the leader and now somebody else is the leader. However, it does
-    // not handle the case of a controlled leadership resignation, see below
-    // in handleLocalShard for this.
-    if (shouldResign && !leading) {
-      // This case is a special one which is triggered if a server
-      // restarts, has `NOT_YET_TOUCHED` in its local shard as theLeader
-      // and finds a resignation sign. In that case, it should first officially
-      // take over leadership. In the following round it will then resign.
-      // This enables cleanOutServer jobs to continue to work in case of
-      // a leader restart.
-      shouldBeLeading = true;
-      shouldResign = false;
-    }
-    if ((leading != shouldBeLeading && !shouldResign) || !leaderTouched) {
+    /*
+    LOG_DEVEL_IF(dbname=="foo") << "Col: " << colname << " shard: " << shname;
+    LOG_DEVEL_IF(dbname=="foo") << std::boolalpha << "leading: " << leading << " should: " << shouldBeLeading << " resign: " << shouldResign;
+    LOG_DEVEL_IF(dbname=="foo") << "New leader: " << leaderId << " currentLeader: " << localLeader;
+    */
+    if (!leading && shouldBeLeading) {
       LOG_TOPIC("52412", DEBUG, Logger::MAINTENANCE)
           << "Triggering TakeoverShardLeadership job for shard " << dbname
           << "/" << colname << "/" << shname
           << ", local leader: " << lcol.get(THE_LEADER).copyString()
           << ", leader id: " << leaderId << ", my id: " << serverId
-          << ", should be leader: " << (shouldBeLeading ? std::string() : leaderId)
-          << ", leaderTouched = " << (leaderTouched ? "yes" : "no");
+          << ", should be leader: " << std::string();
       actions.emplace_back(std::make_shared<ActionDescription>(
           std::map<std::string, std::string>{
               {NAME, TAKEOVER_SHARD_LEADERSHIP},
               {DATABASE, dbname},
               {COLLECTION, colname},
               {SHARD, shname},
-              {THE_LEADER, shouldBeLeading ? std::string() : leaderId},
+              {THE_LEADER, std::string()},
               {LOCAL_LEADER, std::string(localLeader)},
               {OLD_CURRENT_COUNTER, "0"},   // legacy, no longer used
               {PLAN_RAFT_INDEX, std::to_string(planIndex)}},
@@ -318,7 +317,7 @@ void handlePlanShard(uint64_t planIndex, VPackSlice const& cprops, VPackSlice co
         }
       }
     }
-  } else {  // Create the sucker, if not a previous error stops us
+  } else {  // Create the collection, if not a previous error stops us
     if (errors.shards.find(dbname + "/" + colname + "/" + shname) ==
         errors.shards.end()) {
       auto props = createProps(cprops);  // Only once might need often!
@@ -328,7 +327,7 @@ void handlePlanShard(uint64_t planIndex, VPackSlice const& cprops, VPackSlice co
              {SHARD, shname},
              {DATABASE, dbname},
              {SERVER_ID, serverId},
-             {THE_LEADER, shouldBeLeading ? std::string() : leaderId}},
+             {THE_LEADER, CreateLeaderString(leaderId, shouldBeLeading)}},
             shouldBeLeading ? LEADER_PRIORITY : FOLLOWER_PRIORITY, std::move(props)));
     } else {
       LOG_TOPIC("c1d8e", DEBUG, Logger::MAINTENANCE)
@@ -343,58 +342,71 @@ void handleLocalShard(std::string const& dbname, std::string const& colname,
                       std::unordered_set<std::string>& commonShrds,
                       std::unordered_set<std::string>& indis, std::string const& serverId,
                       std::vector<std::shared_ptr<ActionDescription>>& actions) {
-  std::unordered_set<std::string>::const_iterator it;
+
+  std::unordered_set<std::string>::const_iterator it =
+      std::find(commonShrds.begin(), commonShrds.end(), colname);
+
+  auto localLeader = cprops.get(THE_LEADER).stringRef();
+  bool const isLeading = localLeader.empty();
+  if (it == commonShrds.end()) {
+    // This collection is not planned anymore, can drop it
+    actions.emplace_back(std::make_shared<ActionDescription>(
+        std::map<std::string, std::string>{{NAME, DROP_COLLECTION},
+                                           {DATABASE, dbname},
+                                           {COLLECTION, colname}},
+        isLeading ? LEADER_PRIORITY : FOLLOWER_PRIORITY));
+    return;
+  }
+  // We dropped out before
+  TRI_ASSERT(it != commonShrds.end());
+  // The shard exists in both Plan and Local
+  commonShrds.erase(it);  // it not a common shard?
 
   std::string plannedLeader;
   if (shardMap.get(colname).isArray()) {
     plannedLeader = shardMap.get(colname)[0].copyString();
   }
-  bool const localLeader = cprops.get(THE_LEADER).stringRef().empty();
-  if (localLeader && plannedLeader == UNDERSCORE + serverId) {
+
+  bool const activeResign = isLeading && plannedLeader != serverId;
+  bool const adjustResignState =
+      (plannedLeader == UNDERSCORE + serverId &&
+       localLeader != ResignShardLeadership::LeaderNotYetKnownString) ||
+      (plannedLeader != serverId && localLeader == LEADER_NOT_YET_KNOWN);
+  /*
+  * We need to resign in the following cases:
+  * 1) (activeResign) We think we are the leader locally, but the plan says we are not. (including, we are resigned)
+  * 2) (adjustResignState) We are not leading, and not in resigned state, but the plan says we should be resigend.
+  *    - This triggers on rebooted servers, that were in resign process
+  *    - This triggers if the shard is moved from the server, before it actually took ownership. 
+  */
+
+  if (activeResign || adjustResignState) {
     actions.emplace_back(std::make_shared<ActionDescription>(
-          std::map<std::string, std::string>{{NAME, RESIGN_SHARD_LEADERSHIP}, {DATABASE, dbname}, {SHARD, colname}},
-          RESIGN_PRIORITY));
-  } else {
-    bool drop = false;
-    // check if shard is in plan, if not drop it
-    if (commonShrds.empty()) {
-      drop = true;
-    } else {
-      it = std::find(commonShrds.begin(), commonShrds.end(), colname);
-      if (it == commonShrds.end()) {
-        drop = true;
-      }
-    }
+        std::map<std::string, std::string>{{NAME, RESIGN_SHARD_LEADERSHIP},
+                                           {DATABASE, dbname},
+                                           {SHARD, colname}},
+        RESIGN_PRIORITY));
+  }
 
-    if (drop) {
-      actions.emplace_back(std::make_shared<ActionDescription>(
-            std::map<std::string, std::string>{{NAME, DROP_COLLECTION}, {DATABASE, dbname}, {COLLECTION, colname}},
-            localLeader ? LEADER_PRIORITY : FOLLOWER_PRIORITY));
-    } else {
-      // The shard exists in both Plan and Local
-      commonShrds.erase(it);  // it not a common shard?
+  // We only drop indexes, when collection is not being dropped already
+  if (cprops.hasKey(INDEXES)) {
+    if (cprops.get(INDEXES).isArray()) {
+      for (auto const& index : VPackArrayIterator(cprops.get(INDEXES))) {
+        VPackStringRef type = index.get(StaticStrings::IndexType).stringRef();
+        if (type != PRIMARY && type != EDGE) {
+          std::string const id = index.get(ID).copyString();
 
-      // We only drop indexes, when collection is not being dropped already
-      if (cprops.hasKey(INDEXES)) {
-        if (cprops.get(INDEXES).isArray()) {
-          for (auto const& index : VPackArrayIterator(cprops.get(INDEXES))) {
-            VPackStringRef type = index.get(StaticStrings::IndexType).stringRef();
-            if (type != PRIMARY && type != EDGE) {
-              std::string const id = index.get(ID).copyString();
-
-              // check if index is in plan
-              if (indis.find(colname + "/" + id) != indis.end() ||
-                  indis.find(id) != indis.end()) {
-                indis.erase(id);
-              } else {
-                actions.emplace_back(std::make_shared<ActionDescription>(
-                      std::map<std::string, std::string>{{NAME, DROP_INDEX},
-                       {DATABASE, dbname},
-                       {COLLECTION, colname},
-                       {"index", id}},
-                      INDEX_PRIORITY));
-              }
-            }
+          // check if index is in plan
+          if (indis.find(colname + "/" + id) != indis.end() ||
+              indis.find(id) != indis.end()) {
+            indis.erase(id);
+          } else {
+            actions.emplace_back(std::make_shared<ActionDescription>(
+                std::map<std::string, std::string>{{NAME, DROP_INDEX},
+                                                   {DATABASE, dbname},
+                                                   {COLLECTION, colname},
+                                                   {"index", id}},
+                INDEX_PRIORITY));
           }
         }
       }

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -269,18 +269,13 @@ void handlePlanShard(uint64_t planIndex, VPackSlice const& cprops, VPackSlice co
             << "for central " << dbname << "/" << colname << "- skipping";
       }
     }
-    /*
-    LOG_DEVEL_IF(dbname=="foo") << "Col: " << colname << " shard: " << shname;
-    LOG_DEVEL_IF(dbname=="foo") << std::boolalpha << "leading: " << leading << " should: " << shouldBeLeading << " resign: " << shouldResign;
-    LOG_DEVEL_IF(dbname=="foo") << "New leader: " << leaderId << " currentLeader: " << localLeader;
-    */
     if (!leading && shouldBeLeading) {
       LOG_TOPIC("52412", DEBUG, Logger::MAINTENANCE)
           << "Triggering TakeoverShardLeadership job for shard " << dbname
           << "/" << colname << "/" << shname
           << ", local leader: " << lcol.get(THE_LEADER).copyString()
           << ", leader id: " << leaderId << ", my id: " << serverId
-          << ", should be leader: " << std::string();
+          << ", should be leader: ";
       actions.emplace_back(std::make_shared<ActionDescription>(
           std::map<std::string, std::string>{
               {NAME, TAKEOVER_SHARD_LEADERSHIP},

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -498,6 +498,7 @@ RestAdminClusterHandler::MoveShardContext::fromVelocyPack(VPackSlice slice) {
     auto shard = slice.get("shard");
     auto fromServer = slice.get("fromServer");
     auto toServer = slice.get("toServer");
+    auto remainsFollower = slice.get("remainsFollower");
 
     bool valid = collection.isString() && shard.isString() &&
                  fromServer.isString() && toServer.isString();
@@ -508,7 +509,8 @@ RestAdminClusterHandler::MoveShardContext::fromVelocyPack(VPackSlice slice) {
                                                 collection.copyString(),
                                                 shard.copyString(),
                                                 fromServer.copyString(),
-                                                toServer.copyString(), std::string{});
+                                                toServer.copyString(), std::string{},
+                                                remainsFollower.isNone() || remainsFollower.isTrue());
     }
   }
 
@@ -632,7 +634,7 @@ RestAdminClusterHandler::FutureVoid RestAdminClusterHandler::createMoveShard(
                    builder.add("fromServer", VPackValue(ctx->fromServer));
                    builder.add("toServer", VPackValue(ctx->toServer));
                    builder.add("isLeader", VPackValue(isLeader));
-                   builder.add("remainsFollower", VPackValue(isLeader));
+                   builder.add("remainsFollower", isLeader ? VPackValue(ctx->remainsFollower) : VPackValue(false));
                    builder.add("creator", VPackValue(ServerState::instance()->getId()));
                    builder.add("timeCreated", VPackValue(timepointToString(
                                                   std::chrono::system_clock::now())));

--- a/arangod/RestHandler/RestAdminClusterHandler.h
+++ b/arangod/RestHandler/RestAdminClusterHandler.h
@@ -97,15 +97,18 @@ class RestAdminClusterHandler : public RestVocbaseBaseHandler {
     std::string fromServer;
     std::string toServer;
     std::string collectionID;
+    bool remainsFollower;
 
     MoveShardContext(std::string database, std::string collection, std::string shard,
-                     std::string from, std::string to, std::string collectionID)
+                     std::string from, std::string to, std::string collectionID,
+                     bool remainsFollower)
         : database(std::move(database)),
           collection(std::move(collection)),
           shard(std::move(shard)),
           fromServer(std::move(from)),
           toServer(std::move(to)),
-          collectionID(std::move(collectionID)) {}
+          collectionID(std::move(collectionID)),
+          remainsFollower(true) {}
 
     static std::unique_ptr<MoveShardContext> fromVelocyPack(arangodb::velocypack::Slice slice);
   };

--- a/tests/Agency/MoveShardTest.cpp
+++ b/tests/Agency/MoveShardTest.cpp
@@ -2180,14 +2180,8 @@ TEST_F(MoveShardTest, aborting_the_job_while_the_new_leader_is_already_in_place_
     EXPECT_EQ(q->slice()[0].length(), 2); // Precondition: to Server not leader yet
     EXPECT_EQ(writes.get("/arango/Supervision/Shards/" + SHARD).get("op").copyString(), "delete");
     EXPECT_TRUE(writes.get("/arango/Supervision/DBServers/" + FREE_SERVER).get("op").isEqualString("read-unlock"));
-    EXPECT_EQ(std::string(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD).typeName()), "array");
     // well apparently this job is not responsible to cleanup its mess
-    EXPECT_TRUE(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD).length() >= 3);
-    EXPECT_EQ(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD)[0].copyString(), SHARD_LEADER);
-    EXPECT_EQ(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD)[1].copyString(), SHARD_FOLLOWER1);
-    EXPECT_EQ(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD)[2].copyString(), FREE_SERVER);
     EXPECT_EQ(std::string(writes.get("/arango/Target/Failed/1").typeName()), "object");
-
     return fakeWriteResult;
   });
   AgentInterface& agent = mockAgent.get();

--- a/tests/Maintenance/MaintenanceTest.cpp
+++ b/tests/Maintenance/MaintenanceTest.cpp
@@ -28,8 +28,10 @@
 
 #include "gtest/gtest.h"
 
+#include "Agency/AgencyPaths.h"
 #include "ApplicationFeatures/GreetingsFeaturePhase.h"
 #include "Cluster/Maintenance.h"
+#include "Cluster/ResignShardLeadership.h"
 #include "Mocks/Servers.h"
 #include "RocksDBEngine/RocksDBEngine.h"
 #include "StorageEngine/EngineSelectorFeature.h"
@@ -50,7 +52,6 @@ using namespace arangodb::consensus;
 using namespace arangodb::maintenance;
 
 #ifndef _WIN32
-
 char const* planStr =
 #include "Plan.json"
     ;
@@ -69,10 +70,8 @@ char const* dbs1Str =
 char const* dbs2Str =
 #include "DBServer0003.json"
     ;
-
-int loadResources(void) { return 0; }
-
 #else  // _WIN32
+
 #include <Windows.h>
 #include "jsonresource.h"
 LPSTR planStr = nullptr;
@@ -82,258 +81,281 @@ LPSTR dbs0Str = nullptr;
 LPSTR dbs1Str = nullptr;
 LPSTR dbs2Str = nullptr;
 
-LPSTR getResource(int which) {
-  HRSRC myResource = ::FindResource(NULL, MAKEINTRESOURCE(which), RT_RCDATA);
-  HGLOBAL myResourceData = ::LoadResource(NULL, myResource);
-  return (LPSTR)::LockResource(myResourceData);
-}
-int loadResources(void) {
-  if ((planStr == nullptr) && (currentStr == nullptr) && (supervisionStr == nullptr) &&
-      (dbs0Str == nullptr) && (dbs1Str == nullptr) && (dbs2Str == nullptr)) {
-    planStr = getResource(IDS_PLAN);
-    currentStr = getResource(IDS_CURRENT);
-    dbs0Str = getResource(IDS_DBSERVER0001);
-    dbs1Str = getResource(IDS_DBSERVER0002);
-    dbs2Str = getResource(IDS_DBSERVER0003);
-    supervisionStr = getResource(IDS_SUPERVISION);
-  }
-  return 0;
-}
-
 #endif  // _WIN32
 
-std::map<std::string, std::string> matchShortLongIds(Node const& supervision) {
-  std::map<std::string, std::string> ret;
-  for (auto const& dbs : supervision("Health").children()) {
-    if (dbs.first.front() == 'P') {
-      ret.emplace((*dbs.second)("ShortName").getString(), dbs.first);
-    }
-  }
-  return ret;
-}
-
-Node createNodeFromBuilder(Builder const& builder) {
-  Builder opBuilder;
-  {
-    VPackObjectBuilder a(&opBuilder);
-    opBuilder.add("new", builder.slice());
-  }
-
-  Node node("");
-  node.handle<SET>(opBuilder.slice());
-  return node;
-}
-
-Builder createBuilder(char const* c) {
-  VPackOptions options;
-  options.checkAttributeUniqueness = true;
-  VPackParser parser(&options);
-  parser.parse(c);
-
-  Builder builder;
-  builder.add(parser.steal()->slice());
-  return builder;
-}
-
-Node createNode(char const* c) {
-  return createNodeFromBuilder(createBuilder(c));
-}
-
 // Random stuff
-std::random_device rd;
+std::random_device rd{};
 std::mt19937 g(rd());
-
-// Relevant agency
-Node plan("");
-Node originalPlan("");
-Node supervision("");
-Node current("");
 
 std::vector<std::string> const shortNames{"DBServer0001", "DBServer0002",
                                           "DBServer0003"};
-
-// map <shortId, UUID>
-std::map<std::string, std::string> dbsIds;
 
 std::string const PLAN_COL_PATH = "/Collections/";
 std::string const PLAN_DB_PATH = "/Databases/";
 
 size_t localId = 1016002;
 
-VPackBuilder createDatabase(std::string const& dbname) {
-  Builder builder;
-  {
-    VPackObjectBuilder o(&builder);
-    builder.add("id", VPackValue(std::to_string(localId++)));
-    builder.add("coordinator",
-                VPackValue("CRDN-42df19c3-73d5-48f4-b02e-09b29008eff8"));
-    builder.add(VPackValue("options"));
-    { VPackObjectBuilder oo(&builder); }
-    builder.add("name", VPackValue(dbname));
-  }
-  return builder;
-}
-
-void createPlanDatabase(std::string const& dbname, Node& plan) {
-  plan(PLAN_DB_PATH + dbname) = createDatabase(dbname).slice();
-}
-
-VPackBuilder createIndex(std::string const& type, std::vector<std::string> const& fields,
-                         bool unique, bool sparse, bool deduplicate) {
-  VPackBuilder index;
-  {
-    VPackObjectBuilder o(&index);
-    {
-      index.add("deduplicate", VPackValue(deduplicate));
-      index.add(VPackValue("fields"));
-      {
-        VPackArrayBuilder a(&index);
-        for (auto const& field : fields) {
-          index.add(VPackValue(field));
-        }
-      }
-      index.add("id", VPackValue(std::to_string(localId++)));
-      index.add("sparse", VPackValue(sparse));
-      index.add("type", VPackValue(type));
-      index.add("unique", VPackValue(unique));
-    }
-  }
-
-  return index;
-}
-
-void createPlanIndex(std::string const& dbname, std::string const& colname,
-                     std::string const& type, std::vector<std::string> const& fields,
-                     bool unique, bool sparse, bool deduplicate, Node& plan) {
-  VPackBuilder val;
-  {
-    VPackObjectBuilder o(&val);
-    val.add("new", createIndex(type, fields, unique, sparse, deduplicate).slice());
-  }
-  plan(PLAN_COL_PATH + dbname + "/" + colname + "/indexes").handle<PUSH>(val.slice());
-}
-
-void createCollection(std::string const& colname, VPackBuilder& col) {
-  VPackBuilder keyOptions;
-  {
-    VPackObjectBuilder o(&keyOptions);
-    keyOptions.add("lastValue", VPackValue(0));
-    keyOptions.add("type", VPackValue("traditional"));
-    keyOptions.add("allowUserKeys", VPackValue(true));
-  }
-
-  VPackBuilder shardKeys;
-  {
-    VPackArrayBuilder a(&shardKeys);
-    shardKeys.add(VPackValue("_key"));
-  }
-
-  VPackBuilder indexes;
-  {
-    VPackArrayBuilder a(&indexes);
-    indexes.add(createIndex("primary", {"_key"}, true, false, false).slice());
-  }
-
-  col.add("id", VPackValue(std::to_string(localId++)));
-  col.add("status", VPackValue(3));
-  col.add("keyOptions", keyOptions.slice());
-  col.add("cacheEnabled", VPackValue(false));
-  col.add("waitForSync", VPackValue(false));
-  col.add("type", VPackValue(2));
-  col.add("isSystem", VPackValue(true));
-  col.add("name", VPackValue(colname));
-  col.add("shardingStrategy", VPackValue("hash"));
-  col.add("statusString", VPackValue("loaded"));
-  col.add("shardKeys", shardKeys.slice());
-}
-
 std::string S("s");
 std::string C("c");
 
-void createPlanShards(size_t numberOfShards, size_t replicationFactor, VPackBuilder& col) {
-  auto servers = shortNames;
-  std::shuffle(servers.begin(), servers.end(), g);
 
-  col.add("numberOfShards", VPackValue(1));
-  col.add("replicationFactor", VPackValue(2));
-  col.add(VPackValue("shards"));
-  {
-    VPackObjectBuilder s(&col);
-    for (size_t i = 0; i < numberOfShards; ++i) {
-      col.add(VPackValue(S + std::to_string(localId++)));
-      {
-        VPackArrayBuilder a(&col);
-        size_t j = 0;
-        for (auto const& server : servers) {
-          if (j++ < replicationFactor) {
-            col.add(VPackValue(dbsIds[server]));
-          }
-        }
-      }
-    }
-  }
-}
-
-void createPlanCollection(std::string const& dbname, std::string const& colname,
-                          size_t numberOfShards, size_t replicationFactor, Node& plan) {
-  VPackBuilder tmp;
-  {
-    VPackObjectBuilder o(&tmp);
-    createCollection(colname, tmp);
-    tmp.add("isSmart", VPackValue(false));
-    tmp.add("deleted", VPackValue(false));
-    createPlanShards(numberOfShards, replicationFactor, tmp);
-  }
-
-  Slice col = tmp.slice();
-  auto id = col.get("id").copyString();
-  plan(PLAN_COL_PATH + dbname + "/" + col.get("id").copyString()) = col;
-}
-
-void createLocalCollection(std::string const& dbname, std::string const& colname, Node& node) {
-  size_t planId = std::stoull(colname);
-  VPackBuilder tmp;
-  {
-    VPackObjectBuilder o(&tmp);
-    createCollection(colname, tmp);
-    tmp.add("planId", VPackValue(colname));
-    tmp.add("theLeader", VPackValue(""));
-    tmp.add("globallyUniqueId",
-            VPackValue(C + colname + "/" + S + std::to_string(planId + 1)));
-    tmp.add("objectId", VPackValue("9031415"));
-  }
-  node(dbname + "/" + S + std::to_string(planId + 1)) = tmp.slice();
-}
-
-std::map<std::string, std::string> collectionMap(Node const& plan) {
-  std::map<std::string, std::string> ret;
-  auto const pb = plan("Collections").toBuilder();
-  auto const ps = pb.slice();
-  for (auto const& db : VPackObjectIterator(ps)) {
-    for (auto const& col : VPackObjectIterator(db.value)) {
-      ret.emplace(db.key.copyString() + "/" + col.value.get("name").copyString(),
-                  col.key.copyString());
-    }
-  }
-  return ret;
-}
 
 namespace arangodb {
 class LogicalCollection;
 }
+using namespace arangodb::maintenance;
 
-class MaintenanceTestActionDescription : public ::testing::Test {
-  // private:
-  //   tests::mocks::MockDBServer _server;
-
+class SharedMaintenanceTest : public ::testing::Test {
  protected:
-  MaintenanceTestActionDescription() /*: _server{}*/ {
+  SharedMaintenanceTest() {
     loadResources();
     plan = createNode(planStr);
     originalPlan = plan;
     supervision = createNode(supervisionStr);
     current = createNode(currentStr);
     dbsIds = matchShortLongIds(supervision);
+  }
+
+ protected:
+  // Relevant agency
+  Node plan{""};
+  Node originalPlan{""};
+  Node supervision{""};
+  Node current{""};
+
+
+
+  // map <shortId, UUID>
+  std::map<std::string, std::string> dbsIds;
+
+  /**
+   * @brief Helper methods
+   *
+   */
+ protected:
+#ifndef _WIN32
+  int loadResources(void) { return 0; }
+
+#else  // _WIN32
+  LPSTR getResource(int which) {
+    HRSRC myResource = ::FindResource(NULL, MAKEINTRESOURCE(which), RT_RCDATA);
+    HGLOBAL myResourceData = ::LoadResource(NULL, myResource);
+    return (LPSTR)::LockResource(myResourceData);
+  }
+  int loadResources(void) {
+    if ((planStr == nullptr) && (currentStr == nullptr) && (supervisionStr == nullptr) &&
+        (dbs0Str == nullptr) && (dbs1Str == nullptr) && (dbs2Str == nullptr)) {
+      planStr = getResource(IDS_PLAN);
+      currentStr = getResource(IDS_CURRENT);
+      dbs0Str = getResource(IDS_DBSERVER0001);
+      dbs1Str = getResource(IDS_DBSERVER0002);
+      dbs2Str = getResource(IDS_DBSERVER0003);
+      supervisionStr = getResource(IDS_SUPERVISION);
+    }
+    return 0;
+  }
+
+#endif  // _WIN32
+
+  std::map<std::string, std::string> matchShortLongIds(Node const& supervision) {
+    std::map<std::string, std::string> ret;
+    for (auto const& dbs : supervision("Health").children()) {
+      if (dbs.first.front() == 'P') {
+        ret.emplace((*dbs.second)("ShortName").getString(), dbs.first);
+      }
+    }
+    return ret;
+  }
+
+  Node createNodeFromBuilder(Builder const& builder) {
+    Builder opBuilder;
+    {
+      VPackObjectBuilder a(&opBuilder);
+      opBuilder.add("new", builder.slice());
+    }
+
+    Node node("");
+    node.handle<SET>(opBuilder.slice());
+    return node;
+  }
+
+  Builder createBuilder(char const* c) {
+    VPackOptions options;
+    options.checkAttributeUniqueness = true;
+    VPackParser parser(&options);
+    parser.parse(c);
+
+    Builder builder;
+    builder.add(parser.steal()->slice());
+    return builder;
+  }
+
+  Node createNode(char const* c) {
+    return createNodeFromBuilder(createBuilder(c));
+  }
+
+  VPackBuilder createDatabase(std::string const& dbname) {
+    Builder builder;
+    {
+      VPackObjectBuilder o(&builder);
+      builder.add("id", VPackValue(std::to_string(localId++)));
+      builder.add("coordinator",
+                  VPackValue("CRDN-42df19c3-73d5-48f4-b02e-09b29008eff8"));
+      builder.add(VPackValue("options"));
+      { VPackObjectBuilder oo(&builder); }
+      builder.add("name", VPackValue(dbname));
+    }
+    return builder;
+  }
+
+  void createPlanDatabase(std::string const& dbname, Node& plan) {
+    plan(PLAN_DB_PATH + dbname) = createDatabase(dbname).slice();
+  }
+
+  VPackBuilder createIndex(std::string const& type, std::vector<std::string> const& fields,
+                           bool unique, bool sparse, bool deduplicate) {
+    VPackBuilder index;
+    {
+      VPackObjectBuilder o(&index);
+      {
+        index.add("deduplicate", VPackValue(deduplicate));
+        index.add(VPackValue("fields"));
+        {
+          VPackArrayBuilder a(&index);
+          for (auto const& field : fields) {
+            index.add(VPackValue(field));
+          }
+        }
+        index.add("id", VPackValue(std::to_string(localId++)));
+        index.add("sparse", VPackValue(sparse));
+        index.add("type", VPackValue(type));
+        index.add("unique", VPackValue(unique));
+      }
+    }
+
+    return index;
+  }
+
+  void createPlanIndex(std::string const& dbname, std::string const& colname,
+                       std::string const& type, std::vector<std::string> const& fields,
+                       bool unique, bool sparse, bool deduplicate, Node& plan) {
+    VPackBuilder val;
+    {
+      VPackObjectBuilder o(&val);
+      val.add("new", createIndex(type, fields, unique, sparse, deduplicate).slice());
+    }
+    plan(PLAN_COL_PATH + dbname + "/" + colname + "/indexes").handle<PUSH>(val.slice());
+  }
+
+  void createCollection(std::string const& colname, VPackBuilder& col) {
+    VPackBuilder keyOptions;
+    {
+      VPackObjectBuilder o(&keyOptions);
+      keyOptions.add("lastValue", VPackValue(0));
+      keyOptions.add("type", VPackValue("traditional"));
+      keyOptions.add("allowUserKeys", VPackValue(true));
+    }
+
+    VPackBuilder shardKeys;
+    {
+      VPackArrayBuilder a(&shardKeys);
+      shardKeys.add(VPackValue("_key"));
+    }
+
+    VPackBuilder indexes;
+    {
+      VPackArrayBuilder a(&indexes);
+      indexes.add(createIndex("primary", {"_key"}, true, false, false).slice());
+    }
+
+    col.add("id", VPackValue(std::to_string(localId++)));
+    col.add("status", VPackValue(3));
+    col.add("keyOptions", keyOptions.slice());
+    col.add("cacheEnabled", VPackValue(false));
+    col.add("waitForSync", VPackValue(false));
+    col.add("type", VPackValue(2));
+    col.add("isSystem", VPackValue(true));
+    col.add("name", VPackValue(colname));
+    col.add("shardingStrategy", VPackValue("hash"));
+    col.add("statusString", VPackValue("loaded"));
+    col.add("shardKeys", shardKeys.slice());
+  }
+
+
+  void createPlanShards(size_t numberOfShards, size_t replicationFactor, VPackBuilder& col) {
+    auto servers = shortNames;
+    std::shuffle(servers.begin(), servers.end(), g);
+
+    col.add("numberOfShards", VPackValue(1));
+    col.add("replicationFactor", VPackValue(2));
+    col.add(VPackValue("shards"));
+    {
+      VPackObjectBuilder s(&col);
+      for (size_t i = 0; i < numberOfShards; ++i) {
+        col.add(VPackValue(S + std::to_string(localId++)));
+        {
+          VPackArrayBuilder a(&col);
+          size_t j = 0;
+          for (auto const& server : servers) {
+            if (j++ < replicationFactor) {
+              col.add(VPackValue(dbsIds[server]));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  void createPlanCollection(std::string const& dbname, std::string const& colname,
+                            size_t numberOfShards, size_t replicationFactor, Node& plan) {
+    VPackBuilder tmp;
+    {
+      VPackObjectBuilder o(&tmp);
+      createCollection(colname, tmp);
+      tmp.add("isSmart", VPackValue(false));
+      tmp.add("deleted", VPackValue(false));
+      createPlanShards(numberOfShards, replicationFactor, tmp);
+    }
+
+    Slice col = tmp.slice();
+    auto id = col.get("id").copyString();
+    plan(PLAN_COL_PATH + dbname + "/" + col.get("id").copyString()) = col;
+  }
+
+  void createLocalCollection(std::string const& dbname,
+                             std::string const& colname, Node& node) {
+    size_t planId = std::stoull(colname);
+    VPackBuilder tmp;
+    {
+      VPackObjectBuilder o(&tmp);
+      createCollection(colname, tmp);
+      tmp.add("planId", VPackValue(colname));
+      tmp.add("theLeader", VPackValue(""));
+      tmp.add("globallyUniqueId",
+              VPackValue(C + colname + "/" + S + std::to_string(planId + 1)));
+      tmp.add("objectId", VPackValue("9031415"));
+    }
+    node(dbname + "/" + S + std::to_string(planId + 1)) = tmp.slice();
+  }
+
+  std::map<std::string, std::string> collectionMap(Node const& plan) {
+    std::map<std::string, std::string> ret;
+    auto const pb = plan("Collections").toBuilder();
+    auto const ps = pb.slice();
+    for (auto const& db : VPackObjectIterator(ps)) {
+      for (auto const& col : VPackObjectIterator(db.value)) {
+        ret.emplace(db.key.copyString() + "/" + col.value.get("name").copyString(),
+                    col.key.copyString());
+      }
+    }
+    return ret;
+  }
+};
+
+class MaintenanceTestActionDescription : public SharedMaintenanceTest {
+
+ protected:
+  MaintenanceTestActionDescription() : SharedMaintenanceTest() {
   }
 };
 
@@ -470,7 +492,7 @@ TEST_F(MaintenanceTestActionDescription, retrieve_array_value_from_actiondescrip
   ASSERT_EQ(desc.properties()->slice().get("array")[2].copyString(), hello);
 }
 
-class MaintenanceTestActionPhaseOne : public ::testing::Test {
+class MaintenanceTestActionPhaseOne : public SharedMaintenanceTest {
  protected:
   int _dummy;
   std::shared_ptr<arangodb::options::ProgramOptions> po;
@@ -483,8 +505,12 @@ class MaintenanceTestActionPhaseOne : public ::testing::Test {
   arangodb::RocksDBEngine engine;  // arbitrary implementation that has index types registered
   arangodb::StorageEngine* origStorageEngine;
 
+
+
+
   MaintenanceTestActionPhaseOne()
-      : _dummy(loadResources()),
+      : SharedMaintenanceTest(),
+        _dummy(loadResources()),
         po(std::make_shared<arangodb::options::ProgramOptions>("test", std::string(),
                                                                std::string(),
                                                                "path")),
@@ -503,6 +529,221 @@ class MaintenanceTestActionPhaseOne : public ::testing::Test {
 
   ~MaintenanceTestActionPhaseOne() {
     arangodb::EngineSelectorFeature::ENGINE = origStorageEngine;
+  }
+
+  auto dbName() const -> std::string {
+    // this is a database known in the test files
+    return "foo";
+  }
+
+  auto planId() const -> std::string {
+    // This is a gobal collection known in the test files.
+    // It is required to have 6 shards, 2 per DBServer
+    return "2010088";
+  }
+
+  auto unusedServer() const -> std::string {
+    return "PRMR-deadbeef-1337-7331-abcd-123456789abc";
+  }
+
+  enum class PLAN_LEADERSHIP_TYPE { SELF, RESIGNED_SELF, OTHER, RESIGNED_OTHER };
+
+  enum class LOCAL_LEADERSHIP_TYPE { SELF, OTHER, RESIGNED, REBOOTED };
+
+  auto getShardsForServer(std::string const& dbName, std::string const& planId,
+                          std::string const& serverId, Node const& plan)
+      -> std::unordered_set<std::string> {
+    auto path = arangodb::cluster::paths::aliases::plan()
+                    ->collections()
+                    ->database(dbName)
+                    ->collection(planId)
+                    ->shards();
+
+    auto vec = path->vec(2);
+    TRI_ASSERT(plan.has(vec));
+    auto const& shardList = plan(vec);
+    std::unordered_set<std::string> res;
+    for (auto const& [shard, servers] : shardList.children()) {
+      auto oldValue = servers->slice();
+      TRI_ASSERT(oldValue.isArray());
+      TRI_ASSERT(oldValue.length() == 2);
+      if (oldValue.at(0).isEqualString(serverId)) {
+        res.emplace(shard);
+      }
+    }
+    return res;
+  }
+
+  auto setLeadershipPlan(std::string const& dbName, std::string const& planId,
+                         PLAN_LEADERSHIP_TYPE type, Node& plan) -> void {
+    auto path = arangodb::cluster::paths::aliases::plan()
+                    ->collections()
+                    ->database(dbName)
+                    ->collection(planId)
+                    ->shards();
+
+    auto vec = path->vec(2);
+    ASSERT_TRUE(plan.has(vec)) << "The underlying test plan is modified, it "
+                                  "does not contain Database '"
+                               << dbName << "' and Collection '" << planId << "' anymore.";
+    auto& shardList = plan(vec);
+    for (auto& [shard, servers] : shardList.children()) {
+      auto oldValue = servers->slice();
+      ASSERT_TRUE(oldValue.isArray());
+      ASSERT_EQ(oldValue.length(), 2)
+          << "We assume to have one leader and one follower";
+      switch (type) {
+        case PLAN_LEADERSHIP_TYPE::SELF: {
+          // Nothing to do here, we are leader
+          break;
+        }
+        case PLAN_LEADERSHIP_TYPE::RESIGNED_SELF: {
+          // We simulate a resign leader, this is indicated by appending an `_` in front of the server name.
+          VPackBuilder newValue;
+          {
+            VPackArrayBuilder guard(&newValue);
+            newValue.add(VPackValue("_" + oldValue.at(0).copyString()));
+            newValue.add(VPackValue(oldValue.at(1).copyString()));
+          }
+          *servers = newValue.slice();
+          break;
+        }
+        case PLAN_LEADERSHIP_TYPE::OTHER: {
+          // We simulate we get told another leader is there.
+          VPackBuilder newValue;
+          {
+            VPackArrayBuilder guard(&newValue);
+            newValue.add(VPackValue(unusedServer()));
+            newValue.add(VPackValue(oldValue.at(0).copyString()));
+            newValue.add(VPackValue(oldValue.at(1).copyString()));
+          }
+          *servers = newValue.slice();
+          break;
+        }
+        case PLAN_LEADERSHIP_TYPE::RESIGNED_OTHER: {
+          // We simulate we get told another leader is there, and resigned, this is indicated by appending an `_` in front of the server name.
+          VPackBuilder newValue;
+          {
+            VPackArrayBuilder guard(&newValue);
+            newValue.add(VPackValue("_" + unusedServer()));
+            newValue.add(VPackValue(oldValue.at(0).copyString()));
+            newValue.add(VPackValue(oldValue.at(1).copyString()));
+          }
+          *servers = newValue.slice();
+          break;
+        }
+      }
+    }
+  }
+
+  // Will resign leadership on the given plan.
+  // The plan will be modified in-place
+  // Asserts that dbName and planId exists in plan
+  auto resignLeadershipPlan(std::string const& dbName, std::string const& planId, Node& plan) -> void {
+    return setLeadershipPlan(dbName, planId, PLAN_LEADERSHIP_TYPE::RESIGNED_SELF, plan);
+  }
+
+  // Will take leadership in plan
+  // Asserts that dbName and planId exists in plan
+  // NOTE: The plan already contians leadersip of SELF so this is a noop besides assertions.
+  auto takeLeadershipPlan(std::string const& dbName, std::string const& planId, Node& plan) -> void {
+    return setLeadershipPlan(dbName, planId, PLAN_LEADERSHIP_TYPE::SELF, plan);
+  }
+
+  // Another server will take leadership in plan
+  // Asserts that dbName and planId exists in plan
+  auto otherTakeLeadershipPlan(std::string const& dbName, std::string const& planId, Node& plan) -> void {
+    return setLeadershipPlan(dbName, planId, PLAN_LEADERSHIP_TYPE::OTHER, plan);
+  }
+
+  // Another server will take resigned leadership in plan
+  // Asserts that dbName and planId exists in plan
+  auto otherTakeResignedLeadershipPlan(std::string const& dbName,
+                               std::string const& planId, Node& plan) -> void {
+    return setLeadershipPlan(dbName, planId, PLAN_LEADERSHIP_TYPE::RESIGNED_OTHER, plan);
+  }
+
+  auto setLeadershipLocal(std::string const& dbName,
+                            std::unordered_set<std::string> const& shardNames,
+                            LOCAL_LEADERSHIP_TYPE type, Node& local) {
+    for (auto const& shardName : shardNames) {
+      auto vec = {dbName, shardName, std::string(THE_LEADER)};
+      ASSERT_TRUE(local.has(vec))
+          << "The underlying test plan is modified, it "
+             "does not contain Database '"
+          << dbName << "' and Shard '" << shardName << "' anymore.";
+      auto& leaderInfo = local(vec);
+      VPackBuilder newValue;
+      switch (type) {
+        case LOCAL_LEADERSHIP_TYPE::SELF: {
+          newValue.add(VPackValue(""));
+          break;
+        }
+        case LOCAL_LEADERSHIP_TYPE::OTHER: {
+          newValue.add(VPackValue(unusedServer()));
+          break;
+        }
+        case LOCAL_LEADERSHIP_TYPE::RESIGNED: {
+          newValue.add(VPackValue(ResignShardLeadership::LeaderNotYetKnownString));
+          break;
+        }
+        case LOCAL_LEADERSHIP_TYPE::REBOOTED: {
+          newValue.add(VPackValue(LEADER_NOT_YET_KNOWN));
+          break;
+        }
+      }
+      leaderInfo = newValue.slice();
+    }
+  }
+
+  // Claim leadership of the given shards ourself.
+  auto takeLeadershipLocal(std::string const& dbName,
+                             std::unordered_set<std::string> const& shardNames,
+                             Node& local) {
+    setLeadershipLocal(dbName, shardNames, LOCAL_LEADERSHIP_TYPE::SELF, local);
+  }
+
+    // Resign leadership of the given shards ourself.
+  auto resignLeadershipLocal(std::string const& dbName,
+                             std::unordered_set<std::string> const& shardNames,
+                             Node& local) {
+    setLeadershipLocal(dbName, shardNames, LOCAL_LEADERSHIP_TYPE::RESIGNED, local);
+  }
+
+  // Let other server claim leadership of the given shards ourself.
+  auto otherTakeLeadershipLocal(std::string const& dbName,
+                                  std::unordered_set<std::string> const& shardNames,
+                                  Node& local) {
+    setLeadershipLocal(dbName, shardNames, LOCAL_LEADERSHIP_TYPE::OTHER, local);
+  }
+
+  // Claim leadership of the given shards ourself.
+  auto rebootLeadershipLocal(std::string const& dbName,
+                               std::unordered_set<std::string> const& shardNames,
+                               Node& local) {
+    setLeadershipLocal(dbName, shardNames, LOCAL_LEADERSHIP_TYPE::REBOOTED, local);
+  }
+
+  auto assertIsTakeoverLeadershipAction(ActionDescription const& action,
+                                        std::string const& dbName,
+                                        std::string const& planId) -> void {
+    ASSERT_EQ(action.name(), "TakeoverShardLeadership");
+    ASSERT_TRUE(action.has(DATABASE));
+    ASSERT_TRUE(action.has(COLLECTION));
+    ASSERT_TRUE(action.has(SHARD));
+    ASSERT_TRUE(action.has(THE_LEADER));
+    ASSERT_TRUE(action.has(LOCAL_LEADER));
+    ASSERT_TRUE(action.has(PLAN_RAFT_INDEX));
+    ASSERT_EQ(action.get(DATABASE), dbName);
+    ASSERT_EQ(action.get(COLLECTION), planId);
+  }
+
+  auto assertIsResignLeadershipAction(ActionDescription const& action,
+                                      std::string const& dbName) -> void {
+    ASSERT_EQ(action.name(), "ResignShardLeadership");
+    ASSERT_TRUE(action.has(DATABASE));
+    ASSERT_TRUE(action.has(SHARD));
+    ASSERT_EQ(action.get(DATABASE), dbName);
   }
 };
 
@@ -715,6 +956,364 @@ TEST_F(MaintenanceTestActionPhaseOne,
   }
 }
 
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_self_local_self) {
+  plan = originalPlan;
+  takeLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    takeLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<std::shared_ptr<ActionDescription>> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(), 0,
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 0);
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_resign_self_local_self) {
+  plan = originalPlan;
+  resignLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    takeLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<std::shared_ptr<ActionDescription>> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(), 0,
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 2);
+    for (auto const& action : actions) {
+      assertIsResignLeadershipAction(*action, dbName());
+      auto shardName = action->get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_other_local_self) {
+  plan = originalPlan;
+  otherTakeLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    takeLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<std::shared_ptr<ActionDescription>> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(), 0,
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 2);
+    for (auto const& action : actions) {
+      assertIsResignLeadershipAction(*action, dbName());
+      auto shardName = action->get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_resign_other_local_self) {
+  plan = originalPlan;
+  otherTakeResignedLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    takeLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<std::shared_ptr<ActionDescription>> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(), 0,
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    for (auto const& action : actions) {
+      assertIsResignLeadershipAction(*action, dbName());
+      auto shardName = action->get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_self_local_other) {
+  plan = originalPlan;
+  takeLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    otherTakeLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<std::shared_ptr<ActionDescription>> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(), 0,
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 2);
+    for (auto const& action : actions) {
+      assertIsTakeoverLeadershipAction(*action, dbName(), planId());
+      auto shardName = action->get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+      EXPECT_EQ(action->get(THE_LEADER), "");
+      EXPECT_EQ(action->get(LOCAL_LEADER), unusedServer());
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_resign_self_local_other) {
+  plan = originalPlan;
+  resignLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    otherTakeLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<std::shared_ptr<ActionDescription>> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(), 0,
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 2);
+    for (auto const& action : actions) {
+      assertIsResignLeadershipAction(*action, dbName());
+      auto shardName = action->get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_other_local_other) {
+  plan = originalPlan;
+  otherTakeLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    otherTakeLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<std::shared_ptr<ActionDescription>> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(), 0,
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 0);
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_resign_other_local_other) {
+  plan = originalPlan;
+  otherTakeResignedLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    otherTakeLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<std::shared_ptr<ActionDescription>> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(), 0,
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 0);
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_self_local_resigned) {
+  plan = originalPlan;
+  takeLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    resignLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<std::shared_ptr<ActionDescription>> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(), 0,
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 2);
+    for (auto const& action : actions) {
+      assertIsTakeoverLeadershipAction(*action, dbName(), planId());
+      auto shardName = action->get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+      EXPECT_EQ(action->get(THE_LEADER), "");
+      EXPECT_EQ(action->get(LOCAL_LEADER), ResignShardLeadership::LeaderNotYetKnownString);
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_resign_self_local_resigned) {
+  plan = originalPlan;
+  resignLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    resignLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<std::shared_ptr<ActionDescription>> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(), 0,
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 0);
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_other_local_resigned) {
+  plan = originalPlan;
+  otherTakeLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    resignLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<std::shared_ptr<ActionDescription>> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(), 0,
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    // Synchronize in Phase 2 is responsible for this.
+    ASSERT_EQ(actions.size(), 0);
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_resign_other_local_resigned) {
+  plan = originalPlan;
+  otherTakeResignedLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    resignLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<std::shared_ptr<ActionDescription>> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(), 0,
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    // Synchronize in Phase 2 is responsible for this.
+    ASSERT_EQ(actions.size(), 0);
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_self_local_reboot) {
+  plan = originalPlan;
+  takeLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    rebootLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<std::shared_ptr<ActionDescription>> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(), 0,
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 2);
+    for (auto const& action : actions) {
+      assertIsTakeoverLeadershipAction(*action, dbName(), planId());
+      auto shardName = action->get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+      EXPECT_EQ(action->get(THE_LEADER), "");
+      EXPECT_EQ(action->get(LOCAL_LEADER), LEADER_NOT_YET_KNOWN);
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_resign_self_local_reboot) {
+  plan = originalPlan;
+  resignLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    rebootLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<std::shared_ptr<ActionDescription>> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(), 0,
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 2);
+    for (auto const& action : actions) {
+      assertIsResignLeadershipAction(*action, dbName());
+      auto shardName = action->get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_other_local_reboot) {
+  plan = originalPlan;
+  otherTakeLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    rebootLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<std::shared_ptr<ActionDescription>> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(), 0,
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+    
+    // We will just resign in this case to get a clear state.
+    ASSERT_EQ(actions.size(), 2);
+    for (auto const& action : actions) {
+      assertIsResignLeadershipAction(*action, dbName());
+      auto shardName = action->get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_resign_other_local_reboot) {
+  plan = originalPlan;
+  otherTakeResignedLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    rebootLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<std::shared_ptr<ActionDescription>> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(), 0,
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    // We will just resign in this case to get a clear state.
+    ASSERT_EQ(actions.size(), 2);
+    for (auto const& action : actions) {
+      assertIsResignLeadershipAction(*action, dbName());
+      auto shardName = action->get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+    }
+  }
+}
+
 TEST_F(MaintenanceTestActionPhaseOne, have_theleader_set_to_empty) {
   VPackBuilder v;
   v.add(VPackValue(std::string()));
@@ -722,7 +1321,7 @@ TEST_F(MaintenanceTestActionPhaseOne, have_theleader_set_to_empty) {
   for (auto node : localNodes) {
     std::vector<std::shared_ptr<ActionDescription>> actions;
 
-    auto& collection = *node.second("foo").children().begin()->second;
+    auto& collection = *node.second(dbName()).children().begin()->second;
     auto& leader = collection("theLeader");
 
     bool check = false;
@@ -730,7 +1329,6 @@ TEST_F(MaintenanceTestActionPhaseOne, have_theleader_set_to_empty) {
       check = true;
       leader = v.slice();
     }
-
     arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(), 0,
                                          node.second.toBuilder().slice(),
                                          node.first, errors, *feature, actions);
@@ -738,11 +1336,31 @@ TEST_F(MaintenanceTestActionPhaseOne, have_theleader_set_to_empty) {
     if (check) {
       ASSERT_EQ(actions.size(), 1);
       for (auto const& action : actions) {
-        ASSERT_EQ(action->name(), "TakeoverShardLeadership");
-        ASSERT_TRUE(action->has("shard"));
+        assertIsResignLeadershipAction(*action, dbName());
         ASSERT_EQ(action->get("shard"), collection("name").getString());
-        ASSERT_TRUE(action->get("localLeader").empty());
       }
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, resign_leadership_plan) {
+  plan = originalPlan;
+  resignLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto node : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), node.first, originalPlan);
+    std::vector<std::shared_ptr<ActionDescription>> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(), 0,
+                                         node.second.toBuilder().slice(),
+                                         node.first, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), relevantShards.size());
+    for (auto const& action : actions) {
+      assertIsResignLeadershipAction(*action, dbName());
+      auto shardName = action->get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
     }
   }
 }
@@ -807,8 +1425,7 @@ TEST_F(MaintenanceTestActionPhaseOne, resign_leadership) {
                                          node.first, errors, *feature, actions);
 
     ASSERT_EQ(actions.size(), 1);
-    ASSERT_EQ(actions[0]->name(), "ResignShardLeadership");
-    ASSERT_EQ(actions[0]->get(DATABASE), dbname);
+    assertIsResignLeadershipAction(*actions[0], "_system");
     ASSERT_EQ(actions[0]->get(SHARD), shname);
   }
 }


### PR DESCRIPTION
During a move-shard job which moves the leader there is a
situation in which the old owner of a shard can reclaim ownership
(after having resigned already), with a small race where it allows to
write documents only locally, but then continue the move-shard to a
server without those documents. An additional bug in the MoveShard
Supervision job would then leave the shard in a bad configuration
with a resigned leader permanently in charge.


### Scope & Purpose

*(Please describe the changes in this PR for reviewers)*

- [X] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [X] Backports required for: 3.5, 3.6, 3.7

#### Related Information

*(Please reference tickets / specification etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [X] Design document: https://github.com/arangodb/documents/blob/master/DesignDocuments/99_UNSORTED/Supervision.md

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [X] This change is already covered by existing tests, such as *(please describe tests)*.
- [X] This PR adds tests that were used to verify all changes:
  - [ ] Added **Regression Tests**
  - [X] Added new C++ **Unit Tests**
  - [ ] Added new **integration tests** (i.e. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)

Additionally:

- [X] There are tests in an external testing repository: arangosync tests
- [ ] I ensured this code runs with ASan / TSan or other static verification tools