### PR TITLE
try to raise file descriptors limit in local start scripts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Try to raise file descriptors limit in local start scripts (in `scripts/`
+  directory - used for development only).
+
 * Fix error reporting in the reloadTLS route.
 
 * Fix potential undefined behavior when iterating over connected nodes in an

--- a/scripts/startLeaderFollower.sh
+++ b/scripts/startLeaderFollower.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 params=("$@")
 
+ulimit -H -n 131072 || true
+ulimit -S -n 131072 || true
+
 rm -rf active
 if [ -d cluster-init ];then
   echo "== creating cluster directory from existing cluster-init directory"
@@ -141,6 +144,7 @@ for aid in `seq 0 $(( $NRAGENTS - 1 ))`; do
         --server.statistics false \
         --log.file active/$PORT.log \
         --log.level $LOG_LEVEL_AGENCY \
+        --server.descriptors-minimum 0 \
         $STORAGE_ENGINE \
         $AUTHENTICATION \
         $SSLKEYFILE \
@@ -170,6 +174,7 @@ start() {
         --javascript.module-directory $SRC_DIR/enterprise/js \
         --javascript.app-path active/apps$PORT \
         --log.level $LOG_LEVEL_CLUSTER \
+        --server.descriptors-minimum 0 \
         $STORAGE_ENGINE \
         $AUTHENTICATION \
         $SSLKEYFILE \

--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 params=("$@")
 
+ulimit -H -n 131072 || true
+ulimit -S -n 131072 || true
+
 rm -rf cluster
 if [ -d cluster-init ];then
   echo "== creating cluster directory from existing cluster-init directory"
@@ -154,6 +157,7 @@ for aid in `seq 0 $(( $NRAGENTS - 1 ))`; do
           --log.file cluster/$PORT.log \
           --log.force-direct false \
           --log.level $LOG_LEVEL_AGENCY \
+          --server.descriptors-minimum 0 \
           $STORAGE_ENGINE \
           $AUTHENTICATION \
           $SSLKEYFILE \
@@ -180,6 +184,7 @@ for aid in `seq 0 $(( $NRAGENTS - 1 ))`; do
         --log.file cluster/$PORT.log \
         --log.force-direct false \
         --log.level $LOG_LEVEL_AGENCY \
+        --server.descriptors-minimum 0 \
         $STORAGE_ENGINE \
         $AUTHENTICATION \
         $SSLKEYFILE \
@@ -236,6 +241,7 @@ start() {
           --javascript.app-path cluster/apps$PORT \
           --log.force-direct false \
           --log.level $LOG_LEVEL_CLUSTER \
+          --server.descriptors-minimum 0 \
           --javascript.allow-admin-execute true \
           $SYSTEM_REPLICATION_FACTOR \
           $STORAGE_ENGINE \
@@ -262,6 +268,7 @@ start() {
         --log.force-direct false \
         --log.thread true \
         --log.level $LOG_LEVEL_CLUSTER \
+        --server.descriptors-minimum 0 \
         --javascript.allow-admin-execute true \
         $SYSTEM_REPLICATION_FACTOR \
         $STORAGE_ENGINE \

--- a/scripts/startStandAloneAgency.sh
+++ b/scripts/startStandAloneAgency.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+ulimit -H -n 131072 || true
+ulimit -S -n 131072 || true
+
 function help() {
   echo "USAGE: scripts/startStandAloneAgency.sh [options]"
   echo ""
@@ -244,6 +247,7 @@ for aid in "${aaid[@]}"; do
     --log.force-direct false \
     $LOG_LEVEL \
     --log.use-microtime $USE_MICROTIME \
+    --server.descriptors-minimum 0 \
     --server.authentication false \
     --server.endpoint $TRANSPORT://[::]:$port \
     --server.statistics false \


### PR DESCRIPTION
### Scope & Purpose

Try to raise file descriptors limit in local start scripts.
The start scripts in `scripts/` (used for development, not production) now try to raise the file descriptors limit to 128K.
That is not guaranteed to work, so they also add the startup parameter `--server.descriptors-minimum 0` to also allow the startup even when only few file descriptors can be used.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13962/