### PR TITLE
3.6 AQL setup now abort if no shards are found

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.6.9 (XXXX-XX-XX)
 -------------------
 
+* If a collection (or database) is dropped during the instantiation of an AQL query,
+  the setup code now aborts with an ERROR_QUERY_COLLECTION_LOCK_FAILED and earlier.
+  Before the setup code could abort with TRI_ERROR_INTERNAL in the same case.
+
 * Bug-fix: Allow to unlink a view created on a SmartGraphEdge collection.
 
 * Fixed an ownership issue which could lead to undefined behavior in case an AQL

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,9 @@
 v3.6.9 (XXXX-XX-XX)
 -------------------
 
-* If a collection (or database) is dropped during the instantiation of an AQL query,
-  the setup code now aborts with an ERROR_QUERY_COLLECTION_LOCK_FAILED and earlier.
+* If a collection (or database) is dropped during the instantiation of an AQL
+  query, the setup code now aborts with an ERROR_QUERY_COLLECTION_LOCK_FAILED
+  and earlier.
   Before the setup code could abort with TRI_ERROR_INTERNAL in the same case.
 
 * Bug-fix: Allow to unlink a view created on a SmartGraphEdge collection.

--- a/arangod/Aql/ShardLocking.cpp
+++ b/arangod/Aql/ShardLocking.cpp
@@ -146,11 +146,14 @@ void ShardLocking::updateLocking(Collection const* col,
     auto const shards = col->shardIds(_query->queryOptions().shardIds);
     // What if we have an empty shard list here?
     if (shards->empty()) {
-      LOG_TOPIC("0997e", WARN, arangodb::Logger::AQL)
-          << "TEMPORARY: A collection access of a query has no result in any "
-             "shard";
-      TRI_ASSERT(false);
-      return;
+      auto const& name = col->name();
+      if (!TRI_vocbase_t::IsSystemName(name)) {
+        LOG_TOPIC("0997e", WARN, arangodb::Logger::AQL)
+          << "Accessing collection: " << name << " does not translate to any shard. Aborting query."; 
+      }
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_QUERY_COLLECTION_LOCK_FAILED,
+          "Could not identify any shard belonging to collection: " + name + ". Maybe it is dropped?");
     }
     for (auto const& s : *shards) {
       info.allShards.emplace(s);

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -4231,6 +4231,10 @@ std::shared_ptr<std::vector<ShardID>> ClusterInfo::getShardList(CollectionID con
   }
 
   int tries = 0;
+  TRI_IF_FAILURE("ClusterInfo::failedToGetShardList") {
+    // Simulate 3 failed tries below.
+    return std::make_shared<std::vector<ShardID>>();
+  }
   while (true) {
     {
       // Get the sharding keys and the number of shards:

--- a/tests/js/server/aql/aql-failures-cluster.js
+++ b/tests/js/server/aql/aql-failures-cluster.js
@@ -33,6 +33,9 @@ var arangodb = require("@arangodb");
 var db = arangodb.db;
 var internal = require("internal");
 
+const {ERROR_QUERY_COLLECTION_LOCK_FAILED} = internal.errors;
+
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test suite
 ////////////////////////////////////////////////////////////////////////////////
@@ -55,7 +58,6 @@ function ahuacatlFailureSuite () {
   };
         
   return {
-
     setUpAll: function () {
       internal.debugClearFailAt();
       db._drop(cn);
@@ -74,50 +76,88 @@ function ahuacatlFailureSuite () {
       db._drop(en);
     },
 
-    tearDown: function() {
+    tearDown: function () {
       internal.debugClearFailAt();
     },
 
-    testQueryRegistryInsert1 : function () {
+    testQueryRegistryInsert1: function () {
       internal.debugSetFailAt("QueryRegistryInsertException1");
       // we need a diamond-query to trigger an insertion into the q-registry
-      assertFailingQuery("FOR doc1 IN " + cn + " FOR doc2 IN " + cn + " FILTER doc1._key != doc2._key RETURN 1", internal.errors.ERROR_CLUSTER_AQL_COMMUNICATION);
+      assertFailingQuery(
+        "FOR doc1 IN " +
+          cn +
+          " FOR doc2 IN " +
+          cn +
+          " FILTER doc1._key != doc2._key RETURN 1",
+        internal.errors.ERROR_CLUSTER_AQL_COMMUNICATION
+      );
     },
-    
-    testQueryRegistryInsert2 : function () {
+
+    testQueryRegistryInsert2: function () {
       internal.debugSetFailAt("QueryRegistryInsertException2");
       // we need a diamond-query to trigger an insertion into the q-registry
-      assertFailingQuery("FOR doc1 IN " + cn + " FOR doc2 IN " + cn + " FILTER doc1._key != doc2._key RETURN 1", internal.errors.ERROR_CLUSTER_AQL_COMMUNICATION);
+      assertFailingQuery(
+        "FOR doc1 IN " +
+          cn +
+          " FOR doc2 IN " +
+          cn +
+          " FILTER doc1._key != doc2._key RETURN 1",
+        internal.errors.ERROR_CLUSTER_AQL_COMMUNICATION
+      );
     },
-    
-    testShutdownSync : function () {
+
+    testShutdownSync: function () {
       internal.debugSetFailAt("ExecutionEngine::shutdownSync");
 
       let res = AQL_EXECUTE("FOR doc IN " + cn + " RETURN doc").json;
       // no real test expectations here, just that the query works and doesn't fail on shutdown
       assertEqual(0, res.length);
     },
-    
-    testShutdownSyncDiamond : function () {
+
+    testShutdownSyncDiamond: function () {
       internal.debugSetFailAt("ExecutionEngine::shutdownSync");
 
-      let res = AQL_EXECUTE("FOR doc1 IN " + cn + " FOR doc2 IN " + en + " FILTER doc1._key == doc2._key RETURN doc1").json;
+      let res = AQL_EXECUTE(
+        "FOR doc1 IN " +
+          cn +
+          " FOR doc2 IN " +
+          en +
+          " FILTER doc1._key == doc2._key RETURN doc1"
+      ).json;
       // no real test expectations here, just that the query works and doesn't fail on shutdown
       assertEqual(0, res.length);
     },
-    
-    testShutdownSyncFailInGetSome : function () {
+
+    testShutdownSyncFailInGetSome: function () {
       internal.debugSetFailAt("ExecutionEngine::shutdownSync");
       internal.debugSetFailAt("RestAqlHandler::getSome");
 
       assertFailingQuery("FOR doc IN " + cn + " RETURN doc");
     },
 
-    testShutdownSyncDiamondFailInGetSome : function () {
+    testShutdownSyncDiamondFailInGetSome: function () {
       internal.debugSetFailAt("ExecutionEngine::shutdownSync");
       internal.debugSetFailAt("RestAqlHandler::getSome");
 
-      assertFailingQuery("FOR doc1 IN " + cn + " FOR doc2 IN " + en + " FILTER doc1._key == doc2._key RETURN doc1");
+      assertFailingQuery(
+        "FOR doc1 IN " +
+          cn +
+          " FOR doc2 IN " +
+          en +
+          " FILTER doc1._key == doc2._key RETURN doc1"
+      );
+    },
+
+    testNoShardsReturned: function () {
+      internal.debugSetFailAt("ClusterInfo::failedToGetShardList");
+      assertFailingQuery(
+        "FOR doc1 IN " +
+          cn +
+          " FOR doc2 IN " +
+          en +
+          " FILTER doc1._key == doc2._key RETURN doc1",
+        ERROR_QUERY_COLLECTION_LOCK_FAILED
+      );
     },
   };
 }


### PR DESCRIPTION
Backport of: https://github.com/arangodb/arangodb/pull/12911/
No issues on cherry-pick

### Scope & Purpose

We now directly abort if we failed to translate Collection => Shard in AQL setup.
This situation can happen if the collection or database is dropped.
Before we still would return an error and leave no harm, this situation is now just a bit cleaner.

- [ ] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [x] Backports required for: 
  - [x] devel
  - [x] 3.7

#### Related Information

*(Please reference tickets / specification etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-158.
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added **Regression Tests**
  - [ ] Added new C++ **Unit Tests**
  - [ ] Added new **integration tests** (i.e. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)

Additionally:

- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Jenkins: http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/12574/

### Documentation

> All new Features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the changelog so that
> developers and users have a concise overview. 

- [x] Added a *Changelog Entry* (referencing the corresponding public or internal issue number)
- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
