### PR TITLE
Make cancelation of asynchronoulsly started JS transactions safe

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.7.5 (XXXX-XX-XX)
 -------------------
 
+* Make the cancel operation safe for asynchronoulsly started JavaScript 
+  transactions (via HTTP POST to `/_api/transaction` with the `x-arango-async`
+  header set).
+
 * Updated OpenSSL to 1.1.1h.
 
 * Make the number of network I/O threads properly configurable via the startup

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,13 @@
-v3.7.5 (XXXX-XX-XX)
+v3.7.6 (XXXX-XX-XX)
 -------------------
 
 * Make the cancel operation safe for asynchronoulsly started JavaScript 
   transactions (via HTTP POST to `/_api/transaction` with the `x-arango-async`
   header set).
+
+
+v3.7.5 (XXXX-XX-XX)
+-------------------
 
 * Updated OpenSSL to 1.1.1h.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,13 +1,9 @@
-v3.7.6 (XXXX-XX-XX)
--------------------
-
-* Make the cancel operation safe for asynchronoulsly started JavaScript 
-  transactions (via HTTP POST to `/_api/transaction` with the `x-arango-async`
-  header set).
-
-
 v3.7.5 (XXXX-XX-XX)
 -------------------
+
+* Make the cancel operation safe for asynchronoulsly started JavaScript
+  transactions (via HTTP POST to `/_api/transaction` with the `x-arango-async`
+  header set).
 
 * Updated OpenSSL to 1.1.1h.
 

--- a/arangod/RestHandler/RestTransactionHandler.cpp
+++ b/arangod/RestHandler/RestTransactionHandler.cpp
@@ -283,26 +283,37 @@ void RestTransactionHandler::executeJSTransaction() {
 
   bool allowUseDatabase = ActionFeature::ACTION->allowUseDatabase();
   JavaScriptSecurityContext securityContext = JavaScriptSecurityContext::createRestActionContext(allowUseDatabase);
-  _v8Context = V8DealerFeature::DEALER->enterContext(&_vocbase, securityContext);
+  V8Context* v8Context = V8DealerFeature::DEALER->enterContext(&_vocbase, securityContext);
 
-  if (!_v8Context) {
+  if (!v8Context) {
     generateError(Result(TRI_ERROR_INTERNAL, "could not acquire v8 context"));
     return;
   }
 
-  TRI_DEFER(returnContext());
+  // register a function to release the V8Context whenever we exit from this scope
+  auto guard = scopeGuard([this]() {
+    WRITE_LOCKER(lock, _lock);
+    if (_v8Context != nullptr) {
+      V8DealerFeature::DEALER->exitContext(_v8Context);
+      _v8Context = nullptr;
+    }
+  });
+     
+  {
+    // make our V8Context available to the cancel function
+    WRITE_LOCKER(lock, _lock);
+    _v8Context = v8Context;
+    if (_canceled) {
+      // if we cancel here, the shutdown function above will perform the necessary cleanup
+      lock.unlock();
+      generateCanceled();
+      return;
+    }
+  }
 
   VPackBuilder result;
   try {
-    {
-      WRITE_LOCKER(lock, _lock);
-      if (_canceled) {
-        generateCanceled();
-        return;
-      }
-    }
-
-    Result res = executeTransaction(_v8Context->_isolate, _lock, _canceled,
+    Result res = executeTransaction(v8Context->_isolate, _lock, _canceled,
                                     slice, portType, result);
     if (res.ok()) {
       VPackSlice slice = result.slice();
@@ -323,19 +334,15 @@ void RestTransactionHandler::executeJSTransaction() {
   }
 }
 
-void RestTransactionHandler::returnContext() {
-  WRITE_LOCKER(writeLock, _lock);
-  V8DealerFeature::DEALER->exitContext(_v8Context);
-  _v8Context = nullptr;
-}
-
 void RestTransactionHandler::cancel() {
   // cancel v8 transaction
   WRITE_LOCKER(writeLock, _lock);
   _canceled.store(true);
-  auto isolate = _v8Context->_isolate;
-  if (!isolate->IsExecutionTerminating()) {
-    isolate->TerminateExecution();
+  if (_v8Context != nullptr) {
+    auto isolate = _v8Context->_isolate;
+    if (!isolate->IsExecutionTerminating()) {
+      isolate->TerminateExecution();
+    }
   }
 }
 

--- a/arangod/RestHandler/RestTransactionHandler.h
+++ b/arangod/RestHandler/RestTransactionHandler.h
@@ -60,8 +60,6 @@ class RestTransactionHandler : public arangodb::RestVocbaseBaseHandler {
 
   /// start a legacy JS transaction
   void executeJSTransaction();
-  /// return the currently used V8Context
-  void returnContext();
 };
 }  // namespace arangodb
 


### PR DESCRIPTION
### Scope & Purpose

The cancelation of JavaScript transactions started via HTTP POST to `/_api/transaction` with the `x-arango-async` header set was previously unsafe, because the cancel code could run after the transaction was executed and its V8Context was already returned. In this case the `_v8Context` instance variable was a nullptr, but `cancel()` did not check for this.

This is a backport of https://github.com/arangodb/arangodb/pull/13084

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [x] Backports required for: *3.6*

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *http_server (but only partially)*.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12859/