### PR TITLE
This sorts out immutable flushed write buffers in RocksDB.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.6.7 (XXXX-XX-XX)
 -------------------
 
+* Add option `--rocksdb.max-write-buffer-number-to-maintain` with default 
+  of 1 for small RAM size and 0 for large RAM size.
+  This configures how much memory RocksDB is allowed to use for immutable
+  flushed memtables/write-buffers. The default of 1 will usually be good
+  for small machines and 0 for all other cases.
+
 * Added metrics for V8 contexts usage:
   * `arangodb_v8_context_alive`: number of V8 contexts currently alive.
   * `arangodb_v8_context_busy`: number of V8 contexts currently busy.

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -432,6 +432,12 @@ void RocksDBEngine::start() {
   _options.enable_pipelined_write = opts._enablePipelinedWrite;
   _options.write_buffer_size = static_cast<size_t>(opts._writeBufferSize);
   _options.max_write_buffer_number = static_cast<int>(opts._maxWriteBufferNumber);
+  // The following setting deserves an explanation: We found that if we leave the
+  // default for max_write_buffer_number_to_maintain at 0, then RocksDB keeps a lot 
+  // of memory in immutable flushed write buffers, which is bad for small deployments.
+  // Therefore, by default, we now set this to 1 if the available memory is less than 4GB,
+  // and to 0 otherwise.
+  _options.max_write_buffer_number_to_maintain = opts._maxWriteBufferNumberToMaintain;
   _options.delayed_write_rate = opts._delayedWriteRate;
   _options.min_write_buffer_number_to_merge =
       static_cast<int>(opts._minWriteBufferNumberToMerge);

--- a/arangod/StorageEngine/RocksDBOptionFeature.cpp
+++ b/arangod/StorageEngine/RocksDBOptionFeature.cpp
@@ -428,7 +428,7 @@ void RocksDBOptionFeature::start() {
       << ", write_buffer_size: " << _writeBufferSize
       << ", total_write_buffer_size: " << _totalWriteBufferSize
       << ", max_write_buffer_number: " << _maxWriteBufferNumber
-      << ", max_write_buffer_size_to_maintain: " << _maxWriteBufferSizeToMaintain
+      << ", max_write_buffer_number_to_maintain: " << _maxWriteBufferNumberToMaintain
       << ", max_total_wal_size: " << _maxTotalWalSize
       << ", delayed_write_rate: " << _delayedWriteRate
       << ", min_write_buffer_number_to_merge: " << _minWriteBufferNumberToMerge

--- a/arangod/StorageEngine/RocksDBOptionFeature.h
+++ b/arangod/StorageEngine/RocksDBOptionFeature.h
@@ -60,6 +60,7 @@ class RocksDBOptionFeature final : public application_features::ApplicationFeatu
   uint64_t _writeBufferSize;
   // Update max_write_buffer_number above if you change number of families used
   uint64_t _maxWriteBufferNumber;
+  int64_t _maxWriteBufferNumberToMaintain;
   uint64_t _maxTotalWalSize;
   uint64_t _delayedWriteRate;
   uint64_t _minWriteBufferNumberToMerge;


### PR DESCRIPTION
The trouble is that RocksDB keeps a certain number of write buffers
allocated in memory, although they have already been flushed to disk.
On small deployments, this can take a significant amount of the available
memory (we have seen 1GB - 2GB). This PR uses a RocksDB option to trim
down this memory usage. We do this if the available RAM is less than
4GB. Otherwise, we keep the original settings. The user can change this
configuration option.