### PR TITLE
fix spurious error when accessing a nullptr transaction context

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.7.5 (XXXX-XX-XX)
 -------------------
 
+* Fixed very spurious errors if the `holdReadLockCollection` replication API for
+  the getting-in-sync procedure of shards was called during server shutdown.
+  In this case that method could ask the transaction manager for a specific
+  transaction, but wasn't return one due to the server shutddown. 
+
 * Bug-fix: Creating an additional index on the edge collection of a disjoint
   SmartGraph could falsely result in an error: 
   `Could not find all smart collections ...`

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -975,7 +975,7 @@ bool SynchronizeShard::first() {
         catchupWithReadLock(ep, database, *collection, clientId, shard,
                             leader, lastTick, builder);
       if (!tickResult.ok()) {
-        LOG_TOPIC("0a4d4", INFO, Logger::MAINTENANCE) << syncRes.errorMessage();
+        LOG_TOPIC("0a4d4", INFO, Logger::MAINTENANCE) << tickResult.errorMessage();
         _result.reset(std::move(tickResult).result());
         return false;
       }

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -440,6 +440,10 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(TRI_voc_tid_t tid
   if (_disallowInserts.load(std::memory_order_acquire)) {
     return nullptr;
   }
+
+  TRI_IF_FAILURE("leaseManagedTrxFail") {
+    return nullptr;
+  }
   
   auto const role = ServerState::instance()->getRole();
   std::chrono::steady_clock::time_point endTime;

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -301,6 +301,11 @@ transaction::Methods::Methods(std::shared_ptr<transaction::Context> const& trans
       _transactionContext(transactionContext),
       _mainTransaction(false) {
   TRI_ASSERT(transactionContext != nullptr);
+  if (ADB_UNLIKELY(transactionContext == nullptr)) {
+    // in production, we must not go on with undefined behavior, so we bail out
+    // here with an exception as last resort
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "invalid transaction context pointer");
+  }
 
   // initialize the transaction
   _state = _transactionContext->acquireState(options, _mainTransaction);

--- a/tests/js/client/shell/shell-collection-counts-cluster.js
+++ b/tests/js/client/shell/shell-collection-counts-cluster.js
@@ -74,6 +74,68 @@ function collectionCountsSuite () {
       db._drop(cn);
     },
 
+    testFailureOnLeaderNoManagedTrx : function () {
+      let c = db._create(cn, { numberOfShards: 1, replicationFactor: 1 }); 
+      for (let i = 0; i < 200; ++i) {
+        c.insert({ _key: "test" + i }); 
+      }
+      assertEqual(200, c.count());
+      assertEqual(200, c.toArray().length);
+
+      let servers = getDBServers();
+      let shardInfo = c.shards(true);
+      let shard = Object.keys(shardInfo)[0];
+      let leader = shardInfo[shard][0];
+      let leaderUrl = servers.filter((server) => server.id === leader)[0].url;
+
+      // break leaseManagedTrx on the leader, so it will return a nullptr
+      let result = request({ method: "PUT", url: leaderUrl + "/_admin/debug/failat/leaseManagedTrxFail", body: {} });
+      assertEqual(200, result.status);
+
+      // add a follower. this will kick off the getting-in-sync protocol,
+      // which will eventually call the holdReadLockCollection API, which then
+      // will call leaseManagedTrx and get the nullptr back
+      c.properties({ replicationFactor: 2 });
+
+      // wait until we have an in-sync follower
+      let tries = 0;
+      while (tries++ < 120) {
+        shardInfo = c.shards(true);
+        servers = shardInfo[shard];
+        if (tries > 20) {
+          if (servers.length === 2 && c.count() === 200) {
+            break;
+          }
+        } else if (tries === 20) {
+          // wait several seconds so we can be sure the
+          clearFailurePoints();
+        }
+        require("internal").sleep(0.5);
+      }
+      assertEqual(2, servers.length);
+      assertEqual(200, c.count());
+      assertEqual(200, c.toArray().length);
+
+      tries = 0;
+      let total;
+      while (tries++ < 120) {
+        total = 0;
+        getDBServers().forEach((server) => {
+          if (servers.indexOf(server.id) === -1) {
+            return;
+          }
+          let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
+          assertEqual(200, result.status);
+          total += result.json.count;
+        });
+        if (total === 2 * 200) {
+          break;
+        }
+        require("internal").sleep(0.5);
+      }
+      assertEqual(2 * 200, total);
+    },
+
     testWrongCountOnLeaderFullSync : function () {
       let c = db._create(cn, { numberOfShards: 1, replicationFactor: 1 }); 
       for (let i = 0; i < 100; ++i) {


### PR DESCRIPTION
### Scope & Purpose

Fixed very spurious errors if the `holdReadLockCollection` replication API for the getting-in-sync procedure of shards was called during server shutdown. In this case that method could ask the transaction manager for a specific transaction, but wasn't return one due to the server shutddown. 

A new failure point has been added to make the transaction manager always return a nullptr, so the problematic behavior can be reproduced. A test was added to set the failure point and trigger the issue.
Test invcation: `scripts/unittest shell_client --cluster true --test tests/js/client/shell/test-collection-counts-cluster.js`

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (i.e. in shell_client)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12537/