### PR TITLE
fixed compiler flags ordering, spezialized flags get added after base…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -987,8 +987,8 @@ else () # NOT MSVC
 endif ()
 
 # put together the final flags
-set(CMAKE_C_FLAGS    "${CMAKE_C_FLAGS} ${BASE_FLAGS} ${BASE_C_FLAGS}")
-set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${BASE_FLAGS} ${BASE_CXX_FLAGS}")
+set(CMAKE_C_FLAGS    "${BASE_FLAGS} ${BASE_C_FLAGS} ${CMAKE_C_FLAGS}")
+set(CMAKE_CXX_FLAGS  "${BASE_FLAGS} ${BASE_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
 
 if (VERBOSE)
   message(STATUS "Info BASE_FLAGS:     ${BASE_FLAGS}")


### PR DESCRIPTION
Addition to: https://github.com/arangodb/arangodb/pull/12895

Specialized flags will now be added behind the general flags. This is needed as some base flags overwrite specialised ones. This is not wanted behaviour. 