### PR TITLE
attempt to make the debug info for `USE_MINIMAL_DEBUGINFO` even smaller

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -956,7 +956,7 @@ else () # NOT MSVC
   # flags for builds with debug symbols
   if (USE_MINIMAL_DEBUGINFO)
     # minimal debug symbols
-    set(DEBUGINFO_FLAGS "-g1 -feliminate-unused-debug-symbols")
+    set(DEBUGINFO_FLAGS "-g1 -gno-column-info -gz -feliminate-unused-debug-symbols")
   else ()
     # full debug symbols
     set(DEBUGINFO_FLAGS "-g")


### PR DESCRIPTION
### Scope & Purpose

Attempt to reduce the size of the debug information packaged when using `USE_MINIMAL_DEBUGINFO`.
This should reduce the size of the debug info in the executable, by removing column info from source locations, and by gzipping debug info.

In my local RelWithDebInfo devel build, this change reduces the size of the arangod executable from 320MB to 150MB when it contains debug symbols.

Filesize comparison for bin/arangod, with and without this PR:

**Without this PR**:
```
    FILE SIZE        VM SIZE    
 --------------  -------------- 
  26.1%  87.4Mi   0.0%       0    .debug_info
  18.6%  62.2Mi   0.0%       0    .debug_str
  18.1%  60.7Mi  68.1%  60.7Mi    .text
  16.9%  56.7Mi   0.0%       0    .debug_ranges
   9.8%  32.8Mi   0.0%       0    .debug_line
   0.0%       0  16.1%  14.3Mi    .bss
   3.8%  12.7Mi   0.0%       0    .strtab
   1.4%  4.65Mi   5.2%  4.65Mi    .eh_frame
   1.2%  4.06Mi   4.6%  4.06Mi    .rodata
   1.1%  3.62Mi   0.0%       0    .symtab
   0.7%  2.28Mi   0.0%       0    .debug_loc
   0.6%  1.90Mi   2.1%  1.90Mi    .rela.dyn
   0.4%  1.37Mi   1.5%  1.37Mi    .gcc_except_table
   0.4%  1.28Mi   0.0%       0    .debug_abbrev
   0.3%  1.05Mi   0.0%       0    .debug_aranges
   0.3%   996Ki   1.1%   996Ki    .data.rel.ro
   0.2%   841Ki   0.9%   841Ki    .eh_frame_hdr
   0.0%   143Ki   0.2%   143Ki    .data
   0.0%   142Ki   0.0%       0    .debug_macro
   0.0%  99.0Ki   0.1%  92.0Ki    [26 Others]
   0.0%  33.0Ki   0.0%  32.9Ki    .dynstr
 100.0%   334Mi 100.0%  89.1Mi    TOTAL
```

**With this PR**:
```
    FILE SIZE        VM SIZE    
 --------------  -------------- 
  40.8%  60.7Mi  68.1%  60.7Mi    .text
  22.8%  33.8Mi   0.0%       0    .debug_info
   0.0%       0  16.1%  14.3Mi    .bss
   8.5%  12.7Mi   0.0%       0    .strtab
   7.1%  10.5Mi   0.0%       0    .debug_line
   4.5%  6.74Mi   0.0%       0    .debug_ranges
   3.9%  5.73Mi   0.0%       0    .debug_str
   3.1%  4.65Mi   5.2%  4.65Mi    .eh_frame
   2.7%  4.06Mi   4.6%  4.06Mi    .rodata
   2.4%  3.62Mi   0.0%       0    .symtab
   1.3%  1.90Mi   2.1%  1.90Mi    .rela.dyn
   0.9%  1.37Mi   1.5%  1.37Mi    .gcc_except_table
   0.7%   996Ki   1.1%   996Ki    .data.rel.ro
   0.6%   841Ki   0.9%   841Ki    .eh_frame_hdr
   0.2%   352Ki   0.0%       0    .debug_loc
   0.1%   184Ki   0.0%       0    .debug_aranges
   0.1%   170Ki   0.0%       0    .debug_abbrev
   0.1%   143Ki   0.2%   143Ki    .data
   0.1%  99.0Ki   0.1%  92.0Ki    [26 Others]
   0.0%  61.3Ki   0.0%       0    .debug_macro
   0.0%  33.0Ki   0.0%  32.9Ki    .dynstr
 100.0%   148Mi 100.0%  89.1Mi    TOTAL
```

The `USE_MINIMAL_DEBUGINFO` option was added only recently to devel only, so there is no need to backport this PR.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12583/