### PR TITLE
Fuse single-use filter calculations with their filters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 devel
 -----
 
+* Add AQL optimizer rule to fuse calculations that are only used in a 
+  single filter together with their filter, so that the calculation result
+  is never stored and does not allocate any register in an AqlItemBlock.
+
+  This adds a new optimizer rule `fuse-calculation-filter` and a new
+  ExecutionNode type `CalculationFilterNode`.
+
 * Fix a bug in the agency Supervision which could lead to removeFollower
   jobs constantly being created and immediately stopped again.
 

--- a/arangod/Aql/CalculationExecutor.cpp
+++ b/arangod/Aql/CalculationExecutor.cpp
@@ -48,22 +48,7 @@ CalculationExecutorInfos::CalculationExecutorInfos(RegisterId outputRegister,
       _query(query),
       _expression(expression),
       _expInVars(std::move(expInVars)),
-      _expInRegs(std::move(expInRegs)) {
-}
-
-template <CalculationType calculationType>
-CalculationExecutor<calculationType>::CalculationExecutor(Fetcher& fetcher,
-                                                          CalculationExecutorInfos& infos)
-    :
-      _trx(infos.getQuery().newTrxContext()),
-      _infos(infos),
-      _fetcher(fetcher),
-      _currentRow(InputAqlItemRow{CreateInvalidInputRowHint{}}),
-      _rowState(ExecutionState::HASMORE),
-      _hasEnteredContext(false) {}
-
-template <CalculationType calculationType>
-CalculationExecutor<calculationType>::~CalculationExecutor() = default;
+      _expInRegs(std::move(expInRegs)) {}
 
 RegisterId CalculationExecutorInfos::getOutputRegisterId() const noexcept {
   return _outputRegisterId;
@@ -82,6 +67,16 @@ std::vector<Variable const*> const& CalculationExecutorInfos::getExpInVars() con
 std::vector<RegisterId> const& CalculationExecutorInfos::getExpInRegs() const noexcept {
   return _expInRegs;
 }
+
+template <CalculationType calculationType>
+CalculationExecutor<calculationType>::CalculationExecutor(Fetcher& /*fetcher*/,
+                                                          CalculationExecutorInfos& infos)
+    : _trx(infos.getQuery().newTrxContext()),
+      _infos(infos),
+      _hasEnteredContext(false) {}
+
+template <CalculationType calculationType>
+CalculationExecutor<calculationType>::~CalculationExecutor() = default;
 
 template <CalculationType calculationType>
 std::tuple<ExecutorState, typename CalculationExecutor<calculationType>::Stats, AqlCall>

--- a/arangod/Aql/CalculationExecutor.h
+++ b/arangod/Aql/CalculationExecutor.h
@@ -24,16 +24,13 @@
 #ifndef ARANGOD_AQL_CALACULATION_EXECUTOR_H
 #define ARANGOD_AQL_CALACULATION_EXECUTOR_H
 
+#include "Aql/AqlFunctionsInternalCache.h"
 #include "Aql/ExecutionState.h"
 #include "Aql/InputAqlItemRow.h"
-#include "Aql/AqlFunctionsInternalCache.h"
 #include "Aql/RegisterInfos.h"
 #include "Aql/Stats.h"
 #include "Aql/types.h"
 #include "Transaction/Methods.h"
-
-#include <unordered_set>
-#include <vector>
 
 namespace arangodb {
 namespace transaction {
@@ -96,7 +93,7 @@ class CalculationExecutor {
   using Infos = CalculationExecutorInfos;
   using Stats = NoStats;
 
-  CalculationExecutor(Fetcher& fetcher, CalculationExecutorInfos&);
+  CalculationExecutor(Fetcher& /*fetcher*/, CalculationExecutorInfos&);
   ~CalculationExecutor();
 
   /**
@@ -125,11 +122,6 @@ class CalculationExecutor {
   transaction::Methods _trx;
   aql::AqlFunctionsInternalCache _aqlFunctionsInternalCache;
   CalculationExecutorInfos& _infos;
-
-  Fetcher& _fetcher;
-
-  InputAqlItemRow _currentRow;
-  ExecutionState _rowState;
 
   // true iff we entered a V8 context and didn't exit it yet.
   // Necessary for owned contexts, which will not be exited when we call

--- a/arangod/Aql/CalculationFilterExecutor.cpp
+++ b/arangod/Aql/CalculationFilterExecutor.cpp
@@ -1,0 +1,135 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2021 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#include "CalculationFilterExecutor.h"
+
+#include "Aql/AqlCall.h"
+#include "Aql/AqlCallStack.h"
+#include "Aql/AqlItemBlockInputRange.h"
+#include "Aql/ExecutorExpressionContext.h"
+#include "Aql/Expression.h"
+#include "Aql/InputAqlItemRow.h"
+#include "Aql/OutputAqlItemRow.h"
+#include "Aql/Query.h"
+#include "Aql/RegisterInfos.h"
+#include "Aql/SingleRowFetcher.h"
+#include "Aql/Stats.h"
+#include "Basics/Exceptions.h"
+
+#include <utility>
+
+using namespace arangodb;
+using namespace arangodb::aql;
+
+CalculationFilterExecutorInfos::CalculationFilterExecutorInfos(QueryContext& query, Expression& expression,
+                                                               std::vector<Variable const*>&& expInVars,
+                                                               std::vector<RegisterId>&& expInRegs)
+    : _query(query),
+      _expression(expression),
+      _expInVars(std::move(expInVars)),
+      _expInRegs(std::move(expInRegs)) {}
+
+QueryContext& CalculationFilterExecutorInfos::getQuery() const noexcept { return _query; }
+
+Expression& CalculationFilterExecutorInfos::getExpression() const noexcept {
+  return _expression;
+}
+
+std::vector<Variable const*> const& CalculationFilterExecutorInfos::getExpInVars() const noexcept {
+  return _expInVars;
+}
+
+std::vector<RegisterId> const& CalculationFilterExecutorInfos::getExpInRegs() const noexcept {
+  return _expInRegs;
+}
+
+CalculationFilterExecutor::CalculationFilterExecutor(Fetcher& /*fetcher*/,
+                                                     CalculationFilterExecutorInfos& infos)
+    : _trx(infos.getQuery().newTrxContext()),
+      _infos(infos) {}
+
+CalculationFilterExecutor::~CalculationFilterExecutor() = default;
+
+auto CalculationFilterExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange, AqlCall& call)
+    -> std::tuple<ExecutorState, Stats, size_t, AqlCall> {
+  CalculationFilterStats stats{};
+  
+  while (inputRange.hasDataRow() && call.needSkipMore()) {
+    auto const [unused, input] = inputRange.nextDataRow(AqlItemBlockInputRange::HasDataRow{});
+    TRI_ASSERT(input);
+    if (doEvaluation(input)) {
+      call.didSkip(1);
+    } else {
+      stats.incrFiltered();
+    }
+  }
+
+  // Just fetch everything from above, allow overfetching
+  return {inputRange.upstreamState(), stats, call.getSkipCount(), AqlCall{}};
+}
+
+auto CalculationFilterExecutor::produceRows(AqlItemBlockInputRange& inputRange, OutputAqlItemRow& output)
+    -> std::tuple<ExecutorState, Stats, AqlCall> {
+  TRI_IF_FAILURE("FilterExecutor::produceRows") {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
+  }
+  CalculationFilterStats stats{};
+
+  while (inputRange.hasDataRow() && !output.isFull()) {
+    auto const& [state, input] = inputRange.nextDataRow(AqlItemBlockInputRange::HasDataRow{});
+    TRI_ASSERT(input);
+    TRI_ASSERT(input.isInitialized());
+    if (doEvaluation(input)) {
+      output.copyRow(input);
+      output.advanceRow();
+    } else {
+      stats.incrFiltered();
+    }
+  }
+
+  // Just fetch everything from above, allow overfetching
+  return {inputRange.upstreamState(), stats, AqlCall{}};
+}
+
+[[nodiscard]] auto CalculationFilterExecutor::expectedNumberOfRowsNew(AqlItemBlockInputRange const& input,
+                                                                      AqlCall const& call) const
+    noexcept -> size_t {
+  if (input.finalState() == ExecutorState::DONE) {
+    return std::min(call.getLimit(), input.countDataRows());
+  }
+  // We do not know how many more rows will be returned from upstream.
+  // So we can only overestimate
+  return call.getLimit();
+}
+
+bool CalculationFilterExecutor::doEvaluation(InputAqlItemRow const& input) {
+  // execute the expression
+  ExecutorExpressionContext ctx(_trx, _infos.getQuery(), _aqlFunctionsInternalCache, input,
+                                _infos.getExpInVars(), _infos.getExpInRegs());
+
+  bool mustDestroy;  // will get filled by execution
+  AqlValue a = _infos.getExpression().execute(&ctx, mustDestroy);
+  AqlValueGuard guard(a, mustDestroy);
+
+  return a.toBoolean();
+}

--- a/arangod/Aql/CalculationFilterExecutor.h
+++ b/arangod/Aql/CalculationFilterExecutor.h
@@ -1,0 +1,124 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2021 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef ARANGOD_AQL_CALCULATION_FILTER_EXECUTOR_H
+#define ARANGOD_AQL_CALCULATION_FILTER_EXECUTOR_H
+
+#include "Aql/AqlFunctionsInternalCache.h"
+#include "Aql/ExecutionState.h"
+#include "Aql/RegisterInfos.h"
+#include "Aql/Stats.h"
+#include "Aql/types.h"
+#include "Transaction/Methods.h"
+
+namespace arangodb::aql {
+
+struct AqlCall;
+class AqlItemBlockInputRange;
+class Expression;
+class InputAqlItemRow;
+class OutputAqlItemRow;
+class QueryContext;
+class RegisterInfos;
+class CalculationFilterStats;
+template <BlockPassthrough>
+class SingleRowFetcher;
+struct Variable;
+
+struct CalculationFilterExecutorInfos {
+  CalculationFilterExecutorInfos(QueryContext& query, Expression& expression,
+                                 std::vector<Variable const*>&& expInVars,
+                                 std::vector<RegisterId>&& expInRegs);
+
+  CalculationFilterExecutorInfos() = delete;
+  CalculationFilterExecutorInfos(CalculationFilterExecutorInfos&&) = default;
+  CalculationFilterExecutorInfos(CalculationFilterExecutorInfos const&) = delete;
+  ~CalculationFilterExecutorInfos() = default;
+
+  QueryContext& getQuery() const noexcept;
+  transaction::Methods* getTrx() const noexcept;
+
+  Expression& getExpression() const noexcept;
+
+  std::vector<Variable const*> const& getExpInVars() const noexcept;
+
+  std::vector<RegisterId> const& getExpInRegs() const noexcept;
+
+ private:
+  QueryContext& _query;
+  Expression& _expression;
+  std::vector<Variable const*> _expInVars;  // input variables for expression
+  std::vector<RegisterId> _expInRegs;       // input registers for expression
+};
+
+/**
+ * @brief Implementation of CalculationFilter Node
+ */
+class CalculationFilterExecutor {
+ public:
+  struct Properties {
+    static constexpr bool preservesOrder = true;
+    static constexpr BlockPassthrough allowsBlockPassthrough = BlockPassthrough::Disable;
+    static constexpr bool inputSizeRestrictsOutputSize = true;
+  };
+  using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
+  using Infos = CalculationFilterExecutorInfos;
+  using Stats = CalculationFilterStats;
+
+  CalculationFilterExecutor() = delete;
+  CalculationFilterExecutor(CalculationFilterExecutor&&) = default;
+  CalculationFilterExecutor(CalculationFilterExecutor const&) = delete;
+  CalculationFilterExecutor(Fetcher& fetcher, Infos&);
+  ~CalculationFilterExecutor();
+
+  /**
+   * @brief produce the next Rows of Aql Values.
+   *
+   * @return ExecutorState, the stats, and a new Call that needs to be send to upstream
+   */
+  [[nodiscard]] std::tuple<ExecutorState, Stats, AqlCall> produceRows(
+      AqlItemBlockInputRange& input, OutputAqlItemRow& output);
+
+  /**
+   * @brief skip the next Row of Aql Values.
+   *
+   * @return ExecutorState, the stats, and a new Call that needs to be send to upstream
+   */
+  [[nodiscard]] std::tuple<ExecutorState, Stats, size_t, AqlCall> skipRowsRange(
+      AqlItemBlockInputRange& inputRange, AqlCall& call);
+  
+  [[nodiscard]] auto expectedNumberOfRowsNew(AqlItemBlockInputRange const& input,
+                                             AqlCall const& call) const noexcept -> size_t;
+
+ private:
+  bool doEvaluation(InputAqlItemRow const& input);
+
+ private:
+  transaction::Methods _trx;
+  aql::AqlFunctionsInternalCache _aqlFunctionsInternalCache;
+  Infos& _infos;
+};
+
+}  // namespace arangodb::aql
+
+#endif

--- a/arangod/Aql/CollectNode.cpp
+++ b/arangod/Aql/CollectNode.cpp
@@ -456,6 +456,7 @@ auto isStartNode(ExecutionNode const& node) -> bool {
       return true;
     case ExecutionNode::ENUMERATE_COLLECTION:
     case ExecutionNode::ENUMERATE_LIST:
+    case ExecutionNode::CALCULATION_FILTER:
     case ExecutionNode::FILTER:
     case ExecutionNode::LIMIT:
     case ExecutionNode::CALCULATION:
@@ -502,6 +503,7 @@ auto isVariableInvalidatingNode(ExecutionNode const& node) -> bool {
     case ExecutionNode::ENUMERATE_COLLECTION:
     case ExecutionNode::ENUMERATE_LIST:
     case ExecutionNode::FILTER:
+    case ExecutionNode::CALCULATION_FILTER:
     case ExecutionNode::LIMIT:
     case ExecutionNode::CALCULATION:
     case ExecutionNode::SUBQUERY:
@@ -551,6 +553,7 @@ auto isLoop(ExecutionNode const& node) -> bool {
     case ExecutionNode::SINGLETON:
     case ExecutionNode::SUBQUERY_START:
     case ExecutionNode::FILTER:
+    case ExecutionNode::CALCULATION_FILTER:
     case ExecutionNode::LIMIT:
     case ExecutionNode::CALCULATION:
     case ExecutionNode::SUBQUERY:

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -30,6 +30,7 @@
 #include "Aql/AqlCallStack.h"
 #include "Aql/AqlItemBlock.h"
 #include "Aql/CalculationExecutor.h"
+#include "Aql/CalculationFilterExecutor.h"
 #include "Aql/ConstFetcher.h"
 #include "Aql/ConstrainedSortExecutor.h"
 #include "Aql/CountCollectExecutor.h"
@@ -550,7 +551,7 @@ static SkipRowsRangeVariant constexpr skipRowsType() {
   static_assert(
       useExecutor ==
           (is_one_of_v<
-              Executor, FilterExecutor, ShortestPathExecutor, ReturnExecutor,
+              Executor, CalculationFilterExecutor, FilterExecutor, ShortestPathExecutor, ReturnExecutor,
               KShortestPathsExecutor<graph::KPathFinder>, KShortestPathsExecutor<graph::KShortestPathsFinder>,
               KShortestPathsExecutor<KPathRefactored>, KShortestPathsExecutor<KPathRefactoredTracer>, ParallelUnsortedGatherExecutor,
               IdExecutor<SingleRowFetcher<BlockPassthrough::Enable>>, IdExecutor<ConstFetcher>, HashedCollectExecutor,
@@ -1908,6 +1909,9 @@ auto ExecutionBlockImpl<Executor>::testInjectInputRange(DataRange range, SkipRes
 template class ::arangodb::aql::ExecutionBlockImpl<CalculationExecutor<CalculationType::Condition>>;
 template class ::arangodb::aql::ExecutionBlockImpl<CalculationExecutor<CalculationType::Reference>>;
 template class ::arangodb::aql::ExecutionBlockImpl<CalculationExecutor<CalculationType::V8Condition>>;
+
+template class ::arangodb::aql::ExecutionBlockImpl<CalculationFilterExecutor>;
+
 template class ::arangodb::aql::ExecutionBlockImpl<ConstrainedSortExecutor>;
 template class ::arangodb::aql::ExecutionBlockImpl<CountCollectExecutor>;
 template class ::arangodb::aql::ExecutionBlockImpl<DistinctCollectExecutor>;

--- a/arangod/Aql/OptimizerRule.h
+++ b/arangod/Aql/OptimizerRule.h
@@ -342,6 +342,10 @@ struct OptimizerRule {
     // for index
     lateDocumentMaterializationRule,
 
+    // fuses calculations with following filter if the calculation is only
+    // used by the filter
+    fuseCalculationAndFilterRule,
+
     // splice subquery into the place of a subquery node
     // enclosed by a SubqueryStartNode and a SubqueryEndNode
     // Must run last.

--- a/arangod/Aql/OptimizerRules.h
+++ b/arangod/Aql/OptimizerRules.h
@@ -293,6 +293,9 @@ void optimizeCountRule(Optimizer*, std::unique_ptr<ExecutionPlan>, OptimizerRule
 /// @brief parallelize Gather nodes (cluster-only)
 void parallelizeGatherRule(Optimizer*, std::unique_ptr<ExecutionPlan>, OptimizerRule const&);
 
+//// @brief fuse calculation with following filter
+void fuseCalculationAndFilterRule(Optimizer*, std::unique_ptr<ExecutionPlan>, OptimizerRule const&);
+
 //// @brief splice in subqueries
 void spliceSubqueriesRule(Optimizer*, std::unique_ptr<ExecutionPlan>, OptimizerRule const&);
 

--- a/arangod/Aql/OptimizerRulesFeature.cpp
+++ b/arangod/Aql/OptimizerRulesFeature.cpp
@@ -455,6 +455,12 @@ void OptimizerRulesFeature::addRules() {
 
   // add the storage-engine specific rules
   addStorageEngineRules();
+  
+  // fuses calculation with following filter if the calculation is only
+  // used by the filter
+  registerRule("fuse-calculation-filter", fuseCalculationAndFilterRule, 
+               OptimizerRule::fuseCalculationAndFilterRule,
+               OptimizerRule::makeFlags(OptimizerRule::Flags::CanBeDisabled));
 
   // Splice subqueries
   //

--- a/arangod/Aql/Stats.h
+++ b/arangod/Aql/Stats.h
@@ -37,7 +37,7 @@ namespace aql {
 // no-op statistics for all Executors that don't have custom stats.
 class NoStats {
  public:
-  void operator+= (NoStats const&) {}
+  void operator+=(NoStats const&) {}
 };
 
 inline ExecutionStats& operator+=(ExecutionStats& stats, NoStats const&) {
@@ -56,7 +56,7 @@ class CountStats {
 
   std::size_t getCounted() const noexcept { return _counted; }
   
-  void operator+= (CountStats const& stats) {
+  void operator+=(CountStats const& stats) {
     _counted += stats._counted;
   }
 
@@ -67,6 +67,32 @@ class CountStats {
 inline ExecutionStats& operator+=(ExecutionStats& executionStats,
                                   CountStats const& filterStats) noexcept {
   executionStats.count += filterStats.getCounted();
+  return executionStats;
+}
+
+class CalculationFilterStats {
+ public:
+  CalculationFilterStats() noexcept : _filtered(0) {}
+
+  void setFiltered(std::size_t filtered) noexcept { _filtered = filtered; }
+
+  void addFiltered(std::size_t filtered) noexcept { _filtered += filtered; }
+
+  void incrFiltered() noexcept { _filtered++; }
+
+  std::size_t getFiltered() const noexcept { return _filtered; }
+  
+  void operator+=(CalculationFilterStats const& stats) {
+    _filtered += stats._filtered;
+  }
+
+ private:
+  std::size_t _filtered;
+};
+
+inline ExecutionStats& operator+=(ExecutionStats& executionStats,
+                                  CalculationFilterStats const& filterStats) noexcept {
+  executionStats.filtered += filterStats.getFiltered();
   return executionStats;
 }
 
@@ -82,7 +108,7 @@ class FilterStats {
 
   std::size_t getFiltered() const noexcept { return _filtered; }
   
-  void operator+= (FilterStats const& stats) {
+  void operator+=(FilterStats const& stats) {
     _filtered += stats._filtered;
   }
 
@@ -107,7 +133,7 @@ class EnumerateCollectionStats {
   std::size_t getScanned() const noexcept { return _scannedFull; }
   std::size_t getFiltered() const noexcept { return _filtered; }
   
-  void operator+= (EnumerateCollectionStats const& stats) {
+  void operator+=(EnumerateCollectionStats const& stats) {
     _scannedFull += stats._scannedFull;
     _filtered += stats._filtered;
   }
@@ -137,7 +163,7 @@ class IndexStats {
   std::size_t getScanned() const noexcept { return _scannedIndex; }
   std::size_t getFiltered() const noexcept { return _filtered; }
   
-  void operator+= (IndexStats const& stats) {
+  void operator+=(IndexStats const& stats) {
     _scannedIndex += stats._scannedIndex;
     _filtered += stats._filtered;
   }
@@ -176,7 +202,7 @@ class ModificationStats {
   void incrWritesIgnored() noexcept { _writesIgnored++; }
   std::size_t getWritesIgnored() const noexcept { return _writesIgnored; }
   
-  void operator+= (ModificationStats const& stats) {
+  void operator+=(ModificationStats const& stats) {
     _writesExecuted += stats._writesExecuted;
     _writesIgnored += stats._writesIgnored;
   }
@@ -225,7 +251,7 @@ class SingleRemoteModificationStats {
   void incrScannedIndex() noexcept { _scannedIndex++; }
   std::size_t getScannedIndex() const noexcept { return _scannedIndex; }
   
-  void operator+= (SingleRemoteModificationStats const& stats) {
+  void operator+=(SingleRemoteModificationStats const& stats) {
     _writesExecuted += stats._writesExecuted;
     _writesIgnored += stats._writesIgnored;
     _scannedIndex += stats._scannedIndex;

--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -269,6 +269,7 @@ set(LIB_ARANGO_AQL_SOURCES
   Aql/BindParameters.cpp
   Aql/BlocksWithClients.cpp
   Aql/CalculationExecutor.cpp
+  Aql/CalculationFilterExecutor.cpp
   Aql/CalculationNodeVarFinder.cpp
   Aql/ClusterNodes.cpp
   Aql/CollectNode.cpp

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -1647,6 +1647,11 @@ function processQuery(query, explain, planIndex) {
         return keyword('LET') + ' ' + variableName(node.outVariable) + ' = ' + buildExpression(node.expression) + '   ' + annotation('/* ' + node.expressionType + ' expression */');
       case 'FilterNode':
         return keyword('FILTER') + ' ' + variableName(node.inVariable);
+      case 'CalculationFilterNode':
+        (node.functions || []).forEach(function (f) {
+          functions[f.name] = f;
+        });
+        return keyword('FILTER') + ' ' + buildExpression(node.expression) + '   ' + annotation('/* ' + node.expressionType + ' expression */');
       case 'AggregateNode': /* old-style COLLECT node */
         return keyword('COLLECT') + ' ' + node.aggregates.map(function (node) {
           return variableName(node.outVariable) + ' = ' + variableName(node.inVariable);
@@ -2008,7 +2013,7 @@ function processQuery(query, explain, planIndex) {
         indent(level, node.type === 'SingletonNode') + label(node);
     }
 
-    if (node.type === 'CalculationNode') {
+    if (node.type === 'CalculationNode' || node.type === 'CalculationFilterNode') {
       line += variablesUsed() + constNess();
     }
     stringBuilder.appendLine(line);


### PR DESCRIPTION
### Scope & Purpose

This is a request for comments.

Add AQL optimizer rule to fuse calculations that are only used in a single filter together with their filter, so that the calculation result is never stored and does not allocate any register in an AqlItemBlock.

This adds a new optimizer rule `fuse-calculation-filter` and a new ExecutionNode type `CalculationFilterNode`.

For example, a (contrived) query without the feature in effect:
```
Query String (146 chars, cacheable: true):
 FOR doc1 IN x FOR doc2 IN x FILTER doc1.value >=92 && doc2.value <= 93 && doc1.value >= doc2.value 
 && doc1.value <= doc2.value RETURN {doc1, doc2}

Execution plan:
 Id   NodeType                     Est.   Comment
  1   SingletonNode                   1   * ROOT
  2   EnumerateCollectionNode      1000     - FOR doc1 IN x   /* full collection scan */
  3   EnumerateCollectionNode   1000000       - FOR doc2 IN x   /* full collection scan */
  4   CalculationNode           1000000         - LET #2 = ((((doc1.`value` >= 92) && (doc2.`value` <= 93)) && (doc1.`value` >= doc2.`value`)) && (doc1.`value` <= doc2.`value`))   /* simple expression */   /* collections used: doc1 : x, doc2 : x */
  5   FilterNode                1000000         - FILTER #2
  6   CalculationNode           1000000         - LET #4 = { "doc1" : doc1, "doc2" : doc2 }   /* simple expression */   /* collections used: doc1 : x, doc2 : x */
  7   ReturnNode                1000000         - RETURN #4

Optimization rules applied:
 none
```

With the feature enabled, the execution plan changes to
```
Query String (146 chars, cacheable: true):
 FOR doc1 IN x FOR doc2 IN x FILTER doc1.value >=92 && doc2.value <= 93 && doc1.value >= doc2.value 
 && doc1.value <= doc2.value RETURN {doc1, doc2}

Execution plan:
 Id   NodeType                     Est.   Comment
  1   SingletonNode                   1   * ROOT
  3   EnumerateCollectionNode      1000     - FOR doc2 IN x   /* full collection scan */
  2   EnumerateCollectionNode   1000000       - FOR doc1 IN x   /* full collection scan */
  8   CalculationFilterNode     1000000         - FILTER ((((doc1.`value` >= 92) && (doc2.`value` <= 93)) && (doc1.`value` >= doc2.`value`)) && (doc1.`value` <= doc2.`value`))   /* simple expression */   /* collections used: doc1 : x, doc2 : x */
  6   CalculationNode           1000000         - LET #4 = { "doc1" : doc1, "doc2" : doc2 }   /* simple expression */   /* collections used: doc1 : x, doc2 : x */
  7   ReturnNode                1000000         - RETURN #4

Optimization rules applied:
 Id   RuleName
  1   move-calculations-up
  2   move-filters-up
  3   interchange-adjacent-enumerations
  4   move-calculations-up-2
  5   move-filters-up-2
  6   fuse-calculation-filter
```
The second plan, with the feature enabled, has one processing step less, and uses one less output register, so a lot of stores of the filter conditions results (`#2`) into the AqlItemBlock are saved. In addition, this allows to reduce the width of the AqlItemBlock by one register, shortening the AqlItemBlocks internal storage vector. This makes initialization and cleanup of the AqlItemBlock slightly more efficient, because no work needs to be done for an entire register.

Note that only queries will benefit in which the filter condition is not on the data of a single collection. Filter conditions on data from a single collection are normally moved into the EnumerateCollectionNode/IndexNode and executed in there via early pruning. These types of queries will not benefit, but other queries with more complex filters will. And there the small savings may add up.

The contrived example query runs approximately 15% faster with the change, when the underlying collection contains 1,000 documents.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Docs PR: TO DO

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:

