### PR TITLE
Fix deadlocks between write transactions and hotbackup, take 2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.6.9 (XXXX-XX-XX)
 -------------------
 
+* Fixed a deadlock between AQL write transactions and hotbackup, since
+  in AQL write transactions follower transactions did not know they are
+  follower transactions.
+
 * Fixed potential deadlock in cluster transactions if a transaction is returned
   that was soft-aborted by transaction garbage collection before.
   This deadlock should rarely ever occur in practice, as it can only be

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,9 @@
 v3.6.9 (XXXX-XX-XX)
 -------------------
 
-* Fixed a deadlock between AQL write transactions and hotbackup, since
-  in AQL write transactions follower transactions did not know they are
-  follower transactions.
+* Fixed a deadlock between AQL write transactions and hotbackup, since in AQL
+  write transactions follower transactions did not know they are follower
+  transactions.
 
 * Fix REST API endpoint PUT `/_api/collection/<collection>/recalculateCount` on
   coordinators. Coordinators sent a wrong message body to DB servers here, so

--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -504,7 +504,7 @@ RestStatus RestCollectionHandler::handleCommandPut() {
         _request->value(StaticStrings::IsSynchronousReplicationString);
     opts.truncateCompact = _request->parsedValue(StaticStrings::Compact, true);
 
-    _activeTrx = createTransaction(coll->name(), AccessMode::Type::EXCLUSIVE);
+    _activeTrx = createTransaction(coll->name(), AccessMode::Type::EXCLUSIVE, opts);
     _activeTrx->addHint(transaction::Hints::Hint::INTERMEDIATE_COMMITS);
     _activeTrx->addHint(transaction::Hints::Hint::ALLOW_RANGE_DELETE);
     res = _activeTrx->begin();
@@ -806,7 +806,7 @@ RestStatus RestCollectionHandler::standardResponse() {
 
 void RestCollectionHandler::initializeTransaction(LogicalCollection& coll) {
   try {
-    _activeTrx = createTransaction(coll.name(), AccessMode::Type::READ);
+    _activeTrx = createTransaction(coll.name(), AccessMode::Type::READ, OperationOptions());
   } catch (basics::Exception const& ex) {
     if (ex.code() == TRI_ERROR_TRANSACTION_NOT_FOUND) {
       // this will happen if the tid of a managed transaction is passed in,

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -199,9 +199,6 @@ RestStatus RestDocumentHandler::insertDocument() {
   if (!isMultiple && !opOptions.overwrite) {
      _activeTrx->addHint(transaction::Hints::Hint::SINGLE_OPERATION);
   }
-  if (!opOptions.isSynchronousReplicationFrom.empty()) {
-    _activeTrx->addHint(transaction::Hints::Hint::IS_FOLLOWER_TRX);
-  }
 
   Result res = _activeTrx->begin();
   if (!res.ok()) {
@@ -489,9 +486,6 @@ RestStatus RestDocumentHandler::modifyDocument(bool isPatch) {
   if (!isArrayCase) {
     _activeTrx->addHint(transaction::Hints::Hint::SINGLE_OPERATION);
   }
-  if (!opOptions.isSynchronousReplicationFrom.empty()) {
-    _activeTrx->addHint(transaction::Hints::Hint::IS_FOLLOWER_TRX);
-  }
 
   // ...........................................................................
   // inside write transaction
@@ -610,9 +604,6 @@ RestStatus RestDocumentHandler::removeDocument() {
   _activeTrx = createTransaction(cname, AccessMode::Type::WRITE, opOptions);
   if (suffixes.size() == 2 || !search.isArray()) {
     _activeTrx->addHint(transaction::Hints::Hint::SINGLE_OPERATION);
-  }
-  if (!opOptions.isSynchronousReplicationFrom.empty()) {
-    _activeTrx->addHint(transaction::Hints::Hint::IS_FOLLOWER_TRX);
   }
 
   Result res = _activeTrx->begin();

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -193,7 +193,7 @@ RestStatus RestDocumentHandler::insertDocument() {
                          opOptions.isSynchronousReplicationFrom);
 
   // find and load collection given by name or identifier
-  _activeTrx = createTransaction(cname, AccessMode::Type::WRITE);
+  _activeTrx = createTransaction(cname, AccessMode::Type::WRITE, opOptions);
   bool const isMultiple = body.isArray();
 
   if (!isMultiple && !opOptions.overwrite) {
@@ -298,7 +298,7 @@ RestStatus RestDocumentHandler::readSingleDocument(bool generateBody) {
   VPackSlice search = builder.slice();
 
   // find and load collection given by name or identifier
-  _activeTrx = createTransaction(collection, AccessMode::Type::READ);
+  _activeTrx = createTransaction(collection, AccessMode::Type::READ, options);
 
   _activeTrx->addHint(transaction::Hints::Hint::SINGLE_OPERATION);
 
@@ -484,7 +484,7 @@ RestStatus RestDocumentHandler::modifyDocument(bool isPatch) {
   }
 
   // find and load collection given by name or identifier
-  _activeTrx = createTransaction(cname, AccessMode::Type::WRITE);
+  _activeTrx = createTransaction(cname, AccessMode::Type::WRITE, opOptions);
 
   if (!isArrayCase) {
     _activeTrx->addHint(transaction::Hints::Hint::SINGLE_OPERATION);
@@ -607,7 +607,7 @@ RestStatus RestDocumentHandler::removeDocument() {
     return RestStatus::DONE;
   }
 
-  _activeTrx = createTransaction(cname, AccessMode::Type::WRITE);
+  _activeTrx = createTransaction(cname, AccessMode::Type::WRITE, opOptions);
   if (suffixes.size() == 2 || !search.isArray()) {
     _activeTrx->addHint(transaction::Hints::Hint::SINGLE_OPERATION);
   }
@@ -667,7 +667,7 @@ RestStatus RestDocumentHandler::readManyDocuments() {
   OperationOptions opOptions;
   opOptions.ignoreRevs = _request->parsedValue(StaticStrings::IgnoreRevsString, true);
 
-  _activeTrx = createTransaction(cname, AccessMode::Type::READ);
+  _activeTrx = createTransaction(cname, AccessMode::Type::READ, opOptions);
 
   // ...........................................................................
   // inside read transaction

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -186,7 +186,7 @@ RestStatus RestIndexHandler::getSelectivityEstimates() {
   std::unique_ptr<transaction::Methods> trx;
 
   try {
-    trx = createTransaction(cName, AccessMode::Type::READ);
+    trx = createTransaction(cName, AccessMode::Type::READ, OperationOptions());
   } catch (basics::Exception const& ex) {
     if (ex.code() == TRI_ERROR_TRANSACTION_NOT_FOUND) {
       // this will happen if the tid of a managed transaction is passed in,

--- a/arangod/RestHandler/RestTransactionHandler.cpp
+++ b/arangod/RestHandler/RestTransactionHandler.cpp
@@ -176,7 +176,7 @@ void RestTransactionHandler::executeBegin() {
   transaction::Manager* mgr = transaction::ManagerFeature::manager();
   TRI_ASSERT(mgr != nullptr);
     
-  Result res = mgr->createManagedTrx(_vocbase, tid, slice);
+  Result res = mgr->createManagedTrx(_vocbase, tid, slice, false);
   if (res.fail()) {
     generateError(res);
   } else {

--- a/arangod/RestHandler/RestVocbaseBaseHandler.cpp
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.cpp
@@ -592,7 +592,7 @@ std::unique_ptr<transaction::Methods> RestVocbaseBaseHandler::createTransaction(
   if (!found) {
     auto tmp = std::make_unique<SingleCollectionTransaction>(transaction::StandaloneContext::Create(_vocbase),
                                                          collectionName, type);
-    if (!opOptions.isSynchronousReplicationFrom.empty() && ServerState::instance()->isDBServer()) {
+    if (!opOptions.isSynchronousReplicationFrom.empty()) {
       tmp->addHint(transaction::Hints::Hint::IS_FOLLOWER_TRX);
     }
     return tmp;

--- a/arangod/RestHandler/RestVocbaseBaseHandler.cpp
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.cpp
@@ -592,7 +592,7 @@ std::unique_ptr<transaction::Methods> RestVocbaseBaseHandler::createTransaction(
   if (!found) {
     auto tmp = std::make_unique<SingleCollectionTransaction>(transaction::StandaloneContext::Create(_vocbase),
                                                          collectionName, type);
-    if (!opOptions.isSynchronousReplicationFrom.empty()) {
+    if (!opOptions.isSynchronousReplicationFrom.empty() && ServerState::instance()->isDBServer()) {
       tmp->addHint(transaction::Hints::Hint::IS_FOLLOWER_TRX);
     }
     return tmp;

--- a/arangod/RestHandler/RestVocbaseBaseHandler.cpp
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.cpp
@@ -586,12 +586,16 @@ void RestVocbaseBaseHandler::extractStringParameter(std::string const& name,
 }
 
 std::unique_ptr<transaction::Methods> RestVocbaseBaseHandler::createTransaction(
-    std::string const& collectionName, AccessMode::Type type) const {
+    std::string const& collectionName, AccessMode::Type type, OperationOptions const& opOptions) const {
   bool found = false;
   std::string const& value = _request->header(StaticStrings::TransactionId, found);
   if (!found) {
-    return std::make_unique<SingleCollectionTransaction>(transaction::StandaloneContext::Create(_vocbase),
+    auto tmp = std::make_unique<SingleCollectionTransaction>(transaction::StandaloneContext::Create(_vocbase),
                                                          collectionName, type);
+    if (!opOptions.isSynchronousReplicationFrom.empty()) {
+      tmp->addHint(transaction::Hints::Hint::IS_FOLLOWER_TRX);
+    }
+    return tmp;
   }
   
   TRI_voc_tid_t tid = 0;
@@ -616,7 +620,7 @@ std::unique_ptr<transaction::Methods> RestVocbaseBaseHandler::createTransaction(
     std::string const& trxDef = _request->header(StaticStrings::TransactionBody, found);
     if (found) {
       auto trxOpts = VPackParser::fromJson(trxDef);
-      Result res = mgr->createManagedTrx(_vocbase, tid, trxOpts->slice());
+      Result res = mgr->createManagedTrx(_vocbase, tid, trxOpts->slice(), !opOptions.isSynchronousReplicationFrom.empty());
       if (res.fail()) {
         THROW_ARANGO_EXCEPTION(res);
       }
@@ -664,7 +668,7 @@ std::shared_ptr<transaction::Context> RestVocbaseBaseHandler::createTransactionC
       std::string const& trxDef = _request->header(StaticStrings::TransactionBody, found);
       if (found) {
         auto trxOpts = VPackParser::fromJson(trxDef);
-        Result res = mgr->createManagedTrx(_vocbase, tid, trxOpts->slice());
+        Result res = mgr->createManagedTrx(_vocbase, tid, trxOpts->slice(), false);
         if (res.fail()) {
           THROW_ARANGO_EXCEPTION(res);
         }

--- a/arangod/RestHandler/RestVocbaseBaseHandler.h
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.h
@@ -234,7 +234,8 @@ class RestVocbaseBaseHandler : public RestBaseHandler {
    * locking or a leased transaction.
    */
   std::unique_ptr<transaction::Methods> createTransaction(std::string const& cname,
-                                                          AccessMode::Type mode) const;
+                                                          AccessMode::Type mode,
+                                                          OperationOptions const& opOptions) const;
   
   /// @brief create proper transaction context, including the proper IDs
   std::shared_ptr<transaction::Context> createTransactionContext(AccessMode::Type mode) const;

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -346,7 +346,7 @@ Result Manager::createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,
     return res.reset(TRI_ERROR_BAD_PARAMETER,
                      "<lockTimeout> needs to be positive");
   }
-  if (isFollowerTransaction && ServerState::instance()->isDBServer()) {
+  if (isFollowerTransaction) {
     options.isFollowerTransaction = true;
   }
 

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -346,7 +346,7 @@ Result Manager::createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,
     return res.reset(TRI_ERROR_BAD_PARAMETER,
                      "<lockTimeout> needs to be positive");
   }
-  if (isFollowerTransaction) {
+  if (isFollowerTransaction && ServerState::instance()->isDBServer()) {
     options.isFollowerTransaction = true;
   }
 

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -328,7 +328,7 @@ void Manager::unregisterAQLTrx(TRI_voc_tid_t tid) noexcept {
 }
 
 Result Manager::createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,
-                                 VPackSlice const trxOpts) {
+                                 VPackSlice const trxOpts, bool isFollowerTransaction) {
   Result res;
   if (_disallowInserts) {
     return res.reset(TRI_ERROR_SHUTTING_DOWN);
@@ -345,6 +345,9 @@ Result Manager::createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,
   if (options.lockTimeout < 0.0) {
     return res.reset(TRI_ERROR_BAD_PARAMETER,
                      "<lockTimeout> needs to be positive");
+  }
+  if (isFollowerTransaction) {
+    options.isFollowerTransaction = true;
   }
 
   auto fillColls = [](VPackSlice const& slice, std::vector<std::string>& cols) {
@@ -485,6 +488,9 @@ Result Manager::createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,
   transaction::Hints hints;
   hints.set(transaction::Hints::Hint::LOCK_ENTIRELY);
   hints.set(transaction::Hints::Hint::GLOBAL_MANAGED);
+  if (options.isFollowerTransaction) {
+    hints.set(transaction::Hints::Hint::IS_FOLLOWER_TRX);
+  }
   res = state->beginTransaction(hints);  // registers with transaction manager
   if (res.fail()) {
     TRI_ASSERT(!state->isRunning());

--- a/arangod/Transaction/Manager.h
+++ b/arangod/Transaction/Manager.h
@@ -128,7 +128,8 @@ class Manager final {
 
   /// @brief create managed transaction
   Result createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,
-                          velocypack::Slice const trxOpts);
+                          velocypack::Slice const trxOpts,
+                          bool isFollowerTransaction);
 
   /// @brief create managed transaction
   Result createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,

--- a/arangod/Transaction/Options.cpp
+++ b/arangod/Transaction/Options.cpp
@@ -41,11 +41,11 @@ Options::Options()
       intermediateCommitSize(defaultIntermediateCommitSize),
       intermediateCommitCount(defaultIntermediateCommitCount),
       allowImplicitCollections(true),
-      waitForSync(false)
+      waitForSync(false),
 #ifdef USE_ENTERPRISE
-      ,
-      skipInaccessibleCollections(false)
+      skipInaccessibleCollections(false),
 #endif
+      isFollowerTransaction(false)
 {
 }
 
@@ -90,6 +90,10 @@ void Options::fromVelocyPack(arangodb::velocypack::Slice const& slice) {
     skipInaccessibleCollections = value.getBool();
   }
 #endif
+  value = slice.get("isFollowerTransaction");
+  if (value.isBool()) {
+    isFollowerTransaction = value.getBool();
+  }
 }
 
 /// @brief add the options to an opened vpack builder
@@ -105,4 +109,5 @@ void Options::toVelocyPack(arangodb::velocypack::Builder& builder) const {
 #ifdef USE_ENTERPRISE
   builder.add("skipInaccessibleCollections", VPackValue(skipInaccessibleCollections));
 #endif
+  builder.add("isFollowerTransaction", VPackValue(isFollowerTransaction));
 }

--- a/arangod/Transaction/Options.h
+++ b/arangod/Transaction/Options.h
@@ -64,6 +64,7 @@ struct Options {
 #ifdef USE_ENTERPRISE
   bool skipInaccessibleCollections;
 #endif
+  bool isFollowerTransaction;
 };
 
 }  // namespace transaction

--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -130,8 +130,8 @@ if [ ! -z "$INTERACTIVE_MODE" ] ; then
         CO_ARANGOD="$XTERM $XTERMOPTIONS ${BUILD}/bin/arangod --console"
         echo "Starting one coordinator in terminal with --console"
     elif [ "$INTERACTIVE_MODE" == "R" ] ; then
-        ARANGOD="rr ${BUILD}/bin/arangod"
-        CO_ARANGOD="$ARANGOD"
+        ARANGOD="$XTERM $XTERMOPTIONS rr ${BUILD}/bin/arangod"
+        CO_ARANGOD="$ARANGOD --console"
         echo Running cluster in rr with --console.
     fi
 else

--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -130,8 +130,8 @@ if [ ! -z "$INTERACTIVE_MODE" ] ; then
         CO_ARANGOD="$XTERM $XTERMOPTIONS ${BUILD}/bin/arangod --console"
         echo "Starting one coordinator in terminal with --console"
     elif [ "$INTERACTIVE_MODE" == "R" ] ; then
-        ARANGOD="$XTERM $XTERMOPTIONS rr ${BUILD}/bin/arangod"
-        CO_ARANGOD="$ARANGOD --console"
+        ARANGOD="rr ${BUILD}/bin/arangod"
+        CO_ARANGOD="$ARANGOD"
         echo Running cluster in rr with --console.
     fi
 else

--- a/tests/Transaction/Manager-test.cpp
+++ b/tests/Transaction/Manager-test.cpp
@@ -95,12 +95,12 @@ class TransactionManagerTest : public ::testing::Test {
 
 TEST_F(TransactionManagerTest, parsing_errors) {
   auto json = arangodb::velocypack::Parser::fromJson("{ \"write\": [33] }");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   EXPECT_TRUE(res.is(TRI_ERROR_BAD_PARAMETER));
 
   json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": \"33\"}, \"lockTimeout\": -1 }");
-  res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   EXPECT_TRUE(res.is(TRI_ERROR_BAD_PARAMETER));
 }
 
@@ -109,17 +109,17 @@ TEST_F(TransactionManagerTest, collection_not_found) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"read\": [\"33\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   EXPECT_EQ(res.errorNumber(), TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
 
   json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"33\"]}}");
-  res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   EXPECT_EQ(res.errorNumber(), TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
 
   json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"exclusive\": [\"33\"]}}");
-  res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   EXPECT_EQ(res.errorNumber(), TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
 }
 
@@ -134,12 +134,12 @@ TEST_F(TransactionManagerTest, transaction_id_reuse) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"read\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_TRUE(res.ok());
 
   json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"33\"]}}");
-  res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   EXPECT_EQ(res.errorNumber(), TRI_ERROR_TRANSACTION_INTERNAL);
 
   res = mgr->abortManagedTrx(tid);
@@ -157,7 +157,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_abort) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_TRUE(res.ok());
 
   auto doc = arangodb::velocypack::Parser::fromJson("{ \"_key\": \"1\"}");
@@ -209,7 +209,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_TRUE(res.ok());
 
   {
@@ -247,7 +247,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit_while_in_use) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_TRUE(res.ok());
 
   {
@@ -286,7 +286,7 @@ TEST_F(TransactionManagerTest, leading_multiple_readonly_transactions) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"read\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_TRUE(res.ok());
 
   {
@@ -317,7 +317,7 @@ TEST_F(TransactionManagerTest, lock_conflict) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_TRUE(res.ok());
   {
     auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE);
@@ -340,7 +340,7 @@ TEST_F(TransactionManagerTest, garbage_collection_shutdown) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_TRUE(res.ok());
   {
     auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE);
@@ -395,7 +395,7 @@ TEST_F(TransactionManagerTest, abort_transactions_with_matcher) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_TRUE(res.ok());
 
   {
@@ -441,14 +441,14 @@ TEST_F(TransactionManagerTest, permission_denied_readonly) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"read\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   EXPECT_TRUE(res.ok());
   ASSERT_TRUE(mgr->abortManagedTrx(tid).ok());
 
   tid = TRI_NewTickServer();
   json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"42\"]}}");
-  res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_EQ(res.errorNumber(), TRI_ERROR_ARANGO_READ_ONLY);
 }
 
@@ -471,6 +471,6 @@ TEST_F(TransactionManagerTest, permission_denied_forbidden) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"read\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_EQ(res.errorNumber(), TRI_ERROR_FORBIDDEN);
 }


### PR DESCRIPTION
Make sure all follower trxs know that they are follower trxs.

Before this patch, follower transactions created from AQL or other
El Cheapo transactions did not know they are follower transactions.
This could cause deadlocks between write transactions and hotbackups.

# Pull Request Guidelines

Pull requests are an essential collaborative tool for modern software development. 

The below list is intended to help you figure out whether your code is ready to be reviewed
and merged into ArangoDB. The overarching goal is to:

- Reduce the amount of *recurring* defects
- Reduce the impact to the other developer’s time and energy spent on defects in your code
- Increase the overall autonomy and productivity of individual developers

## Acceptance Checklist

*The below list is not exhaustive, think thoroughly whether the provided information is sufficient.*
*Remove options that do not apply*

### Scope & Purpose

*(Can you describe what functional change your PR is trying to effect?)*

- [ ] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [+] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [ ] Strictly *new functionality* (i.e. a new feature / new option, no need for porting)
- [+] The behavior in this PR can be (and was) *manually tested* (support / qa / customers can test it)
- [ ] The behavior change can be verified via automatic tests

#### Related Information

*(Please reference tickets / specification etc )*

- [ ] There is a GitHub Issue reported by a Community User: 
- [ ] There is an internal planning ticket:
- [ ] There is a *JIRA Ticket number* (In case a customer was affected / involved): 
- [ ] There is a design document: 

### Testing & Verification

This should be put under automatic tests. These are not yet implemented
in this PR. Our test framework is not particularly well suited to test
this.

Test that should be done:

Create a one shard database.

Run this in `arangosh`:

```
c = db._create("c");
for (i = 0; i < 1000; ++i) { c.insert({Hallo:i}); }
for (i = 0; i < 1000; ++i) { 
  db._query(`LET m = (FOR d IN c SORT d.Hallo DESC LIMIT 1 RETURN d)
             INSERT {Hallo: m[0].Hallo+1} INTO c RETURN NEW 
             OPTIONS {exclusive:true}`,).toArray();
  require("internal").wait(0.01);
  print(i);
}
```

Constantly create hotbackups during the time. Hotbackups should succeed
quickly and the above loop should not be slowed down too much.
