### PR TITLE
fix reloading "clientId" values from persistence

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+v3.6.11 (XXXX-XX-XX)
+--------------------
+
+* Fix recovery of "clientId" values in Agency when restarting an agent from
+  persistence.
+
+
 v3.6.10 (2020-12-08)
 --------------------
 

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -757,6 +757,11 @@ bool State::checkCollection(std::string const& name) {
 
 /// Create collection by name
 bool State::createCollection(std::string const& name) {
+  if (_vocbase->lookupCollection(name) != nullptr) {
+    // collection already exists. nothing to do
+    return true;
+  }
+  
   Builder body;
   {
     VPackObjectBuilder b(&body);
@@ -1066,8 +1071,8 @@ bool State::loadRemaining() {
       auto req = ii.get("request");
       tmp->append(req.startAs<char const>(), req.byteSize());
 
-      clientId = req.hasKey("clientId") ? req.get("clientId").copyString()
-                                        : std::string();
+      clientId = ii.hasKey("clientId") ? ii.get("clientId").copyString()
+                                       : std::string();
 
       // Dummy fill missing entries (Not good at all.)
       index_t index(StringUtils::uint64(ii.get(StaticStrings::KeyString).copyString()));


### PR DESCRIPTION
### Scope & Purpose

Fix recovery of "clientId" values in Agency when restarting an agent from persistence. 

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13336/