### PR TITLE
fix initial population of AgencyCache

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.7.5 (XXXX-XX-XX)
 -------------------
 
+* Fixed initial population of local AgencyCache values after a server restart.
+  Previously the local cache was populated from the agency using a commit index
+  value of 1, whereas it should have been 0 to get the full agency snapshot.
+
 * Updated OpenSSL to 1.1.1h.
 
 * Make the number of network I/O threads properly configurable via the startup

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -280,7 +280,7 @@ AgentInterface::raft_commit_t Agent::waitFor(index_t index, double timeout) {
     _waitForCV.wait(static_cast<uint64_t>(1.0e6 * (timeout - d.count())));
 
     // shutting down
-    if (this->isStopping()) {
+    if (isStopping()) {
       return Agent::raft_commit_t::UNKNOWN;
     }
   }
@@ -908,7 +908,7 @@ void Agent::advanceCommitIndex() {
 
 }
 
-futures::Future<query_t> Agent::poll(
+std::pair<futures::Future<query_t>, bool> Agent::poll(
   index_t const& index, double const& timeout) {
 
   using namespace std::chrono;
@@ -920,9 +920,23 @@ futures::Future<query_t> Agent::poll(
   // lead to immediate deletion of data. Therefore, it is critical that this
   // code here answers with a current snapshot of the readDB, whenever it is
   // asked for updates since index 0!
-
+  
   std::vector<log_t> logs;
   query_t builder;
+
+  auto leader = _constituent.leaderID();
+  if (!loaded() || (size() > 1 && leader != id())) {
+    return std::pair<futures::Future<query_t>, bool>{
+      futures::makeFuture(std::move(builder)),true};
+  }
+
+  {
+    CONDITION_LOCKER(guard, _waitForCV);
+    while (getPrepareLeadership() != 0 && !isStopping()) {
+      _waitForCV.wait(100);
+    }
+  }
+  
   {
     READ_LOCKER(oLocker, _outputLock);
     if (index == 0 || index < _state.firstIndex()) {  // deliver as if index = 0
@@ -953,7 +967,8 @@ futures::Future<query_t> Agent::poll(
       }
     }
     if (builder != nullptr) {
-      return futures::makeFuture(std::move(builder));
+      return std::pair<futures::Future<query_t>, bool>{
+        futures::makeFuture(std::move(builder)),true};
     }
   }
 
@@ -966,7 +981,7 @@ futures::Future<query_t> Agent::poll(
     if (_lowestPromise > index) {
       _lowestPromise = index;
     }
-    return res->second.getFuture();
+    return std::pair<futures::Future<query_t>, bool>{res->second.getFuture(), true};
   } catch (...) {
     THROW_ARANGO_EXCEPTION_MESSAGE(
       TRI_ERROR_INTERNAL, "Failed to add promise for polling");
@@ -1024,7 +1039,7 @@ void Agent::load() {
   // one agent, since no AppendEntriesRPC have to be issued. Therefore,
   // this thread is almost certainly terminated (and thus isStopping() returns
   // true), when we get here.
-  if (size() > 1 && this->isStopping()) {
+  if (size() > 1 && isStopping()) {
     return;
   }
 
@@ -1161,7 +1176,7 @@ trans_ret_t Agent::transact(query_t const& queries) {
 
   {
     CONDITION_LOCKER(guard, _waitForCV);
-    while (getPrepareLeadership() != 0) {
+    while (getPrepareLeadership() != 0 && !isStopping()) {
       _waitForCV.wait(100);
     }
   }
@@ -1243,7 +1258,7 @@ trans_ret_t Agent::transient(query_t const& queries) {
 
   {
     CONDITION_LOCKER(guard, _waitForCV);
-    while (getPrepareLeadership() != 0) {
+    while (getPrepareLeadership() != 0 && !isStopping()) {
       _waitForCV.wait(100);
     }
   }
@@ -1341,7 +1356,7 @@ write_ret_t Agent::write(query_t const& query, WriteMode const& wmode) {
 
   if (!wmode.discardStartup()) {
     CONDITION_LOCKER(guard, _waitForCV);
-    while (getPrepareLeadership() != 0) {
+    while (getPrepareLeadership() != 0 && !isStopping()) {
       _waitForCV.wait(100);
     }
   }
@@ -1438,7 +1453,7 @@ read_ret_t Agent::read(query_t const& query) {
 
   {
     CONDITION_LOCKER(guard, _waitForCV);
-    while (getPrepareLeadership() != 0) {
+    while (getPrepareLeadership() != 0 && !isStopping()) {
       _waitForCV.wait(100);
     }
   }
@@ -1520,7 +1535,7 @@ void Agent::triggerPollsNoLock(query_t qu, SteadyTimePoint const& tp) {
 /// Send out append entries to followers regularly or on event
 void Agent::run() {
   // Only run in case we are in multi-host mode
-  while (!this->isStopping() && size() > 1) {
+  while (!isStopping() && size() > 1) {
     {
       // We set the variable to false here, if any change happens during
       // or after the calls in this loop, this will be set to true to

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -927,7 +927,7 @@ std::pair<futures::Future<query_t>, bool> Agent::poll(
   auto leader = _constituent.leaderID();
   if (!loaded() || (size() > 1 && leader != id())) {
     return std::pair<futures::Future<query_t>, bool>{
-      futures::makeFuture(std::move(builder)),true};
+      futures::makeFuture(std::move(builder)),false};
   }
 
   {

--- a/arangod/Agency/Agent.h
+++ b/arangod/Agency/Agent.h
@@ -122,8 +122,8 @@ class Agent final : public arangodb::Thread, public AgentInterface {
   /// @brief Read from agency
   read_ret_t read(query_t const&);
 
-  /// @brief Long pool for higher index than given
-  futures::Future<query_t> poll(index_t const& index, double const& timeout);
+  /// @brief Long pool for higher index than given if leader or else empty builder and false
+  std::pair<futures::Future<query_t>, bool> poll(index_t const& index, double const& timeout);
 
   /// @brief Inquire success of logs given clientIds
   write_ret_t inquire(query_t const&);

--- a/arangod/Agency/RestAgencyHandler.cpp
+++ b/arangod/Agency/RestAgencyHandler.cpp
@@ -161,69 +161,69 @@ RestStatus RestAgencyHandler::pollIndex(
   auto pollResult = _agent->poll(start, timeout);
   
   if (pollResult.second) {
-  return waitForFuture(
-    std::move(pollResult.first).thenValue([this, start](std::shared_ptr<VPackBuilder>&& rb) {
-      VPackSlice res = rb->slice();
+    return waitForFuture(
+      std::move(pollResult.first).thenValue([this, start](std::shared_ptr<VPackBuilder>&& rb) {
+        VPackSlice res = rb->slice();
 
-      if (res.isObject() && res.hasKey("result")) {
+        if (res.isObject() && res.hasKey("result")) {
 
-        if (res.hasKey("error")) { // leadership loss
-          generateError(
-            rest::ResponseCode::SERVICE_UNAVAILABLE,
-            TRI_ERROR_HTTP_SERVICE_UNAVAILABLE, "No leader");
-          return;
-        }
-
-        VPackSlice slice = res.get("result");
-
-        if (slice.hasKey("log")) {
-          VPackBuilder builder;
-          {
-            VPackObjectBuilder ob(&builder);
-            builder.add(StaticStrings::Error, VPackValue(false));
-            builder.add("code", VPackValue(int(ResponseCode::OK)));
-            builder.add(VPackValue("result"));
-            VPackObjectBuilder r(&builder);
-            if (!slice.get("firstIndex").isNumber()) {
-              generateError(
-                rest::ResponseCode::SERVER_ERROR,
-                TRI_ERROR_HTTP_SERVER_ERROR, "invalid first log index.");
-              return;
-            } else if (slice.get("firstIndex").getNumber<uint64_t>() > start) {
-              generateError(
-                rest::ResponseCode::SERVER_ERROR,
-                TRI_ERROR_HTTP_SERVER_ERROR, "first log index is greater than requested.");
-              return;
-            }
-            uint64_t i = start - slice.get("firstIndex").getNumber<uint64_t>();
-            builder.add("commitIndex", slice.get("commitIndex"));
-            VPackSlice logs = slice.get("log");
-            builder.add("firstIndex", logs[i].get("index"));
-            builder.add(VPackValue("log"));
-            VPackArrayBuilder a(&builder);
-            for (; i < logs.length(); ++i) {
-              builder.add(logs[i]);
-            }
+          if (res.hasKey("error")) { // leadership loss
+            generateError(
+              rest::ResponseCode::SERVICE_UNAVAILABLE,
+              TRI_ERROR_HTTP_SERVICE_UNAVAILABLE, "No leader");
+            return;
           }
-          generateResult(rest::ResponseCode::OK, std::move(*builder.steal()));
-          return;
+
+          VPackSlice slice = res.get("result");
+
+          if (slice.hasKey("log")) {
+            VPackBuilder builder;
+            {
+              VPackObjectBuilder ob(&builder);
+              builder.add(StaticStrings::Error, VPackValue(false));
+              builder.add("code", VPackValue(int(ResponseCode::OK)));
+              builder.add(VPackValue("result"));
+              VPackObjectBuilder r(&builder);
+              if (!slice.get("firstIndex").isNumber()) {
+                generateError(
+                  rest::ResponseCode::SERVER_ERROR,
+                  TRI_ERROR_HTTP_SERVER_ERROR, "invalid first log index.");
+                return;
+              } else if (slice.get("firstIndex").getNumber<uint64_t>() > start) {
+                generateError(
+                  rest::ResponseCode::SERVER_ERROR,
+                  TRI_ERROR_HTTP_SERVER_ERROR, "first log index is greater than requested.");
+                return;
+              }
+              uint64_t i = start - slice.get("firstIndex").getNumber<uint64_t>();
+              builder.add("commitIndex", slice.get("commitIndex"));
+              VPackSlice logs = slice.get("log");
+              builder.add("firstIndex", logs[i].get("index"));
+              builder.add(VPackValue("log"));
+              VPackArrayBuilder a(&builder);
+              for (; i < logs.length(); ++i) {
+                builder.add(logs[i]);
+              }
+            }
+            generateResult(rest::ResponseCode::OK, std::move(*builder.steal()));
+            return;
+          } else {
+            generateResult(rest::ResponseCode::OK, std::move(*rb->steal()));
+            return;
+          }
         } else {
-          generateResult(rest::ResponseCode::OK, std::move(*rb->steal()));
-          return;
+          generateError(
+            rest::ResponseCode::SERVER_ERROR,
+            TRI_ERROR_HTTP_SERVER_ERROR, "No leader");
         }
-      } else {
+      })
+      .thenError<VPackException>([this](VPackException const& e) {
+        generateError(Result{e.errorCode(), e.what()});
+      })
+      .thenError<std::exception>([this](std::exception const& e) {
         generateError(
-          rest::ResponseCode::SERVER_ERROR,
-          TRI_ERROR_HTTP_SERVER_ERROR, "No leader");
-      }
-    })
-    .thenError<VPackException>([this](VPackException const& e) {
-      generateError(Result{e.errorCode(), e.what()});
-    })
-    .thenError<std::exception>([this](std::exception const& e) {
-      generateError(
-        rest::ResponseCode::SERVER_ERROR, TRI_ERROR_HTTP_SERVER_ERROR, e.what());
-    }));
+          rest::ResponseCode::SERVER_ERROR, TRI_ERROR_HTTP_SERVER_ERROR, e.what());
+      }));
   } else {
     generateError(
       rest::ResponseCode::SERVER_ERROR,

--- a/arangod/Agency/RestAgencyHandler.cpp
+++ b/arangod/Agency/RestAgencyHandler.cpp
@@ -213,8 +213,8 @@ RestStatus RestAgencyHandler::pollIndex(
           }
         } else {
           generateError(
-            rest::ResponseCode::SERVER_ERROR,
-            TRI_ERROR_HTTP_SERVER_ERROR, "No leader");
+            rest::ResponseCode::SERVICE_UNAVAILABLE,
+            TRI_ERROR_HTTP_SERVICE_UNAVAILABLE, "No leader");
         }
       })
       .thenError<VPackException>([this](VPackException const& e) {
@@ -226,8 +226,8 @@ RestStatus RestAgencyHandler::pollIndex(
       }));
   } else {
     generateError(
-      rest::ResponseCode::SERVER_ERROR,
-      TRI_ERROR_HTTP_SERVER_ERROR, "No leader");
+      rest::ResponseCode::SERVICE_UNAVAILABLE,
+      TRI_ERROR_HTTP_SERVICE_UNAVAILABLE, "No leader");
     return RestStatus::DONE;
   }
   

--- a/arangod/Cluster/AgencyCache.cpp
+++ b/arangod/Cluster/AgencyCache.cpp
@@ -37,7 +37,7 @@ AgencyCache::AgencyCache(
   application_features::ApplicationServer& server,
   AgencyCallbackRegistry& callbackRegistry)
   : Thread(server, "AgencyCache"), _commitIndex(0), _readDB(server, nullptr, "readDB"),
-    _initialised(false), _callbackRegistry(callbackRegistry), _lastSnapshot(0) {}
+    _initialized(false), _callbackRegistry(callbackRegistry), _lastSnapshot(0) {}
 
 
 AgencyCache::~AgencyCache() {
@@ -335,7 +335,7 @@ void AgencyCache::run() {
                 index_t firstIndex = rs.get("firstIndex").getNumber<uint64_t>();
 
                 if (firstIndex > 0) {
-                  TRI_ASSERT(_initialised);
+                  TRI_ASSERT(_initialized);
                   // Do incoming logs match our cache's index?
                   if (firstIndex != curIndex + 1) {
                     LOG_TOPIC("a9a09", WARN, Logger::CLUSTER)
@@ -380,7 +380,7 @@ void AgencyCache::run() {
                   LOG_TOPIC("4579f", TRACE, Logger::CLUSTER) <<
                     "Fresh start: overwriting agency cache with " << rs.toJson();
                   _readDB = rs;                  // overwrite
-                  _initialised.store(true, std::memory_order_relaxed);
+                  _initialized.store(true, std::memory_order_relaxed);
                   std::unordered_set<std::string> pc = reInitPlan();
                   for (auto const& i : pc) {
                     _planChanges.emplace(_commitIndex, i);

--- a/arangod/Cluster/AgencyCache.cpp
+++ b/arangod/Cluster/AgencyCache.cpp
@@ -360,7 +360,6 @@ void AgencyCache::run() {
                         _readDB.applyTransaction(i); // apply logs
                         _commitIndex = i.get("index").getNumber<uint64_t>();
 
-                        std::unordered_set<std::string> pc, cc;
                         {
                           std::lock_guard g(_callbacksLock);
                           handleCallbacksNoLock(i.get("query"), uniq, toCall, pc, cc);

--- a/arangod/Cluster/AgencyCache.h
+++ b/arangod/Cluster/AgencyCache.h
@@ -166,6 +166,9 @@ private:
   /// @brief Local copy of the read DB from the agency
   arangodb::consensus::Store _readDB;
 
+  /// @brief Make sure, that we have seen in the beginning a snapshot
+  std::atomic<bool> _initialised;
+
   /// @brief Agency callback registry
   AgencyCallbackRegistry& _callbackRegistry;
 

--- a/arangod/Cluster/AgencyCache.h
+++ b/arangod/Cluster/AgencyCache.h
@@ -167,7 +167,7 @@ private:
   arangodb::consensus::Store _readDB;
 
   /// @brief Make sure, that we have seen in the beginning a snapshot
-  std::atomic<bool> _initialised;
+  std::atomic<bool> _initialized;
 
   /// @brief Agency callback registry
   AgencyCallbackRegistry& _callbackRegistry;

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -637,10 +637,10 @@ ClusterInfo::CollectionWithHash ClusterInfo::buildCollection(
     auto type = data.get(StaticStrings::DataSourceType);
 
     if (type.isInteger() && type.getUInt() == TRI_COL_TYPE_EDGE) {
-      return std::make_shared<VirtualSmartEdgeCollection>(vocbase, data, planVersion); 
-    } 
-    return std::make_shared<SmartVertexCollection>(vocbase, data, planVersion); 
-  } 
+      return std::make_shared<VirtualSmartEdgeCollection>(vocbase, data, planVersion);
+    }
+    return std::make_shared<SmartVertexCollection>(vocbase, data, planVersion);
+  }
 #endif
   return std::make_shared<LogicalCollection>(vocbase, data, true, planVersion);
 }
@@ -4902,9 +4902,11 @@ void ClusterInfo::invalidateCurrentMappings() {
 
 std::unordered_map<std::string,std::shared_ptr<VPackBuilder>>
 ClusterInfo::getPlan(uint64_t& index, std::unordered_set<std::string> const& dirty) {
-  if (!_planProt.isValid) {
-    loadPlan();
-  }
+
+  // We should never proceed here, until we have seen an
+  // initial agency cache through loadPlan
+  waitForPlan(1);
+
   std::unordered_map<std::string,std::shared_ptr<VPackBuilder>> ret;
   READ_LOCKER(readLocker, _planProt.lock);
   index = _planIndex;
@@ -4924,9 +4926,11 @@ ClusterInfo::getPlan(uint64_t& index, std::unordered_set<std::string> const& dir
 
 std::unordered_map<std::string,std::shared_ptr<VPackBuilder>>
 ClusterInfo::getCurrent(uint64_t& index, std::unordered_set<std::string> const& dirty) {
-  if (!_currentProt.isValid) {
-    loadCurrent();
-  }
+
+  // We should never proceed here, until we have seen an
+  // initial agency cache through loadCurrent
+  waitForCurrent(1);
+
   std::unordered_map<std::string,std::shared_ptr<VPackBuilder>> ret;
   READ_LOCKER(readLocker, _currentProt.lock);
   index = _currentIndex;

--- a/arangod/Cluster/DBServerAgencySync.cpp
+++ b/arangod/Cluster/DBServerAgencySync.cpp
@@ -203,12 +203,6 @@ DBServerAgencySyncResult DBServerAgencySync::execute() {
     return result;
   }
 
-  // TODO: figure out if waiting here for the initial plan to arrive
-  // is required and sensible. also check if we need to wait here until
-  // the DatabaseFeature has reported ready or it is good enough as it
-  // is now.
-  // clusterInfo.waitForPlan(1);
-
   AgencyCache::databases_t plan = clusterInfo.getPlan(planIndex, dirty);
   if (!dirty.empty() && plan.empty()) {
     // TODO increase log level, except during shutdown?

--- a/arangod/Cluster/DBServerAgencySync.cpp
+++ b/arangod/Cluster/DBServerAgencySync.cpp
@@ -203,6 +203,12 @@ DBServerAgencySyncResult DBServerAgencySync::execute() {
     return result;
   }
 
+  // TODO: figure out if waiting here for the initial plan to arrive
+  // is required and sensible. also check if we need to wait here until
+  // the DatabaseFeature has reported ready or it is good enough as it
+  // is now.
+  // clusterInfo.waitForPlan(1);
+
   AgencyCache::databases_t plan = clusterInfo.getPlan(planIndex, dirty);
   if (!dirty.empty() && plan.empty()) {
     // TODO increase log level, except during shutdown?

--- a/arangod/Cluster/DBServerAgencySync.cpp
+++ b/arangod/Cluster/DBServerAgencySync.cpp
@@ -194,7 +194,6 @@ DBServerAgencySyncResult DBServerAgencySync::execute() {
     }
   }
 
-
   if (dirty.empty()) {
     LOG_TOPIC("0a62f", DEBUG, Logger::MAINTENANCE)
       << "DBServerAgencySync::execute no dirty collections";

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -398,9 +398,16 @@ DBServerAgencySync& HeartbeatThread::agencySync() { return _agencySync; }
 
 void HeartbeatThread::runDBServer() {
 
-    using namespace std::chrono_literals;
+  using namespace std::chrono_literals;
 
   _maintenanceThread = std::make_unique<HeartbeatBackgroundJobThread>(_server, this);
+
+  while (!isStopping() && !server().getFeature<DatabaseFeature>().started()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    LOG_TOPIC("eec21", DEBUG, Logger::HEARTBEAT)
+        << "Waiting for database feature to finish start up";
+  }
+
   if (!_maintenanceThread->start()) {
     // WHAT TO DO NOW?
     LOG_TOPIC("12cee", ERR, Logger::HEARTBEAT)

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -255,7 +255,8 @@ DatabaseFeature::DatabaseFeature(application_features::ApplicationServer& server
       _isInitiallyEmpty(false),
       _checkVersion(false),
       _upgrade(false),
-      _useOldSystemCollections(true) {
+      _useOldSystemCollections(true),
+      _started(false) {
   setOptional(false);
   startsAfter<BasicFeaturePhaseServer>();
 
@@ -391,6 +392,8 @@ void DatabaseFeature::start() {
 
   // update all v8 contexts
   updateContexts();
+
+  _started.store(true);
 }
 
 // signal to all databases that active cursors can be wiped
@@ -582,6 +585,10 @@ Result DatabaseFeature::registerPostRecoveryCallback(std::function<Result()>&& c
   _pendingRecoveryCallbacks.emplace_back(std::move(callback));
 
   return Result();
+}
+
+bool DatabaseFeature::started() const noexcept {
+  return _started.load(std::memory_order_relaxed);
 }
   
 void DatabaseFeature::enumerate(std::function<void(TRI_vocbase_t*)> const& callback) {

--- a/arangod/RestServer/DatabaseFeature.h
+++ b/arangod/RestServer/DatabaseFeature.h
@@ -93,6 +93,11 @@ class DatabaseFeature : public application_features::ApplicationFeature {
   /// the replication appliers) for all databases
   void recoveryDone();
 
+  /// @brief whether or not the DatabaseFeature has started (and thus has
+  /// completely populated its lists of databases and collections from 
+  /// persistent storage)
+  bool started() const noexcept;
+
   /// @brief enumerate all databases
   void enumerate(std::function<void(TRI_vocbase_t*)> const& callback);
 
@@ -195,6 +200,8 @@ class DatabaseFeature : public application_features::ApplicationFeature {
   bool _checkVersion;
   bool _upgrade;
   bool _useOldSystemCollections;
+  
+  std::atomic<bool> _started;
 
   /// @brief lock for serializing the creation of databases
   arangodb::Mutex _databaseCreateLock;


### PR DESCRIPTION
### Scope & Purpose

Fix the initial population of the AgencyCache after a server restart.
The previous version used to poll from the agency with a commit index value of `1`, whereas I think it should be `0` for the initial call to get a full snapshot from the agency.

This PR also contains a code comment in DBServerAgencySync.cpp that we need to sort out. @kvahed suggested to wait here until we have got initial data from the agency, but I can't tell if it is necessary and what would be the side effects (blocking?). 
The changes in this PR seem to fix the issues found by mini chaos (:tm:), even without the change in DBServerAgencySync.cpp, but this may be coincidence.

This does not need a port for 3.5 or 3.6, as these versions do not have the AgencyCache machinery. 

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *cluster tests*.
- [x] There are tests in an external testing repository: mini chaos

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12893/