### PR TITLE
Bug fix 3.8/connection time statistic

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.8.0-alpha.1 (XXXX-XX-XX)
 ---------------------------
 
+* Fix connectionTime statistic. This statistic should provide the distribution
+  of the connection lifetimes, but in previous versions the tracking was broken
+  and no values were reported.
+  
 * When using connections to multiple endpoints and switching between them,
   arangosh can now reuse existing connections by referring to an internal
   connection cache. This helps for arangosh scripts that repeatedly connect

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -81,7 +81,9 @@ CommTask::CommTask(GeneralServer& server,
   _connectionStatistics.SET_START();
 }
 
-CommTask::~CommTask() = default;
+CommTask::~CommTask() {
+  _connectionStatistics.SET_END();
+}
 
 // -----------------------------------------------------------------------------
 // --SECTION--                                                 protected methods

--- a/arangod/Statistics/ConnectionStatistics.h
+++ b/arangod/Statistics/ConnectionStatistics.h
@@ -67,6 +67,12 @@ class ConnectionStatistics {
       }
     }
 
+    void SET_END() {
+      if (_stat != nullptr) {
+        _stat->_connEnd = StatisticsFeature::time();
+      }
+    }
+    
     void SET_HTTP();
 
    private:


### PR DESCRIPTION
### Scope & Purpose

Backport of #13829

Fix connectionTime statistic. This statistic should provide the distribution of the connection lifetimes, but in previous versions the tracking was broken and no values were reported.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
