### PR TITLE
Make `padded` and `autoincrement` key generators export their `lastValue` values, so that they are available in dumps and can be restored elsewhere from a dump.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Make `padded` and `autoincrement` key generators export their `lastValue` 
+  values, so that they are available in dumps and can be restored elsewhere
+  from a dump.
+
 * Fix decoding of values in `padded` key generator when restoring from a dump.
 
 * Fixed error reporting for hotbackup restore from dbservers back to

--- a/arangod/VocBase/KeyGenerator.cpp
+++ b/arangod/VocBase/KeyGenerator.cpp
@@ -195,6 +195,23 @@ enum class GeneratorType : int {
 /// @brief for older compilers
 typedef std::underlying_type<GeneratorType>::type GeneratorMapType;
 
+uint64_t readLastValue(VPackSlice options) {
+  uint64_t lastValue = 0;
+
+  if (VPackSlice lastValueSlice = options.get(StaticStrings::LastValue); lastValueSlice.isNumber()) {
+    double v = lastValueSlice.getNumericValue<double>();
+    if (v < 0.0) {
+      // negative lastValue is not allowed
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_ARANGO_INVALID_KEY_GENERATOR,
+          "'lastValue' value must be greater than zero");
+    }
+
+    lastValue = lastValueSlice.getNumericValue<uint64_t>();
+  }
+  return lastValue;
+}
+
 /// Actual key generators following...
 
 /// @brief base class for traditional key generators
@@ -204,7 +221,7 @@ class TraditionalKeyGenerator : public KeyGenerator {
   explicit TraditionalKeyGenerator(bool allowUserKeys)
       : KeyGenerator(allowUserKeys) {}
 
-  bool hasDynamicState() const override { return true; }
+  bool hasDynamicState() const override final { return true; }
 
   /// @brief generate a key
   std::string generate() override final {
@@ -261,8 +278,8 @@ class TraditionalKeyGenerator : public KeyGenerator {
 class TraditionalKeyGeneratorSingle final : public TraditionalKeyGenerator {
  public:
   /// @brief create the generator
-  explicit TraditionalKeyGeneratorSingle(bool allowUserKeys)
-      : TraditionalKeyGenerator(allowUserKeys), _lastValue(0) {
+  explicit TraditionalKeyGeneratorSingle(bool allowUserKeys, uint64_t lastValue)
+      : TraditionalKeyGenerator(allowUserKeys), _lastValue(lastValue) {
     TRI_ASSERT(!ServerState::instance()->isCoordinator());
   }
 
@@ -297,7 +314,7 @@ class TraditionalKeyGeneratorSingle final : public TraditionalKeyGenerator {
         tick = _lastValue.fetch_add(1, std::memory_order_relaxed) + 1;
         break;
       }
-    } while(!_lastValue.compare_exchange_weak(lastValue, tick, std::memory_order_relaxed));
+    } while (!_lastValue.compare_exchange_weak(lastValue, tick, std::memory_order_relaxed));
 
     return tick;
   }
@@ -347,20 +364,34 @@ class TraditionalKeyGeneratorCluster final : public TraditionalKeyGenerator {
 class PaddedKeyGenerator : public KeyGenerator {
  public:
   /// @brief create the generator
-  explicit PaddedKeyGenerator(bool allowUserKeys)
-      : KeyGenerator(allowUserKeys) {}
+  explicit PaddedKeyGenerator(bool allowUserKeys, uint64_t lastValue)
+      : KeyGenerator(allowUserKeys), _lastValue(lastValue) {}
 
-  bool hasDynamicState() const override { return true; }
-
+  bool hasDynamicState() const override final { return true; }
+  
   /// @brief generate a key
   std::string generate() override {
     uint64_t tick = generateValue();
-
-    if (ADB_UNLIKELY(tick == 0)) {
+    
+    if (ADB_UNLIKELY(tick == 0 || tick == UINT64_MAX)) {
       // unlikely case we have run out of keys
       // returning an empty string will trigger an error on the call site
       return std::string();
     }
+
+    auto lastValue = _lastValue.load(std::memory_order_relaxed);
+    if (ADB_UNLIKELY(lastValue >= UINT64_MAX - 1ULL)) {
+      // oops, out of keys!
+      return std::string();
+    }
+
+    do {
+      if (tick <= lastValue) {
+        tick = _lastValue.fetch_add(1, std::memory_order_relaxed) + 1;
+        break;
+      }
+    } while (!_lastValue.compare_exchange_weak(lastValue, tick, std::memory_order_relaxed));
+
 
     return KeyGeneratorHelper::encodePadded(tick);
   }
@@ -377,85 +408,51 @@ class PaddedKeyGenerator : public KeyGenerator {
   }
 
   /// @brief track usage of a key
-  void track(char const* p, size_t length) override {
+  void track(char const* p, size_t length) override final {
     // check the numeric key part
     uint64_t value = KeyGeneratorHelper::decodePadded(p, length);
     if (value > 0) {
-      track(value);
+      auto lastValue = _lastValue.load(std::memory_order_relaxed);
+      while (value > lastValue) {
+        // and update our last value
+        if (_lastValue.compare_exchange_weak(lastValue, value, std::memory_order_relaxed)) {
+          break;
+        }
+      }
     }
   }
 
   /// @brief build a VelocyPack representation of the generator in the builder
-  void toVelocyPack(arangodb::velocypack::Builder& builder) const override {
+  void toVelocyPack(arangodb::velocypack::Builder& builder) const override final {
     KeyGenerator::toVelocyPack(builder);
     builder.add("type", VPackValue("padded"));
+    
+    // add our own specific values
+    builder.add(StaticStrings::LastValue, VPackValue(_lastValue.load(std::memory_order_relaxed)));
   }
 
  protected:
   /// @brief generate a key value (internal)
   virtual uint64_t generateValue() = 0;
-
-  /// @brief track a value (internal)
-  virtual void track(uint64_t value) = 0;
+ 
+ private:
+  std::atomic<uint64_t> _lastValue;
 };
 
 /// @brief padded key generator for a single server
 class PaddedKeyGeneratorSingle final : public PaddedKeyGenerator {
  public:
   /// @brief create the generator
-  explicit PaddedKeyGeneratorSingle(bool allowUserKeys)
-      : PaddedKeyGenerator(allowUserKeys), _lastValue(0) {
+  explicit PaddedKeyGeneratorSingle(bool allowUserKeys, uint64_t lastValue)
+      : PaddedKeyGenerator(allowUserKeys, lastValue) {
     TRI_ASSERT(!ServerState::instance()->isCoordinator());
-  }
-
-  /// @brief build a VelocyPack representation of the generator in the builder
-  void toVelocyPack(arangodb::velocypack::Builder& builder) const override {
-    PaddedKeyGenerator::toVelocyPack(builder);
-
-    // add our own specific values
-    builder.add(StaticStrings::LastValue, VPackValue(_lastValue.load(std::memory_order_relaxed)));
   }
 
  private:
   /// @brief generate a key
   uint64_t generateValue() override {
-    uint64_t tick = TRI_NewTickServer();
-
-    if (ADB_UNLIKELY(tick == UINT64_MAX)) {
-      // oops, out of keys!
-      return 0;
-    }
-
-    auto lastValue = _lastValue.load(std::memory_order_relaxed);
-    if (ADB_UNLIKELY(lastValue >= UINT64_MAX - 1ULL)) {
-      // oops, out of keys!
-      return 0;
-    }
-
-    do {
-      if (tick <= lastValue) {
-        tick = _lastValue.fetch_add(1, std::memory_order_relaxed) + 1;
-        break;
-      }
-    } while (!_lastValue.compare_exchange_weak(lastValue, tick, std::memory_order_relaxed));
-
-
-    return tick;
+    return TRI_NewTickServer();
   }
-
-  /// @brief generate a key value (internal)
-  void track(uint64_t value) override {
-    auto lastValue = _lastValue.load(std::memory_order_relaxed);
-    while (value > lastValue) {
-      // and update our last value
-      if (_lastValue.compare_exchange_weak(lastValue, value, std::memory_order_relaxed)) {
-        break;
-      }
-    }
-  }
-
- private:
-  std::atomic<uint64_t> _lastValue;
 };
 
 /// @brief padded key generator for a coordinator
@@ -468,17 +465,14 @@ class PaddedKeyGeneratorSingle final : public PaddedKeyGenerator {
 class PaddedKeyGeneratorCluster final : public PaddedKeyGenerator {
  public:
   /// @brief create the generator
-  explicit PaddedKeyGeneratorCluster(ClusterInfo& ci, bool allowUserKeys)
-      : PaddedKeyGenerator(allowUserKeys), _ci(ci) {
+  explicit PaddedKeyGeneratorCluster(ClusterInfo& ci, bool allowUserKeys, uint64_t lastValue)
+      : PaddedKeyGenerator(allowUserKeys, lastValue), _ci(ci) {
     TRI_ASSERT(ServerState::instance()->isCoordinator());
   }
 
  private:
   /// @brief generate a key value (internal)
   uint64_t generateValue() override { return _ci.uniqid(); }
-
-  /// @brief generate a key value (internal)
-  void track(uint64_t /* value */) override {}
 
  private:
   ClusterInfo& _ci;
@@ -488,8 +482,8 @@ class PaddedKeyGeneratorCluster final : public PaddedKeyGenerator {
 class AutoIncrementKeyGenerator final : public KeyGenerator {
  public:
   /// @brief create the generator
-  AutoIncrementKeyGenerator(bool allowUserKeys, uint64_t offset, uint64_t increment)
-      : KeyGenerator(allowUserKeys), _lastValue(0), _offset(offset), _increment(increment) {}
+  AutoIncrementKeyGenerator(bool allowUserKeys, uint64_t lastValue, uint64_t offset, uint64_t increment)
+      : KeyGenerator(allowUserKeys), _lastValue(lastValue), _offset(offset), _increment(increment) {}
 
   bool hasDynamicState() const override { return true; }
 
@@ -513,7 +507,7 @@ class AutoIncrementKeyGenerator final : public KeyGenerator {
 
       TRI_ASSERT(keyValue > lastValue);
       // update our last value
-    } while(!_lastValue.compare_exchange_weak(lastValue, keyValue, std::memory_order_relaxed));
+    } while (!_lastValue.compare_exchange_weak(lastValue, keyValue, std::memory_order_relaxed));
 
     return arangodb::basics::StringUtils::itoa(keyValue);
   }
@@ -568,8 +562,8 @@ class AutoIncrementKeyGenerator final : public KeyGenerator {
 
  private:
   std::atomic<uint64_t> _lastValue;  // last value assigned
-  const uint64_t _offset;  // start value
-  const uint64_t _increment;  // increment value
+  uint64_t const _offset;  // start value
+  uint64_t const _increment;  // increment value
 };
 
 /// @brief uuid key generator
@@ -644,7 +638,7 @@ std::unordered_map<GeneratorMapType, std::function<KeyGenerator*(application_fea
          auto& ci = server.getFeature<ClusterFeature>().clusterInfo();
          return new TraditionalKeyGeneratorCluster(ci, allowUserKeys);
        }
-       return new TraditionalKeyGeneratorSingle(allowUserKeys);
+       return new TraditionalKeyGeneratorSingle(allowUserKeys, ::readLastValue(options));
      }},
     {static_cast<GeneratorMapType>(GeneratorType::AUTOINCREMENT),
      [](application_features::ApplicationServer&, bool allowUserKeys,
@@ -654,12 +648,11 @@ std::unordered_map<GeneratorMapType, std::function<KeyGenerator*(application_fea
                                         "the specified key generator is not "
                                         "supported for sharded collections");
        }
+
        uint64_t offset = 0;
        uint64_t increment = 1;
-
-       VPackSlice const incrementSlice = options.get("increment");
-
-       if (incrementSlice.isNumber()) {
+       
+       if (VPackSlice incrementSlice = options.get("increment"); incrementSlice.isNumber()) {
          double v = incrementSlice.getNumericValue<double>();
          if (v <= 0.0) {
            // negative or 0 increment is not allowed
@@ -678,9 +671,7 @@ std::unordered_map<GeneratorMapType, std::function<KeyGenerator*(application_fea
          }
        }
 
-       VPackSlice const offsetSlice = options.get("offset");
-
-       if (offsetSlice.isNumber()) {
+       if (VPackSlice offsetSlice = options.get("offset"); offsetSlice.isNumber()) {
          double v = offsetSlice.getNumericValue<double>();
          if (v < 0.0) {
            // negative or 0 offset is not allowed
@@ -697,7 +688,7 @@ std::unordered_map<GeneratorMapType, std::function<KeyGenerator*(application_fea
          }
        }
 
-       return new AutoIncrementKeyGenerator(allowUserKeys, offset, increment);
+       return new AutoIncrementKeyGenerator(allowUserKeys, ::readLastValue(options), offset, increment);
      }},
     {static_cast<GeneratorMapType>(GeneratorType::UUID),
      [](application_features::ApplicationServer&, bool allowUserKeys, VPackSlice) -> KeyGenerator* {
@@ -708,9 +699,9 @@ std::unordered_map<GeneratorMapType, std::function<KeyGenerator*(application_fea
         VPackSlice options) -> KeyGenerator* {
        if (ServerState::instance()->isCoordinator()) {
          auto& ci = server.getFeature<ClusterFeature>().clusterInfo();
-         return new PaddedKeyGeneratorCluster(ci, allowUserKeys);
+         return new PaddedKeyGeneratorCluster(ci, allowUserKeys, ::readLastValue(options));
        }
-       return new PaddedKeyGeneratorSingle(allowUserKeys);
+       return new PaddedKeyGeneratorSingle(allowUserKeys, ::readLastValue(options));
      }}};
 
 }  // namespace

--- a/tests/js/client/shell/shell-dump-integration.js
+++ b/tests/js/client/shell/shell-dump-integration.js
@@ -32,6 +32,7 @@ let arangodb = require('@arangodb');
 let fs = require('fs');
 let pu = require('@arangodb/testutils/process-utils');
 let db = arangodb.db;
+let isCluster = require("internal").isCluster();
 
 function dumpIntegrationSuite () {
   'use strict';
@@ -72,13 +73,18 @@ function dumpIntegrationSuite () {
     assertEqual(expected, data);
   };
 
-  let checkStructureFile = function(tree, path, readable, cn) {
+  let structureFile = function(path, cn) {
     const prefix = cn + "_" + require("@arangodb/crypto").md5(cn);
     let structure = prefix + ".structure.json";
     if (!fs.isFile(fs.join(path, structure))) {
       // seems necessary in cluster
       structure = cn + ".structure.json";
     }
+    return structure;
+  };
+
+  let checkStructureFile = function(tree, path, readable, cn) {
+    let structure = structureFile(path, cn);
     assertTrue(fs.isFile(fs.join(path, structure)), structure);
     assertNotEqual(-1, tree.indexOf(structure));
 
@@ -159,11 +165,84 @@ function dumpIntegrationSuite () {
       db._drop(cn + "Other");
       c = db._create(cn + "Other", { numberOfShards: 3 });
       c.insert(docs);
+      
+      db._drop(cn + "Padded");
+      c = db._create(cn + "Padded", { keyOptions: { type: "padded" }, numberOfShards: 3 });
+      docs = [];
+      for (let i = 0; i < 1000; ++i) {
+        docs.push({});
+      }
+      c.insert(docs);
+      
+      db._drop(cn + "AutoIncrement");
+      if (!isCluster) {
+        c = db._create(cn + "AutoIncrement", { keyOptions: { type: "autoincrement" }, numberOfShards: 3 });
+        docs = [];
+        for (let i = 0; i < 1000; ++i) {
+          docs.push({});
+        }
+        c.insert(docs);
+      }
     },
 
     tearDownAll: function () {
       db._drop(cn);
       db._drop(cn + "Other");
+      db._drop(cn + "Padded");
+      db._drop(cn + "AutoIncrement");
+    },
+    
+    testDumpAutoIncrementKeyGenerator: function () {
+      if (isCluster) {
+        // autoincrement key generator is not supported in cluster
+        return;
+      }
+
+      let keyfile = fs.getTempFile();
+      let path = fs.getTempFile();
+      try {
+        let args = ['--collection', cn + 'AutoIncrement', '--dump-data', 'false'];
+        let tree = runDump(path, args, 0); 
+        checkStructureFile(tree, path, true, cn + 'AutoIncrement');
+        let structure = structureFile(path, cn + 'AutoIncrement');
+        let data = JSON.parse(fs.readFileSync(fs.join(path, structure)).toString());
+        assertEqual("autoincrement", data.parameters.keyOptions.type);
+        let c = db._collection(cn + 'AutoIncrement');
+        assertEqual(1000, c.count());
+        let p = c.properties();
+        let lastValue = p.keyOptions.lastValue;
+        assertTrue(lastValue > 0, lastValue);
+        assertEqual(lastValue, data.parameters.keyOptions.lastValue);
+
+      } finally {
+        try {
+          fs.removeDirectory(path);
+        } catch (err) {}
+      }
+    },
+    
+    testDumpPaddedKeyGenerator: function () {
+      let keyfile = fs.getTempFile();
+      let path = fs.getTempFile();
+      try {
+        let args = ['--collection', cn + 'Padded', '--dump-data', 'false'];
+        let tree = runDump(path, args, 0); 
+        checkStructureFile(tree, path, true, cn + 'Padded');
+        let structure = structureFile(path, cn + 'Padded');
+        let data = JSON.parse(fs.readFileSync(fs.join(path, structure)).toString());
+        assertEqual("padded", data.parameters.keyOptions.type);
+        let c = db._collection(cn + 'Padded');
+        assertEqual(1000, c.count());
+        let p = c.properties();
+        let lastValue = p.keyOptions.lastValue;
+        assertTrue(lastValue > 0, lastValue);
+        assertEqual(lastValue, data.parameters.keyOptions.lastValue);
+
+      } finally {
+        try {
+          fs.removeDirectory(path);
+        } catch (err) {}
+      }
     },
     
     testDumpCompressedEncryptedNoEnvelope: function () {


### PR DESCRIPTION
### Scope & Purpose

Make `padded` and `autoincrement` key generators export their `lastValue` values, so that they are available in dumps and can be restored elsewhere from a dump.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.6, 3.7

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_client)

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13692/