### PR TITLE
micro cleanup

### DIFF
--- a/arangod/Agency/Store.h
+++ b/arangod/Agency/Store.h
@@ -181,7 +181,6 @@ class Store {
   /// @brief Clear entries, whose time to live has expired
   query_t clearExpired() const;
 
-  /// @brief Run thread
  private:
   /// @brief underlying application server, needed for testing code
   application_features::ApplicationServer& _server;

--- a/arangod/Cluster/AgencyCache.h
+++ b/arangod/Cluster/AgencyCache.h
@@ -46,10 +46,10 @@ class AgencyCache final : public arangodb::Thread {
     uint64_t version;        // Plan / Current version
     databases_t dbs; // touched databases
     consensus::query_t rest; // Plan / Current rest
-    change_set_t (consensus::index_t const& i, uint64_t const& v, databases_t const& d,
-                  consensus::query_t const& r) :
+    change_set_t(consensus::index_t const& i, uint64_t const& v, databases_t const& d,
+                 consensus::query_t const& r) :
       ind(i), version(v), dbs(d), rest(r) {}
-    change_set_t (consensus::index_t&& i, uint64_t&& v, databases_t&& d, consensus::query_t&& r) :
+    change_set_t(consensus::index_t&& i, uint64_t&& v, databases_t&& d, consensus::query_t&& r) :
       ind(std::move(i)), version(std::move(v)), dbs(std::move(d)), rest(std::move(r)) {}
   };
 

--- a/arangod/Cluster/MaintenanceFeature.h
+++ b/arangod/Cluster/MaintenanceFeature.h
@@ -334,7 +334,7 @@ class MaintenanceFeature : public application_features::ApplicationFeature {
   std::unordered_set<std::string> dirty(
     std::unordered_set<std::string> const& = std::unordered_set<std::string>());
   /// @brief get n random db names
-  std::unordered_set<std::string> pickRandomDirty (size_t n);
+  std::unordered_set<std::string> pickRandomDirty(size_t n);
 
 
  protected:

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
@@ -893,7 +893,8 @@ void RocksDBEdgeIndex::handleValNode(VPackBuilder* keys,
 
 void RocksDBEdgeIndex::afterTruncate(TRI_voc_tick_t tick,
                                      arangodb::transaction::Methods* trx) {
-  if (unique()) {
+  if (unique() || _estimator == nullptr) {
+    // the edge index is never unique - however, this extra check will not do any harm
     return;
   }
   TRI_ASSERT(_estimator != nullptr);

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -1291,7 +1291,7 @@ std::unique_ptr<IndexIterator> RocksDBVPackIndex::iteratorForCondition(
 
 void RocksDBVPackIndex::afterTruncate(TRI_voc_tick_t tick,
                                       arangodb::transaction::Methods* trx) {
-  if (unique()) {
+  if (unique() || _estimator == nullptr) {
     return;
   }
   TRI_ASSERT(_estimator != nullptr);
@@ -1310,13 +1310,9 @@ void RocksDBVPackIndex::setEstimator(std::unique_ptr<RocksDBCuckooIndexEstimator
 }
 
 void RocksDBVPackIndex::recalculateEstimates() {
-  if (unique()) {
+  if (unique() || _estimator == nullptr) {
     return;
   }
-  if (_estimator == nullptr) {
-    return;
-  }
-
   TRI_ASSERT(_estimator != nullptr);
   _estimator->clear();
 


### PR DESCRIPTION
### Scope & Purpose

Minimal code cleanup. Fixes whitespace in function declarations, adds a code comment, plus adds an early exit for case in which `_estimator` is null in indexes. This situation should never occur, however, it is better to make the code safe by not derefencing a pointer that under some (other) conditions can be a nullptr.

This is an internal-only change and should not require any CHANGELOG entry.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13901/