### PR TITLE
Added REST API POST `/_api/cursor/<cursor-id>`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,19 @@
+v3.7.12 (XXXX-XX-XX)
+--------------------
+
+* Add HTTP REST API endpoint POST `/_api/cursor/<cursor-id>` as a drop-in
+  replacement for PUT `/_api/cursor/<cursor-id>`. The POST API is functionally
+  equivalent to the existing PUT API. The benefit of using the POST API is
+  that HTTP POST requests will not be considered as idempotent, so proxies
+  may not retry them if they fail. This was the case with the existing PUT
+  API, as HTTP PUT requests can be considered idempotent according to the
+  HTTP specification.
+
+  The POST API is not used internally by ArangoDB's own requests in this version.
+  This means that compatibility to older versions of ArangoDB that do not
+  provide the new API is ensured.
+
+
 v3.7.11 (XXXX-XX-XX)
 --------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-v3.7.12 (XXXX-XX-XX)
+v3.7.11 (XXXX-XX-XX)
 --------------------
 
 * Add HTTP REST API endpoint POST `/_api/cursor/<cursor-id>` as a drop-in
@@ -12,10 +12,6 @@ v3.7.12 (XXXX-XX-XX)
   The POST API is not used internally by ArangoDB's own requests in this version.
   This means that compatibility to older versions of ArangoDB that do not
   provide the new API is ensured.
-
-
-v3.7.11 (XXXX-XX-XX)
---------------------
 
 * Timely updates of rebootId / cluster membership of DB servers and coordinators
   in ClusterInfo. Fixes BTS-368 detected in chaos tests.

--- a/Documentation/DocuBlocks/Rest/Cursors/put_api_cursor_identifier.md
+++ b/Documentation/DocuBlocks/Rest/Cursors/put_api_cursor_identifier.md
@@ -1,8 +1,14 @@
 
-@startDocuBlock post_api_cursor_identifier
+@startDocuBlock put_api_cursor_identifier
 @brief return the next results from an existing cursor
 
-@RESTHEADER{POST /_api/cursor/{cursor-identifier}, Read next batch from cursor, modifyQueryCursorPost}
+@RESTHEADER{PUT /_api/cursor/{cursor-identifier}, Read next batch from cursor, modifyQueryCursorPut}
+
+@HINTS
+{% hint 'warning' %}
+There is a functionally equivalent HTTP POST counterpart to this endpoint, which should
+be used preferrably.
+{% endhint %}
 
 @RESTURLPARAMETERS
 
@@ -39,7 +45,7 @@ with *HTTP 404*.
 
 Valid request for next batch
 
-@EXAMPLE_ARANGOSH_RUN{RestCursorPostForLimitReturnCont}
+@EXAMPLE_ARANGOSH_RUN{RestCursorPutForLimitReturnCont}
     var url = "/_api/cursor";
     var cn = "products";
     db._drop(cn);
@@ -70,7 +76,7 @@ Valid request for next batch
 
 Missing identifier
 
-@EXAMPLE_ARANGOSH_RUN{RestCursorPostMissingCursorIdentifier}
+@EXAMPLE_ARANGOSH_RUN{RestCursorPutMissingCursorIdentifier}
     var url = "/_api/cursor";
 
     var response = logCurlRequest('PUT', url, '');
@@ -82,7 +88,7 @@ Missing identifier
 
 Unknown identifier
 
-@EXAMPLE_ARANGOSH_RUN{RestCursorPostInvalidCursorIdentifier}
+@EXAMPLE_ARANGOSH_RUN{RestCursorPutInvalidCursorIdentifier}
     var url = "/_api/cursor/123123";
 
     var response = logCurlRequest('PUT', url, '');

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/collections/arangoDocuments.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/collections/arangoDocuments.js
@@ -141,32 +141,21 @@
     },
 
     moveDocument: function (key, fromCollection, toCollection, callback) {
-      var querySave;
-      var queryRemove;
-      var bindVars = {
-        '@collection': fromCollection,
-        'filterid': key
-      };
-      var queryObj1;
-      var queryObj2;
-
-      querySave = 'FOR x IN @@collection';
-      querySave += ' FILTER x._key == @filterid';
-      querySave += ' INSERT x IN ';
-      querySave += toCollection;
-
-      queryRemove = 'FOR x in @@collection';
-      queryRemove += ' FILTER x._key == @filterid';
-      queryRemove += ' REMOVE x IN @@collection';
-
-      queryObj1 = {
-        query: querySave,
-        bindVars: bindVars
+      var queryObj1 = {
+        query: 'FOR x IN @@fromCollection FILTER x._key == @filterid INSERT x IN @@toCollection',
+        bindVars: {
+          '@fromCollection': fromCollection,
+          '@toCollection': toCollection,
+          'filterid': key
+        }
       };
 
-      queryObj2 = {
-        query: queryRemove,
-        bindVars: bindVars
+      var queryObj2 = {
+        query: 'FOR x in @@collection FILTER x._key == @filterid REMOVE x IN @@collection',
+        bindVars: {
+          '@collection': fromCollection,
+          'filterid': key
+        }
       };
 
       window.progressView.show();

--- a/tests/js/client/load-balancing/load-balancing-cursor-auth-cluster.js
+++ b/tests/js/client/load-balancing/load-balancing-cursor-auth-cluster.js
@@ -144,7 +144,7 @@ function CursorSyncAuthSuite () {
       coordinators = [];
     },
 
-    testCursorForwardingSameUserBasic: function() {
+    testCursorForwardingSameUserBasicPut: function() {
       let url = baseCursorUrl;
       const query = {
         query: `FOR doc IN @@coll LIMIT 4 RETURN doc`,
@@ -181,8 +181,46 @@ function CursorSyncAuthSuite () {
       assertTrue(result.error);
       assertEqual(result.code, 404);
     },
+    
+    testCursorForwardingSameUserBasicPost: function() {
+      let url = baseCursorUrl;
+      const query = {
+        query: `FOR doc IN @@coll LIMIT 4 RETURN doc`,
+        count: true,
+        batchSize: 2,
+        bindVars: {
+          "@coll": cns[0]
+        }
+      };
+      let result = sendRequest(users[0], 'POST', url, query, true);
 
-    testCursorForwardingSameUserDeletion: function() {
+      assertFalse(result === undefined || result === {});
+      assertFalse(result.error);
+      assertEqual(result.code, 201);
+      assertTrue(result.hasMore);
+      assertEqual(result.count, 4);
+      assertEqual(result.result.length, 2);
+
+      const cursorId = result.id;
+      url = `${baseCursorUrl}/${cursorId}`;
+      result = sendRequest(users[0], 'POST', url, {}, false);
+
+      assertFalse(result === undefined || result === {});
+      assertFalse(result.error);
+      assertEqual(result.code, 200);
+      assertFalse(result.hasMore);
+      assertEqual(result.count, 4);
+      assertEqual(result.result.length, 2);
+
+      url = `${baseCursorUrl}/${cursorId}`;
+      result = sendRequest(users[0], 'POST', url, {}, false);
+
+      assertFalse(result === undefined || result === {});
+      assertTrue(result.error);
+      assertEqual(result.code, 404);
+    },
+
+    testCursorForwardingSameUserDeletionPut: function() {
       let url = baseCursorUrl;
       const query = {
         query: `FOR doc IN @@coll LIMIT 4 RETURN doc`,
@@ -216,8 +254,43 @@ function CursorSyncAuthSuite () {
       assertTrue(result.error);
       assertEqual(result.code, 404);
     },
+    
+    testCursorForwardingSameUserDeletionPost: function() {
+      let url = baseCursorUrl;
+      const query = {
+        query: `FOR doc IN @@coll LIMIT 4 RETURN doc`,
+        count: true,
+        batchSize: 2,
+        bindVars: {
+          "@coll": cns[0]
+        }
+      };
+      let result = sendRequest(users[0], 'POST', url, query, true);
 
-    testCursorForwardingDifferentUser: function() {
+      assertFalse(result === undefined || result === {});
+      assertFalse(result.error);
+      assertEqual(result.code, 201);
+      assertTrue(result.hasMore);
+      assertEqual(result.count, 4);
+      assertEqual(result.result.length, 2);
+
+      const cursorId = result.id;
+      url = `${baseCursorUrl}/${cursorId}`;
+      result = sendRequest(users[0], 'DELETE', url, {}, false);
+
+      assertFalse(result === undefined || result === {});
+      assertFalse(result.error);
+      assertEqual(result.code, 202);
+
+      url = `${baseCursorUrl}/${cursorId}`;
+      result = sendRequest(users[0], 'POST', url, {}, false);
+
+      assertFalse(result === undefined || result === {});
+      assertTrue(result.error);
+      assertEqual(result.code, 404);
+    },
+
+    testCursorForwardingDifferentUserPut: function() {
       let url = baseCursorUrl;
       const query = {
         query: `FOR doc IN @@coll LIMIT 4 RETURN doc`,
@@ -239,6 +312,41 @@ function CursorSyncAuthSuite () {
       const cursorId = result.id;
       url = `${baseCursorUrl}/${cursorId}`;
       result = sendRequest(users[1], 'PUT', url, {}, false);
+
+      assertFalse(result === undefined || result === {});
+      assertTrue(result.error);
+      assertEqual(result.code, 404);
+
+      url = `${baseCursorUrl}/${cursorId}`;
+      result = sendRequest(users[0], 'DELETE', url, {}, false);
+
+      assertFalse(result === undefined || result === {});
+      assertFalse(result.error);
+      assertEqual(result.code, 202);
+    },
+    
+    testCursorForwardingDifferentUserPost: function() {
+      let url = baseCursorUrl;
+      const query = {
+        query: `FOR doc IN @@coll LIMIT 4 RETURN doc`,
+        count: true,
+        batchSize: 2,
+        bindVars: {
+          "@coll": cns[0]
+        }
+      };
+      let result = sendRequest(users[0], 'POST', url, query, true);
+
+      assertFalse(result === undefined || result === {});
+      assertFalse(result.error);
+      assertEqual(result.code, 201);
+      assertTrue(result.hasMore);
+      assertEqual(result.count, 4);
+      assertEqual(result.result.length, 2);
+
+      const cursorId = result.id;
+      url = `${baseCursorUrl}/${cursorId}`;
+      result = sendRequest(users[1], 'POST', url, {}, false);
 
       assertFalse(result === undefined || result === {});
       assertTrue(result.error);

--- a/tests/js/client/load-balancing/load-balancing-cursor-noauth-cluster.js
+++ b/tests/js/client/load-balancing/load-balancing-cursor-noauth-cluster.js
@@ -117,7 +117,7 @@ function CursorSyncSuite () {
       coordinators = [];
     },
 
-    testCursorForwardingBasic: function() {
+    testCursorForwardingBasicPut: function() {
       let url = baseCursorUrl;
       const query = {
         query: `FOR doc IN @@coll LIMIT 4 RETURN doc`,
@@ -154,8 +154,46 @@ function CursorSyncSuite () {
       assertTrue(result.error);
       assertEqual(result.code, 404);
     },
+    
+    testCursorForwardingBasicPost: function() {
+      let url = baseCursorUrl;
+      const query = {
+        query: `FOR doc IN @@coll LIMIT 4 RETURN doc`,
+        count: true,
+        batchSize: 2,
+        bindVars: {
+          "@coll": cns[0]
+        }
+      };
+      let result = sendRequest('POST', url, query, true);
 
-    testCursorForwardingDeletion: function() {
+      assertFalse(result === undefined || result === {});
+      assertFalse(result.error);
+      assertEqual(result.code, 201);
+      assertTrue(result.hasMore);
+      assertEqual(result.count, 4);
+      assertEqual(result.result.length, 2);
+
+      const cursorId = result.id;
+      url = `${baseCursorUrl}/${cursorId}`;
+      result = sendRequest('POST', url, {}, false);
+
+      assertFalse(result === undefined || result === {});
+      assertFalse(result.error);
+      assertEqual(result.code, 200);
+      assertFalse(result.hasMore);
+      assertEqual(result.count, 4);
+      assertEqual(result.result.length, 2);
+
+      url = `${baseCursorUrl}/${cursorId}`;
+      result = sendRequest('POST', url, {}, false);
+
+      assertFalse(result === undefined || result === {});
+      assertTrue(result.error);
+      assertEqual(result.code, 404);
+    },
+
+    testCursorForwardingDeletionPut: function() {
       let url = baseCursorUrl;
       const query = {
         query: `FOR doc IN @@coll LIMIT 4 RETURN doc`,
@@ -184,6 +222,41 @@ function CursorSyncSuite () {
 
       url = `${baseCursorUrl}/${cursorId}`;
       result = sendRequest('PUT', url, {}, false);
+
+      assertFalse(result === undefined || result === {});
+      assertTrue(result.error);
+      assertEqual(result.code, 404);
+    },
+    
+    testCursorForwardingDeletionPost: function() {
+      let url = baseCursorUrl;
+      const query = {
+        query: `FOR doc IN @@coll LIMIT 4 RETURN doc`,
+        count: true,
+        batchSize: 2,
+        bindVars: {
+          "@coll": cns[0]
+        }
+      };
+      let result = sendRequest('POST', url, query, true);
+
+      assertFalse(result === undefined || result === {});
+      assertFalse(result.error);
+      assertEqual(result.code, 201);
+      assertTrue(result.hasMore);
+      assertEqual(result.count, 4);
+      assertEqual(result.result.length, 2);
+
+      const cursorId = result.id;
+      url = `${baseCursorUrl}/${cursorId}`;
+      result = sendRequest('DELETE', url, {}, false);
+
+      assertFalse(result === undefined || result === {});
+      assertFalse(result.error);
+      assertEqual(result.code, 202);
+
+      url = `${baseCursorUrl}/${cursorId}`;
+      result = sendRequest('POST', url, {}, false);
 
       assertFalse(result === undefined || result === {});
       assertTrue(result.error);

--- a/tests/rb/HttpInterface/api-cursor-spec.rb
+++ b/tests/rb/HttpInterface/api-cursor-spec.rb
@@ -99,9 +99,20 @@ describe ArangoDB do
         doc.parsed_response['errorNum'].should eq(400)
       end
 
-      it "returns an error if cursor identifier is invalid" do
+      it "returns an error if cursor identifier is invalid - PUT" do
         cmd = api + "/123456"
         doc = ArangoDB.log_put("#{prefix}-invalid-cursor-identifier", cmd)
+        
+        doc.code.should eq(404)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(true)
+        doc.parsed_response['code'].should eq(404)
+        doc.parsed_response['errorNum'].should eq(1600)
+      end
+      
+      it "returns an error if cursor identifier is invalid - POST" do
+        cmd = api + "/123456"
+        doc = ArangoDB.log_post("#{prefix}-invalid-cursor-identifier", cmd)
         
         doc.code.should eq(404)
         doc.headers['content-type'].should eq("application/json; charset=utf-8")
@@ -193,7 +204,7 @@ describe ArangoDB do
         ArangoDB.drop_collection(@cn)
       end
 
-      it "creates a cursor" do
+      it "creates a cursor and consumes data incrementally - PUT" do
         cmd = api
         body = "{ \"query\" : \"FOR u IN #{@cn} RETURN u\", \"count\" : true }"
         doc = ArangoDB.log_post("#{prefix}-create-batchsize", cmd, :body => body)
@@ -241,6 +252,62 @@ describe ArangoDB do
 
         cmd = api + "/#{id}"
         doc = ArangoDB.log_put("#{prefix}-create-batchsize", cmd)
+        
+        doc.code.should eq(404)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(true)
+        doc.parsed_response['errorNum'].should eq(1600)
+        doc.parsed_response['code'].should eq(404)
+      end
+      
+      it "creates a cursor and consumes data incrementally - POST" do
+        cmd = api
+        body = "{ \"query\" : \"FOR u IN #{@cn} RETURN u\", \"count\" : true }"
+        doc = ArangoDB.log_post("#{prefix}-create-batchsize", cmd, :body => body)
+        
+        doc.code.should eq(201)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(201)
+        doc.parsed_response['id'].should be_kind_of(String)
+        doc.parsed_response['id'].should match(@reId)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['count'].should eq(2001)
+        doc.parsed_response['result'].length.should eq(1000)
+        doc.parsed_response['cached'].should eq(false)
+
+        id = doc.parsed_response['id']
+
+        cmd = api + "/#{id}"
+        doc = ArangoDB.log_post("#{prefix}-create-batchsize", cmd)
+        
+        doc.code.should eq(200)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(200)
+        doc.parsed_response['id'].should be_kind_of(String)
+        doc.parsed_response['id'].should match(@reId)
+        doc.parsed_response['id'].should eq(id)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['count'].should eq(2001)
+        doc.parsed_response['result'].length.should eq(1000)
+        doc.parsed_response['cached'].should eq(false)
+
+        cmd = api + "/#{id}"
+        doc = ArangoDB.log_post("#{prefix}-create-batchsize", cmd)
+        
+        doc.code.should eq(200)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(200)
+        doc.parsed_response['id'].should be_nil
+        doc.parsed_response['hasMore'].should eq(false)
+        doc.parsed_response['count'].should eq(2001)
+        doc.parsed_response['result'].length.should eq(1)
+        doc.parsed_response['cached'].should eq(false)
+
+        cmd = api + "/#{id}"
+        doc = ArangoDB.log_post("#{prefix}-create-batchsize", cmd)
         
         doc.code.should eq(404)
         doc.headers['content-type'].should eq("application/json; charset=utf-8")
@@ -372,8 +439,8 @@ describe ArangoDB do
         doc.parsed_response['errorNum'].should eq(1600)
         doc.parsed_response['code'].should eq(404)
       end
-
-      it "creates a cursor and deletes it in the middle" do
+      
+      it "creates a usable cursor and consumes data incrementally - PUT" do
         cmd = api
         body = "{ \"query\" : \"FOR u IN #{@cn} LIMIT 5 RETURN u.n\", \"count\" : true, \"batchSize\" : 2 }"
         doc = ArangoDB.log_post("#{prefix}-create-for-limit-return", cmd, :body => body)
@@ -393,6 +460,162 @@ describe ArangoDB do
 
         cmd = api + "/#{id}"
         doc = ArangoDB.log_put("#{prefix}-create-for-limit-return-cont", cmd)
+        
+        doc.code.should eq(200)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(200)
+        doc.parsed_response['id'].should be_kind_of(String)
+        doc.parsed_response['id'].should match(@reId)
+        doc.parsed_response['id'].should eq(id)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['count'].should eq(5)
+        doc.parsed_response['result'].length.should eq(2)
+        doc.parsed_response['cached'].should eq(false)
+
+        cmd = api + "/#{id}"
+        doc = ArangoDB.log_put("#{prefix}-create-for-limit-return-cont2", cmd)
+        
+        doc.code.should eq(200)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(200)
+        doc.parsed_response['id'].should be_nil
+        doc.parsed_response['hasMore'].should eq(false)
+        doc.parsed_response['count'].should eq(5)
+        doc.parsed_response['result'].length.should eq(1)
+        doc.parsed_response['cached'].should eq(false)
+
+        cmd = api + "/#{id}"
+        doc = ArangoDB.log_put("#{prefix}-create-for-limit-return-cont3", cmd)
+        
+        doc.code.should eq(404)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(true)
+        doc.parsed_response['errorNum'].should eq(1600)
+        doc.parsed_response['code'].should eq(404)
+      end
+      
+      it "creates a usable cursor and consumes data incrementally - POST" do
+        cmd = api
+        body = "{ \"query\" : \"FOR u IN #{@cn} LIMIT 5 RETURN u.n\", \"count\" : true, \"batchSize\" : 2 }"
+        doc = ArangoDB.log_post("#{prefix}-create-for-limit-return", cmd, :body => body)
+        
+        doc.code.should eq(201)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(201)
+        doc.parsed_response['id'].should be_kind_of(String)
+        doc.parsed_response['id'].should match(@reId)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['count'].should eq(5)
+        doc.parsed_response['result'].length.should eq(2)
+        doc.parsed_response['cached'].should eq(false)
+
+        id = doc.parsed_response['id']
+
+        cmd = api + "/#{id}"
+        doc = ArangoDB.log_post("#{prefix}-create-for-limit-return-cont", cmd)
+        
+        doc.code.should eq(200)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(200)
+        doc.parsed_response['id'].should be_kind_of(String)
+        doc.parsed_response['id'].should match(@reId)
+        doc.parsed_response['id'].should eq(id)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['count'].should eq(5)
+        doc.parsed_response['result'].length.should eq(2)
+        doc.parsed_response['cached'].should eq(false)
+
+        cmd = api + "/#{id}"
+        doc = ArangoDB.log_post("#{prefix}-create-for-limit-return-cont2", cmd)
+        
+        doc.code.should eq(200)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(200)
+        doc.parsed_response['id'].should be_nil
+        doc.parsed_response['hasMore'].should eq(false)
+        doc.parsed_response['count'].should eq(5)
+        doc.parsed_response['result'].length.should eq(1)
+        doc.parsed_response['cached'].should eq(false)
+
+        cmd = api + "/#{id}"
+        doc = ArangoDB.log_post("#{prefix}-create-for-limit-return-cont3", cmd)
+        
+        doc.code.should eq(404)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(true)
+        doc.parsed_response['errorNum'].should eq(1600)
+        doc.parsed_response['code'].should eq(404)
+      end
+
+      it "creates a cursor and deletes it in the middle - PUT" do
+        cmd = api
+        body = "{ \"query\" : \"FOR u IN #{@cn} LIMIT 5 RETURN u.n\", \"count\" : true, \"batchSize\" : 2 }"
+        doc = ArangoDB.log_post("#{prefix}-create-for-limit-return", cmd, :body => body)
+        
+        doc.code.should eq(201)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(201)
+        doc.parsed_response['id'].should be_kind_of(String)
+        doc.parsed_response['id'].should match(@reId)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['count'].should eq(5)
+        doc.parsed_response['result'].length.should eq(2)
+        doc.parsed_response['cached'].should eq(false)
+
+        id = doc.parsed_response['id']
+
+        cmd = api + "/#{id}"
+        doc = ArangoDB.log_put("#{prefix}-create-for-limit-return-cont", cmd)
+        
+        doc.code.should eq(200)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(200)
+        doc.parsed_response['id'].should be_kind_of(String)
+        doc.parsed_response['id'].should match(@reId)
+        doc.parsed_response['id'].should eq(id)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['count'].should eq(5)
+        doc.parsed_response['result'].length.should eq(2)
+        doc.parsed_response['cached'].should eq(false)
+
+        cmd = api + "/#{id}"
+        doc = ArangoDB.log_delete("#{prefix}-delete", cmd)
+
+        doc.code.should eq(202)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(202)
+        doc.parsed_response['id'].should be_kind_of(String)
+        doc.parsed_response['id'].should match(@reId)
+      end
+      
+      it "creates a cursor and deletes it in the middle - POST" do
+        cmd = api
+        body = "{ \"query\" : \"FOR u IN #{@cn} LIMIT 5 RETURN u.n\", \"count\" : true, \"batchSize\" : 2 }"
+        doc = ArangoDB.log_post("#{prefix}-create-for-limit-return", cmd, :body => body)
+        
+        doc.code.should eq(201)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(201)
+        doc.parsed_response['id'].should be_kind_of(String)
+        doc.parsed_response['id'].should match(@reId)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['count'].should eq(5)
+        doc.parsed_response['result'].length.should eq(2)
+        doc.parsed_response['cached'].should eq(false)
+
+        id = doc.parsed_response['id']
+
+        cmd = api + "/#{id}"
+        doc = ArangoDB.log_post("#{prefix}-create-for-limit-return-cont", cmd)
         
         doc.code.should eq(200)
         doc.headers['content-type'].should eq("application/json; charset=utf-8")
@@ -497,7 +720,7 @@ describe ArangoDB do
         doc.parsed_response['id'].should be_nil
       end
 
-      it "creates a cursor that will expire" do
+      it "creates a cursor that will expire - PUT" do
         cmd = api
         body = "{ \"query\" : \"FOR u IN #{@cn} LIMIT 5 RETURN u.n\", \"count\" : true, \"batchSize\" : 1, \"ttl\" : 5 }"
         doc = ArangoDB.log_post("#{prefix}-create-ttl", cmd, :body => body)
@@ -559,7 +782,69 @@ describe ArangoDB do
         doc.parsed_response['code'].should eq(404)
       end
       
-      it "creates a cursor that will not expire" do
+      it "creates a cursor that will expire - POST" do
+        cmd = api
+        body = "{ \"query\" : \"FOR u IN #{@cn} LIMIT 5 RETURN u.n\", \"count\" : true, \"batchSize\" : 1, \"ttl\" : 5 }"
+        doc = ArangoDB.log_post("#{prefix}-create-ttl", cmd, :body => body)
+        
+        doc.code.should eq(201)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(201)
+        doc.parsed_response['id'].should be_kind_of(String)
+        doc.parsed_response['id'].should match(@reId)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['count'].should eq(5)
+        doc.parsed_response['result'].length.should eq(1)
+        doc.parsed_response['cached'].should eq(false)
+
+        sleep 1
+        id = doc.parsed_response['id']
+
+        cmd = api + "/#{id}"
+        doc = ArangoDB.log_post("#{prefix}-create-ttl", cmd)
+        
+        doc.code.should eq(200)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(200)
+        doc.parsed_response['id'].should be_kind_of(String)
+        doc.parsed_response['id'].should match(@reId)
+        doc.parsed_response['id'].should eq(id)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['count'].should eq(5)
+        doc.parsed_response['result'].length.should eq(1)
+        doc.parsed_response['cached'].should eq(false)
+
+        sleep 1
+
+        doc = ArangoDB.log_post("#{prefix}-create-ttl", cmd)
+        
+        doc.code.should eq(200)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(200)
+        doc.parsed_response['id'].should eq(id)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['count'].should eq(5)
+        doc.parsed_response['result'].length.should eq(1)
+        doc.parsed_response['cached'].should eq(false)
+
+        # after this, the cursor might expire eventually
+        # the problem is that we cannot exactly determine the point in time
+        # when it really vanishes, as this depends on thread scheduling, state     
+        # of the cleanup thread etc.
+
+        sleep 8 # this should delete the cursor on the server
+        doc = ArangoDB.log_post("#{prefix}-create-ttl", cmd)
+        doc.code.should eq(404)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(true)
+        doc.parsed_response['errorNum'].should eq(1600)
+        doc.parsed_response['code'].should eq(404)
+      end
+      
+      it "creates a cursor that will not expire - PUT" do
         cmd = api
         body = "{ \"query\" : \"FOR u IN #{@cn} LIMIT 5 RETURN u.n\", \"count\" : true, \"batchSize\" : 1, \"ttl\" : 60 }"
         doc = ArangoDB.log_post("#{prefix}-create-ttl", cmd, :body => body)
@@ -609,6 +894,67 @@ describe ArangoDB do
 
         sleep 5 # this should not delete the cursor on the server
         doc = ArangoDB.log_put("#{prefix}-create-ttl", cmd)
+        
+        doc.code.should eq(200)
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(200)
+        doc.parsed_response['id'].should eq(id)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['count'].should eq(5)
+        doc.parsed_response['result'].length.should eq(1)
+        doc.parsed_response['cached'].should eq(false)
+      end
+      
+      it "creates a cursor that will not expire - POST" do
+        cmd = api
+        body = "{ \"query\" : \"FOR u IN #{@cn} LIMIT 5 RETURN u.n\", \"count\" : true, \"batchSize\" : 1, \"ttl\" : 60 }"
+        doc = ArangoDB.log_post("#{prefix}-create-ttl", cmd, :body => body)
+        
+        doc.code.should eq(201)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(201)
+        doc.parsed_response['id'].should be_kind_of(String)
+        doc.parsed_response['id'].should match(@reId)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['count'].should eq(5)
+        doc.parsed_response['result'].length.should eq(1)
+        doc.parsed_response['cached'].should eq(false)
+
+        sleep 1
+        id = doc.parsed_response['id']
+
+        cmd = api + "/#{id}"
+        doc = ArangoDB.log_post("#{prefix}-create-ttl", cmd)
+        
+        doc.code.should eq(200)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(200)
+        doc.parsed_response['id'].should be_kind_of(String)
+        doc.parsed_response['id'].should match(@reId)
+        doc.parsed_response['id'].should eq(id)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['count'].should eq(5)
+        doc.parsed_response['result'].length.should eq(1)
+        doc.parsed_response['cached'].should eq(false)
+
+        sleep 1
+
+        doc = ArangoDB.log_post("#{prefix}-create-ttl", cmd)
+        
+        doc.code.should eq(200)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(200)
+        doc.parsed_response['id'].should eq(id)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['count'].should eq(5)
+        doc.parsed_response['result'].length.should eq(1)
+        doc.parsed_response['cached'].should eq(false)
+
+        sleep 5 # this should not delete the cursor on the server
+        doc = ArangoDB.log_post("#{prefix}-create-ttl", cmd)
         
         doc.code.should eq(200)
         doc.parsed_response['error'].should eq(false)


### PR DESCRIPTION
### Scope & Purpose

Jira ticket: https://arangodb.atlassian.net/browse/APM-75
Backport of https://github.com/arangodb/arangodb/pull/14004
Docs PR: arangodb/docs#686

Add HTTP REST API endpoint POST `/_api/cursor/<cursor-id>` as a drop-in replacement for PUT `/_api/cursor/<cursor-id>`. The POST API is functionally equivalent to the existing PUT API. The benefit of using the POST API is that HTTP POST requests will not be considered as idempotent, so proxies may not retry them if they fail. This was the case with the existing PUT API, as HTTP PUT requests can be considered idempotent according to the HTTP specification.

The POST API is now used internally by ArangoDB's own requests in devel, including the web UI and the client tools. Previous versions (i.e. 3.8 and 3.7) will not make use of the new API for their requests. 
That means the web UI and client tools in devel will only work with ArangoDB versions that have support for the new POST API (i.e. devel, 3.8 and 3.7), but that 3.8 and 3.7 will not require the new POST API to be present.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required.

#### Related Information

- [x] Docs PR: arangodb/docs#686

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (shell_client, load_balancing, http_server)
