### PR TITLE
rename an internal flag

### DIFF
--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -154,7 +154,7 @@ arangodb::Result fetchRevisions(arangodb::transaction::Methods& trx,
   options.isRestore = true;
   options.validate = false; // no validation during replication
   options.indexOperationMode = arangodb::IndexOperationMode::internal;
-  options.ignoreUniqueConstraints = true;
+  options.checkUniqueConstraintsInPreflight = true;
   options.waitForSync = false; // no waitForSync during replication
   if (!state.leaderId.empty()) {
     options.isSynchronousReplicationFrom = state.leaderId;

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -1522,7 +1522,7 @@ Result RocksDBCollection::insertDocument(arangodb::transaction::Methods* trx,
   RocksDBTransactionState* state = RocksDBTransactionState::toState(trx);
   RocksDBMethods* mthds = state->rocksdbMethods();
 
-  if (options.ignoreUniqueConstraints) {
+  if (options.checkUniqueConstraintsInPreflight) {
     // we can only afford the separation of checking and inserting in a
     // transaction that disallows concurrency, i.e. we need to have the
     // exclusive lock on the collection.
@@ -1673,7 +1673,7 @@ Result RocksDBCollection::updateDocument(transaction::Methods* trx,
   RocksDBTransactionState* state = RocksDBTransactionState::toState(trx);
   RocksDBMethods* mthds = state->rocksdbMethods();
 
-  if (options.ignoreUniqueConstraints) {
+  if (options.checkUniqueConstraintsInPreflight) {
     // we can only afford the separation of checking and inserting in a
     // transaction that disallows concurrency, i.e. we need to have the
     // exclusive lock on the collection.

--- a/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
+++ b/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
@@ -184,7 +184,7 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
   options.indexOperationMode = IndexOperationMode::internal;
   options.waitForSync = false;
   options.validate = false;
-  options.ignoreUniqueConstraints = true;
+  options.checkUniqueConstraintsInPreflight = true;
 
   if (!syncer._state.leaderId.empty()) {
     options.isSynchronousReplicationFrom = syncer._state.leaderId;

--- a/arangod/RocksDBEngine/RocksDBMethods.h
+++ b/arangod/RocksDBEngine/RocksDBMethods.h
@@ -24,7 +24,6 @@
 #ifndef ARANGOD_ROCKSDB_ROCKSDB_METHODS_H
 #define ARANGOD_ROCKSDB_ROCKSDB_METHODS_H 1
 
-#include "Basics/Result.h"
 #include "RocksDBEngine/RocksDBCommon.h"
 
 namespace rocksdb {
@@ -38,10 +37,6 @@ struct ReadOptions;
 }  // namespace rocksdb
 
 namespace arangodb {
-namespace transaction {
-class Methods;
-}
-
 class RocksDBKey;
 class RocksDBMethods;
 class RocksDBTransactionState;

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
@@ -646,7 +646,7 @@ Result RocksDBPrimaryIndex::insert(transaction::Methods& trx,
   
   Result res;
 
-  if (!options.ignoreUniqueConstraints) {
+  if (!options.checkUniqueConstraintsInPreflight) {
     res = probeKey(trx, mthd, key, keySlice, options, /*lock*/ true);
 
     if (res.fail()) {

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -831,7 +831,7 @@ Result RocksDBVPackIndex::insert(transaction::Methods& trx, RocksDBMethods* mthd
     transaction::StringLeaser leased(&trx);
     rocksdb::PinnableSlice existing(leased.get());
     for (RocksDBKey const& key : elements) {
-      if (!options.ignoreUniqueConstraints) {
+      if (!options.checkUniqueConstraintsInPreflight) {
         s = mthds->GetForUpdate(_cf, key.string(), &existing);
         if (s.ok()) {  // detected conflicting index entry
           res.reset(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED);

--- a/arangod/Utils/OperationOptions.cpp
+++ b/arangod/Utils/OperationOptions.cpp
@@ -40,7 +40,7 @@ OperationOptions::OperationOptions()
   returnOld(false),
   returnNew(false),
   isRestore(false),
-  ignoreUniqueConstraints(false),
+  checkUniqueConstraintsInPreflight(false),
   truncateCompact(true),
   _context(nullptr) {}
 

--- a/arangod/Utils/OperationOptions.h
+++ b/arangod/Utils/OperationOptions.h
@@ -118,9 +118,14 @@ struct OperationOptions {
   // restored by replicated and arangorestore
   bool isRestore;
 
-  // for replication; only set true if you an guarantee that any conflicts have
-  // already been removed, and are simply not reflected in the transaction read
-  bool ignoreUniqueConstraints;
+  // for replication; only set true if case insert/replace should have a read-only
+  // preflight phase, in which it checks whether a document can actually be inserted
+  // before carrying out the actual insert/replace.
+  // separating the check phase from the actual insert/replace allows running the
+  // preflight check without modifying the transaction's underlying WriteBatch object,
+  // so in case a unique constraint violation is detected, it does not need to be
+  // rebuilt (this would be _very_ expensive).
+  bool checkUniqueConstraintsInPreflight;
 
   // when truncating - should we also run the compaction?
   // defaults to true.


### PR DESCRIPTION
### Scope & Purpose

Renames an internal boolean flag to a more appropriate name, and adds a code comment about its (updated) purpose.
This is an internal-only change, without user-visibile effects, so it is intentionally missing a CHANGELOG entry.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13945/