### PR TITLE
Added option `--query.max-runtime`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,19 @@
 devel
 -----
 
+* Added startup option `--query.max-runtime` to limit the maximum runtime of
+  all AQL queries to a specified threshold value (in seconds). By default,
+  the threshold is 0, meaning that the runtime of AQL queries is not limited.
+  Setting it to any positive value will restrict the runtime of all AQL
+  queries unless it is overwritten in the per-query "maxRuntime" query option.
+  Please note that setting this option will affect *all* queries in all
+  databases, and also queries issues for administration and database-internal
+  purposes.
+  If a query exceeds the configured runtime, it will be killed on the next
+  occasion when the query checks its own status. Killing is best effort, 
+  so it is not guaranteed that a query will no longer than exactly the 
+  configured amount of time.
+
 * Ensure that the argument to an AQL OPTIONS clause is always an object
   which does not contain any dynamic (run-time) values. Previously, this
   was only enforced for traversal options and options for data-modification

--- a/arangod/Aql/QueryOptions.cpp
+++ b/arangod/Aql/QueryOptions.cpp
@@ -37,6 +37,7 @@ using namespace arangodb::aql;
 
 size_t QueryOptions::defaultMemoryLimit = 0;
 size_t QueryOptions::defaultMaxNumberOfPlans = 128;
+double QueryOptions::defaultMaxRuntime= 0.0;
 double QueryOptions::defaultTtl;
 bool QueryOptions::defaultFailOnWarning;
 
@@ -44,7 +45,7 @@ QueryOptions::QueryOptions()
     : memoryLimit(0),
       maxNumberOfPlans(QueryOptions::defaultMaxNumberOfPlans),
       maxWarningCount(10),
-      maxRuntime(0),
+      maxRuntime(0.0),
       satelliteSyncWait(60.0),
       ttl(QueryOptions::defaultTtl), // get global default ttl
       profile(ProfileLevel::None),
@@ -58,13 +59,22 @@ QueryOptions::QueryOptions()
       count(false),
       verboseErrors(false),
       inspectSimplePlans(true),
-      explainRegisters(ExplainRegisterPlan::No)
-{
+      explainRegisters(ExplainRegisterPlan::No) {
   // now set some default values from server configuration options
-  // use global memory limit value
-  uint64_t globalLimit = QueryOptions::defaultMemoryLimit;
-  if (globalLimit > 0) {
-    memoryLimit = globalLimit;
+  {
+    // use global memory limit value
+    uint64_t globalLimit = QueryOptions::defaultMemoryLimit;
+    if (globalLimit > 0) {
+      memoryLimit = globalLimit;
+    }
+  }
+
+  {
+    // use global max runtime value
+    double globalLimit = QueryOptions::defaultMaxRuntime;
+    if (globalLimit > 0.0) {
+      maxRuntime = globalLimit;
+    }
   }
   
   // "cache" only defaults to true if query cache is turned on

--- a/arangod/Aql/QueryOptions.h
+++ b/arangod/Aql/QueryOptions.h
@@ -102,6 +102,7 @@ struct QueryOptions {
   
   static size_t defaultMemoryLimit;
   static size_t defaultMaxNumberOfPlans;
+  static double defaultMaxRuntime;
   static double defaultTtl;
   static bool defaultFailOnWarning;
 };

--- a/arangod/RestServer/QueryRegistryFeature.h
+++ b/arangod/RestServer/QueryRegistryFeature.h
@@ -63,6 +63,7 @@ class QueryRegistryFeature final : public application_features::ApplicationFeatu
   bool parallelizeTraversals() const { return _parallelizeTraversals; }
 #endif
   uint64_t queryMemoryLimit() const { return _queryMemoryLimit; }
+  double queryMaxRuntime() const { return _queryMaxRuntime; }
   uint64_t maxQueryPlans() const { return _maxQueryPlans; }
   aql::QueryRegistry* queryRegistry() const { return _queryRegistry.get(); }
   uint64_t maxParallelism() const { return _maxParallelism; }
@@ -77,6 +78,7 @@ class QueryRegistryFeature final : public application_features::ApplicationFeatu
   bool _parallelizeTraversals;
 #endif
   uint64_t _queryMemoryLimit;
+  double _queryMaxRuntime;
   uint64_t _maxQueryPlans;
   uint64_t _queryCacheMaxResultsCount;
   uint64_t _queryCacheMaxResultsSize;

--- a/tests/js/client/server_parameters/test-query-max-runtime.js
+++ b/tests/js/client/server_parameters/test-query-max-runtime.js
@@ -1,0 +1,88 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, fail */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for security-related server options
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'query.max-runtime': "5.0"
+  };
+}
+let jsunity = require('jsunity');
+const errors = require('@arangodb').errors;
+let db = require('internal').db;
+
+function testSuite() {
+  return {
+    testDefaultOk : function() {
+      let res = db._query("FOR i IN 1..3 RETURN SLEEP(0.1)").toArray();
+      assertEqual(3, res.length);
+    },
+
+    testDefaultExceeding : function() {
+      try {
+        // should be killed
+        db._query("FOR i IN 1..10 RETURN SLEEP(1)");
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_QUERY_KILLED.code, err.errorNum);
+      }
+    },
+
+    testOverwrittenOk : function() {
+      let res = db._query("FOR i IN 1..5 RETURN SLEEP(1)", {}, { maxRuntime: 30 }).toArray();
+      assertEqual(5, res.length);
+      
+      res = db._query("FOR i IN 1..10 RETURN SLEEP(1)", {}, { maxRuntime: 30 }).toArray();
+      assertEqual(10, res.length);
+    },
+    
+    testOverwrittenExceeding : function() {
+      try {
+        // should be killed
+        db._query("FOR i IN 1..10 RETURN SLEEP(1)", {}, { maxRuntime: 1 });
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_QUERY_KILLED.code, err.errorNum);
+      }
+      
+      try {
+        // should be killed
+        db._query("FOR i IN 1..5 RETURN SLEEP(0.1)", {}, { maxRuntime: 0.2 });
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_QUERY_KILLED.code, err.errorNum);
+      }
+    },
+
+    
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

* Added startup option `--query.max-runtime` to limit the maximum runtime of
  all AQL queries to a specified threshold value (in seconds). By default,
  the threshold is 0, meaning that the runtime of AQL queries is not limited.
  Setting it to any positive value will restrict the runtime of all AQL
  queries unless it is overwritten in the per-query "maxRuntime" query option.
  Please note that setting this option will affect *all* queries in all
  databases, and also queries issues for administration and database-internal
  purposes.

- [ ] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [x] Backports required for: *3.7, 3.6*

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests**: server_parameters

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11819/