### PR TITLE
Fix assertion failure in fuerte

### DIFF
--- a/3rdParty/fuerte/src/H2Connection.cpp
+++ b/3rdParty/fuerte/src/H2Connection.cpp
@@ -723,7 +723,7 @@ template <SocketType T>
 void H2Connection<T>::abortRequests(fuerte::Error err, Clock::time_point now) {
   auto it = this->_streams.begin();
   while (it != this->_streams.end()) {
-    if (it->second->expires < now) {
+    if (it->second->expires <= now) {
       it->second->invokeOnError(err);
 
       if (now == Clock::time_point::max()) {

--- a/3rdParty/fuerte/src/VstConnection.cpp
+++ b/3rdParty/fuerte/src/VstConnection.cpp
@@ -378,7 +378,7 @@ void VstConnection<ST>::abortRequests(
 
   auto it = this->_streams.begin();
   while (it != this->_streams.end()) {
-    if (it->second->expires < now) {
+    if (it->second->expires <= now) {
       FUERTE_LOG_DEBUG << "VST-Request timeout\n";
       it->second->invokeOnError(err);
       it = this->_streams.erase(it);

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.8.0 (XXXX-XX-XX)
 -------------------
 
+* Fixed a small problem in fuerte which could lead to an assertion failure.
+
 * Fixed issue BTS-373: ASan detected possible heap-buffer-overflow at
   arangodb::transaction::V8Context::exitV8Context().
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,9 @@ v3.8.0 (XXXX-XX-XX)
 
 * Fixed a small problem in fuerte which could lead to an assertion failure.
 
+* Retry if an ex-leader can no longer drop a follower because it is no longer
+  leading.
+
 * Fixed issue BTS-373: ASan detected possible heap-buffer-overflow at
   arangodb::transaction::V8Context::exitV8Context().
 

--- a/arangod/Cluster/ClusterTrxMethods.cpp
+++ b/arangod/Cluster/ClusterTrxMethods.cpp
@@ -291,7 +291,11 @@ Future<Result> commitAbortTransaction(arangodb::TransactionState* state,
                       << "synchronous replication: could not drop follower " << follower
                       << " for shard " << cc->vocbase().name() << "/" << tc.collectionName()
                       << ": " << r.errorMessage();
-                  res.reset(TRI_ERROR_CLUSTER_COULD_NOT_DROP_FOLLOWER);
+                  if (res.is(TRI_ERROR_CLUSTER_NOT_LEADER)) {
+                    res.reset(TRI_ERROR_CLUSTER_SHARD_LEADER_RESIGNED);
+                  } else {
+                    res.reset(TRI_ERROR_CLUSTER_COULD_NOT_DROP_FOLLOWER);
+                  }
                 }
               }
               // continue dropping the follower for all shards in this

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -754,7 +754,7 @@ Result transaction::Methods::documentFastPath(std::string const& collectionName,
     return opRes.result;
   }
 
-  auto translateName = [this](std::string const& collectionName) { 
+  auto translateName = [this](std::string const& collectionName) {
     if (_state->isDBServer()) {
       auto collection = resolver()->getCollectionStructCluster(collectionName);
       if (collection != nullptr) {
@@ -1752,7 +1752,7 @@ OperationResult transaction::Methods::allLocal(std::string const& collectionName
   }
 
   resultBuilder.openArray();
-  
+
   auto iterator = indexScan(collectionName, transaction::Methods::CursorType::ALL);
 
   iterator->allDocuments(
@@ -1904,7 +1904,23 @@ Future<OperationResult> transaction::Methods::truncateLocal(std::string const& c
                 << "truncateLocal: could not drop follower " << (*followers)[i]
                 << " for shard " << collection->vocbase().name() << "/" << collection->name()
                 << ": " << res.errorMessage();
-            THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_COULD_NOT_DROP_FOLLOWER);
+            // Note: it is safe here to exit the loop early. We are losing the leadership here.
+            // No matter what happens next, the Current entry in the agency is rewritten and
+            // thus replication is restarted from the new leader. There is no need to keep
+            // trying to drop followers at this point.
+
+            if (res.is(TRI_ERROR_CLUSTER_NOT_LEADER)) {
+              // In this case, we know that we are not or no longer
+              // the leader for this shard. Therefore we need to
+              // send a code which let's the coordinator retry.
+              THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_SHARD_LEADER_RESIGNED);
+            } else {
+              // In this case, some other error occurred and we
+              // most likely are still the proper leader, so
+              // the error needs to be reported and the local
+              // transaction must be rolled back.
+              THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_COULD_NOT_DROP_FOLLOWER);
+            }
           }
         }
       }
@@ -2455,7 +2471,25 @@ Future<Result> Methods::replicateOperations(
               << "could not drop follower " << follower << " for shard "
               << collection->vocbase().name() << "/" << collection->name()
               << ": " << res.errorMessage();
-          THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_COULD_NOT_DROP_FOLLOWER);
+
+          // Note: it is safe here to exit the loop early. We are losing the leadership here.
+          // No matter what happens next, the Current entry in the agency is rewritten and
+          // thus replication is restarted from the new leader. There is no need to keep
+          // trying to drop followers at this point.
+
+          if (res.is(TRI_ERROR_CLUSTER_NOT_LEADER)) {
+            // In this case, we know that we are not or no longer
+            // the leader for this shard. Therefore we need to
+            // send a code which let's the coordinator retry.
+            THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_SHARD_LEADER_RESIGNED);
+          } else {
+            // In this case, some other error occurred and we
+            // most likely are still the proper leader, so
+            // the error needs to be reported and the local
+            // transaction must be rolled back.
+            THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_COULD_NOT_DROP_FOLLOWER);
+          }
+
         }
       }
     }


### PR DESCRIPTION
We had an assertion failure in fuerte in

3rdParty\fuerte\src\H2Connection.cpp:746

The reason is that there may be requests with an expiry time of
Clock::time_point::max() and at destruction time, when all requests
must be aborted, these must be aborted, too. So far, we compared with
< and thus lost those with Clock::time_point::max() as expire time. Now we
use <=.

This is a trivial change and is covered by existing tests.
Otherwise, the PR speaks for itself.

This is a backport of https://github.com/arangodb/arangodb/pull/14058
