### PR TITLE
fix "hash" property in /_admin/status?overview=true case

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -4898,7 +4898,7 @@ void ClusterInfo::invalidateCurrentMappings() {
 /// @brief get current "Plan" structure
 //////////////////////////////////////////////////////////////////////////////
 
-std::unordered_map<std::string,std::shared_ptr<VPackBuilder>>
+std::unordered_map<std::string, std::shared_ptr<VPackBuilder>>
 ClusterInfo::getPlan(uint64_t& index, std::unordered_set<std::string> const& dirty) {
   if (!_planProt.isValid) {
     loadPlan();

--- a/arangod/RestHandler/RestRepairHandler.cpp
+++ b/arangod/RestHandler/RestRepairHandler.cpp
@@ -132,8 +132,8 @@ RestStatus RestRepairHandler::repairDistributeShardsLike() {
       return RestStatus::DONE;
     }
 
-    auto [b,i] = agencyCache.get("arango/Plan");
-    VPackSlice plan = b->slice().get(std::vector<std::string>{AgencyCommHelper::path(),"Plan"});
+    auto [b, i] = agencyCache.get("arango/Plan");
+    VPackSlice plan = b->slice().get(std::vector<std::string>{AgencyCommHelper::path(), "Plan"});
     VPackSlice planCollections = plan.get("Collections");
 
     ResultT<VPackBufferPtr> healthResult = getFromAgency("Supervision/Health");

--- a/tests/js/client/shell/shell-admin-status.js
+++ b/tests/js/client/shell/shell-admin-status.js
@@ -1,0 +1,84 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global assertTrue, assertEqual, assertNotEqual, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief ArangoTransaction sTests
+// /
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2018 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// //////////////////////////////////////////////////////////////////////////////
+
+let jsunity = require('jsunity');
+
+function adminStatusSuite () {
+  'use strict';
+  
+  return {
+
+    testShort: function () {
+      let result = arango.GET('/_admin/status');
+
+      assertEqual("arango", result.server);
+      
+      assertTrue(result.hasOwnProperty("version"));
+      
+      assertTrue(result.hasOwnProperty("pid"));
+      assertEqual("number", typeof result.pid);
+      
+      assertTrue(result.hasOwnProperty("license"));
+      assertNotEqual(-1, ["enterprise", "community"].indexOf(result.license));
+      
+      assertEqual("server", result.mode);
+      assertEqual("server", result.operationMode);
+
+      assertTrue(result.hasOwnProperty("foxxApi"));
+
+      assertTrue(result.hasOwnProperty("host"));
+      assertEqual("string", typeof result.host);
+      
+      assertTrue(result.hasOwnProperty("serverInfo"));
+      assertTrue(result.serverInfo.hasOwnProperty("maintenance"));
+      assertTrue(result.serverInfo.hasOwnProperty("role"));
+      assertNotEqual(-1, ["SINGLE", "COORDINATOR"].indexOf(result.serverInfo.role));
+      assertTrue(result.serverInfo.hasOwnProperty("readOnly"));
+      assertTrue(result.serverInfo.hasOwnProperty("writeOpsEnabled"));
+    },
+    
+    testOverview: function () {
+      let result = arango.GET('/_admin/status?overview=true');
+
+      assertTrue(result.hasOwnProperty("version"));
+      assertTrue(result.hasOwnProperty("platform"));
+      assertTrue(result.hasOwnProperty("license"));
+      assertNotEqual(-1, ["enterprise", "community"].indexOf(result.license));
+      assertTrue(result.hasOwnProperty("engine"));
+      assertTrue(result.hasOwnProperty("role"));
+      assertNotEqual(-1, ["SINGLE", "COORDINATOR"].indexOf(result.role));
+      assertTrue(result.hasOwnProperty("hash"));
+      assertTrue(result.hash.length > 0);
+    },
+
+  };
+}
+
+jsunity.run(adminStatusSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

For generating the "hash" property value, the current Plan was retrieved to find out the number of Coordinators and DBServers. The return value of getPlan seems to have changed in 3.7, and the code here was not adjusted. 
This PR fixes it and adds a test.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.7

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (i.e. in shell_client)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12008/