### PR TITLE
expose disk space metrics for RocksDB database directory

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 devel
 -----
 
+* Added new metrics for the total and the free disk space for the mount
+  used for the RocksDB database directory:
+
+  * `arangodb_rocksdb_free_disk_space`: provides the free disk space for
+    the mount, in bytes
+  * `arangodb_rocksdb_free_disk_space`: provides the total disk space of
+    the mount, in bytes
+
 * Don't allow creation of smart satellite graphs or collections (i.e. using
   `"isSmart":true` together with `"replicationFactor":"satellite"` when creating
   graphs or collections. This combination of parameters makes no sense, so that

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@ devel
 
   * `arangodb_rocksdb_free_disk_space`: provides the free disk space for
     the mount, in bytes
-  * `arangodb_rocksdb_free_disk_space`: provides the total disk space of
+  * `arangodb_rocksdb_total_disk_space`: provides the total disk space of
     the mount, in bytes
 
 * Apply user-defined idle connection timeouts for HTTP/2 and VST connections.

--- a/arangod/Pregel/Algos/DMID/DMID.cpp
+++ b/arangod/Pregel/Algos/DMID/DMID.cpp
@@ -21,7 +21,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "DMID.h"
-#include <cmath>
+#include "Basics/StringUtils.h"
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
 #include "Pregel/Aggregator.h"
@@ -32,6 +32,8 @@
 #include "Pregel/IncomingCache.h"
 #include "Pregel/MasterContext.h"
 #include "Pregel/VertexComputation.h"
+
+#include <cmath>
 
 using namespace arangodb;
 using namespace arangodb::pregel;

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2311,6 +2311,22 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
   if (_listener) {
     builder.add("rocksdbengine.throttle.bps", VPackValue(_listener->GetThrottle()));
   }  // if
+  
+  {
+    // total disk space in database directory
+    uint64_t totalSpace = 0;
+    // free disk space in database directory
+    uint64_t freeSpace = 0;
+    Result res = TRI_GetDiskSpace(_basePath, totalSpace, freeSpace);
+    if (res.ok()) {
+      builder.add("rocksdb.free-disk-space", VPackValue(freeSpace));
+      builder.add("rocksdb.total-disk-space", VPackValue(totalSpace));
+    } else {
+      builder.add("rocksdb.free-disk-space", VPackValue(VPackValueType::Null));
+      builder.add("rocksdb.total-disk-space", VPackValue(VPackValueType::Null));
+    }
+  }
+
 
   builder.close();
 }

--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -2632,7 +2632,7 @@ arangodb::Result TRI_GetDiskSpace(std::string const& path,
   PULARGE_INTEGER totalNumberOfBytes;
   if (GetDiskFreeSpaceExW(toWString(path).data(), freeBytesAvailableToCaller, totalNumberOfBytes, nullptr) == 0) {
     DWORD lastError = GetLastError();
-    return {TRI_ERROR_SYS_ERROR, translateWindowsError(::GetLastError()) };
+    return translateWindowsError(::GetLastError());
   }
   freeSpace = static_cast<uint64_t>(freeBytesAvailableToCaller.QuadPart);
   totalSpace = static_cast<uint64_t>(totalNumberOfBytes.QuadPart);

--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -2644,8 +2644,8 @@ arangodb::Result TRI_GetDiskSpace(std::string const& path,
     TRI_set_errno(TRI_ERROR_SYS_ERROR);
     return {TRI_errno(), TRI_last_error()};
   }
-  totalSpace = static_cast<uint64_t>(stat.f_bsize) * static_cast<uint64_t>(stat.f_blocks);
-  freeSpace = static_cast<uint64_t>(stat.f_bsize) * static_cast<uint64_t>(stat.f_bfree);
+  totalSpace = static_cast<uint64_t>(stat.f_frsize) * static_cast<uint64_t>(stat.f_blocks);
+  freeSpace = static_cast<uint64_t>(stat.f_frsize) * static_cast<uint64_t>(stat.f_bfree);
 #endif
   return {};
 }

--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -44,6 +44,10 @@
 #include <windows.h>
 #endif
 
+#ifndef _WIN32
+#include <sys/statvfs.h>
+#endif
+
 #ifdef TRI_HAVE_DIRENT_H
 #include <dirent.h>
 #endif
@@ -332,8 +336,7 @@ bool TRI_CreateSymbolicLink(std::string const& target,
   int res = symlink(target.c_str(), linkpath.c_str());
 
   if (res < 0) {
-    error = "failed to create a symlink " + target + " -> " + linkpath + " - " +
-            strerror(errno);
+    error = "failed to create a symlink " + target + " -> " + linkpath + " - " + strerror(errno);
   }
   return res == 0;
 #endif
@@ -2618,6 +2621,33 @@ bool TRI_PathIsAbsolute(std::string const& path) {
 #else
   return (!path.empty()) && path.c_str()[0] == '/';
 #endif
+}
+
+/// @brief return the amount of total and free disk space for the given path
+arangodb::Result TRI_GetDiskSpace(std::string const& path, 
+                                  uint64_t& totalSpace, 
+                                  uint64_t& freeSpace) {
+#if _WIN32
+  PULARGE_INTEGER freeBytesAvailableToCaller;
+  PULARGE_INTEGER totalNumberOfBytes;
+  if (GetDiskFreeSpaceExW(toWString(path).data(), &freeBytesAvailableToCaller, &totalNumberOfBytes, nullptr) == 0) {
+    DWORD lastError = GetLastError();
+    return {TRI_ERROR_SYS_ERROR, translateWindowsError(::GetLastError()) };
+  }
+  freeSpace = static_cast<uint64_t>(freeBytesAvailableToCaller.QuadPart);
+  totalSpace = static_cast<uint64_t>(totalNumberOfBytes.QuadPart);
+#else
+  struct statvfs stat;
+
+  if (statvfs(path.c_str(), &stat) == -1) {
+    TRI_SYSTEM_ERROR();
+    TRI_set_errno(TRI_ERROR_SYS_ERROR);
+    return {TRI_errno(), TRI_last_error()};
+  }
+  totalSpace = static_cast<uint64_t>(stat.f_bsize) * static_cast<uint64_t>(stat.f_blocks);
+  freeSpace = static_cast<uint64_t>(stat.f_bsize) * static_cast<uint64_t>(stat.f_bfree);
+#endif
+  return {};
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -2630,7 +2630,7 @@ arangodb::Result TRI_GetDiskSpace(std::string const& path,
 #if _WIN32
   PULARGE_INTEGER freeBytesAvailableToCaller;
   PULARGE_INTEGER totalNumberOfBytes;
-  if (GetDiskFreeSpaceExW(toWString(path).data(), &freeBytesAvailableToCaller, &totalNumberOfBytes, nullptr) == 0) {
+  if (GetDiskFreeSpaceExW(toWString(path).data(), freeBytesAvailableToCaller, totalNumberOfBytes, nullptr) == 0) {
     DWORD lastError = GetLastError();
     return {TRI_ERROR_SYS_ERROR, translateWindowsError(::GetLastError()) };
   }

--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -2628,9 +2628,9 @@ arangodb::Result TRI_GetDiskSpace(std::string const& path,
                                   uint64_t& totalSpace, 
                                   uint64_t& freeSpace) {
 #if _WIN32
-  PULARGE_INTEGER freeBytesAvailableToCaller;
-  PULARGE_INTEGER totalNumberOfBytes;
-  if (GetDiskFreeSpaceExW(toWString(path).data(), freeBytesAvailableToCaller, totalNumberOfBytes, nullptr) == 0) {
+  ULARGE_INTEGER freeBytesAvailableToCaller;
+  ULARGE_INTEGER totalNumberOfBytes;
+  if (GetDiskFreeSpaceExW(toWString(path).data(), &freeBytesAvailableToCaller, &totalNumberOfBytes, nullptr) == 0) {
     DWORD lastError = GetLastError();
     return translateWindowsError(::GetLastError());
   }

--- a/lib/Basics/files.h
+++ b/lib/Basics/files.h
@@ -36,7 +36,7 @@
 #include <openssl/evp.h>
 
 #include "Basics/Common.h"
-#include "Basics/StringUtils.h"
+#include "Basics/Result.h"
 #include "Basics/debugging.h"
 
 #ifdef USE_ENTERPRISE
@@ -397,6 +397,11 @@ int TRI_CreateDatafile(std::string const& filename, size_t maximalSize);
 ////////////////////////////////////////////////////////////////////////////////
 
 bool TRI_PathIsAbsolute(std::string const& path);
+
+/// @brief return the amount of total and free disk space for the given path
+arangodb::Result TRI_GetDiskSpace(std::string const& path, 
+                                  uint64_t& totalSpace,
+                                  uint64_t& freeSpace);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief reads an environment variable. returns false if env var was not set.

--- a/lib/Logger/LogAppenderFile.cpp
+++ b/lib/Logger/LogAppenderFile.cpp
@@ -24,6 +24,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <algorithm>
+#include <cstring>
 #include <iostream>
 
 #include "Basics/operating-system.h"


### PR DESCRIPTION
### Scope & Purpose

Added new metrics for the total and the free disk space for the mount used for the RocksDB database directory:

* `arangodb_rocksdb_free_disk_space`: provides the free disk space for the mount, in bytes
* `arangodb_rocksdb_total_disk_space`: provides the total disk space of the mount, in bytes

Should work on Linux already, may not yet work on MacOS or Windows.
Definitely needs manual testing by someone with the respective OSes available.

Docs PR: https://github.com/arangodb/docs/pull/539

- [ ] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [ ] Backports required for: if it works, we can backport it to 3.7.

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

Needs to be used in k8s operator as well, as filesystems may behave different there.