### PR TITLE
Fix introduced/deprecated in versions for --arangosearch.*threads* startup option

### DIFF
--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -735,26 +735,22 @@ void IResearchFeature::collectOptions(std::shared_ptr<arangodb::options::Program
                      "upper limit to the allowed number of consolidation threads "
                      "(0 == autodetect)",
                      new options::UInt32Parameter(&_consolidationThreads))
-                     .setIntroducedIn(30705)
-                     .setIntroducedIn(30800);
+                     .setIntroducedIn(30705);
   options->addOption(CONSOLIDATION_THREADS_IDLE_PARAM,
                      "upper limit to the allowed number of idle threads to use "
                      "for consolidation tasks (0 == autodetect)",
                      new options::UInt32Parameter(&_consolidationThreadsIdle))
-                     .setIntroducedIn(30705)
-                     .setIntroducedIn(30800);
+                     .setIntroducedIn(30705);
   options->addOption(COMMIT_THREADS_PARAM,
                      "upper limit to the allowed number of commit threads "
                      "(0 == autodetect)",
                      new options::UInt32Parameter(&_commitThreads))
-                     .setIntroducedIn(30705)
-                     .setIntroducedIn(30800);
+                     .setIntroducedIn(30705);
   options->addOption(COMMIT_THREADS_IDLE_PARAM,
                      "upper limit to the allowed number of idle threads to use "
                      "for commit tasks (0 == autodetect)",
                      new options::UInt32Parameter(&_commitThreadsIdle))
-                     .setIntroducedIn(30705)
-                     .setIntroducedIn(30800);
+                     .setIntroducedIn(30705);
 }
 
 void IResearchFeature::validateOptions(std::shared_ptr<arangodb::options::ProgramOptions> options) {

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -725,32 +725,36 @@ void IResearchFeature::collectOptions(std::shared_ptr<arangodb::options::Program
                      "the exact number of threads to use for asynchronous "
                      "tasks (0 == autodetect)",
                      new options::UInt32Parameter(&_threads))
-                     .setDeprecatedIn(30800);
+                     .setDeprecatedIn(30705);
   options->addOption(THREADS_LIMIT_PARAM,
                      "upper limit to the autodetected number of threads to use "
                      "for asynchronous tasks (0 == use default)",
                      new options::UInt32Parameter(&_threadsLimit))
-                     .setDeprecatedIn(30800);
+                     .setDeprecatedIn(30705);
   options->addOption(CONSOLIDATION_THREADS_PARAM,
                      "upper limit to the allowed number of consolidation threads "
                      "(0 == autodetect)",
                      new options::UInt32Parameter(&_consolidationThreads))
-                     .setIntroducedIn(30760);
+                     .setIntroducedIn(30705)
+                     .setIntroducedIn(30800);
   options->addOption(CONSOLIDATION_THREADS_IDLE_PARAM,
                      "upper limit to the allowed number of idle threads to use "
                      "for consolidation tasks (0 == autodetect)",
                      new options::UInt32Parameter(&_consolidationThreadsIdle))
-                     .setIntroducedIn(30760);
+                     .setIntroducedIn(30705)
+                     .setIntroducedIn(30800);
   options->addOption(COMMIT_THREADS_PARAM,
                      "upper limit to the allowed number of commit threads "
                      "(0 == autodetect)",
                      new options::UInt32Parameter(&_commitThreads))
-                     .setIntroducedIn(30760);
+                     .setIntroducedIn(30705)
+                     .setIntroducedIn(30800);
   options->addOption(COMMIT_THREADS_IDLE_PARAM,
                      "upper limit to the allowed number of idle threads to use "
                      "for commit tasks (0 == autodetect)",
                      new options::UInt32Parameter(&_commitThreadsIdle))
-                     .setIntroducedIn(30760);
+                     .setIntroducedIn(30705)
+                     .setIntroducedIn(30800);
 }
 
 void IResearchFeature::validateOptions(std::shared_ptr<arangodb::options::ProgramOptions> options) {


### PR DESCRIPTION
### Scope & Purpose

Adjust code to match https://github.com/arangodb/docs/pull/593/commits/72dcbffbed2d25b08145bd07618c37880f8c6531

Also add v3.8.0 as version, even though this isn't strictly necessary. We do this for other options however.

#### Backports:

- [x] Backports required for: 3.7

#### Related Information

https://github.com/arangodb/arangodb/pull/13008
https://github.com/arangodb/arangodb/pull/13146
https://github.com/arangodb/docs/pull/593

### Testing & Verification

*(Please pick either of the following options)*

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
