### PR TITLE
Replaced MAINTAINERMODE with GTEST makro to include testing code

### DIFF
--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -1882,7 +1882,7 @@ auto ExecutionBlockImpl<Executor>::countShadowRowProduced(AqlCallStack& stack, s
   }
 }
 
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+#ifdef ARANGODB_USE_GOOGLE_TESTS
 // This is a helper method to inject a prepared
 // input range in the tests. It should simulate
 // an ongoing query in a specific state.

--- a/arangod/Aql/ExecutionBlockImpl.h
+++ b/arangod/Aql/ExecutionBlockImpl.h
@@ -211,7 +211,7 @@ class ExecutionBlockImpl final : public ExecutionBlock {
   template <class exec = Executor, typename = std::enable_if_t<std::is_same_v<exec, IdExecutor<SingleRowFetcher<BlockPassthrough::Enable>>>>>
   [[nodiscard]] RegisterId getOutputRegisterId() const noexcept;
 
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+#ifdef ARANGODB_USE_GOOGLE_TESTS
   // This is a helper method to inject a prepared
   // input range in the tests. It should simulate
   // an ongoing query in a specific state.

--- a/arangod/Aql/MultiDependencySingleRowFetcher.cpp
+++ b/arangod/Aql/MultiDependencySingleRowFetcher.cpp
@@ -276,7 +276,7 @@ auto MultiDependencySingleRowFetcher::upstreamState() const -> ExecutionState {
 auto MultiDependencySingleRowFetcher::resetDidReturnSubquerySkips(size_t shadowRowDepth) -> void {
   _didReturnSubquerySkips = false;
 
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+#ifdef ARANGODB_USE_GOOGLE_TESTS
   // Validate that the skip number is identical in all branches
   for (size_t i = 0; i < shadowRowDepth; ++i) {
     auto const reportedSkip = _maximumSkipReport.getSkipped(i);

--- a/arangod/Aql/MultiDependencySingleRowFetcher.cpp
+++ b/arangod/Aql/MultiDependencySingleRowFetcher.cpp
@@ -276,7 +276,7 @@ auto MultiDependencySingleRowFetcher::upstreamState() const -> ExecutionState {
 auto MultiDependencySingleRowFetcher::resetDidReturnSubquerySkips(size_t shadowRowDepth) -> void {
   _didReturnSubquerySkips = false;
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // Validate that the skip number is identical in all branches
   for (size_t i = 0; i < shadowRowDepth; ++i) {
     auto const reportedSkip = _maximumSkipReport.getSkipped(i);
@@ -294,7 +294,7 @@ auto MultiDependencySingleRowFetcher::resetDidReturnSubquerySkips(size_t shadowR
   }
 }
 
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+#ifdef ARANGODB_USE_GOOGLE_TESTS
 auto MultiDependencySingleRowFetcher::initialize(size_t subqueryDepth) -> void {
   initializeReports(subqueryDepth);
 }

--- a/arangod/Aql/MultiDependencySingleRowFetcher.h
+++ b/arangod/Aql/MultiDependencySingleRowFetcher.h
@@ -131,7 +131,7 @@ class MultiDependencySingleRowFetcher {
   void reportSubqueryFullCounts(size_t subqueryDepth,
                                 std::vector<size_t> const& skippedInDependency);
 
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+#ifdef ARANGODB_USE_GOOGLE_TESTS
   auto initialize(size_t subqueryDepth) -> void;
 #endif
 


### PR DESCRIPTION
This PR has no User Impact.
The modified place inject some test-case preparation code.
This should only be enabled with the GTEST flag enabled, and is independent of MAINTAINER_MODE which was used here wrongly.
Jenkins runs either both on or both of, so it slipped through.

Jenkins:
http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/13613/