### PR TITLE
clean up logging a bit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 devel
 -----
 
+* Remove CMake control variable `UNCONDITIONALLY_BUILD_LOG_MESSAGES`.
+  Now, any maintainer mode build will build all log messages automatically,
+  so we will have full coverage of log message construction during our
+  tests. In non-maintainer mode, log messages are still only built when
+  actually required. This simplifies the build and increases coverage.
+
 * Updated ArangoDB Starter to 0.15.0-preview-2.
 
 * Updated OpenSSL to 1.1.1k and OpenLDAP to 2.4.58.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -728,14 +728,6 @@ endif (ASM_OPTIMIZATIONS)
 ## MAINTAINER MODE
 ################################################################################
 
-option(UNCONDITIONALLY_BUILD_LOG_MESSAGES
-  "whether log strings should be generated regardless of active loglevel"
-  OFF
-  )
-if (UNCONDITIONALLY_BUILD_LOG_MESSAGES)
-  add_definitions("-DARANGODB_UNCONDITIONALLY_BUILD_LOG_MESSAGES=1")
-endif()
-
 option(USE_MAINTAINER_MODE
   "whether we want to have assertions and other development features"
   OFF

--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -264,10 +264,13 @@ bool Conductor::_startGlobalStep() {
   b.add(Utils::edgeCountKey, VPackValue(_totalEdgesCount));
   b.add(Utils::activateAllKey, VPackValue(activateAll));
 
-  b.add(Utils::masterToWorkerMessagesKey, toWorkerMessages.slice());
+  if (!toWorkerMessages.slice().isNone()) {
+    b.add(Utils::masterToWorkerMessagesKey, toWorkerMessages.slice());
+  }
   _aggregators->serializeValues(b);
 
   b.close();
+
   LOG_TOPIC("d98de", DEBUG, Logger::PREGEL) << b.toString();
 
   _stepStartTimeSecs = TRI_microtime();

--- a/lib/Logger/LogMacros.h
+++ b/lib/Logger/LogMacros.h
@@ -58,46 +58,44 @@
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
 
-
 #define ARANGO_INTERNAL_LOG_HELPER(id)                        \
   ::arangodb::Logger::LINE(__LINE__)                          \
   << ::arangodb::Logger::FILE(__FILE__)                       \
   << ::arangodb::Logger::FUNCTION(__FUNCTION__)               \
   << ::arangodb::Logger::LOGID((id))
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief logs a message for a topic
-////////////////////////////////////////////////////////////////////////////////
-#if ARANGODB_UNCONDITIONALLY_BUILD_LOG_MESSAGES
-#define LOG_TOPIC(id, level, topic)                                     \
-  ::arangodb::LoggerStream() << (::arangodb::LogLevel::level)           \
-                             << (topic)                                 \
-                             << ARANGO_INTERNAL_LOG_HELPER(id)
-#else
-#define LOG_TOPIC(id, level, topic)                                     \
-  !::arangodb::Logger::isEnabled((::arangodb::LogLevel::level), (topic))    \
-    ? (void)nullptr                                                         \
-    : ::arangodb::LogVoidify() & (::arangodb::LoggerStream()                \
-      << (::arangodb::LogLevel::level))                                     \
-      << (topic)                                                            \
-      << ARANGO_INTERNAL_LOG_HELPER(id)
-#endif
-////////////////////////////////////////////////////////////////////////////////
 /// @brief logs a message for a topic given that a condition is true
-////////////////////////////////////////////////////////////////////////////////
+#if ARANGODB_ENABLE_MAINTAINER_MODE
+// in maintainer mode, we *intentionally and always build all log messages*.
+// we do this to find any errors when building log messages in low log levels
+// (e.g. trace) that would otherwise go undetected. we store a boolean in the
+// LoggerStream then to indicate whether we want to show the log message or
+// not.
+#define ARANGO_INTERNAL_LOG_STREAM(level, topic, cond)                                                        \
+  ::arangodb::LoggerStream((::arangodb::Logger::isEnabled((::arangodb::LogLevel::level), (topic)) && (cond))) \
+  << (::arangodb::LogLevel::level)
 
-#define LOG_TOPIC_IF(id, level, topic, cond)                                            \
-  !(::arangodb::Logger::isEnabled((::arangodb::LogLevel::level), (topic)) && (cond))    \
-    ? (void)nullptr                                                                     \
-    : ::arangodb::LogVoidify() & (::arangodb::LoggerStream()                            \
-      << (::arangodb::LogLevel::level))                                                 \
-      << (topic)                                                                        \
-      << ARANGO_INTERNAL_LOG_HELPER(id)
+#else
+// outside of maintainer mode, we check if the log message should be emitted,
+// and only then build the log log message. this is a performance optimization
+// so we can save constructing log messages which will not be emitted anyway.
+#define ARANGO_INTERNAL_LOG_STREAM(level, topic, cond)                                                        \
+  !(::arangodb::Logger::isEnabled((::arangodb::LogLevel::level), (topic)) && (cond))                          \
+    ? (void)nullptr                                                                                           \
+    : ::arangodb::LogVoidify() & (::arangodb::LoggerStream() << (::arangodb::LogLevel::level))                                                 
 
-////////////////////////////////////////////////////////////////////////////////
+#endif
+
+#define LOG_TOPIC_IF(id, level, topic, cond)                                                                  \
+  ARANGO_INTERNAL_LOG_STREAM(level, topic, (cond))                                                            \
+  << (topic)                                                                                                  \
+  << ARANGO_INTERNAL_LOG_HELPER((id))
+
+/// @brief logs a message for a topic.
+/// this simply redirects to LOG_TOPIC_IF(...) with an always true condition
+#define LOG_TOPIC(id, level, topic) LOG_TOPIC_IF(id, level, topic, true)
+
 /// @brief logs a message for debugging during development
-////////////////////////////////////////////////////////////////////////////////
-
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   #define LOG_DEVEL_LEVEL ERR
 #else

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -302,17 +302,6 @@ class Logger {
                      std::function<void(std::unique_ptr<LogMessage>&)> const& inactive =
                          [](std::unique_ptr<LogMessage>&) -> void {});
 
-#if ARANGODB_UNCONDITIONALLY_BUILD_LOG_MESSAGES
-  static bool isEnabled(LogLevel level) {
-    return true;
-  }
-  static bool isEnabled(LogLevel level, LogTopic const& topic) {
-    return true;
-  }
-  static bool _isEnabled(LogLevel level, LogLevel topicLevel) {
-    return level == LogLevel::FATAL || (int)level <= (int)topicLevel;
-  }
-#else
   static bool isEnabled(LogLevel level) {
     return (int)level <= (int)_level.load(std::memory_order_relaxed);
   }
@@ -321,7 +310,6 @@ class Logger {
                                    ? _level.load(std::memory_order_relaxed)
                                    : topic.level());
   }
-#endif
 
  public:
   static void initialize(application_features::ApplicationServer&, bool);

--- a/lib/Logger/LoggerStream.cpp
+++ b/lib/Logger/LoggerStream.cpp
@@ -36,10 +36,12 @@ LoggerStreamBase::LoggerStreamBase(bool enabled)
     : _topicId(LogTopic::MAX_LOG_TOPICS),
       _level(LogLevel::DEFAULT),
       _line(0),
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+      _enabled(enabled),
+#endif
       _logid(nullptr),
       _file(nullptr),
-      _function(nullptr),
-      _enabled(enabled) {}
+      _function(nullptr) {}
 
 LoggerStreamBase::LoggerStreamBase()
     : LoggerStreamBase(true) {}

--- a/lib/Logger/LoggerStream.cpp
+++ b/lib/Logger/LoggerStream.cpp
@@ -140,6 +140,9 @@ LoggerStream::LoggerStream(bool enabled)
     : LoggerStreamBase(enabled) {}
 #endif
 
+LoggerStream::LoggerStream() {
+    : LoggerStreamBase(true) {}
+
 LoggerStream::~LoggerStream() {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // this instance variable can only be false in maintainer mode.

--- a/lib/Logger/LoggerStream.cpp
+++ b/lib/Logger/LoggerStream.cpp
@@ -133,6 +133,11 @@ LoggerStreamBase& LoggerStreamBase::operator<<(Logger::LOGID const& logid) noexc
   return *this;
 }
 
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+LoggerStream::LoggerStream(bool enabled)
+    : LoggerStreamBase(enabled) {}
+#endif
+
 LoggerStream::~LoggerStream() {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // this instance variable can only be false in maintainer mode.

--- a/lib/Logger/LoggerStream.cpp
+++ b/lib/Logger/LoggerStream.cpp
@@ -140,7 +140,7 @@ LoggerStream::LoggerStream(bool enabled)
     : LoggerStreamBase(enabled) {}
 #endif
 
-LoggerStream::LoggerStream() {
+LoggerStream::LoggerStream() 
     : LoggerStreamBase(true) {}
 
 LoggerStream::~LoggerStream() {

--- a/lib/Logger/LoggerStream.h
+++ b/lib/Logger/LoggerStream.h
@@ -90,6 +90,9 @@ class LoggerStreamBase {
 
 class LoggerStream : public LoggerStreamBase {
  public:
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  explicit LoggerStream(bool enabled);
+#endif
   ~LoggerStream();
 };
 

--- a/lib/Logger/LoggerStream.h
+++ b/lib/Logger/LoggerStream.h
@@ -95,6 +95,7 @@ class LoggerStream : public LoggerStreamBase {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   explicit LoggerStream(bool enabled);
 #endif
+  LoggerStream();
   ~LoggerStream();
 };
 

--- a/lib/Logger/LoggerStream.h
+++ b/lib/Logger/LoggerStream.h
@@ -82,10 +82,12 @@ class LoggerStreamBase {
   size_t _topicId;
   LogLevel _level;
   int _line;
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  bool const _enabled;
+#endif
   char const* _logid;
   char const* _file;
   char const* _function;
-  bool const _enabled;
 };
 
 class LoggerStream : public LoggerStreamBase {

--- a/lib/Logger/LoggerStream.h
+++ b/lib/Logger/LoggerStream.h
@@ -41,6 +41,7 @@ class LoggerStreamBase {
   LoggerStreamBase& operator=(LoggerStreamBase const&) = delete;
 
   LoggerStreamBase();
+  explicit LoggerStreamBase(bool enabled);
 
   // intentionally not virtual, as such objects can be created _very_ often!
   ~LoggerStreamBase() = default;
@@ -79,14 +80,12 @@ class LoggerStreamBase {
  protected:
   std::stringstream _out;
   size_t _topicId;
-#if ARANGODB_UNCONDITIONALLY_BUILD_LOG_MESSAGES
-  LogLevel _topicLevel;
-#endif
   LogLevel _level;
   int _line;
   char const* _logid;
   char const* _file;
   char const* _function;
+  bool const _enabled;
 };
 
 class LoggerStream : public LoggerStreamBase {


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/663

Remove CMake control variable `UNCONDITIONALLY_BUILD_LOG_MESSAGES`.
Now, any maintainer mode build will build all log messages automatically, so we will have full coverage of log message construction during our tests. In non-maintainer mode, log messages are still only built when actually required. This simplifies the build and increases coverage.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
