### PR TITLE
move some parts of LogMessage from header to cpp file

### DIFF
--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -102,7 +102,7 @@ void LogMessage::shrink(std::size_t maxLength) {
     if (_offset > _message.size()) {
       // we need to make sure that the offset is not outside of the message
       // after shrinking
-      _offset = _message.size();
+      _offset = static_cast<uint32_t>(_message.size());
     }
     _message.append("...", 3);
     _shrunk = true;

--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -78,6 +78,37 @@ class DefaultLogGroup final : public LogGroup {
 DefaultLogGroup defaultLogGroupInstance;
 
 }  // namespace
+  
+LogMessage::LogMessage(char const* function, char const* file, int line,
+                       LogLevel level, size_t topicId, std::string&& message, 
+                       uint32_t offset, bool shrunk) noexcept
+    : _function(function),
+      _file(file),
+      _line(line),
+      _level(level),
+      _topicId(topicId),
+      _message(std::move(message)),
+      _offset(offset),
+      _shrunk(shrunk) {}
+  
+void LogMessage::shrink(std::size_t maxLength) {
+  // no need to shrink an already shrunk message
+  if (!_shrunk && _message.size() > maxLength) {
+    _message.resize(maxLength);
+
+    // normally, offset should be around 20 to 30 bytes,
+    // whereas the minimum for maxLength should be around 256 bytes.
+    TRI_ASSERT(maxLength > _offset);
+    if (_offset > _message.size()) {
+      // we need to make sure that the offset is not outside of the message
+      // after shrinking
+      _offset = _message.size();
+    }
+    _message.append("...", 3);
+    _shrunk = true;
+  }
+}
+
 
 Mutex Logger::_initializeMutex;
 

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -87,27 +87,13 @@ struct LogMessage {
 
   LogMessage(char const* function, char const* file, int line,
              LogLevel level, size_t topicId, std::string&& message, 
-             uint32_t offset, bool shrunk)
-      : _function(function),
-        _file(file),
-        _line(line),
-        _level(level),
-        _topicId(topicId),
-        _message(std::move(message)),
-        _offset(offset),
-        _shrunk(shrunk) {}
+             uint32_t offset, bool shrunk) noexcept;
 
   /// @brief whether or no the message was already shrunk
   bool shrunk() const noexcept { return _shrunk; }
 
-  void shrink(std::size_t maxLength) {
-    // no need to shrink an already shrunk message
-    if (!_shrunk && _message.size() > maxLength) {
-      _message.resize(maxLength);
-      _message.append("...", 3);
-      _shrunk = true;
-    }
-  }
+  /// @brief shrink log message to at most maxLength bytes (plus "..." appended)
+  void shrink(std::size_t maxLength);
 
   /// @brief all details about the log message. we need to
   /// keep all this data around and not just the big log
@@ -127,7 +113,7 @@ struct LogMessage {
   /// @biref the actual log message
   std::string _message;
   /// @brief byte offset where actual message starts (i.e. excluding prologue)
-  uint32_t const _offset;
+  uint32_t _offset;
   /// @brief whether or not the log message was already shrunk (used to
   /// prevent duplicate shrinking of message)
   bool _shrunk;


### PR DESCRIPTION
### Scope & Purpose

Small cleanup for some logging code

* moved some parts of LogMessage from header to cpp file, so less recompilation will be required if that code is changed later on
* verify that `_offset` does not point outside the log message after shrinking. this is very unlikely, because offset is something between 20 or 30 characters only, and the minimum log message length for shrinking is 256 characters. so it is a theoretical issue right now, but the fix will be useful should the limits/bounds be changed later.

Inspired by a fix that was necessary for 3.7, but didn't affect devel: https://github.com/arangodb/arangodb/pull/13580

Intentionally no CHANGELOG entry written, as it is an internal code cleanup PR only, without effects for end users.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is already covered by existing tests, such as *server_parameters*.

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/14051/