### PR TITLE
simplify operations from division to bit arithmetic

### DIFF
--- a/arangod/Agency/AgencyComm.h
+++ b/arangod/Agency/AgencyComm.h
@@ -25,8 +25,6 @@
 #ifndef ARANGOD_CLUSTER_AGENCY_COMM_H
 #define ARANGOD_CLUSTER_AGENCY_COMM_H 1
 
-#include <deque>
-#include <list>
 #include <memory>
 #include <optional>
 #include <string>
@@ -47,6 +45,10 @@
 
 namespace arangodb {
 class Endpoint;
+
+namespace application_features {
+class ApplicationServer;
+}
 
 namespace velocypack {
 class Builder;

--- a/arangod/Aql/AqlValue.cpp
+++ b/arangod/Aql/AqlValue.cpp
@@ -1022,7 +1022,7 @@ v8::Handle<v8::Value> AqlValue::toV8(v8::Isolate* isolate, velocypack::Options c
                                     )
                     ).FromMaybe(true);
 
-        if (i % 1000 == 0) {
+        if (i % 1024 == 0) {
           if (V8PlatformFeature::isOutOfMemory(isolate)) {
             THROW_ARANGO_EXCEPTION(TRI_ERROR_OUT_OF_MEMORY);
           }

--- a/arangod/Cluster/ClusterRepairDistributeShardsLike.h
+++ b/arangod/Cluster/ClusterRepairDistributeShardsLike.h
@@ -27,8 +27,10 @@
 #include <velocypack/Compare.h>
 #include <velocypack/Slice.h>
 #include <velocypack/velocypack-common.h>
+#include <list>
 #include <optional>
 #include <variant>
+#include <vector>
 
 #include "Agency/AgencyComm.h"
 #include "Basics/ResultT.h"

--- a/arangod/RestServer/Metrics.h
+++ b/arangod/RestServer/Metrics.h
@@ -25,19 +25,18 @@
 #define ARANGODB_REST_SERVER_METRICS_H 1
 
 #include <atomic>
-#include <map>
 #include <iostream>
 #include <string>
-#include <memory>
-#include <variant>
 #include <vector>
-#include <unordered_map>
-#include <cassert>
 #include <cmath>
 #include <limits>
 
-#include "Basics/VelocyPackHelper.h"
-#include "Logger/LogMacros.h"
+#include "Basics/debugging.h"
+
+#include <velocypack/Builder.h>
+#include <velocypack/Value.h>
+#include <velocypack/velocypack-aliases.h>
+
 #include "counter.h"
 
 class Metric {
@@ -305,19 +304,6 @@ struct lin_scale_t : public scale_t<T> {
  private:
   T _base, _div;
 };
-
-
-template<typename ... Args>
-std::string strfmt (std::string const& format, Args ... args) {
-  size_t size = snprintf( nullptr, 0, format.c_str(), args ... ) + 1;
-  if( size <= 0 ) {
-    throw std::runtime_error( "Error during formatting." );
-  }
-  std::unique_ptr<char[]> buf(new char[size]);
-  snprintf(buf.get(), size, format.c_str(), args ...);
-  return std::string(buf.get(), buf.get() + size - 1); // We don't want the '\0' inside
-}
-
 
 
 /**

--- a/lib/V8/v8-utils.cpp
+++ b/lib/V8/v8-utils.cpp
@@ -5534,7 +5534,7 @@ bool TRI_RunGarbageCollectionV8(v8::Isolate* isolate, double availableTime) {
 
     size_t i = 0;
     while (TRI_microtime() < until) {
-      if (++i % 1000 == 0) {
+      if (++i % 1024 == 0) {
         // garbage collection only every x iterations, otherwise we'll use too
         // much CPU
         if (++gcTries > gcAttempts || SingleRunGarbageCollectionV8(isolate, idleTimeInMs)) {


### PR DESCRIPTION
### Scope & Purpose

* Simplify two operations from divisions to bitwise arithmetic (moving from `% 1000 == 0` to `% 1024 == 0` enables this optimization in g++ with optimizations, as tested in compiler explorer)
* Removed stock include headers from Metrics.h

- [x] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13106