### PR TITLE
Correctly handle development flag in upgrade (3.7)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ v3.7.7 (XXXX-XX-XX)
 -------------------
 
 * Fixed issue #12363: Foxx HTTP API upgrade/replace always enables
-  development mode
+  development mode.
 
 * Normalize user-provided input/output directory names in arangoimport,
   arangoexport, arangodump and arangorestore before splitting them into path

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.7.7 (XXXX-XX-XX)
 -------------------
 
+* Fixed issue #12363: Foxx HTTP API upgrade/replace always enables
+  development mode
+
 * Normalize user-provided input/output directory names in arangoimport,
   arangoexport, arangodump and arangorestore before splitting them into path
   components, in the sense that now both forward and backward slashes can be

--- a/js/apps/system/_api/foxx/APP/index.js
+++ b/js/apps/system/_api/foxx/APP/index.js
@@ -194,6 +194,7 @@ serviceRouter.patch(prepareServiceRequestBody, (req, res) => {
   res.json(serviceToJson(service));
 })
 .body(schemas.service, ['application/javascript', 'application/zip', 'multipart/form-data', 'application/json'])
+.queryParam('development', schemas.flag.optional())
 .queryParam('teardown', schemas.flag.default(false))
 .queryParam('setup', schemas.flag.default(true))
 .queryParam('legacy', schemas.flag.default(false))
@@ -213,6 +214,7 @@ serviceRouter.put(prepareServiceRequestBody, (req, res) => {
   res.json(serviceToJson(service));
 })
 .body(schemas.service, ['application/javascript', 'application/zip', 'multipart/form-data', 'application/json'])
+.queryParam('development', schemas.flag.optional())
 .queryParam('teardown', schemas.flag.default(true))
 .queryParam('setup', schemas.flag.default(true))
 .queryParam('legacy', schemas.flag.default(false))

--- a/js/apps/system/_api/foxx/APP/index.js
+++ b/js/apps/system/_api/foxx/APP/index.js
@@ -214,7 +214,7 @@ serviceRouter.put(prepareServiceRequestBody, (req, res) => {
   res.json(serviceToJson(service));
 })
 .body(schemas.service, ['application/javascript', 'application/zip', 'multipart/form-data', 'application/json'])
-.queryParam('development', schemas.flag.optional())
+.queryParam('development', schemas.flag.default(false))
 .queryParam('teardown', schemas.flag.default(true))
 .queryParam('setup', schemas.flag.default(true))
 .queryParam('legacy', schemas.flag.default(false))

--- a/js/server/modules/@arangodb/foxx/manager.js
+++ b/js/server/modules/@arangodb/foxx/manager.js
@@ -948,20 +948,20 @@ function install (serviceInfo, mount, options = {}) {
       `
     });
   }
-  const tempPaths = _prepareService(serviceInfo, options.legacy);
+  const tempPaths = _prepareService(serviceInfo, Boolean(options.legacy));
   const tempService = FoxxService.create({
     mount,
     basePath: tempPaths.tempServicePath,
     noisy: true,
     options: {
-      development: options.development,
+      development: Boolean(options.development),
       configuration: options.configuration,
       dependencies: options.dependencies
     }
   });
   _install(tempService, tempPaths.tempBundlePath, {
-    setup: options.setup !== false,
-    force: options.force === true
+    setup: options.setup === undefined || Boolean(options.setup),
+    force: Boolean(options.force)
   });
   selfHeal();
   propagateSelfHeal();
@@ -995,23 +995,23 @@ function replace (serviceInfo, mount, options = {}) {
   } else {
     utils.validateMount(mount);
   }
-  const tempPaths = _prepareService(serviceInfo, options.legacy);
+  const tempPaths = _prepareService(serviceInfo, Boolean(options.legacy));
   const tempService = FoxxService.create({
     mount,
     basePath: tempPaths.tempServicePath,
     noisy: true,
     options: {
-      development: options.development,
+      development: Boolean(options.development),
       configuration: options.configuration,
       dependencies: options.dependencies
     }
   });
   _uninstall(mount, {
-    teardown: options.teardown !== false,
+    teardown: options.teardown === undefined || Boolean(options.teardown),
     force: true
   });
   _install(tempService, tempPaths.tempBundlePath, {
-    setup: options.setup !== false,
+    setup: options.setup === undefined || Boolean(options.setup),
     force: true
   });
   selfHeal();
@@ -1040,23 +1040,27 @@ function upgrade (serviceInfo, mount, options = {}) {
     utils.validateMount(mount);
   }
 
-  const tempPaths = _prepareService(serviceInfo, options.legacy);
+  const tempPaths = _prepareService(serviceInfo, Boolean(options.legacy));
   const tempService = FoxxService.create({
     mount,
     basePath: tempPaths.tempServicePath,
     noisy: true,
     options: {
-      development: options.development,
+      development: Boolean(
+        options.development === undefined
+        ? old.development
+        : options.development
+      ),
       configuration: Object.assign({}, old.configuration, options.configuration),
       dependencies: Object.assign({}, old.dependencies, options.dependencies)
     }
   });
   _uninstall(mount, {
-    teardown: options.teardown === true,
+    teardown: Boolean(options.teardown),
     force: true
   });
   _install(tempService, tempPaths.tempBundlePath, {
-    setup: options.setup !== false,
+    setup: options.setup === undefined || Boolean(options.setup),
     force: true
   });
   selfHeal();


### PR DESCRIPTION
Fixes #12363. Backport of #12694 for 3.7.

### Scope & Purpose

This fixes a bug in the Foxx HTTP API where the `development` query parameter would not be parsed before being handed over to the Foxx Manager, resulting in `"false"` being interpreted as `true`.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required
- [ ] Backports required for: *(Please specify versions)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket number: #12363 
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [x] This PR adds tests that were used to verify all changes:
  - [ ] Added **Regression Tests**
  - [ ] Added new C++ **Unit Tests**
  - [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)

Additionally:

- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

*(Include link to Jenkins run etc)*

### Documentation

> All new Features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the changelog so that
> developers and users have a concise overview. 

- [x] Added a *Changelog Entry* (referencing the corresponding public or internal issue number)
- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries