### PR TITLE
add some instrumentation for collection locking

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,22 @@
 devel
 -----
 
+* Added metrics for collection locks:
+  - `arangodb_collection_lock_timeouts_exclusive`: Number of lock timeouts 
+    when trying to acquire collection exclusive locks
+  - `arangodb_collection_lock_timeouts_write`: Number of lock timeouts when 
+    trying to acquire collection write locks
+  - `arangodb_collection_lock_acquisition_micros`: Total amount of collection 
+    lock acquisition time [μs]
+  - `arangodb_collection_lock_acquisition_time`: Total collection lock 
+    acquisition time histogram [s]
+
+* Reduce lock timeout on followers to 15 seconds.
+  Rationale: we should not have any locking conflicts on followers, generally. 
+  Any shard locking should be performed on leaders first, which will then, 
+  eventually replicate changes to followers. replication to followers is only 
+  done once the locks have been acquired on the leader(s). 
+
 * Remove extra CMake option `DEBUG_SYNC_REPLICATION` and use the already
   existing `USE_FAILURE_TESTS` options for its purpose.
 

--- a/arangod/Aql/AqlFunctionFeature.cpp
+++ b/arangod/Aql/AqlFunctionFeature.cpp
@@ -113,6 +113,11 @@ void AqlFunctionFeature::toVelocyPack(VPackBuilder& builder) {
     } else {
       builder.add(VPackValue("cxx"));
     }
+    // a "stub" here is just a placeholder for a function with no implementation.
+    // this is used for functions which are translated to other constructs during parsing,
+    // e.g. WITHIN_RECTANGLE is translated into a FOR ... FILTER ... loop internally,
+    // so that WITHIN_RECTANGLE is actually never called
+    builder.add("stub", VPackValue(it.second.implementation == &Functions::NotImplemented));
     builder.close();  // implementations
     builder.add("deterministic", VPackValue(it.second.hasFlag(FF::Deterministic)));
     builder.add("cacheable", VPackValue(it.second.hasFlag(FF::Cacheable)));

--- a/arangod/Aql/AqlFunctionFeature.cpp
+++ b/arangod/Aql/AqlFunctionFeature.cpp
@@ -113,11 +113,6 @@ void AqlFunctionFeature::toVelocyPack(VPackBuilder& builder) {
     } else {
       builder.add(VPackValue("cxx"));
     }
-    // a "stub" here is just a placeholder for a function with no implementation.
-    // this is used for functions which are translated to other constructs during parsing,
-    // e.g. WITHIN_RECTANGLE is translated into a FOR ... FILTER ... loop internally,
-    // so that WITHIN_RECTANGLE is actually never called
-    builder.add("stub", VPackValue(it.second.implementation == &Functions::NotImplemented));
     builder.close();  // implementations
     builder.add("deterministic", VPackValue(it.second.hasFlag(FF::Deterministic)));
     builder.add("cacheable", VPackValue(it.second.hasFlag(FF::Cacheable)));

--- a/arangod/Aql/Function.cpp
+++ b/arangod/Aql/Function.cpp
@@ -41,7 +41,7 @@ Function::Function(std::string const& name, char const* arguments,
 
   // almost all AQL functions have a cxx implementation
   // only function V8() plus the ArangoSearch functions do not
-  LOG_TOPIC("c70f6", TRACE, Logger::FIXME)
+  LOG_TOPIC("c70f6", TRACE, Logger::AQL)
       << "registered AQL function '" << name
       << "'. cacheable: " << hasFlag(Flags::Cacheable)
       << ", deterministic: " << hasFlag(Flags::Deterministic)

--- a/arangod/RestServer/QueryRegistryFeature.cpp
+++ b/arangod/RestServer/QueryRegistryFeature.cpp
@@ -285,7 +285,7 @@ void QueryRegistryFeature::unprepare() {
 void QueryRegistryFeature::trackQuery(double time) { 
   ++_queriesCounter; 
   _queryTimes.count(time);
-  _totalQueryExecutionTime += static_cast<uint64_t>(1000 * time);
+  _totalQueryExecutionTime += static_cast<uint64_t>(1000.0 * time);
 }
 
 void QueryRegistryFeature::trackSlowQuery(double time) { 

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -885,9 +885,7 @@ int RocksDBMetaCollection::doLock(double timeout, AccessMode::Type mode) {
       return TRI_ERROR_INTERNAL;
     }
 
-    if (gotLock && waitTime == 0) {
-      // got lock on first iteration!
-      TRI_ASSERT(startTime == 0.0);
+    if (gotLock) {
       // keep the lock and exit the loop
       return TRI_ERROR_NO_ERROR;
     }

--- a/arangod/RocksDBEngine/RocksDBTransactionState.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.cpp
@@ -27,13 +27,13 @@
 #include "Aql/QueryCache.h"
 #include "Basics/Exceptions.h"
 #include "Basics/system-compiler.h"
+#include "Basics/system-functions.h"
 #include "Cache/CacheManagerFeature.h"
 #include "Cache/Manager.h"
 #include "Cache/Transaction.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
-#include "RestServer/MetricsFeature.h"
 #include "RocksDBEngine/RocksDBCollection.h"
 #include "RocksDBEngine/RocksDBCommon.h"
 #include "RocksDBEngine/RocksDBEngine.h"
@@ -91,7 +91,24 @@ Result RocksDBTransactionState::beginTransaction(transaction::Hints hints) {
 
   _hints = hints;  // set hints before useCollections
 
-  Result res = useCollections();
+  auto& stats = statistics();
+
+  Result res;
+  if (isReadOnlyTransaction()) {
+    // for read-only transactions there will be no locking. so we will not
+    // even call TRI_microtime() to save some cycles
+    res = useCollections();
+  } else {
+    // measure execution time of "useCollections" operation, which is
+    // responsible for acquring locks as well
+    double start = TRI_microtime();
+    res = useCollections();
+    
+    double diff = TRI_microtime() - start;
+    stats._lockTimeMicros += static_cast<uint64_t>(1000000.0 * diff);
+    stats._lockTimes.count(diff);
+  }
+  
   if (res.fail()) {
     // something is wrong
     updateStatus(transaction::Status::ABORTED);
@@ -101,7 +118,7 @@ Result RocksDBTransactionState::beginTransaction(transaction::Hints hints) {
   // register with manager
   transaction::ManagerFeature::manager()->registerTransaction(id(), isReadOnlyTransaction(), hasHint(transaction::Hints::Hint::IS_FOLLOWER_TRX));
   updateStatus(transaction::Status::RUNNING);
-  _vocbase.server().getFeature<MetricsFeature>().serverStatistics()._transactionsStatistics._transactionsStarted++;
+  ++stats._transactionsStarted;
 
   setRegistered();
 
@@ -400,7 +417,7 @@ Result RocksDBTransactionState::commitTransaction(transaction::Methods* activeTr
   if (res.ok()) {
     updateStatus(transaction::Status::COMMITTED);
     cleanupTransaction();  // deletes trx
-    _vocbase.server().getFeature<MetricsFeature>().serverStatistics()._transactionsStatistics._transactionsCommitted++;
+    ++statistics()._transactionsCommitted;
   } else {
     abortTransaction(activeTrx);  // deletes trx
   }
@@ -430,7 +447,7 @@ Result RocksDBTransactionState::abortTransaction(transaction::Methods* activeTrx
     clearQueryCache();
   }
   TRI_ASSERT(!_rocksTransaction && !_cacheTx && !_readSnapshot);
-  _vocbase.server().getFeature<MetricsFeature>().serverStatistics()._transactionsStatistics._transactionsAborted++;
+  ++statistics()._transactionsAborted;
 
   return result;
 }
@@ -608,7 +625,7 @@ Result RocksDBTransactionState::triggerIntermediateCommit(bool& hasPerformedInte
   }
 
   hasPerformedIntermediateCommit = true;
-  _vocbase.server().getFeature<MetricsFeature>().serverStatistics()._transactionsStatistics._intermediateCommits++;
+  ++statistics()._intermediateCommits;
 
   TRI_IF_FAILURE("FailAfterIntermediateCommit") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
@@ -717,7 +734,7 @@ rocksdb::SequenceNumber RocksDBTransactionState::beginSeq() const {
   rocksdb::TransactionDB* db = engine.db();
   return db->GetLatestSequenceNumber();
 }
-
+  
 /// @brief constructor, leases a builder
 RocksDBKeyLeaser::RocksDBKeyLeaser(transaction::Methods* trx)
     : _ctx(trx->transactionContextPtr()),

--- a/arangod/RocksDBEngine/RocksDBTransactionState.h
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.h
@@ -56,7 +56,6 @@ struct Transaction;
 }
 
 class LogicalCollection;
-struct RocksDBDocumentOperation;
 class RocksDBMethods;
 
 /// @brief transaction type
@@ -90,7 +89,7 @@ class RocksDBTransactionState final : public TransactionState {
   uint64_t numUpdates() const { return _numUpdates; }
   /// @brief number of remove operations
   uint64_t numRemoves() const { return _numRemoves; }
-
+  
   inline bool hasOperations() const {
     return (_numInserts > 0 || _numRemoves > 0 || _numUpdates > 0);
   }

--- a/arangod/Statistics/ServerStatistics.cpp
+++ b/arangod/Statistics/ServerStatistics.cpp
@@ -31,13 +31,22 @@ using namespace arangodb;
 TransactionStatistics::TransactionStatistics(MetricsFeature& metrics)
     : _metrics(metrics),
       _transactionsStarted(_metrics.counter("arangodb_transactions_started", 0,
-                                            "Transactions started")),
+                                            "Number of transactions started")),
       _transactionsAborted(_metrics.counter("arangodb_transactions_aborted", 0,
-                                            "Transactions aborted")),
+                                            "Number of transactions aborted")),
       _transactionsCommitted(_metrics.counter("arangodb_transactions_committed",
-                                              0, "Transactions committed")),
+                                              0, "Number of transactions committed")),
       _intermediateCommits(_metrics.counter("arangodb_intermediate_commits", 0,
-                                            "Intermediate commits")) {}
+                                            "Number of intermediate commits performed in transactions")),
+      _exclusiveLockTimeouts(_metrics.counter("arangodb_collection_lock_timeouts_exclusive", 0,
+                                              "Number of timeouts when trying to acquire collection exclusive locks")),
+      _writeLockTimeouts(_metrics.counter("arangodb_collection_lock_timeouts_write", 0,
+                                          "Number of timeouts when trying to acquire collection write locks")),
+      _lockTimeMicros(_metrics.counter("arangodb_collection_lock_acquisition_micros", 0,
+                                       "Total amount of collection lock acquisition time [μs]")),
+      _lockTimes(
+        _metrics.histogram("arangodb_collection_lock_acquisition_time", log_scale_t(10., 0.0, 1000.0, 11),
+                           "Collection lock acquisition time histogram [s]")) {}
 
 // -----------------------------------------------------------------------------
 // --SECTION--                                             static public methods

--- a/arangod/Statistics/ServerStatistics.h
+++ b/arangod/Statistics/ServerStatistics.h
@@ -24,13 +24,11 @@
 #ifndef ARANGOD_STATISTICS_SERVER_STATISTICS_H
 #define ARANGOD_STATISTICS_SERVER_STATISTICS_H 1
 
-#include <atomic>
 #include <cstdint>
 #include "RestServer/Metrics.h"
 
 namespace arangodb {
 class MetricsFeature;
-}
 
 struct TransactionStatistics {
   explicit TransactionStatistics(arangodb::MetricsFeature&);
@@ -45,10 +43,17 @@ struct TransactionStatistics {
   Counter& _transactionsAborted;
   Counter& _transactionsCommitted;
   Counter& _intermediateCommits;
+  // total number of lock timeouts for exclusive locks
+  Counter& _exclusiveLockTimeouts;
+  // total number of lock timeouts for write locks
+  Counter& _writeLockTimeouts;
+  // total duration of lock acquisition (in microseconds)
+  Counter& _lockTimeMicros;
+  // histogram for lock acquisition (in seconds)
+  Histogram<log_scale_t<double>>& _lockTimes;
 };
 
 struct ServerStatistics {
-
   ServerStatistics(ServerStatistics const&) = delete;
   ServerStatistics(ServerStatistics &&) = delete;
   ServerStatistics& operator=(ServerStatistics const&) = delete;
@@ -57,12 +62,14 @@ struct ServerStatistics {
   ServerStatistics& statistics();
 
   TransactionStatistics _transactionsStatistics;
-  const double _startTime;
+  double const _startTime;
   
   double uptime() const noexcept;
 
   explicit ServerStatistics(arangodb::MetricsFeature& metrics, double start)
       : _transactionsStatistics(metrics), _startTime(start) {}
 };
+
+} // namespace
 
 #endif

--- a/arangod/StorageEngine/TransactionState.cpp
+++ b/arangod/StorageEngine/TransactionState.cpp
@@ -23,12 +23,14 @@
 
 #include "TransactionState.h"
 
+#include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/QueryCache.h"
 #include "Basics/Exceptions.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
-#include "ApplicationFeatures/ApplicationServer.h"
+#include "RestServer/MetricsFeature.h"
+#include "Statistics/ServerStatistics.h"
 #include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/StorageEngine.h"
 #include "StorageEngine/TransactionCollection.h"
@@ -41,7 +43,6 @@
 
 using namespace arangodb;
 
-
 /// @brief transaction type
 TransactionState::TransactionState(TRI_vocbase_t& vocbase, TransactionId tid,
                                    transaction::Options const& options)
@@ -53,8 +54,8 @@ TransactionState::TransactionState(TRI_vocbase_t& vocbase, TransactionId tid,
       _arena(),
       _collections{_arena},  // assign arena to vector
       _hints(),
-      _options(options),
       _serverRole(ServerState::instance()->getRole()),
+      _options(options),
       _registeredTransaction(false) {}
 
 /// @brief free a transaction container
@@ -383,4 +384,23 @@ void TransactionState::updateStatus(transaction::Status status) {
   }
 
   _status = status;
+}
+  
+/// @brief returns the name of the actor the transaction runs on:
+/// - leader
+/// - follower
+/// - coordinator
+/// - single
+char const* TransactionState::actorName() const noexcept {
+  if (isDBServer()) {
+    return hasHint(transaction::Hints::Hint::IS_FOLLOWER_TRX) ? "follower" : "leader";
+  } else if (isCoordinator()) {
+    return "coordinator";
+  } 
+  return "single";
+}
+
+/// @brief return a reference to the global transaction statistics
+TransactionStatistics& TransactionState::statistics() noexcept {
+  return _vocbase.server().getFeature<MetricsFeature>().serverStatistics()._transactionsStatistics;
 }

--- a/arangod/StorageEngine/TransactionState.h
+++ b/arangod/StorageEngine/TransactionState.h
@@ -63,6 +63,7 @@ struct Options;
 }  // namespace transaction
 
 class TransactionCollection;
+struct TransactionStatistics;
 
 /// @brief transaction type
 class TransactionState {
@@ -107,6 +108,16 @@ class TransactionState {
   }
   void setRegistered() noexcept { _registeredTransaction = true; }
   bool wasRegistered() const noexcept { return _registeredTransaction; }
+
+  /// @brief returns the name of the actor the transaction runs on:
+  /// - leader
+  /// - follower
+  /// - coordinator
+  /// - single
+  char const* actorName() const noexcept; 
+  
+  /// @brief return a reference to the global transaction statistics/counters
+  TransactionStatistics& statistics() noexcept;
 
   double lockTimeout() const { return _options.lockTimeout; }
   void lockTimeout(double value) {
@@ -273,10 +284,10 @@ class TransactionState {
   ListType _collections;  // list of participating collections
 
   transaction::Hints _hints;  // hints; set on _nestingLevel == 0
+  
+  ServerState::RoleEnum const _serverRole;  /// role of the server
 
   transaction::Options _options;
-
-  ServerState::RoleEnum const _serverRole;  /// role of the server
 
  private:
   /// a collection of stored cookies


### PR DESCRIPTION
### Scope & Purpose

* Added metrics for collection locks:
  - `arangodb_collection_lock_timeouts_exclusive`: Number of lock timeouts when trying to acquire collection exclusive locks 
  - `arangodb_collection_lock_timeouts_write`: Number of lock timeouts when trying to acquire collection write locks 
  - `arangodb_collection_lock_acquisition_micros`: Total amount of collection lock acquisition time [μs]
  - `arangodb_collection_lock_acquisition_time`: Total collection lock acquisition time histogram [s]

* Reduce lock timeout on followers to 15 seconds.
  Rationale: we should not have any locking conflicts on followers, generally. Any shard locking should be performed on leaders first, which will then, eventually replicate changes to followers. replication to followers is only done once the locks have been acquired on the leader(s). 

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.7

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12643/