### PR TITLE
Ensure failoverCandidates have no servers not in Plan.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,10 @@
 v3.6.7.2 (XXXX-XX-XX)
+---------------------
 
 * Fixed handling of failoverCandidates. Sometimes, a server can still be a
   failoverCandidate even though it has been taken out of the Plan. With this
-  fix, such a server is quickly taken out of failoverCandidates and it can
-  never be re-added to the Plan before this has happened.
+  fix, such a server is quickly taken out of failoverCandidates and it can never
+  be re-added to the Plan before this has happened.
 
 
 v3.6.7.1 (2020-10-03)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+v3.6.7.2 (XXXX-XX-XX)
+
+* Fixed handling of failoverCandidates. Sometimes, a server can still be a
+  failoverCandidate even though it has been taken out of the Plan. With this
+  fix, such a server is quickly taken out of failoverCandidates and it can
+  never be re-added to the Plan before this has happened.
+
+
 v3.6.7.1 (2020-10-03)
 ---------------------
 

--- a/arangod/Agency/AddFollower.cpp
+++ b/arangod/Agency/AddFollower.cpp
@@ -204,6 +204,19 @@ bool AddFollower::start(bool&) {
     }
   }
 
+  // Exclude servers in failoverCandidates for some clone and those in Plan:
+  auto shardsLikeMe = clones(_snapshot, _database, _collection, _shard);
+  auto failoverCands = Job::findAllFailoverCandidates(
+      _snapshot, _database, shardsLikeMe);
+  it = available.begin();
+  while (it != available.end()) {
+    if (failoverCands.find(*it) != failoverCands.end()) {
+      it = available.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
   // Check that we have enough:
   if (available.size() < desiredReplFactor - actualReplFactor) {
     LOG_TOPIC("50086", DEBUG, Logger::SUPERVISION)
@@ -225,8 +238,6 @@ bool AddFollower::start(bool&) {
   }
 
   // Now we can act, simply add all in chosen to all plans for all shards:
-  std::vector<Job::shard_t> shardsLikeMe =
-      clones(_snapshot, _database, _collection, _shard);
 
   // Copy todo to finished:
   Builder todo, trx;
@@ -291,6 +302,20 @@ bool AddFollower::start(bool&) {
       VPackObjectBuilder precondition(&trx);
       // --- Check that Planned servers are still as we expect
       addPreconditionUnchanged(trx, planPath, planned);
+      // Check that failoverCandidates are still as we inspected them:
+      doForAllShards(_snapshot, _database, shardsLikeMe,
+          [this, &trx](Slice plan, Slice current,
+                           std::string& planPath,
+                           std::string& curPath) {
+            // take off "servers" from curPath and add
+            // "failoverCandidates":
+            std::string foCandsPath = curPath.substr(0, curPath.size() - 7);
+            foCandsPath += StaticStrings::FailoverCandidates;
+            auto foCands = this->_snapshot.hasAsSlice(foCandsPath);
+            if (foCands.second) {
+              addPreconditionUnchanged(trx, foCandsPath, foCands.first);
+            }
+          });
       addPreconditionShardNotBlocked(trx, _shard);
       for (auto const& srv : chosen) {
         addPreconditionServerHealth(trx, srv, "GOOD");

--- a/arangod/Agency/FailedFollower.cpp
+++ b/arangod/Agency/FailedFollower.cpp
@@ -166,8 +166,25 @@ bool FailedFollower::start(bool& aborts) {
     return false;
   }
 
-  // Get proper replacement
-  _to = randomIdleAvailableServer(_snapshot, planned);
+  // Exclude servers in failoverCandidates for some clone and those in Plan:
+  auto shardsLikeMe = clones(_snapshot, _database, _collection, _shard);
+  auto failoverCands = Job::findAllFailoverCandidates(
+      _snapshot, _database, shardsLikeMe);
+  std::vector<std::string> excludes;
+  for (const auto& s : VPackArrayIterator(planned)) {
+    if (s.isString()) {
+      std::string id = s.copyString();
+      if (failoverCands.find(id) == failoverCands.end()) {
+        excludes.push_back(s.copyString());
+      }
+    }
+  }
+  for (auto const& id : failoverCands) {
+    excludes.push_back(id);
+  }
+
+  // Get proper replacement:
+  _to = randomIdleAvailableServer(_snapshot, excludes);
   if (_to.empty()) {
     finish("", _shard, false, "Did not find available alternative server");
     return false;
@@ -242,7 +259,7 @@ bool FailedFollower::start(bool& aborts) {
         }
         addRemoveJobFromSomewhere(job, "ToDo", _jobId);
         // Plan change ------------
-        for (auto const& clone : clones(_snapshot, _database, _collection, _shard)) {
+        for (auto const& clone : shardsLikeMe) {
           job.add(planColPrefix + _database + "/" + clone.collection +
                       "/shards/" + clone.shard,
                   ns.slice());
@@ -259,7 +276,22 @@ bool FailedFollower::start(bool& aborts) {
           VPackObjectBuilder stillExists(&job);
           job.add("old", VPackValue("FAILED"));
         }
+        // Plan still as we see it:
         addPreconditionUnchanged(job, planPath, planned);
+        // Check that failoverCandidates are still as we inspected them:
+        doForAllShards(_snapshot, _database, shardsLikeMe,
+            [this, &job](Slice plan, Slice current,
+                             std::string& planPath,
+                             std::string& curPath) {
+              // take off "servers" from curPath and add
+              // "failoverCandidates":
+              std::string foCandsPath = curPath.substr(0, curPath.size() - 7);
+              foCandsPath += StaticStrings::FailoverCandidates;
+              auto foCands = this->_snapshot.hasAsSlice(foCandsPath);
+              if (foCands.second) {
+                addPreconditionUnchanged(job, foCandsPath, foCands.first);
+              }
+            });
         // toServer not blocked
         addPreconditionServerNotBlocked(job, _to);
         // shard not blocked

--- a/arangod/Agency/FailedLeader.cpp
+++ b/arangod/Agency/FailedLeader.cpp
@@ -238,8 +238,25 @@ bool FailedLeader::start(bool& aborts) {
     }
   }
 
+  // Exclude servers in failoverCandidates for some clone and those in Plan:
+  auto shardsLikeMe = clones(_snapshot, _database, _collection, _shard);
+  auto failoverCands = Job::findAllFailoverCandidates(
+      _snapshot, _database, shardsLikeMe);
+  std::vector<std::string> excludes;
+  for (const auto& s : VPackArrayIterator(planned)) {
+    if (s.isString()) {
+      std::string id = s.copyString();
+      if (failoverCands.find(id) == failoverCands.end()) {
+        excludes.push_back(s.copyString());
+      }
+    }
+  }
+  for (auto const& id : failoverCands) {
+    excludes.push_back(id);
+  }
+
   // Additional follower, if applicable
-  auto additionalFollower = randomIdleAvailableServer(_snapshot, planned);
+  auto additionalFollower = randomIdleAvailableServer(_snapshot, excludes);
   if (!additionalFollower.empty()) {
     planv.push_back(additionalFollower);
   }
@@ -292,7 +309,7 @@ bool FailedLeader::start(bool& aborts) {
             ns.add(VPackValue(i));
           }
         }
-        for (auto const& clone : clones(_snapshot, _database, _collection, _shard)) {
+        for (auto const& clone : shardsLikeMe) {
           pending.add(planColPrefix + _database + "/" + clone.collection +
                           "/shards/" + clone.shard,
                       ns.slice());
@@ -309,13 +326,22 @@ bool FailedLeader::start(bool& aborts) {
         addPreconditionServerHealth(pending, _to, "GOOD");
         // Server list in plan still as before
         addPreconditionUnchanged(pending, planPath, planned);
-        // Server list in Current still as known
-        addPreconditionUnchanged(pending, curPath + "/servers", current);
-        // Failover candidates in Current still as known
-        auto const& failoverCandidates = _snapshot.hasAsSlice(curPath + "/failoverCandidates");
-        if (failoverCandidates.second) {
-          addPreconditionUnchanged(pending, curPath + "/failoverCandidates", failoverCandidates.first);
-        }
+        // Check that Current/servers and failoverCandidates are still as
+        // we inspected them:
+        doForAllShards(_snapshot, _database, shardsLikeMe,
+            [this, &pending](Slice plan, Slice current,
+                             std::string& planPath,
+                             std::string& curPath) {
+              addPreconditionUnchanged(pending, curPath, current);
+              // take off "servers" from curPath and add
+              // "failoverCandidates":
+              std::string foCandsPath = curPath.substr(0, curPath.size() - 7);
+              foCandsPath += StaticStrings::FailoverCandidates;
+              auto foCands = this->_snapshot.hasAsSlice(foCandsPath);
+              if (foCands.second) {
+                addPreconditionUnchanged(pending, foCandsPath, foCands.first);
+              }
+            });
         // Destination server should not be blocked by another job
         addPreconditionServerNotBlocked(pending, _to);
         // Shard to be handled is block by another job

--- a/arangod/Agency/Job.cpp
+++ b/arangod/Agency/Job.cpp
@@ -459,6 +459,7 @@ std::vector<Job::shard_t> Job::clones(Node const& snapshot, std::string const& d
 std::string Job::findNonblockedCommonHealthyInSyncFollower(  // Which is in "GOOD" health
     Node const& snap, std::string const& db, std::string const& col, std::string const& shrd,
     std::string const& serverToAvoid) {
+
   // serverToAvoid is the leader for which we are seeking a replacement. Note that
   // it is not a given that this server is the first one in Current/servers or
   // Current/failoverCandidates.
@@ -545,6 +546,35 @@ std::string Job::findNonblockedCommonHealthyInSyncFollower(  // Which is in "GOO
   }
 
   return std::string();
+}
+
+/// @brief The shard must be one of a collection without
+/// `distributeShardsLike`. This returns all servers which
+/// are in `failoverCandidates` for this shard or for any of its clones.
+std::unordered_set<std::string> Job::findAllFailoverCandidates(
+    Node const& snap,
+    std::string const& db,
+    std::vector<Job::shard_t> const& shardsLikeMe) {
+
+  std::unordered_set<std::string> result;
+
+  for (const auto& clone : shardsLikeMe) {
+    auto sharedPath = db + "/" + clone.collection + "/";
+    auto currentFailoverCandidatesPath =
+        curColPrefix + sharedPath + clone.shard + "/failoverCandidates";
+    bool isArray = false;
+    VPackSlice serverList;
+    // If we do have failover candidates, we should use them
+    std::tie(serverList, isArray) = snap.hasAsArray(currentFailoverCandidatesPath);
+    if (isArray) {
+      for (const auto& server : VPackArrayIterator(serverList)) {
+        auto id = server.copyString();
+        result.insert(id);
+      }
+    }
+  }
+
+  return result;
 }
 
 std::string Job::uuidLookup(std::string const& shortID) {

--- a/arangod/Agency/Job.h
+++ b/arangod/Agency/Job.h
@@ -158,6 +158,14 @@ struct Job {
                                                                std::string const& shrd,
                                                                std::string const& serverToAvoid);
 
+  /// @brief The shard must be one of a collection without
+  /// `distributeShardsLike`. This returns all servers which 
+  /// are in `failoverCandidates` for this shard or for any of its clones.
+  static std::unordered_set<std::string> findAllFailoverCandidates(
+      Node const& snap,
+      std::string const& db,
+      std::vector<Job::shard_t> const& shardsLikeMe);
+
   JOB_STATUS _status;
   Node const& _snapshot;
   AgentInterface* _agent;

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -25,6 +25,7 @@
 
 #include "Agency/AgentInterface.h"
 #include "Agency/Job.h"
+#include "Basics/StaticStrings.h"
 #include "Cluster/ClusterHelpers.h"
 
 using namespace arangodb;
@@ -272,11 +273,13 @@ bool MoveShard::start(bool&) {
   TRI_ASSERT(planned.isArray());
 
   int found = -1;
+  int foundTo = -1;
   int count = 0;
   _toServerIsFollower = false;
   for (VPackSlice srv : VPackArrayIterator(planned)) {
     TRI_ASSERT(srv.isString());
     if (srv.copyString() == _to) {
+      foundTo = count;
       if (!_isLeader) {
         finish("", "", false, "toServer must not be planned for a following shard");
         return false;
@@ -298,6 +301,19 @@ bool MoveShard::start(bool&) {
     return false;
   }
 
+  // Compute group to move shards together:
+  std::vector<Job::shard_t> shardsLikeMe =
+      clones(_snapshot, _database, _collection, _shard);
+
+  if (foundTo < 0) { // _to not in Plan, then it must not be a failoverCandidate:
+    auto failoverCands = Job::findAllFailoverCandidates(
+        _snapshot, _database, shardsLikeMe);
+    if (failoverCands.find(_to) != failoverCands.end()) {
+      finish("", "", false, "toServer must not be in failoverCandidates for shard or any of its distributeShardsLike colleagues");
+      return false;
+    }
+  }
+
   if (!_isLeader) {
     if (_remainsFollower) {
       finish("", "", false, "remainsFollower is invalid without isLeader");
@@ -309,10 +325,6 @@ bool MoveShard::start(bool&) {
       return false;
     }
   }
-
-  // Compute group to move shards together:
-  std::vector<Job::shard_t> shardsLikeMe =
-      clones(_snapshot, _database, _collection, _shard);
 
   // Copy todo to pending
   Builder todo, pending;
@@ -392,6 +404,20 @@ bool MoveShard::start(bool&) {
 
       // --- Check that Planned servers are still as we expect
       addPreconditionUnchanged(pending, planPath, planned);
+      // Check that failoverCandidates are still as we inspected them:
+      doForAllShards(_snapshot, _database, shardsLikeMe,
+          [this, &pending](Slice plan, Slice current,
+                           std::string& planPath,
+                           std::string& curPath) {
+            // take off "servers" from curPath and add
+            // "failoverCandidates":
+            std::string foCandsPath = curPath.substr(0, curPath.size() - 7);
+            foCandsPath += StaticStrings::FailoverCandidates;
+            auto foCands = this->_snapshot.hasAsSlice(foCandsPath);
+            if (foCands.second) {
+              addPreconditionUnchanged(pending, foCandsPath, foCands.first);
+            }
+          });
       addPreconditionShardNotBlocked(pending, _shard);
       addPreconditionServerNotBlocked(pending, _to);
       addPreconditionServerHealth(pending, _to, "GOOD");

--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -162,12 +162,19 @@ Result FollowerInfo::remove(ServerID const& sid) {
                                          // local data is modified again.
 
   // First check if there is anything to do:
-  if (std::find(_followers->begin(), _followers->end(), sid) == _followers->end()) {
-    TRI_ASSERT(std::find(_failoverCandidates->begin(), _failoverCandidates->end(),
-                         sid) == _failoverCandidates->end());
+  if (std::find(_followers->begin(), _followers->end(), sid)
+        == _followers->end() &&
+      std::find(_failoverCandidates->begin(), _failoverCandidates->end(), sid)
+        == _failoverCandidates->end()) {
     return {TRI_ERROR_NO_ERROR};  // nothing to do
   }
-  // Both lists have to be in sync at any time!
+  // Both lists have to be in sync most of the time, sometimes the
+  // _failoverCandidates have additional servers, and sometimes, this
+  // code here is called to remove a server from the _failoverCandidates,
+  // even if it is not on _followers. There should never be a follower
+  // which is in _followers but not in _failoverCandidates. Therefore,
+  // there should never be a call to remove here for a server which is
+  // not in the failoverCandidates.
   TRI_ASSERT(std::find(_failoverCandidates->begin(), _failoverCandidates->end(),
                        sid) != _failoverCandidates->end());
   auto oldFollowers = _followers;

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -234,19 +234,32 @@ void handlePlanShard(VPackSlice const& cprops, VPackSlice const& ldb,
     // Check if there is some in-sync-follower which is no longer in the Plan:
     std::string followersToDropString;
     if (leading && shouldBeLeading) {
-      VPackSlice shards = cprops.get("shards");
-      if (shards.isObject()) {
-        VPackSlice planServers = shards.get(shname);
-        if (planServers.isArray()) {
-          VPackSlice inSyncFollowers = lcol.get("servers");
-          if (inSyncFollowers.isArray()) {
-            // Now we have two server lists, we are looking for a server
-            // which does not occur in the plan, but is in the followers
-            // at an index > 0:
+      TRI_IF_FAILURE("Maintenance::doNotRemoveUnPlannedFollowers") {
+        LOG_TOPIC("de342", ERR, Logger::MAINTENANCE)
+          << "Skipping check for followers not in Plan because of failure point.";
+      } else {
+        VPackSlice shards = cprops.get("shards");
+        if (shards.isObject()) {
+          VPackSlice planServers = shards.get(shname);
+          if (planServers.isArray()) {
             std::unordered_set<std::string> followersToDrop;
-            for (auto const& q : VPackArrayIterator(inSyncFollowers)) {
-              followersToDrop.insert(q.copyString());
+            // Now we have two server lists (servers and
+            // failoverCandidates, we are looking for a server which
+            // occurs in either of them but not in the plan
+            VPackSlice serverList = lcol.get("servers");
+            if (serverList.isArray()) {
+              for (auto const& q : VPackArrayIterator(serverList)) {
+                followersToDrop.insert(q.copyString());
+              }
             }
+            serverList = lcol.get(StaticStrings::FailoverCandidates);
+            if (serverList.isArray()) {
+              // And again for the failoverCandidates:
+              for (auto const& q : VPackArrayIterator(serverList)) {
+                followersToDrop.insert(q.copyString());
+              }
+            }
+            // Remove those in Plan:
             for (auto const& p : VPackArrayIterator(planServers)) {
               if (p.isString()) {
                 followersToDrop.erase(p.copyString());

--- a/arangod/Cluster/v8-cluster.cpp
+++ b/arangod/Cluster/v8-cluster.cpp
@@ -789,6 +789,15 @@ static void JS_GetCollectionInfoCurrentClusterInfo(v8::FunctionCallbackInfo<v8::
   result->Set(TRI_V8_ASCII_STRING(isolate, "servers"), list);
   result->Set(TRI_V8_ASCII_STRING(isolate, "shorts"), shorts);
 
+  servers = cic->failoverCandidates(shardID);
+  list = v8::Array::New(isolate, static_cast<int>(servers.size()));
+  pos = 0;
+  for (auto const& s : servers) {
+    list->Set(pos, TRI_V8_STD_STRING(isolate, s));
+    pos++;
+  }
+  result->Set(TRI_V8_ASCII_STRING(isolate, "failoverCandidates"), list);
+
   TRI_V8_RETURN(result);
   TRI_V8_TRY_CATCH_END
 }

--- a/tests/js/server/resilience/failover-failure/resilience-synchronous-repl-failureAt-cluster.js
+++ b/tests/js/server/resilience/failover-failure/resilience-synchronous-repl-failureAt-cluster.js
@@ -132,6 +132,16 @@ function SynchronousReplicationSuite() {
       replicas = ccinfo.map(s => s.servers.length);
       if (replicas.every(x => x > 1)) {
         console.info("Replication up and running!");
+        // The following wait has a purpose, so please do not remove it.
+        // We have just seen that all followers are in sync. However, this
+        // means that the leader has told the agency so, it has not necessarily
+        // responded to the followers, so they might still be in
+        // SynchronizeShard. If we STOP the leader too quickly in a subsequent
+        // test, then the follower might get stuck in SynchronizeShard
+        // and the expected failover cannot happen. A second should be plenty
+        // of time to receive the response and finish the SynchronizeShard
+        // operation.
+        wait(1);
         return true;
       }
       wait(0.5);

--- a/tests/js/server/resilience/failover-view/resilience-synchronous-repl-with-arangosearch-view-cluster-grey.js
+++ b/tests/js/server/resilience/failover-view/resilience-synchronous-repl-with-arangosearch-view-cluster-grey.js
@@ -98,6 +98,16 @@ function SynchronousReplicationWithViewSuite () {
       replicas = ccinfo.map(s => s.servers.length);
       if (replicas.every(x => x > 1)) {
         console.info("Replication up and running!");
+        // The following wait has a purpose, so please do not remove it.
+        // We have just seen that all followers are in sync. However, this
+        // means that the leader has told the agency so, it has not necessarily
+        // responded to the followers, so they might still be in
+        // SynchronizeShard. If we STOP the leader too quickly in a subsequent
+        // test, then the follower might get stuck in SynchronizeShard
+        // and the expected failover cannot happen. A second should be plenty
+        // of time to receive the response and finish the SynchronizeShard
+        // operation.
+        wait(1);
         return true;
       }  
       wait(0.5);

--- a/tests/js/server/resilience/failover/resilience-synchronous-repl-cluster.js
+++ b/tests/js/server/resilience/failover/resilience-synchronous-repl-cluster.js
@@ -84,9 +84,22 @@ function SynchronousReplicationSuite () {
         s => global.ArangoClusterInfo.getCollectionInfoCurrent(database, cn, s)
       );
       console.info("Plan:", cinfo.shards, "Current:", ccinfo.map(s => s.servers));
-      replicas = ccinfo.map(s => s.servers.length);
-      if (replicas.every(x => x > 1)) {
+      replicas = ccinfo.map(s => [s.servers.length, s.failoverCandidates.length]);
+      if (replicas.every(x => x[0] > 1 && x[0] === x[1])) {
+        // This also checks that there are as many failoverCandidates
+        // as there are followers in sync. This should eventually be
+        // reached.
         console.info("Replication up and running!");
+        // The following wait has a purpose, so please do not remove it.
+        // We have just seen that all followers are in sync. However, this
+        // means that the leader has told the agency so, it has not necessarily
+        // responded to the followers, so they might still be in
+        // SynchronizeShard. If we STOP the leader too quickly in a subsequent
+        // test, then the follower might get stuck in SynchronizeShard
+        // and the expected failover cannot happen. A second should be plenty
+        // of time to receive the response and finish the SynchronizeShard
+        // operation.
+        wait(1);
         return true;
       }
       wait(0.5);

--- a/tests/js/server/resilience/move-view/moving-shards-with-arangosearch-view-grey-cluster-disabled.js
+++ b/tests/js/server/resilience/move-view/moving-shards-with-arangosearch-view-grey-cluster-disabled.js
@@ -140,8 +140,11 @@ function MovingShardsWithViewSuite (options) {
           s => global.ArangoClusterInfo.getCollectionInfoCurrent(
             database, c[i].name(), s)
         );
-        let replicas = ccinfo.map(s => s.servers.length);
-        if (_.every(replicas, x => x === replFactor)) {
+        var replicas = ccinfo.map(s => [s.servers.length, s.failoverCandidates.length]);
+        if (replicas.every(x => x[0] === replFactor && x[0] === x[1])) {
+          // This also checks that there are as many failoverCandidates
+          // as there are followers in sync. This should eventually be
+          // reached.
           console.info("Replication up and running!");
           break;
         }

--- a/tests/js/server/resilience/move/moving-shards-cluster.js
+++ b/tests/js/server/resilience/move/moving-shards-cluster.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/*global assertTrue, assertEqual, ArangoAgency */
+/*global assertTrue, assertEqual, ArangoAgency, ArangoClusterInfo */
 'use strict';
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -32,10 +32,12 @@ const jsunity = require("jsunity");
 const arangodb = require("@arangodb");
 const db = arangodb.db;
 const _ = require("lodash");
-const wait = require("internal").wait;
+const internal = require("internal");
+const wait = internal.wait;
 const supervisionState = require("@arangodb/cluster").supervisionState;
 const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
-const errors = require("internal").errors;
+const errors = internal.errors;
+const request = require('@arangodb/request');
 
 // in the `useData` case, use this many documents:
 const numDocuments = 1000;
@@ -50,6 +52,44 @@ function getDBServers() {
 }
 
 var servers = getDBServers();
+
+function getEndpointById(id) {
+  const endpointToURL = (endpoint) => {
+    if (endpoint.substr(0, 6) === 'ssl://') {
+      return 'https://' + endpoint.substr(6);
+    }
+    let pos = endpoint.indexOf('://');
+    if (pos === -1) {
+      return 'http://' + endpoint;
+    }
+    return 'http' + endpoint.substr(pos);
+  };
+
+  const endpoint = ArangoClusterInfo.getServerEndpoint(id);
+  return endpointToURL(endpoint);
+}
+
+/// @brief set failure point
+function debugSetFailAt(endpoint, failAt) {
+  let res = request.put({
+    url: endpoint + '/_admin/debug/failat/' + failAt,
+    body: ""
+  });
+  if (res.status !== 200) {
+    throw "Error setting failure point";
+  }
+}
+
+/// @brief remove failure points
+function debugClearFailAt(endpoint) {
+  let res = request.delete({
+    url: endpoint + '/_admin/debug/failat',
+    body: ""
+  });
+  if (res.status !== 200) {
+    throw "Error removing failure points";
+  }
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test suite
@@ -92,8 +132,11 @@ function MovingShardsSuite ({useData}) {
           s => global.ArangoClusterInfo.getCollectionInfoCurrent(
             database, c[i].name(), s)
         );
-        let replicas = ccinfo.map(s => s.servers.length);
-        if (_.every(replicas, x => x === replFactor)) {
+        var replicas = ccinfo.map(s => [s.servers.length, s.failoverCandidates.length]);
+        if (replicas.every(x => x[0] === replFactor && x[0] === x[1])) {
+          // This also checks that there are as many failoverCandidates
+          // as there are followers in sync. This should eventually be
+          // reached.
           console.info("Replication up and running!");
           break;
         }
@@ -103,6 +146,39 @@ function MovingShardsSuite ({useData}) {
       if (count > 120) {
         return false;
       }
+    }
+    return true;
+  }
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief wait for an incomplete moveShard to have happened, this is a
+/// very special test for "testMoveShardFromFollowerRepl3_failoverCands".
+////////////////////////////////////////////////////////////////////////////////
+
+  function waitForIncompleteMoveShard(database, collection, replFactor) {
+    console.info("Waiting for incomplete move shard to settle...");
+    global.ArangoClusterInfo.flush();
+    var cinfo = global.ArangoClusterInfo.getCollectionInfo( database, collection);
+    var shards = Object.keys(cinfo.shards);
+    var count = 0;
+    while (++count <= 180) {
+      var ccinfo = shards.map(
+        s => global.ArangoClusterInfo.getCollectionInfoCurrent(
+          database, collection, s)
+      );
+      var replicas = ccinfo.map(s => [s.servers.length, s.failoverCandidates.length]);
+      if (replicas.every(x => x[0] === replFactor + 1 && x[0] === x[1])) {
+        // This also checks that there are as many failoverCandidates
+        // as there are followers in sync. This should eventually be
+        // reached.
+        console.info("Incomplete moveShard completed!");
+        break;
+      }
+      wait(0.5);
+      global.ArangoClusterInfo.flush();
+    }
+    if (count > 120) {
+      return false;
     }
     return true;
   }
@@ -322,7 +398,7 @@ function MovingShardsSuite ({useData}) {
           + JSON.stringify(body));
         return false;
       }
-      require("internal").wait(1.0);
+      wait(1.0);
     }
   }
 
@@ -363,7 +439,7 @@ function MovingShardsSuite ({useData}) {
           + JSON.stringify(body));
         return false;
       }
-      require("internal").wait(1.0);
+      wait(1.0);
     }
   }
 
@@ -441,7 +517,7 @@ function MovingShardsSuite ({useData}) {
 /// @brief move a single shard
 ////////////////////////////////////////////////////////////////////////////////
 
-  function moveShard(database, collection, shard, fromServer, toServer, dontwait) {
+  function moveShard(database, collection, shard, fromServer, toServer, dontwait, expectedResult) {
     var coordEndpoint =
         global.ArangoClusterInfo.getServerEndpoint("Coordinator0001");
     var request = require("@arangodb/request");
@@ -468,7 +544,7 @@ function MovingShardsSuite ({useData}) {
     while (true) {
       var job = require("@arangodb/cluster").queryAgencyJob(result.json.id);
       console.info("Status of moveShard job:", job.status);
-      if (job.error === false && job.status === "Finished") {
+      if (job.error === false && job.status === expectedResult) {
         return result;
       }
       if (count-- < 0) {
@@ -477,7 +553,7 @@ function MovingShardsSuite ({useData}) {
           + JSON.stringify(body));
         return false;
       }
-      require("internal").wait(1.0);
+      wait(1.0);
     }
   }
 
@@ -675,7 +751,7 @@ function MovingShardsSuite ({useData}) {
       var cinfo = global.ArangoClusterInfo.getCollectionInfo(
           "_system", c[0].name());
       var shard = Object.keys(cinfo.shards)[0];
-      assertTrue(moveShard("_system", c[0]._id, shard, fromServer, toServer, false));
+      assertTrue(moveShard("_system", c[0]._id, shard, fromServer, toServer, false, "Finished"));
       assertTrue(testServerEmpty(fromServer), false);
       assertTrue(waitForSupervision());
       checkCollectionContents();
@@ -693,7 +769,7 @@ function MovingShardsSuite ({useData}) {
       var cinfo = global.ArangoClusterInfo.getCollectionInfo(
           "_system", c[0].name());
       var shard = Object.keys(cinfo.shards)[0];
-      assertTrue(moveShard("_system", c[0]._id, shard, fromServer, toServer, false));
+      assertTrue(moveShard("_system", c[0]._id, shard, fromServer, toServer, false, "Finished"));
       assertTrue(testServerEmpty(fromServer), false);
       assertTrue(waitForSupervision());
       checkCollectionContents();
@@ -712,7 +788,7 @@ function MovingShardsSuite ({useData}) {
       var cinfo = global.ArangoClusterInfo.getCollectionInfo(
           "_system", c[1].name());
       var shard = Object.keys(cinfo.shards)[0];
-      assertTrue(moveShard("_system", c[1]._id, shard, fromServer, toServer, false));
+      assertTrue(moveShard("_system", c[1]._id, shard, fromServer, toServer, false, "Finished"));
       assertTrue(testServerEmpty(fromServer, false, 1, 1));
       assertTrue(waitForSupervision());
       checkCollectionContents();
@@ -731,7 +807,7 @@ function MovingShardsSuite ({useData}) {
       var cinfo = global.ArangoClusterInfo.getCollectionInfo(
           "_system", c[1].name());
       var shard = Object.keys(cinfo.shards)[0];
-      assertTrue(moveShard("_system", c[1]._id, shard, fromServer, toServer, false));
+      assertTrue(moveShard("_system", c[1]._id, shard, fromServer, toServer, false, "Finished"));
       assertTrue(testServerEmpty(fromServer, false, 1, 1));
       assertTrue(waitForSupervision());
       checkCollectionContents();
@@ -750,7 +826,7 @@ function MovingShardsSuite ({useData}) {
       var cinfo = global.ArangoClusterInfo.getCollectionInfo(
           "_system", c[1].name());
       var shard = Object.keys(cinfo.shards)[0];
-      assertTrue(moveShard("_system", c[1]._id, shard, fromServer, toServer, false));
+      assertTrue(moveShard("_system", c[1]._id, shard, fromServer, toServer, false, "Finished"));
       assertTrue(testServerEmpty(fromServer, false, 1, 1));
       assertTrue(waitForSupervision());
       checkCollectionContents();
@@ -769,7 +845,7 @@ function MovingShardsSuite ({useData}) {
       var cinfo = global.ArangoClusterInfo.getCollectionInfo(
           "_system", c[1].name());
       var shard = Object.keys(cinfo.shards)[0];
-      assertTrue(moveShard("_system", c[1]._id, shard, fromServer, toServer, false));
+      assertTrue(moveShard("_system", c[1]._id, shard, fromServer, toServer, false, "Finished"));
       assertTrue(testServerEmpty(fromServer, false, 1, 1));
       assertTrue(waitForSupervision());
       checkCollectionContents();
@@ -788,7 +864,7 @@ function MovingShardsSuite ({useData}) {
       var cinfo = global.ArangoClusterInfo.getCollectionInfo(
           "_system", c[1].name());
       var shard = Object.keys(cinfo.shards)[0];
-      assertTrue(moveShard("_system", c[1]._id, shard, fromServer, toServer, false));
+      assertTrue(moveShard("_system", c[1]._id, shard, fromServer, toServer, false, "Finished"));
       assertTrue(testServerNoLeader(fromServer, 1, 1));
       assertTrue(waitForSupervision());
       checkCollectionContents();
@@ -912,7 +988,7 @@ function MovingShardsSuite ({useData}) {
           "_system", c[1].name());
       var shard = Object.keys(cinfo.shards)[0];
       assertTrue(maintenanceMode("on"));
-      assertTrue(moveShard("_system", c[1]._id, shard, fromServer, toServer, true));
+      assertTrue(moveShard("_system", c[1]._id, shard, fromServer, toServer, true, "Finished"));
       var first = global.ArangoAgency.transient([["/arango/Supervision/State"]])[0].
           arango.Supervision.State, state;
       var waitUntil = new Date().getTime() + 30.0*1000;
@@ -934,9 +1010,49 @@ function MovingShardsSuite ({useData}) {
       checkCollectionContents();
     },
 
+////////////////////////////////////////////////////////////////////////////////
+/// @brief pausing supervision for a couple of seconds
+////////////////////////////////////////////////////////////////////////////////
+
+    testMoveShardFromFollowerRepl3_failoverCands : function() {
+      if (!internal.debugCanUseFailAt()) {
+        console.log("Skipping test for failoverCandidates because failure points are not compiled in!");
+        return;
+      }
+      createSomeCollections(1, 1, 3, useData);
+      assertTrue(waitForSynchronousReplication("_system"));
+      var servers = findCollectionServers("_system", c[1].name());
+      var leader = servers[0];
+      var fromServer = servers[1];
+      var leaderEndpoint = getEndpointById(leader);
+      // Switch off something in the maintenance on the leader to detect
+      // followers which are not in Plan. This means that the moveShard
+      // below will leave the old server in Current/servers and
+      // Current/failoverCandidates.
+      debugSetFailAt(leaderEndpoint, "Maintenance::doNotRemoveUnPlannedFollowers");
+
+      var toServer = findServerNotOnList(servers);
+      var cinfo = global.ArangoClusterInfo.getCollectionInfo(
+          "_system", c[1].name());
+      var shard = Object.keys(cinfo.shards)[0];
+      assertTrue(moveShard("_system", c[1]._id, shard, fromServer, toServer, false, "Finished"));
+      assertTrue(waitForIncompleteMoveShard("_system", c[1].name(), 3));
+      wait(5);   // After 5 seconds the situation should be unchanged!
+      assertTrue(waitForIncompleteMoveShard("_system", c[1].name(), 3));
+      // Now we know that the old follower is not in the plan but is in
+      // failoverCandidates (and indeed in Current/servers). Let's now
+      // try to move the shard back, this ought to be denied:
+      assertTrue(moveShard("_system", c[1]._id, shard, toServer, fromServer, false, "Failed"));
+      debugClearFailAt(leaderEndpoint);
+      // Now we should go back to only 3 servers in Current.
+      assertTrue(waitForSynchronousReplication("_system"));
+      assertTrue(testServerEmpty(fromServer, false, 1, 1));
+      assertTrue(waitForSupervision());
+      checkCollectionContents();
+    },
+
   };
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief executes the test suite


### PR DESCRIPTION
Fix failoverCandidates for servers not in Plan.

Problem: we must never fail over to a server which is not in Plan
because it might not have the data.

TODO:

 - [X] AddFollower, FailedFollower, CleanOutServer and MoveShard will not
       add a server to the Plan which is in failoverCandidates for this
       shard or any of the ones with distributeShardsLike.
 - [X] add preconditions to ensure that it is snapshot-safe
 - [X] make dbserver Maintenance remove servers that are not in Plan from
       failoverCandidates.
