### PR TITLE
Remove idle connections

### DIFF
--- a/3rdParty/fuerte/src/GeneralConnection.h
+++ b/3rdParty/fuerte/src/GeneralConnection.h
@@ -48,7 +48,7 @@ class GeneralConnection : public fuerte::Connection {
 
   virtual ~GeneralConnection() noexcept {
     _state.store(Connection::State::Closed);
-    terminateActivity(fuerte::Error::ConnectionClosed);
+    terminateActivity(fuerte::Error::ConnectionCanceled);
   }
 
   /// @brief connection state
@@ -107,11 +107,9 @@ class GeneralConnection : public fuerte::Connection {
   /// @brief cancel the connection, unusable afterwards
   void cancel() override {
     FUERTE_LOG_DEBUG << "cancel: this=" << this << "\n";
-    asio_ns::post(*_io_context, [self(weak_from_this()), this] {
-      auto s = self.lock();
-      if (s) {
+    asio_ns::post(*_io_context, [self(shared_from_this())] {
+      static_cast<GeneralConnection<ST, RT>&>(*self).
         shutdownConnection(Error::ConnectionCanceled);
-      }
     });
   }
 

--- a/3rdParty/fuerte/src/GeneralConnection.h
+++ b/3rdParty/fuerte/src/GeneralConnection.h
@@ -107,9 +107,11 @@ class GeneralConnection : public fuerte::Connection {
   /// @brief cancel the connection, unusable afterwards
   void cancel() override {
     FUERTE_LOG_DEBUG << "cancel: this=" << this << "\n";
-    asio_ns::post(*_io_context, [self(shared_from_this())] {
-      static_cast<GeneralConnection<ST, RT>&>(*self).
+    asio_ns::post(*_io_context, [self(weak_from_this()), this] {
+      auto s = self.lock();
+      if (s) {
         shutdownConnection(Error::ConnectionCanceled);
+      }
     });
   }
 

--- a/3rdParty/fuerte/src/H1Connection.h
+++ b/3rdParty/fuerte/src/H1Connection.h
@@ -105,18 +105,20 @@ class H1Connection final : public fuerte::GeneralConnection<ST, RequestItem> {
 
   fuerte::Error translateError(asio_ns::error_code const& e,
                                fuerte::Error c) const {
+#ifdef _WIN32
     if (this->_timeoutOnReadWrite && (c == Error::ReadError ||
                                       c == Error::WriteError)) {
       return Error::RequestTimeout;
     }
+#endif
     
     if (e == asio_ns::error::misc_errors::eof ||
         e == asio_ns::error::connection_reset) {
       return fuerte::Error::ConnectionClosed;
-    } else if (e == asio_ns::error::operation_aborted ||
-               e == asio_ns::error::connection_aborted) {
+    } else if (e == asio_ns::error::operation_aborted) {
       // keepalive timeout may have expired
-      return fuerte::Error::ConnectionCanceled;
+      return _timeoutOnReadWrite ? fuerte::Error::Timeout :
+                                   fuerte::Error::Canceled;
     }
     return c;
   }

--- a/3rdParty/fuerte/src/H1Connection.h
+++ b/3rdParty/fuerte/src/H1Connection.h
@@ -117,8 +117,8 @@ class H1Connection final : public fuerte::GeneralConnection<ST, RequestItem> {
       return fuerte::Error::ConnectionClosed;
     } else if (e == asio_ns::error::operation_aborted) {
       // keepalive timeout may have expired
-      return _timeoutOnReadWrite ? fuerte::Error::RequestTimeout :
-                                   fuerte::Error::ConnectionCanceled;
+      return this->_timeoutOnReadWrite ? fuerte::Error::RequestTimeout :
+                                         fuerte::Error::ConnectionCanceled;
     }
     return c;
   }

--- a/3rdParty/fuerte/src/H1Connection.h
+++ b/3rdParty/fuerte/src/H1Connection.h
@@ -117,8 +117,8 @@ class H1Connection final : public fuerte::GeneralConnection<ST, RequestItem> {
       return fuerte::Error::ConnectionClosed;
     } else if (e == asio_ns::error::operation_aborted) {
       // keepalive timeout may have expired
-      return _timeoutOnReadWrite ? fuerte::Error::Timeout :
-                                   fuerte::Error::Canceled;
+      return _timeoutOnReadWrite ? fuerte::Error::RequestTimeout :
+                                   fuerte::Error::ConnectionCanceled;
     }
     return c;
   }

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -438,7 +438,7 @@ void ClusterFeature::prepare() {
   network::ConnectionPool::Config config;
   config.numIOThreads = 2u;
   config.maxOpenConnections = 2;
-  config.idleConnectionMilli = 1000;
+  config.idleConnectionMilli = 10000;
   config.verifyHosts = false;
   config.clusterInfo = &clusterInfo();
   config.name = "AgencyComm";

--- a/arangod/Network/ConnectionPool.cpp
+++ b/arangod/Network/ConnectionPool.cpp
@@ -41,7 +41,6 @@ ConnectionPool::ConnectionPool(ConnectionPool::Config const& config)
     : _config(config), 
       _loop(config.numIOThreads, config.name) {
   TRI_ASSERT(config.numIOThreads > 0);
-  TRI_ASSERT(_config.minOpenConnections <= _config.maxOpenConnections);
 }
 
 ConnectionPool::~ConnectionPool() { shutdownConnections(); }
@@ -56,12 +55,11 @@ network::ConnectionPtr ConnectionPool::leaseConnection(std::string const& endpoi
     guard.unlock();
 
     auto tmp = std::make_unique<Bucket>(); //get memory outside lock
-    
     WRITE_LOCKER(wguard, _lock);
     auto [it2, emplaced] = _connections.try_emplace(endpoint, std::move(tmp));
-    it = it2;
+    return selectConnection(endpoint,*it2->second);
   }
-  return selectConnection(it->first,*(it->second));
+  return selectConnection(endpoint, *it->second);
 }
 
 /// @brief drain all connections
@@ -89,11 +87,11 @@ void ConnectionPool::shutdownConnections() {
 
 /// remove unused and broken connections
 void ConnectionPool::pruneConnections() {
-  const auto ttl = std::chrono::milliseconds(_config.idleConnectionMilli + 10);
+  const std::chrono::milliseconds ttl(_config.idleConnectionMilli);
+  auto now = std::chrono::steady_clock::now();
 
   READ_LOCKER(guard, _lock);
   for (auto& pair : _connections) {
-    auto now = std::chrono::steady_clock::now();
 
     Bucket& buck = *(pair.second);
     std::lock_guard<std::mutex> lock(buck.mutex);
@@ -110,18 +108,10 @@ void ConnectionPool::pruneConnections() {
       if ((*it)->fuerte->state() == fuerte::Connection::State::Closed) {
         // lets not keep around disconnected fuerte connection objects
         remove = true;
-      } else {
-        // connection has not yet failed
-        if ((*it)->leases.load() > 0 || (*it)->fuerte->requestsLeft() > 0) {  // continuously update lastUsed
-          (*it)->lastLeased = now;
-          // connection will be kept
-        } else if (aliveCount >= _config.minOpenConnections &&
-                   (now - (*it)->lastLeased) > ttl) {
-          // connection hasn't been used for a while, remove it
-          // if we still have enough others
-          remove = true;
-        } else if (aliveCount >= _config.maxOpenConnections) {
-          // remove superfluous connections
+      } else if ((*it)->leases.load() == 0 && (*it)->fuerte->requestsLeft() == 0) {
+        if ((now - (*it)->lastLeased) > ttl ||
+            aliveCount >= _config.maxOpenConnections) {
+          // connection hasn't been used for a while, or there are too many connections
           remove = true;
         } // else keep the connection
       }
@@ -199,11 +189,14 @@ std::shared_ptr<fuerte::Connection> ConnectionPool::createConnection(fuerte::Con
 
 ConnectionPtr ConnectionPool::selectConnection(std::string const& endpoint,
                                                ConnectionPool::Bucket& bucket) {
+  const std::chrono::milliseconds ttl(_config.idleConnectionMilli);
+  auto now = std::chrono::steady_clock::now();
+  
   std::lock_guard<std::mutex> guard(bucket.mutex);
 
   for (std::shared_ptr<Context>& c : bucket.list) {
-    const fuerte::Connection::State state = c->fuerte->state();
-    if (state == fuerte::Connection::State::Closed) {
+    if (c->fuerte->state() == fuerte::Connection::State::Closed ||
+        (now - c->lastLeased) > ttl) {
       continue;
     }
 
@@ -220,16 +213,17 @@ ConnectionPtr ConnectionPool::selectConnection(std::string const& endpoint,
     }
 
     // first check against number of active users
-    std::size_t num = c->leases.load();
+    std::size_t num = c->leases.load(std::memory_order_relaxed);
     while (num <= limit) {
-      bool const leased = c->leases.compare_exchange_strong(num, num + 1);
+      bool const leased = c->leases.compare_exchange_strong(num, num + 1, std::memory_order_relaxed);
       if (leased) {
         // next check against the number of requests in flight
-        if (c->fuerte->requestsLeft() <= limit) {
+        if (c->fuerte->requestsLeft() <= limit &&
+            c->fuerte->state() != fuerte::Connection::State::Closed) {
           c->lastLeased = std::chrono::steady_clock::now();
           return {c};
-        } else {
-          --(c->leases);
+        } else {  // too many requests,
+          c->leases.fetch_sub(1, std::memory_order_relaxed);
           break;
         }
       }
@@ -243,8 +237,8 @@ ConnectionPtr ConnectionPool::selectConnection(std::string const& endpoint,
   fuerte::ConnectionBuilder builder;
   builder.endpoint(endpoint); // picks the socket type
 
-  std::shared_ptr<fuerte::Connection> fuerte = createConnection(builder);
-  auto c = std::make_shared<Context>(fuerte, std::chrono::steady_clock::now(), 1 /* leases*/);
+  auto c = std::make_shared<Context>(createConnection(builder),
+                                     std::chrono::steady_clock::now(), 1 /* leases*/);
   bucket.list.push_back(c);
   return {c};
 }
@@ -259,7 +253,7 @@ ConnectionPtr::ConnectionPtr(ConnectionPtr&& other)
 
 ConnectionPtr::~ConnectionPtr() {
   if (_context) {
-    --(_context->leases);
+    _context->leases.fetch_sub(1, std::memory_order_relaxed);
   }
 }
 

--- a/arangod/Network/ConnectionPool.h
+++ b/arangod/Network/ConnectionPool.h
@@ -25,7 +25,7 @@
 #define ARANGOD_NETWORK_CONNECTION_POOL_H 1
 
 #include "Basics/Common.h"
-#include "Basics/ReadWriteSpinLock.h"
+#include "Basics/ReadWriteLock.h"
 #include "Containers/SmallVector.h"
 #include "Network/types.h"
 #include "VocBase/voc-types.h"
@@ -62,10 +62,9 @@ class ConnectionPool final {
  public:
   struct Config {
     ClusterInfo* clusterInfo;
-    uint64_t minOpenConnections = 1;       /// minimum number of open connections
-    uint64_t maxOpenConnections = 1024;    /// max number of connections
-    uint64_t idleConnectionMilli = 60000;  /// unused connection lifetime
-    unsigned int numIOThreads = 1;         /// number of IO threads
+    uint64_t maxOpenConnections = 1024;     /// max number of connections
+    uint64_t idleConnectionMilli = 120000;  /// unused connection lifetime
+    unsigned int numIOThreads = 1;          /// number of IO threads
     bool verifyHosts = false;
     fuerte::ProtocolType protocol = fuerte::ProtocolType::Http;
     char const* name = "";
@@ -115,7 +114,7 @@ class ConnectionPool final {
 
   /// @brief endpoint bucket
   struct Bucket {
-    std::mutex mutex;
+    mutable std::mutex mutex;
     // TODO statistics ?
     //    uint64_t bytesSend;
     //    uint64_t bytesReceived;
@@ -130,7 +129,7 @@ class ConnectionPool final {
  private:
   Config const _config;
 
-  mutable basics::ReadWriteSpinLock _lock;
+  mutable basics::ReadWriteLock _lock;
   std::unordered_map<std::string, std::unique_ptr<Bucket>> _connections;
 
   /// @brief contains fuerte asio::io_context

--- a/arangod/Network/Methods.cpp
+++ b/arangod/Network/Methods.cpp
@@ -173,13 +173,15 @@ FutureRes sendRequest(ConnectionPool* pool, DestinationId dest, RestVerb type,
     struct Pack {
       DestinationId dest;
       futures::Promise<network::Response> promise;
-      std::unique_ptr<fuerte::Response> tmp;
+      std::unique_ptr<fuerte::Response> tmp_res;
       std::unique_ptr<fuerte::Request> tmp_req;
+      fuerte::Error tmp_err;
       bool skipScheduler;
       Pack(DestinationId&& dest, bool skip)
-        : dest(std::move(dest)), promise(), skipScheduler(skip) {}
+        : dest(std::move(dest)),  skipScheduler(skip) {}
     };
 
+    
     // fits in SSO of std::function
     static_assert(sizeof(std::shared_ptr<Pack>) <= 2 * sizeof(void*), "");
     auto conn = pool->leaseConnection(spec.endpoint);
@@ -188,24 +190,27 @@ FutureRes sendRequest(ConnectionPool* pool, DestinationId dest, RestVerb type,
     FutureRes f = p->promise.getFuture();
     conn->sendRequest(
       std::move(req),
-      [p(std::move(p))](fuerte::Error err, std::unique_ptr<fuerte::Request> req,
-                        std::unique_ptr<fuerte::Response> res) {
+      [p(std::move(p))](fuerte::Error err,
+                        std::unique_ptr<fuerte::Request> req,
+                        std::unique_ptr<fuerte::Response> res) mutable {
         Scheduler* sch = SchedulerFeature::SCHEDULER;
         if (p->skipScheduler || sch == nullptr) {
           p->promise.setValue(network::Response{std::move(p->dest), err, std::move(res), std::move(req)});
           return;
         }
 
-        p->tmp = std::move(res);
+        p->tmp_err = err;
+        p->tmp_res = std::move(res);
         p->tmp_req = std::move(req);
 
         bool queued = sch->queue(
           RequestLane::CLUSTER_INTERNAL,
-          [p, err]() {
-            p->promise.setValue(Response{std::move(p->dest), err, std::move(p->tmp), std::move(p->tmp_req)});
+          [p]() mutable {
+            p->promise.setValue(Response{std::move(p->dest), p->tmp_err,
+                                         std::move(p->tmp_res), std::move(p->tmp_req)});
           });
         if (ADB_UNLIKELY(!queued)) {
-          p->promise.setValue(Response{std::move(p->dest), fuerte::Error::ConnectionCanceled, nullptr, std::move(p->tmp_req)});
+          p->promise.setValue(Response{std::move(p->dest), fuerte::Error::QueueCapacityExceeded, nullptr, std::move(p->tmp_req)});
         }
       });
     return f;
@@ -232,9 +237,6 @@ class RequestsState final : public std::enable_shared_from_this<RequestsState> {
         _options(options),
         _pool(pool),
         _type(type),
-        _workItem(nullptr),
-        _response(nullptr),
-        _promise(),
         _startTime(std::chrono::steady_clock::now()),
         _endTime(_startTime + std::chrono::duration_cast<std::chrono::steady_clock::duration>(
                                   options.timeout)) {}
@@ -242,21 +244,24 @@ class RequestsState final : public std::enable_shared_from_this<RequestsState> {
   ~RequestsState() = default;
 
  private:
-  velocypack::Buffer<uint8_t> _payload;
-  DestinationId _destination;
-  std::string _path;
-  Headers _headers;
+  velocypack::Buffer<uint8_t> const _payload;
+  DestinationId const _destination;
+  std::string const _path;
+  Headers const _headers;
   RequestOptions const _options;
   ConnectionPool* _pool;
-  RestVerb _type;
+  RestVerb const _type;
 
   std::shared_ptr<arangodb::Scheduler::WorkItem> _workItem;
-  std::unique_ptr<fuerte::Response> _response;   /// temporary response
-  std::unique_ptr<fuerte::Request> _request;
+  std::unique_ptr<fuerte::Response> _tmp_res;   /// temporary response
+  std::unique_ptr<fuerte::Request> _tmp_req;
+  
   futures::Promise<network::Response> _promise;  /// promise called
 
   std::chrono::steady_clock::time_point const _startTime;
   std::chrono::steady_clock::time_point const _endTime;
+  
+  fuerte::Error _tmp_err;
 
  public:
   FutureRes future() { return _promise.getFuture(); }
@@ -267,13 +272,13 @@ class RequestsState final : public std::enable_shared_from_this<RequestsState> {
     if (ADB_UNLIKELY(!_pool)) {
       LOG_TOPIC("5949f", ERR, Logger::COMMUNICATION)
           << "connection pool unavailable";
-      callResponse(Error::ConnectionCanceled, nullptr, std::move(_request));
+      callResponse(Error::ConnectionCanceled, nullptr, nullptr);
       return;
     }
 
     auto now = std::chrono::steady_clock::now();
     if (now > _endTime || _pool->config().clusterInfo->server().isStopping()) {
-      callResponse(Error::RequestTimeout, nullptr, std::move(_request));
+      callResponse(Error::RequestTimeout, nullptr, nullptr);
       return;  // we are done
     }
 
@@ -283,7 +288,7 @@ class RequestsState final : public std::enable_shared_from_this<RequestsState> {
       // We fake a successful request with statusCode 503 and a backend not available
       // error here:
       auto resp = buildResponse(fuerte::StatusServiceUnavailable, Result{res});
-      callResponse(Error::NoError, std::move(resp), std::move(_request));
+      callResponse(Error::NoError, nullptr, nullptr);
       return;
     }
     
@@ -311,7 +316,7 @@ class RequestsState final : public std::enable_shared_from_this<RequestsState> {
     switch (err) {
       case fuerte::Error::NoError: {
         TRI_ASSERT(res);
-        if (checkResponse(err, req, res)) {
+        if (checkResponse(req, res)) {
           break;
         }
         [[fallthrough]];
@@ -349,7 +354,7 @@ class RequestsState final : public std::enable_shared_from_this<RequestsState> {
         }
 
         if (found || (now + tryAgainAfter) >= _endTime) { // cancel out
-          callResponse(err, std::move(res), std::move(req));
+          callResponse(err, std::move(req), std::move(res));
         } else {
           retryLater(tryAgainAfter);
         }
@@ -357,20 +362,19 @@ class RequestsState final : public std::enable_shared_from_this<RequestsState> {
       }
 
       default:  // a "proper error" which has to be returned to the client
-        callResponse(err, std::move(res), std::move(req));
+        callResponse(err, std::move(req), std::move(res));
         break;
     }
   }
 
-  bool checkResponse(fuerte::Error err,
-                     std::unique_ptr<fuerte::Request>& req,
+  bool checkResponse(std::unique_ptr<fuerte::Request>& req,
                      std::unique_ptr<fuerte::Response>& res) {
     switch (res->statusCode()) {
       case fuerte::StatusOK:
       case fuerte::StatusCreated:
       case fuerte::StatusAccepted:
       case fuerte::StatusNoContent:
-        callResponse(Error::NoError, std::move(res), std::move(req));
+        callResponse(Error::NoError, std::move(req), std::move(res));
         return true; // done
 
       case fuerte::StatusServiceUnavailable:
@@ -383,13 +387,15 @@ class RequestsState final : public std::enable_shared_from_this<RequestsState> {
         }
         [[fallthrough]];
       default:  // a "proper error" which has to be returned to the client
-        callResponse(err, std::move(res), std::move(req));
+        callResponse(Error::NoError, std::move(req), std::move(res));
         return true; // done
     }
   }
 
   /// @brief schedule calling the response promise
-  void callResponse(Error err, std::unique_ptr<fuerte::Response> res, std::unique_ptr<fuerte::Request> req) {
+  void callResponse(Error err,
+                    std::unique_ptr<fuerte::Request> req,
+                    std::unique_ptr<fuerte::Response> res) {
 
     LOG_TOPIC_IF("2713e", DEBUG, Logger::COMMUNICATION, err != fuerte::Error::NoError)
         << "error on request to '" << _destination
@@ -401,17 +407,19 @@ class RequestsState final : public std::enable_shared_from_this<RequestsState> {
       _promise.setValue(Response{std::move(_destination), err, std::move(res), std::move(req)});
       return;
     }
-
-    _response = std::move(res);
-    _request = std::move(req);
+    
+    _tmp_err = err;
+    _tmp_req = std::move(req);
+    _tmp_res = std::move(res);
     bool queued =
-        sch->queue(RequestLane::CLUSTER_INTERNAL, [self = shared_from_this(), err]() {
-          self->_promise.setValue(Response{std::move(self->_destination), err,
-                                           std::move(self->_response),
-                                           std::move(self->_request)});
+        sch->queue(RequestLane::CLUSTER_INTERNAL, [self = shared_from_this()]() {
+          self->_promise.setValue(Response{std::move(self->_destination),
+                                           self->_tmp_err,
+                                           std::move(self->_tmp_res),
+                                           std::move(self->_tmp_req)});
         });
     if (ADB_UNLIKELY(!queued)) {
-      _promise.setValue(Response{std::move(_destination), fuerte::Error::QueueCapacityExceeded, nullptr, std::move(_request)});
+      _promise.setValue(Response{std::move(_destination), fuerte::Error::QueueCapacityExceeded, nullptr, std::move(_tmp_req)});
     }
   }
 
@@ -423,7 +431,7 @@ class RequestsState final : public std::enable_shared_from_this<RequestsState> {
 
     auto* sch = SchedulerFeature::SCHEDULER;
     if (ADB_UNLIKELY(sch == nullptr)) {
-      _promise.setValue(Response{std::move(_destination), fuerte::Error::ConnectionCanceled, nullptr, std::move(_request)});
+      _promise.setValue(Response{std::move(_destination), fuerte::Error::ConnectionCanceled, nullptr, nullptr});
       return;
     }
 
@@ -432,14 +440,14 @@ class RequestsState final : public std::enable_shared_from_this<RequestsState> {
         sch->queueDelay(RequestLane::CLUSTER_INTERNAL, tryAgainAfter,
                         [self = shared_from_this()](bool canceled) {
           if (canceled) {
-            self->_promise.setValue(Response{std::move(self->_destination), Error::ConnectionCanceled, nullptr, std::move(self->_request)});
+            self->_promise.setValue(Response{std::move(self->_destination), Error::ConnectionCanceled, nullptr, nullptr});
           } else {
             self->startRequest();
           }
         });
     if (ADB_UNLIKELY(!queued)) {
       // scheduler queue is full, cannot requeue
-      _promise.setValue(Response{std::move(_destination), Error::QueueCapacityExceeded, nullptr, std::move(_request)});
+      _promise.setValue(Response{std::move(_destination), Error::QueueCapacityExceeded, nullptr, nullptr});
     }
   }
 };

--- a/arangod/Network/NetworkFeature.cpp
+++ b/arangod/Network/NetworkFeature.cpp
@@ -28,7 +28,7 @@
 #include "Basics/application-exit.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
-#include "Logger/Logger.h"
+#include "GeneralServer/GeneralServerFeature.h"
 #include "Network/ConnectionPool.h"
 #include "ProgramOptions/ProgramOptions.h"
 #include "ProgramOptions/Section.h"
@@ -96,7 +96,7 @@ void NetworkFeature::collectOptions(std::shared_ptr<options::ProgramOptions> opt
                      new UInt32Parameter(&_numIOThreads))
                      .setIntroducedIn(30600);
   options->addOption("--network.max-open-connections",
-                     "max open network connections for cluster-internal communication",
+                     "max open TCP connections for cluster-internal communication per endpoint",
                      new UInt64Parameter(&_maxOpenConnections))
                      .setIntroducedIn(30600);
   options->addOption("--network.idle-connection-ttl",
@@ -115,10 +115,13 @@ void NetworkFeature::collectOptions(std::shared_ptr<options::ProgramOptions> opt
                      .setIntroducedIn(30700);
 }
 
-void NetworkFeature::validateOptions(std::shared_ptr<options::ProgramOptions>) {
+void NetworkFeature::validateOptions(std::shared_ptr<options::ProgramOptions> opts) {
   _numIOThreads = std::min<unsigned>(1, std::max<unsigned>(_numIOThreads, 8));
   if (_maxOpenConnections < 8) {
     _maxOpenConnections = 8;
+  }
+  if (!opts->processingResult().touched("--network.idle-connection-ttl")) {
+    _idleTtlMilli = uint64_t(GeneralServerFeature::keepAliveTimeout() * 1000 / 2);
   }
   if (_idleTtlMilli < 10000) {
     _idleTtlMilli = 10000;

--- a/tests/AsyncAgencyComm/AsyncAgencyCommTest.cpp
+++ b/tests/AsyncAgencyComm/AsyncAgencyCommTest.cpp
@@ -183,7 +183,6 @@ struct AsyncAgencyCommTest
     network::ConnectionPool::Config config;
     config.clusterInfo = &server.getFeature<ClusterFeature>().clusterInfo();
     config.numIOThreads = 1;
-    config.minOpenConnections = 1;
     config.maxOpenConnections = 3;
     config.verifyHosts = false;
     return config;

--- a/tests/IResearch/IResearchAnalyzerFeature-test.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeature-test.cpp
@@ -2098,7 +2098,6 @@ TEST_F(IResearchAnalyzerFeatureTest, test_remove) {
   arangodb::network::ConnectionPool::Config poolConfig;
   poolConfig.clusterInfo = &server.getFeature<arangodb::ClusterFeature>().clusterInfo();
   poolConfig.numIOThreads = 1;
-  poolConfig.minOpenConnections = 1;
   poolConfig.maxOpenConnections = 3;
   poolConfig.verifyHosts = false;
 

--- a/tests/IResearch/IResearchFeature-test.cpp
+++ b/tests/IResearch/IResearchFeature-test.cpp
@@ -757,7 +757,6 @@ class IResearchFeatureTestCoordinator
     arangodb::network::ConnectionPool::Config poolConfig;
     poolConfig.clusterInfo = &server.getFeature<arangodb::ClusterFeature>().clusterInfo();
     poolConfig.numIOThreads = 1;
-    poolConfig.minOpenConnections = 1;
     poolConfig.maxOpenConnections = 3;
     poolConfig.verifyHosts = false;
     _pool = std::make_unique<AsyncAgencyStorePoolMock>(server.server(), poolConfig);
@@ -1008,7 +1007,6 @@ class IResearchFeatureTestDBServer
     arangodb::network::ConnectionPool::Config poolConfig;
     poolConfig.clusterInfo = &server.getFeature<arangodb::ClusterFeature>().clusterInfo();
     poolConfig.numIOThreads = 1;
-    poolConfig.minOpenConnections = 1;
     poolConfig.maxOpenConnections = 3;
     poolConfig.verifyHosts = false;
     _pool = std::make_unique<AsyncAgencyStorePoolMock>(server.server(), poolConfig);

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -401,7 +401,6 @@ MockClusterServer::MockClusterServer() : MockServer() {
 
   arangodb::network::ConnectionPool::Config config;
   config.numIOThreads = 1;
-  config.minOpenConnections = 1;
   config.maxOpenConnections = 8;
   config.verifyHosts = false;
   addFeature<arangodb::NetworkFeature>(true, config);
@@ -419,7 +418,6 @@ void MockClusterServer::startFeatures() {
   arangodb::network::ConnectionPool::Config poolConfig;
   poolConfig.clusterInfo = &getFeature<arangodb::ClusterFeature>().clusterInfo();
   poolConfig.numIOThreads = 1;
-  poolConfig.minOpenConnections = 1;
   poolConfig.maxOpenConnections = 3;
   poolConfig.verifyHosts = false;
 

--- a/tests/Network/ConnectionPoolTest.cpp
+++ b/tests/Network/ConnectionPoolTest.cpp
@@ -42,7 +42,6 @@ void doNothing(fuerte::Error, std::unique_ptr<fuerte::Request> req,
 TEST(NetworkConnectionPoolTest, acquire_endpoint) {
   ConnectionPool::Config config;
   config.numIOThreads = 1;
-  config.minOpenConnections = 1;
   config.maxOpenConnections = 3;
   config.idleConnectionMilli = 10; // extra small for testing
   config.verifyHosts = false;
@@ -62,7 +61,6 @@ TEST(NetworkConnectionPoolTest, acquire_endpoint) {
 TEST(NetworkConnectionPoolTest, acquire_multiple_endpoint) {
   ConnectionPool::Config config;
   config.numIOThreads = 1;
-  config.minOpenConnections = 1;
   config.maxOpenConnections = 3;
   config.idleConnectionMilli = 10; // extra small for testing
   config.verifyHosts = false;
@@ -90,15 +88,13 @@ TEST(NetworkConnectionPoolTest, acquire_multiple_endpoint) {
 TEST(NetworkConnectionPoolTest, release_multiple_endpoints_one) {
   ConnectionPool::Config config;
   config.numIOThreads = 1;
-  config.minOpenConnections = 1;
   config.maxOpenConnections = 3;
-  config.idleConnectionMilli = 10; // extra small for testing
+  config.idleConnectionMilli = 5; // extra small for testing
   config.verifyHosts = false;
   config.protocol = fuerte::ProtocolType::Http;
   
   ConnectionPool pool(config);
 
-  
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80");
     ASSERT_EQ(pool.numOpenConnections(), 1);
@@ -111,16 +107,15 @@ TEST(NetworkConnectionPoolTest, release_multiple_endpoints_one) {
   }
   ASSERT_EQ(pool.numOpenConnections(), 2);
   
-  std::this_thread::sleep_for(std::chrono::milliseconds(11));
+  std::this_thread::sleep_for(std::chrono::milliseconds(15));
   pool.pruneConnections();
   
-  ASSERT_EQ(pool.numOpenConnections(), 2); // keep one endpoint each
+  ASSERT_EQ(pool.numOpenConnections(), 1); // keep one busy connection
 }
 
 TEST(NetworkConnectionPoolTest, release_multiple_endpoints_two) {
   ConnectionPool::Config config;
   config.numIOThreads = 1;
-  config.minOpenConnections = 0;
   config.maxOpenConnections = 3;
   config.idleConnectionMilli = 10; // extra small for testing
   config.verifyHosts = false;
@@ -189,7 +184,6 @@ TEST(NetworkConnectionPoolTest, release_multiple_endpoints_two) {
 TEST(NetworkConnectionPoolTest, checking_min_and_max_connections) {
   ConnectionPool::Config config;
   config.numIOThreads = 1;
-  config.minOpenConnections = 1;
   config.maxOpenConnections = 2;
   config.idleConnectionMilli = 10; // extra small for testing
   config.verifyHosts = false;
@@ -264,7 +258,6 @@ TEST(NetworkConnectionPoolTest, checking_min_and_max_connections) {
 TEST(NetworkConnectionPoolTest, checking_expiration) {
   ConnectionPool::Config config;
   config.numIOThreads = 1;
-  config.minOpenConnections = 0;
   config.maxOpenConnections = 2;
   config.idleConnectionMilli = 10; // extra small for testing
   config.verifyHosts = false;
@@ -331,7 +324,6 @@ TEST(NetworkConnectionPoolTest, checking_expiration) {
 TEST(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
   ConnectionPool::Config config;
   config.numIOThreads = 1;
-  config.minOpenConnections = 1;
   config.maxOpenConnections = 2;
   config.idleConnectionMilli = 10; // extra small for testing
   config.verifyHosts = false;
@@ -354,7 +346,7 @@ TEST(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
 
   // expires the connection(s)
   pool.pruneConnections();
-  ASSERT_EQ(pool.numOpenConnections(), 1);
+  ASSERT_EQ(pool.numOpenConnections(), 0);
 
   pool.drainConnections();
   
@@ -372,7 +364,7 @@ TEST(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
 
   // expires the connection
   pool.pruneConnections();
-  ASSERT_EQ(pool.numOpenConnections(), 2);
+  ASSERT_EQ(pool.numOpenConnections(), 0);
 
   pool.drainConnections();
   
@@ -393,7 +385,7 @@ TEST(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
 
   // expires the connections
   pool.pruneConnections();
-  ASSERT_EQ(pool.numOpenConnections(), 2);
+  ASSERT_EQ(pool.numOpenConnections(), 0);
   
   pool.drainConnections();
   
@@ -406,21 +398,22 @@ TEST(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
     
     auto conn3 = pool.leaseConnection("tcp://example.org:80");
     ASSERT_EQ(pool.numOpenConnections(), 3);
+  }  
+  {
     
     auto conn4 = pool.leaseConnection("tcp://example.com:80");
     ASSERT_EQ(pool.numOpenConnections(), 4);
     
     auto conn5 = pool.leaseConnection("tcp://example.com:80");
     ASSERT_EQ(pool.numOpenConnections(), 5);
-  }
-  ASSERT_EQ(pool.numOpenConnections(), 5);
-  
-  // 21ms > 2 * 10ms
-  std::this_thread::sleep_for(std::chrono::milliseconds(21));
+    
+    // 21ms > 2 * 10ms
+    std::this_thread::sleep_for(std::chrono::milliseconds(21));
 
-  // expires the connections
-  pool.pruneConnections();
-  ASSERT_EQ(pool.numOpenConnections(), 2);
+    // expires the connections
+    pool.pruneConnections();
+    ASSERT_EQ(pool.numOpenConnections(), 2);
+  }
   
   pool.drainConnections();
   
@@ -441,7 +434,7 @@ TEST(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
 
   // expires the connections
   pool.pruneConnections();
-  ASSERT_EQ(pool.numOpenConnections(), 3);
+  ASSERT_EQ(pool.numOpenConnections(), 0);
   
   pool.drainConnections();
 }

--- a/tests/Network/MethodsTest.cpp
+++ b/tests/Network/MethodsTest.cpp
@@ -94,7 +94,6 @@ struct NetworkMethodsTest
     network::ConnectionPool::Config config;
     config.clusterInfo = &server.getFeature<ClusterFeature>().clusterInfo();
     config.numIOThreads = 1;
-    config.minOpenConnections = 1;
     config.maxOpenConnections = 3;
     config.verifyHosts = false;
     return config;


### PR DESCRIPTION
### Scope & Purpose

Make sure the connection pool removes idle connections before the remote closes them

- [x] :hankey: Bugfix 

#### Backports:

- [x] No backports required


#### Related Information

- [x] GitHub issue / Jira ticket number: BTS-204

