### PR TITLE
Control unintended usage of collection names in AQL

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,22 @@
+v3.8.0 (XXXX-XX-XX)
+-------------------
+
+* Added startup option `--query.allow-collections-in-expressions` to control
+  whether collection names can be used in arbitrary places in AQL expressions,
+  e.g. `collection + 1`. This was allowed before, as a collection can be seen
+  as an array of documents. However, referring to a collection like this in a
+  query would materialize all the collection's documents in RAM, making such
+  constructs prohibitively expensive for medium-size to large-size collections.
+
+  The option can now be set to `false` to prohibit accidental usage of 
+  collection names in AQL expressions. With that setting, using a collection
+  inside an arbitrary expression will trigger the error `collection used as 
+  expression operand` and make the query fail.
+  Even with the option being set to `false`, it is still possible to use 
+  collection names in AQL queries where they are expected, e.g. `FOR doc IN 
+  collection RETURN doc`.
+
+
 v3.8.0-alpha.1 (2021-03-29)
 ---------------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,12 @@ v3.8.0 (XXXX-XX-XX)
   collection names in AQL queries where they are expected, e.g. `FOR doc IN 
   collection RETURN doc`.
 
+  The option `--query.allow-collections-in-expressions` is introduced with a
+  default value of `true` in 3.8 to ensure downwards-compatibility, but the
+  default value will change to `false` in 3.9. Furthermore, the option will
+  be deprecated in 3.9 and removed in later versions, in addition to making
+  unintended usage of collection names always an error.
+
 
 v3.8.0-alpha.1 (2021-03-29)
 ---------------------------

--- a/arangod/RestServer/QueryRegistryFeature.cpp
+++ b/arangod/RestServer/QueryRegistryFeature.cpp
@@ -163,6 +163,7 @@ QueryRegistryFeature::QueryRegistryFeature(application_features::ApplicationServ
       _smartJoins(true),
       _parallelizeTraversals(true),
 #endif
+      _allowCollectionsInExpressions(true),
       _queryGlobalMemoryLimit(defaultMemoryLimit(PhysicalMemory::getValue(), 0.1, 0.90)),
       _queryMemoryLimit(defaultMemoryLimit(PhysicalMemory::getValue(), 0.2, 0.75)),
       _queryMaxRuntime(aql::QueryOptions::defaultMaxRuntime),
@@ -327,6 +328,13 @@ void QueryRegistryFeature::collectOptions(std::shared_ptr<ProgramOptions> option
                                               arangodb::options::Flags::Enterprise))
       .setIntroducedIn(30701);
 #endif
+ 
+  // the default value of this option is true in 3.8, but will change to false in 3.9.
+  // in 3.9 the option will also be deprecated
+  options->addOption("--query.allow-collections-in-expressions",
+                     "allow full collections to be used in AQL expressions",
+                     new BooleanParameter(&_allowCollectionsInExpressions))
+                     .setIntroducedIn(30800);
 }
 
 void QueryRegistryFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {

--- a/arangod/RestServer/QueryRegistryFeature.h
+++ b/arangod/RestServer/QueryRegistryFeature.h
@@ -69,6 +69,7 @@ class QueryRegistryFeature final : public application_features::ApplicationFeatu
   bool smartJoins() const { return _smartJoins; }
   bool parallelizeTraversals() const { return _parallelizeTraversals; }
 #endif
+  bool allowCollectionsInExpressions() const { return _allowCollectionsInExpressions; }
   uint64_t queryGlobalMemoryLimit() const { return _queryGlobalMemoryLimit; }
   uint64_t queryMemoryLimit() const { return _queryMemoryLimit; }
   double queryMaxRuntime() const { return _queryMaxRuntime; }
@@ -89,6 +90,7 @@ class QueryRegistryFeature final : public application_features::ApplicationFeatu
   bool _smartJoins;
   bool _parallelizeTraversals;
 #endif
+  bool _allowCollectionsInExpressions;
   uint64_t _queryGlobalMemoryLimit;
   uint64_t _queryMemoryLimit;
   double _queryMaxRuntime;

--- a/js/common/bootstrap/errors.js
+++ b/js/common/bootstrap/errors.js
@@ -200,6 +200,7 @@
     "ERROR_QUERY_INVALID_ARITHMETIC_VALUE" : { "code" : 1561, "message" : "invalid arithmetic value" },
     "ERROR_QUERY_DIVISION_BY_ZERO" : { "code" : 1562, "message" : "division by zero" },
     "ERROR_QUERY_ARRAY_EXPECTED"   : { "code" : 1563, "message" : "array expected" },
+    "ERROR_QUERY_COLLECTION_USED_IN_EXPRESSION" : { "code" : 1568, "message" : "collection '%s' used as expression operand" },
     "ERROR_QUERY_FAIL_CALLED"      : { "code" : 1569, "message" : "FAIL(%s) called" },
     "ERROR_QUERY_GEO_INDEX_MISSING" : { "code" : 1570, "message" : "no suitable geo index found for geo restriction on '%s'" },
     "ERROR_QUERY_FULLTEXT_INDEX_MISSING" : { "code" : 1571, "message" : "no suitable fulltext index found for fulltext query on '%s'" },

--- a/lib/Basics/error-registry.h
+++ b/lib/Basics/error-registry.h
@@ -16,7 +16,7 @@ struct elsa<ErrorCode> {
 #include <frozen/unordered_map.h>
 
 namespace arangodb::error {
-constexpr static frozen::unordered_map<ErrorCode, const char*, 352> ErrorMessages = {
+constexpr static frozen::unordered_map<ErrorCode, const char*, 353> ErrorMessages = {
     {TRI_ERROR_NO_ERROR,  // 0
       "no error"},
     {TRI_ERROR_FAILED,  // 1
@@ -401,6 +401,8 @@ constexpr static frozen::unordered_map<ErrorCode, const char*, 352> ErrorMessage
       "division by zero"},
     {TRI_ERROR_QUERY_ARRAY_EXPECTED,  // 1563
       "array expected"},
+    {TRI_ERROR_QUERY_COLLECTION_USED_IN_EXPRESSION,  // 1568
+      "collection '%s' used as expression operand"},
     {TRI_ERROR_QUERY_FAIL_CALLED,  // 1569
       "FAIL(%s) called"},
     {TRI_ERROR_QUERY_GEO_INDEX_MISSING,  // 1570

--- a/lib/Basics/errors.dat
+++ b/lib/Basics/errors.dat
@@ -243,6 +243,7 @@ ERROR_QUERY_BIND_PARAMETER_TYPE,1553,"bind parameter '%s' has an invalid value o
 ERROR_QUERY_INVALID_ARITHMETIC_VALUE,1561,"invalid arithmetic value","Will be raised when a non-numeric value is used in an arithmetic operation."
 ERROR_QUERY_DIVISION_BY_ZERO,1562,"division by zero","Will be raised when there is an attempt to divide by zero."
 ERROR_QUERY_ARRAY_EXPECTED,1563,"array expected","Will be raised when a non-array operand is used for an operation that expects an array argument operand."
+ERROR_QUERY_COLLECTION_USED_IN_EXPRESSION,1568,"collection '%s' used as expression operand","Will be raised when a collection is used as an operand in an AQL expression."
 ERROR_QUERY_FAIL_CALLED,1569,"FAIL(%s) called","Will be raised when the function FAIL() is called from inside a query."
 ERROR_QUERY_GEO_INDEX_MISSING,1570,"no suitable geo index found for geo restriction on '%s'","Will be raised when a geo restriction was specified but no suitable geo index is found to resolve it."
 ERROR_QUERY_FULLTEXT_INDEX_MISSING,1571,"no suitable fulltext index found for fulltext query on '%s'","Will be raised when a fulltext query is performed on a collection without a suitable fulltext index."

--- a/lib/Basics/voc-errors.h
+++ b/lib/Basics/voc-errors.h
@@ -1062,6 +1062,11 @@ constexpr auto TRI_ERROR_QUERY_DIVISION_BY_ZERO                                 
 /// expects an array argument operand.
 constexpr auto TRI_ERROR_QUERY_ARRAY_EXPECTED                                    = ErrorCode{1563};
 
+/// 1568: ERROR_QUERY_COLLECTION_USED_IN_EXPRESSION
+/// "collection '%s' used as expression operand"
+/// Will be raised when a collection is used as an operand in an AQL expression.
+constexpr auto TRI_ERROR_QUERY_COLLECTION_USED_IN_EXPRESSION                     = ErrorCode{1568};
+
 /// 1569: ERROR_QUERY_FAIL_CALLED
 /// "FAIL(%s) called"
 /// Will be raised when the function FAIL() is called from inside a query.

--- a/tests/js/client/server_parameters/test-allow-collections-in-expressions-off.js
+++ b/tests/js/client/server_parameters/test-allow-collections-in-expressions-off.js
@@ -1,0 +1,165 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertTrue, fail */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for server parameters
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'query.allow-collections-in-expressions': "false",
+  };
+}
+const jsunity = require('jsunity');
+const errors = require('@arangodb').errors;
+const cn = "UnitTestsCollection";
+const en = "UnitTestsEdge";
+const db = require('internal').db;
+
+function testSuite() {
+  return {
+    setUpAll: function() {
+      db._drop(cn);
+      let c = db._create(cn);
+      let docs = [];
+      for (let i = 0; i < 500; ++i) {
+        docs.push({ _key: "test" + i, value: i, text: "testi" + i, loc: [i * 0.001, -i * 0.001] });
+      }
+      c.insert(docs);
+      c.ensureIndex({ type: "fulltext", fields: ["text"] }); 
+      c.ensureIndex({ type: "geo", fields: ["loc"] }); 
+      
+      db._drop(en);
+      db._createEdgeCollection(en);
+    },
+    
+    tearDownAll: function() {
+      db._drop(cn);
+      db._drop(en);
+    },
+
+    testUseInForLoop: function() {
+      let result = db._query("FOR doc IN " + cn + " RETURN doc").toArray();
+      assertEqual(500, result.length);
+      result.forEach((doc) => {
+        assertTrue(doc.hasOwnProperty('_key'));
+        assertTrue(doc.hasOwnProperty('value'));
+      });
+    },
+
+    testUseInSubquery: function() {
+      let result = db._query("LET sub = (FOR doc IN " + cn + " RETURN doc) RETURN sub").toArray();
+      assertEqual(1, result.length);
+      assertEqual(500, result[0].length);
+      result[0].forEach((doc) => {
+        assertTrue(doc.hasOwnProperty('_key'));
+        assertTrue(doc.hasOwnProperty('value'));
+      });
+    },
+    
+    testUseInInsert: function() {
+      let result = db._query("FOR i IN 1..1000 FILTER i > 10000 INSERT {} INTO " + cn).toArray();
+      assertEqual(0, result.length);
+    },
+    
+    testUseInUpdate: function() {
+      let result = db._query("FOR doc IN " + cn + " FILTER doc.value == 9999999 UPDATE doc WITH {} IN " + cn).toArray();
+      assertEqual(0, result.length);
+    },
+    
+    testUseInReplace: function() {
+      let result = db._query("FOR doc IN " + cn + " FILTER doc.value == 9999999 REPLACE doc WITH {} IN " + cn).toArray();
+      assertEqual(0, result.length);
+    },
+    
+    testUseInRemove: function() {
+      let result = db._query("FOR doc IN " + cn + " FILTER doc.value == 9999999 REMOVE doc IN " + cn).toArray();
+      assertEqual(0, result.length);
+    },
+    
+    testUseInTraversal: function() {
+      let result = db._query("WITH " + cn + " FOR v, e, p IN 1..3 OUTBOUND '" + cn + "/test0' " + en + " RETURN [v, e, p]").toArray();
+      assertEqual(0, result.length);
+    },
+    
+    testUseInShortestPath: function() {
+      let result = db._query("WITH " + cn + " FOR s IN OUTBOUND SHORTEST_PATH '" + cn + "/test0' TO '" + cn + "/test1' " + en + " RETURN s").toArray();
+      assertEqual(0, result.length);
+    },
+    
+    testUseInCollectionCount: function() {
+      let result = db._query("RETURN COLLECTION_COUNT(" + cn + ")").toArray();
+      assertEqual(1, result.length);
+      assertEqual(db[cn].count(), result[0]);
+    },
+    
+    testUseInCount: function() {
+      let result = db._query("RETURN COUNT(" + cn + ")").toArray();
+      assertEqual(1, result.length);
+      assertEqual(db[cn].count(), result[0]);
+    },
+    
+    testUseInLength: function() {
+      let result = db._query("RETURN LENGTH(" + cn + ")").toArray();
+      assertEqual(1, result.length);
+      assertEqual(db[cn].count(), result[0]);
+    },
+    
+    testUseInFulltext: function() {
+      let result = db._query("RETURN FULLTEXT(" + cn + ", 'text', 'prefix:testi')").toArray();
+      assertEqual(1, result.length);
+      assertEqual(500, result[0].length);
+    },
+    
+    testUseInWithinRectangle: function() {
+      let result = db._query("RETURN WITHIN_RECTANGLE(" + cn + ", -1, -1, 1, 1)").toArray();
+      assertEqual(1, result.length);
+      assertEqual(500, result[0].length);
+    },
+    
+    testUseInExpressions: function() {
+      let queries = [
+        "RETURN " + cn,
+        "RETURN " + cn + "[*].value",
+        "FOR value IN " + cn + "[*].value RETURN value",
+        "FOR doc IN " + cn + " RETURN " + cn + "[0]",
+        "FOR doc IN " + cn + " RETURN " + cn + " + 1",
+        "FOR doc IN " + cn + " RETURN NOOPT(" + cn + ")",
+        "RETURN APPEND(" + cn + ", 'foo')",
+      ];
+
+      queries.forEach((query) => {
+        try {
+          db._query(query);
+          fail();
+        } catch (err) {
+          assertEqual(errors.ERROR_QUERY_COLLECTION_USED_IN_EXPRESSION.code, err.errorNum);
+        }
+      });
+    },
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/test-allow-collections-in-expressions-on.js
+++ b/tests/js/client/server_parameters/test-allow-collections-in-expressions-on.js
@@ -1,0 +1,112 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertTrue */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for server parameters
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'query.allow-collections-in-expressions': "true",
+  };
+}
+const jsunity = require('jsunity');
+const cn = "UnitTestsCollection";
+const db = require('internal').db;
+
+function testSuite() {
+  return {
+    setUpAll: function() {
+      db._drop(cn);
+      let c = db._create(cn);
+      let docs = [];
+      for (let i = 0; i < 500; ++i) {
+        docs.push({ _key: "test" + i, value: i });
+      }
+      c.insert(docs);
+    },
+    
+    tearDownAll: function() {
+      db._drop(cn);
+    },
+
+    testUseInForLoop: function() {
+      let result = db._query("FOR doc IN " + cn + " RETURN doc").toArray();
+      assertEqual(500, result.length);
+      result.forEach((doc) => {
+        assertTrue(doc.hasOwnProperty('_key'));
+        assertTrue(doc.hasOwnProperty('value'));
+      });
+    },
+
+    testUseInSubquery: function() {
+      let result = db._query("LET sub = (FOR doc IN " + cn + " RETURN doc) RETURN sub").toArray();
+      assertEqual(1, result.length);
+      assertEqual(500, result[0].length);
+      result[0].forEach((doc) => {
+        assertTrue(doc.hasOwnProperty('_key'));
+        assertTrue(doc.hasOwnProperty('value'));
+      });
+    },
+
+    testUseInExpression1: function() {
+      let result = db._query("RETURN " + cn).toArray();
+      assertEqual(1, result.length);
+      assertEqual(500, result[0].length);
+      result[0].forEach((doc) => {
+        assertTrue(doc.hasOwnProperty('_key'));
+        assertTrue(doc.hasOwnProperty('value'));
+      });
+    },
+    
+    testUseInExpression2: function() {
+      let result = db._query("RETURN " + cn + "[*].value").toArray();
+      assertEqual(1, result.length);
+      assertEqual(500, result[0].length);
+      result[0].forEach((value) => {
+        assertTrue(typeof value === 'number');
+      });
+    },
+    
+    testUseInExpression3: function() {
+      let result = db._query("FOR value IN " + cn + "[*].value RETURN value").toArray();
+      assertEqual(500, result.length);
+      result.forEach((value) => {
+        assertTrue(typeof value === 'number');
+      });
+    },
+    
+    testUseInExpression4: function() {
+      let result = db._query("FOR doc IN " + cn + " RETURN " + cn + "[0]").toArray();
+      assertEqual(500, result.length);
+      result.forEach((doc) => {
+        assertTrue(doc.hasOwnProperty('_key'));
+        assertTrue(doc.hasOwnProperty('value'));
+      });
+    },
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();

--- a/tests/js/server/aql/aql-optimizer-rule-parallelize-gather-cluster.js
+++ b/tests/js/server/aql/aql-optimizer-rule-parallelize-gather-cluster.js
@@ -81,7 +81,6 @@ function optimizerRuleTestSuite () {
         "FOR i IN 1..1000 INSERT {} IN " + cn,
         "FOR doc1 IN " + cn + " FOR doc2 IN " + cn + " FILTER doc1._key == doc2._key RETURN doc1",
         "FOR doc1 IN " + cn + " FOR doc2 IN " + cn + " FOR doc3 IN " + cn + " FILTER doc1._key == doc2._key FILTER doc2._key == doc3._key RETURN doc1",
-        "FOR i IN 1..1000 IN " + cn + " FOR doc IN " + cn + " FILTER doc.value == i RETURN doc",
         "FOR i IN 1..100 LET sub = (FOR doc IN " + cn + " FILTER doc.value == i RETURN doc) RETURN sub",
         "LET sub = (FOR doc IN " + cn + " FILTER doc.value == 12 LIMIT 10 RETURN doc) FOR doc IN sub RETURN doc",
         "FOR v, e, p IN 1..1 OUTBOUND '" + cn + "/1' " + en + " RETURN p",
@@ -106,6 +105,7 @@ function optimizerRuleTestSuite () {
         "FOR doc IN " + cn + " SORT doc.value1 RETURN doc",
         "FOR doc IN " + cn + " SORT doc.value1 LIMIT 1000 RETURN doc",
         "FOR doc IN " + cn + " SORT doc.value1 LIMIT 1000, 1000 RETURN doc",
+        "FOR i IN 1..1000 FOR doc IN " + cn + " FILTER doc.value == i RETURN doc",
       ];
 
       if (require("internal").options()["query.parallelize-gather-writes"]) {


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/13872

Docs PR: https://github.com/arangodb/docs/pull/660

Added startup option `--query.allow-collections-in-expressions` to control whether collection names can be used in arbitrary places in AQL expressions, e.g. `collection + 1`. This was allowed before, as a collection can be seen as an array of documents. However, referring to a collection like this in a query would materialize all the collection's documents in RAM, making such constructs prohibitively expensive for medium-size to large-size collections.

The option can now be set to `false` to prohibit accidental usage of collection names in AQL expressions. With that setting, using a collection inside an arbitrary expression will trigger the error `collection used as expression operand` and make the query fail.
Even with the option being set to `false`, it is still possible to use collection names in AQL queries where they are expected, e.g. `FOR doc IN collection RETURN doc`.

The option `--query.allow-collections-in-expressions` is introduced with a default value of `true` in 3.8 to ensure downwards-compatibility, but the default value will change to `false` in 3.9. Furthermore, the option will be deprecated in 3.9 and removed in later versions, in addition to making unintended usage of collection names always an error.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/660

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in server_parameters)