### PR TITLE
fix cluster recovery test timeouts

### DIFF
--- a/js/client/modules/@arangodb/testsuites/recovery_cluster.js
+++ b/js/client/modules/@arangodb/testsuites/recovery_cluster.js
@@ -121,9 +121,9 @@ function runArangodRecovery (params) {
   // arangosh has different name for parameter :(
   additionalTestParams['javascript.execute'] =  params.script;
   additionalTestParams['javascript.run-main'] = true;
-  additionalTestParams['server.request-timeout'] = '60';
 
   if (params.setup) {
+    additionalTestParams['server.request-timeout'] = '60';
     additionalTestParams['javascript.script-parameter'] = 'setup';
 
     // special handling for crash-handler recovery tests

--- a/js/client/modules/@arangodb/testsuites/recovery_cluster.js
+++ b/js/client/modules/@arangodb/testsuites/recovery_cluster.js
@@ -61,7 +61,7 @@ function ensureServers(options, numServers) {
 
 function checkServersGOOD(instanceInfo) {
   try {
-    let health = require('internal').clusterHealth();
+    let health = internal.clusterHealth();
     let rc = instanceInfo.arangods.reduce((previous, arangod) => {
         if (arangod.role === "agent") return true;
         if (health.hasOwnProperty(arangod.id)) {
@@ -99,6 +99,8 @@ function runArangodRecovery (params) {
   }
 
   let additionalParams= {
+    'foxx.queues': 'false',
+    'server.statistics': 'false',
     'log.foreground-tty': 'true',
     'database.ignore-datafile-errors': 'false', // intentionally false!
   };
@@ -119,6 +121,7 @@ function runArangodRecovery (params) {
   // arangosh has different name for parameter :(
   additionalTestParams['javascript.execute'] =  params.script;
   additionalTestParams['javascript.run-main'] = true;
+  additionalTestParams['server.request-timeout'] = '60';
 
   if (params.setup) {
     additionalTestParams['javascript.script-parameter'] = 'setup';
@@ -127,7 +130,7 @@ function runArangodRecovery (params) {
     if (params.script.match(/crash-handler/)) {
       // forcefully enable crash handler, even if turned off globally
       // during testing
-      require('internal').env["ARANGODB_OVERRIDE_CRASH_HANDLER"] = "on";
+      internal.env["ARANGODB_OVERRIDE_CRASH_HANDLER"] = "on";
     }
 
     params.options.disableMonitor = true;
@@ -219,12 +222,14 @@ function runArangodRecovery (params) {
 }
 
 function recovery (options) {
-  if (!global.ARANGODB_CLIENT_VERSION(true)['failure-tests'] ||
-      global.ARANGODB_CLIENT_VERSION(true)['failure-tests'] === 'false') {
+  if ((!global.ARANGODB_CLIENT_VERSION(true)['failure-tests'] ||
+       global.ARANGODB_CLIENT_VERSION(true)['failure-tests'] === 'false') ||
+      (!global.ARANGODB_CLIENT_VERSION(true)['maintainer-mode'] ||
+       global.ARANGODB_CLIENT_VERSION(true)['maintainer-mode'] === 'false')) {
     return {
       recovery: {
         status: false,
-        message: 'failure-tests not enabled. please recompile with -DUSE_FAILURE_TESTS=On'
+        message: 'failure-tests not enabled. please recompile with -DUSE_FAILURE_TESTS=On and -DUSE_MAINTAINER_MODE=On'
       },
       status: false
     };


### PR DESCRIPTION
### Scope & Purpose

set the http-timeout on the arangosh doing the `setup` for the testcase. By it aborting after 60s we don't wait 15 minutes for the coordinator to return. 

- [x] :hankey: Bugfix (requires CHANGELOG entry)
