### PR TITLE
fix a test-only memleak

### DIFF
--- a/tests/Aql/BitFunctionsTest.cpp
+++ b/tests/Aql/BitFunctionsTest.cpp
@@ -94,6 +94,7 @@ AqlValue callFn(AstNode const& node, char const* input1, char const* input2 = nu
 template <typename T>
 T evaluate(AstNode const& node, char const* input1, char const* input2 = nullptr, char const* input3 = nullptr) {
   AqlValue actual = callFn(node, input1, input2, input3);
+  AqlValueGuard guard(actual, true);
   if constexpr (std::is_same<T, int64_t>::value) {
     EXPECT_TRUE(actual.isNumber());
     return actual.toInt64();


### PR DESCRIPTION
### Scope & Purpose

Fix a memleak that occurred only in AQL bit functions test code.
This does not affect any users, and does not need to be fixed in other versions.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13691/