### PR TITLE
fix spurious error in shell-pregel.js test suite

### DIFF
--- a/tests/js/common/shell/shell-pregel.js
+++ b/tests/js/common/shell/shell-pregel.js
@@ -51,12 +51,14 @@ function testAlgo(a, p) {
       assertEqual(stats.vertexCount, 11, stats);
       assertEqual(stats.edgeCount, 17, stats);
       let attrs = ["totalRuntime", "startupTime", "computationTime"];
-      if (p.store) {
-        attrs.push("storageTime");
+      if (p.store && stats.hasOwnProperty('storageTime')) {
+        assertEqual("number", typeof stats.storageTime);
+        assertTrue(stats.storageTime >= 0.0, stats);
       }
       attrs.forEach((k) => {
         assertTrue(stats.hasOwnProperty(k), { p, stats });
         assertEqual("number", typeof stats[k]);
+        assertTrue(stats[k] >= 0.0, stats);
       });
 
       db[vColl].all().toArray()


### PR DESCRIPTION
### Scope & Purpose

Fix spurious error in shell-pregel.js `shell_client` or `shell_server` tests.
This is an error in the test only, which assumes that the attribute "storageTime" is always present in the result if "store" is true. However, this is not guaranteed, as the status of a Pregel run can be checked _before_ the run is completed. In that case, the "storageTime" attribute is intentionally missing from the result.
This is a test fix only, so there is no CHANGELOG entry for it.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.7

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *shell_client, shell_server*.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13502/