### PR TITLE
Fix shard error multiplication

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.7.11 (XXXX-XX-XX)
 --------------------
 
+* Fixed a problem in document batch operations, where errors from one shard
+  were reported multiple times, if the shard is completely off line.
+
 * Fixed issue #13169: arangoimport tsv conversion of bools and null, although
   switched off by `--convert false`.
 

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -335,17 +335,10 @@ OperationResult handleCRUDShardResponsesFast(F&& func, CT const& opCtx,
     if (it == resultMap.end()) { // no answer from this shard
       auto const& it2 = shardError.find(sId);
       TRI_ASSERT(it2 != shardError.end());
-
-      auto weSend = opCtx.shardMap.find(sId);
-      TRI_ASSERT(weSend != opCtx.shardMap.end());  // We send sth there earlier.
-      size_t count = weSend->second.size();
-      for (size_t i = 0; i < count; ++i) {
-        resultBody.openObject(/*unindexed*/ true);
-        resultBody.add(StaticStrings::Error, VPackValue(true));
-        resultBody.add(StaticStrings::ErrorNum, VPackValue(it2->second));
-        resultBody.close();
-      }
-
+      resultBody.openObject(/*unindexed*/ true);
+      resultBody.add(StaticStrings::Error, VPackValue(true));
+      resultBody.add(StaticStrings::ErrorNum, VPackValue(it2->second));
+      resultBody.close();
     } else {
       VPackSlice arr = it->second;
       // we expect an array of baby-documents, but the response might


### PR DESCRIPTION
This fixes a problem found with the new testagent. In document batch
operations (which are also used for import jobs) there is a problem in
the error handling if a shard is completely off line (all replicas
cannot be reached for 15 minutes). In that case, the errors for the
individual documents of the batch for that shard are multiplied, for
each document, as many errors are created as the batch size is.
This essentially squares the number of bad responses.

 - Do not multiply shard errors.
 - CHANGELOG.

Scope & Purpose

(Please describe the changes in this PR for reviewers - mandatory)

    [*] Bugfix (requires CHANGELOG entry)

Backports:

    [*] Backports required for: 3.6, 3.7, 3.8

Related Information

(Please reference tickets / specification / other PRs etc)

    [*] This is a backport from: https://github.com/arangodb/arangodb/pull/13970/
    [*] Jira ticket number: https://arangodb.atlassian.net/browse/BTS-369

Testing & Verification

(Please pick either of the following options)

    [*] This change is a trivial rework / code cleanup without any test coverage.
    [*] The behavior in this PR was manually tested

