### PR TITLE
fix idle timeouts for VST and HTTP/2

### DIFF
--- a/arangod/GeneralServer/H2CommTask.cpp
+++ b/arangod/GeneralServer/H2CommTask.cpp
@@ -417,7 +417,9 @@ void H2CommTask<T>::setIOTimeout() {
 
   const bool wasReading = this->_reading;
   const bool wasWriting = this->_writing;
-  TRI_ASSERT(wasReading || wasWriting);
+  // when we are finished writing and get here, we may have
+  // neither an active reader nor writer
+  // TRI_ASSERT(wasReading || wasWriting);
   if (wasWriting) {
     secs = std::max(this->WriteTimeout, secs);
   }
@@ -792,6 +794,8 @@ void H2CommTask<T>::doWrite() {
     this->_writing = false;
     if (shouldStop()) {
       this->close();
+    } else {
+      setIOTimeout();
     }
     return;
   }

--- a/arangod/GeneralServer/VstCommTask.cpp
+++ b/arangod/GeneralServer/VstCommTask.cpp
@@ -435,6 +435,7 @@ void VstCommTask<T>::doWrite() {
     // a new request item
     _writeLoopActive.store(false);
     if (_writeQueue.empty()) {
+      this->setIOTimeout();
       return;  // done, someone else may restart
     }
 

--- a/arangosh/Shell/V8ClientConnection.cpp
+++ b/arangosh/Shell/V8ClientConnection.cpp
@@ -77,7 +77,9 @@ V8ClientConnection::V8ClientConnection(application_features::ApplicationServer& 
       _loop(1, "V8ClientConnection"),
       _vpackOptions(VPackOptions::Defaults),
       _forceJson(false),
-      _setCustomError(false) {
+      _setCustomError(false),
+      _connects(0),
+      _requests(0) {
   _vpackOptions.buildUnindexedObjects = true;
   _vpackOptions.buildUnindexedArrays = true;
 
@@ -110,12 +112,19 @@ std::shared_ptr<fu::Connection> V8ClientConnection::createConnection() {
     setCustomError(400, "no endpoint specified");
     return nullptr;
   }
+
   auto newConnection = _builder.connect(_loop);
   fu::StringMap params{{"details", "true"}};
   auto req = fu::createRequest(fu::RestVerb::Get, "/_api/version", params);
   req->header.database = _databaseName;
   req->timeout(std::chrono::seconds(30));
+  
+  // update statistics
+  ++_connects;
+
   try {
+    // update statistics
+    ++_requests; 
     auto res = newConnection->sendRequest(std::move(req));
 
     _lastHttpReturnCode = res->statusCode();
@@ -557,6 +566,37 @@ static void ClientConnection_connectedUser(v8::FunctionCallbackInfo<v8::Value> c
   }
 
   TRI_V8_RETURN(TRI_V8_STD_STRING(isolate, client->username()));
+  TRI_V8_TRY_CATCH_END
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief ClientConnection method "connectionStatistics"
+////////////////////////////////////////////////////////////////////////////////
+
+static void ClientConnection_connectionStatistics(v8::FunctionCallbackInfo<v8::Value> const& args) {
+  TRI_V8_TRY_CATCH_BEGIN(isolate);
+  v8::Isolate* isolate = args.GetIsolate();
+  v8::HandleScope scope(isolate);
+
+  V8ClientConnection* v8connection =
+      TRI_UnwrapClass<V8ClientConnection>(args.Holder(), WRAP_TYPE_CONNECTION, TRI_IGETC);
+  
+  if (v8connection == nullptr) {
+    TRI_V8_THROW_EXCEPTION_INTERNAL("connectionStatistics() must be invoked on an arango connection object instance.");
+  }
+
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+
+  v8::Local<v8::Object> result = v8::Object::New(isolate);
+  result->Set(context,
+              TRI_V8_ASCII_STRING(isolate, "connects"),
+              v8::Integer::New(isolate, static_cast<uint32_t>(v8connection->connects()))).FromMaybe(false);
+  
+  result->Set(context,
+              TRI_V8_ASCII_STRING(isolate, "requests"),
+              v8::Integer::New(isolate, static_cast<uint32_t>(v8connection->requests()))).FromMaybe(false);
+
+  TRI_V8_RETURN(result);
   TRI_V8_TRY_CATCH_END
 }
 
@@ -1764,6 +1804,8 @@ again:
   fu::Error rc = fu::Error::NoError;
   std::unique_ptr<fu::Response> response;
   try {
+    // update statistics
+    ++_requests; 
     response = connection->sendRequest(std::move(req));
   } catch (fu::Error const& ec) {
     rc = ec;
@@ -1847,6 +1889,8 @@ again:
   fu::Error rc = fu::Error::NoError;
   std::unique_ptr<fu::Response> response;
   try {
+    // update statistics
+    ++_requests; 
     response = connection->sendRequest(std::move(req));
   } catch (fu::Error const& e) {
     rc = e;
@@ -2149,6 +2193,10 @@ void V8ClientConnection::initServer(v8::Isolate* isolate, v8::Local<v8::Context>
 
   connection_proto->Set(isolate, "connectedUser",
                         v8::FunctionTemplate::New(isolate, ClientConnection_connectedUser,
+                                                  v8client));
+  
+  connection_proto->Set(isolate, "connectionStatistics",
+                        v8::FunctionTemplate::New(isolate, ClientConnection_connectionStatistics,
                                                   v8client));
 
   connection_proto->Set(isolate, "timeout",

--- a/arangosh/Shell/V8ClientConnection.h
+++ b/arangosh/Shell/V8ClientConnection.h
@@ -74,6 +74,9 @@ class V8ClientConnection {
 
   void timeout(double value);
 
+  uint64_t connects() const { return _connects; }
+  uint64_t requests() const { return _requests; }
+
   std::string const& databaseName() const { return _databaseName; }
   void setDatabaseName(std::string const& value) { _databaseName = value; }
   void setForceJson(bool value) { _forceJson = value; };
@@ -171,6 +174,9 @@ class V8ClientConnection {
   velocypack::Options _vpackOptions;
   bool _forceJson;
   bool _setCustomError;
+
+  uint64_t _connects;
+  uint64_t _requests;
 };
 }  // namespace arangodb
 

--- a/tests/js/client/server_parameters/test-idle-timeouts.js
+++ b/tests/js/client/server_parameters/test-idle-timeouts.js
@@ -1,0 +1,102 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertTrue, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for security-related server options
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'http.keep-alive-timeout': '5'
+  };
+}
+let jsunity = require('jsunity');
+let internal = require('internal');
+let db = internal.db;
+const originalEndpoint = arango.getEndpoint();
+
+function testSuite() {
+  let connectWith = function(protocol) {
+    let endpoint = arango.getEndpoint().replace(/^[a-zA-Z0-9\+]+:/, protocol + ':');
+    arango.reconnect(endpoint, db._name(), arango.connectedUser(), "");
+  };
+
+  let checkReconnect = function(timeout) {
+    // make a request so we are reconnecting if necessary
+    db._databases();
+    let statsBefore = arango.connectionStatistics();
+    internal.sleep(timeout);
+
+    // make a request so we are reconnecting if necessary
+    db._databases();
+    let statsAfter = arango.connectionStatistics();
+    assertTrue(statsAfter.connects > statsBefore.connects, { statsBefore, statsAfter });
+  };
+
+  return {
+    tearDown: function() {
+      // restore original connection type
+      arango.reconnect(originalEndpoint, db._name(), arango.connectedUser(), "");
+    },
+
+    testKeepAliveTimeoutHttp1 : function() {
+      connectWith("tcp");
+      // the query should succeed despite it running longer than the configured 
+      // connection timeout
+      let result = db._query("FOR i IN 1..10 RETURN SLEEP(1)").toArray();
+      assertEqual(10, result.length);
+    },
+    
+    testKeepAliveTimeoutVst : function() {
+      connectWith("vst");
+      // the query should succeed despite it running longer than the configured 
+      // connection timeout
+      let result = db._query("FOR i IN 1..10 RETURN SLEEP(1)").toArray();
+      assertEqual(10, result.length);
+    },
+    
+    testIdleTimeoutVst : function() {
+      connectWith("vst");
+      checkReconnect(7);
+    },
+    
+    testKeepAliveTimeoutHttp2 : function() {
+      connectWith("h2");
+      // the query should succeed despite it running longer than the configured 
+      // connection timeout
+      let result = db._query("FOR i IN 1..10 RETURN SLEEP(1)").toArray();
+      assertEqual(10, result.length);
+    },
+    
+    testIdleTimeoutHttp2 : function() {
+      connectWith("h2");
+      checkReconnect(7);
+    },
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

The effective idle timeout was almost always bumped up to the full 300 seconds (i.e. this->WriteTimeout) instead of the configured value of `--http.keep-alive-timeout`.
This was supposed to be fixed for 3.7.3 already, but apparently did not work properly.

We should add additional tests by drivers (e.g. Java) to cover this case.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12476/