### PR TITLE
If we fail to switch the database, flush the cache too.

### DIFF
--- a/js/client/modules/@arangodb/arango-database.js
+++ b/js/client/modules/@arangodb/arango-database.js
@@ -1088,6 +1088,7 @@ ArangoDatabase.prototype._useDatabase = function (name) {
     this._queryProperties(true);
     this._flushCache();
   } catch (err) {
+    this._flushCache();
     this._connection.setDatabaseName(old);
 
     if (err.hasOwnProperty('errorNum')) {


### PR DESCRIPTION
### Scope & Purpose
The client (arangosh) needs to re-assure with the server what the current state
is after the error. A cache must not stop that from happening - hence
flush it.

This miss-behaviour was discovered while using arangosh for load-testing. 

- [x] :hankey: Bugfix 
#### Backports:
- [ ] No backports required
- [ ] Backports required for: *(Please specify versions)*
