### PR TITLE
Added "startupTime", "computationTime" and "storageTime" to Pregel result statistics

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Added "startupTime", "computationTime" and "storageTime" to Pregel result
+  statistics.
+
 * Limit value of `--rocksdb.block-cache-size` to 1 GB for agent instances to
   reduce agency RAM usage, unless configured otherwise. In addition, limit the 
   value of `--rocksdb.total-write-buffer-size` to 512 MB on agent instances for

--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -745,13 +745,15 @@ void Conductor::finishedWorkerFinalize(VPackSlice data) {
 
   double compTime = _finalizationStartTimeSecs - _computationStartTimeSecs;
   TRI_ASSERT(compTime >= 0);
-  double storeTime = TRI_microtime() - _finalizationStartTimeSecs;
+  if (didStore) {
+    _storeTimeSecs = TRI_microtime() - _finalizationStartTimeSecs;
+  }
 
   LOG_TOPIC("063b5", INFO, Logger::PREGEL) << "Done. We did " << _globalSuperstep << " rounds";
   LOG_TOPIC("3cfa8", INFO, Logger::PREGEL)
       << "Startup Time: " << _computationStartTimeSecs - _startTimeSecs << "s";
-  LOG_TOPIC("d43cb", INFO, Logger::PREGEL) << "Computation Time: " << compTime << "s";
-  LOG_TOPIC_IF("74e05", INFO, Logger::PREGEL, didStore) << "Storage Time: " << storeTime << "s";
+  LOG_TOPIC("d43cb", INFO, Logger::PREGEL) << "Computation time: " << compTime << "s";
+  LOG_TOPIC_IF("74e05", INFO, Logger::PREGEL, didStore) << "Storage time: " << _storeTimeSecs << "s";
   LOG_TOPIC("06f03", INFO, Logger::PREGEL) << "Overall: " << totalRuntimeSecs() << "s";
   LOG_TOPIC("03f2e", DEBUG, Logger::PREGEL) << "Stats: " << debugOut.toString();
 
@@ -809,6 +811,11 @@ VPackBuilder Conductor::toVelocyPack() const {
   result.add("state", VPackValue(pregel::ExecutionStateNames[_state]));
   result.add("gss", VPackValue(_globalSuperstep));
   result.add("totalRuntime", VPackValue(totalRuntimeSecs()));
+  result.add("startupTime", VPackValue(_computationStartTimeSecs - _startTimeSecs));
+  result.add("computationTime", VPackValue(_finalizationStartTimeSecs - _computationStartTimeSecs));
+  if (_storeTimeSecs > 0.0) {
+    result.add("storageTime", VPackValue(_storeTimeSecs));
+  }
   _aggregators->serializeValues(result);
   _statistics.serializeValues(result);
   if (_state != ExecutionState::RUNNING) {

--- a/arangod/Pregel/Conductor.h
+++ b/arangod/Pregel/Conductor.h
@@ -97,10 +97,11 @@ class Conductor {
   uint64_t _totalEdgesCount = 0;
   /// some tracking info
   double _startTimeSecs = 0;
-  double _computationStartTimeSecs = 0;
-  double _finalizationStartTimeSecs = 0;
-  double _endTimeSecs = 0;
-  double _stepStartTimeSecs = 0; // start time of current gss
+  double _computationStartTimeSecs = 0.0;
+  double _finalizationStartTimeSecs = 0.0;
+  double _storeTimeSecs = 0.0;
+  double _endTimeSecs = 0.0;
+  double _stepStartTimeSecs = 0.0; // start time of current gss
   Scheduler::WorkHandle _workHandle;
 
   bool _startGlobalStep();

--- a/tests/js/common/shell/shell-pregel.js
+++ b/tests/js/common/shell/shell-pregel.js
@@ -43,13 +43,21 @@ const vColl = "UnitTest_pregel_v", eColl = "UnitTest_pregel_e";
 function testAlgo(a, p) {
   let pid = pregel.start(a, graphName, p);
   assertTrue(typeof pid === "string");
-  var i = 10000;
+  let i = 10000;
   do {
     internal.sleep(0.2);
-    var stats = pregel.status(pid);
+    let stats = pregel.status(pid);
     if (stats.state !== "running") {
       assertEqual(stats.vertexCount, 11, stats);
       assertEqual(stats.edgeCount, 17, stats);
+      let attrs = ["totalRuntime", "startupTime", "computationTime"];
+      if (p.store) {
+        attrs.push("storageTime");
+      }
+      attrs.forEach((k) => {
+        assertTrue(stats.hasOwnProperty(k));
+        assertEqual("number", typeof stats[k]);
+      });
 
       db[vColl].all().toArray()
         .forEach(function (d) {


### PR DESCRIPTION
### Scope & Purpose

Added "startupTime", "computationTime" and "storageTime" to Pregel result statistics.
This makes the more detailed timings available as part of the Pregel job result, so it can be better understood how long the individual parts of a run took.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.7*

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13301/