### PR TITLE
fix potential deadlock in cluster transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@ v3.5.7 (XXXX-XX-XX)
 
 * Fixed potential deadlock in cluster transactions if a transaction is
   returned that was soft-aborted by transaction garbage collection before.
+  This deadlock should rarely ever occur in practice, as it can only be 
+  triggered once during the server shutdown sequence.
 
 * Fixed issue #12248: Web UI - Added missing HTML escaping in the setup script
   section of a foxx app.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.5.7 (XXXX-XX-XX)
 -------------------
 
+* Fixed potential deadlock in cluster transactions if a transaction is
+  returned that was soft-aborted by transaction garbage collection before.
+
 * Fixed issue #12248: Web UI - Added missing HTML escaping in the setup script
   section of a foxx app.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,9 @@
 v3.5.7 (XXXX-XX-XX)
 -------------------
 
-* Fixed potential deadlock in cluster transactions if a transaction is
-  returned that was soft-aborted by transaction garbage collection before.
-  This deadlock should rarely ever occur in practice, as it can only be 
+* Fixed potential deadlock in cluster transactions if a transaction is returned
+  that was soft-aborted by transaction garbage collection before.
+  This deadlock should rarely ever occur in practice, as it can only be
   triggered once during the server shutdown sequence.
 
 * Fixed BTS-233 issue: Fixed invalid IndexId comparator.

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -570,7 +570,7 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(TRI_voc_tid_t tid
 }
 
 void Manager::returnManagedTrx(TRI_voc_tid_t tid, AccessMode::Type mode) noexcept {
-  bool isSoftAborted;
+  bool isSoftAborted = false;
 
   {
     const size_t bucket = getBucket(tid);
@@ -602,6 +602,15 @@ void Manager::returnManagedTrx(TRI_voc_tid_t tid, AccessMode::Type mode) noexcep
     } else {
       TRI_ASSERT(false);
     }
+  }
+
+  // it is important that we release the write lock for the bucket here,
+  // because abortManagedTrx will call statusChangeWithTimeout, which will
+  // call updateTransaction, which then will try to acquire the same 
+  // write lock
+  
+  TRI_IF_FAILURE("returnManagedTrxForceSoftAbort") {
+    isSoftAborted = true;
   }
 
   if (isSoftAborted) {

--- a/js/client/modules/@arangodb/test-utils.js
+++ b/js/client/modules/@arangodb/test-utils.js
@@ -830,6 +830,7 @@ function runInLocalArangosh (options, instanceInfo, file, addArgs) {
       'return runTest(' + JSON.stringify(file) + ', true' + mochaGrep + ');\n';
   }
 
+  require('internal').env.INSTANCEINFO = JSON.stringify(instanceInfo);
   let testFunc;
   eval('testFunc = function () { \nglobal.instanceInfo = ' + JSON.stringify(instanceInfo) + ';\n' + testCode + "}");
   

--- a/tests/js/client/shell/shell-transaction-intermediate-commit-cluster-rocksdb.js
+++ b/tests/js/client/shell/shell-transaction-intermediate-commit-cluster-rocksdb.js
@@ -1,0 +1,197 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global fail, assertEqual, assertNotEqual */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief ArangoTransaction sTests
+// /
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2018 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// //////////////////////////////////////////////////////////////////////////////
+
+let jsunity = require('jsunity');
+let internal = require('internal');
+let arangodb = require('@arangodb');
+let db = arangodb.db;
+let errors = arangodb.errors;
+const request = require('@arangodb/request');
+
+function getEndpointById(id) {
+  const toEndpoint = (d) => (d.endpoint);
+  const endpointToURL = (endpoint) => {
+    if (endpoint.substr(0, 6) === 'ssl://') {
+      return 'https://' + endpoint.substr(6);
+    }
+    let pos = endpoint.indexOf('://');
+    if (pos === -1) {
+      return 'http://' + endpoint;
+    }
+    return 'http' + endpoint.substr(pos);
+  };
+
+  const instanceInfo = JSON.parse(internal.env.INSTANCEINFO);
+  return instanceInfo.arangods.filter((d) => (d.id === id))
+                              .map(toEndpoint)
+                              .map(endpointToURL)[0];
+}
+
+function getEndpointsByType(type) {
+  const isType = (d) => (d.role.toLowerCase() === type);
+  const toEndpoint = (d) => (d.endpoint);
+  const endpointToURL = (endpoint) => {
+    if (endpoint.substr(0, 6) === 'ssl://') {
+      return 'https://' + endpoint.substr(6);
+    }
+    let pos = endpoint.indexOf('://');
+    if (pos === -1) {
+      return 'http://' + endpoint;
+    }
+    return 'http' + endpoint.substr(pos);
+  };
+
+  const instanceInfo = JSON.parse(internal.env.INSTANCEINFO);
+  return instanceInfo.arangods.filter(isType)
+                              .map(toEndpoint)
+                              .map(endpointToURL);
+}
+  
+/// @brief set failure point
+function debugCanUseFailAt(endpoint) {
+  let res = request.get({
+    url: endpoint + '/_admin/debug/failat',
+  });
+  return res.status === 200;
+}
+
+/// @brief set failure point
+function debugSetFailAt(endpoint, failAt) {
+  let res = request.put({
+    url: endpoint + '/_admin/debug/failat/' + failAt,
+    body: ""
+  });
+  if (res.status !== 200) {
+    throw "Error setting failure point";
+  }
+}
+
+/// @brief remove failure point
+function debugRemoveFailAt(endpoint, failAt) {
+  let res = request.delete({
+    url: endpoint + '/_admin/debug/failat/' + failAt,
+    body: ""
+  });
+  if (res.status !== 200) {
+    throw "Error removing failure point";
+  }
+}
+
+function debugClearFailAt(endpoint) {
+  let res = request.delete({
+    url: endpoint + '/_admin/debug/failat',
+    body: ""
+  });
+  if (res.status !== 200) {
+    throw "Error removing failure points";
+  }
+}
+
+function getChecksum(endpoint, name) {
+  let res = request.get({
+    url: endpoint + '/_api/collection/' + name + '/checksum',
+  });
+  return JSON.parse(res.body).checksum;
+}
+
+function assertInSync(leader, follower, shardId) {
+  const leaderChecksum = getChecksum(leader, shardId);
+  let followerChecksum;
+  let tries = 0;
+  while (++tries < 120) {
+    followerChecksum = getChecksum(follower, shardId);
+    if (followerChecksum === leaderChecksum) {
+      break;
+    }
+    internal.sleep(0.25);
+  }
+  assertEqual(leaderChecksum, followerChecksum);
+}
+
+function transactionIntermediateCommitsSingleSuite() {
+  'use strict';
+  const cn = 'UnitTestsTransaction';
+
+  return {
+
+    setUp: function () {
+      getEndpointsByType("dbserver").forEach((ep) => debugClearFailAt(ep));
+      db._drop(cn);
+    },
+
+    tearDown: function () {
+      getEndpointsByType("dbserver").forEach((ep) => debugClearFailAt(ep));
+      db._drop(cn);
+    },
+    
+    testSoftAbort: function () {
+      let c = db._create(cn, { numberOfShards: 1, replicationFactor: 2 });
+      let shards = db._collection(cn).shards(true);
+      let shardId = Object.keys(shards)[0];
+      let leader = getEndpointById(shards[shardId][0]);
+      let follower = getEndpointById(shards[shardId][1]);
+      debugSetFailAt(leader, "returnManagedTrxForceSoftAbort");
+      debugSetFailAt(follower, "returnManagedTrxForceSoftAbort");
+      
+      const opts = {
+        collections: {
+          write: [cn]
+        },
+        intermediateCommitCount: 1000,
+        options: { intermediateCommitCount: 1000 }
+      };
+      
+      const trx = db._createTransaction(opts);
+      const tc = trx.collection(cn);
+      // the transaction will be soft-aborted after this call on the server
+      let res = tc.insert({ _key: "test" });
+      assertEqual("test", res._key);
+      try {
+        tc.insert({});
+        fail();
+      } catch (err) {
+        assertEqual(err.errorNum, errors.ERROR_TRANSACTION_NOT_FOUND.code);
+      }
+
+      assertEqual(0, c.count());
+      res = trx.abort();
+      assertEqual("aborted", res.status);
+
+      assertEqual(0, c.count());
+      assertInSync(leader, follower, shardId);
+    },
+   
+  };
+}
+
+let ep = getEndpointsByType('dbserver');
+if (ep.length && debugCanUseFailAt(ep[0])) {
+  // only execute if failure tests are available
+  jsunity.run(transactionIntermediateCommitsSingleSuite);
+}
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Fix a potential deadlock in cluster transaction code in `transactions::Manager::returnManagedTrx()`.
This method acquired the write-lock on the transactions bucket, and then can call into `abortManagedTrx` while the lock is still being held.
`abortManagedTrx` directly calls `statusChangeWithTimeout`, which itself unconditionally calls `updateTransaction`, which will also unconditionally try to acquire the same bucket lock. This would be a deadlock.
We have never seen this in practice, and according to the code it looks like it can only happening when `beginShutdown()` or `stop()` are called on the TransactionManagerFeature. If this deadlock ever happened, it should be pretty rare.

Backport of the actual fix in https://github.com/arangodb/arangodb/pull/12955

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12592/