### PR TITLE
Bug fix 3.6/fix getting in sync for mmfiles

### DIFF
--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -1264,12 +1264,9 @@ Result SynchronizeShard::catchupWithExclusiveLock(
     return {TRI_ERROR_INTERNAL, errorMessage};
   }
   
-  uint64_t finalDocCount;
-  collectionCount(collection, finalDocCount);
-
   // Report success:
   LOG_TOPIC("3423d", INFO, Logger::MAINTENANCE)
-      << "synchronizeOneShard: synchronization worked for shard " << database << "/" << shard << ", number of documents: " << finalDocCount;
+      << "synchronizeOneShard: synchronization worked for shard " << database << "/" << shard;
   _result.reset(TRI_ERROR_NO_ERROR);
   return {TRI_ERROR_NO_ERROR};
 }


### PR DESCRIPTION
### Scope & Purpose

Fix the shard-getting-in-sync procedure for MMFiles. 
We recently disabled the getting-in-sync shortcut, which is the right solution for the RocksDB storage engine, but MMFiles seems to depend on it. These changes were not released yet, but were still in testing. During testing it turned out that the changes harm the getting-in-sync protocol for MMFiles.
This PR reenables the shortcut just for MMFiles, and also avoids calling a non-implemented API for recalculating collection counts also in case the storage engine is MMFiles.

The test plan for this PR is to run `scripts/unittest dump --cluster true --storageEngine mmfiles`, which should show no replication errors with this PR.

In addition, the PR also removes a collection count operation at the end of the getting-in-sync phase that was added for debug-only purposes. It is potentially better to not do the counting here, as it may have adverse effects (requiring a lock to perform the counting etc.). 

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] Backports required for: 3.5: https://github.com/arangodb/arangodb/pull/12918

### Testing & Verification

- [x] This change is already covered by existing tests, such as *scripts/unittest dump --cluster true --storageEngine mmfiles*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12488/