### PR TITLE
Bug fix/fix tls reload result

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fix error reporting in the reloadTLS route
+
 * Fix potential undefined behavior when iterating over connected nodes in an
   execution plan and calling callbacks for each of the nodes: if the callbacks
   modified the list of connected nodes of the current that they were called

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 devel
 -----
 
-* Fix error reporting in the reloadTLS route
+* Fix error reporting in the reloadTLS route.
 
 * Fix potential undefined behavior when iterating over connected nodes in an
   execution plan and calling callbacks for each of the nodes: if the callbacks

--- a/arangod/GeneralServer/GeneralServerFeature.cpp
+++ b/arangod/GeneralServer/GeneralServerFeature.cpp
@@ -295,7 +295,7 @@ Result GeneralServerFeature::reloadTLS() {  // reload TLS data from disk
   Result res;
   for (auto& up : _servers) {
     Result res2 = up->reloadTLS();
-    if (!res2.fail()) {
+    if (res2.fail()) {
       res = res2;  // yes, we only report the last error if there is one
     }
   }


### PR DESCRIPTION
### Scope & Purpose
The TLS reload route doesn't pass up own error messages. 

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x]  Backports required - https://github.com/arangodb/arangodb/pull/13531

#### Related Information

- [x] GitHub issue https://github.com/arangodb/arangodb/issues/13525

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

Link to Jenkins PR run:

http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/13928/