### PR TITLE
Fix crashes during arangorestore operations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.6.14 (XXXX-XX-XX)
 --------------------
 
+* Fix crashes during arangorestore operations due to usage of wrong pointer
+  value for updating user permissions.
+
 * Fixed BTS-360 and ES-826: sporadic ArangoSearch error `Invalid RL encoding in
   'dense_fixed_offset_column_key'`.
 

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1228,7 +1228,7 @@ Result RestReplicationHandler::processRestoreCollection(
     s = parameters.get("shardingStrategy");
     if (s.isString() && s.copyString().find("enterprise") != std::string::npos) {
       // downgrade sharding strategy to just hash
-      toMerge.add(StaticStrings::shardingStrategy, VPackValue("hash"));
+      toMerge.add(StaticStrings::ShardingStrategy, VPackValue("hash"));
       changes.push_back("changed 'shardingStrategy' attribute value to 'hash'");
     }
 

--- a/arangod/RestHandler/RestReplicationHandler.h
+++ b/arangod/RestHandler/RestReplicationHandler.h
@@ -349,7 +349,7 @@ class RestReplicationHandler : public RestVocbaseBaseHandler {
   /// @brief creates a collection, based on the VelocyPack provided
   //////////////////////////////////////////////////////////////////////////////
 
-  int createCollection(VPackSlice, arangodb::LogicalCollection**);
+  int createCollection(VPackSlice, arangodb::LogicalCollection*& dst);
 
  private:
   //////////////////////////////////////////////////////////////////////////////

--- a/tests/js/client/authentication/restore.js
+++ b/tests/js/client/authentication/restore.js
@@ -1,0 +1,187 @@
+/*jshint globalstrict:false, strict:false */
+/*global assertTrue, assertEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test the authentication
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2013, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const arango = require("@arangodb").arango;
+const db = require("internal").db;
+const users = require("@arangodb/users");
+
+function AuthSuite() {
+  'use strict';
+
+  const user1 = 'hackers@arangodb.com';
+  const user2 = 'noone@arangodb.com';
+
+  const cn = 'UnitTestsCollection';
+      
+  return {
+    setUpAll: function () {
+      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+
+      try {
+        users.remove(user1);
+      } catch (err) {
+      }
+      try {
+        users.remove(user2);
+      } catch (err) {
+      }
+    
+      try {
+        db._dropDatabase('UnitTestsDatabase');
+      } catch (err) {
+      }
+      
+      db._createDatabase('UnitTestsDatabase');
+      
+      users.save(user1, "foobar");
+      users.save(user2, "foobar");
+      users.grantDatabase(user1, 'UnitTestsDatabase');
+      users.grantCollection(user1, 'UnitTestsDatabase', "*");
+      users.grantDatabase(user2, 'UnitTestsDatabase', 'ro');
+      users.reload();
+    },
+
+    tearDownAll: function () {
+      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+      try {
+        users.remove(user1);
+      } catch (err) {
+      }
+      try {
+        users.remove(user2);
+      } catch (err) {
+      }
+
+      try {
+        db._dropDatabase('UnitTestsDatabase');
+      } catch (err) {
+      }
+    },
+    
+    tearDown: function () {
+      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', "root", "");
+      db._drop(cn);
+
+      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+      db._drop(cn);
+    },
+    
+    testRestoreSystemDBRoot: function () {
+      arango.reconnect(arango.getEndpoint(), '_system', 'root', '');
+    
+      let result = arango.PUT('/_api/replication/restore-collection', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.result);
+    },
+    
+    testRestoreSystemDBRootOverwrite: function () {
+      arango.reconnect(arango.getEndpoint(), '_system', 'root', '');
+    
+      let result = arango.PUT('/_api/replication/restore-collection', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.result);
+      
+      result = arango.PUT('/_api/replication/restore-collection?overwrite=true', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.result);
+      
+      result = arango.PUT('/_api/replication/restore-collection?overwrite=false', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.error);
+      assertEqual(409, result.code);
+      
+      result = arango.PUT('/_api/replication/restore-collection?overwrite=true', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.result);
+    },
+    
+    testRestoreOtherDBRoot: function () {
+      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', 'root', '');
+    
+      let result = arango.PUT('/_api/replication/restore-collection', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.result);
+    },
+    
+    testRestoreOtherDBRW: function () {
+      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user1, 'foobar');
+    
+      let result = arango.PUT('/_api/replication/restore-collection', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.result);
+    },
+    
+    testRestoreOtherDBRWOverwrite: function () {
+      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user1, 'foobar');
+    
+      let result = arango.PUT('/_api/replication/restore-collection', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.result);
+      
+      result = arango.PUT('/_api/replication/restore-collection?overwrite=true', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.result);
+      
+      result = arango.PUT('/_api/replication/restore-collection?overwrite=false', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.error);
+      assertEqual(409, result.code);
+      
+      result = arango.PUT('/_api/replication/restore-collection?overwrite=true', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.result);
+    },
+    
+    testRestoreOtherDBRO: function () {
+      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user2, 'foobar');
+    
+      let result = arango.PUT('/_api/replication/restore-collection', {
+        parameters: { name: cn, type: 2 }, indexes: [] 
+      });
+      assertTrue(result.error);
+      assertEqual(403, result.code);
+    },
+  };
+}
+
+
+jsunity.run(AuthSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/14021

Fix crashes during arangorestore operations due to usage of wrong pointer value for updating user permissions.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required.

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in authentication)
