### PR TITLE
make sure we catch syntax error while eval'ing in runInLocalArangosh

### DIFF
--- a/js/client/modules/@arangodb/testutils/test-utils.js
+++ b/js/client/modules/@arangodb/testutils/test-utils.js
@@ -208,14 +208,17 @@ function performTests (options, testList, testname, runFn, serverOptions, startS
 
           if (!results.hasOwnProperty('SKIPPED')) {
             print('oops! Skipping remaining tests, server is unavailable for testing.');
-
+            let originalMessage;
+            if (results.hasOwnProperty(te) && results[te].hasOwnProperty('message')) {
+              originalMessage = results[te].message;
+            }
             results['SKIPPED'] = {
               status: false,
               message: ""
             };
             results[te] = {
               status: false,
-              message: 'server unavailable for testing.'
+              message: 'server unavailable for testing. ' + originalMessage
             };
           } else {
             if (results['SKIPPED'].message !== '') {
@@ -902,21 +905,7 @@ function runInLocalArangosh (options, instanceInfo, file, addArgs) {
 
   try {
     SetGlobalExecutionDeadlineTo(options.oneTestTimeout * 1000);
-    let result;
-    try {
-      result = testFunc();
-    } catch (ex) {
-      let timeout = SetGlobalExecutionDeadlineTo(0.0);
-      print(RED + 'test has thrown:');
-      print(ex);
-      print(RESET);
-      return {
-        timeout: 0,
-        status: false,
-        message: "test has thrown! '" + file + "' - " + ex.message || String(ex),
-        stack: ex.stack
-      };
-    }
+    let result = testFunc();
     let timeout = SetGlobalExecutionDeadlineTo(0.0);
     if (timeout) {
       return {
@@ -929,6 +918,9 @@ function runInLocalArangosh (options, instanceInfo, file, addArgs) {
     return result;
   } catch (ex) {
     let timeout = SetGlobalExecutionDeadlineTo(0.0);
+    print(RED + 'test has thrown: ' + (timeout? "because of timeout in execution":""));
+    print(ex);
+    print(RESET);
     return {
       timeout: timeout,
       forceTerminate: true,


### PR DESCRIPTION
### Scope & Purpose
`runInLocalArangosh` eval's testcodes into the local arangosh.
However, so far it doesn't properly catch all errors, but rather slashes the SUT hiding the original error. 

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required - should only occur during writing tests.
- [ ] Backports required for: *(Please specify versions and link PRs)*

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:
http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/12843/