### PR TITLE
Reimplement coordshort request handler.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 devel
 -----
+* Reimplement coordshort request handler. The new implementation only runs
+  two DB queries without any additional requests to other coordinators,
+  resulting in reduced load on the cluster. Previously this involved
+  requests to all coordinators, where each of them ran two DB queries.
 
 * Increase background garbage-collection interval for cluster transactions
   from 1 second to 2 seconds. This change should reduce the amount of

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/clusterView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/clusterView.js
@@ -315,7 +315,7 @@
           self.chartsOptions[1].options[0].values.push({x: time, y: self.calcTotalHttp(data.http, key)});
 
           // AVERAGE
-          self.chartsOptions[2].options[0].values.push({x: time, y: data.avgRequestTime[key] / self.coordinators.length});
+          self.chartsOptions[2].options[0].values.push({x: time, y: data.avgRequestTime[key]});
         });
         self.historyInit = true;
       } else {
@@ -338,7 +338,7 @@
         // AVERAGE
         self.chartsOptions[2].options[0].values.push({
           x: data.times[data.times.length - 1],
-          y: data.avgRequestTime[data.bytesSentPerSecond.length - 1] / self.coordinators.length
+          y: data.avgRequestTime[data.bytesSentPerSecond.length - 1]
         });
       }
     },

--- a/js/apps/system/_admin/aardvark/APP/statistics.js
+++ b/js/apps/system/_admin/aardvark/APP/statistics.js
@@ -416,7 +416,6 @@ router.get('/coordshort', function (req, res) {
         FILTER s.time > @start
         FILTER s.clusterId IN @clusterIds
         SORT s.time
-        LET clientConnectionsCurrent = s.client.httpConnections
         COLLECT clusterId = s.clusterId INTO clientConnections = s.client.httpConnections
         LET clientConnectionsCurrent = LAST(clientConnections)
         COLLECT AGGREGATE clientConnections15M = SUM(clientConnectionsCurrent)

--- a/js/apps/system/_admin/aardvark/APP/statistics.js
+++ b/js/apps/system/_admin/aardvark/APP/statistics.js
@@ -38,6 +38,7 @@ const STATISTICS_HISTORY_INTERVAL = 15 * 60; // seconds
 const joi = require('joi');
 const httperr = require('http-errors');
 const createRouter = require('@arangodb/foxx/router');
+const { MergeStatisticSamples } = require('../../../../../server/modules/@arangodb/statistics-helper');
 
 const router = createRouter();
 module.exports = router;
@@ -406,152 +407,57 @@ router.use((req, res, next) => {
 });
 
 router.get('/coordshort', function (req, res) {
-  var merged = {
-    http: {}
-  };
+  var merged = { };
 
-  var mergeHistory = function (data) {
-    var onetime = ['times'];
-    var values = [
-      'physicalMemory',
-      'residentSizeCurrent',
-      'clientConnections15M',
-      'clientConnectionsCurrent'
-    ];
-    var http = [
-      'optionsPerSecond',
-      'putsPerSecond',
-      'headsPerSecond',
-      'postsPerSecond',
-      'getsPerSecond',
-      'deletesPerSecond',
-      'othersPerSecond',
-      'patchesPerSecond'
-    ];
-    var arrays = [
-      'bytesSentPerSecond',
-      'bytesReceivedPerSecond',
-      'avgRequestTime'
-    ];
+  const coordinators = global.ArangoClusterInfo.getCoordinators();
+  try {
+    const stats15Query = `
+      FOR s IN _statistics15
+        FILTER s.time > @start
+        FILTER s.clusterId IN @clusterIds
+        SORT s.time
+        LET clientConnectionsCurrent = s.client.httpConnections
+        LET time = s.time
+        COLLECT clusterId = s.clusterId INTO server KEEP clientConnectionsCurrent, time
+        LET clientConnectionsCurrent = LAST(server).clientConnectionsCurrent
+        COLLECT AGGREGATE clientConnections15M = SUM(clientConnectionsCurrent)
+        RETURN {clientConnections15M: clientConnections15M || 0}`;
 
-    var counter = 0;
-    var counter2;
-
-    _.each(data, function (stat) {
-      if (typeof stat === 'object' && Object.keys(stat).length !== 0) {
-        if (counter === 0) {
-          // one time value
-          _.each(onetime, function (value) {
-            merged[value] = stat[value];
-          });
-
-          // values
-          _.each(values, function (value) {
-            merged[value] = stat[value];
-          });
-
-          // http requests arrays
-          _.each(http, function (value) {
-            merged.http[value] = stat[value];
-          });
-
-          // arrays
-          _.each(arrays, function (value) {
-            merged[value] = stat[value];
-          });
-        } else {
-          // values
-          _.each(values, function (value) {
-            merged[value] = merged[value] + stat[value];
-          });
-          // http requests arrays
-          _.each(http, function (value) {
-            counter2 = 0;
-            _.each(stat[value], function (x) {
-              try {
-                if (merged.http[value][counter2] === undefined) {
-                  // this will hit if a previous coordinator was not able to deliver
-                  // proper current statistics, but the current one already has statistics.
-                  merged.http[value][counter2] = x;
-                } else {
-                  merged.http[value][counter2] += x;
-                }
-              } catch (err) {}
-              counter2++;
-            });
-          });
-          _.each(arrays, function (value) {
-            counter2 = 0;
-            _.each(stat[value], function (x) {
-              try {
-                if (merged[value][counter2] === undefined) {
-                  merged[value][counter2] = 0;
-                } else {
-                  merged[value][counter2] += x;
-                }
-              } catch (err) {}
-              counter2++;
-            });
-          });
-        }
-        counter++;
-      }
-    });
-  };
-
-  var coordinators = global.ArangoClusterInfo.getCoordinators();
-  var coordinatorStats;
-  if (Array.isArray(coordinators)) {
-    coordinatorStats = coordinators.map(coordinator => {
-      const op = ArangoClusterComm.asyncRequest(
-        "GET",
-        "server:" + coordinator,
-        "_system",
-        '/_admin/aardvark/statistics/short',
-        "",
-        {},
-        { timeout: 10 }
-      );
-
-      const r = ArangoClusterComm.wait(op);
-
-      if (r.status === "RECEIVED") {
-        res.set("content-type", "application/json; charset=utf-8");
-        return JSON.parse(r.body);
-      } 
-      if (r.status === "TIMEOUT") {
-        throw new httperr.BadRequest("operation timed out");
-      } 
-      let body;
-      try {
-        body = JSON.parse(r.body);
-      } catch (e) {
-        // noop
-      }
-
-      return {};
-
-      /* don't throw here, as this will render the entire web UI cluster stats broken */
-      /*
-      throw Object.assign(
-        new httperr.BadRequest("error from Coordinator '" + coordinator + "', possibly Coordinator unknown or down"),
-        {extra: {body}}
-      );
-      */
-    });
-
-    if (coordinatorStats) {
-      mergeHistory(coordinatorStats);
+    const statsSampleQuery = `
+      FOR s IN _statistics
+        FILTER s.time > @start
+        FILTER s.clusterId IN @clusterIds
+        RETURN {
+          time: s.time,
+          clusterId: s.clusterId,
+          avgRequestTime: s.client.avgRequestTime,
+          bytesSentPerSecond: s.client.bytesSentPerSecond,
+          bytesReceivedPerSecond: s.client.bytesReceivedPerSecond,
+          http: {
+            optionsPerSecond: s.http.requestsOptionsPerSecond,
+            putsPerSecond: s.http.requestsPutPerSecond,
+            headsPerSecond: s.http.requestsHeadPerSecond,
+            postsPerSecond: s.http.requestsPostPerSecond,
+            getsPerSecond: s.http.requestsGetPerSecond,
+            deletesPerSecond: s.http.requestsDeletePerSecond,
+            othersPerSecond: s.http.requestsOptionsPerSecond,
+            patchesPerSecond: s.http.requestsPatchPerSecond
+          }
+      }`;
+    
+    const params = { start: startOffsetSchema - 2 * STATISTICS_INTERVAL, clusterIds: coordinators };
+    const stats15 = db._query(stats15Query, params).toArray();
+    const statsSamples = db._query(statsSampleQuery, params).toArray();
+    if (statsSamples.length !== 0) {
+      // we have no samples -> either statistics are disabled, or the server has just been started
+      merged = MergeStatisticSamples(statsSamples);
+      merged.clientConnections15M = stats15.length === 0 ? 0 : stats15[0].clientConnections15M;
     }
+  } catch (e) {
+    // ignore exceptions, because throwing here will render the entire web UI cluster stats broken
   }
-  if (coordinatorStats) {
-    res.json({'enabled': coordinatorStats.some(stat => stat.enabled), 'data': merged});
-  } else {
-    res.json({
-      'enabled': false,
-      'data': {}
-    });
-  }
+
+  res.json({'enabled': Object.keys(merged).length !== 0 , 'data': merged});
 })
   .summary('Short term history for all coordinators')
   .description('This function is used to get the statistics history.');

--- a/js/server/modules/@arangodb/statistics-helper.js
+++ b/js/server/modules/@arangodb/statistics-helper.js
@@ -1,0 +1,96 @@
+'use strict';
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief Statistics Helper
+// /
+// / @file
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2020 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+// / @author Manuel Pöter
+// / @author Copyright 2020, ArangoDB GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+const _ = require('lodash');
+
+function MergeStatisticSamples(samples) {
+  const merged = {
+    physicalMemory: 0,
+    residentSizeCurrent: 0,
+    clientConnectionsCurrent: 0
+  };
+
+  const clusterIds = _.uniq(_.map(samples, s => s.clusterId));
+  _.each(clusterIds, clusterId => {
+    const sample = _.maxBy(_.filter(samples, s => s.clusterId === clusterId), s => s.time);
+    merged.physicalMemory += sample.physicalMemory;
+    merged.residentSizeCurrent += sample.residentSizeCurrent;
+    merged.clientConnectionsCurrent += sample.clientConnectionsCurrent;
+  });
+
+  const paths = [
+    "avgRequestTime",
+    "bytesSentPerSecond",
+    "bytesReceivedPerSecond",
+    "http.optionsPerSecond",
+    "http.putsPerSecond",
+    "http.headsPerSecond",
+    "http.postsPerSecond",
+    "http.getsPerSecond",
+    "http.deletesPerSecond",
+    "http.othersPerSecond",
+    "http.patchesPerSecond"
+  ];
+
+  const sampleTimes = _.map(samples, (s) => s.time);
+  const empty = samples.length === 0;
+  const minTime = empty ? 0 : Math.floor(_.min(sampleTimes));
+  const maxTime = empty ? 0 : Math.ceil(_.max(sampleTimes));
+  // the statisics samples are stored every 10 seconds, so our bucketSize should be a multiple of 10
+  const bucketSize = 10;
+  const numBuckets = Math.ceil((maxTime - minTime) / bucketSize);
+  
+  const calcBucket = (time) => Math.floor((time - minTime) / bucketSize);
+  merged.times = _.range(minTime, minTime + numBuckets * bucketSize, bucketSize);
+
+  _.each(paths, (path) => {
+    const values = Array(numBuckets).fill(0);
+    _.set(merged, path, values);
+  });
+
+  const counts = Array(numBuckets).fill(0);
+  _.each(samples, (sample) => {
+    const bucket = calcBucket(sample.time);
+    ++counts[bucket];
+    _.each(paths, (path) => {
+      const values = _.get(merged, path);
+      values[bucket] += _.get(sample, path);
+    });
+  });
+  
+  for (let i = 0; i < counts.length; ++i) {
+    if (counts[i] !== 0) {
+      merged.avgRequestTime[i] /= counts[i];
+    }
+  }
+
+  return merged;
+}
+
+exports.MergeStatisticSamples = MergeStatisticSamples;

--- a/tests/js/server/shell/shell-statistics-helper.js
+++ b/tests/js/server/shell/shell-statistics-helper.js
@@ -1,0 +1,182 @@
+/*jshint globalstrict:false, strict:false, maxlen: 5000 */
+/*global fail, assertTrue, assertFalse, assertEqual, assertNotEqual, assertTypeOf */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test statistics helper interface
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Manuel Pöter
+/// @author Copyright 2020, ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+
+let jsunity = require("jsunity");
+let helper = require("@arangodb/statistics-helper");
+
+function StatisticsHelpers () {
+  return {
+    testMergeStatisticsSamples : function () {
+      const samples = [{
+        time: 0.09,
+        clusterId: "c1",
+        physicalMemory: 1,
+        residentSizeCurrent: 1,
+        clientConnectionsCurrent: 1,
+        avgRequestTime: 1,
+        bytesSentPerSecond: 1,
+        bytesReceivedPerSecond: 1,
+        http: {
+          optionsPerSecond: 1,
+          putsPerSecond: 1,
+          headsPerSecond: 1,
+          postsPerSecond: 1,
+          getsPerSecond: 1,
+          deletesPerSecond: 1,
+          othersPerSecond: 1,
+          patchesPerSecond: 1
+        }
+      }, {
+        time: 10.2,
+        clusterId: "c1",
+        physicalMemory: 1,
+        residentSizeCurrent: 1,
+        clientConnectionsCurrent: 10,
+        avgRequestTime: 2,
+        bytesSentPerSecond: 1,
+        bytesReceivedPerSecond: 1,
+        http: {
+          optionsPerSecond: 1,
+          putsPerSecond: 1,
+          headsPerSecond: 1,
+          postsPerSecond: 1,
+          getsPerSecond: 1,
+          deletesPerSecond: 1,
+          othersPerSecond: 1,
+          patchesPerSecond: 1
+        }
+      }, {
+        time: 29.9,
+        clusterId: "c1",
+        physicalMemory: 1,
+        residentSizeCurrent: 2,
+        clientConnectionsCurrent: 7,
+        avgRequestTime: 2,
+        bytesSentPerSecond: 1,
+        bytesReceivedPerSecond: 1,
+        http: {
+          optionsPerSecond: 1,
+          putsPerSecond: 1,
+          headsPerSecond: 1,
+          postsPerSecond: 1,
+          getsPerSecond: 1,
+          deletesPerSecond: 1,
+          othersPerSecond: 1,
+          patchesPerSecond: 1
+        }
+      }, {
+        time: 9.9,
+        clusterId: "c2",
+        physicalMemory: 1,
+        residentSizeCurrent: 1,
+        clientConnectionsCurrent: 1,
+        avgRequestTime: 2,
+        bytesSentPerSecond: 1,
+        bytesReceivedPerSecond: 1,
+        http: {
+          optionsPerSecond: 1,
+          putsPerSecond: 1,
+          headsPerSecond: 1,
+          postsPerSecond: 1,
+          getsPerSecond: 1,
+          deletesPerSecond: 1,
+          othersPerSecond: 1,
+          patchesPerSecond: 1
+        }
+      }, {
+        time: 19.7,
+        clusterId: "c2",
+        physicalMemory: 1,
+        residentSizeCurrent: 3,
+        clientConnectionsCurrent: 0,
+        avgRequestTime: 1,
+        bytesSentPerSecond: 1,
+        bytesReceivedPerSecond: 1,
+        http: {
+          optionsPerSecond: 1,
+          putsPerSecond: 1,
+          headsPerSecond: 1,
+          postsPerSecond: 1,
+          getsPerSecond: 1,
+          deletesPerSecond: 1,
+          othersPerSecond: 1,
+          patchesPerSecond: 1
+        }
+      }, {
+        time: 15.0,
+        clusterId: "c3",
+        physicalMemory: 2,
+        residentSizeCurrent: 2,
+        clientConnectionsCurrent: 2,
+        avgRequestTime: 3,
+        bytesSentPerSecond: 1,
+        bytesReceivedPerSecond: 2,
+        http: {
+          optionsPerSecond: 2,
+          putsPerSecond: 2,
+          headsPerSecond: 2,
+          postsPerSecond: 2,
+          getsPerSecond: 2,
+          deletesPerSecond: 2,
+          othersPerSecond: 5,
+          patchesPerSecond: 0
+        }
+      }];
+      const merged = helper.MergeStatisticSamples(samples);
+
+      const expected = {
+        physicalMemory: 4,
+        residentSizeCurrent: 7,
+        clientConnectionsCurrent: 9,
+        times: [0, 10, 20],
+        avgRequestTime: [1.5, 2, 2],
+        bytesSentPerSecond: [2, 3, 1],
+        bytesReceivedPerSecond: [2, 4, 1],
+        http: {
+          optionsPerSecond: [2, 4, 1],
+          putsPerSecond: [2, 4, 1],
+          headsPerSecond: [2, 4, 1],
+          postsPerSecond: [2, 4, 1],
+          getsPerSecond: [2, 4, 1],
+          deletesPerSecond: [2, 4, 1],
+          othersPerSecond: [2, 7, 1],
+          patchesPerSecond: [2, 2, 1],
+        }
+      };
+      assertEqual(expected, merged);
+    }
+  };
+}
+
+jsunity.run(StatisticsHelpers);
+
+return jsunity.done();


### PR DESCRIPTION
The old implementation sent `statistcs/short` requests to all coordinators (including itself). The `statistics/short` handler is also implemented in JS and runs two DB queries. So for a cluster with 3 coordinators, the old implementation issued 3 network requests, which triggered a total of 6 DB queries and required 4 V8 contexts (one for the initial coordshort request, and one for each statistic/short request).

The new implementation only runs two DB queries without any additional requests to other coordinators, resulting in reduced load on the cluster.

In addition this reimplementation fixes the way statistics samples of coordinators are merged. Previously we simply took the timestamps from the samples of one coordinator and simply merged all samples based on their index. However, coordinators don't necessarily write their statistics sample at the same time, and it is also not guaranteed that all coordinators have the same number of samples.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers - **mandatory**)*

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.6, 3.7

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [x] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [x] Added new **integration tests** in shell_server
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12917/
