### PR TITLE
Fixed logical error in MockGraphProviderTest

### DIFF
--- a/tests/Graph/GenericGraphProviderTest.cpp
+++ b/tests/Graph/GenericGraphProviderTest.cpp
@@ -228,10 +228,10 @@ TYPED_TEST(GraphProviderTest, no_results_if_graph_is_empty) {
   TraversalStats stats = testee.stealStats();
   EXPECT_EQ(stats.getFiltered(), 0);
 
-
-  if constexpr (std::is_same_v<TypeParam, SingleServerProvider> || std::is_same_v<TypeParam, MockGraphProvider>) {
+  if constexpr (std::is_same_v<TypeParam, SingleServerProvider> ||
+                std::is_same_v<TypeParam, MockGraphProvider>) {
     EXPECT_EQ(stats.getHttpRequests(), 0);
-  } else if (std::is_same_v<TypeParam, SingleServerProvider>) {
+  } else if (std::is_same_v<TypeParam, ClusterProvider>) {
     EXPECT_EQ(stats.getHttpRequests(), 1);
   }
 
@@ -272,9 +272,10 @@ TYPED_TEST(GraphProviderTest, should_enumerate_a_single_edge) {
   {
     TraversalStats stats = testee.stealStats();
     EXPECT_EQ(stats.getFiltered(), 0);
-    if constexpr (std::is_same_v<TypeParam, SingleServerProvider> || std::is_same_v<TypeParam, MockGraphProvider>) {
+    if constexpr (std::is_same_v<TypeParam, SingleServerProvider> ||
+                  std::is_same_v<TypeParam, MockGraphProvider>) {
       EXPECT_EQ(stats.getHttpRequests(), 0);
-    } else if (std::is_same_v<TypeParam, SingleServerProvider>) {
+    } else if (std::is_same_v<TypeParam, ClusterProvider>) {
       EXPECT_EQ(stats.getHttpRequests(), 1);
     }
     // We have 1 edge, this shall be counted
@@ -334,9 +335,10 @@ TYPED_TEST(GraphProviderTest, should_enumerate_all_edges) {
   {
     TraversalStats stats = testee.stealStats();
     EXPECT_EQ(stats.getFiltered(), 0);
-    if constexpr (std::is_same_v<TypeParam, SingleServerProvider> || std::is_same_v<TypeParam, MockGraphProvider>) {
+    if constexpr (std::is_same_v<TypeParam, SingleServerProvider> ||
+                  std::is_same_v<TypeParam, MockGraphProvider>) {
       EXPECT_EQ(stats.getHttpRequests(), 0);
-    } else if (std::is_same_v<TypeParam, SingleServerProvider>) {
+    } else if (std::is_same_v<TypeParam, ClusterProvider>) {
       EXPECT_EQ(stats.getHttpRequests(), 1);
     }
     // We have 3 edges, this shall be counted

--- a/tests/Graph/GenericGraphProviderTest.cpp
+++ b/tests/Graph/GenericGraphProviderTest.cpp
@@ -232,7 +232,7 @@ TYPED_TEST(GraphProviderTest, no_results_if_graph_is_empty) {
                 std::is_same_v<TypeParam, MockGraphProvider>) {
     EXPECT_EQ(stats.getHttpRequests(), 0);
   } else if (std::is_same_v<TypeParam, ClusterProvider>) {
-    EXPECT_EQ(stats.getHttpRequests(), 1);
+    EXPECT_EQ(stats.getHttpRequests(), 2);
   }
 
   // We have no edges, so nothing scanned in the Index.
@@ -276,7 +276,7 @@ TYPED_TEST(GraphProviderTest, should_enumerate_a_single_edge) {
                   std::is_same_v<TypeParam, MockGraphProvider>) {
       EXPECT_EQ(stats.getHttpRequests(), 0);
     } else if (std::is_same_v<TypeParam, ClusterProvider>) {
-      EXPECT_EQ(stats.getHttpRequests(), 1);
+      EXPECT_EQ(stats.getHttpRequests(), 2);
     }
     // We have 1 edge, this shall be counted
     EXPECT_EQ(stats.getScannedIndex(), 1);
@@ -339,7 +339,7 @@ TYPED_TEST(GraphProviderTest, should_enumerate_all_edges) {
                   std::is_same_v<TypeParam, MockGraphProvider>) {
       EXPECT_EQ(stats.getHttpRequests(), 0);
     } else if (std::is_same_v<TypeParam, ClusterProvider>) {
-      EXPECT_EQ(stats.getHttpRequests(), 1);
+      EXPECT_EQ(stats.getHttpRequests(), 2);
     }
     // We have 3 edges, this shall be counted
     EXPECT_EQ(stats.getScannedIndex(), 3);


### PR DESCRIPTION
Fixed logical error. Type SingleServerProvider in "else if tree" used instead of the ClusterProvider type.

### Scope & Purpose

- [x] :hankey: Bugfix (requires CHANGELOG entry)

#### Backports:

- [x] No backports required

#### Related Information

Found during testing.

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools