### PR TITLE
Slightly speed up initial replication of collections/shards

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,15 @@
 devel
 -----
 
+* Slightly speed up initial replication of collections/shards data by not
+  wrapping each document in a seperate `{"type":2300,"data":...}` envelope.
+  Stripping of the envelopes allows for slightly smaller data sizes when 
+  exchanging the documents, and thus can less to small savings in document
+  packing and unpacking as well as slightly reduce the number of required
+  HTTP requests. 
+  The non-wrapping of the documents is opt-in, so the existing dump API 
+  stays downwards-compatible.
+
 * Data definition reconsiliation in cluster has been modified
   extensively to greatly accelerate the creation of 1000s of
   databases through following means:

--- a/arangod/RocksDBEngine/RocksDBReplicationContext.h
+++ b/arangod/RocksDBEngine/RocksDBReplicationContext.h
@@ -173,12 +173,14 @@ class RocksDBReplicationContext {
   // iterates over at most 'limit' documents in the collection specified,
   // creating a new iterator if one does not exist for this collection
   DumpResult dumpJson(TRI_vocbase_t& vocbase, std::string const& cname,
-                      basics::StringBuffer&, uint64_t chunkSize);
+                      basics::StringBuffer&, uint64_t chunkSize,
+                      bool useEnvelope);
 
   // iterates over at most 'limit' documents in the collection specified,
   // creating a new iterator if one does not exist for this collection
   DumpResult dumpVPack(TRI_vocbase_t& vocbase, std::string const& cname,
-                       velocypack::Buffer<uint8_t>& buffer, uint64_t chunkSize);
+                       velocypack::Buffer<uint8_t>& buffer, uint64_t chunkSize,
+                       bool useEnvelope);
 
   // ==================== Incremental Sync ===========================
 

--- a/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
@@ -684,6 +684,8 @@ void RocksDBRestReplicationHandler::handleCommandDump() {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_FORBIDDEN);
     return;
   }
+  
+  bool const useEnvelope = _request->parsedValue("useEnvelope", true);
 
   uint64_t chunkSize = determineChunkSize();
   size_t reserve = std::max<size_t>(chunkSize, 8192);
@@ -694,9 +696,8 @@ void RocksDBRestReplicationHandler::handleCommandDump() {
     buffer.reserve(reserve);  // avoid reallocs
     
     auto trxCtx = transaction::StandaloneContext::Create(_vocbase);
-    
 
-    res = ctx->dumpVPack(_vocbase, cname, buffer, chunkSize);
+    res = ctx->dumpVPack(_vocbase, cname, buffer, chunkSize, useEnvelope);
     // generate the result
     if (res.fail()) {
       generateError(res.result());
@@ -720,7 +721,7 @@ void RocksDBRestReplicationHandler::handleCommandDump() {
     StringBuffer dump(reserve, false);
 
     // do the work!
-    res = ctx->dumpJson(_vocbase, cname, dump, determineChunkSize());
+    res = ctx->dumpJson(_vocbase, cname, dump, determineChunkSize(), useEnvelope);
 
     if (res.fail()) {
       if (res.is(TRI_ERROR_BAD_PARAMETER)) {


### PR DESCRIPTION
### Scope & Purpose

Slightly speed up initial replication of collections/shards data by not wrapping each document in a seperate `{"type":2300,"data":...}` envelope. The "type" attribute is from the MMFiles era, when collections included document and removal markers, but is superfluous in the RocksDB era, where a dump response will only contain documents.

Stripping of the envelopes allows slightly smaller data sizes when exchanging the documents, and thus can less to small savings in document packing and unpacking as well as slightly reduce the number of required HTTP requests.
The non-wrapping of the documents is opt-in, so the existing dump API stays downwards-compatible. The current replication code on the follower will ask the follower to produce a dump result without envelopes, which the leader is free to ignore. The follower code will automatically figure out which format the response has, so there should be no compatibility issues here in any case.
The complexity added by this PR is tolerable IMHO.

The actual savings depend on the number of documents and their sizes, the available processing power and the network speed/capacity. In some scenarios, a speedup of a single-digit percentage value can be expected.

- [ ] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] This change is already covered by existing tests, such as *replication tests*.
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (i.e. in http_replication)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12019/