### PR TITLE
properly shut down AgencyCache in tests

### DIFF
--- a/arangod/Cluster/AgencyCache.cpp
+++ b/arangod/Cluster/AgencyCache.cpp
@@ -49,7 +49,12 @@ AgencyCache::AgencyCache(
         "arangodb_agency_cache_callback_count", uint64_t(0), "Current number of entries in agency cache callbacks table")) {}
 
 AgencyCache::~AgencyCache() {
-  beginShutdown();
+  try {
+    beginShutdown();
+  } catch (...) {
+    // unfortunately there is not much we can do here
+  }
+  shutdown();
 }
 
 bool AgencyCache::isSystem() const { return true; }
@@ -561,9 +566,11 @@ void AgencyCache::beginShutdown() {
         }
       }
     }
-    _callbacks.clear();
+    if (!_callbacks.empty()) {
+      _callbacks.clear();
+      _callbacksCount = 0;
+    }
   }
-  _callbacksCount = 0;
 
   Thread::beginShutdown();
 }

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -61,9 +61,7 @@ ClusterFeature::~ClusterFeature() {
     // have been shut down already when we get here, but there are rare cases in
     // which ClusterFeature::stop() isn't called (e.g. during testing or if 
     // something goes very wrong at startup)
-    if (_clusterInfo != nullptr) {
-      _clusterInfo->waitForSyncersToStop();
-    }
+    waitForSyncersToStop();
 
     // force shutdown of AgencyCache. under normal circumstances the cache will
     // have been shut down already when we get here, but there are rare cases in
@@ -685,7 +683,7 @@ void ClusterFeature::stop() {
   }
 
   // Make sure ClusterInfo's syncer threads have stopped.
-  _clusterInfo->waitForSyncersToStop();
+  waitForSyncersToStop();
 
   AsyncAgencyCommManager::INSTANCE->setStopping(true);
   shutdownAgencyCache();
@@ -736,6 +734,14 @@ void ClusterFeature::shutdownHeartbeatThread() {
         << "waiting for heartbeat thread to finish";
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+}
+
+/// @brief wait for the Plan and Current syncer to shut down
+/// note: this may be called multiple times during shutdown
+void ClusterFeature::waitForSyncersToStop() {
+  if (_clusterInfo != nullptr) {
+    _clusterInfo->waitForSyncersToStop();
   }
 }
 

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -57,6 +57,20 @@ ClusterFeature::ClusterFeature(application_features::ApplicationServer& server)
 
 ClusterFeature::~ClusterFeature() {
   if (_enableCluster) {
+    // force shutdown of Plan/Current syncers. under normal circumstances they
+    // have been shut down already when we get here, but there are rare cases in
+    // which ClusterFeature::stop() isn't called (e.g. during testing or if 
+    // something goes very wrong at startup)
+    if (_clusterInfo != nullptr) {
+      _clusterInfo->waitForSyncersToStop();
+    }
+
+    // force shutdown of AgencyCache. under normal circumstances the cache will
+    // have been shut down already when we get here, but there are rare cases in
+    // which ClusterFeature::stop() isn't called (e.g. during testing or if 
+    // something goes very wrong at startup)
+    shutdownAgencyCache();
+
     AgencyCommHelper::shutdown();
   }
 }
@@ -411,7 +425,7 @@ void ClusterFeature::prepare() {
     FATAL_ERROR_EXIT();
   }
 
-  if (!_allocated) {
+  if (_agencyCache == nullptr || _clusterInfo == nullptr) {
     allocateMembers();
   }
 
@@ -725,6 +739,8 @@ void ClusterFeature::shutdownHeartbeatThread() {
   }
 }
 
+/// @brief wait for the AgencyCache to shut down
+/// note: this may be called multiple times during shutdown
 void ClusterFeature::shutdownAgencyCache() {
   if (_agencyCache == nullptr) {
     return;
@@ -784,7 +800,6 @@ void ClusterFeature::allocateMembers() {
   _clusterInfo = std::make_unique<ClusterInfo>(server(), _agencyCallbackRegistry.get());
   _agencyCache =
     std::make_unique<AgencyCache>(server(), *_agencyCallbackRegistry);
-  _allocated = true;
 }
 
 void ClusterFeature::addDirty(std::unordered_set<std::string> const& databases, bool callNotify) {

--- a/arangod/Cluster/ClusterFeature.h
+++ b/arangod/Cluster/ClusterFeature.h
@@ -147,7 +147,6 @@ class ClusterFeature : public application_features::ApplicationFeature {
   bool _unregisterOnShutdown = false;
   bool _enableCluster = false;
   bool _requirePersistedId = false;
-  bool _allocated = false;
   double _indexCreationTimeout = 3600.0;
   std::unique_ptr<ClusterInfo> _clusterInfo;
   std::shared_ptr<HeartbeatThread> _heartbeatThread;

--- a/arangod/Cluster/ClusterFeature.h
+++ b/arangod/Cluster/ClusterFeature.h
@@ -119,14 +119,22 @@ class ClusterFeature : public application_features::ApplicationFeature {
   void pruneAsyncAgencyConnectionPool() {
     _asyncAgencyCommPool->pruneConnections();
   }
+  
+  /// the following methods may also be called from tests
+  
+  void shutdownHeartbeatThread();
+  /// @brief wait for the AgencyCache to shut down
+  /// note: this may be called multiple times during shutdown
+  void shutdownAgencyCache();
+  /// @brief wait for the Plan and Current syncer to shut down
+  /// note: this may be called multiple times during shutdown
+  void waitForSyncersToStop();
+
 
  protected:
   void startHeartbeatThread(AgencyCallbackRegistry* agencyCallbackRegistry,
                             uint64_t interval_ms, uint64_t maxFailsBeforeWarning,
                             std::string const& endpoints);
-
-  void shutdownHeartbeatThread();
-  void shutdownAgencyCache();
 
  private:
   void reportRole(ServerState::RoleEnum);

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -5533,13 +5533,16 @@ std::unordered_map<ServerID, RebootId> ClusterInfo::ServersKnown::rebootIds() co
 
 void ClusterInfo::startSyncers() {
   _planSyncer = std::make_unique<SyncerThread>(_server, "Plan", std::bind(&ClusterInfo::loadPlan, this), _agencyCallbackRegistry);
-  _planSyncer->start();
   _curSyncer = std::make_unique<SyncerThread>(_server, "Current", std::bind(&ClusterInfo::loadCurrent, this), _agencyCallbackRegistry);
-  _curSyncer->start();
+  
+  if (!_planSyncer->start() || !_curSyncer->start()) {
+    LOG_TOPIC("b4fa6", FATAL, Logger::CLUSTER)
+      << "unable to start PlanSyncer/CurrentSYncer";
+    FATAL_ERROR_EXIT();
+  }
 }
 
 void ClusterInfo::shutdownSyncers() {
-
   {
     std::lock_guard g(_waitPlanLock);
     auto pit = _waitPlan.begin();
@@ -5560,14 +5563,19 @@ void ClusterInfo::shutdownSyncers() {
     _waitCurrent.clear();
   }
 
-  _planSyncer->beginShutdown();
-  _curSyncer->beginShutdown();
+  if (_planSyncer != nullptr) {
+    _planSyncer->beginShutdown();
+  }
+  if (_curSyncer != nullptr) {
+    _curSyncer->beginShutdown();
+  }
 }
 
 
 void ClusterInfo::waitForSyncersToStop() {
   auto start = std::chrono::steady_clock::now();
-  while(_planSyncer->isRunning() || _curSyncer->isRunning()) {
+  while ((_planSyncer != nullptr && _planSyncer->isRunning()) || 
+         (_curSyncer != nullptr && _curSyncer->isRunning())) {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     if (std::chrono::steady_clock::now() - start > std::chrono::seconds(30)) {
       LOG_TOPIC("b8a5d", FATAL, Logger::CLUSTER)
@@ -5626,9 +5634,9 @@ void ClusterInfo::SyncerThread::beginShutdown() {
   _cv.notify_one();
 }
 
-void ClusterInfo::SyncerThread::start() {
+bool ClusterInfo::SyncerThread::start() {
   LOG_TOPIC("38256", DEBUG, Logger::CLUSTER) << "Starting " << currentThreadName();
-  Thread::start();
+  return Thread::start();
 }
 
 void ClusterInfo::SyncerThread::run() {

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -370,7 +370,7 @@ class ClusterInfo final {
     ~SyncerThread();
     void beginShutdown() override;
     void run() override;
-    void start();
+    bool start();
     bool notify(velocypack::Slice const&);
 
    private:


### PR DESCRIPTION
### Scope & Purpose

Properly shut down AgencyCache and Syncers during testing.
These components are normally shut down by the ClusterFeature under normal conditions, and the ClusterFeature waits in its `stop` method for the proper shutdown.
However, in case the `stop` method is not run or does not complete, the components may be left running.
This PR thus tries to shut down the components in the destructor of the ClusterFeature once more, should they still be around.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *gtest, ASan tests*.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13350/