### PR TITLE
Improve TTL handling for streaming cursors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.7.11 (XXXX-XX-XX)
 --------------------
 
+* Make the time-to-live (TTL) value of a streaming cursor only count after
+  the first response has been sent to the client.
+
 * Fix BTS-374: thread race between ArangoSearch link unloading and storage
   engine WAL flushing.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ v3.7.11 (XXXX-XX-XX)
 --------------------
 
 * Make the time-to-live (TTL) value of a streaming cursor only count after
-  the first response has been sent to the client.
+  the response has been sent to the client.
 
 * Fix BTS-374: thread race between ArangoSearch link unloading and storage
   engine WAL flushing.

--- a/arangod/Utils/Cursor.h
+++ b/arangod/Utils/Cursor.h
@@ -83,7 +83,6 @@ class Cursor {
     TRI_ASSERT(!_isUsed);
 
     _isUsed = true;
-    _expires = TRI_microtime() + _ttl;
   }
 
   void release() {

--- a/arangod/Utils/Cursor.h
+++ b/arangod/Utils/Cursor.h
@@ -56,6 +56,7 @@ class Cursor {
         _ttl(ttl),
         _expires(TRI_microtime() + _ttl),
         _hasCount(hasCount),
+        _canUseExpire(false),
         _isDeleted(false),
         _isUsed(false) {}
 
@@ -71,6 +72,8 @@ class Cursor {
   inline double ttl() const { return _ttl; }
 
   inline double expires() const { return _expires; }
+  
+  inline bool canUseExpire() const { return _canUseExpire; }
 
   inline bool isUsed() const { return _isUsed; }
 
@@ -89,6 +92,10 @@ class Cursor {
   void release() {
     TRI_ASSERT(_isUsed);
     _isUsed = false;
+    if (!_canUseExpire) {
+      _expires = TRI_microtime() + _ttl;
+      _canUseExpire = true;
+    }
   }
 
   virtual void kill() {}
@@ -137,6 +144,10 @@ class Cursor {
   double _ttl;
   double _expires;
   bool const _hasCount;
+  /// @brief this flag is initially false, but will flip to true once the cursor
+  /// is returned to the cursor repository. if the flag is still false, a cursor
+  /// cannot expire (e.g. because it is still operating)
+  bool _canUseExpire;
   bool _isDeleted;
   bool _isUsed;
 };

--- a/arangod/Utils/Cursor.h
+++ b/arangod/Utils/Cursor.h
@@ -137,9 +137,6 @@ class Cursor {
   double _ttl;
   double _expires;
   bool const _hasCount;
-  /// @brief this flag is initially false, but will flip to true once the cursor
-  /// is returned to the cursor repository. if the flag is still false, a cursor
-  /// cannot expire (e.g. because it is still operating)
   bool _isDeleted;
   bool _isUsed;
 };

--- a/arangod/Utils/Cursor.h
+++ b/arangod/Utils/Cursor.h
@@ -56,7 +56,6 @@ class Cursor {
         _ttl(ttl),
         _expires(TRI_microtime() + _ttl),
         _hasCount(hasCount),
-        _canUseExpire(false),
         _isDeleted(false),
         _isUsed(false) {}
 
@@ -73,8 +72,6 @@ class Cursor {
 
   inline double expires() const { return _expires; }
   
-  inline bool canUseExpire() const { return _canUseExpire; }
-
   inline bool isUsed() const { return _isUsed; }
 
   inline bool isDeleted() const { return _isDeleted; }
@@ -92,10 +89,7 @@ class Cursor {
   void release() {
     TRI_ASSERT(_isUsed);
     _isUsed = false;
-    if (!_canUseExpire) {
-      _expires = TRI_microtime() + _ttl;
-      _canUseExpire = true;
-    }
+    _expires = TRI_microtime() + _ttl;
   }
 
   virtual void kill() {}
@@ -147,7 +141,6 @@ class Cursor {
   /// @brief this flag is initially false, but will flip to true once the cursor
   /// is returned to the cursor repository. if the flag is still false, a cursor
   /// cannot expire (e.g. because it is still operating)
-  bool _canUseExpire;
   bool _isDeleted;
   bool _isUsed;
 };

--- a/arangod/Utils/CursorRepository.cpp
+++ b/arangod/Utils/CursorRepository.cpp
@@ -223,7 +223,7 @@ Cursor* CursorRepository::find(CursorId id, bool& busy) {
       return nullptr;
     }
     
-    if (cursor->canUseExpire() && cursor->expires() < TRI_microtime()) {
+    if (cursor->expires() < TRI_microtime()) {
       // cursor has expired already
       return nullptr;
     }
@@ -300,7 +300,7 @@ bool CursorRepository::garbageCollect(bool force) {
         continue;
       }
 
-      if (force || (cursor->canUseExpire() && cursor->expires() < now)) {
+      if (force || cursor->expires() < now) {
         cursor->kill();
         cursor->setDeleted();
       }

--- a/arangod/Utils/CursorRepository.cpp
+++ b/arangod/Utils/CursorRepository.cpp
@@ -223,7 +223,7 @@ Cursor* CursorRepository::find(CursorId id, bool& busy) {
       return nullptr;
     }
     
-    if (cursor->expires() < TRI_microtime()) {
+    if (cursor->canUseExpire() && cursor->expires() < TRI_microtime()) {
       // cursor has expired already
       return nullptr;
     }
@@ -300,7 +300,7 @@ bool CursorRepository::garbageCollect(bool force) {
         continue;
       }
 
-      if (force || cursor->expires() < now) {
+      if (force || (cursor->canUseExpire() && cursor->expires() < now)) {
         cursor->kill();
         cursor->setDeleted();
       }

--- a/tests/rb/HttpInterface/api-cursor-spec.rb
+++ b/tests/rb/HttpInterface/api-cursor-spec.rb
@@ -719,6 +719,72 @@ describe ArangoDB do
         doc.parsed_response['code'].should eq(404)
         doc.parsed_response['id'].should be_nil
       end
+      
+      it "creates a streaming cursor with a low TTL" do
+        cmd = api
+        body = "{ \"query\" : \"LET x = SLEEP(10) FOR i IN 1..10 RETURN i\", \"batchSize\" : 1, \"ttl\" : 10, \"options\": { \"stream\": true } }"
+        doc = ArangoDB.log_post("#{prefix}-create-low-ttl", cmd, :body => body)
+        
+        doc.code.should eq(201)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(201)
+        doc.parsed_response['id'].should be_kind_of(String)
+        doc.parsed_response['id'].should match(@reId)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['result'].length.should eq(1)
+        doc.parsed_response['cached'].should eq(false)
+
+        id = doc.parsed_response['id']
+        cmd = api + "/#{id}"
+        doc = ArangoDB.log_post("#{prefix}-create-ttl", cmd)
+        
+        doc.code.should eq(200)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(200)
+        doc.parsed_response['id'].should be_kind_of(String)
+        doc.parsed_response['id'].should match(@reId)
+        doc.parsed_response['id'].should eq(id)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['result'].length.should eq(1)
+        doc.parsed_response['cached'].should eq(false)
+        
+        doc = ArangoDB.log_delete("#{prefix}-create-ttl", cmd)
+      end
+      
+      it "creates a non-streaming cursor with a low TTL" do
+        cmd = api
+        body = "{ \"query\" : \"LET x = SLEEP(10) FOR i IN 1..10 RETURN i\", \"batchSize\" : 1, \"ttl\" : 10 }"
+        doc = ArangoDB.log_post("#{prefix}-create-low-ttl", cmd, :body => body)
+        
+        doc.code.should eq(201)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(201)
+        doc.parsed_response['id'].should be_kind_of(String)
+        doc.parsed_response['id'].should match(@reId)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['result'].length.should eq(1)
+        doc.parsed_response['cached'].should eq(false)
+
+        id = doc.parsed_response['id']
+        cmd = api + "/#{id}"
+        doc = ArangoDB.log_post("#{prefix}-create-ttl", cmd)
+        
+        doc.code.should eq(200)
+        doc.headers['content-type'].should eq("application/json; charset=utf-8")
+        doc.parsed_response['error'].should eq(false)
+        doc.parsed_response['code'].should eq(200)
+        doc.parsed_response['id'].should be_kind_of(String)
+        doc.parsed_response['id'].should match(@reId)
+        doc.parsed_response['id'].should eq(id)
+        doc.parsed_response['hasMore'].should eq(true)
+        doc.parsed_response['result'].length.should eq(1)
+        doc.parsed_response['cached'].should eq(false)
+        
+        doc = ArangoDB.log_delete("#{prefix}-create-ttl", cmd)
+      end
 
       it "creates a cursor that will expire - PUT" do
         cmd = api

--- a/tests/rb/HttpInterface/api-cursor-spec.rb
+++ b/tests/rb/HttpInterface/api-cursor-spec.rb
@@ -722,7 +722,7 @@ describe ArangoDB do
       
       it "creates a streaming cursor with a low TTL" do
         cmd = api
-        body = "{ \"query\" : \"LET x = SLEEP(10) FOR i IN 1..10 RETURN i\", \"batchSize\" : 1, \"ttl\" : 10, \"options\": { \"stream\": true } }"
+        body = "{ \"query\" : \"FOR i IN 1..10 LET x = SLEEP(5) RETURN i\", \"batchSize\" : 1, \"ttl\" : 2, \"options\": { \"stream\": true } }"
         doc = ArangoDB.log_post("#{prefix}-create-low-ttl", cmd, :body => body)
         
         doc.code.should eq(201)
@@ -737,25 +737,27 @@ describe ArangoDB do
 
         id = doc.parsed_response['id']
         cmd = api + "/#{id}"
-        doc = ArangoDB.log_post("#{prefix}-create-ttl", cmd)
         
-        doc.code.should eq(200)
-        doc.headers['content-type'].should eq("application/json; charset=utf-8")
-        doc.parsed_response['error'].should eq(false)
-        doc.parsed_response['code'].should eq(200)
-        doc.parsed_response['id'].should be_kind_of(String)
-        doc.parsed_response['id'].should match(@reId)
-        doc.parsed_response['id'].should eq(id)
-        doc.parsed_response['hasMore'].should eq(true)
-        doc.parsed_response['result'].length.should eq(1)
-        doc.parsed_response['cached'].should eq(false)
+        2.times do
+          doc = ArangoDB.log_post("#{prefix}-create-ttl", cmd)
+          doc.code.should eq(200)
+          doc.headers['content-type'].should eq("application/json; charset=utf-8")
+          doc.parsed_response['error'].should eq(false)
+          doc.parsed_response['code'].should eq(200)
+          doc.parsed_response['id'].should be_kind_of(String)
+          doc.parsed_response['id'].should match(@reId)
+          doc.parsed_response['id'].should eq(id)
+          doc.parsed_response['hasMore'].should eq(true)
+          doc.parsed_response['result'].length.should eq(1)
+          doc.parsed_response['cached'].should eq(false)
+        end
         
         doc = ArangoDB.log_delete("#{prefix}-create-ttl", cmd)
       end
       
       it "creates a non-streaming cursor with a low TTL" do
         cmd = api
-        body = "{ \"query\" : \"LET x = SLEEP(10) FOR i IN 1..10 RETURN i\", \"batchSize\" : 1, \"ttl\" : 10 }"
+        body = "{ \"query\" : \"FOR i IN 1..10 LET x = SLEEP(5) RETURN i\", \"batchSize\" : 1, \"ttl\" : 2 }"
         doc = ArangoDB.log_post("#{prefix}-create-low-ttl", cmd, :body => body)
         
         doc.code.should eq(201)
@@ -770,18 +772,20 @@ describe ArangoDB do
 
         id = doc.parsed_response['id']
         cmd = api + "/#{id}"
-        doc = ArangoDB.log_post("#{prefix}-create-ttl", cmd)
         
-        doc.code.should eq(200)
-        doc.headers['content-type'].should eq("application/json; charset=utf-8")
-        doc.parsed_response['error'].should eq(false)
-        doc.parsed_response['code'].should eq(200)
-        doc.parsed_response['id'].should be_kind_of(String)
-        doc.parsed_response['id'].should match(@reId)
-        doc.parsed_response['id'].should eq(id)
-        doc.parsed_response['hasMore'].should eq(true)
-        doc.parsed_response['result'].length.should eq(1)
-        doc.parsed_response['cached'].should eq(false)
+        2.times do
+          doc = ArangoDB.log_post("#{prefix}-create-ttl", cmd)
+          doc.code.should eq(200)
+          doc.headers['content-type'].should eq("application/json; charset=utf-8")
+          doc.parsed_response['error'].should eq(false)
+          doc.parsed_response['code'].should eq(200)
+          doc.parsed_response['id'].should be_kind_of(String)
+          doc.parsed_response['id'].should match(@reId)
+          doc.parsed_response['id'].should eq(id)
+          doc.parsed_response['hasMore'].should eq(true)
+          doc.parsed_response['result'].length.should eq(1)
+          doc.parsed_response['cached'].should eq(false)
+        end
         
         doc = ArangoDB.log_delete("#{prefix}-create-ttl", cmd)
       end


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/14044

Make the time-to-live (TTL) value of a streaming cursor only count after the first response has been sent to the client.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required.

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. http_server)
