### PR TITLE
prepare explainer code for 3.8 DistributeNode output

### DIFF
--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -1821,6 +1821,10 @@ function processQuery(query, explain, planIndex) {
       case 'RemoteNode':
         return keyword('REMOTE');
       case 'DistributeNode':
+        if (!node.hasOwnProperty('createKeys')) {
+          // this must be a 3.8 or higher!
+          return keyword('DISTRIBUTE') + ' ' + variableName(node.variable);
+        }
         return keyword('DISTRIBUTE') + '  ' + annotation('/* create keys: ' + node.createKeys + ', variable: ') + variableName(node.variable) + ' ' + annotation('*/');
       case 'ScatterNode':
         return keyword('SCATTER');


### PR DESCRIPTION
### Scope & Purpose

Prepare AQL query explainer code in 3.7 for a forthcoming change to the explain output of DistributeNodes in 3.8, so that the 3.7 explainer can handle both types of DistributeNode.

This change will only have an effect if a 3.7 explainer is used against a 3.8 cluster, which is relatively unlikely, but possible.
There is intentionally no CHANGELOG entry for this, as it is a very minor adjustment only.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13910/