### PR TITLE
Fix URLs in request logging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 devel
 -----
 
+* Fix logging of urls when using `--log.level requests=debug`. There was an
+  issue since v3.7.7 with the wrong URL being logged in request logging if
+  multiple requests were sent over the same connection. In this case, the
+  request logging only reported the first URL requested in the connection,
+  even for all subsequent requests.
+
 * Remove obsolete API endpoint /_admin/repair/distributeShardsLike`. This
   API was intended to correct some bad state introduced before 3.2.12 or 3.3.4,
   respectively. It had to be invoked manually by callers and there was never

--- a/arangod/GeneralServer/GeneralCommTask.h
+++ b/arangod/GeneralServer/GeneralCommTask.h
@@ -70,7 +70,6 @@ class GeneralCommTask : public CommTask {
   
   bool _reading;
   bool _writing;
-  std::string _url;
   
  private:
   

--- a/arangod/GeneralServer/H2CommTask.cpp
+++ b/arangod/GeneralServer/H2CommTask.cpp
@@ -462,12 +462,12 @@ static void DTraceH2CommTaskProcessStream(size_t) {}
 #endif
 
 template <SocketType T>
-std::string const& H2CommTask<T>::url(HttpRequest* req) {
-  if (this->_url.empty() && req != nullptr) {
-    this->_url = std::string((req->databaseName().empty() ? "" : "/_db/" + req->databaseName())) +
+std::string H2CommTask<T>::url(HttpRequest const* req) const {
+  if (req != nullptr) {
+    return std::string((req->databaseName().empty() ? "" : "/_db/" + req->databaseName())) +
       (Logger::logRequestParameters() ? req->fullUrl() : req->requestPath());
   }
-  return this->_url;
+  return "";
 }
 
 template <SocketType T>

--- a/arangod/GeneralServer/H2CommTask.h
+++ b/arangod/GeneralServer/H2CommTask.h
@@ -116,7 +116,7 @@ class H2CommTask final : public GeneralCommTask<T> {
  private:
 
   /// @brief used to generate the full url for debugging
-  std::string const& url(HttpRequest* req);
+  std::string url(HttpRequest const* req) const;
 
   velocypack::Buffer<uint8_t> _outbuffer;
 

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -387,12 +387,12 @@ static void DTraceHttpCommTaskProcessRequest(size_t) {}
 #endif
 
 template <SocketType T>
-std::string const& HttpCommTask<T>::url() {
-  if (this->_url.empty() && _request != nullptr) {
-    this->_url = std::string((_request->databaseName().empty() ? "" : "/_db/" + _request->databaseName())) +
+std::string HttpCommTask<T>::url() const {
+  if (_request != nullptr) {
+    return std::string((_request->databaseName().empty() ? "" : "/_db/" + _request->databaseName())) +
       (Logger::logRequestParameters() ? _request->fullUrl() : _request->requestPath());
   }
-  return this->_url;
+  return "";
 }
 
 template <SocketType T>

--- a/arangod/GeneralServer/HttpCommTask.h
+++ b/arangod/GeneralServer/HttpCommTask.h
@@ -74,7 +74,7 @@ class HttpCommTask final : public GeneralCommTask<T> {
   // called on IO context thread
   void writeResponse(RequestStatistics::Item stat);
 
-  std::string const& url();
+  std::string url() const;
 
   /// the node http-parser
   llhttp_t _parser;

--- a/arangod/GeneralServer/VstCommTask.cpp
+++ b/arangod/GeneralServer/VstCommTask.cpp
@@ -236,12 +236,12 @@ static void DTraceVstCommTaskProcessMessage(size_t) {}
 #endif
 
 template <SocketType T>
-std::string const& VstCommTask<T>::url(VstRequest* req) {
-  if (this->_url.empty() && req != nullptr) {
-    this->_url = std::string((req->databaseName().empty() ? "" : "/_db/" + req->databaseName())) +
+std::string VstCommTask<T>::url(VstRequest const* req) const {
+  if (req != nullptr) {
+    return std::string((req->databaseName().empty() ? "" : "/_db/" + req->databaseName())) +
       (Logger::logRequestParameters() ? req->fullUrl() : req->requestPath());
   }
-  return this->_url;
+  return "";
 }
 
 /// process a VST message

--- a/arangod/GeneralServer/VstCommTask.h
+++ b/arangod/GeneralServer/VstCommTask.h
@@ -104,7 +104,7 @@ class VstCommTask final : public GeneralCommTask<T> {
 
  private:
 
-  std::string const& url(VstRequest* req);
+  std::string url(VstRequest const* req) const;
 
   std::map<uint64_t, Message> _messages;
 


### PR DESCRIPTION
### Scope & Purpose

Fix URLs in request logging

Fix logging of urls when using `--log.level requests=debug`. There was an issue since v3.7.7 with the wrong URL being logged in request logging if multiple requests were sent over the same connection. In this case, the request logging only reported the first URL requested in the connection, even for all subsequent requests.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.7: https://github.com/arangodb/arangodb/pull/13890, 3.8: https://github.com/arangodb/arangodb/pull/13891

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
