### PR TITLE
Fix and document memory profiling

### DIFF
--- a/arangod/RestHandler/RestStatusHandler.cpp
+++ b/arangod/RestHandler/RestStatusHandler.cpp
@@ -287,12 +287,12 @@ RestStatus RestStatusHandler::executeOverview() {
 RestStatus RestStatusHandler::executeMemoryProfile() {
 #if defined(USE_MEMORY_PROFILE)
   long err;
-  std::string filename;
+  std::string fileName;
   std::string msg;
-  int res = TRI_GetTempName(nullptr, filename, true, err, msg);
+  int res = TRI_GetTempName(nullptr, fileName, true, err, msg);
 
   if (res != TRI_ERROR_NO_ERROR) {
-    generateError(rest::ResponseCode::INTERNAL_ERROR, res, msg);
+    generateError(rest::ResponseCode::SERVER_ERROR, res, msg);
   } else {
     char const* f = fileName.c_str();
     try {


### PR DESCRIPTION
This adds documentation for memory profiling to README_maintainers.md.
It also fixes memory profiling for `devel`.

This is no user facing capability.

