### PR TITLE
Feature 3.8/auto check statistics metrics

### DIFF
--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -702,7 +702,7 @@ void StatisticsFeature::appendHistogram(
 
   result += concatT(
       "\n# HELP ", name, " ", stat[2],
-      "\n# TYPE ", name, " ", stat[1], '\n');
+      "\n# TYPE ", name, " ", stat[1], "\n");
 
   TRI_ASSERT(les.size() == counts.length());
   size_t i = 0;
@@ -711,12 +711,12 @@ void StatisticsFeature::appendHistogram(
     uint64_t v = counts.at(i++).getNumber<uint64_t>();
     sum += v;
     v = v2 ? sum : v;
-    result += concatT(name, "_bucket{le=\"", le, "\"}", " ", v, '\n');
+    result += concatT(name, "_bucket{le=\"", le, "\"}", " ", v, "\n");
   }
-  result += concatT(name, "_count ", sum, '\n');
+  result += concatT(name, "_count ", sum, "\n");
   if (v2) {
     double v = slc.get("sum").getNumber<double>();
-    result += concatT(name, "_sum ", v, '\n');
+    result += concatT(name, "_sum ", v, "\n");
   }
 }
 
@@ -734,7 +734,7 @@ void StatisticsFeature::appendMetric(std::string& result, std::string const& val
     "\n# HELP ", name, " ", stat[2],
     "\n# TYPE ", name, " ");
   result.append(type.data(), type.size());
-  result += concatT('\n', name, " ", val, '\n');
+  result += concatT("\n", name, " ", val, "\n");
 }
 
 void StatisticsFeature::toPrometheus(std::string& result, double const& now, bool v2) {

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -513,8 +513,11 @@ StatisticsFeature::StatisticsFeature(application_features::ApplicationServer& se
       if (it.second != nullptr) {
         auto const& builder = *it.second;
         auto const& stat = statIt->second;
-        auto const& statName = stat[0];
+        std::string statName(stat[0]);
         auto const& statType = metricType(stat[1], true);
+        if (statType == "counter") {
+          statName += "_total";
+        }
         [[maybe_unused]] auto const& statHelp = stat[2];
         if (builder.name() != statName) {
           foundError = true;

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -207,7 +207,7 @@ auto const statStrings = std::map<std::string_view, std::vector<std::string_view
    {"arangodb_process_statistics_minor_page_faults", "gauge/counter",
     "The number of minor faults the process has made which have not required loading a memory page from disk. This figure is not reported on Windows"}},
   {"majorPageFaults",
-   {"arangodb_process_statistics_major_page_faults", "gauge",
+   {"arangodb_process_statistics_major_page_faults", "gauge/counter",
     "On Windows, this figure contains the total number of page faults. On other system, this figure contains the number of major faults the process has made which have required loading a memory page from disk"}},
   {"userTime",
    {"arangodb_process_statistics_user_time", "gauge",


### PR DESCRIPTION
### Scope & Purpose

Backport of #13837

Add some assertions in maintainer mode that the metrics from the statistics feature are in sync with the new metrics used for documentation.

- [x] :hammer: Refactoring/simplification

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
