### PR TITLE
[3.7] Fix read-only counter adjustments

### DIFF
--- a/arangod/RocksDBEngine/RocksDBMetadata.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetadata.cpp
@@ -107,13 +107,13 @@ Result RocksDBMetadata::placeBlocker(TRI_voc_tid_t trxId, rocksdb::SequenceNumbe
       if (!crosslist.second) {
         return res.reset(TRI_ERROR_INTERNAL);
       }
+      LOG_TOPIC("1587a", TRACE, Logger::ENGINES)
+          << "[" << this << "] placed blocker (" << trxId << ", " << seq << ")";
       return res;
     } catch (...) {
       _blockers.erase(trxId);
       throw;
     }
-    LOG_TOPIC("1587a", TRACE, Logger::ENGINES)
-        << "[" << this << "] placed blocker (" << trxId << ", " << seq << ")";
   });
 }
 

--- a/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
@@ -24,6 +24,7 @@
 
 #include "RocksDBReplicationContext.h"
 
+#include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/MutexLocker.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/StringBuffer.h"
@@ -41,6 +42,8 @@
 #include "RocksDBEngine/RocksDBMetaCollection.h"
 #include "RocksDBEngine/RocksDBMethods.h"
 #include "RocksDBEngine/RocksDBPrimaryIndex.h"
+#include "RocksDBEngine/RocksDBSettingsManager.h"
+#include "StorageEngine/EngineSelectorFeature.h"
 #include "Transaction/Context.h"
 #include "Transaction/Helpers.h"
 #include "Utils/DatabaseGuard.h"
@@ -67,6 +70,14 @@ TRI_voc_cid_t normalizeIdentifier(TRI_vocbase_t& vocbase, std::string const& ide
   }
 
   return id;
+}
+
+rocksdb::SequenceNumber forceWrite(RocksDBEngine& engine) {
+  auto* sm = engine.settingsManager();
+  if (sm) {
+    sm->sync(true); // force
+  }
+  return engine.db()->GetLatestSequenceNumber();
 }
 
 }  // namespace
@@ -287,6 +298,18 @@ RocksDBReplicationContext::DumpResult RocksDBReplicationContext::dumpJson(
 
   TRI_ASSERT(cIter->bounds.columnFamily() == RocksDBColumnFamily::documents());
 
+  auto& engine = vocbase.server().getFeature<EngineSelectorFeature>().engine<RocksDBEngine>();
+  auto* rcoll = static_cast<RocksDBMetaCollection*>(cIter->logical->getPhysical());
+  TRI_voc_tid_t trxId{0};
+  auto blockerGuard = scopeGuard([&] {  // remove blocker afterwards
+    if (trxId != 0) {
+      rcoll->meta().removeBlocker(trxId);
+    }
+  });
+  auto blockerSeq = engine.db()->GetLatestSequenceNumber();
+  trxId = transaction::Context::makeTransactionId();
+  rcoll->meta().placeBlocker(trxId, blockerSeq);
+
   arangodb::basics::VPackStringBufferAdapter adapter(buff.stringBuffer());
   VPackDumper dumper(&adapter, &cIter->vpackOptions);
   TRI_ASSERT(cIter->iter && !cIter->sorted());
@@ -312,9 +335,12 @@ RocksDBReplicationContext::DumpResult RocksDBReplicationContext::dumpJson(
           << "inconsistent collection count detected for "
           << vocbase.name() << "/" << cIter->logical->name() 
           << ", an offet of " << adjustment << " will be applied";
-      auto* rcoll = static_cast<RocksDBMetaCollection*>(cIter->logical->getPhysical());
-      auto seq = rocksutils::latestSequenceNumber();
-      rcoll->meta().adjustNumberDocuments(seq, TRI_voc_rid_t(0), adjustment);
+      auto adjustSeq = engine.db()->GetLatestSequenceNumber();
+      if (adjustSeq <= blockerSeq) {
+        adjustSeq = ::forceWrite(engine);
+        TRI_ASSERT(adjustSeq > blockerSeq);
+      }
+      rcoll->meta().adjustNumberDocuments(adjustSeq, 0, adjustment);
     }
 
     cIter->numberDocumentsDumped = 0;
@@ -347,6 +373,18 @@ RocksDBReplicationContext::DumpResult RocksDBReplicationContext::dumpVPack(
 
   TRI_ASSERT(cIter->bounds.columnFamily() == RocksDBColumnFamily::documents());
 
+  auto& engine = vocbase.server().getFeature<EngineSelectorFeature>().engine<RocksDBEngine>();
+  auto* rcoll = static_cast<RocksDBMetaCollection*>(cIter->logical->getPhysical());
+  TRI_voc_tid_t trxId{0};
+  auto blockerGuard = scopeGuard([&] {  // remove blocker afterwards
+    if (trxId != 0) {
+      rcoll->meta().removeBlocker(trxId);
+    }
+  });
+  auto blockerSeq = engine.db()->GetLatestSequenceNumber();
+  trxId = transaction::Context::makeTransactionId();
+  rcoll->meta().placeBlocker(trxId, blockerSeq);
+
   VPackBuilder builder(buffer, &cIter->vpackOptions);
   TRI_ASSERT(cIter->iter && !cIter->sorted());
   while (cIter->hasMore() && buffer.length() < chunkSize) {
@@ -370,9 +408,12 @@ RocksDBReplicationContext::DumpResult RocksDBReplicationContext::dumpVPack(
           << "inconsistent collection count detected for "
           << vocbase.name() << "/" << cIter->logical->name() 
           << ", an offet of " << adjustment << " will be applied";
-      auto* rcoll = static_cast<RocksDBMetaCollection*>(cIter->logical->getPhysical());
-      auto seq = rocksutils::latestSequenceNumber();
-      rcoll->meta().adjustNumberDocuments(seq, TRI_voc_rid_t(0), adjustment);
+      auto adjustSeq = engine.db()->GetLatestSequenceNumber();
+      if (adjustSeq <= blockerSeq) {
+        adjustSeq = ::forceWrite(engine);
+        TRI_ASSERT(adjustSeq > blockerSeq);
+      }
+      rcoll->meta().adjustNumberDocuments(adjustSeq, 0, adjustment);
     }
 
     cIter->numberDocumentsDumped = 0;
@@ -409,13 +450,24 @@ arangodb::Result RocksDBReplicationContext::dumpKeyChunks(TRI_vocbase_t& vocbase
   TRI_ASSERT(cIter->lastSortedIteratorOffset == 0);
   TRI_ASSERT(cIter->bounds.columnFamily() == RocksDBColumnFamily::primary());
 
+  auto& engine = vocbase.server().getFeature<EngineSelectorFeature>().engine<RocksDBEngine>();
+  auto* rcoll = static_cast<RocksDBMetaCollection*>(cIter->logical->getPhysical());
+  TRI_voc_tid_t trxId{0};
+  auto blockerGuard = scopeGuard([&] {  // remove blocker afterwards
+    if (trxId != 0) {
+      rcoll->meta().removeBlocker(trxId);
+    }
+  });
+  auto blockerSeq = engine.db()->GetLatestSequenceNumber();
+  trxId = transaction::Context::makeTransactionId();
+  rcoll->meta().placeBlocker(trxId, blockerSeq);
+
   // reserve some space in the result builder to avoid frequent reallocations
   b.reserve(8192);
   char ridBuffer[21];  // temporary buffer for stringifying revision ids
   RocksDBKey docKey;
   VPackBuilder tmpHashBuilder;
   rocksdb::TransactionDB* db = globalRocksDB();
-  auto* rcoll = static_cast<RocksDBMetaCollection*>(cIter->logical->getPhysical());
   const uint64_t cObjectId = rcoll->objectId();
   uint64_t snapNumDocs = 0;
 
@@ -493,9 +545,12 @@ arangodb::Result RocksDBReplicationContext::dumpKeyChunks(TRI_vocbase_t& vocbase
           << "inconsistent collection count detected for "
           << vocbase.name() << "/" << cIter->logical->name() 
           << ", an offet of " << adjustment << " will be applied";
-      auto* rcoll = static_cast<RocksDBMetaCollection*>(cIter->logical->getPhysical());
-      auto seq = rocksutils::latestSequenceNumber();
-      rcoll->meta().adjustNumberDocuments(seq, static_cast<TRI_voc_rid_t>(0), adjustment);
+      auto adjustSeq = engine.db()->GetLatestSequenceNumber();
+      if (adjustSeq <= blockerSeq) {
+        adjustSeq = ::forceWrite(engine);
+        TRI_ASSERT(adjustSeq > blockerSeq);
+      }
+      rcoll->meta().adjustNumberDocuments(adjustSeq, 0, adjustment);
     }
   }
 

--- a/arangod/RocksDBEngine/RocksDBTransactionState.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.cpp
@@ -230,15 +230,6 @@ void RocksDBTransactionState::commitCollections(rocksdb::SequenceNumber lastWrit
     // we need this in case of an intermediate commit. The number of
     // initial documents is adjusted and numInserts / removes is set to 0
     // index estimator updates are buffered
-      
-    TRI_IF_FAILURE("RocksDBCommitCounts") {
-      continue;
-    }
-    TRI_IF_FAILURE("RocksDBCommitCountsRandom") {
-      if (RandomGenerator::interval(uint16_t(100)) >= 50) {
-        continue;
-      }
-    }
     coll->commitCounts(id(), lastWritten);
   }
 }


### PR DESCRIPTION
### Scope & Purpose

In a few places, we make counter adjustments in read-only contexts, in order to correct a counter which is out of sync with the underlying document store. This leads to broken invariants in the sequence tracking we use for these counters. This PR updates these cases to correctly place blockers and conditionally force a write of the settings in order to restore the invariants.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.5? 3.6, devel

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added **Regression Tests**
  - [ ] Added new C++ **Unit Tests**
  - [ ] Added new **integration tests** (i.e. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)

Jenkins: https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/12384/