### PR TITLE
fix some potential issues in Pregel tests

### DIFF
--- a/tests/js/common/shell/shell-pregel-basics-example.js
+++ b/tests/js/common/shell/shell-pregel-basics-example.js
@@ -47,7 +47,7 @@ function testAlgo(a, p) {
   do {
     internal.sleep(0.2);
     let stats = pregel.status(pid);
-    if (stats.state !== "running") {
+    if (stats.state !== "running" && stats.state !== "storing") {
       assertEqual(stats.vertexCount, 11, stats);
       assertEqual(stats.edgeCount, 17, stats);
       let attrs = ["totalRuntime", "startupTime", "computationTime"];
@@ -181,7 +181,7 @@ function basicTestSuite() {
       do {
         internal.sleep(0.2);
         var stats = pregel.status(pid);
-        if (stats.state !== "running") {
+        if (stats.state !== "running" && stats.state !== "storing") {
           assertEqual(stats.vertexCount, 11, stats);
           assertEqual(stats.edgeCount, 17, stats);
 
@@ -266,7 +266,7 @@ function exampleTestSuite() {
       do {
         internal.sleep(0.2);
         var stats = pregel.status(key);
-        if (stats.state !== "running") {
+        if (stats.state !== "running" && stats.state !== "storing") {
           assertEqual(stats.vertexCount, 4, stats);
           assertEqual(stats.edgeCount, 4, stats);
           break;

--- a/tests/js/common/shell/shell-pregel-components.js
+++ b/tests/js/common/shell/shell-pregel-components.js
@@ -243,7 +243,7 @@ function componentsTestSuite() {
 
       while (true) {
         var status = pregel.status(handle);
-        if (status.state !== 'running') {
+        if (status.state !== 'running' && status.state !== 'storing') {
           console.log(status);
           break;
         } else {

--- a/tests/js/common/shell/shell-pregel-random.js
+++ b/tests/js/common/shell/shell-pregel-random.js
@@ -51,7 +51,7 @@ function randomTestSuite() {
     do {
       internal.sleep(0.2);
       let stats = pregel.status(key);
-      if (stats.state !== "running") {
+      if (stats.state !== "running" && stats.state !== 'storing') {
         break;
       }
     } while (i-- >= 0);
@@ -161,7 +161,7 @@ function randomTestSuite() {
       do {
         internal.sleep(0.2);
         var stats = pregel.status(pid);
-        if (stats.state !== "running") {
+        if (stats.state !== "running" && stats.state !== "storing") {
           assertEqual(stats.vertexCount, n, stats);
           assertEqual(stats.edgeCount, m * 2, stats);
           break;
@@ -182,7 +182,7 @@ function randomTestSuite() {
       do {
         internal.sleep(0.2);
         var stats = pregel.status(pid);
-        if (stats.state !== "running") {
+        if (stats.state !== "running" && stats.state !== "storing") {
           assertEqual(stats.vertexCount, n, stats);
           assertEqual(stats.edgeCount, m * 2, stats);
           break;
@@ -203,7 +203,7 @@ function randomTestSuite() {
       do {
         internal.sleep(0.2);
         var stats = pregel.status(pid);
-        if (stats.state !== "running") {
+        if (stats.state !== "running" && stats.state !== "storing") {
           assertEqual(stats.vertexCount, n, stats);
           assertEqual(stats.edgeCount, m * 2, stats);
           break;

--- a/tests/js/common/shell/shell-pregel-start-cluster.js
+++ b/tests/js/common/shell/shell-pregel-start-cluster.js
@@ -138,7 +138,7 @@ function basicTestSuite() {
     do {
       internal.wait(0.2);
       var stats = pregel.status(pid);
-      if (stats.state !== "running") {
+      if (stats.state !== "running" && stats.state !== "storing") {
         assertEqual(stats.vertexCount, 11, stats);
         assertEqual(stats.edgeCount, 17, stats);
   
@@ -260,7 +260,7 @@ function basicTestSuite() {
       do {
         internal.wait(0.2);
         var stats = pregel.status(pid);
-        if (stats.state !== "running") {
+        if (stats.state !== "running" && stats.state !== "storing") {
           assertEqual(stats.vertexCount, 11, stats);
           assertEqual(stats.edgeCount, 17, stats);
 


### PR DESCRIPTION
### Scope & Purpose

Fix some potential issues in Pregel tests
Some tests considered a Pregel job done if it is not in state "running" anymore. however, after running comes "storing", and checking job results while still storing is too early!
This PR unifies the behavior so tests wait until a job is not in state "running" **and** not in state "storing".

This is a test bugfix, so it intentionally doesn't have a CHANGELOG entry.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is already covered by existing tests, such as *shell_client*.
