### PR TITLE
Remove logging options `--log.api-enabled` and `--log.keep-logrotate` for client tools

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Remove logging startup options `--log.api-enabled` and `--log.keep-logrotate` 
+  for all client tools (arangosh, arangodump, arangorestore etc.), as these 
+  options are only meaningful for arangod.
+
 * Don't allocate ahead-of-time memory for striped PRNG array in arangod,
   but instead use thread-local PRNG instances. Not only does this save a 
   few megabytes or memory, but it also avoids potential (but unlikely)

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -21,8 +21,6 @@
 /// @author Dr. Frank Celler
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <unordered_set>
-
 #include "Basics/operating-system.h"
 
 #ifdef ARANGODB_HAVE_GETGRGID
@@ -70,11 +68,16 @@ void LogHackWriter(char const* p) {
 
 namespace arangodb {
 
-LoggerFeature::LoggerFeature(application_features::ApplicationServer& server, bool threaded)
+LoggerFeature::LoggerFeature(application_features::ApplicationServer& server, 
+                             bool threaded)
     : ApplicationFeature(server, "Logger"),
       _timeFormatString(LogTimeFormats::defaultFormatName()),
       _threaded(threaded) {
 
+  // note: we use the _threaded option to determine whether we are arangod
+  // (_threaded = true) or one of the client tools (_threaded = false). in
+  // the latter case we disable some options for the Logger, which only make
+  // sense when we are running in server mode
   setOptional(false);
 
   startsAfter<ShellColorsFeature>();
@@ -149,12 +152,15 @@ void LoggerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
       .setIntroducedIn(30405)
       .setIntroducedIn(30500);
 
-  options->addOption("--log.api-enabled",
-                     "whether the log api is enabled (true) or not (false), or only enabled for superuser JWT (jwt)",
-                     new StringParameter(&_apiSwitch))
-      .setIntroducedIn(30411)
-      .setIntroducedIn(30506)
-      .setIntroducedIn(30605);
+  if (_threaded) {
+    // this option only makes sense for arangod, not for arangosh etc.
+    options->addOption("--log.api-enabled",
+                       "whether the log api is enabled (true) or not (false), or only enabled for superuser JWT (jwt)",
+                       new StringParameter(&_apiSwitch))
+        .setIntroducedIn(30411)
+        .setIntroducedIn(30506)
+        .setIntroducedIn(30605);
+  }
 
   options
       ->addOption("--log.use-json-format", "use json output format",
@@ -210,10 +216,13 @@ void LoggerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                   arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden))
       .setDeprecatedIn(30500);
 
-  options->addOption("--log.keep-logrotate",
-                     "keep the old log file after receiving a sighup",
-                     new BooleanParameter(&_keepLogRotate),
-                     arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden));
+  if (_threaded) {
+    // this option only makes sense for arangod, not for arangosh etc.
+    options->addOption("--log.keep-logrotate",
+                       "keep the old log file after receiving a sighup",
+                       new BooleanParameter(&_keepLogRotate),
+                       arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden));
+  }
 
   options->addOption("--log.foreground-tty", "also log to tty if backgrounded",
                      new BooleanParameter(&_foregroundTty),


### PR DESCRIPTION
### Scope & Purpose

Remove logging options `--log.api-enabled` and `--log.keep-logrotate` for client tools (arangosh, arangodump, arangorestore etc.), as these options are only meaningful for arangod.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13831/