### PR TITLE
deprecate collection load/unload functions

### DIFF
--- a/Documentation/DocuBlocks/Rest/Collections/put_api_collection_load.md
+++ b/Documentation/DocuBlocks/Rest/Collections/put_api_collection_load.md
@@ -6,6 +6,10 @@
 
 @HINTS
 {% hint 'warning' %}
+The load function is deprecated from version 3.8.0 onwards and should no longer be used.
+{% endhint %}
+
+{% hint 'warning' %}
 Accessing collections by their numeric ID is deprecated from version 3.4.0 on.
 You should reference them via their names instead.
 {% endhint %}

--- a/Documentation/DocuBlocks/Rest/Collections/put_api_collection_unload.md
+++ b/Documentation/DocuBlocks/Rest/Collections/put_api_collection_unload.md
@@ -6,6 +6,10 @@
 
 @HINTS
 {% hint 'warning' %}
+The unload function is deprecated from version 3.8.0 onwards and should no longer be used.
+{% endhint %}
+
+{% hint 'warning' %}
 Accessing collections by their numeric ID is deprecated from version 3.4.0 on.
 You should reference them via their names instead.
 {% endhint %}


### PR DESCRIPTION
### Scope & Purpose

Add deprecation notes to collection load/unload functions in the docs.
Docs PR: https://github.com/arangodb/docs/pull/690

This PR only contains documentation changes.

- [x] :hankey: Bugfix (requires CHANGELOG entry)

#### Backports:

- [x] Backports required for: *3.8*

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/690

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
