### PR TITLE
Remove HTTP "Connection" header when forwarding requests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+v3.6.11 (XXXX-XX-XX)
+--------------------
+
+* Remove HTTP "Connection" header when forwarding requests in the cluster
+  from one coordinator to another, and let the internal network layer
+  handle closing of connections and keep-alive.
+
+
 v3.6.10 (2020-12-08)
 --------------------
 

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -158,6 +158,10 @@ futures::Future<Result> RestHandler::forwardRequest(bool& forwarded) {
   std::map<std::string, std::string> headers{_request->headers().begin(),
                                              _request->headers().end()};
 
+  // always remove HTTP "Connection" header, so that we don't relay 
+  // "Connection: Close" or "Connection: Keep-Alive" or such
+  headers.erase(StaticStrings::Connection);
+
   if (headers.find(StaticStrings::Authorization) == headers.end()) {
     // No authorization header is set, this is in particular the case if this
     // request is coming in with VelocyStream, where the authentication happens


### PR DESCRIPTION
### Scope & Purpose

Remove HTTP "Connection" header when forwarding requests in the cluster from one coordinator to another, and let the internal network layer handle closing of connections and keep-alive.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [x] This PR adds tests that were used to verify ~~all~~ some changes:
  - [x] Added new **integration tests** (e.g. in load-balancing)

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13353/