### PR TITLE
Fix an issue in arangoimport filename handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,3 @@
-v3.7.4 (XXXX-XX-XX)
--------------------
-
-* Fix an issue in arangoimport improperly handling filenames with less than 3
-  characters. The specified input filename was checked for a potential ".gz"
-  ending, but the check required the filename to have at least 3 characters.
-  This is now fixed.
-
-
 v3.7.3 (XXXX-XX-XX)
 -------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+v3.7.4 (XXXX-XX-XX)
+-------------------
+
+* Fix an issue in arangoimport improperly handling filenames with less than 3
+  characters. The specified input filename was checked for a potential ".gz"
+  ending, but the check required the filename to have at least 3 characters.
+  This is now fixed.
+
+
 v3.7.3 (XXXX-XX-XX)
 -------------------
 

--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -729,7 +729,8 @@ arangodb::Result restoreData(arangodb::httpclient::SimpleHttpClient& httpClient,
   int64_t numReadForThisCollection = 0;
   int64_t numReadSinceLastReport = 0;
 
-  bool const isGzip = (0 == datafile->path().substr(datafile->path().size() - 3).compare(".gz"));
+  bool const isGzip = datafile->path().size() > 3 &&
+                      (0 == datafile->path().substr(datafile->path().size() - 3).compare(".gz"));
 
   buffer.clear();
   while (true) {

--- a/arangosh/Utils/ManagedDirectory.cpp
+++ b/arangosh/Utils/ManagedDirectory.cpp
@@ -337,7 +337,8 @@ std::unique_ptr<ManagedDirectory::File> ManagedDirectory::readableFile(std::stri
 
   if (!_status.fail()) {  // directory is in a bad state?
     try {
-      bool gzFlag = (0 == filename.substr(filename.size() - 3).compare(".gz"));
+      bool gzFlag = filename.size() > 3 && 
+                    (0 == filename.substr(filename.size() - 3).compare(".gz"));
       file = std::make_unique<File>(*this, filename,
                                     (ManagedDirectory::DefaultReadFlags ^ flags), gzFlag);
     } catch (...) {


### PR DESCRIPTION
### Scope & Purpose

arangoimport improperly handled filenames with less than 3 characters.
The specified input filename was checked for a potential ".gz" ending, but the check required the filename to have at least 3 characters.
This is now fixed.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] Backports required for: *3.5, 3.6, 3.7*

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12237/