### PR TITLE
Fix shard leader behaviour if a follower does not play ball.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fixed a bug in handling of followers which refuse to replicate operations.
+  In the case that the follower has simply been dropped in the meantime, we now
+  avoid an error reported by the shard leader.
+
 * Added weighted traversal. Use `mode: "weighted"` as option to enumerate
   paths by increasing weights. The cost of an edge can be read from an
   attribute which can be specified using `weightAttribute` option.

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2298,9 +2298,14 @@ Future<Result> Methods::replicateOperations(
   // this operation to succeed, since the new leader is now responsible.
   // In case (2) we at least have to drop the follower such that it
   // resyncs and we can be sure that it is in sync again.
-  // Therefore, we drop the follower here (just in case), and refuse to
-  // return with a refusal error (note that we use the follower version,
-  // since we have lost leadership):
+  // We have some hint from the error message of the follower. If it is
+  // TRI_ERROR_CLUSTER_SHARD_LEADER_REFUSES_REPLICATION, we have reason
+  // to believe that the follower is now the new leader and we assume
+  // case (1).
+  // If the error is TRI_ERROR_CLUSTER_SHARD_FOLLOWER_REFUSES_OPERATION,
+  // we continue with the operation, since most likely, the follower was
+  // simply dropped in the meantime.
+  // In any case, we drop the follower here (just in case).
   auto cb = [=](std::vector<futures::Try<network::Response>>&& responses) -> Result {
 
     bool didRefuse = false;


### PR DESCRIPTION
There are two cases in which a shard follower refuses to execute a
synchronous replication request by a shard leader.

One is if the follower has in the meantime taken over leadership for the
shard. The other is if it is simply no longer following that leader, for
example because of a restart or because it was dropped in the meantime
by another thread.

In the first case it is correct behaviour for the leader to run into an
error, because most likely it is no longer actually the leader.
In the second case it is better to drop the follower (even if already
dropped) and move on without an error.

This PR implements fixes this behaviour.
- Fix behaviour of a shard leader if follower does not play ball.
- Improve comment.
- CHANGELOG.
