### PR TITLE
add MockMetricsServer

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -218,6 +218,7 @@ set(ARANGODB_TESTS_SOURCES
   ${RCFILE}
   Metrics/MetricsTest.cpp
   Metrics/MetricsFeatureTest.cpp
+  Metrics/MetricsServerTest.cpp
   Network/ConnectionPoolTest.cpp
   Network/MethodsTest.cpp
   Network/UtilsTest.cpp

--- a/tests/Metrics/MetricsServerTest.cpp
+++ b/tests/Metrics/MetricsServerTest.cpp
@@ -1,0 +1,40 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2017-2018, ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "RestServer/MetricsFeature.h"
+#include "Mocks/Servers.h"
+
+using namespace arangodb;
+
+TEST(MetricsServerTest, test_setup) {
+  tests::mocks::MockMetricsServer server;
+  MetricsFeature& feature = server.getFeature<MetricsFeature>();
+
+  auto& counter = feature.counter("counter", 0, "one counter");
+  ASSERT_EQ(counter.load(), 0);
+  counter.count();
+  ASSERT_EQ(counter.load(), 1);
+}

--- a/tests/Metrics/MetricsTest.cpp
+++ b/tests/Metrics/MetricsTest.cpp
@@ -42,12 +42,7 @@ constexpr size_t numThreads = 4;
 constexpr uint64_t numOpsPerThread = 25 * 1000 * 1000;
 }
 
-class MetricsTest : public ::testing::Test {
-protected:
-  MetricsTest () {}
-};
-
-TEST_F(MetricsTest, test_counter_concurrency) {
+TEST(MetricsTest, test_counter_concurrency) {
   Counter c(0, "counter", "Counter");
 
   ASSERT_EQ(c.load(),  0);
@@ -77,7 +72,7 @@ TEST_F(MetricsTest, test_counter_concurrency) {
   ASSERT_EQ(c.load(), ::numThreads * ::numOpsPerThread);
 }
 
-TEST_F(MetricsTest, test_histogram_concurrency_same) {
+TEST(MetricsTest, test_histogram_concurrency_same) {
   lin_scale_t scale(1, 100, 4);
   Histogram h(scale, "histogram", "Histogram");
 
@@ -114,7 +109,7 @@ TEST_F(MetricsTest, test_histogram_concurrency_same) {
   ASSERT_EQ(h.load(3), 0);
 }
 
-TEST_F(MetricsTest, test_histogram_concurrency_distributed) {
+TEST(MetricsTest, test_histogram_concurrency_distributed) {
   lin_scale_t scale(1, 100, 4);
   Histogram h(scale, "histogram", "Histogram");
 
@@ -151,7 +146,7 @@ TEST_F(MetricsTest, test_histogram_concurrency_distributed) {
   ASSERT_EQ(h.load(3), (::numThreads > 3 ? (::numThreads - 3) : 0) * ::numOpsPerThread);
 }
 
-TEST_F(MetricsTest, test_histogram_simple) {
+TEST(MetricsTest, test_histogram_simple) {
   lin_scale_t scale(1, 100, 4);
   Histogram h(scale, "histogram", "Histogram");
 
@@ -234,7 +229,7 @@ TEST_F(MetricsTest, test_histogram_simple) {
 }
 
 
-TEST_F(MetricsTest, test_counter) {
+TEST(MetricsTest, test_counter) {
   Counter c(0, "counter_1", "Counter 1");
 
   ASSERT_EQ(c.load(),  0);
@@ -349,11 +344,11 @@ template<typename T> void gauge_test() {
   }
 }
 
-TEST_F(MetricsTest, test_gauge_double) {
+TEST(MetricsTest, test_gauge_double) {
   gauge_test<double>();
 }
 
-TEST_F(MetricsTest, test_gauge_float) {
+TEST(MetricsTest, test_gauge_float) {
   gauge_test<float>();
 }
 
@@ -412,61 +407,61 @@ template<typename Scale> void histogram_test(Scale const& scale) {
 }
 
 
-TEST_F(MetricsTest, test_double_histogram) {
+TEST(MetricsTest, test_double_histogram) {
   histogram_test(lin_scale_t( 1.,  2.,  9));
   histogram_test(lin_scale_t(-1.,  1., 10));
   histogram_test(lin_scale_t(-2., -1.,  8));
 }
-TEST_F(MetricsTest, test_float_histogram) {
+TEST(MetricsTest, test_float_histogram) {
   histogram_test(lin_scale_t( 1.f,  2.f,  9));
   histogram_test(lin_scale_t(-1.f,  1.f, 10));
   histogram_test(lin_scale_t(-2.f, -1.f,  8));
 }
 
-TEST_F(MetricsTest, test_short_histogram) {
+TEST(MetricsTest, test_short_histogram) {
   histogram_test(lin_scale_t<short>(-17, 349, 6));
   histogram_test(lin_scale_t<short>( 20,  40, 7));
   histogram_test(lin_scale_t<short>(-63, -11, 8));
 }
-TEST_F(MetricsTest, test_int_histogram) {
+TEST(MetricsTest, test_int_histogram) {
   histogram_test(lin_scale_t<int>(-17, 349, 6));
   histogram_test(lin_scale_t<int>( 20,  40, 7));
   histogram_test(lin_scale_t<int>(-63, -11, 8));
 }
 
-TEST_F(MetricsTest, test_double_log_10_histogram) {
+TEST(MetricsTest, test_double_log_10_histogram) {
   histogram_test(log_scale_t(10., 0.,  2000.,  5));
 }
-TEST_F(MetricsTest, test_float_log_10_histogram) {
+TEST(MetricsTest, test_float_log_10_histogram) {
   histogram_test(log_scale_t(10.f, 0.f,  2000.f,  5));
 }
-TEST_F(MetricsTest, test_double_log_2_histogram) {
+TEST(MetricsTest, test_double_log_2_histogram) {
   histogram_test(log_scale_t(2., 0.,  2000.,  10));
 }
-TEST_F(MetricsTest, test_float_log_2_histogram) {
+TEST(MetricsTest, test_float_log_2_histogram) {
   histogram_test(log_scale_t(2.f, 0.f,  2000.f,  10));
 }
-TEST_F(MetricsTest, test_double_log_e_histogram) {
+TEST(MetricsTest, test_double_log_e_histogram) {
   histogram_test(log_scale_t(std::exp(1.), 0.,  2000.,  10));
 }
-TEST_F(MetricsTest, test_float_log_e_histogram) {
+TEST(MetricsTest, test_float_log_e_histogram) {
   histogram_test(log_scale_t(std::exp(1.f), 0.f,  2000.f,  10));
 }
-TEST_F(MetricsTest, test_double_log_bin_histogram) {
+TEST(MetricsTest, test_double_log_bin_histogram) {
   histogram_test(log_scale_t(2., 0.,  128.,  8));
 }
-TEST_F(MetricsTest, test_float_log_bin_histogram) {
+TEST(MetricsTest, test_float_log_bin_histogram) {
   histogram_test(log_scale_t(2.f, 0.f,  128.f,  8));
 }
-TEST_F(MetricsTest, test_double_log_offset_histogram) {
+TEST(MetricsTest, test_double_log_offset_histogram) {
   histogram_test(log_scale_t(2., 0.,  128.,  8));
 }
-TEST_F(MetricsTest, test_float_log__histogram) {
+TEST(MetricsTest, test_float_log__histogram) {
   histogram_test(log_scale_t(2.f, 0.f,  128.f,  8));
 }
-TEST_F(MetricsTest, test_int64_log_bin_histogram) {
+TEST(MetricsTest, test_int64_log_bin_histogram) {
   histogram_test(log_scale_t<int64_t>(2, 50,  8000,  10));
 }
-TEST_F(MetricsTest, test_uint64_log_bin_histogram) {
+TEST(MetricsTest, test_uint64_log_bin_histogram) {
   histogram_test(log_scale_t<uint64_t>(2, 50, 8000, 10));
 }

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -302,6 +302,16 @@ TRI_vocbase_t& MockServer::getSystemDatabase() const {
   return *system;
 }
 
+MockMetricsServer::MockMetricsServer(bool start) : MockServer() {
+  // setup required application features
+  SetupGreetingsPhase(*this);
+  addFeature<arangodb::EngineSelectorFeature>(false);
+
+  if (start) {
+    startFeatures();
+  }
+}
+
 MockV8Server::MockV8Server(bool start) : MockServer() {
   // setup required application features
   SetupV8Phase(*this);

--- a/tests/Mocks/Servers.h
+++ b/tests/Mocks/Servers.h
@@ -54,6 +54,7 @@ class ApplicationFeature;
 namespace tests {
 namespace mocks {
 
+/// @brief mock application server with no features added
 class MockServer {
  public:
   MockServer();
@@ -110,6 +111,19 @@ class MockServer {
   bool _started;
 };
 
+/// @brief a server with almost no features added (Metrics are available
+/// though)
+class MockMetricsServer : public MockServer,
+                          public LogSuppressor<Logger::AUTHENTICATION, LogLevel::WARN>,
+                          public LogSuppressor<Logger::FIXME, LogLevel::ERR>,
+                          public LogSuppressor<iresearch::TOPIC, LogLevel::FATAL>,
+                          public IResearchLogSuppressor {
+ public:
+  MockMetricsServer(bool startFeatures = true);
+};
+
+/// @brief a server with features added that allow to execute V8 code
+/// and bindings
 class MockV8Server : public MockServer,
                      public LogSuppressor<Logger::AUTHENTICATION, LogLevel::WARN>,
                      public LogSuppressor<Logger::FIXME, LogLevel::ERR>,
@@ -119,6 +133,7 @@ class MockV8Server : public MockServer,
   MockV8Server(bool startFeatures = true);
 };
 
+/// @brief a server with features added that allow to execute AQL queries
 class MockAqlServer : public MockServer,
                       public LogSuppressor<Logger::AUTHENTICATION, LogLevel::WARN>,
                       public LogSuppressor<Logger::CLUSTER, LogLevel::ERR>,
@@ -133,6 +148,8 @@ class MockAqlServer : public MockServer,
   std::unique_ptr<arangodb::aql::Query> createFakeQuery(bool activateTracing = false, std::string queryString = "") const;
 };
 
+/// @brief a server with features added that allow to execute RestHandler
+/// code
 class MockRestServer : public MockServer,
                        public LogSuppressor<Logger::AUTHENTICATION, LogLevel::WARN>,
                        public LogSuppressor<Logger::FIXME, LogLevel::ERR>,


### PR DESCRIPTION
### Scope & Purpose

Add a `MockMetricsServer` for testing.
This is a very basic ApplicationServer with only the relevant features enabled for metrics to work.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new C++ **Unit tests**

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13317/