### PR TITLE
fix activation of maintenance via REST API `/_admin/cluster/maintenance`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fix the activation of the agency supervision maintenance via the REST API
+  `/_admin/cluster/maintenance`. This API stored a boolean value instead of
+  an (expected) maintenance period end date/time string.
+
 * Make the cancel operation safe for asynchronoulsly started JavaScript 
   transactions (via HTTP POST to `/_api/transaction` with the `x-arango-async`
   header set).

--- a/arangod/Agency/Supervision.h
+++ b/arangod/Agency/Supervision.h
@@ -132,7 +132,7 @@ class Supervision : public arangodb::Thread {
  private:
 
   /// @brief get reference to the spearhead snapshot
-  Node const& snapshot() const ;
+  Node const& snapshot() const;
 
   /// @brief decide, if we can start supervision ahead of armageddon delay
   bool earlyBird() const;

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -1150,7 +1150,10 @@ RestStatus RestAdminClusterHandler::setMaintenance(bool wantToActive) {
 
   auto sendTransaction = [&] {
     if (wantToActive) {
-      return AsyncAgencyComm().setValue(60s, maintenancePath, VPackValue(true), 3600);
+      constexpr int timeout = 3600; // 1 hour
+      return AsyncAgencyComm().setValue(60s, maintenancePath, 
+          VPackValue(timepointToString(
+              std::chrono::system_clock::now() + std::chrono::seconds(timeout))), 3600);
     } else {
       return AsyncAgencyComm().deleteKey(60s, maintenancePath);
     }


### PR DESCRIPTION
### Scope & Purpose

Fix the activation of the agency supervision maintenance via the REST API `/_admin/cluster/maintenance`. This API stored a boolean value instead of an (expected) maintenance period end date/time string.
This affects 3.7 and devel only, but not 3.6.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.7

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12869/