### PR TITLE
improve audit logging messages and robustness

### DIFF
--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -59,6 +59,7 @@
 #include "Transaction/V8Context.h"
 #include "Utils/CollectionNameResolver.h"
 #include "Utils/ExecContext.h"
+#include "Utils/Events.h"
 #include "V8/JavaScriptSecurityContext.h"
 #include "V8/v8-vpack.h"
 #include "V8Server/V8DealerFeature.h"
@@ -172,6 +173,17 @@ Query::~Query() {
   }
 
   _queryProfile.reset(); // unregister from QueryList
+  
+  // log to audit log
+  if (!_queryOptions.skipAudit &&
+     (ServerState::instance()->isCoordinator() ||
+      ServerState::instance()->isSingleServer())) {
+    try {
+      events::AqlQuery(*this);
+    } catch (...) {
+      // we must not make any exception escape from here!
+    }
+  }
 
   // this will reset _trx, so _trx is invalid after here
   try {
@@ -179,7 +191,7 @@ Query::~Query() {
     TRI_ASSERT(state != ExecutionState::WAITING);
   } catch (...) {
     // unfortunately we cannot do anything here, as we are in 
-    // a destructor
+    // the destructor
   }
   
   unregisterSnippets();
@@ -232,10 +244,6 @@ void Query::prepareQuery(SerializationFormat format) {
   try {
     init(/*createProfile*/ true);
     
-    if (_queryProfile) {
-      _queryProfile->registerInQueryList();
-    }
-
     enterState(QueryExecutionState::ValueType::PARSING);
 
     std::unique_ptr<ExecutionPlan> plan = preparePlan();
@@ -268,6 +276,10 @@ void Query::prepareQuery(SerializationFormat format) {
         THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_SHUTTING_DOWN, "query registry not available");
       }
       registry->registerSnippets(_snippets);
+    }
+    
+    if (_queryProfile) {
+      _queryProfile->registerInQueryList();
     }
     
     enterState(QueryExecutionState::ValueType::EXECUTION);

--- a/arangod/Aql/QueryList.cpp
+++ b/arangod/Aql/QueryList.cpp
@@ -38,7 +38,6 @@
 #include "Logger/LoggerStream.h"
 #include "RestServer/MetricsFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
-#include "Utils/Events.h"
 #include "VocBase/vocbase.h"
 
 #include <velocypack/Builder.h>
@@ -169,11 +168,6 @@ void QueryList::remove(Query* query) {
   double const elapsed = elapsedSince(query->startTime());
 
   _queryRegistryFeature.trackQuery(elapsed);
-
-  // log to audit log
-  if (!query->queryOptions().skipAudit) {
-    events::AqlQuery(*query);
-  }
 
   if (!trackSlowQueries()) {
     return;

--- a/arangod/Aql/QueryProfile.h
+++ b/arangod/Aql/QueryProfile.h
@@ -65,8 +65,6 @@ struct QueryProfile {
 
   /// @brief convert the profile to VelocyPack
   void toVelocyPack(arangodb::velocypack::Builder&) const;
-  
- private:
 
  private:
   Query* _query;

--- a/arangod/Aql/QueryRegistry.cpp
+++ b/arangod/Aql/QueryRegistry.cpp
@@ -443,7 +443,7 @@ void QueryRegistry::registerSnippets(SnippetList const& snippets) {
 void QueryRegistry::unregisterSnippets(SnippetList const& snippets) noexcept {
   TRI_ASSERT(ServerState::instance()->isCoordinator());
 
-  while(true) {
+  while (true) {
     WRITE_LOCKER(guard, _lock);
     size_t remain = snippets.size();
     for (auto& engine : snippets) {


### PR DESCRIPTION
### Scope & Purpose

Slightly improve audit logging for edge cases, e.g. empty query string/no bind variables, and when query was not inserted into the list of running queries because query tracking was turned off.
In addition, this PR should fix errors that were observed in the shell-query-kill test in cluster.

No backports are required because the changes to auditing were not done in 3.6 or 3.7 (only cosmetic changes were done in the stable branches).

There is also an enterprise part for this PR: https://github.com/arangodb/enterprise/pull/614

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Enterprise repository PR: https://github.com/arangodb/enterprise/pull/614

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *audit_client audit_server*.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13391/