### PR TITLE
Add truncate context for audit logging

### DIFF
--- a/arangod/Agency/Constituent.cpp
+++ b/arangod/Agency/Constituent.cpp
@@ -144,7 +144,7 @@ void Constituent::termNoLock(term_t t, std::string const& votedFor) {
       OperationResult result = (tmp != t)
                                    ? trx.insert("election", body.slice(), options)
                                    : trx.replace("election", body.slice(), options);
-      res = trx.finish(result.errorNumber());
+      res = trx.finish(result.result);
     } catch (std::exception const& e) {
       LOG_TOPIC("334ae", FATAL, Logger::AGENCY)
           << "Failed to " << ((tmp != t) ? "insert" : "replace")

--- a/arangod/Agency/Constituent.cpp
+++ b/arangod/Agency/Constituent.cpp
@@ -140,28 +140,17 @@ void Constituent::termNoLock(term_t t, std::string const& votedFor) {
 
     options.waitForSync = _agent->config().waitForSync();
     options.silent = true;
-
-    OperationResult result;
-
-    if (tmp != t) {
-      try {
-        result = trx.insert("election", body.slice(), options);
-      } catch (std::exception const& e) {
-        LOG_TOPIC("334ae", FATAL, Logger::AGENCY)
-            << "Failed to insert RAFT election ballot: " << e.what() << ". Bailing out.";
-        FATAL_ERROR_EXIT();
-      }
-    } else {
-      try {
-        result = trx.replace("election", body.slice(), options);
-      } catch (std::exception const& e) {
-        LOG_TOPIC("ac75f", FATAL, Logger::AGENCY)
-            << "Failed to replace  RAFT election ballot: " << e.what() << ". Bailing out.";
-        FATAL_ERROR_EXIT();
-      }
+    try {
+      OperationResult result = (tmp != t)
+                                   ? trx.insert("election", body.slice(), options)
+                                   : trx.replace("election", body.slice(), options);
+      res = trx.finish(result.errorNumber());
+    } catch (std::exception const& e) {
+      LOG_TOPIC("334ae", FATAL, Logger::AGENCY)
+          << "Failed to " << ((tmp != t) ? "insert" : "replace")
+          << " RAFT election ballot: " << e.what() << ". Bailing out.";
+      FATAL_ERROR_EXIT();
     }
-
-    res = trx.finish(result.errorNumber());
   }
 }
 

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -206,11 +206,14 @@ bool State::persistConf(index_t index, term_t term, uint64_t millis,
 
   try {
     OperationResult logResult = trx.insert("log", log.slice(), _options);
+    if (logResult.fail()) {
+      THROW_ARANGO_EXCEPTION(logResult.result);
+    }
     OperationResult confResult =
         trx.replace("configuration", configuration.slice(), _options);
     res = trx.finish(confResult.result);
   } catch (std::exception const& e) {
-    LOG_TOPIC("ced35", ERR, Logger::AGENCY) << "Failed to persist log entry:" << e.what();
+    LOG_TOPIC("ced35", ERR, Logger::AGENCY) << "Failed to persist log entry: " << e.what();
     return false;
   }
 

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -125,16 +125,13 @@ bool State::persist(index_t index, term_t term, uint64_t millis,
     THROW_ARANGO_EXCEPTION(res);
   }
 
-  OperationResult result;
-
   try {
-    result = trx.insert("log", body.slice(), _options);
+    OperationResult result = trx.insert("log", body.slice(), _options);
+    res = trx.finish(result.result);
   } catch (std::exception const& e) {
     LOG_TOPIC("ec1ca", ERR, Logger::AGENCY) << "Failed to persist log entry:" << e.what();
     return false;
   }
-
-  res = trx.finish(result.result);
 
   LOG_TOPIC("e0321", TRACE, Logger::AGENCY)
       << "persist done index=" << index << " term=" << term
@@ -207,16 +204,15 @@ bool State::persistConf(index_t index, term_t term, uint64_t millis,
     THROW_ARANGO_EXCEPTION(res);
   }
 
-  OperationResult logResult, confResult;
   try {
-    logResult = trx.insert("log", log.slice(), _options);
-    confResult = trx.replace("configuration", configuration.slice(), _options);
+    OperationResult logResult = trx.insert("log", log.slice(), _options);
+    OperationResult confResult =
+        trx.replace("configuration", configuration.slice(), _options);
+    res = trx.finish(confResult.result);
   } catch (std::exception const& e) {
     LOG_TOPIC("ced35", ERR, Logger::AGENCY) << "Failed to persist log entry:" << e.what();
     return false;
   }
-
-  res = trx.finish(confResult.result);
 
   // Successful persistence affects local configuration ------------------------
   if (res.ok()) {
@@ -1016,7 +1012,6 @@ bool State::loadOrPersistConfiguration() {
     auto ctx = std::make_shared<transaction::StandaloneContext>(*_vocbase);
     SingleCollectionTransaction trx(ctx, "configuration", AccessMode::Type::WRITE);
     Result res = trx.begin();
-    OperationResult result;
 
     if (!res.ok()) {
       THROW_ARANGO_EXCEPTION(res);
@@ -1030,14 +1025,13 @@ bool State::loadOrPersistConfiguration() {
     }
 
     try {
-      result = trx.insert("configuration", doc.slice(), _options);
+      OperationResult result = trx.insert("configuration", doc.slice(), _options);
+      res = trx.finish(result.result);
     } catch (std::exception const& e) {
       LOG_TOPIC("4384a", ERR, Logger::AGENCY)
           << "Failed to persist configuration entry:" << e.what();
       FATAL_ERROR_EXIT();
     }
-
-    res = trx.finish(result.result);
 
     LOG_TOPIC("c5d88", DEBUG, Logger::AGENCY)
         << "Persisted configuration: " << doc.slice().toJson();
@@ -1335,9 +1329,8 @@ bool State::persistCompactionSnapshot(index_t cind, arangodb::consensus::term_t 
       THROW_ARANGO_EXCEPTION(res);
     }
 
-    OperationResult result;
     try {
-      result = trx.insert("compact", store.slice(), _options);
+      OperationResult result = trx.insert("compact", store.slice(), _options);
       if (!result.ok()) {
         if (result.is(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED)) {
           LOG_TOPIC("b1b55", DEBUG, Logger::AGENCY)
@@ -1350,13 +1343,12 @@ bool State::persistCompactionSnapshot(index_t cind, arangodb::consensus::term_t 
           FATAL_ERROR_EXIT();
         }
       }
+      res = trx.finish(result.result);
     } catch (std::exception const& e) {
       LOG_TOPIC("41965", FATAL, Logger::AGENCY)
         << "Failed to persist compacted agency state: " << e.what();
       FATAL_ERROR_EXIT();
     }
-
-    res = trx.finish(result.result);
 
     if (res.ok()) {
       _lastCompactionAt = cind;

--- a/arangod/Aql/Collection.cpp
+++ b/arangod/Aql/Collection.cpp
@@ -97,7 +97,8 @@ TRI_col_type_e Collection::type() const { return getCollection()->type(); }
 
 /// @brief count the number of documents in the collection
 size_t Collection::count(transaction::Methods* trx, transaction::CountType type) const {
-  OperationResult res = trx->count(_name, type); 
+  OperationOptions options;  // TODO get from trx?
+  OperationResult res = trx->count(_name, type, options);
   if (res.fail()) {
     THROW_ARANGO_EXCEPTION(res.result);
   }

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -7074,7 +7074,8 @@ AqlValue Functions::CollectionCount(ExpressionContext*, transaction::Methods* tr
 
   TRI_ASSERT(ServerState::instance()->isSingleServerOrCoordinator());
   std::string const collectionName = element.slice().copyString();
-  OperationResult res = trx->count(collectionName, transaction::CountType::Normal);
+  OperationOptions options(ExecContext::current());
+  OperationResult res = trx->count(collectionName, transaction::CountType::Normal, options);
   if (res.fail()) {
     THROW_ARANGO_EXCEPTION(res.result);
   }

--- a/arangod/Aql/QueryCursor.cpp
+++ b/arangod/Aql/QueryCursor.cpp
@@ -164,7 +164,9 @@ QueryStreamCursor::QueryStreamCursor(std::unique_ptr<arangodb::aql::Query> q,
   // this is a hack for the export API only
   auto const& exportCollection = _query->queryOptions().exportCollection;
   if (!exportCollection.empty()) {
-     OperationResult opRes = trx.count(exportCollection, transaction::CountType::Normal);
+    OperationOptions opOptions(ExecContext::current());
+    OperationResult opRes =
+        trx.count(exportCollection, transaction::CountType::Normal, opOptions);
     if (opRes.fail()) {
       THROW_ARANGO_EXCEPTION(opRes.result);
     }

--- a/arangod/Aql/SimpleModifier.h
+++ b/arangod/Aql/SimpleModifier.h
@@ -104,6 +104,7 @@ class SimpleModifier {
   explicit SimpleModifier(ModificationExecutorInfos& infos)
       : _infos(infos),
         _completion(infos),
+        _results(Result(), infos._options),
         _resultsIterator(VPackArrayIterator::Empty{}),
         _batchSize(ExecutionBlock::DefaultBatchSize) {}
   ~SimpleModifier() = default;

--- a/arangod/Aql/SingleRemoteModificationExecutor.cpp
+++ b/arangod/Aql/SingleRemoteModificationExecutor.cpp
@@ -107,8 +107,6 @@ template <typename Modifier>
 template <typename Modifier>
 auto SingleRemoteModificationExecutor<Modifier>::doSingleRemoteModificationOperation(
     InputAqlItemRow& input, Stats& stats) -> OperationResult {
-  OperationOptions& options = _info._options;
-
   _info._options.silent = false;
   _info._options.returnOld = _info._options.returnOld ||
                              _info._outputRegisterId != RegisterPlan::MaxRegisterId;
@@ -145,7 +143,7 @@ auto SingleRemoteModificationExecutor<Modifier>::doSingleRemoteModificationOpera
   if (isIndex) {
     result = _trx.document(_info._aqlCollection->name(), inSlice, _info._options);
   } else if (isInsert) {
-    if (options.returnOld && !options.isOverwriteModeUpdateReplace()) {
+    if (_info.options.returnOld && !_info.options.isOverwriteModeUpdateReplace()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_QUERY_VARIABLE_NAME_UNKNOWN,
           "OLD is only available when using INSERT with overwriteModes 'update' or 'replace'");

--- a/arangod/Aql/SingleRemoteModificationExecutor.cpp
+++ b/arangod/Aql/SingleRemoteModificationExecutor.cpp
@@ -107,12 +107,13 @@ template <typename Modifier>
 template <typename Modifier>
 auto SingleRemoteModificationExecutor<Modifier>::doSingleRemoteModificationOperation(
     InputAqlItemRow& input, Stats& stats) -> OperationResult {
-  OperationResult result;
   OperationOptions& options = _info._options;
 
   _info._options.silent = false;
   _info._options.returnOld = _info._options.returnOld ||
                              _info._outputRegisterId != RegisterPlan::MaxRegisterId;
+
+  OperationResult result(Result(), _info._options);
 
   const bool isIndex = std::is_same<Modifier, IndexTag>::value;
   const bool isInsert = std::is_same<Modifier, Insert>::value;

--- a/arangod/Aql/SingleRemoteModificationExecutor.cpp
+++ b/arangod/Aql/SingleRemoteModificationExecutor.cpp
@@ -143,7 +143,7 @@ auto SingleRemoteModificationExecutor<Modifier>::doSingleRemoteModificationOpera
   if (isIndex) {
     result = _trx.document(_info._aqlCollection->name(), inSlice, _info._options);
   } else if (isInsert) {
-    if (_info.options.returnOld && !_info.options.isOverwriteModeUpdateReplace()) {
+    if (_info._options.returnOld && !_info._options.isOverwriteModeUpdateReplace()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_QUERY_VARIABLE_NAME_UNKNOWN,
           "OLD is only available when using INSERT with overwriteModes 'update' or 'replace'");

--- a/arangod/Aql/UpsertModifier.h
+++ b/arangod/Aql/UpsertModifier.h
@@ -75,6 +75,8 @@ class UpsertModifier {
  public:
   explicit UpsertModifier(ModificationExecutorInfos& infos)
       : _infos(infos),
+        _updateResults(Result(), infos._options),
+        _insertResults(Result(), infos._options),
 
         // Batch size has to be 1 so that the upsert modifier sees its own
         // writes.

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -196,11 +196,11 @@ void addTransactionHeaderForShard(transaction::Methods const& trx, ShardMap cons
 /// handler callback, reduce-style. Finally, it will be passed to the post
 /// callback and then returned via the OperationResult.
 OperationResult handleResponsesFromAllShards(
+    OperationOptions const& options,
     std::vector<futures::Try<arangodb::network::Response>>& responses,
     std::function<void(Result&, VPackBuilder&, ShardID&, VPackSlice)> handler,
     std::function<void(Result&, VPackBuilder&)> pre = [](Result&, VPackBuilder&) -> void {},
-    std::function<void(Result&, VPackBuilder&)> post = [](Result&, VPackBuilder&) -> void {},
-    OperationOptions const options = OperationOptions()) {
+    std::function<void(Result&, VPackBuilder&)> post = [](Result&, VPackBuilder&) -> void {}) {
   // If none of the shards responds we return a SERVER_ERROR;
   Result result;
   VPackBuilder builder;
@@ -398,10 +398,10 @@ OperationResult handleCRUDShardResponsesSlow(F&& func, size_t expectedLen, Opera
     }
 
     if (nrok == 0) {  // This can only happen, if a commError was encountered!
-      return OperationResult(commError);
+      return OperationResult(commError, options);
     }
     if (nrok > 1) {
-      return OperationResult(TRI_ERROR_CLUSTER_GOT_CONTRADICTING_ANSWERS);
+      return OperationResult(TRI_ERROR_CLUSTER_GOT_CONTRADICTING_ANSWERS, options);
     }
 
     return std::forward<F>(func)(code, std::move(buffer), std::move(options), {});
@@ -416,7 +416,7 @@ OperationResult handleCRUDShardResponsesSlow(F&& func, size_t expectedLen, Opera
   for (Try<network::Response> const& tryRes : responses) {
     network::Response const& res = tryRes.get();
     if (res.error != fuerte::Error::NoError) {
-      return OperationResult(network::fuerteToArangoErrorCode(res));
+      return OperationResult(network::fuerteToArangoErrorCode(res), options);
     }
 
     allResults.push_back(res.response->slice());
@@ -932,7 +932,8 @@ void aggregateClusterFigures(bool details, bool isSmartEdgeCollectionPart,
 
 futures::Future<OperationResult> revisionOnCoordinator(ClusterFeature& feature,
                                                        std::string const& dbname,
-                                                       std::string const& collname) {
+                                                       std::string const& collname,
+                                                       OperationOptions const& options) {
   // Set a few variables needed for our work:
   ClusterInfo& ci = feature.clusterInfo();
 
@@ -940,7 +941,7 @@ futures::Future<OperationResult> revisionOnCoordinator(ClusterFeature& feature,
   std::shared_ptr<LogicalCollection> collinfo;
   collinfo = ci.getCollectionNT(dbname, collname);
   if (collinfo == nullptr) {
-    return futures::makeFuture(OperationResult(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND));
+    return futures::makeFuture(OperationResult(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, options));
   }
 
   network::RequestOptions reqOpts;
@@ -962,9 +963,10 @@ futures::Future<OperationResult> revisionOnCoordinator(ClusterFeature& feature,
     futures.emplace_back(std::move(future));
   }
 
-  auto cb = [](std::vector<Try<network::Response>>&& results) -> OperationResult {
+  auto cb = [options](std::vector<Try<network::Response>>&& results) -> OperationResult {
     return handleResponsesFromAllShards(
-        results, [](Result& result, VPackBuilder& builder, ShardID&, VPackSlice answer) -> void {
+        options, results,
+        [](Result& result, VPackBuilder& builder, ShardID&, VPackSlice answer) -> void {
           if (answer.isObject()) {
             VPackSlice r = answer.get("revision");
             if (r.isString()) {
@@ -989,7 +991,8 @@ futures::Future<OperationResult> revisionOnCoordinator(ClusterFeature& feature,
 
 futures::Future<Result> warmupOnCoordinator(ClusterFeature& feature,
                                             std::string const& dbname,
-                                            std::string const& cid) {
+                                            std::string const& cid,
+                                            OperationOptions const& options) {
   // Set a few variables needed for our work:
   ClusterInfo& ci = feature.clusterInfo();
 
@@ -1025,8 +1028,8 @@ futures::Future<Result> warmupOnCoordinator(ClusterFeature& feature,
     futures.emplace_back(std::move(future));
   }
 
-  auto cb = [](std::vector<Try<network::Response>>&& results) -> OperationResult {
-    return handleResponsesFromAllShards(results,
+  auto cb = [options](std::vector<Try<network::Response>>&& results) -> OperationResult {
+    return handleResponsesFromAllShards(options, results,
                                         [](Result&, VPackBuilder&, ShardID&, VPackSlice) -> void {
                                           // we don't care about response bodies, just that the requests succeeded
                                         });
@@ -1042,8 +1045,8 @@ futures::Future<Result> warmupOnCoordinator(ClusterFeature& feature,
 
 futures::Future<OperationResult> figuresOnCoordinator(ClusterFeature& feature,
                                                       std::string const& dbname,
-                                                      std::string const& collname, 
-                                                      bool details) {
+                                                      std::string const& collname, bool details,
+                                                      OperationOptions const& options) {
   // Set a few variables needed for our work:
   ClusterInfo& ci = feature.clusterInfo();
 
@@ -1051,7 +1054,7 @@ futures::Future<OperationResult> figuresOnCoordinator(ClusterFeature& feature,
   std::shared_ptr<LogicalCollection> collinfo;
   collinfo = ci.getCollectionNT(dbname, collname);
   if (collinfo == nullptr) {
-    return futures::makeFuture(OperationResult(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND));
+    return futures::makeFuture(OperationResult(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, options));
   }
 
   network::RequestOptions reqOpts;
@@ -1075,7 +1078,7 @@ futures::Future<OperationResult> figuresOnCoordinator(ClusterFeature& feature,
     futures.emplace_back(std::move(future));
   }
 
-  auto cb = [details](std::vector<Try<network::Response>>&& results) mutable -> OperationResult {
+  auto cb = [details, options](std::vector<Try<network::Response>>&& results) mutable -> OperationResult {
     auto handler = [details](Result& result, VPackBuilder& builder, ShardID&,
                              VPackSlice answer) mutable -> void {
       if (answer.isObject()) {
@@ -1093,7 +1096,7 @@ futures::Future<OperationResult> figuresOnCoordinator(ClusterFeature& feature,
       // initialize to empty object
       builder.add(VPackSlice::emptyObjectSlice());
     };
-    return handleResponsesFromAllShards(results, handler, pre);
+    return handleResponsesFromAllShards(options, results, handler, pre);
   };
   return futures::collectAll(std::move(futures)).thenValue(std::move(cb));
 }
@@ -1103,7 +1106,8 @@ futures::Future<OperationResult> figuresOnCoordinator(ClusterFeature& feature,
 ////////////////////////////////////////////////////////////////////////////////
 
 futures::Future<OperationResult> countOnCoordinator(transaction::Methods& trx,
-                                                    std::string const& cname) {
+                                                    std::string const& cname,
+                                                    OperationOptions const& options) {
   std::vector<std::pair<std::string, uint64_t>> result;
 
   // Set a few variables needed for our work:
@@ -1115,7 +1119,7 @@ futures::Future<OperationResult> countOnCoordinator(transaction::Methods& trx,
   std::shared_ptr<LogicalCollection> collinfo;
   collinfo = ci.getCollectionNT(dbname, cname);
   if (collinfo == nullptr) {
-    return futures::makeFuture(OperationResult(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND));
+    return futures::makeFuture(OperationResult(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, options));
   }
 
   std::shared_ptr<ShardMap> shardIds = collinfo->shardIds();
@@ -1123,7 +1127,7 @@ futures::Future<OperationResult> countOnCoordinator(transaction::Methods& trx,
   if (isManaged) {
     Result res = ::beginTransactionOnAllLeaders(trx, *shardIds).get();
     if (res.fail()) {
-      return futures::makeFuture(OperationResult(res));
+      return futures::makeFuture(OperationResult(res, options));
     }
   }
 
@@ -1144,7 +1148,7 @@ futures::Future<OperationResult> countOnCoordinator(transaction::Methods& trx,
                                                    VPackBuffer<uint8_t>(), reqOpts, std::move(headers)));
   }
 
-  auto cb = [](std::vector<Try<network::Response>>&& results) mutable -> OperationResult {
+  auto cb = [options](std::vector<Try<network::Response>>&& results) mutable -> OperationResult {
     auto handler = [](Result& result, VPackBuilder& builder, ShardID& shardId,
                       VPackSlice answer) mutable -> void {
       if (answer.isObject()) {
@@ -1169,7 +1173,7 @@ futures::Future<OperationResult> countOnCoordinator(transaction::Methods& trx,
         builder.clear();
       }
     };
-    return handleResponsesFromAllShards(results, handler, pre, post);
+    return handleResponsesFromAllShards(options, results, handler, pre, post);
   };
   return futures::collectAll(std::move(futures)).thenValue(std::move(cb));
 }
@@ -1309,13 +1313,13 @@ Future<OperationResult> createDocumentOnCoordinator(transaction::Methods const& 
     for (VPackSlice value : VPackArrayIterator(slice)) {
       int res = distributeBabyOnShards(opCtx, coll, value, options.isRestore);
       if (res != TRI_ERROR_NO_ERROR) {
-        return makeFuture(OperationResult(res));
+        return makeFuture(OperationResult(res, options));
       }
     }
   } else {
     int res = distributeBabyOnShards(opCtx, coll, slice, options.isRestore);
     if (res != TRI_ERROR_NO_ERROR) {
-      return makeFuture(OperationResult(res));
+      return makeFuture(OperationResult(res, options));
     }
   }
 
@@ -1328,7 +1332,7 @@ Future<OperationResult> createDocumentOnCoordinator(transaction::Methods const& 
   return std::move(f).thenValue([=, &trx, &coll, opCtx(std::move(opCtx))]
                                 (Result&& r) mutable -> Future<OperationResult> {
     if (r.fail()) {
-      return OperationResult(std::move(r));
+      return OperationResult(std::move(r), options);
     }
 
     std::string const baseUrl = "/_api/document/";
@@ -1399,7 +1403,7 @@ Future<OperationResult> createDocumentOnCoordinator(transaction::Methods const& 
 
       auto cb = [options](network::Response&& res) -> OperationResult {
         if (res.error != fuerte::Error::NoError) {
-          return OperationResult(network::fuerteToArangoErrorCode(res));
+          return OperationResult(network::fuerteToArangoErrorCode(res), options);
         }
 
         return network::clusterResultInsert(res.response->statusCode(),
@@ -1471,7 +1475,7 @@ Future<OperationResult> removeDocumentOnCoordinator(arangodb::transaction::Metho
     return std::move(f).thenValue([=, &trx, opCtx(std::move(opCtx))]
                                   (Result&& r) mutable -> Future<OperationResult> {
       if (r.fail()) {
-        return OperationResult(std::move(r));
+        return OperationResult(std::move(r), options);
       }
 
       // Now prepare the requests:
@@ -1506,7 +1510,7 @@ Future<OperationResult> removeDocumentOnCoordinator(arangodb::transaction::Metho
         TRI_ASSERT(futures.size() == 1);
         auto cb = [options](network::Response&& res) -> OperationResult {
           if (res.error != fuerte::Error::NoError) {
-            return OperationResult(network::fuerteToArangoErrorCode(res));
+            return OperationResult(network::fuerteToArangoErrorCode(res), options);
           }
           return network::clusterResultDelete(res.response->statusCode(),
                                               res.response->stealPayload(), options, {});
@@ -1533,7 +1537,7 @@ Future<OperationResult> removeDocumentOnCoordinator(arangodb::transaction::Metho
 
   return std::move(f).thenValue([=, &trx](Result&& r) mutable -> Future<OperationResult> {
     if (r.fail()) {
-      return OperationResult(r);
+      return OperationResult(r, options);
     }
 
     // We simply send the body to all shards and await their results.
@@ -1628,14 +1632,12 @@ futures::Future<OperationResult> truncateCollectionOnCoordinator(
 
   auto cb = [options](std::vector<Try<network::Response>>&& results) -> OperationResult {
     return handleResponsesFromAllShards(
-        results,
+        options, results,
         [](Result& result, VPackBuilder&, ShardID&, VPackSlice answer) -> void {
           if (Helper::getBooleanValue(answer, StaticStrings::Error, false)) {
             result = network::resultFromBody(answer, TRI_ERROR_NO_ERROR);
           }
-        },
-        /* pre */ [](Result&, VPackBuilder&) -> void {},
-        /* post */ [](Result&, VPackBuilder&) -> void {}, options);
+        });
   };
   return futures::collectAll(std::move(futures)).thenValue(std::move(cb));
 }
@@ -1711,7 +1713,7 @@ Future<OperationResult> getDocumentOnCoordinator(transaction::Methods& trx,
     return std::move(f).thenValue([=, &trx, opCtx(std::move(opCtx))]
                                   (Result&& r) mutable -> Future<OperationResult> {
       if (r.fail()) {
-        return OperationResult(std::move(r));
+        return OperationResult(std::move(r), options);
       }
 
       // Now prepare the requests:
@@ -1761,7 +1763,7 @@ Future<OperationResult> getDocumentOnCoordinator(transaction::Methods& trx,
         TRI_ASSERT(futures.size() == 1);
         return std::move(futures[0]).thenValue([options](network::Response res) -> OperationResult {
           if (res.error != fuerte::Error::NoError) {
-            return OperationResult(network::fuerteToArangoErrorCode(res));
+            return OperationResult(network::fuerteToArangoErrorCode(res), options);
           }
           return network::clusterResultDocument(res.response->statusCode(),
                                                 res.response->stealPayload(), options, {});
@@ -1782,7 +1784,7 @@ Future<OperationResult> getDocumentOnCoordinator(transaction::Methods& trx,
   if (isManaged) {  // lazily begin the transaction
     Result res = ::beginTransactionOnAllLeaders(trx, *shardIds).get();
     if (res.fail()) {
-      return makeFuture(OperationResult(res));
+      return makeFuture(OperationResult(res, options));
     }
   }
 
@@ -2170,7 +2172,7 @@ Future<OperationResult> modifyDocumentOnCoordinator(
       int res = distributeBabyOnShards(opCtx, coll, value);
       if (res != TRI_ERROR_NO_ERROR) {
         if (!isPatch) { // shard keys cannot be changed, error out early
-          return makeFuture(OperationResult(res));
+          return makeFuture(OperationResult(res, options));
         }
         canUseFastPath = false;
         break;
@@ -2180,7 +2182,7 @@ Future<OperationResult> modifyDocumentOnCoordinator(
     int res = distributeBabyOnShards(opCtx, coll, slice);
     if (res != TRI_ERROR_NO_ERROR) {
       if (!isPatch) { // shard keys cannot be changed, error out early
-        return makeFuture(OperationResult(res));
+        return makeFuture(OperationResult(res, options));
       }
       canUseFastPath = false;
     }
@@ -2227,7 +2229,7 @@ Future<OperationResult> modifyDocumentOnCoordinator(
 
     return std::move(f).thenValue([=, &trx, opCtx(std::move(opCtx))](Result&& r) mutable -> Future<OperationResult> {
       if (r.fail()) { // bail out
-        return OperationResult(r);
+        return OperationResult(r, opCtx.options);
       }
 
       // Now prepare the requests:
@@ -2274,7 +2276,7 @@ Future<OperationResult> modifyDocumentOnCoordinator(
         TRI_ASSERT(futures.size() == 1);
         auto cb = [options](network::Response&& res) -> OperationResult {
           if (res.error != fuerte::Error::NoError) {
-            return OperationResult(network::fuerteToArangoErrorCode(res));
+            return OperationResult(network::fuerteToArangoErrorCode(res), options);
           }
           return network::clusterResultModify(res.response->statusCode(),
                                               res.response->stealPayload(), options, {});

--- a/arangod/Cluster/ClusterMethods.h
+++ b/arangod/Cluster/ClusterMethods.h
@@ -95,15 +95,16 @@ void aggregateClusterFigures(bool details,
 
 futures::Future<OperationResult> revisionOnCoordinator(ClusterFeature&,
                                                        std::string const& dbname,
-                                                       std::string const& collname);
+                                                       std::string const& collname,
+                                                       OperationOptions const& options);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief Warmup index caches on Shards
 ////////////////////////////////////////////////////////////////////////////////
 
-futures::Future<Result> warmupOnCoordinator(ClusterFeature&,
-                                            std::string const& dbname,
-                                            std::string const& cid);
+futures::Future<Result> warmupOnCoordinator(ClusterFeature&, std::string const& dbname,
+                                            std::string const& cid,
+                                            OperationOptions const& options);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief returns figures for a sharded collection
@@ -111,15 +112,16 @@ futures::Future<Result> warmupOnCoordinator(ClusterFeature&,
 
 futures::Future<OperationResult> figuresOnCoordinator(ClusterFeature&,
                                                       std::string const& dbname,
-                                                      std::string const& collname,
-                                                      bool details);
+                                                      std::string const& collname, bool details,
+                                                      OperationOptions const& options);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief counts number of documents in a coordinator, by shard
 ////////////////////////////////////////////////////////////////////////////////
 
 futures::Future<OperationResult> countOnCoordinator(transaction::Methods& trx,
-                                                    std::string const& collname);
+                                                    std::string const& collname,
+                                                    OperationOptions const& options);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief gets the selectivity estimates from DBservers

--- a/arangod/Cluster/ClusterMethods.h
+++ b/arangod/Cluster/ClusterMethods.h
@@ -224,8 +224,8 @@ futures::Future<OperationResult> modifyDocumentOnCoordinator(
 /// @brief truncate a cluster collection on a coordinator
 ////////////////////////////////////////////////////////////////////////////////
 
-futures::Future<OperationResult> truncateCollectionOnCoordinator(transaction::Methods& trx,
-                                                                 std::string const& collname);
+futures::Future<OperationResult> truncateCollectionOnCoordinator(
+    transaction::Methods& trx, std::string const& collname, OperationOptions const& options);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief flush Wal on all DBservers

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -186,8 +186,9 @@ static arangodb::Result collectionCount(std::shared_ptr<arangodb::LogicalCollect
     return res;
   }
 
+  OperationOptions options(ExecContext::current());
   OperationResult opResult =
-    trx.count(collectionName, arangodb::transaction::CountType::Normal);
+      trx.count(collectionName, arangodb::transaction::CountType::Normal, options);
   res = trx.finish(opResult.result);
 
   if (res.fail()) {

--- a/arangod/ClusterEngine/ClusterCollection.cpp
+++ b/arangod/ClusterEngine/ClusterCollection.cpp
@@ -161,10 +161,12 @@ void ClusterCollection::getPropertiesVPack(velocypack::Builder& result) const {
 }
 
 /// @brief return the figures for a collection
-futures::Future<OperationResult> ClusterCollection::figures(bool details) {
+futures::Future<OperationResult> ClusterCollection::figures(bool details,
+                                                            OperationOptions const& options) {
   auto& feature = _logicalCollection.vocbase().server().getFeature<ClusterFeature>();
   return figuresOnCoordinator(feature, _logicalCollection.vocbase().name(),
-                              std::to_string(_logicalCollection.id().id()), details);
+                              std::to_string(_logicalCollection.id().id()),
+                              details, options);
 }
 
 void ClusterCollection::figuresSpecific(bool /*details*/, arangodb::velocypack::Builder& /*builder*/) {

--- a/arangod/ClusterEngine/ClusterCollection.h
+++ b/arangod/ClusterEngine/ClusterCollection.h
@@ -78,7 +78,7 @@ class ClusterCollection final : public PhysicalCollection {
   void getPropertiesVPack(velocypack::Builder&) const override;
 
   /// @brief return the figures for a collection
-  futures::Future<OperationResult> figures(bool details) override;
+  futures::Future<OperationResult> figures(bool details, OperationOptions const& options) override;
 
   /// @brief closes an open collection
   int close() override;

--- a/arangod/Graph/GraphManager.cpp
+++ b/arangod/Graph/GraphManager.cpp
@@ -79,18 +79,18 @@ std::shared_ptr<transaction::Context> GraphManager::ctx() const {
   return transaction::V8Context::CreateWhenRequired(_vocbase, true);
 }
 
-OperationResult GraphManager::createEdgeCollection(std::string const& name,
-                                                   bool waitForSync, VPackSlice options) {
+Result GraphManager::createEdgeCollection(std::string const& name,
+                                          bool waitForSync, VPackSlice options) {
   return createCollection(name, TRI_COL_TYPE_EDGE, waitForSync, options);
 }
 
-OperationResult GraphManager::createVertexCollection(std::string const& name, bool waitForSync,
-                                                     VPackSlice options) {
+Result GraphManager::createVertexCollection(std::string const& name,
+                                            bool waitForSync, VPackSlice options) {
   return createCollection(name, TRI_COL_TYPE_DOCUMENT, waitForSync, options);
 }
 
-OperationResult GraphManager::createCollection(std::string const& name, TRI_col_type_e colType,
-                                               bool waitForSync, VPackSlice options) {
+Result GraphManager::createCollection(std::string const& name, TRI_col_type_e colType,
+                                      bool waitForSync, VPackSlice options) {
   TRI_ASSERT(colType == TRI_COL_TYPE_DOCUMENT || colType == TRI_COL_TYPE_EDGE);
 
   auto& vocbase = ctx()->vocbase();
@@ -102,7 +102,7 @@ OperationResult GraphManager::createCollection(std::string const& name, TRI_col_
     Result res =
         ShardingInfo::validateShardsAndReplicationFactor(options, vocbase.server(), true);
     if (res.fail()) {
-      return OperationResult(res);
+      return res;
     }
 
     bool const forceOneShard =
@@ -130,12 +130,11 @@ OperationResult GraphManager::createCollection(std::string const& name, TRI_col_
       mergedBuilder.slice(),                          // collection properties
       waitForSync, true, false, coll);
 
-  return OperationResult(res);
+  return res;
 }
 
-OperationResult GraphManager::findOrCreateVertexCollectionByName(const std::string& name,
-                                                                 bool waitForSync,
-                                                                 VPackSlice options) {
+Result GraphManager::findOrCreateVertexCollectionByName(const std::string& name, bool waitForSync,
+                                                        VPackSlice options) {
   std::shared_ptr<LogicalCollection> def;
 
   def = getCollectionByName(ctx()->vocbase(), name);
@@ -143,7 +142,7 @@ OperationResult GraphManager::findOrCreateVertexCollectionByName(const std::stri
     return createVertexCollection(name, waitForSync, options);
   }
 
-  return OperationResult(TRI_ERROR_NO_ERROR);
+  return Result(TRI_ERROR_NO_ERROR);
 }
 
 bool GraphManager::renameGraphCollection(std::string const& oldName,
@@ -171,8 +170,7 @@ bool GraphManager::renameGraphCollection(std::string const& oldName,
   if (!res.ok()) {
     return false;
   }
-  OperationOptions options;
-  OperationResult checkDoc;
+  OperationOptions options(ExecContext::current());
 
   for (auto const& graph : renamedGraphs) {
     VPackBuilder builder;
@@ -193,7 +191,7 @@ bool GraphManager::renameGraphCollection(std::string const& oldName,
     }
   }
 
-  res = trx.finish(checkDoc.result);
+  res = trx.finish(Result());  // if we get here, it was a success
   if (res.fail()) {
     return false;
   }
@@ -226,32 +224,32 @@ Result GraphManager::checkForEdgeDefinitionConflicts(std::map<std::string, EdgeD
   return applyOnAllGraphs(callback);
 }
 
-OperationResult GraphManager::findOrCreateCollectionsByEdgeDefinitions(
+Result GraphManager::findOrCreateCollectionsByEdgeDefinitions(
     Graph const& graph, std::map<std::string, EdgeDefinition> const& edgeDefinitions,
     bool waitForSync, VPackSlice options) {
   for (auto const& it : edgeDefinitions) {
     EdgeDefinition const& edgeDefinition = it.second;
-    OperationResult res =
-        findOrCreateCollectionsByEdgeDefinition(graph, edgeDefinition,
-                                                waitForSync, options);
+    Result res = findOrCreateCollectionsByEdgeDefinition(graph, edgeDefinition,
+                                                         waitForSync, options);
 
     if (res.fail()) {
       return res;
     }
   }
 
-  return OperationResult{TRI_ERROR_NO_ERROR};
+  return Result{TRI_ERROR_NO_ERROR};
 }
 
-OperationResult GraphManager::findOrCreateCollectionsByEdgeDefinition(
-    Graph const& graph, EdgeDefinition const& edgeDefinition, bool waitForSync,
-    VPackSlice const options) {
+Result GraphManager::findOrCreateCollectionsByEdgeDefinition(Graph const& graph,
+                                                             EdgeDefinition const& edgeDefinition,
+                                                             bool waitForSync,
+                                                             VPackSlice const options) {
   std::string const& edgeCollection = edgeDefinition.getName();
   std::shared_ptr<LogicalCollection> def =
       getCollectionByName(ctx()->vocbase(), edgeCollection);
 
   if (def == nullptr) {
-    OperationResult res = createEdgeCollection(edgeCollection, waitForSync, options);
+    Result res = createEdgeCollection(edgeCollection, waitForSync, options);
     if (res.fail()) {
       return res;
     }
@@ -269,19 +267,19 @@ OperationResult GraphManager::findOrCreateCollectionsByEdgeDefinition(
   for (auto const& colName : vertexCollections) {
     def = getCollectionByName(ctx()->vocbase(), colName);
     if (def == nullptr) {
-      OperationResult res = createVertexCollection(colName, waitForSync, options);
+      Result res = createVertexCollection(colName, waitForSync, options);
       if (res.fail()) {
         return res;
       }
     } else {
       auto res = graph.validateCollection(*def.get());
       if (res.fail()) {
-        return OperationResult{std::move(res)};
+        return res;
       }
     }
   }
 
-  return OperationResult{TRI_ERROR_NO_ERROR};
+  return Result{TRI_ERROR_NO_ERROR};
 }
 
 /// @brief extract the collection by either id or name, may return nullptr!
@@ -379,19 +377,20 @@ ResultT<std::unique_ptr<Graph>> GraphManager::lookupGraphByName(std::string cons
 }
 
 OperationResult GraphManager::createGraph(VPackSlice document, bool waitForSync) const {
+  OperationOptions options(ExecContext::current());
   VPackSlice graphNameSlice = document.get("name");
   if (!graphNameSlice.isString()) {
-    return OperationResult{TRI_ERROR_GRAPH_CREATE_MISSING_NAME};
+    return OperationResult{TRI_ERROR_GRAPH_CREATE_MISSING_NAME, options};
   }
   std::string const graphName = graphNameSlice.copyString();
 
   if (graphExists(graphName)) {
-    return OperationResult{TRI_ERROR_GRAPH_DUPLICATE};
+    return OperationResult{TRI_ERROR_GRAPH_DUPLICATE, options};
   }
 
   auto graphRes = buildGraphFromInput(graphName, document);
   if (graphRes.fail()) {
-    return OperationResult{std::move(graphRes).result()};
+    return OperationResult{std::move(graphRes).result(), options};
   }
   // Guaranteed to not be nullptr
   std::unique_ptr<Graph> graph = std::move(graphRes.get());
@@ -400,19 +399,19 @@ OperationResult GraphManager::createGraph(VPackSlice document, bool waitForSync)
   // check permissions
   Result res = checkCreateGraphPermissions(graph.get());
   if (res.fail()) {
-    return OperationResult{res};
+    return OperationResult{res, options};
   }
 
   // check edgeDefinitionConflicts
   res = checkForEdgeDefinitionConflicts(graph->edgeDefinitions(), graph->name());
   if (res.fail()) {
-    return OperationResult{res};
+    return OperationResult{res, options};
   }
 
   // Make sure all collections exist and are created
   res = ensureCollections(graph.get(), waitForSync);
   if (res.fail()) {
-    return OperationResult{res};
+    return OperationResult{res, options};
   }
 
   // finally save the graph
@@ -433,25 +432,23 @@ OperationResult GraphManager::storeGraph(Graph const& graph, bool waitForSync,
                                   AccessMode::Type::WRITE);
   trx.addHint(transaction::Hints::Hint::SINGLE_OPERATION);
 
-  OperationOptions options;
+  OperationOptions options(ExecContext::current());
   options.waitForSync = waitForSync;
   Result res = trx.begin();
   if (res.fail()) {
-    return OperationResult{std::move(res)};
+    return OperationResult{std::move(res), options};
   }
-  OperationResult result;
-  if (isUpdate) {
-    result = trx.update(StaticStrings::GraphCollection, builder.slice(), options);
-  } else {
-    result = trx.insert(StaticStrings::GraphCollection, builder.slice(), options);
-  }
+  OperationResult result =
+      isUpdate ? trx.update(StaticStrings::GraphCollection, builder.slice(), options)
+               : trx.insert(StaticStrings::GraphCollection, builder.slice(), options);
+
   if (!result.ok()) {
     trx.finish(result.result);
     return result;
   }
   res = trx.finish(result.result);
   if (res.fail()) {
-    return OperationResult{std::move(res)};
+    return OperationResult{std::move(res), options};
   }
   return result;
 }
@@ -635,19 +632,19 @@ bool GraphManager::onlySatellitesUsed(Graph const* graph) const {
   return true;
 }
 
-OperationResult GraphManager::readGraphs(velocypack::Builder& builder) const {
+Result GraphManager::readGraphs(velocypack::Builder& builder) const {
   std::string const queryStr{
       "FOR g IN _graphs RETURN MERGE(g, {name: g._key})"};
   return readGraphByQuery(builder, queryStr);
 }
 
-OperationResult GraphManager::readGraphKeys(velocypack::Builder& builder) const {
+Result GraphManager::readGraphKeys(velocypack::Builder& builder) const {
   std::string const queryStr{"FOR g IN _graphs RETURN g._key"};
   return readGraphByQuery(builder, queryStr);
 }
 
-OperationResult GraphManager::readGraphByQuery(velocypack::Builder& builder,
-                                               std::string const& queryStr) const {
+Result GraphManager::readGraphByQuery(velocypack::Builder& builder,
+                                      std::string const& queryStr) const {
   arangodb::aql::Query query(ctx(), arangodb::aql::QueryString(queryStr),
                              nullptr, nullptr);
 
@@ -658,15 +655,15 @@ OperationResult GraphManager::readGraphByQuery(velocypack::Builder& builder,
   if (queryResult.result.fail()) {
     if (queryResult.result.is(TRI_ERROR_REQUEST_CANCELED) ||
         (queryResult.result.is(TRI_ERROR_QUERY_KILLED))) {
-      return OperationResult(TRI_ERROR_REQUEST_CANCELED);
+      return Result(TRI_ERROR_REQUEST_CANCELED);
     }
-    return OperationResult(std::move(queryResult.result));
+    return std::move(queryResult.result);
   }
 
   VPackSlice graphsSlice = queryResult.data->slice();
 
   if (graphsSlice.isNone()) {
-    return OperationResult(TRI_ERROR_OUT_OF_MEMORY);
+    return Result(TRI_ERROR_OUT_OF_MEMORY);
   } 
   if (!graphsSlice.isArray()) {
     LOG_TOPIC("338b7", ERR, arangodb::Logger::GRAPHS)
@@ -677,7 +674,7 @@ OperationResult GraphManager::readGraphByQuery(velocypack::Builder& builder,
   builder.add("graphs", graphsSlice);
   builder.close();
 
-  return OperationResult(TRI_ERROR_NO_ERROR);
+  return Result(TRI_ERROR_NO_ERROR);
 }
 
 Result GraphManager::checkForEdgeDefinitionConflicts(arangodb::graph::EdgeDefinition const& edgeDefinition,
@@ -788,6 +785,7 @@ OperationResult GraphManager::removeGraph(Graph const& graph, bool waitForSync,
                                           bool dropCollections) {
   std::unordered_set<std::string> leadersToBeRemoved;
   std::unordered_set<std::string> followersToBeRemoved;
+  OperationOptions options(ExecContext::current());
 
   if (dropCollections) {
     auto addToRemoveCollections = [this, &graph, &leadersToBeRemoved,
@@ -819,7 +817,7 @@ OperationResult GraphManager::removeGraph(Graph const& graph, bool waitForSync,
   Result permRes =
       checkDropGraphPermissions(graph, followersToBeRemoved, leadersToBeRemoved);
   if (permRes.fail()) {
-    return OperationResult{std::move(permRes)};
+    return OperationResult{std::move(permRes), options};
   }
 
   VPackBuilder builder;
@@ -829,27 +827,26 @@ OperationResult GraphManager::removeGraph(Graph const& graph, bool waitForSync,
   }
 
   {  // Remove from _graphs
-    OperationOptions options;
+    OperationOptions options(ExecContext::current());
     options.waitForSync = waitForSync;
 
     Result res;
-    OperationResult result;
     SingleCollectionTransaction trx{ctx(), StaticStrings::GraphCollection,
                                     AccessMode::Type::WRITE};
 
     res = trx.begin();
     if (res.fail()) {
-      return OperationResult(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND);
+      return OperationResult(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND, options);
     }
     VPackSlice search = builder.slice();
-    result = trx.remove(StaticStrings::GraphCollection, search, options);
+    OperationResult result = trx.remove(StaticStrings::GraphCollection, search, options);
 
     res = trx.finish(result.result);
     if (result.fail()) {
       return result;
     }
     if (res.fail()) {
-      return OperationResult{res};
+      return OperationResult{res, options};
     }
     TRI_ASSERT(res.ok() && result.ok());
   }
@@ -887,18 +884,18 @@ OperationResult GraphManager::removeGraph(Graph const& graph, bool waitForSync,
     }
 
     if (firstDropError.fail()) {
-      return OperationResult{firstDropError};
+      return OperationResult{firstDropError, options};
     }
   }
 
-  return OperationResult{TRI_ERROR_NO_ERROR};
+  return OperationResult{TRI_ERROR_NO_ERROR, options};
 }
 
-OperationResult GraphManager::pushCollectionIfMayBeDropped(
-    std::string const& colName, std::string const& graphName,
-    std::unordered_set<std::string>& toBeRemoved) {
+Result GraphManager::pushCollectionIfMayBeDropped(std::string const& colName,
+                                                  std::string const& graphName,
+                                                  std::unordered_set<std::string>& toBeRemoved) {
   VPackBuilder graphsBuilder;
-  OperationResult result = readGraphs(graphsBuilder);
+  Result result = readGraphs(graphsBuilder);
   if (result.fail()) {
     return result;
   }
@@ -909,7 +906,7 @@ OperationResult GraphManager::pushCollectionIfMayBeDropped(
   TRI_ASSERT(graphs.get("graphs").isArray());
 
   if (!graphs.get("graphs").isArray()) {
-    return OperationResult(TRI_ERROR_GRAPH_INTERNAL_DATA_CORRUPT);
+    return Result(TRI_ERROR_GRAPH_INTERNAL_DATA_CORRUPT);
   }
 
   for (auto graph : VPackArrayIterator(graphs.get("graphs"))) {
@@ -943,7 +940,7 @@ OperationResult GraphManager::pushCollectionIfMayBeDropped(
         }
       }
     } else {
-      return OperationResult(TRI_ERROR_GRAPH_INTERNAL_DATA_CORRUPT);
+      return Result(TRI_ERROR_GRAPH_INTERNAL_DATA_CORRUPT);
     }
 
     // check orphan collections
@@ -960,7 +957,7 @@ OperationResult GraphManager::pushCollectionIfMayBeDropped(
     toBeRemoved.emplace(colName);
   }
 
-  return OperationResult(TRI_ERROR_NO_ERROR);
+  return Result(TRI_ERROR_NO_ERROR);
 }
 
 Result GraphManager::checkDropGraphPermissions(

--- a/arangod/Graph/GraphManager.h
+++ b/arangod/Graph/GraphManager.h
@@ -50,24 +50,23 @@ class GraphManager {
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief find or create vertex collection by name
   ////////////////////////////////////////////////////////////////////////////////
-  OperationResult findOrCreateVertexCollectionByName(const std::string& name,
-                                                     bool waitForSync, VPackSlice options);
+  Result findOrCreateVertexCollectionByName(const std::string& name,
+                                            bool waitForSync, VPackSlice options);
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief find or create collection by name and type
   ////////////////////////////////////////////////////////////////////////////////
-  OperationResult createCollection(std::string const& name, TRI_col_type_e colType,
-                                   bool waitForSync, VPackSlice options);
+  Result createCollection(std::string const& name, TRI_col_type_e colType,
+                          bool waitForSync, VPackSlice options);
 
  public:
   explicit GraphManager(TRI_vocbase_t& vocbase) : _vocbase(vocbase) {}
 
-  OperationResult readGraphs(velocypack::Builder& builder) const;
+  Result readGraphs(velocypack::Builder& builder) const;
 
-  OperationResult readGraphKeys(velocypack::Builder& builder) const;
+  Result readGraphKeys(velocypack::Builder& builder) const;
 
-  OperationResult readGraphByQuery(velocypack::Builder& builder,
-                                   std::string const& queryStr) const;
+  Result readGraphByQuery(velocypack::Builder& builder, std::string const& queryStr) const;
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief find and return a collections if available
@@ -93,26 +92,23 @@ class GraphManager {
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief find or create collections by EdgeDefinitions
   ////////////////////////////////////////////////////////////////////////////////
-  OperationResult findOrCreateCollectionsByEdgeDefinitions(
-      Graph const& graph, std::map<std::string, EdgeDefinition> const& edgeDefinitions,
-      bool waitForSync, VPackSlice options);
+  Result findOrCreateCollectionsByEdgeDefinitions(Graph const& graph,
+                                                  std::map<std::string, EdgeDefinition> const& edgeDefinitions,
+                                                  bool waitForSync, VPackSlice options);
 
-  OperationResult findOrCreateCollectionsByEdgeDefinition(Graph const& graph,
-                                                          EdgeDefinition const& edgeDefinition,
-                                                          bool waitForSync,
-                                                          VPackSlice options);
+  Result findOrCreateCollectionsByEdgeDefinition(Graph const& graph,
+                                                 EdgeDefinition const& edgeDefinition,
+                                                 bool waitForSync, VPackSlice options);
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief create a vertex collection
   ////////////////////////////////////////////////////////////////////////////////
-  OperationResult createVertexCollection(std::string const& name,
-                                         bool waitForSync, VPackSlice options);
+  Result createVertexCollection(std::string const& name, bool waitForSync, VPackSlice options);
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief create an edge collection
   ////////////////////////////////////////////////////////////////////////////////
-  OperationResult createEdgeCollection(std::string const& name,
-                                       bool waitForSync, VPackSlice options);
+  Result createEdgeCollection(std::string const& name, bool waitForSync, VPackSlice options);
 
   /// @brief rename a collection used in an edge definition
   bool renameGraphCollection(std::string const& oldName, std::string const& newName);
@@ -130,9 +126,8 @@ class GraphManager {
   /// @brief Remove a graph and optional all connected collections
   OperationResult removeGraph(Graph const& graph, bool waitForSync, bool dropCollections);
 
-  OperationResult pushCollectionIfMayBeDropped(const std::string& colName,
-                                               const std::string& graphName,
-                                               std::unordered_set<std::string>& toBeRemoved);
+  Result pushCollectionIfMayBeDropped(const std::string& colName, const std::string& graphName,
+                                      std::unordered_set<std::string>& toBeRemoved);
 
   bool collectionExists(std::string const& collection) const;
 

--- a/arangod/Graph/GraphOperations.cpp
+++ b/arangod/Graph/GraphOperations.cpp
@@ -74,11 +74,14 @@ OperationResult GraphOperations::changeEdgeDefinitionForGraph(Graph& graph,
                                                               EdgeDefinition const& newEdgeDef,
                                                               bool waitForSync,
                                                               transaction::Methods& trx) {
+  OperationOptions options(ExecContext::current());
+  options.waitForSync = waitForSync;
+
   VPackBuilder builder;
   // remove old definition, insert the new one instead
   Result res = graph.replaceEdgeDefinition(newEdgeDef);
   if (res.fail()) {
-    return OperationResult(res);
+    return OperationResult(res, options);
   }
 
   builder.openObject();
@@ -105,15 +108,13 @@ OperationResult GraphOperations::changeEdgeDefinitionForGraph(Graph& graph,
       continue;
     }
 
-    OperationResult result = gmngr.createVertexCollection(newCollection, waitForSync,
-                                                          collectionOptions.slice());
+    Result result = gmngr.createVertexCollection(newCollection, waitForSync,
+                                                 collectionOptions.slice());
     if (result.fail()) {
-      return result;
+      return OperationResult(result, options);
     }
   }
 
-  OperationOptions options;
-  options.waitForSync = waitForSync;
   // now write to database
   return trx.update(StaticStrings::GraphCollection, builder.slice(), options);
 }
@@ -121,21 +122,21 @@ OperationResult GraphOperations::changeEdgeDefinitionForGraph(Graph& graph,
 OperationResult GraphOperations::eraseEdgeDefinition(bool waitForSync,
                                                      std::string const& edgeDefinitionName,
                                                      bool dropCollection) {
+  OperationOptions options(ExecContext::current());
+  options.waitForSync = waitForSync;
+
   // check if edgeCollection is available
-  OperationResult result = checkEdgeCollectionAvailability(edgeDefinitionName);
-  if (result.fail()) {
-    return result;
+  Result res = checkEdgeCollectionAvailability(edgeDefinitionName);
+  if (res.fail()) {
+    return OperationResult(res, options);
   }
 
   if (dropCollection && !hasRWPermissionsFor(edgeDefinitionName)) {
-    return OperationResult{TRI_ERROR_FORBIDDEN};
+    return OperationResult{TRI_ERROR_FORBIDDEN, options};
   }
 
   // remove edgeDefinition from graph config
   _graph.removeEdgeDefinition(edgeDefinitionName);
-
-  OperationOptions options;
-  options.waitForSync = waitForSync;
 
   VPackBuilder builder;
   builder.openObject();
@@ -146,13 +147,14 @@ OperationResult GraphOperations::eraseEdgeDefinition(bool waitForSync,
                                   AccessMode::Type::WRITE);
   trx.addHint(transaction::Hints::Hint::SINGLE_OPERATION);
 
-  Result res = trx.begin();
+  res = trx.begin();
 
   if (!res.ok()) {
     res = trx.finish(res);
-    return OperationResult(res);
+    return OperationResult(res, options);
   }
-  result = trx.update(StaticStrings::GraphCollection, builder.slice(), options);
+  OperationResult result =
+      trx.update(StaticStrings::GraphCollection, builder.slice(), options);
 
   if (dropCollection) {
     std::unordered_set<std::string> collectionsToBeRemoved;
@@ -170,7 +172,7 @@ OperationResult GraphOperations::eraseEdgeDefinition(bool waitForSync,
           if (coll->type() == TRI_COL_TYPE_DOCUMENT) {
             bool initial = isUsedAsInitialCollection(cname);
             if (initial) {
-              return OperationResult(TRI_ERROR_GRAPH_COLLECTION_IS_INITIAL);
+              return OperationResult(TRI_ERROR_GRAPH_COLLECTION_IS_INITIAL, options);
             }
           }
         }
@@ -178,11 +180,11 @@ OperationResult GraphOperations::eraseEdgeDefinition(bool waitForSync,
         res = methods::Collections::drop(*coll, false, -1.0);
         if (res.fail()) {
           res = trx.finish(result.result);
-          return OperationResult(res);
+          return OperationResult(res, options);
         }
       } else {
         res = trx.finish(result.result);
-        return OperationResult(res);
+        return OperationResult(res, options);
       }
     }
   }
@@ -190,55 +192,58 @@ OperationResult GraphOperations::eraseEdgeDefinition(bool waitForSync,
   res = trx.finish(result.result);
 
   if (result.ok() && res.fail()) {
-    return OperationResult(res);
+    return OperationResult(res, options);
   }
 
   return result;
 }
 
-OperationResult GraphOperations::checkEdgeCollectionAvailability(std::string const& edgeCollectionName) {
+Result GraphOperations::checkEdgeCollectionAvailability(std::string const& edgeCollectionName) {
   bool found = _graph.edgeCollections().find(edgeCollectionName) !=
                _graph.edgeCollections().end();
 
   if (!found) {
-    return OperationResult(TRI_ERROR_GRAPH_EDGE_COLLECTION_NOT_USED);
+    return Result(TRI_ERROR_GRAPH_EDGE_COLLECTION_NOT_USED);
   }
 
-  return OperationResult(TRI_ERROR_NO_ERROR);
+  return Result(TRI_ERROR_NO_ERROR);
 }
 
-OperationResult GraphOperations::checkVertexCollectionAvailability(std::string const& vertexCollectionName) {
+Result GraphOperations::checkVertexCollectionAvailability(std::string const& vertexCollectionName) {
   std::shared_ptr<LogicalCollection> def =
       GraphManager::getCollectionByName(_vocbase, vertexCollectionName);
 
   if (def == nullptr) {
-    return OperationResult(
-        Result(TRI_ERROR_GRAPH_VERTEX_COL_DOES_NOT_EXIST,
-               vertexCollectionName + " " +
-                   std::string{TRI_errno_string(TRI_ERROR_GRAPH_VERTEX_COL_DOES_NOT_EXIST)}));
+    return Result(Result(TRI_ERROR_GRAPH_VERTEX_COL_DOES_NOT_EXIST,
+                         vertexCollectionName + " " +
+                             std::string{TRI_errno_string(TRI_ERROR_GRAPH_VERTEX_COL_DOES_NOT_EXIST)}));
   }
 
-  return OperationResult(TRI_ERROR_NO_ERROR);
+  return Result(TRI_ERROR_NO_ERROR);
 }
 
 OperationResult GraphOperations::editEdgeDefinition(VPackSlice edgeDefinitionSlice,
                                                     bool waitForSync,
                                                     std::string const& edgeDefinitionName) {
+  OperationOptions options(ExecContext::current());
   auto maybeEdgeDef = EdgeDefinition::createFromVelocypack(edgeDefinitionSlice);
   if (!maybeEdgeDef) {
-    return OperationResult{std::move(maybeEdgeDef).result()};
+    return OperationResult{std::move(maybeEdgeDef).result(), options};
   }
   EdgeDefinition const& edgeDefinition = maybeEdgeDef.get();
 
   // check if edgeCollection is available
-  OperationResult result = checkEdgeCollectionAvailability(edgeDefinitionName);
-  if (result.fail()) {
-    return result;
+  Result res = checkEdgeCollectionAvailability(edgeDefinitionName);
+  if (res.fail()) {
+    return OperationResult(res, options);
   }
 
   Result permRes = checkEdgeDefinitionPermissions(edgeDefinition);
   if (permRes.fail()) {
-    return OperationResult{permRes};
+    return OperationResult{
+        permRes,
+        options,
+    };
   }
 
   GraphManager gmngr{_vocbase};
@@ -246,14 +251,14 @@ OperationResult GraphOperations::editEdgeDefinition(VPackSlice edgeDefinitionSli
   collectionsOptions.openObject();
   _graph.createCollectionOptions(collectionsOptions, waitForSync);
   collectionsOptions.close();
-  result = gmngr.findOrCreateCollectionsByEdgeDefinition(_graph, edgeDefinition, waitForSync,
-                                                         collectionsOptions.slice());
-  if (result.fail()) {
-    return result;
+  res = gmngr.findOrCreateCollectionsByEdgeDefinition(_graph, edgeDefinition, waitForSync,
+                                                      collectionsOptions.slice());
+  if (res.fail()) {
+    return OperationResult(res, options);
   }
 
   if (!_graph.hasEdgeCollection(edgeDefinition.getName())) {
-    return OperationResult(TRI_ERROR_GRAPH_EDGE_COLLECTION_NOT_USED);
+    return OperationResult(TRI_ERROR_GRAPH_EDGE_COLLECTION_NOT_USED, options);
   }
 
   // change definition for ALL graphs
@@ -262,16 +267,16 @@ OperationResult GraphOperations::editEdgeDefinition(VPackSlice edgeDefinitionSli
   VPackSlice graphs = graphsBuilder.slice();
 
   if (!graphs.get("graphs").isArray()) {
-    return OperationResult{TRI_ERROR_GRAPH_INTERNAL_DATA_CORRUPT};
+    return OperationResult{TRI_ERROR_GRAPH_INTERNAL_DATA_CORRUPT, options};
   }
 
   SingleCollectionTransaction trx(ctx(), StaticStrings::GraphCollection,
                                   AccessMode::Type::WRITE);
 
-  Result res = trx.begin();
+  res = trx.begin();
 
   if (!res.ok()) {
-    return OperationResult(res);
+    return OperationResult(res, options);
   }
 
   for (auto singleGraph : VPackArrayIterator(graphs.get("graphs"))) {
@@ -279,7 +284,8 @@ OperationResult GraphOperations::editEdgeDefinition(VPackSlice edgeDefinitionSli
         Graph::fromPersistence(_vocbase, singleGraph.resolveExternals());
     if (graph->hasEdgeCollection(edgeDefinition.getName())) {
       // only try to modify the edgeDefinition if it's available.
-      result = changeEdgeDefinitionForGraph(*(graph.get()), edgeDefinition, waitForSync, trx);
+      OperationResult result =
+          changeEdgeDefinitionForGraph(*(graph.get()), edgeDefinition, waitForSync, trx);
       if (result.fail()) {
         return result;
       }
@@ -287,10 +293,7 @@ OperationResult GraphOperations::editEdgeDefinition(VPackSlice edgeDefinitionSli
   }
 
   res = trx.finish(TRI_ERROR_NO_ERROR);
-  if (result.ok() && res.fail()) {
-    return OperationResult(res);
-  }
-  return result;
+  return OperationResult(res, options);
 }
 
 OperationResult GraphOperations::addOrphanCollection(VPackSlice document, bool waitForSync,
@@ -299,16 +302,18 @@ OperationResult GraphOperations::addOrphanCollection(VPackSlice document, bool w
   std::string collectionName = document.get("collection").copyString();
   std::shared_ptr<LogicalCollection> def;
 
-  OperationResult result;
+  OperationOptions options(ExecContext::current());
+  options.waitForSync = waitForSync;
+  OperationResult result(Result(), options);
 
   if (_graph.hasVertexCollection(collectionName)) {
     if (_graph.hasOrphanCollection(collectionName)) {
-      return OperationResult(TRI_ERROR_GRAPH_COLLECTION_USED_IN_ORPHANS);
+      return OperationResult(TRI_ERROR_GRAPH_COLLECTION_USED_IN_ORPHANS, options);
     }
-    return OperationResult(
-        Result(TRI_ERROR_GRAPH_COLLECTION_USED_IN_EDGE_DEF,
-               collectionName + " " +
-                   std::string{TRI_errno_string(TRI_ERROR_GRAPH_COLLECTION_USED_IN_EDGE_DEF)}));
+    return OperationResult(Result(TRI_ERROR_GRAPH_COLLECTION_USED_IN_EDGE_DEF,
+                                  collectionName + " " +
+                                      std::string{TRI_errno_string(TRI_ERROR_GRAPH_COLLECTION_USED_IN_EDGE_DEF)}),
+                           options);
   }
 
   // add orphan collection to graph
@@ -323,28 +328,28 @@ OperationResult GraphOperations::addOrphanCollection(VPackSlice document, bool w
       res = gmngr.ensureCollections(&_graph, waitForSync);
 
       if (res.fail()) {
-        return OperationResult{std::move(res)};
+        return OperationResult{std::move(res), options};
       }
     } else {
-      return OperationResult(
-          Result(TRI_ERROR_GRAPH_VERTEX_COL_DOES_NOT_EXIST,
-                 collectionName + " " +
-                     std::string{TRI_errno_string(TRI_ERROR_GRAPH_VERTEX_COL_DOES_NOT_EXIST)}));
+      return OperationResult(Result(TRI_ERROR_GRAPH_VERTEX_COL_DOES_NOT_EXIST,
+                                    collectionName + " " +
+                                        std::string{TRI_errno_string(TRI_ERROR_GRAPH_VERTEX_COL_DOES_NOT_EXIST)}),
+                             options);
     }
   } else {
     // Hint: Now needed because of the initial property
     res = gmngr.ensureCollections(&_graph, waitForSync);
     if (res.fail()) {
-      return OperationResult{std::move(res)};
+      return OperationResult{std::move(res), options};
     }
 
     if (def->type() != TRI_COL_TYPE_DOCUMENT) {
-      return OperationResult(TRI_ERROR_GRAPH_WRONG_COLLECTION_TYPE_VERTEX);
+      return OperationResult(TRI_ERROR_GRAPH_WRONG_COLLECTION_TYPE_VERTEX, options);
     }
 
     res = _graph.validateCollection(*(def.get()));
     if (res.fail()) {
-      return OperationResult{std::move(res)};
+      return OperationResult{std::move(res), options};
     }
   }
 
@@ -359,16 +364,14 @@ OperationResult GraphOperations::addOrphanCollection(VPackSlice document, bool w
   res = trx.begin();
 
   if (!res.ok()) {
-    return OperationResult(res);
+    return OperationResult(res, options);
   }
 
-  OperationOptions options;
-  options.waitForSync = waitForSync;
   result = trx.update(StaticStrings::GraphCollection, builder.slice(), options);
 
   res = trx.finish(result.result);
   if (result.ok() && res.fail()) {
-    return OperationResult(res);
+    return OperationResult(res, options);
   }
   return result;
 }
@@ -376,12 +379,13 @@ OperationResult GraphOperations::addOrphanCollection(VPackSlice document, bool w
 OperationResult GraphOperations::eraseOrphanCollection(bool waitForSync,
                                                        std::string const& collectionName,
                                                        bool dropCollection) {
+  OperationOptions options(ExecContext::current());
 #ifdef USE_ENTERPRISE
   {
     if (dropCollection) {
       bool initial = isUsedAsInitialCollection(collectionName);
       if (initial) {
-        return OperationResult(TRI_ERROR_GRAPH_COLLECTION_IS_INITIAL);
+        return OperationResult(TRI_ERROR_GRAPH_COLLECTION_IS_INITIAL, options);
       }
     }
   }
@@ -396,22 +400,22 @@ OperationResult GraphOperations::eraseOrphanCollection(bool waitForSync,
     }
   }
   if (!found) {
-    return OperationResult(TRI_ERROR_GRAPH_NOT_IN_ORPHAN_COLLECTION);
+    return OperationResult(TRI_ERROR_GRAPH_NOT_IN_ORPHAN_COLLECTION, options);
   }
 
   // check if collection exists in the database
-  OperationResult result = checkVertexCollectionAvailability(collectionName);
-  if (result.fail()) {
-    return result;
+  Result res = checkVertexCollectionAvailability(collectionName);
+  if (res.fail()) {
+    return OperationResult(res, options);
   }
 
   if (!hasRWPermissionsFor(collectionName)) {
-    return OperationResult{TRI_ERROR_FORBIDDEN};
+    return OperationResult{TRI_ERROR_FORBIDDEN, options};
   }
 
-  Result res = _graph.removeOrphanCollection(collectionName);
+  res = _graph.removeOrphanCollection(collectionName);
   if (res.fail()) {
-    return OperationResult(res);
+    return OperationResult(res, options);
   }
 
   VPackBuilder builder;
@@ -419,6 +423,7 @@ OperationResult GraphOperations::eraseOrphanCollection(bool waitForSync,
   _graph.toPersistence(builder);
   builder.close();
 
+  OperationResult result(Result(), options);
   {
     SingleCollectionTransaction trx(ctx(), StaticStrings::GraphCollection,
                                     AccessMode::Type::WRITE);
@@ -427,7 +432,7 @@ OperationResult GraphOperations::eraseOrphanCollection(bool waitForSync,
     res = trx.begin();
 
     if (!res.ok()) {
-      return OperationResult(res);
+      return OperationResult(res, options);
     }
     OperationOptions options;
     options.waitForSync = waitForSync;
@@ -439,10 +444,10 @@ OperationResult GraphOperations::eraseOrphanCollection(bool waitForSync,
   if (dropCollection) {
     std::unordered_set<std::string> collectionsToBeRemoved;
     GraphManager gmngr{_vocbase};
-    res = gmngr.pushCollectionIfMayBeDropped(collectionName, "", collectionsToBeRemoved).result;
-      
+    res = gmngr.pushCollectionIfMayBeDropped(collectionName, "", collectionsToBeRemoved);
+
     if (res.fail()) {
-      return OperationResult(res);
+      return OperationResult(res, options);
     }
 
     for (auto const& cname : collectionsToBeRemoved) {
@@ -453,13 +458,13 @@ OperationResult GraphOperations::eraseOrphanCollection(bool waitForSync,
         res = methods::Collections::drop(*coll, false, -1.0);
       }
       if (res.fail()) {
-        return OperationResult(res);
+        return OperationResult(res, options);
       }
     }
   }
 
   if (result.ok() && res.fail()) {
-    return OperationResult(res);
+    return OperationResult(res, options);
   }
 
   return result;
@@ -467,9 +472,10 @@ OperationResult GraphOperations::eraseOrphanCollection(bool waitForSync,
 
 OperationResult GraphOperations::addEdgeDefinition(VPackSlice edgeDefinitionSlice,
                                                    bool waitForSync) {
+  OperationOptions options(ExecContext::current());
   ResultT<EdgeDefinition const*> defRes = _graph.addEdgeDefinition(edgeDefinitionSlice);
   if (defRes.fail()) {
-    return OperationResult(std::move(defRes).result());
+    return OperationResult(std::move(defRes).result(), options);
   }
   // Guaranteed to be non nullptr
   TRI_ASSERT(defRes.get() != nullptr);
@@ -477,17 +483,16 @@ OperationResult GraphOperations::addEdgeDefinition(VPackSlice edgeDefinitionSlic
   // ... in different graph
   GraphManager gmngr{_vocbase};
 
-  OperationResult result{
-      gmngr.checkForEdgeDefinitionConflicts(*(defRes.get()), _graph.name())};
-  if (result.fail()) {
+  Result res = gmngr.checkForEdgeDefinitionConflicts(*(defRes.get()), _graph.name());
+  if (res.fail()) {
     // If this fails we will not persist.
-    return result;
+    return OperationResult(res, options);
   }
 
-  Result res = gmngr.ensureCollections(&_graph, waitForSync);
+  res = gmngr.ensureCollections(&_graph, waitForSync);
 
   if (res.fail()) {
-    return OperationResult{std::move(res)};
+    return OperationResult{std::move(res), options};
   }
 
   // finally save the graph
@@ -527,7 +532,7 @@ OperationResult GraphOperations::getDocument(std::string const& collectionName,
   Result res = trx.begin();
 
   if (!res.ok()) {
-    return OperationResult(res);
+    return OperationResult(res, options);
   }
 
   OperationResult result = trx.document(collectionName, search, options);
@@ -535,7 +540,7 @@ OperationResult GraphOperations::getDocument(std::string const& collectionName,
   res = trx.finish(result.result);
 
   if (result.ok() && res.fail()) {
-    return OperationResult(res);
+    return OperationResult(res, options);
   }
   return result;
 }
@@ -589,7 +594,7 @@ OperationResult GraphOperations::modifyDocument(
   options.waitForSync = waitForSync;
   options.returnNew = returnNew;
   options.returnOld = returnOld;
-  OperationResult result;
+  OperationResult result(Result(), options);
 
   if (isPatch) {
     options.keepNull = keepNull;
@@ -601,7 +606,7 @@ OperationResult GraphOperations::modifyDocument(
   Result res = trx.finish(result.result);
 
   if (result.ok() && res.fail()) {
-    return OperationResult(res);
+    return OperationResult(res, options);
   }
   return result;
 }
@@ -625,11 +630,9 @@ OperationResult GraphOperations::updateEdge(const std::string& definitionName,
                                             std::optional<RevisionId> rev,
                                             bool waitForSync, bool returnOld,
                                             bool returnNew, bool keepNull) {
-  OperationResult res;
-  std::unique_ptr<transaction::Methods> trx;
-  std::tie(res, trx) = validateEdge(definitionName, document, waitForSync, true);
+  auto [res, trx] = validateEdge(definitionName, document, waitForSync, true);
   if (res.fail()) {
-    return res;
+    return std::move(res);
   }
   TRI_ASSERT(trx != nullptr);
 
@@ -642,11 +645,9 @@ OperationResult GraphOperations::replaceEdge(const std::string& definitionName,
                                              std::optional<RevisionId> rev,
                                              bool waitForSync, bool returnOld,
                                              bool returnNew, bool keepNull) {
-  OperationResult res;
-  std::unique_ptr<transaction::Methods> trx;
-  std::tie(res, trx) = validateEdge(definitionName, document, waitForSync, false);
+  auto [res, trx] = validateEdge(definitionName, document, waitForSync, false);
   if (res.fail()) {
-    return res;
+    return std::move(res);
   }
   TRI_ASSERT(trx != nullptr);
 
@@ -662,10 +663,7 @@ std::pair<OperationResult, std::unique_ptr<transaction::Methods>> GraphOperation
   std::string toCollectionName;
   std::string toCollectionKey;
 
-  OperationResult res;
-  bool foundEdgeDefinition;
-
-  std::tie(res, foundEdgeDefinition) =
+  auto [res, foundEdgeDefinition] =
       validateEdgeContent(document, fromCollectionName, fromCollectionKey,
                           toCollectionName, toCollectionKey, isUpdate);
   if (res.fail()) {
@@ -690,8 +688,10 @@ std::pair<OperationResult, std::unique_ptr<transaction::Methods>> GraphOperation
 
   Result tRes = trx->begin();
 
+  OperationOptions options(ExecContext::current());
+
   if (!tRes.ok()) {
-    return std::make_pair(OperationResult(tRes), nullptr);
+    return std::make_pair(OperationResult(tRes, options), nullptr);
   }
 
   if (foundEdgeDefinition) {
@@ -722,19 +722,19 @@ OperationResult GraphOperations::validateEdgeVertices(
     bF.add(StaticStrings::KeyString, VPackValue(fromCollectionKey));
   }
 
-  OperationOptions options;
+  OperationOptions options(ExecContext::current());
   OperationResult resultFrom = trx.document(fromCollectionName, bF.slice(), options);
   OperationResult resultTo = trx.document(toCollectionName, bT.slice(), options);
 
   // actual result doesn't matter here
   if (!resultFrom.ok()) {
     trx.finish(resultFrom.result);
-    return OperationResult(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND);
+    return OperationResult(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND, options);
   } else if (!resultTo.ok()) {
     trx.finish(resultTo.result);
-    return OperationResult(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND);
+    return OperationResult(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND, options);
   }
-  return OperationResult(TRI_ERROR_NO_ERROR);
+  return OperationResult(TRI_ERROR_NO_ERROR, options);
 }
 
 std::pair<OperationResult, bool> GraphOperations::validateEdgeContent(
@@ -742,12 +742,14 @@ std::pair<OperationResult, bool> GraphOperations::validateEdgeContent(
     std::string& toCollectionName, std::string& toCollectionKey, bool isUpdate) {
   VPackSlice fromStringSlice = document.get(StaticStrings::FromString);
   VPackSlice toStringSlice = document.get(StaticStrings::ToString);
+  OperationOptions options(ExecContext::current());
 
   if (fromStringSlice.isNone() || toStringSlice.isNone()) {
     if (isUpdate) {
-      return std::make_pair(OperationResult(TRI_ERROR_NO_ERROR), false);
+      return std::make_pair(OperationResult(TRI_ERROR_NO_ERROR, options), false);
     }
-    return std::make_pair(OperationResult(TRI_ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE), false);
+    return std::make_pair(OperationResult(TRI_ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE, options),
+                          false);
   }
   std::string fromString = fromStringSlice.copyString();
   std::string toString = toStringSlice.copyString();
@@ -757,7 +759,7 @@ std::pair<OperationResult, bool> GraphOperations::validateEdgeContent(
     fromCollectionName = fromString.substr(0, pos);
     fromCollectionKey = fromString.substr(pos + 1, fromString.length());
   } else {
-    return std::make_pair(OperationResult(TRI_ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE), true);
+    return std::make_pair(OperationResult(TRI_ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE, options), true);
   }
 
   pos = toString.find('/');
@@ -765,32 +767,30 @@ std::pair<OperationResult, bool> GraphOperations::validateEdgeContent(
     toCollectionName = toString.substr(0, pos);
     toCollectionKey = toString.substr(pos + 1, toString.length());
   } else {
-    return std::make_pair(OperationResult(TRI_ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE), true);
+    return std::make_pair(OperationResult(TRI_ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE, options), true);
   }
 
   // check if vertex collections are part of the graph definition
   auto it = _graph.vertexCollections().find(fromCollectionName);
   if (it == _graph.vertexCollections().end()) {
     // not found from vertex
-    return std::make_pair(OperationResult(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND), true);
+    return std::make_pair(OperationResult(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, options), true);
   }
   it = _graph.vertexCollections().find(toCollectionName);
   if (it == _graph.vertexCollections().end()) {
     // not found to vertex
-    return std::make_pair(OperationResult(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND), true);
+    return std::make_pair(OperationResult(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, options), true);
   }
 
-  return std::make_pair(OperationResult(TRI_ERROR_NO_ERROR), true);
+  return std::make_pair(OperationResult(TRI_ERROR_NO_ERROR, options), true);
 }
 
 OperationResult GraphOperations::createEdge(const std::string& definitionName,
                                             VPackSlice document,
                                             bool waitForSync, bool returnNew) {
-  OperationResult res;
-  std::unique_ptr<transaction::Methods> trx;
-  std::tie(res, trx) = validateEdge(definitionName, document, waitForSync, false);
+  auto [res, trx] = validateEdge(definitionName, document, waitForSync, false);
   if (res.fail()) {
-    return res;
+    return std::move(res);
   }
   TRI_ASSERT(trx != nullptr);
 
@@ -812,7 +812,8 @@ OperationResult GraphOperations::updateVertex(const std::string& collectionName,
   Result tRes = trx.begin();
 
   if (!tRes.ok()) {
-    return OperationResult(tRes);
+    OperationOptions options(ExecContext::current());
+    return OperationResult(tRes, options);
   }
   return modifyDocument(collectionName, key, document, true, std::move(rev),
                         waitForSync, returnOld, returnNew, keepNull, trx);
@@ -833,7 +834,8 @@ OperationResult GraphOperations::replaceVertex(const std::string& collectionName
   Result tRes = trx.begin();
 
   if (!tRes.ok()) {
-    return OperationResult(tRes);
+    OperationOptions options(ExecContext::current());
+    return OperationResult(tRes, options);
   }
   return modifyDocument(collectionName, key, document, false, std::move(rev),
                         waitForSync, returnOld, returnNew, keepNull, trx);
@@ -851,7 +853,8 @@ OperationResult GraphOperations::createVertex(const std::string& collectionName,
   Result res = trx.begin();
 
   if (!res.ok()) {
-    return OperationResult(res);
+    OperationOptions options(ExecContext::current());
+    return OperationResult(res, options);
   }
 
   return createDocument(&trx, collectionName, document, waitForSync, returnNew);
@@ -880,7 +883,7 @@ OperationResult GraphOperations::removeEdgeOrVertex(const std::string& collectio
   };
   Result res = gmngr.applyOnAllGraphs(callback);
   if (res.fail()) {
-    return OperationResult(res);
+    return OperationResult(res, options);
   }
 
   auto edgeCollections = _graph.edgeCollections();
@@ -910,7 +913,7 @@ OperationResult GraphOperations::removeEdgeOrVertex(const std::string& collectio
   res = trx.begin();
 
   if (!res.ok()) {
-    return OperationResult(res);
+    return OperationResult(res, options);
   }
 
   OperationResult result = trx.remove(collectionName, search, options);
@@ -935,7 +938,7 @@ OperationResult GraphOperations::removeEdgeOrVertex(const std::string& collectio
       auto queryResult = query.executeSync();
 
       if (queryResult.result.fail()) {
-        return OperationResult(std::move(queryResult.result));
+        return OperationResult(std::move(queryResult.result), options);
       }
     }
   }
@@ -943,7 +946,7 @@ OperationResult GraphOperations::removeEdgeOrVertex(const std::string& collectio
   res = trx.finish(result.result);
 
   if (result.ok() && res.fail()) {
-    return OperationResult(res);
+    return OperationResult(res, options);
   }
   return result;
 }

--- a/arangod/Graph/GraphOperations.cpp
+++ b/arangod/Graph/GraphOperations.cpp
@@ -214,9 +214,9 @@ Result GraphOperations::checkVertexCollectionAvailability(std::string const& ver
       GraphManager::getCollectionByName(_vocbase, vertexCollectionName);
 
   if (def == nullptr) {
-    return Result(Result(TRI_ERROR_GRAPH_VERTEX_COL_DOES_NOT_EXIST,
+    return Result(TRI_ERROR_GRAPH_VERTEX_COL_DOES_NOT_EXIST,
                          vertexCollectionName + " " +
-                             std::string{TRI_errno_string(TRI_ERROR_GRAPH_VERTEX_COL_DOES_NOT_EXIST)}));
+                             std::string{TRI_errno_string(TRI_ERROR_GRAPH_VERTEX_COL_DOES_NOT_EXIST)});
   }
 
   return Result(TRI_ERROR_NO_ERROR);

--- a/arangod/Graph/GraphOperations.h
+++ b/arangod/Graph/GraphOperations.h
@@ -200,8 +200,8 @@ class GraphOperations {
   OperationResult createDocument(transaction::Methods* trx, const std::string& collectionName,
                                  VPackSlice document, bool waitForSync, bool returnNew);
 
-  OperationResult checkEdgeCollectionAvailability(std::string const& edgeCollectionName);
-  OperationResult checkVertexCollectionAvailability(std::string const& vertexCollectionName);
+  Result checkEdgeCollectionAvailability(std::string const& edgeCollectionName);
+  Result checkVertexCollectionAvailability(std::string const& vertexCollectionName);
 
   bool hasROPermissionsFor(std::string const& collection) const;
   bool hasRWPermissionsFor(std::string const& collection) const;

--- a/arangod/Network/ClusterUtils.cpp
+++ b/arangod/Network/ClusterUtils.cpp
@@ -48,15 +48,20 @@ OperationResult clusterResultInsert(arangodb::fuerte::StatusCode code,
       return OperationResult(Result(), std::move(body), std::move(options), errorCounter);
     }
     case fuerte::StatusPreconditionFailed:
-      return network::opResultFromBody(std::move(body), TRI_ERROR_ARANGO_CONFLICT);
+      return network::opResultFromBody(std::move(body), TRI_ERROR_ARANGO_CONFLICT,
+                                       std::move(options));
     case fuerte::StatusBadRequest:
-      return network::opResultFromBody(std::move(body), TRI_ERROR_INTERNAL);
+      return network::opResultFromBody(std::move(body), TRI_ERROR_INTERNAL,
+                                       std::move(options));
     case fuerte::StatusNotFound:
-      return network::opResultFromBody(std::move(body), TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
+      return network::opResultFromBody(std::move(body), TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
+                                       std::move(options));
     case fuerte::StatusConflict:
-      return network::opResultFromBody(std::move(body), TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED);
+      return network::opResultFromBody(std::move(body), TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED,
+                                       std::move(options));
     default:
-      return network::opResultFromBody(std::move(body), TRI_ERROR_INTERNAL);
+      return network::opResultFromBody(std::move(body), TRI_ERROR_INTERNAL,
+                                       std::move(options));
   }
 }
 
@@ -73,9 +78,11 @@ OperationResult clusterResultDocument(arangodb::fuerte::StatusCode code,
       return OperationResult(Result(TRI_ERROR_ARANGO_CONFLICT), std::move(body),
                              std::move(options), errorCounter);
     case fuerte::StatusNotFound:
-      return network::opResultFromBody(std::move(body), TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND);
+      return network::opResultFromBody(std::move(body), TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND,
+                                       std::move(options));
     default:
-      return network::opResultFromBody(std::move(body), TRI_ERROR_INTERNAL);
+      return network::opResultFromBody(std::move(body), TRI_ERROR_INTERNAL,
+                                       std::move(options));
   }
 }
 
@@ -97,9 +104,11 @@ OperationResult clusterResultModify(arangodb::fuerte::StatusCode code,
       return OperationResult(network::resultFromBody(body, TRI_ERROR_ARANGO_CONFLICT),
                              body, std::move(options), errorCounter);
     case fuerte::StatusNotFound:
-      return network::opResultFromBody(std::move(body), TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND);
+      return network::opResultFromBody(std::move(body), TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND,
+                                       std::move(options));
     default: {
-      return network::opResultFromBody(std::move(body), TRI_ERROR_INTERNAL);
+      return network::opResultFromBody(std::move(body), TRI_ERROR_INTERNAL,
+                                       std::move(options));
     }
   }
 }
@@ -121,9 +130,11 @@ OperationResult clusterResultDelete(arangodb::fuerte::StatusCode code,
       return OperationResult(network::resultFromBody(body, TRI_ERROR_ARANGO_CONFLICT),
                              body, std::move(options), errorCounter);
     case fuerte::StatusNotFound:
-      return network::opResultFromBody(std::move(body), TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND);
+      return network::opResultFromBody(std::move(body), TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND,
+                                       std::move(options));
     default: {
-      return network::opResultFromBody(std::move(body), TRI_ERROR_INTERNAL);
+      return network::opResultFromBody(std::move(body), TRI_ERROR_INTERNAL,
+                                       std::move(options));
     }
   }
 }

--- a/arangod/Network/Utils.h
+++ b/arangod/Network/Utils.h
@@ -54,8 +54,10 @@ Result resultFromBody(arangodb::velocypack::Slice b, int defaultError);
 
 /// @brief extract the error from a cluster response
 template <typename T>
-OperationResult opResultFromBody(T const& body, int defaultErrorCode) {
-  return OperationResult(arangodb::network::resultFromBody(body, defaultErrorCode));
+OperationResult opResultFromBody(T const& body, int defaultErrorCode,
+                                 OperationOptions&& options) {
+  return OperationResult(arangodb::network::resultFromBody(body, defaultErrorCode),
+                         std::move(options));
 }
 
 /// @brief extract the error code form the body

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -1548,7 +1548,8 @@ int64_t DatabaseInitialSyncer::getSize(arangodb::LogicalCollection const& col) {
     return -1;
   }
 
-  auto result = trx.count(col.name(), transaction::CountType::Normal);
+  OperationOptions options(ExecContext::current());
+  auto result = trx.count(col.name(), transaction::CountType::Normal, options);
 
   if (result.result.fail()) {
     return -1;

--- a/arangod/Replication/Syncer.cpp
+++ b/arangod/Replication/Syncer.cpp
@@ -141,7 +141,7 @@ arangodb::Result applyCollectionDumpMarkerInternal(
     options.indexOperationMode = arangodb::IndexOperationMode::internal;
 
     try {
-      OperationResult opRes;
+      OperationResult opRes(Result(), options);
       bool useReplace = false;
       VPackSlice keySlice = arangodb::transaction::helpers::extractKeyFromDocument(slice);
 

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -842,12 +842,12 @@ Result TailingSyncer::truncateCollection(arangodb::velocypack::Slice const& slic
       return res;
     }
 
-    OperationResult opRes = trx.count(col->name(), transaction::CountType::Normal);
+    OperationOptions opts(ExecContext::current());
+    OperationResult opRes = trx.count(col->name(), transaction::CountType::Normal, opts);
     if (opRes.ok() && opRes.slice().isNumber()) {
       count = opRes.slice().getNumber<uint64_t>();
     }
 
-    OperationOptions opts;
     opts.isRestore = true;
     opRes = trx.truncate(col->name(), opts);
 

--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -474,7 +474,7 @@ RestStatus RestCollectionHandler::handleCommandPut() {
     }
 
   } else if (sub == "truncate") {
-    OperationOptions opts;
+    OperationOptions opts(_context);
 
     opts.waitForSync = _request->parsedValue("waitForSync", false);
     opts.isSynchronousReplicationFrom =

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -209,7 +209,7 @@ RestStatus RestDocumentHandler::insertDocument() {
 
   Result res = _activeTrx->begin();
   if (!res.ok()) {
-    generateTransactionError(cname, res, "");
+    generateTransactionError(cname, OperationResult(res, opOptions), "");
     return RestStatus::DONE;
   }
 
@@ -226,7 +226,8 @@ RestStatus RestDocumentHandler::insertDocument() {
             }
 
             if (res.fail()) {
-              generateTransactionError(cname, res, "");
+              generateTransactionError(cname, OperationResult(res, opOptions),
+                                       "");
               return;
             }
 
@@ -313,7 +314,7 @@ RestStatus RestDocumentHandler::readSingleDocument(bool generateBody) {
   Result res = _activeTrx->begin();
 
   if (!res.ok()) {
-    generateTransactionError(collection, res, "");
+    generateTransactionError(collection, OperationResult(res, options), "");
     return RestStatus::DONE;
   }
 
@@ -327,7 +328,7 @@ RestStatus RestDocumentHandler::readSingleDocument(bool generateBody) {
         }
 
         if (!res.ok()) {
-          generateTransactionError(collection, res, key, ifRid);
+          generateTransactionError(collection, OperationResult(res, options), key, ifRid);
           return;
         }
 
@@ -430,14 +431,13 @@ RestStatus RestDocumentHandler::modifyDocument(bool isPatch) {
     return RestStatus::DONE;
   }
 
+  OperationOptions opOptions(_context);
   if ((!isArrayCase && !body.isObject()) || (isArrayCase && !body.isArray())) {
-    generateTransactionError(cname,
-                             OperationResult(TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID),
+    generateTransactionError(cname, OperationResult(TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID, opOptions),
                              "");
     return RestStatus::DONE;
   }
 
-  OperationOptions opOptions(_context);
   opOptions.isRestore = _request->parsedValue(StaticStrings::IsRestoreString, false);
   opOptions.ignoreRevs = _request->parsedValue(StaticStrings::IgnoreRevsString, true);
   opOptions.waitForSync = _request->parsedValue(StaticStrings::WaitForSyncString, false);
@@ -499,7 +499,7 @@ RestStatus RestDocumentHandler::modifyDocument(bool isPatch) {
 
   Result res = _activeTrx->begin();
   if (!res.ok()) {
-    generateTransactionError(cname, res, "");
+    generateTransactionError(cname, OperationResult(res, opOptions), "");
     return RestStatus::DONE;
   }
 
@@ -527,7 +527,7 @@ RestStatus RestDocumentHandler::modifyDocument(bool isPatch) {
     }
 
     if (!res.ok()) {
-      generateTransactionError(cname, res, key, headerRev);
+      generateTransactionError(cname, OperationResult(res, opOptions), key, headerRev);
       return;
     }
 
@@ -618,7 +618,7 @@ RestStatus RestDocumentHandler::removeDocument() {
   Result res = _activeTrx->begin();
 
   if (!res.ok()) {
-    generateTransactionError(cname, res, "");
+    generateTransactionError(cname, OperationResult(res, opOptions), "");
     return RestStatus::DONE;
   }
 
@@ -638,7 +638,7 @@ RestStatus RestDocumentHandler::removeDocument() {
     }
 
     if (!res.ok()) {
-      generateTransactionError(cname, res, key);
+      generateTransactionError(cname, OperationResult(res, opOptions), key);
       return;
     }
 
@@ -676,7 +676,7 @@ RestStatus RestDocumentHandler::readManyDocuments() {
   Result res = _activeTrx->begin();
 
   if (!res.ok()) {
-    generateTransactionError(cname, res, "");
+    generateTransactionError(cname, OperationResult(res, opOptions), "");
     return RestStatus::DONE;
   }
 
@@ -696,7 +696,7 @@ RestStatus RestDocumentHandler::readManyDocuments() {
     }
 
     if (!res.ok()) {
-      generateTransactionError(cname, res, "");
+      generateTransactionError(cname, OperationResult(res, opOptions), "");
       return;
     }
 

--- a/arangod/RestHandler/RestGraphHandler.cpp
+++ b/arangod/RestHandler/RestGraphHandler.cpp
@@ -681,7 +681,8 @@ Result RestGraphHandler::modifyEdgeDefinition(graph::Graph& graph, EdgeDefinitio
   // simon: why is this part of el-cheapo ??
   auto ctx = createTransactionContext(AccessMode::Type::WRITE);
   GraphOperations gops{graph, _vocbase, ctx};
-  OperationResult result;
+  OperationOptions options(_context);
+  OperationResult result(Result(), options);
 
   if (action == EdgeDefinitionAction::CREATE) {
     result = gops.addEdgeDefinition(body, waitForSync);
@@ -730,7 +731,8 @@ Result RestGraphHandler::modifyVertexDefinition(graph::Graph& graph,
 
   auto ctx = createTransactionContext(AccessMode::Type::WRITE);
   GraphOperations gops{graph, _vocbase, ctx};
-  OperationResult result;
+  OperationOptions options(_context);
+  OperationResult result(Result(), options);
 
   if (action == VertexDefinitionAction::CREATE) {
     result = gops.addOrphanCollection(body, waitForSync, createCollection);
@@ -789,7 +791,8 @@ Result RestGraphHandler::documentModify(graph::Graph& graph, const std::string& 
   auto ctx = createTransactionContext(AccessMode::Type::WRITE);
   GraphOperations gops{graph, _vocbase, ctx};
 
-  OperationResult result;
+  OperationOptions options(_context);
+  OperationResult result(Result(), options);
   // TODO get rid of this branching, rather use several functions and reuse the
   // common code another way.
   if (isPatch && colType == TRI_COL_TYPE_DOCUMENT) {
@@ -849,7 +852,8 @@ Result RestGraphHandler::documentCreate(graph::Graph& graph, std::string const& 
   auto ctx = createTransactionContext(AccessMode::Type::WRITE);
   GraphOperations gops{graph, _vocbase, ctx};
 
-  OperationResult result;
+  OperationOptions options(_context);
+  OperationResult result(Result(), options);
   if (colType == TRI_COL_TYPE_DOCUMENT) {
     result = gops.createVertex(collectionName, body, waitForSync, returnNew);
   } else if (colType == TRI_COL_TYPE_EDGE) {

--- a/arangod/RestHandler/RestImportHandler.cpp
+++ b/arangod/RestHandler/RestImportHandler.cpp
@@ -345,14 +345,15 @@ bool RestImportHandler::createFromJson(std::string const& type) {
   Result res = trx.begin();
 
   if (res.fail()) {
-    generateTransactionError(collectionName, res, "");
+    generateTransactionError(collectionName, OperationResult(res, opOptions),
+                             "");
     return false;
   }
 
   bool const isEdgeCollection = trx.isEdgeCollection(collectionName);
 
   if (overwrite) {
-    OperationOptions truncateOpts;
+    OperationOptions truncateOpts(_context);
     truncateOpts.waitForSync = false;
     // truncate collection first
     trx.truncate(collectionName, truncateOpts);
@@ -493,7 +494,8 @@ bool RestImportHandler::createFromJson(std::string const& type) {
   res = trx.finish(res);
 
   if (res.fail()) {
-    generateTransactionError(collectionName, res, "");
+    generateTransactionError(collectionName, OperationResult(res, opOptions),
+                             "");
   } else {
     generateDocumentsCreated(result);
   }
@@ -542,7 +544,8 @@ bool RestImportHandler::createFromVPack(std::string const& type) {
   Result res = trx.begin();
 
   if (res.fail()) {
-    generateTransactionError(collectionName, res, "");
+    generateTransactionError(collectionName, OperationResult(res, opOptions),
+                             "");
 
     return false;
   }
@@ -597,7 +600,8 @@ bool RestImportHandler::createFromVPack(std::string const& type) {
   res = trx.finish(res);
 
   if (res.fail()) {
-    generateTransactionError(collectionName, res, "");
+    generateTransactionError(collectionName, OperationResult(res, opOptions),
+                             "");
   } else {
     generateDocumentsCreated(result);
   }
@@ -627,7 +631,7 @@ bool RestImportHandler::createFromKeyValueList() {
   bool const complete = _request->parsedValue("complete", false);
   bool const overwrite = _request->parsedValue("overwrite", false);
   _ignoreMissing = _request->parsedValue("ignoreMissing", false);
-  OperationOptions opOptions;
+  OperationOptions opOptions(_context);
   opOptions.waitForSync = _request->parsedValue("waitForSync", false);
 
   // extract the collection name
@@ -720,14 +724,15 @@ bool RestImportHandler::createFromKeyValueList() {
   Result res = trx.begin();
 
   if (res.fail()) {
-    generateTransactionError(collectionName, res, "");
+    generateTransactionError(collectionName, OperationResult(res, opOptions),
+                             "");
     return false;
   }
 
   bool const isEdgeCollection = trx.isEdgeCollection(collectionName);
 
   if (overwrite) {
-    OperationOptions truncateOpts;
+    OperationOptions truncateOpts(_context);
     truncateOpts.waitForSync = false;
     // truncate collection first
     trx.truncate(collectionName, truncateOpts);
@@ -822,7 +827,8 @@ bool RestImportHandler::createFromKeyValueList() {
   res = trx.finish(res);
 
   if (res.fail()) {
-    generateTransactionError(collectionName, res, "");
+    generateTransactionError(collectionName, OperationResult(res, opOptions),
+                             "");
   } else {
     generateDocumentsCreated(result);
   }
@@ -1023,7 +1029,7 @@ bool RestImportHandler::checkKeys(VPackSlice const& keys) const {
 }
 
 OperationOptions RestImportHandler::buildOperationOptions() const {
-  OperationOptions opOptions;
+  OperationOptions opOptions(_context);
 
   opOptions.waitForSync = _request->parsedValue(StaticStrings::WaitForSyncString, false);
   opOptions.validate = !_request->parsedValue(StaticStrings::SkipDocumentValidation, false);

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1727,15 +1727,14 @@ Result RestReplicationHandler::processRestoreDataBatch(transaction::Methods& trx
   }
 
   VPackSlice requestSlice = builder.slice();
-  OperationResult opRes;
+  OperationOptions options(_context);
+  options.silent = false;
+  options.ignoreRevs = true;
+  options.isRestore = true;
+  options.waitForSync = false;
+  options.overwriteMode = OperationOptions::OverwriteMode::Replace;
+  OperationResult opRes(Result(), options);
   try {
-    OperationOptions options;
-    options.silent = false;
-    options.ignoreRevs = true;
-    options.isRestore = true;
-    options.waitForSync = false;
-    options.overwriteMode = OperationOptions::OverwriteMode::Replace;
-    
     double startTime = TRI_microtime();
     opRes = trx.insert(collectionName, requestSlice, options);
     double duration = TRI_microtime() - startTime;
@@ -1801,7 +1800,7 @@ Result RestReplicationHandler::processRestoreDataBatch(transaction::Methods& trx
   }
 
   try {
-    OperationOptions options;
+    OperationOptions options(_context);
     options.silent = true;
     options.ignoreRevs = true;
     options.isRestore = true;
@@ -2470,7 +2469,8 @@ void RestReplicationHandler::handleCommandAddFollower() {
     auto res = trx.begin();
 
     if (res.ok()) {
-      auto countRes = trx.count(col->name(), transaction::CountType::Normal);
+      OperationOptions options(_context);
+      auto countRes = trx.count(col->name(), transaction::CountType::Normal, options);
 
       if (countRes.ok()) {
         VPackSlice nrSlice = countRes.slice();

--- a/arangod/RestHandler/RestVocbaseBaseHandler.cpp
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.cpp
@@ -498,8 +498,8 @@ void RestVocbaseBaseHandler::generateTransactionError(std::string const& collect
       } else {
         // This case happens if we call this method directly with a dummy
         // OperationResult:
-        
-        OperationResult tmp(result.result);
+
+        OperationResult tmp(result.result, result.options);
         tmp.buffer = std::make_shared<VPackBufferUInt8>();
         VPackBuilder builder(tmp.buffer);
         builder.openObject();

--- a/arangod/RestHandler/RestVocbaseBaseHandler.h
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.h
@@ -200,13 +200,6 @@ class RestVocbaseBaseHandler : public RestBaseHandler {
                                 std::string const& key = "",
                                 RevisionId rid = RevisionId::none());
 
-  /// @brief generate an error message for a transaction error
-  void generateTransactionError(std::string const& collectionName,
-                                Result const& res, std::string const& key,
-                                RevisionId rid = RevisionId::none()) {
-    generateTransactionError(collectionName, OperationResult(res), key, rid);
-  }
-  
   /// @brief extracts the revision. "header" must be lowercase.
   RevisionId extractRevision(char const* header, bool& isValid) const;
 

--- a/arangod/StorageEngine/PhysicalCollection.cpp
+++ b/arangod/StorageEngine/PhysicalCollection.cpp
@@ -582,7 +582,8 @@ void PhysicalCollection::getIndexesVPack(VPackBuilder& result,
 }
 
 /// @brief return the figures for a collection
-futures::Future<OperationResult> PhysicalCollection::figures(bool details) {
+futures::Future<OperationResult> PhysicalCollection::figures(bool details,
+                                                             OperationOptions const& options) {
   auto buffer = std::make_shared<VPackBufferUInt8>();
   VPackBuilder builder(buffer);
   
@@ -615,7 +616,7 @@ futures::Future<OperationResult> PhysicalCollection::figures(bool details) {
   // add engine-specific figures
   figuresSpecific(details, builder);
   builder.close();
-  return OperationResult(Result(), std::move(buffer));
+  return OperationResult(Result(), std::move(buffer), options);
 }
 
 std::unique_ptr<ReplicationIterator> PhysicalCollection::getReplicationIterator(

--- a/arangod/StorageEngine/PhysicalCollection.h
+++ b/arangod/StorageEngine/PhysicalCollection.h
@@ -122,7 +122,8 @@ class PhysicalCollection {
                        std::function<bool(arangodb::Index const*, std::underlying_type<Index::Serialize>::type&)> const& filter) const;
 
   /// @brief return the figures for a collection
-  virtual futures::Future<OperationResult> figures(bool details);
+  virtual futures::Future<OperationResult> figures(bool details,
+                                                   OperationOptions const& options);
 
   /// @brief create or restore an index
   /// @param restore utilize specified ID, assume index has to be created

--- a/arangod/Transaction/Helpers.cpp
+++ b/arangod/Transaction/Helpers.cpp
@@ -350,6 +350,7 @@ velocypack::StringRef transaction::helpers::extractCollectionFromId(velocypack::
 }
 
 OperationResult transaction::helpers::buildCountResult(
+    OperationOptions const& options,
     std::vector<std::pair<std::string, uint64_t>> const& count,
     transaction::CountType type, uint64_t& total) {
   total = 0;
@@ -370,7 +371,7 @@ OperationResult transaction::helpers::buildCountResult(
     }
     resultBuilder.add(VPackValue(result));
   }
-  return OperationResult(Result(), resultBuilder.steal());
+  return OperationResult(Result(), resultBuilder.steal(), options);
 }
 
 /// @brief creates an id string from a custom _id value and the _key string

--- a/arangod/Transaction/Helpers.h
+++ b/arangod/Transaction/Helpers.h
@@ -92,7 +92,8 @@ velocypack::StringRef extractCollectionFromId(velocypack::StringRef id);
 RevisionId extractRevFromDocument(VPackSlice slice);
 VPackSlice extractRevSliceFromDocument(VPackSlice slice);
 
-OperationResult buildCountResult(std::vector<std::pair<std::string, uint64_t>> const& count,
+OperationResult buildCountResult(OperationOptions const& options,
+                                 std::vector<std::pair<std::string, uint64_t>> const& count,
                                  transaction::CountType type, uint64_t& total);
 
 /// @brief creates an id string from a custom _id value and the _key string

--- a/arangod/Transaction/Methods.h
+++ b/arangod/Transaction/Methods.h
@@ -221,7 +221,8 @@ class Methods {
   /// @brief read many documents, using skip and limit in arbitrary order
   /// The result guarantees that all documents are contained exactly once
   /// as long as the collection is not modified.
-  ENTERPRISE_VIRT OperationResult any(std::string const& collectionName);
+  ENTERPRISE_VIRT OperationResult any(std::string const& collectionName,
+                                      OperationOptions const& options);
 
   /// @brief add a collection to the transaction for read, at runtime
   DataSourceId addCollectionAtRuntime(DataSourceId cid, std::string const& collectionName,
@@ -335,13 +336,15 @@ class Methods {
                                         OperationOptions const& options);
 
   /// deprecated, use async variant
-  virtual OperationResult count(std::string const& collectionName, CountType type) {
-    return countAsync(collectionName, type).get();
+  virtual OperationResult count(std::string const& collectionName,
+                                CountType type, OperationOptions const& options) {
+    return countAsync(collectionName, type, options).get();
   }
 
   /// @brief count the number of documents in a collection
   virtual futures::Future<OperationResult> countAsync(std::string const& collectionName,
-                                                      CountType type);
+                                                      CountType type,
+                                                      OperationOptions const& options);
 
   /// @brief factory for IndexIterator objects from AQL
   /// note: the caller must have read-locked the underlying collection when
@@ -436,9 +439,10 @@ class Methods {
   OperationResult allLocal(std::string const& collectionName, uint64_t skip,
                            uint64_t limit, OperationOptions& options);
 
-  OperationResult anyCoordinator(std::string const& collectionName);
+  OperationResult anyCoordinator(std::string const& collectionName,
+                                 OperationOptions const& options);
 
-  OperationResult anyLocal(std::string const& collectionName);
+  OperationResult anyLocal(std::string const& collectionName, OperationOptions const& options);
 
   Future<OperationResult> truncateCoordinator(std::string const& collectionName,
                                               OperationOptions& options);
@@ -455,13 +459,15 @@ class Methods {
       std::string const& name, AccessMode::Type type = AccessMode::Type::READ) const;
 
   futures::Future<OperationResult> countCoordinator(std::string const& collectionName,
-                                                    CountType type);
+                                                    CountType type,
+                                                    OperationOptions const& options);
 
   futures::Future<OperationResult> countCoordinatorHelper(
-      std::shared_ptr<LogicalCollection> const& collinfo,
-      std::string const& collectionName, CountType type);
+      std::shared_ptr<LogicalCollection> const& collinfo, std::string const& collectionName,
+      CountType type, OperationOptions const& options);
 
-  OperationResult countLocal(std::string const& collectionName, CountType type);
+  OperationResult countLocal(std::string const& collectionName, CountType type,
+                             OperationOptions const& options);
 
   /// @brief add a collection by id, with the name supplied
   Result addCollection(DataSourceId, std::string const&, AccessMode::Type);

--- a/arangod/Utils/Events.cpp
+++ b/arangod/Utils/Events.cpp
@@ -35,7 +35,8 @@ void NotAuthorized(GeneralRequest const&) {}
 void CreateCollection(std::string const& db, std::string const& name, int result) {}
 void DropCollection(std::string const& db, std::string const& name, int result) {}
 void PropertyUpdateCollection(std::string const& db, std::string const& collectionName, VPackSlice const& propertiesSlice) {}
-void TruncateCollection(std::string const& db, std::string const& name, int result) {}
+void TruncateCollection(std::string const& db, std::string const& name,
+                        OperationResult const& result) {}
 void CreateDatabase(std::string const& name, int result) {}
 void DropDatabase(std::string const& name, int result) {}
 void CreateIndex(std::string const& db, std::string const& col,

--- a/arangod/Utils/Events.h
+++ b/arangod/Utils/Events.h
@@ -49,7 +49,8 @@ void NotAuthorized(GeneralRequest const&);
 void CreateCollection(std::string const& db, std::string const& name, int result);
 void DropCollection(std::string const& db, std::string const& name, int result);
 void PropertyUpdateCollection(std::string const& db, std::string const& collectionName, VPackSlice const& propertiesSlice);
-void TruncateCollection(std::string const& db, std::string const& name, int result);
+void TruncateCollection(std::string const& db, std::string const& name,
+                        OperationResult const& result);
 void CreateDatabase(std::string const& name, int result);
 void DropDatabase(std::string const& name, int result);
 void CreateIndex(std::string const& db, std::string const& col, VPackSlice const&, int result);

--- a/arangod/Utils/OperationResult.h
+++ b/arangod/Utils/OperationResult.h
@@ -39,13 +39,9 @@
 namespace arangodb {
 
 struct OperationResult final {
-  OperationResult() {}
-
   // create from Result
-  explicit OperationResult(Result const& other) : result(other) {}
   explicit OperationResult(Result const& other, OperationOptions const& options)
       : result(other), options(options) {}
-  explicit OperationResult(Result&& other) : result(std::move(other)) {}
   explicit OperationResult(Result&& other, OperationOptions const& options)
       : result(std::move(other)), options(options) {}
 
@@ -67,7 +63,7 @@ struct OperationResult final {
 
   // create result with details
   OperationResult(Result result, std::shared_ptr<VPackBuffer<uint8_t>> buffer,
-                  OperationOptions options = {},
+                  OperationOptions options,
                   std::unordered_map<int, size_t> countErrorCodes = std::unordered_map<int, size_t>())
       : result(std::move(result)),
         buffer(std::move(buffer)),

--- a/arangod/V8Server/v8-collection.cpp
+++ b/arangod/V8Server/v8-collection.cpp
@@ -968,7 +968,8 @@ static void JS_FiguresVocbaseCol(v8::FunctionCallbackInfo<v8::Value> const& args
     TRI_V8_THROW_EXCEPTION(res);
   }
 
-  auto opRes = collection->figures(details).get();
+  OperationOptions options(ExecContext::current());
+  auto opRes = collection->figures(details, options).get();
 
   trx.finish(TRI_ERROR_NO_ERROR);
 
@@ -1463,12 +1464,9 @@ static void ModifyVocbaseCol(TRI_voc_document_operation_e operation,
     TRI_V8_THROW_EXCEPTION(res);
   }
 
-  OperationResult opResult;
-  if (operation == TRI_VOC_DOCUMENT_OPERATION_REPLACE) {
-    opResult = trx.replace(collectionName, update, options);
-  } else {
-    opResult = trx.update(collectionName, update, options);
-  }
+  OperationResult opResult = (operation == TRI_VOC_DOCUMENT_OPERATION_REPLACE)
+                                 ? trx.replace(collectionName, update, options)
+                                 : trx.update(collectionName, update, options);
   res = trx.finish(opResult.result);
 
   if (!res.ok()) {
@@ -1579,12 +1577,9 @@ static void ModifyVocbase(TRI_voc_document_operation_e operation,
 
   VPackSlice const update = updateBuilder.slice();
 
-  OperationResult opResult;
-  if (operation == TRI_VOC_DOCUMENT_OPERATION_REPLACE) {
-    opResult = trx.replace(collectionName, update, options);
-  } else {
-    opResult = trx.update(collectionName, update, options);
-  }
+  OperationResult opResult = (operation == TRI_VOC_DOCUMENT_OPERATION_REPLACE)
+                                 ? trx.replace(collectionName, update, options)
+                                 : trx.update(collectionName, update, options);
 
   res = trx.finish(opResult.result);
 
@@ -1824,7 +1819,8 @@ static void JS_RevisionVocbaseCol(v8::FunctionCallbackInfo<v8::Value> const& arg
   // shared_ptr here
   std::shared_ptr<LogicalCollection> coll(collection, NonDeleter());
   methods::Collections::Context ctxt(coll);
-  auto res = methods::Collections::revisionId(ctxt).get();
+  OperationOptions options(ExecContext::current());
+  auto res = methods::Collections::revisionId(ctxt, options).get();
 
   if (res.fail()) {
     TRI_V8_THROW_EXCEPTION(res.result);
@@ -2498,9 +2494,11 @@ static void JS_CountVocbaseCol(v8::FunctionCallbackInfo<v8::Value> const& args) 
     TRI_V8_THROW_EXCEPTION(res);
   }
 
-  OperationResult opResult =
-      trx.count(collectionName, details ? transaction::CountType::Detailed
-                                        : transaction::CountType::Normal);
+  OperationOptions options(ExecContext::current());
+  OperationResult opResult = trx.count(collectionName,
+                                       details ? transaction::CountType::Detailed
+                                               : transaction::CountType::Normal,
+                                       options);
   res = trx.finish(opResult.result);
 
   if (res.fail()) {

--- a/arangod/V8Server/v8-general-graph.cpp
+++ b/arangod/V8Server/v8-general-graph.cpp
@@ -181,7 +181,7 @@ static void JS_GetGraphs(v8::FunctionCallbackInfo<v8::Value> const& args) {
 
   GraphManager gmngr{vocbase};
   VPackBuilder result;
-  OperationResult r = gmngr.readGraphs(result);
+  Result r = gmngr.readGraphs(result);
 
   if (r.fail()) {
     TRI_V8_THROW_EXCEPTION_MESSAGE(r.errorNumber(), r.errorMessage());
@@ -204,7 +204,7 @@ static void JS_GetGraphKeys(v8::FunctionCallbackInfo<v8::Value> const& args) {
 
   GraphManager gmngr{vocbase};
   VPackBuilder result;
-  OperationResult r = gmngr.readGraphKeys(result);
+  Result r = gmngr.readGraphKeys(result);
 
   if (r.fail()) {
     TRI_V8_THROW_EXCEPTION_MESSAGE(r.errorNumber(), r.errorMessage());

--- a/arangod/V8Server/v8-query.cpp
+++ b/arangod/V8Server/v8-query.cpp
@@ -277,7 +277,8 @@ static void JS_AnyQuery(v8::FunctionCallbackInfo<v8::Value> const& args) {
     TRI_V8_THROW_EXCEPTION(res);
   }
 
-  OperationResult cursor = trx.any(collectionName);
+  OperationOptions options(ExecContext::current());
+  OperationResult cursor = trx.any(collectionName, options);
 
   res = trx.finish(cursor.result);
 

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -976,8 +976,9 @@ arangodb::Result LogicalCollection::properties(velocypack::Slice const& slice, b
 }
 
 /// @brief return the figures for a collection
-futures::Future<OperationResult> LogicalCollection::figures(bool details) const {
-  return getPhysical()->figures(details);
+futures::Future<OperationResult> LogicalCollection::figures(bool details,
+                                                            OperationOptions const& options) const {
+  return getPhysical()->figures(details, options);
 }
 
 /// SECTION Indexes

--- a/arangod/VocBase/LogicalCollection.h
+++ b/arangod/VocBase/LogicalCollection.h
@@ -242,7 +242,8 @@ class LogicalCollection : public LogicalDataSource {
   virtual arangodb::Result properties(velocypack::Slice const& slice, bool partialUpdate) override;
 
   /// @brief return the figures for a collection
-  virtual futures::Future<OperationResult> figures(bool details) const;
+  virtual futures::Future<OperationResult> figures(bool details,
+                                                   OperationOptions const& options) const;
 
   /// @brief closes an open collection
   int close();

--- a/arangod/VocBase/Methods/AqlUserFunctions.cpp
+++ b/arangod/VocBase/Methods/AqlUserFunctions.cpp
@@ -300,8 +300,8 @@ Result arangodb::registerUserFunction(TRI_vocbase_t& vocbase, velocypack::Slice 
       return res;
     }
 
-    arangodb::OperationResult result;
-    result = trx.insert(collectionName, oneFunctionDocument.slice(), opOptions);
+    arangodb::OperationResult result =
+        trx.insert(collectionName, oneFunctionDocument.slice(), opOptions);
 
     if (result.ok()) {
       VPackSlice oldSlice = result.slice().get(StaticStrings::Old);

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -892,7 +892,8 @@ futures::Future<Result> Collections::warmup(TRI_vocbase_t& vocbase,
   if (ServerState::instance()->isCoordinator()) {
     auto cid = std::to_string(coll.id().id());
     auto& feature = vocbase.server().getFeature<ClusterFeature>();
-    return warmupOnCoordinator(feature, vocbase.name(), cid);
+    OperationOptions options(exec);
+    return warmupOnCoordinator(feature, vocbase.name(), cid, options);
   }
 
   auto ctx = transaction::V8Context::CreateWhenRequired(vocbase, false);
@@ -949,12 +950,13 @@ futures::Future<Result> Collections::upgrade(TRI_vocbase_t& vocbase,
   return futures::makeFuture(res);
 }
 
-futures::Future<OperationResult> Collections::revisionId(Context& ctxt) {
+futures::Future<OperationResult> Collections::revisionId(Context& ctxt,
+                                                         OperationOptions const& options) {
   if (ServerState::instance()->isCoordinator()) {
     auto& databaseName = ctxt.coll()->vocbase().name();
     auto cid = std::to_string(ctxt.coll()->id().id());
     auto& feature = ctxt.coll()->vocbase().server().getFeature<ClusterFeature>();
-    return revisionOnCoordinator(feature, databaseName, cid);
+    return revisionOnCoordinator(feature, databaseName, cid, options);
   }
 
   RevisionId rid = ctxt.coll()->revision(ctxt.trx(AccessMode::Type::READ, true, true));
@@ -962,7 +964,7 @@ futures::Future<OperationResult> Collections::revisionId(Context& ctxt) {
   VPackBuilder builder;
   builder.add(VPackValue(rid.toString()));
 
-  return futures::makeFuture(OperationResult(Result(), builder.steal()));
+  return futures::makeFuture(OperationResult(Result(), builder.steal(), options));
 }
 
 /// @brief Helper implementation similar to ArangoCollection.all() in v8

--- a/arangod/VocBase/Methods/Collections.h
+++ b/arangod/VocBase/Methods/Collections.h
@@ -129,7 +129,8 @@ struct Collections {
   static futures::Future<Result> upgrade(TRI_vocbase_t& vocbase,
                                          LogicalCollection const& coll);
 
-  static futures::Future<OperationResult> revisionId(Context& ctxt);
+  static futures::Future<OperationResult> revisionId(Context& ctxt,
+                                                     OperationOptions const& options);
 
   typedef std::function<void(velocypack::Slice const&)> DocCallback;
   /// @brief Helper implementation similar to ArangoCollection.all() in v8


### PR DESCRIPTION
### Scope & Purpose

Fix mistaken "internal" audit logging for truncate operation

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required
- [ ] Backports required for:

Enterprise component: https://github.com/arangodb/enterprise/pull/549

Jenkins: https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/11823/ (blue except unrelated)