### PR TITLE
Fix URLs in request logging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,8 +4,8 @@ v3.7.11 (XXXX-XX-XX)
 * Fix logging of urls when using `--log.level requests=debug`. There was an
   issue since v3.7.7 with the wrong URL being logged in request logging if
   multiple requests were sent over the same connection. In this case, the
-  request logging only reported the first URL requested in the connection,
-  even for all subsequent requests.
+  request logging only reported the first URL requested in the connection, even
+  for all subsequent requests.
 
 * Updated OpenSSL to 1.1.1k and OpenLDAP to 2.4.58.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.7.11 (XXXX-XX-XX)
 --------------------
 
+* Fix logging of urls when using `--log.level requests=debug`. There was an
+  issue since v3.7.7 with the wrong URL being logged in request logging if
+  multiple requests were sent over the same connection. In this case, the
+  request logging only reported the first URL requested in the connection,
+  even for all subsequent requests.
+
 * Updated OpenSSL to 1.1.1k and OpenLDAP to 2.4.58.
 
 * When using connections to multiple endpoints and switching between them,

--- a/arangod/GeneralServer/GeneralCommTask.h
+++ b/arangod/GeneralServer/GeneralCommTask.h
@@ -66,7 +66,6 @@ class GeneralCommTask : public CommTask {
   
   bool _reading;
   bool _writing;
-  std::string _url;
   
  private:
   

--- a/arangod/GeneralServer/H2CommTask.cpp
+++ b/arangod/GeneralServer/H2CommTask.cpp
@@ -460,12 +460,12 @@ static void DTraceH2CommTaskProcessStream(size_t) {}
 #endif
 
 template <SocketType T>
-std::string const& H2CommTask<T>::url(HttpRequest* req) {
-  if (this->_url.empty() && req != nullptr) {
-    this->_url = std::string((req->databaseName().empty() ? "" : "/_db/" + req->databaseName())) +
+std::string H2CommTask<T>::url(HttpRequest const* req) const {
+  if (req != nullptr) {
+    return std::string((req->databaseName().empty() ? "" : "/_db/" + req->databaseName())) +
       (Logger::logRequestParameters() ? req->fullUrl() : req->requestPath());
   }
-  return this->_url;
+  return "";
 }
 
 template <SocketType T>

--- a/arangod/GeneralServer/H2CommTask.h
+++ b/arangod/GeneralServer/H2CommTask.h
@@ -114,7 +114,7 @@ class H2CommTask final : public GeneralCommTask<T> {
 
  private:
 
-  std::string const& url(HttpRequest* req);
+  std::string url(HttpRequest const* req) const;
 
   velocypack::Buffer<uint8_t> _outbuffer;
 

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -386,12 +386,12 @@ static void DTraceHttpCommTaskProcessRequest(size_t) {}
 #endif
 
 template <SocketType T>
-std::string const& HttpCommTask<T>::url() {
-  if (this->_url.empty() && _request != nullptr) {
-    this->_url = std::string((_request->databaseName().empty() ? "" : "/_db/" + _request->databaseName())) +
+std::string HttpCommTask<T>::url() const {
+  if (_request != nullptr) {
+    return std::string((_request->databaseName().empty() ? "" : "/_db/" + _request->databaseName())) +
       (Logger::logRequestParameters() ? _request->fullUrl() : _request->requestPath());
   }
-  return this->_url;
+  return "";
 }
 
 template <SocketType T>

--- a/arangod/GeneralServer/HttpCommTask.h
+++ b/arangod/GeneralServer/HttpCommTask.h
@@ -74,7 +74,7 @@ class HttpCommTask final : public GeneralCommTask<T> {
   void writeResponse(RequestStatistics::Item stat);
 
  private:
-  std::string const& url();
+  std::string url() const;
 
   /// the node http-parser
   llhttp_t _parser;

--- a/arangod/GeneralServer/VstCommTask.cpp
+++ b/arangod/GeneralServer/VstCommTask.cpp
@@ -236,12 +236,12 @@ static void DTraceVstCommTaskProcessMessage(size_t) {}
 #endif
 
 template <SocketType T>
-std::string const& VstCommTask<T>::url(VstRequest* req) {
-  if (this->_url.empty() && req != nullptr) {
-    this->_url = std::string((req->databaseName().empty() ? "" : "/_db/" + req->databaseName())) +
+std::string VstCommTask<T>::url(VstRequest const* req) const {
+  if (req != nullptr) {
+    return std::string((req->databaseName().empty() ? "" : "/_db/" + req->databaseName())) +
       (Logger::logRequestParameters() ? req->fullUrl() : req->requestPath());
   }
-  return this->_url;
+  return "";
 }
 
 /// process a VST message

--- a/arangod/GeneralServer/VstCommTask.h
+++ b/arangod/GeneralServer/VstCommTask.h
@@ -60,7 +60,7 @@ class VstCommTask final : public GeneralCommTask<T> {
 
  private:
 
-  std::string const& url(VstRequest* req);
+  std::string url(VstRequest const* req) const;
 
   // Process the given incoming chunk.
   bool processChunk(fuerte::vst::Chunk const& chunk);


### PR DESCRIPTION
### Scope & Purpose

Fix URLs in request logging

Fix logging of urls when using `--log.level requests=debug`. There was an issue since v3.7.7 with the wrong URL being logged in request logging if multiple requests were sent over the same connection. In this case, the request logging only reported the first URL requested in the connection, even for all subsequent requests.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
