### PR TITLE
fix assertion failure when database is specified with no URL path

### DIFF
--- a/lib/Rest/HttpRequest.cpp
+++ b/lib/Rest/HttpRequest.cpp
@@ -403,7 +403,7 @@ void HttpRequest::parseUrl(const char* path, size_t length) {
   for (size_t i = 0; i < length; ++i) {
     tmp.push_back(path[i]);
     if (path[i] == '/') {
-      while (i + 1 < length && path[i+1] == '/') {
+      while (i + 1 < length && path[i + 1] == '/') {
         ++i;
       }
     }
@@ -439,6 +439,10 @@ void HttpRequest::parseUrl(const char* path, size_t length) {
     }
   } else {
     _fullUrl.assign(start, end - start);
+  }
+
+  if (_fullUrl.empty()) {
+    _fullUrl.push_back('/');
   }
   TRI_ASSERT(!_fullUrl.empty());
 


### PR DESCRIPTION
### Scope & Purpose

Fix assertion failure when database is specified without URL path (e.g. `/_db/system`). In this case, in maintainer mode an assertion failure was triggered, but it didn't have any effect in non-maintainer
mode.

- [x] :hankey: Bugfix (requires CHANGELOG entry)

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13076/