### PR TITLE
add metrics for V8 contexts usage

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 devel
 -----
 
+* Added metrics for V8 contexts usage:
+  * `arangodb_v8_context_alive`: number of V8 contexts currently alive.
+  * `arangodb_v8_context_busy`: number of V8 contexts currently busy.
+  * `arangodb_v8_context_dirty`: number of V8 contexts currently dirty.
+  * `arangodb_v8_context_free`: number of V8 contexts currently free.
+  * `arangodb_v8_context_max`: maximum number of concurrent V8 contexts.
+  * `arangodb_v8_context_min`: minimum number of concurrent V8 contexts.
+
 * Allow calling of REST APIs `/_api/engine/stats`, GET `/_api/collection` and
   GET `/_api/database/current` on followers in active failover deployments. 
   This can help debugging and inspecting the follower.

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_statistics.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_statistics.md
@@ -184,7 +184,10 @@ the number of contexts that were previously used, and should now be garbage coll
 the number of V8 contexts that are free to use
 
 @RESTSTRUCT{max,v8_context_struct,integer,required,}
-the total number of V8 contexts we may spawn as configured by --javascript.v8-contexts
+the maximum number of V8 concurrent contexts we may spawn as configured by --javascript.v8-contexts
+
+@RESTSTRUCT{min,v8_context_struct,integer,required,}
+the minimum number of V8 contexts that are spawned as configured by --javascript.v8-contexts-minimum
 
 @RESTSTRUCT{memory,v8_context_struct,array,required,v8_isolate_memory}
 a list of V8 memory / garbage collection watermarks; Refreshed on every garbage collection run;

--- a/arangod/Statistics/Descriptions.cpp
+++ b/arangod/Statistics/Descriptions.cpp
@@ -437,6 +437,7 @@ void stats::Descriptions::serverStatistics(velocypack::Builder& b) const {
     b.add("dirty", VPackValue(v8Counters.dirty));
     b.add("free", VPackValue(v8Counters.free));
     b.add("max", VPackValue(v8Counters.max));
+    b.add("min", VPackValue(v8Counters.min));
     {
       b.add("memory", VPackValue(VPackValueType::Array));
       for (auto const& memStatistic : memoryStatistics) {

--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -1593,7 +1593,7 @@ V8DealerFeature::Statistics V8DealerFeature::getCurrentContextNumbers() {
   CONDITION_LOCKER(guard, _contextCondition);
 
   return {_contexts.size(), _busyContexts.size(), _dirtyContexts.size(),
-          _idleContexts.size(), _nrMaxContexts};
+          _idleContexts.size(), _nrMaxContexts, _nrMinContexts};
 }
 
 std::vector<V8DealerFeature::DetailedContextStatistics> V8DealerFeature::getCurrentContextDetails() {

--- a/arangod/V8Server/V8DealerFeature.h
+++ b/arangod/V8Server/V8DealerFeature.h
@@ -53,6 +53,7 @@ class V8DealerFeature final : public application_features::ApplicationFeature {
     size_t dirty;
     size_t free;
     size_t max;
+    size_t min;
   };
   struct DetailedContextStatistics {
     size_t id;

--- a/arangod/V8Server/v8-statistics.cpp
+++ b/arangod/V8Server/v8-statistics.cpp
@@ -142,6 +142,8 @@ static void JS_ServerStatistics(v8::FunctionCallbackInfo<v8::Value> const& args)
                      v8::Number::New(isolate, static_cast<uint32_t>(v8Counters.free))).FromMaybe(false);
   v8CountersObj->Set(context, TRI_V8_ASCII_STRING(isolate, "max"),
                      v8::Number::New(isolate, static_cast<uint32_t>(v8Counters.max))).FromMaybe(false);
+  v8CountersObj->Set(context, TRI_V8_ASCII_STRING(isolate, "min"),
+                     v8::Number::New(isolate, static_cast<uint32_t>(v8Counters.min))).FromMaybe(false);
 
   auto memoryStatistics = dealer.getCurrentContextDetails();
 


### PR DESCRIPTION
### Scope & Purpose

Added metrics for V8 contexts usage:

* `arangodb_v8_context_alive`: number of V8 contexts currently alive.
* `arangodb_v8_context_busy`: number of V8 contexts currently busy. 
* `arangodb_v8_context_dirty`: number of V8 contexts currently dirty.
* `arangodb_v8_context_free`: number of V8 contexts currently free. 
* `arangodb_v8_context_max`: maximum number of concurrent V8 contexts.
* `arangodb_v8_context_min`: minimum number of concurrent V8 contexts.

Docs PR: https://github.com/arangodb/docs/pull/538

- [ ] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.7

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11688/