### PR TITLE
avoid usage of potentially unsafe slices() method

### DIFF
--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -215,6 +215,7 @@ OperationResult handleResponsesFromAllShards(
       result.reset(commError);
       break;
     } else {
+      TRI_ASSERT(res.response);
       std::vector<VPackSlice> const& slices = res.response->slices();
       if (!slices.empty()) {
         VPackSlice answer = slices[0];

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -841,7 +841,7 @@ arangodb::Result visitAnalyzers(
         continue;
       }
 
-      if (response.response->statusCode() == arangodb::fuerte::StatusNotFound) {
+      if (response.statusCode() == arangodb::fuerte::StatusNotFound) {
         return { TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND };
       }
 
@@ -849,8 +849,8 @@ arangodb::Result visitAnalyzers(
         return { arangodb::network::fuerteToArangoErrorCode(response) };
       }
 
-      std::vector<VPackSlice> slices = response.response->slices();
-      if (slices.empty() || !slices[0].isObject()) {
+      VPackSlice answer = response.slice();
+      if (!answer.isObject()) {
         return {
           TRI_ERROR_INTERNAL,
           "got misformed result while visiting Analyzer collection'" +
@@ -859,7 +859,6 @@ arangodb::Result visitAnalyzers(
         };
       }
 
-      VPackSlice answer = slices[0];
       auto result = arangodb::network::resultFromBody(answer, TRI_ERROR_NO_ERROR);
       if (result.fail()) {
         return result;

--- a/arangod/Sharding/ShardDistributionReporter.cpp
+++ b/arangod/Sharding/ShardDistributionReporter.cpp
@@ -357,21 +357,21 @@ void ShardDistributionReporter::helperDistributionForDatabase(
             // Wait for responses
             // First wait for Leader
             {
-              auto& res = leaderF.get();
+              auto const& res = leaderF.get();
               if (fuerteToArangoErrorCode(res) != TRI_ERROR_NO_ERROR || !res.response) {
                 // We did not even get count for leader, use defaults
                 continue;
               }
 
-              std::vector<VPackSlice> const& slices = res.response->slices();
-              if (slices.empty() || !slices[0].isObject()) {
+              VPackSlice slice = res.slice();
+              if (!slice.isObject()) {
                 LOG_TOPIC("c02b2", WARN, arangodb::Logger::CLUSTER)
                     << "Received invalid response for count. Shard "
                     << "distribution inaccurate";
                 continue;
               }
 
-              VPackSlice response = slices[0].get("count");
+              VPackSlice response = slice.get("count");
               if (!response.isNumber()) {
                 LOG_TOPIC("fe868", WARN, arangodb::Logger::CLUSTER)
                     << "Received invalid response for count. Shard "
@@ -395,16 +395,16 @@ void ShardDistributionReporter::helperDistributionForDatabase(
                   continue;
                 }
 
-                auto& res = response.get();
-                std::vector<VPackSlice> const& slices = res.response->slices();
-                if (slices.empty() || !slices[0].isObject()) {
+                auto const& res = response.get();
+                VPackSlice slice = res.slice();
+                if (!slice.isObject()) {
                   LOG_TOPIC("fcbb3", WARN, arangodb::Logger::CLUSTER)
                       << "Received invalid response for count. Shard "
                       << "distribution inaccurate";
                   continue;
                 }
 
-                VPackSlice answer = slices[0].get("count");
+                VPackSlice answer = slice.get("count");
                 if (!answer.isNumber()) {
                   LOG_TOPIC("8d7b0", WARN, arangodb::Logger::CLUSTER)
                       << "Received invalid response for count. Shard "


### PR DESCRIPTION
### Scope & Purpose

calling slices() on the `response` member in arangodb::network::Response is potentially unsafe if there are no prior checks, as `response` can be a nullptr.

This is in response to a test failure observed in http://172.16.10.101:8080/job/arangodb-matrix-pr-linux/13716/EDITION=community,STORAGE_ENGINE=rocksdb,TEST_SUITE=cluster,limit=(linux&&test)%7C%7Cgce/

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/559
Backport of https://github.com/arangodb/arangodb/pull/12760

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [] Backports required for: potentially 3.6

### Testing & Verification

- [x] This change is already covered by existing tests, such as *all networking tests*

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12096/