### PR TITLE
Bug fix 3.7/bts 223 (#12868)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,12 +3,12 @@ v3.7.7 (XXXX-XX-XX)
 
 * Minor and rare AQL performance improvement, in nested subqueries:
   LET sq1 ([..] FILTER false == true LET sq2 = (<X>) [..])
-  where sq1 produces no data (e.g. by the above filter) for sq2,
-  the part <X> have been asked two times (second returns empty result),
-  instead of one, if and only if the mainquery executes sq1 exactly one time.
+  where sq1 produces no data (e.g. by the above filter) for sq2, the part <X>
+  have been asked two times (second returns empty result), instead of one, if
+  and only if the mainquery executes sq1 exactly one time.
   Now we get away with one call only.
-  In the case sq1 has data, or sq1 is executed more often, only one call was needed
-  (assuming the data fits in one batch).
+  In the case sq1 has data, or sq1 is executed more often, only one call was
+  needed (assuming the data fits in one batch).
 
 * Improve internal error reporting by cluster maintenance.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,15 @@
 v3.7.7 (XXXX-XX-XX)
 -------------------
 
+* Minor and rare AQL performance improvement, in nested subqueries:
+  LET sq1 ([..] FILTER false == true LET sq2 = (<X>) [..])
+  where sq1 produces no data (e.g. by the above filter) for sq2,
+  the part <X> have been asked two times (second returns empty result),
+  instead of one, if and only if the mainquery executes sq1 exactly one time.
+  Now we get away with one call only.
+  In the case sq1 has data, or sq1 is executed more often, only one call was needed
+  (assuming the data fits in one batch).
+
 * Improve internal error reporting by cluster maintenance.
 
 * Bug-Fix: In one-shard-database setups that were created in 3.6.* and then

--- a/arangod/Aql/AqlItemBlockInputMatrix.cpp
+++ b/arangod/Aql/AqlItemBlockInputMatrix.cpp
@@ -53,7 +53,7 @@ AqlItemBlockInputMatrix::AqlItemBlockInputMatrix(ExecutorState state, AqlItemMat
   TRI_ASSERT(_aqlItemMatrix != nullptr);
   if (_aqlItemMatrix->size() == 0 && _aqlItemMatrix->stoppedOnShadowRow()) {
     // Fast forward to initialize the _shadowRow
-    skipAllRemainingDataRows();
+    advanceBlockIndexAndShadowRow();
   }
 }
 
@@ -142,18 +142,10 @@ bool AqlItemBlockInputMatrix::hasShadowRow() const noexcept {
   return _shadowRow.isInitialized();
 }
 
-size_t AqlItemBlockInputMatrix::skipAllRemainingDataRows() {
-  if (_aqlItemMatrix == nullptr) {
-    // Have not been initialized.
-    // We need to be called before.
-    TRI_ASSERT(!hasShadowRow());
-    TRI_ASSERT(!hasDataRow());
-    return 0;
-  }
+void AqlItemBlockInputMatrix::advanceBlockIndexAndShadowRow() noexcept {
   if (!hasShadowRow()) {
     if (_aqlItemMatrix->stoppedOnShadowRow()) {
       _shadowRow = _aqlItemMatrix->popShadowRow();
-      TRI_ASSERT(_shadowRow.isRelevant());
     } else {
       // This can happen if we are either DONE.
       // or if the executor above produced
@@ -163,6 +155,21 @@ size_t AqlItemBlockInputMatrix::skipAllRemainingDataRows() {
     }
     resetBlockIndex();
   }
+}
+
+size_t AqlItemBlockInputMatrix::skipAllRemainingDataRows() {
+  if (_aqlItemMatrix == nullptr) {
+    // Have not been initialized.
+    // We need to be called before.
+    TRI_ASSERT(!hasShadowRow());
+    TRI_ASSERT(!hasDataRow());
+    return 0;
+  }
+  advanceBlockIndexAndShadowRow();
+  // If we advance here, we either need more input (no shadowRow)
+  // Or we have a relevant shadowRow and only skipped the dataset
+  TRI_ASSERT(!hasShadowRow() || _shadowRow.isRelevant());
+
   // Else we did already skip once.
   // nothing to do
   return 0;

--- a/arangod/Aql/AqlItemBlockInputMatrix.h
+++ b/arangod/Aql/AqlItemBlockInputMatrix.h
@@ -57,7 +57,7 @@ class AqlItemBlockInputMatrix {
 
   ExecutorState upstreamState() const noexcept;
   bool upstreamHasMore() const noexcept;
-  size_t skipAllRemainingDataRows();
+  size_t skipAllRemainingDataRows() noexcept;
 
   // Will return HASMORE if we were able to increase the row index.
   // Otherwise will return DONE.

--- a/arangod/Aql/AqlItemBlockInputMatrix.h
+++ b/arangod/Aql/AqlItemBlockInputMatrix.h
@@ -81,6 +81,9 @@ class AqlItemBlockInputMatrix {
   [[nodiscard]] auto finalState() const noexcept -> ExecutorState;
 
  private:
+  void advanceBlockIndexAndShadowRow() noexcept;
+
+ private:
   arangodb::aql::SharedAqlItemBlockPtr _block{nullptr};
   ExecutorState _finalState{ExecutorState::HASMORE};
 

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -1674,6 +1674,8 @@ ExecutionBlockImpl<Executor>::executeWithoutTrace(AqlCallStack stack) {
         }
 
         if (_lastRange.hasShadowRow() && !_lastRange.peekShadowRow().isRelevant()) {
+          // Nothing relevant fetched for this Executor, we are not going to ask it again.
+          localExecutorState = ExecutorState::DONE;
           _execState = ExecState::SHADOWROWS;
         } else {
           _execState = ExecState::CHECKCALL;

--- a/tests/Aql/SortExecutorTest.cpp
+++ b/tests/Aql/SortExecutorTest.cpp
@@ -26,8 +26,7 @@
 #include "gtest/gtest.h"
 
 #include "AqlExecutorTestCase.h"
-
-#include "fakeit.hpp"
+#include "TestLambdaExecutor.h"
 
 #include "RowFetcherHelper.h"
 
@@ -39,6 +38,7 @@
 #include "Aql/SortExecutor.h"
 #include "Aql/SortRegister.h"
 #include "Aql/Stats.h"
+#include "Aql/SubqueryStartExecutor.h"
 #include "Aql/Variable.h"
 #include "Basics/ResourceUsage.h"
 #include "Transaction/Context.h"
@@ -66,12 +66,17 @@ class SortExecutorTest : public AqlExecutorTestCaseWithParam<SortInputParam> {
     return split;
   }
 
-  auto makeRegisterInfos() -> RegisterInfos {
+  auto makeRegisterInfos(size_t nestingLevel = 1) -> RegisterInfos {
     SortElement sl{&sortVar, true};
     SortRegister sortReg{0, sl};
     std::vector<SortRegister> sortRegisters;
     sortRegisters.emplace_back(std::move(sortReg));
-    return RegisterInfos(RegIdSet{sortReg.reg}, {}, 1, 1, {}, {RegIdSet{0}});
+    TRI_ASSERT(nestingLevel > 0);
+    RegIdSetStack toKeepStack{};
+    for (size_t i = 0; i < nestingLevel; ++i) {
+      toKeepStack.emplace_back(RegIdSet{0});
+    }
+    return RegisterInfos(RegIdSet{sortReg.reg}, {}, 1, 1, {}, std::move(toKeepStack));
   }
 
   auto makeExecutorInfos() -> SortExecutorInfos {
@@ -82,6 +87,41 @@ class SortExecutorTest : public AqlExecutorTestCaseWithParam<SortInputParam> {
     return SortExecutorInfos(1, 1, {}, std::move(sortRegisters),
                              /*limit (ignored for default sort)*/ 0, manager(),
                              vpackOptions, monitor, false);
+  }
+
+  auto makeSubqueryRegisterInfos(size_t nestingLevel) -> RegisterInfos {
+    TRI_ASSERT(nestingLevel > 0);
+    RegIdSetStack toKeepStack{};
+    for (size_t i = 0; i < nestingLevel; ++i) {
+      toKeepStack.emplace_back(RegIdSet{0});
+    }
+    return RegisterInfos(RegIdSet{0}, {}, 1, 1, {}, std::move(toKeepStack));
+  }
+
+  auto dropAllLambdaExecutorInfos() -> TestLambdaSkipExecutor::Infos {
+    auto dropAll = [](AqlItemBlockInputRange& input, OutputAqlItemRow& output)
+        -> std::tuple<ExecutorState, TestLambdaSkipExecutor::Stats, AqlCall> {
+      while (input.hasDataRow() && !output.isFull()) {
+        auto const [state, row] = input.nextDataRow();
+        // Just drop!
+      }
+      NoStats stats{};
+      // Fetch all
+      AqlCall call{};
+      return {input.upstreamState(), stats, call};
+    };
+    auto dropSkipAll = [](AqlItemBlockInputRange& input, AqlCall& inCall)
+        -> std::tuple<ExecutorState, TestLambdaSkipExecutor::Stats, size_t, AqlCall> {
+      while (input.hasDataRow()) {
+        auto const [state, row] = input.nextDataRow();
+        // Just drop!
+      }
+      NoStats stats{};
+      AqlCall call{};
+
+      return {input.upstreamState(), stats, 0, call};
+    };
+    return TestLambdaSkipExecutor::Infos{dropAll, dropSkipAll};
   }
 
  private:
@@ -206,6 +246,26 @@ TEST_P(SortExecutorTest, skip_too_much) {
       .expectOutput({0}, {})
       .setCall(call)
       .expectSkipped(5)
+      .expectedState(ExecutionState::DONE)
+      .run();
+}
+
+TEST_P(SortExecutorTest, skip_nested_subquery_no_data) {
+  // Take a double nested subquery-fetch all Stack
+  AqlCallStack callStack{AqlCallList{AqlCall{}}};
+  callStack.pushCall(AqlCallList{AqlCall{}, AqlCall{}});
+  callStack.pushCall(AqlCallList{AqlCall{}, AqlCall{}});
+
+  ExecutionStats stats{};  // No stats here
+  makeExecutorTestHelper()
+      .addConsumer<SubqueryStartExecutor>(makeSubqueryRegisterInfos(2), makeSubqueryRegisterInfos(2), ExecutionNode::SUBQUERY_START)
+      .addConsumer<TestLambdaSkipExecutor>(makeSubqueryRegisterInfos(2), dropAllLambdaExecutorInfos(), ExecutionNode::FILTER)
+      .addConsumer<SubqueryStartExecutor>(makeSubqueryRegisterInfos(3), makeSubqueryRegisterInfos(3), ExecutionNode::SUBQUERY_START)
+      .addConsumer<SortExecutor>(makeRegisterInfos(3), makeExecutorInfos(), ExecutionNode::SORT)
+      .setInputValue({{1}})
+      .expectOutput({0}, {{1}}, {{0, 1}})
+      .setCallStack(callStack)
+      .expectSkipped(0, 0, 0)
       .expectedState(ExecutionState::DONE)
       .run();
 }

--- a/tests/js/server/aql/aql-shadowrow-block-return-regression.js
+++ b/tests/js/server/aql/aql-shadowrow-block-return-regression.js
@@ -247,6 +247,56 @@ function collectionInSubqeryRegressionSuite() {
       const splicedRes = db._query(query, bindVars, activateSplicing).toArray();
       const nosplicedRes = db._query(query, bindVars, deactivateSplicing).toArray();
       deepAssertElements(splicedRes, nosplicedRes, "result");
+    },
+
+    testNestedSubqueryNothingToSortNoCollections: function() {
+      // The main query has one Run.
+      // SQ1 has no Data
+      // SQ2 will not be executed
+      // The SORT should be able to NOT sort
+      // and forward outermost subquery data
+      const query = `
+        FOR x IN 1..1
+          LET sq1 = (
+            FOR y IN []
+            LET sq2 = (
+              FOR z IN 1..2
+              SORT z
+              RETURN z
+            )
+            RETURN sq2
+          )
+          RETURN sq1
+      `;
+      const bindVars = {};
+      const splicedRes = db._query(query, bindVars, activateSplicing).toArray();
+      const nosplicedRes = db._query(query, bindVars, deactivateSplicing).toArray();
+      deepAssertElements(splicedRes, nosplicedRes, "result");
+    },
+
+    testNestedSubqueryNothingToSort: function() {
+      // The main query has one Run.
+      // SQ1 has no Data (collection is empty)
+      // SQ2 will not be executed
+      // The SORT should be able to NOT sort
+      // and forward outermost subquery data
+      const query = `
+        FOR x IN 1..1
+          LET sq1 = (
+            FOR y IN @@collectionName
+            LET sq2 = (
+              FOR z IN 1..2
+              SORT z
+              RETURN z
+            )
+            RETURN sq2
+          )
+          RETURN sq1
+      `;
+      const bindVars = { "@collectionName": col.name() };
+      const splicedRes = db._query(query, bindVars, activateSplicing).toArray();
+      const nosplicedRes = db._query(query, bindVars, deactivateSplicing).toArray();
+      deepAssertElements(splicedRes, nosplicedRes, "result");
     }
   };
 }

--- a/tests/js/server/aql/aql-subquery.js
+++ b/tests/js/server/aql/aql-subquery.js
@@ -367,7 +367,7 @@ function ahuacatlSubqueryTestSuite () {
 
         var actual = getQueryResults(query);
         assertEqual(expected, actual);
-        assertEqual(db[colName].count(), 1);
+        assertEqual(db[colName].count(), 0);
       } finally {
         db._drop(colName);
       }


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/12868
Fixes an assertion, and a very minor performance issue.

Reviewer Info:
This PR basically creates two versions of the same internal function, one that asserts on final state (which is to be expected during execution) and one without the final state assert, which can happen during the Construction of the object.
The constructor now uses the new variant.
Also added tests that triggered the assert on construction.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [ ] :muscle: The behavior in this PR was *manually tested*
- [ ] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [ ] No backports required
- [] Backports required for

#### Related Information

*(Please reference tickets / specification etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-223
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added **Regression Tests**
  - [x] Added new C++ **Unit Tests**
  - [ ] Added new **integration tests** (i.e. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)

Additionally:

- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

*(Include link to Jenkins run etc)*

### Documentation

> All new Features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the changelog so that
> developers and users have a concise overview. 

- [x] Added a *Changelog Entry* (referencing the corresponding public or internal issue number)
- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
