### PR TITLE
Introduce --failed filter for unit tests.

### DIFF
--- a/README_maintainers.md
+++ b/README_maintainers.md
@@ -677,6 +677,14 @@ Running a test against a server you started (instead of letting the script start
 
     scripts/unittest http_server --test api-batch-spec.rb --server tcp://127.0.0.1:8529 --serverRoot /tmp/123
 
+Re-running previously failed tests:
+
+    scripts/unittest <args> --failed
+
+The `<args>` should be the same as in the previous run, only `--test`/`--testCase` can be omitted.
+The information which tests failed is taken from the `UNITTEST_RESULT.json` in your test output folder.
+This failed filter should work for all jsunity and mocha tests.
+
 #### Running Foxx Tests with a Fake Foxx Repo
 
 Since downloading Foxx apps from GitHub can be cumbersome with shaky DSL and

--- a/README_maintainers.md
+++ b/README_maintainers.md
@@ -683,7 +683,7 @@ Re-running previously failed tests:
 
 The `<args>` should be the same as in the previous run, only `--test`/`--testCase` can be omitted.
 The information which tests failed is taken from the `UNITTEST_RESULT.json` in your test output folder.
-This failed filter should work for all jsunity and mocha tests.
+This failed filter should work for all jsunity, mocha and rspec tests.
 
 #### Running Foxx Tests with a Fake Foxx Repo
 

--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -35,6 +35,7 @@ const fs = require('fs');
 const pu = require('@arangodb/testutils/process-utils');
 const cu = require('@arangodb/testutils/crash-utils');
 const yaml = require('js-yaml');
+const _ = require('lodash');
 
 /* Constants: */
 const BLUE = internal.COLORS.COLOR_BLUE;

--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -843,6 +843,27 @@ function yamlDumpResults(options, results) {
   }
 }
 
+function getFailedTestCases(options) {
+  try {
+    let resultFile = fs.join(options.testOutputDirectory, 'UNITTEST_RESULT.json');
+    let lastRun = JSON.parse(fs.readFileSync(resultFile));
+    let filter;
+    filter = (obj) => {
+      return _.pickBy(_.mapValues(obj, v => {
+          if (typeof v === 'object' && v.status === false) {
+            return filter(v);
+          }
+          return undefined;
+        }),
+        v => v !== undefined);
+    };
+    return filter(lastRun);
+  } catch (err) {
+    print("Failed to read previous test results");
+    throw err;
+  }
+}
+
 exports.gatherStatus = gatherStatus;
 exports.gatherFailed = gatherFailed;
 exports.yamlDumpResults = yamlDumpResults;
@@ -850,6 +871,7 @@ exports.addFailRunsMessage = addFailRunsMessage;
 exports.dumpAllResults = dumpAllResults;
 exports.writeDefaultReports = writeDefaultReports;
 exports.writeReports = writeReports;
+exports.getFailedTestCases = getFailedTestCases;
 
 exports.analyze = {
   unitTestPrettyPrintResults: unitTestPrettyPrintResults,

--- a/js/client/modules/@arangodb/testutils/test-utils.js
+++ b/js/client/modules/@arangodb/testutils/test-utils.js
@@ -263,7 +263,7 @@ function performTests (options, testList, testname, runFn, serverOptions, startS
         }
         if (pu.arangod.check.instanceAlive(instanceInfo, options) &&
             healthCheck(options, serverOptions, instanceInfo, customInstanceInfos, startStopHandlers)) {
-          continueTesting = true; 
+          continueTesting = true;
 
           // Check whether some collections & views were left behind, and if mark test as failed.
           let collectionsAfter = [];
@@ -292,7 +292,7 @@ function performTests (options, testList, testname, runFn, serverOptions, startS
 
           let deltaViews = diffArray(viewsBefore, viewsAfter).filter(function(name) {
             return ! ((name[0] === '_') || (name === "compact") || (name === "election")
-                     || (name === "log")); 
+                     || (name === "log"));
           });
           if ((delta.length !== 0) || (deltaViews.length !== 0)){
             results[te] = {
@@ -353,7 +353,7 @@ function performTests (options, testList, testname, runFn, serverOptions, startS
             message: 'server is dead: ' + msg + instanceInfo.message
           };
         }
-        
+
         if (startStopHandlers !== undefined && startStopHandlers.hasOwnProperty('alive')) {
           customInstanceInfos['alive'] = startStopHandlers.alive(options,
                                                                  serverOptions,
@@ -445,7 +445,7 @@ function performTests (options, testList, testname, runFn, serverOptions, startS
   results.shutdown = results.shutdown && pu.shutdownInstance(instanceInfo, clonedOpts, forceTerminate);
 
   loadClusterTestStabilityInfo(results, instanceInfo);
-  
+
   if (startStopHandlers !== undefined && startStopHandlers.hasOwnProperty('postStop')) {
     customInstanceInfos['postStop'] = startStopHandlers.postStop(options,
                                                                  serverOptions,
@@ -704,7 +704,7 @@ function getTestCode(file, options, instanceInfo) {
   if (file.indexOf('-spec') === -1) {
     filter = filter || '"undefined"';
     runTest = 'const runTest = require("jsunity").runTest;\n';
-      
+
   } else {
     filter = filter || '';
     runTest = 'const runTest = require("@arangodb/mocha-runner");\n';
@@ -721,7 +721,7 @@ function runThere (options, instanceInfo, file) {
     let testCode = getTestCode(file, options, instanceInfo);
     let httpOptions = pu.makeAuthorizationHeaders(options);
     httpOptions.method = 'POST';
-    
+
     httpOptions.timeout = options.oneTestTimeout;
     if (options.isAsan) {
       httpOptions.timeout *= 2;
@@ -824,7 +824,7 @@ function readTestResult(path, rc, testCase) {
     rc.failed = rc.status ? 0 : 1;
     rc.message = "readTestResult: don't know howto handle '" + buf + "'";
     return rc;
-  }    
+  }
 }
 
 function writeTestResult(path, data) {
@@ -886,7 +886,7 @@ function runInLocalArangosh (options, instanceInfo, file, addArgs) {
       arango.reconnect(newEndpoint, '_system', 'root', '');
     }
   }
-  
+
   let testCode = getTestCode(file, options, instanceInfo);
   print(testCode);
   require('internal').env.INSTANCEINFO = JSON.stringify(instanceInfo);
@@ -1037,7 +1037,7 @@ function runInRSpec (options, instanceInfo, file, addArgs) {
   if (rspec !== undefined) {
     args = [rspec].concat(args);
   }
-  
+
   let start = Date();
   const res = pu.executeAndWait(command, args, options, 'rspec', instanceInfo.rootDir, false, options.oneTestTimeout);
   let end = Date();

--- a/js/client/modules/@arangodb/testutils/test-utils.js
+++ b/js/client/modules/@arangodb/testutils/test-utils.js
@@ -692,7 +692,7 @@ function loadClusterTestStabilityInfo(results, instanceInfo){
 }
 
 function getTestCode(file, options, instanceInfo) {
-  let filter = undefined;
+  let filter;
   if (options.testCase) {
     filter = JSON.stringify(options.testCase);
   } else if (options.failed) {

--- a/js/client/modules/@arangodb/testutils/testing.js
+++ b/js/client/modules/@arangodb/testutils/testing.js
@@ -564,27 +564,6 @@ function iterateTests(cases, options) {
   return results;
 }
 
-function getFailedTestCases(options) {
-  try {
-    let resultFile = fs.join(options.testOutputDirectory, 'UNITTEST_RESULT.json');
-    let lastRun = JSON.parse(fs.readFileSync(resultFile));
-    let filter;
-    filter = (obj) => {
-      return _.pickBy(_.mapValues(obj, v => {
-          if (typeof v === 'object' && v.status === false) {
-            return filter(v);
-          }
-          return undefined;
-        }),
-        v => v !== undefined);
-    };
-    return filter(lastRun);
-  } catch (err) {
-    print("Failed to read previous test results - omitting failed filter.", err);
-    return false;
-  }
-}
-
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief framework to perform unittests
 // /
@@ -603,7 +582,7 @@ function unitTest (cases, options) {
   _.defaults(options, optionsDefaults);
   if (options.failed ||
       (Array.isArray(options.commandSwitches) && options.commandSwitches.includes("failed"))) {
-    options.failed = getFailedTestCases(options);
+    options.failed = rp.getFailedTestCases(options);
   }
 
   try {

--- a/js/common/modules/@arangodb/mocha.js
+++ b/js/common/modules/@arangodb/mocha.js
@@ -82,9 +82,9 @@ exports.run = function runMochaTests (run, files, reporterName, grep) {
     options: options,
     grep (re) {
       if (typeof re === 'string') {
-        re = new RegExp(escapeRe(re))
+        re = new RegExp(escapeRe(re));
       } else if (Array.isArray(re)) {
-        re = new RegExp(re.map(v => escapeRe(v)).join("|"))
+        re = new RegExp(re.map(v => escapeRe(v)).join("|"));
       }
       this.options.grep = re;
       return this;

--- a/js/common/modules/@arangodb/mocha.js
+++ b/js/common/modules/@arangodb/mocha.js
@@ -81,11 +81,12 @@ exports.run = function runMochaTests (run, files, reporterName, grep) {
   var mocha = {
     options: options,
     grep (re) {
-      this.options.grep = (
-        typeof re === 'string'
-        ? new RegExp(escapeRe(re))
-        : re
-      );
+      if (typeof re === 'string') {
+        re = new RegExp(escapeRe(re))
+      } else if (Array.isArray(re)) {
+        re = new RegExp(re.map(v => escapeRe(v)).join("|"))
+      }
+      this.options.grep = re;
       return this;
     },
     invert () {

--- a/js/common/modules/jsunity.js
+++ b/js/common/modules/jsunity.js
@@ -193,6 +193,18 @@ jsUnity.results.endTeardownAll = function(index) {
   TOTALTEARDOWNS += RESULTS.teardownAllDuration;
 };
 
+function MatchesTestFilter(key) {
+  if (testFilter === "undefined" || testFilter === undefined || testFilter === null) {
+    return true;
+  }
+  if (typeof testFilter === 'string') {
+    return key === testFilter;
+  }
+  if (Array.isArray(testFilter)) {
+    return testFilter.includes(key);
+  }
+  return false;
+}
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief runs a test with context
 // //////////////////////////////////////////////////////////////////////////////
@@ -232,7 +244,7 @@ function Run (testsuite) {
 
   for (var key in definition) {
     if (key.indexOf('test') === 0) {
-      if ((testFilter !== "undefined" && testFilter !== undefined && testFilter !== null) && (key !== testFilter)) {
+      if (!MatchesTestFilter(key)) {
         // print(`test "${key}" doesn't match "${testFilter}", skipping`);
         nonMatchedTests.push(key);
         continue;


### PR DESCRIPTION
### Scope & Purpose

This allows to re-run only those tests that failed in the previous test run. The information which tests previously failed is taken from the "UNITTEST_RESULT.json" (if available).

This should work for all jsunity and mocha tests.

- [x] :pizza: New feature for maintainers

### Testing & Verification

- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13537/
