### PR TITLE
Fix SORT in subqueries when crossing block boundaries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix #12693: SORT inside a subquery could sometimes swallow part of its input
+  when it crossed boundaries of internal row batches.
+
 * Fix a performance regression when a LIMIT is combined with a COLLECT WITH
   COUNT INTO. Reported in ES-692.
 

--- a/arangod/Aql/AllRowsFetcher.cpp
+++ b/arangod/Aql/AllRowsFetcher.cpp
@@ -27,8 +27,6 @@
 #include "Aql/AqlItemBlock.h"
 #include "Aql/AqlItemMatrix.h"
 #include "Aql/DependencyProxy.h"
-#include "Aql/InputAqlItemRow.h"
-#include "Aql/ShadowAqlItemRow.h"
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/AqlItemBlockInputMatrix.cpp
+++ b/arangod/Aql/AqlItemBlockInputMatrix.cpp
@@ -113,12 +113,10 @@ bool AqlItemBlockInputMatrix::hasDataRow() const noexcept {
   if (_aqlItemMatrix == nullptr) {
     return false;
   }
-  return !hasShadowRow() && _aqlItemMatrix != nullptr && (
-        (_aqlItemMatrix->stoppedOnShadowRow())
-        || (_aqlItemMatrix->size() > 0 && _finalState == ExecutorState::DONE)
-      );
 
-  //return (!_shadowRow.isInitialized() && _aqlItemMatrix->size() != 0);
+  return !hasShadowRow() && _aqlItemMatrix != nullptr &&
+         ((_aqlItemMatrix->stoppedOnShadowRow()) ||
+          (_aqlItemMatrix->size() > 0 && _finalState == ExecutorState::DONE));
 }
 
 std::pair<ExecutorState, ShadowAqlItemRow> AqlItemBlockInputMatrix::nextShadowRow() {

--- a/arangod/Aql/AqlItemBlockInputMatrix.cpp
+++ b/arangod/Aql/AqlItemBlockInputMatrix.cpp
@@ -34,6 +34,9 @@ using namespace arangodb::aql;
 
 AqlItemBlockInputMatrix::AqlItemBlockInputMatrix(ExecutorState state)
     : _finalState{state}, _aqlItemMatrix{nullptr} {
+  // TODO As we only allow HASMORE, just use the default constructor and remove
+  //      this one.
+  TRI_ASSERT(state == ExecutorState::HASMORE);
   TRI_ASSERT(_aqlItemMatrix == nullptr);
   TRI_ASSERT(!hasDataRow());
 }
@@ -110,7 +113,12 @@ bool AqlItemBlockInputMatrix::hasDataRow() const noexcept {
   if (_aqlItemMatrix == nullptr) {
     return false;
   }
-  return (!_shadowRow.isInitialized() && _aqlItemMatrix->size() != 0);
+  return !hasShadowRow() && _aqlItemMatrix != nullptr && (
+        (_aqlItemMatrix->stoppedOnShadowRow())
+        || (_aqlItemMatrix->size() > 0 && _finalState == ExecutorState::DONE)
+      );
+
+  //return (!_shadowRow.isInitialized() && _aqlItemMatrix->size() != 0);
 }
 
 std::pair<ExecutorState, ShadowAqlItemRow> AqlItemBlockInputMatrix::nextShadowRow() {

--- a/arangod/Aql/AqlItemMatrix.cpp
+++ b/arangod/Aql/AqlItemMatrix.cpp
@@ -89,9 +89,7 @@ void AqlItemMatrix::clear() {
 
 RegisterCount AqlItemMatrix::getNumRegisters() const noexcept { return _nrRegs; }
 
-uint64_t AqlItemMatrix::size() const noexcept {
-  return _numDataRows;
-}
+uint64_t AqlItemMatrix::size() const noexcept { return _numDataRows; }
 
 void AqlItemMatrix::addBlock(SharedAqlItemBlockPtr blockPtr) {
   // If we are stopped by shadow row, we first need to solve this blockage

--- a/arangod/Aql/AqlItemMatrix.h
+++ b/arangod/Aql/AqlItemMatrix.h
@@ -73,7 +73,7 @@ class AqlItemMatrix {
    *
    * @return True if empty
    */
-  bool empty() const noexcept;
+  bool blocksEmpty() const noexcept;
 
   void clear();
 
@@ -107,7 +107,7 @@ class AqlItemMatrix {
  private:
   std::vector<SharedAqlItemBlockPtr> _blocks;
 
-  uint64_t _size;
+  uint64_t _numDataRows;
 
   RegisterCount _nrRegs;
   size_t _startIndexInFirstBlock{0};

--- a/arangod/Aql/SortExecutor.cpp
+++ b/arangod/Aql/SortExecutor.cpp
@@ -151,7 +151,6 @@ std::tuple<ExecutorState, NoStats, AqlCall> SortExecutor::produceRows(
     AqlItemBlockInputMatrix& inputMatrix, OutputAqlItemRow& output) {
   AqlCall upstreamCall{};
 
-  // if (inputMatrix.upstreamState() == ExecutorState::HASMORE) {
   if (!inputMatrix.hasDataRow()) {
     // If our inputMatrix does not contain all upstream rows
     return {inputMatrix.upstreamState(), NoStats{}, upstreamCall};

--- a/tests/Aql/AqlItemMatrixTest.cpp
+++ b/tests/Aql/AqlItemMatrixTest.cpp
@@ -44,7 +44,7 @@ TEST_F(AqlItemMatrixTest, expose_size_of_data_only) {
   auto& manager = this->manager();
 
   AqlItemMatrix testee(1);
-  EXPECT_TRUE(testee.empty());
+  EXPECT_TRUE(testee.blocksEmpty());
   {
     // 12
     auto block =
@@ -52,14 +52,14 @@ TEST_F(AqlItemMatrixTest, expose_size_of_data_only) {
                       {{1}, {2}, {3}, {4}, {1}, {2}, {3}, {4}, {1}, {2}, {3}, {4}});
     testee.addBlock(block);
   }
-  EXPECT_FALSE(testee.empty());
+  EXPECT_FALSE(testee.blocksEmpty());
   ASSERT_EQ(testee.size(), 12);
   {
     // 8
     auto block = buildBlock<1>(manager, {{1}, {2}, {3}, {4}, {1}, {2}, {3}, {4}});
     testee.addBlock(block);
   }
-  EXPECT_FALSE(testee.empty());
+  EXPECT_FALSE(testee.blocksEmpty());
   ASSERT_EQ(testee.size(), 20);
 
   {
@@ -67,7 +67,7 @@ TEST_F(AqlItemMatrixTest, expose_size_of_data_only) {
     auto block = buildBlock<1>(manager, {{1}, {2}, {3}, {4}, {1}, {2}, {3}, {4}, {1}});
     testee.addBlock(block);
   }
-  EXPECT_FALSE(testee.empty());
+  EXPECT_FALSE(testee.blocksEmpty());
   ASSERT_EQ(testee.size(), 29);
 }
 

--- a/tests/Aql/InputRangeTest.cpp
+++ b/tests/Aql/InputRangeTest.cpp
@@ -53,13 +53,12 @@ std::string const stateToString(ExecutorState state) {
 
 template <typename Range>
 class InputRangeTest : public AqlExecutorTestCase<> {
- private:
+ protected:
   // Used to holdData for InputMatrixTests
   AqlItemMatrix _matrix{1};
   // Picked a random number of dependencies for MultiInputRanges
   size_t _numberDependencies{3};
 
- protected:
   auto buildRange(ExecutorState state, SharedAqlItemBlockPtr block) -> Range {
     if constexpr (std::is_same_v<Range, AqlItemBlockInputRange>) {
       return AqlItemBlockInputRange{state, 0, block, 0};
@@ -136,8 +135,28 @@ TYPED_TEST_CASE_P(InputRangeTest);
 TYPED_TEST_P(InputRangeTest, test_default_initializer) {
   std::vector<ExecutorState> states{ExecutorState::DONE, ExecutorState::HASMORE};
   for (auto const& finalState : states) {
+    if (std::is_same_v<AqlItemBlockInputMatrix, TypeParam> &&
+        finalState == ExecutorState::DONE) {
+      // The AqlItemBlockInputMatrix may not be instantiated with DON
+      continue;
+    }
     SCOPED_TRACE("Testing state: " + stateToString(finalState));
-    TypeParam testee{finalState};
+    auto testee = std::invoke([&]() {
+      if constexpr (std::is_same_v<TypeParam, AqlItemBlockInputMatrix>) {
+        if (finalState == ExecutorState::HASMORE) {
+          return TypeParam{finalState};
+        } else {
+          TRI_ASSERT(finalState == ExecutorState::DONE);
+          // AqlItemBlockInputMatrix may not be instantiated with DONE and
+          // without a matrix, thus this conditionals.
+          return TypeParam{finalState, &this->_matrix};
+        }
+      } else {
+        return TypeParam{finalState};
+      }
+    });
+    // assert is just for documentation
+    static_assert(std::is_same_v<decltype(testee), TypeParam>);
     if constexpr (std::is_same_v<decltype(testee), MultiAqlItemBlockInputRange>) {
       // Default has only 1 dependency
       EXPECT_EQ(testee.upstreamState(0), finalState);
@@ -180,7 +199,14 @@ TYPED_TEST_P(InputRangeTest, test_block_only_datarows) {
       EXPECT_EQ(testee.upstreamState(), ExecutorState::HASMORE);
     }
 
-    EXPECT_TRUE(testee.hasDataRow());
+    if constexpr (std::is_same_v<decltype(testee), AqlItemBlockInputMatrix>) {
+      // The AqlItemBlockInputMatrix may only report it has a data row when it
+      // knows it has consumed all input (of the current subquery iteration, if
+      // applicable).
+      EXPECT_EQ(testee.hasDataRow(), finalState == ExecutorState::DONE);
+    } else {
+      EXPECT_TRUE(testee.hasDataRow());
+    }
     EXPECT_FALSE(testee.hasShadowRow());
 
     // Required for expected Number Of Rows

--- a/tests/Aql/InputRangeTest.cpp
+++ b/tests/Aql/InputRangeTest.cpp
@@ -137,7 +137,7 @@ TYPED_TEST_P(InputRangeTest, test_default_initializer) {
   for (auto const& finalState : states) {
     if (std::is_same_v<AqlItemBlockInputMatrix, TypeParam> &&
         finalState == ExecutorState::DONE) {
-      // The AqlItemBlockInputMatrix may not be instantiated with DON
+      // The AqlItemBlockInputMatrix may not be instantiated with DONE
       continue;
     }
     SCOPED_TRACE("Testing state: " + stateToString(finalState));


### PR DESCRIPTION
### Scope & Purpose

SORT inside a subquery could sometimes swallow part of its input when it crossed block boundaries.

- [X] :hankey: Bugfix 
- [x] :book: CHANGELOG entry made
- [X] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [X] Backport required for: *3.7*

#### Related Information

- [X] GitHub issue: https://github.com/arangodb/arangodb/issues/12693

### Testing & Verification

- [X] This change is already covered by existing tests, such as `InputRangeTest` in the gtest suite `arangodbtest`.
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added **Regression Tests**

### Documentation

- [x] Added a *Changelog Entry* (referencing the corresponding public or internal issue number)
