### PR TITLE
disable /_api/tasks API in case JavaScript is turned off

### DIFF
--- a/arangod/GeneralServer/GeneralServerFeature.cpp
+++ b/arangod/GeneralServer/GeneralServerFeature.cpp
@@ -386,8 +386,11 @@ void GeneralServerFeature::defineHandlers() {
                                     RestHandlerCreator<RestSimpleHandler>::createData<aql::QueryRegistry*>,
                                     queryRegistry);
 
-  _handlerFactory->addPrefixHandler(RestVocbaseBaseHandler::TASKS_PATH,
-                                    RestHandlerCreator<RestTasksHandler>::createNoData);
+  if (server().isEnabled<V8DealerFeature>()) {
+    // the tasks feature depends on V8. only enable it if JavaScript is enabled
+    _handlerFactory->addPrefixHandler(RestVocbaseBaseHandler::TASKS_PATH,
+                                      RestHandlerCreator<RestTasksHandler>::createNoData);
+  }
 
   _handlerFactory->addPrefixHandler(RestVocbaseBaseHandler::UPLOAD_PATH,
                                     RestHandlerCreator<RestUploadHandler>::createNoData);


### PR DESCRIPTION
### Scope & Purpose

Disable `/_api/tasks` REST handler automatically in case JavaScript is turned off.
The API is dysfunctional then anyway, and turning it off completely prevents undefined behavior when invoking it accidentially

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required
- [ ] Backports required for: *(Please specify versions)*

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12105/