### PR TITLE
turn off StatisticsWorker thread on DB servers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,12 @@
 devel
 -----
+
+* Turn off `StatisticsWorker` thread on DB servers. 
+  This thread was previously only running queries on the local RocksDB 
+  instance, but using the cluster-wide collection names. So effectively it 
+  did nothing except use a bit of background CPU. In this case it is better 
+  to turn off the background thread entirely on the DB servers.
+
 * Reimplement coordshort request handler. The new implementation only runs
   two DB queries without any additional requests to other coordinators,
   resulting in reduced load on the cluster. Previously this involved

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -388,7 +388,15 @@ void StatisticsFeature::start() {
     _statisticsHistory = false;
   } 
 
+  if (ServerState::instance()->isDBServer()) {
+    // the StatisticsWorker runs queries against the _statistics
+    // collections, so it does not work on DB servers
+    _statisticsHistory = false;
+  }
+
   if (_statisticsHistory) {
+    TRI_ASSERT(!ServerState::instance()->isDBServer());
+
     _statisticsWorker.reset(new StatisticsWorker(*vocbase));
 
     if (!_statisticsWorker->start()) {

--- a/arangod/Statistics/StatisticsWorker.h
+++ b/arangod/Statistics/StatisticsWorker.h
@@ -42,7 +42,6 @@ class StatisticsWorker final : public Thread {
 
   void run() override;
   void beginShutdown() override;
-  void generateRawStatistics(std::string& result, double const& now);
 
  private:
   // removes old statistics


### PR DESCRIPTION
### Scope & Purpose

The `StatisticsWorker` thread was previously only running queries on the local RocksDB instance, but using the cluster-wide collection names. So effectively it did nothing except use a bit of background CPU. In this case it is better to turn off the background thread entirely on the DB servers.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12948/