### PR TITLE
BTS-309: Rename error message 1947 to match actual behavior

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ devel
 * Fixed issue BTS-309: The Graph API (Gharial) did not respond with the correct
   HTTP status code when validating edges. It now responds with 400 (Bad Request)
   as documented and a new, more precise error code (1947) and message if a vertex
-  collection referenced in the _from or _to attribute cannot be found.
+  collection referenced in the _from or _to attribute is not part of the graph.
 
 * Added `--shard` option to arangodump, so that dumps can be restricted to one or
   multiple shards only.

--- a/Documentation/DocuBlocks/Rest/Graph/general_graph_edge_create_http_examples.md
+++ b/Documentation/DocuBlocks/Rest/Graph/general_graph_edge_create_http_examples.md
@@ -76,7 +76,7 @@ Will only be present if returnNew is true.
 @RESTRETURNCODE{400}
 Returned if the input document is invalid.
 This can for instance be the case if the `_from` or `_to` attribute is missing
-or malformed, or if the referenced vertex collection does not exist.
+or malformed, or if the referenced vertex collection is not part of the graph.
 
 @RESTREPLYBODY{error,boolean,required,}
 Flag if there was an error (true) or not (false).
@@ -114,6 +114,7 @@ A message created for this error.
 Returned in any of the following cases:
 * no graph with this name could be found.
 * the edge collection is not part of the graph.
+* the vertex collection is part of the graph, but does not exist.
 * `_from` or `_to` vertex does not exist.
 
 @RESTREPLYBODY{error,boolean,required,}

--- a/arangod/Graph/GraphOperations.cpp
+++ b/arangod/Graph/GraphOperations.cpp
@@ -776,7 +776,7 @@ std::pair<OperationResult, bool> GraphOperations::validateEdgeContent(
   if (it == _graph.vertexCollections().end()) {
     // not found _from vertex
     return std::make_pair(
-        OperationResult(Result(TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF,
+        OperationResult(Result(TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED,
                                "referenced _from collection '" + fromCollectionName + "' is not part of the graph"),
                         options),
         true);
@@ -785,7 +785,7 @@ std::pair<OperationResult, bool> GraphOperations::validateEdgeContent(
   if (it == _graph.vertexCollections().end()) {
     // not found _to vertex
     return std::make_pair(
-        OperationResult(Result(TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF,
+        OperationResult(Result(TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED,
                                "referenced _to collection '" + toCollectionName + "' is not part of the graph"),
                         options),
         true);

--- a/arangod/Graph/GraphOperations.cpp
+++ b/arangod/Graph/GraphOperations.cpp
@@ -776,19 +776,19 @@ std::pair<OperationResult, bool> GraphOperations::validateEdgeContent(
   if (it == _graph.vertexCollections().end()) {
     // not found _from vertex
     return std::make_pair(
-        OperationResult(Result(TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_DOES_NOT_EXIST,
-                               "referenced _from collection: " + fromCollectionName + " does not exist."),
+        OperationResult(Result(TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF,
+                               "referenced _from collection '" + fromCollectionName + "' is not part of the graph"),
                         options),
         true);
   }
   it = _graph.vertexCollections().find(toCollectionName);
   if (it == _graph.vertexCollections().end()) {
     // not found _to vertex
-    return std::make_pair(OperationResult(Result(TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_DOES_NOT_EXIST,
-                                                 "referenced _to collection: " + toCollectionName +
-                                                     " does not exist."),
-                                          options),
-                          true);
+    return std::make_pair(
+        OperationResult(Result(TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF,
+                               "referenced _to collection '" + toCollectionName + "' is not part of the graph"),
+                        options),
+        true);
   }
 
   return std::make_pair(OperationResult(TRI_ERROR_NO_ERROR, options), true);

--- a/js/common/bootstrap/errors.js
+++ b/js/common/bootstrap/errors.js
@@ -290,7 +290,7 @@
     "ERROR_GRAPH_EDGE_DEFINITION_IS_DOCUMENT" : { "code" : 1944, "message" : "edge definition collection is a document collection" },
     "ERROR_GRAPH_COLLECTION_IS_INITIAL" : { "code" : 1945, "message" : "initial collection is not allowed to be removed manually" },
     "ERROR_GRAPH_NO_INITIAL_COLLECTION" : { "code" : 1946, "message" : "no valid initial collection found" },
-    "ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_DOES_NOT_EXIST" : { "code" : 1947, "message" : "referenced vertex collection does not exist" },
+    "ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF" : { "code" : 1947, "message" : "referenced vertex collection is not part of the graph" },
     "ERROR_SESSION_UNKNOWN"        : { "code" : 1950, "message" : "unknown session" },
     "ERROR_SESSION_EXPIRED"        : { "code" : 1951, "message" : "session expired" },
     "ERROR_SIMPLE_CLIENT_UNKNOWN_ERROR" : { "code" : 2000, "message" : "unknown client error" },

--- a/js/common/bootstrap/errors.js
+++ b/js/common/bootstrap/errors.js
@@ -290,7 +290,7 @@
     "ERROR_GRAPH_EDGE_DEFINITION_IS_DOCUMENT" : { "code" : 1944, "message" : "edge definition collection is a document collection" },
     "ERROR_GRAPH_COLLECTION_IS_INITIAL" : { "code" : 1945, "message" : "initial collection is not allowed to be removed manually" },
     "ERROR_GRAPH_NO_INITIAL_COLLECTION" : { "code" : 1946, "message" : "no valid initial collection found" },
-    "ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF" : { "code" : 1947, "message" : "referenced vertex collection is not part of the graph" },
+    "ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED" : { "code" : 1947, "message" : "referenced vertex collection is not part of the graph" },
     "ERROR_SESSION_UNKNOWN"        : { "code" : 1950, "message" : "unknown session" },
     "ERROR_SESSION_EXPIRED"        : { "code" : 1951, "message" : "session expired" },
     "ERROR_SIMPLE_CLIENT_UNKNOWN_ERROR" : { "code" : 2000, "message" : "unknown client error" },

--- a/lib/Basics/error-registry.h
+++ b/lib/Basics/error-registry.h
@@ -581,7 +581,7 @@ constexpr static frozen::unordered_map<ErrorCode, const char*, 367> ErrorMessage
       "initial collection is not allowed to be removed manually"},
     {TRI_ERROR_GRAPH_NO_INITIAL_COLLECTION,  // 1946
       "no valid initial collection found"},
-    {TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF,  // 1947
+    {TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED,  // 1947
       "referenced vertex collection is not part of the graph"},
     {TRI_ERROR_SESSION_UNKNOWN,  // 1950
       "unknown session"},

--- a/lib/Basics/error-registry.h
+++ b/lib/Basics/error-registry.h
@@ -581,8 +581,8 @@ constexpr static frozen::unordered_map<ErrorCode, const char*, 367> ErrorMessage
       "initial collection is not allowed to be removed manually"},
     {TRI_ERROR_GRAPH_NO_INITIAL_COLLECTION,  // 1946
       "no valid initial collection found"},
-    {TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_DOES_NOT_EXIST,  // 1947
-      "referenced vertex collection does not exist"},
+    {TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF,  // 1947
+      "referenced vertex collection is not part of the graph"},
     {TRI_ERROR_SESSION_UNKNOWN,  // 1950
       "unknown session"},
     {TRI_ERROR_SESSION_EXPIRED,  // 1951

--- a/lib/Basics/errors.dat
+++ b/lib/Basics/errors.dat
@@ -386,7 +386,7 @@ ERROR_GRAPH_CREATE_MALFORMED_ORPHAN_LIST,1943,"malformed orphan list","the orpha
 ERROR_GRAPH_EDGE_DEFINITION_IS_DOCUMENT,1944,"edge definition collection is a document collection","the collection used as a relation is existing, but is a document collection, it cannot be used here."
 ERROR_GRAPH_COLLECTION_IS_INITIAL,1945,"initial collection is not allowed to be removed manually","the collection is used as the initial collection of this graph and is not allowed to be removed manually."
 ERROR_GRAPH_NO_INITIAL_COLLECTION,1946,"no valid initial collection found","during the graph creation process no collection could be selected as the needed initial collection. Happens if a distributeShardsLike or replicationFactor mismatch was found."
-ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_DOES_NOT_EXIST,1947,"referenced vertex collection does not exist","the _from or _to collection specified for the edge does not exist."
+ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF,1947,"referenced vertex collection is not part of the graph","the _from or _to collection specified for the edge refers to a vertex collection which is not used in any edge definition."
 
 ################################################################################
 ## Session errors

--- a/lib/Basics/errors.dat
+++ b/lib/Basics/errors.dat
@@ -386,7 +386,7 @@ ERROR_GRAPH_CREATE_MALFORMED_ORPHAN_LIST,1943,"malformed orphan list","the orpha
 ERROR_GRAPH_EDGE_DEFINITION_IS_DOCUMENT,1944,"edge definition collection is a document collection","the collection used as a relation is existing, but is a document collection, it cannot be used here."
 ERROR_GRAPH_COLLECTION_IS_INITIAL,1945,"initial collection is not allowed to be removed manually","the collection is used as the initial collection of this graph and is not allowed to be removed manually."
 ERROR_GRAPH_NO_INITIAL_COLLECTION,1946,"no valid initial collection found","during the graph creation process no collection could be selected as the needed initial collection. Happens if a distributeShardsLike or replicationFactor mismatch was found."
-ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF,1947,"referenced vertex collection is not part of the graph","the _from or _to collection specified for the edge refers to a vertex collection which is not used in any edge definition."
+ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED,1947,"referenced vertex collection is not part of the graph","the _from or _to collection specified for the edge refers to a vertex collection which is not used in any edge definition of the graph."
 
 ################################################################################
 ## Session errors

--- a/lib/Basics/voc-errors.h
+++ b/lib/Basics/voc-errors.h
@@ -1534,10 +1534,11 @@ constexpr auto TRI_ERROR_GRAPH_COLLECTION_IS_INITIAL                            
 /// replicationFactor mismatch was found.
 constexpr auto TRI_ERROR_GRAPH_NO_INITIAL_COLLECTION                             = ErrorCode{1946};
 
-/// 1947: ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_DOES_NOT_EXIST
-/// "referenced vertex collection does not exist"
-/// the specified referenced vertex collection does not exist.
-constexpr auto TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_DOES_NOT_EXIST       = ErrorCode{1947};
+/// 1947: ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF
+/// "referenced vertex collection is not part of the graph"
+/// the _from or _to collection specified for the edge refers to a vertex
+/// collection which is not used in any edge definition.
+constexpr auto TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF      = ErrorCode{1947};
 
 /// 1950: ERROR_SESSION_UNKNOWN
 /// "unknown session"

--- a/lib/Basics/voc-errors.h
+++ b/lib/Basics/voc-errors.h
@@ -1534,11 +1534,11 @@ constexpr auto TRI_ERROR_GRAPH_COLLECTION_IS_INITIAL                            
 /// replicationFactor mismatch was found.
 constexpr auto TRI_ERROR_GRAPH_NO_INITIAL_COLLECTION                             = ErrorCode{1946};
 
-/// 1947: ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF
+/// 1947: ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED
 /// "referenced vertex collection is not part of the graph"
 /// the _from or _to collection specified for the edge refers to a vertex
-/// collection which is not used in any edge definition.
-constexpr auto TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF      = ErrorCode{1947};
+/// collection which is not used in any edge definition of the graph.
+constexpr auto TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED             = ErrorCode{1947};
 
 /// 1950: ERROR_SESSION_UNKNOWN
 /// "unknown session"

--- a/lib/Rest/GeneralResponse.cpp
+++ b/lib/Rest/GeneralResponse.cpp
@@ -376,7 +376,7 @@ rest::ResponseCode GeneralResponse::responseCode(ErrorCode code) {
     case static_cast<int>(TRI_ERROR_CLUSTER_MUST_NOT_CHANGE_SMART_JOIN_ATTRIBUTE):
     case static_cast<int>(TRI_ERROR_VALIDATION_FAILED):
     case static_cast<int>(TRI_ERROR_VALIDATION_BAD_PARAMETER):
-    case static_cast<int>(TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_DOES_NOT_EXIST):
+    case static_cast<int>(TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF):
       return ResponseCode::BAD;
 
     case static_cast<int>(TRI_ERROR_ARANGO_USE_SYSTEM_DATABASE):

--- a/lib/Rest/GeneralResponse.cpp
+++ b/lib/Rest/GeneralResponse.cpp
@@ -376,7 +376,7 @@ rest::ResponseCode GeneralResponse::responseCode(ErrorCode code) {
     case static_cast<int>(TRI_ERROR_CLUSTER_MUST_NOT_CHANGE_SMART_JOIN_ATTRIBUTE):
     case static_cast<int>(TRI_ERROR_VALIDATION_FAILED):
     case static_cast<int>(TRI_ERROR_VALIDATION_BAD_PARAMETER):
-    case static_cast<int>(TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF):
+    case static_cast<int>(TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED):
       return ResponseCode::BAD;
 
     case static_cast<int>(TRI_ERROR_ARANGO_USE_SYSTEM_DATABASE):

--- a/tests/js/client/http/api-gharial-spec.js
+++ b/tests/js/client/http/api-gharial-spec.js
@@ -365,7 +365,7 @@ describe('_api/gharial', () => {
           };
           let req = arango.POST(url + '/' + exampleGraphName + '/edge/knows', edgeDef);
           expect(req.code).to.equal(400);
-          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_DOES_NOT_EXIST.code);
+          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF.code);
 
           expect(db._collection(eName)).to.not.be.null;
           expect(db._collection(vName)).to.not.be.null;
@@ -443,7 +443,7 @@ describe('_api/gharial', () => {
           };
           let req = arango.POST(url + '/' + exampleGraphName + '/edge/knows', edgeDef);
           expect(req.code).to.equal(400);
-          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_DOES_NOT_EXIST.code);
+          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF.code);
 
           expect(db._collection(eName)).to.not.be.null;
           expect(db._collection(vName)).to.not.be.null;
@@ -461,7 +461,7 @@ describe('_api/gharial', () => {
           };
           let req = arango.POST(url + '/' + exampleGraphName + '/edge/knows', edgeDef);
           expect(req.code).to.equal(400);
-          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_DOES_NOT_EXIST.code);
+          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF.code);
 
           expect(db._collection(eName)).to.not.be.null;
           expect(db._collection(vName)).to.not.be.null;
@@ -604,7 +604,7 @@ describe('_api/gharial', () => {
           const _key = db.knows.any()._key;
           let req = arango.PATCH(url + '/' + exampleGraphName + '/edge/knows/' + _key, edgeDef);
           expect(req.code).to.equal(400);
-          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_DOES_NOT_EXIST.code);
+          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF.code);
 
           expect(db._collection(eName)).to.not.be.null;
           expect(db._collection(vName)).to.not.be.null;
@@ -625,7 +625,7 @@ describe('_api/gharial', () => {
           const _key = db.knows.any()._key;
           let req = arango.PATCH(url + '/' + exampleGraphName + '/edge/knows/' + _key, edgeDef);
           expect(req.code).to.equal(400);
-          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_DOES_NOT_EXIST.code);
+          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF.code);
 
           expect(db._collection(eName)).to.not.be.null;
           expect(db._collection(vName)).to.not.be.null;
@@ -854,7 +854,7 @@ describe('_api/gharial', () => {
           const _key = db.knows.any()._key;
           let req = arango.PUT(url + '/' + exampleGraphName + '/edge/knows/' + _key, edgeDef);
           expect(req.code).to.equal(400);
-          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_DOES_NOT_EXIST.code);
+          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF.code);
 
           expect(db._collection(eName)).to.not.be.null;
           expect(db._collection(vName)).to.not.be.null;
@@ -875,7 +875,7 @@ describe('_api/gharial', () => {
           const _key = db.knows.any()._key;
           let req = arango.PUT(url + '/' + exampleGraphName + '/edge/knows/' + _key, edgeDef);
           expect(req.code).to.equal(400);
-          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_DOES_NOT_EXIST.code);
+          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF.code);
 
           expect(db._collection(eName)).to.not.be.null;
           expect(db._collection(vName)).to.not.be.null;
@@ -1219,7 +1219,7 @@ describe('_api/gharial', () => {
 
           let reqx = arango.POST(url + '/' + exampleGraphName + '/edge/' + eName, edgeLinkDef);
           expect(reqx.code).to.equal(400);
-          expect(reqx.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_DOES_NOT_EXIST.code);
+          expect(reqx.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF.code);
           expect(reqx.error).to.equal(true);
         });
       });

--- a/tests/js/client/http/api-gharial-spec.js
+++ b/tests/js/client/http/api-gharial-spec.js
@@ -365,7 +365,7 @@ describe('_api/gharial', () => {
           };
           let req = arango.POST(url + '/' + exampleGraphName + '/edge/knows', edgeDef);
           expect(req.code).to.equal(400);
-          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF.code);
+          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED.code);
 
           expect(db._collection(eName)).to.not.be.null;
           expect(db._collection(vName)).to.not.be.null;
@@ -443,7 +443,7 @@ describe('_api/gharial', () => {
           };
           let req = arango.POST(url + '/' + exampleGraphName + '/edge/knows', edgeDef);
           expect(req.code).to.equal(400);
-          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF.code);
+          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED.code);
 
           expect(db._collection(eName)).to.not.be.null;
           expect(db._collection(vName)).to.not.be.null;
@@ -461,7 +461,7 @@ describe('_api/gharial', () => {
           };
           let req = arango.POST(url + '/' + exampleGraphName + '/edge/knows', edgeDef);
           expect(req.code).to.equal(400);
-          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF.code);
+          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED.code);
 
           expect(db._collection(eName)).to.not.be.null;
           expect(db._collection(vName)).to.not.be.null;
@@ -604,7 +604,7 @@ describe('_api/gharial', () => {
           const _key = db.knows.any()._key;
           let req = arango.PATCH(url + '/' + exampleGraphName + '/edge/knows/' + _key, edgeDef);
           expect(req.code).to.equal(400);
-          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF.code);
+          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED.code);
 
           expect(db._collection(eName)).to.not.be.null;
           expect(db._collection(vName)).to.not.be.null;
@@ -625,7 +625,7 @@ describe('_api/gharial', () => {
           const _key = db.knows.any()._key;
           let req = arango.PATCH(url + '/' + exampleGraphName + '/edge/knows/' + _key, edgeDef);
           expect(req.code).to.equal(400);
-          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF.code);
+          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED.code);
 
           expect(db._collection(eName)).to.not.be.null;
           expect(db._collection(vName)).to.not.be.null;
@@ -854,7 +854,7 @@ describe('_api/gharial', () => {
           const _key = db.knows.any()._key;
           let req = arango.PUT(url + '/' + exampleGraphName + '/edge/knows/' + _key, edgeDef);
           expect(req.code).to.equal(400);
-          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF.code);
+          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED.code);
 
           expect(db._collection(eName)).to.not.be.null;
           expect(db._collection(vName)).to.not.be.null;
@@ -875,7 +875,7 @@ describe('_api/gharial', () => {
           const _key = db.knows.any()._key;
           let req = arango.PUT(url + '/' + exampleGraphName + '/edge/knows/' + _key, edgeDef);
           expect(req.code).to.equal(400);
-          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF.code);
+          expect(req.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED.code);
 
           expect(db._collection(eName)).to.not.be.null;
           expect(db._collection(vName)).to.not.be.null;
@@ -1219,7 +1219,7 @@ describe('_api/gharial', () => {
 
           let reqx = arango.POST(url + '/' + exampleGraphName + '/edge/' + eName, edgeLinkDef);
           expect(reqx.code).to.equal(400);
-          expect(reqx.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_IN_EDGE_DEF.code);
+          expect(reqx.errorNum).to.equal(ERRORS.ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED.code);
           expect(reqx.error).to.equal(true);
         });
       });

--- a/tests/rb/HttpInterface/api-general-graph-spec.rb
+++ b/tests/rb/HttpInterface/api-general-graph-spec.rb
@@ -747,7 +747,7 @@ describe ArangoDB do
             doc = create_edge( sync, graph_name, friend_collection, "MISSING/v2", v1, {})
             doc.parsed_response['error'].should eq(true)
             doc.parsed_response['code'].should eq(400)
-            doc.parsed_response['errorMessage'].should include("referenced _from collection: MISSING does not exist")
+            doc.parsed_response['errorMessage'].should include("referenced _from collection 'MISSING' is not part of the graph")
             doc.parsed_response['errorNum'].should eq(1947)
           end
 
@@ -757,7 +757,7 @@ describe ArangoDB do
             doc = create_edge( sync, graph_name, friend_collection, v1, "MISSING/v2", {})
             doc.parsed_response['error'].should eq(true)
             doc.parsed_response['code'].should eq(400)
-            doc.parsed_response['errorMessage'].should include("referenced _to collection: MISSING does not exist")
+            doc.parsed_response['errorMessage'].should include("referenced _to collection 'MISSING' is not part of the graph")
             doc.parsed_response['errorNum'].should eq(1947)
           end
 


### PR DESCRIPTION
Follow-up PR to #13560 to correct the error message to "referenced vertex collection is not part of graph" instead of "... does not exist". In the latter case, a different error and HTTP status 404 is returned. The actual check that raises error 1947 only looks at the edge definitions to determine if the vertex collection is part of the graph.