### PR TITLE
auto-adjust count values during the getting-in-sync protocol

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,13 @@
 v3.7.3 (XXXX-XX-XX)
 -------------------
+      
+* Added the following metrics for synchronous replication in the cluster:
+
+  - `arangodb_refused_followers_count`: Number of times a shard leader received 
+    a refusal answer from a follower during synchronous replication.
+  - `arangodb_sync_wrong_checksum`: Number of times a mismatching shard 
+    checksum was detected when syncing shards. In case this happens, a resync
+    will be triggered for the shard.
 
 * Added configuration option `--query.tracking-slow-queries` to decide whether
   slow queries are tracked extra.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,16 @@ v3.7.3 (XXXX-XX-XX)
   slow queries are tracked extra.
 
 * Added configuration option `--query.tracking-with-querystring` to decide
-  whether the query string is shown.
+  whether the query string is shown in the slow query log and the list of 
+  currently running queries. The option is true by default. 
+  When turned off, querystrings in the slow query log and the list of currently
+  running queries are just shown as "<hidden>".
+
+* Added configuration option `--query.tracking-with-datasources` to toggle
+  whether the names of data sources used by queries are shown in the slow query 
+  log and the list of currently running queries. The option is false by default. 
+  When turned on, the names of data sources used by the query will be shown in
+  the slow query log and the list of currently running queries.
 
 * Fixed handling of failoverCandidates. Sometimes, a server can still be a
   failoverCandidate even though it has been taken out of the Plan. With this

--- a/arangod/Aql/Collections.cpp
+++ b/arangod/Aql/Collections.cpp
@@ -83,6 +83,10 @@ std::vector<std::string> Collections::collectionNames() const {
   result.reserve(_collections.size());
 
   for (auto const& it : _collections) {
+    if (!it.first.empty() && it.first[0] >= '0' && it.first[0] <= '9') {
+      // numeric collection id. don't return them
+      continue;
+    }
     result.emplace_back(it.first);
   }
   return result;

--- a/arangod/Aql/QueryContext.cpp
+++ b/arangod/Aql/QueryContext.cpp
@@ -79,7 +79,6 @@ Collections const& QueryContext::collections() const {
 
 /// @brief return the names of collections used in the query
 std::vector<std::string> QueryContext::collectionNames() const {
-  TRI_ASSERT(_execState != QueryExecutionState::ValueType::EXECUTION);
   return _collections.collectionNames();
 }
 

--- a/arangod/Aql/QueryList.cpp
+++ b/arangod/Aql/QueryList.cpp
@@ -41,6 +41,8 @@
 #include "VocBase/vocbase.h"
 
 #include <velocypack/Builder.h>
+#include <velocypack/Dumper.h>
+#include <velocypack/Sink.h>
 #include <velocypack/StringRef.h>
 #include <velocypack/Value.h>
 #include <velocypack/velocypack-aliases.h>
@@ -51,6 +53,7 @@ using namespace arangodb::aql;
 QueryEntryCopy::QueryEntryCopy(TRI_voc_tick_t id, std::string const& database,
                                std::string const& user, std::string&& queryString,
                                std::shared_ptr<arangodb::velocypack::Builder> const& bindParameters,
+                               std::vector<std::string> collections,
                                double started, double runTime,
                                QueryExecutionState::ValueType state, bool stream)
     : id(id),
@@ -58,6 +61,7 @@ QueryEntryCopy::QueryEntryCopy(TRI_voc_tick_t id, std::string const& database,
       user(user),
       queryString(std::move(queryString)),
       bindParameters(bindParameters),
+      collections(std::move(collections)),
       started(started),
       runTime(runTime),
       state(state),
@@ -76,6 +80,13 @@ void QueryEntryCopy::toVelocyPack(velocypack::Builder& out) const {
   } else {
     out.add("bindVars", arangodb::velocypack::Slice::emptyObjectSlice());
   }
+  if (!collections.empty()) {
+    out.add("collections", VPackValue(VPackValueType::Array));
+    for (auto const& cn : collections) {
+      out.add(VPackValue(cn));
+    }
+    out.close();
+  }
   out.add("started", VPackValue(timeString));
   out.add("runTime", VPackValue(runTime));
   out.add("state", VPackValue(aql::QueryExecutionState::toString(state)));
@@ -90,6 +101,7 @@ QueryList::QueryList(QueryRegistryFeature& feature)
       _trackSlowQueries(_enabled && feature.trackSlowQueries()),
       _trackQueryString(feature.trackQueryString()),
       _trackBindVars(feature.trackBindVars()),
+      _trackCollections(feature.trackCollections()),
       _slowQueryThreshold(feature.slowQueryThreshold()),
       _slowStreamingQueryThreshold(feature.slowStreamingQueryThreshold()),
       _maxSlowQueries(defaultMaxSlowQueries),
@@ -185,14 +197,34 @@ void QueryList::remove(Query* query) {
           }
         }
       }
+      
+      std::string collections;
+      if (_trackCollections) {
+        auto const c = query->collectionNames();
+        if (!c.empty()) {
+          size_t i = 0;
+          collections = ", collections: [";
+          arangodb::velocypack::StringSink sink(&collections);
+          arangodb::velocypack::Dumper dumper(&sink);
+          for (auto const& cn : c) {
+            if (i > 0) {
+              collections.push_back(',');
+            }
+            dumper.appendString(cn.data(), cn.size());
+            ++i;
+          }
+          collections.push_back(']');
+        }
+      }
 
       LOG_TOPIC("8bcee", WARN, Logger::QUERIES)
           << "slow " << (isStreaming ? "streaming " : "") << "query: '" << q << "'"
-          << bindParameters << ", database: " << query->vocbase().name()
+          << bindParameters << collections << ", database: " << query->vocbase().name()
           << ", user: " << query->user() << ", took: " << Logger::FIXED(elapsed) << " s";
 
       _slow.emplace_back(query->id(), query->vocbase().name(), query->user(), std::move(q),
                          _trackBindVars ? query->bindParameters() : nullptr,
+                         _trackCollections ? query->collectionNames() : std::vector<std::string>(),
                          now - elapsed, /* start timestamp */ 
                          elapsed /* run time */,
                          query->killed() ? QueryExecutionState::ValueType::KILLED
@@ -291,6 +323,7 @@ std::vector<QueryEntryCopy> QueryList::listCurrent() {
       result.emplace_back(query->id(), query->vocbase().name(), query->user(),
                           extractQueryString(query, maxLength),
                           _trackBindVars ? query->bindParameters() : nullptr,
+                          _trackCollections ? query->collectionNames() : std::vector<std::string>(),
                           now - elapsed /* start timestamp */, 
                           elapsed /* run time */,
                           query->killed() ? QueryExecutionState::ValueType::KILLED

--- a/arangod/Aql/QueryList.h
+++ b/arangod/Aql/QueryList.h
@@ -47,6 +47,7 @@ struct QueryEntryCopy {
   QueryEntryCopy(TRI_voc_tick_t id, std::string const& database,
                  std::string const& user, std::string&& queryString,
                  std::shared_ptr<arangodb::velocypack::Builder> const& bindParameters,
+                 std::vector<std::string> collections,
                  double started, double runTime,
                  QueryExecutionState::ValueType state, bool stream);
   
@@ -57,6 +58,7 @@ struct QueryEntryCopy {
   std::string const user;
   std::string const queryString;
   std::shared_ptr<arangodb::velocypack::Builder> const bindParameters;
+  std::vector<std::string> collections;
   double const started;
   double const runTime;
   QueryExecutionState::ValueType const state;
@@ -251,6 +253,9 @@ class QueryList {
 
   /// @brief whether or not bind vars are also tracked with queries
   std::atomic<bool> _trackBindVars;
+  
+  /// @brief whether or not collection names are also tracked with queries
+  std::atomic<bool> _trackCollections;
 
   /// @brief threshold for slow queries (in seconds)
   std::atomic<double> _slowQueryThreshold;

--- a/arangod/Aql/QueryList.h
+++ b/arangod/Aql/QueryList.h
@@ -47,7 +47,7 @@ struct QueryEntryCopy {
   QueryEntryCopy(TRI_voc_tick_t id, std::string const& database,
                  std::string const& user, std::string&& queryString,
                  std::shared_ptr<arangodb::velocypack::Builder> const& bindParameters,
-                 std::vector<std::string> collections,
+                 std::vector<std::string> dataSources,
                  double started, double runTime,
                  QueryExecutionState::ValueType state, bool stream);
   
@@ -58,7 +58,7 @@ struct QueryEntryCopy {
   std::string const user;
   std::string const queryString;
   std::shared_ptr<arangodb::velocypack::Builder> const bindParameters;
-  std::vector<std::string> collections;
+  std::vector<std::string> dataSources;
   double const started;
   double const runTime;
   QueryExecutionState::ValueType const state;
@@ -254,8 +254,8 @@ class QueryList {
   /// @brief whether or not bind vars are also tracked with queries
   std::atomic<bool> _trackBindVars;
   
-  /// @brief whether or not collection names are also tracked with queries
-  std::atomic<bool> _trackCollections;
+  /// @brief whether or not data source names are also tracked with queries
+  std::atomic<bool> _trackDataSources;
 
   /// @brief threshold for slow queries (in seconds)
   std::atomic<double> _slowQueryThreshold;

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -572,9 +572,15 @@ void ClusterFeature::start() {
   std::string myId = ServerState::instance()->getId();
 
   if (role == ServerState::RoleEnum::ROLE_DBSERVER) {
-    _dropped_follower_counter = server().getFeature<arangodb::MetricsFeature>().counter(
+    _followersDroppedCounter = server().getFeature<arangodb::MetricsFeature>().counter(
         StaticStrings::DroppedFollowerCount, 0,
         "Number of drop-follower events");
+    _followersRefusedCounter = server().getFeature<arangodb::MetricsFeature>().counter(
+        "arangodb_refused_followers_count", 0,
+        "Number of refusal answers from a follower during synchronous replication");
+    _followersWrongChecksumCounter = server().getFeature<arangodb::MetricsFeature>().counter(
+        "arangodb_sync_wrong_checksum", 0,
+        "Number of times a mismatching shard checksum was detected when syncing shards");
   }
 
   LOG_TOPIC("b6826", INFO, arangodb::Logger::CLUSTER)

--- a/arangod/Cluster/ClusterFeature.h
+++ b/arangod/Cluster/ClusterFeature.h
@@ -90,8 +90,10 @@ class ClusterFeature : public application_features::ApplicationFeature {
   std::shared_ptr<HeartbeatThread> heartbeatThread();
 
   ClusterInfo& clusterInfo();
-
-  Counter& getDroppedFollowerCounter() { return _dropped_follower_counter->get(); }
+  
+  Counter& followersDroppedCounter() { return _followersDroppedCounter->get(); }
+  Counter& followersRefusedCounter() { return _followersRefusedCounter->get(); }
+  Counter& followersWrongChecksumCounter() { return _followersWrongChecksumCounter->get(); }
 
  protected:
   void startHeartbeatThread(AgencyCallbackRegistry* agencyCallbackRegistry,
@@ -129,7 +131,9 @@ class ClusterFeature : public application_features::ApplicationFeature {
   std::unique_ptr<AgencyCallbackRegistry> _agencyCallbackRegistry;
   ServerState::RoleEnum _requestedRole = ServerState::RoleEnum::ROLE_UNDEFINED;
   std::unique_ptr<network::ConnectionPool> _asyncAgencyCommPool;
-  std::optional<std::reference_wrapper<Counter>> _dropped_follower_counter;
+  std::optional<std::reference_wrapper<Counter>> _followersDroppedCounter;
+  std::optional<std::reference_wrapper<Counter>> _followersRefusedCounter;
+  std::optional<std::reference_wrapper<Counter>> _followersWrongChecksumCounter;
 };
 
 }  // namespace arangodb

--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -203,7 +203,7 @@ Result FollowerInfo::remove(ServerID const& sid) {
       _canWrite = false;
     }
     // we are finished
-    _docColl->vocbase().server().getFeature<arangodb::ClusterFeature>().getDroppedFollowerCounter()++;
+    _docColl->vocbase().server().getFeature<arangodb::ClusterFeature>().followersDroppedCounter()++;
     LOG_TOPIC("be0cb", DEBUG, Logger::CLUSTER)
         << "Removing follower " << sid << " from " << _docColl->name() << " succeeded";
     return agencyRes;

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -1182,6 +1182,8 @@ Result SynchronizeShard::catchupWithExclusiveLock(
     // give up the lock on the leader, so writes aren't stopped unncessarily
     // on the leader while we are recalculating the counts
     readLockGuard.fire();
+    
+    collection.vocbase().server().getFeature<ClusterFeature>().followersWrongChecksumCounter()++;
 
     // recalculate collection count on follower
     LOG_TOPIC("29384", INFO, Logger::MAINTENANCE) 

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -47,6 +47,7 @@
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/ServerIdFeature.h"
 #include "StorageEngine/EngineSelectorFeature.h"
+#include "StorageEngine/PhysicalCollection.h"
 #include "StorageEngine/StorageEngine.h"
 #include "Transaction/StandaloneContext.h"
 #include "Utils/CollectionNameResolver.h"
@@ -179,10 +180,10 @@ static arangodb::Result getReadLockId(network::ConnectionPool* pool,
   }
 }
 
-static arangodb::Result collectionCount(std::shared_ptr<arangodb::LogicalCollection> const& col,
+static arangodb::Result collectionCount(arangodb::LogicalCollection const& collection,
                                         uint64_t& c) {
-  std::string collectionName(col->name());
-  auto ctx = std::make_shared<transaction::StandaloneContext>(col->vocbase());
+  std::string collectionName(collection.name());
+  auto ctx = std::make_shared<transaction::StandaloneContext>(collection.vocbase());
   SingleCollectionTransaction trx(ctx, collectionName, AccessMode::Type::READ);
 
   Result res = trx.begin();
@@ -196,7 +197,7 @@ static arangodb::Result collectionCount(std::shared_ptr<arangodb::LogicalCollect
   res = trx.finish(opResult.result);
 
   if (res.fail()) {
-    LOG_TOPIC("263d2", ERR, Logger::MAINTENANCE)
+    LOG_TOPIC("26ed2", ERR, Logger::MAINTENANCE)
         << "Failed to finish count transaction: " << res;
     return res;
   }
@@ -208,6 +209,17 @@ static arangodb::Result collectionCount(std::shared_ptr<arangodb::LogicalCollect
   return opResult.result;
 }
 
+arangodb::Result collectionReCount(LogicalCollection& collection,
+                                   uint64_t& c) {
+  Result res;
+  try {
+    c = collection.getPhysical()->recalculateCounts();
+  } catch (basics::Exception const& e) {
+    res.reset(e.code(), e.message());
+  }
+  return res;
+}
+
 static arangodb::Result addShardFollower(
     network::ConnectionPool* pool, std::string const& endpoint,
     std::string const& database, std::string const& shard, uint64_t lockJobId,
@@ -215,7 +227,7 @@ static arangodb::Result addShardFollower(
     std::string const& clientInfoString, double timeout = 120.0) {
   LOG_TOPIC("b982e", DEBUG, Logger::MAINTENANCE)
       << "addShardFollower: tell the leader to put us into the follower "
-         "list...";
+         "list for " << database << "/" << shard << "...";
 
   if (pool == nullptr) {  // nullptr only happens during controlled shutdown
     return arangodb::Result(TRI_ERROR_SHUTTING_DOWN,
@@ -236,12 +248,11 @@ static arangodb::Result addShardFollower(
     }
 
     uint64_t docCount;
-    {
-      Result res = collectionCount(collection, docCount);
-      if (res.fail()) {
-        return res;
-      }
+    Result res = collectionCount(*collection, docCount);
+    if (res.fail()) {
+       return res;
     }
+    
     VPackBuilder body;
     {
       VPackObjectBuilder b(&body);
@@ -258,6 +269,8 @@ static arangodb::Result addShardFollower(
       }
       if (lockJobId != 0) {
         body.add("readLockId", VPackValue(std::to_string(lockJobId)));
+#if 0
+        // shortcut code disabled
       } else {  // short cut case
         if (docCount != 0) {
           // This can happen if we once were an in-sync follower and a
@@ -267,11 +280,12 @@ static arangodb::Result addShardFollower(
           // here. Note that we are in the lockJobId == 0 case, which is
           // the shortcut.
           std::string msg =
-              "Short cut synchronization for shard " + shard +
+              "Short cut synchronization for " + database + "/" + shard +
               " did not work, since we got a document in the meantime.";
           LOG_TOPIC("ef299", INFO, Logger::MAINTENANCE) << msg;
           return arangodb::Result(TRI_ERROR_INTERNAL, msg);
         }
+#endif
       }
     }
 
@@ -288,16 +302,18 @@ static arangodb::Result addShardFollower(
 
     if (result.fail()) {
       auto const errorMessage =
-          "addShardFollower: could not add us to the leader's follower list. ";
+          "addShardFollower: could not add us to the leader's follower list for " +
+          database + "/" + shard;
 
       if (lockJobId != 0) {
         LOG_TOPIC("22e0a", WARN, Logger::MAINTENANCE)
-            << errorMessage << result.errorMessage();
+            << errorMessage << ", " << result.errorMessage();
       } else {
         LOG_TOPIC("abf2e", INFO, Logger::MAINTENANCE)
-            << errorMessage << "With shortcut (can happen, no problem).";
+            << errorMessage << " with shortcut (can happen, no problem).";
       }
-      return arangodb::Result(TRI_ERROR_INTERNAL, errorMessage);
+      return arangodb::Result(result.errorNumber(),
+                              errorMessage + ", " + result.errorMessage());
     }
 
     LOG_TOPIC("79935", DEBUG, Logger::MAINTENANCE) << "addShardFollower: success";
@@ -791,7 +807,7 @@ bool SynchronizeShard::first() {
 
     auto ep = clusterInfo.getServerEndpoint(leader);
     uint64_t docCount;
-    if (!collectionCount(collection, docCount).ok()) {
+    if (!collectionCount(*collection, docCount).ok()) {
       std::stringstream error;
       error << "failed to get a count on leader " << shard;
       LOG_TOPIC("da225", ERR, Logger::MAINTENANCE) << "SynchronizeShard " << error.str();
@@ -807,6 +823,12 @@ bool SynchronizeShard::first() {
           "/" + resolver.getCollectionName(collection->id());
     }
 
+    // old "shortcut" code for getting in sync. This code takes a shortcut if the
+    // shard in question is supposed to be empty. in this case it will simply try
+    // to add itself as an in-sync follower, without running the full replication
+    // protocol. this shortcut relies on the collection counts being correct, and
+    // as these can be at least temporarily off, we need to disable it.
+#if 0
     if (docCount == 0) {
       // We have a short cut:
       LOG_TOPIC("0932a", DEBUG, Logger::MAINTENANCE)
@@ -843,6 +865,7 @@ bool SynchronizeShard::first() {
       } catch (...) {
       }
     }
+#endif
 
     LOG_TOPIC("53337", DEBUG, Logger::MAINTENANCE)
         << "synchronizeOneShard: trying to synchronize local shard '" << database
@@ -1095,7 +1118,7 @@ ResultT<TRI_voc_tick_t> SynchronizeShard::catchupWithReadLock(
 }
 
 Result SynchronizeShard::catchupWithExclusiveLock(
-    std::string const& ep, std::string const& database, LogicalCollection const& collection,
+    std::string const& ep, std::string const& database, LogicalCollection& collection,
     std::string const& clientId, std::string const& shard, std::string const& leader,
     SyncerId const syncerId, TRI_voc_tick_t lastLogTick, VPackBuilder& builder) {
   uint64_t lockJobId = 0;
@@ -1149,6 +1172,81 @@ Result SynchronizeShard::catchupWithExclusiveLock(
   res = addShardFollower(pool, ep, database, shard, lockJobId, clientId,
                          syncerId, _clientInfoString, 60.0);
 
+  // if we get a checksum mismatch, it means that we got different counts of
+  // documents on the leader and the follower, which can happen if collection
+  // counts are off for whatever reason. 
+  // under many cicrumstances the counts will have been auto-healed by the initial
+  // or the incremental replication before, so in many cases we will not even get
+  // into this if case
+  if (res.is(TRI_ERROR_REPLICATION_WRONG_CHECKSUM)) {
+    // give up the lock on the leader, so writes aren't stopped unncessarily
+    // on the leader while we are recalculating the counts
+    readLockGuard.fire();
+
+    // recalculate collection count on follower
+    LOG_TOPIC("29384", INFO, Logger::MAINTENANCE) 
+       << "recalculating collection count on follower for "
+       << database << "/" << shard;
+
+    uint64_t docCount;
+    Result countRes = collectionCount(collection, docCount);
+    if (countRes.fail()) {
+      return countRes;
+    }
+    // store current count value
+    uint64_t oldCount = docCount;
+
+    // recalculate on follower. this can take a long time
+    countRes = collectionReCount(collection, docCount);
+    if (countRes.fail()) {
+      return countRes;
+    }
+
+    // check if our recalculation has made a difference
+    if (oldCount == docCount) {
+      // no change happened due to recalculation. now try recounting on leader too.
+      // this is last resort and should not happen often!
+      LOG_TOPIC("3dc64", INFO, Logger::MAINTENANCE) 
+         << "recalculating collection count on leader for "
+         << database << "/" << shard;
+
+      VPackBuffer<uint8_t> buffer;
+      VPackBuilder tmp(buffer);
+      tmp.add(VPackSlice::emptyObjectSlice());
+
+      network::RequestOptions options;
+      options.database = database;
+      options.timeout = network::Timeout(600.0);  // this can be slow!!!
+      options.skipScheduler = true;  // hack to speed up future.get()
+
+      std::string const url = "/_api/collection/" + collection.name() + "/recalculateCount";
+
+      auto response = network::sendRequest(pool, ep, fuerte::RestVerb::Put,
+                                           url, std::move(buffer), options)
+                          .get();
+      auto result = response.combinedResult();
+
+      if (result.fail()) {
+        std::string const errorMessage =
+            "addShardFollower: could not add us to the leader's follower "
+            "list for " + database + "/" + shard +
+            ", error while recalculating count on leader: " +
+            result.errorMessage();
+        LOG_TOPIC("22e0b", WARN, Logger::MAINTENANCE) << errorMessage;
+        return arangodb::Result(result.errorNumber(), errorMessage);
+      }
+    }
+
+    // still let the operation fail here, because we gave up the lock 
+    // already and cannot be sure the data on the leader hasn't changed in
+    // the meantime. we will sort this issue out during the next maintenance
+    // run
+    TRI_ASSERT(res.fail());
+    TRI_ASSERT(res.is(TRI_ERROR_REPLICATION_WRONG_CHECKSUM));
+    return res;
+  }
+
+  // no more retrying...
   if (!res.ok()) {
     std::string errorMessage(
       "synchronizeOneshard: error in addShardFollower: ");

--- a/arangod/Cluster/SynchronizeShard.h
+++ b/arangod/Cluster/SynchronizeShard.h
@@ -71,7 +71,7 @@ class SynchronizeShard : public ActionBase {
 
   arangodb::Result catchupWithExclusiveLock(
       std::string const& ep, std::string const& database,
-      LogicalCollection const& collection, std::string const& clientId,
+      LogicalCollection& collection, std::string const& clientId,
       std::string const& shard, std::string const& leader, SyncerId syncerId,
       TRI_voc_tick_t lastLogTick, VPackBuilder& builder);
 

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -1669,29 +1669,9 @@ Result DatabaseInitialSyncer::changeCollection(arangodb::LogicalCollection* col,
   return guard.collection()->properties(slice, false);  // always a full-update
 }
 
-/// @brief determine the number of documents in a collection
-int64_t DatabaseInitialSyncer::getSize(arangodb::LogicalCollection const& col) {
-  SingleCollectionTransaction trx(transaction::StandaloneContext::Create(vocbase()),
-                                  col, AccessMode::Type::READ);
-  Result res = trx.begin();
-
-  if (res.fail()) {
-    return -1;
-  }
-
-  auto result = trx.count(col.name(), transaction::CountType::Normal);
-
-  if (result.result.fail()) {
-    return -1;
-  }
-
-  VPackSlice s = result.slice();
-
-  if (!s.isNumber()) {
-    return -1;
-  }
-
-  return s.getNumber<int64_t>();
+/// @brief whether or not the collection has documents
+bool DatabaseInitialSyncer::hasDocuments(arangodb::LogicalCollection const& col) {
+  return col.getPhysical()->hasDocuments();
 }
 
 /// @brief handle the information about a collection
@@ -1888,7 +1868,7 @@ Result DatabaseInitialSyncer::handleCollection(VPackSlice const& parameters,
     }
 
     std::string const& masterColl = !masterUuid.empty() ? masterUuid : itoa(masterCid);
-    auto res = incremental && getSize(*col) > 0
+    auto res = incremental && hasDocuments(*col) 
                    ? fetchCollectionSync(col, masterColl, _config.master.lastLogTick)
                    : fetchCollectionDump(col, masterColl, _config.master.lastLogTick);
 

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -415,7 +415,7 @@ Result DatabaseInitialSyncer::runWithInventory(bool incremental, VPackSlice dbIn
 
       // enable patching of collection count for ShardSynchronization Job
       std::string patchCount = StaticStrings::Empty;
-      if (incremental && _config.applier._skipCreateDrop &&
+      if (_config.applier._skipCreateDrop &&
           _config.applier._restrictType == ReplicationApplierConfiguration::RestrictType::Include &&
           _config.applier._restrictCollections.size() == 1) {
         patchCount = *_config.applier._restrictCollections.begin();

--- a/arangod/Replication/DatabaseInitialSyncer.h
+++ b/arangod/Replication/DatabaseInitialSyncer.h
@@ -182,8 +182,8 @@ class DatabaseInitialSyncer final : public InitialSyncer {
   Result parseCollectionDump(transaction::Methods&, LogicalCollection* col,
                              httpclient::SimpleHttpResult*, uint64_t&);
 
-  /// @brief determine the number of documents in a collection
-  int64_t getSize(arangodb::LogicalCollection const& col);
+  /// @brief whether or not the collection has documents
+  bool hasDocuments(arangodb::LogicalCollection const& col);
 
   /// @brief incrementally fetch data from a collection
   // TODO worker safety

--- a/arangod/RestServer/QueryRegistryFeature.cpp
+++ b/arangod/RestServer/QueryRegistryFeature.cpp
@@ -53,6 +53,7 @@ QueryRegistryFeature::QueryRegistryFeature(application_features::ApplicationServ
       _trackSlowQueries(true),
       _trackQueryString(true),
       _trackBindVars(true),
+      _trackCollections(false),
       _failOnWarning(false),
       _queryCacheIncludeSystem(false),
       _smartJoins(true),
@@ -112,6 +113,10 @@ void QueryRegistryFeature::collectOptions(std::shared_ptr<ProgramOptions> option
   options->addOption("--query.tracking-with-bindvars",
                      "whether to track bind vars with AQL queries",
                      new BooleanParameter(&_trackBindVars));
+  
+  options->addOption("--query.tracking-with-collections", "whether to track the query collection names",
+                     new BooleanParameter(&_trackCollections))
+                     .setIntroducedIn(30704);
 
   options->addOption("--query.fail-on-warning",
                      "whether AQL queries should fail with errors even for "

--- a/arangod/RestServer/QueryRegistryFeature.cpp
+++ b/arangod/RestServer/QueryRegistryFeature.cpp
@@ -53,7 +53,7 @@ QueryRegistryFeature::QueryRegistryFeature(application_features::ApplicationServ
       _trackSlowQueries(true),
       _trackQueryString(true),
       _trackBindVars(true),
-      _trackCollections(false),
+      _trackDataSources(false),
       _failOnWarning(false),
       _queryCacheIncludeSystem(false),
       _smartJoins(true),
@@ -114,8 +114,8 @@ void QueryRegistryFeature::collectOptions(std::shared_ptr<ProgramOptions> option
                      "whether to track bind vars with AQL queries",
                      new BooleanParameter(&_trackBindVars));
   
-  options->addOption("--query.tracking-with-collections", "whether to track the query collection names",
-                     new BooleanParameter(&_trackCollections))
+  options->addOption("--query.tracking-with-datasources", "whether to track data sources with AQL queries",
+                     new BooleanParameter(&_trackDataSources))
                      .setIntroducedIn(30704);
 
   options->addOption("--query.fail-on-warning",

--- a/arangod/RestServer/QueryRegistryFeature.h
+++ b/arangod/RestServer/QueryRegistryFeature.h
@@ -52,6 +52,7 @@ class QueryRegistryFeature final : public application_features::ApplicationFeatu
   bool trackSlowQueries() const { return _trackSlowQueries; }
   bool trackQueryString() const { return _trackQueryString; }
   bool trackBindVars() const { return _trackBindVars; }
+  bool trackCollections() const { return _trackCollections; }
   double slowQueryThreshold() const { return _slowQueryThreshold; }
   double slowStreamingQueryThreshold() const {
     return _slowStreamingQueryThreshold;
@@ -70,6 +71,7 @@ class QueryRegistryFeature final : public application_features::ApplicationFeatu
   bool _trackSlowQueries;
   bool _trackQueryString;
   bool _trackBindVars;
+  bool _trackCollections;
   bool _failOnWarning;
   bool _queryCacheIncludeSystem;
   bool _smartJoins;

--- a/arangod/RestServer/QueryRegistryFeature.h
+++ b/arangod/RestServer/QueryRegistryFeature.h
@@ -52,7 +52,7 @@ class QueryRegistryFeature final : public application_features::ApplicationFeatu
   bool trackSlowQueries() const { return _trackSlowQueries; }
   bool trackQueryString() const { return _trackQueryString; }
   bool trackBindVars() const { return _trackBindVars; }
-  bool trackCollections() const { return _trackCollections; }
+  bool trackDataSources() const { return _trackDataSources; }
   double slowQueryThreshold() const { return _slowQueryThreshold; }
   double slowStreamingQueryThreshold() const {
     return _slowStreamingQueryThreshold;
@@ -71,7 +71,7 @@ class QueryRegistryFeature final : public application_features::ApplicationFeatu
   bool _trackSlowQueries;
   bool _trackQueryString;
   bool _trackBindVars;
-  bool _trackCollections;
+  bool _trackDataSources;
   bool _failOnWarning;
   bool _queryCacheIncludeSystem;
   bool _smartJoins;

--- a/arangod/RestServer/arangod.cpp
+++ b/arangod/RestServer/arangod.cpp
@@ -178,6 +178,7 @@ static int runServer(int argc, char** argv, ArangoGlobalContext& context) {
     server.addFeature<V8FeaturePhase>();
 
     // Adding the features
+    server.addFeature<MetricsFeature>();
     server.addFeature<ActionFeature>();
     server.addFeature<AgencyFeature>();
     server.addFeature<AqlFeature>();
@@ -209,7 +210,6 @@ static int runServer(int argc, char** argv, ArangoGlobalContext& context) {
     server.addFeature<LoggerFeature>(true);
     server.addFeature<MaintenanceFeature>();
     server.addFeature<MaxMapCountFeature>();
-    server.addFeature<MetricsFeature>();
     server.addFeature<NetworkFeature>();
     server.addFeature<NonceFeature>();
     server.addFeature<PrivilegeFeature>();

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -1832,6 +1832,12 @@ Result RocksDBCollection::cleanupAfterUpgrade() {
                                         ::clearTemporaryObjectId, false);
 }
 
+bool RocksDBCollection::hasDocuments() {
+  rocksdb::TransactionDB* db = rocksutils::globalRocksDB();
+  RocksDBKeyBounds bounds = RocksDBKeyBounds::CollectionDocuments(objectId());
+  return rocksutils::hasKeys(db, bounds, true);
+}
+
 /// @brief return engine-specific figures
 void RocksDBCollection::figuresSpecific(bool details, arangodb::velocypack::Builder& builder) {
   rocksdb::TransactionDB* db = rocksutils::globalRocksDB();

--- a/arangod/RocksDBEngine/RocksDBCollection.h
+++ b/arangod/RocksDBEngine/RocksDBCollection.h
@@ -132,6 +132,8 @@ class RocksDBCollection final : public RocksDBMetaCollection {
 
   inline bool cacheEnabled() const { return _cacheEnabled; }
 
+  bool hasDocuments() override;
+
   void adjustNumberDocuments(transaction::Methods&, int64_t) override;
 
   Result upgrade() override;

--- a/arangod/RocksDBEngine/RocksDBCommon.cpp
+++ b/arangod/RocksDBEngine/RocksDBCommon.cpp
@@ -119,6 +119,7 @@ std::size_t countKeys(rocksdb::DB* db, rocksdb::ColumnFamilyHandle* cf) {
   rocksdb::ReadOptions opts;
   opts.fill_cache = false;
   opts.total_order_seek = true;
+  opts.verify_checksums = false;
 
   std::unique_ptr<rocksdb::Iterator> it(db->NewIterator(opts, cf));
   std::size_t count = 0;
@@ -157,6 +158,26 @@ std::size_t countKeyRange(rocksdb::DB* db, RocksDBKeyBounds const& bounds,
     it->Next();
   }
   return count;
+}
+
+/// @brief whether or not the specified range has keys
+bool hasKeys(rocksdb::DB* db, RocksDBKeyBounds const& bounds, bool prefix_same_as_start) {
+  rocksdb::Slice lower(bounds.start());
+  rocksdb::Slice upper(bounds.end());
+
+  rocksdb::ReadOptions readOptions;
+  readOptions.prefix_same_as_start = prefix_same_as_start;
+  readOptions.iterate_upper_bound = &upper;
+  readOptions.total_order_seek = !prefix_same_as_start;
+  readOptions.verify_checksums = false;
+  readOptions.fill_cache = false;
+
+  rocksdb::ColumnFamilyHandle* cf = bounds.columnFamily();
+  rocksdb::Comparator const* cmp = cf->GetComparator();
+  std::unique_ptr<rocksdb::Iterator> it(db->NewIterator(readOptions, cf));
+
+  it->Seek(lower);
+  return (it->Valid() && cmp->Compare(it->key(), upper) < 0);
 }
 
 /// @brief helper method to remove large ranges of data

--- a/arangod/RocksDBEngine/RocksDBCommon.h
+++ b/arangod/RocksDBEngine/RocksDBCommon.h
@@ -86,6 +86,9 @@ std::size_t countKeys(rocksdb::DB*, rocksdb::ColumnFamilyHandle* cf);
 /// @brief iterate over all keys in range and count them
 std::size_t countKeyRange(rocksdb::DB*, RocksDBKeyBounds const&, bool prefix_same_as_start);
 
+/// @brief whether or not the specified range has keys
+bool hasKeys(rocksdb::DB*, RocksDBKeyBounds const&, bool prefix_same_as_start);
+
 /// @brief helper method to remove large ranges of data
 /// Should mainly be used to implement the drop() call
 Result removeLargeRange(rocksdb::DB* db, RocksDBKeyBounds const& bounds,

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -39,6 +39,7 @@
 #include "RocksDBEngine/RocksDBTransactionCollection.h"
 #include "RocksDBEngine/RocksDBTransactionState.h"
 #include "StorageEngine/EngineSelectorFeature.h"
+#include "Transaction/Context.h"
 #include "Transaction/Methods.h"
 #include "Transaction/StandaloneContext.h"
 #include "Utils/CollectionGuard.h"
@@ -162,6 +163,8 @@ void RocksDBMetaCollection::trackWaitForSync(arangodb::transaction::Methods* trx
 
 // rescans the collection to update document count
 uint64_t RocksDBMetaCollection::recalculateCounts() {
+  std::unique_lock<std::mutex> guard(_recalculationLock);
+
   RocksDBEngine* engine = rocksutils::globalRocksEngine();
   rocksdb::TransactionDB* db = engine->db();
   const rocksdb::Snapshot* snapshot = nullptr;
@@ -179,8 +182,15 @@ uint64_t RocksDBMetaCollection::recalculateCounts() {
   });
 
   // makes sure collection doesn't get unloaded
-  CollectionGuard guard(&vocbase, _logicalCollection.id());
-  
+  CollectionGuard collGuard(&vocbase, _logicalCollection.id());
+
+  TRI_voc_tid_t trxId{0};
+  auto blockerGuard = scopeGuard([&] {  // remove blocker afterwards
+    if (trxId != 0) {
+      _meta.removeBlocker(trxId);
+    }
+  });
+
   uint64_t snapNumberOfDocuments = 0;
   {
     // fetch number docs and snapshot under exclusive lock
@@ -191,14 +201,38 @@ uint64_t RocksDBMetaCollection::recalculateCounts() {
       lockGuard.cancel();
       THROW_ARANGO_EXCEPTION(res);
     }
-    
-    snapNumberOfDocuments = _meta.numberDocuments();
+
+    // generate a unique transaction id for a blocker
+    trxId = transaction::Context::makeTransactionId();
+
+    // place a blocker. will be removed by blockerGuard automatically
+    _meta.placeBlocker(trxId, engine->db()->GetLatestSequenceNumber());
+
     snapshot = engine->db()->GetSnapshot();
+    snapNumberOfDocuments = _meta.numberDocuments();
     TRI_ASSERT(snapshot);
+  }
+
+  auto seq = snapshot->GetSequenceNumber();
+
+  auto bounds = RocksDBKeyBounds::Empty();
+  bool set = false;
+  {
+    READ_LOCKER(guard, _indexesLock);
+    for (auto it : _indexes) {
+      if (it->type() == Index::TRI_IDX_TYPE_PRIMARY_INDEX) {
+        RocksDBIndex const* rix = static_cast<RocksDBIndex const*>(it.get());
+        bounds = RocksDBKeyBounds::PrimaryIndex(rix->objectId());
+        set = true;
+        break;
+      }
+    }
+  }
+  if (!set) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "did not find primary index");
   }
   
   // count documents
-  RocksDBKeyBounds bounds = this->bounds();
   rocksdb::Slice upper(bounds.end());
   
   rocksdb::ReadOptions ro;
@@ -211,18 +245,26 @@ uint64_t RocksDBMetaCollection::recalculateCounts() {
   rocksdb::ColumnFamilyHandle* cf = bounds.columnFamily();
   std::unique_ptr<rocksdb::Iterator> it(db->NewIterator(ro, cf));
   std::size_t count = 0;
+
+  application_features::ApplicationServer& server = vocbase.server();
   
   for (it->Seek(bounds.start()); it->Valid(); it->Next()) {
     TRI_ASSERT(it->key().compare(upper) < 0);
     ++count;
+
+    if (count % 4096 == 0 &&
+        server.isStopping()) {
+      // check for server shutdown
+      THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+    }
   }
   
   int64_t adjustment = count - snapNumberOfDocuments;
   if (adjustment != 0) {
-    auto seq = snapshot->GetSequenceNumber();
-    LOG_TOPIC("ad6d3", WARN, Logger::REPLICATION)
-    << "inconsistent collection count detected, "
-    << "an offet of " << adjustment << " will be applied";
+    LOG_TOPIC("ad613", WARN, Logger::REPLICATION)
+      << "inconsistent collection count detected for "
+      << vocbase.name() << "/" << _logicalCollection.name()
+      << ", an offet of " << adjustment << " will be applied";
     _meta.adjustNumberDocuments(seq, static_cast<TRI_voc_rid_t>(0), adjustment);
   }
   

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.h
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.h
@@ -62,9 +62,9 @@ class RocksDBMetaCollection : public PhysicalCollection {
   int lockRead(double timeout = 0.0);
   void unlockRead();
   
-  /// recalculte counts for collection in case of failure
-  uint64_t recalculateCounts();
-  
+  /// recalculate counts for collection in case of failure, blocks other writes for a short period
+  uint64_t recalculateCounts() override;
+ 
   /// @brief compact-data operation
   /// triggers rocksdb compaction for documentDB and indexes
   Result compact() override final;
@@ -128,6 +128,8 @@ class RocksDBMetaCollection : public PhysicalCollection {
   RocksDBMetadata _meta;     /// collection metadata
   /// @brief collection lock used for write access
   mutable basics::ReadWriteLock _exclusiveLock;
+  /// @brief collection lock used for recalculation count values
+  mutable std::mutex _recalculationLock;
 
  private:
   std::atomic<uint64_t> _objectId;  /// rocksdb-specific object id for collection

--- a/arangod/RocksDBEngine/RocksDBMetadata.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetadata.cpp
@@ -99,11 +99,19 @@ Result RocksDBMetadata::placeBlocker(TRI_voc_tid_t trxId, rocksdb::SequenceNumbe
     TRI_ASSERT(_blockersBySeq.end() == _blockersBySeq.find(std::make_pair(seq, trxId)));
 
     auto insert = _blockers.try_emplace(trxId, seq);
-    auto crosslist = _blockersBySeq.emplace(seq, trxId);
-    if (!insert.second || !crosslist.second) {
+    if (!insert.second) {
       return res.reset(TRI_ERROR_INTERNAL);
     }
-    return res;
+    try {
+      auto crosslist = _blockersBySeq.emplace(seq, trxId);
+      if (!crosslist.second) {
+        return res.reset(TRI_ERROR_INTERNAL);
+      }
+      return res;
+    } catch (...) {
+      _blockers.erase(trxId);
+      throw;
+    }
   });
 }
 

--- a/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
@@ -214,6 +214,7 @@ std::tuple<Result, TRI_voc_cid_t, uint64_t> RocksDBReplicationContext::bindColle
                            0, 0);
   }
   cIter->numberDocuments = numberDocuments;
+  cIter->numberDocumentsDumped = 0;
   cIter->isNumberDocumentsExclusive = isNumberDocsExclusive;
 
   // we should have a valid iterator if there are documents in here
@@ -297,11 +298,26 @@ RocksDBReplicationContext::DumpResult RocksDBReplicationContext::dumpJson(
     dumper.dump(velocypack::Slice(reinterpret_cast<uint8_t const*>(cIter->iter->value().data())));
     buff.appendText("}\n");
     cIter->iter->Next();
+    ++cIter->numberDocumentsDumped;
   }
 
   bool hasMore = cIter->hasMore();
   if (hasMore) {
     cIter->currentTick++;
+  } else if (cIter->isNumberDocumentsExclusive) {
+    // reached the end
+    int64_t adjustment = cIter->numberDocumentsDumped - cIter->numberDocuments;
+    if (adjustment != 0) {
+      LOG_TOPIC("5575c", WARN, Logger::REPLICATION)
+          << "inconsistent collection count detected for "
+          << vocbase.name() << "/" << cIter->logical->name() 
+          << ", an offet of " << adjustment << " will be applied";
+      auto* rcoll = static_cast<RocksDBMetaCollection*>(cIter->logical->getPhysical());
+      auto seq = rocksutils::latestSequenceNumber();
+      rcoll->meta().adjustNumberDocuments(seq, TRI_voc_rid_t(0), adjustment);
+    }
+
+    cIter->numberDocumentsDumped = 0;
   }
   return DumpResult(TRI_ERROR_NO_ERROR, hasMore, cIter->currentTick);
 }
@@ -340,11 +356,26 @@ RocksDBReplicationContext::DumpResult RocksDBReplicationContext::dumpVPack(
     builder.add(velocypack::Slice(reinterpret_cast<uint8_t const*>(cIter->iter->value().data())));
     builder.close();
     cIter->iter->Next();
+    ++cIter->numberDocumentsDumped;
   }
 
   bool hasMore = cIter->hasMore();
   if (hasMore) {
     cIter->currentTick++;
+  } else if (cIter->isNumberDocumentsExclusive) {
+    // reached the end
+    int64_t adjustment = cIter->numberDocumentsDumped - cIter->numberDocuments;
+    if (adjustment != 0) {
+      LOG_TOPIC("5575d", WARN, Logger::REPLICATION)
+          << "inconsistent collection count detected for "
+          << vocbase.name() << "/" << cIter->logical->name() 
+          << ", an offet of " << adjustment << " will be applied";
+      auto* rcoll = static_cast<RocksDBMetaCollection*>(cIter->logical->getPhysical());
+      auto seq = rocksutils::latestSequenceNumber();
+      rcoll->meta().adjustNumberDocuments(seq, TRI_voc_rid_t(0), adjustment);
+    }
+
+    cIter->numberDocumentsDumped = 0;
   }
   return DumpResult(TRI_ERROR_NO_ERROR, hasMore, cIter->currentTick);
 }
@@ -390,7 +421,7 @@ arangodb::Result RocksDBReplicationContext::dumpKeyChunks(TRI_vocbase_t& vocbase
 
   b.openArray(true);
   while (cIter->hasMore()) {
-    // needs to be a strings because rocksdb::Slice gets invalidated
+    // needs to be strings because rocksdb::Slice gets invalidated
     std::string lowKey, highKey;
     uint64_t hashval = 0x012345678;
 
@@ -459,8 +490,9 @@ arangodb::Result RocksDBReplicationContext::dumpKeyChunks(TRI_vocbase_t& vocbase
     int64_t adjustment = snapNumDocs - cIter->numberDocuments;
     if (adjustment != 0) {
       LOG_TOPIC("4986d", WARN, Logger::REPLICATION)
-          << "inconsistent collection count detected, "
-          << "an offet of " << adjustment << " will be applied";
+          << "inconsistent collection count detected for "
+          << vocbase.name() << "/" << cIter->logical->name() 
+          << ", an offet of " << adjustment << " will be applied";
       auto* rcoll = static_cast<RocksDBMetaCollection*>(cIter->logical->getPhysical());
       auto seq = rocksutils::latestSequenceNumber();
       rcoll->meta().adjustNumberDocuments(seq, static_cast<TRI_voc_rid_t>(0), adjustment);
@@ -817,6 +849,7 @@ RocksDBReplicationContext::CollectionIterator::CollectionIterator(
       lastSortedIteratorOffset{0},
       vpackOptions{Options::Defaults},
       numberDocuments{0},
+      numberDocumentsDumped{0},
       isNumberDocumentsExclusive{false},
       _resolver(vocbase),
       _cTypeHandler{},

--- a/arangod/RocksDBEngine/RocksDBReplicationContext.h
+++ b/arangod/RocksDBEngine/RocksDBReplicationContext.h
@@ -83,6 +83,8 @@ class RocksDBReplicationContext {
     /// @brief number of documents in this collection
     /// only set in a very specific use-case
     uint64_t numberDocuments;
+     /// @brief number of documents we iterated over in /dump
+    uint64_t numberDocumentsDumped;
     /// @brief snapshot and number documents were fetched exclusively
     bool isNumberDocumentsExclusive;
 

--- a/arangod/RocksDBEngine/RocksDBTransactionState.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.cpp
@@ -33,6 +33,7 @@
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
+#include "Random/RandomGenerator.h"
 #include "RestServer/MetricsFeature.h"
 #include "RocksDBEngine/RocksDBCollection.h"
 #include "RocksDBEngine/RocksDBCommon.h"
@@ -229,6 +230,15 @@ void RocksDBTransactionState::commitCollections(rocksdb::SequenceNumber lastWrit
     // we need this in case of an intermediate commit. The number of
     // initial documents is adjusted and numInserts / removes is set to 0
     // index estimator updates are buffered
+      
+    TRI_IF_FAILURE("RocksDBCommitCounts") {
+      continue;
+    }
+    TRI_IF_FAILURE("RocksDBCommitCountsRandom") {
+      if (RandomGenerator::interval(uint16_t(100)) >= 50) {
+        continue;
+      }
+    }
     coll->commitCounts(id(), lastWritten);
   }
 }

--- a/arangod/StorageEngine/PhysicalCollection.cpp
+++ b/arangod/StorageEngine/PhysicalCollection.cpp
@@ -91,6 +91,10 @@ uint64_t PhysicalCollection::recalculateCounts() {
   THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_NOT_IMPLEMENTED, "recalculateCounts not implemented for this engine");
 }
 
+bool PhysicalCollection::hasDocuments() {
+  THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_NOT_IMPLEMENTED, "hasDocuments not implemented for this engine");
+}
+
 bool PhysicalCollection::isValidEdgeAttribute(VPackSlice const& slice) const {
   if (!slice.isString()) {
     return false;

--- a/arangod/StorageEngine/PhysicalCollection.cpp
+++ b/arangod/StorageEngine/PhysicalCollection.cpp
@@ -86,6 +86,11 @@ void PhysicalCollection::drop() {
   }
 }
 
+
+uint64_t PhysicalCollection::recalculateCounts() {
+  THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_NOT_IMPLEMENTED, "recalculateCounts not implemented for this engine");
+}
+
 bool PhysicalCollection::isValidEdgeAttribute(VPackSlice const& slice) const {
   if (!slice.isString()) {
     return false;

--- a/arangod/StorageEngine/PhysicalCollection.h
+++ b/arangod/StorageEngine/PhysicalCollection.h
@@ -82,6 +82,10 @@ class PhysicalCollection {
   /// recalculate counts for collection in case of failure, blocking
   virtual uint64_t recalculateCounts();
 
+  /// @brief whether or not the collection contains any documents. this
+  /// function is allowed to return true even if there are no documents
+  virtual bool hasDocuments();
+
   ////////////////////////////////////
   // -- SECTION Indexes --
   ///////////////////////////////////

--- a/arangod/StorageEngine/PhysicalCollection.h
+++ b/arangod/StorageEngine/PhysicalCollection.h
@@ -79,6 +79,9 @@ class PhysicalCollection {
 
   void drop();
 
+  /// recalculate counts for collection in case of failure, blocking
+  virtual uint64_t recalculateCounts();
+
   ////////////////////////////////////
   // -- SECTION Indexes --
   ///////////////////////////////////

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2376,6 +2376,10 @@ Future<Result> Methods::replicateOperations(
         }
       }
 
+      TRI_IF_FAILURE("replicateOperationsDropFollower") {
+        replicationWorked = false;
+      }
+
       if (!replicationWorked) {
         ServerID const& deadFollower = (*followerList)[i];
         Result res = collection->followers()->remove(deadFollower);

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -285,7 +285,11 @@ static bool findRefusal(std::vector<futures::Try<network::Response>> const& resp
   for (auto const& it : responses) {
     if (it.hasValue() && it.get().ok() &&
         it.get().response->statusCode() == fuerte::StatusNotAcceptable) {
-      return true;
+      auto r = it.get().combinedResult();
+      bool followerRefused = (r.errorNumber() == TRI_ERROR_CLUSTER_SHARD_LEADER_REFUSES_REPLICATION);
+      if (followerRefused) {
+        return true;
+      }
     }
   }
   return false;
@@ -1851,6 +1855,7 @@ Future<OperationResult> transaction::Methods::truncateLocal(std::string const& c
       // error (note that we use the follower version, since we have
       // lost leadership):
       if (findRefusal(responses)) {
+        vocbase().server().getFeature<arangodb::ClusterFeature>().followersRefusedCounter()++;
         return futures::makeFuture(OperationResult(TRI_ERROR_CLUSTER_SHARD_LEADER_RESIGNED));
       }
     }
@@ -2366,8 +2371,10 @@ Future<Result> Methods::replicateOperations(
         auto r = resp.combinedResult();
         bool followerRefused = (r.errorNumber() == TRI_ERROR_CLUSTER_SHARD_LEADER_REFUSES_REPLICATION);
         didRefuse = didRefuse || followerRefused;
-
+  
         if (followerRefused) {
+          vocbase().server().getFeature<arangodb::ClusterFeature>().followersRefusedCounter()++;
+
           LOG_TOPIC("3032c", WARN, Logger::REPLICATION)
               << "synchronous replication: follower "
               << (*followerList)[i] << " for shard " << collection->name()
@@ -2382,6 +2389,7 @@ Future<Result> Methods::replicateOperations(
 
       if (!replicationWorked) {
         ServerID const& deadFollower = (*followerList)[i];
+        
         Result res = collection->followers()->remove(deadFollower);
         if (res.ok()) {
           // TODO: what happens if a server is re-added during a transaction ?

--- a/arangod/V8Server/v8-vocbase.cpp
+++ b/arangod/V8Server/v8-vocbase.cpp
@@ -1065,7 +1065,6 @@ static void JS_QueriesPropertiesAql(v8::FunctionCallbackInfo<v8::Value> const& a
 static void JS_QueriesCurrentAql(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
-  auto context = TRI_IGETC;
   auto& vocbase = GetContextVocBase(isolate);
 
   if (args.Length() != 0) {
@@ -1075,53 +1074,15 @@ static void JS_QueriesCurrentAql(v8::FunctionCallbackInfo<v8::Value> const& args
   auto* queryList = vocbase.queryList();
   TRI_ASSERT(queryList != nullptr);
 
-  try {
-    auto queries = queryList->listCurrent();
-
-    uint32_t i = 0;
-    auto result = v8::Array::New(isolate, static_cast<int>(queries.size()));
-
-    for (auto q : queries) {
-      auto timeString = TRI_StringTimeStamp(q.started, false);
-
-      v8::Handle<v8::Object> obj = v8::Object::New(isolate);
-      obj->Set(context,
-               TRI_V8_ASCII_STRING(isolate, "id"),
-               TRI_V8UInt64String<TRI_voc_tick_t>(isolate, q.id)).FromMaybe(false);
-      obj->Set(context,
-               TRI_V8_ASCII_STRING(isolate, "database"),
-               TRI_V8_STD_STRING(isolate, q.database)).FromMaybe(false);
-      obj->Set(context,
-               TRI_V8_ASCII_STRING(isolate, "user"),
-               TRI_V8_STD_STRING(isolate, q.user)).FromMaybe(false);
-      obj->Set(context,
-               TRI_V8_ASCII_STRING(isolate, "query"),
-               TRI_V8_STD_STRING(isolate, q.queryString)).FromMaybe(false);
-      if (q.bindParameters != nullptr) {
-        obj->Set(context,
-                 TRI_V8_ASCII_STRING(isolate, "bindVars"),
-                 TRI_VPackToV8(isolate, q.bindParameters->slice())).FromMaybe(false);
-      } else {
-        obj->Set(context,
-                 TRI_V8_ASCII_STRING(isolate, "bindVars"), v8::Object::New(isolate)).FromMaybe(false);
-      }
-      obj->Set(context,
-               TRI_V8_ASCII_STRING(isolate, "started"),
-               TRI_V8_STD_STRING(isolate, timeString)).FromMaybe(false);
-      obj->Set(context,
-               TRI_V8_ASCII_STRING(isolate, "runTime"), v8::Number::New(isolate, q.runTime)).FromMaybe(false);
-      obj->Set(context,
-               TRI_V8_ASCII_STRING(isolate, "state"),
-               TRI_V8_STD_STRING(isolate, aql::QueryExecutionState::toString(q.state))).FromMaybe(false);
-      obj->Set(context,
-               TRI_V8_ASCII_STRING(isolate, "stream"), v8::Boolean::New(isolate, q.stream)).FromMaybe(false);
-      result->Set(context, i++, obj).FromMaybe(false);
-    }
-
-    TRI_V8_RETURN(result);
-  } catch (...) {
-    TRI_V8_THROW_EXCEPTION_MEMORY();
+  VPackBuilder b;
+  b.openArray();
+  for (auto const& q : queryList->listCurrent()) {
+    q.toVelocyPack(b);
   }
+  b.close();
+              
+  TRI_V8_RETURN(TRI_VPackToV8(isolate, b.slice()));
+  
   TRI_V8_TRY_CATCH_END
 }
 
@@ -1132,7 +1093,6 @@ static void JS_QueriesCurrentAql(v8::FunctionCallbackInfo<v8::Value> const& args
 static void JS_QueriesSlowAql(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
-  auto context = TRI_IGETC;
   auto& vocbase = GetContextVocBase(isolate);
   auto* queryList = vocbase.queryList();
   TRI_ASSERT(queryList != nullptr);
@@ -1146,53 +1106,15 @@ static void JS_QueriesSlowAql(v8::FunctionCallbackInfo<v8::Value> const& args) {
     TRI_V8_THROW_EXCEPTION_USAGE("AQL_QUERIES_SLOW()");
   }
 
-  try {
-    auto queries = queryList->listSlow();
-
-    uint32_t i = 0;
-    auto result = v8::Array::New(isolate, static_cast<int>(queries.size()));
-
-    for (auto q : queries) {
-      auto timeString = TRI_StringTimeStamp(q.started, false);
-
-      v8::Handle<v8::Object> obj = v8::Object::New(isolate);
-      obj->Set(context,
-               TRI_V8_ASCII_STRING(isolate, "id"),
-               TRI_V8UInt64String<TRI_voc_tick_t>(isolate, q.id)).FromMaybe(false);
-      obj->Set(context,
-               TRI_V8_ASCII_STRING(isolate, "database"),
-               TRI_V8_STD_STRING(isolate, q.database)).FromMaybe(false);
-      obj->Set(context,
-               TRI_V8_ASCII_STRING(isolate, "user"),
-               TRI_V8_STD_STRING(isolate, q.user)).FromMaybe(false);
-      obj->Set(context,
-               TRI_V8_ASCII_STRING(isolate, "query"),
-               TRI_V8_STD_STRING(isolate, q.queryString)).FromMaybe(false);
-      if (q.bindParameters != nullptr) {
-        obj->Set(context,
-                 TRI_V8_ASCII_STRING(isolate, "bindVars"),
-                 TRI_VPackToV8(isolate, q.bindParameters->slice())).FromMaybe(false);
-      } else {
-        obj->Set(context,
-                 TRI_V8_ASCII_STRING(isolate, "bindVars"), v8::Object::New(isolate)).FromMaybe(false);
-      }
-      obj->Set(context,
-               TRI_V8_ASCII_STRING(isolate, "started"),
-               TRI_V8_STD_STRING(isolate, timeString)).FromMaybe(false);
-      obj->Set(context,
-               TRI_V8_ASCII_STRING(isolate, "runTime"), v8::Number::New(isolate, q.runTime)).FromMaybe(false);
-      obj->Set(context,
-               TRI_V8_ASCII_STRING(isolate, "state"),
-               TRI_V8_STD_STRING(isolate, aql::QueryExecutionState::toString(q.state))).FromMaybe(false);
-      obj->Set(context,
-               TRI_V8_ASCII_STRING(isolate, "stream"), v8::Boolean::New(isolate, q.stream)).FromMaybe(false);
-      result->Set(context, i++, obj).FromMaybe(false);
-    }
-
-    TRI_V8_RETURN(result);
-  } catch (...) {
-    TRI_V8_THROW_EXCEPTION_MEMORY();
+  VPackBuilder b;
+  b.openArray();
+  for (auto const& q : queryList->listSlow()) {
+    q.toVelocyPack(b);
   }
+  b.close();
+              
+  TRI_V8_RETURN(TRI_VPackToV8(isolate, b.slice()));
+  
   TRI_V8_TRY_CATCH_END
 }
 

--- a/tests/Cluster/ClusterInfo-test.cpp
+++ b/tests/Cluster/ClusterInfo-test.cpp
@@ -161,13 +161,13 @@ class ClusterInfoTest : public ::testing::Test,
     arangodb::EngineSelectorFeature::ENGINE = &engine;
 
     // setup required application features
+    features.emplace_back(server.addFeature<arangodb::MetricsFeature>());  
     features.emplace_back(server.addFeature<arangodb::AuthenticationFeature>(), false);  // required for ClusterFeature::prepare()
     features.emplace_back(server.addFeature<arangodb::DatabaseFeature>(), false);
     features.emplace_back(server.addFeature<arangodb::application_features::CommunicationFeaturePhase>(),
                           false);
     features.emplace_back(server.addFeature<arangodb::ClusterFeature>(),
                           false);  // required for ClusterInfo::instance()
-    features.emplace_back(server.addFeature<arangodb::MetricsFeature>());  
     features.emplace_back(server.addFeature<arangodb::QueryRegistryFeature>(), false);  // required for DatabaseFeature::createDatabase(...)
     features.emplace_back(server.addFeature<arangodb::V8DealerFeature>(), false);  // required for DatabaseFeature::createDatabase(...)
     features.emplace_back(server.addFeature<arangodb::ViewTypesFeature>(), false);  // required for LogicalView::instantiate(...)

--- a/tests/IResearch/ExpressionFilter-test.cpp
+++ b/tests/IResearch/ExpressionFilter-test.cpp
@@ -261,11 +261,11 @@ struct IResearchExpressionFilterTest
     arangodb::tests::init(true);
 
     // setup required application features
+    features.emplace_back(server.addFeature<arangodb::MetricsFeature>(), false);
     features.emplace_back(server.addFeature<arangodb::ViewTypesFeature>(), true);
     features.emplace_back(server.addFeature<arangodb::AuthenticationFeature>(), true);
     features.emplace_back(server.addFeature<arangodb::DatabasePathFeature>(), false);
     features.emplace_back(server.addFeature<arangodb::DatabaseFeature>(), false);
-    features.emplace_back(server.addFeature<arangodb::MetricsFeature>(), false);
     features.emplace_back(server.addFeature<arangodb::QueryRegistryFeature>(), false);  // must be first
     system = irs::memory::make_unique<TRI_vocbase_t>(TRI_vocbase_type_e::TRI_VOCBASE_TYPE_NORMAL,
                                                      systemDBInfo(server));

--- a/tests/RestServer/FlushFeature-test.cpp
+++ b/tests/RestServer/FlushFeature-test.cpp
@@ -65,11 +65,11 @@ class FlushFeatureTest
   FlushFeatureTest() : engine(server), server(nullptr, nullptr) {
     arangodb::EngineSelectorFeature::ENGINE = &engine;
 
+    features.emplace_back(server.addFeature<arangodb::MetricsFeature>(), false); 
     features.emplace_back(server.addFeature<arangodb::AuthenticationFeature>(),
                           false);  // required for ClusterFeature::prepare()
     features.emplace_back(server.addFeature<arangodb::ClusterFeature>(), false);  // required for V8DealerFeature::prepare()
     features.emplace_back(server.addFeature<arangodb::DatabaseFeature>(), false);  // required for MMFilesWalRecoverState constructor
-    features.emplace_back(server.addFeature<arangodb::MetricsFeature>(), false); 
     features.emplace_back(server.addFeature<arangodb::QueryRegistryFeature>(), false);  // required for TRI_vocbase_t
     features.emplace_back(server.addFeature<arangodb::V8DealerFeature>(), false);  // required for DatabaseFeature::createDatabase(...)
 

--- a/tests/Sharding/ShardDistributionReporterTest.cpp
+++ b/tests/Sharding/ShardDistributionReporterTest.cpp
@@ -187,9 +187,9 @@ class ShardDistributionReporterTest
     aliases[dbserver3] = dbserver3short;
     arangodb::EngineSelectorFeature::ENGINE = &engine;
 
+    features.emplace_back(server.addFeature<arangodb::MetricsFeature>(), false);
     features.emplace_back(server.addFeature<arangodb::DatabaseFeature>(),
                           false);  // required for TRI_vocbase_t::dropCollection(...)
-    features.emplace_back(server.addFeature<arangodb::MetricsFeature>(), false);
     features.emplace_back(server.addFeature<arangodb::QueryRegistryFeature>(),
                           false);  // required for TRI_vocbase_t instantiation
 

--- a/tests/StorageEngine/PhysicalCollectionTest.cpp
+++ b/tests/StorageEngine/PhysicalCollectionTest.cpp
@@ -64,9 +64,9 @@ class PhysicalCollectionTest
     arangodb::EngineSelectorFeature::ENGINE = &engine;
 
     // setup required application features
+    features.emplace_back(server.addFeature<arangodb::MetricsFeature>());  
     features.emplace_back(server.addFeature<arangodb::AuthenticationFeature>());  // required for VocbaseContext
     features.emplace_back(server.addFeature<arangodb::DatabaseFeature>());
-    features.emplace_back(server.addFeature<arangodb::MetricsFeature>());  
     features.emplace_back(server.addFeature<arangodb::QueryRegistryFeature>());  // required for TRI_vocbase_t
 
 #if USE_ENTERPRISE

--- a/tests/VocBase/LogicalView-test.cpp
+++ b/tests/VocBase/LogicalView-test.cpp
@@ -111,8 +111,8 @@ class LogicalViewTest
   LogicalViewTest() : engine(server), server(nullptr, nullptr) {
     arangodb::EngineSelectorFeature::ENGINE = &engine;
 
-    features.emplace_back(server.addFeature<arangodb::AuthenticationFeature>(), false);  // required for ExecContext
     features.emplace_back(server.addFeature<arangodb::MetricsFeature>(), false);  
+    features.emplace_back(server.addFeature<arangodb::AuthenticationFeature>(), false);  // required for ExecContext
     features.emplace_back(server.addFeature<arangodb::QueryRegistryFeature>(), false);  // required for TRI_vocbase_t
     features.emplace_back(server.addFeature<arangodb::ViewTypesFeature>(), false);  // required for LogicalView::create(...)
 

--- a/tests/js/client/shell/shell-collection-counts-cluster.js
+++ b/tests/js/client/shell/shell-collection-counts-cluster.js
@@ -281,15 +281,22 @@ function collectionCountsSuite () {
       assertEqual(100000, c.toArray().length);
 
       let total = 0;
-      getDBServers().forEach((server) => {
-        if (servers.indexOf(server.id) === -1) {
-          return;
+      tries = 0;
+      while (tries++ < 120) {
+        getDBServers().forEach((server) => {
+          if (servers.indexOf(server.id) === -1) {
+            return;
+          }
+          let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
+          assertEqual(200, result.status);
+          assertEqual(100000, result.json.count);
+          total += result.json.count;
+        });
+        if (total === 2 * 100000) {
+          break;
         }
-        let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
-        assertEqual(200, result.status);
-        assertEqual(100000, result.json.count);
-        total += result.json.count;
-      });
+        require("internal").sleep(0.5);
+      }
       assertEqual(2 * 100000, total);
     },
     

--- a/tests/js/client/shell/shell-collection-counts-cluster.js
+++ b/tests/js/client/shell/shell-collection-counts-cluster.js
@@ -107,7 +107,7 @@ function collectionCountsSuite () {
       while (tries++ < 120) {
         shardInfo = c.shards(true);
         servers = shardInfo[shard];
-        if (servers.length === 2) {
+        if (servers.length === 2 && c.count() === 200) {
           break;
         }
         require("internal").sleep(0.5);
@@ -116,16 +116,23 @@ function collectionCountsSuite () {
       assertEqual(200, c.count());
       assertEqual(200, c.toArray().length);
 
-      let total = 0;
-      getDBServers().forEach((server) => {
-        if (servers.indexOf(server.id) === -1) {
-          return;
+      tries = 0;
+      let total;
+      while (tries++ < 120) {
+        total = 0;
+        getDBServers().forEach((server) => {
+          if (servers.indexOf(server.id) === -1) {
+            return;
+          }
+          let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
+          assertEqual(200, result.status);
+          total += result.json.count;
+        });
+        if (total === 2 * 200) {
+          break;
         }
-        let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
-        assertEqual(200, result.status);
-        assertEqual(200, result.json.count);
-        total += result.json.count;
-      });
+        require("internal").sleep(0.5);
+      }
       assertEqual(2 * 200, total);
     },
     
@@ -165,17 +172,24 @@ function collectionCountsSuite () {
       assertEqual(2, servers.length);
       assertEqual(100, c.count());
       assertEqual(100, c.toArray().length);
-      
-      let total = 0;
-      getDBServers().forEach((server) => {
-        if (servers.indexOf(server.id) === -1) {
-          return;
+     
+      tries = 0;
+      let total;
+      while (tries++ < 120) {
+        total = 0;
+        getDBServers().forEach((server) => {
+          if (servers.indexOf(server.id) === -1) {
+            return;
+          }
+          let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
+          assertEqual(200, result.status);
+          total += result.json.count;
+        });
+        if (total === 2 * 100) {
+          break;
         }
-        let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
-        assertEqual(200, result.status);
-        assertEqual(100, result.json.count);
-        total += result.json.count;
-      });
+        require("internal").sleep(0.5);
+      }
       assertEqual(2 * 100, total);
     },
     
@@ -221,16 +235,23 @@ function collectionCountsSuite () {
       assertEqual(200, c.count());
       assertEqual(200, c.toArray().length);
 
-      let total = 0;
-      getDBServers().forEach((server) => {
-        if (servers.indexOf(server.id) === -1) {
-          return;
+      tries = 0;
+      let total;
+      while (tries++ < 120) {
+        total = 0;
+        getDBServers().forEach((server) => {
+          if (servers.indexOf(server.id) === -1) {
+            return;
+          }
+          let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
+          assertEqual(200, result.status);
+          total += result.json.count;
+        });
+        if (total === 2 * 200) {
+          break;
         }
-        let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
-        assertEqual(200, result.status);
-        assertEqual(200, result.json.count);
-        total += result.json.count;
-      });
+        require("internal").sleep(0.5);
+      }
       assertEqual(2 * 200, total);
     },
     
@@ -280,16 +301,16 @@ function collectionCountsSuite () {
       assertEqual(100000, c.count());
       assertEqual(100000, c.toArray().length);
 
-      let total = 0;
       tries = 0;
+      let total;
       while (tries++ < 120) {
+        total = 0;
         getDBServers().forEach((server) => {
           if (servers.indexOf(server.id) === -1) {
             return;
           }
           let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
           assertEqual(200, result.status);
-          assertEqual(100000, result.json.count);
           total += result.json.count;
         });
         if (total === 2 * 100000) {
@@ -334,16 +355,16 @@ function collectionCountsSuite () {
       assertEqual(100, c.count());
       assertEqual(100, c.toArray().length);
       
-      let total = 0;
       tries = 0;
+      let total;
       while (tries++ < 120) {
+        total = 0;
         getDBServers().forEach((server) => {
           if (servers.indexOf(server.id) === -1) {
             return;
           }
           let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
           assertEqual(200, result.status);
-          assertEqual(100, result.json.count);
           total += result.json.count;
         });
         if (total === 2 * 100) {
@@ -387,17 +408,24 @@ function collectionCountsSuite () {
       assertEqual(2, servers.length);
       assertEqual(100, c.count());
       assertEqual(100, c.toArray().length);
-      
-      let total = 0;
-      getDBServers().forEach((server) => {
-        if (servers.indexOf(server.id) === -1) {
-          return;
+     
+      tries = 0;
+      let total;
+      while (tries++ < 120) {
+        total = 0;
+        getDBServers().forEach((server) => {
+          if (servers.indexOf(server.id) === -1) {
+            return;
+          }
+          let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
+          assertEqual(200, result.status);
+          total += result.json.count;
+        });
+        if (total === 2 * 100) {
+          break;
         }
-        let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
-        assertEqual(200, result.status);
-        assertEqual(100, result.json.count);
-        total += result.json.count;
-      });
+        require("internal").sleep(0.5);
+      }
       assertEqual(2 * 100, total);
     },
     
@@ -456,16 +484,23 @@ function collectionCountsSuite () {
       assertEqual(101, c.count());
       assertEqual(101, c.toArray().length);
       
-      let total = 0;
-      getDBServers().forEach((server) => {
-        if (servers.indexOf(server.id) === -1) {
-          return;
+      tries = 0;
+      let total;
+      while (tries++ < 120) {
+        total = 0;
+        getDBServers().forEach((server) => {
+          if (servers.indexOf(server.id) === -1) {
+            return;
+          }
+          let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
+          assertEqual(200, result.status);
+          total += result.json.count;
+        });
+        if (total === 2 * 101) {
+          break;
         }
-        let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
-        assertEqual(200, result.status);
-        assertEqual(101, result.json.count);
-        total += result.json.count;
-      });
+        require("internal").sleep(0.5);
+      }
       assertEqual(2 * 101, total);
     },
     
@@ -524,16 +559,23 @@ function collectionCountsSuite () {
       assertEqual(101, c.count());
       assertEqual(101, c.toArray().length);
       
-      let total = 0;
-      getDBServers().forEach((server) => {
-        if (servers.indexOf(server.id) === -1) {
-          return;
+      tries = 0;
+      let total;
+      while (tries++ < 120) {
+        total = 0;
+        getDBServers().forEach((server) => {
+          if (servers.indexOf(server.id) === -1) {
+            return;
+          }
+          let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
+          assertEqual(200, result.status);
+          total += result.json.count;
+        });
+        if (total === 2 * 101) {
+          break;
         }
-        let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
-        assertEqual(200, result.status);
-        assertEqual(101, result.json.count);
-        total += result.json.count;
-      });
+        require("internal").sleep(0.5);
+      }
       assertEqual(2 * 101, total);
     },
     
@@ -597,17 +639,24 @@ function collectionCountsSuite () {
       assertEqual(2, servers.length);
       assertEqual(101, c.count());
       assertEqual(101, c.toArray().length);
-      
-      let total = 0;
-      getDBServers().forEach((server) => {
-        if (servers.indexOf(server.id) === -1) {
-          return;
+     
+      tries = 0;
+      let total;
+      while (tries++ < 120) {
+        total = 0;
+        getDBServers().forEach((server) => {
+          if (servers.indexOf(server.id) === -1) {
+            return;
+          }
+          let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
+          assertEqual(200, result.status);
+          total += result.json.count;
+        });
+        if (total === 2 * 101) {
+          break;
         }
-        let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
-        assertEqual(200, result.status);
-        assertEqual(101, result.json.count);
-        total += result.json.count;
-      });
+        require("internal").sleep(0.5);
+      }
       assertEqual(2 * 101, total);
     },
 

--- a/tests/js/client/shell/shell-collection-counts-cluster.js
+++ b/tests/js/client/shell/shell-collection-counts-cluster.js
@@ -1,0 +1,611 @@
+/*jshint globalstrict:false, strict:false, maxlen : 4000 */
+/* global arango, assertTrue, assertFalse, assertEqual, assertNotEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief tests for inventory
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+const jsunity = require('jsunity');
+const db = require("@arangodb").db;
+const request = require("@arangodb/request");
+const _ = require("lodash");
+
+function collectionCountsSuite () {
+  const cn = "UnitTestsCollection";
+
+  let getDBServers = function() {
+    const isDBServer = (d) => (_.toLower(d.role) === 'dbserver');
+    const endpointToURL = (server) => {
+      let endpoint = server.endpoint;
+      if (endpoint.substr(0, 6) === 'ssl://') {
+        return 'https://' + endpoint.substr(6);
+      }
+      let pos = endpoint.indexOf('://');
+      if (pos === -1) {
+        return 'http://' + endpoint;
+      }
+      return 'http' + endpoint.substr(pos);
+    };
+
+    return global.instanceInfo.arangods.filter(isDBServer)
+                                .map((server) => { 
+                                  return { url: endpointToURL(server), id: server.id };
+                                });
+  };
+
+  let clearFailurePoints = function () {
+    getDBServers().forEach((server) => {
+      // clear all failure points
+      request({ method: "DELETE", url: server.url + "/_admin/debug/failat" });
+    });
+  };
+  
+  return {
+    setUp : function () {
+      db._drop(cn);
+    },
+
+    tearDown : function () {
+      clearFailurePoints();
+      db._drop(cn);
+    },
+
+    testWrongCountOnLeaderFullSync : function () {
+      let c = db._create(cn, { numberOfShards: 1, replicationFactor: 1 }); 
+      for (let i = 0; i < 100; ++i) {
+        c.insert({ _key: "test" + i }); 
+      }
+      assertEqual(100, c.count());
+      assertEqual(100, c.toArray().length);
+
+      let servers = getDBServers();
+      let shardInfo = c.shards(true);
+      let shard = Object.keys(shardInfo)[0];
+      let leader = shardInfo[shard][0];
+      let leaderUrl = servers.filter((server) => server.id === leader)[0].url;
+
+      // set a failure point to get the counts wrong on the leader
+      let result = request({ method: "PUT", url: leaderUrl + "/_admin/debug/failat/RocksDBCommitCounts", body: {} });
+      assertEqual(200, result.status);
+      
+      for (let i = 100; i < 200; ++i) {
+        c.insert({ _key: "test" + i }); 
+      }
+
+      assertNotEqual(200, c.count());
+      assertEqual(200, c.toArray().length);
+      clearFailurePoints();
+
+      c.properties({ replicationFactor: 2 });
+
+      // wait until we have an in-sync follower
+      let tries = 0;
+      while (tries++ < 120) {
+        shardInfo = c.shards(true);
+        servers = shardInfo[shard];
+        if (servers.length === 2) {
+          break;
+        }
+        require("internal").sleep(0.5);
+      }
+      assertEqual(2, servers.length);
+      assertEqual(200, c.count());
+      assertEqual(200, c.toArray().length);
+
+      let total = 0;
+      getDBServers().forEach((server) => {
+        if (servers.indexOf(server.id) === -1) {
+          return;
+        }
+        let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
+        assertEqual(200, result.status);
+        assertEqual(200, result.json.count);
+        total += result.json.count;
+      });
+      assertEqual(2 * 200, total);
+    },
+    
+    testWrongCountOnLeaderFullSync2 : function () {
+      let c = db._create(cn, { numberOfShards: 1, replicationFactor: 1 }); 
+
+      let servers = getDBServers();
+      let shardInfo = c.shards(true);
+      let shard = Object.keys(shardInfo)[0];
+      let leader = shardInfo[shard][0];
+      let leaderUrl = servers.filter((server) => server.id === leader)[0].url;
+
+      // set a failure point to get the counts wrong on the leader
+      let result = request({ method: "PUT", url: leaderUrl + "/_admin/debug/failat/RocksDBCommitCounts", body: {} });
+      assertEqual(200, result.status);
+      
+      for (let i = 0; i < 100; ++i) {
+        c.insert({ _key: "test" + i }); 
+      }
+      
+      assertEqual(100, c.toArray().length);
+      assertNotEqual(100, c.count());
+
+      c.properties({ replicationFactor: 2 });
+
+      // wait until we have an in-sync follower
+      let tries = 0;
+      while (tries++ < 120) {
+        shardInfo = c.shards(true);
+        servers = shardInfo[shard];
+        if (servers.length === 2 && c.count() === 100) {
+          break;
+        }
+        require("internal").sleep(0.5);
+      }
+      
+      assertEqual(2, servers.length);
+      assertEqual(100, c.count());
+      assertEqual(100, c.toArray().length);
+      
+      let total = 0;
+      getDBServers().forEach((server) => {
+        if (servers.indexOf(server.id) === -1) {
+          return;
+        }
+        let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
+        assertEqual(200, result.status);
+        assertEqual(100, result.json.count);
+        total += result.json.count;
+      });
+      assertEqual(2 * 100, total);
+    },
+    
+    testRandomCountOnLeaderFullSync : function () {
+      let c = db._create(cn, { numberOfShards: 1, replicationFactor: 1 }); 
+      for (let i = 0; i < 100; ++i) {
+        c.insert({ _key: "test" + i }); 
+      }
+      assertEqual(100, c.count());
+      assertEqual(100, c.toArray().length);
+
+      let servers = getDBServers();
+      let shardInfo = c.shards(true);
+      let shard = Object.keys(shardInfo)[0];
+      let leader = shardInfo[shard][0];
+      let leaderUrl = servers.filter((server) => server.id === leader)[0].url;
+
+      // set a failure point to get the counts wrong on the leader
+      let result = request({ method: "PUT", url: leaderUrl + "/_admin/debug/failat/RocksDBCommitCountsRandom", body: {} });
+      assertEqual(200, result.status);
+      
+      for (let i = 100; i < 200; ++i) {
+        c.insert({ _key: "test" + i }); 
+      }
+
+      assertNotEqual(200, c.count());
+      assertEqual(200, c.toArray().length);
+      clearFailurePoints();
+
+      c.properties({ replicationFactor: 2 });
+
+      // wait until we have an in-sync follower
+      let tries = 0;
+      while (tries++ < 120) {
+        shardInfo = c.shards(true);
+        servers = shardInfo[shard];
+        if (servers.length === 2 && c.count() === 200) {
+          break;
+        }
+        require("internal").sleep(0.5);
+      }
+      assertEqual(2, servers.length);
+      assertEqual(200, c.count());
+      assertEqual(200, c.toArray().length);
+
+      let total = 0;
+      getDBServers().forEach((server) => {
+        if (servers.indexOf(server.id) === -1) {
+          return;
+        }
+        let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
+        assertEqual(200, result.status);
+        assertEqual(200, result.json.count);
+        total += result.json.count;
+      });
+      assertEqual(2 * 200, total);
+    },
+    
+    testWrongCountOnLeaderFullSyncLargeCollection : function () {
+      let c = db._create(cn, { numberOfShards: 1, replicationFactor: 1 }); 
+      let docs = [];
+      for (let i = 0; i < 5000; ++i) {
+        docs.push({ value: i });
+      }
+      for (let i = 0; i < 10; ++i) {
+        c.insert(docs);
+      }
+      assertEqual(50000, c.count());
+      assertEqual(50000, c.toArray().length);
+
+      let servers = getDBServers();
+      let shardInfo = c.shards(true);
+      let shard = Object.keys(shardInfo)[0];
+      let leader = shardInfo[shard][0];
+      let leaderUrl = servers.filter((server) => server.id === leader)[0].url;
+
+      // set a failure point to get the counts wrong on the leader
+      let result = request({ method: "PUT", url: leaderUrl + "/_admin/debug/failat/RocksDBCommitCounts", body: {} });
+      assertEqual(200, result.status);
+      
+      for (let i = 0; i < 10; ++i) {
+        c.insert(docs);
+      }
+
+      assertNotEqual(100000, c.count());
+      assertEqual(100000, c.toArray().length);
+      clearFailurePoints();
+
+      c.properties({ replicationFactor: 2 });
+
+      // wait until we have an in-sync follower
+      let tries = 0;
+      while (tries++ < 120) {
+        shardInfo = c.shards(true);
+        servers = shardInfo[shard];
+        if (servers.length === 2 && c.count() === 100000) {
+          break;
+        }
+        require("internal").sleep(0.5);
+      }
+      assertEqual(2, servers.length);
+      assertEqual(100000, c.count());
+      assertEqual(100000, c.toArray().length);
+
+      let total = 0;
+      getDBServers().forEach((server) => {
+        if (servers.indexOf(server.id) === -1) {
+          return;
+        }
+        let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
+        assertEqual(200, result.status);
+        assertEqual(100000, result.json.count);
+        total += result.json.count;
+      });
+      assertEqual(2 * 100000, total);
+    },
+    
+    testWrongCountOnFollowerFullSync : function () {
+      let c = db._create(cn, { numberOfShards: 1, replicationFactor: 1 }); 
+      for (let i = 0; i < 100; ++i) {
+        c.insert({ _key: "test" + i }); 
+      }
+      assertEqual(100, c.count());
+      assertEqual(100, c.toArray().length);
+
+      let servers = getDBServers();
+      let shardInfo = c.shards(true);
+      let shard = Object.keys(shardInfo)[0];
+      let leader = shardInfo[shard][0];
+      // set failure points to get the counts wrong on the followers
+      getDBServers().filter((server) => server.id !== leader).forEach((server) => {
+        let result = request({ method: "PUT", url: server.url + "/_admin/debug/failat/RocksDBCommitCounts", body: {} });
+        assertEqual(200, result.status);
+      });
+
+      c.properties({ replicationFactor: 2 });
+
+      // wait until we have an in-sync follower
+      let tries = 0;
+      while (tries++ < 120) {
+        shardInfo = c.shards(true);
+        servers = shardInfo[shard];
+        if (servers.length === 2) {
+          break;
+        }
+        require("internal").sleep(0.5);
+      }
+      assertEqual(2, servers.length);
+      assertEqual(100, c.count());
+      assertEqual(100, c.toArray().length);
+      
+      let total = 0;
+      tries = 0;
+      while (tries++ < 120) {
+        getDBServers().forEach((server) => {
+          if (servers.indexOf(server.id) === -1) {
+            return;
+          }
+          let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
+          assertEqual(200, result.status);
+          assertEqual(100, result.json.count);
+          total += result.json.count;
+        });
+        if (total === 2 * 100) {
+          break;
+        }
+        require("internal").sleep(0.5);
+      }
+      assertEqual(2 * 100, total);
+    },
+    
+    testRandomCountOnFollowerFullSync : function () {
+      let c = db._create(cn, { numberOfShards: 1, replicationFactor: 1 }); 
+      for (let i = 0; i < 100; ++i) {
+        c.insert({ _key: "test" + i }); 
+      }
+      assertEqual(100, c.count());
+      assertEqual(100, c.toArray().length);
+
+      let servers = getDBServers();
+      let shardInfo = c.shards(true);
+      let shard = Object.keys(shardInfo)[0];
+      let leader = shardInfo[shard][0];
+      // set failure points to get the counts wrong on the followers
+      getDBServers().filter((server) => server.id !== leader).forEach((server) => {
+        let result = request({ method: "PUT", url: server.url + "/_admin/debug/failat/RocksDBCommitCountsRandom", body: {} });
+        assertEqual(200, result.status);
+      });
+
+      c.properties({ replicationFactor: 2 });
+
+      // wait until we have an in-sync follower
+      let tries = 0;
+      while (tries++ < 120) {
+        shardInfo = c.shards(true);
+        servers = shardInfo[shard];
+        if (servers.length === 2) {
+          break;
+        }
+        require("internal").sleep(0.5);
+      }
+      assertEqual(2, servers.length);
+      assertEqual(100, c.count());
+      assertEqual(100, c.toArray().length);
+      
+      let total = 0;
+      getDBServers().forEach((server) => {
+        if (servers.indexOf(server.id) === -1) {
+          return;
+        }
+        let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
+        assertEqual(200, result.status);
+        assertEqual(100, result.json.count);
+        total += result.json.count;
+      });
+      assertEqual(2 * 100, total);
+    },
+    
+    testWrongCountOnLeaderIncrementalSync : function () {
+      let c = db._create(cn, { numberOfShards: 1, replicationFactor: 2 }); 
+
+      let servers = getDBServers();
+      let shardInfo = c.shards(true);
+      let shard = Object.keys(shardInfo)[0];
+      assertEqual(2, shardInfo[shard].length);
+      let leader = shardInfo[shard][0];
+      let leaderUrl = servers.filter((server) => server.id === leader)[0].url;
+
+      for (let i = 0; i < 100; ++i) {
+        c.insert({ _key: "test" + i }); 
+      }
+      
+      // wait until we have an in-sync follower
+      let tries = 0;
+      while (tries++ < 120) {
+        shardInfo = c.shards(true);
+        servers = shardInfo[shard];
+        if (servers.length === 2) {
+          break;
+        }
+        require("internal").sleep(0.5);
+      }
+      
+      // set a failure point to get the counts wrong on the leader
+      let result = request({ method: "PUT", url: leaderUrl + "/_admin/debug/failat/RocksDBCommitCounts", body: {} });
+      assertEqual(200, result.status);
+      
+      // set a failure point on the leader to drop the follower
+      result = request({ method: "PUT", url: leaderUrl + "/_admin/debug/failat/replicateOperationsDropFollower", body: {} });
+      assertEqual(200, result.status);
+     
+      c.insert({ _key: "test100" });
+
+      assertEqual(101, c.toArray().length);
+      
+      clearFailurePoints();
+        
+      // wait until we have an in-sync follower again
+      tries = 0;
+      while (tries++ < 120) {
+        shardInfo = c.shards(true);
+        servers = shardInfo[shard];
+        // also wait for the replication to have repaired the count on the leader
+        if (servers.length === 2 && c.count() === 101) {
+          break;
+        }
+        require("internal").sleep(0.5);
+      }
+      
+      assertEqual(2, servers.length);
+      assertEqual(101, c.count());
+      assertEqual(101, c.toArray().length);
+      
+      let total = 0;
+      getDBServers().forEach((server) => {
+        if (servers.indexOf(server.id) === -1) {
+          return;
+        }
+        let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
+        assertEqual(200, result.status);
+        assertEqual(101, result.json.count);
+        total += result.json.count;
+      });
+      assertEqual(2 * 101, total);
+    },
+    
+    testRandomCountOnLeaderIncrementalSync : function () {
+      let c = db._create(cn, { numberOfShards: 1, replicationFactor: 2 }); 
+
+      let servers = getDBServers();
+      let shardInfo = c.shards(true);
+      let shard = Object.keys(shardInfo)[0];
+      assertEqual(2, shardInfo[shard].length);
+      let leader = shardInfo[shard][0];
+      let leaderUrl = servers.filter((server) => server.id === leader)[0].url;
+      
+      // set a failure point to get the counts wrong on the leader
+      let result = request({ method: "PUT", url: leaderUrl + "/_admin/debug/failat/RocksDBCommitCountsRandom", body: {} });
+      assertEqual(200, result.status);
+
+      for (let i = 0; i < 100; ++i) {
+        c.insert({ _key: "test" + i }); 
+      }
+      
+      // wait until we have an in-sync follower
+      let tries = 0;
+      while (tries++ < 120) {
+        shardInfo = c.shards(true);
+        servers = shardInfo[shard];
+        if (servers.length === 2) {
+          break;
+        }
+        require("internal").sleep(0.5);
+      }
+      
+      // set a failure point on the leader to drop the follower
+      result = request({ method: "PUT", url: leaderUrl + "/_admin/debug/failat/replicateOperationsDropFollower", body: {} });
+      assertEqual(200, result.status);
+     
+      c.insert({ _key: "test100" });
+
+      assertEqual(101, c.toArray().length);
+      
+      clearFailurePoints();
+        
+      // wait until we have an in-sync follower again
+      tries = 0;
+      while (tries++ < 120) {
+        shardInfo = c.shards(true);
+        servers = shardInfo[shard];
+        // also wait for the replication to have repaired the count on the leader
+        if (servers.length === 2 && c.count() === 101) {
+          break;
+        }
+        require("internal").sleep(0.5);
+      }
+      
+      assertEqual(2, servers.length);
+      assertEqual(101, c.count());
+      assertEqual(101, c.toArray().length);
+      
+      let total = 0;
+      getDBServers().forEach((server) => {
+        if (servers.indexOf(server.id) === -1) {
+          return;
+        }
+        let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
+        assertEqual(200, result.status);
+        assertEqual(101, result.json.count);
+        total += result.json.count;
+      });
+      assertEqual(2 * 101, total);
+    },
+    
+    testWrongCountOnFollowerIncrementalSync : function () {
+      let c = db._create(cn, { numberOfShards: 1, replicationFactor: 2 }); 
+
+      let servers = getDBServers();
+      let shardInfo = c.shards(true);
+      let shard = Object.keys(shardInfo)[0];
+      assertEqual(2, shardInfo[shard].length);
+      let leader = shardInfo[shard][0];
+      let leaderUrl = servers.filter((server) => server.id === leader)[0].url;
+      let follower = shardInfo[shard][1];
+      let followerUrl = servers.filter((server) => server.id === follower)[0].url;
+      
+      // set a failure point to get the counts wrong on the follower
+      let result = request({ method: "PUT", url: followerUrl + "/_admin/debug/failat/RocksDBCommitCounts", body: {} });
+      assertEqual(200, result.status);
+
+      for (let i = 0; i < 100; ++i) {
+        c.insert({ _key: "test" + i }); 
+      }
+      
+      // wait until we have an in-sync follower
+      let tries = 0;
+      while (tries++ < 120) {
+        shardInfo = c.shards(true);
+        servers = shardInfo[shard];
+        if (servers.length === 2) {
+          break;
+        }
+        require("internal").sleep(0.5);
+      }
+      
+      // set a failure point on the leader to drop the follower
+      result = request({ method: "PUT", url: leaderUrl + "/_admin/debug/failat/replicateOperationsDropFollower", body: {} });
+      assertEqual(200, result.status);
+     
+      c.insert({ _key: "test100" });
+
+      assertEqual(101, c.toArray().length);
+      assertEqual(101, c.count());
+      
+      clearFailurePoints();
+        
+      // wait until we have an in-sync follower again
+      tries = 0;
+      while (tries++ < 120) {
+        shardInfo = c.shards(true);
+        servers = shardInfo[shard];
+        // also wait for the replication to have repaired the count on the follower
+        try {
+          let result = request({ method: "GET", url: followerUrl + "/_api/collection/" + shard + "/count" });
+          if (servers.length === 2 && result.json.count === 101) {
+            break;
+          }
+        } catch (err) {}
+        require("internal").sleep(0.5);
+      }
+      
+      assertEqual(2, servers.length);
+      assertEqual(101, c.count());
+      assertEqual(101, c.toArray().length);
+      
+      let total = 0;
+      getDBServers().forEach((server) => {
+        if (servers.indexOf(server.id) === -1) {
+          return;
+        }
+        let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
+        assertEqual(200, result.status);
+        assertEqual(101, result.json.count);
+        total += result.json.count;
+      });
+      assertEqual(2 * 101, total);
+    },
+
+  };
+}
+
+jsunity.run(collectionCountsSuite);
+return jsunity.done();

--- a/tests/js/server/replication/sync/replication-sync.js
+++ b/tests/js/server/replication/sync/replication-sync.js
@@ -134,7 +134,7 @@ function BaseTestConfig () {
           arango.PUT_RAW("/_admin/debug/failat/RocksDBCommitCounts", "");
           c.insert({});
           arango.DELETE_RAW("/_admin/debug/failat", "");
-          assertEqual(5001, c.count());
+          assertEqual(5000, c.count());
           assertEqual(5001, c.toArray().length);
         },
         function (state) {
@@ -191,7 +191,7 @@ function BaseTestConfig () {
             c.insert({ _key: "testmann" + i });
           }
           arango.DELETE_RAW("/_admin/debug/failat", "");
-          assertEqual(9100, c.count());
+          assertEqual(9000, c.count());
           assertEqual(9100, c.toArray().length);
         },
         function (state) {


### PR DESCRIPTION
### Scope & Purpose

If there's a checksum mismatch, we can currently get stuck in an endless loop since the checksum is currently just a collection count, and it may not get corrected if all documents are actually present and the cached count is simply wrong. This PR triggers a recount first on the  follower, then the leader if necessary, using a new non-blocking method to recalculate the count.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] Backports required for: *3.6*

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [ ] Added **Regression Tests**
  - [ ] Added new C++ **Unit Tests**
  - [x] Added new **integration tests** (i.e. in shell_client)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12259/