### PR TITLE
improve performance of shard synchronization protocol

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Improve shard synchronization protocol by only transferring the required
+  parts of the inventory from leader to follower. Previously, for each shard
+  the entire inventory was exchanged, which included all shards of the
+  respective database with all their details.
+
 * Fixed some wrong behavior in single document updates. If the option
   ignoreRevs=false was given and the precondition _rev was given in the body
   but the _key was given in the URL path, then the rev was wrongly taken

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@ devel
   parts of the inventory from leader to follower. Previously, for each shard
   the entire inventory was exchanged, which included all shards of the
   respective database with all their details.
-  In addition, save 3 cluster-internal requests per shard in the shard
+  In addition, save 3 cluster-internal requests per shard in the initial shard
   synchronization protocol by reusing already existing information in the
   different steps of the replication process.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,9 @@ devel
   parts of the inventory from leader to follower. Previously, for each shard
   the entire inventory was exchanged, which included all shards of the
   respective database with all their details.
+  In addition, save 3 cluster-internal requests per shard in the shard
+  synchronization protocol by reusing already existing information in the
+  different steps of the replication process.
 
 * Fixed some wrong behavior in single document updates. If the option
   ignoreRevs=false was given and the precondition _rev was given in the body

--- a/Documentation/DocuBlocks/Rest/Collections/get_api_collection_figures.md
+++ b/Documentation/DocuBlocks/Rest/Collections/get_api_collection_figures.md
@@ -15,12 +15,16 @@ You should reference them via their names instead.
 @RESTURLPARAM{collection-name,string,required}
 The name of the collection.
 
-@RESTURLPARAM{details,boolean,required}
+@RESTQUERYPARAMETERS
+
+@RESTQUERYPARAM{details,boolean,optional}
 Setting `details` to `true` will return extended storage engine-specific
 details to the figures. The details are intended for debugging ArangoDB itself
 and their format is subject to change. By default, `details` is set to `false`,
 so no details are returned and the behavior is identical to previous versions
 of ArangoDB.
+Please note that requesting `details` may cause additional load and thus have
+an impact on performace.
 
 @RESTDESCRIPTION
 In addition to the above, the result also contains the number of documents

--- a/Documentation/DocuBlocks/Rest/Replication/post_batch_replication.md
+++ b/Documentation/DocuBlocks/Rest/Replication/post_batch_replication.md
@@ -6,6 +6,14 @@
 
 **Note**: These calls are uninteresting to users.
 
+@RESTQUERYPARAMETERS
+
+@RESTQUERYPARAM{state,boolean,optional}
+setting `state` to true will make the response also contain
+a `state` attribute with information about the leader state.
+This is used only internally during the replication process 
+and should not be used by client applications.
+
 @RESTBODYPARAM{ttl,integer,required,int64}
 the time-to-live for the new batch (in seconds)<br>
 A JSON object with the batch configuration.
@@ -16,6 +24,9 @@ Creates a new dump batch and returns the batch's id.
 The response is a JSON object with the following attributes:
 
 - *id*: the id of the batch
+- *lastTick*: snapshot tick value using when creating the batch
+- *state*: additional leader state information (only present if the
+  `state` URL parameter was set to `true` in the request)
 
 **Note**: on a Coordinator, this request must have the query parameter
 *DBserver* which must be an ID of a DB-Server.

--- a/Documentation/DocuBlocks/Rest/Replication/put_api_replication_inventory.md
+++ b/Documentation/DocuBlocks/Rest/Replication/put_api_replication_inventory.md
@@ -15,12 +15,24 @@ Include all databases in the response. Only works on `_system` The default value
 @RESTQUERYPARAM{batchId,number,required}
 A valid batchId is required for this API call
 
-@RESTDESCRIPTION
-Returns the array of collections and indexes available on the server. This
-array can be used by replication clients to initiate an initial sync with the
-server.
+@RESTQUERYPARAM{collection,string,optional}
+If this parameter is set, the response will be restricted to a single collection (the one
+specified), and no views will be returned. This can be used as an optimization to reduce
+the size of the response.
 
-The response will contain a JSON object with the *collection* and *state* and
+@RESTDESCRIPTION
+Returns the array of collections and their indexes, and the array of views available. These
+arrays can be used by replication clients to initiate an initial synchronization with the
+server. 
+The response will contain all collections, their indexes and views in the requested database
+if *global* is not set, and all collections, indexes and views in all databases if *global*
+is set.
+In case *global* is not set, it is possible to restrict the response to a single collection
+by setting the *collection* parameter. In this case the response will contain only information
+about the requested collection in the *collections* array, and no information about views
+(i.e. the *views* response attribute will be an empty array).
+
+The response will contain a JSON object with the *collections*, *views*, *state* and
 *tick* attributes.
 
 *collections* is an array of collections with the following sub-attributes:
@@ -39,6 +51,8 @@ contains the following sub-attributes:
 - *lastLogTick*: the value of the last tick the replication logger has written
 
 - *time*: the current time on the server
+
+*views* is an array of available views.
 
 Replication clients should note the *lastLogTick* value returned. They can then
 fetch collections' data using the dump method up to the value of lastLogTick, and

--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -877,7 +877,7 @@ uint64_t AgencyComm::uniqid(uint64_t count, double timeout) {
 
     try {
       oldValue = oldSlice.getNumber<decltype(oldValue)>();
-    } catch (velocypack::Exception& e) {
+    } catch (velocypack::Exception const& e) {
       LOG_TOPIC("74f97", ERR, Logger::AGENCYCOMM)
           << "Sync/LatestID in agency could not be parsed: " << e.what()
           << "; If this error persists, contact the ArangoDB support.";

--- a/arangod/Cluster/SynchronizeShard.h
+++ b/arangod/Cluster/SynchronizeShard.h
@@ -25,9 +25,10 @@
 #ifndef ARANGODB_MAINTENANCE_SYNCHRONIZE_SHARD_H
 #define ARANGODB_MAINTENANCE_SYNCHRONIZE_SHARD_H
 
-#include "ActionBase.h"
-#include "ActionDescription.h"
 #include "Basics/ResultT.h"
+#include "Cluster/ActionBase.h"
+#include "Cluster/ActionDescription.h"
+#include "Replication/utilities.h"
 #include "VocBase/voc-types.h"
 
 #include <chrono>
@@ -51,6 +52,11 @@ class SynchronizeShard : public ActionBase {
   bool first() override final;
 
   void setState(ActionState state) override final;
+
+  std::string const& clientInfoString() const;
+
+  arangodb::replutils::LeaderInfo const& leaderInfo() const;
+  void setLeaderInfo(arangodb::replutils::LeaderInfo const& leaderInfo);
 
  private:
   arangodb::Result getReadLock(network::ConnectionPool* pool,
@@ -77,6 +83,9 @@ class SynchronizeShard : public ActionBase {
 
   /// @brief Short, informative description of the replication client, passed to the server
   std::string _clientInfoString;
+
+  /// @brief information about the leader, reused across multiple replication steps
+  arangodb::replutils::LeaderInfo _leaderInfo;
 };
 
 }  // namespace maintenance

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -354,6 +354,22 @@ DatabaseInitialSyncer::DatabaseInitialSyncer(TRI_vocbase_t& vocbase,
     _state.databaseName = vocbase.name();
   }
 }
+  
+std::shared_ptr<DatabaseInitialSyncer> DatabaseInitialSyncer::create(TRI_vocbase_t& vocbase,
+                                                                     ReplicationApplierConfiguration const& configuration) {
+  // enable make_shared on a class with a private constructor
+  struct Enabler final : public DatabaseInitialSyncer {
+    Enabler(TRI_vocbase_t& vocbase, ReplicationApplierConfiguration const& configuration)
+      : DatabaseInitialSyncer(vocbase, configuration) {}
+  };
+
+  return std::make_shared<Enabler>(vocbase, configuration);
+}
+  
+/// @brief return information about the leader
+replutils::LeaderInfo DatabaseInitialSyncer::leaderInfo() const {
+  return _config.leader;
+}
 
 /// @brief run method, performs a full synchronization
 Result DatabaseInitialSyncer::runWithInventory(bool incremental, VPackSlice dbInventory,
@@ -377,32 +393,35 @@ Result DatabaseInitialSyncer::runWithInventory(bool incremental, VPackSlice dbIn
 
     Result r;
     if (!_config.isChild()) {
-      r = _config.leader.getState(_config.connection, _config.isChild(), context);
-
-      if (r.fail()) {
-        return r;
-      }
-    }
-
-    TRI_ASSERT(!_config.leader.endpoint.empty());
-    TRI_ASSERT(_config.leader.serverId.isSet());
-    TRI_ASSERT(_config.leader.majorVersion != 0);
-
-    LOG_TOPIC("6fd2b", DEBUG, Logger::REPLICATION) << "client: got leader state";
-
-    if (!_config.isChild()) {
       // enable patching of collection count for ShardSynchronization Job
-      std::string patchCount = StaticStrings::Empty;
+      std::string patchCount;
       if (_config.applier._skipCreateDrop &&
           _config.applier._restrictType == ReplicationApplierConfiguration::RestrictType::Include &&
           _config.applier._restrictCollections.size() == 1) {
         patchCount = *_config.applier._restrictCollections.begin();
       }
-
-      r = batchStart(patchCount);
+    
+      // with a 3.8 leader, this call combines fetching the leader state with starting the batch.
+      // this saves us one request per shard.
+      // a 3.7 leader will does not return the leader state together with this call, so we need
+      // to be prepared for not yet getting it here
+      r = batchStart(context, patchCount);
+      
+      if (r.ok() && !_config.leader.serverId.isSet()) {
+        // a 3.7 leader, which does not return leader state when stating a batch.
+        // so we need to fetch the leader state in addition
+        r = _config.leader.getState(_config.connection, _config.isChild(), context);
+      }
+        
       if (r.fail()) {
         return r;
       }
+     
+      TRI_ASSERT(!_config.leader.endpoint.empty());
+      TRI_ASSERT(_config.leader.serverId.isSet());
+      TRI_ASSERT(_config.leader.majorVersion != 0);
+
+      LOG_TOPIC("6fd2b", DEBUG, Logger::REPLICATION) << "client: got leader state";
 
       startRecurringBatchExtension();
     }
@@ -415,9 +434,9 @@ Result DatabaseInitialSyncer::runWithInventory(bool incremental, VPackSlice dbIn
     VPackBuilder inventoryResponse;  // hold response data
     if (!collections.isArray()) {
       // caller did not supply an inventory, we need to fetch it
-      Result res = fetchInventory(inventoryResponse);
-      if (!res.ok()) {
-        return res;
+      r = fetchInventory(inventoryResponse);
+      if (!r.ok()) {
+        return r;
       }
       // we do not really care about the state response
       collections = inventoryResponse.slice().get("collections");
@@ -472,7 +491,7 @@ Result DatabaseInitialSyncer::getInventory(VPackBuilder& builder) {
     return Result(TRI_ERROR_INTERNAL, "invalid endpoint");
   }
 
-  auto r = batchStart();
+  auto r = batchStart(nullptr);
   if (r.fail()) {
     return r;
   }
@@ -2072,9 +2091,9 @@ Result DatabaseInitialSyncer::handleViewCreation(VPackSlice const& views) {
   return {};
 }
 
-Result DatabaseInitialSyncer::batchStart(std::string const& patchCount) {
+Result DatabaseInitialSyncer::batchStart(char const* context, std::string const& patchCount) {
   return _config.batch.start(_config.connection, _config.progress,
-                             _config.leader, _config.state.syncerId, patchCount);
+                             _config.leader, _config.state.syncerId, context, patchCount);
 }
 
 Result DatabaseInitialSyncer::batchExtend() {

--- a/arangod/Replication/DatabaseInitialSyncer.h
+++ b/arangod/Replication/DatabaseInitialSyncer.h
@@ -32,6 +32,8 @@
 #include "Replication/utilities.h"
 #include "Utils/SingleCollectionTransaction.h"
 
+#include <memory>
+
 struct TRI_vocbase_t;
 
 namespace arangodb {
@@ -40,7 +42,7 @@ class LogicalCollection;
 class DatabaseInitialSyncer;
 class ReplicationApplierConfiguration;
 
-class DatabaseInitialSyncer final : public InitialSyncer {
+class DatabaseInitialSyncer : public InitialSyncer {
   friend ::arangodb::Result handleSyncKeysRocksDB(DatabaseInitialSyncer& syncer,
                                                   arangodb::LogicalCollection* col,
                                                   std::string const& keysId);
@@ -49,8 +51,16 @@ class DatabaseInitialSyncer final : public InitialSyncer {
       ReplicationMetricsFeature::InitialSyncStats& stats, std::string const& keysId,
       uint64_t chunkId, std::string const& lowString,
       std::string const& highString, std::vector<std::string> const& markers);
+ private:
+  // constructor is private, as DatabaseInitialSyncer uses shared_from_this() and
+  // we must ensure that it is only created via make_shared.
+  DatabaseInitialSyncer(TRI_vocbase_t& vocbase,
+                        ReplicationApplierConfiguration const& configuration);
 
  public:
+  static std::shared_ptr<DatabaseInitialSyncer> create(TRI_vocbase_t& vocbase,
+                                                       ReplicationApplierConfiguration const& configuration);
+
   /// @brief apply phases
   typedef enum {
     PHASE_NONE,
@@ -85,9 +95,6 @@ class DatabaseInitialSyncer final : public InitialSyncer {
 
     bool isChild() const;  // TODO worker safety
   };
-
-  DatabaseInitialSyncer(TRI_vocbase_t& vocbase,
-                        ReplicationApplierConfiguration const& configuration);
 
   /// @brief run method, performs a full synchronization
   Result run(bool incremental, char const* context = nullptr) override {
@@ -147,6 +154,9 @@ class DatabaseInitialSyncer final : public InitialSyncer {
 
   /// @brief fetch the server's inventory, public method
   Result getInventory(arangodb::velocypack::Builder& builder);
+  
+  /// @brief return information about the leader
+  replutils::LeaderInfo leaderInfo() const;
 
  private:
   enum class FormatHint {
@@ -232,7 +242,7 @@ class DatabaseInitialSyncer final : public InitialSyncer {
   /// @param patchCount (optional)
   ///        Try to patch count of this collection (must be a collection name).
   ///        Only effective with the incremental sync.
-  Result batchStart(std::string const& patchCount = "");
+  Result batchStart(char const* context, std::string const& patchCount = "");
 
   /// @brief send an "extend batch" command
   Result batchExtend();

--- a/arangod/Replication/DatabaseReplicationApplier.cpp
+++ b/arangod/Replication/DatabaseReplicationApplier.cpp
@@ -157,13 +157,12 @@ void DatabaseReplicationApplier::storeConfiguration(bool doSync) {
 }
 
 std::shared_ptr<InitialSyncer> DatabaseReplicationApplier::buildInitialSyncer() const {
-  return std::make_shared<arangodb::DatabaseInitialSyncer>(_vocbase, _configuration);
+  return arangodb::DatabaseInitialSyncer::create(_vocbase, _configuration);
 }
 
 std::shared_ptr<TailingSyncer> DatabaseReplicationApplier::buildTailingSyncer(
     TRI_voc_tick_t initialTick, bool useTick) const {
-  return std::make_shared<arangodb::DatabaseTailingSyncer>(_vocbase, _configuration,
-                                                           initialTick, useTick);
+  return arangodb::DatabaseTailingSyncer::create(_vocbase, _configuration, initialTick, useTick);
 }
 
 std::string DatabaseReplicationApplier::getStateFilename() const {

--- a/arangod/Replication/DatabaseTailingSyncer.cpp
+++ b/arangod/Replication/DatabaseTailingSyncer.cpp
@@ -73,6 +73,19 @@ DatabaseTailingSyncer::DatabaseTailingSyncer(TRI_vocbase_t& vocbase,
   }
 }
 
+std::shared_ptr<DatabaseTailingSyncer> DatabaseTailingSyncer::create(TRI_vocbase_t& vocbase,
+                                                                     ReplicationApplierConfiguration const& configuration,
+                                                                     TRI_voc_tick_t initialTick,
+                                                                     bool useTick) {
+  // enable make_shared on a class with a private constructor
+  struct Enabler final : public DatabaseTailingSyncer {
+    Enabler(TRI_vocbase_t& vocbase, ReplicationApplierConfiguration const& configuration, TRI_voc_tick_t initialTick, bool useTick)
+      : DatabaseTailingSyncer(vocbase, configuration, initialTick, useTick) {}
+  };
+
+  return std::make_shared<Enabler>(vocbase, configuration, initialTick, useTick);
+}
+
 /// @brief save the current applier state
 Result DatabaseTailingSyncer::saveApplierState() {
   auto rv = _applier->persistStateResult(false);
@@ -84,18 +97,54 @@ Result DatabaseTailingSyncer::saveApplierState() {
 
 /// @brief finalize the synchronization of a collection by tailing the WAL
 /// and filtering on the collection name until no more data is available
-Result DatabaseTailingSyncer::syncCollectionCatchupInternal(std::string const& collectionName,
+Result DatabaseTailingSyncer::syncCollectionCatchupInternal(arangodb::replutils::LeaderInfo const& leaderInfo,
+                                                            std::string const& collectionName,
                                                             double timeout, bool hard,
                                                             TRI_voc_tick_t& until,
                                                             bool& didTimeout, char const* context) {
   didTimeout = false;
 
   setAborted(false);
+
   // fetch leader state just once
-  Result r = _state.leader.getState(_state.connection, _state.isChildSyncer, context);
-  if (r.fail()) {
-    return r;
+  TRI_ASSERT(!_state.isChildSyncer);
+  TRI_ASSERT(!_state.leader.endpoint.empty());
+  TRI_ASSERT(!_state.leader.serverId.isSet());
+  TRI_ASSERT(_state.leader.engine.empty());
+  TRI_ASSERT(_state.leader.version() == 0);
+  
+  TRI_ASSERT(!leaderInfo.endpoint.empty());
+  TRI_ASSERT(leaderInfo.endpoint == _state.leader.endpoint);
+  TRI_ASSERT(leaderInfo.serverId.isSet());
+  TRI_ASSERT(!leaderInfo.engine.empty());
+  TRI_ASSERT(leaderInfo.version() > 0);
+
+  _state.leader.serverId = leaderInfo.serverId;;
+  _state.leader.engine = leaderInfo.engine;
+  _state.leader.majorVersion = leaderInfo.majorVersion;
+  _state.leader.minorVersion = leaderInfo.minorVersion;
+  // note: neither LeaderInfo::lastLogTick is not used during tailing syncing
+
+  Result r;
+
+  if (_state.leader.engine.empty()) {
+    // fetch leader state only if we need to. this should not be needed, normally
+    TRI_ASSERT(false);
+
+    r = _state.leader.getState(_state.connection, /*_state.isChildSyncer*/ false, context);
+    if (r.fail()) {
+      return r;
+    }
+  } else {
+    LOG_TOPIC("6c922", DEBUG, arangodb::Logger::REPLICATION)
+      << "connected to leader at " << _state.leader.endpoint 
+      << ", version " << _state.leader.majorVersion << "." << _state.leader.minorVersion 
+      << ", context: " << context;
   }
+  
+  TRI_ASSERT(_state.leader.serverId.isSet());
+  TRI_ASSERT(!_state.leader.engine.empty());
+  TRI_ASSERT(_state.leader.version() > 0);
 
   // print extra info for debugging
   _state.applier._verbose = true;
@@ -287,8 +336,8 @@ bool DatabaseTailingSyncer::skipMarker(VPackSlice const& slice) {
     try {
       VPackBuilder inventoryResponse;
 
-      auto init = std::make_shared<DatabaseInitialSyncer>(*_vocbase, _state.applier);
-      Result res = init->getInventory(inventoryResponse);
+      auto syncer = DatabaseInitialSyncer::create(*_vocbase, _state.applier);
+      Result res = syncer->getInventory(inventoryResponse);
       _queriedTranslations = true;
       if (res.fail()) {
         LOG_TOPIC("89080", ERR, Logger::REPLICATION)

--- a/arangod/Replication/DatabaseTailingSyncer.cpp
+++ b/arangod/Replication/DatabaseTailingSyncer.cpp
@@ -113,6 +113,8 @@ Result DatabaseTailingSyncer::syncCollectionCatchupInternal(std::string const& c
                                           << ", fromTick " << fromTick;
   }
 
+  VPackBuilder builder; // will be recycled for every batch
+
   auto clock = std::chrono::steady_clock();
   auto startTime = clock.now();
     
@@ -204,9 +206,11 @@ Result DatabaseTailingSyncer::syncCollectionCatchupInternal(std::string const& c
               "number of historic logfiles on the leader.");
     }
 
+    builder.clear();
+
     ApplyStats applyStats;
     uint64_t ignoreCount = 0;
-    r = applyLog(response.get(), fromTick, applyStats, ignoreCount);
+    r = applyLog(response.get(), fromTick, applyStats, builder, ignoreCount);
     if (r.fail()) {
       until = fromTick;
       return r;

--- a/arangod/Replication/DatabaseTailingSyncer.h
+++ b/arangod/Replication/DatabaseTailingSyncer.h
@@ -26,16 +26,26 @@
 
 #include "Replication/DatabaseReplicationApplier.h"
 #include "Replication/ReplicationApplierConfiguration.h"
+#include "Replication/utilities.h"
 #include "TailingSyncer.h"
+
+#include <memory>
 
 namespace arangodb {
 class DatabaseReplicationApplier;
 
-class DatabaseTailingSyncer final : public TailingSyncer {
- public:
+class DatabaseTailingSyncer : public TailingSyncer {
+ private:
+  // constructor is private, as DatabaseTailingSyncer uses shared_from_this() and
+  // we must ensure that it is only created via make_shared.
   DatabaseTailingSyncer(TRI_vocbase_t& vocbase,
                         ReplicationApplierConfiguration const& configuration,
                         TRI_voc_tick_t initialTick, bool useTick);
+
+ public:
+  static std::shared_ptr<DatabaseTailingSyncer> create(TRI_vocbase_t& vocbase,
+                                                       ReplicationApplierConfiguration const& configuration,
+                                                       TRI_voc_tick_t initialTick, bool useTick);
 
   TRI_vocbase_t* resolveVocbase(velocypack::Slice const&) override {
     return _vocbase;
@@ -48,11 +58,12 @@ class DatabaseTailingSyncer final : public TailingSyncer {
 
   /// @brief finalize the synchronization of a collection by tailing the WAL
   /// and filtering on the collection name until no more data is available
-  Result syncCollectionFinalize(std::string const& collectionName, char const* context) {
+  Result syncCollectionFinalize(arangodb::replutils::LeaderInfo const& leaderInfo,
+                                std::string const& collectionName, char const* context) {
     TRI_voc_tick_t dummy = 0;
     bool dummyDidTimeout = false;
     double dummyTimeout = 300.0;
-    return syncCollectionCatchupInternal(collectionName, dummyTimeout, true,
+    return syncCollectionCatchupInternal(leaderInfo, collectionName, dummyTimeout, true,
                                          dummy, dummyDidTimeout, context);
   }
 
@@ -66,13 +77,15 @@ class DatabaseTailingSyncer final : public TailingSyncer {
   /// by getting an exclusive lock on the leader and use
   /// `syncCollectionFinalize` to finish off the rest.
   /// Internally, both use `syncCollectionCatchupInternal`.
-  Result syncCollectionCatchup(std::string const& collectionName, double timeout,
+  Result syncCollectionCatchup(arangodb::replutils::LeaderInfo const& leaderInfo,
+                               std::string const& collectionName, double timeout,
                                TRI_voc_tick_t& until, bool& didTimeout, char const* context) {
-    return syncCollectionCatchupInternal(collectionName, timeout, false, until, didTimeout, context);
+    return syncCollectionCatchupInternal(leaderInfo, collectionName, timeout, false, until, didTimeout, context);
   }
 
  protected:
-  Result syncCollectionCatchupInternal(std::string const& collectionName,
+  Result syncCollectionCatchupInternal(arangodb::replutils::LeaderInfo const& leaderInfo, 
+                                       std::string const& collectionName,
                                        double timeout, bool hard,
                                        TRI_voc_tick_t& until, bool& didTimeout, char const* context);
   /// @brief save the current applier state

--- a/arangod/Replication/GlobalInitialSyncer.cpp
+++ b/arangod/Replication/GlobalInitialSyncer.cpp
@@ -55,6 +55,16 @@ GlobalInitialSyncer::GlobalInitialSyncer(ReplicationApplierConfiguration const& 
   _state.databaseName = StaticStrings::SystemDatabase;
 }
 
+std::shared_ptr<GlobalInitialSyncer> GlobalInitialSyncer::create(ReplicationApplierConfiguration const& configuration) {
+  // enable make_shared on a class with a private constructor
+  struct Enabler final : public GlobalInitialSyncer {
+    explicit Enabler(ReplicationApplierConfiguration const& configuration)
+      : GlobalInitialSyncer(configuration) {}
+  };
+
+  return std::make_shared<Enabler>(configuration);
+}
+
 GlobalInitialSyncer::~GlobalInitialSyncer() {
   try {
     if (!_state.isChildSyncer) {
@@ -111,7 +121,7 @@ Result GlobalInitialSyncer::runInternal(bool incremental, char const* context) {
   if (!_state.isChildSyncer) {
     // start batch is required for the inventory request
     LOG_TOPIC("0da14", DEBUG, Logger::REPLICATION) << "sending start batch";
-    r = _batch.start(_state.connection, _progress, _state.leader, _state.syncerId);
+    r = _batch.start(_state.connection, _progress, _state.leader, _state.syncerId, nullptr);
     if (r.fail()) {
       return r;
     }
@@ -188,7 +198,7 @@ Result GlobalInitialSyncer::runInternal(bool incremental, char const* context) {
       ReplicationApplierConfiguration configurationCopy = _state.applier;
       configurationCopy._database = nameSlice.copyString();
 
-      auto syncer = std::make_shared<DatabaseInitialSyncer>(*vocbase, configurationCopy);
+      auto syncer = DatabaseInitialSyncer::create(*vocbase, configurationCopy);
       syncer->useAsChildSyncer(_state.leader, _state.syncerId, _batch.id, _batch.updateTime);
 
       // run the syncer with the supplied inventory collections
@@ -350,7 +360,7 @@ Result GlobalInitialSyncer::getInventory(VPackBuilder& builder) {
     return Result(TRI_ERROR_SHUTTING_DOWN);
   }
 
-  auto r = _batch.start(_state.connection, _progress, _state.leader, _state.syncerId);
+  auto r = _batch.start(_state.connection, _progress, _state.leader, _state.syncerId, nullptr);
   if (r.fail()) {
     return r;
   }

--- a/arangod/Replication/GlobalInitialSyncer.h
+++ b/arangod/Replication/GlobalInitialSyncer.h
@@ -26,16 +26,22 @@
 
 #include "Replication/InitialSyncer.h"
 
+#include <memory>
+
 namespace arangodb {
 
 /// Meta Syncer driving multiple initial syncer
-class GlobalInitialSyncer final : public InitialSyncer {
- public:
+class GlobalInitialSyncer : public InitialSyncer {
+ private:
+  // constructor is private, as GlobalInitialSyncer uses shared_from_this() and
+  // we must ensure that it is only created via make_shared.
   explicit GlobalInitialSyncer(ReplicationApplierConfiguration const&);
+ 
+ public:
+  static std::shared_ptr<GlobalInitialSyncer> create(ReplicationApplierConfiguration const&);
 
   ~GlobalInitialSyncer();
 
- public:
   /// @brief run method, performs a full synchronization
   /// public method, catches exceptions
   arangodb::Result run(bool incremental, char const* context = nullptr) override;

--- a/arangod/Replication/GlobalReplicationApplier.cpp
+++ b/arangod/Replication/GlobalReplicationApplier.cpp
@@ -100,13 +100,12 @@ ReplicationApplierConfiguration GlobalReplicationApplier::loadConfiguration(
 }
 
 std::shared_ptr<InitialSyncer> GlobalReplicationApplier::buildInitialSyncer() const {
-  return std::make_shared<arangodb::GlobalInitialSyncer>(_configuration);
+  return arangodb::GlobalInitialSyncer::create(_configuration);
 }
 
 std::shared_ptr<TailingSyncer> GlobalReplicationApplier::buildTailingSyncer(
     TRI_voc_tick_t initialTick, bool useTick) const {
-  return std::make_shared<arangodb::GlobalTailingSyncer>(_configuration, initialTick,
-                                                         useTick);
+  return arangodb::GlobalTailingSyncer::create(_configuration, initialTick, useTick);
 }
 
 std::string GlobalReplicationApplier::getStateFilename() const {

--- a/arangod/Replication/GlobalTailingSyncer.h
+++ b/arangod/Replication/GlobalTailingSyncer.h
@@ -28,15 +28,24 @@
 #include "Replication/ReplicationApplierConfiguration.h"
 #include "TailingSyncer.h"
 
+#include <memory>
+
 namespace arangodb {
 class GlobalReplicationApplier;
 
 class GlobalTailingSyncer : public TailingSyncer {
- public:
-  GlobalTailingSyncer(ReplicationApplierConfiguration const&, TRI_voc_tick_t initialTick,
+ private:
+  // constructor is private, as GlobalTailingSyncer uses shared_from_this() and
+  // we must ensure that it is only created via make_shared.
+  GlobalTailingSyncer(ReplicationApplierConfiguration const&, 
+                      TRI_voc_tick_t initialTick,
                       bool useTick);
-
+  
  public:
+  static std::shared_ptr<GlobalTailingSyncer> create(ReplicationApplierConfiguration const&, 
+                                                     TRI_voc_tick_t initialTick,
+                                                     bool useTick);
+
   /// @brief return the syncer's replication applier
   GlobalReplicationApplier* applier() const {
     return static_cast<GlobalReplicationApplier*>(_applier);
@@ -57,6 +66,7 @@ class GlobalTailingSyncer : public TailingSyncer {
 
   bool _queriedTranslations;
 };
+
 }  // namespace arangodb
 
 #endif

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -1423,6 +1423,7 @@ retry:
         Result r = syncer->run(_state.applier._incremental);
         if (r.ok()) {
           TRI_voc_tick_t lastLogTick = syncer->getLastLogTick();
+          TRI_ASSERT(lastLogTick > 0);
           LOG_TOPIC("ee130", INFO, Logger::REPLICATION)
               << "automatic resynchronization for " << _applier->databaseName()
               << " finished. restarting continuous replication applier from "

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -1072,7 +1072,8 @@ Result TailingSyncer::applyLogMarker(VPackSlice const& slice,
 
 /// @brief apply the data from the continuous log
 Result TailingSyncer::applyLog(SimpleHttpResult* response, TRI_voc_tick_t firstRegularTick,
-                               ApplyStats& applyStats, uint64_t& ignoreCount) {
+                               ApplyStats& applyStats, arangodb::velocypack::Builder& builder, 
+                               uint64_t& ignoreCount) {
   // reload users if they were modified
   _usersModified = false;
   _analyzersModified.clear();
@@ -1109,9 +1110,6 @@ Result TailingSyncer::applyLog(SimpleHttpResult* response, TRI_voc_tick_t firstR
   // buffer must end with a NUL byte
   TRI_ASSERT(*end == '\0');
 
-  // TODO: re-use a builder!
-  auto builder = std::make_shared<VPackBuilder>();
-
   while (p < end) {
     char const* q = static_cast<char const*>(memchr(p, '\n', (end - p)));
 
@@ -1131,7 +1129,7 @@ Result TailingSyncer::applyLog(SimpleHttpResult* response, TRI_voc_tick_t firstR
 
     applyStats.processedMarkers++;
 
-    builder->clear();
+    builder.clear();
     try {
       VPackParser parser(builder);
       parser.parse(p, static_cast<size_t>(q - p));
@@ -1143,7 +1141,7 @@ Result TailingSyncer::applyLog(SimpleHttpResult* response, TRI_voc_tick_t firstR
 
     p = q + 1;
 
-    VPackSlice const slice = builder->slice();
+    VPackSlice const slice = builder.slice();
 
     if (!slice.isObject()) {
       return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
@@ -1580,9 +1578,14 @@ Result TailingSyncer::runContinuousSync() {
   bool worked = false;
   bool mustFetchBatch = true;
 
+  // will be recycled for every batch
+  VPackBuilder builder;
+
   // run in a loop. the loop is terminated when the applier is stopped or an
   // error occurs
   while (true) {
+    builder.clear();
+
     // fetchTick, worked and mustFetchBatch are passed by reference and are
     // updated by processLeaderLog!
 
@@ -1590,7 +1593,7 @@ Result TailingSyncer::runContinuousSync() {
     // initially fetch the next batch from the leader passing "mustFetchBatch =
     // false" to processLeaderLog requires that processLeaderLog has already
     // requested the next batch in the background on the previous invocation
-    Result res = processLeaderLog(sharedStatus, fetchTick, lastScannedTick, fromTick,
+    Result res = processLeaderLog(sharedStatus, builder, fetchTick, lastScannedTick, fromTick,
                                   _state.applier._ignoreErrors, worked, mustFetchBatch);
 
     uint64_t sleepTime;
@@ -1854,6 +1857,7 @@ void TailingSyncer::fetchLeaderLog(std::shared_ptr<Syncer::JobSynchronizer> shar
 
 /// @brief apply continuous synchronization data from a batch
 Result TailingSyncer::processLeaderLog(std::shared_ptr<Syncer::JobSynchronizer> sharedStatus,
+                                       arangodb::velocypack::Builder& builder,
                                        TRI_voc_tick_t& fetchTick, TRI_voc_tick_t& lastScannedTick,
                                        TRI_voc_tick_t firstRegularTick, uint64_t& ignoreCount,
                                        bool& worked, bool& mustFetchBatch) {
@@ -1996,9 +2000,11 @@ Result TailingSyncer::processLeaderLog(std::shared_ptr<Syncer::JobSynchronizer> 
     });
   }
 
+  TRI_ASSERT(builder.isEmpty());
+
   ApplyStats applyStats;
   double time = TRI_microtime();
-  Result r = applyLog(response.get(), firstRegularTick, applyStats, ignoreCount);
+  Result r = applyLog(response.get(), firstRegularTick, applyStats, builder, ignoreCount);
   time = TRI_microtime() - time;
       
   _stats.numProcessedMarkers += applyStats.processedMarkers;

--- a/arangod/Replication/TailingSyncer.h
+++ b/arangod/Replication/TailingSyncer.h
@@ -135,7 +135,8 @@ class TailingSyncer : public Syncer {
 
   /// @brief apply the data from the continuous log
   Result applyLog(httpclient::SimpleHttpResult*, TRI_voc_tick_t firstRegularTick,
-                  ApplyStats& applyStats, uint64_t& ignoreCount);
+                  ApplyStats& applyStats, arangodb::velocypack::Builder& builder,
+                  uint64_t& ignoreCount);
 
   /// @brief perform a continuous sync with the leader
   Result runContinuousSync();
@@ -167,6 +168,7 @@ class TailingSyncer : public Syncer {
 
   /// @brief apply continuous synchronization data from a batch
   arangodb::Result processLeaderLog(std::shared_ptr<Syncer::JobSynchronizer> sharedStatus,
+                                    arangodb::velocypack::Builder& builder,
                                     TRI_voc_tick_t& fetchTick, TRI_voc_tick_t& lastScannedTick,
                                     TRI_voc_tick_t firstRegularTick, uint64_t& ignoreCount,
                                     bool& worked, bool& mustFetchBatch);

--- a/arangod/Replication/utilities.h
+++ b/arangod/Replication/utilities.h
@@ -123,16 +123,20 @@ struct ProgressInfo {
 };
 
 struct LeaderInfo {
+ private:
+  LeaderInfo() = default; // used only internally
+
+ public:
   std::string endpoint;
   std::string engine;  // storage engine (optional)
   ServerId serverId{0};
   int majorVersion{0};
   int minorVersion{0};
-  TRI_voc_tick_t lastLogTick{0};
-  TRI_voc_tick_t lastUncommittedLogTick{0};
-  bool active{false};
+  TRI_voc_tick_t lastLogTick{0}; // only used during initialSync
 
   explicit LeaderInfo(ReplicationApplierConfiguration const& applierConfig);
+
+  static LeaderInfo createEmpty() { return LeaderInfo(); }
 
   /// @brief returns major version number * 10000 + minor version number * 100
   uint64_t version() const;
@@ -163,7 +167,8 @@ struct BatchInfo {
   /// @param patchCount try to patch count of this collection
   ///        only effective with the incremental sync
   Result start(Connection const& connection, ProgressInfo& progress, LeaderInfo& leader,
-               SyncerId syncerId, std::string const& patchCount = "");
+               SyncerId const& syncerId, char const* context, 
+               std::string const& patchCount = "");
 
   /// @brief send an "extend batch" command
   Result extend(Connection const& connection, ProgressInfo& progress, SyncerId syncerId);

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -2097,9 +2097,9 @@ void RestReplicationHandler::handleCommandSync() {
   std::shared_ptr<InitialSyncer> syncer;
 
   if (isGlobal) {
-    syncer.reset(new GlobalInitialSyncer(config));
+    syncer = GlobalInitialSyncer::create(config);
   } else {
-    syncer.reset(new DatabaseInitialSyncer(_vocbase, config));
+    syncer = DatabaseInitialSyncer::create(_vocbase, config);
   }
 
   Result r = syncer->run(config._incremental);

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2454,11 +2454,18 @@ Result RocksDBEngine::createLoggerState(TRI_vocbase_t* vocbase, VPackBuilder& bu
 
   // "state" part
   builder.add("state", VPackValue(VPackValueType::Object));  // open
+
+  // always hard-coded to true
   builder.add("running", VPackValue(true));
+
   builder.add("lastLogTick", VPackValue(std::to_string(lastTick)));
+
+  // not used anymore in 3.8:
   builder.add("lastUncommittedLogTick", VPackValue(std::to_string(lastTick)));
-  builder.add("totalEvents",
-              VPackValue(lastTick));  // s.numEvents + s.numEventsSync
+
+  // not used anymore in 3.8:
+  builder.add("totalEvents", VPackValue(lastTick));  
+
   builder.add("time", VPackValue(utilities::timeString()));
   builder.close();
 

--- a/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
@@ -279,6 +279,41 @@ Result RocksDBReplicationContext::getInventory(TRI_vocbase_t& vocbase, bool incl
 
   return Result();
 }
+
+// returns a stripped down version of the inventory, used for shard synchronization only
+Result RocksDBReplicationContext::getInventory(TRI_vocbase_t& vocbase,
+                                               std::string const& collectionName,
+                                               VPackBuilder& result) {
+  {
+    MUTEX_LOCKER(locker, _contextLock);
+    lazyCreateSnapshot();
+  }
+
+  TRI_ASSERT(_snapshot != nullptr);
+
+  // add a "collections" array with just our collection
+  result.add("collections", VPackValue(VPackValueType::Array));
+      
+  ExecContext const& exec = ExecContext::current();
+  if (exec.canUseCollection(vocbase.name(), collectionName, auth::Level::RO)) {
+    auto collection = vocbase.lookupCollection(collectionName);
+    if (collection->status() != TRI_VOC_COL_STATUS_DELETED &&
+        collection->status() != TRI_VOC_COL_STATUS_CORRUPTED) {
+      // dump inventory data for collection/shard into result
+      collection->toVelocyPackForInventory(result);
+    }
+  }
+
+  result.close(); // collections
+  
+  // fake an empty "views" array here
+  result.add("views", VPackValue(VPackValueType::Array));
+  result.close(); // views
+
+  vocbase.replicationClients().track(syncerId(), replicationClientServerId(), clientInfo(), _snapshotTick, _ttl);
+
+  return Result();
+}
   
 void RocksDBReplicationContext::setPatchCount(std::string const& patchCount) {
   // _patchCount can only be set once in a context, and if it is set, it should be non-empty.

--- a/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
@@ -297,10 +297,12 @@ Result RocksDBReplicationContext::getInventory(TRI_vocbase_t& vocbase,
   ExecContext const& exec = ExecContext::current();
   if (exec.canUseCollection(vocbase.name(), collectionName, auth::Level::RO)) {
     auto collection = vocbase.lookupCollection(collectionName);
-    if (collection->status() != TRI_VOC_COL_STATUS_DELETED &&
-        collection->status() != TRI_VOC_COL_STATUS_CORRUPTED) {
-      // dump inventory data for collection/shard into result
-      collection->toVelocyPackForInventory(result);
+    if (collection != nullptr) {
+      if (collection->status() != TRI_VOC_COL_STATUS_DELETED &&
+          collection->status() != TRI_VOC_COL_STATUS_CORRUPTED) {
+        // dump inventory data for collection/shard into result
+        collection->toVelocyPackForInventory(result);
+      }
     }
   }
 

--- a/arangod/RocksDBEngine/RocksDBReplicationContext.h
+++ b/arangod/RocksDBEngine/RocksDBReplicationContext.h
@@ -148,6 +148,10 @@ class RocksDBReplicationContext {
   Result getInventory(TRI_vocbase_t& vocbase, bool includeSystem,
                       bool includeFoxxQueues, bool global,
                       velocypack::Builder&);
+  
+  // returns inventory for a single shard (DB server only!)
+  Result getInventory(TRI_vocbase_t& vocbase, std::string const& collectionName,
+                      velocypack::Builder&);
 
   void setPatchCount(std::string const& patchCount);
   std::string const& patchCount() const;

--- a/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
@@ -103,11 +103,40 @@ void RocksDBRestReplicationHandler::handleCommandBatch() {
             << " collection count patching: " << res.errorMessage();
       }
     }
+    
+    std::string const snapTick = std::to_string(ctx->snapshotTick());
+    bool withState = _request->parsedValue("state", false);
 
     VPackBuilder b;
-    b.add(VPackValue(VPackValueType::Object));
+    b.openObject();
     b.add("id", VPackValue(std::to_string(ctx->id())));  // id always string
-    b.add("lastTick", VPackValue(std::to_string(ctx->snapshotTick())));
+    b.add("lastTick", VPackValue(snapTick));
+    if (withState) {
+      // we have been asked to also return the "state" attribute. 
+      // this is used from 3.8 onwards during shard synchronization, in order
+      // to combine the two requests for starting a batch and fetching the
+      // leader state into a single one.
+      
+      // get original logger state data
+      VPackBuilder tmp;
+      engine.createLoggerState(nullptr, tmp);
+      TRI_ASSERT(tmp.slice().isObject());
+      
+      // and now merge it into our response, while rewriting the "lastLogTick"
+      // and "lastUncommittedLogTick"
+      b.add("state", VPackValue(VPackValueType::Object));
+      for (auto it : VPackObjectIterator(tmp.slice())) {
+        if (it.key.stringRef() == "lastLogTick" ||
+            it.key.stringRef() == "lastUncommittedLogTick") {
+          // put into the tick from our own snapshot
+          b.add(it.key.stringRef(), VPackValue(snapTick));
+        } else {
+          // write our other attributes as they are
+          b.add(it.key.stringRef(), it.value);
+        }
+      }
+      b.close(); // state
+    }
     b.close();
 
     _vocbase.replicationClients().track(syncerId, clientId, clientInfo,

--- a/arangod/V8Server/v8-replication.cpp
+++ b/arangod/V8Server/v8-replication.cpp
@@ -220,7 +220,7 @@ static void SynchronizeReplication(v8::FunctionCallbackInfo<v8::Value> const& ar
 
   if (applierType == APPLIER_DATABASE) {
     // database-specific synchronization
-    syncer.reset(new DatabaseInitialSyncer(vocbase, configuration));
+    syncer = DatabaseInitialSyncer::create(vocbase, configuration);
 
     if (TRI_HasProperty(context, isolate, object, "leaderId")) {
       syncer->setLeaderId(TRI_ObjectToString(
@@ -230,7 +230,7 @@ static void SynchronizeReplication(v8::FunctionCallbackInfo<v8::Value> const& ar
     }
   } else if (applierType == APPLIER_GLOBAL) {
     configuration._skipCreateDrop = false;
-    syncer.reset(new GlobalInitialSyncer(configuration));
+    syncer = GlobalInitialSyncer::create(configuration);
   } else {
     TRI_ASSERT(false);
   }

--- a/arangod/VocBase/LogicalCollection.h
+++ b/arangod/VocBase/LogicalCollection.h
@@ -234,6 +234,8 @@ class LogicalCollection : public LogicalDataSource {
 
   velocypack::Builder toVelocyPackIgnore(std::unordered_set<std::string> const& ignoreKeys,
                                          Serialization context) const;
+  
+  void toVelocyPackForInventory(velocypack::Builder&) const;
 
   virtual void toVelocyPackForClusterInventory(velocypack::Builder&, bool useSystem,
                                                bool isReady, bool allInSync) const;

--- a/js/client/modules/@arangodb/testutils/test-utils.js
+++ b/js/client/modules/@arangodb/testutils/test-utils.js
@@ -888,7 +888,6 @@ function runInLocalArangosh (options, instanceInfo, file, addArgs) {
   }
 
   let testCode = getTestCode(file, options, instanceInfo);
-  print(testCode);
   require('internal').env.INSTANCEINFO = JSON.stringify(instanceInfo);
   let testFunc;
   try {


### PR DESCRIPTION
### Scope & Purpose

Improve performance of shard synchronization protocol by calling a special version of the inventory, which will only return structural information for the requested shard, and not for all shards in the requested database. This can reduce the amount of data transferred in case there are many shards present and they are mostly in sync.

The smaller response format is triggered by sending the "collection" URL parameter to the `/_api/replication/inventory` endpoint. This is an optional parameter, so there shouldn't be any issues if it is not set in any request.

In 3.8, the shard synchronization will use that smaller format by default, by setting that URL parameter when calling the inventory during shard synchronization. 
Any calls from a 3.7 follower to a 3.8 leader will get the same (verbose) answers as before, as 3.7 will need send the new URL parameter.
In addition, asking a 3.7 leader for the smaller format from a 3.8 follower will also produce the previous (verbose) answers, because 3.7 will not check for the new URL parameter.

The URL parameter is supposed to be used internally, in DB server-to-DB server communication.

In addition, this PR saves 3 cluster-internal requests per shard in the initial shard synchronization protocol by reusing already existing information across the different steps of the replication process.
The first request is saved by combining the two previously separate requests for fetching the leader's state and the starting of a replication batch in the `DatabaseInitialSyncer`.
Another request is saved in the `DatabaseTailingSyncer` by not querying the leader state again, because we can simply reuse the leader state from the DatabaseInitialSyncer her. As there are two usages of the `DatabaseTailingSyncer` during shard synchronization, we save twice.
This sums up to 3 saved requests per shard.

TODO: should be added to arangosync as well, in case it uses this API.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *all cluster tests*.
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in http_replication)

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13712/