### PR TITLE
Fix REST API endpoint PUT `/_api/collection/<collection>/recalculateCount

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.7.5 (XXXX-XX-XX)
 -------------------
 
+* Fix REST API endpoint PUT `/_api/collection/<collection>/recalculateCount` on
+  coordinators. Coordinators sent a wrong message body to DB servers here, so
+  the request could not be handled properly.
+
 * Added missing exceptions catch clause for some parts of supervision and
   heartbeat threads.
 

--- a/arangod/ClusterEngine/RocksDBMethods.cpp
+++ b/arangod/ClusterEngine/RocksDBMethods.cpp
@@ -65,6 +65,9 @@ Result recalculateCountsOnAllDBServers(std::string const& dbname, std::string co
   std::string const baseUrl = "/_api/collection/";
 
   VPackBuffer<uint8_t> body;
+  VPackBuilder builder(body);
+  builder.add(VPackSlice::emptyObjectSlice());
+
   network::Headers headers;
   network::RequestOptions options;
   options.database = dbname;
@@ -85,12 +88,13 @@ Result recalculateCountsOnAllDBServers(std::string const& dbname, std::string co
 
   auto responses = futures::collectAll(futures).get();
   for (auto const& r : responses) {
-    if (!r.hasValue() || r.get().fail()) {
-      return TRI_ERROR_FAILED;
+    Result res = r.get().combinedResult();
+    if (res.fail()) {
+      return res;
     }
   }
 
-  return TRI_ERROR_NO_ERROR;
+  return {};
 }
 
 }  // namespace rocksdb

--- a/tests/js/client/shell/shell-recalculate-count-cluster.js
+++ b/tests/js/client/shell/shell-recalculate-count-cluster.js
@@ -1,0 +1,143 @@
+/*jshint globalstrict:false, strict:false */
+/*global assertEqual, assertNotEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2018 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+let jsunity = require("jsunity");
+let arangodb = require("@arangodb");
+let internal = require("internal");
+let request = require("@arangodb/request");
+let db = arangodb.db;
+
+function getEndpointById(id) {
+  const toEndpoint = (d) => (d.endpoint);
+  const endpointToURL = (endpoint) => {
+    if (endpoint.substr(0, 6) === 'ssl://') {
+      return 'https://' + endpoint.substr(6);
+    }
+    let pos = endpoint.indexOf('://');
+    if (pos === -1) {
+      return 'http://' + endpoint;
+    }
+    return 'http' + endpoint.substr(pos);
+  };
+
+  const instanceInfo = JSON.parse(internal.env.INSTANCEINFO);
+  return instanceInfo.arangods.filter((d) => (d.id === id))
+                              .map(toEndpoint)
+                              .map(endpointToURL)[0];
+}
+
+function getEndpointsByType(type) {
+  const isType = (d) => (d.role.toLowerCase() === type);
+  const toEndpoint = (d) => (d.endpoint);
+  const endpointToURL = (endpoint) => {
+    if (endpoint.substr(0, 6) === 'ssl://') {
+      return 'https://' + endpoint.substr(6);
+    }
+    let pos = endpoint.indexOf('://');
+    if (pos === -1) {
+      return 'http://' + endpoint;
+    }
+    return 'http' + endpoint.substr(pos);
+  };
+
+  const instanceInfo = JSON.parse(internal.env.INSTANCEINFO);
+  return instanceInfo.arangods.filter(isType)
+                              .map(toEndpoint)
+                              .map(endpointToURL);
+}
+
+/// @brief set failure point
+function debugCanUseFailAt(endpoint) {
+  let res = request.get({
+    url: endpoint + '/_admin/debug/failat',
+  });
+  return res.status === 200;
+}
+
+/// @brief set failure point
+function debugSetFailAt(endpoint, failAt) {
+  let res = request.put({
+    url: endpoint + '/_admin/debug/failat/' + failAt,
+    body: ""
+  });
+  if (res.status !== 200) {
+    throw "Error setting failure point";
+  }
+}
+
+function debugClearFailAt(endpoint) {
+  let res = request.delete({
+    url: endpoint + '/_admin/debug/failat',
+    body: ""
+  });
+  if (res.status !== 200) {
+    throw "Error removing failure points";
+  }
+}
+
+function RecalculateCountSuite() {
+  const cn = "UnitTestsCollection";
+
+  return {
+
+    setUp : function () {
+      getEndpointsByType("dbserver").forEach((ep) => debugClearFailAt(ep));
+      db._drop(cn);
+    },
+
+    tearDown : function () {
+      getEndpointsByType("dbserver").forEach((ep) => debugClearFailAt(ep));
+      db._drop(cn);
+    },
+    
+    testFixBrokenCounts : function () {
+      let c = db._create(cn, { numberOfShards: 5 });
+
+      getEndpointsByType("dbserver").forEach((ep) => debugSetFailAt(ep, "DisableCommitCounts"));
+
+      for (let i = 0; i < 1000; ++i) {
+        c.insert({});
+      }
+
+      assertNotEqual(1000, c.count());
+      assertEqual(1000, c.toArray().length);
+
+      getEndpointsByType("dbserver").forEach((ep) => debugClearFailAt(ep));
+ 
+      c.recalculateCount();
+      
+      assertEqual(1000, c.count());
+      assertEqual(1000, c.toArray().length);
+    },
+    
+  };
+}
+
+let ep = getEndpointsByType('dbserver');
+if (ep.length && debugCanUseFailAt(ep[0])) {
+  jsunity.run(RecalculateCountSuite);
+}
+return jsunity.done();

--- a/tests/js/client/shell/shell-recalculate-count-noncluster.js
+++ b/tests/js/client/shell/shell-recalculate-count-noncluster.js
@@ -1,0 +1,72 @@
+/*jshint globalstrict:false, strict:false */
+/*global arango, assertEqual, assertNotEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2018 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+let jsunity = require("jsunity");
+let arangodb = require("@arangodb");
+let db = arangodb.db;
+
+function RecalculateCountSuite() {
+  const cn = "UnitTestsCollection";
+
+  return {
+
+    setUp : function () {
+      arango.DELETE("/_admin/debug/failat");
+      db._drop(cn);
+    },
+
+    tearDown : function () {
+      arango.DELETE("/_admin/debug/failat");
+      db._drop(cn);
+    },
+    
+    testFixBrokenCounts : function () {
+      let c = db._create(cn);
+
+      arango.PUT("/_admin/debug/failat/DisableCommitCounts", {});
+
+      for (let i = 0; i < 1000; ++i) {
+        c.insert({});
+      }
+
+      assertNotEqual(1000, c.count());
+      assertEqual(1000, c.toArray().length);
+
+      arango.DELETE("/_admin/debug/failat");
+ 
+      c.recalculateCount();
+      
+      assertEqual(1000, c.count());
+      assertEqual(1000, c.toArray().length);
+    },
+    
+  };
+}
+
+if (arango.GET("/_admin/debug/failat") === true) {
+  jsunity.run(RecalculateCountSuite);
+}
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Fix REST API endpoint PUT `/_api/collection/<collection>/recalculateCount on coordinators. Coordinators sent a wrong message body to DB servers here, so the request could not be handled properly.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.6

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_client)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12630/