### PR TITLE
Make sure _recoveryManagerPtr is initialized correctly.

### DIFF
--- a/arangod/Pregel/PregelFeature.h
+++ b/arangod/Pregel/PregelFeature.h
@@ -93,7 +93,7 @@ class PregelFeature final : public application_features::ApplicationFeature {
   /// lazily at a time when other threads are already running and potentially trying to read the
   /// pointer. This only works because _recoveryManager is only initialzed once and lives until the
   /// owning PregelFeature instance is also destroyed.
-  std::atomic<RecoveryManager*> _recoveryManagerPtr;
+  std::atomic<RecoveryManager*> _recoveryManagerPtr{nullptr};
   std::unordered_map<uint64_t, std::pair<std::string, std::shared_ptr<Conductor>>> _conductors;
   std::unordered_map<uint64_t, std::pair<std::string, std::shared_ptr<IWorker>>> _workers;
 };


### PR DESCRIPTION
### Scope & Purpose

Fixes a missing initialization of `_recoveryManagerPtr` which could lead to random crashes.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *(please describe tests)*.
