### PR TITLE
allow calling additional APIs on followers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Allow calling of REST APIs `/_api/engine/stats`, GET `/_api/collection` and
+  GET `/_api/database/current` on followers in active failover deployments. 
+  This can help debugging and inspecting the follower.
+
 * Don't allow creation of smart satellite graphs or collections (i.e. using
   `"isSmart":true` together with `"replicationFactor":"satellite"` when creating
   graphs or collections. This combination of parameters makes no sense, so that

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -193,7 +193,10 @@ CommTask::Flow CommTask::prepareExecution(auth::TokenCache::Entry const& authTok
           !::startsWith(path, "/_admin/status") &&
           !::startsWith(path, "/_admin/statistics") &&
           !::startsWith(path, "/_api/agency/agency-callbacks") &&
+          !(req.requestType() == RequestType::GET && ::startsWith(path, "/_api/collection")) &&
           !::startsWith(path, "/_api/cluster/") &&
+          !(req.requestType() == RequestType::GET && path == "/_api/database/current") &&
+          !::startsWith(path, "/_api/engine/stats") &&
           !::startsWith(path, "/_api/replication") &&
           !::startsWith(path, "/_api/ttl/statistics") &&
           (mode == ServerState::Mode::TRYAGAIN ||


### PR DESCRIPTION
### Scope & Purpose

Allow calling of REST APIs `/_api/engine/stats`, GET `/_api/collection` and GET `/_api/database/current` on followers in active failover deployments. 
This can help debugging and inspecting the follower.

- [ ] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required
- [ ] Backports required for: *(Please specify versions)*

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11658/