### PR TITLE
Added `--query-max-runtime` option for arangoexport

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+v3.8.0 (XXXX-XX-XX)
+-------------------
+
+* Added option `--query-max-runtime` to arangoexport, in order to control
+  maximum query runtime.
+
+
 v3.8.0-beta.1 (2021-04-20)
 --------------------------
 

--- a/arangosh/Export/ExportFeature.cpp
+++ b/arangosh/Export/ExportFeature.cpp
@@ -70,6 +70,7 @@ ExportFeature::ExportFeature(application_features::ApplicationServer& server, in
       _xgmmlLabelAttribute("label"),
       _typeExport("json"),
       _queryMaxRuntime(0.0),
+      _useMaxRuntime(false),
       _xgmmlLabelOnly(false),
       _overwrite(false),
       _progress(true),
@@ -194,6 +195,9 @@ void ExportFeature::validateOptions(std::shared_ptr<options::ProgramOptions> opt
 
     _csvFields = StringUtils::split(_csvFieldOptions, ',');
   }
+  
+  // we will use _maxRuntime only if the option was set by the user
+  _useMaxRuntime = options->processingResult().touched("--query-max-runtime");
 }
 
 void ExportFeature::prepare() {
@@ -381,7 +385,9 @@ void ExportFeature::queryExport(SimpleHttpClient* httpClient) {
   post.add("ttl", VPackValue(::ttlValue));
   post.add("batchSize", VPackValue(_documentsPerBatch));
   post.add("options", VPackValue(VPackValueType::Object));
-  post.add("maxRuntime", VPackValue(_queryMaxRuntime));
+  if (_useMaxRuntime) {
+    post.add("maxRuntime", VPackValue(_queryMaxRuntime));
+  }
   post.add("stream", VPackSlice::trueSlice());
   post.close();
   post.close();

--- a/arangosh/Export/ExportFeature.h
+++ b/arangosh/Export/ExportFeature.h
@@ -76,9 +76,9 @@ class ExportFeature final : public application_features::ApplicationFeature,
   std::string _typeExport;
   std::string _csvFieldOptions;
   std::vector<std::string> _csvFields;
-  bool _xgmmlLabelOnly;
-
   std::string _outputDirectory;
+  double _queryMaxRuntime;
+  bool _xgmmlLabelOnly;
   bool _overwrite;
   bool _progress;
   bool _useGzip;

--- a/arangosh/Export/ExportFeature.h
+++ b/arangosh/Export/ExportFeature.h
@@ -78,6 +78,7 @@ class ExportFeature final : public application_features::ApplicationFeature,
   std::vector<std::string> _csvFields;
   std::string _outputDirectory;
   double _queryMaxRuntime;
+  bool _useMaxRuntime; 
   bool _xgmmlLabelOnly;
   bool _overwrite;
   bool _progress;

--- a/js/client/modules/@arangodb/testsuites/export.js
+++ b/js/client/modules/@arangodb/testsuites/export.js
@@ -176,7 +176,7 @@ function exportTest (options) {
       fs.remove(fs.join(tmpPath, 'ENCRYPTION'));
     }
     results.exportJsonEncrypt = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), options, 'arangosh', tmpPath, options.coreCheck);
-    results.exportJsonEncrypt.failed = results.exportJsonGz.status ? 0 : 1;
+    results.exportJsonEncrypt.failed = results.exportJsonEncrypt.status ? 0 : 1;
 
     try {
       const decBuffer = fs.readDecrypt(fs.join(tmpPath, 'UnitTestsExport.json'), keyfile);
@@ -224,7 +224,7 @@ function exportTest (options) {
   print(CYAN + Date() + ': Export data (jsonl.gz)' + RESET);
   args['compress-output'] = 'true';
   results.exportJsonlGz = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), options, 'arangosh', tmpPath, options.coreCheck);
-  results.exportJsonlGz.failed = results.exportJsonl.status ? 0 : 1;
+  results.exportJsonlGz.failed = results.exportJsonlGz.status ? 0 : 1;
   try {
     fs.readGzip(fs.join(tmpPath, 'UnitTestsExport.jsonl.gz')).split('\n')
     .filter(line => line.trim() !== '')
@@ -276,7 +276,7 @@ function exportTest (options) {
   print(CYAN + Date() + ': Export data (xgmml.gz)' + RESET);
   args['compress-output'] = 'true';
   results.exportXgmmlGz = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), options, 'arangosh', tmpPath, options.coreCheck);
-  results.exportXgmmlGz.failed = results.exportXgmml.status ? 0 : 1;
+  results.exportXgmmlGz.failed = results.exportXgmmlGz.status ? 0 : 1;
   try {
     const filesContent = fs.readGzip(fs.join(tmpPath, 'UnitTestsExport.xgmml.gz'));
     DOMParser.parseFromString(filesContent);
@@ -302,7 +302,7 @@ function exportTest (options) {
   }
   args['compress-output'] = 'false';
 
-  print(CYAN + Date() + ': Export query (xgmml)' + RESET);
+  print(CYAN + Date() + ': Export query (jsonl)' + RESET);
   args['type'] = 'jsonl';
   args['query'] = 'FOR doc IN UnitTestsExport RETURN doc';
   delete args['graph-name'];
@@ -327,10 +327,10 @@ function exportTest (options) {
     };
   }
 
-  print(CYAN + Date() + ': Export query (xgmml.gz)' + RESET);
+  print(CYAN + Date() + ': Export query (jsonl.gz)' + RESET);
   args['compress-output'] = 'true';
   results.exportQueryGz = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), options, 'arangosh', tmpPath, options.coreCheck);
-  results.exportQueryGz.failed = results.exportQuery.status ? 0 : 1;
+  results.exportQueryGz.failed = results.exportQueryGz.status ? 0 : 1;
   try {
     fs.readGzip(fs.join(tmpPath, 'query.jsonl.gz')).split('\n')
     .filter(line => line.trim() !== '')
@@ -354,7 +354,7 @@ function exportTest (options) {
   args['query'] = 'FOR doc IN UnitTestsExport RETURN doc';
   args['fields'] = '_key,value1,value2,value3,value4';
   results.exportCsv = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), options, 'arangosh', tmpPath, false, options.coreCheck);
-  results.exportCsv.failed = results.exportJsonl.status ? 0 : 1;
+  results.exportCsv.failed = results.exportCsv.status ? 0 : 1;
   try {
     fs.read(fs.join(tmpPath, 'query.csv'));
 
@@ -371,6 +371,24 @@ function exportTest (options) {
     };
   }
   delete args['fields'];
+  
+  print(CYAN + Date() + ': Export query (maxRuntime, failure)' + RESET);
+  args['type'] = 'jsonl';
+  args['query'] = 'RETURN SLEEP(4)';
+  args['query-max-runtime'] = '2.0';
+  results.exportQueryMaxRuntimeFail = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), options, 'arangosh', tmpPath, options.coreCheck);
+  // we expect a failure here!
+  results.exportQueryMaxRuntimeFail.status = !results.exportQueryMaxRuntimeFail.status;
+  results.exportQueryMaxRuntimeFail.failed = results.exportQueryMaxRuntimeFail.status ? 0 : 1;
+  delete args['query-max-runtime'];
+  
+  print(CYAN + Date() + ': Export query (maxRuntime, ok)' + RESET);
+  args['type'] = 'jsonl';
+  args['query'] = 'RETURN SLEEP(3)';
+  args['query-max-runtime'] = '20.0';
+  results.exportQueryMaxRuntimeOk = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), options, 'arangosh', tmpPath, options.coreCheck);
+  results.exportQueryMaxRuntimeOk.failed = results.exportQueryMaxRuntimeOk.status ? 0 : 1;
+  delete args['query-max-runtime'];
 
   return shutdown();
 }


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/14039

This adds the option `--query-max-runtime` to arangoexport, so that the maximum runtime of AQL queries can be restricted.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required.

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/691

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (export)
