### PR TITLE
Fix lost coordinators in UI after long maintenance

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fixed a problem that coordinators would vanish from the UI and the Health
+  API if one switched the agency Supervision into maintenance mode and kept
+  left that maintenance mode on for more than 24h.
+
 * Fixed a bug in the web interface that displayed the error "Not authorized to 
   execute this request" when trying to create an index in the web interface in a
   database other than `_system` with a user that does not have any access

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1067,16 +1067,6 @@ void Supervision::run() {
                 // 55 seconds is less than a minute, which fits to the
                 // 60 seconds timeout in /_admin/cluster/health
 
-                // wait 5 min or until next scheduled run
-                if (_agent->leaderFor() > 300 &&
-                    _nextServerCleanup < std::chrono::system_clock::now()) {
-                  LOG_TOPIC("dcded", TRACE, Logger::SUPERVISION)
-                      << "Begin cleanupExpiredServers";
-                  cleanupExpiredServers(snapshot(), _transient);
-                  LOG_TOPIC("dedcd", TRACE, Logger::SUPERVISION)
-                      << "Finished cleanupExpiredServers";
-                }
-
                 try {
                   LOG_TOPIC("aa565", TRACE, Logger::SUPERVISION)
                       << "Begin doChecks";
@@ -1091,6 +1081,29 @@ void Supervision::run() {
                       << "Supervision::doChecks() generated an uncaught "
                          "exception.";
                 }
+
+                // wait 5 min or until next scheduled run
+                if (_agent->leaderFor() > 300 &&
+                    _nextServerCleanup < std::chrono::system_clock::now()) {
+                  // Make sure that we have the latest and greatest information
+                  // about heartbeats in _transient. Note that after a long
+                  // Maintenance mode of the supervision, the `doChecks` above
+                  // might have updated /arango/Supervision/Health in the transient
+                  // store *just now above*. We need to reflect these changes in
+                  // _transient.
+                  _agent->executeTransientLocked([&]() {
+                    if (_agent->transient().has(_agencyPrefix)) {
+                      _transient = _agent->transient().get(_agencyPrefix);
+                    }
+                  });
+
+                  LOG_TOPIC("dcded", TRACE, Logger::SUPERVISION)
+                      << "Begin cleanupExpiredServers";
+                  cleanupExpiredServers(snapshot(), _transient);
+                  LOG_TOPIC("dedcd", TRACE, Logger::SUPERVISION)
+                      << "Finished cleanupExpiredServers";
+                }
+
               } else {
                 LOG_TOPIC("7928f", INFO, Logger::SUPERVISION)
                     << "Postponing supervision for now, waiting for incoming "


### PR DESCRIPTION
This PR fixes the following problem: If one switches the agency
supervision to maintenance mode and leaves this on for more than
24h, then the first run of the supervision maintenance would erase all
coordinators (and dbservers which are not shard leaders) in the agency
data. This leads to the coordinators (and potentially dbservers) become
invisible in the UI.

The reason for this is that after 24h the heartbeats arriving in the
agency have not been processed in the agency supervision (due to it
being in maintenance mode), therefore the subroutine
`cleanupExpiredServers` would erase the servers as a cleanup job.

The fix is to run this subroutine *after* the most recent heartbeats
have been processed and to update the transient store snapshot in
between.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers - **mandatory**)*

- [*] :hankey: Bugfix (requires CHANGELOG entry)

#### Backports:

- [*] Backports required for: 3.6 and 3.7

### Testing & Verification

*(Please pick either of the following options)*

- [*] This change is a trivial rework / code cleanup without any test coverage.
- [*] The behavior in this PR was *manually tested*

The behaviour was manually tested by setting the times for the cleanup
to much smaller values. We would have to run a 24h test to test this
behaviour or mess with the numbers, which is both not desirable.
