### PR TITLE
always show documents for a collection in web interface

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/collections/arangoDocuments.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/collections/arangoDocuments.js
@@ -267,16 +267,14 @@
               if (data.extra && data.extra.stats && data.extra.stats.fullCount !== undefined) {
                 self.setTotal(data.extra.stats.fullCount);
               }
-              if (self.getTotal() !== 0) {
-                _.each(data.result, function (v) {
-                  self.add({
-                    'id': v._id,
-                    'rev': v._rev,
-                    'key': v._key,
-                    'content': v
-                  });
+              _.each(data.result, function (v) {
+                self.add({
+                  'id': v._id,
+                  'rev': v._rev,
+                  'key': v._key,
+                  'content': v
                 });
-              }
+              });
               self.lastQuery = queryObj;
 
               callback(false, data);


### PR DESCRIPTION
### Scope & Purpose

Always show documents for a collection in web interface, regardless of what `collection.count()` says. This fixes a potential race between fetching the count and fetching the documents.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [ ] Backports required for: *(Please specify versions)*

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12224/