### PR TITLE
since ARGUMENTS is const for .js 

### DIFF
--- a/tests/js/server/replication/aql/replication-aql.js
+++ b/tests/js/server/replication/aql/replication-aql.js
@@ -38,7 +38,7 @@ const reconnectRetry = require('@arangodb/replication-common').reconnectRetry;
 const console = require("console");
 const internal = require("internal");
 const masterEndpoint = arango.getEndpoint();
-const slaveEndpoint = ARGUMENTS[0];
+const slaveEndpoint = ARGUMENTS[ARGUMENTS.length - 1];
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test suite

--- a/tests/js/server/replication/fuzz/replication-fuzz-global.js
+++ b/tests/js/server/replication/fuzz/replication-fuzz-global.js
@@ -38,7 +38,7 @@ let compareTicks = replication.compareTicks;
 var console = require("console");
 var internal = require("internal");
 var masterEndpoint = arango.getEndpoint();
-var slaveEndpoint = ARGUMENTS[0];
+const slaveEndpoint = ARGUMENTS[ARGUMENTS.length - 1];
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test suite

--- a/tests/js/server/replication/fuzz/replication-fuzz.js
+++ b/tests/js/server/replication/fuzz/replication-fuzz.js
@@ -38,7 +38,7 @@ let compareTicks = replication.compareTicks;
 var console = require("console");
 var internal = require("internal");
 var masterEndpoint = arango.getEndpoint();
-var slaveEndpoint = ARGUMENTS[0];
+const slaveEndpoint = ARGUMENTS[ARGUMENTS.length - 1];
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test suite

--- a/tests/js/server/replication/ongoing/32/replication-ongoing-32.js
+++ b/tests/js/server/replication/ongoing/32/replication-ongoing-32.js
@@ -36,7 +36,7 @@ let compareTicks = replication.compareTicks;
 var console = require('console');
 var internal = require('internal');
 var masterEndpoint = arango.getEndpoint();
-var slaveEndpoint = ARGUMENTS[0];
+const slaveEndpoint = ARGUMENTS[ARGUMENTS.length - 1];
 
 const cn = 'UnitTestsReplication';
 const cn2 = 'UnitTestsReplication2';

--- a/tests/js/server/replication/ongoing/frompresent/32/replication-ongoing-frompresent-32.js
+++ b/tests/js/server/replication/ongoing/frompresent/32/replication-ongoing-frompresent-32.js
@@ -39,7 +39,7 @@ let compareTicks = replication.compareTicks;
 var console = require('console');
 var internal = require('internal');
 var masterEndpoint = arango.getEndpoint();
-var slaveEndpoint = ARGUMENTS[0];
+const slaveEndpoint = ARGUMENTS[ARGUMENTS.length - 1];
 
 var cn = 'UnitTestsReplication';
 var cn2 = 'UnitTestsReplication2';

--- a/tests/js/server/replication/ongoing/frompresent/replication-ongoing-frompresent.js
+++ b/tests/js/server/replication/ongoing/frompresent/replication-ongoing-frompresent.js
@@ -39,7 +39,7 @@ let compareTicks = replication.compareTicks;
 var console = require('console');
 var internal = require('internal');
 var masterEndpoint = arango.getEndpoint();
-var slaveEndpoint = ARGUMENTS[0];
+const slaveEndpoint = ARGUMENTS[ARGUMENTS.length - 1];
 
 var cn = 'UnitTestsReplication';
 var cn2 = 'UnitTestsReplication2';

--- a/tests/js/server/replication/ongoing/global/replication-ongoing-global.js
+++ b/tests/js/server/replication/ongoing/global/replication-ongoing-global.js
@@ -40,7 +40,7 @@ const console = require('console');
 const internal = require('internal');
 
 const masterEndpoint = arango.getEndpoint();
-const slaveEndpoint = ARGUMENTS[0];
+const slaveEndpoint = ARGUMENTS[ARGUMENTS.length - 1];
 
 const cn = 'UnitTestsReplication';
 const cn2 = 'UnitTestsReplication2';

--- a/tests/js/server/replication/ongoing/global/spec/replication-ongoing-global-spec.js
+++ b/tests/js/server/replication/ongoing/global/spec/replication-ongoing-global-spec.js
@@ -40,7 +40,7 @@ const internal = require("internal");
 const time = internal.time;
 
 const masterEndpoint = arango.getEndpoint();
-const slaveEndpoint = ARGUMENTS[0];
+const slaveEndpoint = ARGUMENTS[ARGUMENTS.length - 1];
 
 const username = "root";
 const password = "";

--- a/tests/js/server/replication/ongoing/replication-ongoing.js
+++ b/tests/js/server/replication/ongoing/replication-ongoing.js
@@ -40,7 +40,7 @@ const compareTicks = replication.compareTicks;
 const console = require('console');
 const internal = require('internal');
 const masterEndpoint = arango.getEndpoint();
-const slaveEndpoint = ARGUMENTS[0];
+const slaveEndpoint = ARGUMENTS[ARGUMENTS.length - 1];
 
 const cn = 'UnitTestsReplication';
 const cn2 = 'UnitTestsReplication2';

--- a/tests/js/server/replication/random/replication-random.js
+++ b/tests/js/server/replication/random/replication-random.js
@@ -38,7 +38,7 @@ const compareTicks = replication.compareTicks;
 const console = require("console");
 const internal = require("internal");
 const masterEndpoint = arango.getEndpoint();
-const slaveEndpoint = ARGUMENTS[0];
+const slaveEndpoint = ARGUMENTS[ARGUMENTS.length - 1];
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test suite

--- a/tests/js/server/replication/static/replication-static.js
+++ b/tests/js/server/replication/static/replication-static.js
@@ -44,7 +44,7 @@ const console = require('console');
 const internal = require('internal');
 const arango = internal.arango;
 const masterEndpoint = arango.getEndpoint();
-const slaveEndpoint = ARGUMENTS[0];
+const slaveEndpoint = ARGUMENTS[ARGUMENTS.length - 1];
 
 const cn = 'UnitTestsReplication';
 const cn2 = 'UnitTestsReplication2';

--- a/tests/js/server/replication/sync/replication-sync.js
+++ b/tests/js/server/replication/sync/replication-sync.js
@@ -39,7 +39,7 @@ const _ = require('lodash');
 const replication = require('@arangodb/replication');
 const internal = require('internal');
 const masterEndpoint = arango.getEndpoint();
-const slaveEndpoint = ARGUMENTS[0];
+const slaveEndpoint = ARGUMENTS[ARGUMENTS.length - 1];
 
 const cn = 'UnitTestsReplication';
 const sysCn = '_UnitTestsReplication';


### PR DESCRIPTION
its easier to have the last argument be the other node than the first (which obviously is the same in the case of 1 argument)
