### PR TITLE
Fix deadlocks between write transactions and hotbackup, take 2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,9 @@
 v3.7.5 (XXXX-XX-XX)
 -------------------
 
-* Fixed a deadlock between AQL write transactions and hotbackup, since
-  in AQL write transactions follower transactions did not know they are
-  follower transactions.
+* Fixed a deadlock between AQL write transactions and hotbackup, since in AQL
+  write transactions follower transactions did not know they are follower
+  transactions.
 
 * Fix REST API endpoint PUT `/_api/collection/<collection>/recalculateCount` on
   coordinators. Coordinators sent a wrong message body to DB servers here, so

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.7.5 (XXXX-XX-XX)
 -------------------
 
+* Fixed a deadlock between AQL write transactions and hotbackup, since
+  in AQL write transactions follower transactions did not know they are
+  follower transactions.
+
 * Fix REST API endpoint PUT `/_api/collection/<collection>/recalculateCount` on
   coordinators. Coordinators sent a wrong message body to DB servers here, so
   the request could not be handled properly.

--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -482,7 +482,7 @@ RestStatus RestCollectionHandler::handleCommandPut() {
         _request->value(StaticStrings::IsSynchronousReplicationString);
     opts.truncateCompact = _request->parsedValue(StaticStrings::Compact, true);
 
-    _activeTrx = createTransaction(coll->name(), AccessMode::Type::EXCLUSIVE);
+    _activeTrx = createTransaction(coll->name(), AccessMode::Type::EXCLUSIVE, opts);
     _activeTrx->addHint(transaction::Hints::Hint::INTERMEDIATE_COMMITS);
     _activeTrx->addHint(transaction::Hints::Hint::ALLOW_RANGE_DELETE);
     res = _activeTrx->begin();
@@ -781,7 +781,7 @@ RestStatus RestCollectionHandler::standardResponse() {
 
 void RestCollectionHandler::initializeTransaction(LogicalCollection& coll) {
   try {
-    _activeTrx = createTransaction(coll.name(), AccessMode::Type::READ);
+    _activeTrx = createTransaction(coll.name(), AccessMode::Type::READ, OperationOptions());
   } catch (basics::Exception const& ex) {
     if (ex.code() == TRI_ERROR_TRANSACTION_NOT_FOUND) {
       // this will happen if the tid of a managed transaction is passed in,

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -197,14 +197,11 @@ RestStatus RestDocumentHandler::insertDocument() {
                          opOptions.isSynchronousReplicationFrom);
 
   // find and load collection given by name or identifier
-  _activeTrx = createTransaction(cname, AccessMode::Type::WRITE);
+  _activeTrx = createTransaction(cname, AccessMode::Type::WRITE, opOptions);
   bool const isMultiple = body.isArray();
 
   if (!isMultiple && !opOptions.isOverwriteModeUpdateReplace()) {
     _activeTrx->addHint(transaction::Hints::Hint::SINGLE_OPERATION);
-  }
-  if (!opOptions.isSynchronousReplicationFrom.empty()) {
-    _activeTrx->addHint(transaction::Hints::Hint::IS_FOLLOWER_TRX);
   }
 
   Result res = _activeTrx->begin();
@@ -302,7 +299,7 @@ RestStatus RestDocumentHandler::readSingleDocument(bool generateBody) {
   VPackSlice search = builder.slice();
 
   // find and load collection given by name or identifier
-  _activeTrx = createTransaction(collection, AccessMode::Type::READ);
+  _activeTrx = createTransaction(collection, AccessMode::Type::READ, options);
 
   _activeTrx->addHint(transaction::Hints::Hint::SINGLE_OPERATION);
 
@@ -487,13 +484,10 @@ RestStatus RestDocumentHandler::modifyDocument(bool isPatch) {
   }
 
   // find and load collection given by name or identifier
-  _activeTrx = createTransaction(cname, AccessMode::Type::WRITE);
+  _activeTrx = createTransaction(cname, AccessMode::Type::WRITE, opOptions);
 
   if (!isArrayCase) {
     _activeTrx->addHint(transaction::Hints::Hint::SINGLE_OPERATION);
-  }
-  if (!opOptions.isSynchronousReplicationFrom.empty()) {
-    _activeTrx->addHint(transaction::Hints::Hint::IS_FOLLOWER_TRX);
   }
 
   // ...........................................................................
@@ -610,12 +604,9 @@ RestStatus RestDocumentHandler::removeDocument() {
     return RestStatus::DONE;
   }
 
-  _activeTrx = createTransaction(cname, AccessMode::Type::WRITE);
+  _activeTrx = createTransaction(cname, AccessMode::Type::WRITE, opOptions);
   if (suffixes.size() == 2 || !search.isArray()) {
     _activeTrx->addHint(transaction::Hints::Hint::SINGLE_OPERATION);
-  }
-  if (!opOptions.isSynchronousReplicationFrom.empty()) {
-    _activeTrx->addHint(transaction::Hints::Hint::IS_FOLLOWER_TRX);
   }
 
   Result res = _activeTrx->begin();
@@ -670,7 +661,7 @@ RestStatus RestDocumentHandler::readManyDocuments() {
   OperationOptions opOptions;
   opOptions.ignoreRevs = _request->parsedValue(StaticStrings::IgnoreRevsString, true);
 
-  _activeTrx = createTransaction(cname, AccessMode::Type::READ);
+  _activeTrx = createTransaction(cname, AccessMode::Type::READ, opOptions);
 
   // ...........................................................................
   // inside read transaction

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -186,7 +186,7 @@ RestStatus RestIndexHandler::getSelectivityEstimates() {
   std::unique_ptr<transaction::Methods> trx;
 
   try {
-    trx = createTransaction(cName, AccessMode::Type::READ);
+    trx = createTransaction(cName, AccessMode::Type::READ, OperationOptions());
   } catch (basics::Exception const& ex) {
     if (ex.code() == TRI_ERROR_TRANSACTION_NOT_FOUND) {
       // this will happen if the tid of a managed transaction is passed in,

--- a/arangod/RestHandler/RestTransactionHandler.cpp
+++ b/arangod/RestHandler/RestTransactionHandler.cpp
@@ -176,7 +176,7 @@ void RestTransactionHandler::executeBegin() {
   transaction::Manager* mgr = transaction::ManagerFeature::manager();
   TRI_ASSERT(mgr != nullptr);
     
-  Result res = mgr->createManagedTrx(_vocbase, tid, slice);
+  Result res = mgr->createManagedTrx(_vocbase, tid, slice, false);
   if (res.fail()) {
     generateError(res);
   } else {

--- a/arangod/RestHandler/RestVocbaseBaseHandler.cpp
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.cpp
@@ -574,12 +574,16 @@ void RestVocbaseBaseHandler::extractStringParameter(std::string const& name,
 }
 
 std::unique_ptr<transaction::Methods> RestVocbaseBaseHandler::createTransaction(
-    std::string const& collectionName, AccessMode::Type type) const {
+    std::string const& collectionName, AccessMode::Type type, OperationOptions const& opOptions) const {
   bool found = false;
   std::string const& value = _request->header(StaticStrings::TransactionId, found);
   if (!found) {
-    return std::make_unique<SingleCollectionTransaction>(transaction::StandaloneContext::Create(_vocbase),
+    auto tmp = std::make_unique<SingleCollectionTransaction>(transaction::StandaloneContext::Create(_vocbase),
                                                          collectionName, type);
+    if (!opOptions.isSynchronousReplicationFrom.empty() && ServerState::instance()->isDBServer()) {
+      tmp->addHint(transaction::Hints::Hint::IS_FOLLOWER_TRX);
+    }
+    return tmp;
   }
   
   TRI_voc_tid_t tid = 0;
@@ -604,7 +608,7 @@ std::unique_ptr<transaction::Methods> RestVocbaseBaseHandler::createTransaction(
     std::string const& trxDef = _request->header(StaticStrings::TransactionBody, found);
     if (found) {
       auto trxOpts = VPackParser::fromJson(trxDef);
-      Result res = mgr->createManagedTrx(_vocbase, tid, trxOpts->slice());
+      Result res = mgr->createManagedTrx(_vocbase, tid, trxOpts->slice(), !opOptions.isSynchronousReplicationFrom.empty());
       if (res.fail()) {
         THROW_ARANGO_EXCEPTION(res);
       }
@@ -652,7 +656,7 @@ std::shared_ptr<transaction::Context> RestVocbaseBaseHandler::createTransactionC
       std::string const& trxDef = _request->header(StaticStrings::TransactionBody, found);
       if (found) {
         auto trxOpts = VPackParser::fromJson(trxDef);
-        Result res = mgr->createManagedTrx(_vocbase, tid, trxOpts->slice());
+        Result res = mgr->createManagedTrx(_vocbase, tid, trxOpts->slice(), false);
         if (res.fail()) {
           THROW_ARANGO_EXCEPTION(res);
         }

--- a/arangod/RestHandler/RestVocbaseBaseHandler.h
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.h
@@ -224,7 +224,8 @@ class RestVocbaseBaseHandler : public RestBaseHandler {
    * locking or a leased transaction.
    */
   std::unique_ptr<transaction::Methods> createTransaction(std::string const& cname,
-                                                          AccessMode::Type mode) const;
+                                                          AccessMode::Type mode,
+                                                          OperationOptions const& opOptions) const;
   
   /// @brief create proper transaction context, including the proper IDs
   std::shared_ptr<transaction::Context> createTransactionContext(AccessMode::Type mode) const;

--- a/arangod/Transaction/Manager.h
+++ b/arangod/Transaction/Manager.h
@@ -118,7 +118,8 @@ class Manager final {
 
   /// @brief create managed transaction
   Result createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,
-                          velocypack::Slice const trxOpts);
+                          velocypack::Slice const trxOpts,
+                          bool isFollowerTransaction);
 
   /// @brief create managed transaction
   Result createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,

--- a/arangod/Transaction/Options.cpp
+++ b/arangod/Transaction/Options.cpp
@@ -45,7 +45,8 @@ Options::Options()
 #ifdef USE_ENTERPRISE
       skipInaccessibleCollections(false),
 #endif
-      waitForSync(false) {}
+      waitForSync(false),
+      isFollowerTransaction(false) {}
   
 Options Options::replicationDefaults() {
   Options options;
@@ -97,6 +98,10 @@ void Options::fromVelocyPack(arangodb::velocypack::Slice const& slice) {
   if (value.isBool()) {
     waitForSync = value.getBool();
   }
+  value = slice.get("isFollowerTransaction");
+  if (value.isBool()) {
+    isFollowerTransaction = value.getBool();
+  }
   // we are intentionally *not* reading allowImplicitCollectionForWrite here.
   // this is an internal option only used in replication
 }
@@ -116,4 +121,5 @@ void Options::toVelocyPack(arangodb::velocypack::Builder& builder) const {
   builder.add("waitForSync", VPackValue(waitForSync));
   // we are intentionally *not* writing allowImplicitCollectionForWrite here.
   // this is an internal option only used in replication
+  builder.add("isFollowerTransaction", VPackValue(isFollowerTransaction));
 }

--- a/arangod/Transaction/Options.h
+++ b/arangod/Transaction/Options.h
@@ -68,6 +68,7 @@ struct Options {
   bool skipInaccessibleCollections;
 #endif
   bool waitForSync;
+  bool isFollowerTransaction;
 };
 
 }  // namespace transaction

--- a/arangod/V8Server/v8-actions.cpp
+++ b/arangod/V8Server/v8-actions.cpp
@@ -46,6 +46,7 @@
 #include "Rest/GeneralRequest.h"
 #include "Rest/HttpRequest.h"
 #include "Rest/HttpResponse.h"
+#include "StorageEngine/HotBackup.h"
 #include "Utils/ExecContext.h"
 #include "V8/JavaScriptSecurityContext.h"
 #include "V8/v8-buffer.h"
@@ -1756,6 +1757,38 @@ static void JS_RunInRestrictedContext(v8::FunctionCallbackInfo<v8::Value> const&
   TRI_V8_TRY_CATCH_END
 }
 
+//////////////////////////////////////////////////////////////////////////////
+/// @brief creates a hotbackup
+//////////////////////////////////////////////////////////////////////////////
+
+static void JS_CreateHotbackup(v8::FunctionCallbackInfo<v8::Value> const& args) {
+  TRI_V8_TRY_CATCH_BEGIN(isolate);
+
+  if (args.Length() != 1 || !args[0]->IsObject()) {
+    TRI_V8_THROW_EXCEPTION_USAGE("createHotbackup(obj)");
+  }
+  VPackBuilder obj;
+  int res = TRI_V8ToVPack(isolate, obj, args[0], false, true);
+  if (res != TRI_ERROR_NO_ERROR) {
+    TRI_V8_THROW_EXCEPTION_USAGE("createHotbackup(obj): could not convert body to object");
+  }
+
+  VPackBuilder result;
+#if USE_ENTERPRISE
+  TRI_GET_GLOBALS();
+  HotBackup h(v8g->_server);
+  auto r = h.execute("create", obj.slice(), result);
+  if (r.fail()) {
+    TRI_V8_THROW_EXCEPTION_MESSAGE(r.errorNumber(), r.errorMessage());
+  }
+#else
+  result.add(obj.slice());
+#endif
+
+  TRI_V8_RETURN(TRI_VPackToV8(isolate, result.slice()));
+  TRI_V8_TRY_CATCH_END
+}
+
 void TRI_InitV8ServerUtils(v8::Isolate* isolate) {
   TRI_AddGlobalFunctionVocbase(isolate,
                                TRI_V8_ASCII_STRING(isolate, "SYS_IS_FOXX_API_DISABLED"), JS_IsFoxxApiDisabled, true);
@@ -1769,6 +1802,11 @@ void TRI_InitV8ServerUtils(v8::Isolate* isolate) {
                                TRI_V8_ASCII_STRING(isolate,
                                                    "SYS_DEBUG_CLEAR_FAILAT"),
                                JS_DebugClearFailAt);
+
+  TRI_AddGlobalFunctionVocbase(isolate,
+                               TRI_V8_ASCII_STRING(isolate,
+                                                   "SYS_CREATE_HOTBACKUP"),
+                               JS_CreateHotbackup);
 
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
   TRI_AddGlobalFunctionVocbase(

--- a/js/server/bootstrap/modules/internal.js
+++ b/js/server/bootstrap/modules/internal.js
@@ -586,4 +586,9 @@
     return (role !== undefined && role !== 'SINGLE' && role !== 'AGENT');
   };
 
+  if (global.SYS_CREATE_HOTBACKUP) {
+    exports.createHotbackup = global.SYS_CREATE_HOTBACKUP;
+    delete global.SYS_CREATE_HOTBACKUP;
+  };
+
 }());

--- a/lib/Maskings/AttributeMasking.cpp
+++ b/lib/Maskings/AttributeMasking.cpp
@@ -48,7 +48,7 @@ ParseResult<AttributeMasking> AttributeMasking::parse(Maskings* maskings,
   std::string path = "";
   std::string type = "";
 
-  for (auto const& entry : VPackObjectIterator(def, false)) {
+  for (auto const entry : VPackObjectIterator(def, false)) {
     std::string key = entry.key.copyString();
 
     if (key == "type") {

--- a/lib/Maskings/Collection.cpp
+++ b/lib/Maskings/Collection.cpp
@@ -37,7 +37,7 @@ ParseResult<Collection> Collection::parse(Maskings* maskings, VPackSlice const& 
   std::string type = "";
   std::vector<AttributeMasking> attributes;
 
-  for (auto const& entry : VPackObjectIterator(def, false)) {
+  for (auto const entry : VPackObjectIterator(def, false)) {
     std::string key = entry.key.copyString();
 
     if (key == "type") {
@@ -55,7 +55,7 @@ ParseResult<Collection> Collection::parse(Maskings* maskings, VPackSlice const& 
             "expecting an array for collection maskings");
       }
 
-      for (auto const& mask : VPackArrayIterator(entry.value)) {
+      for (auto const mask : VPackArrayIterator(entry.value)) {
         ParseResult<AttributeMasking> am = AttributeMasking::parse(maskings, mask);
 
         if (am.status != ParseResult<AttributeMasking>::VALID) {

--- a/lib/Maskings/Maskings.cpp
+++ b/lib/Maskings/Maskings.cpp
@@ -95,7 +95,7 @@ ParseResult<Maskings> Maskings::parse(VPackSlice const& def) {
                                  "expecting an object for masking definition");
   }
 
-  for (auto const& entry : VPackObjectIterator(def, false)) {
+  for (auto const entry : VPackObjectIterator(def, false)) {
     std::string key = entry.key.copyString();
 
     if (key == "*") {
@@ -257,7 +257,7 @@ void Maskings::addMaskedArray(Collection& collection, VPackBuilder& builder,
 
 void Maskings::addMaskedObject(Collection& collection, VPackBuilder& builder,
                                std::vector<std::string>& path, VPackSlice const& data) {
-  for (auto const& entry : VPackObjectIterator(data, false)) {
+  for (auto const entry : VPackObjectIterator(data, false)) {
     std::string key = entry.key.copyString();
     VPackSlice const& value = entry.value;
 
@@ -304,7 +304,7 @@ void Maskings::addMasked(Collection& collection, basics::StringBuffer& data,
   {
     VPackObjectBuilder ob(&builder);
 
-    for (auto const& entry : VPackObjectIterator(slice, false)) {
+    for (auto const entry : VPackObjectIterator(slice, false)) {
       velocypack::StringRef key = entry.key.stringRef();
 
       if (key.equals(dataStrRef)) {

--- a/tests/Transaction/Manager-test.cpp
+++ b/tests/Transaction/Manager-test.cpp
@@ -225,14 +225,14 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit) {
     ASSERT_TRUE(opRes.ok());
     ASSERT_TRUE(trx.finish(opRes.result).ok());
   }
-  ASSERT_EQ(mgr->getManagedTrxStatus(tid, vocbase.name()), transaction::Status::RUNNING);
-  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).ok());
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
+  ASSERT_TRUE(mgr->commitManagedTrx(tid).ok());
   // perform same operation
-  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).ok());
+  ASSERT_TRUE(mgr->commitManagedTrx(tid).ok());
   // cannot commit aborted transaction
-  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).is(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION));
+  ASSERT_TRUE(mgr->abortManagedTrx(tid).is(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION));
 
-  ASSERT_EQ(mgr->getManagedTrxStatus(tid, vocbase.name()), transaction::Status::COMMITTED);
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::COMMITTED);
 }
 
 TEST_F(TransactionManagerTest, simple_transaction_and_commit_is_follower) {

--- a/tests/js/client/shell/shell-deadlock-trx-hotbackup-cluster.js
+++ b/tests/js/client/shell/shell-deadlock-trx-hotbackup-cluster.js
@@ -48,11 +48,7 @@ function trxWriteHotbackupDeadlock () {
     },
 
     tearDown: function () {
-      if (c !== null) {
-        c.drop();
-      }
-      c = null;
-      internal.wait(0);
+      db._drop(cn);
     },
 
     testRunAQLWritingTransactionsDuringHotbackup: function () {
@@ -81,7 +77,7 @@ function trxWriteHotbackupDeadlock () {
                         bad++;
                       }
                     }
-                    return {good,bad};
+                    return {good, bad};
                   }`,
           collections: {} }, {"x-arango-async":"store"});
       assertFalse(res.error, "Could not POST transaction.");
@@ -115,11 +111,13 @@ function trxWriteHotbackupDeadlock () {
           assertEqual(200, res.code, "Response code bad.");
           assertEqual(0, res.result.bad, "Not all hotbackups went through!");
           print("Managed to perform", res.result.good, "hotbackups.");
-          break;
+          return;
         }
         wait(1.0);
         print("Waiting for hotbackups to finish...");
       }
+      arango.DELETE(`/_api/job/${jobid}`);
+      assertFalse(true, "Did not finish in expected time.");
     }
   };
 

--- a/tests/js/client/shell/shell-deadlock-trx-hotbackup-cluster.js
+++ b/tests/js/client/shell/shell-deadlock-trx-hotbackup-cluster.js
@@ -1,0 +1,129 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global fail, assertTrue, assertFalse, assertEqual, assertNotUndefined, arango, print */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief ArangoDeadLockTests
+// /
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2020 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / @author Max Neunhoeffer
+// //////////////////////////////////////////////////////////////////////////////
+
+// tests for deadlocks in the cluster with writing trxs and hotbackup
+
+var jsunity = require('jsunity');
+var internal = require('internal');
+var arangodb = require('@arangodb');
+var db = arangodb.db;
+const isCluster = internal.isCluster();
+const time = internal.time;
+const wait = internal.wait;
+
+function trxWriteHotbackupDeadlock () {
+  'use strict';
+  var cn = 'UnitTestsDeadlockHotbackup';
+  var c = null;
+
+  return {
+
+    setUp: function () {
+      db._drop(cn);
+      c = db._create(cn, {numberOfShards: 1, replicationFactor: 2},
+                     {waitForSyncReplication: true});
+    },
+
+    tearDown: function () {
+      if (c !== null) {
+        c.drop();
+      }
+      c = null;
+      internal.wait(0);
+    },
+
+    testRunAQLWritingTransactionsDuringHotbackup: function () {
+      if (!isCluster) {
+        return true;
+      }
+
+      let start = time();
+      // This will create lots of hotbackups for approximately 60 seconds
+      let res = arango.POST_RAW("/_api/transaction",
+        { action: `function() {
+                    let console = require("console");
+                    let internal = require("internal");
+                    let wait = internal.wait;
+                    let time = internal.time;
+                    let start = time();
+                    let good = 0;
+                    let bad = 0;
+                    while (time() - start < 60) {
+                      try {
+                        internal.createHotbackup({});
+                        console.log("Created a hotbackup!");
+                        good++;
+                      } catch(e) {
+                        console.error("Caught exception when creating a hotbackup!", e);
+                        bad++;
+                      }
+                    }
+                    return {good,bad};
+                  }`,
+          collections: {} }, {"x-arango-async":"store"});
+      assertFalse(res.error, "Could not POST transaction.");
+      assertEqual(202, res.code, "Bad response code.");
+      let jobid = res.headers["x-arango-async-id"];
+
+      // Now we try to write something:
+      for (let i = 0; i < 1000; ++i) {
+        c.insert({Hallo:i});
+      }
+      // And now to execute exclusive write locking transactions:
+      for (let i = 1; i <= 750; ++i) {
+        db._query(`LET m = (FOR d IN ${cn}
+                              SORT d.Hallo DESC
+                              LIMIT 1
+                              RETURN d)
+                   INSERT {Hallo: m[0].Hallo+1} INTO ${cn}
+                   OPTIONS {exclusive: true}
+                   RETURN NEW`).toArray();
+        if (i % 50 === 0) {
+          print("Done", i, "write transactions.");
+        }
+        wait(0.01);
+      }
+      let diff = time() - start;
+      print("Done 750 exclusive transactions in", diff, "seconds!");
+      assertTrue(diff < 60, "750 transactions took too long, probably some deadlock with hotbackups");
+      while (time() - start < 80) {
+        res = arango.PUT(`/_api/job/${jobid}`, {});
+        if (res.code !== 204) {
+          assertEqual(200, res.code, "Response code bad.");
+          assertEqual(0, res.result.bad, "Not all hotbackups went through!");
+          print("Managed to perform", res.result.good, "hotbackups.");
+          break;
+        }
+        wait(1.0);
+        print("Waiting for hotbackups to finish...");
+      }
+    }
+  };
+
+}
+
+jsunity.run(trxWriteHotbackupDeadlock);
+return jsunity.done();


### PR DESCRIPTION
Make sure all follower trxs know that they are follower trxs.

Before this patch, follower transactions created from AQL or other
El Cheapo transactions did not know they are follower transactions.
This could cause deadlocks between write transactions and hotbackups.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers)*

- [+] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [ ] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [+] Backports required for: *(Please specify versions)* all, in
  progress.

#### Related Information

*(Please reference tickets / specification etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added **Regression Tests**
  - [ ] Added new C++ **Unit Tests**
  - [ ] Added new **integration tests** (i.e. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)

Additionally:

- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

*(Include link to Jenkins run etc)*

Testing will be added later. This is difficult in the current framework.

