### PR TITLE
Make internal ClusterInfo::getPlan() wait for initial plan load from agency

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.7.6 (XXXX-XX-XX)
 -------------------
 
+* Make internal ClusterInfo::getPlan() wait for initial plan load from agency.
+
 * Added "startupTime", "computationTime" and "storageTime" to Pregel result
   statistics.
 

--- a/arangod/Cluster/AgencyCache.h
+++ b/arangod/Cluster/AgencyCache.h
@@ -54,7 +54,8 @@ class AgencyCache final : public arangodb::Thread {
   /// @brief start off with our server
   explicit AgencyCache(
     application_features::ApplicationServer& server,
-    AgencyCallbackRegistry& callbackRegistry);
+    AgencyCallbackRegistry& callbackRegistry,
+    int shutdownCode);
 
   ~AgencyCache();
 
@@ -102,13 +103,17 @@ class AgencyCache final : public arangodb::Thread {
   /// @brief Cache has these path? Paths are absolute
   std::vector<bool> has(std::vector<std::string> const& paths) const;
 
+#ifdef ARANGODB_USE_GOOGLE_TESTS
   /// @brief Used exclusively in unit tests!
   ///        Do not use for production code under any circumstances
-  std::pair<std::vector<consensus::apply_ret_t>, consensus::index_t> applyTestTransaction (
+  std::pair<std::vector<consensus::apply_ret_t>, consensus::index_t> applyTestTransaction(
     consensus::query_t const& trx);
+#endif
 
+#ifdef ARANGODB_USE_GOOGLE_TESTS
   /// @brief Used exclusively in unit tests
   consensus::Store& store();
+#endif
 
   /**
    * @brief         Get a list of planned/current  changes and other
@@ -163,6 +168,11 @@ class AgencyCache final : public arangodb::Thread {
 
   /// @brief Local copy of the read DB from the agency
   arangodb::consensus::Store _readDB;
+
+  /// @brief shut down code for futures that are unresolved.
+  /// this should be TRI_ERROR_SHUTTING_DOWN normally, but can be overridden
+  /// during testing
+  int const _shutdownCode;
 
   /// @brief Make sure, that we have seen in the beginning a snapshot
   std::atomic<bool> _initialized;

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -57,6 +57,18 @@ ClusterFeature::ClusterFeature(application_features::ApplicationServer& server)
 
 ClusterFeature::~ClusterFeature() {
   if (_enableCluster) {
+    // force shutdown of Plan/Current syncers. under normal circumstances they
+    // have been shut down already when we get here, but there are rare cases in
+    // which ClusterFeature::stop() isn't called (e.g. during testing or if 
+    // something goes very wrong at startup)
+    waitForSyncersToStop();
+
+    // force shutdown of AgencyCache. under normal circumstances the cache will
+    // have been shut down already when we get here, but there are rare cases in
+    // which ClusterFeature::stop() isn't called (e.g. during testing or if 
+    // something goes very wrong at startup)
+    shutdownAgencyCache();
+
     AgencyCommHelper::shutdown();
   }
 }
@@ -411,7 +423,7 @@ void ClusterFeature::prepare() {
     FATAL_ERROR_EXIT();
   }
 
-  if (!_allocated) {
+  if (_agencyCache == nullptr || _clusterInfo == nullptr) {
     allocateMembers();
   }
 
@@ -671,7 +683,7 @@ void ClusterFeature::stop() {
   }
 
   // Make sure ClusterInfo's syncer threads have stopped.
-  _clusterInfo->waitForSyncersToStop();
+  waitForSyncersToStop();
 
   AsyncAgencyCommManager::INSTANCE->setStopping(true);
   shutdownAgencyCache();
@@ -725,6 +737,16 @@ void ClusterFeature::shutdownHeartbeatThread() {
   }
 }
 
+/// @brief wait for the Plan and Current syncer to shut down
+/// note: this may be called multiple times during shutdown
+void ClusterFeature::waitForSyncersToStop() {
+  if (_clusterInfo != nullptr) {
+    _clusterInfo->waitForSyncersToStop();
+  }
+}
+
+/// @brief wait for the AgencyCache to shut down
+/// note: this may be called multiple times during shutdown
 void ClusterFeature::shutdownAgencyCache() {
   if (_agencyCache == nullptr) {
     return;
@@ -777,10 +799,9 @@ void ClusterFeature::allocateMembers() {
       "Request time for Agency requests");
   } catch (...) {}
   _agencyCallbackRegistry.reset(new AgencyCallbackRegistry(server(), agencyCallbacksPath()));
-  _clusterInfo = std::make_unique<ClusterInfo>(server(), _agencyCallbackRegistry.get());
+  _clusterInfo = std::make_unique<ClusterInfo>(server(), _agencyCallbackRegistry.get(), _syncerShutdownCode);
   _agencyCache =
-    std::make_unique<AgencyCache>(server(), *_agencyCallbackRegistry);
-  _allocated = true;
+    std::make_unique<AgencyCache>(server(), *_agencyCallbackRegistry, _syncerShutdownCode);
 }
 
 void ClusterFeature::addDirty(std::unordered_set<std::string> const& databases, bool callNotify) {

--- a/arangod/Cluster/ClusterFeature.h
+++ b/arangod/Cluster/ClusterFeature.h
@@ -152,8 +152,8 @@ class ClusterFeature : public application_features::ApplicationFeature {
   std::uint32_t _minReplicationFactor = 1;     // minimum replication factor (0 = unrestricted)
   std::uint32_t _maxReplicationFactor = 10;    // maximum replication factor (0 = unrestricted)
   std::uint32_t _maxNumberOfShards = 1000;     // maximum number of shards (0 = unrestricted)
-  bool _createWaitsForSyncReplication = true;
   int _syncerShutdownCode = TRI_ERROR_SHUTTING_DOWN;
+  bool _createWaitsForSyncReplication = true;
   bool _forceOneShard = false;
   bool _unregisterOnShutdown = false;
   bool _enableCluster = false;

--- a/arangod/Cluster/ClusterFeature.h
+++ b/arangod/Cluster/ClusterFeature.h
@@ -119,14 +119,24 @@ class ClusterFeature : public application_features::ApplicationFeature {
   void pruneAsyncAgencyConnectionPool() {
     _asyncAgencyCommPool->pruneConnections();
   }
+  /// the following methods may also be called from tests
+  
+  void shutdownHeartbeatThread();
+  /// @brief wait for the AgencyCache to shut down
+  /// note: this may be called multiple times during shutdown
+  void shutdownAgencyCache();
+  /// @brief wait for the Plan and Current syncer to shut down
+  /// note: this may be called multiple times during shutdown
+  void waitForSyncersToStop();
+
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+  void setSyncerShutdownCode(int code) { _syncerShutdownCode = code; }
+#endif
 
  protected:
   void startHeartbeatThread(AgencyCallbackRegistry* agencyCallbackRegistry,
                             uint64_t interval_ms, uint64_t maxFailsBeforeWarning,
                             std::string const& endpoints);
-
-  void shutdownHeartbeatThread();
-  void shutdownAgencyCache();
 
  private:
   void reportRole(ServerState::RoleEnum);
@@ -143,11 +153,11 @@ class ClusterFeature : public application_features::ApplicationFeature {
   std::uint32_t _maxReplicationFactor = 10;    // maximum replication factor (0 = unrestricted)
   std::uint32_t _maxNumberOfShards = 1000;     // maximum number of shards (0 = unrestricted)
   bool _createWaitsForSyncReplication = true;
+  int _syncerShutdownCode = TRI_ERROR_SHUTTING_DOWN;
   bool _forceOneShard = false;
   bool _unregisterOnShutdown = false;
   bool _enableCluster = false;
   bool _requirePersistedId = false;
-  bool _allocated = false;
   double _indexCreationTimeout = 3600.0;
   std::unique_ptr<ClusterInfo> _clusterInfo;
   std::shared_ptr<HeartbeatThread> _heartbeatThread;

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -5021,7 +5021,7 @@ ClusterInfo::getPlan(uint64_t& index, std::unordered_set<std::string> const& dir
 
   // We should never proceed here, until we have seen an
   // initial agency cache through loadPlan
-  waitForPlan(1);
+  waitForPlan(1).get();
 
   std::unordered_map<std::string,std::shared_ptr<VPackBuilder>> ret;
   READ_LOCKER(readLocker, _planProt.lock);

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -369,7 +369,7 @@ class ClusterInfo final {
     ~SyncerThread();
     void beginShutdown();
     void run();
-    void start();
+    bool start();
     bool notify(velocypack::Slice const&);
 
    private:
@@ -420,7 +420,8 @@ public:
   /// @brief creates library
   //////////////////////////////////////////////////////////////////////////////
 
-  explicit ClusterInfo(application_features::ApplicationServer&, AgencyCallbackRegistry*);
+  explicit ClusterInfo(application_features::ApplicationServer&, AgencyCallbackRegistry*, 
+                       int syncerShutdownCode);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief shuts down library
@@ -1093,6 +1094,10 @@ public:
   };
 
   cluster::RebootTracker _rebootTracker;
+
+  /// @brief error code sent to all remaining promises of the syncers at shutdown. 
+  /// normally this is TRI_ERROR_SHUTTING_DOWN, but it can be overridden during testing
+  int const _syncerShutdownCode;
 
   // The servers, first all, we only need Current here:
   std::unordered_map<ServerID, std::string> _servers;  // from Current/ServersRegistered

--- a/arangod/Cluster/DBServerAgencySync.cpp
+++ b/arangod/Cluster/DBServerAgencySync.cpp
@@ -203,18 +203,7 @@ DBServerAgencySyncResult DBServerAgencySync::execute() {
   }
 
   AgencyCache::databases_t plan = clusterInfo.getPlan(planIndex, dirty);
-
-  if (plan.empty()) {
-    // this early exit is a safeguard against overzealous cleanup by 
-    // the maintenance. in case the plan is empty and compared to the
-    // local state, the maintenance may decide to drop everyting 💥
-    LOG_TOPIC("0a6f2", DEBUG, Logger::MAINTENANCE)
-        << "DBServerAgencySync::execute no plan change set";
-    result.success = true;
-    result.errorMessage = "DBServerAgencySync::execute no reconciliation plan";
-    return result;
-  }
-
+  
   auto serverId = arangodb::ServerState::instance()->getId();
 
   // It is crucial that the following happens before we do `getLocalCollections`!

--- a/arangod/GeneralServer/IoContext.cpp
+++ b/arangod/GeneralServer/IoContext.cpp
@@ -22,7 +22,11 @@
 
 #include "IoContext.h"
 
-#include "Basics/cpu-relax.h"
+#include <thread>
+
+#include "Logger/LogMacros.h"
+#include "Logger/Logger.h"
+#include "Logger/LoggerStream.h"
 
 using namespace arangodb;
 using namespace arangodb::basics;
@@ -38,7 +42,12 @@ IoContext::IoThread::~IoThread() { shutdown(); }
 
 void IoContext::IoThread::run() {
   // run the asio io context
-  _iocontext.io_context.run();
+  try {
+    _iocontext.io_context.run();
+  } catch (std::exception const& ex) {
+    LOG_TOPIC("6794f", WARN, Logger::THREADS)
+      << "caught exception in IO thread: " << ex.what();
+  }
 }
 
 IoContext::IoContext(application_features::ApplicationServer& server)

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -134,6 +134,11 @@ static void SetupClusterFeaturePhase(MockServer& server) {
   SetupDatabaseFeaturePhase(server);
   server.addFeature<arangodb::application_features::ClusterFeaturePhase>(false);
   server.addFeature<arangodb::ClusterFeature>(false);
+ 
+  // fake the exit code with which unresolved futures are returned on
+  // shutdown. if we don't do this lots of places in ClusterInfo will
+  // report failures during testing
+  server.getFeature<ClusterFeature>().setSyncerShutdownCode(TRI_ERROR_NO_ERROR);
 }
 
 static void SetupCommunicationFeaturePhase(MockServer& server) {
@@ -421,7 +426,6 @@ MockClusterServer::MockClusterServer() : MockServer() {
   config.maxOpenConnections = 8;
   config.verifyHosts = false;
   addFeature<arangodb::NetworkFeature>(true, config);
-
 }
 
 MockClusterServer::~MockClusterServer() {


### PR DESCRIPTION
### Scope & Purpose

Otherwise the maintenance, fired off by the heartbeat thread, may not wait for the initial data to arrive from the agency, which can cause Plan and Current to be empty when maintenance starts.
No backport for 3.6 is needed, as 3.6 has blocking agency communication here in case the Plan is not there.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *mini chaos*.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13365/