### PR TITLE
Let arangoexport throw an exception in case of write errors

### DIFF
--- a/arangosh/Export/ExportFeature.cpp
+++ b/arangosh/Export/ExportFeature.cpp
@@ -540,6 +540,7 @@ void ExportFeature::writeBatch(ManagedDirectory::File & fd, VPackArrayIterator i
 
 void ExportFeature::writeToFile(ManagedDirectory::File & fd, std::string const& line) {
   fd.write(line.c_str(), line.size());
+  THROW_ARANGO_EXCEPTION_IF_FAIL(fd.status());
 }
 
 std::shared_ptr<VPackBuilder> ExportFeature::httpCall(SimpleHttpClient* httpClient,

--- a/arangosh/Utils/ManagedDirectory.cpp
+++ b/arangosh/Utils/ManagedDirectory.cpp
@@ -559,7 +559,10 @@ void ManagedDirectory::File::writeNoLock(char const* data, size_t length) {
   }
 #endif
   if (isGzip()) {
-    gzwrite(_gzFile, data, static_cast<unsigned int>(length));
+    int const written = gzwrite(_gzFile, data, static_cast<unsigned int>(length));
+    if (written < (int)length) {
+      _status = ::genericError(_path, _flags);
+    }
   } else {
     ::rawWrite(_fd, data, length, _status, _path, _flags);
   }


### PR DESCRIPTION
### Scope & Purpose

Write errors during arangoexport (in case e.g. the disk was full) were just ignored. Throw an exception instead.

- [X] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

### Testing & Verification

*(Please pick either of the following options)*

- [X] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

