### PR TITLE
make clang version 12.0.0 happy

### DIFF
--- a/arangod/Agency/AddFollower.cpp
+++ b/arangod/Agency/AddFollower.cpp
@@ -165,7 +165,7 @@ bool AddFollower::start(bool&) {
   {
     VPackArrayBuilder guard(&onlyFollowers);
     bool first = true;
-    for (auto const& pp : VPackArrayIterator(planned)) {
+    for (auto&& pp : VPackArrayIterator(planned)) {
       if (!first) {
         onlyFollowers.add(pp);
       }

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -1179,7 +1179,7 @@ trans_ret_t Agent::transact(query_t const& queries) {
     _tiLock.assertNotLockedByCurrentThread();
     MUTEX_LOCKER(ioLocker, _ioLock);
 
-    for (const auto& query : VPackArrayIterator(qs)) {
+    for (auto&& query : VPackArrayIterator(qs)) {
       // Check that we are actually still the leader:
       if (!leading()) {
         return trans_ret_t(false, NO_LEADER);
@@ -1245,7 +1245,7 @@ trans_ret_t Agent::transient(query_t const& queries) {
     MUTEX_LOCKER(transientLocker, _transientLock);
 
     // Read and writes
-    for (const auto& query : VPackArrayIterator(queries->slice())) {
+    for (const auto&& query : VPackArrayIterator(queries->slice())) {
       if (query[0].isObject()) {
         ret->add(VPackValue(_transient.applyTransaction(query).successful()));
       } else if (query[0].isString()) {
@@ -2208,7 +2208,7 @@ void Agent::trashStoreCallback(std::string const& url, VPackSlice slice) {
 
   // body consists of object holding keys index, term and the observed keys
   // we'll remove observation on every key and according observer url
-  for (auto const& i : VPackObjectIterator(slice)) {
+  for (auto&& i : VPackObjectIterator(slice)) {
     if (!i.key.isEqualString("term") && !i.key.isEqualString("index")) {
       MUTEX_LOCKER(lock, _cbtLock);
       _callbackTrashBin[i.key.copyString()].emplace(url);
@@ -2320,7 +2320,7 @@ query_t Agent::buildDB(arangodb::consensus::index_t index) {
 void Agent::addTrxsOngoing(Slice trxs) {
   try {
     MUTEX_LOCKER(guard, _trxsLock);
-    for (auto const& trx : VPackArrayIterator(trxs)) {
+    for (auto&& trx : VPackArrayIterator(trxs)) {
       if (trx.isArray() && trx.length() == 3 && trx[0].isObject() && trx[2].isString()) {
         // only those are interesting:
         _ongoingTrxs.insert(trx[2].copyString());
@@ -2333,7 +2333,7 @@ void Agent::addTrxsOngoing(Slice trxs) {
 void Agent::removeTrxsOngoing(Slice trxs) {
   try {
     MUTEX_LOCKER(guard, _trxsLock);
-    for (auto const& trx : VPackArrayIterator(trxs)) {
+    for (auto&& trx : VPackArrayIterator(trxs)) {
       if (trx.isArray() && trx.length() == 3 && trx[0].isObject() && trx[2].isString()) {
         // only those are interesting:
         _ongoingTrxs.erase(trx[2].copyString());

--- a/arangod/Agency/AgentConfiguration.cpp
+++ b/arangod/Agency/AgentConfiguration.cpp
@@ -295,7 +295,7 @@ bool config_t::addGossipPeer(std::string const& endpoint) {
 config_t::upsert_t config_t::upsertPool(VPackSlice const& otherPool,
                                         std::string const& otherId) {
   WRITE_LOCKER(lock, _lock);
-  for (auto const& entry : VPackObjectIterator(otherPool)) {
+  for (auto&& entry : VPackObjectIterator(otherPool)) {
     auto const id = entry.key.copyString();
     auto const endpoint = entry.value.copyString();
     if (_pool.find(id) == _pool.end()) {
@@ -396,7 +396,7 @@ void config_t::update(query_t const& message) {
   VPackSlice slice = message->slice();
   std::unordered_map<std::string, std::string> pool;
   bool changed = false;
-  for (auto const& p : VPackObjectIterator(slice.get(poolStr))) {
+  for (auto&& p : VPackObjectIterator(slice.get(poolStr))) {
     auto const& id = p.key.copyString();
     if (id != _id) {
       pool[id] = p.value.copyString();
@@ -405,7 +405,7 @@ void config_t::update(query_t const& message) {
     }
   }
   std::vector<std::string> active;
-  for (auto const& a : VPackArrayIterator(slice.get(activeStr))) {
+  for (auto&& a : VPackArrayIterator(slice.get(activeStr))) {
     active.push_back(a.copyString());
   }
   double minPing = slice.get(minPingStr).getNumber<double>();
@@ -563,7 +563,7 @@ bool config_t::merge(VPackSlice const& conf) {
   ss << "Agent pool: ";
   if (conf.hasKey(poolStr)) {  // Persistence only
     LOG_TOPIC("fc6ad", DEBUG, Logger::AGENCY) << "Found agent pool in persistence:";
-    for (auto const& peer : VPackObjectIterator(conf.get(poolStr))) {
+    for (auto&& peer : VPackObjectIterator(conf.get(poolStr))) {
       auto const& id = peer.key.copyString();
       if (id != _id) {
         _pool[id] = peer.value.copyString();
@@ -581,7 +581,7 @@ bool config_t::merge(VPackSlice const& conf) {
   ss.clear();
   ss << "Active agents: ";
   if (conf.hasKey(activeStr)) {  // Persistence only?
-    for (auto const& a : VPackArrayIterator(conf.get(activeStr))) {
+    for (auto&& a : VPackArrayIterator(conf.get(activeStr))) {
       _active.push_back(a.copyString());
       ss << a.copyString() << " ";
     }

--- a/arangod/Agency/Constituent.cpp
+++ b/arangod/Agency/Constituent.cpp
@@ -599,7 +599,7 @@ void Constituent::run() {
     VPackSlice result = queryResult.data->slice();
 
     if (result.isArray()) {
-      for (auto const& i : VPackArrayIterator(result)) {
+      for (auto&& i : VPackArrayIterator(result)) {
         auto ii = i.resolveExternals();
         try {
           MUTEX_LOCKER(locker, _termVoteLock);

--- a/arangod/Agency/FailedFollower.cpp
+++ b/arangod/Agency/FailedFollower.cpp
@@ -203,7 +203,7 @@ bool FailedFollower::start(bool& aborts) {
   Builder ns;
   {
     VPackArrayBuilder servers(&ns);
-    for (auto const& i : VPackArrayIterator(planned)) {
+    for (auto&& i : VPackArrayIterator(planned)) {
       auto s = i.copyString();
       ns.add(VPackValue((s != _from) ? s : _to));
     }
@@ -231,7 +231,7 @@ bool FailedFollower::start(bool& aborts) {
           job.add("timeFinished",  // same same :)
                   VPackValue(timepointToString(system_clock::now())));
           job.add("toServer", VPackValue(_to));  // toServer
-          for (auto const& obj : VPackObjectIterator(todo.slice()[0])) {
+          for (auto&& obj : VPackObjectIterator(todo.slice()[0])) {
             job.add(obj.key.copyString(), obj.value);
           }
         }

--- a/arangod/Agency/FailedLeader.cpp
+++ b/arangod/Agency/FailedLeader.cpp
@@ -231,7 +231,7 @@ bool FailedLeader::start(bool& aborts) {
 
   // New plan vector excluding _to and _from
   std::vector<std::string> planv;
-  for (auto const& i : VPackArrayIterator(planned)) {
+  for (auto&& i : VPackArrayIterator(planned)) {
     auto s = i.copyString();
     if (s != _from && s != _to) {
       planv.push_back(s);
@@ -262,7 +262,7 @@ bool FailedLeader::start(bool& aborts) {
           pending.add("timeStarted",  // start
                       VPackValue(timepointToString(system_clock::now())));
           pending.add("toServer", VPackValue(_to));  // toServer
-          for (auto const& obj : VPackObjectIterator(todo.slice()[0])) {
+          for (auto&& obj : VPackObjectIterator(todo.slice()[0])) {
             pending.add(obj.key.copyString(), obj.value);
           }
         }
@@ -275,7 +275,7 @@ bool FailedLeader::start(bool& aborts) {
           // We prefer servers in sync and want to put them early in the new Plan
           // (behind the leader). This helps so that RemoveFollower prefers others
           // to remove.
-          for (auto const& i : VPackArrayIterator(current)) {
+          for (auto&& i : VPackArrayIterator(current)) {
             std::string s = i.copyString();
             if (s.size() > 0 && s[0] == '_') {
               s = s.substr(1);

--- a/arangod/Agency/FailedServer.cpp
+++ b/arangod/Agency/FailedServer.cpp
@@ -95,7 +95,7 @@ bool FailedServer::start(bool& aborts) {
       _snapshot.hasAsSlice(blockedServersPrefix + _server);
   if (auto const& s = dbserverLock.first; dbserverLock.second) {
     if (s.isArray()) {
-      for (auto const& m : VPackArrayIterator(s)) {
+      for (auto&& m : VPackArrayIterator(s)) {
         if (m.isString()) {
           if (!abortJob(m)) {
             return false;
@@ -230,7 +230,7 @@ bool FailedServer::start(bool& aborts) {
         VPackObjectBuilder ts(transactions.get());
         transactions->add("timeStarted",
                           VPackValue(timepointToString(system_clock::now())));
-        for (auto const& obj : VPackObjectIterator(todo.slice()[0])) {
+        for (auto&& obj : VPackObjectIterator(todo.slice()[0])) {
           transactions->add(obj.key.copyString(), obj.value);
         }
       }

--- a/arangod/Agency/Job.cpp
+++ b/arangod/Agency/Job.cpp
@@ -153,7 +153,7 @@ bool Job::finish(std::string const& server, std::string const& shard,
         addRemoveJobFromSomewhere(finished, "Pending", _jobId);
 
         if (operations.length() > 0) {
-          for (auto const& oper : VPackObjectIterator(operations)) {
+          for (auto&& oper : VPackObjectIterator(operations)) {
             finished.add(oper.key.copyString(), oper.value);
           }
         }
@@ -170,7 +170,7 @@ bool Job::finish(std::string const& server, std::string const& shard,
 
       if (preconditions.isObject() && preconditions.length() > 0) {  // preconditions --
         VPackObjectBuilder precguard(&finished);
-        for (auto const& prec : VPackObjectIterator(preconditions)) {
+        for (auto&& prec : VPackObjectIterator(preconditions)) {
           finished.add(prec.key.copyString(), prec.value);
         }
       }  // -- preconditions
@@ -239,7 +239,7 @@ std::string Job::randomIdleAvailableServer(Node const& snap,
 std::string Job::randomIdleAvailableServer(Node const& snap, Slice const& exclude) {
   std::vector<std::string> ev;
   if (exclude.isArray()) {
-    for (const auto& s : VPackArrayIterator(exclude)) {
+    for (const auto&& s : VPackArrayIterator(exclude)) {
       if (s.isString()) {
         ev.push_back(s.copyString());
       }
@@ -505,7 +505,7 @@ std::string Job::findNonblockedCommonHealthyInSyncFollower(  // Which is in "GOO
     // Guaranteed by if above
     TRI_ASSERT(serverList.isArray());
 
-    for (const auto& server : VPackArrayIterator(serverList)) {
+    for (const auto&& server : VPackArrayIterator(serverList)) {
       auto id = server.copyString();
       if (id == serverToAvoid) {
         // Skip current leader for which we are seeking a replacement
@@ -525,7 +525,7 @@ std::string Job::findNonblockedCommonHealthyInSyncFollower(  // Which is in "GOO
       // check if it is also part of the plan...because if not the soon to be
       // leader will drop the collection
       bool found = false;
-      for (const auto& plannedServer :
+      for (const auto&& plannedServer :
            VPackArrayIterator(snap.hasAsArray(plannedShardPath).first)) {
         if (plannedServer.isEqualString(server.stringRef())) {
           found = true;
@@ -658,7 +658,7 @@ void Job::addPutJobIntoSomewhere(Builder& trx, std::string const& where,
       trx.add("timeFinished",
               VPackValue(timepointToString(std::chrono::system_clock::now())));
     }
-    for (auto const& obj : VPackObjectIterator(job)) {
+    for (auto&& obj : VPackObjectIterator(job)) {
       trx.add(obj.key.copyString(), obj.value);
     }
     if (!reason.empty()) {

--- a/arangod/Agency/Job.h
+++ b/arangod/Agency/Job.h
@@ -243,13 +243,13 @@ inline arangodb::consensus::write_ret_t singleWriteTransaction(AgentInterface* _
       VPackArrayBuilder onePair(envelope.get());
       {
         VPackObjectBuilder mutationPart(envelope.get());
-        for (auto const& pair : VPackObjectIterator(trx[0])) {
+        for (auto&& pair : VPackObjectIterator(trx[0])) {
           envelope->add("/" + Job::agencyPrefix + pair.key.copyString(), pair.value);
         }
       }
       if (trx.length() > 1) {
         VPackObjectBuilder preconditionPart(envelope.get());
-        for (auto const& pair : VPackObjectIterator(trx[1])) {
+        for (auto&& pair : VPackObjectIterator(trx[1])) {
           envelope->add("/" + Job::agencyPrefix + pair.key.copyString(), pair.value);
         }
       }
@@ -277,25 +277,25 @@ inline arangodb::consensus::trans_ret_t generalTransaction(AgentInterface* _agen
   try {
     {
       VPackArrayBuilder listOfTrxs(envelope.get());
-      for (auto const& singleTrans : VPackArrayIterator(trx)) {
+      for (auto&& singleTrans : VPackArrayIterator(trx)) {
         TRI_ASSERT(singleTrans.isArray() && singleTrans.length() > 0);
         if (singleTrans[0].isObject()) {
           VPackArrayBuilder onePair(envelope.get());
           {
             VPackObjectBuilder mutationPart(envelope.get());
-            for (auto const& pair : VPackObjectIterator(singleTrans[0])) {
+            for (auto&& pair : VPackObjectIterator(singleTrans[0])) {
               envelope->add("/" + Job::agencyPrefix + pair.key.copyString(), pair.value);
             }
           }
           if (singleTrans.length() > 1) {
             VPackObjectBuilder preconditionPart(envelope.get());
-            for (auto const& pair : VPackObjectIterator(singleTrans[1])) {
+            for (auto&& pair : VPackObjectIterator(singleTrans[1])) {
               envelope->add("/" + Job::agencyPrefix + pair.key.copyString(), pair.value);
             }
           }
         } else if (singleTrans[0].isString()) {
           VPackArrayBuilder reads(envelope.get());
-          for (auto const& path : VPackArrayIterator(singleTrans)) {
+          for (auto&& path : VPackArrayIterator(singleTrans)) {
             envelope->add(VPackValue("/" + Job::agencyPrefix + path.copyString()));
           }
         }
@@ -328,13 +328,13 @@ inline arangodb::consensus::trans_ret_t transient(AgentInterface* _agent,
       VPackArrayBuilder onePair(envelope.get());
       {
         VPackObjectBuilder mutationPart(envelope.get());
-        for (auto const& pair : VPackObjectIterator(trx[0])) {
+        for (auto&& pair : VPackObjectIterator(trx[0])) {
           envelope->add("/" + Job::agencyPrefix + pair.key.copyString(), pair.value);
         }
       }
       if (trx.length() > 1) {
         VPackObjectBuilder preconditionPart(envelope.get());
-        for (auto const& pair : VPackObjectIterator(trx[1])) {
+        for (auto&& pair : VPackObjectIterator(trx[1])) {
           envelope->add("/" + Job::agencyPrefix + pair.key.copyString(), pair.value);
         }
       }

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -576,7 +576,7 @@ JOB_STATUS MoveShard::pendingLeader() {
         auto const tmp = _snapshot.hasAsArray(shardPath + "/servers");
         if (tmp.second) {
           bool found = false;
-          for (auto const& server : VPackArrayIterator(tmp.first)) {
+          for (auto&& server : VPackArrayIterator(tmp.first)) {
             if (server.isEqualString(_to)) {
               found = true;
               break;
@@ -648,7 +648,7 @@ JOB_STATUS MoveShard::pendingLeader() {
                          size_t found = 0;
                          for (size_t i = 1; i < plan.length() - 1; ++i) {
                            VPackSlice p = plan[i];
-                           for (auto const& c : VPackArrayIterator(current)) {
+                           for (auto&& c : VPackArrayIterator(current)) {
                              if (arangodb::basics::VelocyPackHelper::equal(p, c, true)) {
                                ++found;
                                break;

--- a/arangod/Agency/Node.cpp
+++ b/arangod/Agency/Node.cpp
@@ -488,7 +488,7 @@ ResultT<std::shared_ptr<Node>> Node::handle<PUSH>(VPackSlice const& slice) {
   {
     VPackArrayBuilder t(&tmp);
     if (this->slice().isArray() && !lifetimeExpired()) {
-      for (auto const& old : VPackArrayIterator(this->slice())) tmp.add(old);
+      for (auto&& old : VPackArrayIterator(this->slice())) tmp.add(old);
     }
     tmp.add(v);
   }
@@ -523,7 +523,7 @@ ResultT<std::shared_ptr<Node>> Node::handle<ERASE>(VPackSlice const& slice) {
     if (this->slice().isArray() && !lifetimeExpired()) {
       if (haveVal) {
         VPackSlice valToErase = slice.get("val");
-        for (auto const& old : VPackArrayIterator(this->slice())) {
+        for (auto&& old : VPackArrayIterator(this->slice())) {
           if (!VelocyPackHelper::equal(old, valToErase, /*useUTF8*/ true)) {
             tmp.add(old);
           }
@@ -536,7 +536,7 @@ ResultT<std::shared_ptr<Node>> Node::handle<ERASE>(VPackSlice const& slice) {
               "Erase with position out of range: ") + slice.toJson());
         }
         size_t n = 0;
-        for (const auto& old : VPackArrayIterator(this->slice())) {
+        for (const auto&& old : VPackArrayIterator(this->slice())) {
           if (n != pos) {
             tmp.add(old);
           }
@@ -568,7 +568,7 @@ ResultT<std::shared_ptr<Node>> Node::handle<REPLACE>(VPackSlice const& slice) {
     VPackArrayBuilder t(&tmp);
     if (this->slice().isArray() && !lifetimeExpired()) {
       VPackSlice valToRepl = slice.get("val");
-      for (auto const& old : VPackArrayIterator(this->slice())) {
+      for (auto&& old : VPackArrayIterator(this->slice())) {
         if (VelocyPackHelper::equal(old, valToRepl, /*useUTF8*/ true)) {
           tmp.add(slice.get("new"));
         } else {
@@ -617,7 +617,7 @@ ResultT<std::shared_ptr<Node>> Node::handle<PREPEND>(VPackSlice const& slice) {
     VPackArrayBuilder t(&tmp);
     tmp.add(slice.get("new"));
     if (this->slice().isArray() && !lifetimeExpired()) {
-      for (auto const& old : VPackArrayIterator(this->slice())) tmp.add(old);
+      for (auto&& old : VPackArrayIterator(this->slice())) tmp.add(old);
     }
   }
   *this = tmp.slice();
@@ -632,7 +632,7 @@ ResultT<std::shared_ptr<Node>> Node::handle<SHIFT>(VPackSlice const& slice) {
     if (this->slice().isArray() && !lifetimeExpired()) {  // If a
       VPackArrayIterator it(this->slice());
       bool first = true;
-      for (auto const& old : it) {
+      for (auto&& old : it) {
         if (first) {
           first = false;
         } else {
@@ -682,7 +682,7 @@ ResultT<std::shared_ptr<Node>> Node::handle<READ_UNLOCK>(VPackSlice const& slice
     {
       // isReadUnlockable ensured that `this->slice()` is always an array of strings
       VPackArrayBuilder arr(&newValue);
-      for (auto const& i : VPackArrayIterator(this->slice())) {
+      for (auto&& i : VPackArrayIterator(this->slice())) {
         if (!i.isEqualString(user.stringRef())) {
           newValue.add(i);
         }
@@ -744,7 +744,7 @@ bool Node::isReadLockable(const VPackStringRef& by) const {
   // empty object - when the node is created
   if (slice.isArray()) {
     // check if `by` is not in the array
-    for (auto const& i : VPackArrayIterator(slice)) {
+    for (auto&& i : VPackArrayIterator(slice)) {
       if (!i.isString() || i.isEqualString(VPackStringRef(by.data(), by.length()))) {
         return false;
       }
@@ -764,7 +764,7 @@ bool Node::isReadUnlockable(const VPackStringRef& by) const {
   // array of strings containing the value `by`
   if (slice.isArray()) {
     bool valid = false;
-    for (auto const& i : VPackArrayIterator(slice)) {
+    for (auto&& i : VPackArrayIterator(slice)) {
       if (!i.isString()) {
         valid = false;
         break;
@@ -845,7 +845,7 @@ bool Node::applies(VPackSlice const& slice) {
   clear();
 
   if (slice.isObject()) {
-    for (auto const& i : VPackObjectIterator(slice)) {
+    for (auto&& i : VPackObjectIterator(slice)) {
       // note: no need to remove duplicate forward slashes here...
       //  if i.key contains duplicate forward slashes, then we will go
       //  into the  key.find('/')  case, and will be calling  operator()

--- a/arangod/Agency/RemoveFollower.cpp
+++ b/arangod/Agency/RemoveFollower.cpp
@@ -266,7 +266,7 @@ bool RemoveFollower::start(bool&) {
     std::vector<ServerID> reversedPlannedServers{planned.length()};
     {
       auto rDbIt = reversedPlannedServers.rbegin();
-      for (auto const& vPackIt : VPackArrayIterator(planned)) {
+      for (auto&& vPackIt : VPackArrayIterator(planned)) {
         *rDbIt = vPackIt.copyString();
         rDbIt++;
       }

--- a/arangod/Agency/RestAgencyPrivHandler.cpp
+++ b/arangod/Agency/RestAgencyPrivHandler.cpp
@@ -234,7 +234,7 @@ RestStatus RestAgencyPrivHandler::execute() {
             redirectRequest(slice.get("id").copyString());
             return RestStatus::DONE;
           }
-          for (auto const& obj : VPackObjectIterator(ret->slice())) {
+          for (auto&& obj : VPackObjectIterator(ret->slice())) {
             result.add(obj.key.copyString(), obj.value);
           }
         } catch (std::exception const& e) {

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -172,7 +172,7 @@ bool State::persistConf(index_t index, term_t term, uint64_t millis,
   if (config.get("id").copyString() != myId) {
     {
       VPackObjectBuilder b(&builder);
-      for (auto const& i : VPackObjectIterator(config)) {
+      for (auto&& i : VPackObjectIterator(config)) {
         auto key = i.key.copyString();
         if (key == "endpoint") {
           builder.add(key, VPackValue(_agent->endpoint()));
@@ -253,7 +253,7 @@ std::vector<index_t> State::logLeaderMulti(query_t const& transactions,
 
   TRI_ASSERT(!_log.empty());  // log must never be empty
 
-  for (auto const& i : VPackArrayIterator(slice)) {
+  for (auto&& i : VPackArrayIterator(slice)) {
     if (!i.isArray()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(30000,
                                      "Transaction syntax is [{<operations>}, "
@@ -695,13 +695,13 @@ VPackBuilder State::slices(index_t start, index_t end) const {
       try { //{ "a" : {"op":"set", "ttl":20, ...}}
         auto slice = VPackSlice(_log.at(i).entry->data());
         VPackObjectBuilder o(&slices);
-        for (auto const& oper : VPackObjectIterator(slice)) {
+        for (auto&& oper : VPackObjectIterator(slice)) {
           slices.add(VPackValue(oper.key.copyString()));
 
           if (oper.value.isObject() && oper.value.hasKey("op") &&
               oper.value.get("op").isEqualString("set") && oper.value.hasKey("ttl")) {
             VPackObjectBuilder oo(&slices);
-            for (auto const& i : VPackObjectIterator(oper.value)) {
+            for (auto&& i : VPackObjectIterator(oper.value)) {
               slices.add(i.key.copyString(), i.value);
             }
             slices.add("epoch_millis", VPackValue(_log.at(i).timestamp.count()));
@@ -1073,7 +1073,7 @@ bool State::loadRemaining() {
     // snapshot that was loaded or to 0 if there is no snapshot.
     index_t lastIndex = _cur;
 
-    for (auto const& i : VPackArrayIterator(result)) {
+    for (auto&& i : VPackArrayIterator(result)) {
       buffer_t tmp = std::make_shared<arangodb::velocypack::Buffer<uint8_t>>();
 
       auto ii = i.resolveExternals();
@@ -1503,7 +1503,7 @@ std::vector<index_t> State::inquire(query_t const& query) const {
   size_t pos = 0;
 
   MUTEX_LOCKER(mutexLocker, _logLock);  // Cannot be read lock (Compaction)
-  for (auto const& i : VPackArrayIterator(query->slice())) {
+  for (auto&& i : VPackArrayIterator(query->slice())) {
     if (!i.isString()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           210002, std::string("ClientIds must be strings. On position ") +
@@ -1590,7 +1590,7 @@ std::shared_ptr<VPackBuilder> State::latestAgencyState(TRI_vocbase_t& vocbase,
     VPackBuilder b;
     {
       VPackArrayBuilder bb(&b);
-      for (auto const& i : VPackArrayIterator(result)) {
+      for (auto&& i : VPackArrayIterator(result)) {
         buffer_t tmp = std::make_shared<arangodb::velocypack::Buffer<uint8_t>>();
 
         auto ii = i.resolveExternals();
@@ -1662,7 +1662,7 @@ uint64_t State::toVelocyPack(index_t lastIndex, VPackBuilder& builder) const {
   auto copyWithoutId = [&](VPackSlice slice, VPackBuilder& builder) {
     // Need to remove custom attribute in _id:
     { VPackObjectBuilder guard(&builder);
-      for (auto const& p : VPackObjectIterator(slice)) {
+      for (auto&& p : VPackObjectIterator(slice)) {
         if (p.key.copyString() != "_id") {
           builder.add(p.key);
           builder.add(p.value);

--- a/arangod/Agency/Store.cpp
+++ b/arangod/Agency/Store.cpp
@@ -134,10 +134,10 @@ std::vector<apply_ret_t> Store::applyTransactions(query_t const& query,
 
   if (query->slice().isArray()) {
     try {
-      for (auto const& i : VPackArrayIterator(query->slice())) {
+      for (auto&& i : VPackArrayIterator(query->slice())) {
         if (!wmode.privileged()) {
           bool found = false;
-          for (auto const& o : VPackObjectIterator(i[0])) {
+          for (auto&& o : VPackObjectIterator(i[0])) {
             size_t pos = o.key.copyString().find(RECONFIGURE);
             if (pos != std::string::npos && (pos == 0 || pos == 1)) {
               found = true;
@@ -274,7 +274,7 @@ std::vector<bool> Store::applyLogEntries(arangodb::velocypack::Builder const& qu
     while (queriesIterator.valid()) {
       VPackSlice const& i = queriesIterator.value();
 
-      for (auto const& j : VPackObjectIterator(i)) {
+      for (auto&& j : VPackObjectIterator(i)) {
         if (j.value.isObject() && j.value.hasKey("op")) {
           std::string oper = j.value.get("op").copyString();
           if (!(oper == "observe" || oper == "unobserve")) {
@@ -408,7 +408,7 @@ check_ret_t Store::check(VPackSlice const& slice, CheckMode mode) const {
 
   _storeLock.assertLockedByCurrentThread();
 
-  for (auto const& precond : VPackObjectIterator(slice)) {  // Preconditions
+  for (auto&& precond : VPackObjectIterator(slice)) {  // Preconditions
 
     std::string key = precond.key.copyString();
     std::vector<std::string> pv = split(key);
@@ -422,7 +422,7 @@ check_ret_t Store::check(VPackSlice const& slice, CheckMode mode) const {
     }
 
     if (precond.value.isObject()) {
-      for (auto const& op : VPackObjectIterator(precond.value)) {
+      for (auto&& op : VPackObjectIterator(precond.value)) {
         std::string const& oper = op.key.copyString();
         if (oper == "old") {  // old
           if (*node != op.value) {
@@ -473,7 +473,7 @@ check_ret_t Store::check(VPackSlice const& slice, CheckMode mode) const {
           if (found) {
             if (node->slice().isArray()) {
               bool found = false;
-              for (auto const& i : VPackArrayIterator(node->slice())) {
+              for (auto&& i : VPackArrayIterator(node->slice())) {
                 if (basics::VelocyPackHelper::equal(i, op.value, false)) {
                   found = true;
                   break;
@@ -495,7 +495,7 @@ check_ret_t Store::check(VPackSlice const& slice, CheckMode mode) const {
           }
           if (node->slice().isArray()) {
             bool found = false;
-            for (auto const& i : VPackArrayIterator(node->slice())) {
+            for (auto&& i : VPackArrayIterator(node->slice())) {
               if (basics::VelocyPackHelper::equal(i, op.value, false)) {
                 found = true;
                 break;
@@ -528,7 +528,7 @@ check_ret_t Store::check(VPackSlice const& slice, CheckMode mode) const {
           // contained in the node array.
           if (found && op.value.isString() && node->slice().isArray()) {
             bool isValid = false;
-            for (auto const& i : VPackArrayIterator(node->slice())) {
+            for (auto&& i : VPackArrayIterator(node->slice())) {
               if (!i.isString()) {
                 isValid = false;
                 break;  // invalid, only strings allowed
@@ -643,7 +643,7 @@ std::vector<bool> Store::read(query_t const& queries, query_t& result) const {
   std::vector<bool> success;
   if (queries->slice().isArray()) {
     VPackArrayBuilder r(result.get());
-    for (auto const& query : VPackArrayIterator(queries->slice())) {
+    for (auto&& query : VPackArrayIterator(queries->slice())) {
       success.push_back(read(query, *result));
     }
   } else {
@@ -663,7 +663,7 @@ bool Store::read(VPackSlice const& query, Builder& ret) const {
   }
   
   std::vector<std::string> query_strs;
-  for (auto const& sub_query : VPackArrayIterator(query)) {
+  for (auto&& sub_query : VPackArrayIterator(query)) {
     query_strs.emplace_back(sub_query.copyString());
     showHidden |= (query_strs.back().find("/.") != std::string::npos);
   }
@@ -936,7 +936,7 @@ Store& Store::operator=(VPackSlice const& s) {
 
     if (s.hasKey("version")) {
       TRI_ASSERT(slice[1].isObject());
-      for (auto const& entry : VPackObjectIterator(slice[1])) {
+      for (auto&& entry : VPackObjectIterator(slice[1])) {
         if (entry.value.isNumber()) {
           auto const& key = entry.key.copyString();
           if (_node.has(key)) {

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -794,14 +794,14 @@ bool Supervision::earlyBird() const {
   VPackSlice serverStates = serverStatesB.slice();
 
   // every db server in plan accounted for in transient store?
-  for (auto const& server : VPackObjectIterator(dbservers)) {
+  for (auto&& server : VPackObjectIterator(dbservers)) {
     auto serverId = server.key.copyString();
     if (!serverStates.hasKey(serverId)) {
       return false;
     }
   }
   // every db server in plan accounted for in transient store?
-  for (auto const& server : VPackObjectIterator(coordinators)) {
+  for (auto&& server : VPackObjectIterator(coordinators)) {
     auto serverId = server.key.copyString();
     if (!serverStates.hasKey(serverId)) {
       return false;
@@ -1268,7 +1268,7 @@ std::unordered_map<ServerID, std::string> deletionCandidates(Node const& snapsho
             Slice const servers = (*shard.second).getArray();
             if (servers.length() > 0) {
               try {
-                for (auto const& server : VPackArrayIterator(servers)) {
+                for (auto&& server : VPackArrayIterator(servers)) {
                   if (serverList.find(server.copyString()) != serverList.end()) {
                     serverList.erase(server.copyString());
                   }
@@ -2076,7 +2076,7 @@ void Supervision::readyOrphanedIndexCreations() {
         if (collection.has("indexes")) {
           indexes = collection("indexes").getArray();
           if (indexes.length() > 0) {
-            for (auto const& planIndex : VPackArrayIterator(indexes)) {
+            for (auto&& planIndex : VPackArrayIterator(indexes)) {
               if (planIndex.hasKey(StaticStrings::IndexIsBuilding) &&
                   collection.has("shards")) {
                 auto const& planId = planIndex.get("id");
@@ -2094,7 +2094,7 @@ void Supervision::readyOrphanedIndexCreations() {
                     if (currentDBs.has(colPath + shname + "/indexes")) {
                       auto const& curIndexes =
                           currentDBs(colPath + shname + "/indexes").slice();
-                      for (auto const& curIndex : VPackArrayIterator(curIndexes)) {
+                      for (auto&& curIndex : VPackArrayIterator(curIndexes)) {
                         auto const& curId = curIndex.get("id");
                         if (basics::VelocyPackHelper::equal(planId, curId, false)) {
                           ++nIndexes;
@@ -2127,11 +2127,11 @@ void Supervision::readyOrphanedIndexCreations() {
                 }
                 envelope->add(VPackValue(_agencyPrefix + planColPrefix + colPath + "indexes"));
                 VPackArrayBuilder value(envelope.get());
-                for (auto const& planIndex : VPackArrayIterator(indexes)) {
+                for (auto&& planIndex : VPackArrayIterator(indexes)) {
                   if (built.find(planIndex.get("id").copyString()) != built.end()) {
                     {
                       VPackObjectBuilder props(envelope.get());
-                      for (auto const& prop : VPackObjectIterator(planIndex)) {
+                      for (auto&& prop : VPackObjectIterator(planIndex)) {
                         auto const& key = prop.key.copyString();
                         if (key != StaticStrings::IndexIsBuilding) {
                           envelope->add(key, prop.value);
@@ -2228,7 +2228,7 @@ void Supervision::enforceReplication() {
           {
             VPackArrayBuilder guard(&onlyFollowers);
             bool first = true;
-            for (auto const& pp : VPackArrayIterator(shard.slice())) {
+            for (auto&& pp : VPackArrayIterator(shard.slice())) {
               if (!first) {
                 onlyFollowers.add(pp);
               }

--- a/arangod/Aql/AqlCallList.cpp
+++ b/arangod/Aql/AqlCallList.cpp
@@ -136,7 +136,7 @@ auto AqlCallList::fromVelocyPack(VPackSlice slice) -> ResultT<AqlCallList> {
     }
     std::vector<AqlCall> res;
     res.reserve(slice.length());
-    for (auto const& c : VPackArrayIterator(slice)) {
+    for (auto&& c : VPackArrayIterator(slice)) {
       auto maybeAqlCall = AqlCall::fromVelocyPack(c);
       if (ADB_UNLIKELY(maybeAqlCall.fail())) {
         auto message = std::string{"When deserializing AqlCallList: entry "};
@@ -299,7 +299,7 @@ bool arangodb::aql::operator==(AqlCallList const& left, AqlCallList const& right
   if (!(left._defaultCall == right._defaultCall)) {
     return false;
   }
-  for (auto const& [index, call] : enumerate(left._specificCalls)) {
+  for (auto&& [index, call] : enumerate(left._specificCalls)) {
     if (!(call == right._specificCalls[index])) {
       return false;
     }
@@ -309,7 +309,7 @@ bool arangodb::aql::operator==(AqlCallList const& left, AqlCallList const& right
 
 auto arangodb::aql::operator<<(std::ostream& out, AqlCallList const& list) -> std::ostream& {
   out << "{specific: [ ";
-  for (auto const& [index, call] : enumerate(list._specificCalls)) {
+  for (auto&& [index, call] : enumerate(list._specificCalls)) {
     if (index > 0) {
       out << ", ";
     }

--- a/arangod/Aql/AqlItemMatrix.cpp
+++ b/arangod/Aql/AqlItemMatrix.cpp
@@ -57,7 +57,7 @@ std::vector<AqlItemMatrix::RowIndex> AqlItemMatrix::produceRowIndexes() const {
   std::vector<RowIndex> result;
   if (!empty()) {
     result.reserve(size());
-    for (auto const& [index, block] : enumerate(_blocks)) {
+    for (auto&& [index, block] : enumerate(_blocks)) {
       // Default case, 0 -> end
       size_t startRow = 0;
       // We know block size is <= DefaultBatchSize (1000) so it should easily fit into 32bit...

--- a/arangod/Aql/ClusterQuery.cpp
+++ b/arangod/Aql/ClusterQuery.cpp
@@ -146,7 +146,7 @@ void ClusterQuery::prepareClusterQuery(VPackSlice querySlice,
   if (traverserSlice.isArray()) {
     // used to be RestAqlHandler::registerTraverserEngines
     answerBuilder.add("traverserEngines", VPackValue(VPackValueType::Array));
-    for (auto const& te : VPackArrayIterator(traverserSlice)) {
+    for (auto&& te : VPackArrayIterator(traverserSlice)) {
 
       auto engine = traverser::BaseEngine::BuildEngine(_vocbase, *this, te);
       answerBuilder.add(VPackValue(engine->engineId()));

--- a/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
+++ b/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
@@ -414,7 +414,7 @@ Result EngineInfoContainerDBServerServerBased::parseResponse(
   
   VPackSlice snippets = result.get("snippets");
   // Link Snippets to their sinks
-  for (auto const& resEntry : VPackObjectIterator(snippets)) {
+  for (auto&& resEntry : VPackObjectIterator(snippets)) {
     if (!resEntry.value.isString()) {
       return {TRI_ERROR_CLUSTER_AQL_COMMUNICATION,
               "Unable to deploy query snippets on all required "

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -197,7 +197,7 @@ void ExecutionNode::getSortElements(SortElementVector& elements, ExecutionPlan* 
     if (path.isArray()) {
       // Get a list of strings out and add to the path:
       auto& element = elements.back();
-      for (auto const& it2 : VPackArrayIterator(path)) {
+      for (auto&& it2 : VPackArrayIterator(path)) {
         if (it2.isString()) {
           element.attributePath.push_back(it2.copyString());
         }

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -384,7 +384,7 @@ void ExecutionPlan::getCollectionsFromVelocyPack(aql::Collections& colls, VPackS
        "json node \"collections\" not found or not an array");
   }
 
-  for (auto const& collection : VPackArrayIterator(collectionsSlice)) {
+  for (auto&& collection : VPackArrayIterator(collectionsSlice)) {
     colls.add(
         basics::VelocyPackHelper::checkAndGetStringValue(collection, "name"),
         AccessMode::fromString(arangodb::basics::VelocyPackHelper::checkAndGetStringValue(collection,
@@ -2401,7 +2401,7 @@ ExecutionNode* ExecutionPlan::fromSlice(VPackSlice const& slice) {
     // now re-link the dependencies
     VPackSlice dependencies = it.get("dependencies");
     if (dependencies.isArray()) {
-      for (auto const& it2 : VPackArrayIterator(dependencies)) {
+      for (auto&& it2 : VPackArrayIterator(dependencies)) {
         if (it2.isNumber()) {
           auto depId =
               ExecutionNodeId{it2.getNumericValue<ExecutionNodeId::BaseType>()};

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -838,7 +838,7 @@ bool sortNumberList(transaction::Methods* trx, AqlValue const& values,
 
   VPackArrayIterator it(slice);
   result.reserve(it.size());
-  for (auto const& element : it) {
+  for (auto&& element : it) {
     if (!element.isNull()) {
       if (!element.isNumber()) {
         return false;
@@ -859,7 +859,7 @@ void unsetOrKeep(transaction::Methods* trx, VPackSlice const& value,
                  bool recursive, VPackBuilder& result) {
   TRI_ASSERT(value.isObject());
   VPackObjectBuilder b(&result);  // Close the object after this function
-  for (auto const& entry : VPackObjectIterator(value, false)) {
+  for (auto&& entry : VPackObjectIterator(value, false)) {
     TRI_ASSERT(entry.key.isString());
     std::string key = entry.key.copyString();
     if ((names.find(key) == names.end()) == unset) {
@@ -1001,7 +1001,7 @@ AqlValue mergeParameters(ExpressionContext* expressionContext, transaction::Meth
 void flattenList(VPackSlice const& array, size_t maxDepth, size_t curDepth,
                  VPackBuilder& result) {
   TRI_ASSERT(result.isOpenArray());
-  for (auto const& tmp : VPackArrayIterator(array)) {
+  for (auto&& tmp : VPackArrayIterator(array)) {
     if (tmp.isArray() && curDepth < maxDepth) {
       ::flattenList(tmp, maxDepth, curDepth + 1, result);
     } else {
@@ -1252,7 +1252,7 @@ static Result parseGeoPolygon(VPackSlice polygon, VPackBuilder& b) {
   for (VPackSlice v : VPackArrayIterator(polygon)) {
     if (v.isArray() && v.length() > 2) {
       b.openArray();
-      for (auto const& coord : VPackArrayIterator(v)) {
+      for (auto&& coord : VPackArrayIterator(v)) {
         if (coord.isNumber()) {
           b.add(VPackValue(coord.getNumber<double>()));
         } else if (coord.isArray()) {
@@ -1261,7 +1261,7 @@ static Result parseGeoPolygon(VPackSlice polygon, VPackBuilder& b) {
                           "a Position needs at least two numeric values");
           } else {
             b.openArray();
-            for (auto const& innercord : VPackArrayIterator(coord)) {
+            for (auto&& innercord : VPackArrayIterator(coord)) {
               if (innercord.isNumber()) {
                 b.add(VPackValue(innercord.getNumber<double>()));  // TODO
               } else if (innercord.isArray() && innercord.length() == 2) {
@@ -1290,7 +1290,7 @@ static Result parseGeoPolygon(VPackSlice polygon, VPackBuilder& b) {
     } else if (v.isArray() && v.length() == 2) {
       if (polygon.length() > 2) {
         b.openArray();
-        for (auto const& innercord : VPackArrayIterator(v)) {
+        for (auto&& innercord : VPackArrayIterator(v)) {
           if (innercord.isNumber()) {
             b.add(VPackValue(innercord.getNumber<double>()));
           } else if (innercord.isArray() && innercord.length() == 2) {
@@ -4364,7 +4364,7 @@ AqlValue Functions::Values(ExpressionContext* expressionContext, transaction::Me
   VPackSlice slice = materializer.slice(value, false);
   transaction::BuilderLeaser builder(trx);
   builder->openArray();
-  for (auto const& entry : VPackObjectIterator(slice, true)) {
+  for (auto&& entry : VPackObjectIterator(slice, true)) {
     if (!entry.key.isString()) {
       // somehow invalid
       continue;
@@ -5725,7 +5725,7 @@ AqlValue Functions::GeoMultiPoint(ExpressionContext* expressionContext,
   for (VPackSlice v : VPackArrayIterator(s)) {
     if (v.isArray()) {
       builder->openArray();
-      for (auto const& coord : VPackArrayIterator(v)) {
+      for (auto&& coord : VPackArrayIterator(v)) {
         if (coord.isNumber()) {
           builder->add(VPackValue(coord.getNumber<double>()));
         } else {
@@ -5835,7 +5835,7 @@ AqlValue Functions::GeoMultiPolygon(ExpressionContext* expressionContext,
   builder->add("type", VPackValue("MultiPolygon"));
   builder->add("coordinates", VPackValue(VPackValueType::Array));
 
-  for (auto const& arrayOfPolygons : VPackArrayIterator(s)) {
+  for (auto&& arrayOfPolygons : VPackArrayIterator(s)) {
     if (!arrayOfPolygons.isArray()) {
       registerWarning(
           expressionContext, "GEO_MULTIPOLYGON",
@@ -5895,7 +5895,7 @@ AqlValue Functions::GeoLinestring(ExpressionContext* expressionContext,
   for (VPackSlice v : VPackArrayIterator(s)) {
     if (v.isArray()) {
       builder->openArray();
-      for (auto const& coord : VPackArrayIterator(v)) {
+      for (auto&& coord : VPackArrayIterator(v)) {
         if (coord.isNumber()) {
           builder->add(VPackValue(coord.getNumber<double>()));
         } else {
@@ -5957,10 +5957,10 @@ AqlValue Functions::GeoMultiLinestring(ExpressionContext* expressionContext,
     if (v.isArray()) {
       if (v.length() > 1) {
         builder->openArray();
-        for (auto const& inner : VPackArrayIterator(v)) {
+        for (auto&& inner : VPackArrayIterator(v)) {
           if (inner.isArray()) {
             builder->openArray();
-            for (auto const& coord : VPackArrayIterator(inner)) {
+            for (auto&& coord : VPackArrayIterator(inner)) {
               if (coord.isNumber()) {
                 builder->add(VPackValue(coord.getNumber<double>()));
               } else {
@@ -6320,7 +6320,7 @@ AqlValue Functions::Document(ExpressionContext* expressionContext, transaction::
       AqlValueMaterializer materializer(trx);
       VPackSlice idSlice = materializer.slice(id, false);
       builder->openArray();
-      for (auto const& next : VPackArrayIterator(idSlice)) {
+      for (auto&& next : VPackArrayIterator(idSlice)) {
         if (next.isString()) {
           std::string identifier = next.copyString();
           std::string colName;
@@ -6357,7 +6357,7 @@ AqlValue Functions::Document(ExpressionContext* expressionContext, transaction::
 
     AqlValueMaterializer materializer(trx);
     VPackSlice idSlice = materializer.slice(id, false);
-    for (auto const& next : VPackArrayIterator(idSlice)) {
+    for (auto&& next : VPackArrayIterator(idSlice)) {
       if (next.isString()) {
         std::string identifier(next.copyString());
         ::getDocumentByIdentifier(trx, collectionName, identifier, true,
@@ -6412,7 +6412,7 @@ AqlValue Functions::Matches(ExpressionContext* expressionContext, transaction::M
   bool foundMatch;
   int32_t idx = -1;
 
-  for (auto const& example : VPackArrayIterator(examples)) {
+  for (auto&& example : VPackArrayIterator(examples)) {
     idx++;
 
     if (!example.isObject()) {

--- a/arangod/Aql/GraphNode.cpp
+++ b/arangod/Aql/GraphNode.cpp
@@ -392,7 +392,7 @@ GraphNode::GraphNode(ExecutionPlan* plan, arangodb::velocypack::Slice const& bas
         TRI_ERROR_QUERY_BAD_JSON_PLAN,
         "graph needs a translation from collection to shard names");
   }
-  for (auto const& item : VPackObjectIterator(collectionToShard)) {
+  for (auto&& item : VPackObjectIterator(collectionToShard)) {
     _collectionToShard.insert({item.key.copyString(), item.value.copyString()});
   }
 

--- a/arangod/Aql/IResearchViewNode.cpp
+++ b/arangod/Aql/IResearchViewNode.cpp
@@ -157,7 +157,7 @@ void toVelocyPack(velocypack::Builder& builder, IResearchViewNode::Options const
     builder.add("collections", VPackValue(VPackValueType::Null));
   } else {
     VPackArrayBuilder arrayScope(&builder, "collections");
-    for (auto const cid : options.sources) {
+    for (auto&& cid : options.sources) {
       builder.add(VPackValue(cid.id()));
     }
   }
@@ -1233,7 +1233,7 @@ std::vector<std::reference_wrapper<aql::Collection const>> IResearchViewNode::co
 
   if (_options.restrictSources) {
     viewCollections.reserve(_options.sources.size());
-    for (auto const cid : _options.sources) {
+    for (auto&& cid : _options.sources) {
       visitor(cid);
     }
   } else {
@@ -1324,7 +1324,7 @@ aql::CostEstimate IResearchViewNode::estimateCost() const {
   };
 
   if (_options.restrictSources) {
-    for (auto const cid : _options.sources) {
+    for (auto&& cid : _options.sources) {
       visitor(cid);
     }
   } else {

--- a/arangod/Aql/Projections.cpp
+++ b/arangod/Aql/Projections.cpp
@@ -290,12 +290,12 @@ void Projections::toVelocyPack(arangodb::velocypack::Builder& b) const {
 
   VPackSlice p = slice.get(::projectionsKey);
   if (p.isArray()) {
-    for (auto const& it : arangodb::velocypack::ArrayIterator(p)) {
+    for (auto&& it : arangodb::velocypack::ArrayIterator(p)) {
       if (it.isString()) {
         projections.emplace_back(arangodb::aql::AttributeNamePath(it.copyString()));
       } else if (it.isArray()) {
         arangodb::aql::AttributeNamePath path;
-        for (auto const& it2 : arangodb::velocypack::ArrayIterator(it)) {
+        for (auto&& it2 : arangodb::velocypack::ArrayIterator(it)) {
           path.path.emplace_back(it2.copyString());
         }
         projections.emplace_back(std::move(path));

--- a/arangod/Aql/QueryOptions.cpp
+++ b/arangod/Aql/QueryOptions.cpp
@@ -195,7 +195,7 @@ void QueryOptions::fromVelocyPack(VPackSlice const slice) {
     }
     value = optimizer.get("rules");
     if (value.isArray()) {
-      for (auto const& rule : VPackArrayIterator(value)) {
+      for (auto&& rule : VPackArrayIterator(value)) {
         if (rule.isString()) {
           optimizerRules.emplace_back(rule.copyString());
         }

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -215,7 +215,7 @@ void RestAqlHandler::setupClusterQuery() {
   // Build the collection information
   VPackBuilder collectionBuilder;
   collectionBuilder.openArray();
-  for (auto const& lockInf : VPackObjectIterator(lockInfoSlice)) {
+  for (auto&& lockInf : VPackObjectIterator(lockInfoSlice)) {
     if (!lockInf.value.isArray()) {
       LOG_TOPIC("1dc00", ERR, arangodb::Logger::AQL)
           << "Invalid VelocyPack: \"lockInfo." << lockInf.key.copyString()

--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -232,21 +232,21 @@ TraversalNode::TraversalNode(ExecutionPlan* plan, arangodb::velocypack::Slice co
 
   list = base.get("globalEdgeConditions");
   if (list.isArray()) {
-    for (auto const& cond : VPackArrayIterator(list)) {
+    for (auto&& cond : VPackArrayIterator(list)) {
       _globalEdgeConditions.emplace_back(plan->getAst()->createNode(cond));
     }
   }
 
   list = base.get("globalVertexConditions");
   if (list.isArray()) {
-    for (auto const& cond : VPackArrayIterator(list)) {
+    for (auto&& cond : VPackArrayIterator(list)) {
       _globalVertexConditions.emplace_back(plan->getAst()->createNode(cond));
     }
   }
 
   list = base.get("vertexConditions");
   if (list.isObject()) {
-    for (auto const& cond : VPackObjectIterator(list)) {
+    for (auto&& cond : VPackObjectIterator(list)) {
       std::string key = cond.key.copyString();
       _vertexConditions.try_emplace(StringUtils::uint64(key),
                                     plan->getAst()->createNode(cond.value));
@@ -255,7 +255,7 @@ TraversalNode::TraversalNode(ExecutionPlan* plan, arangodb::velocypack::Slice co
 
   list = base.get("edgeConditions");
   if (list.isObject()) {
-    for (auto const& cond : VPackObjectIterator(list)) {
+    for (auto&& cond : VPackObjectIterator(list)) {
       std::string key = cond.key.copyString();
       auto ecbuilder = std::make_unique<TraversalEdgeConditionBuilder>(this, cond.value);
       _edgeConditions.try_emplace(StringUtils::uint64(key), std::move(ecbuilder));
@@ -268,7 +268,7 @@ TraversalNode::TraversalNode(ExecutionPlan* plan, arangodb::velocypack::Slice co
     TRI_ASSERT(base.hasKey("pruneVariables"));
     list = base.get("pruneVariables");
     TRI_ASSERT(list.isArray());
-    for (auto const& varinfo : VPackArrayIterator(list)) {
+    for (auto&& varinfo : VPackArrayIterator(list)) {
       _pruneVariables.emplace(plan->getAst()->variables()->createVariable(varinfo));
     }
   }

--- a/arangod/Aql/VariableGenerator.cpp
+++ b/arangod/Aql/VariableGenerator.cpp
@@ -164,7 +164,7 @@ void VariableGenerator::fromVelocyPack(VPackSlice const slice) {
   auto len = allVariablesList.length();
   _variables.reserve(static_cast<size_t>(len));
 
-  for (auto const& var : VPackArrayIterator(allVariablesList)) {
+  for (auto&& var : VPackArrayIterator(allVariablesList)) {
     createVariable(var);
   }
 }

--- a/arangod/Auth/TokenCache.cpp
+++ b/arangod/Auth/TokenCache.cpp
@@ -342,7 +342,7 @@ auth::TokenCache::Entry auth::TokenCache::validateJwtBody(std::string const& bod
         << "allowed_paths may not be empty";
       return auth::TokenCache::Entry::Unauthenticated();
     }
-    for (auto const& path : VPackArrayIterator(paths)) {
+    for (auto&& path : VPackArrayIterator(paths)) {
       if (!path.isString()) {
         LOG_TOPIC("89891", TRACE, arangodb::Logger::AUTHENTICATION)
           << "allowed_paths may only contain strings";

--- a/arangod/Auth/User.cpp
+++ b/arangod/Auth/User.cpp
@@ -167,7 +167,7 @@ auth::User auth::User::newUser(std::string const& user,
 
 void auth::User::fromDocumentDatabases(auth::User& entry, VPackSlice const& databasesSlice,
                                        VPackSlice const& userSlice) {
-  for (auto const& obj : VPackObjectIterator(databasesSlice)) {
+  for (auto&& obj : VPackObjectIterator(databasesSlice)) {
     std::string const dbName = obj.key.copyString();
 
     if (obj.value.isObject()) {
@@ -188,7 +188,7 @@ void auth::User::fromDocumentDatabases(auth::User& entry, VPackSlice const& data
       VPackSlice collectionsSlice = obj.value.get("collections");
 
       if (collectionsSlice.isObject()) {
-        for (auto const& collection : VPackObjectIterator(collectionsSlice)) {
+        for (auto&& collection : VPackObjectIterator(collectionsSlice)) {
           std::string const cName = collection.key.copyString();
           auto const collPerSlice = collection.value.get("permissions");
 

--- a/arangod/Auth/UserManager.cpp
+++ b/arangod/Auth/UserManager.cpp
@@ -104,7 +104,7 @@ auth::UserManager::UserManager(application_features::ApplicationServer& server,
 static auth::UserMap ParseUsers(VPackSlice const& slice) {
   TRI_ASSERT(slice.isArray());
   auth::UserMap result;
-  for (VPackSlice const& authSlice : VPackArrayIterator(slice)) {
+  for (auto&& authSlice : VPackArrayIterator(slice)) {
     VPackSlice s = authSlice.resolveExternal();
 
     if (s.hasKey("source") && s.get("source").isString() &&
@@ -380,7 +380,7 @@ VPackBuilder auth::UserManager::allUsers() {
   {
     VPackArrayBuilder a(&result);
     if (users && !users->isEmpty()) {
-      for (VPackSlice const& doc : VPackArrayIterator(users->slice())) {
+      for (auto&& doc : VPackArrayIterator(users->slice())) {
         ConvertLegacyFormat(doc, result);
       }
     }

--- a/arangod/Cluster/AgencyCache.cpp
+++ b/arangod/Cluster/AgencyCache.cpp
@@ -157,7 +157,7 @@ void AgencyCache::handleCallbacksNoLock(
   // Collect and normalize keys
   std::vector<std::string> keys;
   keys.reserve(slice.length());
-  for (auto const& i : VPackObjectIterator(slice)) {
+  for (auto&& i : VPackObjectIterator(slice)) {
     VPackValueLength l;
     char const* p = i.key.getString(l);
     keys.emplace_back(Store::normalize(p, l));
@@ -333,7 +333,7 @@ void AgencyCache::run() {
                     TRI_ASSERT(rs.get("log").isArray());
                     LOG_TOPIC("4579e", TRACE, Logger::CLUSTER) <<
                       "Applying to cache " << rs.get("log").toJson();
-                    for (auto const& i : VPackArrayIterator(rs.get("log"))) {
+                    for (auto&& i : VPackArrayIterator(rs.get("log"))) {
                       {
                         std::lock_guard g(_storeLock);
                         _readDB.applyTransaction(i); // apply logs

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -884,7 +884,7 @@ void ClusterInfo::loadPlan() {
       continue;
     }
 
-    for (auto const& viewPairSlice : velocypack::ObjectIterator(viewsSlice, true)) {
+    for (auto&& viewPairSlice : velocypack::ObjectIterator(viewsSlice, true)) {
       auto const& viewSlice = viewPairSlice.value;
 
       if (!viewSlice.isObject()) {
@@ -1101,7 +1101,7 @@ void ClusterInfo::loadPlan() {
     // for the same database
     AllCollections::const_iterator existingCollections = _plannedCollections.find(databaseName);
 
-    for (auto const& collectionPairSlice : velocypack::ObjectIterator(collectionsSlice)) {
+    for (auto&& collectionPairSlice : velocypack::ObjectIterator(collectionsSlice)) {
       auto const& collectionSlice = collectionPairSlice.value;
 
       if (!collectionSlice.isObject()) {
@@ -1356,7 +1356,7 @@ void ClusterInfo::loadCurrent() {
 
     std::unordered_map<ServerID, velocypack::Slice> serverList;
     if (databaseSlice.isObject()) {
-      for (auto const& serverSlicePair : VPackObjectIterator(databaseSlice)) {
+      for (auto&& serverSlicePair : VPackObjectIterator(databaseSlice)) {
         serverList.try_emplace(serverSlicePair.key.copyString(), serverSlicePair.value);
       }
     }
@@ -1386,13 +1386,13 @@ void ClusterInfo::loadCurrent() {
 
     DatabaseCollectionsCurrent databaseCollections;
 
-    for (auto const& collectionSlice : VPackObjectIterator(databaseSlice)) {
+    for (auto&& collectionSlice : VPackObjectIterator(databaseSlice)) {
       std::string collectionName = collectionSlice.key.copyString();
 
       auto collectionDataCurrent =
         std::make_shared<CollectionInfoCurrent>(changeSet.version);
 
-      for (auto const& shardSlice : velocypack::ObjectIterator(collectionSlice.value)) {
+      for (auto&& shardSlice : velocypack::ObjectIterator(collectionSlice.value)) {
         std::string shardID = shardSlice.key.copyString();
 
         collectionDataCurrent->add(shardID, shardSlice.value);
@@ -2278,7 +2278,7 @@ Result ClusterInfo::createCollectionsCoordinator(
       ShardID shardID = pair.key.copyString();
       std::vector<ServerID> serverIds;
 
-      for (auto const& serv : VPackArrayIterator(pair.value)) {
+      for (auto&& serv : VPackArrayIterator(pair.value)) {
         auto const sid = serv.copyString();
         serverIds.emplace_back(sid);
         allServers.emplace(sid);
@@ -2308,7 +2308,7 @@ Result ClusterInfo::createCollectionsCoordinator(
       if (result.isObject() && result.length() == (size_t)info.numberOfShards) {
         std::string tmpError = "";
 
-        for (auto const& p : VPackObjectIterator(result)) {
+        for (auto&& p : VPackObjectIterator(result)) {
           if (arangodb::basics::VelocyPackHelper::getBooleanValue(p.value,
                                                                   StaticStrings::Error, false)) {
             tmpError += " shardID:" + p.key.copyString() + ":";
@@ -2365,7 +2365,7 @@ Result ClusterInfo::createCollectionsCoordinator(
             if (!servers.isArray()) {
               return true;
             }
-            for (auto const& server : VPackArrayIterator(servers)) {
+            for (auto&& server : VPackArrayIterator(servers)) {
               if (!server.isString()) {
                 return true;
               }
@@ -3487,7 +3487,7 @@ Result ClusterInfo::setCollectionStatusCoordinator(std::string const& databaseNa
   VPackBuilder builder;
   try {
     VPackObjectBuilder b(&builder);
-    for (auto const& entry : VPackObjectIterator(col)) {
+    for (auto&& entry : VPackObjectIterator(col)) {
       std::string key = entry.key.copyString();
       if (key != "status") {
         builder.add(key, entry.value);
@@ -3633,7 +3633,7 @@ Result ClusterInfo::ensureIndexCoordinatorInner(LogicalCollection const& collect
   }
 
   VPackSlice indexes = collectionFromPlan.indexes();
-  for (auto const& other : VPackArrayIterator(indexes)) {
+  for (auto&& other : VPackArrayIterator(indexes)) {
     TRI_ASSERT(other.isObject());
     if (true == arangodb::Index::Compare(slice, other)) {
       {  // found an existing index... Copy over all elements in slice.
@@ -3670,7 +3670,7 @@ Result ClusterInfo::ensureIndexCoordinatorInner(LogicalCollection const& collect
     }
 
     size_t found = 0;
-    for (auto const& shard : VPackObjectIterator(result)) {
+    for (auto&& shard : VPackObjectIterator(result)) {
       VPackSlice const slice = shard.value;
       if (slice.hasKey("indexes")) {
         VPackSlice const indexes = slice.get("indexes");
@@ -3717,7 +3717,7 @@ Result ClusterInfo::ensureIndexCoordinatorInner(LogicalCollection const& collect
   {
     VPackObjectBuilder ob(&newIndexBuilder);
     // Add the new index ignoring "id"
-    for (auto const& e : VPackObjectIterator(slice)) {
+    for (auto&& e : VPackObjectIterator(slice)) {
       TRI_ASSERT(e.key.isString());
       std::string const& key = e.key.copyString();
       if (key != StaticStrings::IndexId && key != StaticStrings::IndexIsBuilding) {
@@ -3840,7 +3840,7 @@ Result ClusterInfo::ensureIndexCoordinatorInner(LogicalCollection const& collect
         VPackBuilder finishedPlanIndex;
         {
           VPackObjectBuilder o(&finishedPlanIndex);
-          for (auto const& entry : VPackObjectIterator(newIndexBuilder.slice())) {
+          for (auto&& entry : VPackObjectIterator(newIndexBuilder.slice())) {
             auto const key = entry.key.copyString();
             if (key != StaticStrings::IndexIsBuilding &&
                 key != "isNewlyCreated") {
@@ -4072,7 +4072,7 @@ Result ClusterInfo::dropIndexCoordinator(  // drop index
 
     if (shards.size() == numberOfShards) {
       bool found = false;
-      for (auto const& shard : shards) {
+      for (auto&& shard : shards) {
         VPackSlice const indexes = shard.value.get("indexes");
 
         if (indexes.isArray()) {
@@ -4221,7 +4221,7 @@ void ClusterInfo::loadServers() {
 
     std::unordered_set<ServerID> serverIds;
 
-    for (auto const& res : VPackObjectIterator(serversRegistered)) {
+    for (auto&& res : VPackObjectIterator(serversRegistered)) {
       velocypack::Slice slice = res.value;
 
       if (slice.isObject() && slice.hasKey("endpoint")) {
@@ -4472,7 +4472,7 @@ void ClusterInfo::loadCurrentCoordinators() {
     if (currentCoordinators.isObject()) {
       decltype(_coordinators) newCoordinators;
 
-      for (auto const& coordinator : VPackObjectIterator(currentCoordinators)) {
+      for (auto&& coordinator : VPackObjectIterator(currentCoordinators)) {
         newCoordinators.try_emplace(coordinator.key.copyString(), coordinator.value.copyString());
       }
 
@@ -4520,7 +4520,7 @@ void ClusterInfo::loadCurrentMappings() {
     if (mappings.isObject()) {
       decltype(_coordinatorIdMap) newCoordinatorIdMap;
 
-      for (auto const& mapping : VPackObjectIterator(mappings)) {
+      for (auto&& mapping : VPackObjectIterator(mappings)) {
         auto mapObject = mapping.value;
         if (mapObject.isObject()) {
           ServerID fullId = mapping.key.copyString();
@@ -4607,10 +4607,10 @@ void ClusterInfo::loadCurrentDBServers() {
   if (currentDBServers.isObject() && failedDBServers.isObject()) {
     decltype(_DBServers) newDBServers;
 
-    for (auto const& dbserver : VPackObjectIterator(currentDBServers)) {
+    for (auto&& dbserver : VPackObjectIterator(currentDBServers)) {
       bool found = false;
       if (failedDBServers.isObject()) {
-        for (auto const& failedServer : VPackObjectIterator(failedDBServers)) {
+        for (auto&& failedServer : VPackObjectIterator(failedDBServers)) {
           if (basics::VelocyPackHelper::equal(dbserver.key, failedServer.key, false)) {
             found = true;
             break;
@@ -4623,7 +4623,7 @@ void ClusterInfo::loadCurrentDBServers() {
 
       if (cleanedDBServers.isArray()) {
         found = false;
-        for (auto const& cleanedServer : VPackArrayIterator(cleanedDBServers)) {
+        for (auto&& cleanedServer : VPackArrayIterator(cleanedDBServers)) {
           if (basics::VelocyPackHelper::equal(dbserver.key, cleanedServer, false)) {
             found = true;
             break;
@@ -4636,7 +4636,7 @@ void ClusterInfo::loadCurrentDBServers() {
 
       if (toBeCleanedDBServers.isArray()) {
         found = false;
-        for (auto const& toBeCleanedServer : VPackArrayIterator(toBeCleanedDBServers)) {
+        for (auto&& toBeCleanedServer : VPackArrayIterator(toBeCleanedDBServers)) {
           if (basics::VelocyPackHelper::equal(dbserver.key, toBeCleanedServer, false)) {
             found = true;
             break;

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -875,7 +875,7 @@ void aggregateClusterFigures(bool details, bool isSmartEdgeCollectionPart,
     VPackSlice rocksDBValues = value.get("engine");
 
     if (!isSmartEdgeCollectionPart) {
-      for (auto const& it : VPackArrayIterator(rocksDBValues.get("indexes"))) {
+      for (auto&& it : VPackArrayIterator(rocksDBValues.get("indexes"))) {
         VPackSlice idSlice = it.get("id");
         if (!idSlice.isNumber()) {
           continue;
@@ -886,7 +886,7 @@ void aggregateClusterFigures(bool details, bool isSmartEdgeCollectionPart,
   
     rocksDBValues = builder.slice().get("engine");
     if (rocksDBValues.isObject()) {
-      for (auto const& it : VPackArrayIterator(rocksDBValues.get("indexes"))) {
+      for (auto&& it : VPackArrayIterator(rocksDBValues.get("indexes"))) {
         VPackSlice idSlice = it.get("id");
         if (!idSlice.isNumber()) {
           continue;

--- a/arangod/Cluster/ClusterRepairDistributeShardsLike.cpp
+++ b/arangod/Cluster/ClusterRepairDistributeShardsLike.cpp
@@ -38,12 +38,12 @@ using namespace arangodb::cluster_repairs;
 std::map<ShardID, DBServers, VersionSort> DistributeShardsLikeRepairer::readShards(Slice const& shards) {
   std::map<ShardID, DBServers, VersionSort> shardsById;
 
-  for (auto const& shardIterator : ObjectIterator(shards)) {
+  for (auto&& shardIterator : ObjectIterator(shards)) {
     ShardID const shardId = shardIterator.key.copyString();
 
     DBServers dbServers;
 
-    for (auto const& dbServerIterator : ArrayIterator(shardIterator.value)) {
+    for (auto&& dbServerIterator : ArrayIterator(shardIterator.value)) {
       ServerID const dbServerId = dbServerIterator.copyString();
       dbServers.emplace_back(std::move(dbServerId));
     }
@@ -57,7 +57,7 @@ std::map<ShardID, DBServers, VersionSort> DistributeShardsLikeRepairer::readShar
 DBServers DistributeShardsLikeRepairer::readDatabases(const Slice& supervisionHealth) {
   DBServers dbServers;
 
-  for (auto const& it : ObjectIterator(supervisionHealth)) {
+  for (auto&& it : ObjectIterator(supervisionHealth)) {
     ServerID const& serverId = it.key.copyString();
     if (serverId.substr(0, 5) == "PRMR-" && it.value.hasKey("Status") &&
         it.value.get("Status").copyString() == "GOOD") {
@@ -72,12 +72,12 @@ ResultT<std::map<CollectionID, struct cluster_repairs::Collection>>
 DistributeShardsLikeRepairer::readCollections(const Slice& collectionsByDatabase) {
   std::map<CollectionID, struct Collection> collections;
 
-  for (auto const& databaseIterator : ObjectIterator(collectionsByDatabase)) {
+  for (auto&& databaseIterator : ObjectIterator(collectionsByDatabase)) {
     DatabaseID const databaseId = databaseIterator.key.copyString();
 
     Slice const& collectionsSlice = databaseIterator.value;
 
-    for (auto const& collectionIterator : ObjectIterator(collectionsSlice)) {
+    for (auto&& collectionIterator : ObjectIterator(collectionsSlice)) {
       CollectionID const collectionId = collectionIterator.key.copyString();
       Slice const& collectionSlice = collectionIterator.value;
 
@@ -91,7 +91,7 @@ DistributeShardsLikeRepairer::readCollections(const Slice& collectionsByDatabase
       Slice shardsSlice;
       std::map<std::string, Slice> residualAttributes;
 
-      for (auto const& it : ObjectIterator(collectionSlice)) {
+      for (auto&& it : ObjectIterator(collectionSlice)) {
         std::string const& key = it.key.copyString();
         if (key == StaticStrings::DataSourceName) {
           collectionName = it.value.copyString();
@@ -194,7 +194,7 @@ std::vector<std::pair<CollectionID, Result>> DistributeShardsLikeRepairer::findC
       continue;
     }
 
-    for (auto const& zippedShardsIt :
+    for (auto&& zippedShardsIt :
          boost::combine(collection.shardsById, proto.shardsById)) {
       auto const& shardIt = zippedShardsIt.get<0>();
       auto const& protoShardIt = zippedShardsIt.get<1>();
@@ -402,7 +402,7 @@ ResultT<std::list<RepairOperation>> DistributeShardsLikeRepairer::fixShard(
                   errorMessage.str());
   }
 
-  for (auto const& zipIt : boost::combine(serversOnlyOnProto, serversOnlyOnShard)) {
+  for (auto&& zipIt : boost::combine(serversOnlyOnProto, serversOnlyOnShard)) {
     auto const& protoServerIt = zipIt.get<0>();
     auto const& shardServerIt = zipIt.get<1>();
 
@@ -707,7 +707,7 @@ std::vector<cluster_repairs::ShardWithProtoAndDbServers> DistributeShardsLikeRep
     std::map<ShardID, DBServers, VersionSort> const& protoShardsById) {
   std::vector<ShardWithProtoAndDbServers> shards;
 
-  for (auto const& it : boost::combine(shardsById, protoShardsById)) {
+  for (auto&& it : boost::combine(shardsById, protoShardsById)) {
     auto const& shardIt = it.get<0>();
     auto const& protoShardIt = it.get<1>();
     ShardID const& shard = shardIt.first;
@@ -729,7 +729,7 @@ ResultT<std::list<RepairOperation>> DistributeShardsLikeRepairer::fixAllShardsOf
     struct cluster_repairs::Collection const& proto, DBServers const& availableDbServers) {
   std::list<RepairOperation> shardRepairOperations;
 
-  for (auto const& zippedShardsIterator :
+  for (auto&& zippedShardsIterator :
        boost::combine(collection.shardsById, proto.shardsById)) {
     auto const& shardIterator = zippedShardsIterator.get<0>();
     auto const& protoShardIterator = zippedShardsIterator.get<1>();

--- a/arangod/Cluster/CreateCollection.cpp
+++ b/arangod/Cluster/CreateCollection.cpp
@@ -138,7 +138,7 @@ bool CreateCollection::first() {
     VPackBuilder docket;
     {
       VPackObjectBuilder d(&docket);
-      for (auto const& i : VPackObjectIterator(props)) {
+      for (auto&& i : VPackObjectIterator(props)) {
         auto const& key = i.key.copyString();
         if (key == ID || key == NAME || key == GLOB_UID || key == OBJECT_ID) {
           if (key == GLOB_UID || key == OBJECT_ID) {

--- a/arangod/Cluster/DBServerAgencySync.cpp
+++ b/arangod/Cluster/DBServerAgencySync.cpp
@@ -313,7 +313,7 @@ DBServerAgencySyncResult DBServerAgencySync::execute() {
         if (!agency.isEmptyObject()) {
           std::vector<AgencyOperation> operations;
           std::vector<AgencyPrecondition> preconditions;
-          for (auto const& ao : VPackObjectIterator(agency)) {
+          for (auto&& ao : VPackObjectIterator(agency)) {
             auto const key = ao.key.copyString();
             auto const op = ao.value.get("op").copyString();
 

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -339,7 +339,7 @@ void HeartbeatThread::getNewsFromAgencyForDBServer() {
         {AgencyCommHelper::path(), "Target", "FailedServers"}));
     if (failedServersSlice.isObject()) {
       std::vector<ServerID> failedServers = {};
-      for (auto const& server : VPackObjectIterator(failedServersSlice)) {
+      for (auto&& server : VPackObjectIterator(failedServersSlice)) {
         failedServers.push_back(server.key.copyString());
       }
       LOG_TOPIC("52626", DEBUG, Logger::HEARTBEAT)
@@ -612,7 +612,7 @@ void HeartbeatThread::getNewsFromAgencyForCoordinator() {
 
     if (failedServersSlice.isObject()) {
       std::vector<ServerID> failedServers = {};
-      for (auto const& server : VPackObjectIterator(failedServersSlice)) {
+      for (auto&& server : VPackObjectIterator(failedServersSlice)) {
         failedServers.push_back(server.key.copyString());
       }
       LOG_TOPIC("43332", DEBUG, Logger::HEARTBEAT)

--- a/arangod/Cluster/RestClusterHandler.cpp
+++ b/arangod/Cluster/RestClusterHandler.cpp
@@ -208,7 +208,7 @@ void RestClusterHandler::handleCommandEndpoints() {
     }
 
     // {"serverId" : {"Status" : "GOOD", ...}}
-    for (VPackObjectIterator::ObjectPair const& pair : VPackObjectIterator(healthMap)) {
+    for (auto&& pair : VPackObjectIterator(healthMap)) {
       TRI_ASSERT(pair.key.isString() && pair.value.isObject());
       if (pair.key.compareString(leaderId) != 0) {
         VPackSlice status = pair.value.get("Status");

--- a/arangod/Cluster/TraverserEngine.cpp
+++ b/arangod/Cluster/TraverserEngine.cpp
@@ -123,7 +123,7 @@ BaseEngine::BaseEngine(TRI_vocbase_t& vocbase,
 
   // Add all Vertex shards to the transaction
   TRI_ASSERT(vertexSlice.isObject());
-  for (auto const& collection : VPackObjectIterator(vertexSlice)) {
+  for (auto&& collection : VPackObjectIterator(vertexSlice)) {
     std::vector<std::string> shards;
     TRI_ASSERT(collection.value.isArray());
     for (VPackSlice const shard : VPackArrayIterator(collection.value)) {
@@ -347,7 +347,7 @@ aql::VariableGenerator const* BaseTraverserEngine::variables() const {
 void BaseTraverserEngine::injectVariables(VPackSlice variableSlice) {
   if (variableSlice.isArray()) {
     _opts->clearVariableValues();
-    for (auto const& pair : VPackArrayIterator(variableSlice)) {
+    for (auto&& pair : VPackArrayIterator(variableSlice)) {
       if ((!pair.isArray()) || pair.length() != 2) {
         // Invalid communication. Skip
         TRI_ASSERT(false);

--- a/arangod/Cluster/v8-cluster.cpp
+++ b/arangod/Cluster/v8-cluster.cpp
@@ -276,8 +276,8 @@ static void JS_GetAgency(v8::FunctionCallbackInfo<v8::Value> const& args) {
 
   // return just the value for each key
 
-  for (auto const& a : VPackArrayIterator(result.slice())) {
-    for (auto const& o : VPackObjectIterator(a)) {
+  for (auto&& a : VPackArrayIterator(result.slice())) {
+    for (auto&& o : VPackObjectIterator(a)) {
       std::string const key = o.key.copyString();
       VPackSlice const slice = o.value;
 
@@ -675,7 +675,7 @@ static void JS_GetCollectionInfoClusterInfo(v8::FunctionCallbackInfo<v8::Value> 
   VPackSlice shards = info.get("shards");
   TRI_ASSERT(shards.isObject());
   v8::Handle<v8::Object> shardShorts = v8::Object::New(isolate);
-  for (auto const& p : VPackObjectIterator(shards)) {
+  for (auto&& p : VPackObjectIterator(shards)) {
     TRI_ASSERT(p.value.isArray());
     v8::Handle<v8::Array> shorts = v8::Array::New(isolate);
     uint32_t pos = 0;

--- a/arangod/Graph/Graph.cpp
+++ b/arangod/Graph/Graph.cpp
@@ -184,7 +184,7 @@ void Graph::parseEdgeDefinitions(VPackSlice edgeDefs) {
         "'edgeDefinitions' are not an array in the graph definition");
   }
 
-  for (auto const& def : VPackArrayIterator(edgeDefs)) {
+  for (auto&& def : VPackArrayIterator(edgeDefs)) {
     auto edgeDefRes = addEdgeDefinition(def);
     if (edgeDefRes.fail()) {
       THROW_ARANGO_EXCEPTION(std::move(edgeDefRes).result());
@@ -198,7 +198,7 @@ void Graph::insertOrphanCollections(VPackSlice const arr) {
         TRI_ERROR_GRAPH_INVALID_GRAPH,
         "'orphanCollections' are not an array in the graph definition");
   }
-  for (auto const& c : VPackArrayIterator(arr)) {
+  for (auto&& c : VPackArrayIterator(arr)) {
     THROW_ARANGO_EXCEPTION_IF_FAIL(validateOrphanCollection(c));
     addOrphanCollection(c.copyString());
   }

--- a/arangod/Graph/GraphManager.cpp
+++ b/arangod/Graph/GraphManager.cpp
@@ -925,7 +925,7 @@ Result GraphManager::pushCollectionIfMayBeDropped(std::string const& colName,
     // check edge definitions
     VPackSlice edgeDefinitions = graph.get(StaticStrings::GraphEdgeDefinitions);
     if (edgeDefinitions.isArray()) {
-      for (auto const& edgeDefinition : VPackArrayIterator(edgeDefinitions)) {
+      for (auto&& edgeDefinition : VPackArrayIterator(edgeDefinitions)) {
         // edge collection
         if (edgeDefinition.get("collection").stringRef() == colName) {
           collectionUnused = false;

--- a/arangod/Graph/TraverserOptions.cpp
+++ b/arangod/Graph/TraverserOptions.cpp
@@ -309,7 +309,7 @@ arangodb::traverser::TraverserOptions::TraverserOptions(arangodb::aql::QueryCont
     }
     _depthLookupInfo.reserve(read.length());
     size_t length = collections.length();
-    for (auto const& depth : VPackObjectIterator(read)) {
+    for (auto&& depth : VPackObjectIterator(read)) {
       uint64_t d = basics::StringUtils::uint64(depth.key.copyString());
       auto [it, emplaced] = _depthLookupInfo.try_emplace(d, std::vector<LookupInfo>());
       TRI_ASSERT(emplaced);
@@ -331,7 +331,7 @@ arangodb::traverser::TraverserOptions::TraverserOptions(arangodb::aql::QueryCont
     }
 
     _vertexExpressions.reserve(read.length());
-    for (auto const& info : VPackObjectIterator(read)) {
+    for (auto&& info : VPackObjectIterator(read)) {
       uint64_t d = basics::StringUtils::uint64(info.key.copyString());
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
       bool emplaced = false;

--- a/arangod/IResearch/IResearchView.cpp
+++ b/arangod/IResearch/IResearchView.cpp
@@ -882,7 +882,7 @@ IResearchView::Snapshot const* IResearchView::snapshot(
 
   try {
     // collect snapshots from all requested links
-    for (auto const cid : *collections) {
+    for (auto&& cid : *collections) {
       auto itr = _links.find(cid);
       auto* link = itr != _links.end() && itr->second
                        ? itr->second->get()

--- a/arangod/Pregel/AggregatorHandler.cpp
+++ b/arangod/Pregel/AggregatorHandler.cpp
@@ -80,7 +80,7 @@ void AggregatorHandler::aggregateValues(AggregatorHandler const& workerValues) {
 void AggregatorHandler::aggregateValues(VPackSlice const& workerValues) {
   VPackSlice values = workerValues.get(Utils::aggregatorValuesKey);
   if (values.isObject()) {
-    for (auto const& keyValue : VPackObjectIterator(values)) {
+    for (auto&& keyValue : VPackObjectIterator(values)) {
       AggregatorID name = keyValue.key.copyString();
       IAggregator* agg = getAggregator(name);
       if (agg) {
@@ -93,7 +93,7 @@ void AggregatorHandler::aggregateValues(VPackSlice const& workerValues) {
 void AggregatorHandler::setAggregatedValues(VPackSlice const& workerValues) {
   VPackSlice values = workerValues.get(Utils::aggregatorValuesKey);
   if (values.isObject()) {
-    for (auto const& keyValue : VPackObjectIterator(values)) {
+    for (auto&& keyValue : VPackObjectIterator(values)) {
       AggregatorID name = keyValue.key.copyString();
       IAggregator* agg = getAggregator(name);
       if (agg) {

--- a/arangod/Pregel/Algos/DMID/VertexSumAggregator.h
+++ b/arangod/Pregel/Algos/DMID/VertexSumAggregator.h
@@ -52,11 +52,11 @@ struct VertexSumAggregator : public IAggregator {
   };
 
   void parseAggregate(VPackSlice const& slice) override {
-    for (auto const& pair : VPackObjectIterator(slice)) {
+    for (auto&& pair : VPackObjectIterator(slice)) {
       PregelShard shard = std::stoi(pair.key.copyString());
       std::string key;
       VPackValueLength i = 0;
-      for (VPackSlice const& val : VPackArrayIterator(pair.value)) {
+      for (VPackSlice const&& val : VPackArrayIterator(pair.value)) {
         if (i % 2 == 0) {
           key = val.copyString();
         } else {
@@ -70,11 +70,11 @@ struct VertexSumAggregator : public IAggregator {
   void const* getAggregatedValue() const override { return &_entries; };
 
   void setAggregatedValue(VPackSlice const& slice) override {
-    for (auto const& pair : VPackObjectIterator(slice)) {
+    for (auto&& pair : VPackObjectIterator(slice)) {
       PregelShard shard = std::stoi(pair.key.copyString());
       std::string key;
       VPackValueLength i = 0;
-      for (VPackSlice const& val : VPackArrayIterator(pair.value)) {
+      for (VPackSlice const&& val : VPackArrayIterator(pair.value)) {
         if (i % 2 == 0) {
           key = val.copyString();
         } else {

--- a/arangod/Pregel/Recovery.cpp
+++ b/arangod/Pregel/Recovery.cpp
@@ -102,7 +102,7 @@ int RecoveryManager::filterGoodServers(std::vector<ServerID> const& servers,
     LOG_TOPIC("68f55", INFO, Logger::PREGEL) << "Server Status: " << serversRegistered.toJson();
 
     if (serversRegistered.isObject()) {
-      for (auto const& res : VPackObjectIterator(serversRegistered)) {
+      for (auto&& res : VPackObjectIterator(serversRegistered)) {
         VPackSlice serverId = res.key;
         VPackSlice slice = res.value;
         if (slice.isObject() && slice.hasKey("Status")) {

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -1838,7 +1838,7 @@ Result DatabaseInitialSyncer::handleCollection(VPackSlice const& parameters,
                            " index(es) for " + collectionMsg);
 
       try {
-        for (auto const& idxDef : VPackArrayIterator(indexes)) {
+        for (auto&& idxDef : VPackArrayIterator(indexes)) {
           if (idxDef.isObject()) {
             VPackSlice const type = idxDef.get(StaticStrings::IndexType);
             if (type.isString()) {

--- a/arangod/Replication/GlobalInitialSyncer.cpp
+++ b/arangod/Replication/GlobalInitialSyncer.cpp
@@ -156,7 +156,7 @@ Result GlobalInitialSyncer::runInternal(bool incremental) {
 
   try {
     // actually sync the database
-    for (auto const& dbEntry : VPackObjectIterator(databases)) {
+    for (auto&& dbEntry : VPackObjectIterator(databases)) {
       if (_state.applier._server.isStopping()) {
         return Result(TRI_ERROR_SHUTTING_DOWN);
       } else if (isAborted()) {
@@ -223,7 +223,7 @@ Result GlobalInitialSyncer::updateServerInventory(VPackSlice const& leaderDataba
   DatabaseFeature::DATABASE->enumerateDatabases(
       [&](TRI_vocbase_t& vocbase) -> void { existingDBs.insert(vocbase.name()); });
 
-  for (auto const& database : VPackObjectIterator(leaderDatabases)) {
+  for (auto&& database : VPackObjectIterator(leaderDatabases)) {
     VPackSlice it = database.value;
 
     if (!it.isObject()) {
@@ -264,7 +264,7 @@ Result GlobalInitialSyncer::updateServerInventory(VPackSlice const& leaderDataba
       // database already exists. now check which collections should survive
       std::unordered_set<std::string> survivingCollections;
 
-      for (auto const& coll : VPackArrayIterator(collections)) {
+      for (auto&& coll : VPackArrayIterator(collections)) {
         if (!coll.isObject() || !coll.hasKey("parameters")) {
           continue;  // somehow invalid
         }

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -67,11 +67,11 @@ struct agentConfigHealthResult {
 };
 
 void removePlanServers(std::unordered_set<std::string>& servers, VPackSlice plan) {
-  for (auto const& database : VPackObjectIterator(plan.get("Collections"))) {
-    for (auto const& collection : VPackObjectIterator(database.value)) {
+  for (auto&& database : VPackObjectIterator(plan.get("Collections"))) {
+    for (auto&& collection : VPackObjectIterator(database.value)) {
       VPackSlice shards = collection.value.get("shards");
-      for (auto const& shard : VPackObjectIterator(shards)) {
-        for (auto const& server : VPackArrayIterator(shard.value)) {
+      for (auto&& shard : VPackObjectIterator(shards)) {
+        for (auto&& server : VPackArrayIterator(shard.value)) {
           servers.erase(server.copyString());
           if (servers.empty()) {
             return;
@@ -83,10 +83,10 @@ void removePlanServers(std::unordered_set<std::string>& servers, VPackSlice plan
 }
 
 void removeCurrentServers(std::unordered_set<std::string>& servers, VPackSlice current) {
-  for (auto const& database : VPackObjectIterator(current.get("Collections"))) {
-    for (auto const& collection : VPackObjectIterator(database.value)) {
-      for (auto const& shard : VPackObjectIterator(collection.value)) {
-        for (auto const& server :
+  for (auto&& database : VPackObjectIterator(current.get("Collections"))) {
+    for (auto&& collection : VPackObjectIterator(database.value)) {
+      for (auto&& shard : VPackObjectIterator(collection.value)) {
+        for (auto&& server :
              VPackArrayIterator(shard.value.get("servers"))) {
           servers.erase(server.copyString());
           if (servers.empty()) {
@@ -174,7 +174,7 @@ void buildHealthResult(VPackBuilder& builder,
           continue;
         }
         agents[agent.name].leader = true;
-        for (const auto& agentIter : VPackObjectIterator(lastAcked)) {
+        for (auto&& agentIter : VPackObjectIterator(lastAcked)) {
           agents[agentIter.key.copyString()].lastAcked =
               agentIter.value.get("lastAckedTime").getDouble();
         }

--- a/arangod/RestHandler/RestImportHandler.cpp
+++ b/arangod/RestHandler/RestImportHandler.cpp
@@ -1019,7 +1019,7 @@ bool RestImportHandler::checkKeys(VPackSlice const& keys) const {
     return false;
   }
 
-  for (VPackSlice const& key : VPackArrayIterator(keys)) {
+  for (auto&& key : VPackArrayIterator(keys)) {
     if (!key.isString()) {
       return false;
     }

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -127,7 +127,7 @@ RestStatus RestIndexHandler::getIndexes() {
     tmp.add(StaticStrings::Code, VPackValue(static_cast<int>(ResponseCode::OK)));
     tmp.add("indexes", indexes.slice());
     tmp.add("identifiers", VPackValue(VPackValueType::Object));
-    for (VPackSlice const& index : VPackArrayIterator(indexes.slice())) {
+    for (auto&& index : VPackArrayIterator(indexes.slice())) {
       VPackSlice idd = index.get("id");
       VPackValueLength l = 0;
       char const* str = idd.getString(l);

--- a/arangod/RestHandler/RestRepairHandler.cpp
+++ b/arangod/RestHandler/RestRepairHandler.cpp
@@ -222,9 +222,9 @@ bool RestRepairHandler::repairAllCollections(
 
   std::unordered_map<CollectionID, DatabaseID> databaseByDataSourceId;
 
-  for (auto const& dbIt : VPackObjectIterator(planCollections)) {
+  for (auto&& dbIt : VPackObjectIterator(planCollections)) {
     DatabaseID database = dbIt.key.copyString();
-    for (auto const& colIt : VPackObjectIterator(dbIt.value)) {
+    for (auto&& colIt : VPackObjectIterator(dbIt.value)) {
       CollectionID collectionId = colIt.key.copyString();
       databaseByDataSourceId[collectionId] = database;
     }
@@ -531,9 +531,9 @@ ResultT<JobStatus> RestRepairHandler::getJobStatusFromAgency(std::string const& 
 
 ResultT<std::string> RestRepairHandler::getDbAndCollectionName(VPackSlice const planCollections,
                                                                CollectionID const& collectionID) {
-  for (auto const& db : VPackObjectIterator{planCollections}) {
+  for (auto&& db : VPackObjectIterator{planCollections}) {
     std::string dbName = db.key.copyString();
-    for (auto const& collection : VPackObjectIterator{db.value}) {
+    for (auto&& collection : VPackObjectIterator{db.value}) {
       std::string currentDataSourceId = collection.key.copyString();
       if (currentDataSourceId == collectionID) {
         return dbName + "/" + collection.value.get("name").copyString();

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1919,7 +1919,7 @@ Result RestReplicationHandler::processRestoreIndexes(VPackSlice const& collectio
         rebuilder.clear();
         rebuilder.openObject();
         rebuilder.add(StaticStrings::IndexType, VPackValue("geo"));
-        for (auto const& it : VPackObjectIterator(idxDef)) {
+        for (auto&& it : VPackObjectIterator(idxDef)) {
           if (!it.key.isEqualString(StaticStrings::IndexType)) {
             rebuilder.add(it.key);
             rebuilder.add(it.value);
@@ -2042,7 +2042,7 @@ Result RestReplicationHandler::processRestoreIndexesCoordinator(VPackSlice const
       rebuilder.clear();
       rebuilder.openObject();
       rebuilder.add(StaticStrings::IndexType, VPackValue("geo"));
-      for (auto const& it : VPackObjectIterator(idxDef)) {
+      for (auto&& it : VPackObjectIterator(idxDef)) {
         if (!it.key.isEqualString(StaticStrings::IndexType)) {
           rebuilder.add(it.key);
           rebuilder.add(it.value);
@@ -2060,7 +2060,7 @@ Result RestReplicationHandler::processRestoreIndexesCoordinator(VPackSlice const
           rebuilder.clear();
           rebuilder.openObject();
           rebuilder.add("minLength", VPackValue(1));
-          for (auto const& it : VPackObjectIterator(idxDef)) {
+          for (auto&& it : VPackObjectIterator(idxDef)) {
             if (!it.key.isEqualString("minLength")) {
               rebuilder.add(it.key);
               rebuilder.add(it.value);

--- a/arangod/RestHandler/RestWalAccessHandler.cpp
+++ b/arangod/RestHandler/RestWalAccessHandler.cpp
@@ -143,7 +143,7 @@ bool RestWalAccessHandler::parseFilter(WalAccess::Filter& filter) {
       return false;
     }
 
-    for (auto const& id : VPackArrayIterator(slice)) {
+    for (auto&& id : VPackArrayIterator(slice)) {
       if (!id.isString()) {
         generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                       "invalid body value. expecting array of ids");

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2028,7 +2028,7 @@ bool RocksDBEngine::systemDatabaseExists() {
   velocypack::Builder builder;
   getDatabases(builder);
 
-  for (auto const& item : velocypack::ArrayIterator(builder.slice())) {
+  for (auto&& item : velocypack::ArrayIterator(builder.slice())) {
     TRI_ASSERT(item.isObject());
     TRI_ASSERT(item.get(StaticStrings::DatabaseName).isString());
     if (item.get(StaticStrings::DatabaseName)
@@ -2160,7 +2160,7 @@ void RocksDBEngine::getStatistics(std::string& result) const {
   getStatistics(stats);
   VPackSlice sslice = stats.slice();
   TRI_ASSERT(sslice.isObject());
-  for (auto const& a : VPackObjectIterator(sslice)) {
+  for (auto&& a : VPackObjectIterator(sslice)) {
     if (a.value.isNumber()) {
       std::string name = a.key.copyString();
       std::replace(name.begin(), name.end(), '.', '_');

--- a/arangod/RocksDBEngine/RocksDBIndexFactory.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndexFactory.cpp
@@ -467,7 +467,7 @@ void RocksDBIndexFactory::prepareIndexes(
 
         b.openObject();
 
-        for (auto const& f : VPackObjectIterator(v)) {
+        for (auto&& f : VPackObjectIterator(v)) {
           if (arangodb::velocypack::StringRef(f.key) == StaticStrings::IndexId) {
             last = IndexId{last.id() + 1};
             b.add(StaticStrings::IndexId, VPackValue(std::to_string(last.id())));

--- a/arangod/RocksDBEngine/RocksDBRestExportHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestExportHandler.cpp
@@ -170,7 +170,7 @@ VPackBuilder RocksDBRestExportHandler::buildQueryOptions(std::string const& cnam
     if (fields.length() > 0) {
       // "restrict"."fields"
       int i = 0;
-      for (auto const& name : VPackArrayIterator(fields)) {
+      for (auto&& name : VPackArrayIterator(fields)) {
         if (name.isString()) {
           std::string varName = std::string("var").append(std::to_string(i++));
           query.append(", @").append(varName);

--- a/arangod/Sharding/ShardingInfo.cpp
+++ b/arangod/Sharding/ShardingInfo.cpp
@@ -218,12 +218,12 @@ ShardingInfo::ShardingInfo(arangodb::velocypack::Slice info, LogicalCollection* 
 
   auto shardsSlice = info.get("shards");
   if (shardsSlice.isObject()) {
-    for (auto const& shardSlice : VPackObjectIterator(shardsSlice)) {
+    for (auto&& shardSlice : VPackObjectIterator(shardsSlice)) {
       if (shardSlice.key.isString() && shardSlice.value.isArray()) {
         ShardID shard = shardSlice.key.copyString();
 
         std::vector<ServerID> servers;
-        for (auto const& serverSlice : VPackArrayIterator(shardSlice.value)) {
+        for (auto&& serverSlice : VPackArrayIterator(shardSlice.value)) {
           servers.push_back(serverSlice.copyString());
         }
         _shardIds->try_emplace(shard, servers);

--- a/arangod/Statistics/StatisticsWorker.cpp
+++ b/arangod/Statistics/StatisticsWorker.cpp
@@ -347,7 +347,7 @@ void StatisticsWorker::compute15Minute(VPackBuilder& builder, double start) {
          clientBytesReceivedPerSecond = 0, clientAvgTotalTime = 0,
          clientAvgRequestTime = 0, clientAvgQueueTime = 0, clientAvgIoTime = 0;
 
-  for (auto const& vs : VPackArrayIterator(result)) {
+  for (auto&& vs : VPackArrayIterator(result)) {
     VPackSlice const values = vs.resolveExternals();
 
     if (!values.isObject()) {

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -660,7 +660,7 @@ void LogicalCollection::toVelocyPackForClusterInventory(VPackBuilder& result,
   {
     VPackObjectBuilder guard(&result);
 
-    for (auto const& p : VPackObjectIterator(params.slice())) {
+    for (auto&& p : VPackObjectIterator(params.slice())) {
       result.add(p.key);
       result.add(p.value);
     }

--- a/arangod/VocBase/Methods/Indexes.cpp
+++ b/arangod/VocBase/Methods/Indexes.cpp
@@ -91,7 +91,7 @@ Result Indexes::getIndex(LogicalCollection const* collection, VPackSlice const& 
   Result res =
       Indexes::getAll(collection, Index::makeFlags(), /*withHidden*/ true, tmp, trx);
   if (res.ok()) {
-    for (VPackSlice const& index : VPackArrayIterator(tmp.slice())) {
+    for (VPackSlice&& index : VPackArrayIterator(tmp.slice())) {
       if (index.get(StaticStrings::IndexId).compareString(id) == 0 ||
           index.get(StaticStrings::IndexName).compareString(name) == 0) {
         out.add(index);
@@ -139,7 +139,7 @@ arangodb::Result Indexes::getAll(LogicalCollection const* collection,
     });
 
     tmp.openArray();
-    for (VPackSlice const& s : VPackArrayIterator(tmpInner.slice())) {
+    for (VPackSlice&& s : VPackArrayIterator(tmpInner.slice())) {
       auto id = arangodb::velocypack::StringRef(s.get(StaticStrings::IndexId));
       auto found = std::find_if(estimates.begin(), estimates.end(),
                                 [&id](std::pair<std::string, double> const& v) {
@@ -202,7 +202,7 @@ arangodb::Result Indexes::getAll(LogicalCollection const* collection,
          cacheLifeTimeHitRate = 0, cacheWindowedHitRate = 0;
 
   VPackArrayBuilder a(&result);
-  for (VPackSlice const& index : VPackArrayIterator(tmp.slice())) {
+  for (VPackSlice&& index : VPackArrayIterator(tmp.slice())) {
     std::string id = collection->name() + TRI_INDEX_HANDLE_SEPARATOR_CHR +
                      index.get(arangodb::StaticStrings::IndexId).copyString();
     VPackBuilder merge;

--- a/arangod/VocBase/Methods/Queries.cpp
+++ b/arangod/VocBase/Methods/Queries.cpp
@@ -110,7 +110,7 @@ void getQueries(TRI_vocbase_t& vocbase, std::vector<aql::QueryEntryCopy> const& 
           auto slice = resp.response->slice();
           // copy results from other coordinators
           if (slice.isArray()) {
-            for (auto const& entry : VPackArrayIterator(slice)) {
+            for (auto&& entry : VPackArrayIterator(slice)) {
               out.add(entry);
             }
           }

--- a/arangod/VocBase/VocbaseInfo.cpp
+++ b/arangod/VocBase/VocbaseInfo.cpp
@@ -185,7 +185,7 @@ Result CreateDatabaseInfo::extractUsers(VPackSlice const& users) {
     return Result(TRI_ERROR_HTTP_BAD_PARAMETER, "invalid users slice");
   }
 
-  for (VPackSlice const& user : VPackArrayIterator(users)) {
+  for (VPackSlice&& user : VPackArrayIterator(users)) {
     if (!user.isObject()) {
       events::CreateDatabase(_name, Result(TRI_ERROR_HTTP_BAD_PARAMETER), _context);
       return Result(TRI_ERROR_HTTP_BAD_PARAMETER);

--- a/lib/Maskings/AttributeMasking.cpp
+++ b/lib/Maskings/AttributeMasking.cpp
@@ -49,7 +49,7 @@ ParseResult<AttributeMasking> AttributeMasking::parse(Maskings* maskings,
   std::string path = "";
   std::string type = "";
 
-  for (auto const& entry : VPackObjectIterator(def, false)) {
+  for (auto&& entry : VPackObjectIterator(def, false)) {
     std::string key = entry.key.copyString();
 
     if (key == "type") {

--- a/lib/Maskings/Collection.cpp
+++ b/lib/Maskings/Collection.cpp
@@ -38,7 +38,7 @@ ParseResult<Collection> Collection::parse(Maskings* maskings, VPackSlice const& 
   std::string type = "";
   std::vector<AttributeMasking> attributes;
 
-  for (auto const& entry : VPackObjectIterator(def, false)) {
+  for (auto&& entry : VPackObjectIterator(def, false)) {
     std::string key = entry.key.copyString();
 
     if (key == "type") {
@@ -56,7 +56,7 @@ ParseResult<Collection> Collection::parse(Maskings* maskings, VPackSlice const& 
             "expecting an array for collection maskings");
       }
 
-      for (auto const& mask : VPackArrayIterator(entry.value)) {
+      for (auto&& mask : VPackArrayIterator(entry.value)) {
         ParseResult<AttributeMasking> am = AttributeMasking::parse(maskings, mask);
 
         if (am.status != ParseResult<AttributeMasking>::VALID) {

--- a/lib/Maskings/Maskings.cpp
+++ b/lib/Maskings/Maskings.cpp
@@ -96,7 +96,7 @@ ParseResult<Maskings> Maskings::parse(VPackSlice const& def) {
                                  "expecting an object for masking definition");
   }
 
-  for (auto const& entry : VPackObjectIterator(def, false)) {
+  for (auto&& entry : VPackObjectIterator(def, false)) {
     std::string key = entry.key.copyString();
 
     if (key == "*") {
@@ -258,7 +258,7 @@ void Maskings::addMaskedArray(Collection& collection, VPackBuilder& builder,
 
 void Maskings::addMaskedObject(Collection& collection, VPackBuilder& builder,
                                std::vector<std::string>& path, VPackSlice const& data) {
-  for (auto const& entry : VPackObjectIterator(data, false)) {
+  for (auto&& entry : VPackObjectIterator(data, false)) {
     std::string key = entry.key.copyString();
     VPackSlice const& value = entry.value;
 
@@ -305,7 +305,7 @@ void Maskings::addMasked(Collection& collection, basics::StringBuffer& data,
   {
     VPackObjectBuilder ob(&builder);
 
-    for (auto const& entry : VPackObjectIterator(slice, false)) {
+    for (auto&& entry : VPackObjectIterator(slice, false)) {
       velocypack::StringRef key = entry.key.stringRef();
 
       if (key.equals(dataStrRef)) {


### PR DESCRIPTION
### Scope & Purpose

Make ArangoDB compile with clang version 12.0.0.
```
Apple clang version 12.0.0 (clang-1200.0.32.2)
Target: x86_64-apple-darwin19.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

Original messages:
```
/Volumes/External/Git/devel/lib/Maskings/AttributeMasking.cpp:52:20: error: loop variable 'entry' is always a copy because the range of type '(anonymous namespace)::VPackObjectIterator' (aka 'arangodb::velocypack::ObjectIterator') does not return a reference [-Werror,-Wrange-loop-analysis]
  for (auto const& entry : VPackObjectIterator(def, false)) {
                   ^
/Volumes/External/Git/devel/lib/Maskings/AttributeMasking.cpp:52:8: note: use non-reference type 'arangodb::velocypack::ObjectIteratorPair'
  for (auto const& entry : VPackObjectIterator(def, false)) {
       ^~~~~~~~~~~~~~~~~~~
1 error generated.
make[3]: *** [lib/CMakeFiles/arango.dir/Maskings/AttributeMasking.cpp.o] Error 1
make[3]: *** Waiting for unfinished jobs....
/Volumes/External/Git/devel/lib/Maskings/Collection.cpp:59:24: error: loop variable 'mask' is always a copy because the range of type '(anonymous namespace)::VPackArrayIterator' (aka 'arangodb::velocypack::ArrayIterator') does not return a reference [-Werror,-Wrange-loop-analysis]
      for (auto const& mask : VPackArrayIterator(entry.value)) {
                       ^
/Volumes/External/Git/devel/lib/Maskings/Collection.cpp:59:12: note: use non-reference type 'arangodb::velocypack::Slice'
      for (auto const& mask : VPackArrayIterator(entry.value)) {
           ^~~~~~~~~~~~~~~~~~
/Volumes/External/Git/devel/lib/Maskings/Collection.cpp:41:20: error: loop variable 'entry' is always a copy because the range of type '(anonymous namespace)::VPackObjectIterator' (aka 'arangodb::velocypack::ObjectIterator') does not return a reference [-Werror,-Wrange-loop-analysis]
  for (auto const& entry : VPackObjectIterator(def, false)) {
                   ^
/Volumes/External/Git/devel/lib/Maskings/Collection.cpp:41:8: note: use non-reference type 'arangodb::velocypack::ObjectIteratorPair'
  for (auto const& entry : VPackObjectIterator(def, false)) {
```

- [x] :hankey: Bugfix 
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required (all we want to support with clang 12)

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

Additionally:

Jenkins:
*(Include link to Jenkins run etc)*