### PR TITLE
take a copy before moving from the same object

### DIFF
--- a/arangod/Aql/QueryRegistry.cpp
+++ b/arangod/Aql/QueryRegistry.cpp
@@ -22,7 +22,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "QueryRegistry.h"
-#include <Cluster/CallbackGuard.h>
 
 #include "Aql/AqlItemBlock.h"
 #include "Aql/ClusterQuery.h"
@@ -30,6 +29,7 @@
 #include "Basics/ReadLocker.h"
 #include "Basics/WriteLocker.h"
 #include "Basics/system-functions.h"
+#include "Cluster/CallbackGuard.h"
 #include "Cluster/ServerState.h"
 #include "Cluster/TraverserEngine.h"
 #include "Logger/LogMacros.h"


### PR DESCRIPTION
### Scope & Purpose

The following existing code
```
    auth::User user = auth::User::fromDocument(s);
    result.try_emplace(user.username(), std::move(user));
```
moves frod `user` and accesses a member function of `user` in the same expression.

In practice, this should be safe, because the map's insert key should be calculated first, and the value is only moved from if the key does not exist in the map.
But I couldn't find any proof that this is guaranteed to be safe.
So changing it to an intentional and explicit copy to avoid potential UB:
```
    auth::User user = auth::User::fromDocument(s);
    // intentional copy, as we are about to move-away from user
    std::string username = user.username();
    result.try_emplace(std::move(username), std::move(user));
```

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [ ] Backports required for: *(Please specify versions)*

### Testing & Verification

- [x] This change is already covered by existing tests, such as *any authentication/user tests*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12004/