### PR TITLE
Fix zero distance geo NN search

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,8 @@
-v3.7.6 (XXXX-XX-XX)
--------------------
-
-* Fix an issue where a query would not return a result when the geo index was used.
-
-
 v3.7.5 (XXXX-XX-XX)
 -------------------
+
+* Fix an issue where a query would not return a result when the geo index was
+  used.
 
 * Updated OpenSSL to 1.1.1h.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 v3.7.5 (XXXX-XX-XX)
 -------------------
+* Fix an issue where a query would not return a result when the geo index was used.
 
 * Updated OpenSSL to 1.1.1h.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
+v3.7.6 (XXXX-XX-XX)
+-------------------
+
+* Fix an issue where a query would not return a result when the geo index was used.
+
+
 v3.7.5 (XXXX-XX-XX)
 -------------------
-* Fix an issue where a query would not return a result when the geo index was used.
 
 * Updated OpenSSL to 1.1.1h.
 

--- a/arangod/GeoIndex/Index.cpp
+++ b/arangod/GeoIndex/Index.cpp
@@ -295,6 +295,14 @@ void Index::parseCondition(aql::AstNode const* node, aql::Variable const* refere
   } else {
     handleNode(node, reference, params);
   }
+  
+  // allow for GEO_DISTANCE(g, d.geometry) <= 0
+  if (params.filterType == geo::FilterType::NONE &&
+      params.minDistance == 0 &&
+      params.maxDistance == 0 &&
+      params.maxInclusive) {
+    params.maxDistance = geo::kRadEps * geo::kEarthRadiusInMeters;
+  }
 }
 
 }  // namespace geo_index

--- a/arangod/GeoIndex/Near.cpp
+++ b/arangod/GeoIndex/Near.cpp
@@ -159,6 +159,8 @@ std::vector<geo::Interval> NearUtils<CMP>::intervals() {
   // TRI_ASSERT(!_params.ascending || _innerAngle != _maxAngle);
   TRI_ASSERT(_deltaAngle >=
              S1ChordAngle::Radians(S2::kMaxEdge.GetValue(S2::kMaxCellLevel - 2)));
+  
+  std::vector<geo::Interval> intervals;
 
   if (_numScans == 0) {
     calculateBounds();
@@ -169,13 +171,8 @@ std::vector<geo::Interval> NearUtils<CMP>::intervals() {
   _numScans++;
 
   TRI_ASSERT(_innerAngle <= _outerAngle && _outerAngle <= _maxAngle);
+  
   TRI_ASSERT(_innerAngle != _outerAngle);
-
-  /*if (!_buffer.empty()) {
-    LOG_TOPIC("bf909", ERR, Logger::FIXME) << "Inner angle: " << _innerAngle.radians() <<
-  "  top distance: " << _buffer.top().distAngle.radians();
-  }*/
-
   std::vector<S2CellId> cover;
   if (_innerAngle == _minAngle) {
     // LOG_TOPIC("55f3b", INFO, Logger::FIXME) << "[Scan] 0 to something";
@@ -230,10 +227,9 @@ std::vector<geo::Interval> NearUtils<CMP>::intervals() {
 
   } else {  // invalid bounds
     TRI_ASSERT(false);
-    return {};
+    return intervals;
   }
 
-  std::vector<geo::Interval> intervals;
   if (!cover.empty()) {
     geo::utils::scanIntervals(_params, cover, intervals);
     _scannedCells.insert(_scannedCells.end(), cover.begin(), cover.end());

--- a/lib/Geo/GeoParams.h
+++ b/lib/Geo/GeoParams.h
@@ -39,8 +39,8 @@ class Slice;
 }  // namespace velocypack
 namespace geo {
 constexpr double kPi = M_PI;
-// assume up to 16x machine epsilon in precision errors for radian calculations
-constexpr double kRadEps = 16 * std::numeric_limits<double>::epsilon();
+// assume up to 8x machine epsilon in precision errors for radian calculations
+constexpr double kRadEps = 8 * std::numeric_limits<double>::epsilon();
 constexpr double kMaxRadiansBetweenPoints = kPi + kRadEps;
 // Equatorial radius of earth.
 // Source: http://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html

--- a/tests/js/server/aql/aql-queries-geo.js
+++ b/tests/js/server/aql/aql-queries-geo.js
@@ -558,13 +558,13 @@ function pointsTestSuite() {
       db._drop("UnitTestsPointsTestSuite");
 
       locations = db._create("UnitTestsPointsTestSuite");
+      locations.ensureIndex({ type: "geo", fields: ["lat", "lng"]});
+
       for (lat = -40; lat <= 40; ++lat) {
         for (lon = -40; lon <= 40; ++lon) {
           locations.save({ "lat": lat, "lng": lon });
         }
       }
-
-      locations.ensureIndex({ type: "geo", fields: ["lat", "lng"]});
     },
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -573,6 +573,27 @@ function pointsTestSuite() {
 
     tearDownAll: function () {
       db._drop("UnitTestsPointsTestSuite");
+    },
+
+    ////////////////////////////////////////////////////////////////////////////////
+    /// @brief test empty circly
+    ////////////////////////////////////////////////////////////////////////////////
+
+    testContainsEmptyCircle: function () {
+      // run on a few test samples
+      for (let lat = -40; lat <= 40; lat += 8) {
+        for (let lon = -40; lon <= 40; lon += 8) {
+          runQuery({
+            string: "FOR x IN @@cc FILTER DISTANCE(@lat, @lng, x.lat, x.lng) <= 0 RETURN x",
+            bindVars: {
+              "@cc": locations.name(),
+              lat: lat,
+              lng: lon
+            },
+            expected: [{ "lat": lat, "lng": lon }]
+          });
+        }
+      }
     },
 
     ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose

Backport of #12917

Fix an issue where a query would not return a result when the geo index was used.
```
LET g = GEO_POINT(37.616522, 55.704235) 
FOR d IN geo 
  FILTER GEO_DISTANCE(g, d.geometry) <= 0 
  RETURN d
```

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [x] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12884/
