### PR TITLE
add option to run arangobench for a duration, instead of a count of operations

### DIFF
--- a/arangosh/Benchmark/BenchFeature.cpp
+++ b/arangosh/Benchmark/BenchFeature.cpp
@@ -253,7 +253,7 @@ void BenchFeature::start() {
       }
 
       LOG_TOPIC("5cda8", FATAL, arangodb::Logger::FIXME)
-        << "failed to create the specified database " << msg;
+        << "failed to create the specified database: " << msg;
       FATAL_ERROR_EXIT();
     }
 

--- a/arangosh/Benchmark/BenchFeature.h
+++ b/arangosh/Benchmark/BenchFeature.h
@@ -81,11 +81,14 @@ class BenchFeature final : public application_features::ApplicationFeature {
   bool _async;
   uint64_t _concurrency;
   uint64_t _operations;
+  uint64_t _realOperations;
   uint64_t _batchSize;
+  uint64_t _duration;
   bool _keepAlive;
   std::string _collection;
   std::string _testCase;
   uint64_t _complexity;
+  bool _createDatabase;
   bool _delay;
   bool _progress;
   bool _verbose;

--- a/arangosh/Benchmark/BenchmarkCounter.h
+++ b/arangosh/Benchmark/BenchmarkCounter.h
@@ -38,13 +38,14 @@ class BenchmarkCounter {
   /// @brief create the counter
   //////////////////////////////////////////////////////////////////////////////
 
-  BenchmarkCounter(T initialValue, T const maxValue)
+  BenchmarkCounter(T initialValue, T const maxValue, double const runUntil)
       : _mutex(),
         _value(initialValue),
         _maxValue(maxValue),
         _incompleteFailures(0),
         _failures(0),
-        _done(0) {}
+        _done(0),
+        _runUntil(runUntil) {}
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief destroy the counter
@@ -94,7 +95,15 @@ class BenchmarkCounter {
     MUTEX_LOCKER(mutexLocker, this->_mutex);
 
     T oldValue = _value;
-    if (oldValue + realValue > _maxValue) {
+    if (_runUntil != 0.0) {
+      if (_runUntil - TRI_microtime() <= 0.0) {
+        _value = _maxValue;
+        _done = _maxValue;
+        return 0;
+      }
+      _value += realValue;
+      return realValue;
+    } else if (oldValue + realValue > _maxValue) {
       _value = _maxValue;
       return _maxValue - oldValue;
     }
@@ -177,7 +186,8 @@ private:
   //////////////////////////////////////////////////////////////////////////////
 
   T _done;
-  
+
+  double _runUntil;
 };
 }  // namespace arangobench
 }  // namespace arangodb

--- a/js/client/modules/@arangodb/testsuites/arangobench.js
+++ b/js/client/modules/@arangodb/testsuites/arangobench.js
@@ -154,6 +154,11 @@ const benchTodos = [{
   'concurrency': '3',
   'test-case': 'multitrx',
   'transaction': true
+}, {
+  'duration': 15,
+  'concurrency': '2',
+  'test-case': 'skiplist',
+  'complexity': '1'
 }];
 
 function arangobench (options) {
@@ -218,6 +223,15 @@ function arangobench (options) {
       let oneResult = pu.run.arangoBenchmark(options, instanceInfo, args, instanceInfo.rootDir, options.coreCheck);
       print();
 
+      if (benchTodo.hasOwnProperty('duration')) {
+        oneResult.status = oneResult.status && oneResult.duration >= benchTodo['duration'];
+        if (!oneResult.status) {
+          oneResult.message += ` didn't run for the expected time ${benchTodo.duration} but only ${oneResult.duration}`;
+        }
+        if (!oneResult.status && options.extremeVerbosity){
+          print("Duration test failed: " + JSON.stringify(oneResult));
+        }
+      }
       results[name] = oneResult;
       results[name].total++;
       results[name].failed = 0;

--- a/js/client/modules/@arangodb/testsuites/arangobench.js
+++ b/js/client/modules/@arangodb/testsuites/arangobench.js
@@ -37,6 +37,7 @@ const optionsDocumentation = [
 
 const _ = require('lodash');
 const pu = require('@arangodb/testutils/process-utils');
+const internal = require('internal');
 
 // const BLUE = require('internal').COLORS.COLOR_BLUE;
 const CYAN = require('internal').COLORS.COLOR_CYAN;
@@ -159,6 +160,13 @@ const benchTodos = [{
   'concurrency': '2',
   'test-case': 'skiplist',
   'complexity': '1'
+},{
+  'requests': '1',
+  'concurrency': '1',
+  'test-case': 'version',
+  'keep-alive': 'true',
+  'server.database': 'arangobench_testdb',
+  'create-database': true
 }];
 
 function arangobench (options) {
@@ -232,6 +240,17 @@ function arangobench (options) {
           print("Duration test failed: " + JSON.stringify(oneResult));
         }
       }
+
+      if (benchTodo.hasOwnProperty('create-database') && benchTodo['create-database']) {
+        if (internal.db._databases().find(
+          dbName => dbName === benchTodo['server.database']) === undefined) {
+          oneResult.message += " no database was created!";
+          oneResult.status = false;
+        } else {
+          internal.db._dropDatabase(benchTodo['server.database']);
+        }
+      }
+
       results[name] = oneResult;
       results[name].total++;
       results[name].failed = 0;


### PR DESCRIPTION
### Scope & Purpose

this PR enables arangobench to be ran for a specific time duration instead of a specified count. 
So if you want to load your system for a while, this way its more convenient.

It may now also create the database it operates on on start.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.7, 3.6

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [x] Added new **integration tests** a new arangobench test checks, whether the specified run-time is respected.
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
