### PR TITLE
Bug in behaviour of ignoreRevs=false

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,11 @@ v3.6.12 (XXXX-XX-XX)
   values, so that they are available in dumps and can be restored elsewhere from
   a dump.
 
+* Fixed some wrong behaviour in single document updates. If the option
+  ignoreRevs=false was given and the precondition _rev was given in the body
+  but the _key was given in the URL path, then the rev was wrongly taken
+  as 0, rather than using the one from the document body.
+
 * Fixed error reporting for hotbackup restore from dbservers back to
   coordinators. This could for example swallow out of disk errors during
   hotbackup restore.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,14 +1,14 @@
 v3.6.12 (XXXX-XX-XX)
 --------------------
 
+* Fixed some wrong behaviour in single document updates. If the option
+  ignoreRevs=false was given and the precondition _rev was given in the body but
+  the _key was given in the URL path, then the rev was wrongly taken as 0,
+  rather than using the one from the document body.
+
 * Make `padded` and `autoincrement` key generators export their `lastValue`
   values, so that they are available in dumps and can be restored elsewhere from
   a dump.
-
-* Fixed some wrong behaviour in single document updates. If the option
-  ignoreRevs=false was given and the precondition _rev was given in the body
-  but the _key was given in the URL path, then the rev was wrongly taken
-  as 0, rather than using the one from the document body.
 
 * Fixed error reporting for hotbackup restore from dbservers back to
   coordinators. This could for example swallow out of disk errors during

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -456,7 +456,7 @@ RestStatus RestDocumentHandler::modifyDocument(bool isPatch) {
         if (headerRev != 0) {
           builder.add(StaticStrings::RevString, VPackValue(TRI_RidToString(headerRev)));
         } else if (!opOptions.ignoreRevs && revInBody != 0) {
-          builder.add(StaticStrings::RevString, VPackValue(TRI_RidToString(headerRev)));
+          builder.add(StaticStrings::RevString, VPackValue(TRI_RidToString(revInBody)));
         }
       }
 

--- a/tests/rb/HttpInterface/api-document-update-spec.rb
+++ b/tests/rb/HttpInterface/api-document-update-spec.rb
@@ -118,6 +118,177 @@ describe ArangoDB do
 
         ArangoDB.size_collection(@cid).should eq(0)
       end
+      
+      it "create a document and update it with invalid JSON" do
+        cmd = "/_api/document?collection=#{@cid}"
+        body = "{ \"Hallo\" : \"World\" }"
+        doc = ArangoDB.post(cmd, :body => body)
+
+        doc.code.should eq(201)
+        did = doc.parsed_response['_id']
+
+        # update document
+        cmd = "/_api/document/#{did}"
+        body = "{ \"World\" : \"Hallo\xff\" }"
+        doc = ArangoDB.log_put("#{prefix}", cmd, :body => body)
+
+        doc.code.should eq(400)
+        doc.parsed_response['error'].should eq(true)
+        doc.parsed_response['errorNum'].should eq(600)
+        doc.parsed_response['code'].should eq(400)
+      end
+
+      it "create a document and replace it, using ignoreRevs=false" do
+        cmd = "/_api/document?collection=#{@cid}"
+        body = "{ \"Hallo\" : \"World\" }"
+        doc = ArangoDB.post(cmd, :body => body)
+
+        doc.code.should eq(201)
+
+        location = doc.headers['location']
+        location.should be_kind_of(String)
+
+        did = doc.parsed_response['_id']
+        rev = doc.parsed_response['_rev']
+
+        # update document, different revision
+        cmd = "/_api/document/#{did}?ignoreRevs=false"
+        body = "{ \"_rev\": \"658993\", \"World\" : \"Hallo\" }"
+        doc = ArangoDB.log_put("#{prefix}-ignore-revs-false", cmd, :body => body)
+
+        doc.code.should eq(409)
+        doc.parsed_response['error'].should eq(true)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+
+        did2 = doc.parsed_response['_id']
+        did2.should be_kind_of(String)
+        did2.should eq(did)
+        
+        rev2 = doc.parsed_response['_rev']
+        rev2.should be_kind_of(String)
+        rev2.should eq(rev)
+
+        # update document, same revision
+        cmd = "/_api/document/#{did}?ignoreRevs=false"
+        body = "{ \"_rev\": \"#{rev}\", \"World\" : \"Hallo\" }"
+        doc = ArangoDB.log_put("#{prefix}-ignore-revs-false", cmd, :body => body)
+
+        doc.code.should eq(201)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+
+        did2 = doc.parsed_response['_id']
+        did2.should be_kind_of(String)
+        did2.should eq(did)
+
+        rev2 = doc.parsed_response['_rev']
+        rev2.should be_kind_of(String)
+        rev2.should_not eq(rev)
+
+        cmd = "/_api/collection/#{@cid}/properties"
+        body = "{ \"waitForSync\" : false }"
+        doc = ArangoDB.put(cmd, :body => body)
+
+        # wait for dbservers to pick up the change
+        sleep 2
+
+        # update document 
+        cmd = "/_api/document/#{did}?ignoreRevs=false"
+        body = "{ \"_rev\": \"#{rev2}\", \"World\" : \"Hallo2\" }"
+        doc3 = ArangoDB.log_put("#{prefix}-ignore-revs-false", cmd, :body => body)
+
+        doc3.code.should eq(202)
+        doc3.headers['content-type'].should eq("application/json; charset=utf-8")
+        rev3 = doc3.parsed_response['_rev']
+
+        # update document 
+        cmd = "/_api/document/#{did}?ignoreRevs=false&waitForSync=true"
+        body = "{ \"_rev\": \"#{rev3}\", \"World\" : \"Hallo3\" }"
+        doc4 = ArangoDB.log_put("#{prefix}-ignore-revs-false", cmd, :body => body)
+
+        doc4.code.should eq(201)
+        doc4.headers['content-type'].should eq("application/json; charset=utf-8")
+        rev4 = doc4.parsed_response['_rev']
+
+        ArangoDB.delete(location)
+
+        ArangoDB.size_collection(@cid).should eq(0)
+      end
+
+      it "create a document and replace it, using ignoreRevs=false (with key)" do
+        cmd = "/_api/document?collection=#{@cid}"
+        body = "{ \"_key\" : \"hello\", \"Hallo\" : \"World\" }"
+        doc = ArangoDB.post(cmd, :body => body)
+
+        doc.code.should eq(201)
+
+        location = doc.headers['location']
+        location.should be_kind_of(String)
+
+        did = doc.parsed_response['_id']
+        rev = doc.parsed_response['_rev']
+
+        # update document, different revision
+        cmd = "/_api/document/#{did}?ignoreRevs=false"
+        body = "{ \"_key\" : \"hello\", \"_rev\" : \"658993\", \"World\" : \"Hallo\" }"
+        doc = ArangoDB.log_put("#{prefix}-ignore-revs-false", cmd, :body => body)
+
+        doc.code.should eq(409)
+        doc.parsed_response['error'].should eq(true)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+
+        did2 = doc.parsed_response['_id']
+        did2.should be_kind_of(String)
+        did2.should eq(did)
+        
+        rev2 = doc.parsed_response['_rev']
+        rev2.should be_kind_of(String)
+        rev2.should eq(rev)
+
+        # update document, same revision
+        cmd = "/_api/document/#{did}?ignoreRevs=false"
+        body = "{ \"_key\" : \"hello\", \"_rev\": \"#{rev}\", \"World\" : \"Hallo\" }"
+        doc = ArangoDB.log_put("#{prefix}-ignore-revs-false", cmd, :body => body)
+
+        doc.code.should eq(201)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+
+        did2 = doc.parsed_response['_id']
+        did2.should be_kind_of(String)
+        did2.should eq(did)
+
+        rev2 = doc.parsed_response['_rev']
+        rev2.should be_kind_of(String)
+        rev2.should_not eq(rev)
+
+        cmd = "/_api/collection/#{@cid}/properties"
+        body = "{ \"waitForSync\" : false }"
+        doc = ArangoDB.put(cmd, :body => body)
+
+        # wait for dbservers to pick up the change
+        sleep 2
+
+        # update document 
+        cmd = "/_api/document/#{did}?ignoreRevs=false"
+        body = "{ \"_key\" : \"hello\", \"_rev\": \"#{rev2}\", \"World\" : \"Hallo2\" }"
+        doc3 = ArangoDB.log_put("#{prefix}-ignore-revs-false", cmd, :body => body)
+
+        doc3.code.should eq(202)
+        doc3.headers['content-type'].should eq("application/json; charset=utf-8")
+        rev3 = doc3.parsed_response['_rev']
+
+        # update document 
+        cmd = "/_api/document/#{did}?ignoreRevs=false&waitForSync=true"
+        body = "{ \"_key\" : \"hello\", \"_rev\": \"#{rev3}\", \"World\" : \"Hallo3\" }"
+        doc4 = ArangoDB.log_put("#{prefix}-ignore-revs-false", cmd, :body => body)
+
+        doc4.code.should eq(201)
+        doc4.headers['content-type'].should eq("application/json; charset=utf-8")
+        rev4 = doc4.parsed_response['_rev']
+
+        ArangoDB.delete(location)
+
+        ArangoDB.size_collection(@cid).should eq(0)
+      end
     end
 
 ################################################################################
@@ -181,7 +352,7 @@ describe ArangoDB do
         did = doc.parsed_response['_id']
         rev = doc.parsed_response['_rev']
 
-        # update document, different revision
+        # replace document, different revision
         cmd = "/_api/document/#{did}"
         hdr = { "if-match" => "\"658993\"" }
         body = "{ \"World\" : \"Hallo\" }"
@@ -557,7 +728,158 @@ describe ArangoDB do
         doc.parsed_response['code'].should eq(400)
         doc.headers['content-type'].should eq("application/json; charset=utf-8")
       end
-    end
 
+      it "create a document and update it, using ignoreRevs=false" do
+        cmd = "/_api/document?collection=#{@cid}"
+        body = "{ \"Hallo\" : \"World\" }"
+        doc = ArangoDB.post(cmd, :body => body)
+
+        doc.code.should eq(201)
+
+        location = doc.headers['location']
+        location.should be_kind_of(String)
+
+        did = doc.parsed_response['_id']
+        rev = doc.parsed_response['_rev']
+
+        # update document, different revision
+        cmd = "/_api/document/#{did}?ignoreRevs=false"
+        body = "{ \"_rev\": \"658993\", \"World\" : \"Hallo\" }"
+        doc = ArangoDB.log_patch("#{prefix}-ignore-revs-false", cmd, :body => body)
+
+        doc.code.should eq(409)
+        doc.parsed_response['error'].should eq(true)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+
+        did2 = doc.parsed_response['_id']
+        did2.should be_kind_of(String)
+        did2.should eq(did)
+        
+        rev2 = doc.parsed_response['_rev']
+        rev2.should be_kind_of(String)
+        rev2.should eq(rev)
+
+        # update document, same revision
+        cmd = "/_api/document/#{did}?ignoreRevs=false"
+        body = "{ \"_rev\": \"#{rev}\", \"World\" : \"Hallo\" }"
+        doc = ArangoDB.log_patch("#{prefix}-ignore-revs-false", cmd, :body => body)
+
+        doc.code.should eq(201)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+
+        did2 = doc.parsed_response['_id']
+        did2.should be_kind_of(String)
+        did2.should eq(did)
+
+        rev2 = doc.parsed_response['_rev']
+        rev2.should be_kind_of(String)
+        rev2.should_not eq(rev)
+
+        cmd = "/_api/collection/#{@cid}/properties"
+        body = "{ \"waitForSync\" : false }"
+        doc = ArangoDB.put(cmd, :body => body)
+
+        # wait for dbservers to pick up the change
+        sleep 2
+
+        # update document 
+        cmd = "/_api/document/#{did}?ignoreRevs=false"
+        body = "{ \"_rev\": \"#{rev2}\", \"World\" : \"Hallo2\" }"
+        doc3 = ArangoDB.log_put("#{prefix}-ignore-revs-false", cmd, :body => body)
+
+        doc3.code.should eq(202)
+        doc3.headers['content-type'].should eq("application/json; charset=utf-8")
+        rev3 = doc3.parsed_response['_rev']
+
+        # update document 
+        cmd = "/_api/document/#{did}?ignoreRevs=false&waitForSync=true"
+        body = "{ \"_rev\": \"#{rev3}\", \"World\" : \"Hallo3\" }"
+        doc4 = ArangoDB.log_patch("#{prefix}-ignore-revs-false", cmd, :body => body)
+
+        doc4.code.should eq(201)
+        doc4.headers['content-type'].should eq("application/json; charset=utf-8")
+        rev4 = doc4.parsed_response['_rev']
+
+        ArangoDB.delete(location)
+
+        ArangoDB.size_collection(@cid).should eq(0)
+      end
+
+      it "create a document and update it, using ignoreRevs=false (with key)" do
+        cmd = "/_api/document?collection=#{@cid}"
+        body = "{ \"_key\" : \"hello\", \"Hallo\" : \"World\" }"
+        doc = ArangoDB.post(cmd, :body => body)
+
+        doc.code.should eq(201)
+
+        location = doc.headers['location']
+        location.should be_kind_of(String)
+
+        did = doc.parsed_response['_id']
+        rev = doc.parsed_response['_rev']
+
+        # update document, different revision
+        cmd = "/_api/document/#{did}?ignoreRevs=false"
+        body = "{ \"_key\" : \"hello\", \"_rev\" : \"658993\", \"World\" : \"Hallo\" }"
+        doc = ArangoDB.log_patch("#{prefix}-ignore-revs-false", cmd, :body => body)
+
+        doc.code.should eq(409)
+        doc.parsed_response['error'].should eq(true)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+
+        did2 = doc.parsed_response['_id']
+        did2.should be_kind_of(String)
+        did2.should eq(did)
+        
+        rev2 = doc.parsed_response['_rev']
+        rev2.should be_kind_of(String)
+        rev2.should eq(rev)
+
+        # update document, same revision
+        cmd = "/_api/document/#{did}?ignoreRevs=false"
+        body = "{ \"_key\" : \"hello\", \"_rev\" : \"#{rev}\", \"World\" : \"Hallo\" }"
+        doc = ArangoDB.log_patch("#{prefix}-ignore-revs-false", cmd, :body => body)
+
+        doc.code.should eq(201)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+
+        did2 = doc.parsed_response['_id']
+        did2.should be_kind_of(String)
+        did2.should eq(did)
+
+        rev2 = doc.parsed_response['_rev']
+        rev2.should be_kind_of(String)
+        rev2.should_not eq(rev)
+
+        cmd = "/_api/collection/#{@cid}/properties"
+        body = "{ \"waitForSync\" : false }"
+        doc = ArangoDB.put(cmd, :body => body)
+
+        # wait for dbservers to pick up the change
+        sleep 2
+
+        # update document 
+        cmd = "/_api/document/#{did}?ignoreRevs=false"
+        body = "{ \"_key\" : \"hello\", \"_rev\": \"#{rev2}\", \"World\" : \"Hallo2\" }"
+        doc3 = ArangoDB.log_put("#{prefix}-ignore-revs-false", cmd, :body => body)
+
+        doc3.code.should eq(202)
+        doc3.headers['content-type'].should eq("application/json; charset=utf-8")
+        rev3 = doc3.parsed_response['_rev']
+
+        # update document 
+        cmd = "/_api/document/#{did}?ignoreRevs=false&waitForSync=true"
+        body = "{ \"_key\" : \"hello\", \"_rev\": \"#{rev3}\", \"World\" : \"Hallo3\" }"
+        doc4 = ArangoDB.log_patch("#{prefix}-ignore-revs-false", cmd, :body => body)
+
+        doc4.code.should eq(201)
+        doc4.headers['content-type'].should eq("application/json; charset=utf-8")
+        rev4 = doc4.parsed_response['_rev']
+
+        ArangoDB.delete(location)
+
+        ArangoDB.size_collection(@cid).should eq(0)
+      end
+    end
   end
 end

--- a/tests/rb/HttpInterface/api-document-update-spec.rb
+++ b/tests/rb/HttpInterface/api-document-update-spec.rb
@@ -119,25 +119,6 @@ describe ArangoDB do
         ArangoDB.size_collection(@cid).should eq(0)
       end
       
-      it "create a document and update it with invalid JSON" do
-        cmd = "/_api/document?collection=#{@cid}"
-        body = "{ \"Hallo\" : \"World\" }"
-        doc = ArangoDB.post(cmd, :body => body)
-
-        doc.code.should eq(201)
-        did = doc.parsed_response['_id']
-
-        # update document
-        cmd = "/_api/document/#{did}"
-        body = "{ \"World\" : \"Hallo\xff\" }"
-        doc = ArangoDB.log_put("#{prefix}", cmd, :body => body)
-
-        doc.code.should eq(400)
-        doc.parsed_response['error'].should eq(true)
-        doc.parsed_response['errorNum'].should eq(600)
-        doc.parsed_response['code'].should eq(400)
-      end
-
       it "create a document and replace it, using ignoreRevs=false" do
         cmd = "/_api/document?collection=#{@cid}"
         body = "{ \"Hallo\" : \"World\" }"

--- a/tests/rb/HttpInterface/api-document-update-spec.rb
+++ b/tests/rb/HttpInterface/api-document-update-spec.rb
@@ -156,7 +156,7 @@ describe ArangoDB do
         body = "{ \"_rev\": \"658993\", \"World\" : \"Hallo\" }"
         doc = ArangoDB.log_put("#{prefix}-ignore-revs-false", cmd, :body => body)
 
-        doc.code.should eq(409)
+        doc.code.should eq(412)
         doc.parsed_response['error'].should eq(true)
         doc.headers['content-type'].should eq("application/json; charset=utf-8")
 
@@ -232,7 +232,7 @@ describe ArangoDB do
         body = "{ \"_key\" : \"hello\", \"_rev\" : \"658993\", \"World\" : \"Hallo\" }"
         doc = ArangoDB.log_put("#{prefix}-ignore-revs-false", cmd, :body => body)
 
-        doc.code.should eq(409)
+        doc.code.should eq(412)
         doc.parsed_response['error'].should eq(true)
         doc.headers['content-type'].should eq("application/json; charset=utf-8")
 
@@ -747,7 +747,7 @@ describe ArangoDB do
         body = "{ \"_rev\": \"658993\", \"World\" : \"Hallo\" }"
         doc = ArangoDB.log_patch("#{prefix}-ignore-revs-false", cmd, :body => body)
 
-        doc.code.should eq(409)
+        doc.code.should eq(412)
         doc.parsed_response['error'].should eq(true)
         doc.headers['content-type'].should eq("application/json; charset=utf-8")
 
@@ -823,7 +823,7 @@ describe ArangoDB do
         body = "{ \"_key\" : \"hello\", \"_rev\" : \"658993\", \"World\" : \"Hallo\" }"
         doc = ArangoDB.log_patch("#{prefix}-ignore-revs-false", cmd, :body => body)
 
-        doc.code.should eq(409)
+        doc.code.should eq(412)
         doc.parsed_response['error'].should eq(true)
         doc.headers['content-type'].should eq("application/json; charset=utf-8")
 


### PR DESCRIPTION
There is a small bug in the implementation of our API. If one updates
(or replaces) a single document and gives the key only in the URL
but not in the body of the document, and also adds the option
ignoreRevs=false and specifies the _rev in the body, then this
rev is silently rewritten to 0 due to a bug.

This PR fixes this bug. Also see #13232.

### Scope & Purpose

*(Can you describe what functional change your PR is trying to effect?)*

- [*] Bug-Fix for *devel-branch* (i.e. no need for backports?)
- [*] Bug-Fix for a *released version* (did you remember to port this to all relevant release branches?)
- [*] The behavior change can be verified via automatic tests


### Testing & Verification

This PR adds tests that were used to verify all changes:

- [*] Added **Regression Tests** (Only for bug-fixes) 
