### PR TITLE
bug-fix-3.7/save-unique-id-counter-in-agency-with-each-hotback

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.7.10 (XXXX-XX-XX)
 --------------------
 
+* Put Sync/LatestID into hotbackup and restore it on hotbackup restore
+  if it is in the backup. This helps with unique key generation after
+  a hotbackup is restored to a young cluster.
+
 * Reasonably harden MoveShard against unexpected VelocyPack input.
 
 * Follower DB servers will now respond with error code

--- a/arangod/Cluster/ClusterFeature.h
+++ b/arangod/Cluster/ClusterFeature.h
@@ -166,7 +166,8 @@ class ClusterFeature : public application_features::ApplicationFeature {
   std::unique_ptr<AgencyCallbackRegistry> _agencyCallbackRegistry;
   ServerState::RoleEnum _requestedRole = ServerState::RoleEnum::ROLE_UNDEFINED;
   std::unique_ptr<network::ConnectionPool> _asyncAgencyCommPool;
-
+  std::shared_ptr<AgencyCallback> _hotbackupRestoreCallback;
+  
   /// @brief lock for dirty database list
   mutable arangodb::Mutex _dirtyLock;
   /// @brief dirty databases, where a job could not be posted)

--- a/arangod/Cluster/v8-cluster.cpp
+++ b/arangod/Cluster/v8-cluster.cpp
@@ -548,7 +548,7 @@ static void JS_UniqidAgency(v8::FunctionCallbackInfo<v8::Value> const& args) {
     count = TRI_ObjectToUInt64(isolate, args[0], true);
   }
 
-  if (count < 1 || count > 10000000) {
+  if (count < 1 || count > 100000000) {
     TRI_V8_THROW_EXCEPTION_PARAMETER("<count> is invalid");
   }
 

--- a/tests/js/server/dump/dump-cluster.js
+++ b/tests/js/server/dump/dump-cluster.js
@@ -61,7 +61,8 @@ jsunity.run(function dump_cluster_testsuite() {
       "testAqlGraphQueryAny",
       "testSmartGraphSharding",
       "testViewOnSmartEdgeCollection",
-      "testSmartGraphAttribute"
+      "testSmartGraphAttribute",
+      "testLatestId"
     ];
   }
   deriveTestSuite(

--- a/tests/js/server/dump/dump-modified.js
+++ b/tests/js/server/dump/dump-modified.js
@@ -49,7 +49,8 @@ jsunity.run(function dump_single_testsuite() {
       "testKeygenAutoInc",
       "testTransactionCommit",
       "testTransactionUpdate",
-      "testTransactionAbort"
+      "testTransactionAbort",
+      "testLatestId"
     ];
   }
 

--- a/tests/js/server/dump/dump-modify.js
+++ b/tests/js/server/dump/dump-modify.js
@@ -501,6 +501,27 @@ function dumpTestSuite () {
       res = db._query("FOR doc IN " + c.name() + " FILTER doc.value >= 10000 RETURN doc").toArray();
       assertEqual(0, res.length);
     },
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test latestId
+////////////////////////////////////////////////////////////////////////////////
+
+  testLatestId : function () {
+    if (arango.getRole() === "COORDINATOR") {
+      // Only executed in the cluster
+      // The following increases /arango/Sync/LatestID in the agency
+      // by 100.000.000 and thus consumes so many cluster wide unique
+      // ids. This is checked below.
+      // Then, after a hotbackup restore, we check in the file
+      // `tests/js/server/dump/dump-cluster.js` (by means of including
+      // `tests/js/server/dump/dump-test.js`) that the lower number
+      // has been stored in the hotbackup and restored in the restore
+      // process.
+      let next = JSON.parse(db._connection.POST("/_admin/execute?returnAsJSON=true", "return global.ArangoAgency.uniqid(100000000)"));
+      assertTrue(next < 100000000, "expected next uniqid in agency to be less than 100000000, not " + next);
+      next = JSON.parse(db._connection.POST("/_admin/execute?returnAsJSON=true", "return global.ArangoAgency.uniqid(100000000)"));
+      assertTrue(next > 100000000, "expected next uniqid in agency to be greater than 100000000, not " + next);
+    }
+  }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test view restoring

--- a/tests/js/server/dump/dump-test.inc
+++ b/tests/js/server/dump/dump-test.inc
@@ -1174,7 +1174,20 @@
         assertTrue(doc._key.startsWith("cheese:"));
       },
 
-
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test whether hotbackup restore restores the uniqid
+      ////////////////////////////////////////////////////////////////////////////////
+      testLatestId : function() {
+        if (arango.getRole() === "COORDINATOR") {
+          // Only executed in the cluster
+          // After the hotbackup was taken, we have consumed 100.000.000
+          // cluster wide unique ids. Here, we check that after the
+          // hotbackup restore the number in /arango/Sync/LatestID
+          // in the agency is lower again.
+          let next = JSON.parse(db._connection.POST("/_admin/execute?returnAsJSON=true", "return global.ArangoAgency.uniqid(1)"));
+          assertTrue(next < 100000000, "expected next uniqid after restore to be less than 100000000, not " + next);
+        }
+      },
       
     };
   };

--- a/tests/js/server/dump/dump.js
+++ b/tests/js/server/dump/dump.js
@@ -72,7 +72,10 @@ jsunity.run(function dump_single_testsuite() {
       "testAqlGraphQueryAny",
       "testSmartGraphSharding",
       "testViewOnSmartEdgeCollection",
-      "testSmartGraphAttribute"
+      "testSmartGraphAttribute",
+
+      // Hotbackup tests:
+      "testLatestId"
     ]
   );
 


### PR DESCRIPTION
### Scope & Purpose

When a hotbackup is restored to a cluster which is a lot "younger" than
the one where it was taken, the entry Sync/LatestID in the agency in the
new cluster is a lot smaller than the one in the old cluster. Therefore,
the unique key generation does no longer work well. Therefore, it makes
sense to put the Sync/LatestID into the hotbackup and restore it with a
hotbackup restore. This solves the key generation problem at least in
this hotbackup related case.

This PR is a back port into 3.7 of the implementation of that, from #13699 .

Old hotbackups can still be restored, even if they do not contain
Sync/LatestID.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] This is a backport of #13699 into 3.6

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [x] GitHub issue / Jira ticket number: TC-18

### Testing & Verification

*(Please pick either of the following options)*

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_server / shell_server_aql)

Link to Jenkins PR run:
