### PR TITLE
expose scheduler threads metrics

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,11 @@ v3.6.7 (XXXX-XX-XX)
 
 * Exposed the following metrics via the `/_admin/metrics` endpoint:
 
+  - `arangodb_scheduler_awake_threads`: Number of awake worker threads
+  - `arangodb_scheduler_num_worker_threads`: Number of worker threads
+
+* Exposed the following metrics via the `/_admin/metrics` endpoint:
+
   - arangodb_http_request_statistics_total_requests: Total number of HTTP requests
   - arangodb_http_request_statistics_async_requests: Number of asynchronously executed HTTP requests
   - arangodb_http_request_statistics_http_delete_requests: Number of HTTP DELETE requests

--- a/arangod/Scheduler/SupervisedScheduler.h
+++ b/arangod/Scheduler/SupervisedScheduler.h
@@ -164,6 +164,8 @@ class SupervisedScheduler final : public Scheduler {
   uint64_t const _fifo2Size;
 
   Gauge<uint64_t>& _metricsQueueLength;
+  Gauge<uint64_t>& _metricsAwakeThreads;
+  Gauge<uint64_t>& _metricsNumWorkerThreads;
   Counter& _metricsQueueFull;
 
   std::unique_ptr<WorkItem> getWork(std::shared_ptr<WorkerState>& state);


### PR DESCRIPTION
### Scope & Purpose

Exposed the following metrics via the `/_admin/metrics` endpoint:

- `arangodb_scheduler_awake_threads`: Number of awake worker threads
- `arangodb_scheduler_num_worker_threads`: Number of worker threads

- [ ] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required
- [ ] Backports required for: *(Please specify versions)*

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11862/