### PR TITLE
Docs: Check protocol(), throw if not http/1.1, don't filter common headers

### DIFF
--- a/js/client/bootstrap/modules/internal.js
+++ b/js/client/bootstrap/modules/internal.js
@@ -236,13 +236,23 @@
   let appendHeaders = function(appender, headers) {
     var key;
     // generate header
-    appender('HTTP/1.1 ' + headers['http/1.1'] + '\n');
+    const protocol = exports.arango.protocol();
+    if (protocol === 'http') {
+      if (headers.hasOwnProperty('http/1.1')) {
+        appender(`HTTP/1.1 ${headers['http/1.1']}\n`);
+      } else {
+        throw `Header field 'http/1.1' is missing.`;
+      }
+    } else {
+      throw `ArangoConnection::protocol() is '${protocol}', expected 'http'.`;
+    }
 
     for (key in headers) {
       if (headers.hasOwnProperty(key)) {
-        if (key !== 'http/1.1' && key !== 'server' && key !== 'connection'
-            && key !== 'content-length') {
-          appender(key + ': ' + headers[key] + '\n');
+        if (key !== 'http/1.1') {
+          // Could filter out some common header fields here
+          //key !== 'server' && key !== 'connection' && key !== 'content-length'
+          appender(`${key}: ${headers[key]}\n`);
         }
       }
     }


### PR DESCRIPTION
### Scope & Purpose

Let appendHeaders() check the protocol (#13038) and throw if the `http/1.1` header field isn't set.
Still doesn't support HTTP/2 or VST, but at least we will see an error should the protocol be changed at some point.

No longer filter out the header fields `server`, `connection` and `content-length`. This makes the generated examples slightly longer but accurate.

- [x] :hammer: Refactoring/simplification

https://jenkins01.arangodb.biz/view/Documentation/job/arangodb-ANY-examples/698/

#### Backports:

- [ ] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

#### Related Information

https://arangodb.atlassian.net/browse/DOC-71

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
