### PR TITLE
make OperationOptions const in index operations

### DIFF
--- a/arangod/IResearch/IResearchRocksDBLink.h
+++ b/arangod/IResearch/IResearchRocksDBLink.h
@@ -61,8 +61,8 @@ class IResearchRocksDBLink final : public RocksDBIndex, public IResearchLink {
   Result insert(transaction::Methods& trx,
                 RocksDBMethods* /*methods*/,
                 LocalDocumentId const& documentId,
-                VPackSlice const doc,
-                OperationOptions& /*options*/) override {
+                VPackSlice doc,
+                OperationOptions const& /*options*/) override {
     return IResearchLink::insert(trx, documentId, doc);
   }
 
@@ -86,7 +86,7 @@ class IResearchRocksDBLink final : public RocksDBIndex, public IResearchLink {
   Result remove(transaction::Methods& trx,
                 RocksDBMethods*,
                 LocalDocumentId const& documentId,
-                VPackSlice const doc) override {
+                VPackSlice doc) override {
     return IResearchLink::remove(trx, documentId, doc);
   }
 

--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
@@ -102,8 +102,8 @@ void RocksDBBuilderIndex::toVelocyPack(VPackBuilder& builder,
 /// insert index elements into the specified write batch.
 Result RocksDBBuilderIndex::insert(transaction::Methods& trx, RocksDBMethods* mthd,
                                    LocalDocumentId const& documentId,
-                                   arangodb::velocypack::Slice const slice,
-                                   OperationOptions& options) {
+                                   arangodb::velocypack::Slice slice,
+                                   OperationOptions const& /*options*/) {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   auto* ctx = dynamic_cast<::BuilderCookie*>(trx.state()->cookie(this));
 #else
@@ -127,7 +127,7 @@ Result RocksDBBuilderIndex::insert(transaction::Methods& trx, RocksDBMethods* mt
 /// remove index elements and put it in the specified write batch.
 Result RocksDBBuilderIndex::remove(transaction::Methods& trx, RocksDBMethods* mthd,
                                    LocalDocumentId const& documentId,
-                                   arangodb::velocypack::Slice const slice) {
+                                   arangodb::velocypack::Slice slice) {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   auto* ctx = dynamic_cast<::BuilderCookie*>(trx.state()->cookie(this));
 #else

--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.h
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.h
@@ -82,11 +82,11 @@ class RocksDBBuilderIndex final : public arangodb::RocksDBIndex {
 
   /// insert index elements into the specified write batch.
   Result insert(transaction::Methods& trx, RocksDBMethods*, LocalDocumentId const& documentId,
-                arangodb::velocypack::Slice const, OperationOptions& options) override;
+                arangodb::velocypack::Slice slice, OperationOptions const& options) override;
 
   /// remove index elements and put it in the specified write batch.
   Result remove(transaction::Methods& trx, RocksDBMethods*, LocalDocumentId const& documentId,
-                arangodb::velocypack::Slice const) override;
+                arangodb::velocypack::Slice slice) override;
 
   /// @brief get index estimator, optional
   RocksDBCuckooIndexEstimator<uint64_t>* estimator() override {

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
@@ -470,7 +470,7 @@ void RocksDBEdgeIndex::toVelocyPack(VPackBuilder& builder,
 
 Result RocksDBEdgeIndex::insert(transaction::Methods& trx, RocksDBMethods* mthd,
                                 LocalDocumentId const& documentId,
-                                velocypack::Slice const doc, OperationOptions& options) {
+                                velocypack::Slice const doc, OperationOptions const& /*options*/) {
   Result res;
   VPackSlice fromTo = doc.get(_directionAttr);
   TRI_ASSERT(fromTo.isString());
@@ -506,7 +506,7 @@ Result RocksDBEdgeIndex::insert(transaction::Methods& trx, RocksDBMethods* mthd,
 
 Result RocksDBEdgeIndex::remove(transaction::Methods& trx, RocksDBMethods* mthd,
                                 LocalDocumentId const& documentId,
-                                velocypack::Slice const doc) {
+                                velocypack::Slice doc) {
   Result res;
 
   // VPackSlice primaryKey = doc.get(StaticStrings::KeyString);

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.h
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.h
@@ -115,11 +115,11 @@ class RocksDBEdgeIndex final : public RocksDBIndex {
 
   Result insert(transaction::Methods& trx, RocksDBMethods* methods,
                 LocalDocumentId const& documentId, velocypack::Slice const doc,
-                OperationOptions& options) override;
+                OperationOptions const& /*options*/) override;
 
   Result remove(transaction::Methods& trx, RocksDBMethods* methods,
                 LocalDocumentId const& documentId,
-                velocypack::Slice const doc) override;
+                velocypack::Slice doc) override;
 
  private:
   /// @brief create the iterator

--- a/arangod/RocksDBEngine/RocksDBFulltextIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBFulltextIndex.cpp
@@ -215,8 +215,8 @@ bool RocksDBFulltextIndex::matchesDefinition(VPackSlice const& info) const {
 
 Result RocksDBFulltextIndex::insert(transaction::Methods& trx, RocksDBMethods* mthd,
                                     LocalDocumentId const& documentId,
-                                    velocypack::Slice const doc,
-                                    OperationOptions& options) {
+                                    velocypack::Slice doc,
+                                    OperationOptions const& /*options*/) {
   Result res;
   std::set<std::string> words = wordlist(doc);
 
@@ -249,7 +249,7 @@ Result RocksDBFulltextIndex::insert(transaction::Methods& trx, RocksDBMethods* m
 
 Result RocksDBFulltextIndex::remove(transaction::Methods& trx, RocksDBMethods* mthd,
                                     LocalDocumentId const& documentId,
-                                    velocypack::Slice const doc) {
+                                    velocypack::Slice doc) {
   Result res;
   std::set<std::string> words = wordlist(doc);
 

--- a/arangod/RocksDBEngine/RocksDBFulltextIndex.h
+++ b/arangod/RocksDBEngine/RocksDBFulltextIndex.h
@@ -96,13 +96,13 @@ class RocksDBFulltextIndex final : public RocksDBIndex {
  protected:
   /// insert index elements into the specified write batch.
   Result insert(transaction::Methods& trx, RocksDBMethods* methods,
-                LocalDocumentId const& documentId, velocypack::Slice const doc,
-                OperationOptions& options) override;
+                LocalDocumentId const& documentId, velocypack::Slice doc,
+                OperationOptions const& /*options*/) override;
 
   /// remove index elements and put it in the specified write batch.
   Result remove(transaction::Methods& trx, RocksDBMethods* methods,
                 LocalDocumentId const& documentId,
-                velocypack::Slice const doc) override;
+                velocypack::Slice doc) override;
 
  private:
   std::set<std::string> wordlist(arangodb::velocypack::Slice const&);

--- a/arangod/RocksDBEngine/RocksDBGeoIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBGeoIndex.cpp
@@ -377,8 +377,8 @@ std::unique_ptr<IndexIterator> RocksDBGeoIndex::iteratorForCondition(
 /// internal insert function, set batch or trx before calling
 Result RocksDBGeoIndex::insert(transaction::Methods& trx, RocksDBMethods* mthd,
                                LocalDocumentId const& documentId,
-                               velocypack::Slice const doc,
-                               arangodb::OperationOptions& options) {
+                               velocypack::Slice doc,
+                               arangodb::OperationOptions const& /*options*/) {
   // covering and centroid of coordinate / polygon / ...
   size_t reserve = _variant == Variant::GEOJSON ? 8 : 1;
   std::vector<S2CellId> cells;
@@ -426,7 +426,7 @@ Result RocksDBGeoIndex::insert(transaction::Methods& trx, RocksDBMethods* mthd,
 /// internal remove function, set batch or trx before calling
 Result RocksDBGeoIndex::remove(transaction::Methods& trx, RocksDBMethods* mthd,
                                LocalDocumentId const& documentId,
-                               velocypack::Slice const doc) {
+                               velocypack::Slice doc) {
   Result res;
 
   // covering and centroid of coordinate / polygon / ...

--- a/arangod/RocksDBEngine/RocksDBGeoIndex.h
+++ b/arangod/RocksDBEngine/RocksDBGeoIndex.h
@@ -76,12 +76,12 @@ class RocksDBGeoIndex final : public RocksDBIndex, public geo_index::Index {
 
   /// insert index elements into the specified write batch.
   Result insert(transaction::Methods& trx, RocksDBMethods* methods,
-                LocalDocumentId const& documentId, velocypack::Slice const doc,
-                arangodb::OperationOptions& options) override;
+                LocalDocumentId const& documentId, velocypack::Slice doc,
+                arangodb::OperationOptions const& /*options*/) override;
 
   /// remove index elements and put it in the specified write batch.
   Result remove(transaction::Methods& trx, RocksDBMethods* methods,
-                LocalDocumentId const& documentId, velocypack::Slice const docs) override;
+                LocalDocumentId const& documentId, velocypack::Slice doc) override;
 
  private:
   std::string const _typeName;

--- a/arangod/RocksDBEngine/RocksDBIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndex.cpp
@@ -256,10 +256,10 @@ void RocksDBIndex::afterTruncate(TRI_voc_tick_t, arangodb::transaction::Methods*
 
 Result RocksDBIndex::update(transaction::Methods& trx, RocksDBMethods* mthd,
                             LocalDocumentId const& oldDocumentId,
-                            velocypack::Slice const oldDoc,
+                            velocypack::Slice oldDoc,
                             LocalDocumentId const& newDocumentId,
-                            velocypack::Slice const newDoc,
-                            OperationOptions& options) {
+                            velocypack::Slice newDoc,
+                            OperationOptions const& options) {
   // It is illegal to call this method on the primary index
   // RocksDBPrimaryIndex must override this method accordingly
   TRI_ASSERT(type() != TRI_IDX_TYPE_PRIMARY_INDEX);

--- a/arangod/RocksDBEngine/RocksDBIndex.h
+++ b/arangod/RocksDBEngine/RocksDBIndex.h
@@ -93,20 +93,20 @@ class RocksDBIndex : public Index {
   /// insert index elements into the specified write batch.
   virtual Result insert(transaction::Methods& trx, RocksDBMethods* methods,
                         LocalDocumentId const& documentId,
-                        arangodb::velocypack::Slice const doc,
-                        OperationOptions& options) = 0;
+                        arangodb::velocypack::Slice doc,
+                        OperationOptions const& options) = 0;
 
   /// remove index elements and put it in the specified write batch.
   virtual Result remove(transaction::Methods& trx, RocksDBMethods* methods,
                         LocalDocumentId const& documentId,
-                        arangodb::velocypack::Slice const doc) = 0;
+                        arangodb::velocypack::Slice doc) = 0;
 
   virtual Result update(transaction::Methods& trx, RocksDBMethods* methods,
                         LocalDocumentId const& oldDocumentId,
-                        arangodb::velocypack::Slice const oldDoc,
+                        arangodb::velocypack::Slice oldDoc,
                         LocalDocumentId const& newDocumentId,
-                        velocypack::Slice const newDoc,
-                        OperationOptions& options);
+                        velocypack::Slice newDoc,
+                        OperationOptions const& options);
 
   rocksdb::ColumnFamilyHandle* columnFamily() const { return _cf; }
 

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
@@ -581,7 +581,7 @@ bool RocksDBPrimaryIndex::lookupRevision(transaction::Methods* trx,
 Result RocksDBPrimaryIndex::insert(transaction::Methods& trx, RocksDBMethods* mthd,
                                    LocalDocumentId const& documentId,
                                    velocypack::Slice const slice,
-                                   OperationOptions& options) {
+                                   OperationOptions const& options) {
   IndexOperationMode mode = options.indexOperationMode;
   VPackSlice keySlice;
   RevisionId revision;
@@ -628,10 +628,10 @@ Result RocksDBPrimaryIndex::insert(transaction::Methods& trx, RocksDBMethods* mt
 
 Result RocksDBPrimaryIndex::update(transaction::Methods& trx, RocksDBMethods* mthd,
                                    LocalDocumentId const& oldDocumentId,
-                                   velocypack::Slice const oldDoc,
+                                   velocypack::Slice oldDoc,
                                    LocalDocumentId const& newDocumentId,
-                                   velocypack::Slice const newDoc,
-                                   OperationOptions& options) {
+                                   velocypack::Slice newDoc,
+                                   OperationOptions const& /*options*/) {
   Result res;
   VPackSlice keySlice = transaction::helpers::extractKeyFromDocument(oldDoc);
   TRI_ASSERT(keySlice.binaryEquals(oldDoc.get(StaticStrings::KeyString)));
@@ -655,7 +655,7 @@ Result RocksDBPrimaryIndex::update(transaction::Methods& trx, RocksDBMethods* mt
 
 Result RocksDBPrimaryIndex::remove(transaction::Methods& trx, RocksDBMethods* mthd,
                                    LocalDocumentId const& documentId,
-                                   velocypack::Slice const slice) {
+                                   velocypack::Slice slice) {
   Result res;
 
   // TODO: deal with matching revisions?

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.h
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.h
@@ -112,18 +112,18 @@ class RocksDBPrimaryIndex final : public RocksDBIndex {
   /// insert index elements into the specified write batch.
   Result insert(transaction::Methods& trx, RocksDBMethods* methods,
                 LocalDocumentId const& documentId, velocypack::Slice const doc,
-                OperationOptions& options) override;
+                OperationOptions const& options) override;
 
   /// remove index elements and put it in the specified write batch.
   Result remove(transaction::Methods& trx, RocksDBMethods* methods,
                 LocalDocumentId const& documentId,
-                velocypack::Slice const doc) override;
+                velocypack::Slice doc) override;
 
   Result update(transaction::Methods& trx, RocksDBMethods* methods,
                 LocalDocumentId const& oldDocumentId,
-                velocypack::Slice const oldDoc, LocalDocumentId const& newDocumentId,
-                velocypack::Slice const newDoc,
-                OperationOptions& options) override;
+                velocypack::Slice oldDoc, LocalDocumentId const& newDocumentId,
+                velocypack::Slice newDoc,
+                OperationOptions const& /*options*/) override;
 
  private:
   /// @brief create the iterator, for a single attribute, IN operator

--- a/arangod/RocksDBEngine/RocksDBTtlIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBTtlIndex.cpp
@@ -67,7 +67,7 @@ void RocksDBTtlIndex::toVelocyPack(arangodb::velocypack::Builder& builder,
 /// @brief inserts a document into the index
 Result RocksDBTtlIndex::insert(transaction::Methods& trx, RocksDBMethods* mthds,
                                LocalDocumentId const& documentId,
-                               velocypack::Slice const doc, OperationOptions& options) {
+                               velocypack::Slice doc, OperationOptions const& options) {
   double timestamp = getTimestamp(doc);
   if (timestamp < 0) {
     // index attribute not present or invalid. nothing to do 
@@ -83,7 +83,7 @@ Result RocksDBTtlIndex::insert(transaction::Methods& trx, RocksDBMethods* mthds,
 /// @brief removes a document from the index
 Result RocksDBTtlIndex::remove(transaction::Methods& trx, RocksDBMethods* mthds,
                                LocalDocumentId const& documentId,
-                               velocypack::Slice const doc) {
+                               velocypack::Slice doc) {
   double timestamp = getTimestamp(doc);
   if (timestamp < 0) {
     // index attribute not present or invalid. nothing to do 

--- a/arangod/RocksDBEngine/RocksDBTtlIndex.h
+++ b/arangod/RocksDBEngine/RocksDBTtlIndex.h
@@ -53,13 +53,13 @@ class RocksDBTtlIndex final : public RocksDBSkiplistIndex {
  protected:
   // special override method that extracts a timestamp value from the index attribute
   Result insert(transaction::Methods& trx, RocksDBMethods* methods,
-                LocalDocumentId const& documentId, velocypack::Slice const doc,
-                OperationOptions& options) override;
+                LocalDocumentId const& documentId, velocypack::Slice doc,
+                OperationOptions const& options) override;
 
   // special override method that extracts a timestamp value from the index attribute
   Result remove(transaction::Methods& trx, RocksDBMethods* methods,
                 LocalDocumentId const& documentId,
-                velocypack::Slice const doc) override;
+                velocypack::Slice doc) override;
 
  private:
   /// @brief extract a timestamp value from the index attribute value

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -665,7 +665,7 @@ void RocksDBVPackIndex::fillPaths(std::vector<std::vector<std::string>>& paths,
 /// @brief inserts a document into the index
 Result RocksDBVPackIndex::insert(transaction::Methods& trx, RocksDBMethods* mthds,
                                  LocalDocumentId const& documentId,
-                                 velocypack::Slice const doc, OperationOptions& options) {
+                                 velocypack::Slice const doc, OperationOptions const& options) {
   IndexOperationMode mode = options.indexOperationMode;
   Result res;
   rocksdb::Status s;
@@ -811,10 +811,10 @@ namespace {
 
 Result RocksDBVPackIndex::update(transaction::Methods& trx, RocksDBMethods* mthds,
                                  LocalDocumentId const& oldDocumentId,
-                                 velocypack::Slice const oldDoc,
+                                 velocypack::Slice oldDoc,
                                  LocalDocumentId const& newDocumentId,
-                                 velocypack::Slice const newDoc,
-                                 OperationOptions& options) {
+                                 velocypack::Slice newDoc,
+                                 OperationOptions const& options) {
   if (!_unique) {
     // only unique index supports in-place updates
     // lets also not handle the complex case of expanded arrays

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.h
@@ -122,17 +122,17 @@ class RocksDBVPackIndex : public RocksDBIndex {
  protected:
   Result insert(transaction::Methods& trx, RocksDBMethods* methods,
                 LocalDocumentId const& documentId, velocypack::Slice const doc,
-                OperationOptions& options) override;
+                OperationOptions const& options) override;
 
   Result remove(transaction::Methods& trx, RocksDBMethods* methods,
                 LocalDocumentId const& documentId,
-                velocypack::Slice const doc) override;
+                velocypack::Slice doc) override;
 
   Result update(transaction::Methods& trx, RocksDBMethods* methods,
                 LocalDocumentId const& oldDocumentId,
-                velocypack::Slice const oldDoc, LocalDocumentId const& newDocumentId,
-                velocypack::Slice const newDoc,
-                OperationOptions& options) override;
+                velocypack::Slice oldDoc, LocalDocumentId const& newDocumentId,
+                velocypack::Slice newDoc,
+                OperationOptions const& options) override;
 
  private:
   /// @brief return the number of paths


### PR DESCRIPTION
### Scope & Purpose

Make OperationOperations parameter const in internal RocksDB index APIs.
This is an internal API change only, and has no effect for end users or externally visible APIs.
As this is a simple internal-only change, there is intentionally no CHANGELOG entry.

If this change does not work, the compiler will tell us.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13858/