### PR TITLE
fix decoding of values in `padded` key generator

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.6.11 (XXXX-XX-XX)
 --------------------
 
+* Fix decoding of values in `padded` key generator when restoring from a dump.
+
 * Fix a bug in the agency Supervision which could lead to removeFollower jobs
   constantly being created and immediately stopped again.
 

--- a/arangod/VocBase/KeyGenerator.cpp
+++ b/arangod/VocBase/KeyGenerator.cpp
@@ -362,7 +362,7 @@ class PaddedKeyGenerator : public KeyGenerator {
       return std::string();
     }
 
-    return encode(tick);
+    return KeyGeneratorHelper::encodePadded(tick);
   }
 
   /// @brief validate a key
@@ -381,7 +381,7 @@ class PaddedKeyGenerator : public KeyGenerator {
   /// @brief track usage of a key
   void track(char const* p, size_t length) override {
     // check the numeric key part
-    uint64_t value = decode(p, length);
+    uint64_t value = KeyGeneratorHelper::decodePadded(p, length);
     if (value > 0) {
       track(value);
     }
@@ -399,59 +399,6 @@ class PaddedKeyGenerator : public KeyGenerator {
 
   /// @brief track a value (internal)
   virtual void track(uint64_t value) = 0;
-
- private:
-  uint64_t decode(char const* p, size_t length) {
-    uint64_t result = 0;
-
-    if (length != sizeof(uint64_t) * 2) {
-      return result;
-    }
-
-    char const* e = p + length;
-    while (p < e) {
-      uint64_t high, low;
-      uint8_t c = (uint8_t)(*p++);
-      if (c >= 'a' && c <= 'f') {
-        high = (c - 'a') + 10;
-      } else if (c >= '0' && c <= '9') {
-        high = (c - '0');
-      } else {
-        return 0;
-      }
-      c = (uint8_t)(*p++);
-      if (c >= 'a' && c <= 'f') {
-        low = (c - 'a') + 10;
-      } else if (c >= '0' && c <= '9') {
-        low = (c - '0');
-      } else {
-        return 0;
-      }
-      result += ((high << 4) | low) << ((e - p) / 2);
-    }
-
-    return result;
-  }
-
-  std::string encode(uint64_t value) {
-    // convert to big endian
-    uint64_t big = basics::hostToBig(value);
-
-    uint8_t const* p = reinterpret_cast<uint8_t const*>(&big);
-    uint8_t const* e = p + sizeof(value);
-
-    char buffer[16];
-    uint8_t* out = reinterpret_cast<uint8_t*>(&buffer[0]);
-    while (p < e) {
-      uint8_t c = (uint8_t)(*p++);
-      uint8_t n1 = c >> 4;
-      uint8_t n2 = c & 0x0F;
-      *out++ = ((n1 < 10) ? ('0' + n1) : ('a' + n1 - 10));
-      *out++ = ((n2 < 10) ? ('0' + n2) : ('a' + n2 - 10));
-    }
-
-    return std::string(&buffer[0], sizeof(uint64_t) * 2);
-  }
 };
 
 /// @brief padded key generator for a single server
@@ -492,7 +439,7 @@ class PaddedKeyGeneratorSingle final : public PaddedKeyGenerator {
         tick = _lastValue.fetch_add(1, std::memory_order_relaxed) + 1;
         break;
       }
-    } while(!_lastValue.compare_exchange_weak(lastValue, tick, std::memory_order_relaxed));
+    } while (!_lastValue.compare_exchange_weak(lastValue, tick, std::memory_order_relaxed));
 
 
     return tick;
@@ -770,6 +717,59 @@ std::unordered_map<GeneratorMapType, std::function<KeyGenerator*(bool, VPackSlic
      }}};
 
 }  // namespace
+
+uint64_t KeyGeneratorHelper::decodePadded(char const* data, size_t length) {
+  uint64_t result = 0;
+
+  if (length != sizeof(uint64_t) * 2) {
+    return result;
+  }
+
+  char const* p = data;
+  char const* e = p + length;
+  while (p < e) {
+    uint64_t high, low;
+    uint8_t c = (uint8_t)(*p++);
+    if (c >= 'a' && c <= 'f') {
+      high = (c - 'a') + 10;
+    } else if (c >= '0' && c <= '9') {
+      high = (c - '0');
+    } else {
+      return 0;
+    }
+    c = (uint8_t)(*p++);
+    if (c >= 'a' && c <= 'f') {
+      low = (c - 'a') + 10;
+    } else if (c >= '0' && c <= '9') {
+      low = (c - '0');
+    } else {
+      return 0;
+    }
+    result += ((high << 4) | low) << (uint64_t(8) * ((e - p) / 2));
+  }
+
+  return result;
+}
+
+std::string KeyGeneratorHelper::encodePadded(uint64_t value) {
+  // convert to big endian
+  uint64_t big = basics::hostToBig(value);
+
+  uint8_t const* p = reinterpret_cast<uint8_t const*>(&big);
+  uint8_t const* e = p + sizeof(value);
+
+  char buffer[16];
+  uint8_t* out = reinterpret_cast<uint8_t*>(&buffer[0]);
+  while (p < e) {
+    uint8_t c = (uint8_t)(*p++);
+    uint8_t n1 = c >> 4;
+    uint8_t n2 = c & 0x0F;
+    *out++ = ((n1 < 10) ? ('0' + n1) : ('a' + n1 - 10));
+    *out++ = ((n2 < 10) ? ('0' + n2) : ('a' + n2 - 10));
+  }
+
+  return std::string(&buffer[0], sizeof(uint64_t) * 2);
+}
 
 /// @brief create the key generator
 KeyGenerator::KeyGenerator(bool allowUserKeys)

--- a/arangod/VocBase/KeyGenerator.h
+++ b/arangod/VocBase/KeyGenerator.h
@@ -28,12 +28,19 @@
 #include "VocBase/vocbase.h"
 
 #include <array>
+#include <string>
 
 namespace arangodb {
 namespace velocypack {
 class Builder;
 class Slice;
 }  // namespace velocypack
+
+// static helper functions for key generators
+struct KeyGeneratorHelper {
+  static std::string encodePadded(uint64_t value);
+  static uint64_t decodePadded(char const* p, size_t length);
+};
 
 /// generic key generator interface
 ///

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -227,6 +227,7 @@ set(ARANGODB_TESTS_SOURCES
   V8Server/v8-users-test.cpp
   V8Server/v8-views-test.cpp
   VocBase/vocbase-test.cpp
+  VocBase/KeyGenerator-test.cpp
   VocBase/LogicalDataSource-test.cpp
   VocBase/LogicalView-test.cpp
   VocBase/VersionTest.cpp

--- a/tests/VocBase/KeyGenerator-test.cpp
+++ b/tests/VocBase/KeyGenerator-test.cpp
@@ -1,0 +1,96 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#include "VocBase/KeyGenerator.h"
+
+#include "gtest/gtest.h"
+
+using namespace arangodb;
+
+TEST(KeyGeneratorTest, encodePadded) {
+  ASSERT_EQ(std::string("0000000000000000"), KeyGeneratorHelper::encodePadded(0));
+  ASSERT_EQ(std::string("0000000000000001"), KeyGeneratorHelper::encodePadded(1));
+  ASSERT_EQ(std::string("0000000000000002"), KeyGeneratorHelper::encodePadded(2));
+  ASSERT_EQ(std::string("0000000000000005"), KeyGeneratorHelper::encodePadded(5));
+  ASSERT_EQ(std::string("0000000000000009"), KeyGeneratorHelper::encodePadded(9));
+  ASSERT_EQ(std::string("000000000000000a"), KeyGeneratorHelper::encodePadded(10));
+  ASSERT_EQ(std::string("000000000000000c"), KeyGeneratorHelper::encodePadded(12));
+  ASSERT_EQ(std::string("000000000000000f"), KeyGeneratorHelper::encodePadded(15));
+  ASSERT_EQ(std::string("0000000000000010"), KeyGeneratorHelper::encodePadded(16));
+  ASSERT_EQ(std::string("0000000000000011"), KeyGeneratorHelper::encodePadded(17));
+  ASSERT_EQ(std::string("0000000000000019"), KeyGeneratorHelper::encodePadded(25));
+  ASSERT_EQ(std::string("0000000000000020"), KeyGeneratorHelper::encodePadded(32));
+  ASSERT_EQ(std::string("0000000000000021"), KeyGeneratorHelper::encodePadded(33));
+  ASSERT_EQ(std::string("000000000000003f"), KeyGeneratorHelper::encodePadded(63));
+  ASSERT_EQ(std::string("0000000000000040"), KeyGeneratorHelper::encodePadded(64));
+  ASSERT_EQ(std::string("000000000000007f"), KeyGeneratorHelper::encodePadded(127));
+  ASSERT_EQ(std::string("00000000000000ff"), KeyGeneratorHelper::encodePadded(255));
+  ASSERT_EQ(std::string("0000000000000100"), KeyGeneratorHelper::encodePadded(256));
+  ASSERT_EQ(std::string("0000000000000101"), KeyGeneratorHelper::encodePadded(257));
+  ASSERT_EQ(std::string("00000000000001ff"), KeyGeneratorHelper::encodePadded(511));
+  ASSERT_EQ(std::string("0000000000000200"), KeyGeneratorHelper::encodePadded(512));
+  ASSERT_EQ(std::string("0000000000001002"), KeyGeneratorHelper::encodePadded(4098));
+  ASSERT_EQ(std::string("000000000000ffff"), KeyGeneratorHelper::encodePadded(65535));
+  ASSERT_EQ(std::string("0000000000010000"), KeyGeneratorHelper::encodePadded(65536));
+  ASSERT_EQ(std::string("0000000007a9f3bf"), KeyGeneratorHelper::encodePadded(128578495));
+  ASSERT_EQ(std::string("00000000ffffffff"), KeyGeneratorHelper::encodePadded(UINT32_MAX));
+  ASSERT_EQ(std::string("000019a33af7f8cf"), KeyGeneratorHelper::encodePadded(28188859693263ULL));
+  ASSERT_EQ(std::string("03e9782f766722ab"), KeyGeneratorHelper::encodePadded(281888596932633259ULL));
+  ASSERT_EQ(std::string("ffffffffffffffff"), KeyGeneratorHelper::encodePadded(UINT64_MAX));
+}
+
+TEST(KeyGeneratorTest, decodePadded) {
+  auto decode = [](std::string const& value) {
+    return KeyGeneratorHelper::decodePadded(value.data(), value.size());
+  };
+
+  ASSERT_EQ(uint64_t(0), decode("0000000000000000"));
+  ASSERT_EQ(uint64_t(1), decode("0000000000000001"));
+  ASSERT_EQ(uint64_t(2), decode("0000000000000002"));
+  ASSERT_EQ(uint64_t(5), decode("0000000000000005"));
+  ASSERT_EQ(uint64_t(9), decode("0000000000000009"));
+  ASSERT_EQ(uint64_t(10), decode("000000000000000a"));
+  ASSERT_EQ(uint64_t(12), decode("000000000000000c"));
+  ASSERT_EQ(uint64_t(15), decode("000000000000000f"));
+  ASSERT_EQ(uint64_t(16), decode("0000000000000010"));
+  ASSERT_EQ(uint64_t(17), decode("0000000000000011"));
+  ASSERT_EQ(uint64_t(25), decode("0000000000000019"));
+  ASSERT_EQ(uint64_t(32), decode("0000000000000020"));
+  ASSERT_EQ(uint64_t(33), decode("0000000000000021"));
+  ASSERT_EQ(uint64_t(63), decode("000000000000003f"));
+  ASSERT_EQ(uint64_t(64), decode("0000000000000040"));
+  ASSERT_EQ(uint64_t(127), decode("000000000000007f"));
+  ASSERT_EQ(uint64_t(255), decode("00000000000000ff"));
+  ASSERT_EQ(uint64_t(256), decode("0000000000000100"));
+  ASSERT_EQ(uint64_t(257), decode("0000000000000101"));
+  ASSERT_EQ(uint64_t(511), decode("00000000000001ff"));
+  ASSERT_EQ(uint64_t(512), decode("0000000000000200"));
+  ASSERT_EQ(uint64_t(4098), decode("0000000000001002"));
+  ASSERT_EQ(uint64_t(65535), decode("000000000000ffff"));
+  ASSERT_EQ(uint64_t(65536), decode("0000000000010000"));
+  ASSERT_EQ(uint64_t(128578495), decode("0000000007a9f3bf"));
+  ASSERT_EQ(uint64_t(UINT32_MAX), decode("00000000ffffffff"));
+  ASSERT_EQ(uint64_t(28188859693263ULL), decode("000019a33af7f8cf"));
+  ASSERT_EQ(uint64_t(281888596932633259ULL), decode("03e9782f766722ab"));
+  ASSERT_EQ(uint64_t(UINT64_MAX), decode("ffffffffffffffff"));
+}


### PR DESCRIPTION
### Scope & Purpose

Fix decoding of values in `padded` key generator when restoring data.
Added unit test.

Backport of https://github.com/arangodb/arangodb/pull/13415

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *shell_client, shell_server*.
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new C++ **Unit tests**

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13682/