### PR TITLE
Fix potential undefined behavior

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 devel
 -----
 
+* Fix potential undefined behavior when iterating over connected nodes in an
+  execution plan and calling callbacks for each of the nodes: if the callbacks
+  modified the list of connected nodes of the current that they were called
+  from, this could lead to potentially undefined behavior due to iterator
+  invalidation. The issue occurred when using a debug STL via `_GLIBCXX_DEBUG`.
+
 * Issue #13141: The `move-filters-into-enumerate` optimization, when applied to
   an EnumerateCollectionNode (i.e. full collection scan), did not do regular
   checks for the query being killed during the filtering of documents, resulting


### PR DESCRIPTION
### Scope & Purpose

Fix potential undefined behavior when iterating over connected nodes in an execution plan and calling callbacks for each of the nodes: if the callbacks modified the list of connected nodes of the current that they were called from, this could lead to potentially undefined behavior due to iterator invalidation. The issue occurred when using a debug STL via `_GLIBCXX_DEBUG`.

I verified that the issue (debug STL assertion failure when running the cluster AQL tests) goes away with this PR.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.7*: https://github.com/arangodb/arangodb/pull/13521, *3.6*: https://github.com/arangodb/arangodb/pull/13522

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
  - [x] Added new **integration tests** (shell_server_aql, but only with debug STL)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [x] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13911/