### PR TITLE
Memoize hash for group values in HashedCollectExecutor.

### DIFF
--- a/arangod/Aql/AqlValueGroup.cpp
+++ b/arangod/Aql/AqlValueGroup.cpp
@@ -37,7 +37,9 @@ AqlValueGroupHash::AqlValueGroupHash([[maybe_unused]] size_t num)
 size_t AqlValueGroupHash::operator()(const std::vector<AqlValue>& value) const {
   uint64_t hash = 0x12345678;
 
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   TRI_ASSERT(value.size() == _num);
+#endif
 
   for (AqlValue const& it : value) {
     // we must use the slow hash function here, because a value may have

--- a/arangod/Aql/AqlValueGroup.cpp
+++ b/arangod/Aql/AqlValueGroup.cpp
@@ -28,8 +28,11 @@
 using namespace arangodb;
 using namespace arangodb::aql;
 
-AqlValueGroupHash::AqlValueGroupHash(size_t num)
-    : _num(num) {}
+AqlValueGroupHash::AqlValueGroupHash([[maybe_unused]] size_t num)
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    : _num(num)
+#endif
+{}
 
 size_t AqlValueGroupHash::operator()(const std::vector<AqlValue>& value) const {
   uint64_t hash = 0x12345678;
@@ -49,6 +52,11 @@ size_t AqlValueGroupHash::operator()(const std::vector<AqlValue>& value) const {
 size_t AqlValueGroupHash::operator()(AqlValue const& value) const {
   uint64_t hash = 0x12345678;
   return value.hash(hash);
+}
+
+size_t AqlValueGroupHash::operator()(HashedAqlValueGroup const& value) const noexcept {
+  TRI_ASSERT(operator()(value.values) == value.hash);
+  return value.hash;
 }
 
 AqlValueGroupEqual::AqlValueGroupEqual(velocypack::Options const* opts)
@@ -71,4 +79,13 @@ bool AqlValueGroupEqual::operator()(const std::vector<AqlValue>& lhs,
 
 bool AqlValueGroupEqual::operator()(AqlValue const& lhs, AqlValue const& rhs) const {
   return AqlValue::Compare(_vpackOptions, lhs, rhs, false) == 0;
+}
+
+bool AqlValueGroupEqual::operator()(HashedAqlValueGroup const& lhs, HashedAqlValueGroup const& rhs) const {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  AqlValueGroupHash hasher(lhs.values.size());
+  TRI_ASSERT(hasher(lhs.values) == lhs.hash);
+  TRI_ASSERT(hasher(rhs.values) == rhs.hash);
+#endif
+  return lhs.hash == rhs.hash && operator()(lhs.values, rhs.values);
 }

--- a/arangod/Aql/AqlValueGroup.h
+++ b/arangod/Aql/AqlValueGroup.h
@@ -34,14 +34,24 @@ struct Options;
 
 namespace aql {
 
+using AqlValueGroup = std::vector<AqlValue>;
+
+struct HashedAqlValueGroup {
+  size_t hash;
+  AqlValueGroup values;
+};
+
 /// @brief hasher for a vector of AQL values
 struct AqlValueGroupHash {
   explicit AqlValueGroupHash(size_t num);
 
   size_t operator()(std::vector<AqlValue> const& value) const;
   size_t operator()(AqlValue const& value) const;
+  size_t operator()(HashedAqlValueGroup const& value) const noexcept;
 
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   size_t const _num;
+#endif
 };
 
 /// @brief comparator for a vector of AQL values
@@ -50,6 +60,7 @@ struct AqlValueGroupEqual {
 
   bool operator()(std::vector<AqlValue> const& lhs, std::vector<AqlValue> const& rhs) const;
   bool operator()(AqlValue const& lhs, AqlValue const& rhs) const;
+  bool operator()(HashedAqlValueGroup const& lhs, HashedAqlValueGroup const& rhs) const;
 
   velocypack::Options const* _vpackOptions;
 };

--- a/arangod/Aql/AqlValueGroup.h
+++ b/arangod/Aql/AqlValueGroup.h
@@ -37,7 +37,7 @@ namespace aql {
 using AqlValueGroup = std::vector<AqlValue>;
 
 struct HashedAqlValueGroup {
-  size_t hash;
+  size_t hash{0};
   AqlValueGroup values;
 };
 

--- a/arangod/Aql/HashedCollectExecutor.h
+++ b/arangod/Aql/HashedCollectExecutor.h
@@ -162,7 +162,7 @@ class HashedCollectExecutor {
    private:
     std::size_t _size;
   };
-  using GroupKeyType = std::vector<AqlValue>;
+  using GroupKeyType = HashedAqlValueGroup;
   using GroupValueType = std::unique_ptr<ValueAggregators>;
   using GroupMapType =
       std::unordered_map<GroupKeyType, GroupValueType, AqlValueGroupHash, AqlValueGroupEqual>;
@@ -214,7 +214,7 @@ class HashedCollectExecutor {
 
   std::vector<Aggregator::Factory const*> _aggregatorFactories;
 
-  GroupKeyType _nextGroupValues;
+  GroupKeyType _nextGroup;
 
   size_t _returnedGroups = 0;
 };


### PR DESCRIPTION
### Scope & Purpose

`HashedCollectExecutor::findOrEmplaceGroup` first calls `find` and if we don't have a matching value we call `try_emplace`. In that case we have to calculate the hash twice (once for each function). On top of that, a rehash of the unordered_map has to recalculate the hashes of all entries. This can be quite expensive, especially for non-scalar values like lists or objects.

This PR introduces the `HashedAqlValueGroup` struct which holds a hash value in addition to the `AqlValue`s. This allows us to calculate the hash only once and store it in the struct. Since we already use our own `Hash` type for the unordered-map, we can simply extend it to return the memoized hash value. In addition to that, we can also make use of the memoized hash value in the `KeyEqual` comparer to short-circuit if the hashes do not match. 

I have tested this with the following script:
```
queries = {
  group1: "FOR i IN 1..500 FOR j IN 1..300 COLLECT a = i, b = j SORT NULL RETURN {a,b}",
  group2: "FOR p IN 1..10000 FOR i IN 1..10 FOR j IN 1..10 COLLECT a = i, b = j SORT NULL RETURN {a,b}",
  group3: "FOR i IN 1..10 FOR j IN 1..10 FOR p IN 1..10000 COLLECT a = i, b = j SORT NULL RETURN {a,b}",
  group4: "FOR i IN 1..100 FOR j IN 1..100 LET x = 1..i*10 LET y = 1..j*10 COLLECT a = x, b = y SORT NULL RETURN {a,b}",
}

for (var k in queries) {
  console.log(k);
  let total = 0;
  let rounds = 10;
  for (var i = 0; i < rounds; ++i) {
    let start = new Date().getTime();
    db._query(queries[k], null, {silent: true}).toArray().length;
    let diff = new Date().getTime() - start;
    total += diff;
    console.log(diff);
  }
  console.log(total / rounds);
}
```
which resulted in the following speedups on my machine:
```
  group1: 7,98%
  group2: 2,12%
  group3: 3,34%
  group4: 22,54%
```

Note: there are a few assertions to ensure that the hash value of the struct is set correctly, so in maintainer mode the performance can actually be worse than before.

- [x] :fire: Performance improvement

#### Backports:

- [x] No backports required

### Testing & Verification

*(Please pick either of the following options)*

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13276/