### PR TITLE
added "details" option to collection figures

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,16 @@
 devel
 -----
 
+* Added `details` option to figures command of a collection:
+  `collection.figures(details)`
+
+  Setting `details` to `true` will return extended storage engine-specific 
+  details to the figures. The details are intended for debugging ArangoDB
+  itself and their format is subject to change. There is not much use in using
+  the details from a client application.
+  By default, `details` is set to `false`, so no details are returned and the
+  behavior is identical to previous versions of ArangoDB.
+
 * Implement RebootTracker usage for AQL queries in case of coordinator
   restarts or failures. This will clean up the rest of an AQL query
   on dbservers more quickly and in particular release locks faster.

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -76,6 +76,7 @@
 #include "ClusterEngine/ClusterEngine.h"
 
 #include <velocypack/Buffer.h>
+#include <velocypack/Builder.h>
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
@@ -123,49 +124,6 @@ T addFigures(VPackSlice const& v1, VPackSlice const& v2,
   }
 
   return value;
-}
-
-void recursiveAdd(VPackSlice const& value, VPackBuilder& builder) {
-  TRI_ASSERT(value.isObject());
-  TRI_ASSERT(builder.slice().isObject());
-  TRI_ASSERT(builder.isClosed());
-
-  VPackBuilder updated;
-
-  updated.openObject();
-
-  bool cacheInUse = Helper::getBooleanValue(value, "cacheInUse", false);
-  bool totalCacheInUse = cacheInUse || Helper::getBooleanValue(builder.slice(), "cacheInUse", false);
-  updated.add("cacheInUse", VPackValue(totalCacheInUse));
-
-  if (cacheInUse) {
-    updated.add("cacheLifeTimeHitRate", VPackValue(addFigures<double>(value, builder.slice(),
-                                                                      {"cacheLifeTimeHitRate"})));
-    updated.add("cacheWindowedHitRate", VPackValue(addFigures<double>(value, builder.slice(),
-                                                                      {"cacheWindowedHitRate"})));
-  }
-  updated.add("cacheSize", VPackValue(addFigures<size_t>(value, builder.slice(),
-                                                               {"cacheSize"})));
-  updated.add("cacheUsage", VPackValue(addFigures<size_t>(value, builder.slice(),
-                                                               {"cacheUsage"})));
-  updated.add("documentsSize", VPackValue(addFigures<size_t>(value, builder.slice(),
-                                                               {"documentsSize"})));
-
-  updated.add("indexes", VPackValue(VPackValueType::Object));
-  updated.add("count", VPackValue(addFigures<size_t>(value, builder.slice(),
-                                                     {"indexes", "count"})));
-  updated.add("size", VPackValue(addFigures<size_t>(value, builder.slice(),
-                                                    {"indexes", "size"})));
-  updated.close();
-
-  updated.close();
-
-  TRI_ASSERT(updated.slice().isObject());
-  TRI_ASSERT(updated.isClosed());
-
-  builder = VPackCollection::merge(builder.slice(), updated.slice(), true, false);
-  TRI_ASSERT(builder.slice().isObject());
-  TRI_ASSERT(builder.isClosed());
 }
 
 /// @brief begin a transaction on some leader shards
@@ -857,6 +815,116 @@ bool smartJoinAttributeChanged(LogicalCollection const& collection, VPackSlice c
   return !Helper::equal(n, o, false);
 }
 
+void aggregateClusterFigures(bool details, bool isSmartEdgeCollectionPart, 
+                             VPackSlice value, VPackBuilder& builder) {
+  TRI_ASSERT(value.isObject());
+  TRI_ASSERT(builder.slice().isObject());
+  TRI_ASSERT(builder.isClosed());
+
+  VPackBuilder updated;
+
+  updated.openObject();
+
+  bool cacheInUse = Helper::getBooleanValue(value, "cacheInUse", false);
+  bool totalCacheInUse = cacheInUse || Helper::getBooleanValue(builder.slice(), "cacheInUse", false);
+  updated.add("cacheInUse", VPackValue(totalCacheInUse));
+
+  if (cacheInUse) {
+    updated.add("cacheLifeTimeHitRate", VPackValue(addFigures<double>(value, builder.slice(),
+                                                                      {"cacheLifeTimeHitRate"})));
+    updated.add("cacheWindowedHitRate", VPackValue(addFigures<double>(value, builder.slice(),
+                                                                      {"cacheWindowedHitRate"})));
+  }
+  updated.add("cacheSize", VPackValue(addFigures<size_t>(value, builder.slice(),
+                                                               {"cacheSize"})));
+  updated.add("cacheUsage", VPackValue(addFigures<size_t>(value, builder.slice(),
+                                                               {"cacheUsage"})));
+  updated.add("documentsSize", VPackValue(addFigures<size_t>(value, builder.slice(),
+                                                               {"documentsSize"})));
+
+  updated.add("indexes", VPackValue(VPackValueType::Object));
+  VPackSlice indexes = builder.slice().get("indexes");
+  if (isSmartEdgeCollectionPart || indexes.isObject()) {
+    // don't count indexes multiple times - all shards have the same indexes!
+    // in addition: don't count the indexes from the sub-collections of a smart
+    // edge collection multiple times!
+    updated.add("count", indexes.get("count"));
+  } else {
+    updated.add("count", VPackValue(addFigures<size_t>(value, builder.slice(),
+                                                       {"indexes", "count"})));
+  }
+  updated.add("size", VPackValue(addFigures<size_t>(value, builder.slice(),
+                                                    {"indexes", "size"})));
+  updated.close(); // "indexes"
+
+  if (details && value.hasKey("engine")) {
+    updated.add("engine", VPackValue(VPackValueType::Object));
+    if (isSmartEdgeCollectionPart) {
+      // don't count documents from the sub-collections of a smart edge collection
+      // multiple times
+      updated.add("documents", builder.slice().get(std::vector<std::string>{"engine", "documents"}));
+    } else {
+      updated.add("documents", VPackValue(addFigures<size_t>(value, builder.slice(),
+                                                             {"engine", "documents"})));
+    }
+    // merge indexes together
+    std::map<uint64_t, std::pair<VPackSlice, VPackSlice>> indexes;
+
+    updated.add("indexes", VPackValue(VPackValueType::Array));
+    VPackSlice rocksDBValues = value.get("engine");
+
+    if (!isSmartEdgeCollectionPart) {
+      for (auto const& it : VPackArrayIterator(rocksDBValues.get("indexes"))) {
+        VPackSlice idSlice = it.get("id");
+        if (!idSlice.isNumber()) {
+          continue;
+        }
+        indexes.emplace(idSlice.getNumber<uint64_t>(), std::make_pair(it, VPackSlice::noneSlice()));
+      }
+    }
+  
+    rocksDBValues = builder.slice().get("engine");
+    if (rocksDBValues.isObject()) {
+      for (auto const& it : VPackArrayIterator(rocksDBValues.get("indexes"))) {
+        VPackSlice idSlice = it.get("id");
+        if (!idSlice.isNumber()) {
+          continue;
+        }
+        auto idx = indexes.find(idSlice.getNumber<uint64_t>());
+        if (idx == indexes.end()) {
+          indexes.emplace(idSlice.getNumber<uint64_t>(), std::make_pair(it, VPackSlice::noneSlice()));
+        } else {
+          (*idx).second.second = it;
+        }
+      }
+    }
+
+    for (auto const& it : indexes) {
+      updated.openObject();
+      updated.add("type", it.second.first.get("type"));
+      updated.add("id", it.second.first.get("id"));
+      uint64_t count = it.second.first.get("count").getNumber<uint64_t>();
+      if (it.second.second.isObject()) {
+        count += it.second.second.get("count").getNumber<uint64_t>();
+      }
+      updated.add("count", VPackValue(count));
+      updated.close();
+    }
+
+    updated.close(); // "indexes" array
+    updated.close(); // "engine" object
+  }
+
+  updated.close();
+
+  TRI_ASSERT(updated.slice().isObject());
+  TRI_ASSERT(updated.isClosed());
+
+  builder = VPackCollection::merge(builder.slice(), updated.slice(), true, false);
+  TRI_ASSERT(builder.slice().isObject());
+  TRI_ASSERT(builder.isClosed());
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief returns revision for a sharded collection
 ////////////////////////////////////////////////////////////////////////////////
@@ -973,7 +1041,8 @@ futures::Future<Result> warmupOnCoordinator(ClusterFeature& feature,
 
 futures::Future<OperationResult> figuresOnCoordinator(ClusterFeature& feature,
                                                       std::string const& dbname,
-                                                      std::string const& collname) {
+                                                      std::string const& collname, 
+                                                      bool details) {
   // Set a few variables needed for our work:
   ClusterInfo& ci = feature.clusterInfo();
 
@@ -986,6 +1055,7 @@ futures::Future<OperationResult> figuresOnCoordinator(ClusterFeature& feature,
 
   network::RequestOptions reqOpts;
   reqOpts.database = dbname;
+  reqOpts.param("details", details ? "true" : "false");
   reqOpts.timeout = network::Timeout(300.0);
 
   // If we get here, the sharding attributes are not only _key, therefore
@@ -1004,14 +1074,14 @@ futures::Future<OperationResult> figuresOnCoordinator(ClusterFeature& feature,
     futures.emplace_back(std::move(future));
   }
 
-  auto cb = [](std::vector<Try<network::Response>>&& results) mutable -> OperationResult {
-    auto handler = [](Result& result, VPackBuilder& builder, ShardID&,
-                      VPackSlice answer) mutable -> void {
+  auto cb = [details](std::vector<Try<network::Response>>&& results) mutable -> OperationResult {
+    auto handler = [details](Result& result, VPackBuilder& builder, ShardID&,
+                             VPackSlice answer) mutable -> void {
       if (answer.isObject()) {
         VPackSlice figures = answer.get("figures");
         // add to the total
         if (figures.isObject()) {
-          recursiveAdd(figures, builder);
+          aggregateClusterFigures(details, false, figures, builder);
         }
       } else {
         // didn't get the expected response
@@ -1020,8 +1090,7 @@ futures::Future<OperationResult> figuresOnCoordinator(ClusterFeature& feature,
     };
     auto pre = [](Result&, VPackBuilder& builder) -> void {
       // initialize to empty object
-      builder.openObject();
-      builder.close();
+      builder.add(VPackSlice::emptyObjectSlice());
     };
     return handleResponsesFromAllShards(results, handler, pre);
   };
@@ -2565,7 +2634,7 @@ std::vector<std::shared_ptr<LogicalCollection>> ClusterMethods::persistCollectio
     }
   }
   return usableCollectionPointers;
-}  // namespace arangodb
+}  
 
 std::string const apiStr("/_admin/backup/");
 

--- a/arangod/Cluster/ClusterMethods.h
+++ b/arangod/Cluster/ClusterMethods.h
@@ -49,6 +49,10 @@ namespace graph {
 class ClusterTraverserCache;
 }
 
+namespace velocypack {
+class Builder;
+}
+
 namespace traverser {
 struct TraverserOptions;
 }
@@ -56,7 +60,6 @@ struct TraverserOptions;
 struct ClusterCommResult;
 class ClusterFeature;
 struct OperationOptions;
-class TransactionState;
 
 /// @brief convert ClusterComm error into arango error code
 int handleGeneralCommErrors(arangodb::ClusterCommResult const* res);
@@ -78,6 +81,13 @@ bool shardKeysChanged(LogicalCollection const& collection, VPackSlice const& old
 /// @brief check if the value of the smartJoinAttribute has changed
 bool smartJoinAttributeChanged(LogicalCollection const& collection, VPackSlice const& oldValue,
                                VPackSlice const& newValue, bool isPatch);
+
+/// @brief aggregate the results of multiple figures responses (e.g. from 
+/// multiple shards or for a smart edge collection)
+void aggregateClusterFigures(bool details, 
+                             bool isSmartEdgeCollectionPart,
+                             arangodb::velocypack::Slice value, 
+                             arangodb::velocypack::Builder& builder);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief returns revision for a sharded collection
@@ -101,7 +111,8 @@ futures::Future<Result> warmupOnCoordinator(ClusterFeature&,
 
 futures::Future<OperationResult> figuresOnCoordinator(ClusterFeature&,
                                                       std::string const& dbname,
-                                                      std::string const& collname);
+                                                      std::string const& collname,
+                                                      bool details);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief counts number of documents in a coordinator, by shard

--- a/arangod/ClusterEngine/ClusterCollection.cpp
+++ b/arangod/ClusterEngine/ClusterCollection.cpp
@@ -161,13 +161,13 @@ void ClusterCollection::getPropertiesVPack(velocypack::Builder& result) const {
 }
 
 /// @brief return the figures for a collection
-futures::Future<OperationResult> ClusterCollection::figures() {
+futures::Future<OperationResult> ClusterCollection::figures(bool details) {
   auto& feature = _logicalCollection.vocbase().server().getFeature<ClusterFeature>();
   return figuresOnCoordinator(feature, _logicalCollection.vocbase().name(),
-                              std::to_string(_logicalCollection.id().id()));
+                              std::to_string(_logicalCollection.id().id()), details);
 }
 
-void ClusterCollection::figuresSpecific(arangodb::velocypack::Builder& builder) {
+void ClusterCollection::figuresSpecific(bool /*details*/, arangodb::velocypack::Builder& /*builder*/) {
   THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);  // not used here
 }
 

--- a/arangod/ClusterEngine/ClusterCollection.h
+++ b/arangod/ClusterEngine/ClusterCollection.h
@@ -78,7 +78,7 @@ class ClusterCollection final : public PhysicalCollection {
   void getPropertiesVPack(velocypack::Builder&) const override;
 
   /// @brief return the figures for a collection
-  futures::Future<OperationResult> figures() override;
+  futures::Future<OperationResult> figures(bool details) override;
 
   /// @brief closes an open collection
   int close() override;
@@ -147,7 +147,7 @@ class ClusterCollection final : public PhysicalCollection {
 
  protected:
   /// @brief Inject figures that are specific to StorageEngine
-  void figuresSpecific(arangodb::velocypack::Builder&) override;
+  void figuresSpecific(bool details, arangodb::velocypack::Builder&) override;
 
  private:
   void addIndex(std::shared_ptr<arangodb::Index> idx);

--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -99,8 +99,8 @@ RestStatus RestCollectionHandler::handleCommandGet() {
 
         collectionRepresentation(ctxt,
                                  /*showProperties*/ false,
-                                 /*showFigures*/ false, /*showCount*/ false,
-                                 /*detailedCount*/ false);
+                                 /*showFigures*/ FiguresType::None,
+                                 /*showCount*/ CountType::None);
       }
     });
 
@@ -115,8 +115,8 @@ RestStatus RestCollectionHandler::handleCommandGet() {
   if (suffixes.size() == 1) {
     try {
       collectionRepresentation(name, /*showProperties*/ false,
-                               /*showFigures*/ false, /*showCount*/ false,
-                               /*detailedCount*/ false);
+                               /*showFigures*/ FiguresType::None, 
+                               /*showCount*/ CountType::None);
       generateOk(rest::ResponseCode::OK, _builder);
     } catch (basics::Exception const& ex) {  // do not log not found exceptions
       generateError(GeneralResponse::responseCode(ex.code()), ex.code(), ex.what());
@@ -167,9 +167,8 @@ RestStatus RestCollectionHandler::handleCommandGet() {
 
         collectionRepresentation(coll,
                                  /*showProperties*/ false,
-                                 /*showFigures*/ false,
-                                 /*showCount*/ false,
-                                 /*detailedCount*/ true);
+                                 /*showFigures*/ FiguresType::None,
+                                 /*showCount*/ CountType::None);
       }
       return standardResponse();
     }
@@ -179,13 +178,13 @@ RestStatus RestCollectionHandler::handleCommandGet() {
 
   } else if (sub == "figures") {
     // /_api/collection/<identifier>/figures
+    bool details = _request->parsedValue("details", false);
     _ctxt = std::make_unique<methods::Collections::Context>(coll);
     return waitForFuture(
         collectionRepresentationAsync(*_ctxt,
                                       /*showProperties*/ true,
-                                      /*showFigures*/ true,
-                                      /*showCount*/ true,
-                                      /*detailedCount*/ false)
+                                      details ? FiguresType::Detailed : FiguresType::Standard,
+                                      CountType::Standard)
             .thenValue([this](futures::Unit&&) { standardResponse(); }));
   } else if (sub == "count") {
     // /_api/collection/<identifier>/count
@@ -196,17 +195,15 @@ RestStatus RestCollectionHandler::handleCommandGet() {
     return waitForFuture(
         collectionRepresentationAsync(*_ctxt,
                                       /*showProperties*/ true,
-                                      /*showFigures*/ false,
-                                      /*showCount*/ true,
-                                      /*detailedCount*/ details)
+                                      /*showFigures*/ FiguresType::None,
+                                      /*showCount*/ details ? CountType::Detailed : CountType::Standard)
             .thenValue([this](futures::Unit&&) { standardResponse(); }));
   } else if (sub == "properties") {
     // /_api/collection/<identifier>/properties
     collectionRepresentation(coll,
                              /*showProperties*/ true,
-                             /*showFigures*/ false,
-                             /*showCount*/ false,
-                             /*detailedCount*/ true);
+                             /*showFigures*/ FiguresType::None,
+                             /*showCount*/ CountType::None);
     return standardResponse();
 
   } else if (sub == "revision") {
@@ -227,8 +224,8 @@ RestStatus RestCollectionHandler::handleCommandGet() {
 
             // no need to use async variant
             collectionRepresentation(*_ctxt, /*showProperties*/ true,
-                                     /*showFigures*/ false, /*showCount*/ false,
-                                     /*detailedCount*/ true);
+                                     FiguresType::None,
+                                     CountType::None);
           }
 
           standardResponse();
@@ -245,9 +242,8 @@ RestStatus RestCollectionHandler::handleCommandGet() {
 
       collectionRepresentation(coll,
                                /*showProperties*/ true,
-                               /*showFigures*/ false,
-                               /*showCount*/ false,
-                               /*detailedCount*/ true);
+                               FiguresType::None,
+                               CountType::None);
 
       auto& ci = server().getFeature<ClusterFeature>().clusterInfo();
       auto shards = ci.getShardList(std::to_string(coll->planId().id()));
@@ -353,9 +349,8 @@ void RestCollectionHandler::handleCommandPost() {
     TRI_ASSERT(coll);
     collectionRepresentation(coll->name(),
     /*showProperties*/ true,
-    /*showFigures*/ false,
-    /*showCount*/ false,
-    /*detailedCount*/ true);
+    FiguresType::None,
+    CountType::None);
 
     generateOk(rest::ResponseCode::OK, _builder);
   } else {
@@ -404,8 +399,8 @@ RestStatus RestCollectionHandler::handleCommandPut() {
     if (res.ok()) {
       bool cc = VelocyPackHelper::getBooleanValue(body, "count", true);
       collectionRepresentation(name, /*showProperties*/ false,
-                               /*showFigures*/ false, /*showCount*/ cc,
-                               /*detailedCount*/ false);
+                               /*showFigures*/ FiguresType::None, 
+                               /*showCount*/ cc ? CountType::Standard : CountType::None);
       return standardResponse();
     } else {
       generateError(res);
@@ -423,8 +418,8 @@ RestStatus RestCollectionHandler::handleCommandPut() {
 
     if (res.ok()) {
       collectionRepresentation(name, /*showProperties*/ false,
-                               /*showFigures*/ false, /*showCount*/ false,
-                               /*detailedCount*/ true);
+                               /*showFigures*/ FiguresType::None,
+                               /*showCount*/ CountType::None);
       return standardResponse();
     } else {
       generateError(res);
@@ -436,8 +431,8 @@ RestStatus RestCollectionHandler::handleCommandPut() {
 
     if (res.ok()) {
       collectionRepresentation(name, /*showProperties*/ false,
-                               /*showFigures*/ false, /*showCount*/ false,
-                               /*detailedCount*/ true);
+                               /*showFigures*/ FiguresType::None,
+                               /*showCount*/ CountType::None);
       return standardResponse();
     }
     generateError(res);
@@ -527,9 +522,8 @@ RestStatus RestCollectionHandler::handleCommandPut() {
           // no need to use async method, no
           collectionRepresentation(coll,
                                    /*showProperties*/ false,
-                                   /*showFigures*/ false,
-                                   /*showCount*/ false,
-                                   /*detailedCount*/ true);
+                                   /*showFigures*/ FiguresType::None,
+                                   /*showCount*/ CountType::None);
           standardResponse();
         }));
 
@@ -552,8 +546,8 @@ RestStatus RestCollectionHandler::handleCommandPut() {
     }
 
     collectionRepresentation(name, /*showProperties*/ true,
-                             /*showFigures*/ false, /*showCount*/ false,
-                             /*detailedCount*/ true);
+                             /*showFigures*/ FiguresType::None,
+                             /*showCount*/ CountType::None);
     return standardResponse();
 
   } else if (sub == "rename") {
@@ -569,8 +563,8 @@ RestStatus RestCollectionHandler::handleCommandPut() {
 
     if (res.ok()) {
       collectionRepresentation(newName, /*showProperties*/ false,
-                               /*showFigures*/ false, /*showCount*/ false,
-                               /*detailedCount*/ true);
+                               /*showFigures*/ FiguresType::None,
+                               /*showCount*/ CountType::None);
       return standardResponse();
     }
 
@@ -670,44 +664,48 @@ void RestCollectionHandler::handleCommandDelete() {
 /// and create will not immediately show the expected results on a collection
 /// object.
 void RestCollectionHandler::collectionRepresentation(std::string const& name,
-                                                     bool showProperties, bool showFigures,
-                                                     bool showCount, bool detailedCount) {
+                                                     bool showProperties, 
+                                                     FiguresType showFigures,
+                                                     CountType showCount) {
   std::shared_ptr<LogicalCollection> coll;
   Result r = methods::Collections::lookup(_vocbase, name, coll);
   if (r.fail()) {
     THROW_ARANGO_EXCEPTION(r);
   }
   TRI_ASSERT(coll);
-  collectionRepresentation(coll, showProperties, showFigures, showCount, detailedCount);
+  collectionRepresentation(coll, showProperties, showFigures, showCount);
 }
 
 void RestCollectionHandler::collectionRepresentation(std::shared_ptr<LogicalCollection> coll,
-                                                     bool showProperties, bool showFigures,
-                                                     bool showCount, bool detailedCount) {
-  if (showProperties || showCount) {
+                                                     bool showProperties, 
+                                                     FiguresType showFigures,
+                                                     CountType showCount) {
+  if (showProperties || showCount != CountType::None) {
     // Here we need a transaction
     initializeTransaction(*coll);
     methods::Collections::Context ctxt(coll, _activeTrx.get());
 
-    collectionRepresentation(ctxt, showProperties, showFigures, showCount, detailedCount);
+    collectionRepresentation(ctxt, showProperties, showFigures, showCount);
   } else {
     // We do not need a transaction here
     methods::Collections::Context ctxt(coll);
 
-    collectionRepresentation(ctxt, showProperties, showFigures, showCount, detailedCount);
+    collectionRepresentation(ctxt, showProperties, showFigures, showCount);
   }
 }
 
 void RestCollectionHandler::collectionRepresentation(methods::Collections::Context& ctxt,
-                                                     bool showProperties, bool showFigures,
-                                                     bool showCount, bool detailedCount) {
-  collectionRepresentationAsync(ctxt, showProperties, showFigures, showCount, detailedCount)
-      .get();
+                                                     bool showProperties, 
+                                                     FiguresType showFigures,
+                                                     CountType showCount) {
+  collectionRepresentationAsync(ctxt, showProperties, showFigures, showCount).get();
 }
 
 futures::Future<futures::Unit> RestCollectionHandler::collectionRepresentationAsync(
-    methods::Collections::Context& ctxt, bool showProperties, bool showFigures,
-    bool showCount, bool detailedCount) {
+    methods::Collections::Context& ctxt,
+    bool showProperties,
+    FiguresType showFigures,
+    CountType showCount) {
   bool wasOpen = _builder.isOpenObject();
   if (!wasOpen) {
     _builder.openObject();
@@ -733,8 +731,8 @@ futures::Future<futures::Unit> RestCollectionHandler::collectionRepresentationAs
   }
 
   futures::Future<OperationResult> figures = futures::makeFuture(OperationResult());
-  if (showFigures) {
-    figures = coll->figures();
+  if (showFigures != FiguresType::None) {
+    figures = coll->figures(showFigures == FiguresType::Detailed);
   }
 
   return std::move(figures)
@@ -743,18 +741,18 @@ futures::Future<futures::Unit> RestCollectionHandler::collectionRepresentationAs
           _builder.add("figures", figures.slice());
         }
 
-        if (showCount) {
+        if (showCount != CountType::None) {
           auto trx = ctxt.trx(AccessMode::Type::READ, true, true);
           TRI_ASSERT(trx != nullptr);
           return trx->countAsync(coll->name(),
-                                 detailedCount ? transaction::CountType::Detailed
-                                               : transaction::CountType::Normal);
+                                 showCount == CountType::Detailed ? transaction::CountType::Detailed
+                                                                  : transaction::CountType::Normal);
         }
         return futures::makeFuture(OperationResult());
       })
       .thenValue([=, &ctxt](OperationResult&& opRes) -> void {
         if (opRes.fail()) {
-          if (showCount) {
+          if (showCount != CountType::None) {
             auto trx = ctxt.trx(AccessMode::Type::READ, true, true);
             TRI_ASSERT(trx != nullptr);
             trx->finish(opRes.result);
@@ -762,7 +760,7 @@ futures::Future<futures::Unit> RestCollectionHandler::collectionRepresentationAs
           THROW_ARANGO_EXCEPTION(opRes.result);
         }
 
-        if (showCount) {
+        if (showCount != CountType::None) {
           _builder.add("count", opRes.slice());
         }
 

--- a/arangod/RestHandler/RestCollectionHandler.h
+++ b/arangod/RestHandler/RestCollectionHandler.h
@@ -45,18 +45,30 @@ class RestCollectionHandler : public arangodb::RestVocbaseBaseHandler {
   void shutdownExecute(bool isFinalized) noexcept override final;
 
  protected:
+  enum class FiguresType {
+    None = 0,
+    Standard = 1,
+    Detailed = 2
+  };
+
+  enum class CountType {
+    None = 0,
+    Standard = 1,
+    Detailed = 2
+  };
+
   void collectionRepresentation(std::string const& name, bool showProperties,
-                                bool showFigures, bool showCount, bool detailedCount);
+                                FiguresType showFigures, CountType showCount);
 
   void collectionRepresentation(std::shared_ptr<LogicalCollection> coll, bool showProperties,
-                                bool showFigures, bool showCount, bool detailedCount);
+                                FiguresType showFigures, CountType showCount);
 
   void collectionRepresentation(methods::Collections::Context& ctxt, bool showProperties,
-                                bool showFigures, bool showCount, bool detailedCount);
+                                FiguresType showFigures, CountType showCount);
 
   futures::Future<futures::Unit> collectionRepresentationAsync(
       methods::Collections::Context& ctxt, bool showProperties,
-      bool showFigures, bool showCount, bool detailedCount);
+      FiguresType showFigures, CountType showCount);
 
   virtual Result handleExtraCommandPut(std::shared_ptr<LogicalCollection> coll, std::string const& command,
                                        velocypack::Builder& builder) = 0;

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -1833,7 +1833,7 @@ Result RocksDBCollection::cleanupAfterUpgrade() {
 }
 
 /// @brief return engine-specific figures
-void RocksDBCollection::figuresSpecific(arangodb::velocypack::Builder& builder) {
+void RocksDBCollection::figuresSpecific(bool details, arangodb::velocypack::Builder& builder) {
   rocksdb::TransactionDB* db = rocksutils::globalRocksDB();
   RocksDBKeyBounds bounds = RocksDBKeyBounds::CollectionDocuments(objectId());
   rocksdb::Range r(bounds.start(), bounds.end());
@@ -1860,6 +1860,68 @@ void RocksDBCollection::figuresSpecific(arangodb::velocypack::Builder& builder) 
   } else {
     builder.add("cacheSize", VPackValue(0));
     builder.add("cacheUsage", VPackValue(0));
+  }
+
+  if (details) {
+    // engine-specific stuff here
+    rocksdb::DB* db = rocksutils::globalRocksDB()->GetRootDB();
+
+    builder.add("engine", VPackValue(VPackValueType::Object));
+    
+    builder.add("documents", VPackValue(rocksutils::countKeyRange(db, RocksDBKeyBounds::CollectionDocuments(objectId()), true)));
+    builder.add("indexes", VPackValue(VPackValueType::Array));
+    {
+      READ_LOCKER(guard, _indexesLock);
+      for (auto it : _indexes) {
+        auto type = it->type();
+        if (type == Index::TRI_IDX_TYPE_UNKNOWN ||
+            type == Index::TRI_IDX_TYPE_IRESEARCH_LINK ||
+            type == Index::TRI_IDX_TYPE_NO_ACCESS_INDEX) {
+          continue;
+        }
+        
+        builder.openObject();
+        builder.add("type", VPackValue(it->typeName()));
+        builder.add("id", VPackValue(it->id().id()));
+        
+        RocksDBIndex const* rix = static_cast<RocksDBIndex const*>(it.get());
+        size_t count = 0;
+        switch (type) {
+          case Index::TRI_IDX_TYPE_PRIMARY_INDEX:
+            count = rocksutils::countKeyRange(db, RocksDBKeyBounds::PrimaryIndex(rix->objectId()), true);
+            break;
+          case Index::TRI_IDX_TYPE_GEO_INDEX:
+          case Index::TRI_IDX_TYPE_GEO1_INDEX:
+          case Index::TRI_IDX_TYPE_GEO2_INDEX: 
+            count = rocksutils::countKeyRange(db, RocksDBKeyBounds::GeoIndex(rix->objectId()), true);
+            break;
+          case Index::TRI_IDX_TYPE_HASH_INDEX:
+          case Index::TRI_IDX_TYPE_SKIPLIST_INDEX:
+          case Index::TRI_IDX_TYPE_TTL_INDEX:
+          case Index::TRI_IDX_TYPE_PERSISTENT_INDEX: 
+            if (it->unique()) {
+              count = rocksutils::countKeyRange(db, RocksDBKeyBounds::UniqueVPackIndex(rix->objectId(), false), true);
+            } else {
+              count = rocksutils::countKeyRange(db, RocksDBKeyBounds::VPackIndex(rix->objectId(), false), true);
+            }
+            break;
+          case Index::TRI_IDX_TYPE_EDGE_INDEX: 
+            count = rocksutils::countKeyRange(db, RocksDBKeyBounds::EdgeIndex(rix->objectId()), false);
+            break;
+          case Index::TRI_IDX_TYPE_FULLTEXT_INDEX: 
+            count = rocksutils::countKeyRange(db, RocksDBKeyBounds::FulltextIndex(rix->objectId()), true);
+            break;
+          default: 
+            // we should not get here
+            TRI_ASSERT(false);
+        }
+
+        builder.add("count", VPackValue(count));
+        builder.close();
+      }
+    }
+    builder.close(); // "indexes" array
+    builder.close(); // "engine" object
   }
 }
 

--- a/arangod/RocksDBEngine/RocksDBCollection.h
+++ b/arangod/RocksDBEngine/RocksDBCollection.h
@@ -145,7 +145,7 @@ class RocksDBCollection final : public RocksDBMetaCollection {
 
  private:
   /// @brief return engine-specific figures
-  void figuresSpecific(velocypack::Builder&) override;
+  void figuresSpecific(bool details, velocypack::Builder&) override;
 
   // @brief return the primary index
   // WARNING: Make sure that this instance

--- a/arangod/StorageEngine/PhysicalCollection.cpp
+++ b/arangod/StorageEngine/PhysicalCollection.cpp
@@ -582,7 +582,7 @@ void PhysicalCollection::getIndexesVPack(VPackBuilder& result,
 }
 
 /// @brief return the figures for a collection
-futures::Future<OperationResult> PhysicalCollection::figures() {
+futures::Future<OperationResult> PhysicalCollection::figures(bool details) {
   auto buffer = std::make_shared<VPackBufferUInt8>();
   VPackBuilder builder(buffer);
   
@@ -613,7 +613,7 @@ futures::Future<OperationResult> PhysicalCollection::figures() {
   builder.close();  // indexes
 
   // add engine-specific figures
-  figuresSpecific(builder);
+  figuresSpecific(details, builder);
   builder.close();
   return OperationResult(Result(), std::move(buffer));
 }

--- a/arangod/StorageEngine/PhysicalCollection.h
+++ b/arangod/StorageEngine/PhysicalCollection.h
@@ -122,7 +122,7 @@ class PhysicalCollection {
                        std::function<bool(arangodb::Index const*, std::underlying_type<Index::Serialize>::type&)> const& filter) const;
 
   /// @brief return the figures for a collection
-  virtual futures::Future<OperationResult> figures();
+  virtual futures::Future<OperationResult> figures(bool details);
 
   /// @brief create or restore an index
   /// @param restore utilize specified ID, assume index has to be created
@@ -223,7 +223,7 @@ class PhysicalCollection {
   PhysicalCollection(LogicalCollection& collection, arangodb::velocypack::Slice const& info);
 
   /// @brief Inject figures that are specific to StorageEngine
-  virtual void figuresSpecific(arangodb::velocypack::Builder&) = 0;
+  virtual void figuresSpecific(bool details, arangodb::velocypack::Builder&) = 0;
 
   // SECTION: Document pre commit preperation
 

--- a/arangod/V8Server/v8-collection.cpp
+++ b/arangod/V8Server/v8-collection.cpp
@@ -955,6 +955,11 @@ static void JS_FiguresVocbaseCol(v8::FunctionCallbackInfo<v8::Value> const& args
     TRI_V8_THROW_EXCEPTION_INTERNAL("cannot extract collection");
   }
 
+  bool details = false;
+  if (args.Length() != 0) {
+    details = TRI_ObjectToBoolean(isolate, args[0]);
+  }
+
   SingleCollectionTransaction trx(transaction::V8Context::Create(collection->vocbase(), true),
                                   *collection, AccessMode::Type::READ);
   Result res = trx.begin();
@@ -963,7 +968,7 @@ static void JS_FiguresVocbaseCol(v8::FunctionCallbackInfo<v8::Value> const& args
     TRI_V8_THROW_EXCEPTION(res);
   }
 
-  auto opRes = collection->figures().get();
+  auto opRes = collection->figures(details).get();
 
   trx.finish(TRI_ERROR_NO_ERROR);
 

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -976,8 +976,8 @@ arangodb::Result LogicalCollection::properties(velocypack::Slice const& slice, b
 }
 
 /// @brief return the figures for a collection
-futures::Future<OperationResult> LogicalCollection::figures() const {
-  return getPhysical()->figures();
+futures::Future<OperationResult> LogicalCollection::figures(bool details) const {
+  return getPhysical()->figures(details);
 }
 
 /// SECTION Indexes

--- a/arangod/VocBase/LogicalCollection.h
+++ b/arangod/VocBase/LogicalCollection.h
@@ -242,7 +242,7 @@ class LogicalCollection : public LogicalDataSource {
   virtual arangodb::Result properties(velocypack::Slice const& slice, bool partialUpdate) override;
 
   /// @brief return the figures for a collection
-  virtual futures::Future<OperationResult> figures() const;
+  virtual futures::Future<OperationResult> figures(bool details) const;
 
   /// @brief closes an open collection
   int close();

--- a/js/client/modules/@arangodb/arango-collection.js
+++ b/js/client/modules/@arangodb/arango-collection.js
@@ -428,8 +428,8 @@ ArangoCollection.prototype.recalculateCount = function () {
 // / @brief gets the figures of a collection
 // //////////////////////////////////////////////////////////////////////////////
 
-ArangoCollection.prototype.figures = function () {
-  var requestResult = this._database._connection.GET(this._baseurl('figures'));
+ArangoCollection.prototype.figures = function (details) {
+  var requestResult = this._database._connection.GET(this._baseurl('figures') + '?details=' + (details ? 'true' : 'false'));
 
   arangosh.checkRequestResult(requestResult);
 

--- a/tests/Mocks/StorageEngineMock.cpp
+++ b/tests/Mocks/StorageEngineMock.cpp
@@ -1057,7 +1057,7 @@ bool PhysicalCollectionMock::dropIndex(arangodb::IndexId iid) {
   return false;
 }
 
-void PhysicalCollectionMock::figuresSpecific(arangodb::velocypack::Builder&) {
+void PhysicalCollectionMock::figuresSpecific(bool /*details*/, arangodb::velocypack::Builder&) {
   before();
   TRI_ASSERT(false);
 }

--- a/tests/Mocks/StorageEngineMock.h
+++ b/tests/Mocks/StorageEngineMock.h
@@ -75,7 +75,7 @@ class PhysicalCollectionMock : public arangodb::PhysicalCollection {
                                                        bool restore, bool& created) override;
   virtual void deferDropCollection(std::function<bool(arangodb::LogicalCollection&)> const& callback) override;
   virtual bool dropIndex(arangodb::IndexId iid) override;
-  virtual void figuresSpecific(arangodb::velocypack::Builder&) override;
+  virtual void figuresSpecific(bool details, arangodb::velocypack::Builder&) override;
   virtual std::unique_ptr<arangodb::IndexIterator> getAllIterator(
       arangodb::transaction::Methods* trx) const override;
   virtual std::unique_ptr<arangodb::IndexIterator> getAnyIterator(

--- a/tests/js/common/shell/shell-figures-rocksdb.js
+++ b/tests/js/common/shell/shell-figures-rocksdb.js
@@ -1,0 +1,495 @@
+/* jshint globalstrict:false, strict:false */
+/* global assertEqual, assertFalse */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2010-2012 triagens GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// / @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+let jsunity = require('jsunity');
+let arangodb = require('@arangodb');
+let internal = require('internal');
+let db = arangodb.db;
+
+function FiguresSuite () {
+  'use strict';
+
+  const cn = "UnitTestsFigures";
+  const isCluster = internal.isCluster();
+  const isEnterprise = internal.isEnterprise();
+
+  return {
+    
+    testNonDetailed: function () {
+      let c = db._create(cn, { numberOfShards: 4 });
+      try {
+        let figures = c.figures(false);
+        assertFalse(figures.hasOwnProperty("rocksdb"));
+      } finally {
+        db._drop(cn);
+      }
+    },
+
+    testDetailedEmpty: function () {
+      let c = db._create(cn, { numberOfShards: 4 });
+      try {
+        let figures = c.figures(true).engine;
+        assertEqual(0, figures.documents);
+
+        let indexes = figures.indexes;
+        assertEqual(1, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(0, indexes[0].id);
+        assertEqual(0, indexes[0].count);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testDetailedJustPrimary: function () {
+      let c = db._create(cn, { numberOfShards: 4 });
+      for (let i = 0; i < 100; ++i) {
+        c.insert({ value: i });
+      }
+      try {
+        let figures = c.figures(true).engine;
+        assertEqual(100, figures.documents);
+
+        let indexes = figures.indexes;
+        assertEqual(1, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(0, indexes[0].id);
+        assertEqual(100, indexes[0].count);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testDetailedEmptyEdge: function () {
+      let c = db._createEdgeCollection(cn, { numberOfShards: 4 });
+      try {
+        let figures = c.figures(true).engine;
+        assertEqual(0, figures.documents);
+
+        let indexes = figures.indexes;
+        assertEqual(3, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(0, indexes[0].id);
+        assertEqual(0, indexes[0].count);
+        assertEqual("edge", indexes[1].type);
+        assertEqual(1, indexes[1].id);
+        assertEqual(0, indexes[1].count);
+        assertEqual("edge", indexes[2].type);
+        assertEqual(2, indexes[2].id);
+        assertEqual(0, indexes[2].count);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testDetailedEdge: function () {
+      let c = db._createEdgeCollection(cn, { numberOfShards: 4 });
+      try {
+        for (let i = 0; i < 100; ++i) {
+          c.insert({ _from: "test/a", _to: "test/b" });
+        }
+        let figures = c.figures(true).engine;
+        assertEqual(100, figures.documents);
+
+        let indexes = figures.indexes;
+        assertEqual(3, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(0, indexes[0].id);
+        assertEqual(100, indexes[0].count);
+        assertEqual("edge", indexes[1].type);
+        assertEqual(1, indexes[1].id);
+        assertEqual(100, indexes[1].count);
+        assertEqual("edge", indexes[2].type);
+        assertEqual(2, indexes[2].id);
+        assertEqual(100, indexes[2].count);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testDetailedHash: function () {
+      let c = db._create(cn, { numberOfShards: 4 });
+      try {
+        let idxs = [];
+        idxs.push(c.ensureIndex({ type: "hash", fields: ["value1"] }));
+        for (let i = 0; i < 100; ++i) {
+          c.insert({ value1: i, value2: "test" + i });
+        }
+        let figures = c.figures(true).engine;
+        assertEqual(100, figures.documents);
+
+        let indexes = figures.indexes;
+        assertEqual(2, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(0, indexes[0].id);
+        assertEqual(100, indexes[0].count);
+        assertEqual("rocksdb-hash", indexes[1].type);
+        assertEqual(idxs[0].id, cn + '/' + indexes[1].id);
+        assertEqual(100, indexes[1].count);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testDetailedHashSparse: function () {
+      let c = db._create(cn, { numberOfShards: 4 });
+      try {
+        let idxs = [];
+        idxs.push(c.ensureIndex({ type: "hash", fields: ["value1"], sparse: true }));
+        for (let i = 0; i < 100; ++i) {
+          c.insert({ value1: i < 50 ? null : i, value2: "test" + i });
+        }
+        let figures = c.figures(true).engine;
+        assertEqual(100, figures.documents);
+
+        let indexes = figures.indexes;
+        assertEqual(2, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(0, indexes[0].id);
+        assertEqual(100, indexes[0].count);
+        assertEqual("rocksdb-hash", indexes[1].type);
+        assertEqual(idxs[0].id, cn + '/' + indexes[1].id);
+        assertEqual(50, indexes[1].count);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testDetailedHashUnique: function () {
+      let c = db._create(cn, { numberOfShards: 4 });
+      try {
+        let idxs = [];
+        idxs.push(c.ensureIndex({ type: "hash", fields: ["value1", "_key"], unique: true }));
+        for (let i = 0; i < 100; ++i) {
+          c.insert({ value1: i, value2: "test" + i });
+        } 
+        let figures = c.figures(true).engine;
+        assertEqual(100, figures.documents);
+
+        let indexes = figures.indexes;
+        assertEqual(2, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(0, indexes[0].id);
+        assertEqual(100, indexes[0].count);
+        assertEqual("rocksdb-hash", indexes[1].type);
+        assertEqual(idxs[0].id, cn + '/' + indexes[1].id);
+        assertEqual(100, indexes[1].count);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testDetailedHashCombined: function () {
+      let c = db._create(cn, { numberOfShards: 4 });
+      try {
+        let idxs = [];
+        idxs.push(c.ensureIndex({ type: "hash", fields: ["value1", "value2"] }));
+        for (let i = 0; i < 100; ++i) {
+          c.insert({ value1: i, value2: "test" + i });
+        }
+        let figures = c.figures(true).engine;
+        assertEqual(100, figures.documents);
+
+        let indexes = figures.indexes;
+        assertEqual(2, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(0, indexes[0].id);
+        assertEqual(100, indexes[0].count);
+        assertEqual("rocksdb-hash", indexes[1].type);
+        assertEqual(idxs[0].id, cn + '/' + indexes[1].id);
+        assertEqual(100, indexes[1].count);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testDetailedHashArray: function () {
+      let c = db._create(cn, { numberOfShards: 4 });
+      try {
+        let idxs = [];
+        idxs.push(c.ensureIndex({ type: "hash", fields: ["value1[*]"] }));
+        for (let i = 0; i < 100; ++i) {
+          c.insert({ value1: [1, 2, 3], value2: "test" + i });
+        }
+        let figures = c.figures(true).engine;
+        assertEqual(100, figures.documents);
+
+        let indexes = figures.indexes;
+        assertEqual(2, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(0, indexes[0].id);
+        assertEqual(100, indexes[0].count);
+        assertEqual("rocksdb-hash", indexes[1].type);
+        assertEqual(idxs[0].id, cn + '/' + indexes[1].id);
+        assertEqual(300, indexes[1].count);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testDetailedHashArrayDeduplicate: function () {
+      let c = db._create(cn, { numberOfShards: 4 });
+      try {
+        let idxs = [];
+        idxs.push(c.ensureIndex({ type: "hash", fields: ["value1[*]"], deduplicate: true }));
+        for (let i = 0; i < 100; ++i) {
+          c.insert({ value1: [1, 2, 1], value2: "test" + i });
+        }
+        let figures = c.figures(true).engine;
+        assertEqual(100, figures.documents);
+
+        let indexes = figures.indexes;
+        assertEqual(2, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(0, indexes[0].id);
+        assertEqual(100, indexes[0].count);
+        assertEqual("rocksdb-hash", indexes[1].type);
+        assertEqual(idxs[0].id, cn + '/' + indexes[1].id);
+        assertEqual(200, indexes[1].count);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testDetailedSkiplist: function () {
+      let c = db._create(cn, { numberOfShards: 4 });
+      try {
+        let idxs = [];
+        idxs.push(c.ensureIndex({ type: "skiplist", fields: ["value1"] }));
+        for (let i = 0; i < 100; ++i) {
+          c.insert({ value1: i, value2: "test" + i });
+        }
+        let figures = c.figures(true).engine;
+        assertEqual(100, figures.documents);
+
+        let indexes = figures.indexes;
+        assertEqual(2, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(0, indexes[0].id);
+        assertEqual(100, indexes[0].count);
+        assertEqual("rocksdb-skiplist", indexes[1].type);
+        assertEqual(idxs[0].id, cn + '/' + indexes[1].id);
+        assertEqual(100, indexes[1].count);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testDetailedPersistent: function () {
+      let c = db._create(cn, { numberOfShards: 4 });
+      try {
+        let idxs = [];
+        idxs.push(c.ensureIndex({ type: "persistent", fields: ["value1"] }));
+        for (let i = 0; i < 100; ++i) {
+          c.insert({ value1: i, value2: "test" + i });
+        }
+        let figures = c.figures(true).engine;
+        assertEqual(100, figures.documents);
+
+        let indexes = figures.indexes;
+        assertEqual(2, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(0, indexes[0].id);
+        assertEqual(100, indexes[0].count);
+        assertEqual("rocksdb-persistent", indexes[1].type);
+        assertEqual(idxs[0].id, cn + '/' + indexes[1].id);
+        assertEqual(100, indexes[1].count);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testDetailedTtlInvalid: function () {
+      let c = db._create(cn, { numberOfShards: 4 });
+      try {
+        let idxs = [];
+        idxs.push(c.ensureIndex({ type: "ttl", fields: ["value1"], expireAfter: 100000 }));
+        for (let i = 0; i < 100; ++i) {
+          c.insert({ value1: "piffpaff", value2: "test" + i });
+        }
+        let figures = c.figures(true).engine;
+        assertEqual(100, figures.documents);
+
+        let indexes = figures.indexes;
+        assertEqual(2, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(0, indexes[0].id);
+        assertEqual(100, indexes[0].count);
+        assertEqual("rocksdb-ttl", indexes[1].type);
+        assertEqual(idxs[0].id, cn + '/' + indexes[1].id);
+        assertEqual(0, indexes[1].count);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testDetailedTtl: function () {
+      let c = db._create(cn, { numberOfShards: 4 });
+      try {
+        let idxs = [];
+        idxs.push(c.ensureIndex({ type: "ttl", fields: ["value1"], expireAfter: 100000 }));
+        let dt = (new Date()).toISOString();
+        for (let i = 0; i < 100; ++i) {
+          c.insert({ value1: dt, value2: "test" + i });
+        }
+        let figures = c.figures(true).engine;
+        assertEqual(100, figures.documents);
+
+        let indexes = figures.indexes;
+        assertEqual(2, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(0, indexes[0].id);
+        assertEqual(100, indexes[0].count);
+        assertEqual("rocksdb-ttl", indexes[1].type);
+        assertEqual(idxs[0].id, cn + '/' + indexes[1].id);
+        assertEqual(100, indexes[1].count);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testDetailedGeoInvalid: function () {
+      let c = db._create(cn, { numberOfShards: 4 });
+      try {
+        let idxs = [];
+        idxs.push(c.ensureIndex({ type: "geo", fields: ["lat", "lon"] }));
+        for (let i = 0; i < 100; ++i) {
+          c.insert({ lat: "piff", lon: "paff" });
+        }
+        let figures = c.figures(true).engine;
+        assertEqual(100, figures.documents);
+
+        let indexes = figures.indexes;
+        assertEqual(2, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(0, indexes[0].id);
+        assertEqual(100, indexes[0].count);
+        assertEqual("geo", indexes[1].type);
+        assertEqual(idxs[0].id, cn + '/' + indexes[1].id);
+        assertEqual(0, indexes[1].count);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testDetailedGeo: function () {
+      let c = db._create(cn, { numberOfShards: 4 });
+      try {
+        let idxs = [];
+        idxs.push(c.ensureIndex({ type: "geo", fields: ["lat", "lon"] }));
+        for (let i = 0; i < 100; ++i) {
+          c.insert({ lat: 50 - i, lon: 50 - i });
+        }
+        let figures = c.figures(true).engine;
+        assertEqual(100, figures.documents);
+
+        let indexes = figures.indexes;
+        assertEqual(2, indexes.length);
+        assertEqual("primary", indexes[0].type);
+        assertEqual(0, indexes[0].id);
+        assertEqual(100, indexes[0].count);
+        assertEqual("geo", indexes[1].type);
+        assertEqual(idxs[0].id, cn + '/' + indexes[1].id);
+        assertEqual(100, indexes[1].count);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testDetailedSmartEdge: function () {
+      if (!isCluster || !isEnterprise) {
+        return;
+      }
+
+      db._create(cn + "v", { numberOfShards: 4, isSmart: true, shardKeys: ["_key:"], smartGraphAttribute: "value1" });
+      try {
+        let c = db._createEdgeCollection(cn + "e", { numberOfShards: 4, isSmart: true, shardKeys: ["_key:"], distributeShardsLike: cn + "v" });
+        try {
+          for (let i = 0; i < 100; ++i) {
+            c.insert({ _from: "test/1:1", _to: "test/2:2", value1: i });
+          }
+          let figures = c.figures(true).engine;
+          assertEqual(100, figures.documents);
+
+          let indexes = figures.indexes;
+          assertEqual(3, indexes.length);
+          assertEqual("primary", indexes[0].type);
+          assertEqual(0, indexes[0].id);
+          assertEqual(100, indexes[0].count);
+          assertEqual("edge", indexes[1].type);
+          assertEqual(1, indexes[1].id);
+          assertEqual(100, indexes[1].count);
+          assertEqual("edge", indexes[2].type);
+          assertEqual(2, indexes[2].id);
+          assertEqual(100, indexes[2].count);
+        } finally {
+          db._drop(cn + "e");
+        }
+      } finally {
+        db._drop(cn + "v");
+      }
+    },
+    
+    testDetailedDisjointSmartEdge: function () {
+      if (!isCluster || !isEnterprise) {
+        return;
+      }
+
+      db._create(cn + "v", { numberOfShards: 4, isSmart: true, shardKeys: ["_key:"], smartGraphAttribute: "value1" });
+      try {
+        let c = db._createEdgeCollection(cn + "e", { numberOfShards: 4, isDisjoint: true, isSmart: true, shardKeys: ["_key:"], distributeShardsLike: cn + "v" });
+        try {
+          for (let i = 0; i < 100; ++i) {
+            c.insert({ _from: "test/1:1", _to: "test/2:2", value1: i });
+          }
+          let figures = c.figures(true).engine;
+          assertEqual(100, figures.documents);
+
+          let indexes = figures.indexes;
+          assertEqual(3, indexes.length);
+          assertEqual("primary", indexes[0].type);
+          assertEqual(0, indexes[0].id);
+          assertEqual(100, indexes[0].count);
+          assertEqual("edge", indexes[1].type);
+          assertEqual(1, indexes[1].id);
+          assertEqual(100, indexes[1].count);
+          assertEqual("edge", indexes[2].type);
+          assertEqual(2, indexes[2].id);
+          assertEqual(100, indexes[2].count);
+        } finally {
+          db._drop(cn + "e");
+        }
+      } finally {
+        db._drop(cn + "v");
+      }
+    },
+    
+  };
+}
+
+jsunity.run(FiguresSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Added `details` option to figures command of a collection: `collection.figures(details)`

Setting `details` to `true` will return extended storage engine-specific details to the figures. The details are intended for debugging ArangoDB itself and their format is subject to change. Currently, the details are returned for the RocksDB storage engine only.
By default, `details` is set to `false`, so no details are returned and the behavior is identical to previous versions of ArangoDB.

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/545

- [ ] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required
- [x] Backports required for: 3.7, 3.6

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (i.e. in shell_server / shell_client)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11781/