### PR TITLE
Bug fix/bts 357

### DIFF
--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -527,8 +527,9 @@ arangodb::aql::AqlValue aqlFnTokens(arangodb::aql::ExpressionContext* expression
   }
 
   auto* token = irs::get<irs::term_attribute>(*analyzer);
+  auto* vpack_token = irs::get<VPackTermAttribute>(*analyzer);
 
-  if (ADB_UNLIKELY(!token)) {
+  if (ADB_UNLIKELY(!token && !vpack_token)) {
     auto const message =
         "failure to retrieve values from arangosearch analyzer name '"s +
         static_cast<std::string>(name) +
@@ -547,6 +548,46 @@ arangodb::aql::AqlValue aqlFnTokens(arangodb::aql::ExpressionContext* expression
   VPackBuilder builder(buffer);
   builder.openArray();
   std::vector<VPackArrayIterator> arrayIteratorStack;
+
+  auto processNumeric = [&numeric_analyzer, &numeric_token, &builder](VPackSlice value) {
+    if (value.isNumber()) { // there are many "number" types. To adopt all current and future ones just
+                              // deal with them all here in generic way
+      if (!numeric_analyzer) {
+        numeric_analyzer = std::make_unique<irs::numeric_token_stream>();
+        numeric_token = irs::get<irs::term_attribute>(*numeric_analyzer);
+        if (ADB_UNLIKELY(!numeric_token)) {
+          auto const message =
+            "failure to retrieve values from arangosearch numeric analyzer "
+            "while computing result for function 'TOKENS'";
+          LOG_TOPIC("7d5df", WARN, arangodb::iresearch::TOPIC) << message;
+          THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, message);
+        }
+      }
+      // we read all numers as doubles because ArangoSearch indexes
+      // all numbers as doubles, so do we there, as out goal is to
+      // return same tokens as will be in index for this specific number
+      numeric_analyzer->reset(value.getNumber<double>());
+      while (numeric_analyzer->next()) {
+        builder.add(
+          arangodb::iresearch::toValuePair(
+            arangodb::basics::StringUtils::encodeBase64(
+                irs::ref_cast<char>(numeric_token->value))));
+      }
+    } else {
+      auto const message = "unexpected parameter type '"s + value.typeName() +
+        "' while computing result for function 'TOKENS'";
+      LOG_TOPIC("45a2e", WARN, arangodb::iresearch::TOPIC) << message;
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER, message);
+    }
+  };
+
+  auto processBool = [&builder](VPackSlice value) {
+    builder.add(
+      arangodb::iresearch::toValuePair(
+        basics::StringUtils::encodeBase64(irs::ref_cast<char>(
+          irs::boolean_token_stream::value(value.getBoolean())))));
+  };
+
   auto current = args[0].slice();
   do {
     // stack opening non-empty arrays
@@ -583,16 +624,39 @@ arangodb::aql::AqlValue aqlFnTokens(arangodb::aql::ExpressionContext* expression
           LOG_TOPIC("45a2d", WARN, arangodb::iresearch::TOPIC) << message;
           THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, message);
         }
-        while (analyzer->next()) {
-          builder.add(
-            arangodb::iresearch::toValuePair(irs::ref_cast<char>(token->value)));
+        switch (pool->returnType()) {
+          case AnalyzerValueType::String:
+            TRI_ASSERT(token);
+            while (analyzer->next()) {
+              builder.add(
+                arangodb::iresearch::toValuePair(irs::ref_cast<char>(token->value)));
+            }
+            break;
+          case AnalyzerValueType::Number:
+            TRI_ASSERT(vpack_token);
+            while (analyzer->next()) {
+              VPackArrayBuilder arr(&builder);
+              TRI_ASSERT(vpack_token->value.isNumber());
+              processNumeric(vpack_token->value);
+            }
+            break;
+          case AnalyzerValueType::Bool:
+            TRI_ASSERT(vpack_token);
+            while (analyzer->next()) {
+              VPackArrayBuilder arr(&builder);
+              TRI_ASSERT(vpack_token->value.isBool());
+              processBool(vpack_token->value);
+            }
+            break;
+          default:
+            TRI_ASSERT(false);
+            LOG_TOPIC("1c838", WARN, arangodb::iresearch::TOPIC) << "Unexpected custom analyzer return type "
+              <<   static_cast<std::underlying_type_t<AnalyzerValueType>>(pool->returnType());
+            break;
         }
       } break;
       case VPackValueType::Bool:
-        builder.add(
-          arangodb::iresearch::toValuePair(
-            basics::StringUtils::encodeBase64(irs::ref_cast<char>(
-              irs::boolean_token_stream::value(current.getBoolean())))));
+        processBool(current);
         break;
       case VPackValueType::Null:
         builder.add(
@@ -607,35 +671,7 @@ arangodb::aql::AqlValue aqlFnTokens(arangodb::aql::ExpressionContext* expression
         builder.close();
         break;
       default:
-        if (current.isNumber()) { // there are many "number" types. To adopt all current and future ones just
-                                  // deal with them all here in generic way
-          if (!numeric_analyzer) {
-            numeric_analyzer = std::make_unique<irs::numeric_token_stream>();
-            numeric_token = irs::get<irs::term_attribute>(*numeric_analyzer);
-            if (ADB_UNLIKELY(!numeric_token)) {
-              auto const message =
-                "failure to retrieve values from arangosearch numeric analyzer "
-                "while computing result for function 'TOKENS'";
-              LOG_TOPIC("7d5df", WARN, arangodb::iresearch::TOPIC) << message;
-              THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, message);
-            }
-          }
-          // we read all numers as doubles because ArangoSearch indexes
-          // all numbers as doubles, so do we there, as out goal is to
-          // return same tokens as will be in index for this specific number
-          numeric_analyzer->reset(current.getNumber<double>());
-          while (numeric_analyzer->next()) {
-            builder.add(
-              arangodb::iresearch::toValuePair(
-                arangodb::basics::StringUtils::encodeBase64(
-                    irs::ref_cast<char>(numeric_token->value))));
-          }
-        } else {
-          auto const message = "unexpected parameter type '"s + current.typeName() +
-            "' while computing result for function 'TOKENS'";
-          LOG_TOPIC("45a2e", WARN, arangodb::iresearch::TOPIC) << message;
-          THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER, message);
-        }
+        processNumeric(current);
     }
     // de-stack all closing arrays
     while (!arrayIteratorStack.empty()) {

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -564,7 +564,7 @@ arangodb::aql::AqlValue aqlFnTokens(arangodb::aql::ExpressionContext* expression
         }
       }
       // we read all numers as doubles because ArangoSearch indexes
-      // all numbers as doubles, so do we there, as out goal is to
+      // all numbers as doubles, so do we there, as our goal is to
       // return same tokens as will be in index for this specific number
       numeric_analyzer->reset(value.getNumber<double>());
       while (numeric_analyzer->next()) {

--- a/tests/IResearch/IResearchAnalyzerFeature-test.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeature-test.cpp
@@ -56,6 +56,7 @@
 #include "IResearch/IResearchAnalyzerFeature.h"
 #include "IResearch/IResearchCommon.h"
 #include "IResearch/IResearchFeature.h"
+#include "IResearch/IResearchVPackTermAttribute.h"
 #include "IResearch/VelocyPackHelper.h"
 #include "Indexes/IndexFactory.h"
 #include "Network/NetworkFeature.h"
@@ -254,6 +255,105 @@ class TestAnalyzer : public irs::analysis::analyzer {
 };
 
 REGISTER_ANALYZER_VPACK(TestAnalyzer, TestAnalyzer::make, TestAnalyzer::normalize);
+
+
+class TestTokensTypedAnalyzer : public irs::analysis::analyzer {
+ public:
+  static constexpr irs::string_ref type_name() noexcept {
+    return "iresearch-tokens-typed";
+  }
+
+  static ptr make(irs::string_ref const& args) {
+    PTR_NAMED(TestTokensTypedAnalyzer, ptr, args);
+    return ptr;
+  }
+
+  static bool normalize(irs::string_ref const& args, std::string& out) {
+    out.assign(args.c_str(), args.size());
+    return true;
+  }
+
+  explicit TestTokensTypedAnalyzer(irs::string_ref const& args) : irs::analysis::analyzer(irs::type<TestTokensTypedAnalyzer>::get()) {
+    VPackSlice slice(irs::ref_cast<irs::byte_type>(args).c_str());
+    if (slice.hasKey("type")) {
+      auto type = slice.get("type").stringRef();
+      if (type == "number") {
+        _returnType.value = arangodb::iresearch::AnalyzerValueType::Number;
+        _typedValue = arangodb::aql::AqlValue(arangodb::aql::AqlValueHintDouble(1));
+        _vpackTerm.value = _typedValue.slice();
+      } else if (type == "bool") {
+         _returnType.value = arangodb::iresearch::AnalyzerValueType::Bool;
+      } else if (type == "string") {
+         _returnType.value = arangodb::iresearch::AnalyzerValueType::String;
+         _term.value = irs::ref_cast<irs::byte_type>(_strVal);
+      } else {
+        // Failure here means we have unexpected type
+        EXPECT_TRUE(false);
+      }
+    }
+  }
+
+  virtual bool reset(irs::string_ref const& data) override {
+    switch (_returnType.value) {
+      case arangodb::iresearch::AnalyzerValueType::Bool:
+        _typedValue = arangodb::aql::AqlValue(arangodb::aql::AqlValueHintBool(!data.null()));
+        _vpackTerm.value = _typedValue.slice();
+        break;
+      case arangodb::iresearch::AnalyzerValueType::Number:
+        _typedValue = arangodb::aql::AqlValue(arangodb::aql::AqlValueHintDouble(data.null() ? 0 : 1));
+        _vpackTerm.value = _typedValue.slice();
+        break;
+      case arangodb::iresearch::AnalyzerValueType::String:
+        if (!data.null()) {
+          _strVal = data;
+        } else {
+          _strVal.clear();
+        }
+        _term.value = irs::ref_cast<irs::byte_type>(_strVal);
+        break;
+    }
+    _resetted = true;
+    return true;
+  }
+
+  virtual bool next() override {
+    if (_resetted) {
+      _resetted = false;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  virtual irs::attribute* get_mutable(irs::type_info::type_id type) noexcept override {
+    if (type == irs::type<irs::term_attribute>::id()) {
+      return &_term;
+    }
+    if (type == irs::type<irs::increment>::id()) {
+      return &_inc;
+    }
+    if (type == irs::type<arangodb::iresearch::AnalyzerValueTypeAttribute>::id()) {
+      return &_returnType;
+    }
+    if (type == irs::type<arangodb::iresearch::VPackTermAttribute>::id()) {
+      return &_vpackTerm;
+    }
+    return nullptr;
+  }
+
+ private:
+  std::string _strVal;
+  irs::term_attribute _term;
+  arangodb::iresearch::VPackTermAttribute _vpackTerm;
+  irs::increment _inc;
+  bool _resetted{false};
+  arangodb::iresearch::AnalyzerValueTypeAttribute _returnType;
+  arangodb::aql::AqlValue _typedValue;
+};
+
+REGISTER_ANALYZER_VPACK(TestTokensTypedAnalyzer, TestTokensTypedAnalyzer::make,
+                        TestTokensTypedAnalyzer::normalize);
+
 
 struct Analyzer {
   irs::string_ref type;
@@ -2703,6 +2803,16 @@ TEST_F(IResearchAnalyzerFeatureTest, test_tokens) {
                    .emplace(result, arangodb::StaticStrings::SystemDatabase + "::test_analyzer",
                             "TestAnalyzer", VPackParser::fromJson("\"abc\"")->slice())
                    .ok()));
+  ASSERT_TRUE(
+      (true == analyzers
+                   .emplace(result, arangodb::StaticStrings::SystemDatabase + "::test_number_analyzer",
+                            "iresearch-tokens-typed", VPackParser::fromJson("{\"type\":\"number\"}")->slice())
+                   .ok()));
+  ASSERT_TRUE(
+      (true == analyzers
+                   .emplace(result, arangodb::StaticStrings::SystemDatabase + "::test_bool_analyzer",
+                            "iresearch-tokens-typed", VPackParser::fromJson("{\"type\":\"bool\"}")->slice())
+                   .ok()));
   ASSERT_FALSE(!result.first);
 
   arangodb::SingleCollectionTransaction trx(
@@ -2746,6 +2856,49 @@ TEST_F(IResearchAnalyzerFeatureTest, test_tokens) {
     auto value = entry.slice().copyString();
     EXPECT_EQ(data, value);
   }
+
+  // test typed analyzer tokenization BTS-357
+  {
+    std::string analyzer(arangodb::StaticStrings::SystemDatabase +
+                         "::test_number_analyzer");
+    irs::string_ref data("abcdefghijklmnopqrstuvwxyz");
+    VPackFunctionParametersWrapper args;
+    args->emplace_back(data.c_str(), data.size());
+    args->emplace_back(analyzer.c_str(), analyzer.size());
+    AqlValueWrapper result(impl(&exprCtx, node, *args));
+    EXPECT_TRUE(result->isArray());
+    EXPECT_EQ(4, result->length());
+    std::string expected1[] = {"oL/wAAAAAAAA",
+                               "sL/wAAAAAA==", "wL/wAAA=", "0L/w"};
+    for (size_t i = 0; i < result->length(); ++i) {
+      bool mustDestroy;
+      auto entry = result->at(i, mustDestroy, false).slice();
+      EXPECT_TRUE(entry.isString());
+      EXPECT_EQ(expected1[i], arangodb::iresearch::getStringRef(entry));
+    }
+  }
+
+  // test typed analyzer tokenization BTS-357
+  {
+    std::string analyzer(arangodb::StaticStrings::SystemDatabase +
+                         "::test_bool_analyzer");
+    irs::string_ref data("abcdefghijklmnopqrstuvwxyz");
+    VPackFunctionParametersWrapper args;
+    args->emplace_back(data.c_str(), data.size());
+    args->emplace_back(analyzer.c_str(), analyzer.size());
+    AqlValueWrapper result(impl(&exprCtx, node, *args));
+    EXPECT_TRUE(result->isArray());
+    EXPECT_EQ(1, result->length());
+    std::string expected1[] = {"/w=="};
+    for (size_t i = 0; i < result->length(); ++i) {
+      bool mustDestroy;
+      auto entry = result->at(i, mustDestroy, false).slice();
+      EXPECT_TRUE(entry.isString());
+      EXPECT_EQ(expected1[i], arangodb::iresearch::getStringRef(entry));
+    }
+  }
+
+
 
   // test invalid arg count
   // Zero count (less than expected)

--- a/tests/IResearch/IResearchAnalyzerFeature-test.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeature-test.cpp
@@ -317,6 +317,10 @@ class TestTokensTypedAnalyzer : public irs::analysis::analyzer {
         case arangodb::iresearch::AnalyzerValueType::String:
           _term.value = irs::ref_cast<irs::byte_type>(_strVal);
           break;
+        default:
+          // New return type was added?
+          EXPECT_TRUE(false);
+          break;
       }
       _strVal.pop_back();
       return true;

--- a/tests/js/common/aql/aql-view-arangosearch-feature.js
+++ b/tests/js/common/aql/aql-view-arangosearch-feature.js
@@ -815,6 +815,23 @@ function iResearchFeatureAqlTestSuite () {
       }
 
     },
+    
+    testTokensFunctionWithNumberAnalyzer : function() {
+      let analyzer = analyzers.save("gd","aql",
+        { queryString: "RETURN @param",
+          returnType: "number"}, []);
+      assertNotNull(analyzer);
+      try {
+        let result = db._query("RETURN TOKENS('1', 'gd')").toArray();
+        assertEqual(1, result.length);
+        assertTrue(Array === result[0].constructor);
+        assertEqual(1, result[0].length);
+        assertEqual([["oL/wAAAAAAAA", "sL/wAAAAAA==", "wL/wAAA=", "0L/w"]],
+                    result[0]);
+      } finally {
+        analyzers.remove("gd");
+      }
+    },
 
     testDefaultAnalyzers : function() {
       // invalid

--- a/tests/js/common/aql/aql-view-arangosearch-feature.js
+++ b/tests/js/common/aql/aql-view-arangosearch-feature.js
@@ -829,7 +829,7 @@ function iResearchFeatureAqlTestSuite () {
         assertEqual([["oL/wAAAAAAAA", "sL/wAAAAAA==", "wL/wAAA=", "0L/w"]],
                     result[0]);
       } finally {
-        analyzers.remove("gd");
+        analyzers.remove("gd", true);
       }
     },
 


### PR DESCRIPTION
Fix for BTS-357
TOKENS function will now correctly process analyzer with non-string value types

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [x] Backports required for:  3.8
