### PR TITLE
Bug fix 3.6/save unique id counter in agency with each hotback

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.6.13 (XXXX-XX-XX)
 --------------------
 
+* Put Sync/LatestID into hotbackup and restore it on hotbackup restore
+  if it is in the backup. This helps with unique key generation after
+  a hotbackup is restored to a young cluster.
+  
 * Fixed a bug in the web interface that displayed the error "Not authorized to
   execute this request" when trying to create an index in the web interface in a
   database other than `_system` with a user that does not have any access

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -565,9 +565,11 @@ void ClusterFeature::start() {
   // whenever a hotbackup restore is done:
   if (role == ServerState::ROLE_COORDINATOR) {
     auto hotBackupRestoreDone = [this](VPackSlice const& result) -> bool {
-      LOG_TOPIC("12636", INFO, Logger::BACKUP) << "Got a hotbackup restore "
-        "event, getting new cluster-wide unique IDs...";
-      this->_clusterInfo->uniqid(1000000);
+      if (!server().isStopping()) {
+        LOG_TOPIC("12636", INFO, Logger::BACKUP) << "Got a hotbackup restore "
+          "event, getting new cluster-wide unique IDs...";
+        this->_clusterInfo->uniqid(1000000);
+      }
       return true;
     };
     _hotbackupRestoreCallback =
@@ -585,10 +587,12 @@ void ClusterFeature::start() {
 void ClusterFeature::beginShutdown() { ClusterComm::instance()->disable(); }
 
 void ClusterFeature::stop() {
-  if (!_agencyCallbackRegistry->unregisterCallback(_hotbackupRestoreCallback)) {
+  #ifdef USE_ENTERPRISE
+  if (_hotbackupRestoreCallback != nullptr && !_agencyCallbackRegistry->unregisterCallback(_hotbackupRestoreCallback)) {
     LOG_TOPIC("84152", INFO, Logger::BACKUP) << "Strange, we could not "
       "unregister the hotbackup restore callback.";
   }
+  #endif
 
   shutdownHeartbeatThread();
   ClusterComm::instance()->stopBackgroundThreads();

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -574,8 +574,8 @@ void ClusterFeature::start() {
     };
     _hotbackupRestoreCallback =
       std::make_shared<AgencyCallback>(
-        server(), "Sync/HotBackupRestoreDone", hotBackupRestoreDone, true, false);
-    auto r =_agencyCallbackRegistry->registerCallback(_hotbackupRestoreCallback);
+        comm, "Sync/HotBackupRestoreDone", hotBackupRestoreDone, true, false);
+    bool r =_agencyCallbackRegistry->registerCallback(_hotbackupRestoreCallback);
     if (!r) {
       LOG_TOPIC("82516", WARN, Logger::BACKUP)
         << "Could not register hotbackup restore callback, this could lead "
@@ -588,7 +588,7 @@ void ClusterFeature::beginShutdown() { ClusterComm::instance()->disable(); }
 
 void ClusterFeature::stop() {
   #ifdef USE_ENTERPRISE
-  if (_hotbackupRestoreCallback != nullptr && !_agencyCallbackRegistry->unregisterCallback(_hotbackupRestoreCallback)) {
+  if (ServerState::instance()->getRole() == ServerState::ROLE_COORDINATOR && _hotbackupRestoreCallback != nullptr && !_agencyCallbackRegistry->unregisterCallback(_hotbackupRestoreCallback)) {
     LOG_TOPIC("84152", INFO, Logger::BACKUP) << "Strange, we could not "
       "unregister the hotbackup restore callback.";
   }

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -573,8 +573,8 @@ void ClusterFeature::start() {
     _hotbackupRestoreCallback =
       std::make_shared<AgencyCallback>(
         server(), "Sync/HotBackupRestoreDone", hotBackupRestoreDone, true, false);
-    Result r =_agencyCallbackRegistry->registerCallback(_hotbackupRestoreCallback, true);
-    if (r.fail()) {
+    auto r =_agencyCallbackRegistry->registerCallback(_hotbackupRestoreCallback);
+    if (!r) {
       LOG_TOPIC("82516", WARN, Logger::BACKUP)
         << "Could not register hotbackup restore callback, this could lead "
            "to problems after a restore!";

--- a/arangod/Cluster/ClusterFeature.h
+++ b/arangod/Cluster/ClusterFeature.h
@@ -133,6 +133,7 @@ class ClusterFeature : public application_features::ApplicationFeature {
   Counter& _followersRefused;
   Counter& _followersDropped;
   Counter& _addFollowerWrongChecksum;
+  std::shared_ptr<AgencyCallback> _hotbackupRestoreCallback;
 };
 
 }  // namespace arangodb

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -4510,6 +4510,16 @@ arangodb::Result ClusterInfo::agencyPlan(std::shared_ptr<VPackBuilder> body) {
   }
 
   body->add(dump.slice());
+  
+  dump = _agency.getValues("Sync/LatestID");
+
+  if (!dump.successful()) {
+    LOG_TOPIC("ce937", ERR, Logger::CLUSTER)
+        << "failed to acquire agency dump: " << dump.errorMessage();
+    return Result(dump.errorCode(), dump.errorMessage());
+  }
+
+  body->add(dump.slice());
   return Result();
 }
 
@@ -4526,8 +4536,14 @@ arangodb::Result ClusterInfo::agencyReplan(VPackSlice const plan) {
                       plan.get(
                           std::vector<std::string>{"arango", "Plan", "Views"})),
       AgencyOperation("Plan/Version", AgencySimpleOperationType::INCREMENT_OP),
-      AgencyOperation("Sync/UserVersion", AgencySimpleOperationType::INCREMENT_OP)});
+      AgencyOperation("Sync/UserVersion", AgencySimpleOperationType::INCREMENT_OP),
+      {"Sync/HotBackupRestoreDone", AgencySimpleOperationType::INCREMENT_OP}});
 
+  VPackSlice latestIdSlice = plan.get(std::vector<const char*>{"arango", "Sync", "LatestID"});
+  if (!latestIdSlice.isNone()) {
+    planTransaction.operations.push_back(
+      {"Sync/LatestID", AgencyValueOperationType::SET, latestIdSlice});
+  }
   AgencyCommResult r = _agency.sendTransactionWithFailover(planTransaction);
   if (!r.successful()) {
     arangodb::Result result(TRI_ERROR_HOT_BACKUP_INTERNAL,

--- a/arangod/Cluster/v8-cluster.cpp
+++ b/arangod/Cluster/v8-cluster.cpp
@@ -529,7 +529,7 @@ static void JS_UniqidAgency(v8::FunctionCallbackInfo<v8::Value> const& args) {
     count = TRI_ObjectToUInt64(isolate, args[0], true);
   }
 
-  if (count < 1 || count > 10000000) {
+  if (count < 1 || count > 100000000) {
     TRI_V8_THROW_EXCEPTION_PARAMETER("<count> is invalid");
   }
 

--- a/tests/js/server/dump/dump-rocksdb-cluster.js
+++ b/tests/js/server/dump/dump-rocksdb-cluster.js
@@ -811,6 +811,22 @@ function dumpTestEnterpriseSuite () {
       assertEqual(doc.cheesyness, "bread");
       assertTrue(doc._key.startsWith("cheese:"));
     },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test whether hotbackup restore restores the uniqid
+////////////////////////////////////////////////////////////////////////////////
+    testLatestId : function() {
+      if (arango.getRole() === "COORDINATOR") {
+        // Only executed in the cluster
+        // After the hotbackup was taken, we have consumed 100.000.000
+        // cluster wide unique ids. Here, we check that after the
+        // hotbackup restore the number in /arango/Sync/LatestID
+        // in the agency is lower again.
+        let next = JSON.parse(db._connection.POST("/_admin/execute?returnAsJSON=true", "return global.ArangoAgency.uniqid(1)"));
+        assertTrue(next < 100000000, "expected next uniqid after restore to be less than 100000000, not " + next);
+      }
+    },
+
   };
 }
 

--- a/tests/js/server/dump/dump-rocksdb-cluster.js
+++ b/tests/js/server/dump/dump-rocksdb-cluster.js
@@ -816,7 +816,7 @@ function dumpTestEnterpriseSuite () {
 /// @brief test whether hotbackup restore restores the uniqid
 ////////////////////////////////////////////////////////////////////////////////
     testLatestId : function() {
-      if (arango.getRole() === "COORDINATOR") {
+      if (db._connection.getRole() === "COORDINATOR") {
         // Only executed in the cluster
         // After the hotbackup was taken, we have consumed 100.000.000
         // cluster wide unique ids. Here, we check that after the

--- a/tests/js/server/dump/dump-rocksdb-modify.js
+++ b/tests/js/server/dump/dump-rocksdb-modify.js
@@ -433,6 +433,28 @@ function dumpTestSuite () {
     },
 
 ////////////////////////////////////////////////////////////////////////////////
+/// @brief test latestId
+////////////////////////////////////////////////////////////////////////////////
+
+    testLatestId : function () {
+      if (arango.getRole() === "COORDINATOR") {
+        // Only executed in the cluster
+        // The following increases /arango/Sync/LatestID in the agency
+        // by 100.000.000 and thus consumes so many cluster wide unique
+        // ids. This is checked below.
+        // Then, after a hotbackup restore, we check in the file
+        // `tests/js/server/dump/dump-cluster.js` (by means of including
+        // `tests/js/server/dump/dump-test.js`) that the lower number
+        // has been stored in the hotbackup and restored in the restore
+        // process.
+        let next = JSON.parse(db._connection.POST("/_admin/execute?returnAsJSON=true", "return global.ArangoAgency.uniqid(100000000)"));
+        assertTrue(next < 100000000, "expected next uniqid in agency to be less than 100000000, not " + next);
+        next = JSON.parse(db._connection.POST("/_admin/execute?returnAsJSON=true", "return global.ArangoAgency.uniqid(100000000)"));
+        assertTrue(next > 100000000, "expected next uniqid in agency to be greater than 100000000, not " + next);
+      }
+    }
+
+////////////////////////////////////////////////////////////////////////////////
 /// @brief test view restoring
 ////////////////////////////////////////////////////////////////////////////////
 /* not yet implemented


### PR DESCRIPTION
### Scope & Purpose

When a hotbackup is restored to a cluster which is a lot "younger" than
the one where it was taken, the entry Sync/LatestID in the agency in the
new cluster is a lot smaller than the one in the old cluster. Therefore,
the unique key generation does no longer work well. Therefore, it makes
sense to put the Sync/LatestID into the hotbackup and restore it with a
hotbackup restore. This solves the key generation problem at least in
this hotbackup related case.

This PR is a back port of the implementation of that, from #13699 .

Old hotbackups can still be restored, even if they do not contain
Sync/LatestID.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] This is a backport of #13699 into 3.6

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [x] GitHub issue / Jira ticket number: TC-18

### Testing & Verification

*(Please pick either of the following options)*

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_server / shell_server_aql)

Link to Jenkins PR run:
