### PR TITLE
add peak memory usage to AQL query profiling output

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Show peak memory usage in AQL query profiling output.
+
 * UI builds are now using the yarn package manager instead of the previously
   used node package manager.
 

--- a/arangod/Aql/AqlCallStack.cpp
+++ b/arangod/Aql/AqlCallStack.cpp
@@ -48,7 +48,7 @@ AqlCallStack::AqlCallStack(AqlCallStack const& other, AqlCallList call)
 #endif
 }
 
-AqlCallStack::AqlCallStack(std::vector<AqlCallList>&& operations)
+AqlCallStack::AqlCallStack(std::vector<AqlCallList>&& operations) noexcept
     : _operations(std::move(operations)) {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   validateNoCallHasSkippedRows();

--- a/arangod/Aql/AqlCallStack.h
+++ b/arangod/Aql/AqlCallStack.h
@@ -57,10 +57,10 @@ class AqlCallStack {
   AqlCallStack(AqlCallStack const& other, AqlCallList call);
   // Used to pass between blocks
   AqlCallStack(AqlCallStack const& other) = default;
-  AqlCallStack(AqlCallStack&& other) = default;
+  AqlCallStack(AqlCallStack&& other) noexcept = default;
 
   AqlCallStack& operator=(AqlCallStack const& other) = default;
-  AqlCallStack& operator=(AqlCallStack&& other) = default;
+  AqlCallStack& operator=(AqlCallStack&& other) noexcept = default;
 
   static auto fromVelocyPack(velocypack::Slice) -> ResultT<AqlCallStack>;
 
@@ -174,7 +174,7 @@ class AqlCallStack {
   auto requestLessDataThan(AqlCallStack const& other) const noexcept -> bool;
 
  private:
-  explicit AqlCallStack(std::vector<AqlCallList>&& operations);
+  explicit AqlCallStack(std::vector<AqlCallList>&& operations) noexcept;
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   auto validateNoCallHasSkippedRows() -> void;

--- a/arangod/Aql/AsyncExecutor.cpp
+++ b/arangod/Aql/AsyncExecutor.cpp
@@ -47,7 +47,7 @@ ExecutionBlockImpl<AsyncExecutor>::ExecutionBlockImpl(
     : ExecutionBlock(engine, node),
       _sharedState(engine->sharedState()) {}
 
-std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> ExecutionBlockImpl<AsyncExecutor>::execute(AqlCallStack stack) {
+std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> ExecutionBlockImpl<AsyncExecutor>::execute(AqlCallStack const& stack) {
   traceExecuteBegin(stack);
   auto res = executeWithoutTrace(stack);
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE

--- a/arangod/Aql/AsyncExecutor.h
+++ b/arangod/Aql/AsyncExecutor.h
@@ -57,7 +57,7 @@ class ExecutionBlockImpl<AsyncExecutor> : public ExecutionBlock {
   // moved into some AsyncExecutorInfos class.
   ExecutionBlockImpl(ExecutionEngine* engine, AsyncNode const* node);
 
-  std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> execute(AqlCallStack stack) override;
+  std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> execute(AqlCallStack const& stack) override;
  
   std::pair<ExecutionState, Result> initializeCursor(InputAqlItemRow const& input) override;
 

--- a/arangod/Aql/BlocksWithClients.cpp
+++ b/arangod/Aql/BlocksWithClients.cpp
@@ -147,7 +147,7 @@ size_t BlocksWithClientsImpl<Executor>::getClientId(std::string const& shardId) 
 
 template <class Executor>
 std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr>
-BlocksWithClientsImpl<Executor>::execute(AqlCallStack stack) {
+BlocksWithClientsImpl<Executor>::execute(AqlCallStack const& /*stack*/) {
   // This will not be implemented here!
   TRI_ASSERT(false);
   THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
@@ -173,7 +173,7 @@ auto BlocksWithClientsImpl<Executor>::executeForClient(AqlCallStack stack,
   });
   
   traceExecuteBegin(stack, clientId);
-  auto res = executeWithoutTraceForClient(stack, clientId);
+  auto res = executeWithoutTraceForClient(std::move(stack), clientId);
   traceExecuteEnd(res, clientId);
   return res;
 }
@@ -273,7 +273,7 @@ template <class Executor>
 std::pair<ExecutionState, SharedAqlItemBlockPtr> BlocksWithClientsImpl<Executor>::getSomeForShard(
     size_t atMost, std::string const& shardId) {
   AqlCallStack stack(AqlCallList{AqlCall::SimulateGetSome(atMost)});
-  auto [state, skipped, block] = executeForClient(stack, shardId);
+  auto [state, skipped, block] = executeForClient(std::move(stack), shardId);
   TRI_ASSERT(skipped.nothingSkipped());
   return {state, std::move(block)};
 }
@@ -284,7 +284,7 @@ template <class Executor>
 std::pair<ExecutionState, size_t> BlocksWithClientsImpl<Executor>::skipSomeForShard(
     size_t atMost, std::string const& shardId) {
   AqlCallStack stack(AqlCallList{AqlCall::SimulateSkipSome(atMost)});
-  auto [state, skipped, block] = executeForClient(stack, shardId);
+  auto [state, skipped, block] = executeForClient(std::move(stack), shardId);
   TRI_ASSERT(block == nullptr);
   return {state, skipped.getSkipCount()};
 }

--- a/arangod/Aql/BlocksWithClients.h
+++ b/arangod/Aql/BlocksWithClients.h
@@ -121,7 +121,7 @@ class BlocksWithClientsImpl : public ExecutionBlock, public BlocksWithClients {
       -> std::pair<ExecutionState, Result> override;
 
   /// @brief execute: shouldn't be used, use executeForClient
-  std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> execute(AqlCallStack stack) override;
+  std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> execute(AqlCallStack const& stack) override;
 
   /**
    * @brief Execute for client.

--- a/arangod/Aql/DistributeClientBlock.cpp
+++ b/arangod/Aql/DistributeClientBlock.cpp
@@ -161,10 +161,10 @@ auto DistributeClientBlock::popJoinedBlock()
       output.advanceRow();
     }
     // All required rows copied.
-    // Drop block form queue.
+    // Drop block from queue.
     _queue.pop_front();
   }
-  return {newBlock, skipRes};
+  return {std::move(newBlock), skipRes};
 }
 
 auto DistributeClientBlock::execute(AqlCallStack callStack, ExecutionState upstreamState)

--- a/arangod/Aql/DistributeExecutor.cpp
+++ b/arangod/Aql/DistributeExecutor.cpp
@@ -80,7 +80,7 @@ auto DistributeExecutorInfos::getResponsibleClient(arangodb::velocypack::Slice v
 DistributeExecutor::DistributeExecutor(DistributeExecutorInfos const& infos)
     : _infos(infos) {}
 
-auto DistributeExecutor::distributeBlock(SharedAqlItemBlockPtr block, SkipResult skipped,
+auto DistributeExecutor::distributeBlock(SharedAqlItemBlockPtr const& block, SkipResult skipped,
                                          std::unordered_map<std::string, ClientBlockData>& blockMap)
     -> void {
   std::unordered_map<std::string, std::vector<std::size_t>> choosenMap;
@@ -123,12 +123,10 @@ auto DistributeExecutor::distributeBlock(SharedAqlItemBlockPtr block, SkipResult
   }
 }
 
-auto DistributeExecutor::getClient(SharedAqlItemBlockPtr block, size_t rowIndex)
+auto DistributeExecutor::getClient(SharedAqlItemBlockPtr const& block, size_t rowIndex) const
     -> std::string {
-  InputAqlItemRow row{block, rowIndex};
-   
   // check first input register
-  AqlValue val = row.getValue(_infos.registerId());
+  AqlValue val = InputAqlItemRow{block, rowIndex}.getValue(_infos.registerId());
 
   VPackSlice input = val.slice();  // will throw when wrong type
   if (input.isNone()) {

--- a/arangod/Aql/DistributeExecutor.h
+++ b/arangod/Aql/DistributeExecutor.h
@@ -88,7 +88,7 @@ class DistributeExecutor {
    * @param skipped The rows that have been skipped from upstream
    * @param blockMap Map client => Data. Will provide the required data to the correct client.
    */
-  auto distributeBlock(SharedAqlItemBlockPtr block, SkipResult skipped,
+  auto distributeBlock(SharedAqlItemBlockPtr const& block, SkipResult skipped,
                        std::unordered_map<std::string, ClientBlockData>& blockMap) -> void;
 
  private:
@@ -103,7 +103,7 @@ class DistributeExecutor {
    * @param rowIndex
    * @return std::string Identifier used by the client
    */
-  auto getClient(SharedAqlItemBlockPtr block, size_t rowIndex) -> std::string;
+  auto getClient(SharedAqlItemBlockPtr const& block, size_t rowIndex) const -> std::string;
 
  private:
   DistributeExecutorInfos const& _infos;

--- a/arangod/Aql/ExecutionBlock.h
+++ b/arangod/Aql/ExecutionBlock.h
@@ -111,7 +111,7 @@ class ExecutionBlock {
   ///          * DONE: Here is some data, and there will be no further data available.
   ///        2. SkipResult: Amount of documents skipped.
   ///        3. SharedAqlItemBlockPtr: The next data block.
-  virtual std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> execute(AqlCallStack stack) = 0;
+  virtual std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> execute(AqlCallStack const& stack) = 0;
   
   virtual void collectExecStats(ExecutionStats&) const;
   [[nodiscard]] bool isInSplicedSubquery() const noexcept;

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -316,7 +316,7 @@ std::pair<ExecutionState, Result> ExecutionBlockImpl<Executor>::initializeCursor
 
 template <class Executor>
 std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr>
-ExecutionBlockImpl<Executor>::execute(AqlCallStack stack) {
+ExecutionBlockImpl<Executor>::execute(AqlCallStack const& stack) {
   if (getQuery().killed()) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
   }
@@ -332,7 +332,7 @@ ExecutionBlockImpl<Executor>::execute(AqlCallStack stack) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
   initOnce();
-  auto res = executeWithoutTrace(std::move(stack));
+  auto res = executeWithoutTrace(stack);
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   auto const& [state, skipped, block] = res;
   if (block != nullptr) {

--- a/arangod/Aql/ExecutionBlockImpl.h
+++ b/arangod/Aql/ExecutionBlockImpl.h
@@ -201,7 +201,7 @@ class ExecutionBlockImpl final : public ExecutionBlock {
   ///          * DONE: Here is some data, and there will be no further data available.
   ///        2. SkipResult: Amount of documents skipped.
   ///        3. SharedAqlItemBlockPtr: The next data block.
-  std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> execute(AqlCallStack stack) override;
+  std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> execute(AqlCallStack const& stack) override;
 
   virtual void collectExecStats(ExecutionStats& stats) const override {
     ExecutionBlock::collectExecStats(stats);

--- a/arangod/Aql/ExecutionEngine.cpp
+++ b/arangod/Aql/ExecutionEngine.cpp
@@ -516,10 +516,9 @@ std::pair<ExecutionState, Result> ExecutionEngine::initializeCursor(SharedAqlIte
     inputRow = InputAqlItemRow{std::move(items), pos};
   }
   auto res = _root->initializeCursor(inputRow);
-  if (res.first == ExecutionState::WAITING) {
-    return res;
+  if (res.first != ExecutionState::WAITING) {
+    _initializeCursorCalled = true;
   }
-  _initializeCursorCalled = true;
   return res;
 }
 

--- a/arangod/Aql/MutexExecutor.cpp
+++ b/arangod/Aql/MutexExecutor.cpp
@@ -51,7 +51,7 @@ MutexExecutorInfos::MutexExecutorInfos(
 MutexExecutor::MutexExecutor(MutexExecutorInfos const& infos)
   : _infos(infos), _numClient(0) {}
 
-auto MutexExecutor::distributeBlock(SharedAqlItemBlockPtr block, SkipResult skipped,
+auto MutexExecutor::distributeBlock(SharedAqlItemBlockPtr const& block, SkipResult skipped,
                                     std::unordered_map<std::string, ClientBlockData>& blockMap)
     -> void {
 

--- a/arangod/Aql/MutexExecutor.h
+++ b/arangod/Aql/MutexExecutor.h
@@ -66,7 +66,7 @@ class MutexExecutor {
    * @param skipped The rows that have been skipped from upstream
    * @param blockMap Map client => Data. Will provide the required data to the correct client.
    */
-  auto distributeBlock(SharedAqlItemBlockPtr block, SkipResult skipped,
+  auto distributeBlock(SharedAqlItemBlockPtr const& block, SkipResult skipped,
                        std::unordered_map<std::string, ClientBlockData>& blockMap) -> void;
   
   void acquireLock() {

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -81,6 +81,10 @@
 using namespace arangodb;
 using namespace arangodb::aql;
 using namespace arangodb::basics;
+        
+namespace {
+AqlCallStack const defaultStack{AqlCallList{AqlCall{}}};
+}
 
 /// @brief internal constructor, Used to construct a full query or a ClusterQuery
 Query::Query(std::shared_ptr<transaction::Context> const& ctx,
@@ -448,8 +452,7 @@ ExecutionState Query::execute(QueryResult& queryResult) {
         // In case of WAITING we return, this function is repeatable!
         // In case of HASMORE we loop
         while (true) {
-          AqlCallStack defaultStack{AqlCallList{AqlCall{}}};
-          auto const& [state, skipped, block] = engine->execute(defaultStack);
+          auto const& [state, skipped, block] = engine->execute(::defaultStack);
           // The default call asks for No skips.
           TRI_ASSERT(skipped.nothingSkipped());
           if (state == ExecutionState::WAITING) {

--- a/arangod/Aql/RemoteExecutor.h
+++ b/arangod/Aql/RemoteExecutor.h
@@ -64,7 +64,7 @@ class ExecutionBlockImpl<RemoteExecutor> : public ExecutionBlock {
 
   std::pair<ExecutionState, Result> initializeCursor(InputAqlItemRow const& input) override;
 
-  std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> execute(AqlCallStack stack) override;
+  std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> execute(AqlCallStack const& stack) override;
 
   std::string const& distributeId() const { return _distributeId; }
 
@@ -83,10 +83,7 @@ class ExecutionBlockImpl<RemoteExecutor> : public ExecutionBlock {
 
   std::pair<ExecutionState, size_t> skipSomeWithoutTrace(size_t atMost);
 
-  auto executeWithoutTrace(AqlCallStack stack)
-      -> std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr>;
-
-  auto executeViaNewApi(AqlCallStack stack)
+  auto executeWithoutTrace(AqlCallStack const& stack)
       -> std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr>;
 
   [[nodiscard]] auto deserializeExecuteCallResultBody(velocypack::Slice) const
@@ -110,7 +107,7 @@ class ExecutionBlockImpl<RemoteExecutor> : public ExecutionBlock {
   void traceGetSomeRequest(velocypack::Slice slice, size_t atMost);
   void traceSkipSomeRequest(velocypack::Slice slice, size_t atMost);
   void traceInitializeCursorRequest(velocypack::Slice slice);
-  void traceRequest(const char* rpc, velocypack::Slice slice, std::string const& args);
+  void traceRequest(char const* rpc, velocypack::Slice slice, std::string const& args);
 
  private:
 
@@ -128,10 +125,6 @@ class ExecutionBlockImpl<RemoteExecutor> : public ExecutionBlock {
   /// @brief the ID of the query on the server as a string
   std::string const _queryId;
 
-  /// @brief whether or not this block will forward initialize,
-  /// initializeCursor requests
-  bool const _isResponsibleForInitializeCursor;
-
   std::mutex _communicationMutex;
 
   /// @brief the last unprocessed result. Make sure to reset it
@@ -141,9 +134,13 @@ class ExecutionBlockImpl<RemoteExecutor> : public ExecutionBlock {
   /// @brief the last remote response Result object, may contain an error.
   arangodb::Result _lastError;
 
-  unsigned _lastTicket;  /// used to check for canceled requests
+  /// @brief whether or not this block will forward initialize,
+  /// initializeCursor requests
+  bool const _isResponsibleForInitializeCursor;
 
   bool _requestInFlight;
+  
+  unsigned _lastTicket;  /// used to check for canceled requests
 };
 
 }  // namespace arangodb::aql

--- a/arangod/Aql/ScatterExecutor.cpp
+++ b/arangod/Aql/ScatterExecutor.cpp
@@ -82,7 +82,7 @@ auto ScatterExecutor::ClientBlockData::hasDataFor(AqlCall const& call) -> bool {
   return _executorHasMore || !_queue.empty();
 }
 
-auto ScatterExecutor::ClientBlockData::execute(AqlCallStack callStack, ExecutionState upstreamState)
+auto ScatterExecutor::ClientBlockData::execute(AqlCallStack const& callStack, ExecutionState upstreamState)
     -> std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> {
   TRI_ASSERT(_executor != nullptr);
 

--- a/arangod/Aql/ScatterExecutor.h
+++ b/arangod/Aql/ScatterExecutor.h
@@ -57,7 +57,7 @@ class ScatterExecutor {
     auto addBlock(SharedAqlItemBlockPtr block, SkipResult skipped) -> void;
     auto hasDataFor(AqlCall const& call) -> bool;
 
-    auto execute(AqlCallStack callStack, ExecutionState upstreamState)
+    auto execute(AqlCallStack const& callStack, ExecutionState upstreamState)
         -> std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr>;
 
    private:

--- a/arangod/Aql/SingleRowFetcher.cpp
+++ b/arangod/Aql/SingleRowFetcher.cpp
@@ -66,10 +66,10 @@ SingleRowFetcher<passBlocksThrough>::execute(AqlCallStack& stack) {
     TRI_ASSERT(block != nullptr);
     return {state, skipped,
             AqlItemBlockInputRange{ExecutorState::HASMORE,
-                                   skipped.getSkipCount(), block, start}};
+                                   skipped.getSkipCount(), std::move(block), start}};
   }
   return {state, skipped,
-          AqlItemBlockInputRange{ExecutorState::DONE, skipped.getSkipCount(), block, start}};
+          AqlItemBlockInputRange{ExecutorState::DONE, skipped.getSkipCount(), std::move(block), start}};
 }
 
 

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -291,16 +291,18 @@ function printStats(stats) {
   var maxSFLen = String('Scan Full').length;
   var maxSILen = String('Scan Index').length;
   var maxFLen = String('Filtered').length;
+  var maxMem = String('Peak Mem [b]').length;
   var maxETen = String('Exec Time [s]').length;
   stats.executionTime = stats.executionTime.toFixed(5);
   stringBuilder.appendLine(' ' + header('Writes Exec') + '   ' + header('Writes Ign') + '   ' + header('Scan Full') + '   ' +
-    header('Scan Index') + '   ' + header('Filtered') + '   ' + header('Exec Time [s]'));
+    header('Scan Index') + '   ' + header('Filtered') + '   ' + header('Peak Mem [b]') + '   ' + header('Exec Time [s]'));
 
   stringBuilder.appendLine(' ' + pad(1 + maxWELen - String(stats.writesExecuted).length) + value(stats.writesExecuted) + '   ' +
     pad(1 + maxWILen - String(stats.writesIgnored).length) + value(stats.writesIgnored) + '   ' +
     pad(1 + maxSFLen - String(stats.scannedFull).length) + value(stats.scannedFull) + '   ' +
     pad(1 + maxSILen - String(stats.scannedIndex).length) + value(stats.scannedIndex) + '   ' +
     pad(1 + maxFLen - String(stats.filtered).length) + value(stats.filtered) + '   ' +
+    pad(1 + maxMem - String(stats.peakMemoryUsage).length) + value(stats.peakMemoryUsage) + '   ' +
     pad(1 + maxETen - String(stats.executionTime).length) + value(stats.executionTime));
   stringBuilder.appendLine();
 }
@@ -2128,7 +2130,9 @@ function profileQuery(data, shouldPrint) {
     throw 'ArangoStatement needs initial data';
   }
   let options = data.options || {};
-  options.silent = true;
+  if (!options.hasOwnProperty('silent')) {
+    options.silent = true;
+  }
   options.allPlans = false; // always turn this off, as it will not work with profiling
   setColors(options.colors === undefined ? true : options.colors);
 

--- a/tests/Aql/WaitingExecutionBlockMock.cpp
+++ b/tests/Aql/WaitingExecutionBlockMock.cpp
@@ -107,7 +107,7 @@ std::pair<arangodb::aql::ExecutionState, arangodb::Result> WaitingExecutionBlock
   return {ExecutionState::DONE, TRI_ERROR_NO_ERROR};
 }
 
-std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> WaitingExecutionBlockMock::execute(AqlCallStack stack) {
+std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> WaitingExecutionBlockMock::execute(AqlCallStack const& stack) {
   traceExecuteBegin(stack);
   auto res = executeWithoutTrace(stack);
   traceExecuteEnd(res);

--- a/tests/Aql/WaitingExecutionBlockMock.h
+++ b/tests/Aql/WaitingExecutionBlockMock.h
@@ -82,7 +82,7 @@ class WaitingExecutionBlockMock final : public arangodb::aql::ExecutionBlock {
       arangodb::aql::InputAqlItemRow const& input) override;
 
   std::tuple<arangodb::aql::ExecutionState, arangodb::aql::SkipResult, arangodb::aql::SharedAqlItemBlockPtr> execute(
-      arangodb::aql::AqlCallStack stack) override;
+      arangodb::aql::AqlCallStack const& stack) override;
 
  private:
   // Implementation of execute


### PR DESCRIPTION
### Scope & Purpose

This PR contains two changes:
1) show peak memory usage in AQL query profiling output
2) slightly improve the efficiency of some internal AQL APIs by copying less data

Re 2): the efficiency gains will be potentially not noticable, but avoiding a few copies here and there should do no harm.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
