### PR TITLE
improvements for observability

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,20 @@
 devel
 -----
 
+* Add database, shard name and error information to several shard-related log 
+  messages.
+
+* Display shard names of a collection in the web interface when in the details
+  view of the collection.
+
+* Added HTTP requests metrics for tracking the number of superuser and normal
+  user requests separately:
+
+  - `arangodb_http_request_statistics_superuser_requests`: Total number of HTTP
+    requests executed by superuser/JWT
+  - `arangodb_http_request_statistics_user_requests`: Total number of HTTP 
+    requests executed by clients
+
 * Fixed a bug in handling of followers which refuse to replicate operations.
   In the case that the follower has simply been dropped in the meantime, we now
   avoid an error reported by the shard leader.

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -520,7 +520,8 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
   SyncerId syncerId{syncer->syncerId()};
 
   try {
-    Result r = syncer->run(configuration._incremental);
+    std::string const context = "synchronization of shard " + shard + " in database " + database;
+    Result r = syncer->run(configuration._incremental, context.c_str());
 
     if (r.fail()) {
       LOG_TOPIC("3efff", DEBUG, Logger::REPLICATION)

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -359,7 +359,8 @@ DatabaseInitialSyncer::DatabaseInitialSyncer(TRI_vocbase_t& vocbase,
 }
 
 /// @brief run method, performs a full synchronization
-Result DatabaseInitialSyncer::runWithInventory(bool incremental, VPackSlice dbInventory) {
+Result DatabaseInitialSyncer::runWithInventory(bool incremental, VPackSlice dbInventory,
+                                               char const* context) {
   if (!_config.connection.valid()) {
     return Result(TRI_ERROR_INTERNAL, "invalid endpoint");
   }
@@ -379,7 +380,7 @@ Result DatabaseInitialSyncer::runWithInventory(bool incremental, VPackSlice dbIn
 
     Result r;
     if (!_config.isChild()) {
-      r = _config.leader.getState(_config.connection, _config.isChild());
+      r = _config.leader.getState(_config.connection, _config.isChild(), context);
 
       if (r.fail()) {
         return r;

--- a/arangod/Replication/DatabaseInitialSyncer.h
+++ b/arangod/Replication/DatabaseInitialSyncer.h
@@ -90,13 +90,13 @@ class DatabaseInitialSyncer final : public InitialSyncer {
                         ReplicationApplierConfiguration const& configuration);
 
   /// @brief run method, performs a full synchronization
-  Result run(bool incremental) override {
-    return runWithInventory(incremental, velocypack::Slice::noneSlice());
+  Result run(bool incremental, char const* context = nullptr) override {
+    return runWithInventory(incremental, velocypack::Slice::noneSlice(), context);
   }
 
   /// @brief run method, performs a full synchronization with the
   ///        given list of collections.
-  Result runWithInventory(bool incremental, velocypack::Slice collections);
+  Result runWithInventory(bool incremental, velocypack::Slice collections, char const* context = nullptr);
 
   TRI_vocbase_t* resolveVocbase(velocypack::Slice const& slice) override {
     return &_config.vocbase;

--- a/arangod/Replication/DatabaseTailingSyncer.cpp
+++ b/arangod/Replication/DatabaseTailingSyncer.cpp
@@ -92,7 +92,7 @@ Result DatabaseTailingSyncer::syncCollectionCatchupInternal(std::string const& c
 
   setAborted(false);
   // fetch leader state just once
-  Result r = _state.leader.getState(_state.connection, _state.isChildSyncer);
+  Result r = _state.leader.getState(_state.connection, _state.isChildSyncer, nullptr);
   if (r.fail()) {
     return r;
   }

--- a/arangod/Replication/GlobalInitialSyncer.cpp
+++ b/arangod/Replication/GlobalInitialSyncer.cpp
@@ -66,9 +66,9 @@ GlobalInitialSyncer::~GlobalInitialSyncer() {
 
 /// @brief run method, performs a full synchronization
 /// public method, catches exceptions
-Result GlobalInitialSyncer::run(bool incremental) {
+Result GlobalInitialSyncer::run(bool incremental, char const* context) {
   try {
-    return runInternal(incremental);
+    return runInternal(incremental, context);
   } catch (arangodb::basics::Exception const& ex) {
     return Result(ex.code(),
                   std::string("initial synchronization for database '") +
@@ -86,7 +86,7 @@ Result GlobalInitialSyncer::run(bool incremental) {
 
 /// @brief run method, performs a full synchronization
 /// internal method, may throw exceptions
-Result GlobalInitialSyncer::runInternal(bool incremental) {
+Result GlobalInitialSyncer::runInternal(bool incremental, char const* context) {
   if (!_state.connection.valid()) {
     return Result(TRI_ERROR_INTERNAL, "invalid endpoint");
   } else if (_state.applier._server.isStopping()) {
@@ -96,7 +96,7 @@ Result GlobalInitialSyncer::runInternal(bool incremental) {
   setAborted(false);
 
   LOG_TOPIC("23d92", DEBUG, Logger::REPLICATION) << "client: getting leader state";
-  Result r = _state.leader.getState(_state.connection, _state.isChildSyncer);
+  Result r = _state.leader.getState(_state.connection, _state.isChildSyncer, context);
   if (r.fail()) {
     return r;
   }

--- a/arangod/Replication/GlobalInitialSyncer.h
+++ b/arangod/Replication/GlobalInitialSyncer.h
@@ -38,7 +38,7 @@ class GlobalInitialSyncer final : public InitialSyncer {
  public:
   /// @brief run method, performs a full synchronization
   /// public method, catches exceptions
-  arangodb::Result run(bool incremental) override;
+  arangodb::Result run(bool incremental, char const* context = nullptr) override;
 
   /// @brief fetch the server's inventory, public method
   Result getInventory(arangodb::velocypack::Builder& builder);
@@ -46,7 +46,7 @@ class GlobalInitialSyncer final : public InitialSyncer {
  private:
   /// @brief run method, performs a full synchronization
   /// internal method, may throw exceptions
-  arangodb::Result runInternal(bool incremental);
+  arangodb::Result runInternal(bool incremental, char const* context);
 
   /// @brief check whether the initial synchronization should be aborted
   bool checkAborted();

--- a/arangod/Replication/InitialSyncer.h
+++ b/arangod/Replication/InitialSyncer.h
@@ -45,7 +45,7 @@ class InitialSyncer : public Syncer {
   ~InitialSyncer();
 
  public:
-  virtual Result run(bool incremental) = 0;
+  virtual Result run(bool incremental, char const* context = nullptr) = 0;
 
   /// @brief return the last log tick of the leader at start
   TRI_voc_tick_t getLastLogTick() const { return _state.leader.lastLogTick; }

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -1265,7 +1265,7 @@ retry:
 
   while (true) {
     setProgress("fetching leader state information");
-    res = _state.leader.getState(_state.connection, _state.isChildSyncer);
+    res = _state.leader.getState(_state.connection, _state.isChildSyncer, nullptr);
 
     if (res.is(TRI_ERROR_REPLICATION_NO_RESPONSE)) {
       // leader error. try again after a sleep period

--- a/arangod/Replication/utilities.h
+++ b/arangod/Replication/utilities.h
@@ -135,7 +135,7 @@ struct LeaderInfo {
   explicit LeaderInfo(ReplicationApplierConfiguration const& applierConfig);
 
   /// @brief get leader state
-  Result getState(Connection& connection, bool isChildSyncer);
+  Result getState(Connection& connection, bool isChildSyncer, char const* context);
 
   /// we need to act like a 3.2 client
   bool simulate32Client() const;

--- a/arangod/Statistics/ConnectionStatistics.cpp
+++ b/arangod/Statistics/ConnectionStatistics.cpp
@@ -79,6 +79,8 @@ void ConnectionStatistics::getSnapshot(Snapshot& snapshot) {
 
   snapshot.httpConnections = statistics::HttpConnections;
   snapshot.totalRequests = statistics::TotalRequests;
+  snapshot.totalRequestsSuperuser = statistics::TotalRequestsSuperuser;
+  snapshot.totalRequestsUser = statistics::TotalRequestsUser;
   snapshot.methodRequests = statistics::MethodRequests;
   snapshot.asyncRequests = statistics::AsyncRequests;
   snapshot.connectionTime = statistics::ConnectionTimeDistribution;

--- a/arangod/Statistics/ConnectionStatistics.h
+++ b/arangod/Statistics/ConnectionStatistics.h
@@ -78,6 +78,8 @@ class ConnectionStatistics {
   struct Snapshot {
     statistics::Counter httpConnections;
     statistics::Counter totalRequests;
+    statistics::Counter totalRequestsSuperuser;
+    statistics::Counter totalRequestsUser;
     statistics::MethodRequestCounters methodRequests;
     statistics::Counter asyncRequests;
     statistics::Distribution connectionTime;

--- a/arangod/Statistics/Descriptions.cpp
+++ b/arangod/Statistics/Descriptions.cpp
@@ -319,6 +319,22 @@ stats::Descriptions::Descriptions(application_features::ApplicationServer& serve
                                stats::FigureType::Accumulated,
                                stats::Unit::Number,
                                {}});
+  
+  _figures.emplace_back(Figure{stats::GroupType::Http,
+                               "requestsSuperuser",
+                               "Total superuser requests",
+                               "Total number of HTTP requests executed by superuser/JWT.",
+                               stats::FigureType::Accumulated,
+                               stats::Unit::Number,
+                               {}});
+  
+  _figures.emplace_back(Figure{stats::GroupType::Http,
+                               "requestsUser",
+                               "Total user requests",
+                               "Total number of HTTP requests executed by clients.",
+                               stats::FigureType::Accumulated,
+                               stats::Unit::Number,
+                               {}});
 
   _figures.emplace_back(
       Figure{stats::GroupType::Http,
@@ -502,6 +518,8 @@ void stats::Descriptions::httpStatistics(velocypack::Builder& b) const {
 
   // request counters
   b.add("requestsTotal", VPackValue(stats.totalRequests.get()));
+  b.add("requestsSuperuser", VPackValue(stats.totalRequestsSuperuser.get()));
+  b.add("requestsUser", VPackValue(stats.totalRequestsUser.get()));
   b.add("requestsAsync", VPackValue(stats.asyncRequests.get()));
   b.add("requestsGet", VPackValue(stats.methodRequests[(int)rest::RequestType::GET].get()));
   b.add("requestsHead", VPackValue(stats.methodRequests[(int)rest::RequestType::HEAD].get()));

--- a/arangod/Statistics/RequestStatistics.cpp
+++ b/arangod/Statistics/RequestStatistics.cpp
@@ -124,9 +124,16 @@ void RequestStatistics::process(RequestStatistics* statistics) {
       } else {
         totalTime = statistics->_writeEnd - statistics->_readStart;
       }
+      
+      bool const isSuperuser = statistics->_superuser;
+      if (isSuperuser) {
+        statistics::TotalRequestsSuperuser.incCounter();
+      } else {
+        statistics::TotalRequestsUser.incCounter();
+      }
 
-      statistics::RequestFigures& figures = statistics->_superuser
-        ? statistics::GeneralRequestFigures
+      statistics::RequestFigures& figures = isSuperuser
+        ? statistics::SuperuserRequestFigures
         : statistics::UserRequestFigures;
 
       figures.totalTimeDistribution.addFigure(totalTime);
@@ -195,7 +202,7 @@ void RequestStatistics::getSnapshot(Snapshot& snapshot, stats::RequestStatistics
 
   statistics::RequestFigures& figures = source == stats::RequestStatisticsSource::USER
     ? statistics::UserRequestFigures
-    : statistics::GeneralRequestFigures;
+    : statistics::SuperuserRequestFigures;
 
   snapshot.totalTime = figures.totalTimeDistribution;
   snapshot.requestTime = figures.requestTimeDistribution;
@@ -205,6 +212,7 @@ void RequestStatistics::getSnapshot(Snapshot& snapshot, stats::RequestStatistics
   snapshot.bytesReceived = figures.bytesReceivedDistribution;
   
   if (source == stats::RequestStatisticsSource::ALL) {
+    TRI_ASSERT(&figures == &statistics::SuperuserRequestFigures);
     snapshot.totalTime.add(statistics::UserRequestFigures.totalTimeDistribution);
     snapshot.requestTime.add(statistics::UserRequestFigures.requestTimeDistribution);
     snapshot.queueTime.add(statistics::UserRequestFigures.queueTimeDistribution);

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -65,6 +65,8 @@ std::initializer_list<double> const RequestTimeDistributionCuts{0.01, 0.05, 0.1,
 Counter AsyncRequests;
 Counter HttpConnections;
 Counter TotalRequests;
+Counter TotalRequestsSuperuser;
+Counter TotalRequestsUser;
 MethodRequestCounters MethodRequests;
 Distribution ConnectionTimeDistribution(ConnectionTimeDistributionCuts);
 
@@ -74,10 +76,9 @@ RequestFigures::RequestFigures() :
   ioTimeDistribution(RequestTimeDistributionCuts),
   queueTimeDistribution(RequestTimeDistributionCuts),
   requestTimeDistribution(RequestTimeDistributionCuts),
-  totalTimeDistribution(RequestTimeDistributionCuts)
-{}
+  totalTimeDistribution(RequestTimeDistributionCuts) {}
 
-RequestFigures GeneralRequestFigures;
+RequestFigures SuperuserRequestFigures;
 RequestFigures UserRequestFigures;
 }  // namespace statistics
 }  // namespace arangodb

--- a/arangod/Statistics/StatisticsFeature.h
+++ b/arangod/Statistics/StatisticsFeature.h
@@ -47,6 +47,8 @@ extern std::initializer_list<double> const RequestTimeDistributionCuts;
 extern Counter AsyncRequests;
 extern Counter HttpConnections;
 extern Counter TotalRequests;
+extern Counter TotalRequestsSuperuser;
+extern Counter TotalRequestsUser;
 
 constexpr size_t MethodRequestsStatisticsSize =
     ((size_t)arangodb::rest::RequestType::ILLEGAL) + 1;
@@ -69,7 +71,7 @@ struct RequestFigures {
   Distribution requestTimeDistribution;
   Distribution totalTimeDistribution;
 };
-extern RequestFigures GeneralRequestFigures;
+extern RequestFigures SuperuserRequestFigures;
 extern RequestFigures UserRequestFigures;
 }  // namespace statistics
 

--- a/arangod/Statistics/StatisticsWorker.cpp
+++ b/arangod/Statistics/StatisticsWorker.cpp
@@ -907,6 +907,12 @@ std::map<std::string, std::vector<std::string>> statStrings{
   {"httpReqsTotal",
    {"arangodb_http_request_statistics_total_requests", "gauge",
     "Total number of HTTP requests"}},
+  {"httpReqsSuperuser",
+   {"arangodb_http_request_statistics_superuser_requests", "gauge",
+    "Total number of HTTP requests executed by superuser/JWT"}},
+  {"httpReqsUser",
+   {"arangodb_http_request_statistics_user_requests", "gauge",
+    "Total number of HTTP requests executed by clients"}},
   {"httpReqsAsync",
    {"arangodb_http_request_statistics_async_requests", "gauge",
     "Number of asynchronously executed HTTP requests"}},
@@ -1018,6 +1024,8 @@ void StatisticsWorker::generateRawStatistics(std::string& result, double const& 
   appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::PUT].get()), "httpReqsPut");
   appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::ILLEGAL].get()), "httpReqsOther");
   appendMetric(result, std::to_string(connectionStats.totalRequests.get()), "httpReqsTotal");
+  appendMetric(result, std::to_string(connectionStats.totalRequestsSuperuser.get()), "httpReqsSuperuser");
+  appendMetric(result, std::to_string(connectionStats.totalRequestsUser.get()), "httpReqsUser");
 
   V8DealerFeature::Statistics v8Counters{};
   if (_server.hasFeature<V8DealerFeature>()) {
@@ -1144,6 +1152,8 @@ void StatisticsWorker::generateRawStatistics(VPackBuilder& builder, double const
   using rest::RequestType;
   builder.add("http", VPackValue(VPackValueType::Object));
   builder.add("requestsTotal", VPackValue(connectionStats.totalRequests.get()));
+  builder.add("requestsSuperuser", VPackValue(connectionStats.totalRequestsSuperuser.get()));
+  builder.add("requestsUser", VPackValue(connectionStats.totalRequestsUser.get()));
   builder.add("requestsAsync", VPackValue(connectionStats.asyncRequests.get()));
   builder.add("requestsGet",
               VPackValue(connectionStats.methodRequests[(int)RequestType::GET].get()));

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2312,6 +2312,7 @@ Future<Result> Methods::replicateOperations(
     // We drop all followers that were not successful:
     for (size_t i = 0; i < followerList->size(); ++i) {
       network::Response const& resp = responses[i].get();
+      ServerID const& follower = (*followerList)[i];
 
       bool replicationWorked = false;
       if (resp.error == fuerte::Error::NoError) {
@@ -2322,31 +2323,43 @@ Future<Result> Methods::replicateOperations(
           bool found;
           resp.response->header.metaByKey(StaticStrings::ErrorCodes, found);
           replicationWorked = !found;
+        } else {
+          auto r = resp.combinedResult();
+          bool followerRefused = (r.errorNumber() == TRI_ERROR_CLUSTER_SHARD_LEADER_REFUSES_REPLICATION);
+          didRefuse = didRefuse || followerRefused;
+
+          if (followerRefused) {
+            LOG_TOPIC("3032c", WARN, Logger::REPLICATION)
+                << "synchronous replication: follower "
+                << follower << " for shard " << collection->name()
+                << " in database " << collection->vocbase().name() 
+                << " refused the operation: " << r.errorMessage();
+          }
         }
-        auto r = resp.combinedResult();
-        didRefuse = didRefuse || r.errorNumber() == TRI_ERROR_CLUSTER_SHARD_LEADER_REFUSES_REPLICATION;
       }
 
       if (!replicationWorked) {
-        ServerID const& deadFollower = (*followerList)[i];
         LOG_TOPIC("20f31", INFO, Logger::REPLICATION)
             << "synchronous replication: dropping follower "
-            << deadFollower << " for shard " << collection->name()
-            << ", status code: " << static_cast<int>(resp.statusCode())
-            << ", message: " << network::fuerteToArangoErrorMessage(resp);
+            << follower << " for shard " << collection->name()
+            << " in database " << collection->vocbase().name() 
+            << ": " << resp.combinedResult().errorMessage();
         
-        Result res = collection->followers()->remove(deadFollower);
+        Result res = collection->followers()->remove(follower);
         if (res.ok()) {
           // simon: follower cannot be re-added without lock on collection
-          _state->removeKnownServer(deadFollower);
+          _state->removeKnownServer(follower);
           LOG_TOPIC("12d8c", WARN, Logger::REPLICATION)
               << "synchronous replication: dropped follower "
-              << deadFollower << " for shard " << collection->name();
+              << follower << " for shard " << collection->name()
+              << " in database " << collection->vocbase().name() 
+              << ": " << resp.combinedResult().errorMessage();
         } else {
           LOG_TOPIC("db473", ERR, Logger::REPLICATION)
               << "synchronous replication: could not drop follower "
-              << deadFollower << " for shard " << collection->name() << ": "
-              << res.errorMessage();
+              << follower << " for shard " << collection->name() 
+              << " in database " << collection->vocbase().name() 
+              << ": " << res.errorMessage();
           THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_COULD_NOT_DROP_FOLLOWER);
         }
       }

--- a/arangod/V8Server/v8-statistics.cpp
+++ b/arangod/V8Server/v8-statistics.cpp
@@ -257,6 +257,10 @@ static void JS_HttpStatistics(v8::FunctionCallbackInfo<v8::Value> const& args) {
   // request counters
   result->Set(context, TRI_V8_ASCII_STRING(isolate, "requestsTotal"),
               v8::Number::New(isolate, (double)stats.totalRequests.get())).FromMaybe(false);
+  result->Set(context, TRI_V8_ASCII_STRING(isolate, "requestsSuperuser"),
+              v8::Number::New(isolate, (double)stats.totalRequestsSuperuser.get())).FromMaybe(false);
+  result->Set(context, TRI_V8_ASCII_STRING(isolate, "requestsUser"),
+              v8::Number::New(isolate, (double)stats.totalRequestsUser.get())).FromMaybe(false);
   result->Set(context, TRI_V8_ASCII_STRING(isolate, "requestsAsync"),
               v8::Number::New(isolate, (double)stats.asyncRequests.get())).FromMaybe(false);
   result->Set(context, TRI_V8_ASCII_STRING(isolate, "requestsGet"),

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/models/arangoCollectionModel.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/models/arangoCollectionModel.js
@@ -31,6 +31,21 @@
         }
       });
     },
+    getShards: function (callback) {
+      $.ajax({
+        type: 'GET',
+        cache: false,
+        url: arangoHelper.databaseUrl('/_api/collection/' + this.get('id') + '/shards?details=true'),
+        contentType: 'application/json',
+        processData: false,
+        success: function (data) {
+          callback(false, data);
+        },
+        error: function () {
+          callback(true);
+        }
+      });
+    },
     getFigures: function (callback) {
       $.ajax({
         type: 'GET',
@@ -45,6 +60,28 @@
           callback(true);
         }
       });
+    },
+    getFiguresCombined: function (callback, isCluster) {
+      var self = this;
+      var shardsCallback = function (error, data) {
+        if (error) {
+          callback(true);
+        } else {
+          var figures = data;
+          if (isCluster) {
+            self.getShards(function (error, data) {
+              if (error) {
+                callback(true);
+              } else {
+                callback(false, Object.assign(figures, { shards: data.shards }));
+              }
+            });
+          } else {
+            callback(false, figures);
+          }
+        }
+      };
+      this.getFigures(shardsCallback);
     },
     getRevision: function (callback, figures) {
       $.ajax({

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/templates/modalCollectionInfo.ejs
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/templates/modalCollectionInfo.ejs
@@ -72,6 +72,25 @@
             </tr>
           <% } %>
           
+          <% if (figuresData.shards) { %>
+            <tr>
+              <th class="collectionInfoTh2">Shards:</th>
+              <th class="collectionInfoTh">
+                <div class="modal-text">
+                <% var allShards = Object.keys(figuresData.shards); 
+                   allShards.forEach(function(shardName, index) {
+                %>
+                <%=(index > 0 ? '<br />' : '')%>
+                <%=shardName%>: [ <%=figuresData.shards[shardName].join('  -  ') %> ] 
+                
+                <%});%>
+                </div>
+              </th>
+              <th class="collectionInfoTh">
+              </th>
+            </tr>
+          <% } %>
+          
           <% if (figuresData.replicationFactor) { %>
             <tr>
               <th class="collectionInfoTh2">Replication factor:</th>

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/infoView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/infoView.js
@@ -65,6 +65,7 @@
             revision: revision,
             model: this.model
           };
+
           window.modalView.show(
             'modalCollectionInfo.ejs',
             'Collection: ' + (this.model.get('name').length > 64 ? this.model.get('name').substr(0, 64) + "..." : this.model.get('name')),
@@ -85,7 +86,7 @@
         }
       }.bind(this);
 
-      this.model.getFigures(callback);
+      this.model.getFiguresCombined(callback, frontendConfig.isCluster);
     }
 
   });


### PR DESCRIPTION
### Scope & Purpose

This PR improves observability in the following ways:

* Add database, shard name and error information to several shard-related log messages.
* Display shard names of a collection in the web interface when in the details view of the collection.
* Added HTTP requests metrics for tracking the number of superuser and normal user requests separately:
  - `arangodb_http_request_statistics_superuser_requests`: Total number of HTTP requests executed by superuser/JWT
  - `arangodb_http_request_statistics_user_requests`: Total number of HTTP requests executed by clients

- [ ] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x]:muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12091/