### PR TITLE
remove now superfluous retry code

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -5001,26 +5001,22 @@ std::unordered_map<ShardID, ServerID> ClusterInfo::getResponsibleServers(
 ////////////////////////////////////////////////////////////////////////////////
 
 std::shared_ptr<std::vector<ShardID>> ClusterInfo::getShardList(CollectionID const& collectionID) {
-  int tries = 0;
   TRI_IF_FAILURE("ClusterInfo::failedToGetShardList") {
-    // Simulate 3 failed tries below.
+    // Simulate no results
     return std::make_shared<std::vector<ShardID>>();
   }
-  while (true) {
-    {
-      // Get the sharding keys and the number of shards:
-      READ_LOCKER(readLocker, _planProt.lock);
-      // _shards is a map-type <DataSourceId, shared_ptr<vector<string>>>
-      auto it = _shards.find(collectionID);
 
-      if (it != _shards.end()) {
-        return it->second;
-      }
-    }
-    if (++tries >= 2) {
-      return std::make_shared<std::vector<ShardID>>();
+  {
+    // Get the sharding keys and the number of shards:
+    READ_LOCKER(readLocker, _planProt.lock);
+    // _shards is a map-type <DataSourceId, shared_ptr<vector<string>>>
+    auto it = _shards.find(collectionID);
+
+    if (it != _shards.end()) {
+      return it->second;
     }
   }
+  return std::make_shared<std::vector<ShardID>>();
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose

Remove now superfluous retry logic.
The retry logic was previously useful when we still contacted the agency after each failed attempt. However, nowadays we don't do this, so we can get away without ever retrying here.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13481/