### PR TITLE
fix json forcing; add test

### DIFF
--- a/arangosh/Shell/V8ClientConnection.cpp
+++ b/arangosh/Shell/V8ClientConnection.cpp
@@ -1748,6 +1748,9 @@ again:
       req->header.acceptType(fu::ContentType::VPack);
     }
   }
+  else if (_forceJson && (req->header.acceptType() == fu::ContentType::VPack)) {
+    req->header.acceptType(fu::ContentType::Json);
+  }
   req->timeout(
       correctTimeoutToExecutionDeadline(
         std::chrono::duration_cast<std::chrono::milliseconds>(_requestTimeout)));
@@ -1827,6 +1830,10 @@ again:
   if (req->header.acceptType() == fu::ContentType::Unset) {
     req->header.acceptType(fu::ContentType::VPack);
   }
+  if (_forceJson && (req->header.acceptType() == fu::ContentType::VPack)) {
+    req->header.acceptType(fu::ContentType::Json);
+  }
+
   req->timeout(
       correctTimeoutToExecutionDeadline(
         std::chrono::duration_cast<std::chrono::milliseconds>(_requestTimeout)));

--- a/js/client/modules/@arangodb/testsuites/endpoints.js
+++ b/js/client/modules/@arangodb/testsuites/endpoints.js
@@ -62,6 +62,7 @@ function endpoints (options) {
   const keyFile = fs.join(tu.pathForTesting('.'), '..', '..', 'UnitTests', 'server.pem');
   let endpoints = {
     ssl: {
+      skip: function () { return options.skipEndpointsSSL; },
       serverArgs: function () {
         return {
           'server.endpoint': 'ssl://127.0.0.1:' + pu.findFreePort(options.minPort, options.maxPort),
@@ -72,55 +73,71 @@ function endpoints (options) {
         {
           name: 'tcp',
           endpoint: function (endpoint) { return endpoint; },
-          success: true
+          success: true,
+          forceJson: false
         },
         { 
           name: 'any',
           endpoint: function (endpoint) { return endpoint.replace(/^ssl:\/\/.*:/, 'ssl://0.0.0.0:'); },
-          success: false
+          success: false,
+          forceJson: false
         },
         { 
           name: 'vst',
           endpoint: function (endpoint) { return endpoint.replace(/^ssl:\/\//, 'vst+ssl://'); },
-          success: true
+          success: true,
+          forceJson: false
         },
         { 
           name: 'h2',
           endpoint: function (endpoint) { return endpoint.replace(/^tcp:\/\//, 'h2+ssl://'); },
-          success: true
+          success: true,
+          forceJson: false
         },
         { 
           name: 'non-ssl',
           endpoint: function (endpoint) { return endpoint.replace(/^ssl:\/\//, 'tcp://'); },
-          success: false
+          success: false,
+          forceJson: false
         },
       ],
     },
 
     tcpv4: {
+      skip: function () { return options.skipEndpointsIpv4; },
       serverArgs: function () {
         return 'tcp://127.0.0.1:' + pu.findFreePort(options.minPort, options.maxPort);
       },
       shellTests: [
         {
+          name: 'tcp-json',
+          endpoint: function (endpoint) { return endpoint; },
+          success: true,
+          forceJson: true
+        },
+        {
           name: 'tcp',
           endpoint: function (endpoint) { return endpoint; },
-          success: true
+          success: true,
+          forceJson: false
         },
         { 
           name: 'tcp-any',
           endpoint: function (endpoint) { return endpoint.replace(/^tcp:\/\/.*:/, 'tcp://0.0.0.0:'); },
-          success: false
+          success: false,
+          forceJson: false
         },
         { 
           name: 'vst',
           endpoint: function (endpoint) { return endpoint.replace(/^tcp:\/\//, 'vst://'); },
-          success: true
+          success: true,
+          forceJson: false
         },
         { 
           name: 'h2',
           endpoint: function (endpoint) { return endpoint.replace(/^tcp:\/\//, 'h2://'); },
-          success: true
+          success: true,
+          forceJson: false
         },
         {
           name: 'ssl',
@@ -137,29 +154,40 @@ function endpoints (options) {
       },
       shellTests: [
         {
+          name: 'tcp-json',
+          endpoint: function (endpoint) { return endpoint; },
+          success: true,
+          forceJson: false
+        },
+        {
           name: 'tcp',
           endpoint: function (endpoint) { return endpoint; },
-          success: true
+          success: true,
+          forceJson: false
         },
         { 
           name: 'tcp-any',
           endpoint: function (endpoint) { return endpoint.replace(/^tcp:\/\/\[::1\]:/, 'tcp://[::]:'); },
-          success: false
+          success: false,
+          forceJson: false
         },
         { 
           name: 'vst',
           endpoint: function (endpoint) { return endpoint.replace(/^tcp:\/\//, 'vst://'); },
-          success: true
+          success: true,
+          forceJson: false
         },
         { 
           name: 'h2',
           endpoint: function (endpoint) { return endpoint.replace(/^tcp:\/\//, 'h2://'); },
-          success: true
+          success: true,
+          forceJson: false
         },
         {
           name: 'ssl',
           endpoint: function (endpoint) { return endpoint.replace(/^tcp:\/\//, 'ssl://'); },
-          success: false
+          success: false,
+          forceJson: false
         },
       ],
     },
@@ -208,22 +236,33 @@ function endpoints (options) {
     }
 
     const specFile = testPaths.endpoints[0];
-    
+    let filtered = {};
+
     testCase.shellTests.forEach(function(testCase) {
-      let old = instanceInfo.endpoint;
-      let shellEndpoint = testCase.endpoint(serverArgs['server.endpoint']);
-      instanceInfo.endpoint = shellEndpoint;
-      try {
-        let result = tu.runInArangosh(options, instanceInfo, specFile, { 'server.connection-timeout': 2, 'server.request-timeout': 2 });
-        let success = result.status === testCase.success;
-        results[endpointName + '-' + testCase.name] = { status: success }; 
-        if (!success) {
-          // arangosh or the test returned an error
-          results[endpointName + '-' + testCase.name].message = result.message;
-          results.failed += 1;
+      if (tu.filterTestcaseByOptions(testCase.name, options, filtered)) {
+        let old = instanceInfo.endpoint;
+        let shellEndpoint = testCase.endpoint(serverArgs['server.endpoint']);
+        instanceInfo.endpoint = shellEndpoint;
+        try {
+          let arangoshOpts = { 'server.connection-timeout': 2, 'server.request-timeout': 2 };
+          if (testCase.forceJson) {
+            arangoshOpts['server.force-json'] = true;
+          }
+          let result = tu.runInArangosh(options, instanceInfo, specFile, arangoshOpts);
+          let success = result.status === testCase.success;
+          results[endpointName + '-' + testCase.name] = { status: success }; 
+          if (!success) {
+            // arangosh or the test returned an error
+            results[endpointName + '-' + testCase.name].message = result.message;
+            results.failed += 1;
+          }
+        } finally {
+          instanceInfo.endpoint = old;
         }
-      } finally {
-        instanceInfo.endpoint = old;
+      } else {
+        if (options.extremeVerbosity) {
+          print('Skipped ' + testCase.name + ' because of ' + filtered.filter);
+        }
       }
     });
 
@@ -248,6 +287,8 @@ exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTest
 
   opts['skipEndpoints'] = false;
   opts['skipEndpointsIpv6'] = false;
+  opts['skipEndpointsIpv4'] = false;
+  opts['skipEndpointsSSL'] = false;
   opts['skipEndpointsUnix'] = (platform.substr(0, 3) === 'win');
 
   defaultFns.push('endpoints');

--- a/tests/js/client/endpoint-spec.js
+++ b/tests/js/client/endpoint-spec.js
@@ -34,4 +34,10 @@ describe('Endpoint Connection test', function() {
   it('should be able to connect', function() {
     expect(db._version()).to.not.be.undefined;    
   });
+  if (require('internal').options()['server.force-json']) {
+    it('should have plain json documents', function() {
+      let req = arango.GET_RAW('/_api/version');
+      expect(req.headers['content-type']).not.to.equal('application/x-velocypack');
+    });
+  }
 });

--- a/tests/js/client/endpoint-spec.js
+++ b/tests/js/client/endpoint-spec.js
@@ -1,4 +1,4 @@
-/* global db, describe, it, beforeEach, afterEach*/
+/* global db, describe, it, beforeEach, afterEach, arango */
 'use strict';
 
 // //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose
The debugging option `--server.force-json` should downgrade the arangosh connection and its requests to lean on JSON being used for the sake of sniffeability. 
Its here to aid development.

- [x] :hankey: Bugfix of development feature

#### Backports:

- [x] No backports required

### Testing & Verification

*(Please pick either of the following options)*

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested* by observing the traffic using ngrep
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [x] Added new **integration tests** in endpoints testuite
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
