### PR TITLE
added escaping of the filename string when printing it in the web ui

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/lib/jquery.uploadfile.min.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/lib/jquery.uploadfile.min.js
@@ -227,7 +227,7 @@
 				fileNameStr += " ("+getSizeStr(filesize)+")";
 
 
-            pd.filename.html(fileNameStr);
+            pd.filename.html(arangoHelper.escapeHtml(fileNameStr));
             obj.fileCounter++;
             obj.selectedFiles++;
             if(s.showPreview)
@@ -409,7 +409,7 @@
 
                 ts.fileData = fd;
                 var pd = new createProgressDiv(obj, s);
-                pd.filename.html(fileListStr);
+                pd.filename.html(arangoHelper.escapeHtml(fileNameStr));
                 var form = $("<form style='display:block; position:absolute;left: 150px;' class='" + obj.formGroup + "' method='" + s.method + "' action='" + s.url + "' enctype='" + s.enctype + "'></form>");
                 form.appendTo('body');
                 ajaxFormSubmit(form, ts, pd, fileArray, obj);
@@ -463,7 +463,7 @@
 				if(s.showFileSize)
 				fileNameStr += " ("+getSizeStr(files[i].size)+")";
 
-				pd.filename.html(fileNameStr);
+				pd.filename.html(arangoHelper.escapeHtml(fileNameStr));
                 var form = $("<form style='display:block; position:absolute;left: 150px;' class='" + obj.formGroup + "' method='" + s.method + "' action='" +
                     s.url + "' enctype='" + s.enctype + "'></form>");
                 form.appendTo('body');
@@ -606,7 +606,7 @@
                     obj.selectedFiles += fileArray.length;
 
                     var pd = new createProgressDiv(obj, s);
-                    pd.filename.html(fileList);
+                    pd.filename.html(arangoHelper.escapeHtml(fileList));
                     ajaxFormSubmit(form, s, pd, fileArray, obj, null);
                 }
 


### PR DESCRIPTION
### Scope & Purpose

When a zip file is being uploaded, the file name of the file (or filelist in case multiple files are supplied) will be printed during /after the upload process. That name (string) is not being escaped., but it needs to be.

This PR fixes this behaviour. 

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.7

### Testing & Verification

*(Please pick either of the following options)*

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*