### PR TITLE
fix potential invalid derefence on audit log shutdown

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.6.11 (XXXX-XX-XX)
 --------------------
 
+* Fix potential invalid pointer dereference on audit log shutdown.
+
 * Fix agency restart with mismatching compation and log indexes.
 
 * Updated OpenSSL to 1.1.1i and OpenLDAP to 2.4.56.

--- a/lib/Logger/LogAppenderFile.cpp
+++ b/lib/Logger/LogAppenderFile.cpp
@@ -278,11 +278,11 @@ void LogAppenderFile::closeAll() {
       TRI_CLOSE(fd);
     }
   }
+  _fds.clear();
 }
 
 void LogAppenderFile::clear() {
   closeAll();
-  _fds.clear();
 }
 
 LogAppenderStdStream::LogAppenderStdStream(std::string const& filename,


### PR DESCRIPTION
backport of "bug-fix-3.6/fix-audit-log-shutdown"