### PR TITLE
Prevent write during RocksDB recovery

### DIFF
--- a/arangod/RocksDBEngine/RocksDBUpgrade.cpp
+++ b/arangod/RocksDBEngine/RocksDBUpgrade.cpp
@@ -53,24 +53,24 @@ void arangodb::rocksdbStartupVersionCheck(rocksdb::TransactionDB* db, bool dbExi
   static_assert(std::is_same<char, std::underlying_type<RocksDBEndianness>::type>::value,
                 "RocksDBEndianness has wrong type");
 
-  // try to find version
-  char version = rocksDBFormatVersion();
+  // try to find version, using the version key
+  char const version = rocksDBFormatVersion();
   RocksDBKey versionKey, endianKey;
   versionKey.constructSettingsValue(RocksDBSettingsType::Version);
   endianKey.constructSettingsValue(RocksDBSettingsType::Endianness);
 
-  // read the co
-  rocksdb::PinnableSlice oldVersion;
-  rocksdb::Status s;
-  s = db->Get(rocksdb::ReadOptions(),
-              RocksDBColumnFamilyManager::get(RocksDBColumnFamilyManager::Family::Definitions),
-              versionKey.string(), &oldVersion);
-
   // default endianess for existing DBs
   RocksDBEndianness endianess = RocksDBEndianness::Invalid;
+
   if (dbExisted) {
+    rocksdb::PinnableSlice oldVersion;
+    rocksdb::Status s = db->Get(rocksdb::ReadOptions(),
+                                RocksDBColumnFamilyManager::get(RocksDBColumnFamilyManager::Family::Definitions),
+                                versionKey.string(), &oldVersion);
+    
     if (s.IsNotFound() || oldVersion.size() != 1) {
-      LOG_TOPIC("614d7", FATAL, Logger::ENGINES) << "Your db directory is invalid";
+      LOG_TOPIC("614d7", FATAL, Logger::ENGINES) 
+        << "Error reading stored version from database";
       FATAL_ERROR_EXIT();
     } else if (oldVersion.data()[0] < version) {
       // Performing 'upgrade' routine
@@ -78,16 +78,16 @@ void arangodb::rocksdbStartupVersionCheck(rocksdb::TransactionDB* db, bool dbExi
         endianess = RocksDBEndianness::Little;
       } else {
         LOG_TOPIC("c30ee", FATAL, Logger::ENGINES)
-            << "Your db directory is in an old "
+            << "Your database is in an old "
             << "format. Please downgrade the server, "
-            << "export & re-import your data.";
+            << "dump & restore the data";
         FATAL_ERROR_EXIT();
       }
 
     } else if (oldVersion.data()[0] > version) {
       LOG_TOPIC("c9009", FATAL, Logger::ENGINES)
           << "You are using an old version of ArangoDB, please update "
-          << "before opening this dir.";
+          << "before opening this database";
       FATAL_ERROR_EXIT();
     } else {
       TRI_ASSERT(oldVersion.data()[0] == version);
@@ -111,24 +111,35 @@ void arangodb::rocksdbStartupVersionCheck(rocksdb::TransactionDB* db, bool dbExi
     // new DBs are always created with Big endian data-format
     endianess = RocksDBEndianness::Big;
   }
+
   // enable correct key format
+  TRI_ASSERT(endianess == RocksDBEndianness::Little || endianess == RocksDBEndianness::Big);
   rocksutils::setRocksDBKeyFormatEndianess(endianess);
 
   if (!dbExisted) {
     // store endianess forever
-    const char endVal = static_cast<char>(endianess);
-    s = db->Put(rocksdb::WriteOptions(),
-                RocksDBColumnFamilyManager::get(RocksDBColumnFamilyManager::Family::Definitions),
-                endianKey.string(), rocksdb::Slice(&endVal, sizeof(char)));
+    TRI_ASSERT(endianess == RocksDBEndianness::Big);
+
+    char const endVal = static_cast<char>(endianess);
+    rocksdb::Status s = db->Put(rocksdb::WriteOptions(),
+                                RocksDBColumnFamilyManager::get(RocksDBColumnFamilyManager::Family::Definitions),
+                                endianKey.string(), rocksdb::Slice(&endVal, sizeof(char)));
+    if (s.ok()) {
+      // store current version
+      TRI_ASSERT(version == rocksDBFormatVersion());
+
+      s = db->Put(rocksdb::WriteOptions(),
+                  RocksDBColumnFamilyManager::get(RocksDBColumnFamilyManager::Family::Definitions),
+                  versionKey.string(), rocksdb::Slice(&version, sizeof(char)));
+    }
+
     if (!s.ok()) {
-      LOG_TOPIC("3d88b", FATAL, Logger::ENGINES) << "Error storing endianess";
+      LOG_TOPIC("3d88b", FATAL, Logger::ENGINES) 
+          << "Error storing endianess/version: " 
+          << rocksutils::convertStatus(s).errorMessage();
       FATAL_ERROR_EXIT();
     }
 
-    // store current version
-    s = db->Put(rocksdb::WriteOptions(),
-                RocksDBColumnFamilyManager::get(RocksDBColumnFamilyManager::Family::Definitions),
-                versionKey.string(), rocksdb::Slice(&version, sizeof(char)));
     TRI_ASSERT(s.ok());
   }
 }

--- a/arangod/RocksDBEngine/RocksDBUpgrade.cpp
+++ b/arangod/RocksDBEngine/RocksDBUpgrade.cpp
@@ -114,19 +114,21 @@ void arangodb::rocksdbStartupVersionCheck(rocksdb::TransactionDB* db, bool dbExi
   // enable correct key format
   rocksutils::setRocksDBKeyFormatEndianess(endianess);
 
-  // store endianess forever
-  const char endVal = static_cast<char>(endianess);
-  s = db->Put(rocksdb::WriteOptions(),
-              RocksDBColumnFamilyManager::get(RocksDBColumnFamilyManager::Family::Definitions),
-              endianKey.string(), rocksdb::Slice(&endVal, sizeof(char)));
-  if (!s.ok()) {
-    LOG_TOPIC("3d88b", FATAL, Logger::ENGINES) << "Error storing endianess";
-    FATAL_ERROR_EXIT();
-  }
+  if (!dbExisted) {
+    // store endianess forever
+    const char endVal = static_cast<char>(endianess);
+    s = db->Put(rocksdb::WriteOptions(),
+                RocksDBColumnFamilyManager::get(RocksDBColumnFamilyManager::Family::Definitions),
+                endianKey.string(), rocksdb::Slice(&endVal, sizeof(char)));
+    if (!s.ok()) {
+      LOG_TOPIC("3d88b", FATAL, Logger::ENGINES) << "Error storing endianess";
+      FATAL_ERROR_EXIT();
+    }
 
-  // store current version
-  s = db->Put(rocksdb::WriteOptions(),
-              RocksDBColumnFamilyManager::get(RocksDBColumnFamilyManager::Family::Definitions),
-              versionKey.string(), rocksdb::Slice(&version, sizeof(char)));
-  TRI_ASSERT(s.ok());
+    // store current version
+    s = db->Put(rocksdb::WriteOptions(),
+                RocksDBColumnFamilyManager::get(RocksDBColumnFamilyManager::Family::Definitions),
+                versionKey.string(), rocksdb::Slice(&version, sizeof(char)));
+    TRI_ASSERT(s.ok());
+  }
 }


### PR DESCRIPTION
### Scope & Purpose

Prevent a write to RocksDB during recovery in the case that the database already exists. If the database didn't already exist, it's okay to do the write. If it exists, we shouldn't write anything until after recovery has finished. Other than simply wanting to avoid writes during recovery for safety, we have also seen at least one case where a server shut down while in a write-stopped state, and on startup re-entered that write-stopped state; the write at startup then could not proceed, and the server was not able to proceed with recovery, start up, and serve health check requests.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [ ] Backports required for: 3.7, 3.6

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run: https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/13334/ (all blue)