### PR TITLE
Fix infinite UI reload

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.7.3 (XXXX-XX-XX)
 -------------------
 
+* Fixed inifinite reload of the login window after logout of an LDAP user.
+
 * Updated rclone to 1.53.0.
 
 * Add attributes `database` and `user` when tracking current and slow AQL

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/loginView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/loginView.js
@@ -85,6 +85,7 @@
               errCallback();
             } else {
               // existing jwt login is not valid anymore => reload
+              arangoHelper.setCurrentJwt(null, null);
               location.reload(true);
             }
           }


### PR DESCRIPTION
### Scope & Purpose

Whenever an LDAP user was logged out due to a failed LDAP search, the UI kept infinitely reloading the login window. Another login was only possible with a new browser-tab. This pull request changes the behavior, such that the user is entirely logged out when the jwt login is not valid anymore and a subsequent login can be performed in the same browser-tab. 

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required
- [ ] Backports required for: 

#### Related Information

*(Please reference tickets / specification etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added **Regression Tests**
  - [ ] Added new C++ **Unit Tests**
  - [ ] Added new **integration tests** (i.e. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)

Additionally:

- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

*(Include link to Jenkins run etc)*

### Documentation

> All new Features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the changelog so that
> developers and users have a concise overview. 

- [x] Added a *Changelog Entry* (referencing the corresponding public or internal issue number)
- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
