### PR TITLE
Fix return code on shutting down in sendRequestRetry

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.8.0 (XXXX-XX-XX)
 -------------------
 
+* Fixed proper return value in sendRequestRetry if server is shutting down.
+
 * Fixed issue BTS-373: ASan detected possible heap-buffer-overflow at
   arangodb::transaction::V8Context::exitV8Context().
 

--- a/tests/Network/MethodsTest.cpp
+++ b/tests/Network/MethodsTest.cpp
@@ -257,6 +257,27 @@ TEST_F(NetworkMethodsTest, request_failure_on_timeout) {
   ASSERT_FALSE(res.hasResponse());
 }
 
+TEST_F(NetworkMethodsTest, request_failure_on_shutdown) {
+  pool->_conn->_err = fuerte::Error::NoError;
+  auto& server = pool->config().clusterInfo->server();
+  server.beginShutdown();
+
+  network::RequestOptions reqOpts;
+
+  VPackBuffer<uint8_t> buffer;
+  auto f = network::sendRequestRetry(pool.get(), "tcp://example.org:80", fuerte::RestVerb::Get,
+                                "/", buffer, reqOpts);
+
+  network::Response res = std::move(f).get();
+  ASSERT_EQ(res.destination, "tcp://example.org:80");
+  ASSERT_EQ(res.error, fuerte::Error::NoError);
+  ASSERT_TRUE(res.hasResponse());
+  ASSERT_EQ(res.statusCode(), fuerte::StatusServiceUnavailable);
+  VPackSlice body = res.slice();
+  VPackSlice errorNum = body.get("errorNum");
+  ASSERT_EQ(static_cast<int>(TRI_ERROR_SHUTTING_DOWN), errorNum.getNumber<int>());
+}
+
 TEST_F(NetworkMethodsTest, request_failure_on_connection_closed) {
   pool->_conn->_err = fuerte::Error::ConnectionClosed;
   


### PR DESCRIPTION
Currently, if a server that is shutting down is using sendRequestRetry,
an immediate error "Timeout" is reported. This is wrong and should
better be a 503 TRI_ERROR_SHUTTING_DOWN.

This was found in chaos tests with the new test agent.

- Report proper error on shutdown in sendRequestRetry.
- CHANGELOG.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers - **mandatory**)*

- [*] :hankey: Bugfix (requires CHANGELOG entry)

#### Backports:

- [ ] No backports required
- [*] Back-/Forwardports required for: 3.7, devel, 3.6

### Testing & Verification

*(Please pick either of the following options)*

- [*] This change is a trivial rework / code cleanup without any further 
      test coverage.
- [*] This change is already covered by existing tests, such as chaos
      tests.

