### PR TITLE
potential bugfix for disjoint smartgraph queries that refer to collections on other servers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,30 @@
 v3.7.8 (XXXX-XX-XX)
 -------------------
 
+* EE only bugfix: On DisjointSmartGraphs that are used in anonymous way,
+  there was a chance that the query could fail, if non-disjoint collections
+  were part of the query. Named DisjointSmartGraphs have been save to this bug.
+  Example:
+  DisjointSmartGraph (graph) on vertices -edges-> vertices
+  Query:
+
+  WITH vertices, unrelated
+  FOR out IN 1 OUTBOUND "v/1:1" edges
+    FOR u IN unrelated
+    RETURN [out, u]
+  
+  The "unrelated" collection was pulled into the DisjointSmartGraph, causing
+  the AQL setup to create erroneous state.
+  This is now fixed and the above query works.
+  This query:
+
+  WITH vertices, unrelated
+  FOR out IN 1 OUTBOUND "v/1:1" GRAPH "graph"
+    FOR u IN unrelated
+    RETURN [out, u]
+
+  was not effected by this bug.
+
 * Issue #13141: The `move-filters-into-enumerate` optimization, when applied to
   an EnumerateCollectionNode (i.e. full collection scan), did not do regular
   checks for the query being killed during the filtering of documents, resulting

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,7 +23,7 @@ v3.7.8 (XXXX-XX-XX)
     FOR u IN unrelated
     RETURN [out, u]
 
-  was not effected by this bug.
+  was not affected by this bug.
 
 * Issue #13141: The `move-filters-into-enumerate` optimization, when applied to
   an EnumerateCollectionNode (i.e. full collection scan), did not do regular

--- a/arangod/Aql/Collection.cpp
+++ b/arangod/Aql/Collection.cpp
@@ -129,7 +129,7 @@ size_t Collection::responsibleServers(std::unordered_set<std::string>& result) c
   return n;
 }
 
-std::string Collection::distributeShardsLike() const {
+std::string const& Collection::distributeShardsLike() const {
   return getCollection()->distributeShardsLike();
 }
 

--- a/arangod/Aql/Collection.h
+++ b/arangod/Aql/Collection.h
@@ -85,7 +85,7 @@ struct Collection {
   std::unordered_set<std::string> responsibleServers() const;
 
   /// @brief returns the "distributeShardsLike" attribute for the collection
-  std::string distributeShardsLike() const;
+  std::string const& distributeShardsLike() const;
 
   /// @brief fills the set with the responsible servers for the collection
   /// returns the number of responsible servers found for the collection

--- a/arangod/Aql/GraphNode.cpp
+++ b/arangod/Aql/GraphNode.cpp
@@ -509,9 +509,8 @@ std::string const& GraphNode::collectionToShardName(std::string const& collName)
 
   auto found = _collectionToShard.find(collName);
   if (found == _collectionToShard.end()) {
-    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "unable to find shard '" + collName + "' in query shard map");
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL_AQL, "unable to find shard '" + collName + "' in query shard map");
   }
-  TRI_ASSERT(found != _collectionToShard.cend());
   return found->second;
 }
 

--- a/arangod/Aql/GraphNode.cpp
+++ b/arangod/Aql/GraphNode.cpp
@@ -783,9 +783,11 @@ void GraphNode::addVertexCollection(Collections const& collections, std::string 
   }
 }
 
+#ifndef USE_ENTERPRISE
 void GraphNode::addVertexCollection(aql::Collection& collection) {
   _vertexColls.emplace_back(&collection);
 }
+#endif
 
 std::vector<aql::Collection const*> GraphNode::collections() const {
   std::unordered_set<aql::Collection const*> set;

--- a/arangod/Aql/QuerySnippet.cpp
+++ b/arangod/Aql/QuerySnippet.cpp
@@ -668,6 +668,16 @@ auto QuerySnippet::prepareFirstBranch(
           if (localGraphNode->isDisjoint()) {
             if (found->second == server) {
               myExp.emplace(shard);
+            } else {
+              // the target server does not have anything to do with the particular
+              // collection (e.g. because the collection's shards are all on other
+              // servers), but it may be asked for this collection, because vertex
+              // collections are registered _globally_ with the TraversalNode and
+              // not on a per-target server basis.
+              // so in order to serve later lookups for this collection, we insert
+              // an empty string into the collection->shard map.
+              // on lookup, we will react to this.
+              localGraphNode->addCollectionToShard(aqlCollection->name(), "");
             }
           } else {
             localGraphNode->addCollectionToShard(aqlCollection->name(), shard);
@@ -675,7 +685,7 @@ auto QuerySnippet::prepareFirstBranch(
 
           numShards++;
         }
-
+        
         if (myExp.size() > 0) {
           localGraphNode->addCollectionToShard(aqlCollection->name(), *myExp.begin());
           if (myExp.size() > 1) {

--- a/arangod/Sharding/ShardingInfo.cpp
+++ b/arangod/Sharding/ShardingInfo.cpp
@@ -342,7 +342,7 @@ void ShardingInfo::toVelocyPack(VPackBuilder& result, bool translateCids) const 
   _shardingStrategy->toVelocyPack(result);
 }
 
-std::string ShardingInfo::distributeShardsLike() const {
+std::string const& ShardingInfo::distributeShardsLike() const {
   return _distributeShardsLike;
 }
 

--- a/arangod/Sharding/ShardingInfo.h
+++ b/arangod/Sharding/ShardingInfo.h
@@ -57,7 +57,7 @@ class ShardingInfo {
   LogicalCollection* collection() const;
   void toVelocyPack(arangodb::velocypack::Builder& result, bool translateCids) const;
 
-  std::string distributeShardsLike() const;
+  std::string const& distributeShardsLike() const;
   void distributeShardsLike(std::string const& cid, ShardingInfo const* other);
 
   std::vector<std::string> const& avoidServers() const;

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -324,7 +324,7 @@ size_t LogicalCollection::writeConcern() const {
   return _sharding->writeConcern();
 }
 
-std::string LogicalCollection::distributeShardsLike() const {
+std::string const& LogicalCollection::distributeShardsLike() const {
   TRI_ASSERT(_sharding != nullptr);
   return _sharding->distributeShardsLike();
 }

--- a/arangod/VocBase/LogicalCollection.h
+++ b/arangod/VocBase/LogicalCollection.h
@@ -165,7 +165,7 @@ class LogicalCollection : public LogicalDataSource {
   size_t numberOfShards() const;
   size_t replicationFactor() const;
   size_t writeConcern() const;
-  std::string distributeShardsLike() const;
+  std::string const& distributeShardsLike() const;
   std::vector<std::string> const& avoidServers() const;
   bool isSatellite() const;
   bool usesDefaultShardKeys() const;


### PR DESCRIPTION
### Scope & Purpose

Potential bugfix/workaround for issues with disjoint smart graph queries that have a "WITH" declaration and that can refer to other collections/shards, on different servers.

Given a query such as
```
WITH a, c
FOR v, e IN 1 .. 1 ANY "a/11:82238118" b 
  FOR doc in c
    FILTER doc.color == e.color
    RETURN doc
```
and collections with the following setup:

* `a` is a disjoint smart vertex collection, with 3 shards, on 3 different servers
* `b` is a disjoint smart edge collection, with 3 shards, on 3 different servers
* `c` is an unrelated collection, with just 1 shard, on only one server

The problem here is that `a` and `b` are distributed in the same way, but `c` is not. Especially, on some servers that there will be no shards for `c`.

Now, when the query snippets are created, all extra vertex and edge collections will be enumerated and their shards will be added. Here, this is `c`. But on some servers there are no shards for `c`, so there will be no entry in the collection->shard map for it.

This PR inserts a placeholder for such collections which have no shard attached, and on lookup just ignores them. This seems to work in my quick tests, and prevents the coordinator from running into undefined behavior.
The PR also returns a proper error in case no shard is mapped for a collection, so that it is clear what happened and the coordinator can live on.

It is unclear to me if this is a proper way to address the problem, as my knowledge about the subject is only 5 minutes of code-reading and poking with [the one true debugger](https://news.ycombinator.com/item?id=25858969).

If this fix is considered ok, we will need to add tests for this particular case, and port the fix to devel, too.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [x] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [x] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13954/