### PR TITLE
Fixed issue #14122

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,13 +1,13 @@
 v3.6.14 (XXXX-XX-XX)
 --------------------
 
-* Fixed issue #14122: when the optimizer rule "inline-subqueries" is applied,
-  it may rename some variables in the query. The variable renaming was however
-  not carried out for traversal PRUNE conditions, so the PRUNE conditions 
-  could still refer to obsolete variables, which would make the query fail with
-  errors such as 
-    
-      Query: AQL: missing variable ... for node ... while planning registers
+* Fixed issue #14122: when the optimizer rule "inline-subqueries" is applied, it
+  may rename some variables in the query. The variable renaming was however not
+  carried out for traversal PRUNE conditions, so the PRUNE conditions could
+  still refer to obsolete variables, which would make the query fail with errors
+  such as
+
+    Query: AQL: missing variable ... for node ... while planning registers
 
 * Fixed a use after free bug in the connection pool.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 v3.6.14 (XXXX-XX-XX)
 --------------------
 
+* Fixed issue #14122: when the optimizer rule "inline-subqueries" is applied,
+  it may rename some variables in the query. The variable renaming was however
+  not carried out for traversal PRUNE conditions, so the PRUNE conditions 
+  could still refer to obsolete variables, which would make the query fail with
+  errors such as 
+    
+      Query: AQL: missing variable ... for node ... while planning registers
+
 * Fixed a use after free bug in the connection pool.
 
 * Fixed bug in error reporting when a database create did not work, which lead

--- a/tests/js/server/aql/aql-graph-traverser.js
+++ b/tests/js/server/aql/aql-graph-traverser.js
@@ -4397,6 +4397,41 @@ function pruneTraversalSuite() {
 
   // We have identical tests for all traversal options.
   const appendTests = (testObj, name, opts) => {
+    testObj['testRenameConditionVariablesNested'] = () => {
+      const q = `
+        WITH ${vn}
+        LET sub = NOOPT({ value: 'C' })
+        LET sub2 = sub.value
+        LET sub3 = sub.value
+        LET sub4 = sub.value
+          FOR v, e, p IN 1..3 ANY "${vertex.B}" ${en}
+            PRUNE v._key == 'C'
+            OPTIONS ${JSON.stringify(opts)}
+            FILTER p.edges[*]._key ALL != sub2 
+            FILTER p.edges[*]._key ALL != sub3 
+            FILTER p.edges[*]._key ALL != sub4 
+            FILTER p.vertices[*]._key ALL != sub2 
+            FILTER p.vertices[*]._key ALL != sub3
+            FILTER p.vertices[*]._key ALL != sub4
+            FILTER p.edges[0]._key != sub2 
+            FILTER p.edges[0]._key != sub3 
+            FILTER p.edges[0]._key != sub4 
+            FILTER p.vertices[0]._key != sub2 
+            FILTER p.vertices[0]._key != sub3
+            FILTER p.vertices[0]._key != sub4
+            RETURN v._key
+      `;
+      const res = db._query(q);
+
+      if (name === "Neighbors") {
+        assertEqual(res.count(), 3, `In query ${q}`);
+        assertEqual(res.toArray().sort(), ['A', 'E', 'F'].sort(), `In query ${q}`);
+      } else {
+        assertEqual(res.count(), 5, `In query ${q}`);
+        assertEqual(res.toArray().sort(), ['A', 'C', 'C', 'E', 'F'].sort(), `In query ${q}`);
+      }
+    };
+    
     testObj['testRenamePruneVariablesNested'] = () => {
       const q = `
         WITH ${vn}

--- a/tests/js/server/aql/aql-graph-traverser.js
+++ b/tests/js/server/aql/aql-graph-traverser.js
@@ -4397,41 +4397,6 @@ function pruneTraversalSuite() {
 
   // We have identical tests for all traversal options.
   const appendTests = (testObj, name, opts) => {
-    testObj['testRenameConditionVariablesNested'] = () => {
-      const q = `
-        WITH ${vn}
-        LET sub = NOOPT({ value: 'C' })
-        LET sub2 = sub.value
-        LET sub3 = sub.value
-        LET sub4 = sub.value
-          FOR v, e, p IN 1..3 ANY "${vertex.B}" ${en}
-            PRUNE v._key == 'C'
-            OPTIONS ${JSON.stringify(opts)}
-            FILTER p.edges[*]._key ALL != sub2 
-            FILTER p.edges[*]._key ALL != sub3 
-            FILTER p.edges[*]._key ALL != sub4 
-            FILTER p.vertices[*]._key ALL != sub2 
-            FILTER p.vertices[*]._key ALL != sub3
-            FILTER p.vertices[*]._key ALL != sub4
-            FILTER p.edges[0]._key != sub2 
-            FILTER p.edges[0]._key != sub3 
-            FILTER p.edges[0]._key != sub4 
-            FILTER p.vertices[0]._key != sub2 
-            FILTER p.vertices[0]._key != sub3
-            FILTER p.vertices[0]._key != sub4
-            RETURN v._key
-      `;
-      const res = db._query(q);
-
-      if (name === "Neighbors") {
-        assertEqual(res.count(), 3, `In query ${q}`);
-        assertEqual(res.toArray().sort(), ['A', 'E', 'F'].sort(), `In query ${q}`);
-      } else {
-        assertEqual(res.count(), 5, `In query ${q}`);
-        assertEqual(res.toArray().sort(), ['A', 'C', 'C', 'E', 'F'].sort(), `In query ${q}`);
-      }
-    };
-    
     testObj['testRenamePruneVariablesNested'] = () => {
       const q = `
         WITH ${vn}

--- a/tests/js/server/aql/aql-graph-traverser.js
+++ b/tests/js/server/aql/aql-graph-traverser.js
@@ -4397,6 +4397,46 @@ function pruneTraversalSuite() {
 
   // We have identical tests for all traversal options.
   const appendTests = (testObj, name, opts) => {
+    testObj['testRenamePruneVariablesNested'] = () => {
+      const q = `
+        WITH ${vn}
+        LET sub = (FOR s IN ['C'] RETURN s)
+        FOR sub2 IN sub
+          FOR v IN 1..3 ANY "${vertex.B}" ${en}
+            PRUNE v._key == sub2
+            OPTIONS ${JSON.stringify(opts)}
+            RETURN v._key
+      `;
+      const res = db._query(q);
+
+      if (name === "Neighbors") {
+        assertEqual(res.count(), 4, `In query ${q}`);
+        assertEqual(res.toArray().sort(), ['A', 'C', 'E', 'F'].sort(), `In query ${q}`);
+      } else {
+        assertEqual(res.count(), 5, `In query ${q}`);
+        assertEqual(res.toArray().sort(), ['A', 'C', 'C', 'E', 'F'].sort(), `In query ${q}`);
+      }
+    };
+
+    testObj['testPruneVariableReferringToOuter'] = () => {
+      const q = `
+        WITH ${vn}
+        LET sub = (FOR s IN ['C'] RETURN s)
+        FOR v IN 1..3 ANY "${vertex.B}" ${en}
+          PRUNE v._key IN sub 
+          OPTIONS ${JSON.stringify(opts)}
+          RETURN v._key
+      `;
+      const res = db._query(q);
+
+      if (name === "Neighbors") {
+        assertEqual(res.count(), 4, `In query ${q}`);
+        assertEqual(res.toArray().sort(), ['A', 'C', 'E', 'F'].sort(), `In query ${q}`);
+      } else {
+        assertEqual(res.count(), 5, `In query ${q}`);
+        assertEqual(res.toArray().sort(), ['A', 'C', 'C', 'E', 'F'].sort(), `In query ${q}`);
+      }
+    };
 
     testObj[`testAllowPruningOnV${name}`] = () => {
       const q = `


### PR DESCRIPTION
### Scope & Purpose

Fixed issue #14122: when the optimizer rule "inline-subqueries" is applied, it may rename some variables in the query. The variable renaming was however not carried out for traversal PRUNE conditions, so the PRUNE conditions could still refer to obsolete variables, which would make the query fail with errors such as

    Query: AQL: missing variable ... for node ... while planning registers


- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] GitHub issue / Jira ticket number: #14122 

### Testing & Verification

*(Please pick either of the following options)*

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (shell_server_aql)
