### PR TITLE
force DATABASE_UPGRADE flag on upgrade

### DIFF
--- a/arangod/VocBase/Methods/Upgrade.cpp
+++ b/arangod/VocBase/Methods/Upgrade.cpp
@@ -140,7 +140,12 @@ UpgradeResult Upgrade::startup(TRI_vocbase_t& vocbase, bool isUpgrade, bool igno
   switch (vinfo.status) {
     case VersionResult::INVALID:
       TRI_ASSERT(false);  // never returned by Version::check
+      break;
     case VersionResult::VERSION_MATCH:
+      if (isUpgrade) {
+        dbflag = Flags::DATABASE_UPGRADE; // forcing the upgrade as server is in 
+                                          // upgrade state with some features disabled
+      }
       break;  // just run tasks that weren't run yet
     case VersionResult::UPGRADE_NEEDED: {
       if (!isUpgrade) {

--- a/tests/IResearch/IResearchFeature-test.cpp
+++ b/tests/IResearch/IResearchFeature-test.cpp
@@ -2646,7 +2646,7 @@ TEST_F(IResearchFeatureTestDBServer, test_upgrade1_link_collectionName) {
     }
   }
 
-  EXPECT_TRUE(arangodb::methods::Upgrade::startup(*vocbase, true, false).ok());  // run upgrade
+  EXPECT_TRUE(arangodb::methods::Upgrade::startup(*vocbase, false, false).ok());  // run upgrade
 
   {
     auto indexes = logicalCollection->getIndexes();


### PR DESCRIPTION
### Scope & Purpose

Additional fix for BTS-284. Forces DATABASE_UPGRADE  flag during database.auto-upgrade even iv Version check reports VERSION_MATCH. This covers upgrade between patches (e.g. 3.7.6->3.7.7)

- [x] :hankey: Bugfix (requires CHANGELOG entry)

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as k8s tests

Link to Jenkins PR run:
https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/13869/
