### PR TITLE
Fix issue with ApplicationFeature registration and startup order

### DIFF
--- a/lib/ApplicationFeatures/ApplicationFeature.cpp
+++ b/lib/ApplicationFeatures/ApplicationFeature.cpp
@@ -42,6 +42,7 @@ namespace application_features {
 
 ApplicationFeature::ApplicationFeature(ApplicationServer& server, std::string const& name)
     : _server(server),
+      _registration(std::type_index(typeid(ApplicationFeature))),
       _name(name),
       _state(State::UNINITIALIZED),
       _enabled(true),
@@ -110,7 +111,7 @@ bool ApplicationFeature::doesStartBefore(std::type_index type) const {
   }
 
   auto otherAncestors = _server.getFeature<ApplicationFeature>(type).ancestors();
-  if (otherAncestors.find(std::type_index(typeid(*this))) != otherAncestors.end()) {
+  if (otherAncestors.find(_registration) != otherAncestors.end()) {
     // we are an ancestor of the other feature
     return true;
   }
@@ -131,7 +132,7 @@ void ApplicationFeature::addAncestorToAllInPath(
   std::function<bool(std::pair<size_t, std::reference_wrapper<ApplicationFeature>>&)> typeMatch =
       [ancestorType](std::pair<size_t, std::reference_wrapper<ApplicationFeature>>& pair) -> bool {
     auto& feature = pair.second.get();
-    return std::type_index(typeid(feature)) == ancestorType;
+    return feature.registration() == ancestorType;
   };
 
   if (std::find_if(path.begin(), path.end(), typeMatch) != path.end()) {
@@ -141,7 +142,7 @@ void ApplicationFeature::addAncestorToAllInPath(
     std::vector<std::type_index> pathTypes;
     for (std::pair<size_t, std::reference_wrapper<ApplicationFeature>>& pair : path) {
       auto& feature = pair.second.get();
-      pathTypes.emplace_back(std::type_index(typeid(feature)));
+      pathTypes.emplace_back(feature.registration());
     }
     pathTypes.emplace_back(ancestorType);  // make sure we show the duplicate
 
@@ -204,6 +205,14 @@ void ApplicationFeature::determineAncestors(std::type_index rootAsType) {
   }
 
   TRI_ASSERT(_ancestorsDetermined);
+}
+
+std::type_index ApplicationFeature::registration() const {
+  return _registration;
+}
+
+void ApplicationFeature::setRegistration(std::type_index registration) {
+  _registration = registration;
 }
 
 }  // namespace application_features

--- a/lib/ApplicationFeatures/ApplicationFeature.h
+++ b/lib/ApplicationFeatures/ApplicationFeature.h
@@ -168,6 +168,9 @@ class ApplicationFeature {
     return _startsBefore;
   }
 
+  std::type_index registration() const;
+  void setRegistration(std::type_index registration);
+
  protected:
   void setOptional() { setOptional(true); }
 
@@ -224,6 +227,9 @@ class ApplicationFeature {
 
   // pointer to application server
   ApplicationServer& _server;
+
+  // type registration for lookup within the ApplicationServer
+  std::type_index _registration;
 
   // name of feature
   std::string const _name;

--- a/lib/ApplicationFeatures/ApplicationServer.cpp
+++ b/lib/ApplicationFeatures/ApplicationServer.cpp
@@ -420,7 +420,7 @@ void ApplicationServer::setupDependencies(bool failOnMissing) {
         }
         continue;
       }
-      getFeature<ApplicationFeature>(other).startsAfter(std::type_index(typeid(feature)));
+      getFeature<ApplicationFeature>(other).startsAfter(feature.registration());
     }
   }
 
@@ -452,15 +452,15 @@ void ApplicationServer::setupDependencies(bool failOnMissing) {
   // first insert all features, even the inactive ones
   std::vector<std::reference_wrapper<ApplicationFeature>> features;
   for (auto& it : _features) {
-    auto const& us = *it.second;
+    auto& us = *it.second;
     auto insertPosition = features.end();
 
     for (size_t i = features.size(); i > 0; --i) {
       auto const& other = features[i - 1].get();
-      if (us.doesStartBefore(std::type_index(typeid(other)))) {
+      if (us.doesStartBefore(other.registration())) {
         // we start before the other feature. so move ourselves up
         insertPosition = features.begin() + (i - 1);
-      } else if (other.doesStartBefore(std::type_index(typeid(us)))) {
+      } else if (other.doesStartBefore(us.registration())) {
         // the other feature starts before us. so stop moving up
         break;
       } else {
@@ -470,7 +470,7 @@ void ApplicationServer::setupDependencies(bool failOnMissing) {
         }
       }
     }
-    features.insert(insertPosition, *it.second);
+    features.insert(insertPosition, us);
   }
 
   LOG_TOPIC("0fafb", TRACE, Logger::STARTUP) << "ordered features:";

--- a/lib/ApplicationFeatures/ApplicationServer.h
+++ b/lib/ApplicationFeatures/ApplicationServer.h
@@ -231,6 +231,7 @@ class ApplicationServer {
          _features.try_emplace(std::type_index(typeid(As)),
                            std::make_unique<Type>(*this, std::forward<Args>(args)...));
      TRI_ASSERT(result.second);
+     result.first->second->setRegistration(std::type_index(typeid(As)));
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
      auto obj = dynamic_cast<As*>(result.first->second.get());
      TRI_ASSERT(obj != nullptr);


### PR DESCRIPTION
### Scope & Purpose

This fixes a bug in the `ApplicationServer`/`ApplicationFeature` framework. Specifically in the case that a derived feature registers as it's base type, the methods which determine feature order may not correctly respect dependencies. This hasn't had any concrete effect yet, as the dependencies which were broken in 3.7 and devel did not have any adverse effects. Thus, omitting a CHANGELOG entry, since it has no practical effect yet.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [s] Backports required for: 3.7

### Testing & Verification

Link to Jenkins PR run: https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/12949/