### PR TITLE
Fix internal issue BTS-183

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
-
+* Fix for issue BTS-183: added pending operations purging before ArangoSearch
+  index truncation
+  
 * Allow calling of REST APIs `/_api/engine/stats`, GET `/_api/collection` and
   GET `/_api/database/current` on followers in active failover deployments. 
   This can help debugging and inspecting the follower.

--- a/arangod/IResearch/IResearchLink.cpp
+++ b/arangod/IResearch/IResearchLink.cpp
@@ -377,7 +377,7 @@ void IResearchLink::afterTruncate(TRI_voc_tick_t tick,
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     auto* ctx = dynamic_cast<LinkTrxState*>(state.cookie(key));
 #else
-    auto *ctx = static_cast<LinkTrxState*>(state.cookie(key));
+    auto* ctx = static_cast<LinkTrxState*>(state.cookie(key));
 #endif
 
     if (ctx) {

--- a/arangod/IResearch/IResearchLink.cpp
+++ b/arangod/IResearch/IResearchLink.cpp
@@ -350,7 +350,8 @@ bool IResearchLink::operator==(IResearchLinkMeta const& meta) const noexcept {
   return _meta == meta;
 }
 
-void IResearchLink::afterTruncate(TRI_voc_tick_t tick) {
+void IResearchLink::afterTruncate(TRI_voc_tick_t tick,
+                                  arangodb::transaction::Methods* trx) {
   SCOPED_LOCK(_asyncSelf->mutex());  // '_dataStore' can be asynchronously modified
 
   TRI_IF_FAILURE("ArangoSearchTruncateFailure") {
@@ -366,6 +367,24 @@ void IResearchLink::afterTruncate(TRI_voc_tick_t tick) {
   }
 
   TRI_ASSERT(_dataStore);  // must be valid if _asyncSelf->get() is valid
+
+  if (trx != nullptr) {
+    auto* key = this;
+
+    auto& state = *(trx->state());
+
+    // TODO FIXME find a better way to look up a ViewState
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    auto* ctx = dynamic_cast<LinkTrxState*>(state.cookie(key));
+#else
+    auto *ctx = static_cast<LinkTrxState*>(state.cookie(key));
+#endif
+
+    if (ctx) {
+      ctx->reset(); // throw away all pending operations as clear will overwrite them all
+      state.cookie(key, nullptr); // force active segment release to allow commit go and avoid deadlock in clear
+    }
+  }
 
   auto const lastCommittedTick = _lastCommittedTick;
   bool recoverCommittedTick = true;

--- a/arangod/IResearch/IResearchLink.h
+++ b/arangod/IResearch/IResearchLink.h
@@ -94,7 +94,8 @@ class IResearchLink {
     return !(*this == meta);
   }
 
-  void afterTruncate(TRI_voc_tick_t tick); // arangodb::Index override
+  void afterTruncate(TRI_voc_tick_t tick,
+                     arangodb::transaction::Methods* trx); // arangodb::Index override
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief insert a set of ArangoDB documents into an iResearch View using

--- a/arangod/IResearch/IResearchRocksDBLink.h
+++ b/arangod/IResearch/IResearchRocksDBLink.h
@@ -43,8 +43,9 @@ class IResearchRocksDBLink final : public arangodb::RocksDBIndex, public IResear
  public:
   IResearchRocksDBLink(IndexId iid, arangodb::LogicalCollection& collection);
 
-  void afterTruncate(TRI_voc_tick_t tick) override {
-    IResearchLink::afterTruncate(tick);
+  void afterTruncate(TRI_voc_tick_t tick,
+                     arangodb::transaction::Methods* trx) override {
+    IResearchLink::afterTruncate(tick, trx);
   }
 
   bool canBeDropped() const override {

--- a/arangod/IResearch/IResearchRocksDBRecoveryHelper.cpp
+++ b/arangod/IResearch/IResearchRocksDBRecoveryHelper.cpp
@@ -365,7 +365,7 @@ void IResearchRocksDBRecoveryHelper::LogData(
       if (coll != nullptr) {
         auto const links = lookupLinks(*coll);
         for (auto link : links) {
-          link->afterTruncate(tick);
+          link->afterTruncate(tick, nullptr);
         }
       }
 

--- a/arangod/Indexes/Index.h
+++ b/arangod/Indexes/Index.h
@@ -386,7 +386,7 @@ class Index {
 
   /// @brief called after the collection was truncated
   /// @param tick at which truncate was applied
-  virtual void afterTruncate(TRI_voc_tick_t tick) {}
+  virtual void afterTruncate(TRI_voc_tick_t, transaction::Methods*) {}
 
   /// @brief whether or not the filter condition is supported by the index
   /// returns detailed information about the costs associated with using this index

--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
@@ -392,7 +392,7 @@ struct ReplayHandler final : public rocksdb::WriteBatch::Handler {
     if (column_family_id == _index.columnFamily()->GetID() &&
         RocksDBKey::objectId(begin_key) == _objectId &&
         RocksDBKey::objectId(end_key) == _objectId) {
-      _index.afterTruncate(_currentSequence);
+      _index.afterTruncate(_currentSequence, &_trx);
     }
     return rocksdb::Status();  // make WAL iterator happy
   }

--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.h
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.h
@@ -68,8 +68,9 @@ class RocksDBBuilderIndex final : public arangodb::RocksDBIndex {
 
   Result drop() override { return _wrapped->drop(); }
 
-  void afterTruncate(TRI_voc_tick_t tick) override {
-    _wrapped->afterTruncate(tick);
+  void afterTruncate(TRI_voc_tick_t tick,
+                     arangodb::transaction::Methods* trx) override {
+    _wrapped->afterTruncate(tick, trx);
   }
 
   void load() override { _wrapped->load(); }

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -1129,7 +1129,7 @@ Result RocksDBCollection::truncate(transaction::Methods& trx, OperationOptions& 
     {
       READ_LOCKER(idxGuard, _indexesLock);
       for (std::shared_ptr<Index> const& idx : _indexes) {
-        idx->afterTruncate(seq);  // clears caches / clears links (if applicable)
+        idx->afterTruncate(seq, &trx);  // clears caches / clears links (if applicable)
       }
     }
     bufferTruncate(seq);

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
@@ -920,10 +920,11 @@ void RocksDBEdgeIndex::handleValNode(VPackBuilder* keys,
   }
 }
 
-void RocksDBEdgeIndex::afterTruncate(TRI_voc_tick_t tick) {
+void RocksDBEdgeIndex::afterTruncate(TRI_voc_tick_t tick,
+                                     arangodb::transaction::Methods* trx) {
   TRI_ASSERT(_estimator != nullptr);
   _estimator->bufferTruncate(tick);
-  RocksDBIndex::afterTruncate(tick);
+  RocksDBIndex::afterTruncate(tick, trx);
 }
 
 RocksDBCuckooIndexEstimator<uint64_t>* RocksDBEdgeIndex::estimator() {

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.h
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.h
@@ -110,7 +110,8 @@ class RocksDBEdgeIndex final : public RocksDBIndex {
   void warmup(arangodb::transaction::Methods* trx,
               std::shared_ptr<basics::LocalTaskQueue> queue) override;
 
-  void afterTruncate(TRI_voc_tick_t tick) override;
+  void afterTruncate(TRI_voc_tick_t tick,
+                     arangodb::transaction::Methods* trx) override;
 
   Result insert(transaction::Methods& trx, RocksDBMethods* methods,
                 LocalDocumentId const& documentId, velocypack::Slice const& doc,

--- a/arangod/RocksDBEngine/RocksDBIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndex.cpp
@@ -232,7 +232,7 @@ Result RocksDBIndex::drop() {
   return r;
 }
 
-void RocksDBIndex::afterTruncate(TRI_voc_tick_t) {
+void RocksDBIndex::afterTruncate(TRI_voc_tick_t, arangodb::transaction::Methods*) {
   // simply drop the cache and re-create it
   if (_cacheEnabled) {
     destroyCache();

--- a/arangod/RocksDBEngine/RocksDBIndex.h
+++ b/arangod/RocksDBEngine/RocksDBIndex.h
@@ -75,7 +75,8 @@ class RocksDBIndex : public Index {
 
   Result drop() override;
 
-  virtual void afterTruncate(TRI_voc_tick_t tick) override;
+  virtual void afterTruncate(TRI_voc_tick_t tick,
+                             transaction::Methods* trx) override;
 
   void load() override;
   void unload() override;

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -1279,13 +1279,14 @@ std::unique_ptr<IndexIterator> RocksDBVPackIndex::iteratorForCondition(
   return lookup(trx, searchSlice, !opts.ascending);
 }
 
-void RocksDBVPackIndex::afterTruncate(TRI_voc_tick_t tick) {
+void RocksDBVPackIndex::afterTruncate(TRI_voc_tick_t tick,
+                                      arangodb::transaction::Methods* trx) {
   if (unique()) {
     return;
   }
   TRI_ASSERT(_estimator != nullptr);
   _estimator->bufferTruncate(tick);
-  RocksDBIndex::afterTruncate(tick);
+  RocksDBIndex::afterTruncate(tick, trx);
 }
 
 RocksDBCuckooIndexEstimator<uint64_t>* RocksDBVPackIndex::estimator() {

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.h
@@ -116,7 +116,8 @@ class RocksDBVPackIndex : public RocksDBIndex {
                                                       arangodb::aql::Variable const* reference,
                                                       IndexIteratorOptions const& opts) override;
 
-  void afterTruncate(TRI_voc_tick_t tick) override;
+  void afterTruncate(TRI_voc_tick_t tick,
+                     arangodb::transaction::Methods* trx) override;
 
  protected:
   Result insert(transaction::Methods& trx, RocksDBMethods* methods,

--- a/tests/Mocks/StorageEngineMock.cpp
+++ b/tests/Mocks/StorageEngineMock.cpp
@@ -180,7 +180,7 @@ class EdgeIndexMock final : public arangodb::Index {
 
   void load() override {}
   void unload() override {}
-  void afterTruncate(TRI_voc_tick_t) override {
+  void afterTruncate(TRI_voc_tick_t, arangodb::transaction::Methods*) override {
     _edgesFrom.clear();
     _edgesTo.clear();
   }
@@ -733,7 +733,7 @@ class HashIndexMock final : public arangodb::Index {
 
   void unload() override {}
 
-  void afterTruncate(TRI_voc_tick_t) override {
+  void afterTruncate(TRI_voc_tick_t, arangodb::transaction::Methods*) override {
     _hashData.clear();
   }
 


### PR DESCRIPTION
PR fixes possible deadlock inside ArangoSearch with removes followed by clear call inside same ArangoDB transaction.
So to perform index truncation ArangoSearch waits for removes transaction to be committed (or rollbacked) but it waits inside same transaction so it never ends. This would be the issue now only for already  EOLed MMFiles storage engine but could raise again during future development.

To fix this afterTruncate index handler is made aware of current transaction. For ArangoSearch - transaction state is wiped before truncation (anyway truncation will overwrite all operations).

This case is coverd existing recovery tests namely: 
view-arangosearch-link-populate-truncate.js
view-arangosearch-link-populate-truncate-no-flushthread.js

http://jenkins.arangodb.biz:8080/job/arangodb-matrix-pr/11697/