### PR TITLE
Make reportLogs function non-blocking.

### DIFF
--- a/arangod/RestHandler/RestAdminLogHandler.h
+++ b/arangod/RestHandler/RestAdminLogHandler.h
@@ -46,7 +46,7 @@ class RestAdminLogHandler : public RestBaseHandler {
  private:
   arangodb::Result verifyPermitted();
   void clearLogs();
-  void reportLogs(bool newFormat);
+  RestStatus reportLogs(bool newFormat);
   void handleLogLevel();
 
 };


### PR DESCRIPTION
### Scope & Purpose

The recently introduced feature to support viewing DBServer logs (#13637) used a blocking function to fetch the logs from the DB server.
This PR adaptes this function so that it uses the future in a non-blocking way.
No changelog entry is mande since this is a minor improvement for a new feature that already has a changelog entry.

- [x] :hankey: Bugfix

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
