### PR TITLE
[zkd] Strict comparsion

### DIFF
--- a/arangod/RocksDBEngine/RocksDBZkdIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBZkdIndex.cpp
@@ -430,7 +430,6 @@ arangodb::aql::AstNode* arangodb::RocksDBZkdIndex::specializeCondition(
     condition->addMember(it);
   }
 
-  LOG_DEVEL << "specialized condition = " << condition->toString();
 
   return condition;
 }

--- a/arangod/RocksDBEngine/RocksDBZkdIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBZkdIndex.cpp
@@ -381,10 +381,6 @@ arangodb::Index::FilterCosts arangodb::RocksDBZkdIndex::supportsFilterCondition(
   std::unordered_set<aql::AstNode const*> unusedExpressions;
   extractBoundsFromCondition(this, node, reference, extractedBounds, unusedExpressions);
 
-  if (!unusedExpressions.empty()) {
-    return FilterCosts();
-  }
-
   if (extractedBounds.empty()) {
     return FilterCosts();
   }
@@ -408,6 +404,14 @@ arangodb::aql::AstNode* arangodb::RocksDBZkdIndex::specializeCondition(
         case arangodb::aql::NODE_TYPE_OPERATOR_BINARY_EQ:
         case arangodb::aql::NODE_TYPE_OPERATOR_BINARY_LE:
         case arangodb::aql::NODE_TYPE_OPERATOR_BINARY_GE:
+          children.emplace_back(op);
+          break;
+        case arangodb::aql::NODE_TYPE_OPERATOR_BINARY_LT:
+          op->type = aql::NODE_TYPE_OPERATOR_BINARY_LE;
+          children.emplace_back(op);
+          break;
+        case arangodb::aql::NODE_TYPE_OPERATOR_BINARY_GT:
+          op->type = aql::NODE_TYPE_OPERATOR_BINARY_GE;
           children.emplace_back(op);
           break;
         default:

--- a/arangod/RocksDBEngine/RocksDBZkdIndex.h
+++ b/arangod/RocksDBEngine/RocksDBZkdIndex.h
@@ -52,7 +52,7 @@ class RocksDBZkdIndex final : public RocksDBIndex {
                                       const arangodb::aql::Variable* reference,
                                       size_t itemsInIndex) const override;
 
-  aql::AstNode* specializeCondition(arangodb::aql::AstNode* node,
+  aql::AstNode* specializeCondition(arangodb::aql::AstNode* condition,
                                     const arangodb::aql::Variable* reference) const override;
 
   std::unique_ptr<IndexIterator> iteratorForCondition(transaction::Methods* trx,


### PR DESCRIPTION
### Scope & Purpose
This is feature development branch. It belongs to #13650 and will be merged into it. This branch adds support for strict comparsion operators. While the zkd index itself only allows the non-strict variants (and equality) we can add support for the strict operators by post-filtering in the index node in aql.

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as other zkd index tests..
- [x] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [x] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

