### PR TITLE
AQL setup now abort earlier if no shards of a collection can be ident…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.7.5 (XXXX-XX-XX)
 -------------------
 
+* If a collection (or database) is dropped during the instantiation of an AQL query,
+  the setup code now aborts with an ERROR_QUERY_COLLECTION_LOCK_FAILED and earlier.
+  Before the setup code could abort with TRI_ERROR_INTERNAL in the same case.
+
 * Fixed issue #12248: Web UI - Added missing HTML escaping in the setup script
   section of a foxx app.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,9 @@
 v3.7.5 (XXXX-XX-XX)
 -------------------
 
-* If a collection (or database) is dropped during the instantiation of an AQL query,
-  the setup code now aborts with an ERROR_QUERY_COLLECTION_LOCK_FAILED and earlier.
+* If a collection (or database) is dropped during the instantiation of an AQL
+  query, the setup code now aborts with an ERROR_QUERY_COLLECTION_LOCK_FAILED
+  and earlier.
   Before the setup code could abort with TRI_ERROR_INTERNAL in the same case.
 
 * Bug-fix: Creating an additional index on the edge collection of a disjoint

--- a/arangod/Aql/ShardLocking.cpp
+++ b/arangod/Aql/ShardLocking.cpp
@@ -152,11 +152,14 @@ void ShardLocking::updateLocking(Collection const* col,
     auto const shards = col->shardIds(_query.queryOptions().restrictToShards);
     // What if we have an empty shard list here?
     if (shards->empty()) {
-      LOG_TOPIC("0997e", WARN, arangodb::Logger::AQL)
-          << "TEMPORARY: A collection access of a query has no result in any "
-             "shard";
-      TRI_ASSERT(false);
-      return;
+      auto const& name = col->name();
+      if (!TRI_vocbase_t::IsSystemName(name)) {
+        LOG_TOPIC("0997e", WARN, arangodb::Logger::AQL)
+          << "Accessing collection: " << name << " does not translate to any shard. Aborting query."; 
+      }
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_QUERY_COLLECTION_LOCK_FAILED,
+          "Could not identify any shard belonging to collection: " + name + ". Maybe it is dropped?");
     }
     for (auto const& s : *shards) {
       info.allShards.emplace(s);

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -4809,6 +4809,10 @@ std::unordered_map<ShardID, ServerID> ClusterInfo::getResponsibleServers(
 
 std::shared_ptr<std::vector<ShardID>> ClusterInfo::getShardList(CollectionID const& collectionID) {
   int tries = 0;
+  TRI_IF_FAILURE("ClusterInfo::failedToGetShardList") {
+    // Simulate 3 failed tries below.
+    return std::make_shared<std::vector<ShardID>>();
+  }
   while (true) {
     {
       // Get the sharding keys and the number of shards:

--- a/tests/js/server/aql/aql-failures-cluster.js
+++ b/tests/js/server/aql/aql-failures-cluster.js
@@ -45,12 +45,12 @@ function ahuacatlFailureSuite () {
   const cn = "UnitTestsAhuacatlFailures";
   const en = "UnitTestsAhuacatlEdgeFailures";
   
-  let  assertFailingQuery = function (query) {
+  let  assertFailingQuery = function (query, expectedError = internal.errors.ERROR_DEBUG) {
     try {
       AQL_EXECUTE(query);
       fail();
     } catch (err) {
-      assertEqual(internal.errors.ERROR_DEBUG.code, err.errorNum, query);
+      assertEqual(expectedError.code, err.errorNum, query);
     }
   };
         

--- a/tests/js/server/aql/aql-failures-cluster.js
+++ b/tests/js/server/aql/aql-failures-cluster.js
@@ -33,6 +33,9 @@ var arangodb = require("@arangodb");
 var db = arangodb.db;
 var internal = require("internal");
 
+const {ERROR_QUERY_COLLECTION_LOCK_FAILED} = internal.errors;
+
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test suite
 ////////////////////////////////////////////////////////////////////////////////
@@ -52,7 +55,6 @@ function ahuacatlFailureSuite () {
   };
         
   return {
-
     setUpAll: function () {
       internal.debugClearFailAt();
       db._drop(cn);
@@ -71,7 +73,7 @@ function ahuacatlFailureSuite () {
       db._drop(en);
     },
 
-    tearDown: function() {
+    tearDown: function () {
       internal.debugClearFailAt();
     },
 
@@ -82,27 +84,51 @@ function ahuacatlFailureSuite () {
       // no real test expectations here, just that the query works and doesn't fail on shutdown
       assertEqual(0, res.length);
     },
-    
-    testShutdownSyncDiamond : function () {
+
+    testShutdownSyncDiamond: function () {
       internal.debugSetFailAt("ExecutionEngine::shutdownSync");
 
-      let res = AQL_EXECUTE("FOR doc1 IN " + cn + " FOR doc2 IN " + en + " FILTER doc1._key == doc2._key RETURN doc1").json;
+      let res = AQL_EXECUTE(
+        "FOR doc1 IN " +
+          cn +
+          " FOR doc2 IN " +
+          en +
+          " FILTER doc1._key == doc2._key RETURN doc1"
+      ).json;
       // no real test expectations here, just that the query works and doesn't fail on shutdown
       assertEqual(0, res.length);
     },
-    
-    testShutdownSyncFailInGetSome : function () {
+
+    testShutdownSyncFailInGetSome: function () {
       internal.debugSetFailAt("ExecutionEngine::shutdownSync");
       internal.debugSetFailAt("RestAqlHandler::getSome");
 
       assertFailingQuery("FOR doc IN " + cn + " RETURN doc");
     },
 
-    testShutdownSyncDiamondFailInGetSome : function () {
+    testShutdownSyncDiamondFailInGetSome: function () {
       internal.debugSetFailAt("ExecutionEngine::shutdownSync");
       internal.debugSetFailAt("RestAqlHandler::getSome");
 
-      assertFailingQuery("FOR doc1 IN " + cn + " FOR doc2 IN " + en + " FILTER doc1._key == doc2._key RETURN doc1");
+      assertFailingQuery(
+        "FOR doc1 IN " +
+          cn +
+          " FOR doc2 IN " +
+          en +
+          " FILTER doc1._key == doc2._key RETURN doc1"
+      );
+    },
+
+    testNoShardsReturned: function () {
+      internal.debugSetFailAt("ClusterInfo::failedToGetShardList");
+      assertFailingQuery(
+        "FOR doc1 IN " +
+          cn +
+          " FOR doc2 IN " +
+          en +
+          " FILTER doc1._key == doc2._key RETURN doc1",
+        ERROR_QUERY_COLLECTION_LOCK_FAILED
+      );
     },
   };
 }


### PR DESCRIPTION
Backport of: https://github.com/arangodb/arangodb/pull/12911/
No issues on cherry-pick

### Scope & Purpose

We now directly abort if we failed to translate Collection => Shard in AQL setup.
This situation can happen if the collection or database is dropped.
Before we still would return an error and leave no harm, this situation is now just a bit cleaner.

- [ ] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [x] Backports required for: 
  - [x] devel
  - [x] 3.7

#### Related Information

*(Please reference tickets / specification etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-158.
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added **Regression Tests**
  - [ ] Added new C++ **Unit Tests**
  - [ ] Added new **integration tests** (i.e. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)

Additionally:

- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Jenkins: http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/12472/

### Documentation

> All new Features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the changelog so that
> developers and users have a concise overview. 

- [x] Added a *Changelog Entry* (referencing the corresponding public or internal issue number)
- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
