### PR TITLE
fixed issue #13632

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.7.10 (XXXX-XX-XX)
 --------------------
 
+* Fixed Github issue #13632: Query Fails on Upsert with Replace_nth.
+
 * Fixed a problem that coordinators would vanish from the UI and the Health API
   if one switched the agency Supervision into maintenance mode and kept left
   that maintenance mode on for more than 24h.

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -7340,9 +7340,10 @@ AqlValue Functions::ReplaceNth(ExpressionContext* expressionContext,
     THROW_ARANGO_EXCEPTION_PARAMS(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH, AFN);
   }
 
-  AqlValueMaterializer materializer(trx);
-  VPackSlice arraySlice = materializer.slice(baseArray, false);
-  VPackSlice replaceValue = materializer.slice(newValue, false);
+  AqlValueMaterializer materializer1(trx);
+  VPackSlice arraySlice = materializer1.slice(baseArray, false);
+  AqlValueMaterializer materializer2(trx);
+  VPackSlice replaceValue = materializer2.slice(newValue, false);
 
   transaction::BuilderLeaser builder(trx);
   builder->openArray();
@@ -7359,6 +7360,7 @@ AqlValue Functions::ReplaceNth(ExpressionContext* expressionContext,
 
   uint64_t pos = length;
   if (replaceOffset >= length) {
+    AqlValueMaterializer materializer(trx);
     VPackSlice paddVpValue = materializer.slice(paddValue, false);
     while (pos < replaceOffset) {
       builder->add(paddVpValue);

--- a/tests/js/server/aql/aql-functions.js
+++ b/tests/js/server/aql/aql-functions.js
@@ -885,7 +885,6 @@ function ahuacatlFunctionsTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 
     testReplaceNthCxx : function () {
-
       var testArray = [
         null,
         true,
@@ -936,6 +935,39 @@ function ahuacatlFunctionsTestSuite () {
                                       );
           assertEqual(actual[0][actualReplaceIndex], testArray[replaceValue], msg);
         }
+      }
+    },
+
+    testReplaceNthIssue13632 : function () {
+      const cn = "UnitTestsCollection";
+      db._drop(cn);
+      db._create(cn);
+      try {
+        let query = `
+  LET values = [["t1", 0, 0], ["t1", 1, 0]]
+  FOR value_set IN values
+    LET t = value_set[0]
+    LET index = value_set[1]
+    LET value = value_set[2]
+    UPSERT {}
+    INSERT {v: {[t]: []}}
+    UPDATE { 
+      'v' : {[t]: REPLACE_NTH(OLD.v[t], index, value, value)}
+    } IN ${cn}
+    RETURN [OLD, NEW]`;
+        let actual = getQueryResults(query);
+        assertEqual(2, actual.length);
+
+        let OLD, NEW;
+        [OLD, NEW] = actual[0];
+        assertNull(OLD);
+        assertEqual({ t1: [] }, NEW.v);
+
+        [OLD, NEW] = actual[1];
+        assertEqual({ t1: [] }, OLD.v);
+        assertEqual({ t1: [0, 0] }, NEW.v);
+      } finally {
+        db._drop(cn);
       }
     },
 

--- a/tests/js/server/aql/aql-functions.js
+++ b/tests/js/server/aql/aql-functions.js
@@ -939,6 +939,10 @@ function ahuacatlFunctionsTestSuite () {
     },
 
     testReplaceNthIssue13632 : function () {
+      if (require("internal").isCluster()) {
+        return;
+      }
+
       const cn = "UnitTestsCollection";
       db._drop(cn);
       db._create(cn);

--- a/tests/js/server/aql/aql-functions.js
+++ b/tests/js/server/aql/aql-functions.js
@@ -949,7 +949,6 @@ FOR s IN NOOPT([["t1", 0, 0, null], ["t1", 1, 0, first]])
   RETURN [old, IS_NULL(old) ? first : MERGE(first, {v: {[t]: REPLACE_NTH(old.v[t], index, value, value)}})]
 `;
       let actual = getQueryResults(query);
-      print(actual);
       assertEqual(2, actual.length);
 
       let OLD, NEW;


### PR DESCRIPTION
### Scope & Purpose

Fixed issue #13632: Query Fails on Upsert with Replace_nth

The problem was caused by the same AqlValueMaterializer being used to hold two objects at the same time, which obviously does not work.

No backports are required for 3.6, as REPLACE_NTH does not exist in 3.6.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] GitHub issue / Jira ticket number: https://github.com/arangodb/arangodb/issues/13632

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (shell_server_aql)

Link to Jenkins PR run:
