### PR TITLE
Sort followerinfo in maintainermode right

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fixed a bug in maintainer mode sorting followerinfo lists the wrong way.
+
 * Fixed issue #13238 Thread naming API on Windows are now used only if
   available in KERNEL32.DLL
 

--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -313,6 +313,16 @@ bool FollowerInfo::updateFailoverCandidates() {
     std::set_symmetric_difference(failoverCandidates.begin(),
                                   failoverCandidates.end(), followers.begin(),
                                   followers.end(), std::back_inserter(diff));
+    if (!diff.empty()) {
+      std::stringstream s;
+      s << "Symmetric difference alert: ";
+      for (auto const& d : diff) { s << d << " "; }
+      s << "failoverCandidates: ";
+      for (auto const& d : failoverCandidates) { s << d << " "; }
+      s << "followers: ";
+      for (auto const& d : followers) { s << d << " "; }
+      LOG_DEVEL << s.str();
+    }
     TRI_ASSERT(diff.empty());
 #endif
     return _canWrite;
@@ -332,6 +342,16 @@ bool FollowerInfo::updateFailoverCandidates() {
   std::set_symmetric_difference(failoverCandidates.begin(),
                                 failoverCandidates.end(), followers.begin(),
                                 followers.end(), std::back_inserter(diff));
+  if (!diff.empty()) {
+    std::stringstream s;
+    s << "Symmetric difference alert: ";
+    for (auto const& d : diff) { s << d << " "; }
+    s << "failoverCandidates: ";
+    for (auto const& d : failoverCandidates) { s << d << " "; }
+    s << "followers: ";
+    for (auto const& d : followers) { s << d << " "; }
+    LOG_DEVEL << s.str();
+  }
   TRI_ASSERT(diff.empty());
 #endif
   Result res = persistInAgency(true);

--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -25,6 +25,7 @@
 #include "FollowerInfo.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Basics/ScopeGuard.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/MaintenanceStrings.h"
 #include "Cluster/ServerState.h"
@@ -33,11 +34,42 @@
 #include "Logger/LoggerStream.h"
 #include "VocBase/LogicalCollection.h"
 
-#include "Basics/ScopeGuard.h"
-
 using namespace arangodb;
 
-static std::string inline reportName(bool isRemove) {
+namespace {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+// compare the two vectors for equality, regardless of the order
+// of their items. will trigger an assertion failure in maintainer mode
+// if the vector elements are not identical
+void checkDifference(std::vector<ServerID> const& followers,
+                     std::vector<ServerID> const& failoverCandidates) {
+  // intentionally copy the vectors here, as we don't want to modify the originals
+  auto followersCopy = followers;
+  auto failoverCandidatesCopy = failoverCandidates;
+  std::sort(failoverCandidatesCopy.begin(), failoverCandidatesCopy.end());
+  std::sort(followersCopy.begin(), followersCopy.end());
+  
+  std::vector<std::string> diff;
+  std::set_symmetric_difference(failoverCandidatesCopy.begin(),
+                                failoverCandidatesCopy.end(), 
+                                followersCopy.begin(),
+                                followersCopy.end(), 
+                                std::back_inserter(diff));
+  if (!diff.empty()) {
+    std::stringstream s;
+    s << "Symmetric difference alert: ";
+    for (auto const& d : diff) { s << d << " "; }
+    s << "failoverCandidates: ";
+    for (auto const& d : failoverCandidates) { s << d << " "; }
+    s << "followers: ";
+    for (auto const& d : followers) { s << d << " "; }
+    LOG_DEVEL << s.str();
+  }
+  TRI_ASSERT(diff.empty());
+}
+#endif
+
+char const* reportName(bool isRemove) {
   if (isRemove) {
     return "FollowerInfo::remove";
   } else {
@@ -45,29 +77,31 @@ static std::string inline reportName(bool isRemove) {
   }
 }
 
-static std::string CurrentShardPath(arangodb::LogicalCollection const& col) {
+std::string currentShardPath(arangodb::LogicalCollection const& col) {
   // Agency path is
   //   Current/Collections/<dbName>/<collectionID>/<shardID>
   return "Current/Collections/" + col.vocbase().name() + "/" +
          std::to_string(col.planId().id()) + "/" + col.name();
 }
 
-static VPackSlice CurrentShardEntry(arangodb::LogicalCollection const& col, VPackSlice current) {
+VPackSlice currentShardEntry(arangodb::LogicalCollection const& col, VPackSlice current) {
   return current.get(std::vector<std::string>(
       {AgencyCommHelper::path(), "Current", "Collections", col.vocbase().name(),
        std::to_string(col.planId().id()), col.name()}));
 }
 
-static std::string PlanShardPath(arangodb::LogicalCollection const& col) {
+std::string planShardPath(arangodb::LogicalCollection const& col) {
   return "Plan/Collections/" + col.vocbase().name() + "/" +
          std::to_string(col.planId().id()) + "/shards/" + col.name();
 }
 
-static VPackSlice PlanShardEntry(arangodb::LogicalCollection const& col, VPackSlice plan) {
+VPackSlice planShardEntry(arangodb::LogicalCollection const& col, VPackSlice plan) {
   return plan.get(std::vector<std::string>(
       {AgencyCommHelper::path(), "Plan", "Collections", col.vocbase().name(),
        std::to_string(col.planId().id()), "shards", col.name()}));
 }
+
+} // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief add a follower to a shard, this is only done by the server side
@@ -305,25 +339,7 @@ bool FollowerInfo::updateFailoverCandidates() {
 // All followers can return as soon as the lock is released
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     TRI_ASSERT(_failoverCandidates->size() == _followers->size());
-    std::vector<std::string> diff;
-    auto followers = *_followers;
-    auto failoverCandidates = *_failoverCandidates;
-    std::sort(failoverCandidates.begin(), failoverCandidates.end(), std::less<std::string>());
-    std::sort(followers.begin(), followers.end(), std::greater<std::string>());
-    std::set_symmetric_difference(failoverCandidates.begin(),
-                                  failoverCandidates.end(), followers.begin(),
-                                  followers.end(), std::back_inserter(diff));
-    if (!diff.empty()) {
-      std::stringstream s;
-      s << "Symmetric difference alert: ";
-      for (auto const& d : diff) { s << d << " "; }
-      s << "failoverCandidates: ";
-      for (auto const& d : failoverCandidates) { s << d << " "; }
-      s << "followers: ";
-      for (auto const& d : followers) { s << d << " "; }
-      LOG_DEVEL << s.str();
-    }
-    TRI_ASSERT(diff.empty());
+    checkDifference(*_followers, *_failoverCandidates);
 #endif
     return _canWrite;
   }
@@ -334,25 +350,7 @@ bool FollowerInfo::updateFailoverCandidates() {
   TRI_ASSERT(_failoverCandidates.get() != _followers.get());
   TRI_ASSERT(_failoverCandidates->size() == _followers->size());
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-  std::vector<std::string> diff;
-  auto followers = *_followers;
-  auto failoverCandidates = *_failoverCandidates;
-  std::sort(failoverCandidates.begin(), failoverCandidates.end(), std::less<std::string>());
-  std::sort(followers.begin(), followers.end(), std::greater<std::string>());
-  std::set_symmetric_difference(failoverCandidates.begin(),
-                                failoverCandidates.end(), followers.begin(),
-                                followers.end(), std::back_inserter(diff));
-  if (!diff.empty()) {
-    std::stringstream s;
-    s << "Symmetric difference alert: ";
-    for (auto const& d : diff) { s << d << " "; }
-    s << "failoverCandidates: ";
-    for (auto const& d : failoverCandidates) { s << d << " "; }
-    s << "followers: ";
-    for (auto const& d : followers) { s << d << " "; }
-    LOG_DEVEL << s.str();
-  }
-  TRI_ASSERT(diff.empty());
+  checkDifference(*_followers, *_failoverCandidates);
 #endif
   Result res = persistInAgency(true);
   if (!res.ok()) {
@@ -375,8 +373,8 @@ bool FollowerInfo::updateFailoverCandidates() {
 Result FollowerInfo::persistInAgency(bool isRemove) const {
   // Now tell the agency
   TRI_ASSERT(_docColl != nullptr);
-  std::string curPath = CurrentShardPath(*_docColl);
-  std::string planPath = PlanShardPath(*_docColl);
+  std::string curPath = ::currentShardPath(*_docColl);
+  std::string planPath = ::planShardPath(*_docColl);
   AgencyComm ac(_docColl->vocbase().server());
   int badCurrentCount = 0;
   using namespace std::chrono_literals;
@@ -393,12 +391,12 @@ Result FollowerInfo::persistInAgency(bool isRemove) const {
       TRI_ASSERT(res.slice().isArray() && res.slice().length() == 1);
       VPackSlice resSlice = res.slice()[0];
       // Let's look at the results, note that both can be None!
-      velocypack::Slice planEntry = PlanShardEntry(*_docColl, resSlice);
-      velocypack::Slice currentEntry = CurrentShardEntry(*_docColl, resSlice);
+      velocypack::Slice planEntry = ::planShardEntry(*_docColl, resSlice);
+      velocypack::Slice currentEntry = ::currentShardEntry(*_docColl, resSlice);
 
       if (!currentEntry.isObject()) {
         LOG_TOPIC("01896", ERR, Logger::CLUSTER)
-            << reportName(isRemove) << ", did not find object in " << curPath;
+            << ::reportName(isRemove) << ", did not find object in " << curPath;
         if (!currentEntry.isNone()) {
           LOG_TOPIC("57c84", ERR, Logger::CLUSTER) << "Found: " << currentEntry.toJson();
         }
@@ -416,7 +414,7 @@ Result FollowerInfo::persistInAgency(bool isRemove) const {
             !(planEntry[0].isEqualString(ServerState::instance()->getId()) ||
               planEntry[0].isEqualString("_" + ServerState::instance()->getId()))) {
           LOG_TOPIC("42231", INFO, Logger::CLUSTER)
-              << reportName(isRemove)
+              << ::reportName(isRemove)
               << ", did not find myself in Plan: " << _docColl->vocbase().name()
               << "/" << std::to_string(_docColl->planId().id())
               << " (can happen when the leader changed recently).";
@@ -443,7 +441,7 @@ Result FollowerInfo::persistInAgency(bool isRemove) const {
       }
     } else {
       LOG_TOPIC("b7333", WARN, Logger::CLUSTER)
-          << reportName(isRemove) << ", could not read " << planPath << " and "
+          << ::reportName(isRemove) << ", could not read " << planPath << " and "
           << curPath << " in agency.";
     }
 

--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -308,7 +308,7 @@ bool FollowerInfo::updateFailoverCandidates() {
     std::vector<std::string> diff;
     auto followers = *_followers;
     auto failoverCandidates = *_failoverCandidates;
-    std::sort(failoverCandidates.begin(), failoverCandidates.end(), std::greater<std::string>());
+    std::sort(failoverCandidates.begin(), failoverCandidates.end(), std::less<std::string>());
     std::sort(followers.begin(), followers.end(), std::greater<std::string>());
     std::set_symmetric_difference(failoverCandidates.begin(),
                                   failoverCandidates.end(), followers.begin(),
@@ -327,7 +327,7 @@ bool FollowerInfo::updateFailoverCandidates() {
   std::vector<std::string> diff;
   auto followers = *_followers;
   auto failoverCandidates = *_failoverCandidates;
-  std::sort(failoverCandidates.begin(), failoverCandidates.end(), std::greater<std::string>());
+  std::sort(failoverCandidates.begin(), failoverCandidates.end(), std::less<std::string>());
   std::sort(followers.begin(), followers.end(), std::greater<std::string>());
   std::set_symmetric_difference(failoverCandidates.begin(),
                                 failoverCandidates.end(), followers.begin(),


### PR DESCRIPTION
This fixes the sort order in maintainer mode for the sorting of
followerinfo lists. This is a trivial change.

