### PR TITLE
Feature 3.7/improved observability

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.7.3 (XXXX-XX-XX)
 -------------------
 
+* Fixed a bug in handling of followers which refuse to replicate operations.
+  In the case that the follower has simply been dropped in the meantime, we now
+  avoid an error reported by the shard leader.
+
 * Fix a performance regression when a LIMIT is combined with a COLLECT WITH
   COUNT INTO. Reported in ES-692.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,27 @@
-v3.7.3 (XXXX-XX-XX)
+v3.7.4 (XXXX-XX-XX)
 -------------------
+
+* Add database, shard name and error information to several shard-related log 
+  messages.
+
+* Display shard names of a collection in the web interface when in the details
+  view of the collection.
+
+* Added HTTP requests metrics for tracking the number of superuser and normal
+  user requests separately:
+
+  - `arangodb_http_request_statistics_superuser_requests`: Total number of HTTP
+    requests executed by superuser/JWT
+  - `arangodb_http_request_statistics_user_requests`: Total number of HTTP 
+    requests executed by clients
 
 * Fixed a bug in handling of followers which refuse to replicate operations.
   In the case that the follower has simply been dropped in the meantime, we now
   avoid an error reported by the shard leader.
+
+
+v3.7.3 (XXXX-XX-XX)
+-------------------
 
 * Fix a performance regression when a LIMIT is combined with a COLLECT WITH
   COUNT INTO. Reported in ES-692.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.7.4 (XXXX-XX-XX)
 -------------------
 
+* Added configuration option `--rocksdb.sync-delay-threshold`.
+  This option can be used to track if any RocksDB WAL sync operations is 
+  delayed by more than the configured value (in milliseconds). The intention
+  is to get aware of severely delayed WAL sync operations.
+
 * Add database, shard name and error information to several shard-related log 
   messages.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-v3.7.4 (XXXX-XX-XX)
+v3.7.3 (XXXX-XX-XX)
 -------------------
 
 * Added configuration option `--rocksdb.sync-delay-threshold`.
@@ -6,7 +6,7 @@ v3.7.4 (XXXX-XX-XX)
   delayed by more than the configured value (in milliseconds). The intention
   is to get aware of severely delayed WAL sync operations.
 
-* Add database, shard name and error information to several shard-related log 
+* Add database, shard name and error information to several shard-related log
   messages.
 
 * Display shard names of a collection in the web interface when in the details
@@ -17,12 +17,8 @@ v3.7.4 (XXXX-XX-XX)
 
   - `arangodb_http_request_statistics_superuser_requests`: Total number of HTTP
     requests executed by superuser/JWT
-  - `arangodb_http_request_statistics_user_requests`: Total number of HTTP 
+  - `arangodb_http_request_statistics_user_requests`: Total number of HTTP
     requests executed by clients
-
-
-v3.7.3 (XXXX-XX-XX)
--------------------
 
 * Fixed a bug in handling of followers which refuse to replicate operations.
   In the case that the follower has simply been dropped in the meantime, we now

--- a/arangod/Cluster/ClusterTrxMethods.cpp
+++ b/arangod/Cluster/ClusterTrxMethods.cpp
@@ -268,11 +268,13 @@ Future<Result> commitAbortTransaction(transaction::Methods& trx, transaction::St
                   // TODO: what happens if a server is re-added during a transaction ?
                   LOG_TOPIC("709c9", WARN, Logger::REPLICATION)
                       << "synchronous replication: dropping follower "
-                      << follower << " for shard " << tc.collectionName();
+                      << follower << " for shard " << tc.collectionName()
+                      << " in database " << cc->vocbase().name();
                 } else {
                   LOG_TOPIC("4971f", ERR, Logger::REPLICATION)
                       << "synchronous replication: could not drop follower "
                       << follower << " for shard " << tc.collectionName()
+                      << " in database " << cc->vocbase().name()
                       << ": " << r.errorMessage();
                   res.reset(TRI_ERROR_CLUSTER_COULD_NOT_DROP_FOLLOWER);
                   return false;  // cancel transaction

--- a/arangod/Cluster/ClusterTrxMethods.cpp
+++ b/arangod/Cluster/ClusterTrxMethods.cpp
@@ -270,6 +270,11 @@ Future<Result> commitAbortTransaction(transaction::Methods& trx, transaction::St
                       << "synchronous replication: dropping follower "
                       << follower << " for shard " << tc.collectionName()
                       << " in database " << cc->vocbase().name();
+                  LOG_TOPIC("b071c", WARN, Logger::DEVEL)
+                      << "synchronous replication: dropping follower "
+                      << follower << " for shard " << tc.collectionName()
+                      << " in database " << cc->vocbase().name()
+                      << ": " << resp.combinedResult().errorMessage();
                 } else {
                   LOG_TOPIC("4971f", ERR, Logger::REPLICATION)
                       << "synchronous replication: could not drop follower "

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -534,8 +534,6 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
 
   auto database = vocbase.name();
 
-  auto shard = col->name();
-
   bool keepBarrier = config.get(KEEP_BARRIER).getBool();
   std::string leaderId;
   if (config.hasKey(LEADER_ID)) {
@@ -566,7 +564,8 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
   SyncerId syncerId{syncer->syncerId()};
 
   try {
-    Result r = syncer->run(configuration._incremental);
+    std::string const context = "synchronization of shard " + col->name() + " in database " + database;
+    Result r = syncer->run(configuration._incremental, context.c_str());
 
     if (r.fail()) {
       LOG_TOPIC("3efff", DEBUG, Logger::REPLICATION)

--- a/arangod/ClusterEngine/ClusterEngine.h
+++ b/arangod/ClusterEngine/ClusterEngine.h
@@ -151,9 +151,10 @@ class ClusterEngine final : public StorageEngine {
     return std::vector<std::string>();
   }
 
-  Result flushWal(bool waitForSync, bool waitForCollector, bool writeShutdownFile) override {
-    return {TRI_ERROR_NO_ERROR};
+  Result flushWal(bool waitForSync, bool waitForCollector) override {
+    return {};
   }
+
   void waitForEstimatorSync(std::chrono::milliseconds maxWaitTime) override;
 
   virtual std::unique_ptr<TRI_vocbase_t> openDatabase(arangodb::CreateDatabaseInfo&& info,

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -242,14 +242,14 @@ void RestHandler::handleExceptionPtr(std::exception_ptr eptr) noexcept {
   } catch (Exception const& ex) {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     LOG_TOPIC("11929", WARN, arangodb::Logger::FIXME)
-    << "caught exception in " << name() << ": " << ex.what();
+    << "maintainer mode: caught exception in " << name() << ": " << ex.what();
 #endif
     _statistics.SET_EXECUTE_ERROR();
     handleError(ex);
   } catch (arangodb::velocypack::Exception const& ex) {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     LOG_TOPIC("fdcbc", WARN, arangodb::Logger::FIXME)
-    << "caught velocypack exception in " << name() << ": "
+    << "maintainer mode: caught velocypack exception in " << name() << ": "
     << ex.what();
 #endif
     _statistics.SET_EXECUTE_ERROR();
@@ -262,7 +262,7 @@ void RestHandler::handleExceptionPtr(std::exception_ptr eptr) noexcept {
   } catch (std::bad_alloc const& ex) {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     LOG_TOPIC("5c9f6", WARN, arangodb::Logger::FIXME)
-    << "caught memory exception in " << name() << ": "
+    << "maintainer mode: caught memory exception in " << name() << ": "
     << ex.what();
 #endif
     _statistics.SET_EXECUTE_ERROR();
@@ -271,14 +271,14 @@ void RestHandler::handleExceptionPtr(std::exception_ptr eptr) noexcept {
   } catch (std::exception const& ex) {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     LOG_TOPIC("252ea", WARN, arangodb::Logger::FIXME)
-    << "caught exception in " << name() << ": " << ex.what();
+    << "maintainer mode: caught exception in " << name() << ": " << ex.what();
 #endif
     _statistics.SET_EXECUTE_ERROR();
     Exception err(TRI_ERROR_INTERNAL, ex.what(), __FILE__, __LINE__);
     handleError(err);
   } catch (...) {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-    LOG_TOPIC("f729d", WARN, arangodb::Logger::FIXME) << "caught unknown exception in " << name();
+    LOG_TOPIC("f729d", WARN, arangodb::Logger::FIXME) << "maintainer mode: caught unknown exception in " << name();
 #endif
     _statistics.SET_EXECUTE_ERROR();
     Exception err(TRI_ERROR_INTERNAL, __FILE__, __LINE__);

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -439,14 +439,14 @@ void RestHandler::executeEngine(bool isContinue) {
   } catch (Exception const& ex) {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     LOG_TOPIC("11928", WARN, arangodb::Logger::FIXME)
-        << "caught exception in " << name() << ": " << ex.what();
+        << "maintainer mode: caught exception in " << name() << ": " << ex.what();
 #endif
     _statistics.SET_EXECUTE_ERROR();
     handleError(ex);
   } catch (arangodb::velocypack::Exception const& ex) {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     LOG_TOPIC("fdcbb", WARN, arangodb::Logger::FIXME)
-        << "caught velocypack exception in " << name() << ": "
+        << "maintainer mode: caught velocypack exception in " << name() << ": "
         << ex.what();
 #endif
     _statistics.SET_EXECUTE_ERROR();
@@ -459,7 +459,7 @@ void RestHandler::executeEngine(bool isContinue) {
   } catch (std::bad_alloc const& ex) {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     LOG_TOPIC("5c9f5", WARN, arangodb::Logger::FIXME)
-        << "caught memory exception in " << name() << ": "
+        << "maintainer mode: caught memory exception in " << name() << ": "
         << ex.what();
 #endif
     _statistics.SET_EXECUTE_ERROR();
@@ -468,14 +468,14 @@ void RestHandler::executeEngine(bool isContinue) {
   } catch (std::exception const& ex) {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     LOG_TOPIC("252e9", WARN, arangodb::Logger::FIXME)
-        << "caught exception in " << name() << ": " << ex.what();
+        << "maintainer mode: caught exception in " << name() << ": " << ex.what();
 #endif
     _statistics.SET_EXECUTE_ERROR();
     Exception err(TRI_ERROR_INTERNAL, ex.what(), __FILE__, __LINE__);
     handleError(err);
   } catch (...) {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-    LOG_TOPIC("f729c", WARN, arangodb::Logger::FIXME) << "caught unknown exception in " << name();
+    LOG_TOPIC("f729c", WARN, arangodb::Logger::FIXME) << "maintainer mode: caught unknown exception in " << name();
 #endif
     _statistics.SET_EXECUTE_ERROR();
     Exception err(TRI_ERROR_INTERNAL, __FILE__, __LINE__);

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -358,7 +358,8 @@ DatabaseInitialSyncer::DatabaseInitialSyncer(TRI_vocbase_t& vocbase,
 }
 
 /// @brief run method, performs a full synchronization
-Result DatabaseInitialSyncer::runWithInventory(bool incremental, VPackSlice dbInventory) {
+Result DatabaseInitialSyncer::runWithInventory(bool incremental, VPackSlice dbInventory,
+                                               char const* context) {
   if (!_config.connection.valid()) {
     return Result(TRI_ERROR_INTERNAL, "invalid endpoint");
   }
@@ -382,7 +383,7 @@ Result DatabaseInitialSyncer::runWithInventory(bool incremental, VPackSlice dbIn
     }
 
     if (!_config.isChild()) {
-      r = _config.master.getState(_config.connection, _config.isChild());
+      r = _config.master.getState(_config.connection, _config.isChild(), context);
 
       if (r.fail()) {
         return r;

--- a/arangod/Replication/DatabaseInitialSyncer.h
+++ b/arangod/Replication/DatabaseInitialSyncer.h
@@ -91,13 +91,13 @@ class DatabaseInitialSyncer final : public InitialSyncer {
                         ReplicationApplierConfiguration const& configuration);
 
   /// @brief run method, performs a full synchronization
-  Result run(bool incremental) override {
-    return runWithInventory(incremental, velocypack::Slice::noneSlice());
+  Result run(bool incremental, char const* context = nullptr) override {
+    return runWithInventory(incremental, velocypack::Slice::noneSlice(), context);
   }
 
   /// @brief run method, performs a full synchronization with the
   ///        given list of collections.
-  Result runWithInventory(bool incremental, velocypack::Slice collections);
+  Result runWithInventory(bool incremental, velocypack::Slice collections, char const* context = nullptr);
 
   TRI_vocbase_t* resolveVocbase(velocypack::Slice const& slice) override {
     return &_config.vocbase;

--- a/arangod/Replication/DatabaseTailingSyncer.cpp
+++ b/arangod/Replication/DatabaseTailingSyncer.cpp
@@ -86,12 +86,13 @@ Result DatabaseTailingSyncer::saveApplierState() {
 Result DatabaseTailingSyncer::syncCollectionCatchupInternal(std::string const& collectionName,
                                                             double timeout, bool hard,
                                                             TRI_voc_tick_t& until,
-                                                            bool& didTimeout) {
+                                                            bool& didTimeout,
+                                                            char const* context) {
   didTimeout = false;
 
   setAborted(false);
   // fetch master state just once
-  Result r = _state.master.getState(_state.connection, _state.isChildSyncer, nullptr);
+  Result r = _state.master.getState(_state.connection, _state.isChildSyncer, context);
   if (r.fail()) {
     return r;
   }
@@ -140,8 +141,13 @@ Result DatabaseTailingSyncer::syncCollectionCatchupInternal(std::string const& c
 
     if (response->getHttpReturnCode() == 204) {
       // HTTP 204 No content: this means we are done
+      TRI_ASSERT(r.ok());
+      if (hard) {
+        // now do a final sync-to-disk call. note that this can fail
+        r = EngineSelectorFeature::ENGINE->flushWal(/*waitForSync*/ true, /*waitForCollector*/ false);
+      }
       until = fromTick;
-      return Result();
+      return r;
     }
 
     bool found;
@@ -227,9 +233,15 @@ Result DatabaseTailingSyncer::syncCollectionCatchupInternal(std::string const& c
 
     if (!checkMore) {
       // done!
+      TRI_ASSERT(r.ok());
+      if (hard) {
+        // now do a final sync-to-disk call. note that this can fail
+        r = EngineSelectorFeature::ENGINE->flushWal(/*waitForSync*/ true, /*waitForCollector*/ false);
+      }
       until = fromTick;
-      return Result();
+      return r;
     }
+
     LOG_TOPIC("2598f", DEBUG, Logger::REPLICATION) << "Fetching more data, fromTick: " << fromTick
                                           << ", lastScannedTick: " << lastScannedTick;
   }

--- a/arangod/Replication/DatabaseTailingSyncer.cpp
+++ b/arangod/Replication/DatabaseTailingSyncer.cpp
@@ -91,7 +91,7 @@ Result DatabaseTailingSyncer::syncCollectionCatchupInternal(std::string const& c
 
   setAborted(false);
   // fetch master state just once
-  Result r = _state.master.getState(_state.connection, _state.isChildSyncer);
+  Result r = _state.master.getState(_state.connection, _state.isChildSyncer, nullptr);
   if (r.fail()) {
     return r;
   }

--- a/arangod/Replication/DatabaseTailingSyncer.h
+++ b/arangod/Replication/DatabaseTailingSyncer.h
@@ -48,12 +48,12 @@ class DatabaseTailingSyncer final : public TailingSyncer {
 
   /// @brief finalize the synchronization of a collection by tailing the WAL
   /// and filtering on the collection name until no more data is available
-  Result syncCollectionFinalize(std::string const& collectionName) {
+  Result syncCollectionFinalize(std::string const& collectionName, char const* context) {
     TRI_voc_tick_t dummy = 0;
     bool dummyDidTimeout = false;
     double dummyTimeout = 300.0;
     return syncCollectionCatchupInternal(collectionName, dummyTimeout, true,
-                                         dummy, dummyDidTimeout);
+                                         dummy, dummyDidTimeout, context);
   }
 
   /// @brief catch up with changes in a leader shard by doing the same
@@ -67,14 +67,14 @@ class DatabaseTailingSyncer final : public TailingSyncer {
   /// `syncCollectionFinalize` to finish off the rest.
   /// Internally, both use `syncCollectionCatchupInternal`.
   Result syncCollectionCatchup(std::string const& collectionName, double timeout,
-                               TRI_voc_tick_t& until, bool& didTimeout) {
-    return syncCollectionCatchupInternal(collectionName, timeout, false, until, didTimeout);
+                               TRI_voc_tick_t& until, bool& didTimeout, char const* context) {
+    return syncCollectionCatchupInternal(collectionName, timeout, false, until, didTimeout, context);
   }
 
  protected:
   Result syncCollectionCatchupInternal(std::string const& collectionName,
                                        double timeout, bool hard,
-                                       TRI_voc_tick_t& until, bool& didTimeout);
+                                       TRI_voc_tick_t& until, bool& didTimeout, char const* context);
   /// @brief save the current applier state
   Result saveApplierState() override;
 

--- a/arangod/Replication/GlobalInitialSyncer.cpp
+++ b/arangod/Replication/GlobalInitialSyncer.cpp
@@ -65,9 +65,9 @@ GlobalInitialSyncer::~GlobalInitialSyncer() {
 
 /// @brief run method, performs a full synchronization
 /// public method, catches exceptions
-Result GlobalInitialSyncer::run(bool incremental) {
+Result GlobalInitialSyncer::run(bool incremental, char const* context) {
   try {
-    return runInternal(incremental);
+    return runInternal(incremental, context);
   } catch (arangodb::basics::Exception const& ex) {
     return Result(ex.code(),
                   std::string("initial synchronization for database '") +
@@ -85,7 +85,7 @@ Result GlobalInitialSyncer::run(bool incremental) {
 
 /// @brief run method, performs a full synchronization
 /// internal method, may throw exceptions
-Result GlobalInitialSyncer::runInternal(bool incremental) {
+Result GlobalInitialSyncer::runInternal(bool incremental, char const* context) {
   if (!_state.connection.valid()) {
     return Result(TRI_ERROR_INTERNAL, "invalid endpoint");
   } else if (_state.applier._server.isStopping()) {
@@ -95,7 +95,7 @@ Result GlobalInitialSyncer::runInternal(bool incremental) {
   setAborted(false);
 
   LOG_TOPIC("23d92", DEBUG, Logger::REPLICATION) << "client: getting master state";
-  Result r = _state.master.getState(_state.connection, _state.isChildSyncer);
+  Result r = _state.master.getState(_state.connection, _state.isChildSyncer, context);
   if (r.fail()) {
     return r;
   }

--- a/arangod/Replication/GlobalInitialSyncer.h
+++ b/arangod/Replication/GlobalInitialSyncer.h
@@ -38,7 +38,7 @@ class GlobalInitialSyncer final : public InitialSyncer {
  public:
   /// @brief run method, performs a full synchronization
   /// public method, catches exceptions
-  arangodb::Result run(bool incremental) override;
+  arangodb::Result run(bool incremental, char const* context = nullptr) override;
 
   /// @brief fetch the server's inventory, public method
   Result getInventory(arangodb::velocypack::Builder& builder);
@@ -46,7 +46,7 @@ class GlobalInitialSyncer final : public InitialSyncer {
  private:
   /// @brief run method, performs a full synchronization
   /// internal method, may throw exceptions
-  arangodb::Result runInternal(bool incremental);
+  arangodb::Result runInternal(bool incremental, char const* context);
 
   /// @brief check whether the initial synchronization should be aborted
   bool checkAborted();

--- a/arangod/Replication/InitialSyncer.h
+++ b/arangod/Replication/InitialSyncer.h
@@ -77,7 +77,7 @@ class InitialSyncer : public Syncer {
   ~InitialSyncer();
 
  public:
-  virtual Result run(bool incremental) = 0;
+  virtual Result run(bool incremental, char const* context = nullptr) = 0;
 
   /// @brief return the last log tick of the master at start
   TRI_voc_tick_t getLastLogTick() const { return _state.master.lastLogTick; }

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -1266,7 +1266,7 @@ retry:
 
   while (true) {
     setProgress("fetching master state information");
-    res = _state.master.getState(_state.connection, _state.isChildSyncer);
+    res = _state.master.getState(_state.connection, _state.isChildSyncer, nullptr);
 
     if (res.is(TRI_ERROR_REPLICATION_NO_RESPONSE)) {
       // master error. try again after a sleep period

--- a/arangod/Replication/utilities.h
+++ b/arangod/Replication/utilities.h
@@ -153,7 +153,7 @@ struct MasterInfo {
   explicit MasterInfo(ReplicationApplierConfiguration const& applierConfig);
 
   /// @brief get master state
-  Result getState(Connection& connection, bool isChildSyncer);
+  Result getState(Connection& connection, bool isChildSyncer, char const* context);
 
   /// we need to act like a 3.2 client
   bool simulate32Client() const;

--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -412,7 +412,7 @@ RestStatus RestCollectionHandler::handleCommandPut() {
 
     if (flush && TRI_vocbase_col_status_e::TRI_VOC_COL_STATUS_LOADED ==
                      coll->status()) {
-      EngineSelectorFeature::ENGINE->flushWal(false, false, false);
+      EngineSelectorFeature::ENGINE->flushWal(false, false);
     }
 
     res = methods::Collections::unload(&_vocbase, coll.get());

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -1704,12 +1704,24 @@ std::vector<std::string> RocksDBEngine::currentWalFiles() const {
   return names;
 }
 
+/// @brief flushes the RocksDB WAL. 
+/// the optional parameter "waitForSync" is currently only used when the
+/// "waitForCollector" parameter is also set to true. If "waitForCollector"
+/// is true, all the RocksDB column family memtables are flushed, and, if
+/// "waitForSync" is set, additionally synced to disk. The only call site
+/// that uses "waitForCollector" currently is hot backup.
+/// The function parameter name are a remainder from MMFiles times, when
+/// they made more sense. This can be refactored at any point, so that
+/// flushing column families becomes a separate API.
 Result RocksDBEngine::flushWal(bool waitForSync, bool waitForCollector) {
   Result res;
 
   if (_syncThread) {
     // _syncThread may be a nullptr, in case automatic syncing is turned off
     res = _syncThread->syncWal();
+  } else {
+    // no syncThread...
+    res = RocksDBSyncThread::sync(_db->GetBaseDB());
   }
 
   if (res.ok() && waitForCollector) {

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -203,6 +203,7 @@ RocksDBEngine::RocksDBEngine(application_features::ApplicationServer& server)
 #else
       _syncInterval(100),
 #endif
+      _syncDelayThreshold(5000),
       _useThrottle(true),
       _useReleasedTick(false),
       _debugLogging(false),
@@ -294,7 +295,18 @@ void RocksDBEngine::collectOptions(std::shared_ptr<options::ProgramOptions> opti
   options->addOption("--rocksdb.sync-interval",
                      "interval for automatic, non-requested disk syncs (in "
                      "milliseconds, use 0 to turn automatic syncing off)",
-                     new UInt64Parameter(&_syncInterval));
+                     new UInt64Parameter(&_syncInterval),
+                     arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer));
+  
+  options->addOption("--rocksdb.sync-delay-threshold",
+                     "threshold value for self-observation of WAL disk syncs. "
+                     "any WAL disk sync longer ago than this threshold will trigger "
+                     "a warning (in milliseconds, use 0 for no warnings)",
+                     new UInt64Parameter(&_syncDelayThreshold),
+                     arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::Hidden))
+                     .setIntroducedIn(30800)
+                     .setIntroducedIn(30705)
+                     .setIntroducedIn(30608);
 
   options->addOption("--rocksdb.wal-file-timeout",
                      "timeout after which unused WAL files are deleted",
@@ -345,12 +357,28 @@ void RocksDBEngine::validateOptions(std::shared_ptr<options::ProgramOptions> opt
   validateEnterpriseOptions(options);
 #endif
 
-  if (_syncInterval > 0 && _syncInterval < minSyncInterval) {
-    // _syncInterval = 0 means turned off!
-    LOG_TOPIC("bbd68", FATAL, arangodb::Logger::CONFIG)
-        << "invalid value for --rocksdb.sync-interval. Please use a value "
-        << "of at least " << minSyncInterval;
-    FATAL_ERROR_EXIT();
+  if (_syncInterval > 0) {
+    if (_syncInterval < minSyncInterval) {
+      // _syncInterval = 0 means turned off!
+      LOG_TOPIC("bbd68", FATAL, arangodb::Logger::CONFIG)
+          << "invalid value for --rocksdb.sync-interval. Please use a value "
+          << "of at least " << minSyncInterval;
+      FATAL_ERROR_EXIT();
+    }
+    
+    if (_syncDelayThreshold > 0 && _syncDelayThreshold <= _syncInterval) {
+      if (!options->processingResult().touched("rocksdb.sync-interval") &&
+          options->processingResult().touched("rocksdb.sync-delay-threshold")) {
+        // user has not set --rocksdb.sync-interval, but set --rocksdb.sync-delay-threshold
+        LOG_TOPIC("c3f45", WARN, arangodb::Logger::CONFIG)
+            << "invalid value for --rocksdb.sync-delay-threshold. should be higher "
+            << "than the value of --rocksdb.sync-interval (" << _syncInterval << ")";
+      }
+      
+      _syncDelayThreshold = 10 * _syncInterval;
+      LOG_TOPIC("c0fa3", WARN, arangodb::Logger::CONFIG)
+          << "auto-adjusting value of --rocksdb.sync-delay-threshold to " << _syncDelayThreshold << " ms";
+    }
   }
 
 #ifdef _WIN32
@@ -808,7 +836,7 @@ void RocksDBEngine::start() {
              _useReleasedTick);
 
   if (_syncInterval > 0) {
-    _syncThread.reset(new RocksDBSyncThread(*this, std::chrono::milliseconds(_syncInterval)));
+    _syncThread.reset(new RocksDBSyncThread(*this, std::chrono::milliseconds(_syncInterval), std::chrono::milliseconds(_syncDelayThreshold)));
     if (!_syncThread->start()) {
       LOG_TOPIC("63919", FATAL, Logger::ENGINES)
           << "could not start rocksdb sync thread";
@@ -1676,25 +1704,28 @@ std::vector<std::string> RocksDBEngine::currentWalFiles() const {
   return names;
 }
 
-Result RocksDBEngine::flushWal(bool waitForSync, bool waitForCollector,
-                               bool /*writeShutdownFile*/) {
+Result RocksDBEngine::flushWal(bool waitForSync, bool waitForCollector) {
+  Result res;
+
   if (_syncThread) {
     // _syncThread may be a nullptr, in case automatic syncing is turned off
-    _syncThread->syncWal();
+    res = _syncThread->syncWal();
   }
 
-  if (waitForCollector) {
+  if (res.ok() && waitForCollector) {
     rocksdb::FlushOptions flushOptions;
     flushOptions.wait = waitForSync;
 
     for (auto cf : RocksDBColumnFamily::_allHandles) {
       rocksdb::Status status = _db->GetBaseDB()->Flush(flushOptions, cf);
       if (!status.ok()) {
-        return rocksutils::convertStatus(status);
+        res.reset(rocksutils::convertStatus(status));
+        break;
       }
     }
   }
-  return Result();
+
+  return res;
 }
 
 void RocksDBEngine::waitForEstimatorSync(std::chrono::milliseconds maxWaitTime) {
@@ -1736,7 +1767,7 @@ void RocksDBEngine::determinePrunableWalFiles(TRI_voc_tick_t minTickExternal) {
   auto status = _db->GetSortedWalFiles(files);
   if (!status.ok()) {
     LOG_TOPIC("078ef", INFO, Logger::ENGINES)
-        << "could not get WAL files " << status.ToString();
+        << "could not get WAL files: " << status.ToString();
     return;
   }
 

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -205,7 +205,7 @@ class RocksDBEngine final : public StorageEngine {
   /// @brief return a list of the currently open WAL files
   std::vector<std::string> currentWalFiles() const override;
 
-  Result flushWal(bool waitForSync, bool waitForCollector, bool writeShutdownFile) override;
+  Result flushWal(bool waitForSync, bool waitForCollector) override;
   void waitForEstimatorSync(std::chrono::milliseconds maxWaitTime) override;
 
   virtual std::unique_ptr<TRI_vocbase_t> openDatabase(arangodb::CreateDatabaseInfo&& info,
@@ -456,6 +456,10 @@ class RocksDBEngine final : public StorageEngine {
   // WAL sync interval, specified in milliseconds by end user, but uses
   // microseconds internally
   uint64_t _syncInterval;
+  
+  // WAL sync delay threshold. Any WAL disk sync longer ago than this value
+  // will trigger a warning (in milliseconds)
+  uint64_t _syncDelayThreshold;
 
   // use write-throttling
   bool _useThrottle;

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -205,6 +205,15 @@ class RocksDBEngine final : public StorageEngine {
   /// @brief return a list of the currently open WAL files
   std::vector<std::string> currentWalFiles() const override;
 
+  /// @brief flushes the RocksDB WAL. 
+  /// the optional parameter "waitForSync" is currently only used when the
+  /// "waitForCollector" parameter is also set to true. If "waitForCollector"
+  /// is true, all the RocksDB column family memtables are flushed, and, if
+  /// "waitForSync" is set, additionally synced to disk. The only call site
+  /// that uses "waitForCollector" currently is hot backup.
+  /// The function parameter name are a remainder from MMFiles times, when
+  /// they made more sense. This can be refactored at any point, so that
+  /// flushing column families becomes a separate API.
   Result flushWal(bool waitForSync, bool waitForCollector) override;
   void waitForEstimatorSync(std::chrono::milliseconds maxWaitTime) override;
 

--- a/arangod/RocksDBEngine/RocksDBSyncThread.cpp
+++ b/arangod/RocksDBEngine/RocksDBSyncThread.cpp
@@ -143,11 +143,10 @@ void RocksDBSyncThread::run() {
       }
 
       {
-        std::chrono::duration<double> diff = lastSyncTime - previousLastSyncTime;
-        if (_delayThreshold.count() > 0 && diff > _delayThreshold) {
+        if (_delayThreshold.count() > 0 && (lastSyncTime - previousLastSyncTime) > _delayThreshold) {
           LOG_TOPIC("5b708", INFO, Logger::ENGINES)
             << "last RocksDB WAL sync happened longer ago than configured threshold. "
-            << "last sync happened " << std::chrono::duration_cast<std::chrono::milliseconds>(diff).count() << " ms ago, "
+            << "last sync happened " << (std::chrono::duration_cast<std::chrono::milliseconds>(lastSyncTime - previousLastSyncTime)).count() << " ms ago, "
             << "threshold value: " << _delayThreshold.count() << " ms";
         }
       }

--- a/arangod/RocksDBEngine/RocksDBSyncThread.cpp
+++ b/arangod/RocksDBEngine/RocksDBSyncThread.cpp
@@ -33,12 +33,15 @@
 
 using namespace arangodb;
 
-RocksDBSyncThread::RocksDBSyncThread(RocksDBEngine& engine, std::chrono::milliseconds interval)
+RocksDBSyncThread::RocksDBSyncThread(RocksDBEngine& engine, 
+                                     std::chrono::milliseconds interval,
+                                     std::chrono::milliseconds delayThreshold)
     : Thread(engine.server(), "RocksDBSync"),
       _engine(engine),
       _interval(interval),
       _lastSyncTime(std::chrono::steady_clock::now()),
-      _lastSequenceNumber(0) {}
+      _lastSequenceNumber(0),
+      _delayThreshold(delayThreshold) {}
 
 RocksDBSyncThread::~RocksDBSyncThread() { shutdown(); }
 
@@ -105,12 +108,17 @@ void RocksDBSyncThread::run() {
     try {
       auto const now = std::chrono::steady_clock::now();
 
+      rocksdb::SequenceNumber lastSequenceNumber;
+      rocksdb::SequenceNumber previousLastSequenceNumber;
+      std::chrono::time_point<std::chrono::steady_clock> lastSyncTime;
+      std::chrono::time_point<std::chrono::steady_clock> previousLastSyncTime;
+
       {
         // wait for time to elapse, and after that update last sync time
         CONDITION_LOCKER(guard, _condition);
 
-        auto const previousLastSequenceNumber = _lastSequenceNumber;
-        auto const previousLastSyncTime = _lastSyncTime;
+        previousLastSequenceNumber = _lastSequenceNumber;
+        previousLastSyncTime = _lastSyncTime;
         auto const end = _lastSyncTime + _interval;
         if (end > now) {
           guard.wait(std::chrono::microseconds(
@@ -122,23 +130,45 @@ void RocksDBSyncThread::run() {
           continue;
         }
 
-        _lastSyncTime = std::chrono::steady_clock::now();
-
-        auto lastSequenceNumber = db->GetLatestSequenceNumber();
+        lastSyncTime = std::chrono::steady_clock::now();
+        lastSequenceNumber = db->GetLatestSequenceNumber();
 
         if (lastSequenceNumber == previousLastSequenceNumber) {
-          // nothing to sync, so don't cause unnecessary load
+          // nothing to sync, so don't cause unnecessary load.
+          // still update our lastSyncTime to now, so we don't run into warnings
+          // later with syncs being reported as delayed
+          _lastSyncTime = lastSyncTime;
           continue;
         }
-
-        _lastSequenceNumber = lastSequenceNumber;
       }
 
-      // will update last sync time, and do the actual sync
-      Result res = sync(db);
+      {
+        std::chrono::duration<double> diff = lastSyncTime - previousLastSyncTime;
+        if (_delayThreshold.count() > 0 && diff > _delayThreshold) {
+          LOG_TOPIC("5b708", INFO, Logger::ENGINES)
+            << "last RocksDB WAL sync happened longer ago than configured threshold. "
+            << "last sync happened " << std::chrono::duration_cast<std::chrono::milliseconds>(diff).count() << " ms ago, "
+            << "threshold value: " << _delayThreshold.count() << " ms";
+        }
+      }
 
-      if (res.fail()) {
-        LOG_TOPIC("5e275", WARN, Logger::ENGINES)
+      Result res = this->sync(db);
+
+      if (res.ok()) {
+        // success case
+        CONDITION_LOCKER(guard, _condition);
+
+        if (lastSequenceNumber > _lastSequenceNumber) {
+          // bump last sequence number we have synced
+          _lastSequenceNumber = lastSequenceNumber;
+        }
+        if (lastSyncTime > _lastSyncTime) {
+          _lastSyncTime = lastSyncTime;
+        }
+      } else {
+        // could not sync... in this case, don't advance our last
+        // sync time and last synced sequence number
+        LOG_TOPIC("5e275", ERR, Logger::ENGINES)
             << "could not sync RocksDB WAL: " << res.errorMessage();
       }
     } catch (std::exception const& ex) {

--- a/arangod/RocksDBEngine/RocksDBSyncThread.h
+++ b/arangod/RocksDBEngine/RocksDBSyncThread.h
@@ -42,7 +42,9 @@ class RocksDBEngine;
 
 class RocksDBSyncThread final : public Thread {
  public:
-  RocksDBSyncThread(RocksDBEngine& engine, std::chrono::milliseconds interval);
+  RocksDBSyncThread(RocksDBEngine& engine, 
+                    std::chrono::milliseconds interval,
+                    std::chrono::milliseconds delayThreshold);
 
   ~RocksDBSyncThread();
 
@@ -70,6 +72,12 @@ class RocksDBSyncThread final : public Thread {
 
   /// @brief the last definitely synced RocksDB WAL sequence number
   rocksdb::SequenceNumber _lastSequenceNumber;
+
+  /// @brief threshold for self-observation of WAL disk syncs.
+  /// if the last WAL sync happened longer ago than this configured
+  /// threshold, a warning will be logged on every invocation of the
+  /// sync thread
+  std::chrono::milliseconds const _delayThreshold;
 
   /// @brief protects _lastSyncTime and _lastSequenceNumber
   arangodb::basics::ConditionVariable _condition;

--- a/arangod/RocksDBEngine/RocksDBV8Functions.cpp
+++ b/arangod/RocksDBEngine/RocksDBV8Functions.cpp
@@ -53,7 +53,6 @@ static void JS_FlushWal(v8::FunctionCallbackInfo<v8::Value> const& args) {
 
   bool waitForSync = false;
   bool waitForCollector = false;
-  bool writeShutdownFile = false;
 
   if (args.Length() > 0) {
     if (args[0]->IsObject()) {
@@ -69,25 +68,16 @@ static void JS_FlushWal(v8::FunctionCallbackInfo<v8::Value> const& args) {
             isolate,
             obj->Get(context, TRI_V8_ASCII_STRING(isolate, "waitForCollector")).FromMaybe(v8::Local<v8::Value>()));
       }
-      if (TRI_HasProperty(context, isolate, obj, "writeShutdownFile")) {
-        writeShutdownFile = TRI_ObjectToBoolean(
-            isolate,
-            obj->Get(context, TRI_V8_ASCII_STRING(isolate, "writeShutdownFile")).FromMaybe(v8::Local<v8::Value>()));
-      }
     } else {
       waitForSync = TRI_ObjectToBoolean(isolate, args[0]);
 
       if (args.Length() > 1) {
         waitForCollector = TRI_ObjectToBoolean(isolate, args[1]);
-
-        if (args.Length() > 2) {
-          writeShutdownFile = TRI_ObjectToBoolean(isolate, args[2]);
-        }
       }
     }
   }
 
-  EngineSelectorFeature::ENGINE->flushWal(waitForSync, waitForCollector, writeShutdownFile);
+  EngineSelectorFeature::ENGINE->flushWal(waitForSync, waitForCollector);
   TRI_V8_RETURN_TRUE();
   TRI_V8_TRY_CATCH_END
 }

--- a/arangod/RocksDBEngine/RocksDBWalAccess.cpp
+++ b/arangod/RocksDBEngine/RocksDBWalAccess.cpp
@@ -65,7 +65,7 @@ Result RocksDBWalAccess::tickRange(std::pair<TRI_voc_tick_t, TRI_voc_tick_t>& mi
 ///  }}
 ///
 TRI_voc_tick_t RocksDBWalAccess::lastTick() const {
-  rocksutils::globalRocksEngine()->flushWal(false, false, false);
+  rocksutils::globalRocksEngine()->flushWal(false, false);
   return rocksutils::globalRocksDB()->GetLatestSequenceNumber();
 }
 

--- a/arangod/Statistics/ConnectionStatistics.cpp
+++ b/arangod/Statistics/ConnectionStatistics.cpp
@@ -79,6 +79,8 @@ void ConnectionStatistics::getSnapshot(Snapshot& snapshot) {
 
   snapshot.httpConnections = statistics::HttpConnections;
   snapshot.totalRequests = statistics::TotalRequests;
+  snapshot.totalRequestsSuperuser = statistics::TotalRequestsSuperuser;
+  snapshot.totalRequestsUser = statistics::TotalRequestsUser;
   snapshot.methodRequests = statistics::MethodRequests;
   snapshot.asyncRequests = statistics::AsyncRequests;
   snapshot.connectionTime = statistics::ConnectionTimeDistribution;

--- a/arangod/Statistics/ConnectionStatistics.h
+++ b/arangod/Statistics/ConnectionStatistics.h
@@ -78,6 +78,8 @@ class ConnectionStatistics {
   struct Snapshot {
     statistics::Counter httpConnections;
     statistics::Counter totalRequests;
+    statistics::Counter totalRequestsSuperuser;
+    statistics::Counter totalRequestsUser;
     statistics::MethodRequestCounters methodRequests;
     statistics::Counter asyncRequests;
     statistics::Distribution connectionTime;

--- a/arangod/Statistics/Descriptions.cpp
+++ b/arangod/Statistics/Descriptions.cpp
@@ -318,6 +318,22 @@ stats::Descriptions::Descriptions(application_features::ApplicationServer& serve
                                stats::FigureType::Accumulated,
                                stats::Unit::Number,
                                {}});
+  
+  _figures.emplace_back(Figure{stats::GroupType::Http,
+                               "requestsSuperuser",
+                               "Total superuser requests",
+                               "Total number of HTTP requests executed by superuser/JWT.",
+                               stats::FigureType::Accumulated,
+                               stats::Unit::Number,
+                               {}});
+  
+  _figures.emplace_back(Figure{stats::GroupType::Http,
+                               "requestsUser",
+                               "Total user requests",
+                               "Total number of HTTP requests executed by clients.",
+                               stats::FigureType::Accumulated,
+                               stats::Unit::Number,
+                               {}});
 
   _figures.emplace_back(
       Figure{stats::GroupType::Http,
@@ -501,6 +517,8 @@ void stats::Descriptions::httpStatistics(velocypack::Builder& b) const {
 
   // request counters
   b.add("requestsTotal", VPackValue(stats.totalRequests.get()));
+  b.add("requestsSuperuser", VPackValue(stats.totalRequestsSuperuser.get()));
+  b.add("requestsUser", VPackValue(stats.totalRequestsUser.get()));
   b.add("requestsAsync", VPackValue(stats.asyncRequests.get()));
   b.add("requestsGet", VPackValue(stats.methodRequests[(int)rest::RequestType::GET].get()));
   b.add("requestsHead", VPackValue(stats.methodRequests[(int)rest::RequestType::HEAD].get()));

--- a/arangod/Statistics/RequestStatistics.cpp
+++ b/arangod/Statistics/RequestStatistics.cpp
@@ -124,9 +124,16 @@ void RequestStatistics::process(RequestStatistics* statistics) {
       } else {
         totalTime = statistics->_writeEnd - statistics->_readStart;
       }
+      
+      bool const isSuperuser = statistics->_superuser;
+      if (isSuperuser) {
+        statistics::TotalRequestsSuperuser.incCounter();
+      } else {
+        statistics::TotalRequestsUser.incCounter();
+      }
 
-      statistics::RequestFigures& figures = statistics->_superuser
-        ? statistics::GeneralRequestFigures
+      statistics::RequestFigures& figures = isSuperuser
+        ? statistics::SuperuserRequestFigures
         : statistics::UserRequestFigures;
 
       figures.totalTimeDistribution.addFigure(totalTime);
@@ -195,7 +202,7 @@ void RequestStatistics::getSnapshot(Snapshot& snapshot, stats::RequestStatistics
 
   statistics::RequestFigures& figures = source == stats::RequestStatisticsSource::USER
     ? statistics::UserRequestFigures
-    : statistics::GeneralRequestFigures;
+    : statistics::SuperuserRequestFigures;
 
   snapshot.totalTime = figures.totalTimeDistribution;
   snapshot.requestTime = figures.requestTimeDistribution;
@@ -205,6 +212,7 @@ void RequestStatistics::getSnapshot(Snapshot& snapshot, stats::RequestStatistics
   snapshot.bytesReceived = figures.bytesReceivedDistribution;
   
   if (source == stats::RequestStatisticsSource::ALL) {
+    TRI_ASSERT(&figures == &statistics::SuperuserRequestFigures);
     snapshot.totalTime.add(statistics::UserRequestFigures.totalTimeDistribution);
     snapshot.requestTime.add(statistics::UserRequestFigures.requestTimeDistribution);
     snapshot.queueTime.add(statistics::UserRequestFigures.queueTimeDistribution);

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -65,6 +65,8 @@ std::initializer_list<double> const RequestTimeDistributionCuts{0.01, 0.05, 0.1,
 Counter AsyncRequests;
 Counter HttpConnections;
 Counter TotalRequests;
+Counter TotalRequestsSuperuser;
+Counter TotalRequestsUser;
 MethodRequestCounters MethodRequests;
 Distribution ConnectionTimeDistribution(ConnectionTimeDistributionCuts);
 
@@ -74,10 +76,9 @@ RequestFigures::RequestFigures() :
   ioTimeDistribution(RequestTimeDistributionCuts),
   queueTimeDistribution(RequestTimeDistributionCuts),
   requestTimeDistribution(RequestTimeDistributionCuts),
-  totalTimeDistribution(RequestTimeDistributionCuts)
-{}
+  totalTimeDistribution(RequestTimeDistributionCuts) {}
 
-RequestFigures GeneralRequestFigures;
+RequestFigures SuperuserRequestFigures;
 RequestFigures UserRequestFigures;
 }  // namespace statistics
 }  // namespace arangodb

--- a/arangod/Statistics/StatisticsFeature.h
+++ b/arangod/Statistics/StatisticsFeature.h
@@ -46,6 +46,8 @@ extern std::initializer_list<double> const RequestTimeDistributionCuts;
 extern Counter AsyncRequests;
 extern Counter HttpConnections;
 extern Counter TotalRequests;
+extern Counter TotalRequestsSuperuser;
+extern Counter TotalRequestsUser;
 
 constexpr size_t MethodRequestsStatisticsSize =
     ((size_t)arangodb::rest::RequestType::ILLEGAL) + 1;
@@ -68,7 +70,7 @@ struct RequestFigures {
   Distribution requestTimeDistribution;
   Distribution totalTimeDistribution;
 };
-extern RequestFigures GeneralRequestFigures;
+extern RequestFigures SuperuserRequestFigures;
 extern RequestFigures UserRequestFigures;
 }  // namespace statistics
 

--- a/arangod/Statistics/StatisticsWorker.cpp
+++ b/arangod/Statistics/StatisticsWorker.cpp
@@ -909,6 +909,12 @@ std::map<std::string, std::vector<std::string>> statStrings{
   {"httpReqsTotal",
    {"arangodb_http_request_statistics_total_requests", "gauge",
     "Total number of HTTP requests"}},
+  {"httpReqsSuperuser",
+   {"arangodb_http_request_statistics_superuser_requests", "gauge",
+    "Total number of HTTP requests executed by superuser/JWT"}},
+  {"httpReqsUser",
+   {"arangodb_http_request_statistics_user_requests", "gauge",
+    "Total number of HTTP requests executed by clients"}},
   {"httpReqsAsync",
    {"arangodb_http_request_statistics_async_requests", "gauge",
     "Number of asynchronously executed HTTP requests"}},
@@ -1020,6 +1026,8 @@ void StatisticsWorker::generateRawStatistics(std::string& result, double const& 
   appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::PUT].get()), "httpReqsPut");
   appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::ILLEGAL].get()), "httpReqsOther");
   appendMetric(result, std::to_string(connectionStats.totalRequests.get()), "httpReqsTotal");
+  appendMetric(result, std::to_string(connectionStats.totalRequestsSuperuser.get()), "httpReqsSuperuser");
+  appendMetric(result, std::to_string(connectionStats.totalRequestsUser.get()), "httpReqsUser");
 
   V8DealerFeature::Statistics v8Counters{};
   if (_server.hasFeature<V8DealerFeature>()) {
@@ -1146,6 +1154,8 @@ void StatisticsWorker::generateRawStatistics(VPackBuilder& builder, double const
   using rest::RequestType;
   builder.add("http", VPackValue(VPackValueType::Object));
   builder.add("requestsTotal", VPackValue(connectionStats.totalRequests.get()));
+  builder.add("requestsSuperuser", VPackValue(connectionStats.totalRequestsSuperuser.get()));
+  builder.add("requestsUser", VPackValue(connectionStats.totalRequestsUser.get()));
   builder.add("requestsAsync", VPackValue(connectionStats.asyncRequests.get()));
   builder.add("requestsGet",
               VPackValue(connectionStats.methodRequests[(int)RequestType::GET].get()));

--- a/arangod/StorageEngine/StorageEngine.h
+++ b/arangod/StorageEngine/StorageEngine.h
@@ -167,8 +167,7 @@ class StorageEngine : public application_features::ApplicationFeature {
   /// @brief return a list of the currently open WAL files
   virtual std::vector<std::string> currentWalFiles() const = 0;
 
-  virtual Result flushWal(bool waitForSync = false, bool waitForCollector = false,
-                          bool writeShutdownFile = false) = 0;
+  virtual Result flushWal(bool waitForSync = false, bool waitForCollector = false) = 0;
 
   virtual void waitForEstimatorSync(std::chrono::milliseconds maxWaitTime) = 0;
 

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2337,9 +2337,14 @@ Future<Result> Methods::replicateOperations(
   // this operation to succeed, since the new leader is now responsible.
   // In case (2) we at least have to drop the follower such that it
   // resyncs and we can be sure that it is in sync again.
-  // Therefore, we drop the follower here (just in case), and refuse to
-  // return with a refusal error (note that we use the follower version,
-  // since we have lost leadership):
+  // We have some hint from the error message of the follower. If it is
+  // TRI_ERROR_CLUSTER_SHARD_LEADER_REFUSES_REPLICATION, we have reason
+  // to believe that the follower is now the new leader and we assume
+  // case (1).
+  // If the error is TRI_ERROR_CLUSTER_SHARD_FOLLOWER_REFUSES_OPERATION,
+  // we continue with the operation, since most likely, the follower was
+  // simply dropped in the meantime.
+  // In any case, we drop the follower here (just in case).
   auto cb = [=](std::vector<futures::Try<network::Response>>&& responses) -> Result {
 
     bool didRefuse = false;

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2386,6 +2386,11 @@ Future<Result> Methods::replicateOperations(
               << "synchronous replication: dropping follower "
               << deadFollower << " for shard " << collection->name()
               << " in database " << collection->vocbase().name();
+          LOG_TOPIC("a4c06", WARN, Logger::DEVEL)
+              << "synchronous replication: dropping follower "
+              << deadFollower << " for shard " << collection->name()
+              << " in database " << collection->vocbase().name()
+              << ": " << resp.combinedResult().errorMessage();
         } else {
           LOG_TOPIC("db473", ERR, Logger::REPLICATION)
               << "synchronous replication: could not drop follower "

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2385,8 +2385,7 @@ Future<Result> Methods::replicateOperations(
           LOG_TOPIC("12d8c", WARN, Logger::REPLICATION)
               << "synchronous replication: dropping follower "
               << deadFollower << " for shard " << collection->name()
-              << " in database " << collection->vocbase().name() 
-              << ": " << resp.combinedResult().errorMessage();
+              << " in database " << collection->vocbase().name();
         } else {
           LOG_TOPIC("db473", ERR, Logger::REPLICATION)
               << "synchronous replication: could not drop follower "

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -975,7 +975,7 @@ static double chooseTimeout(size_t count, size_t totalBytes) {
   // Really big documents need additional adjustment. Using total size
   // of all messages to handle worst case scenario of constrained resource
   // processing all
-  timeout += (totalBytes / 4096) * ReplicationTimeoutFeature::timeoutPer4k;
+  timeout += (totalBytes / 4096.0) * ReplicationTimeoutFeature::timeoutPer4k;
 
   if (timeout < ReplicationTimeoutFeature::lowerLimit) {
     return ReplicationTimeoutFeature::lowerLimit * ReplicationTimeoutFeature::timeoutFactor;
@@ -1003,6 +1003,7 @@ Future<OperationResult> transaction::Methods::insertLocal(std::string const& cna
     auto const& followerInfo = collection->followers();
     std::string theLeader = followerInfo->getLeader();
     if (theLeader.empty()) {
+      // This indicates that we believe to be the leader.
       if (!options.isSynchronousReplicationFrom.empty()) {
         return OperationResult(TRI_ERROR_CLUSTER_SHARD_LEADER_REFUSES_REPLICATION, options);
       }
@@ -2357,7 +2358,8 @@ Future<Result> Methods::replicateOperations(
           resp.response->header.metaByKey(StaticStrings::ErrorCodes, found);
           replicationWorked = !found;
         }
-        didRefuse = didRefuse || resp.response->statusCode() == fuerte::StatusNotAcceptable;
+        auto r = resp.combinedResult();
+        didRefuse = didRefuse || r.errorNumber() == TRI_ERROR_CLUSTER_SHARD_LEADER_REFUSES_REPLICATION;
       }
 
       if (!replicationWorked) {

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2364,7 +2364,16 @@ Future<Result> Methods::replicateOperations(
           replicationWorked = !found;
         }
         auto r = resp.combinedResult();
-        didRefuse = didRefuse || r.errorNumber() == TRI_ERROR_CLUSTER_SHARD_LEADER_REFUSES_REPLICATION;
+        bool followerRefused = (r.errorNumber() == TRI_ERROR_CLUSTER_SHARD_LEADER_REFUSES_REPLICATION);
+        didRefuse = didRefuse || followerRefused;
+
+        if (followerRefused) {
+          LOG_TOPIC("3032c", WARN, Logger::REPLICATION)
+              << "synchronous replication: follower "
+              << (*followerList)[i] << " for shard " << collection->name()
+              << " in database " << collection->vocbase().name() 
+              << " refused the operation: " << r.errorMessage();
+        }
       }
 
       if (!replicationWorked) {
@@ -2375,12 +2384,15 @@ Future<Result> Methods::replicateOperations(
           _state->removeKnownServer(deadFollower);
           LOG_TOPIC("12d8c", WARN, Logger::REPLICATION)
               << "synchronous replication: dropping follower "
-              << deadFollower << " for shard " << collection->name();
+              << deadFollower << " for shard " << collection->name()
+              << " in database " << collection->vocbase().name() 
+              << ": " << resp.combinedResult().errorMessage();
         } else {
           LOG_TOPIC("db473", ERR, Logger::REPLICATION)
               << "synchronous replication: could not drop follower "
-              << deadFollower << " for shard " << collection->name() << ": "
-              << res.errorMessage();
+              << deadFollower << " for shard " << collection->name() 
+              << " in database " << collection->vocbase().name() 
+              << ": " << res.errorMessage();
           THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_COULD_NOT_DROP_FOLLOWER);
         }
       }

--- a/arangod/V8Server/v8-replication.cpp
+++ b/arangod/V8Server/v8-replication.cpp
@@ -305,104 +305,6 @@ static void JS_SynchronizeGlobalReplication(v8::FunctionCallbackInfo<v8::Value> 
   SynchronizeReplication(args, APPLIER_GLOBAL);
 }
 
-/// @brief finalize the synchronization of a collection by tailing the WAL
-/// and filtering on the collection name until no more data is available
-static void JS_SynchronizeReplicationFinalize(v8::FunctionCallbackInfo<v8::Value> const& args) {
-  TRI_V8_TRY_CATCH_BEGIN(isolate);
-  v8::HandleScope scope(isolate);
-  auto context = TRI_IGETC;
-
-  if (args.Length() != 1 || !args[0]->IsObject()) {
-    TRI_V8_THROW_EXCEPTION_USAGE("syncCollectionFinalize(<configure>)");
-  }
-
-  // treat the argument as an object from now on
-  v8::Handle<v8::Object> object = v8::Handle<v8::Object>::Cast(args[0]);
-
-  VPackBuilder builder;
-  int res = TRI_V8ToVPack(isolate, builder, args[0], false);
-
-  if (res != TRI_ERROR_NO_ERROR) {
-    TRI_V8_THROW_EXCEPTION(res);
-  }
-
-  std::string database;
-  if (TRI_HasProperty(context, isolate, object, "database")) {
-    database = TRI_ObjectToString(
-        isolate,
-        object->Get(context, TRI_V8_ASCII_STRING(isolate, "database"))
-            .FromMaybe(v8::Local<v8::Value>()));
-  }
-  if (database.empty()) {
-    TRI_V8_THROW_EXCEPTION_PARAMETER(
-        "<database> must be a valid database name");
-  }
-
-  std::string collection;
-  if (TRI_HasProperty(context, isolate, object, "collection")) {
-    collection = TRI_ObjectToString(
-        isolate,
-        object->Get(context, TRI_V8_ASCII_STRING(isolate, "collection"))
-            .FromMaybe(v8::Local<v8::Value>()));
-  }
-  if (collection.empty()) {
-    TRI_V8_THROW_EXCEPTION_PARAMETER(
-        "<collection> must be a valid collection name");
-  }
-
-  TRI_voc_tick_t fromTick = 0;
-  if (TRI_HasProperty(context, isolate, object, "from")) {
-    fromTick = TRI_ObjectToUInt64(
-        isolate,
-        object->Get(context, TRI_V8_ASCII_STRING(isolate, "from")).FromMaybe(v8::Local<v8::Value>()),
-        true);
-  }
-  if (fromTick == 0) {
-    TRI_V8_THROW_EXCEPTION_PARAMETER("<from> must be a valid start tick");
-  }
-
-  TRI_GET_GLOBALS();
-  ReplicationApplierConfiguration configuration =
-      ReplicationApplierConfiguration::fromVelocyPack(v8g->_server, builder.slice(), database);
-  // will throw if invalid
-  configuration.validate();
-
-  DatabaseGuard guard(database);
-
-  DatabaseTailingSyncer syncer(guard.database(), configuration, fromTick, true, 0);
-
-  if (TRI_HasProperty(context, isolate, object, "leaderId")) {
-    syncer.setLeaderId(TRI_ObjectToString(
-        isolate,
-        object->Get(context, TRI_V8_ASCII_STRING(isolate, "leaderId"))
-            .FromMaybe(v8::Local<v8::Value>())));
-  }
-
-  v8::Handle<v8::Object> result = v8::Object::New(isolate);
-
-  Result r;
-  try {
-    r = syncer.syncCollectionFinalize(collection);
-  } catch (arangodb::basics::Exception const& ex) {
-    r = Result(ex.code(), ex.what());
-  } catch (std::exception const& ex) {
-    r = Result(TRI_ERROR_INTERNAL, ex.what());
-  } catch (...) {
-    r = Result(TRI_ERROR_INTERNAL, "unknown exception");
-  }
-
-  if (r.fail()) {
-    LOG_TOPIC("f5995", ERR, Logger::REPLICATION)
-        << "syncCollectionFinalize failed: " << r.errorMessage();
-    std::string errorMsg = std::string("cannot sync data for shard '") + collection +
-                           "' from remote endpoint: " + r.errorMessage();
-    TRI_V8_THROW_EXCEPTION_MESSAGE(r.errorNumber(), errorMsg);
-  }
-
-  TRI_V8_RETURN(result);
-  TRI_V8_TRY_CATCH_END
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief return the server's id
 ////////////////////////////////////////////////////////////////////////////////
@@ -778,9 +680,6 @@ void TRI_InitV8Replication(v8::Isolate* isolate, v8::Handle<v8::Context> context
   TRI_AddGlobalFunctionVocbase(
       isolate, TRI_V8_ASCII_STRING(isolate, "GLOBAL_REPLICATION_SYNCHRONIZE"),
       JS_SynchronizeGlobalReplication, true);
-  TRI_AddGlobalFunctionVocbase(
-      isolate, TRI_V8_ASCII_STRING(isolate, "REPLICATION_SYNCHRONIZE_FINALIZE"),
-      JS_SynchronizeReplicationFinalize, true);
   TRI_AddGlobalFunctionVocbase(isolate,
                                TRI_V8_ASCII_STRING(isolate,
                                                    "REPLICATION_SERVER_ID"),

--- a/arangod/V8Server/v8-statistics.cpp
+++ b/arangod/V8Server/v8-statistics.cpp
@@ -257,6 +257,10 @@ static void JS_HttpStatistics(v8::FunctionCallbackInfo<v8::Value> const& args) {
   // request counters
   result->Set(context, TRI_V8_ASCII_STRING(isolate, "requestsTotal"),
               v8::Number::New(isolate, (double)stats.totalRequests.get())).FromMaybe(false);
+  result->Set(context, TRI_V8_ASCII_STRING(isolate, "requestsSuperuser"),
+              v8::Number::New(isolate, (double)stats.totalRequestsSuperuser.get())).FromMaybe(false);
+  result->Set(context, TRI_V8_ASCII_STRING(isolate, "requestsUser"),
+              v8::Number::New(isolate, (double)stats.totalRequestsUser.get())).FromMaybe(false);
   result->Set(context, TRI_V8_ASCII_STRING(isolate, "requestsAsync"),
               v8::Number::New(isolate, (double)stats.asyncRequests.get())).FromMaybe(false);
   result->Set(context, TRI_V8_ASCII_STRING(isolate, "requestsGet"),

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/models/arangoCollectionModel.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/models/arangoCollectionModel.js
@@ -31,6 +31,21 @@
         }
       });
     },
+    getShards: function (callback) {
+      $.ajax({
+        type: 'GET',
+        cache: false,
+        url: arangoHelper.databaseUrl('/_api/collection/' + this.get('id') + '/shards?details=true'),
+        contentType: 'application/json',
+        processData: false,
+        success: function (data) {
+          callback(false, data);
+        },
+        error: function () {
+          callback(true);
+        }
+      });
+    },
     getFigures: function (callback) {
       $.ajax({
         type: 'GET',
@@ -45,6 +60,28 @@
           callback(true);
         }
       });
+    },
+    getFiguresCombined: function (callback, isCluster) {
+      var self = this;
+      var shardsCallback = function (error, data) {
+        if (error) {
+          callback(true);
+        } else {
+          var figures = data;
+          if (isCluster) {
+            self.getShards(function (error, data) {
+              if (error) {
+                callback(true);
+              } else {
+                callback(false, Object.assign(figures, { shards: data.shards }));
+              }
+            });
+          } else {
+            callback(false, figures);
+          }
+        }
+      };
+      this.getFigures(shardsCallback);
     },
     getRevision: function (callback, figures) {
       $.ajax({

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/templates/modalCollectionInfo.ejs
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/templates/modalCollectionInfo.ejs
@@ -72,6 +72,25 @@
             </tr>
           <% } %>
           
+          <% if (figuresData.shards) { %>
+            <tr>
+              <th class="collectionInfoTh2">Shards:</th>
+              <th class="collectionInfoTh">
+                <div class="modal-text">
+                <% var allShards = Object.keys(figuresData.shards); 
+                   allShards.forEach(function(shardName, index) {
+                %>
+                <%=(index > 0 ? '<br />' : '')%>
+                <%=shardName%>: [ <%=figuresData.shards[shardName].join('  -  ') %> ] 
+                
+                <%});%>
+                </div>
+              </th>
+              <th class="collectionInfoTh">
+              </th>
+            </tr>
+          <% } %>
+          
           <% if (figuresData.replicationFactor) { %>
             <tr>
               <th class="collectionInfoTh2">Replication factor:</th>

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/infoView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/infoView.js
@@ -65,6 +65,7 @@
             revision: revision,
             model: this.model
           };
+
           window.modalView.show(
             'modalCollectionInfo.ejs',
             'Collection: ' + (this.model.get('name').length > 64 ? this.model.get('name').substr(0, 64) + "..." : this.model.get('name')),
@@ -85,7 +86,7 @@
         }
       }.bind(this);
 
-      this.model.getFigures(callback);
+      this.model.getFiguresCombined(callback, frontendConfig.isCluster);
     }
 
   });

--- a/js/server/modules/@arangodb/cluster.js
+++ b/js/server/modules/@arangodb/cluster.js
@@ -1,4 +1,4 @@
-/* global ArangoServerState, ArangoClusterInfo, REPLICATION_SYNCHRONIZE_FINALIZE */
+/* global ArangoServerState, ArangoClusterInfo */
 'use strict';
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/tests/Mocks/StorageEngineMock.cpp
+++ b/tests/Mocks/StorageEngineMock.cpp
@@ -1732,8 +1732,7 @@ std::vector<std::string> StorageEngineMock::currentWalFiles() const {
   return std::vector<std::string>();
 }
 
-arangodb::Result StorageEngineMock::flushWal(bool waitForSync, bool waitForCollector,
-                                             bool writeShutdownFile) {
+arangodb::Result StorageEngineMock::flushWal(bool waitForSync, bool waitForCollector) {
   TRI_ASSERT(false);
   return arangodb::Result();
 }

--- a/tests/Mocks/StorageEngineMock.h
+++ b/tests/Mocks/StorageEngineMock.h
@@ -218,8 +218,7 @@ class StorageEngineMock : public arangodb::StorageEngine {
                                     arangodb::LogicalView const& view) override;
   virtual arangodb::Result firstTick(uint64_t&) override;
   virtual std::vector<std::string> currentWalFiles() const override;
-  virtual arangodb::Result flushWal(bool waitForSync, bool waitForCollector,
-                                    bool writeShutdownFile) override;
+  virtual arangodb::Result flushWal(bool waitForSync, bool waitForCollector) override;
   virtual void getCollectionInfo(TRI_vocbase_t& vocbase, TRI_voc_cid_t cid,
                                  arangodb::velocypack::Builder& result,
                                  bool includeIndexes, TRI_voc_tick_t maxTick) override;


### PR DESCRIPTION
### Scope & Purpose

This PR improves observability in the following ways:

* Add database, shard name and error information to several shard-related log messages.
* Display shard names of a collection in the web interface when in the details view of the collection.
* Added HTTP requests metrics for tracking the number of superuser and normal user requests separately:
  - `arangodb_http_request_statistics_superuser_requests`: Total number of HTTP requests executed by superuser/JWT
  - `arangodb_http_request_statistics_user_requests`: Total number of HTTP requests executed by clients

This PR also contains all commits from https://github.com/arangodb/arangodb/pull/12753, which will make no difference when this gets merged into 3.7.

- [ ] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x]:muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12088/