### PR TITLE
Bug fix/cleanup 20201003

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Added metrics `arangodb_agency_callback_registered counter` for tracking the
+  total number of agency callbacks that were registered.
+
 * Fixed a bug in handling of followers which refuse to replicate operations.
   In the case that the follower has simply been dropped in the meantime, we now
   avoid an error reported by the shard leader.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 devel
 -----
 
-* Added metrics `arangodb_agency_callback_registered counter` for tracking the
+* Added metric `arangodb_agency_callback_registered counter` for tracking the
   total number of agency callbacks that were registered.
 
 * Fixed a bug in handling of followers which refuse to replicate operations.

--- a/arangod/Agency/Constituent.cpp
+++ b/arangod/Agency/Constituent.cpp
@@ -490,7 +490,7 @@ void Constituent::callElection() {
             maxTermReceived->compare_exchange_strong(expectedT, receivedT);
           } else {
             // Check result and counts
-            if (slc.get("voteGranted").getBool()) {  // majority in favour?
+            if (slc.get("voteGranted").getBool()) {  // majority in favor?
               yea->fetch_add(1);
               // Vote is counted as yea
               return;

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -498,7 +498,7 @@ SharedAqlItemBlockPtr ExecutionBlockImpl<Executor>::requestBlock(size_t nrItems,
 //           it produced any output.
 //           With the new architecture we should be able to just skip
 //           ahead on the input range, fetching new blocks when necessary
-// EXECUTOR: the executor has a specialised skipRowsRange method
+// EXECUTOR: the executor has a specialized skipRowsRange method
 //           that will be called to skip
 // SUBQUERY_START:
 // SUBQUERY_END:

--- a/arangod/Cluster/AgencyCallback.cpp
+++ b/arangod/Cluster/AgencyCallback.cpp
@@ -26,6 +26,8 @@
 #include <chrono>
 #include <thread>
 
+#include <velocypack/Builder.h>
+#include <velocypack/Slice.h>
 #include <velocypack/velocypack-aliases.h>
 
 #include "Basics/ConditionLocker.h"
@@ -131,11 +133,13 @@ void AgencyCallback::refetchAndUpdate(bool needToAcquireMutex, bool forceCheck) 
 void AgencyCallback::checkValue(std::shared_ptr<VPackBuilder> newData, bool forceCheck) {
   // Only called from refetchAndUpdate, we always have the mutex when
   // we get here!
-  if (!_lastData || !arangodb::basics::VelocyPackHelper::equal(_lastData->slice(), newData->slice(), false) || forceCheck) {
+  if (!_lastData || 
+      forceCheck || 
+      !arangodb::basics::VelocyPackHelper::equal(_lastData->slice(), newData->slice(), false)) {
     LOG_TOPIC("2bd14", DEBUG, Logger::CLUSTER)
         << "AgencyCallback: Got new value " << newData->slice().typeName()
         << " " << newData->toJson() << " forceCheck=" << forceCheck;
-    if (execute(newData)) {
+    if (execute(newData->slice())) {
       _lastData = newData;
     } else {
       LOG_TOPIC("337dc", DEBUG, Logger::CLUSTER)
@@ -147,25 +151,24 @@ void AgencyCallback::checkValue(std::shared_ptr<VPackBuilder> newData, bool forc
 bool AgencyCallback::executeEmpty() {
   // only called from refetchAndUpdate, we always have the mutex when
   // we get here!
-  LOG_TOPIC("96022", DEBUG, Logger::CLUSTER) << "Executing (empty)";
-  bool result = _cb(VPackSlice::noneSlice());
-  if (result) {
-    _wasSignaled = true;
-    _cv.signal();
-  }
-  return result;
+  return execute(VPackSlice::noneSlice());
 }
 
-bool AgencyCallback::execute(std::shared_ptr<VPackBuilder> newData) {
+bool AgencyCallback::execute(velocypack::Slice newData) {
   // only called from refetchAndUpdate, we always have the mutex when
   // we get here!
-  LOG_TOPIC("add4e", DEBUG, Logger::CLUSTER) << "Executing";
-  bool result = _cb(newData->slice());
-  if (result) {
-    _wasSignaled = true;
-    _cv.signal();
+  LOG_TOPIC("add4e", DEBUG, Logger::CLUSTER) << "Executing" << (newData.isNone() ? " (empty)" : "");
+  try {
+    bool result = _cb(newData);
+    if (result) {
+      _wasSignaled = true;
+      _cv.signal();
+    }
+    return result;
+  } catch (std::exception const& ex) {
+    LOG_TOPIC("1de99", WARN, Logger::CLUSTER) << "AgencyCallback execution failed: " << ex.what();
+    throw;
   }
-  return result;
 }
 
 bool AgencyCallback::executeByCallbackOrTimeout(double maxTimeout) {

--- a/arangod/Cluster/AgencyCallback.h
+++ b/arangod/Cluster/AgencyCallback.h
@@ -26,15 +26,20 @@
 
 #include "Basics/Common.h"
 
-#include <velocypack/Builder.h>
 #include <functional>
 #include <memory>
 
-#include "Agency/AgencyComm.h"
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/ConditionVariable.h"
 
 namespace arangodb {
+class AgencyComm;
+
+namespace velocypack {
+class Builder;
+class Slice;
+}
+
 namespace application_features {
 class ApplicationServer;
 }
@@ -127,10 +132,16 @@ class AgencyCallback {
   void local(bool b);
   bool local() const;
   
+ private:
+  // execute callback with current value data:
+  bool execute(velocypack::Slice data);
+  
+  // execute callback without any data:
+  bool executeEmpty();
 
-  //////////////////////////////////////////////////////////////////////////////
-  /// @brief private members
-  //////////////////////////////////////////////////////////////////////////////
+  // Compare last value and newly read one and call execute if the are
+  // different:
+  void checkValue(std::shared_ptr<velocypack::Builder>, bool forceCheck);
 
  private:
   application_features::ApplicationServer& _server;
@@ -150,15 +161,6 @@ class AgencyCallback {
 
   /// Determined when registered in registery. Default: true 
   bool _local;
-
-  // execute callback with current value data:
-  bool execute(std::shared_ptr<velocypack::Builder>);
-  // execute callback without any data:
-  bool executeEmpty();
-
-  // Compare last value and newly read one and call execute if the are
-  // different:
-  void checkValue(std::shared_ptr<velocypack::Builder>, bool forceCheck);
 };
 
 }  // namespace arangodb

--- a/arangod/Cluster/AgencyCallbackRegistry.cpp
+++ b/arangod/Cluster/AgencyCallbackRegistry.cpp
@@ -23,8 +23,6 @@
 
 #include "AgencyCallbackRegistry.h"
 
-#include <ctime>
-
 #include <velocypack/Slice.h>
 #include <velocypack/velocypack-aliases.h>
 
@@ -33,36 +31,40 @@
 #include "Basics/ReadLocker.h"
 #include "Basics/WriteLocker.h"
 #include "Cluster/AgencyCache.h"
+#include "Cluster/AgencyCallback.h"
 #include "Cluster/ServerState.h"
 #include "Endpoint/Endpoint.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
 #include "Random/RandomGenerator.h"
+#include "RestServer/MetricsFeature.h"
 
 using namespace arangodb;
 
 AgencyCallbackRegistry::AgencyCallbackRegistry(application_features::ApplicationServer& server,
                                                std::string const& callbackBasePath)
-  : _agency(server), _callbackBasePath(callbackBasePath) {}
+  : _agency(server), 
+    _callbackBasePath(callbackBasePath),
+    _totalCallbacksRegistered(
+        server.getFeature<arangodb::MetricsFeature>().counter(
+          "arangodb_agency_callback_registered", 0, "Total number of agency callbacks registered")) {}
 
 AgencyCallbackRegistry::~AgencyCallbackRegistry() = default;
 
 bool AgencyCallbackRegistry::registerCallback(std::shared_ptr<AgencyCallback> cb, bool local) {
   uint64_t rand;
-  {
+  while (true) {
+    rand = RandomGenerator::interval(std::numeric_limits<uint64_t>::max());
+
     WRITE_LOCKER(locker, _lock);
-    while (true) {
-      rand = RandomGenerator::interval(std::numeric_limits<uint64_t>::max());
-      if (_endpoints.try_emplace(rand, cb).second) {
-        break;
-      }
+    if (_endpoints.try_emplace(rand, cb).second) {
+      break;
     }
   }
 
-  
-  bool ok = false;
   try {
+    bool ok = false;
     if (local) {
       auto& cache = _agency.server().getFeature<ClusterFeature>().agencyCache();
       ok = cache.registerCallback(cb->key, rand);
@@ -70,20 +72,21 @@ bool AgencyCallbackRegistry::registerCallback(std::shared_ptr<AgencyCallback> cb
       ok = _agency.registerCallback(cb->key, getEndpointUrl(rand)).successful();
       cb->local(false);
     }
-    if (!ok) {
-      LOG_TOPIC("b88f4", ERR, Logger::CLUSTER) << "Registering callback failed";
+    if (ok) {
+      ++_totalCallbacksRegistered;
+      return true;
     }
+    LOG_TOPIC("b88f4", ERR, Logger::CLUSTER) << "Registering callback failed";
   } catch (std::exception const& e) {
-    LOG_TOPIC("f5330", ERR, Logger::CLUSTER) << "Couldn't register callback " << e.what();
+    LOG_TOPIC("f5330", ERR, Logger::CLUSTER) << "Couldn't register callback: " << e.what();
   } catch (...) {
     LOG_TOPIC("1d24f", ERR, Logger::CLUSTER)
-        << "Couldn't register callback. Unknown exception";
+        << "Couldn't register callback: unknown exception";
   }
-  if (!ok) {
-    WRITE_LOCKER(locker, _lock);
-    _endpoints.erase(rand);
-  }
-  return ok;
+    
+  WRITE_LOCKER(locker, _lock);
+  _endpoints.erase(rand);
+  return false;
 }
 
 std::shared_ptr<AgencyCallback> AgencyCallbackRegistry::getCallback(uint64_t id) {

--- a/arangod/Cluster/AgencyCallbackRegistry.h
+++ b/arangod/Cluster/AgencyCallbackRegistry.h
@@ -24,10 +24,15 @@
 #ifndef CLUSTER_AGENCY_CALLBACK_REGISTRY_H
 #define CLUSTER_AGENCY_CALLBACK_REGISTRY_H 1
 
+#include "Agency/AgencyComm.h"
 #include "Basics/ReadWriteLock.h"
-#include "Cluster/AgencyCallback.h"
+#include "RestServer/Metrics.h"
+
+#include <memory>
 
 namespace arangodb {
+class AgencyCallback;
+
 namespace application_features {
 class ApplicationServer;
 }
@@ -35,7 +40,7 @@ class ApplicationServer;
 class AgencyCallbackRegistry {
  public:
   explicit AgencyCallbackRegistry(application_features::ApplicationServer&,
-                                  std::string const&);
+                                  std::string const& callbackBasePath);
 
   ~AgencyCallbackRegistry();
 
@@ -58,6 +63,8 @@ class AgencyCallbackRegistry {
   std::string const _callbackBasePath;
 
   std::unordered_map<uint64_t, std::shared_ptr<AgencyCallback>> _endpoints;
+  
+  Counter& _totalCallbacksRegistered;
 };
 
 }  // namespace arangodb

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -41,6 +41,7 @@
 #include "Basics/StaticStrings.h"
 #include "Basics/Thread.h"
 #include "Basics/VelocyPackHelper.h"
+#include "Cluster/AgencyCallback.h"
 #include "Cluster/AgencyCallbackRegistry.h"
 #include "Cluster/ClusterTypes.h"
 #include "Cluster/RebootTracker.h"
@@ -91,10 +92,10 @@ class CollectionWatcher {
     // Make sure we did not miss a callback
     _agencyCallback->refetchAndUpdate(true, false);
     return _present.load();
-  };
+  }
 
-private:
-  AgencyCallbackRegistry *_agencyCallbackRegistry;
+ private:
+  AgencyCallbackRegistry* _agencyCallbackRegistry;
   std::shared_ptr<AgencyCallback> _agencyCallback;
 
   // TODO: this does not really need to be atomic: We only write to it

--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -109,7 +109,7 @@ class FollowerInfo {
   ///        before a failover to this server has happened
   ///        The second parameter may be nullptr. It is an additional list
   ///        of declared to be insync followers. If it is nullptr the follower
-  ///        list is initialised empty.
+  ///        list is initialized empty.
   ////////////////////////////////////////////////////////////////////////////////
 
   void takeOverLeadership(std::vector<ServerID> const& previousInsyncFollowers,

--- a/arangod/Cluster/MaintenanceFeature.cpp
+++ b/arangod/Cluster/MaintenanceFeature.cpp
@@ -267,7 +267,7 @@ void MaintenanceFeature::start() {
 void MaintenanceFeature::beginShutdown() {
   if (_resignLeadershipOnShutdown && ServerState::instance()->isDBServer()) {
     struct callback_data {
-      uint64_t _jobId;  // initialised before callback
+      uint64_t _jobId;  // initialized before callback
       bool _completed;  // populated by the callback
       std::mutex _mutex;  // mutex used by callback and loop to sync access to callback_data
       std::condition_variable _cv;  // signaled if callback has found something

--- a/arangod/Cluster/RestAgencyCallbacksHandler.cpp
+++ b/arangod/Cluster/RestAgencyCallbacksHandler.cpp
@@ -23,6 +23,7 @@
 
 #include "RestAgencyCallbacksHandler.h"
 
+#include "Cluster/AgencyCallback.h"
 #include "Cluster/AgencyCallbackRegistry.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
@@ -65,8 +66,8 @@ RestStatus RestAgencyCallbacksHandler::execute() {
 
   uint64_t index = basics::StringUtils::uint64(suffixes.at(0));
   auto cb = _agencyCallbackRegistry->getCallback(index);
-  if (cb.get() == nullptr) {
-    // no entry by this id!
+  if (cb == nullptr) {
+    // no entry for this id!
     resetResponse(arangodb::rest::ResponseCode::NOT_FOUND);
   } else {
     LOG_TOPIC("76a8a", DEBUG, Logger::CLUSTER)
@@ -75,7 +76,7 @@ RestStatus RestAgencyCallbacksHandler::execute() {
     try {
       cb->refetchAndUpdate(true, false);
     } catch (arangodb::basics::Exception const& e) {
-      LOG_TOPIC("c3910", WARN, Logger::AGENCYCOMM) << "Error executing callback: " << e.message();
+      LOG_TOPIC("c3910", WARN, Logger::CLUSTER) << "Error executing callback: " << e.message();
     }
     resetResponse(arangodb::rest::ResponseCode::ACCEPTED);
   }

--- a/arangod/Graph/KShortestPathsFinder.h
+++ b/arangod/Graph/KShortestPathsFinder.h
@@ -222,7 +222,7 @@ class KShortestPathsFinder : public ShortestPathFinder {
 
   // reset the traverser; this is mainly needed because the traverser is
   // part of the KShortestPathsExecutorInfos, and hence not recreated when
-  // a cursor is initialised.
+  // a cursor is initialized.
   void clear() override;
 
   // This is here because we inherit from ShortestPathFinder (to get the destroyEngines function)
@@ -234,7 +234,7 @@ class KShortestPathsFinder : public ShortestPathFinder {
     return false;
   }
 
-  // initialise k Shortest Paths
+  // initialize k Shortest Paths
   TEST_VIRTUAL bool startKShortestPathsTraversal(arangodb::velocypack::Slice const& start,
                                                  arangodb::velocypack::Slice const& end);
 

--- a/arangod/IResearch/IResearchView.cpp
+++ b/arangod/IResearch/IResearchView.cpp
@@ -1017,7 +1017,7 @@ arangodb::Result IResearchView::updateProperties(arangodb::velocypack::Slice con
               TRI_ERROR_FORBIDDEN,
               std::string("while updating arangosearch definition, error: "
                           "collection '") +
-                  collection->name() + "' not authorised for read access");
+                  collection->name() + "' not authorized for read access");
         }
       }
     }


### PR DESCRIPTION
### Scope & Purpose

* Slightly improve parallelism for creating agency callbacks, by not creating the pseudorandom callback ids under the lock.
* Avoid unnecessary comparisons in AgencyCallback::checkValue(...).
* Added metric `arangodb_agency_callback_registered counter` for tracking the total number of agency callbacks that were registered.
* BE -> AE

- [ ] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [x] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12089/