### PR TITLE
fix reboot tracker

### DIFF
--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -413,12 +413,11 @@ void handleOnStatusCoordinator(Agent* agent, Node const& snapshot, HealthRecord&
         VPackObjectBuilder b(&create);
         // unconditionally increase reboot id and plan version
         Job::addIncreaseRebootId(create, serverID);
-      }
 
-      // if the current foxxmaster server failed => reset the value to ""
-      if (snapshot.hasAsString(foxxmaster).first == serverID) {
-        VPackObjectBuilder d(&create);
-        create.add(foxxmaster, VPackValue(""));
+        // if the current foxxmaster server failed => reset the value to ""
+        if (snapshot.hasAsString(foxxmaster).first == serverID) {
+          create.add(foxxmaster, VPackValue(""));
+        }
       }
     }
     singleWriteTransaction(agent, create, false);


### PR DESCRIPTION
### Scope & Purpose

Follow-up PR to https://github.com/arangodb/arangodb/pull/12606

Make the reboot tracker catch failed coordinators, too.
Previously the reboot tracker was invoked only when a DB server failed or was restarted, and when a coordinator was restarted.
Now it will also act if a coordinator just fails (without restart).

- [x] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] Backports required for: 3.5

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11880/