### PR TITLE
Fix maintenance amok and HTTP responses

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.6.14 (XXXX-XX-XX)
 --------------------
 
+* Fixed bug in error reporting when a database create did not work, which
+  lead to a busy loop reporting this error to the agency.
+
+* Fixed the error response if the HTTP version is not 1.0 or 1.1 and if
+  the Content-Length is too large (> 1 GB).
+
 * Fixed proper return value in sendRequestRetry if server is shutting down.
 
 * Updated ArangoDB Starter to 0.15.0.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,11 @@
 v3.6.14 (XXXX-XX-XX)
 --------------------
 
-* Fixed bug in error reporting when a database create did not work, which
-  lead to a busy loop reporting this error to the agency.
+* Fixed bug in error reporting when a database create did not work, which lead
+  to a busy loop reporting this error to the agency.
 
-* Fixed the error response if the HTTP version is not 1.0 or 1.1 and if
-  the Content-Length is too large (> 1 GB).
+* Fixed the error response if the HTTP version is not 1.0 or 1.1 and if the
+  Content-Length is too large (> 1 GB).
 
 * Fixed proper return value in sendRequestRetry if server is shutting down.
 

--- a/arangod/Cluster/MaintenanceFeature.cpp
+++ b/arangod/Cluster/MaintenanceFeature.cpp
@@ -636,7 +636,7 @@ arangodb::Result MaintenanceFeature::dbError(std::string const& database,
 arangodb::Result MaintenanceFeature::removeDBError(std::string const& database) {
   try {
     MUTEX_LOCKER(guard, _seLock);
-    _shardErrors.erase(database);
+    _dbErrors.erase(database);
   } catch (std::exception const&) {
     std::stringstream error;
     error << "erasing database error for " << database << " failed";

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -151,16 +151,16 @@ int HttpCommTask<T>::on_header_complete(llhttp_t* p) {
                                 std::move(self->_lastHeaderValue));
   }
 
-  if ((p->http_major != 1 && p->http_minor != 0) &&
-      (p->http_major != 1 && p->http_minor != 1)) {
+  if ((p->http_major != 1 || p->http_minor != 0) &&
+      (p->http_major != 1 || p->http_minor != 1)) {
     self->addSimpleResponse(rest::ResponseCode::HTTP_VERSION_NOT_SUPPORTED,
                             rest::ContentType::UNSET, 1, VPackBuffer<uint8_t>());
-    return HPE_USER;
+    return HPE_OK;
   }
   if (p->content_length > GeneralCommTask<T>::MaximalBodySize) {
     self->addSimpleResponse(rest::ResponseCode::REQUEST_ENTITY_TOO_LARGE,
                             rest::ContentType::UNSET, 1, VPackBuffer<uint8_t>());
-    return HPE_USER;
+    return HPE_OK;
   }
   if (p->content_length > 0) {
     // lets not reserve more than 64MB at once


### PR DESCRIPTION
This is a PR with very tiny fixes.

It does 2 things:

 - Fix removeDBErrors busy loop error.
 - Respond correctly on wrong HTTP version and too large body.

The first is a bug in the error reporting in case of a create database
has not worked. This error is currently reported in a busy loop to the
agency, if it happens. The fix clears the error after the first report.

The second is a bug in the parsing of HTTP headers and the corresponding
responses. In case the HTTP version is not 1.1 or 1.0, we now report
505 HTTP VERSION NOT SUPPORTED (and do not simply close off the
connection). In case that the content length is larger than 1 GB, we
now respond with a proper 413 REQUEST ENTITY TOO LARGE instead of
simply closing the connection.

This is the first easy step to fix these error responses. Therefore,
we will not test the correct responses in this PR. A future PR will test
the complete behaviour under wrong HTTP requests (which is not entirely
fixed in this PR!).

This is a backport of #14084
