### PR TITLE
improvements for logging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -370,7 +370,7 @@ devel
   run in parallel. The defaults are intentionally high in order to not stop any valid,
   previously working queries from succedding.
 
-* Added startup options `--audit.queue` to control audit logging queuing
+* Added startup option `--audit.queue` to control audit logging queuing
   behavior (Enterprise Edition only):
 
   The option controls whether audit log messages are submitted to a queue

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,45 @@
 devel
 -----
 
+* Improvements for logging. This adds the following startup options to arangod:
+
+- `--log.max-entry-length`: controls the maximum line length for individual
+    log messages that are written into normal logfiles by arangod (note: this
+    does not include audit log messages). 
+    Any log messages longer than the specified value will be truncated and the 
+    suffix '...' will be added to them. The purpose of this parameter is to 
+    shorten long log messages in case there is not a lot of space for logfiles, 
+    and to keep rogue log messages from overusing resources. 
+    The default value is 128 MB, which is very high and should effectively
+    mean downwards-compatiblity with previous arangod versions, which did not
+    restrict the maximum size of log messages.
+  
+  - `--audit.max-entry-length`: controls the maximum line length for individual
+    audit log messages that are written into audit logs by arangod. Any audit
+    log messages longer than the specified value will be truncated and the 
+    suffix '...' will be added to them. 
+    The default value is 128 MB, which is very high and should effectively
+    mean downwards-compatiblity with previous arangod versions, which did not
+    restrict the maximum size of log messages.
+
+  - `--log.in-memory-level`: controls which log messages are preserved in 
+    memory (in case `--log.in-memory` is set to `true`). The default value is
+    `info`, meaning all log messages of types `info`, `warning`, `error` and
+    `fatal` will be stored by an instance in memory (this was also the behavior
+    in previous versions of ArangoDB). By setting this option to `warning`,
+    only `warning` log messages will be preserved in memory, and by setting
+    the option to `error` only error messages will be kept.
+    This option is useful because the number of in-memory log messages is 
+    limited to the latest 2048 messages, and these slots are by default shared 
+    between informational, warning and error messages. 
+
+* Honor the value of startup option `--log.api-enabled` when set to `false`.
+  THe desired behavior in this case is to turn off the REST API for logging,
+  but was not implemented. The default value for the option is `true`, so the
+  REST API is enabled. This behavior did not change, and neither did the 
+  behavior when setting the option to a value of `jwt` (meaning the REST API
+  for logging is only available for superusers with a valid JWT token).
+
 * Fix `/_admin/cluster/removeServer` API.
   This often returned HTTP 500 with an error message "Need open Array" due to
   an internal error when setting up agency preconditions.

--- a/arangod/RestHandler/RestAdminLogHandler.h
+++ b/arangod/RestHandler/RestAdminLogHandler.h
@@ -45,6 +45,7 @@ class RestAdminLogHandler : public RestBaseHandler {
 
  private:
   arangodb::Result verifyPermitted();
+  void clearLogs();
   void reportLogs();
   void setLogLevel();
 

--- a/lib/Logger/LogBufferFeature.h
+++ b/lib/Logger/LogBufferFeature.h
@@ -64,8 +64,12 @@ class LogBufferFeature final : public application_features::ApplicationFeature {
   /// @brief return all buffered log entries
   std::vector<LogBuffer> entries(LogLevel, uint64_t start, bool upToLevel);
 
+  /// @brief clear all log entries
+  void clear();
+
  private:
   std::shared_ptr<LogAppender> _inMemoryAppender;
+  std::string _minInMemoryLogLevel;
   bool _useInMemoryAppender;
 };
 

--- a/lib/Logger/LogGroup.h
+++ b/lib/Logger/LogGroup.h
@@ -24,6 +24,7 @@
 #ifndef ARANGODB_LOGGER_LOG_GROUP_H
 #define ARANGODB_LOGGER_LOG_GROUP_H 1
 
+#include <atomic>
 #include <cstddef>
 
 namespace arangodb {
@@ -32,11 +33,30 @@ class LogGroup {
  public:
   // @brief Number of log groups; must increase this when a new group is added
   static constexpr std::size_t Count = 2;
+
+  LogGroup() 
+      : _maxLogEntryLength(256U * 1048576U) {}
+
   virtual ~LogGroup() = default;
 
   /// @brief Must return a UNIQUE identifier amongst all LogGroup derivatives
   /// and must be less than Count
   virtual std::size_t id() const = 0;
+
+  /// @brief max length of log entries in this group
+  std::size_t maxLogEntryLength() const noexcept {
+    return _maxLogEntryLength.load(std::memory_order_relaxed);
+  }
+  
+  /// @brief set the max length of log entries in this group.
+  /// should not be called during the setup of the Logger, and not at runtime
+  void maxLogEntryLength(std::size_t value) {
+    _maxLogEntryLength.store(value);
+  }
+
+ protected:
+  /// @brief maximum length of log entries in this LogGroup
+  std::atomic<std::size_t> _maxLogEntryLength;
 };
 
 }  // namespace arangodb

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -55,8 +55,8 @@
 #ifndef ARANGODB_LOGGER_LOGGER_H
 #define ARANGODB_LOGGER_LOGGER_H 1
 
-#include <stddef.h>
 #include <atomic>
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <string>
@@ -95,12 +95,19 @@ struct LogMessage {
         _message(std::move(message)),
         _offset(offset) {}
 
+  void shrink(std::size_t maxLength) {
+    if (_message.size() > maxLength) {
+      _message.resize(maxLength);
+    }
+    _message.append("...", 3);
+  }
+
   char const* _function;
   char const* _file;
   int const _line;
   LogLevel const _level;
   size_t const _topicId;
-  std::string const _message;
+  std::string _message;
   size_t const _offset;
 };
 
@@ -273,6 +280,8 @@ class Logger {
 
   // can be called after fork()
   static void clearCachedPid() { _cachedPid = 0; }
+
+  static bool translateLogLevel(std::string const& l, bool isGeneral, LogLevel& level) noexcept;
 
   static std::string const& translateLogLevel(LogLevel) noexcept;
 

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -120,6 +120,11 @@ void LoggerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
 
   options->addOption("--log.level,-l", "the global or topic-specific log level",
                      new VectorParameter<StringParameter>(&_levels));
+  
+  options
+      ->addOption("--log.max-entry-length", "maximum length of a log entry (in bytes)",
+                  new UInt32Parameter(&_maxEntryLength))
+      .setIntroducedIn(30800);
 
   options
       ->addOption("--log.use-local-time", "use local timezone instead of UTC",
@@ -364,6 +369,9 @@ void LoggerFeature::prepare() {
     FATAL_ERROR_EXIT();
   }
 #endif
+  
+  // set maximum length for each log entry
+  Logger::defaultLogGroup().maxLogEntryLength(std::max<uint32_t>(128, _maxEntryLength));
 
   Logger::setLogLevel(_levels);
   Logger::setShowIds(_showIds);

--- a/lib/Logger/LoggerFeature.h
+++ b/lib/Logger/LoggerFeature.h
@@ -24,6 +24,7 @@
 #ifndef ARANGODB_LOGGER_LOGGER_FEATURE_H
 #define ARANGODB_LOGGER_LOGGER_FEATURE_H 1
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -65,6 +66,7 @@ class LoggerFeature final : public application_features::ApplicationFeature {
   std::string _fileMode;
   std::string _fileGroup;
   std::string _timeFormatString;
+  uint32_t _maxEntryLength = 128U * 1048576U;
   bool _useJson = false;
   bool _useLocalTime = false;
   bool _useColor = true;

--- a/lib/V8/v8-utils.cpp
+++ b/lib/V8/v8-utils.cpp
@@ -2124,48 +2124,50 @@ static void JS_Log(v8::FunctionCallbackInfo<v8::Value> const& args) {
     ls = splitted[1];
   }
 
-  std::string prefix;
-
   StringUtils::tolowerInPlace(ls);
   StringUtils::tolowerInPlace(ts);
+  
+  std::string prefix;
+  if (ls == "fatal") {
+    prefix = "FATAL! ";
+  } else if (ls != "error" && ls != "warning" && ls != "warn" && ls != "info" && ls != "debug" && ls != "trace") {
+    // invalid log level
+    prefix = ls + "!";
+  }
 
   LogTopic const* topicPtr = ts.empty() ? nullptr : LogTopic::lookup(ts);
   LogTopic const& topic = (topicPtr != nullptr) ? *topicPtr : Logger::FIXME;
+
+  auto logMessage = [&](auto const& message) {
+    if (ls == "fatal") {
+      LOG_TOPIC("ecbc6", FATAL, topic) << prefix << message;
+    } else if (ls == "error") {
+      LOG_TOPIC("24213", ERR, topic) << prefix << message;
+    } else if (ls == "warning" || ls == "warn") {
+      LOG_TOPIC("514da", WARN, topic) << prefix << message;
+    } else if (ls == "info") {
+      LOG_TOPIC("99d80", INFO, topic) << prefix << message;
+    } else if (ls == "debug") {
+      LOG_TOPIC("f3533", DEBUG, topic) << prefix << message;
+    } else if (ls == "trace") {
+      LOG_TOPIC("74c21", TRACE, topic) << prefix << message;
+    } else {
+      LOG_TOPIC("6b817", WARN, topic) << prefix << message;
+    }
+  };
+
   auto context = TRI_IGETC;
 
   if (args[1]->IsArray()) {
     auto loglines = v8::Handle<v8::Array>::Cast(args[1]);
-    std::vector<std::string> logLineVec;
-
-    logLineVec.reserve(loglines->Length());
 
     for (uint32_t i = 0; i < loglines->Length(); ++i) {
       v8::Handle<v8::Value> line = loglines->Get(context, i).FromMaybe(v8::Handle<v8::Value>());
       TRI_Utf8ValueNFC message(isolate, line);
       if (line->IsString()) {
-        logLineVec.push_back(*message);
+        logMessage(*message);
       }
     }
-
-    for (auto& message : logLineVec) {
-      if (ls == "fatal") {
-        prefix = "FATAL! ";
-        LOG_TOPIC("ecbc6", ERR, topic) << prefix << message;
-      } else if (ls == "error") {
-        LOG_TOPIC("24213", ERR, topic) << prefix << message;
-      } else if (ls == "warning" || ls == "warn") {
-        LOG_TOPIC("514da", WARN, topic) << prefix << message;
-      } else if (ls == "info") {
-        LOG_TOPIC("99d80", INFO, topic) << prefix << message;
-      } else if (ls == "debug") {
-        LOG_TOPIC("f3533", DEBUG, topic) << prefix << message;
-      } else if (ls == "trace") {
-        LOG_TOPIC("74c21", TRACE, topic) << prefix << message;
-      } else {
-        prefix = ls + "!";
-        LOG_TOPIC("6b817", WARN, topic) << prefix << message;
-      }
-    }  // for
   } else {
     TRI_Utf8ValueNFC message(isolate, args[1]);
 
@@ -2173,25 +2175,7 @@ static void JS_Log(v8::FunctionCallbackInfo<v8::Value> const& args) {
       TRI_V8_THROW_TYPE_ERROR("<message> must be a string or an array");
     }
 
-    std::string msg = *message;
-
-    if (ls == "fatal") {
-      prefix = "FATAL! ";
-      LOG_TOPIC("d1117", ERR, topic) << prefix << msg;
-    } else if (ls == "error") {
-      LOG_TOPIC("10407", ERR, topic) << prefix << msg;
-    } else if (ls == "warning" || ls == "warn") {
-      LOG_TOPIC("ebe22", WARN, topic) << prefix << msg;
-    } else if (ls == "info") {
-      LOG_TOPIC("365ec", INFO, topic) << prefix << msg;
-    } else if (ls == "debug") {
-      LOG_TOPIC("599b7", DEBUG, topic) << prefix << msg;
-    } else if (ls == "trace") {
-      LOG_TOPIC("42416", TRACE, topic) << prefix << msg;
-    } else {
-      prefix = ls + "!";
-      LOG_TOPIC("0c009", WARN, topic) << prefix << msg;
-    }
+    logMessage(*message);
   }
 
   TRI_V8_RETURN_UNDEFINED();

--- a/tests/js/client/server_parameters/log-max-length-default.js
+++ b/tests/js/client/server_parameters/log-max-length-default.js
@@ -1,0 +1,89 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertTrue, assertEqual, arango, assertMatch */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for server startup options
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const fs = require('fs');
+
+if (getOptions === true) {
+  return {
+    'log.output': 'file://' + fs.getTempFile(),
+    'log.foreground-tty': 'false',
+  };
+}
+
+const jsunity = require('jsunity');
+
+function LoggerSuite() {
+  'use strict';
+
+  return {
+    
+    testLogEntries: function() {
+      let res = arango.POST("/_admin/execute?returnBodyAsJSON=true", `
+require('console').log("testmann: start"); 
+require('console').log("testmann: " + Array(1048576).join("x")); 
+require('console').log("testmann: done"); 
+return require('internal').options()["log.output"];
+`);
+
+      assertTrue(Array.isArray(res));
+      assertTrue(res.length > 0);
+
+      let logfile = res[res.length - 1].replace(/^file:\/\//, '');
+
+      // log is buffered, so give it a few tries until the log messages appear
+      let tries = 0;
+      let filtered = [];
+      while (++tries < 60) {
+        let content = fs.readFileSync(logfile, 'ascii');
+        let lines = content.split('\n');
+
+        filtered = lines.filter((line) => {
+          return line.match(/testmann: /);
+        });
+
+        if (filtered.length === 3) {
+          break;
+        }
+
+        require("internal").sleep(0.5);
+      }
+      assertEqual(3, filtered.length);
+          
+      assertTrue(filtered[0].match(/testmann: start/));
+      assertTrue(filtered[1].match(/testmann: xxxxxxxx/));
+      assertTrue(filtered[2].match(/testmann: done/));
+
+      // the log line must not have been shortened
+      assertTrue(filtered[1].length >= 1048576, filtered[1].length);
+    },
+
+  };
+}
+
+jsunity.run(LoggerSuite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/log-max-length-large.js
+++ b/tests/js/client/server_parameters/log-max-length-large.js
@@ -1,0 +1,96 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertTrue, arango, assertMatch, assertEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for server startup options
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const fs = require('fs');
+
+if (getOptions === true) {
+  return {
+    'log.max-entry-length': '1048576', 
+    'log.output': 'file://' + fs.getTempFile(),
+    'log.foreground-tty': 'false',
+  };
+}
+
+const jsunity = require('jsunity');
+
+function LoggerSuite() {
+  'use strict';
+
+  return {
+    
+    testLogEntries: function() {
+      let res = arango.POST("/_admin/execute?returnBodyAsJSON=true", `
+require('console').log("testmann: start"); 
+require('console').log("testmann: " + Array(32768).join("x")); 
+require('console').log("testmann: " + Array(65536).join("y")); 
+require('console').log("testmann: " + Array(1048576).join("z")); 
+require('console').log("testmann: done"); 
+return require('internal').options()["log.output"];
+`);
+
+      assertTrue(Array.isArray(res));
+      assertTrue(res.length > 0);
+
+      let logfile = res[res.length - 1].replace(/^file:\/\//, '');
+
+      // log is buffered, so give it a few tries until the log messages appear
+      let tries = 0;
+      let filtered = [];
+      while (++tries < 60) {
+        let content = fs.readFileSync(logfile, 'ascii');
+        let lines = content.split('\n');
+
+        filtered = lines.filter((line) => {
+          return line.match(/testmann: /);
+        });
+
+        if (filtered.length === 5) {
+          break;
+        }
+
+        require("internal").sleep(0.5);
+      }
+      assertEqual(5, filtered.length);
+          
+      assertTrue(filtered[0].match(/testmann: start/));
+      assertTrue(filtered[1].match(/testmann: xxxxxxxx/));
+      assertTrue(filtered[2].match(/testmann: yyyyyyyy/));
+      assertTrue(filtered[3].match(/testmann: zzzzzzzz/));
+      assertTrue(filtered[4].match(/testmann: done/));
+
+      assertTrue(filtered[1].length >= 32768, filtered[1].length);
+      assertTrue(filtered[2].length >= 65536, filtered[2].length);
+      // this line must have been shortened
+      assertTrue(filtered[3].length === 1048576 + '...'.length, filtered[3].length);
+    },
+
+  };
+}
+
+jsunity.run(LoggerSuite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/log-max-length-small.js
+++ b/tests/js/client/server_parameters/log-max-length-small.js
@@ -1,0 +1,89 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertTrue, arango, assertMatch, assertEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for server startup options
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const fs = require('fs');
+
+if (getOptions === true) {
+  return {
+    'log.max-entry-length': '16384',
+    'log.output': 'file://' + fs.getTempFile(),
+    'log.foreground-tty': 'false',
+  };
+}
+
+const jsunity = require('jsunity');
+
+function LoggerSuite() {
+  'use strict';
+
+  return {
+    
+    testLogEntries: function() {
+      let res = arango.POST("/_admin/execute?returnBodyAsJSON=true", `
+require('console').log("testmann: start"); 
+require('console').log("testmann: " + Array(32768).join("x")); 
+require('console').log("testmann: done"); 
+return require('internal').options()["log.output"];
+`);
+
+      assertTrue(Array.isArray(res));
+      assertTrue(res.length > 0);
+
+      let logfile = res[res.length - 1].replace(/^file:\/\//, '');
+
+      // log is buffered, so give it a few tries until the log messages appear
+      let tries = 0;
+      let filtered = [];
+      while (++tries < 60) {
+        let content = fs.readFileSync(logfile, 'ascii');
+        let lines = content.split('\n');
+
+        filtered = lines.filter((line) => {
+          return line.match(/testmann: /);
+        });
+
+        if (filtered.length === 3) {
+          break;
+        }
+
+        require("internal").sleep(0.5);
+      }
+      assertEqual(3, filtered.length);
+          
+      assertTrue(filtered[0].match(/testmann: start/));
+      assertTrue(filtered[1].match(/testmann: xxxxxxxx/));
+      assertTrue(filtered[2].match(/testmann: done/));
+
+      assertTrue(filtered[1].length <= 16384 + '...'.length, filtered[1].length);
+    },
+
+  };
+}
+
+jsunity.run(LoggerSuite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/test-log-api-enabled-false.js
+++ b/tests/js/client/server_parameters/test-log-api-enabled-false.js
@@ -1,0 +1,69 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertTrue, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for security-related server options
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'log.api-enabled': "false"
+  };
+}
+
+const jsunity = require('jsunity');
+
+function testSuite() {
+  return {
+    testApiGet : function() {
+      let res = arango.GET("/_admin/log");
+      assertTrue(res.error);
+      assertEqual(403, res.code);
+    },
+    
+    testApiGetLevel : function() {
+      let res = arango.GET("/_admin/log/level");
+      assertTrue(res.error);
+      assertEqual(403, res.code);
+    },
+    
+    testApiPutLevel : function() {
+      let res = arango.PUT("/_admin/log/level", {});
+      assertTrue(res.error);
+      assertEqual(403, res.code);
+    },
+    
+    testApiDelete : function() {
+      let res = arango.DELETE("/_admin/log");
+      assertTrue(res.error);
+      assertEqual(403, res.code);
+    },
+    
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/test-log-api-enabled-true.js
+++ b/tests/js/client/server_parameters/test-log-api-enabled-true.js
@@ -1,0 +1,89 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertNotEqual, assertTrue, assertFalse, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for security-related server options
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'log.api-enabled': "true"
+  };
+}
+
+const jsunity = require('jsunity');
+
+function testSuite() {
+  return {
+    testApiGet : function() {
+      let res = arango.GET("/_admin/log");
+      assertTrue(res.hasOwnProperty("totalAmount"));
+      assertTrue(res.hasOwnProperty("lid"));
+      assertTrue(res.hasOwnProperty("timestamp"));
+      assertTrue(res.hasOwnProperty("level"));
+      assertTrue(res.hasOwnProperty("text"));
+    },
+    
+    testApiGetLevel : function() {
+      const levels = ["FATAL", "ERROR", "WARNING", "INFO", "DEBUG", "TRACE", "DEFAULT"];
+
+      let res = arango.GET("/_admin/log/level");
+      Object.keys(res).forEach((k) => {
+        let level = res[k];
+        assertNotEqual(-1, levels.indexOf(level));
+      });
+    },
+    
+    testApiPutLevel : function() {
+      const levels = ["FATAL", "ERROR", "WARNING", "INFO", "DEBUG", "TRACE", "DEFAULT"];
+
+      let res = arango.PUT("/_admin/log/level", {});
+      Object.keys(res).forEach((k) => {
+        let level = res[k];
+        assertNotEqual(-1, levels.indexOf(level));
+      });
+
+      levels.forEach((level) => {
+        res = arango.PUT("/_admin/log/level", { "replication": level });
+        Object.keys(res).forEach((k) => {
+          let level = res[k];
+          assertNotEqual(-1, levels.indexOf(level));
+        });
+
+        assertEqual(level, res["replication"]);
+      });
+    },
+    
+    testApiDelete : function() {
+      let res = arango.DELETE("/_admin/log");
+      assertEqual(200, res.code);
+    },
+    
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/test-log-in-memory-level-err.js
+++ b/tests/js/client/server_parameters/test-log-in-memory-level-err.js
@@ -1,0 +1,106 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertMatch, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for security-related server options
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'log.in-memory': 'true',
+    'log.in-memory-level' : 'error',
+  };
+}
+
+const jsunity = require('jsunity');
+
+function testSuite() {
+  let checkEmpty = function() {
+    // check that the in-memory logger does not return them (min log level is FATAL)
+    let res = arango.GET("/_admin/log?upto=trace");
+    assertEqual(0, res.totalAmount);
+    assertEqual([], res.lid);
+    assertEqual([], res.topic);
+    assertEqual([], res.level);
+    assertEqual([], res.timestamp);
+    assertEqual([], res.text);
+  };
+  
+  let checkPresent = function(level) {
+    let res = arango.GET("/_admin/log?upto=trace");
+    assertEqual(50, res.totalAmount, res);
+    assertEqual(50, res.lid.length, res);
+    assertEqual(50, res.topic.length, res);
+    assertEqual(50, res.level.length, res);
+    res.level.forEach((l) => assertEqual(level, l, res));
+    assertEqual(50, res.timestamp.length, res);
+    assertEqual(50, res.text.length, res);
+    res.text.forEach((t) => assertMatch(/testi/, t, res));
+  };
+      
+  let log = function(level) {
+    arango.POST("/_admin/execute", `for (let i = 0; i < 50; ++i) require('console')._log('general=${level}', 'testi');`);
+  };
+
+  return {
+    setUp : function() {
+      arango.DELETE("/_admin/log");
+    },
+
+    testApiTrace : function() {
+      log("trace");
+      checkEmpty();
+    },
+
+    testApiDebug : function() {
+      log("debug");
+      checkEmpty();
+    },
+
+    testApiInfo : function() {
+      log("info");
+      checkEmpty();
+    },
+    
+    testApiWarn : function() {
+      log("warn");
+      checkEmpty();
+    },
+    
+    testApiErr : function() {
+      log("error");
+      checkPresent(1);
+    },
+    
+    testApiFatal : function() {
+      log("fatal");
+      checkPresent(0);
+    },
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/test-log-in-memory-level-fatal.js
+++ b/tests/js/client/server_parameters/test-log-in-memory-level-fatal.js
@@ -1,0 +1,106 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertMatch, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for security-related server options
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'log.in-memory': 'true',
+    'log.in-memory-level' : 'fatal',
+  };
+}
+
+const jsunity = require('jsunity');
+
+function testSuite() {
+  let checkEmpty = function() {
+    // check that the in-memory logger does not return them (min log level is FATAL)
+    let res = arango.GET("/_admin/log?upto=trace");
+    assertEqual(0, res.totalAmount);
+    assertEqual([], res.lid);
+    assertEqual([], res.topic);
+    assertEqual([], res.level);
+    assertEqual([], res.timestamp);
+    assertEqual([], res.text);
+  };
+  
+  let checkPresent = function(level) {
+    let res = arango.GET("/_admin/log?upto=trace");
+    assertEqual(50, res.totalAmount, res);
+    assertEqual(50, res.lid.length, res);
+    assertEqual(50, res.topic.length, res);
+    assertEqual(50, res.level.length, res);
+    res.level.forEach((l) => assertEqual(level, l, res));
+    assertEqual(50, res.timestamp.length, res);
+    assertEqual(50, res.text.length, res);
+    res.text.forEach((t) => assertMatch(/testi/, t, res));
+  };
+      
+  let log = function(level) {
+    arango.POST("/_admin/execute", `for (let i = 0; i < 50; ++i) require('console')._log('general=${level}', 'testi');`);
+  };
+
+  return {
+    setUp : function() {
+      arango.DELETE("/_admin/log");
+    },
+
+    testApiTrace : function() {
+      log("trace");
+      checkEmpty();
+    },
+
+    testApiDebug : function() {
+      log("debug");
+      checkEmpty();
+    },
+
+    testApiInfo : function() {
+      log("info");
+      checkEmpty();
+    },
+    
+    testApiWarn : function() {
+      log("warn");
+      checkEmpty();
+    },
+    
+    testApiErr : function() {
+      log("error");
+      checkEmpty();
+    },
+    
+    testApiFatal : function() {
+      log("fatal");
+      checkPresent(0);
+    },
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/test-log-in-memory-level-info.js
+++ b/tests/js/client/server_parameters/test-log-in-memory-level-info.js
@@ -1,0 +1,106 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertMatch, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for security-related server options
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'log.in-memory': 'true',
+    'log.in-memory-level' : 'info',
+  };
+}
+
+const jsunity = require('jsunity');
+
+function testSuite() {
+  let checkEmpty = function() {
+    // check that the in-memory logger does not return them (min log level is FATAL)
+    let res = arango.GET("/_admin/log?upto=trace");
+    assertEqual(0, res.totalAmount);
+    assertEqual([], res.lid);
+    assertEqual([], res.topic);
+    assertEqual([], res.level);
+    assertEqual([], res.timestamp);
+    assertEqual([], res.text);
+  };
+  
+  let checkPresent = function(level) {
+    let res = arango.GET("/_admin/log?upto=trace");
+    assertEqual(50, res.totalAmount, res);
+    assertEqual(50, res.lid.length, res);
+    assertEqual(50, res.topic.length, res);
+    assertEqual(50, res.level.length, res);
+    res.level.forEach((l) => assertEqual(level, l, res));
+    assertEqual(50, res.timestamp.length, res);
+    assertEqual(50, res.text.length, res);
+    res.text.forEach((t) => assertMatch(/testi/, t, res));
+  };
+      
+  let log = function(level) {
+    arango.POST("/_admin/execute", `for (let i = 0; i < 50; ++i) require('console')._log('general=${level}', 'testi');`);
+  };
+
+  return {
+    setUp : function() {
+      arango.DELETE("/_admin/log");
+    },
+
+    testApiTrace : function() {
+      log("trace");
+      checkEmpty();
+    },
+
+    testApiDebug : function() {
+      log("debug");
+      checkEmpty();
+    },
+
+    testApiInfo : function() {
+      log("info");
+      checkPresent(3);
+    },
+    
+    testApiWarn : function() {
+      log("warn");
+      checkPresent(2);
+    },
+    
+    testApiErr : function() {
+      log("error");
+      checkPresent(1);
+    },
+    
+    testApiFatal : function() {
+      log("fatal");
+      checkPresent(0);
+    },
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/test-log-in-memory-level-warn.js
+++ b/tests/js/client/server_parameters/test-log-in-memory-level-warn.js
@@ -1,0 +1,106 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertMatch, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for security-related server options
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'log.in-memory': 'true',
+    'log.in-memory-level' : 'warn',
+  };
+}
+
+const jsunity = require('jsunity');
+
+function testSuite() {
+  let checkEmpty = function() {
+    // check that the in-memory logger does not return them (min log level is FATAL)
+    let res = arango.GET("/_admin/log?upto=trace");
+    assertEqual(0, res.totalAmount);
+    assertEqual([], res.lid);
+    assertEqual([], res.topic);
+    assertEqual([], res.level);
+    assertEqual([], res.timestamp);
+    assertEqual([], res.text);
+  };
+  
+  let checkPresent = function(level) {
+    let res = arango.GET("/_admin/log?upto=trace");
+    assertEqual(50, res.totalAmount, res);
+    assertEqual(50, res.lid.length, res);
+    assertEqual(50, res.topic.length, res);
+    assertEqual(50, res.level.length, res);
+    res.level.forEach((l) => assertEqual(level, l, res));
+    assertEqual(50, res.timestamp.length, res);
+    assertEqual(50, res.text.length, res);
+    res.text.forEach((t) => assertMatch(/testi/, t, res));
+  };
+      
+  let log = function(level) {
+    arango.POST("/_admin/execute", `for (let i = 0; i < 50; ++i) require('console')._log('general=${level}', 'testi');`);
+  };
+
+  return {
+    setUp : function() {
+      arango.DELETE("/_admin/log");
+    },
+
+    testApiTrace : function() {
+      log("trace");
+      checkEmpty();
+    },
+
+    testApiDebug : function() {
+      log("debug");
+      checkEmpty();
+    },
+
+    testApiInfo : function() {
+      log("info");
+      checkEmpty();
+    },
+    
+    testApiWarn : function() {
+      log("warn");
+      checkPresent(2);
+    },
+    
+    testApiErr : function() {
+      log("error");
+      checkPresent(1);
+    },
+    
+    testApiFatal : function() {
+      log("fatal");
+      checkPresent(0);
+    },
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/test-log-in-memory-off.js
+++ b/tests/js/client/server_parameters/test-log-in-memory-off.js
@@ -1,0 +1,55 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for security-related server options
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'log.in-memory': "false"
+  };
+}
+
+const jsunity = require('jsunity');
+
+function testSuite() {
+  return {
+    testApiGet : function() {
+      let res = arango.GET("/_admin/log");
+      assertEqual(0, res.totalAmount);
+      assertEqual([], res.lid);
+      assertEqual([], res.topic);
+      assertEqual([], res.level);
+      assertEqual([], res.timestamp);
+      assertEqual([], res.text);
+    },
+    
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/644
Docs PR: https://github.com/arangodb/docs/pull/616

Improvements for logging. This adds the following startup options to arangod:

- `--log.max-entry-length`: controls the maximum line length for individual log messages that are written into normal logfiles by arangod (note: this does not include audit log messages). 
  Any log messages longer than the specified value will be truncated and the suffix '...' will be added to them. The purpose of this parameter is to shorten long log messages in case there is not a lot of space for logfiles, and to keep rogue log messages from overusing resources. 
  The default value is 128 MB, which is very high and should effectively mean downwards-compatiblity with previous arangod versions, which did not restrict the maximum size of log messages.

- `--audit.max-entry-length`: controls the maximum line length for individual audit log messages that are written into audit logs by arangod. Any audit log messages longer than the specified value will be truncated and the suffix '...' will be added to them. 
  The default value is 128 MB, which is very high and should effectively mean downwards-compatiblity with previous arangod versions, which did not restrict the maximum size of log messages.

- `--log.in-memory-level`: controls which log messages are preserved in memory (in case `--log.in-memory` is set to `true`). The default value is `info`, meaning all log messages of types `info`, `warning`, `error` and `fatal` will be stored by an instance in memory (this was also the behavior in previous versions of ArangoDB). By setting this option to `warning`, only `warning` log messages will be preserved in memory, and by setting the option to `error` only error messages will be kept.
  This option is useful because the number of in-memory log messages is limited to the latest 2048 messages, and these slots are by default shared between informational, warning and error messages. 

Honor the value of startup option `--log.api-enabled` when set to `false`. The desired behavior in this case is to turn off the REST API for logging, but was not implemented. The default value for the option is `true`, so the REST API is enabled. This behavior did not change, and neither did the behavior when setting the option to a value of `jwt` (meaning the REST API for logging is only available for superusers with a valid JWT token).

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/616
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/644

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in server_parameters)

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13864/