### PR TITLE
two small unrelated fixes

### DIFF
--- a/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
@@ -415,6 +415,8 @@ void RocksDBRestReplicationHandler::handleCommandCreateKeys() {
   }
   // to is ignored because the snapshot time is the latest point in time
 
+  ExecContextSuperuserScope escope(ExecContext::current().isAdminUser());
+
   RocksDBReplicationContext* ctx = nullptr;
   // get batchId from url parameters
   bool found;

--- a/lib/Basics/NumberUtils.h
+++ b/lib/Basics/NumberUtils.h
@@ -64,7 +64,7 @@ template <typename T>
 inline T atoi_positive_unchecked(char const* p, char const* e) noexcept {
   T result = 0;
   while (p != e) {
-    result = (result * 10) + *(p++) - '0';
+    result = (result * 10) + (*(p++) - '0');
   }
 
   return result;


### PR DESCRIPTION
### Scope & Purpose

* Fix a potential signed integer underflow in NumberUtils, uncovered by unit tests with UBSan.
* Make sure that privileges for replication are sufficient when doing incremental sync.

It is unclear whether these issues are hit in practice (e.g. the NumberUtils issue depends on specific template instatiations and values), but the possibility at least exists.

Backport of https://github.com/arangodb/arangodb/pull/13178

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required.

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage (true for 3.7, not true for devel)
- [x] The behavior in this PR was *manually tested*
- [x] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13110/