### PR TITLE
disable OldSubqueriesTest g++ unit test if USE_FAILURE_TESTS=Off

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -126,7 +126,6 @@ set(ARANGODB_TESTS_SOURCES
   Aql/NgramSimilarityFunctionTest.cpp
   Aql/NgramPosSimilarityFunctionTest.cpp
   Aql/NoResultsExecutorTest.cpp
-  Aql/OldSubqueriesTest.cpp
   Aql/ProjectionsTest.cpp
   Aql/QueryHelper.cpp
   Aql/RegisterPlanTest.cpp
@@ -268,6 +267,12 @@ set(ARANGODB_TESTS_SOURCES
   VocBase/LogicalView-test.cpp
   VocBase/VersionTest.cpp
   VPackDeserializer/BasicTests.cpp)
+
+if (USE_FAILURE_TESTS)
+  # add test that depends on USE_FAILURE_TESTS
+  set(ARANGODB_TESTS_SOURCES ${ARANGODB_TESTS_SOURCES} Aql/OldSubqueriesTest.cpp)
+endif ()
+
 
 if (LINUX)
   # add "-fno-var-tracking" to the compiler flags


### PR DESCRIPTION
### Scope & Purpose

The g++ unit test in `tests/Aql/OldSubqueriesTest.cpp` depends on the build being compiled with the `USE_FAILURE_TESTS=On` build option.
If the option is not set, the test will fail.

This PR hopefully fixes it, and only compiles and links the OldSubqueriesTest g++ unit test if `USE_FAILURE_TEST=On`.
It should not have any effect on end users. Because it is an internal change to the tests and only affects devel, there is intentionally no CHANGELOG entry written for it.

- [x] :hankey: Bugfix (~requires CHANGELOG entry~)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13736/