### PR TITLE
Quiet suggest-override warning as error

### DIFF
--- a/3rdParty/iresearch/core/analysis/token_streams.hpp
+++ b/3rdParty/iresearch/core/analysis/token_streams.hpp
@@ -37,7 +37,7 @@ namespace iresearch {
 //////////////////////////////////////////////////////////////////////////////
 class IRESEARCH_API basic_token_stream : public token_stream {
  public:
-  virtual attribute* get_mutable(type_info::type_id type) noexcept final;
+  virtual attribute* get_mutable(type_info::type_id type) noexcept override final;
 
  protected:
   term_attribute term_;

--- a/3rdParty/iresearch/core/formats/formats_burst_trie.cpp
+++ b/3rdParty/iresearch/core/formats/formats_burst_trie.cpp
@@ -1765,7 +1765,7 @@ class term_iterator_base
     it.load_data(*field_, *this, state_, *postings_);
   }
 
-  virtual seek_term_iterator::seek_cookie::ptr cookie() const final {
+  virtual seek_term_iterator::seek_cookie::ptr cookie() const override final {
     return ::cookie::make(state_, freq_.value);
   }
 

--- a/3rdParty/iresearch/core/index/iterators.cpp
+++ b/3rdParty/iresearch/core/index/iterators.cpp
@@ -68,15 +68,15 @@ empty_doc_iterator EMPTY_DOC_ITERATOR;
 /// @brief represents an iterator without terms
 //////////////////////////////////////////////////////////////////////////////
 struct empty_term_iterator : irs::term_iterator {
-  virtual const irs::bytes_ref& value() const noexcept final {
+  virtual const irs::bytes_ref& value() const noexcept override final {
     return irs::bytes_ref::NIL;
   }
-  virtual irs::doc_iterator::ptr postings(const irs::flags&) const noexcept final {
+  virtual irs::doc_iterator::ptr postings(const irs::flags&) const noexcept override final {
     return irs::doc_iterator::empty();
   }
-  virtual void read() noexcept final { }
-  virtual bool next() noexcept final { return false; }
-  virtual irs::attribute* get_mutable(irs::type_info::type_id) noexcept final {
+  virtual void read() noexcept override final { }
+  virtual bool next() noexcept override final { return false; }
+  virtual irs::attribute* get_mutable(irs::type_info::type_id) noexcept override final {
     return nullptr;
   }
 }; // empty_term_iterator
@@ -88,15 +88,15 @@ empty_term_iterator EMPTY_TERM_ITERATOR;
 /// @brief represents an iterator without terms
 //////////////////////////////////////////////////////////////////////////////
 struct empty_seek_term_iterator final : irs::seek_term_iterator {
-  virtual const irs::bytes_ref& value() const noexcept final {
+  virtual const irs::bytes_ref& value() const noexcept override final {
     return irs::bytes_ref::NIL;
   }
-  virtual irs::doc_iterator::ptr postings(const irs::flags&) const noexcept final {
+  virtual irs::doc_iterator::ptr postings(const irs::flags&) const noexcept override final {
     return irs::doc_iterator::empty();
   }
-  virtual void read() noexcept final { }
-  virtual bool next() noexcept final { return false; }
-  virtual irs::attribute* get_mutable(irs::type_info::type_id) noexcept final {
+  virtual void read() noexcept override final { }
+  virtual bool next() noexcept override final { return false; }
+  virtual irs::attribute* get_mutable(irs::type_info::type_id) noexcept override final {
     return nullptr;
   }
   virtual irs::SeekResult seek_ge(const irs::bytes_ref&) noexcept override {

--- a/3rdParty/iresearch/core/search/sort.hpp
+++ b/3rdParty/iresearch/core/search/sort.hpp
@@ -714,14 +714,14 @@ class prepared_sort_base<ScoreType, void, TraitsType> : public sort::prepared {
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief number of bytes required to store the score type (i.e. sizeof(score))
   ////////////////////////////////////////////////////////////////////////////////
-  virtual inline std::pair<size_t, size_t> score_size() const noexcept final {
+  virtual inline std::pair<size_t, size_t> score_size() const noexcept override final {
     return std::make_pair(sizeof(score_t), alignof(score_t));
   }
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief number of bytes required to store stats
   ////////////////////////////////////////////////////////////////////////////////
-  virtual inline std::pair<size_t, size_t> stats_size() const noexcept final {
+  virtual inline std::pair<size_t, size_t> stats_size() const noexcept override final {
     return std::make_pair(size_t(0), size_t(0));
   }
 }; // prepared_sort_base

--- a/3rdParty/iresearch/core/store/data_input.hpp
+++ b/3rdParty/iresearch/core/store/data_input.hpp
@@ -161,7 +161,7 @@ class IRESEARCH_API buffered_index_input : public index_input {
 
   virtual size_t read_bytes(byte_type* b, size_t count) override final;
 
-  virtual const byte_type* read_buffer(size_t size, BufferHint hint) noexcept final;
+  virtual const byte_type* read_buffer(size_t size, BufferHint hint) noexcept override final;
 
   virtual size_t file_pointer() const noexcept override final {
     return start_ + offset();

--- a/3rdParty/iresearch/core/store/store_utils.hpp
+++ b/3rdParty/iresearch/core/store/store_utils.hpp
@@ -399,7 +399,7 @@ class IRESEARCH_API bytes_ref_input : public index_input {
     return *pos_++;
   }
 
-  virtual const byte_type* read_buffer(size_t size, BufferHint /*hint*/) noexcept final {
+  virtual const byte_type* read_buffer(size_t size, BufferHint /*hint*/) noexcept override final {
     const auto* pos = pos_ + size;
 
     if (pos > data_.end()) {

--- a/3rdParty/iresearch/core/utils/frozen_attributes.hpp
+++ b/3rdParty/iresearch/core/utils/frozen_attributes.hpp
@@ -47,7 +47,7 @@ template<
       attrs_(values) {
   }
 
-  virtual attribute* get_mutable(type_info::type_id type) noexcept final {
+  virtual attribute* get_mutable(type_info::type_id type) noexcept override final {
     const auto it = attrs_.find(type);
     return it == attrs_.end() ? nullptr : it->second;
   }

--- a/3rdParty/iresearch/core/utils/fstext/fst_table_matcher.hpp
+++ b/3rdParty/iresearch/core/utils/fstext/fst_table_matcher.hpp
@@ -169,7 +169,7 @@ class TableMatcher final : public MatcherBase<typename F::Arc> {
     }
   }
 
-  virtual void SetState(StateId s) noexcept final {
+  virtual void SetState(StateId s) noexcept override final {
     assert(!error_);
     assert(s*start_labels_.size() < transitions_.size());
     state_begin_ = transitions_.data() + s*start_labels_.size();
@@ -177,7 +177,7 @@ class TableMatcher final : public MatcherBase<typename F::Arc> {
     state_end_ = state_begin_ + start_labels_.size();
   }
 
-  virtual bool Find(Label label) noexcept final {
+  virtual bool Find(Label label) noexcept override final {
     assert(!error_);
     auto label_offset = (size_t(label) < IRESEARCH_COUNTOF(cached_label_offsets_)
                            ? cached_label_offsets_[size_t(label)]
@@ -198,17 +198,17 @@ class TableMatcher final : public MatcherBase<typename F::Arc> {
     return arc_.nextstate != kNoStateId;
   }
 
-  virtual bool Done() const noexcept final {
+  virtual bool Done() const noexcept override final {
     assert(!error_);
     return state_ == state_end_;
   }
 
-  virtual const Arc& Value() const noexcept final {
+  virtual const Arc& Value() const noexcept override final {
     assert(!error_);
     return arc_;
   }
 
-  virtual void Next() noexcept final {
+  virtual void Next() noexcept override final {
     assert(!error_);
 
     if (Done()) {
@@ -232,11 +232,11 @@ class TableMatcher final : public MatcherBase<typename F::Arc> {
     }
   }
 
-  virtual Weight Final(StateId s) const final {
+  virtual Weight Final(StateId s) const override final {
     return MatcherBase<Arc>::Final(s);
   }
 
-  virtual ssize_t Priority(StateId s) final {
+  virtual ssize_t Priority(StateId s) override final {
     return MatcherBase<Arc>::Priority(s);
   }
 

--- a/3rdParty/iresearch/external/openfst/fst/lookahead-matcher.h
+++ b/3rdParty/iresearch/external/openfst/fst/lookahead-matcher.h
@@ -286,22 +286,22 @@ class ArcLookAheadMatcher : public LookAheadMatcherBase<typename M::FST::Arc> {
 
   MatchType Type(bool test) const override { return matcher_.Type(test); }
 
-  void SetState(StateId s) final {
+  void SetState(StateId s) override final {
     state_ = s;
     matcher_.SetState(s);
   }
 
-  bool Find(Label label) final { return matcher_.Find(label); }
+  bool Find(Label label) override final { return matcher_.Find(label); }
 
-  bool Done() const final { return matcher_.Done(); }
+  bool Done() const override final { return matcher_.Done(); }
 
-  const Arc &Value() const final { return matcher_.Value(); }
+  const Arc &Value() const override final { return matcher_.Value(); }
 
-  void Next() final { matcher_.Next(); }
+  void Next() override final { matcher_.Next(); }
 
-  Weight Final(StateId s) const final { return matcher_.Final(s); }
+  Weight Final(StateId s) const override final { return matcher_.Final(s); }
 
-  ssize_t Priority(StateId s) final { return matcher_.Priority(s); }
+  ssize_t Priority(StateId s) override final { return matcher_.Priority(s); }
 
   const FST &GetFst() const override { return fst_; }
 
@@ -330,7 +330,7 @@ class ArcLookAheadMatcher : public LookAheadMatcherBase<typename M::FST::Arc> {
   // at (state_, s).
   bool LookAheadFst(const Fst<Arc> &, StateId) final;
 
-  bool LookAheadLabel(Label label) const final { return matcher_.Find(label); }
+  bool LookAheadLabel(Label label) const override final { return matcher_.Find(label); }
 
  private:
   mutable M matcher_;
@@ -483,14 +483,14 @@ class LabelLookAheadMatcher
 
   MatchType Type(bool test) const override { return matcher_.Type(test); }
 
-  void SetState(StateId s) final {
+  void SetState(StateId s) override final {
     if (state_ == s) return;
     state_ = s;
     match_set_state_ = false;
     reach_set_state_ = false;
   }
 
-  bool Find(Label label) final {
+  bool Find(Label label) override final {
     if (!match_set_state_) {
       matcher_.SetState(state_);
       match_set_state_ = true;
@@ -498,15 +498,15 @@ class LabelLookAheadMatcher
     return matcher_.Find(label);
   }
 
-  bool Done() const final { return matcher_.Done(); }
+  bool Done() const override final { return matcher_.Done(); }
 
-  const Arc &Value() const final { return matcher_.Value(); }
+  const Arc &Value() const override final { return matcher_.Value(); }
 
-  void Next() final { matcher_.Next(); }
+  void Next() override final { matcher_.Next(); }
 
-  Weight Final(StateId s) const final { return matcher_.Final(s); }
+  Weight Final(StateId s) const override final { return matcher_.Final(s); }
 
-  ssize_t Priority(StateId s) final { return matcher_.Priority(s); }
+  ssize_t Priority(StateId s) override final { return matcher_.Priority(s); }
 
   const FST &GetFst() const override { return matcher_.GetFst(); }
 
@@ -542,7 +542,7 @@ class LabelLookAheadMatcher
   bool LookAheadFst(const LFST &fst, StateId s);
 
   // Required to make class concrete.
-  bool LookAheadFst(const Fst<Arc> &fst, StateId s) final {
+  bool LookAheadFst(const Fst<Arc> &fst, StateId s) override final {
     return LookAheadFst<Fst<Arc>>(fst, s);
   }
 
@@ -563,7 +563,7 @@ class LabelLookAheadMatcher
     }
   }
 
-  bool LookAheadLabel(Label label) const final {
+  bool LookAheadLabel(Label label) const override final {
     if (label == 0) return true;
     if (label_reachable_) {
       if (!reach_set_state_) {

--- a/3rdParty/iresearch/external/openfst/fst/matcher.h
+++ b/3rdParty/iresearch/external/openfst/fst/matcher.h
@@ -231,7 +231,7 @@ class SortedMatcher : public MatcherBase<typename F::Arc> {
     }
   }
 
-  void SetState(StateId s) final {
+  void SetState(StateId s) override final {
     if (state_ == s) return;
     state_ = s;
     if (match_type_ == MATCH_NONE) {
@@ -245,7 +245,7 @@ class SortedMatcher : public MatcherBase<typename F::Arc> {
     loop_.nextstate = s;
   }
 
-  bool Find(Label match_label) final {
+  bool Find(Label match_label) override final {
     exact_match_ = true;
     if (error_) {
       current_loop_ = false;
@@ -276,7 +276,7 @@ class SortedMatcher : public MatcherBase<typename F::Arc> {
 
   // After Find(), returns false if no more exact matches.
   // After LowerBound(), returns false if no more arcs.
-  bool Done() const final {
+  bool Done() const override final {
     if (current_loop_) return false;
     if (aiter_->Done()) return true;
     if (!exact_match_) return false;
@@ -286,13 +286,13 @@ class SortedMatcher : public MatcherBase<typename F::Arc> {
     return GetLabel() != match_label_;
   }
 
-  const Arc &Value() const final {
+  const Arc &Value() const override final {
     if (current_loop_) return loop_;
     aiter_->SetFlags(kArcValueFlags, kArcValueFlags);
     return aiter_->Value();
   }
 
-  void Next() final {
+  void Next() override final {
     if (current_loop_) {
       current_loop_ = false;
     } else {
@@ -300,11 +300,11 @@ class SortedMatcher : public MatcherBase<typename F::Arc> {
     }
   }
 
-  Weight Final(StateId s) const final {
+  Weight Final(StateId s) const override final {
     return MatcherBase<Arc>::Final(s);
   }
 
-  ssize_t Priority(StateId s) final {
+  ssize_t Priority(StateId s) override final {
     return MatcherBase<Arc>::Priority(s);
   }
 
@@ -912,14 +912,14 @@ class RhoMatcher : public MatcherBase<typename M::Arc> {
 
   MatchType Type(bool test) const override { return matcher_->Type(test); }
 
-  void SetState(StateId s) final {
+  void SetState(StateId s) override final {
     if (state_ == s) return;
     state_ = s;
     matcher_->SetState(s);
     has_rho_ = rho_label_ != kNoLabel;
   }
 
-  bool Find(Label label) final {
+  bool Find(Label label) override final {
     if (label == rho_label_ && rho_label_ != kNoLabel) {
       FSTERROR() << "RhoMatcher::Find: bad label (rho)";
       error_ = true;
@@ -937,9 +937,9 @@ class RhoMatcher : public MatcherBase<typename M::Arc> {
     }
   }
 
-  bool Done() const final { return matcher_->Done(); }
+  bool Done() const override final { return matcher_->Done(); }
 
-  const Arc &Value() const final {
+  const Arc &Value() const override final {
     if (rho_match_ == kNoLabel) {
       return matcher_->Value();
     } else {
@@ -956,11 +956,11 @@ class RhoMatcher : public MatcherBase<typename M::Arc> {
     }
   }
 
-  void Next() final { matcher_->Next(); }
+  void Next() override final { matcher_->Next(); }
 
-  Weight Final(StateId s) const final { return matcher_->Final(s); }
+  Weight Final(StateId s) const override final { return matcher_->Final(s); }
 
-  ssize_t Priority(StateId s) final {
+  ssize_t Priority(StateId s) override final {
     state_ = s;
     matcher_->SetState(s);
     has_rho_ = matcher_->Find(rho_label_);

--- a/3rdParty/iresearch/external/openfst/fst/vector-fst.h
+++ b/3rdParty/iresearch/external/openfst/fst/vector-fst.h
@@ -739,19 +739,19 @@ class MutableArcIterator<VectorFst<Arc, State>>
     properties_ = &fst->GetImpl()->properties_;
   }
 
-  bool Done() const final { return i_ >= state_->NumArcs(); }
+  bool Done() const override final { return i_ >= state_->NumArcs(); }
 
-  const Arc &Value() const final { return state_->GetArc(i_); }
+  const Arc &Value() const override final { return state_->GetArc(i_); }
 
-  void Next() final { ++i_; }
+  void Next() override final { ++i_; }
 
-  size_t Position() const final { return i_; }
+  size_t Position() const override final { return i_; }
 
-  void Reset() final { i_ = 0; }
+  void Reset() override final { i_ = 0; }
 
-  void Seek(size_t a) final { i_ = a; }
+  void Seek(size_t a) override final { i_ = a; }
 
-  void SetValue(const Arc &arc) final {
+  void SetValue(const Arc &arc) override final {
     const auto &oarc = state_->GetArc(i_);
     if (oarc.ilabel != oarc.olabel) *properties_ &= ~kNotAcceptor;
     if (oarc.ilabel == 0) {
@@ -788,9 +788,9 @@ class MutableArcIterator<VectorFst<Arc, State>>
                     kNoOEpsilons | kWeighted | kUnweighted;
   }
 
-  uint32 Flags() const final { return kArcValueFlags; }
+  uint32 Flags() const override final { return kArcValueFlags; }
 
-  void SetFlags(uint32, uint32) final {}
+  void SetFlags(uint32, uint32) override final {}
 
  private:
   State *state_;

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix warnings about suggest-override which can break builds when warnings
+  are treated as errors.
+
 * Turn off option `--server.export-read-write-metrics` for now, until there
   is certainty about the runtime overhead it introduces.
 

--- a/arangod/Agency/AgencyPaths.h
+++ b/arangod/Agency/AgencyPaths.h
@@ -123,7 +123,7 @@ auto root() -> std::shared_ptr<Root const>;
 // base case for recursions.
 class Root : public std::enable_shared_from_this<Root>, public Path {
  public:
-  void forEach(std::function<void(char const* component)> const&) const final {}
+  void forEach(std::function<void(char const* component)> const&) const override final {}
 
  public:
   class Arango : public StaticComponent<Arango, Root> {

--- a/arangod/Agency/PathComponent.h
+++ b/arangod/Agency/PathComponent.h
@@ -82,7 +82,7 @@ class StaticComponent : public std::enable_shared_from_this<T> /* (sic) */, publ
 
   StaticComponent() = delete;
 
-  void forEach(std::function<void(char const* component)> const& callback) const final {
+  void forEach(std::function<void(char const* component)> const& callback) const override final {
     parent().forEach(callback);
     callback(child().component());
   }
@@ -126,7 +126,7 @@ class DynamicComponent : public std::enable_shared_from_this<T> /* (sic) */, pub
 
   DynamicComponent() = delete;
 
-  void forEach(std::function<void(char const* component)> const& callback) const final {
+  void forEach(std::function<void(char const* component)> const& callback) const override final {
     parent().forEach(callback);
     callback(child().component());
   }

--- a/arangod/Aql/ClusterNodes.h
+++ b/arangod/Aql/ClusterNodes.h
@@ -243,7 +243,7 @@ class DistributeNode final : public ScatterNode, public CollectionAccessingNode 
   }
 
   /// @brief getVariablesUsedHere, modifying the set in-place
-  void getVariablesUsedHere(VarSet& vars) const final;
+  void getVariablesUsedHere(VarSet& vars) const override final;
 
   /// @brief estimateCost
   CostEstimate estimateCost() const override final;
@@ -342,7 +342,7 @@ class GatherNode final : public ExecutionNode {
   CostEstimate estimateCost() const override final;
 
   /// @brief getVariablesUsedHere, modifying the set in-place
-  void getVariablesUsedHere(VarSet& vars) const final;
+  void getVariablesUsedHere(VarSet& vars) const override final;
 
   /// @brief get Variables used here including ASC/DESC
   SortElementVector const& elements() const { return _elements; }
@@ -432,7 +432,7 @@ class SingleRemoteOperationNode final : public ExecutionNode, public CollectionA
   }
 
   /// @brief getVariablesUsedHere, modifying the set in-place
-  void getVariablesUsedHere(VarSet& vars) const final;
+  void getVariablesUsedHere(VarSet& vars) const override final;
 
   /// @brief getVariablesSetHere
   virtual std::vector<Variable const*> getVariablesSetHere() const override final;

--- a/arangod/Aql/CollectNode.h
+++ b/arangod/Aql/CollectNode.h
@@ -70,7 +70,7 @@ class CollectNode : public ExecutionNode {
   ~CollectNode() override;
 
   /// @brief return the type of the node
-  NodeType getType() const final;
+  NodeType getType() const override final;
 
   /// @brief whether or not the node requires an additional post SORT
   bool isDistinctCommand() const;
@@ -92,7 +92,7 @@ class CollectNode : public ExecutionNode {
 
   /// @brief export to VelocyPack
   void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const final;
+                          std::unordered_set<ExecutionNode const*>& seen) const override final;
 
   /// @brief calculate the expression register
   void calcExpressionRegister(RegisterId& expressionRegister,
@@ -123,10 +123,10 @@ class CollectNode : public ExecutionNode {
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
-                       bool withProperties) const final;
+                       bool withProperties) const override final;
 
   /// @brief estimateCost
-  CostEstimate estimateCost() const final;
+  CostEstimate estimateCost() const override final;
 
   /// @brief whether or not the node has an outVariable (i.e. INTO ...)
   bool hasOutVariable() const;
@@ -180,10 +180,10 @@ class CollectNode : public ExecutionNode {
   std::vector<AggregateVarInfo>& aggregateVariables();
 
   /// @brief getVariablesUsedHere, modifying the set in-place
-  void getVariablesUsedHere(VarSet& vars) const final;
+  void getVariablesUsedHere(VarSet& vars) const override final;
 
   /// @brief getVariablesSetHere
-  std::vector<Variable const*> getVariablesSetHere() const final;
+  std::vector<Variable const*> getVariablesSetHere() const override final;
 
   static void calculateAccessibleUserVariables(ExecutionNode const& node,
                                                std::vector<Variable const*>& userVariables);

--- a/arangod/Aql/ExecutionEngine.cpp
+++ b/arangod/Aql/ExecutionEngine.cpp
@@ -389,7 +389,7 @@ struct DistributedQueryInstanciator final
   /// @brief before method for collection of pieces phase
   ///        Collects all nodes on the path and divides them
   ///        into coordinator and dbserver parts
-  bool before(ExecutionNode* en) final {
+  bool before(ExecutionNode* en) override final {
     auto const nodeType = en->getType();
     if (_isCoordinator) {
       _coordinatorParts.addNode(en);
@@ -432,7 +432,7 @@ struct DistributedQueryInstanciator final
     return false;
   }
 
-  void after(ExecutionNode* en) final {
+  void after(ExecutionNode* en) override final {
     if (en->getType() == ExecutionNode::REMOTE) {
       if (_isCoordinator) {
         _lastClosed = _coordinatorParts.closeSnippet();

--- a/arangod/Aql/IndexNode.h
+++ b/arangod/Aql/IndexNode.h
@@ -74,7 +74,7 @@ class IndexNode : public ExecutionNode, public DocumentProducingNode, public Col
   ~IndexNode() override;
 
   /// @brief return the type of the node
-  NodeType getType() const final;
+  NodeType getType() const override final;
 
   /// @brief return the condition for the node
   Condition* condition() const;
@@ -94,7 +94,7 @@ class IndexNode : public ExecutionNode, public DocumentProducingNode, public Col
 
   /// @brief export to VelocyPack
   void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const final;
+                          std::unordered_set<ExecutionNode const*>& seen) const override final;
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
@@ -103,16 +103,16 @@ class IndexNode : public ExecutionNode, public DocumentProducingNode, public Col
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
-                       bool withProperties) const final;
+                       bool withProperties) const override final;
 
   /// @brief getVariablesSetHere
-  std::vector<Variable const*> getVariablesSetHere() const final;
+  std::vector<Variable const*> getVariablesSetHere() const override final;
 
   /// @brief getVariablesUsedHere, modifying the set in-place
-  void getVariablesUsedHere(VarSet& vars) const final;
+  void getVariablesUsedHere(VarSet& vars) const override final;
 
   /// @brief estimateCost
-  CostEstimate estimateCost() const final;
+  CostEstimate estimateCost() const override final;
 
   /// @brief getIndexes, hand out the indexes used
   std::vector<transaction::Methods::IndexHandle> const& getIndexes() const;

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -8015,7 +8015,7 @@ void findSubqueriesSuitableForSplicing(ExecutionPlan const& plan,
       _isSuitableLevel.emplace(true);
     }
 
-    bool before(ExecutionNode* node) final {
+    bool before(ExecutionNode* node) override final {
       TRI_ASSERT(node->getType() != EN::MUTEX); // should never appear here
 
       if (node->getType() == ExecutionNode::SUBQUERY) {
@@ -8031,14 +8031,14 @@ void findSubqueriesSuitableForSplicing(ExecutionPlan const& plan,
       return abort;
     }
 
-    bool enterSubquery(ExecutionNode* subq, ExecutionNode* root) final {
+    bool enterSubquery(ExecutionNode* subq, ExecutionNode* root) override final {
       _isSuitableLevel.emplace(true);
 
       constexpr bool enterSubqueries = true;
       return enterSubqueries;
     }
 
-    void leaveSubquery(ExecutionNode* subqueryNode, ExecutionNode*) final {
+    void leaveSubquery(ExecutionNode* subqueryNode, ExecutionNode*) override final {
       TRI_ASSERT(!_isSuitableLevel.empty());
 
       const bool subqueryDoesNotSkipInside = _isSuitableLevel.top();

--- a/arangod/Aql/QuerySnippet.cpp
+++ b/arangod/Aql/QuerySnippet.cpp
@@ -112,8 +112,8 @@ class CloneWorker final : public WalkerWorker<ExecutionNode, WalkerUniqueness::N
   void process();
 
  private:
-  bool before(ExecutionNode* node) final;
-  bool enterSubquery(ExecutionNode* subq, ExecutionNode* root) final;
+  bool before(ExecutionNode* node) override final;
+  bool enterSubquery(ExecutionNode* subq, ExecutionNode* root) override final;
 
   void processAfter(ExecutionNode* node);
 

--- a/arangod/Aql/RegisterPlan.h
+++ b/arangod/Aql/RegisterPlan.h
@@ -88,8 +88,8 @@ struct RegisterPlanWalkerT final : public WalkerWorker<T, WalkerUniqueness::NonU
         explain(explainRegisterPlan == ExplainRegisterPlan::Yes) {}
   virtual ~RegisterPlanWalkerT() noexcept = default;
 
-  void after(T* eb) final;
-  bool enterSubquery(T*, T*) final {
+  void after(T* eb) override final;
+  bool enterSubquery(T*, T*) override final {
     return false;  // do not walk into subquery
   }
 

--- a/arangod/Aql/SubqueryEndExecutionNode.h
+++ b/arangod/Aql/SubqueryEndExecutionNode.h
@@ -60,7 +60,7 @@ class SubqueryEndNode : public ExecutionNode {
 
   bool isEqualTo(ExecutionNode const& other) const override final;
 
-  void getVariablesUsedHere(VarSet& usedVars) const final {
+  void getVariablesUsedHere(VarSet& usedVars) const override final {
     if (_inVariable != nullptr) {
       usedVars.emplace(_inVariable);
     }

--- a/arangod/Aql/VarUsageFinder.h
+++ b/arangod/Aql/VarUsageFinder.h
@@ -70,7 +70,7 @@ struct VarUsageFinderT final : public WalkerWorker<T, WalkerUniqueness::NonUniqu
     }
   }
 
-  bool before(T* en) final;
+  bool before(T* en) override final;
 
   /*
    * o  set: x, z   valid = x, z  usedLater = (z, x)
@@ -89,7 +89,7 @@ struct VarUsageFinderT final : public WalkerWorker<T, WalkerUniqueness::NonUniqu
 
   void after(T* en) override final;
 
-  bool enterSubquery(T*, T*) final;
+  bool enterSubquery(T*, T*) override final;
 };
 
 }  // namespace arangodb::aql

--- a/arangod/Aql/WindowNode.h
+++ b/arangod/Aql/WindowNode.h
@@ -113,11 +113,11 @@ class WindowNode : public ExecutionNode {
   ~WindowNode() override;
 
   /// @brief return the type of the node
-  NodeType getType() const final;
+  NodeType getType() const override final;
 
   /// @brief export to VelocyPack
   void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const final;
+                          std::unordered_set<ExecutionNode const*>& seen) const override final;
 
   /// @brief calculate the aggregate registers
   void calcAggregateRegisters(std::vector<std::pair<RegisterId, RegisterId>>& aggregateRegisters,
@@ -133,18 +133,18 @@ class WindowNode : public ExecutionNode {
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
-                       bool withProperties) const final;
+                       bool withProperties) const override final;
 
   /// @brief estimateCost
-  CostEstimate estimateCost() const final;
+  CostEstimate estimateCost() const override final;
 
   void setAggregateVariables(std::vector<AggregateVarInfo> const& aggregateVariables);
 
   /// @brief getVariablesUsedHere, modifying the set in-place
-  void getVariablesUsedHere(VarSet& vars) const final;
+  void getVariablesUsedHere(VarSet& vars) const override final;
 
   /// @brief getVariablesSetHere
-  std::vector<Variable const*> getVariablesSetHere() const final;
+  std::vector<Variable const*> getVariablesSetHere() const override final;
 
   // does this WINDOW need to look at rows following the current one
   bool needsFollowingRows() const;

--- a/arangod/IResearch/GeoAnalyzer.h
+++ b/arangod/IResearch/GeoAnalyzer.h
@@ -52,7 +52,7 @@ class GeoAnalyzer
   : public irs::frozen_attributes<2, irs::analysis::analyzer>,
     private irs::util::noncopyable {
  public:
-  virtual bool next() noexcept final;
+  virtual bool next() noexcept override final;
   using irs::analysis::analyzer::reset;
 
   virtual void prepare(S2RegionTermIndexer::Options& opts) const = 0;

--- a/arangod/IResearch/IResearchLink.cpp
+++ b/arangod/IResearch/IResearchLink.cpp
@@ -193,7 +193,7 @@ class IResearchFlushSubscription final : public FlushSubscription {
   }
 
   /// @brief earliest tick that can be released
-  TRI_voc_tick_t tick() const noexcept final {
+  TRI_voc_tick_t tick() const noexcept override final {
     return _tick.load(std::memory_order_acquire);
   }
 

--- a/arangod/RestHandler/RestAdminClusterHandler.h
+++ b/arangod/RestHandler/RestAdminClusterHandler.h
@@ -43,8 +43,8 @@ class RestAdminClusterHandler : public RestVocbaseBaseHandler {
 
  public:
   RestStatus execute() override;
-  char const* name() const final { return "RestAdminClusterHandler"; }
-  RequestLane lane() const final { return RequestLane::CLIENT_SLOW; }
+  char const* name() const override final { return "RestAdminClusterHandler"; }
+  RequestLane lane() const override final { return RequestLane::CLIENT_SLOW; }
 
  private:
   static std::string const Health;

--- a/tests/Aql/MockTypedNode.h
+++ b/tests/Aql/MockTypedNode.h
@@ -37,7 +37,7 @@ class MockTypedNode : public ::arangodb::aql::ExecutionNode {
   MockTypedNode(::arangodb::aql::ExecutionPlan* plan, arangodb::aql::ExecutionNodeId id, NodeType);
 
   // return mocked type
-  NodeType getType() const final;
+  NodeType getType() const override final;
 
   // Necessary overrides, all not implemented:
 

--- a/tests/Aql/SpliceSubqueryOptimizerRuleTest.cpp
+++ b/tests/Aql/SpliceSubqueryOptimizerRuleTest.cpp
@@ -68,7 +68,7 @@ struct Comparator final : public WalkerWorker<ExecutionNode, WalkerUniqueness::N
            en->getType() == ExecutionNode::SINGLETON;
   }
 
-  bool before(ExecutionNode* en) final {
+  bool before(ExecutionNode* en) override final {
     std::set<ExecutionNodeId> depids, otherdepids;
 
     if (!isSubqueryRelated(en)) {
@@ -97,9 +97,9 @@ struct Comparator final : public WalkerWorker<ExecutionNode, WalkerUniqueness::N
     return false;
   }
 
-  void after(ExecutionNode* en) final {}
+  void after(ExecutionNode* en) override final {}
 
-  bool enterSubquery(ExecutionNode*, ExecutionNode* sub) final {
+  bool enterSubquery(ExecutionNode*, ExecutionNode* sub) override final {
     EXPECT_TRUE(_expectNormalSubqueries)
         << "Optimized plan must not contain SUBQUERY nodes";
     return false;


### PR DESCRIPTION
### Scope & Purpose

This is an integration PR to land the PR https://github.com/arangodb/arangodb/pull/13244 and run Jenkins tests on it.
The original PR silences a few compile warnings due to missing override specifiers.

There is also an accompanying PR to the iresearch repository to make the changes there, too: https://github.com/iresearch-toolkit/iresearch/pull/238

However, the changes made to third party openfst will be lost eventually, when a new version of openfst is pulled. The only sensible way to prevent this from happening is to make the changes in the external openfst upstream repository. 

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13818/