### PR TITLE
Docs: Don't list implied introducedIn versions

### DIFF
--- a/arangod/Replication/ReplicationFeature.cpp
+++ b/arangod/Replication/ReplicationFeature.cpp
@@ -142,7 +142,7 @@ void ReplicationFeature::collectOptions(std::shared_ptr<ProgramOptions> options)
                      "Limit at which 'quick' calls to the replication keys API return only the document count for second run",
                      new UInt64Parameter(&_quickKeysLimit),
                      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden))
-                     .setIntroducedIn(30709).setIntroducedIn(30800);
+                     .setIntroducedIn(30709);
 
   options
       ->addOption(

--- a/arangod/RestServer/QueryRegistryFeature.cpp
+++ b/arangod/RestServer/QueryRegistryFeature.cpp
@@ -235,7 +235,7 @@ void QueryRegistryFeature::collectOptions(std::shared_ptr<ProgramOptions> option
                      "enable SmartJoins query optimization",
                      new BooleanParameter(&_smartJoins),
                      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden, arangodb::options::Flags::Enterprise))
-                     .setIntroducedIn(30405).setIntroducedIn(30500);
+                     .setIntroducedIn(30405);
   
   options->addOption("--query.parallelize-traversals",
                      "enable traversal parallelization",

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -317,9 +317,8 @@ void RocksDBEngine::collectOptions(std::shared_ptr<options::ProgramOptions> opti
                      "a warning (in milliseconds, use 0 for no warnings)",
                      new UInt64Parameter(&_syncDelayThreshold),
                      arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
-                     .setIntroducedIn(30800)
-                     .setIntroducedIn(30705)
-                     .setIntroducedIn(30608);
+                     .setIntroducedIn(30608)
+                     .setIntroducedIn(30705);
 
   options->addOption("--rocksdb.wal-file-timeout",
                      "timeout after which unused WAL files are deleted",

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -450,8 +450,7 @@ void RocksDBOptionFeature::collectOptions(std::shared_ptr<ProgramOptions> option
                   "startup, in order to startup reduce IO",
                   new BooleanParameter(&_limitOpenFilesAtStartup),
                   arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden))
-      .setIntroducedIn(30405)
-      .setIntroducedIn(30500);
+      .setIntroducedIn(30405);
 
   options
       ->addOption("--rocksdb.allow-fallocate",
@@ -459,8 +458,7 @@ void RocksDBOptionFeature::collectOptions(std::shared_ptr<ProgramOptions> option
                   "fallocate calls are bypassed",
                   new BooleanParameter(&_allowFAllocate),
                   arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden))
-      .setIntroducedIn(30405)
-      .setIntroducedIn(30500);
+      .setIntroducedIn(30405);
   options
       ->addOption("--rocksdb.exclusive-writes",
                   "if true, writes are exclusive. This allows the RocksDB engine to mimic "

--- a/arangosh/Dump/DumpFeature.cpp
+++ b/arangosh/Dump/DumpFeature.cpp
@@ -689,8 +689,7 @@ void DumpFeature::collectOptions(std::shared_ptr<options::ProgramOptions> option
   options->addOption("--compress-output",
                      "compress files containing collection contents using gzip format (not compatible with encryption)",
                      new BooleanParameter(&_options.useGzip))
-                     .setIntroducedIn(30406)
-                     .setIntroducedIn(30500);
+                     .setIntroducedIn(30406);
 }
 
 void DumpFeature::validateOptions(std::shared_ptr<options::ProgramOptions> options) {

--- a/arangosh/Shell/ConsoleFeature.cpp
+++ b/arangosh/Shell/ConsoleFeature.cpp
@@ -131,8 +131,7 @@ void ConsoleFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addOption("--console.history",
                      "whether or not to load and persist command-line history",
                      new BooleanParameter(&_useHistory))
-                     .setIntroducedIn(30405)
-                     .setIntroducedIn(30500);
+                     .setIntroducedIn(30405);
 
   options->addOption("--console.pager", "enable paging", new BooleanParameter(&_pager));
 

--- a/lib/Logger/LogBufferFeature.cpp
+++ b/lib/Logger/LogBufferFeature.cpp
@@ -232,7 +232,7 @@ void LogBufferFeature::collectOptions(std::shared_ptr<options::ProgramOptions> o
                   new DiscreteValuesParameter<StringParameter>(
                       &_minInMemoryLogLevel, logLevels),
                   arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden))
-                  .setIntroducedIn(30800).setIntroducedIn(30709);
+                  .setIntroducedIn(30709);
 }
 
 void LogBufferFeature::prepare() {

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -124,7 +124,7 @@ void LoggerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options
       ->addOption("--log.max-entry-length", "maximum length of a log entry (in bytes)",
                   new UInt32Parameter(&_maxEntryLength))
-      .setIntroducedIn(30800).setIntroducedIn(30709);
+      .setIntroducedIn(30709);
 
   options
       ->addOption("--log.use-local-time", "use local timezone instead of UTC",
@@ -154,8 +154,7 @@ void LoggerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
       ->addOption("--log.file-mode",
                   "mode to use for new log file, umask will be applied as well",
                   new StringParameter(&_fileMode))
-      .setIntroducedIn(30405)
-      .setIntroducedIn(30500);
+      .setIntroducedIn(30405);
 
   if (_threaded) {
     // this option only makes sense for arangod, not for arangosh etc.
@@ -178,8 +177,7 @@ void LoggerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
           "--log.file-group",
           "group to use for new log file, user must be a member of this group",
           new StringParameter(&_fileGroup))
-      .setIntroducedIn(30405)
-      .setIntroducedIn(30500);
+      .setIntroducedIn(30405);
 #endif
 
   options->addOption("--log.prefix", "prefix log message with this string",


### PR DESCRIPTION
### Scope & Purpose

Don't list e.g. v3.5.0 if v3.4.5 implies that a feature is available in subsequent releases, as discussed with Jörg.

This only affects --help and the docs.

#### Backports:

- [x] Backports required for: 3.7, 3.6

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*