### PR TITLE
Bug fix 3.6/cleanup 20201117

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,18 @@
 v3.6.10 (XXXX-XX-XX)
 --------------------
 
+* Make the number of network I/O threads properly configurable via the
+  startup option `--network.io-threads`. This option existed before, but its
+  configured value was effectively clamped to a value of `1`. 
+
+* Disable cluster maintenance background threads on coordinators.
+
+  The maintenance threads don't have any purpose on coordinators, so there
+  is no need to start them there. This saves 2 or more background threads on 
+  coordinators. These threads should have mostly been idle before, so saving
+  them will not have a huge impact except saving a few MB of thread stack
+  memory.
+
 * Updated arangosync to 0.7.12.
 
 * Added new metric `arangodb_network_forwarded_requests` to track the number

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,14 +3,14 @@ v3.6.10 (XXXX-XX-XX)
 
 * Make the number of network I/O threads properly configurable via the startup
   option `--network.io-threads`. This option existed before, but its configured
-  value was effectively clamped to a value of `1`. ArangoDB 3.6.10 thus also 
+  value was effectively clamped to a value of `1`. ArangoDB 3.6.10 thus also
   uses a default value of `1` for this option to remain compatible in terms of
   default option values.
 
 * Disable cluster maintenance background threads on coordinators.
 
-  The maintenance threads don't have any purpose on coordinators, so there
-  is no need to start them there. This saves 2 or more background threads on 
+  The maintenance threads don't have any purpose on coordinators, so there is no
+  need to start them there. This saves 2 or more background threads on
   coordinators. These threads should have mostly been idle before, so saving
   them will not have a huge impact except saving a few MB of thread stack
   memory.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,7 +26,7 @@ v3.6.10 (XXXX-XX-XX)
   inventory API is called at the beginning of a dump process or by arangosync.
 
 * Added new AQL metrics:
-  - `arangodb_aql_total_query_time_msec": Total execution time of all AQL 
+  - `arangodb_aql_total_query_time_msec": Total execution time of all AQL
     queries (ms)
   - `arangodb_aql_all_query`: total number of all AQL queries
 
@@ -35,38 +35,41 @@ v3.6.10 (XXXX-XX-XX)
 
 * Added more scheduler metrics:
 
-  - `arangodb_scheduler_threads_started`: Total number of scheduler threads started
-  - `arangodb_scheduler_threads_stopped`: Total number of scheduler threads stopped
+  - `arangodb_scheduler_threads_started`: Total number of scheduler threads
+    started
+  - `arangodb_scheduler_threads_stopped`: Total number of scheduler threads
+    stopped
   - `arangodb_scheduler_jobs_done`: Total number of scheduler queue jobs done
-  - `arangodb_scheduler_jobs_submitted`: Total number of jobs submitted to the 
+  - `arangodb_scheduler_jobs_submitted`: Total number of jobs submitted to the
     scheduler queue
-  - `arangodb_scheduler_jobs_dequeued`: Total number of jobs dequeued from the 
+  - `arangodb_scheduler_jobs_dequeued`: Total number of jobs dequeued from the
     scheduler queue
-  - `arangodb_scheduler_num_working_threads`: Number of currently working 
+  - `arangodb_scheduler_num_working_threads`: Number of currently working
     scheduler threads
 
 * Added startup option `--server.unavailability-queue-fill-grade`. This option
   has a consequence for the `/_admin/server/availability` API only, which is
-  often called by load-balancers and other availability probing systems. 
-  The `/_admin/server/availability` API will now return HTTP 200 if the fill 
-  grade of the scheduler's queue is below the configured value, or HTTP 503 if 
-  the fill grade is above it. This can be used to flag a server as unavailable 
+  often called by load-balancers and other availability probing systems.
+  The `/_admin/server/availability` API will now return HTTP 200 if the fill
+  grade of the scheduler's queue is below the configured value, or HTTP 503 if
+  the fill grade is above it. This can be used to flag a server as unavailable
   in case it is already highly loaded.
-  The default value for this option is `1`, which will mean that the availability
-  API will start returning HTTP 503 responses in case the scheduler queue is
-  completely full. This is mostly compatible with previous versions of ArangoDB. 
+  The default value for this option is `1`, which will mean that the
+  availability API will start returning HTTP 503 responses in case the scheduler
+  queue is completely full. This is mostly compatible with previous versions of
+  ArangoDB.
   Previously the availability API still returned HTTP 200 in this situation, but
   this can be considered a bug, because the server was effectively totally
   overloaded.
   To restore 100% compatible behavior with previous version, it is possible to
-  set the option to a value of `0`, which is a special value indicating that 
-  the queue fill grade will not be honored. 
-  
-  To prevent sending more traffic to an already overloaded server, it can be 
+  set the option to a value of `0`, which is a special value indicating that the
+  queue fill grade will not be honored.
+
+  To prevent sending more traffic to an already overloaded server, it can be
   sensible to reduce the default value to `0.75` or even `0.5`.
-  This would mean that instances with a queue longer than 75% (or 50%, resp.) 
-  of their maximum queue capacity would return HTTP 503 instead of HTTP 200 
-  when their availability API is probed. 
+  This would mean that instances with a queue longer than 75% (or 50%, resp.) of
+  their maximum queue capacity would return HTTP 503 instead of HTTP 200 when
+  their availability API is probed.
 
   nb: the default value for the scheduler queue length is 4096.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,11 @@
 v3.6.10 (XXXX-XX-XX)
 --------------------
 
-* Make the number of network I/O threads properly configurable via the
-  startup option `--network.io-threads`. This option existed before, but its
-  configured value was effectively clamped to a value of `1`. 
+* Make the number of network I/O threads properly configurable via the startup
+  option `--network.io-threads`. This option existed before, but its configured
+  value was effectively clamped to a value of `1`. ArangoDB 3.6.10 thus also 
+  uses a default value of `1` for this option to remain compatible in terms of
+  default option values.
 
 * Disable cluster maintenance background threads on coordinators.
 

--- a/arangod/Cluster/MaintenanceFeature.cpp
+++ b/arangod/Cluster/MaintenanceFeature.cpp
@@ -131,7 +131,7 @@ void MaintenanceFeature::validateOptions(std::shared_ptr<ProgramOptions> options
     LOG_TOPIC("37726", WARN, Logger::MAINTENANCE)
         << "Need at least" << minThreadLimit << "maintenance-threads";
     _maintenanceThreadsMax = minThreadLimit;
-  } else if (_maintenanceThreadsMax >= maxThreadLimit) {
+  } else if (_maintenanceThreadsMax > maxThreadLimit) {
     LOG_TOPIC("8fb0e", WARN, Logger::MAINTENANCE)
         << "maintenance-threads limited to " << maxThreadLimit;
     _maintenanceThreadsMax = maxThreadLimit;
@@ -149,6 +149,11 @@ void MaintenanceFeature::start() {
     LOG_TOPIC("deb1a", TRACE, Logger::MAINTENANCE)
         << "Disable maintenance-threads"
         << " for single-server or agents.";
+    return;
+  }
+
+  if (serverState->isCoordinator()) {
+    // no need for maintenance on a coordinator
     return;
   }
 

--- a/arangod/Cluster/RestClusterHandler.cpp
+++ b/arangod/Cluster/RestClusterHandler.cpp
@@ -40,10 +40,7 @@ using namespace arangodb::rest;
 
 RestClusterHandler::RestClusterHandler(application_features::ApplicationServer& server,
                                        GeneralRequest* request, GeneralResponse* response)
-    : RestBaseHandler(server, request, response) {
-  std::vector<std::string> const& suffixes = _request->suffixes();
-  _allowDirectExecution = !suffixes.empty() && suffixes[0] == "endpoints";
-}
+    : RestBaseHandler(server, request, response) {}
 
 RestStatus RestClusterHandler::execute() {
   if (_request->requestType() != RequestType::GET) {

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -61,7 +61,7 @@ RestHandler::RestHandler(application_features::ApplicationServer& server,
       _statistics(nullptr),
       _handlerId(0),
       _state(HandlerState::PREPARE),
-      _enableHandlerLogging(false)
+      _enableHandlerLogging(false),
       _canceled(false) {
 
   _enableHandlerLogging = Logger::isEnabled(LogLevel::TRACE, Logger::HANDLER); 

--- a/arangod/GeneralServer/RestHandler.h
+++ b/arangod/GeneralServer/RestHandler.h
@@ -223,6 +223,8 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
 
   HandlerState _state;
 
+  bool _enableHandlerLogging;
+
  protected:
   std::atomic<bool> _canceled;
 };

--- a/arangod/GeneralServer/RestHandler.h
+++ b/arangod/GeneralServer/RestHandler.h
@@ -109,9 +109,6 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
   // what lane to use for this request
   virtual RequestLane lane() const = 0;
 
-  // return true if direct handler execution is allowed
-  bool allowDirectExecution() const { return _allowDirectExecution; }
-
   RequestLane getRequestLane() {
     bool found;
     _request->header(StaticStrings::XArangoFrontend, found);
@@ -191,6 +188,8 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
 
   /// handler state machine
   HandlerState state() const { return _state; }
+  
+  static char const* stateString(HandlerState state);
 
  private:
   void runHandlerStateMachine();
@@ -202,6 +201,10 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
   ///        otherwise execute() will be called
   void executeEngine(bool isContinue);
   void compressResponse();
+
+  /// @brief log information about the handler state,
+  /// in log topic HANDLER
+  void logState(char const* context) const;
 
  protected:
   std::unique_ptr<GeneralRequest> _request;
@@ -222,8 +225,6 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
 
  protected:
   std::atomic<bool> _canceled;
-
-  bool _allowDirectExecution = false;
 };
 
 }  // namespace rest

--- a/arangod/Network/NetworkFeature.cpp
+++ b/arangod/Network/NetworkFeature.cpp
@@ -104,7 +104,7 @@ void NetworkFeature::collectOptions(std::shared_ptr<options::ProgramOptions> opt
 }
 
 void NetworkFeature::validateOptions(std::shared_ptr<options::ProgramOptions>) {
-  _numIOThreads = std::min<unsigned>(1, std::max<unsigned>(_numIOThreads, 8));
+  _numIOThreads = std::max<unsigned>(1, std::min<unsigned>(_numIOThreads, 8));
   if (_maxOpenConnections < 8) {
     _maxOpenConnections = 8;
   }

--- a/arangod/Network/NetworkFeature.cpp
+++ b/arangod/Network/NetworkFeature.cpp
@@ -127,7 +127,6 @@ void NetworkFeature::prepare() {
   config.verifyHosts = _verifyHosts;
   config.clusterInfo = ci;
 
-  LOG_DEVEL << "NUM: " << _numIOThreads;
   _pool = std::make_unique<network::ConnectionPool>(config);
   _poolPtr.store(_pool.get(), std::memory_order_release);
   

--- a/arangod/Network/NetworkFeature.cpp
+++ b/arangod/Network/NetworkFeature.cpp
@@ -65,7 +65,7 @@ namespace arangodb {
 
 NetworkFeature::NetworkFeature(application_features::ApplicationServer& server)
     : NetworkFeature(server, network::ConnectionPool::Config{}) {
-      this->_numIOThreads = 2; // override default
+  this->_numIOThreads = 1; // override default
 }
 
 NetworkFeature::NetworkFeature(application_features::ApplicationServer& server,
@@ -127,6 +127,7 @@ void NetworkFeature::prepare() {
   config.verifyHosts = _verifyHosts;
   config.clusterInfo = ci;
 
+  LOG_DEVEL << "NUM: " << _numIOThreads;
   _pool = std::make_unique<network::ConnectionPool>(config);
   _poolPtr.store(_pool.get(), std::memory_order_release);
   

--- a/arangod/RestHandler/RestAdminLogHandler.cpp
+++ b/arangod/RestHandler/RestAdminLogHandler.cpp
@@ -40,9 +40,7 @@ using namespace arangodb::rest;
 
 RestAdminLogHandler::RestAdminLogHandler(application_features::ApplicationServer& server,
                                          GeneralRequest* request, GeneralResponse* response)
-    : RestBaseHandler(server, request, response) {
-  _allowDirectExecution = true;
-}
+    : RestBaseHandler(server, request, response) {}
 
 arangodb::Result RestAdminLogHandler::verifyPermitted() {
   auto& server = application_features::ApplicationServer::server();

--- a/arangod/RestHandler/RestAdminServerHandler.cpp
+++ b/arangod/RestHandler/RestAdminServerHandler.cpp
@@ -41,9 +41,7 @@ using namespace arangodb::rest;
 RestAdminServerHandler::RestAdminServerHandler(application_features::ApplicationServer& server,
                                                GeneralRequest* request,
                                                GeneralResponse* response)
-    : RestBaseHandler(server, request, response) {
-  _allowDirectExecution = true;
-}
+    : RestBaseHandler(server, request, response) {}
 
 RestStatus RestAdminServerHandler::execute() {
   std::vector<std::string> const& suffixes = _request->suffixes();

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -45,23 +45,7 @@ using namespace arangodb::rest;
 
 RestDocumentHandler::RestDocumentHandler(application_features::ApplicationServer& server,
                                          GeneralRequest* request, GeneralResponse* response)
-    : RestVocbaseBaseHandler(server, request, response) {
-  
-  if (!ServerState::instance()->isClusterRole()) {
-    // in the cluster we will have (blocking) communication, so we only
-    // want the request to be executed directly when we are on a single server.
-    auto const type = _request->requestType();
-    if ((type == rest::RequestType::GET ||
-         type == rest::RequestType::POST ||
-         type == rest::RequestType::PUT ||
-         type == rest::RequestType::PATCH ||
-         type == rest::RequestType::DELETE_REQ) &&
-        request->contentLength() <= 1024) {
-      // only allow direct execution if we don't have huge payload
-      _allowDirectExecution = true;
-    }
-  }
-}
+    : RestVocbaseBaseHandler(server, request, response) {}
 
 RestDocumentHandler::~RestDocumentHandler() = default;
 

--- a/arangod/RestHandler/RestEngineHandler.cpp
+++ b/arangod/RestHandler/RestEngineHandler.cpp
@@ -35,9 +35,7 @@ using namespace arangodb::rest;
 
 RestEngineHandler::RestEngineHandler(application_features::ApplicationServer& server,
                                      GeneralRequest* request, GeneralResponse* response)
-    : RestBaseHandler(server, request, response) {
-  _allowDirectExecution = true;
-}
+    : RestBaseHandler(server, request, response) {}
 
 RestStatus RestEngineHandler::execute() {
   // extract the sub-request type

--- a/arangod/RestHandler/RestJobHandler.cpp
+++ b/arangod/RestHandler/RestJobHandler.cpp
@@ -43,7 +43,6 @@ RestJobHandler::RestJobHandler(application_features::ApplicationServer& server,
                                AsyncJobManager* jobManager)
     : RestBaseHandler(server, request, response), _jobManager(jobManager) {
   TRI_ASSERT(jobManager != nullptr);
-  _allowDirectExecution = true;
 }
 
 RestStatus RestJobHandler::execute() {

--- a/arangod/RestHandler/RestPleaseUpgradeHandler.cpp
+++ b/arangod/RestHandler/RestPleaseUpgradeHandler.cpp
@@ -31,9 +31,7 @@ using velocypack::StringRef;
 RestPleaseUpgradeHandler::RestPleaseUpgradeHandler(application_features::ApplicationServer& server,
                                                    GeneralRequest* request,
                                                    GeneralResponse* response)
-    : RestHandler(server, request, response) {
-  _allowDirectExecution = true;
-}
+    : RestHandler(server, request, response) {}
 
 RestStatus RestPleaseUpgradeHandler::execute() {
   resetResponse(rest::ResponseCode::OK);

--- a/arangod/RestHandler/RestShutdownHandler.cpp
+++ b/arangod/RestHandler/RestShutdownHandler.cpp
@@ -39,9 +39,7 @@ using namespace arangodb::rest;
 
 RestShutdownHandler::RestShutdownHandler(application_features::ApplicationServer& server,
                                          GeneralRequest* request, GeneralResponse* response)
-    : RestBaseHandler(server, request, response) {
-  _allowDirectExecution = true;
-}
+    : RestBaseHandler(server, request, response) {}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief was docuBlock JSF_get_api_initiate

--- a/arangod/RestHandler/RestStatusHandler.cpp
+++ b/arangod/RestHandler/RestStatusHandler.cpp
@@ -49,9 +49,7 @@ using namespace arangodb::rest;
 
 RestStatusHandler::RestStatusHandler(application_features::ApplicationServer& server,
                                      GeneralRequest* request, GeneralResponse* response)
-    : RestBaseHandler(server, request, response) {
-  _allowDirectExecution = true;
-}
+    : RestBaseHandler(server, request, response) {}
 
 RestStatus RestStatusHandler::execute() {
   auto& server = application_features::ApplicationServer::server();

--- a/arangod/RestHandler/RestVersionHandler.cpp
+++ b/arangod/RestHandler/RestVersionHandler.cpp
@@ -41,9 +41,7 @@ using namespace arangodb::rest;
 
 RestVersionHandler::RestVersionHandler(application_features::ApplicationServer& server,
                                        GeneralRequest* request, GeneralResponse* response)
-    : RestBaseHandler(server, request, response) {
-  _allowDirectExecution = true;
-}
+    : RestBaseHandler(server, request, response) {}
 
 RestStatus RestVersionHandler::execute() {
   VPackBuilder result;

--- a/lib/Logger/LogTopic.cpp
+++ b/lib/Logger/LogTopic.cpp
@@ -129,6 +129,7 @@ LogTopic Logger::ENGINES("engines", LogLevel::INFO);
 LogTopic Logger::FIXME("general", LogLevel::INFO);
 LogTopic Logger::FLUSH("flush", LogLevel::INFO);
 LogTopic Logger::GRAPHS("graphs", LogLevel::INFO);
+LogTopic Logger::HANDLER("handler", LogLevel::FATAL);
 LogTopic Logger::HEARTBEAT("heartbeat", LogLevel::INFO);
 LogTopic Logger::HTTPCLIENT("httpclient", LogLevel::WARN);
 LogTopic Logger::MAINTENANCE("maintenance", LogLevel::WARN);

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -153,6 +153,7 @@ class Logger {
   static LogTopic FIXME;
   static LogTopic FLUSH;
   static LogTopic GRAPHS;
+  static LogTopic HANDLER;
   static LogTopic HEARTBEAT;
   static LogTopic HTTPCLIENT;
   static LogTopic MAINTENANCE;


### PR DESCRIPTION
### Scope & Purpose

This is a multi-purpose PR:

It makes the number of network I/O threads properly configurable via the startup option `--network.io-threads`. This option existed before, but its configured value was effectively clamped to a value of `1`. 
This change requires forward ports to 3.7 and devel.

It also disables cluster maintenance background threads on coordinators.
The maintenance threads don't have any purpose on coordinators, so there is no need to start them there. This saves 2 or more background threads on coordinators. These threads should have mostly been idle before, so saving them will not have a huge impact except saving a few MB of thread stack memory.
The maintenance threads are already turned off on coordinators in 3.7 and devel for a while, so this does not need to be ported.

In addition this PR removes the `_allowDirectExecution` instance variable from RestHandlers, which in 3.6 was only set but never read back. This variable lost its meaning at point in the 3.5 cycle, so it is now useless and can be removed.
The instance variable has already been removed in 3.7 and devel a while ago, so this does not need to be ported.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12786/