### PR TITLE
Bug fix/prevent assertion failure for numeric key

### DIFF
--- a/arangod/Aql/ModificationExecutorHelpers.cpp
+++ b/arangod/Aql/ModificationExecutorHelpers.cpp
@@ -67,7 +67,7 @@ Result ModificationExecutorHelpers::getKey(CollectionNameResolver const& resolve
 
   if (!keyEntry.isString()) {
     return Result{TRI_ERROR_ARANGO_DOCUMENT_KEY_MISSING,
-                  std::string{"Expected _key to be present in document."}};
+                  std::string{"Expected _key to be a string attribute in document."}};
   }
 
   // Key found and assigned, note rev is empty by assertion

--- a/arangod/Aql/OptimizerRulesCluster.cpp
+++ b/arangod/Aql/OptimizerRulesCluster.cpp
@@ -349,13 +349,15 @@ bool substituteClusterSingleDocumentOperationsNoIndex(Optimizer* opt, ExecutionP
         bool foundKey = false;
         for (std::size_t i = 0; i < expr->numMembers(); i++) {
           auto* anode = expr->getMemberUnchecked(i);
-          if (anode->getString() == StaticStrings::KeyString) {
-            key = anode->getMember(0)->getString();
-            foundKey = true;
-          }
-          if (anode->getString() == StaticStrings::RevString) {
-            foundKey = false;  // decline if _rev is in the game
-            break;
+          if (anode->isStringValue()) {
+            if (anode->getString() == StaticStrings::KeyString) {
+              key = anode->getMember(0)->getString();
+              foundKey = true;
+            }
+            if (anode->getString() == StaticStrings::RevString) {
+              foundKey = false;  // decline if _rev is in the game
+              break;
+            }
           }
         }
         if (!foundKey) {

--- a/arangod/Aql/OptimizerRulesCluster.cpp
+++ b/arangod/Aql/OptimizerRulesCluster.cpp
@@ -349,15 +349,14 @@ bool substituteClusterSingleDocumentOperationsNoIndex(Optimizer* opt, ExecutionP
         bool foundKey = false;
         for (std::size_t i = 0; i < expr->numMembers(); i++) {
           auto* anode = expr->getMemberUnchecked(i);
-          if (anode->isStringValue()) {
-            if (anode->getString() == StaticStrings::KeyString) {
+          if (anode->getStringRef() == StaticStrings::KeyString) {
+            if (anode->getMember(0)->isStringValue()) {
               key = anode->getMember(0)->getString();
-              foundKey = true;
             }
-            if (anode->getString() == StaticStrings::RevString) {
-              foundKey = false;  // decline if _rev is in the game
-              break;
-            }
+            foundKey = true;
+          } else if (anode->getStringRef() == StaticStrings::RevString) {
+            foundKey = false;  // decline if _rev is in the game
+            break;
           }
         }
         if (!foundKey) {

--- a/tests/js/server/aql/aql-optimizer-optimize-cluster-single-document-operations.js
+++ b/tests/js/server/aql/aql-optimizer-optimize-cluster-single-document-operations.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global assertTrue, assertEqual, assertNotEqual, AQL_EXECUTE, AQL_EXPLAIN */
+/*global assertTrue, assertEqual, assertNotEqual, AQL_EXECUTE, AQL_EXPLAIN, fail */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief tests for single operation nodes in cluster
@@ -159,6 +159,42 @@ function optimizerClusterSingleDocumentTestSuite () {
       db._drop(cn1);
       db._drop(cn2);
       db._drop(cn3);
+    },
+
+    testNumericKeyInsert : function () {
+      try {
+        db._query("INSERT { _key: 1234 } INTO " + cn1);
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_ARANGO_DOCUMENT_KEY_BAD.code, err.errorNum);
+      }
+    },
+    
+    testNumericKeyUpdate : function () {
+      try {
+        db._query("UPDATE { _key: 1234 } WITH { value: 1 } IN " + cn1);
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_ARANGO_DOCUMENT_KEY_MISSING.code, err.errorNum);
+      }
+    },
+    
+    testNumericKeyReplace : function () {
+      try {
+        db._query("REPLACE { _key: 1234 } WITH { value: 1 } IN " + cn1);
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_ARANGO_DOCUMENT_KEY_MISSING.code, err.errorNum);
+      }
+    },
+    
+    testNumericKeyRemove : function () {
+      try {
+        db._query("REMOVE { _key: 1234 } IN " + cn1);
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_ARANGO_DOCUMENT_KEY_MISSING.code, err.errorNum);
+      }
     },
 
     testFetchDocumentWithOldAttribute : function() {


### PR DESCRIPTION
### Scope & Purpose

Prevent running into an assertion failure for numeric `_key` values.
    
Single-document AQL queries that are executed with a hard-coded, but (invalid) numeric literal value for `_key` can trigger an assertion failure in the cluster, due to the value of _key being interpreted as a string.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.7, 3.6

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (in shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12098/