### PR TITLE
Fix move after free bug in connection pool

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.6.14 (XXXX-XX-XX)
 --------------------
 
+* Fixed a use after free bug in the connection pool.
+
 * Fixed bug in error reporting when a database create did not work, which lead
   to a busy loop reporting this error to the agency.
 

--- a/arangod/Network/ConnectionPool.cpp
+++ b/arangod/Network/ConnectionPool.cpp
@@ -175,11 +175,14 @@ size_t ConnectionPool::cancelConnections(std::string const& endpoint) {
   WRITE_LOCKER(guard, _lock);
   auto const& it = _connections.find(endpoint);
   if (it != _connections.end()) {
-    Bucket& buck = *(it->second);
-    std::lock_guard<std::mutex> lock(buck.mutex);
-    size_t n = buck.list.size();
-    for (std::shared_ptr<Context>& c : buck.list) {
-      c->fuerte->cancel();
+    size_t n;
+    {
+      Bucket& buck = *(it->second);
+      std::lock_guard<std::mutex> lock(buck.mutex);
+      n = buck.list.size();
+      for (std::shared_ptr<Context>& c : buck.list) {
+        c->fuerte->cancel();
+      }
     }
     _connections.erase(it);
     return n;


### PR DESCRIPTION
This fixes a relatively subtle use-after-free bug in the connection
pool. It only showed up in a specific cluster failure test and only
if the glibc malloc (as opposed to jemalloc) was used. A lock guard
destructor was using already freed memory and destroyed some
glibc/malloc internal thread local data structures.

 - Fix a use-after free.
 - CHANGELOG.

The fix speaks for itself and does not need any additional tests. It
was manually verified that this fixes the observed problem.

This is a backport of https://github.com/arangodb/arangodb/pull/14110
from 3.8 to 3.6.
