### PR TITLE
added configuration option `--audit.queue` for audit logging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,17 @@
 devel
 -----
 
+* Added startup options `--audit.queue` to control audit logging queuing
+  behavior (Enterprise Edition only):
+
+  The option controls whether audit log messages are submitted to a queue 
+  and written to disk in batches or if they should be written to disk directly 
+  without being queued.
+  Queueing audit log entries may be beneficial for latency, but can lead to
+  unqueued messages being lost in case of a power loss or crash. Setting
+  this option to `false` mimics the behavior from 3.7 and before, where
+  audit log messages where not queued but written in a blocking fashion.
+
 * Fixed some situations of
   [...]
   SUBQUERY

--- a/lib/Basics/debugging.cpp
+++ b/lib/Basics/debugging.cpp
@@ -149,9 +149,14 @@ bool TRI_ShouldFailDebugging(char const* value) {
 
 /// @brief add a failure point
 void TRI_AddFailurePointDebugging(char const* value) {
-  WRITE_LOCKER(writeLocker, ::failurePointsLock);
+  bool added = false;
+  {
+    WRITE_LOCKER(writeLocker, ::failurePointsLock);
 
-  if (::failurePoints.emplace(value).second) {
+    added = ::failurePoints.emplace(value).second;
+  }
+
+  if (added) {
     LOG_TOPIC("d8a5f", WARN, arangodb::Logger::FIXME)
         << "activating intentional failure point '" << value
         << "'. the server will misbehave!";

--- a/lib/Logger/LogThread.cpp
+++ b/lib/Logger/LogThread.cpp
@@ -23,6 +23,7 @@
 
 #include "LogThread.h"
 #include "Basics/ConditionLocker.h"
+#include "Basics/debugging.h"
 #include "Logger/LogAppender.h"
 #include "Logger/Logger.h"
 
@@ -40,6 +41,11 @@ LogThread::~LogThread() {
 
 bool LogThread::log(LogGroup& group, std::unique_ptr<LogMessage>& message) {
   TRI_ASSERT(message != nullptr);
+
+  TRI_IF_FAILURE("LogThread::log") {
+    // simulate a successful logging, but actually don't log anything
+    return true;
+  }
 
   bool const isDirectLogLevel =
              (message->_level == LogLevel::FATAL || message->_level == LogLevel::ERR || message->_level == LogLevel::WARN);

--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -559,7 +559,7 @@ void Logger::log(char const* logid, char const* function, char const* file, int 
 
   auto msg = std::make_unique<LogMessage>(function, file, line, level, topicId, std::move(out), offset);
 
-  append(defaultLogGroup(), msg, [level, topicId](std::unique_ptr<LogMessage>& msg) -> void {
+  append(defaultLogGroup(), msg, false, [level, topicId](std::unique_ptr<LogMessage>& msg) -> void {
     LogAppenderStdStream::writeLogMessage(STDERR_FILENO, (isatty(STDERR_FILENO) == 1),
                                           level, topicId, msg->_message.data(),
                                           msg->_message.size(), true);
@@ -569,9 +569,10 @@ void Logger::log(char const* logid, char const* function, char const* file, int 
 }
 
 void Logger::append(LogGroup& group, std::unique_ptr<LogMessage>& msg,
+                    bool forceDirect,
                     std::function<void(std::unique_ptr<LogMessage>&)> const& inactive) {
   // first log to all "global" appenders, which are the in-memory ring buffer logger plus
-  // some Windows-specifc appenders for the debug output windows and the Windows event log.
+  // some Windows-specifc appenders for the debug output window and the Windows event log.
   // note that these loggers do not require any configuration so we can always and safely invoke them.
   LogAppender::logGlobal(group, *msg);
 
@@ -581,7 +582,7 @@ void Logger::append(LogGroup& group, std::unique_ptr<LogMessage>& msg,
   } else {
     // now either queue or output the message
     bool handled = false;
-    if (_threaded) {
+    if (_threaded && !forceDirect) {
       handled = _loggingThread->log(group, msg);
     }
 

--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -588,6 +588,12 @@ void Logger::append(LogGroup& group, std::unique_ptr<LogMessage>& msg,
 
     if (!handled) {
       TRI_ASSERT(msg != nullptr);
+
+      TRI_IF_FAILURE("Logger::append") {
+        // cut off all logging
+        return;
+      }
+
       LogAppender::log(group, *msg);
     }
   }

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -280,6 +280,7 @@ class Logger {
                   LogLevel level, size_t topicId, std::string const& message);
 
   static void append(LogGroup&, std::unique_ptr<LogMessage>& msg,
+                     bool forceDirect,
                      std::function<void(std::unique_ptr<LogMessage>&)> const& inactive =
                          [](std::unique_ptr<LogMessage>&) -> void {});
 


### PR DESCRIPTION
### Scope & Purpose


Added startup option `--audit.queue` to control audit logging queuing behavior (Enterprise Edition only):

  The option controls whether audit log messages are submitted to a queue 
  and written to disk in batches or if they should be written to disk directly 
  without being queued.
  Queueing audit log entries may be beneficial for latency, but can lead to
  unqueued messages being lost in case of a power loss or crash. Setting
  this option to `false` mimics the behavior from 3.7 and before, where
  audit log messages where not queued but written in a blocking fashion.

There is also an enterprise companion PR: https://github.com/arangodb/enterprise/pull/626

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Docs PR: TO DO
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/626

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13534/