### PR TITLE
fix shutdown issue during gtests

### DIFF
--- a/arangod/Cluster/AgencyCache.cpp
+++ b/arangod/Cluster/AgencyCache.cpp
@@ -566,14 +566,20 @@ void AgencyCache::beginShutdown() {
     {
       std::lock_guard g(_callbacksLock);
       if (_callbacks.empty()) {
-        _callbacksCount = 0;
+        // we are intentionally _not_ setting the metric to 0 here, as the metrics
+        // may already be unavailable. As we are in shutdown anyway here, this should
+        // not cause major issues.
+        // _callbacksCount = 0;
         break;
       }
       auto it = _callbacks.begin();
       TRI_ASSERT(it != _callbacks.end());
       callbackId = it->second;
       _callbacks.erase(it);
-      _callbacksCount -= 1;
+      // we are intentionally _not_ setting the metric to 0 here, as the metrics
+      // may already be unavailable. As we are in shutdown anyway here, this should
+      // not cause major issues.
+      // _callbacksCount -= 1;
     } // release _callbacksLock
 
     auto cb = _callbackRegistry.getCallback(callbackId);

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -600,7 +600,7 @@ void ClusterFeature::start() {
       << ", server id: '" << myId << "', internal endpoint / address: " << _myEndpoint
       << "', advertised endpoint: " << _myAdvertisedEndpoint << ", role: " << role;
 
-  auto [acb,idx] = _agencyCache->read(
+  auto [acb, idx] = _agencyCache->read(
     std::vector<std::string>{AgencyCommHelper::path("Sync/HeartbeatIntervalMs")});
   auto result = acb->slice();
 
@@ -764,6 +764,7 @@ void ClusterFeature::shutdownAgencyCache() {
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
+  _agencyCache.reset();
 }
 
 void ClusterFeature::notify() {

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -439,6 +439,7 @@ MockClusterServer::MockClusterServer() : MockServer() {
 
 MockClusterServer::~MockClusterServer() {
   _server.getFeature<arangodb::ClusterFeature>().clusterInfo().shutdownSyncers();
+  _server.getFeature<arangodb::ClusterFeature>().shutdownAgencyCache();
   arangodb::ServerState::instance()->setRole(_oldRole);
 }
 


### PR DESCRIPTION
### Scope & Purpose

Fix a shutdown issue that happens at least during testing.
When `ClusterFeature` shuts down, it needs to make sure that its `_agencyCache` member was successfully shut down as well. So it tries to shut down the `_agencyCache` in `ClusterFeature::stop()` and in `ClusterFeature::~ClusterFeature()` (in case `stop` isn't called for whatever reason).
The `AgencyCache` itself updates metrics on shutdown, so it relies on the `MetricsFeature` to be valid.

Now, in case we are in `ApplicationServer::~ApplicationServer()`, the destructors of all ApplicationFeatures are called in a random order (features are stored in an unordered_map). In my case the `MetricsFeature` was destroyed before the `ClusterFeature`. Now, when `~ClusterFeature()` is executed, it tries to shut down the `_agencyCache` member, which relies on the metrics. And then it may reference already freed memory.

This PR tries to fix it by resetting the `_agencyCache` member in `ClusterFeature::stop()`, so that when the destructor runs, there is no need to call into the `_agencyCache` anymore. In addition, it removes the usage of metrics in `AgencyCache::beginShutdown()`, because that may be unsafe. We have to live with the metrics not being counted down when the server is shutting down. This shouldn't be a problem IMO.

I found this issue by accident when running the gtests in devel.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: potentially 3.7 

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *gtest with ASan*.
- [x] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13607/