### PR TITLE
more granular error reporting in Maintenance

### DIFF
--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -496,6 +496,7 @@ VPackBuilder getShardMap(VPackSlice const& collections) {
     // But then shardMap can also be empty, so we are good.
     if (collections.isObject()) {
       for (auto collection : VPackObjectIterator(collections)) {
+        TRI_ASSERT(collection.value.isObject());
         for (auto shard : VPackObjectIterator(collection.value.get(SHARDS))) {
           shardMap.add(shard.key.stringRef(), shard.value);
         }
@@ -608,6 +609,7 @@ arangodb::Result arangodb::maintenance::diffPlanLocal(
           for (auto const& pcol : VPackObjectIterator(pdb, true)) { // each plan collection
             auto const& cprops = pcol.value;
             // for each shard
+            TRI_ASSERT(cprops.isObject());
             for (auto const& shard : VPackObjectIterator(cprops.get(SHARDS))) { // each shard
 
               if (shard.value.isArray()) {
@@ -1026,6 +1028,8 @@ static std::tuple<VPackBuilder, bool, bool> assembleLocalCollectionInfo(
 }
 
 bool equivalent(VPackSlice const& local, VPackSlice const& current) {
+  TRI_ASSERT(local.isObject());
+  TRI_ASSERT(current.isObject());
   for (auto const& i : VPackObjectIterator(local, true)) {
     if (!VPackNormalizedCompare::equals(i.value, current.get(i.key.stringRef()))) {
       return false;
@@ -1088,7 +1092,6 @@ arangodb::Result arangodb::maintenance::reportInCurrent(
     MaintenanceFeature::errors_t const& allErrors, std::string const& serverId,
     VPackBuilder& report, ShardStatistics& shardStats) {
   for (auto const& dbName : dirty) {
-
     auto lit = local.find(dbName);
     VPackSlice ldb;
     if (lit == local.end()) {
@@ -1121,12 +1124,15 @@ arangodb::Result arangodb::maintenance::reportInCurrent(
       pdb = pit->second->slice()[0];
       std::vector<std::string> ppath{
         AgencyCommHelper::path(), PLAN, COLLECTIONS, dbName};
-      if (pdb.hasKey(ppath)) {   // Plan of this database's collections
-        pdb = pdb.get(ppath);
+      TRI_ASSERT(pdb.isObject());
+
+      TRI_ASSERT(pdb.isObject());
+
+      // Plan of this database's collections
+      pdb = pdb.get(ppath);
+      if (!pdb.isNone()) {
         shardMap = getShardMap(pdb);
-      } else {                   // Else set noneSlice
-        pdb = Slice();
-      }
+      } 
     }
 
     auto cdbpath = std::vector<std::string>{
@@ -1151,146 +1157,162 @@ arangodb::Result arangodb::maintenance::reportInCurrent(
       for (auto const& shard : VPackObjectIterator(ldb, true)) {
         auto const shName = shard.key.copyString();
         auto const shSlice = shard.value;
+        TRI_ASSERT(shSlice.isObject());
         auto const colName = shSlice.get(StaticStrings::DataSourcePlanId).copyString();
         shardStats.numShards += 1;
 
         VPackBuilder error;
         if (shSlice.get(THE_LEADER).copyString().empty()) {  // Leader
+          try {
+            // Check that we are the leader of this shard in the Plan, together
+            // with the precondition below that the Plan is unchanged, this ensures
+            // that we only ever modify Current if we are the leader in the Plan:
 
-          // Check that we are the leader of this shard in the Plan, together
-          // with the precondition below that the Plan is unchanged, this ensures
-          // that we only ever modify Current if we are the leader in the Plan:
+            auto const planPath = std::vector<std::string>{colName, "shards", shName};
+            if (!pdb.isObject() || !pdb.hasKey(planPath)) {
+              LOG_TOPIC("43242", DEBUG, Logger::MAINTENANCE)
+                << "Ooops, we have a shard for which we believe to be the "
+                "leader, but the Plan does not have it any more, we do not "
+                "report in Current about this, database: "
+                << dbName << ", shard: " << shName;
+              continue;
+            }
 
-          auto const planPath = std::vector<std::string>{colName, "shards", shName};
-          if (!pdb.isObject() || !pdb.hasKey(planPath)) {
-            LOG_TOPIC("43242", DEBUG, Logger::MAINTENANCE)
-              << "Ooops, we have a shard for which we believe to be the "
-              "leader, but the Plan does not have it any more, we do not "
-              "report in Current about this, database: "
-              << dbName << ", shard: " << shName;
-            continue;
-          }
+            TRI_ASSERT(pdb.isObject() && pdb.hasKey(planPath));
 
-          VPackSlice thePlanList = pdb.get(planPath);
-          if (!thePlanList.isArray() || thePlanList.length() == 0 ||
-              !thePlanList[0].isString() || !thePlanList[0].isEqualStringUnchecked(serverId)) {
-            LOG_TOPIC("87776", DEBUG, Logger::MAINTENANCE)
-              << "Ooops, we have a shard for which we believe to be the "
-              "leader,"
-              " but the Plan says otherwise, we do not report in Current "
-              "about this, database: "
-              << dbName << ", shard: " << shName;
-            continue;
-          }
+            VPackSlice thePlanList = pdb.get(planPath);
+            if (!thePlanList.isArray() || thePlanList.length() == 0 ||
+                !thePlanList[0].isString() || !thePlanList[0].isEqualStringUnchecked(serverId)) {
+              LOG_TOPIC("87776", DEBUG, Logger::MAINTENANCE)
+                << "Ooops, we have a shard for which we believe to be the "
+                "leader,"
+                " but the Plan says otherwise, we do not report in Current "
+                "about this, database: "
+                << dbName << ", shard: " << shName;
+              continue;
+            }
+            
+            TRI_ASSERT(shardMap.slice().isObject());
 
-          auto const [localCollectionInfo, shardInSync, shardReplicated] =
-              assembleLocalCollectionInfo(df, shSlice, shardMap.slice().get(shName),
-                                          dbName, shName, serverId, allErrors);
-          // Collection no longer exists
-          TRI_ASSERT(!localCollectionInfo.slice().isNone());
-          if (localCollectionInfo.slice().isEmptyObject() ||
-              localCollectionInfo.slice().isNone()) {
-            continue;
-          }
+            auto const [localCollectionInfo, shardInSync, shardReplicated] =
+                assembleLocalCollectionInfo(df, shSlice, shardMap.slice().get(shName),
+                                            dbName, shName, serverId, allErrors);
+            // Collection no longer exists
+            TRI_ASSERT(!localCollectionInfo.slice().isNone());
+            if (localCollectionInfo.slice().isEmptyObject() ||
+                localCollectionInfo.slice().isNone()) {
+              continue;
+            }
 
-          shardStats.numLeaderShards += 1;
-          if (!shardInSync) {
-            shardStats.numOutOfSyncShards += 1;
-          }
-          if (!shardReplicated) {
-            shardStats.numNotReplicated += 1;
-          }
+            shardStats.numLeaderShards += 1;
+            if (!shardInSync) {
+              shardStats.numOutOfSyncShards += 1;
+            }
+            if (!shardReplicated) {
+              shardStats.numNotReplicated += 1;
+            }
 
-          auto cp = std::vector<std::string>{
-            AgencyCommHelper::path(), CURRENT, COLLECTIONS, dbName, colName, shName};
-          auto inCurrent = cur.isObject() && cur.hasKey(cp);
+            auto cp = std::vector<std::string>{
+              AgencyCommHelper::path(), CURRENT, COLLECTIONS, dbName, colName, shName};
+            auto inCurrent = cur.isObject() && cur.hasKey(cp);
 
-          if (!inCurrent || !equivalent(localCollectionInfo.slice(), cur.get(cp))) {
-            report.add(VPackValue(CURRENT_COLLECTIONS + dbName + "/" + colName + "/" + shName));
+            if (!inCurrent || !equivalent(localCollectionInfo.slice(), cur.get(cp))) {
+              report.add(VPackValue(CURRENT_COLLECTIONS + dbName + "/" + colName + "/" + shName));
 
-            {
-              VPackObjectBuilder o(&report);
-              report.add(OP, VP_SET);
-              // Report new current entry ...
-              report.add("payload", localCollectionInfo.slice());
-              // ... if and only if plan for this shard has changed in the
-              // meantime Add a precondition:
-              report.add(VPackValue("precondition"));
               {
-                VPackObjectBuilder p(&report);
-                report.add(PLAN_COLLECTIONS + dbName + "/" + colName + "/shards/" + shName,
-                           thePlanList);
+                VPackObjectBuilder o(&report);
+                report.add(OP, VP_SET);
+                // Report new current entry ...
+                report.add("payload", localCollectionInfo.slice());
+                // ... if and only if plan for this shard has changed in the
+                // meantime Add a precondition:
+                report.add(VPackValue("precondition"));
+                {
+                  VPackObjectBuilder p(&report);
+                  report.add(PLAN_COLLECTIONS + dbName + "/" + colName + "/shards/" + shName,
+                             thePlanList);
+                }
               }
             }
+          } catch (std::exception const& ex) {
+            LOG_TOPIC("cc837", WARN, Logger::MAINTENANCE) 
+                << "caught exception in Maintenance for database '" << dbName << "': " << ex.what();
+            throw;
           }
         } else {  // Follower
 
           if (cur.isObject()) {
-            auto servers =
-              std::vector<std::string>{
-              AgencyCommHelper::path(), CURRENT, COLLECTIONS, dbName, colName, shName, SERVERS};
-            auto s = cur.get(servers);
-            if (s.isArray() && cur.get(servers)[0].copyString() == serverId) {
-              // We are in the situation after a restart, that we do not know
-              // who the leader is because FollowerInfo is not updated yet.
-              // Hence, in the case we are the Leader in Plan but do not
-              // know it yet, do nothing here.
-              if (shSlice.get("theLeaderTouched").isTrue()) {
-                // we were previously leader and we are done resigning.
-                // update current and let supervision handle the rest, however
-                // check that we are in the Plan a leader which is supposed to
-                // resign and add a precondition that this is still the case:
+            try {
+              auto servers =
+                std::vector<std::string>{
+                AgencyCommHelper::path(), CURRENT, COLLECTIONS, dbName, colName, shName, SERVERS};
+              auto s = cur.get(servers);
+              if (s.isArray() && s[0].copyString() == serverId) {
+                // We are in the situation after a restart, that we do not know
+                // who the leader is because FollowerInfo is not updated yet.
+                // Hence, in the case we are the Leader in Plan but do not
+                // know it yet, do nothing here.
+                if (shSlice.get("theLeaderTouched").isTrue()) {
+                  // we were previously leader and we are done resigning.
+                  // update current and let supervision handle the rest, however
+                  // check that we are in the Plan a leader which is supposed to
+                  // resign and add a precondition that this is still the case:
 
-                auto const planPath =
-                  std::vector<std::string>{colName, "shards", shName};
-                if (!pdb.isObject() || !pdb.hasKey(planPath)) {
-                  LOG_TOPIC("65432", DEBUG, Logger::MAINTENANCE)
-                    << "Ooops, we have a shard for which we believe that we "
-                    "just resigned, but the Plan does not have it any "
-                    "more,"
-                    " we do not report in Current about this, database: "
-                    << dbName << ", shard: " << shName;
-                  continue;
-                }
+                  auto const planPath =
+                    std::vector<std::string>{colName, "shards", shName};
+                  if (!pdb.isObject() || !pdb.hasKey(planPath)) {
+                    LOG_TOPIC("65432", DEBUG, Logger::MAINTENANCE)
+                      << "Ooops, we have a shard for which we believe that we "
+                      "just resigned, but the Plan does not have it any "
+                      "more,"
+                      " we do not report in Current about this, database: "
+                      << dbName << ", shard: " << shName;
+                    continue;
+                  }
 
-                VPackSlice thePlanList = pdb.get(planPath);
-                if (!thePlanList.isArray() || thePlanList.length() == 0 ||
-                    !thePlanList[0].isString() ||
-                    !thePlanList[0].isEqualStringUnchecked(UNDERSCORE + serverId)) {
-                  LOG_TOPIC("99987", DEBUG, Logger::MAINTENANCE)
-                    << "Ooops, we have a shard for which we believe that we "
-                    "have just resigned, but the Plan says otherwise, we "
-                    "do not report in Current about this, database: "
-                    << dbName << ", shard: " << shName;
-                  continue;
-                }
-                VPackBuilder ns;
-                {
-                  VPackArrayBuilder a(&ns);
-                  if (s.isArray()) {
-                    bool front = true;
-                    for (auto const& i : VPackArrayIterator(s)) {
-                      ns.add(VPackValue((!front) ? i.copyString()
-                                        : UNDERSCORE + i.copyString()));
-                      front = false;
+                  VPackSlice thePlanList = pdb.get(planPath);
+                  if (!thePlanList.isArray() || thePlanList.length() == 0 ||
+                      !thePlanList[0].isString() ||
+                      !thePlanList[0].isEqualStringUnchecked(UNDERSCORE + serverId)) {
+                    LOG_TOPIC("99987", DEBUG, Logger::MAINTENANCE)
+                      << "Ooops, we have a shard for which we believe that we "
+                      "have just resigned, but the Plan says otherwise, we "
+                      "do not report in Current about this, database: "
+                      << dbName << ", shard: " << shName;
+                    continue;
+                  }
+                  VPackBuilder ns;
+                  {
+                    VPackArrayBuilder a(&ns);
+                    if (s.isArray()) {
+                      bool front = true;
+                      for (auto const& i : VPackArrayIterator(s)) {
+                        ns.add(VPackValue((!front) ? i.copyString()
+                                          : UNDERSCORE + i.copyString()));
+                        front = false;
+                      }
+                    }
+                  }
+                  report.add(VPackValue(CURRENT_COLLECTIONS + dbName + "/" +
+                                        colName + "/" + shName + "/" + SERVERS));
+
+                  {
+                    VPackObjectBuilder o(&report);
+                    report.add(OP, VP_SET);
+                    report.add("payload", ns.slice());
+                    {
+                      VPackObjectBuilder p(&report, "precondition");
+                      report.add(PLAN_COLLECTIONS + dbName + "/" + colName +
+                                 "/shards/" + shName,
+                                 thePlanList);
                     }
                   }
                 }
-                report.add(VPackValue(CURRENT_COLLECTIONS + dbName + "/" +
-                                      colName + "/" + shName + "/" + SERVERS));
-
-                {
-                  VPackObjectBuilder o(&report);
-                  report.add(OP, VP_SET);
-                  report.add("payload", ns.slice());
-                  {
-                    VPackObjectBuilder p(&report, "precondition");
-                    report.add(PLAN_COLLECTIONS + dbName + "/" + colName +
-                               "/shards/" + shName,
-                               thePlanList);
-                  }
-                }
               }
+            } catch (std::exception const& ex) {
+              LOG_TOPIC("8f63e", WARN, Logger::MAINTENANCE) 
+                  << "caught exception in Maintenance for database '" << dbName << "': " << ex.what();
+              throw;
             }
           }
         }
@@ -1298,65 +1320,31 @@ arangodb::Result arangodb::maintenance::reportInCurrent(
     }
 
     // UpdateCurrentForDatabases
-    VPackSlice cdb;
-    cdbpath = std::vector<std::string>{AgencyCommHelper::path(), CURRENT, DATABASES, dbName};
-    if (cur.isObject() && cur.hasKey(cdbpath)) {
-      cdb = cur.get(cdbpath);
-    }
-
-    if (cdb.isObject()) {
-
-      VPackSlice myEntry = cdb.get(serverId);
-      if (!myEntry.isNone()) {
-        // Database no longer in Plan and local
-
-        if (lit == local.end() && (pit == plan.end() || pdb.isNone())) {
-          // This covers the case that the database is neither in Local nor in
-          // Plan. It remains to make sure an error is reported to Current if
-          // there is a database in the Plan but not in Local
-          report.add(VPackValue(CURRENT_DATABASES + dbName + "/" + serverId));
-          {
-            VPackObjectBuilder o(&report);
-            report.add(OP, VP_DELETE);
-          }
-          // We delete all under /Current/Collections/<dbName>, it does not
-          // hurt if every DBserver does this, since it is an idempotent
-          // operation.
-          report.add(VPackValue(CURRENT_COLLECTIONS + dbName));
-          {
-            VPackObjectBuilder o(&report);
-            report.add(OP, VP_DELETE);
-          }
-        }
+    try {
+      VPackSlice cdb;
+      if (cur.isObject()) {
+        cdbpath = std::vector<std::string>{AgencyCommHelper::path(), CURRENT, DATABASES, dbName};
+        cdb = cur.get(cdbpath);
       }
-    }
 
-    // UpdateCurrentForCollections
-    std::vector<std::string> curcolpath{AgencyCommHelper::path(), CURRENT, COLLECTIONS, dbName};
-    VPackSlice curcolls;
-    if (cur.isObject() && cur.hasKey(curcolpath)) {
-      curcolls = cur.get(curcolpath);
-    }
+      if (cdb.isObject()) {
+        VPackSlice myEntry = cdb.get(serverId);
+        if (!myEntry.isNone()) {
+          // Database no longer in Plan and local
 
-    // UpdateCurrentForCollections (Current/Collections/Collection)
-    if (curcolls.isObject()) {
-      for (auto const& collection : VPackObjectIterator(curcolls)) {
-        auto const colName = collection.key.copyString();
-
-        for (auto const& shard : VPackObjectIterator(collection.value)) {
-          auto const shName = shard.key.copyString();
-
-          // Shard in current and has servers
-          auto servers = shard.value.get(SERVERS);
-
-          if (!pdb.isObject()) { //This database is no longer in plan,
-            continue;            // thus no shardMap exists for it
-          }
-          if (servers.isArray() && servers.length() > 0  // servers in current
-              && servers[0].stringRef() == serverId     // we are leading
-              && !ldb.hasKey(shName)  // no local collection
-              && !shardMap.slice().hasKey(shName)) {  // no such shard in plan
-            report.add(VPackValue(CURRENT_COLLECTIONS + dbName + "/" + colName + "/" + shName));
+          if (lit == local.end() && (pit == plan.end() || pdb.isNone())) {
+            // This covers the case that the database is neither in Local nor in
+            // Plan. It remains to make sure an error is reported to Current if
+            // there is a database in the Plan but not in Local
+            report.add(VPackValue(CURRENT_DATABASES + dbName + "/" + serverId));
+            {
+              VPackObjectBuilder o(&report);
+              report.add(OP, VP_DELETE);
+            }
+            // We delete all under /Current/Collections/<dbName>, it does not
+            // hurt if every DBserver does this, since it is an idempotent
+            // operation.
+            report.add(VPackValue(CURRENT_COLLECTIONS + dbName));
             {
               VPackObjectBuilder o(&report);
               report.add(OP, VP_DELETE);
@@ -1364,80 +1352,150 @@ arangodb::Result arangodb::maintenance::reportInCurrent(
           }
         }
       }
+    } catch (std::exception const& ex) {
+      LOG_TOPIC("999ff", WARN, Logger::MAINTENANCE) 
+          << "caught exception in Maintenance for database '" << dbName << "': " << ex.what();
+      throw;
+    }
+  
+
+    // UpdateCurrentForCollections
+    try {
+      std::vector<std::string> curcolpath{AgencyCommHelper::path(), CURRENT, COLLECTIONS, dbName};
+      VPackSlice curcolls;
+      if (cur.isObject() && cur.hasKey(curcolpath)) {
+        curcolls = cur.get(curcolpath);
+      }
+
+      // UpdateCurrentForCollections (Current/Collections/Collection)
+      if (curcolls.isObject()) {
+        for (auto const& collection : VPackObjectIterator(curcolls)) {
+          auto const colName = collection.key.copyString();
+
+          TRI_ASSERT(collection.value.isObject());
+          for (auto const& shard : VPackObjectIterator(collection.value)) {
+            TRI_ASSERT(shard.value.isObject());
+
+            if (!pdb.isObject()) { //This database is no longer in plan,
+              continue;            // thus no shardMap exists for it
+            }
+            
+            // Shard in current and has servers
+            auto servers = shard.value.get(SERVERS);
+            auto const shName = shard.key.copyString();
+
+            TRI_ASSERT(ldb.isObject());
+            
+            if (servers.isArray() && servers.length() > 0  // servers in current
+                && servers[0].stringRef() == serverId     // we are leading
+                && !ldb.hasKey(shName)  // no local collection
+                && !shardMap.slice().hasKey(shName)) {  // no such shard in plan
+              report.add(VPackValue(CURRENT_COLLECTIONS + dbName + "/" + colName + "/" + shName));
+              {
+                VPackObjectBuilder o(&report);
+                report.add(OP, VP_DELETE);
+              }
+            }
+          }
+        }
+      }
+    } catch (std::exception const& ex) {
+      LOG_TOPIC("13c97", WARN, Logger::MAINTENANCE) 
+          << "caught exception in Maintenance for database '" << dbName << "': " << ex.what();
+      throw;
     }
 
-  }
+  } // next database
 
   // Let's find database errors for databases which do not occur in Local
   // but in Plan:
-  for (auto const& p : allErrors.databases) {
-    auto const& dbName = p.first;
-    if (dirty.find(dbName) != dirty.end()) {
-      // Need to create an error entry:
-      report.add(VPackValue(CURRENT_DATABASES + dbName + "/" + serverId));
-      {
-        VPackObjectBuilder o(&report);
-        report.add(OP, VP_SET);
-        report.add(VPackValue("payload"));
+  try {
+    for (auto const& p : allErrors.databases) {
+      auto const& dbName = p.first;
+      if (dirty.find(dbName) != dirty.end()) {
+        // Need to create an error entry:
+        report.add(VPackValue(CURRENT_DATABASES + dbName + "/" + serverId));
         {
-          VPackObjectBuilder pp(&report);
-          VPackSlice errs(static_cast<uint8_t const*>(p.second->data()));
-          report.add(StaticStrings::Error, errs.get(StaticStrings::Error));
-          report.add(StaticStrings::ErrorNum, errs.get(StaticStrings::ErrorNum));
-          report.add(StaticStrings::ErrorMessage, errs.get(StaticStrings::ErrorMessage));
+          VPackObjectBuilder o(&report);
+          report.add(OP, VP_SET);
+          report.add(VPackValue("payload"));
+          {
+            VPackObjectBuilder pp(&report);
+            VPackSlice errs(static_cast<uint8_t const*>(p.second->data()));
+            TRI_ASSERT(errs.isObject());
+            report.add(StaticStrings::Error, errs.get(StaticStrings::Error));
+            report.add(StaticStrings::ErrorNum, errs.get(StaticStrings::ErrorNum));
+            report.add(StaticStrings::ErrorMessage, errs.get(StaticStrings::ErrorMessage));
+          }
         }
       }
     }
+  } catch (std::exception const& ex) {
+    LOG_TOPIC("d40a3", WARN, Logger::MAINTENANCE) 
+        << "caught exception in Maintenance databases error reporting: " << ex.what();
+    throw;
   }
 
   // Finally, let's find shard errors for shards which do not occur in
   // Local but in Plan, we need to make sure that these errors are reported
   // in Current:
-  for (auto const& p : allErrors.shards) {
-    // First split the key:
-    std::string const& key = p.first;
-    auto pos = key.find('/');
-    TRI_ASSERT(pos != std::string::npos);
-    std::string d = key.substr(0, pos);  // database
-    if (dirty.find(d) != dirty.end()) {
-      auto const pit = plan.find(d);
-      if (pit == plan.end()) {
-        continue;
-      }
-      auto const lit = local.find(d);
-      auto const cit = current.find(d);
+  try {
+    for (auto const& p : allErrors.shards) {
+      // First split the key:
+      std::string const& key = p.first;
+      auto pos = key.find('/');
+      TRI_ASSERT(pos != std::string::npos);
+      std::string d = key.substr(0, pos);  // database
+      if (dirty.find(d) != dirty.end()) {
+        auto const pit = plan.find(d);
+        if (pit == plan.end()) {
+          continue;
+        }
+        auto const lit = local.find(d);
+        auto const cit = current.find(d);
 
-      if (lit != local.end()) {
-        auto pos2 = key.find('/', pos + 1);  // collection
-        TRI_ASSERT(pos2 != std::string::npos);
+        if (lit != local.end()) {
+          auto pos2 = key.find('/', pos + 1);  // collection
+          TRI_ASSERT(pos2 != std::string::npos);
 
-        std::string c = key.substr(pos + 1, pos2);
-        std::string s = key.substr(pos2 + 1);  // shard name
-        auto const pdb = pit->second->slice();
-        auto const ldb = lit->second->slice();
+          std::string c = key.substr(pos + 1, pos2);
+          std::string s = key.substr(pos2 + 1);  // shard name
+          auto const pdb = pit->second->slice();
+          auto const ldb = lit->second->slice();
 
-        // Now find out if the shard appears in the Plan but not in Local:
-        std::vector<std::string> const planPath {
-          AgencyCommHelper::path(), PLAN, COLLECTIONS, d, c, "shards", s};
-        if (pdb.hasKey(planPath) && !ldb.hasKey(s)) {
-          VPackSlice servers = pdb.get(planPath);
-          if (servers.isArray()) {
-            std::vector<std::string> const curPath {
-              AgencyCommHelper::path(), CURRENT, COLLECTIONS, d, c, s};
-            VPackSlice theErr(static_cast<uint8_t const*>(p.second->data()));
-            if (!cit->second->slice().hasKey(curPath) ||
-                !equivalent(theErr, cit->second->slice().get(curPath))) {
-              report.add(VPackValue(CURRENT_COLLECTIONS + d + "/" + c + "/" + s));
-              {
-                VPackObjectBuilder o(&report);
-                report.add(OP, VP_SET);
-                report.add("payload", theErr);
+          // Now find out if the shard appears in the Plan but not in Local:
+          std::vector<std::string> const planPath {
+            AgencyCommHelper::path(), PLAN, COLLECTIONS, d, c, "shards", s};
+
+          TRI_ASSERT(pdb.isObject());
+          TRI_ASSERT(ldb.isObject());
+          if (pdb.hasKey(planPath) && !ldb.hasKey(s)) {
+            VPackSlice servers = pdb.get(planPath);
+            if (servers.isArray()) {
+              TRI_ASSERT(cit != current.end());
+
+              std::vector<std::string> const curPath {
+                AgencyCommHelper::path(), CURRENT, COLLECTIONS, d, c, s};
+              VPackSlice theErr(static_cast<uint8_t const*>(p.second->data()));
+              TRI_ASSERT(cit->second->slice().isObject());
+              if (!cit->second->slice().hasKey(curPath) ||
+                  !equivalent(theErr, cit->second->slice().get(curPath))) {
+                report.add(VPackValue(CURRENT_COLLECTIONS + d + "/" + c + "/" + s));
+                {
+                  VPackObjectBuilder o(&report);
+                  report.add(OP, VP_SET);
+                  report.add("payload", theErr);
+                }
               }
             }
           }
         }
       }
     }
+  } catch (std::exception const& ex) {
+    LOG_TOPIC("ceb1a", WARN, Logger::MAINTENANCE) 
+        << "caught exception in Maintenance shards error reporting: " << ex.what();
+    throw;
   }
 
   return {};
@@ -1484,6 +1542,8 @@ void arangodb::maintenance::syncReplicatedShardsWithLeaders(
     VPackSlice cdb;
     if (cit != current.end()) {
       cdb = cit->second->slice()[0];
+      TRI_ASSERT(cdb.isObject());
+
       auto const cpath =
         std::vector<std::string>{AgencyCommHelper::path(), CURRENT, COLLECTIONS, dbname};
       if (!cdb.hasKey(cpath)) {
@@ -1495,15 +1555,17 @@ void arangodb::maintenance::syncReplicatedShardsWithLeaders(
       continue;
     }
 
-
+    TRI_ASSERT(pdb.isObject());
     for (auto const& pcol : VPackObjectIterator(pdb)) {
       VPackStringRef const colname = pcol.key.stringRef();
 
+      TRI_ASSERT(cdb.isObject());
       VPackSlice const cdbcol = cdb.get(colname);
       if (!cdbcol.isObject()) {
         continue;
       }
 
+      TRI_ASSERT(pcol.value.isObject());
       for (auto const& pshrd : VPackObjectIterator(pcol.value.get(SHARDS))) {
         VPackStringRef const shname = pshrd.key.stringRef();
 
@@ -1608,7 +1670,7 @@ arangodb::Result arangodb::maintenance::phaseTwo(
                                  serverId, report, shardStats);
       } catch (std::exception const& e) {
         LOG_TOPIC("c9a75", ERR, Logger::MAINTENANCE)
-          << "Error reporting in current: " << e.what() << ". " << __FILE__ << ":" << __LINE__;
+          << "Error reporting in current: " << e.what();
       }
     }
 
@@ -1622,7 +1684,7 @@ arangodb::Result arangodb::maintenance::phaseTwo(
         feature.addDirty(makeDirty, false);
       } catch (std::exception const& e) {
         LOG_TOPIC("7e286", ERR, Logger::MAINTENANCE)
-          << "Error scheduling shards: " << e.what() << ". " << __FILE__ << ":" << __LINE__;
+          << "Error scheduling shards: " << e.what();
       }
     }
   }

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -1126,8 +1126,6 @@ arangodb::Result arangodb::maintenance::reportInCurrent(
         AgencyCommHelper::path(), PLAN, COLLECTIONS, dbName};
       TRI_ASSERT(pdb.isObject());
 
-      TRI_ASSERT(pdb.isObject());
-
       // Plan of this database's collections
       pdb = pdb.get(ppath);
       if (!pdb.isNone()) {

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -497,6 +497,10 @@ VPackBuilder getShardMap(VPackSlice const& collections) {
     if (collections.isObject()) {
       for (auto collection : VPackObjectIterator(collections)) {
         TRI_ASSERT(collection.value.isObject());
+        if (!collection.value.get(SHARDS).isObject()) {
+          continue;
+        }
+
         for (auto shard : VPackObjectIterator(collection.value.get(SHARDS))) {
           shardMap.add(shard.key.stringRef(), shard.value);
         }

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -513,12 +513,12 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
   try {
     std::string const context = "synchronization of shard " + database + "/" + col->name();
     Result r = syncer->run(configuration._incremental, context.c_str());
-
+  
     if (r.fail()) {
       LOG_TOPIC("3efff", DEBUG, Logger::REPLICATION)
           << "initial sync failed for " << database << "/" << col->name()
           << ": " << r.errorMessage();
-      THROW_ARANGO_EXCEPTION_MESSAGE(r.errorNumber(), r.errorMessage());
+      THROW_ARANGO_EXCEPTION(r);
     }
 
     {


### PR DESCRIPTION
### Scope & Purpose

Add more granular error reporting to `reportInCurrent` maintenance function, and add lots of assertions.
This is not a bugfix, but a vehicle to simplify debugging and bug hunts.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13495/