### PR TITLE
Fix some log messages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+v3.8.0 (XXXX-XX-XX)
+-------------------
+
+* Fix errors caused by creating some log messages in log level DEBUG in log
+  topics PREGEL and GRAPHS. Setting the log level to DEBUG for these topics
+  could lead to errors when running some Pregel jobs or SmartGraph traversals.
+
+
 v3.8.0-alpha.1 (2021-03-29)
 ---------------------------
 

--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -264,10 +264,13 @@ bool Conductor::_startGlobalStep() {
   b.add(Utils::edgeCountKey, VPackValue(_totalEdgesCount));
   b.add(Utils::activateAllKey, VPackValue(activateAll));
 
-  b.add(Utils::masterToWorkerMessagesKey, toWorkerMessages.slice());
+  if (!toWorkerMessages.slice().isNone()) {
+    b.add(Utils::masterToWorkerMessagesKey, toWorkerMessages.slice());
+  }
   _aggregators->serializeValues(b);
 
   b.close();
+
   LOG_TOPIC("d98de", DEBUG, Logger::PREGEL) << b.toString();
 
   _stepStartTimeSecs = TRI_microtime();


### PR DESCRIPTION
### Scope & Purpose

Backport of some changes from https://github.com/arangodb/arangodb/pull/13870
Enterprise PR: https://github.com/arangodb/enterprise/pull/664

* Fix errors caused by creating some log messages in log level DEBUG in log
  topics PREGEL and GRAPHS. Setting the log level to DEBUG for these topics
  could lead to errors when running some Pregel jobs or SmartGraph traversals.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/664

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
