### PR TITLE
add timeout if the server seems to be alive but we can't reach it after er 5 minutes bail out.

### DIFF
--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -1896,7 +1896,8 @@ function launchFinalize(options, instanceInfo, startTime) {
           if (!checkArangoAlive(arangod, options)) {
             throw new Error('startup failed! bailing out!');
           }
-        } else if (count === 300) {
+        }
+        if (count === 300) {
           throw new Error('startup timed out! bailing out!');
         }
       }

--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -1896,6 +1896,8 @@ function launchFinalize(options, instanceInfo, startTime) {
           if (!checkArangoAlive(arangod, options)) {
             throw new Error('startup failed! bailing out!');
           }
+        } else if (count === 300) {
+          throw new Error('startup timed out! bailing out!');
         }
       }
     });


### PR DESCRIPTION
### Scope & Purpose

this fixes an incident where the server comes up, but we can't reach it because of other reasons.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
