### PR TITLE
Reduced the amount of test combinations in (K-)ShortestPathsTests.

### DIFF
--- a/tests/Aql/KShortestPathsExecutorTest.cpp
+++ b/tests/Aql/KShortestPathsExecutorTest.cpp
@@ -67,6 +67,46 @@ using Vertex = GraphNode::InputVertex;
 using RegisterSet = RegIdSet;
 using Path = std::vector<std::string>;
 using PathSequence = std::vector<Path>;
+namespace {
+Vertex const constSource("vertex/source"), constTarget("vertex/target"),
+    regSource(0), regTarget(1), brokenSource{"IwillBreakYourSearch"},
+    brokenTarget{"I will also break your search"};
+
+  MatrixBuilder<2> const noneRow{{{{}}}};
+  MatrixBuilder<2> const oneRow{{{{R"("vertex/source")"}, {R"("vertex/target")"}}}};
+  MatrixBuilder<2> const twoRows{{{{R"("vertex/source")"}, {R"("vertex/target")"}}},
+                                 {{{R"("vertex/a")"}, {R"("vertex/b")"}}}};
+  MatrixBuilder<2> const threeRows{{{{R"("vertex/source")"}, {R"("vertex/target")"}}},
+                                   {{{R"("vertex/a")"}, {R"("vertex/b")"}}},
+                                   {{{R"("vertex/a")"}, {R"("vertex/target")"}}}};
+  MatrixBuilder<2> const someRows{{{{R"("vertex/c")"}, {R"("vertex/target")"}}},
+                                  {{{R"("vertex/b")"}, {R"("vertex/target")"}}},
+                                  {{{R"("vertex/e")"}, {R"("vertex/target")"}}},
+                                  {{{R"("vertex/a")"}, {R"("vertex/target")"}}}};
+
+  PathSequence const noPath = {};
+  PathSequence const onePath = {
+      {"vertex/source", "vertex/intermed", "vertex/target"}};
+
+  PathSequence const threePaths = {
+      {"vertex/source", "vertex/intermed", "vertex/target"},
+      {"vertex/a", "vertex/b", "vertex/c", "vertex/d"},
+      {"vertex/source", "vertex/b", "vertex/c", "vertex/d"},
+      {"vertex/a", "vertex/b", "vertex/target"}};
+
+  PathSequence const somePaths = {
+      {"vertex/source", "vertex/intermed0", "vertex/target"},
+      {"vertex/a", "vertex/b", "vertex/c", "vertex/d"},
+      {"vertex/source", "vertex/intermed1", "vertex/target"},
+      {"vertex/source", "vertex/intermed2", "vertex/target"},
+      {"vertex/a", "vertex/b", "vertex/c", "vertex/d"},
+      {"vertex/source", "vertex/intermed3", "vertex/target"},
+      {"vertex/source", "vertex/intermed4", "vertex/target"},
+      {"vertex/a", "vertex/b", "vertex/c", "vertex/d"},
+      {"vertex/source", "vertex/intermed5", "vertex/target"},
+  };
+
+  }  // namespace  // namespace
 
 // The FakeShortestPathsFinder does not do any real k shortest paths search; it
 // is merely initialized with a set of "paths" and then outputs them, keeping a
@@ -151,15 +191,24 @@ class FakeKShortestPathsFinder : public KShortestPathsFinder {
 
 // TODO: this needs a << operator
 struct KShortestPathsTestParameters {
-  KShortestPathsTestParameters(std::tuple<Vertex, Vertex, MatrixBuilder<2>, PathSequence, AqlCall, size_t> params)
+  KShortestPathsTestParameters(std::tuple<Vertex, Vertex> const& params)
       : _source(std::get<0>(params)),
         _target(std::get<1>(params)),
+        _outputRegisters(std::initializer_list<RegisterId>{2}),
+        _inputMatrix(oneRow),
+        _paths(threePaths),
+        _call(AqlCall{0, AqlCall::Infinity{}, AqlCall::Infinity{}, true}),
+        _blockSize(1000) {}
+
+  KShortestPathsTestParameters(std::tuple<MatrixBuilder<2>, PathSequence, AqlCall, size_t> params)
+      : _source(constSource),
+        _target(constTarget),
         // TODO: Make output registers configurable?
         _outputRegisters(std::initializer_list<RegisterId>{2}),
-        _inputMatrix(std::get<2>(params)),
-        _paths(std::get<3>(params)),
-        _call(std::get<4>(params)),
-        _blockSize(std::get<5>(params)){};
+        _inputMatrix(std::get<0>(params)),
+        _paths(std::get<1>(params)),
+        _call(std::get<2>(params)),
+        _blockSize(std::get<3>(params)){};
 
   Vertex _source;
   Vertex _target;
@@ -172,9 +221,9 @@ struct KShortestPathsTestParameters {
 };
 
 class KShortestPathsExecutorTest
-    : public ::testing::Test,
-      public ::testing::WithParamInterface<std::tuple<Vertex, Vertex, MatrixBuilder<2>, PathSequence, AqlCall, size_t>> {
+    : public ::testing::Test {
  protected:
+
   // parameters are copied because they are const otherwise
   // and that doesn't mix with std::move
   KShortestPathsTestParameters parameters;
@@ -202,8 +251,8 @@ class KShortestPathsExecutorTest
   KShortestPathsExecutor<KShortestPathsFinder> testee;
   OutputAqlItemRow output;
 
-  KShortestPathsExecutorTest()
-      : parameters(GetParam()),
+  KShortestPathsExecutorTest(KShortestPathsTestParameters parameters__)
+      : parameters(std::move(parameters__)),
         server{},
         itemBlockManager(monitor, SerializationFormat::SHADOWROWS),
         fakedQuery(server.createFakeQuery()),
@@ -362,50 +411,30 @@ class KShortestPathsExecutorTest
   }
 };  // namespace aql
 
-TEST_P(KShortestPathsExecutorTest, the_test) {
+class KShortestPathsExecutorInputsTest
+    : public KShortestPathsExecutorTest,
+      public ::testing::WithParamInterface<std::tuple<Vertex, Vertex>> {
+ protected:
+  KShortestPathsExecutorInputsTest() : KShortestPathsExecutorTest(GetParam()) {}
+};
+
+TEST_P(KShortestPathsExecutorInputsTest, the_test) {
+  TestExecutor(registerInfos, executorInfos, input);
+}
+
+class KShortestPathsExecutorPathsTest
+    : public KShortestPathsExecutorTest,
+      public ::testing::WithParamInterface<std::tuple<MatrixBuilder<2>, PathSequence, AqlCall, size_t>> {
+ protected:
+  KShortestPathsExecutorPathsTest() : KShortestPathsExecutorTest(GetParam()) {}
+};
+
+TEST_P(KShortestPathsExecutorPathsTest, the_test) {
   TestExecutor(registerInfos, executorInfos, input);
 }
 
 // Conflict with the other shortest path finder
 namespace {
-
-Vertex const constSource("vertex/source"), constTarget("vertex/target"),
-    regSource(0), regTarget(1), brokenSource{"IwillBreakYourSearch"},
-    brokenTarget{"I will also break your search"};
-
-MatrixBuilder<2> const noneRow{{{{}}}};
-MatrixBuilder<2> const oneRow{{{{R"("vertex/source")"}, {R"("vertex/target")"}}}};
-MatrixBuilder<2> const twoRows{{{{R"("vertex/source")"}, {R"("vertex/target")"}}},
-                               {{{R"("vertex/a")"}, {R"("vertex/b")"}}}};
-MatrixBuilder<2> const threeRows{{{{R"("vertex/source")"}, {R"("vertex/target")"}}},
-                                 {{{R"("vertex/a")"}, {R"("vertex/b")"}}},
-                                 {{{R"("vertex/a")"}, {R"("vertex/target")"}}}};
-MatrixBuilder<2> const someRows{{{{R"("vertex/c")"}, {R"("vertex/target")"}}},
-                                {{{R"("vertex/b")"}, {R"("vertex/target")"}}},
-                                {{{R"("vertex/e")"}, {R"("vertex/target")"}}},
-                                {{{R"("vertex/a")"}, {R"("vertex/target")"}}}};
-
-PathSequence const noPath = {};
-PathSequence const onePath = {
-    {"vertex/source", "vertex/intermed", "vertex/target"}};
-
-PathSequence const threePaths = {
-    {"vertex/source", "vertex/intermed", "vertex/target"},
-    {"vertex/a", "vertex/b", "vertex/c", "vertex/d"},
-    {"vertex/source", "vertex/b", "vertex/c", "vertex/d"},
-    {"vertex/a", "vertex/b", "vertex/target"}};
-
-PathSequence const somePaths = {
-    {"vertex/source", "vertex/intermed0", "vertex/target"},
-    {"vertex/a", "vertex/b", "vertex/c", "vertex/d"},
-    {"vertex/source", "vertex/intermed1", "vertex/target"},
-    {"vertex/source", "vertex/intermed2", "vertex/target"},
-    {"vertex/a", "vertex/b", "vertex/c", "vertex/d"},
-    {"vertex/source", "vertex/intermed3", "vertex/target"},
-    {"vertex/source", "vertex/intermed4", "vertex/target"},
-    {"vertex/a", "vertex/b", "vertex/c", "vertex/d"},
-    {"vertex/source", "vertex/intermed5", "vertex/target"},
-};
 
 // Some of the bigger test cases we should generate and not write out like a caveperson
 PathSequence generateSomeBiggerCase(size_t n) {
@@ -432,8 +461,11 @@ auto calls =
                     AqlCall{0, AqlCall::Infinity{}, AqlCall::Infinity{}, true});
 auto blockSizes = testing::Values(5, 1000);
 
-INSTANTIATE_TEST_CASE_P(KShortestPathExecutorTestInstance, KShortestPathsExecutorTest,
-                        testing::Combine(sources, targets, inputs, paths, calls, blockSizes));
+INSTANTIATE_TEST_CASE_P(KShortestPathExecutorInputTestInstance, KShortestPathsExecutorInputsTest,
+                        testing::Combine(sources, targets));
+
+INSTANTIATE_TEST_CASE_P(KShortestPathExecutorPathsTestInstance, KShortestPathsExecutorPathsTest,
+                        testing::Combine(inputs, paths, calls, blockSizes));
 }  // namespace
 
 }  // namespace aql

--- a/tests/Aql/ShortestPathExecutorTest.cpp
+++ b/tests/Aql/ShortestPathExecutorTest.cpp
@@ -206,6 +206,67 @@ using PathSequence = std::vector<Path>;
 
 enum class ShortestPathOutput { VERTEX_ONLY, VERTEX_AND_EDGE };
 
+// Namespace conflict with the other shortest path executor
+namespace {
+Vertex const constSource("vertex/source"), constTarget("vertex/target"),
+    regSource(0), regTarget(1), brokenSource{"IwillBreakYourSearch"},
+    brokenTarget{"I will also break your search"};
+MatrixBuilder<2> const noneRow{{{{}}}};
+MatrixBuilder<2> const oneRow{{{{R"("vertex/source")"}, {R"("vertex/target")"}}}};
+MatrixBuilder<2> const twoRows{{{{R"("vertex/source")"}, {R"("vertex/target")"}}},
+                               {{{R"("vertex/a")"}, {R"("vertex/b")"}}}};
+MatrixBuilder<2> const threeRows{{{{R"("vertex/source")"}, {R"("vertex/target")"}}},
+                                 {{{R"("vertex/a")"}, {R"("vertex/b")"}}},
+                                 {{{R"("vertex/a")"}, {R"("vertex/target")"}}}};
+MatrixBuilder<2> const someRows{{{{R"("vertex/c")"}, {R"("vertex/target")"}}},
+                                {{{R"("vertex/b")"}, {R"("vertex/target")"}}},
+                                {{{R"("vertex/e")"}, {R"("vertex/target")"}}},
+                                {{{R"("vertex/a")"}, {R"("vertex/target")"}}}};
+
+auto pathBetween(std::string const& start, std::string const& end, size_t n) -> Path {
+  auto path = std::vector<std::string>{};
+  path.reserve(2 + n);
+  path.push_back(start);
+  for (size_t i = 0; i < n; ++i) {
+    path.emplace_back(std::to_string(i));
+  }
+  path.push_back(end);
+  return {path};
+}
+
+PathSequence const noPath = {};
+PathSequence const onePath = {pathBetween("vertex/source", "vertex/target", 10)};
+PathSequence const threePaths = {pathBetween("vertex/source", "vertex/target", 10),
+                                 pathBetween("vertex/source", "vertex/b", 100),
+                                 pathBetween("vertex/a", "vertex/b", 1000)};
+PathSequence const somePaths = {pathBetween("vertex/source", "vertex/target", 10),
+                                pathBetween("vertex/source", "vertex/b", 100),
+                                pathBetween("vertex/a", "vertex/b", 1000),
+                                pathBetween("vertex/c", "vertex/d", 2001)};
+PathSequence const someOtherPaths = {pathBetween("vertex/a", "vertex/target", 10),
+                                     pathBetween("vertex/b", "vertex/target", 999),
+                                     pathBetween("vertex/c", "vertex/target", 1001),
+                                     pathBetween("vertex/d", "vertex/target", 2000),
+                                     pathBetween("vertex/e", "vertex/target", 200),
+                                     pathBetween("vertex/f", "vertex/target", 15),
+                                     pathBetween("vertex/g", "vertex/target", 10)};
+
+auto sources = testing::Values(constSource, regSource, brokenSource);
+auto targets = testing::Values(constTarget, regTarget, brokenTarget);
+static auto inputs = testing::Values(noneRow, oneRow, twoRows, threeRows, someRows);
+auto paths = testing::Values(noPath, onePath, threePaths, somePaths);
+auto calls =
+    testing::Values(AqlCall{}, AqlCall{0, 0u, 0u, false},
+                    AqlCall{0, 1u, 0u, false}, AqlCall{0, 0u, 1u, false},
+                    AqlCall{0, 1u, 1u, false}, AqlCall{1, 1u, 1u},
+                    AqlCall{100, 1u, 1u}, AqlCall{1000}, AqlCall{0, 0u, 0u, true},
+                    AqlCall{0, AqlCall::Infinity{}, AqlCall::Infinity{}, true});
+
+auto variants = testing::Values(ShortestPathOutput::VERTEX_ONLY,
+                                ShortestPathOutput::VERTEX_AND_EDGE);
+auto blockSizes = testing::Values(size_t{5}, 1000);
+}  // namespace
+
 // TODO: this needs a << operator
 struct ShortestPathTestParameters {
   static RegIdSet _makeOutputRegisters(ShortestPathOutput in) {
@@ -229,17 +290,27 @@ struct ShortestPathTestParameters {
     return RegisterMapping{};
   }
 
-  ShortestPathTestParameters(
-      std::tuple<Vertex, Vertex, MatrixBuilder<2>, PathSequence, AqlCall, ShortestPathOutput, size_t> params)
+  ShortestPathTestParameters(std::tuple<Vertex, Vertex, ShortestPathOutput> params)
       : _source(std::get<0>(params)),
         _target(std::get<1>(params)),
-        _outputRegisters(_makeOutputRegisters(std::get<5>(params))),
-        _registerMapping(_makeRegisterMapping(std::get<5>(params))),
-        _inputMatrix{std::get<2>(params)},
-        _inputMatrixCopy{std::get<2>(params)},
-        _paths(std::get<3>(params)),
-        _call(std::get<4>(params)),
-        _blockSize(std::get<6>(params)) {}
+        _outputRegisters(_makeOutputRegisters(std::get<2>(params))),
+        _registerMapping(_makeRegisterMapping(std::get<2>(params))),
+        _inputMatrix{oneRow},
+        _inputMatrixCopy{oneRow},
+        _paths(threePaths),
+        _call(AqlCall{0, AqlCall::Infinity{}, AqlCall::Infinity{}, true}),
+        _blockSize(1000) {}
+
+  ShortestPathTestParameters(std::tuple<MatrixBuilder<2>, PathSequence, AqlCall, size_t> params)
+      : _source(constSource),
+        _target(constTarget),
+        _outputRegisters(_makeOutputRegisters(ShortestPathOutput::VERTEX_ONLY)),
+        _registerMapping(_makeRegisterMapping(ShortestPathOutput::VERTEX_ONLY)),
+        _inputMatrix{std::get<0>(params)},
+        _inputMatrixCopy{std::get<0>(params)},
+        _paths(std::get<1>(params)),
+        _call(std::get<2>(params)),
+        _blockSize(std::get<3>(params)) {}
 
   Vertex _source;
   Vertex _target;
@@ -253,56 +324,54 @@ struct ShortestPathTestParameters {
   size_t _blockSize{1000};
 };
 
-class ShortestPathExecutorTest
-    : public ::testing::Test,
-      public ::testing::WithParamInterface<std::tuple<Vertex, Vertex, MatrixBuilder<2>, PathSequence, AqlCall, ShortestPathOutput, size_t>> {
- protected:
+class ShortestPathExecutorTest : public ::testing::Test {
+  protected:
   ShortestPathTestParameters parameters;
 
-  MockAqlServer server;
-  ExecutionState state;
-  arangodb::ResourceMonitor monitor;
-  AqlItemBlockManager itemBlockManager;
-  std::unique_ptr<arangodb::aql::Query> fakedQuery;
-  TestShortestPathOptions options;
-  TokenTranslator& translator;
+MockAqlServer server;
+ExecutionState state;
+arangodb::ResourceMonitor monitor;
+AqlItemBlockManager itemBlockManager;
+std::unique_ptr<arangodb::aql::Query> fakedQuery;
+TestShortestPathOptions options;
+TokenTranslator& translator;
 
-  RegisterInfos registerInfos;
-  // parameters are copied because they are const otherwise
-  // and that doesn't mix with std::move
-  ShortestPathExecutorInfos executorInfos;
+RegisterInfos registerInfos;
+// parameters are copied because they are const otherwise
+// and that doesn't mix with std::move
+ShortestPathExecutorInfos executorInfos;
 
-  FakePathFinder& finder;
+FakePathFinder& finder;
 
-  SharedAqlItemBlockPtr inputBlock;
-  AqlItemBlockInputRange input;
+SharedAqlItemBlockPtr inputBlock;
+AqlItemBlockInputRange input;
 
-  std::shared_ptr<arangodb::velocypack::Builder> fakeUnusedBlock;
-  SingleRowFetcherHelper<::arangodb::aql::BlockPassthrough::Disable> fetcher;
+std::shared_ptr<arangodb::velocypack::Builder> fakeUnusedBlock;
+SingleRowFetcherHelper<::arangodb::aql::BlockPassthrough::Disable> fetcher;
 
-  ShortestPathExecutor testee;
+ShortestPathExecutor testee;
 
-  ShortestPathExecutorTest()
-      : parameters(GetParam()),
-        server{},
-        itemBlockManager(monitor, SerializationFormat::SHADOWROWS),
-        fakedQuery(server.createFakeQuery()),
-        options(fakedQuery.get()),
-        translator(*(static_cast<TokenTranslator*>(options.cache()))),
-        registerInfos(parameters._inputRegisters, parameters._outputRegisters,
-                      2, 4, {}, {RegIdSet{0, 1}}),
-        executorInfos(std::make_unique<FakePathFinder>(options, translator),
-                      std::move(parameters._registerMapping),
-                      std::move(parameters._source), std::move(parameters._target)),
-        finder(static_cast<FakePathFinder&>(executorInfos.finder())),
-        inputBlock(buildBlock<2>(itemBlockManager, std::move(parameters._inputMatrix))),
-        input(AqlItemBlockInputRange(ExecutorState::DONE, 0, inputBlock, 0)),
-        fakeUnusedBlock(VPackParser::fromJson("[]")),
-        fetcher(itemBlockManager, fakeUnusedBlock->steal(), false),
-        testee(fetcher, executorInfos) {
-    for (auto&& p : parameters._paths) {
-      finder.addPath(std::move(p));
-    }
+ShortestPathExecutorTest(ShortestPathTestParameters parameters_)
+    : parameters(std::move(parameters_)),
+      server{},
+      itemBlockManager(monitor, SerializationFormat::SHADOWROWS),
+      fakedQuery(server.createFakeQuery()),
+      options(fakedQuery.get()),
+      translator(*(static_cast<TokenTranslator*>(options.cache()))),
+      registerInfos(parameters._inputRegisters, parameters._outputRegisters, 2,
+                    4, {}, {RegIdSet{0, 1}}),
+      executorInfos(std::make_unique<FakePathFinder>(options, translator),
+                    std::move(parameters._registerMapping),
+                    std::move(parameters._source), std::move(parameters._target)),
+      finder(static_cast<FakePathFinder&>(executorInfos.finder())),
+      inputBlock(buildBlock<2>(itemBlockManager, std::move(parameters._inputMatrix))),
+      input(AqlItemBlockInputRange(ExecutorState::DONE, 0, inputBlock, 0)),
+      fakeUnusedBlock(VPackParser::fromJson("[]")),
+      fetcher(itemBlockManager, fakeUnusedBlock->steal(), false),
+      testee(fetcher, executorInfos) {
+  for (auto&& p : parameters._paths) {
+    finder.addPath(std::move(p));
+  }
   }
 
   size_t ExpectedNumberOfRowsProduced(size_t expectedFound) {
@@ -496,71 +565,38 @@ class ShortestPathExecutorTest
  * responsibility of the test for the shortest path finder.
  */
 
-TEST_P(ShortestPathExecutorTest, the_test) { TestExecutor(); }
+class ShortestPathExecutorInputOutputTest
+    : public ShortestPathExecutorTest,
+      public ::testing::WithParamInterface<std::tuple<Vertex, Vertex, ShortestPathOutput>> {
+ protected:
+  ShortestPathExecutorInputOutputTest()
+      : ShortestPathExecutorTest(GetParam()) {}
+};
+
+class ShortestPathExecutorPathTest
+    : public ShortestPathExecutorTest,
+      public ::testing::WithParamInterface<std::tuple<MatrixBuilder<2>, PathSequence, AqlCall, size_t>> {
+ protected:
+  ShortestPathExecutorPathTest() : ShortestPathExecutorTest(GetParam()) {}
+};
+
+TEST_P(ShortestPathExecutorInputOutputTest, the_test) {
+  TestExecutor();
+}
+
+TEST_P(ShortestPathExecutorPathTest, the_test) {
+  TestExecutor();
+}
 
 // Namespace conflict with the other shortest path executor
 namespace {
-Vertex const constSource("vertex/source"), constTarget("vertex/target"),
-    regSource(0), regTarget(1), brokenSource{"IwillBreakYourSearch"},
-    brokenTarget{"I will also break your search"};
-MatrixBuilder<2> const noneRow{{{{}}}};
-MatrixBuilder<2> const oneRow{{{{R"("vertex/source")"}, {R"("vertex/target")"}}}};
-MatrixBuilder<2> const twoRows{{{{R"("vertex/source")"}, {R"("vertex/target")"}}},
-                               {{{R"("vertex/a")"}, {R"("vertex/b")"}}}};
-MatrixBuilder<2> const threeRows{{{{R"("vertex/source")"}, {R"("vertex/target")"}}},
-                                 {{{R"("vertex/a")"}, {R"("vertex/b")"}}},
-                                 {{{R"("vertex/a")"}, {R"("vertex/target")"}}}};
-MatrixBuilder<2> const someRows{{{{R"("vertex/c")"}, {R"("vertex/target")"}}},
-                                {{{R"("vertex/b")"}, {R"("vertex/target")"}}},
-                                {{{R"("vertex/e")"}, {R"("vertex/target")"}}},
-                                {{{R"("vertex/a")"}, {R"("vertex/target")"}}}};
 
-auto pathBetween(std::string const& start, std::string const& end, size_t n) -> Path {
-  auto path = std::vector<std::string>{};
-  path.reserve(2 + n);
-  path.push_back(start);
-  for (size_t i = 0; i < n; ++i) {
-    path.emplace_back(std::to_string(i));
-  }
-  path.push_back(end);
-  return {path};
-}
+INSTANTIATE_TEST_CASE_P(ShortestPathExecutorInputOutputTestInstance,
+                        ShortestPathExecutorInputOutputTest,
+                        testing::Combine(sources, targets, variants));
 
-PathSequence const noPath = {};
-PathSequence const onePath = {pathBetween("vertex/source", "vertex/target", 10)};
-PathSequence const threePaths = {pathBetween("vertex/source", "vertex/target", 10),
-                                 pathBetween("vertex/source", "vertex/b", 100),
-                                 pathBetween("vertex/a", "vertex/b", 1000)};
-PathSequence const somePaths = {pathBetween("vertex/source", "vertex/target", 10),
-                                pathBetween("vertex/source", "vertex/b", 100),
-                                pathBetween("vertex/a", "vertex/b", 1000),
-                                pathBetween("vertex/c", "vertex/d", 2001)};
-PathSequence const someOtherPaths = {pathBetween("vertex/a", "vertex/target", 10),
-                                     pathBetween("vertex/b", "vertex/target", 999),
-                                     pathBetween("vertex/c", "vertex/target", 1001),
-                                     pathBetween("vertex/d", "vertex/target", 2000),
-                                     pathBetween("vertex/e", "vertex/target", 200),
-                                     pathBetween("vertex/f", "vertex/target", 15),
-                                     pathBetween("vertex/g", "vertex/target", 10)};
-
-auto sources = testing::Values(constSource, regSource, brokenSource);
-auto targets = testing::Values(constTarget, regTarget, brokenTarget);
-static auto inputs = testing::Values(noneRow, oneRow, twoRows, threeRows, someRows);
-auto paths = testing::Values(noPath, onePath, threePaths, somePaths);
-auto calls =
-    testing::Values(AqlCall{}, AqlCall{0, 0u, 0u, false},
-                    AqlCall{0, 1u, 0u, false}, AqlCall{0, 0u, 1u, false},
-                    AqlCall{0, 1u, 1u, false}, AqlCall{1, 1u, 1u},
-                    AqlCall{100, 1u, 1u}, AqlCall{1000}, AqlCall{0, 0u, 0u, true},
-                    AqlCall{0, AqlCall::Infinity{}, AqlCall::Infinity{}, true});
-
-auto variants = testing::Values(ShortestPathOutput::VERTEX_ONLY,
-                                ShortestPathOutput::VERTEX_AND_EDGE);
-auto blockSizes = testing::Values(size_t{5}, 1000);
-
-INSTANTIATE_TEST_CASE_P(ShortestPathExecutorTestInstance, ShortestPathExecutorTest,
-                        testing::Combine(sources, targets, inputs, paths, calls,
-                                         variants, blockSizes));
+INSTANTIATE_TEST_CASE_P(ShortestPathExecutorPathsTestInstance, ShortestPathExecutorPathTest,
+                        testing::Combine(inputs, paths, calls, blockSizes));
 }  // namespace
 }  // namespace aql
 }  // namespace tests


### PR DESCRIPTION
This test does not have any User Impact.

It only reduces the amount of tested combinations of input / data in the tests.
It is fine to have the input format tested once, and the data tested once.
This speeds up initial load of tests by ~66% on my machine.
Also speeds up the tests of the specific files by factor of ~10 or more.

Jenkins:
http://jenkins.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/13604/