### PR TITLE
added metrics "arangodb_server_statistics_cpu_cores"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 devel
 -----
 
+* Added metric `arangodb_server_statistics_cpu_cores` to provide the number of
+  CPU cores visibile to the arangod process. This is the number of CPU cores
+  reported by the operating system to the process.
+  If the environment variable `ARANGODB_OVERRIDE_DETECTED_NUMBER_OF_CORES` is
+  set to a positive value at instance startup, this value will be returned
+  instead.
+
 * `COLLECT WITH COUNT INTO x` and `COLLECT var = expr WITH COUNT INTO x` are now
   internally transformed into `COLLECT AGGREGATE x = LENGTH(null)` and
   `COLLECT var = expr AGGREGATE x = LENGTH(null)` respectively. This not only

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -25,6 +25,7 @@
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "ApplicationFeatures/CpuUsageFeature.h"
+#include "Basics/NumberOfCores.h"
 #include "Basics/PhysicalMemory.h"
 #include "Basics/application-exit.h"
 #include "Basics/process-utils.h"
@@ -199,6 +200,9 @@ std::map<std::string, std::vector<std::string>> statStrings{
   {"physicalSize",
    {"arangodb_server_statistics_physical_memory", "gauge",
     "Physical memory in bytes"}},
+  {"cores",
+   {"arangodb_server_statistics_cpu_cores", "gauge",
+    "Number of CPU cores visible to the arangod process"}},
   {"userPercent",
    {"arangodb_server_statistics_user_percent", "gauge",
     "Percentage of time that the system CPUs have spent in user mode"}},
@@ -512,6 +516,7 @@ void StatisticsFeature::toPrometheus(std::string& result, double const& now) {
   appendMetric(result, std::to_string(info._virtualSize), "virtualSize");
   appendMetric(result, std::to_string(PhysicalMemory::getValue()), "physicalSize");
   appendMetric(result, std::to_string(serverInfo.uptime()), "uptime");
+  appendMetric(result, std::to_string(NumberOfCores::getValue()), "cores");
 
   CpuUsageFeature& cpuUsage = server().getFeature<CpuUsageFeature>();
   if (cpuUsage.isEnabled()) {


### PR DESCRIPTION
### Scope & Purpose

Added metric `arangodb_server_statistics_cpu_cores` to provide the number of CPU cores visibile to the arangod process. This is the number of CPU cores reported by the operating system to the process.
If the environment variable `ARANGODB_OVERRIDE_DETECTED_NUMBER_OF_CORES` is set to a positive value at instance startup, this value will be returned instead.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13512/