### PR TITLE
make a hot backup test less whimsical

### DIFF
--- a/tests/js/client/shell/shell-deadlock-trx-hotbackup-cluster.js
+++ b/tests/js/client/shell/shell-deadlock-trx-hotbackup-cluster.js
@@ -85,7 +85,7 @@ function trxWriteHotbackupDeadlock () {
                         internal.createHotbackup({});
                         console.log("Created a hotbackup!");
                         good++;
-                      } catch(e) {
+                      } catch (e) {
                         console.error("Caught exception when creating a hotbackup!", e);
                         bad++;
                       }
@@ -136,8 +136,9 @@ function trxWriteHotbackupDeadlock () {
         res = arango.PUT(`/_api/job/${jobid}`, {});
         if (res.code !== 204) {
           assertEqual(200, res.code, "Response code bad.");
-          assertEqual(0, res.result.bad, "Not all hotbackups went through!");
           print("Managed to perform", res.result.good, "hotbackups.");
+          assertTrue(res.result.bad < 3, "Too many failed hotbackups!");
+          assertTrue(res.result.good > 2, "Too few good hotbackups!");
           return;
         }
         wait(1.0, false);


### PR DESCRIPTION
### Scope & Purpose

(Hopefully) make a hot backup test more stable, by allowing a certain number of failed hot backup attempts.
Failed attempts are possible if during the hot backup the cluster configuration changes. This possibility cannot be totally excluded.
So we allow _some_ failures in the test.

This only changes the behavior of a test, so there is no CHANGELOG entry for it.
The test change is already present in devel.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] This change is already covered by existing tests, such as *shell_client --cluster true*.

Link to Jenkins PR run:
