### PR TITLE
Fix connectionTime statistic.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fix connectionTime statistic. This statistic should provide the distribution
+  of the connection lifetimes, but in previous versions the tracking was broken
+  and no values were reported.
+
 * Add an option for locking down all endpoints in the `/_admin/cluster` REST
   API for callers without a proper JWT set in the request. There is a new
   startup option `--cluster.api-jwt-policy` that allows *additional* checks

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -81,7 +81,9 @@ CommTask::CommTask(GeneralServer& server,
   _connectionStatistics.SET_START();
 }
 
-CommTask::~CommTask() = default;
+CommTask::~CommTask() {
+  _connectionStatistics.SET_END();
+}
 
 // -----------------------------------------------------------------------------
 // --SECTION--                                                 protected methods

--- a/arangod/Statistics/ConnectionStatistics.h
+++ b/arangod/Statistics/ConnectionStatistics.h
@@ -67,6 +67,12 @@ class ConnectionStatistics {
       }
     }
 
+    void SET_END() {
+      if (_stat != nullptr) {
+        _stat->_connEnd = StatisticsFeature::time();
+      }
+    }
+    
     void SET_HTTP();
 
    private:


### PR DESCRIPTION
### Scope & Purpose

Fix connectionTime statistic. This statistic should provide the distribution of the connection lifetimes, but in previous versions the tracking was broken and no values were reported.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.8

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
