### PR TITLE
Bug fix/do not reclaim shard ownership.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 v3.5.6 (XXXX-XX-XX)
 -------------------
 
+* Fixed: During a move-shard job which moves the leader there is a
+  situation in which the old owner of a shard can reclaim ownership
+  (after having resigned already), with a small race where it allows to
+  write documents only locally, but then continue the move-shard to a
+  server without those documents. An additional bug in the MoveShard
+  Supervision job would then leave the shard in a bad configuration
+  with a resigned leader permanently in charge.
+
 * Fixed a problem with potentially lost updates because a failover could happen
   at a wrong time or a restarted leader could come back at an unlucky time.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,13 +1,12 @@
 v3.5.6 (XXXX-XX-XX)
 -------------------
 
-* Fixed: During a move-shard job which moves the leader there is a
-  situation in which the old owner of a shard can reclaim ownership
-  (after having resigned already), with a small race where it allows to
-  write documents only locally, but then continue the move-shard to a
-  server without those documents. An additional bug in the MoveShard
-  Supervision job would then leave the shard in a bad configuration
-  with a resigned leader permanently in charge.
+* Fixed: During a MoveShard job which moves the leader there is a situation in
+  which the old owner of a shard can reclaim ownership (after having resigned
+  already), with a small race where it allows to write documents only locally,
+  but then continue the move-shard to a server without those documents. An
+  additional bug in the MoveShard Supervision job would then leave the shard in
+  a bad configuration with a resigned leader permanently in charge.
 
 * Fixed a problem with potentially lost updates because a failover could happen
   at a wrong time or a restarted leader could come back at an unlucky time.

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -298,9 +298,16 @@ bool MoveShard::start(bool&) {
     return false;
   }
 
-  if (!_isLeader && _remainsFollower) {
-    finish("", "", false, "remainsFollower is invalid without isLeader");
-    return false;
+  if (!_isLeader) {
+    if (_remainsFollower) {
+      finish("", "", false, "remainsFollower is invalid without isLeader");
+      return false;
+    }
+  } else {
+    if (_toServerIsFollower && !_remainsFollower) {
+      finish("", "", false, "remainsFollower must be true if the toServer is a follower");
+      return false;
+    }
   }
 
   // Compute group to move shards together:
@@ -541,6 +548,12 @@ JOB_STATUS MoveShard::pendingLeader() {
 
     // We need to switch leaders:
     {
+      // First make sure that the server we want to go to is still in Current
+      // for all shards. This is important, since some transaction which the leader
+      // has still executed before its resignation might have dropped a follower
+      // for some shard, and this could have been our new leader. In this case we
+      // must abort and go back to the original leader, which is still perfectly
+      // safe.
       for (auto const& sh : shardsLikeMe) {
         auto const shardPath = curColPrefix + _database + "/" + sh.collection + "/" + sh.shard;
         auto const tmp = _snapshot.hasAsArray(shardPath + "/servers");
@@ -563,6 +576,7 @@ JOB_STATUS MoveShard::pendingLeader() {
           return FAILED;
         }
       }
+
       VPackArrayBuilder trxArray(&trx);
       {
         VPackObjectBuilder trxObject(&trx);
@@ -838,18 +852,19 @@ arangodb::Result MoveShard::abort(std::string const& reason) {
   std::vector<Job::shard_t> shardsLikeMe =
     clones(_snapshot, _database, _collection, _shard);
 
+  // If we move the leader: Once the toServer has been put into the Plan
+  // as leader, we always abort by moving forwards:
   // We can no longer abort by reverting to where we started, if any of the
   // shards of the distributeShardsLike group has already gone to new leader
   if (_isLeader) {
-    for (auto const& i : shardsLikeMe) {
-      auto const& cur = _snapshot.hasAsArray(
-        curColPrefix + _database + "/" + i.collection + "/" + i.shard + "/" + "servers");
-      if (cur.second && cur.first[0].copyString() == _to) {
-        LOG_TOPIC("72a82", INFO, Logger::SUPERVISION) <<
-          "MoveShard can no longer abort through reversion to where it started. Flight forward";
-        finish(_to, _shard, true, "job aborted (2) - new leader already in place: " + reason);
-        return result;
-      }
+    auto const& plan = _snapshot.hasAsArray(planColPrefix + _database + "/" + _collection + "/shards/" + _shard);
+    if (plan.second && plan.first[0].copyString() == _to) {
+      LOG_TOPIC("72a82", INFO, Logger::SUPERVISION)
+      << "MoveShard can no longer abort through reversion to where it "
+         "started. Flight forward, leaving Plan as it is now.";
+      finish(_to, _shard, false, "job aborted (2) - new leader already in place: " + reason);
+      return result;
+
     }
   }
 
@@ -888,7 +903,7 @@ arangodb::Result MoveShard::abort(std::string const& reason) {
                          {
                            VPackArrayBuilder guard(&trx);
                            for (auto const& srv : VPackArrayIterator(plan)) {
-                             if (false == srv.isEqualString(_to)) {
+                             if (!srv.isEqualString(_to)) {
                                trx.add(srv);
                              }
                            }
@@ -905,17 +920,8 @@ arangodb::Result MoveShard::abort(std::string const& reason) {
     }
     {
       VPackObjectBuilder preconditionObj(&trx);
-      if (_isLeader) { // Precondition, that current is still as in snapshot
-        // Current preconditions for all shards
-        doForAllShards(
-          _snapshot, _database, shardsLikeMe,
-          [&trx](
-            Slice plan, Slice current, std::string& planPath, std::string& curPath) {
-            // Current still as is
-            trx.add(curPath, current);
-          });
-        addPreconditionJobStillInPending(trx, _jobId);
-      }
+      // If the collection is gone in the meantime, we do nothing here, but the
+      // round will move the job to Finished anyway:
       addPreconditionCollectionStillThere(trx, _database, _collection);
     }
 
@@ -927,16 +933,25 @@ arangodb::Result MoveShard::abort(std::string const& reason) {
                     std::string("Lost leadership"));
     return result;
   } else if (res.indices[0] == 0) {
+    // Precondition failed
     if (_isLeader) {
       // Tough luck. Things have changed. We'll move on
-      LOG_TOPIC("513e6", INFO, Logger::SUPERVISION) <<
-        "MoveShard can no longer abort through reversion to where it started. Flight forward";
-      finish(_to, _shard, true, "job aborted (4) - new leader already in place: " + reason);
+      LOG_TOPIC("513e6", INFO, Logger::SUPERVISION)
+          << "Precondition failed on MoveShard::abort() for shard " << _shard << " of collection " << _collection
+          << ", if the collection has been deleted in the meantime, the job will be finished soon, if this message repeats, tell us.";
+      result = Result(
+          TRI_ERROR_SUPERVISION_GENERAL_FAILURE,
+          std::string("Precondition failed while aborting moveShard job ") + _jobId);
       return result;
+      // We intentionally do not move the job object to Failed or Finished here! The failed
+      // precondition can either be one of the read locks, which suggests a fundamental problem,
+      // and in which case we will log this message in every round of the supervision.
+      // Or the collection has been dropped since we took the snapshot, in this case we
+      // will move the job to Finished in the next round.
     }
     result = Result(
-    TRI_ERROR_SUPERVISION_GENERAL_FAILURE,
-    std::string("Precondition failed while aborting moveShard job ") + _jobId);
+        TRI_ERROR_SUPERVISION_GENERAL_FAILURE,
+        std::string("Precondition failed while aborting moveShard job ") + _jobId);
   }
 
   return result;

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -205,7 +205,7 @@ void handlePlanShard(VPackSlice const& cprops, VPackSlice const& ldb,
 
   if (ldb.hasKey(shname)) {  // Have local collection with that name
     auto const lcol = ldb.get(shname);
-    StringRef const localLeader = lcol.get(THE_LEADER).copyString()
+    std::string const localLeader = lcol.get(THE_LEADER).copyString();
     bool leading = localLeader.empty();
     auto const properties = compareRelevantProps(cprops, lcol);
 

--- a/js/server/modules/@arangodb/cluster.js
+++ b/js/server/modules/@arangodb/cluster.js
@@ -255,6 +255,12 @@ function moveShard (info) {
   var id;
   try {
     id = global.ArangoClusterInfo.uniqid();
+    var remainsFollower = info.remainsFollower;
+    if (remainsFollower === undefined) {
+      remainsFollower = isLeader;
+    } else if (!isLeader) {
+      remainsFollower = false;
+    }
     var todo = { 'type': 'moveShard',
       'database': info.database,
       'collection': collInfo.id,
@@ -265,7 +271,7 @@ function moveShard (info) {
       'timeCreated': (new Date()).toISOString(),
       'creator': ArangoServerState.id(),
       'isLeader': isLeader,
-      'remainsFollower': isLeader};
+      'remainsFollower': remainsFollower };
     global.ArangoAgency.set('Target/ToDo/' + id, todo);
   } catch (e1) {
     return {error: true, errorMessage: 'Cannot write to agency.'};

--- a/jsonresource.h
+++ b/jsonresource.h
@@ -1,7 +1,0 @@
-
-#define IDS_CURRENT 1
-#define IDS_DBSERVER0001 2
-#define IDS_DBSERVER0002 3
-#define IDS_DBSERVER0003 4
-#define IDS_PLAN 5
-#define IDS_SUPERVISION 6

--- a/tests/Agency/MoveShardTest.cpp
+++ b/tests/Agency/MoveShardTest.cpp
@@ -2112,15 +2112,10 @@ TEST_F(MoveShardTest, aborting_the_job_while_the_new_leader_is_already_in_place_
 
     auto writes = q->slice()[0][0];
     EXPECT_TRUE(writes.get("/arango/Target/Pending/1").get("op").copyString() == "delete");
-    EXPECT_TRUE(q->slice()[0].length() == 2); // Precondition: to Server not leader yet
+    EXPECT_TRUE(q->slice()[0].length() == 1); // Precondition: to Server not leader yet
     EXPECT_TRUE(writes.get("/arango/Supervision/DBServers/" + FREE_SERVER).get("op").copyString() == "delete");
     EXPECT_TRUE(writes.get("/arango/Supervision/Shards/" + SHARD).get("op").copyString() == "delete");
-    EXPECT_TRUE(std::string(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD).typeName()) == "array");
     // well apparently this job is not responsible to cleanup its mess
-    EXPECT_TRUE(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD).length() >= 3);
-    EXPECT_TRUE(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD)[0].copyString() == SHARD_LEADER);
-    EXPECT_TRUE(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD)[1].copyString() == SHARD_FOLLOWER1);
-    EXPECT_TRUE(writes.get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION + "/shards/" + SHARD)[2].copyString() == FREE_SERVER);
     EXPECT_TRUE(std::string(writes.get("/arango/Target/Failed/1").typeName()) == "object");
 
     return fakeWriteResult;

--- a/tests/Maintenance/MaintenanceTest.cpp
+++ b/tests/Maintenance/MaintenanceTest.cpp
@@ -28,7 +28,10 @@
 
 #include "gtest/gtest.h"
 
+#include "Agency/AgencyPaths.h"
+#include "ApplicationFeatures/GreetingsFeaturePhase.h"
 #include "Cluster/Maintenance.h"
+#include "Cluster/ResignShardLeadership.h"
 #include "MMFiles/MMFilesEngine.h"
 #include "StorageEngine/EngineSelectorFeature.h"
 
@@ -67,235 +70,291 @@ char const* dbs1Str =
 char const* dbs2Str =
 #include "DBServer0003.json"
     ;
+#else  // _WIN32
+#include <Windows.h>
+#include "jsonresource.h"
+LPSTR planStr = nullptr;
+LPSTR currentStr = nullptr;
+LPSTR supervisionStr = nullptr;
+LPSTR dbs0Str = nullptr;
+LPSTR dbs1Str = nullptr;
+LPSTR dbs2Str = nullptr;
 
-std::map<std::string, std::string> matchShortLongIds(Node const& supervision) {
-  std::map<std::string, std::string> ret;
-  for (auto const& dbs : supervision("Health").children()) {
-    if (dbs.first.front() == 'P') {
-      ret.emplace((*dbs.second)("ShortName").getString(), dbs.first);
-    }
-  }
-  return ret;
-}
-
-Node createNodeFromBuilder(Builder const& builder) {
-  Builder opBuilder;
-  {
-    VPackObjectBuilder a(&opBuilder);
-    opBuilder.add("new", builder.slice());
-  }
-
-  Node node("");
-  node.handle<SET>(opBuilder.slice());
-  return node;
-}
-
-Builder createBuilder(char const* c) {
-  VPackOptions options;
-  options.checkAttributeUniqueness = true;
-  VPackParser parser(&options);
-  parser.parse(c);
-
-  Builder builder;
-  builder.add(parser.steal()->slice());
-  return builder;
-}
-
-Node createNode(char const* c) {
-  return createNodeFromBuilder(createBuilder(c));
-}
+#endif  // _WIN32
 
 // Random stuff
-std::random_device rd;
+std::random_device rd{};
 std::mt19937 g(rd());
-
-// Relevant agency
-Node plan("");
-Node originalPlan("");
-Node supervision("");
-Node current("");
 
 std::vector<std::string> const shortNames{"DBServer0001", "DBServer0002",
                                           "DBServer0003"};
-
-// map <shortId, UUID>
-std::map<std::string, std::string> dbsIds;
 
 std::string const PLAN_COL_PATH = "/Collections/";
 std::string const PLAN_DB_PATH = "/Databases/";
 
 size_t localId = 1016002;
 
-VPackBuilder createDatabase(std::string const& dbname) {
-  Builder builder;
-  {
-    VPackObjectBuilder o(&builder);
-    builder.add("id", VPackValue(std::to_string(localId++)));
-    builder.add("coordinator",
-                VPackValue("CRDN-42df19c3-73d5-48f4-b02e-09b29008eff8"));
-    builder.add(VPackValue("options"));
-    { VPackObjectBuilder oo(&builder); }
-    builder.add("name", VPackValue(dbname));
-  }
-  return builder;
-}
-
-void createPlanDatabase(std::string const& dbname, Node& plan) {
-  plan(PLAN_DB_PATH + dbname) = createDatabase(dbname).slice();
-}
-
-VPackBuilder createIndex(std::string const& type, std::vector<std::string> const& fields,
-                         bool unique, bool sparse, bool deduplicate) {
-  VPackBuilder index;
-  {
-    VPackObjectBuilder o(&index);
-    {
-      index.add("deduplicate", VPackValue(deduplicate));
-      index.add(VPackValue("fields"));
-      {
-        VPackArrayBuilder a(&index);
-        for (auto const& field : fields) {
-          index.add(VPackValue(field));
-        }
-      }
-      index.add("id", VPackValue(std::to_string(localId++)));
-      index.add("sparse", VPackValue(sparse));
-      index.add("type", VPackValue(type));
-      index.add("unique", VPackValue(unique));
-    }
-  }
-
-  return index;
-}
-
-void createPlanIndex(std::string const& dbname, std::string const& colname,
-                     std::string const& type, std::vector<std::string> const& fields,
-                     bool unique, bool sparse, bool deduplicate, Node& plan) {
-  VPackBuilder val;
-  {
-    VPackObjectBuilder o(&val);
-    val.add("new", createIndex(type, fields, unique, sparse, deduplicate).slice());
-  }
-  plan(PLAN_COL_PATH + dbname + "/" + colname + "/indexes").handle<PUSH>(val.slice());
-}
-
-void createCollection(std::string const& colname, VPackBuilder& col) {
-  VPackBuilder keyOptions;
-  {
-    VPackObjectBuilder o(&keyOptions);
-    keyOptions.add("lastValue", VPackValue(0));
-    keyOptions.add("type", VPackValue("traditional"));
-    keyOptions.add("allowUserKeys", VPackValue(true));
-  }
-
-  VPackBuilder shardKeys;
-  {
-    VPackArrayBuilder a(&shardKeys);
-    shardKeys.add(VPackValue("_key"));
-  }
-
-  VPackBuilder indexes;
-  {
-    VPackArrayBuilder a(&indexes);
-    indexes.add(createIndex("primary", {"_key"}, true, false, false).slice());
-  }
-
-  col.add("id", VPackValue(std::to_string(localId++)));
-  col.add("status", VPackValue(3));
-  col.add("keyOptions", keyOptions.slice());
-  col.add("cacheEnabled", VPackValue(false));
-  col.add("waitForSync", VPackValue(false));
-  col.add("type", VPackValue(2));
-  col.add("isSystem", VPackValue(true));
-  col.add("name", VPackValue(colname));
-  col.add("shardingStrategy", VPackValue("hash"));
-  col.add("statusString", VPackValue("loaded"));
-  col.add("shardKeys", shardKeys.slice());
-}
-
 std::string S("s");
 std::string C("c");
 
-void createPlanShards(size_t numberOfShards, size_t replicationFactor, VPackBuilder& col) {
-  auto servers = shortNames;
-  std::shuffle(servers.begin(), servers.end(), g);
 
-  col.add("numberOfShards", VPackValue(1));
-  col.add("replicationFactor", VPackValue(2));
-  col.add(VPackValue("shards"));
-  {
-    VPackObjectBuilder s(&col);
-    for (size_t i = 0; i < numberOfShards; ++i) {
-      col.add(VPackValue(S + std::to_string(localId++)));
-      {
-        VPackArrayBuilder a(&col);
-        size_t j = 0;
-        for (auto const& server : servers) {
-          if (j++ < replicationFactor) {
-            col.add(VPackValue(dbsIds[server]));
-          }
-        }
-      }
-    }
-  }
-}
-
-void createPlanCollection(std::string const& dbname, std::string const& colname,
-                          size_t numberOfShards, size_t replicationFactor, Node& plan) {
-  VPackBuilder tmp;
-  {
-    VPackObjectBuilder o(&tmp);
-    createCollection(colname, tmp);
-    tmp.add("isSmart", VPackValue(false));
-    tmp.add("deleted", VPackValue(false));
-    createPlanShards(numberOfShards, replicationFactor, tmp);
-  }
-
-  Slice col = tmp.slice();
-  auto id = col.get("id").copyString();
-  plan(PLAN_COL_PATH + dbname + "/" + col.get("id").copyString()) = col;
-}
-
-void createLocalCollection(std::string const& dbname, std::string const& colname, Node& node) {
-  size_t planId = std::stoull(colname);
-  VPackBuilder tmp;
-  {
-    VPackObjectBuilder o(&tmp);
-    createCollection(colname, tmp);
-    tmp.add("planId", VPackValue(colname));
-    tmp.add("theLeader", VPackValue(""));
-    tmp.add("globallyUniqueId",
-            VPackValue(C + colname + "/" + S + std::to_string(planId + 1)));
-    tmp.add("objectId", VPackValue("9031415"));
-  }
-  node(dbname + "/" + S + std::to_string(planId + 1)) = tmp.slice();
-}
-
-std::map<std::string, std::string> collectionMap(Node const& plan) {
-  std::map<std::string, std::string> ret;
-  auto const pb = plan("Collections").toBuilder();
-  auto const ps = pb.slice();
-  for (auto const& db : VPackObjectIterator(ps)) {
-    for (auto const& col : VPackObjectIterator(db.value)) {
-      ret.emplace(db.key.copyString() + "/" + col.value.get("name").copyString(),
-                  col.key.copyString());
-    }
-  }
-  return ret;
-}
 
 namespace arangodb {
 class LogicalCollection;
 }
+using namespace arangodb::maintenance;
 
-class MaintenanceTestActionDescription : public ::testing::Test {
+class SharedMaintenanceTest : public ::testing::Test {
  protected:
-  MaintenanceTestActionDescription() {
+  SharedMaintenanceTest() {
+    loadResources();
     plan = createNode(planStr);
     originalPlan = plan;
     supervision = createNode(supervisionStr);
     current = createNode(currentStr);
     dbsIds = matchShortLongIds(supervision);
+  }
+
+ protected:
+  // Relevant agency
+  Node plan{""};
+  Node originalPlan{""};
+  Node supervision{""};
+  Node current{""};
+
+
+
+  // map <shortId, UUID>
+  std::map<std::string, std::string> dbsIds;
+
+  /**
+   * @brief Helper methods
+   *
+   */
+ protected:
+#ifndef _WIN32
+  int loadResources(void) { return 0; }
+
+#else  // _WIN32
+  LPSTR getResource(int which) {
+    HRSRC myResource = ::FindResource(NULL, MAKEINTRESOURCE(which), RT_RCDATA);
+    HGLOBAL myResourceData = ::LoadResource(NULL, myResource);
+    return (LPSTR)::LockResource(myResourceData);
+  }
+  int loadResources(void) {
+    if ((planStr == nullptr) && (currentStr == nullptr) && (supervisionStr == nullptr) &&
+        (dbs0Str == nullptr) && (dbs1Str == nullptr) && (dbs2Str == nullptr)) {
+      planStr = getResource(IDS_PLAN);
+      currentStr = getResource(IDS_CURRENT);
+      dbs0Str = getResource(IDS_DBSERVER0001);
+      dbs1Str = getResource(IDS_DBSERVER0002);
+      dbs2Str = getResource(IDS_DBSERVER0003);
+      supervisionStr = getResource(IDS_SUPERVISION);
+    }
+    return 0;
+  }
+
+#endif  // _WIN32
+
+  std::map<std::string, std::string> matchShortLongIds(Node const& supervision) {
+    std::map<std::string, std::string> ret;
+    for (auto const& dbs : supervision("Health").children()) {
+      if (dbs.first.front() == 'P') {
+        ret.emplace((*dbs.second)("ShortName").getString(), dbs.first);
+      }
+    }
+    return ret;
+  }
+
+  Node createNodeFromBuilder(Builder const& builder) {
+    Builder opBuilder;
+    {
+      VPackObjectBuilder a(&opBuilder);
+      opBuilder.add("new", builder.slice());
+    }
+
+    Node node("");
+    node.handle<SET>(opBuilder.slice());
+    return node;
+  }
+
+  Builder createBuilder(char const* c) {
+    VPackOptions options;
+    options.checkAttributeUniqueness = true;
+    VPackParser parser(&options);
+    parser.parse(c);
+
+    Builder builder;
+    builder.add(parser.steal()->slice());
+    return builder;
+  }
+
+  Node createNode(char const* c) {
+    return createNodeFromBuilder(createBuilder(c));
+  }
+
+  VPackBuilder createDatabase(std::string const& dbname) {
+    Builder builder;
+    {
+      VPackObjectBuilder o(&builder);
+      builder.add("id", VPackValue(std::to_string(localId++)));
+      builder.add("coordinator",
+                  VPackValue("CRDN-42df19c3-73d5-48f4-b02e-09b29008eff8"));
+      builder.add(VPackValue("options"));
+      { VPackObjectBuilder oo(&builder); }
+      builder.add("name", VPackValue(dbname));
+    }
+    return builder;
+  }
+
+  void createPlanDatabase(std::string const& dbname, Node& plan) {
+    plan(PLAN_DB_PATH + dbname) = createDatabase(dbname).slice();
+  }
+
+  VPackBuilder createIndex(std::string const& type, std::vector<std::string> const& fields,
+                           bool unique, bool sparse, bool deduplicate) {
+    VPackBuilder index;
+    {
+      VPackObjectBuilder o(&index);
+      {
+        index.add("deduplicate", VPackValue(deduplicate));
+        index.add(VPackValue("fields"));
+        {
+          VPackArrayBuilder a(&index);
+          for (auto const& field : fields) {
+            index.add(VPackValue(field));
+          }
+        }
+        index.add("id", VPackValue(std::to_string(localId++)));
+        index.add("sparse", VPackValue(sparse));
+        index.add("type", VPackValue(type));
+        index.add("unique", VPackValue(unique));
+      }
+    }
+
+    return index;
+  }
+
+  void createPlanIndex(std::string const& dbname, std::string const& colname,
+                       std::string const& type, std::vector<std::string> const& fields,
+                       bool unique, bool sparse, bool deduplicate, Node& plan) {
+    VPackBuilder val;
+    {
+      VPackObjectBuilder o(&val);
+      val.add("new", createIndex(type, fields, unique, sparse, deduplicate).slice());
+    }
+    plan(PLAN_COL_PATH + dbname + "/" + colname + "/indexes").handle<PUSH>(val.slice());
+  }
+
+  void createCollection(std::string const& colname, VPackBuilder& col) {
+    VPackBuilder keyOptions;
+    {
+      VPackObjectBuilder o(&keyOptions);
+      keyOptions.add("lastValue", VPackValue(0));
+      keyOptions.add("type", VPackValue("traditional"));
+      keyOptions.add("allowUserKeys", VPackValue(true));
+    }
+
+    VPackBuilder shardKeys;
+    {
+      VPackArrayBuilder a(&shardKeys);
+      shardKeys.add(VPackValue("_key"));
+    }
+
+    VPackBuilder indexes;
+    {
+      VPackArrayBuilder a(&indexes);
+      indexes.add(createIndex("primary", {"_key"}, true, false, false).slice());
+    }
+
+    col.add("id", VPackValue(std::to_string(localId++)));
+    col.add("status", VPackValue(3));
+    col.add("keyOptions", keyOptions.slice());
+    col.add("cacheEnabled", VPackValue(false));
+    col.add("waitForSync", VPackValue(false));
+    col.add("type", VPackValue(2));
+    col.add("isSystem", VPackValue(true));
+    col.add("name", VPackValue(colname));
+    col.add("shardingStrategy", VPackValue("hash"));
+    col.add("statusString", VPackValue("loaded"));
+    col.add("shardKeys", shardKeys.slice());
+  }
+
+
+  void createPlanShards(size_t numberOfShards, size_t replicationFactor, VPackBuilder& col) {
+    auto servers = shortNames;
+    std::shuffle(servers.begin(), servers.end(), g);
+
+    col.add("numberOfShards", VPackValue(1));
+    col.add("replicationFactor", VPackValue(2));
+    col.add(VPackValue("shards"));
+    {
+      VPackObjectBuilder s(&col);
+      for (size_t i = 0; i < numberOfShards; ++i) {
+        col.add(VPackValue(S + std::to_string(localId++)));
+        {
+          VPackArrayBuilder a(&col);
+          size_t j = 0;
+          for (auto const& server : servers) {
+            if (j++ < replicationFactor) {
+              col.add(VPackValue(dbsIds[server]));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  void createPlanCollection(std::string const& dbname, std::string const& colname,
+                            size_t numberOfShards, size_t replicationFactor, Node& plan) {
+    VPackBuilder tmp;
+    {
+      VPackObjectBuilder o(&tmp);
+      createCollection(colname, tmp);
+      tmp.add("isSmart", VPackValue(false));
+      tmp.add("deleted", VPackValue(false));
+      createPlanShards(numberOfShards, replicationFactor, tmp);
+    }
+
+    Slice col = tmp.slice();
+    auto id = col.get("id").copyString();
+    plan(PLAN_COL_PATH + dbname + "/" + col.get("id").copyString()) = col;
+  }
+
+  void createLocalCollection(std::string const& dbname,
+                             std::string const& colname, Node& node) {
+    size_t planId = std::stoull(colname);
+    VPackBuilder tmp;
+    {
+      VPackObjectBuilder o(&tmp);
+      createCollection(colname, tmp);
+      tmp.add("planId", VPackValue(colname));
+      tmp.add("theLeader", VPackValue(""));
+      tmp.add("globallyUniqueId",
+              VPackValue(C + colname + "/" + S + std::to_string(planId + 1)));
+      tmp.add("objectId", VPackValue("9031415"));
+    }
+    node(dbname + "/" + S + std::to_string(planId + 1)) = tmp.slice();
+  }
+
+  std::map<std::string, std::string> collectionMap(Node const& plan) {
+    std::map<std::string, std::string> ret;
+    auto const pb = plan("Collections").toBuilder();
+    auto const ps = pb.slice();
+    for (auto const& db : VPackObjectIterator(ps)) {
+      for (auto const& col : VPackObjectIterator(db.value)) {
+        ret.emplace(db.key.copyString() + "/" + col.value.get("name").copyString(),
+                    col.key.copyString());
+      }
+    }
+    return ret;
+  }
+};
+
+class MaintenanceTestActionDescription : public SharedMaintenanceTest {
+
+ protected:
+  MaintenanceTestActionDescription() : SharedMaintenanceTest() {
   }
 };
 
@@ -303,7 +362,7 @@ TEST_F(MaintenanceTestActionDescription, construct_minimal_actiondescription) {
   ActionDescription desc(std::map<std::string, std::string>{{"name",
                                                              "SomeAction"}},
                          NORMAL_PRIORITY);
-  ASSERT_TRUE(desc.get("name") == "SomeAction");
+  ASSERT_EQ(desc.get("name"), "SomeAction");
 }
 
 TEST_F(MaintenanceTestActionDescription, construct_minimal_actiondescription_with_nullptr_props) {
@@ -314,50 +373,48 @@ TEST_F(MaintenanceTestActionDescription, construct_minimal_actiondescription_wit
 TEST_F(MaintenanceTestActionDescription, construct_minimal_actiondescription_with_empty_props) {
   std::shared_ptr<VPackBuilder> props;
   ActionDescription desc({{"name", "SomeAction"}}, NORMAL_PRIORITY, props);
-  ASSERT_TRUE(desc.get("name") == "SomeAction");
+  ASSERT_EQ(desc.get("name"), "SomeAction");
 }
 
 TEST_F(MaintenanceTestActionDescription, retrieve_nonassigned_key_from_actiondescription) {
   std::shared_ptr<VPackBuilder> props;
   ActionDescription desc({{"name", "SomeAction"}}, NORMAL_PRIORITY, props);
-  ASSERT_TRUE(desc.get("name") == "SomeAction");
+  ASSERT_EQ(desc.get("name"), "SomeAction");
   try {
     auto bogus = desc.get("bogus");
-    ASSERT_TRUE(bogus == "bogus");
-  } catch (std::out_of_range const& e) {
-  }
+    ASSERT_EQ(bogus, "bogus");
+  } catch (std::out_of_range const&) { }
   std::string value;
   auto res = desc.get("bogus", value);
   ASSERT_TRUE(value.empty());
-  ASSERT_TRUE(!res.ok());
+  ASSERT_FALSE(res.ok());
 }
 
 TEST_F(MaintenanceTestActionDescription, retrieve_nonassigned_key_from_actiondescription_2) {
   std::shared_ptr<VPackBuilder> props;
   ActionDescription desc({{"name", "SomeAction"}, {"bogus", "bogus"}}, NORMAL_PRIORITY, props);
-  ASSERT_TRUE(desc.get("name") == "SomeAction");
+  ASSERT_EQ(desc.get("name"), "SomeAction");
   try {
     auto bogus = desc.get("bogus");
-    ASSERT_TRUE(bogus == "bogus");
-  } catch (std::out_of_range const& e) {
-  }
+    ASSERT_EQ(bogus, "bogus");
+  } catch (std::out_of_range const&) { }
   std::string value;
   auto res = desc.get("bogus", value);
-  ASSERT_TRUE(value == "bogus");
+  ASSERT_EQ(value, "bogus");
   ASSERT_TRUE(res.ok());
 }
 
 TEST_F(MaintenanceTestActionDescription, retrieve_nonassigned_properties_from_actiondescription) {
   std::shared_ptr<VPackBuilder> props;
   ActionDescription desc({{"name", "SomeAction"}}, NORMAL_PRIORITY, props);
-  ASSERT_TRUE(desc.get("name") == "SomeAction");
-  ASSERT_TRUE(desc.properties() == nullptr);
+  ASSERT_EQ(desc.get("name"), "SomeAction");
+  ASSERT_EQ(desc.properties(), nullptr);
 }
 
 TEST_F(MaintenanceTestActionDescription, retrieve_empty_properties_from_actiondescription) {
   auto props = std::make_shared<VPackBuilder>();
   ActionDescription desc({{"name", "SomeAction"}}, NORMAL_PRIORITY, props);
-  ASSERT_TRUE(desc.get("name") == "SomeAction");
+  ASSERT_EQ(desc.get("name"), "SomeAction");
   ASSERT_TRUE(desc.properties()->isEmpty());
 }
 
@@ -365,7 +422,7 @@ TEST_F(MaintenanceTestActionDescription, retrieve_empty_object_properties_from_a
   auto props = std::make_shared<VPackBuilder>();
   { VPackObjectBuilder empty(props.get()); }
   ActionDescription desc({{"name", "SomeAction"}}, NORMAL_PRIORITY, props);
-  ASSERT_TRUE(desc.get("name") == "SomeAction");
+  ASSERT_EQ(desc.get("name"), "SomeAction");
   ASSERT_TRUE(desc.properties()->slice().isEmptyObject());
 }
 
@@ -376,9 +433,9 @@ TEST_F(MaintenanceTestActionDescription, retrieve_string_value_from_actiondescri
     props->add("hello", VPackValue("world"));
   }
   ActionDescription desc({{"name", "SomeAction"}}, NORMAL_PRIORITY, props);
-  ASSERT_TRUE(desc.get("name") == "SomeAction");
+  ASSERT_EQ(desc.get("name"), "SomeAction");
   ASSERT_TRUE(desc.properties()->slice().hasKey("hello"));
-  ASSERT_TRUE(desc.properties()->slice().get("hello").copyString() == "world");
+  ASSERT_EQ(desc.properties()->slice().get("hello").copyString(), "world");
 }
 
 TEST_F(MaintenanceTestActionDescription, retrieve_double_value_from_actiondescriptions_properties) {
@@ -389,9 +446,9 @@ TEST_F(MaintenanceTestActionDescription, retrieve_double_value_from_actiondescri
     props->add("pi", VPackValue(3.14159265359));
   }
   ActionDescription desc({{"name", "SomeAction"}}, NORMAL_PRIORITY, props);
-  ASSERT_TRUE(desc.get("name") == "SomeAction");
+  ASSERT_EQ(desc.get("name"), "SomeAction");
   ASSERT_TRUE(desc.properties()->slice().hasKey("pi"));
-  ASSERT_TRUE(desc.properties()->slice().get("pi").getNumber<double>() == pi);
+  ASSERT_EQ(desc.properties()->slice().get("pi").getNumber<double>(), pi);
 }
 
 TEST_F(MaintenanceTestActionDescription, retrieve_integer_value_from_actiondescriptions_property) {
@@ -402,9 +459,9 @@ TEST_F(MaintenanceTestActionDescription, retrieve_integer_value_from_actiondescr
     props->add("one", VPackValue(one));
   }
   ActionDescription desc({{"name", "SomeAction"}}, NORMAL_PRIORITY, props);
-  ASSERT_TRUE(desc.get("name") == "SomeAction");
+  ASSERT_EQ(desc.get("name"), "SomeAction");
   ASSERT_TRUE(desc.properties()->slice().hasKey("one"));
-  ASSERT_TRUE(desc.properties()->slice().get("one").getNumber<size_t>() == one);
+  ASSERT_EQ(desc.properties()->slice().get("one").getNumber<size_t>(), one);
 }
 
 TEST_F(MaintenanceTestActionDescription, retrieve_array_value_from_actiondescriptions_properties) {
@@ -423,20 +480,21 @@ TEST_F(MaintenanceTestActionDescription, retrieve_array_value_from_actiondescrip
     }
   }
   ActionDescription desc({{"name", "SomeAction"}}, NORMAL_PRIORITY, props);
-  ASSERT_TRUE(desc.get("name") == "SomeAction");
+  ASSERT_EQ(desc.get("name"), "SomeAction");
   ASSERT_TRUE(desc.properties()->slice().hasKey("array"));
   ASSERT_TRUE(desc.properties()->slice().get("array").isArray());
-  ASSERT_TRUE(desc.properties()->slice().get("array").length() == 3);
-  ASSERT_TRUE(desc.properties()->slice().get("array")[0].getNumber<double>() == pi);
-  ASSERT_TRUE(desc.properties()->slice().get("array")[1].getNumber<size_t>() == one);
-  ASSERT_TRUE(desc.properties()->slice().get("array")[2].copyString() == hello);
+  ASSERT_EQ(desc.properties()->slice().get("array").length(), 3);
+  ASSERT_EQ(desc.properties()->slice().get("array")[0].getNumber<double>(), pi);
+  ASSERT_EQ(desc.properties()->slice().get("array")[1].getNumber<size_t>(), one);
+  ASSERT_EQ(desc.properties()->slice().get("array")[2].copyString(), hello);
 }
 
-class MaintenanceTestActionPhaseOne : public ::testing::Test {
+class MaintenanceTestActionPhaseOne : public SharedMaintenanceTest {
  protected:
+  int _dummy;
   std::shared_ptr<arangodb::options::ProgramOptions> po;
   arangodb::application_features::ApplicationServer as;
-  TestMaintenanceFeature feature;
+  std::unique_ptr<TestMaintenanceFeature> feature;
   MaintenanceFeature::errors_t errors;
 
   std::map<std::string, Node> localNodes;
@@ -444,22 +502,243 @@ class MaintenanceTestActionPhaseOne : public ::testing::Test {
   arangodb::MMFilesEngine engine;  // arbitrary implementation that has index types registered
   arangodb::StorageEngine* origStorageEngine;
 
+
+
+
   MaintenanceTestActionPhaseOne()
-      : po(std::make_shared<arangodb::options::ProgramOptions>("test", std::string(),
+      : SharedMaintenanceTest(),
+        _dummy(loadResources()),
+        po(std::make_shared<arangodb::options::ProgramOptions>("test", std::string(),
                                                                std::string(),
                                                                "path")),
         as(po, nullptr),
-        feature(as),
         localNodes{{dbsIds[shortNames[0]], createNode(dbs0Str)},
                    {dbsIds[shortNames[1]], createNode(dbs1Str)},
                    {dbsIds[shortNames[2]], createNode(dbs2Str)}},
         engine(as),
         origStorageEngine(arangodb::EngineSelectorFeature::ENGINE) {
+    as.addFeature<arangodb::application_features::GreetingsFeaturePhase>(false);
+    feature = std::make_unique<TestMaintenanceFeature>(as);
+
     arangodb::EngineSelectorFeature::ENGINE = &engine;
   }
 
   ~MaintenanceTestActionPhaseOne() {
     arangodb::EngineSelectorFeature::ENGINE = origStorageEngine;
+  }
+
+  auto dbName() const -> std::string {
+    // this is a database known in the test files
+    return "foo";
+  }
+
+  auto planId() const -> std::string {
+    // This is a gobal collection known in the test files.
+    // It is required to have 6 shards, 2 per DBServer
+    return "2010088";
+  }
+
+  auto unusedServer() const -> std::string {
+    return "PRMR-deadbeef-1337-7331-abcd-123456789abc";
+  }
+
+  enum class PLAN_LEADERSHIP_TYPE { SELF, RESIGNED_SELF, OTHER, RESIGNED_OTHER };
+
+  enum class LOCAL_LEADERSHIP_TYPE { SELF, OTHER, RESIGNED, REBOOTED };
+
+  auto getShardsForServer(std::string const& dbName, std::string const& planId,
+                          std::string const& serverId, Node const& plan)
+      -> std::unordered_set<std::string> {
+    auto path = arangodb::cluster::paths::aliases::plan()
+                    ->collections()
+                    ->database(dbName)
+                    ->collection(planId)
+                    ->shards();
+
+    auto vec = path->vec(2);
+    TRI_ASSERT(plan.has(vec));
+    auto const& shardList = plan(vec);
+    std::unordered_set<std::string> res;
+    for (auto const& [shard, servers] : shardList.children()) {
+      auto oldValue = servers->slice();
+      TRI_ASSERT(oldValue.isArray());
+      TRI_ASSERT(oldValue.length() == 2);
+      if (oldValue.at(0).isEqualString(serverId)) {
+        res.emplace(shard);
+      }
+    }
+    return res;
+  }
+
+  auto setLeadershipPlan(std::string const& dbName, std::string const& planId,
+                         PLAN_LEADERSHIP_TYPE type, Node& plan) -> void {
+    auto path = arangodb::cluster::paths::aliases::plan()
+                    ->collections()
+                    ->database(dbName)
+                    ->collection(planId)
+                    ->shards();
+
+    auto vec = path->vec(2);
+    ASSERT_TRUE(plan.has(vec)) << "The underlying test plan is modified, it "
+                                  "does not contain Database '"
+                               << dbName << "' and Collection '" << planId << "' anymore.";
+    auto& shardList = plan(vec);
+    for (auto& [shard, servers] : shardList.children()) {
+      auto oldValue = servers->slice();
+      ASSERT_TRUE(oldValue.isArray());
+      ASSERT_EQ(oldValue.length(), 2)
+          << "We assume to have one leader and one follower";
+      switch (type) {
+        case PLAN_LEADERSHIP_TYPE::SELF: {
+          // Nothing to do here, we are leader
+          break;
+        }
+        case PLAN_LEADERSHIP_TYPE::RESIGNED_SELF: {
+          // We simulate a resign leader, this is indicated by appending an `_` in front of the server name.
+          VPackBuilder newValue;
+          {
+            VPackArrayBuilder guard(&newValue);
+            newValue.add(VPackValue("_" + oldValue.at(0).copyString()));
+            newValue.add(VPackValue(oldValue.at(1).copyString()));
+          }
+          *servers = newValue.slice();
+          break;
+        }
+        case PLAN_LEADERSHIP_TYPE::OTHER: {
+          // We simulate we get told another leader is there.
+          VPackBuilder newValue;
+          {
+            VPackArrayBuilder guard(&newValue);
+            newValue.add(VPackValue(unusedServer()));
+            newValue.add(VPackValue(oldValue.at(0).copyString()));
+            newValue.add(VPackValue(oldValue.at(1).copyString()));
+          }
+          *servers = newValue.slice();
+          break;
+        }
+        case PLAN_LEADERSHIP_TYPE::RESIGNED_OTHER: {
+          // We simulate we get told another leader is there, and resigned, this is indicated by appending an `_` in front of the server name.
+          VPackBuilder newValue;
+          {
+            VPackArrayBuilder guard(&newValue);
+            newValue.add(VPackValue("_" + unusedServer()));
+            newValue.add(VPackValue(oldValue.at(0).copyString()));
+            newValue.add(VPackValue(oldValue.at(1).copyString()));
+          }
+          *servers = newValue.slice();
+          break;
+        }
+      }
+    }
+  }
+
+  // Will resign leadership on the given plan.
+  // The plan will be modified in-place
+  // Asserts that dbName and planId exists in plan
+  auto resignLeadershipPlan(std::string const& dbName, std::string const& planId, Node& plan) -> void {
+    return setLeadershipPlan(dbName, planId, PLAN_LEADERSHIP_TYPE::RESIGNED_SELF, plan);
+  }
+
+  // Will take leadership in plan
+  // Asserts that dbName and planId exists in plan
+  // NOTE: The plan already contians leadersip of SELF so this is a noop besides assertions.
+  auto takeLeadershipPlan(std::string const& dbName, std::string const& planId, Node& plan) -> void {
+    return setLeadershipPlan(dbName, planId, PLAN_LEADERSHIP_TYPE::SELF, plan);
+  }
+
+  // Another server will take leadership in plan
+  // Asserts that dbName and planId exists in plan
+  auto otherTakeLeadershipPlan(std::string const& dbName, std::string const& planId, Node& plan) -> void {
+    return setLeadershipPlan(dbName, planId, PLAN_LEADERSHIP_TYPE::OTHER, plan);
+  }
+
+  // Another server will take resigned leadership in plan
+  // Asserts that dbName and planId exists in plan
+  auto otherTakeResignedLeadershipPlan(std::string const& dbName,
+                               std::string const& planId, Node& plan) -> void {
+    return setLeadershipPlan(dbName, planId, PLAN_LEADERSHIP_TYPE::RESIGNED_OTHER, plan);
+  }
+
+  auto setLeadershipLocal(std::string const& dbName,
+                            std::unordered_set<std::string> const& shardNames,
+                            LOCAL_LEADERSHIP_TYPE type, Node& local) {
+    for (auto const& shardName : shardNames) {
+      auto vec = {dbName, shardName, std::string(THE_LEADER)};
+      ASSERT_TRUE(local.has(vec))
+          << "The underlying test plan is modified, it "
+             "does not contain Database '"
+          << dbName << "' and Shard '" << shardName << "' anymore.";
+      auto& leaderInfo = local(vec);
+      VPackBuilder newValue;
+      switch (type) {
+        case LOCAL_LEADERSHIP_TYPE::SELF: {
+          newValue.add(VPackValue(""));
+          break;
+        }
+        case LOCAL_LEADERSHIP_TYPE::OTHER: {
+          newValue.add(VPackValue(unusedServer()));
+          break;
+        }
+        case LOCAL_LEADERSHIP_TYPE::RESIGNED: {
+          newValue.add(VPackValue(ResignShardLeadership::LeaderNotYetKnownString));
+          break;
+        }
+        case LOCAL_LEADERSHIP_TYPE::REBOOTED: {
+          newValue.add(VPackValue(LEADER_NOT_YET_KNOWN));
+          break;
+        }
+      }
+      leaderInfo = newValue.slice();
+    }
+  }
+
+  // Claim leadership of the given shards ourself.
+  auto takeLeadershipLocal(std::string const& dbName,
+                             std::unordered_set<std::string> const& shardNames,
+                             Node& local) {
+    setLeadershipLocal(dbName, shardNames, LOCAL_LEADERSHIP_TYPE::SELF, local);
+  }
+
+    // Resign leadership of the given shards ourself.
+  auto resignLeadershipLocal(std::string const& dbName,
+                             std::unordered_set<std::string> const& shardNames,
+                             Node& local) {
+    setLeadershipLocal(dbName, shardNames, LOCAL_LEADERSHIP_TYPE::RESIGNED, local);
+  }
+
+  // Let other server claim leadership of the given shards ourself.
+  auto otherTakeLeadershipLocal(std::string const& dbName,
+                                  std::unordered_set<std::string> const& shardNames,
+                                  Node& local) {
+    setLeadershipLocal(dbName, shardNames, LOCAL_LEADERSHIP_TYPE::OTHER, local);
+  }
+
+  // Claim leadership of the given shards ourself.
+  auto rebootLeadershipLocal(std::string const& dbName,
+                               std::unordered_set<std::string> const& shardNames,
+                               Node& local) {
+    setLeadershipLocal(dbName, shardNames, LOCAL_LEADERSHIP_TYPE::REBOOTED, local);
+  }
+
+  auto assertIsTakeoverLeadershipAction(ActionDescription const& action,
+                                        std::string const& dbName,
+                                        std::string const& planId) -> void {
+    ASSERT_EQ(action.name(), "TakeoverShardLeadership");
+    ASSERT_TRUE(action.has(DATABASE));
+    ASSERT_TRUE(action.has(COLLECTION));
+    ASSERT_TRUE(action.has(SHARD));
+    ASSERT_TRUE(action.has(THE_LEADER));
+    ASSERT_TRUE(action.has(LOCAL_LEADER));
+    ASSERT_EQ(action.get(DATABASE), dbName);
+    ASSERT_EQ(action.get(COLLECTION), planId);
+  }
+
+  auto assertIsResignLeadershipAction(ActionDescription const& action,
+                                      std::string const& dbName) -> void {
+    ASSERT_EQ(action.name(), "ResignShardLeadership");
+    ASSERT_TRUE(action.has(DATABASE));
+    ASSERT_TRUE(action.has(SHARD));
+    ASSERT_EQ(action.get(DATABASE), dbName);
   }
 };
 
@@ -469,12 +748,12 @@ TEST_F(MaintenanceTestActionPhaseOne, in_sync_should_have_0_effects) {
   for (auto const& node : localNodes) {
     arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
                                          node.second.toBuilder().slice(),
-                                         node.first, errors, feature, actions);
+                                         node.first, errors, *feature, actions);
 
     if (actions.size() != 0) {
       std::cout << __FILE__ << ":" << __LINE__ << " " << actions << std::endl;
     }
-    ASSERT_TRUE(actions.size() == 0);
+    ASSERT_EQ(actions.size(), 0);
   }
 }
 
@@ -485,14 +764,14 @@ TEST_F(MaintenanceTestActionPhaseOne, local_databases_one_more_empty_database_sh
 
   arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
                                        localNodes.begin()->second.toBuilder().slice(),
-                                       localNodes.begin()->first, errors, feature, actions);
+                                       localNodes.begin()->first, errors, *feature, actions);
 
   if (actions.size() != 1) {
     std::cout << __FILE__ << ":" << __LINE__ << " " << actions << std::endl;
   }
-  ASSERT_TRUE(actions.size() == 1);
-  ASSERT_TRUE(actions.front().name() == "DropDatabase");
-  ASSERT_TRUE(actions.front().get("database") == "db3");
+  ASSERT_EQ(actions.size(), 1);
+  ASSERT_EQ(actions.front().name(), "DropDatabase");
+  ASSERT_EQ(actions.front().get("database"), "db3");
 }
 
 TEST_F(MaintenanceTestActionPhaseOne,
@@ -502,11 +781,11 @@ TEST_F(MaintenanceTestActionPhaseOne,
 
   arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
                                        localNodes.begin()->second.toBuilder().slice(),
-                                       localNodes.begin()->first, errors, feature, actions);
+                                       localNodes.begin()->first, errors, *feature, actions);
 
-  ASSERT_TRUE(actions.size() == 1);
-  ASSERT_TRUE(actions.front().name() == "DropDatabase");
-  ASSERT_TRUE(actions.front().get("database") == "db3");
+  ASSERT_EQ(actions.size(), 1);
+  ASSERT_EQ(actions.front().name(), "DropDatabase");
+  ASSERT_EQ(actions.front().get("database"), "db3");
 }
 
 TEST_F(MaintenanceTestActionPhaseOne,
@@ -524,14 +803,14 @@ TEST_F(MaintenanceTestActionPhaseOne,
 
     arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
                                          node.second.toBuilder().slice(),
-                                         node.first, errors, feature, actions);
+                                         node.first, errors, *feature, actions);
 
     if (actions.size() != 1) {
       std::cout << __FILE__ << ":" << __LINE__ << " " << actions << std::endl;
     }
-    ASSERT_TRUE(actions.size() == 1);
+    ASSERT_EQ(actions.size(), 1);
     for (auto const& action : actions) {
-      ASSERT_TRUE(action.name() == "CreateCollection");
+      ASSERT_EQ(action.name(), "CreateCollection");
     }
   }
 }
@@ -552,14 +831,14 @@ TEST_F(MaintenanceTestActionPhaseOne,
 
     arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
                                          node.second.toBuilder().slice(),
-                                         node.first, errors, feature, actions);
+                                         node.first, errors, *feature, actions);
 
     if (actions.size() != 2) {
       std::cout << __FILE__ << ":" << __LINE__ << " " << actions << std::endl;
     }
-    ASSERT_TRUE(actions.size() == 2);
+    ASSERT_EQ(actions.size(), 2);
     for (auto const& action : actions) {
-      ASSERT_TRUE(action.name() == "CreateCollection");
+      ASSERT_EQ(action.name(), "CreateCollection");
     }
   }
 }
@@ -578,7 +857,7 @@ TEST_F(MaintenanceTestActionPhaseOne, add_an_index_to_queues) {
 
     arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
                                          local.toBuilder().slice(), node.first,
-                                         errors, feature, actions);
+                                         errors, *feature, actions);
 
     size_t n = 0;
     for (auto const& shard : shards) {
@@ -590,9 +869,9 @@ TEST_F(MaintenanceTestActionPhaseOne, add_an_index_to_queues) {
     if (actions.size() != n) {
       std::cout << __FILE__ << ":" << __LINE__ << " " << actions << std::endl;
     }
-    ASSERT_TRUE(actions.size() == n);
+    ASSERT_EQ(actions.size(), n);
     for (auto const& action : actions) {
-      ASSERT_TRUE(action.name() == "EnsureIndex");
+      ASSERT_EQ(action.name(), "EnsureIndex");
     }
   }
 }
@@ -614,7 +893,7 @@ TEST_F(MaintenanceTestActionPhaseOne, remove_an_index_from_plan) {
 
     arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
                                          local.toBuilder().slice(), node.first,
-                                         errors, feature, actions);
+                                         errors, *feature, actions);
 
     size_t n = 0;
     for (auto const& shard : shards) {
@@ -626,9 +905,9 @@ TEST_F(MaintenanceTestActionPhaseOne, remove_an_index_from_plan) {
     if (actions.size() != n) {
       std::cout << __FILE__ << ":" << __LINE__ << " " << actions << std::endl;
     }
-    ASSERT_TRUE(actions.size() == n);
+    ASSERT_EQ(actions.size(), n);
     for (auto const& action : actions) {
-      ASSERT_TRUE(action.name() == "DropIndex");
+      ASSERT_EQ(action.name(), "DropIndex");
     }
   }
 }
@@ -642,16 +921,16 @@ TEST_F(MaintenanceTestActionPhaseOne, add_one_collection_to_local) {
 
     arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
                                          node.second.toBuilder().slice(),
-                                         node.first, errors, feature, actions);
+                                         node.first, errors, *feature, actions);
 
     if (actions.size() != 1) {
       std::cout << __FILE__ << ":" << __LINE__ << " " << actions << std::endl;
     }
-    ASSERT_TRUE(actions.size() == 1);
+    ASSERT_EQ(actions.size(), 1);
     for (auto const& action : actions) {
-      ASSERT_TRUE(action.name() == "DropCollection");
-      ASSERT_TRUE(action.get("database") == "_system");
-      ASSERT_TRUE(action.get("collection") == "s1111112");
+      ASSERT_EQ(action.name(), "DropCollection");
+      ASSERT_EQ(action.get("database"), "_system");
+      ASSERT_EQ(action.get("collection"), "s1111112");
     }
   }
 }
@@ -674,22 +953,380 @@ TEST_F(MaintenanceTestActionPhaseOne,
 
     arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
                                          node.second.toBuilder().slice(),
-                                         node.first, errors, feature, actions);
+                                         node.first, errors, *feature, actions);
 
     /*
     if (actions.size() != 1) {
       std::cout << __FILE__ << ":" << __LINE__ << " " << actions  << std::endl;
     }
-    ASSERT_TRUE(actions.size() == 1);
+    ASSERT_EQ(actions.size(), 1);
     for (auto const& action : actions) {
 
-      ASSERT_TRUE(action.name() == "UpdateCollection");
-      ASSERT_TRUE(action.get("shard") == shname);
-      ASSERT_TRUE(action.get("database") == dbname);
+      ASSERT_EQ(action.name(), "UpdateCollection");
+      ASSERT_EQ(action.get("shard"), shname);
+      ASSERT_EQ(action.get("database"), dbname);
       auto const props = action.properties();
 
     }
     */
+  }
+}
+
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_self_local_self) {
+  plan = originalPlan;
+  takeLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    takeLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<ActionDescription> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 0);
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_resign_self_local_self) {
+  plan = originalPlan;
+  resignLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    takeLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<ActionDescription> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 2);
+    for (auto const& action : actions) {
+      assertIsResignLeadershipAction(action, dbName());
+      auto shardName = action.get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_other_local_self) {
+  plan = originalPlan;
+  otherTakeLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    takeLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<ActionDescription> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 2);
+    for (auto const& action : actions) {
+      assertIsResignLeadershipAction(action, dbName());
+      auto shardName = action.get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_resign_other_local_self) {
+  plan = originalPlan;
+  otherTakeResignedLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    takeLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<ActionDescription> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    for (auto const& action : actions) {
+      assertIsResignLeadershipAction(action, dbName());
+      auto shardName = action.get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_self_local_other) {
+  plan = originalPlan;
+  takeLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    otherTakeLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<ActionDescription> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 2);
+    for (auto const& action : actions) {
+      assertIsTakeoverLeadershipAction(action, dbName(), planId());
+      auto shardName = action.get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+      EXPECT_EQ(action.get(THE_LEADER), "");
+      EXPECT_EQ(action.get(LOCAL_LEADER), unusedServer());
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_resign_self_local_other) {
+  plan = originalPlan;
+  resignLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    otherTakeLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<ActionDescription> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 2);
+    for (auto const& action : actions) {
+      assertIsResignLeadershipAction(action, dbName());
+      auto shardName = action.get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_other_local_other) {
+  plan = originalPlan;
+  otherTakeLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    otherTakeLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<ActionDescription> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 0);
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_resign_other_local_other) {
+  plan = originalPlan;
+  otherTakeResignedLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    otherTakeLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<ActionDescription> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 0);
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_self_local_resigned) {
+  plan = originalPlan;
+  takeLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    resignLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<ActionDescription> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 2);
+    for (auto const& action : actions) {
+      assertIsTakeoverLeadershipAction(action, dbName(), planId());
+      auto shardName = action.get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+      EXPECT_EQ(action.get(THE_LEADER), "");
+      EXPECT_EQ(action.get(LOCAL_LEADER), ResignShardLeadership::LeaderNotYetKnownString);
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_resign_self_local_resigned) {
+  plan = originalPlan;
+  resignLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    resignLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<ActionDescription> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 0);
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_other_local_resigned) {
+  plan = originalPlan;
+  otherTakeLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    resignLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<ActionDescription> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    // Synchronize in Phase 2 is responsible for this.
+    ASSERT_EQ(actions.size(), 0);
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_resign_other_local_resigned) {
+  plan = originalPlan;
+  otherTakeResignedLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    resignLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<ActionDescription> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    // Synchronize in Phase 2 is responsible for this.
+    ASSERT_EQ(actions.size(), 0);
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_self_local_reboot) {
+  plan = originalPlan;
+  takeLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    rebootLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<ActionDescription> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 2);
+    for (auto const& action : actions) {
+      assertIsTakeoverLeadershipAction(action, dbName(), planId());
+      auto shardName = action.get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+      EXPECT_EQ(action.get(THE_LEADER), "");
+      EXPECT_EQ(action.get(LOCAL_LEADER), LEADER_NOT_YET_KNOWN);
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_resign_self_local_reboot) {
+  plan = originalPlan;
+  resignLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    rebootLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<ActionDescription> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), 2);
+    for (auto const& action : actions) {
+      assertIsResignLeadershipAction(action, dbName());
+      auto shardName = action.get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_other_local_reboot) {
+  plan = originalPlan;
+  otherTakeLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    rebootLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<ActionDescription> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+    
+    // We will just resign in this case to get a clear state.
+    ASSERT_EQ(actions.size(), 2);
+    for (auto const& action : actions) {
+      assertIsResignLeadershipAction(action, dbName());
+      auto shardName = action.get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_resign_other_local_reboot) {
+  plan = originalPlan;
+  otherTakeResignedLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto [server, local]  : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), server, originalPlan);
+    rebootLeadershipLocal(dbName(), relevantShards, local);
+
+    std::vector<ActionDescription> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
+                                         local.toBuilder().slice(),
+                                         server, errors, *feature, actions);
+
+    // We will just resign in this case to get a clear state.
+    ASSERT_EQ(actions.size(), 2);
+    for (auto const& action : actions) {
+      assertIsResignLeadershipAction(action, dbName());
+      auto shardName = action.get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
+    }
   }
 }
 
@@ -700,7 +1337,7 @@ TEST_F(MaintenanceTestActionPhaseOne, have_theleader_set_to_empty) {
   for (auto node : localNodes) {
     std::vector<ActionDescription> actions;
 
-    auto& collection = *node.second("foo").children().begin()->second;
+    auto& collection = *node.second(dbName()).children().begin()->second;
     auto& leader = collection("theLeader");
 
     bool check = false;
@@ -711,19 +1348,39 @@ TEST_F(MaintenanceTestActionPhaseOne, have_theleader_set_to_empty) {
 
     arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
                                          node.second.toBuilder().slice(),
-                                         node.first, errors, feature, actions);
+                                         node.first, errors, *feature, actions);
 
     if (check) {
       if (actions.size() != 1) {
         std::cout << __FILE__ << ":" << __LINE__ << " " << actions << std::endl;
       }
-      ASSERT_TRUE(actions.size() == 1);
+      ASSERT_EQ(actions.size(), 1);
       for (auto const& action : actions) {
-        ASSERT_TRUE(action.name() == "TakeoverShardLeadership");
-        ASSERT_TRUE(action.has("shard"));
-        ASSERT_TRUE(action.get("shard") == collection("name").getString());
-        ASSERT_TRUE(action.get("localLeader").empty());
+        assertIsResignLeadershipAction(action, dbName());
+        ASSERT_EQ(action.get("shard"), collection("name").getString());
       }
+    }
+  }
+}
+
+TEST_F(MaintenanceTestActionPhaseOne, resign_leadership_plan) {
+  plan = originalPlan;
+  resignLeadershipPlan(dbName(), planId(), plan);
+
+  for (auto node : localNodes) {
+    auto relevantShards = getShardsForServer(dbName(), planId(), node.first, originalPlan);
+    std::vector<ActionDescription> actions;
+    // every server is responsible for two shards of dbName() and planId()
+    arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
+                                         node.second.toBuilder().slice(),
+                                         node.first, errors, *feature, actions);
+
+    ASSERT_EQ(actions.size(), relevantShards.size());
+    for (auto const& action : actions) {
+      assertIsResignLeadershipAction(action, dbName());
+      auto shardName = action.get(SHARD);
+      auto removed = relevantShards.erase(shardName);
+      EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
     }
   }
 }
@@ -740,11 +1397,11 @@ TEST_F(MaintenanceTestActionPhaseOne,
 
     arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
                                          node.second.toBuilder().slice(),
-                                         node.first, errors, feature, actions);
+                                         node.first, errors, *feature, actions);
 
-    ASSERT_TRUE(actions.size() == node.second("db3").children().size());
+    ASSERT_EQ(actions.size(), node.second("db3").children().size());
     for (auto const& action : actions) {
-      ASSERT_TRUE(action.name() == "DropCollection");
+      ASSERT_EQ(action.name(), "DropCollection");
     }
   }
 }
@@ -767,7 +1424,7 @@ TEST_F(MaintenanceTestActionPhaseOne, resign_leadership) {
       Slice servers = shardBuilder.slice();
 
       ASSERT_TRUE(servers.isArray());
-      ASSERT_TRUE(servers.length() == 2);
+      ASSERT_EQ(servers.length(), 2);
       auto const leader = servers[0].copyString();
       auto const follower = servers[1].copyString();
 
@@ -785,15 +1442,14 @@ TEST_F(MaintenanceTestActionPhaseOne, resign_leadership) {
 
     arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
                                          node.second.toBuilder().slice(),
-                                         node.first, errors, feature, actions);
+                                         node.first, errors, *feature, actions);
 
-    if (actions.size() != 2) {
+    if (actions.size() != 1) {
       std::cout << actions << std::endl;
     }
-    ASSERT_TRUE(actions.size() == 1);
-    ASSERT_TRUE(actions[0].name() == "ResignShardLeadership");
-    ASSERT_TRUE(actions[0].get(DATABASE) == dbname);
-    ASSERT_TRUE(actions[0].get(SHARD) == shname);
+    ASSERT_EQ(actions.size(), 1);
+    assertIsResignLeadershipAction(actions[0], "_system");
+    ASSERT_EQ(actions[0].get(SHARD), shname);
   }
 }
 
@@ -815,26 +1471,24 @@ TEST_F(MaintenanceTestActionPhaseOne, removed_follower_in_plan_must_be_dropped) 
 
     arangodb::maintenance::diffPlanLocal(plan.toBuilder().slice(),
                                          node.second.toBuilder().slice(),
-                                         node.first, errors, feature, actions);
+                                         node.first, errors, *feature, actions);
 
     if (node.first == followerName) {
       // Must see an action dropping the shard
-      ASSERT_TRUE(actions.size() == 1);
-      ASSERT_TRUE(actions.front().name() == "DropCollection");
-      ASSERT_TRUE(actions.front().get(DATABASE) == dbname);
-      ASSERT_TRUE(actions.front().get(COLLECTION) == shname);
+      ASSERT_EQ(actions.size(), 1);
+      ASSERT_EQ(actions.front().name(), "DropCollection");
+      ASSERT_EQ(actions.front().get(DATABASE), dbname);
+      ASSERT_EQ(actions.front().get(COLLECTION), shname);
     } else if (node.first == leaderName) {
       // Must see an UpdateCollection action to drop the follower
-      ASSERT_TRUE(actions.size() == 1);
-      ASSERT_TRUE(actions.front().name() == "UpdateCollection");
-      ASSERT_TRUE(actions.front().get(DATABASE) == dbname);
-      ASSERT_TRUE(actions.front().get(SHARD) == shname);
-      ASSERT_TRUE(actions.front().get(FOLLOWERS_TO_DROP) == followerName);
+      ASSERT_EQ(actions.size(), 1);
+      ASSERT_EQ(actions.front().name(), "UpdateCollection");
+      ASSERT_EQ(actions.front().get(DATABASE), dbname);
+      ASSERT_EQ(actions.front().get(SHARD), shname);
+      ASSERT_EQ(actions.front().get(FOLLOWERS_TO_DROP), followerName);
     } else {
       // No actions required
-      ASSERT_TRUE(actions.size() == 0);
+      ASSERT_EQ(actions.size(), 0);
     }
   }
 }
-
-#endif

--- a/tests/Maintenance/MaintenanceTest.cpp
+++ b/tests/Maintenance/MaintenanceTest.cpp
@@ -68,17 +68,6 @@ char const* dbs1Str =
 char const* dbs2Str =
 #include "DBServer0003.json"
     ;
-#else  // _WIN32
-#include <Windows.h>
-#include "jsonresource.h"
-LPSTR planStr = nullptr;
-LPSTR currentStr = nullptr;
-LPSTR supervisionStr = nullptr;
-LPSTR dbs0Str = nullptr;
-LPSTR dbs1Str = nullptr;
-LPSTR dbs2Str = nullptr;
-
-#endif  // _WIN32
 
 // Random stuff
 std::random_device rd{};
@@ -1512,3 +1501,6 @@ TEST_F(MaintenanceTestActionPhaseOne, removed_follower_in_plan_must_be_dropped) 
     }
   }
 }
+
+#endif  // _WIN32
+


### PR DESCRIPTION
During a move-shard job which moves the leader there is a
situation in which the old owner of a shard can reclaim ownership
(after having resigned already), with a small race where it allows to
write documents only locally, but then continue the move-shard to a
server without those documents. An additional bug in the MoveShard
Supervision job would then leave the shard in a bad configuration
with a resigned leader permanently in charge.