### PR TITLE
Improve exception safety for maintenance thread & shard unlocking

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.8.0 (XXXX-XX-XX)
 -------------------
 
+* Improve exception safety for maintenance thread and shard unlock
+  operations.
+
 * Fixed issue BTS-354: Assertion related to getCollection. 
 
 * Fix DEVSUP-749: Fix potential deadlock when executing concurrent view/link DDL

--- a/arangod/Cluster/ActionBase.cpp
+++ b/arangod/Cluster/ActionBase.cpp
@@ -173,6 +173,12 @@ void ActionBase::endStats() {
 
 }  // ActionBase::endStats
 
+ShardDefinition::ShardDefinition(std::string const& database, std::string const& shard)
+    : _database(database), _shard(shard) {
+  TRI_ASSERT(!database.empty());
+  TRI_ASSERT(!shard.empty());
+}
+
 Result arangodb::actionError(ErrorCode errorCode, std::string const& errorMessage) {
   LOG_TOPIC("c889d", ERR, Logger::MAINTENANCE) << errorMessage;
   return Result(errorCode, errorMessage);
@@ -235,19 +241,19 @@ void ActionBase::setState(ActionState state) {
 Result ActionBase::result() const {
   Result result;
   {
-    const std::lock_guard<std::mutex> lock(resLock);
+    std::lock_guard<std::mutex> lock(resLock);
     result.reset(_result);
   }
   return result;
 }
 
 void ActionBase::result(Result const& result) {
-  const std::lock_guard<std::mutex> lock(resLock);
+  std::lock_guard<std::mutex> lock(resLock);
   _result.reset(result);
 }
 
 void ActionBase::result(ErrorCode errorNumber, std::string const& errorString) {
-  const std::lock_guard<std::mutex> lock(resLock);
+  std::lock_guard<std::mutex> lock(resLock);
   _result.reset(errorNumber, errorString);
 }
 
@@ -257,7 +263,7 @@ void ActionBase::result(ErrorCode errorNumber, std::string const& errorString) {
  */
 arangodb::Result ActionBase::progress(double& progress) {
   progress = 0.5;
-  return arangodb::Result(TRI_ERROR_NO_ERROR);
+  return {};
 }
 
 namespace std {

--- a/arangod/Cluster/ActionBase.cpp
+++ b/arangod/Cluster/ActionBase.cpp
@@ -241,19 +241,19 @@ void ActionBase::setState(ActionState state) {
 Result ActionBase::result() const {
   Result result;
   {
-    std::lock_guard<std::mutex> lock(resLock);
+    const std::lock_guard<std::mutex> lock(resLock);
     result.reset(_result);
   }
   return result;
 }
 
 void ActionBase::result(Result const& result) {
-  std::lock_guard<std::mutex> lock(resLock);
+  const std::lock_guard<std::mutex> lock(resLock);
   _result.reset(result);
 }
 
 void ActionBase::result(ErrorCode errorNumber, std::string const& errorString) {
-  std::lock_guard<std::mutex> lock(resLock);
+  const std::lock_guard<std::mutex> lock(resLock);
   _result.reset(errorNumber, errorString);
 }
 

--- a/arangod/Cluster/ActionBase.h
+++ b/arangod/Cluster/ActionBase.h
@@ -233,6 +233,30 @@ private:
 
 };  // class ActionBase
 
+class ShardDefinition {
+ public:
+  ShardDefinition(ShardDefinition const&) = delete;
+  ShardDefinition& operator=(ShardDefinition const&) = delete;
+
+  ShardDefinition(std::string const& database, std::string const& shard);
+
+  std::string const& getDatabase() const noexcept {
+    return _database;
+  }
+  
+  std::string const& getShard() const noexcept {
+    return _shard;
+  }
+
+  bool isValid() const noexcept {
+    return !_database.empty() && !_shard.empty();
+  }
+
+ private:
+  std::string const _database;
+  std::string const _shard;
+};
+
 }  // namespace maintenance
 
 Result actionError(ErrorCode errorCode, std::string const& errorMessage);

--- a/arangod/Cluster/ActionBase.h
+++ b/arangod/Cluster/ActionBase.h
@@ -239,6 +239,8 @@ class ShardDefinition {
   ShardDefinition& operator=(ShardDefinition const&) = delete;
 
   ShardDefinition(std::string const& database, std::string const& shard);
+  
+  virtual ~ShardDefinition() = default;
 
   std::string const& getDatabase() const noexcept {
     return _database;

--- a/arangod/Cluster/CreateCollection.cpp
+++ b/arangod/Cluster/CreateCollection.cpp
@@ -215,7 +215,7 @@ bool CreateCollection::first() {
 void CreateCollection::setState(ActionState state) {
   if ((COMPLETE == state || FAILED == state) && _state != state) {
     // calling unlockShard here is safe, because nothing before it
-    // can go throw. if some code is added before the unlock that
+    // can throw. if some code is added before the unlock that
     // can throw, it must be made sure that the unlock is always called
     _feature.unlockShard(getShard());
     if (!_doNotIncrement) {

--- a/arangod/Cluster/CreateCollection.cpp
+++ b/arangod/Cluster/CreateCollection.cpp
@@ -53,25 +53,20 @@ constexpr auto WAIT_FOR_SYNC_REPL = "waitForSyncReplication";
 constexpr auto ENF_REPL_FACT = "enforceReplicationFactor";
 
 CreateCollection::CreateCollection(MaintenanceFeature& feature, ActionDescription const& desc)
-    : ActionBase(feature, desc) {
+    : ActionBase(feature, desc),
+      ShardDefinition(desc.get(DATABASE), desc.get(SHARD)) {
   std::stringstream error;
 
   _labels.emplace(FAST_TRACK);
-
-  if (!desc.has(DATABASE)) {
-    error << "database must be specified. ";
-  }
-  TRI_ASSERT(desc.has(DATABASE));
 
   if (!desc.has(COLLECTION)) {
     error << "cluster-wide collection must be specified. ";
   }
   TRI_ASSERT(desc.has(COLLECTION));
 
-  if (!desc.has(SHARD)) {
-    error << "shard must be specified. ";
+  if (!ShardDefinition::isValid()) {
+    error << "database and shard must be specified. ";
   }
-  TRI_ASSERT(desc.has(SHARD));
 
   if (!desc.has(THE_LEADER)) {
     error << "shard leader must be specified. ";
@@ -107,9 +102,9 @@ CreateCollection::CreateCollection(MaintenanceFeature& feature, ActionDescriptio
 CreateCollection::~CreateCollection() = default;
 
 bool CreateCollection::first() {
-  auto const& database = _description.get(DATABASE);
+  auto const& database = getDatabase();
   auto const& collection = _description.get(COLLECTION);
-  auto const& shard = _description.get(SHARD);
+  auto const& shard = getShard();
   auto const& leader = _description.get(THE_LEADER);
   auto const& props = properties();
 
@@ -219,10 +214,12 @@ bool CreateCollection::first() {
 
 void CreateCollection::setState(ActionState state) {
   if ((COMPLETE == state || FAILED == state) && _state != state) {
-    TRI_ASSERT(_description.has(SHARD));
-    _feature.unlockShard(_description.get(SHARD));
+    // calling unlockShard here is safe, because nothing before it
+    // can go throw. if some code is added before the unlock that
+    // can throw, it must be made sure that the unlock is always called
+    _feature.unlockShard(getShard());
     if (!_doNotIncrement) {
-      _feature.incShardVersion(_description.get(SHARD));
+      _feature.incShardVersion(getShard());
     }
   }
   ActionBase::setState(state);

--- a/arangod/Cluster/CreateCollection.h
+++ b/arangod/Cluster/CreateCollection.h
@@ -33,7 +33,7 @@
 namespace arangodb {
 namespace maintenance {
 
-class CreateCollection : public ActionBase {
+class CreateCollection : public ActionBase, public ShardDefinition {
  public:
   CreateCollection(MaintenanceFeature&, ActionDescription const& d);
 

--- a/arangod/Cluster/DropCollection.h
+++ b/arangod/Cluster/DropCollection.h
@@ -28,12 +28,10 @@
 #include "ActionBase.h"
 #include "ActionDescription.h"
 
-#include <chrono>
-
 namespace arangodb {
 namespace maintenance {
 
-class DropCollection : public ActionBase {
+class DropCollection : public ActionBase, ShardDefinition {
  public:
   DropCollection(MaintenanceFeature&, ActionDescription const&);
 

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -1612,14 +1612,14 @@ void arangodb::maintenance::syncReplicatedShardsWithLeaders(
           continue;
         }
 
-        auto const leader = pservers[0].copyString();
+        std::string leader = pservers[0].copyString();
         std::shared_ptr<ActionDescription> description = std::make_shared<ActionDescription>(
           std::map<std::string, std::string>{
             {NAME, SYNCHRONIZE_SHARD},
             {DATABASE, dbname},
             {COLLECTION, colname.toString()},
             {SHARD, shname.toString()},
-            {THE_LEADER, leader},
+            {THE_LEADER, std::move(leader)},
             {SHARD_VERSION, std::to_string(feature.shardVersion(shname.toString()))}},
           SYNCHRONIZE_PRIORITY, true);
         std::string shardName = description->get(SHARD);

--- a/arangod/Cluster/MaintenanceWorker.cpp
+++ b/arangod/Cluster/MaintenanceWorker.cpp
@@ -82,6 +82,9 @@ void MaintenanceWorker::run() {
                 << "MaintenanceWorkerRun:  unexpected state (" << _loopState << ")";
 
         }  // switch
+      
+        // determine next loop state
+        nextState(more);
 
       } catch (std::exception const& ex) {
         if (_curAction) {
@@ -108,9 +111,6 @@ void MaintenanceWorker::run() {
               << " state:" << _loopState;
         }
       }
-
-      // determine next loop state
-      nextState(more);
 
     } else {
       std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/arangod/Cluster/MaintenanceWorker.cpp
+++ b/arangod/Cluster/MaintenanceWorker.cpp
@@ -56,64 +56,82 @@ void MaintenanceWorker::run() {
   bool more(false);
 
   while (eSTOP != _loopState && !_feature.isShuttingDown()) {
-    if (!_feature.isPaused()) {
-      try {
-        switch (_loopState) {
-          case eFIND_ACTION:
-            _curAction = _feature.findReadyAction(_labels);
-            more = (bool)_curAction;
-            break;
+    try {
+      if (!_feature.isPaused()) {
+        try {
+          switch (_loopState) {
+            case eFIND_ACTION:
+              _curAction = _feature.findReadyAction(_labels);
+              more = (bool)_curAction;
+              break;
 
-          case eRUN_FIRST:
-            if (_curAction->getState() == READY) {
-              _curAction->setState(EXECUTING);
+            case eRUN_FIRST:
+              if (_curAction->getState() == READY) {
+                _curAction->setState(EXECUTING);
+              }
+              _curAction->startStats();
+              more = _curAction->first();
+              break;
+
+            case eRUN_NEXT:
+              more = _curAction->next();
+              break;
+
+            default:
+              _loopState = eSTOP;
+              LOG_TOPIC("dc389", ERR, Logger::CLUSTER)
+                  << "MaintenanceWorkerRun:  unexpected state (" << _loopState << ")";
+
+          }  // switch
+        
+          // determine next loop state
+          nextState(more);
+
+        } catch (std::exception const& ex) {
+          if (_curAction) {
+            LOG_TOPIC("dd8e8", ERR, Logger::CLUSTER)
+                << "MaintenanceWorkerRun:  caught exception (" << ex.what() << ")"
+                << " state:" << _loopState << " action:" << *_curAction;
+
+            try {
+              _curAction->setState(FAILED);
+            } catch (...) {
+              // even setState() can fail, e.g. with OOM
+              // there is not much we can do in this case
             }
-            _curAction->startStats();
-            more = _curAction->first();
-            break;
+          } else {
+            LOG_TOPIC("16d4c", ERR, Logger::CLUSTER)
+                << "MaintenanceWorkerRun:  caught exception (" << ex.what() << ")"
+                << " state:" << _loopState;
+          }
+        } catch (...) {
+          if (_curAction) {
+            LOG_TOPIC("ac2a2", ERR, Logger::CLUSTER)
+                << "MaintenanceWorkerRun: caught error, state: " << _loopState
+                << " state:" << _loopState << " action:" << *_curAction;
 
-          case eRUN_NEXT:
-            more = _curAction->next();
-            break;
-
-          default:
-            _loopState = eSTOP;
-            LOG_TOPIC("dc389", ERR, Logger::CLUSTER)
-                << "MaintenanceWorkerRun:  unexpected state (" << _loopState << ")";
-
-        }  // switch
-      
-        // determine next loop state
-        nextState(more);
-
-      } catch (std::exception const& ex) {
-        if (_curAction) {
-          LOG_TOPIC("dd8e8", ERR, Logger::CLUSTER)
-              << "MaintenanceWorkerRun:  caught exception (" << ex.what() << ")"
-              << " state:" << _loopState << " action:" << *_curAction;
-
-          _curAction->setState(FAILED);
-        } else {
-          LOG_TOPIC("16d4c", ERR, Logger::CLUSTER)
-              << "MaintenanceWorkerRun:  caught exception (" << ex.what() << ")"
-              << " state:" << _loopState;
+            try {
+              _curAction->setState(FAILED);
+            } catch (...) {
+              // even setState() can fail, e.g. with OOM
+              // there is not much we can do in this case
+            }
+          } else {
+            LOG_TOPIC("88771", ERR, Logger::CLUSTER)
+                << "MaintenanceWorkerRun: caught error, state: " << _loopState
+                << " state:" << _loopState;
+          }
         }
-      } catch (...) {
-        if (_curAction) {
-          LOG_TOPIC("ac2a2", ERR, Logger::CLUSTER)
-              << "MaintenanceWorkerRun: caught error, state: " << _loopState
-              << " state:" << _loopState << " action:" << *_curAction;
 
-          _curAction->setState(FAILED);
-        } else {
-          LOG_TOPIC("88771", ERR, Logger::CLUSTER)
-              << "MaintenanceWorkerRun: caught error, state: " << _loopState
-              << " state:" << _loopState;
-        }
+      } else {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
       }
-
-    } else {
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    } catch (std::exception const& ex) {
+      LOG_TOPIC("56021", WARN, Logger::CLUSTER)
+          << "caught exception in Maintenance worker thread: " << ex.what();
+    } catch (...) {
+      LOG_TOPIC("2d64f", WARN, Logger::CLUSTER)
+          << "caught unknown exception in Maintenance worker thread";
     }
 
   }  // while

--- a/arangod/Cluster/ResignShardLeadership.cpp
+++ b/arangod/Cluster/ResignShardLeadership.cpp
@@ -53,22 +53,19 @@ using namespace arangodb::application_features;
 using namespace arangodb::maintenance;
 using namespace arangodb::methods;
 
+std::string const ResignShardLeadership::LeaderNotYetKnownString = "LEADER_NOT_YET_KNOWN";
+
 ResignShardLeadership::ResignShardLeadership(MaintenanceFeature& feature,
                                              ActionDescription const& desc)
-    : ActionBase(feature, desc) {
+    : ActionBase(feature, desc),
+      ShardDefinition(desc.get(DATABASE), desc.get(SHARD)) {
   std::stringstream error;
 
   _labels.emplace(FAST_TRACK);
 
-  if (!desc.has(DATABASE)) {
-    error << "database must be specified";
+  if (!ShardDefinition::isValid()) {
+    error << "database and shard must be specified. ";
   }
-  TRI_ASSERT(desc.has(DATABASE));
-
-  if (!desc.has(SHARD)) {
-    error << "shard must be specified";
-  }
-  TRI_ASSERT(desc.has(SHARD));
 
   if (!error.str().empty()) {
     LOG_TOPIC("2aa84", ERR, Logger::MAINTENANCE) << "ResignLeadership: " << error.str();
@@ -80,8 +77,8 @@ ResignShardLeadership::ResignShardLeadership(MaintenanceFeature& feature,
 ResignShardLeadership::~ResignShardLeadership() = default;
 
 bool ResignShardLeadership::first() {
-  std::string const& database = _description.get(DATABASE);
-  std::string const& collection = _description.get(SHARD);
+  std::string const& database = getDatabase();
+  std::string const& collection = getShard();
 
   LOG_TOPIC("14f43", DEBUG, Logger::MAINTENANCE)
       << "trying to withdraw as leader of shard '" << database << "/" << collection;
@@ -141,11 +138,9 @@ bool ResignShardLeadership::first() {
   return false;
 }
 
-std::string const ResignShardLeadership::LeaderNotYetKnownString = "LEADER_NOT_YET_KNOWN";
-
 void ResignShardLeadership::setState(ActionState state) {
   if ((COMPLETE == state || FAILED == state) && _state != state) {
-    _feature.unlockShard(_description.get(SHARD));
+    _feature.unlockShard(getShard());
   }
   ActionBase::setState(state);
 }

--- a/arangod/Cluster/ResignShardLeadership.h
+++ b/arangod/Cluster/ResignShardLeadership.h
@@ -28,12 +28,10 @@
 #include "ActionBase.h"
 #include "ActionDescription.h"
 
-#include <chrono>
-
 namespace arangodb {
 namespace maintenance {
 
-class ResignShardLeadership : public ActionBase {
+class ResignShardLeadership : public ActionBase, public ShardDefinition {
  public:
   ResignShardLeadership(MaintenanceFeature&, ActionDescription const& d);
 

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -27,6 +27,7 @@
 #include "Agency/AgencyStrings.h"
 #include "Agency/TimeString.h"
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Basics/ScopeGuard.h"
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Cluster/ActionDescription.h"
@@ -90,26 +91,21 @@ using namespace std::chrono;
 
 SynchronizeShard::SynchronizeShard(MaintenanceFeature& feature, ActionDescription const& desc)
   : ActionBase(feature, desc),
+    ShardDefinition(desc.get(DATABASE), desc.get(SHARD)),
     _leaderInfo(arangodb::replutils::LeaderInfo::createEmpty()) {
   std::stringstream error;
 
   if (!desc.has(COLLECTION)) {
-    error << "collection must be specified";
+    error << "collection must be specified. ";
   }
   TRI_ASSERT(desc.has(COLLECTION));
 
-  if (!desc.has(DATABASE)) {
-    error << "database must be specified";
+  if (!ShardDefinition::isValid()) {
+    error << "database and shard must be specified. ";
   }
-  TRI_ASSERT(desc.has(DATABASE));
-
-  if (!desc.has(SHARD)) {
-    error << "SHARD must be specified";
-  }
-  TRI_ASSERT(desc.has(SHARD));
 
   if (!desc.has(THE_LEADER) || desc.get(THE_LEADER).empty()) {
-    error << "leader must be specified and must be non-empty";
+    error << "leader must be specified and must be non-empty. ";
   }
   TRI_ASSERT(desc.has(THE_LEADER) && !desc.get(THE_LEADER).empty());
 
@@ -401,7 +397,7 @@ static arangodb::Result cancelReadLockOnLeader(network::ConnectionPool* pool,
 
 arangodb::Result SynchronizeShard::getReadLock(
   network::ConnectionPool* pool,
-  std::string const& endpoint, std::string const& database,
+  std::string const& endpoint, 
   std::string const& collection, std::string const& clientId,
   uint64_t rlid, bool soft, double timeout) {
 
@@ -436,7 +432,7 @@ arangodb::Result SynchronizeShard::getReadLock(
   // SynchroShard anew. 
   network::RequestOptions options;
   options.timeout = network::Timeout(timeout);
-  options.database = database;
+  options.database = getDatabase();
 
   auto response = network::sendRequest(
     pool, endpoint, fuerte::RestVerb::Post,
@@ -469,7 +465,7 @@ arangodb::Result SynchronizeShard::getReadLock(
     if (res.fail()) {
       LOG_TOPIC("4f34d", WARN, Logger::MAINTENANCE)
           << "startReadLockOnLeader: cancelation error for shard "
-          << database << "/" << collection << ": " << res.errorMessage();
+          << getDatabase() << "/" << collection << ": " << res.errorMessage();
     }
   } catch (std::exception const& e) {
     LOG_TOPIC("7fcc9", WARN, Logger::MAINTENANCE)
@@ -481,7 +477,7 @@ arangodb::Result SynchronizeShard::getReadLock(
 }
 
 arangodb::Result SynchronizeShard::startReadLockOnLeader(
-  std::string const& endpoint, std::string const& database, std::string const& collection,
+  std::string const& endpoint, std::string const& collection,
   std::string const& clientId, uint64_t& rlid, bool soft, double timeout) {
 
   TRI_ASSERT(timeout > 0);
@@ -490,13 +486,13 @@ arangodb::Result SynchronizeShard::startReadLockOnLeader(
   NetworkFeature& nf = _feature.server().getFeature<NetworkFeature>();
   network::ConnectionPool* pool = nf.pool();
   arangodb::Result result =
-      getReadLockId(pool, endpoint, database, clientId, timeout, rlid);
+      getReadLockId(pool, endpoint, getDatabase(), clientId, timeout, rlid);
   if (!result.ok()) {
     LOG_TOPIC("2e5ae", WARN, Logger::MAINTENANCE) << result.errorMessage();
   } else {
     LOG_TOPIC("c8d18", DEBUG, Logger::MAINTENANCE) << "Got read lock id: " << rlid;
 
-    result.reset(getReadLock(pool, endpoint, database, collection, clientId, rlid, soft, timeout));
+    result.reset(getReadLock(pool, endpoint, collection, clientId, rlid, soft, timeout));
   }
 
   return result;
@@ -665,9 +661,9 @@ static arangodb::Result replicationSynchronizeFinalize(SynchronizeShard const& j
 }
 
 bool SynchronizeShard::first() {
-  std::string database = _description.get(DATABASE);
+  std::string const& database = getDatabase();
   std::string planId = _description.get(COLLECTION);
-  std::string shard = _description.get(SHARD);
+  std::string const& shard = getShard();
   std::string leader = _description.get(THE_LEADER);
 
   LOG_TOPIC("fa651", DEBUG, Logger::MAINTENANCE)
@@ -918,8 +914,7 @@ bool SynchronizeShard::first() {
       VPackBuilder builder;
 
       ResultT<TRI_voc_tick_t> tickResult =
-        catchupWithReadLock(ep, database, *collection, clientId, shard,
-                            leader, lastTick, builder);
+        catchupWithReadLock(ep, *collection, clientId, leader, lastTick, builder);
       if (!tickResult.ok()) {
         LOG_TOPIC("0a4d4", INFO, Logger::MAINTENANCE) << tickResult.errorMessage();
         result(std::move(tickResult).result());
@@ -928,7 +923,7 @@ bool SynchronizeShard::first() {
       lastTick = tickResult.get();
 
       // Now start an exclusive transaction to stop writes:
-      Result res = catchupWithExclusiveLock(ep, database, *collection, clientId, shard,
+      Result res = catchupWithExclusiveLock(ep, *collection, clientId,
                                             leader, syncerId, lastTick, builder);
       if (!res.ok()) {
         LOG_TOPIC("be85f", INFO, Logger::MAINTENANCE) << res.errorMessage();
@@ -977,8 +972,8 @@ bool SynchronizeShard::first() {
 }
 
 ResultT<TRI_voc_tick_t> SynchronizeShard::catchupWithReadLock(
-  std::string const& ep, std::string const& database, LogicalCollection const& collection,
-  std::string const& clientId, std::string const& shard,
+  std::string const& ep, LogicalCollection const& collection,
+  std::string const& clientId, 
   std::string const& leader, TRI_voc_tick_t lastLogTick, VPackBuilder& builder) {
   bool didTimeout = true;
   int tries = 0;
@@ -998,8 +993,8 @@ ResultT<TRI_voc_tick_t> SynchronizeShard::catchupWithReadLock(
     uint64_t lockJobId = 0;
     LOG_TOPIC("b4f2b", DEBUG, Logger::MAINTENANCE)
         << "synchronizeOneShard: startReadLockOnLeader (soft): " << ep << ":"
-        << database << ":" << collection.name();
-    Result res = startReadLockOnLeader(ep, database, collection.name(),
+        << getDatabase() << ":" << collection.name();
+    Result res = startReadLockOnLeader(ep, collection.name(),
                                        clientId, lockJobId, true, timeout);
     if (!res.ok()) {
       auto errorMessage = StringUtils::concatT(
@@ -1012,7 +1007,7 @@ ResultT<TRI_voc_tick_t> SynchronizeShard::catchupWithReadLock(
       // Reported seperately
       NetworkFeature& nf = _feature.server().getFeature<NetworkFeature>();
       network::ConnectionPool* pool = nf.pool();
-      auto res = cancelReadLockOnLeader(pool, ep, database, lockJobId, clientId, 60.0);
+      auto res = cancelReadLockOnLeader(pool, ep, getDatabase(), lockJobId, clientId, 60.0);
       if (!res.ok()) {
         LOG_TOPIC("b15ee", INFO, Logger::MAINTENANCE)
             << "Could not cancel soft read lock on leader: " << res.errorMessage();
@@ -1031,8 +1026,8 @@ ResultT<TRI_voc_tick_t> SynchronizeShard::catchupWithReadLock(
     {
       VPackObjectBuilder o(&builder);
       builder.add(ENDPOINT, VPackValue(ep));
-      builder.add(DATABASE, VPackValue(database));
-      builder.add(COLLECTION, VPackValue(shard));
+      builder.add(DATABASE, VPackValue(getDatabase()));
+      builder.add(COLLECTION, VPackValue(getShard()));
       builder.add(LEADER_ID, VPackValue(leader));
       builder.add("from", VPackValue(lastLogTick));
       builder.add("requestTimeout", VPackValue(600.0));
@@ -1055,7 +1050,7 @@ ResultT<TRI_voc_tick_t> SynchronizeShard::catchupWithReadLock(
     // Stop the read lock again:
     NetworkFeature& nf = _feature.server().getFeature<NetworkFeature>();
     network::ConnectionPool* pool = nf.pool();
-    res = cancelReadLockOnLeader(pool, ep, database, lockJobId, clientId, 60.0);
+    res = cancelReadLockOnLeader(pool, ep, getDatabase(), lockJobId, clientId, 60.0);
     // We removed the readlock
     readLockGuard.cancel();
     if (!res.ok()) {
@@ -1068,26 +1063,26 @@ ResultT<TRI_voc_tick_t> SynchronizeShard::catchupWithReadLock(
     lastLogTick = tickReached;
     if (didTimeout) {
       LOG_TOPIC("e516e", INFO, Logger::MAINTENANCE)
-        << "Renewing softLock for " << shard << " on leader: " << leader;
+        << "Renewing softLock for " << getShard() << " on leader: " << leader;
     }
   }
   if (didTimeout) {
     LOG_TOPIC("f1a61", WARN, Logger::MAINTENANCE)
-        << "Could not catchup under softLock for " << shard << " on leader: " << leader
+        << "Could not catchup under softLock for " << getShard() << " on leader: " << leader
         << " now activating hardLock. This is expected under high load.";
   }
   return ResultT<TRI_voc_tick_t>::success(tickReached);
 }
 
 Result SynchronizeShard::catchupWithExclusiveLock(
-    std::string const& ep, std::string const& database, LogicalCollection& collection,
-    std::string const& clientId, std::string const& shard, std::string const& leader,
+    std::string const& ep, LogicalCollection& collection,
+    std::string const& clientId, std::string const& leader,
     SyncerId const syncerId, TRI_voc_tick_t lastLogTick, VPackBuilder& builder) {
   uint64_t lockJobId = 0;
   LOG_TOPIC("da129", DEBUG, Logger::MAINTENANCE)
-      << "synchronizeOneShard: startReadLockOnLeader: " << ep << ":" << database
+      << "synchronizeOneShard: startReadLockOnLeader: " << ep << ":" << getDatabase()
       << ":" << collection.name();
-  Result res = startReadLockOnLeader(ep, database, collection.name(), clientId,
+  Result res = startReadLockOnLeader(ep, collection.name(), clientId,
                                      lockJobId, false);
   if (!res.ok()) {
     auto errorMessage = StringUtils::concatT(
@@ -1099,7 +1094,7 @@ Result SynchronizeShard::catchupWithExclusiveLock(
     // Reported seperately
     NetworkFeature& nf = _feature.server().getFeature<NetworkFeature>();
     network::ConnectionPool* pool = nf.pool();
-    auto res = cancelReadLockOnLeader(pool, ep, database, lockJobId, clientId, 60.0);
+    auto res = cancelReadLockOnLeader(pool, ep, getDatabase(), lockJobId, clientId, 60.0);
     if (!res.ok()) {
       LOG_TOPIC("067a8", INFO, Logger::MAINTENANCE)
           << "Could not cancel hard read lock on leader: " << res.errorMessage();
@@ -1112,8 +1107,8 @@ Result SynchronizeShard::catchupWithExclusiveLock(
   {
     VPackObjectBuilder o(&builder);
     builder.add(ENDPOINT, VPackValue(ep));
-    builder.add(DATABASE, VPackValue(database));
-    builder.add(COLLECTION, VPackValue(shard));
+    builder.add(DATABASE, VPackValue(getDatabase()));
+    builder.add(COLLECTION, VPackValue(getShard()));
     builder.add(LEADER_ID, VPackValue(leader));
     builder.add("from", VPackValue(lastLogTick));
     builder.add("requestTimeout", VPackValue(600.0));
@@ -1131,7 +1126,7 @@ Result SynchronizeShard::catchupWithExclusiveLock(
 
   NetworkFeature& nf = _feature.server().getFeature<NetworkFeature>();
   network::ConnectionPool* pool = nf.pool();
-  res = addShardFollower(pool, ep, database, shard, lockJobId, clientId,
+  res = addShardFollower(pool, ep, getDatabase(), getShard(), lockJobId, clientId,
                          syncerId, _clientInfoString, 60.0);
 
   // if we get a checksum mismatch, it means that we got different counts of
@@ -1150,7 +1145,7 @@ Result SynchronizeShard::catchupWithExclusiveLock(
     // recalculate collection count on follower
     LOG_TOPIC("29384", INFO, Logger::MAINTENANCE) 
        << "recalculating collection count on follower for "
-       << database << "/" << shard;
+       << getDatabase() << "/" << getShard();
 
     uint64_t docCount = 0;
     Result countRes = collectionCount(collection, docCount);
@@ -1168,7 +1163,7 @@ Result SynchronizeShard::catchupWithExclusiveLock(
 
     LOG_TOPIC("d2689", INFO, Logger::MAINTENANCE) 
        << "recalculated collection count on follower for "
-       << database << "/" << shard << ", old: " << oldCount << ", new: " << docCount;
+       << getDatabase() << "/" << getShard() << ", old: " << oldCount << ", new: " << docCount;
 
     // check if our recalculation has made a difference
     if (oldCount == docCount) {
@@ -1176,14 +1171,14 @@ Result SynchronizeShard::catchupWithExclusiveLock(
       // this is last resort and should not happen often!
       LOG_TOPIC("3dc64", INFO, Logger::MAINTENANCE) 
          << "recalculating collection count on leader for "
-         << database << "/" << shard;
+         << getDatabase() << "/" << getShard();
 
       VPackBuffer<uint8_t> buffer;
       VPackBuilder tmp(buffer);
       tmp.add(VPackSlice::emptyObjectSlice());
 
       network::RequestOptions options;
-      options.database = database;
+      options.database = getDatabase();
       options.timeout = network::Timeout(600.0);  // this can be slow!!!
       options.skipScheduler = true;  // hack to speed up future.get()
 
@@ -1198,7 +1193,7 @@ Result SynchronizeShard::catchupWithExclusiveLock(
         auto const errorMessage = StringUtils::concatT(
             "addShardFollower: could not add us to the leader's follower list "
             "for ",
-            database, "/", shard,
+            getDatabase(), "/", getShard(),
             ", error while recalculating count on leader: ", result.errorMessage());
         LOG_TOPIC("22e0b", WARN, Logger::MAINTENANCE) << errorMessage;
         return arangodb::Result(result.errorNumber(), std::move(errorMessage));
@@ -1229,18 +1224,21 @@ Result SynchronizeShard::catchupWithExclusiveLock(
 
   // Report success:
   LOG_TOPIC("3423d", DEBUG, Logger::MAINTENANCE)
-      << "synchronizeOneShard: synchronization worked for shard " << shard;
+      << "synchronizeOneShard: synchronization worked for shard " << getShard();
   result(TRI_ERROR_NO_ERROR);
-  return {TRI_ERROR_NO_ERROR};
+  return {};
 }
 
 void SynchronizeShard::setState(ActionState state) {
   if ((COMPLETE == state || FAILED == state) && _state != state) {
-    auto const& shard = _description.get(SHARD);
-    std::string database = _description.get(DATABASE);
+    // by all means we must unlock when we leave this scope
+    auto shardUnlocker = scopeGuard([this] {
+      _feature.unlockShard(getShard());
+    });
+
     if (COMPLETE == state) {
       LOG_TOPIC("50827", INFO, Logger::MAINTENANCE)
-        << "SynchronizeShard: synchronization completed for shard " << database << "/" << shard;
+        << "SynchronizeShard: synchronization completed for shard " << getDatabase() << "/" << getShard();
     }
 
     // Acquire current version from agency and wait for it to have been dealt
@@ -1253,15 +1251,15 @@ void SynchronizeShard::setState(ActionState state) {
     auto timeout = duration<double>(600.0);
     auto stoppage = clock::now() + timeout;
     auto snooze = milliseconds(100);
-    while (!_feature.server().isStopping() && clock::now() < stoppage ) {
+    while (!_feature.server().isStopping() && clock::now() < stoppage) {
       cluster::fetchCurrentVersion(0.1 * timeout)
         .thenValue(
           [&v] (auto&& res) { v = res.get(); })
         .thenError<std::exception>(
-          [&shard, database] (std::exception const& e) {
+          [this] (std::exception const& e) {
             LOG_TOPIC("3ae99", ERR, Logger::CLUSTER)
               << "Failed to acquire current version from agency while increasing shard version"
-              << " for shard "  << database << "/" << shard << e.what();
+              << " for shard "  << getDatabase() << "/" << getShard() << e.what();
           })
         .wait();
       if (v > 0) {
@@ -1280,8 +1278,7 @@ void SynchronizeShard::setState(ActionState state) {
     if ( v > 0) {
       _feature.server().getFeature<ClusterFeature>().clusterInfo().waitForCurrentVersion(v).wait();
     }
-    _feature.incShardVersion(shard);
-    _feature.unlockShard(shard);
+    _feature.incShardVersion(getShard());
   }
   ActionBase::setState(state);
 }

--- a/arangod/Cluster/SynchronizeShard.h
+++ b/arangod/Cluster/SynchronizeShard.h
@@ -43,7 +43,7 @@ struct SyncerId;
 
 namespace maintenance {
 
-class SynchronizeShard : public ActionBase {
+class SynchronizeShard : public ActionBase, public ShardDefinition {
  public:
   SynchronizeShard(MaintenanceFeature&, ActionDescription const& d);
 
@@ -60,25 +60,31 @@ class SynchronizeShard : public ActionBase {
 
  private:
   arangodb::Result getReadLock(network::ConnectionPool* pool,
-                               std::string const& endpoint, std::string const& database,
-                               std::string const& collection, std::string const& clientId,
-                               uint64_t rlid, bool soft, double timeout);
+                               std::string const& endpoint, 
+                               std::string const& collection, 
+                               std::string const& clientId,
+                               uint64_t rlid, 
+                               bool soft, 
+                               double timeout);
 
   arangodb::Result startReadLockOnLeader(std::string const& endpoint,
-                                         std::string const& database,
                                          std::string const& collection,
-                                         std::string const& clientId, uint64_t& rlid,
-                                         bool soft, double timeout = 300.0);
+                                         std::string const& clientId, 
+                                         uint64_t& rlid,
+                                         bool soft, 
+                                         double timeout = 300.0);
 
   arangodb::ResultT<TRI_voc_tick_t> catchupWithReadLock(
-      std::string const& ep, std::string const& database, LogicalCollection const& collection,
-      std::string const& clientId, std::string const& shard,
+      std::string const& ep, 
+      LogicalCollection const& collection,
+      std::string const& clientId, 
       std::string const& leader, TRI_voc_tick_t lastLogTick, VPackBuilder& builder);
 
   arangodb::Result catchupWithExclusiveLock(
-      std::string const& ep, std::string const& database,
-      LogicalCollection& collection, std::string const& clientId,
-      std::string const& shard, std::string const& leader, SyncerId syncerId,
+      std::string const& ep, 
+      LogicalCollection& collection, 
+      std::string const& clientId,
+      std::string const& leader, SyncerId syncerId,
       TRI_voc_tick_t lastLogTick, VPackBuilder& builder);
 
   /// @brief Short, informative description of the replication client, passed to the server

--- a/arangod/Cluster/TakeoverShardLeadership.h
+++ b/arangod/Cluster/TakeoverShardLeadership.h
@@ -29,12 +29,10 @@
 #include "ActionBase.h"
 #include "ActionDescription.h"
 
-#include <chrono>
-
 namespace arangodb {
 namespace maintenance {
 
-class TakeoverShardLeadership : public ActionBase {
+class TakeoverShardLeadership : public ActionBase, public ShardDefinition {
  public:
   TakeoverShardLeadership(MaintenanceFeature&, ActionDescription const& d);
 

--- a/arangod/Cluster/UpdateCollection.h
+++ b/arangod/Cluster/UpdateCollection.h
@@ -28,12 +28,10 @@
 #include "ActionBase.h"
 #include "ActionDescription.h"
 
-#include <chrono>
-
 namespace arangodb {
 namespace maintenance {
 
-class UpdateCollection : public ActionBase {
+class UpdateCollection : public ActionBase, public ShardDefinition {
  public:
   UpdateCollection(MaintenanceFeature&, ActionDescription const&);
 


### PR DESCRIPTION
### Scope & Purpose

Improve exception safety for cluster maintenance threads.
If the `nextState()` method in MaintenanceWorker.cpp threw an exception, the maintenance thread was stopped and not restarted. Now this is properly caught, and the action will be set to `FAILED` state.

In addition, shard unlock in maintenance actions that had to do with shards was potentially unsafe, because it was happening in an action's `setState()` method but could require several memory allocations, with potential to throw exceptions before unlocking is carried out.
Shard unlocking is now ensured by storing the shard name as an instance variable, so there do not need to be lookups and temporary string creations to find out the shard name. In SynchronizeShard.cpp, shard unlocking was also put into a scopeGuard so we will see a guaranteed execution even with exceptions.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *cluster tests*.
