### PR TITLE
Fix error message in case of index unique constraint violations.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fix error message in case of index unique constraint violations. They were
+  lacking the actual error message (i.e. "unique constraint violated") and
+  only showed the index details. The issue was introduced only in devel in Feb.
+
 * Allow process-specific logfile names.
 
   This change allows replacing '$PID' with the current process id in the 

--- a/lib/Basics/ResultError.h
+++ b/lib/Basics/ResultError.h
@@ -50,6 +50,9 @@ class Error final {
 
   template <typename S>
   void appendErrorMessage(S&& msg) {
+    if (_errorMessage.empty()) {
+      _errorMessage += errorMessage();
+    }
     _errorMessage += std::forward<S>(msg);
   }
 


### PR DESCRIPTION
### Scope & Purpose

Fix error message in case of index unique constraint violations.

The index error messages were lacking the actual base error description (i.e. "unique constraint violated") and only showed the index details. The issue was introduced only in devel in Feb.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
