### PR TITLE
Feature/introduce effective rows

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Introduce an internal high-water mark for the maximum row number that was
+  written to in an AqlItemBlock. Using this number several operations on the
+  whole block, such as cleaning up or copying can be made more efficient when
+  run on only partially filled blocks.
+
 * Fixed that dropping a vanished follower works again. An exception response
   to the replication request is now handled properly.
 

--- a/arangod/Aql/AqlItemBlockInputRange.cpp
+++ b/arangod/Aql/AqlItemBlockInputRange.cpp
@@ -40,14 +40,14 @@ AqlItemBlockInputRange::AqlItemBlockInputRange(ExecutorState state, std::size_t 
                                                arangodb::aql::SharedAqlItemBlockPtr const& block,
                                                std::size_t index)
     : _block{block}, _rowIndex{index}, _finalState{state}, _skipped{skipped} {
-  TRI_ASSERT(index <= _block->size());
+  TRI_ASSERT(index <= _block->numRows());
 }
 
 AqlItemBlockInputRange::AqlItemBlockInputRange(ExecutorState state, std::size_t skipped,
                                                arangodb::aql::SharedAqlItemBlockPtr&& block,
                                                std::size_t index) noexcept
     : _block{std::move(block)}, _rowIndex{index}, _finalState{state}, _skipped{skipped} {
-  TRI_ASSERT(index <= _block->size());
+  TRI_ASSERT(index <= _block->numRows());
 }
 
 SharedAqlItemBlockPtr AqlItemBlockInputRange::getBlock() const noexcept {
@@ -115,7 +115,7 @@ bool AqlItemBlockInputRange::hasShadowRow() const noexcept {
 }
 
 bool AqlItemBlockInputRange::isIndexValid(std::size_t index) const noexcept {
-  return _block != nullptr && index < _block->size();
+  return _block != nullptr && index < _block->numRows();
 }
 
 bool AqlItemBlockInputRange::isShadowRowAtIndex(std::size_t index) const noexcept {
@@ -197,7 +197,7 @@ auto AqlItemBlockInputRange::countDataRows() const noexcept -> std::size_t {
     return 0;
   }
   auto const& block = getBlock();
-  auto total = block->size();
+  auto total = block->numRows();
   if (_rowIndex >= total) {
     return 0;
   }

--- a/arangod/Aql/AqlItemBlockManager.cpp
+++ b/arangod/Aql/AqlItemBlockManager.cpp
@@ -43,8 +43,8 @@ AqlItemBlockManager::AqlItemBlockManager(ResourceMonitor* resourceMonitor,
 AqlItemBlockManager::~AqlItemBlockManager() = default;
 
 /// @brief request a block with the specified size
-SharedAqlItemBlockPtr AqlItemBlockManager::requestBlock(size_t nrItems, RegisterCount nrRegs) {
-  size_t const targetSize = nrItems * nrRegs;
+SharedAqlItemBlockPtr AqlItemBlockManager::requestBlock(size_t numRows, RegisterCount numRegisters) {
+  size_t const targetSize = numRows * numRegisters;
 
   AqlItemBlock* block = nullptr;
   uint32_t i = Bucket::getId(targetSize);
@@ -67,15 +67,16 @@ SharedAqlItemBlockPtr AqlItemBlockManager::requestBlock(size_t nrItems, Register
   // perform potentially expensive allocation/cleanup tasks outside
   // of the locked section
   if (block == nullptr) {
-    block = new AqlItemBlock(*this, nrItems, nrRegs);
+    block = new AqlItemBlock(*this, numRows, numRegisters);
   } else {
-    block->rescale(nrItems, nrRegs);
+    block->rescale(numRows, numRegisters);
   }
 
   TRI_ASSERT(block != nullptr);
-  TRI_ASSERT(block->size() == nrItems);
-  TRI_ASSERT(block->getNrRegs() == nrRegs);
+  TRI_ASSERT(block->numRows() == numRows);
+  TRI_ASSERT(block->numRegisters() == numRegisters);
   TRI_ASSERT(block->numEntries() == targetSize);
+  TRI_ASSERT(block->numEffectiveEntries() == 0);
   TRI_ASSERT(block->getRefCount() == 0);
   TRI_ASSERT(block->hasShadowRows() == false);
 
@@ -126,13 +127,13 @@ SharedAqlItemBlockPtr AqlItemBlockManager::requestAndInitBlock(arangodb::velocyp
   if (nrItemsSigned <= 0) {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "nrItems must be > 0");
   }
-  auto const nrItems = static_cast<size_t>(nrItemsSigned);
+  auto const numRows = static_cast<size_t>(nrItemsSigned);
 
-  SharedAqlItemBlockPtr block = requestBlock(nrItems, nrRegs);
+  SharedAqlItemBlockPtr block = requestBlock(numRows, nrRegs);
   block->initFromSlice(slice);
 
-  TRI_ASSERT(block->size() == nrItems);
-  TRI_ASSERT(block->getNrRegs() == nrRegs);
+  TRI_ASSERT(block->numRows() == numRows);
+  TRI_ASSERT(block->numRegisters() == nrRegs);
 
   return block;
 }

--- a/arangod/Aql/AqlItemBlockUtils.cpp
+++ b/arangod/Aql/AqlItemBlockUtils.cpp
@@ -36,21 +36,21 @@ SharedAqlItemBlockPtr itemBlock::concatenate(AqlItemBlockManager& manager,
                                              std::vector<SharedAqlItemBlockPtr>& blocks) {
   TRI_ASSERT(!blocks.empty());
 
-  size_t totalSize = 0;
-  RegisterCount nrRegs = 0;
+  size_t totalRows = 0;
+  RegisterCount numRegisters = 0;
   for (auto& it : blocks) {
-    totalSize += it->size();
-    if (nrRegs == 0) {
-      nrRegs = it->getNrRegs();
+    totalRows += it->numRows();
+    if (numRegisters == 0) {
+      numRegisters = it->numRegisters();
     } else {
-      TRI_ASSERT(it->getNrRegs() == nrRegs);
+      TRI_ASSERT(it->numRegisters() == numRegisters);
     }
   }
 
-  TRI_ASSERT(totalSize > 0);
-  TRI_ASSERT(nrRegs > 0);
+  TRI_ASSERT(totalRows > 0);
+  TRI_ASSERT(numRegisters > 0);
 
-  auto resultBlock = manager.requestBlock(totalSize, nrRegs);
+  auto resultBlock = manager.requestBlock(totalRows, numRegisters);
 
   size_t nextFreeRow = 0;
   for (auto& inputBlock : blocks) {

--- a/arangod/Aql/AqlItemMatrix.h
+++ b/arangod/Aql/AqlItemMatrix.h
@@ -65,7 +65,7 @@ class AqlItemMatrix {
   /**
    * @brief Number of registers, i.e. width of the matrix.
    */
-  RegisterCount getNrRegisters() const noexcept;
+  RegisterCount getNumRegisters() const noexcept;
 
   /**
    * @brief Test if this matrix is empty

--- a/arangod/Aql/ConstFetcher.cpp
+++ b/arangod/Aql/ConstFetcher.cpp
@@ -54,7 +54,7 @@ auto ConstFetcher::execute(AqlCallStack& stack)
   arangodb::containers::SmallVector<std::pair<size_t, size_t>>::allocator_type::arena_type arena;
   arangodb::containers::SmallVector<std::pair<size_t, size_t>> sliceIndexes{arena};
 
-  sliceIndexes.emplace_back(_rowIndex, _blockForPassThrough->size());
+  sliceIndexes.emplace_back(_rowIndex, _blockForPassThrough->numRows());
 
   // Modifiable first slice indexes.
   // from is the first data row to be returned
@@ -134,7 +134,7 @@ auto ConstFetcher::execute(AqlCallStack& stack)
       _rowIndex = sliceIndexes.back().second;
     } else {
       // We do not have shadowRows in use, need to to go the end.
-      _rowIndex = _blockForPassThrough->size();
+      _rowIndex = _blockForPassThrough->numRows();
     }
   } else {
     // No hardLimit, but softLimit.
@@ -165,7 +165,7 @@ auto ConstFetcher::execute(AqlCallStack& stack)
 
   SharedAqlItemBlockPtr resultBlock = _blockForPassThrough;
 
-  if (_rowIndex >= resultBlock->size()) {
+  if (_rowIndex >= resultBlock->numRows()) {
     // used the full block by now.
     _blockForPassThrough.reset(nullptr);
   }
@@ -207,14 +207,14 @@ void ConstFetcher::injectBlock(SharedAqlItemBlockPtr block, SkipResult skipped) 
 }
 
 auto ConstFetcher::indexIsValid() const noexcept -> bool {
-  return _currentBlock != nullptr && _rowIndex + 1 <= _currentBlock->size();
+  return _currentBlock != nullptr && _rowIndex + 1 <= _currentBlock->numRows();
 }
 
 auto ConstFetcher::numRowsLeft() const noexcept -> size_t {
   if (!indexIsValid()) {
     return 0;
   }
-  return _currentBlock->size() - _rowIndex;
+  return _currentBlock->numRows() - _rowIndex;
 }
 
 auto ConstFetcher::canUseFullBlock(arangodb::containers::SmallVector<std::pair<size_t, size_t>> const& ranges) const
@@ -224,7 +224,7 @@ auto ConstFetcher::canUseFullBlock(arangodb::containers::SmallVector<std::pair<s
     // We do not start at the first index.
     return false;
   }
-  if (ranges.back().second != _currentBlock->size()) {
+  if (ranges.back().second != _currentBlock->numRows()) {
     // We de not stop at the last index
     return false;
   }

--- a/arangod/Aql/ConstrainedSortExecutor.cpp
+++ b/arangod/Aql/ConstrainedSortExecutor.cpp
@@ -39,7 +39,7 @@ using namespace arangodb::aql;
 namespace {
 
 void eraseRow(SharedAqlItemBlockPtr& block, size_t row) {
-  auto const nrRegs = block->getNrRegs();
+  auto const nrRegs = block->numRegisters();
   for (arangodb::aql::RegisterId i = 0; i < nrRegs; i++) {
     block->destroyValue(row, i);
   }

--- a/arangod/Aql/DistributeExecutor.cpp
+++ b/arangod/Aql/DistributeExecutor.cpp
@@ -126,7 +126,7 @@ auto DistributeExecutor::distributeBlock(SharedAqlItemBlockPtr block, SkipResult
   choosenMap.reserve(blockMap.size());
 
   if (block != nullptr) {
-    for (size_t i = 0; i < block->size(); ++i) {
+    for (size_t i = 0; i < block->numRows(); ++i) {
       if (block->isShadowRow(i)) {
         // ShadowRows need to be added to all Clients
         for (auto const& [key, value] : blockMap) {

--- a/arangod/Aql/ExecutionBlock.cpp
+++ b/arangod/Aql/ExecutionBlock.cpp
@@ -163,7 +163,7 @@ void ExecutionBlock::traceExecuteEnd(std::tuple<ExecutionState, SkipResult, Shar
 
   if (_profile >= PROFILE_LEVEL_BLOCKS) {
     auto const& [state, skipped, block] = result;
-    auto const items = block != nullptr ? block->size() : 0;
+    auto const items = block != nullptr ? block->numRows() : 0;
 
     _execNodeStats.calls += 1;
     _execNodeStats.items += skipped.getSkipCount() + items;
@@ -178,7 +178,7 @@ void ExecutionBlock::traceExecuteEnd(std::tuple<ExecutionState, SkipResult, Shar
       size_t shadowRows = 0;
       if (block != nullptr) {
         shadowRows = block->numShadowRows();
-        rows = block->size() - shadowRows;
+        rows = block->numRows() - shadowRows;
       }
       ExecutionNode const* node = getPlanNode();
       LOG_QUERY("60bbc", INFO)

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -174,9 +174,9 @@ std::unique_ptr<OutputAqlItemRow> ExecutionBlockImpl<Executor>::createOutputRow(
   if (newBlock != nullptr) {
     // Assert that the block has enough registers. This must be guaranteed by
     // the register planning.
-    TRI_ASSERT(newBlock->getNrRegs() == _registerInfos.numberOfOutputRegisters());
+    TRI_ASSERT(newBlock->numRegisters() == _registerInfos.numberOfOutputRegisters());
     // Check that all output registers are empty.
-    size_t const n = newBlock->size();
+    size_t const n = newBlock->numRows();
     auto const& regs = _registerInfos.getOutputRegisters();
     if (!regs.empty()) {
       bool const hasShadowRows = newBlock->hasShadowRows();

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -611,6 +611,8 @@ AqlValue Expression::executeSimpleExpressionArray(AstNode const* node,
   if (n == 0) {
     return AqlValue(AqlValueHintEmptyArray());
   }
+    
+  auto const* vpackOptions = &trx->vpackOptions();
 
   transaction::BuilderLeaser builder(trx);
   builder->openArray();
@@ -620,7 +622,7 @@ AqlValue Expression::executeSimpleExpressionArray(AstNode const* node,
     bool localMustDestroy = false;
     AqlValue result = executeSimpleExpression(member, trx, localMustDestroy, false);
     AqlValueGuard guard(result, localMustDestroy);
-    result.toVelocyPack(&trx->vpackOptions(), *builder.get(), /*resolveExternals*/false,
+    result.toVelocyPack(vpackOptions, *builder.get(), /*resolveExternals*/false,
                         /*allowUnindexed*/false);
   }
 
@@ -653,6 +655,7 @@ AqlValue Expression::executeSimpleExpressionObject(AstNode const* node,
   // unordered set for tracking unique object keys
   std::unordered_set<std::string> keys;
   bool const mustCheckUniqueness = node->mustCheckUniqueness();
+  auto const* vpackOptions = &trx->vpackOptions();
 
   transaction::BuilderLeaser builder(trx);
   builder->openObject();
@@ -732,7 +735,7 @@ AqlValue Expression::executeSimpleExpressionObject(AstNode const* node,
     bool localMustDestroy;
     AqlValue result = executeSimpleExpression(member, trx, localMustDestroy, false);
     AqlValueGuard guard(result, localMustDestroy);
-    result.toVelocyPack(&trx->vpackOptions(), *builder.get(), /*resolveExternals*/false,
+    result.toVelocyPack(vpackOptions, *builder.get(), /*resolveExternals*/false,
                         /*allowUnindexed*/false);
   }
 

--- a/arangod/Aql/InAndOutRowExpressionContext.cpp
+++ b/arangod/Aql/InAndOutRowExpressionContext.cpp
@@ -107,7 +107,7 @@ AqlValue InAndOutRowExpressionContext::getVariableValue(Variable const* variable
         }
         // Search InputRow
         RegisterId const& regId = _regs[i];
-        TRI_ASSERT(regId < _input.getNrRegisters());
+        TRI_ASSERT(regId < _input.getNumRegisters());
         return _input.getValue(regId).clone();
       } else {
         mustDestroy = false;
@@ -122,7 +122,7 @@ AqlValue InAndOutRowExpressionContext::getVariableValue(Variable const* variable
         }
         // Search InputRow
         RegisterId const& regId = _regs[i];
-        TRI_ASSERT(regId < _input.getNrRegisters());
+        TRI_ASSERT(regId < _input.getNumRegisters());
         return _input.getValue(regId);
       }
     }

--- a/arangod/Aql/InputAqlItemRow.cpp
+++ b/arangod/Aql/InputAqlItemRow.cpp
@@ -52,9 +52,9 @@ SharedAqlItemBlockPtr InputAqlItemRow::cloneToBlock(AqlItemBlockManager& manager
       manager.requestBlock(1, static_cast<RegisterId>(newNrRegs));
   if (isInitialized()) {
     std::unordered_set<AqlValue> cache;
-    TRI_ASSERT(getNrRegisters() <= newNrRegs);
+    TRI_ASSERT(getNumRegisters() <= newNrRegs);
     // Should we transform this to output row and reuse copy row?
-    for (RegisterId col = 0; col < getNrRegisters(); col++) {
+    for (RegisterId col = 0; col < getNumRegisters(); col++) {
       if (registers.find(col) == registers.end()) {
         continue;
       }
@@ -135,26 +135,26 @@ void InputAqlItemRow::toSimpleVelocyPack(velocypack::Options const* trxOpts,
 InputAqlItemRow::InputAqlItemRow(SharedAqlItemBlockPtr const& block, size_t baseIndex) noexcept
     : _block(block), _baseIndex(baseIndex) {
   TRI_ASSERT(_block != nullptr);
-  TRI_ASSERT(_baseIndex < _block->size());
+  TRI_ASSERT(_baseIndex < _block->numRows());
   TRI_ASSERT(!_block->isShadowRow(baseIndex));
 }
 
 InputAqlItemRow::InputAqlItemRow(SharedAqlItemBlockPtr&& block, size_t baseIndex) noexcept
     : _block(std::move(block)), _baseIndex(baseIndex) {
   TRI_ASSERT(_block != nullptr);
-  TRI_ASSERT(_baseIndex < _block->size());
+  TRI_ASSERT(_baseIndex < _block->numRows());
   TRI_ASSERT(!_block->isShadowRow(baseIndex));
 }
 
 AqlValue const& InputAqlItemRow::getValue(RegisterId registerId) const {
   TRI_ASSERT(isInitialized());
-  TRI_ASSERT(registerId < getNrRegisters());
+  TRI_ASSERT(registerId < getNumRegisters());
   return block().getValueReference(_baseIndex, registerId);
 }
 
 AqlValue InputAqlItemRow::stealValue(RegisterId registerId) {
   TRI_ASSERT(isInitialized());
-  TRI_ASSERT(registerId < getNrRegisters());
+  TRI_ASSERT(registerId < getNumRegisters());
   AqlValue const& a = block().getValueReference(_baseIndex, registerId);
   if (!a.isEmpty() && a.requiresDestruction()) {
     // Now no one is responsible for AqlValue a
@@ -164,8 +164,8 @@ AqlValue InputAqlItemRow::stealValue(RegisterId registerId) {
   return a;
 }
 
-RegisterCount InputAqlItemRow::getNrRegisters() const noexcept {
-  return block().getNrRegs();
+RegisterCount InputAqlItemRow::getNumRegisters() const noexcept {
+  return block().numRegisters();
 }
 
 bool InputAqlItemRow::isSameBlockAndIndex(InputAqlItemRow const& other) const noexcept {
@@ -178,14 +178,14 @@ bool InputAqlItemRow::equates(InputAqlItemRow const& other,
   if (!isInitialized() || !other.isInitialized()) {
     return isInitialized() == other.isInitialized();
   }
-  TRI_ASSERT(getNrRegisters() == other.getNrRegisters());
-  if (getNrRegisters() != other.getNrRegisters()) {
+  TRI_ASSERT(getNumRegisters() == other.getNumRegisters());
+  if (getNumRegisters() != other.getNumRegisters()) {
     return false;
   }
   auto const eq = [options](auto left, auto right) {
     return 0 == AqlValue::Compare(options, left, right, false);
   };
-  for (RegisterId i = 0; i < getNrRegisters(); ++i) {
+  for (RegisterId i = 0; i < getNumRegisters(); ++i) {
     if (!eq(getValue(i), other.getValue(i))) {
       return false;
     }
@@ -208,7 +208,7 @@ InputAqlItemRow::operator bool() const noexcept { return isInitialized(); }
 
 bool InputAqlItemRow::isFirstDataRowInBlock() const noexcept {
   TRI_ASSERT(isInitialized());
-  TRI_ASSERT(_baseIndex < block().size());
+  TRI_ASSERT(_baseIndex < block().numRows());
 
   auto [shadowRowsBegin, shadowRowsEnd] = block().getShadowRowIndexesFrom(0);
 
@@ -231,7 +231,7 @@ bool InputAqlItemRow::isFirstDataRowInBlock() const noexcept {
 
 bool InputAqlItemRow::blockHasMoreDataRowsAfterThis() const noexcept {
   TRI_ASSERT(isInitialized());
-  TRI_ASSERT(_baseIndex < block().size());
+  TRI_ASSERT(_baseIndex < block().numRows());
 
   // Count the number of shadow rows after this row.
   size_t const numShadowRowsAfterCurrentRow = [this]() {
@@ -247,7 +247,7 @@ bool InputAqlItemRow::blockHasMoreDataRowsAfterThis() const noexcept {
   }();
 
   // block().size() is strictly greater than baseIndex
-  size_t const totalRowsAfterCurrentRow = block().size() - _baseIndex - 1;
+  size_t const totalRowsAfterCurrentRow = block().numRows() - _baseIndex - 1;
 
   return totalRowsAfterCurrentRow > numShadowRowsAfterCurrentRow;
 }

--- a/arangod/Aql/InputAqlItemRow.h
+++ b/arangod/Aql/InputAqlItemRow.h
@@ -86,7 +86,7 @@ class InputAqlItemRow {
    */
   AqlValue stealValue(RegisterId registerId);
 
-  RegisterCount getNrRegisters() const noexcept;
+  RegisterCount getNumRegisters() const noexcept;
 
   // This the old operator==. It tests if both rows refer to the _same_ block and
   // the _same_ index.

--- a/arangod/Aql/MultiAqlItemBlockInputRange.cpp
+++ b/arangod/Aql/MultiAqlItemBlockInputRange.cpp
@@ -36,7 +36,7 @@ using namespace arangodb::aql;
 namespace {
   static auto RowHasNonEmptyValue(ShadowAqlItemRow const& row) -> bool {
     if (row.isInitialized()) {
-      RegisterId const numRegisters = static_cast<RegisterId>(row.getNrRegisters());
+      RegisterId const numRegisters = static_cast<RegisterId>(row.getNumRegisters());
       for (RegisterId registerId = 0; registerId < numRegisters; ++registerId) {
         if (!row.getValue(registerId).isEmpty()) {
           return true;

--- a/arangod/Aql/MultiDependencySingleRowFetcher.cpp
+++ b/arangod/Aql/MultiDependencySingleRowFetcher.cpp
@@ -119,7 +119,7 @@ void MultiDependencySingleRowFetcher::init() {
 
 bool MultiDependencySingleRowFetcher::indexIsValid(
     const MultiDependencySingleRowFetcher::DependencyInfo& info) const {
-  return info._currentBlock != nullptr && info._rowIndex < info._currentBlock->size();
+  return info._currentBlock != nullptr && info._rowIndex < info._currentBlock->numRows();
 }
 
 bool MultiDependencySingleRowFetcher::isDone(

--- a/arangod/Aql/MutexExecutor.cpp
+++ b/arangod/Aql/MutexExecutor.cpp
@@ -55,7 +55,7 @@ auto MutexExecutor::distributeBlock(SharedAqlItemBlockPtr block, SkipResult skip
     std::unordered_map<std::string, std::vector<std::size_t>> choosenMap;
     choosenMap.reserve(blockMap.size());
 
-    for (size_t i = 0; i < block->size(); ++i) {
+    for (size_t i = 0; i < block->numRows(); ++i) {
       if (block->isShadowRow(i)) {
         // ShadowRows need to be added to all Clients
         for (auto const& [key, value] : blockMap) {

--- a/arangod/Aql/OutputAqlItemRow.cpp
+++ b/arangod/Aql/OutputAqlItemRow.cpp
@@ -69,20 +69,20 @@ OutputAqlItemRow::OutputAqlItemRow(SharedAqlItemBlockPtr block, RegIdSet const& 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if (_block != nullptr) {
     for (auto const& reg : _outputRegisters) {
-      TRI_ASSERT(reg < _block->getNrRegs());
+      TRI_ASSERT(reg < _block->numRegisters());
     }
     // the block must have enough columns for the registers of both data rows,
     // and all the different shadow row depths
     if (_doNotCopyInputRow) {
       // pass-through case, we won't use _registersToKeep
       for (auto const& reg : _registersToClear) {
-        TRI_ASSERT(reg < _block->getNrRegs());
+        TRI_ASSERT(reg < _block->numRegisters());
       }
     } else {
       // copying (non-pass-through) case, we won't use _registersToClear
       for (auto const& stackEntry : _registersToKeep) {
         for (auto const& reg : stackEntry) {
-          TRI_ASSERT(reg < _block->getNrRegs());
+          TRI_ASSERT(reg < _block->numRegisters());
         }
       }
     }
@@ -110,7 +110,7 @@ template <class ItemRowType, class ValueType>
 void OutputAqlItemRow::moveValueWithoutRowCopy(RegisterId registerId, ValueType& value) {
   TRI_ASSERT(isOutputRegister(registerId));
   // This is already implicitly asserted by isOutputRegister:
-  TRI_ASSERT(registerId < getNrRegisters());
+  TRI_ASSERT(registerId < getNumRegisters());
   TRI_ASSERT(_numValuesWritten < numRegistersToWrite());
   TRI_ASSERT(block().getValueReference(_baseIndex, registerId).isNone());
 
@@ -211,7 +211,7 @@ auto OutputAqlItemRow::fastForwardAllRows(InputAqlItemRow const& sourceRow, size
   // We only need to adjust internal indexes.
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // Safely assert that the API is not missused.
-  TRI_ASSERT(_baseIndex + rows <= _block->size());
+  TRI_ASSERT(_baseIndex + rows <= _block->numRows());
   for (size_t i = _baseIndex; i < _baseIndex + rows; ++i) {
     TRI_ASSERT(!_block->isShadowRow(i));
   }
@@ -232,7 +232,7 @@ void OutputAqlItemRow::copyBlockInternalRegister(InputAqlItemRow const& sourceRo
 #endif
   TRI_ASSERT(isOutputRegister(output));
   // This is already implicitly asserted by isOutputRegister:
-  TRI_ASSERT(output < getNrRegisters());
+  TRI_ASSERT(output < getNumRegisters());
   TRI_ASSERT(_numValuesWritten < numRegistersToWrite());
   TRI_ASSERT(block().getValueReference(_baseIndex, output).isNone());
 
@@ -461,7 +461,7 @@ void OutputAqlItemRow::doCopyOrMoveRow(ItemRowType& sourceRow, bool ignoreMissin
         TRI_ASSERT(sourceRow.isInitialized());
       }
 #endif
-      if (ignoreMissing && itemId >= sourceRow.getNrRegisters()) {
+      if (ignoreMissing && itemId >= sourceRow.getNumRegisters()) {
         continue;
       }
       if (ADB_LIKELY(!_allowSourceRowUninitialized || sourceRow.isInitialized())) {
@@ -524,8 +524,8 @@ auto constexpr OutputAqlItemRow::depthDelta(AdaptRowDepth adaptRowDepth)
   return static_cast<std::underlying_type_t<AdaptRowDepth>>(adaptRowDepth);
 }
 
-RegisterCount OutputAqlItemRow::getNrRegisters() const {
-  return block().getNrRegs();
+RegisterCount OutputAqlItemRow::getNumRegisters() const {
+  return block().numRegisters();
 }
 
 template void OutputAqlItemRow::copyRow<InputAqlItemRow>(InputAqlItemRow const& sourceRow,

--- a/arangod/Aql/OutputAqlItemRow.h
+++ b/arangod/Aql/OutputAqlItemRow.h
@@ -127,7 +127,7 @@ class OutputAqlItemRow {
    */
   auto fastForwardAllRows(InputAqlItemRow const& sourceRow, size_t rows) -> void;
 
-  [[nodiscard]] RegisterCount getNrRegisters() const;
+  [[nodiscard]] RegisterCount getNumRegisters() const;
 
   /**
    * @brief May only be called after all output values in the current row have
@@ -165,7 +165,7 @@ class OutputAqlItemRow {
    *        the left-over space for ShadowRows.
    */
   [[nodiscard]] bool allRowsUsed() const {
-    return _block == nullptr || block().size() <= _baseIndex;
+    return _block == nullptr || block().numRows() <= _baseIndex;
   }
 
   /**
@@ -183,7 +183,7 @@ class OutputAqlItemRow {
     if (_block == nullptr) {
       return 0;
     }
-    return (std::min)(block().size() - _baseIndex, _call.getLimit());
+    return (std::min)(block().numRows() - _baseIndex, _call.getLimit());
   }
 
   // Use this function with caution! We need it only for the ConstrainedSortExecutor

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -414,7 +414,7 @@ ExecutionState Query::execute(QueryResult& queryResult) {
             auto& resultBuilder = *queryResult.data;
             auto& vpackOpts = vpackOptions();
 
-            size_t const n = block->size();
+            size_t const n = block->numRows();
 
             for (size_t i = 0; i < n; ++i) {
               AqlValue const& val = block->getValueReference(i, resultRegister);
@@ -616,7 +616,7 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
         }
 
         if (!_queryOptions.silent) {
-          size_t const n = value->size();
+          size_t const n = value->numRows();
 
           auto const& vpackOpts = vpackOptions();
           for (size_t i = 0; i < n; ++i) {

--- a/arangod/Aql/RemoteExecutor.cpp
+++ b/arangod/Aql/RemoteExecutor.cpp
@@ -338,7 +338,7 @@ auto ExecutionBlockImpl<RemoteExecutor>::executeViaOldApi(AqlCallStack stack)
     // We do not need to count as softLimit will be overwritten, and hard cannot be set.
     if (stack.empty() && myCall.hasHardLimit() && !myCall.needsFullCount() && block != nullptr) {
       // However we can do a short-cut here to report DONE on hardLimit if we are on the top-level query.
-      myCall.didProduce(block->size());
+      myCall.didProduce(block->numRows());
       if (myCall.getLimit() == 0) {
         return {ExecutionState::DONE, SkipResult{}, std::move(block)};
       }

--- a/arangod/Aql/ShadowAqlItemRow.cpp
+++ b/arangod/Aql/ShadowAqlItemRow.cpp
@@ -32,12 +32,12 @@ using namespace arangodb::aql;
 ShadowAqlItemRow::ShadowAqlItemRow(SharedAqlItemBlockPtr block, size_t baseIndex)
     : _block(std::move(block)), _baseIndex(baseIndex) {
   TRI_ASSERT(isInitialized());
-  TRI_ASSERT(_baseIndex < _block->size());
+  TRI_ASSERT(_baseIndex < _block->numRows());
   TRI_ASSERT(_block->isShadowRow(_baseIndex));
 }
 
-RegisterCount ShadowAqlItemRow::getNrRegisters() const noexcept {
-  return block().getNrRegs();
+RegisterCount ShadowAqlItemRow::getNumRegisters() const noexcept {
+  return block().numRegisters();
 }
 
 bool ShadowAqlItemRow::isRelevant() const noexcept { return getDepth() == 0; }
@@ -54,13 +54,13 @@ bool ShadowAqlItemRow::internalBlockIs(SharedAqlItemBlockPtr const& other, size_
 
 AqlValue const& ShadowAqlItemRow::getValue(RegisterId registerId) const {
   TRI_ASSERT(isInitialized());
-  TRI_ASSERT(registerId < getNrRegisters());
+  TRI_ASSERT(registerId < getNumRegisters());
   return block().getValueReference(_baseIndex, registerId);
 }
 
 AqlValue ShadowAqlItemRow::stealAndEraseValue(RegisterId registerId) {
   TRI_ASSERT(isInitialized());
-  TRI_ASSERT(registerId < getNrRegisters());
+  TRI_ASSERT(registerId < getNumRegisters());
   // caller needs to take immediate ownership.
   return block().stealAndEraseValue(_baseIndex, registerId);
 }
@@ -95,8 +95,8 @@ bool ShadowAqlItemRow::equates(ShadowAqlItemRow const& other,
   if (!isInitialized() || !other.isInitialized()) {
     return isInitialized() == other.isInitialized();
   }
-  TRI_ASSERT(getNrRegisters() == other.getNrRegisters());
-  if (getNrRegisters() != other.getNrRegisters()) {
+  TRI_ASSERT(getNumRegisters() == other.getNumRegisters());
+  if (getNumRegisters() != other.getNumRegisters()) {
     return false;
   }
   if (getDepth() != other.getDepth()) {
@@ -105,7 +105,7 @@ bool ShadowAqlItemRow::equates(ShadowAqlItemRow const& other,
   auto const eq = [options](auto left, auto right) {
     return 0 == AqlValue::Compare(options, left, right, false);
   };
-  for (RegisterId i = 0; i < getNrRegisters(); ++i) {
+  for (RegisterId i = 0; i < getNumRegisters(); ++i) {
     if (!eq(getValue(i), other.getValue(i))) {
       return false;
     }

--- a/arangod/Aql/ShadowAqlItemRow.h
+++ b/arangod/Aql/ShadowAqlItemRow.h
@@ -66,7 +66,7 @@ class ShadowAqlItemRow {
   /// @brief get the number of data registers in the underlying block.
   ///        Not all of these registers are necessarily filled by this
   ///        ShadowRow. There might be empty registers on deeper levels.
-  [[nodiscard]] RegisterCount getNrRegisters() const noexcept;
+  [[nodiscard]] RegisterCount getNumRegisters() const noexcept;
 
   /// @brief a ShadowRow is relevant iff it indicates an end of subquery block on the subquery context
   ///        we are in right now. This will only be of importance on nested subqueries.

--- a/arangod/Aql/SubqueryExecutor.cpp
+++ b/arangod/Aql/SubqueryExecutor.cpp
@@ -152,7 +152,7 @@ auto SubqueryExecutor<isModificationSubquery>::produceRows(AqlItemBlockInputRang
         if (_infos.returnsData()) {
           TRI_ASSERT(_subqueryResults != nullptr);
           INTERNAL_LOG_SQ << uint64_t(this)
-                       << " store subquery result for writing " << block->size();
+                       << " store subquery result for writing " << block->numRows();
           _subqueryResults->emplace_back(std::move(block));
         }
       }

--- a/arangod/Transaction/Context.cpp
+++ b/arangod/Transaction/Context.cpp
@@ -177,8 +177,6 @@ VPackBuilder* transaction::Context::leaseBuilder() {
     return new VPackBuilder();
   }
 
-  TRI_ASSERT(!_builders.empty());
-
   // re-use an existing builder
   VPackBuilder* b = _builders.back();
   b->clear();

--- a/arangod/Transaction/Context.cpp
+++ b/arangod/Transaction/Context.cpp
@@ -177,6 +177,8 @@ VPackBuilder* transaction::Context::leaseBuilder() {
     return new VPackBuilder();
   }
 
+  TRI_ASSERT(!_builders.empty());
+
   // re-use an existing builder
   VPackBuilder* b = _builders.back();
   b->clear();

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -238,7 +238,7 @@ void Manager::unregisterAQLTrx(TransactionId tid) noexcept {
 }
 
 Result Manager::createManagedTrx(TRI_vocbase_t& vocbase, TransactionId tid,
-                                 VPackSlice const trxOpts) {
+                                 VPackSlice trxOpts) {
   Result res;
   if (_disallowInserts) {
     return res.reset(TRI_ERROR_SHUTTING_DOWN);
@@ -248,6 +248,8 @@ Result Manager::createManagedTrx(TRI_vocbase_t& vocbase, TransactionId tid,
   if (!trxOpts.isObject() || !trxOpts.get("collections").isObject()) {
     return res.reset(TRI_ERROR_BAD_PARAMETER, "missing 'collections'");
   }
+
+  LOG_DEVEL << "CREATEMANAGED TRX CALLED WITH: " << trxOpts.toJson();
 
   // extract the properties from the object
   transaction::Options options;
@@ -319,8 +321,22 @@ Result Manager::createManagedTrx(TRI_vocbase_t& vocbase, TransactionId tid,
   }
 
   // enforce size limit per DBServer
-  options.maxTransactionSize =
-      std::min<size_t>(options.maxTransactionSize, Manager::maxTransactionSize);
+  if (tid.isFollowerTransactionId()) {
+    // if we are a follower, we reuse the leader's max transaction size and slightly
+    // increase it. this is to ensure that the follower can process at least as many
+    // data as the leader, even if the data representation is slightly varied for
+    // network transport etc.
+    // note that this increase may overflow the value beyond what a uint64_t can hold
+    decltype(options.maxTransactionSize) adjustedSize = double(options.maxTransactionSize) * 1.25;
+    if (adjustedSize > options.maxTransactionSize) {
+      options.maxTransactionSize = adjustedSize;
+    }
+  } else {
+    options.maxTransactionSize =
+        std::min<size_t>(options.maxTransactionSize, Manager::maxTransactionSize);
+  }
+  
+  LOG_DEVEL << "EFFECTIVE MAX TRANSACTION SIZE: " << options.maxTransactionSize;
 
   std::shared_ptr<TransactionState> state;
   try {
@@ -401,6 +417,9 @@ Result Manager::createManagedTrx(TRI_vocbase_t& vocbase, TransactionId tid,
   // start the transaction
   transaction::Hints hints;
   hints.set(transaction::Hints::Hint::GLOBAL_MANAGED);
+  if (tid.isFollowerTransactionId()) {
+    hints.set(transaction::Hints::Hint::INTERMEDIATE_COMMITS);
+  }
   try {
     res = state->beginTransaction(hints);  // registers with transaction manager
   } catch (basics::Exception const& ex) {

--- a/arangod/Transaction/Manager.h
+++ b/arangod/Transaction/Manager.h
@@ -120,7 +120,7 @@ class Manager final {
 
   /// @brief create managed transaction
   Result createManagedTrx(TRI_vocbase_t& vocbase, TransactionId tid,
-                          velocypack::Slice const trxOpts);
+                          velocypack::Slice trxOpts);
 
   /// @brief create managed transaction
   Result createManagedTrx(TRI_vocbase_t& vocbase, TransactionId tid,

--- a/arangod/Transaction/Manager.h
+++ b/arangod/Transaction/Manager.h
@@ -120,7 +120,7 @@ class Manager final {
 
   /// @brief create managed transaction
   Result createManagedTrx(TRI_vocbase_t& vocbase, TransactionId tid,
-                          velocypack::Slice trxOpts);
+                          velocypack::Slice const trxOpts);
 
   /// @brief create managed transaction
   Result createManagedTrx(TRI_vocbase_t& vocbase, TransactionId tid,

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2335,22 +2335,8 @@ Future<Result> Methods::replicateOperations(
           bool found;
           resp.response->header.metaByKey(StaticStrings::ErrorCodes, found);
           replicationWorked = !found;
-          if (found) {
-            LOG_DEVEL << "oopsi, got error codes back!";
-          }
         }
         didRefuse = didRefuse || resp.response->statusCode() == fuerte::StatusNotAcceptable;
-          
-        if (!replicationWorked) {
-          ServerID const& deadFollower = (*followerList)[i];
-          LOG_DEVEL 
-              << "synchronous replication: dropping follower "
-              << deadFollower << " for shard " << collection->name() 
-              << ", status code: " << (int) resp.response->statusCode() 
-              << ", didRefuse: " << didRefuse 
-              << ", operation: " << (int) operation 
-              << ", data: " << resp.slice().toJson();
-        }
       }
 
       if (!replicationWorked) {

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2335,8 +2335,22 @@ Future<Result> Methods::replicateOperations(
           bool found;
           resp.response->header.metaByKey(StaticStrings::ErrorCodes, found);
           replicationWorked = !found;
+          if (found) {
+            LOG_DEVEL << "oopsi, got error codes back!";
+          }
         }
         didRefuse = didRefuse || resp.response->statusCode() == fuerte::StatusNotAcceptable;
+          
+        if (!replicationWorked) {
+          ServerID const& deadFollower = (*followerList)[i];
+          LOG_DEVEL 
+              << "synchronous replication: dropping follower "
+              << deadFollower << " for shard " << collection->name() 
+              << ", status code: " << (int) resp.response->statusCode() 
+              << ", didRefuse: " << didRefuse 
+              << ", operation: " << (int) operation 
+              << ", data: " << resp.slice().toJson();
+        }
       }
 
       if (!replicationWorked) {

--- a/tests/Aql/AllRowsFetcherTest.cpp
+++ b/tests/Aql/AllRowsFetcherTest.cpp
@@ -116,7 +116,7 @@ TEST_F(AllRowsFetcherTest, a_single_upstream_block_producer_returns_done_immedia
     std::tie(state, matrix) = testee.fetchAllRows();
     ASSERT_EQ(state, ExecutionState::DONE);
     ASSERT_NE(matrix, nullptr);
-    EXPECT_EQ(1, matrix->getNrRegisters());
+    EXPECT_EQ(1, matrix->getNumRegisters());
     EXPECT_FALSE(matrix->empty());
     EXPECT_EQ(1, matrix->size());
     auto rowIndexes = matrix->produceRowIndexes();
@@ -145,7 +145,7 @@ TEST_F(AllRowsFetcherTest, a_single_upstream_block_producer_returns_hasmore_then
     std::tie(state, matrix) = testee.fetchAllRows();
     ASSERT_EQ(state, ExecutionState::DONE);
     ASSERT_NE(matrix, nullptr);
-    EXPECT_EQ(1, matrix->getNrRegisters());
+    EXPECT_EQ(1, matrix->getNumRegisters());
     EXPECT_FALSE(matrix->empty());
     EXPECT_EQ(1, matrix->size());
     auto rowIndexes = matrix->produceRowIndexes();
@@ -178,7 +178,7 @@ TEST_F(AllRowsFetcherTest, a_single_upstream_block_producer_waits_then_returns_d
     std::tie(state, matrix) = testee.fetchAllRows();
     ASSERT_EQ(state, ExecutionState::DONE);
     ASSERT_NE(matrix, nullptr);
-    EXPECT_EQ(1, matrix->getNrRegisters());
+    EXPECT_EQ(1, matrix->getNumRegisters());
     EXPECT_FALSE(matrix->empty());
     EXPECT_EQ(1, matrix->size());
     auto rowIndexes = matrix->produceRowIndexes();
@@ -212,7 +212,7 @@ TEST_F(AllRowsFetcherTest, a_single_upstream_block_producer_waits_returns_hasmor
     std::tie(state, matrix) = testee.fetchAllRows();
     ASSERT_EQ(state, ExecutionState::DONE);
     ASSERT_NE(matrix, nullptr);
-    EXPECT_EQ(1, matrix->getNrRegisters());
+    EXPECT_EQ(1, matrix->getNumRegisters());
     EXPECT_FALSE(matrix->empty());
     EXPECT_EQ(1, matrix->size());
     auto rowIndexes = matrix->produceRowIndexes();
@@ -248,7 +248,7 @@ TEST_F(AllRowsFetcherTest, multiple_blocks_upstream_producer_does_not_wait) {
     std::tie(state, matrix) = testee.fetchAllRows();
     ASSERT_EQ(state, ExecutionState::DONE);
     ASSERT_NE(matrix, nullptr);
-    EXPECT_EQ(1, matrix->getNrRegisters());
+    EXPECT_EQ(1, matrix->getNumRegisters());
     EXPECT_FALSE(matrix->empty());
     EXPECT_EQ(6, matrix->size());
     auto rowIndexes = matrix->produceRowIndexes();
@@ -301,7 +301,7 @@ TEST_F(AllRowsFetcherTest, multiple_blocks_upstream_producer_waits) {
     std::tie(state, matrix) = testee.fetchAllRows();
     ASSERT_EQ(state, ExecutionState::DONE);
     ASSERT_NE(matrix, nullptr);
-    EXPECT_EQ(1, matrix->getNrRegisters());
+    EXPECT_EQ(1, matrix->getNumRegisters());
     EXPECT_FALSE(matrix->empty());
     EXPECT_EQ(6, matrix->size());
     auto rowIndexes = matrix->produceRowIndexes();
@@ -354,7 +354,7 @@ TEST_F(AllRowsFetcherTest, multiple_blocks_upstream_producer_waits_and_does_not_
     std::tie(state, matrix) = testee.fetchAllRows();
     ASSERT_EQ(state, ExecutionState::DONE);
     ASSERT_NE(matrix, nullptr);
-    EXPECT_EQ(1, matrix->getNrRegisters());
+    EXPECT_EQ(1, matrix->getNumRegisters());
     EXPECT_FALSE(matrix->empty());
     EXPECT_EQ(6, matrix->size());
     auto rowIndexes = matrix->produceRowIndexes();

--- a/tests/Aql/AqlHelper.cpp
+++ b/tests/Aql/AqlHelper.cpp
@@ -36,14 +36,14 @@ std::ostream& arangodb::aql::operator<<(std::ostream& stream, ExecutionStats con
 
 std::ostream& arangodb::aql::operator<<(std::ostream& stream, AqlItemBlock const& block) {
   stream << "[";
-  for (size_t row = 0; row < block.size(); row++) {
+  for (size_t row = 0; row < block.numRows(); row++) {
     if (row > 0) {
       stream << ",";
     }
     stream << " ";
     VPackBuilder builder{};
     builder.openArray();
-    for (RegisterId reg = 0; reg < block.getNrRegs(); reg++) {
+    for (RegisterId reg = 0; reg < block.numRegisters(); reg++) {
       if (reg > 0) {
         stream << ",";
       }
@@ -78,14 +78,14 @@ bool arangodb::aql::operator==(arangodb::aql::ExecutionStats const& left,
 }
 bool arangodb::aql::operator==(arangodb::aql::AqlItemBlock const& left,
                                arangodb::aql::AqlItemBlock const& right) {
-  if (left.size() != right.size()) {
+  if (left.numRows() != right.numRows()) {
     return false;
   }
-  if (left.getNrRegs() != right.getNrRegs()) {
+  if (left.numRegisters() != right.numRegisters()) {
     return false;
   }
-  size_t const rows = left.size();
-  RegisterCount const regs = left.getNrRegs();
+  size_t const rows = left.numRows();
+  RegisterCount const regs = left.numRegisters();
   for (size_t row = 0; row < rows; row++) {
     for (RegisterId reg = 0; reg < regs; reg++) {
       AqlValue const& l = left.getValueReference(row, reg);

--- a/tests/Aql/AqlItemBlockTest.cpp
+++ b/tests/Aql/AqlItemBlockTest.cpp
@@ -222,8 +222,8 @@ TEST_F(AqlItemBlockTest, test_serialization_deserialization_1) {
   SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
   // Check exposed attributes
-  EXPECT_EQ(testee->size(), block->size());
-  EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+  EXPECT_EQ(testee->numRows(), block->numRows());
+  EXPECT_EQ(testee->numRegisters(), block->numRegisters());
   EXPECT_EQ(testee->numEntries(), block->numEntries());
   EXPECT_EQ(testee->capacity(), block->capacity());
   // check data
@@ -251,8 +251,8 @@ TEST_F(AqlItemBlockTest, test_serialization_deserialization_2) {
     SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
     // Check exposed attributes
-    EXPECT_EQ(testee->size(), block->size());
-    EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+    EXPECT_EQ(testee->numRows(), block->numRows());
+    EXPECT_EQ(testee->numRegisters(), block->numRegisters());
     EXPECT_EQ(testee->numEntries(), block->numEntries());
     EXPECT_EQ(testee->capacity(), block->capacity());
     // check data
@@ -287,8 +287,8 @@ TEST_F(AqlItemBlockTest, test_serialization_deserialization_3) {
     SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
     // Check exposed attributes
-    EXPECT_EQ(testee->size(), block->size());
-    EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+    EXPECT_EQ(testee->numRows(), block->numRows());
+    EXPECT_EQ(testee->numRegisters(), block->numRegisters());
     EXPECT_EQ(testee->numEntries(), block->numEntries());
     EXPECT_EQ(testee->capacity(), block->capacity());
     // check data
@@ -331,8 +331,8 @@ TEST_F(AqlItemBlockTest, test_serialization_deserialization_shadowrows) {
   SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
   // Check exposed attributes
-  EXPECT_EQ(testee->size(), block->size());
-  EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+  EXPECT_EQ(testee->numRows(), block->numRows());
+  EXPECT_EQ(testee->numRegisters(), block->numRegisters());
   EXPECT_EQ(testee->numEntries(), block->numEntries());
   EXPECT_EQ(testee->capacity(), block->capacity());
   // check data
@@ -372,8 +372,8 @@ TEST_F(AqlItemBlockTest, test_serialization_deserialization_slices) {
     SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
     // Check exposed attributes
-    EXPECT_EQ(testee->size(), 1);
-    EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+    EXPECT_EQ(testee->numRows(), 1);
+    EXPECT_EQ(testee->numRegisters(), block->numRegisters());
     // check data
     compareWithDummy(testee, 0, 0, 4);
     compareWithDummy(testee, 0, 1, 5);
@@ -390,8 +390,8 @@ TEST_F(AqlItemBlockTest, test_serialization_deserialization_slices) {
     SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
     // Check exposed attributes
-    EXPECT_EQ(testee->size(), 1);
-    EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+    EXPECT_EQ(testee->numRows(), 1);
+    EXPECT_EQ(testee->numRegisters(), block->numRegisters());
     // check data
     compareWithDummy(testee, 0, 0, 0);
     compareWithDummy(testee, 0, 1, 1);
@@ -419,8 +419,8 @@ TEST_F(AqlItemBlockTest, test_serialization_deserialization_with_ranges) {
     SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
     // Check exposed attributes
-    EXPECT_EQ(testee->size(), 1);
-    EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+    EXPECT_EQ(testee->numRows(), 1);
+    EXPECT_EQ(testee->numRegisters(), block->numRegisters());
     // check data
     compareWithDummy(testee, 0, 0, 4);
     compareWithDummy(testee, 0, 1, 5);
@@ -439,8 +439,8 @@ TEST_F(AqlItemBlockTest, test_serialization_deserialization_with_ranges) {
     SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
     // Check exposed attributes
-    EXPECT_EQ(testee->size(), 1);
-    EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+    EXPECT_EQ(testee->numRows(), 1);
+    EXPECT_EQ(testee->numRegisters(), block->numRegisters());
     // check data
     compareWithDummy(testee, 0, 0, 0);
     compareWithDummy(testee, 0, 1, 1);
@@ -459,8 +459,8 @@ TEST_F(AqlItemBlockTest, test_serialization_deserialization_with_ranges) {
     SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
     // Check exposed attributes
-    EXPECT_EQ(testee->size(), 2);
-    EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+    EXPECT_EQ(testee->numRows(), 2);
+    EXPECT_EQ(testee->numRegisters(), block->numRegisters());
     // check data
     compareWithDummy(testee, 0, 0, 4);
     compareWithDummy(testee, 0, 1, 5);
@@ -488,8 +488,8 @@ TEST_F(AqlItemBlockTest, test_serialization_deserialization_input_row) {
     SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
     // Check exposed attributes
-    EXPECT_EQ(testee->size(), 1);
-    EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+    EXPECT_EQ(testee->numRows(), 1);
+    EXPECT_EQ(testee->numRegisters(), block->numRegisters());
     // check data
     compareWithDummy(testee, 0, 0, 4);
     compareWithDummy(testee, 0, 1, 5);
@@ -506,8 +506,8 @@ TEST_F(AqlItemBlockTest, test_serialization_deserialization_input_row) {
     SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
     // Check exposed attributes
-    EXPECT_EQ(testee->size(), 1);
-    EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+    EXPECT_EQ(testee->numRows(), 1);
+    EXPECT_EQ(testee->numRegisters(), block->numRegisters());
     // check data
     compareWithDummy(testee, 0, 0, 0);
     compareWithDummy(testee, 0, 1, 1);
@@ -567,8 +567,8 @@ TEST_F(AqlItemBlockClassicTest, test_serialization_deserialization_1) {
   SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
   // Check exposed attributes
-  EXPECT_EQ(testee->size(), block->size());
-  EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+  EXPECT_EQ(testee->numRows(), block->numRows());
+  EXPECT_EQ(testee->numRegisters(), block->numRegisters());
   EXPECT_EQ(testee->numEntries(), block->numEntries());
   EXPECT_EQ(testee->capacity(), block->capacity());
   // check data
@@ -595,8 +595,8 @@ TEST_F(AqlItemBlockClassicTest, test_serialization_deserialization_2) {
     SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
     // Check exposed attributes
-    EXPECT_EQ(testee->size(), block->size());
-    EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+    EXPECT_EQ(testee->numRows(), block->numRows());
+    EXPECT_EQ(testee->numRegisters(), block->numRegisters());
     EXPECT_EQ(testee->numEntries(), block->numEntries());
     EXPECT_EQ(testee->capacity(), block->capacity());
     // check data
@@ -630,8 +630,8 @@ TEST_F(AqlItemBlockClassicTest, test_serialization_deserialization_3) {
     SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
     // Check exposed attributes
-    EXPECT_EQ(testee->size(), block->size());
-    EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+    EXPECT_EQ(testee->numRows(), block->numRows());
+    EXPECT_EQ(testee->numRegisters(), block->numRegisters());
     EXPECT_EQ(testee->numEntries(), block->numEntries());
     EXPECT_EQ(testee->capacity(), block->capacity());
     // check data
@@ -672,8 +672,8 @@ TEST_F(AqlItemBlockClassicTest, test_serialization_deserialization_shadowrows) {
   SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
   // Check exposed attributes
-  EXPECT_EQ(testee->size(), block->size());
-  EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+  EXPECT_EQ(testee->numRows(), block->numRows());
+  EXPECT_EQ(testee->numRegisters(), block->numRegisters());
   EXPECT_EQ(testee->numEntries(), block->numEntries());
   EXPECT_EQ(testee->capacity(), block->capacity());
   // check data
@@ -711,8 +711,8 @@ TEST_F(AqlItemBlockClassicTest, test_serialization_deserialization_slices) {
     SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
     // Check exposed attributes
-    EXPECT_EQ(testee->size(), 1);
-    EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+    EXPECT_EQ(testee->numRows(), 1);
+    EXPECT_EQ(testee->numRegisters(), block->numRegisters());
     // check data
     compareWithDummy(testee, 0, 0, 4);
     compareWithDummy(testee, 0, 1, 5);
@@ -729,8 +729,8 @@ TEST_F(AqlItemBlockClassicTest, test_serialization_deserialization_slices) {
     SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
     // Check exposed attributes
-    EXPECT_EQ(testee->size(), 1);
-    EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+    EXPECT_EQ(testee->numRows(), 1);
+    EXPECT_EQ(testee->numRegisters(), block->numRegisters());
     // check data
     compareWithDummy(testee, 0, 0, 0);
     compareWithDummy(testee, 0, 1, 1);
@@ -754,8 +754,8 @@ TEST_F(AqlItemBlockClassicTest, test_serialization_deserialization_input_row) {
     SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
     // Check exposed attributes
-    EXPECT_EQ(testee->size(), 1);
-    EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+    EXPECT_EQ(testee->numRows(), 1);
+    EXPECT_EQ(testee->numRegisters(), block->numRegisters());
     // check data
     compareWithDummy(testee, 0, 0, 4);
     compareWithDummy(testee, 0, 1, 5);
@@ -772,8 +772,8 @@ TEST_F(AqlItemBlockClassicTest, test_serialization_deserialization_input_row) {
     SharedAqlItemBlockPtr testee = itemBlockManager.requestAndInitBlock(result.slice());
 
     // Check exposed attributes
-    EXPECT_EQ(testee->size(), 1);
-    EXPECT_EQ(testee->getNrRegs(), block->getNrRegs());
+    EXPECT_EQ(testee->numRows(), 1);
+    EXPECT_EQ(testee->numRegisters(), block->numRegisters());
     // check data
     compareWithDummy(testee, 0, 0, 0);
     compareWithDummy(testee, 0, 1, 1);

--- a/tests/Aql/AqlItemMatrixTest.cpp
+++ b/tests/Aql/AqlItemMatrixTest.cpp
@@ -35,7 +35,7 @@ class AqlItemMatrixTest : public AqlExecutorTestCase<> {};
 TEST_F(AqlItemMatrixTest, should_forward_number_of_regs) {
   for (RegisterCount c = 1; c < 3; c++) {
     AqlItemMatrix testee(c);
-    EXPECT_EQ(testee.getNrRegisters(), c);
+    EXPECT_EQ(testee.getNumRegisters(), c);
   }
 }
 

--- a/tests/Aql/AqlItemRowPrinter.cpp
+++ b/tests/Aql/AqlItemRowPrinter.cpp
@@ -60,10 +60,10 @@ std::ostream& arangodb::aql::operator<<(std::ostream& stream, RowType const& row
   printHead(stream, row);
 
   stream << "{";
-  if (row.getNrRegisters() > 0) {
+  if (row.getNumRegisters() > 0) {
     stream << row.getValue(0).slice().toJson();
   }
-  for (RegisterId i = 1; i < row.getNrRegisters(); ++i) {
+  for (RegisterId i = 1; i < row.getNumRegisters(); ++i) {
     stream << ", ";
     stream << row.getValue(i).slice().toJson();
   }

--- a/tests/Aql/AqlItemRowTest.cpp
+++ b/tests/Aql/AqlItemRowTest.cpp
@@ -52,12 +52,12 @@ class AqlItemRowsTest : public ::testing::Test {
   void AssertResultMatrix(AqlItemBlock* in, VPackSlice result,
                           RegIdFlatSet const& regsToKeep, bool assertNotInline = false) {
     ASSERT_TRUE(result.isArray());
-    ASSERT_EQ(in->size(), result.length());
-    for (size_t rowIdx = 0; rowIdx < in->size(); ++rowIdx) {
+    ASSERT_EQ(in->numRows(), result.length());
+    for (size_t rowIdx = 0; rowIdx < in->numRows(); ++rowIdx) {
       VPackSlice row = result.at(rowIdx);
       ASSERT_TRUE(row.isArray());
-      ASSERT_EQ(in->getNrRegs(), row.length());
-      for (RegisterId regId = 0; regId < in->getNrRegs(); ++regId) {
+      ASSERT_EQ(in->numRegisters(), row.length());
+      for (RegisterId regId = 0; regId < in->numRegisters(); ++regId) {
         AqlValue v = in->getValueReference(rowIdx, regId);
         if (regsToKeep.find(regId) == regsToKeep.end()) {
           // If this should not be kept it has to be set to NONE!

--- a/tests/Aql/AqlShadowRowTest.cpp
+++ b/tests/Aql/AqlShadowRowTest.cpp
@@ -51,8 +51,8 @@ class AqlShadowItemRowTest : public ::testing::Test {
                        std::unordered_set<RegisterId> const& regsToIgnore = {}) {
     ASSERT_TRUE(result.isArray());
     ASSERT_TRUE(input.isInitialized());
-    ASSERT_EQ(input.getNrRegisters(), static_cast<size_t>(result.length()));
-    for (RegisterId i = 0; i < input.getNrRegisters(); ++i) {
+    ASSERT_EQ(input.getNumRegisters(), static_cast<size_t>(result.length()));
+    for (RegisterId i = 0; i < input.getNumRegisters(); ++i) {
       if (regsToIgnore.find(i) == regsToIgnore.end()) {
         auto val = input.getValue(i);
         ASSERT_TRUE(VelocyPackHelper::equal(val.slice(), result.at(i), false))
@@ -65,12 +65,12 @@ class AqlShadowItemRowTest : public ::testing::Test {
   void InsertNewShadowRowAfterEachDataRow(size_t targetNumberOfRows,
                                           SharedAqlItemBlockPtr const& inputBlock,
                                           SharedAqlItemBlockPtr& outputBlock) {
-    auto numRegisters = inputBlock->getNrRegs();
+    auto numRegisters = inputBlock->numRegisters();
     outputBlock = itemBlockManager.requestBlock(targetNumberOfRows, numRegisters);
     // We do not add or remove anything, just move
     auto outputRegisters = RegIdSet{};
     size_t maxShadowRowDepth = 0;
-    for (size_t rowIdx = 0; rowIdx < inputBlock->size(); ++rowIdx) {
+    for (size_t rowIdx = 0; rowIdx < inputBlock->numRows(); ++rowIdx) {
       if (inputBlock->isShadowRow(rowIdx)) {
         maxShadowRowDepth =
             std::max(maxShadowRowDepth, inputBlock->getShadowRowDepth(rowIdx) + 1);
@@ -89,7 +89,7 @@ class AqlShadowItemRowTest : public ::testing::Test {
     OutputAqlItemRow testee(std::move(outputBlock), outputRegisters,
                             registersToKeep, registersToClear);
 
-    for (size_t rowIdx = 0; rowIdx < inputBlock->size(); ++rowIdx) {
+    for (size_t rowIdx = 0; rowIdx < inputBlock->numRows(); ++rowIdx) {
       ASSERT_FALSE(testee.isFull());
       if (!inputBlock->isShadowRow(rowIdx)) {
         // simply copy over every row, and insert a shadowRow after it
@@ -112,19 +112,19 @@ class AqlShadowItemRowTest : public ::testing::Test {
     ASSERT_TRUE(testee.isFull());
     ASSERT_EQ(testee.numRowsWritten(), targetNumberOfRows);
     outputBlock = testee.stealBlock();
-    ASSERT_EQ(outputBlock->size(), targetNumberOfRows);
+    ASSERT_EQ(outputBlock->numRows(), targetNumberOfRows);
   }
 
   void ConsumeRelevantShadowRows(size_t targetNumberOfRows,
                                  SharedAqlItemBlockPtr const& inputBlock,
                                  SharedAqlItemBlockPtr& outputBlock) {
-    auto numRegisters = inputBlock->getNrRegs();
+    auto numRegisters = inputBlock->numRegisters();
     outputBlock.reset(new AqlItemBlock(itemBlockManager, targetNumberOfRows,
                                        numRegisters + 1));
     // We do not add or remove anything, just move
     auto outputRegisters = RegIdSet{static_cast<RegisterId>(numRegisters)};
     size_t maxShadowRowDepth = 0;
-    for (size_t rowIdx = 0; rowIdx < inputBlock->size(); ++rowIdx) {
+    for (size_t rowIdx = 0; rowIdx < inputBlock->numRows(); ++rowIdx) {
       if (inputBlock->isShadowRow(rowIdx)) {
         maxShadowRowDepth =
             std::max(maxShadowRowDepth, inputBlock->getShadowRowDepth(rowIdx) + 1);
@@ -146,7 +146,7 @@ class AqlShadowItemRowTest : public ::testing::Test {
     AqlValue shadowRowData{VPackSlice::emptyArraySlice()};
 
     // Let this go out of scope before assertions, to make sure no references are bound here.
-    for (size_t rowIdx = 0; rowIdx < inputBlock->size(); ++rowIdx) {
+    for (size_t rowIdx = 0; rowIdx < inputBlock->numRows(); ++rowIdx) {
       ASSERT_FALSE(testee.isFull());
 
       // Transform relevant ShadowRows to new DataRows
@@ -174,7 +174,7 @@ class AqlShadowItemRowTest : public ::testing::Test {
     ASSERT_TRUE(testee.isFull());
     ASSERT_EQ(testee.numRowsWritten(), targetNumberOfRows);
     outputBlock = testee.stealBlock();
-    ASSERT_EQ(outputBlock->size(), targetNumberOfRows);
+    ASSERT_EQ(outputBlock->numRows(), targetNumberOfRows);
   }
 };
 
@@ -187,7 +187,7 @@ TEST_F(AqlShadowItemRowTest, inject_new_shadow_rows) {
   InsertNewShadowRowAfterEachDataRow(6, inputBlock, outputBlock);
   auto expected =
       VPackParser::fromJson("[[1,2,3],[4,5,6],[\"a\",\"b\",\"c\"]]");
-  for (size_t rowIdx = 0; rowIdx < outputBlock->size(); ++rowIdx) {
+  for (size_t rowIdx = 0; rowIdx < outputBlock->numRows(); ++rowIdx) {
     if (rowIdx % 2 == 0) {
       // Data Row Case
       ASSERT_FALSE(outputBlock->isShadowRow(rowIdx));
@@ -219,7 +219,7 @@ TEST_F(AqlShadowItemRowTest, consume_shadow_rows) {
 
   auto expected =
       VPackParser::fromJson("[[1,2,3,[]],[4,5,6,[]],[\"a\",\"b\",\"c\",[]]]");
-  for (size_t rowIdx = 0; rowIdx < outputBlock->size(); ++rowIdx) {
+  for (size_t rowIdx = 0; rowIdx < outputBlock->numRows(); ++rowIdx) {
     ASSERT_FALSE(outputBlock->isShadowRow(rowIdx));
     InputAqlItemRow testResult{outputBlock, rowIdx};
     AssertResultRow(testResult, expected->slice().at(rowIdx));
@@ -241,7 +241,7 @@ TEST_F(AqlShadowItemRowTest, multi_level_shadow_rows) {
   {
     auto expected =
         VPackParser::fromJson("[[1,2,3],[4,5,6],[\"a\",\"b\",\"c\"]]");
-    for (size_t rowIdx = 0; rowIdx < outputBlock->size(); ++rowIdx) {
+    for (size_t rowIdx = 0; rowIdx < outputBlock->numRows(); ++rowIdx) {
       switch (rowIdx % 3) {
         case 0:
           // First is always datarow
@@ -280,7 +280,7 @@ TEST_F(AqlShadowItemRowTest, multi_level_shadow_rows) {
   {
     auto expected = VPackParser::fromJson(
         "[[1,2,3,[]],[4,5,6,[]],[\"a\",\"b\",\"c\", []]]");
-    for (size_t rowIdx = 0; rowIdx < outputBlock->size(); ++rowIdx) {
+    for (size_t rowIdx = 0; rowIdx < outputBlock->numRows(); ++rowIdx) {
       switch (rowIdx % 2) {
         case 0:
           // First is always datarow
@@ -311,7 +311,7 @@ TEST_F(AqlShadowItemRowTest, multi_level_shadow_rows) {
   {
     auto expected = VPackParser::fromJson(
         "[[1,2,3,[]],[4,5,6,[]],[\"a\",\"b\",\"c\", []]]");
-    for (size_t rowIdx = 0; rowIdx < outputBlock->size(); ++rowIdx) {
+    for (size_t rowIdx = 0; rowIdx < outputBlock->numRows(); ++rowIdx) {
         ASSERT_FALSE(outputBlock->isShadowRow(rowIdx));
         InputAqlItemRow testResult{outputBlock, rowIdx};
         AssertResultRow(testResult, expected->slice().at(rowIdx));

--- a/tests/Aql/BlockCollector.cpp
+++ b/tests/Aql/BlockCollector.cpp
@@ -42,7 +42,7 @@ size_t BlockCollector::totalSize() const { return _totalSize; }
 RegisterId BlockCollector::nrRegs() const {
   TRI_ASSERT(_totalSize > 0);
   TRI_ASSERT(!_blocks.empty());
-  return _blocks[0]->getNrRegs();
+  return _blocks[0]->numRegisters();
 }
 
 void BlockCollector::clear() {
@@ -55,13 +55,13 @@ void BlockCollector::clear() {
 
 void BlockCollector::add(SharedAqlItemBlockPtr block) {
   TRI_ASSERT(block != nullptr);
-  TRI_ASSERT(block->size() > 0);
+  TRI_ASSERT(block->numRows() > 0);
 
   if (_blocks.capacity() == 0) {
     _blocks.reserve(8);
   }
   _blocks.push_back(block);
-  _totalSize += block->size();
+  _totalSize += block->numRows();
 }
 
 SharedAqlItemBlockPtr BlockCollector::steal() {

--- a/tests/Aql/ExecutionBlockImplTest.cpp
+++ b/tests/Aql/ExecutionBlockImplTest.cpp
@@ -435,7 +435,7 @@ TEST_P(ExecutionBlockImplExecuteSpecificTest, test_toplevel_unlimited_call) {
   EXPECT_EQ(state, ExecutionState::DONE);
   EXPECT_EQ(skipped.getSkipCount(), 0);
   EXPECT_NE(block, nullptr);
-  EXPECT_EQ(block->size(), 1);
+  EXPECT_EQ(block->numRows(), 1);
   // Once with empty, once with the line by Singleton
   EXPECT_EQ(nrCalls, 2);
 }
@@ -460,7 +460,7 @@ TEST_P(ExecutionBlockImplExecuteSpecificTest, test_toplevel_softlimit_call) {
   EXPECT_EQ(skipped.getSkipCount(), 0);
   // We produce one row
   ASSERT_NE(block, nullptr);
-  EXPECT_EQ(block->size(), 1);
+  EXPECT_EQ(block->numRows(), 1);
   // Once with empty, once with the line by Singleton
   EXPECT_EQ(nrCalls, 2);
 }
@@ -485,7 +485,7 @@ TEST_P(ExecutionBlockImplExecuteSpecificTest, test_toplevel_hardlimit_call) {
   EXPECT_EQ(skipped.getSkipCount(), 0);
   // We produce one row
   ASSERT_NE(block, nullptr);
-  EXPECT_EQ(block->size(), 1);
+  EXPECT_EQ(block->numRows(), 1);
   // Once with empty, once with the line by Singleton
   EXPECT_EQ(nrCalls, 2);
 }
@@ -571,7 +571,7 @@ TEST_P(ExecutionBlockImplExecuteSpecificTest, test_relevant_shadowrow_does_not_f
     EXPECT_EQ(state, ExecutionState::HASMORE);
     EXPECT_EQ(skipped.getSkipCount(), 0);
     ASSERT_NE(block, nullptr);
-    EXPECT_EQ(block->size(), ExecutionBlock::DefaultBatchSize);
+    EXPECT_EQ(block->numRows(), ExecutionBlock::DefaultBatchSize);
     EXPECT_FALSE(block->hasShadowRows());
   }
   {
@@ -580,7 +580,7 @@ TEST_P(ExecutionBlockImplExecuteSpecificTest, test_relevant_shadowrow_does_not_f
     EXPECT_EQ(state, ExecutionState::DONE);
     EXPECT_EQ(skipped.getSkipCount(), 0);
     ASSERT_NE(block, nullptr);
-    EXPECT_EQ(block->size(), 1);
+    EXPECT_EQ(block->numRows(), 1);
     EXPECT_TRUE(block->hasShadowRows());
     ASSERT_TRUE(block->isShadowRow(0));
     ShadowAqlItemRow shadow{block, 0};
@@ -620,7 +620,7 @@ TEST_P(ExecutionBlockImplExecuteSpecificTest, set_of_shadowrows_does_not_fit_in_
     EXPECT_EQ(state, ExecutionState::HASMORE);
     EXPECT_EQ(skipped.getSkipCount(), 0);
     ASSERT_NE(block, nullptr);
-    EXPECT_EQ(block->size(), ExecutionBlock::DefaultBatchSize);
+    EXPECT_EQ(block->numRows(), ExecutionBlock::DefaultBatchSize);
     EXPECT_FALSE(block->hasShadowRows());
   }
   {
@@ -629,7 +629,7 @@ TEST_P(ExecutionBlockImplExecuteSpecificTest, set_of_shadowrows_does_not_fit_in_
     EXPECT_EQ(state, ExecutionState::DONE);
     EXPECT_EQ(skipped.getSkipCount(), 0);
     ASSERT_NE(block, nullptr);
-    ASSERT_EQ(block->size(), 2);
+    ASSERT_EQ(block->numRows(), 2);
     EXPECT_TRUE(block->hasShadowRows());
     {
       ASSERT_TRUE(block->isShadowRow(0));
@@ -677,10 +677,10 @@ TEST_P(ExecutionBlockImplExecuteSpecificTest, set_of_shadowrows_does_not_fit_ful
     EXPECT_EQ(state, ExecutionState::HASMORE);
     EXPECT_EQ(skipped.getSkipCount(), 0);
     ASSERT_NE(block, nullptr);
-    EXPECT_EQ(block->size(), ExecutionBlock::DefaultBatchSize);
+    EXPECT_EQ(block->numRows(), ExecutionBlock::DefaultBatchSize);
     EXPECT_TRUE(block->hasShadowRows());
-    ASSERT_TRUE(block->isShadowRow(block->size() - 1));
-    ShadowAqlItemRow shadow{block, block->size() - 1};
+    ASSERT_TRUE(block->isShadowRow(block->numRows() - 1));
+    ShadowAqlItemRow shadow{block, block->numRows() - 1};
     EXPECT_EQ(shadow.getDepth(), 0);
   }
   {
@@ -689,7 +689,7 @@ TEST_P(ExecutionBlockImplExecuteSpecificTest, set_of_shadowrows_does_not_fit_ful
     EXPECT_EQ(state, ExecutionState::DONE);
     EXPECT_EQ(skipped.getSkipCount(), 0);
     ASSERT_NE(block, nullptr);
-    EXPECT_EQ(block->size(), 1);
+    EXPECT_EQ(block->numRows(), 1);
     EXPECT_TRUE(block->hasShadowRows());
     ASSERT_TRUE(block->isShadowRow(0));
     ShadowAqlItemRow shadow{block, 0};
@@ -1044,8 +1044,8 @@ class ExecutionBlockImplExecuteIntegrationTest
   auto AssertValueEquals(SharedAqlItemBlockPtr const& block, size_t row,
                          RegisterId reg, size_t expected) const -> void {
     ASSERT_NE(block, nullptr);
-    ASSERT_GT(block->size(), row);
-    ASSERT_GE(block->getNrRegs(), reg);
+    ASSERT_GT(block->numRows(), row);
+    ASSERT_GE(block->numRegisters(), reg);
     auto const& value = block->getValueReference(row, reg);
     ASSERT_TRUE(value.isNumber());
     EXPECT_EQ(static_cast<size_t>(value.toInt64()), expected);
@@ -1061,7 +1061,7 @@ class ExecutionBlockImplExecuteIntegrationTest
   auto AssertIsShadowRowOfDepth(SharedAqlItemBlockPtr const& block, size_t row,
                                 size_t expected) -> void {
     ASSERT_NE(block, nullptr);
-    ASSERT_GT(block->size(), row);
+    ASSERT_GT(block->numRows(), row);
     ASSERT_TRUE(block->isShadowRow(row));
     size_t val = block->getShadowRowDepth(row);
     EXPECT_EQ(val, expected);
@@ -1334,9 +1334,9 @@ class ExecutionBlockImplExecuteIntegrationTest
     }
     size_t limit =
         (std::min)(call.getLimit(), static_cast<size_t>(expected.length()) - offset);
-    if (result != nullptr && result->size() > numShadowRows) {
+    if (result != nullptr && result->numRows() > numShadowRows) {
       // GetSome part
-      EXPECT_EQ(limit, result->size() - numShadowRows);
+      EXPECT_EQ(limit, result->numRows() - numShadowRows);
       for (size_t i = 0; i < limit; ++i) {
         // The next have to match
         auto got = result->getValueReference(i, testReg).slice();
@@ -1759,7 +1759,7 @@ TEST_P(ExecutionBlockImplExecuteIntegrationTest, test_multiple_upstream_calls_pa
       }
 
       ASSERT_NE(block, nullptr);
-      ASSERT_EQ(block->size(), 1);
+      ASSERT_EQ(block->numRows(), 1);
       // Book-keeping for call.
       // We need to request data from above with the correct call.
       if (!skipped.nothingSkipped()) {
@@ -1885,7 +1885,7 @@ TEST_P(ExecutionBlockImplExecuteIntegrationTest, only_relevant_shadowRows) {
     // Cannot skip a shadowRow
     EXPECT_EQ(skipped.getSkipCount(), 0);
     ASSERT_NE(block, nullptr);
-    ASSERT_EQ(block->size(), 1);
+    ASSERT_EQ(block->numRows(), 1);
     EXPECT_TRUE(block->hasShadowRows());
     EXPECT_TRUE(block->isShadowRow(0));
     auto rowIndex = block->getShadowRowDepth(0);
@@ -1943,7 +1943,7 @@ TEST_P(ExecutionBlockImplExecuteIntegrationTest, input_and_relevant_shadowRow) {
     // Forward to shadowRow on hardLimit
     ValidateResult(builder, skipped, block, outReg, 1);
     ASSERT_TRUE(block != nullptr);
-    ValidateShadowRow(block, block->size() - 1, 0);
+    ValidateShadowRow(block, block->numRows() - 1, 0);
   }
 }
 
@@ -2001,8 +2001,8 @@ TEST_P(ExecutionBlockImplExecuteIntegrationTest, input_and_non_relevant_shadowRo
     ValidateResult(builder, skipped, block, outReg, 2);
     ASSERT_TRUE(block != nullptr);
     // Include both shadow rows
-    ValidateShadowRow(block, block->size() - 2, 0);
-    ValidateShadowRow(block, block->size() - 1, 1);
+    ValidateShadowRow(block, block->numRows() - 2, 0);
+    ValidateShadowRow(block, block->numRows() - 1, 1);
   }
 }
 
@@ -2089,7 +2089,7 @@ TEST_P(ExecutionBlockImplExecuteIntegrationTest, multiple_subqueries) {
         EXPECT_EQ(forwardSkipped.getSkipCount(), 0);
         // However there need to be two shadow rows
         ASSERT_NE(forwardBlock, nullptr);
-        ASSERT_EQ(forwardBlock->size(), 2);
+        ASSERT_EQ(forwardBlock->numRows(), 2);
         ValidateShadowRow(forwardBlock, 0, 0);
         ValidateShadowRow(forwardBlock, 1, 1);
       }
@@ -2108,8 +2108,8 @@ TEST_P(ExecutionBlockImplExecuteIntegrationTest, multiple_subqueries) {
       ValidateResult(subqueryData, skipped, block, 0, 2);
       ASSERT_NE(block, nullptr);
       // Include both shadow rows
-      ValidateShadowRow(block, block->size() - 2, 0);
-      ValidateShadowRow(block, block->size() - 1, 1);
+      ValidateShadowRow(block, block->numRows() - 2, 0);
+      ValidateShadowRow(block, block->numRows() - 1, 1);
     }
   }
 }
@@ -2249,10 +2249,10 @@ TEST_P(ExecutionBlockImplExecuteIntegrationTest, empty_subquery) {
     ASSERT_NE(block, nullptr);
     if (skip) {
       EXPECT_EQ(skipped.getSkipCount(), 1);
-      EXPECT_EQ(block->size(), 2);
+      EXPECT_EQ(block->numRows(), 2);
     } else {
       EXPECT_EQ(skipped.getSkipCount(), 0);
-      EXPECT_EQ(block->size(), 3);
+      EXPECT_EQ(block->numRows(), 3);
     }
     size_t row = 0;
     if (!skip) {
@@ -2288,7 +2288,7 @@ TEST_P(ExecutionBlockImplExecuteIntegrationTest, empty_subquery) {
     EXPECT_EQ(state, ExecutionState::HASMORE);
     ASSERT_NE(block, nullptr);
     EXPECT_EQ(skipped.getSkipCount(), 0);
-    EXPECT_EQ(block->size(), 1);
+    EXPECT_EQ(block->numRows(), 1);
     size_t row = 0;
     AssertIsShadowRowOfDepth(block, row, 0);
     AssertValueEquals(block, row, depth1Reg, 4);
@@ -2315,7 +2315,7 @@ TEST_P(ExecutionBlockImplExecuteIntegrationTest, empty_subquery) {
     EXPECT_EQ(state, ExecutionState::DONE);
     ASSERT_NE(block, nullptr);
     EXPECT_EQ(skipped.getSkipCount(), 0);
-    EXPECT_EQ(block->size(), 2);
+    EXPECT_EQ(block->numRows(), 2);
     size_t row = 0;
     AssertIsShadowRowOfDepth(block, row, 0);
     AssertValueEquals(block, row, depth1Reg, 5);

--- a/tests/Aql/ExecutorTestHelper.cpp
+++ b/tests/Aql/ExecutorTestHelper.cpp
@@ -37,18 +37,18 @@ auto asserthelper::RowsAreIdentical(SharedAqlItemBlockPtr actual, size_t actualR
                                     std::optional<std::vector<RegisterId>> const& onlyCompareRegisters)
     -> bool {
   if (onlyCompareRegisters) {
-    if (actual->getNrRegs() < onlyCompareRegisters->size()) {
+    if (actual->numRegisters() < onlyCompareRegisters->size()) {
       // Registers do not match
       return false;
     }
   } else {
-    if (actual->getNrRegs() != expected->getNrRegs()) {
+    if (actual->numRegisters() != expected->numRegisters()) {
       // Registers do not match
       return false;
     }
   }
 
-  for (RegisterId reg = 0; reg < expected->getNrRegs(); ++reg) {
+  for (RegisterId reg = 0; reg < expected->numRegisters(); ++reg) {
     auto const& x =
         actual->getValueReference(actualRow, onlyCompareRegisters
                                                  ? onlyCompareRegisters->at(reg)
@@ -81,16 +81,16 @@ auto asserthelper::ValidateBlocksAreEqual(SharedAqlItemBlockPtr actual,
     -> void {
   ASSERT_NE(expected, nullptr);
   ASSERT_NE(actual, nullptr);
-  EXPECT_EQ(actual->size(), expected->size());
-  auto outRegs = (std::min)(actual->getNrRegs(), expected->getNrRegs());
+  EXPECT_EQ(actual->numRows(), expected->numRows());
+  auto outRegs = (std::min)(actual->numRegisters(), expected->numRegisters());
   if (onlyCompareRegisters) {
     outRegs = onlyCompareRegisters->size();
-    ASSERT_GE(actual->getNrRegs(), outRegs);
+    ASSERT_GE(actual->numRegisters(), outRegs);
   } else {
-    EXPECT_EQ(actual->getNrRegs(), expected->getNrRegs());
+    EXPECT_EQ(actual->numRegisters(), expected->numRegisters());
   }
 
-  for (size_t row = 0; row < (std::min)(actual->size(), expected->size()); ++row) {
+  for (size_t row = 0; row < (std::min)(actual->numRows(), expected->numRows()); ++row) {
     // Compare registers
     for (RegisterId reg = 0; reg < outRegs; ++reg) {
       RegisterId actualRegister =
@@ -128,20 +128,20 @@ auto asserthelper::ValidateBlocksAreEqualUnordered(
       << "unordered validation does not support shadowRows yet. If you need "
          "this please implement!";
 
-  EXPECT_EQ(actual->size() + numRowsNotContained, expected->size());
+  EXPECT_EQ(actual->numRows() + numRowsNotContained, expected->numRows());
 
-  auto outRegs = (std::min)(actual->getNrRegs(), expected->getNrRegs());
+  auto outRegs = (std::min)(actual->numRegisters(), expected->numRegisters());
   if (onlyCompareRegisters) {
     outRegs = onlyCompareRegisters->size();
-    ASSERT_GE(actual->getNrRegs(), outRegs);
+    ASSERT_GE(actual->numRegisters(), outRegs);
   } else {
-    EXPECT_EQ(actual->getNrRegs(), expected->getNrRegs());
+    EXPECT_EQ(actual->numRegisters(), expected->numRegisters());
   }
 
   matchedRows.clear();
 
-  for (size_t expectedRow = 0; expectedRow < expected->size(); ++expectedRow) {
-    for (size_t actualRow = 0; actualRow < actual->size(); ++actualRow) {
+  for (size_t expectedRow = 0; expectedRow < expected->numRows(); ++expectedRow) {
+    for (size_t actualRow = 0; actualRow < actual->numRows(); ++actualRow) {
       if (RowsAreIdentical(actual, actualRow, expected, expectedRow, onlyCompareRegisters)) {
         auto const& [unused, inserted] = matchedRows.emplace(expectedRow);
         if (inserted) {
@@ -152,10 +152,10 @@ auto asserthelper::ValidateBlocksAreEqualUnordered(
     }
   }
 
-  if (matchedRows.size() + numRowsNotContained < expected->size()) {
+  if (matchedRows.size() + numRowsNotContained < expected->numRows()) {
     // Did not find all rows.
     // This is for reporting only:
-    for (size_t expectedRow = 0; expectedRow < expected->size(); ++expectedRow) {
+    for (size_t expectedRow = 0; expectedRow < expected->numRows(); ++expectedRow) {
       if (matchedRows.find(expectedRow) == matchedRows.end()) {
         InputAqlItemRow missing(expected, expectedRow);
         velocypack::Options vpackOptions;

--- a/tests/Aql/ExecutorTestHelper.h
+++ b/tests/Aql/ExecutorTestHelper.h
@@ -308,7 +308,7 @@ struct ExecutorTestHelper {
         skippedTotal.merge(skipped, false);
         call.didSkip(skipped.getSkipCount());
         if (result != nullptr) {
-          call.didProduce(result->size());
+          call.didProduce(result->numRows());
           allResults.add(result);
         }
         call.resetSkipCount();

--- a/tests/Aql/GatherExecutorCommonTest.cpp
+++ b/tests/Aql/GatherExecutorCommonTest.cpp
@@ -342,7 +342,7 @@ class CommonGatherExecutorTest
 
   auto assertResultValid(SharedAqlItemBlockPtr block, ResultMaps& result) -> void {
     if (block != nullptr) {
-      for (size_t row = 0; row < block->size(); ++row) {
+      for (size_t row = 0; row < block->numRows(); ++row) {
         if (block->isShadowRow(row)) {
           ShadowAqlItemRow in{block, row};
           auto val = in.getValue(0);

--- a/tests/Aql/IdExecutorTest.cpp
+++ b/tests/Aql/IdExecutorTest.cpp
@@ -198,7 +198,7 @@ TEST_P(IdExecutorTestCombiner, test_produce_datarange_constFetcher) {
   auto result = outputRow.stealBlock();
   if (input > 0) {
     ASSERT_NE(result, nullptr);
-    ASSERT_EQ(result->size(), input);
+    ASSERT_EQ(result->numRows(), input);
     for (size_t i = 0; i < input; ++i) {
       auto val = result->getValueReference(i, 0);
       ASSERT_TRUE(val.isNumber());
@@ -278,7 +278,7 @@ TEST_F(IdExecutionBlockTest, test_initialize_cursor_get) {
                                                       std::move(executorInfos)};
   auto inputBlock = buildBlock<1>(itemBlockManager, {{0}, {1}, {2}});
 
-  for (size_t i = 0; i < inputBlock->size(); ++i) {
+  for (size_t i = 0; i < inputBlock->numRows(); ++i) {
     InputAqlItemRow input{inputBlock, i};
     ASSERT_TRUE(input.isInitialized());
     {
@@ -304,7 +304,7 @@ TEST_F(IdExecutionBlockTest, test_initialize_cursor_get) {
       EXPECT_EQ(state, ExecutionState::DONE);
       EXPECT_EQ(skipped.getSkipCount(), 0);
       ASSERT_NE(block, nullptr);
-      EXPECT_EQ(block->size(), 1);
+      EXPECT_EQ(block->numRows(), 1);
       auto const& val = block->getValueReference(0, 0);
       ASSERT_TRUE(val.isNumber());
       EXPECT_EQ(static_cast<size_t>(val.toInt64()), i);
@@ -322,7 +322,7 @@ TEST_F(IdExecutionBlockTest, test_initialize_cursor_skip) {
                                                       std::move(executorInfos)};
   auto inputBlock = buildBlock<1>(itemBlockManager, {{0}, {1}, {2}});
 
-  for (size_t i = 0; i < inputBlock->size(); ++i) {
+  for (size_t i = 0; i < inputBlock->numRows(); ++i) {
     InputAqlItemRow input{inputBlock, i};
     ASSERT_TRUE(input.isInitialized());
     {
@@ -364,7 +364,7 @@ TEST_F(IdExecutionBlockTest, test_initialize_cursor_fullCount) {
                                                       std::move(executorInfos)};
   auto inputBlock = buildBlock<1>(itemBlockManager, {{0}, {1}, {2}});
 
-  for (size_t i = 0; i < inputBlock->size(); ++i) {
+  for (size_t i = 0; i < inputBlock->numRows(); ++i) {
     InputAqlItemRow input{inputBlock, i};
     ASSERT_TRUE(input.isInitialized());
     {

--- a/tests/Aql/InputRangeTest.cpp
+++ b/tests/Aql/InputRangeTest.cpp
@@ -78,7 +78,7 @@ class InputRangeTest : public AqlExecutorTestCase<> {
         chosenRows.emplace(i, std::vector<size_t>{});
       }
 
-      for (size_t i = 0; i < block->size(); ++i) {
+      for (size_t i = 0; i < block->numRows(); ++i) {
         if (block->isShadowRow(i)) {
           // ShadowRows need to be added to all Clients
           for (auto& [key, value] : chosenRows) {
@@ -97,9 +97,9 @@ class InputRangeTest : public AqlExecutorTestCase<> {
           auto copiedBlock = block->slice(chosen, 0, chosen.size());
           if (index != 0) {
             // Simulate that shadowRows have been "moved"  by clearing their dataRegisters
-            for (size_t i = 0; i < copiedBlock->size(); ++i) {
+            for (size_t i = 0; i < copiedBlock->numRows(); ++i) {
               if (copiedBlock->isShadowRow(i)) {
-                for (RegisterId r = 0; r < copiedBlock->getNrRegs(); ++r) {
+                for (RegisterId r = 0; r < copiedBlock->numRegisters(); ++r) {
                   copiedBlock->destroyValue(i, r);
                 }
 

--- a/tests/Aql/KShortestPathsExecutorTest.cpp
+++ b/tests/Aql/KShortestPathsExecutorTest.cpp
@@ -235,7 +235,7 @@ class KShortestPathsExecutorTest
     auto block = buildBlock<2>(itemBlockManager, std::move(parameters._inputMatrix));
 
     // We should always only call the finder at most for all input rows
-    ASSERT_LE(calledWith.size(), block->size());
+    ASSERT_LE(calledWith.size(), block->numRows());
 
     auto blockIndex = size_t{0};
     for (auto const& input : calledWith) {
@@ -282,7 +282,7 @@ class KShortestPathsExecutorTest
     auto expectedRowsIndex = size_t{skippedInitial};
     for (auto const& block : results) {
       if (block != nullptr) {
-        for (size_t blockIndex = 0; blockIndex < block->size(); ++blockIndex, ++expectedRowsIndex) {
+        for (size_t blockIndex = 0; blockIndex < block->numRows(); ++blockIndex, ++expectedRowsIndex) {
           AqlValue value =
               block->getValue(blockIndex, executorInfos.getOutputRegister());
           EXPECT_TRUE(value.isArray());

--- a/tests/Aql/RowFetcherHelper.cpp
+++ b/tests/Aql/RowFetcherHelper.cpp
@@ -65,7 +65,7 @@ SingleRowFetcherHelper<passBlocksThrough>::SingleRowFetcherHelper(
     bool const returnsWaiting, ::arangodb::aql::SharedAqlItemBlockPtr input)
     : SingleRowFetcher<passBlocksThrough>(),
       _returnsWaiting(returnsWaiting),
-      _nrItems(input == nullptr ? 0 : input->size()),
+      _nrItems(input == nullptr ? 0 : input->numRows()),
       _blockSize(blockSize),
       _itemBlockManager(manager),
       _itemBlock(std::move(input)),

--- a/tests/Aql/ScatterExecutorTest.cpp
+++ b/tests/Aql/ScatterExecutorTest.cpp
@@ -130,9 +130,9 @@ class SharedScatterExecutionBlockTest {
   auto ValidateBlocksAreEqual(SharedAqlItemBlockPtr actual, SharedAqlItemBlockPtr expected) {
     ASSERT_NE(expected, nullptr);
     ASSERT_NE(actual, nullptr);
-    EXPECT_EQ(actual->size(), expected->size());
-    EXPECT_EQ(actual->getNrRegs(), 1);
-    for (size_t i = 0; i < (std::min)(actual->size(), expected->size()); ++i) {
+    EXPECT_EQ(actual->numRows(), expected->numRows());
+    EXPECT_EQ(actual->numRegisters(), 1);
+    for (size_t i = 0; i < (std::min)(actual->numRows(), expected->numRows()); ++i) {
       if (actual->isShadowRow(i)) {
         ASSERT_TRUE(expected->isShadowRow(i))
             << "Row " << i << " is not supposed to be a shadow row.";

--- a/tests/Aql/ShortestPathExecutorTest.cpp
+++ b/tests/Aql/ShortestPathExecutorTest.cpp
@@ -314,7 +314,7 @@ class ShortestPathExecutorTest
     auto block = buildBlock<2>(itemBlockManager, std::move(parameters._inputMatrix));
 
     // We should always only call the finder at most for all input rows
-    ASSERT_LE(pathsQueriedBetween.size(), block->size());
+    ASSERT_LE(pathsQueriedBetween.size(), block->numRows());
 
     auto blockIndex = size_t{0};
     for (auto const& input : pathsQueriedBetween) {
@@ -375,7 +375,7 @@ class ShortestPathExecutorTest
     for (auto const& block : results) {
       if (block != nullptr) {
         ASSERT_NE(block, nullptr);
-        for (size_t blockIndex = 0; blockIndex < block->size(); ++blockIndex, ++expectedRowsIndex) {
+        for (size_t blockIndex = 0; blockIndex < block->numRows(); ++blockIndex, ++expectedRowsIndex) {
           if (executorInfos.usesOutputRegister(ShortestPathExecutorInfos::VERTEX)) {
             AqlValue value =
                 block->getValue(blockIndex, executorInfos.getOutputRegister(

--- a/tests/Aql/SingleRowFetcherTest.cpp
+++ b/tests/Aql/SingleRowFetcherTest.cpp
@@ -477,7 +477,7 @@ TEST_F(SingleRowFetcherTestPassBlocks,
     std::tie(state, row) = testee.fetchRow();
     ASSERT_EQ(state, ExecutionState::DONE);
     ASSERT_TRUE(row);
-    ASSERT_EQ(row.getNrRegisters(), 1);
+    ASSERT_EQ(row.getNumRegisters(), 1);
     ASSERT_EQ(row.getValue(0).slice().getInt(), 42);
   }  // testee is destroyed here
   // testee must be destroyed before verify, because it may call returnBlock
@@ -500,7 +500,7 @@ TEST_F(SingleRowFetcherTestDoNotPassBlocks,
     std::tie(state, row) = testee.fetchRow();
     ASSERT_EQ(state, ExecutionState::DONE);
     ASSERT_TRUE(row);
-    ASSERT_EQ(row.getNrRegisters(), 1);
+    ASSERT_EQ(row.getNumRegisters(), 1);
     ASSERT_EQ(row.getValue(0).slice().getInt(), 42);
   }  // testee is destroyed here
   // testee must be destroyed before verify, because it may call returnBlock
@@ -524,7 +524,7 @@ TEST_F(SingleRowFetcherTestPassBlocks,
     std::tie(state, row) = testee.fetchRow();
     ASSERT_EQ(state, ExecutionState::HASMORE);
     ASSERT_TRUE(row);
-    ASSERT_EQ(row.getNrRegisters(), 1);
+    ASSERT_EQ(row.getNumRegisters(), 1);
     ASSERT_EQ(row.getValue(0).slice().getInt(), 42);
 
     std::tie(state, row) = testee.fetchRow();
@@ -552,7 +552,7 @@ TEST_F(SingleRowFetcherTestDoNotPassBlocks,
     std::tie(state, row) = testee.fetchRow();
     ASSERT_EQ(state, ExecutionState::HASMORE);
     ASSERT_TRUE(row);
-    ASSERT_EQ(row.getNrRegisters(), 1);
+    ASSERT_EQ(row.getNumRegisters(), 1);
     ASSERT_EQ(row.getValue(0).slice().getInt(), 42);
 
     std::tie(state, row) = testee.fetchRow();
@@ -584,7 +584,7 @@ TEST_F(SingleRowFetcherTestPassBlocks,
     std::tie(state, row) = testee.fetchRow();
     ASSERT_EQ(state, ExecutionState::DONE);
     ASSERT_TRUE(row);
-    ASSERT_EQ(row.getNrRegisters(), 1);
+    ASSERT_EQ(row.getNumRegisters(), 1);
     ASSERT_EQ(row.getValue(0).slice().getInt(), 42);
   }  // testee is destroyed here
   // testee must be destroyed before verify, because it may call returnBlock
@@ -612,7 +612,7 @@ TEST_F(SingleRowFetcherTestDoNotPassBlocks,
     std::tie(state, row) = testee.fetchRow();
     ASSERT_EQ(state, ExecutionState::DONE);
     ASSERT_TRUE(row);
-    ASSERT_EQ(row.getNrRegisters(), 1);
+    ASSERT_EQ(row.getNumRegisters(), 1);
     ASSERT_EQ(row.getValue(0).slice().getInt(), 42);
   }  // testee is destroyed here
   // testee must be destroyed before verify, because it may call returnBlock
@@ -641,7 +641,7 @@ TEST_F(SingleRowFetcherTestPassBlocks,
     std::tie(state, row) = testee.fetchRow();
     ASSERT_EQ(state, ExecutionState::HASMORE);
     ASSERT_TRUE(row);
-    ASSERT_EQ(row.getNrRegisters(), 1);
+    ASSERT_EQ(row.getNumRegisters(), 1);
     ASSERT_EQ(row.getValue(0).slice().getInt(), 42);
 
     std::tie(state, row) = testee.fetchRow();
@@ -674,7 +674,7 @@ TEST_F(SingleRowFetcherTestDoNotPassBlocks,
     std::tie(state, row) = testee.fetchRow();
     ASSERT_EQ(state, ExecutionState::HASMORE);
     ASSERT_TRUE(row);
-    ASSERT_EQ(row.getNrRegisters(), 1);
+    ASSERT_EQ(row.getNumRegisters(), 1);
     ASSERT_EQ(row.getValue(0).slice().getInt(), 42);
 
     std::tie(state, row) = testee.fetchRow();
@@ -710,14 +710,14 @@ TEST_F(SingleRowFetcherTestPassBlocks, multiple_blocks_upstream_producer_doesnt_
       std::tie(state, row) = testee.fetchRow();
       ASSERT_EQ(state, ExecutionState::HASMORE);
       ASSERT_TRUE(row);
-      ASSERT_EQ(row.getNrRegisters(), 1);
+      ASSERT_EQ(row.getNumRegisters(), 1);
       ASSERT_EQ(row.getValue(0).slice().getInt(), rowIdxAndValue);
     }
     rowIdxAndValue = 6;
     std::tie(state, row) = testee.fetchRow();
     ASSERT_EQ(state, ExecutionState::DONE);
     ASSERT_TRUE(row);
-    ASSERT_EQ(row.getNrRegisters(), 1);
+    ASSERT_EQ(row.getNumRegisters(), 1);
     ASSERT_EQ(row.getValue(0).slice().getInt(), rowIdxAndValue);
   }  // testee is destroyed here
   // testee must be destroyed before verify, because it may call returnBlock
@@ -746,14 +746,14 @@ TEST_F(SingleRowFetcherTestDoNotPassBlocks, multiple_blocks_upstream_producer_do
       std::tie(state, row) = testee.fetchRow();
       ASSERT_EQ(state, ExecutionState::HASMORE);
       ASSERT_TRUE(row);
-      ASSERT_EQ(row.getNrRegisters(), 1);
+      ASSERT_EQ(row.getNumRegisters(), 1);
       ASSERT_EQ(row.getValue(0).slice().getInt(), rowIdxAndValue);
     }
     rowIdxAndValue = 6;
     std::tie(state, row) = testee.fetchRow();
     ASSERT_EQ(state, ExecutionState::DONE);
     ASSERT_TRUE(row);
-    ASSERT_EQ(row.getNrRegisters(), 1);
+    ASSERT_EQ(row.getNumRegisters(), 1);
     ASSERT_EQ(row.getValue(0).slice().getInt(), rowIdxAndValue);
   }  // testee is destroyed here
   // testee must be destroyed before verify, because it may call returnBlock
@@ -791,7 +791,7 @@ TEST_F(SingleRowFetcherTestPassBlocks, multiple_blocks_upstream_producer_waits) 
       std::tie(state, row) = testee.fetchRow();
       ASSERT_EQ(state, ExecutionState::HASMORE);
       ASSERT_TRUE(row);
-      ASSERT_EQ(row.getNrRegisters(), 1);
+      ASSERT_EQ(row.getNumRegisters(), 1);
       ASSERT_EQ(row.getValue(0).slice().getInt(), rowIdxAndValue);
     }
     rowIdxAndValue = 6;
@@ -803,7 +803,7 @@ TEST_F(SingleRowFetcherTestPassBlocks, multiple_blocks_upstream_producer_waits) 
     std::tie(state, row) = testee.fetchRow();
     ASSERT_EQ(state, ExecutionState::DONE);
     ASSERT_TRUE(row);
-    ASSERT_EQ(row.getNrRegisters(), 1);
+    ASSERT_EQ(row.getNumRegisters(), 1);
     ASSERT_EQ(row.getValue(0).slice().getInt(), rowIdxAndValue);
   }  // testee is destroyed here
   // testee must be destroyed before verify, because it may call returnBlock
@@ -841,7 +841,7 @@ TEST_F(SingleRowFetcherTestDoNotPassBlocks, multiple_blocks_upstream_producer_wa
       std::tie(state, row) = testee.fetchRow();
       ASSERT_EQ(state, ExecutionState::HASMORE);
       ASSERT_TRUE(row);
-      ASSERT_EQ(row.getNrRegisters(), 1);
+      ASSERT_EQ(row.getNumRegisters(), 1);
       ASSERT_EQ(row.getValue(0).slice().getInt(), rowIdxAndValue);
     }
     rowIdxAndValue = 6;
@@ -853,7 +853,7 @@ TEST_F(SingleRowFetcherTestDoNotPassBlocks, multiple_blocks_upstream_producer_wa
     std::tie(state, row) = testee.fetchRow();
     ASSERT_EQ(state, ExecutionState::DONE);
     ASSERT_TRUE(row);
-    ASSERT_EQ(row.getNrRegisters(), 1);
+    ASSERT_EQ(row.getNumRegisters(), 1);
     ASSERT_EQ(row.getValue(0).slice().getInt(), rowIdxAndValue);
   }  // testee is destroyed here
   // testee must be destroyed before verify, because it may call returnBlock
@@ -892,7 +892,7 @@ TEST_F(SingleRowFetcherTestPassBlocks,
       std::tie(state, row) = testee.fetchRow();
       ASSERT_EQ(state, ExecutionState::HASMORE);
       ASSERT_TRUE(row);
-      ASSERT_EQ(row.getNrRegisters(), 1);
+      ASSERT_EQ(row.getNumRegisters(), 1);
       ASSERT_EQ(row.getValue(0).slice().getInt(), rowIdxAndValue);
     }
     std::tie(state, row) = testee.fetchRow();
@@ -935,7 +935,7 @@ TEST_F(SingleRowFetcherTestDoNotPassBlocks,
       std::tie(state, row) = testee.fetchRow();
       ASSERT_EQ(state, ExecutionState::HASMORE);
       ASSERT_TRUE(row);
-      ASSERT_EQ(row.getNrRegisters(), 1);
+      ASSERT_EQ(row.getNumRegisters(), 1);
       ASSERT_EQ(row.getValue(0).slice().getInt(), rowIdxAndValue);
     }
     std::tie(state, row) = testee.fetchRow();

--- a/tests/Aql/SortedCollectExecutorTest.cpp
+++ b/tests/Aql/SortedCollectExecutorTest.cpp
@@ -244,7 +244,7 @@ TEST_F(SortedCollectExecutorTestRowsUpstream, producer_2) {
   AqlItemBlockInputRange inputRange(ExecutorState::DONE, 0, inputBlock, 0);
 
   SharedAqlItemBlockPtr outputBlock =
-      itemBlockManager.requestBlock(inputBlock->size(),
+      itemBlockManager.requestBlock(inputBlock->numRows(),
                                     registerInfos.numberOfOutputRegisters());
   OutputAqlItemRow result(outputBlock, registerInfos.getOutputRegisters(),
                           registerInfos.registersToKeep(),
@@ -265,7 +265,7 @@ TEST_F(SortedCollectExecutorTestRowsUpstream, producer_2) {
     auto [state, stats, upstreamCall] = testee.produceRows(inputRange, result);
     ASSERT_EQ(ExecutorState::DONE, state);
     ASSERT_EQ(clientCall.fullCount, upstreamCall.fullCount);
-    ASSERT_EQ(inputBlock->size(), result.numRowsWritten());
+    ASSERT_EQ(inputBlock->numRows(), result.numRowsWritten());
     ASSERT_FALSE(result.produced());
   }
 
@@ -297,7 +297,7 @@ TEST_F(SortedCollectExecutorTestRowsUpstream, producer_3) {
   AqlItemBlockInputRange inputRange(ExecutorState::DONE, 0, inputBlock, 0);
 
   SharedAqlItemBlockPtr outputBlock =
-      itemBlockManager.requestBlock(inputBlock->size(),
+      itemBlockManager.requestBlock(inputBlock->numRows(),
                                     registerInfos.numberOfOutputRegisters());
   OutputAqlItemRow result(outputBlock, registerInfos.getOutputRegisters(),
                           registerInfos.registersToKeep(),
@@ -349,7 +349,7 @@ TEST_F(SortedCollectExecutorTestRowsUpstream, producer_4) {
   AqlItemBlockInputRange inputRange(ExecutorState::DONE, 0, inputBlock, 0);
 
   SharedAqlItemBlockPtr outputBlock =
-      itemBlockManager.requestBlock(inputBlock->size(),
+      itemBlockManager.requestBlock(inputBlock->numRows(),
                                     registerInfos.numberOfOutputRegisters());
   OutputAqlItemRow result(outputBlock, registerInfos.getOutputRegisters(),
                           registerInfos.registersToKeep(),
@@ -426,7 +426,7 @@ TEST(SortedCollectExecutorTestRowsUpstreamCount, test) {
   AqlItemBlockInputRange inputRange(ExecutorState::DONE, 0, inputBlock, 0);
 
   SharedAqlItemBlockPtr outputBlock =
-      itemBlockManager.requestBlock(inputBlock->size(),
+      itemBlockManager.requestBlock(inputBlock->numRows(),
                                     registerInfos.numberOfOutputRegisters());
   OutputAqlItemRow result(outputBlock, registerInfos.getOutputRegisters(),
                           registerInfos.registersToKeep(),
@@ -527,7 +527,7 @@ TEST(SortedCollectExecutorTestRowsUpstreamCountStrings, test) {
   AqlItemBlockInputRange inputRange(ExecutorState::DONE, 0, inputBlock, 0);
 
   SharedAqlItemBlockPtr outputBlock =
-      itemBlockManager.requestBlock(inputBlock->size(),
+      itemBlockManager.requestBlock(inputBlock->numRows(),
                                     registerInfos.numberOfOutputRegisters());
   OutputAqlItemRow result(outputBlock, registerInfos.getOutputRegisters(),
                           registerInfos.registersToKeep(),
@@ -706,7 +706,7 @@ TEST_F(SortedCollectExecutorTestSkip, skip_2) {
 
   {
     SharedAqlItemBlockPtr outputBlock =
-        itemBlockManager.requestBlock(inputBlock->size(),
+        itemBlockManager.requestBlock(inputBlock->numRows(),
                                       registerInfos.numberOfOutputRegisters());
     OutputAqlItemRow result(outputBlock, registerInfos.getOutputRegisters(),
                             registerInfos.registersToKeep(),
@@ -828,7 +828,7 @@ TEST_F(SortedCollectExecutorTestSkip, skip_4) {
 
   {
     SharedAqlItemBlockPtr outputBlock =
-        itemBlockManager.requestBlock(inputBlock->size(),
+        itemBlockManager.requestBlock(inputBlock->numRows(),
                                       registerInfos.numberOfOutputRegisters());
     OutputAqlItemRow result(outputBlock, registerInfos.getOutputRegisters(),
                             registerInfos.registersToKeep(),
@@ -843,7 +843,7 @@ TEST_F(SortedCollectExecutorTestSkip, skip_4) {
 
   {
     SharedAqlItemBlockPtr outputBlock =
-        itemBlockManager.requestBlock(inputBlock->size(),
+        itemBlockManager.requestBlock(inputBlock->numRows(),
                                       registerInfos.numberOfOutputRegisters());
     OutputAqlItemRow result(outputBlock, registerInfos.getOutputRegisters(),
                             registerInfos.registersToKeep(),
@@ -900,7 +900,7 @@ TEST_F(SortedCollectExecutorTestSkip, skip_5) {
 
   {
     SharedAqlItemBlockPtr outputBlock =
-        itemBlockManager.requestBlock(inputBlock->size(),
+        itemBlockManager.requestBlock(inputBlock->numRows(),
                                       registerInfos.numberOfOutputRegisters());
     OutputAqlItemRow result(outputBlock, registerInfos.getOutputRegisters(),
                             registerInfos.registersToKeep(),

--- a/tests/Aql/SubqueryEndExecutorTest.cpp
+++ b/tests/Aql/SubqueryEndExecutorTest.cpp
@@ -60,9 +60,9 @@ class SubqueryEndExecutorTest : public ::testing::Test {
                       std::unordered_map<size_t, uint64_t> const& shadowRows) const {
     auto block = itemRow.stealBlock();
 
-    ASSERT_EQ(expectedStrings.size(), block->size());
+    ASSERT_EQ(expectedStrings.size(), block->numRows());
 
-    for (size_t rowIdx = 0; rowIdx < block->size(); rowIdx++) {
+    for (size_t rowIdx = 0; rowIdx < block->numRows(); rowIdx++) {
       if (block->isShadowRow(rowIdx)) {
         ShadowAqlItemRow shadow{block, rowIdx};
 
@@ -77,7 +77,7 @@ class SubqueryEndExecutorTest : public ::testing::Test {
             << "expected row " << rowIdx << " to be a shadow row";
 
         InputAqlItemRow input{block, rowIdx};
-        for (unsigned int colIdx = 0; colIdx < block->getNrRegs(); colIdx++) {
+        for (unsigned int colIdx = 0; colIdx < block->numRegisters(); colIdx++) {
           auto expected = VPackParser::fromJson(expectedStrings.at(rowIdx).at(colIdx));
           auto value = input.getValue(RegisterId{colIdx}).slice();
           EXPECT_TRUE(VelocyPackHelper::equal(value, expected->slice(), false))

--- a/tests/Aql/WaitingExecutionBlockMock.cpp
+++ b/tests/Aql/WaitingExecutionBlockMock.cpp
@@ -48,7 +48,7 @@ static auto blocksToInfos(std::deque<SharedAqlItemBlockPtr> const& blocks) -> Re
   for (auto const& b : blocks) {
     if (b != nullptr) {
       // Find the first non-nullptr block
-      regs = b->getNrRegs();
+      regs = b->numRegisters();
 
       break;
     }
@@ -142,7 +142,7 @@ std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> WaitingExecutionBl
     if (result != nullptr && !result->hasShadowRows()) {
       // Count produced rows
       auto& modCall = stack.modifyTopCall();
-      modCall.didProduce(result->size());
+      modCall.didProduce(result->numRows());
     }
 
     if (!skipped.nothingSkipped()) {

--- a/tests/js/server/aql/aql-modify-subqueries.js
+++ b/tests/js/server/aql/aql-modify-subqueries.js
@@ -1864,9 +1864,6 @@ function ahuacatlGeneratedSuite() {
       `;
       const resNoSplice = db._query(q, {}, deactivateSplice);
       const resSplice = db._query(q, {}, activateSplice);
-      require("internal").print(
-        `Splice: ${resSplice.getExtra().stats.writesExecuted} vs. NoSplice: ${resNoSplice.getExtra().stats.writesExecuted}`
-      );
       
       assertEqual(resSplice.getExtra().stats.writesExecuted, resNoSplice.getExtra().stats.writesExecuted);
       assertEqual(resSplice.toArray().length, resNoSplice.toArray().length);


### PR DESCRIPTION
### Scope & Purpose

Introduce `_numEffectiveRows` for AqlItemBlock, which keeps track of the maximum modified (i.e. writtenTo) row number in the AqlItemBlock.
It is updated on every write, and read back when mass operations, such as cleanup or copying, or executed for all rows of the block. The idea is that such operations can be saved for rows that are known to be empty anyway.

This PR also changes the misleading instance variables names `AqlItemBlock::_nrItems` and `AqlItemBlock::_nrRegs` to `AqlItemBlock::_numRows` and `AqlItemBlock::_numRegisters`, and renames the `size()` method to `numRows()`.

- [ ] :hankey: Bugfix 
- [x] :pizza: New feature 
- [x] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [x] Backports required for: the non-renaming part can be backported to 3.7 if it turns out to be working.

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] This change is already covered by existing tests, such as *(please describe tests)*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11542/