### PR TITLE
feature/move-calculations-out-of-subqueries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 devel
 -----
 
-* Extend the "move-calculations-up optimizer" rule so that it can move
+* Extend the "move-calculations-up" optimizer rule so that it can move
   calculations out of subqueries into the outer query.
 
 * Fix warnings about suggest-override which can break builds when warnings

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Extend the "move-calculations-up optimizer" rule so that it can move
+  calculations out of subqueries into the outer query.
+
 * Fix warnings about suggest-override which can break builds when warnings
   are treated as errors.
 
@@ -21,44 +24,44 @@ devel
   possible for a very small number of queries and even had adverse effects,
   so it is now removed entirely.
 
-* On Linux and MacOS, require at least 8192 usable file descriptors at startup. 
+* On Linux and MacOS, require at least 8192 usable file descriptors at startup.
   If less file descriptors are available to the arangod process, then the
   startup is automatically aborted.
 
-  Even the chosen minimum value of 8192 will often not be high enough to 
-  store considerable amounts of data. However, no higher value was chosen 
+  Even the chosen minimum value of 8192 will often not be high enough to
+  store considerable amounts of data. However, no higher value was chosen
   in order to not make too many existing small installations fail at startup
   after upgrading.
 
   The required number of file descriptors can be configured using the startup
   option `--server.descriptors-minimum`. It defaults to 8192, but it can be
   increased to ensure that arangod can make use of a sufficiently high number
-  of files. Setting `--server.descriptors-minimum` to a value of `0` will 
-  make the startup require only an absolute minimum limit of 1024 file 
+  of files. Setting `--server.descriptors-minimum` to a value of `0` will
+  make the startup require only an absolute minimum limit of 1024 file
   descriptors, effectively disabling the change.
   Such low values should only be used to bypass the file descriptors check
   in case of an emergency, but this is not recommended for production.
-          
-* Added metric `arangodb_transactions_expired` to track the total number 
+
+* Added metric `arangodb_transactions_expired` to track the total number
   of expired and then garbage-collected transactions.
 
 * Allow toggling the document read/write counters and histograms via the
-  new startup option `--server.export-read-write-metrics false`. This 
+  new startup option `--server.export-read-write-metrics false`. This
   option defaults to `true`, so these metrics will be exposed by default.
 
 * Upgraded bundled version of libunwind to v1.5.
 
-* Added startup option `--javascript.tasks` to allow turning off JavaScript 
-  tasks if not needed. The default value for this option is `true`, meaning 
+* Added startup option `--javascript.tasks` to allow turning off JavaScript
+  tasks if not needed. The default value for this option is `true`, meaning
   JavaScript tasks are available as before.
-  However, with this option they can be turned off by admins to limit the 
+  However, with this option they can be turned off by admins to limit the
   amount of JavaScript user code that is executed.
 
-* Only instantiate a striped PRNG instance for the arangod server, but not 
-  for any of the client tools (e.g. arangosh, arangodump, arangorestore). 
-  The client tools do not use the striped PRNG, so we can save a few MBs of 
-  memory for allocating the striped PRNG instance there, plus some CPU time 
-  for initializing it. 
+* Only instantiate a striped PRNG instance for the arangod server, but not
+  for any of the client tools (e.g. arangosh, arangodump, arangorestore).
+  The client tools do not use the striped PRNG, so we can save a few MBs of
+  memory for allocating the striped PRNG instance there, plus some CPU time
+  for initializing it.
 
 * Improve shard synchronization protocol by only transferring the required
   parts of the inventory from leader to follower. Previously, for each shard
@@ -68,13 +71,13 @@ devel
   synchronization protocol by reusing already existing information in the
   different steps of the replication process.
 
-* Added metric `arangodb_scheduler_low_prio_queue_last_dequeue_time` that 
-  provides the time (in millseconds) it took for the most recent low priority 
-  scheduler queue item to bubble up to the queue's head. This metric can be 
-  used to estimate the queuing time for incoming requests. 
-  The metric will be updated probabilistically when a request is pulled from 
-  the scheduler queue, and may remain at its previous value for a while if 
-  only few requests are coming in or remain permanently at its previous value 
+* Added metric `arangodb_scheduler_low_prio_queue_last_dequeue_time` that
+  provides the time (in millseconds) it took for the most recent low priority
+  scheduler queue item to bubble up to the queue's head. This metric can be
+  used to estimate the queuing time for incoming requests.
+  The metric will be updated probabilistically when a request is pulled from
+  the scheduler queue, and may remain at its previous value for a while if
+  only few requests are coming in or remain permanently at its previous value
   if no further requests are incoming at all.
 
 * Allow {USER} placeholder string also in `--ldap.search-filter`.
@@ -87,24 +90,24 @@ devel
     (successful and failed) not performed by synchronous replication.
   - `arangodb_document_writes_replication`: Total number of document write
     operations (successful and failed) by cluster synchronous replication.
-  - `arangodb_collection_truncates`: Total number of collection truncate 
-    operations (successful and failed) not performed by cluster synchronous 
+  - `arangodb_collection_truncates`: Total number of collection truncate
+    operations (successful and failed) not performed by cluster synchronous
     replication.
-  - `arangodb_collection_truncates_replication`: Total number of collection 
+  - `arangodb_collection_truncates_replication`: Total number of collection
     truncate operations (successful and failed) by synchronous replication.
-  - `arangodb_document_read_time`: Execution time histogram of all document 
-    primary key read operations (successful and failed) [s]. Note: this 
+  - `arangodb_document_read_time`: Execution time histogram of all document
+    primary key read operations (successful and failed) [s]. Note: this
     does not include secondary index lookups, range scans and full collection
     scans.
-  - `arangodb_document_insert_time`: Execution time histogram of all 
+  - `arangodb_document_insert_time`: Execution time histogram of all
     document insert operations (successful and failed) [s].
-  - `arangodb_document_replace_time`: Execution time histogram of all 
+  - `arangodb_document_replace_time`: Execution time histogram of all
     document replace operations (successful and failed) [s].
-  - `arangodb_document_remove_time`: Execution time histogram of all 
+  - `arangodb_document_remove_time`: Execution time histogram of all
     document remove operations (successful and failed) [s].
-  - `arangodb_document_update_time`: Execution time histogram of all 
+  - `arangodb_document_update_time`: Execution time histogram of all
     document update operations (successful and failed) [s].
-  - `arangodb_collection_truncate_time`: Execution time histogram of all 
+  - `arangodb_collection_truncate_time`: Execution time histogram of all
     collection truncate operations (successful and failed) [s].
 
 * Fixed some wrong behavior in single document updates. If the option
@@ -141,9 +144,9 @@ devel
   the same (shared) output file.
 
 * Add option `--envelope` for arangodump, to control if each dumped document
-  should be wrapped into a small JSON envelope (e.g. 
-  `{"type":2300,"data":{...}}`). This JSON envelope is not necessary anymore 
-  since ArangoDB 3.8, so omitting it can produce smaller (and slightly faster) 
+  should be wrapped into a small JSON envelope (e.g.
+  `{"type":2300,"data":{...}}`). This JSON envelope is not necessary anymore
+  since ArangoDB 3.8, so omitting it can produce smaller (and slightly faster)
   dumps.
   Restoring a dump without these JSON envelopers is handled automatically by
   ArangoDB 3.8 and higher. Restoring a dump without these JSON envelopes into
@@ -222,7 +225,7 @@ devel
   level of the query never decreased when going from one level to the
   next. Even though unused registers were recycled since 3.7, this did
   not lead to unused registers being completely dismantled.
- 
+
   Now there is an extra step at the end of the register planning that
   keeps track of the actually used registers on each depth, and that
   will shrink the number of registers for the depth to the id of the
@@ -458,7 +461,7 @@ devel
 
   Using the `all` parameter is only allowed when making the call inside the
   `_system` database and with superuser privileges.
- 
+
 * Improve performance and memory efficiency of agency restart from persisted
   database directory.
 
@@ -493,7 +496,7 @@ devel
 
 * Lowered the minimum allowed value for `--rocksdb.max-write-buffer-number` from
   9 to 4 to allow more fine-grained memory usage control.
- 
+
 * Fix for issue #772: Optimized document counting for ArangoSearch views.
   Added new ArangoSearch view option 'countApproximate' for customizing
   view count strategy.
@@ -665,16 +668,16 @@ devel
   grade of the scheduler's queue is below the configured value, or HTTP 503 if
   the fill grade is above it. This can be used to flag a server as unavailable
   in case it is already highly loaded.
- 
+
   The default value for this option is `0.75`, i.e. 75%. This is a change
   compared to previous versions of ArangoDB, where the default value was `1`.
- 
+
   To prevent sending more traffic to an already overloaded server, it can be
   sensible to reduce the default value to even `0.5`.
   This would mean that instances with a queue longer than 50% of their
   maximum queue capacity would return HTTP 503 instead of HTTP 200 when their
   availability API is probed.
- 
+
   nb: the default value for the scheduler queue length is 4096.
 
 * Added metrics for the system CPU usage:

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -949,13 +949,13 @@ void arangodb::aql::sortInValuesRule(Optimizer* opt, std::unique_ptr<ExecutionPl
         // number of values is below threshold
         continue;
       }
-      
-      if (testNode->type == NODE_TYPE_FCALL && 
+
+      if (testNode->type == NODE_TYPE_FCALL &&
           (static_cast<Function const*>(testNode->getData())->name == "SORTED_UNIQUE" ||
            static_cast<Function const*>(testNode->getData())->name == "SORTED")) {
         // we don't need to sort results of a function that already returns sorted
         // results
-    
+
         AstNode* clone = ast->shallowCopyForModify(inNode);
         TRI_DEFER(FINALIZE_SUBTREE(clone));
         // set sortedness bit for the IN operator
@@ -1636,8 +1636,13 @@ void arangodb::aql::moveCalculationsUpRule(Optimizer* opt,
     auto current = n->getFirstDependency();
 
     while (current != nullptr) {
-      auto dep = current->getFirstDependency();
+      if (current->setsVariable(neededVars)) {
+        // shared variable, cannot move up any more
+        // done with optimizing this calculation node
+        break;
+      }
 
+      auto dep = current->getFirstDependency();
       if (dep == nullptr) {
         auto it = subqueries.find(current);
         if (it != subqueries.end()) {
@@ -1656,12 +1661,6 @@ void arangodb::aql::moveCalculationsUpRule(Optimizer* opt,
         // node either has no or more than one dependency. we don't know what to
         // do and must abort
         // note: this will also handle Singleton nodes
-        break;
-      }
-
-      if (current->setsVariable(neededVars)) {
-        // shared variable, cannot move up any more
-        // done with optimizing this calculation node
         break;
       }
 
@@ -1774,7 +1773,7 @@ void arangodb::aql::moveCalculationsDownRule(Optimizer* opt,
       }
 
       auto const currentType = current->getType();
-      
+
       if (currentType == EN::FILTER || currentType == EN::SORT ||
           currentType == EN::LIMIT || currentType == EN::SUBQUERY) {
         // we found something interesting that justifies moving our node down
@@ -2275,7 +2274,7 @@ class arangodb::aql::RedundantCalculationsReplacer final
         }
         break;
       }
-     
+
       case EN::WINDOW: {
         auto node = ExecutionNode::castTo<WindowNode*>(en);
         node->_rangeVariable = Variable::replace(node->_rangeVariable, _replacements);
@@ -2899,7 +2898,7 @@ void arangodb::aql::removeUnnecessaryCalculationsRule(Optimizer* opt,
           // expression types (V8 vs. non-V8) do not match. give up
           continue;
         }
-       
+
         auto otherLoop = other->getLoop();
 
         if (otherLoop != nullptr && rootNode->callsFunction()) {
@@ -2925,7 +2924,7 @@ void arangodb::aql::removeUnnecessaryCalculationsRule(Optimizer* opt,
             continue;
           }
         }
-        
+
         TRI_ASSERT(other != nullptr);
         otherExpression->replaceVariableReference(outVariable, rootNode);
 
@@ -3126,11 +3125,11 @@ struct SortToIndexNode final
       Variable const* outVariable = enumerateCollectionNode->outVariable();
       std::vector<transaction::Methods::IndexHandle> usedIndexes;
       size_t coveredAttributes = 0;
-      
+
       Collection const* coll = enumerateCollectionNode->collection();
       TRI_ASSERT(coll != nullptr);
       size_t numDocs = coll->count(&_plan->getAst()->query().trxForOptimization(), transaction::CountType::TryCache);
-      
+
       bool canBeUsed = arangodb::aql::utils::getIndexForSortCondition(*coll,
           &sortCondition, outVariable, numDocs,
           enumerateCollectionNode->hint(), usedIndexes, coveredAttributes);
@@ -4496,7 +4495,7 @@ void arangodb::aql::collectInClusterRule(Optimizer* opt, std::unique_ptr<Executi
             collectNode->aggregateVariables()[0].type = "SUM";
             collectNode->aggregateVariables()[0].inVar = outVariable;
             collectNode->aggregationMethod(CollectOptions::CollectMethod::SORTED);
-            
+
             removeGatherNodeSort = true;
           } else if (collectNode->aggregationMethod() ==
                      CollectOptions::CollectMethod::DISTINCT) {
@@ -7669,17 +7668,17 @@ void arangodb::aql::optimizeCountRule(Optimizer* opt,
                                       std::unique_ptr<ExecutionPlan> plan,
                                       OptimizerRule const& rule) {
   bool modified = false;
-  
+
   if (plan->getAst()->query().queryOptions().fullCount) {
     // fullCount is unsupported yet
     opt->addPlan(std::move(plan), rule, modified);
     return;
   }
-  
+
   ::arangodb::containers::SmallVector<ExecutionNode*>::allocator_type::arena_type a;
   ::arangodb::containers::SmallVector<ExecutionNode*> nodes{a};
   plan->findNodesOfType(nodes, EN::CALCULATION, true);
-    
+
   VarSet vars;
   std::unordered_map<ExecutionNode*, std::pair<bool, std::unordered_set<AstNode const*>>> candidates;
 
@@ -7690,7 +7689,7 @@ void arangodb::aql::optimizeCountRule(Optimizer* opt,
     if (root == nullptr) {
       continue;
     }
-  
+
     std::unordered_map<ExecutionNode*, std::pair<bool, std::unordered_set<AstNode const*>>> localCandidates;
 
     // look for all expressions that contain COUNT(subquery) or LENGTH(subquery)
@@ -7715,7 +7714,7 @@ void arangodb::aql::optimizeCountRule(Optimizer* opt,
                 // subquery is non-deterministic. cannot apply the optimization
                 return true;
               }
-    
+
               auto current = sn->getSubquery();
               if (current == nullptr || current->getType() != EN::RETURN) {
                 // subquery does not end with a RETURN instruction - we cannot handle this
@@ -7754,13 +7753,13 @@ void arangodb::aql::optimizeCountRule(Optimizer* opt,
         // subquery result is used for other calculations than COUNT(subquery)
         continue;
       }
-      
+
       SubqueryNode const* sn = ExecutionNode::castTo<SubqueryNode const*>(it.first);
       if (n->isVarUsedLater(sn->outVariable())) {
         // subquery result is used elsewhere later - we cannot optimize
         continue;
       }
-     
+
       bool valid = true;
       // check if subquery result is used somewhere else before the current calculation
       // we are looking at
@@ -7796,7 +7795,7 @@ void arangodb::aql::optimizeCountRule(Optimizer* opt,
     if (returnSetter == nullptr) {
       continue;
     }
-    if (returnSetter->getType() == EN::CALCULATION) { 
+    if (returnSetter->getType() == EN::CALCULATION) {
       // check if we can understand this type of calculation
       auto cn = ExecutionNode::castTo<CalculationNode*>(returnSetter);
       auto expr = cn->expression();
@@ -7804,11 +7803,11 @@ void arangodb::aql::optimizeCountRule(Optimizer* opt,
         continue;
       }
     }
-    
+
     // find the head of the plan/subquery
     while (current->hasDependency()) {
       current = current->getFirstDependency();
-    } 
+    }
 
     TRI_ASSERT(current != nullptr);
 
@@ -7836,11 +7835,11 @@ void arangodb::aql::optimizeCountRule(Optimizer* opt,
           } else {
             TRI_ASSERT(valid);
             if (dynamic_cast<DocumentProducingNode*>(current)->hasFilter()) {
-              // node uses early pruning. this is not supported 
+              // node uses early pruning. this is not supported
               valid = false;
             } else {
               outVariable = dynamic_cast<DocumentProducingNode*>(current)->outVariable();
-        
+
               if (type == EN::INDEX && ExecutionNode::castTo<IndexNode const*>(current)->getIndexes().size() != 1) {
                 // more than one index, so we would need to run uniqueness checks on the
                 // results. this is currently unsupported, so don't apply the optimization
@@ -7863,7 +7862,7 @@ void arangodb::aql::optimizeCountRule(Optimizer* opt,
         case EN::REMOVE:
         case EN::UPSERT:
           // we don't handle data-modification queries
-        
+
         case EN::LIMIT:
           // limit is not yet supported
 
@@ -7877,7 +7876,7 @@ void arangodb::aql::optimizeCountRule(Optimizer* opt,
           valid = false;
           break;
         }
-        
+
         case EN::RETURN:{
           // we reached the end
           break;
@@ -7897,7 +7896,7 @@ void arangodb::aql::optimizeCountRule(Optimizer* opt,
           break;
         }
       }
-      
+
       if (!valid) {
         break;
       }
@@ -7908,18 +7907,18 @@ void arangodb::aql::optimizeCountRule(Optimizer* opt,
     if (valid && found != nullptr) {
       dynamic_cast<DocumentProducingNode*>(found)->setCountFlag();
       returnNode->inVariable(outVariable);
-   
+
       // replace COUNT/LENGTH with SUM, as we are getting an array from the subquery
       auto& server = plan->getAst()->query().vocbase().server();
       auto func = server.getFeature<AqlFunctionFeature>().byName("SUM");
       for (AstNode const* funcNode : it.second.second) {
         const_cast<AstNode*>(funcNode)->setData(static_cast<void const*>(func));
       }
-    
-      if (returnSetter->getType() == EN::CALCULATION) { 
+
+      if (returnSetter->getType() == EN::CALCULATION) {
         plan->clearVarUsageComputed();
         plan->findVarUsage();
-      
+
         auto cn = ExecutionNode::castTo<CalculationNode*>(returnSetter);
         if (cn->expression()->isConstant() && !cn->isVarUsedLater(cn->outVariable())) {
           plan->unlinkNode(cn);
@@ -7928,7 +7927,7 @@ void arangodb::aql::optimizeCountRule(Optimizer* opt,
       modified = true;
     }
   }
-  
+
   opt->addPlan(std::move(plan), rule, modified);
 }
 
@@ -8147,7 +8146,7 @@ void arangodb::aql::spliceSubqueriesRule(Optimizer* opt, std::unique_ptr<Executi
       cb(node);
     }
   };
-    
+
   TRI_IF_FAILURE("Optimizer::allowOldSubqueries") {
     // intentionally let old subqueries pass. this is used only in testing and can be removed in 3.9
     subqueryNodes.clear();

--- a/tests/js/server/aql/aql-optimizer-costs.js
+++ b/tests/js/server/aql/aql-optimizer-costs.js
@@ -224,7 +224,7 @@ function optimizerCostsTestSuite () {
 
       // Check the rough outline first for a better overview in case of a failure
       // of the plan.
-      assertEqual(["SingletonNode", "CalculationNode", "EnumerateListNode", "SubqueryStartNode", "CalculationNode", "EnumerateListNode", "CalculationNode", "SubqueryEndNode", "ReturnNode"],
+      assertEqual(["SingletonNode", "CalculationNode", "CalculationNode", "EnumerateListNode", "SubqueryStartNode", "EnumerateListNode", "CalculationNode", "SubqueryEndNode", "ReturnNode"],
 nodeTypes);
 
       let node, prevNode;
@@ -239,22 +239,22 @@ nodeTypes);
       assertEqual("CalculationNode", node.type);
       assertEqual(1, node.estimatedNrItems);
       assertEqual(1 + prevNode.estimatedCost, node.estimatedCost);
-      // EnumerateListNode
+      // CalculationNode
       prevNode = node;
       node = nodes[2];
+      assertEqual("CalculationNode", node.type);
+      assertEqual(1, node.estimatedNrItems);
+      assertEqual(1 + prevNode.estimatedCost, node.estimatedCost);
+      // EnumerateListNode
+      prevNode = node;
+      node = nodes[3];
       assertEqual("EnumerateListNode", node.type);
       assertEqual(3, node.estimatedNrItems);
       assertEqual(3 + prevNode.estimatedCost, node.estimatedCost);
       // SubqueryStartNode
       prevNode = node;
-      node = nodes[3];
-      assertEqual("SubqueryStartNode", node.type);
-      assertEqual(3, node.estimatedNrItems);
-      assertEqual(3 + prevNode.estimatedCost, node.estimatedCost);
-      // CalculationNode
-      prevNode = node;
       node = nodes[4];
-      assertEqual("CalculationNode", node.type);
+      assertEqual("SubqueryStartNode", node.type);
       assertEqual(3, node.estimatedNrItems);
       assertEqual(3 + prevNode.estimatedCost, node.estimatedCost);
       // EnumerateListNode

--- a/tests/js/server/aql/aql-optimizer-rule-move-filters-up.js
+++ b/tests/js/server/aql/aql-optimizer-rule-move-filters-up.js
@@ -114,7 +114,7 @@ function optimizerRuleTestSuite () {
     testPlans : function () {
       var plans = [ 
         [ "FOR i IN 1..10 FOR j IN 1..10 FILTER i > 1 RETURN i", [ "SingletonNode", "CalculationNode", "CalculationNode", "EnumerateListNode", "CalculationNode", "FilterNode", "EnumerateListNode", "ReturnNode" ] ],
-        [ "FOR i IN 1..10 LET x = (FOR j IN [i] RETURN j) FILTER i > 1 RETURN i", [ "SingletonNode", "CalculationNode", "EnumerateListNode", "CalculationNode", "FilterNode", "SubqueryStartNode", "CalculationNode", "EnumerateListNode", "SubqueryEndNode", "ReturnNode" ] ],
+        [ "FOR i IN 1..10 LET x = (FOR j IN [i] RETURN j) FILTER i > 1 RETURN i", [ "SingletonNode", "CalculationNode", "EnumerateListNode", "CalculationNode", "CalculationNode", "FilterNode", "SubqueryStartNode", "EnumerateListNode", "SubqueryEndNode", "ReturnNode" ] ],
         [ "FOR i IN 1..10 FOR l IN 1..10 LET a = 2 * i FILTER i == 1 RETURN a", [ "SingletonNode", "CalculationNode", "CalculationNode", "EnumerateListNode", "CalculationNode", "CalculationNode", "FilterNode", "EnumerateListNode", "ReturnNode" ] ],
         [ "FOR i IN 1..10 FOR j IN 1..10 FILTER i == 1 FILTER j == 2 RETURN i", [ "SingletonNode", "CalculationNode", "CalculationNode", "EnumerateListNode", "CalculationNode", "FilterNode", "EnumerateListNode", "CalculationNode", "FilterNode", "ReturnNode" ] ]
       ];

--- a/tests/js/server/aql/aql-optimizer-rule-sort-in-values.js
+++ b/tests/js/server/aql/aql-optimizer-rule-sort-in-values.js
@@ -307,8 +307,10 @@ function optimizerRuleTestSuite () {
 
       let nodes = plan.nodes;
       assertEqual("SingletonNode", nodes[0].type);
+      assertEqual("CalculationNode", nodes[1].type);
+
       // ignore the entire subquery contents
-      assertEqual("SubqueryStartNode", nodes[1].type);
+      assertEqual("SubqueryStartNode", nodes[2].type);
       assertEqual("SubqueryEndNode", nodes[4].type);
 
       assertEqual("CalculationNode", nodes[6].type);

--- a/tests/js/server/aql/aql-sort.js
+++ b/tests/js/server/aql/aql-sort.js
@@ -137,10 +137,10 @@ function sortTestSuite () {
       assertEqual([
           'SingletonNode',
           'CalculationNode',
+          'CalculationNode',
+          'CalculationNode',
           'EnumerateListNode',
           'SubqueryStartNode',
-          'CalculationNode',
-          'CalculationNode',
           'EnumerateListNode',
           'SortNode',
           'SubqueryEndNode',


### PR DESCRIPTION
### Scope & Purpose

Extend the move-calculations-up rule so that it can move calculations out of subqueries into the outer query.

- [x] :pizza: New feature (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is already covered by existing tests, such as shell_server_aql.
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** in shell_server_aql

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13830/