### PR TITLE
fix make directory windows error handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fix Windows directory creation error handling.
+
 * Add an AQL query kill check during early pruning. Fixes issue #13141.
 
 * Remove a case in which followers were dropped unnecessarily in streaming

--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -544,8 +544,6 @@ int TRI_CreateRecursiveDirectory(char const* path, long& systemError,
 ////////////////////////////////////////////////////////////////////////////////
 
 int TRI_CreateDirectory(char const* path, long& systemError, std::string& systemErrorStr) {
-  TRI_ERRORBUF;
-
   // reset error flag
   TRI_set_errno(TRI_ERROR_NO_ERROR);
 
@@ -556,10 +554,9 @@ int TRI_CreateDirectory(char const* path, long& systemError, std::string& system
   }
 
   // check errno
-  TRI_SYSTEM_ERROR();
   res = errno;
   if (res != TRI_ERROR_NO_ERROR) {
-    systemErrorStr = std::string("failed to create directory '") + path + "': " + TRI_GET_ERRORBUF;
+    systemErrorStr = std::string("failed to create directory '") + path + "': " + TRI_LAST_ERROR_STR;
     systemError = res;
 
     if (res == ENOENT) {

--- a/lib/Basics/operating-system.h
+++ b/lib/Basics/operating-system.h
@@ -731,7 +731,7 @@ void TRI_GET_ARGV_WIN(int& argc, char** argv);
     auto result = translateWindowsError(::GetLastError());                    \
     errno = result.errorNumber();                                             \
     auto const& mesg = result.errorMessage();                                 \
-    memset(windowsErrorBuf, 0, sizeof(windowsErrorBuf);                       \
+    memset(windowsErrorBuf, 0, sizeof(windowsErrorBuf));                      \
     if (mesg.empty()) {                                                       \
       memcpy(&windowsErrorBuf[0], "unknown error", strlen("unknown error"));  \
     } else {                                                                  \

--- a/lib/Basics/operating-system.h
+++ b/lib/Basics/operating-system.h
@@ -726,18 +726,19 @@ int TRI_UNLINK(char const* filename);
 void TRI_GET_ARGV_WIN(int& argc, char** argv);
 
 // system error string macro requires ERRORBUF to instantiate its buffer before.
-#define TRI_SYSTEM_ERROR()                                                       \
-  do {                                                                           \
-    auto result = translateWindowsError(::GetLastError());                       \
-    errno = result.errorNumber();                                                \
-    auto const& mesg = result.errorMessage();                                    \
-    if (mesg.empty()) {                                                          \
-      memcpy(&windowsErrorBuf[0], "unknown error\0", strlen("unknown error\0")); \
-    } else {                                                                     \
-      memcpy(&windowsErrorBuf[0], mesg.data(),                                   \
-             (std::min)(sizeof(windowsErrorBuf) / sizeof(windowsErrorBuf[0]),    \
-                        mesg.size()));                                           \
-    }                                                                            \
+#define TRI_SYSTEM_ERROR()                                                    \
+  do {                                                                        \
+    auto result = translateWindowsError(::GetLastError());                    \
+    errno = result.errorNumber();                                             \
+    auto const& mesg = result.errorMessage();                                 \
+    memset(windowsErrorBuf, 0, sizeof(windowsErrorBuf);                       \
+    if (mesg.empty()) {                                                       \
+      memcpy(&windowsErrorBuf[0], "unknown error", strlen("unknown error"));  \
+    } else {                                                                  \
+      memcpy(&windowsErrorBuf[0], mesg.data(),                                \
+             (std::min)(sizeof(windowsErrorBuf) / sizeof(windowsErrorBuf[0]), \
+                        mesg.size()));                                        \
+    }                                                                         \
   } while (false)
 
 #define STDERR_FILENO 2


### PR DESCRIPTION
### Scope & Purpose

windows make directory would not throw on error

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [x] Backports required for: *(Please specify versions and link PRs)*

#### Related Information

discovered during testing

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
