### PR TITLE
Fix an assertion failure that occurred when restoring view definitions from a cluster into a single server.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
-* Added new ArangoSearch analyzer type "mask"
+
+* Fix an assertion failure that occurred when restoring view definitions from
+  a cluster into a single server.
+
+* Added new ArangoSearch analyzer type "mask".
 
 * Fix error message in case of index unique constraint violations. They were
   lacking the actual error message (i.e. "unique constraint violated") and

--- a/arangod/IResearch/IResearchLinkMeta.cpp
+++ b/arangod/IResearch/IResearchLinkMeta.cpp
@@ -770,8 +770,8 @@ bool IResearchLinkMeta::init(arangodb::application_features::ApplicationServer& 
     }
   }
 
-  if (slice.hasKey(StaticStrings::CollectionNameField)) {
-    TRI_ASSERT(ServerState::instance()->isClusterRole());
+  if (slice.hasKey(StaticStrings::CollectionNameField) &&
+      ServerState::instance()->isClusterRole()) {
     auto const field = slice.get(StaticStrings::CollectionNameField);
     if (!field.isString()) {
       return false;


### PR DESCRIPTION
### Scope & Purpose

Fix an assertion failure that occurred when restoring view definitions from a cluster into a single server.
The assertion failure occured when running the following test
```
scripts/unittest dump_mixed_cluster_single --cluster true
```

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*: https://github.com/arangodb/arangodb/pull/13775, *3.7*: https://github.com/arangodb/arangodb/pull/13771

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *dump_mixed_cluster_single*.

