### PR TITLE
Fix ordering of Database and FlushFeatures

### DIFF
--- a/arangod/RestServer/FlushFeature.cpp
+++ b/arangod/RestServer/FlushFeature.cpp
@@ -56,6 +56,7 @@ FlushFeature::FlushFeature(application_features::ApplicationServer& server)
   setOptional(true);
   startsAfter<BasicFeaturePhaseServer>();
 
+  startsAfter<DatabaseFeature>();
   startsAfter<StorageEngineFeature>();
 }
 


### PR DESCRIPTION
### Scope & Purpose

The FlushFeature uses the Instance of DatabaseFeature during start().
This instance is only set during start() of DatabaseFeature but the dependency is not defined.
As the startup is consistent after a build it by accident worked, now we force it to be correct.
Hence no changelog as it will not have visible effect.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made
