### PR TITLE
validate lockTimeout value for transactions to be >= 0

### DIFF
--- a/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
+++ b/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
@@ -390,7 +390,7 @@ Result EngineInfoContainerDBServerServerBased::buildEngines(
   std::vector<ServerID> dbServers = _shardLocking.getRelevantServers();
   if (dbServers.empty()) {
     // No snippets to be placed on dbservers
-    return TRI_ERROR_NO_ERROR;
+    return {};
   }
   // We at least have one Snippet, or one graph node.
   // Otherwise the locking needs to be empty.
@@ -519,7 +519,7 @@ Result EngineInfoContainerDBServerServerBased::buildEngines(
   }
 
   cleanupGuard.cancel();
-  return TRI_ERROR_NO_ERROR;
+  return {};
 }
 
 Result EngineInfoContainerDBServerServerBased::parseResponse(

--- a/arangod/StorageEngine/TransactionState.cpp
+++ b/arangod/StorageEngine/TransactionState.cpp
@@ -162,8 +162,8 @@ Result TransactionState::addCollection(DataSourceId cid, std::string const& cnam
     if (AccessMode::isWriteOrExclusive(accessType) &&
         !AccessMode::isWriteOrExclusive(_type)) {
       // if one collection is written to, the whole transaction becomes a
-      // write-transaction
-      _type = AccessMode::Type::WRITE;
+      // write-y transaction
+      _type = std::max(_type, accessType);
     }
   }
 

--- a/arangod/Transaction/Manager.h
+++ b/arangod/Transaction/Manager.h
@@ -208,7 +208,7 @@ class Manager final {
   }
 
  private:
-  void prepareOptions(transaction::Options& options);
+  Result prepareOptions(transaction::Options& options);
   bool isFollowerTransactionOnDBServer(transaction::Options const& options) const;
   Result lockCollections(TRI_vocbase_t& vocbase, std::shared_ptr<TransactionState> state,
                          std::vector<std::string> const& exclusiveCollections,

--- a/tests/js/client/shell/shell-transaction.js
+++ b/tests/js/client/shell/shell-transaction.js
@@ -1607,6 +1607,28 @@ function transactionOperationsSuite () {
       c2 = null;
       internal.wait(0);
     },
+        
+    // //////////////////////////////////////////////////////////////////////////////
+    // / @brief test: trx with negative lock timeout
+    // //////////////////////////////////////////////////////////////////////////////
+
+    testNegativeLockTimeout: function () {
+      c1 = db._create(cn1, {numberOfShards: 3, replicationFactor: 2});
+
+      let obj = {
+        collections: {
+          read: [ cn1 ],
+        },
+        lockTimeout: -1
+      };
+
+      try {
+        db._createTransaction(obj);
+        fail();
+      } catch (err) {
+        assertEqual(internal.errors.ERROR_BAD_PARAMETER.code, err.errorNum);
+      }
+    },
 
     // //////////////////////////////////////////////////////////////////////////////
     // / @brief test: trx with read operation


### PR DESCRIPTION
### Scope & Purpose

Make sure that `lockTimeout` value is at least >= 0.
Passing in a value < 0 did not do any harm, but is clear a user error. So in this case, we will now tell the user.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_server / shell_server_aql)

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13706/