### PR TITLE
fix log topic for shutdown message

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fix log topic of general shutdown message from "cluster" to general.
+
 * Make the DOCUMENT AQL function eligible for running on DB servers in
   OneShard deployment mode. This allows pushing more query parts to DB servers
   for execution.

--- a/arangod/Scheduler/SchedulerFeature.cpp
+++ b/arangod/Scheduler/SchedulerFeature.cpp
@@ -338,7 +338,7 @@ extern "C" void c_exit_handler(int signal) {
 
       application_features::ApplicationServer::CTRL_C.store(true);
     } else {
-      LOG_TOPIC("11ca3", FATAL, arangodb::Logger::CLUSTER)
+      LOG_TOPIC("11ca3", FATAL, arangodb::Logger::FIXME)
           << "control-c received (again!), terminating";
       FATAL_ERROR_EXIT();
     }


### PR DESCRIPTION
### Scope & Purpose

Fix misleading log topic "cluster" for general shutdown message.
The shutdown has nothing to do with the cluster in particular, so the log message shouldn't use the "cluster" topic.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12730/