### PR TITLE
Fix potential deadlock in RecursiveReadLocker.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,15 @@
 v3.8.0 (XXXX-XX-XX)
 -------------------
 
+* Fixed a potential deadlock in RecursiveReadLocker. This could happen if 
+  some thread A has acquired a read-lock, then some thread B signals that
+  it wants to acquire a write-lock and now thread A recursively wants to
+  acquire another read-lock. Since our ReadWriteLocks usually prefer writers,
+  the second attempt to acquire the read-lock would block, waiting for the
+  writer to finish while the writer would block, waiting for the first read
+  to finish. To solve this, the RecursiveReadLock does no longer follow the
+  principal that writes have precedence over reads.
+  
 * Fixed a use after free bug in the connection pool.
 
 * Show peak memory usage in AQL query profiling output.

--- a/lib/Basics/ReadLocker.h
+++ b/lib/Basics/ReadLocker.h
@@ -143,6 +143,13 @@ class ReadLocker {
     _readWriteLock->lockRead();
     _isLocked = true;
   }
+  
+  /// @brief acquire the read lock, regardless of queued writers, blocking
+  void lockPrivileged() {
+    TRI_ASSERT(!_isLocked);
+    _readWriteLock->lockReadPrivileged();
+    _isLocked = true;
+  }
 
   /// @brief unlocks the lock if we own it
   bool unlock() {

--- a/lib/Basics/ReadWriteLock.h
+++ b/lib/Basics/ReadWriteLock.h
@@ -67,9 +67,15 @@ class ReadWriteLock {
   /// @brief locks for reading
   void lockRead();
 
+  /// @brief locks for reading, regardless of pending queued writers
+  void lockReadPrivileged();
+  
   /// @brief locks for reading, tries only
   [[nodiscard]] bool tryLockRead() noexcept;
 
+  /// @brief tries to lock for reading, regardless of pending queued writers
+  [[nodiscard]] bool tryLockReadPrivileged() noexcept;
+  
   /// @brief releases the read-lock or write-lock
   void unlock() noexcept;
 

--- a/lib/Basics/RecursiveLocker.h
+++ b/lib/Basics/RecursiveLocker.h
@@ -99,9 +99,12 @@ class RecursiveReadLocker {
       std::atomic<std::thread::id>& owner, // owner
       char const* file, // file
       int line // line
-): _locker(&mutex, arangodb::basics::LockerType::TRY, true, file, line) {
-    if (!_locker.isLocked() && owner.load() != std::this_thread::get_id()) {
-      _locker.lock();
+): _locker(&mutex, arangodb::basics::LockerType::TRY, false, file, line) {
+    // if we are the owner of a write lock there is nothing to do here!
+    if (owner.load() != std::this_thread::get_id()) {
+      // if we do not own the write lock we acquire a read lock
+      // Important: 
+      _locker.lockPrivileged();
     }
   }
 


### PR DESCRIPTION
### Scope & Purpose

Fixed a potential deadlock in RecursiveReadLocker. This could happen if some thread A has acquired a read-lock, then some thread B signals that it wants to acquire a write-lock and now thread A recursively wants to acquire another read-lock. Since our ReadWriteLocks usually prefer writers, the second attempt to acquire the read-lock would block, waiting for the writer to finish while the writer would block, waiting for the first read to finish. To solve this, the RecursiveReadLock does no longer follow the principal that writes have precedence over reads.

Should only be merged after #14102

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new C++ **Unit tests**
