### PR TITLE
UI added one shard smart graph info hint

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/templates/modalGraphTable.ejs
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/templates/modalGraphTable.ejs
@@ -65,6 +65,10 @@
       <span>SmartGraph Info: Only use non-existent collection names (vertices/edges).</span>
     </div>
 
+    <div id="smartGraphInfoOneShard" class="infoMessage" style="display: none">
+      <span>Creating SmartGraphs in a OneShard database is discouraged. SmartGraphs only make sense when data are actually distributed, which is exactly opposite to the purpose of the OneShard feature. Using a SmartGraph in a OneShard database may lead to some OneShard query optimizations being disabled.</span>
+    </div>
+
     <%
     var createTR = function(row, disableSubmitOnEnter) {
       var mandatory = '';

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/graphManagementView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/graphManagementView.js
@@ -59,6 +59,10 @@
       'row_general-writeConcern'
     ],
 
+    potentiallyNeededSmartGraphRows: [
+      'smartGraphInfoOneShard'
+    ],
+
     // rows that needs to be added while creating smarties
     neededSmartGraphRows: [
       'smartGraphInfo',
@@ -95,11 +99,36 @@
       });
     },
 
+    checkSmartGraphOneShardInfoHint: function () {
+      var self = this;
+
+      let showOneShardInfoHint = (result) => {
+        if (result.sharding === 'single') {
+          $('#' + self.potentiallyNeededSmartGraphRows[0]).show();
+        }
+      };
+
+      $.ajax({
+        type: 'GET',
+        cache: false,
+        url: arangoHelper.databaseUrl('/_api/database/current'),
+        contentType: 'application/json',
+        processData: false,
+        async: true,
+        success: function (data) {
+          showOneShardInfoHint(data.result);
+        },
+        error: function (ignore) {
+        }
+      });
+    },
+
     setSmartGraphRows: function (cache) {
       $('#createGraph').addClass('active');
       this.setCacheModeState(cache);
 
       this.hideGeneralGraphRows();
+      this.checkSmartGraphOneShardInfoHint();
       _.each(this.neededSmartGraphRows, function (rowId) {
         $('#' + rowId).show();
       });
@@ -107,6 +136,9 @@
 
     hideSmartGraphRows: function () {
       _.each(this.neededSmartGraphRows, function (rowId) {
+        $('#' + rowId).hide();
+      });
+      _.each(this.potentiallyNeededSmartGraphRows, function (rowId) {
         $('#' + rowId).hide();
       });
     },

--- a/js/apps/system/_admin/aardvark/APP/frontend/scss/_modals.scss
+++ b/js/apps/system/_admin/aardvark/APP/frontend/scss/_modals.scss
@@ -365,6 +365,9 @@
     border-radius: 3px;
     font-size: 9pt;
     padding: 5px;
+    font-weight: 400;
+    color: #000;
+    margin-bottom: 10px;
   }
 }
 


### PR DESCRIPTION
### Scope & Purpose

The web UI displays now an additional hint during smart graph creation (modal dialog) in case a user wants to 
create a smart graph in a one shard database.

- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Design document: https://arangodb.atlassian.net/browse/GORDO-1037

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*