### PR TITLE
better visualize time consumed during setup / teardown

### DIFF
--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -601,7 +601,7 @@ function locateLongRunning(options, results, otherResults) {
                 sortedByDuration[i].test.totalSetUp +
                 sortedByDuration[i].test.totalTearDown) / 1000) + "] - " +
             sortedByDuration[i].testName.replace('/\\/g', '/');
-        let setupStatistics = []
+        let setupStatistics = [];
         if (_.size(sortedByDuration[i].test.setUpAllDuration) > 1) {
           let sortStart = [];
           let d = sortedByDuration[i].test.setUpAllDuration;


### PR DESCRIPTION
### Scope & Purpose

This PR adds the setup/teardown times to the `locateLongRunning` analyzer suite:

```
shell_client - startup [1.005397081375122] => run [12.465092658996582] => shutdown [3.002624034881592]
' - 0:12 - ^ 0:01 v 0:00 - 9 - [0:13] - tests/js/common/shell/shell-pregel-4.js':
  processStatistics:
    minorPageFaults: 79432
    majorPageFaults: 160
    userTime: 10.71
    systemTime: 1.3499999999999999
    numberOfThreads: 3
    residentSize: 48750592
    residentSizePercent: 0.0007243830738783703
    virtualSize: 1779642368
    rchar: 54943
    wchar: 11176252
    syscr: 6825
    syscw: 13060
    read_bytes: 155648
    write_bytes: 13414400
    cancelled_write_bytes: 2134016
  stats:
    - '0:04 - testMultiWCCParallelismMemoryMapping'
    - '0:04 - testMultiWCCParallelism'
    - '0:01 - testMultiWCC'
    - '0:00 - testWithEdgeCollectionRestrictions'
    - '0:00 - testNoEdgeCollectionRestrictions'
  setupStatistics:
    - '0:01 - multiCollectionTestSuite'
    - '0:00 - edgeCollectionRestrictionsTestSuite'
```
new here:
 - `' - 0:12 - ^ 0:01 v 0:00 - 9 - [0:13] - tests/js/common/shell/shell-pregel-4.js':` is the summaries of `^ => setup` and `v => teardown`
 - `setupStatistics` is per testsuite (if multiple testsuites are in one file); 
