### PR TITLE
SubQuery NoResults Cost Estimation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,9 @@ devel
   from some unusual locations, when it can't find its `tzdata` directory 
   automatically.
 
+* Fixed a bug in query cost estimation when a NoResults node occured in a spliced
+  subquery. This could lead to a server crash.
+
 * Fix slower-than-necessary arangoimport behavior:
   arangoimport has a built-in rate limiter, which can be useful for importing
   data with a somewhat constant rate. However, it is enabled by default and

--- a/arangod/Aql/CostEstimate.cpp
+++ b/arangod/Aql/CostEstimate.cpp
@@ -61,6 +61,7 @@ void CostEstimate::saveEstimatedNrItems() {
 }
 
 void CostEstimate::restoreEstimatedNrItems() {
+  TRI_ASSERT(!_outerSubqueryEstimatedNrItems.empty());
   estimatedNrItems = _outerSubqueryEstimatedNrItems.top();
   _outerSubqueryEstimatedNrItems.pop();
 }

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -2553,7 +2553,10 @@ std::unique_ptr<ExecutionBlock> NoResultsNode::createBlock(
 
 /// @brief estimateCost, the cost of a NoResults is nearly 0
 CostEstimate NoResultsNode::estimateCost() const {
-  CostEstimate estimate = CostEstimate::empty();
+  // we have trigger cost estimation for parent nodes because this node could be
+  // spliced into a subquery.
+  CostEstimate estimate = _dependencies.at(0)->getCost();
+  estimate.estimatedNrItems = 0;
   estimate.estimatedCost = 0.5;  // just to make it non-zero
   return estimate;
 }

--- a/tests/js/server/aql/aql-optimizer-costs.js
+++ b/tests/js/server/aql/aql-optimizer-costs.js
@@ -283,6 +283,95 @@ nodeTypes);
       assertEqual(3 + prevNode.estimatedCost, node.estimatedCost);
     },
 
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test that in spliced subquerys NoResult blocks ask their parent for
+///        cost estimates. Otherwise the subquery end will pop from an empty stack
+////////////////////////////////////////////////////////////////////////////////
+
+    testSplicedSubqueryNoResults : function () {
+      const query = `
+        FOR i IN 1..3
+          LET sq = (
+            FOR k IN 1..5
+              FILTER false
+              RETURN {i, k}
+          )
+          RETURN sq
+      `;
+
+      const explain = AQL_EXPLAIN(query);
+      const nodes = explain.plan.nodes;
+      const nodeTypes = nodes.map(n => n.type);
+
+      // Check the rough outline first for a better overview in case of a failure
+      // of the plan.
+      assertEqual(["SingletonNode", "CalculationNode", "CalculationNode", "EnumerateListNode", "SubqueryStartNode", "EnumerateListNode", "CalculationNode", "NoResultsNode", "SubqueryEndNode", "ReturnNode"],
+          nodeTypes);
+
+      let node, prevNode;
+      // SingletonNode
+      node = nodes[0];
+      assertEqual("SingletonNode", node.type);
+      assertEqual(1, node.estimatedNrItems);
+      assertEqual(1, node.estimatedCost);
+      // CalculationNode
+      prevNode = node;
+      node = nodes[1];
+      assertEqual("CalculationNode", node.type);
+      assertEqual(1, node.estimatedNrItems);
+      assertEqual(1 + prevNode.estimatedCost, node.estimatedCost);
+      // CalculationNode
+      prevNode = node;
+      node = nodes[2];
+      assertEqual("CalculationNode", node.type);
+      assertEqual(1, node.estimatedNrItems);
+      assertEqual(1 + prevNode.estimatedCost, node.estimatedCost);
+      // EnumerateListNode
+      prevNode = node;
+      node = nodes[3];
+      assertEqual("EnumerateListNode", node.type);
+      assertEqual(3, node.estimatedNrItems);
+      assertEqual(3 + prevNode.estimatedCost, node.estimatedCost);
+      // SubqueryStartNode
+      prevNode = node;
+      node = nodes[4];
+      assertEqual("SubqueryStartNode", node.type);
+      assertEqual(3, node.estimatedNrItems);
+      assertEqual(3 + prevNode.estimatedCost, node.estimatedCost);
+      // EnumerateListNode
+      prevNode = node;
+      node = nodes[5];
+      assertEqual("EnumerateListNode", node.type);
+      assertEqual(15, node.estimatedNrItems);
+      assertEqual(15 + prevNode.estimatedCost, node.estimatedCost);
+      // CalculationNode
+      prevNode = node;
+      node = nodes[6];
+      assertEqual("CalculationNode", node.type);
+      assertEqual(15, node.estimatedNrItems);
+      assertEqual(15 + prevNode.estimatedCost, node.estimatedCost);
+      // NoResultsNode
+      prevNode = node;
+      node = nodes[7];
+      assertEqual("NoResultsNode", node.type);
+      assertEqual(0, node.estimatedNrItems);
+      assertEqual(0.5, node.estimatedCost);
+      // SubqueryEndNode
+      prevNode = node;
+      node = nodes[8];
+      assertEqual("SubqueryEndNode", node.type);
+      assertEqual(3, node.estimatedNrItems);
+      assertEqual(3 + prevNode.estimatedCost, node.estimatedCost);
+      // ReturnNode
+      prevNode = node;
+      node = nodes[9];
+      assertEqual("ReturnNode", node.type);
+      assertEqual(3, node.estimatedNrItems);
+      assertEqual(3 + prevNode.estimatedCost, node.estimatedCost);
+    },
+
   };
 }
 


### PR DESCRIPTION
### Scope & Purpose

When a NoResults node is in a spliced subquery the cost estimation will crash because the `estimateCosts` for the SubqueryStartNode was not called. Thus the stack for item estimates was not populated. Now the NoResults node
calls its parents `estimateCosts` and then sets the costs to zero.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: to be decided

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [x] GitHub issue / Jira ticket number: https://github.com/arangodb/arangodb/issues/13702

### Testing & Verification

*(Please pick either of the following options)*

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *(please describe tests)*.
- [x] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [x] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
