### PR TITLE
Improved observability

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,10 +9,10 @@ v3.6.10 (XXXX-XX-XX)
   the number of requests received for cluster inventories. The cluster
   inventory API is called at the beginning of a dump process or by arangosync.
 
-* Added new mtric `arangodb_aql_all_query` to track the total number of AQL 
+* Added new metric `arangodb_aql_all_query` to track the total number of AQL 
   queries.
 
-* Added new mtric `arangodb_aql_total_query_time_msec` to track the combined
+* Added new metric `arangodb_aql_total_query_time_msec` to track the combined
   runtime of AQL queries (slow queries and non-slow queries).
 
 * Added more scheduler metrics:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,8 +36,16 @@ v3.6.10 (XXXX-XX-XX)
   grade of the scheduler's queue is below the configured value, or HTTP 503 if 
   the fill grade is above it. This can be used to flag a server as unavailable 
   in case it is already highly loaded.
-  The default value for this option is `1.0`, i.e. 100%. This is fully compatible
-  with previous versions of ArangoDB. 
+  The default value for this option is `1`, which will mean that the availability
+  API will start returning HTTP 503 responses in case the scheduler queue is
+  completely full. This is mostly compatible with previous versions of ArangoDB. 
+  Previously the availability API still returned HTTP 200 in this situation, but
+  this can be considered a bug, because the server was effectively totally
+  overloaded.
+  To restore 100% compatible behavior with previous version, it is possible to
+  set the option to a value of `0`, which is a special value indicating that 
+  the queue fill grade will not be honored. 
+  
   To prevent sending more traffic to an already overloaded server, it can be 
   sensible to reduce the default value to `0.75` or even `0.5`.
   This would mean that instances with a queue longer than 75% (or 50%, resp.) 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,49 @@
 v3.6.10 (XXXX-XX-XX)
 --------------------
 
+* Added new metric `arangodb_network_forwarded_requests` to track the number
+  of requests forwarded from one coordinator to another in a load-balancing
+  context.
+
+* Added new metric `arangodb_replication_cluster_inventory_requests` to track
+  the number of requests received for cluster inventories. The cluster
+  inventory API is called at the beginning of a dump process or by arangosync.
+
+* Added new mtric `arangodb_aql_all_query` to track the total number of AQL 
+  queries.
+
+* Added new mtric `arangodb_aql_total_query_time_msec` to track the combined
+  runtime of AQL queries (slow queries and non-slow queries).
+
+* Added more scheduler metrics:
+
+  - `arangodb_scheduler_threads_started`: Total number of scheduler threads started
+  - `arangodb_scheduler_threads_stopped`: Total number of scheduler threads stopped
+  - `arangodb_scheduler_jobs_done`: Total number of scheduler queue jobs done
+  - `arangodb_scheduler_jobs_submitted`: Total number of jobs submitted to the 
+    scheduler queue
+  - `arangodb_scheduler_jobs_dequeued`: Total number of jobs dequeued from the 
+    scheduler queue
+  - `arangodb_scheduler_num_working_threads`: Number of currently working 
+    scheduler threads
+
+* Added startup option `--server.unavailability-queue-fill-grade`. This option
+  has a consequence for the `/_admin/server/availability` API only, which is
+  often called by load-balancers and other availability probing systems. 
+  The `/_admin/server/availability` API will now return HTTP 200 if the fill 
+  grade of the scheduler's queue is below the configured value, or HTTP 503 if 
+  the fill grade is above it. This can be used to flag a server as unavailable 
+  in case it is already highly loaded.
+  The default value for this option is `0.5`, i.e. if the scheduler's queue
+  is already longer than 50% of its maximum capacity, the availability API will
+  return HTTP 503 instead of HTTP 200. The default value for the scheduler
+  queue length is 4096.
+  This change will lead to 3.6.10 reporting an instance as unavailable via the
+  availability API earlier than previous versions. However, we consider this 
+  to be a sensible change, because it can help avoid sending more traffic to
+  an already overloaded instance. To restore the pre-3.6.10-behavior, the value
+  of `--server.unavailability-queue-fill-grade` can be set to `1` at startup.
+
 * Added startup option `--foxx.force-update-on-startup` to toggle waiting for
   all Foxx services in all databases to be propagated to a coordinator before it
   completes the boot sequence.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,15 +34,15 @@ v3.6.10 (XXXX-XX-XX)
   grade of the scheduler's queue is below the configured value, or HTTP 503 if 
   the fill grade is above it. This can be used to flag a server as unavailable 
   in case it is already highly loaded.
-  The default value for this option is `0.5`, i.e. if the scheduler's queue
-  is already longer than 50% of its maximum capacity, the availability API will
-  return HTTP 503 instead of HTTP 200. The default value for the scheduler
-  queue length is 4096.
-  This change will lead to 3.6.10 reporting an instance as unavailable via the
-  availability API earlier than previous versions. However, we consider this 
-  to be a sensible change, because it can help avoid sending more traffic to
-  an already overloaded instance. To restore the pre-3.6.10-behavior, the value
-  of `--server.unavailability-queue-fill-grade` can be set to `1` at startup.
+  The default value for this option is `1.0`, i.e. 100%. This is fully compatible
+  with previous versions of ArangoDB. 
+  To prevent sending more traffic to an already overloaded server, it can be 
+  sensible to reduce the default value to `0.75` or even `0.5`.
+  This would mean that instances with a queue longer than 75% (or 50%, resp.) 
+  of their maximum queue capacity would return HTTP 503 instead of HTTP 200 
+  when their availability API is probed. 
+
+  nb: the default value for the scheduler queue length is 4096.
 
 * Added startup option `--foxx.force-update-on-startup` to toggle waiting for
   all Foxx services in all databases to be propagated to a coordinator before it

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,8 +9,10 @@ v3.6.10 (XXXX-XX-XX)
   the number of requests received for cluster inventories. The cluster
   inventory API is called at the beginning of a dump process or by arangosync.
 
-* Added new metric `arangodb_aql_all_query` to track the total number of AQL 
-  queries.
+* Added new AQL metrics:
+  - `arangodb_aql_total_query_time_msec": Total execution time of all AQL 
+    queries (ms)
+  - `arangodb_aql_all_query`: total number of all AQL queries
 
 * Added new metric `arangodb_aql_total_query_time_msec` to track the combined
   runtime of AQL queries (slow queries and non-slow queries).

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_server_availability.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_server_availability.md
@@ -20,4 +20,9 @@ in case of an active failover setup.
 @RESTRETURNCODE{503}
 HTTP 503 will be returned in case the server is during startup or during shutdown,
 is set to read-only mode or is currently a follower in an active failover setup.
+
+In addition, since ArangoDB version 3.7.6, HTTP 503 will be returned in case the 
+fill grade of the scheduler queue exceeds the configured high-water mark (adjustable 
+via startup option `--server.unavailability-queue-fill-grade`), which by default is 
+set to 100 % of the maximum queue length. I
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_statistics.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_statistics.md
@@ -33,6 +33,9 @@ intermediate commits and will not increase the value.
 @RESTRETURNCODE{200}
 Statistics were returned successfully.
 
+@RESTRETURNCODE{404}
+Statistics are disabled on the instance.
+
 @RESTREPLYBODY{error,boolean,required,}
 boolean flag to indicate whether an error occurred (*false* in this case)
 

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -132,7 +132,7 @@ futures::Future<Result> RestHandler::forwardRequest(bool& forwarded) {
     return futures::makeFuture(Result());
   }
 
-  NetworkFeature const& nf = server().getFeature<NetworkFeature>();
+  NetworkFeature& nf = server().getFeature<NetworkFeature>();
   network::ConnectionPool* pool = nf.pool();
   if (pool == nullptr) {
     // nullptr happens only during controlled shutdown
@@ -200,6 +200,8 @@ futures::Future<Result> RestHandler::forwardRequest(bool& forwarded) {
   VPackStringRef resPayload = _request->rawPayload();
   VPackBuffer<uint8_t> payload(resPayload.size());
   payload.append(resPayload.data(), resPayload.size());
+  
+  nf.trackForwardedRequest();
  
   auto future = network::sendRequest(pool, "server:" + serverId, requestType,
                                      _request->requestPath(),

--- a/arangod/GeneralServer/VstCommTask.cpp
+++ b/arangod/GeneralServer/VstCommTask.cpp
@@ -94,7 +94,7 @@ bool VstCommTask<T>::readCallback(asio_ns::error_code ec) {
   using namespace fuerte;
   if (ec) {
     if (ec != asio_ns::error::misc_errors::eof) {
-      LOG_TOPIC("495fe", INFO, Logger::REQUESTS)
+      LOG_TOPIC("495fe", DEBUG, Logger::REQUESTS)
       << "Error while reading from socket: '" << ec.message() << "'";
     }
     this->close();

--- a/arangod/Network/NetworkFeature.h
+++ b/arangod/Network/NetworkFeature.h
@@ -25,6 +25,7 @@
 
 #include "ApplicationFeatures/ApplicationFeature.h"
 #include "Network/ConnectionPool.h"
+#include "RestServer/Metrics.h"
 #include "Scheduler/Scheduler.h"
 
 #include <atomic>
@@ -51,6 +52,9 @@ class NetworkFeature final : public application_features::ApplicationFeature {
 #ifdef ARANGODB_USE_GOOGLE_TESTS
   void setPoolTesting(arangodb::network::ConnectionPool* pool);
 #endif
+  
+  /// @brief increase the counter for forwarded requests
+  void trackForwardedRequest();
 
  private:
   uint32_t _numIOThreads;
@@ -65,6 +69,11 @@ class NetworkFeature final : public application_features::ApplicationFeature {
 
   std::unique_ptr<network::ConnectionPool> _pool;
   std::atomic<network::ConnectionPool*> _poolPtr;
+  
+  /// @brief number of cluster-internal forwarded requests
+  /// (from one coordinator to another, in case load-balancing
+  /// is used)
+  Counter& _forwardedRequests;
 };
 
 }  // namespace arangodb

--- a/arangod/Replication/ReplicationFeature.cpp
+++ b/arangod/Replication/ReplicationFeature.cpp
@@ -37,6 +37,7 @@
 #include "Replication/ReplicationApplierConfiguration.h"
 #include "Rest/GeneralResponse.h"
 #include "RestServer/DatabaseFeature.h"
+#include "RestServer/MetricsFeature.h"
 #include "RestServer/SystemDatabaseFeature.h"
 #include "StorageEngine/StorageEngineFeature.h"
 #include "VocBase/vocbase.h"
@@ -57,7 +58,10 @@ ReplicationFeature::ReplicationFeature(ApplicationServer& server)
       _replicationApplierAutoStart(true),
       _enableActiveFailover(false),
       _parallelTailingInvocations(0),
-      _maxParallelTailingInvocations(0) {
+      _maxParallelTailingInvocations(0),
+      _inventoryRequests(
+        server.getFeature<arangodb::MetricsFeature>().counter(
+          "arangodb_replication_cluster_inventory_requests", 0, "Number of cluster replication inventory requests received")) {
   setOptional(true);
   startsAfter<BasicFeaturePhaseServer>();
 

--- a/arangod/Replication/ReplicationFeature.h
+++ b/arangod/Replication/ReplicationFeature.h
@@ -26,6 +26,7 @@
 #include "ApplicationFeatures/ApplicationFeature.h"
 #include "Cluster/ServerState.h"
 #include "Replication/GlobalReplicationApplier.h"
+#include "RestServer/Metrics.h"
 
 struct TRI_vocbase_t;
 
@@ -90,6 +91,8 @@ class ReplicationFeature final : public application_features::ApplicationFeature
   /// must only be called after a successful call to trackTailingstart
   void trackTailingEnd() noexcept;
 
+  void trackInventoryRequest() { ++_inventoryRequests; }
+
   /// @brief set the x-arango-endpoint header
   static void setEndpointHeader(GeneralResponse*, arangodb::ServerState::Mode);
 
@@ -125,6 +128,8 @@ class ReplicationFeature final : public application_features::ApplicationFeature
   uint64_t _maxParallelTailingInvocations;
 
   std::unique_ptr<GlobalReplicationApplier> _globalReplicationApplier;
+  
+  Counter& _inventoryRequests;
 };
 
 }  // namespace arangodb

--- a/arangod/RestHandler/RestAdminServerHandler.cpp
+++ b/arangod/RestHandler/RestAdminServerHandler.cpp
@@ -132,7 +132,7 @@ void RestAdminServerHandler::handleAvailability() {
       available = !server.isStopping();
       Scheduler* scheduler = SchedulerFeature::SCHEDULER;
       if (available && scheduler) {
-        // if the scheduler's queue is more than 50% full, render
+        // if the scheduler's queue is more than x% full, render
         // the server unavailable
         double fillGrade = scheduler->approximateQueueFillGrade();
         if (fillGrade > scheduler->unavailabilityQueueFillGrade()) {

--- a/arangod/RestHandler/RestAdminServerHandler.cpp
+++ b/arangod/RestHandler/RestAdminServerHandler.cpp
@@ -134,10 +134,13 @@ void RestAdminServerHandler::handleAvailability() {
       if (available && scheduler) {
         // if the scheduler's queue is more than x% full, render
         // the server unavailable
-        double fillGrade = scheduler->approximateQueueFillGrade();
-        if (fillGrade > scheduler->unavailabilityQueueFillGrade()) {
-          // oops, queue is relatively full
-          available = false;
+        double unavailabilityFillGrade = scheduler->unavailabilityQueueFillGrade();
+        if (unavailabilityFillGrade > 0.0) {
+          double fillGrade = scheduler->approximateQueueFillGrade();
+          if (fillGrade > unavailabilityFillGrade) {
+            // oops, queue is relatively full
+            available = false;
+          }
         }
       }
       break;

--- a/arangod/RestHandler/RestAdminServerHandler.cpp
+++ b/arangod/RestHandler/RestAdminServerHandler.cpp
@@ -135,7 +135,7 @@ void RestAdminServerHandler::handleAvailability() {
         // if the scheduler's queue is more than 50% full, render
         // the server unavailable
         double fillGrade = scheduler->approximateQueueFillGrade();
-        if (fillGrade > scheduler->unavailablityQueueFillGrade()) {
+        if (fillGrade > scheduler->unavailabilityQueueFillGrade()) {
           // oops, queue is relatively full
           available = false;
         }

--- a/arangod/RestHandler/RestAdminServerHandler.cpp
+++ b/arangod/RestHandler/RestAdminServerHandler.cpp
@@ -137,7 +137,7 @@ void RestAdminServerHandler::handleAvailability() {
         double unavailabilityFillGrade = scheduler->unavailabilityQueueFillGrade();
         if (unavailabilityFillGrade > 0.0) {
           double fillGrade = scheduler->approximateQueueFillGrade();
-          if (fillGrade > unavailabilityFillGrade) {
+          if (fillGrade >= unavailabilityFillGrade) {
             // oops, queue is relatively full
             available = false;
           }

--- a/arangod/RestHandler/RestAdminServerHandler.cpp
+++ b/arangod/RestHandler/RestAdminServerHandler.cpp
@@ -29,6 +29,8 @@
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
 #include "Replication/ReplicationFeature.h"
+#include "Scheduler/Scheduler.h"
+#include "Scheduler/SchedulerFeature.h"
 #include "VocBase/VocbaseInfo.h"
 #include "VocBase/vocbase.h"
 
@@ -126,9 +128,20 @@ void RestAdminServerHandler::handleAvailability() {
   auto& server = application_features::ApplicationServer::server();
   bool available = false;
   switch (ServerState::mode()) {
-    case ServerState::Mode::DEFAULT:
+    case ServerState::Mode::DEFAULT: {
       available = !server.isStopping();
+      Scheduler* scheduler = SchedulerFeature::SCHEDULER;
+      if (available && scheduler) {
+        // if the scheduler's queue is more than 50% full, render
+        // the server unavailable
+        double fillGrade = scheduler->approximateQueueFillGrade();
+        if (fillGrade > scheduler->unavailablityQueueFillGrade()) {
+          // oops, queue is relatively full
+          available = false;
+        }
+      }
       break;
+    }
     case ServerState::Mode::MAINTENANCE:
     case ServerState::Mode::REDIRECT:
     case ServerState::Mode::TRYAGAIN:

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -793,6 +793,9 @@ void RestReplicationHandler::handleUnforwardedTrampolineCoordinator() {
 ////////////////////////////////////////////////////////////////////////////////
 
 void RestReplicationHandler::handleCommandClusterInventory() {
+  auto& replicationFeature = _vocbase.server().getFeature<ReplicationFeature>();
+  replicationFeature.trackInventoryRequest();
+
   std::string const& dbName = _request->databaseName();
   bool includeSystem = _request->parsedValue("includeSystem", true);
 

--- a/arangod/RestServer/QueryRegistryFeature.cpp
+++ b/arangod/RestServer/QueryRegistryFeature.cpp
@@ -62,6 +62,12 @@ QueryRegistryFeature::QueryRegistryFeature(application_features::ApplicationServ
       _slowStreamingQueryThreshold(10.0),
       _queryRegistryTTL(0.0),
       _queryCacheMode("off"),
+      _totalQueryExecutionTime(
+        server.getFeature<arangodb::MetricsFeature>().counter(
+          "arangodb_aql_total_query_time_msec", 0, "Total execution time of all AQL queries [ms]")),
+      _queriesCounter(
+        server.getFeature<arangodb::MetricsFeature>().counter(
+          "arangodb_aql_all_query", 0, "Total number of AQL queries")),
       _slowQueriesCounter(
         server.getFeature<arangodb::MetricsFeature>().counter(
           "arangodb_aql_slow_query", 0, "Number of slow AQL queries")) {
@@ -226,6 +232,17 @@ void QueryRegistryFeature::stop() {
 void QueryRegistryFeature::unprepare() {
   // clear the query registery
   QUERY_REGISTRY.store(nullptr, std::memory_order_release);
+}
+
+void QueryRegistryFeature::trackQuery(double time) { 
+  ++_queriesCounter; 
+  _totalQueryExecutionTime += static_cast<uint64_t>(1000.0 * time);
+}
+
+void QueryRegistryFeature::trackSlowQuery(double time) { 
+  // query is already counted here as normal query, so don't count it
+  // again in _totalQueryExecutionTime
+  ++_slowQueriesCounter; 
 }
 
 }  // namespace arangodb

--- a/arangod/RestServer/QueryRegistryFeature.h
+++ b/arangod/RestServer/QueryRegistryFeature.h
@@ -61,8 +61,10 @@ class QueryRegistryFeature final : public application_features::ApplicationFeatu
   uint64_t maxQueryPlans() const { return _maxQueryPlans; }
   aql::QueryRegistry* queryRegistry() const { return _queryRegistry.get(); }
 
-  // tracks a slow query by increasing the counter
-  void trackSlowQuery() { ++_slowQueriesCounter; }
+  // tracks a query, using execution time
+  void trackQuery(double time);
+  // tracks a slow query, using execution time
+  void trackSlowQuery(double time);
 
  private:
   bool _trackingEnabled;
@@ -84,6 +86,8 @@ class QueryRegistryFeature final : public application_features::ApplicationFeatu
   double _queryRegistryTTL;
   std::string _queryCacheMode;
   
+  Counter& _totalQueryExecutionTime;
+  Counter& _queriesCounter;
   Counter& _slowQueriesCounter;
 
  private:

--- a/arangod/Scheduler/Scheduler.h
+++ b/arangod/Scheduler/Scheduler.h
@@ -176,6 +176,13 @@ class Scheduler {
 
   virtual void toVelocyPack(velocypack::Builder&) const = 0;
   virtual QueueStatistics queueStatistics() const = 0;
+ 
+  /// @brief approximate fill grade of the scheduler's queue (in %)
+  virtual double approximateQueueFillGrade() const = 0;
+  
+  /// @brief fill grade of the scheduler's queue (in %) from which onwards
+  /// the server is considered unavailable (because of overload)
+  virtual double unavailabilityQueueFillGrade() const = 0;
 
   // ---------------------------------------------------------------------------
   // Start/Stop/IsRunning stuff

--- a/arangod/Scheduler/SchedulerFeature.cpp
+++ b/arangod/Scheduler/SchedulerFeature.cpp
@@ -192,7 +192,8 @@ void SchedulerFeature::prepare() {
 #endif
   auto sched = std::make_unique<SupervisedScheduler>(server(), _nrMinimalThreads,
                                                      _nrMaximalThreads, _queueSize,
-                                                     _fifo1Size, _fifo2Size);
+                                                     _fifo1Size, _fifo2Size,
+                                                     _unavailabilityQueueFillGrade);
 #if (_MSC_VER >= 1)
 #pragma warning(pop)
 #endif

--- a/arangod/Scheduler/SchedulerFeature.cpp
+++ b/arangod/Scheduler/SchedulerFeature.cpp
@@ -107,7 +107,7 @@ void SchedulerFeature::collectOptions(std::shared_ptr<options::ProgramOptions> o
                      "size of the priority 2 fifo", new UInt64Parameter(&_fifo2Size));
   
   options->addOption("--server.unavailability-queue-fill-grade",
-                     "queue fill grade from which onwards the server is considered unavailable because of overload (in %)", 
+                     "queue fill grade from which onwards the server is considered unavailable because of overload (ratio, use a value of 0 to disable it)", 
                      new DoubleParameter(&_unavailabilityQueueFillGrade))
                      .setIntroducedIn(30610);
 
@@ -157,7 +157,7 @@ void SchedulerFeature::validateOptions(std::shared_ptr<options::ProgramOptions>)
     _nrMaximalThreads = _nrMinimalThreads;
   }
 
-  if (_unavailabilityQueueFillGrade <= 0.0 ||
+  if (_unavailabilityQueueFillGrade < 0.0 ||
       _unavailabilityQueueFillGrade > 1.0) {
     LOG_TOPIC("055a1", FATAL, arangodb::Logger::THREADS)
         << "invalid value for --server.unavailability-queue-fill-grade";

--- a/arangod/Scheduler/SchedulerFeature.cpp
+++ b/arangod/Scheduler/SchedulerFeature.cpp
@@ -105,6 +105,11 @@ void SchedulerFeature::collectOptions(std::shared_ptr<options::ProgramOptions> o
 
   options->addOption("--server.maximal-queue-size",
                      "size of the priority 2 fifo", new UInt64Parameter(&_fifo2Size));
+  
+  options->addOption("--server.unavailability-queue-fill-grade",
+                     "queue fill grade from which onwards the server is considered unavailable because of overload (in %)", 
+                     new DoubleParameter(&_unavailabilityQueueFillGrade))
+                     .setIntroducedIn(30610);
 
   options->addOption(
       "--server.scheduler-queue-size",
@@ -152,8 +157,17 @@ void SchedulerFeature::validateOptions(std::shared_ptr<options::ProgramOptions>)
     _nrMaximalThreads = _nrMinimalThreads;
   }
 
+  if (_unavailabilityQueueFillGrade <= 0.0 ||
+      _unavailabilityQueueFillGrade > 1.0) {
+    LOG_TOPIC("055a1", FATAL, arangodb::Logger::THREADS)
+        << "invalid value for --server.unavailability-queue-fill-grade";
+    FATAL_ERROR_EXIT();
+  }
+
   if (_queueSize == 0) {
+    TRI_ASSERT(_nrMaximalThreads > 0);
     _queueSize = _nrMaximalThreads * 8;
+    TRI_ASSERT(_queueSize > 0);
   }
 
   if (_fifo1Size < 1) {
@@ -163,11 +177,14 @@ void SchedulerFeature::validateOptions(std::shared_ptr<options::ProgramOptions>)
   if (_fifo2Size < 1) {
     _fifo2Size = 1;
   }
+
+  TRI_ASSERT(_queueSize > 0);
 }
 
 void SchedulerFeature::prepare() {
   TRI_ASSERT(2 <= _nrMinimalThreads);
   TRI_ASSERT(_nrMinimalThreads <= _nrMaximalThreads);
+  TRI_ASSERT(_queueSize > 0);
 // wait for windows fix or implement operator new
 #if (_MSC_VER >= 1)
 #pragma warning(push)

--- a/arangod/Scheduler/SchedulerFeature.h
+++ b/arangod/Scheduler/SchedulerFeature.h
@@ -51,7 +51,7 @@ class SchedulerFeature final : public application_features::ApplicationFeature {
   uint64_t _queueSize = 4096;
   uint64_t _fifo1Size = 4096;
   uint64_t _fifo2Size = 4096;
-  double _unavailabilityQueueFillGrade = 100.0;
+  double _unavailabilityQueueFillGrade = 1.0;
 
   std::unique_ptr<Scheduler> _scheduler;
 

--- a/arangod/Scheduler/SchedulerFeature.h
+++ b/arangod/Scheduler/SchedulerFeature.h
@@ -51,7 +51,7 @@ class SchedulerFeature final : public application_features::ApplicationFeature {
   uint64_t _queueSize = 4096;
   uint64_t _fifo1Size = 4096;
   uint64_t _fifo2Size = 4096;
-  double _unavailabilityQueueFillGrade = 1.0;
+  double _unavailabilityQueueFillGrade = 100.0;
 
   std::unique_ptr<Scheduler> _scheduler;
 

--- a/arangod/Scheduler/SchedulerFeature.h
+++ b/arangod/Scheduler/SchedulerFeature.h
@@ -51,6 +51,7 @@ class SchedulerFeature final : public application_features::ApplicationFeature {
   uint64_t _queueSize = 4096;
   uint64_t _fifo1Size = 4096;
   uint64_t _fifo2Size = 4096;
+  double _unavailabilityQueueFillGrade = 0.5;
 
   std::unique_ptr<Scheduler> _scheduler;
 

--- a/arangod/Scheduler/SchedulerFeature.h
+++ b/arangod/Scheduler/SchedulerFeature.h
@@ -51,7 +51,7 @@ class SchedulerFeature final : public application_features::ApplicationFeature {
   uint64_t _queueSize = 4096;
   uint64_t _fifo1Size = 4096;
   uint64_t _fifo2Size = 4096;
-  double _unavailabilityQueueFillGrade = 0.5;
+  double _unavailabilityQueueFillGrade = 1.0;
 
   std::unique_ptr<Scheduler> _scheduler;
 

--- a/arangod/Scheduler/SupervisedScheduler.cpp
+++ b/arangod/Scheduler/SupervisedScheduler.cpp
@@ -143,7 +143,8 @@ class SupervisedSchedulerWorkerThread final : public SupervisedSchedulerThread {
 SupervisedScheduler::SupervisedScheduler(application_features::ApplicationServer& server,
                                          uint64_t minThreads, uint64_t maxThreads,
                                          uint64_t maxQueueSize,
-                                         uint64_t fifo1Size, uint64_t fifo2Size)
+                                         uint64_t fifo1Size, uint64_t fifo2Size,
+                                         double unavailabilityQueueFillGrade)
     : Scheduler(server),
       _numWorkers(0),
       _stopping(false),
@@ -156,6 +157,7 @@ SupervisedScheduler::SupervisedScheduler(application_features::ApplicationServer
       _maxFifoSize(maxQueueSize),
       _fifo1Size(fifo1Size),
       _fifo2Size(fifo2Size),
+      _unavailabilityQueueFillGrade(unavailabilityQueueFillGrade),
       _numWorking(0),
       _numAwake(0),
       _metricsQueueLength(server.getFeature<arangodb::MetricsFeature>().gauge<uint64_t>(
@@ -183,6 +185,8 @@ SupervisedScheduler::SupervisedScheduler(application_features::ApplicationServer
   _queues[0].reserve(maxQueueSize);
   _queues[1].reserve(fifo1Size);
   _queues[2].reserve(fifo2Size);
+
+  TRI_ASSERT(_maxFifoSize > 0);
 }
 
 SupervisedScheduler::~SupervisedScheduler() = default;
@@ -770,4 +774,14 @@ void SupervisedScheduler::toVelocyPack(velocypack::Builder& b) const {
   b.add("queued", VPackValue(qs._queued));
   b.add("in-progress", VPackValue(qs._working));
   b.add("direct-exec", VPackValue(qs._directExec));
+}
+  
+double SupervisedScheduler::approximateQueueFillGrade() const {
+  uint64_t const maxLength = _maxFifoSize;
+  uint64_t const qLength = std::min<uint64_t>(maxLength, _metricsQueueLength.load());
+  return static_cast<double>(qLength) / static_cast<double>(maxLength);
+}
+
+double SupervisedScheduler::unavailabilityQueueFillGrade() const {
+  return _unavailabilityQueueFillGrade;
 }

--- a/arangod/Scheduler/SupervisedScheduler.cpp
+++ b/arangod/Scheduler/SupervisedScheduler.cpp
@@ -151,23 +151,33 @@ SupervisedScheduler::SupervisedScheduler(application_features::ApplicationServer
       _jobsSubmitted(0),
       _jobsDequeued(0),
       _jobsDone(0),
-      _jobsDirectExec(0),
-      _wakeupQueueLength(5),
-      _wakeupTime_ns(1000),
-      _definitiveWakeupTime_ns(100000),
-      _minNumWorker(minThreads),
-      _maxNumWorker(maxThreads),
-      _nrWorking(0),
-      _nrAwake(0),
+      _minNumWorkers(minThreads),
+      _maxNumWorkers(maxThreads),
       _maxFifoSize(maxQueueSize),
       _fifo1Size(fifo1Size),
       _fifo2Size(fifo2Size),
+      _numWorking(0),
+      _numAwake(0),
       _metricsQueueLength(server.getFeature<arangodb::MetricsFeature>().gauge<uint64_t>(
           "arangodb_scheduler_queue_length", 0, "Servers internal queue length (approximate)")),
+      _metricsJobsDone(server.getFeature<arangodb::MetricsFeature>().gauge<uint64_t>(
+          "arangodb_scheduler_jobs_done", 0, "Total number of queue jobs done")),
+      _metricsJobsSubmitted(server.getFeature<arangodb::MetricsFeature>().gauge<uint64_t>(
+          "arangodb_scheduler_jobs_submitted", 0, "Total number of jobs submitted to the queue")),
+      _metricsJobsDequeued(server.getFeature<arangodb::MetricsFeature>().gauge<uint64_t>(
+          "arangodb_scheduler_jobs_dequeued", 0, "Total number of jobs dequeued")),
       _metricsAwakeThreads(server.getFeature<arangodb::MetricsFeature>().gauge<uint64_t>(
-          "arangodb_scheduler_awake_threads", 0, "Number of awake worker threads")),
+          "arangodb_scheduler_awake_threads", 0, "Number of awake worker threads (working or spinning)")),
+      _metricsNumWorkingThreads(server.getFeature<arangodb::MetricsFeature>().gauge<uint64_t>(
+          "arangodb_scheduler_num_working_threads", 0, "Number of working threads")),
       _metricsNumWorkerThreads(server.getFeature<arangodb::MetricsFeature>().gauge<uint64_t>(
           "arangodb_scheduler_num_worker_threads", 0, "Number of worker threads")),
+      _metricsThreadsStarted(server.getFeature<arangodb::MetricsFeature>().counter(
+          "arangodb_scheduler_threads_started", 0,
+          "Number of scheduler threads started")),
+      _metricsThreadsStopped(server.getFeature<arangodb::MetricsFeature>().counter(
+          "arangodb_scheduler_threads_stopped", 0,
+          "Number of scheduler threads stopped")),
       _metricsQueueFull(server.getFeature<arangodb::MetricsFeature>().counter(
           "arangodb_scheduler_queue_full_failures", 0, "Tasks dropped and not added to internal queue")) {
   _queues[0].reserve(maxQueueSize);
@@ -242,18 +252,18 @@ bool SupervisedScheduler::queue(RequestLane lane, std::function<void()> handler)
   // for much longer, rather, we would like to have the work done.
   // Therefore, we follow this algorithm:
   // If nobody is sleeping, we also do not wake up anybody
-  // (i.e. _nrAwake >= _numWorker).
+  // (i.e. _numAwake >= _numWorkers).
   // If there is a spinning worker
-  // (i.e. _nrAwake > _nrWorking), then we do not try to wake up anybody,
+  // (i.e. _numAwake > _numWorking), then we do not try to wake up anybody,
   // however, we need to actually see a spinning worker in this case.
   // Otherwise, we walk through the threads, and wake up the first we
   // see which is sleeping.
-  uint64_t awake = _nrAwake.load(std::memory_order_relaxed);
-  if (awake == _numWorkers) {
-    // Everybody labouring away, no need to wake nobody up.
+  uint64_t numAwake = _numAwake.load(std::memory_order_relaxed);
+  if (numAwake == _numWorkers) {
+    // Everybody laboring away, no need to wake anybody up.
     return true;
   }
-  if (awake > _nrWorking.load(std::memory_order_relaxed)) {
+  if (numAwake > _numWorking.load(std::memory_order_relaxed)) {
     // This indicates that one is spinning, let's actually see this
     // one with out own eyes, if not, go on.
     // Without this additional loop we run the risk that a thread which
@@ -380,11 +390,11 @@ void SupervisedScheduler::runWorker() {
     }
     
     // inform the supervisor that this thread is alive
-    state->_ready = true;
     std::lock_guard<std::mutex> guard(_mutexSupervisor);
+    state->_ready = true;
     _conditionSupervisor.notify_one();
   }
-  _nrAwake.fetch_add(1, std::memory_order_relaxed);
+  _numAwake.fetch_add(1, std::memory_order_relaxed);
   while (true) {
     try {
       std::unique_ptr<WorkItem> work = getWork(state);
@@ -396,14 +406,14 @@ void SupervisedScheduler::runWorker() {
 
       state->_lastJobStarted = clock::now();
       state->_working = true;
-      _nrWorking.fetch_add(1, std::memory_order_relaxed);
+      _numWorking.fetch_add(1, std::memory_order_relaxed);
       try {
         work->_handler();
         state->_working = false;
-        _nrWorking.fetch_sub(1, std::memory_order_relaxed);
+        _numWorking.fetch_sub(1, std::memory_order_relaxed);
       } catch (...) {
         state->_working = false;
-        _nrWorking.fetch_sub(1, std::memory_order_relaxed);
+        _numWorking.fetch_sub(1, std::memory_order_relaxed);
         throw;
       }
     } catch (std::exception const& ex) {
@@ -416,11 +426,11 @@ void SupervisedScheduler::runWorker() {
 
     _jobsDone.fetch_add(1, std::memory_order_release);
   }
-  _nrAwake.fetch_sub(1, std::memory_order_relaxed);
+  _numAwake.fetch_sub(1, std::memory_order_relaxed);
 }
 
 void SupervisedScheduler::runSupervisor() {
-  while (_numWorkers < _minNumWorker) {
+  while (_numWorkers < _minNumWorkers) {
     startOneThread();
   }
 
@@ -442,9 +452,10 @@ void SupervisedScheduler::runSupervisor() {
 
     uint64_t queueLength = jobsSubmitted - jobsDequeued;
 
-    uint64_t awake = _nrAwake.load(std::memory_order_relaxed);
-    uint64_t numWorker = _numWorkers.load(std::memory_order_relaxed);
-    bool sleeperFound = (awake < numWorker);
+    uint64_t numAwake = _numAwake.load(std::memory_order_relaxed);
+    uint64_t numWorkers = _numWorkers.load(std::memory_order_relaxed);
+    uint64_t numWorking = _numWorking.load(std::memory_order_relaxed);
+    bool sleeperFound = (numAwake < numWorkers);
 
     bool doStartOneThread = (((queueLength >= 3 * _numWorkers) &&
                               ((lastQueueLength + _numWorkers) < queueLength)) ||
@@ -463,16 +474,20 @@ void SupervisedScheduler::runSupervisor() {
     if (roundCount++ >= 5) {
       // approx every 0.5s update the metrics
       _metricsQueueLength.operator=(queueLength);
-      _metricsAwakeThreads.operator=(awake);
-      _metricsNumWorkerThreads.operator=(numWorker);
+      _metricsJobsDone.operator=(jobsDone);
+      _metricsJobsSubmitted.operator=(jobsSubmitted);
+      _metricsJobsDequeued.operator=(jobsDequeued);
+      _metricsAwakeThreads.operator=(numAwake);
+      _metricsNumWorkingThreads.operator=(numWorking);
+      _metricsNumWorkerThreads.operator=(numWorkers);
       roundCount = 0;
     }
 
     try {
-      if (doStartOneThread && _numWorkers < _maxNumWorker) {
+      if (doStartOneThread && _numWorkers < _maxNumWorkers) {
         jobsStallingTick = 0;
         startOneThread();
-      } else if (doStopOneThread && _numWorkers > _minNumWorker) {
+      } else if (doStopOneThread && _numWorkers > _minNumWorkers) {
         stopOneThread();
       }
 
@@ -562,7 +577,7 @@ bool SupervisedScheduler::canPullFromQueue(uint64_t queueIndex) const {
   // 25% reserved for FastLane only
   // upto 75% of work can go on MedLane and FastLane
   // uptop 50% of work can go on Slow, Med and FastLane
-  TRI_ASSERT(_maxNumWorker >= 2);
+  TRI_ASSERT(_maxNumWorkers >= 2);
 
   // The ordering of Done and dequeued is important, hence acquire.
   // Otherwise we might have the unlucky case that we first check dequeued,
@@ -574,11 +589,11 @@ bool SupervisedScheduler::canPullFromQueue(uint64_t queueIndex) const {
 
   if (queueIndex == 1) {
     // We can work on med if less than 75% of the workers are busy
-    return (jobsDequeued - jobsDone) < (_maxNumWorker * 3 / 4);
+    return (jobsDequeued - jobsDone) < (_maxNumWorkers * 3 / 4);
   }
       
   // We can work on low if less than 50% of the workers are busy
-  return (jobsDequeued - jobsDone) < (_maxNumWorker / 2);
+  return (jobsDequeued - jobsDone) < (_maxNumWorkers / 2);
 }
 
 std::unique_ptr<SupervisedScheduler::WorkItem> SupervisedScheduler::getWork(
@@ -599,7 +614,6 @@ std::unique_ptr<SupervisedScheduler::WorkItem> SupervisedScheduler::getWork(
   };
 
   while (!state->_stop) {
-    uint64_t triesCount = 0;
     auto loopStart = std::chrono::steady_clock::now();
     uint64_t timeOutForNow = state->_queueRetryTime_us;
     if (loopStart - state->_lastJobStarted > std::chrono::seconds(1)) {
@@ -610,7 +624,6 @@ std::unique_ptr<SupervisedScheduler::WorkItem> SupervisedScheduler::getWork(
       if (work != nullptr) {
         return std::unique_ptr<WorkItem>(work);
       }
-      triesCount++;
       cpu_relax();
     } while ((std::chrono::steady_clock::now() - loopStart) < std::chrono::microseconds(timeOutForNow));
 
@@ -627,13 +640,13 @@ std::unique_ptr<SupervisedScheduler::WorkItem> SupervisedScheduler::getWork(
     }
 
     state->_sleeping = true;
-    _nrAwake.fetch_sub(1, std::memory_order_relaxed);
+    _numAwake.fetch_sub(1, std::memory_order_relaxed);
 
     work = checkAllQueues();
     if (work != nullptr) {
       // Fix the sleep indicators:
       state->_sleeping = false;
-      _nrAwake.fetch_add(1, std::memory_order_relaxed);
+      _numAwake.fetch_add(1, std::memory_order_relaxed);
       return std::unique_ptr<WorkItem>(work);
     }
 
@@ -643,7 +656,7 @@ std::unique_ptr<SupervisedScheduler::WorkItem> SupervisedScheduler::getWork(
       state->_conditionWork.wait_for(guard, std::chrono::milliseconds(state->_sleepTimeout_ms));
     }
     state->_sleeping = false;
-    _nrAwake.fetch_add(1, std::memory_order_relaxed);
+    _numAwake.fetch_add(1, std::memory_order_relaxed);
   }  // while
 
   return nullptr;
@@ -654,8 +667,7 @@ void SupervisedScheduler::startOneThread() {
   {
     std::unique_lock<std::mutex> guard(_mutex);
 
-    // TRI_ASSERT(_numWorkers < _maxNumWorker);
-    if (_numWorkers + _abandonedWorkerStates.size() >= _maxNumWorker) {
+    if (_numWorkers + _abandonedWorkerStates.size() >= _maxNumWorkers) {
       return;  // do not add more threads than maximum allows
     }
 
@@ -677,6 +689,7 @@ void SupervisedScheduler::startOneThread() {
   _conditionSupervisor.wait(guard2, [&state]() {
     return state->_ready;
   });
+  ++_metricsThreadsStarted;
   LOG_TOPIC("f9de8", TRACE, Logger::THREADS) << "Started new thread";
 }
 
@@ -699,6 +712,8 @@ void SupervisedScheduler::stopOneThread() {
     state->_conditionWork.notify_one();
     // _stop is set under the mutex, then the worker thread is notified.
   }
+  
+  ++_metricsThreadsStopped;
 
   // However the thread may be working on a long job. Hence we enqueue it on
   // the cleanup list and wait for its termination.
@@ -744,9 +759,7 @@ Scheduler::QueueStatistics SupervisedScheduler::queueStatistics() const {
   uint64_t const queued = jobsSubmitted - jobsDone;
   uint64_t const working = jobsDequeued - jobsDone;
 
-  uint64_t const directExec = _jobsDirectExec.load(std::memory_order_relaxed);
-
-  return QueueStatistics{numWorkers, 0, queued, working, directExec};
+  return QueueStatistics{numWorkers, 0, queued, working, 0 /*directExec*/};
 }
 
 void SupervisedScheduler::toVelocyPack(velocypack::Builder& b) const {

--- a/arangod/Scheduler/SupervisedScheduler.h
+++ b/arangod/Scheduler/SupervisedScheduler.h
@@ -42,7 +42,8 @@ class SupervisedScheduler final : public Scheduler {
  public:
   SupervisedScheduler(application_features::ApplicationServer& server,
                       uint64_t minThreads, uint64_t maxThreads, uint64_t maxQueueSize,
-                      uint64_t fifo1Size, uint64_t fifo2Size);
+                      uint64_t fifo1Size, uint64_t fifo2Size,
+                      double unavailabilityQueueFillGrade);
   virtual ~SupervisedScheduler();
 
   bool queue(RequestLane lane, std::function<void()>) override ADB_WARN_UNUSED_RESULT;
@@ -53,6 +54,13 @@ class SupervisedScheduler final : public Scheduler {
 
   void toVelocyPack(velocypack::Builder&) const override;
   Scheduler::QueueStatistics queueStatistics() const override;
+
+  /// @brief approximate fill grade of the scheduler's queue (in %)
+  double approximateQueueFillGrade() const override;
+  
+  /// @brief fill grade of the scheduler's queue (in %) from which onwards
+  /// the server is considered unavailable (because of overload)
+  double unavailabilityQueueFillGrade() const override;
  
  protected:
   bool isStopping() override { return _stopping; }
@@ -129,6 +137,10 @@ class SupervisedScheduler final : public Scheduler {
   uint64_t const _maxFifoSize;
   uint64_t const _fifo1Size;
   uint64_t const _fifo2Size;
+
+  /// @brief fill grade of the scheduler's queue (in %) from which onwards
+  /// the server is considered unavailable (because of overload)
+  double const _unavailabilityQueueFillGrade;
 
   std::list<std::shared_ptr<WorkerState>> _workerStates;
   std::list<std::shared_ptr<WorkerState>> _abandonedWorkerStates;

--- a/tests/Cluster/ClusterCommTest.cpp
+++ b/tests/Cluster/ClusterCommTest.cpp
@@ -45,7 +45,7 @@ class ClusterCommTester : public ClusterComm {
   ClusterCommTester(application_features::ApplicationServer& server)
       : ClusterComm(server, false),
         _oldSched(nullptr),
-        _testerSched(server, 1, 2, 3, 4, 5) {
+        _testerSched(server, 1, 2, 3, 4, 5, 0.0) {
     // fake a scheduler object
     _oldSched = SchedulerFeature::SCHEDULER;
     SchedulerFeature::SCHEDULER = &_testerSched;

--- a/tests/Cluster/RebootTrackerTest.cpp
+++ b/tests/Cluster/RebootTrackerTest.cpp
@@ -142,7 +142,7 @@ class RebootTrackerTest : public ::testing::Test,
   RebootTrackerTest()
       : mockApplicationServer(),
         scheduler(std::make_unique<SupervisedScheduler>(mockApplicationServer.server(),
-                                                        2, 64, 128, 1024 * 1024, 4096)) {}
+                                                        2, 64, 128, 1024 * 1024, 4096, 0.0)) {}
 #if (_MSC_VER >= 1)
 #pragma warning(pop)
 #endif


### PR DESCRIPTION
### Scope & Purpose

This is a PR to add more observability.

**Metrics**:

* Added new metric `arangodb_network_forwarded_requests` to track the number of requests forwarded from one coordinator to another in a load-balancing context.
* Added new metric `arangodb_replication_cluster_inventory_requests` to track the number of requests received for cluster inventories. The cluster inventory API is called at the beginning of a dump process or by arangosync.
* Added new metric `arangodb_aql_all_query` to track the total number of AQL queries.
* Added new metric `arangodb_aql_total_query_time_msec` to track the combined runtime of AQL queries (slow queries and non-slow queries).
* Added more scheduler metrics:
  * `arangodb_scheduler_threads_started`: Total number of scheduler threads started
  * `arangodb_scheduler_threads_stopped`: Total number of scheduler threads stopped
  * `arangodb_scheduler_jobs_done`: Total number of scheduler queue jobs done
  * `arangodb_scheduler_jobs_submitted`: Total number of jobs submitted to the scheduler queue
  * `arangodb_scheduler_jobs_dequeued`: Total number of jobs dequeued from the scheduler queue
  * `arangodb_scheduler_num_working_threads`: Number of currently working scheduler threads

**Availability API**:
Added startup option `--server.unavailability-queue-fill-grade`. 
This option has a consequence for the `/_admin/server/availability` API only, which is often called by load-balancers and other availability probing systems. 

The `/_admin/server/availability` API will now return HTTP 200 if the fill grade of the scheduler's queue is below the configured value, or HTTP 503 if  the fill grade is above it. This can be used to flag a server as unavailable in case it is already highly loaded.

The default value for this option is `1`, which will mean that the availability API will start returning HTTP 503 responses in case the scheduler queue is completely full. This is mostly compatible with previous versions of ArangoDB. 
Previously the availability API still returned HTTP 200 in this situation, but this can be considered a bug, because the server was effectively totally overloaded.
To restore 100% compatible behavior with previous version, it is possible to set the option to a value of `0`, which is a special value indicating that the queue fill grade will not be honored. 
  
To prevent sending more traffic to an already overloaded server, it can be sensible to reduce the default value to `0.75` or even `0.5`. This would mean that instances with a queue longer than 75% (or 50%, resp.) of their maximum queue capacity would return HTTP 503 instead of HTTP 200 when their availability API is probed. 

Docs PR: https://github.com/arangodb/docs/pull/580

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12751/