### PR TITLE
don't mask errors in cursor API with vpack errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,16 @@
 v3.7.11 (XXXX-XX-XX)
 --------------------
 
+* Fix velocypack errors in cursor API in case an exception occurs while the
+  cursor is being filled with data. In this case, the result could be in an
+  arbitrary state (e.g. halfway produced), so adding more attributes to the
+  result such as "error" and "code" was potentially unsafe. If the result
+  was not properly built, trying to add "error" and "code" attributes could
+  have led to arbitrary velocypack errors, which were then reported back to
+  callers, masking the original error.
+  Now the original error is returned, and no attempt is made to write into
+  the result after an exception has occurred.
+
 * Updated OpenSSL to 1.1.1k and OpenLDAP to 2.4.58.
 
 * When using connections to multiple endpoints and switching between them,

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,12 +4,12 @@ v3.7.11 (XXXX-XX-XX)
 * Fix velocypack errors in cursor API in case an exception occurs while the
   cursor is being filled with data. In this case, the result could be in an
   arbitrary state (e.g. halfway produced), so adding more attributes to the
-  result such as "error" and "code" was potentially unsafe. If the result
-  was not properly built, trying to add "error" and "code" attributes could
-  have led to arbitrary velocypack errors, which were then reported back to
-  callers, masking the original error.
-  Now the original error is returned, and no attempt is made to write into
-  the result after an exception has occurred.
+  result such as "error" and "code" was potentially unsafe. If the result was
+  not properly built, trying to add "error" and "code" attributes could have led
+  to arbitrary velocypack errors, which were then reported back to callers,
+  masking the original error.
+  Now the original error is returned, and no attempt is made to write into the
+  result after an exception has occurred.
 
 * Updated OpenSSL to 1.1.1k and OpenLDAP to 2.4.58.
 

--- a/arangod/Aql/QueryCursor.cpp
+++ b/arangod/Aql/QueryCursor.cpp
@@ -272,8 +272,6 @@ Result QueryStreamCursor::dumpSync(VPackBuilder& builder) {
     aql::ExecutionEngine* engine = _query->rootEngine();
     TRI_ASSERT(engine != nullptr);
 
-    SharedAqlItemBlockPtr value;
-
     ExecutionState state = ExecutionState::WAITING;
 
     while (state == ExecutionState::WAITING) {

--- a/arangod/RestHandler/RestCursorHandler.cpp
+++ b/arangod/RestHandler/RestCursorHandler.cpp
@@ -582,15 +582,16 @@ RestStatus RestCursorHandler::generateCursorResult(rest::ResponseCode code) {
     TRI_ASSERT(r.ok());
     return RestStatus::WAITING;
   }
-
-  builder.add(StaticStrings::Error, VPackValue(false));
-  builder.add(StaticStrings::Code, VPackValue(static_cast<int>(code)));
-  builder.close();
-
+    
   if (r.ok()) {
+    builder.add(StaticStrings::Error, VPackValue(false));
+    builder.add(StaticStrings::Code, VPackValue(static_cast<int>(code)));
+    builder.close();
+
     _response->setContentType(rest::ContentType::JSON);
     generateResult(code, std::move(buffer), std::move(ctx));
   } else {
+    // builder can be in a broken state here. simply return the error
     generateError(r);
   }
   


### PR DESCRIPTION
### Scope & Purpose

Fix velocypack errors in cursor API in case an exception occurs while the cursor result is being filled with data. In this case, the result could be in an arbitrary state (e.g. halfway produced), so adding more attributes to the result such as "error" and "code" was potentially unsafe. If the result was not properly built, trying to add "error" and "code" attributes could have led to arbitrary velocypack errors, which were then reported back to callers, masking the original error.

Now the original error is returned, and no attempt is made to write into the result after an exception has occurred.

The fix has already been made in devel and 3.8.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
