### PR TITLE
Added error handling for cluster figures command

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.7.11 (XXXX-XX-XX)
 --------------------
 
+* Added error handling for figures command in cluster. Previously errors
+  returned by shards were ignored when aggregating the individual responses.
+
 * Fixed issue BTS-353: memleak when running into an out-of-memory situation
   while repurposing an existing AqlItemBlock.
 

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -1115,15 +1115,20 @@ futures::Future<OperationResult> figuresOnCoordinator(ClusterFeature& feature,
   auto cb = [details](std::vector<Try<network::Response>>&& results) mutable -> OperationResult {
     auto handler = [details](Result& result, VPackBuilder& builder, ShardID&,
                              VPackSlice answer) mutable -> void {
-      if (answer.isObject()) {
-        VPackSlice figures = answer.get("figures");
-        // add to the total
-        if (figures.isObject()) {
-          aggregateClusterFigures(details, false, figures, builder);
-        }
-      } else {
+      if (!answer.isObject()) {
         // didn't get the expected response
         result.reset(TRI_ERROR_INTERNAL);
+      } else if (!result.fail()) {
+        Result r = network::resultFromBody(answer, TRI_ERROR_NO_ERROR);
+        if (r.fail()) {
+          result.reset(r);
+        } else {
+          VPackSlice figures = answer.get("figures");
+          // add to the total
+          if (figures.isObject()) {
+            aggregateClusterFigures(details, false, figures, builder);
+          }
+        }
       }
     };
     auto pre = [](Result&, VPackBuilder& builder) -> void {

--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -736,6 +736,9 @@ futures::Future<futures::Unit> RestCollectionHandler::collectionRepresentationAs
 
   return std::move(figures)
       .thenValue([=, &ctxt](OperationResult&& figures) -> futures::Future<OperationResult> {
+        if (figures.fail()) {
+          THROW_ARANGO_EXCEPTION(figures.result);
+        }
         if (figures.buffer) {
           _builder.add("figures", figures.slice());
         }


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/13931

Added error handling for figures command in cluster. Previously errors returned by shards were ignored when aggregating the individual responses.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.6*

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
