### PR TITLE
Discard unused Foxx config when saving config in production (3.7)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.7.7 (XXXX-XX-XX)
 -------------------
 
+* Fixed issue #12543: Unused Foxx service config can not be discarded.
+
 * Normalize user-provided input/output directory names in arangoimport,
   arangoexport, arangodump and arangorestore before splitting them into path
   components, in the sense that now both forward and backward slashes can be

--- a/js/apps/system/_api/foxx/APP/index.js
+++ b/js/apps/system/_api/foxx/APP/index.js
@@ -262,6 +262,7 @@ configRouter.patch((req, res) => {
   } else {
     if (warnings) {
       for (const key of Object.keys(warnings)) {
+        if (!values[key]) continue;
         values[key].warning = warnings[key];
       }
     }
@@ -282,6 +283,7 @@ configRouter.put((req, res) => {
   } else {
     if (warnings) {
       for (const key of Object.keys(warnings)) {
+        if (!values[key]) continue;
         values[key].warning = warnings[key];
       }
     }
@@ -311,6 +313,7 @@ depsRouter.patch((req, res) => {
   } else {
     if (warnings) {
       for (const key of Object.keys(warnings)) {
+        if (!values[key]) continue;
         values[key].warning = warnings[key];
       }
     }
@@ -331,6 +334,7 @@ depsRouter.put((req, res) => {
   } else {
     if (warnings) {
       for (const key of Object.keys(warnings)) {
+        if (!values[key]) continue;
         values[key].warning = warnings[key];
       }
     }

--- a/js/server/modules/@arangodb/foxx/service.js
+++ b/js/server/modules/@arangodb/foxx/service.js
@@ -198,6 +198,14 @@ module.exports =
       const names = replace ? configNames.concat(omittedNames) : configNames;
       const warnings = {};
 
+      if (!this.isDevelopment) {
+        for (const name of Object.keys(this._configuration)) {
+          if (!knownNames.includes(name) && !configNames.includes(name)) {
+            delete this._configuration[name];
+          }
+        }
+      }
+
       for (const name of names) {
         if (!knownNames.includes(name)) {
           warnings[name] = 'is not allowed';

--- a/js/server/modules/@arangodb/foxx/service.js
+++ b/js/server/modules/@arangodb/foxx/service.js
@@ -163,8 +163,8 @@ module.exports =
       const warnings = this.applyConfiguration(this._configuration, false);
       if (warnings) {
         console.warnLines(`Stored configuration for service "${this.mount}" has errors:\n  ${
-          Object.keys(warnings).map((key) => warnings[key]).join('\n  ')
-        }\nValues for unknown options will be discarded if you save the configuration in production mode using the web interface.`);
+          Object.keys(warnings).map((key) => `${key} ${warnings[key]}`).join('\n  ')
+        }\nValues for unknown options will be discarded if you save the configuration in production mode.`);
       }
 
       this.thumbnail = null;

--- a/tests/js/client/shell/shell-foxx-api-spec.js
+++ b/tests/js/client/shell/shell-foxx-api-spec.js
@@ -676,7 +676,7 @@ describe('Foxx service', () => {
       test1: 'test1',
       test2: 'test2'
     });
-    installFoxx(mount, {type: 'dir', buffer: confPath2}, "upgrade");
+    installFoxx(mount, {type: 'dir', buffer: confPath2, devmode: true}, "upgrade");
     const resp1 = db._query(aql`
       FOR service IN _apps
         FILTER service.mount == ${mount}
@@ -695,7 +695,7 @@ describe('Foxx service', () => {
   });
 
   it('should discard obsolete config after update in production', () => {
-    installFoxx(mount, {type: 'dir', buffer: confPath, devmode: false});
+    installFoxx(mount, {type: 'dir', buffer: confPath});
     arango.PATCH('/_api/foxx/configuration?mount=' + mount, {
       test1: 'test1',
       test2: 'test2'

--- a/tests/js/client/shell/shell-foxx-api-spec.js
+++ b/tests/js/client/shell/shell-foxx-api-spec.js
@@ -672,7 +672,6 @@ describe('Foxx service', () => {
 
   it('should retain obsolete config after update in development', () => {
     installFoxx(mount, {type: 'dir', buffer: confPath, devmode: true});
-    arango.POST('/_api/foxx/development?mount=' + mount, '');
     arango.PATCH('/_api/foxx/configuration?mount=' + mount, {
       test1: 'test1',
       test2: 'test2'
@@ -685,7 +684,6 @@ describe('Foxx service', () => {
     `).next();
     expect(resp1).to.have.property('test1', 'test1');
     expect(resp1).to.have.property('test2', 'test2');
-    arango.POST('/_api/foxx/development?mount=' + mount, '');
     arango.PATCH('/_api/foxx/configuration?mount=' + mount, {});
     const resp2 = db._query(aql`
       FOR service IN _apps
@@ -698,7 +696,6 @@ describe('Foxx service', () => {
 
   it('should discard obsolete config after update in production', () => {
     installFoxx(mount, {type: 'dir', buffer: confPath, devmode: false});
-    arango.DELETE('/_api/foxx/development?mount=' + mount, '');
     arango.PATCH('/_api/foxx/configuration?mount=' + mount, {
       test1: 'test1',
       test2: 'test2'
@@ -711,7 +708,6 @@ describe('Foxx service', () => {
     `).next();
     expect(resp1).to.have.property('test1', 'test1');
     expect(resp1).to.have.property('test2', 'test2');
-    arango.DELETE('/_api/foxx/development?mount=' + mount, '');
     arango.PATCH('/_api/foxx/configuration?mount=' + mount, {});
     const resp2 = db._query(aql`
       FOR service IN _apps

--- a/tests/js/common/test-data/apps/with-configuration2/manifest.json
+++ b/tests/js/common/test-data/apps/with-configuration2/manifest.json
@@ -1,0 +1,12 @@
+{
+  "configuration": {
+    "test1": {
+      "description": "a string",
+      "type": "string"
+    },
+    "test3": {
+      "description": "a different string",
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #12543. Backport of #12728 for 3.7.

### Scope & Purpose

This fixes the behavior of Foxx that was supposed to discard unused stored configuration options when options are renamed or removed after a service has been upgraded. These will result in warnings until discarded.

Additionally the warnings now indicate which configuration options they refer to, making them more meaningful to users.

- [x] :hankey: Bugfix 
- [ ] :pizza: New feature 
- [ ] :hammer: Refactoring 
- [x] :book: CHANGELOG entry made
- [x] :muscle: The behavior in this PR was *manually tested*
- [x] :computer: The behavior change can be verified via automatic tests

#### Backports:

- [x] No backports required
- [ ] Backports required for: *(Please specify versions)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket number: #12543
- [ ] Design document: 

### Testing & Verification

The changes to tests in this PR overlap with #12694 but should merge cleanly.

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [x] This PR adds tests that were used to verify all changes:
  - [ ] Added **Regression Tests**
  - [ ] Added new C++ **Unit Tests**
  - [x] Added new **integration tests** (i.e. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)

Additionally:

- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

*(Include link to Jenkins run etc)*

### Documentation

> All new Features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the changelog so that
> developers and users have a concise overview. 

- [x] Added a *Changelog Entry* (referencing the corresponding public or internal issue number)
- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries
