### PR TITLE
Prevent write during RocksDB recovery

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.7.6 (XXXX-XX-XX)
 -------------------
 
+* Prevent a write to RocksDB during recovery in the case that the 
+  database already exists. The write at startup is potentially blocking,
+  and will delay the startup for servers that were stopped shut down while
+  in a write-stopped state.
+
 * Added "startupTime", "computationTime" and "storageTime" to Pregel result
   statistics.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@ v3.7.6 (XXXX-XX-XX)
 
 * Prevent a write to RocksDB during recovery in the case that the 
   database already exists. The write at startup is potentially blocking,
-  and will delay the startup for servers that were stopped shut down while
+  and will delay the startup for servers that were shut down while
   in a write-stopped state.
 
 * Added "startupTime", "computationTime" and "storageTime" to Pregel result

--- a/arangod/RocksDBEngine/RocksDBUpgrade.cpp
+++ b/arangod/RocksDBEngine/RocksDBUpgrade.cpp
@@ -52,23 +52,24 @@ void arangodb::rocksdbStartupVersionCheck(rocksdb::TransactionDB* db, bool dbExi
   static_assert(std::is_same<char, std::underlying_type<RocksDBEndianness>::type>::value,
                 "RocksDBEndianness has wrong type");
 
-  // try to find version
-  char version = rocksDBFormatVersion();
+  // try to find version, using the version key
+  char const version = rocksDBFormatVersion();
   RocksDBKey versionKey, endianKey;
   versionKey.constructSettingsValue(RocksDBSettingsType::Version);
   endianKey.constructSettingsValue(RocksDBSettingsType::Endianness);
 
-  // read the co
-  rocksdb::PinnableSlice oldVersion;
-  rocksdb::Status s;
-  s = db->Get(rocksdb::ReadOptions(), RocksDBColumnFamily::definitions(),
-              versionKey.string(), &oldVersion);
-
   // default endianess for existing DBs
   RocksDBEndianness endianess = RocksDBEndianness::Invalid;
+  
   if (dbExisted) {
+    rocksdb::PinnableSlice oldVersion;
+    rocksdb::Status s = db->Get(rocksdb::ReadOptions(),
+                                RocksDBColumnFamily::definitions(),
+                                versionKey.string(), &oldVersion);
+
     if (s.IsNotFound() || oldVersion.size() != 1) {
-      LOG_TOPIC("614d7", FATAL, Logger::ENGINES) << "Your db directory is invalid";
+      LOG_TOPIC("614d7", FATAL, Logger::ENGINES) 
+        << "Error reading stored version from database";
       FATAL_ERROR_EXIT();
     } else if (oldVersion.data()[0] < version) {
       // Performing 'upgrade' routine
@@ -76,16 +77,16 @@ void arangodb::rocksdbStartupVersionCheck(rocksdb::TransactionDB* db, bool dbExi
         endianess = RocksDBEndianness::Little;
       } else {
         LOG_TOPIC("c30ee", FATAL, Logger::ENGINES)
-            << "Your db directory is in an old "
+            << "Your database is in an old "
             << "format. Please downgrade the server, "
-            << "export & re-import your data.";
+            << "dump & restore the data";
         FATAL_ERROR_EXIT();
       }
 
     } else if (oldVersion.data()[0] > version) {
       LOG_TOPIC("c9009", FATAL, Logger::ENGINES)
           << "You are using an old version of ArangoDB, please update "
-          << "before opening this dir.";
+          << "before opening this database";
       FATAL_ERROR_EXIT();
     } else {
       TRI_ASSERT(oldVersion.data()[0] == version);
@@ -109,19 +110,29 @@ void arangodb::rocksdbStartupVersionCheck(rocksdb::TransactionDB* db, bool dbExi
     endianess = RocksDBEndianness::Big;
   }
   // enable correct key format
+  TRI_ASSERT(endianess == RocksDBEndianness::Little || endianess == RocksDBEndianness::Big);
   rocksutils::setRocksDBKeyFormatEndianess(endianess);
 
-  // store endianess forever
-  const char endVal = static_cast<char>(endianess);
-  s = db->Put(rocksdb::WriteOptions(), RocksDBColumnFamily::definitions(),
-              endianKey.string(), rocksdb::Slice(&endVal, sizeof(char)));
-  if (!s.ok()) {
-    LOG_TOPIC("3d88b", FATAL, Logger::ENGINES) << "Error storing endianess";
-    FATAL_ERROR_EXIT();
-  }
+  if (!dbExisted) {
+    // store endianess forever
+    TRI_ASSERT(endianess == RocksDBEndianness::Big);
 
-  // store current version
-  s = db->Put(rocksdb::WriteOptions(), RocksDBColumnFamily::definitions(),
-              versionKey.string(), rocksdb::Slice(&version, sizeof(char)));
-  TRI_ASSERT(s.ok());
+    char const endVal = static_cast<char>(endianess);
+    rocksdb::Status s = db->Put(rocksdb::WriteOptions(),
+                                RocksDBColumnFamily::definitions(),
+                                endianKey.string(), rocksdb::Slice(&endVal, sizeof(char)));
+
+    if (s.ok()) {
+      // store current version
+      s = db->Put(rocksdb::WriteOptions(), RocksDBColumnFamily::definitions(),
+                  versionKey.string(), rocksdb::Slice(&version, sizeof(char)));
+    }
+  
+    if (!s.ok()) {
+      LOG_TOPIC("3d88b", FATAL, Logger::ENGINES) 
+          << "Error storing endianess/version: " 
+          << rocksutils::convertStatus(s).errorMessage();
+      FATAL_ERROR_EXIT();
+    }
+  }
 }


### PR DESCRIPTION
### Scope & Purpose

Prevent a write to RocksDB during recovery in the case that the database already exists. If the database didn't already exist, it's okay to do the write. If it exists, we shouldn't write anything until after recovery has finished. Other than simply wanting to avoid writes during recovery for safety, we have also seen at least one case where a server shut down while in a write-stopped state, and on startup re-entered that write-stopped state; the write at startup then could not proceed, and the server was not able to proceed with recovery, start up, and serve health check requests.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.6

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *recovery, upgrade_data*.

Link to Jenkins PR run: 
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13346/