### PR TITLE
Remove some leftover replication tailing clients from internal bookkeeping

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 devel
 -----
 
+* Remove some leftover replication tailing clients from internal bookkeeping
+  once they are finished with getting a shard in sync. Previously, such 
+  replication clients could have been left in the internal bookkeeping until
+  they were removed by the automatic garbage collection after 2 hours. While
+  the client entries were still in the bookkeeping tables, they could prevent
+  archived RocksDB WAL files from being dropped, leading to leader DB servers
+  keeping more WAL files around than necessary.
+
 * Allow process-specific logfile names.
 
   This change allows replacing '$PID' with the current process id in the 

--- a/arangod/Replication/DatabaseTailingSyncer.cpp
+++ b/arangod/Replication/DatabaseTailingSyncer.cpp
@@ -169,17 +169,44 @@ Result DatabaseTailingSyncer::syncCollectionCatchupInternal(arangodb::replutils:
     
   auto headers = replutils::createHeaders();
 
+  // when we leave this method, we must unregister ourselves from the leader,
+  // otherwise the leader may keep WAL logs around for us for too long
+  auto unregister = scopeGuard([&]() {
+    if (ServerState::instance()->isRunningInCluster()) {
+      try {
+        _state.connection.lease([&](httpclient::SimpleHttpClient* client) {
+          std::unique_ptr<httpclient::SimpleHttpResult> response;
+          std::string const url = tailingBaseUrl("tail") +
+                                  "serverId=" + _state.localServerIdString +
+                                  "&syncerId=" + syncerId().toString();
+          // simply send the request, but don't care about the response. if it
+          // fails, there is not much we can do from here.
+          response.reset(client->request(rest::RequestType::DELETE_REQ, url, nullptr, 0, headers));
+        });
+      } catch (...) {
+        // this must be exception-safe, but if an exception occurs, there is not
+        // much we can do
+      }
+    }
+  });
+
   while (true) {
     if (vocbase()->server().isStopping()) {
       return Result(TRI_ERROR_SHUTTING_DOWN);
     }
 
-    std::string const url = tailingBaseUrl("tail") +
-                            "chunkSize=" + StringUtils::itoa(_state.applier._chunkSize) +
-                            "&from=" + StringUtils::itoa(fromTick) +
-                            "&lastScanned=" + StringUtils::itoa(lastScannedTick) +
-                            "&serverId=" + _state.localServerIdString +
-                            "&collection=" + StringUtils::urlEncode(collectionName);
+    std::string url = tailingBaseUrl("tail") +
+                      "chunkSize=" + StringUtils::itoa(_state.applier._chunkSize) +
+                      "&from=" + StringUtils::itoa(fromTick) +
+                      "&lastScanned=" + StringUtils::itoa(lastScannedTick) +
+                      "&serverId=" + _state.localServerIdString +
+                      "&collection=" + StringUtils::urlEncode(collectionName);
+                      
+    if (syncerId().value > 0) {
+      // we must only send the syncerId along if it is != 0, otherwise we will
+      // trigger an error on the leader
+      url += "&syncerId=" + syncerId().toString();
+    }
 
     // send request
     double start = TRI_microtime();

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -1571,6 +1571,28 @@ Result TailingSyncer::runContinuousSync() {
               ", fetch tick " + StringUtils::itoa(fetchTick) +
               ", open transactions: " + StringUtils::itoa(_ongoingTransactions.size()) +
               ", parallel: yes");
+  
+  // when we leave this method, we must unregister ourselves from the leader,
+  // otherwise the leader may keep WAL logs around for us for too long
+  auto unregister = scopeGuard([&]() {
+    if (ServerState::instance()->isRunningInCluster()) {
+      try {
+        _state.connection.lease([&](httpclient::SimpleHttpClient* client) {
+          std::unique_ptr<httpclient::SimpleHttpResult> response;
+          std::string const url = tailingBaseUrl("tail") +
+                                  "serverId=" + _state.localServerIdString +
+                                  "&syncerId=" + syncerId().toString();
+          // simply send the request, but don't care about the response. if it
+          // fails, there is not much we can do from here.
+          auto headers = replutils::createHeaders();
+          response.reset(client->request(rest::RequestType::DELETE_REQ, url, nullptr, 0, headers));
+        });
+      } catch (...) {
+        // this must be exception-safe, but if an exception occurs, there is not
+        // much we can do
+      }
+    }
+  });
 
   // the shared status will wait in its destructor until all posted
   // requests have been completed/canceled!
@@ -1809,7 +1831,7 @@ void TailingSyncer::fetchLeaderLog(std::shared_ptr<Syncer::JobSynchronizer> shar
                                    TRI_voc_tick_t fetchTick, TRI_voc_tick_t lastScannedTick,
                                    TRI_voc_tick_t firstRegularTick) {
   try {
-    std::string const url =
+    std::string url =
         tailingBaseUrl("tail") +
         "chunkSize=" + StringUtils::itoa(_state.applier._chunkSize) +
         "&from=" + StringUtils::itoa(fetchTick) +
@@ -1819,6 +1841,12 @@ void TailingSyncer::fetchLeaderLog(std::shared_ptr<Syncer::JobSynchronizer> shar
         "&serverId=" + _state.localServerIdString +
         "&includeSystem=" + (_state.applier._includeSystem ? "true" : "false") +
         "&includeFoxxQueues=" + (_state.applier._includeFoxxQueues ? "true" : "false");
+    
+    if (syncerId().value > 0) {
+      // we must only send the syncerId along if it is != 0, otherwise we will
+      // trigger an error on the leader
+      url += "&syncerId=" + syncerId().toString();
+    }
     
     // send request
     setProgress(std::string("fetching leader log from tick ") + StringUtils::itoa(fetchTick) +

--- a/arangod/Replication/utilities.h
+++ b/arangod/Replication/utilities.h
@@ -154,7 +154,8 @@ struct LeaderInfo {
 };
 
 struct BatchInfo {
-  static constexpr double DefaultTimeout = 7200.0;
+  static constexpr double DefaultTimeout = 3600.0;
+  static constexpr double DefaultTimeoutForTailing = 1800.0;
 
   /// @brief dump batch id
   uint64_t id{0};

--- a/arangod/RestHandler/RestWalAccessHandler.cpp
+++ b/arangod/RestHandler/RestWalAccessHandler.cpp
@@ -185,7 +185,8 @@ RestStatus RestWalAccessHandler::execute() {
   } else if (suffixes[0] == "lastTick" && _request->requestType() == RequestType::GET) {
     handleCommandLastTick(wal);
   } else if (suffixes[0] == "tail" && (_request->requestType() == RequestType::GET ||
-                                       _request->requestType() == RequestType::PUT)) {
+                                       _request->requestType() == RequestType::PUT ||
+                                       _request->requestType() == RequestType::DELETE_REQ)) {
     handleCommandTail(wal);
   } else if (suffixes[0] == "open-transactions" &&
              _request->requestType() == RequestType::GET) {
@@ -238,6 +239,21 @@ void RestWalAccessHandler::handleCommandLastTick(WalAccess const* wal) {
 }
 
 void RestWalAccessHandler::handleCommandTail(WalAccess const* wal) {
+  // check for serverId
+  ServerId const clientId{StringUtils::uint64(_request->value("serverId"))};
+  SyncerId const syncerId = SyncerId::fromRequest(*_request);
+  std::string const& clientInfo = _request->value("clientInfo");
+
+  if (_request->requestType() == arangodb::rest::RequestType::DELETE_REQ) {
+    // this is a notification that tailing has come to an end, so we
+    // can unregister the client from the list of tracked clients
+    server().getFeature<DatabaseFeature>().enumerateDatabases([&](TRI_vocbase_t& vocbase) -> void {
+      vocbase.replicationClients().untrack(syncerId, clientId, clientInfo);
+    });
+    generateOk(rest::ResponseCode::OK, VPackSlice::emptyObjectSlice());
+    return;
+  }
+
   // track the number of parallel invocations of the tailing API
   auto& rf = _vocbase.server().getFeature<ReplicationFeature>();
   // this may throw when too many threads are going into tailing
@@ -251,11 +267,6 @@ void RestWalAccessHandler::handleCommandTail(WalAccess const* wal) {
   if (!parseFilter(filter)) {
     return;
   }
-
-  // check for serverId
-  ServerId const clientId{StringUtils::uint64(_request->value("serverId"))};
-  SyncerId const syncerId = SyncerId::fromRequest(*_request);
-  std::string const clientInfo = _request->value("clientInfo");
 
   ExecContextSuperuserScope escope(ExecContext::current().isAdminUser());
 
@@ -358,7 +369,7 @@ void RestWalAccessHandler::handleCommandTail(WalAccess const* wal) {
 
   server().getFeature<DatabaseFeature>().enumerateDatabases([&](TRI_vocbase_t& vocbase) -> void {
     vocbase.replicationClients().track(syncerId, clientId, clientInfo, filter.tickStart,
-                                       replutils::BatchInfo::DefaultTimeout);
+                                       replutils::BatchInfo::DefaultTimeoutForTailing);
   });
 }
 

--- a/tests/js/client/shell/shell-tailing-clients-cluster.js
+++ b/tests/js/client/shell/shell-tailing-clients-cluster.js
@@ -1,0 +1,226 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global assertEqual, assertTrue, assertNotEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2021 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require('jsunity');
+const arangodb = require('@arangodb');
+const db = arangodb.db;
+const request = require("@arangodb/request");
+
+let getServers = function(role) {
+  const isRole = (d) => (d.role.toLowerCase() === role);
+  const endpointToURL = (server) => {
+    let endpoint = server.endpoint;
+    if (endpoint.substr(0, 6) === 'ssl://') {
+      return 'https://' + endpoint.substr(6);
+    }
+    let pos = endpoint.indexOf('://');
+    if (pos === -1) {
+      return 'http://' + endpoint;
+    }
+    return 'http' + endpoint.substr(pos);
+  };
+
+  return global.instanceInfo.arangods.filter(isRole)
+                              .map((server) => { 
+                                return { url: endpointToURL(server), id: server.id };
+                              });
+};
+
+function replicationClientsSuite() {
+  'use strict';
+  const cn = 'UnitTestsCollection';
+      
+  let getClients = (shardLeaderUrl, maxIterations) => {
+    let clients;
+    let iterations = 0;
+    while (++iterations < maxIterations) {
+      let result = request({ method: "GET", url: shardLeaderUrl + "/_api/replication/logger-state", body: {} });
+      clients = result.json.clients;
+      assertTrue(Array.isArray(clients));
+      if (clients.length === 0) {
+        break;
+      }
+      require("internal").sleep(0.5);
+    }
+    return clients;
+  };
+
+  return {
+    testNoClientsThenIncreaseReplicationFactor: function () {
+      const dbservers = getServers("dbserver");
+      const findServer = (id) => dbservers.filter((s) => s.id === id)[0];
+      
+      let docs = [];
+      for (let i = 0; i < 5000; ++i) {
+        docs.push({ _key: "test" + i, value: i });
+      }
+
+      let c = db._create(cn, { numberOfShards: 1, replicationFactor: 1 });
+      try {
+        c.insert(docs);
+        
+        let shards = c.shards(true);
+        let shardName = Object.keys(shards)[0];
+        let shardServers = shards[shardName];
+        let shardLeader = shardServers[0];
+
+        // leader should have 0 clients registered
+        assertEqual([], getClients(findServer(shardLeader).url, 120));
+
+        // add a follower
+        c.properties({ replicationFactor: 2 });
+       
+        // wait until follower is ready
+        let iterations = 0;
+        while (++iterations < 120) {
+          shards = c.shards(true);
+          if (shards[shardName].length === 2) {
+            break;
+          }
+          require("internal").sleep(0.5);
+        }
+        assertEqual(2, shards[shardName].length);
+        let shardFollower = shards[shardName][1];
+        assertNotEqual(shardLeader, shardFollower);
+        
+        // leader should have 0 clients registered
+        assertEqual([], getClients(findServer(shardLeader).url, 120));
+        // follower should have 0 clients registered
+        assertEqual([], getClients(findServer(shardFollower).url, 120));
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testNoClientsWithFollowerFromTheStart: function () {
+      const dbservers = getServers("dbserver");
+      const findServer = (id) => dbservers.filter((s) => s.id === id)[0];
+      
+      let docs = [];
+      for (let i = 0; i < 5000; ++i) {
+        docs.push({ _key: "test" + i, value: i });
+      }
+
+      let c = db._create(cn, { numberOfShards: 1, replicationFactor: 2 });
+      try {
+        c.insert(docs);
+        
+        let shards = c.shards(true);
+        let shardName = Object.keys(shards)[0];
+        assertEqual(2, shards[shardName].length);
+        let shardServers = shards[shardName];
+        let shardLeader = shardServers[0];
+        let shardFollower = shards[shardName][1];
+        assertNotEqual(shardLeader, shardFollower);
+        
+        // leader should have 0 clients registered
+        assertEqual([], getClients(findServer(shardLeader).url, 120));
+        // follower should have 0 clients registered
+        assertEqual([], getClients(findServer(shardFollower).url, 120));
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testNoClientsMultipleDatabaseMultipleCollections: function () {
+      const dbservers = getServers("dbserver");
+      assertTrue(dbservers.length > 1);
+
+      let docs = [];
+      for (let i = 0; i < 5000; ++i) {
+        docs.push({ _key: "test" + i, value: i });
+      }
+      try {
+        // set up 5 databases with 10 collections each
+        for (let i = 0; i < 5; ++i) {
+          db._useDatabase("_system");
+          db._createDatabase(cn + i);
+          db._useDatabase(cn + i);
+          for (let j = 0; j < 10; ++j) {
+            let c = db._create(cn + j, { numberOfShards: i + 1, replicationFactor: 1 });
+            c.insert(docs);
+          }
+        }
+
+        // now add followers for all collections!
+        for (let i = 0; i < 5; ++i) {
+          db._useDatabase(cn + i);
+          for (let j = 0; j < 10; ++j) {
+            db._collection(cn + j).properties({ replicationFactor: 1 + (i % dbservers.length) });
+          }
+        }
+
+        // wait until they all have all their replicas in place
+        for (let i = 0; i < 5; ++i) {
+          db._useDatabase(cn + i);
+          for (let j = 0; j < 10; ++j) {
+            let c = db._collection(cn + j);
+            let shards = c.shards(true);
+            assertEqual(i + 1, Object.keys(shards).length);
+
+            let totalFollowerShards;
+            let expectedFollowerShards;
+            let iterations = 0;
+            while (++iterations < 120) {
+              totalFollowerShards = 0;
+              expectedFollowerShards = 0;
+              shards = c.shards(true);
+              for (let k = 0; k < i + 1; ++k) {
+                totalFollowerShards += Object.values(shards)[k].length - 1;
+                expectedFollowerShards += (i % dbservers.length); 
+              }
+              if (expectedFollowerShards === totalFollowerShards) {
+                break;
+              }
+              require("internal").sleep(0.5);
+            }
+            assertEqual(expectedFollowerShards, totalFollowerShards);
+          }
+        }
+
+        // no server should have any clients registered, in none of the dbs
+        dbservers.forEach((dbs) => {
+          for (let i = 0; i < 5; ++i) {
+            assertEqual([], getClients(dbs.url + "/_db/" + cn + i, 120));
+          }
+        });
+
+      } finally {
+        // clean it all up
+        db._useDatabase("_system");
+        for (let i = 0; i < 5; ++i) {
+          try {
+            db._dropDatabase(cn + i);
+          } catch (err) {}
+        }
+      }
+    },
+
+  };
+}
+
+jsunity.run(replicationClientsSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Remove some leftover replication tailing clients from internal bookkeeping once they are finished with getting a shard in sync. 
Previously, such replication clients could have been left in the internal bookkeeping until they were removed by the automatic garbage collection after 2 hours. While the client entries were still in the bookkeeping tables, they could prevent archived RocksDB WAL files from being dropped, leading to leader DB servers keeping more WAL files around than necessary.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_client)

