### PR TITLE
(3.7) Only run Test in Enterprise mode

### DIFF
--- a/tests/js/client/communication/test-communication.js
+++ b/tests/js/client/communication/test-communication.js
@@ -831,7 +831,9 @@ if (internal.isCluster()) {
   jsunity.run(AqlGraphSetupPathSuite);
   jsunity.run(AqlNamedGraphSetupPathSuite);
   jsunity.run(AqlViewSetupPathSuite);
-  jsunity.run(AqlSatelliteSetupPathSuite);
+  if (internal.isEnterprise()) {
+    jsunity.run(AqlSatelliteSetupPathSuite);
+  }
 }
 
 return jsunity.done();


### PR DESCRIPTION
This PR just fixes a test, that should only run in Enterprise mode, as the feature under test is enterprise only.
No Production Change.

Jenkins:
http://jenkins.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/13479/