### PR TITLE
Fixed a count collect bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fixed issue #DEVSUP-720: Within an AQL query, the "COLLECT WITH COUNT INTO"
+  statement could lead to a wrong count output when used in combination with
+  an index which has been created with an array index attribute.
+
 * Improved the wording for sharding options displayed in the web interface.
 
   Instead of offering `flexible` and `single`, now use the more intuitive

--- a/arangod/Aql/IndexExecutor.cpp
+++ b/arangod/Aql/IndexExecutor.cpp
@@ -356,7 +356,8 @@ IndexExecutor::CursorReader::CursorReader(transaction::Methods& trx,
                           : _cursor->hasCovering() &&  // if change see IndexNode::canApplyLateDocumentMaterializationRule()
                                     infos.getProjections().supportsCoveringIndex()
                                 ? Type::Covering
-                                : Type::Document) {
+                                : Type::Document),
+      _checkUniqueness(checkUniqueness) {
   switch (_type) {
     case Type::NoResult: {
       _documentNonProducer = checkUniqueness ? getNullCallback<true>(context)
@@ -389,6 +390,7 @@ IndexExecutor::CursorReader::CursorReader(CursorReader&& other) noexcept
       _cursor(std::move(other._cursor)),
       _context(other._context),
       _type(other._type),
+      _checkUniqueness(other._checkUniqueness),
       _documentNonProducer(std::move(other._documentNonProducer)),
       _documentProducer(std::move(other._documentProducer)),
       _documentSkipper(std::move(other._documentSkipper)) {}
@@ -442,13 +444,13 @@ bool IndexExecutor::CursorReader::readIndex(OutputAqlItemRow& output) {
 
 size_t IndexExecutor::CursorReader::skipIndex(size_t toSkip) {
   TRI_ASSERT(_type != Type::Count);
-  
+
   if (!hasMore()) {
     return 0;
   }
 
   uint64_t skipped = 0;
-  if (_infos.getFilter() != nullptr) {
+  if (_infos.getFilter() != nullptr || _checkUniqueness) {
     switch (_type) {
       case Type::Covering:
       case Type::LateMaterialized:

--- a/arangod/Aql/IndexExecutor.h
+++ b/arangod/Aql/IndexExecutor.h
@@ -200,6 +200,7 @@ class IndexExecutor {
     std::unique_ptr<IndexIterator> _cursor;
     DocumentProducingFunctionContext& _context;
     Type const _type;
+    bool const _checkUniqueness;
 
     // Only one of _documentProducer and _documentNonProducer is set at a time,
     // depending on _type. As std::function is not trivially destructible, it's

--- a/tests/js/server/aql/aql-queries-optimizer-count.js
+++ b/tests/js/server/aql/aql-queries-optimizer-count.js
@@ -1,0 +1,105 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global assertEqual, AQL_EXPLAIN */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief tests for query language, sort optimizations
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2021 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Heiko Kernbach
+/// @author Copyright 2021, ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+let jsunity = require("jsunity");
+let internal = require("internal");
+let helper = require("@arangodb/aql-helper");
+let getQueryResults = helper.getQueryResults;
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test suite
+////////////////////////////////////////////////////////////////////////////////
+
+function ahuacatlQueryOptimizerCollectTestSuite() {
+  let collection = null;
+  let cn = "UnitTestsAhuacatlOptimizerCountCollect";
+
+  return {
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief set up
+////////////////////////////////////////////////////////////////////////////////
+
+    setUp: function () {
+      internal.db._drop(cn);
+      collection = internal.db._create(cn);
+
+      // create an index with two attributes (first: boolean, second: array)
+      collection.ensureIndex({type: "persistent", fields: ["someBoolean", "someArray[*]"]});
+
+      // create 100 (50+50) documents in total
+      for (let outer = 0; outer < 50; outer++) {
+        let myArray = [];
+        // create 100 entries for our inner document array
+        for (let inner = 0; inner < 10; inner++) {
+          // write numeric strings
+          myArray.push(JSON.stringify(inner));
+        }
+        collection.save({"someBoolean": true, "someArray": myArray});
+        collection.save({"someBoolean": false, "someArray": myArray});
+      }
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief tear down
+////////////////////////////////////////////////////////////////////////////////
+
+    tearDown: function () {
+      internal.db._drop(cn);
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief check sort optimization without index
+////////////////////////////////////////////////////////////////////////////////
+
+    testCountWithMultipleAttributesIncludingIndexArray: function () {
+      let countWithLengthQuery = "RETURN LENGTH(" + cn + ")";
+      let countWithCollectQuery = "FOR d IN " + cn + " FILTER (d.someBoolean == true) OR (d.someBoolean == false) COLLECT WITH COUNT INTO c RETURN c";
+
+      let resCountWithLength = getQueryResults(countWithLengthQuery);
+      let resCountWithCollect = getQueryResults(countWithCollectQuery);
+
+      assertEqual(1, resCountWithLength.length);
+      assertEqual(1, resCountWithCollect.length);
+      assertEqual(resCountWithLength[0], 100);
+      assertEqual(resCountWithCollect[0], 100);
+
+      assertEqual(resCountWithCollect[0], resCountWithLength[0]);
+    }
+  };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief executes the test suite
+////////////////////////////////////////////////////////////////////////////////
+
+jsunity.run(ahuacatlQueryOptimizerCollectTestSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

This PR fixes issue #DEVSUP-720:

Within an AQL query, the "COLLECT WITH COUNT INTO" statement could lead to a wrong count output when used in combination with an index which has been created with an array index attribute.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.7 / 3.6 

#### Related Information

Ticket: 
- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/DEVSUP-720

### Testing & Verification
- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run: http://jenkins.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/13997/