### PR TITLE
Fix multi comment detection

### DIFF
--- a/lib/V8/V8LineEditor.cpp
+++ b/lib/V8/V8LineEditor.cpp
@@ -197,6 +197,10 @@ class V8Completer : public Completer {
         if (*ptr == '/') {
           state = NORMAL;
           --openComments;
+        } else if (*ptr == '*') {
+          // state stays at MULTI_COMMENT_1
+        } else {
+          state = MULTI_COMMENT;
         }
 
         ++ptr;


### PR DESCRIPTION
### Scope & Purpose

This concerns the detection of the arangosh repl whether a line is complete. When inside a multi-line comment, i.e. after a `/*`, after encountering a `*`, any `/` would end the comment; e.g. `/** GET /` would be seen as a terminated multi-line comment.

- [X] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

### Testing & Verification

I couldn't find existing tests for this. Maybe some should be added in this PR, but if so, we need tests for the whole behaviour, not just this fix.

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
