### PR TITLE
Fix assertion failure in fuerte

### DIFF
--- a/3rdParty/fuerte/src/H2Connection.cpp
+++ b/3rdParty/fuerte/src/H2Connection.cpp
@@ -721,7 +721,7 @@ template <SocketType T>
 void H2Connection<T>::abortRequests(fuerte::Error err, Clock::time_point now) {
   auto it = this->_streams.begin();
   while (it != this->_streams.end()) {
-    if (it->second->expires < now) {
+    if (it->second->expires <= now) {
       it->second->invokeOnError(err);
 
       if (now == Clock::time_point::max()) {

--- a/3rdParty/fuerte/src/VstConnection.cpp
+++ b/3rdParty/fuerte/src/VstConnection.cpp
@@ -378,7 +378,7 @@ void VstConnection<ST>::abortRequests(
 
   auto it = this->_streams.begin();
   while (it != this->_streams.end()) {
-    if (it->second->expires < now) {
+    if (it->second->expires <= now) {
       FUERTE_LOG_DEBUG << "VST-Request timeout\n";
       it->second->invokeOnError(err);
       it = this->_streams.erase(it);

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fixed a small problem in fuerte which could lead to an assertion failure.
+
 * Fixed issue BTS-373: ASan detected possible heap-buffer-overflow at 
   arangodb::transaction::V8Context::exitV8Context().
 


### PR DESCRIPTION
We had an assertion failure in fuerte in 

  3rdParty\fuerte\src\H2Connection.cpp:746

The reason is that there may be requests with an expiry time of
Clock::time_point::max() and at destruction time, when all requests
must be aborted, these must be aborted, too. So far, we compared with
< and thus lost those with Clock::time_point::max() as expire time. Now we
use <=.

This is a trivial change and is covered by existing tests.
Otherwise, the PR speaks for itself.
