### PR TITLE
Feature/test repl factor 2 adjust non default tests

### DIFF
--- a/tests/js/common/http/api-gharial-creation-cluster-spec.js
+++ b/tests/js/common/http/api-gharial-creation-cluster-spec.js
@@ -52,9 +52,8 @@ describe('General graph creation', function () {
 
   const clean = () => {
     try {
-      request['delete'](`/_api/gharial/${gn}?dropCollections=true`);
-    } catch (ignore) {
-    }
+      request["delete"](`/_api/gharial/${gn}?dropCollections=true`);
+    } catch (ignore) {}
 
     expect(db._collection(vn)).to.not.exist;
     expect(db._collection(en)).to.not.exist;
@@ -66,23 +65,45 @@ describe('General graph creation', function () {
     expect(db._collection(vn3)).to.not.exist;
   };
 
-  before(clean);
-  after(clean);
+  const testSuite = (options) => {
+    // Extract desired values, if absent use defaults
+    const replicationFactor =
+      options.replicationFactor || defaultReplicationFactor;
+    const minReplicationFactor = options.minReplicationFactor || 1;
+    const numberOfShards = options.numberOfShards || 1;
 
-  describe('with defaults', function () {
+    // Assert that we do not tests defaults again if we want to overwrite
+    // with specific values
+    if (options.hasOwnProperty("replicationFactor")) {
+      expect(replicationFactor).to.not.equal(defaultReplicationFactor);
+    }
+    if (options.hasOwnProperty("minReplicationFactor")) {
+      expect(minReplicationFactor).to.not.equal(1);
+    }
+    if (options.hasOwnProperty("numberOfShards")) {
+      expect(numberOfShards).to.not.equal(1);
+    }
 
-    before(function() {
+    const validateProperties = (collectionName) => {
+      let props = db._collection(collectionName).properties();
+      expect(props.replicationFactor).to.equal(replicationFactor);
+      expect(props.minReplicationFactor).to.equal(minReplicationFactor);
+      expect(props.numberOfShards).to.equal(numberOfShards);
+    };
+
+    before(function () {
       let rel = graph._relation(en, vn, vn);
       let body = {
         orphanCollections: [on],
         edgeDefinitions: [rel],
         name: gn,
-        isSmart: false
+        options,
+        isSmart: false,
       };
 
       // Create with default options
       let res = request.post(`/_api/gharial`, {
-        body: JSON.stringify(body)
+        body: JSON.stringify(body),
       });
       expect(res.statusCode).to.equal(202);
 
@@ -101,82 +122,55 @@ describe('General graph creation', function () {
 
     after(clean);
 
-    describe('during graph construction', function () {
-
-      describe('replication factor and minimal replication factor', function () {
-
-        it('should be stored in the internal document', function () {
-          let gdoc = db._collection('_graphs').document(gn);
-          expect(gdoc.replicationFactor).to.equal(defaultReplicationFactor);
-          expect(gdoc.minReplicationFactor).to.equal(1);
-        });
-
-        it('should be 1 for vertex collection', function () {
-          let props = db._collection(vn).properties();
-          expect(props.replicationFactor).to.equal(defaultReplicationFactor);
-          expect(props.minReplicationFactor).to.equal(1);
-        });
-
-        it('should be 1 for edge collection', function () {
-          let props = db._collection(en).properties();
-          expect(props.replicationFactor).to.equal(defaultReplicationFactor);
-          expect(props.minReplicationFactor).to.equal(1);
-        });
-
-        it('should be 1 for orphan collection', function () {
-          let props = db._collection(on).properties();
-          expect(props.replicationFactor).to.equal(defaultReplicationFactor);
-          expect(props.minReplicationFactor).to.equal(1);
-        });
-
+    describe("during graph construction, the options", function () {
+      it("should be stored in the internal document", function () {
+        let gdoc = db._collection("_graphs").document(gn);
+        expect(gdoc.replicationFactor).to.equal(replicationFactor);
+        expect(gdoc.minReplicationFactor).to.equal(minReplicationFactor);
+        expect(gdoc.numberOfShards).to.equal(numberOfShards);
       });
 
-      describe('number of shards', function () {
+      it(
+        "should be honored for vertex collection",
+        validateProperties.bind(this, vn)
+      );
 
-        it('should be stored in the internal document', function () {
-          let gdoc = db._collection('_graphs').document(gn);
-          expect(gdoc.numberOfShards).to.equal(1);
-        });
+      it(
+        "should be honored for edge collection",
+        validateProperties.bind(this, en)
+      );
 
-        it('should be 1 for vertex collection', function () {
-          let props = db._collection(vn).properties();
-          expect(props.numberOfShards).to.equal(1);
-        });
-
-        it('should be 1 for edge collection', function () {
-          let props = db._collection(en).properties();
-          expect(props.numberOfShards).to.equal(1);
-        });
-
-        it('should be 1 for orphan collection', function () {
-          let props = db._collection(on).properties();
-          expect(props.numberOfShards).to.equal(1);
-        });
-
-      });
-
+      it(
+        "should be honored for orphan collection",
+        validateProperties.bind(this, on)
+      );
     });
 
-    describe('adding collections later', function () {
-
-      before(function() {
+    describe("adding collections later, options", function () {
+      before(function () {
         let body = {
           to: [vn2],
           from: [vn2],
-          collection: en2
+          collection: en2,
         };
-        let res = request.post(`/_api/gharial/${gn}/edge`, extend(endpoint, {
-          body: JSON.stringify(body)
-        }));
+        let res = request.post(
+          `/_api/gharial/${gn}/edge`,
+          extend(endpoint, {
+            body: JSON.stringify(body),
+          })
+        );
 
         expect(res.statusCode).to.equal(202);
 
         body = {
-          collection: on2
+          collection: on2,
         };
-        res = request.post(`/_api/gharial/${gn}/vertex`, extend(endpoint, {
-          body: JSON.stringify(body)
-        }));
+        res = request.post(
+          `/_api/gharial/${gn}/vertex`,
+          extend(endpoint, {
+            body: JSON.stringify(body),
+          })
+        );
 
         expect(res.statusCode).to.equal(202);
 
@@ -188,303 +182,64 @@ describe('General graph creation', function () {
         expect(db._collection(on2)).to.exist;
       });
 
-      describe('replication factor', function () {
+      it(
+        "should be honored for vertex collection",
+        validateProperties.bind(this, vn2)
+      );
 
-        it('should be 1 for vertex collection', function () {
-          let props = db._collection(vn2).properties();
-          expect(props.replicationFactor).to.equal(defaultReplicationFactor);
-        });
+      it(
+        "should be honored for edge collection",
+        validateProperties.bind(this, en2)
+      );
 
-        it('should be 1 for edge collection', function () {
-          let props = db._collection(en2).properties();
-          expect(props.replicationFactor).to.equal(defaultReplicationFactor);
-        });
-
-        it('should be 1 for orphan collection', function () {
-          let props = db._collection(on2).properties();
-          expect(props.replicationFactor).to.equal(defaultReplicationFactor);
-        });
-
-      });
-
-      describe('number of shards', function () {
-
-        it('should be 1 for vertex collection', function () {
-          let props = db._collection(vn2).properties();
-          expect(props.numberOfShards).to.equal(1);
-        });
-
-        it('should be 1 for edge collection', function () {
-          let props = db._collection(en2).properties();
-          expect(props.numberOfShards).to.equal(1);
-        });
-
-        it('should be 1 for orphan collection', function () {
-          let props = db._collection(on2).properties();
-          expect(props.numberOfShards).to.equal(1);
-        });
-
-      });
-
+      it(
+        "should be honored for orphan collection",
+        validateProperties.bind(this, on2)
+      );
     });
 
-    describe('modify edge definition', function () {
-
-      before(function() {
+    describe("modify edge definition, options", function () {
+      before(function () {
         // We modify the first relation by adding a new vertex collection
 
         let body = {
           from: [vn],
           to: [vn3],
-          collection: en
+          collection: en,
         };
 
-        let res = request.put(`/_api/gharial/${gn}/edge/${en}`, extend(endpoint, {
-          body: JSON.stringify(body)
-        }));
+        let res = request.put(
+          `/_api/gharial/${gn}/edge/${en}`,
+          extend(endpoint, {
+            body: JSON.stringify(body),
+          })
+        );
 
         expect(res.statusCode).to.equal(202);
 
         expect(db._collection(vn3)).to.exist;
       });
 
-      describe('replication factor', function () {
-
-        it(`should be 1 for vertex collection`, function () {
-          let props = db._collection(vn3).properties();
-          expect(props.replicationFactor).to.equal(defaultReplicationFactor);
-        });
-
-      });
-
-      describe('number of shards', function () {
-
-        it(`should be 1 for vertex collection`, function () {
-          let props = db._collection(vn3).properties();
-          expect(props.numberOfShards).to.equal(1);
-        });
-
-      });
-
+      it(
+        "should be honored for vertex collection",
+        validateProperties.bind(this, vn3)
+      );
     });
+  };
 
-  });
+  before(clean);
+  after(clean);
 
-  describe('with startup options', function () {
-    const replicationFactor = 2;
-    const minReplicationFactor = 2;
-    const numberOfShards = 3;
+  describe("with defaults", testSuite.bind(this, {}));
 
-    before(function() {
-      const options = {
-        replicationFactor,
-        minReplicationFactor,
-        numberOfShards
-      };
-      let rel = graph._relation(en, vn, vn);
-
-      let body = {
-        orphanCollections: [on],
-        edgeDefinitions: [rel],
-        name: gn,
-        isSmart: false,
-        options
-      };
-
-      let res = request.post(`/_api/gharial`, {
-        body: JSON.stringify(body)
-      });
-
-      expect(res.statusCode).to.equal(202);
-
-      // Do we need to wait here?
-
-      // Validate all collections get created
-      expect(db._collection(vn)).to.exist;
-      expect(db._collection(en)).to.exist;
-      expect(db._collection(on)).to.exist;
-
-      // Validate create later collections to not exist
-      expect(db._collection(vn2)).to.not.exist;
-      expect(db._collection(en2)).to.not.exist;
-      expect(db._collection(on2)).to.not.exist;
-    });
-
-    after(clean);
-
-    describe('during graph construction', function () {
-
-      describe('replication factor', function () {
-
-        it('should be stored in the internal document', function () {
-          let gdoc = db._collection('_graphs').document(gn);
-          expect(gdoc.replicationFactor).to.equal(replicationFactor);
-          expect(gdoc.minReplicationFactor).to.equal(minReplicationFactor);
-        });
-
-        it(`should be ${replicationFactor} for vertex collection`, function () {
-          let props = db._collection(vn).properties();
-          expect(props.replicationFactor).to.equal(replicationFactor);
-          expect(props.minReplicationFactor).to.equal(minReplicationFactor);
-        });
-
-        it(`should be ${replicationFactor} for edge collection`, function () {
-          let props = db._collection(en).properties();
-          expect(props.replicationFactor).to.equal(replicationFactor);
-          expect(props.minReplicationFactor).to.equal(minReplicationFactor);
-        });
-
-        it(`should be ${replicationFactor} for orphan collection`, function () {
-          let props = db._collection(on).properties();
-          expect(props.replicationFactor).to.equal(replicationFactor);
-          expect(props.minReplicationFactor).to.equal(minReplicationFactor);
-        });
-
-      });
-
-      describe('number of shards', function () {
-
-        it('should be stored in the internal document', function () {
-          let gdoc = db._collection('_graphs').document(gn);
-          expect(gdoc.numberOfShards).to.equal(numberOfShards);
-        });
-
-        it(`should be ${numberOfShards} for vertex collection`, function () {
-          let props = db._collection(vn).properties();
-          expect(props.numberOfShards).to.equal(numberOfShards);
-        });
-
-        it(`should be ${numberOfShards} for edge collection`, function () {
-          let props = db._collection(en).properties();
-          expect(props.numberOfShards).to.equal(numberOfShards);
-        });
-
-        it(`should be ${numberOfShards} for orphan collection`, function () {
-          let props = db._collection(on).properties();
-          expect(props.numberOfShards).to.equal(numberOfShards);
-        });
-
-      });
-
-    });
-
-    describe('adding collections later', function () {
-
-      before(function() {
-        let body = {
-          to: [vn2],
-          from: [vn2],
-          collection: en2
-        };
-        let res = request.post(`/_api/gharial/${gn}/edge`, extend(endpoint, {
-          body: JSON.stringify(body)
-        }));
-
-        expect(res.statusCode).to.equal(202);
-
-        body = {
-          collection: on2
-        };
-
-        res = request.post(`/_api/gharial/${gn}/vertex`, extend(endpoint, {
-          body: JSON.stringify(body)
-        }));
-
-        expect(res.statusCode).to.equal(202);
-
-        // Do we need to wait here?
-
-        // Validate create later collections to now exist
-        expect(db._collection(vn2)).to.exist;
-        expect(db._collection(en2)).to.exist;
-        expect(db._collection(on2)).to.exist;
-      });
-
-      describe('replication factor', function () {
-
-        it(`should be ${replicationFactor} for vertex collection`, function () {
-          let props = db._collection(vn2).properties();
-          expect(props.replicationFactor).to.equal(replicationFactor);
-          expect(props.minReplicationFactor).to.equal(minReplicationFactor);
-        });
-
-        it(`should be ${replicationFactor} for edge collection`, function () {
-          let props = db._collection(en2).properties();
-          expect(props.replicationFactor).to.equal(replicationFactor);
-          expect(props.minReplicationFactor).to.equal(minReplicationFactor);
-        });
-
-        it(`should be ${replicationFactor} for orphan collection`, function () {
-          let props = db._collection(on2).properties();
-          expect(props.replicationFactor).to.equal(replicationFactor);
-          expect(props.minReplicationFactor).to.equal(minReplicationFactor);
-        });
-
-      });
-
-      describe('number of shards', function () {
-
-        it(`should be ${numberOfShards} for vertex collection`, function () {
-          let props = db._collection(vn2).properties();
-          expect(props.numberOfShards).to.equal(numberOfShards);
-        });
-
-        it(`should be ${numberOfShards} for edge collection`, function () {
-          let props = db._collection(en2).properties();
-          expect(props.numberOfShards).to.equal(numberOfShards);
-        });
-
-        it(`should be ${numberOfShards} for orphan collection`, function () {
-          let props = db._collection(on2).properties();
-          expect(props.numberOfShards).to.equal(numberOfShards);
-        });
-
-      });
-
-    });
-
-    describe('modify edge definition', function () {
-
-      before(function() {
-        // We modify the first relation by adding a new vertex collection
-
-        let body = {
-          from: [vn],
-          to: [vn3],
-          collection: en
-        };
-
-        let res = request.put(`/_api/gharial/${gn}/edge/${en}`, extend(endpoint, {
-          body: JSON.stringify(body)
-        }));
-
-        expect(res.statusCode).to.equal(202);
-
-        expect(db._collection(vn3)).to.exist;
-      });
-
-      describe('replication factor', function () {
-
-        it(`should be ${replicationFactor} for vertex collection`, function () {
-          let props = db._collection(vn3).properties();
-          expect(props.replicationFactor).to.equal(replicationFactor);
-          expect(props.minReplicationFactor).to.equal(minReplicationFactor);
-        });
-
-      });
-
-      describe('number of shards', function () {
-
-        it(`should be ${numberOfShards} for vertex collection`, function () {
-          let props = db._collection(vn3).properties();
-          expect(props.numberOfShards).to.equal(numberOfShards);
-        });
-
-      });
-
-    });
-
-
-  });
-
+  describe(
+    "with min replication factor startup options",
+    testSuite.bind(this, { minReplicationFactor: 2 })
+  );
+  
+  describe(
+    "with replication factor and shards startup options",
+    testSuite.bind(this, { replciationFactor: 1, numberOfShards: 3 })
+  );
+  
 });

--- a/tests/js/common/shell/general-graph-creation-cluster-spec.js
+++ b/tests/js/common/shell/general-graph-creation-cluster-spec.js
@@ -63,16 +63,43 @@ describe('General graph creation', function () {
     expect(db._collection(vn3)).to.not.exist;
   };
 
-  before(clean);
-  after(clean);
+  const testSuite = (options) => {
+    // Extract desired values, if absent use defaults
+    const replicationFactor =
+      options.replicationFactor || defaultReplicationFactor;
+    const minReplicationFactor = options.minReplicationFactor || 1;
+    const numberOfShards = options.numberOfShards || 1;
 
-  describe('with defaults', function () {
+    // Assert that we do not tests defaults again if we want to overwrite
+    // with specific values
+    if (options.hasOwnProperty("replicationFactor")) {
+      expect(replicationFactor).to.not.equal(defaultReplicationFactor);
+    }
+    if (options.hasOwnProperty("minReplicationFactor")) {
+      expect(minReplicationFactor).to.not.equal(1);
+    }
+    if (options.hasOwnProperty("numberOfShards")) {
+      expect(numberOfShards).to.not.equal(1);
+    }
+
+    const validateProperties = (collectionName) => {
+      let props = db._collection(collectionName).properties();
+      expect(props.replicationFactor).to.equal(replicationFactor);
+      expect(props.minReplicationFactor).to.equal(minReplicationFactor);
+      expect(props.numberOfShards).to.equal(numberOfShards);
+    };
+
     let g;
 
     before(function () {
       let rel = graph._relation(en, vn, vn);
-      // Create with default options
-      g = graph._create(gn, [rel], [on]);
+      if (Object.keys(options).length === 0) {
+        // Create with default empty options
+        g = graph._create(gn, [rel], [on]);
+      } else {
+        // Create with given options
+        g = graph._create(gn, [rel], [on], options);
+      }
 
       // Validate all collections get created
       expect(db._collection(vn)).to.exist;
@@ -87,60 +114,31 @@ describe('General graph creation', function () {
 
     after(clean);
 
-    describe('during graph construction', function () {
-
-      describe('replication factor', function () {
-
-        it('should be stored in the internal document', function () {
-          let gdoc = db._collection('_graphs').document(gn);
-          expect(gdoc.replicationFactor).to.equal(defaultReplicationFactor);
-        });
-
-        it('should be n for vertex collection', function () {
-          let props = db._collection(vn).properties();
-          expect(props.replicationFactor).to.equal(defaultReplicationFactor);
-        });
-
-        it('should be n for edge collection', function () {
-          let props = db._collection(en).properties();
-          expect(props.replicationFactor).to.equal(defaultReplicationFactor);
-        });
-
-        it('should be n for orphan collection', function () {
-          let props = db._collection(on).properties();
-          expect(props.replicationFactor).to.equal(defaultReplicationFactor);
-        });
-
+    describe("during graph construction, the options", function () {
+      it("should be stored in the internal document", function () {
+        let gdoc = db._collection("_graphs").document(gn);
+        expect(gdoc.replicationFactor).to.equal(replicationFactor);
+        expect(gdoc.minReplicationFactor).to.equal(minReplicationFactor);
+        expect(gdoc.numberOfShards).to.equal(numberOfShards);
       });
 
-      describe('number of shards', function () {
+      it(
+        "should be honored for vertex collection",
+        validateProperties.bind(this, vn)
+      );
 
-        it('should be stored in the internal document', function () {
-          let gdoc = db._collection('_graphs').document(gn);
-          expect(gdoc.numberOfShards).to.equal(1);
-        });
+      it(
+        "should be honored for edge collection",
+        validateProperties.bind(this, en)
+      );
 
-        it('should be 1 for vertex collection', function () {
-          let props = db._collection(vn).properties();
-          expect(props.numberOfShards).to.equal(1);
-        });
-
-        it('should be 1 for edge collection', function () {
-          let props = db._collection(en).properties();
-          expect(props.numberOfShards).to.equal(1);
-        });
-
-        it('should be 1 for orphan collection', function () {
-          let props = db._collection(on).properties();
-          expect(props.numberOfShards).to.equal(1);
-        });
-
-      });
-
+      it(
+        "should be honored for orphan collection",
+        validateProperties.bind(this, on)
+      );
     });
 
-    describe('adding collections later', function () {
-
+    describe("adding collections later, options", function () {
       before(function () {
         let rel = graph._relation(en2, vn2, vn2);
         g._extendEdgeDefinitions(rel);
@@ -152,47 +150,23 @@ describe('General graph creation', function () {
         expect(db._collection(on2)).to.exist;
       });
 
-      describe('replication factor', function () {
+      it(
+        "should be honored for vertex collection",
+        validateProperties.bind(this, vn2)
+      );
 
-        it('should be n for vertex collection', function () {
-          let props = db._collection(vn2).properties();
-          expect(props.replicationFactor).to.equal(defaultReplicationFactor);
-        });
+      it(
+        "should be honored for edge collection",
+        validateProperties.bind(this, en2)
+      );
 
-        it('should be n for edge collection', function () {
-          let props = db._collection(en2).properties();
-          expect(props.replicationFactor).to.equal(defaultReplicationFactor);
-        });
-
-        it('should be n for orphan collection', function () {
-          let props = db._collection(on2).properties();
-          expect(props.replicationFactor).to.equal(defaultReplicationFactor);
-        });
-
-      });
-
-      describe('number of shards', function () {
-
-        it('should be 1 for vertex collection', function () {
-          let props = db._collection(vn2).properties();
-          expect(props.numberOfShards).to.equal(1);
-        });
-
-        it('should be 1 for edge collection', function () {
-          let props = db._collection(en2).properties();
-          expect(props.numberOfShards).to.equal(1);
-        });
-
-        it('should be 1 for orphan collection', function () {
-          let props = db._collection(on2).properties();
-          expect(props.numberOfShards).to.equal(1);
-        });
-
-      });
-
+      it(
+        "should be honored for orphan collection",
+        validateProperties.bind(this, on2)
+      );
     });
 
-    describe('modify edge definition', function () {
+    describe("modify edge definition, options", function () {
       before(function () {
         // We modify the first relation by adding a new vertex collection
         let rel = graph._relation(en, vn, vn3);
@@ -201,181 +175,10 @@ describe('General graph creation', function () {
         expect(db._collection(vn3)).to.exist;
       });
 
-      describe('replication factor', function () {
-
-        it(`should be n for vertex collection`, function () {
-          let props = db._collection(vn3).properties();
-          expect(props.replicationFactor).to.equal(defaultReplicationFactor);
-        });
-
-      });
-
-      describe('number of shards', function () {
-
-        it(`should be 1 for vertex collection`, function () {
-          let props = db._collection(vn3).properties();
-          expect(props.numberOfShards).to.equal(1);
-        });
-
-      });
-
-    });
-
-  });
-
-  describe('with startup options', function () {
-    let g;
-    const replicationFactor = 2;
-    const numberOfShards = 3;
-
-    before(function () {
-      const options = {
-        replicationFactor,
-        numberOfShards
-      };
-      let rel = graph._relation(en, vn, vn);
-      // Create with default options
-      g = graph._create(gn, [rel], [on], options);
-
-      // Validate all collections get created
-      expect(db._collection(vn)).to.exist;
-      expect(db._collection(en)).to.exist;
-      expect(db._collection(on)).to.exist;
-
-      // Validate create later collections to not exist
-      expect(db._collection(vn2)).to.not.exist;
-      expect(db._collection(en2)).to.not.exist;
-      expect(db._collection(on2)).to.not.exist;
-    });
-
-    after(clean);
-
-    describe('during graph construction', function () {
-
-      describe('replication factor', function () {
-
-        it('should be stored in the internal document', function () {
-          let gdoc = db._collection('_graphs').document(gn);
-          expect(gdoc.replicationFactor).to.equal(replicationFactor);
-        });
-
-        it(`should be ${replicationFactor} for vertex collection`, function () {
-          let props = db._collection(vn).properties();
-          expect(props.replicationFactor).to.equal(replicationFactor);
-        });
-
-        it(`should be ${replicationFactor} for edge collection`, function () {
-          let props = db._collection(en).properties();
-          expect(props.replicationFactor).to.equal(replicationFactor);
-        });
-
-        it(`should be ${replicationFactor} for orphan collection`, function () {
-          let props = db._collection(on).properties();
-          expect(props.replicationFactor).to.equal(replicationFactor);
-        });
-
-      });
-
-      describe('number of shards', function () {
-
-        it('should be stored in the internal document', function () {
-          let gdoc = db._collection('_graphs').document(gn);
-          expect(gdoc.numberOfShards).to.equal(numberOfShards);
-        });
-
-        it(`should be ${numberOfShards} for vertex collection`, function () {
-          let props = db._collection(vn).properties();
-          expect(props.numberOfShards).to.equal(numberOfShards);
-        });
-
-        it(`should be ${numberOfShards} for edge collection`, function () {
-          let props = db._collection(en).properties();
-          expect(props.numberOfShards).to.equal(numberOfShards);
-        });
-
-        it(`should be ${numberOfShards} for orphan collection`, function () {
-          let props = db._collection(on).properties();
-          expect(props.numberOfShards).to.equal(numberOfShards);
-        });
-
-      });
-
-    });
-
-    describe('adding collections later', function () {
-
-      before(function () {
-        let rel = graph._relation(en2, vn2, vn2);
-        g._extendEdgeDefinitions(rel);
-        g._addVertexCollection(on2);
-
-        // Validate create later collections to now exist
-        expect(db._collection(vn2)).to.exist;
-        expect(db._collection(en2)).to.exist;
-        expect(db._collection(on2)).to.exist;
-      });
-
-      describe('replication factor', function () {
-
-        it(`should be ${replicationFactor} for vertex collection`, function () {
-          let props = db._collection(vn2).properties();
-          expect(props.replicationFactor).to.equal(replicationFactor);
-        });
-
-        it(`should be ${replicationFactor} for edge collection`, function () {
-          let props = db._collection(en2).properties();
-          expect(props.replicationFactor).to.equal(replicationFactor);
-        });
-
-        it(`should be ${replicationFactor} for orphan collection`, function () {
-          let props = db._collection(on2).properties();
-          expect(props.replicationFactor).to.equal(replicationFactor);
-        });
-
-      });
-
-      describe('number of shards', function () {
-
-        it(`should be ${numberOfShards} for vertex collection`, function () {
-          let props = db._collection(vn2).properties();
-          expect(props.numberOfShards).to.equal(numberOfShards);
-        });
-
-        it(`should be ${numberOfShards} for edge collection`, function () {
-          let props = db._collection(en2).properties();
-          expect(props.numberOfShards).to.equal(numberOfShards);
-        });
-
-        it(`should be ${numberOfShards} for orphan collection`, function () {
-          let props = db._collection(on2).properties();
-          expect(props.numberOfShards).to.equal(numberOfShards);
-        });
-
-      });
-
-    });
-
-    describe('modify edge definition', function () {
-      before(function () {
-        // We modify the first relation by adding a new vertex collection
-        let rel = graph._relation(en, vn, vn3);
-        g._editEdgeDefinitions(rel);
-        expect(db._collection(vn3)).to.exist;
-      });
-
-      describe('replication factor', function () {
-        it(`should be ${replicationFactor} for vertex collection`, function () {
-          let props = db._collection(vn3).properties();
-          expect(props.replicationFactor).to.equal(replicationFactor);
-        });
-      });
-
-      describe('number of shards', function () {
-        it(`should be ${numberOfShards} for vertex collection`, function () {
-          let props = db._collection(vn3).properties();
-          expect(props.numberOfShards).to.equal(numberOfShards);
-        });
-      });
+      it(
+        "should be honored for vertex collection",
+        validateProperties.bind(this, vn3)
+      );
     });
 
     describe('modify vertices', function () {
@@ -396,6 +199,21 @@ describe('General graph creation', function () {
         expect(found).to.be.false;
       });
     });
+  };
 
-  });
+
+  before(clean);
+  after(clean);
+
+  describe("with defaults", testSuite.bind(this, {}));
+
+  describe(
+    "with min replication factor startup options",
+    testSuite.bind(this, { minReplicationFactor: 2 })
+  );
+  
+  describe(
+    "with replication factor and shards startup options",
+    testSuite.bind(this, { replciationFactor: 1, numberOfShards: 3 })
+  );
 });


### PR DESCRIPTION
This PR only adapts existing tests.
No User-Impact at all => No CHANGELOG.

We have modified the default replication factor used in tests to `2` in a previous PR.
Now during graph creation we tested the default replication factor and a specific replication factor of `2`.
Those are not distinguishable anymore. So with this PR we use default replication factor `2` and specific replication factor `1`.
It is asserted that the specific value is different from the default value, to ensure if defaults change this test will get red either way, and needs to be adapted.

Both test suites touched here consisted of a lot of copy-paste code, so I replaced them by a generator instead to make it simpler.

NOTE:
Before we tested replicationFactor, minReplicationFactor and numberOfShards specific values in the same suite.
This is not possible any more as minReplicationFactor by default is 1, and needs to be less then replicationFactor. So they would contradict each other, so we got one test suite more.