### PR TITLE
lower the default value for required file descriptors from 64k to 8k.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -364,17 +364,17 @@ devel
   possible for a very small number of queries and even had adverse effects,
   so it is now removed entirely.
 
-* On Linux and MacOS, require at least 65535 usable file descriptors at startup.
+* On Linux and MacOS, require at least 8192 usable file descriptors at startup.
   If less file descriptors are available to the arangod process, then the
   startup is automatically aborted.
 
-  Even the chosen minimum value of 65535 will often not be high enough to
+  Even the chosen minimum value of 8192 will often not be high enough to
   store considerable amounts of data. However, no higher value was chosen
   in order to not make too many existing small installations fail at startup
   after upgrading.
 
   The required number of file descriptors can be configured using the startup
-  option `--server.descriptors-minimum`. It defaults to 65535, but it can be
+  option `--server.descriptors-minimum`. It defaults to 8192, but it can be
   increased to ensure that arangod can make use of a sufficiently high number
   of files. Setting `--server.descriptors-minimum` to a value of `0` will
   make the startup require only an absolute minimum limit of 1024 file

--- a/arangod/RestServer/FileDescriptorsFeature.cpp
+++ b/arangod/RestServer/FileDescriptorsFeature.cpp
@@ -36,6 +36,8 @@
 #include <sys/resource.h>
 #endif
 
+#include <cstdlib>
+#include <cstring>
 #include <string>
 #include <sstream>
 
@@ -48,7 +50,6 @@ namespace arangodb {
 
 struct FileDescriptors {
   static constexpr rlim_t requiredMinimum = 1024;
-  static constexpr rlim_t recommendedMinimum = 65535;
 
   rlim_t hard;
   rlim_t soft;
@@ -74,6 +75,26 @@ struct FileDescriptors {
     return setrlimit(RLIMIT_NOFILE, &rlim);
   }
 
+  static rlim_t recommendedMinimum() {
+    // check if we are running under Valgrind...
+    char const* v = getenv("LD_PRELOAD");
+    if (v != nullptr &&
+        (strstr(v, "/valgrind/") != nullptr || strstr(v, "/vgpreload") != nullptr)) {
+      // valgrind will somehow reset the ulimit values to some very low values.
+      return requiredMinimum;
+    }
+
+#ifdef __APPLE__
+    // some MacOS versions disallow raising file descriptor limits higher than this 🙄
+    return 8192;
+#else
+    // on Linux, we will also use 8192 for now. this should be low enough so that it
+    // doesn't cause too much trouble when upgrading. however, this is not a high 
+    // enough value to operate with larger amounts of data! it is a MINIMUM!
+    return 8192;
+#endif
+  }
+
   static bool isUnlimited(rlim_t value) {
     auto max = std::numeric_limits<decltype(value)>::max();
     return (value == max || value == max / 2);
@@ -89,7 +110,7 @@ struct FileDescriptors {
 
 FileDescriptorsFeature::FileDescriptorsFeature(application_features::ApplicationServer& server)
     : ApplicationFeature(server, "FileDescriptors"), 
-      _descriptorsMinimum(FileDescriptors::recommendedMinimum) {
+      _descriptorsMinimum(FileDescriptors::recommendedMinimum()) {
   setOptional(false);
   startsAfter<GreetingsFeaturePhase>();
 }
@@ -136,8 +157,8 @@ void FileDescriptorsFeature::start() {
     s << "file-descriptors (nofiles) soft limit is too low, currently "
       << FileDescriptors::stringify(current.soft) 
       << ". please raise to at least " << required 
-      << " (e.g. ulimit -n " << required << ") or" 
-      << " adjust the value of --servers.descriptors-minimum";
+      << " (e.g. via ulimit -n " << required << ") or" 
+      << " adjust the value of the startup option --servers.descriptors-minimum";
     if (_descriptorsMinimum == 0) {
       LOG_TOPIC("a33ba", WARN, arangodb::Logger::SYSCALL) << s.str();
     } else {
@@ -148,50 +169,59 @@ void FileDescriptorsFeature::start() {
 }
 
 void FileDescriptorsFeature::adjustFileDescriptors() {
-  FileDescriptors current = FileDescriptors::load();
+  auto doAdjust = [](rlim_t recommended) {
+    FileDescriptors current = FileDescriptors::load();
 
-  LOG_TOPIC("6762c", DEBUG, arangodb::Logger::SYSCALL)
-      << "file-descriptors (nofiles) hard limit is "
-      << FileDescriptors::stringify(current.hard) 
-      << ", soft limit is "
-      << FileDescriptors::stringify(current.soft);
+    LOG_TOPIC("6762c", DEBUG, arangodb::Logger::SYSCALL)
+        << "file-descriptors (nofiles) hard limit is "
+        << FileDescriptors::stringify(current.hard) 
+        << ", soft limit is "
+        << FileDescriptors::stringify(current.soft);
 
-  rlim_t recommended = std::max<rlim_t>(
+    if (recommended > 0) {
+      if (current.hard < recommended) {
+        LOG_TOPIC("0835c", DEBUG, arangodb::Logger::SYSCALL)
+          << "hard limit " << current.hard << " is too small, trying to raise";
+
+        FileDescriptors copy = current;
+        copy.hard = recommended;
+        if (copy.store() == 0) {
+          // value adjusted successfully
+          current.hard = recommended;
+        }
+      } else {
+        TRI_ASSERT(current.hard >= recommended);
+        recommended = current.hard;
+      }
+    
+      if (current.soft < recommended) {
+        LOG_TOPIC("2940e", DEBUG, arangodb::Logger::SYSCALL)
+          << "soft limit " << current.soft << " is too small, trying to raise";
+
+        FileDescriptors copy = current;
+        copy.soft = recommended;
+        if (copy.store() != 0) {
+          LOG_TOPIC("ba733", WARN, arangodb::Logger::SYSCALL)
+            << "cannot raise the file descriptors limit to " << recommended << ": "
+            << strerror(errno);
+        }
+      }
+    }
+  };
+
+  // first try to raise file descriptors to at least the recommended minimum value.
+  // as the recommended minimum value is pretty low, there is a high chance that this
+  // actually succeeds and does not violate any hard limits
+  doAdjust(std::max<rlim_t>(
     static_cast<rlim_t>(_descriptorsMinimum),
-    FileDescriptors::recommendedMinimum
-  );
+    FileDescriptors::recommendedMinimum()
+  ));
 
-  if (recommended > 0) {
-    if (current.hard < recommended) {
-      LOG_TOPIC("0835c", DEBUG, arangodb::Logger::SYSCALL)
-        << "hard limit " << current.hard << " is too small, trying to raise";
-
-      FileDescriptors copy = current;
-      copy.hard = recommended;
-      if (copy.store() == 0) {
-        // value adjusted successfully
-        current.hard = recommended;
-      }
-    } else {
-      TRI_ASSERT(current.hard >= recommended);
-      recommended = current.hard;
-    }
-  
-    if (current.soft < recommended) {
-      LOG_TOPIC("2940e", DEBUG, arangodb::Logger::SYSCALL)
-        << "soft limit " << current.soft << " is too small, trying to raise";
-
-      FileDescriptors copy = current;
-      copy.soft = recommended;
-      if (copy.store() != 0) {
-        LOG_TOPIC("ba733", WARN, arangodb::Logger::SYSCALL)
-          << "cannot raise the file descriptors limit to " << recommended << ": "
-          << strerror(errno);
-      }
-    }
-  }
+  // still, we are not satisfied and will now try to raise the file descriptors limit
+  // even further. if that fails, then it is at least likely that the small raise in
+  // step 1 has worked.
+  doAdjust(65535);
 }
-
 
 }  // namespace arangodb
 

--- a/lib/ApplicationFeatures/EnvironmentFeature.cpp
+++ b/lib/ApplicationFeatures/EnvironmentFeature.cpp
@@ -176,12 +176,25 @@ void EnvironmentFeature::prepare() {
 
 #ifdef __linux__
   {
+#ifdef ARANGODB_HAVE_JEMALLOC
+    char const* v = getenv("LD_PRELOAD");
+    if (v != nullptr &&
+        (strstr(v, "/valgrind/") != nullptr || strstr(v, "/vgpreload") != nullptr)) {
+      // smells like Valgrind
+      LOG_TOPIC("a2a1e", WARN, arangodb::Logger::MEMORY)
+          << "found LD_PRELOAD env variable value that looks like we are running under Valgrind. "
+          << "this is unsupported in combination with jemalloc and may cause undefined behavior at least with memcheck!";
+    }
+#endif
+  }
+
+  {
     char const* v = getenv("MALLOC_CONF");
 
     if (v != nullptr) {
       // report value of MALLOC_CONF environment variable
       LOG_TOPIC("d89f7", WARN, arangodb::Logger::MEMORY)
-          << "found custom MALLOC_CONF environment value '" << v << "'";
+          << "found custom MALLOC_CONF environment value: " << v;
     }
   }
 


### PR DESCRIPTION
### Scope & Purpose

Lower the default value for required file descriptors from 64k to 8k.

this is done to avoid prolonged downtimes for users upgrading to 3.8 using _improperly configured environments_. In this case we still want to start, because the only other alternative is to fail hard and render the instance unavailable.

The very much preferred solution would be to expect a properly configured environment that can handle a large number of open files, and refuse to start otherwise. But that seems too much to expect in reality, as many people don't like reading upgrade notices, log warnings etc. and would get stuck then.

Still hopeful that we can get this through with the next major release (i.e. 4.0).

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
