### PR TITLE
Bug fix 3.7/indexes on disjoint smart edges

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.7.5 (XXXX-XX-XX)
 -------------------
 
+* Bug-fix: Creating an additional index on the edge collection of a disjoint
+  SmartGraph could falsly result into an error: 
+  `Could not find all smart collections ...`
+  This is now ruled out and indexes can be created as expected.
+
 * Fixed issue #12248: Web UI - Added missing HTML escaping in the setup script
   section of a foxx app.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ v3.7.5 (XXXX-XX-XX)
 -------------------
 
 * Bug-fix: Creating an additional index on the edge collection of a disjoint
-  SmartGraph could falsly result into an error: 
+  SmartGraph could falsely result in an error: 
   `Could not find all smart collections ...`
   This is now ruled out and indexes can be created as expected.
 


### PR DESCRIPTION
### Scope & Purpose

This is just CHANGELOG PR.
The fix is enterprise only
Backport of https://github.com/arangodb/arangodb/pull/12900

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [x] Backports required for:
  - [x] devel
  - [x] 3.7

#### Related Information

*(Please reference tickets / specification etc)*

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/572
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added **Regression Tests**
  - [ ] Added new C++ **Unit Tests**
  - [ ] Added new **integration tests** (i.e. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)

Additionally:

- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

http://jenkins.arangodb.biz:8080/job/arangodb-matrix-pr/12468/

### Documentation

> All new Features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the changelog so that
> developers and users have a concise overview. 

- [x] Added a *Changelog Entry* (referencing the corresponding public or internal issue number)
- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
