### PR TITLE
fix a potential wrong length calculation after log messages were shrunk

### DIFF
--- a/lib/Logger/LogBufferFeature.cpp
+++ b/lib/Logger/LogBufferFeature.cpp
@@ -212,11 +212,11 @@ void LogBufferFeature::collectOptions(std::shared_ptr<options::ProgramOptions> o
 }
 
 void LogBufferFeature::prepare() {
-    LogLevel level;
-    bool isValid = Logger::translateLogLevel(_minInMemoryLogLevel, true, level);
-    if (!isValid) {
-      level = LogLevel::INFO;
-    }
+  LogLevel level;
+  bool isValid = Logger::translateLogLevel(_minInMemoryLogLevel, true, level);
+  if (!isValid) {
+    level = LogLevel::INFO;
+  }
 
   // only create the in-memory appender when we really need it. if we created it
   // in the ctor, we would waste a lot of memory in case we don't need the in-memory

--- a/lib/Logger/LogBufferFeature.cpp
+++ b/lib/Logger/LogBufferFeature.cpp
@@ -208,7 +208,7 @@ void LogBufferFeature::collectOptions(std::shared_ptr<options::ProgramOptions> o
                   new DiscreteValuesParameter<StringParameter>(
                       &_minInMemoryLogLevel, logLevels),
                   arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden))
-                  .setIntroducedIn(30708);
+                  .setIntroducedIn(30709);
 }
 
 void LogBufferFeature::prepare() {

--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -387,18 +387,23 @@ void Logger::log(char const* function, char const* file, int line,
     StringUtils::itoa(uint64_t(line), out);
     out.append("] ", 2);
   }
+  
+  size_t offset = out.size();
 
   // generate the complete message
   out.append(message);
-
+  
   uint32_t maxLength = _maxEntryLength;
   // truncate message to maximum size
   if (out.size() > maxLength) {
     out.resize(maxLength);
     out.append("...", 3);
+
+    if (offset > maxLength) {
+      offset = maxLength;
+    }
   }
  
-  size_t offset = out.size() - message.size();
   auto msg = std::make_unique<LogMessage>(function, file, line, level, topicId, std::move(out), offset);
 
   // first log to all "global" appenders, which are the in-memory ring buffer logger plus

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -97,13 +97,6 @@ struct LogMessage {
         _message(std::move(message)),
         _offset(offset) {}
 
-  void shrink(std::size_t maxLength) {
-    if (_message.size() > maxLength) {
-      _message.resize(maxLength);
-      _message.append("...", 3);
-    }
-  }
-
   char const* _function;
   char const* _file;
   int const _line;


### PR DESCRIPTION
### Scope & Purpose

Fix a potentially wrong length calculation after log messages were shrunk.

Reproduction: compile with ASan and execute:
```
scripts/unittest server_parameters --test log-max --cluster true
```

ASan errors are gone with the fix in place.

New ASan run:
http://172.16.10.101:8080/job/arangodb-ANY-linux-asan/560/

This is a fix for a yet-unreleased feature, so intentionally no CHANGELOG entry added for it.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *server_parameters*.
- [x] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/14050/
http://172.16.10.101:8080/job/arangodb-ANY-linux-asan/560/