### PR TITLE
Fix an assertion failure that occurred when restoring view definitions from a cluster into a single server

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.7.11 (XXXX-XX-XX)
 --------------------
 
+* Fix an assertion failure that occurred when restoring view definitions from
+  a cluster into a single server.
+
 * Allow process-specific logfile names.
 
   This change allows replacing '$PID' with the current process id in the

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.7.11 (XXXX-XX-XX)
 --------------------
 
-* Fix an assertion failure that occurred when restoring view definitions from
-  a cluster into a single server.
+* Fix an assertion failure that occurred when restoring view definitions from a
+  cluster into a single server.
 
 * Allow process-specific logfile names.
 

--- a/arangod/IResearch/IResearchLinkMeta.cpp
+++ b/arangod/IResearch/IResearchLinkMeta.cpp
@@ -757,8 +757,8 @@ bool IResearchLinkMeta::init(arangodb::application_features::ApplicationServer& 
     }
   }
 
-  if (slice.hasKey(StaticStrings::CollectionNameField)) {
-    TRI_ASSERT(ServerState::instance()->isClusterRole());
+  if (slice.hasKey(StaticStrings::CollectionNameField) &&
+      ServerState::instance()->isClusterRole()) {
     auto const field = slice.get(StaticStrings::CollectionNameField);
     if (!field.isString()) {
       return false;


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/13770

Fix an assertion failure that occurred when restoring view definitions from a cluster into a single server.

The assertion failure occured when running the following test
```
scripts/unittest dump_mixed_cluster_single --cluster true
```

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *dump_mixed_cluster_single*.

