### PR TITLE
fix spurious error when accessing a nullptr transaction context

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 devel
 -----
-* Added new 'aql' type for ArangoSearch analyzers
+
+* Fixed very spurious errors if the `holdReadLockCollection` replication API for
+  the getting-in-sync procedure of shards was called during server shutdown.
+  In this case that method could ask the transaction manager for a specific
+  transaction, but wasn't return one due to the server shutddown. 
+
+* Added new 'aql' type for ArangoSearch analyzers.
 
 * Obsoleted the startup options `--database.throw-collection-not-loaded-error` 
   and `--ttl.only-loaded-collection`.

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -487,11 +487,11 @@ arangodb::Result SynchronizeShard::startReadLockOnLeader(
       getReadLockId(pool, endpoint, database, clientId, timeout, rlid);
   if (!result.ok()) {
     LOG_TOPIC("2e5ae", WARN, Logger::MAINTENANCE) << result.errorMessage();
-    return result;
-  }
-  LOG_TOPIC("c8d18", DEBUG, Logger::MAINTENANCE) << "Got read lock id: " << rlid;
+  } else {
+    LOG_TOPIC("c8d18", DEBUG, Logger::MAINTENANCE) << "Got read lock id: " << rlid;
 
-  result = getReadLock(pool, endpoint, database, collection, clientId, rlid, soft, timeout);
+    result.reset(getReadLock(pool, endpoint, database, collection, clientId, rlid, soft, timeout));
+  }
 
   return result;
 }
@@ -909,7 +909,7 @@ bool SynchronizeShard::first() {
         catchupWithReadLock(ep, database, *collection, clientId, shard,
                             leader, lastTick, builder);
       if (!tickResult.ok()) {
-        LOG_TOPIC("0a4d4", INFO, Logger::MAINTENANCE) << syncRes.errorMessage();
+        LOG_TOPIC("0a4d4", INFO, Logger::MAINTENANCE) << tickResult.errorMessage();
         _result.reset(std::move(tickResult).result());
         return false;
       }

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -3488,28 +3488,36 @@ Result RestReplicationHandler::createBlockingTransaction(
 
   std::string vn = _vocbase.name();
   try {
-    std::function<void(void)> f = [=]() {
-      try {
-        // Code does not matter, read only access, so we can roll back.
-        transaction::Manager* mgr = transaction::ManagerFeature::manager();
-        if (mgr) {
-          mgr->abortManagedTrx(id, vn);
-        }
-      } catch (...) {
-        // All errors that show up here can only be
-        // triggered if the query is destroyed in between.
-      }
-    };
-
-    std::string comment = std::string("SynchronizeShard from ") + serverId +
-                          " for " + col.name() + " access mode " +
-                          AccessMode::typeString(access);
-    
     if (!serverId.empty()) {
+      std::string comment = std::string("SynchronizeShard from ") + serverId +
+                            " for " + col.name() + " access mode " +
+                            AccessMode::typeString(access);
+    
+      std::function<void(void)> f = [=]() {
+        try {
+          // Code does not matter, read only access, so we can roll back.
+          transaction::Manager* mgr = transaction::ManagerFeature::manager();
+          if (mgr) {
+            mgr->abortManagedTrx(id, vn);
+          }
+        } catch (...) {
+          // All errors that show up here can only be
+          // triggered if the query is destroyed in between.
+        }
+      };
+    
       auto rGuard = std::make_unique<RebootCookie>(
         ci.rebootTracker().callMeOnChange(RebootTracker::PeerState(serverId, rebootId),
-                                          f, comment));
-      transaction::Methods trx{mgr->leaseManagedTrx(id, AccessMode::Type::WRITE)};
+                                          std::move(f), std::move(comment)));
+      auto ctx = mgr->leaseManagedTrx(id, AccessMode::Type::WRITE);
+    
+      if (!ctx) {
+        // Trx does not exist. So we assume it got cancelled.
+        return {TRI_ERROR_TRANSACTION_INTERNAL, "read transaction was cancelled"};
+      }
+
+      transaction::Methods trx{ctx};
+
       void* key = this; // simon: not important to get it again
       trx.state()->cookie(key, std::move(rGuard));
     }

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -493,6 +493,10 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(TransactionId tid
   if (_disallowInserts.load(std::memory_order_acquire)) {
     return nullptr;
   }
+      
+  TRI_IF_FAILURE("leaseManagedTrxFail") {
+    return nullptr;
+  }
   
   auto const role = ServerState::instance()->getRole();
   std::chrono::steady_clock::time_point endTime;

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -300,7 +300,13 @@ transaction::Methods::Methods(std::shared_ptr<transaction::Context> const& trans
     : _state(nullptr),
       _transactionContext(transactionContext),
       _mainTransaction(false) {
+
   TRI_ASSERT(transactionContext != nullptr);
+  if (ADB_UNLIKELY(transactionContext == nullptr)) {
+    // in production, we must not go on with undefined behavior, so we bail out
+    // here with an exception as last resort
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "invalid transaction context pointer");
+  }
 
   // initialize the transaction
   _state = _transactionContext->acquireState(options, _mainTransaction);


### PR DESCRIPTION
### Scope & Purpose

Fixed very spurious errors if the `holdReadLockCollection` replication API for the getting-in-sync procedure of shards was called during server shutdown. In this case that method could ask the transaction manager for a specific transaction, but wasn't return one due to the server shutddown. 

A new failure point has been added to make the transaction manager always return a nullptr, so the problematic behavior can be reproduced. A test was added to set the failure point and trigger the issue.
Test invcation: `scripts/unittest shell_client --cluster true --test tests/js/client/shell/test-collection-counts-cluster.js`

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] Backports required for: 3.7: https://github.com/arangodb/arangodb/pull/12934 - older versions are not affected.

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (i.e. in shell_client)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12535/