### PR TITLE
fix the getting-in-sync of shards for MMFiles collections

### DIFF
--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -808,15 +808,15 @@ bool SynchronizeShard::first() {
           " of shard " + database + "/" + collection->name() + " of collection " + database +
           "/" + resolver.getCollectionName(collection->id());
     }
-
+  
+    std::string const& engineName = EngineSelectorFeature::ENGINE->typeName();
 
     // old "shortcut" code for getting in sync. This code takes a shortcut if the
     // shard in question is supposed to be empty. in this case it will simply try
     // to add itself as an in-sync follower, without running the full replication
     // protocol. this shortcut relies on the collection counts being correct, and
     // as these can be at least temporarily off, we need to disable it.
-#if 0
-    if (docCount == 0) {
+    if (docCount == 0 && engineName == "mmfiles") {
       // We have a short cut:
       LOG_TOPIC("0932a", DEBUG, Logger::MAINTENANCE)
           << "synchronizeOneShard: trying short cut to synchronize local shard "
@@ -841,7 +841,6 @@ bool SynchronizeShard::first() {
       } catch (...) {
       }
     }
-#endif
 
     LOG_TOPIC("53337", DEBUG, Logger::MAINTENANCE)
         << "synchronizeOneShard: trying to synchronize local shard '" << database
@@ -1145,7 +1144,7 @@ Result SynchronizeShard::catchupWithExclusiveLock(
   // under many cicrumstances the counts will have been auto-healed by the initial
   // or the incremental replication before, so in many cases we will not even get
   // into this if case
-  if (res.is(TRI_ERROR_REPLICATION_WRONG_CHECKSUM)) {
+  if (EngineSelectorFeature::isRocksDB() && res.is(TRI_ERROR_REPLICATION_WRONG_CHECKSUM)) {
     // give up the lock on the leader, so writes aren't stopped unncessarily
     // on the leader while we are recalculating the counts
     readLockGuard.fire();

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -2515,9 +2515,9 @@ void RestReplicationHandler::handleCommandAddFollower() {
     const std::string checksum = checksumSlice.copyString();
     LOG_TOPIC("592ef", WARN, Logger::REPLICATION)
         << "Cannot add follower, mismatching checksums. "
-        << "Expected (leader): " << referenceChecksum.get() << " Actual (follower): " << checksum;
+        << "Expected (leader): " << leaderChecksum << " Actual (follower): " << checksum;
     generateError(rest::ResponseCode::BAD, TRI_ERROR_REPLICATION_WRONG_CHECKSUM,
-                  "'checksum' is wrong. Expected (leader): " + referenceChecksum.get() +
+                  "'checksum' is wrong. Expected (leader): " + leaderChecksum +
                       ". Actual (follower): " + checksum);
     return;
   }


### PR DESCRIPTION
### Scope & Purpose

Fix the shard-getting-in-sync procedure for MMFiles. 
We recently disabled the getting-in-sync shortcut, which is the right solution for the RocksDB storage engine, but MMFiles seems to depend on it. These changes were not released yet, but were still in testing. During testing it turned out that the changes harm the getting-in-sync protocol for MMFiles.
This PR reenables the shortcut just for MMFiles, and also avoids calling a non-implemented API for recalculating collection counts also in case the storage engine is MMFiles.

The test plan for this PR is to run `scripts/unittest dump --cluster true --storageEngine mmfiles`, which should show no replication errors with this PR.


- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is already covered by existing tests, such as *scripts/unittest dump --cluster true --storageEngine mmfiles*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12487/