### PR TITLE
instead of silently ignoring / asserting return an error if one tries to create a collection on a dbserver

### DIFF
--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -322,21 +322,8 @@ RestStatus RestCollectionHandler::handleCommandGet() {
 
 // create a collection
 void RestCollectionHandler::handleCommandPost() {
-
-  switch (ServerState::instance()->getRole()) {
-  case ServerState::ROLE_SINGLE:
-    break;
-  case ServerState::ROLE_DBSERVER:
-    generateError(rest::ResponseCode::BAD, TRI_ERROR_FORBIDDEN, "may not create collections on DB-Servers");
-    events::CreateCollection(_vocbase.name(), "", TRI_ERROR_FORBIDDEN);
-    return;
-  case ServerState::ROLE_COORDINATOR:
-    break;
-  case ServerState::ROLE_AGENT:
-    break;
-  case ServerState::ROLE_UNDEFINED:
-    generateError(rest::ResponseCode::BAD, TRI_ERROR_FORBIDDEN, "may not create collections on who am I anyways?");
-    events::CreateCollection(_vocbase.name(), "", TRI_ERROR_FORBIDDEN);
+  if (ServerState::instance()->isDBServer()) {
+    generateError(Result(TRI_ERROR_CLUSTER_ONLY_ON_COORDINATOR));
     return;
   }
 

--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -57,11 +57,6 @@ RestCollectionHandler::RestCollectionHandler(application_features::ApplicationSe
     : RestVocbaseBaseHandler(server, request, response) {}
 
 RestStatus RestCollectionHandler::execute() {
-  if ((_request->requestType() != rest::RequestType::GET) &&
-      ServerState::instance()->isDBServer()) {
-    generateError(Result(TRI_ERROR_CLUSTER_ONLY_ON_COORDINATOR));
-    return RestStatus::DONE;
-  }
   switch (_request->requestType()) {
     case rest::RequestType::GET:
       return handleCommandGet();
@@ -327,6 +322,11 @@ RestStatus RestCollectionHandler::handleCommandGet() {
 
 // create a collection
 void RestCollectionHandler::handleCommandPost() {
+  if (ServerState::instance()->isDBServer()) {
+    generateError(Result(TRI_ERROR_CLUSTER_ONLY_ON_COORDINATOR));
+    return;
+  }
+
   bool parseSuccess = false;
   VPackSlice const body = this->parseVPackBody(parseSuccess);
   if (!parseSuccess) {
@@ -376,6 +376,7 @@ void RestCollectionHandler::handleCommandPost() {
   _builder.clear();
   std::shared_ptr<LogicalCollection> coll;
   OperationOptions options(_context);
+
   Result res =
       methods::Collections::create(_vocbase,  // collection vocbase
                                    options,


### PR DESCRIPTION
### Scope & Purpose

behave honest to the wrongly API on DB-Server using instead of silently ignoring the collection cretion or asserting.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: all

### Testing & Verification

use arangosh to create a collection on a dbserver.

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*

Link to Jenkins PR run:
http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/14776/