### PR TITLE
StringUtils concat and join

### DIFF
--- a/lib/Basics/StringUtils.h
+++ b/lib/Basics/StringUtils.h
@@ -418,7 +418,7 @@ std::string decodeHex(std::string const& value);
 void escapeRegexParams(std::string& out, const char* ptr, size_t length);
 std::string escapeRegexParams(std::string const& in);
 
-namespace impl {
+namespace detail {
 template <typename T>
 auto constexpr isStringOrView = std::is_same_v<std::string, std::decay_t<T>> ||
                                 std::is_same_v<std::string_view, std::decay_t<T>>;
@@ -493,7 +493,7 @@ auto joinImplStr(std::string_view delim, Args&&... args) -> std::string {
     return joinImplIter(delim, std::make_pair(args.begin(), args.end())...);
   }
 }
-}  // namespace impl
+}  // namespace detail
 
 /// @brief Creates a string concatenation of all its arguments.
 /// Arguments that aren't either a std::string, std::string_view,
@@ -501,7 +501,7 @@ auto joinImplStr(std::string_view delim, Args&&... args) -> std::string {
 /// or via `to_string`.
 template <typename... Args>
 auto concatT(Args&&... args) -> std::string {
-  return impl::concatImplStr(impl::toStringOrView(args)...);
+  return detail::concatImplStr(detail::toStringOrView(args)...);
 }
 
 /// @brief Creates a string, joining all of its arguments delimited by delim.
@@ -510,7 +510,7 @@ auto concatT(Args&&... args) -> std::string {
 /// or via `to_string`.
 template <typename... Args>
 auto joinT(std::string_view delim, Args&&... args) -> std::string {
-  return impl::joinImplStr(delim, impl::toStringOrView(args)...);
+  return detail::joinImplStr(delim, detail::toStringOrView(args)...);
 }
 
 }  // namespace StringUtils

--- a/lib/Basics/StringUtils.h
+++ b/lib/Basics/StringUtils.h
@@ -35,6 +35,7 @@
 #include <vector>
 
 #include "Basics/Common.h"
+#include "Basics/debugging.h"
 
 // use non-throwing, non-allocating std::from_chars etc. from standard library
 
@@ -443,7 +444,7 @@ template <typename... Iters>
 auto concatImplIter(std::pair<Iters, Iters>&&... iters) -> std::string {
   auto result = std::string{};
 
-  constexpr auto newcap = (std::distance(iters.first, iters.second) + ... + 0);
+  auto const newcap = (std::distance(iters.first, iters.second) + ... + 0);
   result.reserve(newcap);
 
   ([&] { result.append(iters.first, iters.second); }(), ...);

--- a/lib/Basics/StringUtils.h
+++ b/lib/Basics/StringUtils.h
@@ -443,9 +443,12 @@ template <typename... Iters>
 auto concatImplIter(std::pair<Iters, Iters>&&... iters) -> std::string {
   auto result = std::string{};
 
-  result.reserve((std::distance(iters.first, iters.second) + ... + 0));
+  constexpr auto newcap = (std::distance(iters.first, iters.second) + ... + 0);
+  result.reserve(newcap);
 
   ([&] { result.append(iters.first, iters.second); }(), ...);
+
+  TRI_ASSERT(newcap == result.length());
 
   return result;
 }
@@ -467,7 +470,8 @@ auto joinImplIter(std::string_view delim, std::pair<Iter, Iter>&& head,
   auto const valueSizes = std::distance(head.first, head.second) +
                           (std::distance(tail.first, tail.second) + ... + 0);
   auto const delimSizes = sizeof...(Iters) * delim.size();
-  result.reserve(valueSizes + delimSizes);
+  auto const newcap = valueSizes + delimSizes;
+  result.reserve(newcap);
 
   result.append(head.first, head.second);
 
@@ -477,6 +481,8 @@ auto joinImplIter(std::string_view delim, std::pair<Iter, Iter>&& head,
         result.append(tail.first, tail.second);
       }(),
       ...);
+
+  TRI_ASSERT(newcap == result.length());
 
   return result;
 }

--- a/lib/Basics/StringUtils.h
+++ b/lib/Basics/StringUtils.h
@@ -444,7 +444,8 @@ template <typename... Iters>
 auto concatImplIter(std::pair<Iters, Iters>&&... iters) -> std::string {
   auto result = std::string{};
 
-  auto const newcap = (std::distance(iters.first, iters.second) + ... + 0);
+  auto const newcap =
+      static_cast<std::size_t>((std::distance(iters.first, iters.second) + ... + 0));
   result.reserve(newcap);
 
   ([&] { result.append(iters.first, iters.second); }(), ...);

--- a/tests/Basics/StringUtilsTest.cpp
+++ b/tests/Basics/StringUtilsTest.cpp
@@ -357,7 +357,7 @@ TEST_F(StringUtilsTest, concatT) {
   EXPECT_EQ("", StringUtils::concatT(""s));
   EXPECT_EQ("", StringUtils::concatT(""sv));
   EXPECT_EQ("42", StringUtils::concatT(42));
-  EXPECT_EQ("2.5", StringUtils::concatT(2.5));
+  EXPECT_EQ("2.500000", StringUtils::concatT(2.5));
   EXPECT_EQ("hello, world", StringUtils::concatT("hello", ", ", "world"));
   EXPECT_EQ("cstr 42 stdstr view",
             StringUtils::concatT("cstr ", 42, " stdstr "s, "view"sv));
@@ -371,11 +371,11 @@ TEST_F(StringUtilsTest, joinT) {
   EXPECT_EQ("", StringUtils::joinT(", "sv, ""s));
   EXPECT_EQ("", StringUtils::joinT(", "sv, ""sv));
   EXPECT_EQ("42", StringUtils::joinT(", "sv, 42));
-  EXPECT_EQ("2.5", StringUtils::joinT(", "sv, 2.5));
+  EXPECT_EQ("2.500000", StringUtils::joinT(", "sv, 2.5));
   EXPECT_EQ(", ", StringUtils::joinT(", "sv, "", ""));
   EXPECT_EQ(", , ", StringUtils::joinT(", "sv, "", "", ""));
   EXPECT_EQ("hello, world", StringUtils::joinT(", "sv, "hello", "world"));
   EXPECT_EQ("hello, world", StringUtils::joinT(""sv, "hello", ", ", "world"));
-  EXPECT_EQ("cstr 42 stdstr view", StringUtils::joinT(""sv, "cstr ", 42, "stdstr "s, "view"sv));
+  EXPECT_EQ("cstr 42 stdstr view", StringUtils::joinT(""sv, "cstr ", 42, " stdstr "s, "view"sv));
   EXPECT_EQ("cstr, 42, stdstr, view", StringUtils::joinT(", "sv, "cstr", 42, "stdstr"s, "view"sv));
 }

--- a/tests/Basics/StringUtilsTest.cpp
+++ b/tests/Basics/StringUtilsTest.cpp
@@ -348,3 +348,34 @@ TEST_F(StringUtilsTest, test_encodeURLComponent) {
   StringUtils::encodeURIComponent(result, ".!:$%@b013/-", 12);
   EXPECT_EQ("%20%25abcabc%20abc.!%3A%24%25%40b013%2F-", result);
 }
+
+TEST_F(StringUtilsTest, concatT) {
+  using namespace std::string_literals;
+  using namespace std::string_view_literals;
+  EXPECT_EQ("", StringUtils::concatT());
+  EXPECT_EQ("", StringUtils::concatT(""));
+  EXPECT_EQ("", StringUtils::concatT(""s));
+  EXPECT_EQ("", StringUtils::concatT(""sv));
+  EXPECT_EQ("42", StringUtils::concatT(42));
+  EXPECT_EQ("2.5", StringUtils::concatT(2.5));
+  EXPECT_EQ("hello, world", StringUtils::concatT("hello", ", ", "world"));
+  EXPECT_EQ("cstr 42 stdstr view",
+            StringUtils::concatT("cstr ", 42, " stdstr "s, "view"sv));
+}
+
+TEST_F(StringUtilsTest, joinT) {
+  using namespace std::string_literals;
+  using namespace std::string_view_literals;
+  EXPECT_EQ("", StringUtils::joinT(", "sv));
+  EXPECT_EQ("", StringUtils::joinT(", "sv, ""));
+  EXPECT_EQ("", StringUtils::joinT(", "sv, ""s));
+  EXPECT_EQ("", StringUtils::joinT(", "sv, ""sv));
+  EXPECT_EQ("42", StringUtils::joinT(", "sv, 42));
+  EXPECT_EQ("2.5", StringUtils::joinT(", "sv, 2.5));
+  EXPECT_EQ(", ", StringUtils::joinT(", "sv, "", ""));
+  EXPECT_EQ(", , ", StringUtils::joinT(", "sv, "", "", ""));
+  EXPECT_EQ("hello, world", StringUtils::joinT(", "sv, "hello", "world"));
+  EXPECT_EQ("hello, world", StringUtils::joinT(""sv, "hello", ", ", "world"));
+  EXPECT_EQ("cstr 42 stdstr view", StringUtils::joinT(""sv, "cstr ", 42, "stdstr "s, "view"sv));
+  EXPECT_EQ("cstr, 42, stdstr, view", StringUtils::joinT(", "sv, "cstr", 42, "stdstr"s, "view"sv));
+}


### PR DESCRIPTION
### Scope & Purpose

Added variadic `concat` and `join` functions to `StringUtils`.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [X] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [X] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [X] This PR adds tests that were used to verify all changes:
  - [X] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
