### PR TITLE
Revert "change feature order so that ServerIdFeature is before ReplicationFeature (#13743)"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,13 +40,6 @@ devel
 * Rename "save" return attribute to "dst" in AQL functions `DATE_UTCTOLOCAL` and
   `DATE_LOCALTOUTC`.
 
-* Make ReplicationFeature formally depend on ServerIdFeature, because the
-  former relies on the server id being already loaded by the latter.
-  If this dependency is not established properly, it is undefined if the
-  ReplicationFeature starts earlier than the ServerIdFeature, which can lead
-  to the ReplicationFeature not sending its server id properly to the leader
-  when doing replication between two single servers.
-
 * Fix potentially undefined behavior when creating a CalculationTransactionContext
   for an arangosearch analyzer. An uninitialized struct member was passed as an
   argument to its base class. This potentially had no observable effects, but

--- a/arangod/Replication/ReplicationFeature.cpp
+++ b/arangod/Replication/ReplicationFeature.cpp
@@ -39,7 +39,6 @@
 #include "Rest/GeneralResponse.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/MetricsFeature.h"
-#include "RestServer/ServerIdFeature.h"
 #include "RestServer/SystemDatabaseFeature.h"
 #include "StorageEngine/StorageEngineFeature.h"
 #include "VocBase/vocbase.h"
@@ -98,7 +97,6 @@ ReplicationFeature::ReplicationFeature(ApplicationServer& server)
   startsAfter<BasicFeaturePhaseServer>();
 
   startsAfter<DatabaseFeature>();
-  startsAfter<ServerIdFeature>();
   startsAfter<StorageEngineFeature>();
   startsAfter<SystemDatabaseFeature>();
 }


### PR DESCRIPTION
### Scope & Purpose

Revert "change feature order so that ServerIdFeature is before ReplicationFeature (#13743)"

This reverts commit 48dba7dd84a42fb164522134e941ea81d7efd5fe.
This was an unsafe change, so we now just roll it back.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [x] Backports required for: *3.7*: https://github.com/arangodb/arangodb/pull/13773, *3.8*: https://github.com/arangodb/arangodb/pull/13774

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
