### PR TITLE
fix oversight spottet by @mpoeter

### DIFF
--- a/arangosh/Benchmark/BenchFeature.cpp
+++ b/arangosh/Benchmark/BenchFeature.cpp
@@ -563,7 +563,7 @@ void BenchFeature::printResult(BenchRunResult const& result, VPackBuilder& build
   builder.add("requestResponseDurationPerThread", VPackValue(result.requestTime / (double)_concurrency));
 
   std::cout << "Time needed per operation: " << std::fixed
-            << (result.time / _operations) << " s" << std::endl;
+            << (result.time / _realOperations) << " s" << std::endl;
   builder.add("timeNeededPerOperation", VPackValue(result.time / _realOperations));
   
   std::cout << "Time needed per operation per thread: " << std::fixed


### PR DESCRIPTION
Renaming the variable for printing arangobench results was missed in one space while adding the `--duration` feature.