### PR TITLE
Added optional verbose logging for agency write operations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,20 @@
 devel
 -----
 
+* Added optional verbose logging for agency write operations. This logging
+  is configurable by using the new log topic "agencystore".
+
+  The following log levels can be used for for the "agencystore" log topic
+  to log writes to the agency:
+  - DEBUG: will log all writes on the leader
+  - TRACE: will log all writes on both leaders and followers
+  The default log level for the "agencystore" log topic is WARN, meaning no
+  agency writes will be logged.
+  Turning on this logging can be used for auditing and debugging, but it is
+  not recommended in the general case, as it can lead to large amounts of 
+  data being logged, which can have a performance impact and will lead to
+  higher disk space usage.
+
 * Fix for BTS-191: Made transaction API database-aware.
 
 * Minor clean up of and less verbosity in agent callbacks. 

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_modules_flush.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_modules_flush.md
@@ -126,6 +126,9 @@ One of the possible log levels.
 @RESTBODYPARAM{agencycomm,string,optional,string}
 One of the possible log levels.
 
+@RESTBODYPARAM{agencystore,string,optional,string}
+One of the possible log levels.
+
 @RESTBODYPARAM{aql,string,optional,string}
 One of the possible log levels.
 

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -293,10 +293,21 @@ index_t State::logNonBlocking(index_t idx, velocypack::Slice const& slice,
                               term_t term, uint64_t millis, std::string const& clientId,
                               bool leading, bool reconfiguration) {
   _logLock.assertLockedByCurrentThread();
-
-  auto byteSize = slice.byteSize();
-  auto buf = std::make_shared<Buffer<uint8_t>>();
-  buf->append((char const*)slice.begin(), byteSize);
+  
+  // verbose logging for all agency operations
+  // there are two different log levels in use here for the AGENCYSTORE topic
+  // - DEBUG: will log writes only on the leader
+  // - TRACE: will log writes on both leaders and followers
+  // the default log level for the AGENCYSTORE topic is WARN
+  if (leading) {
+    LOG_TOPIC("b578f", DEBUG, Logger::AGENCYSTORE)
+        << "leader: true, client: " << clientId << ", index: " << idx << ", term: " << term
+        << ", data: " << slice.toJson();
+  } else {
+    LOG_TOPIC("f586f", TRACE, Logger::AGENCYSTORE)
+        << "leader: false, client: " << clientId << ", index: " << idx << ", term: " << term
+        << ", data: " << slice.toJson();
+  }
 
   bool success = reconfiguration ? persistConf(idx, term, millis, slice, clientId)
     : persist(idx, term, millis, slice, clientId);
@@ -306,8 +317,12 @@ index_t State::logNonBlocking(index_t idx, velocypack::Slice const& slice,
       << "RAFT member fails to persist log entries!";
     FATAL_ERROR_EXIT();
   }
+  
+  auto byteSize = slice.byteSize();
+  auto buf = std::make_shared<Buffer<uint8_t>>(byteSize);
+  buf->append(slice.begin(), byteSize);
 
-  logEmplaceBackNoLock(log_t(idx, term, buf, clientId, millis));
+  logEmplaceBackNoLock(log_t(idx, term, std::move(buf), clientId, millis));
   _log_size += byteSize;
 
   return _log.back().index;
@@ -315,7 +330,6 @@ index_t State::logNonBlocking(index_t idx, velocypack::Slice const& slice,
 
 
 void State::logEmplaceBackNoLock(log_t&& l) {
-
   if (!l.clientId.empty()) {
     try {
       _clientIdLookupTable.emplace(  // keep track of client or die
@@ -326,7 +340,7 @@ void State::logEmplaceBackNoLock(log_t&& l) {
       FATAL_ERROR_EXIT();
     }
   }
-
+  
   try {
     _log.emplace_back(std::forward<log_t>(l));  // log to RAM or die
   } catch (std::bad_alloc const&) {
@@ -334,7 +348,6 @@ void State::logEmplaceBackNoLock(log_t&& l) {
       << "RAFT member fails to allocate volatile log entries!";
     FATAL_ERROR_EXIT();
   }
-
 }
 
 /// Log transactions (follower)

--- a/lib/Logger/LogTopic.cpp
+++ b/lib/Logger/LogTopic.cpp
@@ -110,6 +110,7 @@ class Topics {
 
 LogTopic Logger::AGENCY("agency", LogLevel::INFO);
 LogTopic Logger::AGENCYCOMM("agencycomm", LogLevel::INFO);
+LogTopic Logger::AGENCYSTORE("agencystore", LogLevel::WARN);
 LogTopic Logger::AQL("aql", LogLevel::INFO);
 LogTopic Logger::AUTHENTICATION("authentication", LogLevel::WARN);
 LogTopic Logger::AUTHORIZATION("authorization");
@@ -119,10 +120,8 @@ LogTopic Logger::CLUSTER("cluster", LogLevel::INFO);
 LogTopic Logger::CLUSTERCOMM("clustercomm", LogLevel::INFO);
 LogTopic Logger::COLLECTOR("collector");
 LogTopic Logger::COMMUNICATION("communication", LogLevel::INFO);
-LogTopic Logger::COMPACTOR("compactor");
 LogTopic Logger::CONFIG("config");
 LogTopic Logger::CRASH("crash");
-LogTopic Logger::DATAFILES("datafiles", LogLevel::INFO);
 LogTopic Logger::DEVEL("development", LogLevel::FATAL);
 LogTopic Logger::DUMP("dump", LogLevel::INFO);
 LogTopic Logger::ENGINES("engines", LogLevel::INFO);

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -142,6 +142,7 @@ class Logger {
  public:
   static LogTopic AGENCY;
   static LogTopic AGENCYCOMM;
+  static LogTopic AGENCYSTORE;
   static LogTopic AQL;
   static LogTopic AUTHENTICATION;
   static LogTopic AUTHORIZATION;
@@ -151,10 +152,8 @@ class Logger {
   static LogTopic CLUSTERCOMM;
   static LogTopic COLLECTOR;
   static LogTopic COMMUNICATION;
-  static LogTopic COMPACTOR;
   static LogTopic CONFIG;
   static LogTopic CRASH;
-  static LogTopic DATAFILES;
   static LogTopic DEVEL;
   static LogTopic DUMP;
   static LogTopic ENGINES;


### PR DESCRIPTION
### Scope & Purpose

Added optional verbose logging for agency write operations.
This logging is configurable by using the new log topic "agencystore".

The following log levels can be used for for the "agencystore" log topic to log writes to the agency:
* DEBUG: will log all writes on the leader
+ TRACE: will log all writes on both leaders and followers
The default log level for the "agencystore" log topic is WARN, meaning no agency writes will be logged.
Turning on this logging can be used for auditing and debugging, but it is not recommended in the general case, as it can lead to large amounts of data being logged, which can have a performance impact and will lead to higher disk space usage.

- [ ] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.7

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12164/