### PR TITLE
fix default value for `--database.old-system-collections`

### DIFF
--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -255,7 +255,7 @@ DatabaseFeature::DatabaseFeature(application_features::ApplicationServer& server
       _isInitiallyEmpty(false),
       _checkVersion(false),
       _upgrade(false),
-      _useOldSystemCollections(false) {
+      _useOldSystemCollections(true) {
   setOptional(false);
   startsAfter<BasicFeaturePhaseServer>();
 


### PR DESCRIPTION
### Scope & Purpose

The announced default value for the new `--database.old-system-collections` options is `false`, but the original PR set it to `true` in the code unintentionally. This PR rectifies that.

- [x] :hankey: Bugfix 

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12115/