### PR TITLE
fixed issue BTS-373

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fixed issue BTS-373: ASan detected possible heap-buffer-overflow at 
+  arangodb::transaction::V8Context::exitV8Context().
+
 * Changed default value of arangodump's `--envelope` option from `true` to
   `false`. This allows using higher parallelism in arangorestore when 
   restoring large collection dumps. As a side-effect, this will also decrease 

--- a/arangod/Transaction/V8Context.cpp
+++ b/arangod/Transaction/V8Context.cpp
@@ -37,14 +37,11 @@ using namespace arangodb;
 transaction::V8Context::V8Context(TRI_vocbase_t& vocbase, bool embeddable)
     : Context(vocbase),
       _currentTransaction(nullptr),
-      _embeddable(embeddable) {
-  // need to set everything here
-  v8::Isolate* isolate = v8::Isolate::GetCurrent();
-  _v8g = static_cast<TRI_v8_global_t*>(isolate->GetData(arangodb::V8PlatformFeature::V8_DATA_SLOT));
-}
+      _embeddable(embeddable) {}
 
 transaction::V8Context::~V8Context() noexcept {
-  if (_v8g->_transactionContext == this) {
+  auto v8g = getV8State();
+  if (v8g != nullptr && v8g->_transactionContext == this) {
     this->exitV8Context();
   }
 }
@@ -79,11 +76,14 @@ CollectionNameResolver const& transaction::V8Context::resolver() {
     responsibleForCommit = false;
     return _currentTransaction;
   }
+ 
+  auto v8g = getV8State();
+  TRI_ASSERT(v8g != nullptr);
   
-  if (_v8g->_transactionContext != nullptr) {
-    _currentTransaction = _v8g->_transactionContext->_currentTransaction;
-  } else if (_v8g->_transactionState) {
-    _currentTransaction = _v8g->_transactionState;
+  if (v8g->_transactionContext != nullptr) {
+    _currentTransaction = v8g->_transactionContext->_currentTransaction;
+  } else if (v8g->_transactionState) {
+    _currentTransaction = v8g->_transactionState;
   }
   
   if (!_currentTransaction) {
@@ -102,17 +102,21 @@ CollectionNameResolver const& transaction::V8Context::resolver() {
 
 void transaction::V8Context::enterV8Context() {
   // registerTransaction
-  TRI_ASSERT(_v8g != nullptr);
-  TRI_ASSERT(_currentTransaction != nullptr);
-  TRI_ASSERT(_v8g->_transactionContext == nullptr ||
-             _v8g->_transactionContext == this);
+  auto v8g = getV8State();
+  TRI_ASSERT(v8g != nullptr);
   
-  _v8g->_transactionContext = this;
+  TRI_ASSERT(_currentTransaction != nullptr);
+  TRI_ASSERT(v8g->_transactionContext == nullptr ||
+             v8g->_transactionContext == this);
+  
+  v8g->_transactionContext = this;
 }
 
 void transaction::V8Context::exitV8Context() {
-  TRI_ASSERT(_v8g != nullptr);
-  _v8g->_transactionContext = nullptr;
+  auto v8g = getV8State();
+  if (v8g != nullptr && v8g->_transactionContext == this) {
+    v8g->_transactionContext = nullptr;
+  }
 }
 
 /// @brief unregister the transaction from the context
@@ -137,8 +141,7 @@ bool transaction::V8Context::isEmbeddable() const { return _embeddable; }
 
 /// @brief return parent transaction state or none
 /*static*/ std::shared_ptr<TransactionState> transaction::V8Context::getParentState() {
-  TRI_v8_global_t* v8g = static_cast<TRI_v8_global_t*>(
-      v8::Isolate::GetCurrent()->GetData(V8PlatformFeature::V8_DATA_SLOT));
+  auto v8g = getV8State();
   if (v8g == nullptr || v8g->_transactionContext == nullptr) {
     return nullptr;
   }
@@ -166,4 +169,13 @@ std::shared_ptr<transaction::Context> transaction::V8Context::CreateWhenRequired
   }
 
   return transaction::StandaloneContext::Create(vocbase);
+}
+
+/*static*/ TRI_v8_global_t* transaction::V8Context::getV8State() noexcept {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  if (isolate == nullptr) {
+    return nullptr;
+  }
+  auto v8g = static_cast<TRI_v8_global_t*>(isolate->GetData(arangodb::V8PlatformFeature::V8_DATA_SLOT));
+  return v8g;
 }

--- a/arangod/Transaction/V8Context.h
+++ b/arangod/Transaction/V8Context.h
@@ -82,8 +82,9 @@ class V8Context final : public Context {
                                                                   bool embeddable);
 
  private:
-  TRI_v8_global_t* _v8g;
- 
+  static TRI_v8_global_t* getV8State() noexcept;
+
+ private:
   /// @brief the currently ongoing transaction
   std::shared_ptr<TransactionState> _currentTransaction;
 


### PR DESCRIPTION
### Scope & Purpose

Fixed issue BTS-373: ASan detected possible heap-buffer-overflow at `arangodb::transaction::V8Context::exitV8Context()`.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*

#### Related Information

- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-373

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *shell_server, with ASan*.
- [x] I ensured this code runs with ASan / TSan or other static verification tools
