### PR TITLE
Fix potential deadlock in RecursiveReadLocker.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,15 @@
 v3.7.12 (XXXX-XX-XX)
 --------------------
 
+* Fixed a potential deadlock in RecursiveReadLocker. This could happen if 
+  some thread A has acquired a read-lock, then some thread B signals that
+  it wants to acquire a write-lock and now thread A recursively wants to
+  acquire another read-lock. Since our ReadWriteLocks usually prefer writers,
+  the second attempt to acquire the read-lock would block, waiting for the
+  writer to finish while the writer would block, waiting for the first read
+  to finish. To solve this, the RecursiveReadLock does no longer follow the
+  principal that writes have precedence over reads.
+  
 * Fixed bug in error reporting when a database create did not work, which lead
   to a busy loop reporting this error to the agency.
 

--- a/lib/Basics/ReadLocker.h
+++ b/lib/Basics/ReadLocker.h
@@ -143,6 +143,13 @@ class ReadLocker {
     _readWriteLock->lockRead();
     _isLocked = true;
   }
+  
+  /// @brief acquire the read lock, regardless of queued writers, blocking
+  void lockPrivileged() {
+    TRI_ASSERT(!_isLocked);
+    _readWriteLock->lockReadPrivileged();
+    _isLocked = true;
+  }
 
   /// @brief unlocks the lock if we own it
   bool unlock() {

--- a/lib/Basics/ReadWriteLock.cpp
+++ b/lib/Basics/ReadWriteLock.cpp
@@ -122,12 +122,42 @@ void ReadWriteLock::lockRead() {
   }
 }
 
+/// @brief locks for reading, regardless of pending queued writers
+void ReadWriteLock::lockReadPrivileged() {
+  if (tryLockReadPrivileged()) {
+    return;
+  }
+
+  std::unique_lock<std::mutex> guard(_reader_mutex);
+  while (true) {
+    if (tryLockReadPrivileged()) {
+      return;
+    }
+
+    _readers_bell.wait(guard);
+  }
+}
+
 /// @brief locks for reading, tries only
 bool ReadWriteLock::tryLockRead() {
   // order_relaxed is an optimization, cmpxchg will synchronize side-effects
   auto state = _state.load(std::memory_order_relaxed);
   // try to acquire read lock as long as no writers are active or queued
   while ((state & ~READER_MASK) == 0) {
+    if (_state.compare_exchange_weak(state, state + READER_INC, std::memory_order_acquire)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// @brief tries to locks for reading, regardless of pending queued writers
+bool ReadWriteLock::tryLockReadPrivileged() noexcept {
+  // order_relaxed is an optimization, cmpxchg will synchronize side-effects
+  auto state = _state.load(std::memory_order_relaxed);
+  // try to acquire read lock as long as no writers are active, but we deliberately ignore
+  // queued writers here.
+  while ((state & WRITE_LOCK) == 0) {
     if (_state.compare_exchange_weak(state, state + READER_INC, std::memory_order_acquire)) {
       return true;
     }

--- a/lib/Basics/ReadWriteLock.h
+++ b/lib/Basics/ReadWriteLock.h
@@ -67,9 +67,15 @@ class ReadWriteLock {
   /// @brief locks for reading
   void lockRead();
 
+  /// @brief locks for reading, regardless of pending queued writers
+  void lockReadPrivileged();
+  
   /// @brief locks for reading, tries only
   [[nodiscard]] bool tryLockRead();
 
+  /// @brief tries to lock for reading, regardless of pending queued writers
+  [[nodiscard]] bool tryLockReadPrivileged() noexcept;
+  
   /// @brief releases the read-lock or write-lock
   void unlock() noexcept;
 

--- a/lib/Basics/RecursiveLocker.h
+++ b/lib/Basics/RecursiveLocker.h
@@ -98,9 +98,16 @@ class RecursiveReadLocker {
       std::atomic<std::thread::id>& owner, // owner
       char const* file, // file
       int line // line
-): _locker(&mutex, arangodb::basics::LockerType::TRY, true, file, line) {
-    if (!_locker.isLocked() && owner.load() != std::this_thread::get_id()) {
-      _locker.lock();
+): _locker(&mutex, arangodb::basics::LockerType::TRY, false, file, line) {
+    // if we are the owner of a write lock, there is nothing to do here!
+    if (owner.load() != std::this_thread::get_id()) {
+      // if we do not own the write lock we acquire a read lock
+      // Important: we use lockPrivileged here to bypass any queued writers.
+      // This means that we do not follow the principal that writes have
+      // precedence over reads, but this is necessary to prevent a potential
+      // deadlock in case this is a recursive call, and this thread has already
+      // acquired a read-lock.
+      _locker.lockPrivileged();
     }
   }
 

--- a/tests/Basics/ReadWriteLockTest.cpp
+++ b/tests/Basics/ReadWriteLockTest.cpp
@@ -1,0 +1,309 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2015, ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Basics/Common.h"
+#include "Basics/ReadWriteLock.h"
+#include "Basics/RecursiveLocker.h"
+
+#include "gtest/gtest.h"
+
+#include <chrono>
+
+using namespace arangodb::basics;
+
+TEST(ReadWriteLockTest, testTryLockWrite) {
+  ReadWriteLock lock;
+
+  ASSERT_FALSE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+  
+  // try lock write
+  ASSERT_TRUE(lock.tryLockWrite());
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_TRUE(lock.isLockedWrite());
+
+  // try write-locking again
+  ASSERT_FALSE(lock.tryLockWrite());
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_TRUE(lock.isLockedWrite());
+  
+  // try write-locking again, with timeout
+  ASSERT_FALSE(lock.lockWrite(std::chrono::microseconds(1000)));
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_TRUE(lock.isLockedWrite());
+  
+  // try read-locking 
+  ASSERT_FALSE(lock.tryLockRead());
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_TRUE(lock.isLockedWrite());
+}
+
+TEST(ReadWriteLockTest, testLockWrite) {
+  ReadWriteLock lock;
+
+  ASSERT_FALSE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+  
+  // lock write
+  lock.lockWrite();
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_TRUE(lock.isLockedWrite());
+
+  // try write-locking again
+  ASSERT_FALSE(lock.tryLockWrite());
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_TRUE(lock.isLockedWrite());
+  
+  // try write-locking again, with timeout
+  ASSERT_FALSE(lock.lockWrite(std::chrono::microseconds(1000)));
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_TRUE(lock.isLockedWrite());
+  
+  // try read-locking 
+  ASSERT_FALSE(lock.tryLockRead());
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_TRUE(lock.isLockedWrite());
+}
+
+TEST(ReadWriteLockTest, testTryLockRead) {
+  ReadWriteLock lock;
+
+  ASSERT_FALSE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+  
+  // try lock read
+  ASSERT_TRUE(lock.tryLockRead());
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_TRUE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+
+  // try read-locking again
+  ASSERT_TRUE(lock.tryLockRead());
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_TRUE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+  
+  // read-lock again
+  lock.lockRead();
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_TRUE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+  
+  // try write-locking 
+  ASSERT_FALSE(lock.tryLockWrite());
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_TRUE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+  
+  // try write-locking again, with timeout
+  ASSERT_FALSE(lock.lockWrite(std::chrono::microseconds(1000)));
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_TRUE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+
+  // unlock one level
+  lock.unlock();
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_TRUE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+  ASSERT_FALSE(lock.tryLockWrite());
+  
+  // unlock one another level
+  lock.unlock();
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_TRUE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+  ASSERT_FALSE(lock.tryLockWrite());
+  
+  // unlock final level
+  lock.unlock();
+  ASSERT_FALSE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+  ASSERT_TRUE(lock.tryLockWrite());
+}
+
+TEST(ReadWriteLockTest, testLockRead) {
+  ReadWriteLock lock;
+
+  ASSERT_FALSE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+  
+  // lock read
+  lock.lockRead();
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_TRUE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+
+  // try read-locking again
+  ASSERT_TRUE(lock.tryLockRead());
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_TRUE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+  
+  // read-lock again
+  lock.lockRead();
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_TRUE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+  
+  // try write-locking 
+  ASSERT_FALSE(lock.tryLockWrite());
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_TRUE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+  
+  // try write-locking again, with timeout
+  ASSERT_FALSE(lock.lockWrite(std::chrono::microseconds(1000)));
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_TRUE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+
+  // unlock one level
+  lock.unlock();
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_TRUE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+  ASSERT_FALSE(lock.tryLockWrite());
+  
+  // unlock one another level
+  lock.unlock();
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_TRUE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+  ASSERT_FALSE(lock.tryLockWrite());
+  
+  // unlock final level
+  lock.unlock();
+  ASSERT_FALSE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+  ASSERT_TRUE(lock.tryLockWrite());
+}
+
+TEST(ReadWriteLockTest, testLockWriteAttempted) {
+  ReadWriteLock lock;
+
+  ASSERT_FALSE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+  
+  // lock write
+  ASSERT_TRUE(lock.lockWrite(std::chrono::microseconds(1000000)));
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_TRUE(lock.isLockedWrite());
+
+  // try locking again
+  ASSERT_FALSE(lock.lockWrite(std::chrono::microseconds(1000000)));
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_TRUE(lock.isLockedWrite());
+  
+  ASSERT_FALSE(lock.tryLockRead());
+  ASSERT_TRUE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_TRUE(lock.isLockedWrite());
+
+  lock.unlock();
+  ASSERT_FALSE(lock.isLocked());
+  ASSERT_FALSE(lock.isLockedRead());
+  ASSERT_FALSE(lock.isLockedWrite());
+}
+
+TEST(ReadWriteLockTest, recursiveReadLock) {
+  using namespace arangodb;
+
+  ReadWriteLock lock;
+  std::atomic<std::thread::id> writeLockOwner;
+  
+  std::atomic<bool> attemptWriteLock{false};
+   
+  std::thread reader([&]() {
+    RECURSIVE_READ_LOCKER(lock, writeLockOwner);
+    
+    // signal the writer thread that it should attempt to acquire the write lock
+    attemptWriteLock = true;
+    
+    // give the writer thread a chance to register the queued writer before we
+    // acquire the recursive read lock (again)
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    
+    RECURSIVE_READ_LOCKER(lock, writeLockOwner);
+  });
+  
+  std::thread writer([&]() {
+    while (!attemptWriteLock) {
+      // wait until the reader thread has acquired the first read lock
+    }
+    ASSERT_TRUE(lock.lockWrite(std::chrono::seconds(10)));
+  });
+
+  reader.join();
+  writer.join();
+}
+
+TEST(ReadWriteLockTest, recursiveWriteLock) {
+  using namespace arangodb;
+
+  ReadWriteLock lock;
+  std::atomic<std::thread::id> writeLockOwner;
+
+  std::atomic<bool> attemptWriteLock{false};
+
+  std::thread readerWriter([&]() {
+    RECURSIVE_WRITE_LOCKER(lock, writeLockOwner);
+
+    // signal the writer thread that it should attempt to acquire the write lock
+    attemptWriteLock = true;
+
+    // give the writer thread a chance to register the queued writer before we
+    // acquire the recursive read lock
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+    RECURSIVE_READ_LOCKER(lock, writeLockOwner);
+  });
+
+  std::thread writer([&]() {
+    while (!attemptWriteLock) {
+      // wait until the readerWriter thread has acquired the first write lock
+    }
+    ASSERT_TRUE(lock.lockWrite(std::chrono::seconds(10)));
+  });
+
+  readerWriter.join();
+  writer.join();
+}


### PR DESCRIPTION
### Scope & Purpose

Fixed a potential deadlock in RecursiveReadLocker. This could happen if some thread A has acquired a read-lock, then some thread B signals that it wants to acquire a write-lock and now thread A recursively wants to acquire another read-lock. Since our ReadWriteLocks usually prefer writers, the second attempt to acquire the read-lock would block, waiting for the writer to finish while the writer would block, waiting for the first read to finish. To solve this, the RecursiveReadLock does no longer follow the principal that writes have precedence over reads.

Should only be merged after #14101 

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new C++ **Unit tests**
