### PR TITLE
Small improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 devel
 -----
+
+* Log a proper message if an unexpected state is encountered when taking over
+  shard leadership. In addition, make the change to the internal followerinfo 
+  state atomic so that it cannot be semi-changed.
+
 * Fix response when isBuilding could not be removed from newly created
   collection, when agency precondition fails. This can happen, when own
   rebootId increment has triggered plan entry to be removed.

--- a/arangod/Cluster/TakeoverShardLeadership.cpp
+++ b/arangod/Cluster/TakeoverShardLeadership.cpp
@@ -191,7 +191,7 @@ static void handleLeadership(uint64_t planIndex, LogicalCollection& collection,
           ci.getCollectionCurrent(databaseName,
                                   std::to_string(collection.planId().id()));
       if (currentInfo == nullptr) {
-        // Collection has been dropped we cannot continue here.
+        // Collection has been dropped. we cannot continue here.
         return;
       }
       TRI_ASSERT(currentInfo != nullptr);

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -976,7 +976,7 @@ Result DatabaseInitialSyncer::fetchCollectionDump(arangodb::LogicalCollection* c
 Result DatabaseInitialSyncer::fetchCollectionSync(arangodb::LogicalCollection* coll,
                                                   std::string const& leaderColl,
                                                   TRI_voc_tick_t maxTick) {
-  if (coll->syncByRevision() && _config.leader.version() >= 30700) {
+  if (coll->syncByRevision() && _config.leader.version() >= 30800) {
     // local collection should support revisions, and leader is at least aware
     // of the revision-based protocol, so we can query it to find out if we
     // can use the new protocol; will fall back to old one if leader collection

--- a/arangod/RestServer/LanguageCheckFeature.cpp
+++ b/arangod/RestServer/LanguageCheckFeature.cpp
@@ -137,7 +137,7 @@ void LanguageCheckFeature::start() {
   auto defaultLang = feature.getDefaultLanguage();
   auto language = feature.getCollatorLanguage();
   auto previous = ::getOrSetPreviousLanguage(server(), language);
-
+  
   if (defaultLang.empty() && !previous.empty()) {
     // override the empty current setting with the previous one
     feature.resetDefaultLanguage(previous);
@@ -145,11 +145,18 @@ void LanguageCheckFeature::start() {
   }
 
   if (language != previous) {
-    // current not empty and not the same as previous, get out!
-    LOG_TOPIC("7ef60", FATAL, arangodb::Logger::CONFIG)
-        << "specified language '" << language
-        << "' does not match previously used language '" << previous << "'";
-    FATAL_ERROR_EXIT();
+    if (feature.forceLanguageCheck()) {
+      // current not empty and not the same as previous, get out!
+      LOG_TOPIC("7ef60", FATAL, arangodb::Logger::CONFIG)
+          << "specified language '" << language
+          << "' does not match previously used language '" << previous << "'";
+      FATAL_ERROR_EXIT();
+    } else {
+      LOG_TOPIC("54a68", WARN, arangodb::Logger::CONFIG)
+          << "specified language '" << language
+          << "' does not match previously used language '" << previous 
+          << "'. starting anyway due to --default-language-check=false setting";
+    }
   }
 }
 

--- a/arangod/RestServer/LanguageCheckFeature.h
+++ b/arangod/RestServer/LanguageCheckFeature.h
@@ -33,7 +33,6 @@ class LanguageCheckFeature final : public application_features::ApplicationFeatu
   explicit LanguageCheckFeature(application_features::ApplicationServer& server);
   ~LanguageCheckFeature();
 
-  static std::string const& name() noexcept;
   void start() override final;
 };
 

--- a/arangod/RocksDBEngine/RocksDBReplicationIterator.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationIterator.cpp
@@ -26,6 +26,7 @@
 #include <rocksdb/utilities/transaction_db.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Basics/Exceptions.h"
 #include "RocksDBEngine/RocksDBCollection.h"
 #include "RocksDBEngine/RocksDBEngine.h"
 #include "RocksDBEngine/RocksDBKey.h"
@@ -58,6 +59,10 @@ RocksDBRevisionReplicationIterator::RocksDBRevisionReplicationIterator(
   _cmp = cf->GetComparator();
 
   _iter.reset(db->NewIterator(_readOptions, cf));
+  TRI_ASSERT(_iter != nullptr);
+  if (_iter == nullptr) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "unable to build RocksDBRevisionReplicationIterator for snapshot");
+  }
   _iter->Seek(_bounds.start());
 }
 
@@ -78,6 +83,9 @@ RocksDBRevisionReplicationIterator::RocksDBRevisionReplicationIterator(
   _cmp = cf->GetComparator();
 
   _iter = methods->NewIterator(_readOptions, cf);
+  if (_iter == nullptr) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "unable to build RocksDBRevisionReplicationIterator for transaction");
+  }
   _iter->Seek(_bounds.start());
 }
 

--- a/lib/ApplicationFeatures/LanguageFeature.cpp
+++ b/lib/ApplicationFeatures/LanguageFeature.cpp
@@ -89,7 +89,8 @@ LanguageFeature::LanguageFeature(application_features::ApplicationServer& server
     : ApplicationFeature(server, "Language"),
       _locale(),
       _binaryPath(server.getBinaryPath()),
-      _icuDataPtr(nullptr) {
+      _icuDataPtr(nullptr),
+      _forceLanguageCheck(true) {
   setOptional(false);
   startsAfter<application_features::GreetingsFeaturePhase>();
 }
@@ -104,6 +105,11 @@ void LanguageFeature::collectOptions(std::shared_ptr<options::ProgramOptions> op
   options->addOption("--default-language", "ISO-639 language code",
                      new StringParameter(&_language),
                      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden));
+  
+  options->addOption("--default-language-check", "check if default language matches stored language",
+                     new BooleanParameter(&_forceLanguageCheck),
+                     arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden))
+                     .setIntroducedIn(30800);
 }
 
 void* LanguageFeature::prepareIcu(std::string const& binaryPath,
@@ -187,6 +193,10 @@ icu::Locale& LanguageFeature::getLocale() { return _locale; }
 
 std::string const& LanguageFeature::getDefaultLanguage() const {
   return _language;
+}
+
+bool LanguageFeature::forceLanguageCheck() const {
+  return _forceLanguageCheck;
 }
 
 std::string LanguageFeature::getCollatorLanguage() const {

--- a/lib/ApplicationFeatures/LanguageFeature.h
+++ b/lib/ApplicationFeatures/LanguageFeature.h
@@ -49,6 +49,7 @@ class LanguageFeature final : public application_features::ApplicationFeature {
                           std::string& path, std::string const& binaryName);
   icu::Locale& getLocale();
   std::string const& getDefaultLanguage() const;
+  bool forceLanguageCheck() const;
   std::string getCollatorLanguage() const;
   void resetDefaultLanguage(std::string const& language);
 
@@ -57,6 +58,7 @@ class LanguageFeature final : public application_features::ApplicationFeature {
   std::string _language;
   char const* _binaryPath;
   void* _icuDataPtr;
+  bool _forceLanguageCheck;
 };
 
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose

A few small improvements made during debugging other issues:
- add a proper log message in takeOverLeadership if it encounters an unexpected situation. this log message can make aware of that there is an issue, and also provides details about the state
- in takeOverLeadership, make the changes to the internal followerinfo state atomic, so we do not have an invalid state if any modification goes wrong
- require at least 3.8 for sync-by-revisions protocol. technically this should not be necessary, as 3.7 will not offer collections with that protocol enabled. however, this was not reflected properly in the code.
- fail with an exception if we get an invalid pointer back from rocksdb. this is a precaution for an unlikely (potentially even impossible) situation, but it doesn't hurt.
- added hidden option --default-language-check so that the startup language check (`--default-language` value vs. persisted language value) can be bypassed. the default value for the option is `true`, meaning the check will take place normally. it is not recommended to turn it off except when debugging binary data from other deployments.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for 3.8: https://github.com/arangodb/arangodb/pull/14150

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
