### PR TITLE
clean up after initial syncer changes, add tests

### DIFF
--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -1013,10 +1013,18 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
   std::string msg =
       "fetching collection keys for collection '" + coll->name() + "' from " + url;
   _config.progress.set(msg);
+  
+  // use a lower bound for maxWaitTime of 180M microseconds, i.e. 180 seconds
+  constexpr uint64_t lowerBoundForWaitTime = 180000000;
 
+  // note: maxWaitTime has a unit of microseconds
+  uint64_t maxWaitTime = _config.applier._initialSyncMaxWaitTime;
+  maxWaitTime = std::max<uint64_t>(maxWaitTime, lowerBoundForWaitTime);
+  
+
+  // the following two variables can be modified by the "keysCall" lambda
   VPackBuilder builder;
   VPackSlice slice;
-  auto maxWaitTime = _config.applier._initialSyncMaxWaitTime;
 
   auto keysCall = [&](bool quick) {
     // send an initial async request to collect the collection keys on the other
@@ -1082,6 +1090,8 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
                         _config.leader.endpoint);
         }
       }
+    
+      TRI_ASSERT(maxWaitTime >= lowerBoundForWaitTime);
 
       if (static_cast<uint64_t>(waitTime * 1000.0 * 1000.0) >= maxWaitTime) {
         ++stats.numFailedConnects;
@@ -1135,14 +1145,13 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
     return ck;
   }
   VPackSlice const c = slice.get("count");
-  uint64_t ndocs = 0;
-  if (c.isNumber()) {
-    ndocs = c.getNumber<uint64_t>();
-  } else {
+  if (!c.isNumber()) {
     return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                   std::string("got invalid response from master at ") +
                   _config.leader.endpoint + url + ": response count not a number");
-  }
+  } 
+    
+  uint64_t ndocs = c.getNumber<uint64_t>();
 
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
   if (ndocs > _quickKeysNumDocsLimit && slice.hasKey("id")) {
@@ -1153,9 +1162,21 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
 #endif
 
   if (!slice.hasKey("id")) { // we only have count
-    if (ndocs > 3750000) { // only bother beyond a 
-      maxWaitTime = ndocs * 80;
-    }
+    // calculate a wait time proportional to the number of documents on the leader
+    // if we get 1M documents back, the wait time is 80M microseconds, i.e. 80 seconds
+    // if we get 10M documents back, the wait time is 800M microseconds, i.e. 800 seconds
+    // ...
+    maxWaitTime = std::max<uint64_t>(maxWaitTime, ndocs * 80);
+
+    // there is an additional lower bound for the wait time as defined initially in
+    //    _config.applier._initialSyncMaxWaitTime
+    // we also apply an additional lower bound of 180 seconds here, in case that value
+    // is configured too low, for whatever reason
+    maxWaitTime = std::max<uint64_t>(maxWaitTime, lowerBoundForWaitTime);
+
+    TRI_ASSERT(maxWaitTime >= lowerBoundForWaitTime);
+    
+    // note: keysCall() can modify the "slice" variable
     ck = keysCall(false);
     if (!ck.ok()) {
       return ck;
@@ -1163,7 +1184,6 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
   }
 
   VPackSlice const keysId = slice.get("id");
-
   if (!keysId.isString()) {
     ++stats.numFailedConnects;
     return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,

--- a/arangod/Replication/ReplicationFeature.cpp
+++ b/arangod/Replication/ReplicationFeature.cpp
@@ -139,10 +139,10 @@ void ReplicationFeature::collectOptions(std::shared_ptr<ProgramOptions> options)
                      .setIntroducedIn(30409).setIntroducedIn(30504);
 
   options->addOption("--replication.quick-keys-limit",
-                     "Limit at which quick calls to replication keys return only a count for second run",
+                     "Limit at which 'quick' calls to the replication keys API return only the document count for second run",
                      new UInt64Parameter(&_quickKeysLimit),
                      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden))
-                     .setIntroducedIn(30708);
+                     .setIntroducedIn(30709).setIntroducedIn(30800);
 
   options
       ->addOption(

--- a/tests/js/client/shell/shell-quick-keys-noncluster.js
+++ b/tests/js/client/shell/shell-quick-keys-noncluster.js
@@ -1,0 +1,161 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global assertEqual, assertTrue, assertFalse, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief ArangoTransaction sTests
+// /
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2018 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// //////////////////////////////////////////////////////////////////////////////
+
+let jsunity = require('jsunity');
+let arangodb = require('@arangodb');
+let db = arangodb.db;
+
+function debugCanUseFailAt() {
+  let res = arango.GET('/_admin/debug/failat');
+  return res === true;
+}
+
+/// @brief set failure point
+function debugSetFailAt(failAt) {
+  let res = arango.PUT('/_admin/debug/failat/' + encodeURIComponent(failAt), {});
+  if (res !== true) {
+    throw "Error setting failure point";
+  }
+}
+
+function debugClearFailAt(endpoint) {
+  let res = arango.DELETE('/_admin/debug/failat');
+  if (res !== true) {
+    throw "Error removing failure points";
+  }
+}
+
+function quickKeysSuite() {
+  'use strict';
+  const cn = 'UnitTestsQuickKeys';
+
+  let createCollection = function(n) {
+    let c = db._create(cn);
+    let docs = [];
+    for (let i = 0; i < n; ++i) {
+      docs.push({ _key: "test" + i });
+    }
+    c.insert(docs);
+  };
+
+  let runTestForCount = function(n, quick, adjustQuickLimit) {
+    debugSetFailAt("disableRevisionsAsDocumentIds");
+    createCollection(n);
+    
+    let quickLimit = 1000000;
+    if (adjustQuickLimit) {
+      debugSetFailAt("RocksDBRestReplicationHandler::quickKeysNumDocsLimit100");
+      quickLimit = 100;
+    }
+
+    let batch = arango.POST('/_api/replication/batch', {});
+    try {
+      let url = '/_api/replication/keys?collection=' + encodeURIComponent(cn) + '&batchId=' + encodeURIComponent(batch.id);
+      if (quick) {
+        url += '&quick=true';
+      }
+      let keys = arango.POST(url, {}); 
+      if (n >= quickLimit && quick) {
+        assertFalse(keys.hasOwnProperty('id'));
+      } else {
+        assertTrue(keys.hasOwnProperty('id'));
+      }
+      assertTrue(keys.hasOwnProperty('count'));
+      assertEqual(n, keys.count);
+    } finally {
+      arango.DELETE('/_api/replication/batch/' + encodeURIComponent(batch.id));
+    }
+  };
+
+  return {
+
+    setUp: function () {
+      debugClearFailAt();
+      db._drop(cn);
+    },
+
+    tearDown: function () {
+      debugClearFailAt();
+      db._drop(cn);
+    },
+    
+    testKeys0: function () {
+      runTestForCount(0, false, false);
+    },
+    
+    testKeys1000: function () {
+      runTestForCount(1000, false, false);
+    },
+    
+    testKeys5000: function () {
+      runTestForCount(5000, false, false);
+    },
+    
+    testKeys0WithLowQuickLimit: function () {
+      runTestForCount(0, false, true);
+    },
+    
+    testKeys1000WithLowQuickLimit: function () {
+      runTestForCount(1000, false, true);
+    },
+    
+    testKeys5000WithLowQuickLimit: function () {
+      runTestForCount(5000, false, true);
+    },
+    
+    testKeys0WithQuick: function () {
+      runTestForCount(0, true, false);
+    },
+    
+    testKeys1000WithQuick: function () {
+      runTestForCount(1000, true, false);
+    },
+    
+    testKeys5000WithQuick: function () {
+      runTestForCount(5000, true, false);
+    },
+    
+    testKeys0WithQuickWithLowQuickLimit: function () {
+      runTestForCount(0, true, true);
+    },
+    
+    testKeys1000WithQuickWithLowQuickLimit: function () {
+      runTestForCount(1000, true, true);
+    },
+    
+    testKeys5000WithQuickWithLowQuickLimit: function () {
+      runTestForCount(5000, true, true);
+    },
+  };
+}
+
+if (debugCanUseFailAt()) {
+  // only execute if failure tests are available
+  jsunity.run(quickKeysSuite);
+}
+return jsunity.done();

--- a/tests/js/server/replication/sync/replication-sync-malarkey.js
+++ b/tests/js/server/replication/sync/replication-sync-malarkey.js
@@ -147,6 +147,108 @@ function BaseTestConfig () {
       clearFailurePoints();
       db._drop(cn);
     },
+    
+    testInsertRemoveInsertRemove: function () {
+      let c = db._create(cn);
+      let rev1 = c.insert({ _rev: "_b5TF-Oy---", _key: "a" }, { isRestore: true })._rev;
+      c.remove("a");
+      let rev2 = c.insert({ _rev: "_b5TF-Oy---", _key: "a" }, { isRestore: true })._rev;
+      c.remove("a");
+
+      assertEqual("_b5TF-Oy---", rev1);
+      assertEqual("_b5TF-Oy---", rev2);
+
+      connectToFollower();
+      db._flushCache();
+      c = db._create(cn);
+      
+      assertEqual("_b5TF-Oy---", c.insert({ _rev: "_b5TF-Oy---", _key: "a" }, { isRestore: true })._rev);
+      assertEqual("_b5TF-Oy---", c.document("a")._rev);
+      assertEqual("_b5TF-Oz---", c.insert({ _rev: "_b5TF-Oz---", _key: "b" }, { isRestore: true })._rev);
+      assertEqual("_b5TF-Oz---", c.document("b")._rev);
+
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      c = db._collection(cn);
+     
+      checkCountConsistency(cn, 0);
+    },
+    
+    testInsertRemoveInsertRemoveInsert: function () {
+      let c = db._create(cn);
+      let rev1 = c.insert({ _rev: "_b5TF-Oy---", _key: "a" }, { isRestore: true })._rev;
+      c.remove("a");
+      let rev2 = c.insert({ _rev: "_b5TF-Oy---", _key: "a" }, { isRestore: true })._rev;
+      c.remove("a");
+      let rev3 = c.insert({ _rev: "_b5TF-Oy---", _key: "a" }, { isRestore: true })._rev;
+
+      assertEqual("_b5TF-Oy---", rev1);
+      assertEqual("_b5TF-Oy---", rev2);
+      assertEqual("_b5TF-Oy---", rev3);
+
+      connectToFollower();
+      db._flushCache();
+      c = db._create(cn);
+      
+      assertEqual("_b5TF-Oy---", c.insert({ _rev: "_b5TF-Oy---", _key: "a" }, { isRestore: true })._rev);
+      assertEqual("_b5TF-Oy---", c.document("a")._rev);
+      assertEqual("_b5TF-Oz---", c.insert({ _rev: "_b5TF-Oz---", _key: "b" }, { isRestore: true })._rev);
+      assertEqual("_b5TF-Oz---", c.document("b")._rev);
+
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      c = db._collection(cn);
+     
+      assertEqual(rev1, c.document("a")._rev);
+     
+      checkCountConsistency(cn, 1);
+    },
+
+    testSecondaryIndexConflicts: function () {
+      let c = db._create(cn);
+      c.ensureIndex({ type: "hash", fields: ["value"], unique: true });
+
+      let rev1 = c.insert({ _rev: "_b5TF-Oy---", _key: "a", value: 1 }, { isRestore: true })._rev;
+      let rev2 = c.insert({ _rev: "_b5TGvDC---", _key: "b", value: 2 }, { isRestore: true })._rev;
+      let rev3 = c.insert({ _rev: "_b5TGwvm---", _key: "c", value: 3 }, { isRestore: true })._rev;
+      
+      assertEqual("_b5TF-Oy---", rev1);
+      assertEqual("_b5TGvDC---", rev2);
+      assertEqual("_b5TGwvm---", rev3);
+
+      connectToFollower();
+      db._flushCache();
+      c = db._create(cn);
+      c.ensureIndex({ type: "hash", fields: ["value"], unique: true });
+      
+      assertEqual("_b5TF-Oy---", c.insert({ _rev: "_b5TF-Oy---", _key: "b", value: 3 }, { isRestore: true })._rev);
+      assertEqual("_b5TGwvm---", c.insert({ _rev: "_b5TGwvm---", _key: "c", value: 2 }, { isRestore: true })._rev);
+
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      c = db._collection(cn);
+      
+      assertEqual(rev1, c.document("a")._rev);
+      assertEqual(rev2, c.document("b")._rev);
+      assertEqual(rev3, c.document("c")._rev);
+     
+      checkCountConsistency(cn, 3);
+    },
 
     // create different state on follower
     testDowngradeManyRevisions: function () {


### PR DESCRIPTION
### Scope & Purpose

Cleanup after initial syncer "quick" feature addition (https://github.com/arangodb/arangodb/pull/13394) was merged:
- fixes wrong version number for new startup option
- adds code comments
- adds new test that explicitly tests the "quick" parameter
- adds missing lower bound for the wait time

Re the last point, the previous calculation used a default value of 300 implictly, but in a non-obvious way:
```
if (ndocs > 3750000) { // only bother beyond a 
  maxWaitTime = ndocs * 80;
}
```
This would fall apart if the default value of 300 seconds for the wait time was ever adjusted, and it was not obvious in the code how 3850000 and the default wait time were related.

This is now
```
// use a lower bound for maxWaitTime of 180M microseconds, i.e. 180 seconds
constexpr uint64_t lowerBoundForWaitTime = 180000000;
  
...

// calculate a wait time proportional to the number of documents on the leader
// if we get 1M documents back, the wait time is 80M microseconds, i.e. 80 seconds
// if we get 10M documents back, the wait time is 800M microseconds, i.e. 800 seconds
// ...
maxWaitTime = std::max<uint64_t>(maxWaitTime, ndocs * 80);

// there is an additional lower bound for the wait time as defined initially in
//    _config.applier._initialSyncMaxWaitTime
// we also apply an additional lower bound of 180 seconds here, in case that value
// is configured too low, for whatever reason
maxWaitTime = std::max<uint64_t>(maxWaitTime, lowerBoundForWaitTime);
```

As this is an internal cleanup only, there is intentionally no CHANGELOG entry for it.
There was a CHANGELOG entry for the original PR already, which should be enough.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [x] Backports required for: *3.7* (will be done in https://github.com/arangodb/arangodb/pull/13359)

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_client)

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/14039/