### PR TITLE
remove compiler directive `-felmininate-unused-debug-symbols`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -961,7 +961,7 @@ else () # NOT MSVC
   # flags for builds with debug symbols
   if (USE_MINIMAL_DEBUGINFO)
     # minimal debug symbols
-    set(DEBUGINFO_FLAGS "-g1 -gno-column-info -gz -feliminate-unused-debug-symbols")
+    set(DEBUGINFO_FLAGS "-g1 -gno-column-info -gz")
   else ()
     # full debug symbols
     set(DEBUGINFO_FLAGS "-g")


### PR DESCRIPTION
### Scope & Purpose

Remove compiler directive `-felmininate-unused-debug-symbols` from CMakeLists.txt, because it is enabled by default on g++, and clang++ does not support it.
Backports are not required because we added the `USE_MINIMAL_DEBUGINFO` CMake variable only in devel.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12762/