### PR TITLE
add agency-restart tests to the blocklist

### DIFF
--- a/UnitTests/OskarTestSuitesBlackList
+++ b/UnitTests/OskarTestSuitesBlackList
@@ -9,3 +9,4 @@ shell_client_http2
 shell_client_aql_http2
 resilience_analyzers
 fuerte
+agency-restart


### PR DESCRIPTION
### Scope & Purpose

Add `agency-restart` test suite to the blocklist in this version, as the test suite is only available in devel.
This is required for merging https://github.com/arangodb/oskar/pull/282

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

