### PR TITLE
Always enable FATAL log level, even with build unconditional log lines

### DIFF
--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -310,7 +310,7 @@ class Logger {
     return true;
   }
   static bool _isEnabled(LogLevel level, LogLevel topicLevel) {
-    return (int)level <= (int)topicLevel;
+    return level == LogLevel::FATAL || (int)level <= (int)topicLevel;
   }
 #else
   static bool isEnabled(LogLevel level) {


### PR DESCRIPTION
This is a simple easy of use-PR for development that will NOT have any impact on customers.

For coverage testing we have a build flag to enable all LOG messages to be generated (ignoring the log level) s.t. these lines do not flag untested.

As an unwanted side-effect: If build with this flag, the ASSERT output in development mode was also discarded and not printed.
With this PR we will print assertions again even if we compile with the log-message flags.