### PR TITLE
downgrade exclusive writes on followers to normal writes

### DIFF
--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -452,7 +452,7 @@ Result Manager::createManagedTrx(TRI_vocbase_t& vocbase, TransactionId tid,
   // locking keys and checking for conflicts, so disabling it may be 
   // somewhat expensive. we have to evaluate this change and potentially
   // revert. TODO
-  AccessMode::type const exclusiveLockMode = isFollowerTransactionOnDBServer
+  AccessMode::Type const exclusiveLockMode = isFollowerTransactionOnDBServer
     ? AccessMode::Type::WRITE 
     : AccessMode::Type::EXCLUSIVE;
  

--- a/arangod/Transaction/Manager.h
+++ b/arangod/Transaction/Manager.h
@@ -136,7 +136,8 @@ class Manager final {
                           transaction::Options options,
                           double ttl = 0.0);
 
-  /// @brief lease the transaction, increases nesting
+  /// @brief lease the transaction, increases nesting.
+  /// note: this can return a nullptr Context during shutdown or in error cases!
   std::shared_ptr<transaction::Context> leaseManagedTrx(TransactionId tid,
                                                         AccessMode::Type mode);
   void returnManagedTrx(TransactionId) noexcept;


### PR DESCRIPTION
### Scope & Purpose

Downgrade exclusive locks on followers to simple write locks, in order to reduce the potential for deadlocks on followers.
It is unclear yet if this helpful, so this PR is a draft for now.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *cluster tests, chaos tests*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12621/