### PR TITLE
for obvious reasons, don't discard the future!

### DIFF
--- a/arangod/Cluster/AgencyCache.h
+++ b/arangod/Cluster/AgencyCache.h
@@ -97,7 +97,7 @@ class AgencyCache final : public arangodb::Thread {
   void unregisterCallback(std::string const& key, uint64_t const& id);
 
   /// @brief Wait to be notified, when a Raft index has arrived.
-  futures::Future<Result> waitFor(consensus::index_t index);
+  [[nodiscard]] futures::Future<Result> waitFor(consensus::index_t index);
 
   /// @brief Cache has these path? AgencyCommHelper::path is prepended
   bool has(std::string const& path) const;


### PR DESCRIPTION
### Scope & Purpose

Don't allow discarding the result of AgencyCache::waitFor(), because as consequence, all kinds of things can go wrong.
This PR will prevent this from happening by adding the `[[nodiscard]]` attribute to the method, so its result must be handled.

If something does not work or some existing code does not handle the result yet, the compiler will tell us by issuing a warning, which will be turned into a compile error.

This is an internal change without any end-user visibility, so it is intentionally lacking a CHANGELOG entry.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13877/