### PR TITLE
Don't store selectivity estimate values for newly created system collections

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,7 +11,7 @@ devel
   The change now turns off the selectivity estimates for indexes in all newly 
   created system collections, and for new user-defined indexes of type
   "persistent", "hash" or "skiplist", there is now an attribute "estimates"
-  which can be set to `true` to disable the selectivity estimates for the index.
+  which can be set to `false` to disable the selectivity estimates for the index.
   The attribute is optional. Not setting it will lead to the index being
   created with selectivity estimates, so this is a downwards-compatible change
   for user-defined indexes.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,27 @@
 devel
 -----
 
+* Don't store selectivity estimate values for newly created system collections.
+
+  Not storing the estimates has a benefit especially for the `_statistics`
+  system collections, which are written to periodically even on otherwise
+  idle servers. In this particular case, the actual statistics data was way
+  smaller than the writes caused by the index estimate values, causing a
+  disproportional overhead just for maintaining the selectivity estimates.
+  The change now turns off the selectivity estimates for indexes in all newly 
+  created system collections, and for new user-defined indexes of type
+  "persistent", "hash" or "skiplist", there is now an attribute "estimates"
+  which can be set to `true` to disable the selectivity estimates for the index.
+  The attribute is optional. Not setting it will lead to the index being
+  created with selectivity estimates, so this is a downwards-compatible change
+  for user-defined indexes.
+
 * Added startup option `--query.global-memory-limit` to set a limit on the
   combined estimated memory usage of all AQL queries (in bytes). 
   If this option has a value of `0`, then no memory limit is in place. 
   This is also the default value and the same behavior as in previous versions
   of ArangoDB. 
-  Setting the option to a value greater zero will mean that the total memory
+  Setting the option to a value greater than zero will mean that the total memory
   usage of all AQL queries will be limited approximately to the configured value. 
   The limit is enforced by each server in a cluster independently, i.e. it can 
   be set separately for coordinators, DB servers etc. The memory usage of a 
@@ -41,7 +56,6 @@ devel
 
 * Added metric `arangodb_aql_global_memory_limit` to expose the memory limit 
   from startup option `--query.global-memory-limit`.
-
 
 * Allow setting path to the timezone information via the `TZ_DATA` environment
   variable, in the same fashion as the currently existing `ICU_DATA` environment

--- a/arangod/ClusterEngine/ClusterIndex.cpp
+++ b/arangod/ClusterEngine/ClusterIndex.cpp
@@ -153,7 +153,7 @@ bool ClusterIndex::hasSelectivityEstimate() const {
            (_estimates && 
             (_indexType == Index::TRI_IDX_TYPE_HASH_INDEX ||
              _indexType == Index::TRI_IDX_TYPE_SKIPLIST_INDEX ||
-              _indexType == Index::TRI_IDX_TYPE_PERSISTENT_INDEX));
+             _indexType == Index::TRI_IDX_TYPE_PERSISTENT_INDEX));
 #ifdef ARANGODB_USE_GOOGLE_TESTS
   } else if (_engineType == ClusterEngineType::MockEngine) {
     return false;

--- a/arangod/ClusterEngine/ClusterIndex.cpp
+++ b/arangod/ClusterEngine/ClusterIndex.cpp
@@ -57,6 +57,7 @@ ClusterIndex::ClusterIndex(IndexId id, LogicalCollection& collection,
       _engineType(engineType),
       _indexType(itype),
       _info(info),
+      _estimates(true),
       _clusterSelectivity(/* default */ 0.1) {
   TRI_ASSERT(_info.slice().isObject());
   TRI_ASSERT(_info.isClosed());
@@ -78,6 +79,17 @@ ClusterIndex::ClusterIndex(IndexId id, LogicalCollection& collection,
       // The Primary Index on RocksDB can serve _key and _id when being asked.
       _coveredFields = ::primaryIndexAttributes;
     }
+
+    // check for "estimates" attribute
+    if (_unique) {
+      _estimates = true;
+    } else if (_indexType == TRI_IDX_TYPE_HASH_INDEX ||
+               _indexType == TRI_IDX_TYPE_SKIPLIST_INDEX ||
+               _indexType == TRI_IDX_TYPE_PERSISTENT_INDEX) {
+      if (VPackSlice s = info.get(StaticStrings::IndexEstimates); s.isBoolean()) {
+        _estimates = s.getBoolean();
+      }
+    }
   }
 }
 
@@ -97,6 +109,12 @@ void ClusterIndex::toVelocyPack(VPackBuilder& builder,
   Index::toVelocyPack(builder, flags);
   builder.add(StaticStrings::IndexUnique, VPackValue(_unique));
   builder.add(StaticStrings::IndexSparse, VPackValue(_sparse));
+    
+  if (_indexType == Index::TRI_IDX_TYPE_HASH_INDEX ||
+      _indexType == Index::TRI_IDX_TYPE_SKIPLIST_INDEX ||
+      _indexType == Index::TRI_IDX_TYPE_PERSISTENT_INDEX) {
+    builder.add(StaticStrings::IndexEstimates, VPackValue(_estimates));
+  }
 
   for (auto pair : VPackObjectIterator(_info.slice())) {
     if (!pair.key.isEqualString(StaticStrings::IndexId) &&
@@ -105,7 +123,8 @@ void ClusterIndex::toVelocyPack(VPackBuilder& builder,
         !pair.key.isEqualString(StaticStrings::IndexFields) &&
         !pair.key.isEqualString("selectivityEstimate") && !pair.key.isEqualString("figures") &&
         !pair.key.isEqualString(StaticStrings::IndexUnique) &&
-        !pair.key.isEqualString(StaticStrings::IndexSparse)) {
+        !pair.key.isEqualString(StaticStrings::IndexSparse) &&
+        !pair.key.isEqualString(StaticStrings::IndexEstimates)) {
       builder.add(pair.key);
       builder.add(pair.value);
     }
@@ -130,10 +149,11 @@ bool ClusterIndex::hasSelectivityEstimate() const {
   if (_engineType == ClusterEngineType::RocksDBEngine) {
     return _indexType == Index::TRI_IDX_TYPE_PRIMARY_INDEX ||
            _indexType == Index::TRI_IDX_TYPE_EDGE_INDEX ||
-           _indexType == Index::TRI_IDX_TYPE_HASH_INDEX ||
-           _indexType == Index::TRI_IDX_TYPE_SKIPLIST_INDEX ||
            _indexType == Index::TRI_IDX_TYPE_TTL_INDEX ||
-           _indexType == Index::TRI_IDX_TYPE_PERSISTENT_INDEX;
+           (_estimates && 
+            (_indexType == Index::TRI_IDX_TYPE_HASH_INDEX ||
+             _indexType == Index::TRI_IDX_TYPE_SKIPLIST_INDEX ||
+              _indexType == Index::TRI_IDX_TYPE_PERSISTENT_INDEX));
 #ifdef ARANGODB_USE_GOOGLE_TESTS
   } else if (_engineType == ClusterEngineType::MockEngine) {
     return false;
@@ -149,6 +169,9 @@ double ClusterIndex::selectivityEstimate(arangodb::velocypack::StringRef const&)
   TRI_ASSERT(hasSelectivityEstimate());
   if (_unique) {
     return 1.0;
+  }
+  if (!_estimates) {
+    return 0.0; 
   }
 
   // floating-point tolerance

--- a/arangod/ClusterEngine/ClusterIndex.h
+++ b/arangod/ClusterEngine/ClusterIndex.h
@@ -108,6 +108,7 @@ class ClusterIndex : public Index {
   ClusterEngineType _engineType;
   Index::IndexType _indexType;
   velocypack::Builder _info;
+  bool _estimates;
   double _clusterSelectivity;
 
   // Only used in RocksDB edge index.

--- a/arangod/RocksDBEngine/RocksDBIndexFactory.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndexFactory.cpp
@@ -257,6 +257,10 @@ struct SecondaryIndexFactory : public DefaultIndexFactory {
       normalized.add("objectId",
                      arangodb::velocypack::Value(std::to_string(TRI_NewTickServer())));
     }
+    if (isCreation) { 
+      bool est = basics::VelocyPackHelper::getBooleanValue(definition, StaticStrings::IndexEstimates, true);
+      normalized.add(StaticStrings::IndexEstimates, arangodb::velocypack::Value(est));
+    }
 
     return IndexFactory::enhanceJsonIndexGeneric(definition, normalized, isCreation);
   }
@@ -289,6 +293,8 @@ struct TtlIndexFactory : public DefaultIndexFactory {
       normalized.add("objectId",
                      arangodb::velocypack::Value(std::to_string(TRI_NewTickServer())));
     }
+    // a TTL index never uses index estimates
+    normalized.add(StaticStrings::IndexEstimates, arangodb::velocypack::Value(false));
 
     return IndexFactory::enhanceJsonIndexTtl(definition, normalized, isCreation);
   }

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.h
@@ -192,6 +192,9 @@ class RocksDBVPackIndex : public RocksDBIndex {
   /// @brief whether or not partial indexing is allowed
   bool _allowPartialIndex;
 
+  /// @brief whether or not we want to have estimates
+  bool _estimates;
+
   /// @brief A fixed size library to estimate the selectivity of the index.
   /// On insertion of a document we have to insert it into the estimator,
   /// On removal we have to remove it in the estimator as well.

--- a/arangod/VocBase/Methods/Indexes.cpp
+++ b/arangod/VocBase/Methods/Indexes.cpp
@@ -483,7 +483,7 @@ Result Indexes::ensureIndex(LogicalCollection* collection, VPackSlice const& inp
 
 arangodb::Result Indexes::createIndex(LogicalCollection* coll, Index::IndexType type,
                                       std::vector<std::string> const& fields,
-                                      bool unique, bool sparse) {
+                                      bool unique, bool sparse, bool estimates) {
   VPackBuilder props;
 
   props.openObject();
@@ -499,6 +499,7 @@ arangodb::Result Indexes::createIndex(LogicalCollection* coll, Index::IndexType 
   props.close();
   props.add(arangodb::StaticStrings::IndexUnique, arangodb::velocypack::Value(unique));
   props.add(arangodb::StaticStrings::IndexSparse, arangodb::velocypack::Value(sparse));
+  props.add(arangodb::StaticStrings::IndexEstimates, arangodb::velocypack::Value(estimates));
   props.close();
 
   VPackBuilder ignored;

--- a/arangod/VocBase/Methods/Indexes.h
+++ b/arangod/VocBase/Methods/Indexes.h
@@ -53,7 +53,8 @@ struct Indexes {
 
   static arangodb::Result createIndex(LogicalCollection*, Index::IndexType,
                                       std::vector<std::string> const&,
-                                      bool unique, bool sparse);
+                                      bool unique, bool sparse,
+                                      bool estimates);
 
   static arangodb::Result ensureIndex(LogicalCollection* collection,
                                       velocypack::Slice const& definition,

--- a/arangod/VocBase/Methods/UpgradeTasks.cpp
+++ b/arangod/VocBase/Methods/UpgradeTasks.cpp
@@ -336,7 +336,7 @@ static Result createIndex(std::string const& name, Index::IndexType type,
     return Result(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
                   "Collection " + name + " not found");
   }
-  return methods::Indexes::createIndex(colIt->get(), type, fields, unique, sparse);
+  return methods::Indexes::createIndex(colIt->get(), type, fields, unique, sparse, false /*estimates*/);
 }
 
 Result createSystemStatisticsIndices(TRI_vocbase_t& vocbase,

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/templates/indicesView.ejs
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/templates/indicesView.ejs
@@ -185,6 +185,19 @@
                   </th>
                 </tr>
                 <tr>
+                  <th class="collectionTh">Maintain index selectivity estimates:</th>
+                  <th>
+                    <input id="newPersistentEstimates" type="checkbox" name="newPersistentEstimates" value="true">
+                  </th>
+                  <th class="tooltipInfoTh">
+                    <div class="tooltipDiv">
+                      <a class="index-tooltip" data-toggle="tooltip" data-placement="left" title="Maintain index selectivity estimates for this index. This option can be turned off for non-unique-indexes to improve efficiency of write operations, but will lead to the optimizer being unaware of the data distribution inside this index">
+                        <span rel="tooltip" class="arangoicon icon_arangodb_info"></span>
+                      </a>
+                    </div>
+                  </th>
+                </tr>
+                <tr>
                   <th class="collectionTh">Create in background:</th>
                   <th>
                     <input id="newPersistentBackground" type="checkbox" name="newPersistentBackground" value="true">
@@ -257,6 +270,19 @@
                   <th class="tooltipInfoTh">
                     <div class="tooltipDiv">
                       <a class="index-tooltip" data-toggle="tooltip" data-placement="left" title="Duplicate index values from the same document into a unique array index will lead to an error or not.">
+                        <span rel="tooltip" class="arangoicon icon_arangodb_info"></span>
+                      </a>
+                    </div>
+                  </th>
+                </tr>
+                <tr>
+                  <th class="collectionTh">Maintain index selectivity estimates:</th>
+                  <th>
+                    <input id="newHashEstimates" type="checkbox" name="newHashEstimates" value="true">
+                  </th>
+                  <th class="tooltipInfoTh">
+                    <div class="tooltipDiv">
+                      <a class="index-tooltip" data-toggle="tooltip" data-placement="left" title="Maintain index selectivity estimates for this index. This option can be turned off for non-unique-indexes to improve efficiency of write operations, but will lead to the optimizer being unaware of the data distribution inside this index">
                         <span rel="tooltip" class="arangoicon icon_arangodb_info"></span>
                       </a>
                     </div>
@@ -386,6 +412,19 @@
                   <th class="tooltipInfoTh">
                     <div class="tooltipDiv">
                       <a class="index-tooltip" data-toggle="tooltip" data-placement="left" title="Duplicate index values from the same document into a unique array index will lead to an error or not.">
+                        <span rel="tooltip" class="arangoicon icon_arangodb_info"></span>
+                      </a>
+                    </div>
+                  </th>
+                </tr>
+                <tr>
+                  <th class="collectionTh">Maintain index selectivity estimates:</th>
+                  <th>
+                    <input id="newSkiplistEstimates" type="checkbox" name="newSkiplistEstimates" value="true">
+                  </th>
+                  <th class="tooltipInfoTh">
+                    <div class="tooltipDiv">
+                      <a class="index-tooltip" data-toggle="tooltip" data-placement="left" title="Maintain index selectivity estimates for this index. This option can be turned off for non-unique-indexes to improve efficiency of write operations, but will lead to the optimizer being unaware of the data distribution inside this index">
                         <span rel="tooltip" class="arangoicon icon_arangodb_info"></span>
                       </a>
                     </div>

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/indicesView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/indicesView.js
@@ -128,6 +128,7 @@
       var unique;
       var sparse;
       var deduplicate;
+      var estimates;
       var background;
       var name;
 
@@ -164,6 +165,7 @@
           unique = self.checkboxToValue('#newPersistentUnique');
           sparse = self.checkboxToValue('#newPersistentSparse');
           deduplicate = self.checkboxToValue('#newPersistentDeduplicate');
+          estimates = self.checkboxToValue('#newPersistentEstimates');
           background = self.checkboxToValue('#newPersistentBackground');
           name = $('#newPersistentName').val();
           postParameter = {
@@ -172,6 +174,7 @@
             unique: unique,
             sparse: sparse,
             deduplicate: deduplicate,
+            estimates: estimates,
             inBackground: background,
             name: name
           };
@@ -181,6 +184,7 @@
           unique = self.checkboxToValue('#newHashUnique');
           sparse = self.checkboxToValue('#newHashSparse');
           deduplicate = self.checkboxToValue('#newHashDeduplicate');
+          estimates = self.checkboxToValue('#newHashEstimates');
           background = self.checkboxToValue('#newHashBackground');
           name = $('#newHashName').val();
           postParameter = {
@@ -189,6 +193,7 @@
             unique: unique,
             sparse: sparse,
             deduplicate: deduplicate,
+            estimates: estimates,
             inBackground: background,
             name: name
           };
@@ -211,6 +216,7 @@
           unique = self.checkboxToValue('#newSkiplistUnique');
           sparse = self.checkboxToValue('#newSkiplistSparse');
           deduplicate = self.checkboxToValue('#newSkiplistDeduplicate');
+          estimates = self.checkboxToValue('#newSkiplistEstimates');
           background = self.checkboxToValue('#newSkiplistBackground');
           name = $('#newSkiplistName').val();
           postParameter = {
@@ -219,6 +225,7 @@
             unique: unique,
             sparse: sparse,
             deduplicate: deduplicate,
+            estimates: estimates,
             inBackground: background,
             name: name
           };
@@ -435,7 +442,7 @@
           );
           var sparse = (v.hasOwnProperty('sparse') ? v.sparse : 'n/a');
           var extras = [];
-          ["deduplicate", "expireAfter", "minLength", "geoJson"].forEach(function(k) {
+          ["deduplicate", "expireAfter", "minLength", "geoJson", "estimates"].forEach(function(k) {
             if (v.hasOwnProperty(k)) {
               extras.push(k + ": " + v[k]);
             }
@@ -467,6 +474,9 @@
         $('#newIndexType').val(arangoHelper.escapeHtml(type));
       }
       $('#newIndexType' + type).show();
+      if (type) {
+        $('#new' + type + 'Estimates').prop('checked', true);
+      }
     },
 
     resetIndexForms: function () {
@@ -490,7 +500,6 @@
           $('#cancelIndex').detach().appendTo(elem);
           $('#createIndex').detach().appendTo(elem);
         }
-
         this.resetIndexForms();
       }
       arangoHelper.createTooltips('.index-tooltip');

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -134,6 +134,7 @@ std::string const StaticStrings::IndexName("name");
 std::string const StaticStrings::IndexSparse("sparse");
 std::string const StaticStrings::IndexType("type");
 std::string const StaticStrings::IndexUnique("unique");
+std::string const StaticStrings::IndexEstimates("estimates");
 
 // static index names
 std::string const StaticStrings::IndexNameEdge("edge");

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -131,6 +131,7 @@ class StaticStrings {
   static std::string const IndexSparse;        // index sparsity marker
   static std::string const IndexType;          // index type
   static std::string const IndexUnique;        // index uniqueness marker
+  static std::string const IndexEstimates;     // index estimates flag
 
   // static index names
   static std::string const IndexNameEdge;

--- a/tests/js/common/shell/shell-index-estimates.js
+++ b/tests/js/common/shell/shell-index-estimates.js
@@ -1,0 +1,170 @@
+/*jshint globalstrict:false, strict:false */
+/*global assertEqual, assertTrue, assertFalse */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2021 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const db = require("@arangodb").db;
+
+function indexEstimatesSuite() {
+  'use strict';
+  const cn = "UnitTestsCollectionIdx";
+
+  return {
+
+    setUp: function () {
+      db._drop(cn);
+    },
+
+    tearDown: function () {
+      db._drop(cn);
+    },
+
+    testPrimary: function () {
+      let c = db._create(cn);
+      let indexes = c.indexes();
+      assertEqual(1, indexes.length);
+      assertEqual("primary", indexes[0].type);
+      // primary index does not have an "estimates" attribute
+      assertFalse(indexes[0].hasOwnProperty("estimates"));
+      assertTrue(indexes[0].hasOwnProperty("selectivityEstimate"));
+    },
+    
+    testEdge: function () {
+      let c = db._createEdgeCollection(cn);
+      let indexes = c.indexes();
+      assertEqual(2, indexes.length);
+      assertEqual("primary", indexes[0].type);
+      assertEqual("edge", indexes[1].type);
+      // primary and edge indexes does not have an "estimates" attribute
+      assertFalse(indexes[0].hasOwnProperty("estimates"));
+      assertTrue(indexes[0].hasOwnProperty("selectivityEstimate"));
+      assertFalse(indexes[1].hasOwnProperty("estimates"));
+      assertTrue(indexes[1].hasOwnProperty("selectivityEstimate"));
+    },
+    
+    testPersistentNonUniqueDefaults: function () {
+      let c = db._create(cn);
+      c.ensureIndex({ type: "persistent", fields: ["value"], unique: false });
+      let indexes = c.indexes();
+      assertEqual(2, indexes.length);
+      assertEqual("primary", indexes[0].type);
+      assertEqual("persistent", indexes[1].type);
+      assertFalse(indexes[0].hasOwnProperty("estimates"));
+      assertTrue(indexes[0].hasOwnProperty("selectivityEstimate"));
+      // vpack index should have an estimate by default
+      assertTrue(indexes[1].hasOwnProperty("estimates"));
+      assertTrue(indexes[1].estimates);
+      assertTrue(indexes[1].hasOwnProperty("selectivityEstimate"));
+    },
+    
+    testPersistentUniqueDefaults: function () {
+      let c = db._create(cn);
+      c.ensureIndex({ type: "persistent", fields: ["value"], unique: true });
+      let indexes = c.indexes();
+      assertEqual(2, indexes.length);
+      assertEqual("primary", indexes[0].type);
+      assertEqual("persistent", indexes[1].type);
+      assertFalse(indexes[0].hasOwnProperty("estimates"));
+      assertTrue(indexes[0].hasOwnProperty("selectivityEstimate"));
+      // vpack index should have an estimate by default
+      assertTrue(indexes[1].hasOwnProperty("estimates"));
+      assertTrue(indexes[1].estimates);
+      assertTrue(indexes[1].hasOwnProperty("selectivityEstimate"));
+    },
+    
+    testPersistentNonUniqueWithEstimates: function () {
+      let c = db._create(cn);
+      c.ensureIndex({ type: "persistent", fields: ["value"], unique: false, estimates: true });
+      let indexes = c.indexes();
+      assertEqual(2, indexes.length);
+      assertEqual("primary", indexes[0].type);
+      assertEqual("persistent", indexes[1].type);
+      assertFalse(indexes[0].hasOwnProperty("estimates"));
+      assertTrue(indexes[0].hasOwnProperty("selectivityEstimate"));
+      assertTrue(indexes[1].hasOwnProperty("estimates"));
+      assertTrue(indexes[1].estimates);
+      assertTrue(indexes[1].hasOwnProperty("selectivityEstimate"));
+    },
+    
+    testPersistentUniqueWithEstimates: function () {
+      let c = db._create(cn);
+      c.ensureIndex({ type: "persistent", fields: ["value"], unique: true, estimates: true });
+      let indexes = c.indexes();
+      assertEqual(2, indexes.length);
+      assertEqual("primary", indexes[0].type);
+      assertEqual("persistent", indexes[1].type);
+      assertFalse(indexes[0].hasOwnProperty("estimates"));
+      assertTrue(indexes[0].hasOwnProperty("selectivityEstimate"));
+      assertTrue(indexes[1].hasOwnProperty("estimates"));
+      assertTrue(indexes[1].estimates);
+      assertTrue(indexes[1].hasOwnProperty("selectivityEstimate"));
+    },
+    
+    testPersistentNonUniqueNoEstimates: function () {
+      let c = db._create(cn);
+      c.ensureIndex({ type: "persistent", fields: ["value"], unique: false, estimates: false });
+      let indexes = c.indexes();
+      assertEqual(2, indexes.length);
+      assertEqual("primary", indexes[0].type);
+      assertEqual("persistent", indexes[1].type);
+      assertFalse(indexes[0].hasOwnProperty("estimates"));
+      assertTrue(indexes[0].hasOwnProperty("selectivityEstimate"));
+      assertTrue(indexes[1].hasOwnProperty("estimates"));
+      assertFalse(indexes[1].estimates);
+      assertFalse(indexes[1].hasOwnProperty("selectivityEstimate"));
+    },
+    
+    testPersistentUniqueNoEstimates: function () {
+      let c = db._create(cn);
+      c.ensureIndex({ type: "persistent", fields: ["value"], unique: true, estimates: false });
+      let indexes = c.indexes();
+      assertEqual(2, indexes.length);
+      assertEqual("primary", indexes[0].type);
+      assertEqual("persistent", indexes[1].type);
+      assertFalse(indexes[0].hasOwnProperty("estimates"));
+      assertTrue(indexes[0].hasOwnProperty("selectivityEstimate"));
+      assertTrue(indexes[1].hasOwnProperty("estimates"));
+      assertTrue(indexes[1].estimates);
+      assertTrue(indexes[1].hasOwnProperty("selectivityEstimate"));
+    },
+    
+    testTtl: function () {
+      let c = db._create(cn);
+      c.ensureIndex({ type: "ttl", fields: ["value"], expireAfter: 1800 });
+      let indexes = c.indexes();
+      assertEqual(2, indexes.length);
+      assertEqual("primary", indexes[0].type);
+      assertEqual("ttl", indexes[1].type);
+      assertFalse(indexes[0].hasOwnProperty("estimates"));
+      assertTrue(indexes[0].hasOwnProperty("selectivityEstimate"));
+      assertFalse(indexes[1].hasOwnProperty("estimates"));
+      assertFalse(indexes[1].hasOwnProperty("selectivityEstimate"));
+    },
+  };
+}
+
+jsunity.run(indexEstimatesSuite);
+
+return jsunity.done();

--- a/tests/js/server/recovery/index-selectivity.js
+++ b/tests/js/server/recovery/index-selectivity.js
@@ -1,0 +1,95 @@
+/* jshint globalstrict:false, strict:false, unused : false */
+/* global assertEqual, assertTrue, assertFalse */
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2021 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+const db = require('@arangodb').db;
+const internal = require('internal');
+const jsunity = require('jsunity');
+  
+const cn = 'UnitTestsRecovery';
+
+function runSetup () {
+  'use strict';
+  internal.debugClearFailAt();
+
+  let c1 = db._create(cn + '1');
+  c1.ensureIndex({ type: "persistent", fields: ["a"], estimates: true });
+  
+  let c2 = db._create(cn + '2');
+  c2.ensureIndex({ type: "persistent", fields: ["a"], estimates: false });
+  
+  let c3 = db._create(cn + '3');
+  c3.ensureIndex({ type: "persistent", fields: ["a"] });
+
+  c1.insert({ _key: 'crashme' }, true);
+
+  internal.debugTerminate('crashing server');
+}
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief test suite
+// //////////////////////////////////////////////////////////////////////////////
+
+function recoverySuite () {
+  'use strict';
+  jsunity.jsUnity.attachAssertions();
+
+  return {
+
+    testIndexEstimates: function () {
+      let c = db._collection(cn + '1');
+      let indexes = c.indexes();
+      assertEqual("persistent", indexes[1].type);
+      assertTrue(indexes[1].hasOwnProperty('estimates'));
+      assertTrue(indexes[1].estimates);
+      assertTrue(indexes[1].hasOwnProperty('selectivityEstimate'));
+
+      c = db._collection(cn + '2');
+      indexes = c.indexes();
+      assertEqual("persistent", indexes[1].type);
+      assertTrue(indexes[1].hasOwnProperty('estimates'));
+      assertFalse(indexes[1].estimates);
+      assertFalse(indexes[1].hasOwnProperty('selectivityEstimate'));
+      
+      c = db._collection(cn + '3');
+      indexes = c.indexes();
+      assertEqual("persistent", indexes[1].type);
+      assertTrue(indexes[1].hasOwnProperty('estimates'));
+      assertTrue(indexes[1].estimates);
+      assertTrue(indexes[1].hasOwnProperty('selectivityEstimate'));
+    }
+
+  };
+}
+
+function main (argv) {
+  'use strict';
+  if (argv[1] === 'setup') {
+    runSetup();
+    return 0;
+  } else {
+    jsunity.run(recoverySuite);
+    return jsunity.writeDone().status ? 0 : 1;
+  }
+}


### PR DESCRIPTION
### Scope & Purpose

Don't store selectivity estimate values for newly created system collections

Not storing the estimates has a benefit especially for the `_statistics`
system collections, which are written to periodically even on otherwise
idle servers. In this particular case, the actual statistics data was way
smaller than the writes caused by the index estimate values, causing a
disproportional overhead just for maintaining the selectivity estimates.
The change now turns off the selectivity estimates for indexes in all newly
created system collections, and for new user-defined indexes of type
"persistent", "hash" or "skiplist", there is now an attribute "estimates"
which can be set to `false` to disable the selectivity estimates for the index.
The attribute is optional. Not setting it will lead to the index being
created with selectivity estimates, so this is a downwards-compatible change
for user-defined indexes.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Docs PR: to be done

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in recovery, shell_server)

