### PR TITLE
fix a potential deadlock in cluster transaction code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 devel
 -----
+
+* Fixed potential deadlock in cluster transactions if a transaction is
+  returned that was soft-aborted by transaction garbage collection before.
+  This deadlock should rarely ever occur in practice, as it can only be 
+  triggered once during the server shutdown sequence.
+
 * Fixed BTS-233 issue: Fixed invalid IndexId comparator.
 
 * Fixed handling of failedLeaderJob. In case of a plan modification, that

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -617,8 +617,12 @@ void Manager::returnManagedTrx(TransactionId tid) noexcept {
     
     it->second.rwlock.unlock();
   }
+  
+  TRI_IF_FAILURE("returnManagedTrxForceSoftAbort") {
+    isSoftAborted = true;
+  }
 
-  // it is imporant that we release the write lock for the bucket here,
+  // it is important that we release the write lock for the bucket here,
   // because abortManagedTrx will call statusChangeWithTimeout, which will
   // call updateTransaction, which then will try to acquire the same 
   // write lock

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -618,14 +618,14 @@ void Manager::returnManagedTrx(TransactionId tid) noexcept {
     it->second.rwlock.unlock();
   }
   
-  TRI_IF_FAILURE("returnManagedTrxForceSoftAbort") {
-    isSoftAborted = true;
-  }
-
   // it is important that we release the write lock for the bucket here,
   // because abortManagedTrx will call statusChangeWithTimeout, which will
   // call updateTransaction, which then will try to acquire the same 
   // write lock
+  
+  TRI_IF_FAILURE("returnManagedTrxForceSoftAbort") {
+    isSoftAborted = true;
+  }
 
   if (isSoftAborted) {
     abortManagedTrx(tid, "" /* any database */);

--- a/tests/js/client/shell/shell-transaction-intermediate-commit-cluster.js
+++ b/tests/js/client/shell/shell-transaction-intermediate-commit-cluster.js
@@ -316,7 +316,7 @@ function transactionIntermediateCommitsSingleSuite() {
     // make follower execute intermediate commits (before the leader), and let the
     // transaction fail
     testSingleStreamingIntermediateCommitsOnFollowerWithRollback: function () {
-      db._create(cn, { numberOfShards: 1, replicationFactor: 2 });
+      let c = db._create(cn, { numberOfShards: 1, replicationFactor: 2 });
       let shards = db._collection(cn).shards(true);
       let shardId = Object.keys(shards)[0];
       let leader = getEndpointById(shards[shardId][0]);
@@ -339,9 +339,17 @@ function transactionIntermediateCommitsSingleSuite() {
       
       const trx = db._createTransaction(opts);
       const tc = trx.collection(cn);
-      for (let i = 0; i < 9999; ++i) {
-        tc.insert({ _key: "test" + i });
+      let docs = [];
+      for (let i = 0; i < 9950; ++i) {
+        docs.push({ _key: "test" + i });
+        if (docs.length === 50) {
+          tc.insert(docs);
+          docs = [];
+        }
       }
+
+      assertEqual(0, c.count());
+      assertEqual(9950, tc.count());
       trx.abort();
       
       // follower must have been dropped
@@ -351,6 +359,7 @@ function transactionIntermediateCommitsSingleSuite() {
       let intermediateCommitsAfter = getMetric(follower, "arangodb_intermediate_commits");
       assertEqual(intermediateCommitsBefore + 9, intermediateCommitsAfter);
       
+      assertEqual(0, c.count());
       assertInSync(leader, follower, shardId);
     },
     
@@ -483,6 +492,138 @@ function transactionIntermediateCommitsMultiSuite() {
       assertInSync(leader2, follower2, shardId2);
     },
     
+    // make two leaders write to the same follower, using exclusive locks and
+    // intermediate commits
+    testMultiAqlIntermediateCommitsOnFollowerExclusive: function () {
+      db._create(cn + "1", { numberOfShards: 1, replicationFactor: 2 });
+      let shards1 = db._collection(cn + "1").shards(true);
+      let shardId1 = Object.keys(shards1)[0];
+      let leader1 = getEndpointById(shards1[shardId1][0]);
+      let follower1 = getEndpointById(shards1[shardId1][1]);
+
+      let shards2, shardId2, leader2, follower2;
+
+      let tries = 0;
+      // try to set up 2 collections with different leaders but the same follower
+      // DB server
+      while (tries++ < 250) {
+        db._create(cn + "2", { numberOfShards: 1, replicationFactor: 2 });
+      
+        shards2 = db._collection(cn + "2").shards(true);
+        shardId2 = Object.keys(shards2)[0];
+        leader2 = getEndpointById(shards2[shardId2][0]);
+        follower2 = getEndpointById(shards2[shardId2][1]);
+
+        if (leader1 !== leader2 && follower1 === follower2) {
+          break;
+        }
+
+        db._drop(cn + "2");
+      }
+      assertNotEqual(leader1, leader2);
+      assertEqual(follower1, follower2);
+      
+      // disable intermediate commits on leaders
+      debugSetFailAt(leader1, "noIntermediateCommits");
+      debugSetFailAt(leader2, "noIntermediateCommits");
+      // turn on intermediate commits on follower
+      debugClearFailAt(follower1, "noIntermediateCommits");
+
+      let droppedFollowersBefore1 = getMetric(leader1, "arangodb_dropped_followers_count");
+      let droppedFollowersBefore2 = getMetric(leader2, "arangodb_dropped_followers_count");
+      db._query('FOR i IN 1..10000 INSERT { _key: CONCAT("test", i) } IN ' + cn + '1 OPTIONS { exclusive: true } INSERT { _key: CONCAT("test", i) } IN ' + cn + '2 OPTIONS { exclusive: true }', {}, {intermediateCommitCount: 1000});
+      
+      // follower must not have been dropped
+      let droppedFollowersAfter1 = getMetric(leader1, "arangodb_dropped_followers_count");
+      let droppedFollowersAfter2 = getMetric(leader2, "arangodb_dropped_followers_count");
+      assertEqual(droppedFollowersBefore1, droppedFollowersAfter1);
+      assertEqual(droppedFollowersBefore2, droppedFollowersAfter2);
+    
+      assertInSync(leader1, follower1, shardId1);
+      assertInSync(leader2, follower2, shardId2);
+    },
+    
+    // make two leaders write to the same follower, using exclusive locks and
+    // intermediate commits
+    testMultiStreamingIntermediateCommitsOnFollowerExclusive: function () {
+      let c1 = db._create(cn + "1", { numberOfShards: 1, replicationFactor: 2 });
+      let shards1 = db._collection(cn + "1").shards(true);
+      let shardId1 = Object.keys(shards1)[0];
+      let leader1 = getEndpointById(shards1[shardId1][0]);
+      let follower1 = getEndpointById(shards1[shardId1][1]);
+
+      let shards2, shardId2, leader2, follower2;
+
+      let tries = 0;
+      // try to set up 2 collections with different leaders but the same follower
+      // DB server
+      let c2;
+      while (tries++ < 250) {
+        c2 = db._create(cn + "2", { numberOfShards: 1, replicationFactor: 2 });
+      
+        shards2 = db._collection(cn + "2").shards(true);
+        shardId2 = Object.keys(shards2)[0];
+        leader2 = getEndpointById(shards2[shardId2][0]);
+        follower2 = getEndpointById(shards2[shardId2][1]);
+
+        if (leader1 !== leader2 && follower1 === follower2) {
+          break;
+        }
+
+        db._drop(cn + "2");
+      }
+      assertNotEqual(leader1, leader2);
+      assertEqual(follower1, follower2);
+      
+      // disable intermediate commits on leaders
+      debugSetFailAt(leader1, "noIntermediateCommits");
+      debugSetFailAt(leader2, "noIntermediateCommits");
+      // turn on intermediate commits on follower
+      debugClearFailAt(follower1, "noIntermediateCommits");
+      
+      let droppedFollowersBefore1 = getMetric(leader1, "arangodb_dropped_followers_count");
+      let droppedFollowersBefore2 = getMetric(leader2, "arangodb_dropped_followers_count");
+      let intermediateCommitsBefore = getMetric(follower1, "arangodb_intermediate_commits");
+      
+      const opts = {
+        collections: {
+          write: [cn + "1", cn + "2" ]
+        },
+        intermediateCommitCount: 1000,
+        options: { intermediateCommitCount: 1000 }
+      };
+      
+      const trx = db._createTransaction(opts);
+      const tc1 = trx.collection(cn + "1");
+      const tc2 = trx.collection(cn + "2");
+      let docs = [];
+      for (let i = 0; i < 9950; ++i) {
+        docs.push({ _key: "test" + i });
+        if (docs.length === 50) {
+          tc1.insert(docs);
+          tc2.insert(docs);
+          docs = [];
+        }
+      }
+      assertEqual(9950, tc1.count());
+      assertEqual(9950, tc2.count());
+      assertEqual(0, c1.count());
+      assertEqual(0, c2.count());
+      trx.commit();
+      
+      assertEqual(9950, c1.count());
+      assertEqual(9950, c2.count());
+      
+      let droppedFollowersAfter1 = getMetric(leader1, "arangodb_dropped_followers_count");
+      let droppedFollowersAfter2 = getMetric(leader2, "arangodb_dropped_followers_count");
+      let intermediateCommitsAfter = getMetric(follower1, "arangodb_intermediate_commits");
+      assertEqual(droppedFollowersBefore1, droppedFollowersAfter1);
+      assertEqual(droppedFollowersBefore2, droppedFollowersAfter2);
+      assertEqual(intermediateCommitsBefore + Math.floor((9950 + 9950) / 1000), intermediateCommitsAfter);
+    
+      assertInSync(leader1, follower1, shardId1);
+      assertInSync(leader2, follower2, shardId2);
+    },
   };
 }
 


### PR DESCRIPTION
### Scope & Purpose

Fix a potential deadlock in cluster transaction code in `transactions::Manager::returnManagedTrx()`.
This method acquired the write-lock on the transactions bucket, and then can call into `abortManagedTrx` while the lock is still being held.
`abortManagedTrx` directly calls `statusChangeWithTimeout`, which itself unconditionally calls `updateTransaction`, which will also unconditionally try to acquire the same bucket lock. This would be a deadlock.
We have never seen this in practice, and according to the code it looks like it can only happening when `beginShutdown()` or `stop()` are called on the TransactionManagerFeature. If this deadlock ever happened, it should be pretty rare.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.7, 3.6, 3.5

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_client)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12588/