### PR TITLE
Fixed issue #14122

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,14 @@ v3.8.0 (XXXX-XX-XX)
 
 * Fixed various issues (mainly data races) reported by ThreadSanitizer.
 
+* Fixed issue #14122: when the optimizer rule "inline-subqueries" is applied,
+  it may rename some variables in the query. The variable renaming was however
+  not carried out for traversal PRUNE conditions, so the PRUNE conditions 
+  could still refer to obsolete variables, which would make the query fail with
+  errors such as 
+    
+      Query: AQL: missing variable ... for node ... while planning registers
+
 * Fixed bug in error reporting when a database create did not work, which lead
   to a busy loop reporting this error to the agency.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,6 @@
 v3.8.0 (XXXX-XX-XX)
 -------------------
 
-* Fixed a use after free bug in the connection pool.
-
-* Show peak memory usage in AQL query profiling output.
-
-* Fixed various issues (mainly data races) reported by ThreadSanitizer.
-
 * Fixed issue #14122: when the optimizer rule "inline-subqueries" is applied,
   it may rename some variables in the query. The variable renaming was however
   not carried out for traversal PRUNE conditions, so the PRUNE conditions 
@@ -14,6 +8,12 @@ v3.8.0 (XXXX-XX-XX)
   errors such as 
     
       Query: AQL: missing variable ... for node ... while planning registers
+
+* Fixed a use after free bug in the connection pool.
+
+* Show peak memory usage in AQL query profiling output.
+
+* Fixed various issues (mainly data races) reported by ThreadSanitizer.
 
 * Fixed bug in error reporting when a database create did not work, which lead
   to a busy loop reporting this error to the agency.

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -2082,20 +2082,37 @@ class arangodb::aql::RedundantCalculationsReplacer final
     auto node = ExecutionNode::castTo<T*>(en);
     node->_inVariable = Variable::replace(node->_inVariable, _replacements);
   }
-
-  void replaceInCalculation(ExecutionNode* en) {
-    auto node = ExecutionNode::castTo<CalculationNode*>(en);
+  
+  void replaceInExpression(Expression& e) {
     VarSet variables;
-    node->expression()->variables(variables);
+    e.variables(variables);
 
     // check if the calculation uses any of the variables that we want to
     // replace
     for (auto const& it : variables) {
       if (_replacements.find(it->id) != _replacements.end()) {
         // calculation uses a to-be-replaced variable
-        node->expression()->replaceVariables(_replacements);
+        e.replaceVariables(_replacements);
         return;
       }
+    }
+  }
+
+  void replaceInCalculation(ExecutionNode* en) {
+    auto node = ExecutionNode::castTo<CalculationNode*>(en);
+    replaceInExpression(*node->expression());
+  }
+  
+  void replaceInTraversal(ExecutionNode* en) {
+    auto node = ExecutionNode::castTo<TraversalNode*>(en);
+    if (node->pruneExpression() != nullptr) {
+      // need to replace variables in the prune expression
+      replaceInExpression(*node->pruneExpression());
+      // and need to recalculate the set of variables used
+      // by the prune expression
+      VarSet pruneVariables;
+      node->pruneExpression()->variables(pruneVariables);
+      node->_pruneVariables = pruneVariables;
     }
   }
 
@@ -2158,6 +2175,7 @@ class arangodb::aql::RedundantCalculationsReplacer final
 
       case EN::TRAVERSAL: {
         replaceInVariable<TraversalNode>(en);
+        replaceInTraversal(en);
         break;
       }
 

--- a/tests/js/server/aql/aql-graph-traverser.js
+++ b/tests/js/server/aql/aql-graph-traverser.js
@@ -4301,7 +4301,6 @@ function pruneTraversalSuite() {
           OPTIONS ${JSON.stringify(opts)}
           RETURN v._key
       `;
-      db._explain(q);
       const res = db._query(q);
 
       if (name === "Neighbors") {

--- a/tests/js/server/aql/aql-graph-traverser.js
+++ b/tests/js/server/aql/aql-graph-traverser.js
@@ -4271,6 +4271,41 @@ function pruneTraversalSuite() {
   // We have identical tests for all traversal options.
   const appendTests = (testObj, name, opts) => {
     
+    testObj['testRenameConditionVariablesNested'] = () => {
+      const q = `
+        WITH ${vn}
+        LET sub = NOOPT({ value: 'C' })
+        LET sub2 = sub.value
+        LET sub3 = sub.value
+        LET sub4 = sub.value
+          FOR v, e, p IN 1..3 ANY "${vertex.B}" ${en}
+            PRUNE v._key == 'C'
+            OPTIONS ${JSON.stringify(opts)}
+            FILTER p.edges[*]._key ALL != sub2 
+            FILTER p.edges[*]._key ALL != sub3 
+            FILTER p.edges[*]._key ALL != sub4 
+            FILTER p.vertices[*]._key ALL != sub2 
+            FILTER p.vertices[*]._key ALL != sub3
+            FILTER p.vertices[*]._key ALL != sub4
+            FILTER p.edges[0]._key != sub2 
+            FILTER p.edges[0]._key != sub3 
+            FILTER p.edges[0]._key != sub4 
+            FILTER p.vertices[0]._key != sub2 
+            FILTER p.vertices[0]._key != sub3
+            FILTER p.vertices[0]._key != sub4
+            RETURN v._key
+      `;
+      const res = db._query(q);
+
+      if (name === "Neighbors") {
+        assertEqual(res.count(), 3, `In query ${q}`);
+        assertEqual(res.toArray().sort(), ['A', 'E', 'F'].sort(), `In query ${q}`);
+      } else {
+        assertEqual(res.count(), 5, `In query ${q}`);
+        assertEqual(res.toArray().sort(), ['A', 'C', 'C', 'E', 'F'].sort(), `In query ${q}`);
+      }
+    };
+    
     testObj['testRenamePruneVariablesNested'] = () => {
       const q = `
         WITH ${vn}


### PR DESCRIPTION
### Scope & Purpose

Fixed issue #14122: when the optimizer rule "inline-subqueries" is applied, it may rename some variables in the query. The variable renaming was however not carried out for traversal PRUNE conditions, so the PRUNE conditions could still refer to obsolete variables, which would make the query fail with errors such as

    Query: AQL: missing variable ... for node ... while planning registers


- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.7: https://github.com/arangodb/arangodb/pull/14124, 3.6: https://github.com/arangodb/arangodb/pull/14126

#### Related Information

- [x] GitHub issue / Jira ticket number: #14122 

### Testing & Verification

*(Please pick either of the following options)*

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (shell_server_aql)
