### PR TITLE
fix reloading of TLS certificates error reporting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.7.8 (XXXX-XX-XX)
 -------------------
 
+* Fix error reporting in the reloadTLS route
+
 * Split the update operations for the _fishbowl system collection with Foxx apps
   into separate insert/replace and remove operations. This makes the overall
   update not atomic, but as removes are unlikely here, we can now get away with

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.7.8 (XXXX-XX-XX)
 -------------------
 
-* Fix error reporting in the reloadTLS route
+* Fix error reporting in the reloadTLS route.
 
 * Split the update operations for the _fishbowl system collection with Foxx apps
   into separate insert/replace and remove operations. This makes the overall

--- a/arangod/GeneralServer/GeneralServerFeature.h
+++ b/arangod/GeneralServer/GeneralServerFeature.h
@@ -97,7 +97,7 @@ class GeneralServerFeature final : public application_features::ApplicationFeatu
     Result res;
     for (auto& up : _servers) {
       Result res2 = up->reloadTLS();
-      if (!res2.fail()) {
+      if (res2.fail()) {
         res = res2;   // yes, we only report the last error if there is one
       }
     }


### PR DESCRIPTION
backport of https://github.com/arangodb/arangodb/pull/13529
http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/13933/  