### PR TITLE
to measure TW counts of insulated tests better, wait for their number to get below 100

### DIFF
--- a/js/client/modules/@arangodb/testutils/test-utils.js
+++ b/js/client/modules/@arangodb/testutils/test-utils.js
@@ -246,6 +246,14 @@ function performTests (options, testList, testname, runFn, serverOptions, startS
           results[te] = reply;
           results[te]['processStats'] = pu.getDeltaProcessStats(instanceInfo);
 
+          if (options.zeroTimeWaitWait) {
+            let stat = pu.getDeltaProcessStats(instanceInfo);
+            while (stat.sum_servers.sockstat_TCP_tw > 100) {
+              sleep(5);
+              print('. ' + stat.sum_servers.sockstat_TCP_tw);
+              stat = pu.getDeltaProcessStats(instanceInfo);
+            }
+          }
           if (results[te].status === false) {
             options.cleanup = false;
           }

--- a/js/client/modules/@arangodb/testutils/test-utils.js
+++ b/js/client/modules/@arangodb/testutils/test-utils.js
@@ -250,7 +250,7 @@ function performTests (options, testList, testname, runFn, serverOptions, startS
             let stat = pu.getDeltaProcessStats(instanceInfo);
             while (stat.sum_servers.sockstat_TCP_tw > 100) {
               sleep(5);
-              print('. ' + stat.sum_servers.sockstat_TCP_tw);
+              print(new Date()).toISOString() + 'Sockets in TIME_WAIT state remained after the test: ' + stat.sum_servers.sockstat_TCP_tw);
               stat = pu.getDeltaProcessStats(instanceInfo);
             }
           }

--- a/js/client/modules/@arangodb/testutils/test-utils.js
+++ b/js/client/modules/@arangodb/testutils/test-utils.js
@@ -250,7 +250,7 @@ function performTests (options, testList, testname, runFn, serverOptions, startS
             let stat = pu.getDeltaProcessStats(instanceInfo);
             while (stat.sum_servers.sockstat_TCP_tw > 100) {
               sleep(5);
-              print(new Date().toISOString() + 'Sockets in TIME_WAIT state remained after the test: ' + stat.sum_servers.sockstat_TCP_tw);
+              print(new Date().toISOString() + ' Sockets in TIME_WAIT state remained after the test: ' + stat.sum_servers.sockstat_TCP_tw);
               stat = pu.getDeltaProcessStats(instanceInfo);
             }
           }

--- a/js/client/modules/@arangodb/testutils/test-utils.js
+++ b/js/client/modules/@arangodb/testutils/test-utils.js
@@ -250,7 +250,7 @@ function performTests (options, testList, testname, runFn, serverOptions, startS
             let stat = pu.getDeltaProcessStats(instanceInfo);
             while (stat.sum_servers.sockstat_TCP_tw > 100) {
               sleep(5);
-              print(new Date()).toISOString() + 'Sockets in TIME_WAIT state remained after the test: ' + stat.sum_servers.sockstat_TCP_tw);
+              print(new Date().toISOString() + 'Sockets in TIME_WAIT state remained after the test: ' + stat.sum_servers.sockstat_TCP_tw);
               stat = pu.getDeltaProcessStats(instanceInfo);
             }
           }

--- a/js/client/modules/@arangodb/testutils/testing.js
+++ b/js/client/modules/@arangodb/testutils/testing.js
@@ -158,6 +158,7 @@ let optionsDocumentation = [
   '     previous test run. The information which tests previously failed is taken',
   '     from the "UNITTEST_RESULT.json" (if available).',
   '   - `encryptionAtRest`: enable on disk encryption, enterprise only',
+  '   - `zeroTimeWaitWait`: (linux only) wait for all processes to have zero sockets it "TIME_WAIT" state',
   ''
 ];
 
@@ -239,6 +240,7 @@ const optionsDefaults = {
   'sleepBeforeStart' : 0,
   'sleepBeforeShutdown' : 0,
   'failed': false,
+  'zeroTimeWaitWait': false
 };
 
 let globalStatus = true;


### PR DESCRIPTION
### Scope & Purpose

to be able to more precisely measure counters of insulated tests and their resource usage in terms of sockets remaining in `TIME_WAIT` -state, 
add a new option to wait between tests for their count to go below 100; It seems that if we wait longer more connections are closed, and the number rises again.

- [x] Instrumentation of the testframework.