### PR TITLE
Fix potential undefined behavior

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,13 @@
 v3.6.12 (XXXX-XX-XX)
 --------------------
 
-* Fixed some wrong behaviour in single document updates. If the option
+* Fix potential undefined behavior when iterating over connected nodes in an
+  execution plan and calling callbacks for each of the nodes: if the callbacks
+  modified the list of connected nodes of the current that they were called
+  from, this could lead to potentially undefined behavior due to iterator
+  invalidation. The issue occurred when using a debug STL via `_GLIBCXX_DEBUG`.
+
+* Fixed some wrong behavior in single document updates. If the option
   ignoreRevs=false was given and the precondition _rev was given in the body but
   the _key was given in the URL path, then the rev was wrongly taken as 0,
   rather than using the one from the document body.

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -607,10 +607,28 @@ bool ExecutionNode::walk(WalkerWorker<ExecutionNode>& worker) {
     return true;
   }
 
-  // Now the children in their natural order:
-  for (auto const& it : _dependencies) {
-    if (it->walk(worker)) {
-      return true;
+  if (!_dependencies.empty()) {
+    // intentionally copy the dependencies from before you we iterate
+    // over them.
+    // we keep this copy to check that no worker function modifies the
+    // dependencies while we are working over them. this would be
+    // inherently unsafe, e.g. adding to _dependencies while walking 
+    // over them could lead to vector storage reallocation, and
+    // removing dependencies while walking over them can invalidate
+    // iterators.
+    ::arangodb::containers::SmallVector<ExecutionNode*>::allocator_type::arena_type arena;
+    ::arangodb::containers::SmallVector<ExecutionNode*> dependencies{arena};
+
+    // we normally should have 1, at most 2 dependencies here!
+    dependencies.assign(_dependencies.begin(), _dependencies.end());
+
+    // Now the children in their natural order:
+    for (auto const& it : dependencies) {
+      bool stopWalking = it->walk(worker);
+
+      if (stopWalking) {
+        return true;
+      }
     }
   }
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/13519

Fix potential undefined behavior when iterating over connected nodes in an execution plan and calling callbacks for each of the nodes: if the callbacks modified the list of connected nodes of the current that they were called from, this could lead to potentially undefined behavior due to iterator invalidation. The issue occurred when using a debug STL via `_GLIBCXX_DEBUG`.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *shell_server_aql*.
- [x] I ensured this code runs with ASan / TSan or other static verification tools (`_GLIBCXX_DEBUG`)

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13914/