### PR TITLE
Add deprecation warning to /_api/export (#13929)

### DIFF
--- a/Documentation/DocuBlocks/Rest/Bulk/post_api_export.md
+++ b/Documentation/DocuBlocks/Rest/Bulk/post_api_export.md
@@ -9,7 +9,7 @@
 This endpoint should no longer be used. It is deprecated in version 3.8.0 and
 removed in 3.9.0.
 
-You may use streaming AQL queries instead (`POST /_api/cursor` with
+Use streaming AQL queries instead (`POST /_api/cursor` with
 `{ "options": { "stream": true } }`.
 {% endhint %}
 

--- a/Documentation/DocuBlocks/Rest/Bulk/post_api_export.md
+++ b/Documentation/DocuBlocks/Rest/Bulk/post_api_export.md
@@ -4,6 +4,15 @@
 
 @RESTHEADER{POST /_api/export, Create export cursor, createCursorExport}
 
+@HINTS
+{% hint 'warning' %}
+This endpoint should no longer be used. It is deprecated in version 3.8.0 and
+removed in 3.9.0.
+
+You may use streaming AQL queries instead (`POST /_api/cursor` with
+`{ "options": { "stream": true } }`.
+{% endhint %}
+
 @RESTBODYPARAM{flush,boolean,required,}
 if set to *true*, a WAL flush operation will be executed prior to the
 export. The flush operation will start copying documents from the WAL to the


### PR DESCRIPTION
Follow-up to #13929 and https://github.com/arangodb/docs/pull/685/files#diff-b6a39937a28a7120bf661455c493fc356859177f566d7503a61098e462695a3bR319-R326