### PR TITLE
3.7: added elapsed time logging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.7.9 (XXXX-XX-XX)
 -------------------
 
+* added logging of elapsed time of ArangoSearch commit/consolidation/cleanup jobs
+
 * Fix too early stop of replication, when waiting for keys in large
   collections/shards.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,8 @@
 v3.7.9 (XXXX-XX-XX)
 -------------------
 
-* added logging of elapsed time of ArangoSearch commit/consolidation/cleanup jobs
+* Added logging of elapsed time of ArangoSearch commit/consolidation/cleanup
+  jobs.
 
 * Fix too early stop of replication, when waiting for keys in large
   collections/shards.

--- a/arangod/IResearch/IResearchLink.cpp
+++ b/arangod/IResearch/IResearchLink.cpp
@@ -405,13 +405,16 @@ void CommitTask::operator()() {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
+  auto const syncStart = std::chrono::steady_clock::now(); // FIXME: add sync durations to metrics
   auto res = link->commitUnsafe(false, &code); // run commit ('_asyncSelf' locked by async task)
 
   if (res.ok()) {
     LOG_TOPIC("7e323", TRACE, iresearch::TOPIC)
         << "successful sync of arangosearch link '" << id
-        << "', run id '" << size_t(&runId) << "'";
-
+        << "', run id '" << size_t(&runId) << "', took: " << 
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::steady_clock::now() - syncStart).count()
+        << "ms";
     if (code == IResearchLink::CommitResult::DONE) {
       if (cleanupIntervalStep && cleanupIntervalCount++ > cleanupIntervalStep) { // if enabled
         cleanupIntervalCount = 0;
@@ -420,15 +423,22 @@ void CommitTask::operator()() {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
 
+        auto const cleanupStart = std::chrono::steady_clock::now(); // FIXME: add cleanup durations to metrics
         res = link->cleanupUnsafe(); // run cleanup ('_asyncSelf' locked by async task)
 
         if (res.ok()) {
           LOG_TOPIC("7e821", TRACE, iresearch::TOPIC)
               << "successful cleanup of arangosearch link '" << id
-              << "', run id '" << size_t(&runId) << "'";
+              << "', run id '" << size_t(&runId) << "', took: " << 
+              std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - cleanupStart).count()
+              << "ms";
         } else {
           LOG_TOPIC("130de", WARN, iresearch::TOPIC)
-              << "error while cleaning up arangosearch link '" << id
+              << "error after running for " <<
+              std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - cleanupStart).count()
+              << "ms while cleaning up arangosearch link '" << id
               << "', run id '" << size_t(&runId)
               << "': " << res.errorNumber() << " " << res.errorMessage();
         }
@@ -436,7 +446,10 @@ void CommitTask::operator()() {
     }
   } else {
     LOG_TOPIC("8377b", WARN, iresearch::TOPIC)
-        << "error while committing arangosearch link '" << link->id()
+        << "error after running for " <<
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::steady_clock::now() - syncStart).count()
+        << "ms while committing arangosearch link '" << link->id()
         << "', run id '" << size_t(&runId)
         << "': " << res.errorNumber() << " " << res.errorMessage();
   }
@@ -542,6 +555,7 @@ void ConsolidationTask::operator()() {
   }
 
   // run consolidation ('_asyncSelf' locked by async task)
+  auto const consolidationStart = std::chrono::steady_clock::now(); // FIXME: add consolidation durations to metrics
   bool emptyConsolidation = false;
   auto const res = link->consolidateUnsafe(consolidationPolicy, progress, emptyConsolidation);
 
@@ -551,13 +565,18 @@ void ConsolidationTask::operator()() {
     } else {
        state->noopConsolidationCount = 0;
     }
-
     LOG_TOPIC("7e828", TRACE, iresearch::TOPIC)
         << "successful consolidation of arangosearch link '" << link->id()
-        << "', run id '" << size_t(&runId) << "'";
+        << "', run id '" << size_t(&runId) << "', took: " << 
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::steady_clock::now() - consolidationStart).count()
+        << "ms";
   } else {
     LOG_TOPIC("bce4f", DEBUG, iresearch::TOPIC)
-        << "error while consolidating arangosearch link '" << link->id()
+        << "error after running for " <<
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::steady_clock::now() - consolidationStart).count()
+        << "ms while consolidating arangosearch link '" << link->id()
         << "', run id '" << size_t(&runId)
         << "': " << res.errorNumber() << " " << res.errorMessage();
   }


### PR DESCRIPTION
### Scope & Purpose

added logging of elapsed time of ArangoSearch commit/consolidation/cleanup jobs

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made


### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:
https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/14116/