### PR TITLE
adjust value to changelog entry

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -224,17 +224,17 @@ devel
   possible for a very small number of queries and even had adverse effects,
   so it is now removed entirely.
 
-* On Linux and MacOS, require at least 8192 usable file descriptors at startup.
+* On Linux and MacOS, require at least 65535 usable file descriptors at startup.
   If less file descriptors are available to the arangod process, then the
   startup is automatically aborted.
 
-  Even the chosen minimum value of 8192 will often not be high enough to
+  Even the chosen minimum value of 65535 will often not be high enough to
   store considerable amounts of data. However, no higher value was chosen
   in order to not make too many existing small installations fail at startup
   after upgrading.
 
   The required number of file descriptors can be configured using the startup
-  option `--server.descriptors-minimum`. It defaults to 8192, but it can be
+  option `--server.descriptors-minimum`. It defaults to 65535, but it can be
   increased to ensure that arangod can make use of a sufficiently high number
   of files. Setting `--server.descriptors-minimum` to a value of `0` will
   make the startup require only an absolute minimum limit of 1024 file

--- a/Installation/Windows/Plugins/exitcodes.nsh
+++ b/Installation/Windows/Plugins/exitcodes.nsh
@@ -17,6 +17,7 @@
 !define ARANGO_EXIT_UNSUPPORTED_STORAGE_ENGINE 25
 !define ARANGO_EXIT_ICU_INITIALIZATION_FAILED 26
 !define ARANGO_EXIT_TZDATA_INITIALIZATION_FAILED 27
+!define ARANGO_EXIT_RESOURCES_TO_LOW 28
 
 !macro printExitCode exitCode Message DetailMessage
   Push "${exitCode}"
@@ -97,6 +98,10 @@ ${Switch} $1
 
   ${Case} 27 # EXIT_TZDATA_INITIALIZATION_FAILED
     MessageBox MB_ICONEXCLAMATION '$2:$\r$\n>> failed to locate tzdata <<$\r$\n"Will be returned if tzdata is not found"$\r$\n$3'
+  ${Break}
+
+  ${Case} 28 # EXIT_RESOURCES_TO_LOW
+    MessageBox MB_ICONEXCLAMATION '$2:$\r$\n>> the system restricts resources below what we can bear <<$\r$\n"Will be returned if i.e. ulimit is too restrictive"$\r$\n$3'
   ${Break}
 
   ${Default}

--- a/Installation/Windows/Plugins/exitcodes.nsh
+++ b/Installation/Windows/Plugins/exitcodes.nsh
@@ -17,7 +17,7 @@
 !define ARANGO_EXIT_UNSUPPORTED_STORAGE_ENGINE 25
 !define ARANGO_EXIT_ICU_INITIALIZATION_FAILED 26
 !define ARANGO_EXIT_TZDATA_INITIALIZATION_FAILED 27
-!define ARANGO_EXIT_RESOURCES_TO_LOW 28
+!define ARANGO_EXIT_RESOURCES_TOO_LOW 28
 
 !macro printExitCode exitCode Message DetailMessage
   Push "${exitCode}"
@@ -100,8 +100,8 @@ ${Switch} $1
     MessageBox MB_ICONEXCLAMATION '$2:$\r$\n>> failed to locate tzdata <<$\r$\n"Will be returned if tzdata is not found"$\r$\n$3'
   ${Break}
 
-  ${Case} 28 # EXIT_RESOURCES_TO_LOW
-    MessageBox MB_ICONEXCLAMATION '$2:$\r$\n>> the system restricts resources below what we can bear <<$\r$\n"Will be returned if i.e. ulimit is too restrictive"$\r$\n$3'
+  ${Case} 28 # EXIT_RESOURCES_TOO_LOW
+    MessageBox MB_ICONEXCLAMATION '$2:$\r$\n>> the system restricts resources below what is required to start arangod <<$\r$\n"Will be returned if i.e. ulimit is too restrictive"$\r$\n$3'
   ${Break}
 
   ${Default}

--- a/arangod/RestServer/FileDescriptorsFeature.cpp
+++ b/arangod/RestServer/FileDescriptorsFeature.cpp
@@ -60,7 +60,7 @@ struct FileDescriptors {
     if (res != 0) {
       LOG_TOPIC("17d7b", FATAL, arangodb::Logger::SYSCALL)
           << "cannot get the file descriptors limit value: " << strerror(errno);
-      FATAL_ERROR_EXIT_CODE(TRI_EXIT_RESOURCES_TO_LOW);
+      FATAL_ERROR_EXIT_CODE(TRI_EXIT_RESOURCES_TOO_LOW);
     }
 
     return {rlim.rlim_max, rlim.rlim_cur};
@@ -142,7 +142,7 @@ void FileDescriptorsFeature::start() {
       LOG_TOPIC("a33ba", WARN, arangodb::Logger::SYSCALL) << s.str();
     } else {
       LOG_TOPIC("8c771", FATAL, arangodb::Logger::SYSCALL) << s.str();
-      FATAL_ERROR_EXIT();
+      FATAL_ERROR_EXIT_CODE(TRI_EXIT_RESOURCES_TOO_LOW);
     }
   }
 }

--- a/arangod/RestServer/FileDescriptorsFeature.cpp
+++ b/arangod/RestServer/FileDescriptorsFeature.cpp
@@ -24,6 +24,7 @@
 #include "FileDescriptorsFeature.h"
 
 #include "ApplicationFeatures/GreetingsFeaturePhase.h"
+#include "Basics/exitcodes.h"
 #include "Basics/application-exit.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
@@ -59,7 +60,7 @@ struct FileDescriptors {
     if (res != 0) {
       LOG_TOPIC("17d7b", FATAL, arangodb::Logger::SYSCALL)
           << "cannot get the file descriptors limit value: " << strerror(errno);
-      FATAL_ERROR_EXIT();
+     FATAL_ERROR_EXIT_CODE(TRI_EXIT_RESOURCES_TO_LOW);
     }
 
     return {rlim.rlim_max, rlim.rlim_cur};

--- a/arangod/RestServer/FileDescriptorsFeature.cpp
+++ b/arangod/RestServer/FileDescriptorsFeature.cpp
@@ -47,7 +47,7 @@ namespace arangodb {
 
 struct FileDescriptors {
   static constexpr rlim_t requiredMinimum = 1024;
-  static constexpr rlim_t recommendedMinimum = 65536;
+  static constexpr rlim_t recommendedMinimum = 8192;
 
   rlim_t hard;
   rlim_t soft;

--- a/arangod/RestServer/FileDescriptorsFeature.cpp
+++ b/arangod/RestServer/FileDescriptorsFeature.cpp
@@ -47,7 +47,7 @@ namespace arangodb {
 
 struct FileDescriptors {
   static constexpr rlim_t requiredMinimum = 1024;
-  static constexpr rlim_t recommendedMinimum = 8192;
+  static constexpr rlim_t recommendedMinimum = 65535;
 
   rlim_t hard;
   rlim_t soft;

--- a/arangod/RestServer/FileDescriptorsFeature.cpp
+++ b/arangod/RestServer/FileDescriptorsFeature.cpp
@@ -60,7 +60,7 @@ struct FileDescriptors {
     if (res != 0) {
       LOG_TOPIC("17d7b", FATAL, arangodb::Logger::SYSCALL)
           << "cannot get the file descriptors limit value: " << strerror(errno);
-     FATAL_ERROR_EXIT_CODE(TRI_EXIT_RESOURCES_TO_LOW);
+      FATAL_ERROR_EXIT_CODE(TRI_EXIT_RESOURCES_TO_LOW);
     }
 
     return {rlim.rlim_max, rlim.rlim_cur};

--- a/js/common/bootstrap/exitcodes.js
+++ b/js/common/bootstrap/exitcodes.js
@@ -24,7 +24,8 @@
     "EXIT_DB_NOT_EMPTY"            : { "code" : 24, "message" : "database not empty" },
     "EXIT_UNSUPPORTED_STORAGE_ENGINE" : { "code" : 25, "message" : "unsupported storage engine" },
     "EXIT_ICU_INITIALIZATION_FAILED" : { "code" : 26, "message" : "failed to initialize ICU library" },
-    "EXIT_TZDATA_INITIALIZATION_FAILED" : { "code" : 27, "message" : "failed to locate tzdata" }
+    "EXIT_TZDATA_INITIALIZATION_FAILED" : { "code" : 27, "message" : "failed to locate tzdata" },
+    "EXIT_RESOURCES_TO_LOW"        : { "code" : 28, "message" : "the system restricts resources below what we can bear" }
   };
 }());
 

--- a/js/common/bootstrap/exitcodes.js
+++ b/js/common/bootstrap/exitcodes.js
@@ -25,7 +25,7 @@
     "EXIT_UNSUPPORTED_STORAGE_ENGINE" : { "code" : 25, "message" : "unsupported storage engine" },
     "EXIT_ICU_INITIALIZATION_FAILED" : { "code" : 26, "message" : "failed to initialize ICU library" },
     "EXIT_TZDATA_INITIALIZATION_FAILED" : { "code" : 27, "message" : "failed to locate tzdata" },
-    "EXIT_RESOURCES_TO_LOW"        : { "code" : 28, "message" : "the system restricts resources below what we can bear" }
+    "EXIT_RESOURCES_TOO_LOW"       : { "code" : 28, "message" : "the system restricts resources below what is required to start arangod" }
   };
 }());
 

--- a/lib/Basics/exitcodes.dat
+++ b/lib/Basics/exitcodes.dat
@@ -25,7 +25,7 @@ EXIT_DB_NOT_EMPTY,24,"database not empty","Will be returned when commanding to i
 EXIT_UNSUPPORTED_STORAGE_ENGINE,25,"unsupported storage engine","Will be returned when trying to start with an unsupported storage engine"
 EXIT_ICU_INITIALIZATION_FAILED,26,"failed to initialize ICU library","Will be returned if icudtl.dat is not found, of the wrong version or invalid. Check for an incorrectly set ICU_DATA environment variable"
 EXIT_TZDATA_INITIALIZATION_FAILED,27,"failed to locate tzdata","Will be returned if tzdata is not found"
-EXIT_RESOURCES_TO_LOW,28,"the system restricts resources below what we can bear","Will be returned if i.e. ulimit is too restrictive"
+EXIT_RESOURCES_TOO_LOW,28,"the system restricts resources below what is required to start arangod","Will be returned if i.e. ulimit is too restrictive"
 # network
 #EXIT_NO_COORDINATOR
 #EXIT_NO_AGENCY

--- a/lib/Basics/exitcodes.dat
+++ b/lib/Basics/exitcodes.dat
@@ -25,7 +25,7 @@ EXIT_DB_NOT_EMPTY,24,"database not empty","Will be returned when commanding to i
 EXIT_UNSUPPORTED_STORAGE_ENGINE,25,"unsupported storage engine","Will be returned when trying to start with an unsupported storage engine"
 EXIT_ICU_INITIALIZATION_FAILED,26,"failed to initialize ICU library","Will be returned if icudtl.dat is not found, of the wrong version or invalid. Check for an incorrectly set ICU_DATA environment variable"
 EXIT_TZDATA_INITIALIZATION_FAILED,27,"failed to locate tzdata","Will be returned if tzdata is not found"
-
+EXIT_RESOURCES_TO_LOW,28,"the system restricts resources below what we can bear","Will be returned if i.e. ulimit is too restrictive"
 # network
 #EXIT_NO_COORDINATOR
 #EXIT_NO_AGENCY

--- a/lib/Basics/exitcodes.h
+++ b/lib/Basics/exitcodes.h
@@ -95,10 +95,10 @@ constexpr int TRI_EXIT_ICU_INITIALIZATION_FAILED                                
 /// Will be returned if tzdata is not found
 constexpr int TRI_EXIT_TZDATA_INITIALIZATION_FAILED                             = 27;
 
-/// 28: EXIT_RESOURCES_TO_LOW
-/// the system restricts resources below what we can bear
+/// 28: EXIT_RESOURCES_TOO_LOW
+/// the system restricts resources below what is required to start arangod
 /// Will be returned if i.e. ulimit is too restrictive
-constexpr int TRI_EXIT_RESOURCES_TO_LOW                                         = 28;
+constexpr int TRI_EXIT_RESOURCES_TOO_LOW                                        = 28;
 
 
 #endif

--- a/lib/Basics/exitcodes.h
+++ b/lib/Basics/exitcodes.h
@@ -95,6 +95,11 @@ constexpr int TRI_EXIT_ICU_INITIALIZATION_FAILED                                
 /// Will be returned if tzdata is not found
 constexpr int TRI_EXIT_TZDATA_INITIALIZATION_FAILED                             = 27;
 
+/// 28: EXIT_RESOURCES_TO_LOW
+/// the system restricts resources below what we can bear
+/// Will be returned if i.e. ulimit is too restrictive
+constexpr int TRI_EXIT_RESOURCES_TO_LOW                                         = 28;
+
 
 #endif
 


### PR DESCRIPTION
### Scope & Purpose

The required ulimit -n value is 8k according to the changelog entry. This PR adjusts the code to actually do this. 
The previously existing 65536 shouldn't be used in any case, since the ubuntu user default seems to be 65535 - 
which would be a better fit and introduce less support cases.
Details see https://arangodb.atlassian.net/browse/BTS-311

- [x] :hankey: Bugfix (requires CHANGELOG entry)
