### PR TITLE
work around a potential issue found in `restart` test suite

### DIFF
--- a/tests/js/client/restart/test-foxx-selfheal-cluster.js
+++ b/tests/js/client/restart/test-foxx-selfheal-cluster.js
@@ -40,6 +40,9 @@ const path = require('path');
 const FoxxManager = require('@arangodb/foxx/manager');
 const basePath = path.resolve(require("internal").pathForTesting('common'), 'test-data', 'apps', 'perdb1');
 
+const originalEndpoint = arango.getEndpoint();
+const originalUser = arango.connectedUser();
+
 function testSuite() {
   const jwtSecret = 'haxxmann';
 
@@ -109,6 +112,7 @@ function testSuite() {
     },
 
     tearDown : function() {
+      arango.reconnect(originalEndpoint, "_system", originalUser, "");
       // make sure self heal has run, otherwise we may not be able to uninstall
       let res = arango.POST(`/_admin/execute`, "require('@arangodb/foxx/manager').healAll(); return 1");
       assertEqual("1", res);
@@ -173,6 +177,7 @@ function testSuite() {
       }
       
       // make sure self heal has run, otherwise we may not be able to access the app
+      arango.reconnect(originalEndpoint, "_system", originalUser, "");
       let res = arango.POST(`/_admin/execute`, "require('@arangodb/foxx/manager').healAll(); return 1");
       assertEqual("1", res);
         
@@ -215,6 +220,7 @@ function testSuite() {
       waitForAlive(30, coordinator.url, {});
       
       // make sure self heal has run 
+      arango.reconnect(originalEndpoint, "_system", originalUser, "");
       let res = arango.POST(`/_admin/execute`, "require('@arangodb/foxx/manager').healAll(); return 1");
       assertEqual("1", res);
 


### PR DESCRIPTION
### Scope & Purpose

The `restart` suite seems to fail with connection errors on Windows.
This is potentially due to arangosh/fuerte not playing nice with connections that are established to a server that is shut down and then restarted.
This PR is an attempt to work around this issue. It may fix the problem in the tests, or it may not.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.6

### Testing & Verification

- [x] This change is already covered by existing tests, such as *restart*.

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13241/