### PR TITLE
harden addAction function against invalid inputs

### DIFF
--- a/arangod/Cluster/MaintenanceFeature.cpp
+++ b/arangod/Cluster/MaintenanceFeature.cpp
@@ -398,7 +398,15 @@ Result MaintenanceFeature::deleteAction(uint64_t action_id) {
 ///  pool. not yet:  ActionDescription parameter will be MOVED to new object.
 Result MaintenanceFeature::addAction(std::shared_ptr<maintenance::Action> newAction,
                                      bool executeNow) {
+
+  TRI_ASSERT(newAction != nullptr);
+  TRI_ASSERT(newAction->ok());
+
   Result result;
+  
+  if (newAction == nullptr) {
+    return result.reset(TRI_ERROR_INTERNAL, "invalid call of MaintenanceFeature::addAction");
+  }
 
   // the underlying routines are believed to be safe and throw free,
   //  but just in case
@@ -411,7 +419,7 @@ Result MaintenanceFeature::addAction(std::shared_ptr<maintenance::Action> newAct
 
     // similar action not in the queue (or at least no longer viable)
     if (!curAction) {
-      if (newAction && newAction->ok()) {
+      if (newAction->ok()) {
         // Register action only if construction was ok
         registerAction(newAction, executeNow);
       } else {

--- a/arangod/Cluster/MaintenanceRestHandler.cpp
+++ b/arangod/Cluster/MaintenanceRestHandler.cpp
@@ -173,11 +173,10 @@ void MaintenanceRestHandler::putAction() {
   }    // if
 
   if (good) {
-    Result result;
-
     // build the action
+    TRI_ASSERT(_actionDesc != nullptr);
     auto& maintenance = server().getFeature<MaintenanceFeature>();
-    result = maintenance.addAction(_actionDesc);
+    Result result = maintenance.addAction(_actionDesc);
 
     if (!result.ok()) {
       // possible errors? TRI_ERROR_BAD_PARAMETER    TRI_ERROR_TASK_DUPLICATE_ID


### PR DESCRIPTION
### Scope & Purpose

Harden `MaintenaceFeature::addAction` function against invalid inputs.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
