### PR TITLE
Disable ligatures in CSS for Ace editor / fix mode-aql.js

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -63,6 +63,10 @@ devel
   statement could lead to a wrong count output when used in combination with
   an index which has been created with an array index attribute.
 
+* Fixed issue #13117: Aardvark: Weird cursor offsets in query editor.
+
+  Disabled font ligatures for Ace editor in Web UI to avoid rare display issue.
+
 * Fixed ES-784 regression related to encryption cipher propagation to
   ArangoSearch data.
 
@@ -174,14 +178,14 @@ devel
 * More improvements for logging:
   
   * Added new REST API endpoint GET `/_admin/log/entries` to return log entries
-    in a more intuitve format, putting each log entry with all its properties
+    in a more intuitive format, putting each log entry with all its properties
     into an object. The API response is an array with all log message objects
     that match the search criteria.
     This is an extension to the already existing API endpoint GET `/_admin/log`,
     which returned log messages fragmented into 5 separate arrays.
 
     The already existing API endpoint GET `/_admin/log` for retrieving log 
-    messages is now deprecated, altough it will stay available for some time.
+    messages is now deprecated, although it will stay available for some time.
 
   * Truncation of log messages now takes JSON format into account, so that
     the truncation of oversized JSON log messages still keeps a valid JSON
@@ -200,7 +204,7 @@ devel
     shorten long log messages in case there is not a lot of space for logfiles, 
     and to keep rogue log messages from overusing resources. 
     The default value is 128 MB, which is very high and should effectively
-    mean downwards-compatiblity with previous arangod versions, which did not
+    mean downwards-compatibility with previous arangod versions, which did not
     restrict the maximum size of log messages.
   
   - `--audit.max-entry-length`: controls the maximum line length for individual
@@ -208,7 +212,7 @@ devel
     log messages longer than the specified value will be truncated and the 
     suffix '...' will be added to them. 
     The default value is 128 MB, which is very high and should effectively
-    mean downwards-compatiblity with previous arangod versions, which did not
+    mean downwards-compatibility with previous arangod versions, which did not
     restrict the maximum size of log messages.
 
   - `--log.in-memory-level`: controls which log messages are preserved in 

--- a/js/apps/system/_admin/aardvark/APP/frontend/scss/_general.scss
+++ b/js/apps/system/_admin/aardvark/APP/frontend/scss/_general.scss
@@ -96,6 +96,11 @@
   cursor: default !important;
 }
 
+// Ligatures can cause issues with the cursor on a few systems
+.ace_editor {
+  font-variant-ligatures: none !important;
+}
+
 //still in use???
 .container {
   margin-left: 20px;

--- a/js/apps/system/_admin/aardvark/APP/frontend/scss/_queryView.scss
+++ b/js/apps/system/_admin/aardvark/APP/frontend/scss/_queryView.scss
@@ -420,7 +420,6 @@
     border-right: 1px solid $c-content-border;
     height: 280px;
     width: 100%;
-    font-variant-ligatures: none;
 
     .ace_active-line {
       background: $c-white !important;

--- a/js/apps/system/_admin/aardvark/APP/frontend/scss/_queryView.scss
+++ b/js/apps/system/_admin/aardvark/APP/frontend/scss/_queryView.scss
@@ -420,6 +420,7 @@
     border-right: 1px solid $c-content-border;
     height: 280px;
     width: 100%;
+    font-variant-ligatures: none;
 
     .ace_active-line {
       background: $c-white !important;

--- a/js/apps/system/_admin/aardvark/APP/react/public/assets/src/mode-aql.js
+++ b/js/apps/system/_admin/aardvark/APP/react/public/assets/src/mode-aql.js
@@ -95,12 +95,13 @@ var AqlHighlightRules = function() {
         "(to_bool|to_number|to_string|to_list|is_null|is_bool|is_number|is_string|is_list|is_document|typename|json_stringify|json_parse|" +
         "concat|concat_separator|char_length|lower|upper|substring|left|right|trim|reverse|contains|" +
         "log|log2|log10|exp|exp2|sin|cos|tan|asin|acos|atan|atan2|radians|degrees|pi|regex_test|" +
-        "like|floor|ceil|round|abs|rand|sqrt|pow|length|count|min|max|average|sum|product|median|variance_population|" +
-        "variance_sample|first|last|unique|outersection|interleave|in_range|jaccard|matches|merge|merge_recursive|has|attributes|values|unset|unset_recursive|keep|" +
+        "like|floor|ceil|round|abs|rand|sqrt|pow|length|count|min|max|average|sum|product|median|variance_population|variance_sample|" +
+        "bit_and|bit_or|bit_xor|bit_negate|bit_test|bit_popcount|bit_shift_left|bit_shift_right|bit_construct|bit_deconstruct|bit_to_string|bit_from_string|" +
+        "first|last|unique|outersection|interleave|in_range|jaccard|matches|merge|merge_recursive|has|attributes|values|unset|unset_recursive|keep|" +
         "near|within|within_rectangle|is_in_polygon|distance|fulltext|paths|traversal|traversal_tree|edges|stddev_sample|stddev_population|" +
-        "slice|nth|position|translate|zip|call|apply|push|append|pop|shift|unshift|remove_value|remove_values|" + 
+        "slice|nth|position|translate|zip|call|apply|push|append|pop|shift|unshift|remove_value|remove_values|" +
         "remove_nth|replace_nth|date_now|date_timestamp|date_iso8601|date_dayofweek|date_year|date_month|date_day|date_hour|" +
-        "date_minute|date_second|date_millisecond|date_dayofyear|date_isoweek|date_leapyear|date_quarter|date_days_in_month|" + 
+        "date_minute|date_second|date_millisecond|date_dayofyear|date_isoweek|date_leapyear|date_quarter|date_days_in_month|" +
         "date_add|date_subtract|date_diff|date_compare|date_format|date_utctolocal|date_localtoutc|date_timezone|date_timezones|fail|passthru|sleep|not_null|" +
         "first_list|first_document|parse_identifier|current_user|current_database|" +
         "collections|document|decode_rev|union|union_distinct|intersection|flatten|is_same_collection|check_document|" +


### PR DESCRIPTION
### Scope & Purpose

Avoid rare display issue in Web UI where `fi` is turned into a ligature that throws off the cursor position.

This seems to occur only on very few systems and we we not able to reproduce it, but it shouldn't hurt to disable ligatures.

Also fixes a mistake of [#13399](https://github.com/arangodb/arangodb/pull/13399/files#diff-f3cdfd124afe97d1e97528e938a91ca713fc35d46a65025b1ce950e2fe4b5e11) which added the AQL bit handling functions to a generated file instead of its source file. The rebuild also updates the generated file with missing AQL functions and fixes a typo.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made
- [ ] ~Rebuild Ardvaark~ to be done later, or maybe we can finally remove it as build artifact from the repo?

#### Backports:

- [x] No backports required
- [ ] Backports required for: 3.6, 3.7

#### Related Information

- [x] GitHub issue / Jira ticket number: https://github.com/arangodb/arangodb/issues/13117

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
