### PR TITLE
Fix crashes during arangorestore operations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,11 @@
 v3.8.0 (XXXX-XX-XX)
 -------------------
 
-* Fixed BTS-360 and ES-826: sporadic ArangoSearch error `Invalid RL encoding in
-  'dense_fixed_offset_column_key'`.
-
 * Fix crashes during arangorestore operations due to usage of wrong pointer
   value for updating user permissions.
+
+* Fixed BTS-360 and ES-826: sporadic ArangoSearch error `Invalid RL encoding in
+  'dense_fixed_offset_column_key'`.
 
 * Add HTTP REST API endpoint POST `/_api/cursor/<cursor-id>` as a drop-in
   replacement for PUT `/_api/cursor/<cursor-id>`. The POST API is functionally

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,9 @@ v3.8.0 (XXXX-XX-XX)
 * Fixed BTS-360 and ES-826: sporadic ArangoSearch error `Invalid RL encoding in
   'dense_fixed_offset_column_key'`.
 
+* Fix crashes during arangorestore operations due to usage of wrong pointer
+  value for updating user permissions.
+
 * Add HTTP REST API endpoint POST `/_api/cursor/<cursor-id>` as a drop-in
   replacement for PUT `/_api/cursor/<cursor-id>`. The POST API is functionally
   equivalent to the existing PUT API. The benefit of using the POST API is that

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1262,7 +1262,7 @@ Result RestReplicationHandler::processRestoreCollection(VPackSlice const& collec
     }
 
     // finally rewrite all Enterprise Edition sharding strategies to a simple hash-based strategy
-    s = parameters.get(StaticSrings::ShardingStrategy);
+    s = parameters.get(StaticStrings::ShardingStrategy);
     if (s.isString() && s.copyString().find("enterprise") != std::string::npos) {
       // downgrade sharding strategy to just hash
       toMerge.add(StaticStrings::shardingStrategy, VPackValue("hash"));

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1068,6 +1068,7 @@ Result RestReplicationHandler::processRestoreCollection(VPackSlice const& collec
 
   std::shared_ptr<LogicalCollection> col;
   auto lookupResult = methods::Collections::lookup(_vocbase, name, col);
+
   if (lookupResult.ok()) {
     TRI_ASSERT(col);
     if (dropExisting) {
@@ -1108,6 +1109,9 @@ Result RestReplicationHandler::processRestoreCollection(VPackSlice const& collec
                             "unable to drop collection '", name,
                             "': ", dropResult.errorMessage()));
         }
+
+        // we just removed the collection, so we cannot rely on it being present now
+        col.reset();
       } catch (basics::Exception const& ex) {
         LOG_TOPIC("41579", DEBUG, Logger::REPLICATION)
             << "processRestoreCollection "
@@ -1258,10 +1262,10 @@ Result RestReplicationHandler::processRestoreCollection(VPackSlice const& collec
     }
 
     // finally rewrite all Enterprise Edition sharding strategies to a simple hash-based strategy
-    s = parameters.get("shardingStrategy");
+    s = parameters.get(StaticSrings::ShardingStrategy);
     if (s.isString() && s.copyString().find("enterprise") != std::string::npos) {
       // downgrade sharding strategy to just hash
-      toMerge.add("shardingStrategy", VPackValue("hash"));
+      toMerge.add(StaticStrings::shardingStrategy, VPackValue("hash"));
       changes.push_back("changed 'shardingStrategy' attribute value to 'hash'");
     }
 
@@ -1341,7 +1345,7 @@ Result RestReplicationHandler::processRestoreCollection(VPackSlice const& collec
     // We do never take any responsibility of the
     // value this pointer will point to.
     LogicalCollection* colPtr = nullptr;
-    auto res = createCollection(parameters, &colPtr);
+    auto res = createCollection(parameters, colPtr);
 
     if (res != TRI_ERROR_NO_ERROR) {
       return Result(res, StringUtils::concatT("unable to create collection: ",
@@ -1349,15 +1353,16 @@ Result RestReplicationHandler::processRestoreCollection(VPackSlice const& collec
     }
     // If we get here, we must have a collection ptr.
     TRI_ASSERT(colPtr != nullptr);
-
+  
     // might be also called on dbservers
     if (name[0] != '_' && !ExecContext::current().isSuperuser() &&
         ServerState::instance()->isSingleServer()) {
+
       auth::UserManager* um = AuthenticationFeature::instance()->userManager();
       TRI_ASSERT(um != nullptr);  // should not get here
       if (um != nullptr) {
         um->updateUser(ExecContext::current().user(), [&](auth::User& entry) {
-          entry.grantCollection(_vocbase.name(), col->name(), auth::Level::RW);
+          entry.grantCollection(_vocbase.name(), name, auth::Level::RW);
           return TRI_ERROR_NO_ERROR;
         });
       }
@@ -3207,8 +3212,8 @@ void RestReplicationHandler::handleCommandRevisionDocuments() {
 ////////////////////////////////////////////////////////////////////////////////
 
 ErrorCode RestReplicationHandler::createCollection(VPackSlice slice,
-                                                   arangodb::LogicalCollection** dst) {
-  TRI_ASSERT(dst != nullptr);
+                                                   arangodb::LogicalCollection*& dst) {
+  TRI_ASSERT(dst == nullptr);
 
   if (!slice.isObject()) {
     return TRI_ERROR_HTTP_BAD_PARAMETER;
@@ -3241,6 +3246,7 @@ ErrorCode RestReplicationHandler::createCollection(VPackSlice slice,
   if (col != nullptr && col->type() == type) {
     // TODO
     // collection already exists. TODO: compare attributes
+    dst = col.get();
     return TRI_ERROR_NO_ERROR;
   }
 
@@ -3295,9 +3301,7 @@ ErrorCode RestReplicationHandler::createCollection(VPackSlice slice,
   TRI_ASSERT(col->planId() == planId);
 #endif
 
-  if (dst != nullptr) {
-    *dst = col.get();
-  }
+  dst = col.get();
 
   return TRI_ERROR_NO_ERROR;
 }

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1265,7 +1265,7 @@ Result RestReplicationHandler::processRestoreCollection(VPackSlice const& collec
     s = parameters.get(StaticStrings::ShardingStrategy);
     if (s.isString() && s.copyString().find("enterprise") != std::string::npos) {
       // downgrade sharding strategy to just hash
-      toMerge.add(StaticStrings::shardingStrategy, VPackValue("hash"));
+      toMerge.add(StaticStrings::ShardingStrategy, VPackValue("hash"));
       changes.push_back("changed 'shardingStrategy' attribute value to 'hash'");
     }
 

--- a/arangod/RestHandler/RestReplicationHandler.h
+++ b/arangod/RestHandler/RestReplicationHandler.h
@@ -417,7 +417,7 @@ class RestReplicationHandler : public RestVocbaseBaseHandler {
   /// @brief creates a collection, based on the VelocyPack provided
   //////////////////////////////////////////////////////////////////////////////
 
-  ErrorCode createCollection(VPackSlice slice, arangodb::LogicalCollection** dst);
+  ErrorCode createCollection(VPackSlice slice, arangodb::LogicalCollection*& dst);
 
  private:
   //////////////////////////////////////////////////////////////////////////////

--- a/tests/js/client/authentication/restore.js
+++ b/tests/js/client/authentication/restore.js
@@ -1,0 +1,187 @@
+/*jshint globalstrict:false, strict:false */
+/*global assertTrue, assertEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test the authentication
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2013, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const arango = require("@arangodb").arango;
+const db = require("internal").db;
+const users = require("@arangodb/users");
+
+function AuthSuite() {
+  'use strict';
+
+  const user1 = 'hackers@arangodb.com';
+  const user2 = 'noone@arangodb.com';
+
+  const cn = 'UnitTestsCollection';
+      
+  return {
+    setUpAll: function () {
+      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+
+      try {
+        users.remove(user1);
+      } catch (err) {
+      }
+      try {
+        users.remove(user2);
+      } catch (err) {
+      }
+    
+      try {
+        db._dropDatabase('UnitTestsDatabase');
+      } catch (err) {
+      }
+      
+      db._createDatabase('UnitTestsDatabase');
+      
+      users.save(user1, "foobar");
+      users.save(user2, "foobar");
+      users.grantDatabase(user1, 'UnitTestsDatabase');
+      users.grantCollection(user1, 'UnitTestsDatabase', "*");
+      users.grantDatabase(user2, 'UnitTestsDatabase', 'ro');
+      users.reload();
+    },
+
+    tearDownAll: function () {
+      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+      try {
+        users.remove(user1);
+      } catch (err) {
+      }
+      try {
+        users.remove(user2);
+      } catch (err) {
+      }
+
+      try {
+        db._dropDatabase('UnitTestsDatabase');
+      } catch (err) {
+      }
+    },
+    
+    tearDown: function () {
+      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', "root", "");
+      db._drop(cn);
+
+      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+      db._drop(cn);
+    },
+    
+    testRestoreSystemDBRoot: function () {
+      arango.reconnect(arango.getEndpoint(), '_system', 'root', '');
+    
+      let result = arango.PUT('/_api/replication/restore-collection', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.result);
+    },
+    
+    testRestoreSystemDBRootOverwrite: function () {
+      arango.reconnect(arango.getEndpoint(), '_system', 'root', '');
+    
+      let result = arango.PUT('/_api/replication/restore-collection', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.result);
+      
+      result = arango.PUT('/_api/replication/restore-collection?overwrite=true', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.result);
+      
+      result = arango.PUT('/_api/replication/restore-collection?overwrite=false', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.error);
+      assertEqual(409, result.code);
+      
+      result = arango.PUT('/_api/replication/restore-collection?overwrite=true', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.result);
+    },
+    
+    testRestoreOtherDBRoot: function () {
+      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', 'root', '');
+    
+      let result = arango.PUT('/_api/replication/restore-collection', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.result);
+    },
+    
+    testRestoreOtherDBRW: function () {
+      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user1, 'foobar');
+    
+      let result = arango.PUT('/_api/replication/restore-collection', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.result);
+    },
+    
+    testRestoreOtherDBRWOverwrite: function () {
+      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user1, 'foobar');
+    
+      let result = arango.PUT('/_api/replication/restore-collection', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.result);
+      
+      result = arango.PUT('/_api/replication/restore-collection?overwrite=true', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.result);
+      
+      result = arango.PUT('/_api/replication/restore-collection?overwrite=false', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.error);
+      assertEqual(409, result.code);
+      
+      result = arango.PUT('/_api/replication/restore-collection?overwrite=true', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.result);
+    },
+    
+    testRestoreOtherDBRO: function () {
+      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user2, 'foobar');
+    
+      let result = arango.PUT('/_api/replication/restore-collection', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.error);
+      assertEqual(403, result.code);
+    },
+  };
+}
+
+
+jsunity.run(AuthSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/14021

Fix crashes during arangorestore operations due to usage of wrong pointer value for updating user permissions.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.7*: https://github.com/arangodb/arangodb/pull/14023, *3.6*: https://github.com/arangodb/arangodb/pull/14024

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in authentication)
