### PR TITLE
fix undefined behavior in issue #9834

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,19 @@
 v3.5.6 (XXXX-XX-XX)
 -------------------
 
+* Enfore a maximum result register usage limit in AQL queries. In an AQL
+  query, every user-defined or internal (unnamed) variable will need a 
+  register to store results in.
+
+  AQL queries that use more result registers than allowed (currently 1000) 
+  will now abort deterministically during the planning stage with error 32 
+  (`resource limit exceeded`) and the error message 
+  "too many registers (1000) needed for AQL query".
+
+  Before this fix, an AQL query that used more than 1000 result registers
+  crashed the server when assertions were turned on, and the behavior was 
+  undefined when assertions were turned off.
+
 * Updated arangosync to 0.7.11.
 
 * Make followers in active failover run a compaction after they process a

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,17 +1,17 @@
 v3.5.6 (XXXX-XX-XX)
 -------------------
 
-* Enforce a maximum result register usage limit in AQL queries. In an AQL
-  query, every user-defined or internal (unnamed) variable will need a 
-  register to store results in.
+* Enforce a maximum result register usage limit in AQL queries. In an AQL query,
+  every user-defined or internal (unnamed) variable will need a register to
+  store results in.
 
-  AQL queries that use more result registers than allowed (currently 1000) 
-  will now abort deterministically during the planning stage with error 32 
-  (`resource limit exceeded`) and the error message 
+  AQL queries that use more result registers than allowed (currently 1000) will
+  now abort deterministically during the planning stage with error 32
+  (`resource limit exceeded`) and the error message
   "too many registers (1000) needed for AQL query".
 
   Before this fix, an AQL query that used more than 1000 result registers
-  crashed the server when assertions were turned on, and the behavior was 
+  crashed the server when assertions were turned on, and the behavior was
   undefined when assertions were turned off.
 
 * Updated arangosync to 0.7.11.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.5.6 (XXXX-XX-XX)
 -------------------
 
-* Enfore a maximum result register usage limit in AQL queries. In an AQL
+* Enforce a maximum result register usage limit in AQL queries. In an AQL
   query, every user-defined or internal (unnamed) variable will need a 
   register to store results in.
 

--- a/arangod/Aql/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode.h
@@ -65,6 +65,7 @@
 #include "Aql/WalkerWorker.h"
 #include "Aql/types.h"
 #include "Basics/Common.h"
+#include "Basics/Exceptions.h"
 #include "VocBase/LogicalView.h"
 #include "VocBase/voc-types.h"
 #include "VocBase/vocbase.h"
@@ -449,6 +450,11 @@ class ExecutionNode {
     VarInfo() = delete;
     VarInfo(int depth, RegisterId registerId)
         : depth(depth), registerId(registerId) {
+
+      if (registerId >= MaxRegisterId) {
+        THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_RESOURCE_LIMIT, 
+                                       std::string("too many registers (") + std::to_string(MaxRegisterId) + ") needed for AQL query");
+      }
       TRI_ASSERT(registerId < MaxRegisterId);
     }
   };

--- a/tests/js/server/aql/aql-registers-limit.js
+++ b/tests/js/server/aql/aql-registers-limit.js
@@ -1,0 +1,76 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global assertEqual, fail, AQL_EXPLAIN */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief tests for registers limits
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+let internal = require("internal");
+let jsunity = require("jsunity");
+
+function aqlRegistersLimitTestSuite () {
+  const errors = internal.errors;
+  // the value of 1000 needs to match the maximum allowed register number in
+  // arangod (currently in RegisterPlan::MaxRegisterId)
+  const maxRegisters = 1000;
+
+  let buildQuery = function(numRegisters) {
+    let subs = [], returns = [];
+    // we need to subtract a register here because we have one extra results
+    // register
+    for (let i = 0; i < numRegisters - 1; ++i) {
+      subs.push(`LET test${i} = NOOPT(${i})`);
+      returns.push(`test${i}`);
+    }
+    return subs.join('\n') + 'RETURN [\n' + returns.join(',\n') + ']\n';
+  };
+
+  return {
+    testBelowLimit : function () {
+      let query = buildQuery(maxRegisters - 1);
+      let plan = AQL_EXPLAIN(query).plan;
+      assertEqual(maxRegisters - 1, plan.variables.length);
+    },
+    
+    testAtLimit : function () {
+      let query = buildQuery(maxRegisters);
+      let plan = AQL_EXPLAIN(query).plan;
+      assertEqual(maxRegisters, plan.variables.length);
+    },
+    
+    testBeyondLimit : function () {
+      let query = buildQuery(maxRegisters + 1);
+      try {
+        AQL_EXPLAIN(query);
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_RESOURCE_LIMIT.code, err.errorNum);
+      }
+    },
+  };
+}
+
+jsunity.run(aqlRegistersLimitTestSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Enforce a maximum result register usage limit in AQL queries. In an AQL query, every user-defined or internal (unnamed) variable will need a register to store results in.

AQL queries that use more result registers than allowed (currently 1000) will now abort deterministically during the planning stage with error 32 (`resource limit exceeded`) and the error message "too many registers (1000) needed for AQL query".

Before this fix, an AQL query that used more than 1000 result registers crashed the server when assertions were turned on, and the behavior was undefined when assertions were turned off.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required

#### Related Information

- [x] GitHub issue / Jira ticket number: https://github.com/arangodb/arangodb/issues/9834

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (i.e. in shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11789/