### PR TITLE
Forward port of bugfix in AQL Document within one-shard database created in 3.6 series

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -907,6 +907,9 @@ devel
 
 * Updated OpenSSL to 1.1.1i and OpenLDAP to 2.4.56.
 
+* Bug-Fix: In one-shard-database setups that were created in 3.6.* and then
+  upgraded to 3.7.5 the DOCUMENT method in AQL will now return documents again.
+
 * Make internal ClusterInfo::getPlan() wait for initial plan load from agency.
 
 * Added AQL timezone functions `DATE_TIMEZONE` and `DATE_TIMEZONES`.

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -753,13 +753,14 @@ Result transaction::Methods::documentFastPath(std::string const& collectionName,
     return opRes.result;
   }
 
-  auto translateName = [this](std::string const& collectionName) {
-    if (_state->isDBServer() && vocbase().isOneShard()) {
+  auto translateName = [this](std::string const& collectionName) { 
+    if (_state->isDBServer()) {
       auto collection = resolver()->getCollectionStructCluster(collectionName);
       if (collection != nullptr) {
         auto& ci = vocbase().server().getFeature<ClusterFeature>().clusterInfo();
         auto shards = ci.getShardList(std::to_string(collection->id().id()));
         if (shards != nullptr && shards->size() == 1) {
+          TRI_ASSERT(vocbase().isOneShard());
           return (*shards)[0];
         }
       }


### PR DESCRIPTION
### Scope & Purpose

There is a bug in DOCUMENT method in AQL. That only shows up if upgraded from 3.6.* to 3.7.5
Where the DOCUMENT method may not return any documents anymore. This PR will only do a hot-fix
of the issue, the inconsistency in 3.6 and 3.7 format is not yet sorted out, but only DOCUMENT hits this case for now.

Original 3.7 PR:
https://github.com/arangodb/arangodb/pull/13324

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required (I will not do a devel PR, as we intend to fix the data-format inconsistency instead of circumventing it)
- [ ] Backports required for: *(Please specify versions and link PRs)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket number: oasis-428
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

### Documentation

> All new features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the CHANGELOG so that
> support, end users, and other developers have a concise overview. 

- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
