### PR TITLE
Deprecate option `--rocksdb.exclusive-writes`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Deprecate option `--rocksdb.exclusive-writes`, which was meant to serve
+  only as a stopgap measure while porting applications from the MMFiles
+  storage engine to RocksDB.
+
 * Remove obsolete API endpoint /_admin/repair/distributeShardsLike`. This
   API was intended to correct some bad state introduced before 3.2.12 or 3.3.4,
   respectively. It had to be invoked manually by callers and there was never

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -466,7 +466,7 @@ void RocksDBOptionFeature::collectOptions(std::shared_ptr<ProgramOptions> option
                   "but will inhibit concurrent write operations",
                   new BooleanParameter(&_exclusiveWrites),
                   arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden))
-      .setIntroducedIn(30504);
+      .setIntroducedIn(30504).setDeprecatedIn(30800);
 
   //////////////////////////////////////////////////////////////////////////////
   /// add column family-specific options now


### PR DESCRIPTION
### Scope & Purpose

Deprecate option `--rocksdb.exclusive-writes`

The option was meant to serve only as a stopgap measure while porting applications from the MMFiles storage engine to RocksDB.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
