### PR TITLE
Removed (empty) exitcodes.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1264,7 +1264,6 @@ if (USE_MAINTAINER_MODE)
 
   set(EXIT_CODE_FILES
     lib/Basics/exitcodes.h
-    lib/Basics/exitcodes.cpp
     js/common/bootstrap/exitcodes.js
     Installation/Windows/Plugins/exitcodes.nsh
   )
@@ -1278,7 +1277,7 @@ if (USE_MAINTAINER_MODE)
       COMMAND ${PYTHON_EXECUTABLE} ./utils/generateExitCodesFiles.py ./${EXIT_CODES_DAT} ./${m}.tmp
       COMMAND ${CMAKE_COMMAND} -E copy_if_different ./${m}.tmp ./${m}
       COMMAND ${CMAKE_COMMAND} -E remove ./${m}.tmp
-      DEPENDS ${CMAKE_SOURCE_DIR}/${EXIT_CODES_DAT}
+      DEPENDS ${CMAKE_SOURCE_DIR}/${EXIT_CODES_DAT} ./utils/generateExitCodesFiles.py
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
       COMMENT  "Building exitcode files ${m}"
       VERBATIM

--- a/lib/Basics/exitcodes.cpp
+++ b/lib/Basics/exitcodes.cpp
@@ -1,3 +1,0 @@
-/// auto-generated file generated from exitcodes.dat
-
-#include "Basics/exitcodes.h"

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -151,7 +151,6 @@ add_library(arango STATIC
   Basics/terminal-utils.cpp
   Basics/tri-strings.cpp
   Basics/tri-zip.cpp
-  Basics/exitcodes.cpp
   Containers/MerkleTree.cpp
   Endpoint/Endpoint.cpp
   Endpoint/EndpointIp.cpp

--- a/utils/generateExitCodesFiles.py
+++ b/utils/generateExitCodesFiles.py
@@ -106,15 +106,6 @@ FunctionEnd
 
   return impl.replace("\r", "\r\n")
 
-# generate C implementation file from errors
-def genCFile(errors, filename):
-
-  headerfile = os.path.splitext(filename)[0] + ".h"
-
-  impl = prologue\
-         + "#include \"Basics/exitcodes.h\"\n"
-  return impl
-
 
 # generate C header file from errors
 def genCHeaderFile(errors):
@@ -189,8 +180,6 @@ if extension == ".js":
   out = genJsFile(errorsList)
 elif extension == ".h":
   out = genCHeaderFile(errorsList)
-elif extension == ".cpp":
-  out = genCFile(errorsList, filename)
 elif extension == ".nsh":
   out = genNSISFile(errorsList, filename)
 else:


### PR DESCRIPTION
### Scope & Purpose

Remove an unused file. This also has the benefit of cmake no longer shooting itself in the foot by removing it after switching branches or so, and no longer being able to configure the project because of it.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [X] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [X] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

### Testing & Verification

- [X] This change is a trivial rework / code cleanup without any test coverage.
