### PR TITLE
add missing sentence to documentation

### DIFF
--- a/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
+++ b/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
@@ -64,7 +64,8 @@ specifies the type of the key generator. The currently available generators are
 *traditional*, *autoincrement*, *uuid* and *padded*.<br>
 The *traditional* key generator generates numerical keys in ascending order.
 The *autoincrement* key generator generates numerical keys in ascending order,
-the initial offset and the spacing can be configured
+the initial offset and the spacing can be configured (**note**: *autoincrement* is currently only 
++supported for non-sharded collections). 
 The *padded* key generator generates keys of a fixed length (16 bytes) in
 ascending lexicographical sort order. This is ideal for usage with the _RocksDB_
 engine, which will slightly benefit keys that are inserted in lexicographically


### PR DESCRIPTION
### Scope & Purpose

Adds a missing sentence to the documentation about the auto-increment key generator not being support in the cluster.
Affects only the documentation.
The documentation change has been made in devel already.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13628/