### PR TITLE
Try to resume RocksDB operations after bg error

### DIFF
--- a/3rdParty/rocksdb/6.8/util/status.cc
+++ b/3rdParty/rocksdb/6.8/util/status.cc
@@ -135,6 +135,9 @@ std::string Status::ToString() const {
   }
 
   if (state_ != nullptr) {
+    if (subcode_ != kNone) {
+      result.append(": ");
+    }
     result.append(state_);
   }
   return result;

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,16 @@
 devel
 -----
 
+* Try to automatically resume RocksDB operations after a RocksDB background
+  error. On a background error, RocksDB may have gone into read-only mode and
+  not try to recover from it automatically in some situations, e.g. if the
+  background error happened during compaction. In this case it will stay in
+  read-only mode until shutdown, or until its Resume() API is called.
+  Now we try to automatically resume RocksDB operations about every 15 seconds
+  in case a background error has happened. Resuming may not succeed in all
+  cases, but it can help in some cases if the original error condition is
+  fixed.
+
 * Fix cluster internal retry behavior for network communications. In particular
   retry on 421 (leader refuses operation). This leads to the cluster letting
   less internal errors out to clients.

--- a/arangod/RocksDBEngine/Listeners/RocksDBBackgroundErrorListener.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBBackgroundErrorListener.cpp
@@ -39,7 +39,7 @@ void RocksDBBackgroundErrorListener::OnBackgroundError(rocksdb::BackgroundErrorR
   }
 
   if (!_called.exchange(true)) {
-    std::string operation = "unknown";
+    char const* operation = "unknown";
     switch (reason) {
       case rocksdb::BackgroundErrorReason::kFlush: {
         operation = "flush";
@@ -63,6 +63,11 @@ void RocksDBBackgroundErrorListener::OnBackgroundError(rocksdb::BackgroundErrorR
         << "RocksDB encountered a background error during a " << operation << " operation: "
         << (status != nullptr ? status->ToString() : "unknown error") << "; The database will be put in read-only mode, and subsequent write errors are likely. It is advised to shut down this instance, resolve the error offline and then restart it.";
   }
+}
+
+void RocksDBBackgroundErrorListener::resume() noexcept {
+  bool expected = true;
+  _called.compare_exchange_strong(expected, false);
 }
 
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/Listeners/RocksDBBackgroundErrorListener.h
+++ b/arangod/RocksDBEngine/Listeners/RocksDBBackgroundErrorListener.h
@@ -38,7 +38,8 @@ class RocksDBBackgroundErrorListener : public rocksdb::EventListener {
 
   void OnBackgroundError(rocksdb::BackgroundErrorReason reason, rocksdb::Status* error) override;
 
-  bool called() const { return _called.load(std::memory_order_relaxed); }
+  bool called() const noexcept { return _called.load(std::memory_order_relaxed); }
+  void resume() noexcept;
 
  private:
   std::atomic<bool> _called{false};

--- a/arangod/RocksDBEngine/RocksDBBackgroundThread.cpp
+++ b/arangod/RocksDBEngine/RocksDBBackgroundThread.cpp
@@ -50,6 +50,7 @@ void RocksDBBackgroundThread::beginShutdown() {
 
 void RocksDBBackgroundThread::run() {
   double const startTime = TRI_microtime();
+  uint64_t runs = 0;
 
   while (!isStopping()) {
     {
@@ -60,9 +61,14 @@ void RocksDBBackgroundThread::run() {
     if (_engine.inRecovery()) {
       continue;
     }
+    
+    if (++runs % 16 == 0) {
+      // send a Resume() command to RocksDB
+      _engine.tryResume();
+    }
 
     TRI_IF_FAILURE("RocksDBBackgroundThread::run") { continue; }
-
+    
     try {
       if (!isStopping()) {
         double start = TRI_microtime();

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -311,6 +311,9 @@ class RocksDBEngine final : public StorageEngine {
   virtual TRI_voc_tick_t currentTick() const override;
   virtual TRI_voc_tick_t releasedTick() const override;
   virtual void releaseTick(TRI_voc_tick_t) override;
+
+  // try to resume operations in case there was a background error
+  void tryResume();
   
 #ifdef USE_ENTERPRISE
   bool encryptionKeyRotationEnabled() const;


### PR DESCRIPTION
### Scope & Purpose

Try to automatically resume RocksDB operations after a RocksDB background error. 

On a background error, RocksDB may have gone into read-only mode and not try to recover from it automatically in some situations, e.g. if the background error happened during compaction. In this case it will stay in read-only mode until shutdown, or until its Resume() API is called.

Now we try to automatically resume RocksDB operations about every 15 seconds in case a background error has happened. Resuming may not succeed in all cases, but it can help in some cases if the original error condition is fixed.

This may fix a few cases of RocksDB going into read-only mode and not automatically recovering from it.

Can be verified manually by making the disk run full temporarily, or by temporarily hacking RocksDB to produce write errors with random probability.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
