### PR TITLE
make sure the x-arango-source header is set for all internal requests

### DIFF
--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -56,9 +56,6 @@
 #include "Random/RandomGenerator.h"
 #include "Rest/GeneralRequest.h"
 #include "RestServer/MetricsFeature.h"
-#include "SimpleHttpClient/GeneralClientConnection.h"
-#include "SimpleHttpClient/SimpleHttpClient.h"
-#include "SimpleHttpClient/SimpleHttpResult.h"
 
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
@@ -66,7 +63,6 @@
 
 using namespace arangodb;
 using namespace arangodb::application_features;
-using namespace arangodb::httpclient;
 using namespace arangodb::rest;
 
 #ifdef DEBUG_SYNC_REPLICATION

--- a/arangod/Agency/AgencyComm.h
+++ b/arangod/Agency/AgencyComm.h
@@ -45,7 +45,6 @@
 #include "GeneralServer/GeneralDefinitions.h"
 #include "Rest/CommonDefines.h"
 #include "RestServer/Metrics.h"
-#include "SimpleHttpClient/GeneralClientConnection.h"
 
 namespace arangodb {
 class Endpoint;

--- a/arangod/Agency/AgencyFeature.cpp
+++ b/arangod/Agency/AgencyFeature.cpp
@@ -32,6 +32,7 @@
 #include "ApplicationFeatures/V8PlatformFeature.h"
 #include "Basics/application-exit.h"
 #include "Cluster/ClusterFeature.h"
+#include "Endpoint/Endpoint.h"
 #include "FeaturePhases/FoxxFeaturePhase.h"
 #include "IResearch/IResearchAnalyzerFeature.h"
 #include "IResearch/IResearchFeature.h"

--- a/arangod/Agency/AsyncAgencyComm.cpp
+++ b/arangod/Agency/AsyncAgencyComm.cpp
@@ -27,6 +27,7 @@
 #include "Basics/StaticStrings.h"
 #include "Basics/StringUtils.h"
 #include "Cluster/ClusterInfo.h"
+#include "Endpoint/Endpoint.h"
 #include "Futures/Utilities.h"
 #include "Logger/LogMacros.h"
 #include "Scheduler/SchedulerFeature.h"

--- a/arangod/Aql/RemoteExecutor.cpp
+++ b/arangod/Aql/RemoteExecutor.cpp
@@ -489,7 +489,7 @@ Result ExecutionBlockImpl<RemoteExecutor>::sendAsyncRequest(fuerte::RestVerb typ
 
   arangodb::network::EndpointSpec spec;
   int res = network::resolveDestination(nf, _server, spec);
-  if (res != TRI_ERROR_NO_ERROR) {  // FIXME return an error  ?!
+  if (res != TRI_ERROR_NO_ERROR) { 
     return Result(res);
   }
   TRI_ASSERT(!spec.endpoint.empty());
@@ -503,8 +503,8 @@ Result ExecutionBlockImpl<RemoteExecutor>::sendAsyncRequest(fuerte::RestVerb typ
   req->timeout(kDefaultTimeOutSecs);
   if (!_distributeId.empty()) {
     req->header.addMeta("x-shard-id", _distributeId);
-    req->header.addMeta("shard-id", _distributeId);  // deprecated in 3.7, remove later
   }
+  network::addSourceHeader(*req);
 
   LOG_TOPIC("2713c", DEBUG, Logger::COMMUNICATION)
       << "request to '" << _server << "' '" << fuerte::to_string(type) << " "

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -619,10 +619,7 @@ auto AqlExecuteCall::fromVelocyPack(VPackSlice const slice) -> ResultT<AqlExecut
 RestStatus RestAqlHandler::handleUseQuery(std::string const& operation,
                                           VPackSlice const querySlice) {
   bool found;
-  std::string shardId = _request->header("x-shard-id", found);
-  if (!found) {  // simon: deprecated in 3.7, remove later
-    shardId = _request->header("shard-id", found);
-  }
+  std::string const& shardId = _request->header("x-shard-id", found);
 
   // upon first usage, the "initializeCursor" method must be called
   // note: if the operation is "initializeCursor" itself, we do not initialize

--- a/arangod/Network/Methods.cpp
+++ b/arangod/Network/Methods.cpp
@@ -100,15 +100,7 @@ auto prepareRequest(RestVerb type, std::string path, VPackBufferUInt8 payload,
   req->header.addMeta(StaticStrings::HLCHeader,
                       arangodb::basics::HybridLogicalClock::encodeTimeStamp(timeStamp));
 
-  auto state = ServerState::instance();
-  if (state->isCoordinator() || state->isDBServer()) {
-    req->header.addMeta(StaticStrings::ClusterCommSource, state->getId());
-  } else if (state->isAgent()) {
-    auto agent = AgencyFeature::AGENT;
-    if (agent != nullptr) {
-      req->header.addMeta(StaticStrings::ClusterCommSource, "AGENT-" + agent->id());
-    }
-  }
+  network::addSourceHeader(*req);
 
   return req;
 }

--- a/arangod/Network/Utils.cpp
+++ b/arangod/Network/Utils.cpp
@@ -30,6 +30,7 @@
 #include "Basics/NumberUtils.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
+#include "Cluster/ServerState.h"
 #include "Logger/LogMacros.h"
 #include "Network/Methods.h"
 #include "Network/NetworkFeature.h"
@@ -315,6 +316,18 @@ int fuerteStatusToArangoErrorCode(fuerte::Response const& res) {
 
 std::string fuerteStatusToArangoErrorMessage(fuerte::Response const& res) {
   return fuerte::status_code_to_string(res.statusCode());
+}
+
+void addSourceHeader(fuerte::Request& req) {
+  auto state = ServerState::instance();
+  if (state->isCoordinator() || state->isDBServer()) {
+    req.header.addMeta(StaticStrings::ClusterCommSource, state->getId());
+  } else if (state->isAgent()) {
+    auto agent = AgencyFeature::AGENT;
+    if (agent != nullptr) {
+      req.header.addMeta(StaticStrings::ClusterCommSource, "AGENT-" + agent->id());
+    }
+  }
 }
 
 }  // namespace network

--- a/arangod/Network/Utils.h
+++ b/arangod/Network/Utils.h
@@ -80,6 +80,8 @@ std::string fuerteStatusToArangoErrorMessage(fuerte::Response const& res);
 fuerte::RestVerb arangoRestVerbToFuerte(rest::RequestType);
 rest::RequestType fuerteRestVerbToArango(fuerte::RestVerb);
 
+void addSourceHeader(fuerte::Request& req);
+
 }  // namespace network
 }  // namespace arangodb
 

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -389,19 +389,8 @@ Result DatabaseInitialSyncer::runWithInventory(bool incremental, VPackSlice dbIn
     TRI_ASSERT(_config.leader.majorVersion != 0);
 
     LOG_TOPIC("6fd2b", DEBUG, Logger::REPLICATION) << "client: got leader state";
-    if (incremental) {
-      if (_config.leader.majorVersion == 1 ||
-          (_config.leader.majorVersion == 2 && _config.leader.minorVersion <= 6)) {
-        LOG_TOPIC("15183", WARN, Logger::REPLICATION) << "incremental replication is "
-                                                "not supported with a leader < "
-                                                "ArangoDB 2.7";
-        incremental = false;
-      }
-    }
-
 
     if (!_config.isChild()) {
-
       // enable patching of collection count for ShardSynchronization Job
       std::string patchCount = StaticStrings::Empty;
       if (_config.applier._skipCreateDrop &&
@@ -697,8 +686,7 @@ void DatabaseInitialSyncer::fetchDumpChunk(std::shared_ptr<Syncer::JobSynchroniz
     }
 
     auto headers = replutils::createHeaders();
-    int vv = _config.leader.majorVersion * 1000000 + _config.leader.minorVersion * 1000;
-    if (vv >= 3008000) {
+    if (_config.leader.version() >= 30800) {
       // from 3.8 onwards, it is safe and also faster to retrieve vpack-encoded dumps.
       // in previous versions there may be vpack encoding issues for the /_api/replication/dump
       // responses.
@@ -947,9 +935,7 @@ Result DatabaseInitialSyncer::fetchCollectionDump(arangodb::LogicalCollection* c
 Result DatabaseInitialSyncer::fetchCollectionSync(arangodb::LogicalCollection* coll,
                                                   std::string const& leaderColl,
                                                   TRI_voc_tick_t maxTick) {
-  if (coll->syncByRevision() &&
-      (_config.leader.majorVersion > 3 ||
-       (_config.leader.majorVersion == 3 && _config.leader.minorVersion >= 7))) {
+  if (coll->syncByRevision() && _config.leader.version() >= 30700) {
     // local collection should support revisions, and leader is at least aware
     // of the revision-based protocol, so we can query it to find out if we
     // can use the new protocol; will fall back to old one if leader collection
@@ -1013,6 +999,8 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
   }
 
   double const startTime = TRI_microtime();
+    
+  headers = replutils::createHeaders();
 
   while (true) {
     if (!_config.isChild()) {
@@ -1021,7 +1009,7 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
 
     std::string const jobUrl = "/_api/job/" + jobId;
     _config.connection.lease([&](httpclient::SimpleHttpClient* client) {
-      response.reset(client->request(rest::RequestType::PUT, jobUrl, nullptr, 0));
+      response.reset(client->request(rest::RequestType::PUT, jobUrl, nullptr, 0, headers));
     });
     
     double waitTime = TRI_microtime() - startTime;
@@ -1103,11 +1091,12 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
         "deleting remote collection keys object for collection '" +
         coll->name() + "' from " + url;
     _config.progress.set(msg);
-
+    
     // now delete the keys we ordered
     std::unique_ptr<httpclient::SimpleHttpResult> response;
     _config.connection.lease([&](httpclient::SimpleHttpClient* client) {
-      response.reset(client->retryRequest(rest::RequestType::DELETE_REQ, url, nullptr, 0));
+      auto headers = replutils::createHeaders();
+      response.reset(client->retryRequest(rest::RequestType::DELETE_REQ, url, nullptr, 0, headers));
     });
   };
 
@@ -1875,7 +1864,8 @@ arangodb::Result DatabaseInitialSyncer::fetchInventory(VPackBuilder& builder) {
   _config.progress.set("fetching leader inventory from " + url);
   std::unique_ptr<httpclient::SimpleHttpResult> response;
   _config.connection.lease([&](httpclient::SimpleHttpClient* client) {
-    response.reset(client->retryRequest(rest::RequestType::GET, url, nullptr, 0));
+    auto headers = replutils::createHeaders();
+    response.reset(client->retryRequest(rest::RequestType::GET, url, nullptr, 0, headers));
   });
 
   if (replutils::hasFailed(response.get())) {

--- a/arangod/Replication/DatabaseTailingSyncer.cpp
+++ b/arangod/Replication/DatabaseTailingSyncer.cpp
@@ -115,6 +115,8 @@ Result DatabaseTailingSyncer::syncCollectionCatchupInternal(std::string const& c
 
   auto clock = std::chrono::steady_clock();
   auto startTime = clock.now();
+    
+  auto headers = replutils::createHeaders();
 
   while (true) {
     if (vocbase()->server().isStopping()) {
@@ -133,7 +135,7 @@ Result DatabaseTailingSyncer::syncCollectionCatchupInternal(std::string const& c
     std::unique_ptr<httpclient::SimpleHttpResult> response;
     _state.connection.lease([&](httpclient::SimpleHttpClient* client) {
       ++_stats.numTailingRequests;
-      response.reset(client->request(rest::RequestType::GET, url, nullptr, 0));
+      response.reset(client->request(rest::RequestType::GET, url, nullptr, 0, headers));
     });
 
     _stats.waitedForTailing += TRI_microtime() - start;
@@ -270,8 +272,7 @@ bool DatabaseTailingSyncer::skipMarker(VPackSlice const& slice) {
     return false;
   }
 
-  if (_state.leader.majorVersion < 3 ||
-      (_state.leader.majorVersion == 3 && _state.leader.minorVersion <= 2)) {
+  if (_state.leader.version() < 30300) {
     // globallyUniqueId only exists in 3.3 and higher
     return false;
   }

--- a/arangod/Replication/GlobalTailingSyncer.cpp
+++ b/arangod/Replication/GlobalTailingSyncer.cpp
@@ -51,8 +51,7 @@ std::string GlobalTailingSyncer::tailingBaseUrl(std::string const& command) {
   TRI_ASSERT(_state.leader.serverId.isSet());
   TRI_ASSERT(_state.leader.majorVersion != 0);
 
-  if (_state.leader.majorVersion < 3 ||
-      (_state.leader.majorVersion == 3 && _state.leader.minorVersion <= 2)) {
+  if (_state.leader.version() < 30300) {
     std::string err =
         "You need >= 3.3 to perform the replication of an entire server";
     LOG_TOPIC("75fa1", ERR, Logger::REPLICATION) << err;
@@ -76,8 +75,7 @@ bool GlobalTailingSyncer::skipMarker(VPackSlice const& slice) {
     return false;
   }
 
-  if (_state.leader.majorVersion < 3 ||
-      (_state.leader.majorVersion == 3 && _state.leader.minorVersion <= 2)) {
+  if (_state.leader.version() < 30300) {
     // globallyUniqueId only exists in 3.3 and higher
     return false;
   }

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -1694,7 +1694,8 @@ Result TailingSyncer::fetchOpenTransactions(TRI_voc_tick_t fromTick, TRI_voc_tic
   // send request
   std::unique_ptr<httpclient::SimpleHttpResult> response;
   _state.connection.lease([&](httpclient::SimpleHttpClient* client) {
-    response.reset(client->request(rest::RequestType::GET, url, nullptr, 0));
+    auto headers = replutils::createHeaders();
+    response.reset(client->request(rest::RequestType::GET, url, nullptr, 0, headers));
   });
 
   if (replutils::hasFailed(response.get())) {
@@ -1826,8 +1827,9 @@ void TailingSyncer::fetchLeaderLog(std::shared_ptr<Syncer::JobSynchronizer> shar
     double time = TRI_microtime();
 
     _state.connection.lease([&](httpclient::SimpleHttpClient* client) {
+      auto headers = replutils::createHeaders();
       response.reset(client->request(rest::RequestType::PUT, url, body.c_str(),
-                                     body.size()));
+                                     body.size(), headers));
     });
 
     time = TRI_microtime() - time;

--- a/arangod/Replication/utilities.h
+++ b/arangod/Replication/utilities.h
@@ -134,6 +134,9 @@ struct LeaderInfo {
 
   explicit LeaderInfo(ReplicationApplierConfiguration const& applierConfig);
 
+  /// @brief returns major version number * 10000 + minor version number * 100
+  uint64_t version() const;
+
   /// @brief get leader state
   Result getState(Connection& connection, bool isChildSyncer, char const* context);
 

--- a/lib/ApplicationFeatures/ConfigFeature.cpp
+++ b/lib/ApplicationFeatures/ConfigFeature.cpp
@@ -29,7 +29,6 @@
 #include "ApplicationFeatures/ShellColorsFeature.h"
 #include "ApplicationFeatures/VersionFeature.h"
 #include "Basics/ArangoGlobalContext.h"
-#include "Basics/FileResultString.h"
 #include "Basics/FileUtils.h"
 #include "Basics/StringUtils.h"
 #include "Basics/application-exit.h"

--- a/lib/ApplicationFeatures/V8SecurityFeature.cpp
+++ b/lib/ApplicationFeatures/V8SecurityFeature.cpp
@@ -36,7 +36,6 @@
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "ApplicationFeatures/TempFeature.h"
 #include "ApplicationFeatures/V8PlatformFeature.h"
-#include "Basics/FileResultString.h"
 #include "Basics/FileUtils.h"
 #include "Basics/StringUtils.h"
 #include "Basics/application-exit.h"


### PR DESCRIPTION
### Scope & Purpose

Make sure the x-arango-source header is set for all internal requests.

There is currently no consequence from setting or not setting this header except that there will be additional request logging in log level DEBUG if the header is set. It is not used for anything else, but it may help with debugging. Now it is set consistently for internal requests.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12426/