### PR TITLE
Added metric for current scheduler dequeue time

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,14 @@
 devel
 -----
 
-* Added metric `arangodb_scheduler_current_current_queue_time` to estimate
-  the amount of time it takes a low priority queue item to bubble up to the 
-  queue's head (in ms).
+* Added metric `arangodb_scheduler_low_prio_queue_last_dequeue_time` that provides 
+  the time (in millseconds) it took for the most recent low priority scheduler queue 
+  item to bubble up to the queue's head. This metric can be used to estimate the
+  queuing time for incoming requests. 
+  The metric will be updated probabilistically when a request is pulled from the 
+  scheduler queue, and may remain at its previous value for a while if only few
+  requests are coming in or remain permanently at its previous value if no further 
+  requests are incoming at all.
 
 * Added metrics for document read and write operations:
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Added metric `arangodb_scheduler_current_current_queue_time` to estimate
+  the amount of time it takes a low priority queue item to bubble up to the 
+  queue's head (in ms).
+
 * Fix decoding of values in `padded` key generator when restoring from a dump.
 
 * Fixed error reporting for hotbackup restore from dbservers back to

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -481,26 +481,20 @@ void CommTask::sendErrorResponse(rest::ResponseCode code,
 // a scheduler worker thread eventually.
 bool CommTask::handleRequestSync(std::shared_ptr<RestHandler> handler) {
   DTRACE_PROBE2(arangod, CommTaskHandleRequestSync, this, handler.get());
-  handler->statistics().SET_QUEUE_START(SchedulerFeature::SCHEDULER->queueStatistics()._queued);
 
-  RequestLane lane = handler->getRequestLane();
-  RequestPriority prio = PriorityRequestLane(lane);
+  RequestLane lane = handler->determineRequestLane();
+  handler->trackQueueStart();
 
   ContentType respType = handler->request()->contentTypeResponse();
   uint64_t mid = handler->messageId();
 
-  // queue the operation in the scheduler, and make it eligible for direct execution
-  // only if the current CommTask type allows it (HttpCommTask: yes, CommTask: no)
-  // and there is currently only a single client handled by the IoContext
-  auto cb = [self = shared_from_this(), handler = std::move(handler), prio]() mutable {
-    if (prio == RequestPriority::LOW) {
-      SchedulerFeature::SCHEDULER->trackBeginOngoingLowPriorityTask();
-    }
-    handler->statistics().SET_QUEUE_END();
-    handler->runHandler([self = std::move(self), prio](rest::RestHandler* handler) {
-      if (prio == RequestPriority::LOW) {
-        SchedulerFeature::SCHEDULER->trackEndOngoingLowPriorityTask();
-      }
+  // queue the operation for execution in the scheduler
+  auto cb = [self = shared_from_this(), handler = std::move(handler)]() mutable {
+    handler->trackQueueEnd();
+    handler->trackTaskStart();
+
+    handler->runHandler([self = std::move(self)](rest::RestHandler* handler) {
+      handler->trackTaskEnd();
       try {
         // Pass the response to the io context
         self->sendResponse(handler->stealResponse(), handler->stealStatistics());
@@ -527,8 +521,9 @@ bool CommTask::handleRequestAsync(std::shared_ptr<RestHandler> handler,
   if (_server.server().isStopping()) {
     return false;
   }
-
-  auto const lane = handler->getRequestLane();
+ 
+  RequestLane lane = handler->determineRequestLane();
+  handler->trackQueueStart();
 
   if (jobId != nullptr) {
     auto& jobManager = _server.server().getFeature<GeneralServerFeature>().jobManager();
@@ -536,15 +531,24 @@ bool CommTask::handleRequestAsync(std::shared_ptr<RestHandler> handler,
     *jobId = handler->handlerId();
 
     // callback will persist the response with the AsyncJobManager
-    return SchedulerFeature::SCHEDULER->queue(lane, [handler = std::move(handler),
-                                                     manager(&jobManager)] {
-      handler->runHandler(
-          [manager](RestHandler* h) { manager->finishAsyncJob(h); });
+    return SchedulerFeature::SCHEDULER->queue(lane, [handler = std::move(handler), manager(&jobManager)] {
+      handler->trackQueueEnd();
+      handler->trackTaskStart();
+
+      handler->runHandler([manager](RestHandler* h) { 
+        h->trackTaskEnd();
+        manager->finishAsyncJob(h); 
+      });
     });
   } else {
     // here the response will just be ignored
     return SchedulerFeature::SCHEDULER->queue(lane, [handler = std::move(handler)] {
-      handler->runHandler([](RestHandler*) {});
+      handler->trackQueueEnd();
+      handler->trackTaskStart();
+      
+      handler->runHandler([](RestHandler* h) {
+        h->trackTaskEnd();
+      });
     });
   }
 }

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -493,12 +493,10 @@ bool CommTask::handleRequestSync(std::shared_ptr<RestHandler> handler) {
   // only if the current CommTask type allows it (HttpCommTask: yes, CommTask: no)
   // and there is currently only a single client handled by the IoContext
   auto cb = [self = shared_from_this(), handler = std::move(handler), prio]() mutable {
-    auto& stats = handler->statistics();
-    stats.SET_QUEUE_END();
     if (prio == RequestPriority::LOW) {
       SchedulerFeature::SCHEDULER->trackBeginOngoingLowPriorityTask();
-      SchedulerFeature::SCHEDULER->setLastLowPriorityDequeueTime(static_cast<uint64_t>(stats.QUEUE_TIME() * 1000.0));
     }
+    handler->statistics().SET_QUEUE_END();
     handler->runHandler([self = std::move(self), prio](rest::RestHandler* handler) {
       if (prio == RequestPriority::LOW) {
         SchedulerFeature::SCHEDULER->trackEndOngoingLowPriorityTask();

--- a/arangod/GeneralServer/RequestLane.h
+++ b/arangod/GeneralServer/RequestLane.h
@@ -113,6 +113,9 @@ enum class RequestLane {
 
   // Used by futures that have been delayed using Scheduler::delay.
   DELAYED_FUTURE,
+
+  // undefined request lane, used only in the beginning
+  UNDEFINED,
 };
 
 enum class RequestPriority {
@@ -162,6 +165,9 @@ inline RequestPriority PriorityRequestLane(RequestLane lane) {
       return RequestPriority::HIGH;
     case RequestLane::CONTINUATION:
       return RequestPriority::MED;
+    case RequestLane::UNDEFINED: {
+      TRI_ASSERT(false);
+    }
   }
   return RequestPriority::LOW;
 }

--- a/arangod/GeneralServer/RestHandler.h
+++ b/arangod/GeneralServer/RestHandler.h
@@ -66,10 +66,21 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
   RestHandler(application_features::ApplicationServer&, GeneralRequest*, GeneralResponse*);
   virtual ~RestHandler();
 
- public:
   void assignHandlerId();
   uint64_t handlerId() const { return _handlerId; }
   uint64_t messageId() const;
+
+  /// @brief called when the handler is queued for execution in the scheduler
+  void trackQueueStart() noexcept;
+
+  /// @brief called when the handler is dequeued in the scheduler
+  void trackQueueEnd() noexcept;
+  
+  /// @brief called when the handler execution is started
+  void trackTaskStart() noexcept;
+
+  /// @brief called when the handler execution is finalized
+  void trackTaskEnd() noexcept;
 
   GeneralRequest const* request() const { return _request.get(); }
   GeneralResponse* response() const { return _response.get(); }
@@ -106,16 +117,7 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
   // what lane to use for this request
   virtual RequestLane lane() const = 0;
 
-  RequestLane getRequestLane() {
-    bool found;
-    _request->header(StaticStrings::XArangoFrontend, found);
-
-    if (found) {
-      return RequestLane::CLIENT_UI;
-    }
-
-    return lane();
-  }
+  RequestLane determineRequestLane(); 
 
   virtual void prepareExecute(bool isContinue) {}
   virtual RestStatus execute() = 0;
@@ -213,6 +215,7 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
   std::atomic<std::thread::id> _executionMutexOwner;
 
   HandlerState _state;
+  RequestLane _lane;
 
  protected:
   std::atomic<bool> _canceled;

--- a/arangod/RestServer/Metrics.h
+++ b/arangod/RestServer/Metrics.h
@@ -95,11 +95,14 @@ template<typename T> class Gauge : public Metric {
     : Metric(name, help, labels) {
     _g.store(val);
   }
+  
   Gauge(Gauge const&) = delete;
   ~Gauge() = default;
-  std::ostream& print (std::ostream&) const;
-  Gauge<T>& operator+=(T const& t) {
-    if constexpr(std::is_integral_v<T>) {
+  
+  std::ostream& print(std::ostream&) const;
+  
+  Gauge<T>& operator+=(T const& t) noexcept {
+    if constexpr (std::is_integral_v<T>) {
       _g.fetch_add(t);
     } else {
       T tmp(_g.load(std::memory_order_relaxed));
@@ -109,8 +112,9 @@ template<typename T> class Gauge : public Metric {
     }
     return *this;
   }
-  Gauge<T>& operator-=(T const& t) {
-    if constexpr(std::is_integral_v<T>) {
+
+  Gauge<T>& operator-=(T const& t) noexcept {
+    if constexpr (std::is_integral_v<T>) {
       _g.fetch_sub(t);
     } else {
       T tmp(_g.load(std::memory_order_relaxed));
@@ -120,33 +124,36 @@ template<typename T> class Gauge : public Metric {
     }
     return *this;
   }
-  Gauge<T>& operator*=(T const& t) {
-      T tmp(_g.load(std::memory_order_relaxed));
-      do {
-      } while (!_g.compare_exchange_weak(
-                 tmp, tmp * t));
+
+  Gauge<T>& operator*=(T const& t) noexcept {
+    T tmp(_g.load(std::memory_order_relaxed));
+    while (!_g.compare_exchange_weak(tmp, tmp * t)) { /*nothing*/ }
     return *this;
   }
-  Gauge<T>& operator/=(T const& t) {
+
+  Gauge<T>& operator/=(T const& t) noexcept {
     TRI_ASSERT(t != T(0));
-      T tmp(_g.load(std::memory_order_relaxed));
-      do {
-      } while (!_g.compare_exchange_weak(tmp, tmp / t));
+    T tmp(_g.load(std::memory_order_relaxed));
+    while (!_g.compare_exchange_weak(tmp, tmp / t)) { /*nothing*/ }
     return *this;
   }
-  Gauge<T>& operator=(T const& t) {
+
+  Gauge<T>& operator=(T const& t) noexcept {
     _g.store(t);
     return *this;
   }
-  T load() const { return _g.load(); }
-  virtual void toPrometheus(std::string& result) const override {
+
+  T load() const noexcept { return _g.load(); }
+
+  void toPrometheus(std::string& result) const override {
     result += "\n#TYPE " + name() + " gauge\n";
     result += "#HELP " + name() + " " + help() + "\n" + name();
     if (!labels().empty()) {
       result += "{" + labels() + "}";
     }
     result += " " + std::to_string(load()) + "\n";
-  };
+  }
+
  private:
   std::atomic<T> _g;
 };

--- a/arangod/RestServer/MetricsFeature.cpp
+++ b/arangod/RestServer/MetricsFeature.cpp
@@ -186,11 +186,15 @@ metrics_key::metrics_key(std::initializer_list<std::string> const& il) {
 }
 
 metrics_key::metrics_key(std::string const& name) : name(name) {
+  // the metric name should not include any spaces
+  TRI_ASSERT(name.find(' ') == std::string::npos);
   _hash = std::hash<std::string>{}(name);
 }
 
 metrics_key::metrics_key(std::string const& name, std::string const& labels) :
   name(name), labels(labels) {
+  // the metric name should not include any spaces
+  TRI_ASSERT(name.find(' ') == std::string::npos);
   _hash = std::hash<std::string>{}(name + labels);
 }
 

--- a/arangod/Scheduler/Scheduler.h
+++ b/arangod/Scheduler/Scheduler.h
@@ -142,9 +142,6 @@ class Scheduler {
   struct WorkItemBase {
     virtual ~WorkItemBase() = default;
     virtual void invoke() = 0;
-  
-    /// @brief the date/time when the item was queued
-    std::chrono::time_point<std::chrono::steady_clock> queueStart;
   };
 
   template<typename F>

--- a/arangod/Scheduler/Scheduler.h
+++ b/arangod/Scheduler/Scheduler.h
@@ -142,6 +142,9 @@ class Scheduler {
   struct WorkItemBase {
     virtual ~WorkItemBase() = default;
     virtual void invoke() = 0;
+  
+    /// @brief the date/time when the item was queued
+    std::chrono::time_point<std::chrono::steady_clock> queueStart;
   };
 
   template<typename F>
@@ -152,8 +155,7 @@ class Scheduler {
 
   // Enqueues a task - this is implemented on the specific scheduler
   // May throw.
-  virtual bool queueItem(RequestLane lane, std::unique_ptr<WorkItemBase> item) ADB_WARN_UNUSED_RESULT = 0;
-
+  [[nodiscard]] virtual bool queueItem(RequestLane lane, std::unique_ptr<WorkItemBase> item) = 0;
 
  public:
     // delay Future returns a future that will be fulfilled after the given duration

--- a/arangod/Scheduler/SupervisedScheduler.h
+++ b/arangod/Scheduler/SupervisedScheduler.h
@@ -58,7 +58,22 @@ class SupervisedScheduler final : public Scheduler {
   void trackBeginOngoingLowPriorityTask();
   void trackEndOngoingLowPriorityTask();
 
+  /// @brief set the time it took for the last low prio item to be dequeued
+  /// (time between queuing and dequeing) [ms]
+  void setLastLowPriorityDequeueTime(uint64_t time) noexcept;
+
   constexpr static uint64_t const NumberOfQueues = 4;
+
+  constexpr static uint64_t const HighPriorityQueue = 1;
+  constexpr static uint64_t const MediumPriorityQueue = 2;
+  constexpr static uint64_t const LowPriorityQueue = 3;
+
+  static_assert(HighPriorityQueue < NumberOfQueues);
+  static_assert(MediumPriorityQueue < NumberOfQueues);
+  static_assert(LowPriorityQueue < NumberOfQueues);
+  
+  static_assert(HighPriorityQueue < MediumPriorityQueue);
+  static_assert(MediumPriorityQueue < LowPriorityQueue);
 
   /// @brief approximate fill grade of the scheduler's queue (in %)
   double approximateQueueFillGrade() const override;
@@ -138,7 +153,7 @@ class SupervisedScheduler final : public Scheduler {
   void runWorker();
   void runSupervisor();
 
-  bool queueItem(RequestLane lane, std::unique_ptr<WorkItemBase> item) override ADB_WARN_UNUSED_RESULT;
+  [[nodiscard]] bool queueItem(RequestLane lane, std::unique_ptr<WorkItemBase> item) override;
 
  private:
   NetworkFeature& _nf;
@@ -190,11 +205,16 @@ class SupervisedScheduler final : public Scheduler {
   Gauge<uint64_t>& _metricsAwakeThreads;
   Gauge<uint64_t>& _metricsNumWorkingThreads;
   Gauge<uint64_t>& _metricsNumWorkerThreads;
-
+  
   Counter& _metricsThreadsStarted;
   Counter& _metricsThreadsStopped;
   Counter& _metricsQueueFull;
   Gauge<uint64_t>& _ongoingLowPriorityGauge;
+  
+  /// @brief amount of time it took for the last low prio item to be dequeued
+  /// (time between queuing and dequeing) [ms]
+  Gauge<uint64_t>& _metricsLastLowPriorityDequeueTime;
+
   std::array<std::reference_wrapper<Gauge<uint64_t>>, NumberOfQueues> _metricsQueueLengths;
 };
 

--- a/arangod/Scheduler/SupervisedScheduler.h
+++ b/arangod/Scheduler/SupervisedScheduler.h
@@ -212,7 +212,8 @@ class SupervisedScheduler final : public Scheduler {
   Gauge<uint64_t>& _ongoingLowPriorityGauge;
   
   /// @brief amount of time it took for the last low prio item to be dequeued
-  /// (time between queuing and dequeing) [ms]
+  /// (time between queuing and dequeing) [ms].
+  /// this metric is only updated probabilistically
   Gauge<uint64_t>& _metricsLastLowPriorityDequeueTime;
 
   std::array<std::reference_wrapper<Gauge<uint64_t>>, NumberOfQueues> _metricsQueueLengths;


### PR DESCRIPTION
### Scope & Purpose

Added gauge `arangodb_scheduler_current_current_queue_time` to estimate the amount of time it takes a low priority queue item to bubble up to the queue's head (in ms).

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13698/