### PR TITLE
Bug fix 3.7/bts 284

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 v3.7.7 (XXXX-XX-XX)
 -------------------
+* Fixed BTS-284. Fixed upgrading from 3.6 to 3.7 in cluster enviroment.
+  Moved upgrade ArangoSearch links task to later step as it needs cluster
+  connection. Removed misleading error log records for failed
+  ArangoSearch index creation during upgrade phase.
 
 * Normalize user-provided input/output directory names in arangoimport,
   arangoexport, arangodump and arangorestore before splitting them into path

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,10 @@
 v3.7.7 (XXXX-XX-XX)
 -------------------
-* Fixed BTS-284. Fixed upgrading from 3.6 to 3.7 in cluster enviroment.
+
+* Fixed BTS-284: upgrading from 3.6 to 3.7 in cluster enviroment.
   Moved upgrade ArangoSearch links task to later step as it needs cluster
-  connection. Removed misleading error log records for failed
-  ArangoSearch index creation during upgrade phase.
+  connection. Removed misleading error log records for failed ArangoSearch index
+  creation during upgrade phase.
 
 * Normalize user-provided input/output directory names in arangoimport,
   arangoexport, arangodump and arangorestore before splitting them into path

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -618,7 +618,8 @@ void registerUpgradeTasks(arangodb::application_features::ApplicationServer& ser
     task.clusterFlags = arangodb::methods::Upgrade::Flags::CLUSTER_DB_SERVER_LOCAL  // db-server
                         | arangodb::methods::Upgrade::Flags::CLUSTER_NONE           // local server
                         | arangodb::methods::Upgrade::Flags::CLUSTER_LOCAL;
-    task.databaseFlags = arangodb::methods::Upgrade::Flags::DATABASE_UPGRADE;
+    task.databaseFlags = arangodb::methods::Upgrade::Flags::DATABASE_UPGRADE |
+                         arangodb::methods::Upgrade::Flags::DATABASE_ONLY_ONCE;
     task.action = &upgradeSingleServerArangoSearchView0_1;
     upgrade.addTask(std::move(task));
   }
@@ -632,7 +633,7 @@ void registerUpgradeTasks(arangodb::application_features::ApplicationServer& ser
     task.systemFlag = arangodb::methods::Upgrade::Flags::DATABASE_ALL;
     task.clusterFlags = arangodb::methods::Upgrade::Flags::CLUSTER_DB_SERVER_LOCAL |
                         arangodb::methods::Upgrade::Flags::CLUSTER_LOCAL;  // db-server
-    task.databaseFlags = arangodb::methods::Upgrade::Flags::DATABASE_UPGRADE |
+    task.databaseFlags = arangodb::methods::Upgrade::Flags::DATABASE_ONLY_ONCE |
                          arangodb::methods::Upgrade::Flags::DATABASE_EXISTING;
     task.action = &upgradeArangoSearchLinkCollectionName;
     upgrade.addTask(std::move(task));

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -310,6 +310,8 @@ bool upgradeArangoSearchLinkCollectionName(TRI_vocbase_t& vocbase,
   // persist collection names in links
   for (auto& collection : vocbase.collections(false)) {
     auto indexes = collection->getIndexes();
+    LOG_TOPIC("423b3", TRACE, arangodb::iresearch::TOPIC)
+          << " Checking collection '" << collection->name() << "' in database '" << vocbase.name() << "'";
     auto clusterCollection =
         clusterInfo.getCollectionNT(vocbase.name(),
                                     collection->name());

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -316,6 +316,8 @@ bool upgradeArangoSearchLinkCollectionName(TRI_vocbase_t& vocbase,
       do {
         LOG_TOPIC("423b3", TRACE, arangodb::iresearch::TOPIC)
             << " Checking collection '" << collection->name() << "' in database '" << vocbase.name() << "'";
+        // we use getCollectionNameForShard as getCollectionNT here is still not available
+        // but shard-collection mapping is loaded eventually
         clusterCollectionName = clusterInfo.getCollectionNameForShard(collection->name());
         if (!clusterCollectionName.empty()) {
          break;

--- a/arangod/IResearch/IResearchLink.cpp
+++ b/arangod/IResearch/IResearchLink.cpp
@@ -1069,7 +1069,9 @@ Result IResearchLink::init(
       // this could be received from  agency while shard of the collection was moved (or added)
       // to the server.
       // New links already has collection name set, but here we must get this name on our own
-      if (meta._collectionName.empty()) {
+      if (meta._collectionName.empty() &&
+          vocbase.server().getFeature<ClusterFeature>().state() ==
+            arangodb::application_features::ApplicationFeature::State::STARTED ) {
         if (clusterWideLink) {// could set directly
           LOG_TOPIC("86ecd", TRACE, iresearch::TOPIC) << "Setting collection name '" << _collection.name() << "' for new link '"
             << this->id().id() << "'";

--- a/arangod/IResearch/IResearchLink.cpp
+++ b/arangod/IResearch/IResearchLink.cpp
@@ -1059,105 +1059,110 @@ Result IResearchLink::init(
           "failure to get cluster info while initializing arangosearch link '" +
               std::to_string(_id.id()) + "'"};
     }
-    auto& ci = vocbase.server().getFeature<ClusterFeature>().clusterInfo();
+    if (vocbase.server().getFeature<ClusterFeature>().isEnabled()) { // cluster feature is disabled during UPGRADE step
+      auto& ci = vocbase.server().getFeature<ClusterFeature>().clusterInfo();
 
-    // cluster-wide link
-    auto clusterWideLink = _collection.id() == _collection.planId() && _collection.isAStub();
+      // cluster-wide link
+      auto clusterWideLink = _collection.id() == _collection.planId() && _collection.isAStub();
 
-    // upgrade step for old link definition without collection name
-    // this could be received from  agency while shard of the collection was moved (or added)
-    // to the server.
-    // New links already has collection name set, but here we must get this name on our own
-    if (meta._collectionName.empty()) {
-      if (clusterWideLink) {// could set directly
-        LOG_TOPIC("86ecd", TRACE, iresearch::TOPIC) << "Setting collection name '" << _collection.name() << "' for new link '"
-          << this->id().id() << "'";
-        meta._collectionName = _collection.name();
-      } else {
-        meta._collectionName = ci.getCollectionNameForShard(_collection.name());
-        LOG_TOPIC("86ece", TRACE, iresearch::TOPIC) << "Setting collection name '" << meta._collectionName << "' for new link '"
-          << this->id().id() << "'";
-      }
-      if (ADB_UNLIKELY(meta._collectionName.empty())) {
-        LOG_TOPIC("67da6", WARN, iresearch::TOPIC) << "Failed to init collection name for the link '"
-          << this->id().id() << "'. Link will not index '_id' attribute. Please recreate the link if this is necessary!";
-      }
+      // upgrade step for old link definition without collection name
+      // this could be received from  agency while shard of the collection was moved (or added)
+      // to the server.
+      // New links already has collection name set, but here we must get this name on our own
+      if (meta._collectionName.empty()) {
+        if (clusterWideLink) {// could set directly
+          LOG_TOPIC("86ecd", TRACE, iresearch::TOPIC) << "Setting collection name '" << _collection.name() << "' for new link '"
+            << this->id().id() << "'";
+          meta._collectionName = _collection.name();
+        } else {
+          meta._collectionName = ci.getCollectionNameForShard(_collection.name());
+          LOG_TOPIC("86ece", TRACE, iresearch::TOPIC) << "Setting collection name '" << meta._collectionName << "' for new link '"
+            << this->id().id() << "'";
+        }
+        if (ADB_UNLIKELY(meta._collectionName.empty())) {
+          LOG_TOPIC("67da6", WARN, iresearch::TOPIC) << "Failed to init collection name for the link '"
+            << this->id().id() << "'. Link will not index '_id' attribute. Please recreate the link if this is necessary!";
+        }
 
 #ifdef USE_ENTERPRISE
-      // enterprise name is not used in _id so should not be here!
-      if (ADB_LIKELY(!meta._collectionName.empty())) {
-        arangodb::ClusterMethods::realNameFromSmartName(meta._collectionName);
-      }
-#endif
-    }
-
-    if (!clusterWideLink) {
-      // prepare data-store which can then update options
-      // via the IResearchView::link(...) call
-      auto const res = initDataStore(initCallback, sorted, storedValuesColumns, primarySortCompression);
-
-      if (!res.ok()) {
-        return res;
-      }
-    }
-
-    // valid to call ClusterInfo (initialized in ClusterFeature::prepare()) even from Databasefeature::start()
-    auto logicalView = ci.getView(vocbase.name(), viewId);
-
-    // if there is no logicalView present yet then skip this step
-    if (logicalView) {
-      if (iresearch::DATA_SOURCE_TYPE != logicalView->type()) {
-        unload(); // unlock the data store directory
-        return {TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
-                "error finding view: '" + viewId + "' for link '" +
-                    std::to_string(_id.id()) + "' : no such view"};
-      }
-
-      auto* view = LogicalView::cast<IResearchView>(logicalView.get());
-
-      if (!view) {
-        unload(); // unlock the data store directory
-        return {TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
-                "error finding view: '" + viewId + "' for link '" +
-                    std::to_string(_id.id()) + "'"};
-      }
-
-      viewId = view->guid(); // ensue that this is a GUID (required by operator==(IResearchView))
-
-      if (clusterWideLink) { // cluster cluster-wide link
-        auto shardIds = _collection.shardIds();
-
-        // go through all shard IDs of the collection and try to link any links
-        // missing links will be populated when they are created in the
-        // per-shard collection
-        if (shardIds) {
-          for (auto& entry : *shardIds) {
-            auto collection = vocbase.lookupCollection(entry.first); // per-shard collections are always in 'vocbase'
-
-            if (!collection) {
-              continue; // missing collection should be created after Plan becomes Current
-            }
-
-            auto link = IResearchLinkHelper::find(*collection, *view);
-
-            if (link) {
-              auto res = view->link(link->self());
-
-              if (!res.ok()) {
-                return res;
-              }
-            }
-          }
+        // enterprise name is not used in _id so should not be here!
+        if (ADB_LIKELY(!meta._collectionName.empty())) {
+          arangodb::ClusterMethods::realNameFromSmartName(meta._collectionName);
         }
-      } else { // cluster per-shard link
-        auto res = view->link(_asyncSelf);
+#endif
+      }
+
+      if (!clusterWideLink) {
+        // prepare data-store which can then update options
+        // via the IResearchView::link(...) call
+        auto const res = initDataStore(initCallback, sorted, storedValuesColumns, primarySortCompression);
 
         if (!res.ok()) {
-          unload(); // unlock the data store directory
-
           return res;
         }
       }
+
+      // valid to call ClusterInfo (initialized in ClusterFeature::prepare()) even from Databasefeature::start()
+      auto logicalView = ci.getView(vocbase.name(), viewId);
+
+      // if there is no logicalView present yet then skip this step
+      if (logicalView) {
+        if (iresearch::DATA_SOURCE_TYPE != logicalView->type()) {
+          unload(); // unlock the data store directory
+          return {TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
+                  "error finding view: '" + viewId + "' for link '" +
+                      std::to_string(_id.id()) + "' : no such view"};
+        }
+
+        auto* view = LogicalView::cast<IResearchView>(logicalView.get());
+
+        if (!view) {
+          unload(); // unlock the data store directory
+          return {TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
+                  "error finding view: '" + viewId + "' for link '" +
+                      std::to_string(_id.id()) + "'"};
+        }
+
+        viewId = view->guid(); // ensue that this is a GUID (required by operator==(IResearchView))
+
+        if (clusterWideLink) { // cluster cluster-wide link
+          auto shardIds = _collection.shardIds();
+
+          // go through all shard IDs of the collection and try to link any links
+          // missing links will be populated when they are created in the
+          // per-shard collection
+          if (shardIds) {
+            for (auto& entry : *shardIds) {
+              auto collection = vocbase.lookupCollection(entry.first); // per-shard collections are always in 'vocbase'
+
+              if (!collection) {
+                continue; // missing collection should be created after Plan becomes Current
+              }
+
+              auto link = IResearchLinkHelper::find(*collection, *view);
+
+              if (link) {
+                auto res = view->link(link->self());
+
+                if (!res.ok()) {
+                  return res;
+                }
+              }
+            }
+          }
+        } else { // cluster per-shard link
+          auto res = view->link(_asyncSelf);
+
+          if (!res.ok()) {
+            unload(); // unlock the data store directory
+
+            return res;
+          }
+        }
+      }
+    } else {
+      LOG_TOPIC("67dd6", DEBUG, iresearch::TOPIC) << "Skipped link '"
+        << this->id().id() << "' due to disabled cluster features.";
     }
   } else if (ServerState::instance()->isSingleServer()) {  // single-server link
     // prepare data-store which can then update options

--- a/arangod/VocBase/Methods/Upgrade.cpp
+++ b/arangod/VocBase/Methods/Upgrade.cpp
@@ -305,7 +305,7 @@ UpgradeResult methods::Upgrade::runTasks(TRI_vocbase_t& vocbase, VersionResult& 
     // check that the database occurs in the database list
     if (!(t.databaseFlags & dbFlag)) {
       // special optimization: for local server and new database,
-      // an upgrade-only task can be viewed as executed.
+      // an one-shot task can be viewed as executed.
       if (isLocal && dbFlag == DATABASE_INIT && (t.databaseFlags & DATABASE_ONLY_ONCE)) {
         vinfo.tasks.try_emplace(t.name, true);
       }

--- a/arangod/VocBase/Methods/Upgrade.cpp
+++ b/arangod/VocBase/Methods/Upgrade.cpp
@@ -306,7 +306,7 @@ UpgradeResult methods::Upgrade::runTasks(TRI_vocbase_t& vocbase, VersionResult& 
     if (!(t.databaseFlags & dbFlag)) {
       // special optimization: for local server and new database,
       // an upgrade-only task can be viewed as executed.
-      if (isLocal && dbFlag == DATABASE_INIT && t.databaseFlags == DATABASE_UPGRADE) {
+      if (isLocal && dbFlag == DATABASE_INIT && (t.databaseFlags & DATABASE_ONLY_ONCE)) {
         vinfo.tasks.try_emplace(t.name, true);
       }
       LOG_TOPIC("346ba", DEBUG, Logger::STARTUP)

--- a/arangod/VocBase/Methods/Upgrade.h
+++ b/arangod/VocBase/Methods/Upgrade.h
@@ -69,8 +69,8 @@ struct Upgrade {
     DATABASE_INIT = (1u << 3),
     DATABASE_UPGRADE = (1u << 4),
     DATABASE_EXISTING = (1u << 5),
-    DATABASE_ONLY_ONCE = (1u << 6), // hint that task should be run on
-                                     // database only once. New database
+    DATABASE_ONLY_ONCE = (1u << 6),  // hint that task should be run on
+                                     // database only once. New databases
                                      // should assume this task as executed
     // =============
     CLUSTER_NONE = (1u << 7),

--- a/arangod/VocBase/Methods/Upgrade.h
+++ b/arangod/VocBase/Methods/Upgrade.h
@@ -69,11 +69,14 @@ struct Upgrade {
     DATABASE_INIT = (1u << 3),
     DATABASE_UPGRADE = (1u << 4),
     DATABASE_EXISTING = (1u << 5),
+    DATABASE_ONLY_ONCE = (1u << 6), // hint that task should be run on
+                                     // database only once. New database
+                                     // should assume this task as executed
     // =============
-    CLUSTER_NONE = (1u << 6),
-    CLUSTER_LOCAL = (1u << 7),  // agency
-    CLUSTER_COORDINATOR_GLOBAL = (1u << 8),
-    CLUSTER_DB_SERVER_LOCAL = (1u << 9)
+    CLUSTER_NONE = (1u << 7),
+    CLUSTER_LOCAL = (1u << 8),  // agency
+    CLUSTER_COORDINATOR_GLOBAL = (1u << 9),
+    CLUSTER_DB_SERVER_LOCAL = (1u << 10)
   };
 
   typedef std::function<bool(TRI_vocbase_t&, velocypack::Slice const&)> TaskFunction;


### PR DESCRIPTION
### Scope & Purpose
PR fixes BTS-284 issue by moving  upgrading ArangoSearchLinks task to stage of DATABASE_EXISTING from DATABASE_UPGRADE as this task needs  enabled Cluster Feature which is not available during DATABASE_UPGRADE phase.
Also introduced new 'hint' flag for upgrade tasks DATABASE_ONLY_ONCE to mark tasks which should be run only once if was not run before and for new databases this task should either be run on DATABASE_INIT (if corresponding flag is set) or should be considered executed. Previously that was implicitly declared as having only DATABASE_UPGRADE flag for task. But as new name upgrade task is also 'one-shot' but has DATABASE_EXISTING this implicit consideration became unusable.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [x] Backports required for:  devel

### Testing & Verification

- [x] The behaviour in this PR was *manually tested*
- [x] There are tests in an external testing repository: upgrade tests in repository release-test-automation/release_tester/upgrade.py

Link to Jenkins PR run:

https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/13828/