### PR TITLE
Make sure response is set if no error is indicated (#12766)

### DIFF
--- a/arangod/Network/Methods.cpp
+++ b/arangod/Network/Methods.cpp
@@ -69,8 +69,8 @@ Result Response::combinedResult() const {
     return Result{fuerteToArangoErrorCode(*this), fuerteToArangoErrorMessage(*this)};
   } else {
     if (!statusIsSuccess(response->statusCode())) {
-      // HTTP status error. Try to extract a precise error from the body, and fall
-      // back to the HTTP status.
+      // HTTP status error. Try to extract a precise error from the body, and
+      // fall back to the HTTP status.
       return resultFromBody(response->slice(), fuerteStatusToArangoErrorCode(*response));
     } else {
       return Result{};
@@ -80,6 +80,9 @@ Result Response::combinedResult() const {
 
 auto prepareRequest(RestVerb type, std::string path, VPackBufferUInt8 payload,
                     RequestOptions const& options, Headers headers) {
+  TRI_ASSERT(path.find("/_db/") == std::string::npos);
+  TRI_ASSERT(path.find('?') == std::string::npos);
+
   auto req = fuerte::createRequest(type, path, options.parameters, std::move(payload));
 
   req->header.database = options.database;
@@ -96,8 +99,6 @@ auto prepareRequest(RestVerb type, std::string path, VPackBufferUInt8 payload,
   req->header.addMeta(StaticStrings::HLCHeader,
                       arangodb::basics::HybridLogicalClock::encodeTimeStamp(timeStamp));
 
-  req->timeout(std::chrono::duration_cast<std::chrono::milliseconds>(options.timeout));
-
   auto state = ServerState::instance();
   if (state->isCoordinator() || state->isDBServer()) {
     req->header.addMeta(StaticStrings::ClusterCommSource, state->getId());
@@ -112,7 +113,8 @@ auto prepareRequest(RestVerb type, std::string path, VPackBufferUInt8 payload,
 }
 
 /// @brief Function to produce a response object from thin air:
-static std::unique_ptr<fuerte::Response> buildResponse(fuerte::StatusCode statusCode, Result const& res) {
+static std::unique_ptr<fuerte::Response> buildResponse(fuerte::StatusCode statusCode,
+                                                       Result const& res) {
   VPackBuffer<uint8_t> buffer;
   VPackBuilder builder(buffer);
   {
@@ -137,41 +139,43 @@ static std::unique_ptr<fuerte::Response> buildResponse(fuerte::StatusCode status
 FutureRes sendRequest(ConnectionPool* pool, DestinationId dest, RestVerb type,
                       std::string path, velocypack::Buffer<uint8_t> payload,
                       RequestOptions const& options, Headers headers) {
-
   LOG_TOPIC("2713a", DEBUG, Logger::COMMUNICATION)
-      << "request to '" << dest
-      << "' '" << fuerte::to_string(type) << " " << path << "'";
+      << "request to '" << dest << "' '" << fuerte::to_string(type) << " "
+      << path << "'";
 
   // FIXME build future.reset(..)
   try {
-
     auto req = prepareRequest(type, std::move(path), std::move(payload),
                               options, std::move(headers));
+    req->timeout(std::chrono::duration_cast<std::chrono::milliseconds>(options.timeout));
 
     if (!pool || !pool->config().clusterInfo) {
       LOG_TOPIC("59b95", ERR, Logger::COMMUNICATION)
-        << "connection pool unavailable";
-      return futures::makeFuture(Response{std::move(dest), Error::Canceled, nullptr, std::move(req)});
+          << "connection pool unavailable";
+      return futures::makeFuture(Response{std::move(dest), Error::Canceled,
+                                          std::move(req), nullptr});
     }
 
     arangodb::network::EndpointSpec spec;
     int res = resolveDestination(*pool->config().clusterInfo, dest, spec);
     if (res != TRI_ERROR_NO_ERROR) {
-      // We fake a successful request with statusCode 503 and a backend not available
-      // error here:
+      // We fake a successful request with statusCode 503 and a backend not
+      // available error here:
       auto resp = buildResponse(fuerte::StatusServiceUnavailable, Result{res});
-      return futures::makeFuture(Response{std::move(dest), Error::NoError, std::move(resp), std::move(req)});
+      return futures::makeFuture(Response{std::move(dest), Error::NoError,
+                                          std::move(req), std::move(resp)});
     }
     TRI_ASSERT(!spec.endpoint.empty());
 
     struct Pack {
       DestinationId dest;
       futures::Promise<network::Response> promise;
-      std::unique_ptr<fuerte::Response> tmp;
+      std::unique_ptr<fuerte::Response> tmp_res;
       std::unique_ptr<fuerte::Request> tmp_req;
+      fuerte::Error tmp_err;
       bool skipScheduler;
       Pack(DestinationId&& dest, bool skip)
-        : dest(std::move(dest)), promise(), skipScheduler(skip) {}
+          : dest(std::move(dest)), skipScheduler(skip) {}
     };
 
     // fits in SSO of std::function
@@ -180,132 +184,140 @@ FutureRes sendRequest(ConnectionPool* pool, DestinationId dest, RestVerb type,
     auto p = std::make_shared<Pack>(std::move(dest), options.skipScheduler);
 
     FutureRes f = p->promise.getFuture();
-    conn->sendRequest(
-      std::move(req),
-      [p(std::move(p))](fuerte::Error err, std::unique_ptr<fuerte::Request> req,
-                        std::unique_ptr<fuerte::Response> res) {
-        Scheduler* sch = SchedulerFeature::SCHEDULER;
-        if (p->skipScheduler || sch == nullptr) {
-          p->promise.setValue(network::Response{std::move(p->dest), err, std::move(res), std::move(req)});
-          return;
-        }
+    conn->sendRequest(std::move(req), [p(std::move(p))](fuerte::Error err,
+                                                        std::unique_ptr<fuerte::Request> req,
+                                                        std::unique_ptr<fuerte::Response> res) mutable {
+      Scheduler* sch = SchedulerFeature::SCHEDULER;
+      if (p->skipScheduler || sch == nullptr) {
+        p->promise.setValue(network::Response{std::move(p->dest), err,
+                                              std::move(req), std::move(res)});
+        return;
+      }
 
-        p->tmp = std::move(res);
-        p->tmp_req = std::move(req);
+      p->tmp_err = err;
+      p->tmp_res = std::move(res);
+      p->tmp_req = std::move(req);
 
-        bool queued = sch->queue(
-          RequestLane::CLUSTER_INTERNAL,
-          [p, err]() {
-            p->promise.setValue(Response{std::move(p->dest), err, std::move(p->tmp), std::move(p->tmp_req)});
-          });
-        if (ADB_UNLIKELY(!queued)) {
-          p->promise.setValue(Response{std::move(p->dest), fuerte::Error::Canceled, nullptr, std::move(p->tmp_req)});
-        }
+      bool queued = sch->queue(RequestLane::CLUSTER_INTERNAL, [p]() mutable {
+        p->promise.setValue(Response{std::move(p->dest), p->tmp_err,
+                                     std::move(p->tmp_req), std::move(p->tmp_res)});
       });
+      if (ADB_UNLIKELY(!queued)) {
+        p->promise.setValue(Response{std::move(p->dest), fuerte::Error::QueueCapacityExceeded,
+                                     std::move(p->tmp_req), nullptr});
+      }
+    });
     return f;
 
   } catch (std::exception const& e) {
-    LOG_TOPIC("236d7", DEBUG, Logger::COMMUNICATION) << "failed to send request: " << e.what();
+    LOG_TOPIC("236d7", DEBUG, Logger::COMMUNICATION)
+        << "failed to send request: " << e.what();
   } catch (...) {
-    LOG_TOPIC("36d72", DEBUG, Logger::COMMUNICATION) << "failed to send request.";
+    LOG_TOPIC("36d72", DEBUG, Logger::COMMUNICATION)
+        << "failed to send request.";
   }
-  return futures::makeFuture(Response{std::string(), Error::Canceled, nullptr, nullptr});
+  return futures::makeFuture(
+      Response{std::string(), Error::Canceled, nullptr, nullptr});
 }
 
-/// Handler class with enough information to keep retrying
+/// Stateful handler class with enough information to keep retrying
 /// a request until an overall timeout is hit (or the request succeeds)
 class RequestsState final : public std::enable_shared_from_this<RequestsState> {
  public:
   RequestsState(ConnectionPool* pool, DestinationId&& destination, RestVerb type,
                 std::string&& path, velocypack::Buffer<uint8_t>&& payload,
                 Headers&& headers, RequestOptions const& options)
-      : _payload(std::move(payload)),
-        _destination(std::move(destination)),
-        _path(std::move(path)),
-        _headers(std::move(headers)),
+      : _destination(std::move(destination)),
         _options(options),
         _pool(pool),
-        _type(type),
-        _workItem(nullptr),
-        _response(nullptr),
-        _promise(),
         _startTime(std::chrono::steady_clock::now()),
         _endTime(_startTime + std::chrono::duration_cast<std::chrono::steady_clock::duration>(
-                                  options.timeout)) {}
+                                  options.timeout)) {
+    _tmp_req = prepareRequest(type, std::move(path), std::move(payload), _options, std::move(headers));
+  }
 
   ~RequestsState() = default;
 
  private:
-  velocypack::Buffer<uint8_t> _payload;
-  DestinationId _destination;
-  std::string _path;
-  Headers _headers;
+  DestinationId const _destination;
   RequestOptions const _options;
   ConnectionPool* _pool;
-  RestVerb _type;
 
   std::shared_ptr<arangodb::Scheduler::WorkItem> _workItem;
-  std::unique_ptr<fuerte::Response> _response;   /// temporary response
-  std::unique_ptr<fuerte::Request> _request;
+  std::unique_ptr<fuerte::Request> _tmp_req;
+  std::unique_ptr<fuerte::Response> _tmp_res;  /// temporary response
+
   futures::Promise<network::Response> _promise;  /// promise called
 
   std::chrono::steady_clock::time_point const _startTime;
   std::chrono::steady_clock::time_point const _endTime;
 
+  fuerte::Error _tmp_err;
+
  public:
   FutureRes future() { return _promise.getFuture(); }
 
-
   // scheduler requests that are due
   void startRequest() {
+    TRI_ASSERT(_tmp_req != nullptr);
     if (ADB_UNLIKELY(!_pool)) {
       LOG_TOPIC("5949f", ERR, Logger::COMMUNICATION)
           << "connection pool unavailable";
-      callResponse(Error::Canceled, nullptr, std::move(_request));
+      _tmp_err = Error::Canceled;
+      _tmp_res = nullptr;
+      resolvePromise();
       return;
     }
 
     auto now = std::chrono::steady_clock::now();
     if (now > _endTime || _pool->config().clusterInfo->server().isStopping()) {
-      callResponse(Error::Timeout, nullptr, std::move(_request));
+      _tmp_err = Error::Timeout;
+      _tmp_res = nullptr;
+      resolvePromise();
       return;  // we are done
     }
 
     arangodb::network::EndpointSpec spec;
     int res = resolveDestination(*_pool->config().clusterInfo, _destination, spec);
     if (res != TRI_ERROR_NO_ERROR) {  // ClusterInfo did not work
-      // We fake a successful request with statusCode 503 and a backend not available
-      // error here:
-      auto resp = buildResponse(fuerte::StatusServiceUnavailable, Result{res});
-      callResponse(Error::NoError, std::move(resp), std::move(_request));
+      // We fake a successful request with statusCode 503 and a backend not
+      // available error here:
+      _tmp_err = Error::NoError;
+      _tmp_res = buildResponse(fuerte::StatusServiceUnavailable, Result{res});
+      resolvePromise();
       return;
     }
 
-    auto localOptions = _options;
-    localOptions.timeout =
-        std::chrono::duration_cast<std::chrono::milliseconds>(_endTime - now);
-    TRI_ASSERT(localOptions.timeout.count() > 0);
+    // simon: shorten actual request timeouts to allow time for retry
+    //        otherwise resilience_failover tests likely fail
+    auto t = _endTime - now;
+    if (t >= std::chrono::duration<double>(100)) {
+      t -= std::chrono::seconds(30);
+    }
+    TRI_ASSERT(t.count() > 0);
+    _tmp_req->timeout(std::chrono::duration_cast<std::chrono::milliseconds>(t));
 
     auto conn = _pool->leaseConnection(spec.endpoint);
-    auto req = prepareRequest(_type, _path, _payload, localOptions, _headers);
-    conn->sendRequest(std::move(req),
+    conn->sendRequest(std::move(_tmp_req),
                       [self = shared_from_this()](fuerte::Error err,
                                                   std::unique_ptr<fuerte::Request> req,
                                                   std::unique_ptr<fuerte::Response> res) {
-                        self->handleResponse(err, std::move(req), std::move(res));
+                        self->_tmp_err = err;
+                        self->_tmp_req = std::move(req);
+                        self->_tmp_res = std::move(res);
+                        self->handleResponse();
                       });
   }
 
  private:
-  void handleResponse(fuerte::Error err, std::unique_ptr<fuerte::Request> req,
-                      std::unique_ptr<fuerte::Response> res) {
-    switch (err) {
+  void handleResponse() {
+    switch (_tmp_err) {
       case fuerte::Error::NoError: {
-        TRI_ASSERT(res);
-        if (checkResponse(err, req, res)) {
+        TRI_ASSERT(_tmp_res != nullptr);
+        if (checkResponseContent()) {
           break;
         }
-        [[fallthrough]];
+        [[fallthrough]]; // retry case
       }
 
       case fuerte::Error::CouldNotConnect:
@@ -339,8 +351,8 @@ class RequestsState final : public std::enable_shared_from_this<RequestsState> {
           }
         }
 
-        if (found || (now + tryAgainAfter) >= _endTime) { // cancel out
-          callResponse(err, std::move(res), std::move(req));
+        if (found || (now + tryAgainAfter) >= _endTime) {  // cancel out
+          resolvePromise();
         } else {
           retryLater(tryAgainAfter);
         }
@@ -348,73 +360,76 @@ class RequestsState final : public std::enable_shared_from_this<RequestsState> {
       }
 
       default:  // a "proper error" which has to be returned to the client
-        callResponse(err, std::move(res), std::move(req));
+        resolvePromise();
         break;
     }
   }
 
-  bool checkResponse(fuerte::Error err,
-                     std::unique_ptr<fuerte::Request>& req,
-                     std::unique_ptr<fuerte::Response>& res) {
-    switch (res->statusCode()) {
+  bool checkResponseContent() {
+    TRI_ASSERT(_tmp_res != nullptr);
+    switch (_tmp_res->statusCode()) {
       case fuerte::StatusOK:
       case fuerte::StatusCreated:
       case fuerte::StatusAccepted:
       case fuerte::StatusNoContent:
-        callResponse(Error::NoError, std::move(res), std::move(req));
-        return true; // done
+        _tmp_err = Error::NoError;
+        resolvePromise();
+        return true;  // done
 
       case fuerte::StatusServiceUnavailable:
-        return false; // goto retry
+        return false;  // goto retry
 
       case fuerte::StatusNotFound:
-        if (_options.retryNotFound &&
-            TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND == network::errorCodeFromBody(res->slice())) {
-          return false; // goto retry
+        if (_options.retryNotFound && TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND ==
+                                          network::errorCodeFromBody(_tmp_res->slice())) {
+          return false;  // goto retry
         }
         [[fallthrough]];
       default:  // a "proper error" which has to be returned to the client
-        callResponse(err, std::move(res), std::move(req));
-        return true; // done
+        _tmp_err = Error::NoError;
+        resolvePromise();
+        return true;  // done
     }
   }
 
   /// @brief schedule calling the response promise
-  void callResponse(Error err, std::unique_ptr<fuerte::Response> res, std::unique_ptr<fuerte::Request> req) {
-
-    LOG_TOPIC_IF("2713e", DEBUG, Logger::COMMUNICATION, err != fuerte::Error::NoError)
-        << "error on request to '" << _destination
-        << "' '" << fuerte::to_string(_type) << " " << _path
-        << "' '" << fuerte::to_string(err) << "'";
+  void resolvePromise() {
+    TRI_ASSERT(_tmp_req != nullptr);
+    TRI_ASSERT(_tmp_res != nullptr || _tmp_err != Error::NoError);
+    LOG_TOPIC_IF("2713e", DEBUG, Logger::COMMUNICATION, _tmp_err != fuerte::Error::NoError)
+        << "error on request to '" << _destination << "' '"
+        << fuerte::to_string(_tmp_req->type()) << " " << _tmp_req->header.path
+        << "' '" << fuerte::to_string(_tmp_err) << "'";
 
     Scheduler* sch = SchedulerFeature::SCHEDULER;
     if (_options.skipScheduler || sch == nullptr) {
-      _promise.setValue(Response{std::move(_destination), err, std::move(res), std::move(req)});
+      _promise.setValue(Response{std::move(_destination), _tmp_err,
+                                 std::move(_tmp_req), std::move(_tmp_res)});
       return;
     }
 
-    _response = std::move(res);
-    _request = std::move(req);
     bool queued =
-        sch->queue(RequestLane::CLUSTER_INTERNAL, [self = shared_from_this(), err]() {
-          self->_promise.setValue(Response{std::move(self->_destination), err,
-                                           std::move(self->_response),
-                                           std::move(self->_request)});
+        sch->queue(RequestLane::CLUSTER_INTERNAL, [self = shared_from_this()]() mutable {
+          self->_promise.setValue(Response{std::move(self->_destination),
+                                           self->_tmp_err, std::move(self->_tmp_req),
+                                           std::move(self->_tmp_res)});
         });
     if (ADB_UNLIKELY(!queued)) {
-      _promise.setValue(Response{std::move(_destination), fuerte::Error::QueueCapacityExceeded, nullptr, std::move(_request)});
+      _promise.setValue(Response{std::move(_destination), fuerte::Error::QueueCapacityExceeded,
+                                 std::move(_tmp_req), nullptr});
     }
   }
 
   void retryLater(std::chrono::steady_clock::duration tryAgainAfter) {
-
+    TRI_ASSERT(_tmp_req != nullptr);
     LOG_TOPIC("2713f", DEBUG, Logger::COMMUNICATION)
-        << "retry request to '" << _destination
-        << "' '" << fuerte::to_string(_type) << " " << _path << "'";
+        << "retry request to '" << _destination << "' '"
+        << fuerte::to_string(_tmp_req->type()) << " " << _tmp_req->header.path << "'";
 
     auto* sch = SchedulerFeature::SCHEDULER;
     if (ADB_UNLIKELY(sch == nullptr)) {
-      _promise.setValue(Response{std::move(_destination), fuerte::Error::Canceled, nullptr, std::move(_request)});
+      _promise.setValue(Response{std::move(_destination),
+                                 fuerte::Error::Canceled, nullptr, nullptr});
       return;
     }
 
@@ -422,15 +437,18 @@ class RequestsState final : public std::enable_shared_from_this<RequestsState> {
     std::tie(queued, _workItem) =
         sch->queueDelay(RequestLane::CLUSTER_INTERNAL, tryAgainAfter,
                         [self = shared_from_this()](bool canceled) {
-          if (canceled) {
-            self->_promise.setValue(Response{std::move(self->_destination), Error::Canceled, nullptr, std::move(self->_request)});
-          } else {
-            self->startRequest();
-          }
-        });
+                          if (canceled) {
+                            self->_promise.setValue(
+                                Response{std::move(self->_destination),
+                                         Error::Canceled, nullptr, nullptr});
+                          } else {
+                            self->startRequest();
+                          }
+                        });
     if (ADB_UNLIKELY(!queued)) {
       // scheduler queue is full, cannot requeue
-      _promise.setValue(Response{std::move(_destination), Error::QueueCapacityExceeded, nullptr, std::move(_request)});
+      _promise.setValue(Response{std::move(_destination),
+                                 Error::QueueCapacityExceeded, nullptr, nullptr});
     }
   }
 };
@@ -439,35 +457,36 @@ class RequestsState final : public std::enable_shared_from_this<RequestsState> {
 FutureRes sendRequestRetry(ConnectionPool* pool, DestinationId destination,
                            arangodb::fuerte::RestVerb type, std::string path,
                            velocypack::Buffer<uint8_t> payload,
-                           RequestOptions const& options,
-                           Headers headers) {
-
+                           RequestOptions const& options, Headers headers) {
   try {
-
     if (!pool || !pool->config().clusterInfo) {
       LOG_TOPIC("59b96", ERR, Logger::COMMUNICATION)
-        << "connection pool unavailable";
-      return futures::makeFuture(Response{destination, Error::Canceled, nullptr, nullptr});
+          << "connection pool unavailable";
+      return futures::makeFuture(
+          Response{destination, Error::Canceled, nullptr, nullptr});
     }
 
     LOG_TOPIC("2713b", DEBUG, Logger::COMMUNICATION)
-      << "request to '" << destination
-      << "' '" << fuerte::to_string(type) << " " << path << "'";
+        << "request to '" << destination << "' '" << fuerte::to_string(type)
+        << " " << path << "'";
 
-    auto rs = std::make_shared<RequestsState>(pool, std::move(destination),
-                                              type, std::move(path),
-                                              std::move(payload),
+    auto rs = std::make_shared<RequestsState>(pool, std::move(destination), type,
+                                              std::move(path), std::move(payload),
                                               std::move(headers), options);
     rs->startRequest();  // will auto reference itself
     return rs->future();
 
   } catch (std::exception const& e) {
-    LOG_TOPIC("6d723", DEBUG, Logger::COMMUNICATION) << "failed to send request: " << e.what();
+    LOG_TOPIC("6d723", DEBUG, Logger::COMMUNICATION)
+        << "failed to send request: " << e.what();
   } catch (...) {
-    LOG_TOPIC("d7236", DEBUG, Logger::COMMUNICATION) << "failed to send request.";
+    LOG_TOPIC("d7236", DEBUG, Logger::COMMUNICATION)
+        << "failed to send request.";
   }
 
-  return futures::makeFuture(Response{std::string(), Error::Canceled, nullptr, nullptr});
+
+  return futures::makeFuture(
+      Response{std::string(), Error::Canceled, nullptr, nullptr});
 }
 
 }  // namespace network

--- a/arangod/Network/Methods.cpp
+++ b/arangod/Network/Methods.cpp
@@ -80,8 +80,6 @@ Result Response::combinedResult() const {
 
 auto prepareRequest(RestVerb type, std::string path, VPackBufferUInt8 payload,
                     RequestOptions const& options, Headers headers) {
-  TRI_ASSERT(path.find("/_db/") == std::string::npos);
-  TRI_ASSERT(path.find('?') == std::string::npos);
 
   auto req = fuerte::createRequest(type, path, options.parameters, std::move(payload));
 

--- a/arangod/Network/Methods.h
+++ b/arangod/Network/Methods.h
@@ -42,11 +42,13 @@ class ConnectionPool;
 /// Response data structure
 struct Response {
   DestinationId destination;
-  fuerte::Error error;  /// connectivity error
-  std::unique_ptr<arangodb::fuerte::Response> response;
+  fuerte::Error error = fuerte::Error::Canceled;
   std::unique_ptr<arangodb::fuerte::Request> request;
+  std::unique_ptr<arangodb::fuerte::Response> response;
 
-  [[nodiscard]] bool ok() const { return fuerte::Error::NoError == this->error; }
+  [[nodiscard]] bool ok() const {
+    return fuerte::Error::NoError == this->error;
+  }
 
   [[nodiscard]] bool fail() const { return !ok(); }
 
@@ -83,14 +85,14 @@ using FutureRes = arangodb::futures::Future<Response>;
 // Container for optional (often defaulted) parameters
 struct RequestOptions {
   std::string database;
-  std::string contentType; // uses vpack by default
-  std::string acceptType; // uses vpack by default
+  std::string contentType;  // uses vpack by default
+  std::string acceptType;   // uses vpack by default
   fuerte::StringMap parameters;
   Timeout timeout = Timeout(120.0);
   bool retryNotFound = false; // retry if answers is "datasource not found"
   bool skipScheduler = false; // do not use Scheduler queue
 
-  template<typename K, typename V>
+  template <typename K, typename V>
   RequestOptions& param(K&& key, V&& val) {
     this->parameters.insert_or_assign(std::forward<K>(key), std::forward<V>(val));
     return *this;
@@ -102,23 +104,20 @@ struct RequestOptions {
 FutureRes sendRequest(ConnectionPool* pool, DestinationId destination,
                       arangodb::fuerte::RestVerb type, std::string path,
                       velocypack::Buffer<uint8_t> payload = {},
-                      RequestOptions const& options = {},
-                      Headers headers = {});
+                      RequestOptions const& options = {}, Headers headers = {});
 
 /// @brief send a request to a given destination, retry under certain conditions
-/// a retry will be triggered if the connection was lost our could not be established
-/// optionally a retry will be performed in the case of until timeout is exceeded
-/// This method must not throw under penalty of ...
+/// a retry will be triggered if the connection was lost our could not be
+/// established optionally a retry will be performed in the case of until
+/// timeout is exceeded This method must not throw under penalty of ...
 FutureRes sendRequestRetry(ConnectionPool* pool, DestinationId destination,
                            arangodb::fuerte::RestVerb type, std::string path,
                            velocypack::Buffer<uint8_t> payload = {},
-                           RequestOptions const& options = {},
-                           Headers headers = {});
+                           RequestOptions const& options = {}, Headers headers = {});
 
 using Sender =
     std::function<FutureRes(DestinationId const&, arangodb::fuerte::RestVerb, std::string const&,
-                            velocypack::Buffer<uint8_t>, RequestOptions const& options,
-                            Headers)>;
+                            velocypack::Buffer<uint8_t>, RequestOptions const& options, Headers)>;
 
 }  // namespace network
 }  // namespace arangodb

--- a/arangod/Network/types.h
+++ b/arangod/Network/types.h
@@ -39,7 +39,6 @@ struct EndpointSpec {
   std::string shardId;
   std::string serverId;
   std::string endpoint;
-
 };
 
 }  // namespace network


### PR DESCRIPTION
### Scope & Purpose

Make sure to never have a null request member and actually set the response if response.error == NoError.
Additionally we now avoid recreating the request object everytime

- [x] :hankey: Bugfix 
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required

backport of https://github.com/arangodb/arangodb/pull/12766

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] This change is already covered by existing tests, such as the cluster tests

http://jenkins01.arangodb.biz:8080/job/arangodb-matrix-pr/12287/


