### PR TITLE
bug-fix 3.8/Fix typos in metric documentation.

### DIFF
--- a/Documentation/Metrics/arangodb_intermediate_commits_total.yaml
+++ b/Documentation/Metrics/arangodb_intermediate_commits_total.yaml
@@ -22,7 +22,7 @@ description: |
   The values can also be overridden for individual transactions.
   This metric was named `arangodb_intermediate_commits` in previous
   versions of ArangoDb.
-troubeshoot: |
+troubleshoot: |
   If this value is non-zero, it doesn't necessarily indicate a problem. It can
   happen for large transactions and large data-loading jobs. However, as modifications
   performed by intermediate commits are persisted and cannot simply be rolled back in 

--- a/Documentation/Metrics/arangodb_replication_cluster_inventory_requests_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_cluster_inventory_requests_total.yaml
@@ -11,7 +11,7 @@ exposedBy:
   - coordinator
 description: |
   When using a DC-2-DC configuration of ArangoDB this metric is active on both data-centers.
-  It indicates that the follower data-center peridocally matches the available databases and collections
+  It indicates that the follower data-center periodically matches the available databases and collections
   in order to mirror them. If no DC-2-DC is set up this value is expected to be 0.
 troubleshoot: |
   If you have a DC-2-DC installation, and this metric stays constant over a longer period of time in any of the two data centers

--- a/Documentation/Metrics/arangodb_replication_tailing_apply_time_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_tailing_apply_time_total.yaml
@@ -13,9 +13,9 @@ description: |
   The accumulated time needed to locally process the continuous
   replication log on a follower received from a replication
   leader.
-throubleshoot: |
+troubleshoot: |
   If you see unusual spikes here, the follower might not have enough
-  IO bandwith or might be overloaded. Try to provision more IOPS or
+  IO bandwidth or might be overloaded. Try to provision more IOPS or
   more CPU capacity. Additionally, it could make sense to compare the
   value with all other available follower dbservers to detect potential
   differences.

--- a/Documentation/Metrics/arangodb_replication_tailing_request_time_total.yaml
+++ b/Documentation/Metrics/arangodb_replication_tailing_request_time_total.yaml
@@ -13,7 +13,7 @@ description: |
   Aggregated wait time for replication tailing requests.
 troubleshoot:
   If you see unusual spikes here, please inspect potential
-  network issues. It may help to increase network bandwith
+  network issues. It may help to increase network bandwidth
   and/or reduce network latency. In case there are no network
   issues, also check the load of the serving leader dbserver,
   as well as the follower dbserver, as they could potentially


### PR DESCRIPTION
### Scope & Purpose

Backport of #13873

Fix typos in metric documentation.

- [x] :hankey: Bugfix

#### Backports:

- [x] No backports required
