### PR TITLE
add agency-restart test suite

### DIFF
--- a/arangod/Agency/AgencyCommon.h
+++ b/arangod/Agency/AgencyCommon.h
@@ -130,6 +130,18 @@ struct log_t {
         clientId(clientId),
         timestamp(m) {}
 
+  void toVelocyPack(velocypack::Builder& builder) const {
+    builder.openObject();
+
+    builder.add("index", VPackValue(index));
+    builder.add("term", VPackValue(term));
+    builder.add("query", VPackSlice(entry->data()));
+    builder.add("clientId", VPackValue(clientId));
+    builder.add("timestamp", VPackValue(timestamp.count()));
+    
+    builder.close();
+  }
+
   friend std::ostream& operator<<(std::ostream& o, log_t const& l) {
     o << l.index << " " << l.term << " " << VPackSlice(l.entry->data()).toJson() << " "
       << " " << l.clientId << " " << l.timestamp.count();

--- a/arangod/Agency/AgencyFeature.cpp
+++ b/arangod/Agency/AgencyFeature.cpp
@@ -268,14 +268,16 @@ void AgencyFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
       {std::type_index(typeid(iresearch::IResearchFeature)),
        std::type_index(typeid(iresearch::IResearchAnalyzerFeature)),
        std::type_index(typeid(ActionFeature)),
-       std::type_index(typeid(ScriptFeature)), std::type_index(typeid(FoxxFeature)),
+       std::type_index(typeid(FoxxFeature)),
        std::type_index(typeid(FrontendFeature))});
 
-  if (!result.touched("console") || !*(options->get<BooleanParameter>("console")->ptr)) {
+  if ((!result.touched("console") || !*(options->get<BooleanParameter>("console")->ptr)) &&
+      (!result.touched("javascript.enabled") || !*(options->get<BooleanParameter>("javascript.enabled")->ptr))) {
     // specifying --console requires JavaScript, so we can only turn it off
     // if not specified
 
     // console mode inactive. so we can turn off V8
+    disabledFeatures.emplace_back(std::type_index(typeid(ScriptFeature)));
     disabledFeatures.emplace_back(std::type_index(typeid(V8PlatformFeature)));
     disabledFeatures.emplace_back(std::type_index(typeid(V8DealerFeature)));
   }

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -707,7 +707,7 @@ void Agent::sendAppendEntriesRPC() {
       size_t toLog = 0;
       index_t highest = 0;
       for (size_t i = 0; i < unconfirmed.size(); ++i) {
-        auto const& entry = unconfirmed.at(i);
+        auto const& entry = unconfirmed[i];
         if (entry.index > lastConfirmed) {
           // This condition is crucial, because usually we have one more
           // entry than we need in unconfirmed, so we want to skip this. If,
@@ -715,14 +715,7 @@ void Agent::sendAppendEntriesRPC() {
           // with the same index than the snapshot along to retain the
           // invariant of our data structure that the _log in _state is
           // non-empty.
-          {
-            VPackObjectBuilder o(&builder);
-            builder.add("index", VPackValue(entry.index));
-            builder.add("term", VPackValue(entry.term));
-            builder.add("query", VPackSlice(entry.entry->data()));
-            builder.add("clientId", VPackValue(entry.clientId));
-            builder.add("timestamp", VPackValue(entry.timestamp.count()));
-          }
+          entry.toVelocyPack(builder);
           highest = entry.index;
           ++toLog;
         }
@@ -1347,7 +1340,7 @@ write_ret_t Agent::write(query_t const& query, WriteMode const& wmode) {
   // to use leading() or _constituent.leading() here, but can simply
   // look at the leaderID.
   auto leader = _constituent.leaderID();
-  if ((!loaded() && wmode != WriteMode(true,true)) || (multihost && leader != id())) {
+  if ((!loaded() && wmode != WriteMode(true, true)) || (multihost && leader != id())) {
     ++_write_no_leader;
     return write_ret_t(false, leader);
   }

--- a/arangod/Agency/State.h
+++ b/arangod/Agency/State.h
@@ -81,7 +81,12 @@ class State {
   ///        Default: [first, last]
   std::vector<log_t> get(index_t = 0, index_t = (std::numeric_limits<uint64_t>::max)()) const;
 
+  /// @brief load a compacted snapshot, returns the number of entries read.
   uint64_t toVelocyPack(index_t lastIndex, VPackBuilder& builder) const;
+
+  /// @brief dump the entire in-memory state to velocypacj
+  /// should be used for testing only
+  void toVelocyPack(velocypack::Builder& builder) const;
 
  private:
   /// @brief Get complete log entries bound by lower and upper bounds.
@@ -244,8 +249,8 @@ class State {
   /// @brief Create collections
   bool createCollections();
 
-  /// @brief Create collection
-  bool createCollection(std::string const& name);
+  /// @brief Create collection if it does not yet exist
+  bool ensureCollection(std::string const& name);
 
   /// @brief Compact persisted logs
   bool compactPersisted(arangodb::consensus::index_t cind, arangodb::consensus::index_t keep);

--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -58,12 +58,18 @@ void checkDifference(std::vector<ServerID> const& followers,
   if (!diff.empty()) {
     std::stringstream s;
     s << "Symmetric difference alert: ";
-    for (auto const& d : diff) { s << d << " "; }
+    for (auto const& d : diff) { 
+      s << d << " "; 
+    }
     s << "failoverCandidates: ";
-    for (auto const& d : failoverCandidates) { s << d << " "; }
+    for (auto const& d : failoverCandidates) { 
+      s << d << " "; 
+    }
     s << "followers: ";
-    for (auto const& d : followers) { s << d << " "; }
-    LOG_DEVEL << s.str();
+    for (auto const& d : followers) { 
+      s << d << " "; 
+    }
+    LOG_TOPIC("9d8ec", ERR, Logger::CLUSTER) << s.str();
   }
   TRI_ASSERT(diff.empty());
 }

--- a/js/client/modules/@arangodb/testsuites/agency-restart.js
+++ b/js/client/modules/@arangodb/testsuites/agency-restart.js
@@ -1,0 +1,226 @@
+/* jshint strict: false, sub: true */
+/* global print */
+'use strict';
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2016 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2014 triagens GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+// / @author Max Neunhoeffer
+// //////////////////////////////////////////////////////////////////////////////
+
+const functionsDocumentation = {
+  'agency-restart': 'run recovery tests'
+};
+const optionsDocumentation = [
+];
+
+const fs = require('fs');
+const pu = require('@arangodb/testutils/process-utils');
+const tu = require('@arangodb/testutils/test-utils');
+const _ = require('lodash');
+
+const toArgv = require('internal').toArgv;
+
+const RED = require('internal').COLORS.COLOR_RED;
+const RESET = require('internal').COLORS.COLOR_RESET;
+const BLUE = require('internal').COLORS.COLOR_BLUE;
+
+const testPaths = {
+  'agency-restart': [tu.pathForTesting('server/agency-restart')]
+};
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief TEST: agency_restart
+// //////////////////////////////////////////////////////////////////////////////
+
+function runArangodRecovery (params) {
+  let additionalParams= {
+    'log.foreground-tty': 'true',
+    'javascript.enabled': 'true',
+    'agency.activate': 'true',
+    'agency.compaction-keep-size': '10000',
+    'agency.wait-for-sync': 'false',
+    'agency.size': '1',
+  };
+
+  let argv = [];
+
+  let binary = pu.ARANGOD_BIN;
+  let crashLogDir = fs.join(fs.getTempPath(), 'crash');
+  fs.makeDirectoryRecursive(crashLogDir);
+  pu.cleanupDBDirectoriesAppend(crashLogDir);
+
+  let crashLog = fs.join(crashLogDir, 'crash.log');
+
+  if (params.setup) {
+    additionalParams['javascript.script-parameter'] = 'setup';
+    try {
+      // clean up crash log before next test
+      fs.remove(crashLog);
+    } catch (err) {}
+
+
+    params.options.disableMonitor = true;
+    params.testDir = fs.join(params.tempDir, `${params.count}`);
+    pu.cleanupDBDirectoriesAppend(params.testDir);
+    let dataDir = fs.join(params.testDir, 'data');
+    let appDir = fs.join(params.testDir, 'app');
+    let tmpDir = fs.join(params.testDir, 'tmp');
+    fs.makeDirectoryRecursive(params.testDir);
+    fs.makeDirectoryRecursive(dataDir);
+    fs.makeDirectoryRecursive(tmpDir);
+    fs.makeDirectoryRecursive(appDir);
+
+    let args = pu.makeArgs.arangod(params.options, appDir, '', tmpDir);
+    // enable development debugging if extremeVerbosity is set
+    if (params.options.extremeVerbosity === true) {
+      args['log.level'] = 'development=info';
+    }
+    args = Object.assign(args, params.options.extraArgs);
+    args = Object.assign(args, {
+      'database.directory': fs.join(dataDir + 'db'),
+      'server.rest-server': 'false',
+      'javascript.script': params.script
+    });
+      
+    args['log.output'] = 'file://' + crashLog;
+    params.args = args;
+
+    argv = toArgv(Object.assign(params.args, additionalParams));
+  } else {
+    additionalParams['javascript.script-parameter'] = 'recory';
+    argv = toArgv(Object.assign(params.args, additionalParams));
+    
+    if (params.options.rr) {
+      binary = 'rr';
+      argv.unshift(pu.ARANGOD_BIN);
+    }
+  }
+    
+  process.env["crash-log"] = crashLog;
+  params.instanceInfo.pid = pu.executeAndWait(
+    binary,
+    argv,
+    params.options,
+    'recovery',
+    params.instanceInfo.rootDir,
+    !params.setup && params.options.coreCheck);
+}
+
+function agencyRestart (options) {
+  if (!global.ARANGODB_CLIENT_VERSION(true)['failure-tests'] ||
+      global.ARANGODB_CLIENT_VERSION(true)['failure-tests'] === 'false') {
+    return {
+      agencyRestart: {
+        status: false,
+        message: 'failure-tests not enabled. please recompile with -DUSE_FAILURE_TESTS=On'
+      },
+      status: false
+    };
+  }
+
+  let results = {
+    status: true
+  };
+
+  let agencyRestartTests = tu.splitBuckets(options, tu.scanTestPaths(testPaths['agency-restart'], options));
+  let count = 0;
+  let orgTmp = process.env.TMPDIR;
+  let tempDir = fs.join(fs.getTempPath(), 'agency-restart');
+  fs.makeDirectoryRecursive(tempDir);
+  process.env.TMPDIR = tempDir;
+  pu.cleanupDBDirectoriesAppend(tempDir);
+
+  for (let i = 0; i < agencyRestartTests.length; ++i) {
+    let test = agencyRestartTests[i];
+    let filtered = {};
+
+    if (tu.filterTestcaseByOptions(test, options, filtered)) {
+      count += 1;
+      ////////////////////////////////////////////////////////////////////////
+      print(BLUE + "running setup of test " + count + " - " + test + RESET);
+      let params = {
+        tempDir: tempDir,
+        instanceInfo: {
+          rootDir: fs.join(fs.getTempPath(), 'agency-restart', count.toString())
+        },
+        options: _.cloneDeep(options),
+        script: test,
+        setup: true,
+        count: count,
+        testDir: ""
+      };
+      runArangodRecovery(params);
+
+      ////////////////////////////////////////////////////////////////////////
+      print(BLUE + "running recovery of test " + count + " - " + test + RESET);
+      params.options.disableMonitor = options.disableMonitor;
+      params.setup = false;
+      try {
+        tu.writeTestResult(params.args['temp.path'], {
+          failed: 1,
+          status: false, 
+          message: "unable to run agency_restart test " + test,
+          duration: -1
+        });
+      } catch (er) {}
+      runArangodRecovery(params);
+
+      results[test] = tu.readTestResult(
+        params.args['temp.path'],
+        {
+          status: false
+        },
+        test
+      );
+      if (!results[test].status) {
+        print("Not cleaning up " + params.testDir);
+        results.status = false;
+      }
+      else {
+        pu.cleanupLastDirectory(params.options);
+      }
+    } else {
+      if (options.extremeVerbosity) {
+        print('Skipped ' + test + ' because of ' + filtered.filter);
+      }
+    }
+  }
+  process.env.TMPDIR = orgTmp;
+  if (count === 0) {
+    print(RED + 'No testcase matched the filter.' + RESET);
+    return {
+      ALLTESTS: {
+        status: true,
+        skipped: true
+      },
+      status: true
+    };
+  }
+
+  return results;
+}
+
+exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+  Object.assign(allTestPaths, testPaths);
+  testFns['agency-restart'] = agencyRestart;
+  for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
+  for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
+};

--- a/tests/js/server/agency-restart/few-writes.js
+++ b/tests/js/server/agency-restart/few-writes.js
@@ -1,0 +1,114 @@
+/* jshint globalstrict:false, strict:false, unused : false */
+/* global assertEqual, assertTrue, ArangoAgent */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief tests for dump/reload
+// /
+// / @file
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2010-2012 triagens GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// / @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+let db = require('@arangodb').db;
+let internal = require('internal');
+let jsunity = require('jsunity');
+
+function runSetup () {
+  'use strict';
+  internal.debugClearFailAt();
+  
+  db._drop('UnitTestsRecovery');
+  let c = db._create('UnitTestsRecovery');
+
+  // write 10 log entries, and then crash
+  for (let i = 0; i < 10; ++i) {
+    let request = {
+      ["arango/test" + i] : {
+        "op": "set",
+        "new": "testmann" + i
+      }
+    };
+        
+    ArangoAgent.write([[ request, {}, "testi"]]);
+  }
+  
+  // make sure everything is synced to disk before we crash
+  c.insert({ _key: "sync" }, true); // wait for sync 
+  
+  internal.debugTerminate('crashing server');
+}
+
+function recoverySuite () {
+  'use strict';
+  jsunity.jsUnity.attachAssertions();
+
+  return {
+    testRestart: function () {
+      let state = ArangoAgent.state();
+      assertEqual(0, state.current);
+      assertTrue(state.log.length > 10);
+      let start = 0;
+      let index = 0;
+      while (start < state.log.length) {
+        if (state.log[start].clientId === 'testi') {
+          index = state.log[start].index;
+          break;
+        }
+        ++start;
+      }
+
+      for (let i = 0; i < 10; ++i) {
+        let entry = state.log[start + i];
+        assertEqual("testi", entry.clientId);
+        let request = {
+          ["arango/test" + i] : {
+            "op": "set",
+            "new": "testmann" + i
+          }
+        };
+        assertEqual(request, entry.query);
+        assertEqual("number", typeof entry.timestamp);
+        assertEqual("number", typeof entry.term);
+        assertEqual("number", typeof entry.index);
+        assertEqual(index, entry.index);
+        ++index;
+      }
+      
+      for (let i = 0; i < 10; ++i) {
+        let r = ArangoAgent.read([["/arango/test" + i]]);
+        assertEqual([ { "arango": { ["test" + i] : "testmann" +i } } ], r); 
+      }
+    }
+
+  };
+}
+
+function main (argv) {
+  'use strict';
+  if (argv[1] === 'setup') {
+    runSetup();
+    return 0;
+  } else {
+    jsunity.run(recoverySuite);
+    return jsunity.writeDone().status ? 0 : 1;
+  }
+}

--- a/tests/js/server/agency-restart/many-writes.js
+++ b/tests/js/server/agency-restart/many-writes.js
@@ -1,0 +1,127 @@
+/* jshint globalstrict:false, strict:false, unused : false */
+/* global assertEqual, assertNotEqual, assertTrue, ArangoAgent */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief tests for dump/reload
+// /
+// / @file
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2010-2012 triagens GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// / @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+let db = require('@arangodb').db;
+let internal = require('internal');
+let jsunity = require('jsunity');
+
+function runSetup () {
+  'use strict';
+  internal.debugClearFailAt();
+  
+  db._drop('UnitTestsRecovery');
+  let c = db._create('UnitTestsRecovery');
+
+  // write 50k log entries, and then crash
+  for (let i = 0; i < 50000; ++i) {
+    let request = {
+      ["arango/test" + i] : {
+        "op": "set",
+        "new": "testmann" + i
+      }
+    };
+        
+    ArangoAgent.write([[ request, {}, "testi"]]);
+  }
+  
+  // wait until no more compactions occur
+  while (true) {
+    let numCompactions = db.compact.count();
+
+    let start = internal.time();
+    do {
+      internal.wait(0.25);
+      if (db.compact.count() !== numCompactions) {
+        break;
+      }
+    } while (internal.time() - start < 5);
+
+    if (db.compact.count() === numCompactions) {
+      break;
+    }
+  }
+  
+  // make sure everything is synced to disk before we crash
+  c.insert({ _key: "sync" }, true); // wait for sync 
+  
+  internal.debugTerminate('crashing server');
+}
+
+function recoverySuite () {
+  'use strict';
+  jsunity.jsUnity.attachAssertions();
+
+  return {
+    testRestart: function () {
+      let state = ArangoAgent.state();
+      assertNotEqual(0, state.current);
+      assertEqual(state.current, state.log[0].index);
+      let index = state.log[0].index;
+      for (let i = 0; i < state.log.length; ++i) {
+        let entry = state.log[i];
+        if (entry.clientId === 'testi') {
+          assertEqual("testi", entry.clientId);
+          let keys = Object.keys(entry.query);
+          assertEqual(1, keys.length);
+          assertTrue(keys[0].startsWith("arango/test"));
+          let request = {
+            [keys[0]] : {
+              "op": "set",
+              "new": "testmann" + keys[0].substr(- (keys[0].length - "arango/test".length))
+            }
+          };
+          assertEqual(request, entry.query);
+        }
+        assertEqual("number", typeof entry.timestamp);
+        assertEqual("number", typeof entry.term);
+        assertEqual("number", typeof entry.index);
+        assertEqual(index, entry.index);
+        ++index;
+      }
+      
+      for (let i = 0; i < 50000; ++i) {
+        let r = ArangoAgent.read([["/arango/test" + i]]);
+        assertEqual([ { "arango": { ["test" + i] : "testmann" +i } } ], r); 
+      }
+    }
+
+  };
+}
+
+function main (argv) {
+  'use strict';
+  if (argv[1] === 'setup') {
+    runSetup();
+    return 0;
+  } else {
+    jsunity.run(recoverySuite);
+    return jsunity.writeDone().status ? 0 : 1;
+  }
+}

--- a/tests/js/server/agency-restart/no-compact-collection.js
+++ b/tests/js/server/agency-restart/no-compact-collection.js
@@ -1,0 +1,109 @@
+/* jshint globalstrict:false, strict:false, unused : false */
+/* global assertEqual, ArangoAgent */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief tests for dump/reload
+// /
+// / @file
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2010-2012 triagens GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// / @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+let db = require('@arangodb').db;
+let internal = require('internal');
+let jsunity = require('jsunity');
+
+function runSetup () {
+  'use strict';
+  internal.debugClearFailAt();
+ 
+  db._drop('UnitTestsRecovery');
+  let c = db._create('UnitTestsRecovery');
+
+  // write 50k log entries, and then crash
+  for (let i = 0; i < 50000; ++i) {
+    let request = {
+      ["arango/test" + i] : {
+        "op": "set",
+        "new": "testmann" + i
+      }
+    };
+        
+    ArangoAgent.write([[ request, {}, "testi"]]);
+  }
+
+  // intentionally drop "compact" collection so it is
+  // not there at restart
+  db._drop("compact");
+  
+  // make sure everything is synced to disk before we crash
+  c.insert({ _key: "sync" }, true); // wait for sync 
+  
+  internal.debugTerminate('crashing server');
+}
+
+function recoverySuite () {
+  'use strict';
+  jsunity.jsUnity.attachAssertions();
+
+  return {
+    testRestart: function () {
+      let state = ArangoAgent.state();
+      assertEqual(0, state.current);
+      assertEqual(state.current, state.log[0].index);
+
+      // if the compaction collection does not exist, then
+      // it means all data will be wiped at startup
+      let index = state.log[0].index;
+      let found = 0;
+      for (let i = 0; i < state.log.length; ++i) {
+        let entry = state.log[i];
+        if (entry.clientId === 'testi') {
+          ++found;
+        }
+        assertEqual("number", typeof entry.timestamp);
+        assertEqual("number", typeof entry.term);
+        assertEqual("number", typeof entry.index);
+        assertEqual(index, entry.index);
+        ++index;
+      }
+      assertEqual(0, found);
+      
+      for (let i = 0; i < 50000; ++i) {
+        let r = ArangoAgent.read([["/arango/test" + i]]);
+        assertEqual([{}], r);
+      }
+    }
+
+  };
+}
+
+function main (argv) {
+  'use strict';
+  if (argv[1] === 'setup') {
+    runSetup();
+    return 0;
+  } else {
+    jsunity.run(recoverySuite);
+    return jsunity.writeDone().status ? 0 : 1;
+  }
+}

--- a/tests/js/server/agency-restart/no-compaction.js
+++ b/tests/js/server/agency-restart/no-compaction.js
@@ -1,0 +1,118 @@
+/* jshint globalstrict:false, strict:false, unused : false */
+/* global assertEqual, assertTrue, ArangoAgent */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief tests for dump/reload
+// /
+// / @file
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2010-2012 triagens GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// / @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+let db = require('@arangodb').db;
+let internal = require('internal');
+let jsunity = require('jsunity');
+
+function runSetup () {
+  'use strict';
+  internal.debugClearFailAt();
+ 
+  // turn off compaction
+  internal.debugSetFailAt("State::compact");
+  
+  db._drop('UnitTestsRecovery');
+  let c = db._create('UnitTestsRecovery');
+
+  // write 50k log entries, and then crash
+  for (let i = 0; i < 50000; ++i) {
+    let request = {
+      ["arango/test" + i] : {
+        "op": "set",
+        "new": "testmann" + i
+      }
+    };
+        
+    ArangoAgent.write([[ request, {}, "testi"]]);
+  }
+  
+  // make sure everything is synced to disk before we crash
+  c.insert({ _key: "sync" }, true); // wait for sync 
+  
+  internal.debugTerminate('crashing server');
+}
+
+function recoverySuite () {
+  'use strict';
+  jsunity.jsUnity.attachAssertions();
+
+  return {
+    testRestart: function () {
+      let state = ArangoAgent.state();
+      assertEqual(0, state.current);
+      assertEqual(state.current, state.log[0].index);
+      assertTrue(state.log.length >= 50000);
+
+      let found = 0;
+      let index = state.log[0].index;
+      for (let i = 0; i < state.log.length; ++i) {
+        let entry = state.log[i];
+        if (entry.clientId === 'testi') {
+          ++found;
+          assertEqual("testi", entry.clientId);
+          let keys = Object.keys(entry.query);
+          assertEqual(1, keys.length);
+          assertTrue(keys[0].startsWith("arango/test"));
+          let request = {
+            [keys[0]] : {
+              "op": "set",
+              "new": "testmann" + keys[0].substr(- (keys[0].length - "arango/test".length))
+            }
+          };
+          assertEqual(request, entry.query);
+        }
+        assertEqual("number", typeof entry.timestamp);
+        assertEqual("number", typeof entry.term);
+        assertEqual("number", typeof entry.index);
+        assertEqual(index, entry.index);
+        ++index;
+      }
+      assertTrue(found > 0);
+      
+      for (let i = 0; i < 50000; ++i) {
+        let r = ArangoAgent.read([["/arango/test" + i]]);
+        assertEqual([ { "arango": { ["test" + i] : "testmann" +i } } ], r); 
+      }
+    }
+
+  };
+}
+
+function main (argv) {
+  'use strict';
+  if (argv[1] === 'setup') {
+    runSetup();
+    return 0;
+  } else {
+    jsunity.run(recoverySuite);
+    return jsunity.writeDone().status ? 0 : 1;
+  }
+}

--- a/tests/js/server/agency-restart/no-log-collection.js
+++ b/tests/js/server/agency-restart/no-log-collection.js
@@ -1,0 +1,109 @@
+/* jshint globalstrict:false, strict:false, unused : false */
+/* global assertEqual, ArangoAgent */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief tests for dump/reload
+// /
+// / @file
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2010-2012 triagens GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// / @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+let db = require('@arangodb').db;
+let internal = require('internal');
+let jsunity = require('jsunity');
+
+function runSetup () {
+  'use strict';
+  internal.debugClearFailAt();
+ 
+  db._drop('UnitTestsRecovery');
+  let c = db._create('UnitTestsRecovery');
+
+  // write 50k log entries, and then crash
+  for (let i = 0; i < 50000; ++i) {
+    let request = {
+      ["arango/test" + i] : {
+        "op": "set",
+        "new": "testmann" + i
+      }
+    };
+        
+    ArangoAgent.write([[ request, {}, "testi"]]);
+  }
+
+  // intentionally drop "log" collection so it is
+  // not there at restart
+  db._drop("log");
+  
+  // make sure everything is synced to disk before we crash
+  c.insert({ _key: "sync" }, true); // wait for sync 
+  
+  internal.debugTerminate('crashing server');
+}
+
+function recoverySuite () {
+  'use strict';
+  jsunity.jsUnity.attachAssertions();
+
+  return {
+    testRestart: function () {
+      let state = ArangoAgent.state();
+      assertEqual(0, state.current);
+      assertEqual(state.current, state.log[0].index);
+
+      // if the log collection does not exist, then
+      // it means all data will be wiped at startup
+      let index = state.log[0].index;
+      let found = 0;
+      for (let i = 0; i < state.log.length; ++i) {
+        let entry = state.log[i];
+        if (entry.clientId === 'testi') {
+          ++found;
+        }
+        assertEqual("number", typeof entry.timestamp);
+        assertEqual("number", typeof entry.term);
+        assertEqual("number", typeof entry.index);
+        assertEqual(index, entry.index);
+        ++index;
+      }
+      assertEqual(0, found);
+      
+      for (let i = 0; i < 50000; ++i) {
+        let r = ArangoAgent.read([["/arango/test" + i]]);
+        assertEqual([{}], r);
+      }
+    }
+
+  };
+}
+
+function main (argv) {
+  'use strict';
+  if (argv[1] === 'setup') {
+    runSetup();
+    return 0;
+  } else {
+    jsunity.run(recoverySuite);
+    return jsunity.writeDone().status ? 0 : 1;
+  }
+}


### PR DESCRIPTION
### Scope & Purpose

Add `agency-restart` test suite.
This test suite contains tests that put specific data into a single-host agency, crash and then restart it. On restart, it is checked if the data still exists and is as expected.
As few simple tests are added with this PR initially, and this can be extended over time.

The two small issues fixed by this PR will be backported separately.

Also includes bugfixes for reading back `clientId` values from persistence and for handling restarts with gone `log` or `compact` collections.

Requires merging of https://github.com/arangodb/oskar/pull/282 in order to execute the new test suite automatically.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in agency-restart)

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13331/