### PR TITLE
Fixed issue BTS-353

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fixed issue BTS-353: memleak when running into an out-of-memory situation
+  while repurposing an existing AqlItemBlock.
+
 * Fix logging of urls when using `--log.level requests=debug`. There was an
   issue since v3.7.7 with the wrong URL being logged in request logging if
   multiple requests were sent over the same connection. In this case, the

--- a/arangod/Aql/AqlItemBlockManager.cpp
+++ b/arangod/Aql/AqlItemBlockManager.cpp
@@ -74,7 +74,12 @@ SharedAqlItemBlockPtr AqlItemBlockManager::requestBlock(size_t numRows, Register
   if (block == nullptr) {
     block = new AqlItemBlock(*this, numRows, numRegisters);
   } else {
-    block->rescale(numRows, numRegisters);
+    try {
+      block->rescale(numRows, numRegisters);
+    } catch (...) {
+      delete block;
+      throw;
+    }
   }
 
   TRI_ASSERT(block != nullptr);

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -229,7 +229,7 @@ std::unique_ptr<OutputAqlItemRow> ExecutionBlockImpl<Executor>::createOutputRow(
                                             registerInfos().getOutputRegisters(),
                                             registerInfos().registersToKeep(),
                                             registerInfos().registersToClear(),
-                                            call, copyRowBehaviour);
+                                            std::move(call), copyRowBehaviour);
 }
 
 template <class Executor>


### PR DESCRIPTION
### Scope & Purpose

Fixed issue [BTS-353](https://arangodb.atlassian.net/browse/BTS-353). This fixes a memleak when running into an out-of-memory situation while repurposing an existing AqlItemBlock.

This bugfix can be validated by running `scripts/unittest server_parameters --test tests/js/client/server_parameters/test-memory-limit.js` in an ASan-enabled build.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.8 (https://github.com/arangodb/arangodb/pull/13903), 3.7 (https://github.com/arangodb/arangodb/pull/13904), 3.6 (https://github.com/arangodb/arangodb/pull/13905)

#### Related Information

- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-353

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *server_parameters*.
- [x] I ensured this code runs with ASan / TSan or other static verification tools
