### PR TITLE
documentation for more metrics

### DIFF
--- a/Documentation/Metrics/allMetrics.yaml
+++ b/Documentation/Metrics/allMetrics.yaml
@@ -193,12 +193,12 @@
   unit: bytes
 - category: Agency
   complexity: simple
-  description: 'Agency read with no leader.
+  description: 'Total number of agency read operations with no leader or on followers.
 
     '
   exposedBy:
   - agent
-  help: 'Agency read no leader.
+  help: 'Agency read operations with no leader or on followers.
 
     '
   introducedIn: '3.7'
@@ -219,12 +219,24 @@
   unit: number
 - category: Agency
   complexity: simple
-  description: 'Number of agency read operations which went ok.
+  description: 'Number of agency read operations which were successful (i.e. completed
+
+    without any error). Successful reads can only be executed on the leader, so
+
+    this metric is supposed to increase only on agency leaders, but not on
+
+    followers. Read requests that are executed on followers will be rejected
+
+    and can be tracked via the metric `arangodb_agency_read_no_leader_total`.
+
+    This metric was named `arangodb_agency_read_ok` in previous
+
+    versions of ArangoDB.
 
     '
   exposedBy:
   - agent
-  help: 'Agency read ok.
+  help: 'Number of successful agency read operations.
 
     '
   introducedIn: '3.7'
@@ -233,9 +245,10 @@
   unit: number
 - category: Agency
   complexity: medium
-  description: 'Counter for FailedServer jobs.
-
-    '
+  description: "Counter for FailedServer jobs. This counter is increased whenever
+    a \nsupervision run encounters a failed server and starts a FailedServer job.\nThis
+    metric was named `arangodb_agency_supervision_failed_server_count`\nin previous
+    versions of ArangoDB.\n"
   exposedBy:
   - agent
   help: 'Counter for FailedServer jobs.
@@ -258,15 +271,18 @@
   unit: number
 - category: Agency
   complexity: simple
-  description: 'Agency Supervision runtime histogram.
+  description: 'Agency supervision runtime histogram. A new value is recorded for
+    each
+
+    run of the supervision.
 
     '
   exposedBy:
   - agent
-  help: 'Agency Supervision runtime histogram.
+  help: 'Agency supervision runtime histogram.
 
     '
-  introducedIn: '3.7'
+  introducedIn: '3.8'
   name: arangodb_agency_supervision_runtime_msec
   threshold: 'The supervision runtime goes up linearly with the number of collections
 
@@ -277,21 +293,22 @@
   unit: ms
 - category: Agency
   complexity: medium
-  description: 'Agency supervision wait for replication time.
-
-    '
+  description: "Agency supervision replication time histogram. Whenever the agency\nsupervision
+    carries out changes, it will write them to the leader's log \nand replicate the
+    changes to followers. This metric provides a histogram\nof the time it took to
+    replicate the supervision changes to followers.\n"
   exposedBy:
   - agent
   help: 'Agency supervision wait for replication time.
 
     '
-  introducedIn: '3.7'
+  introducedIn: '3.8'
   name: arangodb_agency_supervision_runtime_wait_for_replication_msec
   type: histogram
   unit: ms
 - category: Agency
   complexity: medium
-  description: 'Agency''s term.
+  description: 'The Agency''s current term.
 
     '
   exposedBy:
@@ -317,7 +334,13 @@
   unit: number
 - category: Agency
   complexity: medium
-  description: 'Agency write time histogram.
+  description: 'Agency write time histogram. This histogram provides the distribution
+
+    of the times spent in agency write operations, in milliseconds. This only
+
+    includes the time required to write the data into the leader''s log, but
+
+    does not include the time required to replicate the writes to the followers.
 
     '
   exposedBy:
@@ -331,26 +354,50 @@
   unit: ms
 - category: Agency
   complexity: medium
-  description: 'Agency write operations with no leader.
+  description: 'Total number of agency write operations with no leader or on followers.
 
     '
   exposedBy:
   - agent
-  help: 'Agency write operations with no leader.
+  help: 'Agency write operations with no leader or on followers.
 
     '
   introducedIn: '3.7'
   name: arangodb_agency_write_no_leader_total
+  threshold: 'This should normally not happen. If it happens regularly, the agency
+
+    is reelecting its leader often.
+
+    '
+  troubleshoot: 'The latency of the network between the agents might be too high or
+
+    the agents may be overloaded. It might help to move agent instances
+
+    to separate machines.
+
+    '
   type: counter
   unit: number
 - category: Agency
-  complexity: medium
-  description: 'Agency write operations which went ok.
+  complexity: simple
+  description: 'Number of agency write operations which were successful (i.e. completed
+
+    without any error). Successful writes can only be executed on the leader, so
+
+    this metric is supposed to increase only on agency leaders, but not on
+
+    followers. Write requests that are executed on followers will be rejected
+
+    and can be tracked via the metric `arangodb_agency_write_no_leader_total`.
+
+    This metric was named `arangodb_agency_write_ok` in previous
+
+    versions of ArangoDB.
 
     '
   exposedBy:
   - agent
-  help: 'Agency write operations which went ok.
+  help: 'Number of successful agency write operations.
 
     '
   introducedIn: '3.7'
@@ -1127,7 +1174,7 @@
 
     the agency to report their own liveliness. This counter gets
 
-    increased whenever sending such heartbeat fails. In the single
+    increased whenever sending such a heartbeat fails. In the single
 
     server, this counter is only used in active failover mode.
 
@@ -1890,11 +1937,9 @@
   unit: number
 - category: Network
   complexity: advanced
-  description: 'Internal request round-trip time as a percentage of timeout.
-
-    This metric will have a value between 0 and 100.
-
-    '
+  description: "Histogram providing the round-trip time of internal requests as a
+    percentage \nof the respective request timeout.\nThis metric will provide values
+    between 0 and 100.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -1904,11 +1949,29 @@
     '
   introducedIn: '3.8'
   name: arangodb_network_request_duration_as_percentage_of_timeout
+  troubleshoot: 'High values indicate problems with requests that have timed out or
+    have not been
+
+    far away from running into timeouts. If many requests timeout, this is normally
+
+    a symptom of overload. This can normally be mitigated by reducing the workload
+
+    or adjusting the type of operations that are causing the high response times.
+
+    If the timeouts happen as a result of not enough processing power, it may be
+
+    useful to scale up the cluster.
+
+    '
   type: gauge
   unit: percentage
 - category: Network
   complexity: medium
-  description: 'Number of internal requests that have timed out.
+  description: 'Number of internal requests that have timed out. This metric in increased
+
+    whenever any cluster-internal request executed in the underlying connection
+
+    pool runs into a timeout.
 
     '
   exposedBy:
@@ -1920,13 +1983,24 @@
     '
   introducedIn: '3.8'
   name: arangodb_network_request_timeouts_total
+  troubleshoot: 'Request timeouts can be caused by the destination servers being overloaded
+
+    and thus slow to respond, or by network errors. If this counter increases,
+
+    it is advised to check network connectivity and server loads.
+
+    '
   type: counter
   unit: number
 - category: Network
   complexity: medium
-  description: 'Number of outgoing internal requests in flight.
-
-    '
+  description: "Number of outgoing internal requests in flight. This metric in increased\nwhenever
+    any cluster-internal request is about to be sent via the underlying \nconnection
+    pool, and is decreased whenever a response for such request is\nreceived or the
+    request runs into a timeout.\nThis metric provides an estimate of the fan-out
+    of operations. For example,\na user operation on a collection with a single shard
+    will normally lead to\na single internal request (plus replication), whereas an
+    operation on a\ncollection with 10 shards may lead to a fan-out of 10 (plus replication).\n"
   exposedBy:
   - coordinator
   - dbserver

--- a/Documentation/Metrics/arangodb_agency_read_no_leader_total.yaml
+++ b/Documentation/Metrics/arangodb_agency_read_no_leader_total.yaml
@@ -1,7 +1,7 @@
 name: arangodb_agency_read_no_leader_total
 introducedIn: "3.7"
 help: |
-  Agency read no leader.
+  Agency read operations with no leader or on followers.
 unit: number
 type: counter
 category: Agency
@@ -9,7 +9,7 @@ complexity: simple
 exposedBy:
   - agent
 description: |
-  Agency read with no leader.
+  Total number of agency read operations with no leader or on followers.
 threshold: |
   This should normally not happen. If it happens regularly, the agency
   is reelecting its leader often.

--- a/Documentation/Metrics/arangodb_agency_read_ok_total.yaml
+++ b/Documentation/Metrics/arangodb_agency_read_ok_total.yaml
@@ -1,7 +1,7 @@
 name: arangodb_agency_read_ok_total
 introducedIn: "3.7"
 help: |
-  Agency read ok.
+  Number of successful agency read operations.
 unit: number
 type: counter
 category: Agency
@@ -9,4 +9,10 @@ complexity: simple
 exposedBy:
   - agent
 description: |
-  Number of agency read operations which went ok.
+  Number of agency read operations which were successful (i.e. completed
+  without any error). Successful reads can only be executed on the leader, so
+  this metric is supposed to increase only on agency leaders, but not on
+  followers. Read requests that are executed on followers will be rejected
+  and can be tracked via the metric `arangodb_agency_read_no_leader_total`.
+  This metric was named `arangodb_agency_read_ok` in previous
+  versions of ArangoDB.

--- a/Documentation/Metrics/arangodb_agency_supervision_failed_server_total.yaml
+++ b/Documentation/Metrics/arangodb_agency_supervision_failed_server_total.yaml
@@ -9,7 +9,10 @@ complexity: medium
 exposedBy:
   - agent
 description: |
-  Counter for FailedServer jobs.
+  Counter for FailedServer jobs. This counter is increased whenever a 
+  supervision run encounters a failed server and starts a FailedServer job.
+  This metric was named `arangodb_agency_supervision_failed_server_count`
+  in previous versions of ArangoDB.
 threshold: |
   Many FailedServer jobs indicate frequent failures of dbservers. This
   is generally not good.

--- a/Documentation/Metrics/arangodb_agency_supervision_runtime_msec.yaml
+++ b/Documentation/Metrics/arangodb_agency_supervision_runtime_msec.yaml
@@ -1,7 +1,7 @@
 name: arangodb_agency_supervision_runtime_msec
-introducedIn: "3.7"
+introducedIn: "3.8"
 help: |
-  Agency Supervision runtime histogram.
+  Agency supervision runtime histogram.
 unit: ms
 type: histogram
 category: Agency
@@ -9,7 +9,8 @@ complexity: simple
 exposedBy:
   - agent
 description: |
-  Agency Supervision runtime histogram.
+  Agency supervision runtime histogram. A new value is recorded for each
+  run of the supervision.
 threshold: |
   The supervision runtime goes up linearly with the number of collections
   and shards.

--- a/Documentation/Metrics/arangodb_agency_supervision_runtime_wait_for_replication_msec.yaml
+++ b/Documentation/Metrics/arangodb_agency_supervision_runtime_wait_for_replication_msec.yaml
@@ -1,5 +1,5 @@
 name: arangodb_agency_supervision_runtime_wait_for_replication_msec
-introducedIn: "3.7"
+introducedIn: "3.8"
 help: |
   Agency supervision wait for replication time.
 unit: ms
@@ -9,4 +9,7 @@ complexity: medium
 exposedBy:
   - agent
 description: |
-  Agency supervision wait for replication time.
+  Agency supervision replication time histogram. Whenever the agency
+  supervision carries out changes, it will write them to the leader's log 
+  and replicate the changes to followers. This metric provides a histogram
+  of the time it took to replicate the supervision changes to followers.

--- a/Documentation/Metrics/arangodb_agency_term.yaml
+++ b/Documentation/Metrics/arangodb_agency_term.yaml
@@ -9,7 +9,7 @@ complexity: medium
 exposedBy:
   - agent
 description: |
-  Agency's term.
+  The Agency's current term.
 threshold: |
   This number should usually not grow. If it does, the agency is doing
   repeated reelections, which suggests overload or bad network latency

--- a/Documentation/Metrics/arangodb_agency_write_hist.yaml
+++ b/Documentation/Metrics/arangodb_agency_write_hist.yaml
@@ -9,4 +9,7 @@ complexity: medium
 exposedBy:
   - agent
 description: |
-  Agency write time histogram.
+  Agency write time histogram. This histogram provides the distribution
+  of the times spent in agency write operations, in milliseconds. This only
+  includes the time required to write the data into the leader's log, but
+  does not include the time required to replicate the writes to the followers.

--- a/Documentation/Metrics/arangodb_agency_write_no_leader_total.yaml
+++ b/Documentation/Metrics/arangodb_agency_write_no_leader_total.yaml
@@ -1,7 +1,7 @@
 name: arangodb_agency_write_no_leader_total
 introducedIn: "3.7"
 help: |
-  Agency write operations with no leader.
+  Agency write operations with no leader or on followers.
 unit: number
 type: counter
 category: Agency
@@ -9,4 +9,11 @@ complexity: medium
 exposedBy:
   - agent
 description: |
-  Agency write operations with no leader.
+  Total number of agency write operations with no leader or on followers.
+threshold: |
+  This should normally not happen. If it happens regularly, the agency
+  is reelecting its leader often.
+troubleshoot: |
+  The latency of the network between the agents might be too high or
+  the agents may be overloaded. It might help to move agent instances
+  to separate machines.

--- a/Documentation/Metrics/arangodb_agency_write_ok_total.yaml
+++ b/Documentation/Metrics/arangodb_agency_write_ok_total.yaml
@@ -1,12 +1,18 @@
 name: arangodb_agency_write_ok_total
 introducedIn: "3.7"
 help: |
-  Agency write operations which went ok.
+  Number of successful agency write operations.
 unit: number
 type: counter
 category: Agency
-complexity: medium
+complexity: simple
 exposedBy:
   - agent
 description: |
-  Agency write operations which went ok.
+  Number of agency write operations which were successful (i.e. completed
+  without any error). Successful writes can only be executed on the leader, so
+  this metric is supposed to increase only on agency leaders, but not on
+  followers. Write requests that are executed on followers will be rejected
+  and can be tracked via the metric `arangodb_agency_write_no_leader_total`.
+  This metric was named `arangodb_agency_write_ok` in previous
+  versions of ArangoDB.

--- a/Documentation/Metrics/arangodb_network_request_duration_as_percentage_of_timeout.yaml
+++ b/Documentation/Metrics/arangodb_network_request_duration_as_percentage_of_timeout.yaml
@@ -11,5 +11,13 @@ exposedBy:
   - dbserver
   - agent
 description: |
-  Internal request round-trip time as a percentage of timeout.
-  This metric will have a value between 0 and 100.
+  Histogram providing the round-trip time of internal requests as a percentage 
+  of the respective request timeout.
+  This metric will provide values between 0 and 100.
+troubleshoot: |
+  High values indicate problems with requests that have timed out or have not been
+  far away from running into timeouts. If many requests timeout, this is normally
+  a symptom of overload. This can normally be mitigated by reducing the workload
+  or adjusting the type of operations that are causing the high response times.
+  If the timeouts happen as a result of not enough processing power, it may be
+  useful to scale up the cluster.

--- a/Documentation/Metrics/arangodb_network_request_timeouts_total.yaml
+++ b/Documentation/Metrics/arangodb_network_request_timeouts_total.yaml
@@ -11,4 +11,10 @@ exposedBy:
   - dbserver
   - agent
 description: |
-  Number of internal requests that have timed out.
+  Number of internal requests that have timed out. This metric in increased
+  whenever any cluster-internal request executed in the underlying connection
+  pool runs into a timeout.
+troubleshoot: |
+  Request timeouts can be caused by the destination servers being overloaded
+  and thus slow to respond, or by network errors. If this counter increases,
+  it is advised to check network connectivity and server loads.

--- a/Documentation/Metrics/arangodb_network_request_timeouts_total.yaml
+++ b/Documentation/Metrics/arangodb_network_request_timeouts_total.yaml
@@ -11,7 +11,7 @@ exposedBy:
   - dbserver
   - agent
 description: |
-  Number of internal requests that have timed out. This metric in increased
+  Number of internal requests that have timed out. This metric is increased
   whenever any cluster-internal request executed in the underlying connection
   pool runs into a timeout.
 troubleshoot: |

--- a/Documentation/Metrics/arangodb_network_requests_in_flight.yaml
+++ b/Documentation/Metrics/arangodb_network_requests_in_flight.yaml
@@ -11,4 +11,11 @@ exposedBy:
   - dbserver
   - agent
 description: |
-  Number of outgoing internal requests in flight.
+  Number of outgoing internal requests in flight. This metric in increased
+  whenever any cluster-internal request is about to be sent via the underlying 
+  connection pool, and is decreased whenever a response for such request is
+  received or the request runs into a timeout.
+  This metric provides an estimate of the fan-out of operations. For example,
+  a user operation on a collection with a single shard will normally lead to
+  a single internal request (plus replication), whereas an operation on a
+  collection with 10 shards may lead to a fan-out of 10 (plus replication).

--- a/Documentation/Metrics/arangodb_network_requests_in_flight.yaml
+++ b/Documentation/Metrics/arangodb_network_requests_in_flight.yaml
@@ -13,7 +13,7 @@ exposedBy:
 description: |
   Number of outgoing internal requests in flight. This metric is increased
   whenever any cluster-internal request is about to be sent via the underlying 
-  connection pool, and is decreased whenever a response for such request is
+  connection pool, and is decreased whenever a response for such a request is
   received or the request runs into a timeout.
   This metric provides an estimate of the fan-out of operations. For example,
   a user operation on a collection with a single shard will normally lead to

--- a/Documentation/Metrics/arangodb_network_requests_in_flight.yaml
+++ b/Documentation/Metrics/arangodb_network_requests_in_flight.yaml
@@ -11,7 +11,7 @@ exposedBy:
   - dbserver
   - agent
 description: |
-  Number of outgoing internal requests in flight. This metric in increased
+  Number of outgoing internal requests in flight. This metric is increased
   whenever any cluster-internal request is about to be sent via the underlying 
   connection pool, and is decreased whenever a response for such request is
   received or the request runs into a timeout.

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -1415,7 +1415,7 @@ write_ret_t Agent::write(query_t const& query, WriteMode const& wmode) {
       indices.insert(indices.end(), tmp.begin(), tmp.end());
     }
     _write_hist_msec.count(
-      duration<float, std::milli>(high_resolution_clock::now()-start).count());
+      duration<float, std::milli>(high_resolution_clock::now() - start).count());
   }
 
   // Maximum log index


### PR DESCRIPTION
### Scope & Purpose

This PR adds documentation for the following metrics:
* arangodb_agency_read_ok_total 
* arangodb_agency_write_ok_total 
* arangodb_agency_write_no_leader_total 
* arangodb_agency_term 
* arangodb_agency_write_hist 
* arangodb_agency_supervision_failed_server_total 
* arangodb_agency_supervision_runtime_msec 
* arangodb_agency_supervision_runtime_wait_for_replication_msec 
* arangodb_network_request_duration_as_percentage_of_timeout
* arangodb_network_requests_in_flight 
* arangodb_network_request_timeouts_total 


- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*: https://github.com/arangodb/arangodb/pull/13836

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
