### PR TITLE
more metrics

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,18 @@
 devel
 -----
 
+* Added replication metrics `arangodb_replication_initial_sync_bytes_received`
+  for the number of bytes received during replication initial sync operations
+  and `arangodb_replication_tailing_bytes_received` for the number of bytes
+  received for replication tailing requests.
+  Also added `arangodb_replication_failed_connects` to track the number of
+  connection failures or non-OK response during replication.
+
+* Added metrics `rocksdb_free_inodes` and `rocksdb_total_inodes` to track the
+  number of free inodes and the total/maximum number of inodes for the file
+  system the RocksDB database directory is located in. These metrics will 
+  always be 0 on Windows.
+
 * Fixed inifinite reload of the login window after logout of an LDAP user.
 
 * Added startup option `--query.max-runtime` to limit the maximum runtime of

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -956,6 +956,8 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
   if (!_config.isChild()) {
     batchExtend();
   }
+  
+  ReplicationMetricsFeature::InitialSyncStats stats(coll->vocbase().server().getFeature<ReplicationMetricsFeature>(), true);
 
   std::string const baseUrl = replutils::ReplicationUrl + "/keys";
   std::string url = baseUrl + "?collection=" + urlEncode(leaderColl) +
@@ -979,8 +981,10 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
   _config.connection.lease([&](httpclient::SimpleHttpClient* client) {
     response.reset(client->retryRequest(rest::RequestType::POST, url, nullptr, 0, headers));
   });
+  ++stats.numKeysRequests;
 
   if (replutils::hasFailed(response.get())) {
+    ++stats.numFailedConnects;
     return replutils::buildHttpError(response.get(), url, _config.connection);
   }
 
@@ -988,6 +992,7 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
   std::string jobId = response->getHeaderField(StaticStrings::AsyncId, found);
 
   if (!found) {
+    ++stats.numFailedConnects;
     return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                   std::string("got invalid response from leader at ") +
                       _config.leader.endpoint + url +
@@ -1005,23 +1010,30 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
     _config.connection.lease([&](httpclient::SimpleHttpClient* client) {
       response.reset(client->request(rest::RequestType::PUT, jobUrl, nullptr, 0));
     });
+    
+    double waitTime = TRI_microtime() - startTime;
 
     if (response != nullptr && response->isComplete()) {
-      if (response->hasHeaderField("x-arango-async-id")) {
+      if (response->hasContentLength()) {
+        stats.numSyncBytesReceived += response->getContentLength();
+      }
+      if (response->hasHeaderField(StaticStrings::AsyncId)) {
         // job is done, got the actual response
         break;
       }
       if (response->getHttpReturnCode() == 404) {
         // unknown job, we can abort
+        ++stats.numFailedConnects;
+        stats.waitedForInitial += waitTime;
         return Result(TRI_ERROR_REPLICATION_NO_RESPONSE,
                       std::string("job not found on leader at ") +
                           _config.leader.endpoint);
       }
     }
 
-    double waitTime = TRI_microtime() - startTime;
-
     if (static_cast<uint64_t>(waitTime * 1000.0 * 1000.0) >= _config.applier._initialSyncMaxWaitTime) {
+      ++stats.numFailedConnects;
+      stats.waitedForInitial += waitTime;
       return Result(TRI_ERROR_REPLICATION_NO_RESPONSE,
                     std::string(
                         "timed out waiting for response from leader at ") +
@@ -1029,14 +1041,18 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
     }
 
     if (isAborted()) {
+      stats.waitedForInitial += waitTime;
       return Result(TRI_ERROR_REPLICATION_APPLIER_STOPPED);
     }
 
     std::chrono::milliseconds sleepTime = ::sleepTimeFromWaitTime(waitTime);
     std::this_thread::sleep_for(sleepTime);
   }
+  
+  stats.waitedForInitial += TRI_microtime() - startTime;
 
   if (replutils::hasFailed(response.get())) {
+    ++stats.numFailedConnects;
     return replutils::buildHttpError(response.get(), url, _config.connection);
   }
 
@@ -1044,6 +1060,7 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
   Result r = replutils::parseResponse(builder, response.get());
 
   if (r.fail()) {
+    ++stats.numFailedConnects;
     return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                   std::string("got invalid response from leader at ") +
                       _config.leader.endpoint + url + ": " + r.errorMessage());
@@ -1051,6 +1068,7 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
 
   VPackSlice const slice = builder.slice();
   if (!slice.isObject()) {
+    ++stats.numFailedConnects;
     return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                   std::string("got invalid response from leader at ") +
                       _config.leader.endpoint + url + ": response is no object");
@@ -1059,6 +1077,7 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
   VPackSlice const keysId = slice.get("id");
 
   if (!keysId.isString()) {
+    ++stats.numFailedConnects;
     return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                   std::string("got invalid response from leader at ") +
                       _config.leader.endpoint + url +
@@ -1084,6 +1103,7 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
   VPackSlice const count = slice.get("count");
 
   if (!count.isNumber()) {
+    ++stats.numFailedConnects;
     return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                   std::string("got invalid response from leader at ") +
                       _config.leader.endpoint + url +
@@ -1180,17 +1200,24 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(arangodb::LogicalCo
         // collection on leader doesn't support revisions-based protocol, fallback
         return fetchCollectionSyncByKeys(coll, leaderColl, maxTick);
       }
+      stats.numFailedConnects++;
       return replutils::buildHttpError(response.get(), url, _config.connection);
+    }
+
+    if (response->hasContentLength()) {
+      stats.numSyncBytesReceived += response->getContentLength();
     }
 
     auto body = response->getBodyVelocyPack();
     if (!body) {
+      ++stats.numFailedConnects;
       return Result(
           TRI_ERROR_INTERNAL,
           "received improperly formed response when fetching revision tree");
     }
     treeLeader = containers::RevisionTree::deserialize(body->slice());
     if (!treeLeader) {
+      ++stats.numFailedConnects;
       return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                     std::string("got invalid response from leader at ") +
                         _config.leader.endpoint + url +
@@ -1351,12 +1378,18 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(arangodb::LogicalCo
       ++stats.numKeysRequests;
 
       if (replutils::hasFailed(response.get())) {
+        ++stats.numFailedConnects;
         return replutils::buildHttpError(response.get(), batchUrl, _config.connection);
+      }
+    
+      if (response->hasContentLength()) {
+        stats.numSyncBytesReceived += response->getContentLength();
       }
 
       VPackBuilder responseBuilder;
       Result r = replutils::parseResponse(responseBuilder, response.get());
       if (r.fail()) {
+        ++stats.numFailedConnects;
         return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                       std::string("got invalid response from leader at ") +
                           _config.leader.endpoint + batchUrl + ": " + r.errorMessage());
@@ -1364,6 +1397,7 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(arangodb::LogicalCo
 
       VPackSlice const slice = responseBuilder.slice();
       if (!slice.isObject()) {
+        ++stats.numFailedConnects;
         return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                       std::string("got invalid response from leader at ") +
                           _config.leader.endpoint + batchUrl +
@@ -1372,6 +1406,7 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(arangodb::LogicalCo
 
       VPackSlice const resumeSlice = slice.get("resume");
       if (!resumeSlice.isNone() && !resumeSlice.isString()) {
+        ++stats.numFailedConnects;
         return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                       std::string("got invalid response from leader at ") +
                           _config.leader.endpoint + batchUrl +
@@ -1382,6 +1417,7 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(arangodb::LogicalCo
 
       VPackSlice const rangesSlice = slice.get("ranges");
       if (!rangesSlice.isArray()) {
+        ++stats.numFailedConnects;
         return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                       std::string("got invalid response from leader at ") +
                           _config.leader.endpoint + batchUrl +
@@ -1390,6 +1426,7 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(arangodb::LogicalCo
 
       for (VPackSlice leaderSlice : VPackArrayIterator(rangesSlice)) {
         if (!leaderSlice.isArray()) {
+          ++stats.numFailedConnects;
           return Result(
               TRI_ERROR_REPLICATION_INVALID_RESPONSE,
               std::string("got invalid response from leader at ") +
@@ -1510,13 +1547,14 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(arangodb::LogicalCo
   }
 
   setProgress(
-      std::string("incremental sync statistics for collection '") + coll->name() +
-      "': " + "keys requests: " + std::to_string(stats.numKeysRequests) + ", " +
-      "docs requests: " + std::to_string(stats.numDocsRequests) + ", " +
-      "number of documents requested: " + std::to_string(stats.numDocsRequested) +
-      ", " + "number of documents inserted: " + std::to_string(stats.numDocsInserted) +
-      ", " + "number of documents removed: " + std::to_string(stats.numDocsRemoved) +
-      ", " + "waited for initial: " + std::to_string(stats.waitedForInitial) +
+      std::string("incremental tree sync statistics for collection '") + coll->name() +
+      "': keys requests: " + std::to_string(stats.numKeysRequests) + 
+      ", docs requests: " + std::to_string(stats.numDocsRequests) + 
+      ", bytes received: " + std::to_string(stats.numSyncBytesReceived) +
+      ", number of documents requested: " + std::to_string(stats.numDocsRequested) +
+      ", number of documents inserted: " + std::to_string(stats.numDocsInserted) +
+      ", number of documents removed: " + std::to_string(stats.numDocsRemoved) +
+      ", waited for initial: " + std::to_string(stats.waitedForInitial) +
       " s, " + "waited for keys: " + std::to_string(stats.waitedForKeys) +
       " s, " + "waited for docs: " + std::to_string(stats.waitedForDocs) +
       " s, " + "waited for insertions: " + std::to_string(stats.waitedForInsertions) +

--- a/arangod/Replication/ReplicationMetricsFeature.cpp
+++ b/arangod/Replication/ReplicationMetricsFeature.cpp
@@ -65,6 +65,9 @@ ReplicationMetricsFeature::ReplicationMetricsFeature(arangodb::application_featu
       _numSyncDocsRemoved(
         server.getFeature<arangodb::MetricsFeature>().counter(
           "arangodb_replication_initial_sync_docs_removed", 0, "Number of documents removed by replication initial sync")),
+      _numSyncBytesReceived(
+        server.getFeature<arangodb::MetricsFeature>().counter(
+          "arangodb_replication_initial_sync_bytes_received", 0, "Number of bytes received during replication initial sync")),
       _waitedForSyncInitial(
         server.getFeature<arangodb::MetricsFeature>().counter(
           "arangodb_replication_initial_chunks_requests_time", 0,
@@ -107,6 +110,9 @@ ReplicationMetricsFeature::ReplicationMetricsFeature(arangodb::application_featu
       _numTailingBytesReceived(
         server.getFeature<arangodb::MetricsFeature>().counter(
           "arangodb_replication_tailing_bytes_received", 0, "Number of bytes received for replication tailing requests")),
+      _numFailedConnects(
+        server.getFeature<arangodb::MetricsFeature>().counter(
+          "arangodb_replication_failed_connects", 0, "Number of failed connection attempts and response errors during replication")),
       _waitedForTailing(
         server.getFeature<arangodb::MetricsFeature>().counter(
           "arangodb_replication_tailing_request_time", 0,
@@ -138,6 +144,8 @@ void ReplicationMetricsFeature::InitialSyncStats::publish() {
   feature._numSyncDocsRequested += numDocsRequested;
   feature._numSyncDocsInserted += numDocsInserted;
   feature._numSyncDocsRemoved += numDocsRemoved;
+  feature._numSyncBytesReceived += numSyncBytesReceived;
+  feature._numFailedConnects += numFailedConnects;
   feature._waitedForSyncInitial += static_cast<uint64_t>(waitedForInitial * 1000);
   feature._waitedForSyncKeys += static_cast<uint64_t>(waitedForKeys * 1000);
   feature._waitedForSyncDocs += static_cast<uint64_t>(waitedForDocs * 1000);
@@ -160,6 +168,8 @@ void ReplicationMetricsFeature::InitialSyncStats::reset() noexcept {
   numDocsRequested = 0;
   numDocsInserted = 0;
   numDocsRemoved = 0;
+  numSyncBytesReceived = 0;
+  numFailedConnects = 0;
   waitedForInitial = 0.0;
   waitedForKeys = 0.0;
   waitedForDocs = 0.0;
@@ -180,6 +190,8 @@ ReplicationMetricsFeature::InitialSyncStats& ReplicationMetricsFeature::InitialS
   numDocsRequested += other.numDocsRequested;
   numDocsInserted += other.numDocsInserted;
   numDocsRemoved += other.numDocsRemoved;
+  numSyncBytesReceived += other.numSyncBytesReceived;
+  numFailedConnects += other.numFailedConnects;
   waitedForInitial += other.waitedForInitial;
   waitedForKeys += other.waitedForKeys;
   waitedForDocs += other.waitedForDocs;
@@ -204,6 +216,7 @@ void ReplicationMetricsFeature::TailingSyncStats::publish() {
   feature._numTailingProcessedDocuments += numProcessedDocuments;
   feature._numTailingProcessedRemovals += numProcessedRemovals;
   feature._numTailingBytesReceived += numTailingBytesReceived;
+  feature._numFailedConnects += numFailedConnects;
   feature._waitedForTailing += static_cast<uint64_t>(waitedForTailing * 1000);
   feature._waitedForTailingApply += static_cast<uint64_t>(waitedForTailingApply * 1000);
 
@@ -217,6 +230,7 @@ void ReplicationMetricsFeature::TailingSyncStats::reset() noexcept {
   numProcessedDocuments = 0;
   numProcessedRemovals = 0;
   numTailingBytesReceived = 0;
+  numFailedConnects = 0;
   waitedForTailing = 0;
   waitedForTailingApply = 0;
 }
@@ -228,6 +242,7 @@ ReplicationMetricsFeature::TailingSyncStats& ReplicationMetricsFeature::TailingS
   numProcessedDocuments += other.numProcessedDocuments;
   numProcessedRemovals += other.numProcessedRemovals;
   numTailingBytesReceived += other.numTailingBytesReceived;
+  numFailedConnects += other.numFailedConnects;
   waitedForTailing += other.waitedForTailing;
   waitedForTailingApply += other.waitedForTailingApply;
   

--- a/arangod/Replication/ReplicationMetricsFeature.h
+++ b/arangod/Replication/ReplicationMetricsFeature.h
@@ -66,7 +66,6 @@ class ReplicationMetricsFeature final : public application_features::Application
     // total time spent for locally applying dump markers
     double waitedForDumpApply = 0.0;
 
-    
     // total number of requests to /_api/replication/keys?type=keys
     uint64_t numKeysRequests = 0;
     // total number of requests to /_api/replication/keys?type=docs
@@ -77,6 +76,10 @@ class ReplicationMetricsFeature final : public application_features::Application
     uint64_t numDocsInserted = 0;
     // total number of remove operations performed during sync
     uint64_t numDocsRemoved = 0;
+    // total number of bytes received for keys and docs
+    uint64_t numSyncBytesReceived = 0;
+    // total number of failed connection attempts
+    uint64_t numFailedConnects = 0;
     // total time spent waiting on response for initial call to
     // /_api/replication/keys
     double waitedForInitial = 0.0;
@@ -117,6 +120,7 @@ class ReplicationMetricsFeature final : public application_features::Application
     uint64_t numProcessedRemovals = 0;
     // total number of bytes received for tailing requests
     uint64_t numTailingBytesReceived = 0;
+    uint64_t numFailedConnects = 0;
     double waitedForTailing = 0.0;
     double waitedForTailingApply = 0.0;
 
@@ -149,6 +153,8 @@ class ReplicationMetricsFeature final : public application_features::Application
   Counter& _numSyncDocsInserted;
   // total number of remove operations performed during sync
   Counter& _numSyncDocsRemoved;
+  // total number of bytes received for keys and docs requests
+  Counter& _numSyncBytesReceived;
   // total time spent waiting on response for initial call to
   // /_api/replication/keys
   Counter& _waitedForSyncInitial;
@@ -174,6 +180,8 @@ class ReplicationMetricsFeature final : public application_features::Application
   Counter& _numTailingProcessedRemovals;
   // total number of bytes received for tailing requests
   Counter& _numTailingBytesReceived;
+  // total number of failed connection attempts during tailing syncing
+  Counter& _numFailedConnects;
   // total time spent waiting for tail requests
   Counter& _waitedForTailing;
   // total time spent waiting for applying tailing markers

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -1268,6 +1268,7 @@ retry:
 
     if (res.is(TRI_ERROR_REPLICATION_NO_RESPONSE)) {
       // leader error. try again after a sleep period
+      ++_stats.numFailedConnects;
       connectRetries++;
       {
         WRITE_LOCKER_EVENTUAL(writeLocker, _applier->_statusLock);

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2332,7 +2332,7 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
     uint64_t totalSpace = 0;
     // free disk space in database directory
     uint64_t freeSpace = 0;
-    Result res = TRI_GetDiskSpace(_basePath, totalSpace, freeSpace);
+    Result res = TRI_GetDiskSpaceInfo(_basePath, totalSpace, freeSpace);
     if (res.ok()) {
       builder.add("rocksdb.free-disk-space", VPackValue(freeSpace));
       builder.add("rocksdb.total-disk-space", VPackValue(totalSpace));
@@ -2342,6 +2342,20 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
     }
   }
 
+  {
+    // total inodes for database directory
+    uint64_t totalINodes = 0;
+    // free inodes for database directory
+    uint64_t freeINodes = 0;
+    Result res = TRI_GetINodesInfo(_basePath, totalINodes, freeINodes);
+    if (res.ok()) {
+      builder.add("rocksdb.free-inodes", VPackValue(freeINodes));
+      builder.add("rocksdb.total-inodes", VPackValue(totalINodes));
+    } else {
+      builder.add("rocksdb.free-inodes", VPackValue(VPackValueType::Null));
+      builder.add("rocksdb.total-inodes", VPackValue(VPackValueType::Null));
+    }
+  }
 
   builder.close();
 }

--- a/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
+++ b/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
@@ -214,17 +214,23 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
     ++stats.numKeysRequests;
 
     if (replutils::hasFailed(response.get())) {
+      ++stats.numFailedConnects;
       return replutils::buildHttpError(response.get(), url, syncer._state.connection);
     }
   }
 
   TRI_ASSERT(response != nullptr);
 
+  if (response->hasContentLength()) {
+    stats.numSyncBytesReceived += response->getContentLength();
+  }
+
   VPackBuilder builder;
   Result r = replutils::parseResponse(builder, response.get());
   response.reset();  // not needed anymore
 
   if (r.fail()) {
+    ++stats.numFailedConnects;
     return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                   std::string("got invalid response from leader at ") +
                       syncer._state.leader.endpoint + ": " + r.errorMessage());
@@ -232,6 +238,7 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
 
   VPackSlice const responseBody = builder.slice();
   if (!responseBody.isArray()) {
+    ++stats.numFailedConnects;
     return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                   std::string("got invalid response from leader at ") +
                       syncer._state.leader.endpoint + ": response is no array");
@@ -239,6 +246,7 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
 
   size_t const numKeys = static_cast<size_t>(responseBody.length());
   if (numKeys == 0) {
+    ++stats.numFailedConnects;
     return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                   std::string("got invalid response from leader at ") +
                       syncer._state.leader.endpoint +
@@ -257,6 +265,7 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
 
   for (VPackSlice pair : VPackArrayIterator(responseBody)) {
     if (!pair.isArray() || pair.length() != 2) {
+      ++stats.numFailedConnects;
       return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                     std::string("got invalid response from leader at ") +
                         syncer._state.leader.endpoint +
@@ -266,6 +275,7 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
     // key
     VPackSlice const keySlice = pair.at(0);
     if (!keySlice.isString()) {
+      ++stats.numFailedConnects;
       return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                     std::string("got invalid response from leader at ") +
                         syncer._state.leader.endpoint +
@@ -404,17 +414,23 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
       ++stats.numDocsRequests;
 
       if (replutils::hasFailed(response.get())) {
+        ++stats.numFailedConnects;
         return replutils::buildHttpError(response.get(), url, syncer._state.connection);
       }
     }
 
     TRI_ASSERT(response != nullptr);
 
+    if (response->hasContentLength()) {
+      stats.numSyncBytesReceived += response->getContentLength();
+    }
+
     transaction::BuilderLeaser docsBuilder(trx);
     docsBuilder->clear();
     Result r = replutils::parseResponse(*docsBuilder.get(), response.get());
 
     if (r.fail()) {
+      ++stats.numFailedConnects;
       return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                     std::string("got invalid response from leader at ") +
                         syncer._state.leader.endpoint +
@@ -423,6 +439,7 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
 
     VPackSlice const slice = docsBuilder->slice();
     if (!slice.isArray()) {
+      ++stats.numFailedConnects;
       return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                     std::string("got invalid response from leader at ") +
                         syncer._state.leader.endpoint +
@@ -438,6 +455,7 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
       }
 
       if (!it.isObject()) {
+        ++stats.numFailedConnects;
         return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                       std::string("got invalid response from leader at ") +
                           syncer._state.leader.endpoint +
@@ -447,6 +465,7 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
       VPackSlice const keySlice = it.get(StaticStrings::KeyString);
 
       if (!keySlice.isString()) {
+        ++stats.numFailedConnects;
         return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                       std::string("got invalid response from leader at ") +
                           syncer._state.leader.endpoint +
@@ -456,6 +475,7 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
       VPackSlice const revSlice = it.get(StaticStrings::RevString);
 
       if (!revSlice.isString()) {
+        ++stats.numFailedConnects;
         return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                       std::string("got invalid response from leader at ") +
                           syncer._state.leader.endpoint +
@@ -594,16 +614,22 @@ Result handleSyncKeysRocksDB(DatabaseInitialSyncer& syncer,
     stats.waitedForInitial += TRI_microtime() - t;
 
     if (replutils::hasFailed(response.get())) {
+      ++stats.numFailedConnects;
       return replutils::buildHttpError(response.get(), url, syncer._state.connection);
     }
   }
 
   TRI_ASSERT(response != nullptr);
 
+  if (response->hasContentLength()) {
+    stats.numSyncBytesReceived += response->getContentLength();
+  }
+
   VPackBuilder builder;
   Result r = replutils::parseResponse(builder, response.get());
 
   if (r.fail()) {
+    ++stats.numFailedConnects;
     return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                   std::string("got invalid response from leader at ") +
                       syncer._state.leader.endpoint + ": " + r.errorMessage());
@@ -612,6 +638,7 @@ Result handleSyncKeysRocksDB(DatabaseInitialSyncer& syncer,
   VPackSlice const chunkSlice = builder.slice();
 
   if (!chunkSlice.isArray()) {
+    ++stats.numFailedConnects;
     return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                   std::string("got invalid response from leader at ") +
                       syncer._state.leader.endpoint + ": response is no array");
@@ -877,16 +904,17 @@ Result handleSyncKeysRocksDB(DatabaseInitialSyncer& syncer,
   
   syncer.setProgress(
       std::string("incremental sync statistics for collection '") + col->name() +
-      "': " + "keys requests: " + std::to_string(stats.numKeysRequests) + ", " +
-      "docs requests: " + std::to_string(stats.numDocsRequests) + ", " +
-      "number of documents requested: " + std::to_string(stats.numDocsRequested) +
-      ", " + "number of documents inserted: " + std::to_string(stats.numDocsInserted) +
-      ", " + "number of documents removed: " + std::to_string(stats.numDocsRemoved) +
-      ", " + "waited for initial: " + std::to_string(stats.waitedForInitial) +
-      " s, " + "waited for keys: " + std::to_string(stats.waitedForKeys) +
-      " s, " + "waited for docs: " + std::to_string(stats.waitedForDocs) +
-      " s, " + "waited for insertions: " + std::to_string(stats.waitedForInsertions) +
-      " s, " + "total time: " + std::to_string(TRI_microtime() - startTime) +
+      "': keys requests: " + std::to_string(stats.numKeysRequests) +
+      ", docs requests: " + std::to_string(stats.numDocsRequests) +
+      ", bytes received: " + std::to_string(stats.numSyncBytesReceived) +
+      ", number of documents requested: " + std::to_string(stats.numDocsRequested) +
+      ", number of documents inserted: " + std::to_string(stats.numDocsInserted) +
+      ", number of documents removed: " + std::to_string(stats.numDocsRemoved) +
+      ", waited for initial: " + std::to_string(stats.waitedForInitial) +
+      " s, waited for keys: " + std::to_string(stats.waitedForKeys) +
+      " s, waited for docs: " + std::to_string(stats.waitedForDocs) +
+      " s, waited for insertions: " + std::to_string(stats.waitedForInsertions) +
+      " s, total time: " + std::to_string(TRI_microtime() - startTime) +
       " s");
 
   return Result();

--- a/lib/Basics/files.h
+++ b/lib/Basics/files.h
@@ -399,9 +399,15 @@ int TRI_CreateDatafile(std::string const& filename, size_t maximalSize);
 bool TRI_PathIsAbsolute(std::string const& path);
 
 /// @brief return the amount of total and free disk space for the given path
-arangodb::Result TRI_GetDiskSpace(std::string const& path, 
-                                  uint64_t& totalSpace,
-                                  uint64_t& freeSpace);
+arangodb::Result TRI_GetDiskSpaceInfo(std::string const& path, 
+                                      uint64_t& totalSpace,
+                                      uint64_t& freeSpace);
+
+/// @brief return the amount of total and free inodes for the given path.
+/// always returns 0 on Windows!
+arangodb::Result TRI_GetINodesInfo(std::string const& path, 
+                                   uint64_t& totalINodes, 
+                                   uint64_t& freeINodes); 
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief reads an environment variable. returns false if env var was not set.


### PR DESCRIPTION
### Scope & Purpose

* Added replication metrics `arangodb_replication_initial_sync_bytes_received` for the number of bytes received during replication initial sync operations and `arangodb_replication_tailing_bytes_received` for the number of bytes received for replication tailing requests. Also added `arangodb_replication_failed_connects` to track the number of connection failures or non-OK response during replication.
* Added metrics `rocksdb_free_inodes` and `rocksdb_total_inodes` to track the number of free inodes and the total/maximum number of inodes for the file system the RocksDB database directory is located in. These metrics will always be 0 on Windows.

- [ ] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required
- [ ] Backports required for: *(Please specify versions)*

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11861/