### PR TITLE
fix count updates on leaders with multiple followers

### DIFF
--- a/arangod/RocksDBEngine/RocksDBReplicationContext.h
+++ b/arangod/RocksDBEngine/RocksDBReplicationContext.h
@@ -147,6 +147,9 @@ class RocksDBReplicationContext {
                       bool includeFoxxQueues, bool global,
                       velocypack::Builder&);
 
+  void setPatchCount(std::string const& patchCount);
+  std::string const& patchCount() const;
+
   // ========================= Dump API =============================
 
   struct DumpResult {
@@ -235,6 +238,12 @@ class RocksDBReplicationContext {
   SyncerId const _syncerId;
   ServerId const _clientId;
   std::string const _clientInfo;
+
+  /// @brief collection for which we are allowed to patch counts. this can
+  /// be empty, meaning that the counts should not be patched for any collection.
+  /// if this is set to the name of any collection/shard, it is expected that the
+  /// context will only be used for exactly one collection/shard.
+  std::string _patchCount;
 
   uint64_t _snapshotTick;  // tick in WAL from _snapshot
   rocksdb::Snapshot const* _snapshot;

--- a/arangod/RocksDBEngine/RocksDBReplicationManager.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationManager.cpp
@@ -100,7 +100,11 @@ RocksDBReplicationManager::~RocksDBReplicationManager() {
 //////////////////////////////////////////////////////////////////////////////
 
 RocksDBReplicationContext* RocksDBReplicationManager::createContext(
-    double ttl, SyncerId const syncerId, ServerId const clientId) {
+    double ttl, SyncerId const syncerId, ServerId const clientId,
+    std::string const& patchCount) {
+  // patchCount should only be set on DB servers
+  TRI_ASSERT(ServerState::instance()->isDBServer() || patchCount.empty());
+
   auto context = std::make_unique<RocksDBReplicationContext>(ttl, syncerId, clientId);
   TRI_ASSERT(context != nullptr);
   TRI_ASSERT(context->isUsed());
@@ -113,6 +117,30 @@ RocksDBReplicationContext* RocksDBReplicationManager::createContext(
     if (_isShuttingDown) {
       // do not accept any further contexts when we are already shutting down
       THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+    }
+
+    if (!patchCount.empty()) {
+      // patchCount was set. this is happening only during the getting-in-sync
+      // protocol. now check if any other context has the same patchCount
+      // value set. in this case, the other context is responsible for applying
+      // count patches, and we have to drop ours
+      
+      // note: it is safe here to access the patchCount() method of any context,
+      // as the only place that modifies a context's _patchCount instance variable,
+      // is the call to setPatchcount() a few lines below. there is no concurrency
+      // here, as this method here is executed under a mutex. in addition, _contexts
+      // is only modified under this same mutex, 
+      bool foundOther = 
+        _contexts.end() != std::find_if(_contexts.begin(), _contexts.end(), [&patchCount](decltype(_contexts)::value_type const& entry) {
+          return entry.second->patchCount() == patchCount;
+        });
+      if (!foundOther) {
+        // no other context exists that has "leadership" for patching counts to the
+        // same collection/shard
+        context->setPatchCount(patchCount);
+      }
+      // if we found a different context here, then the other context is responsible
+      // for applying count patches.
     }
 
     _contexts.try_emplace(id, context.get());

--- a/arangod/RocksDBEngine/RocksDBReplicationManager.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationManager.cpp
@@ -102,11 +102,11 @@ RocksDBReplicationManager::~RocksDBReplicationManager() {
 RocksDBReplicationContext* RocksDBReplicationManager::createContext(
     double ttl, SyncerId const syncerId, ServerId const clientId,
     std::string const& patchCount) {
-  // patchCount should only be set on DB servers
-  TRI_ASSERT(ServerState::instance()->isDBServer() || patchCount.empty());
+  // patchCount should only be set on single servers or DB servers
+  TRI_ASSERT(patchCount.empty() ||
+             (ServerState::instance()->isSingleServer() || ServerState::instance()->isDBServer())); 
 
   auto context = std::make_unique<RocksDBReplicationContext>(ttl, syncerId, clientId);
-  TRI_ASSERT(context != nullptr);
   TRI_ASSERT(context->isUsed());
 
   RocksDBReplicationId const id = context->id();

--- a/arangod/RocksDBEngine/RocksDBReplicationManager.h
+++ b/arangod/RocksDBEngine/RocksDBReplicationManager.h
@@ -58,7 +58,8 @@ class RocksDBReplicationManager {
   /// there are active contexts
   //////////////////////////////////////////////////////////////////////////////
 
-  RocksDBReplicationContext* createContext(double ttl, SyncerId syncerId, ServerId clientId);
+  RocksDBReplicationContext* createContext(double ttl, SyncerId syncerId,
+                                           ServerId clientId, std::string const& patchCount);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief remove a context by id

--- a/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
@@ -88,7 +88,7 @@ void RocksDBRestReplicationHandler::handleCommandBatch() {
 
     // create transaction+snapshot, ttl will be default if `ttl == 0``
     auto ttl = VelocyPackHelper::getNumericValue<double>(body, "ttl", replutils::BatchInfo::DefaultTimeout);
-    auto* ctx = _manager->createContext(ttl, syncerId, clientId);
+    auto* ctx = _manager->createContext(ttl, syncerId, clientId, patchCount);
     RocksDBReplicationContextGuard guard(_manager, ctx);
 
     if (!patchCount.empty()) {


### PR DESCRIPTION
### Scope & Purpose

Fixes potential races when applying count updates on leaders if multiple followers of the same shard try to get in sync at the very same time, and all try to apply count updates individually.
This PR introduces a "leadership" for applying count updates, simply by scanning all existing ReplicationContexts for the same shard when creating a ReplicationContext on a leader. If there exists a ReplicationContext for the same shard already, then that context is considered responsible. Otherwise, the to-be-created context will assume responsibility for applying potential count updates.
The changes can be verified by running the following test (needs 3 DB servers):
```
scripts/unittest shell_client --cluster true --test tests/js/client/shell/shell-collection-counts-cluster-rocksdb.js --dbServers 3
```

- [x] :hankey: Bugfix 
- [x] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] Backports required for: 3.5 (https://github.com/arangodb/arangodb/pull/12920), 3.6 (https://github.com/arangodb/arangodb/pull/12921)

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (i.e. in shell_client)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12491/