### PR TITLE
deprecate startup options `--http.hide-product-header` and `--http.allow-method-override`

### DIFF
--- a/arangod/GeneralServer/GeneralServerFeature.cpp
+++ b/arangod/GeneralServer/GeneralServerFeature.cpp
@@ -160,7 +160,8 @@ void GeneralServerFeature::collectOptions(std::shared_ptr<ProgramOptions> option
   options->addOption("--http.allow-method-override",
                      "allow HTTP method override using special headers",
                      new BooleanParameter(&_allowMethodOverride),
-                     arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden));
+                     arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden))
+                     .setDeprecatedIn(30800);
 
   options->addOption("--http.keep-alive-timeout",
                      "keep-alive timeout in seconds",
@@ -169,7 +170,8 @@ void GeneralServerFeature::collectOptions(std::shared_ptr<ProgramOptions> option
   options->addOption(
       "--http.hide-product-header",
       "do not expose \"Server: ArangoDB\" header in HTTP responses",
-      new BooleanParameter(&HttpResponse::HIDE_PRODUCT_HEADER));
+      new BooleanParameter(&HttpResponse::HIDE_PRODUCT_HEADER))
+      .setDeprecatedIn(30800);
 
   options->addOption("--http.trusted-origin",
                      "trusted origin URLs for CORS requests with credentials",


### PR DESCRIPTION
### Scope & Purpose

Deprecate startup options `--http.hide-product-header` and `--http.allow-method-override`.
These options are seldomly used and do not provide a lot of value.
The options are only marked as deprecated by this PR, but are still functional.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*: https://github.com/arangodb/arangodb/pull/13947

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/677

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
