### PR TITLE
Minor syntactic fix in Prometheus metrics output

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Drop a pair of braces {} in /_admin/metrics in case of empty labels, which
+  makes the API adhere better to the official Prometheus syntax.
+
 * Added new metric: "arangodb_collection_lock_sequential_mode" this will count
   how many times we need to do a sequential locking of collections. If this
   metric increases this indicates lock contention in transaction setup.

--- a/arangod/RestServer/Metrics.cpp
+++ b/arangod/RestServer/Metrics.cpp
@@ -104,7 +104,11 @@ void Counter::toPrometheus(std::string& result) const {
   _b.push();
   result += "\n#TYPE " + name() + " counter\n";
   result += "#HELP " + name() + " " + help() + "\n";
-  result += name() + "{" + labels() + "} " + std::to_string(load()) + "\n";
+  result += name();
+  if (!labels().empty()) {
+    result += "{" + labels() + "}";
+  }
+  result += " " + std::to_string(load()) + "\n";
 }
 
 Counter::Counter(

--- a/arangod/RestServer/Metrics.h
+++ b/arangod/RestServer/Metrics.h
@@ -141,8 +141,11 @@ template<typename T> class Gauge : public Metric {
   T load() const { return _g.load(); }
   virtual void toPrometheus(std::string& result) const override {
     result += "\n#TYPE " + name() + " gauge\n";
-    result += "#HELP " + name() + " " + help() + "\n";
-    result += name() + "{" + labels() + "} " + std::to_string(load()) + "\n";
+    result += "#HELP " + name() + " " + help() + "\n" + name();
+    if (!labels().empty()) {
+      result += "{" + labels() + "}";
+    }
+    result += " " + std::to_string(load()) + "\n";
   };
  private:
   std::atomic<T> _g;
@@ -453,7 +456,11 @@ template<typename Scale> class Histogram : public Metric {
       }
       result += "le=\"" + _scale.delim(i) + "\"} " + std::to_string(n) + "\n";
     }
-    result += name() + "_count{" + labels() + "} " + std::to_string(sum) + "\n";
+    result += name() + "_count";
+    if (!labels().empty()) {
+      result += "{" + labels() + "}";
+    }
+    result += " " + std::to_string(sum) + "\n";
   }
 
   std::ostream& print(std::ostream& o) const {

--- a/tests/js/client/communication/test-communication.js
+++ b/tests/js/client/communication/test-communication.js
@@ -710,12 +710,12 @@ function GenericAqlSetupPathSuite(type) {
           // Both transactions need to write
           return false;
         }
-        if (sExclusive === NO_SHARD_SYNC || fExclusive == NO_SHARD_SYNC) {
+        if (sExclusive === NO_SHARD_SYNC || fExclusive === NO_SHARD_SYNC) {
           // We do not sync shard-locks, so no deadlock possible
           return false;
         }
-        // If any of the writes is exclusive we enfoce sequential locking
-        return fExclusive === USE_EXCLUSIVE || sExclusive == USE_EXCLUSIVE;
+        // If any of the writes is exclusive we enforce sequential locking
+        return fExclusive === USE_EXCLUSIVE || sExclusive === USE_EXCLUSIVE;
       };
 
       if (expectsSequentialLock()) {

--- a/tests/js/client/shell/shell-transaction-intermediate-commit-cluster.js
+++ b/tests/js/client/shell/shell-transaction-intermediate-commit-cluster.js
@@ -85,12 +85,12 @@ function getMetric(endpoint, name) {
   let res = request.get({
     url: endpoint + '/_admin/metrics',
   });
-  let re = new RegExp("^" + name + "\\{");
+  let re = new RegExp("^" + name);
   let matches = res.body.split('\n').filter((line) => !line.match(/^#/)).filter((line) => line.match(re));
   if (!matches.length) {
     throw "Metric " + name + " not found";
   }
-  return Number(matches[0].replace(/^.*?\} (\d+)$/, '$1'));
+  return Number(matches[0].replace(/^.* (\d+)$/, '$1'));
 }
 
 function assertInSync(leader, follower, shardId) {


### PR DESCRIPTION
Fix a minor syntax error in metrics for prometheus.

In case that a metrics has no labels, drop a pair of braces {} which
are officially not allowed in the Prometheus metrics output.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers - **mandatory**)*

- [*] :hankey: Bugfix (requires CHANGELOG entry)

#### Backports:

- [*] No backports required

### Testing & Verification

*(Please pick either of the following options)*

- [*] This change is a trivial rework / code cleanup without any test coverage.
