### PR TITLE
fix two issues with COLLECT COUNT

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,12 +2,13 @@ devel
 -----
 
 * `COLLECT WITH COUNT INTO x` and `COLLECT var = expr WITH COUNT INTO x` are now
-  internally transformed into `COLLECT AGGREGATE x = LENGTH(null)` and
-  `COLLECT var = expr AGGREGATE x = LENGTH(null)` respectively. This not only
-  simplified the code, but also allows more query optimizations:
+  internally transformed into `COLLECT AGGREGATE x = LENGTH()` and
+  `COLLECT var = expr AGGREGATE x = LENGTH()` respectively. In addition, any
+  argument passed to the `COUNT`/`LENGTH` aggregator functions are now optimized
+  away. This not only simplified the code, but also allows more query optimizations:
     - If the variable in `COLLECT WITH COUNT INTO var` is not used, the implicit
       aggregator is now removed.
-    - All queries of the form `COLLECT AGGREGATE x = LENGTH(_)` are now executed
+    - All queries of the form `COLLECT AGGREGATE x = LENGTH()` are now executed
       using the count executor, which can result in significantly improved
       performance.
 

--- a/arangod/Aql/RegisterPlan.cpp
+++ b/arangod/Aql/RegisterPlan.cpp
@@ -327,10 +327,6 @@ void RegisterPlanWalkerT<T>::after(T* en) {
   TRI_ASSERT(regsToKeepStack == actual);
 #endif
   
-  if (en->getType() == ExecutionNode::COLLECT) {
-    LOG_DEVEL << "REGISTERPLAN REGS TO CLEAR: " << regsToClear;
-  }
-
   // We need to delete those variables that have been used here but are
   // not used any more later:
   en->setRegsToClear(std::move(regsToClear));

--- a/arangod/Aql/RegisterPlan.cpp
+++ b/arangod/Aql/RegisterPlan.cpp
@@ -326,6 +326,10 @@ void RegisterPlanWalkerT<T>::after(T* en) {
                                      en->getVariablesSetHere());
   TRI_ASSERT(regsToKeepStack == actual);
 #endif
+  
+  if (en->getType() == ExecutionNode::COLLECT) {
+    LOG_DEVEL << "REGISTERPLAN REGS TO CLEAR: " << regsToClear;
+  }
 
   // We need to delete those variables that have been used here but are
   // not used any more later:
@@ -455,7 +459,6 @@ void RegisterPlanT<T>::toVelocyPackEmpty(VPackBuilder& builder) {
   { VPackArrayBuilder guard(&builder); }
   builder.add(VPackValue("nrRegs"));
   { VPackArrayBuilder guard(&builder); }
-  builder.add("totalNrRegs", VPackValue(0));
 }
 
 template <typename T>
@@ -480,15 +483,6 @@ void RegisterPlanT<T>::toVelocyPack(VPackBuilder& builder) const {
       builder.add(VPackValue(oneRegisterID));
     }
   }
-
-  // nrRegsHere is not used anymore and is intentionally left empty
-  // can be removed in ArangoDB 3.8
-  builder.add(VPackValue("nrRegsHere"));
-  { VPackArrayBuilder guard(&builder); }
-
-  // totalNrRegs is not used anymore and is intentionally left empty
-  // can be removed in ArangoDB 3.8
-  builder.add("totalNrRegs", VPackSlice::noneSlice());
 }
 
 template <typename T>

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -670,15 +670,13 @@ RestStatus RestAqlHandler::handleUseQuery(std::string const& operation,
     if (shardId.empty()) {
       std::tie(state, skipped, items) =
           _engine->execute(executeCall.callStack());
-      if (state == ExecutionState::WAITING) {
-        return RestStatus::WAITING;
-      }
     } else {
       std::tie(state, skipped, items) =
           _engine->executeForClient(executeCall.callStack(), shardId);
-      if (state == ExecutionState::WAITING) {
-        return RestStatus::WAITING;
-      }
+    }
+      
+    if (state == ExecutionState::WAITING) {
+      return RestStatus::WAITING;
     }
 
     auto result = AqlExecuteResult{state, skipped, std::move(items)};

--- a/arangod/Aql/SortedCollectExecutor.cpp
+++ b/arangod/Aql/SortedCollectExecutor.cpp
@@ -143,7 +143,7 @@ SortedCollectExecutor::SortedCollectExecutor(Fetcher&, Infos& infos)
   // Initialize group with invalid input
   InputAqlItemRow emptyInput{CreateInvalidInputRowHint{}};
   _currentGroup.reset(emptyInput);
-};
+}
 
 void SortedCollectExecutor::CollectGroup::addLine(InputAqlItemRow const& input) {
   // remember the last valid row we had

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -1667,7 +1667,7 @@ function processQuery(query, explain, planIndex) {
           }
           collect += keyword('AGGREGATE') + ' ' +
             node.aggregates.map(function (node) {
-              return variableName(node.outVariable) + ' = ' + func(node.type) + '(' + variableName(node.inVariable) + ')';
+              return variableName(node.outVariable) + ' = ' + func(node.type) + '(' + (node.inVariable ? variableName(node.inVariable) : '') + ')';
             }).join(', ');
         }
         collect +=

--- a/tests/js/server/aql/aql-optimizer-collect-count.js
+++ b/tests/js/server/aql/aql-optimizer-collect-count.js
@@ -107,6 +107,9 @@ function optimizerCountTestSuite () {
         assertEqual("cnt", collectNode.aggregates[0].outVariable.name);
         assertEqual("LENGTH", collectNode.aggregates[0].type);
       }
+
+      let output = require("@arangodb/aql/explainer").explain(query, {colors: false}, false);
+      assertTrue(/\COLLECT AGGREGATE cnt = LENGTH\(\)/.test(output));
     },
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose

Fix two issues with COLLECT COUNT:

* When using a query such as

      FOR i IN 1..1000
        COLLECT AGGREGATE c = COUNT(1)
        RETURN c

  the input variable for COUNT (value `1`) is not needed.
  This PR changes the aggregate variable info in the CollectNode so
  that it forgets about its input variable, allowing further
  optimizer steps to remove the input variable altogether if not
  used elsewhere in the query.

  The above query will now be optimized to

      FOR i IN 1..1000
        COLLECT AGGREGATE c = COUNT()
        RETURN c

* The explainer was not prepared to handle aggregates
  that did not have any input variables, e.g. `AGGREAGTE c = COUNT()`.
  When using them, the explainer produced a JavaScript error.
  This is now fixed.

No CHANGELOG entry added yet because this is a fix/optimization for devel-only functionality that was only very recently added.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/job/arangodb-matrix-pr-mac-onlycatch/10773/