### PR TITLE
Bug fix 3.8/bts 346

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,10 +3,10 @@ v3.8.0 (XXXX-XX-XX)
 
 * Fix BTS-346: Improved handling of AQL query kill command in unlikely
   places, before the query starts to execute and after the query is done
-  but the result is still beeing written. Now the cleanup of queries works
-  more reliably. This unreliable kil time-frames are very small and unlikely
-  to hit, if one was hit transactions were not aborted, and locks could be
-  left until query timeout.
+  but the result is still being written. Now the cleanup of queries works
+  more reliably. This unreliable kill time windows were very short and 
+  unlikely to hit, although if one was hit transactions were not aborted, 
+  and collection locks could be lingering until query timeout.
 
 * Updated ArangoDB Starter to 0.15.0.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 v3.8.0 (XXXX-XX-XX)
 -------------------
 
+* Fix BTS-346: Improved handling of AQL query kill command in unlikely
+  places, before the query starts to execute and after the query is done
+  but the result is still beeing written. Now the cleanup of queries works
+  more reliably. This unreliable kil time-frames are very small and unlikely
+  to hit, if one was hit transactions were not aborted, and locks could be
+  left until query timeout.
+
 * Updated ArangoDB Starter to 0.15.0.
 
 * Fix BTS-357: Fix processing of analyzer with return type by TOKENS function.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,12 @@
 v3.8.0 (XXXX-XX-XX)
 -------------------
 
-* Fix BTS-346: Improved handling of AQL query kill command in unlikely
-  places, before the query starts to execute and after the query is done
-  but the result is still being written. Now the cleanup of queries works
-  more reliably. This unreliable kill time windows were very short and 
-  unlikely to hit, although if one was hit transactions were not aborted, 
-  and collection locks could be lingering until query timeout.
+* Fix BTS-346: Improved handling of AQL query kill command in unlikely places,
+  before the query starts to execute and after the query is done but the result
+  is still being written. Now the cleanup of queries works more reliably. This
+  unreliable kill time windows were very short and unlikely to hit, although if
+  one was hit transactions were not aborted, and collection locks could be
+  lingering until query timeout.
 
 * Updated ArangoDB Starter to 0.15.0.
 

--- a/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
+++ b/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
@@ -35,6 +35,7 @@
 #include "Utils/CollectionNameResolver.h"
 
 #include <set>
+#include <velocypack/Collection.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;
@@ -499,8 +500,17 @@ Result EngineInfoContainerDBServerServerBased::buildEngines(
       serverBefore = server;
 #endif
       VPackSlice infoSlice{buffer->data()};
+      // We need to rewrite the request.
+      // We have modified the options locally so we need to update the VPack representation of Options here.
+      // Note: There may be a more optimized variant, but we have just waited 2 seconds and will linearly
+      // lock all servers, any performance optimization here will not have measureable impact.
+      VPackBuilder overwrittenOptions;
+      overwrittenOptions.openObject();
+      addOptionsPart(overwrittenOptions, server);
+      overwrittenOptions.close();
+      auto newRequest = arangodb::velocypack::Collection::merge(infoSlice, overwrittenOptions.slice(), false);
 
-      auto request = buildSetupRequest(trx, std::move(server), infoSlice,
+      auto request = buildSetupRequest(trx, std::move(server), newRequest.slice(),
                                        std::move(didCreateEngine), snippetIds, serverToQueryId,
                                        serverToQueryIdLock, pool, options);
       _query.incHttpRequests(unsigned(1));

--- a/arangod/Aql/ExecutionEngine.cpp
+++ b/arangod/Aql/ExecutionEngine.cpp
@@ -543,7 +543,17 @@ auto ExecutionEngine::execute(AqlCallStack const& stack)
   if (_query.killed()) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
   }
+
+  TRI_IF_FAILURE("ExecutionEngine::directKillBeforeAQLQueryExecute") {
+    _query.debugKillQuery();
+  }
+
   auto const res = _root->execute(stack);
+
+  TRI_IF_FAILURE("ExecutionEngine::directKillAfterAQLQueryExecute") {
+    _query.debugKillQuery();
+  }
+
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if (std::get<ExecutionState>(res) == ExecutionState::WAITING) {
     auto const skipped = std::get<SkipResult>(res);
@@ -594,7 +604,7 @@ std::pair<ExecutionState, SharedAqlItemBlockPtr> ExecutionEngine::getSome(size_t
   // we use a backwards compatible stack here.
   // This will always continue with a fetch-all on underlying subqueries (if any)
   AqlCallStack compatibilityStack{AqlCallList{AqlCall::SimulateGetSome(atMost)}};
-  auto const [state, skipped, block] = _root->execute(std::move(compatibilityStack));
+  auto const [state, skipped, block] = execute(std::move(compatibilityStack));
   // We cannot trigger a skip operation from here
   TRI_ASSERT(skipped.nothingSkipped());
   return {state, std::move(block)};
@@ -614,7 +624,7 @@ std::pair<ExecutionState, size_t> ExecutionEngine::skipSome(size_t atMost) {
   // we use a backwards compatible stack here.
   // This will always continue with a fetch-all on underlying subqueries (if any)
   AqlCallStack compatibilityStack{AqlCallList{AqlCall::SimulateSkipSome(atMost)}};
-  auto const [state, skipped, block] = _root->execute(std::move(compatibilityStack));
+  auto const [state, skipped, block] = execute(std::move(compatibilityStack));
   // We cannot be triggered within a subquery from earlier versions.
   // Also we cannot produce anything ourselfes here.
   TRI_ASSERT(block == nullptr);

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -37,6 +37,7 @@
 #include "Aql/PlanCache.h"
 #include "Aql/QueryCache.h"
 #include "Aql/QueryExecutionState.h"
+#include "Aql/QueryList.h"
 #include "Aql/QueryProfile.h"
 #include "Aql/QueryRegistry.h"
 #include "Aql/Timing.h"
@@ -151,7 +152,7 @@ Query::Query(std::shared_ptr<transaction::Context> const& ctx,
   // set memory limit for query
   _resourceMonitor.memoryLimit(_queryOptions.memoryLimit);
   _warnings.updateOptions(_queryOptions);
-  
+
   // store name of user that started the query
   _user = ExecContext::current().user();
 }
@@ -182,7 +183,7 @@ Query::~Query() {
   }
 
   _queryProfile.reset(); // unregister from QueryList
-  
+
   // log to audit log
   if (!_queryOptions.skipAudit &&
      (ServerState::instance()->isCoordinator() ||
@@ -199,10 +200,10 @@ Query::~Query() {
     ExecutionState state = cleanupPlanAndEngine(TRI_ERROR_INTERNAL, /*sync*/true);
     TRI_ASSERT(state != ExecutionState::WAITING);
   } catch (...) {
-    // unfortunately we cannot do anything here, as we are in 
+    // unfortunately we cannot do anything here, as we are in
     // the destructor
   }
-  
+
   unregisterSnippets();
 
   exitV8Context();
@@ -210,12 +211,12 @@ Query::~Query() {
   _snippets.clear(); // simon: must be before plan
   _plans.clear(); // simon: must be before AST
   _ast.reset();
-  
+
   LOG_TOPIC("f5cee", DEBUG, Logger::QUERIES)
       << elapsedSince(_startTime)
       << " Query::~Query this: " << (uintptr_t)this;
 }
-  
+
 /// @brief return the user that started the query
 std::string const& Query::user() const {
   return _user;
@@ -239,20 +240,21 @@ bool Query::killed() const {
 
 /// @brief set the query to killed
 void Query::kill() {
-  _queryKilled = true;
-  
-  if (_trx->state()->isCoordinator()) {
+  if (ServerState::instance()->isCoordinator() && !_queryKilled) {
+    _queryKilled = true;
     this->cleanupPlanAndEngine(TRI_ERROR_QUERY_KILLED, /*sync*/false);
+  } else {
+    _queryKilled = true;
   }
 }
-  
+
 /// @brief return the start time of the query (steady clock value)
 double Query::startTime() const noexcept { return _startTime; }
 
 void Query::prepareQuery(SerializationFormat format) {
   try {
     init(/*createProfile*/ true);
-    
+
     enterState(QueryExecutionState::ValueType::PARSING);
 
     std::unique_ptr<ExecutionPlan> plan = preparePlan();
@@ -261,7 +263,7 @@ void Query::prepareQuery(SerializationFormat format) {
 
     TRI_ASSERT(_trx != nullptr);
     TRI_ASSERT(_trx->status() == transaction::Status::RUNNING);
-    
+
     // keep serialized copy of unchanged plan to include in query profile
     // necessary because instantiate / execution replace vars and blocks
     bool const keepPlan = _queryOptions.profile >= ProfileLevel::Blocks &&
@@ -286,11 +288,11 @@ void Query::prepareQuery(SerializationFormat format) {
       }
       registry->registerSnippets(_snippets);
     }
-    
+
     if (_queryProfile) {
       _queryProfile->registerInQueryList();
     }
-    
+
     enterState(QueryExecutionState::ValueType::EXECUTION);
   } catch (arangodb::basics::Exception const& ex) {
     _resultCode = ex.code();
@@ -378,7 +380,7 @@ ExecutionState Query::execute(QueryResult& queryResult) {
   LOG_TOPIC("e8ed7", DEBUG, Logger::QUERIES) << elapsedSince(_startTime)
                                              << " Query::execute"
                                              << " this: " << (uintptr_t)this;
-    
+
   try {
     if (killed()) {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
@@ -422,7 +424,7 @@ ExecutionState Query::execute(QueryResult& queryResult) {
         // reserve some space in Builder to avoid frequent reallocs
         queryResult.data->reserve(16 * 1024);
         queryResult.data->openArray(/*unindexed*/true);
-        
+
         _executionPhase = ExecutionPhase::EXECUTE;
       }
       [[fallthrough]];
@@ -555,7 +557,7 @@ ExecutionState Query::execute(QueryResult& queryResult) {
                                     QueryExecutionState::toStringWithPrefix(_execState))));
     cleanupPlanAndEngine(TRI_ERROR_INTERNAL, /*sync*/true);
   }
-  
+
   return ExecutionState::DONE;
 }
 
@@ -661,6 +663,9 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
       ExecutionState state = ExecutionState::HASMORE;
       auto context = TRI_IGETC;
       while (state != ExecutionState::DONE) {
+        if (killed()) {
+          THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
+        }
         auto res = engine->getSome(ExecutionBlock::DefaultBatchSize);
         state = res.first;
         while (state == ExecutionState::WAITING) {
@@ -678,6 +683,9 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
         }
 
         if (!_queryOptions.silent && resultRegister.isValid()) {
+          TRI_IF_FAILURE("Query::executeV8directKillBeforeQueryResultIsGettingHandled") {
+            debugKillQuery();
+          }
           size_t memoryUsage = 0;
           size_t const n = value->numRows();
 
@@ -707,10 +715,10 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
           // this may throw
           _resourceMonitor.increaseMemoryUsage(memoryUsage);
           _resultMemoryUsage += memoryUsage;
-        }
 
-        if (killed()) {
-          THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
+          TRI_IF_FAILURE("Query::executeV8directKillAfterQueryResultIsGettingHandled") {
+            debugKillQuery();
+          }
         }
       }
 
@@ -745,7 +753,7 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
     }
 
     ss->resetWakeupHandler();
-    
+
     // will set warnings, stats, profile and cleanup plan and engine
     ExecutionState state = finalize(*queryResult.extra);
     while (state == ExecutionState::WAITING) {
@@ -790,15 +798,15 @@ ExecutionState Query::finalize(VPackBuilder& extras) {
     // is about to shut down/be destroyed
     _queryProfile->unregisterFromQueryList();
   }
-  
+
   auto state = cleanupPlanAndEngine(TRI_ERROR_NO_ERROR, /*sync*/false);
   if (state == ExecutionState::WAITING) {
     return state;
   }
-  
+
   extras.openObject(/*unindexed*/true);
   _warnings.toVelocyPack(extras);
-  
+
   if (!_snippets.empty()) {
     _execStats.requests += _numRequests.load(std::memory_order_relaxed);
     _execStats.setPeakMemoryUsage(_resourceMonitor.peak());
@@ -809,7 +817,7 @@ ExecutionState Query::finalize(VPackBuilder& extras) {
 
     extras.add(VPackValue("stats"));
     _execStats.toVelocyPack(extras, _queryOptions.fullCount);
-    
+
     if (_planSliceCopy) {
       extras.add("plan", VPackSlice(_planSliceCopy->data()));
     }
@@ -989,7 +997,7 @@ void Query::enterV8Context() {
       v8g->_transactionState = _trx->stateShrdPtr();
     }
   };
-  
+
   if (!_contextOwnedByExterior) {
     if (_v8Context == nullptr) {
       auto& server = vocbase().server();
@@ -1167,7 +1175,7 @@ ExecutionState Query::cleanupPlanAndEngine(ErrorCode errorCode, bool sync) {
       state = cleanupTrxAndEngines(errorCode);
     }
   }
-  
+
   return cleanupTrxAndEngines(errorCode);
 }
 
@@ -1243,13 +1251,13 @@ futures::Future<Result> finishDBServerParts(Query& query, ErrorCode errorCode) {
   TRI_ASSERT(ServerState::instance()->isCoordinator());
   auto& serverQueryIds = query.serverQueryIds();
   TRI_ASSERT(!serverQueryIds.empty());
-  
+
   NetworkFeature const& nf = query.vocbase().server().getFeature<NetworkFeature>();
   network::ConnectionPool* pool = nf.pool();
   if (pool == nullptr) {
     return futures::makeFuture(Result{TRI_ERROR_SHUTTING_DOWN});
   }
-  
+
   network::RequestOptions options;
   options.database = query.vocbase().name();
   options.timeout = network::Timeout(60.0);  // Picked arbitrarily
@@ -1261,9 +1269,9 @@ futures::Future<Result> finishDBServerParts(Query& query, ErrorCode errorCode) {
   builder.openObject(true);
   builder.add(StaticStrings::Code, VPackValue(errorCode));
   builder.close();
-  
+
   query.incHttpRequests(static_cast<unsigned>(serverQueryIds.size()));
-   
+
   std::vector<futures::Future<Result>> futures;
   futures.reserve(serverQueryIds.size());
   auto ss = query.sharedState();
@@ -1272,7 +1280,7 @@ futures::Future<Result> finishDBServerParts(Query& query, ErrorCode errorCode) {
   for (auto const& [serverDst, queryId] : serverQueryIds) {
 
     TRI_ASSERT(serverDst.substr(0, 7) == "server:");
-    
+
     auto f = network::sendRequest(pool, serverDst, fuerte::RestVerb::Delete,
                          "/_api/aql/finish/" + std::to_string(queryId), body, options)
     .thenValue([ss, &query](network::Response&& res) mutable -> Result {
@@ -1283,7 +1291,7 @@ futures::Future<Result> finishDBServerParts(Query& query, ErrorCode errorCode) {
           return Result(TRI_ERROR_CLUSTER_AQL_COMMUNICATION,
                         "shutdown response of DBServer is malformed");
         }
-        
+
         VPackSlice val = res.slice().get("stats");
         if (val.isObject()) {
           ss->executeLocked([&] {
@@ -1316,7 +1324,7 @@ futures::Future<Result> finishDBServerParts(Query& query, ErrorCode errorCode) {
 
     futures.emplace_back(std::move(f));
   }
-  
+
   return futures::collectAll(std::move(futures))
          .thenValue([](std::vector<futures::Try<Result>>&& results) -> Result{
            for (futures::Try<Result>& tryRes : results) {
@@ -1342,12 +1350,16 @@ aql::ExecutionState Query::cleanupTrxAndEngines(ErrorCode errorCode) {
                                               std::memory_order_relaxed)) {
     return ExecutionState::WAITING; // someone else got here
   }
-  
+
   enterState(QueryExecutionState::ValueType::FINALIZATION);
-  
+
+  TRI_IF_FAILURE("Query::directKillBeforeQueryWillBeFinalized") {
+    debugKillQuery();
+  }
+
   // simon: do not unregister _queryProfile here, since kill() will be called
   //        under the same QueryList lock
-  
+
   // The above condition is not true if we have already waited.
   LOG_TOPIC("fc22c", DEBUG, Logger::QUERIES)
       << elapsedSince(_startTime)
@@ -1377,6 +1389,10 @@ aql::ExecutionState Query::cleanupTrxAndEngines(ErrorCode errorCode) {
     guard.cancel();
   }
 
+  TRI_IF_FAILURE("Query::directKillAfterQueryWillBeFinalized") {
+    debugKillQuery();
+  }
+
   LOG_TOPIC("7ef18", DEBUG, Logger::QUERIES)
       << elapsedSince(_startTime)
       << " Query::finalize: before cleanupPlanAndEngine"
@@ -1386,7 +1402,7 @@ aql::ExecutionState Query::cleanupTrxAndEngines(ErrorCode errorCode) {
     _shutdownState.store(ShutdownState::Done, std::memory_order_relaxed);
     return ExecutionState::DONE;
   }
-  
+
   TRI_ASSERT(ServerState::instance()->isCoordinator());
   TRI_ASSERT(_sharedState);
   try {
@@ -1401,6 +1417,11 @@ aql::ExecutionState Query::cleanupTrxAndEngines(ErrorCode errorCode) {
         return true;
       });
     });
+
+    TRI_IF_FAILURE("Query::directKillAfterDBServerFinishRequests") {
+      debugKillQuery();
+    }
+
     return ExecutionState::WAITING;
   } catch (...) {
     // In case of any error that happened in sending out the requests
@@ -1448,3 +1469,54 @@ aql::ExecutionState Query::cleanupTrxAndEngines(ErrorCode errorCode) {
     return ExecutionState::DONE;
   }
 }
+
+  void Query::debugKillQuery() {
+#ifndef ARANGODB_ENABLE_FAILURE_TESTS
+    TRI_ASSERT(false);
+    return;
+#else
+    if (_wasDebugKilled) {
+      return;
+    }
+    bool usingSystemCollection = false;
+    // Ignore queries on System collections, we do not want them to hit failure points
+    collections().visit([&usingSystemCollection](std::string const&, Collection& col) -> bool {
+      if (col.getCollection()->system()) {
+        usingSystemCollection = true;
+        return false;
+      }
+      return true;
+    });
+
+    if (usingSystemCollection) {
+      return;
+    }
+
+    _wasDebugKilled = true;
+    // A query can only be killed under certain circumstances.
+    // We assert here that one of those is true.
+    // a) Query is in the list of current queries, this can be requested by the user and the query can be killed by user
+    // b) Query is in the query registry. In this case the query registry can hit a timeout, which triggers the kill
+    // c) The query id has been handed out to the user (stream query only)
+    bool isStreaming = queryOptions().stream;
+    bool isInList = false;
+    bool isInRegistry = false;
+    auto const& queryList = vocbase().queryList();
+    if (queryList->enabled()) {
+      auto const& current = queryList->listCurrent();
+      for (auto const& it : current) {
+        if (it.id == _queryId) {
+          isInList = true;
+          break;
+        }
+      }
+    }
+
+    QueryRegistry* registry = QueryRegistryFeature::registry();
+    if (registry != nullptr) {
+      isInRegistry = registry->queryIsRegistered(vocbase().name(), _queryId);
+    }
+    TRI_ASSERT(isInList || isStreaming || isInRegistry || _execState == QueryExecutionState::ValueType::FINALIZATION);
+    kill();
+#endif
+  }

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -206,6 +206,13 @@ class Query : public QueryContext {
   aql::SnippetList& snippets() { return _snippets; }
   aql::ServerQueryIdList& serverQueryIds() { return _serverQueryIds; }
   aql::ExecutionStats& executionStats() { return _execStats; }
+
+
+  // Debug method to kill a query at a specific position
+  // during execution. It internally asserts that the query
+  // is actually visible through other APIS (e.g. current queries)
+  // so user actually has a chance to kill it here.
+  void debugKillQuery() override;
   
  protected:
   /// @brief initializes the query
@@ -333,6 +340,15 @@ class Query : public QueryContext {
 
   /// @brief user that started the query
   std::string _user;
+
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+  // Intentionally initialized here to not
+  // be present in production constructors
+  // Indicator if a query was already killed
+  // via a debug failure. This should not
+  // retrigger a kill.
+  bool _wasDebugKilled{false};
+#endif
 };
 
 }  // namespace aql

--- a/arangod/Aql/QueryContext.h
+++ b/arangod/Aql/QueryContext.h
@@ -118,6 +118,12 @@ class QueryContext {
     
   virtual bool killed() const = 0;
 
+  // Debug method to kill a query at a specific position
+  // during execution. It internally asserts that the query
+  // is actually visible through other APIS (e.g. current queries)
+  // so user actually has a chance to kill it here.
+  virtual void debugKillQuery() = 0;
+
   /// @brief whether or not a query is a modification query
   virtual bool isModificationQuery() const noexcept = 0;
   virtual bool isAsyncQuery() const noexcept = 0;

--- a/arangod/Aql/QueryCursor.cpp
+++ b/arangod/Aql/QueryCursor.cpp
@@ -152,13 +152,21 @@ QueryStreamCursor::QueryStreamCursor(std::unique_ptr<arangodb::aql::Query> q,
       _queryResultPos(0),
       _exportCount(-1),
       _finalization(false) {
-
   _query->prepareQuery(SerializationFormat::SHADOWROWS);
-  TRI_ASSERT(_query->state() == aql::QueryExecutionState::ValueType::EXECUTION);
+  TRI_IF_FAILURE("QueryStreamCursor::directKillAfterPrepare") {
+    debugKillQuery();
+  }
+  // In all the following ASSERTs it is valid (though unlikely) that the query is already killed
+  // In the cluster this kill operation will trigger cleanup side-effects, such as changing the STATE
+  // and commiting / aborting the transaction here
+  TRI_ASSERT(_query->state() == aql::QueryExecutionState::ValueType::EXECUTION || _query->killed());
   _ctx = _query->newTrxContext();
   
   transaction::Methods trx(_ctx);
-  TRI_ASSERT(trx.status() == transaction::Status::RUNNING);
+  TRI_IF_FAILURE("QueryStreamCursor::directKillAfterTrxSetup") {
+    debugKillQuery();
+  }
+  TRI_ASSERT(trx.status() == transaction::Status::RUNNING || _query->killed());
 
   // we replaced the rocksdb export cursor with a stream AQL query
   // for this case we need to support printing the collection "count"
@@ -180,7 +188,7 @@ QueryStreamCursor::QueryStreamCursor(std::unique_ptr<arangodb::aql::Query> q,
    
   // ensures the cursor is cleaned up as soon as the outer transaction ends
   // otherwise we just get issues because we might still try to use the trx
-  TRI_ASSERT(trx.status() == transaction::Status::RUNNING);
+  TRI_ASSERT(trx.status() == transaction::Status::RUNNING || _query->killed());
   // things break if the Query outlives a V8 transaction
   _stateChangeCb = [this](transaction::Methods& /*trx*/, transaction::Status status) {
     if (status == transaction::Status::COMMITTED ||
@@ -214,7 +222,27 @@ void QueryStreamCursor::kill() {
   }
 }
 
+void QueryStreamCursor::debugKillQuery() {
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+  if (_query) {
+    _query->debugKillQuery();
+  }
+#endif
+}
+
 std::pair<ExecutionState, Result> QueryStreamCursor::dump(VPackBuilder& builder) {
+  TRI_IF_FAILURE("QueryCursor::directKillBeforeQueryIsGettingDumped") {
+    debugKillQuery();
+  }
+
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+  TRI_DEFER(
+    TRI_IF_FAILURE("QueryCursor::directKillAfterQueryIsGettingDumped") {
+      debugKillQuery();
+    }
+  )
+#endif
+
   TRI_ASSERT(batchSize() > 0);
   LOG_TOPIC("9af59", TRACE, Logger::QUERIES)
     << "executing query " << _id << ": '"
@@ -261,6 +289,16 @@ std::pair<ExecutionState, Result> QueryStreamCursor::dump(VPackBuilder& builder)
 }
 
 Result QueryStreamCursor::dumpSync(VPackBuilder& builder) {
+  TRI_IF_FAILURE("QueryCursor::directKillBeforeQueryIsGettingDumpedSynced") {
+    debugKillQuery();
+  }
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+  TRI_DEFER(
+    TRI_IF_FAILURE("QueryCursor::directKillAfterQueryIsGettingDumpedSynced") {
+      debugKillQuery();
+    }
+  )
+#endif
   TRI_ASSERT(batchSize() > 0);
   LOG_TOPIC("9dada", TRACE, Logger::QUERIES)
       << "executing query " << _id << ": '"

--- a/arangod/Aql/QueryCursor.h
+++ b/arangod/Aql/QueryCursor.h
@@ -90,6 +90,12 @@ class QueryStreamCursor final : public arangodb::Cursor {
 
   void kill() override;
 
+  // Debug method to kill a query at a specific position
+  // during execution. It internally asserts that the query
+  // is actually visible through other APIS (e.g. current queries)
+  // so user actually has a chance to kill it here.
+  void debugKillQuery() override;
+
   size_t count() const override final { return 0; }
 
   std::pair<ExecutionState, Result> dump(velocypack::Builder& result) override final;

--- a/arangod/Aql/QueryProfile.cpp
+++ b/arangod/Aql/QueryProfile.cpp
@@ -58,6 +58,10 @@ void QueryProfile::registerInQueryList() {
   auto queryList = _query->vocbase().queryList();
   if (queryList) {
     _tracked = queryList->insert(_query);
+
+    TRI_IF_FAILURE("QueryProfile::directKillAfterQueryGotRegistered") {
+      _query->debugKillQuery();
+    }
   }
 }
 

--- a/arangod/Aql/QueryRegistry.cpp
+++ b/arangod/Aql/QueryRegistry.cpp
@@ -478,3 +478,19 @@ QueryRegistry::QueryInfo::QueryInfo(std::unique_ptr<ClusterQuery> query, double 
 {}
 
 QueryRegistry::QueryInfo::~QueryInfo() = default;
+
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+bool QueryRegistry::queryIsRegistered(std::string const& dbName, QueryId id) {
+  READ_LOCKER(readLocker, _lock);
+
+  auto const& m = _queries.find(dbName);
+
+  if (m == _queries.end()) {
+    return false;
+  }
+  
+  auto const& q = m->second.find(id);
+  return q != m->second.end();
+}
+#endif
+

--- a/arangod/Aql/QueryRegistry.h
+++ b/arangod/Aql/QueryRegistry.h
@@ -122,6 +122,10 @@ class QueryRegistry {
   /// @brief return the default TTL value
   TEST_VIRTUAL double defaultTTL() const { return _defaultTTL; }
 
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+  bool queryIsRegistered(std::string const& dbName, QueryId id);
+#endif
+
  private:
   
   /// @brief a struct for all information regarding one query in the registry

--- a/arangod/IResearch/IResearchAqlAnalyzer.cpp
+++ b/arangod/IResearch/IResearchAqlAnalyzer.cpp
@@ -288,6 +288,8 @@ class CalculationQueryContext final : public arangodb::aql::QueryContext {
 
   virtual bool killed() const override { return false; }
 
+  virtual void debugKillQuery() override {}
+
   /// @brief whether or not a query is a modification query
   virtual bool isModificationQuery() const noexcept override { return false; }
 

--- a/arangod/RestHandler/RestCursorHandler.cpp
+++ b/arangod/RestHandler/RestCursorHandler.cpp
@@ -254,6 +254,7 @@ RestStatus RestCursorHandler::processQuery(bool continuation) {
 
     // continue handler is registered earlier
     auto state = _query->execute(_queryResult);
+
     if (state == aql::ExecutionState::WAITING) {
       guard.cancel();
       return RestStatus::WAITING;
@@ -267,6 +268,7 @@ RestStatus RestCursorHandler::processQuery(bool continuation) {
 
 // non stream case, result is complete
 RestStatus RestCursorHandler::handleQueryResult() {
+  TRI_ASSERT(_query == nullptr);
   if (_queryResult.result.fail()) {
     if (_queryResult.result.is(TRI_ERROR_REQUEST_CANCELED) ||
         (_queryResult.result.is(TRI_ERROR_QUERY_KILLED) && wasCanceled())) {
@@ -346,6 +348,7 @@ RestStatus RestCursorHandler::handleQueryResult() {
     // can send back the query result to the client and the client can make follow-up
     // requests on the same transaction (e.g. trx.commit()) without the server code for
     // freeing the resources and the client code racing for who's first
+
     return RestStatus::DONE;
   } else {
     // result is bigger than batchSize, and a cursor will be created
@@ -354,6 +357,7 @@ RestStatus RestCursorHandler::handleQueryResult() {
     TRI_ASSERT(_queryResult.data.get() != nullptr);
     // steal the query result, cursor will take over the ownership
     _cursor = cursors->createFromQueryResult(std::move(_queryResult), batchSize, ttl, count);
+
     return generateCursorResult(rest::ResponseCode::CREATED);
   }
 }
@@ -397,6 +401,7 @@ void RestCursorHandler::registerQuery(std::unique_ptr<arangodb::aql::Query> quer
   }
 
   TRI_ASSERT(_query == nullptr);
+  TRI_ASSERT(query != nullptr);
   _query = std::move(query);
 }
 
@@ -405,6 +410,9 @@ void RestCursorHandler::registerQuery(std::unique_ptr<arangodb::aql::Query> quer
 ////////////////////////////////////////////////////////////////////////////////
 
 void RestCursorHandler::unregisterQuery() {
+  TRI_IF_FAILURE("RestCursorHandler::directKillBeforeQueryResultIsGettingHandled") {
+    _query->debugKillQuery();
+  }
   MUTEX_LOCKER(mutexLocker, _queryLock);
   _query.reset();
 }
@@ -534,6 +542,7 @@ RestStatus RestCursorHandler::generateCursorResult(rest::ResponseCode code) {
   builder.openObject(/*unindexed*/true);
 
   auto const [state, r] = _cursor->dump(builder);
+
   if (state == aql::ExecutionState::WAITING) {
     builder.clear();
     TRI_ASSERT(r.ok());

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -835,6 +835,11 @@ ErrorCode DatabaseFeature::dropDatabase(std::string const& name, bool removeApps
     if (queryRegistry != nullptr) {
       queryRegistry->destroy(vocbase->name());
     }
+    // TODO Temporary fix, this full method needs to be unified.
+    try {
+      vocbase->cursorRepository()->garbageCollect(true);
+    } catch (...) {
+    }
 
     res = engine.prepareDropDatabase(*vocbase).errorNumber();
   }

--- a/arangod/Utils/Cursor.h
+++ b/arangod/Utils/Cursor.h
@@ -93,6 +93,12 @@ class Cursor {
 
   virtual void kill() {}
 
+  // Debug method to kill a query at a specific position
+  // during execution. It internally asserts that the query
+  // is actually visible through other APIS (e.g. current queries)
+  // so user actually has a chance to kill it here.
+  virtual void debugKillQuery() {}
+
   virtual size_t count() const = 0;
 
   virtual std::shared_ptr<transaction::Context> context() const = 0;

--- a/arangod/V8Server/v8-voccursor.cpp
+++ b/arangod/V8Server/v8-voccursor.cpp
@@ -155,6 +155,8 @@ static void JS_JsonCursor(v8::FunctionCallbackInfo<v8::Value> const& args) {
   builder.openObject(true);  // conversion uses sequential iterator, no indexing
   Result r = cursor->dumpSync(builder);
   if (r.fail()) {
+    // On any error the cursor needs to be deleted
+    TRI_ASSERT(cursor->isDeleted());
     TRI_V8_THROW_EXCEPTION_MEMORY();  // for compatibility
   }
   builder.close();
@@ -250,6 +252,8 @@ struct V8Cursor final {
     _tmpResult.openObject();
     Result r = cursor->dumpSync(_tmpResult);
     if (r.fail()) {
+      // On any error the cursor needs to be deleted
+      TRI_ASSERT(cursor->isDeleted());
       return r;
     }
     _tmpResult.close();
@@ -335,12 +339,20 @@ struct V8Cursor final {
     
     // specify ID 0 so it uses the external V8 context
     auto cc = cursors->createQueryStream(std::move(q), batchSize, ttl);
-    TRI_DEFER(cc->release());
+    arangodb::ScopeGuard releaseCursorGuard([&]() {
+      cc->release();
+    });
     // args.Holder() is supposedly better than args.This()
     auto self = std::make_unique<V8Cursor>(isolate, args.Holder(), *vocbase, cc->id());
-    Result r = self->fetchData(cc);
-    self.release();  // args.Holder() owns the pointer
+    V8Cursor* v8Cursor = self.release();  // args.Holder() owns the pointer
+    Result r = v8Cursor->fetchData(cc);
     if (r.fail()) {
+      // Try to free the cursor from cursor repository.
+      // We are in NEW so the caller has no chance to do this operation
+      // as neither the cursor nor the id is known.
+      cursors->release(cc);
+      // cursors->release does cc->release() for us.
+      releaseCursorGuard.cancel();
       TRI_V8_THROW_EXCEPTION(r);
     } else {
       TRI_V8_RETURN(args.This());

--- a/js/client/bootstrap/modules/internal.js
+++ b/js/client/bootstrap/modules/internal.js
@@ -105,6 +105,9 @@
       }
     });
   };
+
+  // On server side the API with failurePointName is called removeFailAt
+  exports.debugRemoveFailAt = exports.debugClearFailAt;
   
   exports.debugSetFailAt = function(failAt) {
     const request = require('@arangodb/request');

--- a/tests/js/common/shell/test-kill-queries.js
+++ b/tests/js/common/shell/test-kill-queries.js
@@ -1,0 +1,283 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global fail, assertTrue, assertFalse, assertEqual, assertNotEqual, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2018 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Heiko Kernbach
+// //////////////////////////////////////////////////////////////////////////////
+
+let jsunity = require('jsunity');
+let internal = require('internal');
+let arangodb = require('@arangodb');
+const isServer = require('@arangodb').isServer;
+// Only required on client
+const arango = isServer ? {} : arangodb.arango;
+let db = arangodb.db;
+
+function GenericQueryKillSuite() { // can be either default or stream
+  'use strict';
+
+  // generate a random collection name
+  const databaseName = "UnitTestsDBTemp";
+  const collectionName = "UnitTests" + require("@arangodb/crypto").md5(internal.genRandomAlphaNumbers(32));
+  const docsPerWrite = 5;
+  const exlusiveWriteQueryString = `FOR x IN 1..${docsPerWrite} INSERT {} INTO ${collectionName} OPTIONS {exclusive: true} RETURN NEW`;
+
+  let executeDefaultCursorQuery = (reportKilled) => {
+    // default execution
+    let localQuery;
+    let stateForBoth = false; // marker that we expect either a kill or a result
+
+    try {
+      localQuery = db._query(exlusiveWriteQueryString);
+      if (reportKilled === 'on') {
+        fail();
+      }
+    } catch (e) {
+      stateForBoth = true;
+      assertEqual(e.errorNum, internal.errors.ERROR_QUERY_KILLED.code);
+    }
+
+    // in case we're expecting a success here
+    if (reportKilled === 'off') {
+      assertTrue(localQuery);
+    }
+    if (localQuery) {
+      stateForBoth = true;
+    }
+    if (reportKilled === 'both') {
+      assertTrue(stateForBoth);
+    }
+  };
+
+  let executeStreamCursorQuery = (reportKilled) => {
+    // stream execution
+    let localQuery;
+    let stateForBoth = false; // marker that we expect either a kill or a result
+
+    try {
+      localQuery = db._query(exlusiveWriteQueryString, null, null, {stream: true});
+      // Make sure we free the local instance of the cursor.
+      // Just to avoid that we depend on the eventual garbage collection in V8
+      // to clear up our references to the cursor.
+      localQuery.dispose();
+
+      if (reportKilled === 'on') {
+        fail();
+      }
+    } catch (e) {
+      stateForBoth = true;
+      assertEqual(e.errorNum, internal.errors.ERROR_QUERY_KILLED.code);
+    }
+
+    // in case we're expecting a success here
+    if (reportKilled === 'off') {
+      assertTrue(localQuery);
+    }
+    if (localQuery) {
+      stateForBoth = true;
+    }
+    if (reportKilled === 'both') {
+      assertTrue(stateForBoth);
+    }
+  };
+
+  /*
+   * failurePointName: <Class::Name>
+   * onlyInCluster: <boolean>
+   * stream: <string> - "on", "off" or "both"
+   * reportKilled: <string> "on", "off", "both"
+   */
+  const createTestCaseEntry = (failurePointName, onlyInCluster, stream, reportKilled) => {
+    let error = false;
+    if (typeof failurePointName !== 'string') {
+      console.error("Wrong definition of failurePointName, given: " + JSON.stringify(failurePointName));
+      error = true;
+    }
+    if (typeof onlyInCluster !== 'boolean') {
+      console.error("Wrong definition of onlyInCluster, given: " + JSON.stringify(onlyInCluster));
+      error = true;
+    }
+    if (typeof stream !== 'string') {
+      console.error("Wrong type used for stream. Must be a string. Given: " + typeof stream);
+    } else if (typeof stream === 'string') {
+      const acceptedValues = ['on', 'off', 'both'];
+      if (!acceptedValues.find(entry => entry === stream)) {
+        console.error("Wrong definition of stream, given: " + JSON.stringify(stream));
+        error = true;
+      }
+    }
+    if (typeof reportKilled !== 'string') {
+      console.error("Wrong definition of reportKilled, given: " + JSON.stringify(reportKilled));
+      error = true;
+    }
+
+    if (error) {
+      throw "Wrong param for createTestCaseEntry()";
+    }
+
+    return {
+      failurePointName: failurePointName,
+      onlyInCluster: onlyInCluster,
+      stream: stream,
+      reportKilled: reportKilled
+    };
+  };
+
+  const testCases = [];
+
+  // defaults
+  testCases.push(createTestCaseEntry("QueryProfile::directKillAfterQueryGotRegistered", false, "both", "on"));
+
+  /*
+   * Stream
+   */
+  testCases.push(createTestCaseEntry("CursorRepository::directKillStreamQueryAfterCursorIsBeingCreated", false, "on", "on"));
+  testCases.push(createTestCaseEntry("QueryStreamCursor::directKillAfterPrepare", false, "on", "on"));
+  testCases.push(createTestCaseEntry("QueryStreamCursor::directKillAfterTrxSetup", false, "on", "on"));
+
+  // On stream the dump happens during process of the query, so it can be killed
+  if (isServer) { // shell_server
+    testCases.push(createTestCaseEntry("QueryCursor::directKillBeforeQueryIsGettingDumpedSynced", false, "on", "on"));
+    testCases.push(createTestCaseEntry("QueryCursor::directKillAfterQueryIsGettingDumpedSynced", false, "on", "off"));
+  } else { // shell_client
+    testCases.push(createTestCaseEntry("QueryCursor::directKillBeforeQueryIsGettingDumped", false, "on", "on"));
+    if (internal.isCluster()) {
+      // In cluster we can return WAITING. This will result in wakeup that will find a killed to report
+      testCases.push(createTestCaseEntry("QueryCursor::directKillAfterQueryIsGettingDumped", false, "on", "on"));
+    } else {
+      // In single server we cannot return WAITING, so once dump is finished everything is done.
+      testCases.push(createTestCaseEntry("QueryCursor::directKillAfterQueryIsGettingDumped", false, "on", "off"));
+    }
+  }
+
+  /*
+   * Non-Stream
+   */
+  // On non stream the (dump) handleQueryResult happens after query is fully processed, so it cannot be killed anymore.
+  if (isServer) { // shell_server
+    testCases.push(createTestCaseEntry("Query::executeV8directKillBeforeQueryResultIsGettingHandled", false, "off", "off"));
+    testCases.push(createTestCaseEntry("Query::executeV8directKillAfterQueryResultIsGettingHandled", false, "off", "off"));
+  } else { // shell_client
+    testCases.push(createTestCaseEntry("RestCursorHandler::directKillBeforeQueryResultIsGettingHandled", false, "off", "off"));
+  }
+
+  /*
+   * Execution in default & stream
+   */
+  testCases.push(createTestCaseEntry("ExecutionEngine::directKillBeforeAQLQueryExecute", false, 'both', "on"));
+  if (internal.isCluster()) {
+    // We wait after first Execute. SO we are not done and can kill the query.
+    testCases.push(createTestCaseEntry("ExecutionEngine::directKillAfterAQLQueryExecute", false, 'both', "on"));
+  } else {
+    // NO waiting, the query is done after a single Execute run
+    // With > 1000 results this should return an error
+    testCases.push(createTestCaseEntry("ExecutionEngine::directKillAfterAQLQueryExecute", false, 'both', "off"));
+  }
+  testCases.push(createTestCaseEntry("Query::directKillBeforeQueryWillBeFinalized", false, 'both', "both"));
+  testCases.push(createTestCaseEntry("Query::directKillAfterQueryWillBeFinalized", false, 'both', "both"));
+  testCases.push(createTestCaseEntry("Query::directKillAfterDBServerFinishRequests", true, 'both', "both"));
+
+  const testSuite = {
+    setUpAll: function () {
+      db._useDatabase("_system");
+      db._createDatabase(databaseName);
+      db._useDatabase(databaseName);
+
+      db._create(collectionName, {numberOfShards: 4});
+    },
+
+    tearDownAll: function () {
+      db._useDatabase("_system");
+      db._dropDatabase(databaseName);
+    },
+  };
+
+  const createTestName = (failurePoint, stream) => {
+    let typedef = '_';
+    if (stream === 'on') {
+      typedef = '_stream_';
+    } else if (stream === 'off') {
+      typedef = '_nonstream_';
+    }
+    return `test${typedef}${failurePoint.split("::")[1]}`;
+  };
+
+  const addTestCase = (suite, testCase) => {
+    if (!internal.isCluster() && testCase.onlyInCluster) {
+      return;
+    }
+
+    suite[createTestName(testCase.failurePointName, testCase.stream)] = function (failurePointName, stream, reportKilled) {
+      try {
+        internal.debugSetFailAt(failurePointName);
+      } catch (e) {
+        // Let the Test fail
+        throw `Failed to initialize failurepoint ${failurePointName}`;
+      }
+
+      try {
+        if (stream === 'on') {
+          executeStreamCursorQuery(reportKilled);
+        } else if (stream === 'off') {
+          executeDefaultCursorQuery(reportKilled);
+        } else if (stream === 'both') {
+          executeStreamCursorQuery(reportKilled);
+          executeDefaultCursorQuery(reportKilled);
+        }
+      } finally {
+        try {
+          internal.debugRemoveFailAt(failurePointName);
+        } catch (e) {
+          // We cannot throw in finally.
+          console.error(`Failed to erase debug point ${failurePointName}. Test may be unreliable`);
+        }
+      }
+
+    }.bind(this, testCase.failurePointName, testCase.stream, testCase.reportKilled, testCase.onlyInCluster);
+  };
+
+  for (const testCase of testCases) {
+    addTestCase(testSuite, testCase);
+  }
+
+  // add two regular tests (one default, one stream) without breakpoint activation
+  testSuite["test_positiveStreamQueryExecution"] = function () {
+    let localQuery = db._query(exlusiveWriteQueryString, null, null, {stream: true});
+    assertTrue(localQuery);
+    localQuery.dispose();
+  };
+
+  testSuite["test_positiveDefaultQueryExecution"] = function () {
+    let localQuery = db._query(exlusiveWriteQueryString);
+    assertTrue(localQuery);
+  };
+
+  return testSuite;
+}
+
+function QueryKillSuite() {
+  return GenericQueryKillSuite();
+}
+
+jsunity.run(QueryKillSuite);
+
+return jsunity.done();
+


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/13939
No changes applied

This PR adds many tests for killing AQL queries at specific "dangerous" positions.
It also fixes all sub-optimal handlings of those Kill commands.
* Sometimes internal ASSERTIONS were wrong (they expect the query to be active although it could be killed)
* A Cluster query will only trigger cleanup once. This was handled later before but caused the test to endless loop.
* A dropped database will now clear and garbage collect all lingering cursors, without this an AQLFeature lease was kept forever prohibiting the Server to shutdown. (Only if a query is killed, and the DB was dropped before the garbage collection kicked in, so unlikely)
* I killed cursor can now be removed from the Cursor list on demand as long as it is not in use. Before we had to wait for garbage collection to kick in for this operation, as our specific remove now call was ignored. This could cause a 5sec delay to release Locks.
* Fixes BTS-346 which actually kills a query during it's setup and got into a wrong assertion.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [x] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [x] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:

### Documentation

This does not require external documentation, everything behaves as described, just faster.

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
