### PR TITLE
avoid usage of potentially unsafe slices() method

### DIFF
--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -198,35 +198,35 @@ void addTransactionHeaderForShard(transaction::Methods const& trx, ShardMap cons
 OperationResult handleResponsesFromAllShards(
     OperationOptions const& options,
     std::vector<futures::Try<arangodb::network::Response>>& responses,
-    std::function<void(Result&, VPackBuilder&, ShardID&, VPackSlice)> handler,
-    std::function<void(Result&, VPackBuilder&)> pre = [](Result&, VPackBuilder&) -> void {},
-    std::function<void(Result&, VPackBuilder&)> post = [](Result&, VPackBuilder&) -> void {}) {
+    std::function<void(Result&, VPackBuilder&, ShardID const&, VPackSlice)> const& handler,
+    std::function<void(Result&, VPackBuilder&)> const& pre = [](Result&, VPackBuilder&) -> void {},
+    std::function<void(Result&, VPackBuilder&)> const& post = [](Result&, VPackBuilder&) -> void {}) {
   // If none of the shards responds we return a SERVER_ERROR;
   Result result;
   VPackBuilder builder;
+  
   pre(result, builder);
-  if (result.fail()) {
-    return OperationResult(result, builder.steal(), options);
-  }
-  for (Try<arangodb::network::Response> const& tryRes : responses) {
-    network::Response const& res = tryRes.get();  // throws exceptions upwards
-    ShardID sId = res.destinationShard();
-    int commError = network::fuerteToArangoErrorCode(res);
-    if (commError != TRI_ERROR_NO_ERROR) {
-      result.reset(commError);
-      break;
-    } else {
-      std::vector<VPackSlice> const& slices = res.response->slices();
-      if (!slices.empty()) {
-        VPackSlice answer = slices[0];
+
+  if (!result.fail()) {
+    for (Try<arangodb::network::Response> const& tryRes : responses) {
+      network::Response const& res = tryRes.get();  // throws exceptions upwards
+      ShardID sId = res.destinationShard();
+      int commError = network::fuerteToArangoErrorCode(res);
+      if (commError != TRI_ERROR_NO_ERROR) {
+        result.reset(commError);
+      } else {
+        TRI_ASSERT(res.error == fuerte::Error::NoError);
+        VPackSlice answer = res.slice();
         handler(result, builder, sId, answer);
-        if (result.fail()) {
-          break;
-        }
+      }
+
+      if (result.fail()) {
+        break;
       }
     }
+    post(result, builder);
   }
-  post(result, builder);
+
   return OperationResult(result, builder.steal(), options);
 }
 
@@ -966,7 +966,7 @@ futures::Future<OperationResult> revisionOnCoordinator(ClusterFeature& feature,
   auto cb = [options](std::vector<Try<network::Response>>&& results) -> OperationResult {
     return handleResponsesFromAllShards(
         options, results,
-        [](Result& result, VPackBuilder& builder, ShardID&, VPackSlice answer) -> void {
+        [](Result& result, VPackBuilder& builder, ShardID const&, VPackSlice answer) -> void {
           if (answer.isObject()) {
             VPackSlice r = answer.get("revision");
             if (r.isString()) {
@@ -1030,7 +1030,7 @@ futures::Future<Result> warmupOnCoordinator(ClusterFeature& feature,
 
   auto cb = [options](std::vector<Try<network::Response>>&& results) -> OperationResult {
     return handleResponsesFromAllShards(options, results,
-                                        [](Result&, VPackBuilder&, ShardID&, VPackSlice) -> void {
+                                        [](Result&, VPackBuilder&, ShardID const&, VPackSlice) -> void {
                                           // we don't care about response bodies, just that the requests succeeded
                                         });
   };
@@ -1079,7 +1079,7 @@ futures::Future<OperationResult> figuresOnCoordinator(ClusterFeature& feature,
   }
 
   auto cb = [details, options](std::vector<Try<network::Response>>&& results) mutable -> OperationResult {
-    auto handler = [details](Result& result, VPackBuilder& builder, ShardID&,
+    auto handler = [details](Result& result, VPackBuilder& builder, ShardID const&,
                              VPackSlice answer) mutable -> void {
       if (answer.isObject()) {
         VPackSlice figures = answer.get("figures");
@@ -1149,7 +1149,7 @@ futures::Future<OperationResult> countOnCoordinator(transaction::Methods& trx,
   }
 
   auto cb = [options](std::vector<Try<network::Response>>&& results) mutable -> OperationResult {
-    auto handler = [](Result& result, VPackBuilder& builder, ShardID& shardId,
+    auto handler = [](Result& result, VPackBuilder& builder, ShardID const& shardId,
                       VPackSlice answer) mutable -> void {
       if (answer.isObject()) {
         // add to the total
@@ -1633,7 +1633,7 @@ futures::Future<OperationResult> truncateCollectionOnCoordinator(
   auto cb = [options](std::vector<Try<network::Response>>&& results) -> OperationResult {
     return handleResponsesFromAllShards(
         options, results,
-        [](Result& result, VPackBuilder&, ShardID&, VPackSlice answer) -> void {
+        [](Result& result, VPackBuilder&, ShardID const&, VPackSlice answer) -> void {
           if (Helper::getBooleanValue(answer, StaticStrings::Error, false)) {
             result = network::resultFromBody(answer, TRI_ERROR_NO_ERROR);
           }

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -854,12 +854,12 @@ arangodb::Result visitAnalyzers(
         return { arangodb::network::fuerteToArangoErrorCode(response) };
       }
 
-      if (response.response->statusCode() == arangodb::fuerte::StatusNotFound) {
+      if (response.statusCode() == arangodb::fuerte::StatusNotFound) {
         return { TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND };
       }
 
-      std::vector<VPackSlice> slices = response.response->slices();
-      if (slices.empty() || !slices[0].isObject()) {
+      VPackSlice answer = response.slice();
+      if (!answer.isObject()) {
         return {
           TRI_ERROR_INTERNAL,
           "got misformed result while visiting Analyzer collection'" +
@@ -868,7 +868,6 @@ arangodb::Result visitAnalyzers(
         };
       }
 
-      VPackSlice answer = slices[0];
       auto result = arangodb::network::resultFromBody(answer, TRI_ERROR_NO_ERROR);
       if (result.fail()) {
         return result;

--- a/arangod/Sharding/ShardDistributionReporter.cpp
+++ b/arangod/Sharding/ShardDistributionReporter.cpp
@@ -358,21 +358,21 @@ void ShardDistributionReporter::helperDistributionForDatabase(
             // Wait for responses
             // First wait for Leader
             {
-              auto& res = leaderF.get();
+              auto const& res = leaderF.get();
               if (fuerteToArangoErrorCode(res) != TRI_ERROR_NO_ERROR || !res.response) {
                 // We did not even get count for leader, use defaults
                 continue;
               }
 
-              std::vector<VPackSlice> const& slices = res.response->slices();
-              if (slices.empty() || !slices[0].isObject()) {
+              VPackSlice slice = res.slice();
+              if (!slice.isObject()) {
                 LOG_TOPIC("c02b2", WARN, arangodb::Logger::CLUSTER)
                     << "Received invalid response for count. Shard "
                     << "distribution inaccurate";
                 continue;
               }
 
-              VPackSlice response = slices[0].get("count");
+              VPackSlice response = slice.get("count");
               if (!response.isNumber()) {
                 LOG_TOPIC("fe868", WARN, arangodb::Logger::CLUSTER)
                     << "Received invalid response for count. Shard "
@@ -396,16 +396,16 @@ void ShardDistributionReporter::helperDistributionForDatabase(
                   continue;
                 }
 
-                auto& res = response.get();
-                std::vector<VPackSlice> const& slices = res.response->slices();
-                if (slices.empty() || !slices[0].isObject()) {
+                auto const& res = response.get();
+                VPackSlice slice = res.slice();
+                if (!slice.isObject()) {
                   LOG_TOPIC("fcbb3", WARN, arangodb::Logger::CLUSTER)
                       << "Received invalid response for count. Shard "
                       << "distribution inaccurate";
                   continue;
                 }
 
-                VPackSlice answer = slices[0].get("count");
+                VPackSlice answer = slice.get("count");
                 if (!answer.isNumber()) {
                   LOG_TOPIC("8d7b0", WARN, arangodb::Logger::CLUSTER)
                       << "Received invalid response for count. Shard "

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -1065,14 +1065,11 @@ Result Manager::abortAllManagedWriteTrx(std::string const& username, bool fanout
     }
 
     for (auto& f : futures) {
-      network::Response& resp = f.get();
+      network::Response const& resp = f.get();
       
-      if (resp.response && resp.response->statusCode() != fuerte::StatusOK) {
-        auto slices = resp.response->slices();
-        if (!slices.empty()) {
-          VPackSlice slice = slices[0];
-          res.reset(network::resultFromBody(slice, TRI_ERROR_FAILED));
-        }
+      if (resp.statusCode() != fuerte::StatusOK) {
+        VPackSlice slice = resp.slice();
+        res.reset(network::resultFromBody(slice, TRI_ERROR_FAILED));
       }
     }
   }

--- a/arangosh/Shell/V8ClientConnection.cpp
+++ b/arangosh/Shell/V8ClientConnection.cpp
@@ -118,6 +118,11 @@ std::shared_ptr<fu::Connection> V8ClientConnection::createConnection() {
   try {
     auto res = newConnection->sendRequest(std::move(req));
 
+    if (!res) {
+      setCustomError(500, "unable to create connection");
+      return nullptr;
+    }
+
     _lastHttpReturnCode = res->statusCode();
 
     std::shared_ptr<VPackBuilder> parsedBody;
@@ -1992,6 +1997,8 @@ v8::Local<v8::Value> V8ClientConnection::handleResult(v8::Isolate* isolate,
 
     return result;
   }
+
+  TRI_ASSERT(res != nullptr);
 
   // complete
   _lastHttpReturnCode = res->statusCode();


### PR DESCRIPTION
### Scope & Purpose

calling slices() on the `response` member in arangodb::network::Response is potentially unsafe if there are no prior checks, as `response` can be a nullptr.

This is in response to a test failure observed in http://172.16.10.101:8080/job/arangodb-matrix-pr-linux/13716/EDITION=community,STORAGE_ENGINE=rocksdb,TEST_SUITE=cluster,limit=(linux&&test)%7C%7Cgce/

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/558

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.7, potentially 3.6

### Testing & Verification

- [x] This change is already covered by existing tests, such as *all networking tests*

