### PR TITLE
Make CLANG-11 compile again

### DIFF
--- a/arangod/Graph/Helpers/TraceEntry.h
+++ b/arangod/Graph/Helpers/TraceEntry.h
@@ -24,6 +24,7 @@
 #ifndef ARANGOD_GRAPH_HELPERS_TRACE_ENTRY_H
 #define ARANGOD_GRAPH_HELPERS_TRACE_ENTRY_H 1
 
+#include <limits>
 #include <numeric>
 #include <ostream>
 


### PR DESCRIPTION
Just Makes CLANG11 and GCC 10.* compile again, our Jenkins do not test those latest versions