### PR TITLE
improve wording for database sharding options in UI

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.7.8 (XXXX-XX-XX)
 -------------------
 
+* Improved the wording for sharding options displayed in the web interface.
+
+  Instead of offering `flexible` and `single`, now use the more intuitive
+  `Sharded` and `OneShard` options, and update the help text for them.
+
 * Avoid a potential deadlock when dropping indexes.
 
   A deadlock could theoretically happen for a thread that is attempting to drop

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/databaseView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/databaseView.js
@@ -428,10 +428,10 @@
       //if enterprise
       if (window.App.isCluster && frontendConfig.isEnterprise && !frontendConfig.forceOneShard) {
         var sharding = [ { value : "",
-                           label : "flexible"
+                           label : "Sharded"
                          },
                          { value : "single",
-                           label : "single"
+                           label : "OneShard"
                          }
                        ];
 
@@ -440,7 +440,7 @@
             'newSharding',
             'Sharding',
             'flexible',
-            'Selects the default sharding setup for new collections in this database. *flexible* means that shards of different collections by default will be randomly distributed to database servers. *single* means that collections by default will use the same sharding setup (number of shards and shard distribution) as one of the system collections.',
+            'Selects the default sharding setup for new collections in this database.\n*Sharded* means that collections can have any number of shards, and that shards will be randomly distributed to database servers.\n*OneShard* means that all collections in the database will have only have a single but are all distributed to the same database server. This enables performance optimizations, e.g. pushing down entire queries to database servers. Use *OneShard* when it is known that the dataset fits on a single instance, and *Sharded* for larger datasets.',
             sharding
           )
         );


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/13543

Improve the wording for sharding options displayed in the web interface.

Instead of offering `flexible` and `single`, now use the more intuitive `Sharded` and `OneShard` options, and update the help text for them (refer to attached screenshots for details).

We may need to adjust documentation referring to "single" and "flexible" before we can merge this. We also need to decide whether this should be backported to 3.7 or not.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/13983/

![Screenshot from 2021-02-11 20-27-12](https://user-images.githubusercontent.com/1423118/107689422-1a36bd80-6ca9-11eb-8e6a-c387c5105290.png)
![Screenshot from 2021-02-11 20-25-39](https://user-images.githubusercontent.com/1423118/107689425-1acf5400-6ca9-11eb-9499-b78f76b84e3d.png)

