### PR TITLE
avoid usage of potentially unsafe slices() method

### DIFF
--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -378,6 +378,7 @@ OperationResult handleResponsesFromAllShards(
       result.reset(commError);
       break;
     } else {
+      TRI_ASSERT(res.response);
       std::vector<VPackSlice> const& slices = res.response->slices();
       if (!slices.empty()) {
         VPackSlice answer = slices[0];

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -819,7 +819,7 @@ arangodb::Result visitAnalyzers(
         continue;
       }
 
-      if (response.response->statusCode() == arangodb::fuerte::StatusNotFound) {
+      if (response.statusCode() == arangodb::fuerte::StatusNotFound) {
         return { TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND };
       }
 
@@ -827,7 +827,7 @@ arangodb::Result visitAnalyzers(
         return { arangodb::network::fuerteToArangoErrorCode(response) };
       }
     
-      VPackSlice answer = response.response->slice();
+      VPackSlice answer = response.slice();
       if (!answer.isObject()) {
         return {
           TRI_ERROR_INTERNAL,

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -819,16 +819,16 @@ arangodb::Result visitAnalyzers(
         continue;
       }
 
-      if (response.response->statusCode() == arangodb::fuerte::StatusNotFound) {
+      if (response.statusCode() == arangodb::fuerte::StatusNotFound) {
         return { TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND };
       }
 
       if (response.error != arangodb::fuerte::Error::NoError) {
         return { arangodb::network::fuerteToArangoErrorCode(response) };
       }
-
-      std::vector<VPackSlice> slices = response.response->slices();
-      if (slices.empty() || !slices[0].isObject()) {
+    
+      VPackSlice answer = response.slice();
+      if (!answer.isObject()) {
         return {
           TRI_ERROR_INTERNAL,
           "got misformed result while visiting Analyzer collection'" +
@@ -837,7 +837,6 @@ arangodb::Result visitAnalyzers(
         };
       }
 
-      VPackSlice answer = slices[0];
       auto result = arangodb::network::resultFromBody(answer, TRI_ERROR_NO_ERROR);
       if (result.fail()) {
         return result;

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -819,7 +819,7 @@ arangodb::Result visitAnalyzers(
         continue;
       }
 
-      if (response.statusCode() == arangodb::fuerte::StatusNotFound) {
+      if (response.response->statusCode() == arangodb::fuerte::StatusNotFound) {
         return { TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND };
       }
 
@@ -827,7 +827,7 @@ arangodb::Result visitAnalyzers(
         return { arangodb::network::fuerteToArangoErrorCode(response) };
       }
     
-      VPackSlice answer = response.slice();
+      VPackSlice answer = response.response->slice();
       if (!answer.isObject()) {
         return {
           TRI_ERROR_INTERNAL,

--- a/arangod/Network/Methods.h
+++ b/arangod/Network/Methods.h
@@ -56,6 +56,13 @@ struct Response {
     }
     return velocypack::Slice();  // none slice
   }
+  
+  fuerte::StatusCode statusCode() const {
+    if (error == fuerte::Error::NoError && response) {
+      return response->statusCode();
+    }
+    return fuerte::StatusUndefined;
+  }
 
   /// @brief Build a Result that contains
   ///   - no error if everything went well, otherwise


### PR DESCRIPTION
### Scope & Purpose

calling slices() on the `response` member in arangodb::network::Response is potentially unsafe if there are no prior checks, as `response` can be a nullptr.

This is in response to a test failure observed in http://172.16.10.101:8080/job/arangodb-matrix-pr-linux/13716/EDITION=community,STORAGE_ENGINE=rocksdb,TEST_SUITE=cluster,limit=(linux&&test)%7C%7Cgce/

Backport of https://github.com/arangodb/arangodb/pull/12760

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required
- [ ] Backports required for: 

### Testing & Verification

- [x] This change is already covered by existing tests, such as *all networking tests*

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12097/