### PR TITLE
Improvements for dropping indexes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,27 @@
 v3.6.12 (XXXX-XX-XX)
 --------------------
 
+* Avoid a potential deadlock when dropping indexes.
+
+  A deadlock could theoretically happen for a thread that is attempting to 
+  drop an index in case there was another thread that tried to create or drop 
+  an index in the very same collection at the very same time. We haven't
+  maanged to trigger the deadlock with concurrency tests, so it may have been
+  a theoretical issue only. The underlying code was changed anyway to make
+  sure this will not cause problems in reality.
+
+* Make dropping of indexes in cluster retry in case of precondition failed.
+
+  When dropping an indexes of a collection in the cluster, the operation could
+  fail with a "precondition failed" error in case there were simultaneous
+  index creation or drop actions running for the same collection. The error
+  was returned properly internally, but got lost at the point when 
+  `<collection>.dropIndex()` simply converted any error to just `false`.
+  We can't make `dropIndex()` throw an exception for any error, because that
+  would affect downwards-compatibility. But in case there is a simultaneous
+  change to the collection indexes, we can just retry our own operation and
+  check if it succeeds then. This is what `dropIndex()` will do now.
+
 * Fixed some wrong behaviour in single document updates. If the option
   ignoreRevs=false was given and the precondition _rev was given in the body but
   the _key was given in the URL path, then the rev was wrongly taken as 0,

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -3449,7 +3449,7 @@ Result ClusterInfo::dropIndexCoordinator(
 
   Result res(TRI_ERROR_CLUSTER_TIMEOUT);
   do {
-    Result res = dropIndexCoordinatorInner(databaseName, collectionID, iid, endTime);
+    res = dropIndexCoordinatorInner(databaseName, collectionID, iid, endTime);
 
     if (res.ok()) {
       // success!

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -851,6 +851,13 @@ class ClusterInfo final {
   application_features::ApplicationServer& server() const;
 
  private:
+  /// @brief worker function for dropIndexCoordinator
+  Result dropIndexCoordinatorInner(
+      std::string const& databaseName, 
+      std::string const& collectionID,
+      TRI_idx_iid_t iid,                   
+      double endTime);
+
   void buildIsBuildingSlice(CreateDatabaseInfo const& database,
                               VPackBuilder& builder);
 

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -23,6 +23,7 @@
 #include "RocksDBCollection.h"
 
 #include "Aql/PlanCache.h"
+#include "Basics/RecursiveLocker.h"
 #include "Basics/Result.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/StringUtils.h"
@@ -141,7 +142,7 @@ void RocksDBCollection::getPropertiesVPack(velocypack::Builder& result) const {
 
 /// @brief closes an open collection
 int RocksDBCollection::close() {
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   for (auto it : _indexes) {
     it->unload();
   }
@@ -158,7 +159,7 @@ void RocksDBCollection::load() {
       }
     }
   }
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   for (auto it : _indexes) {
     it->load();
   }
@@ -170,7 +171,7 @@ void RocksDBCollection::unload() {
     destroyCache();
     TRI_ASSERT(_cache.get() == nullptr);
   }
-  READ_LOCKER(indexGuard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   for (auto it : _indexes) {
     it->unload();
   }
@@ -187,7 +188,8 @@ void RocksDBCollection::prepareIndexes(arangodb::velocypack::Slice indexesSlice)
   StorageEngine* engine = EngineSelectorFeature::ENGINE;
   std::vector<std::shared_ptr<Index>> indexes;
   {
-    READ_LOCKER(guard, _indexesLock);  // link creation needs read-lock too
+    RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
+    // link creation needs read-lock too
     if (indexesSlice.length() == 0 && _indexes.empty()) {
       engine->indexFactory().fillSystemIndexes(_logicalCollection, indexes);
     } else {
@@ -195,7 +197,7 @@ void RocksDBCollection::prepareIndexes(arangodb::velocypack::Slice indexesSlice)
     }
   }
 
-  WRITE_LOCKER(guard, _indexesLock);
+  RECURSIVE_WRITE_LOCKER(_indexesLock, _indexesLockWriteOwner);
   TRI_ASSERT(_indexes.empty());
   for (std::shared_ptr<Index>& idx : indexes) {
     TRI_ASSERT(idx != nullptr);
@@ -267,7 +269,7 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice const& info,
 
   std::shared_ptr<Index> idx;
   {  // Step 1. Check for matching index
-    READ_LOCKER(guard, _indexesLock);
+    RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
     if ((idx = findIndex(info, _indexes)) != nullptr) {
       // We already have this index.
       if (idx->type() == arangodb::Index::TRI_IDX_TYPE_TTL_INDEX) {
@@ -305,7 +307,7 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice const& info,
   TRI_ASSERT(idx->type() != Index::IndexType::TRI_IDX_TYPE_EDGE_INDEX);
 
   {
-    READ_LOCKER(guard, _indexesLock);
+    RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
     for (auto const& other : _indexes) {  // conflicting index exists
       if (other->id() == idx->id() || other->name() == idx->name()) {
         // definition shares an identifier with an existing index with a
@@ -370,7 +372,7 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice const& info,
         basics::VelocyPackHelper::getBooleanValue(info, StaticStrings::IndexInBackground, false);
     if (inBackground) {  // allow concurrent inserts into index
       {
-        WRITE_LOCKER(guard, _indexesLock);
+        RECURSIVE_WRITE_LOCKER(_indexesLock, _indexesLockWriteOwner);
         _indexes.emplace(buildIdx);
       }
       res = buildIdx->fillIndexBackground(locker);
@@ -383,19 +385,20 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice const& info,
     locker.lock(); // always lock to avoid inconsistencies
 
     // Step 5. register in index list
-    WRITE_LOCKER(guard, _indexesLock);
-    if (inBackground) {  // swap in actual index
-      for (auto& it : _indexes) {
-        if (it->id() == buildIdx->id()) {
-          _indexes.erase(it);
-          _indexes.emplace(idx);
-          break;
+    {
+      RECURSIVE_WRITE_LOCKER(_indexesLock, _indexesLockWriteOwner);
+      if (inBackground) {  // swap in actual index
+        for (auto& it : _indexes) {
+          if (it->id() == buildIdx->id()) {
+            _indexes.erase(it);
+            _indexes.emplace(idx);
+            break;
+          }
         }
+      } else {
+        _indexes.emplace(idx);
       }
-    } else {
-      _indexes.emplace(idx);
     }
-    guard.unlock();
 #if USE_PLAN_CACHE
     arangodb::aql::PlanCache::instance()->invalidate(_logicalCollection.vocbase());
 #endif
@@ -421,16 +424,17 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice const& info,
 
   // cleanup routine
   if (res.fail()) { // We could not create the index. Better abort
-    WRITE_LOCKER(guard, _indexesLock);
-    auto it = _indexes.begin();
-    while (it != _indexes.end()) {
-      if ((*it)->id() == idx->id()) {
-        _indexes.erase(it);
-        break;
+    {
+      RECURSIVE_WRITE_LOCKER(_indexesLock, _indexesLockWriteOwner);
+      auto it = _indexes.begin();
+      while (it != _indexes.end()) {
+        if ((*it)->id() == idx->id()) {
+          _indexes.erase(it);
+          break;
+        }
+        it++;
       }
-      it++;
     }
-    guard.unlock();
     idx->drop();
     THROW_ARANGO_EXCEPTION(res);
   }
@@ -449,7 +453,7 @@ bool RocksDBCollection::dropIndex(TRI_idx_iid_t iid) {
 
   std::shared_ptr<arangodb::Index> toRemove;
   {
-    WRITE_LOCKER(guard, _indexesLock);
+    RECURSIVE_WRITE_LOCKER(_indexesLock, _indexesLockWriteOwner);
     for (auto& it : _indexes) {
       if (iid == it->id()) {
         toRemove = it;
@@ -466,7 +470,7 @@ bool RocksDBCollection::dropIndex(TRI_idx_iid_t iid) {
     return false;
   }
 
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
 
   RocksDBIndex* cindex = static_cast<RocksDBIndex*>(toRemove.get());
   TRI_ASSERT(cindex != nullptr);
@@ -560,7 +564,7 @@ Result RocksDBCollection::truncate(transaction::Methods& trx, OperationOptions& 
     
     // delete indexes, place estimator blockers
     {
-      READ_LOCKER(idxGuard, _indexesLock);
+      RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
       for (std::shared_ptr<Index> const& idx : _indexes) {
         RocksDBIndex* ridx = static_cast<RocksDBIndex*>(idx.get());
         bounds = ridx->getBounds();
@@ -596,7 +600,7 @@ Result RocksDBCollection::truncate(transaction::Methods& trx, OperationOptions& 
                                 -static_cast<int64_t>(numDocs));
     
     {
-      READ_LOCKER(guard, _indexesLock);
+      RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
       for (std::shared_ptr<Index> const& idx : _indexes) {
         idx->afterTruncate(seq, &trx);  // clears caches / clears links (if applicable)
       }
@@ -1198,7 +1202,7 @@ void RocksDBCollection::figuresSpecific(bool details, arangodb::velocypack::Buil
     builder.add("documents", VPackValue(rocksutils::countKeyRange(db, RocksDBKeyBounds::CollectionDocuments(_objectId), true)));
     builder.add("indexes", VPackValue(VPackValueType::Array));
     {
-      READ_LOCKER(guard, _indexesLock);
+      RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
       for (auto it : _indexes) {
         auto type = it->type();
         if (type == Index::TRI_IDX_TYPE_UNKNOWN ||
@@ -1302,7 +1306,7 @@ Result RocksDBCollection::insertDocument(arangodb::transaction::Methods* trx,
     return res.reset(rocksutils::convertStatus(s, rocksutils::document));
   }
 
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   
   bool needReversal = false;
   for (auto it = _indexes.begin(); it != _indexes.end(); it++) {

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -24,6 +24,7 @@
 #include "RocksDBMetaCollection.h"
 
 #include "Basics/ReadLocker.h"
+#include "Basics/RecursiveLocker.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/WriteLocker.h"
 #include "Basics/system-functions.h"
@@ -274,7 +275,7 @@ uint64_t RocksDBMetaCollection::recalculateCounts() {
   auto bounds = RocksDBKeyBounds::Empty();
   bool set = false;
   {
-    READ_LOCKER(guard, _indexesLock);
+    RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
     for (auto it : _indexes) {
       if (it->type() == Index::TRI_IDX_TYPE_PRIMARY_INDEX) {
         RocksDBIndex const* rix = static_cast<RocksDBIndex const*>(it.get());
@@ -339,7 +340,7 @@ Result RocksDBMetaCollection::compact() {
   rocksdb::Slice b = bounds.start(), e = bounds.end();
   db->CompactRange(opts, bounds.columnFamily(), &b, &e);
   
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   for (std::shared_ptr<Index> i : _indexes) {
     RocksDBIndex* index = static_cast<RocksDBIndex*>(i.get());
     index->compact();
@@ -365,7 +366,7 @@ void RocksDBMetaCollection::estimateSize(velocypack::Builder& builder) {
   builder.add("documents", VPackValue(out));
   builder.add("indexes", VPackValue(VPackValueType::Object));
   
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   for (std::shared_ptr<Index> i : _indexes) {
     RocksDBIndex* index = static_cast<RocksDBIndex*>(i.get());
     out = index->memory();

--- a/arangod/StorageEngine/PhysicalCollection.h
+++ b/arangod/StorageEngine/PhysicalCollection.h
@@ -24,7 +24,9 @@
 #ifndef ARANGOD_VOCBASE_PHYSICAL_COLLECTION_H
 #define ARANGOD_VOCBASE_PHYSICAL_COLLECTION_H 1
 
+#include <atomic>
 #include <set>
+#include <thread>
 
 #include <velocypack/Builder.h>
 
@@ -254,6 +256,7 @@ class PhysicalCollection {
   bool const _isDBServer;
 
   mutable basics::ReadWriteLock _indexesLock;
+  mutable std::atomic<std::thread::id> _indexesLockWriteOwner;  // current thread owning '_indexesLock'
   IndexContainerType _indexes;
 };
 

--- a/arangod/VocBase/Methods/Indexes.cpp
+++ b/arangod/VocBase/Methods/Indexes.cpp
@@ -669,8 +669,6 @@ arangodb::Result Indexes::drop(LogicalCollection* collection, VPackSlice const& 
         collection->vocbase().name(), std::to_string(collection->id()), iid, 0.0  // args
     );
 #endif
-    events::DropIndex(collection->vocbase().name(), collection->name(),
-                      std::to_string(iid), res.errorNumber());
     return res;
   } else {
     READ_LOCKER(readLocker, collection->vocbase()._inventoryLock);

--- a/tests/js/server/shell/shell-index-parallel-drop-create-rocksdb.js
+++ b/tests/js/server/shell/shell-index-parallel-drop-create-rocksdb.js
@@ -1,0 +1,127 @@
+/*jshint globalstrict:false, strict:false */
+/*global fail, assertEqual, assertTrue */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test parallel index drop/create
+///
+/// DISCLAIMER
+///
+/// Copyright 2018-2019 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const internal = require("internal");
+const errors = internal.errors;
+const db = internal.db;
+
+function ParallelIndexCreateDropSuite() {
+  'use strict';
+  const cn = "UnitTestsCollectionIdx";
+  const tasks = require("@arangodb/tasks");
+  const tasksCompleted = () => {
+    return 0 === tasks.get().filter((task) => {
+      return (task.id.match(/^UnitTest/) || task.name.match(/^UnitTest/));
+    }).length;
+  };
+  const waitForTasks = () => {
+    const time = internal.time;
+    const start = time();
+    while (!tasksCompleted()) {
+      if (time() - start > 300) { // wait for 5 minutes maximum
+        fail("Timeout after 5 minutes");
+      }
+      internal.sleep(0.5);
+    }
+  };
+      
+  const threads = 6;
+  const attrs = 5;
+
+  return {
+
+    setUpAll : function () {
+      db._drop(cn);
+      let c = db._create(cn);
+
+      // fill with some initial data
+      let docs = [];
+      for (let i = 0; i < threads; ++i) {
+        // only populate some of the attributes, to have more variance in 
+        // index creation/drop speed
+        for (let j = i; j < attrs; ++j) {
+          docs.push({ ["thread-" + i - "-attribute-" + j] : i * j });
+        }
+      }
+      c.insert(docs);
+    },
+
+    tearDownAll : function () {
+      tasks.get().forEach(function(task) {
+        if (task.id.match(/^UnitTest/) || task.name.match(/^UnitTest/)) {
+          try {
+            tasks.unregister(task);
+          } catch (err) {
+          }
+        }
+      });
+      db._drop(cn);
+    },
+    
+    testCreateDropInParallel: function () {
+      let c = require("internal").db._collection(cn);
+      // lets insert the rest via tasks
+      for (let i = 0; i < threads; ++i) {
+        let command = `
+let db = require("internal").db;
+let c = db._collection("${cn}");
+for (let iteration = 0; iteration < 15; ++iteration) {
+  require("console").log("thread ${i}, iteration " + iteration);
+  let indexes = [];
+  for (let i = 0; i < ${attrs}; ++i) {
+    indexes.push(c.ensureIndex({ type: "persistent", sparse: ${i} % 2 == 0, fields: ["thread-${i}-attribute-" + i] }));
+  }
+  indexes.forEach(function(index) {
+    c.dropIndex(index);
+  });
+}
+c.insert({ _key: "done${i}", value: true });
+`;
+        tasks.register({ name: "UnitTestsIndexCreateDrop" + i, command: command });
+      }
+
+      // wait for insertion tasks to complete
+      waitForTasks();
+      
+      // check that all indexes except primary are gone
+      assertEqual(1, c.indexes().length);
+      let count = threads;
+      for (let i = 0; i < threads; ++i) {
+        count += attrs <= i ? 0 : attrs - i;
+      }
+      assertEqual(count, c.count());
+      for (let i = 0; i < threads; ++i) {
+        assertTrue(c.document("done" + i).value);
+      }
+    },
+  };
+}
+
+jsunity.run(ParallelIndexCreateDropSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/13532/

* Avoid a potential deadlock when dropping indexes.

  A deadlock could theoretically happen for a thread that is attempting to drop an index in case there was another thread that tried to create or drop an index in the very same collection at the very same time. We haven't managed to trigger the deadlock with concurrency tests, so it may have been a theoretical issue only. The underlying code was changed anyway to make sure this will not cause problems in reality.

* Make dropping of indexes in cluster retry in case of precondition failed.

  When dropping an indexes of a collection in the cluster, the operation could fail with a "precondition failed" error in case there were simultaneous index creation or drop actions running for the same collection. The error was returned properly internally, but got lost at the point when `<collection>.dropIndex()` simply converted any error to just `false`. We can't make `dropIndex()` throw an exception for any error, because that would affect downwards-compatibility. But in case there is a simultaneous change to the collection indexes, we can just retry our own operation and check if it succeeds then. This is what `dropIndex()` will do now.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_server)

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13942/