### PR TITLE
Revert "change feature order so that ServerIdFeature is before ReplicationFeature (#13741)"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -41,13 +41,6 @@ v3.7.11 (XXXX-XX-XX)
 * Fixed a bug in the index count optimization that doubled counted documents
   when using array expansions in the fields definition.
 
-* Make ReplicationFeature formally depend on ServerIdFeature, because the former
-  relies on the server id being already loaded by the latter.
-  If this dependency is not established properly, it is undefined if the
-  ReplicationFeature starts earlier than the ServerIdFeature, which can lead to
-  the ReplicationFeature not sending its server id properly to the leader when
-  doing replication between two single servers.
-
 
 v3.7.10 (2021-03-14)
 --------------------

--- a/arangod/Replication/ReplicationFeature.cpp
+++ b/arangod/Replication/ReplicationFeature.cpp
@@ -38,7 +38,6 @@
 #include "Rest/GeneralResponse.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/MetricsFeature.h"
-#include "RestServer/ServerIdFeature.h"
 #include "RestServer/SystemDatabaseFeature.h"
 #include "StorageEngine/StorageEngineFeature.h"
 #include "VocBase/vocbase.h"
@@ -69,7 +68,6 @@ ReplicationFeature::ReplicationFeature(ApplicationServer& server)
   startsAfter<BasicFeaturePhaseServer>();
 
   startsAfter<DatabaseFeature>();
-  startsAfter<ServerIdFeature>();
   startsAfter<StorageEngineFeature>();
   startsAfter<SystemDatabaseFeature>();
 }


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/13772

Revert "change feature order so that ServerIdFeature is before ReplicationFeature (#13741)"

This reverts commit 959e27b26f80c5dd76c842a6155eb77d6de0d598.
This was an unsafe change, so we just roll it back.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
