### PR TITLE
Various micro-optimizations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,14 @@
 devel
 -----
+          
+* Added metric `arangodb_transactions_expired` to track the total number 
+  of expired and then garbage-collected transactions.
 
 * Allow toggling the document read/write counters and histograms via the
   new startup option `--server.export-read-write-metrics false`. This 
   option defaults to `true`, so these metrics will be exposed by default.
 
-* Upgrade libunwind to v1.5.
+* Upgraded bundled version of libunwind to v1.5.
 
 * Added startup option `--javascript.tasks` to allow turning off JavaScript 
   tasks if not needed. The default value for this option is `true`, meaning 
@@ -52,7 +55,9 @@ devel
   - `arangodb_collection_truncates_replication`: Total number of collection 
     truncate operations (successful and failed) by synchronous replication.
   - `arangodb_document_read_time`: Execution time histogram of all document 
-    read operations (successful and failed) [s].
+    primary key read operations (successful and failed) [s]. Note: this 
+    does not include secondary index lookups, range scans and full collection
+    scans.
   - `arangodb_document_insert_time`: Execution time histogram of all 
     document insert operations (successful and failed) [s].
   - `arangodb_document_replace_time`: Execution time histogram of all 

--- a/arangod/Cluster/ClusterTrxMethods.cpp
+++ b/arangod/Cluster/ClusterTrxMethods.cpp
@@ -41,6 +41,7 @@
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Slice.h>
+#include <velocypack/StringRef.h>
 #include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
@@ -125,7 +126,7 @@ void buildTransactionBody(TransactionState& state, ServerID const& server,
   builder.close();  // </openObject>
 }
 
-/// @brief lazy begin a transaction on subordinate servers
+/// @brief lazily begin a transaction on subordinate servers
 Future<network::Response> beginTransactionRequest(TransactionState& state,
                                                   ServerID const& server) {
   TransactionId tid = state.id().child();
@@ -150,46 +151,53 @@ Future<network::Response> beginTransactionRequest(TransactionState& state,
 /// check the transaction cluster response with desited TID and status
 Result checkTransactionResult(TransactionId desiredTid, transaction::Status desStatus,
                               network::Response const& resp) {
-  int commError = network::fuerteToArangoErrorCode(resp);
-  if (commError != TRI_ERROR_NO_ERROR) {
-    // oh-oh cluster is in a bad state
-    return Result(commError);
+  Result r = resp.combinedResult();
+
+  if (resp.fail()) {
+    // communication error
+    return r;
   }
 
-  VPackSlice answer = resp.slice();
-  if ((resp.statusCode() == fuerte::StatusOK || resp.statusCode() == fuerte::StatusCreated) &&
+  // whatever we got can contain a success (HTTP 2xx) or an error (HTTP >= 400) 
+  if (VPackSlice answer = resp.slice(); (resp.statusCode() == fuerte::StatusOK || resp.statusCode() == fuerte::StatusCreated) &&
       answer.isObject()) {
-    VPackSlice idSlice = answer.get(std::vector<std::string>{"result", "id"});
-    VPackSlice statusSlice =
-        answer.get(std::vector<std::string>{"result", "status"});
+    //VPackSlice idSlice = answer.get(std::vector<std::string>{"result", "id"});
+    //VPackSlice statusSlice =
+    //    answer.get(std::vector<std::string>{"result", "status"});
+    VPackSlice idSlice = answer.get({"result", "id"});
+    VPackSlice statusSlice = answer.get({"result", "status"});
+
 
     if (!idSlice.isString() || !statusSlice.isString()) {
-      return Result(TRI_ERROR_TRANSACTION_INTERNAL,
-                    "transaction has wrong format");
+      return r.reset(TRI_ERROR_TRANSACTION_INTERNAL, "transaction has wrong format");
     }
-    TransactionId tid{StringUtils::uint64(idSlice.copyString())};
-    VPackValueLength len = 0;
-    const char* str = statusSlice.getStringUnchecked(len);
-    if (tid == desiredTid && transaction::statusFromString(str, len) == desStatus) {
-      return Result();  // success
-    }
-  } else if (answer.isObject()) {
-    std::string msg = std::string(" (error while ");
-    if (desStatus == transaction::Status::RUNNING) {
-      msg.append("beginning transaction)");
-    } else if (desStatus == transaction::Status::COMMITTED) {
-      msg.append("committing transaction)");
-    } else if (desStatus == transaction::Status::ABORTED) {
-      msg.append("aborting transaction)");
-    }
-    Result res = network::resultFromBody(answer, TRI_ERROR_TRANSACTION_INTERNAL);
-    res.appendErrorMessage(msg);
-    return res;
-  }
-  LOG_TOPIC("fb343", DEBUG, Logger::TRANSACTIONS)
-      << "failed to begin transaction on " << resp.destination;
 
-  return Result(TRI_ERROR_TRANSACTION_INTERNAL);  // unspecified error
+    VPackStringRef idRef = idSlice.stringRef();
+    TransactionId tid{StringUtils::uint64(idRef.data(), idRef.size())};
+    VPackStringRef statusRef = statusSlice.stringRef();
+    if (tid == desiredTid && transaction::statusFromString(statusRef.data(), statusRef.size()) == desStatus) {
+      // all good
+      return r.reset();
+    }
+  }
+  
+  if (!r.fail()) {
+    r.reset(TRI_ERROR_TRANSACTION_INTERNAL);
+  }
+    
+  TRI_ASSERT(r.fail());
+  std::string msg(" (error while ");
+  if (desStatus == transaction::Status::RUNNING) {
+    msg.append("beginning transaction on ");
+  } else if (desStatus == transaction::Status::COMMITTED) {
+    msg.append("committing transaction on ");
+  } else if (desStatus == transaction::Status::ABORTED) {
+    msg.append("aborting transaction on ");
+  }
+  msg.append(resp.destination);
+  msg.append(")");
+  r.appendErrorMessage(msg);
+  return r;
 }
 
 Future<Result> commitAbortTransaction(arangodb::TransactionState* state,
@@ -211,7 +219,7 @@ Future<Result> commitAbortTransaction(arangodb::TransactionState* state,
   reqOpts.database = state->vocbase().name();
 
   TransactionId tidPlus = state->id().child();
-  const std::string path = "/_api/transaction/" + std::to_string(tidPlus.id());
+  std::string const path = "/_api/transaction/" + std::to_string(tidPlus.id());
   if (state->isDBServer()) {
     // This is a leader replicating the transaction commit or abort and
     // we should tell the follower that this is a replication operation.
@@ -242,15 +250,16 @@ Future<Result> commitAbortTransaction(arangodb::TransactionState* state,
         if (state->isCoordinator()) {
           TRI_ASSERT(state->id().isCoordinatorTransactionId());
 
+          Result res;
           for (Try<arangodb::network::Response> const& tryRes : responses) {
             network::Response const& resp = tryRes.get();  // throws exceptions upwards
             Result res = ::checkTransactionResult(tidPlus, status, resp);
             if (res.fail()) {
-              return res;
+              break;
             }
           }
 
-          return Result();
+          return res;
         }
 
         TRI_ASSERT(state->isDBServer());
@@ -261,11 +270,11 @@ Future<Result> commitAbortTransaction(arangodb::TransactionState* state,
           network::Response const& resp = tryRes.get();  // throws exceptions upwards
 
           Result res = ::checkTransactionResult(tidPlus, status, resp);
-          if (res.fail()) {  // remove follower from all collections
+          if (res.fail()) {  // remove followers for all participating collections
             ServerID follower = resp.serverId();
             LOG_TOPIC("230c3", INFO, Logger::REPLICATION)
-                << "synchronous replication: dropping follower " << follower
-                << " for all participating shards in"
+                << "synchronous replication of transaction commit/abort operation: "
+                << "dropping follower " << follower << " for all participating shards in"
                 << " transaction " << state->id().id() << " (status "
                 << arangodb::transaction::statusString(status)
                 << "), status code: " << static_cast<int>(resp.statusCode())
@@ -274,16 +283,16 @@ Future<Result> commitAbortTransaction(arangodb::TransactionState* state,
               auto cc = tc.collection();
               if (cc) {
                 LOG_TOPIC("709c9", WARN, Logger::REPLICATION)
-                    << "synchronous replication: dropping follower " << follower
-                    << " for shard " << tc.collectionName() << " in database "
-                    << cc->vocbase().name() << ": "
+                    << "synchronous replication of transaction commit/abort operation: "
+                    << "dropping follower " << follower << " for shard " 
+                    << cc->vocbase().name() << "/" << tc.collectionName() << ": "
                     << resp.combinedResult().errorMessage();
 
                 Result r = cc->followers()->remove(follower);
                 if (r.fail()) {
                   LOG_TOPIC("4971f", ERR, Logger::REPLICATION)
-                      << "synchronous replication: could not drop follower "
-                      << follower << " for shard " << tc.collectionName()
+                      << "synchronous replication: could not drop follower " << follower
+                      << " for shard " << cc->vocbase().name() << "/" << tc.collectionName()
                       << ": " << r.errorMessage();
                   res.reset(TRI_ERROR_CLUSTER_COULD_NOT_DROP_FOLLOWER);
                 }
@@ -457,7 +466,7 @@ void addTransactionHeader(transaction::Methods const& trx,
   TRI_ASSERT(!tidPlus.isLegacyTransactionId());
   TRI_ASSERT(!state.hasHint(transaction::Hints::Hint::SINGLE_OPERATION));
 
-  const bool addBegin = !state.knowsServer(server);
+  bool const addBegin = !state.knowsServer(server);
   if (addBegin) {
     if (state.isCoordinator() && state.hasHint(transaction::Hints::Hint::FROM_TOPLEVEL_AQL)) {
       return;  // do not add header to servers without a snippet
@@ -492,7 +501,7 @@ void addAQLTransactionHeader(transaction::Methods const& trx,
   }
 
   std::string value = std::to_string(state.id().child().id());
-  const bool addBegin = !state.knowsServer(server);
+  bool const addBegin = !state.knowsServer(server);
   if (addBegin) {
     if (state.hasHint(transaction::Hints::Hint::FROM_TOPLEVEL_AQL)) {
       value.append(" aql");  // This is a single AQL query

--- a/arangod/Cluster/ClusterTrxMethods.cpp
+++ b/arangod/Cluster/ClusterTrxMethods.cpp
@@ -161,9 +161,6 @@ Result checkTransactionResult(TransactionId desiredTid, transaction::Status desS
   // whatever we got can contain a success (HTTP 2xx) or an error (HTTP >= 400) 
   if (VPackSlice answer = resp.slice(); (resp.statusCode() == fuerte::StatusOK || resp.statusCode() == fuerte::StatusCreated) &&
       answer.isObject()) {
-    //VPackSlice idSlice = answer.get(std::vector<std::string>{"result", "id"});
-    //VPackSlice statusSlice =
-    //    answer.get(std::vector<std::string>{"result", "status"});
     VPackSlice idSlice = answer.get({"result", "id"});
     VPackSlice statusSlice = answer.get({"result", "status"});
 

--- a/arangod/Cluster/ServerState.h
+++ b/arangod/Cluster/ServerState.h
@@ -127,69 +127,69 @@ class ServerState {
   /// @brief whether or not the cluster was properly initialized
   bool initialized() const { return _initialized; }
 
-  bool isSingleServer() { return isSingleServer(loadRole()); }
+  bool isSingleServer() const noexcept { return isSingleServer(loadRole()); }
 
-  static bool isSingleServer(ServerState::RoleEnum role) {
+  static bool isSingleServer(ServerState::RoleEnum role) noexcept {
     TRI_ASSERT(role != ServerState::ROLE_UNDEFINED);
     return (role == ServerState::ROLE_SINGLE);
   }
 
   /// @brief check whether the server is a coordinator
-  bool isCoordinator() { return isCoordinator(loadRole()); }
+  bool isCoordinator() const noexcept { return isCoordinator(loadRole()); }
 
   /// @brief check whether the server is a coordinator
-  static bool isCoordinator(ServerState::RoleEnum role) {
+  static bool isCoordinator(ServerState::RoleEnum role) noexcept {
     TRI_ASSERT(role != ServerState::ROLE_UNDEFINED);
     return (role == ServerState::ROLE_COORDINATOR);
   }
 
   /// @brief check whether the server is a DB server (primary or secondary)
   /// running in cluster mode.
-  bool isDBServer() { return isDBServer(loadRole()); }
+  bool isDBServer() const noexcept { return isDBServer(loadRole()); }
 
   /// @brief check whether the server is a DB server (primary or secondary)
   /// running in cluster mode.
-  static bool isDBServer(ServerState::RoleEnum role) {
+  static bool isDBServer(ServerState::RoleEnum role) noexcept {
     TRI_ASSERT(role != ServerState::ROLE_UNDEFINED);
     return (role == ServerState::ROLE_DBSERVER);
   }
 
   /// @brief whether or not the role is a cluster-related role
-  static bool isClusterRole(ServerState::RoleEnum role) {
+  static bool isClusterRole(ServerState::RoleEnum role) noexcept {
     return (role == ServerState::ROLE_DBSERVER || role == ServerState::ROLE_COORDINATOR);
   }
 
   /// @brief whether or not the role is a cluster-related role
-  bool isClusterRole() { return (isClusterRole(loadRole())); };
+  bool isClusterRole() const noexcept { return (isClusterRole(loadRole())); };
 
   /// @brief check whether the server is an agent
-  bool isAgent() { return isAgent(loadRole()); }
+  bool isAgent() const noexcept { return isAgent(loadRole()); }
 
   /// @brief check whether the server is an agent
-  static bool isAgent(ServerState::RoleEnum role) {
+  static bool isAgent(ServerState::RoleEnum role) noexcept {
     TRI_ASSERT(role != ServerState::ROLE_UNDEFINED);
     return (role == ServerState::ROLE_AGENT);
   }
 
   /// @brief check whether the server is running in a cluster
-  bool isRunningInCluster() { return isClusterRole(loadRole()); }
+  bool isRunningInCluster() const noexcept { return isClusterRole(loadRole()); }
 
   /// @brief check whether the server is running in a cluster
-  static bool isRunningInCluster(ServerState::RoleEnum role) {
+  static bool isRunningInCluster(ServerState::RoleEnum role) noexcept {
     return isClusterRole(role);
   }
 
   /// @brief check whether the server is a single or coordinator
-  bool isSingleServerOrCoordinator() const {
+  bool isSingleServerOrCoordinator() const noexcept {
     return isSingleServerOrCoordinator(loadRole());
   }
   
-  static bool isSingleServerOrCoordinator(ServerState::RoleEnum role) {
+  static bool isSingleServerOrCoordinator(ServerState::RoleEnum role) noexcept {
     return isCoordinator(role) || isSingleServer(role);
   }
 
   /// @brief get the server role
-  inline RoleEnum getRole() const { return loadRole(); }
+  inline RoleEnum getRole() const noexcept { return loadRole(); }
 
   /// @brief register with agency, create / load server ID
   bool integrateIntoCluster(RoleEnum role, std::string const& myAddr,
@@ -272,7 +272,7 @@ class ServerState {
 
  private:
   /// @brief atomically fetches the server role
-  inline RoleEnum loadRole() const {
+  inline RoleEnum loadRole() const noexcept {
     return _role.load(std::memory_order_consume);
   }
 

--- a/arangod/Cluster/TakeoverShardLeadership.cpp
+++ b/arangod/Cluster/TakeoverShardLeadership.cpp
@@ -198,11 +198,11 @@ static void handleLeadership(uint64_t planIndex, LogicalCollection& collection,
       std::vector<ServerID> currentServers = currentInfo->servers(collection.name());
       std::shared_ptr<std::vector<ServerID>> realInsyncFollowers;
 
-      if (currentServers.size() > 0) {
-        std::string& oldLeader = currentServers.at(0);
+      if (!currentServers.empty()) {
+        std::string& oldLeader = currentServers[0];
         // Check if the old leader has resigned and stopped all write
         // (if so, we can assume that all servers are still in sync)
-        if (oldLeader.at(0) == '_') {
+        if (!oldLeader.empty() && oldLeader[0] == '_') {
           // remove the underscore from the list as it is useless anyway
           oldLeader = oldLeader.substr(1);
 

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -1555,17 +1555,19 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(arangodb::LogicalCo
                   std::to_string(numberDocumentsDueToCounter));
 
       if (numberDocumentsAfterSync != numberDocumentsDueToCounter) {
-        LOG_TOPIC("118bf", WARN, Logger::REPLICATION)
-            << "number of remaining documents in collection '" + coll->name() +
-                   "' is " + std::to_string(numberDocumentsAfterSync) +
-                   " and differs from number of documents returned by "
-                   "collection count " +
-                   std::to_string(numberDocumentsDueToCounter);
-
-        // patch the document counter of the collection and the transaction
         int64_t diff = static_cast<int64_t>(numberDocumentsAfterSync) -
                        static_cast<int64_t>(numberDocumentsDueToCounter);
 
+        LOG_TOPIC("118bf", WARN, Logger::REPLICATION)
+            << "number of remaining documents in collection '" << coll->name() 
+            << "' is " << numberDocumentsAfterSync << " and differs from "
+            << "number of documents returned by collection count " << numberDocumentsDueToCounter
+            << ", documents found: " << documentsFound 
+            << ", num docs inserted: " << stats.numDocsInserted
+            << ", num docs removed: " << stats.numDocsRemoved 
+            << ", a diff of " << diff << " will be applied";
+
+        // patch the document counter of the collection and the transaction
         trx->documentCollection()->getPhysical()->adjustNumberDocuments(*trx, diff);
       }
     }

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -123,6 +123,7 @@ struct TimeTracker {
     if (statistics._exportReadWriteMetrics) {
       // metrics collection is not free. only do it if metrics are enabled
       // unit is seconds here
+      TRI_ASSERT(histogram.has_value());
       histogram->get().count(std::chrono::duration<float>(getTime() - start).count());
     }
   }

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -264,13 +264,20 @@ uint64_t RocksDBMetaCollection::recalculateCounts() {
     LOG_TOPIC("ad613", WARN, Logger::REPLICATION)
       << "inconsistent collection count detected for "
       << vocbase.name() << "/" << _logicalCollection.name()
-      << ", an offet of " << adjustment << " will be applied";
+      << ": counted value: " << count << ", snapshot value: " << snapNumberOfDocuments 
+      << ", current value: " << _meta.numberDocuments()
+      << ",  an offet of " << adjustment << " will be applied";
     auto adjustSeq = engine.db()->GetLatestSequenceNumber();
     if (adjustSeq <= snapSeq) {
       adjustSeq = ::forceWrite(engine);
       TRI_ASSERT(adjustSeq > snapSeq);
     }
     _meta.adjustNumberDocuments(adjustSeq, RevisionId::none(), adjustment);
+  } else {
+    LOG_TOPIC("55df5", INFO, Logger::REPLICATION)
+      << "no collection count adjustment needs to be applied for "
+      << vocbase.name() << "/" << _logicalCollection.name()
+      << ": counted value: " << count;
   }
   
   return _meta.numberDocuments();

--- a/arangod/RocksDBEngine/RocksDBMetadata.h
+++ b/arangod/RocksDBEngine/RocksDBMetadata.h
@@ -129,19 +129,19 @@ struct RocksDBMetadata final {
   
   void loadInitialNumberDocuments();
 
-  uint64_t numberDocuments() const {
+  uint64_t numberDocuments() const noexcept {
     return _numberDocuments.load(std::memory_order_acquire);
   }
 
-  rocksdb::SequenceNumber countCommitted() const {
+  rocksdb::SequenceNumber countCommitted() const noexcept {
     return _count._committedSeq;
   }
 
-  RevisionId revisionId() const {
+  RevisionId revisionId() const noexcept {
     return _revisionId.load(std::memory_order_acquire);
   }
 
-public:
+ public:
   // static helper methods to modify collection meta entries in rocksdb
 
   /// @brief load collection document count

--- a/arangod/Transaction/ClusterUtils.cpp
+++ b/arangod/Transaction/ClusterUtils.cpp
@@ -47,8 +47,9 @@ void abortTransactions(LogicalCollection& coll) {
     TransactionCollection* tcoll = state.collection(coll.id(), AccessMode::Type::NONE);
         return tcoll != nullptr;
       });
-  LOG_TOPIC_IF("7eda2", INFO, Logger::TRANSACTIONS, didWork) <<
-  "aborted leader transactions on shard '" << coll.id() << "'";
+
+  LOG_TOPIC_IF("7eda2", INFO, Logger::TRANSACTIONS, didWork) 
+      << "aborted leader transactions on shard " << coll.id() << "'";
 }
 
 void abortLeaderTransactionsOnShard(DataSourceId cid) {
@@ -64,8 +65,9 @@ void abortLeaderTransactionsOnShard(DataSourceId cid) {
         }
         return false;
       });
-  LOG_TOPIC_IF("7edb3", INFO, Logger::TRANSACTIONS, didWork) <<
-  "aborted leader transactions on shard '" << cid << "'";
+
+  LOG_TOPIC_IF("7edb3", INFO, Logger::TRANSACTIONS, didWork) 
+     <<  "aborted leader transactions on shard '" << cid << "'";
 }
 
 void abortFollowerTransactionsOnShard(DataSourceId cid) {
@@ -81,8 +83,9 @@ void abortFollowerTransactionsOnShard(DataSourceId cid) {
         }
         return false;
       });
-  LOG_TOPIC_IF("7dcff", INFO, Logger::TRANSACTIONS, didWork) <<
-  "aborted follower transactions on shard '" << cid << "'";
+
+  LOG_TOPIC_IF("7dcff", INFO, Logger::TRANSACTIONS, didWork) 
+      << "aborted follower transactions on shard '" << cid << "'";
 }
 
 void abortTransactionsWithFailedServers(ClusterInfo& ci) {
@@ -127,8 +130,8 @@ void abortTransactionsWithFailedServers(ClusterInfo& ci) {
         });
   }
   
-  LOG_TOPIC_IF("b59e3", INFO, Logger::TRANSACTIONS, didWork) <<
-  "aborting transactions for servers '" << failed << "'";
+  LOG_TOPIC_IF("b59e3", INFO, Logger::TRANSACTIONS, didWork)
+      << "aborting transactions for servers '" << failed << "'";
 }
 
 }  // namespace cluster

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -150,6 +150,7 @@ uint64_t Manager::getActiveTransactionCount() {
 Manager::ManagedTrx::ManagedTrx(MetaType t, double ttl, std::shared_ptr<TransactionState> st)
     : type(t),
       intermediateCommits(false),
+      wasExpired(false),
       finalStatus(Status::UNDEFINED),
       timeToLive(ttl),
       expiryTime(TRI_microtime() + Manager::ttlForType(t)),
@@ -158,15 +159,15 @@ Manager::ManagedTrx::ManagedTrx(MetaType t, double ttl, std::shared_ptr<Transact
       db(state ? state->vocbase().name() : ""),
       rwlock() {}
 
-bool Manager::ManagedTrx::hasPerformedIntermediateCommits() const {
+bool Manager::ManagedTrx::hasPerformedIntermediateCommits() const noexcept {
   return this->intermediateCommits;
 }
 
-bool Manager::ManagedTrx::expired() const {
+bool Manager::ManagedTrx::expired() const noexcept {
   return this->expiryTime < TRI_microtime();
 }
 
-void Manager::ManagedTrx::updateExpiry() {
+void Manager::ManagedTrx::updateExpiry() noexcept {
   this->expiryTime = TRI_microtime() + this->timeToLive;
 }
 
@@ -228,8 +229,8 @@ void Manager::unregisterAQLTrx(TransactionId tid) noexcept {
   auto& buck = _transactions[bucket];
   auto it = buck._managed.find(tid);
   if (it == buck._managed.end()) {
-    LOG_TOPIC("92a49", ERR, Logger::TRANSACTIONS)
-        << "a registered transaction was not found";
+    LOG_TOPIC("92a49", WARN, Logger::TRANSACTIONS)
+        << "registered transaction " << tid << " not found";
     TRI_ASSERT(false);
     return;
   }
@@ -237,8 +238,8 @@ void Manager::unregisterAQLTrx(TransactionId tid) noexcept {
 
   /// we need to make sure no-one else is still using the TransactionState
   if (!it->second.rwlock.lockWrite(/*maxAttempts*/ 256)) {
-    LOG_TOPIC("9f7d7", ERR, Logger::TRANSACTIONS)
-        << "a transaction is still in use";
+    LOG_TOPIC("9f7d7", WARN, Logger::TRANSACTIONS)
+        << "transaction " << tid << " is still in use";
     TRI_ASSERT(false);
     return;
   }
@@ -767,7 +768,7 @@ void Manager::returnManagedTrx(TransactionId tid) noexcept {
     auto it = _transactions[bucket]._managed.find(tid);
     if (it == _transactions[bucket]._managed.end() || !::authorized(it->second.user)) {
       LOG_TOPIC("1d5b0", WARN, Logger::TRANSACTIONS)
-          << "managed transaction was not found";
+          << "managed transaction " << tid << " not found";
       TRI_ASSERT(false);
       return;
     }
@@ -828,9 +829,10 @@ Result Manager::statusChangeWithTimeout(TransactionId tid, std::string const& da
     if (res.ok() || !res.is(TRI_ERROR_LOCKED)) {
       break;
     }
+    double const now = TRI_microtime();
     if (startTime <= 0.0001) {  // fp tolerance
-      startTime = TRI_microtime();
-    } else if (TRI_microtime() - startTime > maxWaitTime) {
+      startTime = now;
+    } else if (now - startTime > maxWaitTime) {
       // timeout
       break;
     }
@@ -868,9 +870,18 @@ Result Manager::updateTransaction(TransactionId tid, transaction::Status status,
     auto it = buck._managed.find(tid);
     if (it == buck._managed.end() || !::authorized(it->second.user) ||
         (!database.empty() && it->second.db != database)) {
-      return res.reset(TRI_ERROR_TRANSACTION_NOT_FOUND,
-                       std::string("transaction '") + std::to_string(tid.id()) +
-                           "' not found");
+      std::string msg = "transaction " + std::to_string(tid.id());
+      if (it == buck._managed.end()) {
+        msg += " not found";
+      } else {
+        msg += " inaccessible";
+      }
+      if (status == transaction::Status::COMMITTED) {
+        msg += " on commit operation";
+      } else {
+        msg += " on abort operation";
+      }
+      return res.reset(TRI_ERROR_TRANSACTION_NOT_FOUND, std::move(msg));
     }
 
     ManagedTrx& mtrx = it->second;
@@ -901,27 +912,34 @@ Result Manager::updateTransaction(TransactionId tid, transaction::Status status,
         return res;  // all good
       } else {
         std::string msg("transaction was already ");
-        msg.append(statusString(mtrx.finalStatus));
+        if (mtrx.wasExpired) {
+          msg.append("expired");
+        } else {
+          msg.append(statusString(mtrx.finalStatus));
+        }
         return res.reset(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION, std::move(msg));
       }
     }
     TRI_ASSERT(mtrx.type == MetaType::Managed);
 
-    if (mtrx.expired() && status != transaction::Status::ABORTED) {
-      status = transaction::Status::ABORTED;
+    if (mtrx.expired()) {
+      // we will update the expire time of the tombstone shortly afterwards, 
+      // so we need to store the fact that this transaction originally expired
       wasExpired = true;
+      status = transaction::Status::ABORTED;
     }
 
     std::swap(state, mtrx.state);
     TRI_ASSERT(mtrx.state == nullptr);
     mtrx.type = MetaType::Tombstone;
-    mtrx.updateExpiry();
-    mtrx.finalStatus = status;
     if (state->numCommits() > 0) {
       // note that we have performed a commit or an intermediate commit.
       // this is necessary for follower transactions
       mtrx.intermediateCommits = true;
     }
+    mtrx.wasExpired = wasExpired;
+    mtrx.finalStatus = status;
+    mtrx.updateExpiry();
     // it is sufficient to pretend that the operation already succeeded
   }
 
@@ -1002,6 +1020,8 @@ bool Manager::garbageCollect(bool abortAll) {
   ::arangodb::containers::SmallVector<TransactionId, 64>::allocator_type::arena_type a2;
   ::arangodb::containers::SmallVector<TransactionId, 64> toErase{a2};
 
+  uint64_t numAborted = 0;
+
   for (size_t bucket = 0; bucket < numBuckets; ++bucket) {
     if (abortAll) {
       _transactions[bucket]._lock.lockWrite();
@@ -1016,6 +1036,8 @@ bool Manager::garbageCollect(bool abortAll) {
       if (mtrx.type == MetaType::Managed) {
         TRI_ASSERT(mtrx.state != nullptr);
         if (abortAll || mtrx.expired()) {
+          ++numAborted;
+
           TRY_WRITE_LOCKER(tryGuard, mtrx.rwlock);  // needs lock to access state
 
           if (tryGuard.isLocked()) {
@@ -1023,17 +1045,19 @@ bool Manager::garbageCollect(bool abortAll) {
             TRI_ASSERT(it.first == mtrx.state->id());
             toAbort.emplace_back(mtrx.state->id());
             LOG_TOPIC("7ad3f", INFO, Logger::TRANSACTIONS)
-                << "aborting expired transaction '" << it.first << "'";
+                << "aborting expired transaction " << it.first;
           } else if (abortAll) {  // transaction is in use but we want to abort
+            LOG_TOPIC("92431", INFO, Logger::TRANSACTIONS) 
+                << "soft-aborting expired transaction " << it.first;
             mtrx.expiryTime = 0;  // soft-abort transaction
             didWork = true;
             LOG_TOPIC("7ad4f", INFO, Logger::TRANSACTIONS)
-                << "soft aborting transaction '" << it.first << "'";
+                << "soft aborting transaction " << it.first;
           }
         }
       } else if (mtrx.type == MetaType::StandaloneAQL && mtrx.expired()) {
         LOG_TOPIC("7ad5f", INFO, Logger::TRANSACTIONS)
-            << "expired AQL query transaction '" << it.first << "'";
+            << "expired AQL query transaction " << it.first;
       } else if (mtrx.type == MetaType::Tombstone && mtrx.expired()) {
         TRI_ASSERT(mtrx.state == nullptr);
         TRI_ASSERT(mtrx.finalStatus != transaction::Status::UNDEFINED);
@@ -1045,22 +1069,32 @@ bool Manager::garbageCollect(bool abortAll) {
   for (TransactionId tid : toAbort) {
     LOG_TOPIC("6fbaf", INFO, Logger::TRANSACTIONS) << "garbage collecting "
                                                    << "transaction " << tid;
-    Result res = updateTransaction(tid, Status::ABORTED, /*clearSrvs*/ true);
-    // updateTransaction can return TRI_ERROR_TRANSACTION_ABORTED when it
-    // successfully aborts, so ignore this error.
-    // we can also get the TRI_ERROR_LOCKED error in case we cannot
-    // immediately acquire the lock on the transaction. this _can_ happen
-    // infrequently, but is not an error
-    if (res.fail() && !res.is(TRI_ERROR_TRANSACTION_ABORTED) &&
-        !res.is(TRI_ERROR_CLUSTER_FOLLOWER_TRANSACTION_COMMIT_PERFORMED) &&
-        !res.is(TRI_ERROR_LOCKED)) {
-      LOG_TOPIC("0a07f", INFO, Logger::TRANSACTIONS) << "error while aborting "
-                                                        "transaction: "
-                                                     << res.errorMessage();
+    LOG_TOPIC("1df7f", DEBUG, Logger::TRANSACTIONS) << "garbage-collecting expired transaction " << tid;
+    try {
+      Result res = updateTransaction(tid, Status::ABORTED, /*clearSrvs*/ true);
+      // updateTransaction can return TRI_ERROR_TRANSACTION_ABORTED when it
+      // successfully aborts, so ignore this error.
+      // we can also get the TRI_ERROR_LOCKED error in case we cannot
+      // immediately acquire the lock on the transaction. this _can_ happen
+      // infrequently, but is not an error
+      if (res.fail() && !res.is(TRI_ERROR_TRANSACTION_ABORTED) &&
+          !res.is(TRI_ERROR_CLUSTER_FOLLOWER_TRANSACTION_COMMIT_PERFORMED) &&
+          !res.is(TRI_ERROR_LOCKED)) {
+        LOG_TOPIC("0a07f", INFO, Logger::TRANSACTIONS) << "error while aborting "
+                                                          "transaction: "
+                                                       << res.errorMessage();
+      }
+      didWork = true;
+    } catch (...) {
+      // if this fails, this is no problem. we will simply try again in the
+      // next round
     }
-    didWork = true;
   }
 
+  // track the number of hard-/soft-aborted transactions
+  _feature.trackExpired(numAborted);
+
+  // remove all expired tombstones
   for (TransactionId tid : toErase) {
     size_t const bucket = getBucket(tid);
     WRITE_LOCKER(locker, _transactions[bucket]._lock);

--- a/arangod/Transaction/Manager.h
+++ b/arangod/Transaction/Manager.h
@@ -72,9 +72,9 @@ class Manager final {
     ManagedTrx(MetaType t, double ttl, std::shared_ptr<TransactionState> st);
     ~ManagedTrx();
 
-    bool hasPerformedIntermediateCommits() const;
-    bool expired() const;
-    void updateExpiry();
+    bool hasPerformedIntermediateCommits() const noexcept;
+    bool expired() const noexcept;
+    void updateExpiry() noexcept;
 
    public:
     /// @brief managed, AQL or tombstone
@@ -82,11 +82,13 @@ class Manager final {
     /// @brief whether or not the transaction has performed any intermediate
     /// commits
     bool intermediateCommits;
+    /// @brief whether or not the transaction did expire at least once
+    bool wasExpired;
     /// @brief  final TRX state that is valid if this is a tombstone
     /// necessary to avoid getting error on a 'diamond' commit or accidentally
     /// repeated commit / abort messages
     transaction::Status finalStatus;
-    const double timeToLive;
+    double const timeToLive;
     double expiryTime;                        // time this expires
     std::shared_ptr<TransactionState> state;  /// Transaction, may be nullptr
     std::string user;                         /// user owning the transaction
@@ -221,7 +223,7 @@ class Manager final {
                                  transaction::Status status);
 
   /// @brief hashes the transaction id into a bucket
-  inline size_t getBucket(TransactionId tid) const {
+  inline size_t getBucket(TransactionId tid) const noexcept {
     return std::hash<TransactionId>()(tid) % numBuckets;
   }
 

--- a/arangod/Transaction/ManagerFeature.h
+++ b/arangod/Transaction/ManagerFeature.h
@@ -26,6 +26,7 @@
 
 #include "ApplicationFeatures/ApplicationFeature.h"
 #include "Basics/debugging.h"
+#include "RestServer/Metrics.h"
 #include "Scheduler/Scheduler.h"
 
 #include <mutex>
@@ -52,6 +53,9 @@ class ManagerFeature final : public application_features::ApplicationFeature {
     return MANAGER.get();
   }
 
+  /// @brief track number of aborted managed transaction
+  void trackExpired(uint64_t numExpired);
+
  private:
   static std::unique_ptr<transaction::Manager> MANAGER;
   
@@ -63,6 +67,10 @@ class ManagerFeature final : public application_features::ApplicationFeature {
 
   // lock time in seconds
   double _streamingLockTimeout;
+  
+  /// @brief number of expired transactions that were aborted by 
+  /// transaction garbage collection
+  Counter& _numExpiredTransactions;
 };
 
 }  // namespace transaction

--- a/arangosh/Dump/DumpFeature.cpp
+++ b/arangosh/Dump/DumpFeature.cpp
@@ -262,22 +262,23 @@ bool isIgnoredHiddenEnterpriseCollection(arangodb::DumpFeature::Options const& o
 arangodb::Result dumpJsonObjects(arangodb::DumpFeature::DumpJob& job,
                                  arangodb::ManagedDirectory::File& file,
                                  arangodb::basics::StringBuffer const& body) {
-  arangodb::basics::StringBuffer masked(1, false);
-  arangodb::basics::StringBuffer const* result = &body;
-
+  size_t length;
   if (job.maskings != nullptr) {
+    arangodb::basics::StringBuffer masked(256, false);
     job.maskings->mask(job.collectionName, body, masked);
-    result = &masked;
+    file.write(masked.data(), masked.length());
+    length = masked.length();
+  } else {
+    file.write(body.data(), body.length());
+    length = body.length();
   }
-
-  file.write(result->data(), result->length());
 
   if (file.status().fail()) {
     return {TRI_ERROR_CANNOT_WRITE_FILE, std::string("cannot write file '") + file.path() +
                                              "': " + file.status().errorMessage()};
   }
 
-  job.stats.totalWritten += static_cast<uint64_t>(result->length());
+  job.stats.totalWritten += static_cast<uint64_t>(length);
 
   return {};
 }

--- a/arangosh/Import/ImportFeature.cpp
+++ b/arangosh/Import/ImportFeature.cpp
@@ -354,6 +354,7 @@ void ImportFeature::start() {
       std::cout << "separator:              " << _separator << std::endl;
     }
     std::cout << "threads:                " << _threadCount << std::endl;
+    std::cout << "on duplicate:           " << _onDuplicateAction << std::endl;
 
     std::cout << "connect timeout:        " << client.connectionTimeout() << std::endl;
     std::cout << "request timeout:        " << client.requestTimeout() << std::endl;

--- a/tests/RocksDBEngine/TransactionManagerTest.cpp
+++ b/tests/RocksDBEngine/TransactionManagerTest.cpp
@@ -30,6 +30,7 @@
 #include <thread>
 
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "RestServer/MetricsFeature.h"
 #include "Transaction/Manager.h"
 #include "Transaction/ManagerFeature.h"
 
@@ -44,6 +45,7 @@ using namespace arangodb;
 /// @brief simple non-overlapping
 TEST(RocksDBTransactionManager, test_non_overlapping) {
   application_features::ApplicationServer server{nullptr, nullptr};
+  server.addFeature<MetricsFeature>();
   transaction::ManagerFeature feature(server);
   transaction::Manager tm(feature);
 
@@ -63,6 +65,7 @@ TEST(RocksDBTransactionManager, test_non_overlapping) {
 /// @brief simple non-overlapping
 TEST(RocksDBTransactionManager, test_overlapping) {
   application_features::ApplicationServer server{nullptr, nullptr};
+  server.addFeature<MetricsFeature>();
   transaction::ManagerFeature feature(server);
   transaction::Manager tm(feature);
 


### PR DESCRIPTION
### Scope & Purpose

This PR contains a zoo of small changes:
* Adds new metric `arangodb_transactions_expired` to track the total number of expired and then garbage-collected transactions
* Clarifies scope of another metric in the CHANGELOG
* Improves debug and warning log messages, by providing a bit more context
* Downgrades some log messages for recoverable errors into warnings (to comply with our log levels policy)
* micro-optimization for arangodump (no allocation of StringBuffer for masking data when no masking is used)
* micro-optimization for `/_api/import` handling: we can turn off `returnOld` even in case `onDuplicate=update` or `onDuplicate=replace`, because we are only using the "old" attribute in the return to distinguish inserts from updates/replaces. Setting `returnOld` is overkill here however, because it will return the full previous version of the document(s), which can be large. Instead, go with the much small `_oldRev` attribute that is also set when a document is updated/replaced.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is already covered by existing tests, such as *shell_client, shell_server, importing, dump*.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13760/