### PR TITLE
remove wrong assertion that can ruin agency startup in maintainer mode

### DIFF
--- a/arangod/Agency/RestAgencyHandler.cpp
+++ b/arangod/Agency/RestAgencyHandler.cpp
@@ -522,7 +522,6 @@ RestStatus RestAgencyHandler::handleRead() {
         return reportMessage(rest::ResponseCode::SERVICE_UNAVAILABLE,
                              "No leader");
       } else {
-        TRI_ASSERT(ret.redirect != _agent->id());
         redirectRequest(ret.redirect);
       }
     }


### PR DESCRIPTION
### Scope & Purpose

Remove an invalid assertion that sporadically triggered at agency startup in maintenance mode only.
The assertion has been removed in 3.7 and devel for a while already.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12106/