### PR TITLE
deprecate the /_admin/statistics API in favor of /_admin/metrics/v2

### DIFF
--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_statistics.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_statistics.md
@@ -4,6 +4,13 @@
 
 @RESTHEADER{GET /_admin/statistics, Read the statistics, getStatistics}
 
+@HINTS
+{% hint 'warning' %}
+This endpoint should no longer be used. It is deprecated from version 3.8.0 on.
+Use `/_admin/metrics/v2` instead, which provides the data exposed by this API
+and a lot more.
+{% endhint %}
+
 @RESTDESCRIPTION
 Returns the statistics information. The returned object contains the
 statistics figures grouped together according to the description returned by

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_statistics_description.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_statistics_description.md
@@ -4,6 +4,13 @@
 
 @RESTHEADER{GET /_admin/statistics-description, Statistics description, getStatisticsDescription}
 
+@HINTS
+{% hint 'warning' %}
+This endpoint should no longer be used. It is deprecated from version 3.8.0 on.
+Use `/_admin/metrics/v2` instead, which provides the data exposed by the
+statistics API and a lot more.
+{% endhint %}
+
 @RESTDESCRIPTION
 Returns a description of the statistics returned by */_admin/statistics*.
 The returned objects contains an array of statistics groups in the attribute


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/13997

Docs PR: https://github.com/arangodb/docs/pull/685

Deprecates the `/_admin/statistics` API in favor of `/_admin/metrics/v2`.
The latter API provides a lot more information than the former.
This is a documentation-only change, thus no CHANGELOG entry.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [x] Docs PR: https://github.com/arangodb/docs/pull/685

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
