### PR TITLE
Change from _numFiltered to _numScanned to avoid edge cases

### DIFF
--- a/arangod/Aql/DocumentProducingHelper.cpp
+++ b/arangod/Aql/DocumentProducingHelper.cpp
@@ -286,7 +286,7 @@ bool DocumentProducingFunctionContext::checkFilter(
 }
 
 bool DocumentProducingFunctionContext::checkFilter(ExpressionContext& ctx) {
-  if (ADB_UNLIKELY(_numFiltered % 1024 == 0 && _query.killed())) {
+  if (ADB_UNLIKELY(_numScanned % 1024 == 0 && _query.killed())) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
   }
 


### PR DESCRIPTION
### Scope & Purpose

Follow-up of https://github.com/arangodb/arangodb/pull/13151. Use `_numFiltered` instead of `_numScanned` to avoid edge cases.

- [X] :fire: Performance improvement

#### Backports:

- [ ] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

### Testing & Verification

- [X] This change is a trivial rework / code cleanup without any test coverage.