### PR TITLE
add optional hyperlink for program option sections, add subheadlines

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Add optional hyperlink to program option sections for information purposes,
+  and add optional sub-headlines to program options for better grouping.
+  These changes will be visible only when using `--help`.
+
 * For Windows builds, remove the defines `_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS`
   and `_ENABLE_ATOMIC_ALIGNMENT_FIX` that were needed to build Boost components
   with MSVC in older versions of Boost and MSVC.

--- a/lib/ApplicationFeatures/ApplicationServer.cpp
+++ b/lib/ApplicationFeatures/ApplicationServer.cpp
@@ -290,7 +290,7 @@ void ApplicationServer::apply(std::function<void(ApplicationFeature&)> callback,
 void ApplicationServer::collectOptions() {
   LOG_TOPIC("0eac7", TRACE, Logger::STARTUP) << "ApplicationServer::collectOptions";
 
-  _options->addSection(Section("", "Global configuration", "global options", false, false));
+  _options->addSection(Section("", "Global configuration", "", "global options", false, false));
 
   _options->addOption("--dump-dependencies", "dump dependency graph",
                       new BooleanParameter(&_dumpDependencies),

--- a/lib/ApplicationFeatures/ShellColorsFeature.cpp
+++ b/lib/ApplicationFeatures/ShellColorsFeature.cpp
@@ -60,6 +60,9 @@ char const* ShellColorsFeature::SHELL_COLOR_BOLD_MAGENTA = NoColor;
 char const* ShellColorsFeature::SHELL_COLOR_BLINK = NoColor;
 char const* ShellColorsFeature::SHELL_COLOR_BRIGHT = NoColor;
 char const* ShellColorsFeature::SHELL_COLOR_RESET = NoColor;
+char const* ShellColorsFeature::SHELL_COLOR_LINK_START = NoColor;
+char const* ShellColorsFeature::SHELL_COLOR_LINK_MIDDLE = NoColor;
+char const* ShellColorsFeature::SHELL_COLOR_LINK_END = NoColor;
 
 ShellColorsFeature::ShellColorsFeature(application_features::ApplicationServer& server)
     : ApplicationFeature(server, "ShellColors"), _initialized(false) {
@@ -99,6 +102,9 @@ void ShellColorsFeature::prepare() {
     SHELL_COLOR_BLINK = "\x1b[5m";
     SHELL_COLOR_BRIGHT = "\x1b[1m";
     SHELL_COLOR_RESET = "\x1b[0m";
+    SHELL_COLOR_LINK_START = "\x1b]8;;";
+    SHELL_COLOR_LINK_MIDDLE = "\x1b\\";
+    SHELL_COLOR_LINK_END = "\x1b]8;;\x1b\\";
   }
 }
 

--- a/lib/ApplicationFeatures/ShellColorsFeature.h
+++ b/lib/ApplicationFeatures/ShellColorsFeature.h
@@ -61,6 +61,9 @@ class ShellColorsFeature final : public application_features::ApplicationFeature
   static char const* SHELL_COLOR_BLINK;
   static char const* SHELL_COLOR_BRIGHT;
   static char const* SHELL_COLOR_RESET;
+  static char const* SHELL_COLOR_LINK_START;
+  static char const* SHELL_COLOR_LINK_MIDDLE;
+  static char const* SHELL_COLOR_LINK_END;
 
  private:
   bool _initialized;

--- a/lib/ProgramOptions/ProgramOptions.cpp
+++ b/lib/ProgramOptions/ProgramOptions.cpp
@@ -70,6 +70,23 @@ void ProgramOptions::setTranslator(
     std::function<std::string(std::string const&, char const*)> const& translator) {
   _translator = translator;
 }
+  
+// adds a sub-headline for one option or a group of options
+void ProgramOptions::addHeadline(std::string const& prefix, std::string const& description) {
+  checkIfSealed();
+  
+  auto parts = Option::splitName(prefix);
+  if (parts.first.empty()) {
+    std::swap(parts.first, parts.second);
+  }
+  auto it = _sections.find(parts.first);
+
+  if (it == _sections.end()) {
+    throw std::logic_error(std::string("section '") + parts.first + "' not found");
+  }
+    
+  (*it).second.headlines[parts.second] = description;
+}
 
 // prints usage information
 void ProgramOptions::printUsage() const {
@@ -143,6 +160,9 @@ VPackBuilder ProgramOptions::toVPack(bool onlyTouched, bool detailed,
         if (detailed) {
           builder.openObject();
           builder.add("section", VPackValue(option.section));
+          if (!section.link.empty()) {
+            builder.add("link", VPackValue(section.link));
+          }
           builder.add("description", VPackValue(option.description));
           builder.add("category", VPackValue(option.hasFlag(arangodb::options::Flags::Command)
                                                  ? "command"

--- a/lib/ProgramOptions/ProgramOptions.h
+++ b/lib/ProgramOptions/ProgramOptions.h
@@ -140,13 +140,13 @@ class ProgramOptions {
   }
 
   // adds a (regular) section to the program options
-  auto addSection(std::string const& name, std::string const& description) {
-    return addSection(Section(name, description, "", false, false));
+  auto addSection(std::string const& name, std::string const& description, std::string const& link = "") {
+    return addSection(Section(name, description, link, "", false, false));
   }
 
   // adds an enterprise-only section to the program options
-  auto addEnterpriseSection(std::string const& name, std::string const& description) {
-    return addSection(EnterpriseSection(name, description, "", false, false));
+  auto addEnterpriseSection(std::string const& name, std::string const& description, std::string const& link = "") {
+    return addSection(EnterpriseSection(name, description, link, "", false, false));
   }
 
   // adds an option to the program options
@@ -164,6 +164,9 @@ class ProgramOptions {
                      makeFlags(Flags::Hidden, Flags::Obsolete)));
     return getOption(name);
   }
+ 
+  // adds a sub-headline for one option or a group of options
+  void addHeadline(std::string const& prefix, std::string const& description);
 
   // prints usage information
   void printUsage() const;

--- a/lib/ProgramOptions/Section.cpp
+++ b/lib/ProgramOptions/Section.cpp
@@ -48,22 +48,44 @@ void Section::printHelp(std::string const& search, size_t tw, size_t ow, bool co
     return;
   }
 
-  if (colors) {
-    std::cout << "Section '" << ShellColorsFeature::SHELL_COLOR_BRIGHT
-              << displayName() << ShellColorsFeature::SHELL_COLOR_RESET << "' ("
-              << description << ")" << std::endl;
-  } else {
-    std::cout << "Section '" << displayName() << "' (" << description << ")" << std::endl;
+  std::cout 
+    << "Section '" 
+    << (colors ? ShellColorsFeature::SHELL_COLOR_BRIGHT : "")
+    << displayName() 
+    << (colors ? ShellColorsFeature::SHELL_COLOR_RESET : "")
+    << "' (" << description << ")";
+
+  if (!link.empty()) {
+    std::cout << " [";
+    if (colors) {
+      std::cout 
+        << ShellColorsFeature::SHELL_COLOR_LINK_START << link 
+        << ShellColorsFeature::SHELL_COLOR_LINK_MIDDLE << link 
+        << ShellColorsFeature::SHELL_COLOR_LINK_END;
+    } else {
+      std::cout << link;
+    }
+    std::cout << "]";
   }
+  std::cout << std::endl;
+
+  auto hl = headlines.begin();
 
   // propagate print command to options
   for (auto const& it : options) {
+    if (hl != headlines.end() && it.first > (*hl).first) {
+      // must print a headline
+      std::cout << " # " << (*hl).second << std::endl;
+      ++hl;
+    }
+
+    // print help for option
     it.second.printHelp(search, tw, ow, colors);
   }
 
   std::cout << std::endl;
 }
-
+  
 // determine display width for a section
 size_t Section::optionsWidth() const {
   size_t width = 0;

--- a/lib/ProgramOptions/Section.cpp
+++ b/lib/ProgramOptions/Section.cpp
@@ -73,7 +73,7 @@ void Section::printHelp(std::string const& search, size_t tw, size_t ow, bool co
 
   // propagate print command to options
   for (auto const& it : options) {
-    if (hl != headlines.end() && it.first > (*hl).first) {
+    if (hl != headlines.end() && it.first >= (*hl).first) {
       // must print a headline
       std::cout << " # " << (*hl).second << std::endl;
       ++hl;

--- a/lib/ProgramOptions/Section.h
+++ b/lib/ProgramOptions/Section.h
@@ -37,9 +37,11 @@ struct Section {
   // sections are default copy-constructible and default movable
 
   Section(std::string const& name, std::string const& description,
-          std::string const& alias, bool hidden, bool obsolete)
+          std::string const& link, std::string const& alias, 
+          bool hidden, bool obsolete)
       : name(name),
         description(description),
+        link(link),
         alias(alias),
         hidden(hidden),
         obsolete(obsolete),
@@ -47,7 +49,7 @@ struct Section {
 
   // get display name for the section
   std::string displayName() const { return alias.empty() ? name : alias; }
-
+  
   // whether or not the section has (displayable) options
   bool hasOptions() const;
 
@@ -61,6 +63,7 @@ struct Section {
 
   std::string name;
   std::string description;
+  std::string link;
   std::string alias;
   bool hidden;
   bool obsolete;
@@ -68,14 +71,18 @@ struct Section {
 
   // program options of the section
   std::map<std::string, Option> options;
+  
+  // sub-headlines
+  std::map<std::string, std::string> headlines;
 };
 
 /// @brief section only available in enterprise builds
 /// must have the same storage layout as struct Section
 struct EnterpriseSection : public Section {
   EnterpriseSection(std::string const& name, std::string const& description,
-                    std::string const& alias, bool hidden, bool obsolete)
-      : Section(name, description, alias, hidden, obsolete) {
+                    std::string const& link, std::string const& alias, 
+                    bool hidden, bool obsolete)
+      : Section(name, description, link, alias, hidden, obsolete) {
     enterpriseOnly = true;
   }
 };


### PR DESCRIPTION
### Scope & Purpose

Small improvements for program options documentation:
* add optional hyperlink to program option sections, so that one can link to our docs
* add optional subheadlines to program options, so that it is possible to add better grouping

This is experimental and may not be followed to the end.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/14048/