### PR TITLE
fix "hash" property in /_admin/status?overview=true case

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,10 +2,10 @@ v3.7.3 (XXXX-XX-XX)
 -------------------
 
 * Fix REST handler GET /_admin/status when called with URL parameter value
-  `overview=true`. For generating the `hash` attribute in the response, the 
-  current Plan was retrieved and analyzed. Due to a change in the internal
-  Plan format the REST handler code failed to pick up the number of servers,
-  which resulted in the REST handler returning HTTP 500 in cluster mode.
+  `overview=true`. For generating the `hash` attribute in the response, the
+  current Plan was retrieved and analyzed. Due to a change in the internal Plan
+  format the REST handler code failed to pick up the number of servers, which
+  resulted in the REST handler returning HTTP 500 in cluster mode.
 
 * Use rclone built from v1.51.0 source with go1.15.2 instead of prebuilt
   v1.51.0 release.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-v3.7.4 (XXXX-XX-XX)
+v3.7.3 (XXXX-XX-XX)
 -------------------
 
 * Fix REST handler GET /_admin/status when called with URL parameter value
@@ -6,10 +6,6 @@ v3.7.4 (XXXX-XX-XX)
   current Plan was retrieved and analyzed. Due to a change in the internal
   Plan format the REST handler code failed to pick up the number of servers,
   which resulted in the REST handler returning HTTP 500 in cluster mode.
-
-
-v3.7.3 (XXXX-XX-XX)
--------------------
 
 * Use rclone built from v1.51.0 source with go1.15.2 instead of prebuilt
   v1.51.0 release.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+v3.7.4 (XXXX-XX-XX)
+-------------------
+
+* Fix REST handler GET /_admin/status when called with URL parameter value
+  `overview=true`. For generating the `hash` attribute in the response, the 
+  current Plan was retrieved and analyzed. Due to a change in the internal
+  Plan format the REST handler code failed to pick up the number of servers,
+  which resulted in the REST handler returning HTTP 500 in cluster mode.
+
+
 v3.7.3 (XXXX-XX-XX)
 -------------------
 

--- a/arangod/RestHandler/RestStatusHandler.cpp
+++ b/arangod/RestHandler/RestStatusHandler.cpp
@@ -36,7 +36,7 @@
 #include "Agency/AsyncAgencyComm.h"
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/StringBuffer.h"
-#include "Cluster/ClusterInfo.h"
+#include "Cluster/AgencyCache.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ServerState.h"
 #include "GeneralServer/ServerSecurityFeature.h"
@@ -75,7 +75,7 @@ RestStatus RestStatusHandler::execute() {
 
 RestStatus RestStatusHandler::executeStandard(ServerSecurityFeature& security) {
   VPackBuilder result;
-  result.add(VPackValue(VPackValueType::Object));
+  result.openObject();
   result.add("server", VPackValue("arango"));
   result.add("version", VPackValue(ARANGODB_VERSION));
 
@@ -181,7 +181,7 @@ RestStatus RestStatusHandler::executeStandard(ServerSecurityFeature& security) {
 RestStatus RestStatusHandler::executeOverview() {
   VPackBuilder result;
 
-  result.add(VPackValue(VPackValueType::Object));
+  result.openObject();
   result.add("version", VPackValue(ARANGODB_VERSION));
   result.add("platform", VPackValue(TRI_PLATFORM));
 
@@ -205,15 +205,21 @@ RestStatus RestStatusHandler::executeOverview() {
     result.add("role", VPackValue(ServerState::roleToString(role)));
 
     if (role == ServerState::ROLE_COORDINATOR) {
-      ClusterInfo& ci = server().getFeature<ClusterFeature>().clusterInfo();
-      auto plan = ci.getPlan();
+      AgencyCache& agencyCache = server().getFeature<ClusterFeature>().agencyCache();
+      auto [b, i] = agencyCache.get("arango/Plan");
+    
+      VPackSlice planSlice = b->slice().get(std::vector<std::string>{AgencyCommHelper::path(), "Plan"});
 
-      if (plan != nullptr) {
-        auto coordinators = plan->slice().get("Coordinators");
-        buffer.appendHex(static_cast<uint32_t>(VPackObjectIterator(coordinators).size()));
-        buffer.appendText("-");
-        auto dbservers = plan->slice().get("DBServers");
-        buffer.appendHex(static_cast<uint32_t>(VPackObjectIterator(dbservers).size()));
+      if (planSlice.isObject()) {
+        if (planSlice.hasKey("Coordinators")) {
+          auto coordinators =  planSlice.get("Coordinators");
+          buffer.appendHex(static_cast<uint32_t>(VPackObjectIterator(coordinators).size()));
+          buffer.appendText("-");
+        }
+        if (planSlice.hasKey("DBServers")) {
+          auto dbservers = planSlice.get("DBServers");
+          buffer.appendHex(static_cast<uint32_t>(VPackObjectIterator(dbservers).size()));
+        }
       } else {
         buffer.appendHex(static_cast<uint32_t>(0xFFFF));
         buffer.appendText("-");

--- a/tests/js/client/shell/shell-admin-status.js
+++ b/tests/js/client/shell/shell-admin-status.js
@@ -1,0 +1,84 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global assertTrue, assertEqual, assertNotEqual, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief ArangoTransaction sTests
+// /
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2018 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// //////////////////////////////////////////////////////////////////////////////
+
+let jsunity = require('jsunity');
+
+function adminStatusSuite () {
+  'use strict';
+  
+  return {
+
+    testShort: function () {
+      let result = arango.GET('/_admin/status');
+
+      assertEqual("arango", result.server);
+      
+      assertTrue(result.hasOwnProperty("version"));
+      
+      assertTrue(result.hasOwnProperty("pid"));
+      assertEqual("number", typeof result.pid);
+      
+      assertTrue(result.hasOwnProperty("license"));
+      assertNotEqual(-1, ["enterprise", "community"].indexOf(result.license));
+      
+      assertEqual("server", result.mode);
+      assertEqual("server", result.operationMode);
+
+      assertTrue(result.hasOwnProperty("foxxApi"));
+
+      assertTrue(result.hasOwnProperty("host"));
+      assertEqual("string", typeof result.host);
+      
+      assertTrue(result.hasOwnProperty("serverInfo"));
+      assertTrue(result.serverInfo.hasOwnProperty("maintenance"));
+      assertTrue(result.serverInfo.hasOwnProperty("role"));
+      assertNotEqual(-1, ["SINGLE", "COORDINATOR"].indexOf(result.serverInfo.role));
+      assertTrue(result.serverInfo.hasOwnProperty("readOnly"));
+      assertTrue(result.serverInfo.hasOwnProperty("writeOpsEnabled"));
+    },
+    
+    testOverview: function () {
+      let result = arango.GET('/_admin/status?overview=true');
+
+      assertTrue(result.hasOwnProperty("version"));
+      assertTrue(result.hasOwnProperty("platform"));
+      assertTrue(result.hasOwnProperty("license"));
+      assertNotEqual(-1, ["enterprise", "community"].indexOf(result.license));
+      assertTrue(result.hasOwnProperty("engine"));
+      assertTrue(result.hasOwnProperty("role"));
+      assertNotEqual(-1, ["SINGLE", "COORDINATOR"].indexOf(result.role));
+      assertTrue(result.hasOwnProperty("hash"));
+      assertTrue(result.hash.length > 0);
+    },
+
+  };
+}
+
+jsunity.run(adminStatusSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

For generating the "hash" property value, the current Plan was retrieved to find out the number of Coordinators and DBServers. The return value of getPlan seems to have changed in 3.7, and the code here was not adjusted. 
This PR fixes it and adds a test.

Backport #12723 

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.7

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (i.e. in shell_client)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12010/