### PR TITLE
fix anachronistic "master"/"slave" terms in the replication UI

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/templates/replicationView.ejs
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/templates/replicationView.ejs
@@ -5,7 +5,7 @@
 
         <div class="pure-u-1-2 pure-u-md-1-3">
           <div class="valueWrapper">
-            <div id="info-mode-id" class="value"><%=info.state%></div>
+            <div id="info-state-id" class="value"><%=info.state%></div>
             <div class="graphLabel">State</div>
           </div>
         </div>
@@ -20,9 +20,9 @@
         <div class="pure-u-1-2 pure-u-md-1-3">
           <div class="valueWrapper">
             <% if (info.role === 'follower' && mode !== 3) { %>
-              <div id="info-role-id" class="value">Slave</div>
+              <div id="info-role-id" class="value">Follower</div>
             <% } else if (info.role === 'leader' && mode !== 3) { %>
-              <div id="info-role-id" class="value">Master</div>
+              <div id="info-role-id" class="value">Leader</div>
             <% } else { %>
               <div id="info-role-id" class="value"><%=info.role%></div>
             <% } %>
@@ -74,7 +74,7 @@
                 </td>
               </tr>
                 <tr>
-                  <td><div>This node is not replicating from any other node. Also there are no active slaves or followers found. </br>Please visit our <a href="https://www.arangodb.com/docs/stable/architecture-replication.html">Documentation</a> to find out how to setup replication.</div></td>
+                  <td><div>This node is not replicating from any other node. Also there are no active followers found. </br>Please visit our <a href="https://www.arangodb.com/docs/stable/architecture-replication.html">Documentation</a> to find out how to setup replication.</div></td>
                 </tr>
             </tbody>
         </table>
@@ -102,11 +102,7 @@
                 <% if (mode === 3) { %>
                   <td id="info-role-id"><%=info.role%></td>
                 <% } else { %>
-                  <% if (info.role === 'follower') { %>
-                    <td id="info-role-id">Slave</td>
-                  <% } else { %>
-                    <td id="info-role-id">Master</td>
-                  <% } %>
+                  <td id="info-role-id">Follower</td>
                 <% } %>
               </tr>
             </tbody>
@@ -168,11 +164,7 @@
     <% if (info.role === 'leader') { %>
       <div class="repl-logger">
         <div class="categoryBar">
-          <% if (mode === 3) { %>
-            <h4>Leader State</h4>
-          <% } else { %>
-            <h4>Master State</h4>
-          <% } %>
+          <h4>Leader State</h4>
         </div>
         <table class="pure-table">
             <tbody>
@@ -194,11 +186,7 @@
 
       <div class="repl-logger-clients">
         <div class="categoryBar">
-          <% if (mode === 3) { %>
-            <h4>Follower States</h4>
-          <% } else { %>
-            <h4>Slave States</h4>
-          <% } %>
+          <h4>Follower States</h4>
         </div>
         <table class="pure-table" id="repl-logger-clients">
             <thead>
@@ -219,11 +207,7 @@
     <% if (info.role === 'follower') { %>
       <div class="repl-applier">
         <div class="categoryBar">
-          <% if (mode === 3) { %>
-            <h4>Follower States</h4>
-          <% } else { %>
-            <h4>Slave States</h4>
-          <% } %>
+          <h4>Follower States</h4>
         </div>
 
         <table id="repl-follower-table" class="pure-table" style="width: 100%">

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/replicationView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/replicationView.js
@@ -384,12 +384,7 @@
         });
       }
 
-      var leader;
-      if (self.mode === 3) {
-        leader = 'Leader';
-      } else {
-        leader = 'Master';
-      }
+      var leader = 'Leader';
 
       var graphDataTime = {
         leader: {
@@ -416,13 +411,7 @@
         var colorCount = 0;
         _.each(data.clients, function (client) {
           if (!graphDataTime[client.serverId]) {
-            var key;
-            if (self.mode === 3) {
-              key = 'Follower (' + client.serverId + ')';
-            } else {
-              key = 'Slave (' + client.serverId + ')';
-            }
-
+            var key = 'Follower (' + client.serverId + ')';
             graphDataTime[client.serverId] = {
               key: key,
               color: self.colors[colorCount],
@@ -615,15 +604,15 @@
               self.info.mode = 'Active Failover';
               self.info.level = 'Server';
             } else if (self.mode === 2) {
-              self.info.mode = 'Master/Slave';
+              self.info.mode = 'Leader/Follower';
               self.info.level = 'Server';
             } else if (self.mode === 1) {
-              self.info.mode = 'Master/Slave';
+              self.info.mode = 'Leader/Follower';
               if (self.info.role === 'follower') {
                 self.info.level = 'Database';
               } else {
                 // self.info.level = 'Database/Server';
-                self.info.level = 'Check slaves for details';
+                self.info.level = 'Check followers for details';
               }
             }
           }


### PR DESCRIPTION
### Scope & Purpose

Fix revolting "master"/"slave" terms in the replication UI of the web interface, and replace them with more adequate "leader"/"follower" terms.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.7: https://github.com/arangodb/arangodb/pull/13707, 3.6: https://github.com/arangodb/arangodb/pull/13708

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

