### PR TITLE
Bug fix/fix gcc10 bogus compile warning

### DIFF
--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -560,7 +560,7 @@ auto AqlExecuteCall::fromVelocyPack(VPackSlice const slice) -> ResultT<AqlExecut
   auto expectedPropertiesFound = std::map<std::string_view, bool>{};
   expectedPropertiesFound.emplace(StaticStrings::AqlRemoteCallStack, false);
 
-  auto callStack = std::optional<AqlCallStack>{};
+  std::optional<AqlCallStack> callStack;
 
   for (auto const it : VPackObjectIterator(slice)) {
     auto const keySlice = it.key;

--- a/arangod/IResearch/GeoFilter.cpp
+++ b/arangod/IResearch/GeoFilter.cpp
@@ -429,13 +429,18 @@ irs::filter::prepared::ptr prepareOpenInterval(
     : std::forward_as_tuple(range.max, range.max_type);
 
   S2Cap bound;
-  bool incl;
+  // the actual initialization value does not matter. the proper
+  // value for incl will be set below. the initialization is here
+  // just to please the compiler, which may otherwise warn about
+  // uninitialized values
+  bool incl = false;
 
   if (dist < 0.) {
     bound = greater ? S2Cap::Full() : S2Cap::Empty();
   } else if (0. == dist) {
     switch (type) {
       case irs::BoundType::UNBOUNDED:
+        incl = false;
         TRI_ASSERT(false);
         break;
       case irs::BoundType::INCLUSIVE:


### PR DESCRIPTION
### Scope & Purpose

Fix two bogus compile warnings issued by g++-10.
In both cases, it warns about potentially uninitialized variables, but these are false positives.
This PR slightly changes the code to please the compiler.

Example warning message:
```
/home/jsteemann/ArangoNoAsan/arangod/IResearch/GeoFilter.cpp: In function ‘iresearch::filter::prepared::ptr {anonymous}::prepareOpenInterval(const iresearch::index_reader&, const iresearch::order::prepared&, iresearch::boost_t, const string_ref&, const arangodb::iresearch::GeoDistanceFilterOptions&, bool)’:
/home/jsteemann/ArangoNoAsan/arangod/IResearch/GeoFilter.cpp:512:3: warning: ‘incl’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  512 |   if (incl) {
      |   ^~
```

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12581/