### PR TITLE
Add kill-check during early pruning

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Add an AQL query kill check during early pruning. Fixes issue #13141.
+
 * Added new command line options for fine-grained ArangoSearch maintenance
   control:
   - `--arangosearch.commit-threads` - max number of ArangoSearch commit

--- a/arangod/Aql/DocumentProducingHelper.cpp
+++ b/arangod/Aql/DocumentProducingHelper.cpp
@@ -286,6 +286,10 @@ bool DocumentProducingFunctionContext::checkFilter(
 }
 
 bool DocumentProducingFunctionContext::checkFilter(ExpressionContext& ctx) {
+  if (ADB_UNLIKELY(_numFiltered % 1000 == 0 && _query.killed())) {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
+  }
+
   bool mustDestroy;  // will get filled by execution
   AqlValue a = _filter->execute(&ctx, mustDestroy);
   AqlValueGuard guard(a, mustDestroy);

--- a/arangod/Aql/DocumentProducingHelper.cpp
+++ b/arangod/Aql/DocumentProducingHelper.cpp
@@ -286,7 +286,7 @@ bool DocumentProducingFunctionContext::checkFilter(
 }
 
 bool DocumentProducingFunctionContext::checkFilter(ExpressionContext& ctx) {
-  if (ADB_UNLIKELY(_numFiltered % 1000 == 0 && _query.killed())) {
+  if (ADB_UNLIKELY(_numFiltered % 1024 == 0 && _query.killed())) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
   }
 


### PR DESCRIPTION
### Scope & Purpose

Previously, there was no point at which a query was checked for being killed during early pruning. As the number of documents enumerated and filtered is unbounded, such a check is expedient.

- [X] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [X] Backport required for: **3.7**: #13152
- [X] Backport required for: **3.6**: #13153

#### Related Information

- [X] GitHub issue: https://github.com/arangodb/arangodb/issues/13141

### Testing & Verification

- [X] This change is a trivial rework / code cleanup without any test coverage.
- [X] The behavior in this PR was *manually tested*
