### PR TITLE
more logging improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,29 @@
 devel
 -----
 
+* More improvements for logging:
+  
+  * Added new REST API endpoint GET `/_admin/log/entries` to return log entries
+    in a more intuitve format, putting each log entry with all its properties
+    into an object. The API response is an array with all log message objects
+    that match the search criteria.
+    This is an extension of the already existing API endpoint GET `/_admin/log`,
+    which returned log messages in 5 different arrays, with the properties
+    of each log message being separated into the different top-level arrays.
+
+    The already existing API endpoint GET `/_admin/log` for retrieving log 
+    messages is now deprecated, altough it will stay available for some time.
+
+  * Truncation of log messages now takes JSON format into account, so that
+    the truncation of oversized JSON log messages still keeps a valid JSON
+    structure even after the truncation.
+
+  * The maximum size of in-memory log messages was doubled from 256 to 512
+    chars, so that longer parts of each log message can be preserved now.
+
 * Improvements for logging. This adds the following startup options to arangod:
 
-- `--log.max-entry-length`: controls the maximum line length for individual
+  - `--log.max-entry-length`: controls the maximum line length for individual
     log messages that are written into normal logfiles by arangod (note: this
     does not include audit log messages). 
     Any log messages longer than the specified value will be truncated and the 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,9 +7,8 @@ devel
     in a more intuitve format, putting each log entry with all its properties
     into an object. The API response is an array with all log message objects
     that match the search criteria.
-    This is an extension of the already existing API endpoint GET `/_admin/log`,
-    which returned log messages in 5 different arrays, with the properties
-    of each log message being separated into the different top-level arrays.
+    This is an extension to the already existing API endpoint GET `/_admin/log`,
+    which returned log messages fragmented into 5 separate arrays.
 
     The already existing API endpoint GET `/_admin/log` for retrieving log 
     messages is now deprecated, altough it will stay available for some time.

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_log.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_log.md
@@ -1,4 +1,3 @@
-
 @startDocuBlock get_admin_log_entries
 @brief returns the server logs
 
@@ -40,7 +39,10 @@ imposes a chronological order. The default value is *asc*.
 
 @RESTDESCRIPTION
 Returns fatal, error, warning or info log messages from the server's global log.
-The result is a JSON array with log messages that matched the search criteria.
+The result is a JSON object with the following properties:
+
+- **total**: the total amount of log entries before pagination 
+- **messages**: an array with log messages that matched the criteria
 
 This API can be turned off via the startup option `--log.api-enabled`. In case
 the API is disabled, all requests will be responded to with HTTP 403. If the

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_log.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_log.md
@@ -1,4 +1,65 @@
 
+@startDocuBlock get_admin_log_entries
+@brief returns the server logs
+
+@RESTHEADER{GET /_admin/log/entries, Read global logs from the server, getLogEntries}
+
+@RESTQUERYPARAMETERS
+
+@RESTQUERYPARAM{upto,string,optional}
+Returns all log entries up to log level *upto*. Note that *upto* must be:
+- *fatal* or *0*
+- *error* or *1*
+- *warning* or *2*
+- *info* or *3*
+- *debug*  or *4*
+The default value is *info*.
+
+@RESTQUERYPARAM{level,string,optional}
+Returns all log entries of log level *level*. Note that the query parameters
+*upto* and *level* are mutually exclusive.
+
+@RESTQUERYPARAM{start,number,optional}
+Returns all log entries such that their log entry identifier (*lid* value)
+is greater or equal to *start*.
+
+@RESTQUERYPARAM{size,number,optional}
+Restricts the result to at most *size* log entries.
+
+@RESTQUERYPARAM{offset,number,optional}
+Starts to return log entries skipping the first *offset* log entries. *offset*
+and *size* can be used for pagination.
+
+@RESTQUERYPARAM{search,string,optional}
+Only return the log entries containing the text specified in *search*.
+
+@RESTQUERYPARAM{sort,string,optional}
+Sort the log entries either ascending (if *sort* is *asc*) or descending
+(if *sort* is *desc*) according to their *id* values. Note that the *id*
+imposes a chronological order. The default value is *asc*.
+
+@RESTDESCRIPTION
+Returns fatal, error, warning or info log messages from the server's global log.
+The result is a JSON array with log messages that matched the search criteria.
+
+This API can be turned off via the startup option `--log.api-enabled`. In case
+the API is disabled, all requests will be responded to with HTTP 403. If the
+API is enabled, accessing it requires admin privileges, or even superuser
+privileges, depending on the value of the `--log.api-enabled` startup option.
+
+@RESTRETURNCODES
+
+@RESTRETURNCODE{200}
+is returned if the request is valid.
+
+@RESTRETURNCODE{400}
+is returned if invalid values are specified for *upto* or *level*.
+
+@RESTRETURNCODE{403}
+is returned if there are insufficient privileges to access the logs.
+@endDocuBlock
+
+
 @startDocuBlock get_admin_log
 @brief returns the server logs
 
@@ -40,7 +101,12 @@ imposes a chronological order. The default value is *asc*.
 
 @RESTDESCRIPTION
 Returns fatal, error, warning or info log messages from the server's global log.
-The result is a JSON object with the following attributes:
+The result is a JSON object with the attributes described below.
+
+This API can be turned off via the startup option `--log.api-enabled`. In case
+the API is disabled, all requests will be responded to with HTTP 403. If the
+API is enabled, accessing it requires admin privileges, or even superuser
+privileges, depending on the value of the `--log.api-enabled` startup option.
 
 @RESTRETURNCODES
 
@@ -70,9 +136,8 @@ the total amount of log entries before pagination.
 @RESTRETURNCODE{400}
 is returned if invalid values are specified for *upto* or *level*.
 
-@RESTRETURNCODE{500}
-is returned if the server cannot generate the result due to an out-of-memory
-error.
+@RESTRETURNCODE{403}
+is returned if there are insufficient privileges to access the logs.
 @endDocuBlock
 
 
@@ -86,14 +151,18 @@ Returns the server's current log level settings.
 The result is a JSON object with the log topics being the object keys, and
 the log levels being the object values.
 
+This API can be turned off via the startup option `--log.api-enabled`. In case
+the API is disabled, all requests will be responded to with HTTP 403. If the
+API is enabled, accessing it requires admin privileges, or even superuser
+privileges, depending on the value of the `--log.api-enabled` startup option.
+
 @RESTRETURNCODES
 
 @RESTRETURNCODE{200}
 is returned if the request is valid
 
-@RESTRETURNCODE{500}
-is returned if the server cannot generate the result due to an out-of-memory
-error.
+@RESTRETURNCODE{403}
+is returned if there are insufficient privileges to read log levels.
 @endDocuBlock
 
 
@@ -119,6 +188,11 @@ Possible log levels are:
 - INFO - Something has happened, take notice, but no drama attached.
 - DEBUG - output debug messages
 - TRACE - trace - prepare your log to be flooded - don't use in production.
+
+This API can be turned off via the startup option `--log.api-enabled`. In case
+the API is disabled, all requests will be responded to with HTTP 403. If the
+API is enabled, accessing it requires admin privileges, or even superuser
+privileges, depending on the value of the `--log.api-enabled` startup option.
 
 @RESTBODYPARAM{agency,string,optional,string}
 One of the possible log levels.
@@ -296,10 +370,10 @@ is returned if the request is valid
 @RESTRETURNCODE{400}
 is returned when the request body contains invalid JSON.
 
+@RESTRETURNCODE{403}
+is returned if there are insufficient privileges to adjust log levels.
+
 @RESTRETURNCODE{405}
 is returned when an invalid HTTP method is used.
 
-@RESTRETURNCODE{500}
-is returned if the server cannot generate the result due to an out-of-memory
-error.
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_log.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_log.md
@@ -110,6 +110,9 @@ the API is disabled, all requests will be responded to with HTTP 403. If the
 API is enabled, accessing it requires admin privileges, or even superuser
 privileges, depending on the value of the `--log.api-enabled` startup option.
 
+This API is **deprecated** in favor of the `/_admin/log/entries` REST API, which 
+provides the same data in a more intuitive and easier to process format.
+
 @RESTRETURNCODES
 
 @RESTRETURNCODE{200}

--- a/Documentation/DocuBlocks/Rest/Collections/get_api_collections.md
+++ b/Documentation/DocuBlocks/Rest/Collections/get_api_collections.md
@@ -4,22 +4,14 @@
 
 @RESTHEADER{GET /_api/collection,reads all collections, handleCommandGet}
 
-@HINTS
-{% hint 'warning' %}
-Accessing collections by their numeric ID is deprecated from version 3.4.0 on.
-You should reference them via their names instead.
-{% endhint %}
-
 @RESTQUERYPARAMETERS
 
 @RESTQUERYPARAM{excludeSystem,boolean,optional}
 Whether or not system collections should be excluded from the result.
 
 @RESTDESCRIPTION
-Returns an object with an attribute *collections* containing an
-array of all collection descriptions. The same information is also
-available in the *names* as an object with the collection names
-as keys.
+Returns an object with an attribute *result* containing an
+array of all collection descriptions.
 
 By providing the optional query parameter *excludeSystem* with a value of
 *true*, all system collections will be excluded from the response.

--- a/arangod/RestHandler/RestAdminLogHandler.cpp
+++ b/arangod/RestHandler/RestAdminLogHandler.cpp
@@ -87,12 +87,14 @@ RestStatus RestAdminLogHandler::execute() {
       reportLogs(/*newFormat*/ false);
     } else if (suffixes.size() == 1 && suffixes[0] == "entries") {
       reportLogs(/*newFormat*/ true);
+    } else if (suffixes.size() == 1 && suffixes[0] == "level") {
+      handleLogLevel();
     } else {
       generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_SUPERFLUOUS_SUFFICES,
                     "superfluous suffix, expecting /_admin/log/entries");
     }
   } else {
-    setLogLevel();
+    handleLogLevel();
   }
 
   return RestStatus::DONE;
@@ -315,7 +317,7 @@ void RestAdminLogHandler::reportLogs(bool newFormat) {
   generateResult(rest::ResponseCode::OK, result.slice());
 }
 
-void RestAdminLogHandler::setLogLevel() {
+void RestAdminLogHandler::handleLogLevel() {
   std::vector<std::string> const& suffixes = _request->suffixes();
 
   // was validated earlier

--- a/arangod/RestHandler/RestAdminLogHandler.cpp
+++ b/arangod/RestHandler/RestAdminLogHandler.cpp
@@ -30,6 +30,7 @@
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/StringUtils.h"
+#include "Basics/conversions.h"
 #include "GeneralServer/ServerSecurityFeature.h"
 #include "Logger/LogBufferFeature.h"
 #include "Logger/Logger.h"
@@ -76,13 +77,20 @@ RestStatus RestAdminLogHandler::execute() {
     return RestStatus::DONE;
   }
 
+  auto const& suffixes = _request->suffixes();
   auto const type = _request->requestType();
-  size_t const len = _request->suffixes().size();
 
   if (type == rest::RequestType::DELETE_REQ) {
     clearLogs();
-  } else if (len == 0) {
-    reportLogs();
+  } else if (type == rest::RequestType::GET) {
+    if (suffixes.empty()) {
+      reportLogs(/*newFormat*/ false);
+    } else if (suffixes.size() == 1 && suffixes[0] == "entries") {
+      reportLogs(/*newFormat*/ true);
+    } else {
+      generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_SUPERFLUOUS_SUFFICES,
+                    "superfluous suffix, expecting /_admin/log/entries");
+    }
   } else {
     setLogLevel();
   }
@@ -95,7 +103,7 @@ void RestAdminLogHandler::clearLogs() {
   generateOk(rest::ResponseCode::OK, VPackSlice::emptyObjectSlice());
 }
 
-void RestAdminLogHandler::reportLogs() {
+void RestAdminLogHandler::reportLogs(bool newFormat) {
   // check the maximal log level to report
   bool found1;
   std::string const& upto = StringUtils::tolower(_request->value("upto", found1));
@@ -117,23 +125,23 @@ void RestAdminLogHandler::reportLogs() {
   }
 
   if (found1 || found2) {
-    if (logLevel == "fatal" || logLevel == "0") {
-      ul = LogLevel::FATAL;
-    } else if (logLevel == "error" || logLevel == "1") {
-      ul = LogLevel::ERR;
-    } else if (logLevel == "warning" || logLevel == "2") {
-      ul = LogLevel::WARN;
-    } else if (logLevel == "info" || logLevel == "3") {
-      ul = LogLevel::INFO;
-    } else if (logLevel == "debug" || logLevel == "4") {
-      ul = LogLevel::DEBUG;
-    } else if (logLevel == "trace" || logLevel == "5") {
-      ul = LogLevel::TRACE;
+    // translate from number into log level
+    if (logLevel.size() == 1 && logLevel[0] >= '0' && logLevel[0] <= '5') {
+      static_assert(static_cast<int>(LogLevel::FATAL) == 1);
+      static_assert(static_cast<int>(LogLevel::ERR) == 2);
+      static_assert(static_cast<int>(LogLevel::WARN) == 3);
+      static_assert(static_cast<int>(LogLevel::INFO) == 4);
+      static_assert(static_cast<int>(LogLevel::DEBUG) == 5);
+      static_assert(static_cast<int>(LogLevel::TRACE) == 6);
+      ul = static_cast<LogLevel>((logLevel[0] - '0') + 1);
     } else {
-      generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
-                    std::string("unknown '") + (found2 ? "level" : "upto") +
-                        "' log level: '" + logLevel + "'");
-      return;
+      bool isValid = Logger::translateLogLevel(logLevel, true, ul);
+      if (!isValid) {
+        generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
+                      std::string("unknown '") + (found2 ? "level" : "upto") +
+                          "' log level: '" + logLevel + "'");
+        return;
+      }
     }
   }
 
@@ -163,47 +171,55 @@ void RestAdminLogHandler::reportLogs() {
     size = StringUtils::uint64(si);
   }
 
-  // check the sort direction
-  bool sortAscending = true;
-  std::string sortdir = StringUtils::tolower(_request->value("sort", found));
-
-  if (found) {
-    if (sortdir == "desc") {
-      sortAscending = false;
-    }
-  }
-
   // check the search criteria
-  bool search = false;
-  std::string searchString = StringUtils::tolower(_request->value("search", search));
-
+  std::string const& searchString = _request->value("search");
   // generate result
-  std::vector<LogBuffer> entries = server().getFeature<LogBufferFeature>().entries(ul, start, useUpto);
-  std::vector<LogBuffer> clean;
+  std::vector<LogBuffer> entries = server().getFeature<LogBufferFeature>().entries(ul, start, useUpto, searchString);
 
-  if (search) {
-    for (auto const& entry : entries) {
-      std::string text = StringUtils::tolower(entry._message);
-
-      if (text.find(searchString) == std::string::npos) {
-        continue;
-      }
-
-      clean.emplace_back(entry);
-    }
-  } else {
-    clean.swap(entries);
-  }
-
-  if (!sortAscending) {
-    std::reverse(clean.begin(), clean.end());
+  // check the sort direction
+  std::string const& sortdir = StringUtils::tolower(_request->value("sort"));
+  if (sortdir == "desc") {
+    std::reverse(entries.begin(), entries.end());
   }
 
   VPackBuilder result;
-  result.add(VPackValue(VPackValueType::Object));
-  size_t length = clean.size();
 
-  try {
+  if (newFormat) {
+    // new log format - introduced in 3.8.0.
+    // this format is more intuitive and useful than the old format.
+    // the new format because it groups all attributes of a message together 
+    // in an object, whereas in the old format, the attributes of a message
+    // were split into multiple top-level arrays (one array per attribute).
+    size_t start = 0;
+    if (offset > 0) {
+      start += static_cast<uint64_t>(offset);
+      start = std::min<size_t>(start, entries.size());
+    }
+
+    result.openArray();
+    for (size_t i = start; i < entries.size(); ++i) {
+      if (i - start >= size) {
+        // produced enough results
+        break;
+      }
+      auto& buf = entries[i];
+
+      result.openObject();
+      result.add("id", VPackValue(buf._id));
+      result.add("topic", VPackValue(LogTopic::lookup(buf._topicId)));
+      LogLevel lvl = (buf._level == LogLevel::DEFAULT ? LogLevel::INFO : buf._level);
+      result.add("level", VPackValue(Logger::translateLogLevel(lvl)));
+      result.add("date", VPackValue(TRI_StringTimeStamp(buf._timestamp, Logger::getUseLocalTime())));
+      result.add("message", VPackValue(buf._message));
+      result.close();
+    }
+
+    result.close();
+  } else {
+    // old log format
+    size_t length = entries.size();
+
+    result.openObject();
     result.add("totalAmount", VPackValue(length));
 
     if (offset < 0) {
@@ -220,12 +236,12 @@ void RestAdminLogHandler::reportLogs() {
       length = static_cast<size_t>(size);
     }
 
-    // For now we build the arrays one ofter the other first id
+    // For now we build the arrays one after the other first id
     result.add("lid", VPackValue(VPackValueType::Array));
 
     for (size_t i = 0; i < length; ++i) {
       try {
-        auto& buf = clean.at(i + static_cast<size_t>(offset));
+        auto& buf = entries.at(i + static_cast<size_t>(offset));
         result.add(VPackValue(buf._id));
       } catch (...) {
       }
@@ -237,7 +253,7 @@ void RestAdminLogHandler::reportLogs() {
 
     for (size_t i = 0; i < length; ++i) {
       try {
-        auto& buf = clean.at(i + static_cast<size_t>(offset));
+        auto& buf = entries.at(i + static_cast<size_t>(offset));
         result.add(VPackValue(LogTopic::lookup(buf._topicId)));
       } catch (...) {
       }
@@ -249,7 +265,7 @@ void RestAdminLogHandler::reportLogs() {
 
     for (size_t i = 0; i < length; ++i) {
       try {
-        auto& buf = clean.at(i + static_cast<size_t>(offset));
+        auto& buf = entries.at(i + static_cast<size_t>(offset));
 
         if (buf._level == LogLevel::DEFAULT) {
           result.add(VPackValue(3)); // INFO
@@ -268,7 +284,7 @@ void RestAdminLogHandler::reportLogs() {
 
     for (size_t i = 0; i < length; ++i) {
       try {
-        auto& buf = clean.at(i + static_cast<size_t>(offset));
+        auto& buf = entries.at(i + static_cast<size_t>(offset));
         result.add(VPackValue(static_cast<size_t>(buf._timestamp)));
       } catch (...) {
       }
@@ -281,22 +297,18 @@ void RestAdminLogHandler::reportLogs() {
 
     for (size_t i = 0; i < length; ++i) {
       try {
-        auto& buf = clean.at(i + static_cast<size_t>(offset));
+        auto& buf = entries.at(i + static_cast<size_t>(offset));
         result.add(VPackValue(buf._message));
       } catch (...) {
       }
     }
 
     result.close();
-
+  
     result.close();  // Close the result object
+  } // format end
 
-    generateResult(rest::ResponseCode::OK, result.slice());
-  } catch (...) {
-    // Not Enough memory to build everything up
-    // Has been ignored thus far
-    // So ignore again
-  }
+  generateResult(rest::ResponseCode::OK, result.slice());
 }
 
 void RestAdminLogHandler::setLogLevel() {

--- a/arangod/RestHandler/RestAdminLogHandler.cpp
+++ b/arangod/RestHandler/RestAdminLogHandler.cpp
@@ -196,7 +196,10 @@ void RestAdminLogHandler::reportLogs(bool newFormat) {
       start = std::min<size_t>(start, entries.size());
     }
 
-    result.openArray();
+    result.openObject();
+    result.add("total", VPackValue(entries.size()));
+
+    result.add("messages", VPackValue(VPackValueType::Array));
     for (size_t i = start; i < entries.size(); ++i) {
       if (i - start >= size) {
         // produced enough results
@@ -214,6 +217,7 @@ void RestAdminLogHandler::reportLogs(bool newFormat) {
       result.close();
     }
 
+    result.close(); // messages
     result.close();
   } else {
     // old log format

--- a/arangod/RestHandler/RestAdminLogHandler.h
+++ b/arangod/RestHandler/RestAdminLogHandler.h
@@ -46,7 +46,7 @@ class RestAdminLogHandler : public RestBaseHandler {
  private:
   arangodb::Result verifyPermitted();
   void clearLogs();
-  void reportLogs();
+  void reportLogs(bool newFormat);
   void setLogLevel();
 
 };

--- a/arangod/RestHandler/RestAdminLogHandler.h
+++ b/arangod/RestHandler/RestAdminLogHandler.h
@@ -47,7 +47,7 @@ class RestAdminLogHandler : public RestBaseHandler {
   arangodb::Result verifyPermitted();
   void clearLogs();
   void reportLogs(bool newFormat);
-  void setLogLevel();
+  void handleLogLevel();
 
 };
 }  // namespace arangodb

--- a/lib/Logger/LogBufferFeature.cpp
+++ b/lib/Logger/LogBufferFeature.cpp
@@ -27,6 +27,7 @@
 #include "Basics/MutexLocker.h"
 #include "Basics/StringUtils.h"
 #include "Basics/debugging.h"
+#include "Basics/system-functions.h"
 #include "Basics/tri-strings.h"
 #include "Logger/LogAppender.h"
 #include "Logger/LoggerFeature.h"
@@ -50,7 +51,7 @@ LogBuffer::LogBuffer()
     : _id(0), 
       _level(LogLevel::DEFAULT), 
       _topicId(0), 
-      _timestamp(0) {
+      _timestamp(0.0) {
   memset(&_message[0], 0, sizeof(_message));
 }
 
@@ -72,7 +73,7 @@ class LogAppenderRingBuffer final : public LogAppender {
       return;
     }
 
-    auto timestamp = time(nullptr);
+    double timestamp = TRI_microtime();
 
     MUTEX_LOCKER(guard, _lock);
 

--- a/lib/Logger/LogBufferFeature.h
+++ b/lib/Logger/LogBufferFeature.h
@@ -45,7 +45,7 @@ struct LogBuffer {
   uint64_t _id;
   LogLevel _level;
   uint32_t _topicId;
-  time_t _timestamp;
+  double _timestamp;
   char _message[512];
 
   LogBuffer(); 

--- a/lib/Logger/LogBufferFeature.h
+++ b/lib/Logger/LogBufferFeature.h
@@ -46,7 +46,7 @@ struct LogBuffer {
   LogLevel _level;
   uint32_t _topicId;
   time_t _timestamp;
-  char _message[256];
+  char _message[512];
 
   LogBuffer(); 
 };
@@ -62,7 +62,8 @@ class LogBufferFeature final : public application_features::ApplicationFeature {
   void prepare() override;
 
   /// @brief return all buffered log entries
-  std::vector<LogBuffer> entries(LogLevel, uint64_t start, bool upToLevel);
+  std::vector<LogBuffer> entries(LogLevel, uint64_t start, bool upToLevel, 
+                                 std::string const& searchString);
 
   /// @brief clear all log entries
   void clear();

--- a/lib/Logger/LogGroup.h
+++ b/lib/Logger/LogGroup.h
@@ -32,6 +32,9 @@ namespace arangodb {
 class LogGroup {
  public:
   // @brief Number of log groups; must increase this when a new group is added
+  // we currently use the following log groups:
+  // - 0: default log group: normal logging
+  // - 1: audit log group: audit logging
   static constexpr std::size_t Count = 2;
 
   LogGroup() 

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -86,29 +86,51 @@ struct LogMessage {
   LogMessage& operator=(LogMessage const&) = delete;
 
   LogMessage(char const* function, char const* file, int line,
-             LogLevel level, size_t topicId, std::string&& message, size_t offset)
+             LogLevel level, size_t topicId, std::string&& message, 
+             uint32_t offset, bool shrunk)
       : _function(function),
         _file(file),
         _line(line),
         _level(level),
         _topicId(topicId),
         _message(std::move(message)),
-        _offset(offset) {}
+        _offset(offset),
+        _shrunk(shrunk) {}
+
+  /// @brief whether or no the message was already shrunk
+  bool shrunk() const noexcept { return _shrunk; }
 
   void shrink(std::size_t maxLength) {
-    if (_message.size() > maxLength) {
+    // no need to shrink an already shrunk message
+    if (!_shrunk && _message.size() > maxLength) {
       _message.resize(maxLength);
       _message.append("...", 3);
+      _shrunk = true;
     }
   }
 
+  /// @brief all details about the log message. we need to
+  /// keep all this data around and not just the big log
+  /// message string, because some LogAppenders will refer
+  /// to individual components such as file, line etc.
+
+  /// @brief function name of log message source code location
   char const* _function;
+  /// @brief file of log message source code location
   char const* _file;
+  /// @brief line of log message source code location
   int const _line;
+  /// @brief log level
   LogLevel const _level;
+  /// @brief id of log topic
   size_t const _topicId;
+  /// @biref the actual log message
   std::string _message;
-  size_t const _offset;
+  /// @brief byte offset where actual message starts (i.e. excluding prologue)
+  uint32_t const _offset;
+  /// @brief whether or not the log message was already shrunk (used to
+  /// prevent duplicate shrinking of message)
+  bool _shrunk;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -371,7 +371,7 @@ void LoggerFeature::prepare() {
 #endif
   
   // set maximum length for each log entry
-  Logger::defaultLogGroup().maxLogEntryLength(std::max<uint32_t>(128, _maxEntryLength));
+  Logger::defaultLogGroup().maxLogEntryLength(std::max<uint32_t>(256, _maxEntryLength));
 
   Logger::setLogLevel(_levels);
   Logger::setShowIds(_showIds);

--- a/tests/Basics/LoggerTest.cpp
+++ b/tests/Basics/LoggerTest.cpp
@@ -86,8 +86,8 @@ TEST_F(LoggerTest, test_fds) {
   EXPECT_EQ(std::get<1>(fds[0]), logfile1);
   EXPECT_EQ(std::get<2>(fds[0])->fd(), std::get<0>(fds[0]));
 
-  logger1.logMessage(LogMessage(__FUNCTION__, __FILE__, __LINE__, LogLevel::ERR, 0, "some error message", 0));
-  logger2.logMessage(LogMessage(__FUNCTION__, __FILE__, __LINE__, LogLevel::WARN, 0, "some warning message", 0));
+  logger1.logMessage(LogMessage(__FUNCTION__, __FILE__, __LINE__, LogLevel::ERR, 0, "some error message", 0, true));
+  logger2.logMessage(LogMessage(__FUNCTION__, __FILE__, __LINE__, LogLevel::WARN, 0, "some warning message", 0, true));
 
   std::string content = FileUtils::slurp(logfile1);
   EXPECT_NE(content.find("some error message"), std::string::npos);
@@ -110,8 +110,8 @@ TEST_F(LoggerTest, test_fds_after_reopen) {
   EXPECT_EQ(std::get<1>(fds[0]), logfile1);
   EXPECT_EQ(std::get<2>(fds[0])->fd(), std::get<0>(fds[0]));
 
-  logger1.logMessage(LogMessage(__FUNCTION__, __FILE__, __LINE__, LogLevel::ERR, 0, "some error message", 0));
-  logger2.logMessage(LogMessage(__FUNCTION__, __FILE__, __LINE__, LogLevel::WARN, 0, "some warning message", 0));
+  logger1.logMessage(LogMessage(__FUNCTION__, __FILE__, __LINE__, LogLevel::ERR, 0, "some error message", 0, true));
+  logger2.logMessage(LogMessage(__FUNCTION__, __FILE__, __LINE__, LogLevel::WARN, 0, "some warning message", 0, true));
 
   std::string content = FileUtils::slurp(logfile1);
 
@@ -131,8 +131,8 @@ TEST_F(LoggerTest, test_fds_after_reopen) {
   EXPECT_EQ(std::get<1>(fds[0]), logfile1);
   EXPECT_EQ(std::get<2>(fds[0])->fd(), std::get<0>(fds[0]));
 
-  logger1.logMessage(LogMessage(__FUNCTION__, __FILE__, __LINE__, LogLevel::ERR, 0, "some other error message", 0));
-  logger2.logMessage(LogMessage(__FUNCTION__, __FILE__, __LINE__, LogLevel::WARN, 0, "some other warning message", 0));
+  logger1.logMessage(LogMessage(__FUNCTION__, __FILE__, __LINE__, LogLevel::ERR, 0, "some other error message", 0, true));
+  logger2.logMessage(LogMessage(__FUNCTION__, __FILE__, __LINE__, LogLevel::WARN, 0, "some other warning message", 0, true));
 
   content = FileUtils::slurp(logfile1);
   EXPECT_EQ(content.find("some error message"), std::string::npos);

--- a/tests/js/client/server_parameters/log-json-max-length-small.js
+++ b/tests/js/client/server_parameters/log-json-max-length-small.js
@@ -1,0 +1,98 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertTrue, arango, assertMatch, assertEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for server startup options
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const fs = require('fs');
+
+if (getOptions === true) {
+  return {
+    'log.use-json-format': 'true',
+    'log.max-entry-length': '16384',
+    'log.output': 'file://' + fs.getTempFile(),
+    'log.foreground-tty': 'false',
+  };
+}
+
+const jsunity = require('jsunity');
+
+function LoggerSuite() {
+  'use strict';
+
+  return {
+    
+    testLogEntries: function() {
+      let res = arango.POST("/_admin/execute?returnBodyAsJSON=true", `
+require('console').log("testmann: start"); 
+require('console').log("testmann: " + Array(32768).join("x")); 
+require('console').log("testmann: done"); 
+return require('internal').options()["log.output"];
+`);
+
+      assertTrue(Array.isArray(res));
+      assertTrue(res.length > 0);
+
+      let logfile = res[res.length - 1].replace(/^file:\/\//, '');
+
+      // log is buffered, so give it a few tries until the log messages appear
+      let tries = 0;
+      let filtered = [];
+      while (++tries < 60) {
+        let content = fs.readFileSync(logfile, 'ascii');
+        let lines = content.split('\n');
+
+        filtered = lines.filter((line) => {
+          return line.match(/testmann: /);
+        });
+
+        if (filtered.length === 3) {
+          break;
+        }
+
+        require("internal").sleep(0.5);
+      }
+      assertEqual(3, filtered.length);
+          
+      assertTrue(filtered[0].match(/testmann: start/));
+      assertTrue(filtered[1].match(/testmann: xxxxxxxx/));
+      assertTrue(filtered[2].match(/testmann: done/));
+
+      let valid = 0;
+      filtered.forEach((line) => {
+        JSON.parse(line);
+        valid++;
+      });
+      assertEqual(3, valid);
+
+      // + 10 here, because JSON truncation is approximate
+      assertTrue(filtered[1].length <= 16384 + 10, filtered[1].length);
+    },
+
+  };
+}
+
+jsunity.run(LoggerSuite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/log-json.js
+++ b/tests/js/client/server_parameters/log-json.js
@@ -1,0 +1,100 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertTrue, arango, assertMatch, assertEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for server startup options
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const fs = require('fs');
+
+if (getOptions === true) {
+  return {
+    'log.use-json-format': 'true',
+    'log.output': 'file://' + fs.getTempFile(),
+    'log.foreground-tty': 'false',
+  };
+}
+
+const jsunity = require('jsunity');
+
+function LoggerSuite() {
+  'use strict';
+
+  return {
+    
+    testLogEntries: function() {
+      let res = arango.POST("/_admin/execute?returnBodyAsJSON=true", `
+require('console').log("testmann: start"); 
+for (let i = 0; i < 50; ++i) {
+  require('console').log("testmann: testi" + i);
+}
+require('console').log("testmann: done"); 
+return require('internal').options()["log.output"];
+`);
+
+      assertTrue(Array.isArray(res));
+      assertTrue(res.length > 0);
+
+      let logfile = res[res.length - 1].replace(/^file:\/\//, '');
+
+      // log is buffered, so give it a few tries until the log messages appear
+      let tries = 0;
+      let filtered = [];
+      while (++tries < 60) {
+        let content = fs.readFileSync(logfile, 'ascii');
+        let lines = content.split('\n');
+
+        filtered = lines.filter((line) => {
+          return line.match(/testmann: /);
+        });
+
+        if (filtered.length === 52) {
+          break;
+        }
+
+        require("internal").sleep(0.5);
+      }
+      assertEqual(52, filtered.length);
+          
+      assertTrue(filtered[0].match(/testmann: start/));
+      for (let i = 1; i < 51; ++i) {
+        assertTrue(filtered[i].match(/testmann: testi\d+/));
+        let msg = JSON.parse(filtered[i]);
+        assertTrue(msg.hasOwnProperty("time"), msg);
+        assertTrue(msg.hasOwnProperty("pid"), msg);
+        assertTrue(msg.hasOwnProperty("level"), msg);
+        assertTrue(msg.hasOwnProperty("topic"), msg);
+        assertTrue(msg.hasOwnProperty("id"), msg);
+        assertMatch(/^[a-f0-9]{5}/, msg.id, msg);
+        assertTrue(msg.hasOwnProperty("message"), msg);
+        assertEqual("testmann: testi" + (i - 1), msg.message, msg);
+      }
+      assertTrue(filtered[51].match(/testmann: done/));
+    },
+
+  };
+}
+
+jsunity.run(LoggerSuite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/test-log-api-enabled-true.js
+++ b/tests/js/client/server_parameters/test-log-api-enabled-true.js
@@ -53,7 +53,7 @@ function testSuite() {
       let res = arango.GET("/_admin/log/level");
       Object.keys(res).forEach((k) => {
         let level = res[k];
-        assertNotEqual(-1, levels.indexOf(level));
+        assertNotEqual(-1, levels.indexOf(level), level);
       });
     },
     

--- a/tests/js/client/shell/shell-admin-log.js
+++ b/tests/js/client/shell/shell-admin-log.js
@@ -54,13 +54,13 @@ function adminLogSuite() {
     testGetAdminLogNewFormat: function () {
       log("warn");
       let res = arango.GET("/_admin/log/entries?upto=warning");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
 
       let lastId = null;
-      res.forEach((entry) => {
+      res.messages.forEach((entry) => {
         assertEqual("number", typeof entry.id);
-        print(entry, lastId);
         assertTrue(entry.id > lastId || lastId === null);
         lastId = entry.id;
         assertEqual("WARNING", entry.level);
@@ -74,90 +74,107 @@ function adminLogSuite() {
       log("fatal");
       
       let res = arango.GET("/_admin/log/entries?upto=fatal");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=err");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
 
       res = arango.GET("/_admin/log/entries?upto=info");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
     },
     
     testGetAdminLogNewFormatUpToErr: function () {
       log("error");
       
       let res = arango.GET("/_admin/log/entries?upto=fatal");
-      assertTrue(Array.isArray(res));
-      assertEqual(0, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(0, res.messages.length);
+      assertEqual(0, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=error");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
 
       res = arango.GET("/_admin/log/entries?upto=info");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
     },
     
     testGetAdminLogNewFormatUpToWarn: function () {
       log("warn");
       
       let res = arango.GET("/_admin/log/entries?upto=fatal");
-      assertTrue(Array.isArray(res));
-      assertEqual(0, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(0, res.messages.length);
+      assertEqual(0, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=err");
-      assertTrue(Array.isArray(res));
-      assertEqual(0, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(0, res.messages.length);
+      assertEqual(0, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
 
       res = arango.GET("/_admin/log/entries?upto=info");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
     },
     
     testGetAdminLogNewFormatUpToInfo: function () {
       log("info");
       
       let res = arango.GET("/_admin/log/entries?upto=fatal");
-      assertTrue(Array.isArray(res));
-      assertEqual(0, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(0, res.messages.length);
+      assertEqual(0, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=err");
-      assertTrue(Array.isArray(res));
-      assertEqual(0, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(0, res.messages.length);
+      assertEqual(0, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning");
-      assertTrue(Array.isArray(res));
-      assertEqual(0, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(0, res.messages.length);
+      assertEqual(0, res.total);
 
       res = arango.GET("/_admin/log/entries?upto=info");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
     },
     
     testGetAdminLogNewFormatReverse: function () {
       log("warn");
       let res = arango.GET("/_admin/log/entries?upto=warning&sort=desc");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
 
       let lastId = null;
-      res.forEach((entry) => {
+      res.messages.forEach((entry) => {
         assertEqual("number", typeof entry.id);
         assertTrue(entry.id < lastId || lastId === null);
         lastId = entry.id;
@@ -171,106 +188,138 @@ function adminLogSuite() {
     testGetAdminLogNewFormatSearch: function () {
       log("warn");
       let res = arango.GET("/_admin/log/entries?upto=warning&search=testi");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
 
-      res.forEach((entry) => {
+      res.messages.forEach((entry) => {
+        assertMatch(/testi/, entry.message);
+      });
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&search=testi&size=5");
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(5, res.messages.length);
+      assertEqual(50, res.total);
+
+      res.messages.forEach((entry) => {
         assertMatch(/testi/, entry.message);
       });
       
       res = arango.GET("/_admin/log/entries?upto=warning&search=fuxxmann");
-      assertTrue(Array.isArray(res));
-      assertEqual(0, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(0, res.total);
+      assertEqual(0, res.messages.length);
     },
     
     testGetAdminLogNewFormatSize: function () {
       log("warn");
       let res = arango.GET("/_admin/log/entries?upto=warning&size=4");
-      assertTrue(Array.isArray(res));
-      assertEqual(4, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(4, res.messages.length);
+      assertEqual(50, res.total);
 
       res = arango.GET("/_admin/log/entries?upto=warning&size=10");
-      assertTrue(Array.isArray(res));
-      assertEqual(10, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(10, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning&size=50");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning&size=52");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning&size=100000");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
     },
    
     testGetAdminLogNewFormatOffset: function () {
       log("warn");
       let res = arango.GET("/_admin/log/entries?upto=warning&offset=0&size=4");
-      assertTrue(Array.isArray(res));
-      assertEqual(4, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(4, res.messages.length);
+      assertEqual(50, res.total);
 
       res = arango.GET("/_admin/log/entries?upto=warning&offset=0&size=10");
-      assertTrue(Array.isArray(res));
-      assertEqual(10, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(10, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning&offset=0&size=49");
-      assertTrue(Array.isArray(res));
-      assertEqual(49, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(49, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning&offset=0&size=50");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning&offset=0&size=51");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning&offset=0&size=100000");
-      assertTrue(Array.isArray(res));
-      assertEqual(50, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(50, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning&offset=48&size=0");
-      assertTrue(Array.isArray(res));
-      assertEqual(0, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(0, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning&offset=48&size=1");
-      assertTrue(Array.isArray(res));
-      assertEqual(1, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(1, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning&offset=48&size=2");
-      assertTrue(Array.isArray(res));
-      assertEqual(2, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(2, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning&offset=48&size=3");
-      assertTrue(Array.isArray(res));
-      assertEqual(2, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(2, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning&offset=49&size=0");
-      assertTrue(Array.isArray(res));
-      assertEqual(0, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(0, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning&offset=49&size=1");
-      assertTrue(Array.isArray(res));
-      assertEqual(1, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(1, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning&offset=49&size=2");
-      assertTrue(Array.isArray(res));
-      assertEqual(1, res.length);
-      
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(1, res.messages.length);
+      assertEqual(50, res.total);
+
       res = arango.GET("/_admin/log/entries?upto=warning&offset=50&size=0");
-      assertTrue(Array.isArray(res));
-      assertEqual(0, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(0, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning&offset=50&size=1");
-      assertTrue(Array.isArray(res));
-      assertEqual(0, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(0, res.messages.length);
+      assertEqual(50, res.total);
       
       res = arango.GET("/_admin/log/entries?upto=warning&offset=50&size=100");
-      assertTrue(Array.isArray(res));
-      assertEqual(0, res.length);
+      assertTrue(Array.isArray(res.messages));
+      assertEqual(0, res.messages.length);
+      assertEqual(50, res.total);
     },
     
   };

--- a/tests/js/client/shell/shell-admin-log.js
+++ b/tests/js/client/shell/shell-admin-log.js
@@ -1,0 +1,280 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global fail, assertEqual, assertMatch, assertTrue, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2018 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// //////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require('jsunity');
+
+function adminLogSuite() {
+  'use strict';
+      
+  let log = function(level) {
+    arango.POST("/_admin/execute", `for (let i = 0; i < 50; ++i) require('console')._log('general=${level}', 'testi');`);
+  };
+
+  return {
+    setUp : function() {
+      arango.DELETE("/_admin/log");
+    },
+
+    testGetAdminLogOldFormat: function () {
+      log("warn");
+      let res = arango.GET("/_admin/log?upto=warning");
+      let level = 2;
+      assertEqual(50, res.totalAmount, res);
+      assertEqual(50, res.lid.length, res);
+      assertEqual(50, res.topic.length, res);
+      assertEqual(50, res.level.length, res);
+      res.level.forEach((l) => assertEqual(level, l, res));
+      assertEqual(50, res.timestamp.length, res);
+      assertEqual(50, res.text.length, res);
+      res.text.forEach((t) => assertMatch(/testi/, t, res));
+    },
+    
+    testGetAdminLogNewFormat: function () {
+      log("warn");
+      let res = arango.GET("/_admin/log/entries?upto=warning");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+
+      let lastId = null;
+      res.forEach((entry) => {
+        assertEqual("number", typeof entry.id);
+        print(entry, lastId);
+        assertTrue(entry.id > lastId || lastId === null);
+        lastId = entry.id;
+        assertEqual("WARNING", entry.level);
+        assertEqual("general", entry.topic);
+        assertMatch(/^\d+-\d+-\d+T\d+:\d+:\d+/, entry.date);
+        assertMatch(/testi/, entry.message);
+      });
+    },
+    
+    testGetAdminLogNewFormatUpToFatal: function () {
+      log("fatal");
+      
+      let res = arango.GET("/_admin/log/entries?upto=fatal");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=err");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+
+      res = arango.GET("/_admin/log/entries?upto=info");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+    },
+    
+    testGetAdminLogNewFormatUpToErr: function () {
+      log("error");
+      
+      let res = arango.GET("/_admin/log/entries?upto=fatal");
+      assertTrue(Array.isArray(res));
+      assertEqual(0, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=error");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+
+      res = arango.GET("/_admin/log/entries?upto=info");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+    },
+    
+    testGetAdminLogNewFormatUpToWarn: function () {
+      log("warn");
+      
+      let res = arango.GET("/_admin/log/entries?upto=fatal");
+      assertTrue(Array.isArray(res));
+      assertEqual(0, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=err");
+      assertTrue(Array.isArray(res));
+      assertEqual(0, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+
+      res = arango.GET("/_admin/log/entries?upto=info");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+    },
+    
+    testGetAdminLogNewFormatUpToInfo: function () {
+      log("info");
+      
+      let res = arango.GET("/_admin/log/entries?upto=fatal");
+      assertTrue(Array.isArray(res));
+      assertEqual(0, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=err");
+      assertTrue(Array.isArray(res));
+      assertEqual(0, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning");
+      assertTrue(Array.isArray(res));
+      assertEqual(0, res.length);
+
+      res = arango.GET("/_admin/log/entries?upto=info");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+    },
+    
+    testGetAdminLogNewFormatReverse: function () {
+      log("warn");
+      let res = arango.GET("/_admin/log/entries?upto=warning&sort=desc");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+
+      let lastId = null;
+      res.forEach((entry) => {
+        assertEqual("number", typeof entry.id);
+        assertTrue(entry.id < lastId || lastId === null);
+        lastId = entry.id;
+        assertEqual("WARNING", entry.level);
+        assertEqual("general", entry.topic);
+        assertMatch(/^\d+-\d+-\d+T\d+:\d+:\d+/, entry.date);
+        assertMatch(/testi/, entry.message);
+      });
+    },
+    
+    testGetAdminLogNewFormatSearch: function () {
+      log("warn");
+      let res = arango.GET("/_admin/log/entries?upto=warning&search=testi");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+
+      res.forEach((entry) => {
+        assertMatch(/testi/, entry.message);
+      });
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&search=fuxxmann");
+      assertTrue(Array.isArray(res));
+      assertEqual(0, res.length);
+    },
+    
+    testGetAdminLogNewFormatSize: function () {
+      log("warn");
+      let res = arango.GET("/_admin/log/entries?upto=warning&size=4");
+      assertTrue(Array.isArray(res));
+      assertEqual(4, res.length);
+
+      res = arango.GET("/_admin/log/entries?upto=warning&size=10");
+      assertTrue(Array.isArray(res));
+      assertEqual(10, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&size=50");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&size=52");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&size=100000");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+    },
+   
+    testGetAdminLogNewFormatOffset: function () {
+      log("warn");
+      let res = arango.GET("/_admin/log/entries?upto=warning&offset=0&size=4");
+      assertTrue(Array.isArray(res));
+      assertEqual(4, res.length);
+
+      res = arango.GET("/_admin/log/entries?upto=warning&offset=0&size=10");
+      assertTrue(Array.isArray(res));
+      assertEqual(10, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&offset=0&size=49");
+      assertTrue(Array.isArray(res));
+      assertEqual(49, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&offset=0&size=50");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&offset=0&size=51");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&offset=0&size=100000");
+      assertTrue(Array.isArray(res));
+      assertEqual(50, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&offset=48&size=0");
+      assertTrue(Array.isArray(res));
+      assertEqual(0, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&offset=48&size=1");
+      assertTrue(Array.isArray(res));
+      assertEqual(1, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&offset=48&size=2");
+      assertTrue(Array.isArray(res));
+      assertEqual(2, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&offset=48&size=3");
+      assertTrue(Array.isArray(res));
+      assertEqual(2, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&offset=49&size=0");
+      assertTrue(Array.isArray(res));
+      assertEqual(0, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&offset=49&size=1");
+      assertTrue(Array.isArray(res));
+      assertEqual(1, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&offset=49&size=2");
+      assertTrue(Array.isArray(res));
+      assertEqual(1, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&offset=50&size=0");
+      assertTrue(Array.isArray(res));
+      assertEqual(0, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&offset=50&size=1");
+      assertTrue(Array.isArray(res));
+      assertEqual(0, res.length);
+      
+      res = arango.GET("/_admin/log/entries?upto=warning&offset=50&size=100");
+      assertTrue(Array.isArray(res));
+      assertEqual(0, res.length);
+    },
+    
+  };
+}
+
+jsunity.run(adminLogSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Docs PR: https://github.com/arangodb/docs/pull/617
Enterprise companion PR: https://github.com/arangodb/enterprise/pull/646

More improvements for logging:
  
* Added new REST API endpoint GET `/_admin/log/entries` to return log entries in a more intuitve format, putting each log entry with all its properties into an object. The API response is an array with all log message objects that match the search criteria.
  This is an extension to the already existing API endpoint GET `/_admin/log`, which returned log messages fragmented into 5 separate arrays.

 The already existing API endpoint GET `/_admin/log` for retrieving log messages is now deprecated, altough it will stay available for some time.

* Truncation of log messages now takes JSON format into account, so that the truncation of oversized JSON log messages still keeps a valid JSON structure even after the truncation.

* The maximum size of in-memory log messages was doubled from 256 to 512 chars, so that longer parts of each log message can be preserved now.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/617
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/646

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_client, server_parameters)

Link to Jenkins PR:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13878/