### PR TITLE
add a more effective test for parallel traversals

### DIFF
--- a/arangod/Aql/MutexExecutor.cpp
+++ b/arangod/Aql/MutexExecutor.cpp
@@ -32,6 +32,8 @@
 #include "Aql/OutputAqlItemRow.h"
 #include "Aql/SharedQueryState.h"
 #include "Aql/Stats.h"
+#include "Basics/Exceptions.h"
+#include "Basics/debugging.h"
 
 #include "Logger/LogMacros.h"
 
@@ -52,6 +54,11 @@ MutexExecutor::MutexExecutor(MutexExecutorInfos const& infos)
 auto MutexExecutor::distributeBlock(SharedAqlItemBlockPtr block, SkipResult skipped,
                                     std::unordered_map<std::string, ClientBlockData>& blockMap)
     -> void {
+
+  TRI_IF_FAILURE("MutexExecutor::distributeBlock") {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
+  }
+
   if (block != nullptr) {
     std::unordered_map<std::string, std::vector<std::size_t>> choosenMap;
     choosenMap.reserve(blockMap.size());

--- a/arangod/V8Server/v8-actions.cpp
+++ b/arangod/V8Server/v8-actions.cpp
@@ -1845,17 +1845,17 @@ void TRI_InitV8ServerUtils(v8::Isolate* isolate) {
                                TRI_V8_ASCII_STRING(isolate, "SYS_IS_FOXX_STORE_DISABLED"), JS_IsFoxxStoreDisabled, true);
   TRI_AddGlobalFunctionVocbase(isolate,
                                TRI_V8_ASCII_STRING(isolate, "SYS_RUN_IN_RESTRICTED_CONTEXT"), JS_RunInRestrictedContext, true);
+  
+  TRI_AddGlobalFunctionVocbase(isolate,
+                               TRI_V8_ASCII_STRING(isolate,
+                                                   "SYS_CREATE_HOTBACKUP"),
+                               JS_CreateHotbackup);
 
   // debugging functions
   TRI_AddGlobalFunctionVocbase(isolate,
                                TRI_V8_ASCII_STRING(isolate,
                                                    "SYS_DEBUG_CLEAR_FAILAT"),
                                JS_DebugClearFailAt);
-
-  TRI_AddGlobalFunctionVocbase(isolate,
-                               TRI_V8_ASCII_STRING(isolate,
-                                                   "SYS_CREATE_HOTBACKUP"),
-                               JS_CreateHotbackup);
 
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
   TRI_AddGlobalFunctionVocbase(


### PR DESCRIPTION
### Scope & Purpose

As we can't check query execution plans for traversal parallelization, this now adds a failure point that is only triggered during parallel execution. That way the tests have an unambiguous way to tell if traversal parallelism was applied or not.

Community part of https://github.com/arangodb/enterprise/pull/603

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.7

#### Related Information

- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/603

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13214
