### PR TITLE
Use dynamically-sized response queue to prevent full queues

### DIFF
--- a/arangod/GeneralServer/H2CommTask.cpp
+++ b/arangod/GeneralServer/H2CommTask.cpp
@@ -250,7 +250,7 @@ constexpr uint32_t window_size = (1 << 30) - 1;  // 1 GiB
 void submitConnectionPreface(nghttp2_session* session) {
   std::array<nghttp2_settings_entry, 4> iv;
   // 32 streams matches the queue capacity
-  iv[0] = {NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, 32};
+  iv[0] = {NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, arangodb::H2MaxConcurrentStreams};
   // typically client is just a *sink* and just process data as
   // much as possible.  Use large window size by default.
   iv[1] = {NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE, window_size};
@@ -581,21 +581,25 @@ void H2CommTask<T>::sendResponse(std::unique_ptr<GeneralResponse> res,
 
   // this uses a fixed capacity queue, push might fail (unlikely, we limit max streams)
   unsigned retries = 512;
-  while (ADB_UNLIKELY(!_responses.push(tmp))) {
-    std::this_thread::yield();
-    if (--retries == 0) {
-      LOG_TOPIC("924dc", WARN, Logger::REQUESTS)
-          << "was not able to queue response" << (void*)this;
-      // we are overloaded close stream
-      asio_ns::post(this->_protocol->context.io_context,
-                    [self(this->shared_from_this()), mid(res->messageId())] {
-                      auto& me = static_cast<H2CommTask<T>&>(*self);
-                      nghttp2_submit_rst_stream(me._session, NGHTTP2_FLAG_NONE,
-                                                static_cast<int32_t>(mid),
-                                                NGHTTP2_ENHANCE_YOUR_CALM);
-                    });
-      return;
+  try {
+    while (ADB_UNLIKELY(!_responses.push(tmp) && --retries > 0)) {
+      std::this_thread::yield();
     }
+  } catch (...) {
+    retries = 0;
+  }
+  if (--retries == 0) {
+    LOG_TOPIC("924dc", WARN, Logger::REQUESTS)
+        << "was not able to queue response this=" << (void*)this;
+    // we are overloaded close stream
+    asio_ns::post(this->_protocol->context.io_context,
+                  [self(this->shared_from_this()), mid(res->messageId())] {
+                    auto& me = static_cast<H2CommTask<T>&>(*self);
+                    nghttp2_submit_rst_stream(me._session, NGHTTP2_FLAG_NONE,
+                                              static_cast<int32_t>(mid),
+                                              NGHTTP2_ENHANCE_YOUR_CALM);
+                  });
+    return;
   }
   res.release();
 

--- a/arangod/GeneralServer/H2CommTask.h
+++ b/arangod/GeneralServer/H2CommTask.h
@@ -35,10 +35,13 @@
 namespace arangodb {
 class HttpRequest;
 
+/// @brief maximum number of concurrent streams
+static constexpr uint32_t H2MaxConcurrentStreams = 32;
+
 namespace rest {
 
 struct H2Response;
-
+  
 template <SocketType T>
 class H2CommTask final : public GeneralCommTask<T> {
  public:
@@ -48,7 +51,7 @@ class H2CommTask final : public GeneralCommTask<T> {
   void start() override;
   /// @brief upgrade from  H1 connection, must not call start
   void upgradeHttp1(std::unique_ptr<HttpRequest> req);
-
+  
  protected:
   virtual bool readCallback(asio_ns::error_code ec) override;
   virtual void setIOTimeout() override;
@@ -113,8 +116,7 @@ class H2CommTask final : public GeneralCommTask<T> {
  private:
   velocypack::Buffer<uint8_t> _outbuffer;
 
-  // no more than 64 streams allowed
-  boost::lockfree::queue<H2Response*, boost::lockfree::capacity<32>> _responses;
+  boost::lockfree::queue<H2Response*, boost::lockfree::capacity<H2MaxConcurrentStreams>> _responses;
 
   std::map<int32_t, Stream> _streams;
 

--- a/arangod/GeneralServer/VstCommTask.cpp
+++ b/arangod/GeneralServer/VstCommTask.cpp
@@ -60,7 +60,11 @@ VstCommTask<T>::VstCommTask(GeneralServer& server, ConnectionInfo info,
       _numProcessing(0),
       _authToken("", !this->_auth->isActive(), 0),
       _authMethod(rest::AuthenticationMethod::NONE),
-      _vstVersion(v) {}
+      _vstVersion(v) {
+  // arbitrary initial reserve value to save a few memory allocations
+  // in the most common cases.
+  _writeQueue.reserve(32);
+}
 
 template <SocketType T>
 VstCommTask<T>::~VstCommTask() {
@@ -375,14 +379,19 @@ void VstCommTask<T>::sendResponse(std::unique_ptr<GeneralResponse> baseRes,
 
   // this uses a fixed capacity queue, push might fail (unlikely, we limit max streams)
   unsigned retries = 512;
-  while (ADB_UNLIKELY(!_writeQueue.push(resItem.get()))) {
-    std::this_thread::yield();
-    if (--retries == 0) {
-      LOG_TOPIC("a3bfc", WARN, Logger::REQUESTS)
-          << "was not able to queue response this=" << (void*)this;
-      this->stop();  // stop is thread-safe
-      return;
+  try {
+    while (ADB_UNLIKELY(!_writeQueue.push(resItem.get()) && --retries > 0)) {
+      std::this_thread::yield();
+      --retries;
     }
+  } catch (...) {
+    retries = 0;
+  }
+  if (retries == 0) {
+    LOG_TOPIC("a3bfc", WARN, Logger::REQUESTS)
+        << "was not able to queue response this=" << (void*)this;
+    this->stop();  // stop is thread-safe
+    return;
   }
   resItem.release();
 

--- a/arangod/GeneralServer/VstCommTask.h
+++ b/arangod/GeneralServer/VstCommTask.h
@@ -104,7 +104,17 @@ class VstCommTask final : public GeneralCommTask<T> {
 
  private:
   std::map<uint64_t, Message> _messages;
-  boost::lockfree::queue<ResponseItem*, boost::lockfree::capacity<32>> _writeQueue;
+
+  // the queue is dynamically sized because we can't guarantee that
+  // only a fixed number of responses are active at the same time.
+  // the reason is that producing responses may happen faster than
+  // fetching responses from the queue. this is done by different threads
+  // and depends on thread scheduling, so it is somewhat random how
+  // fast producing and consuming happen.
+  // effectively the length of the queue is bounded by the fact that the
+  // scheduler queue length is also bounded, so that we will not see
+  // an endless growth of the queue in a single connection.
+  boost::lockfree::queue<ResponseItem*> _writeQueue;
 
   std::atomic<bool> _writeLoopActive;  /// is writing
   std::atomic<unsigned> _numProcessing;


### PR DESCRIPTION
### Scope & Purpose

Forward port of #12741

This PR adjusts the internal write queue size in server-side VST connections, so that the write queue does not overflow in case a client sends a massive amount of requests and the server produces responses to them at a faster rate than they can be sent out.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.7 (#12741)

### Testing & Verification

- [x] There are tests in an external testing repository: java driver tests

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12031/