### PR TITLE
Add an option to lock down `/_admin/cluster`.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,27 @@
 devel
 -----
 
+* Add an option for locking down all endpoints in the `/_admin/cluster` REST
+  API for callers without a proper JWT set in the request. There is a new
+  startup option `--cluster.api-jwt-policy` that allows *additional* checks
+  for a valid JWT in requests to sub-routes of `/_admin/cluster`. The
+  possible values for the startup option are:
+
+  - "jwt-all": requires a valid JWT for all accesses to `/_admin/cluster` and
+    its sub-routes. If this configuration is used, the "Cluster" and "Nodes"
+    sections of the web interface will be disabled, as they are relying on the
+    ability to read data from several cluster APIs.
+  - "jwt-write": requires a valid JWT for write accesses (all HTTP methods
+    except HTTP GET) to `/_admin/cluster`. This setting can be used to allow
+    privileged users to read data from the cluster APIs, but not to do any
+    modifications. All existing permissions checks for the cluster API routes
+    are still in effect with this setting, meaning that read operations without
+    a valid JWT may still require dedicated other permissions (as in 3.7).
+  - "jwt-compact": no *additional* access checks are in place for the cluster
+    APIs. However, all existing permissions checks for the cluster API routes
+    are still in effect with this setting, meaning that all operations may
+    still require dedicated other permissions (as in 3.7).
+
 * Fix implicit capture of views in a context of JS transaction.
 
 * Fix a crash caused by returning a result produced by ANALYZER function.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,10 +17,13 @@ devel
     modifications. All existing permissions checks for the cluster API routes
     are still in effect with this setting, meaning that read operations without
     a valid JWT may still require dedicated other permissions (as in 3.7).
-  - "jwt-compact": no *additional* access checks are in place for the cluster
+  - "jwt-compat": no *additional* access checks are in place for the cluster
     APIs. However, all existing permissions checks for the cluster API routes
     are still in effect with this setting, meaning that all operations may
     still require dedicated other permissions (as in 3.7).
+
+  The default value for the option is `jwt-compat`, which means this option 
+  will not cause any extra JWT checks compared to 3.7.
 
 * Fix implicit capture of views in a context of JS transaction.
 

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -56,6 +56,7 @@ DECLARE_HISTOGRAM(arangodb_agencycomm_request_time_msec, ClusterFeatureScale, "R
 
 ClusterFeature::ClusterFeature(application_features::ApplicationServer& server)
   : ApplicationFeature(server, "Cluster"),
+    _apiJwtPolicy("jwt-compat"),
     _agency_comm_request_time_ms(
       server.getFeature<arangodb::MetricsFeature>().add(arangodb_agencycomm_request_time_msec{})) {
   setOptional(true);
@@ -226,6 +227,18 @@ void ClusterFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
       arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents,
                                    arangodb::options::Flags::OnCoordinator,
                                    arangodb::options::Flags::Hidden));
+  
+  options
+      ->addOption("--cluster.api-jwt-policy",
+                  "access permissions required for accessing /_admin/cluster REST APIs "
+                  "(jwt-all = JWT required to access all operations, jwt-write = JWT required "
+                  "for post/put/delete operations, jwt-compat = 3.7 compatibility mode)",
+                  new DiscreteValuesParameter<StringParameter>(
+                      &_apiJwtPolicy,
+                      std::unordered_set<std::string>{"jwt-all", "jwt-write", "jwt-compat"}),
+                  arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents,
+                                               arangodb::options::Flags::OnCoordinator))
+      .setIntroducedIn(30800);
 }
 
 void ClusterFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {

--- a/arangod/Cluster/ClusterFeature.h
+++ b/arangod/Cluster/ClusterFeature.h
@@ -90,6 +90,12 @@ class ClusterFeature : public application_features::ApplicationFeature {
   std::shared_ptr<HeartbeatThread> heartbeatThread();
 
   ClusterInfo& clusterInfo();
+
+  /// @brief permissions required to access /_admin/cluster REST API endpoint:
+  /// - "jwt-all"    = JWT required to access all operations
+  /// - "jwt-write"  = JWT required to access post/put/delete operations
+  /// - "jwt-compat" = compatibility mode = same permissions as in 3.7
+  std::string const& apiJwtPolicy() const noexcept { return _apiJwtPolicy; }
   
   Counter& followersDroppedCounter() { return _followersDroppedCounter->get(); }
   Counter& followersRefusedCounter() { return _followersRefusedCounter->get(); }
@@ -149,6 +155,7 @@ class ClusterFeature : public application_features::ApplicationFeature {
   std::string _myRole;
   std::string _myEndpoint;
   std::string _myAdvertisedEndpoint;
+  std::string _apiJwtPolicy;
   std::uint32_t _writeConcern = 1;             // write concern
   std::uint32_t _defaultReplicationFactor = 0; // a value of 0 means it will use the min replication factor
   std::uint32_t _systemReplicationFactor = 2;

--- a/arangod/V8Server/v8-actions.cpp
+++ b/arangod/V8Server/v8-actions.cpp
@@ -34,6 +34,7 @@
 #include "Basics/conversions.h"
 #include "Basics/files.h"
 #include "Basics/tri-strings.h"
+#include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
 #include "Futures/Utilities.h"
@@ -1751,6 +1752,19 @@ static void JS_DebugClearFailAt(v8::FunctionCallbackInfo<v8::Value> const& args)
   TRI_V8_TRY_CATCH_END
 }
 
+static void JS_ClusterApiJwtPolicy(v8::FunctionCallbackInfo<v8::Value> const& args) {
+  TRI_V8_TRY_CATCH_BEGIN(isolate)
+  v8::HandleScope scope(isolate);
+
+  TRI_GET_GLOBALS();
+    
+  ClusterFeature const& cf = v8g->_server.getFeature<ClusterFeature>();
+  std::string const& policy = cf.apiJwtPolicy();
+  TRI_V8_RETURN_STD_STRING(policy);
+
+  TRI_V8_TRY_CATCH_END
+}
+
 static void JS_IsFoxxApiDisabled(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate)
   v8::HandleScope scope(isolate);
@@ -1844,6 +1858,8 @@ static void JS_CreateHotbackup(v8::FunctionCallbackInfo<v8::Value> const& args) 
 }
 
 void TRI_InitV8ServerUtils(v8::Isolate* isolate) {
+  TRI_AddGlobalFunctionVocbase(isolate,
+                               TRI_V8_ASCII_STRING(isolate, "SYS_CLUSTER_API_JWT_POLICY"), JS_ClusterApiJwtPolicy, true);
   TRI_AddGlobalFunctionVocbase(isolate,
                                TRI_V8_ASCII_STRING(isolate, "SYS_IS_FOXX_API_DISABLED"), JS_IsFoxxApiDisabled, true);
   TRI_AddGlobalFunctionVocbase(isolate,

--- a/js/apps/system/_admin/aardvark/APP/aardvark.js
+++ b/js/apps/system/_admin/aardvark/APP/aardvark.js
@@ -93,6 +93,7 @@ router.get('/config.js', function (req, res) {
       statisticsInAllDatabases: internal.enabledStatisticsInAllDatabases(),
       foxxStoreEnabled: !internal.isFoxxStoreDisabled(),
       foxxApiEnabled: !internal.isFoxxApiDisabled(),
+      clusterApiJwtPolicy: internal.clusterApiJwtPolicy(),
       minReplicationFactor: internal.minReplicationFactor,
       maxReplicationFactor: internal.maxReplicationFactor,
       defaultReplicationFactor: internal.defaultReplicationFactor,

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/routers/router.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/routers/router.js
@@ -368,6 +368,13 @@
         this.waitForInit(this.cluster.bind(this));
         return;
       }
+      if (this.isCluster && frontendConfig.clusterApiJwtPolicy === 'jwt-all') {
+        // no privileges to use cluster/nodes from the web UI
+        this.routes[''] = 'collections';
+        this.navigate('#collections', {trigger: true});
+        return;
+      }
+
       if (!this.isCluster) {
         if (this.currentDB.get('name') === '_system') {
           this.routes[''] = 'dashboard';
@@ -399,6 +406,13 @@
         this.waitForInit(this.node.bind(this), id);
         return;
       }
+      if (this.isCluster && frontendConfig.clusterApiJwtPolicy === 'jwt-all') {
+        // no privileges to use cluster/nodes from the web UI
+        this.routes[''] = 'collections';
+        this.navigate('#collections', {trigger: true});
+        return;
+      }
+
       if (this.isCluster === false) {
         this.routes[''] = 'dashboard';
         this.navigate('#dashboard', {trigger: true});

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/templates/maintenanceView.ejs
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/templates/maintenanceView.ejs
@@ -14,18 +14,22 @@
           <p>The cluster supervision maintenance mode is currently enabled.</p>
           <p>While the maintenance mode is enabled, the agency will not organize failovers for shards that are located on unavailable leaders or follower DB servers. This mode can be used for controlled shutdown/restart of servers, e.g. or for upgrading or other planned maintenance.</p>
         </div>
-        <button id="disableMaintenanceMode" class="button-success pull-right"
-                style="margin-right: 20px;">Disable Maintenance Mode
-        </button>
+        <% if (canChange) { %>
+          <button id="disableMaintenanceMode" class="button-success pull-right"
+                  style="margin-right: 20px;">Disable Maintenance Mode
+          </button>
+        <% } %>
       <% } else { %>
         <div id="maintenanceMode" class="infoBox successBox" style="margin-top: 15px; margin-bottom: 20px">
           <h4>Maintenance mode disabled <i class="fa fa-check"></i></h4>
           <p>The cluster supervision maintenance mode is currently disabled.</p>
           <p>This is the expected setting for normal operations: in case a leader or follower DB server becomes unavailable, the agency will organize failovers for all affected shards.
         </div>
-        <button id="enableMaintenanceMode" class="button-warning pull-right"
-                style="margin-right: 20px; margin-bottom: 20px;">Enable Maintenance Mode
-        </button>
+        <% if (canChange) { %>
+          <button id="enableMaintenanceMode" class="button-warning pull-right"
+                  style="margin-right: 20px; margin-bottom: 20px;">Enable Maintenance Mode
+          </button>
+        <% } %>
       <% } %>
     </div>
 

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/templates/navigationView.ejs
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/templates/navigationView.ejs
@@ -1,10 +1,10 @@
   <ul class="navlist arango-collection-ul" id="arangoCollectionUl">
-    <% if (isCluster) { %>
+    <% if (isCluster && frontendConfig.clusterApiJwtPolicy !== 'jwt-all') { %>
       <% if (currentDB.get('isSystem') || statisticsInAllDatabases) { %>
         <li class="cluster-menu"><a id="cluster" class="tab" href="#cluster"><i class="fa fa-circle-o"></i>Cluster</a></li>
       <% } %>
       <li class="nodes-menu"><a id="nodes" class="tab" href="#nodes"><i class="fa fa-server"></i>Nodes</a></li>
-    <% } else { %>
+    <% } else if (!isCluster) { %>
       <li class="dashboard-menu"><a id="dashboard" class="tab" href="#dashboard"><i class="fa fa-dashboard"></i>Dashboard</a></li>
     <% } %>
     <li class="navbar-spacer big"></li>

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/templates/subNavigationView.ejs
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/templates/subNavigationView.ejs
@@ -5,7 +5,11 @@
     </li>
     <li id="healthStatus" class="infoEntry subMenuEntry pull-right positive">
       <a class="info health-info">HEALTH: </a>
-      <a class="state health-state">GOOD</a>
+      <% if (frontendConfig.clusterApiJwtPolicy !== 'jwt-all') { %>
+        <a class="state health-state">GOOD</a>
+      <% } else { %>
+        <a class="state health-state" title="cluster API is inaccessible due to missing permissions">n/a</a>
+      <% } %>
       <a class="icon health-icon">
         <i class="fa fa-check-circle"></i>
       </a>

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/footerView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/footerView.js
@@ -138,30 +138,32 @@
           }
         };
 
-        // check cluster state
-        $.ajax({
-          type: 'GET',
-          cache: false,
-          url: arangoHelper.databaseUrl('/_admin/cluster/health'),
-          contentType: 'application/json',
-          processData: false,
-          async: true,
-          success: function (data) {
-            if (window.App) {
-              window.App.lastHealthCheckResult = data;
+        if (frontendConfig.clusterApiJwtPolicy !== 'jwt-all') {
+          // check cluster state
+          $.ajax({
+            type: 'GET',
+            cache: false,
+            url: arangoHelper.databaseUrl('/_admin/cluster/health'),
+            contentType: 'application/json',
+            processData: false,
+            async: true,
+            success: function (data) {
+              if (window.App) {
+                window.App.lastHealthCheckResult = data;
+              }
+              callbackFunction(data);
+              // notify NodesView about new health data
+              if (window.location.hash === '#nodes' && window.App && window.App.nodesView) {
+                window.App.nodesView.render(false);
+              }
+            },
+            error: function () {
+              if (window.App) {
+                window.App.lastHealthCheckResult = null;
+              }
             }
-            callbackFunction(data);
-            // notify NodesView about new health data
-            if (window.location.hash === '#nodes' && window.App && window.App.nodesView) {
-              window.App.nodesView.render(false);
-            }
-          },
-          error: function () {
-            if (window.App) {
-              window.App.lastHealthCheckResult = null;
-            }
-          }
-        });
+          });
+        }
       } else {
         $('#healthStatus').removeClass('positive');
         $('#healthStatus').addClass('negative');

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/maintenanceView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/maintenanceView.js
@@ -1,6 +1,6 @@
 /* jshint browser: true */
 /* jshint unused: false */
-/* global arangoHelper, Backbone, templateEngine, $, window, _ */
+/* global arangoHelper, Backbone, templateEngine, $, window, frontendConfig _ */
 (function () {
   'use strict';
 
@@ -149,7 +149,8 @@
     continueRender: function (maintenanceMode, error) {
       this.$el.html(this.template.render({
         maintenanceMode: (maintenanceMode !== 'Normal'),
-        error: error
+        error: error,
+        canChange: frontendConfig.clusterApiJwtPolicy === 'jwt-compat'
       }));
     }
   });

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/navigationView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/navigationView.js
@@ -65,7 +65,7 @@
 
     render: function () {
       $(this.subEl).html(this.templateSub.render({
-        frontendConfig: this.frontendConfig,
+        frontendConfig: window.frontendConfig,
         currentDB: this.currentDB.toJSON()
       }));
       arangoHelper.checkDatabasePermissions(this.continueRender.bind(this), this.continueRender.bind(this));

--- a/js/server/bootstrap/modules/internal.js
+++ b/js/server/bootstrap/modules/internal.js
@@ -192,6 +192,11 @@
     delete global.SYS_IS_FOXX_STORE_DISABLED;
   }
 
+  if (global.SYS_CLUSTER_API_JWT_POLICY) {
+    exports.clusterApiJwtPolicy = global.SYS_CLUSTER_API_JWT_POLICY;
+    delete global.SYS_CLUSTER_API_JWT_POLICY;
+  }
+
   // //////////////////////////////////////////////////////////////////////////////
   // / @brief autoload modules from database
   // //////////////////////////////////////////////////////////////////////////////

--- a/tests/js/client/server_permissions/test-cluster-jwt-policy-all.js
+++ b/tests/js/client/server_permissions/test-cluster-jwt-policy-all.js
@@ -1,0 +1,141 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, runSetup, assertEqual, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for security-related server options
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2020, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const crypto = require('@arangodb/crypto');
+const request = require('@arangodb/request');
+
+const jwtSecret = 'abc123';
+
+if (getOptions === true) {
+  return {
+    'server.harden': 'false',
+    'cluster.api-jwt-policy': 'jwt-all',
+    'server.authentication': 'true',
+    'server.jwt-secret': jwtSecret,
+    'runSetup': true
+  };
+}
+
+if (runSetup === true) {
+  let users = require("@arangodb/users");
+  
+  users.save("test_rw", "testi");
+  users.grantDatabase("test_rw", "_system", "rw");
+  
+  return true;
+}
+
+const jsunity = require('jsunity');
+
+function testSuite() {
+  let endpoint = arango.getEndpoint();
+  let db = require("@arangodb").db;
+
+  let baseUrl = function () {
+    return endpoint.replace(/^tcp:/, 'http:').replace(/^ssl:/, 'https:');
+  };
+
+  const jwt = crypto.jwtEncode(jwtSecret, {
+    "server_id": "ABCD",
+    "iss": "arangodb", "exp": Math.floor(Date.now() / 1000) + 3600
+  }, 'HS256');
+
+  return {
+    testCanAccessClusterApiReadHealth : function() {
+      let res = request.get({
+        url: baseUrl() + "/_admin/cluster/health",
+        auth: { username: "test_rw", password: "testi" },
+      });
+      assertEqual(403, res.status);
+    },
+    
+    testCanAccessClusterApiReadNumberOfServers : function() {
+      let res = request.get({
+        url: baseUrl() + "/_admin/cluster/numberOfServers",
+        auth: { username: "test_rw", password: "testi" },
+      });
+      assertEqual(403, res.status);
+    },
+    
+    testCanAccessClusterApiReadMaintenance : function() {
+      let res = request.get({
+        url: baseUrl() + "/_admin/cluster/maintenance",
+        auth: { username: "test_rw", password: "testi" },
+      });
+      assertEqual(403, res.status);
+    },
+    
+    testCanAccessClusterApiWriteMoveShard : function() {
+      let res = request.post({
+        url: baseUrl() + "/_admin/cluster/moveShard", 
+        auth: { username: "test_rw", password: "testi" },
+        body: {},
+      });
+      assertEqual(403, res.status);
+    },
+    
+    testCanAccessClusterApiReadHealthJwt : function() {
+      let res = request.get({
+        url: baseUrl() + "/_admin/cluster/health",
+        auth: { bearer: jwt },
+      });
+      assertEqual(200, res.status);
+    },
+    
+    testCanAccessClusterApiReadNumberOfServersJwt : function() {
+      let res = request.get({
+        url: baseUrl() + "/_admin/cluster/numberOfServers",
+        auth: { bearer: jwt },
+      });
+      assertEqual(200, res.status);
+    },
+    
+    testCanAccessClusterApiReadMaintenanceJwt : function() {
+      let res = request.get({
+        url: baseUrl() + "/_admin/cluster/maintenance",
+        auth: { bearer: jwt },
+      });
+      assertEqual(200, res.status);
+    },
+    
+    testCanAccessClusterApiWriteMoveShardJwt : function() {
+      let res = request.post({
+        url: baseUrl() + "/_admin/cluster/moveShard", 
+        auth: { bearer: jwt },
+        body: {},
+      });
+      // this is not a valid request, however, we expect an HTTP 400
+      // here because we must have got past the permissions check
+      // (which would have returned HTTP 403)
+      assertEqual(400, res.status);
+    },
+    
+  };
+}
+jsunity.run(testSuite);
+return jsunity.done();

--- a/tests/js/client/server_permissions/test-cluster-jwt-policy-compat.js
+++ b/tests/js/client/server_permissions/test-cluster-jwt-policy-compat.js
@@ -1,0 +1,144 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, runSetup, assertEqual, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for security-related server options
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2020, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const crypto = require('@arangodb/crypto');
+const request = require('@arangodb/request');
+
+const jwtSecret = 'abc123';
+
+if (getOptions === true) {
+  return {
+    'server.harden': 'false',
+    'cluster.api-jwt-policy': 'jwt-compat',
+    'server.authentication': 'true',
+    'server.jwt-secret': jwtSecret,
+    'runSetup': true
+  };
+}
+
+if (runSetup === true) {
+  let users = require("@arangodb/users");
+  
+  users.save("test_rw", "testi");
+  users.grantDatabase("test_rw", "_system", "rw");
+  
+  return true;
+}
+
+const jsunity = require('jsunity');
+
+function testSuite() {
+  let endpoint = arango.getEndpoint();
+  let db = require("@arangodb").db;
+
+  let baseUrl = function () {
+    return endpoint.replace(/^tcp:/, 'http:').replace(/^ssl:/, 'https:');
+  };
+
+  const jwt = crypto.jwtEncode(jwtSecret, {
+    "server_id": "ABCD",
+    "iss": "arangodb", "exp": Math.floor(Date.now() / 1000) + 3600
+  }, 'HS256');
+
+  return {
+    testCanAccessClusterApiReadHealth : function() {
+      let res = request.get({
+        url: baseUrl() + "/_admin/cluster/health",
+        auth: { username: "test_rw", password: "testi" },
+      });
+      assertEqual(200, res.status);
+    },
+    
+    testCanAccessClusterApiReadNumberOfServers : function() {
+      let res = request.get({
+        url: baseUrl() + "/_admin/cluster/numberOfServers",
+        auth: { username: "test_rw", password: "testi" },
+      });
+      assertEqual(200, res.status);
+    },
+    
+    testCanAccessClusterApiReadMaintenance : function() {
+      let res = request.get({
+        url: baseUrl() + "/_admin/cluster/maintenance",
+        auth: { username: "test_rw", password: "testi" },
+      });
+      assertEqual(200, res.status);
+    },
+    
+    testCanAccessClusterApiWriteMoveShard : function() {
+      let res = request.post({
+        url: baseUrl() + "/_admin/cluster/moveShard", 
+        auth: { username: "test_rw", password: "testi" },
+        body: {},
+      });
+      // this is not a valid request, however, we expect an HTTP 400
+      // here because we must have got past the permissions check
+      // (which would have returned HTTP 403)
+      assertEqual(400, res.status);
+    },
+    
+    testCanAccessClusterApiReadHealthJwt : function() {
+      let res = request.get({
+        url: baseUrl() + "/_admin/cluster/health",
+        auth: { bearer: jwt },
+      });
+      assertEqual(200, res.status);
+    },
+    
+    testCanAccessClusterApiReadNumberOfServersJwt : function() {
+      let res = request.get({
+        url: baseUrl() + "/_admin/cluster/numberOfServers",
+        auth: { bearer: jwt },
+      });
+      assertEqual(200, res.status);
+    },
+    
+    testCanAccessClusterApiReadMaintenanceJwt : function() {
+      let res = request.get({
+        url: baseUrl() + "/_admin/cluster/maintenance",
+        auth: { bearer: jwt },
+      });
+      assertEqual(200, res.status);
+    },
+    
+    testCanAccessClusterApiWriteMoveShardJwt : function() {
+      let res = request.post({
+        url: baseUrl() + "/_admin/cluster/moveShard", 
+        auth: { bearer: jwt },
+        body: {},
+      });
+      // this is not a valid request, however, we expect an HTTP 400
+      // here because we must have got past the permissions check
+      // (which would have returned HTTP 403)
+      assertEqual(400, res.status);
+    },
+    
+  };
+}
+jsunity.run(testSuite);
+return jsunity.done();

--- a/tests/js/client/server_permissions/test-cluster-jwt-policy-write.js
+++ b/tests/js/client/server_permissions/test-cluster-jwt-policy-write.js
@@ -1,0 +1,141 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, runSetup, assertEqual, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for security-related server options
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2020, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const crypto = require('@arangodb/crypto');
+const request = require('@arangodb/request');
+
+const jwtSecret = 'abc123';
+
+if (getOptions === true) {
+  return {
+    'server.harden': 'false',
+    'cluster.api-jwt-policy': 'jwt-write',
+    'server.authentication': 'true',
+    'server.jwt-secret': jwtSecret,
+    'runSetup': true
+  };
+}
+
+if (runSetup === true) {
+  let users = require("@arangodb/users");
+  
+  users.save("test_rw", "testi");
+  users.grantDatabase("test_rw", "_system", "rw");
+  
+  return true;
+}
+
+const jsunity = require('jsunity');
+
+function testSuite() {
+  let endpoint = arango.getEndpoint();
+  let db = require("@arangodb").db;
+
+  let baseUrl = function () {
+    return endpoint.replace(/^tcp:/, 'http:').replace(/^ssl:/, 'https:');
+  };
+
+  const jwt = crypto.jwtEncode(jwtSecret, {
+    "server_id": "ABCD",
+    "iss": "arangodb", "exp": Math.floor(Date.now() / 1000) + 3600
+  }, 'HS256');
+
+  return {
+    testCanAccessClusterApiReadHealth : function() {
+      let res = request.get({
+        url: baseUrl() + "/_admin/cluster/health",
+        auth: { username: "test_rw", password: "testi" },
+      });
+      assertEqual(200, res.status);
+    },
+    
+    testCanAccessClusterApiReadNumberOfServers : function() {
+      let res = request.get({
+        url: baseUrl() + "/_admin/cluster/numberOfServers",
+        auth: { username: "test_rw", password: "testi" },
+      });
+      assertEqual(200, res.status);
+    },
+    
+    testCanAccessClusterApiReadMaintenance : function() {
+      let res = request.get({
+        url: baseUrl() + "/_admin/cluster/maintenance",
+        auth: { username: "test_rw", password: "testi" },
+      });
+      assertEqual(200, res.status);
+    },
+    
+    testCanAccessClusterApiWriteMoveShard : function() {
+      let res = request.post({
+        url: baseUrl() + "/_admin/cluster/moveShard", 
+        auth: { username: "test_rw", password: "testi" },
+        body: {},
+      });
+      assertEqual(403, res.status);
+    },
+    
+    testCanAccessClusterApiReadHealthJwt : function() {
+      let res = request.get({
+        url: baseUrl() + "/_admin/cluster/health",
+        auth: { bearer: jwt },
+      });
+      assertEqual(200, res.status);
+    },
+    
+    testCanAccessClusterApiReadNumberOfServersJwt : function() {
+      let res = request.get({
+        url: baseUrl() + "/_admin/cluster/numberOfServers",
+        auth: { bearer: jwt },
+      });
+      assertEqual(200, res.status);
+    },
+    
+    testCanAccessClusterApiReadMaintenanceJwt : function() {
+      let res = request.get({
+        url: baseUrl() + "/_admin/cluster/maintenance",
+        auth: { bearer: jwt },
+      });
+      assertEqual(200, res.status);
+    },
+    
+    testCanAccessClusterApiWriteMoveShardJwt : function() {
+      let res = request.post({
+        url: baseUrl() + "/_admin/cluster/moveShard", 
+        auth: { bearer: jwt },
+        body: {},
+      });
+      // this is not a valid request, however, we expect an HTTP 400
+      // here because we must have got past the permissions check
+      // (which would have returned HTTP 403)
+      assertEqual(400, res.status);
+    },
+    
+  };
+}
+jsunity.run(testSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Docs PR: https://github.com/arangodb/docs/pull/651

Add an option to lock down `/_admin/cluster` REST APIs.

* Add an option for locking down all endpoints in the `/_admin/cluster` REST
  API for callers without a proper JWT set in the request. There is a new
  startup option `--cluster.api-jwt-policy` that allows *additional* checks
  for a valid JWT in requests to sub-routes of `/_admin/cluster`. The
  possible values for the startup option are:

  - "jwt-all": requires a valid JWT for all accesses to `/_admin/cluster` and
    its sub-routes. If this configuration is used, the "Cluster" and "Nodes"
    sections of the web interface will be disabled, as they are relying on the
    ability to read data from several cluster APIs.
  - "jwt-write": requires a valid JWT for write accesses (all HTTP methods
    except HTTP GET) to `/_admin/cluster`. This setting can be used to allow
    privileged users to read data from the cluster APIs, but not to do any
    modifications. All existing permissions checks for the cluster API routes
    are still in effect with this setting, meaning that read operations without
    a valid JWT may still require dedicated other permissions (as in 3.7).
  - "jwt-compat": no *additional* access checks are in place for the cluster
    APIs. However, all existing permissions checks for the cluster API routes
    are still in effect with this setting, meaning that all operations may
    still require dedicated other permissions (as in 3.7).

  The default value for the option is `jwt-compat`, which means this option will
  not cause any *extra* JWT checks compared to 3.7.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/651

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (server_permissions)
