### PR TITLE
decouple metrics provisioning from server.statistics-history option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 devel
 -----
 
+* Enable HTTP request statistics and provide metrics even in case 
+  `--server.statistics-history` is set to `false` (this option will set
+  itself to off automatically on agency instances on startup if not
+  explicitly set).
+  This change provides more metrics on all server instances, without the
+  need to persist them in the instance's RocksDB storage engine. 
+
 * Fixed a deadlock between AQL write transactions and hotbackup, since
   in AQL write transactions follower transactions did not know they are
   follower transactions.

--- a/arangod/RestHandler/RestAdminStatisticsHandler.cpp
+++ b/arangod/RestHandler/RestAdminStatisticsHandler.cpp
@@ -74,38 +74,39 @@ RestStatus RestAdminStatisticsHandler::execute() {
 }
 
 void RestAdminStatisticsHandler::getStatistics() {
-  stats::Descriptions const* desc = StatisticsFeature::descriptions();
-  if (!desc) {
+  StatisticsFeature& feature = server().getFeature<StatisticsFeature>();
+  if (!feature.isEnabled()) {
     generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_DISABLED,
                   "statistics not enabled");
     return;
   }
+  stats::Descriptions const& desc = feature.descriptions();
 
   VPackBuffer<uint8_t> buffer;
   VPackBuilder tmp(buffer);
   tmp.add(VPackValue(VPackValueType::Object, true));
 
   tmp.add("time", VPackValue(TRI_microtime()));
-  tmp.add("enabled", VPackValue(StatisticsFeature::enabled()));
+  tmp.add("enabled", VPackValue(true));
 
   tmp.add("system", VPackValue(VPackValueType::Object, true));
-  desc->processStatistics(tmp);
+  desc.processStatistics(tmp);
   tmp.close();  // system
 
   tmp.add("client", VPackValue(VPackValueType::Object, true));
-  desc->clientStatistics(tmp, stats::RequestStatisticsSource::ALL);
+  desc.clientStatistics(tmp, stats::RequestStatisticsSource::ALL);
   tmp.close();  // client
 
   tmp.add("clientUser", VPackValue(VPackValueType::Object, true));
-  desc->clientStatistics(tmp, stats::RequestStatisticsSource::USER);
+  desc.clientStatistics(tmp, stats::RequestStatisticsSource::USER);
   tmp.close();  // clientUser
 
   tmp.add("http", VPackValue(VPackValueType::Object, true));
-  desc->httpStatistics(tmp);
+  desc.httpStatistics(tmp);
   tmp.close();  // http
 
   tmp.add("server", VPackValue(VPackValueType::Object, true));
-  desc->serverStatistics(tmp);
+  desc.serverStatistics(tmp);
   tmp.close();  // server
 
   tmp.add(StaticStrings::Error, VPackValue(false));
@@ -115,19 +116,20 @@ void RestAdminStatisticsHandler::getStatistics() {
 }
 
 void RestAdminStatisticsHandler::getStatisticsDescription() {
-  stats::Descriptions const* desc = StatisticsFeature::descriptions();
-  if (!desc) {
+  StatisticsFeature& feature = server().getFeature<StatisticsFeature>();
+  if (!feature.isEnabled()) {
     generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_DISABLED,
                   "statistics not enabled");
     return;
   }
+  stats::Descriptions const& desc = feature.descriptions();
 
   VPackBuffer<uint8_t> buffer;
   VPackBuilder tmp(buffer);
   tmp.add(VPackValue(VPackValueType::Object));
 
   tmp.add("groups", VPackValue(VPackValueType::Array, true));
-  for (stats::Group const& group : desc->groups()) {
+  for (stats::Group const& group : desc.groups()) {
     tmp.openObject();
     group.toVPack(tmp);
     tmp.close();
@@ -135,7 +137,7 @@ void RestAdminStatisticsHandler::getStatisticsDescription() {
   tmp.close();  // groups
 
   tmp.add("figures", VPackValue(VPackValueType::Array, true));
-  for (stats::Figure const& figure : desc->figures()) {
+  for (stats::Figure const& figure : desc.figures()) {
     tmp.openObject();
     figure.toVPack(tmp);
     tmp.close();

--- a/arangod/RestServer/MetricsFeature.cpp
+++ b/arangod/RestServer/MetricsFeature.cpp
@@ -87,10 +87,8 @@ void MetricsFeature::toPrometheus(std::string& result) const {
 
   // StatisticsFeature
   auto& sf = server().getFeature<StatisticsFeature>();
-  if (sf.enabled()) {
-    sf.toPrometheus(result, std::chrono::duration<double,std::milli>(
-                      std::chrono::system_clock::now().time_since_epoch()).count());
-  }
+  sf.toPrometheus(result, std::chrono::duration<double,std::milli>(
+                    std::chrono::system_clock::now().time_since_epoch()).count());
 
   // RocksDBEngine
   auto& es = server().getFeature<EngineSelectorFeature>().engine();

--- a/arangod/Statistics/ConnectionStatistics.cpp
+++ b/arangod/Statistics/ConnectionStatistics.cpp
@@ -64,7 +64,7 @@ void ConnectionStatistics::initialize() {
 ConnectionStatistics::Item ConnectionStatistics::acquire() {
   ConnectionStatistics* statistics = nullptr;
 
-  if (StatisticsFeature::enabled() && _freeList.pop(statistics)) {
+  if (_freeList.pop(statistics)) {
     return Item{ statistics };
   }
 
@@ -72,11 +72,6 @@ ConnectionStatistics::Item ConnectionStatistics::acquire() {
 }
 
 void ConnectionStatistics::getSnapshot(Snapshot& snapshot) {
-  if (!StatisticsFeature::enabled()) {
-    // all the below objects may be deleted if we don't have statistics enabled
-    return;
-  }
-
   snapshot.httpConnections = statistics::HttpConnections;
   snapshot.totalRequests = statistics::TotalRequests;
   snapshot.totalRequestsSuperuser = statistics::TotalRequestsSuperuser;

--- a/arangod/Statistics/RequestStatistics.cpp
+++ b/arangod/Statistics/RequestStatistics.cpp
@@ -79,10 +79,6 @@ size_t RequestStatistics::processAll() {
 }
 
 RequestStatistics::Item RequestStatistics::acquire() {
-  if (!StatisticsFeature::enabled()) {
-    return Item{};
-  }
-
   RequestStatistics* statistics = nullptr;
 
   if (_freeList.pop(statistics)) {
@@ -189,11 +185,6 @@ void RequestStatistics::release() {
 }
 
 void RequestStatistics::getSnapshot(Snapshot& snapshot, stats::RequestStatisticsSource source) {
-  if (!StatisticsFeature::enabled()) {
-    // all the below objects may be deleted if we don't have statistics enabled
-    return;
-  }
-
   statistics::RequestFigures& figures = source == stats::RequestStatisticsSource::USER
     ? statistics::UserRequestFigures
     : statistics::SuperuserRequestFigures;

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -24,7 +24,9 @@
 #include "StatisticsFeature.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Basics/PhysicalMemory.h"
 #include "Basics/application-exit.h"
+#include "Basics/process-utils.h"
 #include "Cluster/ServerState.h"
 #include "FeaturePhases/AqlFeaturePhase.h"
 #include "Logger/LogMacros.h"
@@ -40,15 +42,20 @@
 #include "Statistics/RequestStatistics.h"
 #include "Statistics/ServerStatistics.h"
 #include "Statistics/StatisticsWorker.h"
+#include "V8Server/V8DealerFeature.h"
 #include "VocBase/vocbase.h"
 
+#include <initializer_list>
 #include <chrono>
 #include <thread>
+
+#include <velocypack/Builder.h>
 
 using namespace arangodb;
 using namespace arangodb::application_features;
 using namespace arangodb::basics;
 using namespace arangodb::options;
+using namespace arangodb::statistics;
 
 // -----------------------------------------------------------------------------
 // --SECTION--                                                  global variables
@@ -56,6 +63,160 @@ using namespace arangodb::options;
 
 namespace arangodb {
 namespace statistics {
+
+// local_name: {"prometheus_name", "type", "help"}
+std::map<std::string, std::vector<std::string>> statStrings{
+  {"bytesReceived",
+   {"arangodb_client_connection_statistics_bytes_received_bucket", "gauge",
+    "Bytes received for a request"}},
+  {"bytesReceivedCount",
+   {"arangodb_client_connection_statistics_bytes_received_count", "gauge",
+    "Bytes received for a request"}},
+  {"bytesReceivedSum",
+   {"arangodb_client_connection_statistics_bytes_received_sum", "gauge",
+    "Bytes received for a request"}},
+  {"bytesSent",
+   {"arangodb_client_connection_statistics_bytes_sent_bucket", "gauge",
+    "Bytes sent for a request"}},
+  {"bytesSentCount",
+   {"arangodb_client_connection_statistics_bytes_sent_count", "gauge",
+    "Bytes sent for a request"}},
+  {"bytesSentSum",
+   {"arangodb_client_connection_statistics_bytes_sent_sum", "gauge",
+    "Bytes sent for a request"}},
+  {"minorPageFaults",
+   {"arangodb_process_statistics_minor_page_faults", "gauge",
+    "The number of minor faults the process has made which have not required loading a memory page from disk. This figure is not reported on Windows"}},
+  {"majorPageFaults",
+   {"arangodb_process_statistics_major_page_faults", "gauge",
+    "On Windows, this figure contains the total number of page faults. On other system, this figure contains the number of major faults the process has made which have required loading a memory page from disk"}},
+  {"bytesReceived",
+   {"arangodb_client_connection_statistics_bytes_received_bucket", "gauge",
+    "Bytes received for a request"}},
+  {"userTime",
+   {"arangodb_process_statistics_user_time", "gauge",
+    "Amount of time that this process has been scheduled in user mode, measured in seconds"}},
+  {"systemTime",
+   {"arangodb_process_statistics_system_time", "gauge",
+    "Amount of time that this process has been scheduled in kernel mode, measured in seconds"}},
+  {"numberOfThreads",
+   {"arangodb_process_statistics_number_of_threads", "gauge",
+    "Number of threads in the arangod process"}},
+  {"residentSize",
+   {"arangodb_process_statistics_resident_set_size", "gauge", "The total size of the number of pages the process has in real memory. This is just the pages which count toward text, data, or stack space. This does not include pages which have not been demand-loaded in, or which are swapped out. The resident set size is reported in bytes"}},
+  {"residentSizePercent",
+   {"arangodb_process_statistics_resident_set_size_percent", "gauge", "The relative size of the number of pages the process has in real memory compared to system memory. This is just the pages which count toward text, data, or stack space. This does not include pages which have not been demand-loaded in, or which are swapped out. The value is a ratio between 0.00 and 1.00"}},
+  {"virtualSize",
+   {"arangodb_process_statistics_virtual_memory_size", "gauge", "On Windows, this figure contains the total amount of memory that the memory manager has committed for the arangod process. On other systems, this figure contains The size of the virtual memory the process is using"}},
+  {"clientHttpConnections",
+   {"arangodb_client_connection_statistics_client_connections", "gauge",
+    "The number of client connections that are currently open"}},
+  {"connectionTime",
+   {"arangodb_client_connection_statistics_connection_time_bucket", "gauge",
+    "Total connection time of a client"}},
+  {"connectionTimeCount",
+   {"arangodb_client_connection_statistics_connection_time_count", "gauge",
+    "Total connection time of a client"}},
+  {"connectionTimeSum",
+   {"arangodb_client_connection_statistics_connection_time_sum", "gauge",
+    "Total connection time of a client"}},
+  {"totalTime",
+   {"arangodb_client_connection_statistics_total_time_bucket", "gauge",
+    "Total time needed to answer a request"}},
+  {"totalTimeCount",
+   {"arangodb_client_connection_statistics_total_time_count", "gauge",
+    "Total time needed to answer a request"}},
+  {"totalTimeSum",
+   {"arangodb_client_connection_statistics_total_time_sum", "gauge",
+    "Total time needed to answer a request"}},
+  {"requestTime",
+   {"arangodb_client_connection_statistics_request_time_bucket", "gauge",
+    "Request time needed to answer a request"}},
+  {"requestTimeCount",
+   {"arangodb_client_connection_statistics_request_time_count", "gauge",
+    "Request time needed to answer a request"}},
+  {"requestTimeSum",
+   {"arangodb_client_connection_statistics_request_time_sum", "gauge",
+    "Request time needed to answer a request"}},
+  {"queueTime",
+   {"arangodb_client_connection_statistics_queue_time_bucket", "gauge",
+    "Request time needed to answer a request"}},
+  {"queueTimeCount",
+   {"arangodb_client_connection_statistics_queue_time_count", "gauge",
+    "Request time needed to answer a request"}},
+  {"queueTimeSum",
+   {"arangodb_client_connection_statistics_queue_time_sum", "gauge",
+    "Request time needed to answer a request"}},
+  {"ioTime",
+   {"arangodb_client_connection_statistics_io_time_bucket", "gauge",
+    "Request time needed to answer a request"}},
+  {"ioTimeCount",
+   {"arangodb_client_connection_statistics_io_time_count", "gauge",
+    "Request time needed to answer a request"}},
+  {"ioTimeSum",
+   {"arangodb_client_connection_statistics_io_time_sum", "gauge",
+    "Request time needed to answer a request"}},
+  {"httpReqsTotal",
+   {"arangodb_http_request_statistics_total_requests", "gauge",
+    "Total number of HTTP requests"}},
+  {"httpReqsSuperuser",
+   {"arangodb_http_request_statistics_superuser_requests", "gauge",
+    "Total number of HTTP requests executed by superuser/JWT"}},
+  {"httpReqsUser",
+   {"arangodb_http_request_statistics_user_requests", "gauge",
+    "Total number of HTTP requests executed by clients"}},
+  {"httpReqsAsync",
+   {"arangodb_http_request_statistics_async_requests", "gauge",
+    "Number of asynchronously executed HTTP requests"}},
+  {"httpReqsDelete",
+   {"arangodb_http_request_statistics_http_delete_requests", "gauge",
+    "Number of HTTP DELETE requests"}},
+  {"httpReqsGet",
+   {"arangodb_http_request_statistics_http_get_requests", "gauge",
+    "Number of HTTP GET requests"}},
+  {"httpReqsHead",
+   {"arangodb_http_request_statistics_http_head_requests", "gauge",
+    "Number of HTTP HEAD requests"}},
+  {"httpReqsOptions",
+   {"arangodb_http_request_statistics_http_options_requests", "gauge",
+    "Number of HTTP OPTIONS requests"}},
+  {"httpReqsPatch",
+   {"arangodb_http_request_statistics_http_patch_requests", "gauge",
+    "Number of HTTP PATCH requests"}},
+  {"httpReqsPost",
+   {"arangodb_http_request_statistics_http_post_requests", "gauge",
+    "Number of HTTP POST requests"}},
+  {"httpReqsPut",
+   {"arangodb_http_request_statistics_http_put_requests", "gauge",
+    "Number of HTTP PUT requests"}},
+  {"httpReqsOther",
+   {"arangodb_http_request_statistics_other_http_requests", "gauge",
+    "Number of other HTTP requests"}},
+  {"uptime",
+   {"arangodb_server_statistics_server_uptime", "gauge",
+    "Number of seconds elapsed since server start"}},
+  {"physicalSize",
+   {"arangodb_server_statistics_physical_memory", "gauge",
+    "Physical memory in bytes"}},
+  {"v8ContextAvailable",
+   {"arangodb_v8_context_alive", "gauge",
+    "Number of V8 contexts currently alive"}},
+  {"v8ContextBusy",
+   {"arangodb_v8_context_busy", "gauge",
+    "Number of V8 contexts currently busy"}},
+  {"v8ContextDirty",
+   {"arangodb_v8_context_dirty", "gauge",
+    "Number of V8 contexts currently dirty"}},
+  {"v8ContextFree",
+   {"arangodb_v8_context_free", "gauge",
+    "Number of V8 contexts currently free"}},
+  {"v8ContextMax",
+   {"arangodb_v8_context_max", "gauge",
+    "Maximum number of concurrent V8 contexts"}},
+  {"v8ContextMin",
+   {"arangodb_v8_context_min", "gauge",
+    "Minimum number of concurrent V8 contexts"}},
+};
 
 std::initializer_list<double> const BytesReceivedDistributionCuts{250, 1000, 2000, 5000, 10000};
 std::initializer_list<double> const BytesSentDistributionCuts{250, 1000, 2000, 5000, 10000};
@@ -106,7 +267,7 @@ class StatisticsThread final : public Thread {
     uint64_t sleepTime = 100;
     int nothingHappened = 0;
 
-    while (!isStopping() && StatisticsFeature::enabled()) {
+    while (!isStopping()) {
       size_t count = RequestStatistics::processAll();
 
       if (count == 0) {
@@ -139,14 +300,12 @@ class StatisticsThread final : public Thread {
 // --SECTION--                                                 StatisticsFeature
 // -----------------------------------------------------------------------------
 
-StatisticsFeature* StatisticsFeature::STATISTICS = nullptr;
-
 StatisticsFeature::StatisticsFeature(application_features::ApplicationServer& server)
     : ApplicationFeature(server, "Statistics"),
       _statistics(true),
       _statisticsHistory(true),
       _statisticsHistoryTouched(false),
-      _descriptions(new stats::Descriptions(server)) {
+      _descriptions(server) {
   setOptional(true);
   startsAfter<AqlFeaturePhase>();
 }
@@ -177,14 +336,10 @@ void StatisticsFeature::validateOptions(std::shared_ptr<ProgramOptions> options)
   }
 
   _statisticsHistoryTouched = options->processingResult().touched("--server.statistics-history");
-
 }
 
 void StatisticsFeature::prepare() {
   // initialize counters for all HTTP request types
-
-  STATISTICS = this;
-
   ConnectionStatistics::initialize();
   RequestStatistics::initialize();
 }
@@ -218,7 +373,7 @@ void StatisticsFeature::start() {
   // force history disable on Agents
   if (arangodb::ServerState::instance()->isAgent() && !_statisticsHistoryTouched) {
     _statisticsHistory = false;
-  } // if
+  } 
 
   if (_statisticsHistory) {
     _statisticsWorker.reset(new StatisticsWorker(*vocbase));
@@ -250,12 +405,137 @@ void StatisticsFeature::stop() {
 
   _statisticsThread.reset();
   _statisticsWorker.reset();
+}
 
-  STATISTICS = nullptr;
+VPackBuilder StatisticsFeature::fillDistribution(statistics::Distribution const& dist) {
+  VPackBuilder builder;
+  builder.openObject();
+
+  builder.add("sum", VPackValue(dist._total));
+  builder.add("count", VPackValue(dist._count));
+
+  builder.add("counts", VPackValue(VPackValueType::Array));
+  for (auto const& val : dist._counts) {
+    builder.add(VPackValue(val));
+  }
+  builder.close();
+
+  builder.close();
+
+  return builder;
+}
+
+void StatisticsFeature::appendHistogram(
+  std::string& result, statistics::Distribution const& dist,
+  std::string const& label, std::initializer_list<std::string> const& les) {
+
+  auto const countLabel = label + "Count";
+  auto const countSum = label + "Sum";
+  VPackBuilder tmp = fillDistribution(dist);
+  VPackSlice slc = tmp.slice();
+  VPackSlice counts = slc.get("counts");
+  
+  auto const& stat = statStrings.at(label); 
+  std::string const& name = stat.at(0);
+
+  result +=
+    "\n#TYPE " + name + " " + stat[1] + 
+    "\n#HELP " + name + " " + stat[2] + '\n';
+
+  TRI_ASSERT(les.size() == counts.length());
+  size_t i = 0;
+  for (auto const& le : les) {
+    result +=
+      name + "{le=\"" + le + "\"}"  + " " +
+      std::to_string(counts.at(i++).getNumber<uint64_t>()) + '\n';
+  }
+}
+
+void StatisticsFeature::appendMetric(std::string& result, std::string const& val, std::string const& label) {
+  auto const& stat = statStrings.at(label); 
+  std::string const& name = stat.at(0);
+
+  result +=
+    "\n#TYPE " + name + " " + stat[1] +
+    "\n#HELP " + name + " " + stat[2] + 
+    '\n' + name + " " + val + '\n';
 }
 
 void StatisticsFeature::toPrometheus(std::string& result, double const& now) {
-  if (_statisticsWorker != nullptr) {
-    _statisticsWorker->generateRawStatistics(result, now);
+  ProcessInfo info = TRI_ProcessInfoSelf();
+  uint64_t rss = static_cast<uint64_t>(info._residentSize);
+  double rssp = 0;
+
+  if (PhysicalMemory::getValue() != 0) {
+    rssp = static_cast<double>(rss) / static_cast<double>(PhysicalMemory::getValue());
   }
+
+  ServerStatistics const& serverInfo =
+      server().getFeature<MetricsFeature>().serverStatistics();
+
+  // processStatistics()
+  appendMetric(result, std::to_string(info._minorPageFaults), "minorPageFaults");
+  appendMetric(result, std::to_string(info._majorPageFaults), "majorPageFaults");
+  if (info._scClkTck != 0) {  // prevent division by zero
+    appendMetric(
+      result, std::to_string(
+        static_cast<double>(info._userTime) / static_cast<double>(info._scClkTck)), "userTime");
+    appendMetric(
+      result, std::to_string(
+        static_cast<double>(info._systemTime) / static_cast<double>(info._scClkTck)), "systemTime");
+  }
+  appendMetric(result, std::to_string(info._numberThreads), "numberOfThreads");
+  appendMetric(result, std::to_string(rss), "residentSize");
+  appendMetric(result, std::to_string(rssp), "residentSizePercent");
+  appendMetric(result, std::to_string(info._virtualSize), "virtualSize");
+  appendMetric(result, std::to_string(PhysicalMemory::getValue()), "physicalSize");
+  appendMetric(result, std::to_string(serverInfo.uptime()), "uptime");
+
+  if (isEnabled()) {
+    ConnectionStatistics::Snapshot connectionStats;
+    ConnectionStatistics::getSnapshot(connectionStats);
+
+    RequestStatistics::Snapshot requestStats;
+    RequestStatistics::getSnapshot(requestStats, stats::RequestStatisticsSource::ALL);
+
+    // _clientStatistics()
+    appendMetric(result, std::to_string(connectionStats.httpConnections.get()), "clientHttpConnections");
+    appendHistogram(result, connectionStats.connectionTime, "connectionTime", {"0.01", "1.0", "60.0", "+Inf"});
+    appendHistogram(result, requestStats.totalTime, "totalTime", {"0.01", "0.05", "0.1", "0.2", "0.5", "1.0", "+Inf"});
+    appendHistogram(result, requestStats.requestTime, "requestTime", {"0.01", "0.05", "0.1", "0.2", "0.5", "1.0", "+Inf"});
+    appendHistogram(result, requestStats.queueTime, "queueTime", {"0.01", "0.05", "0.1", "0.2", "0.5", "1.0", "+Inf"});
+    appendHistogram(result, requestStats.ioTime, "ioTime", {"0.01", "0.05", "0.1", "0.2", "0.5", "1.0", "+Inf"});
+    appendHistogram(result, requestStats.bytesSent, "bytesSent", {"250", "1000", "2000", "5000", "10000", "+Inf"});
+    appendHistogram(result, requestStats.bytesReceived, "bytesReceived", {"250", "1000", "2000", "5000", "10000", "+Inf"});
+
+    // _httpStatistics()
+    using rest::RequestType;
+    appendMetric(result, std::to_string(connectionStats.asyncRequests.get()), "httpReqsAsync");
+    appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::DELETE_REQ].get()), "httpReqsDelete");
+    appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::GET].get()), "httpReqsGet");
+    appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::HEAD].get()), "httpReqsHead");
+    appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::OPTIONS].get()), "httpReqsOptions");
+    appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::PATCH].get()), "httpReqsPatch");
+    appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::POST].get()), "httpReqsPost");
+    appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::PUT].get()), "httpReqsPut");
+    appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::ILLEGAL].get()), "httpReqsOther");
+    appendMetric(result, std::to_string(connectionStats.totalRequests.get()), "httpReqsTotal");
+    appendMetric(result, std::to_string(connectionStats.totalRequestsSuperuser.get()), "httpReqsSuperuser");
+    appendMetric(result, std::to_string(connectionStats.totalRequestsUser.get()), "httpReqsUser");
+  }
+
+  V8DealerFeature::Statistics v8Counters{};
+  if (server().hasFeature<V8DealerFeature>()) {
+    V8DealerFeature& dealer = server().getFeature<V8DealerFeature>();
+    if (dealer.isEnabled()) {
+      v8Counters = dealer.getCurrentContextNumbers();
+    }
+  }
+  appendMetric(result, std::to_string(v8Counters.available), "v8ContextAvailable");
+  appendMetric(result, std::to_string(v8Counters.busy), "v8ContextBusy");
+  appendMetric(result, std::to_string(v8Counters.dirty), "v8ContextDirty");
+  appendMetric(result, std::to_string(v8Counters.free), "v8ContextFree");
+  appendMetric(result, std::to_string(v8Counters.min), "v8ContextMin");
+  appendMetric(result, std::to_string(v8Counters.max), "v8ContextMax");
+  result += "\n";
 }

--- a/arangod/Statistics/StatisticsFeature.h
+++ b/arangod/Statistics/StatisticsFeature.h
@@ -25,17 +25,22 @@
 #define APPLICATION_FEATURES_STATISTICS_FEATURE_H 1
 
 #include <array>
+#include <initializer_list>
 
 #include "ApplicationFeatures/ApplicationFeature.h"
 #include "Basics/system-functions.h"
 #include "Rest/CommonDefines.h"
+#include "Statistics/Descriptions.h"
 #include "Statistics/figures.h"
 
 namespace arangodb {
 class Thread;
 class StatisticsWorker;
 namespace stats {
-  class Descriptions;
+class Descriptions;
+}
+namespace velocypack {
+class Builder;
 }
 
 namespace statistics {
@@ -77,14 +82,7 @@ extern RequestFigures UserRequestFigures;
 
 class StatisticsFeature final : public application_features::ApplicationFeature {
  public:
-  static bool enabled() {
-    return STATISTICS != nullptr && STATISTICS->_statistics;
-  }
-
   static double time() { return TRI_microtime(); }
-
- private:
-  static StatisticsFeature* STATISTICS;
 
  public:
   explicit StatisticsFeature(application_features::ApplicationServer& server);
@@ -97,19 +95,24 @@ class StatisticsFeature final : public application_features::ApplicationFeature 
   void stop() override final;
   void toPrometheus(std::string& result, double const& now);
 
-  static stats::Descriptions const* descriptions() {
-    if (STATISTICS != nullptr) {
-      return STATISTICS->_descriptions.get();
-    }
-    return nullptr;
+  stats::Descriptions const& descriptions() const {
+    return _descriptions;
   }
+
+  static arangodb::velocypack::Builder fillDistribution(statistics::Distribution const& dist);
+  
+  static void appendHistogram(
+    std::string& result, statistics::Distribution const& dist,
+    std::string const& label, std::initializer_list<std::string> const& les);
+  static void appendMetric(
+    std::string& result, std::string const& val, std::string const& label);
 
  private:
   bool _statistics;
   bool _statisticsHistory;
   bool _statisticsHistoryTouched;
 
-  std::unique_ptr<stats::Descriptions> _descriptions;
+  stats::Descriptions _descriptions;
   std::unique_ptr<Thread> _statisticsThread;
   std::unique_ptr<StatisticsWorker> _statisticsWorker;
 };

--- a/arangod/Statistics/StatisticsWorker.cpp
+++ b/arangod/Statistics/StatisticsWorker.cpp
@@ -45,6 +45,7 @@
 #include "RestServer/TtlFeature.h"
 #include "Scheduler/Scheduler.h"
 #include "Scheduler/SchedulerFeature.h"
+#include "Statistics/StatisticsFeature.h"
 #include "Transaction/StandaloneContext.h"
 #include "Utils/OperationOptions.h"
 #include "Utils/SingleCollectionTransaction.h"
@@ -812,274 +813,6 @@ void StatisticsWorker::avgPercentDistributon(VPackBuilder& builder, VPackSlice c
   builder.close();
 }
 
-// local_name: {"prometheus_name", "type", "help"}
-std::map<std::string, std::vector<std::string>> statStrings{
-  {"bytesReceived",
-   {"arangodb_client_connection_statistics_bytes_received_bucket", "gauge",
-    "Bytes received for a request"}},
-  {"bytesReceivedCount",
-   {"arangodb_client_connection_statistics_bytes_received_count", "gauge",
-    "Bytes received for a request"}},
-  {"bytesReceivedSum",
-   {"arangodb_client_connection_statistics_bytes_received_sum", "gauge",
-    "Bytes received for a request"}},
-  {"bytesSent",
-   {"arangodb_client_connection_statistics_bytes_sent_bucket", "gauge",
-    "Bytes sent for a request"}},
-  {"bytesSentCount",
-   {"arangodb_client_connection_statistics_bytes_sent_count", "gauge",
-    "Bytes sent for a request"}},
-  {"bytesSentSum",
-   {"arangodb_client_connection_statistics_bytes_sent_sum", "gauge",
-    "Bytes sent for a request"}},
-  {"minorPageFaults",
-   {"arangodb_process_statistics_minor_page_faults", "gauge",
-    "The number of minor faults the process has made which have not required loading a memory page from disk. This figure is not reported on Windows"}},
-  {"majorPageFaults",
-   {"arangodb_process_statistics_major_page_faults", "gauge",
-    "On Windows, this figure contains the total number of page faults. On other system, this figure contains the number of major faults the process has made which have required loading a memory page from disk"}},
-  {"bytesReceived",
-   {"arangodb_client_connection_statistics_bytes_received_bucket", "gauge",
-    "Bytes received for a request"}},
-  {"userTime",
-   {"arangodb_process_statistics_user_time", "gauge",
-    "Amount of time that this process has been scheduled in user mode, measured in seconds"}},
-  {"systemTime",
-   {"arangodb_process_statistics_system_time", "gauge",
-    "Amount of time that this process has been scheduled in kernel mode, measured in seconds"}},
-  {"numberOfThreads",
-   {"arangodb_process_statistics_number_of_threads", "gauge",
-    "Number of threads in the arangod process"}},
-  {"residentSize",
-   {"arangodb_process_statistics_resident_set_size", "gauge", "The total size of the number of pages the process has in real memory. This is just the pages which count toward text, data, or stack space. This does not include pages which have not been demand-loaded in, or which are swapped out. The resident set size is reported in bytes"}},
-  {"residentSizePercent",
-   {"arangodb_process_statistics_resident_set_size_percent", "gauge", "The relative size of the number of pages the process has in real memory compared to system memory. This is just the pages which count toward text, data, or stack space. This does not include pages which have not been demand-loaded in, or which are swapped out. The value is a ratio between 0.00 and 1.00"}},
-  {"virtualSize",
-   {"arangodb_process_statistics_virtual_memory_size", "gauge", "On Windows, this figure contains the total amount of memory that the memory manager has committed for the arangod process. On other systems, this figure contains The size of the virtual memory the process is using"}},
-  {"clientHttpConnections",
-   {"arangodb_client_connection_statistics_client_connections", "gauge",
-    "The number of client connections that are currently open"}},
-  {"connectionTime",
-   {"arangodb_client_connection_statistics_connection_time_bucket", "gauge",
-    "Total connection time of a client"}},
-  {"connectionTimeCount",
-   {"arangodb_client_connection_statistics_connection_time_count", "gauge",
-    "Total connection time of a client"}},
-  {"connectionTimeSum",
-   {"arangodb_client_connection_statistics_connection_time_sum", "gauge",
-    "Total connection time of a client"}},
-  {"totalTime",
-   {"arangodb_client_connection_statistics_total_time_bucket", "gauge",
-    "Total time needed to answer a request"}},
-  {"totalTimeCount",
-   {"arangodb_client_connection_statistics_total_time_count", "gauge",
-    "Total time needed to answer a request"}},
-  {"totalTimeSum",
-   {"arangodb_client_connection_statistics_total_time_sum", "gauge",
-    "Total time needed to answer a request"}},
-  {"requestTime",
-   {"arangodb_client_connection_statistics_request_time_bucket", "gauge",
-    "Request time needed to answer a request"}},
-  {"requestTimeCount",
-   {"arangodb_client_connection_statistics_request_time_count", "gauge",
-    "Request time needed to answer a request"}},
-  {"requestTimeSum",
-   {"arangodb_client_connection_statistics_request_time_sum", "gauge",
-    "Request time needed to answer a request"}},
-  {"queueTime",
-   {"arangodb_client_connection_statistics_queue_time_bucket", "gauge",
-    "Request time needed to answer a request"}},
-  {"queueTimeCount",
-   {"arangodb_client_connection_statistics_queue_time_count", "gauge",
-    "Request time needed to answer a request"}},
-  {"queueTimeSum",
-   {"arangodb_client_connection_statistics_queue_time_sum", "gauge",
-    "Request time needed to answer a request"}},
-  {"ioTime",
-   {"arangodb_client_connection_statistics_io_time_bucket", "gauge",
-    "Request time needed to answer a request"}},
-  {"ioTimeCount",
-   {"arangodb_client_connection_statistics_io_time_count", "gauge",
-    "Request time needed to answer a request"}},
-  {"ioTimeSum",
-   {"arangodb_client_connection_statistics_io_time_sum", "gauge",
-    "Request time needed to answer a request"}},
-  {"httpReqsTotal",
-   {"arangodb_http_request_statistics_total_requests", "gauge",
-    "Total number of HTTP requests"}},
-  {"httpReqsSuperuser",
-   {"arangodb_http_request_statistics_superuser_requests", "gauge",
-    "Total number of HTTP requests executed by superuser/JWT"}},
-  {"httpReqsUser",
-   {"arangodb_http_request_statistics_user_requests", "gauge",
-    "Total number of HTTP requests executed by clients"}},
-  {"httpReqsAsync",
-   {"arangodb_http_request_statistics_async_requests", "gauge",
-    "Number of asynchronously executed HTTP requests"}},
-  {"httpReqsDelete",
-   {"arangodb_http_request_statistics_http_delete_requests", "gauge",
-    "Number of HTTP DELETE requests"}},
-  {"httpReqsGet",
-   {"arangodb_http_request_statistics_http_get_requests", "gauge",
-    "Number of HTTP GET requests"}},
-  {"httpReqsHead",
-   {"arangodb_http_request_statistics_http_head_requests", "gauge",
-    "Number of HTTP HEAD requests"}},
-  {"httpReqsOptions",
-   {"arangodb_http_request_statistics_http_options_requests", "gauge",
-    "Number of HTTP OPTIONS requests"}},
-  {"httpReqsPatch",
-   {"arangodb_http_request_statistics_http_patch_requests", "gauge",
-    "Number of HTTP PATCH requests"}},
-  {"httpReqsPost",
-   {"arangodb_http_request_statistics_http_post_requests", "gauge",
-    "Number of HTTP POST requests"}},
-  {"httpReqsPut",
-   {"arangodb_http_request_statistics_http_put_requests", "gauge",
-    "Number of HTTP PUT requests"}},
-  {"httpReqsOther",
-   {"arangodb_http_request_statistics_other_http_requests", "gauge",
-    "Number of other HTTP requests"}},
-  {"uptime",
-   {"arangodb_server_statistics_server_uptime", "gauge",
-    "Number of seconds elapsed since server start"}},
-  {"physicalSize",
-   {"arangodb_server_statistics_physical_memory", "gauge",
-    "Physical memory in bytes"}},
-  {"v8ContextAvailable",
-   {"arangodb_v8_context_alive", "gauge",
-    "Number of V8 contexts currently alive"}},
-  {"v8ContextBusy",
-   {"arangodb_v8_context_busy", "gauge",
-    "Number of V8 contexts currently busy"}},
-  {"v8ContextDirty",
-   {"arangodb_v8_context_dirty", "gauge",
-    "Number of V8 contexts currently dirty"}},
-  {"v8ContextFree",
-   {"arangodb_v8_context_free", "gauge",
-    "Number of V8 contexts currently free"}},
-  {"v8ContextMax",
-   {"arangodb_v8_context_max", "gauge",
-    "Maximum number of concurrent V8 contexts"}},
-  {"v8ContextMin",
-   {"arangodb_v8_context_min", "gauge",
-    "Minimum number of concurrent V8 contexts"}},
-};
-
-void StatisticsWorker::generateRawStatistics(std::string& result, double const& now) {
-  ProcessInfo info = TRI_ProcessInfoSelf();
-  uint64_t rss = static_cast<uint64_t>(info._residentSize);
-  double rssp = 0;
-
-  if (PhysicalMemory::getValue() != 0) {
-    rssp = static_cast<double>(rss) / static_cast<double>(PhysicalMemory::getValue());
-  }
-
-  ConnectionStatistics::Snapshot connectionStats;
-  ConnectionStatistics::getSnapshot(connectionStats);
-
-  RequestStatistics::Snapshot requestStats;
-  RequestStatistics::getSnapshot(requestStats, stats::RequestStatisticsSource::ALL);
-
-  ServerStatistics const& serverInfo =
-      _vocbase.server().getFeature<MetricsFeature>().serverStatistics();
-
-  // processStatistics()
-  appendMetric(result, std::to_string(info._minorPageFaults), "minorPageFaults");
-  appendMetric(result, std::to_string(info._majorPageFaults), "majorPageFaults");
-  if (info._scClkTck != 0) {  // prevent division by zero
-    appendMetric(
-      result, std::to_string(
-        static_cast<double>(info._userTime) / static_cast<double>(info._scClkTck)), "userTime");
-    appendMetric(
-      result, std::to_string(
-        static_cast<double>(info._systemTime) / static_cast<double>(info._scClkTck)), "systemTime");
-  }
-  appendMetric(result, std::to_string(info._numberThreads), "numberOfThreads");
-  appendMetric(result, std::to_string(rss), "residentSize");
-  appendMetric(result, std::to_string(rssp), "residentSizePercent");
-  appendMetric(result, std::to_string(info._virtualSize), "virtualSize");
-  appendMetric(result, std::to_string(PhysicalMemory::getValue()), "physicalSize");
-  appendMetric(result, std::to_string(serverInfo.uptime()), "uptime");
-
-  // _clientStatistics()
-  appendMetric(result, std::to_string(connectionStats.httpConnections.get()), "clientHttpConnections");
-  appendHistogram(result, connectionStats.connectionTime, "connectionTime", {"0.01", "1.0", "60.0", "+Inf"});
-  appendHistogram(result, requestStats.totalTime, "totalTime", {"0.01", "0.05", "0.1", "0.2", "0.5", "1.0", "+Inf"});
-  appendHistogram(result, requestStats.requestTime, "requestTime", {"0.01", "0.05", "0.1", "0.2", "0.5", "1.0", "+Inf"});
-  appendHistogram(result, requestStats.queueTime, "queueTime", {"0.01", "0.05", "0.1", "0.2", "0.5", "1.0", "+Inf"});
-  appendHistogram(result, requestStats.ioTime, "ioTime", {"0.01", "0.05", "0.1", "0.2", "0.5", "1.0", "+Inf"});
-  appendHistogram(result, requestStats.bytesSent, "bytesSent", {"250", "1000", "2000", "5000", "10000", "+Inf"});
-  appendHistogram(result, requestStats.bytesReceived, "bytesReceived", {"250", "1000", "2000", "5000", "10000", "+Inf"});
-
-  // _httpStatistics()
-  using rest::RequestType;
-  appendMetric(result, std::to_string(connectionStats.asyncRequests.get()), "httpReqsAsync");
-  appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::DELETE_REQ].get()), "httpReqsDelete");
-  appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::GET].get()), "httpReqsGet");
-  appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::HEAD].get()), "httpReqsHead");
-  appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::OPTIONS].get()), "httpReqsOptions");
-  appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::PATCH].get()), "httpReqsPatch");
-  appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::POST].get()), "httpReqsPost");
-  appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::PUT].get()), "httpReqsPut");
-  appendMetric(result, std::to_string(connectionStats.methodRequests[(int)RequestType::ILLEGAL].get()), "httpReqsOther");
-  appendMetric(result, std::to_string(connectionStats.totalRequests.get()), "httpReqsTotal");
-  appendMetric(result, std::to_string(connectionStats.totalRequestsSuperuser.get()), "httpReqsSuperuser");
-  appendMetric(result, std::to_string(connectionStats.totalRequestsUser.get()), "httpReqsUser");
-
-  V8DealerFeature::Statistics v8Counters{};
-  if (_server.hasFeature<V8DealerFeature>()) {
-    V8DealerFeature& dealer = _server.getFeature<V8DealerFeature>();
-    if (dealer.isEnabled()) {
-      v8Counters = dealer.getCurrentContextNumbers();
-    }
-  }
-  appendMetric(result, std::to_string(v8Counters.available), "v8ContextAvailable");
-  appendMetric(result, std::to_string(v8Counters.busy), "v8ContextBusy");
-  appendMetric(result, std::to_string(v8Counters.dirty), "v8ContextDirty");
-  appendMetric(result, std::to_string(v8Counters.free), "v8ContextFree");
-  appendMetric(result, std::to_string(v8Counters.min), "v8ContextMin");
-  appendMetric(result, std::to_string(v8Counters.max), "v8ContextMax");
-  result += "\n";
-}
-
-void StatisticsWorker::appendMetric(std::string& result, std::string const& val, std::string const& label) const {
-  auto const& stat = statStrings.at(label); 
-  std::string const& name = stat.at(0);
-
-  result +=
-    "\n#TYPE " + name + " " + stat[1] +
-    "\n#HELP " + name + " " + stat[2] + 
-    '\n' + name + " " + val + '\n';
-}
-
-void StatisticsWorker::appendHistogram(
-  std::string& result, Distribution const& dist,
-  std::string const& label, std::initializer_list<std::string> const& les) const {
-
-  auto const countLabel = label + "Count";
-  auto const countSum = label + "Sum";
-  VPackBuilder tmp = fillDistribution(dist);
-  VPackSlice slc = tmp.slice();
-  VPackSlice counts = slc.get("counts");
-  
-  auto const& stat = statStrings.at(label); 
-  std::string const& name = stat.at(0);
-
-  result +=
-    "\n#TYPE " + name + " " + stat[1] + 
-    "\n#HELP " + name + " " + stat[2] + '\n';
-
-  TRI_ASSERT(les.size() == counts.length());
-  size_t i = 0;
-  for (auto const& le : les) {
-    result +=
-      name + "{le=\"" + le + "\"}"  + " " +
-      std::to_string(counts.at(i++).getNumber<uint64_t>()) + '\n';
-  }
-
-}
-
 void StatisticsWorker::generateRawStatistics(VPackBuilder& builder, double const& now) {
   ProcessInfo info = TRI_ProcessInfoSelf();
   uint64_t rss = static_cast<uint64_t>(info._residentSize);
@@ -1126,25 +859,25 @@ void StatisticsWorker::generateRawStatistics(VPackBuilder& builder, double const
   builder.add("client", VPackValue(VPackValueType::Object));
   builder.add("httpConnections", VPackValue(connectionStats.httpConnections.get()));
 
-  VPackBuilder tmp = fillDistribution(connectionStats.connectionTime);
+  VPackBuilder tmp = StatisticsFeature::fillDistribution(connectionStats.connectionTime);
   builder.add("connectionTime", tmp.slice());
 
-  tmp = fillDistribution(requestStats.totalTime);
+  tmp = StatisticsFeature::fillDistribution(requestStats.totalTime);
   builder.add("totalTime", tmp.slice());
 
-  tmp = fillDistribution(requestStats.requestTime);
+  tmp = StatisticsFeature::fillDistribution(requestStats.requestTime);
   builder.add("requestTime", tmp.slice());
 
-  tmp = fillDistribution(requestStats.queueTime);
+  tmp = StatisticsFeature::fillDistribution(requestStats.queueTime);
   builder.add("queueTime", tmp.slice());
 
-  tmp = fillDistribution(requestStats.ioTime);
+  tmp = StatisticsFeature::fillDistribution(requestStats.ioTime);
   builder.add("ioTime", tmp.slice());
 
-  tmp = fillDistribution(requestStats.bytesSent);
+  tmp = StatisticsFeature::fillDistribution(requestStats.bytesSent);
   builder.add("bytesSent", tmp.slice());
 
-  tmp = fillDistribution(requestStats.bytesReceived);
+  tmp = StatisticsFeature::fillDistribution(requestStats.bytesReceived);
   builder.add("bytesReceived", tmp.slice());
   builder.close();
 
@@ -1234,24 +967,6 @@ void StatisticsWorker::generateRawStatistics(VPackBuilder& builder, double const
   builder.close();
 }
 
-VPackBuilder StatisticsWorker::fillDistribution(Distribution const& dist) const {
-  VPackBuilder builder;
-  builder.openObject();
-
-  builder.add("sum", VPackValue(dist._total));
-  builder.add("count", VPackValue(dist._count));
-
-  builder.add("counts", VPackValue(VPackValueType::Array));
-  for (auto const& val : dist._counts) {
-    builder.add(VPackValue(val));
-  }
-  builder.close();
-
-  builder.close();
-
-  return builder;
-}
-
 void StatisticsWorker::saveSlice(VPackSlice const& slice, std::string const& collection) const {
   if (isStopping()) {
     return;
@@ -1315,7 +1030,7 @@ void StatisticsWorker::run() {
   }
 
   uint64_t seconds = 0;
-  while (!isStopping() && StatisticsFeature::enabled()) {
+  while (!isStopping()) {
     seconds++;
     try {
       if (seconds % STATISTICS_INTERVAL == 0) {

--- a/arangod/Statistics/StatisticsWorker.h
+++ b/arangod/Statistics/StatisticsWorker.h
@@ -69,16 +69,8 @@ class StatisticsWorker final : public Thread {
   void avgPercentDistributon(velocypack::Builder& result, velocypack::Slice const&,
                              velocypack::Slice const&, velocypack::Builder const&) const;
 
-  velocypack::Builder fillDistribution(statistics::Distribution const& dist) const;
-
   // save one statistics object
   void saveSlice(velocypack::Slice const&, std::string const&) const;
-
-  void appendHistogram(
-    std::string& result, statistics::Distribution const& dist,
-    std::string const& label, std::initializer_list<std::string> const& les) const;
-  void appendMetric(
-    std::string& result, std::string const& val, std::string const& label) const;
 
   static constexpr uint64_t STATISTICS_INTERVAL = 10;    // 10 secs
   static constexpr uint64_t GC_INTERVAL = 8 * 60;        //  8 mins

--- a/arangod/V8Server/v8-statistics.cpp
+++ b/arangod/V8Server/v8-statistics.cpp
@@ -199,7 +199,9 @@ static void JS_EnabledStatistics(v8::FunctionCallbackInfo<v8::Value> const& args
   TRI_V8_TRY_CATCH_BEGIN(isolate)
   v8::HandleScope scope(isolate);
 
-  v8::Handle<v8::Value> result = v8::Boolean::New(isolate, StatisticsFeature::enabled());
+  TRI_GET_GLOBALS();
+  bool enabled = v8g->_server.getFeature<StatisticsFeature>().isEnabled();
+  v8::Handle<v8::Value> result = v8::Boolean::New(isolate, enabled);
   TRI_V8_RETURN(result);
   TRI_V8_TRY_CATCH_END
 }

--- a/arangod/V8Server/v8-vocbase.cpp
+++ b/arangod/V8Server/v8-vocbase.cpp
@@ -2202,8 +2202,8 @@ void TRI_InitV8VocBridge(v8::Isolate* isolate, v8::Handle<v8::Context> context,
       ->DefineOwnProperty(TRI_IGETC,
                           TRI_V8_ASCII_STRING(isolate, "ENABLE_STATISTICS"),
                           v8::Boolean::New(isolate,
-                                           StatisticsFeature::enabled()))
-      .FromMaybe(false);  // ignore result  //, v8::ReadOnly);
+                                           vocbase.server().getFeature<StatisticsFeature>().isEnabled()), v8::ReadOnly)
+      .FromMaybe(false);  // ignore result  
 
   // replication factors
   context->Global()

--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -150,12 +150,10 @@ for aid in `seq 0 $(( $NRAGENTS - 1 ))`; do
           --database.directory cluster/data$PORT \
           --javascript.enabled false \
           --server.endpoint $TRANSPORT://$ENDPOINT:$PORT \
-          --server.statistics false \
           --log.role true \
           --log.file cluster/$PORT.log \
           --log.force-direct false \
           --log.level $LOG_LEVEL_AGENCY \
-          --javascript.allow-admin-execute true \
           $STORAGE_ENGINE \
           $AUTHENTICATION \
           $SSLKEYFILE \
@@ -178,12 +176,10 @@ for aid in `seq 0 $(( $NRAGENTS - 1 ))`; do
         --database.directory cluster/data$PORT \
         --javascript.enabled false \
         --server.endpoint $TRANSPORT://$ENDPOINT:$PORT \
-        --server.statistics false \
         --log.role true \
         --log.file cluster/$PORT.log \
         --log.force-direct false \
         --log.level $LOG_LEVEL_AGENCY \
-        --javascript.allow-admin-execute true \
         $STORAGE_ENGINE \
         $AUTHENTICATION \
         $SSLKEYFILE \

--- a/tests/js/client/server_parameters/statistics-history-off.js
+++ b/tests/js/client/server_parameters/statistics-history-off.js
@@ -1,0 +1,105 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertTrue, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for server startup options
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'server.statistics': "true",
+    'server.statistics-history': "false"
+  };
+}
+const jsunity = require('jsunity');
+const errors = require('@arangodb').errors;
+const internal = require('internal');
+const db = internal.db;
+
+function getMetric(name) {
+  let res = arango.GET_RAW("/_admin/metrics");
+  let re = new RegExp("^" + name + " ");
+  let matches = res.body.split('\n').filter((line) => !line.match(/^#/)).filter((line) => line.match(re));
+  if (!matches.length) {
+    throw "Metric " + name + " not found";
+  }
+  return Number(matches[0].replace(/^.*? (\d+.*?)$/, '$1'));
+}
+
+function testSuite() {
+  return {
+    testStatisticApi : function() {
+      let value = arango.GET("/_admin/statistics");
+      assertTrue(value.hasOwnProperty("time"));
+      assertTrue(value.hasOwnProperty("enabled"));
+      assertTrue(value.hasOwnProperty("server"));
+      assertTrue(value.hasOwnProperty("system"));
+      assertTrue(value.enabled);
+    },
+
+    testMetricsAlwaysThere : function() {
+      let value = getMetric("arangodb_process_statistics_resident_set_size");
+      assertTrue(value > 0, value);
+      
+      value = getMetric("arangodb_server_statistics_server_uptime");
+      assertTrue(value > 0, value);
+    },
+    
+    testHttpMetrics : function() {
+      let oldValue = getMetric("arangodb_http_request_statistics_total_requests");
+      for (let i = 0; i < 10; ++i) {
+        arango.GET("/_api/version");
+      }
+      // statistics aggregation on server may take a short while - wait for it
+      let newValue;
+      let tries = 0;
+      while (++tries < 4 * 10) {
+        newValue = getMetric("arangodb_http_request_statistics_total_requests");
+        if (newValue - oldValue >= 10) {
+          break;
+        }
+        internal.sleep(0.25);
+      }
+      assertTrue(newValue - oldValue >= 10, { oldValue, newValue });
+    },
+
+    testStatisticsHistory : function() {
+      let count;
+      let tries = 0;
+      // wait until some document has been written into statistics collection
+      while (++tries < 4 * 10) {
+        count = db._statisticsRaw.count();
+        if (count > 0) {
+          break;
+        }
+        internal.sleep(0.25);
+      }
+      assertEqual(0, count);
+    },
+
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/statistics-history-off.js
+++ b/tests/js/client/server_parameters/statistics-history-off.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/* global getOptions, assertTrue, arango */
+/* global getOptions, assertTrue, assertEqual, arango */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test for server startup options

--- a/tests/js/client/server_parameters/statistics-off.js
+++ b/tests/js/client/server_parameters/statistics-off.js
@@ -1,0 +1,92 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertTrue, arango, fail */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for server startup options
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'server.statistics': "false"
+  };
+}
+const jsunity = require('jsunity');
+const errors = require('@arangodb').errors;
+const internal = require('internal');
+const db = internal.db;
+
+function getMetric(name) {
+  let res = arango.GET_RAW("/_admin/metrics");
+  let re = new RegExp("^" + name + " ");
+  let matches = res.body.split('\n').filter((line) => !line.match(/^#/)).filter((line) => line.match(re));
+  if (!matches.length) {
+    throw "Metric " + name + " not found";
+  }
+  return Number(matches[0].replace(/^.*? (\d+.*?)$/, '$1'));
+}
+
+function testSuite() {
+  return {
+    testStatisticApi : function() {
+      let value = arango.GET("/_admin/statistics");
+      assertTrue(value.error);
+      assertEqual(404, value.code);
+    },
+
+    testMetricsAlwaysThere : function() {
+      let value = getMetric("arangodb_process_statistics_resident_set_size");
+      assertTrue(value > 0, value);
+      
+      value = getMetric("arangodb_server_statistics_server_uptime");
+      assertTrue(value > 0, value);
+    },
+
+    testHttpMetrics : function() {
+      try {
+        getMetric("arangodb_http_request_statistics_total_requests");
+        fail();
+      } catch (err) {
+        assertEqual("Metric arangodb_http_request_statistics_total_requests not found", err);
+      }
+    },
+    
+    testStatisticsHistory : function() {
+      let count;
+      let tries = 0;
+      // wait until some document has been written into statistics collection
+      while (++tries < 4 * 10) {
+        count = db._statisticsRaw.count();
+        if (count > 0) {
+          break;
+        }
+        internal.sleep(0.25);
+      }
+      assertEqual(0, count);
+    },
+
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/statistics-off.js
+++ b/tests/js/client/server_parameters/statistics-off.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/* global getOptions, assertTrue, arango, fail */
+/* global getOptions, assertTrue, assertEqual, arango, fail */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test for server startup options

--- a/tests/js/client/server_parameters/statistics-on.js
+++ b/tests/js/client/server_parameters/statistics-on.js
@@ -1,0 +1,104 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertTrue, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for server startup options
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'server.statistics': "true"
+  };
+}
+const jsunity = require('jsunity');
+const errors = require('@arangodb').errors;
+const internal = require('internal');
+const db = internal.db;
+
+function getMetric(name) {
+  let res = arango.GET_RAW("/_admin/metrics");
+  let re = new RegExp("^" + name + " ");
+  let matches = res.body.split('\n').filter((line) => !line.match(/^#/)).filter((line) => line.match(re));
+  if (!matches.length) {
+    throw "Metric " + name + " not found";
+  }
+  return Number(matches[0].replace(/^.*? (\d+.*?)$/, '$1'));
+}
+
+function testSuite() {
+  return {
+    testStatisticApi : function() {
+      let value = arango.GET("/_admin/statistics");
+      assertTrue(value.hasOwnProperty("time"));
+      assertTrue(value.hasOwnProperty("enabled"));
+      assertTrue(value.hasOwnProperty("server"));
+      assertTrue(value.hasOwnProperty("system"));
+      assertTrue(value.enabled);
+    },
+
+    testMetricsAlwaysThere : function() {
+      let value = getMetric("arangodb_process_statistics_resident_set_size");
+      assertTrue(value > 0, value);
+      
+      value = getMetric("arangodb_server_statistics_server_uptime");
+      assertTrue(value > 0, value);
+    },
+
+    testHttpMetrics : function() {
+      let oldValue = getMetric("arangodb_http_request_statistics_total_requests");
+      for (let i = 0; i < 10; ++i) {
+        arango.GET("/_api/version");
+      }
+      // statistics aggregation on server may take a short while - wait for it
+      let newValue;
+      let tries = 0;
+      while (++tries < 4 * 10) {
+        newValue = getMetric("arangodb_http_request_statistics_total_requests");
+        if (newValue - oldValue >= 10) {
+          break;
+        }
+        internal.sleep(0.25);
+      }
+      assertTrue(newValue - oldValue >= 10, { oldValue, newValue });
+    },
+    
+    testStatisticsHistory : function() {
+      let count;
+      let tries = 0;
+      // wait until some document has been written into statistics collection
+      while (++tries < 4 * 30) {
+        count = db._statisticsRaw.count();
+        if (count > 0) {
+          break;
+        }
+        internal.sleep(0.25);
+      }
+      assertTrue(count > 0, { count });
+    },
+
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Enable HTTP request statistics and provide metrics even in case `--server.statistics-history` is set to `false` (this option will set itself to off automatically on agency instances on startup if not explicitly set).
This change provides more metrics on all server instances, without the need to persist them in the instance's RocksDB storage engine. 
This PR also adds tests for the different combinations for the statistics options.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (server_parameters)

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12676/