### PR TITLE
remove 3.6 compatibility API for getSome and friends

### DIFF
--- a/arangod/Aql/ClusterNodes.h
+++ b/arangod/Aql/ClusterNodes.h
@@ -57,16 +57,10 @@ class RemoteNode final : public DistributeConsumerNode {
   friend class ExecutionBlock;
 
  public:
-  /// @brief Type of API; the legacy pre-3.7 getSome/skipSome API, or the
-  ///        execute API. Used for rolling upgrades. Can be removed in 3.8.
-  ///        It is serialized as an integral, changing the values will break the
-  ///        API!
-  enum class Api { GET_SOME = 0, EXECUTE = 1 };
-
   /// @brief constructor with an id
   RemoteNode(ExecutionPlan* plan, ExecutionNodeId id, TRI_vocbase_t* vocbase,
              std::string server, std::string const& ownName,
-             std::string queryId, Api = Api::EXECUTE)
+             std::string queryId)
       : DistributeConsumerNode(plan, id, ownName),
         _vocbase(vocbase),
         _server(std::move(server)),
@@ -92,7 +86,7 @@ class RemoteNode final : public DistributeConsumerNode {
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
                        bool withProperties) const override final {
     return cloneHelper(std::make_unique<RemoteNode>(plan, _id, _vocbase, _server,
-                                                    getDistributeId(), _queryId, _apiToUse),
+                                                    getDistributeId(), _queryId),
                        withDependencies, withProperties);
   }
 
@@ -119,12 +113,6 @@ class RemoteNode final : public DistributeConsumerNode {
     _queryId = arangodb::basics::StringUtils::itoa(queryId);
   }
 
-  [[nodiscard]] auto api() const noexcept -> Api;
-
- private:
-  static auto apiToVpack(Api) -> velocypack::Value;
-  static auto getApiProperty(VPackSlice slice, std::string const& key) -> Api;
-
  private:
   /// @brief the underlying database
   TRI_vocbase_t* _vocbase;
@@ -134,10 +122,6 @@ class RemoteNode final : public DistributeConsumerNode {
 
   /// @brief the ID of the query on the server as a string
   std::string _queryId;
-
-  /// @brief Whether to use the pre-3.7 getSome/skipSome API, instead of the
-  ///        execute API. Used for rolling upgrades, so can be removed in 3.8.
-  Api _apiToUse = Api::EXECUTE;
 };
 
 /// @brief class ScatterNode

--- a/arangod/Aql/ModificationOptions.cpp
+++ b/arangod/Aql/ModificationOptions.cpp
@@ -52,12 +52,6 @@ ModificationOptions::ModificationOptions(VPackSlice const& slice)
   consultAqlWriteFilter =
       basics::VelocyPackHelper::getBooleanValue(obj, "consultAqlWriteFilter", false);
   exclusive = basics::VelocyPackHelper::getBooleanValue(obj, "exclusive", false);
-
-  // legacy: remove in ArangoDB 3.8 
-  VPackSlice s = obj.get("nullMeansRemove");
-  if (s.isBoolean()) {
-    keepNull = !s.getBoolean();
-  }
 }
 
 void ModificationOptions::toVelocyPack(VPackBuilder& builder) const {
@@ -81,7 +75,4 @@ void ModificationOptions::toVelocyPack(VPackBuilder& builder) const {
   builder.add("readCompleteInput", VPackValue(readCompleteInput));
   builder.add("consultAqlWriteFilter", VPackValue(consultAqlWriteFilter));
   builder.add("exclusive", VPackValue(exclusive));
-
-  // legacy: remove in ArangoDB 3.8 
-  builder.add("nullMeansRemove", VPackValue(!keepNull));
 }

--- a/arangod/Aql/RemoteExecutor.cpp
+++ b/arangod/Aql/RemoteExecutor.cpp
@@ -65,7 +65,7 @@ constexpr std::chrono::seconds kDefaultTimeOutSecs(3600);
 ExecutionBlockImpl<RemoteExecutor>::ExecutionBlockImpl(
     ExecutionEngine* engine, RemoteNode const* node, RegisterInfos&& registerInfos,
     std::string const& server, std::string const& distributeId,
-    std::string const& queryId, Api const api)
+    std::string const& queryId)
     : ExecutionBlock(engine, node),
       _registerInfos(std::move(registerInfos)),
       _query(engine->getQuery()),
@@ -75,8 +75,7 @@ ExecutionBlockImpl<RemoteExecutor>::ExecutionBlockImpl(
       _isResponsibleForInitializeCursor(node->isResponsibleForInitializeCursor()),
       _lastError(TRI_ERROR_NO_ERROR),
       _lastTicket(0),
-      _requestInFlight(false),
-      _apiToUse(api) {
+      _requestInFlight(false) {
   TRI_ASSERT(!queryId.empty());
   TRI_ASSERT((arangodb::ServerState::instance()->isCoordinator() && distributeId.empty()) ||
              (!arangodb::ServerState::instance()->isCoordinator() && !distributeId.empty()));
@@ -316,52 +315,6 @@ std::pair<ExecutionState, Result> ExecutionBlockImpl<RemoteExecutor>::initialize
   return {ExecutionState::WAITING, TRI_ERROR_NO_ERROR};
 }
 
-auto ExecutionBlockImpl<RemoteExecutor>::executeViaOldApi(AqlCallStack stack)
-    -> std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> {
-  // Use the old getSome/SkipSome API.
-  auto myCallList = stack.popCall();
-  auto myCall = myCallList.popNextCall();
-
-  TRI_ASSERT(AqlCall::IsSkipSomeCall(myCall) || AqlCall::IsGetSomeCall(myCall) ||
-             AqlCall::IsFullCountCall(myCall) || AqlCall::IsFastForwardCall(myCall));
-
-  if (AqlCall::IsSkipSomeCall(myCall)) {
-    auto const [state, skipped] = skipSomeWithoutTrace(myCall.getOffset());
-    if (state != ExecutionState::WAITING) {
-      myCall.didSkip(skipped);
-    }
-    SkipResult skipRes{};
-    skipRes.didSkip(skipped);
-    return {state, skipRes, nullptr};
-  } else if (AqlCall::IsGetSomeCall(myCall)) {
-    auto const [state, block] = getSomeWithoutTrace(myCall.getLimit());
-    // We do not need to count as softLimit will be overwritten, and hard cannot be set.
-    if (stack.empty() && myCall.hasHardLimit() && !myCall.needsFullCount() && block != nullptr) {
-      // However we can do a short-cut here to report DONE on hardLimit if we are on the top-level query.
-      myCall.didProduce(block->size());
-      if (myCall.getLimit() == 0) {
-        return {ExecutionState::DONE, SkipResult{}, std::move(block)};
-      }
-    }
-
-    return {state, SkipResult{}, std::move(block)};
-  } else if (AqlCall::IsFullCountCall(myCall)) {
-    auto const [state, skipped] = skipSomeWithoutTrace(ExecutionBlock::SkipAllSize());
-    if (state != ExecutionState::WAITING) {
-      myCall.didSkip(skipped);
-    }
-    SkipResult skipRes{};
-    skipRes.didSkip(skipped);
-    return {state, skipRes, nullptr};
-  } else if (AqlCall::IsFastForwardCall(myCall)) {
-    // No idea if DONE is correct here...
-    return {ExecutionState::DONE, SkipResult{}, nullptr};
-  }
-
-  // Should never get here!
-  THROW_ARANGO_EXCEPTION(TRI_ERROR_INTERNAL_AQL);
-}
-
 auto ExecutionBlockImpl<RemoteExecutor>::execute(AqlCallStack stack)
     -> std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> {
   traceExecuteBegin(stack);
@@ -378,10 +331,6 @@ auto ExecutionBlockImpl<RemoteExecutor>::execute(AqlCallStack stack)
 
 auto ExecutionBlockImpl<RemoteExecutor>::executeWithoutTrace(AqlCallStack stack)
     -> std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> {
-  if (ADB_UNLIKELY(api() == Api::GET_SOME)) {
-    return executeViaOldApi(stack);
-  }
-  TRI_ASSERT(api() == Api::EXECUTE);
   return executeViaNewApi(stack);
 }
 
@@ -484,10 +433,6 @@ auto ExecutionBlockImpl<RemoteExecutor>::serializeExecuteCallBody(AqlCallStack c
     builder.close();
   }
   return buffer;
-}
-
-auto ExecutionBlockImpl<RemoteExecutor>::api() const noexcept -> Api {
-  return _apiToUse;
 }
 
 namespace {

--- a/arangod/Aql/RemoteExecutor.h
+++ b/arangod/Aql/RemoteExecutor.h
@@ -52,22 +52,18 @@ class RemoteExecutor final {};
 template <>
 class ExecutionBlockImpl<RemoteExecutor> : public ExecutionBlock {
  public:
-  using Api = ::arangodb::aql::RemoteNode::Api;
-
   // TODO Even if it's not strictly necessary here, for consistency's sake the
   // non-standard arguments (server, ownName and queryId) should probably be
   // moved into some RemoteExecutorInfos class.
   ExecutionBlockImpl(ExecutionEngine* engine, RemoteNode const* node,
                      RegisterInfos&& infos, std::string const& server,
-                     std::string const& distributeId, std::string const& queryId, Api);
+                     std::string const& distributeId, std::string const& queryId);
 
   ~ExecutionBlockImpl() override = default;
 
   std::pair<ExecutionState, Result> initializeCursor(InputAqlItemRow const& input) override;
 
   std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> execute(AqlCallStack stack) override;
-
-  [[nodiscard]] auto api() const noexcept -> Api;
 
   std::string const& distributeId() const { return _distributeId; }
 
@@ -87,9 +83,6 @@ class ExecutionBlockImpl<RemoteExecutor> : public ExecutionBlock {
   std::pair<ExecutionState, size_t> skipSomeWithoutTrace(size_t atMost);
 
   auto executeWithoutTrace(AqlCallStack stack)
-      -> std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr>;
-
-  auto executeViaOldApi(AqlCallStack stack)
       -> std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr>;
 
   auto executeViaNewApi(AqlCallStack stack)
@@ -150,10 +143,6 @@ class ExecutionBlockImpl<RemoteExecutor> : public ExecutionBlock {
   unsigned _lastTicket;  /// used to check for canceled requests
 
   bool _requestInFlight;
-
-  /// @brief Whether to use the pre-3.7 getSome/skipSome API, instead of the
-  ///        execute API. Used for rolling upgrades, so can be removed in 3.8.
-  Api _apiToUse = Api::EXECUTE;
 };
 
 }  // namespace arangodb::aql

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -326,7 +326,6 @@ std::string const StaticStrings::BackupSearchToDeleteName(
 
 // aql api strings
 std::string const StaticStrings::SerializationFormat("serializationFormat");
-std::string const StaticStrings::AqlRemoteApi("api");
 std::string const StaticStrings::AqlRemoteExecute("execute");
 std::string const StaticStrings::AqlRemoteCallStack("callStack");
 std::string const StaticStrings::AqlRemoteLimit("limit");

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -300,7 +300,6 @@ class StaticStrings {
 
   // aql api strings
   static std::string const SerializationFormat;
-  static std::string const AqlRemoteApi;
   static std::string const AqlRemoteExecute;
   static std::string const AqlRemoteCallStack;
   static std::string const AqlRemoteLimit;


### PR DESCRIPTION
### Scope & Purpose

Remove some 3.6-compatibility APIs for AQL, that were only needed for rolling upgrades from 3.6 to 3.7.

- [ ] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [x] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is already covered by existing tests, such as *(please describe tests)*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11568/