### PR TITLE
Expose request metrics

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,21 @@
 v3.6.7 (XXXX-XX-XX)
 -------------------
 
+* Exposed the following metrics via the `/_admin/metrics` endpoint:
+
+  - arangodb_http_request_statistics_total_requests: Total number of HTTP requests
+  - arangodb_http_request_statistics_async_requests: Number of asynchronously executed HTTP requests
+  - arangodb_http_request_statistics_http_delete_requests: Number of HTTP DELETE requests
+  - arangodb_http_request_statistics_http_get_requests: Number of HTTP GET requests
+  - arangodb_http_request_statistics_http_head_requests: Number of HTTP HEAD requests
+  - arangodb_http_request_statistics_http_options_requests: Number of HTTP OPTIONS requests
+  - arangodb_http_request_statistics_http_patch_requests: Number of HTTP PATCH requests
+  - arangodb_http_request_statistics_http_post_requests: Number of HTTP POST requests
+  - arangodb_http_request_statistics_http_put_requests: Number of HTTP PUT requests
+  - arangodb_http_request_statistics_other_http_requests: Number of other HTTP requests
+  - arangodb_server_statistics_server_uptime: Number of seconds elapsed since server start
+  - arangodb_server_statistics_physical_memory: Physical memory in bytes
+
 * Added startup option `--query.max-runtime` to limit the maximum runtime of all
   AQL queries to a specified threshold value (in seconds). By default, the
   threshold is 0, meaning that the runtime of AQL queries is not limited.


### PR DESCRIPTION
### Scope & Purpose

Exposes the following metrics via the `/_admin/metrics` endpoint:

  - arangodb_http_request_statistics_total_requests: Total number of HTTP requests
  - arangodb_http_request_statistics_async_requests: Number of asynchronously executed HTTP requests
  - arangodb_http_request_statistics_http_delete_requests: Number of HTTP DELETE requests
  - arangodb_http_request_statistics_http_get_requests: Number of HTTP GET requests
  - arangodb_http_request_statistics_http_head_requests: Number of HTTP HEAD requests
  - arangodb_http_request_statistics_http_options_requests: Number of HTTP OPTIONS requests
  - arangodb_http_request_statistics_http_patch_requests: Number of HTTP PATCH requests
  - arangodb_http_request_statistics_http_post_requests: Number of HTTP POST requests
  - arangodb_http_request_statistics_http_put_requests: Number of HTTP PUT requests
  - arangodb_http_request_statistics_other_http_requests: Number of other HTTP requests
  - arangodb_server_statistics_server_uptime: Number of seconds elapsed since server start
  - arangodb_server_statistics_physical_memory: Physical memory in bytes

These metrics are all present in ArangoDB 3.7 and later, but they may be useful for 3.6, too.

- [ ] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11844/