### PR TITLE
add failure test for QueryRegistry::insertQuery

### DIFF
--- a/arangod/Aql/AstResources.cpp
+++ b/arangod/Aql/AstResources.cpp
@@ -181,13 +181,13 @@ char* AstResources::registerLongString(char* copy, size_t length) {
   if (capacity > _strings.capacity()) {
     // not enough capacity...
     _resourceMonitor->increaseMemoryUsage(
-        ((capacity - _strings.size()) * sizeof(char*)) + length);
+        ((capacity - _strings.capacity()) * sizeof(char*)) + length);
     try {
       _strings.reserve(capacity);
     } catch (...) {
       // revert change in memory increase
       _resourceMonitor->decreaseMemoryUsage(
-          ((capacity - _strings.size()) * sizeof(char*)) + length);
+          ((capacity - _strings.capacity()) * sizeof(char*)) + length);
       throw;
     }
   } else {


### PR DESCRIPTION
### Scope & Purpose

Add tests for failing insertion into query registry.

- [ ] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (i.e. in shell_server_aql)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12430/