### PR TITLE
Cleanup hotbackup transfer jobs in agency

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.7.9 (XXXX-XX-XX)
 -------------------
 
+* Cleanup old hotbackup transfer jobs in agency.
+
 * Added logging of elapsed time of ArangoSearch commit/consolidation/cleanup
   jobs.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.7.9 (XXXX-XX-XX)
 -------------------
 
-* Cleanup old hotbackup transfer jobs in agency.
+* Cleanup old HotBackup transfer jobs in agency.
 
 * Added logging of elapsed time of ArangoSearch commit/consolidation/cleanup
   jobs.

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1660,6 +1660,10 @@ void arangodb::consensus::cleanupHotbackupTransferJobsFunctional(
 
   auto const& jobs = snapshot.hasAsChildren(prefix).first;
   if (jobs.size() <= maximalNumberTransferJobs + 6) {
+    // We tolerate some more jobs before we take action. This is to
+    // avoid that we go through all jobs every second. Oasis takes
+    // a hotbackup every 2h, so this number 6 would lead to the list
+    // being traversed approximately every 12h.
     return;
   }
   typedef std::pair<std::string, std::string> keyDate;

--- a/arangod/Agency/Supervision.h
+++ b/arangod/Agency/Supervision.h
@@ -199,8 +199,11 @@ class Supervision : public arangodb::CriticalThread {
   // @brief Check shards in agency
   std::vector<check_t> checkShards();
 
-  // @brief
+  /// @brief Cleanup old Supervision jobs
   void cleanupFinishedAndFailedJobs();
+
+  /// @brief Cleanup old hotbackup transfer jobs
+  void cleanupHotbackupTransferJobs();
 
   // @brief these servers have gone for too long without any responsibility
   //        and this are safely removable and so they are

--- a/arangod/Agency/Supervision.h
+++ b/arangod/Agency/Supervision.h
@@ -51,6 +51,13 @@ void enforceReplicationFunctional(Node const& snapshot,
                                   uint64_t& jobId,
                                   std::shared_ptr<VPackBuilder> envelope);
 
+// This is the functional version which actually does the work, it is
+// called by the private method Supervision::cleanupHotbackupTransferJobs
+// and the unit tests:
+void cleanupHotbackupTransferJobsFunctional(
+    Node const& snapshot, 
+    std::shared_ptr<VPackBuilder> envelope);
+
 class Supervision : public arangodb::CriticalThread {
  public:
   typedef std::chrono::system_clock::time_point TimePoint;


### PR DESCRIPTION
This PR adds clean up of old jobs stored in the agency for HotBackup
transfer jobs (upload and download). At most 100 completed jobs are
kept.

### Scope & Purpose

- [*] :hankey: Bugfix 

#### Backports:

- [ ] No backports required
- [*] Backports required for: 3.6 and 3.7, this is the 3.7 backport

