### PR TITLE
 make metrics low()/high() functions return by value

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.6.13 (XXXX-XX-XX)
 --------------------
 
+* Change metrics' internal `low()` and `high()` methods so that they 
+  return by value, not by reference.
+
 * Updated OpenSSL to 1.1.1k and OpenLDAP to 2.4.58.
 
 * When using connections to multiple endpoints and switching between them,

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.6.13 (XXXX-XX-XX)
 --------------------
 
-* Change metrics' internal `low()` and `high()` methods so that they 
-  return by value, not by reference.
+* Change metrics' internal `low()` and `high()` methods so that they return by
+  value, not by reference.
 
 * Updated OpenSSL to 1.1.1k and OpenLDAP to 2.4.58.
 

--- a/arangod/RestServer/Metrics.h
+++ b/arangod/RestServer/Metrics.h
@@ -398,8 +398,8 @@ template<typename Scale> class Histogram : public Metric {
     records(t);
   }
 
-  value_type const& low() const { return _scale.low(); }
-  value_type const& high() const { return _scale.high(); }
+  value_type low() const { return _scale.low(); }
+  value_type high() const { return _scale.high(); }
 
   Metrics::hist_type::value_type& operator[](size_t n) {
     return _c[n];
@@ -413,7 +413,7 @@ template<typename Scale> class Histogram : public Metric {
     return v;
   }
 
-  uint64_t load(size_t i) const { return _c.load(i); };
+  uint64_t load(size_t i) const { return _c.load(i); }
 
   size_t size() const { return _c.size(); }
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/13895

Make metrics `low()`/`high()` methods return data by value, not by reference.
This fixes a potential issue with accessing invalid memory.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
