### PR TITLE
Adds `TAKE/DROP WHILE` and array index iteration variable to the `[*]` AQL operator

### DIFF
--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -304,11 +304,15 @@ class Ast {
   AstNode* createNodeArrayLimit(AstNode const*, AstNode const*);
 
   /// @brief create an AST expansion node
-  AstNode* createNodeExpansion(int64_t, AstNode const*, AstNode const*,
-                               AstNode const*, AstNode const*, AstNode const*);
+  AstNode* createNodeExpansion(int64_t levels, AstNode const* iterator, 
+                               AstNode const* expanded, AstNode const* filter,
+                               AstNode const* limit, AstNode const* projection,
+                               AstNode const* prune);
 
   /// @brief create an AST iterator node
-  AstNode* createNodeIterator(char const*, size_t, AstNode const*);
+  AstNode* createNodeIterator(std::string const& currentVariable,  
+                              std::string const& indexVariable, 
+                              AstNode const* expanded);
 
   /// @brief create an AST null value node
   AstNode* createNodeValueNull();

--- a/arangod/Aql/AstHelper.cpp
+++ b/arangod/Aql/AstHelper.cpp
@@ -48,7 +48,7 @@ bool accessesSearchVariableViaReference(AstNode const* current, Variable const* 
       return false;
     }
     auto it = current->getMemberUnchecked(0);
-    if (it->type != NODE_TYPE_ITERATOR || it->numMembers() != 2) {
+    if (it->type != NODE_TYPE_ITERATOR || (it->numMembers() != 2 && it->numMembers() != 3)) {
       return false;
     }
 
@@ -92,7 +92,7 @@ bool isTargetVariable(AstNode const* node,
       TRI_ASSERT(it);
 
       // The expansion is at the very end
-      if (it->type == NODE_TYPE_ITERATOR && it->numMembers() == 2) {
+      if (it->type == NODE_TYPE_ITERATOR && (it->numMembers() == 2 || it->numMembers() == 3)) {
         if (it->getMember(0)->type != NODE_TYPE_VARIABLE) {
           return false;
         }

--- a/arangod/Aql/Scopes.cpp
+++ b/arangod/Aql/Scopes.cpp
@@ -112,7 +112,7 @@ Variable const* Scope::getVariable(char const* name, size_t nameLength, bool all
 }
 
 /// @brief create the scopes
-Scopes::Scopes() : _activeScopes(), _currentVariables() {
+Scopes::Scopes() {
   _activeScopes.reserve(4);
 }
 
@@ -228,24 +228,23 @@ Variable const* Scopes::getVariable(char const* name, size_t nameLength,
   return nullptr;
 }
 
-/// @brief get the $CURRENT variable
-Variable const* Scopes::getCurrentVariable() const {
-  if (_currentVariables.empty()) {
-    THROW_ARANGO_EXCEPTION_PARAMS(TRI_ERROR_QUERY_VARIABLE_NAME_UNKNOWN, Variable::NAME_CURRENT);
+/// @brief get the $CURRENT and $INDEX variables
+Scopes::IteratorVariables Scopes::getIteratorVariables() const {
+  if (_iteratorVariables.empty()) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "no expansion variables registered");
   }
-  auto result = _currentVariables.back();
-  TRI_ASSERT(result != nullptr);
+  auto result = _iteratorVariables.back();
   return result;
 }
 
-/// @brief stack a $CURRENT variable from the stack
-void Scopes::stackCurrentVariable(Variable const* variable) {
-  _currentVariables.emplace_back(variable);
+/// @brief stack a $CURRENT and $INDEX variable on the stack
+void Scopes::stackIteratorVariables(Scopes::IteratorVariables const& ev) {
+  _iteratorVariables.emplace_back(ev);
 }
 
-/// @brief unregister the $CURRENT variable from the stack
-void Scopes::unstackCurrentVariable() {
-  TRI_ASSERT(!_currentVariables.empty());
+/// @brief unregister the $CURRENT and $INDEX variable from the stack
+void Scopes::unstackIteratorVariables() {
+  TRI_ASSERT(!_iteratorVariables.empty());
 
-  _currentVariables.pop_back();
+  _iteratorVariables.pop_back();
 }

--- a/arangod/Aql/Scopes.h
+++ b/arangod/Aql/Scopes.h
@@ -49,7 +49,6 @@ class Scope {
   /// @brief destroy the scope
   ~Scope();
 
- public:
   /// @brief return the name of a scope type
   std::string typeName() const;
 
@@ -94,8 +93,12 @@ class Scopes {
 
   /// @brief destroy the scopes
   ~Scopes();
+  
+  struct IteratorVariables {
+    Variable const* current;
+    Variable const* index;
+  };
 
- public:
   /// @brief number of currently active scopes
   inline size_t numActive() const { return _activeScopes.size(); }
 
@@ -105,10 +108,10 @@ class Scopes {
     return _activeScopes.back()->type();
   }
 
-  /// @brief whether or not the $CURRENT variable can be used at the caller's
+  /// @brief whether or not the $CURRENT and $INDEX variables can be used at the caller's
   /// current position
-  inline bool canUseCurrentVariable() const {
-    return (!_currentVariables.empty());
+  inline bool canUseIteratorVariables() const {
+    return !_iteratorVariables.empty();
   }
 
   /// @brief start a new scope
@@ -139,21 +142,21 @@ class Scopes {
   /// this also allows using special pseudo vars such as OLD and NEW
   Variable const* getVariable(char const*, size_t, bool) const;
 
-  /// @brief get the $CURRENT variable
-  Variable const* getCurrentVariable() const;
+  /// @brief get the $CURRENT and $INDEX variables
+  IteratorVariables getIteratorVariables() const;
 
-  /// @brief stack a $CURRENT variable from the stack
-  void stackCurrentVariable(Variable const*);
+  /// @brief stack the $CURRENT and $INDEX variable on the stack
+  void stackIteratorVariables(IteratorVariables const& ev);
 
-  /// @brief unregister the $CURRENT variable from the stack
-  void unstackCurrentVariable();
+  /// @brief unregister the $CURRENT and $INDEX variables from the stack
+  void unstackIteratorVariables();
 
  private:
   /// @brief currently active scopes
   std::vector<std::unique_ptr<Scope>> _activeScopes;
 
   /// @brief a stack with aliases for the $CURRENT variable
-  std::vector<Variable const*> _currentVariables;
+  std::vector<Scopes::IteratorVariables> _iteratorVariables;
 };
 }  // namespace aql
 }  // namespace arangodb

--- a/arangod/Aql/TraversalConditionFinder.cpp
+++ b/arangod/Aql/TraversalConditionFinder.cpp
@@ -342,10 +342,11 @@ static bool checkPathVariableAccessFeasible(Ast* ast, AstNode* parent, size_t te
           // Check that the expansion [*] contains no inline expression;
           // members 2, 3 and 4 correspond to FILTER, LIMIT and RETURN,
           // respectively.
-          TRI_ASSERT(node->numMembers() == 5);
+          TRI_ASSERT(node->numMembers() >= 5);
           if (node->getMemberUnchecked(2)->type != NODE_TYPE_NOP ||
               node->getMemberUnchecked(3)->type != NODE_TYPE_NOP ||
-              node->getMemberUnchecked(4)->type != NODE_TYPE_NOP) {
+              node->getMemberUnchecked(4)->type != NODE_TYPE_NOP ||
+              (node->numMembers() > 5 && node->getMemberUnchecked(5)->type != NODE_TYPE_NOP)) {
             notSupported = true;
             return node;
           }

--- a/arangod/IResearch/AqlHelper.cpp
+++ b/arangod/IResearch/AqlHelper.cpp
@@ -527,7 +527,7 @@ bool attributeAccessEqual(aql::AstNode const* lhs,
         auto* itr = node->getMemberUnchecked(0);
         auto* ref = node->getMemberUnchecked(1);
 
-        if (itr && itr->numMembers() == 2) {
+        if (itr && itr->numMembers() >= 2) {
           auto* var = itr->getMemberUnchecked(0);
           auto* root = itr->getMemberUnchecked(1);
 


### PR DESCRIPTION
### Scope & Purpose

Note: this is experimental and may be deleted. PR template is not completed as this is an RFC and thus in draft state.

This is an RFC for an experimental change that adds `PRUNE` support to the `[*]` array iterator operator in AQL. 

**To be implemented**: `DROP WHILE` iterates over the array and ignores all elements for which its condition is satisfied. Once the `DROP WHILE` condition is satisfied, it is ignored in the further iteration.

**To be implemented**: `TAKE WHILE` will stop iterating over the array as soon as its condition is *not* satisfied.

The PR also adds an `INDEX` pseudo variable to the `[*]` AQL operator. `INDEX` is a pseudo variable which contains the current loop iteration index value (zero-based). The variable is made available automatically inside `[* ...]` and is only valid inside. There already exists a pseudo variable `CURRENT` to refer to the current array element, and `INDEX` extends this.

**To be implemented**: The suggestion is to also add a `LENGTH` pseudo variable, returning the length of the array that is iterated over. If there are any DROP WHILE, TAKE WHILE, FILTER, or LIMIT clauses, these will not influence the value of LENGTH.

A few usage examples:

**Stop at first array element which is not greater eql to precending**:
```
LET a = [1, 2, 4, 16, 99, 257, 4, 10000]
RETURN a[* TAKE WHILE INDEX == 0 || a[INDEX - 1] >= CURRENT RETURN CURRENT]

[
  1,
  2,
  4,
  16,
  99,
  257
]
```

**Stop at first array element which is not double the value of the preceding**:
```
LET a = [1, 2, 4, 8, 32, 64, 256]
RETURN a[* TAKE WHILE INDEX == 0 || a[INDEX - 1] * 2 != CURRENT RETURN CURRENT]

[
  1,
  2,
  4,
  8
]
```

**Same, but return array indexes**:
```
LET a = [1, 2, 4, 8, 32, 64, 256]
RETURN a[* TAKE WHILE INDEX == 0 || a[INDEX - 1] * 2 != CURRENT RETURN INDEX]

[
  0,
  1,
  2,
  3
]
```

**Don't abort early, but instead return information that compares current array element with previous**:
```
LET a = [1, 2, 4, 8, 32, 64, 256]
RETURN a[* RETURN {value: CURRENT, isDuplicate: INDEX == 0 || a[INDEX - 1] * 2 == CURRENT}]

[
  {
    "value" : 1,
    "isDuplicate" : true
  },
  {
    "value" : 2,
    "isDuplicate" : true
  },
  {
    "value" : 4,
    "isDuplicate" : true
  },
  {
    "value" : 8,
    "isDuplicate" : true
  },
  {
    "value" : 32,
    "isDuplicate" : false
  },
  {
    "value" : 64,
    "isDuplicate" : true
  },
  {
    "value" : 256,
    "isDuplicate" : false
  }
]
```

**Return only every second array element**:
```
LET a = [1, 2, 4, 8, 16, 32, 64, 256, 512]
RETURN a[* FILTER INDEX % 2 == 1 RETURN CURRENT]

[
  2,
  8,
  32,
  256
]
```

Note: as this is implemented right now, it will only work for the `[*]` array iterator, and not for arbitrary FOR loops.

Open issues: 
- [ ] do we want this, at all?
- [ ] `PRUNE` is not a good term for aborting array iteration, and should probably be renamed.
- [ ] add tests
- [ ] add documentation


The below PR template still needs filling out once we are sure this idea will be pursued.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:

### Documentation

> All new features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the CHANGELOG so that
> support, end users, and other developers have a concise overview. 

- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries