### PR TITLE
Index the result array for streaming cursor

### DIFF
--- a/3rdParty/velocypack/include/velocypack/Builder.h
+++ b/3rdParty/velocypack/include/velocypack/Builder.h
@@ -418,6 +418,11 @@ class Builder {
     return addInternal<Slice>(sub);
   }
 
+  // Add a shared slice to an array
+  inline uint8_t* add(SharedSlice const& sub) {
+    return addInternal<Slice>(sub.slice());
+  }
+
   // Add a subvalue into an array from a ValuePair:
   inline uint8_t* add(ValuePair const& sub) {
     return addInternal<ValuePair>(sub);

--- a/arangod/Aql/QueryCursor.cpp
+++ b/arangod/Aql/QueryCursor.cpp
@@ -101,7 +101,7 @@ Result QueryResultCursor::dumpSync(VPackBuilder& builder) {
     // some reallocs
     // (not accurate, but the actual size is unknown anyway)
     builder.reserve(std::max<size_t>(1, std::min<size_t>(n, 10000)) * 32);
-    builder.add("result", VPackValue(VPackValueType::Array));
+    builder.add("result", VPackValue(VPackValueType::Array, true));
     for (size_t i = 0; i < n; ++i) {
       if (!hasNext()) {
         break;
@@ -328,8 +328,8 @@ ExecutionState QueryStreamCursor::writeResult(VPackBuilder& builder) {
   if (!silent) {
     builder.reserve(16 * 1024);
   }
-  
-  builder.add("result", VPackValue(VPackValueType::Array));
+
+  builder.add("result", VPackValue(VPackValueType::Array, true));
 
   aql::ExecutionEngine* engine = _query->rootEngine();
   TRI_ASSERT(engine != nullptr);

--- a/arangod/Aql/QueryCursor.cpp
+++ b/arangod/Aql/QueryCursor.cpp
@@ -329,7 +329,7 @@ ExecutionState QueryStreamCursor::writeResult(VPackBuilder& builder) {
     builder.reserve(16 * 1024);
   }
   
-  builder.add("result", VPackValue(VPackValueType::Array, true));
+  builder.add("result", VPackValue(VPackValueType::Array));
 
   aql::ExecutionEngine* engine = _query->rootEngine();
   TRI_ASSERT(engine != nullptr);

--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -974,10 +974,11 @@ target_link_libraries(arango_network llhttp)
 target_link_libraries(arango_network nghttp2)
 target_link_libraries(arango_network arango::validation)
 
+target_link_libraries(arango_pregel arango)
 target_link_libraries(arango_pregel arango_agency)
+target_link_libraries(arango_pregel arango_greenspun)
 target_link_libraries(arango_pregel boost_boost)
 target_link_libraries(arango_pregel boost_system)
-target_link_libraries(arango_pregel arango_greenspun)
 
 target_link_libraries(arango_replication arango_storage_engine)
 target_link_libraries(arango_replication arango_utils)

--- a/tests/Aql/QueryCursorTest.cpp
+++ b/tests/Aql/QueryCursorTest.cpp
@@ -1,0 +1,198 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2021 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "RestHandler/RestCursorHandler.h"
+#include "RestServer/QueryRegistryFeature.h"
+
+#include "IResearch/RestHandlerMock.h"
+#include "Mocks/Servers.h"
+
+#include <velocypack/Builder.h>
+#include <velocypack/Options.h>
+#include <velocypack/Parser.h>
+#include <velocypack/SharedSlice.h>
+#include <velocypack/velocypack-aliases.h>
+
+using namespace arangodb::tests;
+
+class QueryCursorTest : public ::testing::Test {
+ public:
+  static void SetUpTestCase() {
+    server = std::make_unique<mocks::MockRestAqlServer>();
+  }
+  static void TearDownTestCase() { server.reset(); }
+
+ protected:
+  static inline std::unique_ptr<mocks::MockRestAqlServer> server;
+};
+
+namespace {
+arangodb::velocypack::SharedSlice operator"" _vpack(const char* json, size_t len) {
+  VPackOptions options;
+  options.checkAttributeUniqueness = true;
+  options.validateUtf8Strings = true;
+  VPackParser parser(&options);
+  parser.parse(json, len);
+  return parser.steal()->sharedSlice();
+}
+}  // namespace
+
+TEST_F(QueryCursorTest, resultCursorResultArrayIndexSingleBatch) {
+  auto& vocbase = server->getSystemDatabase();
+  auto fakeRequest = std::make_unique<GeneralRequestMock>(vocbase);
+  auto fakeResponse = std::make_unique<GeneralResponseMock>();
+  fakeRequest->setRequestType(arangodb::rest::RequestType::POST);
+  fakeRequest->_payload.add(R"json(
+    {
+      "query": "FOR i IN 1..1000 RETURN CONCAT('', i)"
+    }
+  )json"_vpack);
+
+  auto* registry = arangodb::QueryRegistryFeature::registry();
+
+  auto testee =
+      std::make_shared<arangodb::RestCursorHandler>(server->server(),
+                                                    fakeRequest.release(),
+                                                    fakeResponse.release(), registry);
+
+  testee->execute();
+
+  fakeResponse.reset(dynamic_cast<GeneralResponseMock*>(testee->stealResponse().release()));
+
+  auto const responseBodySlice = fakeResponse->_payload.slice();
+
+  ASSERT_TRUE(responseBodySlice.isObject());
+
+  auto resultSlice = responseBodySlice.get("result").resolveExternal();
+  ASSERT_FALSE(resultSlice.isNone());
+  ASSERT_TRUE(resultSlice.isArray())
+      << "Expected array, but got " << valueTypeName(resultSlice.type());
+  // should be a compact array
+  ASSERT_EQ(0x13, resultSlice.head());
+}
+
+TEST_F(QueryCursorTest, resultCursorResultArrayIndexTwoBatches) {
+  auto& vocbase = server->getSystemDatabase();
+  auto fakeRequest = std::make_unique<GeneralRequestMock>(vocbase);
+  auto fakeResponse = std::make_unique<GeneralResponseMock>();
+  fakeRequest->setRequestType(arangodb::rest::RequestType::POST);
+  fakeRequest->_payload.add(R"json(
+    {
+      "query": "FOR i IN 1..2000 RETURN CONCAT('', i)"
+    }
+  )json"_vpack);
+
+  auto* registry = arangodb::QueryRegistryFeature::registry();
+
+  auto testee =
+      std::make_shared<arangodb::RestCursorHandler>(server->server(),
+                                                    fakeRequest.release(),
+                                                    fakeResponse.release(), registry);
+
+  testee->execute();
+
+  fakeResponse.reset(dynamic_cast<GeneralResponseMock*>(testee->stealResponse().release()));
+
+  auto const responseBodySlice = fakeResponse->_payload.slice();
+
+  ASSERT_TRUE(responseBodySlice.isObject());
+
+  auto resultSlice = responseBodySlice.get("result").resolveExternal();
+  ASSERT_FALSE(resultSlice.isNone());
+  ASSERT_TRUE(resultSlice.isArray())
+      << "Expected array, but got " << valueTypeName(resultSlice.type());
+  // should be a compact array
+  ASSERT_EQ(0x13, resultSlice.head());
+}
+
+TEST_F(QueryCursorTest, streamingCursorResultArrayIndexSingleBatch) {
+  auto& vocbase = server->getSystemDatabase();
+  auto fakeRequest = std::make_unique<GeneralRequestMock>(vocbase);
+  auto fakeResponse = std::make_unique<GeneralResponseMock>();
+  fakeRequest->setRequestType(arangodb::rest::RequestType::POST);
+  fakeRequest->_payload.add(R"json(
+    {
+      "query": "FOR i IN 1..1000 RETURN CONCAT('', i)",
+      "options": { "stream": true }
+    }
+  )json"_vpack);
+
+  auto* registry = arangodb::QueryRegistryFeature::registry();
+
+  auto testee =
+      std::make_shared<arangodb::RestCursorHandler>(server->server(),
+                                                    fakeRequest.release(),
+                                                    fakeResponse.release(), registry);
+
+  testee->execute();
+
+  fakeResponse.reset(dynamic_cast<GeneralResponseMock*>(testee->stealResponse().release()));
+
+  auto const responseBodySlice = fakeResponse->_payload.slice();
+
+  ASSERT_TRUE(responseBodySlice.isObject());
+
+  auto const resultSlice = responseBodySlice.get("result").resolveExternal();
+  ASSERT_FALSE(resultSlice.isNone());
+  ASSERT_TRUE(resultSlice.isArray())
+      << "Expected array, but got " << valueTypeName(resultSlice.type());
+  // should be a compact array
+  ASSERT_EQ(0x13, resultSlice.head());
+}
+
+TEST_F(QueryCursorTest, streamingCursorResultArrayIndexTwoBatches) {
+  auto& vocbase = server->getSystemDatabase();
+  auto fakeRequest = std::make_unique<GeneralRequestMock>(vocbase);
+  auto fakeResponse = std::make_unique<GeneralResponseMock>();
+  fakeRequest->setRequestType(arangodb::rest::RequestType::POST);
+  fakeRequest->_payload.add(R"json(
+    {
+      "query": "FOR i IN 1..2000 RETURN CONCAT('', i)",
+      "options": { "stream": true }
+    }
+  )json"_vpack);
+
+  auto* registry = arangodb::QueryRegistryFeature::registry();
+
+  auto testee =
+      std::make_shared<arangodb::RestCursorHandler>(server->server(),
+                                                    fakeRequest.release(),
+                                                    fakeResponse.release(), registry);
+
+  testee->execute();
+
+  fakeResponse.reset(dynamic_cast<GeneralResponseMock*>(testee->stealResponse().release()));
+
+  auto const responseBodySlice = fakeResponse->_payload.slice();
+
+  ASSERT_TRUE(responseBodySlice.isObject());
+
+  auto const resultSlice = responseBodySlice.get("result").resolveExternal();
+  ASSERT_FALSE(resultSlice.isNone());
+  ASSERT_TRUE(resultSlice.isArray())
+      << "Expected array, but got " << valueTypeName(resultSlice.type());
+  // should be a compact array
+  ASSERT_EQ(0x13, resultSlice.head());
+}

--- a/tests/Aql/QueryCursorTest.cpp
+++ b/tests/Aql/QueryCursorTest.cpp
@@ -184,8 +184,31 @@ TEST_F(QueryCursorTest, streamingCursorResultArrayIndexTwoBatches) {
   testee->execute();
 
   fakeResponse.reset(dynamic_cast<GeneralResponseMock*>(testee->stealResponse().release()));
+  // this is necessary to reset the wakeup handler, which otherwise holds a
+  // shared_ptr to testee.
+  testee->shutdownExecute(true);
 
   auto const responseBodySlice = fakeResponse->_payload.slice();
+
+  {  // release the query, so the AQL feature doesn't wait on it during shutdown
+    auto const idSlice = responseBodySlice.get("id");
+    ASSERT_FALSE(idSlice.isNone());
+    ASSERT_TRUE(idSlice.isString());
+    auto fakeRequest = std::make_unique<GeneralRequestMock>(vocbase);
+    fakeRequest->setRequestType(arangodb::rest::RequestType::DELETE_REQ);
+    fakeRequest->addSuffix(idSlice.copyString());
+    auto fakeResponse = std::make_unique<GeneralResponseMock>();
+    auto restHandler =
+        std::make_shared<arangodb::RestCursorHandler>(server->server(),
+                                                      fakeRequest.release(),
+                                                      fakeResponse.release(), registry);
+    restHandler->execute();
+    fakeResponse.reset(
+        dynamic_cast<GeneralResponseMock*>(testee->stealResponse().release()));
+  }
+
+  auto wp = std::weak_ptr{testee};
+  testee.reset();
 
   ASSERT_TRUE(responseBodySlice.isObject());
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,6 +129,7 @@ set(ARANGODB_TESTS_SOURCES
   Aql/NoResultsExecutorTest.cpp
   Aql/ProjectionsTest.cpp
   Aql/QueryHelper.cpp
+  Aql/QueryCursorTest.cpp
   Aql/RegisterPlanTest.cpp
   Aql/RemoteExecutorTest.cpp
   Aql/RemoveExecutorTest.cpp

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -322,7 +322,7 @@ MockMetricsServer::MockMetricsServer(bool start) : MockServer() {
   addFeature<arangodb::EngineSelectorFeature>(false);
 
   if (start) {
-    startFeatures();
+    MockMetricsServer::startFeatures();
   }
 }
 
@@ -332,7 +332,7 @@ MockV8Server::MockV8Server(bool start) : MockServer() {
   addFeature<arangodb::NetworkFeature>(false);
 
   if (start) {
-    startFeatures();
+    MockV8Server::startFeatures();
   }
 }
 
@@ -349,7 +349,7 @@ MockAqlServer::MockAqlServer(bool start) : MockServer() {
   SetupAqlPhase(*this);
 
   if (start) {
-    startFeatures();
+    MockAqlServer::startFeatures();
   }
 }
 
@@ -405,7 +405,7 @@ MockRestServer::MockRestServer(bool start) : MockServer() {
   addFeature<arangodb::QueryRegistryFeature>(false);
   addFeature<arangodb::NetworkFeature>(false);
   if (start) {
-    startFeatures();
+    MockRestServer::startFeatures();
   }
 }
 
@@ -572,8 +572,8 @@ MockDBServer::MockDBServer(bool start) : MockClusterServer() {
   addFeature<arangodb::FlushFeature>(false);        // do not start the thread
   addFeature<arangodb::MaintenanceFeature>(false);  // do not start the thread
   if (start) {
-    startFeatures();
-    createDatabase("_system");
+    MockDBServer::startFeatures();
+    MockDBServer::createDatabase("_system");
   }
 }
 
@@ -620,8 +620,8 @@ void MockDBServer::dropDatabase(std::string const& name) {
 MockCoordinator::MockCoordinator(bool start) : MockClusterServer() {
   arangodb::ServerState::instance()->setRole(arangodb::ServerState::RoleEnum::ROLE_COORDINATOR);
   if (start) {
-    startFeatures();
-    createDatabase("_system");
+    MockCoordinator::startFeatures();
+    MockCoordinator::createDatabase("_system");
   }
 }
 
@@ -641,4 +641,10 @@ void MockCoordinator::dropDatabase(std::string const& name) {
   auto& databaseFeature = _server.getFeature<arangodb::DatabaseFeature>();
   auto vocbase = databaseFeature.lookupDatabase(name);
   TRI_ASSERT(vocbase == nullptr);
+}
+
+MockRestAqlServer::MockRestAqlServer() {
+  SetupAqlPhase(*this);
+  addFeature<arangodb::NetworkFeature>(false);
+  MockRestAqlServer::startFeatures();
 }

--- a/tests/Mocks/Servers.h
+++ b/tests/Mocks/Servers.h
@@ -110,7 +110,8 @@ class MockServer {
   void stopFeatures();
 
  protected:
-  arangodb::application_features::ApplicationServer::State _oldApplicationServerState;
+  arangodb::application_features::ApplicationServer::State _oldApplicationServerState =
+      arangodb::application_features::ApplicationServer::State::UNINITIALIZED;
   arangodb::application_features::ApplicationServer _server;
   StorageEngineMock _engine;
   std::unordered_map<arangodb::application_features::ApplicationFeature*, bool> _features;
@@ -151,8 +152,8 @@ class MockAqlServer : public MockServer,
                       public LogSuppressor<iresearch::TOPIC, LogLevel::FATAL>,
                       public IResearchLogSuppressor {
  public:
-  MockAqlServer(bool startFeatures = true);
-  ~MockAqlServer();
+  explicit MockAqlServer(bool startFeatures = true);
+  ~MockAqlServer() override;
 
   std::shared_ptr<arangodb::transaction::Methods> createFakeTransaction() const;
   // runBeforePrepare gives an entry point to modify the list of collections one want to use within the Query.
@@ -170,7 +171,17 @@ class MockRestServer : public MockServer,
                        public LogSuppressor<iresearch::TOPIC, LogLevel::FATAL>,
                        public IResearchLogSuppressor {
  public:
-  MockRestServer(bool startFeatures = true);
+  explicit MockRestServer(bool startFeatures = true);
+};
+
+class MockRestAqlServer : public MockServer,
+                          public LogSuppressor<Logger::AUTHENTICATION, LogLevel::WARN>,
+                          public LogSuppressor<Logger::CLUSTER, LogLevel::ERR>,
+                          public LogSuppressor<Logger::FIXME, LogLevel::ERR>,
+                          public LogSuppressor<iresearch::TOPIC, LogLevel::FATAL>,
+                          public IResearchLogSuppressor {
+ public:
+  explicit MockRestAqlServer();
 };
 
 class MockClusterServer : public MockServer,
@@ -205,7 +216,7 @@ class MockClusterServer : public MockServer,
  private:
   arangodb::ServerState::RoleEnum _oldRole;
   std::unique_ptr<AsyncAgencyStorePoolMock> _pool;
-  int _dummy;
+  int _dummy{};
 };
 
 class MockDBServer : public MockClusterServer {


### PR DESCRIPTION
### Scope & Purpose

This PR changes (for VelocyPack based protocols) the `result` field of cursors with `stream: true` from an unindexed to an indexed array. This is already the case for non-streaming cursors. The Java driver (as of v6.9.0) accesses those entries with linear runtime each, resulting in degraded performance as reported in #13476. The Java driver will be fixed in an upcoming version, too: https://github.com/arangodb/arangodb-java-driver/commit/5c8324aa5d62f5e468e8b0e2dd0fe8c60e243172

- [X] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [X] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [X] GitHub issue / Jira ticket number: #13476
- [ ] Design document: 
Related fix in the Java driver: https://github.com/arangodb/arangodb-java-driver/commit/5c8324aa5d62f5e468e8b0e2dd0fe8c60e243172

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:

### Documentation

> All new features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the CHANGELOG so that
> support, end users, and other developers have a concise overview. 

- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

