### PR TITLE
test PR to see if a specific change caused a performance regression

### DIFF
--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -146,8 +146,13 @@ RocksDBOptionFeature::RocksDBOptionFeature(application_features::ApplicationServ
       _level0StopTrigger(rocksDBDefaults.level0_stop_writes_trigger),
       _recycleLogFileNum(rocksDBDefaults.recycle_log_file_num),
       _enforceBlockCacheSizeLimit(false),
-      _cacheIndexAndFilterBlocks(true),
-      _cacheIndexAndFilterBlocksWithHighPriority(true),
+      // TODO: this change has been made only to see if setting to true caused a performance
+      // regression or not. it will be rolled back once we know.
+      //_cacheIndexAndFilterBlocks(true),
+      //_cacheIndexAndFilterBlocksWithHighPriority(true),
+      _cacheIndexAndFilterBlocks(rocksDBTableOptionsDefaults.cache_index_and_filter_blocks),
+      _cacheIndexAndFilterBlocksWithHighPriority(
+        rocksDBTableOptionsDefaults.cache_index_and_filter_blocks_with_high_priority),
       _pinl0FilterAndIndexBlocksInCache(
           rocksDBTableOptionsDefaults.pin_l0_filter_and_index_blocks_in_cache),
       _pinTopLevelIndexAndFilter(rocksDBTableOptionsDefaults.pin_top_level_index_and_filter),


### PR DESCRIPTION
### Scope & Purpose

Test PR to see if a specific change of RocksDB options in devel caused a performance regression to some AQL workloads.
We will merge this to devel and then check the performance results with the latest version.

If performance gets better, we will fix this properly, otherwise we will revert this change and try other fixes.

The performance regression was only introduced to devel, so backports needed for 3.7 or 3.6

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13482/