### PR TITLE
Safeguards against using V8 when JavaScript is turned off

### DIFF
--- a/arangod/Actions/ActionFeature.cpp
+++ b/arangod/Actions/ActionFeature.cpp
@@ -28,8 +28,6 @@
 #include "FeaturePhases/ClusterFeaturePhase.h"
 #include "ProgramOptions/ProgramOptions.h"
 #include "ProgramOptions/Section.h"
-#include "V8Server/V8DealerFeature.h"
-#include "V8Server/v8-actions.h"
 
 using namespace arangodb::application_features;
 using namespace arangodb::options;
@@ -57,16 +55,10 @@ void ActionFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
 
 void ActionFeature::start() {
   ACTION = this;
-
-  V8DealerFeature& dealer = server().getFeature<V8DealerFeature>();
-  dealer.defineContextUpdate([](v8::Isolate* isolate, v8::Handle<v8::Context> /*context*/,
-                                size_t) { TRI_InitV8Actions(isolate); },
-                             nullptr);
 }
 
 void ActionFeature::unprepare() {
   TRI_CleanupActions();
-
   ACTION = nullptr;
 }
 

--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -534,6 +534,7 @@ set(LIB_ARANGO_AGENCY_SOURCES
 )
 
 set(LIB_ARANGO_V8SERVER_SOURCES
+  Cluster/v8-cluster.cpp
   Transaction/V8Context.cpp
   V8Server/FoxxQueuesFeature.cpp
   V8Server/V8Context.cpp
@@ -614,7 +615,6 @@ set(LIB_ARANGOSERVER_SOURCES
   Cluster/SynchronizeShard.cpp
   Cluster/TakeoverShardLeadership.cpp
   Cluster/UpdateCollection.cpp
-  Cluster/v8-cluster.cpp
   FeaturePhases/AgencyFeaturePhase.cpp
   FeaturePhases/AqlFeaturePhase.cpp
   FeaturePhases/BasicFeaturePhaseServer.cpp

--- a/arangod/GeneralServer/GeneralServerFeature.cpp
+++ b/arangod/GeneralServer/GeneralServerFeature.cpp
@@ -391,8 +391,11 @@ void GeneralServerFeature::defineHandlers() {
                                     RestHandlerCreator<RestSimpleHandler>::createData<aql::QueryRegistry*>,
                                     queryRegistry);
 
-  _handlerFactory->addPrefixHandler(RestVocbaseBaseHandler::TASKS_PATH,
-                                    RestHandlerCreator<RestTasksHandler>::createNoData);
+  if (server().isEnabled<V8DealerFeature>()) {
+    // the tasks feature depends on V8. only enable it if JavaScript is enabled
+    _handlerFactory->addPrefixHandler(RestVocbaseBaseHandler::TASKS_PATH,
+                                      RestHandlerCreator<RestTasksHandler>::createNoData);
+  }
 
   _handlerFactory->addPrefixHandler(RestVocbaseBaseHandler::UPLOAD_PATH,
                                     RestHandlerCreator<RestUploadHandler>::createNoData);
@@ -414,6 +417,7 @@ void GeneralServerFeature::defineHandlers() {
                                     RestHandlerCreator<RestAqlFunctionsHandler>::createNoData);
 
   if (server().isEnabled<V8DealerFeature>()) {
+    // the AQL UDfs feature depends on V8. only enable it if JavaScript is enabled
     _handlerFactory->addPrefixHandler("/_api/aqlfunction",
                                       RestHandlerCreator<RestAqlUserFunctionsHandler>::createNoData);
   }
@@ -468,6 +472,7 @@ void GeneralServerFeature::defineHandlers() {
                               RestHandlerCreator<RestAuthReloadHandler>::createNoData);
 
   if (V8DealerFeature::DEALER && V8DealerFeature::DEALER->allowAdminExecute()) {
+    // the /_admin/execute API depends on V8. only enable it if JavaScript is enabled
     _handlerFactory->addHandler("/_admin/execute",
                                 RestHandlerCreator<RestAdminExecuteHandler>::createNoData);
   }
@@ -522,6 +527,7 @@ void GeneralServerFeature::defineHandlers() {
                                     RestHandlerCreator<arangodb::RestAdminLogHandler>::createNoData);
 
   if (server().isEnabled<V8DealerFeature>()) {
+    // the routing feature depends on V8. only enable it if JavaScript is enabled
     _handlerFactory->addPrefixHandler("/_admin/routing",
                                       RestHandlerCreator<arangodb::RestAdminRoutingHandler>::createNoData);
   }

--- a/arangod/RestHandler/RestAdminExecuteHandler.cpp
+++ b/arangod/RestHandler/RestAdminExecuteHandler.cpp
@@ -52,9 +52,8 @@ RestAdminExecuteHandler::RestAdminExecuteHandler(application_features::Applicati
     : RestVocbaseBaseHandler(server, request, response) {}
 
 RestStatus RestAdminExecuteHandler::execute() {
-  if (!V8DealerFeature::DEALER) {
-    generateError(rest::ResponseCode::BAD, TRI_ERROR_INTERNAL,
-                  "JavaScript operations are not available");
+  if (!V8DealerFeature::DEALER || !V8DealerFeature::DEALER->isEnabled()) {
+    generateError(rest::ResponseCode::NOT_IMPLEMENTED, TRI_ERROR_NOT_IMPLEMENTED, "JavaScript operations are disabled");
     return RestStatus::DONE;
   }
 

--- a/arangod/RestHandler/RestAdminExecuteHandler.cpp
+++ b/arangod/RestHandler/RestAdminExecuteHandler.cpp
@@ -52,7 +52,7 @@ RestAdminExecuteHandler::RestAdminExecuteHandler(application_features::Applicati
     : RestVocbaseBaseHandler(server, request, response) {}
 
 RestStatus RestAdminExecuteHandler::execute() {
-  if (!V8DealerFeature::DEALER || !V8DealerFeature::DEALER->isEnabled()) {
+  if (!server().isEnabled<V8DealerFeature>()) {
     generateError(rest::ResponseCode::NOT_IMPLEMENTED, TRI_ERROR_NOT_IMPLEMENTED, "JavaScript operations are disabled");
     return RestStatus::DONE;
   }

--- a/arangod/RestHandler/RestAdminRoutingHandler.cpp
+++ b/arangod/RestHandler/RestAdminRoutingHandler.cpp
@@ -36,7 +36,7 @@ RestAdminRoutingHandler::RestAdminRoutingHandler(application_features::Applicati
     : RestVocbaseBaseHandler(server, request, response) {}
 
 RestStatus RestAdminRoutingHandler::execute() {
-  if (!V8DealerFeature::DEALER || !V8DealerFeature::DEALER->isEnabled()) {
+  if (!server().isEnabled<V8DealerFeature>()) {
     generateError(rest::ResponseCode::NOT_IMPLEMENTED, TRI_ERROR_NOT_IMPLEMENTED, "JavaScript operations are disabled");
     return RestStatus::DONE;
   }

--- a/arangod/RestHandler/RestAdminRoutingHandler.cpp
+++ b/arangod/RestHandler/RestAdminRoutingHandler.cpp
@@ -36,6 +36,11 @@ RestAdminRoutingHandler::RestAdminRoutingHandler(application_features::Applicati
     : RestVocbaseBaseHandler(server, request, response) {}
 
 RestStatus RestAdminRoutingHandler::execute() {
+  if (!V8DealerFeature::DEALER || !V8DealerFeature::DEALER->isEnabled()) {
+    generateError(rest::ResponseCode::NOT_IMPLEMENTED, TRI_ERROR_NOT_IMPLEMENTED, "JavaScript operations are disabled");
+    return RestStatus::DONE;
+  }
+
   std::vector<std::string> const& suffixes = _request->suffixes();
   if (suffixes.size() == 1 && suffixes[0] == "reload") {
     reloadRouting();

--- a/arangod/RestHandler/RestControlPregelHandler.cpp
+++ b/arangod/RestHandler/RestControlPregelHandler.cpp
@@ -34,7 +34,6 @@
 #include "Pregel/PregelFeature.h"
 #include "Transaction/StandaloneContext.h"
 #include "V8/v8-vpack.h"
-#include "V8Server/V8DealerFeature.h"
 #include "VocBase/Methods/Tasks.h"
 
 #include <velocypack/Builder.h>

--- a/arangod/RestHandler/RestTasksHandler.cpp
+++ b/arangod/RestHandler/RestTasksHandler.cpp
@@ -48,7 +48,7 @@ RestTasksHandler::RestTasksHandler(application_features::ApplicationServer& serv
     : RestVocbaseBaseHandler(server, request, response) {}
 
 RestStatus RestTasksHandler::execute() {
-  if (!V8DealerFeature::DEALER || !V8DealerFeature::DEALER->isEnabled()) {
+  if (!server().isEnabled<V8DealerFeature>()) {
     generateError(rest::ResponseCode::NOT_IMPLEMENTED, TRI_ERROR_NOT_IMPLEMENTED, "JavaScript operations are disabled");
     return RestStatus::DONE;
   }

--- a/arangod/RestHandler/RestTasksHandler.cpp
+++ b/arangod/RestHandler/RestTasksHandler.cpp
@@ -48,6 +48,11 @@ RestTasksHandler::RestTasksHandler(application_features::ApplicationServer& serv
     : RestVocbaseBaseHandler(server, request, response) {}
 
 RestStatus RestTasksHandler::execute() {
+  if (!V8DealerFeature::DEALER || !V8DealerFeature::DEALER->isEnabled()) {
+    generateError(rest::ResponseCode::NOT_IMPLEMENTED, TRI_ERROR_NOT_IMPLEMENTED, "JavaScript operations are disabled");
+    return RestStatus::DONE;
+  }
+
   auto const type = _request->requestType();
 
   switch (type) {

--- a/arangod/RestHandler/RestTransactionHandler.cpp
+++ b/arangod/RestHandler/RestTransactionHandler.cpp
@@ -267,7 +267,7 @@ void RestTransactionHandler::generateTransactionResult(rest::ResponseCode code,
 
 /// start a legacy JS transaction
 void RestTransactionHandler::executeJSTransaction() {
-  if (!V8DealerFeature::DEALER || !V8DealerFeature::DEALER->isEnabled()) {
+  if (!server().isEnabled<V8DealerFeature>()) {
     generateError(rest::ResponseCode::NOT_IMPLEMENTED, TRI_ERROR_NOT_IMPLEMENTED, "JavaScript operations are disabled");
     return;
   }

--- a/arangod/RestHandler/RestTransactionHandler.cpp
+++ b/arangod/RestHandler/RestTransactionHandler.cpp
@@ -267,9 +267,8 @@ void RestTransactionHandler::generateTransactionResult(rest::ResponseCode code,
 
 /// start a legacy JS transaction
 void RestTransactionHandler::executeJSTransaction() {
-  if (!V8DealerFeature::DEALER) {
-    generateError(rest::ResponseCode::BAD, TRI_ERROR_INTERNAL,
-                  "JavaScript transactions are not available");
+  if (!V8DealerFeature::DEALER || !V8DealerFeature::DEALER->isEnabled()) {
+    generateError(rest::ResponseCode::NOT_IMPLEMENTED, TRI_ERROR_NOT_IMPLEMENTED, "JavaScript operations are disabled");
     return;
   }
 

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -24,7 +24,6 @@
 
 #include "DatabaseFeature.h"
 
-#include "Agency/v8-agency.h"
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/PlanCache.h"
 #include "Aql/QueryCache.h"
@@ -42,7 +41,6 @@
 #include "Basics/files.h"
 #include "Basics/StaticStrings.h"
 #include "Cluster/ServerState.h"
-#include "Cluster/v8-cluster.h"
 #include "FeaturePhases/BasicFeaturePhaseServer.h"
 #include "GeneralServer/AuthenticationFeature.h"
 #include "IResearch/IResearchAnalyzerFeature.h"
@@ -63,8 +61,6 @@
 #include "Utils/CursorRepository.h"
 #include "Utils/Events.h"
 #include "V8Server/V8DealerFeature.h"
-#include "V8Server/v8-query.h"
-#include "V8Server/v8-vocbase.h"
 #include "VocBase/KeyGenerator.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/ticks.h"
@@ -379,9 +375,6 @@ void DatabaseFeature::start() {
   if (!arangodb::ServerState::instance()->isRunningInCluster()) {
     enableDeadlockDetection();
   }
-
-  // update all v8 contexts
-  updateContexts();
 }
 
 // signal to all databases that active cursors can be wiped
@@ -1059,28 +1052,6 @@ void DatabaseFeature::enumerateDatabases(std::function<void(TRI_vocbase_t& vocba
     TRI_ASSERT(vocbase != nullptr);
     func(*vocbase);
   }
-}
-
-void DatabaseFeature::updateContexts() {
-  V8DealerFeature& dealer = server().getFeature<V8DealerFeature>();
-  if (!dealer.isEnabled()) {
-    return;
-  }
-
-  auto* vocbase = useDatabase(StaticStrings::SystemDatabase);
-  TRI_ASSERT(vocbase);
-
-  auto queryRegistry = QueryRegistryFeature::registry();
-  TRI_ASSERT(queryRegistry != nullptr);
-
-  dealer.defineContextUpdate(
-      [queryRegistry, vocbase](v8::Isolate* isolate, v8::Handle<v8::Context> context, size_t i) {
-        TRI_InitV8VocBridge(isolate, context, queryRegistry, *vocbase, i);
-        TRI_InitV8Queries(isolate, context);
-        TRI_InitV8Cluster(isolate, context);
-        TRI_InitV8Agency(isolate, context);
-      },
-      vocbase);
 }
 
 void DatabaseFeature::stopAppliers() {

--- a/arangod/RestServer/DatabaseFeature.h
+++ b/arangod/RestServer/DatabaseFeature.h
@@ -156,7 +156,6 @@ class DatabaseFeature : public application_features::ApplicationFeature {
 
  private:
   void stopAppliers();
-  void updateContexts();
 
   /// @brief create base app directory
   int createBaseApplicationDirectory(std::string const& appPath, std::string const& type);

--- a/arangod/Scheduler/SchedulerFeature.cpp
+++ b/arangod/Scheduler/SchedulerFeature.cpp
@@ -43,8 +43,7 @@
 #include "RestServer/ServerFeature.h"
 #include "Scheduler/Scheduler.h"
 #include "Scheduler/SupervisedScheduler.h"
-#include "V8Server/V8DealerFeature.h"
-#include "V8Server/v8-dispatcher.h"
+#include "VocBase/Methods/Tasks.h"
 
 #ifdef _WIN32
 #include <stdio.h>
@@ -198,45 +197,18 @@ void SchedulerFeature::start() {
     FATAL_ERROR_EXIT();
   }
   LOG_TOPIC("14e6f", DEBUG, Logger::STARTUP) << "scheduler has started";
-
-  initV8Stuff();
 }
 
 void SchedulerFeature::stop() {
+  // shutdown user jobs again, in case new ones appear
+  arangodb::Task::shutdownTasks();
   signalStuffDeinit();
-  deinitV8Stuff();
-
   _scheduler->shutdown();
 }
 
 void SchedulerFeature::unprepare() {
   SCHEDULER = nullptr;
   _scheduler.reset();
-}
-
-// ---------------------------------------------------------------------------
-// Unrelated V8 Stuff - no body knows what this has to do with scheduling
-// ---------------------------------------------------------------------------
-
-void SchedulerFeature::initV8Stuff() {
-  // THIS CODE IS TOTALLY UNRELATED TO THE SCHEDULER!?!
-  try {
-    auto& dealer = server().getFeature<V8DealerFeature>();
-    if (dealer.isEnabled()) {
-      dealer.defineContextUpdate(
-          [](v8::Isolate* isolate, v8::Handle<v8::Context> context, size_t) {
-            TRI_InitV8Dispatcher(isolate, context);
-          },
-          nullptr);
-    }
-  } catch (...) {
-  }
-}
-
-void SchedulerFeature::deinitV8Stuff() {
-  // This was once called twice on shutdown
-  // shutdown user jobs again, in case new ones appear
-  TRI_ShutdownV8Dispatcher();
 }
 
 // ---------------------------------------------------------------------------

--- a/arangod/Scheduler/SchedulerFeature.h
+++ b/arangod/Scheduler/SchedulerFeature.h
@@ -63,8 +63,6 @@ class SchedulerFeature final : public application_features::ApplicationFeature {
   void buildHangupHandler();
 
  private:
-  void initV8Stuff();
-  void deinitV8Stuff();
   void signalStuffInit();
   void signalStuffDeinit();
 

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -40,7 +40,6 @@
 #include "Statistics/RequestStatistics.h"
 #include "Statistics/ServerStatistics.h"
 #include "Statistics/StatisticsWorker.h"
-#include "V8Server/V8DealerFeature.h"
 #include "VocBase/vocbase.h"
 
 #include <chrono>

--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -28,6 +28,7 @@
 
 #include "Actions/ActionFeature.h"
 #include "Actions/actions.h"
+#include "Agency/v8-agency.h"
 #include "ApplicationFeatures/V8PlatformFeature.h"
 #include "ApplicationFeatures/V8SecurityFeature.h"
 #include "Basics/ArangoGlobalContext.h"
@@ -41,6 +42,7 @@
 #include "Basics/system-functions.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ServerState.h"
+#include "Cluster/v8-cluster.h"
 #include "FeaturePhases/ClusterFeaturePhase.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
@@ -49,8 +51,10 @@
 #include "ProgramOptions/Section.h"
 #include "Random/RandomGenerator.h"
 #include "Rest/Version.h"
+#include "RestServer/DatabaseFeature.h"
 #include "RestServer/DatabasePathFeature.h"
 #include "RestServer/FrontendFeature.h"
+#include "RestServer/QueryRegistryFeature.h"
 #include "RestServer/ScriptFeature.h"
 #include "RestServer/SystemDatabaseFeature.h"
 #include "Scheduler/SchedulerFeature.h"
@@ -65,9 +69,12 @@
 #include "V8Server/FoxxQueuesFeature.h"
 #include "V8Server/V8Context.h"
 #include "V8Server/v8-actions.h"
+#include "V8Server/v8-dispatcher.h"
+#include "V8Server/v8-query.h"
 #include "V8Server/v8-ttl.h"
 #include "V8Server/v8-user-functions.h"
 #include "V8Server/v8-user-structures.h"
+#include "V8Server/v8-vocbase.h"
 #include "VocBase/vocbase.h"
 
 using namespace arangodb;
@@ -120,6 +127,9 @@ V8DealerFeature::V8DealerFeature(application_features::ApplicationServer& server
       _stopping(false),
       _gcFinished(false),
       _dynamicContextCreationBlockers(0),
+      _contextsCreationTime(
+        server.getFeature<arangodb::MetricsFeature>().counter(
+          "arangodb_v8_context_creation_time_msec", 0, "Total time for creating V8 contexts [ms]")),
       _contextsCreated(server.getFeature<arangodb::MetricsFeature>().counter(
           "arangodb_v8_context_created", 0, "V8 contexts created")),
       _contextsDestroyed(server.getFeature<arangodb::MetricsFeature>().counter(
@@ -450,6 +460,7 @@ void V8DealerFeature::start() {
 
   defineDouble("V8_CONTEXTS", static_cast<double>(_nrMaxContexts));
 
+  DatabaseFeature& databaseFeature = server().getFeature<DatabaseFeature>();
   // setup instances
   {
     CONDITION_LOCKER(guard, _contextCondition);
@@ -460,26 +471,28 @@ void V8DealerFeature::start() {
 
     for (size_t i = 0; i < _nrMinContexts; ++i) {
       guard.unlock();  // avoid lock order inversion in buildContext
-      V8Context* context = buildContext(nextId());
-      guard.lock();
-      TRI_ASSERT(context != nullptr);
+
+      // use vocbase here and hand ownership to context
+      TRI_vocbase_t* vocbase = databaseFeature.useDatabase(StaticStrings::SystemDatabase);
+      TRI_ASSERT(vocbase != nullptr);
+
+      V8Context* context;
       try {
-        _contexts.push_back(context);
+        context = buildContext(vocbase, nextId());
+        TRI_ASSERT(context != nullptr);
       } catch (...) {
-        delete context;
-        throw;
+        vocbase->release();
       }
+      
+      guard.lock();
+      // push_back will not fail as we reserved enough memory before
+      _contexts.push_back(context);
       ++_contextsCreated;
     }
 
     TRI_ASSERT(_contexts.size() > 0);
     TRI_ASSERT(_contexts.size() <= _nrMaxContexts);
     for (auto& context : _contexts) {
-      // apply context update is only run on contexts that no other
-      // threads can see (yet)
-      guard.unlock();
-      applyContextUpdate(context);
-      guard.lock();
       _idleContexts.push_back(context);
     }
   }
@@ -624,32 +637,40 @@ V8Context* V8DealerFeature::addContext() {
   if (server().isStopping()) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
   }
-
-  V8Context* context = buildContext(nextId());
+  
+  DatabaseFeature& databaseFeature = server().getFeature<DatabaseFeature>();
+  // use vocbase here and hand ownership to context
+  TRI_vocbase_t* vocbase = databaseFeature.useDatabase(StaticStrings::SystemDatabase);
+  TRI_ASSERT(vocbase != nullptr);
 
   try {
-    // apply context update is only run on contexts that no other
-    // threads can see (yet)
-    applyContextUpdate(context);
+    // vocbase will be released when the context is garbage collected
+    V8Context* context = buildContext(vocbase, nextId());
+    TRI_ASSERT(context != nullptr);
 
-    auto& sysDbFeature = server().getFeature<arangodb::SystemDatabaseFeature>();
-    auto database = sysDbFeature.use();
+    try {
+      auto& sysDbFeature = server().getFeature<arangodb::SystemDatabaseFeature>();
+      auto database = sysDbFeature.use();
 
-    TRI_ASSERT(database != nullptr);
+      TRI_ASSERT(database != nullptr);
 
-    // no other thread can use the context when we are here, as the
-    // context has not been added to the global list of contexts yet
-    loadJavaScriptFileInContext(database.get(), "server/initialize.js", context, nullptr);
+      // no other thread can use the context when we are here, as the
+      // context has not been added to the global list of contexts yet
+      loadJavaScriptFileInContext(database.get(), "server/initialize.js", context, nullptr);
 
-    ++_contextsCreated;
+      ++_contextsCreated;
 
-    return context;
+      return context;
+    } catch (...) {
+      delete context;
+      throw;
+    }
   } catch (...) {
-    delete context;
+    vocbase->release();
     throw;
   }
 }
-
+  
 void V8DealerFeature::unprepare() {
   shutdownContexts();
 
@@ -829,6 +850,7 @@ void V8DealerFeature::unblockDynamicContextCreation() {
   --_dynamicContextCreationBlockers;
 }
 
+/// @brief loads a JavaScript file in all contexts, only called at startup
 void V8DealerFeature::loadJavaScriptFileInAllContexts(TRI_vocbase_t* vocbase,
                                                       std::string const& file,
                                                       VPackBuilder* builder) {
@@ -1276,57 +1298,6 @@ void V8DealerFeature::exitContext(V8Context* context) {
   ++_contextsExited;
 }
 
-void V8DealerFeature::defineContextUpdate(
-    std::function<void(v8::Isolate*, v8::Handle<v8::Context>, size_t)> func,
-    TRI_vocbase_t* vocbase) {
-  _contextUpdates.emplace_back(func, vocbase);
-}
-
-// apply context update is only run on contexts that no other
-// threads can see (yet)
-void V8DealerFeature::applyContextUpdate(V8Context* context) {
-  for (auto& p : _contextUpdates) {
-    auto vocbase = p.second;
-
-    if (vocbase == nullptr) {
-      vocbase =
-          server().hasFeature<arangodb::SystemDatabaseFeature>()
-              ? server().getFeature<arangodb::SystemDatabaseFeature>().use().get()
-              : nullptr;
-
-      if (!vocbase) {
-        continue;
-      }
-    }
-
-    if (!vocbase->use()) {
-      // oops
-      continue;
-    }
-
-    JavaScriptSecurityContext securityContext = JavaScriptSecurityContext::createInternalContext();
-
-    context->lockAndEnter();
-    prepareLockedContext(vocbase, context, securityContext);
-    TRI_DEFER(exitContextInternal(context));
-
-    {
-      v8::HandleScope scope(context->_isolate);
-      auto localContext = v8::Local<v8::Context>::New(context->_isolate, context->_context);
-      localContext->Enter();
-
-      {
-        v8::Context::Scope contextScope(localContext);
-        p.first(context->_isolate, localContext, context->id());
-      }
-
-      localContext->Exit();
-    }
-
-    LOG_TOPIC("73e16", TRACE, arangodb::Logger::V8) << "updated V8 context #" << context->id();
-  }
-}
-
 void V8DealerFeature::shutdownContexts() {
   _stopping = true;
 
@@ -1467,17 +1438,21 @@ V8Context* V8DealerFeature::pickFreeContextForGc() {
   return context;
 }
 
-V8Context* V8DealerFeature::buildContext(size_t id) {
-  V8PlatformFeature& v8platform = server().getFeature<V8PlatformFeature>();
+V8Context* V8DealerFeature::buildContext(TRI_vocbase_t* vocbase, size_t id) {
+  double const start = TRI_microtime();
 
+  V8PlatformFeature& v8platform = server().getFeature<V8PlatformFeature>();
+      
   // create isolate
   v8::Isolate* isolate = v8platform.createIsolate();
   TRI_ASSERT(isolate != nullptr);
 
-  // pass isolate to a new context
-  auto context = std::make_unique<V8Context>(id, isolate);
+  std::unique_ptr<V8Context> context;
 
   try {
+    // pass isolate to a new context
+    context = std::make_unique<V8Context>(id, isolate);
+  
     // this guard will lock and enter the isolate
     // and automatically exit and unlock it when it runs out of scope
     V8ContextEntryGuard contextGuard(context.get());
@@ -1495,7 +1470,7 @@ V8Context* V8DealerFeature::buildContext(size_t id) {
     {
       v8::Context::Scope contextScope(localContext);
 
-      TRI_CreateV8Globals(server(), isolate, id);
+      TRI_v8_global_t* v8g = TRI_CreateV8Globals(server(), isolate, id);
       context->_context.Reset(context->_isolate, localContext);
 
       if (context->_context.IsEmpty()) {
@@ -1527,6 +1502,7 @@ V8Context* V8DealerFeature::buildContext(size_t id) {
                    FileUtils::buildFilename(directory, "common/modules") + sep +
                    FileUtils::buildFilename(directory, "node");
       }
+
       TRI_InitV8UserFunctions(isolate, localContext);
       TRI_InitV8UserStructures(isolate, localContext);
       TRI_InitV8Buffer(isolate);
@@ -1534,7 +1510,7 @@ V8Context* V8DealerFeature::buildContext(size_t id) {
       TRI_InitV8ServerUtils(isolate);
       TRI_InitV8Shell(isolate);
       TRI_InitV8Ttl(isolate);
-
+    
       {
         v8::HandleScope scope(isolate);
 
@@ -1565,6 +1541,24 @@ V8Context* V8DealerFeature::buildContext(size_t id) {
               .FromMaybe(false);  // Ignore it...
         }
       }
+      
+      auto queryRegistry = QueryRegistryFeature::registry();
+      TRI_ASSERT(queryRegistry != nullptr);
+  
+      JavaScriptSecurityContext old(v8g->_securityContext);
+      v8g->_securityContext = JavaScriptSecurityContext::createInternalContext();
+
+      {
+        TRI_InitV8VocBridge(isolate, localContext, queryRegistry, *vocbase, id);
+        TRI_InitV8Queries(isolate, localContext);
+        TRI_InitV8Cluster(isolate, localContext);
+        TRI_InitV8Agency(isolate, localContext);
+        TRI_InitV8Dispatcher(isolate, localContext);
+        TRI_InitV8Actions(isolate);
+      }
+    
+      // restore old security settings
+      v8g->_securityContext = old;
     }
 
     // and return from the context
@@ -1580,11 +1574,16 @@ V8Context* V8DealerFeature::buildContext(size_t id) {
   // this avoids collecting all contexts at the very same time
   double const randomWait = static_cast<double>(RandomGenerator::interval(0, 60));
 
+  double const now = TRI_microtime();
+
   // initialize garbage collection for context
   context->_hasActiveExternals = true;
-  context->_lastGcStamp = TRI_microtime() + randomWait;
+  context->_lastGcStamp = now + randomWait;
 
-  LOG_TOPIC("83428", TRACE, arangodb::Logger::V8) << "initialized V8 context #" << id;
+  LOG_TOPIC("83428", TRACE, arangodb::Logger::V8) << "initialized V8 context #" << id << " in " << Logger::FIXED(now - start, 6) << " s";
+ 
+  // add context creation time to global metrics
+  _contextsCreationTime += static_cast<uint64_t>(1000 * (now - start));
 
   return context.release();
 }

--- a/arangod/V8Server/V8DealerFeature.h
+++ b/arangod/V8Server/V8DealerFeature.h
@@ -94,9 +94,10 @@ class V8DealerFeature final : public application_features::ApplicationFeature {
   bool addGlobalContextMethod(std::string const&);
   void collectGarbage();
 
-  // In the following two, if the builder pointer is not nullptr, then
-  // the Javascript result(s) are returned as VPack in the builder,
-  // the builder is not cleared and thus should be empty before the call.
+  /// @brief loads a JavaScript file in all contexts, only called at startup.
+  /// if the builder pointer is not nullptr, then
+  /// the Javascript result(s) are returned as VPack in the builder,
+  /// the builder is not cleared and thus should be empty before the call.
   void loadJavaScriptFileInAllContexts(TRI_vocbase_t*, std::string const& file,
                                        VPackBuilder* builder);
 
@@ -104,9 +105,6 @@ class V8DealerFeature final : public application_features::ApplicationFeature {
   /// currently returns a nullptr if no context can be acquired in time
   V8Context* enterContext(TRI_vocbase_t*, JavaScriptSecurityContext const& securityContext);
   void exitContext(V8Context*);
-
-  void defineContextUpdate(std::function<void(v8::Isolate*, v8::Handle<v8::Context>, size_t)>,
-                           TRI_vocbase_t*);
 
   void setMinimumContexts(size_t nr) {
     if (nr > _nrMinContexts) {
@@ -136,7 +134,7 @@ class V8DealerFeature final : public application_features::ApplicationFeature {
   void copyInstallationFiles();
   void startGarbageCollection();
   V8Context* addContext();
-  V8Context* buildContext(size_t id);
+  V8Context* buildContext(TRI_vocbase_t* vocbase, size_t id);
   V8Context* pickFreeContextForGc();
   void shutdownContext(V8Context* context);
   void unblockDynamicContextCreation();
@@ -169,8 +167,7 @@ class V8DealerFeature final : public application_features::ApplicationFeature {
   std::map<std::string, double> _definedDoubles;
   std::map<std::string, std::string> _definedStrings;
 
-  std::vector<std::pair<std::function<void(v8::Isolate*, v8::Handle<v8::Context>, size_t)>, TRI_vocbase_t*>> _contextUpdates;
-
+  Counter& _contextsCreationTime;
   Counter& _contextsCreated;
   Counter& _contextsDestroyed;
   Counter& _contextsEntered;

--- a/arangod/V8Server/v8-dispatcher.cpp
+++ b/arangod/V8Server/v8-dispatcher.cpp
@@ -445,13 +445,3 @@ void TRI_InitV8Dispatcher(v8::Isolate* isolate, v8::Handle<v8::Context> context)
   TRI_AddGlobalFunctionVocbase(isolate,
                                TRI_V8_ASCII_STRING(isolate, "SYS_GET_TASK"), JS_GetTask);
 }
-
-void TRI_ShutdownV8Dispatcher() {
-  using arangodb::Task;
-  Task::shutdownTasks();
-}
-
-void TRI_RemoveDatabaseTasksV8Dispatcher(std::string const& name) {
-  using arangodb::Task;
-  Task::removeTasksForDatabase(name);
-}

--- a/arangod/V8Server/v8-dispatcher.h
+++ b/arangod/V8Server/v8-dispatcher.h
@@ -30,7 +30,5 @@
 #include <v8.h>
 
 void TRI_InitV8Dispatcher(v8::Isolate* isolate, v8::Handle<v8::Context> context);
-void TRI_ShutdownV8Dispatcher();
-void TRI_RemoveDatabaseTasksV8Dispatcher(std::string const& databaseName);
 
 #endif

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -46,8 +46,8 @@
 #include "V8/v8-vpack.h"
 #include "V8Server/V8Context.h"
 #include "V8Server/V8DealerFeature.h"
-#include "V8Server/v8-dispatcher.h"
 #include "V8Server/v8-user-structures.h"
+#include "VocBase/Methods/Tasks.h"
 #include "VocBase/Methods/Upgrade.h"
 #include "VocBase/vocbase.h"
 
@@ -422,7 +422,7 @@ arangodb::Result Databases::drop(TRI_vocbase_t* systemVocbase, std::string const
           return Result(res);
         }
 
-        TRI_RemoveDatabaseTasksV8Dispatcher(dbName);
+        arangodb::Task::removeTasksForDatabase(dbName);
         // run the garbage collection in case the database held some objects
         // which can now be freed
         TRI_RunGarbageCollectionV8(isolate, 0.25);

--- a/arangod/VocBase/Methods/Tasks.cpp
+++ b/arangod/VocBase/Methods/Tasks.cpp
@@ -219,6 +219,12 @@ void Task::removeTasksForDatabase(std::string const& name) {
 }
 
 bool Task::tryCompile(v8::Isolate* isolate, std::string const& command) {
+  if (!V8DealerFeature::DEALER || !V8DealerFeature::DEALER->isEnabled()) {
+    return false;
+  }
+
+  TRI_ASSERT(isolate != nullptr);
+
   v8::HandleScope scope(isolate);
   auto context = TRI_IGETC;
   // get built-in Function constructor (see ECMA-262 5th edition 15.3.2)
@@ -364,6 +370,10 @@ void Task::start() {
 }
 
 bool Task::queue(std::chrono::microseconds offset) {
+  if (!V8DealerFeature::DEALER || !V8DealerFeature::DEALER->isEnabled()) {
+    return false;
+  }
+
   MUTEX_LOCKER(lock, _taskHandleMutex);
   bool queued = false;
   std::tie(queued, _taskHandle) =

--- a/js/client/bootstrap/modules/internal.js
+++ b/js/client/bootstrap/modules/internal.js
@@ -153,7 +153,10 @@
   // //////////////////////////////////////////////////////////////////////////////
 
   exports.reloadRouting = function () {
-    exports.arango.POST('/_admin/routing/reload', null);
+    const arangosh = require('@arangodb/arangosh');
+    let requestResult = exports.arango.POST('/_admin/routing/reload', null);
+    arangosh.checkRequestResult(requestResult);
+    return requestResult;
   };
 
   // //////////////////////////////////////////////////////////////////////////////

--- a/js/common/bootstrap/modules/internal.js
+++ b/js/common/bootstrap/modules/internal.js
@@ -1673,12 +1673,12 @@ global.DEFINE_MODULE('internal', (function () {
   // / @brief isArangod - find out if we are in a cluster setup or not
   // //////////////////////////////////////////////////////////////////////////////
   exports.isCluster = function() {
-    if(exports.isArangod()) {
+    if (exports.isArangod()) {
       return require("@arangodb/cluster").isCluster();
     } else {
       // ask remote it is a coordinator
       const response = exports.arango.GET('/_admin/server/role');
-      if(response.error === true) {
+      if (response.error === true) {
         throw new exports.ArangoError(response);
       }
       return (response.role === "COORDINATOR");

--- a/tests/js/client/server_parameters/test-javascript-disabled.js
+++ b/tests/js/client/server_parameters/test-javascript-disabled.js
@@ -1,0 +1,103 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertNotEqual, fail, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for security-related server options
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'javascript.enabled': "false"
+  };
+}
+let jsunity = require('jsunity');
+const errors = require('@arangodb').errors;
+const cn = "UnitTestsCollection";
+let db = require('internal').db;
+
+function testSuite() {
+  return {
+    testCallNonExistingJavaScriptRestRoute : function() {
+      let result = arango.GET('/dudel/doedel');
+      assertEqual(errors.ERROR_NOT_IMPLEMENTED.code, result.errorNum);
+    },
+    
+    testCallReloadRouting : function() {
+      try {
+        require('internal').reloadRouting();
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_NOT_IMPLEMENTED.code, err.errorNum);
+      }
+    },
+    
+    testRunSimpleQuery : function() {
+      try {
+        db['_graphs'].any();
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_NOT_IMPLEMENTED.code, err.errorNum);
+      }
+    },
+    
+    testRegisterAqlUDF : function() {
+      try {
+        require('@arangodb/aql/functions').register('foo::bar', function () { return 1; });
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_NOT_IMPLEMENTED.code, err.errorNum);
+      }
+    },
+    
+    testRunJavaScriptTransaction : function() {
+      try {
+        db._executeTransaction({
+          collections: {},
+          action: function() { return 1; }
+        });
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_NOT_IMPLEMENTED.code, err.errorNum);
+      }
+    },
+    
+    testRegisterJavaScriptTask : function() {
+      try {
+        require('@arangodb/tasks').register({
+          name: 'UnitTestTasks',
+          command: 'return 1;'
+        });
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_NOT_IMPLEMENTED.code, err.errorNum);
+      }
+    },
+    
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

This PR adds safeguards against using V8 internally in environments that have JavaScript turned off via the `--javascript.enabled false` option.

The PR also moves a bit of V8 context initialization code from the Scheduler and the DatabaseFeature into the V8DealerFeature, so it is now all in one place.

Finally it adds a new metrics that tracks the total time it took to create V8 contexts.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [x] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] Backports required for: 3.7

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] This change is already covered by existing tests, such as *shell_client, shell_server, http_server*.
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (i.e. in server_parameters)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/11960/