### PR TITLE
Fix profiling of streaming AQL queries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,23 @@
 v3.7.8 (XXXX-XX-XX)
 -------------------
 
+* Fix profiling of AQL queries with the `silent` and `stream` options sets in
+  combination. Using the `silent` option makes a query execute, but discard all
+  its results instantly. This led to some confusion in streaming queries, which
+  can return the first query results once they are available, but don't 
+  necessarily execute the full query.
+  Now, `silent` correctly discards all results even in streaming queries, but
+  this has the effect that a streaming query will likely be executed completely
+  when the `silent` option is set. This is not the default however, and the
+  `silent` option is normally not set. There is no change for streaming queries
+  if the `silent` option is not set.
+
+  As a side-effect of this change, this makes profiling (i.e. using 
+  `db._profileQuery(...)` work for streaming queries as well. Previously, 
+  profiling a streaming query could have led to some internal errors, and even
+  query results being returned, even though profiling a query should not return 
+  any query results.
+
 * Issue #13141: The `move-filters-into-enumerate` optimization, when applied to
   an EnumerateCollectionNode (i.e. full collection scan), did not do regular
   checks for the query being killed during the filtering of documents, resulting

--- a/arangod/Utils/Cursor.h
+++ b/arangod/Utils/Cursor.h
@@ -52,7 +52,7 @@ class Cursor {
 
   Cursor(CursorId id, size_t batchSize, double ttl, bool hasCount)
       : _id(id),
-        _batchSize(batchSize),
+        _batchSize(batchSize == 0 ? 1 : batchSize),
         _ttl(ttl),
         _expires(TRI_microtime() + _ttl),
         _hasCount(hasCount),

--- a/tests/js/common/shell/shell-statement.js
+++ b/tests/js/common/shell/shell-statement.js
@@ -630,6 +630,9 @@ function StatementSuite () {
       });
       let result = st.execute();
       assertTrue(result.getExtra().hasOwnProperty("stats"));
+      while (result.hasNext()) {
+        result.next();
+      }
     },
 
     testProfilingSilentStreamingQueryWithBatchSize: function () {
@@ -641,6 +644,9 @@ function StatementSuite () {
       });
       let result = st.execute();
       assertTrue(result.getExtra().hasOwnProperty("stats"));
+      while (result.hasNext()) {
+        result.next();
+      }
     },
     
     testProfilingStreamingQuery: function () {
@@ -651,6 +657,9 @@ function StatementSuite () {
       });
       let result = st.execute();
       assertTrue(result.getExtra().hasOwnProperty("stats"));
+      while (result.hasNext()) {
+        result.next();
+      }
     },
 
     testProfilingStreamingQueryWithBatchSize: function () {

--- a/tests/js/common/shell/shell-statement.js
+++ b/tests/js/common/shell/shell-statement.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen:1000*/
-/*global assertEqual, assertTrue, assertFalse, assertUndefined, assertMatch, fail */
+/*global assertEqual, assertTrue, assertFalse, assertUndefined, assertMatch, fail, arango */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test the statement class
@@ -28,12 +28,12 @@
 /// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
 ////////////////////////////////////////////////////////////////////////////////
 
-var jsunity = require("jsunity");
-
-var arangodb = require("@arangodb");
-var db = arangodb.db;
-var aql = arangodb.aql;
-var ERRORS = arangodb.errors;
+const jsunity = require("jsunity");
+const arangodb = require("@arangodb");
+const db = arangodb.db;
+const aql = arangodb.aql;
+const ERRORS = arangodb.errors;
+const isServer = typeof arango === 'undefined';
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test suite: statements
@@ -620,6 +620,54 @@ function StatementSuite () {
       
       var docs = result.toArray();
       assertEqual(10, docs.length);
+    },
+    
+    testProfilingSilentStreamingQuery: function () {
+      let st = db._createStatement({
+        query : "FOR i IN 1..10 RETURN i",
+        options: { profile: 2, batchSize: 1, silent: true },
+        stream: true,
+      });
+      let result = st.execute();
+      assertTrue(result.getExtra().hasOwnProperty("stats"));
+    },
+
+    testProfilingSilentStreamingQueryWithBatchSize: function () {
+      let st = db._createStatement({
+        query : "FOR i IN 1..10 RETURN i",
+        options: { profile: 2, batchSize: 1, silent: true },
+        batchSize: 1,
+        stream: true,
+      });
+      let result = st.execute();
+      assertTrue(result.getExtra().hasOwnProperty("stats"));
+    },
+    
+    testProfilingStreamingQuery: function () {
+      let st = db._createStatement({
+        query : "FOR i IN 1..10 RETURN i",
+        options: { profile: 2, batchSize: 1 },
+        stream: true,
+      });
+      let result = st.execute();
+      assertTrue(result.getExtra().hasOwnProperty("stats"));
+    },
+
+    testProfilingStreamingQueryWithBatchSize: function () {
+      let st = db._createStatement({
+        query : "FOR i IN 1..10 RETURN i",
+        options: { profile: 2, batchSize: 1 },
+        batchSize: 1,
+        stream: true
+      });
+      let result = st.execute();
+      // batchSize is ignored in arangod
+      assertEqual(isServer, result.getExtra().hasOwnProperty("stats"));
+      assertTrue(result.hasNext());
+      while (result.hasNext()) {
+        result.next();
+      }
+      assertTrue(result.getExtra().hasOwnProperty("stats"));
     },
     
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/13516

Fix profiling of AQL queries with the `silent` and `stream` options sets in combination. Using the `silent` option makes a query execute, but discard all its results instantly. This led to some confusion in streaming queries, which can return the first query results once they are available, but don't necessarily execute the full query.
Now, `silent` correctly discards all results even in streaming queries, but this has the effect that a streaming query will likely be executed completely when the `silent` option is set. This is not the default however, and the `silent` option is normally not set. There is no change for streaming queries if the `silent` option is not set.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_client / shell_server)

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13963/