### PR TITLE
Bug fix/cleanup 20201016

### DIFF
--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -712,31 +712,6 @@ static std::shared_ptr<std::unordered_map<std::string, std::vector<std::string>>
 namespace arangodb {
 
 ////////////////////////////////////////////////////////////////////////////////
-/// @brief creates a copy of all HTTP headers to forward
-////////////////////////////////////////////////////////////////////////////////
-
-network::Headers getForwardableRequestHeaders(arangodb::GeneralRequest* request) {
-  network::Headers result;
-
-  for (auto const& it : request->headers()) {
-    std::string const& key = it.first;
-
-    // ignore the following headers
-    if (key != "x-arango-async" && key != "authorization" &&
-        key != "content-length" && key != "connection" && key != "expect" &&
-        key != "host" && key != "origin" && key != StaticStrings::HLCHeader &&
-        key != StaticStrings::ErrorCodes &&
-        key.compare(0, 14, "access-control", 14) != 0) {
-      result.try_emplace(key, it.second);
-    }
-  }
-
-  result["content-length"] = StringUtils::itoa(request->contentLength());
-
-  return result;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// @brief check if a list of attributes have the same values in two vpack
 /// documents
 ////////////////////////////////////////////////////////////////////////////////

--- a/arangod/Cluster/ClusterMethods.h
+++ b/arangod/Cluster/ClusterMethods.h
@@ -61,15 +61,6 @@ struct ClusterCommResult;
 class ClusterFeature;
 struct OperationOptions;
 
-/// @brief convert ClusterComm error into arango error code
-int handleGeneralCommErrors(arangodb::ClusterCommResult const* res);
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief creates a copy of all HTTP headers to forward
-////////////////////////////////////////////////////////////////////////////////
-
-network::Headers getForwardableRequestHeaders(GeneralRequest*);
-
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief check if a list of attributes have the same values in two vpack
 /// documents

--- a/arangod/Cluster/DropCollection.cpp
+++ b/arangod/Cluster/DropCollection.cpp
@@ -94,11 +94,22 @@ bool DropCollection::first() {
 
         return false;
       }
+    } catch (basics::Exception const& e) {
+      if (e.code() != TRI_ERROR_ARANGO_DATABASE_NOT_FOUND) {
+        // any error but database not found will be reported properly
+        std::stringstream error;
 
+        error << "action " << _description << " failed with exception " << e.what();
+        LOG_TOPIC("9dbd8", ERR, Logger::MAINTENANCE) << error.str();
+        _result.reset(e.code(), error.str());
+
+        return false;
+      }
+      // TRI_ERROR_ARANGO_DATABASE_NOT_FOUND will fallthrough here, intentionally
     } catch (std::exception const& e) {
       std::stringstream error;
 
-      error << " action " << _description << " failed with exception " << e.what();
+      error << "action " << _description << " failed with exception " << e.what();
       LOG_TOPIC("9dbd8", ERR, Logger::MAINTENANCE) << error.str();
       _result.reset(TRI_ERROR_INTERNAL, error.str());
 

--- a/arangod/Cluster/DropCollection.cpp
+++ b/arangod/Cluster/DropCollection.cpp
@@ -25,7 +25,7 @@
 #include "DropCollection.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
-#include "Basics/VelocyPackHelper.h"
+#include "Basics/Exceptions.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/MaintenanceFeature.h"
 #include "Logger/LogMacros.h"
@@ -100,7 +100,7 @@ bool DropCollection::first() {
         std::stringstream error;
 
         error << "action " << _description << " failed with exception " << e.what();
-        LOG_TOPIC("9dbd8", ERR, Logger::MAINTENANCE) << error.str();
+        LOG_TOPIC("761d2", ERR, Logger::MAINTENANCE) << error.str();
         _result.reset(e.code(), error.str());
 
         return false;

--- a/arangod/Cluster/EnsureIndex.cpp
+++ b/arangod/Cluster/EnsureIndex.cpp
@@ -132,7 +132,8 @@ bool EnsureIndex::first() {
       error << "failed to ensure index " << body.slice().toJson() << " "
             << _result.errorMessage();
 
-      if (!_result.is(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED)) {
+      if (!_result.is(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED) &&
+          !_result.is(TRI_ERROR_BAD_PARAMETER)) {
         // "unique constraint violated" is an expected error that can happen at any time.
         // it does not justify logging and alerting DBAs. The error will be passed back
         // to the caller anyway, so not logging it seems to be good.

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -3549,7 +3549,7 @@ ResultT<bool> RestReplicationHandler::isLockHeld(TransactionId id) const {
   transaction::Status stats = mgr->getManagedTrxStatus(id, _vocbase.name());
   if (stats == transaction::Status::UNDEFINED) {
     return ResultT<bool>::error(TRI_ERROR_HTTP_NOT_FOUND,
-                                "no hold read lock job found for 'id'");
+                                "no hold read lock job found for id " + std::to_string(id.id()));
   }
   
   return ResultT<bool>::success(true);

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -871,7 +871,11 @@ static Result DropVocbaseColCoordinator(arangodb::LogicalCollection* collection,
     res = coll.vocbase().dropCollection(coll.id(), allowDropSystem, timeout);
   }
 
-  LOG_TOPIC_IF("1bf4d", INFO, Logger::ENGINES, res.fail() && res.isNot(TRI_ERROR_FORBIDDEN))
+  LOG_TOPIC_IF("1bf4d", WARN, Logger::ENGINES, 
+               res.fail() && 
+               res.isNot(TRI_ERROR_FORBIDDEN) && 
+               res.isNot(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND) &&
+               res.isNot(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND))
     << "error while dropping collection: '" << collName
     << "' error: '" << res.errorMessage() << "'";
 

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -331,7 +331,7 @@ arangodb::Result Databases::create(application_features::ApplicationServer& serv
   }
 
   if (res.fail()) {
-    if (!res.is(TRI_ERROR_BAD_PARAMETER)) {
+    if (!res.is(TRI_ERROR_BAD_PARAMETER) && !res.is(TRI_ERROR_ARANGO_DUPLICATE_NAME)) {
       LOG_TOPIC("1964a", ERR, Logger::FIXME)
           << "Could not create database: " << res.errorMessage();
     }


### PR DESCRIPTION
### Scope & Purpose

Don't log errors into the log in expected cases
    
In case of "expected" errors they are returned to the end user or client application, so they can handle the error. there is no need to additionally log these errors into the log and cause alerting.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12346/