### PR TITLE
turn off old system collections

### DIFF
--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -281,7 +281,7 @@ DatabaseFeature::DatabaseFeature(application_features::ApplicationServer& server
       _isInitiallyEmpty(false),
       _checkVersion(false),
       _upgrade(false),
-      _useOldSystemCollections(true) {
+      _useOldSystemCollections(false) {
   setOptional(false);
   startsAfter<BasicFeaturePhaseServer>();
 


### PR DESCRIPTION
### Scope & Purpose

Turn off old system collections, as already announced in CHANGELOG and release notes.
For some reason the config variable had a wrong value in devel, potentially this happened when porting the changes across different versions.

3.7 and 3.6 also introduced the config option to control the creation and usage of old system collections, but there the default value of `true` is correct. Only in devel we want to change it to `false`.

The CHANGELOG entry for this already existed in devel, however, the change was not carried out here as announced.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is already covered by existing tests, such as *JavaScript tests*.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12895/