### PR TITLE
Improve parallelism capabilities of arangorestore.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,23 @@
 v3.8.0 (XXXX-XX-XX)
 -------------------
 
+* Improve parallelism capabilities of arangorestore.
+
+  arangorestore can now dispatch restoring data chunks of a collection to idle
+  background threads, so that multiple restore requests can be in flight for 
+  the same collection concurrently.
+
+  This can improve restore speed in situations when there are idle threads 
+  left (number of threads can be configured via arangorestore's `--threads` 
+  option) and the dump file for the collection is large.
+
+  The improved parallelism is only used when restoring dumps that are in the 
+  non-enveloped format. This format has been introduced with ArangoDB 3.8. 
+  The reason is that dumps in the non-enveloped format only contain the raw 
+  documents, which can be restored independent of each other, i.e. in any 
+  order. However, the enveloped format may contain documents and remove 
+  operations, which need to be restored in the original order. 
+
 * Add HTTP REST API endpoint POST `/_api/cursor/<cursor-id>` as a drop-in
   replacement for PUT `/_api/cursor/<cursor-id>`. The POST API is functionally
   equivalent to the existing PUT API. The benefit of using the POST API is that

--- a/arangosh/Restore/RestoreFeature.h
+++ b/arangosh/Restore/RestoreFeature.h
@@ -153,7 +153,7 @@ class RestoreFeature final : public application_features::ApplicationFeature {
     Result result;
 
     /// @brief data chunk offsets (start offset, length) of requests that are currently
-    /// ongoing. it is safe the resume restore only up the minimum value contained
+    /// ongoing. Resumption of the restore must start at the smallest key value contained
     /// in here (note: we also need to track the length of each chunk to test the
     /// resumption of a restore after a crash)
     std::map<size_t, size_t> readOffsets;

--- a/arangosh/Restore/RestoreFeature.h
+++ b/arangosh/Restore/RestoreFeature.h
@@ -25,12 +25,14 @@
 #ifndef ARANGODB_RESTORE_RESTORE_FEATURE_H
 #define ARANGODB_RESTORE_RESTORE_FEATURE_H 1
 
-#include <shared_mutex>
+#include <atomic>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "ApplicationFeatures/ApplicationFeature.h"
 
-#include "Basics/VelocyPackHelper.h"
-#include "Basics/debugging.h"
 #include "Utils/ClientManager.h"
 #include "Utils/ClientTaskQueue.h"
 #include "Utils/ManagedDirectory.h"
@@ -38,8 +40,11 @@
 
 namespace arangodb {
 
-namespace httpclient {
+namespace basics {
+class StringBuffer;
+}
 
+namespace httpclient {
 class SimpleHttpResult;
 }
 
@@ -60,7 +65,7 @@ class RestoreFeature final : public application_features::ApplicationFeature {
    * @return The name of the feature
    */
   static std::string featureName();
-
+  
   /**
    * @brief Saves a worker error for later handling and clears queued jobs
    * @param error Error from a client worker
@@ -72,6 +77,10 @@ class RestoreFeature final : public application_features::ApplicationFeature {
    * @return  First error from the list, or OK if none exist
    */
   Result getFirstError() const;
+
+
+  std::unique_ptr<basics::StringBuffer> leaseBuffer();
+  void returnBuffer(std::unique_ptr<basics::StringBuffer> buffer) noexcept;
 
   /// @brief Holds configuration data to pass between methods
   struct Options {
@@ -132,23 +141,109 @@ class RestoreFeature final : public application_features::ApplicationFeature {
     std::atomic<uint64_t> totalRead{0};
   };
 
+  /// @brief shared state for a single collection, can be shared by multiple
+  /// RestoreJobs (one RestoreMainJob and x RestoreSendJobs)
+  struct SharedState {
+    SharedState() : readCompleteInputfile(false) {}
+
+    Mutex mutex;
+
+    /// @brief this contains errors produced by background send operations
+    /// (i.e. RestoreSendJobs)
+    Result result;
+
+    /// @brief data chunk offsets (start offset, length) of requests that are currently
+    /// ongoing. it is safe the resume restore only up the minimum value contained
+    /// in here (note: we also need to track the length of each chunk to test the
+    /// resumption of a restore after a crash)
+    std::map<size_t, size_t> readOffsets;
+
+    /// @brief whether ot not we have read the complete input data file for the collection
+    bool readCompleteInputfile;
+  };
+  
   /// @brief Stores all necessary data to restore a single collection or shard
-  struct JobData {
-    ManagedDirectory& directory;
+  struct RestoreJob {
+    RestoreJob(RestoreFeature& feature, 
+               RestoreProgressTracker& progressTracker,
+               Options const& options, 
+               Stats& stats, 
+               bool useEnvelope,
+               std::string const& collectionName,
+               std::shared_ptr<SharedState> sharedState);
+
+    virtual ~RestoreJob();
+    
+    virtual Result run(arangodb::httpclient::SimpleHttpClient& client) = 0;
+
+    void updateProgress();
+
+    Result sendRestoreData(arangodb::httpclient::SimpleHttpClient& client,
+                           size_t readOffset,
+                           char const* buffer,
+                           size_t bufferSize);
+    
     RestoreFeature& feature;
     RestoreProgressTracker& progressTracker;
     Options const& options;
     Stats& stats;
-    VPackSlice collection;
     bool useEnvelope;
-
-    JobData(ManagedDirectory& directory, RestoreFeature& feature, RestoreProgressTracker& progressTracker,
-            Options const& options, Stats& stats, VPackSlice collection, bool useEnvelope);
+    std::string const collectionName;
+    std::shared_ptr<SharedState> sharedState;
   };
+
+  struct RestoreMainJob : public RestoreJob {
+    RestoreMainJob(ManagedDirectory& directory, 
+                   RestoreFeature& feature, 
+                   RestoreProgressTracker& progressTracker,
+                   Options const& options, 
+                   Stats& stats, 
+                   VPackSlice parameters,
+                   bool useEnvelope);
+    
+    Result run(arangodb::httpclient::SimpleHttpClient& client) override;
+
+    Result dispatchRestoreData(arangodb::httpclient::SimpleHttpClient& client,
+                               size_t readOffset,
+                               char const* data,
+                               size_t length,
+                               bool forceDirect);
+    
+    Result restoreData(arangodb::httpclient::SimpleHttpClient& client);
+
+    /// @brief Restore a collection's indexes given its description
+    Result restoreIndexes(arangodb::httpclient::SimpleHttpClient& client);
+
+    /// @brief Send command to restore a collection's indexes
+    Result sendRestoreIndexes(arangodb::httpclient::SimpleHttpClient& client,
+                              arangodb::velocypack::Slice);
+    
+    ManagedDirectory& directory;
+    VPackSlice parameters;
+  };
+  
+  struct RestoreSendJob : public RestoreJob {
+    RestoreSendJob(RestoreFeature& feature, 
+                   RestoreProgressTracker& progressTracker,
+                   Options const& options, 
+                   Stats& stats, 
+                   bool useEnvelope, 
+                   std::string const& collectionName,
+                   std::shared_ptr<SharedState> sharedState,
+                   size_t readOffset,
+                   std::unique_ptr<basics::StringBuffer> buffer);
+    
+    Result run(arangodb::httpclient::SimpleHttpClient& client) override;
+    
+    size_t const readOffset;
+    std::unique_ptr<basics::StringBuffer> buffer;
+  };
+  
+  ClientTaskQueue<RestoreJob>& taskQueue();
 
  private:
   ClientManager _clientManager;
-  ClientTaskQueue<JobData> _clientTaskQueue;
+  ClientTaskQueue<RestoreJob> _clientTaskQueue;
   std::unique_ptr<ManagedDirectory> _directory;
   std::unique_ptr<RestoreProgressTracker> _progressTracker;
   int& _exitCode;
@@ -156,6 +251,9 @@ class RestoreFeature final : public application_features::ApplicationFeature {
   Stats _stats;
   Mutex mutable _workerErrorLock;
   std::queue<Result> _workerErrors;
+
+  Mutex _buffersLock;
+  std::vector<std::unique_ptr<basics::StringBuffer>> _buffers;
 };
 
 }  // namespace arangodb

--- a/arangosh/Utils/ManagedDirectory.cpp
+++ b/arangosh/Utils/ManagedDirectory.cpp
@@ -468,21 +468,8 @@ ManagedDirectory::File::File(ManagedDirectory const& directory,
   TRI_ASSERT(::flagNotSet(_flags, O_RDWR));  // disallow read/write (encryption)
 
   if (isGzip) {
-    char const* gzFlags = nullptr;
-
-    if (_fd >= 0) {
-      // gzip is going to perform a redundant close,
-      //  simpler code to give it redundant handle
-      _gzfd = TRI_DUP(_fd);
-    }
-    
-    if (O_WRONLY & flags) {
-      gzFlags = "wb";
-    } else {
-      gzFlags = "rb";
-    } // else
-    _gzFile = gzdopen(_gzfd, gzFlags);
-  } // if
+    prepareGzip((O_WRONLY & _flags) ? "wb" : "rb");
+  }
 }
 
 ManagedDirectory::File::File(ManagedDirectory const& directory,
@@ -504,19 +491,8 @@ ManagedDirectory::File::File(ManagedDirectory const& directory,
   TRI_ASSERT(::flagNotSet(_flags, O_RDWR));  // disallow read/write (encryption)
 
   if (isGzip) {
-    char const* gzFlags = nullptr;
-
-    // gzip is going to perform a redundant close,
-    //  simpler code to give it redundant handle
-    _gzfd = TRI_DUP(_fd);
-
-    if (0 /*O_WRONLY & flags*/) {
-      gzFlags = "wb";
-    } else {
-      gzFlags = "rb";
-    } // else
-    _gzFile = gzdopen(_gzfd, gzFlags);
-  } // if
+    prepareGzip("rb");
+  }
 }
 
 ManagedDirectory::File::~File() {
@@ -532,6 +508,28 @@ ManagedDirectory::File::~File() {
       ::closeFile(_fd, _status);
     }
   } catch (...) {
+  }
+}
+
+void ManagedDirectory::File::prepareGzip(char const* gzFlags) {
+  TRI_ASSERT(_gzFile == nullptr);
+
+  if (_fd >= 0) {
+    // gzip is going to perform a redundant close,
+    //  simpler code to give it redundant handle
+    _gzfd = TRI_DUP(_fd);
+  }
+    
+  _gzFile = gzdopen(_gzfd, gzFlags);
+
+  if (_gzFile != nullptr) {
+    // allocate a larger buffer for decompression.
+    // 128kb seems to be enough here... larger buffers didn't
+    // really improve speed during testing
+    int r = gzbuffer(_gzFile, 128 * 1024); 
+    if (r != 0) {
+      _status.reset(TRI_ERROR_OUT_OF_MEMORY, "unable to allocate gzip buffer");
+    }
   }
 }
 

--- a/arangosh/Utils/ManagedDirectory.h
+++ b/arangosh/Utils/ManagedDirectory.h
@@ -153,6 +153,7 @@ class ManagedDirectory {
    private:
     void writeNoLock(char const* data, size_t length);
     TRI_read_return_t readNoLock(char* buffer, size_t length);
+    void prepareGzip(char const* gzFlags);
 
    private:
     ManagedDirectory const& _directory;

--- a/arangosh/Utils/ProgressTracker.h
+++ b/arangosh/Utils/ProgressTracker.h
@@ -26,6 +26,12 @@
 
 #include "ManagedDirectory.h"
 #include "Basics/FileUtils.h"
+#include "Basics/VelocyPackHelper.h"
+
+#include <atomic>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
 
 namespace arangodb {
 template <typename T>
@@ -64,8 +70,8 @@ bool ProgressTracker<T>::updateStatus(std::string const& collectionName,
   }
 
   {
-    std::unique_lock guard(_writeFileMutex);
     VPackBufferUInt8 buffer;
+    std::unique_lock guard(_writeFileMutex);
 
     {
       std::unique_lock guardState(_collectionStatesMutex);

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -122,6 +122,9 @@ class DumpRestoreHelper {
     if (this.dumpOptions.encrypted) {
       this.dumpConfig.activateEncryption();
     }
+    if (this.dumpOptions.hasOwnProperty("threads")) {
+      this.dumpConfig.setThreads(this.dumpOptions.threads);
+    }
     if (this.dumpOptions.jwtSecret) {
       let keyDir = fs.join(fs.getTempPath(), 'jwtSecrets');
       if (!fs.exists(keyDir)) {  // needed on win32
@@ -148,6 +151,9 @@ class DumpRestoreHelper {
       this.restoreOldConfig.setRootDir(pu.TOP_DIR);
     } else {
       this.restoreOldConfig.setEndpoint(this.instanceInfo.endpoint);
+    }
+    if (this.restoreOptions.hasOwnProperty("threads")) {
+      this.restoreConfig.setThreads(this.restoreOptions.threads);
     }
     if (this.restoreOptions.jwtSecret) {
       let keyDir = fs.join(fs.getTempPath(), 'jwtSecrets');
@@ -698,7 +704,8 @@ function dumpWithCrashes (options) {
   let dumpOptions = {
     allDatabases: true,
     deactivateCompression: true,
-    activateFailurePoint: true
+    activateFailurePoint: true,
+    threads: 1,
   };
   _.defaults(dumpOptions, options);
   return dump_backend(dumpOptions, {}, {}, dumpOptions, dumpOptions, 'dump_with_crashes', tstFiles, function(){});

--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -99,6 +99,12 @@ class ConfigBuilder {
     }
     this.config['server.database'] = database;
   }
+  setThreads(threads) {
+    if (this.type !== 'restore' && this.type !== 'dump') {
+      throw '"threads" is not supported for binary: ' + this.type;
+    }
+    this.config['threads'] = threads;
+  }
   setIncludeSystem(active) {
     if (this.type !== 'restore' && this.type !== 'dump') {
       throw '"include-system-collections" is not supported for binary: ' + this.type;

--- a/lib/Maskings/Maskings.cpp
+++ b/lib/Maskings/Maskings.cpp
@@ -25,8 +25,10 @@
 #include <iostream>
 
 #include <velocypack/Builder.h>
+#include <velocypack/Dumper.h>
 #include <velocypack/Exception.h>
 #include <velocypack/Iterator.h>
+#include <velocypack/Options.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
 #include <velocypack/StringRef.h>
@@ -36,7 +38,9 @@
 #include "Maskings.h"
 
 #include "Basics/FileUtils.h"
+#include "Basics/StaticStrings.h"
 #include "Basics/StringBuffer.h"
+#include "Basics/VPackStringBufferAdapter.h"
 #include "Basics/debugging.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
@@ -47,6 +51,10 @@
 
 using namespace arangodb;
 using namespace arangodb::maskings;
+
+namespace {
+std::string const xxxx("xxxx");
+}
 
 MaskingsResult Maskings::fromFile(std::string const& filename) {
   std::string definition;
@@ -191,8 +199,6 @@ bool Maskings::shouldDumpData(std::string const& name) {
 
 VPackValue Maskings::maskedItem(Collection& collection, std::vector<std::string>& path,
                                 std::string& buffer, VPackSlice const& data) {
-  static std::string xxxx("xxxx");
-
   if (path.size() == 1 && path[0].size() >= 1 && path[0][0] == '_') {
     if (data.isString()) {
       velocypack::ValueLength length;
@@ -242,6 +248,8 @@ VPackValue Maskings::maskedItem(Collection& collection, std::vector<std::string>
 
 void Maskings::addMaskedArray(Collection& collection, VPackBuilder& builder,
                               std::vector<std::string>& path, VPackSlice const& data) {
+  std::string buffer;
+
   for (VPackSlice entry : VPackArrayIterator(data)) {
     if (entry.isObject()) {
       VPackObjectBuilder ob(&builder);
@@ -250,7 +258,6 @@ void Maskings::addMaskedArray(Collection& collection, VPackBuilder& builder,
       VPackArrayBuilder ap(&builder);
       addMaskedArray(collection, builder, path, entry);
     } else {
-      std::string buffer;
       builder.add(maskedItem(collection, path, buffer, entry));
     }
   }
@@ -258,6 +265,8 @@ void Maskings::addMaskedArray(Collection& collection, VPackBuilder& builder,
 
 void Maskings::addMaskedObject(Collection& collection, VPackBuilder& builder,
                                std::vector<std::string>& path, VPackSlice const& data) {
+  std::string buffer;
+
   for (auto const& entry : VPackObjectIterator(data, false)) {
     std::string key = entry.key.copyString();
     VPackSlice const& value = entry.value;
@@ -271,7 +280,6 @@ void Maskings::addMaskedObject(Collection& collection, VPackBuilder& builder,
       VPackArrayBuilder ap(&builder, key);
       addMaskedArray(collection, builder, path, value);
     } else {
-      std::string buffer;
       builder.add(key, maskedItem(collection, path, buffer, value));
     }
 
@@ -280,7 +288,7 @@ void Maskings::addMaskedObject(Collection& collection, VPackBuilder& builder,
 }
 
 void Maskings::addMasked(Collection& collection, VPackBuilder& builder,
-                         VPackSlice const& data) {
+                         VPackSlice data) {
   if (!data.isObject()) {
     return;
   }
@@ -293,32 +301,50 @@ void Maskings::addMasked(Collection& collection, VPackBuilder& builder,
 }
 
 void Maskings::addMasked(Collection& collection, basics::StringBuffer& data,
-                         VPackSlice const& slice) {
+                         VPackSlice slice) {
   if (!slice.isObject()) {
     return;
   }
-
-  velocypack::StringRef dataStrRef("data");
-
+  
   VPackBuilder builder;
 
-  {
-    VPackObjectBuilder ob(&builder);
+  if (slice.hasKey(StaticStrings::KeyString)) {
+    // non-enveloped format - the document is at the top level
+    {
+      VPackObjectBuilder ob(&builder);
+      addMasked(collection, builder, slice);
+    }
+  
+    // the maskings will generate a result object that contains a "data"
+    // attribute at the top
+    slice = builder.slice().get("data");
+  } else {
+    // enveloped format -  the document is underneath the "data" attribute
+    velocypack::StringRef dataStrRef("data");
 
-    for (auto const& entry : VPackObjectIterator(slice, false)) {
-      velocypack::StringRef key = entry.key.stringRef();
+    {
+      VPackObjectBuilder ob(&builder);
 
-      if (key.equals(dataStrRef)) {
-        addMasked(collection, builder, entry.value);
-      } else {
-        builder.add(key, entry.value);
+      for (auto const& entry : VPackObjectIterator(slice, false)) {
+        velocypack::StringRef key = entry.key.stringRef();
+
+        if (key.equals(dataStrRef)) {
+          addMasked(collection, builder, entry.value);
+        } else {
+          builder.add(key, entry.value);
+        }
       }
     }
-  }
 
-  std::string masked = builder.toJson();
-  data.appendText(masked);
-  data.appendText("\n");
+    slice = builder.slice();
+  }
+  
+  // directly emit JSON into result StringBuffer
+  basics::VPackStringBufferAdapter adapter(data.stringBuffer());
+  VPackDumper dumper(&adapter, &VPackOptions::Defaults);
+  dumper.dump(slice);
+    
+  data.appendChar('\n');
 }
 
 void Maskings::mask(std::string const& name, basics::StringBuffer const& data,

--- a/lib/Maskings/Maskings.h
+++ b/lib/Maskings/Maskings.h
@@ -84,8 +84,8 @@ class Maskings {
                       std::vector<std::string>& path, VPackSlice const& data);
   void addMaskedObject(Collection& collection, VPackBuilder& builder,
                        std::vector<std::string>& path, VPackSlice const& data);
-  void addMasked(Collection& collection, VPackBuilder& builder, VPackSlice const& data);
-  void addMasked(Collection& collection, basics::StringBuffer& data, VPackSlice const& slice);
+  void addMasked(Collection& collection, VPackBuilder& builder, VPackSlice  data);
+  void addMasked(Collection& collection, basics::StringBuffer& data, VPackSlice slice);
 
  private:
   std::map<std::string, Collection> _collections;

--- a/tests/js/server/dump/dump-maskings.js
+++ b/tests/js/server/dump/dump-maskings.js
@@ -37,12 +37,6 @@ function dumpMaskingSuite () {
   var db = internal.db;
 
   return {
-    setUp : function () {
-    },
-
-    tearDown : function () {
-    },
-
     testGeneral : function () {
       var c = db._collection("maskings1");
       var d = c.document("1");


### PR DESCRIPTION
### Scope & Purpose

Partial backport of https://github.com/arangodb/arangodb/pull/14010
Docs PR: https://github.com/arangodb/docs/pull/688

Improve parallelism capabilities of arangorestore.

arangorestore can now dispatch restoring data chunks of a collection to idle background threads, so that multiple restore requests can be in flight for the same collection concurrently.

This can improve restore speed in situations when there are idle arangorestore threads left (number of threads can be configured via arangorestore's `--threads` option) and the dump file for the collection is large.
Previously the thread that read the data for file a collection would send HTTP requests to the server and block until the response came back. So even when there were idle threads available they could not be used.
With the change in this PR, the thread that reads the input file for a collection can either dispatch sending the data to another idle thread or send the data itself in case there is no other idle thread. In the former case the original thread continues to read data from the input file and the other thread does the request-response handling. The original thread can even dispatch requests to multiple idle threads if it can read the input file quicker than the request-response handling takes (which is to be expected).
In case there are no other idle threads available, the behavior is effectively unchanged, and the arangorestore thread that reads the input file is also sending requests and blocks until the response comes back.

The improved parallelism is only used when restoring dumps that are in the non-enveloped format. This format has been introduced with ArangoDB 3.8. The reason is that dumps in the non-enveloped format only contain the raw documents, which can be restored independent of each other, i.e. in any order. However, the enveloped format may contain documents and remove operations, which need to be restored in the original order. Thus we can't parallelize the enveloped format's restores.

The non-enveloped format is available for arangodump since ArangoDB 3.8, and is opt-in in 3.8. It will become the default dump format in ArangoDB 3.9.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/688

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
