### PR TITLE
Fixed unused variable warning

### DIFF
--- a/tests/Graph/GenericGraphProviderTest.cpp
+++ b/tests/Graph/GenericGraphProviderTest.cpp
@@ -352,7 +352,7 @@ TYPED_TEST(GraphProviderTest, destroy_engines) {
   TypeParam testee = this->makeProvider(empty, expectedVerticesEdgesBundleToFetch);
 
   // steel the stats, so we reset them internally and have a clean state
-  TraversalStats statsBeforeSteal = testee.stealStats();
+  std::ignore = testee.stealStats();
 
   testee.destroyEngines();
   TraversalStats statsAfterSteal = testee.stealStats();


### PR DESCRIPTION
Internal PR.
There is a variable that is unused within the test, but the called function has required side-effects.
No user impact.