### PR TITLE
Improve incremental sync replication

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 v3.7.8 (XXXX-XX-XX)
 -------------------
 
+* Improve incremental sync replication for single server and cluster to cope
+  with multiple secondary index unique constraint violations (before this
+  was limited to a failure in a single unique secondary index). this allows
+  replicating the leader state to the follower in basically any order, as
+  any *other* conflicting documents in unique secondary indexes will be 
+  detected and removed on the follower.
+
 * Split the update operations for the _fishbowl system collection with Foxx apps
   into separate insert/replace and remove operations. This makes the overall
   update not atomic, but as removes are unlikely here, we can now get away with

--- a/arangod/ClusterEngine/ClusterEngine.cpp
+++ b/arangod/ClusterEngine/ClusterEngine.cpp
@@ -30,7 +30,6 @@
 #include "Basics/StaticStrings.h"
 #include "Basics/StringUtils.h"
 #include "Basics/Thread.h"
-#include "Basics/VelocyPackHelper.h"
 #include "Basics/build.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterMethods.h"

--- a/arangod/ClusterEngine/ClusterTransactionCollection.cpp
+++ b/arangod/ClusterEngine/ClusterTransactionCollection.cpp
@@ -23,7 +23,6 @@
 #include "ClusterTransactionCollection.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
-#include "Basics/Exceptions.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
 #include "Logger/LogMacros.h"

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -153,7 +153,7 @@ arangodb::Result fetchRevisions(arangodb::transaction::Methods& trx,
   options.isRestore = true;
   options.validate = false; // no validation during replication
   options.indexOperationMode = arangodb::Index::OperationMode::internal;
-  options.ignoreUniqueConstraints = true;
+  options.checkUniqueConstraintsInPreflight = true;
   options.waitForSync = false; // no waitForSync during replication
   if (!state.leaderId.empty()) {
     options.isSynchronousReplicationFrom = state.leaderId;

--- a/arangod/RocksDBEngine/CMakeLists.txt
+++ b/arangod/RocksDBEngine/CMakeLists.txt
@@ -74,6 +74,7 @@ set(ROCKSDB_SOURCES
   RocksDBEngine/RocksDBRestHandlers.cpp
   RocksDBEngine/RocksDBRestReplicationHandler.cpp
   RocksDBEngine/RocksDBRestWalHandler.cpp
+  RocksDBEngine/RocksDBSavePoint.cpp
   RocksDBEngine/RocksDBSettingsManager.cpp
   RocksDBEngine/RocksDBSyncThread.cpp
   RocksDBEngine/RocksDBTransactionCollection.cpp

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -2053,7 +2053,7 @@ Result RocksDBCollection::insertDocument(arangodb::transaction::Methods* trx,
   RocksDBTransactionState* state = RocksDBTransactionState::toState(trx);
   RocksDBMethods* mthds = state->rocksdbMethods();
 
-  if (options.ignoreUniqueConstraints) {
+  if (options.checkUniqueConstraintsInPreflight) {
     // we can only afford the separation of checking and inserting in a
     // transaction that disallows concurrency, i.e. we need to have the
     // exclusive lock on the collection.
@@ -2199,7 +2199,7 @@ Result RocksDBCollection::updateDocument(transaction::Methods* trx,
   RocksDBTransactionState* state = RocksDBTransactionState::toState(trx);
   RocksDBMethods* mthds = state->rocksdbMethods();
 
-  if (options.ignoreUniqueConstraints) {
+  if (options.checkUniqueConstraintsInPreflight) {
     // we can only afford the separation of checking and inserting in a
     // transaction that disallows concurrency, i.e. we need to have the
     // exclusive lock on the collection.

--- a/arangod/RocksDBEngine/RocksDBCollection.h
+++ b/arangod/RocksDBEngine/RocksDBCollection.h
@@ -40,6 +40,7 @@ class Cache;
 class LogicalCollection;
 class ManagedDocumentResult;
 class RocksDBPrimaryIndex;
+class RocksDBSavePoint;
 class RocksDBVPackIndex;
 class LocalDocumentId;
 
@@ -160,6 +161,7 @@ class RocksDBCollection final : public RocksDBMetaCollection {
   }
 
   arangodb::Result insertDocument(arangodb::transaction::Methods* trx,
+                                  RocksDBSavePoint& savepoint,
                                   LocalDocumentId const& documentId,
                                   arangodb::velocypack::Slice const& doc,
                                   OperationOptions& options) const;
@@ -169,7 +171,9 @@ class RocksDBCollection final : public RocksDBMetaCollection {
                                   arangodb::velocypack::Slice const& doc,
                                   OperationOptions& options) const;
 
-  arangodb::Result updateDocument(transaction::Methods* trx, LocalDocumentId const& oldDocumentId,
+  arangodb::Result updateDocument(transaction::Methods* trx, 
+                                  RocksDBSavePoint& savepoint,
+                                  LocalDocumentId const& oldDocumentId,
                                   arangodb::velocypack::Slice const& oldDoc,
                                   LocalDocumentId const& newDocumentId,
                                   arangodb::velocypack::Slice const& newDoc,

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
@@ -36,6 +36,7 @@
 #include "Cache/TransactionalCache.h"
 #include "Indexes/SortedIndexAttributeMatcher.h"
 #include "RocksDBEngine/RocksDBCollection.h"
+#include "RocksDBEngine/RocksDBColumnFamily.h"
 #include "RocksDBEngine/RocksDBCommon.h"
 #include "RocksDBEngine/RocksDBEngine.h"
 #include "RocksDBEngine/RocksDBKey.h"

--- a/arangod/RocksDBEngine/RocksDBFulltextIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBFulltextIndex.cpp
@@ -31,6 +31,7 @@
 #include "Basics/tri-strings.h"
 #include "Logger/Logger.h"
 #include "RocksDBEngine/RocksDBCollection.h"
+#include "RocksDBEngine/RocksDBColumnFamily.h"
 #include "RocksDBEngine/RocksDBCommon.h"
 #include "RocksDBEngine/RocksDBMethods.h"
 #include "RocksDBEngine/RocksDBTransactionState.h"

--- a/arangod/RocksDBEngine/RocksDBGeoIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBGeoIndex.cpp
@@ -29,6 +29,7 @@
 #include "Basics/VelocyPackHelper.h"
 #include "GeoIndex/Near.h"
 #include "Logger/Logger.h"
+#include "RocksDBEngine/RocksDBColumnFamily.h"
 #include "RocksDBEngine/RocksDBCommon.h"
 #include "RocksDBEngine/RocksDBMethods.h"
 #include "VocBase/LogicalCollection.h"

--- a/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
+++ b/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
@@ -184,7 +184,7 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
   options.indexOperationMode = Index::OperationMode::internal;
   options.waitForSync = false;
   options.validate = false;
-  options.ignoreUniqueConstraints = true;
+  options.checkUniqueConstraintsInPreflight = true;
 
   if (!syncer._state.leaderId.empty()) {
     options.isSynchronousReplicationFrom = syncer._state.leaderId;

--- a/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
+++ b/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
@@ -184,6 +184,7 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
   options.indexOperationMode = Index::OperationMode::internal;
   options.waitForSync = false;
   options.validate = false;
+  options.ignoreUniqueConstraints = true;
 
   if (!syncer._state.leaderId.empty()) {
     options.isSynchronousReplicationFrom = syncer._state.leaderId;
@@ -370,6 +371,15 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
     syncer._state.barrier.extend(syncer._state.connection);
   }
 
+  // determine number of unique indexes. we may need it later
+  std::size_t numUniqueIndexes = [&]() {
+    std::size_t numUnique = 0;
+    for (auto const& idx : coll->getIndexes()) {
+      numUnique += idx->unique() ? 1 : 0;
+    }
+    return numUnique;
+  }();
+
   LOG_TOPIC("48f94", TRACE, Logger::REPLICATION)
       << "will refetch " << toFetch.size() << " documents for this chunk";
 
@@ -482,67 +492,51 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
       };
 
       std::pair<LocalDocumentId, TRI_voc_rid_t> lookupResult;
-      if (physical->lookupKey(trx, keySlice.stringRef(), lookupResult).is(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND)) {
-        // key does not yet exist
-        // INSERT
-        TRI_ASSERT(options.indexOperationMode == Index::OperationMode::internal);
+      bool mustInsert = physical->lookupKey(trx, keySlice.stringRef(), lookupResult).is(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND);
 
-        Result res = physical->insert(trx, it, mdr, options);
-        
-        if (res.fail()) {
-          if (res.is(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED) &&
-              res.errorMessage() > keySlice.copyString()) {
-            // remove conflict and retry
-            // errorMessage() is this case contains the conflicting key
-            auto inner = removeConflict(res.errorMessage());
-            if (inner.fail()) {
-              return res;
-            }
+      TRI_ASSERT(options.indexOperationMode == Index::OperationMode::internal);
 
-            options.indexOperationMode = Index::OperationMode::normal;
-            res = physical->insert(trx, it, mdr, options);
-            
-            options.indexOperationMode = Index::OperationMode::internal;
-            if (res.fail()) {
-              return res;
-            }
-            // fall-through
-          } else {
-            int errorNumber = res.errorNumber();
-            res.reset(errorNumber, std::string(TRI_errno_string(errorNumber)) + ": " + res.errorMessage());
-            return res;
+      // there exists the problem of secondary unique index violations when we insert
+      // documents here.
+      // we may need as many retries as there are unique indexes here.
+      std::size_t tries = 1 + numUniqueIndexes;
+      while (tries-- > 0) {
+        if (tries == 0) {
+          options.indexOperationMode = Index::OperationMode::normal;
+        }
+        Result res;
+        if (mustInsert) {
+          res = physical->insert(trx, it, mdr, options);
+          if (res.ok()) {
+            ++stats.numDocsInserted;
           }
+        } else {
+          res = physical->replace(trx, it, mdr, options, previous);
+          // do NOT count up stats.numDocsInserted, as this will influence the 
+          // persisted document count later!!
+        }
+        options.indexOperationMode = Index::OperationMode::internal;
+
+        if (res.ok()) {
+          // all good, we can exit the retry loop now!
+          break;
         }
 
-        ++stats.numDocsInserted;
-      } else {
-        // REPLACE
-        TRI_ASSERT(options.indexOperationMode == Index::OperationMode::internal);
+        if (!res.is(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED) ||
+          res.errorMessage() <= keySlice.stringView()) {
 
-        Result res = physical->replace(trx, it, mdr, options, previous);
+          int errorNumber = res.errorNumber();
+          res.reset(errorNumber, std::string(TRI_errno_string(errorNumber)) + ": " + res.errorMessage());
+          return res;
+        }
         
-        if (res.fail()) {
-          if (res.is(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED) &&
-              res.errorMessage() > keySlice.copyString()) {
-            // remove conflict and retry
-            // errorMessage() is this case contains the conflicting key
-            auto inner = removeConflict(res.errorMessage());
-            if (inner.fail()) {
-              return res;
-            }
-            options.indexOperationMode = Index::OperationMode::normal;
-            res = physical->replace(trx, it, mdr, options, previous);
-            
-            options.indexOperationMode = Index::OperationMode::internal;
-            if (res.fail()) {
-              return res;
-            }
-            // fall-through
-          } else {
-            int errorNumber = res.errorNumber();
-            res.reset(errorNumber, std::string(TRI_errno_string(errorNumber)) + ": " + res.errorMessage());
-            return res;
-          }
+        // unique constraint violation!
+        //
+        // remove conflict and retry
+        // errorMessage() is this case contains the conflicting key
+        auto inner = removeConflict(res.errorMessage());
+        if (inner.fail()) {
+          return res;
         }
       }
     }

--- a/arangod/RocksDBEngine/RocksDBIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndex.cpp
@@ -241,6 +241,32 @@ void RocksDBIndex::afterTruncate(TRI_voc_tick_t, arangodb::transaction::Methods*
   }
 }  
 
+/// performs a preflight check for an insert operation, not carrying out any
+/// modifications to the index.
+/// the default implementation does nothing. indexes can override this and
+/// perform useful checks (uniqueness checks etc.) here
+Result RocksDBIndex::checkInsert(transaction::Methods& /*trx*/, 
+                                 RocksDBMethods* /*methods*/,
+                                 LocalDocumentId const& /*documentId*/,
+                                 arangodb::velocypack::Slice /*doc*/,
+                                 OperationOptions const& /*options*/) {
+  // default implementation does nothing - derived indexes can override this!
+  return {};
+}
+
+/// performs a preflight check for an update/replace operation, not carrying out any
+/// modifications to the index.
+/// the default implementation does nothing. indexes can override this and
+/// perform useful checks (uniqueness checks etc.) here
+Result RocksDBIndex::checkReplace(transaction::Methods& /*trx*/, 
+                                  RocksDBMethods* /*methods*/,
+                                  LocalDocumentId const& /*documentId*/,
+                                  arangodb::velocypack::Slice /*doc*/,
+                                  OperationOptions const& /*options*/) {
+  // default implementation does nothing - derived indexes can override this!
+  return {};
+}
+
 Result RocksDBIndex::update(transaction::Methods& trx, RocksDBMethods* mthd,
                             LocalDocumentId const& oldDocumentId,
                             velocypack::Slice const& oldDoc,

--- a/arangod/RocksDBEngine/RocksDBIndex.h
+++ b/arangod/RocksDBEngine/RocksDBIndex.h
@@ -90,6 +90,24 @@ class RocksDBIndex : public Index {
   }
   void createCache();
   void destroyCache();
+  
+  /// performs a preflight check for an insert operation, not carrying out any
+  /// modifications to the index.
+  /// the default implementation does nothing. indexes can override this and
+  /// perform useful checks (uniqueness checks etc.) here
+  virtual Result checkInsert(transaction::Methods& trx, RocksDBMethods* methods,
+                             LocalDocumentId const& documentId,
+                             arangodb::velocypack::Slice doc,
+                             OperationOptions const& options);
+  
+  /// performs a preflight check for an update/replace operation, not carrying out any
+  /// modifications to the index.
+  /// the default implementation does nothing. indexes can override this and
+  /// perform useful checks (uniqueness checks etc.) here
+  virtual Result checkReplace(transaction::Methods& trx, RocksDBMethods* methods,
+                              LocalDocumentId const& documentId,
+                              arangodb::velocypack::Slice doc,
+                              OperationOptions const& options);
 
   /// insert index elements into the specified write batch.
   virtual Result insert(transaction::Methods& trx, RocksDBMethods* methods,

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -30,6 +30,7 @@
 #include "Basics/system-functions.h"
 #include "Cluster/ServerState.h"
 #include "Random/RandomGenerator.h"
+#include "RocksDBEngine/RocksDBColumnFamily.h"
 #include "RocksDBEngine/RocksDBIndex.h"
 #include "RocksDBEngine/RocksDBLogValue.h"
 #include "RocksDBEngine/RocksDBMethods.h"

--- a/arangod/RocksDBEngine/RocksDBMethods.cpp
+++ b/arangod/RocksDBEngine/RocksDBMethods.cpp
@@ -37,67 +37,6 @@
 
 using namespace arangodb;
 
-// ================= RocksDBSavePoint ==================
-
-RocksDBSavePoint::RocksDBSavePoint(transaction::Methods* trx,
-                                   TRI_voc_document_operation_e operationType)
-    : _trx(trx),
-      _operationType(operationType),
-      _handled(_trx->isSingleOperationTransaction()) {
-  TRI_ASSERT(trx != nullptr);
-  if (!_handled) {
-    auto mthds = RocksDBTransactionState::toMethods(_trx);
-    // only create a savepoint when necessary
-    mthds->SetSavePoint();
-  }
-}
-
-RocksDBSavePoint::~RocksDBSavePoint() {
-  if (!_handled) {
-    try {
-      // only roll back if we create a savepoint and have
-      // not performed an intermediate commit in-between
-      rollback();
-    } catch (std::exception const& ex) {
-      LOG_TOPIC("519ed", ERR, Logger::ENGINES)
-          << "caught exception during rollback to savepoint: " << ex.what();
-    } catch (...) {
-      // whatever happens during rollback, no exceptions are allowed to escape
-      // from here
-    }
-  }
-}
-
-void RocksDBSavePoint::finish(bool hasPerformedIntermediateCommit) {
-  if (!_handled && !hasPerformedIntermediateCommit) {
-    // pop the savepoint from the transaction in order to
-    // save some memory for transactions with many operations
-    // this is only safe to do when we have a created a savepoint
-    // when creating the guard, and when there hasn't been an
-    // intermediate commit in the transaction
-    // when there has been an intermediate commit, we must
-    // leave the savepoint alone, because it belonged to another
-    // transaction, and the current transaction will not have any
-    // savepoint
-    auto mthds = RocksDBTransactionState::toMethods(_trx);
-    mthds->PopSavePoint();
-  }
-
-  // this will prevent the rollback call in the destructor
-  _handled = true;
-}
-
-void RocksDBSavePoint::rollback() {
-  TRI_ASSERT(!_handled);
-  auto mthds = RocksDBTransactionState::toMethods(_trx);
-  mthds->RollbackToSavePoint();
-
-  auto state = RocksDBTransactionState::toState(_trx);
-  state->rollbackOperation(_operationType);
-
-  _handled = true;  // in order to not roll back again by accident
-}
-
 // =================== RocksDBMethods ===================
 
 rocksdb::ReadOptions RocksDBMethods::iteratorReadOptions() {

--- a/arangod/RocksDBEngine/RocksDBMethods.h
+++ b/arangod/RocksDBEngine/RocksDBMethods.h
@@ -24,7 +24,6 @@
 #define ARANGOD_ROCKSDB_ROCKSDB_METHODS_H 1
 
 #include "Basics/Result.h"
-#include "RocksDBColumnFamily.h"
 #include "RocksDBCommon.h"
 
 namespace rocksdb {
@@ -39,33 +38,10 @@ struct ReadOptions;
 }  // namespace rocksdb
 
 namespace arangodb {
-namespace transaction {
-class Methods;
-}
 
 class RocksDBKey;
 class RocksDBMethods;
 class RocksDBTransactionState;
-
-class RocksDBSavePoint {
- public:
-  RocksDBSavePoint(transaction::Methods* trx, TRI_voc_document_operation_e operationType);
-  ~RocksDBSavePoint();
-
-  /// @brief acknowledges the current savepoint, so there
-  /// will be no rollback when the destructor is called
-  /// if an intermediate commit was performed, pass a value of
-  /// true, false otherwise
-  void finish(bool hasPerformedIntermediateCommit);
-
- private:
-  void rollback();
-
- private:
-  transaction::Methods* _trx;
-  TRI_voc_document_operation_e const _operationType;
-  bool _handled;
-};
 
 class RocksDBMethods {
  public:

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
@@ -640,7 +640,7 @@ Result RocksDBPrimaryIndex::insert(transaction::Methods& trx, RocksDBMethods* mt
 
   Result res;
 
-  if (!options.ignoreUniqueConstraints) {
+  if (!options.checkUniqueConstraintsInPreflight) {
     res = probeKey(trx, mthd, key, keySlice, options, /*lock*/ true);
     
     if (res.fail()) {

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
@@ -33,6 +33,7 @@
 #include "Indexes/SortedIndexAttributeMatcher.h"
 #include "Logger/Logger.h"
 #include "RocksDBEngine/RocksDBCollection.h"
+#include "RocksDBEngine/RocksDBColumnFamily.h"
 #include "RocksDBEngine/RocksDBCommon.h"
 #include "RocksDBEngine/RocksDBComparator.h"
 #include "RocksDBEngine/RocksDBEngine.h"
@@ -572,37 +573,79 @@ bool RocksDBPrimaryIndex::lookupRevision(transaction::Methods* trx,
   return true;
 }
 
-Result RocksDBPrimaryIndex::insert(transaction::Methods& trx, RocksDBMethods* mthd,
-                                   LocalDocumentId const& documentId,
-                                   velocypack::Slice const& slice,
-                                   OperationOptions& options) {
+Result RocksDBPrimaryIndex::probeKey(transaction::Methods& trx, 
+                                     RocksDBMethods* mthd,
+                                     RocksDBKeyLeaser const& key,
+                                     arangodb::velocypack::Slice keySlice,
+                                     OperationOptions const& options, 
+                                     bool lock) {
   Index::OperationMode mode = options.indexOperationMode;
+  transaction::StringLeaser leased(&trx);
+  rocksdb::PinnableSlice ps(leased.get());
+  Result res;
+  rocksdb::Status s;
+  if (lock) {
+    s = mthd->GetForUpdate(_cf, key->string(), &ps);
+  } else {
+    s = mthd->Get(_cf, key->string(), &ps);
+  }
+
+  if (s.ok()) {  // detected conflicting primary key
+    if (mode == Index::OperationMode::internal) {
+    // in this error mode, we return the conflicting document's key
+    // inside the error message string (and nothing else)!
+      return res.reset(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED, keySlice.copyString());
+    }
+    // build a proper error message
+    res.reset(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED);
+    return addErrorMsg(res, keySlice.copyString());
+  } else if (!s.IsNotFound()) {
+    // IsBusy(), IsTimedOut() etc... this indicates a conflict
+    return addErrorMsg(res.reset(rocksutils::convertStatus(s)));
+  }
+
+  ps.Reset();  // clear used memory
+
+  return res;
+}
+
+Result RocksDBPrimaryIndex::checkInsert(transaction::Methods& trx, 
+                                        RocksDBMethods* mthd,
+                                        LocalDocumentId const& documentId,
+                                        velocypack::Slice slice,
+                                        OperationOptions const& options) {
   VPackSlice keySlice;
   TRI_voc_rid_t revision;
   transaction::helpers::extractKeyAndRevFromDocument(slice, keySlice, revision);
 
   TRI_ASSERT(keySlice.isString());
+
   RocksDBKeyLeaser key(&trx);
   key->constructPrimaryIndexValue(objectId(), arangodb::velocypack::StringRef(keySlice));
 
-  transaction::StringLeaser leased(&trx);
-  rocksdb::PinnableSlice ps(leased.get());
+  return probeKey(trx, mthd, key, keySlice, options, /*lock*/ false);
+}
+
+Result RocksDBPrimaryIndex::insert(transaction::Methods& trx, RocksDBMethods* mthd,
+                                   LocalDocumentId const& documentId,
+                                   velocypack::Slice const& slice,
+                                   OperationOptions& options) {
+  VPackSlice keySlice;
+  TRI_voc_rid_t revision;
+  transaction::helpers::extractKeyAndRevFromDocument(slice, keySlice, revision);
+  TRI_ASSERT(keySlice.isString());
+  
+  RocksDBKeyLeaser key(&trx);
+  key->constructPrimaryIndexValue(objectId(), arangodb::velocypack::StringRef(keySlice));
+
   Result res;
+
   if (!options.ignoreUniqueConstraints) {
-    rocksdb::Status s = mthd->GetForUpdate(_cf, key->string(), &ps);
-
-    if (s.ok()) {  // detected conflicting primary key
-      if (mode == OperationMode::internal) {
-        return res.reset(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED, keySlice.copyString());
-      }
-      res.reset(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED);
-      return addErrorMsg(res, keySlice.copyString());
-    } else if (!s.IsNotFound()) {
-      // IsBusy(), IsTimedOut() etc... this indicates a conflict
-      return addErrorMsg(res.reset(rocksutils::convertStatus(s)));
+    res = probeKey(trx, mthd, key, keySlice, options, /*lock*/ true);
+    
+    if (res.fail()) {
+      return res;
     }
-
-    ps.Reset();  // clear used memory
   }
 
   if (trx.state()->hasHint(transaction::Hints::Hint::GLOBAL_MANAGED)) {

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.h
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.h
@@ -36,6 +36,7 @@
 #include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
+class RocksDBKeyLeaser;
 
 namespace transaction {
 class Methods;
@@ -107,6 +108,12 @@ class RocksDBPrimaryIndex final : public RocksDBIndex {
   arangodb::aql::AstNode* specializeCondition(arangodb::aql::AstNode* node,
                                               arangodb::aql::Variable const* reference) const override;
 
+  /// @brief returns whether the document can be inserted into the primary index
+  /// (or if there will be a conflict)
+  Result checkInsert(transaction::Methods& trx, RocksDBMethods* methods,
+                     LocalDocumentId const& documentId, velocypack::Slice doc,
+                     OperationOptions const& options) override;
+
   /// insert index elements into the specified write batch.
   Result insert(transaction::Methods& trx, RocksDBMethods* methods,
                 LocalDocumentId const& documentId, velocypack::Slice const& doc,
@@ -123,6 +130,15 @@ class RocksDBPrimaryIndex final : public RocksDBIndex {
                 velocypack::Slice const& newDoc, Index::OperationMode mode) override;
 
  private:
+  /// @brief test if the specified key (keySlice) already exists.
+  /// if it exists and the key exists, lock it for updates!
+  Result probeKey(transaction::Methods& trx, 
+                  RocksDBMethods* mthd,
+                  RocksDBKeyLeaser const& key,
+                  arangodb::velocypack::Slice keySlice,
+                  OperationOptions const& options, 
+                  bool lock);
+
   /// @brief create the iterator, for a single attribute, IN operator
   std::unique_ptr<IndexIterator> createInIterator(transaction::Methods*, arangodb::aql::AstNode const*,
                                                   arangodb::aql::AstNode const*, bool ascending);

--- a/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
@@ -38,6 +38,7 @@
 #include "Replication/utilities.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RocksDBEngine/RocksDBCollection.h"
+#include "RocksDBEngine/RocksDBColumnFamily.h"
 #include "RocksDBEngine/RocksDBCommon.h"
 #include "RocksDBEngine/RocksDBMetaCollection.h"
 #include "RocksDBEngine/RocksDBMethods.h"

--- a/arangod/RocksDBEngine/RocksDBSavePoint.cpp
+++ b/arangod/RocksDBEngine/RocksDBSavePoint.cpp
@@ -1,0 +1,104 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Simon Grätzer
+////////////////////////////////////////////////////////////////////////////////
+
+#include "RocksDBSavePoint.h"
+#include "Logger/LogMacros.h"
+#include "Logger/Logger.h"
+#include "Logger/LoggerStream.h"
+#include "RocksDBEngine/RocksDBCommon.h"
+#include "RocksDBEngine/RocksDBMethods.h"
+#include "RocksDBEngine/RocksDBTransactionState.h"
+#include "Transaction/Methods.h"
+
+namespace arangodb {
+
+RocksDBSavePoint::RocksDBSavePoint(transaction::Methods* trx,
+                                   TRI_voc_document_operation_e operationType)
+    : _trx(trx),
+      _operationType(operationType),
+      _handled(_trx->isSingleOperationTransaction()) {
+  TRI_ASSERT(trx != nullptr);
+  if (!_handled) {
+    auto mthds = RocksDBTransactionState::toMethods(_trx);
+    // only create a savepoint when necessary
+    mthds->SetSavePoint();
+  }
+}
+
+RocksDBSavePoint::~RocksDBSavePoint() {
+  if (!_handled) {
+    try {
+      // only roll back if we create a savepoint and have
+      // not performed an intermediate commit in-between
+      rollback();
+    } catch (std::exception const& ex) {
+      LOG_TOPIC("519ed", ERR, Logger::ENGINES)
+          << "caught exception during rollback to savepoint: " << ex.what();
+    } catch (...) {
+      // whatever happens during rollback, no exceptions are allowed to escape
+      // from here
+    }
+  }
+}
+
+void RocksDBSavePoint::cancel() {
+  // unconditionally cancel the savepoint
+  if (!_handled) {
+    auto mthds = RocksDBTransactionState::toMethods(_trx);
+    mthds->PopSavePoint();
+  
+    // this will prevent the rollback call in the destructor
+    _handled = true;
+  }
+}
+
+void RocksDBSavePoint::finish(bool hasPerformedIntermediateCommit) {
+  if (!_handled && !hasPerformedIntermediateCommit) {
+    // pop the savepoint from the transaction in order to
+    // save some memory for transactions with many operations
+    // this is only safe to do when we have a created a savepoint
+    // when creating the guard, and when there hasn't been an
+    // intermediate commit in the transaction
+    // when there has been an intermediate commit, we must
+    // leave the savepoint alone, because it belonged to another
+    // transaction, and the current transaction will not have any
+    // savepoint
+    auto mthds = RocksDBTransactionState::toMethods(_trx);
+    mthds->PopSavePoint();
+  }
+
+  // this will prevent the rollback call in the destructor
+  _handled = true;
+}
+
+void RocksDBSavePoint::rollback() {
+  TRI_ASSERT(!_handled);
+  auto mthds = RocksDBTransactionState::toMethods(_trx);
+  mthds->RollbackToSavePoint();
+
+  auto state = RocksDBTransactionState::toState(_trx);
+  state->rollbackOperation(_operationType);
+
+  _handled = true;  // in order to not roll back again by accident
+}
+
+} // namespace

--- a/arangod/RocksDBEngine/RocksDBSavePoint.h
+++ b/arangod/RocksDBEngine/RocksDBSavePoint.h
@@ -1,0 +1,58 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Simon Grätzer
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef ARANGOD_ROCKSDB_ROCKSDB_SAVEPOINT_H
+#define ARANGOD_ROCKSDB_ROCKSDB_SAVEPOINT_H 1
+
+#include "VocBase/voc-types.h"
+
+namespace arangodb {
+namespace transaction {
+class Methods;
+}
+
+class RocksDBSavePoint {
+ public:
+  RocksDBSavePoint(transaction::Methods* trx, TRI_voc_document_operation_e operationType);
+  ~RocksDBSavePoint();
+  
+  /// @brief unconditionally cancel the savepoint
+  void cancel();
+
+  /// @brief acknowledges the current savepoint, so there
+  /// will be no rollback when the destructor is called
+  /// if an intermediate commit was performed, pass a value of
+  /// true, false otherwise
+  void finish(bool hasPerformedIntermediateCommit);
+
+ private:
+  void rollback();
+
+ private:
+  transaction::Methods* _trx;
+  TRI_voc_document_operation_e const _operationType;
+  bool _handled;
+};
+
+}  // namespace arangodb
+
+#endif

--- a/arangod/RocksDBEngine/RocksDBTransactionState.h
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.h
@@ -229,8 +229,11 @@ class RocksDBKeyLeaser {
   ~RocksDBKeyLeaser();
   inline RocksDBKey* builder() { return &_key; }
   inline RocksDBKey* operator->() { return &_key; }
+  inline RocksDBKey const* operator->() const { return &_key; }
   inline RocksDBKey* get() { return &_key; }
+  inline RocksDBKey const* get() const { return &_key; }
   inline RocksDBKey& ref() { return _key; }
+  inline RocksDBKey const& ref() const { return _key; }
 
  private:
   transaction::Context* _ctx;

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -820,7 +820,7 @@ Result RocksDBVPackIndex::insert(transaction::Methods& trx, RocksDBMethods* mthd
     transaction::StringLeaser leased(&trx);
     rocksdb::PinnableSlice existing(leased.get());
     for (RocksDBKey& key : elements) {
-      if (!options.ignoreUniqueConstraints) {
+      if (!options.checkUniqueConstraintsInPreflight) {
         s = mthds->GetForUpdate(_cf, key.string(), &existing);
         if (s.ok()) {  // detected conflicting index entry
           res.reset(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED);

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.h
@@ -134,6 +134,18 @@ class RocksDBVPackIndex : public RocksDBIndex {
                 velocypack::Slice const& newDoc, Index::OperationMode mode) override;
 
  private:
+  /// @brief returns whether the document can be inserted into the index
+  /// (or if there will be a conflict)
+  Result checkInsert(transaction::Methods& trx, RocksDBMethods* methods,
+                     LocalDocumentId const& documentId, velocypack::Slice doc,
+                     OperationOptions const& options) override;
+  
+  /// @brief returns whether the document can be updated/replaced in the index
+  /// (or if there will be a conflict)
+  Result checkReplace(transaction::Methods& trx, RocksDBMethods* methods,
+                      LocalDocumentId const& documentId, velocypack::Slice doc,
+                      OperationOptions const& options) override;
+
   /// @brief return the number of paths
   inline size_t numPaths() const { return _paths.size(); }
 

--- a/arangod/Utils/OperationOptions.h
+++ b/arangod/Utils/OperationOptions.h
@@ -59,7 +59,7 @@ struct OperationOptions {
         returnOld(false),
         returnNew(false),
         isRestore(false),
-        ignoreUniqueConstraints(false),
+        checkUniqueConstraintsInPreflight(false),
         truncateCompact(true) {}
 
 // The following code does not work with VisualStudi 2019's `cl`
@@ -137,7 +137,7 @@ struct OperationOptions {
 
   // for replication; only set true if you an guarantee that any conflicts have
   // already been removed, and are simply not reflected in the transaction read
-  bool ignoreUniqueConstraints;
+  bool checkUniqueConstraintsInPreflight;
 
   // when truncating - should we also run the compaction?
   // defaults to true.

--- a/tests/js/server/replication/sync/replication-sync-malarkey.js
+++ b/tests/js/server/replication/sync/replication-sync-malarkey.js
@@ -1,0 +1,905 @@
+/* jshint globalstrict:false, strict:false, unused: false */
+/* global arango, assertEqual, assertTrue, ARGUMENTS, fail */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief test the sync method of the replication
+// /
+// / Copyright 2014-2021 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2010-2012 triagens GmbH, Cologne, Germany
+// /
+// / DISCLAIMER
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// / @author Copyright 2013, triAGENS GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require('jsunity');
+const arangodb = require('@arangodb');
+const reconnectRetry = require('@arangodb/replication-common').reconnectRetry;
+const db = arangodb.db;
+const replication = require('@arangodb/replication');
+const leaderEndpoint = arango.getEndpoint();
+const followerEndpoint = ARGUMENTS[ARGUMENTS.length - 1];
+const errors = require("internal").errors;
+const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
+
+const cn = 'UnitTestsReplication';
+
+const connectToLeader = function () {
+  reconnectRetry(leaderEndpoint, db._name(), 'root', '');
+  db._flushCache();
+};
+
+const connectToFollower = function () {
+  reconnectRetry(followerEndpoint, db._name(), 'root', '');
+  db._flushCache();
+};
+  
+const setFailurePoint = function(which) {
+  let res = arango.PUT("/_admin/debug/failat/" + encodeURIComponent(which), {});
+  if (res !== true) {
+    throw "unable to set failure point '" + which + "'";
+  }
+};
+
+const clearFailurePoints = function() {
+  arango.DELETE("/_admin/debug/failat");
+};
+
+function BaseTestConfig () {
+  'use strict';
+  
+  let checkCountConsistency = function(cn, expected) {
+    let check = function() {
+      db._flushCache();
+      let c = db[cn];
+      let figures = c.figures(true).engine;
+
+      assertEqual(expected, c.count());
+      assertEqual(expected, c.toArray().length);
+      assertEqual(expected, figures.documents);
+      figures.indexes.forEach((idx) => {
+        assertEqual(expected, idx.count);
+      });
+    };
+
+    connectToFollower();
+    check();
+    connectToLeader();
+    check();
+  };
+  
+  let runRandomOps = function(cn, n) {
+    let state = {};
+    let c = db[cn];
+    for (let i = 0; i < n; ++i) {
+      let key = "testmann" + Math.floor(Math.random() * 10);
+      if (state.hasOwnProperty(key)) {
+        if (Math.random() >= 0.666) {
+          // remove
+          c.remove(key, { silent: true });
+          delete state[key];
+        } else {
+          c.replace(key, { value: ++state[key] }, { silent: true });
+        }
+      } else {
+        state[key] = Math.floor(Math.random() * 10000);
+        c.insert({ _key: key, value: state[key] }, { silent: true });
+      }
+    };
+
+    return state;
+  };
+
+  let runRandomOpsTransaction = function(cn, n) {
+    return db._executeTransaction({
+      collections: { write: cn },
+      action: function(params) {
+        let db = require("@arangodb").db;
+        let state = {};
+        let c = db[params.cn];
+        for (let i = 0; i < params.n; ++i) {
+          let key = "testmann" + Math.floor(Math.random() * 10);
+          if (state.hasOwnProperty(key)) {
+            if (Math.random() >= 0.666) {
+              // remove
+              c.remove(key, { silent: true });
+              delete state[key];
+            } else {
+              c.replace(key, { value: ++state[key] }, { silent: true });
+            }
+          } else {
+            state[key] = Math.floor(Math.random() * 10000);
+            c.insert({ _key: key, value: state[key] }, { silent: true });
+          }
+        };
+
+        return state;
+      },
+      params: { cn, n }
+    });
+  };
+
+  return {
+
+    tearDown: function () {
+      connectToFollower();
+      // clear all failure points
+      clearFailurePoints();
+      db._drop(cn);
+
+      connectToLeader();
+      // clear all failure points
+      clearFailurePoints();
+      db._drop(cn);
+    },
+
+    // create different state on follower
+    testDowngradeManyRevisions: function () {
+      let c = db._create(cn);
+      let docs = [];
+      for (let i = 0; i < 1 * 100 * 1000; ++i) {
+        docs.push({ value: i });
+        if (docs.length === 10000) {
+          c.insert(docs, { silent: true });
+          docs = [];
+        }
+      }
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true
+      });
+      db._flushCache();
+      c = db._collection(cn);
+     
+      db._query("FOR doc IN " + cn + " REPLACE doc WITH { value: doc.value + 1 } IN " + cn);
+      
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      c = db._collection(cn);
+
+      checkCountConsistency(cn, 100000);
+    },
+    
+    // create different state on follower
+    testRewriteEntireFollowerSecondaryUniqueIndexes: function () {
+      let c = db._create(cn);
+      let docs = [];
+      for (let i = 0; i < 100000; ++i) {
+        docs.push({ value: i });
+        if (docs.length === 10000) {
+          c.insert(docs, { silent: true });
+          docs = [];
+        }
+      }
+
+      c.ensureIndex({ type: "hash", fields: ["value"], unique: true });
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true
+      });
+      db._flushCache();
+      c = db._collection(cn);
+     
+      db._query("FOR doc IN " + cn + " REPLACE doc WITH { value: doc.value + 1000000 } IN " + cn);
+      
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      c = db._collection(cn);
+
+      checkCountConsistency(cn, 100000);
+    },
+    
+    testUniqueConstraints: function () {
+      let c = db._create(cn);
+      c.ensureIndex({type: "hash", unique: true, fields: ["x"]});
+      c.ensureIndex({type: "hash", unique: true, fields: ["y"]});
+      c.ensureIndex({type: "hash", unique: true, fields: ["z"]});
+
+      let docs = [];
+      for (let i = 0; i < 1 * 100000; ++i) {
+        docs.push({ _key: "K" + i, value: i, x: i, y: i, z: i });
+        if (docs.length === 10000) {
+          c.insert(docs, { silent: true });
+          docs = [];
+        }
+      }
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true
+      });
+      db._flushCache();
+      c = db._collection(cn);
+     
+      db._query("FOR doc IN " + cn + " SORT doc.value REPLACE doc WITH { value: doc.value - 1, x: doc.x + 1000000, y: doc.y + 1000000, z: doc.z + 1000000} IN " + cn);
+      
+      docs = [];
+      for (let i = 0; i < 1 * 100 * 1000; ++i) {
+        docs.push({ _key: "L" + i, value: i, x: i, y: i, z: i });
+        if (docs.length === 10000) {
+          c.insert(docs, { silent: true });
+          docs = [];
+        }
+      }
+
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      c = db._collection(cn);
+
+      checkCountConsistency(cn, 100000);
+
+      // Now check that the unique index entries are all in place by
+      // provoking violations:
+      docs = [];
+      for (let i = 0; i < 100000; ++i) {
+        docs.push({ _key: "N", x: i });
+        if (docs.length === 10000) {
+          let res = c.insert(docs);
+          assertEqual(10000, res.length);
+          res.forEach((r) => {
+            assertTrue(r.error);
+            assertEqual(errors.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code,
+                        r.errorNum);
+          });
+          docs = [];
+        }
+      }
+      for (let i = 0; i < 100000; ++i) {
+        docs.push({ _key: "N", y: i });
+        if (docs.length === 10000) {
+          let res = c.insert(docs);
+          assertEqual(10000, res.length);
+          res.forEach((r) => {
+            assertTrue(r.error);
+            assertEqual(errors.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code,
+                        r.errorNum);
+          });
+          docs = [];
+        }
+      }
+      for (let i = 0; i < 100000; ++i) {
+        docs.push({ _key: "N", z: i });
+        if (docs.length === 10000) {
+          let res = c.insert(docs);
+          assertEqual(10000, res.length);
+          res.forEach((r) => {
+            assertTrue(r.error);
+            assertEqual(errors.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code,
+                        r.errorNum);
+          });
+          docs = [];
+        }
+      }
+      // And use the index entries in a query:
+      assertEqual(100000, db._query(
+        `RETURN COUNT(FOR i IN 0..99999
+           FOR doc IN ${cn}
+             FILTER doc.x == i 
+             RETURN 1)`).toArray()[0]);
+      assertEqual(100000, db._query(
+        `RETURN COUNT(FOR i IN 0..99999
+           FOR doc IN ${cn}
+             FILTER doc.y == i 
+             RETURN 1)`).toArray()[0]);
+      assertEqual(100000, db._query(
+        `RETURN COUNT(FOR i IN 0..99999
+           FOR doc IN ${cn} 
+             FILTER doc.z == i 
+             RETURN 1)`).toArray()[0]);
+    },
+    
+    testManyUniqueConstraints: function () {
+      let c = db._create(cn);
+      c.ensureIndex({type: "hash", unique: true, fields: ["x"]});
+      c.ensureIndex({type: "hash", unique: true, fields: ["y"]});
+      c.ensureIndex({type: "hash", unique: true, fields: ["z"]});
+
+      let docs = [];
+      for (let i = 0; i < 100000; ++i) {
+        docs.push({ _key: "K" + i, value: i, x: i, y: i, z: i });
+        if (docs.length === 10000) {
+          c.insert(docs, { silent: true });
+          docs = [];
+        }
+      }
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true
+      });
+      db._flushCache();
+      c = db._collection(cn);
+     
+      db._query("FOR doc IN " + cn + " SORT doc.value REPLACE doc WITH { value: doc.value - 1, x: doc.x - 1, y: doc.y - 2, z: doc.z - 3 } IN " + cn);
+      
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      c = db._collection(cn);
+
+      checkCountConsistency(cn, 100000);
+
+      // Now check that the unique index entries are all in place by
+      // provoking violations:
+      docs = [];
+      for (let i = 0; i < 100000; ++i) {
+        docs.push({ _key: "N", x: i });
+        if (docs.length === 10000) {
+          let res = c.insert(docs);
+          assertEqual(10000, res.length);
+          res.forEach((r) => {
+            assertTrue(r.error);
+            assertEqual(errors.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code,
+                        r.errorNum);
+          });
+          docs = [];
+        }
+      }
+
+      for (let i = 0; i < 100000; ++i) {
+        docs.push({ _key: "N", y: i });
+        if (docs.length === 10000) {
+          let res = c.insert(docs);
+          assertEqual(10000, res.length);
+          res.forEach((r) => {
+            assertTrue(r.error);
+            assertEqual(errors.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code,
+                        r.errorNum);
+          });
+          docs = [];
+        }
+      }
+      
+      for (let i = 0; i < 100000; ++i) {
+        docs.push({ _key: "N", z: i });
+        if (docs.length === 10000) {
+          let res = c.insert(docs);
+          assertEqual(10000, res.length);
+          res.forEach((r) => {
+            assertTrue(r.error);
+            assertEqual(errors.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code,
+                        r.errorNum);
+          });
+          docs = [];
+        }
+      }
+
+      // And use the index entries in a query:
+      assertEqual(100000, db._query(
+        `RETURN COUNT(FOR i IN 0..99999
+           FOR doc IN ${cn} 
+             FILTER doc.x == i 
+             RETURN 1)`).toArray()[0]);
+      assertEqual(100000, db._query(
+        `RETURN COUNT(FOR i IN 0..99999
+           FOR doc IN ${cn} 
+             FILTER doc.y == i 
+             RETURN 1)`).toArray()[0]);
+      assertEqual(100000, db._query(
+        `RETURN COUNT(FOR i IN 0..99999
+           FOR doc IN ${cn} 
+             FILTER doc.z == i 
+             RETURN 1)`).toArray()[0]);
+    },
+    
+    // create different state on follower for the same key
+    testDifferentKeyStateOnFollower: function () {
+      let c = db._create(cn);
+      let rev = c.insert({_key: "testi", value: 1 })._rev;
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true
+      });
+      db._flushCache();
+      c = db._collection(cn);
+     
+      // document on follower must be 100% identical
+      assertEqual(1, c.document("testi").value);
+      assertEqual(rev, c.document("testi")._rev);
+
+      c.remove("testi");
+      c.insert({_key: "testi", value: 2 });
+
+      connectToLeader();
+      db._flushCache();
+      c = db._collection(cn);
+      c.remove("testi");
+      rev = c.insert({ _key: "testi", value: 3 })._rev;
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      c = db._collection(cn);
+      assertEqual(3, c.document("testi").value);
+      assertEqual(rev, c.document("testi")._rev);
+
+      checkCountConsistency(cn, 1);
+    },
+    
+    // create different state on follower for the same key, using replace
+    testDifferentKeyStateOnFollowerUsingReplace: function () {
+      let c = db._create(cn);
+      let rev = c.insert({_key: "testi", value: 1 })._rev;
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true
+      });
+      db._flushCache();
+      c = db._collection(cn);
+     
+      assertEqual(1, c.document("testi").value);
+      assertEqual(rev, c.document("testi")._rev);
+
+      c.replace("testi", {_key: "testi", value: 2 });
+
+      connectToLeader();
+      db._flushCache();
+      c = db._collection(cn);
+      rev = c.replace("testi", { _key: "testi", value: 3 })._rev;
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      c = db._collection(cn);
+      assertEqual(3, c.document("testi").value);
+      assertEqual(rev, c.document("testi")._rev);
+      
+      checkCountConsistency(cn, 1);
+    },
+      
+    // create large AQL operation on leader using AQL
+    testCreateLargeAQLOnLeader: function () {
+      let c = db._create(cn);
+      let rev = c.insert({_key: "testi", value: 1 })._rev;
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true
+      });
+      db._flushCache();
+      c = db._collection(cn);
+      
+      assertEqual(1, c.document("testi").value);
+      assertEqual(rev, c.document("testi")._rev);
+      
+      c.replace("testi", {_key: "testi", value: 2 });
+
+      connectToLeader();
+      db._flushCache();
+      c = db._collection(cn);
+
+      setFailurePoint("TransactionState::intermediateCommitCount1000");
+      db._query("FOR i IN 1..10000 INSERT { _key: CONCAT('testmann', i) } INTO " + cn);
+      
+      rev = c.replace("testi", { _key: "testi", value: 3 })._rev;
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      c = db._collection(cn);
+      assertEqual(3, c.document("testi").value);
+      assertEqual(rev, c.document("testi")._rev);
+
+      checkCountConsistency(cn, 10001);
+    },
+    
+    // create large AQL operation on follower using AQL
+    testCreateLargeAQLOnFollower: function () {
+      let c = db._create(cn);
+      let rev = c.insert({_key: "testi", value: 1 })._rev;
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true
+      });
+      db._flushCache();
+      c = db._collection(cn);
+      
+      assertEqual(1, c.document("testi").value);
+      assertEqual(rev, c.document("testi")._rev);
+      
+      c.replace("testi", {_key: "testi", value: 2 });
+      
+      setFailurePoint("TransactionState::intermediateCommitCount1000");
+      db._query("FOR i IN 1..10000 INSERT { _key: CONCAT('testmann', i) } INTO " + cn);
+
+      connectToLeader();
+      db._flushCache();
+      c = db._collection(cn);
+
+      rev = c.replace("testi", { _key: "testi", value: 3 })._rev;
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      c = db._collection(cn);
+      assertEqual(3, c.document("testi").value);
+      assertEqual(rev, c.document("testi")._rev);
+
+      checkCountConsistency(cn, 1);
+    },
+    
+    // create random operations on leader, with many
+    // operations affected the same keys
+    testCreateRandomOperationsOnLeader: function () {
+      let c = db._create(cn);
+      c.insert({_key: "testi", value: 1 });
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true
+      });
+      db._flushCache();
+      c = db._collection(cn);
+      
+      assertEqual(1, c.document("testi").value);
+      
+      c.replace("testi", {_key: "testi", value: 2 });
+
+      connectToLeader();
+      db._flushCache();
+      c = db._collection(cn);
+
+      let state = runRandomOps(cn, 50000);
+      
+      c.replace("testi", { _key: "testi", value: 3 });
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      c = db._collection(cn);
+      assertEqual(3, c.document("testi").value);
+
+      let expected = 1;
+      for (let s in state) {
+        ++expected;
+        assertEqual(state[s], c.document(s).value);
+      }
+      
+      checkCountConsistency(cn, expected);
+    },
+    
+    // create a transaction with random operations on leader, with many
+    // operations affected the same keys
+    testCreateRandomOperationsTransactionOnLeader: function () {
+      let c = db._create(cn);
+      c.insert({_key: "testi", value: 1 });
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true
+      });
+      db._flushCache();
+      c = db._collection(cn);
+      
+      assertEqual(1, c.document("testi").value);
+      
+      c.replace("testi", {_key: "testi", value: 2 });
+
+      connectToLeader();
+      db._flushCache();
+      c = db._collection(cn);
+
+      let state = runRandomOpsTransaction(cn, 50000);
+      
+      c.replace("testi", { _key: "testi", value: 3 });
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      c = db._collection(cn);
+      assertEqual(3, c.document("testi").value);
+
+      let expected = 1;
+      for (let s in state) {
+        ++expected;
+        assertEqual(state[s], c.document(s).value);
+      }
+      
+      checkCountConsistency(cn, expected);
+    },
+    
+    // create random operations on follower, with many
+    // operations affected the same keys
+    testCreateRandomOperationsOnFollower: function () {
+      let c = db._create(cn);
+      c.insert({_key: "testi", value: 1 });
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true
+      });
+      db._flushCache();
+      c = db._collection(cn);
+      
+      assertEqual(1, c.document("testi").value);
+      
+      c.replace("testi", {_key: "testi", value: 2 });
+      
+      runRandomOps(cn, 50000);
+
+      connectToLeader();
+      db._flushCache();
+      c = db._collection(cn);
+
+      c.replace("testi", { _key: "testi", value: 3 });
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      c = db._collection(cn);
+      assertEqual(3, c.document("testi").value);
+
+      checkCountConsistency(cn, 1);
+    },
+    
+    // create a transaction with random operations on follower, with many
+    // operations affected the same keys
+    testCreateRandomOperationsTransactionOnFollower: function () {
+      let c = db._create(cn);
+      c.insert({_key: "testi", value: 1 });
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true
+      });
+      db._flushCache();
+      c = db._collection(cn);
+      
+      assertEqual(1, c.document("testi").value);
+      
+      c.replace("testi", {_key: "testi", value: 2 });
+      
+      runRandomOpsTransaction(cn, 50000);
+
+      connectToLeader();
+      db._flushCache();
+      c = db._collection(cn);
+
+      c.replace("testi", { _key: "testi", value: 3 });
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      c = db._collection(cn);
+      assertEqual(3, c.document("testi").value);
+
+      checkCountConsistency(cn, 1);
+    },
+    
+    // create random operations on leader and follower, with many
+    // operations affected the same keys
+    testCreateRandomOperationsOnLeaderAndFollower: function () {
+      let c = db._create(cn);
+      c.insert({_key: "testi", value: 1 });
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true
+      });
+      db._flushCache();
+      c = db._collection(cn);
+      
+      assertEqual(1, c.document("testi").value);
+      
+      c.replace("testi", {_key: "testi", value: 2 });
+      
+      runRandomOps(cn, 50000);
+
+      connectToLeader();
+      db._flushCache();
+      c = db._collection(cn);
+
+      let state = runRandomOps(cn, 50000);
+      
+      c.replace("testi", { _key: "testi", value: 3 });
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      c = db._collection(cn);
+      assertEqual(3, c.document("testi").value);
+
+      let expected = 1;
+      for (let s in state) {
+        ++expected;
+        assertEqual(state[s], c.document(s).value);
+      }
+      
+      checkCountConsistency(cn, expected);
+    },
+    
+    // create a transaction with random operations on leader and follower, with many
+    // operations affected the same keys
+    testCreateRandomOperationsTransactionOnLeaderAndFollower: function () {
+      let c = db._create(cn);
+      c.insert({_key: "testi", value: 1 });
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true
+      });
+      db._flushCache();
+      c = db._collection(cn);
+      
+      assertEqual(1, c.document("testi").value);
+      
+      c.replace("testi", {_key: "testi", value: 2 });
+      
+      runRandomOpsTransaction(cn, 50000);
+
+      connectToLeader();
+      db._flushCache();
+      c = db._collection(cn);
+
+      let state = runRandomOpsTransaction(cn, 50000);
+      
+      c.replace("testi", { _key: "testi", value: 3 });
+
+      connectToFollower();
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      c = db._collection(cn);
+      assertEqual(3, c.document("testi").value);
+
+      let expected = 1;
+      for (let s in state) {
+        ++expected;
+        assertEqual(state[s], c.document(s).value);
+      }
+      
+      checkCountConsistency(cn, expected);
+    }, 
+  };
+}
+
+function ReplicationIncrementalMalarkey() {
+  'use strict';
+
+  let suite = {
+    setUp: function () {
+      connectToFollower();
+      clearFailurePoints();
+
+      connectToLeader();
+      clearFailurePoints();
+    },
+  };
+
+  deriveTestSuite(BaseTestConfig(), suite, '_Default');
+  return suite;
+}
+
+function ReplicationIncrementalMalarkeyIntermediateCommits() {
+  'use strict';
+
+  let suite = {
+    setUp: function () {
+      connectToFollower();
+      // clear all failure points
+      clearFailurePoints();
+      setFailurePoint("TransactionState::intermediateCommitCount10000");
+      db._drop(cn);
+
+      connectToLeader();
+      // clear all failure points
+      clearFailurePoints();
+      setFailurePoint("TransactionState::intermediateCommitCount10000");
+      db._drop(cn);
+    },
+  };
+
+  deriveTestSuite(BaseTestConfig(), suite, '_IntermediateCommit');
+  return suite;
+}
+
+let res = arango.GET("/_admin/debug/failat");
+if (res === true) {
+  // tests only work when compiled with -DUSE_FAILURE_TESTS
+  jsunity.run(ReplicationIncrementalMalarkey);
+  jsunity.run(ReplicationIncrementalMalarkeyIntermediateCommits);
+}
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Partial backport of https://github.com/arangodb/arangodb/pull/13507

Improve incremental sync replication for single server and cluster to cope with multiple secondary index unique constraint violations (before this was limited to a failure in a single unique secondary index). this allows replicating the leader state to the follower in basically any order, as any *other* conflicting documents in unique secondary indexes will be detected and removed on the follower.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *replication_sync*.
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in replication_sync)

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13916/