### PR TITLE
Validate OPTIONS argument

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Ensure that the argument to an AQL OPTIONS clause is always an object
+  which does not contain any dynamic (run-time) values. Previously, this
+  was only enforced for traversal options and options for data-modification
+  queries. This change extends the check to all occurrences of OPTIONS.
+
 * Enforce a maximum result register usage limit in AQL queries. In an AQL
   query, every user-defined or internal (unnamed) variable will need a 
   register to store results in.

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -1357,7 +1357,7 @@ void registerError(ExpressionContext* expressionContext, char const* functionNam
   std::string msg;
 
   if (code == TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH) {
-    msg = arangodb::basics::Exception::FillExceptionString(code, functionName);
+    msg = arangodb::aql::QueryWarnings::buildFormattedString(code, functionName);
   } else {
     msg.append("in function '");
     msg.append(functionName);

--- a/arangod/Aql/Parser.cpp
+++ b/arangod/Aql/Parser.cpp
@@ -63,10 +63,9 @@ bool Parser::configureWriteQuery(AstNode const* collectionNode, AstNode* optionN
   bool isExclusiveAccess = false;
 
   if (optionNode != nullptr) {
-    if (!optionNode->isConstant()) {
-      _query.warnings().registerError(TRI_ERROR_QUERY_COMPILE_TIME_OPTIONS);
-    }
-
+    // already validated at parse-time
+    TRI_ASSERT(optionNode->isObject());
+    TRI_ASSERT(optionNode->isConstant());
     isExclusiveAccess = ExecutionPlan::hasExclusiveAccessOption(optionNode);
   }
 
@@ -173,12 +172,7 @@ void Parser::registerParseError(int errorCode, char const* data, int line, int c
     errorMessage << '^' << '^' << std::endl;
   }
 
-  registerError(errorCode, errorMessage.str().c_str());
-}
-
-/// @brief register a non-parse error
-void Parser::registerError(int errorCode, char const* data) {
-  _query.warnings().registerError(errorCode, data);
+  _query.warnings().registerError(errorCode, errorMessage.str().c_str());
 }
 
 /// @brief register a warning
@@ -190,6 +184,7 @@ void Parser::registerWarning(int errorCode, char const* data, int line, int colu
 /// @brief push an AstNode array element on top of the stack
 /// the array must be removed from the stack via popArray
 void Parser::pushArray(AstNode* array) {
+  TRI_ASSERT(array != nullptr);
   TRI_ASSERT(array->type == NODE_TYPE_ARRAY);
   array->setFlag(DETERMINED_CONSTANT, VALUE_CONSTANT);
   pushStack(array);
@@ -205,6 +200,7 @@ AstNode* Parser::popArray() {
 
 /// @brief push an AstNode into the array element on top of the stack
 void Parser::pushArrayElement(AstNode* node) {
+  TRI_ASSERT(node != nullptr);
   auto array = static_cast<AstNode*>(peekStack());
   TRI_ASSERT(array->type == NODE_TYPE_ARRAY);
   array->addMember(node);
@@ -216,6 +212,7 @@ void Parser::pushArrayElement(AstNode* node) {
 /// @brief push an AstNode into the object element on top of the stack
 void Parser::pushObjectElement(char const* attributeName, size_t nameLength, AstNode* node) {
   auto object = static_cast<AstNode*>(peekStack());
+  TRI_ASSERT(object != nullptr);
   TRI_ASSERT(object->type == NODE_TYPE_OBJECT);
   auto element = _ast.createNodeObjectElement(attributeName, nameLength, node);
   object->addMember(element);
@@ -224,19 +221,24 @@ void Parser::pushObjectElement(char const* attributeName, size_t nameLength, Ast
 /// @brief push an AstNode into the object element on top of the stack
 void Parser::pushObjectElement(AstNode* attributeName, AstNode* node) {
   auto object = static_cast<AstNode*>(peekStack());
+  TRI_ASSERT(object != nullptr);
   TRI_ASSERT(object->type == NODE_TYPE_OBJECT);
   auto element = _ast.createNodeCalculatedObjectElement(attributeName, node);
   object->addMember(element);
 }
 
 /// @brief push a temporary value on the parser's stack
-void Parser::pushStack(void* value) { _stack.emplace_back(value); }
+void Parser::pushStack(void* value) {
+  TRI_ASSERT(value != nullptr);
+  _stack.emplace_back(value); 
+}
 
 /// @brief pop a temporary value from the parser's stack
 void* Parser::popStack() {
   TRI_ASSERT(!_stack.empty());
 
   void* result = _stack.back();
+  TRI_ASSERT(result != nullptr);
   _stack.pop_back();
   return result;
 }

--- a/arangod/Aql/Parser.h
+++ b/arangod/Aql/Parser.h
@@ -106,10 +106,7 @@ class Parser {
 
   /// @brief register a parse error, position is specified as line / column
   void registerParseError(int, char const*, int, int);
-
-  /// @brief register a non-parse error
-  void registerError(int, char const* = nullptr);
-
+  
   /// @brief register a warning
   void registerWarning(int, char const*, int, int);
 

--- a/arangod/Aql/QueryWarnings.cpp
+++ b/arangod/Aql/QueryWarnings.cpp
@@ -37,7 +37,7 @@ QueryWarnings::QueryWarnings()
   : _maxWarningCount(std::numeric_limits<size_t>::max()),
     _failOnWarning(false) {}
 
-/// @brief register an error, with an optional parameter inserted into printf
+/// @brief register an error
 /// this also makes the query abort
 void QueryWarnings::registerError(int code, char const* details) {
   TRI_ASSERT(code != TRI_ERROR_NO_ERROR);
@@ -46,7 +46,7 @@ void QueryWarnings::registerError(int code, char const* details) {
     THROW_ARANGO_EXCEPTION(code);
   }
 
-  THROW_ARANGO_EXCEPTION_PARAMS(code, details);
+  THROW_ARANGO_EXCEPTION_MESSAGE(code, details);
 }
 
 void QueryWarnings::registerWarning(int code, std::string const& details) {
@@ -104,8 +104,11 @@ void QueryWarnings::updateOptions(QueryOptions const& opts) {
   _failOnWarning = opts.failOnWarning;
 }
 
-
 std::vector<std::pair<int, std::string>> QueryWarnings::all() const {
   std::lock_guard<std::mutex> guard(_mutex);
   return _list;
+}
+
+std::string QueryWarnings::buildFormattedString(int code, char const* details) {
+  return arangodb::basics::Exception::FillExceptionString(code, details);
 }

--- a/arangod/Aql/QueryWarnings.h
+++ b/arangod/Aql/QueryWarnings.h
@@ -46,9 +46,9 @@ public:
   explicit QueryWarnings();
   ~QueryWarnings() = default;
 
-  /// @brief register an error, with an optional parameter inserted into printf
+  /// @brief register an error
   /// this also makes the query abort
-  void registerError(int, char const* = nullptr);
+  [[noreturn]] void registerError(int, char const* = nullptr);
 
   /// @brief register a warning
   void registerWarning(int, char const* = nullptr);
@@ -63,6 +63,8 @@ public:
   void updateOptions(QueryOptions const&);
   
   std::vector<std::pair<int, std::string>> all() const;
+
+  static std::string buildFormattedString(int code, char const* details);
   
  private:
   

--- a/arangod/Aql/grammar.y
+++ b/arangod/Aql/grammar.y
@@ -47,11 +47,6 @@
 
 using namespace arangodb::aql;
 
-/// @brief shortcut macro for signaling out of memory
-#define ABORT_OOM                                   \
-  parser->registerError(TRI_ERROR_OUT_OF_MEMORY);   \
-  YYABORT;
-
 #define scanner parser->scanner()
 
 /// @brief forward for lexer function defined in Aql/tokens.ll
@@ -65,6 +60,17 @@ void Aqlerror(YYLTYPE* locp,
 }
 
 namespace {
+void validateOptions(Parser* parser, AstNode const* node,
+                     int line, int column) {
+  TRI_ASSERT(node != nullptr);
+  if (!node->isObject()) {
+    parser->registerParseError(TRI_ERROR_QUERY_PARSE, "'OPTIONS' have to be an object", line, column);
+  }
+  if (!node->isConstant()) {
+    parser->registerParseError(TRI_ERROR_QUERY_COMPILE_TIME_OPTIONS, "'OPTIONS' have to be readable at query compile time", line, column);
+  }
+}
+
 /// @brief check if any of the variables used in the INTO expression were
 /// introduced by the COLLECT itself, in which case it would fail
 void checkIntoVariables(Parser* parser, AstNode const* expression,
@@ -121,7 +127,8 @@ void registerAssignVariables(Parser* parser, arangodb::aql::Scopes* scopes,
 }
 
 /// @brief validate the aggregate variables expressions
-bool validateAggregates(Parser* parser, AstNode const* aggregates) {
+bool validateAggregates(Parser* parser, AstNode const* aggregates,
+                        int line, int column) {
   size_t const n = aggregates->numMembers();
 
   for (size_t i = 0; i < n; ++i) {
@@ -132,21 +139,21 @@ bool validateAggregates(Parser* parser, AstNode const* aggregates) {
 
       auto func = member->getMember(1);
 
-      bool isValid = true;
+      char const* error = nullptr;
       if (func->type != NODE_TYPE_FCALL) {
         // aggregate expression must be a function call
-        isValid = false;
+        error = "aggregate expression must be a function call";
       }
       else {
         auto f = static_cast<arangodb::aql::Function*>(func->getData());
         if (!Aggregator::isValid(f->name)) {
           // aggregate expression must be a call to MIN|MAX|LENGTH...
-          isValid = false;
+          error = "unknown aggregate function used";
         }
       }
 
-      if (!isValid) {
-        parser->registerError(TRI_ERROR_QUERY_INVALID_AGGREGATE_EXPRESSION);
+      if (error != nullptr) {
+        parser->registerParseError(TRI_ERROR_QUERY_INVALID_AGGREGATE_EXPRESSION, error, line, column);
         return false;
       }
     }
@@ -526,21 +533,15 @@ prune_and_options:
       auto node = static_cast<AstNode*>(parser->peekStack());
       if (TRI_CaseEqualString($1.value, "PRUNE")) {
         /* Only Prune */
-        if ($2 == nullptr) {
-          ABORT_OOM
-        }
+        TRI_ASSERT($2 != nullptr);
         // Prune
         node->addMember($2);
         // Options
         node->addMember(parser->ast()->createNodeNop());
       } else if (TRI_CaseEqualString($1.value, "OPTIONS")) {
         /* Only Options */
-        if ($2 == nullptr) {
-          ABORT_OOM
-        }
-        if (!$2->isObject()) {
-          parser->registerParseError(TRI_ERROR_QUERY_PARSE, "traversal 'OPTIONS' have to be an object", $1.value, yylloc.first_line, yylloc.first_column);
-        }
+        TRI_ASSERT($2 != nullptr);
+        ::validateOptions(parser, $2, yylloc.first_line, yylloc.first_column);
         // Prune
         node->addMember(parser->ast()->createNodeNop());
         // Options
@@ -555,15 +556,13 @@ prune_and_options:
       if (!TRI_CaseEqualString($1.value, "PRUNE")) {
         parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected qualifier '%s', expecting 'PRUNE'", $1.value, yylloc.first_line, yylloc.first_column);
       }
-      if ($2 == nullptr) {
-        ABORT_OOM
-      }
+      TRI_ASSERT($2 != nullptr);
       if (!TRI_CaseEqualString($3.value, "OPTIONS")) {
         parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected qualifier '%s', expecting 'OPTIONS'", $3.value, yylloc.first_line, yylloc.first_column);
       }
-      if ($4 == nullptr) {
-        ABORT_OOM
-      }
+      TRI_ASSERT($4 != nullptr);
+      ::validateOptions(parser, $4, yylloc.first_line, yylloc.first_column);
+
       // Prune
       node->addMember($2);
       // Options
@@ -647,7 +646,6 @@ for_statement:
       AstNode* variableNameNode = variablesNode->getMemberUnchecked(0);
       TRI_ASSERT(variableNameNode->isStringValue());
       AstNode* variableNode = parser->ast()->createNodeVariable(variableNameNode->getStringValue(), variableNameNode->getStringLength(), true);
-
       parser->pushStack(variableNode);
     } for_options {
       // now we can handle the optional SEARCH condition and OPTIONS.
@@ -803,10 +801,7 @@ collect_variable_list:
       parser->pushStack(node);
     } collect_list {
       auto list = static_cast<AstNode*>(parser->popStack());
-
-      if (list == nullptr) {
-        ABORT_OOM
-      }
+      TRI_ASSERT(list != nullptr);
       $$ = list;
     }
   ;
@@ -843,7 +838,7 @@ collect_statement:
       }
 
       // validate aggregates
-      if (!::validateAggregates(parser, $2)) {
+      if (!::validateAggregates(parser, $2, yylloc.first_line, yylloc.first_column)) {
         YYABORT;
       }
 
@@ -867,7 +862,7 @@ collect_statement:
         ::registerAssignVariables(parser, scopes, yylloc.first_line, yylloc.first_column, variablesIntroduced, $2);
       }
 
-      if (!::validateAggregates(parser, $2)) {
+      if (!::validateAggregates(parser, $2, yylloc.first_line, yylloc.first_column)) {
         YYABORT;
       }
 
@@ -994,9 +989,7 @@ variable_list:
       }
 
       auto node = parser->ast()->createNodeReference($1.value, $1.length);
-      if (node == nullptr) {
-        ABORT_OOM
-      }
+      TRI_ASSERT(node != nullptr);
 
       // indicate the this node is a reference to the variable name, not the variable value
       node->setFlag(FLAG_KEEP_VARIABLENAME);
@@ -1008,9 +1001,7 @@ variable_list:
       }
 
       auto node = parser->ast()->createNodeReference($3.value, $3.length);
-      if (node == nullptr) {
-        ABORT_OOM
-      }
+      TRI_ASSERT(node != nullptr);
 
       // indicate the this node is a reference to the variable name, not the variable value
       node->setFlag(FLAG_KEEP_VARIABLENAME);
@@ -1303,10 +1294,7 @@ function_name:
       temp.append("::");
       temp.append($3.value, $3.length);
       auto p = parser->ast()->resources().registerString(temp);
-
-      if (p == nullptr) {
-        ABORT_OOM
-      }
+      TRI_ASSERT(p != nullptr);
 
       $$.value = p;
       $$.length = temp.size();
@@ -1553,10 +1541,7 @@ for_options:
       $$ = nullptr;
     }
   | T_STRING expression {
-      if ($2 == nullptr) {
-        ABORT_OOM
-      }
-
+      TRI_ASSERT($2 != nullptr);
       // we always return an array with two values: SEARCH and OPTIONS
       // as only one of these values will be set here, the other value is NOP
       auto node = parser->ast()->createNodeArray(2);
@@ -1571,6 +1556,8 @@ for_options:
         if (!TRI_CaseEqualString($1.value, "OPTIONS")) {
           parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected qualifier '%s', expecting 'SEARCH' or 'OPTIONS'", $1.value, yylloc.first_line, yylloc.first_column);
         }
+      
+        ::validateOptions(parser, $2, yylloc.first_line, yylloc.first_column);
 
         node->addMember(parser->ast()->createNodeNop());
         node->addMember($2);
@@ -1579,16 +1566,15 @@ for_options:
       $$ = node;
     }
   | T_STRING expression T_STRING expression {
-      if ($2 == nullptr) {
-        ABORT_OOM
-      }
-
+      TRI_ASSERT($2 != nullptr);
       // two extra qualifiers. we expect them in the order: SEARCH, then OPTIONS
 
       if (!TRI_CaseEqualString($1.value, "SEARCH") ||
           !TRI_CaseEqualString($3.value, "OPTIONS")) {
         parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected qualifier '%s', expecting 'SEARCH' and 'OPTIONS'", $1.value, yylloc.first_line, yylloc.first_column);
       }
+      
+      ::validateOptions(parser, $4, yylloc.first_line, yylloc.first_column);
 
       auto node = parser->ast()->createNodeArray(2);
       node->addMember($2);
@@ -1602,13 +1588,13 @@ options:
       $$ = nullptr;
     }
   | T_STRING object {
-      if ($2 == nullptr) {
-        ABORT_OOM
-      }
+      TRI_ASSERT($2 != nullptr);
 
       if (!TRI_CaseEqualString($1.value, "OPTIONS")) {
         parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected qualifier '%s', expecting 'OPTIONS'", $1.value, yylloc.first_line, yylloc.first_column);
       }
+      
+      ::validateOptions(parser, $2, yylloc.first_line, yylloc.first_column);
 
       $$ = $2;
     }
@@ -1832,11 +1818,8 @@ reference:
       $$ = $1;
     }
   | function_call {
+      TRI_ASSERT($1 != nullptr);
       $$ = $1;
-
-      if ($$ == nullptr) {
-        ABORT_OOM
-      }
     }
   | T_OPEN expression T_CLOSE {
       if ($2->type == NODE_TYPE_EXPANSION) {
@@ -1957,17 +1940,11 @@ simple_value:
 
 numeric_value:
     T_INTEGER {
-      if ($1 == nullptr) {
-        ABORT_OOM
-      }
-
+      TRI_ASSERT($1 != nullptr);
       $$ = $1;
     }
   | T_DOUBLE {
-      if ($1 == nullptr) {
-        ABORT_OOM
-      }
-
+      TRI_ASSERT($1 != nullptr);
       $$ = $1;
     }
   ;

--- a/arangod/Aql/grammar.y
+++ b/arangod/Aql/grammar.y
@@ -67,7 +67,7 @@ void validateOptions(Parser* parser, AstNode const* node,
     parser->registerParseError(TRI_ERROR_QUERY_PARSE, "'OPTIONS' have to be an object", line, column);
   }
   if (!node->isConstant()) {
-    parser->registerParseError(TRI_ERROR_QUERY_COMPILE_TIME_OPTIONS, "'OPTIONS' have to be readable at query compile time", line, column);
+    parser->registerParseError(TRI_ERROR_QUERY_COMPILE_TIME_OPTIONS, "'OPTIONS' have to be known at query compile time", line, column);
   }
 }
 


### PR DESCRIPTION
### Scope & Purpose

Ensure that the argument to an AQL OPTIONS clause is always an object which does not contain any dynamic (run-time) values. 
Previously, this was only enforced for traversal options and options for data-modification queries. This change extends the check to all occurrences of OPTIONS.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] Backports required for: 3.7

### Testing & Verification

- [x] This change is already covered by existing tests, such as *shell_server_aql*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11800/