### PR TITLE
simplify validation code

### DIFF
--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -7683,7 +7683,7 @@ AqlValue Functions::SchemaGet(ExpressionContext* expressionContext,
   }
 
   transaction::BuilderLeaser builder(trx);
-  logicalCollection->validatorsToVelocyPack(*builder.get());
+  logicalCollection->schemaToVelocyPack(*builder.get());
   VPackSlice slice = builder->slice();
 
   if (!slice.isObject()) {

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -2899,7 +2899,7 @@ Result ClusterInfo::setCollectionPropertiesCoordinator(std::string const& databa
            VPackValue(info->usesRevisionsAsDocumentIds()));
   temp.add(StaticStrings::SyncByRevision, VPackValue(info->syncByRevision()));
   temp.add(VPackValue(StaticStrings::Schema));
-  info->validatorsToVelocyPack(temp);
+  info->schemaToVelocyPack(temp);
   info->getPhysical()->getPropertiesVPack(temp);
   temp.close();
 

--- a/arangod/VocBase/LogicalCollection.h
+++ b/arangod/VocBase/LogicalCollection.h
@@ -314,7 +314,7 @@ class LogicalCollection : public LogicalDataSource {
 
   // SECTION: Key Options
   velocypack::Slice keyOptions() const;
-  void validatorsToVelocyPack(VPackBuilder&) const;
+  void schemaToVelocyPack(VPackBuilder&) const;
   Result validate(VPackSlice newDoc, VPackOptions const*) const; // insert
   Result validate(VPackSlice modifiedDoc, VPackSlice oldDoc, VPackOptions const*) const; // update / replace
 
@@ -339,7 +339,7 @@ class LogicalCollection : public LogicalDataSource {
   virtual arangodb::Result appendVelocyPack(arangodb::velocypack::Builder& builder,
                                            Serialization context) const override;
 
-  Result updateValidators(VPackSlice validatorArray);
+  Result updateSchema(VPackSlice schema);
 
  private:
   void prepareIndexes(velocypack::Slice indexesSlice);
@@ -414,10 +414,9 @@ class LogicalCollection : public LogicalDataSource {
   /// @brief sharding information
   std::unique_ptr<ShardingInfo> _sharding;
 
-  using ValidatorVec = std::vector<std::unique_ptr<arangodb::ValidatorBase>>;
-  // `_validators` must be used with atomic accessors only!!
+  // `_schema` must be used with atomic accessors only!!
   // We use relaxed access (load/store) as we only care about atomicity.
-  std::shared_ptr<ValidatorVec> _validators;
+  std::shared_ptr<arangodb::ValidatorBase> _schema;
 };
 
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose

Initially, we created the validation code with having multiple validators per collection in mind. But at some point we settled on having just one or zero schemas for each collection. This PR adjusts the underlying code to reflect that change:
There is either a schema present or no schema.

- [ ] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [x] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required
- [ ] Backports required for: *(Please specify versions)*

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] This change is already covered by existing tests, such as *shell_server*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11632/