### PR TITLE
[3.7] Fix SORT in subqueries when crossing block boundaries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.7.3 (XXXX-XX-XX)
 -------------------
 
+* Fix #12693: SORT inside a subquery could sometimes swallow part of its input
+  when it crossed boundaries of internal row batches.
+
 * Added configuration option `--rocksdb.sync-delay-threshold`.
   This option can be used to track if any RocksDB WAL sync operations is 
   delayed by more than the configured value (in milliseconds). The intention

--- a/arangod/Aql/AllRowsFetcher.cpp
+++ b/arangod/Aql/AllRowsFetcher.cpp
@@ -26,8 +26,6 @@
 #include "Aql/AqlItemBlock.h"
 #include "Aql/AqlItemMatrix.h"
 #include "Aql/DependencyProxy.h"
-#include "Aql/InputAqlItemRow.h"
-#include "Aql/ShadowAqlItemRow.h"
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/AqlItemBlockInputMatrix.cpp
+++ b/arangod/Aql/AqlItemBlockInputMatrix.cpp
@@ -33,6 +33,9 @@ using namespace arangodb::aql;
 
 AqlItemBlockInputMatrix::AqlItemBlockInputMatrix(ExecutorState state)
     : _finalState{state}, _aqlItemMatrix{nullptr} {
+  // TODO As we only allow HASMORE, just use the default constructor and remove
+  //      this one.
+  TRI_ASSERT(state == ExecutorState::HASMORE);
   TRI_ASSERT(_aqlItemMatrix == nullptr);
   TRI_ASSERT(!hasDataRow());
 }
@@ -104,7 +107,10 @@ bool AqlItemBlockInputMatrix::hasDataRow() const noexcept {
   if (_aqlItemMatrix == nullptr) {
     return false;
   }
-  return (!_shadowRow.isInitialized() && _aqlItemMatrix->size() != 0);
+
+  return !hasShadowRow() && _aqlItemMatrix != nullptr &&
+         ((_aqlItemMatrix->stoppedOnShadowRow()) ||
+          (_aqlItemMatrix->size() > 0 && _finalState == ExecutorState::DONE));
 }
 
 std::pair<ExecutorState, ShadowAqlItemRow> AqlItemBlockInputMatrix::nextShadowRow() {

--- a/arangod/Aql/AqlItemMatrix.h
+++ b/arangod/Aql/AqlItemMatrix.h
@@ -72,7 +72,7 @@ class AqlItemMatrix {
    *
    * @return True if empty
    */
-  bool empty() const noexcept;
+  bool blocksEmpty() const noexcept;
 
   void clear();
 
@@ -106,7 +106,7 @@ class AqlItemMatrix {
  private:
   std::vector<SharedAqlItemBlockPtr> _blocks;
 
-  uint64_t _size;
+  uint64_t _numDataRows;
 
   RegisterCount _nrRegs;
   size_t _startIndexInFirstBlock{0};

--- a/arangod/Aql/SortExecutor.cpp
+++ b/arangod/Aql/SortExecutor.cpp
@@ -150,7 +150,6 @@ std::tuple<ExecutorState, NoStats, AqlCall> SortExecutor::produceRows(
     AqlItemBlockInputMatrix& inputMatrix, OutputAqlItemRow& output) {
   AqlCall upstreamCall{};
 
-  // if (inputMatrix.upstreamState() == ExecutorState::HASMORE) {
   if (!inputMatrix.hasDataRow()) {
     // If our inputMatrix does not contain all upstream rows
     return {inputMatrix.upstreamState(), NoStats{}, upstreamCall};

--- a/tests/Aql/AqlItemMatrixTest.cpp
+++ b/tests/Aql/AqlItemMatrixTest.cpp
@@ -43,7 +43,7 @@ TEST_F(AqlItemMatrixTest, expose_size_of_data_only) {
   auto& manager = this->manager();
 
   AqlItemMatrix testee(1);
-  EXPECT_TRUE(testee.empty());
+  EXPECT_TRUE(testee.blocksEmpty());
   {
     // 12
     auto block =
@@ -51,14 +51,14 @@ TEST_F(AqlItemMatrixTest, expose_size_of_data_only) {
                       {{1}, {2}, {3}, {4}, {1}, {2}, {3}, {4}, {1}, {2}, {3}, {4}});
     testee.addBlock(block);
   }
-  EXPECT_FALSE(testee.empty());
+  EXPECT_FALSE(testee.blocksEmpty());
   ASSERT_EQ(testee.size(), 12);
   {
     // 8
     auto block = buildBlock<1>(manager, {{1}, {2}, {3}, {4}, {1}, {2}, {3}, {4}});
     testee.addBlock(block);
   }
-  EXPECT_FALSE(testee.empty());
+  EXPECT_FALSE(testee.blocksEmpty());
   ASSERT_EQ(testee.size(), 20);
 
   {
@@ -66,7 +66,7 @@ TEST_F(AqlItemMatrixTest, expose_size_of_data_only) {
     auto block = buildBlock<1>(manager, {{1}, {2}, {3}, {4}, {1}, {2}, {3}, {4}, {1}});
     testee.addBlock(block);
   }
-  EXPECT_FALSE(testee.empty());
+  EXPECT_FALSE(testee.blocksEmpty());
   ASSERT_EQ(testee.size(), 29);
 }
 

--- a/tests/Aql/InputRangeTest.cpp
+++ b/tests/Aql/InputRangeTest.cpp
@@ -52,13 +52,12 @@ std::string const stateToString(ExecutorState state) {
 
 template <typename Range>
 class InputRangeTest : public AqlExecutorTestCase<> {
- private:
+ protected:
   // Used to holdData for InputMatrixTests
   AqlItemMatrix _matrix{1};
   // Picked a random number of dependencies for MultiInputRanges
   size_t _numberDependencies{3};
 
- protected:
   auto buildRange(ExecutorState state, SharedAqlItemBlockPtr block) -> Range {
     if constexpr (std::is_same_v<Range, AqlItemBlockInputRange>) {
       return AqlItemBlockInputRange{state, 0, block, 0};
@@ -135,8 +134,28 @@ TYPED_TEST_CASE_P(InputRangeTest);
 TYPED_TEST_P(InputRangeTest, test_default_initializer) {
   std::vector<ExecutorState> states{ExecutorState::DONE, ExecutorState::HASMORE};
   for (auto const& finalState : states) {
+    if (std::is_same_v<AqlItemBlockInputMatrix, TypeParam> &&
+        finalState == ExecutorState::DONE) {
+      // The AqlItemBlockInputMatrix may not be instantiated with DONE
+      continue;
+    }
     SCOPED_TRACE("Testing state: " + stateToString(finalState));
-    TypeParam testee{finalState};
+    auto testee = std::invoke([&]() {
+      if constexpr (std::is_same_v<TypeParam, AqlItemBlockInputMatrix>) {
+        if (finalState == ExecutorState::HASMORE) {
+          return TypeParam{finalState};
+        } else {
+          TRI_ASSERT(finalState == ExecutorState::DONE);
+          // AqlItemBlockInputMatrix may not be instantiated with DONE and
+          // without a matrix, thus this conditionals.
+          return TypeParam{finalState, &this->_matrix};
+        }
+      } else {
+        return TypeParam{finalState};
+      }
+    });
+    // assert is just for documentation
+    static_assert(std::is_same_v<decltype(testee), TypeParam>);
     if constexpr (std::is_same_v<decltype(testee), MultiAqlItemBlockInputRange>) {
       // Default has only 1 dependency
       EXPECT_EQ(testee.upstreamState(0), finalState);
@@ -179,7 +198,14 @@ TYPED_TEST_P(InputRangeTest, test_block_only_datarows) {
       EXPECT_EQ(testee.upstreamState(), ExecutorState::HASMORE);
     }
 
-    EXPECT_TRUE(testee.hasDataRow());
+    if constexpr (std::is_same_v<decltype(testee), AqlItemBlockInputMatrix>) {
+      // The AqlItemBlockInputMatrix may only report it has a data row when it
+      // knows it has consumed all input (of the current subquery iteration, if
+      // applicable).
+      EXPECT_EQ(testee.hasDataRow(), finalState == ExecutorState::DONE);
+    } else {
+      EXPECT_TRUE(testee.hasDataRow());
+    }
     EXPECT_FALSE(testee.hasShadowRow());
 
     // Required for expected Number Of Rows


### PR DESCRIPTION
Backport of https://github.com/arangodb/arangodb/pull/12752