### PR TITLE
Fixed issue BTS-268: fix a flaky Foxx test.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.6.12 (XXXX-XX-XX)
 --------------------
 
-* Fixed issue BTS-268: fix a flaky Foxx test.
+* Fixed issue BTS-268: fix a flaky Foxx self-heal procedure.
 
 * Avoid a potential deadlock when dropping indexes.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.6.12 (XXXX-XX-XX)
 --------------------
 
+* Fixed issue BTS-268: fix a flaky Foxx test.
+
 * Avoid a potential deadlock when dropping indexes.
 
   A deadlock could theoretically happen for a thread that is attempting to drop

--- a/arangod/RestServer/BootstrapFeature.h
+++ b/arangod/RestServer/BootstrapFeature.h
@@ -41,6 +41,8 @@ class BootstrapFeature final : public application_features::ApplicationFeature {
 
  private:
   void waitForHealthEntry();
+  /// @brief wait for databases to appear in Plan and Current
+  void waitForDatabases() const;
  
  private:
   bool _isReady;


### PR DESCRIPTION
### Scope & Purpose

Try to stabilize a flaky foxx test.
Ideally, this could fix https://arangodb.atlassian.net/browse/BTS-268
The problem seems to have been a race a coordinator startup between databases appearing in Current and the JavaScript code that runs on coordinators at startup.

On initial start, the coordinator created the system database by writing an entry in the agency's Plan. It did not wait for the system database to appear in Current. So it happily went on executing the JavaScript startup code for coordinators, which iterates over all databases and registers an in-memory value for each.
In case all DB servers now created the system database in Current quickly enough, this was not a problem, and everything went fine.
However, in case not all DB servers created the system database in Current quickly enough, the code on the coordinator could already read the list of available databases and would get an empty array, due to the system database not being ready in Current yet.
Now we wait on coordinator startup for at least one database to appear. No change needs to be done on DB servers, and especially we cannot block there on startup, as the DB servers are responsible for creating the databases in Current themselves, so it is important that each DB server starts up and executes the maintenance to create missing databases.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-268

### Testing & Verification

- [x] This change is already covered by existing tests, such as *shell_server*.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/14027/