### PR TITLE
underscore the purpose of config options a bit more

### DIFF
--- a/arangod/Network/NetworkFeature.cpp
+++ b/arangod/Network/NetworkFeature.cpp
@@ -92,25 +92,25 @@ NetworkFeature::NetworkFeature(application_features::ApplicationServer& server,
 void NetworkFeature::collectOptions(std::shared_ptr<options::ProgramOptions> options) {
   options->addSection("network", "Configure cluster-internal networking");
 
-  options->addOption("--network.io-threads", "number of network IO threads",
+  options->addOption("--network.io-threads", "number of network IO threads for cluster-internal communication",
                      new UInt32Parameter(&_numIOThreads))
                      .setIntroducedIn(30600);
   options->addOption("--network.max-open-connections",
-                     "max open network connections",
+                     "max open network connections for cluster-internal communication",
                      new UInt64Parameter(&_maxOpenConnections))
                      .setIntroducedIn(30600);
   options->addOption("--network.idle-connection-ttl",
-                     "default time-to-live of idle connections (in milliseconds)",
+                     "default time-to-live of idle connections for cluster-internal communication (in milliseconds)",
                      new UInt64Parameter(&_idleTtlMilli))
                      .setIntroducedIn(30600);
-  options->addOption("--network.verify-hosts", "verify hosts when using TLS",
+  options->addOption("--network.verify-hosts", "verify hosts when using TLS in cluster-internal communication",
                      new BooleanParameter(&_verifyHosts))
                      .setIntroducedIn(30600);
 
   std::unordered_set<std::string> protos = {
       "", "http", "http2", "h2", "vst"};
 
-  options->addOption("--network.protocol", "network protocol to use",
+  options->addOption("--network.protocol", "network protocol to use for cluster-internal communication",
                      new DiscreteValuesParameter<StringParameter>(&_protocol, protos))
                      .setIntroducedIn(30700);
 }


### PR DESCRIPTION
### Scope & Purpose

Underscore that the `--network.*` options are for cluster-internal communication.

- [ ] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required
- [ ] Backports required for: *(Please specify versions)*

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11709/