### PR TITLE
fix some issues found during manual fuzzing

### DIFF
--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -154,6 +154,8 @@ static arangodb::Result getReadLockId(network::ConnectionPool* pool,
                                       std::string const& endpoint,
                                       std::string const& database, std::string const& clientId,
                                       double timeout, uint64_t& id) {
+  TRI_ASSERT(timeout > 0);
+
   if (pool == nullptr) {  // nullptr only happens during controlled shutdown
     return arangodb::Result(TRI_ERROR_SHUTTING_DOWN,
                             "startReadLockOnLeader: Shutting down");
@@ -350,7 +352,9 @@ static arangodb::Result cancelReadLockOnLeader(network::ConnectionPool* pool,
                                                std::string const& endpoint,
                                                std::string const& database, uint64_t lockJobId,
                                                std::string const& clientId,
-                                               double timeout = 10.0) {
+                                               double timeout) {
+  TRI_ASSERT(timeout > 0.0);
+
   if (pool == nullptr) {  // nullptr only happens during controlled shutdown
     return arangodb::Result(TRI_ERROR_SHUTTING_DOWN,
                             "cancelReadLockOnLeader: Shutting down");
@@ -400,6 +404,8 @@ arangodb::Result SynchronizeShard::getReadLock(
   std::string const& endpoint, std::string const& database,
   std::string const& collection, std::string const& clientId,
   uint64_t rlid, bool soft, double timeout) {
+
+  TRI_ASSERT(timeout > 0.0);
 
   // This function can be implemented in a more robust manner for server
   // versions > 3.4. Starting with 3.4 the POST requests to the read lock API
@@ -477,6 +483,8 @@ arangodb::Result SynchronizeShard::getReadLock(
 arangodb::Result SynchronizeShard::startReadLockOnLeader(
   std::string const& endpoint, std::string const& database, std::string const& collection,
   std::string const& clientId, uint64_t& rlid, bool soft, double timeout) {
+
+  TRI_ASSERT(timeout > 0);
   // Read lock id
   rlid = 0;
   NetworkFeature& nf = _feature.server().getFeature<NetworkFeature>();

--- a/arangod/Cluster/SynchronizeShard.h
+++ b/arangod/Cluster/SynchronizeShard.h
@@ -62,7 +62,7 @@ class SynchronizeShard : public ActionBase {
   arangodb::Result getReadLock(network::ConnectionPool* pool,
                                std::string const& endpoint, std::string const& database,
                                std::string const& collection, std::string const& clientId,
-                               uint64_t rlid, bool soft, double timeout = 300.0);
+                               uint64_t rlid, bool soft, double timeout);
 
   arangodb::Result startReadLockOnLeader(std::string const& endpoint,
                                          std::string const& database,

--- a/arangod/Network/NetworkFeature.cpp
+++ b/arangod/Network/NetworkFeature.cpp
@@ -330,10 +330,22 @@ void NetworkFeature::finishRequest(network::ConnectionPool const& pool, fuerte::
                                                               req->timestamp());
     std::chrono::milliseconds timeout = req->timeout();
     TRI_ASSERT(timeout.count() > 0);
-    double percentage = std::clamp(100.0 * static_cast<double>(duration.count()) /
-                                       static_cast<double>(timeout.count()),
-                                   0.0, 100.0);
-    _requestDurations.count(percentage);
+    if (timeout.count() > 0) {
+      // only go in here if we are sure to not divide by zero 
+      double percentage = std::clamp(100.0 * static_cast<double>(duration.count()) /
+                                         static_cast<double>(timeout.count()),
+                                     0.0, 100.0);
+      _requestDurations.count(percentage);
+    } else {
+      // the timeout value was 0, for whatever reason. this is unexpected,
+      // but we must not make the program crash here.
+      // so instead log a warning and interpret this as a request that took
+      // 100% of the timeout duration.
+      _requestDurations.count(100.0);
+      LOG_TOPIC("1688c", WARN, Logger::FIXME) 
+          << "encountered invalid 0s timeout for internal request to path " 
+          << req->header.path;
+    }
   }
 }
 

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -3177,7 +3177,7 @@ void RestReplicationHandler::handleCommandRevisionDocuments() {
       }
       VPackSlice res =
           it.hasMore() ? it.document() : velocypack::Slice::emptyObjectSlice();
-      if (size + res.byteSize() > sizeLimit && !response.slice().isEmptyArray()) {
+      if (size + res.byteSize() > sizeLimit && size > 0) {
         break;
       }
       response.add(res);

--- a/arangod/Sharding/ShardDistributionReporter.cpp
+++ b/arangod/Sharding/ShardDistributionReporter.cpp
@@ -341,7 +341,9 @@ void ShardDistributionReporter::helperDistributionForDatabase(
             VPackBuffer<uint8_t> body;
             network::RequestOptions reqOpts;
             reqOpts.database = dbName;
-            reqOpts.timeout = network::Timeout(timeleft);
+            // make sure we have at least 1s for the timeout value. otherwise
+            // other parts of the code may fail when seeing a 0s timeout.
+            reqOpts.timeout = network::Timeout(std::max<double>(1.0, timeleft));
 
             // First Ask the leader
             network::Headers headers;

--- a/tests/js/client/shell/shell-revisions-noncluster.js
+++ b/tests/js/client/shell/shell-revisions-noncluster.js
@@ -1,0 +1,134 @@
+/*jshint globalstrict:false, strict:false, maxlen: 5000 */
+/*global arango, assertEqual, assertTrue, assertFalse, assertMatch */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test the revisions
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const arangodb = require("@arangodb");
+const db = arangodb.db;
+
+function RevisionsSuite () {
+  'use strict';
+
+  const cn = "UnitTestsCollection";
+
+  let revs = [];
+      
+  return {
+    setUp: function () {
+      db._drop(cn);
+      let c = db._create(cn);
+
+      revs = [];
+      let docs = [];
+      for (let i = 0; i < 20000; ++i) {
+        docs.push({ _key: "testi" + i, value1: "testi" + i, value2: "testi" + i });
+        if (docs.length >= 5000) {
+          revs = revs.concat(c.insert(docs).map((doc) => doc._rev));
+          docs = [];
+        }
+      }
+    },
+
+    tearDown: function () {
+      db._drop(cn);
+    },
+    
+    testCallRevisionDocumentsApiReverse: function () {
+      let res = arango.POST("/_api/replication/batch", {});
+      let batchId = res.id;
+
+      let n = 1000;
+      let i = 0;
+      let filteredRevs = revs.filter((rev) => i++ % n === 0);
+
+      assertEqual(20, filteredRevs.length);
+      filteredRevs = filteredRevs.reverse();
+
+      try {
+        res = arango.PUT("/_api/replication/revisions/documents?collection=" + cn + "&batchId=" + batchId + "&chunkSize=16384", filteredRevs);
+        assertTrue(Array.isArray(res));
+        assertEqual(20, res.length);
+        res.forEach((doc) => {
+          assertMatch(/^testi\d+$/, doc._key);
+        });
+      } finally {
+        res = arango.DELETE("/_api/replication/batch/" + batchId);
+        assertTrue(res.hasOwnProperty("error"));
+        assertFalse(res.error);
+      }
+    },
+    
+    testCallRevisionDocumentsApiSome: function () {
+      let res = arango.POST("/_api/replication/batch", {});
+      let batchId = res.id;
+
+      let n = 1000;
+      let i = 0;
+      let filteredRevs = revs.filter((rev) => i++ % n === 0);
+
+      assertEqual(20, filteredRevs.length);
+
+      try {
+        res = arango.PUT("/_api/replication/revisions/documents?collection=" + cn + "&batchId=" + batchId + "&chunkSize=16384", filteredRevs);
+        assertTrue(Array.isArray(res));
+        assertEqual(20, res.length);
+        res.forEach((doc) => {
+          assertMatch(/^testi\d+$/, doc._key);
+        });
+      } finally {
+        res = arango.DELETE("/_api/replication/batch/" + batchId);
+        assertTrue(res.hasOwnProperty("error"));
+        assertFalse(res.error);
+      }
+    },
+
+    testCallRevisionDocumentsApiAll: function () {
+      let res = arango.POST("/_api/replication/batch", {});
+      let batchId = res.id;
+
+      let allRevs = revs;
+      try {
+        res = arango.PUT("/_api/replication/revisions/documents?collection=" + cn + "&batchId=" + batchId + "&chunkSize=16384", allRevs);
+        assertTrue(Array.isArray(res));
+        assertTrue(res.length > 100);
+        assertTrue(res.length <= 1000);
+        res.forEach((doc) => {
+          assertMatch(/^testi\d+$/, doc._key);
+        });
+      } finally {
+        res = arango.DELETE("/_api/replication/batch/" + batchId);
+        assertTrue(res.hasOwnProperty("error"));
+        assertFalse(res.error);
+      }
+    }
+
+  };
+}
+
+jsunity.run(RevisionsSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Fix an invalid internal timeout value of 0s, which lead to an assertion failure/division by zero issue.
Fix an internal "builder value not yet sealed" error when exchanging revision tree parts.
Both issues are present in 3.8/devel only.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
