### PR TITLE
Bug fix 3.6/jemalloc cmake

### DIFF
--- a/3rdParty/CMakeLists.txt
+++ b/3rdParty/CMakeLists.txt
@@ -44,8 +44,9 @@ add_subdirectory(${SNAPPY_SOURCE_DIR} EXCLUDE_FROM_ALL)
 
 if (USE_JEMALLOC)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/jemalloc)
-  include_directories(SYSTEM "${JEMALLOC_HOME}/include")
-  link_directories("${JEMALLOC_HOME}/lib")
+  include_directories(SYSTEM "${JEMALLOC_HOME}/include") # for rocksdb
+  link_directories("${JEMALLOC_HOME}/lib") # for rocksdb
+  set(JEMALLOC_INCLUDE_DIR "${JEMALLOC_HOME}/include" PARENT_SCOPE)
   set(SYS_LIBS ${SYS_LIBS} ${JEMALLOC_LIB} PARENT_SCOPE)
 endif ()
 
@@ -55,7 +56,6 @@ endif ()
 
 option(USE_PRECOMPILED_V8 "use a precompiled V8" OFF)
 
-
 set(V8_VERSION
   "7.1.302.28"
   CACHE INTERNAL
@@ -64,8 +64,8 @@ set(V8_VERSION
   )
 set(V8_SUB_DIR "v${V8_VERSION}")
 set(V8_VERSION ${V8_VERSION} PARENT_SCOPE)
-if (USE_PRECOMPILED_V8)
 
+if (USE_PRECOMPILED_V8)
   set(V8_DIR ${PROJECT_SOURCE_DIR}/build/3rdParty/V8/${V8_SUB_DIR})
   set(V8_SRC_DIR ${PROJECT_SOURCE_DIR}/3rdParty/V8/${V8_SUB_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -873,20 +873,6 @@ endfunction()
 # CREATE_FLAGS(IMPLICIT_CXX_INCLUDES "${CMAKE_CXX_SYSROOT_FLAG} " ${CMAKE_OSX_SYSROOT})
 
 # ------------------------------------------------------------------------------
-# JEMALLOC
-# ------------------------------------------------------------------------------
-
-option(USE_JEMALLOC_PROF "use jemalloc profiler" OFF)
-
-if (USE_JEMALLOC)
-  add_definitions("-DARANGODB_HAVE_JEMALLOC=1")
-endif ()
-
-if (USE_JEMALLOC_PROF)
-  add_definitions("-DUSE_MEMORY_PROFILE=1")
-endif ()
-
-# ------------------------------------------------------------------------------
 # NDEBUG
 # ------------------------------------------------------------------------------
 
@@ -1171,6 +1157,21 @@ include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/3rdParty/rocksdb/${ARANGO_ROCKS
 include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/3rdParty/s2geometry/${ARANGO_S2GEOMETRY_VERSION}/src)
 include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/3rdParty/rocksdb/${ARANGO_ROCKSDB_VERSION})
 include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/3rdParty/date/include)
+
+# ------------------------------------------------------------------------------
+# JEMALLOC
+# ------------------------------------------------------------------------------
+
+option(USE_JEMALLOC_PROF "use jemalloc profiler" OFF)
+
+if (USE_JEMALLOC)
+  add_definitions("-DARANGODB_HAVE_JEMALLOC=1")
+  include_directories(SYSTEM ${JEMALLOC_INCLUDE_DIR})
+endif ()
+
+if (USE_JEMALLOC_PROF)
+  add_definitions("-DUSE_MEMORY_PROFILE=1")
+endif ()
 
 # ------------------------------------------------------------------------------
 # RocksDB


### PR DESCRIPTION
This bug-fix adjust the jemalloc include path, which was not propagate to the arangod build.