### PR TITLE
Docs: Remove indexBuckets, journalSize, doCompact, isVolatile from docs

### DIFF
--- a/Documentation/DocuBlocks/Rest/Collections/1_structs.md
+++ b/Documentation/DocuBlocks/Rest/Collections/1_structs.md
@@ -2,14 +2,6 @@
 If *true* then creating, changing or removing
 documents will wait until the data has been synchronized to disk.
 
-@RESTSTRUCT{doCompact,collection_info,boolean,required,}
-Whether or not the collection will be compacted.
-This option is only present for the MMFiles storage engine.
-
-@RESTSTRUCT{journalSize,collection_info,integer,required,}
-The maximal size setting for journals / datafiles
-in bytes. This option is only present for the MMFiles storage engine.
-
 @RESTSTRUCT{schema,collection_info,object,optional,}
 The collection level schema for documents.
 
@@ -29,11 +21,6 @@ generating keys and supplying own key values in the *_key* attribute
 of documents is considered an error.
 
 @RESTSTRUCT{lastValue,key_generator_type,integer,required,}
-
-@RESTSTRUCT{isVolatile,collection_info,boolean,required,}
-If *true* then the collection data will be
-kept in memory only and ArangoDB will not write or sync the data
-to disk. This option is only present for the MMFiles storage engine.
 
 @RESTSTRUCT{numberOfShards,collection_info,integer,optional,}
 The number of shards of the collection. _(cluster only)_
@@ -68,10 +55,6 @@ Attribute that is used in SmartGraphs (Enterprise Edition only). _(cluster only)
 @RESTSTRUCT{smartJoinAttribute,collection_info,string,optional,}
 Determines an attribute of the collection that must contain the shard key value
 of the referred-to SmartJoin collection (Enterprise Edition only). _(cluster only)_
-
-@RESTSTRUCT{indexBuckets,collection_info,integer,optional,}
-the number of index buckets
-*Only relevant for the MMFiles storage engine*
 
 @RESTSTRUCT{isSystem,collection_info,boolean,optional,}
 true if this is a system collection; usually *name* will start with an underscore.

--- a/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
+++ b/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
@@ -21,34 +21,12 @@ The name of the collection.
 If *true* then the data is synchronized to disk before returning from a
 document create, update, replace or removal operation. (default: false)
 
-@RESTBODYPARAM{doCompact,boolean,optional,}
-whether or not the collection will be compacted (default is *true*)
-This option is meaningful for the MMFiles storage engine only.
-
-@RESTBODYPARAM{journalSize,integer,optional,int64}
-The maximal size of a journal or datafile in bytes. The value
-must be at least `1048576` (1 MiB). (The default is a configuration parameter)
-This option is meaningful for the MMFiles storage engine only.
-
 @RESTBODYPARAM{isSystem,boolean,optional,}
 If *true*, create a  system collection. In this case *collection-name*
 should start with an underscore. End users should normally create non-system
 collections only. API implementors may be required to create system
 collections in very special occasions, but normally a regular collection will do.
 (The default is *false*)
-
-@RESTBODYPARAM{isVolatile,boolean,optional,}
-If *true* then the collection data is kept in-memory only and not made persistent.
-Unloading the collection will cause the collection data to be discarded. Stopping
-or re-starting the server will also cause full loss of data in the
-collection. Setting this option will make the resulting collection be
-slightly faster than regular collections because ArangoDB does not
-enforce any synchronization to disk and does not calculate any CRC
-checksums for datafiles (as there are no datafiles). This option
-should therefore be used for cache-type collections only, and not
-for data that cannot be re-created otherwise.
-(The default is *false*)
-This option is meaningful for the MMFiles storage engine only.
 
 @RESTBODYPARAM{schema,object,optional,}
 Optional object that specifies the collection level schema for

--- a/Documentation/DocuBlocks/Rest/Collections/put_api_collection_properties.md
+++ b/Documentation/DocuBlocks/Rest/Collections/put_api_collection_properties.md
@@ -22,12 +22,6 @@ attribute(s)
 - *waitForSync*: If *true* then creating or changing a
   document will wait until the data has been synchronized to disk.
 
-- *journalSize*: The maximal size of a journal or datafile in bytes.
-  The value must be at least `1048576` (1 MB). Note that when
-  changing the journalSize value, it will only have an effect for
-  additional journals or datafiles that are created. Already
-  existing journals or datafiles will not be affected.
-
 - *schema*: Object that specifies the collection level schema 
   for documents. The attribute keys `rule`, `level` and `message` must follow
   the rules documented in [Document Schema Validation](https://www.arangodb.com/docs/devel/document-schema-validation.html)
@@ -40,8 +34,6 @@ On success an object with the following attributes is returned:
 
 - *waitForSync*: The new value.
 
-- *journalSize*: The new value.
-
 - *status*: The status of the collection as number.
 
 - *type*: The collection type. Valid types are:
@@ -49,12 +41,6 @@ On success an object with the following attributes is returned:
   - 3: edges collection
 
 - *isSystem*: If *true* then the collection is a system collection.
-
-- *isVolatile*: If *true* then the collection data will be
-  kept in memory only and ArangoDB will not write or sync the data
-  to disk.
-
-- *doCompact*: Whether or not the collection will be compacted.
 
 - *keyOptions*: JSON object which contains key generation options:
   - *type*: specifies the type of the key generator. The currently
@@ -71,7 +57,7 @@ On success an object with the following attributes is returned:
   The attribute keys `rule`, `level` and `message` must follow the rules
   documented in [Document Schema Validation](https://www.arangodb.com/docs/devel/document-schema-validation.html)
 
-**Note**: except for *waitForSync*, *journalSize* and *name*, collection
+**Note**: except for *waitForSync* and *name*, collection
 properties **cannot be changed** once a collection is created. To rename
 a collection, the rename endpoint must be used.
 

--- a/Documentation/DocuBlocks/collectionCreateEdgeCollection.md
+++ b/Documentation/DocuBlocks/collectionCreateEdgeCollection.md
@@ -13,9 +13,4 @@ for *waitForSync* is *false*.
 
 * *waitForSync* (optional, default *false*): If *true* creating
   a document will only return after the data was synced to disk.
-* *journalSize* (optional, default is 
-  "configuration parameter"):  The maximal size of
-  a journal or datafile.  Note that this also limits the maximal
-  size of a single object and must be at least 1MB.
-
 

--- a/Documentation/DocuBlocks/collectionDatabaseCreate.md
+++ b/Documentation/DocuBlocks/collectionDatabaseCreate.md
@@ -15,12 +15,6 @@ to the [naming conventions](../NamingConventions/README.md).
 * *waitForSync* (optional, default *false*): If *true* creating
   a document will only return after the data was synced to disk.
 
-* *journalSize* (optional, default is a
-  global config parameter, **mmfiles-only**): The maximal
-  size of a journal or datafile.  Note that this also limits the maximal
-  size of a single object. Must be at least 1MB.
-  This option is meaningful for the MMFiles storage engine only.
-
 * *isSystem* (optional, default is *false*): If *true*, create a
   system collection. In this case *collection-name* should start with
   an underscore. End users should normally create non-system collections
@@ -88,16 +82,6 @@ to the [naming conventions](../NamingConventions/README.md).
   especially if your collection has a subset of frequently accessed keys. Please test this feature
   carefully to ensure that it does not adversely affect the performance of your system.
 
-* *isVolatile* (optional, default is *false*, **mmfiles-only**): If *true* then the
-  collection data is kept in-memory only and not made persistent. Unloading
-  the collection will cause the collection data to be discarded. Stopping
-  or re-starting the server will also cause full loss of data in the
-  collection. Setting this option will make the resulting collection be
-  slightly faster than regular collections because ArangoDB does not
-  enforce any synchronization to disk and does not calculate any CRC
-  checksums for datafiles (as there are no datafiles).
-  This option is meaningful for the MMFiles storage engine only.
-
 * *schema* (optional, default is *null*): 
   Object that specifies the collection level schema for documents.
   The attribute keys `rule`, `level` and `message` must follow the rules
@@ -122,8 +106,7 @@ With defaults:
 With properties:
 
 @EXAMPLE_ARANGOSH_OUTPUT{collectionDatabaseCreateProperties}
-  |c = db._create("users", { waitForSync : true,
-           journalSize : 1024 * 1204});
+  c = db._create("users", { waitForSync: true });
   c.properties();
 ~ db._drop("users");
 @END_EXAMPLE_ARANGOSH_OUTPUT

--- a/Documentation/DocuBlocks/collectionProperties.md
+++ b/Documentation/DocuBlocks/collectionProperties.md
@@ -8,14 +8,6 @@ Returns an object containing all collection properties.
 * *waitForSync*: If *true* creating a document will only return
   after the data was synced to disk.
 
-* *journalSize* : The size of the journal in bytes.
-  This option is meaningful for the MMFiles storage engine only.
-
-* *isVolatile*: If *true* then the collection data will be
-  kept in memory only and ArangoDB will not write or sync the data
-  to disk.
-  This option is meaningful for the MMFiles storage engine only.
-
 * *keyOptions* (optional) additional options for key generation. This is
   a JSON array containing the following attributes (note: some of the
   attributes are optional):
@@ -65,9 +57,6 @@ one or more of the following attribute(s):
 * *waitForSync*: If *true* creating a document will only return
   after the data was synced to disk.
 
-* *journalSize*: The size of the journal in bytes.
-  This option is meaningful for the MMFiles storage engine only.
-
 * *replicationFactor*: Change the number of shard copies kept on
   different DB-Servers. Valid values are integer numbers in the range of 1-10
   or the string `"satellite"` for a SatelliteCollection (Enterprise Edition only).
@@ -79,8 +68,8 @@ one or more of the following attribute(s):
   up-to-date copies will succeed at the same time however. The value of
   *writeConcern* can not be larger than *replicationFactor*. _(cluster only)_
 
-**Note**: some other collection properties, such as *type*, *isVolatile*,
-*keyOptions*, *numberOfShards* or *shardingStrategy* cannot be changed once 
+**Note**: some other collection properties, such as *type*,
+*keyOptions*, *numberOfShards* or *shardingStrategy* cannot be changed once
 the collection is created.
 
 @EXAMPLES


### PR DESCRIPTION
Addendum to https://github.com/arangodb/docs/pull/565 and #12866

@jsteemann What about the `--database.maximal-journal-size` option?
Is it supposed to be removed as well, and hence this DocuBlock?

https://github.com/arangodb/arangodb/blob/devel/Documentation/DocuBlocks/databaseMaximalJournalSize.md
(referenced by arangodb/docs!)