### PR TITLE
Fix cluster-internal replication of documents with special keys

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix cluster-internal replication of documents with special keys (percent
+  character, which has a special meaning when used inside URLs).
+
 * Fix AQL cost estimate of spliced subqueries which could lead to overly large
   numbers in the explain output of such queries.
 

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2231,7 +2231,7 @@ Future<Result> Methods::replicateOperations(
     url.push_back('/');
     VPackValueLength len;
     const char* ptr = value.get(StaticStrings::KeyString).getString(len);
-    url.append(ptr, len);
+    basics::StringUtils::encodeURIComponent(url, ptr, len);
   }
 
   arangodb::fuerte::RestVerb requestType = arangodb::fuerte::RestVerb::Illegal;

--- a/lib/Basics/StringUtils.cpp
+++ b/lib/Basics/StringUtils.cpp
@@ -910,16 +910,15 @@ std::string urlEncode(char const* src, size_t const len) {
   return result;
 }
 
-std::string encodeURIComponent(char const* src, size_t len) {
+void encodeURIComponent(std::string& result, char const* src, size_t len) {
   char const* end = src + len;
 
   // cppcheck-suppress unsignedPositive
-  if (len >= (SIZE_MAX - 1) / 3) {
+  if (result.size() + len >= (SIZE_MAX - 1) / 3) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_OUT_OF_MEMORY);
   }
 
-  std::string result;
-  result.reserve(3 * len);
+  result.reserve(result.size() + 3 * len);
 
   for (; src < end; ++src) {
     if (*src == '-' || *src == '_' || *src == '.' || *src == '!' ||
@@ -936,7 +935,11 @@ std::string encodeURIComponent(char const* src, size_t len) {
       result.push_back(::hexValuesUpper[c % 16]);
     }
   }
+}
 
+std::string encodeURIComponent(char const* src, size_t len) {
+  std::string result;
+  encodeURIComponent(result, src, len);
   return result;
 }
 

--- a/lib/Basics/StringUtils.h
+++ b/lib/Basics/StringUtils.h
@@ -196,6 +196,9 @@ std::string urlDecode(std::string const& str);
 /// @brief url encodes the string
 std::string urlEncode(char const* src, size_t len);
 
+/// @brief url encodes the string into the result buffer
+void encodeURIComponent(std::string& result, char const* src, size_t len);
+
 /// @brief uri encodes the component string
 std::string encodeURIComponent(std::string const& str);
 

--- a/tests/Basics/StringUtilsTest.cpp
+++ b/tests/Basics/StringUtilsTest.cpp
@@ -169,34 +169,34 @@ TEST_F(StringUtilsTest, test_toupper) {
 ////////////////////////////////////////////////////////////////////////////////
 
 TEST_F(StringUtilsTest, test_uint64) {
-  EXPECT_EQ(0ULL,  StringUtils::uint64("abc"s));
-  EXPECT_EQ(0ULL,  StringUtils::uint64("ABC"s));
-  EXPECT_EQ(0ULL,  StringUtils::uint64(" foo"s));
-  EXPECT_EQ(0ULL,  StringUtils::uint64(""s));
-  EXPECT_EQ(0ULL,  StringUtils::uint64(" "s));
-  EXPECT_EQ(12ULL,  StringUtils::uint64("012"s));
-  EXPECT_EQ(12ULL,  StringUtils::uint64("00012"s));
-  EXPECT_EQ(1234ULL,  StringUtils::uint64("1234"s));
-  EXPECT_EQ(1234ULL,  StringUtils::uint64("1234a"s));
-  EXPECT_EQ(0ULL,  StringUtils::uint64("-1"s));
-  EXPECT_EQ(0ULL,  StringUtils::uint64("-12345"s));
-  EXPECT_EQ(1234ULL,  StringUtils::uint64("1234.56"s));
-  EXPECT_EQ(0ULL,  StringUtils::uint64("1234567890123456789012345678901234567890"s));
-  EXPECT_EQ(0ULL,  StringUtils::uint64("@"s));
+  EXPECT_EQ(0ULL, StringUtils::uint64("abc"s));
+  EXPECT_EQ(0ULL, StringUtils::uint64("ABC"s));
+  EXPECT_EQ(0ULL, StringUtils::uint64(" foo"s));
+  EXPECT_EQ(0ULL, StringUtils::uint64(""s));
+  EXPECT_EQ(0ULL, StringUtils::uint64(" "s));
+  EXPECT_EQ(12ULL, StringUtils::uint64("012"s));
+  EXPECT_EQ(12ULL, StringUtils::uint64("00012"s));
+  EXPECT_EQ(1234ULL, StringUtils::uint64("1234"s));
+  EXPECT_EQ(1234ULL, StringUtils::uint64("1234a"s));
+  EXPECT_EQ(0ULL, StringUtils::uint64("-1"s));
+  EXPECT_EQ(0ULL, StringUtils::uint64("-12345"s));
+  EXPECT_EQ(1234ULL, StringUtils::uint64("1234.56"s));
+  EXPECT_EQ(0ULL, StringUtils::uint64("1234567890123456789012345678901234567890"s));
+  EXPECT_EQ(0ULL, StringUtils::uint64("@"s));
 
-  EXPECT_EQ(0ULL,  StringUtils::uint64("0"s));
-  EXPECT_EQ(1ULL,  StringUtils::uint64("1"s));
-  EXPECT_EQ(12ULL,  StringUtils::uint64("12"s));
-  EXPECT_EQ(123ULL,  StringUtils::uint64("123"s));
-  EXPECT_EQ(1234ULL,  StringUtils::uint64("1234"s));
-  EXPECT_EQ(1234ULL,  StringUtils::uint64("01234"s));
-  EXPECT_EQ(9ULL,  StringUtils::uint64("9"s));
-  EXPECT_EQ(9ULL,  StringUtils::uint64("09"s));
-  EXPECT_EQ(9ULL,  StringUtils::uint64("0009"s));
-  EXPECT_EQ(12345678ULL,  StringUtils::uint64("12345678"s));
-  EXPECT_EQ(1234567800ULL,  StringUtils::uint64("1234567800"s));
-  EXPECT_EQ(1234567890123456ULL,  StringUtils::uint64("1234567890123456"s));
-  EXPECT_EQ(UINT64_MAX,  StringUtils::uint64(std::to_string(UINT64_MAX)));
+  EXPECT_EQ(0ULL, StringUtils::uint64("0"s));
+  EXPECT_EQ(1ULL, StringUtils::uint64("1"s));
+  EXPECT_EQ(12ULL, StringUtils::uint64("12"s));
+  EXPECT_EQ(123ULL, StringUtils::uint64("123"s));
+  EXPECT_EQ(1234ULL, StringUtils::uint64("1234"s));
+  EXPECT_EQ(1234ULL, StringUtils::uint64("01234"s));
+  EXPECT_EQ(9ULL, StringUtils::uint64("9"s));
+  EXPECT_EQ(9ULL, StringUtils::uint64("09"s));
+  EXPECT_EQ(9ULL, StringUtils::uint64("0009"s));
+  EXPECT_EQ(12345678ULL, StringUtils::uint64("12345678"s));
+  EXPECT_EQ(1234567800ULL, StringUtils::uint64("1234567800"s));
+  EXPECT_EQ(1234567890123456ULL, StringUtils::uint64("1234567890123456"s));
+  EXPECT_EQ(UINT64_MAX, StringUtils::uint64(std::to_string(UINT64_MAX)));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -204,118 +204,147 @@ TEST_F(StringUtilsTest, test_uint64) {
 ////////////////////////////////////////////////////////////////////////////////
 
 TEST_F(StringUtilsTest, test_uint64_trusted) {
-  EXPECT_EQ(0ULL,  StringUtils::uint64_trusted("0"));
-  EXPECT_EQ(1ULL,  StringUtils::uint64_trusted("1"));
-  EXPECT_EQ(12ULL,  StringUtils::uint64_trusted("12"));
-  EXPECT_EQ(123ULL,  StringUtils::uint64_trusted("123"));
-  EXPECT_EQ(1234ULL,  StringUtils::uint64_trusted("1234"));
-  EXPECT_EQ(1234ULL,  StringUtils::uint64_trusted("01234"));
-  EXPECT_EQ(9ULL,  StringUtils::uint64_trusted("9"));
-  EXPECT_EQ(9ULL,  StringUtils::uint64_trusted("0009"));
-  EXPECT_EQ(12345678ULL,  StringUtils::uint64_trusted("12345678"));
-  EXPECT_EQ(1234567800ULL,  StringUtils::uint64_trusted("1234567800"));
-  EXPECT_EQ(1234567890123456ULL,  StringUtils::uint64_trusted("1234567890123456"));
-  EXPECT_EQ(UINT64_MAX,  StringUtils::uint64_trusted(std::to_string(UINT64_MAX)));
+  EXPECT_EQ(0ULL, StringUtils::uint64_trusted("0"));
+  EXPECT_EQ(1ULL, StringUtils::uint64_trusted("1"));
+  EXPECT_EQ(12ULL, StringUtils::uint64_trusted("12"));
+  EXPECT_EQ(123ULL, StringUtils::uint64_trusted("123"));
+  EXPECT_EQ(1234ULL, StringUtils::uint64_trusted("1234"));
+  EXPECT_EQ(1234ULL, StringUtils::uint64_trusted("01234"));
+  EXPECT_EQ(9ULL, StringUtils::uint64_trusted("9"));
+  EXPECT_EQ(9ULL, StringUtils::uint64_trusted("0009"));
+  EXPECT_EQ(12345678ULL, StringUtils::uint64_trusted("12345678"));
+  EXPECT_EQ(1234567800ULL, StringUtils::uint64_trusted("1234567800"));
+  EXPECT_EQ(1234567890123456ULL, StringUtils::uint64_trusted("1234567890123456"));
+  EXPECT_EQ(UINT64_MAX, StringUtils::uint64_trusted(std::to_string(UINT64_MAX)));
 }
 
 TEST_F(StringUtilsTest, test_encodeHex) {
-  EXPECT_EQ("",  StringUtils::encodeHex(""));
+  EXPECT_EQ("", StringUtils::encodeHex(""));
 
-  EXPECT_EQ("00",  StringUtils::encodeHex(std::string("\x00", 1)));
-  EXPECT_EQ("01",  StringUtils::encodeHex("\x01"));
-  EXPECT_EQ("02",  StringUtils::encodeHex("\x02"));
-  EXPECT_EQ("03",  StringUtils::encodeHex("\x03"));
-  EXPECT_EQ("04",  StringUtils::encodeHex("\x04"));
-  EXPECT_EQ("05",  StringUtils::encodeHex("\x05"));
-  EXPECT_EQ("06",  StringUtils::encodeHex("\x06"));
-  EXPECT_EQ("07",  StringUtils::encodeHex("\x07"));
-  EXPECT_EQ("08",  StringUtils::encodeHex("\x08"));
-  EXPECT_EQ("09",  StringUtils::encodeHex("\x09"));
-  EXPECT_EQ("0a",  StringUtils::encodeHex("\x0a"));
-  EXPECT_EQ("0b",  StringUtils::encodeHex("\x0b"));
-  EXPECT_EQ("0c",  StringUtils::encodeHex("\x0c"));
-  EXPECT_EQ("0d",  StringUtils::encodeHex("\x0d"));
-  EXPECT_EQ("0e",  StringUtils::encodeHex("\x0e"));
-  EXPECT_EQ("0f",  StringUtils::encodeHex("\x0f"));
+  EXPECT_EQ("00", StringUtils::encodeHex(std::string("\x00", 1)));
+  EXPECT_EQ("01", StringUtils::encodeHex("\x01"));
+  EXPECT_EQ("02", StringUtils::encodeHex("\x02"));
+  EXPECT_EQ("03", StringUtils::encodeHex("\x03"));
+  EXPECT_EQ("04", StringUtils::encodeHex("\x04"));
+  EXPECT_EQ("05", StringUtils::encodeHex("\x05"));
+  EXPECT_EQ("06", StringUtils::encodeHex("\x06"));
+  EXPECT_EQ("07", StringUtils::encodeHex("\x07"));
+  EXPECT_EQ("08", StringUtils::encodeHex("\x08"));
+  EXPECT_EQ("09", StringUtils::encodeHex("\x09"));
+  EXPECT_EQ("0a", StringUtils::encodeHex("\x0a"));
+  EXPECT_EQ("0b", StringUtils::encodeHex("\x0b"));
+  EXPECT_EQ("0c", StringUtils::encodeHex("\x0c"));
+  EXPECT_EQ("0d", StringUtils::encodeHex("\x0d"));
+  EXPECT_EQ("0e", StringUtils::encodeHex("\x0e"));
+  EXPECT_EQ("0f", StringUtils::encodeHex("\x0f"));
 
-  EXPECT_EQ("10",  StringUtils::encodeHex("\x10"));
-  EXPECT_EQ("42",  StringUtils::encodeHex("\x42"));
-  EXPECT_EQ("ff",  StringUtils::encodeHex("\xff"));
-  EXPECT_EQ("aa0009",  StringUtils::encodeHex(std::string("\xaa\x00\x09", 3)));
-  EXPECT_EQ("000102",  StringUtils::encodeHex(std::string("\x00\x01\x02", 3)));
-  EXPECT_EQ("00010203",  StringUtils::encodeHex(std::string("\x00\x01\x02\03", 4)));
-  EXPECT_EQ("20",  StringUtils::encodeHex(" "));
-  EXPECT_EQ("2a2a",  StringUtils::encodeHex("**"));
-  EXPECT_EQ("616263646566",  StringUtils::encodeHex("abcdef"));
-  EXPECT_EQ("4142434445462047",  StringUtils::encodeHex("ABCDEF G"));
-  EXPECT_EQ("54686520517569636b2062726f776e20466f78206a756d706564206f76657220746865206c617a7920646f6721",  StringUtils::encodeHex("The Quick brown Fox jumped over the lazy dog!"));
-  EXPECT_EQ("446572204bc3b674c3b67220737072c3bc6e6720c3bc62657220646965204272c3bc636b65",  StringUtils::encodeHex("Der Kötör sprüng über die Brücke"));
+  EXPECT_EQ("10", StringUtils::encodeHex("\x10"));
+  EXPECT_EQ("42", StringUtils::encodeHex("\x42"));
+  EXPECT_EQ("ff", StringUtils::encodeHex("\xff"));
+  EXPECT_EQ("aa0009", StringUtils::encodeHex(std::string("\xaa\x00\x09", 3)));
+  EXPECT_EQ("000102", StringUtils::encodeHex(std::string("\x00\x01\x02", 3)));
+  EXPECT_EQ("00010203", StringUtils::encodeHex(std::string("\x00\x01\x02\03", 4)));
+  EXPECT_EQ("20", StringUtils::encodeHex(" "));
+  EXPECT_EQ("2a2a", StringUtils::encodeHex("**"));
+  EXPECT_EQ("616263646566", StringUtils::encodeHex("abcdef"));
+  EXPECT_EQ("4142434445462047", StringUtils::encodeHex("ABCDEF G"));
+  EXPECT_EQ("54686520517569636b2062726f776e20466f78206a756d706564206f76657220746865206c617a7920646f6721", StringUtils::encodeHex("The Quick brown Fox jumped over the lazy dog!"));
+  EXPECT_EQ("446572204bc3b674c3b67220737072c3bc6e6720c3bc62657220646965204272c3bc636b65", StringUtils::encodeHex("Der Kötör sprüng über die Brücke"));
   EXPECT_EQ("c3a4c3b6c3bcc39fc384c396c39ce282acc2b5", StringUtils::encodeHex("äöüßÄÖÜ€µ"));
 }
 
 TEST_F(StringUtilsTest, test_decodeHex) {
-  EXPECT_EQ("",  StringUtils::decodeHex(""));
+  EXPECT_EQ("", StringUtils::decodeHex(""));
 
-  EXPECT_EQ(std::string("\x00", 1),  StringUtils::decodeHex("00"));
-  EXPECT_EQ("\x01",  StringUtils::decodeHex("01"));
-  EXPECT_EQ("\x02",  StringUtils::decodeHex("02"));
-  EXPECT_EQ("\x03",  StringUtils::decodeHex("03"));
-  EXPECT_EQ("\x04",  StringUtils::decodeHex("04"));
-  EXPECT_EQ("\x05",  StringUtils::decodeHex("05"));
-  EXPECT_EQ("\x06",  StringUtils::decodeHex("06"));
-  EXPECT_EQ("\x07",  StringUtils::decodeHex("07"));
-  EXPECT_EQ("\x08",  StringUtils::decodeHex("08"));
-  EXPECT_EQ("\x09",  StringUtils::decodeHex("09"));
-  EXPECT_EQ("\x0a",  StringUtils::decodeHex("0a"));
-  EXPECT_EQ("\x0b",  StringUtils::decodeHex("0b"));
-  EXPECT_EQ("\x0c",  StringUtils::decodeHex("0c"));
-  EXPECT_EQ("\x0d",  StringUtils::decodeHex("0d"));
-  EXPECT_EQ("\x0e",  StringUtils::decodeHex("0e"));
-  EXPECT_EQ("\x0f",  StringUtils::decodeHex("0f"));
-  EXPECT_EQ("\x0a",  StringUtils::decodeHex("0A"));
-  EXPECT_EQ("\x0b",  StringUtils::decodeHex("0B"));
-  EXPECT_EQ("\x0c",  StringUtils::decodeHex("0C"));
-  EXPECT_EQ("\x0d",  StringUtils::decodeHex("0D"));
-  EXPECT_EQ("\x0e",  StringUtils::decodeHex("0E"));
-  EXPECT_EQ("\x0f",  StringUtils::decodeHex("0F"));
+  EXPECT_EQ(std::string("\x00", 1), StringUtils::decodeHex("00"));
+  EXPECT_EQ("\x01", StringUtils::decodeHex("01"));
+  EXPECT_EQ("\x02", StringUtils::decodeHex("02"));
+  EXPECT_EQ("\x03", StringUtils::decodeHex("03"));
+  EXPECT_EQ("\x04", StringUtils::decodeHex("04"));
+  EXPECT_EQ("\x05", StringUtils::decodeHex("05"));
+  EXPECT_EQ("\x06", StringUtils::decodeHex("06"));
+  EXPECT_EQ("\x07", StringUtils::decodeHex("07"));
+  EXPECT_EQ("\x08", StringUtils::decodeHex("08"));
+  EXPECT_EQ("\x09", StringUtils::decodeHex("09"));
+  EXPECT_EQ("\x0a", StringUtils::decodeHex("0a"));
+  EXPECT_EQ("\x0b", StringUtils::decodeHex("0b"));
+  EXPECT_EQ("\x0c", StringUtils::decodeHex("0c"));
+  EXPECT_EQ("\x0d", StringUtils::decodeHex("0d"));
+  EXPECT_EQ("\x0e", StringUtils::decodeHex("0e"));
+  EXPECT_EQ("\x0f", StringUtils::decodeHex("0f"));
+  EXPECT_EQ("\x0a", StringUtils::decodeHex("0A"));
+  EXPECT_EQ("\x0b", StringUtils::decodeHex("0B"));
+  EXPECT_EQ("\x0c", StringUtils::decodeHex("0C"));
+  EXPECT_EQ("\x0d", StringUtils::decodeHex("0D"));
+  EXPECT_EQ("\x0e", StringUtils::decodeHex("0E"));
+  EXPECT_EQ("\x0f", StringUtils::decodeHex("0F"));
+ 
+  EXPECT_EQ("\x1a", StringUtils::decodeHex("1a"));
+  EXPECT_EQ("\x2b", StringUtils::decodeHex("2b"));
+  EXPECT_EQ("\x3c", StringUtils::decodeHex("3c"));
+  EXPECT_EQ("\x4d", StringUtils::decodeHex("4d"));
+  EXPECT_EQ("\x5e", StringUtils::decodeHex("5e"));
+  EXPECT_EQ("\x6f", StringUtils::decodeHex("6f"));
+  EXPECT_EQ("\x7a", StringUtils::decodeHex("7A"));
+  EXPECT_EQ("\x8b", StringUtils::decodeHex("8B"));
+  EXPECT_EQ("\x9c", StringUtils::decodeHex("9C"));
+  EXPECT_EQ("\xad", StringUtils::decodeHex("AD"));
+  EXPECT_EQ("\xbe", StringUtils::decodeHex("BE"));
+  EXPECT_EQ("\xcf", StringUtils::decodeHex("CF"));
+  EXPECT_EQ("\xdf", StringUtils::decodeHex("df"));
+  EXPECT_EQ("\xef", StringUtils::decodeHex("eF"));
+  EXPECT_EQ("\xff", StringUtils::decodeHex("ff"));
   
-  EXPECT_EQ("\x1a",  StringUtils::decodeHex("1a"));
-  EXPECT_EQ("\x2b",  StringUtils::decodeHex("2b"));
-  EXPECT_EQ("\x3c",  StringUtils::decodeHex("3c"));
-  EXPECT_EQ("\x4d",  StringUtils::decodeHex("4d"));
-  EXPECT_EQ("\x5e",  StringUtils::decodeHex("5e"));
-  EXPECT_EQ("\x6f",  StringUtils::decodeHex("6f"));
-  EXPECT_EQ("\x7a",  StringUtils::decodeHex("7A"));
-  EXPECT_EQ("\x8b",  StringUtils::decodeHex("8B"));
-  EXPECT_EQ("\x9c",  StringUtils::decodeHex("9C"));
-  EXPECT_EQ("\xad",  StringUtils::decodeHex("AD"));
-  EXPECT_EQ("\xbe",  StringUtils::decodeHex("BE"));
-  EXPECT_EQ("\xcf",  StringUtils::decodeHex("CF"));
-  EXPECT_EQ("\xdf",  StringUtils::decodeHex("df"));
-  EXPECT_EQ("\xef",  StringUtils::decodeHex("eF"));
-  EXPECT_EQ("\xff",  StringUtils::decodeHex("ff"));
-  
-  EXPECT_EQ(" ",  StringUtils::decodeHex("20"));
-  EXPECT_EQ("**",  StringUtils::decodeHex("2a2a"));
-  EXPECT_EQ("abcdef",  StringUtils::decodeHex("616263646566"));
+  EXPECT_EQ(" ", StringUtils::decodeHex("20"));
+  EXPECT_EQ("**", StringUtils::decodeHex("2a2a"));
+  EXPECT_EQ("abcdef", StringUtils::decodeHex("616263646566"));
   EXPECT_EQ("ABCDEF G", StringUtils::decodeHex("4142434445462047"));
 
   EXPECT_EQ("The Quick brown Fox jumped over the lazy dog!", StringUtils::decodeHex("54686520517569636b2062726f776e20466f78206a756d706564206f76657220746865206c617a7920646f6721"));
   EXPECT_EQ("Der Kötör sprüng über die Brücke", StringUtils::decodeHex("446572204bc3b674c3b67220737072c3bc6e6720c3bc62657220646965204272c3bc636b65"));
   EXPECT_EQ("äöüßÄÖÜ€µ", StringUtils::decodeHex("c3a4c3b6c3bcc39fc384c396c39ce282acc2b5"));
   
-  EXPECT_EQ("",  StringUtils::decodeHex("1"));
-  EXPECT_EQ("",  StringUtils::decodeHex(" "));
-  EXPECT_EQ("",  StringUtils::decodeHex(" 2"));
-  EXPECT_EQ("",  StringUtils::decodeHex("1 "));
-  EXPECT_EQ("",  StringUtils::decodeHex("12 "));
-  EXPECT_EQ("",  StringUtils::decodeHex("x"));
-  EXPECT_EQ("",  StringUtils::decodeHex("X"));
-  EXPECT_EQ("",  StringUtils::decodeHex("@@@"));
-  EXPECT_EQ("",  StringUtils::decodeHex("111"));
-  EXPECT_EQ("",  StringUtils::decodeHex("1 2 3"));
-  EXPECT_EQ("",  StringUtils::decodeHex("1122334"));
-  EXPECT_EQ("",  StringUtils::decodeHex("112233 "));
-  EXPECT_EQ("",  StringUtils::decodeHex(" 112233"));
-  EXPECT_EQ("",  StringUtils::decodeHex("abcdefgh"));
+  EXPECT_EQ("", StringUtils::decodeHex("1"));
+  EXPECT_EQ("", StringUtils::decodeHex(" "));
+  EXPECT_EQ("", StringUtils::decodeHex(" 2"));
+  EXPECT_EQ("", StringUtils::decodeHex("1 "));
+  EXPECT_EQ("", StringUtils::decodeHex("12 "));
+  EXPECT_EQ("", StringUtils::decodeHex("x"));
+  EXPECT_EQ("", StringUtils::decodeHex("X"));
+  EXPECT_EQ("", StringUtils::decodeHex("@@@"));
+  EXPECT_EQ("", StringUtils::decodeHex("111"));
+  EXPECT_EQ("", StringUtils::decodeHex("1 2 3"));
+  EXPECT_EQ("", StringUtils::decodeHex("1122334"));
+  EXPECT_EQ("", StringUtils::decodeHex("112233 "));
+  EXPECT_EQ("", StringUtils::decodeHex(" 112233"));
+  EXPECT_EQ("", StringUtils::decodeHex("abcdefgh"));
+}
+
+TEST_F(StringUtilsTest, test_encodeURLComponent) {
+  EXPECT_EQ("", StringUtils::encodeURIComponent(""));
+  EXPECT_EQ("%20", StringUtils::encodeURIComponent(" "));
+  EXPECT_EQ("%25", StringUtils::encodeURIComponent("%"));
+  EXPECT_EQ("abc", StringUtils::encodeURIComponent("abc"));
+  EXPECT_EQ("abc%20abc", StringUtils::encodeURIComponent("abc abc"));
+  EXPECT_EQ(".!%3A%24%25%40b013%2F-", StringUtils::encodeURIComponent(".!:$%@b013/-"));
+  
+  std::string result;
+
+  StringUtils::encodeURIComponent(result, "", 0);
+  EXPECT_EQ("", result); 
+
+  StringUtils::encodeURIComponent(result, " ", 1);
+  EXPECT_EQ("%20", result);
+
+  StringUtils::encodeURIComponent(result, "%", 1);
+  EXPECT_EQ("%20%25", result);
+
+  StringUtils::encodeURIComponent(result, "abc", 3);
+  EXPECT_EQ("%20%25abc", result);
+  
+  StringUtils::encodeURIComponent(result, "abc abc", 7);
+  EXPECT_EQ("%20%25abcabc%20abc", result);
+  
+  StringUtils::encodeURIComponent(result, ".!:$%@b013/-", 12);
+  EXPECT_EQ("%20%25abcabc%20abc.!%3A%24%25%40b013%2F-", result);
 }


### PR DESCRIPTION
### Scope & Purpose

Fix cluster-internal replication of documents with special keys (containing the percent character, which has a special meaning when used inside URLs).

Cluster-internal replication of such documents did not work when only a single document was replicated, as the document key was used in a URL without URI-encoding.

This got unearthed by PR https://github.com/arangodb/arangodb/pull/13177, which will also put this under test.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.7, 3.6

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *https://github.com/arangodb/arangodb/pull/13177*.
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new C++ **Unit tests**: test cases for encodeURIComponent
  
Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13157/