### PR TITLE
fix self-assignment in SmallBuffer

### DIFF
--- a/arangod/Agency/Node.h
+++ b/arangod/Agency/Node.h
@@ -103,16 +103,18 @@ class SmallBuffer {
     other._size = 0;
   }
   SmallBuffer& operator=(SmallBuffer const& other) {
-    if (!empty()) {
-      delete[] _start;
-    }
-    if (other.empty()) {
-      _start = nullptr;
-      _size = 0;
-    } else {
-      _start = new uint8_t[other._size];
-      _size = other._size;
-      memcpy(_start, other._start, other._size);
+    if (this != &other) {
+      if (!empty()) {
+        delete[] _start;
+      }
+      if (other.empty()) {
+        _start = nullptr;
+        _size = 0;
+      } else {
+        _start = new uint8_t[other._size];
+        _size = other._size;
+        memcpy(_start, other._start, other._size);
+      }
     }
     return *this;
   }

--- a/tests/Agency/NodeTest.cpp
+++ b/tests/Agency/NodeTest.cpp
@@ -138,7 +138,8 @@ TEST(SmallBufferTest, copySelfAssignment) {
     sb1.data()[i] = (uint8_t)i;
   }
 
-  sb1 = sb1;
+  SmallBuffer* target = &sb1;
+  *target = sb1;
   ASSERT_NE(sb1.data(), nullptr);
   ASSERT_FALSE(sb1.empty());
   ASSERT_EQ(123, sb1.size());
@@ -187,7 +188,9 @@ TEST(SmallBufferTest, moveSelfAssignment) {
   for (size_t i = 0; i < 123; ++i) {
     sb1.data()[i] = (uint8_t)i;
   }
-  sb1 = std::move(sb1);
+
+  SmallBuffer* target = &sb1;
+  *target = std::move(sb1);
 
   ASSERT_NE(nullptr, sb1.data());
   ASSERT_EQ(123, sb1.size());

--- a/tests/Agency/NodeTest.cpp
+++ b/tests/Agency/NodeTest.cpp
@@ -132,6 +132,21 @@ TEST(SmallBufferTest, copyAssignment) {
   }
 }
 
+TEST(SmallBufferTest, copySelfAssignment) {
+  SmallBuffer sb1(123);
+  for (size_t i = 0; i < 123; ++i) {
+    sb1.data()[i] = (uint8_t)i;
+  }
+
+  sb1 = sb1;
+  ASSERT_NE(sb1.data(), nullptr);
+  ASSERT_FALSE(sb1.empty());
+  ASSERT_EQ(123, sb1.size());
+  for (size_t i = 0; i < 123; ++i) {
+    ASSERT_EQ((uint8_t) i, sb1.data()[i]);
+  }
+}
+
 TEST(SmallBufferTest, moveAssignment) {
   SmallBuffer sb1(123);
   for (size_t i = 0; i < 123; ++i) {
@@ -165,7 +180,21 @@ TEST(SmallBufferTest, moveAssignment) {
   for (size_t i = 0; i < 123; ++i) {
     ASSERT_EQ((uint8_t) i, sb3.data()[i]);
   }
+}
 
+TEST(SmallBufferTest, moveSelfAssignment) {
+  SmallBuffer sb1(123);
+  for (size_t i = 0; i < 123; ++i) {
+    sb1.data()[i] = (uint8_t)i;
+  }
+  sb1 = std::move(sb1);
+
+  ASSERT_NE(nullptr, sb1.data());
+  ASSERT_EQ(123, sb1.size());
+  ASSERT_FALSE(sb1.empty());
+  for (size_t i = 0; i < 123; ++i) {
+    ASSERT_EQ((uint8_t) i, sb1.data()[i]);
+  }
 }
 
 class NodeTest

--- a/tests/Agency/NodeTest.cpp
+++ b/tests/Agency/NodeTest.cpp
@@ -138,8 +138,12 @@ TEST(SmallBufferTest, copySelfAssignment) {
     sb1.data()[i] = (uint8_t)i;
   }
 
+  // we want a self-assignment here, but we have
+  // to make it look complicated so compilers don't 
+  // detect it too easily
   SmallBuffer* target = &sb1;
   *target = sb1;
+  
   ASSERT_NE(sb1.data(), nullptr);
   ASSERT_FALSE(sb1.empty());
   ASSERT_EQ(123, sb1.size());
@@ -189,6 +193,9 @@ TEST(SmallBufferTest, moveSelfAssignment) {
     sb1.data()[i] = (uint8_t)i;
   }
 
+  // we want a self-move assignment here, but we have
+  // to make it look complicated so compilers don't 
+  // detect it too easily
   SmallBuffer* target = &sb1;
   *target = std::move(sb1);
 


### PR DESCRIPTION
### Scope & Purpose

Fix self-assignment in Node.h's `SmallBuffer`, and add tests for self-assignment for copy & move.
This is an internal change and currently has no user-visible effects (self-assignment is currently not used).

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new C++ **Unit tests**

