### PR TITLE
Fix deadlocks between write transactions and hotbackup, take 2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,9 @@
 v3.7.3.2 (2020-XX-XX)
 ---------------------
 
-* Fixed a deadlock between AQL write transactions and hotbackup, since
-  in AQL write transactions follower transactions did not know they are
-  follower transactions.
+* Fixed a deadlock between AQL write transactions and hotbackup, since in AQL
+  write transactions follower transactions did not know they are follower
+  transactions.
 
 
 v3.7.3.1 (2020-11-01)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+v3.7.3.2 (2020-XX-XX)
+---------------------
+
+* Fixed a deadlock between AQL write transactions and hotbackup, since
+  in AQL write transactions follower transactions did not know they are
+  follower transactions.
+
+
 v3.7.3.1 (2020-11-01)
 ---------------------
 

--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -481,7 +481,7 @@ RestStatus RestCollectionHandler::handleCommandPut() {
     opts.isSynchronousReplicationFrom =
         _request->value("isSynchronousReplication");
 
-    _activeTrx = createTransaction(coll->name(), AccessMode::Type::EXCLUSIVE);
+    _activeTrx = createTransaction(coll->name(), AccessMode::Type::EXCLUSIVE, opts);
     _activeTrx->addHint(transaction::Hints::Hint::INTERMEDIATE_COMMITS);
     _activeTrx->addHint(transaction::Hints::Hint::ALLOW_RANGE_DELETE);
     res = _activeTrx->begin();
@@ -779,7 +779,7 @@ RestStatus RestCollectionHandler::standardResponse() {
 
 void RestCollectionHandler::initializeTransaction(LogicalCollection& coll) {
   try {
-    _activeTrx = createTransaction(coll.name(), AccessMode::Type::READ);
+    _activeTrx = createTransaction(coll.name(), AccessMode::Type::READ, OperationOptions());
   } catch (basics::Exception const& ex) {
     if (ex.code() == TRI_ERROR_TRANSACTION_NOT_FOUND) {
       // this will happen if the tid of a managed transaction is passed in,

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -197,14 +197,11 @@ RestStatus RestDocumentHandler::insertDocument() {
                          opOptions.isSynchronousReplicationFrom);
 
   // find and load collection given by name or identifier
-  _activeTrx = createTransaction(cname, AccessMode::Type::WRITE);
+  _activeTrx = createTransaction(cname, AccessMode::Type::WRITE, opOptions);
   bool const isMultiple = body.isArray();
 
   if (!isMultiple && !opOptions.isOverwriteModeUpdateReplace()) {
     _activeTrx->addHint(transaction::Hints::Hint::SINGLE_OPERATION);
-  }
-  if (!opOptions.isSynchronousReplicationFrom.empty()) {
-    _activeTrx->addHint(transaction::Hints::Hint::IS_FOLLOWER_TRX);
   }
 
   Result res = _activeTrx->begin();
@@ -302,7 +299,7 @@ RestStatus RestDocumentHandler::readSingleDocument(bool generateBody) {
   VPackSlice search = builder.slice();
 
   // find and load collection given by name or identifier
-  _activeTrx = createTransaction(collection, AccessMode::Type::READ);
+  _activeTrx = createTransaction(collection, AccessMode::Type::READ, options);
 
   _activeTrx->addHint(transaction::Hints::Hint::SINGLE_OPERATION);
 
@@ -487,13 +484,10 @@ RestStatus RestDocumentHandler::modifyDocument(bool isPatch) {
   }
 
   // find and load collection given by name or identifier
-  _activeTrx = createTransaction(cname, AccessMode::Type::WRITE);
+  _activeTrx = createTransaction(cname, AccessMode::Type::WRITE, opOptions);
 
   if (!isArrayCase) {
     _activeTrx->addHint(transaction::Hints::Hint::SINGLE_OPERATION);
-  }
-  if (!opOptions.isSynchronousReplicationFrom.empty()) {
-    _activeTrx->addHint(transaction::Hints::Hint::IS_FOLLOWER_TRX);
   }
 
   // ...........................................................................
@@ -610,12 +604,9 @@ RestStatus RestDocumentHandler::removeDocument() {
     return RestStatus::DONE;
   }
 
-  _activeTrx = createTransaction(cname, AccessMode::Type::WRITE);
+  _activeTrx = createTransaction(cname, AccessMode::Type::WRITE, opOptions);
   if (suffixes.size() == 2 || !search.isArray()) {
     _activeTrx->addHint(transaction::Hints::Hint::SINGLE_OPERATION);
-  }
-  if (!opOptions.isSynchronousReplicationFrom.empty()) {
-    _activeTrx->addHint(transaction::Hints::Hint::IS_FOLLOWER_TRX);
   }
 
   Result res = _activeTrx->begin();
@@ -670,7 +661,7 @@ RestStatus RestDocumentHandler::readManyDocuments() {
   OperationOptions opOptions;
   opOptions.ignoreRevs = _request->parsedValue(StaticStrings::IgnoreRevsString, true);
 
-  _activeTrx = createTransaction(cname, AccessMode::Type::READ);
+  _activeTrx = createTransaction(cname, AccessMode::Type::READ, opOptions);
 
   // ...........................................................................
   // inside read transaction

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -186,7 +186,7 @@ RestStatus RestIndexHandler::getSelectivityEstimates() {
   std::unique_ptr<transaction::Methods> trx;
 
   try {
-    trx = createTransaction(cName, AccessMode::Type::READ);
+    trx = createTransaction(cName, AccessMode::Type::READ, OperationOptions());
   } catch (basics::Exception const& ex) {
     if (ex.code() == TRI_ERROR_TRANSACTION_NOT_FOUND) {
       // this will happen if the tid of a managed transaction is passed in,

--- a/arangod/RestHandler/RestTransactionHandler.cpp
+++ b/arangod/RestHandler/RestTransactionHandler.cpp
@@ -176,7 +176,7 @@ void RestTransactionHandler::executeBegin() {
   transaction::Manager* mgr = transaction::ManagerFeature::manager();
   TRI_ASSERT(mgr != nullptr);
     
-  Result res = mgr->createManagedTrx(_vocbase, tid, slice);
+  Result res = mgr->createManagedTrx(_vocbase, tid, slice, false);
   if (res.fail()) {
     generateError(res);
   } else {

--- a/arangod/RestHandler/RestVocbaseBaseHandler.cpp
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.cpp
@@ -574,12 +574,16 @@ void RestVocbaseBaseHandler::extractStringParameter(std::string const& name,
 }
 
 std::unique_ptr<transaction::Methods> RestVocbaseBaseHandler::createTransaction(
-    std::string const& collectionName, AccessMode::Type type) const {
+    std::string const& collectionName, AccessMode::Type type, OperationOptions const& opOptions) const {
   bool found = false;
   std::string const& value = _request->header(StaticStrings::TransactionId, found);
   if (!found) {
-    return std::make_unique<SingleCollectionTransaction>(transaction::StandaloneContext::Create(_vocbase),
+    auto tmp = std::make_unique<SingleCollectionTransaction>(transaction::StandaloneContext::Create(_vocbase),
                                                          collectionName, type);
+    if (!opOptions.isSynchronousReplicationFrom.empty() && ServerState::instance()->isDBServer()) {
+      tmp->addHint(transaction::Hints::Hint::IS_FOLLOWER_TRX);
+    }
+    return tmp;
   }
   
   TRI_voc_tid_t tid = 0;
@@ -604,7 +608,7 @@ std::unique_ptr<transaction::Methods> RestVocbaseBaseHandler::createTransaction(
     std::string const& trxDef = _request->header(StaticStrings::TransactionBody, found);
     if (found) {
       auto trxOpts = VPackParser::fromJson(trxDef);
-      Result res = mgr->createManagedTrx(_vocbase, tid, trxOpts->slice());
+      Result res = mgr->createManagedTrx(_vocbase, tid, trxOpts->slice(), !opOptions.isSynchronousReplicationFrom.empty());
       if (res.fail()) {
         THROW_ARANGO_EXCEPTION(res);
       }
@@ -652,7 +656,7 @@ std::shared_ptr<transaction::Context> RestVocbaseBaseHandler::createTransactionC
       std::string const& trxDef = _request->header(StaticStrings::TransactionBody, found);
       if (found) {
         auto trxOpts = VPackParser::fromJson(trxDef);
-        Result res = mgr->createManagedTrx(_vocbase, tid, trxOpts->slice());
+        Result res = mgr->createManagedTrx(_vocbase, tid, trxOpts->slice(), false);
         if (res.fail()) {
           THROW_ARANGO_EXCEPTION(res);
         }

--- a/arangod/RestHandler/RestVocbaseBaseHandler.h
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.h
@@ -224,7 +224,8 @@ class RestVocbaseBaseHandler : public RestBaseHandler {
    * locking or a leased transaction.
    */
   std::unique_ptr<transaction::Methods> createTransaction(std::string const& cname,
-                                                          AccessMode::Type mode) const;
+                                                          AccessMode::Type mode,
+                                                          OperationOptions const& opOptions) const;
   
   /// @brief create proper transaction context, including the proper IDs
   std::shared_ptr<transaction::Context> createTransactionContext(AccessMode::Type mode) const;

--- a/arangod/Transaction/Manager.h
+++ b/arangod/Transaction/Manager.h
@@ -118,7 +118,8 @@ class Manager final {
 
   /// @brief create managed transaction
   Result createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,
-                          velocypack::Slice const trxOpts);
+                          velocypack::Slice const trxOpts,
+                          bool isFollowerTransaction);
 
   /// @brief create managed transaction
   Result createManagedTrx(TRI_vocbase_t& vocbase, TRI_voc_tid_t tid,

--- a/arangod/Transaction/Options.cpp
+++ b/arangod/Transaction/Options.cpp
@@ -45,7 +45,8 @@ Options::Options()
 #ifdef USE_ENTERPRISE
       skipInaccessibleCollections(false),
 #endif
-      waitForSync(false) {}
+      waitForSync(false),
+      isFollowerTransaction(false) {}
   
 Options Options::replicationDefaults() {
   Options options;
@@ -97,6 +98,10 @@ void Options::fromVelocyPack(arangodb::velocypack::Slice const& slice) {
   if (value.isBool()) {
     waitForSync = value.getBool();
   }
+  value = slice.get("isFollowerTransaction");
+  if (value.isBool()) {
+    isFollowerTransaction = value.getBool();
+  }
   // we are intentionally *not* reading allowImplicitCollectionForWrite here.
   // this is an internal option only used in replication
 }
@@ -116,4 +121,5 @@ void Options::toVelocyPack(arangodb::velocypack::Builder& builder) const {
   builder.add("waitForSync", VPackValue(waitForSync));
   // we are intentionally *not* writing allowImplicitCollectionForWrite here.
   // this is an internal option only used in replication
+  builder.add("isFollowerTransaction", VPackValue(isFollowerTransaction));
 }

--- a/arangod/Transaction/Options.h
+++ b/arangod/Transaction/Options.h
@@ -68,6 +68,7 @@ struct Options {
   bool skipInaccessibleCollections;
 #endif
   bool waitForSync;
+  bool isFollowerTransaction;
 };
 
 }  // namespace transaction

--- a/arangod/V8Server/v8-actions.cpp
+++ b/arangod/V8Server/v8-actions.cpp
@@ -46,6 +46,7 @@
 #include "Rest/GeneralRequest.h"
 #include "Rest/HttpRequest.h"
 #include "Rest/HttpResponse.h"
+#include "StorageEngine/HotBackup.h"
 #include "Utils/ExecContext.h"
 #include "V8/JavaScriptSecurityContext.h"
 #include "V8/v8-buffer.h"
@@ -1756,6 +1757,38 @@ static void JS_RunInRestrictedContext(v8::FunctionCallbackInfo<v8::Value> const&
   TRI_V8_TRY_CATCH_END
 }
 
+//////////////////////////////////////////////////////////////////////////////
+/// @brief creates a hotbackup
+//////////////////////////////////////////////////////////////////////////////
+
+static void JS_CreateHotbackup(v8::FunctionCallbackInfo<v8::Value> const& args) {
+  TRI_V8_TRY_CATCH_BEGIN(isolate);
+
+  if (args.Length() != 1 || !args[0]->IsObject()) {
+    TRI_V8_THROW_EXCEPTION_USAGE("createHotbackup(obj)");
+  }
+  VPackBuilder obj;
+  int res = TRI_V8ToVPack(isolate, obj, args[0], false, true);
+  if (res != TRI_ERROR_NO_ERROR) {
+    TRI_V8_THROW_EXCEPTION_USAGE("createHotbackup(obj): could not convert body to object");
+  }
+
+  VPackBuilder result;
+#if USE_ENTERPRISE
+  TRI_GET_GLOBALS();
+  HotBackup h(v8g->_server);
+  auto r = h.execute("create", obj.slice(), result);
+  if (r.fail()) {
+    TRI_V8_THROW_EXCEPTION_MESSAGE(r.errorNumber(), r.errorMessage());
+  }
+#else
+  result.add(obj.slice());
+#endif
+
+  TRI_V8_RETURN(TRI_VPackToV8(isolate, result.slice()));
+  TRI_V8_TRY_CATCH_END
+}
+
 void TRI_InitV8ServerUtils(v8::Isolate* isolate) {
   TRI_AddGlobalFunctionVocbase(isolate,
                                TRI_V8_ASCII_STRING(isolate, "SYS_IS_FOXX_API_DISABLED"), JS_IsFoxxApiDisabled, true);
@@ -1769,6 +1802,11 @@ void TRI_InitV8ServerUtils(v8::Isolate* isolate) {
                                TRI_V8_ASCII_STRING(isolate,
                                                    "SYS_DEBUG_CLEAR_FAILAT"),
                                JS_DebugClearFailAt);
+
+  TRI_AddGlobalFunctionVocbase(isolate,
+                               TRI_V8_ASCII_STRING(isolate,
+                                                   "SYS_CREATE_HOTBACKUP"),
+                               JS_CreateHotbackup);
 
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
   TRI_AddGlobalFunctionVocbase(

--- a/js/server/bootstrap/modules/internal.js
+++ b/js/server/bootstrap/modules/internal.js
@@ -586,4 +586,9 @@
     return (role !== undefined && role !== 'SINGLE' && role !== 'AGENT');
   };
 
+  if (global.SYS_CREATE_HOTBACKUP) {
+    exports.createHotbackup = global.SYS_CREATE_HOTBACKUP;
+    delete global.SYS_CREATE_HOTBACKUP;
+  };
+
 }());

--- a/js/server/modules/@arangodb/cluster.js
+++ b/js/server/modules/@arangodb/cluster.js
@@ -32,8 +32,8 @@ var console = require('console');
 var arangodb = require('@arangodb');
 var ArangoError = arangodb.ArangoError;
 var errors = require("internal").errors;
+var wait = require('internal').wait;
 var isEnterprise = require('internal').isEnterprise();
-var request = require('@arangodb/request');
 var _ = require('lodash');
 
 var endpointToURL = function (endpoint) {

--- a/js/server/modules/@arangodb/cluster.js
+++ b/js/server/modules/@arangodb/cluster.js
@@ -33,7 +33,9 @@ var arangodb = require('@arangodb');
 var ArangoError = arangodb.ArangoError;
 var errors = require("internal").errors;
 var wait = require('internal').wait;
+var time = require('internal').time;
 var isEnterprise = require('internal').isEnterprise();
+var request = require('@arangodb/request');
 var _ = require('lodash');
 
 var endpointToURL = function (endpoint) {
@@ -435,6 +437,18 @@ function queryAgencyJob(id) {
   return {error: true, errorMsg: "Did not find job.", id, job: null};
 }
 
+function createManyBackups(t) {
+  let start = time();
+  while (time() - start < t) {
+    try {
+      require("internal").createHotbackup({});
+      console.log("Created a hotbackup!");
+    } catch(e) {
+      console.error("Caught exception when creating a hotbackup!", e);
+    }
+  }
+}
+
 exports.coordinatorId = coordinatorId;
 exports.isCluster = isCluster;
 exports.isCoordinator = isCoordinator;
@@ -450,3 +464,4 @@ exports.supervisionState = supervisionState;
 exports.waitForSyncRepl = waitForSyncRepl;
 exports.endpoints = endpoints;
 exports.queryAgencyJob = queryAgencyJob;
+exports.createManyBackups = createManyBackups;

--- a/js/server/modules/@arangodb/cluster.js
+++ b/js/server/modules/@arangodb/cluster.js
@@ -32,8 +32,6 @@ var console = require('console');
 var arangodb = require('@arangodb');
 var ArangoError = arangodb.ArangoError;
 var errors = require("internal").errors;
-var wait = require('internal').wait;
-var time = require('internal').time;
 var isEnterprise = require('internal').isEnterprise();
 var request = require('@arangodb/request');
 var _ = require('lodash');
@@ -437,18 +435,6 @@ function queryAgencyJob(id) {
   return {error: true, errorMsg: "Did not find job.", id, job: null};
 }
 
-function createManyBackups(t) {
-  let start = time();
-  while (time() - start < t) {
-    try {
-      require("internal").createHotbackup({});
-      console.log("Created a hotbackup!");
-    } catch(e) {
-      console.error("Caught exception when creating a hotbackup!", e);
-    }
-  }
-}
-
 exports.coordinatorId = coordinatorId;
 exports.isCluster = isCluster;
 exports.isCoordinator = isCoordinator;
@@ -464,4 +450,3 @@ exports.supervisionState = supervisionState;
 exports.waitForSyncRepl = waitForSyncRepl;
 exports.endpoints = endpoints;
 exports.queryAgencyJob = queryAgencyJob;
-exports.createManyBackups = createManyBackups;

--- a/lib/Maskings/AttributeMasking.cpp
+++ b/lib/Maskings/AttributeMasking.cpp
@@ -48,7 +48,7 @@ ParseResult<AttributeMasking> AttributeMasking::parse(Maskings* maskings,
   std::string path = "";
   std::string type = "";
 
-  for (auto const& entry : VPackObjectIterator(def, false)) {
+  for (auto const entry : VPackObjectIterator(def, false)) {
     std::string key = entry.key.copyString();
 
     if (key == "type") {

--- a/lib/Maskings/Collection.cpp
+++ b/lib/Maskings/Collection.cpp
@@ -37,7 +37,7 @@ ParseResult<Collection> Collection::parse(Maskings* maskings, VPackSlice const& 
   std::string type = "";
   std::vector<AttributeMasking> attributes;
 
-  for (auto const& entry : VPackObjectIterator(def, false)) {
+  for (auto const entry : VPackObjectIterator(def, false)) {
     std::string key = entry.key.copyString();
 
     if (key == "type") {
@@ -55,7 +55,7 @@ ParseResult<Collection> Collection::parse(Maskings* maskings, VPackSlice const& 
             "expecting an array for collection maskings");
       }
 
-      for (auto const& mask : VPackArrayIterator(entry.value)) {
+      for (auto const mask : VPackArrayIterator(entry.value)) {
         ParseResult<AttributeMasking> am = AttributeMasking::parse(maskings, mask);
 
         if (am.status != ParseResult<AttributeMasking>::VALID) {

--- a/tests/Transaction/Manager-test.cpp
+++ b/tests/Transaction/Manager-test.cpp
@@ -93,12 +93,12 @@ class TransactionManagerTest : public ::testing::Test {
 
 TEST_F(TransactionManagerTest, parsing_errors) {
   auto json = arangodb::velocypack::Parser::fromJson("{ \"write\": [33] }");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   EXPECT_TRUE(res.is(TRI_ERROR_BAD_PARAMETER));
 
   json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": \"33\"}, \"lockTimeout\": -1 }");
-  res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   EXPECT_TRUE(res.is(TRI_ERROR_BAD_PARAMETER));
 }
 
@@ -107,17 +107,17 @@ TEST_F(TransactionManagerTest, collection_not_found) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"read\": [\"33\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   EXPECT_EQ(res.errorNumber(), TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
 
   json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"33\"]}}");
-  res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   EXPECT_EQ(res.errorNumber(), TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
 
   json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"exclusive\": [\"33\"]}}");
-  res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   EXPECT_EQ(res.errorNumber(), TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
 }
 
@@ -132,12 +132,12 @@ TEST_F(TransactionManagerTest, transaction_id_reuse) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"read\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_TRUE(res.ok());
 
   json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"33\"]}}");
-  res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   EXPECT_EQ(res.errorNumber(), TRI_ERROR_TRANSACTION_INTERNAL);
 
   res = mgr->abortManagedTrx(tid);
@@ -155,7 +155,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_abort) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_TRUE(res.ok());
 
   auto doc = arangodb::velocypack::Parser::fromJson("{ \"_key\": \"1\"}");
@@ -207,7 +207,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_TRUE(res.ok());
 
   {
@@ -216,6 +216,46 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit) {
 
     SingleCollectionTransaction trx(ctx, "testCollection", AccessMode::Type::WRITE);
     ASSERT_TRUE(!trx.isMainTransaction());
+    ASSERT_FALSE(trx.state()->hasHint(transaction::Hints::Hint::IS_FOLLOWER_TRX));
+
+    auto doc = arangodb::velocypack::Parser::fromJson("{ \"abc\": 1}");
+
+    OperationOptions opts;
+    auto opRes = trx.insert(coll->name(), doc->slice(), opts);
+    ASSERT_TRUE(opRes.ok());
+    ASSERT_TRUE(trx.finish(opRes.result).ok());
+  }
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
+  ASSERT_TRUE(mgr->commitManagedTrx(tid).ok());
+  // perform same operation
+  ASSERT_TRUE(mgr->commitManagedTrx(tid).ok());
+  // cannot commit aborted transaction
+  ASSERT_TRUE(mgr->abortManagedTrx(tid).is(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION));
+
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::COMMITTED);
+}
+
+TEST_F(TransactionManagerTest, simple_transaction_and_commit_is_follower) {
+  std::shared_ptr<LogicalCollection> coll;
+  {
+    auto json =
+        VPackParser::fromJson("{ \"name\": \"testCollection\", \"id\": 42 }");
+    coll = vocbase.createCollection(json->slice());
+  }
+  ASSERT_NE(coll, nullptr);
+
+  auto json = arangodb::velocypack::Parser::fromJson(
+      "{ \"collections\":{\"write\": [\"42\"]}}");
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), true);
+  ASSERT_TRUE(res.ok());
+
+  {
+    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE);
+    ASSERT_NE(ctx.get(), nullptr);
+
+    SingleCollectionTransaction trx(ctx, "testCollection", AccessMode::Type::WRITE);
+    ASSERT_TRUE(!trx.isMainTransaction());
+    ASSERT_TRUE(trx.state()->hasHint(transaction::Hints::Hint::IS_FOLLOWER_TRX));
 
     auto doc = arangodb::velocypack::Parser::fromJson("{ \"abc\": 1}");
 
@@ -245,7 +285,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit_while_in_use) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_TRUE(res.ok());
 
   {
@@ -284,7 +324,7 @@ TEST_F(TransactionManagerTest, leading_multiple_readonly_transactions) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"read\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_TRUE(res.ok());
 
   {
@@ -324,7 +364,7 @@ TEST_F(TransactionManagerTest, lock_conflict) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_TRUE(res.ok());
   {
     transaction::Options opts;
@@ -352,7 +392,7 @@ TEST_F(TransactionManagerTest, garbage_collection_shutdown) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_TRUE(res.ok());
   {
     transaction::Options opts;
@@ -413,7 +453,7 @@ TEST_F(TransactionManagerTest, abort_transactions_with_matcher) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_TRUE(res.ok());
 
   {
@@ -459,14 +499,14 @@ TEST_F(TransactionManagerTest, permission_denied_readonly) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"read\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   EXPECT_TRUE(res.ok());
   ASSERT_TRUE(mgr->abortManagedTrx(tid).ok());
 
   tid = TRI_NewTickServer();
   json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"42\"]}}");
-  res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_EQ(res.errorNumber(), TRI_ERROR_ARANGO_READ_ONLY);
 }
 
@@ -489,6 +529,6 @@ TEST_F(TransactionManagerTest, permission_denied_forbidden) {
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"read\": [\"42\"]}}");
-  Result res = mgr->createManagedTrx(vocbase, tid, json->slice());
+  Result res = mgr->createManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_EQ(res.errorNumber(), TRI_ERROR_FORBIDDEN);
 }

--- a/tests/js/client/shell/shell-deadlock-trx-hotbackup-cluster.js
+++ b/tests/js/client/shell/shell-deadlock-trx-hotbackup-cluster.js
@@ -48,11 +48,7 @@ function trxWriteHotbackupDeadlock () {
     },
 
     tearDown: function () {
-      if (c !== null) {
-        c.drop();
-      }
-      c = null;
-      internal.wait(0);
+      db._drop(cn);
     },
 
     testRunAQLWritingTransactionsDuringHotbackup: function () {
@@ -81,7 +77,7 @@ function trxWriteHotbackupDeadlock () {
                         bad++;
                       }
                     }
-                    return {good,bad};
+                    return {good, bad};
                   }`,
           collections: {} }, {"x-arango-async":"store"});
       assertFalse(res.error, "Could not POST transaction.");
@@ -115,11 +111,13 @@ function trxWriteHotbackupDeadlock () {
           assertEqual(200, res.code, "Response code bad.");
           assertEqual(0, res.result.bad, "Not all hotbackups went through!");
           print("Managed to perform", res.result.good, "hotbackups.");
-          break;
+          return;
         }
         wait(1.0);
         print("Waiting for hotbackups to finish...");
       }
+      arango.DELETE(`/_api/job/${jobid}`);
+      assertFalse(true, "Did not finish in expected time.");
     }
   };
 

--- a/tests/js/client/shell/shell-deadlock-trx-hotbackup-cluster.js
+++ b/tests/js/client/shell/shell-deadlock-trx-hotbackup-cluster.js
@@ -1,5 +1,5 @@
 /* jshint globalstrict:false, strict:false, maxlen: 200 */
-/* global fail, assertTrue, assertFalse, assertEqual, assertNotUndefined, arango */
+/* global fail, assertTrue, assertFalse, assertEqual, assertNotUndefined, arango, print */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief ArangoDeadLockTests

--- a/tests/js/client/shell/shell-deadlock-trx-hotbackup-cluster.js
+++ b/tests/js/client/shell/shell-deadlock-trx-hotbackup-cluster.js
@@ -94,7 +94,7 @@ function trxWriteHotbackupDeadlock () {
       }
       // And now to execute exclusive write locking transactions:
       for (let i = 1; i <= 750; ++i) {
-        db._query(`LET m = (FOR d IN ${cn} 
+        db._query(`LET m = (FOR d IN ${cn}
                               SORT d.Hallo DESC
                               LIMIT 1
                               RETURN d)

--- a/tests/js/client/shell/shell-deadlock-trx-hotbackup-cluster.js
+++ b/tests/js/client/shell/shell-deadlock-trx-hotbackup-cluster.js
@@ -1,0 +1,99 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global fail, assertTrue, assertFalse, assertEqual, assertNotUndefined, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief ArangoDeadLockTests
+// /
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2020 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / @author Max Neunhoeffer
+// //////////////////////////////////////////////////////////////////////////////
+
+// tests for deadlocks in the cluster with writing trxs and hotbackup
+
+var jsunity = require('jsunity');
+var internal = require('internal');
+var arangodb = require('@arangodb');
+var db = arangodb.db;
+const isCluster = internal.isCluster();
+const time = internal.time;
+const wait = internal.wait;
+
+function trxWriteHotbackupDeadlock () {
+  'use strict';
+  var cn = 'UnitTestsDeadlockHotbackup';
+  var c = null;
+
+  return {
+
+    setUp: function () {
+      db._drop(cn);
+      c = db._create(cn, {numberOfShards: 1, replicationFactor: 2});
+    },
+
+    tearDown: function () {
+      if (c !== null) {
+        c.drop();
+      }
+      c = null;
+      internal.wait(0);
+    },
+
+    testRunAQLWritingTransactionsDuringHotbackup: function () {
+      if (!isCluster) {
+        return true;
+      }
+
+      wait(3);   // give the cluster some time to settle before we start
+                 // the hotbackups
+
+      let start = time();
+      // This will create lots of hotbackups for approximately 60 seconds
+      db._connection.POST("_admin/execute",`require("@arangodb/cluster.js").createManyBackups(60); return true;`,{"x-arango-async":"store"});
+      // Now we try to write something:
+      for (let i = 0; i < 1000; ++i) {
+        c.insert({Hallo:i});
+      }
+      // And now to execute exclusive write locking transactions:
+      for (let i = 1; i <= 750; ++i) {
+        db._query(`LET m = (FOR d IN ${cn} 
+                              SORT d.Hallo DESC
+                              LIMIT 1
+                              RETURN d)
+                   INSERT {Hallo: m[0].Hallo+1} INTO ${cn}
+                   OPTIONS {exclusive: true}
+                   RETURN NEW`).toArray();
+        if (i % 50 === 0) {
+          print("Done", i, "write transactions.");
+        }
+        wait(0.01);
+      }
+      let diff = time() - start;
+      print("Done 750 exclusive transactions in", diff, "seconds!");
+      assertTrue(diff < 60, "750 transactions took too long, probably some deadlock with hotbackups");
+      while (time() - start < 65) {
+        wait(1.0);
+        print("Waiting for hotbackups to finish...");
+      }
+    }
+  };
+
+}
+
+jsunity.run(trxWriteHotbackupDeadlock);
+return jsunity.done();


### PR DESCRIPTION
Make sure all follower trxs know that they are follower trxs.

Before this patch, follower transactions created from AQL or other
El Cheapo transactions did not know they are follower transactions.
This could cause deadlocks between write transactions and hotbackups.

This is the port to the 3.7.3 branch.
