### PR TITLE
Fix accessing metrics API when statistics history is turned off

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.6.7 (XXXX-XX-XX)
 -------------------
 
+* Use rclone built from v1.51.0 source with go1.15.2 instead of prebuilt to
+  1.51.0.
+
 * Fix undefined behavior when accessing the `/_admin/metrics` API to retrieve
   metrics when the server statistics history bookkeeping was turned off via
   `--server.statistics-history false`. The default value for this option is
@@ -93,8 +96,6 @@ v3.6.7 (XXXX-XX-XX)
 * Fixed some cases where subqueries in PRUNE did not result in a parse error,
   but either in an incomprehensible error (in 3.7), or undefined behaviour
   during execution (pre 3.7).
-
-* Updated rclone to 1.53.0.
 
 * Added metrics for V8 contexts usage:
   * `arangodb_v8_context_alive`: number of V8 contexts currently alive.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.6.7 (XXXX-XX-XX)
 -------------------
 
+* Fix undefined behavior when accessing the `/_admin/metrics` API to retrieve
+  metrics when the server statistics history bookkeeping was turned off via
+  `--server.statistics-history false`. The default value for this option is
+  `true`, so the effect is limited to installations which have changed the
+  default and are using the API.
+
 * Make the reboot tracker catch failed coordinators, too. Previously the reboot
   tracker was invoked only when a DB server failed or was restarted, and when a
   coordinator was restarted. Now it will also act if a coordinator just fails

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -257,3 +257,9 @@ void StatisticsFeature::stop() {
 
   STATISTICS = nullptr;
 }
+  
+void StatisticsFeature::toPrometheus(std::string& result, double const& now) {
+  if (_statisticsWorker != nullptr) {
+    _statisticsWorker->generateRawStatistics(result, now);
+  }
+}

--- a/arangod/Statistics/StatisticsFeature.h
+++ b/arangod/Statistics/StatisticsFeature.h
@@ -86,9 +86,7 @@ class StatisticsFeature final : public application_features::ApplicationFeature 
   void prepare() override final;
   void start() override final;
   void stop() override final;
-  void toPrometheus(std::string& result, double const& now) {
-    _statisticsWorker->generateRawStatistics(result, now);
-  }
+  void toPrometheus(std::string& result, double const& now);
 
   static stats::Descriptions const* descriptions() {
     if (STATISTICS != nullptr) {


### PR DESCRIPTION
### Scope & Purpose

  Fix undefined behavior when accessing the `/_admin/metrics` API to retrieve
  metrics when the server statistics history bookkeeping was turned off via
  `--server.statistics-history false`. The default value for this option is
  `true`, so the effect is limited to installations which have changed the
  default and are using the API.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required
- [ ] Backports required for: *(Please specify versions)*

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11931/