### PR TITLE
Add JWT secret support for arangodump and arangorestore

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Add JWT secret support for arangodump and arangorestore, i.e. they now also
+  provide the command-line options `--server.ask-jwt-secret` and 
+  `--server.jwt-secret-keyfile` with the same meanings as in arangosh.
+
 * For Windows builds, remove the defines `_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS`
   and `_ENABLE_ATOMIC_ALIGNMENT_FIX` that were needed to build Boost components
   with MSVC in older versions of Boost and MSVC.

--- a/arangosh/CMakeLists.txt
+++ b/arangosh/CMakeLists.txt
@@ -119,6 +119,7 @@ target_link_libraries(${BIN_ARANGOBACKUP}
   boost_system
   boost_boost
   arango_shell
+  fuerte
 )
 
 install(

--- a/arangosh/CMakeLists.txt
+++ b/arangosh/CMakeLists.txt
@@ -178,6 +178,7 @@ target_link_libraries(${BIN_ARANGODUMP}
   boost_system
   boost_boost
   arango_shell
+  fuerte
 )
 
 install(
@@ -358,6 +359,7 @@ target_link_libraries(${BIN_ARANGORESTORE}
   boost_system
   boost_boost
   arango_shell
+  fuerte
 )
 
 install(

--- a/arangosh/Dump/arangodump.cpp
+++ b/arangosh/Dump/arangodump.cpp
@@ -72,7 +72,7 @@ int main(int argc, char* argv[]) {
     server.addFeature<BasicFeaturePhaseClient>();
     server.addFeature<GreetingsFeaturePhase>(true);
 
-    server.addFeature<ClientFeature, HttpEndpointProvider>(false);
+    server.addFeature<ClientFeature, HttpEndpointProvider>(true);
     server.addFeature<ConfigFeature>("arangodump");
     server.addFeature<DumpFeature>(ret);
     server.addFeature<LoggerFeature>(false);

--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -1855,6 +1855,8 @@ void RestoreFeature::start() {
     if (result.fail()) {
       break;
     }
+    
+    _progressTracker->cleanup();
   }
 
   if (result.fail()) {

--- a/arangosh/Restore/arangorestore.cpp
+++ b/arangosh/Restore/arangorestore.cpp
@@ -64,7 +64,7 @@ int main(int argc, char* argv[]) {
     server.addFeature<CommunicationFeaturePhase>();
     server.addFeature<GreetingsFeaturePhase>(true);
 
-    server.addFeature<ClientFeature, HttpEndpointProvider>(false);
+    server.addFeature<ClientFeature, HttpEndpointProvider>(true);
     server.addFeature<ConfigFeature>("arangorestore");
     server.addFeature<LoggerFeature>(false);
     server.addFeature<RandomFeature>();

--- a/arangosh/Utils/ClientManager.cpp
+++ b/arangosh/Utils/ClientManager.cpp
@@ -33,6 +33,8 @@
 #include "SimpleHttpClient/SimpleHttpClient.h"
 #include "SimpleHttpClient/SimpleHttpResult.h"
 
+#include <fuerte/jwt.h>
+
 namespace {
 
 arangodb::Result getHttpErrorMessage(arangodb::httpclient::SimpleHttpResult* result) {
@@ -95,6 +97,9 @@ Result ClientManager::getConnectedClient(std::unique_ptr<httpclient::SimpleHttpC
   std::string dbName = client.databaseName();
   httpClient->params().setLocationRewriter(static_cast<void*>(&client), &rewriteLocation);
   httpClient->params().setUserNamePassword("/", client.username(), client.password());
+  if (!client.jwtSecret().empty()) {
+    httpClient->params().setJwt(fuerte::jwt::generateInternalToken(client.jwtSecret(), client.endpoint()));
+  }
 
   // now connect by retrieving version
   ErrorCode errorCode = TRI_ERROR_NO_ERROR;

--- a/arangosh/Utils/ClientManager.h
+++ b/arangosh/Utils/ClientManager.h
@@ -36,7 +36,6 @@ class ApplicationServer;
 }
 namespace httpclient {
 class SimpleHttpClient;
-class SimpleHttpResult;
 }  // namespace httpclient
 
 /**

--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -85,8 +85,12 @@ class ConfigBuilder {
   }
 
   setAuth(username, password) {
-    this.config['server.username'] = username;
-    this.config['server.password'] = password;
+    if (username !== undefined) {
+      this.config['server.username'] = username;
+    }
+    if (password !== undefined) {
+      this.config['server.password'] = password;
+    }
   }
   setEndpoint(endpoint) { this.config['server.endpoint'] = endpoint; }
   setDatabase(database) {
@@ -117,6 +121,10 @@ class ConfigBuilder {
     } else {
       this.config['create-database'] = 'false';
     }
+  }
+  setJwtFile(file) {
+    delete this.config['server.password'];
+    this.config['server.jwt-secret-keyfile'] = file;
   }
   setMaskings(dir) {
     if (this.type !== 'dump') {
@@ -189,7 +197,9 @@ class ConfigBuilder {
 
 const createBaseConfigBuilder = function (type, options, instanceInfo, database = '_system') {
   const cfg = new ConfigBuilder(type);
-  cfg.setAuth(options.username, options.password);
+  if (!options.jwtSecret) {
+    cfg.setAuth(options.username, options.password);
+  }
   cfg.setDatabase(database);
   cfg.setEndpoint(instanceInfo.endpoint);
   cfg.setRootDir(instanceInfo.rootDir);


### PR DESCRIPTION
### Scope & Purpose

Add JWT secret support for arangodump and arangorestore, i.e. they now also provide the command-line options `--server.ask-jwt-secret` and `--server.jwt-secret-keyfile` with the same meanings as in arangosh.

This also adds a new test suite `dump_jwt` to the tests.

Oskar PR: https://github.com/arangodb/oskar/pull/293

Blocklist PRs for older branches:
* 3.6: arangodb/arangodb#13586
* 3.7: arangodb/arangodb#13587


- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. dump_jwt)

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/14054/