### PR TITLE
basic support for DOCUMENT function on DB servers in OneShard setups

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.7.5 (XXXX-XX-XX)
 -------------------
 
+* Make the DOCUMENT AQL function eligible for running on DB servers in
+  OneShard deployment mode. This allows pushing more query parts to DB servers
+  for execution.
+
 * Fix REST API endpoint PUT `/_api/collection/<collection>/recalculateCount` on
   coordinators. Coordinators sent a wrong message body to DB servers here, so
   the request could not be handled properly.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,9 @@
 v3.7.5 (XXXX-XX-XX)
 -------------------
 
-* Make the DOCUMENT AQL function eligible for running on DB servers in
-  OneShard deployment mode. This allows pushing more query parts to DB servers
-  for execution.
+* Make the DOCUMENT AQL function eligible for running on DB servers in OneShard
+  deployment mode. This allows pushing more query parts to DB servers for
+  execution.
 
 * Fix REST API endpoint PUT `/_api/collection/<collection>/recalculateCount` on
   coordinators. Coordinators sent a wrong message body to DB servers here, so

--- a/arangod/Aql/AqlFunctionFeature.cpp
+++ b/arangod/Aql/AqlFunctionFeature.cpp
@@ -100,23 +100,10 @@ void AqlFunctionFeature::addAlias(std::string const& alias, std::string const& o
   add(aliasFunction);
 }
 
-void AqlFunctionFeature::toVelocyPack(VPackBuilder& builder) {
+void AqlFunctionFeature::toVelocyPack(VPackBuilder& builder) const {
   builder.openArray();
   for (auto const& it : _functionNames) {
-    builder.openObject();
-    builder.add("name", VPackValue(it.second.name));
-    builder.add("arguments", VPackValue(it.second.arguments));
-    builder.add("implementations", VPackValue(VPackValueType::Array));
-    if (it.second.implementation == nullptr) {
-      builder.add(VPackValue("js"));
-    } else {
-      builder.add(VPackValue("cxx"));
-    }
-    builder.close();  // implementations
-    builder.add("deterministic", VPackValue(it.second.hasFlag(FF::Deterministic)));
-    builder.add("cacheable", VPackValue(it.second.hasFlag(FF::Cacheable)));
-    builder.add("canRunOnDBServer", VPackValue(it.second.hasFlag(FF::CanRunOnDBServer)));
-    builder.close();
+    it.second.toVelocyPack(builder);
   }
   builder.close();
 }
@@ -127,7 +114,7 @@ bool AqlFunctionFeature::exists(std::string const& name) const {
   return it != _functionNames.end();
 }
 
-Function const* AqlFunctionFeature::byName(std::string const& name) {
+Function const* AqlFunctionFeature::byName(std::string const& name) const {
   auto it = _functionNames.find(name);
 
   if (it == _functionNames.end()) {
@@ -150,7 +137,8 @@ Function const* AqlFunctionFeature::byName(std::string const& name) {
 
 void AqlFunctionFeature::addTypeCheckFunctions() {
   // common flags for all these functions
-  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable, FF::CanRunOnDBServer);
+  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable, 
+                                   FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard);
 
   // type check functions
   add({"IS_NULL", ".", flags, &Functions::IsNull});
@@ -172,7 +160,8 @@ void AqlFunctionFeature::addTypeCheckFunctions() {
 
 void AqlFunctionFeature::addTypeCastFunctions() {
   // common flags for all these functions
-  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable, FF::CanRunOnDBServer);
+  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable,
+                                   FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard);
 
   // type cast functions
   add({"TO_NUMBER", ".", flags, &Functions::ToNumber});
@@ -185,7 +174,8 @@ void AqlFunctionFeature::addTypeCastFunctions() {
 
 void AqlFunctionFeature::addStringFunctions() {
   // common flags for all these functions
-  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable, FF::CanRunOnDBServer);
+  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable,
+                                   FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard);
 
   // string functions
   add({"CONCAT", ".|+", flags, &Functions::Concat});
@@ -227,15 +217,18 @@ void AqlFunctionFeature::addStringFunctions() {
   add({"NGRAM_SIMILARITY", ".,.,.", flags, &Functions::NgramSimilarity}); // (attribute, target, ngram size)
   add({"NGRAM_POSITIONAL_SIMILARITY", ".,.,.", flags, &Functions::NgramPositionalSimilarity}); // (attribute, target, ngram size)
   add({"IN_RANGE", ".,.,.,.,.", flags, &Functions::InRange }); // (attribute, lower, upper, include lower, include upper)
+  
   // special flags:
-  add({"RANDOM_TOKEN", ".", Function::makeFlags(FF::CanRunOnDBServer),
-       &Functions::RandomToken});  // not deterministic and not cacheable
-  add({"UUID", "", Function::makeFlags(FF::CanRunOnDBServer), &Functions::Uuid});  // not deterministic and not cacheable
+  // not deterministic and not cacheable
+  auto nonDeterministicFlags = Function::makeFlags(FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard);
+  add({"RANDOM_TOKEN", ".", nonDeterministicFlags, &Functions::RandomToken});  
+  add({"UUID", "", nonDeterministicFlags, &Functions::Uuid});
 }
 
 void AqlFunctionFeature::addNumericFunctions() {
   // common flags for all these functions
-  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable, FF::CanRunOnDBServer);
+  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable,
+                                   FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard);
 
   // numeric functions
   add({"FLOOR", ".", flags, &Functions::Floor});
@@ -261,12 +254,15 @@ void AqlFunctionFeature::addNumericFunctions() {
   add({"PI", "", flags, &Functions::Pi});
 
   // special flags:
-  add({"RAND", "", Function::makeFlags(FF::CanRunOnDBServer), &Functions::Rand});  // not deterministic and not cacheable
+  // not deterministic and not cacheable
+  auto nonDeterministicFlags = Function::makeFlags(FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard);
+  add({"RAND", "", nonDeterministicFlags, &Functions::Rand}); 
 }
 
 void AqlFunctionFeature::addListFunctions() {
   // common flags for all these functions
-  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable, FF::CanRunOnDBServer);
+  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable,
+                                   FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard);
 
   // list functions
   add({"RANGE", ".,.|.", flags, &Functions::Range});
@@ -325,14 +321,16 @@ void AqlFunctionFeature::addListFunctions() {
   // special flags:
   // CALL and APPLY will always run on the coordinator and are not deterministic
   // and not cacheable, as we don't know what function is actually gonna be
-  // called
+  // called. in addition, this may call any user-defined function, so we cannot
+  // run this on DB servers
   add({"CALL", ".|.+", Function::makeFlags(), &Functions::Call});
   add({"APPLY", ".|.", Function::makeFlags(), &Functions::Apply});
 }
 
 void AqlFunctionFeature::addDocumentFunctions() {
   // common flags for all these functions
-  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable, FF::CanRunOnDBServer);
+  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable,
+                                   FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard);
 
   // document functions
   add({"HAS", ".,.", flags, &Functions::Has});
@@ -352,37 +350,30 @@ void AqlFunctionFeature::addDocumentFunctions() {
   add({"JSON_PARSE", ".", flags, &Functions::JsonParse});
 
   // special flags:
-  add({"DOCUMENT", "h.|.", Function::makeFlags(), &Functions::Document});  // not deterministic and non-cacheable
+  // not deterministic and non-cacheable, can only run on DB servers in OneShard mode
+  auto documentFlags = Function::makeFlags(FF::CanRunOnDBServerOneShard, FF::CanReadDocuments);
+  add({"DOCUMENT", "h.|.", documentFlags, &Functions::Document});  
 }
 
 void AqlFunctionFeature::addGeoFunctions() {
+  // common flags for all these functions
+  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable,
+                                   FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard);
+
   // geo functions
-  add({"DISTANCE", ".,.,.,.",
-       Function::makeFlags(FF::Deterministic, FF::Cacheable, FF::CanRunOnDBServer),
-       &Functions::Distance});
-  add({"IS_IN_POLYGON", ".,.|.",
-       Function::makeFlags(FF::Deterministic, FF::Cacheable, FF::CanRunOnDBServer),
-       &Functions::IsInPolygon});
-  add({"GEO_DISTANCE", ".,.|.",
-       Function::makeFlags(FF::Deterministic, FF::Cacheable, FF::CanRunOnDBServer),
-       &Functions::GeoDistance});
-  add({"GEO_CONTAINS", ".,.",
-       Function::makeFlags(FF::Deterministic, FF::Cacheable, FF::CanRunOnDBServer),
-       &Functions::GeoContains});
-  add({"GEO_INTERSECTS", ".,.",
-       Function::makeFlags(FF::Deterministic, FF::Cacheable, FF::CanRunOnDBServer),
-       &Functions::GeoIntersects});
-  add({"GEO_EQUALS", ".,.",
-       Function::makeFlags(FF::Deterministic, FF::Cacheable, FF::CanRunOnDBServer),
-       &Functions::GeoEquals});
-  add({"GEO_AREA", ".|.",
-    Function::makeFlags(FF::Deterministic, FF::Cacheable, FF::CanRunOnDBServer),
-    &Functions::GeoArea});
+  add({"DISTANCE", ".,.,.,.", flags, &Functions::Distance});
+  add({"IS_IN_POLYGON", ".,.|.", flags, &Functions::IsInPolygon});
+  add({"GEO_DISTANCE", ".,.|.", flags, &Functions::GeoDistance});
+  add({"GEO_CONTAINS", ".,.", flags, &Functions::GeoContains});
+  add({"GEO_INTERSECTS", ".,.", flags, &Functions::GeoIntersects});
+  add({"GEO_EQUALS", ".,.", flags, &Functions::GeoEquals});
+  add({"GEO_AREA", ".|.", flags, &Functions::GeoArea});
 }
 
 void AqlFunctionFeature::addGeometryConstructors() {
   // common flags for all these functions
-  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable, FF::CanRunOnDBServer);
+  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable,
+                                   FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard);
 
   // geometry types
   add({"GEO_POINT", ".,.", flags, &Functions::GeoPoint});
@@ -395,7 +386,8 @@ void AqlFunctionFeature::addGeometryConstructors() {
 
 void AqlFunctionFeature::addDateFunctions() {
   // common flags for all these functions
-  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable, FF::CanRunOnDBServer);
+  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable,
+                                   FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard);
 
   // date functions
   add({"DATE_TIMESTAMP", ".|.,.,.,.,.,.", flags, &Functions::DateTimestamp});
@@ -422,13 +414,14 @@ void AqlFunctionFeature::addDateFunctions() {
   add({"DATE_ROUND", ".,.,.", flags, &Functions::DateRound});
 
   // special flags:
-  add({"DATE_NOW", "", Function::makeFlags(FF::Deterministic, FF::CanRunOnDBServer),
+  add({"DATE_NOW", "", Function::makeFlags(FF::Deterministic, FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard),
        &Functions::DateNow});  // deterministic, but not cacheable!
 }
 
 void AqlFunctionFeature::addMiscFunctions() {
   // common flags for most of these functions
-  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable, FF::CanRunOnDBServer);
+  auto flags = Function::makeFlags(FF::Deterministic, FF::Cacheable,
+                                   FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard);
 
   // misc functions
   add({"PASSTHRU", ".", flags, &Functions::Passthru});
@@ -438,32 +431,34 @@ void AqlFunctionFeature::addMiscFunctions() {
   add({"PARSE_IDENTIFIER", ".", flags, &Functions::ParseIdentifier});
   add({"IS_SAME_COLLECTION", ".h,.h", flags, &Functions::IsSameCollection});
   add({"DECODE_REV", ".", flags, &Functions::DecodeRev});
-  add({"V8", ".", Function::makeFlags(FF::Deterministic, FF::Cacheable)});  // only function without a
-                                                                            // C++ implementation
   
+  // only function without a C++ implementation
+  add({"V8", ".", Function::makeFlags(FF::Deterministic, FF::Cacheable), nullptr});  
+  
+  // the following functions are not eligible to run on DB servers
   auto validationFlags = Function::makeFlags(FF::None);
   add({"SCHEMA_GET", ".", validationFlags, &Functions::SchemaGet});
   add({"SCHEMA_VALIDATE", ".,.", validationFlags, &Functions::SchemaValidate});
 
   // special flags:
-  add({"VERSION", "", Function::makeFlags(FF::Deterministic), &Functions::Version});  // deterministic, not cacheable. only on
-                                                                                      // coordinator
-  add({"FAIL", "|.", Function::makeFlags(FF::CanRunOnDBServer), &Functions::Fail});  // not deterministic and not cacheable
-  add({"NOOPT", ".", Function::makeFlags(FF::CanRunOnDBServer, FF::NoEval), &Functions::Passthru});  // prevents all optimizations!
-  add({"NOEVAL", ".", Function::makeFlags(FF::Deterministic, FF::CanRunOnDBServer, FF::NoEval), &Functions::Passthru});  // prevents all optimizations!
-  add({"SLEEP", ".", Function::makeFlags(FF::CanRunOnDBServer), &Functions::Sleep});  // not deterministic and not cacheable
+  // deterministic, not cacheable. only on coordinator
+  add({"VERSION", "", Function::makeFlags(FF::Deterministic), &Functions::Version});  
+  add({"FAIL", "|.", Function::makeFlags(FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard), &Functions::Fail});  // not deterministic and not cacheable
+  add({"NOOPT", ".", Function::makeFlags(FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard, FF::NoEval), &Functions::Passthru});  // prevents all optimizations!
+  add({"NOEVAL", ".", Function::makeFlags(FF::Deterministic, FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard, FF::NoEval), &Functions::Passthru});  // prevents all optimizations!
+  add({"SLEEP", ".", Function::makeFlags(FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard), &Functions::Sleep});  // not deterministic and not cacheable
   add({"COLLECTIONS", "", Function::makeFlags(), &Functions::Collections});  // not deterministic and not cacheable
   add({"CURRENT_USER", "", Function::makeFlags(FF::Deterministic),
        &Functions::CurrentUser});  // deterministic, but not cacheable
   add({"CURRENT_DATABASE", "", Function::makeFlags(FF::Deterministic),
        &Functions::CurrentDatabase});  // deterministic, but not cacheable
-  add({"CHECK_DOCUMENT", ".", Function::makeFlags(FF::CanRunOnDBServer),
+  add({"CHECK_DOCUMENT", ".", Function::makeFlags(FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard),
        &Functions::CheckDocument});  // not deterministic and not cacheable
-  add({"COLLECTION_COUNT", ".h", Function::makeFlags(), &Functions::CollectionCount});  // not deterministic and not cacheable
-  add({"PREGEL_RESULT", ".|.", Function::makeFlags(FF::CanRunOnDBServer),
+  add({"COLLECTION_COUNT", ".h", Function::makeFlags(FF::CanReadDocuments), &Functions::CollectionCount});  // not deterministic and not cacheable
+  add({"PREGEL_RESULT", ".|.", Function::makeFlags(FF::CanReadDocuments, FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard),
        &Functions::PregelResult});  // not deterministic and not cacheable
-  add({"ASSERT", ".,.", Function::makeFlags(FF::CanRunOnDBServer), &Functions::Assert});  // not deterministic and not cacheable
-  add({"WARN", ".,.", Function::makeFlags(FF::CanRunOnDBServer), &Functions::Warn});  // not deterministic and not cacheable
+  add({"ASSERT", ".,.", Function::makeFlags(FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard), &Functions::Assert});  // not deterministic and not cacheable
+  add({"WARN", ".,.", Function::makeFlags(FF::CanRunOnDBServerCluster, FF::CanRunOnDBServerOneShard), &Functions::Warn});  // not deterministic and not cacheable
 
   // NEAR, WITHIN, WITHIN_RECTANGLE and FULLTEXT are replaced by the AQL
   // optimizer with collection-/index-based subqueries. they are all

--- a/arangod/Aql/AqlFunctionFeature.h
+++ b/arangod/Aql/AqlFunctionFeature.h
@@ -53,8 +53,8 @@ class AqlFunctionFeature final : public application_features::ApplicationFeature
   // add a function alias
   void addAlias(std::string const& alias, std::string const& original);
 
-  void toVelocyPack(arangodb::velocypack::Builder&);
-  Function const* byName(std::string const& name);
+  void toVelocyPack(arangodb::velocypack::Builder&) const;
+  Function const* byName(std::string const& name) const;
 
   bool exists(std::string const& name) const;
 

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -1531,9 +1531,8 @@ AstNode* Ast::createNodeFunctionCall(char const* functionName, size_t length,
                                     static_cast<int>(numExpectedArguments.second));
     }
 
-    if (!func->hasFlag(Function::Flags::CanReadDocuments)) {
-      // this also qualifies a query for potentially reading or modifying
-      // documents via function calls!
+    if (func->hasFlag(Function::Flags::CanReadDocuments)) {
+      // this also qualifies a query for potentially reading documents via function calls!
       _functionsMayAccessDocuments = true;
     }
   } else {
@@ -2138,7 +2137,7 @@ void Ast::validateAndOptimize(transaction::Methods& trx) {
     if (node->type == NODE_TYPE_FCALL) {
       auto func = static_cast<Function*>(node->getData());
 
-      if (ctx->hasSeenAnyWriteNode && !func->hasFlag(Function::Flags::CanReadDocuments)) {
+      if (ctx->hasSeenAnyWriteNode && func->hasFlag(Function::Flags::CanReadDocuments)) {
         // if canRunOnDBServer is true, then this is an indicator for a
         // document-accessing function
         std::string name("function ");

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -1531,7 +1531,7 @@ AstNode* Ast::createNodeFunctionCall(char const* functionName, size_t length,
                                     static_cast<int>(numExpectedArguments.second));
     }
 
-    if (!func->hasFlag(Function::Flags::CanRunOnDBServer)) {
+    if (!func->hasFlag(Function::Flags::CanReadDocuments)) {
       // this also qualifies a query for potentially reading or modifying
       // documents via function calls!
       _functionsMayAccessDocuments = true;
@@ -2138,7 +2138,7 @@ void Ast::validateAndOptimize(transaction::Methods& trx) {
     if (node->type == NODE_TYPE_FCALL) {
       auto func = static_cast<Function*>(node->getData());
 
-      if (ctx->hasSeenAnyWriteNode && !func->hasFlag(Function::Flags::CanRunOnDBServer)) {
+      if (ctx->hasSeenAnyWriteNode && !func->hasFlag(Function::Flags::CanReadDocuments)) {
         // if canRunOnDBServer is true, then this is an indicator for a
         // document-accessing function
         std::string name("function ");

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -2138,8 +2138,8 @@ void Ast::validateAndOptimize(transaction::Methods& trx) {
       auto func = static_cast<Function*>(node->getData());
 
       if (ctx->hasSeenAnyWriteNode && func->hasFlag(Function::Flags::CanReadDocuments)) {
-        // if canRunOnDBServer is true, then this is an indicator for a
-        // document-accessing function
+        // we have a document-reading function _after_ a modification/write
+        // operation. this is disallowed
         std::string name("function ");
         name.append(func->name);
         THROW_ARANGO_EXCEPTION_PARAMS(TRI_ERROR_QUERY_ACCESS_AFTER_MODIFICATION,

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -1611,7 +1611,8 @@ bool AstNode::willUseV8() const {
     auto func = static_cast<Function*>(getData());
     TRI_ASSERT(func != nullptr);
     
-    if (func->implementation == nullptr) {
+    if (func->hasV8Implementation()) {
+      TRI_ASSERT(!func->hasCxxImplementation());
       // a function without a C++ implementation
       setFlag(DETERMINED_V8, VALUE_V8);
       return true;
@@ -1749,7 +1750,7 @@ bool AstNode::isArrayComparisonOperator() const {
 
 /// @brief whether or not a node (and its subnodes) can safely be executed on
 /// a DB server
-bool AstNode::canRunOnDBServer() const {
+bool AstNode::canRunOnDBServer(bool isOneShard) const {
   if (hasFlag(DETERMINED_RUNONDBSERVER)) {
     // fast track exit
     return hasFlag(VALUE_RUNONDBSERVER);
@@ -1759,7 +1760,7 @@ bool AstNode::canRunOnDBServer() const {
   size_t const n = numMembers();
   for (size_t i = 0; i < n; ++i) {
     auto member = getMember(i);
-    if (!member->canRunOnDBServer()) {
+    if (!member->canRunOnDBServer(isOneShard)) {
       // if any sub-node cannot run on a DB server, we can't either
       setFlag(DETERMINED_RUNONDBSERVER);
       return false;
@@ -1770,7 +1771,8 @@ bool AstNode::canRunOnDBServer() const {
   if (type == NODE_TYPE_FCALL) {
     // built-in function
     auto func = static_cast<Function*>(getData());
-    if (func->hasFlag(Function::Flags::CanRunOnDBServer)) {
+    if ((isOneShard && func->hasFlag(Function::Flags::CanRunOnDBServerOneShard)) ||
+        (!isOneShard && func->hasFlag(Function::Flags::CanRunOnDBServerCluster))) {
       setFlag(DETERMINED_RUNONDBSERVER, VALUE_RUNONDBSERVER);
       return true;
     }

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -1771,6 +1771,12 @@ bool AstNode::canRunOnDBServer(bool isOneShard) const {
   if (type == NODE_TYPE_FCALL) {
     // built-in function
     auto func = static_cast<Function*>(getData());
+  
+    // currently being able to run on a DB server in cluster always includes being able to run
+    // on a DB server in OneShard mode. this may change at some point in the future.
+    TRI_ASSERT(!func->hasFlag(Function::Flags::CanRunOnDBServerCluster) || 
+               func->hasFlag(Function::Flags::CanRunOnDBServerOneShard));
+
     if ((isOneShard && func->hasFlag(Function::Flags::CanRunOnDBServerOneShard)) ||
         (!isOneShard && func->hasFlag(Function::Flags::CanRunOnDBServerCluster))) {
       setFlag(DETERMINED_RUNONDBSERVER, VALUE_RUNONDBSERVER);

--- a/arangod/Aql/AstNode.h
+++ b/arangod/Aql/AstNode.h
@@ -412,7 +412,7 @@ struct AstNode {
 
   /// @brief whether or not a node (and its subnodes) can safely be executed on
   /// a DB server
-  bool canRunOnDBServer() const;
+  bool canRunOnDBServer(bool isOneShard) const;
 
   /// @brief whether or not an object's keys must be checked for uniqueness
   bool mustCheckUniqueness() const;

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -1793,10 +1793,17 @@ void CalculationNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
             nodes.add("name", VPackValue(func->name));
             nodes.add("isDeterministic",
                       VPackValue(func->hasFlag(Function::Flags::Deterministic)));
-            nodes.add("canRunOnDBServer",
-                      VPackValue(func->hasFlag(Function::Flags::CanRunOnDBServer)));
+            nodes.add("canAccessDocuments", 
+                      VPackValue(func->hasFlag(Function::Flags::CanReadDocuments)));
+            nodes.add("canRunOnDBServerCluster",
+                      VPackValue(func->hasFlag(Function::Flags::CanRunOnDBServerCluster)));
+            nodes.add("canRunOnDBServerOneShard",
+                      VPackValue(func->hasFlag(Function::Flags::CanRunOnDBServerOneShard)));
             nodes.add("cacheable", VPackValue(func->hasFlag(Function::Flags::Cacheable)));
-            nodes.add("usesV8", VPackValue(func->implementation == nullptr));
+            nodes.add("usesV8", VPackValue(func->hasV8Implementation()));
+            // deprecated
+            nodes.add("canRunOnDBServer",
+                      VPackValue(func->hasFlag(Function::Flags::CanRunOnDBServerCluster)));
             nodes.close();
           }
         } else if (node->type == NODE_TYPE_FCALL_USER) {

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -802,7 +802,8 @@ AqlValue Expression::executeSimpleExpressionFCall(AstNode const* node,
   // only some functions have C++ handlers
   // check that the called function actually has one
   auto func = static_cast<Function*>(node->getData());
-  if (func->implementation != nullptr) {
+  TRI_ASSERT(func != nullptr);
+  if (func->hasCxxImplementation()) {
     return executeSimpleExpressionFCallCxx(node, trx, mustDestroy);
   }
   return executeSimpleExpressionFCallJS(node, trx, mustDestroy);
@@ -814,7 +815,8 @@ AqlValue Expression::executeSimpleExpressionFCallCxx(AstNode const* node,
                                                      bool& mustDestroy) {
   mustDestroy = false;
   auto func = static_cast<Function*>(node->getData());
-  TRI_ASSERT(func->implementation != nullptr);
+  TRI_ASSERT(func != nullptr);
+  TRI_ASSERT(func->hasCxxImplementation());
 
   auto member = node->getMemberUnchecked(0);
   TRI_ASSERT(member->type == NODE_TYPE_ARRAY);
@@ -979,6 +981,8 @@ AqlValue Expression::executeSimpleExpressionFCallJS(AstNode const* node,
     } else {
       // a call to a built-in V8 function
       auto func = static_cast<Function*>(node->getData());
+      TRI_ASSERT(func != nullptr);
+      TRI_ASSERT(func->hasV8Implementation());
       jsName = "AQL_" + func->name;
 
       for (size_t i = 0; i < n; ++i) {
@@ -1699,9 +1703,9 @@ AstNode* Expression::nodeForModification() const {
   return _node; 
 }
 
-bool Expression::canRunOnDBServer() {
+bool Expression::canRunOnDBServer(bool isOneShard) {
   TRI_ASSERT(_type != UNPROCESSED);
-  return (_type == JSON || _node->canRunOnDBServer());
+  return (_type == JSON || _node->canRunOnDBServer(isOneShard));
 }
 
 bool Expression::isDeterministic() {

--- a/arangod/Aql/Expression.h
+++ b/arangod/Aql/Expression.h
@@ -92,7 +92,7 @@ class Expression {
   AstNode* nodeForModification() const;
 
   /// @brief whether or not the expression can safely run on a DB server
-  bool canRunOnDBServer();
+  bool canRunOnDBServer(bool isOneShard);
 
   /// @brief whether or not the expression is deterministic
   bool isDeterministic();

--- a/arangod/Aql/Function.cpp
+++ b/arangod/Aql/Function.cpp
@@ -22,10 +22,15 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "Aql/Function.h"
+#include "Aql/Functions.h"
 #include "Basics/Exceptions.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
+
+#include <velocypack/Builder.h>
+#include <velocypack/Value.h>
+#include <velocypack/ValueType.h>
 
 using namespace arangodb::aql;
 
@@ -39,15 +44,20 @@ Function::Function(std::string const& name, char const* arguments,
       conversions() {
   initializeArguments();
 
-  // almost all AQL functions have a cxx implementation
-  // only function V8() plus the ArangoSearch functions do not
-  LOG_TOPIC("c70f6", TRACE, Logger::FIXME)
+  // almost all AQL functions have a cxx implementation, only function V8() does not have one.
+  LOG_TOPIC("c70f6", TRACE, Logger::AQL)
       << "registered AQL function '" << name
       << "'. cacheable: " << hasFlag(Flags::Cacheable)
       << ", deterministic: " << hasFlag(Flags::Deterministic)
-      << ", canRunOnDBServer: " << hasFlag(Flags::CanRunOnDBServer)
-      << ", hasCxxImplementation: " << (implementation != nullptr)
+      << ", canRunOnDBServerCluster: " << hasFlag(Flags::CanRunOnDBServerCluster)
+      << ", canRunOnDBServerOneShard: " << hasFlag(Flags::CanRunOnDBServerOneShard)
+      << ", canReadDocuments: " << hasFlag(Flags::CanReadDocuments)
+      << ", hasCxxImplementation: " << hasCxxImplementation()
       << ", hasConversions: " << !conversions.empty();
+
+  // currently being able to run on a DB server in cluster always includes being able to run
+  // on a DB server in OneShard mode. this may change at some point in the future.
+  TRI_ASSERT(!hasFlag(Flags::CanRunOnDBServerCluster) || hasFlag(Flags::CanRunOnDBServerOneShard));
 }
 
 /// @brief parse the argument list and set the minimum and maximum number of
@@ -145,12 +155,22 @@ void Function::initializeArguments() {
     }
   }
 }
+  
+/// @brief whether or not the function is built using V8
+bool Function::hasV8Implementation() const noexcept {
+  return implementation == nullptr;
+}
 
-std::underlying_type<Function::Flags>::type Function::makeFlags() {
+/// @brief whether or not the function is built using C++
+bool Function::hasCxxImplementation() const noexcept {
+  return implementation != nullptr;
+}
+
+std::underlying_type<Function::Flags>::type Function::makeFlags() noexcept {
   return static_cast<std::underlying_type<Flags>::type>(Flags::None);
 }
 
-bool Function::hasFlag(Function::Flags flag) const {
+bool Function::hasFlag(Function::Flags flag) const noexcept {
   return (flags & static_cast<std::underlying_type<Flags>::type>(flag)) != 0;
 }
 
@@ -163,4 +183,28 @@ Function::Conversion Function::getArgumentConversion(size_t position) const {
     return Conversion::None;
   }
   return conversions[position];
+}
+
+void Function::toVelocyPack(arangodb::velocypack::Builder& builder) const {
+  builder.openObject();
+  builder.add("name", velocypack::Value(name));
+  builder.add("arguments", velocypack::Value(arguments));
+  builder.add("implementations", velocypack::Value(velocypack::ValueType::Array));
+  if (hasV8Implementation()) {
+    builder.add(velocypack::Value("js"));
+  } 
+  if (hasCxxImplementation()) {
+    builder.add(velocypack::Value("cxx"));
+  }
+  builder.close();  // implementations
+  builder.add("deterministic", velocypack::Value(hasFlag(Flags::Deterministic)));
+  builder.add("cacheable", velocypack::Value(hasFlag(Flags::Cacheable)));
+  builder.add("canRunOnDBServerCluster", velocypack::Value(hasFlag(Flags::CanRunOnDBServerCluster)));
+  builder.add("canRunOnDBServerOneShard", velocypack::Value(hasFlag(Flags::CanRunOnDBServerOneShard)));
+  
+  // deprecated: only here for compatibility
+  builder.add("canRunOnDBServer", velocypack::Value(hasFlag(Flags::CanRunOnDBServerCluster)));
+  
+  builder.add("stub", velocypack::Value(implementation == &Functions::NotImplemented));
+  builder.close();
 }

--- a/arangod/Aql/Function.h
+++ b/arangod/Aql/Function.h
@@ -32,6 +32,10 @@
 #include <type_traits>
 
 namespace arangodb {
+namespace velocypack {
+class Builder;
+}
+
 namespace aql {
 
 struct Function {
@@ -50,31 +54,45 @@ struct Function {
     /// cache
     Cacheable = 2,
 
-    /// @brief whether or not the function may be executed on DB servers
-    CanRunOnDBServer = 4,
+    /// @brief whether or not the function may be executed on DB servers, 
+    /// general cluster case (non-OneShard)
+    CanRunOnDBServerCluster = 4,
+    
+    /// @brief whether or not the function may be executed on DB servers,
+    /// OneShard database
+    CanRunOnDBServerOneShard = 8,
+    
+    /// @brief whether or not the function may read documents from the database
+    CanReadDocuments = 16,
 
     /// @brief exclude the function from being evaluated during AST
     /// optimizations evaluation of function will only happen at query runtime
-    NoEval = 8
+    NoEval = 32,
   };
 
   /// @brief helper for building flags
   template <typename... Args>
-  static inline std::underlying_type<Flags>::type makeFlags(Flags flag, Args... args) {
+  static inline std::underlying_type<Flags>::type makeFlags(Flags flag, Args... args) noexcept {
     return static_cast<std::underlying_type<Flags>::type>(flag) + makeFlags(args...);
   }
 
-  static std::underlying_type<Flags>::type makeFlags();
+  static std::underlying_type<Flags>::type makeFlags() noexcept;
 
   Function() = delete;
 
   /// @brief create the function
   Function(std::string const& name, char const* arguments,
            std::underlying_type<Flags>::type flags,
-           FunctionImplementation implementation = nullptr);
+           FunctionImplementation implementation);
+
+  /// @brief whether or not the function is based on V8
+  bool hasV8Implementation() const noexcept;
+  
+  /// @brief whether or not the function is based on cxx
+  bool hasCxxImplementation() const noexcept;
 
   /// @brief return whether a specific flag is set for the function
-  bool hasFlag(Flags flag) const;
+  bool hasFlag(Flags flag) const noexcept;
 
   /// @brief return the number of required arguments
   std::pair<size_t, size_t> numArguments() const;
@@ -86,6 +104,8 @@ struct Function {
   /// @brief parse the argument list and set the minimum and maximum number of
   /// arguments
   void initializeArguments();
+
+  void toVelocyPack(arangodb::velocypack::Builder& builder) const;
 
   /// @brief function name (name visible to the end user, may be an alias)
   std::string name;

--- a/arangod/Aql/Function.h
+++ b/arangod/Aql/Function.h
@@ -54,12 +54,24 @@ struct Function {
     /// cache
     Cacheable = 2,
 
+    // the following two flags control separately if a function can be pushed
+    // down to DB servers for execution. In almost cases we want to have the
+    // "Cluster" flag set for functions that have the "OneShard" flag set,
+    // but this is currently only enforced via assertions - and we may want
+    // to change this in the future so we can have functions that are _not_
+    // pushed down to DB servers in OneShard mode but are in normal Cluster
+    // mode.
+
     /// @brief whether or not the function may be executed on DB servers, 
     /// general cluster case (non-OneShard)
+    /// note: in almost all circumstances it is also useful to set the flag
+    /// CanRunOnDBServerOneShard in addition!
     CanRunOnDBServerCluster = 4,
     
     /// @brief whether or not the function may be executed on DB servers,
-    /// OneShard database
+    /// OneShard databases. 
+    /// note: this flag must be set in addition to CanRunOnDBServerCluster
+    /// to make a function run on DB servers in OneShard mode! 
     CanRunOnDBServerOneShard = 8,
     
     /// @brief whether or not the function may read documents from the database

--- a/arangod/Aql/Function.h
+++ b/arangod/Aql/Function.h
@@ -73,7 +73,7 @@ struct Function {
   /// @brief helper for building flags
   template <typename... Args>
   static inline std::underlying_type<Flags>::type makeFlags(Flags flag, Args... args) noexcept {
-    return static_cast<std::underlying_type<Flags>::type>(flag) + makeFlags(args...);
+    return static_cast<std::underlying_type<Flags>::type>(flag) | makeFlags(args...);
   }
 
   static std::underlying_type<Flags>::type makeFlags() noexcept;

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -1121,7 +1121,7 @@ AqlValue callApplyBackend(ExpressionContext* expressionContext, transaction::Met
   if (ucInvokeFN.find("::") == std::string::npos) {
     // built-in C++ function
     func = AqlFunctionFeature::getFunctionByName(ucInvokeFN);
-    if (func->implementation != nullptr) {
+    if (func->hasCxxImplementation()) {
       std::pair<size_t, size_t> numExpectedArguments = func->numArguments();
 
       if (invokeParams.size() < numExpectedArguments.first ||
@@ -1135,6 +1135,9 @@ AqlValue callApplyBackend(ExpressionContext* expressionContext, transaction::Met
       return func->implementation(expressionContext, trx, invokeParams);
     }
   }
+
+  TRI_ASSERT(func != nullptr);
+  TRI_ASSERT(func->hasV8Implementation());
 
   // JavaScript function (this includes user-defined functions)
   {

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -1136,9 +1136,6 @@ AqlValue callApplyBackend(ExpressionContext* expressionContext, transaction::Met
     }
   }
 
-  TRI_ASSERT(func != nullptr);
-  TRI_ASSERT(func->hasV8Implementation());
-
   // JavaScript function (this includes user-defined functions)
   {
     ISOLATE;
@@ -1174,6 +1171,8 @@ AqlValue callApplyBackend(ExpressionContext* expressionContext, transaction::Met
       args[2] = TRI_V8_ASCII_STRING(isolate, AFN);
     } else {
       // a call to a built-in V8 function
+      TRI_ASSERT(func->hasV8Implementation());
+
       jsName = "AQL_" + func->name;
       for (int i = 0; i < n; ++i) {
         args[i] = invokeParams[i].toV8(isolate, options);

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -4679,9 +4679,10 @@ void arangodb::aql::distributeFilterCalcToClusterRule(Optimizer* opt,
         case EN::FILTER: {
           if (inspectNode->getType() == EN::CALCULATION) {
             // check if the expression can be executed on a DB server safely
+            TRI_vocbase_t& vocbase = plan->getAst()->query().vocbase();
             if (!ExecutionNode::castTo<CalculationNode const*>(inspectNode)
                      ->expression()
-                     ->canRunOnDBServer()) {
+                     ->canRunOnDBServer(vocbase.isOneShard())) {
               stopSearching = true;
               break;
             }
@@ -4903,7 +4904,8 @@ void arangodb::aql::removeUnnecessaryRemoteScatterRule(Optimizer* opt,
         if (node->getType() == EN::CALCULATION) {
           auto calc = ExecutionNode::castTo<CalculationNode const*>(node);
           // check if the expression can be executed on a DB server safely
-          if (!calc->expression()->canRunOnDBServer()) {
+          TRI_vocbase_t& vocbase = plan->getAst()->query().vocbase();
+          if (!calc->expression()->canRunOnDBServer(vocbase.isOneShard())) {
             canOptimize = false;
             break;
           }
@@ -5039,9 +5041,10 @@ void arangodb::aql::restrictToSingleShardRule(Optimizer* opt,
               }
 
               if (c->getType() == EN::CALCULATION) {
+                TRI_vocbase_t& vocbase = plan->getAst()->query().vocbase();
                 auto cn = ExecutionNode::castTo<CalculationNode const*>(c);
                 auto expr = cn->expression();
-                if (expr != nullptr && !expr->canRunOnDBServer()) {
+                if (expr != nullptr && !expr->canRunOnDBServer(vocbase.isOneShard())) {
                   // found something that must not run on a DB server,
                   // but that must run on a coordinator. stop optimization here!
                   toRemove.clear();
@@ -5290,12 +5293,13 @@ class RemoveToEnumCollFinder final : public WalkerWorker<ExecutionNode> {
         return false;  // continue . . .
       }
       case EN::CALCULATION: {
+        TRI_vocbase_t& vocbase = _plan->getAst()->query().vocbase();
         auto calculationNode = ExecutionNode::castTo<CalculationNode*>(en);
         auto expr = calculationNode->expression();
 
         // If we find an expression that is not allowed to run on a DBServer,
         // we cannot undistribute (as then the expression *would* run on a dbserver)
-        if (!expr->canRunOnDBServer()) {
+        if (!expr->canRunOnDBServer(vocbase.isOneShard())) {
           break;
         }
         return false;  // continue . . .
@@ -7524,9 +7528,10 @@ void arangodb::aql::moveFiltersIntoEnumerateRule(Optimizer* opt,
         continue;
       } else if (current->getType() == EN::CALCULATION) {
         // store all calculations we found
+        TRI_vocbase_t& vocbase = plan->getAst()->query().vocbase();
         auto calculationNode = ExecutionNode::castTo<CalculationNode*>(current);
         auto expr = calculationNode->expression();
-        if (!expr->isDeterministic() || !expr->canRunOnDBServer()) {
+        if (!expr->isDeterministic() || !expr->canRunOnDBServer(vocbase.isOneShard())) {
           break;
         }
 

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -666,7 +666,8 @@ void addFunctions(arangodb::aql::AqlFunctionFeature& functions) {
           // used to calculate values for constant expressions)
           arangodb::aql::Function::makeFlags(arangodb::aql::Function::Flags::Deterministic,
                                              arangodb::aql::Function::Flags::Cacheable,
-                                             arangodb::aql::Function::Flags::CanRunOnDBServer),
+                                             arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+                                             arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
           &aqlFnTokens  // function implementation
       });
 }
@@ -778,7 +779,7 @@ arangodb::Result visitAnalyzers(
     if (!coords.empty() &&
         !vocbase.isSystem() && // System database could be on other server so OneShard optimization will not work
         (vocbase.server().getFeature<arangodb::ClusterFeature>().forceOneShard() ||
-          vocbase.isShardingSingle())) {
+          vocbase.isOneShard())) {
       auto& clusterInfo = server.getFeature<arangodb::ClusterFeature>().clusterInfo();
       auto collection = clusterInfo.getCollectionNT(vocbase.name(), arangodb::StaticStrings::AnalyzersCollection);
       if (!collection) {

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -437,7 +437,8 @@ void registerFilters(arangodb::aql::AqlFunctionFeature& functions) {
   auto flags =
       arangodb::aql::Function::makeFlags(arangodb::aql::Function::Flags::Deterministic,
                                          arangodb::aql::Function::Flags::Cacheable,
-                                         arangodb::aql::Function::Flags::CanRunOnDBServer);
+                                         arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+                                         arangodb::aql::Function::Flags::CanRunOnDBServerOneShard);
   addFunction(functions, { "EXISTS", ".|.,.", flags, &dummyFilterFunc });  // (attribute, [ // "analyzer"|"type"|"string"|"numeric"|"bool"|"null" // ])
   addFunction(functions, { "STARTS_WITH", ".,.|.,.", flags, &startsWithFunc });  // (attribute, [ '[' ] prefix [, prefix, ... ']' ] [, scoring-limit|min-match-count ] [, scoring-limit ])
   addFunction(functions, { "PHRASE", ".,.|.+", flags, &dummyFilterFunc });  // (attribute, input [, offset, input... ] [, analyzer])
@@ -502,7 +503,8 @@ void registerScorers(arangodb::aql::AqlFunctionFeature& functions) {
             std::move(upperName), args.c_str(),
             arangodb::aql::Function::makeFlags(arangodb::aql::Function::Flags::Deterministic,
                                                arangodb::aql::Function::Flags::Cacheable,
-                                               arangodb::aql::Function::Flags::CanRunOnDBServer),
+                                               arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+                                               arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
             &dummyScorerFunc  // function implementation
         });
 

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1124,7 +1124,7 @@ Result RestReplicationHandler::processRestoreCollection(VPackSlice const& collec
     toMerge.add("id", VPackValue(newId));
 
     if (_vocbase.server().getFeature<ClusterFeature>().forceOneShard() ||
-        _vocbase.isShardingSingle()) {
+        _vocbase.isOneShard()) {
       auto const isSatellite =
           VelocyPackHelper::getStringRef(parameters, StaticStrings::ReplicationFactor,
                                          velocypack::StringRef{""}) == StaticStrings::Satellite;

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -358,7 +358,7 @@ Result Collections::create(TRI_vocbase_t& vocbase,
         // system-collections will be sharded normally. only user collections will get
         // the forced sharding
         if (vocbase.server().getFeature<ClusterFeature>().forceOneShard() ||
-            vocbase.isShardingSingle()) {
+            vocbase.isOneShard()) {
           auto const isSatellite =
               Helper::getStringRef(info.properties, StaticStrings::ReplicationFactor,
                                    velocypack::StringRef{""}) == StaticStrings::Satellite;

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -1690,7 +1690,7 @@ std::string const& TRI_vocbase_t::sharding() const {
   return _info.sharding();
 }
 
-bool TRI_vocbase_t::isShardingSingle() const {
+bool TRI_vocbase_t::isOneShard() const {
   return _info.sharding() == StaticStrings::ShardingSingle;
 }
 

--- a/arangod/VocBase/vocbase.h
+++ b/arangod/VocBase/vocbase.h
@@ -189,7 +189,7 @@ struct TRI_vocbase_t {
   std::uint32_t replicationFactor() const;
   std::uint32_t writeConcern() const;
   std::string const& sharding() const;
-  bool isShardingSingle() const;
+  bool isOneShard() const;
   TRI_vocbase_type_e type() const { return _type; }
 
   void toVelocyPack(arangodb::velocypack::Builder& result) const;

--- a/tests/IResearch/ExpressionFilter-test.cpp
+++ b/tests/IResearch/ExpressionFilter-test.cpp
@@ -300,7 +300,8 @@ struct IResearchExpressionFilterTest
         "_REFERENCE_", ".",
         arangodb::aql::Function::makeFlags(
             // fake non-deterministic
-            arangodb::aql::Function::Flags::CanRunOnDBServer),
+            arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+            arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
         [](arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*,
            arangodb::aql::VPackFunctionParameters const& params) {
           TRI_ASSERT(!params.empty());

--- a/tests/IResearch/IResearchFilterArrayIn-test.cpp
+++ b/tests/IResearch/IResearchFilterArrayIn-test.cpp
@@ -101,7 +101,8 @@ class IResearchFilterArrayInTest
         "_NONDETERM_", ".",
         arangodb::aql::Function::makeFlags(
             // fake non-deterministic
-            arangodb::aql::Function::Flags::CanRunOnDBServer),
+            arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+            arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
         [](arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*,
            arangodb::aql::VPackFunctionParameters const& params) {
           TRI_ASSERT(!params.empty());
@@ -114,7 +115,8 @@ class IResearchFilterArrayInTest
         arangodb::aql::Function::makeFlags(
             // fake deterministic
             arangodb::aql::Function::Flags::Deterministic, arangodb::aql::Function::Flags::Cacheable,
-            arangodb::aql::Function::Flags::CanRunOnDBServer),
+            arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+            arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
         [](arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*,
            arangodb::aql::VPackFunctionParameters const& params) {
           TRI_ASSERT(!params.empty());

--- a/tests/IResearch/IResearchFilterArrayInterval-test.cpp
+++ b/tests/IResearch/IResearchFilterArrayInterval-test.cpp
@@ -100,7 +100,8 @@ class IResearchFilterArrayIntervalTest
         "_NONDETERM_", ".",
         arangodb::aql::Function::makeFlags(
             // fake non-deterministic
-            arangodb::aql::Function::Flags::CanRunOnDBServer),
+            arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+            arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
         [](arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*,
            arangodb::aql::VPackFunctionParameters const& params) {
           TRI_ASSERT(!params.empty());
@@ -113,7 +114,8 @@ class IResearchFilterArrayIntervalTest
         arangodb::aql::Function::makeFlags(
             // fake deterministic
             arangodb::aql::Function::Flags::Deterministic, arangodb::aql::Function::Flags::Cacheable,
-            arangodb::aql::Function::Flags::CanRunOnDBServer),
+            arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+            arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
         [](arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*,
            arangodb::aql::VPackFunctionParameters const& params) {
           TRI_ASSERT(!params.empty());

--- a/tests/IResearch/IResearchFilterBoolean-test.cpp
+++ b/tests/IResearch/IResearchFilterBoolean-test.cpp
@@ -103,7 +103,8 @@ class IResearchFilterBooleanTest
         "_NONDETERM_", ".",
         arangodb::aql::Function::makeFlags(
             // fake non-deterministic
-            arangodb::aql::Function::Flags::CanRunOnDBServer),
+            arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+            arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
         [](arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*,
            arangodb::aql::VPackFunctionParameters const& params) {
           TRI_ASSERT(!params.empty());
@@ -116,7 +117,8 @@ class IResearchFilterBooleanTest
         arangodb::aql::Function::makeFlags(
             // fake deterministic
             arangodb::aql::Function::Flags::Deterministic, arangodb::aql::Function::Flags::Cacheable,
-            arangodb::aql::Function::Flags::CanRunOnDBServer),
+            arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+            arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
         [](arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*,
            arangodb::aql::VPackFunctionParameters const& params) {
           TRI_ASSERT(!params.empty());

--- a/tests/IResearch/IResearchFilterCompare-test.cpp
+++ b/tests/IResearch/IResearchFilterCompare-test.cpp
@@ -103,7 +103,8 @@ class IResearchFilterCompareTest
         "_NONDETERM_", ".",
         arangodb::aql::Function::makeFlags(
             // fake non-deterministic
-            arangodb::aql::Function::Flags::CanRunOnDBServer),
+            arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+            arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
         [](arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*,
            arangodb::aql::VPackFunctionParameters const& params) {
           TRI_ASSERT(!params.empty());
@@ -116,7 +117,8 @@ class IResearchFilterCompareTest
         arangodb::aql::Function::makeFlags(
             // fake deterministic
             arangodb::aql::Function::Flags::Deterministic, arangodb::aql::Function::Flags::Cacheable,
-            arangodb::aql::Function::Flags::CanRunOnDBServer),
+            arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+            arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
         [](arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*,
            arangodb::aql::VPackFunctionParameters const& params) {
           TRI_ASSERT(!params.empty());

--- a/tests/IResearch/IResearchFilterFunction-test.cpp
+++ b/tests/IResearch/IResearchFilterFunction-test.cpp
@@ -105,7 +105,8 @@ class IResearchFilterFunctionTest
         "_NONDETERM_", ".",
         arangodb::aql::Function::makeFlags(
             // fake non-deterministic
-            arangodb::aql::Function::Flags::CanRunOnDBServer),
+            arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+            arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
         [](arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*,
            arangodb::aql::VPackFunctionParameters const& params) {
           TRI_ASSERT(!params.empty());
@@ -118,7 +119,8 @@ class IResearchFilterFunctionTest
         arangodb::aql::Function::makeFlags(
             // fake deterministic
             arangodb::aql::Function::Flags::Deterministic, arangodb::aql::Function::Flags::Cacheable,
-            arangodb::aql::Function::Flags::CanRunOnDBServer),
+            arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+            arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
         [](arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*,
            arangodb::aql::VPackFunctionParameters const& params) {
           TRI_ASSERT(!params.empty());

--- a/tests/IResearch/IResearchFilterIn-test.cpp
+++ b/tests/IResearch/IResearchFilterIn-test.cpp
@@ -103,7 +103,8 @@ class IResearchFilterInTest
         "_NONDETERM_", ".",
         arangodb::aql::Function::makeFlags(
             // fake non-deterministic
-            arangodb::aql::Function::Flags::CanRunOnDBServer),
+            arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+            arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
         [](arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*,
            arangodb::aql::VPackFunctionParameters const& params) {
           TRI_ASSERT(!params.empty());
@@ -116,7 +117,8 @@ class IResearchFilterInTest
         arangodb::aql::Function::makeFlags(
             // fake deterministic
             arangodb::aql::Function::Flags::Deterministic, arangodb::aql::Function::Flags::Cacheable,
-            arangodb::aql::Function::Flags::CanRunOnDBServer),
+            arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+            arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
         [](arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*,
            arangodb::aql::VPackFunctionParameters const& params) {
           TRI_ASSERT(!params.empty());

--- a/tests/IResearch/IResearchOrder-test.cpp
+++ b/tests/IResearch/IResearchOrder-test.cpp
@@ -247,8 +247,9 @@ class IResearchOrderTest
     auto& functions = server.getFeature<arangodb::aql::AqlFunctionFeature>();
     arangodb::aql::Function invalid("INVALID", "|.",
                                     arangodb::aql::Function::makeFlags(
-                                        arangodb::aql::Function::Flags::CanRunOnDBServer));
-
+                                        arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+                                        arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
+                                    nullptr);
     functions.add(invalid);
   }
 

--- a/tests/IResearch/IResearchQueryCommon.h
+++ b/tests/IResearch/IResearchQueryCommon.h
@@ -117,7 +117,8 @@ class IResearchQueryTest
         "_NONDETERM_", ".",
         arangodb::aql::Function::makeFlags(
             // fake non-deterministic
-            arangodb::aql::Function::Flags::CanRunOnDBServer),
+            arangodb::aql::Function::Flags::CanRunOnDBServerCluster, 
+            arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
         [](arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*,
            arangodb::aql::VPackFunctionParameters const& params) {
           TRI_ASSERT(!params.empty());
@@ -130,7 +131,8 @@ class IResearchQueryTest
         arangodb::aql::Function::makeFlags(
             // fake deterministic
             arangodb::aql::Function::Flags::Deterministic, arangodb::aql::Function::Flags::Cacheable,
-            arangodb::aql::Function::Flags::CanRunOnDBServer),
+            arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+            arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
         [](arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*,
            arangodb::aql::VPackFunctionParameters const& params) {
           TRI_ASSERT(!params.empty());
@@ -144,7 +146,9 @@ class IResearchQueryTest
         "CUSTOMSCORER", ".|+",
         arangodb::aql::Function::makeFlags(arangodb::aql::Function::Flags::Deterministic,
                                            arangodb::aql::Function::Flags::Cacheable,
-                                           arangodb::aql::Function::Flags::CanRunOnDBServer));
+                                           arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+                                           arangodb::aql::Function::Flags::CanRunOnDBServerOneShard), 
+        nullptr);
     arangodb::iresearch::addFunction(functions, customScorer);
 
     auto& dbPathFeature = server.getFeature<arangodb::DatabasePathFeature>();

--- a/tests/IResearch/IResearchViewSorted-test.cpp
+++ b/tests/IResearch/IResearchViewSorted-test.cpp
@@ -99,7 +99,8 @@ class IResearchViewSortedTest
         "_NONDETERM_", ".",
         arangodb::aql::Function::makeFlags(
             // fake non-deterministic
-            arangodb::aql::Function::Flags::CanRunOnDBServer),
+            arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+            arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
         [](arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*,
            arangodb::aql::VPackFunctionParameters const& params) {
           TRI_ASSERT(!params.empty());
@@ -112,7 +113,8 @@ class IResearchViewSortedTest
         arangodb::aql::Function::makeFlags(
             // fake deterministic
             arangodb::aql::Function::Flags::Deterministic, arangodb::aql::Function::Flags::Cacheable,
-            arangodb::aql::Function::Flags::CanRunOnDBServer),
+            arangodb::aql::Function::Flags::CanRunOnDBServerCluster,
+            arangodb::aql::Function::Flags::CanRunOnDBServerOneShard),
         [](arangodb::aql::ExpressionContext*, arangodb::transaction::Methods*,
            arangodb::aql::VPackFunctionParameters const& params) {
           TRI_ASSERT(!params.empty());

--- a/tests/js/server/aql/aql-modify-noncluster.js
+++ b/tests/js/server/aql/aql-modify-noncluster.js
@@ -734,7 +734,7 @@ function ahuacatlModifySuite () {
       var queries = [
         "UPSERT { } INSERT { } UPDATE { } INTO @@cn RETURN DOCUMENT('foo')", 
         "UPSERT { } INSERT { } UPDATE { } INTO @@cn RETURN PASSTHRU(DOCUMENT('foo'))", 
-        "UPSERT { } INSERT { } UPDATE { } INTO @@cn RETURN COLLECTIONS()", 
+        "UPSERT { } INSERT { } UPDATE { } INTO @@cn RETURN COLLECTION_COUNT(@@cn)", 
         "UPSERT { } INSERT { } UPDATE { } INTO @@cn RETURN UNIQUE(@@cn)"
       ];
 


### PR DESCRIPTION
### Scope & Purpose

This PR makes AQL queries that use the DOCUMENT AQL function eligible for being pushed down to DB servers for execution.
Previously, this was not the case, as DOCUMENT was not marked with the `CanRunOnDBServer` flag. 
It still isn't, but now there is an extra flag `CanRunOnDBServerOneShard`, which is checked for OneShard databases. The existing `CanRunOnDBServer` flag has been renamed to `CanRunOnDBServerCluster`.

There is also an enterprise part for this PR, which contains tests: https://github.com/arangodb/enterprise/pull/583

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.7

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/572/files
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/583

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_server)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12662/