### PR TITLE
Add deadlock test for hotbackup

### DIFF
--- a/arangod/V8Server/v8-actions.cpp
+++ b/arangod/V8Server/v8-actions.cpp
@@ -46,6 +46,7 @@
 #include "Rest/GeneralRequest.h"
 #include "Rest/HttpRequest.h"
 #include "Rest/HttpResponse.h"
+#include "StorageEngine/HotBackup.h"
 #include "Utils/ExecContext.h"
 #include "V8/JavaScriptSecurityContext.h"
 #include "V8/v8-buffer.h"
@@ -1738,6 +1739,38 @@ static void JS_RunInRestrictedContext(v8::FunctionCallbackInfo<v8::Value> const&
   TRI_V8_TRY_CATCH_END
 }
 
+//////////////////////////////////////////////////////////////////////////////
+/// @brief creates a hotbackup
+//////////////////////////////////////////////////////////////////////////////
+
+static void JS_CreateHotbackup(v8::FunctionCallbackInfo<v8::Value> const& args) {
+  TRI_V8_TRY_CATCH_BEGIN(isolate);
+
+  if (args.Length() != 1 || !args[0]->IsObject()) {
+    TRI_V8_THROW_EXCEPTION_USAGE("createHotbackup(obj)");
+  }
+  VPackBuilder obj;
+  int res = TRI_V8ToVPack(isolate, obj, args[0], false, true);
+  if (res != TRI_ERROR_NO_ERROR) {
+    TRI_V8_THROW_EXCEPTION_USAGE("createHotbackup(obj): could not convert bodyto object");
+  }
+
+  VPackBuilder result;
+#if USE_ENTERPRISE
+  TRI_GET_GLOBALS();
+  HotBackup h(v8g->_server);
+  auto r = h.execute("create", obj.slice(), result);
+  if (r.fail()) {
+    TRI_V8_THROW_EXCEPTION_MESSAGE(r.errorNumber(), r.errorMessage());
+  }
+#else
+  result.add(obj.slice());
+#endif
+
+  TRI_V8_RETURN(TRI_VPackToV8(isolate, result.slice()));
+  TRI_V8_TRY_CATCH_END
+}
+
 void TRI_InitV8ServerUtils(v8::Isolate* isolate) {
   TRI_AddGlobalFunctionVocbase(isolate,
                                TRI_V8_ASCII_STRING(isolate, "SYS_IS_FOXX_API_DISABLED"), JS_IsFoxxApiDisabled, true);
@@ -1745,6 +1778,11 @@ void TRI_InitV8ServerUtils(v8::Isolate* isolate) {
                                TRI_V8_ASCII_STRING(isolate, "SYS_IS_FOXX_STORE_DISABLED"), JS_IsFoxxStoreDisabled, true);
   TRI_AddGlobalFunctionVocbase(isolate,
                                TRI_V8_ASCII_STRING(isolate, "SYS_RUN_IN_RESTRICTED_CONTEXT"), JS_RunInRestrictedContext, true);
+
+  TRI_AddGlobalFunctionVocbase(isolate,
+                               TRI_V8_ASCII_STRING(isolate,
+                                                   "SYS_CREATE_HOTBACKUP"),
+                               JS_CreateHotbackup);
 
   // debugging functions
   TRI_AddGlobalFunctionVocbase(isolate,

--- a/arangod/V8Server/v8-actions.cpp
+++ b/arangod/V8Server/v8-actions.cpp
@@ -1757,8 +1757,8 @@ static void JS_CreateHotbackup(v8::FunctionCallbackInfo<v8::Value> const& args) 
 
   VPackBuilder result;
 #if USE_ENTERPRISE
-  TRI_GET_GLOBALS();
-  HotBackup h(v8g->_server);
+  auto& server = application_features::ApplicationServer::server();
+  HotBackup h(server);
   auto r = h.execute("create", obj.slice(), result);
   if (r.fail()) {
     TRI_V8_THROW_EXCEPTION_MESSAGE(r.errorNumber(), r.errorMessage());

--- a/js/server/bootstrap/modules/internal.js
+++ b/js/server/bootstrap/modules/internal.js
@@ -591,4 +591,9 @@
     return (role !== undefined && role !== 'SINGLE' && role !== 'AGENT');
   };
 
+  if (global.SYS_CREATE_HOTBACKUP) {
+    exports.createHotbackup = global.SYS_CREATE_HOTBACKUP;
+    delete global.SYS_CREATE_HOTBACKUP;
+  };
+
 }());

--- a/tests/js/client/shell/shell-deadlock-trx-hotbackup-cluster.js
+++ b/tests/js/client/shell/shell-deadlock-trx-hotbackup-cluster.js
@@ -1,0 +1,127 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global fail, assertTrue, assertFalse, assertEqual, assertNotUndefined, arango, print */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief ArangoDeadLockTests
+// /
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2020 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / @author Max Neunhoeffer
+// //////////////////////////////////////////////////////////////////////////////
+
+// tests for deadlocks in the cluster with writing trxs and hotbackup
+
+var jsunity = require('jsunity');
+var internal = require('internal');
+var arangodb = require('@arangodb');
+var db = arangodb.db;
+const isCluster = internal.isCluster();
+const time = internal.time;
+const wait = internal.wait;
+
+function trxWriteHotbackupDeadlock () {
+  'use strict';
+  var cn = 'UnitTestsDeadlockHotbackup';
+  var c = null;
+
+  return {
+
+    setUp: function () {
+      db._drop(cn);
+      c = db._create(cn, {numberOfShards: 1, replicationFactor: 2},
+                     {waitForSyncReplication: true});
+    },
+
+    tearDown: function () {
+      db._drop(cn);
+    },
+
+    testRunAQLWritingTransactionsDuringHotbackup: function () {
+      if (!isCluster) {
+        return true;
+      }
+
+      let start = time();
+      // This will create lots of hotbackups for approximately 60 seconds
+      let res = arango.POST_RAW("/_api/transaction",
+        { action: `function() {
+                    let console = require("console");
+                    let internal = require("internal");
+                    let wait = internal.wait;
+                    let time = internal.time;
+                    let start = time();
+                    let good = 0;
+                    let bad = 0;
+                    while (time() - start < 60) {
+                      try {
+                        internal.createHotbackup({});
+                        console.log("Created a hotbackup!");
+                        good++;
+                      } catch(e) {
+                        console.error("Caught exception when creating a hotbackup!", e);
+                        bad++;
+                      }
+                    }
+                    return {good, bad};
+                  }`,
+          collections: {} }, {"x-arango-async":"store"});
+      assertFalse(res.error, "Could not POST transaction.");
+      assertEqual(202, res.code, "Bad response code.");
+      let jobid = res.headers["x-arango-async-id"];
+
+      // Now we try to write something:
+      for (let i = 0; i < 1000; ++i) {
+        c.insert({Hallo:i});
+      }
+      // And now to execute exclusive write locking transactions:
+      for (let i = 1; i <= 750; ++i) {
+        db._query(`LET m = (FOR d IN ${cn}
+                              SORT d.Hallo DESC
+                              LIMIT 1
+                              RETURN d)
+                   INSERT {Hallo: m[0].Hallo+1} INTO ${cn}
+                   OPTIONS {exclusive: true}
+                   RETURN NEW`).toArray();
+        if (i % 50 === 0) {
+          print("Done", i, "write transactions.");
+        }
+        wait(0.01);
+      }
+      let diff = time() - start;
+      print("Done 750 exclusive transactions in", diff, "seconds!");
+      assertTrue(diff < 60, "750 transactions took too long, probably some deadlock with hotbackups");
+      while (time() - start < 80) {
+        res = arango.PUT(`/_api/job/${jobid}`, {});
+        if (res.code !== 204) {
+          assertEqual(200, res.code, "Response code bad.");
+          assertEqual(0, res.result.bad, "Not all hotbackups went through!");
+          print("Managed to perform", res.result.good, "hotbackups.");
+          return;
+        }
+        wait(1.0);
+        print("Waiting for hotbackups to finish...");
+      }
+      arango.DELETE(`/_api/job/${jobid}`);
+      assertFalse(true, "Did not finish in expected time.");
+    }
+  };
+
+}
+
+jsunity.run(trxWriteHotbackupDeadlock);
+return jsunity.done();


### PR DESCRIPTION
Port additional deadlock test to 3.6.

This is a simple port of a new test which was already reviewed and
tested on 3.7, 3.7.3 and devel.

