### PR TITLE
fix error in the documentation

### DIFF
--- a/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
+++ b/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
@@ -35,7 +35,7 @@ rules documented in [Document Schema Validation](https://www.arangodb.com/docs/d
 
 @RESTBODYPARAM{keyOptions,object,optional,post_api_collection_opts}
 additional options for key generation. If specified, then *keyOptions*
-should be a JSON array containing the following attributes:
+should be a JSON object containing the following attributes:
 
 @RESTSTRUCT{type,post_api_collection_opts,string,required,string}
 specifies the type of the key generator. The currently available generators are

--- a/Documentation/DocuBlocks/collectionDatabaseCreate.md
+++ b/Documentation/DocuBlocks/collectionDatabaseCreate.md
@@ -22,7 +22,7 @@ to the [naming conventions](../NamingConventions/README.md).
   very special occasions, but normally a regular collection will do.
 
 * *keyOptions* (optional): additional options for key generation. If
-  specified, then *keyOptions* should be a JSON array containing the
+  specified, then *keyOptions* should be a JSON object containing the
   following attributes (**note**: some of them are optional):
   * *type*: specifies the type of the key generator. The currently
     available generators are *traditional*, *autoincrement*, *uuid*

--- a/Documentation/DocuBlocks/collectionProperties.md
+++ b/Documentation/DocuBlocks/collectionProperties.md
@@ -9,7 +9,7 @@ Returns an object containing all collection properties.
   after the data was synced to disk.
 
 * *keyOptions* (optional) additional options for key generation. This is
-  a JSON array containing the following attributes (note: some of the
+  a JSON object containing the following attributes (note: some of the
   attributes are optional):
   * *type*: the type of the key generator used for the collection.
   * *allowUserKeys*: if set to *true*, then it is allowed to supply


### PR DESCRIPTION
### Scope & Purpose

Fix wrong data type in the documentation (`array` should be `object`).
This is a documentation-only bugfix.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
