### PR TITLE
Bug fix/executionblockimpl hasmore assertion

### DIFF
--- a/arangod/Aql/AqlExecuteResult.cpp
+++ b/arangod/Aql/AqlExecuteResult.cpp
@@ -55,7 +55,7 @@ AqlExecuteResult::AqlExecuteResult(ExecutionState state, SkipResult skipped,
   // noskip && no data => state != HASMORE
   // <=> skipped || data || state != HASMORE
   TRI_ASSERT(!_skipped.nothingSkipped() ||
-             (_block != nullptr && _block->numEntries() > 0) ||
+             (_block != nullptr && _block->numRows() > 0) ||
              _state != ExecutionState::HASMORE);
 }
 

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -1695,13 +1695,13 @@ ExecutionBlockImpl<Executor>::executeWithoutTrace(AqlCallStack stack) {
       _lastRange.hasShadowRow()) {
     // We have skipped or/and return data, otherwise we cannot return HASMORE
     TRI_ASSERT(!skipped.nothingSkipped() ||
-               (outputBlock != nullptr && outputBlock->numEntries() > 0));
+               (outputBlock != nullptr && outputBlock->numRows() > 0));
     return {ExecutionState::HASMORE, skipped, std::move(outputBlock)};
   }
   // We must return skipped and/or data when reporting HASMORE
   TRI_ASSERT(_upstreamState != ExecutionState::HASMORE ||
              (!skipped.nothingSkipped() ||
-              (outputBlock != nullptr && outputBlock->numEntries() > 0)));
+              (outputBlock != nullptr && outputBlock->numRows() > 0)));
   return {_upstreamState, skipped, std::move(outputBlock)};
 }
 

--- a/tests/js/server/aql/aql-shadowrow-block-return-regression.js
+++ b/tests/js/server/aql/aql-shadowrow-block-return-regression.js
@@ -291,7 +291,7 @@ function nonMaterializingViewRegressionSuite() {
       // and the consumer (Subquery) cannot passthrough the Block.
       // Hence all optimzation is turned off to guarantee these two stay connected.
       const query = `FOR d IN ${vname} OPTIONS {waitForSync:true} LET p = (RETURN 1 + 1) RETURN 1`;
-      const res = db._query(query, {}, {optimizer: {rules: ["-all", "+spliced-subqueries"] }});
+      const res = db._query(query, {}, {optimizer: {rules: ["-all", "+splice-subqueries"] }});
       // This result was never wrong, the internal assertion is tested. 
       assertEqual(res.toArray().length, 1010);
     }

--- a/tests/js/server/aql/aql-shadowrow-block-return-regression.js
+++ b/tests/js/server/aql/aql-shadowrow-block-return-regression.js
@@ -290,7 +290,7 @@ function nonMaterializingViewRegressionSuite() {
       // This test requires that the Producer (View) can optimize away its output
       // and the consumer (Subquery) cannot passthrough the Block.
       // Hence all optimzation is turned off to guarantee these two stay connected.
-      const query = `FOR d IN hv LET p = (RETURN 1 + 1) RETURN 1`;
+      const query = `FOR d IN hv OPTIONS {waitForSync:true} LET p = (RETURN 1 + 1) RETURN 1`;
       const res = db._query(query, {}, {optimizer: {rules: ["-all", "+spliced-subqueries"] }});
       // This result was never wrong, the internal assertion is tested. 
       assertEqual(res.toArray().length, 1010);
@@ -307,4 +307,3 @@ jsunity.run(collectionInSubqeryRegressionSuite);
 jsunity.run(nonMaterializingViewRegressionSuite);
 
 return jsunity.done();
-

--- a/tests/js/server/aql/aql-shadowrow-block-return-regression.js
+++ b/tests/js/server/aql/aql-shadowrow-block-return-regression.js
@@ -290,7 +290,7 @@ function nonMaterializingViewRegressionSuite() {
       // This test requires that the Producer (View) can optimize away its output
       // and the consumer (Subquery) cannot passthrough the Block.
       // Hence all optimzation is turned off to guarantee these two stay connected.
-      const query = `FOR d IN hv OPTIONS {waitForSync:true} LET p = (RETURN 1 + 1) RETURN 1`;
+      const query = `FOR d IN ${vname} OPTIONS {waitForSync:true} LET p = (RETURN 1 + 1) RETURN 1`;
       const res = db._query(query, {}, {optimizer: {rules: ["-all", "+spliced-subqueries"] }});
       // This result was never wrong, the internal assertion is tested. 
       assertEqual(res.toArray().length, 1010);


### PR DESCRIPTION
### Scope & Purpose

This PR fixes a false assertion in AQL ExecutionBlocks.
The assertion tests that something should be written in an AQL block if an executor is finished with it's work and claims there is even more data available.
This assertion tested for the actually existence of a value entry. If this value is NOT used later, it could actually be optimized away here, causing this assertion to trigger. (An empty row is written, but no value)
Now using the number of written rows.
This covers empty rows as well.

This PR does NOT change any production behavior and therefor has no CHANGELOG entry. The code modified here is not compiled into our release.

Jenkins:
http://jenkins.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/12883/