### PR TITLE
Try to resume RocksDB operations after background error

### DIFF
--- a/3rdParty/rocksdb/6.8/util/status.cc
+++ b/3rdParty/rocksdb/6.8/util/status.cc
@@ -135,6 +135,9 @@ std::string Status::ToString() const {
   }
 
   if (state_ != nullptr) {
+    if (subcode_ != kNone) {
+      result.append(": ");
+    }
     result.append(state_);
   }
   return result;

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 v3.7.11 (XXXX-XX-XX)
 --------------------
 
+* Try to automatically resume RocksDB operations after a RocksDB background
+  error. On a background error, RocksDB may have gone into read-only mode and
+  not try to recover from it automatically in some situations, e.g. if the
+  background error happened during compaction.
+  Now we try to automatically resume operations every few seconds in case a
+  background error has happened.
+
 * Fix a crash caused by returning a result produced by ANALYZER function.
 
 * Fix implicit capture of views in a context of JS transaction.

--- a/arangod/RocksDBEngine/RocksDBBackgroundErrorListener.h
+++ b/arangod/RocksDBEngine/RocksDBBackgroundErrorListener.h
@@ -27,16 +27,22 @@
 #include <rocksdb/db.h>
 #include <rocksdb/listener.h>
 
+#include <atomic>
+
 namespace arangodb {
 
 class RocksDBBackgroundErrorListener : public rocksdb::EventListener {
  public:
-  virtual ~RocksDBBackgroundErrorListener();
+  RocksDBBackgroundErrorListener();
+  ~RocksDBBackgroundErrorListener();
 
   void OnBackgroundError(rocksdb::BackgroundErrorReason reason, rocksdb::Status* error) override;
 
+  bool called() const noexcept;
+  void resume();
+
  private:
-  bool _called = false;
+  std::atomic<bool> _called;
 };  // class RocksDBThrottle
 
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -52,6 +52,7 @@ namespace arangodb {
 
 class PhysicalCollection;
 class PhysicalView;
+class RocksDBBackgroundErrorListener;
 class RocksDBBackgroundThread;
 class RocksDBEventListener;
 class RocksDBKey;
@@ -308,6 +309,9 @@ class RocksDBEngine final : public StorageEngine {
   virtual TRI_voc_tick_t releasedTick() const override;
   virtual void releaseTick(TRI_voc_tick_t) override;
 
+  // try to resume operations in case there was a background error
+  void tryResume();
+
  private:
   void shutdownRocksDBInstance() noexcept;
   void waitForCompactionJobsToFinish();
@@ -497,6 +501,9 @@ class RocksDBEngine final : public StorageEngine {
   // optional code to notice when rocksdb creates or deletes .ssh files.  Currently
   //  uses that input to create or delete parallel sha256 files
   std::shared_ptr<RocksDBEventListener> _shaListener;
+  
+  // listener for background errors
+  std::shared_ptr<RocksDBBackgroundErrorListener> _backgroundErrorListener; 
 
   arangodb::basics::ReadWriteLock _purgeLock;
 


### PR DESCRIPTION
### Scope & Purpose

Experimental PR for calling RocksDB's `Resume()` function after a background error has occurred.
This may fix a few cases of RocksDB going into read-only mode and not automatically recovering from it.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
