### PR TITLE
Metrics/replication cluster metrics (#13851)

### DIFF
--- a/Documentation/Metrics/allMetrics.yaml
+++ b/Documentation/Metrics/allMetrics.yaml
@@ -66,10 +66,10 @@
   unit: number
 - category: Agency
   complexity: advanced
-  description: "This metric reflects the current number of agency callbacks being\n\
-    registered, including agency cache callbacks.\nThis metric was named `arangodb_agency_callback_count`\
-    \ in previous versions \nof ArangoDB.\nNote that on single servers this metrics\
-    \ will only have a non-zero value\nin \"active failover\" deployment mode.\n"
+  description: "This metric reflects the current number of agency callbacks being\nregistered,
+    including agency cache callbacks.\nThis metric was named `arangodb_agency_callback_count`
+    in previous versions \nof ArangoDB.\nNote that on single servers this metrics
+    will only have a non-zero value\nin \"active failover\" deployment mode.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -91,9 +91,9 @@
   unit: number
 - category: Agency
   complexity: advanced
-  description: "This metric was named `arangodb_agency_callback_registered` in previous\
-    \ versions \nof ArangoDB.\nNote that on single servers this metrics will only\
-    \ have a non-zero value\nin \"active failover\" deployment mode.\n"
+  description: "This metric was named `arangodb_agency_callback_registered` in previous
+    versions \nof ArangoDB.\nNote that on single servers this metrics will only have
+    a non-zero value\nin \"active failover\" deployment mode.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -107,9 +107,9 @@
   unit: number
 - category: Agency
   complexity: advanced
-  description: "Current number of entries in agency client id lookup table.\nThe lookup\
-    \ table is used internally for agency inquire operations\nand should be compacted\
-    \ at the same time when the agency's in-memory\nlog is compacted. \n"
+  description: "Current number of entries in agency client id lookup table.\nThe lookup
+    table is used internally for agency inquire operations\nand should be compacted
+    at the same time when the agency's in-memory\nlog is compacted. \n"
   exposedBy:
   - agent
   help: 'Current number of entries in agency client id lookup table.
@@ -162,8 +162,8 @@
   unit: ms
 - category: Agency
   complexity: simple
-  description: "This agent's commit index (i.e. the index until it has advanced in\
-    \ \nthe agency's RAFT protocol).\n"
+  description: "This agent's commit index (i.e. the index until it has advanced in
+    \nthe agency's RAFT protocol).\n"
   exposedBy:
   - agent
   help: 'This agent''s commit index.
@@ -251,10 +251,10 @@
   unit: number
 - category: Agency
   complexity: medium
-  description: "Counter for FailedServer jobs. This counter is increased whenever\
-    \ a \nsupervision run encounters a failed server and starts a FailedServer job.\n\
-    This metric was named `arangodb_agency_supervision_failed_server_count`\nin previous\
-    \ versions of ArangoDB.\n"
+  description: "Counter for FailedServer jobs. This counter is increased whenever
+    a \nsupervision run encounters a failed server and starts a FailedServer job.\nThis
+    metric was named `arangodb_agency_supervision_failed_server_count`\nin previous
+    versions of ArangoDB.\n"
   exposedBy:
   - agent
   help: 'Counter for FailedServer jobs.
@@ -299,10 +299,10 @@
   unit: ms
 - category: Agency
   complexity: medium
-  description: "Agency supervision replication time histogram. Whenever the agency\n\
-    supervision carries out changes, it will write them to the leader's log \nand\
-    \ replicate the changes to followers. This metric provides a histogram\nof the\
-    \ time it took to replicate the supervision changes to followers.\n"
+  description: "Agency supervision replication time histogram. Whenever the agency\nsupervision
+    carries out changes, it will write them to the leader's log \nand replicate the
+    changes to followers. This metric provides a histogram\nof the time it took to
+    replicate the supervision changes to followers.\n"
   exposedBy:
   - agent
   help: 'Agency supervision wait for replication time.
@@ -423,8 +423,8 @@
     '
   introducedIn: '3.7'
   name: arangodb_agencycomm_request_time_msec
-  threshold: "Usually, such requests should be relatively quick, mostly clearly\n\
-    sub-second. \n"
+  threshold: "Usually, such requests should be relatively quick, mostly clearly\nsub-second.
+    \n"
   troubleshoot: 'If the network or the agents are overloaded, it can help to move
 
     agent instances to separate machines.
@@ -495,13 +495,12 @@
   unit: bytes
 - category: AQL
   complexity: simple
-  description: "Total memory usage of all AQL queries currently executing.\nThe granularity\
-    \ of this metric is steps of 32768 bytes. The current\nmemory usage of all AQL\
-    \ queries will be compared against the configured\nlimit in the `--query.global-memory-limit`\
-    \ startup option. \nIf the startup option has a value of `0`, then no global memory\
-    \ limit\nwill be enforced. If the startup option has a non-zero value, queries\n\
-    will be aborted once the total query memory usage goes above the configured\n\
-    limit.\n"
+  description: "Total memory usage of all AQL queries currently executing.\nThe granularity
+    of this metric is steps of 32768 bytes. The current\nmemory usage of all AQL queries
+    will be compared against the configured\nlimit in the `--query.global-memory-limit`
+    startup option. \nIf the startup option has a value of `0`, then no global memory
+    limit\nwill be enforced. If the startup option has a non-zero value, queries\nwill
+    be aborted once the total query memory usage goes above the configured\nlimit.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -517,11 +516,11 @@
   unit: bytes
 - category: AQL
   complexity: simple
-  description: "Total number of times the global query memory limit threshold was\
-    \ reached.\nThis can happen if all running AQL queries in total try to use more\
-    \ memory than\nconfigured via the `--query.global-memory-limit` startup option.\n\
-    Every time this counter will increase, an AQL query will have aborted with a \n\
-    \"resource limit exceeded\" error.\n"
+  description: "Total number of times the global query memory limit threshold was
+    reached.\nThis can happen if all running AQL queries in total try to use more
+    memory than\nconfigured via the `--query.global-memory-limit` startup option.\nEvery
+    time this counter will increase, an AQL query will have aborted with a \n\"resource
+    limit exceeded\" error.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -536,11 +535,11 @@
   unit: number
 - category: AQL
   complexity: simple
-  description: "Total number of times a local query memory limit threshold was reached,\
-    \ i.e.\na single query tried to allocate more memory than configured in the query's\n\
-    `memoryLimit` attribute or the value configured via the startup option\n`--query.memory-limit`.\n\
-    Every time this counter will increase, an AQL query will have aborted with a \n\
-    \"resource limit exceeded\" error.\n"
+  description: "Total number of times a local query memory limit threshold was reached,
+    i.e.\na single query tried to allocate more memory than configured in the query's\n`memoryLimit`
+    attribute or the value configured via the startup option\n`--query.memory-limit`.\nEvery
+    time this counter will increase, an AQL query will have aborted with a \n\"resource
+    limit exceeded\" error.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -786,9 +785,9 @@
   unit: s
 - category: Transactions
   complexity: medium
-  description: "Total amount of time it took to acquire collection/shard locks for\n\
-    write operations, summed up for all collections/shards. Will not be increased\
-    \ \nfor any read operations.\nThe value is measured in microseconds.\n"
+  description: "Total amount of time it took to acquire collection/shard locks for\nwrite
+    operations, summed up for all collections/shards. Will not be increased \nfor
+    any read operations.\nThe value is measured in microseconds.\n"
   exposedBy:
   - dbserver
   - agent
@@ -798,10 +797,10 @@
     '
   introducedIn: '3.6'
   name: arangodb_collection_lock_acquisition_micros_total
-  troubleshoot: "In case this value is considered too high, check if there are AQL\
-    \ queries\nor transactions that use exclusive locks on collections, and try to\
-    \ reduce them. \nOperations using exclusive locks may lock out other queries/transactions\
-    \ temporarily, \nwhich will lead to an increase in lock acquisition time.\n"
+  troubleshoot: "In case this value is considered too high, check if there are AQL
+    queries\nor transactions that use exclusive locks on collections, and try to reduce
+    them. \nOperations using exclusive locks may lock out other queries/transactions
+    temporarily, \nwhich will lead to an increase in lock acquisition time.\n"
   type: counter
   unit: us
 - category: RocksDB
@@ -823,10 +822,10 @@
     '
   introducedIn: '3.6'
   name: arangodb_collection_lock_acquisition_time
-  troubleshoot: "In case these values are considered too high, check if there are\
-    \ AQL queries\nor transactions that use exclusive locks on collections, and try\
-    \ to reduce them. \nOperations using exclusive locks may lock out other queries/transactions\
-    \ temporarily, \nwhich will lead to an increase in lock acquisition times.\n"
+  troubleshoot: "In case these values are considered too high, check if there are
+    AQL queries\nor transactions that use exclusive locks on collections, and try
+    to reduce them. \nOperations using exclusive locks may lock out other queries/transactions
+    temporarily, \nwhich will lead to an increase in lock acquisition times.\n"
   type: histogram
   unit: s
 - category: Transactions
@@ -855,11 +854,11 @@
     '
   introducedIn: '3.7'
   name: arangodb_collection_lock_sequential_mode_total
-  troubleshoot: "In case this value is increasing, check if there are AQL queries\
-    \ or transactions that \nuse exclusive locks on collections, and try to reduce\
-    \ them. \nOperations using exclusive locks may lock out other queries/transactions\
-    \ temporarily, \nwhich will lead can lead to (temporary) deadlocks in case the\
-    \ queries/transactions\nare run on multiple shards on different servers.\n"
+  troubleshoot: "In case this value is increasing, check if there are AQL queries
+    or transactions that \nuse exclusive locks on collections, and try to reduce them.
+    \nOperations using exclusive locks may lock out other queries/transactions temporarily,
+    \nwhich will lead can lead to (temporary) deadlocks in case the queries/transactions\nare
+    run on multiple shards on different servers.\n"
   type: counter
   unit: number
 - category: Transactions
@@ -880,20 +879,20 @@
     '
   introducedIn: '3.6'
   name: arangodb_collection_lock_timeouts_exclusive_total
-  troubleshoot: "In case this value is considered too high, check if there are AQL\
-    \ queries\nor transactions that use exclusive locks on collections, and try to\
-    \ reduce them. \nOperations using exclusive locks may lock out other queries/transactions\
-    \ temporarily, \nwhich can lead to other operations running into timeouts waiting\
-    \ for the same locks.\n"
+  troubleshoot: "In case this value is considered too high, check if there are AQL
+    queries\nor transactions that use exclusive locks on collections, and try to reduce
+    them. \nOperations using exclusive locks may lock out other queries/transactions
+    temporarily, \nwhich can lead to other operations running into timeouts waiting
+    for the same locks.\n"
   type: counter
   unit: number
 - category: Transactions
   complexity: medium
-  description: "Number of timeouts when trying to acquire collection write locks.\n\
-    This counter will be increased whenever a collection write lock\ncannot be acquired\
-    \ within the configured lock timeout. \nThis can only happen if writes on a collection\
-    \ are locked out by\nother operations on the collection that use an exclusive\
-    \ lock. Writes\nare not locked out by other, non-exclusively locked writes.\n"
+  description: "Number of timeouts when trying to acquire collection write locks.\nThis
+    counter will be increased whenever a collection write lock\ncannot be acquired
+    within the configured lock timeout. \nThis can only happen if writes on a collection
+    are locked out by\nother operations on the collection that use an exclusive lock.
+    Writes\nare not locked out by other, non-exclusively locked writes.\n"
   exposedBy:
   - dbserver
   - agent
@@ -903,11 +902,11 @@
     '
   introducedIn: '3.6'
   name: arangodb_collection_lock_timeouts_write_total
-  troubleshoot: "In case this value is considered too high, check if there are AQL\
-    \ queries\nor transactions that use exclusive locks on collections, and try to\
-    \ reduce them. \nOperations using exclusive locks may lock out other queries/transactions\
-    \ temporarily, \nwhich can lead to other operations running into timeouts waiting\
-    \ for the same locks.\n"
+  troubleshoot: "In case this value is considered too high, check if there are AQL
+    queries\nor transactions that use exclusive locks on collections, and try to reduce
+    them. \nOperations using exclusive locks may lock out other queries/transactions
+    temporarily, \nwhich can lead to other operations running into timeouts waiting
+    for the same locks.\n"
   type: counter
   unit: number
 - category: Transactions
@@ -1230,12 +1229,11 @@
   unit: s
 - category: Replication
   complexity: medium
-  description: "Total number of document write operations by synchronous replication.\n\
-    This metric is only present if the option\n`--server.export-read-write-metrics`\
-    \ is set to `true`.\nTotal number of document write operations (insert, update,\
-    \ replace, remove)\nexecuted by the synchronous replication on followers.\nThis\
-    \ metric is only present if the option `--server.export-read-write-metrics` \n\
-    is set to `true`.\n"
+  description: "Total number of document write operations by synchronous replication.\nThis
+    metric is only present if the option\n`--server.export-read-write-metrics` is
+    set to `true`.\nTotal number of document write operations (insert, update, replace,
+    remove)\nexecuted by the synchronous replication on followers.\nThis metric is
+    only present if the option `--server.export-read-write-metrics` \nis set to `true`.\n"
   exposedBy:
   - dbserver
   help: 'Total number of document write operations by synchronous replication.
@@ -1247,10 +1245,10 @@
   unit: number
 - category: Transactions
   complexity: medium
-  description: "Total number of document write operations (insert, update, replace,\
-    \ remove) on\nleaders, excluding writes by the synchronous replication on followers.\n\
-    This metric is only present if the option `--server.export-read-write-metrics`\
-    \ \nis set to `true`.\n"
+  description: "Total number of document write operations (insert, update, replace,
+    remove) on\nleaders, excluding writes by the synchronous replication on followers.\nThis
+    metric is only present if the option `--server.export-read-write-metrics` \nis
+    set to `true`.\n"
   exposedBy:
   - agent
   - dbserver
@@ -1264,11 +1262,11 @@
   unit: number
 - category: Health
   complexity: simple
-  description: "Total number of drop-follower events. This metric is increased on\
-    \ leaders\nwhenever a write operation cannot be replicated to a follower during\n\
-    synchronous replication, and it would be unsafe in terms of data consistency \n\
-    to keep that follower.\nThis metric was named `arangodb_dropped_followers_count`\
-    \ in previous\nversions of ArangoDB.\n"
+  description: "Total number of drop-follower events. This metric is increased on
+    leaders\nwhenever a write operation cannot be replicated to a follower during\nsynchronous
+    replication, and it would be unsafe in terms of data consistency \nto keep that
+    follower.\nThis metric was named `arangodb_dropped_followers_count` in previous\nversions
+    of ArangoDB.\n"
   exposedBy:
   - dbserver
   help: 'Number of drop-follower events.
@@ -1335,12 +1333,12 @@
     '
   introducedIn: '3.8'
   name: arangodb_heartbeat_send_time_msec
-  threshold: "It is a bad sign for health if heartbeat transmissions are not fast.\
-    \ \nIf there are heartbeats which frequently take longer than a few hundred\n\
-    milliseconds, or even seconds, this can eventually lead to failover actions \n\
-    which are ultimately bad for the service.\n"
-  troubleshoot: "High heartbeat send times can be a sign of overload or of bad network\
-    \ \nconnectivity. Potentially move the agent instances to separate machines.\n"
+  threshold: "It is a bad sign for health if heartbeat transmissions are not fast.
+    \nIf there are heartbeats which frequently take longer than a few hundred\nmilliseconds,
+    or even seconds, this can eventually lead to failover actions \nwhich are ultimately
+    bad for the service.\n"
+  troubleshoot: "High heartbeat send times can be a sign of overload or of bad network
+    \nconnectivity. Potentially move the agent instances to separate machines.\n"
   type: histogram
   unit: ms
 - category: Statistics
@@ -1387,12 +1385,12 @@
   unit: number
 - category: Statistics
   complexity: simple
-  description: "This counter reflects the total number of HTTP (or VST) **DELETE**\
-    \ \nrequests which have hit this particular instance of `arangod`.\n\nNote that\
-    \ this counter is ever growing during the lifetime of the\n`arangod` process.\
-    \ However, when the process is restarted, it starts\nfrom scratch. In the Grafana\
-    \ dashboards, it is usually visualized as a\nrate per second, averaged with a\
-    \ sliding window of a minute.\n"
+  description: "This counter reflects the total number of HTTP (or VST) **DELETE**
+    \nrequests which have hit this particular instance of `arangod`.\n\nNote that
+    this counter is ever growing during the lifetime of the\n`arangod` process. However,
+    when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards,
+    it is usually visualized as a\nrate per second, averaged with a sliding window
+    of a minute.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -1414,12 +1412,12 @@
   unit: number
 - category: Statistics
   complexity: simple
-  description: "This counter reflects the total number of HTTP (or VST) **GET** \n\
-    requests which have hit this particular instance of `arangod`.\n\nNote that this\
-    \ counter is ever growing during the lifetime of the\n`arangod` process. However,\
-    \ when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards,\
-    \ it is usually visualized as a\nrate per second, averaged with a sliding window\
-    \ of a minute.\n"
+  description: "This counter reflects the total number of HTTP (or VST) **GET** \nrequests
+    which have hit this particular instance of `arangod`.\n\nNote that this counter
+    is ever growing during the lifetime of the\n`arangod` process. However, when the
+    process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is
+    usually visualized as a\nrate per second, averaged with a sliding window of a
+    minute.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -1441,12 +1439,12 @@
   unit: number
 - category: Statistics
   complexity: simple
-  description: "This counter reflects the total number of HTTP (or VST) **HEAD** \n\
-    requests which have hit this particular instance of `arangod`.\n\nNote that this\
-    \ counter is ever growing during the lifetime of the\n`arangod` process. However,\
-    \ when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards,\
-    \ it is usually visualized as a\nrate per second, averaged with a sliding window\
-    \ of a minute.\n"
+  description: "This counter reflects the total number of HTTP (or VST) **HEAD** \nrequests
+    which have hit this particular instance of `arangod`.\n\nNote that this counter
+    is ever growing during the lifetime of the\n`arangod` process. However, when the
+    process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is
+    usually visualized as a\nrate per second, averaged with a sliding window of a
+    minute.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -1468,12 +1466,12 @@
   unit: number
 - category: Statistics
   complexity: simple
-  description: "This counter reflects the total number of HTTP (or VST) **OPTIONS**\
-    \ \nrequests which have hit this particular instance of `arangod`.\n\nNote that\
-    \ this counter is ever growing during the lifetime of the\n`arangod` process.\
-    \ However, when the process is restarted, it starts\nfrom scratch. In the Grafana\
-    \ dashboards, it is usually visualized as a\nrate per second, averaged with a\
-    \ sliding window of a minute.\n"
+  description: "This counter reflects the total number of HTTP (or VST) **OPTIONS**
+    \nrequests which have hit this particular instance of `arangod`.\n\nNote that
+    this counter is ever growing during the lifetime of the\n`arangod` process. However,
+    when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards,
+    it is usually visualized as a\nrate per second, averaged with a sliding window
+    of a minute.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -1495,12 +1493,12 @@
   unit: number
 - category: Statistics
   complexity: simple
-  description: "This counter reflects the total number of HTTP (or VST) **PATCH**\
-    \ \nrequests which have hit this particular instance of `arangod`.\n\nNote that\
-    \ this counter is ever growing during the lifetime of the\n`arangod` process.\
-    \ However, when the process is restarted, it starts\nfrom scratch. In the Grafana\
-    \ dashboards, it is usually visualized as a\nrate per second, averaged with a\
-    \ sliding window of a minute.\n"
+  description: "This counter reflects the total number of HTTP (or VST) **PATCH**
+    \nrequests which have hit this particular instance of `arangod`.\n\nNote that
+    this counter is ever growing during the lifetime of the\n`arangod` process. However,
+    when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards,
+    it is usually visualized as a\nrate per second, averaged with a sliding window
+    of a minute.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -1522,12 +1520,12 @@
   unit: number
 - category: Statistics
   complexity: simple
-  description: "This counter reflects the total number of HTTP (or VST) **POST** \n\
-    requests which have hit this particular instance of `arangod`.\n\nNote that this\
-    \ counter is ever growing during the lifetime of the\n`arangod` process. However,\
-    \ when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards,\
-    \ it is usually visualized as a\nrate per second, averaged with a sliding window\
-    \ of a minute.\n"
+  description: "This counter reflects the total number of HTTP (or VST) **POST** \nrequests
+    which have hit this particular instance of `arangod`.\n\nNote that this counter
+    is ever growing during the lifetime of the\n`arangod` process. However, when the
+    process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is
+    usually visualized as a\nrate per second, averaged with a sliding window of a
+    minute.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -1549,12 +1547,12 @@
   unit: number
 - category: Statistics
   complexity: simple
-  description: "This counter reflects the total number of HTTP (or VST) **PUT** \n\
-    requests which have hit this particular instance of `arangod`.\n\nNote that this\
-    \ counter is ever growing during the lifetime of the\n`arangod` process. However,\
-    \ when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards,\
-    \ it is usually visualized as a\nrate per second, averaged with a sliding window\
-    \ of a minute.\n"
+  description: "This counter reflects the total number of HTTP (or VST) **PUT** \nrequests
+    which have hit this particular instance of `arangod`.\n\nNote that this counter
+    is ever growing during the lifetime of the\n`arangod` process. However, when the
+    process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is
+    usually visualized as a\nrate per second, averaged with a sliding window of a
+    minute.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -1727,15 +1725,15 @@
   unit: number
 - category: Statistics
   complexity: medium
-  description: "Number of intermediate commits performed in transactions.\nAn intermediate\
-    \ commit happens if a logical transaction needs to be\nsplit into multiple physical\
-    \ transaction because of the volume of data\nhandled in the transaction. The thresholds\
-    \ for when to perform an\nintermediate commit can be controlled by startup options\
-    \ \n`--rocksdb.intermediate-commit-count` (number of write operations after\n\
-    which an intermediate commit is triggered) and `--rocksdb.intermediate-commit-size`\n\
-    (cumulated size of write operations after which an intermediate commit is triggered).\n\
-    The values can also be overridden for individual transactions.\nThis metric was\
-    \ named `arangodb_intermediate_commits` in previous\nversions of ArangoDb.\n"
+  description: "Number of intermediate commits performed in transactions.\nAn intermediate
+    commit happens if a logical transaction needs to be\nsplit into multiple physical
+    transaction because of the volume of data\nhandled in the transaction. The thresholds
+    for when to perform an\nintermediate commit can be controlled by startup options
+    \n`--rocksdb.intermediate-commit-count` (number of write operations after\nwhich
+    an intermediate commit is triggered) and `--rocksdb.intermediate-commit-size`\n(cumulated
+    size of write operations after which an intermediate commit is triggered).\nThe
+    values can also be overridden for individual transactions.\nThis metric was named
+    `arangodb_intermediate_commits` in previous\nversions of ArangoDb.\n"
   exposedBy:
   - dbserver
   - single
@@ -1744,24 +1742,23 @@
     '
   introducedIn: '3.6'
   name: arangodb_intermediate_commits_total
-  troubeshoot: "If this value is non-zero, it doesn't necessarily indicate a problem.\
-    \ It can\nhappen for large transactions and large data-loading jobs. However,\
-    \ as modifications\nperformed by intermediate commits are persisted and cannot\
-    \ simply be rolled back in \nmemory, it should be monitored whether the intermediate\
-    \ commits only happen for\noperations where they are expected. If they also happen\
-    \ for operations that are\nsupposed to be atomic, then the intermediate commit\
-    \ size and count parameters need\nto be adjusted, or larger operations should\
-    \ be broken up into smaller ones in the\nclient application.\n"
+  troubeshoot: "If this value is non-zero, it doesn't necessarily indicate a problem.
+    It can\nhappen for large transactions and large data-loading jobs. However, as
+    modifications\nperformed by intermediate commits are persisted and cannot simply
+    be rolled back in \nmemory, it should be monitored whether the intermediate commits
+    only happen for\noperations where they are expected. If they also happen for operations
+    that are\nsupposed to be atomic, then the intermediate commit size and count parameters
+    need\nto be adjusted, or larger operations should be broken up into smaller ones
+    in the\nclient application.\n"
   type: counter
   unit: number
 - category: Maintenance
   complexity: medium
-  description: "Histogram of `Current` loading runtimes, i.e. the runtimes\nof the\
-    \ `ClusterInfo::loadCurrent` internal method. Provides a\ndistribution of all\
-    \ loading times for the `Current`\nsection of the agency data. The `Current` section\
-    \ gets\nloaded on server startup, and then gets reloaded on servers \nonly for\
-    \ any databases in which there have been recent structural \nchanges (i.e. DDL\
-    \ changes).\n"
+  description: "Histogram of `Current` loading runtimes, i.e. the runtimes\nof the
+    `ClusterInfo::loadCurrent` internal method. Provides a\ndistribution of all loading
+    times for the `Current`\nsection of the agency data. The `Current` section gets\nloaded
+    on server startup, and then gets reloaded on servers \nonly for any databases
+    in which there have been recent structural \nchanges (i.e. DDL changes).\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -1787,11 +1784,11 @@
   unit: ms
 - category: Maintenance
   complexity: medium
-  description: "Histogram of `Plan` loading runtimes, i.e. the runtimes\nof the `ClusterInfo::loadPlan`\
-    \ internal method. Provides a\ndistribution of all loading times for the `Plan`\n\
-    section of the agency data. The `Plan` section normally gets\nloaded on server\
-    \ startup, and then gets reloaded on servers \nonly for any databases in which\
-    \ there have been recent structural \nchanges (i.e. DDL changes).\n"
+  description: "Histogram of `Plan` loading runtimes, i.e. the runtimes\nof the `ClusterInfo::loadPlan`
+    internal method. Provides a\ndistribution of all loading times for the `Plan`\nsection
+    of the agency data. The `Plan` section normally gets\nloaded on server startup,
+    and then gets reloaded on servers \nonly for any databases in which there have
+    been recent structural \nchanges (i.e. DDL changes).\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -2039,11 +2036,11 @@
   unit: ms
 - category: Network
   complexity: simple
-  description: "Number of requests forwarded to another coordinator.\nRequest forwarding\
-    \ can happen in load-balanced setups,\nwhen one coordinator receives and forwards\
-    \ requests \nthat can only be handled by a different coordinator.\nThis includes\
-    \ requests for streaming transactions,\nAQL, query cursors, Pregel jobs and some\
-    \ others.\n"
+  description: "Number of requests forwarded to another coordinator.\nRequest forwarding
+    can happen in load-balanced setups,\nwhen one coordinator receives and forwards
+    requests \nthat can only be handled by a different coordinator.\nThis includes
+    requests for streaming transactions,\nAQL, query cursors, Pregel jobs and some
+    others.\n"
   exposedBy:
   - coordinator
   help: 'Number of requests forwarded to another coordinator.
@@ -2055,9 +2052,9 @@
   unit: number
 - category: Network
   complexity: advanced
-  description: "Histogram providing the round-trip time of internal requests as a\
-    \ percentage \nof the respective request timeout.\nThis metric will provide values\
-    \ between 0 and 100.\n"
+  description: "Histogram providing the round-trip time of internal requests as a
+    percentage \nof the respective request timeout.\nThis metric will provide values
+    between 0 and 100.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -2112,14 +2109,13 @@
   unit: number
 - category: Network
   complexity: medium
-  description: "Number of outgoing internal requests in flight. This metric is increased\n\
-    whenever any cluster-internal request is about to be sent via the underlying \n\
-    connection pool, and is decreased whenever a response for such a request is\n\
-    received or the request runs into a timeout.\nThis metric provides an estimate\
-    \ of the fan-out of operations. For example,\na user operation on a collection\
-    \ with a single shard will normally lead to\na single internal request (plus replication),\
-    \ whereas an operation on a\ncollection with 10 shards may lead to a fan-out of\
-    \ 10 (plus replication).\n"
+  description: "Number of outgoing internal requests in flight. This metric is increased\nwhenever
+    any cluster-internal request is about to be sent via the underlying \nconnection
+    pool, and is decreased whenever a response for such a request is\nreceived or
+    the request runs into a timeout.\nThis metric provides an estimate of the fan-out
+    of operations. For example,\na user operation on a collection with a single shard
+    will normally lead to\na single internal request (plus replication), whereas an
+    operation on a\ncollection with 10 shards may lead to a fan-out of 10 (plus replication).\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -2355,14 +2351,14 @@
   unit: bytes
 - category: Replication
   complexity: advanced
-  description: "Number of refusal answers from a follower during synchronous replication.\n\
-    A refusal answer will only be sent by a follower if the follower is under\nthe\
-    \ impression that the replication request was not sent by the current\nshard leader.\
-    \ This can happen if replication requests to the follower are \ndelayed or the\
-    \ follower is slow to process incoming requests and there was \na leader change\
-    \ for the shard.\nIf such a refusal answer is received by the shard leader, it\
-    \ will drop the\nfollower from the list of followers.\nThis metrics was named\
-    \ `arangodb_refused_followers_count` in previous\nversions of ArangoDB.\n"
+  description: "Number of refusal answers from a follower during synchronous replication.\nA
+    refusal answer will only be sent by a follower if the follower is under\nthe impression
+    that the replication request was not sent by the current\nshard leader. This can
+    happen if replication requests to the follower are \ndelayed or the follower is
+    slow to process incoming requests and there was \na leader change for the shard.\nIf
+    such a refusal answer is received by the shard leader, it will drop the\nfollower
+    from the list of followers.\nThis metrics was named `arangodb_refused_followers_count`
+    in previous\nversions of ArangoDB.\n"
   exposedBy:
   - dbserver
   help: 'Number of refusal answers from a follower during synchronous replication.
@@ -2370,47 +2366,87 @@
     '
   introducedIn: '3.6'
   name: arangodb_refused_followers_total
-  threshold: "Usually, refusal answers only occur if request processing on followers\
-    \ is \ndelayed and there was a recent leadership change. This should not be a\n\
-    common case and normally indicates a problem with the setup or with the load.\n"
+  threshold: "Usually, refusal answers only occur if request processing on followers
+    is \ndelayed and there was a recent leadership change. This should not be a\ncommon
+    case and normally indicates a problem with the setup or with the load.\n"
   type: counter
   unit: number
 - category: Replication
-  complexity: medium
-  description: 'Number of cluster replication inventory requests received.
+  complexity: advanced
+  description: 'When using a DC-2-DC configuration of ArangoDB this metric is active
+    on both data-centers.
+
+    It indicates that the follower data-center peridocally matches the available databases
+    and collections
+
+    in order to mirror them. If no DC-2-DC is set up this value is expected to be
+    0.
 
     '
   exposedBy:
   - coordinator
-  help: 'Number of cluster replication inventory requests received.
+  help: '(DC-2-DC only) Number of times the database and collection overviews have
+    been requested.
 
     '
   introducedIn: '3.6'
   name: arangodb_replication_cluster_inventory_requests_total
+  troubleshoot: 'If you have a DC-2-DC installation, and this metric stays constant
+    over a longer period of time in any of the two data centers
+
+    this indicates that the follower data center is not properly connected anymore.
+
+    The issue most likely is within the sync process on either of the two data-centers
+    as they do not compare their inventory anymore.
+
+    This gives no information about the healthyness of the ArangoDB cluster itself,
+    please check other metrics for this.
+
+    '
   type: counter
   unit: number
 - category: Replication
   complexity: medium
-  description: 'Accumulated time needed to apply replication dump data.
+  description: 'Measures the time required to clone the existing leader copy of the
+    data onto a new replica shard.
+
+    Will only be measured on the follower server. This time is expected to increase
+    whenever new followers
+
+    are created, e.g. increasing replication factor, shard redistribution.
 
     '
   exposedBy:
   - dbserver
-  help: 'Accumulated time needed to apply replication dump data.
+  help: 'Accumulated time needed to apply asynchronously replicated data on initial
+    synchronization of shards.
 
     '
   introducedIn: '3.8'
   name: arangodb_replication_dump_apply_time_total
+  troubleshoot: 'This metric measures as typical operation to keep the cluster resilient,
+    so no reaction is required.
+
+    In a stable cluster situation (no outages, no collection modification) this metric
+    should also be stable.
+
+    '
   type: counter
   unit: ms
 - category: Replication
   complexity: medium
-  description: 'Number of bytes received in replication dump requests.
+  description: 'During initial replication the existing data from the leader is copied
+    asynchronously
+
+    over to new shards. The amount of requests required to transport data to this
+    server,
+
+    as a replica for a shard, is counted here.
 
     '
   exposedBy:
   - dbserver
-  help: 'Number of bytes received in replication dump requests.
+  help: 'Total number of bytes replicated in initial asynchronous phase.
 
     '
   introducedIn: '3.8'
@@ -2419,12 +2455,18 @@
   unit: bytes
 - category: Replication
   complexity: simple
-  description: 'Number of documents received in replication dump requests.
+  description: 'During initial replication the existing data from the leader is copied
+    asynchronously
+
+    over to new shards. The amount of documents transported to this server, as a replica
+    for
+
+    a shard, is counted here.
 
     '
   exposedBy:
   - dbserver
-  help: 'Number of documents received in replication dump requests.
+  help: 'Total number of documents replicated in initial asynchronous phase.
 
     '
   introducedIn: '3.8'
@@ -2433,12 +2475,18 @@
   unit: number
 - category: Replication
   complexity: medium
-  description: 'Accumulated wait time for replication requests.
+  description: 'During initial replication the existing data from the leader is copied
+    asynchronously
+
+    over to new shards. The accumulated time the follower waited for the leader to
+    send
+
+    the data is counted here.
 
     '
   exposedBy:
   - dbserver
-  help: 'Accumulated wait time for replication requests.
+  help: 'Accumulated wait time for replication requests in initial asynchronous phase.
 
     '
   introducedIn: '3.8'
@@ -2447,12 +2495,18 @@
   unit: ms
 - category: Replication
   complexity: medium
-  description: 'Number of replication dump requests.
+  description: 'During initial replication the existing data from the leader is copied
+    asynchronously
+
+    over to new shards. The amount of data transported to this server, as a replica
+    for
+
+    a shard, is counted here.
 
     '
   exposedBy:
   - dbserver
-  help: 'Number of replication dump requests.
+  help: 'Number of requests used in initial asynchronous replication phase.
 
     '
   introducedIn: '3.8'
@@ -2461,16 +2515,52 @@
   unit: number
 - category: Replication
   complexity: medium
-  description: 'Number of failed connection attempts and response errors during replication.
+  description: 'During initial replication the existing data from the leader is copied
+    asynchronously
+
+    over to new shards. Whenever there is a communication issue between the follower
+    and
+
+    the leader of the shard it will be counted here for the follower. This communication
+
+    issues cover failed connections or http errors, but they also cover invalid or
+
+    unexpected data formats revieved on the follower.
 
     '
   exposedBy:
   - dbserver
-  help: 'Number of failed connection attempts and response errors during replication.
+  help: 'Number of failed connection attempts and response errors during initial asynchronous
+    replication.
 
     '
   introducedIn: '3.8'
   name: arangodb_replication_failed_connects_total
+  threshold: 'In ideal situation this counter should be 0. It is expected to increase
+    if there is
+
+    server or network outage. However it is not guaranteed that this metric increases
+
+    in such a situation.
+
+    '
+  troubleshoot: "If this counter increases this typically indicates an issue with
+    the communication\nbetween servers. If it is just occasionally an increase of
+    one, it can be a simple\nnetwork hiccup, if you see constant increases here that
+    indicates serious issues.\nThis also indicates that there is a shard trying to
+    get into sync with the existing\ndata, which cannot make progress. So you have
+    only replicationFactor - 1 copies of\nthe data right now. If more servers suffer
+    outage you may loose data in this case.\n* First thing to check: Network connectivity,
+    make sure all servers are online\n  and the machines can communicate to one-another.\n*
+    Second: Check ArangoDB logs of this server for more details, most likely\n  you
+    will see WARN or ERROR messages in \"replication\" log topic. If you contact\n
+    \ ArangoDB support for this issue, it will help to include this servers logs as
+    well.\n* Third: (Unlikely) If the logs contain unexpected format or value entries\n
+    \ please check if you are running all ArangoDB Database servers within the same\n
+    \ version of ArangoDB. Only upgrades of one minor version at a time are supported\n
+    \ in general, so if you are running one server with a much newer / older version\n
+    \ please upgrade all servers to the newest version.\n* Forth: If none of the above
+    applies, please contact ArangoDB Support.\n"
   type: counter
   unit: number
 - category: Replication
@@ -3005,7 +3095,7 @@
 
     replication log on a follower received from a replication
 
-    Leader.
+    leader.
 
     '
   exposedBy:
@@ -3030,7 +3120,7 @@
   unit: ms
 - category: Replication
   complexity: medium
-  description: The accumulated number of bytes received from a Leader for replication
+  description: The accumulated number of bytes received from a leader for replication
     tailing requests. The higher the amount of bytes is, the more data is being processed
     afterwards on the follower dbserver.
   exposedBy:
@@ -3629,9 +3719,9 @@
   unit: number
 - category: Statistics
   complexity: simple
-  description: "Percentage of time that the system CPUs have been idle, as \na value\
-    \ between 0 and 100, and as reported by the operating system.\nThis metric is\
-    \ only reported on some operating systems.\n"
+  description: "Percentage of time that the system CPUs have been idle, as \na value
+    between 0 and 100, and as reported by the operating system.\nThis metric is only
+    reported on some operating systems.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -3668,9 +3758,9 @@
   unit: percentage
 - category: Statistics
   complexity: simple
-  description: "Physical memory of the system in bytes, as reported by the operating\
-    \ system \nunless the environment variable `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY`\
-    \ \nis set. In that case, the environment variable's value will be reported.\n"
+  description: "Physical memory of the system in bytes, as reported by the operating
+    system \nunless the environment variable `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY`
+    \nis set. In that case, the environment variable's value will be reported.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -3946,10 +4036,10 @@
   unit: number
 - category: Transactions
   complexity: simple
-  description: "Total number of transactions aborted. In the cluster, this metric\
-    \ will \nbe collected separately for transactions on coordinators and the\ntransaction\
-    \ counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_aborted`\
-    \ in previous\nversions of ArangoDB.\n"
+  description: "Total number of transactions aborted. In the cluster, this metric
+    will \nbe collected separately for transactions on coordinators and the\ntransaction
+    counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_aborted`
+    in previous\nversions of ArangoDB.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -3964,10 +4054,10 @@
   unit: number
 - category: Transactions
   complexity: simple
-  description: "Total number of transactions committed. In the cluster, this metric\
-    \ will \nbe collected separately for transactions on coordinators and the\ntransaction\
-    \ counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_committed`\
-    \ in previous\nversions of ArangoDB.\n"
+  description: "Total number of transactions committed. In the cluster, this metric
+    will \nbe collected separately for transactions on coordinators and the\ntransaction
+    counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_committed`
+    in previous\nversions of ArangoDB.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -3982,12 +4072,12 @@
   unit: number
 - category: Transactions
   complexity: simple
-  description: "Total number of expired transactions, i.e. transactions that have\n\
-    been begun but that were automatically garbage-collected due to \ninactivity within\
-    \ the transactions' time-to-live (TTL) period.\nIn the cluster, this metric will\
-    \ be collected separately for transactions \non coordinators and the transaction\
-    \ counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_expired`\
-    \ in previous\nversions of ArangoDB.\n"
+  description: "Total number of expired transactions, i.e. transactions that have\nbeen
+    begun but that were automatically garbage-collected due to \ninactivity within
+    the transactions' time-to-live (TTL) period.\nIn the cluster, this metric will
+    be collected separately for transactions \non coordinators and the transaction
+    counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_expired`
+    in previous\nversions of ArangoDB.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -4002,10 +4092,10 @@
   unit: number
 - category: Transactions
   complexity: simple
-  description: "Total number of transactions started/begun. In the cluster, this metric\
-    \ will \nbe collected separately for transactions on coordinators and the\ntransaction\
-    \ counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_started`\
-    \ in previous\nversions of ArangoDB.\n"
+  description: "Total number of transactions started/begun. In the cluster, this metric
+    will \nbe collected separately for transactions on coordinators and the\ntransaction
+    counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_started`
+    in previous\nversions of ArangoDB.\n"
   exposedBy:
   - coordinator
   - dbserver
@@ -4395,9 +4485,9 @@
   unit: bytes
 - category: RocksDB
   complexity: advanced
-  description: "This metric exhibits the RocksDB metric \"rocksdb-block-cache-pinned-usage\"\
-    .\nIt shows the memory size for the RocksDB block cache for the entries \nwhich\
-    \ are pinned, in bytes.\n"
+  description: "This metric exhibits the RocksDB metric \"rocksdb-block-cache-pinned-usage\".\nIt
+    shows the memory size for the RocksDB block cache for the entries \nwhich are
+    pinned, in bytes.\n"
   exposedBy:
   - dbserver
   - agent
@@ -4431,10 +4521,10 @@
   unit: bytes
 - category: RocksDB
   complexity: advanced
-  description: "This metric reflects the current global allocation for the ArangoDB\n\
-    cache which sits in front of RocksDB. For example, the edge cache\ncounts towards\
-    \ this allocation. All these caches together have a \nglobal limit which can be\
-    \ controlled with the `--cache.size` option.\nSee [the manual for details](https://www.arangodb.com/docs/stable/programs-arangod-options.html#cache).\n"
+  description: "This metric reflects the current global allocation for the ArangoDB\ncache
+    which sits in front of RocksDB. For example, the edge cache\ncounts towards this
+    allocation. All these caches together have a \nglobal limit which can be controlled
+    with the `--cache.size` option.\nSee [the manual for details](https://www.arangodb.com/docs/stable/programs-arangod-options.html#cache).\n"
   exposedBy:
   - dbserver
   - agent
@@ -4738,13 +4828,13 @@
   unit: bytes
 - category: RocksDB
   complexity: advanced
-  description: "This metric exposes the current write rate limit of the ArangoDB\n\
-    RocksDB throttle. The throttle limits the write rate to allow\nRocksDB's background\
-    \ threads to catch up with compactions and not\nfall behind too much, since this\
-    \ would in the end lead to nasty\nwrite stops in RocksDB and incur considerable\
-    \ delays. If 0 is\nshown, no throttling happens, otherwise, you see the current\n\
-    write rate limit in bytes per second. See \n[the manual](https://www.arangodb.com/docs/stable/programs-arangod-options.html#rocksdb)\
-    \ for details.\n"
+  description: "This metric exposes the current write rate limit of the ArangoDB\nRocksDB
+    throttle. The throttle limits the write rate to allow\nRocksDB's background threads
+    to catch up with compactions and not\nfall behind too much, since this would in
+    the end lead to nasty\nwrite stops in RocksDB and incur considerable delays. If
+    0 is\nshown, no throttling happens, otherwise, you see the current\nwrite rate
+    limit in bytes per second. See \n[the manual](https://www.arangodb.com/docs/stable/programs-arangod-options.html#rocksdb)
+    for details.\n"
   exposedBy:
   - dbserver
   - agent
@@ -5050,9 +5140,9 @@
   unit: number
 - category: RocksDB
   complexity: advanced
-  description: "This metric exhibits the RocksDB metric \n\"rocksdb-num-entries-active-mem-table\"\
-    .\nIt shows the total number of entries in the active memtable,\nsummed over all\
-    \ column families.\n"
+  description: "This metric exhibits the RocksDB metric \n\"rocksdb-num-entries-active-mem-table\".\nIt
+    shows the total number of entries in the active memtable,\nsummed over all column
+    families.\n"
   exposedBy:
   - dbserver
   - agent
@@ -5214,11 +5304,11 @@
   unit: number
 - category: RocksDB
   complexity: advanced
-  description: "This metric exhibits the RocksDB metric \"num-immutable-mem-table\"\
-    , \nwhich shows the number of immutable memtables that have not yet been\nflushed.\
-    \ This value is the sum over all column families.\n\nMemtables are sorted tables\
-    \ of key/value pairs which begin\nto be built up in memory. At some stage they\
-    \ are closed and become\nimmutable, and some time later they are flushed to disk.\n"
+  description: "This metric exhibits the RocksDB metric \"num-immutable-mem-table\",
+    \nwhich shows the number of immutable memtables that have not yet been\nflushed.
+    This value is the sum over all column families.\n\nMemtables are sorted tables
+    of key/value pairs which begin\nto be built up in memory. At some stage they are
+    closed and become\nimmutable, and some time later they are flushed to disk.\n"
   exposedBy:
   - dbserver
   - agent
@@ -5232,11 +5322,11 @@
   unit: number
 - category: RocksDB
   complexity: advanced
-  description: "This metric exhibits the RocksDB metric \"num-immutable-mem-table-flushed\"\
-    , \nwhich shows the number of immutable memtables that have already been\nflushed.\
-    \ This value is the sum over all column families.\n\nMemtables are sorted tables\
-    \ of key/value pairs which begin\nto be built up in memory. At some stage they\
-    \ are closed and become\nimmutable, and some time later they are flushed to disk.\n"
+  description: "This metric exhibits the RocksDB metric \"num-immutable-mem-table-flushed\",
+    \nwhich shows the number of immutable memtables that have already been\nflushed.
+    This value is the sum over all column families.\n\nMemtables are sorted tables
+    of key/value pairs which begin\nto be built up in memory. At some stage they are
+    closed and become\nimmutable, and some time later they are flushed to disk.\n"
   exposedBy:
   - dbserver
   - agent

--- a/Documentation/Metrics/arangodb_replication_cluster_inventory_requests_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_cluster_inventory_requests_total.yaml
@@ -1,12 +1,19 @@
 name: arangodb_replication_cluster_inventory_requests_total
 introducedIn: "3.6"
 help: |
-  Number of cluster replication inventory requests received.
+  (DC-2-DC only) Number of times the database and collection overviews have been requested.
 unit: number
 type: counter
 category: Replication
-complexity: medium
+complexity: advanced
 exposedBy:
   - coordinator
 description: |
-  Number of cluster replication inventory requests received.
+  When using a DC-2-DC configuration of ArangoDB this metric is active on both data-centers.
+  It indicates that the follower data-center peridocally matches the available databases and collections
+  in order to mirror them. If no DC-2-DC is set up this value is expected to be 0.
+troubleshoot: |
+  If you have a DC-2-DC installation, and this metric stays constant over a longer period of time in any of the two data centers
+  this indicates that the follower data center is not properly connected anymore.
+  The issue most likely is within the sync process on either of the two data-centers as they do not compare their inventory anymore.
+  This gives no information about the healthyness of the ArangoDB cluster itself, please check other metrics for this.

--- a/Documentation/Metrics/arangodb_replication_dump_apply_time_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_dump_apply_time_total.yaml
@@ -1,7 +1,7 @@
 name: arangodb_replication_dump_apply_time_total
 introducedIn: "3.8"
 help: |
-  Accumulated time needed to apply replication dump data.
+  Accumulated time needed to apply asynchronously replicated data on initial synchronization of shards.
 unit: ms
 type: counter
 category: Replication
@@ -9,4 +9,9 @@ complexity: medium
 exposedBy:
   - dbserver
 description: |
-  Accumulated time needed to apply replication dump data.
+  Measures the time required to clone the existing leader copy of the data onto a new replica shard.
+  Will only be measured on the follower server. This time is expected to increase whenever new followers
+  are created, e.g. increasing replication factor, shard redistribution.
+troubleshoot: |
+  This metric measures as typical operation to keep the cluster resilient, so no reaction is required.
+  In a stable cluster situation (no outages, no collection modification) this metric should also be stable.

--- a/Documentation/Metrics/arangodb_replication_dump_bytes_received_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_dump_bytes_received_total.yaml
@@ -1,7 +1,7 @@
 name: arangodb_replication_dump_bytes_received_total
 introducedIn: "3.8"
 help: |
-  Number of bytes received in replication dump requests.
+  Total number of bytes replicated in initial asynchronous phase.
 unit: bytes
 type: counter
 category: Replication
@@ -9,4 +9,6 @@ complexity: medium
 exposedBy:
   - dbserver
 description: |
-  Number of bytes received in replication dump requests.
+  During initial replication the existing data from the leader is copied asynchronously
+  over to new shards. The amount of requests required to transport data to this server,
+  as a replica for a shard, is counted here.

--- a/Documentation/Metrics/arangodb_replication_dump_documents_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_dump_documents_total.yaml
@@ -1,7 +1,7 @@
 name: arangodb_replication_dump_documents_total
 introducedIn: "3.8"
 help: |
-  Number of documents received in replication dump requests.
+  Total number of documents replicated in initial asynchronous phase.
 unit: number
 type: counter
 category: Replication
@@ -9,4 +9,6 @@ complexity: simple
 exposedBy:
   - dbserver
 description: |
-  Number of documents received in replication dump requests.
+  During initial replication the existing data from the leader is copied asynchronously
+  over to new shards. The amount of documents transported to this server, as a replica for
+  a shard, is counted here.

--- a/Documentation/Metrics/arangodb_replication_dump_request_time_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_dump_request_time_total.yaml
@@ -1,7 +1,7 @@
 name: arangodb_replication_dump_request_time_total
 introducedIn: "3.8"
 help: |
-  Accumulated wait time for replication requests.
+  Accumulated wait time for replication requests in initial asynchronous phase.
 unit: ms
 type: counter
 category: Replication
@@ -9,4 +9,6 @@ complexity: medium
 exposedBy:
   - dbserver
 description: |
-  Accumulated wait time for replication requests.
+  During initial replication the existing data from the leader is copied asynchronously
+  over to new shards. The accumulated time the follower waited for the leader to send
+  the data is counted here.

--- a/Documentation/Metrics/arangodb_replication_dump_requests_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_dump_requests_total.yaml
@@ -1,7 +1,7 @@
 name: arangodb_replication_dump_requests_total
 introducedIn: "3.8"
 help: |
-  Number of replication dump requests.
+  Number of requests used in initial asynchronous replication phase.
 unit: number
 type: counter
 category: Replication
@@ -9,4 +9,6 @@ complexity: medium
 exposedBy:
   - dbserver
 description: |
-  Number of replication dump requests.
+  During initial replication the existing data from the leader is copied asynchronously
+  over to new shards. The amount of data transported to this server, as a replica for
+  a shard, is counted here.

--- a/Documentation/Metrics/arangodb_replication_failed_connects_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_failed_connects_total.yaml
@@ -1,7 +1,7 @@
 name: arangodb_replication_failed_connects_total
 introducedIn: "3.8"
 help: |
-  Number of failed connection attempts and response errors during replication.
+  Number of failed connection attempts and response errors during initial asynchronous replication.
 unit: number
 type: counter
 category: Replication
@@ -9,4 +9,30 @@ complexity: medium
 exposedBy:
   - dbserver
 description: |
-  Number of failed connection attempts and response errors during replication.
+  During initial replication the existing data from the leader is copied asynchronously
+  over to new shards. Whenever there is a communication issue between the follower and
+  the leader of the shard it will be counted here for the follower. This communication
+  issues cover failed connections or http errors, but they also cover invalid or
+  unexpected data formats revieved on the follower.
+threshold: |
+  In ideal situation this counter should be 0. It is expected to increase if there is
+  server or network outage. However it is not guaranteed that this metric increases
+  in such a situation.
+troubleshoot: |
+  If this counter increases this typically indicates an issue with the communication
+  between servers. If it is just occasionally an increase of one, it can be a simple
+  network hiccup, if you see constant increases here that indicates serious issues.
+  This also indicates that there is a shard trying to get into sync with the existing
+  data, which cannot make progress. So you have only replicationFactor - 1 copies of
+  the data right now. If more servers suffer outage you may loose data in this case.
+  * First thing to check: Network connectivity, make sure all servers are online
+    and the machines can communicate to one-another.
+  * Second: Check ArangoDB logs of this server for more details, most likely
+    you will see WARN or ERROR messages in "replication" log topic. If you contact
+    ArangoDB support for this issue, it will help to include this servers logs as well.
+  * Third: (Unlikely) If the logs contain unexpected format or value entries
+    please check if you are running all ArangoDB Database servers within the same
+    version of ArangoDB. Only upgrades of one minor version at a time are supported
+    in general, so if you are running one server with a much newer / older version
+    please upgrade all servers to the newest version.
+  * Forth: If none of the above applies, please contact ArangoDB Support.

--- a/arangod/Replication/ReplicationFeature.cpp
+++ b/arangod/Replication/ReplicationFeature.cpp
@@ -75,7 +75,7 @@ void writeError(ErrorCode code, arangodb::GeneralResponse* response) {
 } // namespace
 
 
-DECLARE_COUNTER(arangodb_replication_cluster_inventory_requests_total, "Number of cluster replication inventory requests received");
+DECLARE_COUNTER(arangodb_replication_cluster_inventory_requests_total, "(DC-2-DC only) Number of times the database and collection overviews have been requested.");
 
 namespace arangodb {
 

--- a/arangod/Replication/ReplicationMetricsFeature.cpp
+++ b/arangod/Replication/ReplicationMetricsFeature.cpp
@@ -30,15 +30,15 @@ using namespace arangodb::application_features;
 using namespace arangodb::options;
 
 DECLARE_COUNTER(arangodb_replication_dump_requests_total,
-                "Number of replication dump requests");
+                "Number of requests used in initial asynchronous replication phase.");
 DECLARE_COUNTER(arangodb_replication_dump_bytes_received_total,
-                "Number of bytes received in replication dump requests");
+                "Total number of bytes replicated in initial asynchronous phase.");
 DECLARE_COUNTER(arangodb_replication_dump_documents_total,
-                "Number of documents received in replication dump requests");
+                "Total number of documents replicated in initial asynchronous phase.");
 DECLARE_COUNTER(arangodb_replication_dump_request_time_total,
-                "Wait time for replication requests [ms]");
+                "Accumulated wait time for replication requests in initial asynchronous phase. [ms]");
 DECLARE_COUNTER(arangodb_replication_dump_apply_time_total,
-                "Accumulated time needed to apply replication dump data [ms]");
+                "Accumulated time needed to apply asynchronously replicated data on initial synchronization of shards. [ms]");
 DECLARE_COUNTER(arangodb_replication_initial_sync_keys_requests_total,
                 "Number of replication initial sync keys requests");
 DECLARE_COUNTER(arangodb_replication_initial_sync_docs_requests_total,
@@ -75,7 +75,7 @@ DECLARE_COUNTER(arangodb_replication_tailing_bytes_received_total,
                 "Number of bytes received for replication tailing requests");
 DECLARE_COUNTER(arangodb_replication_failed_connects_total,
                 "Number of failed connection attempts and response errors "
-                "during replication");
+                "during initial asynchronous replication");
 DECLARE_COUNTER(arangodb_replication_tailing_request_time_total,
                 "Wait time for replication tailing requests [ms]");
 DECLARE_COUNTER(arangodb_replication_tailing_apply_time_total,


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/13851

Adding some more documentation for replication in cluster metrics.

The following metrics are documented here:
arangodb_replication_cluster_inventory_requests_total
arangodb_replication_dump_apply_time_total
arangodb_replication_dump_bytes_received_total
arangodb_replication_dump_documents_total
arangodb_replication_dump_request_time_total
arangodb_replication_dump_requests_total
arangodb_replication_failed_connects_total

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
