### PR TITLE
slightly cleanup startup options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Don't display obsoleted startup options and sections in `--help` and
+  `--help-.` commands.
+
 * Fixed a problem in document batch operations, where errors from one shard
   were reported multiple times, if the shard is completely off line.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ devel
 -----
 
 * Don't display obsoleted startup options and sections in `--help` and
-  `--help-.` commands.
+  `--help-.` commands. Also rename "global" to "general" options.
 
 * Fixed a problem in document batch operations, where errors from one shard
   were reported multiple times, if the shard is completely off line.

--- a/arangod/Actions/ActionFeature.cpp
+++ b/arangod/Actions/ActionFeature.cpp
@@ -41,8 +41,6 @@ ActionFeature::ActionFeature(application_features::ApplicationServer& server)
 }
 
 void ActionFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("server", "Server features");
-
   options->addOption(
       "--server.allow-use-database",
       "allow change of database in REST actions, only needed for "

--- a/arangod/Agency/AgencyFeature.cpp
+++ b/arangod/Agency/AgencyFeature.cpp
@@ -75,7 +75,7 @@ AgencyFeature::AgencyFeature(application_features::ApplicationServer& server)
 AgencyFeature::~AgencyFeature() = default;
 
 void AgencyFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("agency", "Configure the agency");
+  options->addSection("agency", "agency");
 
   options->addOption("--agency.activate", "Activate agency",
                      new BooleanParameter(&_activated),

--- a/arangod/Cache/CacheManagerFeature.cpp
+++ b/arangod/Cache/CacheManagerFeature.cpp
@@ -66,7 +66,7 @@ CacheManagerFeature::CacheManagerFeature(application_features::ApplicationServer
 CacheManagerFeature::~CacheManagerFeature() = default;
 
 void CacheManagerFeature::collectOptions(std::shared_ptr<options::ProgramOptions> options) {
-  options->addSection("cache", "Configure the hash cache");
+  options->addSection("cache", "in-memory hash cache");
 
   options->addOption("--cache.size", "size of cache in bytes",
                      new UInt64Parameter(&_cacheSize),

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -83,7 +83,7 @@ ClusterFeature::~ClusterFeature() {
 }
 
 void ClusterFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("cluster", "Configure the cluster");
+  options->addSection("cluster", "cluster");
 
   options->addObsoleteOption("--cluster.username",
                              "username used for cluster-internal communication", true);

--- a/arangod/Cluster/MaintenanceFeature.cpp
+++ b/arangod/Cluster/MaintenanceFeature.cpp
@@ -132,8 +132,6 @@ MaintenanceFeature::MaintenanceFeature(application_features::ApplicationServer& 
 }
 
 void MaintenanceFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("server", "Server features");
-
   options->addOption(
       "--server.maintenance-threads",
       "maximum number of threads available for maintenance actions",

--- a/arangod/Cluster/ReplicationTimeoutFeature.cpp
+++ b/arangod/Cluster/ReplicationTimeoutFeature.cpp
@@ -54,8 +54,6 @@ ReplicationTimeoutFeature::ReplicationTimeoutFeature(application_features::Appli
 }
 
 void ReplicationTimeoutFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("cluster", "Configure the cluster");
-
   options->addOption("--cluster.synchronous-replication-timeout-minimum",
                      "all synchronous replication timeouts will be at least "
                      "this value (in seconds)",

--- a/arangod/GeneralServer/AuthenticationFeature.cpp
+++ b/arangod/GeneralServer/AuthenticationFeature.cpp
@@ -67,8 +67,6 @@ AuthenticationFeature::AuthenticationFeature(application_features::ApplicationSe
 }
 
 void AuthenticationFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("server", "Server features");
-
   options->addOldOption("server.disable-authentication",
                         "server.authentication");
   options->addOldOption("server.disable-authentication-unix-sockets",

--- a/arangod/GeneralServer/GeneralServerFeature.cpp
+++ b/arangod/GeneralServer/GeneralServerFeature.cpp
@@ -140,8 +140,6 @@ GeneralServerFeature::GeneralServerFeature(application_features::ApplicationServ
 }
 
 void GeneralServerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("server", "Server features");
-
   options->addOldOption("server.allow-method-override",
                         "http.allow-method-override");
   options->addOldOption("server.hide-product-header",
@@ -155,7 +153,7 @@ void GeneralServerFeature::collectOptions(std::shared_ptr<ProgramOptions> option
                      new UInt64Parameter(&_numIoThreads),
                      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Dynamic));
 
-  options->addSection("http", "HttpServer features");
+  options->addSection("http", "HTTP server features");
 
   options->addOption("--http.allow-method-override",
                      "allow HTTP method override using special headers",
@@ -176,8 +174,6 @@ void GeneralServerFeature::collectOptions(std::shared_ptr<ProgramOptions> option
   options->addOption("--http.trusted-origin",
                      "trusted origin URLs for CORS requests with credentials",
                      new VectorParameter<StringParameter>(&_accessControlAllowOrigins));
-
-  options->addSection("frontend", "Frontend options");
 
   options->addOption("--frontend.proxy-request-check",
                      "enable proxy request checking",

--- a/arangod/GeneralServer/ServerSecurityFeature.cpp
+++ b/arangod/GeneralServer/ServerSecurityFeature.cpp
@@ -42,14 +42,12 @@ ServerSecurityFeature::ServerSecurityFeature(application_features::ApplicationSe
 }
 
 void ServerSecurityFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("server", "Server features");
   options->addOption("--server.harden",
                      "lock down REST APIs that reveal version information or server "
                      "internals for non-admin users",
                      new BooleanParameter(&_hardenedRestApi))
                      .setIntroducedIn(30500);
 
-  options->addSection("foxx", "Configure Foxx");
   options->addOption("--foxx.api", "enables Foxx management REST APIs",
                      new BooleanParameter(&_enableFoxxApi),
                      arangodb::options::makeFlags(

--- a/arangod/GeneralServer/SslServerFeature.cpp
+++ b/arangod/GeneralServer/SslServerFeature.cpp
@@ -86,7 +86,7 @@ void SslServerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addOldOption("server.ssl-options", "ssl.options");
   options->addOldOption("server.ssl-protocol", "ssl.protocol");
 
-  options->addSection("ssl", "Configure SSL communication");
+  options->addSection("ssl", "SSL communication");
 
   options->addOption("--ssl.cafile", "ca file used for secure connections",
                      new StringParameter(&_cafile));

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -830,8 +830,7 @@ void IResearchFeature::beginShutdown() {
 
 void IResearchFeature::collectOptions(std::shared_ptr<arangodb::options::ProgramOptions> options) {
   _running.store(false);
-  options->addSection("arangosearch",
-                      std::string("Configure the ") + FEATURE_NAME + " feature");
+  options->addSection("arangosearch", FEATURE_NAME + " feature");
   options->addOption(THREADS_PARAM,
                      "the exact number of threads to use for asynchronous "
                      "tasks (0 == autodetect)",

--- a/arangod/Network/NetworkFeature.cpp
+++ b/arangod/Network/NetworkFeature.cpp
@@ -113,7 +113,7 @@ NetworkFeature::NetworkFeature(application_features::ApplicationServer& server,
 }
 
 void NetworkFeature::collectOptions(std::shared_ptr<options::ProgramOptions> options) {
-  options->addSection("network", "Configure cluster-internal networking");
+  options->addSection("network", "cluster-internal networking");
 
   options->addOption("--network.io-threads", "number of network IO threads for cluster-internal communication",
                      new UInt32Parameter(&_numIOThreads))

--- a/arangod/Replication/ReplicationFeature.cpp
+++ b/arangod/Replication/ReplicationFeature.cpp
@@ -110,7 +110,7 @@ ReplicationFeature::ReplicationFeature(ApplicationServer& server)
 ReplicationFeature::~ReplicationFeature() = default;
 
 void ReplicationFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("replication", "Configure the replication");
+  options->addSection("replication", "replication");
   options->addOption("--replication.auto-start",
                      "switch to enable or disable the automatic start "
                      "of replication appliers",

--- a/arangod/RestServer/CheckVersionFeature.cpp
+++ b/arangod/RestServer/CheckVersionFeature.cpp
@@ -69,8 +69,6 @@ CheckVersionFeature::CheckVersionFeature(application_features::ApplicationServer
 }
 
 void CheckVersionFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("database", "Configure the database");
-
   options->addOldOption("check-version", "database.check-version");
 
   options->addOption("--database.check-version",

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -297,7 +297,7 @@ DatabaseFeature::~DatabaseFeature() {
 }
 
 void DatabaseFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("database", "Configure the database");
+  options->addSection("database", "database");
 
   options->addOption("--database.wait-for-sync",
                      "default wait-for-sync behavior, can be overwritten "

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -297,7 +297,7 @@ DatabaseFeature::~DatabaseFeature() {
 }
 
 void DatabaseFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("database", "database");
+  options->addSection("database", "database options");
 
   options->addOption("--database.wait-for-sync",
                      "default wait-for-sync behavior, can be overwritten "

--- a/arangod/RestServer/DatabasePathFeature.cpp
+++ b/arangod/RestServer/DatabasePathFeature.cpp
@@ -60,8 +60,6 @@ DatabasePathFeature::DatabasePathFeature(application_features::ApplicationServer
 }
 
 void DatabasePathFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("database", "Configure the database");
-
   options->addOption("--database.directory", "path to the database directory",
                      new StringParameter(&_directory));
 

--- a/arangod/RestServer/EndpointFeature.cpp
+++ b/arangod/RestServer/EndpointFeature.cpp
@@ -58,8 +58,6 @@ void EndpointFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addOldOption("server.backlog-size", "tcp.backlog-size");
   options->addOldOption("server.reuse-address", "tcp.reuse-address");
 
-  options->addSection("server", "Server features");
-
   options->addOption("--server.endpoint",
                      "endpoint for client requests (e.g. "
                      "'http+tcp://127.0.0.1:8529', or "

--- a/arangod/RestServer/FileDescriptorsFeature.cpp
+++ b/arangod/RestServer/FileDescriptorsFeature.cpp
@@ -116,8 +116,6 @@ FileDescriptorsFeature::FileDescriptorsFeature(application_features::Application
 }
 
 void FileDescriptorsFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("server", "Server features");
-
   options->addOption("--server.descriptors-minimum",
                      "minimum number of file descriptors needed to start (0 = no minimum)",
                      new UInt64Parameter(&_descriptorsMinimum),

--- a/arangod/RestServer/FlushFeature.cpp
+++ b/arangod/RestServer/FlushFeature.cpp
@@ -61,7 +61,6 @@ FlushFeature::FlushFeature(application_features::ApplicationServer& server)
 }
 
 void FlushFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("server", "Server features");
   options->addOption("--server.flush-interval",
                      "interval (in microseconds) for flushing data",
                      new UInt64Parameter(&_flushInterval),

--- a/arangod/RestServer/FrontendFeature.cpp
+++ b/arangod/RestServer/FrontendFeature.cpp
@@ -41,7 +41,7 @@ FrontendFeature::FrontendFeature(application_features::ApplicationServer& server
 }
 
 void FrontendFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("frontend", "Configure the frontend");
+  options->addSection("frontend", "frontend");
 
   options->addOption("--frontend.version-check",
                      "alert the user if new versions are available",

--- a/arangod/RestServer/FrontendFeature.cpp
+++ b/arangod/RestServer/FrontendFeature.cpp
@@ -41,7 +41,7 @@ FrontendFeature::FrontendFeature(application_features::ApplicationServer& server
 }
 
 void FrontendFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("frontend", "frontend");
+  options->addSection("frontend", "web interface");
 
   options->addOption("--frontend.version-check",
                      "alert the user if new versions are available",

--- a/arangod/RestServer/InitDatabaseFeature.cpp
+++ b/arangod/RestServer/InitDatabaseFeature.cpp
@@ -70,8 +70,6 @@ InitDatabaseFeature::InitDatabaseFeature(application_features::ApplicationServer
 }
 
 void InitDatabaseFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("database", "Configure the database");
-
   options->addOption("--database.init-database", "initializes an empty database",
                      new BooleanParameter(&_initDatabase),
                      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden,

--- a/arangod/RestServer/QueryRegistryFeature.cpp
+++ b/arangod/RestServer/QueryRegistryFeature.cpp
@@ -207,7 +207,7 @@ QueryRegistryFeature::QueryRegistryFeature(application_features::ApplicationServ
 }
 
 void QueryRegistryFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("query", "Configure queries");
+  options->addSection("query", "AQL queries");
 
   options->addOldOption("database.query-cache-mode", "query.cache-mode");
   options->addOldOption("database.query-cache-max-results",

--- a/arangod/RestServer/ScriptFeature.cpp
+++ b/arangod/RestServer/ScriptFeature.cpp
@@ -51,8 +51,6 @@ ScriptFeature::ScriptFeature(application_features::ApplicationServer& server, in
 }
 
 void ScriptFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("javascript", "Configure the JavaScript engine");
-
   options->addOption("--javascript.script-parameter", "script parameter",
                      new VectorParameter<StringParameter>(&_scriptParameters));
 }

--- a/arangod/RestServer/ServerFeature.cpp
+++ b/arangod/RestServer/ServerFeature.cpp
@@ -78,7 +78,7 @@ void ServerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addOption("--console", "start a JavaScript emergency console",
                      new BooleanParameter(&_console));
 
-  options->addSection("server", "Server features");
+  options->addSection("server", "server features");
 
   options->addOption("--server.rest-server", "start a rest-server",
                      new BooleanParameter(&_restServer),
@@ -87,8 +87,6 @@ void ServerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addOption("--server.validate-utf8-strings", "perform UTF-8 string validation for incoming JSON and VelocyPack data",
                      new BooleanParameter(&_validateUtf8Strings),
                      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden)).setIntroducedIn(30700);
-
-  options->addSection("javascript", "Configure the JavaScript engine");
 
   options->addOption("--javascript.script", "run scripts and exit",
                      new VectorParameter<StringParameter>(&_scripts));
@@ -101,7 +99,7 @@ void ServerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
 #endif
 
   // add several obsoleted options here
-  options->addSection("vst", "Configure the VelocyStream protocol");
+  options->addSection("vst", "VelocyStream protocol", "", true, true);
   options->addObsoleteOption("--vst.maxsize", "maximal size (in bytes) "
                              "for a VelocyPack chunk", true);
   
@@ -110,7 +108,7 @@ void ServerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
       "timeout of web interface server sessions (in seconds)", true);
 
   // add obsolete MMFiles WAL options (obsoleted in 3.7)
-  options->addSection("wal", "Configure the WAL of the MMFiles engine");
+  options->addSection("wal", "WAL of the MMFiles engine", "", true, true);
   options->addObsoleteOption("--wal.allow-oversize-entries",
                              "allow entries that are bigger than '--wal.logfile-size'", false);
   options->addObsoleteOption("--wal.use-mlock",

--- a/arangod/RestServer/TtlFeature.cpp
+++ b/arangod/RestServer/TtlFeature.cpp
@@ -401,7 +401,7 @@ TtlFeature::~TtlFeature() {
 }
 
 void TtlFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("ttl", "TTL options");
+  options->addSection("ttl", "TTL index options");
 
   options->addOption("ttl.frequency", "frequency (in milliseconds) for the TTL background thread invocation. "
                      "a value of 0 turns the TTL background thread off entirely",

--- a/arangod/RestServer/UpgradeFeature.cpp
+++ b/arangod/RestServer/UpgradeFeature.cpp
@@ -73,8 +73,6 @@ void UpgradeFeature::addTask(methods::Upgrade::Task&& task) {
 }
 
 void UpgradeFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("database", "Configure the database");
-
   options->addOldOption("upgrade", "database.auto-upgrade");
 
   options->addOption("--database.auto-upgrade",

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -270,7 +270,7 @@ void RocksDBEngine::shutdownRocksDBInstance() noexcept {
 
 // add the storage engine's specific options to the global list of options
 void RocksDBEngine::collectOptions(std::shared_ptr<options::ProgramOptions> options) {
-  options->addSection("rocksdb", "RocksDB engine specific configuration");
+  options->addSection("rocksdb", "RocksDB engine");
   
   /// @brief minimum required percentage of free disk space for considering the
   /// server "healthy". this is expressed as a floating point value between 0 and 1!

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -191,7 +191,7 @@ RocksDBOptionFeature::RocksDBOptionFeature(application_features::ApplicationServ
 }
 
 void RocksDBOptionFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("rocksdb", "Configure the RocksDB engine");
+  options->addSection("rocksdb", "RocksDB engine");
 
   options->addObsoleteOption("--rocksdb.enabled",
                              "obsolete always active - Whether or not the "

--- a/arangod/Scheduler/SchedulerFeature.cpp
+++ b/arangod/Scheduler/SchedulerFeature.cpp
@@ -89,8 +89,6 @@ void SchedulerFeature::collectOptions(std::shared_ptr<options::ProgramOptions> o
   // Different implementations of the Scheduler may require different
   // options to be set. This requires a solution here.
 
-  options->addSection("server", "Server features");
-
   // max / min number of threads
   options->addOption("--server.maximal-threads",
                      std::string(

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -561,8 +561,6 @@ StatisticsFeature::~StatisticsFeature() = default;
 void StatisticsFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addOldOption("server.disable-statistics", "server.statistics");
 
-  options->addSection("server", "Server features");
-
   options->addOption("--server.statistics",
                      "turn statistics gathering on or off",
                      new BooleanParameter(&_statistics));

--- a/arangod/StorageEngine/EngineSelectorFeature.cpp
+++ b/arangod/StorageEngine/EngineSelectorFeature.cpp
@@ -73,8 +73,6 @@ EngineSelectorFeature::EngineSelectorFeature(application_features::ApplicationSe
 }
 
 void EngineSelectorFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("server", "Server features");
-
   options->addOption("--server.storage-engine",
                      "storage engine type "
                      "(note that the mmfiles engine is unavailable since "

--- a/arangod/Transaction/ManagerFeature.cpp
+++ b/arangod/Transaction/ManagerFeature.cpp
@@ -105,7 +105,7 @@ ManagerFeature::ManagerFeature(application_features::ApplicationServer& server)
 }
 
 void ManagerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("transaction", "Transaction features");
+  options->addSection("transaction", "transactions");
 
   options->addOption("--transaction.streaming-lock-timeout", "lock timeout in seconds "
 		     "in case of parallel access to the same streaming transaction",

--- a/arangod/V8Server/FoxxFeature.cpp
+++ b/arangod/V8Server/FoxxFeature.cpp
@@ -41,7 +41,7 @@ FoxxFeature::FoxxFeature(application_features::ApplicationServer& server)
 }
 
 void FoxxFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("foxx", "Configure Foxx");
+  options->addSection("foxx", "Foxx services");
 
   options->addOldOption("server.foxx-queues", "foxx.queues");
   options->addOldOption("server.foxx-queues-poll-interval",

--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -155,7 +155,7 @@ V8DealerFeature::V8DealerFeature(application_features::ApplicationServer& server
 }
 
 void V8DealerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("javascript", "Configure the JavaScript engine");
+  options->addSection("javascript", "JavaScript engine and execution");
 
   options->addOption(
       "--javascript.gc-frequency",

--- a/arangosh/Shell/ClientFeature.cpp
+++ b/arangosh/Shell/ClientFeature.cpp
@@ -81,7 +81,7 @@ ClientFeature::ClientFeature(application_features::ApplicationServer& server,
 }
 
 void ClientFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("server", "Configure a connection to the server");
+  options->addSection("server", "server connection");
 
   options->addOption("--server.database", "database name to use when connecting",
                      new StringParameter(&_databaseName));
@@ -155,7 +155,7 @@ void ClientFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
 
   std::unordered_set<uint64_t> const sslProtocols = availableSslProtocols();
 
-  options->addSection("ssl", "Configure SSL communication");
+  options->addSection("ssl", "SSL communication");
   options->addOption("--ssl.protocol", availableSslProtocolsDescription(),
                      new DiscreteValuesParameter<UInt64Parameter>(&_sslProtocol, sslProtocols));
 #if _WIN32

--- a/arangosh/Shell/ConsoleFeature.cpp
+++ b/arangosh/Shell/ConsoleFeature.cpp
@@ -112,7 +112,7 @@ ConsoleFeature::ConsoleFeature(application_features::ApplicationServer& server)
 void ConsoleFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addOption("--quiet", "silent startup", new BooleanParameter(&_quiet));
 
-  options->addSection("console", "Configure the console");
+  options->addSection("console", "console");
 
   options->addOption("--console.colors", "enable color support",
                      new BooleanParameter(&_colors),

--- a/arangosh/Shell/V8ShellFeature.cpp
+++ b/arangosh/Shell/V8ShellFeature.cpp
@@ -95,7 +95,7 @@ V8ShellFeature::V8ShellFeature(application_features::ApplicationServer& server,
 }
 
 void V8ShellFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("javascript", "Configure the JavaScript engine");
+  options->addSection("javascript", "JavaScript engine");
 
   options->addOption("--javascript.startup-directory",
                      "startup paths containing the JavaScript files",

--- a/lib/ApplicationFeatures/ApplicationServer.cpp
+++ b/lib/ApplicationFeatures/ApplicationServer.cpp
@@ -290,7 +290,7 @@ void ApplicationServer::apply(std::function<void(ApplicationFeature&)> callback,
 void ApplicationServer::collectOptions() {
   LOG_TOPIC("0eac7", TRACE, Logger::STARTUP) << "ApplicationServer::collectOptions";
 
-  _options->addSection(Section("", "global settings", "", "global options", false, false));
+  _options->addSection(Section("", "general settings", "", "general options", false, false));
 
   _options->addOption("--dump-dependencies", "dump dependency graph",
                       new BooleanParameter(&_dumpDependencies),

--- a/lib/ApplicationFeatures/ApplicationServer.cpp
+++ b/lib/ApplicationFeatures/ApplicationServer.cpp
@@ -290,7 +290,7 @@ void ApplicationServer::apply(std::function<void(ApplicationFeature&)> callback,
 void ApplicationServer::collectOptions() {
   LOG_TOPIC("0eac7", TRACE, Logger::STARTUP) << "ApplicationServer::collectOptions";
 
-  _options->addSection(Section("", "Global configuration", "", "global options", false, false));
+  _options->addSection(Section("", "global settings", "", "global options", false, false));
 
   _options->addOption("--dump-dependencies", "dump dependency graph",
                       new BooleanParameter(&_dumpDependencies),

--- a/lib/ApplicationFeatures/MaxMapCountFeature.cpp
+++ b/lib/ApplicationFeatures/MaxMapCountFeature.cpp
@@ -46,8 +46,6 @@ MaxMapCountFeature::MaxMapCountFeature(application_features::ApplicationServer& 
 }
 
 void MaxMapCountFeature::collectOptions(std::shared_ptr<options::ProgramOptions> options) {
-  options->addSection("server", "Server Options");
-
   options->addObsoleteOption(
       "--server.check-max-memory-mappings",
       "check the maximum number of memory mappings at startup", true);

--- a/lib/ApplicationFeatures/NonceFeature.cpp
+++ b/lib/ApplicationFeatures/NonceFeature.cpp
@@ -34,20 +34,19 @@ using namespace arangodb::options;
 namespace arangodb {
 
 NonceFeature::NonceFeature(application_features::ApplicationServer& server)
-    : ApplicationFeature(server, "Nonce"), _size(4 * 1024 * 1024) {
+    : ApplicationFeature(server, "Nonce") {
   setOptional(true);
   startsAfter<application_features::GreetingsFeaturePhase>();
 }
 
 void NonceFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("nonce", "Configure the nonces");
-
-  options->addOption("--nonce.size", "the size of the hash array for nonces",
-                     new UInt64Parameter(&_size));
+  options->addSection("nonce", "nonces", "", true, true);
+  options->addObsoleteOption("--nonce.size", "the size of the hash array for nonces", true);
 }
 
 void NonceFeature::prepare() {
-  Nonce::setInitialSize(static_cast<size_t>(_size));
+  constexpr uint64_t initialSize = 2 * 1024 * 1024;
+  Nonce::setInitialSize(static_cast<size_t>(initialSize));
 }
 
 void NonceFeature::unprepare() { Nonce::destroy(); }

--- a/lib/ApplicationFeatures/NonceFeature.h
+++ b/lib/ApplicationFeatures/NonceFeature.h
@@ -37,9 +37,6 @@ class NonceFeature : public application_features::ApplicationFeature {
   void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
   void prepare() override final;
   void unprepare() override final;
-
- private:
-  uint64_t _size;
 };
 
 }  // namespace arangodb

--- a/lib/ApplicationFeatures/PrivilegeFeature.cpp
+++ b/lib/ApplicationFeatures/PrivilegeFeature.cpp
@@ -64,8 +64,6 @@ PrivilegeFeature::PrivilegeFeature(application_features::ApplicationServer& serv
 }
 
 void PrivilegeFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("server", "Server features");
-
 #ifdef ARANGODB_HAVE_SETUID
   options->addOption("--uid", "switch to user-id after reading config files",
                      new StringParameter(&_uid),

--- a/lib/ApplicationFeatures/TempFeature.cpp
+++ b/lib/ApplicationFeatures/TempFeature.cpp
@@ -45,7 +45,7 @@ TempFeature::TempFeature(application_features::ApplicationServer& server,
 void TempFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addOldOption("temp-path", "temp.path");
 
-  options->addSection("temp", "Configure temporary files");
+  options->addSection("temp", "temporary files");
 
   options->addOption("--temp.path", "path for temporary files",
                      new StringParameter(&_path));

--- a/lib/ApplicationFeatures/V8PlatformFeature.cpp
+++ b/lib/ApplicationFeatures/V8PlatformFeature.cpp
@@ -161,7 +161,7 @@ V8PlatformFeature::V8PlatformFeature(application_features::ApplicationServer& se
 }
 
 void V8PlatformFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("javascript", "Configure the JavaScript engine");
+  options->addSection("javascript", "JavaScript engine and execution");
 
   options->addOption("--javascript.v8-options", "options to pass to v8",
                      new VectorParameter<StringParameter>(&_v8Options),

--- a/lib/ApplicationFeatures/V8SecurityFeature.cpp
+++ b/lib/ApplicationFeatures/V8SecurityFeature.cpp
@@ -178,7 +178,7 @@ V8SecurityFeature::V8SecurityFeature(application_features::ApplicationServer& se
 }
 
 void V8SecurityFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("javascript", "Configure the JavaScript engine");
+  options->addSection("javascript", "JavaScript engine and execution");
   options
       ->addOption("--javascript.allow-port-testing",
                   "allow testing of ports from within JavaScript actions",

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -104,7 +104,7 @@ void LoggerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                   arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden))
       .setDeprecatedIn(30500);
 
-  options->addSection("log", "Configure the logging");
+  options->addSection("log", "logging");
 
   options->addOption("--log.color", "use colors for TTY logging",
                      new BooleanParameter(&_useColor),

--- a/lib/ProgramOptions/ProgramOptions.cpp
+++ b/lib/ProgramOptions/ProgramOptions.cpp
@@ -94,7 +94,6 @@ void ProgramOptions::printUsage() const {
 }
 
 // prints a help for all options, or the options of a section
-// the special search string "*" will show help for all sections
 // the special search string "." will show help for all sections, even if
 // hidden
 void ProgramOptions::printHelp(std::string const& search) const {
@@ -106,7 +105,8 @@ void ProgramOptions::printHelp(std::string const& search) const {
   size_t const ow = optionsWidth();
 
   for (auto const& it : _sections) {
-    if (search == "*" || search == "." || search == it.second.name) {
+    if (search == it.second.name ||
+        ((search == "*" || search == ".") && !it.second.obsolete)) {
       it.second.printHelp(search, tw, ow, colors);
     }
   }
@@ -129,7 +129,7 @@ void ProgramOptions::printSectionsHelp() const {
   // print names of sections
   std::cout << _more;
   for (auto const& it : _sections) {
-    if (!it.second.name.empty() && it.second.hasOptions()) {
+    if (!it.second.name.empty() && it.second.hasOptions() && !it.second.obsolete) {
       std::cout << "  " << colorStart << "--help-" << it.second.name << colorEnd;
     }
   }

--- a/lib/ProgramOptions/ProgramOptions.h
+++ b/lib/ProgramOptions/ProgramOptions.h
@@ -140,13 +140,13 @@ class ProgramOptions {
   }
 
   // adds a (regular) section to the program options
-  auto addSection(std::string const& name, std::string const& description, std::string const& link = "") {
-    return addSection(Section(name, description, link, "", false, false));
+  auto addSection(std::string const& name, std::string const& description, std::string const& link = "", bool hidden = false, bool obsolete = false) {
+    return addSection(Section(name, description, link, "", hidden, obsolete));
   }
 
   // adds an enterprise-only section to the program options
-  auto addEnterpriseSection(std::string const& name, std::string const& description, std::string const& link = "") {
-    return addSection(EnterpriseSection(name, description, link, "", false, false));
+  auto addEnterpriseSection(std::string const& name, std::string const& description, std::string const& link = "", bool hidden = false, bool obsolete = false) {
+    return addSection(EnterpriseSection(name, description, link, "", hidden, obsolete));
   }
 
   // adds an option to the program options

--- a/lib/ProgramOptions/Section.cpp
+++ b/lib/ProgramOptions/Section.cpp
@@ -53,7 +53,7 @@ void Section::printHelp(std::string const& search, size_t tw, size_t ow, bool co
     << (colors ? ShellColorsFeature::SHELL_COLOR_BRIGHT : "")
     << displayName() 
     << (colors ? ShellColorsFeature::SHELL_COLOR_RESET : "")
-    << "' (" << description << ")";
+    << "' (configure " << description << ")";
 
   if (!link.empty()) {
     std::cout << " [";
@@ -78,7 +78,12 @@ void Section::printHelp(std::string const& search, size_t tw, size_t ow, bool co
       std::cout << " # " << (*hl).second << std::endl;
       ++hl;
     }
-
+    
+    if (it.second.hasFlag(arangodb::options::Flags::Obsolete)) {
+      // skip obsolete options
+      continue;
+    }
+    
     // print help for option
     it.second.printHelp(search, tw, ow, colors);
   }

--- a/lib/Random/RandomFeature.cpp
+++ b/lib/Random/RandomFeature.cpp
@@ -42,7 +42,7 @@ RandomFeature::RandomFeature(application_features::ApplicationServer& server)
 }
 
 void RandomFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("random", "Configure the random generator");
+  options->addSection("random", "random generator");
 
 #ifdef _WIN32
   std::unordered_set<uint32_t> generators = {1, 5};


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/667

Do not display obsoleted options in `--help` and `--help-.` commands.
Additionally remove redundant declarations of identical program options sections in the code (one declaration is enough).

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/667

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
