### PR TITLE
fix internal-issue #798 

### DIFF
--- a/3rdParty/iresearch/core/index/index_writer.cpp
+++ b/3rdParty/iresearch/core/index/index_writer.cpp
@@ -2159,6 +2159,7 @@ index_writer::pending_context_t index_writer::flush_all() {
     // skip empty segments
     if (!pending_segment.segment.meta.live_docs_count) {
       ctx->segment_mask_.emplace(pending_segment.segment.meta);
+      modified = true;
       continue;
     }
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 devel
 -----
+* Fixed internal issue #798: In  rare case when remove request
+  completely cleans just consolidated segment commit could be cancelled
+  and documents removed from collection may be left dangling in the ArangoSearch index.
+  Also fixes ES-810 and  BTS-279.
 
 * Fixed a small problem in fuerte which could lead to an assertion failure.
 

--- a/tests/js/common/aql/aql-view-arangosearch-feature.js
+++ b/tests/js/common/aql/aql-view-arangosearch-feature.js
@@ -2361,6 +2361,64 @@ function iResearchFeatureAqlTestSuite () {
         db._useDatabase("_system");
         db._dropDatabase(dbName);
       }
+    },
+    testRemoveAllInJustConsolidated : function() {
+      let dbName = "testDb";
+      let colName = "testCollection";
+      let viewName = "testView";
+      db._useDatabase("_system");
+      try { db._dropDatabase(dbName); } catch(e) {}
+      db._createDatabase(dbName);
+      try {
+        db._useDatabase(dbName);
+        let col = db._create(colName);
+        db._createView(viewName, "arangosearch", 
+                                  {consolidationIntervalMsec: 0, commitIntervalMsec: 0, links: 
+                                    {[colName]: 
+                                      {storeValues: 'id',
+                                       includeAllFields:true, 
+                                       analyzers:['identity']}}});
+        let docs = [];
+        for (let i = 0; i < 1000; ++i) {
+          docs.push({field: i});
+        }
+        col.insert(docs);
+        db._view(viewName).properties({commitIntervalMsec: 10});
+        let res1 = db._query("FOR doc IN " + viewName + " SEARCH doc.field >= 0 " 
+                            + " OPTIONS {waitForSync: true} COLLECT WITH COUNT INTO "
+                            + " length RETURN length").toArray();
+        assertEqual(1, res1.length);
+        assertEqual(1000, res1[0]);
+        db._view(viewName).properties({commitIntervalMsec: 0});
+
+        docs = [];
+        for (let i = 1000; i < 2000; ++i) {
+          docs.push({field: i});
+        }
+        col.insert(docs);
+        db._view(viewName).properties({commitIntervalMsec: 10});
+        let res2 = db._query("FOR doc IN " + viewName + " SEARCH doc.field >= 0 " 
+                            + " OPTIONS {waitForSync: true} COLLECT WITH COUNT INTO "
+                            + " length RETURN length").toArray();
+        assertEqual(1, res2.length);
+        assertEqual(2000, res2[0]);
+        db._view(viewName).properties({commitIntervalMsec: 0});
+        db._query("FOR t IN " + colName + " FILTER t.field < 1500 REMOVE t._key IN " + colName);
+        db._view(viewName).properties({consolidationIntervalMsec: 10});
+        internal.sleep(3); // give consolidation some time
+        col.truncate();
+        db._view(viewName).properties({commitIntervalMsec: 10});
+  
+        // force sync
+        let res = db._query("FOR doc IN " + viewName + " SEARCH doc.field >= 0 " 
+                            + " OPTIONS {waitForSync: true} COLLECT WITH COUNT INTO "
+                            + " length RETURN length").toArray();
+        assertEqual(1, res.length);
+        assertEqual(0, res[0]);
+      } finally {
+        db._useDatabase("_system");
+        db._dropDatabase(dbName);
+      }
     }
   };
 }


### PR DESCRIPTION
### Scope & Purpose

Fix case when documents are removed from just-consolidated segment making it empty.
Now the commit is not aborted but empty segment is written (effectively clearing the index, as this is actually expected)

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.6, 3.7, 3.8

#### Related Information
Fixes BTS-279 ES-810

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [x] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [x] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:

https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/15115/
