### PR TITLE
Remove outdated compile definitions for MSVC/Boost

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* For Windows builds, remove the defines `_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS`
+  and `_ENABLE_ATOMIC_ALIGNMENT_FIX` that were needed to build Boost components
+  with MSVC in older versions of Boost and MSVC.
+  Both of these defines are obsolete nowadays.
+
 * EE only bugfix: On DisjointSmartGraphs that are used in anonymous way,
   there was a chance that the query could fail, if non-disjoint collections
   were part of the query. Named DisjointSmartGraphs have been save to this bug.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -605,13 +605,6 @@ if (MSVC)
   add_definitions("-D_CRT_SECURE_NO_WARNINGS=1")
   add_definitions("-DFD_SETSIZE=8192")
   add_definitions("-DU_STATIC_IMPLEMENTATION=1")
-  add_definitions("-D_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS=1") # try to remove this when
-                                                                 # boost is upgraded to 1.70 or later
-
-  # https://blogs.msdn.microsoft.com/vcblog/2016/04/14/stl-fixes-in-vs-2015-update-2/
-  # https://connect.microsoft.com/VisualStudio/feedback/details/1892487
-  # http://lists.boost.org/boost-users/2016/04/85968.php
-  add_definitions("-D_ENABLE_ATOMIC_ALIGNMENT_FIX")
 
   # bcrypt is needed for SSL
   set(MSVC_LIBS Shlwapi.lib;crypt32.lib;bcrypt.lib;WINMM.LIB;Ws2_32.lib;Psapi.lib)


### PR DESCRIPTION
### Scope & Purpose

For Windows builds, remove the defines `_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS` and `_ENABLE_ATOMIC_ALIGNMENT_FIX` from our CMakeListst.txt.
These defines were needed to build Boost components with MSVC in older versions of Boost and MSVC.
Both of these defines are obsolete nowadays.

The `_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS` define was used inside Boost, but is not used there in the version we currently use.
The `_ENABLE_ATOMIC_ALIGNMENT_FIX` was necessary for MSVC to produce correct code in the past. It is also obsolete by now (refer to https://github.com/microsoft/STL/issues/717).

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/14036/