### PR TITLE
Compact collection and index ranges in background

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,15 @@
 devel
 -----
 
+* When dropping a collection or an index with a larger amount of documents, the
+  key range for the collection/index in RocksDB gets compacted. Previously, the
+  compaction was running in foreground and thus would block the deletion operations.
+  Now, the compaction is running in background, so that the deletion operations 
+  can return earlier. 
+  The maximum number of compaction jobs that are executed in background can be
+  configured using the new startup parameter `--rocksdb.max-parallel-compactions`, 
+  which defaults to 2.
+
 * The cluster dashboard charts in the web UI are now more readable during the
   initialization phase. Additionally, the amount of agents are now displayed
   there as well. An agent failure will also appear here in case it exists.

--- a/arangod/ClusterEngine/ClusterCollection.cpp
+++ b/arangod/ClusterEngine/ClusterCollection.cpp
@@ -25,6 +25,7 @@
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/ReadLocker.h"
+#include "Basics/RecursiveLocker.h"
 #include "Basics/Result.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/VelocyPackHelper.h"
@@ -135,7 +136,7 @@ Result ClusterCollection::updateProperties(VPackSlice const& slice, bool doSync)
   TRI_ASSERT(_info.slice().isObject());
   TRI_ASSERT(_info.isClosed());
 
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   for (auto& idx : _indexes) {
     static_cast<ClusterIndex*>(idx.get())->updateProperties(_info.slice());
   }
@@ -181,7 +182,7 @@ void ClusterCollection::figuresSpecific(bool /*details*/, arangodb::velocypack::
 
 /// @brief closes an open collection
 ErrorCode ClusterCollection::close() {
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   for (auto it : _indexes) {
     it->unload();
   }
@@ -189,14 +190,14 @@ ErrorCode ClusterCollection::close() {
 }
 
 void ClusterCollection::load() {
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   for (auto it : _indexes) {
     it->load();
   }
 }
 
 void ClusterCollection::unload() {
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   for (auto it : _indexes) {
     it->unload();
   }
@@ -214,7 +215,7 @@ uint64_t ClusterCollection::numberDocuments(transaction::Methods* trx) const {
 size_t ClusterCollection::memory() const { return 0; }
 
 void ClusterCollection::prepareIndexes(arangodb::velocypack::Slice indexesSlice) {
-  WRITE_LOCKER(guard, _indexesLock);
+  RECURSIVE_WRITE_LOCKER(_indexesLock, _indexesLockWriteOwner);
   TRI_ASSERT(indexesSlice.isArray());
 
   StorageEngine& engine =
@@ -261,7 +262,7 @@ std::shared_ptr<Index> ClusterCollection::createIndex(arangodb::velocypack::Slic
   WRITE_LOCKER(guard, _exclusiveLock);
   std::shared_ptr<Index> idx;
 
-  WRITE_LOCKER(guard2, _indexesLock);
+  RECURSIVE_WRITE_LOCKER(_indexesLock, _indexesLockWriteOwner);
   idx = lookupIndex(info);
   if (idx) {
     created = false;
@@ -291,7 +292,7 @@ bool ClusterCollection::dropIndex(IndexId iid) {
     return true;
   }
 
-  WRITE_LOCKER(guard, _indexesLock);
+  RECURSIVE_WRITE_LOCKER(_indexesLock, _indexesLockWriteOwner);
   for (auto it  : _indexes) {
     if (iid == it->id()) {
       _indexes.erase(it);
@@ -317,11 +318,6 @@ std::unique_ptr<IndexIterator> ClusterCollection::getAnyIterator(transaction::Me
 
 Result ClusterCollection::truncate(transaction::Methods& /*trx*/, OperationOptions& /*options*/) {
   return Result(TRI_ERROR_NOT_IMPLEMENTED);
-}
-
-/// @brief compact-data operation
-Result ClusterCollection::compact() {
-  return {};
 }
 
 Result ClusterCollection::lookupKey(transaction::Methods* /*trx*/, VPackStringRef /*key*/,

--- a/arangod/ClusterEngine/ClusterCollection.h
+++ b/arangod/ClusterEngine/ClusterCollection.h
@@ -114,9 +114,6 @@ class ClusterCollection final : public PhysicalCollection {
 
   Result truncate(transaction::Methods& trx, OperationOptions& options) override;
   
-  /// @brief compact-data operation
-  Result compact() override;
-
   void deferDropCollection(std::function<bool(LogicalCollection&)> const& callback) override;
 
   Result lookupKey(transaction::Methods* trx, velocypack::StringRef key,

--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -464,16 +464,12 @@ RestStatus RestCollectionHandler::handleCommandPut() {
     }
 
   } else if (sub == "compact") {
-    res = coll->compact();
+    coll->compact();
 
-    if (res.ok()) {
-      collectionRepresentation(name, /*showProperties*/ false,
-                               /*showFigures*/ FiguresType::None,
-                               /*showCount*/ CountType::None);
-      return standardResponse();
-    }
-    generateError(res);
-    return RestStatus::DONE;
+    collectionRepresentation(name, /*showProperties*/ false,
+                             /*showFigures*/ FiguresType::None,
+                             /*showCount*/ CountType::None);
+    return standardResponse();
   } else if (sub == "responsibleShard") {
     if (!ServerState::instance()->isCoordinator()) {
       res.reset(TRI_ERROR_CLUSTER_ONLY_ON_COORDINATOR);

--- a/arangod/RocksDBEngine/RocksDBBackgroundThread.cpp
+++ b/arangod/RocksDBEngine/RocksDBBackgroundThread.cpp
@@ -111,6 +111,9 @@ void RocksDBBackgroundThread::run() {
         _engine.pruneWalFiles();
       }
         
+      if (!isStopping()) {
+        _engine.processCompactions();
+      }
     } catch (std::exception const& ex) {
       LOG_TOPIC("8236f", WARN, Logger::ENGINES)
           << "caught exception in rocksdb background thread: " << ex.what();

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -26,6 +26,7 @@
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/PlanCache.h"
 #include "Basics/ReadLocker.h"
+#include "Basics/RecursiveLocker.h"
 #include "Basics/Result.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/StringUtils.h"
@@ -264,7 +265,7 @@ void RocksDBCollection::getPropertiesVPack(velocypack::Builder& result) const {
 
 /// @brief closes an open collection
 ErrorCode RocksDBCollection::close() {
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   for (auto it : _indexes) {
     it->unload();
   }
@@ -281,7 +282,7 @@ void RocksDBCollection::load() {
       }
     }
   }
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   for (auto it : _indexes) {
     it->load();
   }
@@ -293,7 +294,7 @@ void RocksDBCollection::unload() {
     destroyCache();
     TRI_ASSERT(_cache.get() == nullptr);
   }
-  READ_LOCKER(indexGuard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   for (auto it : _indexes) {
     it->unload();
   }
@@ -312,7 +313,8 @@ void RocksDBCollection::prepareIndexes(arangodb::velocypack::Slice indexesSlice)
   auto& engine = selector.engine<RocksDBEngine>();
   std::vector<std::shared_ptr<Index>> indexes;
   {
-    READ_LOCKER(guard, _indexesLock);  // link creation needs read-lock too
+    // link creation needs read-lock too
+    RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
     if (indexesSlice.length() == 0 && _indexes.empty()) {
       engine.indexFactory().fillSystemIndexes(_logicalCollection, indexes);
     } else {
@@ -320,7 +322,7 @@ void RocksDBCollection::prepareIndexes(arangodb::velocypack::Slice indexesSlice)
     }
   }
 
-  WRITE_LOCKER(guard, _indexesLock);
+  RECURSIVE_WRITE_LOCKER(_indexesLock, _indexesLockWriteOwner);
   TRI_ASSERT(_indexes.empty());
   for (std::shared_ptr<Index>& idx : indexes) {
     TRI_ASSERT(idx != nullptr);
@@ -394,7 +396,7 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice const& info,
 
   std::shared_ptr<Index> idx;
   {  // Step 1. Check for matching index
-    READ_LOCKER(guard, _indexesLock);
+    RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
     if ((idx = findIndex(info, _indexes)) != nullptr) {
       // We already have this index.
       if (idx->type() == arangodb::Index::TRI_IDX_TYPE_TTL_INDEX) {
@@ -434,7 +436,7 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice const& info,
   TRI_ASSERT(idx->type() != Index::IndexType::TRI_IDX_TYPE_EDGE_INDEX);
 
   {
-    READ_LOCKER(guard, _indexesLock);
+    RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
     for (auto const& other : _indexes) {  // conflicting index exists
       if (other->id() == idx->id() || other->name() == idx->name()) {
         // definition shares an identifier with an existing index with a
@@ -503,7 +505,7 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice const& info,
         basics::VelocyPackHelper::getBooleanValue(info, StaticStrings::IndexInBackground, false);
     if (inBackground) {  // allow concurrent inserts into index
       {
-        WRITE_LOCKER(guard, _indexesLock);
+        RECURSIVE_WRITE_LOCKER(_indexesLock, _indexesLockWriteOwner);
         _indexes.emplace(buildIdx);
       }
       res = buildIdx->fillIndexBackground(locker);
@@ -516,19 +518,20 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice const& info,
     locker.lock(); // always lock to avoid inconsistencies
 
     // Step 5. register in index list
-    WRITE_LOCKER(guard, _indexesLock);
-    if (inBackground) {  // swap in actual index
-      for (auto& it : _indexes) {
-        if (it->id() == buildIdx->id()) {
-          _indexes.erase(it);
-          _indexes.emplace(idx);
-          break;
+    {
+      RECURSIVE_WRITE_LOCKER(_indexesLock, _indexesLockWriteOwner);
+      if (inBackground) {  // swap in actual index
+        for (auto& it : _indexes) {
+          if (it->id() == buildIdx->id()) {
+            _indexes.erase(it);
+            _indexes.emplace(idx);
+            break;
+          }
         }
+      } else {
+        _indexes.emplace(idx);
       }
-    } else {
-      _indexes.emplace(idx);
     }
-    guard.unlock();
 #if USE_PLAN_CACHE
     arangodb::aql::PlanCache::instance()->invalidate(_logicalCollection.vocbase());
 #endif
@@ -554,16 +557,17 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice const& info,
 
   // cleanup routine
   if (res.fail()) { // We could not create the index. Better abort
-    WRITE_LOCKER(guard, _indexesLock);
-    auto it = _indexes.begin();
-    while (it != _indexes.end()) {
-      if ((*it)->id() == idx->id()) {
-        _indexes.erase(it);
-        break;
+    {
+      RECURSIVE_WRITE_LOCKER(_indexesLock, _indexesLockWriteOwner);
+      auto it = _indexes.begin();
+      while (it != _indexes.end()) {
+        if ((*it)->id() == idx->id()) {
+          _indexes.erase(it);
+          break;
+        }
+        it++;
       }
-      it++;
     }
-    guard.unlock();
     idx->drop();
     THROW_ARANGO_EXCEPTION(res);
   }
@@ -581,7 +585,7 @@ bool RocksDBCollection::dropIndex(IndexId iid) {
 
   std::shared_ptr<arangodb::Index> toRemove;
   {
-    WRITE_LOCKER(guard, _indexesLock);
+    RECURSIVE_WRITE_LOCKER(_indexesLock, _indexesLockWriteOwner);
     for (auto& it : _indexes) {
       if (iid == it->id()) {
         toRemove = it;
@@ -598,7 +602,7 @@ bool RocksDBCollection::dropIndex(IndexId iid) {
     return false;
   }
 
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
 
   RocksDBIndex* cindex = static_cast<RocksDBIndex*>(toRemove.get());
   TRI_ASSERT(cindex != nullptr);
@@ -731,7 +735,7 @@ Result RocksDBCollection::truncate(transaction::Methods& trx, OperationOptions& 
 
     // delete indexes, place estimator blockers
     {
-      READ_LOCKER(idxGuard, _indexesLock);
+      RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
       for (std::shared_ptr<Index> const& idx : _indexes) {
         RocksDBIndex* ridx = static_cast<RocksDBIndex*>(idx.get());
         bounds = ridx->getBounds();
@@ -767,7 +771,7 @@ Result RocksDBCollection::truncate(transaction::Methods& trx, OperationOptions& 
                                 -static_cast<int64_t>(numDocs));
 
     {
-      READ_LOCKER(idxGuard, _indexesLock);
+      RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
       for (std::shared_ptr<Index> const& idx : _indexes) {
         idx->afterTruncate(seq, &trx);  // clears caches / clears links (if applicable)
       }
@@ -1455,7 +1459,7 @@ void RocksDBCollection::figuresSpecific(bool details, arangodb::velocypack::Buil
                     rootDB, RocksDBKeyBounds::CollectionDocuments(objectId()), true)));
     builder.add("indexes", VPackValue(VPackValueType::Array));
     {
-      READ_LOCKER(guard, _indexesLock);
+      RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
       for (auto it : _indexes) {
         auto type = it->type();
         if (type == Index::TRI_IDX_TYPE_UNKNOWN ||
@@ -1536,7 +1540,7 @@ Result RocksDBCollection::insertDocument(arangodb::transaction::Methods* trx,
     // spoil the current WriteBatch, which on a RollbackToSavePoint will
     // need to be completely reconstructed. the reconstruction of write
     // batches is super expensive, so we try to avoid it here.
-    READ_LOCKER(guard, _indexesLock);
+    RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
 
     for (auto const& idx : _indexes) {
       RocksDBIndex* rIdx = static_cast<RocksDBIndex*>(idx.get());
@@ -1573,7 +1577,7 @@ Result RocksDBCollection::insertDocument(arangodb::transaction::Methods* trx,
 
   bool needReversal = false;
   
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
 
   for (auto it = _indexes.begin(); it != _indexes.end(); it++) {
     RocksDBIndex* rIdx = static_cast<RocksDBIndex*>(it->get());
@@ -1631,7 +1635,7 @@ Result RocksDBCollection::removeDocument(arangodb::transaction::Methods* trx,
       << " seq: " << mthds->sequenceNumber()
       << " objectID " << objectId() << " name: " << _logicalCollection.name();*/
 
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   bool needReversal = false;
   for (auto it = _indexes.begin(); it != _indexes.end(); it++) {
     RocksDBIndex* rIdx = static_cast<RocksDBIndex*>(it->get());
@@ -1687,7 +1691,7 @@ Result RocksDBCollection::updateDocument(transaction::Methods* trx,
     // spoil the current WriteBatch, which on a RollbackToSavePoint will
     // need to be completely reconstructed. the reconstruction of write
     // batches is super expensive, so we try to avoid it here.
-    READ_LOCKER(guard, _indexesLock);
+    RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
 
     for (auto const& idx : _indexes) {
       RocksDBIndex* rIdx = static_cast<RocksDBIndex*>(idx.get());
@@ -1734,7 +1738,7 @@ Result RocksDBCollection::updateDocument(transaction::Methods* trx,
     invalidateCacheEntry(key.ref());
   }
 
-  READ_LOCKER(guard, _indexesLock);
+  RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
   bool needReversal = false;
   for (auto it = _indexes.begin(); it != _indexes.end(); it++) {
     auto rIdx = static_cast<RocksDBIndex*>(it->get());

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -84,6 +84,7 @@
 #include "RocksDBEngine/RocksDBV8Functions.h"
 #include "RocksDBEngine/RocksDBValue.h"
 #include "RocksDBEngine/RocksDBWalAccess.h"
+#include "Scheduler/SchedulerFeature.h"
 #include "Transaction/Context.h"
 #include "Transaction/Manager.h"
 #include "Transaction/Options.h"
@@ -178,6 +179,7 @@ RocksDBEngine::RocksDBEngine(application_features::ApplicationServer& server)
       _maxTransactionSize(transaction::Options::defaultMaxTransactionSize),
       _intermediateCommitSize(transaction::Options::defaultIntermediateCommitSize),
       _intermediateCommitCount(transaction::Options::defaultIntermediateCommitCount),
+      _maxParallelCompactions(2),
       _pruneWaitTime(10.0),
       _pruneWaitTimeInitial(180.0),
       _maxWalArchiveSizeLimit(0),
@@ -200,7 +202,8 @@ RocksDBEngine::RocksDBEngine(application_features::ApplicationServer& server)
 #else
       _createShaFiles(false),
 #endif
-      _lastHealthCheckSuccessful(false) {
+      _lastHealthCheckSuccessful(false),
+      _runningCompactions(0) {
   server.addFeature<RocksDBOptionFeature>();
 
   startsAfter<BasicFeaturePhaseServer>();
@@ -304,6 +307,11 @@ void RocksDBEngine::collectOptions(std::shared_ptr<options::ProgramOptions> opti
                      "when this number of "
                      "operations is reached in a transaction",
                      new UInt64Parameter(&_intermediateCommitCount));
+
+  options->addOption("--rocksdb.max-parallel-compactions",
+                     "maximum number of parallel compactions jobs",
+                     new UInt64Parameter(&_maxParallelCompactions))
+                     .setIntroducedIn(30711);
 
   options->addOption("--rocksdb.sync-interval",
                      "interval for automatic, non-requested disk syncs (in "
@@ -1324,6 +1332,90 @@ RecoveryState RocksDBEngine::recoveryState() noexcept {
 // current recovery tick
 TRI_voc_tick_t RocksDBEngine::recoveryTick() noexcept {
   return TRI_voc_tick_t(server().getFeature<RocksDBRecoveryManager>().recoveryTick());
+}
+void RocksDBEngine::compactRange(RocksDBKeyBounds bounds) {
+  {
+    WRITE_LOCKER(locker, _pendingCompactionsLock);
+    _pendingCompactions.push_back(std::move(bounds));
+  }
+
+  // directly kick off compactions if there is enough processing
+  // capacity
+  processCompactions();
+}
+
+void RocksDBEngine::processCompactions() {
+  Scheduler* scheduler = arangodb::SchedulerFeature::SCHEDULER;
+  if (scheduler == nullptr) {
+    return;
+  }
+
+  uint64_t maxIterations = _maxParallelCompactions;
+  uint64_t iterations = 0;
+  while (++iterations <= maxIterations) {
+    if (server().isStopping()) {
+      // don't fire off more compactions while we are shutting down
+      return;
+    }
+
+    RocksDBKeyBounds bounds = RocksDBKeyBounds::Empty();
+    {
+      WRITE_LOCKER(locker, _pendingCompactionsLock);
+      if (_pendingCompactions.empty() || 
+          _runningCompactions >= _maxParallelCompactions) {
+        // nothing to do, or too much to do
+        LOG_TOPIC("d5108", TRACE, Logger::ENGINES) 
+            << "checking compactions. pending: " << _pendingCompactions.size() 
+            << ", running: " << _runningCompactions; 
+        return;
+      }
+      // found something to do, now steal the item from the queue
+      bounds = std::move(_pendingCompactions.front());
+      _pendingCompactions.pop_front();
+      // set it to running already, so that concurrent callers of this method
+      // will not kick off additional jobs
+      ++_runningCompactions;
+    }
+    
+    LOG_TOPIC("6ea1b", TRACE, Logger::ENGINES) 
+          << "scheduling compaction for execution";
+    
+    bool queued = scheduler->queue(arangodb::RequestLane::CLIENT_SLOW, [this, bounds]() {
+      LOG_TOPIC("9485b", TRACE, Logger::ENGINES) 
+            << "executing compaction for range " << bounds;
+    
+      double start = TRI_microtime();
+      try {
+        rocksdb::CompactRangeOptions opts;
+        rocksdb::Slice b = bounds.start(), e = bounds.end();
+        _db->CompactRange(opts, bounds.columnFamily(), &b, &e);
+      } catch (std::exception const& ex) {
+        LOG_TOPIC("a4c42", WARN, Logger::ENGINES) 
+              << "compaction for range " << bounds 
+              << " failed with error: " << ex.what();
+      } catch (...) {
+        // whatever happens, we need to count down _runningCompactions in all cases
+      }
+      
+      LOG_TOPIC("79591", TRACE, Logger::ENGINES) 
+            << "finished compaction for range " << bounds 
+            << ", took: " << Logger::FIXED(TRI_microtime() - start);
+      
+      WRITE_LOCKER(locker, _pendingCompactionsLock);
+      TRI_ASSERT(_runningCompactions > 0);
+      --_runningCompactions;
+    });
+
+    if (ADB_UNLIKELY(!queued)) {
+      // in the very unlikely case that queuing the operation in the scheduler has failed,
+      // we will simply put it back onto our own queue
+      WRITE_LOCKER(locker, _pendingCompactionsLock);
+
+      TRI_ASSERT(_runningCompactions > 0);
+      --_runningCompactions;
+      _pendingCompactions.push_front(std::move(bounds));
+    }
+  }
 }
 
 void RocksDBEngine::createCollection(TRI_vocbase_t& vocbase,

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -938,29 +938,13 @@ void RocksDBEngine::stop() {
     }
     _syncThread.reset();
   }
- 
-  // wait for started compaction jobs to finish
-  bool compactionWarning = false;
-  while (true) {
-    {
-      READ_LOCKER(locker, _pendingCompactionsLock);
-      if (_runningCompactions == 0) {
-        break;
-      }
-    }
-      
-    if (!compactionWarning) {
-      LOG_TOPIC("9cbfd", INFO, Logger::ENGINES) << "waiting for compaction jobs to finish...";
-      compactionWarning = true;
-    }
-    // unfortunately there is not much we can do except waiting for
-    // RocksDB's compaction job(s) to finish.
-    std::this_thread::yield();
-  }
+
+  waitForCompactionJobsToFinish();
 }
 
 void RocksDBEngine::unprepare() {
   TRI_ASSERT(isEnabled());
+  waitForCompactionJobsToFinish();
   shutdownRocksDBInstance();
 }
   
@@ -2802,6 +2786,28 @@ HealthData RocksDBEngine::healthCheck() {
   }
 
   return _healthData;
+}
+
+void RocksDBEngine::waitForCompactionJobsToFinish() {
+  // wait for started compaction jobs to finish
+  int iterations = 0;
+
+  do {
+    {
+      READ_LOCKER(locker, _pendingCompactionsLock);
+      if (_runningCompactions == 0) {
+        return;
+      }
+    }
+      
+    // print this only every few seconds
+    if (iterations++ % 200 == 0) {
+      LOG_TOPIC("9cbfd", INFO, Logger::ENGINES) << "waiting for compaction jobs to finish...";
+    }
+    // unfortunately there is not much we can do except waiting for
+    // RocksDB's compaction job(s) to finish.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  } while (true);
 }
 
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -28,6 +28,7 @@
 #include "Basics/Common.h"
 #include "Basics/Mutex.h"
 #include "Basics/ReadWriteLock.h"
+#include "RocksDBEngine/RocksDBKeyBounds.h"
 #include "RocksDBEngine/RocksDBTypes.h"
 #include "StorageEngine/StorageEngine.h"
 #include "VocBase/AccessMode.h"
@@ -54,7 +55,6 @@ class PhysicalCollection;
 class RocksDBBackgroundErrorListener;
 class RocksDBBackgroundThread;
 class RocksDBKey;
-class RocksDBKeyBounds;
 class RocksDBLogValue;
 class RocksDBRecoveryHelper;
 class RocksDBReplicationManager;

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -373,6 +373,7 @@ class RocksDBEngine final : public StorageEngine {
 
  private:
   void shutdownRocksDBInstance() noexcept;
+  void waitForCompactionJobsToFinish();
   velocypack::Builder getReplicationApplierConfiguration(RocksDBKey const& key,
                                                          ErrorCode& status);
   ErrorCode removeReplicationApplierConfiguration(RocksDBKey const& key);

--- a/arangod/RocksDBEngine/RocksDBIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndex.cpp
@@ -323,13 +323,8 @@ size_t RocksDBIndex::memory() const {
 void RocksDBIndex::compact() {
   auto& selector = _collection.vocbase().server().getFeature<EngineSelectorFeature>();
   auto& engine = selector.engine<RocksDBEngine>();
-  rocksdb::TransactionDB* db = engine.db();
-  rocksdb::CompactRangeOptions opts;
   if (_cf != RocksDBColumnFamilyManager::get(RocksDBColumnFamilyManager::Family::Invalid)) {
-    RocksDBKeyBounds bounds = this->getBounds();
-    TRI_ASSERT(_cf == bounds.columnFamily());
-    rocksdb::Slice b = bounds.start(), e = bounds.end();
-    db->CompactRange(opts, _cf, &b, &e);
+    engine.compactRange(getBounds());
   }
 }
 

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.h
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.h
@@ -67,7 +67,7 @@ class RocksDBMetaCollection : public PhysicalCollection {
  
   /// @brief compact-data operation
   /// triggers rocksdb compaction for documentDB and indexes
-  Result compact() override final;
+  void compact() override final;
   
   /// estimate size of collection and indexes
   void estimateSize(velocypack::Builder& builder);

--- a/arangod/StorageEngine/PhysicalCollection.h
+++ b/arangod/StorageEngine/PhysicalCollection.h
@@ -159,7 +159,7 @@ class PhysicalCollection {
   virtual Result truncate(transaction::Methods& trx, OperationOptions& options) = 0;
 
   /// @brief compact-data operation
-  virtual Result compact() = 0;
+  virtual void compact() {}
 
   /// @brief Defer a callback to be executed when the collection
   ///        can be dropped. The callback is supposed to drop
@@ -260,6 +260,7 @@ class PhysicalCollection {
   bool const _isDBServer;
 
   mutable basics::ReadWriteLock _indexesLock;
+  mutable std::atomic<std::thread::id> _indexesLockWriteOwner;  // current thread owning '_indexesLock'
   IndexContainerType _indexes;
 };
 

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -1101,7 +1101,7 @@ Result LogicalCollection::truncate(transaction::Methods& trx, OperationOptions& 
 }
 
 /// @brief compact-data operation
-Result LogicalCollection::compact() { return getPhysical()->compact(); }
+void LogicalCollection::compact() { getPhysical()->compact(); }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief inserts a document or edge into the collection

--- a/arangod/VocBase/LogicalCollection.h
+++ b/arangod/VocBase/LogicalCollection.h
@@ -274,7 +274,7 @@ class LogicalCollection : public LogicalDataSource {
   Result truncate(transaction::Methods& trx, OperationOptions& options);
 
   /// @brief compact-data operation
-  Result compact();
+  void compact();
 
   Result insert(transaction::Methods* trx, velocypack::Slice slice,
                 ManagedDocumentResult& result, OperationOptions& options);

--- a/tests/Mocks/StorageEngineMock.cpp
+++ b/tests/Mocks/StorageEngineMock.cpp
@@ -1324,10 +1324,6 @@ arangodb::Result PhysicalCollectionMock::truncate(arangodb::transaction::Methods
   return arangodb::Result();
 }
 
-arangodb::Result PhysicalCollectionMock::compact() {
-  return arangodb::Result();
-}
-
 arangodb::Result PhysicalCollectionMock::updateInternal(
     arangodb::transaction::Methods* trx, arangodb::velocypack::Slice newSlice,
     arangodb::ManagedDocumentResult& result, arangodb::OperationOptions& options,

--- a/tests/Mocks/StorageEngineMock.h
+++ b/tests/Mocks/StorageEngineMock.h
@@ -117,7 +117,7 @@ class PhysicalCollectionMock : public arangodb::PhysicalCollection {
   virtual arangodb::RevisionId revision(arangodb::transaction::Methods* trx) const override;
   virtual arangodb::Result truncate(arangodb::transaction::Methods& trx,
                                     arangodb::OperationOptions& options) override;
-  virtual arangodb::Result compact() override;
+  virtual void compact() override {}
   virtual arangodb::Result update(arangodb::transaction::Methods* trx,
                                   arangodb::velocypack::Slice newSlice,
                                   arangodb::ManagedDocumentResult& result,


### PR DESCRIPTION
### Scope & Purpose

When dropping a collection or an index with a larger amount of documents, the
key range for the collection/index in RocksDB gets compacted. Previously, the
compaction was running in foreground and thus would block the deletion operations.
Now, the compaction is running in background, so that the deletion operations
can return earlier.
The maximum number of compaction jobs that are executed in background can be
configured using the new startup parameter `--rocksdb.max-parallel-compactions`,
which defaults to 2.

Performance implications of this change still need to be determined.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.7*: https://github.com/arangodb/arangodb/pull/13711

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
