### PR TITLE
Turn off option `--server.export-read-write-metrics` for now

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Turn off option `--server.export-read-write-metrics` for now, until there
+  is certainty about the runtime overhead it introduces.
+
 * Remove unsafe query option `inspectSimplePlans`. This option previously
   defaulted to `true`, and turning it off could make particular queries fail.
   The option was ignored in the cluster previously, and turning it off only

--- a/arangod/RestServer/MetricsFeature.cpp
+++ b/arangod/RestServer/MetricsFeature.cpp
@@ -51,7 +51,9 @@ using namespace arangodb::options;
 // -----------------------------------------------------------------------------
 
 MetricsFeature::MetricsFeature(application_features::ApplicationServer& server)
-  : ApplicationFeature(server, "Metrics"), _export(true) , _exportReadWriteMetrics(true) {
+  : ApplicationFeature(server, "Metrics"), 
+    _export(true) , 
+    _exportReadWriteMetrics(false) {
   setOptional(false);
   startsAfter<LoggerFeature>();
   startsBefore<GreetingsFeaturePhase>();
@@ -66,6 +68,7 @@ void MetricsFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                      new BooleanParameter(&_export),
                      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden))
                      .setIntroducedIn(30600);
+
   options->addOption("--server.export-read-write-metrics",
                      "turn metrics for document read/write metrics on or off",
                      new BooleanParameter(&_exportReadWriteMetrics),


### PR DESCRIPTION
### Scope & Purpose

Turn off option `--server.export-read-write-metrics` for now, until there is certainty about the runtime overhead it introduces. I agreed on this with @neunhoef today.

There is currently some investigation ongoing by @neunhoef to measure the overhead of metrics in general, which will likely trigger some follow-up optimizations and lead to this option being turned on again by default. But we can do this all separately.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *server_parameters*.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13813/