### PR TITLE
Fix return type of ManagedDirectory::File::offset().

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fix progress reporting for arangoimport with large files on Windows.
+  Previously, progress was only reported for the first 2GB of data due to a
+  int overflow.
+
 * Log the actual signal instead of "control-c" and also include the process id
   of the process that sent the signal.
 

--- a/arangosh/Utils/ManagedDirectory.cpp
+++ b/arangosh/Utils/ManagedDirectory.cpp
@@ -654,15 +654,15 @@ Result const& ManagedDirectory::File::close() {
 }
 
 
-TRI_read_return_t ManagedDirectory::File::offset() const {
+std::size_t ManagedDirectory::File::offset() const {
   MUTEX_LOCKER(lock, _mutex);
 
-  TRI_read_return_t fileBytesRead = -1;
+  std::size_t fileBytesRead = -1;
 
   if (isGzip()) {
     fileBytesRead = gzoffset(_gzFile);
   } else {
-    fileBytesRead = (TRI_read_return_t)TRI_LSEEK(_fd, 0L, SEEK_CUR);
+    fileBytesRead = TRI_LSEEK(_fd, 0L, SEEK_CUR);
   } // else
 
   return fileBytesRead;

--- a/arangosh/Utils/ManagedDirectory.cpp
+++ b/arangosh/Utils/ManagedDirectory.cpp
@@ -654,10 +654,10 @@ Result const& ManagedDirectory::File::close() {
 }
 
 
-std::size_t ManagedDirectory::File::offset() const {
+std::int64_t ManagedDirectory::File::offset() const {
   MUTEX_LOCKER(lock, _mutex);
 
-  std::size_t fileBytesRead = -1;
+  std::int64_t fileBytesRead = -1;
 
   if (isGzip()) {
     fileBytesRead = gzoffset(_gzFile);

--- a/arangosh/Utils/ManagedDirectory.h
+++ b/arangosh/Utils/ManagedDirectory.h
@@ -143,7 +143,7 @@ class ManagedDirectory {
      * @brief Count of bytes read from regular or gzip file, not amount returned by read
      */
 
-    std::size_t offset() const;
+    std::int64_t offset() const;
 
     /**
      * @brief skips `count` bytes of uncompressed data.

--- a/arangosh/Utils/ManagedDirectory.h
+++ b/arangosh/Utils/ManagedDirectory.h
@@ -143,7 +143,7 @@ class ManagedDirectory {
      * @brief Count of bytes read from regular or gzip file, not amount returned by read
      */
 
-    TRI_read_return_t offset() const;
+    std::size_t offset() const;
 
     /**
      * @brief skips `count` bytes of uncompressed data.


### PR DESCRIPTION
### Scope & Purpose

On Windows `TRI_read_return_t` is defined as `int`, so previously `ManagedDirectory::File::offset()` was broken for files > 2GB.

This manifested itself as missing progress reports in arangoimport,

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*