### PR TITLE
remove the use of UsePadding velocypack options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+v3.8.0 (XXXX-XX-XX)
+-------------------
+
+* Fix a potential buffer overflow in RestReplicationHandler.
+
+
 v3.8.0-beta.1 (2021-04-20)
 --------------------------
 

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1454,11 +1454,8 @@ Result RestReplicationHandler::parseBatch(transaction::Methods& trx,
   VPackStringRef bodyStr = _request->rawPayload();
   char const* ptr = bodyStr.data();
   char const* end = ptr + bodyStr.size();
-
-  VPackOptions builderOptions = basics::VelocyPackHelper::strictRequestValidationOptions;
-  builderOptions.paddingBehavior = VPackOptions::PaddingBehavior::UsePadding;
-
-  VPackBuilder builder(&builderOptions);
+  
+  VPackBuilder builder(&basics::VelocyPackHelper::strictRequestValidationOptions);
 
   // First parse and collect all markers, we assemble everything in one
   // large builder holding an array
@@ -1647,10 +1644,7 @@ Result RestReplicationHandler::processRestoreDataBatch(transaction::Methods& trx
                                                        std::string const& collectionName,
                                                        bool generateNewRevisionIds) {
   // we'll build all documents to insert in this builder
-  VPackOptions vpackOptions;
-  vpackOptions.paddingBehavior = VPackOptions::PaddingBehavior::UsePadding;
-
-  VPackBuilder documentsToInsert(&vpackOptions);
+  VPackBuilder documentsToInsert;
   std::unordered_set<std::string> documentsToRemove;
   Result res = parseBatch(trx, collectionName, documentsToInsert, documentsToRemove, generateNewRevisionIds);
   if (res.fail()) {


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/14047

Revert the use of UsePadding velocypack options in RestReplicationHandler.cpp, as it obviously leads to an ASan heap buffer overflow in some restore tests.
The UsePadding behavior was introduced in RestReplicationHandler.cpp only one or two days ago and was not released.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required.

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *shell_client, with ASan*.
