### PR TITLE
fix version number for options additions

### DIFF
--- a/arangod/RestServer/MetricsFeature.cpp
+++ b/arangod/RestServer/MetricsFeature.cpp
@@ -68,7 +68,7 @@ void MetricsFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                      "turn metrics for document read/write metrics on or off",
                      new BooleanParameter(&_exportReadWriteMetrics),
                      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden))
-                     .setIntroducedIn(30708);
+                     .setIntroducedIn(30707);
 }
 
 bool MetricsFeature::exportAPI() const {

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -124,7 +124,7 @@ void LoggerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options
       ->addOption("--log.max-entry-length", "maximum length of a log entry (in bytes)",
                   new UInt32Parameter(&_maxEntryLength))
-      .setIntroducedIn(30800);
+      .setIntroducedIn(30709);
 
   options
       ->addOption("--log.use-local-time", "use local timezone instead of UTC",


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/651

Fix wrong version numbers introduced for backported logging options.
The docs say the options are available in 3.7.8, and that was also the idea.
However, 3.7.8 was built based on 3.7.7 with just a single commit on top, and that rendered all plans invalid.
This PR fixes the version number in the docs to 3.7.9, which will be the real release these options become available.
It also fixes the version number for another option, which was planned for 3.7.8, but was then introduced in 3.7.7.

This change only affects the docs, so there is intentionally no CHANGELOG entry for it.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/622
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/651

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/14045/