### PR TITLE
stringify Pregel execution numbers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,15 @@
 devel
 -----
 
+* Make all Pregel HTTP and JavaScript APIs also accept stringified execution
+  number values, in addition to numeric ones.
+
+  This allows passing larger execution numbers as strings, so that any data
+  loss due to numeric data type conversion (uint32 => double) can be avoided.
+
+  The change also makes the Pregel HTTP and JavaScript APIs for starting a
+  run return a stringified execution number, e.g. "12345" instead of 12345.
+
 * Updated ArangoDB Starter to 0.14.15-1.
 
 * Fix Windows directory creation error handling.

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -7866,7 +7866,7 @@ AqlValue Functions::PregelResult(ExpressionContext* expressionContext,
   static char const* AFN = "PREGEL_RESULT";
 
   AqlValue arg1 = extractFunctionParameterValue(parameters, 0);
-  if (!arg1.isNumber()) {
+  if (!arg1.isNumber() && !arg1.isString()) {
     THROW_ARANGO_EXCEPTION_PARAMS(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH, AFN);
   }
   bool withId = false;

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -28,6 +28,7 @@
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/MutexLocker.h"
 #include "Basics/NumberOfCores.h"
+#include "Basics/StringUtils.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
@@ -349,14 +350,19 @@ void PregelFeature::cleanupAll() {
   }
 
   VPackSlice sExecutionNum = body.get(Utils::executionNumberKey);
-  if (!sExecutionNum.isInteger()) {
+  if (!sExecutionNum.isInteger() && !sExecutionNum.isString()) {
     LOG_TOPIC("8410a", ERR, Logger::PREGEL) << "Invalid execution number";
   }
-  uint64_t exeNum = sExecutionNum.getUInt();
+  uint64_t exeNum = 0;
+  if (sExecutionNum.isInteger()) {
+    exeNum = sExecutionNum.getUInt();
+  } else if (sExecutionNum.isString()) {
+    exeNum = basics::StringUtils::uint64(sExecutionNum.copyString());
+  }
   std::shared_ptr<Conductor> co = instance->conductor(exeNum);
   if (!co) {
     THROW_ARANGO_EXCEPTION_MESSAGE(
-        TRI_ERROR_CURSOR_NOT_FOUND, "Conductor not found, invalid execution number");
+        TRI_ERROR_CURSOR_NOT_FOUND, "Conductor not found, invalid execution number: " + std::to_string(exeNum));
   }
 
   if (path == Utils::finishedStartupPath) {

--- a/arangod/RestHandler/RestControlPregelHandler.cpp
+++ b/arangod/RestHandler/RestControlPregelHandler.cpp
@@ -182,7 +182,7 @@ void RestControlPregelHandler::startExecution() {
   }
 
   VPackBuilder builder;
-  builder.add(VPackValue(res.second));
+  builder.add(VPackValue(std::to_string(res.second)));
   generateResult(rest::ResponseCode::OK, builder.slice());
 }
 

--- a/arangod/V8Server/v8-collection.cpp
+++ b/arangod/V8Server/v8-collection.cpp
@@ -1668,8 +1668,10 @@ static void JS_PregelStart(v8::FunctionCallbackInfo<v8::Value> const& args) {
   if (res.first.fail()) {
     TRI_V8_THROW_EXCEPTION(res.first);
   }
+    
+  auto result = TRI_V8UInt64String<uint64_t>(isolate, res.second);
+  TRI_V8_RETURN(result);
 
-  TRI_V8_RETURN(v8::Number::New(isolate, static_cast<double>(res.second)));
   TRI_V8_TRY_CATCH_END
 }
 
@@ -1709,7 +1711,7 @@ static void JS_PregelCancel(v8::FunctionCallbackInfo<v8::Value> const& args) {
   uint32_t const argLength = args.Length();
   if (argLength != 1 || !(args[0]->IsNumber() || args[0]->IsString())) {
     // TODO extend this for named graphs, use the Graph class
-    TRI_V8_THROW_EXCEPTION_USAGE("_pregelStatus(<executionNum>)");
+    TRI_V8_THROW_EXCEPTION_USAGE("_pregelCancel(<executionNum>)");
   }
 
   std::shared_ptr<pregel::PregelFeature> feature = pregel::PregelFeature::instance();

--- a/tests/js/common/shell/shell-pregel.js
+++ b/tests/js/common/shell/shell-pregel.js
@@ -41,10 +41,11 @@ const graphName = "UnitTest_pregel";
 const vColl = "UnitTest_pregel_v", eColl = "UnitTest_pregel_e";
 
 function testAlgo(a, p) {
-  var pid = pregel.start(a, graphName, p);
+  let pid = pregel.start(a, graphName, p);
+  assertTrue(typeof pid === "string");
   var i = 10000;
   do {
-    internal.wait(0.2);
+    internal.sleep(0.2);
     var stats = pregel.status(pid);
     if (stats.state !== "running") {
       assertEqual(stats.vertexCount, 11, stats);
@@ -169,7 +170,7 @@ function basicTestSuite() {
       var pid = pregel.start("pagerank", graphName, { threshold: EPS / 10, store: false });
       var i = 10000;
       do {
-        internal.wait(0.2);
+        internal.sleep(0.2);
         var stats = pregel.status(pid);
         if (stats.state !== "running") {
           assertEqual(stats.vertexCount, 11, stats);
@@ -207,7 +208,7 @@ function basicTestSuite() {
           });
 
           pregel.cancel(pid); // delete contents
-          internal.wait(5.0);
+          internal.sleep(5.0);
 
           array = db._query("RETURN PREGEL_RESULT(@id)", { "id": pid }).toArray();
           assertEqual(array.length, 1);
@@ -251,9 +252,10 @@ function exampleTestSuite() {
         vertexCollections: ['female', 'male'], 
         edgeCollections: ['relation'],
       }, { resultField: "closeness" });
+      assertTrue(typeof key === "string");
       var i = 10000;
       do {
-        internal.wait(0.2);
+        internal.sleep(0.2);
         var stats = pregel.status(key);
         if (stats.state !== "running") {
           assertEqual(stats.vertexCount, 4, stats);
@@ -273,6 +275,41 @@ function randomTestSuite() {
 
   const n = 20000; // vertices
   const m = 300000; // edges
+  
+  let checkStatus = function(key) {
+    let i = 10000;
+    do {
+      internal.sleep(0.2);
+      let stats = pregel.status(key);
+      if (stats.state !== "running") {
+        break;
+      }
+    } while (i-- >= 0);
+    if (i === 0) {
+      assertTrue(false, "timeout in pregel execution");
+    }
+  };
+  
+  let checkCancel = function(key) {
+    checkStatus(key);
+    pregel.cancel(key);
+    let i = 10000;
+    do {
+      try {
+        let stats = pregel.status(key);
+        if (stats.state === "canceled") {
+          break;
+        }
+      } catch (err) {
+        // fine.
+        break;
+      }
+      internal.sleep(0.2);
+    } while (i-- >= 0);
+    if (i === 0) {
+      assertTrue(false, "timeout in pregel execution");
+    }
+  };
 
   return {
 
@@ -352,7 +389,7 @@ function randomTestSuite() {
       var pid = pregel.start("pagerank", graphName, { threshold: 0.0000001, resultField: "result", store: true });
       var i = 10000;
       do {
-        internal.wait(0.2);
+        internal.sleep(0.2);
         var stats = pregel.status(pid);
         if (stats.state !== "running") {
           assertEqual(stats.vertexCount, n, stats);
@@ -373,7 +410,7 @@ function randomTestSuite() {
       var pid = pregel.start("pagerank", graphName, opts);
       var i = 10000;
       do {
-        internal.wait(0.2);
+        internal.sleep(0.2);
         var stats = pregel.status(pid);
         if (stats.state !== "running") {
           assertEqual(stats.vertexCount, n, stats);
@@ -394,7 +431,7 @@ function randomTestSuite() {
       var pid = pregel.start("hits", graphName, opts);
       var i = 10000;
       do {
-        internal.wait(0.2);
+        internal.sleep(0.2);
         var stats = pregel.status(pid);
         if (stats.state !== "running") {
           assertEqual(stats.vertexCount, n, stats);
@@ -405,7 +442,32 @@ function randomTestSuite() {
       if (i === 0) {
         assertTrue(false, "timeout in pregel execution");
       }
-    }
+    },
+
+    testStatusWithNumericId: function () {
+      let key = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: true });
+      assertTrue(typeof key === "string");
+      checkStatus(Number(key));
+    },
+    
+    testStatusWithStringId: function () {
+      let key = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: true });
+      assertTrue(typeof key === "string");
+      checkStatus(key);
+    },
+    
+    testCancelWithNumericId: function () {
+      let key = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: false });
+      assertTrue(typeof key === "string");
+      checkCancel(Number(key));
+    },
+    
+    testCancelWithStringId: function () {
+      let key = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: false });
+      assertTrue(typeof key === "string");
+      checkCancel(key);
+    },
+
   };
 }
 
@@ -575,7 +637,7 @@ function componentsTestSuite() {
       var pid = pregel.start("wcc", graphName, { resultField: "result", store: true });
       var i = 10000;
       do {
-        internal.wait(0.2);
+        internal.sleep(0.2);
         let stats = pregel.status(pid);
         if (stats.state !== "running" && stats.state !== "storing") {
           assertEqual(stats.vertexCount, numComponents * n, stats);
@@ -792,7 +854,7 @@ function multiCollectionTestSuite() {
       var pid = pregel.start("wcc", graphName, { resultField: "result", store: true });
       var i = 10000;
       do {
-        internal.wait(0.2);
+        internal.sleep(0.2);
         let stats = pregel.status(pid);
         if (stats.state !== "running" && stats.state !== "storing") {
           assertEqual(stats.vertexCount, numComponents * n, stats);
@@ -823,7 +885,7 @@ function multiCollectionTestSuite() {
         let pid = pregel.start("wcc", graphName, { resultField: "result", store: true, parallelism });
         let i = 10000;
         do {
-          internal.wait(0.2);
+          internal.sleep(0.2);
           let stats = pregel.status(pid);
           if (stats.state !== "running" && stats.state !== "storing") {
             assertEqual(500, stats.gss);
@@ -856,7 +918,7 @@ function multiCollectionTestSuite() {
         let pid = pregel.start("wcc", graphName, { resultField: "result", store: true, parallelism, useMemoryMaps: true });
         let i = 10000;
         do {
-          internal.wait(0.2);
+          internal.sleep(0.2);
           let stats = pregel.status(pid);
           if (stats.state !== "running" && stats.state !== "storing") {
             assertEqual(500, stats.gss);
@@ -895,7 +957,7 @@ function edgeCollectionRestrictionsTestSuite() {
   let checkResult = function(pid) {
     var i = 10000;
     do {
-      internal.wait(0.2);
+      internal.sleep(0.2);
       let stats = pregel.status(pid);
       if (stats.state !== "running" && stats.state !== "storing") {
         assertEqual(200, stats.vertexCount, stats);


### PR DESCRIPTION
### Scope & Purpose

Make all Pregel HTTP and JavaScript APIs also accept stringified execution number values, in addition to numeric ones. 

This allows passing larger execution numbers as strings, so that any data loss due to numeric data type conversion (uint32 => double) can be avoided. This change is downwards-compatible.

The change in this PR also makes the Pregel HTTP and JavaScript APIs for starting a run return a stringified execution number, e.g. "12345" instead of 12345. This is not downwards-compatible, so it will be noted in the upgrading section and will not be backported.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/594

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *shell_client, shell_server*.
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_client, shell_server)

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13099/