### PR TITLE
small code cleanup PR

### DIFF
--- a/arangod/ClusterEngine/ClusterEngine.cpp
+++ b/arangod/ClusterEngine/ClusterEngine.cpp
@@ -54,8 +54,10 @@ using namespace arangodb::application_features;
 std::string const ClusterEngine::EngineName("Cluster");
 std::string const ClusterEngine::FeatureName("ClusterEngine");
 
+#ifdef ARANGODB_USE_GOOGLE_TESTS
 // fall back to the using the mock storage engine
 bool ClusterEngine::Mocking = false;
+#endif
 
 // create the storage engine
 ClusterEngine::ClusterEngine(application_features::ApplicationServer& server)
@@ -77,8 +79,12 @@ bool ClusterEngine::isRocksDB() const {
 }
 
 bool ClusterEngine::isMock() const {
+#ifdef ARANGODB_USE_GOOGLE_TESTS
   return ClusterEngine::Mocking ||
          (_actualEngine && _actualEngine->name() == "Mock");
+#else
+  return false;
+#endif
 }
 
 HealthData ClusterEngine::healthCheck() {
@@ -86,9 +92,11 @@ HealthData ClusterEngine::healthCheck() {
 }
 
 ClusterEngineType ClusterEngine::engineType() const {
+#ifdef ARANGODB_USE_GOOGLE_TESTS
   if (isMock()) {
     return ClusterEngineType::MockEngine;
   }
+#endif
   TRI_ASSERT(_actualEngine != nullptr);
 
   TRI_ASSERT(isRocksDB());
@@ -269,7 +277,11 @@ Result ClusterEngine::compactAll(bool changeLevel, bool compactBottomMostLevel) 
 void ClusterEngine::addOptimizerRules(aql::OptimizerRulesFeature& feature) {
   if (engineType() == ClusterEngineType::RocksDBEngine) {
     RocksDBOptimizerRules::registerResources(feature);
-  } else if (engineType() != ClusterEngineType::MockEngine) {
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+  } else if (engineType() == ClusterEngineType::MockEngine) {
+    // do nothing
+#endif
+  } else {
     // invalid engine type...
     TRI_ASSERT(false);
   }

--- a/arangod/ClusterEngine/ClusterEngine.h
+++ b/arangod/ClusterEngine/ClusterEngine.h
@@ -217,7 +217,11 @@ class ClusterEngine final : public StorageEngine {
   static std::string const FeatureName;
 
   // mock mode
+#ifdef ARANGODB_USE_GOOGLE_TESTS
   static bool Mocking;
+#else
+  static constexpr bool Mocking = false;
+#endif
 
  private:
   /// path to arangodb data dir

--- a/arangod/ClusterEngine/ClusterIndex.cpp
+++ b/arangod/ClusterEngine/ClusterIndex.cpp
@@ -116,8 +116,10 @@ void ClusterIndex::toVelocyPack(VPackBuilder& builder,
 bool ClusterIndex::isPersistent() const {
   if (_engineType == ClusterEngineType::RocksDBEngine) {
     return true;
+#ifdef ARANGODB_USE_GOOGLE_TESTS
   } else if (_engineType == ClusterEngineType::MockEngine) {
     return false;
+#endif
   }
   TRI_ASSERT(false);
   THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
@@ -132,8 +134,10 @@ bool ClusterIndex::hasSelectivityEstimate() const {
            _indexType == Index::TRI_IDX_TYPE_SKIPLIST_INDEX ||
            _indexType == Index::TRI_IDX_TYPE_TTL_INDEX ||
            _indexType == Index::TRI_IDX_TYPE_PERSISTENT_INDEX;
+#ifdef ARANGODB_USE_GOOGLE_TESTS
   } else if (_engineType == ClusterEngineType::MockEngine) {
     return false;
+#endif
   }
   TRI_ASSERT(false);
   THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
@@ -165,8 +169,10 @@ bool ClusterIndex::isSorted() const {
            _indexType == Index::TRI_IDX_TYPE_PERSISTENT_INDEX ||
            _indexType == Index::TRI_IDX_TYPE_TTL_INDEX ||
            _indexType == Index::TRI_IDX_TYPE_FULLTEXT_INDEX;
+#ifdef ARANGODB_USE_GOOGLE_TESTS
   } else if (_engineType == ClusterEngineType::MockEngine) {
     return false;
+#endif
   }
   TRI_ASSERT(false);
   THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
@@ -348,9 +354,11 @@ aql::AstNode* ClusterIndex::specializeCondition(aql::AstNode* node,
       break;
   }
 
+#ifdef ARANGODB_USE_GOOGLE_TESTS
   if (_engineType == ClusterEngineType::MockEngine) {
     return node;
   }
+#endif
   TRI_ASSERT(false);
   return node;
 }

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -467,7 +467,7 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice const& info,
           RocksDBLogValue::IndexCreate(_logicalCollection.vocbase().id(),
                                        _logicalCollection.id(), indexInfo.slice()));
     }
-  } while(false);
+  } while (false);
 
   // cleanup routine
   if (res.fail()) { // We could not create the index. Better abort

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -280,9 +280,9 @@ class RocksDBEngine final : public StorageEngine {
 
   Result writeDatabaseMarker(TRI_voc_tick_t id, velocypack::Slice const& slice,
                              RocksDBLogValue&& logValue);
-  int writeCreateCollectionMarker(TRI_voc_tick_t databaseId, DataSourceId id,
-                                  velocypack::Slice const& slice,
-                                  RocksDBLogValue&& logValue);
+  Result writeCreateCollectionMarker(TRI_voc_tick_t databaseId, DataSourceId id,
+                                     velocypack::Slice const& slice,
+                                     RocksDBLogValue&& logValue);
 
   void addCollectionMapping(uint64_t, TRI_voc_tick_t, DataSourceId);
   std::vector<std::pair<TRI_voc_tick_t, DataSourceId>> collectionMappings() const;


### PR DESCRIPTION
### Scope & Purpose

Small code cleanup PR

- only check for Mock storage engine in arangod/ClusterEngine in case we are building with google tests (otherwise there will be no Mock storage engine).
- fixed an unused variable warning for an unchcked return value for a call to RocksDBEngine::writeCreateCollectionMarker() in IResearchFeature when upgrading links.
- make RocksDBEngines's writeCreateCollectionMarker() return a Result instead of an int.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13697/