### PR TITLE
Improved logging for error 1489

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Improved logging for error 1489 ("a shard leader refuses to perform a 
+  replication operation"). The log message will now provide the database and
+  shard name plus the differing information about the shard leader.
+
 * Fix decoding of values in `padded` key generator when restoring from a dump.
 
 * Fixed error reporting for hotbackup restore from dbservers back to


### PR DESCRIPTION
### Scope & Purpose

Improved logging for error 1489 ("a shard leader refuses to perform a replication operation"). The log message will now provide the database and shard name plus the differing information about the shard leader.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13696/