### PR TITLE
Metrics/replication cluster metrics

### DIFF
--- a/Documentation/Metrics/arangodb_replication_cluster_inventory_requests_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_cluster_inventory_requests_total.yaml
@@ -1,4 +1,5 @@
 name: arangodb_replication_cluster_inventory_requests_total
+introducedIn: 3.6
 help: |
   (DC-2-DC only) Number of times the database and collection overviews have been requested.
 unit: number

--- a/Documentation/Metrics/arangodb_replication_cluster_inventory_requests_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_cluster_inventory_requests_total.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication_cluster_inventory_requests_total
-introducedIn: 3.6
+introducedIn: "3.6"
 help: |
   (DC-2-DC only) Number of times the database and collection overviews have been requested.
 unit: number

--- a/Documentation/Metrics/arangodb_replication_cluster_inventory_requests_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_cluster_inventory_requests_total.yaml
@@ -1,12 +1,18 @@
 name: arangodb_replication_cluster_inventory_requests_total
-introducedIn: "3.6"
 help: |
-  Number of cluster replication inventory requests received.
+  (DC-2-DC only) Number of times the database and collection overviews have been requested.
 unit: number
 type: counter
 category: Replication
-complexity: medium
+complexity: advanced
 exposedBy:
   - coordinator
 description: |
-  Number of cluster replication inventory requests received.
+  When using a DC-2-DC configuration of ArangoDB this metric is active on both data-centers.
+  It indicates that the follower data-center peridocally matches the available databases and collections
+  in order to mirror them. If no DC-2-DC is set up this value is expected to be 0.
+troubleshoot: |
+  If you have a DC-2-DC installation, and this metric stays constant over a longer period of time in any of the two data centers
+  this indicates that the follower data center is not properly connected anymore.
+  The issue most likely is within the sync process on either of the two data-centers as they do not compare their inventory anymore.
+  This gives no information about the healthyness of the ArangoDB cluster itself, please check other metrics for this.

--- a/Documentation/Metrics/arangodb_replication_dump_apply_time_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_dump_apply_time_total.yaml
@@ -1,7 +1,7 @@
 name: arangodb_replication_dump_apply_time_total
 introducedIn: "3.8"
 help: |
-  Accumulated time needed to apply replication dump data.
+  Accumulated time needed to apply asynchronously replicated data on initial synchronization of shards.
 unit: ms
 type: counter
 category: Replication
@@ -9,4 +9,9 @@ complexity: medium
 exposedBy:
   - dbserver
 description: |
-  Accumulated time needed to apply replication dump data.
+  Measures the time required to clone the existing leader copy of the data onto a new replica shard.
+  Will only be measured on the follower server. This time is expected to increase whenever new followers
+  are created, e.g. increasing replication factor, shard redistribution.
+troubleshoot: |
+  This metric measures as typical operation to keep the cluster resilient, so no reaction is required.
+  In a stable cluster situation (no outages, no collection modification) this metric should also be stable.

--- a/Documentation/Metrics/arangodb_replication_dump_bytes_received_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_dump_bytes_received_total.yaml
@@ -10,5 +10,5 @@ exposedBy:
   - dbserver
 description: |
   During initial replication the existing data from the leader is copied asynchronously
-  over to new shards. The amount of data transported to this server (as a replica for
-  a shard) is counted here.
+  over to new shards. The amount of data transported to this server, as a replica for
+  a shard, is counted here.

--- a/Documentation/Metrics/arangodb_replication_dump_bytes_received_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_dump_bytes_received_total.yaml
@@ -1,7 +1,7 @@
 name: arangodb_replication_dump_bytes_received_total
 introducedIn: "3.8"
 help: |
-  Number of bytes received in replication dump requests.
+  Total number of bytes replicated in initial asynchronous phase.
 unit: bytes
 type: counter
 category: Replication
@@ -9,4 +9,6 @@ complexity: medium
 exposedBy:
   - dbserver
 description: |
-  Number of bytes received in replication dump requests.
+  During initial replication the existing data from the leader is copied asynchronously
+  over to new shards. The amount of data transported to this server (as a replica for
+  a shard) is counted here.

--- a/Documentation/Metrics/arangodb_replication_dump_bytes_received_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_dump_bytes_received_total.yaml
@@ -10,5 +10,5 @@ exposedBy:
   - dbserver
 description: |
   During initial replication the existing data from the leader is copied asynchronously
-  over to new shards. The amount of data transported to this server, as a replica for
-  a shard, is counted here.
+  over to new shards. The amount of requests required to transport data to this server,
+  as a replica for a shard, is counted here.

--- a/Documentation/Metrics/arangodb_replication_dump_documents_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_dump_documents_total.yaml
@@ -1,7 +1,7 @@
 name: arangodb_replication_dump_documents_total
 introducedIn: "3.8"
 help: |
-  Number of documents received in replication dump requests.
+  Total number of documents replicated in initial asynchronous phase.
 unit: number
 type: counter
 category: Replication
@@ -9,4 +9,6 @@ complexity: simple
 exposedBy:
   - dbserver
 description: |
-  Number of documents received in replication dump requests.
+  During initial replication the existing data from the leader is copied asynchronously
+  over to new shards. The amount of documents transported to this server, as a replica for
+  a shard, is counted here.

--- a/Documentation/Metrics/arangodb_replication_dump_request_time_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_dump_request_time_total.yaml
@@ -1,7 +1,7 @@
 name: arangodb_replication_dump_request_time_total
 introducedIn: "3.8"
 help: |
-  Accumulated wait time for replication requests.
+  Accumulated wait time for replication requests in initial asynchronous phase.
 unit: ms
 type: counter
 category: Replication
@@ -9,4 +9,6 @@ complexity: medium
 exposedBy:
   - dbserver
 description: |
-  Accumulated wait time for replication requests.
+  During initial replication the existing data from the leader is copied asynchronously
+  over to new shards. The accumulated time the follower waited for the leader to send
+  the data is counted here.

--- a/Documentation/Metrics/arangodb_replication_dump_requests_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_dump_requests_total.yaml
@@ -1,7 +1,7 @@
 name: arangodb_replication_dump_requests_total
 introducedIn: "3.8"
 help: |
-  Number of replication dump requests.
+  Number of requests used in initial asynchronous replication phase.
 unit: number
 type: counter
 category: Replication
@@ -9,4 +9,6 @@ complexity: medium
 exposedBy:
   - dbserver
 description: |
-  Number of replication dump requests.
+  During initial replication the existing data from the leader is copied asynchronously
+  over to new shards. The amount of data transported to this server, as a replica for
+  a shard, is counted here.

--- a/Documentation/Metrics/arangodb_replication_failed_connects_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_failed_connects_total.yaml
@@ -1,7 +1,7 @@
 name: arangodb_replication_failed_connects_total
 introducedIn: "3.8"
 help: |
-  Number of failed connection attempts and response errors during replication.
+  Number of failed connection attempts and response errors during initial asynchronous replication.
 unit: number
 type: counter
 category: Replication
@@ -9,4 +9,30 @@ complexity: medium
 exposedBy:
   - dbserver
 description: |
-  Number of failed connection attempts and response errors during replication.
+  During initial replication the existing data from the leader is copied asynchronously
+  over to new shards. Whenever there is a communication issue between the follower and
+  the leader of the shard it will be counted here for the follower. This communication
+  issues cover failed connections or http errors, but they also cover invalid or
+  unexpected data formats revieved on the follower.
+threshold: |
+  In ideal situation this counter should be 0. It is expected to increase if there is
+  server or network outage. However it is not guaranteed that this metric increases
+  in such a situation.
+troubleshoot: |
+  If this counter increases this typically indicates an issue with the communication
+  between servers. If it is just occasionally an increase of one, it can be a simple
+  network hiccup, if you see constant increases here that indicates serious issues.
+  This also indicates that there is a shard trying to get into sync with the existing
+  data, which cannot make progress. So you have only replicationFactor - 1 copies of
+  the data right now. If more servers suffer outage you may loose data in this case.
+  * First thing to check: Network connectivity, make sure all servers are online
+    and the machines can communicate to one-another.
+  * Second: Check ArangoDB logs of this server for more details, most likely
+    you will see WARN or ERROR messages in "replication" log topic. If you contact
+    ArangoDB support for this issue, it will help to include this servers logs as well.
+  * Third: (Unlikely) If the logs contain unexpected format or value entries
+    please check if you are running all ArangoDB Database servers within the same
+    version of ArangoDB. Only upgrades of one minor version at a time are supported
+    in general, so if you are running one server with a much newer / older version
+    please upgrade all servers to the newest version.
+  * Forth: If none of the above applies, please contact ArangoDB Support.

--- a/arangod/Replication/ReplicationFeature.cpp
+++ b/arangod/Replication/ReplicationFeature.cpp
@@ -75,7 +75,7 @@ void writeError(ErrorCode code, arangodb::GeneralResponse* response) {
 } // namespace
 
 
-DECLARE_COUNTER(arangodb_replication_cluster_inventory_requests_total, "Number of cluster replication inventory requests received");
+DECLARE_COUNTER(arangodb_replication_cluster_inventory_requests_total, "(DC-2-DC only) Number of times the database and collection overviews have been requested.");
 
 namespace arangodb {
 

--- a/arangod/Replication/ReplicationMetricsFeature.cpp
+++ b/arangod/Replication/ReplicationMetricsFeature.cpp
@@ -34,7 +34,7 @@ DECLARE_COUNTER(arangodb_replication_dump_requests_total,
 DECLARE_COUNTER(arangodb_replication_dump_bytes_received_total,
                 "Total number of bytes replicated in initial asynchronous phase.");
 DECLARE_COUNTER(arangodb_replication_dump_documents_total,
-                "Number of documents received in replication dump requests");
+                "Total number of documents replicated in initial asynchronous phase.");
 DECLARE_COUNTER(arangodb_replication_dump_request_time_total,
                 "Wait time for replication requests [ms]");
 DECLARE_COUNTER(arangodb_replication_dump_apply_time_total,

--- a/arangod/Replication/ReplicationMetricsFeature.cpp
+++ b/arangod/Replication/ReplicationMetricsFeature.cpp
@@ -32,7 +32,7 @@ using namespace arangodb::options;
 DECLARE_COUNTER(arangodb_replication_dump_requests_total,
                 "Number of replication dump requests");
 DECLARE_COUNTER(arangodb_replication_dump_bytes_received_total,
-                "Number of bytes received in replication dump requests");
+                "Total number of bytes replicated in initial asynchronous phase.");
 DECLARE_COUNTER(arangodb_replication_dump_documents_total,
                 "Number of documents received in replication dump requests");
 DECLARE_COUNTER(arangodb_replication_dump_request_time_total,

--- a/arangod/Replication/ReplicationMetricsFeature.cpp
+++ b/arangod/Replication/ReplicationMetricsFeature.cpp
@@ -30,7 +30,7 @@ using namespace arangodb::application_features;
 using namespace arangodb::options;
 
 DECLARE_COUNTER(arangodb_replication_dump_requests_total,
-                "Number of replication dump requests");
+                "Number of requests used in initial asynchronous replication phase.");
 DECLARE_COUNTER(arangodb_replication_dump_bytes_received_total,
                 "Total number of bytes replicated in initial asynchronous phase.");
 DECLARE_COUNTER(arangodb_replication_dump_documents_total,

--- a/arangod/Replication/ReplicationMetricsFeature.cpp
+++ b/arangod/Replication/ReplicationMetricsFeature.cpp
@@ -36,7 +36,7 @@ DECLARE_COUNTER(arangodb_replication_dump_bytes_received_total,
 DECLARE_COUNTER(arangodb_replication_dump_documents_total,
                 "Total number of documents replicated in initial asynchronous phase.");
 DECLARE_COUNTER(arangodb_replication_dump_request_time_total,
-                "Wait time for replication requests [ms]");
+                "Accumulated wait time for replication requests in initial asynchronous phase. [ms]");
 DECLARE_COUNTER(arangodb_replication_dump_apply_time_total,
                 "Accumulated time needed to apply asynchronously replicated data on initial synchronization of shards. [ms]");
 DECLARE_COUNTER(arangodb_replication_initial_sync_keys_requests_total,

--- a/arangod/Replication/ReplicationMetricsFeature.cpp
+++ b/arangod/Replication/ReplicationMetricsFeature.cpp
@@ -77,7 +77,7 @@ DECLARE_COUNTER(arangodb_replication_tailing_bytes_received_total,
                 "Number of bytes received for replication tailing requests");
 DECLARE_COUNTER(arangodb_replication_failed_connects_total,
                 "Number of failed connection attempts and response errors "
-                "during replication");
+                "during initial asynchronous replication");
 DECLARE_COUNTER(arangodb_replication_tailing_request_time_total,
                 "Wait time for replication tailing requests [ms]");
 DECLARE_COUNTER(arangodb_replication_tailing_apply_time_total,

--- a/arangod/Replication/ReplicationMetricsFeature.cpp
+++ b/arangod/Replication/ReplicationMetricsFeature.cpp
@@ -38,7 +38,7 @@ DECLARE_COUNTER(arangodb_replication_dump_documents_total,
 DECLARE_COUNTER(arangodb_replication_dump_request_time_total,
                 "Wait time for replication requests [ms]");
 DECLARE_COUNTER(arangodb_replication_dump_apply_time_total,
-                "Accumulated time needed to apply replication dump data [ms]");
+                "Accumulated time needed to apply asynchronously replicated data on initial synchronization of shards. [ms]");
 DECLARE_COUNTER(arangodb_replication_initial_sync_keys_requests_total,
                 "Number of replication initial sync keys requests");
 DECLARE_COUNTER(arangodb_replication_initial_sync_docs_requests_total,


### PR DESCRIPTION
Adding some more documentation for replication in cluster metrics.

The following metrics are documented here:
arangodb_replication_cluster_inventory_requests_total
arangodb_replication_dump_apply_time_total
arangodb_replication_dump_bytes_received_total
arangodb_replication_dump_documents_total
arangodb_replication_dump_request_time_total
arangodb_replication_dump_requests_total
arangodb_replication_failed_connects_total