### PR TITLE
bug-fix/make-arangosearch-tests-deterministic

### DIFF
--- a/tests/IResearch/IResearchLink-test.cpp
+++ b/tests/IResearch/IResearchLink-test.cpp
@@ -1373,6 +1373,16 @@ TEST_F(IResearchLinkTest, test_maintenance_disabled_at_creation) {
     cv.notify_one();
   };
 
+  {
+    // assume 10s is more than enough to finish initialization tasks
+    auto const end = std::chrono::steady_clock::now() + 10s;
+    while (std::get<0>(feature.stats(ThreadGroup::_0)) ||
+           std::get<0>(feature.stats(ThreadGroup::_1))) {
+      std::this_thread::sleep_for(10ms);
+      ASSERT_LE(std::chrono::steady_clock::now(), end);
+    }
+  }
+
   ASSERT_EQ(std::make_tuple(size_t(0), size_t(0), size_t(1)),
             feature.stats(ThreadGroup::_0));
   ASSERT_EQ(std::make_tuple(size_t(0), size_t(0), size_t(1)),
@@ -1465,6 +1475,16 @@ TEST_F(IResearchLinkTest, test_maintenance_consolidation) {
       ASSERT_LE(step, expectedStep);
     }
   };
+
+  {
+    // assume 10s is more than enough to finish initialization tasks
+    auto const end = std::chrono::steady_clock::now() + 10s;
+    while (std::get<0>(feature.stats(ThreadGroup::_0)) ||
+           std::get<0>(feature.stats(ThreadGroup::_1))) {
+      std::this_thread::sleep_for(10ms);
+      ASSERT_LE(std::chrono::steady_clock::now(), end);
+    }
+  }
 
   ASSERT_EQ(std::make_tuple(size_t(0), size_t(0), size_t(1)),
             feature.stats(ThreadGroup::_0));
@@ -1682,6 +1702,16 @@ TEST_F(IResearchLinkTest, test_maintenance_commit) {
       ASSERT_LE(step, expectedStep);
     }
   };
+
+  {
+    // assume 10s is more than enough to finish initialization tasks
+    auto const end = std::chrono::steady_clock::now() + 10s;
+    while (std::get<0>(feature.stats(ThreadGroup::_0)) ||
+           std::get<0>(feature.stats(ThreadGroup::_1))) {
+      std::this_thread::sleep_for(10ms);
+      ASSERT_LE(std::chrono::steady_clock::now(), end);
+    }
+  }
 
   ASSERT_EQ(std::make_tuple(size_t(0), size_t(0), size_t(1)),
             feature.stats(ThreadGroup::_0));


### PR DESCRIPTION
### Scope & Purpose

Adjust some arangosearch tests to be more deterministic

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:
http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/13203/

### Documentation

> All new features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the CHANGELOG so that
> support, end users, and other developers have a concise overview. 

- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
