### PR TITLE
added missing documentation for extended REST APIs

### DIFF
--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_log.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_log.md
@@ -40,7 +40,7 @@ imposes a chronological order. The default value is *asc*.
 @RESTQUERYPARAM{serverId,string,optional}
 Returns all log entries of the specified server. All other query parameters 
 remain valid. If no serverId is given, the asked server
-will reply. This parameter is only meaningful on coordinators.
+will reply. This parameter is only meaningful on Coordinators.
 
 @RESTDESCRIPTION
 Returns fatal, error, warning or info log messages from the server's global log.
@@ -109,7 +109,7 @@ imposes a chronological order. The default value is *asc*.
 @RESTQUERYPARAM{serverId,string,optional}
 Returns all log entries of the specified server. All other query parameters 
 remain valid. If no serverId is given, the asked server
-will reply. This parameter is only meaningful on coordinators.
+will reply. This parameter is only meaningful on Coordinators.
 
 @RESTDESCRIPTION
 Returns fatal, error, warning or info log messages from the server's global log.

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_log.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_log.md
@@ -38,9 +38,9 @@ Sort the log entries either ascending (if *sort* is *asc*) or descending
 imposes a chronological order. The default value is *asc*.
 
 @RESTQUERYPARAM{serverId,string,optional}
-Returns all log entries of a specified server by supplying the serverId. All
-other query parameters remain valid. If no serverId is given, the asked server
-will reply.
+Returns all log entries of the specified server. All other query parameters 
+remain valid. If no serverId is given, the asked server
+will reply. This parameter is only meaningful on coordinators.
 
 @RESTDESCRIPTION
 Returns fatal, error, warning or info log messages from the server's global log.
@@ -105,6 +105,11 @@ Only return the log entries containing the text specified in *search*.
 Sort the log entries either ascending (if *sort* is *asc*) or descending
 (if *sort* is *desc*) according to their *lid* values. Note that the *lid*
 imposes a chronological order. The default value is *asc*.
+
+@RESTQUERYPARAM{serverId,string,optional}
+Returns all log entries of the specified server. All other query parameters 
+remain valid. If no serverId is given, the asked server
+will reply. This parameter is only meaningful on coordinators.
 
 @RESTDESCRIPTION
 Returns fatal, error, warning or info log messages from the server's global log.

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_metrics.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_metrics.md
@@ -4,6 +4,12 @@
 
 @RESTHEADER{GET /_admin/metrics, Read the metrics, getMetrics}
 
+@RESTQUERYPARAMETERS
+
+@RESTQUERYPARAM{serverId,string,optional}
+Returns metrics of the specified server. If no serverId is given, the asked 
+server will reply. This parameter is only meaningful on coordinators.
+
 @RESTDESCRIPTION
 Returns the instance's current metrics in Prometheus format. The
 returned document collects all instance metrics, which are measured

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_metrics.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_metrics.md
@@ -8,7 +8,7 @@
 
 @RESTQUERYPARAM{serverId,string,optional}
 Returns metrics of the specified server. If no serverId is given, the asked 
-server will reply. This parameter is only meaningful on coordinators.
+server will reply. This parameter is only meaningful on Coordinators.
 
 @RESTDESCRIPTION
 Returns the instance's current metrics in Prometheus format. The


### PR DESCRIPTION
### Scope & Purpose

Added missing parameters to REST API documentation.
This is a documentation-only change, so there is intentionally no CHANGELOG for it.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
