### PR TITLE
Make the reboot tracker catch failed coordinators, too.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Make the reboot tracker catch failed coordinators, too. Previously the
+  reboot tracker was invoked only when a DB server failed or was restarted, 
+  and when a coordinator was restarted. Now it will also act if a coordinator
+  just fails (without restart).
+
 * Added replication metrics `arangodb_replication_initial_sync_bytes_received`
   for the number of bytes received during replication initial sync operations
   and `arangodb_replication_tailing_bytes_received` for the number of bytes

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -429,12 +429,11 @@ void handleOnStatusCoordinator(Agent* agent, Node const& snapshot, HealthRecord&
         VPackObjectBuilder b(&create);
         // unconditionally increase reboot id and plan version
         Job::addIncreaseRebootId(create, serverID);
-      }
 
-      // if the current foxxmaster server failed => reset the value to ""
-      if (snapshot.hasAsString(foxxmaster).first == serverID) {
-        VPackObjectBuilder d(&create);
-        create.add(foxxmaster, VPackValue(""));
+        // if the current foxxmaster server failed => reset the value to ""
+        if (snapshot.hasAsString(foxxmaster).first == serverID) {
+          create.add(foxxmaster, VPackValue(""));
+        }
       }
     }
     singleWriteTransaction(agent, create, false);

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -422,18 +422,22 @@ void handleOnStatusDBServer(Agent* agent, Node const& snapshot,
 void handleOnStatusCoordinator(Agent* agent, Node const& snapshot, HealthRecord& persisted,
                                HealthRecord& transisted, std::string const& serverID) {
   if (transisted.status == Supervision::HEALTH_STATUS_FAILED) {
-    // if the current foxxmaster server failed => reset the value to ""
-    if (snapshot.hasAsString(foxxmaster).first == serverID) {
-      VPackBuilder create;
+    VPackBuilder create;
+    {
+      VPackArrayBuilder tx(&create);
       {
-        VPackArrayBuilder tx(&create);
-        {
-          VPackObjectBuilder d(&create);
-          create.add(foxxmaster, VPackValue(""));
-        }
+        VPackObjectBuilder b(&create);
+        // unconditionally increase reboot id and plan version
+        Job::addIncreaseRebootId(create, serverID);
       }
-      singleWriteTransaction(agent, create, false);
+
+      // if the current foxxmaster server failed => reset the value to ""
+      if (snapshot.hasAsString(foxxmaster).first == serverID) {
+        VPackObjectBuilder d(&create);
+        create.add(foxxmaster, VPackValue(""));
+      }
     }
+    singleWriteTransaction(agent, create, false);
   }
 }
 


### PR DESCRIPTION
### Scope & Purpose

Make the reboot tracker catch failed coordinators, too.
Previously the reboot tracker was invoked only when a DB server failed or was restarted, and when a coordinator was restarted.
Now it will also act if a coordinator just fails (without restart).

- [x] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] Backports required for: 3.5 (https://github.com/arangodb/arangodb/pull/12636), 3.6 (https://github.com/arangodb/arangodb/pull/12606), 3.7

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11876/