### PR TITLE
Deprecate option `--rocksdb.exclusive-writes`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+v3.8.0 (XXXX-XX-XX)
+-------------------
+
+* Deprecate option `--rocksdb.exclusive-writes`, which was meant to serve
+  only as a stopgap measure while porting applications from the MMFiles
+  storage engine to RocksDB.
+
+
 v3.8.0-alpha.1 (2021-03-29)
 ---------------------------
 

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -466,7 +466,7 @@ void RocksDBOptionFeature::collectOptions(std::shared_ptr<ProgramOptions> option
                   "but will inhibit concurrent write operations",
                   new BooleanParameter(&_exclusiveWrites),
                   arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden))
-      .setIntroducedIn(30504);
+      .setIntroducedIn(30504).setDeprecatedIn(30800);
 
   //////////////////////////////////////////////////////////////////////////////
   /// add column family-specific options now


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/13887

Deprecate option `--rocksdb.exclusive-writes`

The option was meant to serve only as a stopgap measure while porting applications from the MMFiles storage engine to RocksDB.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required.

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
