### PR TITLE
Cleanup hotbackup transfer jobs in agency

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+v3.6.13 (xxxx-xx-xx)
+--------------------
+
+* Cleanup old hotbackup transfer jobs in agency.
+
+
 v3.6.12 (2021-02-18)
 --------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
-v3.6.13 (xxxx-xx-xx)
+v3.6.13 (XXXX-XX-XX)
 --------------------
 
-* Cleanup old hotbackup transfer jobs in agency.
+* Cleanup old HotBackup transfer jobs in agency.
 
 
 v3.6.12 (2021-02-18)

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1461,7 +1461,7 @@ void Supervision::cleanupHotbackupTransferJobs() {
     VPackArrayBuilder guard1(envelope.get());
     VPackObjectBuilder guard2(envelope.get());
     arangodb::consensus::cleanupHotbackupTransferJobsFunctional(
-        snapshot(), envelope);
+        _snapshot, envelope);
   }
   if (envelope->slice()[0].length() > 0) {
     write_ret_t res = singleWriteTransaction(_agent, *envelope, false);

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1401,6 +1401,10 @@ void arangodb::consensus::cleanupHotbackupTransferJobsFunctional(
 
   auto const& jobs = snapshot.hasAsChildren(prefix).first;
   if (jobs.size() <= maximalNumberTransferJobs + 6) {
+    // We tolerate some more jobs before we take action. This is to
+    // avoid that we go through all jobs every second. Oasis takes
+    // a hotbackup every 2h, so this number 6 would lead to the list
+    // being traversed approximately every 12h.
     return;
   }
   typedef std::pair<std::string, std::string> keyDate;

--- a/arangod/Agency/Supervision.h
+++ b/arangod/Agency/Supervision.h
@@ -51,6 +51,13 @@ void enforceReplicationFunctional(Node const& snapshot,
                                   uint64_t& jobId,
                                   std::shared_ptr<VPackBuilder> envelope);
 
+// This is the functional version which actually does the work, it is
+// called by the private method Supervision::cleanupHotbackupTransferJobs
+// and the unit tests:
+void cleanupHotbackupTransferJobsFunctional(
+    Node const& snapshot, 
+    std::shared_ptr<VPackBuilder> envelope);
+
 class Supervision : public arangodb::CriticalThread {
  public:
   typedef std::chrono::system_clock::time_point TimePoint;
@@ -190,6 +197,9 @@ class Supervision : public arangodb::CriticalThread {
 
   // @brief
   void cleanupFinishedAndFailedJobs();
+
+  /// @brief Cleanup old hotbackup transfer jobs
+  void cleanupHotbackupTransferJobs();
 
   void workJobs();
 


### PR DESCRIPTION
Backport cleanup routine for hotbackup transfer jobs to 3.6.
See https://github.com/arangodb/arangodb/pull/13585

### Scope & Purpose

*(Can you describe what functional change your PR is trying to effect?)*

- [*] Bug-Fix for a *released version*

### Testing & Verification

This PR adds tests that were used to verify all changes:

- [*] Added new C++ **Unit Tests** (Either GoogleTest or Catch-Test)

