### PR TITLE
fix status reporting of skipped endpoint tests

### DIFF
--- a/js/client/modules/@arangodb/testsuites/endpoints.js
+++ b/js/client/modules/@arangodb/testsuites/endpoints.js
@@ -211,12 +211,22 @@ function endpoints (options) {
   return Object.keys(endpoints).reduce((results, endpointName) => {
     let testName = 'endpoint-' + endpointName;
     let testCase = endpoints[endpointName];
-    if (options.cluster || options.skipEndpoints || (testCase.skip && testCase.skip())) {
+
+    if (options.cluster || options.skipEndpoints) {
       return {
         failed: 0,
         status: true,
         skipped: true
       };
+    }
+    if (testCase.skip()) {
+      results[endpointName + '-' + 'all'] = {
+        failed: 0,
+        skipped: true,
+        status: true,
+        message: 'test skipped'
+      };
+      return results;
     }
 
     let serverArgs = testCase.serverArgs();
@@ -228,11 +238,13 @@ function endpoints (options) {
 
     if (instanceInfo === false) {
       results.failed += 1;
-      return {
+
+      results[endpointName + '-' + 'all'] = {
         failed: 1,
         status: false,
         message: 'failed to start server!'
       };
+      return results;
     }
 
     const specFile = testPaths.endpoints[0];


### PR DESCRIPTION
### Scope & Purpose

On Windows the endpoints-test will allways report an empty list due to the `skip` callback for the unix domain sockets.
This is wrong and fixed hereby. 

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.7

### Testing & Verification

this is a fix to tests.

