### PR TITLE
Use RebootTracker to abort cluster transactions on DB servers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 v3.7.11 (XXXX-XX-XX)
 --------------------
 
+* Use RebootTracker to abort cluster transactions on DB servers should the
+  originating coordinator die or be rebooted. The previous implementation left
+  the coordinator's transactions open on DB servers until they timed out there.
+  Now, the coordinator's unavailability or reboot will be detected as early as
+  it is reported by the agency, and all open transactions from that coordinator
+  will be auto-aborted on DB servers.
+
 * Fix an assertion failure that occurred when restoring view definitions from a
   cluster into a single server.
 

--- a/arangod/Cluster/RebootTracker.cpp
+++ b/arangod/Cluster/RebootTracker.cpp
@@ -25,10 +25,14 @@
 #include "Basics/Exceptions.h"
 #include "Basics/MutexLocker.h"
 #include "Basics/ScopeGuard.h"
+#include "Basics/StaticStrings.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Scheduler/Scheduler.h"
 #include "Scheduler/SchedulerFeature.h"
+
+#include <velocypack/Builder.h>
+#include <velocypack/Slice.h>
 
 #include <algorithm>
 
@@ -59,9 +63,16 @@ RebootTracker::RebootTracker(RebootTracker::SchedulerPointer scheduler)
 
 void RebootTracker::updateServerState(std::unordered_map<ServerID, RebootId> const& state) {
   MUTEX_LOCKER(guard, _mutex);
-        
-  LOG_TOPIC("77a6e", DEBUG, Logger::CLUSTER)
-      << "updating reboot server state from " << _rebootIds << " to " << state;
+    
+  // FIXME: can't get this log message to compile in some build environments...
+  // ostreaming _rebootIds causes a compiler failure because operator<< is not visible
+  // here anymore for some reason, which is very likely due to a changed order of include
+  // files or some other change in declaration order.
+  // leaving the log message here because it can be compiled in some environments and
+  // maybe someone can fix it in the future
+  //
+  // LOG_TOPIC("77a6e", DEBUG, Logger::CLUSTER)
+  //     << "updating reboot server state from " << _rebootIds << " to " << state;
 
   // Call cb for each iterator.
   auto for_each_iter = [](auto begin, auto end, auto cb) {
@@ -319,6 +330,25 @@ void RebootTracker::queueCallback(DescriptedCallback callback) {
   queueCallbacks({std::make_shared<std::unordered_map<CallbackId, DescriptedCallback>>(
       std::unordered_map<CallbackId, DescriptedCallback>{
           std::make_pair(getNextCallbackId(), std::move(callback))})});
+}
+    
+void RebootTracker::PeerState::toVelocyPack(velocypack::Builder& builder) const {
+  builder.openObject();
+  builder.add(StaticStrings::AttrCoordinatorId, VPackValue(_serverId));
+  builder.add(StaticStrings::AttrCoordinatorRebootId, VPackValue(_rebootId.value()));
+  builder.close();
+}
+
+RebootTracker::PeerState RebootTracker::PeerState::fromVelocyPack(velocypack::Slice slice) {
+  TRI_ASSERT(slice.isObject());
+  VPackSlice serverIdSlice = slice.get(StaticStrings::AttrCoordinatorId);
+  VPackSlice rebootIdSlice = slice.get(StaticStrings::AttrCoordinatorRebootId);
+
+  if (!serverIdSlice.isString() || !rebootIdSlice.isInteger()) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER, "invalid reboot id");
+  }
+  
+  return { serverIdSlice.copyString(), RebootId(rebootIdSlice.getUInt()) };
 }
 
 CallbackGuard::CallbackGuard() : _callback(nullptr) {}

--- a/arangod/Cluster/RebootTracker.h
+++ b/arangod/Cluster/RebootTracker.h
@@ -23,8 +23,8 @@
 #ifndef ARANGOD_CLUSTER_REBOOTTRACKER_H
 #define ARANGOD_CLUSTER_REBOOTTRACKER_H
 
-#include "Cluster/CallbackGuard.h"
 #include "Basics/Mutex.h"
+#include "Cluster/CallbackGuard.h"
 
 #include <map>
 #include <memory>
@@ -35,6 +35,11 @@
 namespace arangodb {
 
 class SupervisedScheduler;
+
+namespace velocypack {
+class Builder;
+class Slice;
+}
 
 namespace cluster {
 
@@ -53,6 +58,9 @@ class RebootTracker {
 
     ServerID const& serverId() const noexcept { return _serverId; }
     RebootId rebootId() const noexcept { return _rebootId; }
+
+    void toVelocyPack(velocypack::Builder& builder) const;
+    static PeerState fromVelocyPack(velocypack::Slice);
 
    private:
     ServerID _serverId;

--- a/arangod/Transaction/Options.cpp
+++ b/arangod/Transaction/Options.cpp
@@ -24,6 +24,7 @@
 #include "Options.h"
 
 #include "Basics/debugging.h"
+#include "Cluster/ServerState.h"
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
@@ -46,7 +47,24 @@ Options::Options()
       skipInaccessibleCollections(false),
 #endif
       waitForSync(false),
-      isFollowerTransaction(false) {
+      isFollowerTransaction(false),
+      origin("", arangodb::RebootId(0)) {
+
+  // if we are a coordinator, fill in our own server id/reboot id.
+  // the data is passed to DB servers when the transaction is started
+  // there. the DB servers use this data to abort the transaction
+  // timely should the coordinator die or be rebooted.
+  // in the DB server case, we leave the origin empty in the beginning,
+  // because the coordinator id will be sent via JSON and thus will be
+  // picked up inside fromVelocyPack()
+  if (ServerState::instance()->isCoordinator()) {
+    // cluster transactions always originate on a coordinator
+    origin = arangodb::cluster::RebootTracker::PeerState(
+        ServerState::instance()->getId(), 
+        ServerState::instance()->getRebootId()
+    );
+  }
+
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
   // patch intermediateCommitCount for testing
   adjustIntermediateCommitCount(*this);
@@ -103,9 +121,20 @@ void Options::fromVelocyPack(arangodb::velocypack::Slice const& slice) {
   if (value.isBool()) {
     waitForSync = value.getBool();
   }
-  value = slice.get("isFollowerTransaction");
-  if (value.isBool()) {
-    isFollowerTransaction = value.getBool();
+  
+  if (!ServerState::instance()->isSingleServer()) {
+    value = slice.get("isFollowerTransaction");
+    if (value.isBool()) {
+      isFollowerTransaction = value.getBool();
+    }
+
+    // pick up the originating coordinator's id. note: this can be
+    // empty if the originating coordinator is an ArangoDB 3.6 or an
+    // older version of 3.7.
+    value = slice.get("origin");
+    if (value.isObject()) {
+      origin = cluster::RebootTracker::PeerState::fromVelocyPack(value);
+    }
   }
 
   // we are intentionally *not* reading allowImplicitCollectionForWrite here.
@@ -131,7 +160,18 @@ void Options::toVelocyPack(arangodb::velocypack::Builder& builder) const {
   builder.add("waitForSync", VPackValue(waitForSync));
   // we are intentionally *not* writing allowImplicitCollectionForWrite here.
   // this is an internal option only used in replication
-  builder.add("isFollowerTransaction", VPackValue(isFollowerTransaction));
+
+  // serialize data for cluster-wide collections
+  if (!ServerState::instance()->isSingleServer()) {
+    builder.add("isFollowerTransaction", VPackValue(isFollowerTransaction));
+    
+    // serialize the server id/reboot id of the originating server (which must
+    // be a coordinator id if set)
+    if (!origin.serverId().empty()) {
+      builder.add(VPackValue("origin"));
+      origin.toVelocyPack(builder);
+    }
+  }
 }
 
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS

--- a/arangod/Transaction/Options.h
+++ b/arangod/Transaction/Options.h
@@ -27,6 +27,7 @@
 #include <cstdint>
 
 #include "Basics/Common.h"
+#include "Cluster/RebootTracker.h"
 
 namespace arangodb {
 namespace velocypack {
@@ -74,6 +75,16 @@ struct Options {
 #endif
   bool waitForSync;
   bool isFollowerTransaction;
+
+  /// @brief originating server of this transaction. will be populated
+  /// only in the cluster, and with a coordinator id/coordinator reboot id
+  /// then. coordinators fill this in when they start a transaction, and
+  /// the info is send with the transaction begin requests to DB servers,
+  /// which will also store the coordinator's id. this is so they can
+  /// abort the transaction should the coordinator die or be rebooted.
+  /// the server id and reboot id are intentionally empty in single server
+  /// case.
+  arangodb::cluster::RebootTracker::PeerState origin;
 };
 
 }  // namespace transaction

--- a/tests/Mocks/Servers.h
+++ b/tests/Mocks/Servers.h
@@ -30,6 +30,7 @@
 
 #include "Agency/Store.h"
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Cluster/ClusterTypes.h"
 #include "Cluster/ServerState.h"
 #include "IResearch/IResearchCommon.h"
 #include "Logger/LogMacros.h"
@@ -114,6 +115,7 @@ class MockServer {
   StorageEngineMock _engine;
   std::unordered_map<arangodb::application_features::ApplicationFeature*, bool> _features;
   std::string _testFilesystemPath;
+  arangodb::RebootId _oldRebootId;
 
  private:
   bool _started;

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -110,6 +110,9 @@ int main(int argc, char* argv[]) {
   ctx.exit(0);  // set "good" exit code by default
 
   arangodb::ServerIdFeature::setId(arangodb::ServerId{12345});
+  // many other places rely on the reboot id being initialized, 
+  // so we do it here in a central place
+  arangodb::ServerState::instance()->setRebootId(arangodb::RebootId{1}); 
   IcuInitializer::setup(ARGV0);
 
   // Run tests in subthread such that it has a larger stack size in libmusl,


### PR DESCRIPTION
### Scope & Purpose

Partial backport of https://github.com/arangodb/arangodb/pull/13731

Use RebootTracker to abort cluster transactions on DB servers should the originating coordinator die or be rebooted. The previous implementation left the coordinator's transactions open on DB servers until they timed out there. 
Now, the coordinator's unavailability or reboot will be detected as early as it is reported by the agency, and all open transactions from that coordinator will be auto-aborted on DB servers.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*

