### PR TITLE
store sharding attribute for databases on db servers

### DIFF
--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -25,6 +25,7 @@
 #include "Cluster/Maintenance.h"
 #include "Agency/AgencyStrings.h"
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Basics/StaticStrings.h"
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Cluster/ClusterFeature.h"
@@ -44,6 +45,7 @@
 #include <velocypack/Compare.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
+#include <velocypack/StringRef.h>
 #include <velocypack/velocypack-aliases.h>
 
 #include <algorithm>

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -49,7 +49,6 @@
 #include <velocypack/velocypack-aliases.h>
 
 #include <algorithm>
-#include <regex>
 
 using namespace arangodb;
 using namespace arangodb::consensus;
@@ -66,7 +65,6 @@ static VPackValue const VP_SET("set");
 
 static VPackStringRef const PRIMARY("primary");
 static VPackStringRef const EDGE("edge");
-
 
 static int indexOf(VPackSlice const& slice, std::string const& val) {
   if (slice.isArray()) {

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -321,6 +321,9 @@ arangodb::Result Databases::create(application_features::ApplicationServer& serv
       auto& clusterInfo = server.getFeature<ClusterFeature>().clusterInfo();
       createInfo.setId(clusterInfo.uniqid());
     }
+    if (server.getFeature<ClusterFeature>().forceOneShard()) {
+      createInfo.sharding("single");
+    }
 
     res = ShardingInfo::validateShardsAndReplicationFactor(options, server, true);
     if (res.ok()) {

--- a/arangod/VocBase/VocbaseInfo.h
+++ b/arangod/VocBase/VocbaseInfo.h
@@ -121,6 +121,9 @@ class CreateDatabaseInfo {
     TRI_ASSERT(_valid);
     return _sharding;
   }
+  void sharding(std::string const& sharding) {
+    _sharding = sharding;
+  }
 
   ShardingPrototype shardingPrototype() const;
   void shardingPrototype(ShardingPrototype type);

--- a/tests/js/common/shell/shell-one-shard.js
+++ b/tests/js/common/shell/shell-one-shard.js
@@ -35,6 +35,42 @@ const internal = require('internal');
 const ERRORS = arangodb.errors;
 const isEnterprise = internal.isEnterprise();
 const isCluster = internal.isCluster();
+const request = require('@arangodb/request');
+
+function getEndpointsByType(type) {
+  const isType = (d) => (d.role.toLowerCase() === type);
+  const toEndpoint = (d) => (d.endpoint);
+  const endpointToURL = (endpoint) => {
+    if (endpoint.substr(0, 6) === 'ssl://') {
+      return 'https://' + endpoint.substr(6);
+    }
+    let pos = endpoint.indexOf('://');
+    if (pos === -1) {
+      return 'http://' + endpoint;
+    }
+    return 'http' + endpoint.substr(pos);
+  };
+
+  const instanceInfo = JSON.parse(internal.env.INSTANCEINFO);
+  return instanceInfo.arangods.filter(isType)
+                              .map(toEndpoint)
+                              .map(endpointToURL);
+}
+
+function checkDBServerSharding(db, expected) {
+  // connect to all db servers and check if they picked up the
+  // "sharding" attribute correctly
+  if (!require('@arangodb').isServer) {
+    // request module can only be used inside arangosh tests
+    let endpoints = getEndpointsByType("dbserver");
+    assertTrue(endpoints.length > 0);
+    endpoints.forEach((ep) => {
+      let res = request.get({ url: ep + "/_db/" + encodeURIComponent(db) + "/_api/database/current" });
+      assertEqual(200, res.status);
+      assertEqual(expected, res.json.result.sharding);
+    });
+  }
+}
 
 function OneShardPropertiesSuite () {
   var dn = "UnitTestsDB";
@@ -83,6 +119,8 @@ function OneShardPropertiesSuite () {
         assertEqual(2, props.writeConcern);
         assertEqual(2, props.replicationFactor);
         assertEqual(1, props.numberOfShards);
+     
+        checkDBServerSharding(dn, "single");
       } else {
         assertEqual(props.sharding, undefined);
         assertEqual(props.replicationFactor, undefined);
@@ -97,6 +135,8 @@ function OneShardPropertiesSuite () {
       if (isCluster) {
         assertEqual(props.sharding, "");
         assertEqual(props.replicationFactor, 1);
+        
+        checkDBServerSharding(dn, "");
       } else {
         assertEqual(props.sharding, undefined);
         assertEqual(props.replicationFactor, undefined);


### PR DESCRIPTION
### Scope & Purpose

This PR will lead to two changes:
* for any newly created databases in `--cluster.force-one-shard` mode, the "sharding" attribute will automatically be set to "single" on database creation, even if not explicitly specified.
* for any newly created databases in the cluster, the "sharding" attribute will be stored on DB servers as well when set to "single".

That way the "sharding" attribute with a value of "single" will propagate to the DB servers so they have local access to it, and also it becomes independent of the value of the `--cluster.force-one-shard` flag for any databases after they have been created.

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/620

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.6: https://github.com/arangodb/arangodb/pull/13325

#### Related Information

- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/620

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *shell_client, shell_server, server_permissions*.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13480/