### PR TITLE
Set CLEAN_NO_CUSTOM for some directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1255,6 +1255,9 @@ endif()
 ################################################################################
 
 if (USE_MAINTAINER_MODE)
+  # If "make clean" removes these files, afterwards neither "make" nor "cmake" work any more.
+  set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM "On")
+
   set(ERROR_FILES
     lib/Basics/voc-errors.h
     lib/Basics/voc-errors.cpp

--- a/Documentation/CMakeLists.txt
+++ b/Documentation/CMakeLists.txt
@@ -42,6 +42,11 @@ foreach (m IN LISTS MAN_NAMES)
 endforeach ()
 set(ARANGO_MAN_DIR "${CMAKE_CURRENT_BINARY_DIR}/man" PARENT_SCOPE)
 
+# avoid deleting README on "make clean"...
+set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM "On")
+# ...but still delete man files
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES ${MAN_FILES})
+
 add_custom_command(
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   OUTPUT  ${CMAKE_SOURCE_DIR}/README

--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -12,6 +12,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin/")
 #generate inside the source tree
 
 if (USE_MAINTAINER_MODE AND NOT MSVC)
+  set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM "On")
+
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/Aql/tokens.cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
### Scope & Purpose

A minor change in the build system to no longer delete some custom targets during `make clean`. Namely:

- Installation/Windows/Plugins/exitcodes.nsh
- js/common/bootstrap/errors.js
- js/common/bootstrap/exitcodes.js
- lib/Basics/exitcodes.cpp
- lib/Basics/exitcodes.h
- lib/Basics/voc-errors.cpp
- lib/Basics/voc-errors.h
- README
- arangod/Aql/grammar.cpp
- arangod/Aql/tokens.cpp

The previous behaviour is undesirable, for one because those files are part of the source tree, and not just in the build directory. Second, because deleting some of these make both subsequent `make` or `cmake` commands fail, making it impossible to regenerate the files without checking them out again.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [X] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [X] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

### Testing & Verification

- [X] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
