### PR TITLE
Fixed a too eager fast forwarding in ID executor.

### DIFF
--- a/arangod/Aql/AqlItemBlockInputRange.cpp
+++ b/arangod/Aql/AqlItemBlockInputRange.cpp
@@ -149,6 +149,15 @@ size_t AqlItemBlockInputRange::skipAllRemainingDataRows() {
   return 0;
 }
 
+size_t AqlItemBlockInputRange::countAndSkipAllRemainingDataRows() {
+  size_t skipped = 0;
+  while (hasDataRow()) {
+    ++_rowIndex;
+    ++skipped;
+  }
+  return skipped;
+}
+
 size_t AqlItemBlockInputRange::skipAllShadowRowsOfDepth(size_t depth) {
   size_t skipped = 0;
   while (hasValidRow()) {

--- a/arangod/Aql/AqlItemBlockInputRange.h
+++ b/arangod/Aql/AqlItemBlockInputRange.h
@@ -104,6 +104,12 @@ class AqlItemBlockInputRange {
 
   [[nodiscard]] auto finalState() const noexcept -> ExecutorState;
 
+  /**
+   * @brief Skip over all remaining data rows until the next shadow row.
+   * Count how many rows are skipped
+   */
+  [[nodiscard]] auto countAndSkipAllRemainingDataRows() -> std::size_t;
+
  private:
   bool isIndexValid(std::size_t index) const noexcept;
 

--- a/arangod/Aql/IdExecutor.cpp
+++ b/arangod/Aql/IdExecutor.cpp
@@ -80,7 +80,6 @@ auto IdExecutor<UsedFetcher>::produceRows(AqlItemBlockInputRange& inputRange,
                                           OutputAqlItemRow& output)
     -> std::tuple<ExecutorState, CountStats, AqlCall> {
   CountStats stats;
-  TRI_ASSERT(output.numRowsWritten() == 0);
   if (inputRange.hasDataRow()) {
     TRI_ASSERT(!output.isFull());
     TRI_IF_FAILURE("SingletonBlock::getOrSkipSome") {
@@ -88,9 +87,9 @@ auto IdExecutor<UsedFetcher>::produceRows(AqlItemBlockInputRange& inputRange,
     }
     auto const& [state, inputRow] = inputRange.peekDataRow();
 
-    output.fastForwardAllRows(inputRow, inputRange.countDataRows());
+    size_t rows = inputRange.countAndSkipAllRemainingDataRows();
 
-    std::ignore = inputRange.skipAllRemainingDataRows();
+    output.fastForwardAllRows(inputRow, rows);
 
     TRI_IF_FAILURE("SingletonBlock::getOrSkipSomeSet") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);

--- a/tests/Aql/IdExecutorTest.cpp
+++ b/tests/Aql/IdExecutorTest.cpp
@@ -39,6 +39,7 @@
 #include "Aql/Query.h"
 #include "Aql/RegisterInfos.h"
 #include "Aql/Stats.h"
+#include "Aql/SubqueryStartExecutor.h"
 #include "Basics/ResourceUsage.h"
 
 #include <velocypack/velocypack-aliases.h>
@@ -267,7 +268,17 @@ INSTANTIATE_TEST_CASE_P(IdExecutorTest, IdExecutorTestCombiner,
                         ::testing::Combine(inputs, upstreamStates, clientCalls,
                                            ::testing::Bool()));
 
-class IdExecutionBlockTest : public AqlExecutorTestCase<> {};
+class IdExecutionBlockTest : public AqlExecutorTestCase<> {
+ protected:
+  auto makeSubqueryRegisterInfos(size_t nestingLevel) -> RegisterInfos {
+    TRI_ASSERT(nestingLevel > 0);
+    RegIdSetStack toKeepStack{};
+    for (size_t i = 0; i < nestingLevel; ++i) {
+      toKeepStack.emplace_back(RegIdSet{0});
+    }
+    return RegisterInfos(RegIdSet{0}, {}, 1, 1, {}, std::move(toKeepStack));
+  }
+};
 
 // The IdExecutor has a specific initializeCursor method in ExecutionBlockImpl
 TEST_F(IdExecutionBlockTest, test_initialize_cursor_get) {
@@ -408,6 +419,26 @@ TEST_F(IdExecutionBlockTest, test_hardlimit_single_row_fetcher) {
       .setCall(AqlCall{0, AqlCall::Infinity{}, 2u, false})
       .expectOutput({0}, {{1}, {2}})
       .expectSkipped(0)
+      .expectedState(ExecutionState::DONE)
+      .run();
+}
+
+TEST_F(IdExecutionBlockTest, test_in_subquery) {
+  RegisterInfos registerInfos{{}, {}, 1, 1, {}, {RegIdSet{0}}};
+  IdExecutorInfos executorInfos{false};
+  AqlCallStack callStack{AqlCallList{AqlCall{}}};
+  callStack.pushCall(AqlCallList{AqlCall{}, AqlCall{}});
+  makeExecutorTestHelper()
+      .addConsumer<SubqueryStartExecutor>(makeSubqueryRegisterInfos(2),
+                                          makeSubqueryRegisterInfos(2),
+                                          ExecutionNode::SUBQUERY_START)
+      .addConsumer<IdExecutor<SingleRowFetcher<BlockPassthrough::Enable>>>(
+          std::move(registerInfos), std::move(executorInfos))
+      .setInputValueList(1, 2, 3, 4)
+      .setCallStack(callStack)
+      .expectOutput({0}, {{1}, {1}, {2}, {2}, {3}, {3}, {4}, {4}},
+                    {{1, 0}, {3, 0}, {5, 0}, {7, 0}})
+      .expectSkipped(0, 0)
       .expectedState(ExecutionState::DONE)
       .run();
 }


### PR DESCRIPTION
### Scope & Purpose

This changes the method a IDExecutor skips over rows.
There are some assertions that it does not skip over shadowRows during i'ts produce phase (violates the API)
which have not ben triggered by our tests.
However as the IDExecutor will always skip over the entire input, this API violation is not relevant, it just does the operation in a different way than intended.
Now we explicitly only forward up to the next shadow row in produce.

=> No User Impact
=> No Changelog

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:

http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/13739/

### Documentation

> All new features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the CHANGELOG so that
> support, end users, and other developers have a concise overview. 

- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
