### PR TITLE
avoid usage of std::regex for constructing date/time values for log messages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 devel
 -----
+
+* Avoid the usage of std::regex when construction date/time string values 
+  for log messages. This is a performance optimization only.
+
 * Reimplement coordshort request handler. The new implementation only runs
   two DB queries without any additional requests to other coordinators,
   resulting in reduced load on the cluster. Previously this involved

--- a/lib/Logger/LogTimeFormat.cpp
+++ b/lib/Logger/LogTimeFormat.cpp
@@ -53,9 +53,12 @@ void appendNumber(uint64_t value, std::string& out, size_t size) {
   char buffer[22];
   size_t len = arangodb::basics::StringUtils::itoa(value, &buffer[0]);
   while (len < size) {
+    // zero-padding at the beginning of the output buffer, because
+    // we haven't yet written our number into it
     out.push_back('0');
     --size;
   }
+  // now, after zero-padding, write our number into the output
   out.append(&buffer[0], len);
 }
 
@@ -104,49 +107,74 @@ TimeFormat formatFromName(std::string const& name) {
   return (*it).second;
 }
   
-void writeTime(std::string& out, TimeFormat format) {
-  std::chrono::system_clock::time_point tp = std::chrono::system_clock::now();
+void writeTime(std::string& out, 
+               TimeFormat format, 
+               std::chrono::system_clock::time_point tp,
+               std::chrono::system_clock::time_point startTp) {
+  using namespace date;
+  using namespace std::chrono;
 
-  if (format == TimeFormat::Uptime) {
+  if (format == TimeFormat::Uptime ||
+      format == TimeFormat::UptimeMillis ||
+      format == TimeFormat::UptimeMicros) {
+    if (startTp == system_clock::time_point()) {
+      // if startTp is not set by caller, we will use the recorded start time.
+      // this way it can be overriden easily from tests
+      startTp = ::startTime;
+    }
     // integral uptime value
-    arangodb::basics::StringUtils::itoa(uint64_t(std::chrono::duration_cast<std::chrono::seconds>(tp - ::startTime).count()), out);
-  } else if (format == TimeFormat::UptimeMillis) {
-    // uptime with millisecond precision
-    std::chrono::system_clock::time_point tp2(std::chrono::duration_cast<std::chrono::seconds>(tp - ::startTime));
-    std::chrono::system_clock::time_point tp3(std::chrono::duration_cast<std::chrono::milliseconds>(tp - ::startTime));
-    arangodb::basics::StringUtils::itoa(uint64_t(std::chrono::duration_cast<std::chrono::seconds>(tp2.time_since_epoch()).count()), out);
-    out.push_back('.');
-    appendNumber(uint64_t(std::chrono::duration_cast<std::chrono::milliseconds>(tp3 - tp2).count()), out, 3);
-  } else if (format == TimeFormat::UptimeMicros) {
-    // uptime with microsecond precision
-    std::chrono::system_clock::time_point tp2(std::chrono::duration_cast<std::chrono::seconds>(tp - ::startTime));
-    std::chrono::system_clock::time_point tp3(std::chrono::duration_cast<std::chrono::microseconds>(tp - ::startTime));
-    arangodb::basics::StringUtils::itoa(uint64_t(std::chrono::duration_cast<std::chrono::seconds>(tp2.time_since_epoch()).count()), out);
-    out.push_back('.');
-    appendNumber(uint64_t(std::chrono::duration_cast<std::chrono::microseconds>(tp3 - tp2).count()), out, 6);
+    arangodb::basics::StringUtils::itoa(uint64_t(duration_cast<seconds>(tp - startTp).count()), out);
+    if (format == TimeFormat::UptimeMillis) {
+      // uptime with millisecond precision
+      out.push_back('.');
+      appendNumber(uint64_t(duration_cast<milliseconds>(tp - startTp).count() % 1000), out, 3);
+    } else if (format == TimeFormat::UptimeMicros) {
+      // uptime with microsecond precision
+      out.push_back('.');
+      appendNumber(uint64_t(duration_cast<microseconds>(tp - startTp).count() % 1000000), out, 6);
+    }
   } else if (format == TimeFormat::UnixTimestamp) {
     // integral unix timestamp
-    arangodb::basics::StringUtils::itoa(uint64_t(std::chrono::duration_cast<std::chrono::seconds>(tp.time_since_epoch()).count()), out);
+    arangodb::basics::StringUtils::itoa(uint64_t(duration_cast<seconds>(tp.time_since_epoch()).count()), out);
   } else if (format == TimeFormat::UnixTimestampMillis) {
     // unix timestamp with millisecond precision
-    std::chrono::system_clock::time_point tp2(std::chrono::duration_cast<std::chrono::seconds>(tp.time_since_epoch()));
-    arangodb::basics::StringUtils::itoa(uint64_t(std::chrono::duration_cast<std::chrono::seconds>(tp2.time_since_epoch()).count()), out);
+    system_clock::time_point tp2(duration_cast<seconds>(tp.time_since_epoch()));
+    arangodb::basics::StringUtils::itoa(uint64_t(duration_cast<seconds>(tp2.time_since_epoch()).count()), out);
     out.push_back('.');
-    appendNumber(uint64_t(std::chrono::duration_cast<std::chrono::milliseconds>(tp - tp2).count()), out, 3);
+    appendNumber(uint64_t(duration_cast<milliseconds>(tp - tp2).count()), out, 3);
   } else if (format == TimeFormat::UnixTimestampMicros) {
     // unix timestamp with microsecond precision
-    std::chrono::system_clock::time_point tp2(std::chrono::duration_cast<std::chrono::seconds>(tp.time_since_epoch()));
-    arangodb::basics::StringUtils::itoa(uint64_t(std::chrono::duration_cast<std::chrono::seconds>(tp2.time_since_epoch()).count()), out);
+    system_clock::time_point tp2(duration_cast<seconds>(tp.time_since_epoch()));
+    arangodb::basics::StringUtils::itoa(uint64_t(duration_cast<seconds>(tp2.time_since_epoch()).count()), out);
     out.push_back('.');
-    appendNumber(uint64_t(std::chrono::duration_cast<std::chrono::microseconds>(tp - tp2).count()), out, 6);
+    appendNumber(uint64_t(duration_cast<microseconds>(tp - tp2).count()), out, 6);
   } else {
     // all date-string variants handled here
-    if (format == TimeFormat::UTCDateString) {
+    if (format == TimeFormat::UTCDateString ||
+        format == TimeFormat::UTCDateStringMillis) {
       // UTC datestring
-      out.append(arangodb::basics::formatDate("%yyyy-%mm-%ddT%hh:%ii:%ssZ", tp_sys_clock_ms(std::chrono::duration_cast<std::chrono::milliseconds>(tp.time_since_epoch()))));
-    } else if (format == TimeFormat::UTCDateStringMillis) {
       // UTC datestring with milliseconds
-      out.append(arangodb::basics::formatDate("%yyyy-%mm-%ddT%hh:%ii:%ss.%fffZ", tp_sys_clock_ms(std::chrono::duration_cast<std::chrono::milliseconds>(tp.time_since_epoch()))));
+      arangodb::tp_sys_clock_ms secs(duration_cast<milliseconds>(tp.time_since_epoch()));
+      auto days = floor<date::days>(secs);
+      auto ymd = year_month_day(days);
+      appendNumber(uint64_t(static_cast<int>(ymd.year())), out, 4);
+      out.push_back('-');
+      appendNumber(uint64_t(static_cast<unsigned>(ymd.month())), out, 2);
+      out.push_back('-');
+      appendNumber(uint64_t(static_cast<unsigned>(ymd.day())), out, 2);
+      out.push_back('T');
+      auto day_time = make_time(secs - days);
+      appendNumber(uint64_t(day_time.hours().count()), out, 2);
+      out.push_back(':');
+      appendNumber(uint64_t(day_time.minutes().count()), out, 2);
+      out.push_back(':');
+      appendNumber(uint64_t(day_time.seconds().count()), out, 2);
+        
+      if (format == TimeFormat::UTCDateStringMillis) {
+        out.push_back('.');
+        appendNumber(uint64_t(day_time.subseconds().count()), out, 3);
+      }
+      out.push_back('Z');
     } else if (format == TimeFormat::LocalDateString) {
       // local datestring
       time_t tt = time(nullptr);

--- a/lib/Logger/LogTimeFormat.h
+++ b/lib/Logger/LogTimeFormat.h
@@ -24,7 +24,7 @@
 #ifndef ARANGODB_LOGGER_LOG_TIME_FORMAT_H
 #define ARANGODB_LOGGER_LOG_TIME_FORMAT_H 1
 
-#include <iosfwd>
+#include <chrono>
 #include <string>
 #include <unordered_set>
 
@@ -59,9 +59,12 @@ std::unordered_set<std::string> getAvailableFormatNames();
 /// @brief derive the time format from the name
 TimeFormat formatFromName(std::string const& name);
 
-/// @brief writes the current time into the given buffer,
+/// @brief writes the given time into the given buffer,
 /// in the specified format
-void writeTime(std::string& out, TimeFormat format);
+void writeTime(std::string& out, 
+               TimeFormat format, 
+               std::chrono::system_clock::time_point tp,
+               std::chrono::system_clock::time_point startTp = std::chrono::system_clock::time_point());
 
 }  // namespace LogTimeFormats
 }  // namespace arangodb

--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -367,7 +367,7 @@ void Logger::log(char const* logid, char const* function, char const* file, int 
         out.push_back('"');
       }
       // value of date/time is always safe to print
-      LogTimeFormats::writeTime(out, _timeFormat);
+      LogTimeFormats::writeTime(out, _timeFormat, std::chrono::system_clock::now());
       if (LogTimeFormats::isStringFormat(_timeFormat)) {
         out.push_back('"');
       }
@@ -466,7 +466,7 @@ void Logger::log(char const* logid, char const* function, char const* file, int 
     out.push_back('}');
   } else {
     // human readable format
-    LogTimeFormats::writeTime(out, _timeFormat);
+    LogTimeFormats::writeTime(out, _timeFormat, std::chrono::system_clock::now());
     out.push_back(' ');
 
     // output prefix

--- a/tests/Basics/LoggerTest.cpp
+++ b/tests/Basics/LoggerTest.cpp
@@ -31,6 +31,11 @@
 #include "Logger/LogAppenderFile.h"
 #include "Logger/Logger.h"
 
+#include <date/date.h>
+
+#include <regex>
+#include <sstream>
+
 #ifdef TRI_HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -140,4 +145,124 @@ TEST_F(LoggerTest, test_fds_after_reopen) {
   EXPECT_NE(content.find("some other warning message"), std::string::npos);
 
   LogAppenderFile::closeAll();
+}
+
+TEST_F(LoggerTest, testTimeFormats) {
+  using namespace date;
+  using namespace std::chrono;
+
+  {
+    // server start time point
+    sys_seconds startTp;
+    {
+      std::istringstream in{"2016-12-11 13:59:55"};
+      in >> parse("%F %T", startTp);
+    }
+
+    // time point we are testing
+    sys_seconds tp;
+    {
+      std::istringstream in{"2016-12-11 14:02:43"};
+      in >> parse("%F %T", tp);
+    }
+
+    std::string out;
+    
+    out.clear();
+    LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::Uptime, tp, startTp);
+    EXPECT_EQ("168", out);
+
+    ASSERT_TRUE(std::regex_match(out, std::regex("^[0-9]+$")));
+
+    out.clear();
+    LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::UptimeMillis, tp, startTp);
+    EXPECT_EQ("168.000", out);
+    ASSERT_TRUE(std::regex_match(out, std::regex("^[0-9]+\\.[0-9]{3}$")));
+    
+    out.clear();
+    LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::UptimeMicros, tp, startTp);
+    EXPECT_EQ("168.000000", out);
+    ASSERT_TRUE(std::regex_match(out, std::regex("^[0-9]+\\.[0-9]{6}$")));
+    
+    out.clear();
+    LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::UnixTimestamp, tp, startTp);
+    EXPECT_EQ("1481464963", out);
+    
+    out.clear();
+    LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::UnixTimestampMillis, tp, startTp);
+    EXPECT_EQ("1481464963.000", out);
+    
+    out.clear();
+    LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::UnixTimestampMicros, tp, startTp);
+    EXPECT_EQ("1481464963.000000", out);
+    
+    out.clear();
+    LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::UTCDateString, tp, startTp);
+    EXPECT_EQ("2016-12-11T14:02:43Z", out);
+
+    out.clear();
+    LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::UTCDateStringMillis, tp, startTp);
+    EXPECT_EQ("2016-12-11T14:02:43.000Z", out);
+    
+    out.clear();
+    LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::LocalDateString, tp, startTp);
+    ASSERT_TRUE(std::regex_match(out, std::regex("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$")));
+  }
+  
+  {
+    // server start time point
+    sys_time<milliseconds> startTp;
+    {
+      std::istringstream in{"2020-12-02 11:57:02.701"};
+      in >> parse("%F %T", startTp);
+    }
+
+    // time point we are testing
+    sys_time<milliseconds> tp;
+    {
+      std::istringstream in{"2020-12-02 11:57:26.004"};
+      in >> parse("%F %T", tp);
+    }
+
+    std::string out;
+    
+    out.clear();
+    LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::Uptime, tp, startTp);
+    EXPECT_EQ("23", out);
+    ASSERT_TRUE(std::regex_match(out, std::regex("^[0-9]+$")));
+
+    out.clear();
+    LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::UptimeMillis, tp, startTp);
+    EXPECT_EQ("23.303", out);
+    ASSERT_TRUE(std::regex_match(out, std::regex("^[0-9]+\\.[0-9]{3}$")));
+    
+    out.clear();
+    LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::UptimeMicros, tp, startTp);
+    EXPECT_EQ("23.303000", out);
+    ASSERT_TRUE(std::regex_match(out, std::regex("^[0-9]+\\.[0-9]{6}$")));
+    
+    out.clear();
+    LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::UnixTimestamp, tp, startTp);
+    EXPECT_EQ("1606910246", out);
+    
+    out.clear();
+    LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::UnixTimestampMillis, tp, startTp);
+    EXPECT_EQ("1606910246.004", out);
+    
+    out.clear();
+    LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::UnixTimestampMicros, tp, startTp);
+    EXPECT_EQ("1606910246.004000", out);
+    
+    out.clear();
+    LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::UTCDateString, tp, startTp);
+    EXPECT_EQ("2020-12-02T11:57:26Z", out);
+
+    out.clear();
+    LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::UTCDateStringMillis, tp, startTp);
+    EXPECT_EQ("2020-12-02T11:57:26.004Z", out);
+    
+    out.clear();
+    LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::LocalDateString, tp, startTp);
+    ASSERT_TRUE(std::regex_match(out, std::regex("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$")));
+  }
 }


### PR DESCRIPTION
### Scope & Purpose

Avoid usage of expensive `std::regex`-based functionality for constructing date/time values for log messages.
This is a performance optimization only.

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/597

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new C++ **Unit tests**

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/12958/