### PR TITLE
Allow dumping of individual shards with arangodump

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 devel
 -----
 
-* Add `--shard` option to arangodump, so that dumps can be restrict to one or
+* Added `--shard` option to arangodump, so that dumps can be restricted to one or
   multiple shards only.
 
 * Updated OpenSSL to 1.1.1j and OpenLDAP to 2.4.57.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Add `--shard` option to arangodump, so that dumps can be restrict to one or
+  multiple shards only.
+
 * Updated OpenSSL to 1.1.1j and OpenLDAP to 2.4.57.
 
 * Added logging of elapsed time of ArangoSearch commit/consolidation/cleanup 

--- a/arangosh/Dump/DumpFeature.cpp
+++ b/arangosh/Dump/DumpFeature.cpp
@@ -636,7 +636,7 @@ void DumpFeature::collectOptions(std::shared_ptr<options::ProgramOptions> option
   
   options->addOption(
       "--shard",
-      "restrict to shard name (can be specified multiple times)",
+      "restrict dump to shard (can be specified multiple times)",
       new VectorParameter<StringParameter>(&_options.shards))
       .setIntroducedIn(30800);
 

--- a/arangosh/Dump/DumpFeature.h
+++ b/arangosh/Dump/DumpFeature.h
@@ -65,6 +65,7 @@ class DumpFeature final : public application_features::ApplicationFeature {
   /// @brief Holds configuration data to pass between methods
   struct Options {
     std::vector<std::string> collections{};
+    std::vector<std::string> shards{};
     std::string outputPath{};
     std::string maskingsFile{};
     uint64_t initialChunkSize{1024 * 1024 * 8};

--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -1164,7 +1164,9 @@ arangodb::Result processInputDirectory(
         if (result.fail()) {
           return result;
         }
+      }
 
+      if (progressTracker.getStatus(name.copyString()).state < arangodb::RestoreFeature::CREATED) {
         progressTracker.updateStatus(name.copyString(),
                                      arangodb::RestoreFeature::CollectionStatus{
                                          arangodb::RestoreFeature::CREATED});


### PR DESCRIPTION
### Scope & Purpose

Added `--shard` option to arangodump, so that dumps can be restricted to one or multiple shards only.

In addition fix an unrelated assertion failure in arangorestore when using `--create-collection false` and clean up an old option in arangodump.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_client)

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/14202/