### PR TITLE
Add truncate context for audit logging

### DIFF
--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -1696,8 +1696,10 @@ Future<OperationResult> transaction::Methods::truncateAsync(std::string const& c
   OperationOptions optionsCopy = options;
   auto cb = [this, collectionName,
              handler = rest::RestHandler::CURRENT_HANDLER](OperationResult res) {
+    auto old = rest::RestHandler::CURRENT_HANDLER;
     rest::RestHandler::CURRENT_HANDLER = handler;
     events::TruncateCollection(vocbase().name(), collectionName, res.errorNumber());
+    rest::RestHandler::CURRENT_HANDLER = old;
     return res;
   };
 

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -51,6 +51,7 @@
 #include "ClusterEngine/ClusterEngine.h"
 #include "Containers/SmallVector.h"
 #include "Futures/Utilities.h"
+#include "GeneralServer/RestHandler.h"
 #include "Indexes/Index.h"
 #include "Logger/Logger.h"
 #include "Network/Methods.h"

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -1693,7 +1693,9 @@ Future<OperationResult> transaction::Methods::truncateAsync(std::string const& c
   TRI_ASSERT(_state->status() == transaction::Status::RUNNING);
 
   OperationOptions optionsCopy = options;
-  auto cb = [this, collectionName](OperationResult res) {
+  auto cb = [this, collectionName,
+             handler = rest::RestHandler::CURRENT_HANDLER](OperationResult res) {
+    rest::RestHandler::CURRENT_HANDLER = handler;
     events::TruncateCollection(vocbase().name(), collectionName, res.errorNumber());
     return res;
   };


### PR DESCRIPTION
### Scope & Purpose

Cleanup of leftovers (truncate) from https://github.com/arangodb/arangodb/pull/12598

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.6

Jenkins: https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/11804/