### PR TITLE
Added optional verbose logging for agency write operations (#12793)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,20 @@
 v3.6.8 (XXXX-XX-XX)
 -------------------
 
+* Added optional verbose logging for agency write operations. This logging
+  is configurable by using the new log topic "agencystore".
+
+  The following log levels can be used for for the "agencystore" log topic
+  to log writes to the agency:
+  - DEBUG: will log all writes on the leader
+  - TRACE: will log all writes on both leaders and followers
+  The default log level for the "agencystore" log topic is WARN, meaning no
+  agency writes will be logged.
+  Turning on this logging can be used for auditing and debugging, but it is
+  not recommended in the general case, as it can lead to large amounts of 
+  data being logged, which can have a performance impact and will lead to
+  higher disk space usage.
+
 * Added configuration option `--query.tracking-slow-queries` to decide whether
   slow queries are tracked extra.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,19 +1,19 @@
 v3.6.8 (XXXX-XX-XX)
 -------------------
 
-* Added optional verbose logging for agency write operations. This logging
-  is configurable by using the new log topic "agencystore".
+* Added optional verbose logging for agency write operations. This logging is
+  configurable by using the new log topic "agencystore".
 
-  The following log levels can be used for for the "agencystore" log topic
-  to log writes to the agency:
+  The following log levels can be used for for the "agencystore" log topic to
+  log writes to the agency:
   - DEBUG: will log all writes on the leader
   - TRACE: will log all writes on both leaders and followers
   The default log level for the "agencystore" log topic is WARN, meaning no
   agency writes will be logged.
-  Turning on this logging can be used for auditing and debugging, but it is
-  not recommended in the general case, as it can lead to large amounts of 
-  data being logged, which can have a performance impact and will lead to
-  higher disk space usage.
+  Turning on this logging can be used for auditing and debugging, but it is not
+  recommended in the general case, as it can lead to large amounts of data being
+  logged, which can have a performance impact and will lead to higher disk space
+  usage.
 
 * Added configuration option `--query.tracking-slow-queries` to decide whether
   slow queries are tracked extra.

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_modules_flush.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_modules_flush.md
@@ -126,6 +126,9 @@ One of the possible log levels.
 @RESTBODYPARAM{agencycomm,string,optional,string}
 One of the possible log levels.
 
+@RESTBODYPARAM{agencystore,string,optional,string}
+One of the possible log levels.
+
 @RESTBODYPARAM{aql,string,optional,string}
 One of the possible log levels.
 

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -281,6 +281,21 @@ index_t State::logNonBlocking(index_t idx, velocypack::Slice const& slice,
                               bool leading, bool reconfiguration) {
   _logLock.assertLockedByCurrentThread();
 
+  // verbose logging for all agency operations
+  // there are two different log levels in use here for the AGENCYSTORE topic
+  // - DEBUG: will log writes only on the leader
+  // - TRACE: will log writes on both leaders and followers
+  // the default log level for the AGENCYSTORE topic is WARN
+  if (leading) {
+    LOG_TOPIC("b578f", DEBUG, Logger::AGENCYSTORE)
+        << "leader: true, client: " << clientId << ", index: " << idx << ", term: " << term
+        << ", data: " << slice.toJson();
+  } else {
+    LOG_TOPIC("f586f", TRACE, Logger::AGENCYSTORE)
+        << "leader: false, client: " << clientId << ", index: " << idx << ", term: " << term
+        << ", data: " << slice.toJson();
+  }
+
   auto buf = std::make_shared<Buffer<uint8_t>>();
   buf->append((char const*)slice.begin(), slice.byteSize());
 

--- a/lib/Logger/LogTopic.cpp
+++ b/lib/Logger/LogTopic.cpp
@@ -110,6 +110,7 @@ class Topics {
 
 LogTopic Logger::AGENCY("agency", LogLevel::INFO);
 LogTopic Logger::AGENCYCOMM("agencycomm", LogLevel::INFO);
+LogTopic Logger::AGENCYSTORE("agencystore", LogLevel::WARN);
 LogTopic Logger::AQL("aql", LogLevel::INFO);
 LogTopic Logger::AUTHENTICATION("authentication", LogLevel::WARN);
 LogTopic Logger::AUTHORIZATION("authorization");

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -134,6 +134,7 @@ class Logger {
  public:
   static LogTopic AGENCY;
   static LogTopic AGENCYCOMM;
+  static LogTopic AGENCYSTORE;
   static LogTopic AQL;
   static LogTopic AUTHENTICATION;
   static LogTopic AUTHORIZATION;


### PR DESCRIPTION
### Scope & Purpose

Added optional verbose logging for agency write operations.
This logging is configurable by using the new log topic "agencystore".

The following log levels can be used for for the "agencystore" log topic to log writes to the agency:
* DEBUG: will log all writes on the leader
+ TRACE: will log all writes on both leaders and followers
The default log level for the "agencystore" log topic is WARN, meaning no agency writes will be logged.
Turning on this logging can be used for auditing and debugging, but it is not recommended in the general case, as it can lead to large amounts of data being logged, which can have a performance impact and will lead to higher disk space usage.

Backport of https://github.com/arangodb/arangodb/pull/12793

- [ ] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [ ] Backports required for: 3.7

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12234/