### PR TITLE
Fix bugs in fuerte with H2 and VST connections

### DIFF
--- a/3rdParty/fuerte/include/fuerte/connection.h
+++ b/3rdParty/fuerte/include/fuerte/connection.h
@@ -35,6 +35,7 @@ namespace arangodb { namespace fuerte { inline namespace v1 {
 // Connection is the base class for a connection between a client
 // and a server.
 // Different protocols (HTTP, VST) are implemented in derived classes.
+// For details of the setup see the top of src/GeneralConnection.h .
 class Connection : public std::enable_shared_from_this<Connection> {
   friend class ConnectionBuilder;
 

--- a/3rdParty/fuerte/src/GeneralConnection.h
+++ b/3rdParty/fuerte/src/GeneralConnection.h
@@ -24,6 +24,48 @@
 #ifndef ARANGO_CXX_DRIVER_GENERAL_CONNECTION_H
 #define ARANGO_CXX_DRIVER_GENERAL_CONNECTION_H 1
 
+/// Here is an overview over the class structure for connections in fuerte.
+/// There is a lot of inheritance and templating going on which can be a
+/// bit confusing at first sight.
+///
+/// The base class for all connections is `Connection` in `connection.h`
+/// which has `std::enable_shared_from_this<Connection>` to sort out
+/// memory allocation and object lifetimes. In this way, a callback
+/// closure can own a shared_ptr to the connection object it is working
+/// on. This base class basically only defines the interface for all
+/// other derived classes. There is not a lot implemented in there.
+///
+/// The class template GeneralConnection<ST, RT> implements code which
+/// is the same for all three cases HTTP/1, VST and HTTP/2. Here, ST
+/// stands for the socket type (which can be Tcp (unencrypted), Ssl (TLS
+/// encryption with openssl) and Unix (unix domain socket, no encryption).
+/// Note that all 9 combination between protocol version and socket type
+/// are possible. RT is a type which represents a request which is run
+/// on the connection. For HTTP/1, this will be a `RequestItem`, for
+/// HTTP/2 it will be a `Stream` and for VST it will be a `vst::RequestItem`.
+/// All three RTs are separate classes but behave similarly and have
+/// similar methods, such that the generic code can use them. They also
+/// have differences, since requests have to be handled differently
+/// in the three protocols.
+///
+/// For the VST and HTTP/2 cases there is an intermediate class template
+/// `MultiConnection<ST, RT>`, which inherits from `GeneralConnection<ST, RT>`
+/// and is needed, because - contrary to HTTP/1 - there can be more than
+/// one request in flight on a connection due to multiplexing. Furthermore,
+/// for VST a single request or response can be distributed across muliple
+/// "chunks" in the communication, and for HTTP/2, a single request or
+/// response can be distributed across multiple "frames".
+///
+/// Therefore, the `MultiConnection<ST, RT>` implementation has a member
+/// `_streams` which holds the current list of requests (instances of RT)
+/// which are currently in flight.
+///
+/// Finally, there are the three class templates
+///   `H1Connection` inheriting from `GeneralConnection<ST, RequestItem>`,
+///   `H2Connection` inheriting from `MultiConnection<ST, Stream>` and
+///   `VstConnection` inheriting from `MultiConnection<ST, vst::RequestItem>`.
+/// 
+
 #include <fuerte/connection.h>
 #include <fuerte/types.h>
 
@@ -403,7 +445,7 @@ struct MultiConnection : public GeneralConnection<ST, RT> {
       }
     }
 
-    const bool wasReading = this->_writing;
+    const bool wasReading = this->_reading;
     const bool wasWriting = this->_writing;
     if (wasReading || wasWriting) {
       FUERTE_ASSERT(_lastIO + kIOTimeout > now);

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 devel
 -----
 
-* Fixex two bugs in fuerte with HTTP/2 and VST connections.
+* Fixed two bugs in fuerte with HTTP/2 and VST connections.
   One could lead to ordered timeouts not being honoured. The other could
   lead to an ordered callback be called multiple times.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 devel
 -----
+
+* Fixex two bugs in fuerte with HTTP/2 and VST connections.
+  One could lead to ordered timeouts not being honoured. The other could
+  lead to an ordered callback be called multiple times.
+
 * When writing to starting shard leader respond with specific
   503. Fixes BTS-390.
 


### PR DESCRIPTION
This fixes two bugs in fuerte with HTTP/2 and VST connections.

- Do not call callbacks more than once. This could happen since in HTTP/2 a request lingers in form of an HTTP/2 stream for some time longer after its callback has been called by a timeout. If the next timeout (for a different request) is hit, the callback could be called a second time. This is now prevented by keeping some more state.
- Fix bug with timeouts in H2 connections in fuerte. This was a simple typo in the tracking if we are reading and/or writing.
- CHANGELOG.

#### Backports:

- [*] Backports required for: 3.6, 3.7 and 3.8

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [*] The behavior in this PR was *manually tested*
- [*] This change is already covered by existing tests: Fuerte tests

