### PR TITLE
Improvements for dropping indexes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+v3.7.8 (XXXX-XX-XX)
+-------------------
+
+* Split the update operations for the _fishbowl system collection with Foxx apps
+  into separate insert/replace and remove operations. This makes the overall
+  update not atomic, but as removes are unlikely here, we can now get away with
+  a simple multi-document insert-replace operation instead of a truncate and an
+  exclusive transaction, which was used before.
+
+
 v3.7.7 (2020-02-05)
 -------------------
 
@@ -6,28 +16,28 @@ v3.7.7 (2020-02-05)
   - `arangodb_document_writes: Total number of document write operations
     (successful and failed) not performed by synchronous replication.
   - `arangodb_document_writes_replication`: Total number of document write
-    operations (successful and failed) by synchronous replication.
+    operations (successful and failed) by cluster synchronous replication.
   - `arangodb_collection_truncates`: Total number of collection truncate
-    operations (successful and failed) not performed by synchronous replication.
+    operations (successful and failed) not performed by cluster synchronous
+    replication.
   - `arangodb_collection_truncates_replication`: Total number of collection
-    truncate
-    operations (successful and failed) by synchronous replication.
-  - `arangodb_document_read_time`: Execution time histogram of all document read
-    operations (successful and failed) [s].
+    truncate operations (successful and failed) by synchronous replication.
+  - `arangodb_document_read_time`: Execution time histogram of all document
+    primary key read operations (successful and failed) [s]. Note: this does not
+    include secondary index lookups, range scans and full collection scans.
   - `arangodb_document_insert_time`: Execution time histogram of all document
-    insert
-    operations (successful and failed) [s].
+    insert operations (successful and failed) [s].
   - `arangodb_document_replace_time`: Execution time histogram of all document
-    replace
-    operations (successful and failed) [s].
+    replace operations (successful and failed) [s].
   - `arangodb_document_remove_time`: Execution time histogram of all document
-    remove
-    operations (successful and failed) [s].
+    remove operations (successful and failed) [s].
   - `arangodb_document_update_time`: Execution time histogram of all document
-    update
-    operations (successful and failed) [s].
+    update operations (successful and failed) [s].
   - `arangodb_collection_truncate_time`: Execution time histogram of all
     collection truncate operations (successful and failed) [s].
+
+  The timer metrics are turned off by default, and can be enabled by setting the
+  startup option `--server.export-read-write-metrics true`.
 
 * Fixed issue #12543: Unused Foxx service config can not be discarded.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,27 @@
 v3.7.8 (XXXX-XX-XX)
 -------------------
 
+* Avoid a potential deadlock when dropping indexes.
+
+  A deadlock could theoretically happen for a thread that is attempting to 
+  drop an index in case there was another thread that tried to create or drop 
+  an index in the very same collection at the very same time. We haven't
+  maanged to trigger the deadlock with concurrency tests, so it may have been
+  a theoretical issue only. The underlying code was changed anyway to make
+  sure this will not cause problems in reality.
+
+* Make dropping of indexes in cluster retry in case of precondition failed.
+
+  When dropping an indexes of a collection in the cluster, the operation could
+  fail with a "precondition failed" error in case there were simultaneous
+  index creation or drop actions running for the same collection. The error
+  was returned properly internally, but got lost at the point when 
+  `<collection>.dropIndex()` simply converted any error to just `false`.
+  We can't make `dropIndex()` throw an exception for any error, because that
+  would affect downwards-compatibility. But in case there is a simultaneous
+  change to the collection indexes, we can just retry our own operation and
+  check if it succeeds then. This is what `dropIndex()` will do now.
+
 * Split the update operations for the _fishbowl system collection with Foxx apps
   into separate insert/replace and remove operations. This makes the overall
   update not atomic, but as removes are unlikely here, we can now get away with

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -4199,7 +4199,7 @@ Result ClusterInfo::dropIndexCoordinator(
 
   Result res(TRI_ERROR_CLUSTER_TIMEOUT);
   do {
-    Result res = dropIndexCoordinatorInner(databaseName, collectionID, iid, endTime);
+    res = dropIndexCoordinatorInner(databaseName, collectionID, iid, endTime);
 
     if (res.ok()) {
       // success!

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -778,7 +778,7 @@ public:
       IndexId iid,                      // index identifier
       double timeout                    // request timeout
   );
-
+  
   //////////////////////////////////////////////////////////////////////////////
   /// @brief (re-)load the information about servers from the agency
   /// Usually one does not have to call this directly.
@@ -991,6 +991,12 @@ public:
   application_features::ApplicationServer& server() const;
 
  private:
+  /// @brief worker function for dropIndexCoordinator
+  Result dropIndexCoordinatorInner(
+      std::string const& databaseName, 
+      std::string const& collectionID,
+      IndexId iid,                   
+      double endTime);
 
   /// @brief helper function to build a new LogicalCollection object from the velocypack
   /// input

--- a/arangod/StorageEngine/PhysicalCollection.cpp
+++ b/arangod/StorageEngine/PhysicalCollection.cpp
@@ -26,6 +26,7 @@
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/Exceptions.h"
 #include "Basics/ReadLocker.h"
+#include "Basics/RecursiveLocker.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/WriteLocker.h"
@@ -75,7 +76,7 @@ void PhysicalCollection::flushClusterIndexEstimates() {
 
 void PhysicalCollection::drop() {
   {
-    WRITE_LOCKER(guard, _indexesLock);
+    RECURSIVE_WRITE_LOCKER(_indexesLock, _indexesLockWriteOwner);
     _indexes.clear();
   }
   try {
@@ -107,7 +108,7 @@ bool PhysicalCollection::isValidEdgeAttribute(VPackSlice const& slice) const {
 }
 
 bool PhysicalCollection::hasIndexOfType(arangodb::Index::IndexType type) const {
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   for (auto const& idx : _indexes) {
     if (idx->type() == type) {
       return true;
@@ -151,12 +152,12 @@ bool PhysicalCollection::hasIndexOfType(arangodb::Index::IndexType type) const {
 
 /// @brief Find index by definition
 std::shared_ptr<Index> PhysicalCollection::lookupIndex(VPackSlice const& info) const {
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   return findIndex(info, _indexes);
 }
 
 std::shared_ptr<Index> PhysicalCollection::lookupIndex(IndexId idxId) const {
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   for (auto const& idx : _indexes) {
     if (idx->id() == idxId) {
       return idx;
@@ -166,7 +167,7 @@ std::shared_ptr<Index> PhysicalCollection::lookupIndex(IndexId idxId) const {
 }
 
 std::shared_ptr<Index> PhysicalCollection::lookupIndex(std::string const& idxName) const {
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   for (auto const& idx : _indexes) {
     if (idx->name() == idxName) {
       return idx;
@@ -574,13 +575,13 @@ int PhysicalCollection::checkRevision(transaction::Methods*, TRI_voc_rid_t expec
 
 /// @brief hands out a list of indexes
 std::vector<std::shared_ptr<Index>> PhysicalCollection::getIndexes() const {
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   return { _indexes.begin(), _indexes.end() };
 }
 
 void PhysicalCollection::getIndexesVPack(VPackBuilder& result,
                                          std::function<bool(Index const*, std::underlying_type<Index::Serialize>::type&)> const& filter) const {
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   result.openArray();
   for (std::shared_ptr<Index> const& idx : _indexes) {
     std::underlying_type<Index::Serialize>::type flags = Index::makeFlags();
@@ -607,7 +608,7 @@ futures::Future<OperationResult> PhysicalCollection::figures(bool details) {
 
   {
     bool seenEdgeIndex = false;
-    READ_LOCKER(guard, _indexesLock);
+    RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
     for (auto const& idx : _indexes) {
       // only count an edge index instance
       if (idx->type() != Index::TRI_IDX_TYPE_EDGE_INDEX || !seenEdgeIndex) {

--- a/arangod/StorageEngine/PhysicalCollection.h
+++ b/arangod/StorageEngine/PhysicalCollection.h
@@ -24,7 +24,9 @@
 #ifndef ARANGOD_VOCBASE_PHYSICAL_COLLECTION_H
 #define ARANGOD_VOCBASE_PHYSICAL_COLLECTION_H 1
 
+#include <atomic>
 #include <set>
+#include <thread>
 
 #include <velocypack/Builder.h>
 
@@ -108,7 +110,7 @@ class PhysicalCollection {
                               const std::shared_ptr<Index>& right) const;
   };
 
-  using IndexContainerType = std::set<std::shared_ptr<Index>, IndexOrder> ;
+  using IndexContainerType = std::set<std::shared_ptr<Index>, IndexOrder>;
   /// @brief find index by definition
   static std::shared_ptr<Index> findIndex(velocypack::Slice const&,
                                           IndexContainerType const&);
@@ -261,6 +263,7 @@ class PhysicalCollection {
   bool const _isDBServer;
 
   mutable basics::ReadWriteLock _indexesLock;
+  mutable std::atomic<std::thread::id> _indexesLockWriteOwner;  // current thread owning '_indexesLock'
   IndexContainerType _indexes;
 };
 

--- a/arangod/VocBase/Methods/Indexes.cpp
+++ b/arangod/VocBase/Methods/Indexes.cpp
@@ -668,8 +668,6 @@ arangodb::Result Indexes::drop(LogicalCollection* collection, VPackSlice const& 
         collection->vocbase().name(), std::to_string(collection->id()), iid, 0.0  // args
     );
 #endif
-    events::DropIndex(collection->vocbase().name(), collection->name(),
-                      std::to_string(iid.id()), res.errorNumber());
     return res;
   } else {
     READ_LOCKER(readLocker, collection->vocbase()._inventoryLock);

--- a/tests/js/server/shell/shell-index-parallel-drop-create.js
+++ b/tests/js/server/shell/shell-index-parallel-drop-create.js
@@ -1,0 +1,127 @@
+/*jshint globalstrict:false, strict:false */
+/*global fail, assertEqual, assertTrue */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test parallel index drop/create
+///
+/// DISCLAIMER
+///
+/// Copyright 2018-2019 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const internal = require("internal");
+const errors = internal.errors;
+const db = internal.db;
+
+function ParallelIndexCreateDropSuite() {
+  'use strict';
+  const cn = "UnitTestsCollectionIdx";
+  const tasks = require("@arangodb/tasks");
+  const tasksCompleted = () => {
+    return 0 === tasks.get().filter((task) => {
+      return (task.id.match(/^UnitTest/) || task.name.match(/^UnitTest/));
+    }).length;
+  };
+  const waitForTasks = () => {
+    const time = internal.time;
+    const start = time();
+    while (!tasksCompleted()) {
+      if (time() - start > 300) { // wait for 5 minutes maximum
+        fail("Timeout after 5 minutes");
+      }
+      internal.sleep(0.5);
+    }
+  };
+      
+  const threads = 6;
+  const attrs = 5;
+
+  return {
+
+    setUpAll : function () {
+      db._drop(cn);
+      let c = db._create(cn);
+
+      // fill with some initial data
+      let docs = [];
+      for (let i = 0; i < threads; ++i) {
+        // only populate some of the attributes, to have more variance in 
+        // index creation/drop speed
+        for (let j = i; j < attrs; ++j) {
+          docs.push({ ["thread-" + i - "-attribute-" + j] : i * j });
+        }
+      }
+      c.insert(docs);
+    },
+
+    tearDownAll : function () {
+      tasks.get().forEach(function(task) {
+        if (task.id.match(/^UnitTest/) || task.name.match(/^UnitTest/)) {
+          try {
+            tasks.unregister(task);
+          } catch (err) {
+          }
+        }
+      });
+      db._drop(cn);
+    },
+    
+    testCreateDropInParallel: function () {
+      let c = require("internal").db._collection(cn);
+      // lets insert the rest via tasks
+      for (let i = 0; i < threads; ++i) {
+        let command = `
+let db = require("internal").db;
+let c = db._collection("${cn}");
+for (let iteration = 0; iteration < 15; ++iteration) {
+  require("console").log("thread ${i}, iteration " + iteration);
+  let indexes = [];
+  for (let i = 0; i < ${attrs}; ++i) {
+    indexes.push(c.ensureIndex({ type: "persistent", sparse: ${i} % 2 == 0, fields: ["thread-${i}-attribute-" + i] }));
+  }
+  indexes.forEach(function(index) {
+    c.dropIndex(index);
+  });
+}
+c.insert({ _key: "done${i}", value: true });
+`;
+        tasks.register({ name: "UnitTestsIndexCreateDrop" + i, command: command });
+      }
+
+      // wait for insertion tasks to complete
+      waitForTasks();
+      
+      // check that all indexes except primary are gone
+      assertEqual(1, c.indexes().length);
+      let count = threads;
+      for (let i = 0; i < threads; ++i) {
+        count += attrs <= i ? 0 : attrs - i;
+      }
+      assertEqual(count, c.count());
+      for (let i = 0; i < threads; ++i) {
+        assertTrue(c.document("done" + i).value);
+      }
+    },
+  };
+}
+
+jsunity.run(ParallelIndexCreateDropSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

* Avoid a potential deadlock when dropping indexes.

  A deadlock could theoretically happen for a thread that is attempting to drop an index in case there was another thread that tried to create or drop an index in the very same collection at the very same time. We haven't managed to trigger the deadlock with concurrency tests, so it may have been a theoretical issue only. The underlying code was changed anyway to make sure this will not cause problems in reality.

* Make dropping of indexes in cluster retry in case of precondition failed.

  When dropping an indexes of a collection in the cluster, the operation could fail with a "precondition failed" error in case there were simultaneous index creation or drop actions running for the same collection. The error was returned properly internally, but got lost at the point when `<collection>.dropIndex()` simply converted any error to just `false`. We can't make `dropIndex()` throw an exception for any error, because that would affect downwards-compatibility. But in case there is a simultaneous change to the collection indexes, we can just retry our own operation and check if it succeeds then. This is what `dropIndex()` will do now.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.6*: https://github.com/arangodb/arangodb/pull/13533

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_server)

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13938/