### PR TITLE
Added metric `arangodb_aql_current_query`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Added metric `arangodb_aql_current_query` to track the number of currently
+  executing AQL queries.
+
 * Updated arangosync to 1.2.2.
 
 * Fix a bug in the agency Supervision which could lead to removeFollower

--- a/arangod/Aql/QueryList.cpp
+++ b/arangod/Aql/QueryList.cpp
@@ -132,7 +132,9 @@ bool QueryList::insert(Query* query) {
     }
 
     // return whether or not insertion worked
-    return _current.insert({query->id(), query}).second;
+    bool inserted = _current.insert({query->id(), query}).second;
+    _queryRegistryFeature.trackQueryStart();
+    return inserted;
   } catch (...) {
     return false;
   }
@@ -167,7 +169,7 @@ void QueryList::remove(Query* query) {
   // elapsed time since query start
   double const elapsed = elapsedSince(query->startTime());
 
-  _queryRegistryFeature.trackQuery(elapsed);
+  _queryRegistryFeature.trackQueryEnd(elapsed);
 
   if (!trackSlowQueries()) {
     return;

--- a/arangod/RestServer/QueryRegistryFeature.cpp
+++ b/arangod/RestServer/QueryRegistryFeature.cpp
@@ -128,10 +128,13 @@ QueryRegistryFeature::QueryRegistryFeature(application_features::ApplicationServ
           "arangodb_aql_total_query_time_msec", 0, "Total execution time of all AQL queries [ms]")),
       _queriesCounter(
         server.getFeature<arangodb::MetricsFeature>().counter(
-          "arangodb_aql_all_query", 0, "Total number of AQL queries")),
+          "arangodb_aql_all_query", 0, "Total number of AQL queries finished")),
       _slowQueriesCounter(
         server.getFeature<arangodb::MetricsFeature>().counter(
-          "arangodb_aql_slow_query", 0, "Total number of slow AQL queries")) {
+          "arangodb_aql_slow_query", 0, "Total number of slow AQL queries finished")),
+      _runningQueries(
+        server.getFeature<arangodb::MetricsFeature>().gauge<uint64_t>(
+          "arangodb_aql_current_query", 0, "Current number of AQL queries executing")) {
   setOptional(false);
   startsAfter<V8FeaturePhase>();
 
@@ -326,10 +329,15 @@ void QueryRegistryFeature::unprepare() {
   QUERY_REGISTRY.store(nullptr, std::memory_order_release);
 }
 
-void QueryRegistryFeature::trackQuery(double time) { 
+void QueryRegistryFeature::trackQueryStart() noexcept {
+  _runningQueries += 1;
+}
+
+void QueryRegistryFeature::trackQueryEnd(double time) { 
   ++_queriesCounter; 
   _queryTimes.count(time);
   _totalQueryExecutionTime += static_cast<uint64_t>(1000.0 * time);
+  _runningQueries -= 1;
 }
 
 void QueryRegistryFeature::trackSlowQuery(double time) { 

--- a/arangod/RestServer/QueryRegistryFeature.h
+++ b/arangod/RestServer/QueryRegistryFeature.h
@@ -46,8 +46,10 @@ class QueryRegistryFeature final : public application_features::ApplicationFeatu
   void stop() override final;
   void unprepare() override final;
 
-  // tracks a query, using execution time
-  void trackQuery(double time);
+  // tracks a query start
+  void trackQueryStart() noexcept;
+  // tracks a query completion, using execution time
+  void trackQueryEnd(double time);
   // tracks a slow query, using execution time
   void trackSlowQuery(double time);
 
@@ -105,6 +107,7 @@ class QueryRegistryFeature final : public application_features::ApplicationFeatu
   Counter& _totalQueryExecutionTime;
   Counter& _queriesCounter;
   Counter& _slowQueriesCounter;
+  Gauge<uint64_t>& _runningQueries;
 };
 
 }  // namespace arangodb

--- a/arangod/Scheduler/SupervisedScheduler.cpp
+++ b/arangod/Scheduler/SupervisedScheduler.cpp
@@ -166,7 +166,7 @@ SupervisedScheduler::SupervisedScheduler(application_features::ApplicationServer
       _numAwake(0),
       _metricsQueueLength(server.getFeature<arangodb::MetricsFeature>().gauge<uint64_t>(
           StaticStrings::SchedulerQueueLength, 0,
-          "Servers internal queue length")),
+          "Server's internal queue length")),
       _metricsJobsDone(server.getFeature<arangodb::MetricsFeature>().gauge<uint64_t>(
           "arangodb_scheduler_jobs_done", 0, "Total number of queue jobs done")),
       _metricsJobsSubmitted(server.getFeature<arangodb::MetricsFeature>().gauge<uint64_t>(


### PR DESCRIPTION
### Scope & Purpose

Added metric `arangodb_aql_current_query` to track the number of currently executing AQL queries.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13619/