### PR TITLE
Fix clang warning about unused variable.

### DIFF
--- a/lib/ApplicationFeatures/CpuUsageFeature.cpp
+++ b/lib/ApplicationFeatures/CpuUsageFeature.cpp
@@ -36,10 +36,6 @@
 #include <cstdio>
 #include <cstring>
 
-namespace {
-constexpr size_t bufferSize = 4096;
-}
-
 namespace arangodb {
 
 #if defined(__linux__)
@@ -71,14 +67,16 @@ CpuUsageFeature::SnapshotProvider::~SnapshotProvider() {
 }
 
 bool CpuUsageFeature::SnapshotProvider::tryTakeSnapshot(CpuUsageSnapshot& result) noexcept {
+  constexpr size_t bufferSize = 4096;
+
   // none of the following methods will throw an exception
   rewind(_statFile);    
   fflush(_statFile); 
 
-  char buffer[::bufferSize];
+  char buffer[bufferSize];
   buffer[0] = '\0';
  
-  size_t nread = readStatFile(&buffer[0], ::bufferSize);
+  size_t nread = readStatFile(&buffer[0], bufferSize);
   // expect a minimum size
   if (nread < 32 || memcmp(&buffer[0], "cpu ", 4) != 0) {
     // invalid data read.


### PR DESCRIPTION
### Scope & Purpose

Fixes a strange error from clang-12 which complains about an unused variable.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12848/
