### PR TITLE
turn off upgrade check even for alpha/beta/preview versions

### DIFF
--- a/js/common/modules/@arangodb/common.js
+++ b/js/common/modules/@arangodb/common.js
@@ -545,7 +545,8 @@ exports.checkAvailableVersions = function() {
           "') of ArangoDB"
       );
     }
-  } else if (internal.isEnterprise()) {
+  } 
+  if (internal.isEnterprise()) {
     // don't check for version updates in the Enterprise Edition
     return;
   }

--- a/js/common/modules/@arangodb/common.js
+++ b/js/common/modules/@arangodb/common.js
@@ -537,7 +537,9 @@ exports.checkAvailableVersions = function() {
     log = internal.print;
   }
 
+  let isStable = true;
   if (version.match(/beta|alpha|preview|milestone|devel/) !== null) {
+    isStable = false;
     if (internal.quiet !== true) {
       log(
         "You are using a milestone/alpha/beta/preview version ('" +
@@ -546,8 +548,13 @@ exports.checkAvailableVersions = function() {
       );
     }
   } 
-  if (internal.isEnterprise()) {
-    // don't check for version updates in the Enterprise Edition
+
+  if (isServer && internal.isEnterprise()) {
+    // don't check for version updates in arangod in Enterprise Edition
+    return;
+  }
+  if (!isServer && internal.isEnterprise() && isStable) {
+    // don't check for version updates in arangosh in stable Enterprise Edition
     return;
   }
   


### PR DESCRIPTION
### Scope & Purpose

Turn off upgrade checks in arangod in alpha/beta/preview Enterprise versions, too.
Previously it was already turned off for Enterprise versions, but only for stable releases.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11897/