### PR TITLE
added extra metrics for scheduler threads

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Added scheduler thread creation/destruction metrics:
+
+  - `arangodb_scheduler_threads_started`: Number of scheduler threads started
+  - `arangodb_scheduler_threads_stopped`: Number of scheduler threads stopped
+
 * Fixed inifinite reload of the login window after logout of an LDAP user.
 
 * Added startup option `--query.max-runtime` to limit the maximum runtime of

--- a/arangod/Scheduler/Scheduler.h
+++ b/arangod/Scheduler/Scheduler.h
@@ -197,10 +197,8 @@ class Scheduler {
  public:
   struct QueueStatistics {
     uint64_t _running; // numWorkers
-    uint64_t _blocked; // obsolete, always 0 now
     uint64_t _queued;
     uint64_t _working;
-    uint64_t _directExec;
   };
 
   virtual void toVelocyPack(velocypack::Builder&) const = 0;

--- a/arangod/Scheduler/SupervisedScheduler.cpp
+++ b/arangod/Scheduler/SupervisedScheduler.cpp
@@ -154,7 +154,6 @@ SupervisedScheduler::SupervisedScheduler(application_features::ApplicationServer
       _jobsSubmitted(0),
       _jobsDequeued(0),
       _jobsDone(0),
-      _jobsDirectExec(0),
       _wakeupQueueLength(5),
       _wakeupTime_ns(1000),
       _definitiveWakeupTime_ns(100000),
@@ -174,6 +173,12 @@ SupervisedScheduler::SupervisedScheduler(application_features::ApplicationServer
       _metricsNumWorkerThreads(server.getFeature<arangodb::MetricsFeature>().gauge<uint64_t>(
           StaticStrings::SchedulerNumWorker, 0,
           "Number of worker threads")),
+      _metricsThreadsStarted(server.getFeature<arangodb::MetricsFeature>().counter(
+          "arangodb_scheduler_threads_started", 0,
+          "Number of scheduler threads started")),
+      _metricsThreadsStopped(server.getFeature<arangodb::MetricsFeature>().counter(
+          "arangodb_scheduler_threads_stopped", 0,
+          "Number of scheduler threads stopped")),
       _metricsQueueFull(server.getFeature<arangodb::MetricsFeature>().counter(
           "arangodb_scheduler_queue_full_failures", 0, "Tasks dropped and not added to internal queue")) {
   _queues[0].reserve(maxQueueSize);
@@ -438,8 +443,8 @@ void SupervisedScheduler::runSupervisor() {
     uint64_t queueLength = jobsSubmitted - jobsDequeued;
 
     uint64_t awake = _nrAwake.load(std::memory_order_relaxed);
-    uint64_t numWorker = _numWorkers.load(std::memory_order_relaxed);
-    bool sleeperFound = (awake < numWorker);
+    uint64_t numWorkers = _numWorkers.load(std::memory_order_relaxed);
+    bool sleeperFound = (awake < numWorkers);
 
     bool doStartOneThread = (((queueLength >= 3 * _numWorkers) &&
                               ((lastQueueLength + _numWorkers) < queueLength)) ||
@@ -458,7 +463,7 @@ void SupervisedScheduler::runSupervisor() {
       // approx every 0.5s update the metrics
       _metricsQueueLength.operator=(queueLength);
       _metricsAwakeThreads.operator=(awake);
-      _metricsNumWorkerThreads.operator=(numWorker);
+      _metricsNumWorkerThreads.operator=(numWorkers);
       roundCount = 0;
     }
 
@@ -669,8 +674,11 @@ void SupervisedScheduler::startOneThread() {
   }
 
   // sync with runWorker()
-  std::unique_lock<std::mutex> guard2(_mutexSupervisor);
-  _conditionSupervisor.wait(guard2, [&state]() { return state->_ready; });
+  {
+    std::unique_lock<std::mutex> guard2(_mutexSupervisor);
+    _conditionSupervisor.wait(guard2, [&state]() { return state->_ready; });
+  }
+  ++_metricsThreadsStarted;
   LOG_TOPIC("f9de8", TRACE, Logger::THREADS) << "Started new thread";
 }
 
@@ -693,6 +701,8 @@ void SupervisedScheduler::stopOneThread() {
     // _stop is set under the mutex, then the worker thread is notified.
   }
   state->_conditionWork.notify_one();
+  
+  ++_metricsThreadsStopped;
 
   // However the thread may be working on a long job. Hence we enqueue it on
   // the cleanup list and wait for its termination.
@@ -738,17 +748,15 @@ Scheduler::QueueStatistics SupervisedScheduler::queueStatistics() const {
   uint64_t const queued = jobsSubmitted - jobsDone;
   uint64_t const working = jobsDequeued - jobsDone;
 
-  uint64_t const directExec = _jobsDirectExec.load(std::memory_order_relaxed);
-
-  return QueueStatistics{numWorkers, 0, queued, working, directExec};
+  return QueueStatistics{numWorkers, queued, working};
 }
 
 void SupervisedScheduler::toVelocyPack(velocypack::Builder& b) const {
   QueueStatistics qs = queueStatistics();
 
-  b.add("scheduler-threads", VPackValue(qs._running));  // numWorkers
-  b.add("blocked", VPackValue(qs._blocked));            // obsolete
-  b.add("queued", VPackValue(qs._queued));
-  b.add("in-progress", VPackValue(qs._working));
-  b.add("direct-exec", VPackValue(qs._directExec));
+  b.add("scheduler-threads", VPackValue(qs._running)); // numWorkers
+  b.add("blocked", VPackValue(0)); // obsolete
+  b.add("queued", VPackValue(qs._queued)); // scheduler queue length
+  b.add("in-progress", VPackValue(qs._working)); // number of working (non-idle) threads
+  b.add("direct-exec", VPackValue(0)); // obsolete
 }

--- a/arangod/Scheduler/SupervisedScheduler.h
+++ b/arangod/Scheduler/SupervisedScheduler.h
@@ -83,7 +83,6 @@ class SupervisedScheduler final : public Scheduler {
   alignas(64) std::atomic<uint64_t> _jobsSubmitted;
   alignas(64) std::atomic<uint64_t> _jobsDequeued;
   alignas(64) std::atomic<uint64_t> _jobsDone;
-  alignas(64) std::atomic<uint64_t> _jobsDirectExec;
 
   // During a queue operation there a two reasons to manually wake up a worker
   //  1. the queue length is bigger than _wakeupQueueLength and the last submit time
@@ -175,6 +174,8 @@ class SupervisedScheduler final : public Scheduler {
   Gauge<uint64_t>& _metricsQueueLength;
   Gauge<uint64_t>& _metricsAwakeThreads;
   Gauge<uint64_t>& _metricsNumWorkerThreads;
+  Counter& _metricsThreadsStarted;
+  Counter& _metricsThreadsStopped;
   Counter& _metricsQueueFull;
 };
 

--- a/tests/Cluster/RebootTrackerTest.cpp
+++ b/tests/Cluster/RebootTrackerTest.cpp
@@ -162,7 +162,7 @@ class RebootTrackerTest : public ::testing::Test,
   bool schedulerEmpty() const {
     auto stats = scheduler->queueStatistics();
 
-    return stats._blocked == 0 && stats._queued == 0 && stats._working == 0;
+    return stats._queued == 0 && stats._working == 0;
   }
 
   void waitForSchedulerEmpty() const {


### PR DESCRIPTION
### Scope & Purpose

Added scheduler thread creation/destruction metrics:

- `arangodb_scheduler_threads_started`: Number of scheduler threads started
- `arangodb_scheduler_threads_stopped`: Number of scheduler threads stopped

- [ ] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.7

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11865/