### PR TITLE
fix dump tests

### DIFF
--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -832,7 +832,7 @@ arangodb::Result restoreData(arangodb::httpclient::SimpleHttpClient& httpClient,
       // note that we have to store the uncompressed offset here, because we
       // potentially have consumed more data than we have sent.
       datafileReadOffset += length;
-      bool wasSynced = jobData.progressTracker.updateStatus(
+      [[maybe_unused]] bool wasSynced = jobData.progressTracker.updateStatus(
           cname, arangodb::RestoreFeature::CollectionStatus{arangodb::RestoreFeature::RESTORING,
                                                             datafileReadOffset});
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -64,8 +64,8 @@ const encryptionKey = '01234567890123456789012345678901';
 const encryptionKeySha256 = "861009ec4d599fab1f40abc76e6f89880cff5833c79c548c99f9045f191cd90b";
 
 let timeoutFactor = 1;
-if (global.ARANGODB_CLIENT_VERSION(true).asan  ||
-    global.ARANGODB_CLIENT_VERSION(true).tsan  ||
+if (global.ARANGODB_CLIENT_VERSION(true).asan === 'true' ||
+    global.ARANGODB_CLIENT_VERSION(true).tsan === 'true' ||
     process.env.hasOwnProperty('GCOV_PREFIX')) {
   timeoutFactor = 8;
 }

--- a/js/client/modules/@arangodb/testutils/test-utils.js
+++ b/js/client/modules/@arangodb/testutils/test-utils.js
@@ -566,7 +566,7 @@ function filterTestcaseByOptions (testname, options, whichFilter) {
     return false;
   }
 
-  if ((testname.indexOf('-noasan') !== -1) && global.ARANGODB_CLIENT_VERSION(true).asan) {
+  if ((testname.indexOf('-noasan') !== -1) && global.ARANGODB_CLIENT_VERSION(true).asan === 'true') {
     whichFilter.filter = 'skip when built with asan';
     return false;
   }

--- a/js/client/modules/@arangodb/testutils/testing.js
+++ b/js/client/modules/@arangodb/testutils/testing.js
@@ -213,8 +213,8 @@ const optionsDefaults = {
   'onlyGrey': false,
   'oneTestTimeout': 15 * 60,
   'isAsan': (
-      global.ARANGODB_CLIENT_VERSION(true).asan  ||
-      global.ARANGODB_CLIENT_VERSION(true).tsan),
+      global.ARANGODB_CLIENT_VERSION(true).asan === 'true' ||
+      global.ARANGODB_CLIENT_VERSION(true).tsan === 'true'),
   'skipTimeCritical': false,
   'storageEngine': 'rocksdb',
   'test': undefined,

--- a/tests/js/client/communication/test-kill.js
+++ b/tests/js/client/communication/test-kill.js
@@ -31,8 +31,8 @@ let pu = require('@arangodb/testutils/process-utils');
 let db = arangodb.db;
 
 let timeout = 60;
-if (global.ARANGODB_CLIENT_VERSION(true).asan  ||
-    global.ARANGODB_CLIENT_VERSION(true).tsan  ||
+if (global.ARANGODB_CLIENT_VERSION(true).asan === 'true' ||
+    global.ARANGODB_CLIENT_VERSION(true).tsan === 'true' ||
     process.env.hasOwnProperty('GCOV_PREFIX')) {
   timeout *= 10;
 }

--- a/tests/js/client/shell/shell-deadlock-trx-hotbackup-cluster.js
+++ b/tests/js/client/shell/shell-deadlock-trx-hotbackup-cluster.js
@@ -104,8 +104,8 @@ function trxWriteHotbackupDeadlock () {
       let jobid = res.headers["x-arango-async-id"];
 
       let timeout = 60;
-      if (global.ARANGODB_CLIENT_VERSION(true).asan  ||
-          global.ARANGODB_CLIENT_VERSION(true).tsan  ||
+      if (global.ARANGODB_CLIENT_VERSION(true).asan === 'true' ||
+          global.ARANGODB_CLIENT_VERSION(true).tsan === 'true' ||
           process.env.hasOwnProperty('GCOV_PREFIX')) {
         timeout *= 10;
       }


### PR DESCRIPTION
### Scope & Purpose

Fix `dump_with_crashes` test suite, plus a few unrelated wrong usage of the global asan/tsan flags.
This PR only adjusts tests. There is no need for CHANGELOG or backports.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is already covered by existing tests, such as *dump_with_crashes*.
- [x] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/14207/