### PR TITLE
fix potential lifecycle issue

### DIFF
--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -3493,7 +3493,7 @@ Result RestReplicationHandler::createBlockingTransaction(
         // Code does not matter, read only access, so we can roll back.
         transaction::Manager* mgr = transaction::ManagerFeature::manager();
         if (mgr) {
-          mgr->abortManagedTrx(id, _vocbase.name());
+          mgr->abortManagedTrx(id, vn);
         }
       } catch (...) {
         // All errors that show up here can only be
@@ -3521,7 +3521,7 @@ Result RestReplicationHandler::createBlockingTransaction(
 
   if (isTombstoned(id)) {
     try {
-      return mgr->abortManagedTrx(id, _vocbase.name());
+      return mgr->abortManagedTrx(id, vn);
     } catch (...) {
       // Maybe thrown in shutdown.
     }


### PR DESCRIPTION
### Scope & Purpose

Fix a potential lifecycle issue, when `_vocbase` is used from inside the callback, but the object has been destroyed/replaced already. This is an issue in current devel only. 3.7 or 3.6 are not affected.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12454/