### PR TITLE
fix arangobench on Linux

### DIFF
--- a/arangosh/Benchmark/BenchFeature.cpp
+++ b/arangosh/Benchmark/BenchFeature.cpp
@@ -96,11 +96,35 @@ BenchFeature::BenchFeature(application_features::ApplicationServer& server, int*
       _result(result),
       _histogramNumIntervals(1000),
       _histogramIntervalSize(0.0),
-      _percentiles({50.0, 80.0, 85.0, 90.0, 95.0, 99.0})
-{
+      _percentiles({50.0, 80.0, 85.0, 90.0, 95.0, 99.0}) {
   requiresElevatedPrivileges(false);
   setOptional(false);
   startsAfter<application_features::BasicFeaturePhaseClient>();
+
+  // the following is not awesome, as all test classes need to be repeated here.
+  // however, it works portably across different compilers.
+  AqlInsertTest::registerTestcase();
+  AqlV8Test::registerTestcase();
+  CollectionCreationTest::registerTestcase();
+  CustomQueryTest::registerTestcase();
+  DocumentCreationTest::registerTestcase();
+  DocumentCrudAppendTest::registerTestcase();
+  DocumentCrudTest::registerTestcase();
+  DocumentCrudWriteReadTest::registerTestcase();
+  DocumentImportTest::registerTestcase();
+  EdgeCrudTest::registerTestcase();
+  HashTest::registerTestcase();
+  RandomShapesTest::registerTestcase();
+  ShapesAppendTest::registerTestcase();
+  ShapesTest::registerTestcase();
+  SkiplistTest::registerTestcase();
+  StreamCursorTest::registerTestcase();
+  TransactionAqlTest::registerTestcase();
+  TransactionCountTest::registerTestcase();
+  TransactionDeadlockTest::registerTestcase();
+  TransactionMultiCollectionTest::registerTestcase();
+  TransactionMultiTest::registerTestcase();
+  VersionTest::registerTestcase();
 }
 
 void BenchFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
@@ -162,7 +186,7 @@ void BenchFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   std::unordered_set<std::string> cases;
   for (auto& [name, _] : BenchmarkOperation::allBenchmarks()) {
     cases.emplace(name);
-  };
+  }
   options->addOption("--test-case", "test case to use",
                      new DiscreteValuesParameter<StringParameter>(&_testCase, cases));
 

--- a/arangosh/Benchmark/testcases/Benchmark.h
+++ b/arangosh/Benchmark/testcases/Benchmark.h
@@ -32,16 +32,12 @@ namespace arangodb::arangobench {
 template <class Derived>
 struct Benchmark : public BenchmarkOperation {
   explicit Benchmark(BenchFeature& arangobench) : BenchmarkOperation(arangobench) {}
- private:
-  struct Registrar {
-    Registrar() {
-      registerBenchmark(Derived::name(), [](BenchFeature& arangobench) {
-        return std::make_unique<Derived>(arangobench);
-      });
-    }
-  };
 
-  static inline Registrar _registrar;
+  static void registerTestcase() {
+    registerBenchmark(Derived::name(), [](BenchFeature& arangobench) {
+      return std::make_unique<Derived>(arangobench);
+    });
+  }
 };
 
 }  // namespace arangodb::arangobench


### PR DESCRIPTION
### Scope & Purpose

Previously, invoking arangobench always failed with an internal error on Linux. It worked on Windows though. The issue is probably due to compiler differences in static member initialization.

No CHANGELOG entry made, as only devel was affected, and only for about 10 days.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *arangobench*.

Link to Jenkins PR run:
