### PR TITLE
Stabilize Foxx cleanup test

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.7.6 (XXXX-XX-XX)
 -------------------
 
+* Stabilize a Foxx cleanup test in Javascript.
+
 * Added new metric: "arangodb_collection_lock_sequential_mode" this will count
   how many times we need to do a sequential locking of collections. If this
   metric increases this indicates lock contention in transaction setup.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,6 @@
 v3.7.6 (XXXX-XX-XX)
 -------------------
 
-* Stabilize a Foxx cleanup test in Javascript.
-
 * Added new metric: "arangodb_collection_lock_sequential_mode" this will count
   how many times we need to do a sequential locking of collections. If this
   metric increases this indicates lock contention in transaction setup.

--- a/tests/js/server/shell/shell-foxx-cleanup-spec.js
+++ b/tests/js/server/shell/shell-foxx-cleanup-spec.js
@@ -22,7 +22,19 @@ describe('Foxx self-heal cleanup', () => {
   });
 
   it('should clean up stray bundles', () => {
-    const fakeBundlePath = path.resolve(FoxxService.rootBundlePath(), 'fakebundle.zip');
+    const rootBundlePath = FoxxService.rootBundlePath();
+    // First wait until the path exists, it is created by the selfheal
+    // mechanism of the Foxx manager, otherwise we might run into an error
+    // with the write:
+    let count = 0;
+    while (!fs.exists(rootBundlePath)) {
+      require("internal").wait(1);
+      count += 1;
+      if (count >= 60) {
+        throw "Banana";
+      }
+    }
+    const fakeBundlePath = path.resolve(rootBundlePath, 'fakebundle.zip');
     fs.write(fakeBundlePath, 'gone in 30 seconds');
     expect(fs.exists(fakeBundlePath)).to.equal(true);
     FoxxManager.heal();


### PR DESCRIPTION
I have observed some instability in this test:

  tests/js/server/shell/shell-foxx-cleanup-spec.js

Namely, it relies on a directory which is only created after startup
by the foxx manager selfheal procedure. This is a race.

This PR adds a wait loop to stabilize the test.

This has been fixed for 3.6 in https://github.com/arangodb/arangodb/pull/13184.

Port to `devel` is forthcoming.
