### PR TITLE
Fixed web UI "not authorized to execute this request" error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 devel
 -----
 
+* Fixed a bug in the web interface that displayed the error "Not authorized to 
+  execute this request" when trying to create an index in the web interface in a
+  database other than `_system` with a user that does not have any access
+  permissions for the `_system` database.
+  The error message previously displayed error actually came from an internal
+  request made by the web interface, but it did not affect the actual index
+  creation.
+
 * Added ability to display Coordinator and DBServer logs from inside the Web UI
   in a clustered environment when privileges are sufficient. 
   Additionally, displayed log entries can now be downloaded from the web UI in

--- a/js/apps/system/_admin/aardvark/APP/aardvark.js
+++ b/js/apps/system/_admin/aardvark/APP/aardvark.js
@@ -399,7 +399,7 @@ authRouter.delete('/job/:id', function (req, res) {
   if (frontend) {
     // get the job result and return before deletion
     let resp = request.put({
-      url: '/_api/job/' + encodeURIComponent(req.pathParams.id),
+      url: '/_db/' + encodeURIComponent(db._name()) + '/_api/job/' + encodeURIComponent(req.pathParams.id),
       json: true,
       headers: {
         'Authorization': req.headers.authorization


### PR DESCRIPTION
### Scope & Purpose

* Fixed a bug in the web interface that displayed the error "Not authorized to
  execute this request" when trying to create an index in the web interface in a
  database other than `_system` with a user that does not have any access
  permissions for the `_system` database.
  The error message previously displayed error actually came from an internal
  request made by the web interface, but it did not affect the actual index
  creation.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.7*: https://github.com/arangodb/arangodb/pull/13651, *3.6*: https://github.com/arangodb/arangodb/pull/13652

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://172.16.10.101:8080/view/PR/job/arangodb-matrix-pr/14266/