### PR TITLE
Remove CMake control variable `UNCONDITIONALLY_BUILD_LOG_MESSAGES`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.8.0 (XXXX-XX-XX)
 -------------------
 
+* Remove CMake control variable `UNCONDITIONALLY_BUILD_LOG_MESSAGES`.
+
 * Fix undefined behavior in dynarray constructor when running into 
   an out-of-memory exception during construction. In arangod, this can only
   happen during metrics objects construction at program start.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -728,14 +728,6 @@ endif (ASM_OPTIMIZATIONS)
 ## MAINTAINER MODE
 ################################################################################
 
-option(UNCONDITIONALLY_BUILD_LOG_MESSAGES
-  "whether log strings should be generated regardless of active loglevel"
-  OFF
-  )
-if (UNCONDITIONALLY_BUILD_LOG_MESSAGES)
-  add_definitions("-DARANGODB_UNCONDITIONALLY_BUILD_LOG_MESSAGES=1")
-endif()
-
 option(USE_MAINTAINER_MODE
   "whether we want to have assertions and other development features"
   OFF

--- a/lib/Logger/LogMacros.h
+++ b/lib/Logger/LogMacros.h
@@ -68,20 +68,14 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief logs a message for a topic
 ////////////////////////////////////////////////////////////////////////////////
-#if ARANGODB_UNCONDITIONALLY_BUILD_LOG_MESSAGES
-#define LOG_TOPIC(id, level, topic)                                     \
-  ::arangodb::LoggerStream() << (::arangodb::LogLevel::level)           \
-                             << (topic)                                 \
-                             << ARANGO_INTERNAL_LOG_HELPER(id)
-#else
-#define LOG_TOPIC(id, level, topic)                                     \
+#define LOG_TOPIC(id, level, topic)                                         \
   !::arangodb::Logger::isEnabled((::arangodb::LogLevel::level), (topic))    \
     ? (void)nullptr                                                         \
     : ::arangodb::LogVoidify() & (::arangodb::LoggerStream()                \
       << (::arangodb::LogLevel::level))                                     \
       << (topic)                                                            \
       << ARANGO_INTERNAL_LOG_HELPER(id)
-#endif
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief logs a message for a topic given that a condition is true
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -302,17 +302,6 @@ class Logger {
                      std::function<void(std::unique_ptr<LogMessage>&)> const& inactive =
                          [](std::unique_ptr<LogMessage>&) -> void {});
 
-#if ARANGODB_UNCONDITIONALLY_BUILD_LOG_MESSAGES
-  static bool isEnabled(LogLevel level) {
-    return true;
-  }
-  static bool isEnabled(LogLevel level, LogTopic const& topic) {
-    return true;
-  }
-  static bool _isEnabled(LogLevel level, LogLevel topicLevel) {
-    return (int)level <= (int)topicLevel;
-  }
-#else
   static bool isEnabled(LogLevel level) {
     return (int)level <= (int)_level.load(std::memory_order_relaxed);
   }
@@ -321,7 +310,6 @@ class Logger {
                                    ? _level.load(std::memory_order_relaxed)
                                    : topic.level());
   }
-#endif
 
  public:
   static void initialize(application_features::ApplicationServer&, bool);

--- a/lib/Logger/LoggerStream.cpp
+++ b/lib/Logger/LoggerStream.cpp
@@ -34,9 +34,6 @@ namespace arangodb {
 
 LoggerStreamBase::LoggerStreamBase()
     : _topicId(LogTopic::MAX_LOG_TOPICS),
-#if ARANGODB_UNCONDITIONALLY_BUILD_LOG_MESSAGES
-      _topicLevel(LogLevel::DEFAULT),
-#endif
       _level(LogLevel::DEFAULT),
       _line(0),
       _logid(nullptr),
@@ -50,9 +47,6 @@ LoggerStreamBase& LoggerStreamBase::operator<<(LogLevel const& level) noexcept {
 
 LoggerStreamBase& LoggerStreamBase::operator<<(LogTopic const& topic) noexcept {
   _topicId = topic.id();
-#if ARANGODB_UNCONDITIONALLY_BUILD_LOG_MESSAGES
-  _topicLevel = topic.level();
-#endif
   return *this;
   }
 
@@ -137,12 +131,6 @@ LoggerStreamBase& LoggerStreamBase::operator<<(Logger::LOGID const& logid) noexc
 
 LoggerStream::~LoggerStream() {
   try {
-#if ARANGODB_UNCONDITIONALLY_BUILD_LOG_MESSAGES
-    // log maintainer mode disables this if in the macro, do it here:
-    if (!::arangodb::Logger::_isEnabled(_level, _topicLevel)) {
-      return;
-    }
-#endif
     // TODO: with c++20, we can get a view on the stream's underlying buffer,
     // without copying it
     Logger::log(_logid, _function, _file, _line, _level, _topicId, _out.str());

--- a/lib/Logger/LoggerStream.h
+++ b/lib/Logger/LoggerStream.h
@@ -79,9 +79,6 @@ class LoggerStreamBase {
  protected:
   std::stringstream _out;
   size_t _topicId;
-#if ARANGODB_UNCONDITIONALLY_BUILD_LOG_MESSAGES
-  LogLevel _topicLevel;
-#endif
   LogLevel _level;
   int _line;
   char const* _logid;


### PR DESCRIPTION
### Scope & Purpose

Remove CMake control variable `UNCONDITIONALLY_BUILD_LOG_MESSAGES`.
This removes a bit of coverage for log messages in case the CMake variable was turned on. However, it isn't consistently used even by our own builds. In devel/3.9 this is properly fixed by always generating all log messages in maintainer mode, thus having maximum coverage without requiring additional build variables.

There is also an Oskar PR to remove the variable there: https://github.com/arangodb/oskar/pull/312

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
