### PR TITLE
do not kill thread in case of exception

### DIFF
--- a/arangod/GeneralServer/IoContext.cpp
+++ b/arangod/GeneralServer/IoContext.cpp
@@ -25,6 +25,10 @@
 
 #include <thread>
 
+#include "Logger/LogMacros.h"
+#include "Logger/Logger.h"
+#include "Logger/LoggerStream.h"
+
 using namespace arangodb;
 using namespace arangodb::basics;
 using namespace arangodb::rest;
@@ -39,7 +43,12 @@ IoContext::IoThread::~IoThread() { shutdown(); }
 
 void IoContext::IoThread::run() {
   // run the asio io context
-  _iocontext.io_context.run();
+  try {
+    _iocontext.io_context.run();
+  } catch (std::exception const& ex) {
+    LOG_TOPIC("6794f", WARN, Logger::THREADS)
+      << "caught exception in IO thread: " << ex.what();
+  }
 }
 
 IoContext::IoContext(application_features::ApplicationServer& server)


### PR DESCRIPTION
Port of 3.5 change: do not delete thread in case of exception, catch and report the exception instead.