### PR TITLE
Fixed issue BTS-353

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.6.13 (XXXX-XX-XX)
 --------------------
 
+* Fixed issue BTS-353: memleak when running into an out-of-memory situation
+  while repurposing an existing AqlItemBlock.
+
 * Change metrics' internal `low()` and `high()` methods so that they return by
   value, not by reference.
 

--- a/arangod/Aql/AqlItemBlockManager.cpp
+++ b/arangod/Aql/AqlItemBlockManager.cpp
@@ -57,7 +57,12 @@ SharedAqlItemBlockPtr AqlItemBlockManager::requestBlock(size_t nrItems, Register
       block = _buckets[i].pop();
       TRI_ASSERT(block != nullptr);
       TRI_ASSERT(block->numEntries() == 0);
-      block->rescale(nrItems, nrRegs);
+      try {
+        block->rescale(nrItems, nrRegs);
+      } catch (...) {
+        delete block;
+        throw;
+      }
       // LOG_TOPIC("7157d", TRACE, arangodb::Logger::FIXME) << "returned cached
       // AqlItemBlock with dimensions " << block->size() << " x " <<
       // block->getNrRegs();

--- a/tests/js/client/server_permissions/test-memory-limit.js
+++ b/tests/js/client/server_permissions/test-memory-limit.js
@@ -1,0 +1,60 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertTrue, assertMatch, fail */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for memory limit
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'query.memory-limit': "5000000"
+  };
+}
+const jsunity = require('jsunity');
+const errors = require('@arangodb').errors;
+const cn = "UnitTestsCollection";
+const db = require('internal').db;
+
+function testSuite() {
+  return {
+    testQueryBelowLimit: function() {
+      let result = db._query("FOR i IN 1..1000 RETURN i").toArray();
+      assertEqual(1000, result.length);
+    },
+    
+    testQueryAboveLimit: function() {
+      try {
+        // we expect this query here to violate the memory limit
+        db._query("LET testi = (FOR i IN 1..10000 FOR j IN 1..100 RETURN CONCAT('testmann-der-fuxxx', i, j)) RETURN testi");
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_RESOURCE_LIMIT.code, err.errorNum);
+      }
+    },
+    
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/13902

Fixed issue [BTS-353](https://arangodb.atlassian.net/browse/BTS-353). This fixes a memleak when running into an out-of-memory situation while repurposing an existing AqlItemBlock.

This bugfix can be validated by running `scripts/unittest server_parameters --test tests/js/client/server_parameters/test-memory-limit.js` in an ASan-enabled build.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required.

#### Related Information

- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-353

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *server_parameters*.
- [x] I ensured this code runs with ASan / TSan or other static verification tools
