### PR TITLE
Backported AQL sort performance improvements from devel

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,45 @@
 v3.7.10 (XXXX-XX-XX)
 --------------------
 
+* Backported AQL sort performance improvements from devel.
+  This change can improve the performance of local sorts operations, e.g.
+
+  Baseline (3.7.9):
+
+      Query String (94 chars, cacheable: false):
+       FOR i IN 1..500000 LET value = CONCAT('testvalue-to-be-sorted', i) SORT value ASC RETURN value
+
+      Execution plan:
+       Id   NodeType            Calls    Items   Runtime [s]   Comment
+        1   SingletonNode           1        1       0.00003   * ROOT
+        2   CalculationNode         1        1       0.00003     - LET #2 = 1 .. 500000   /* range */   /* simple expression */
+        3   EnumerateListNode     500   500000       0.08725     - FOR i IN #2   /* list iteration */
+        4   CalculationNode       500   500000       0.22722       - LET value = CONCAT("testvalue-to-be-sorted", i)   /* simple expression */
+        5   SortNode              500   500000       2.05180       - SORT value ASC   /* sorting strategy: standard */
+        6   ReturnNode            500   500000       0.02911       - RETURN value
+
+      Query Statistics:
+       Writes Exec   Writes Ign   Scan Full   Scan Index   Filtered   Exec Time [s]
+                 0            0           0            0          0         2.39644
+
+  With sort optimization (3.7.10):
+
+      Query String (94 chars, cacheable: false):
+       FOR i IN 1..500000 LET value = CONCAT('testvalue-to-be-sorted', i) SORT value ASC RETURN value
+
+      Execution plan:
+       Id   NodeType            Calls    Items   Runtime [s]   Comment
+        1   SingletonNode           1        1       0.00002   * ROOT
+        2   CalculationNode         1        1       0.00003     - LET #2 = 1 .. 500000   /* range */   /* simple expression */
+        3   EnumerateListNode     500   500000       0.08755     - FOR i IN #2   /* list iteration */
+        4   CalculationNode       500   500000       0.26161       - LET value = CONCAT("testvalue-to-be-sorted", i)   /* simple expression */
+        5   SortNode              500   500000       1.36070       - SORT value ASC   /* sorting strategy: standard */
+        6   ReturnNode            500   500000       0.02864       - RETURN value
+
+      Query Statistics:
+       Writes Exec   Writes Ign   Scan Full   Scan Index   Filtered   Exec Time [s]
+                 0            0           0            0          0         1.73940
+
 * Fixed a problem that coordinators would vanish from the UI and the Health API
   if one switched the agency Supervision into maintenance mode and kept left
   that maintenance mode on for more than 24h.

--- a/arangod/Aql/AqlItemMatrix.cpp
+++ b/arangod/Aql/AqlItemMatrix.cpp
@@ -46,6 +46,16 @@ std::pair<SharedAqlItemBlockPtr, size_t> AqlItemMatrix::getBlock(size_t index) c
   return  {_blocks[index], index == 0 ? _startIndexInFirstBlock : 0};
 }
 
+std::pair<AqlItemBlock const*, size_t> AqlItemMatrix::getBlockRef(size_t index) const noexcept {
+  TRI_ASSERT(index < numberOfBlocks());
+  // The first block could contain a shadowRow
+  // and the first unused data row, could be after the
+  // shadowRow.
+  // All other blocks start with the first row as data row
+  TRI_ASSERT(_blocks[index].get());
+  return  {_blocks[index].get(), index == 0 ? _startIndexInFirstBlock : 0};
+}
+
 InputAqlItemRow AqlItemMatrix::getRow(AqlItemMatrix::RowIndex index) const noexcept {
   auto const& [block, unused] = getBlock(index.first);
   TRI_ASSERT(index.second >= unused);

--- a/arangod/Aql/AqlItemMatrix.h
+++ b/arangod/Aql/AqlItemMatrix.h
@@ -95,6 +95,7 @@ class AqlItemMatrix {
   size_t numberOfBlocks() const noexcept;
 
   std::pair<SharedAqlItemBlockPtr, size_t> getBlock(size_t index) const noexcept;
+  std::pair<AqlItemBlock const*, size_t> getBlockRef(size_t index) const noexcept;
 
   bool stoppedOnShadowRow() const noexcept;
 

--- a/arangod/Aql/SortExecutor.cpp
+++ b/arangod/Aql/SortExecutor.cpp
@@ -46,11 +46,11 @@ class OurLessThan {
       : _vpackOptions(options), _input(input), _sortRegisters(sortRegisters) {}
 
   bool operator()(AqlItemMatrix::RowIndex const& a, AqlItemMatrix::RowIndex const& b) const {
-    InputAqlItemRow const& left = _input.getRow(a);
-    InputAqlItemRow const& right = _input.getRow(b);
+    auto const& left = _input.getBlockRef(a.first);
+    auto const& right = _input.getBlockRef(b.first);
     for (auto const& reg : _sortRegisters) {
-      AqlValue const& lhs = left.getValue(reg.reg);
-      AqlValue const& rhs = right.getValue(reg.reg);
+      AqlValue const& lhs = left.first->getValueReference(a.second, reg.reg);
+      AqlValue const& rhs = right.first->getValueReference(b.second, reg.reg);
 
       int const cmp = AqlValue::Compare(_vpackOptions, lhs, rhs, true);
 


### PR DESCRIPTION
### Scope & Purpose

Backported AQL sort performance improvements from devel (by @gnusi and @Dronplane).

This change can improve the performance of local sorts operations, e.g.

**Baseline (3.7.9)**:

    Query String (94 chars, cacheable: false):
     FOR i IN 1..500000 LET value = CONCAT('testvalue-to-be-sorted', i) SORT value ASC RETURN value

    Execution plan:
     Id   NodeType            Calls    Items   Runtime [s]   Comment
      1   SingletonNode           1        1       0.00003   * ROOT
      2   CalculationNode         1        1       0.00003     - LET #2 = 1 .. 500000   /* range */   /* simple expression */
      3   EnumerateListNode     500   500000       0.08725     - FOR i IN #2   /* list iteration */
      4   CalculationNode       500   500000       0.22722       - LET value = CONCAT("testvalue-to-be-sorted", i)   /* simple expression */
      5   SortNode              500   500000       2.05180       - SORT value ASC   /* sorting strategy: standard */
      6   ReturnNode            500   500000       0.02911       - RETURN value

    Query Statistics:
     Writes Exec   Writes Ign   Scan Full   Scan Index   Filtered   Exec Time [s]
               0            0           0            0          0         2.39644

**With sort optimization (3.7.10)**:

    Query String (94 chars, cacheable: false):
     FOR i IN 1..500000 LET value = CONCAT('testvalue-to-be-sorted', i) SORT value ASC RETURN value

    Execution plan:
     Id   NodeType            Calls    Items   Runtime [s]   Comment
      1   SingletonNode           1        1       0.00002   * ROOT
      2   CalculationNode         1        1       0.00003     - LET #2 = 1 .. 500000   /* range */   /* simple expression */
      3   EnumerateListNode     500   500000       0.08755     - FOR i IN #2   /* list iteration */
      4   CalculationNode       500   500000       0.26161       - LET value = CONCAT("testvalue-to-be-sorted", i)   /* simple expression */
      5   SortNode              500   500000       1.36070       - SORT value ASC   /* sorting strategy: standard */
      6   ReturnNode            500   500000       0.02864       - RETURN value

    Query Statistics:
     Writes Exec   Writes Ign   Scan Full   Scan Index   Filtered   Exec Time [s]
                 0            0           0            0          0         1.73940

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *shell_server_aql*.

Link to Jenkins PR run:
