### PR TITLE
Disable warning for clang-12 on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -925,7 +925,7 @@ elseif (CMAKE_COMPILER_IS_CLANG)
     message(STATUS "Compiler type CLANG: ${CMAKE_CXX_COMPILER}")
   endif ()
 
-  set(BASE_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-deprecated-declarations ${BASE_FLAGS}")
+  set(BASE_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-deprecated-declarations -Wno-range-loop-analysis ${BASE_FLAGS}")
 
   set(CMAKE_C_FLAGS                "-g"                             CACHE INTERNAL "default C compiler flags")
   set(CMAKE_C_FLAGS_DEBUG          "-O0 -g -D_DEBUG=1"              CACHE INTERNAL "C debug flags")


### PR DESCRIPTION
http://jenkins.arangodb.biz:8080/view/Mac/job/arangodb-matrix-pr-mac-onlycompile/1748/