### PR TITLE
use -Wsuggest-override option conditionally for clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -944,6 +944,11 @@ else () # NOT MSVC
     message(STATUS "Compiler type CLANG: ${CMAKE_CXX_COMPILER}")
     set(BASE_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-deprecated-declarations ${BASE_FLAGS}")
     set(EXTRA_CXX_FLAGS "-Wnon-virtual-dtor")
+    
+    if (NOT DARWIN AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "11.0")
+      # clang 11 and higher supports -Wsuggest-override. older versions don't
+      set(EXTRA_CXX_FLAGS "-Wsuggest-override ${EXTRA_CXX_FLAGS}")
+    endif ()
 
     if (DARWIN AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "12.0" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "12.1")
       # With the introduction of apple clang version 12.0.0 (clang-1200.0.32.2) the warning "range-loop-analysis" is now
@@ -956,7 +961,7 @@ else () # NOT MSVC
       # check upcoming versions if the compiler behaviour will be fixed.
       set(EXTRA_C_FLAGS "-Wno-range-loop-analysis")
       set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} -Wno-range-loop-analysis")
-    endif()
+    endif ()
   else ()
     # unknown compiler
     message(STATUS "Compiler type UNKNOWN: ${CMAKE_CXX_COMPILER}")


### PR DESCRIPTION

### Scope & Purpose

Use compiler option `-Wsuggest-override` option only conditionally for clang, because it is only supported from version 11 onwards. Older versions don't have it and produce warnings.
Apple clang 12.0 does not seem to have it either, so disable it there too.

This hopefully fixes a glitch introduced only recently in devel, so I am intentionally not making a CHANGELOG entry for this.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is already covered by existing tests, such as *compilation with clang in Oskar*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12872/