### PR TITLE
try to exclude assertion branches from coverage

### DIFF
--- a/lib/ApplicationFeatures/GreetingsFeature.cpp
+++ b/lib/ApplicationFeatures/GreetingsFeature.cpp
@@ -61,9 +61,9 @@ void GreetingsFeature::prepare() {
   // cppcheck-suppress knownConditionTrueFalse
   if (warn) {
     LOG_TOPIC("0458b", WARN, arangodb::Logger::FIXME)
-      << "This is a maintainer version intended for debugging. DO NOT USE IN PRODUCTION!";
+      << "🥑 This is a maintainer version intended for debugging. DO NOT USE IN PRODUCTION! 🔥";
     LOG_TOPIC("bd666", WARN, arangodb::Logger::FIXME)
-      << "==============================================================================";
+      << "===================================================================================";
 
   }
 }

--- a/lib/Basics/CrashHandler.cpp
+++ b/lib/Basics/CrashHandler.cpp
@@ -185,7 +185,7 @@ void appendAddress(unw_word_t pc, long base, char*& dst) {
 size_t buildLogMessage(char* s, char const* context, int signal, siginfo_t const* info, void* ucontext) {
   // build a crash message
   char* p = s;
-  appendNullTerminatedString("ArangoDB ", p);
+  appendNullTerminatedString("💥 ArangoDB ", p);
   appendNullTerminatedString(ARANGODB_VERSION_FULL, p);
   appendNullTerminatedString(", thread ", p);
   p += arangodb::basics::StringUtils::itoa(uint64_t(arangodb::Thread::currentThreadNumber()), p);
@@ -315,6 +315,18 @@ void logBacktrace(char const* context, int signal, siginfo_t* info, void* uconte
           break;
         }
 
+        if (frame == maxFrames + skipFrames) {
+          memset(&buffer[0], 0, sizeof(buffer));
+          p = &buffer[0];
+          appendNullTerminatedString("..reached maximum frame display depth (", p);
+          p += arangodb::basics::StringUtils::itoa(uint64_t(maxFrames), p);
+          appendNullTerminatedString("). stopping backtrace", p);
+
+          length = p - &buffer[0];
+          LOG_TOPIC("bbb04", INFO, arangodb::Logger::CRASH) << arangodb::Logger::CHARS(&buffer[0], length);
+          break;
+        }
+
         if (frame >= skipFrames) {
           // this is a stack frame we want to display
           memset(&buffer[0], 0, sizeof(buffer));
@@ -359,7 +371,7 @@ void logBacktrace(char const* context, int signal, siginfo_t* info, void* uconte
           length = p - &buffer[0];
           LOG_TOPIC("308c3", INFO, arangodb::Logger::CRASH) << arangodb::Logger::CHARS(&buffer[0], length);
         }
-      } while (++frame < (maxFrames + skipFrames) && unw_step(&cursor) > 0);
+      } while (++frame < (maxFrames + skipFrames + 1) && unw_step(&cursor) > 0);
       // flush logs as early as possible
       arangodb::Logger::flush();
     }

--- a/lib/Basics/debugging.h
+++ b/lib/Basics/debugging.h
@@ -223,14 +223,15 @@ enable_if_t<is_container<T>::value, std::ostream&> operator<<(std::ostream& o, T
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 
-#define TRI_ASSERT(expr)                                                               \
+#define TRI_ASSERT(expr) /*GCOVR_EXCL_LINE*/                                           \
   if (!(ADB_LIKELY(expr))) {                                                           \
     arangodb::CrashHandler::assertionFailure(__FILE__, __LINE__, __FUNCTION__, #expr); \
   } else {}
 
 #else
 
-#define TRI_ASSERT(expr) while (false) { (void)(expr); }
+#define TRI_ASSERT(expr) /*GCOVR_EXCL_LINE*/                                           \
+  while (false) { (void)(expr); }
 
 #endif  // #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 


### PR DESCRIPTION
### Scope & Purpose

Try to exclude assertion branches from code coverage. 
The assertions have a true branch and a false branch, but only one of them is executed during our coverage tests. The not-taken branch would raise an assertion failure and crash the server, thus we don't expect it to be executed under normal conditions. But we also do not want to count this as a non-executed branch.

This needs dedicated testing with the code coverage Jenkins job.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13162/