### PR TITLE
Fix pregel lifetime management.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fixes pregel lifetime management. Previously shutting down the server while a
+  pregel job was still running could result in a segfault or a shutdown hanger.
+  
 * Log a proper message if an unexpected state is encountered when taking over
   shard leadership. In addition, make the change to the internal followerinfo 
   state atomic so that it cannot be semi-changed.

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -8357,16 +8357,17 @@ AqlValue Functions::PregelResult(ExpressionContext* expressionContext,
   }
 
   uint64_t execNr = arg1.toInt64();
-  std::shared_ptr<pregel::PregelFeature> feature = pregel::PregelFeature::instance();
-  if (!feature) {
+  auto& server = expressionContext->trx().vocbase().server();
+  if (!server.hasFeature<pregel::PregelFeature>()) {
     registerWarning(expressionContext, AFN, TRI_ERROR_FAILED);
     return AqlValue(AqlValueHintEmptyArray());
   }
+  pregel::PregelFeature& feature = server.getFeature<pregel::PregelFeature>();
 
   VPackBuffer<uint8_t> buffer;
   VPackBuilder builder(buffer);
   if (ServerState::instance()->isCoordinator()) {
-    std::shared_ptr<pregel::Conductor> c = feature->conductor(execNr);
+    std::shared_ptr<pregel::Conductor> c = feature.conductor(execNr);
     if (!c) {
       registerWarning(expressionContext, AFN, TRI_ERROR_HTTP_NOT_FOUND);
       return AqlValue(AqlValueHintEmptyArray());
@@ -8374,7 +8375,7 @@ AqlValue Functions::PregelResult(ExpressionContext* expressionContext,
     c->collectAQLResults(builder, withId);
 
   } else {
-    std::shared_ptr<pregel::IWorker> worker = feature->worker(execNr);
+    std::shared_ptr<pregel::IWorker> worker = feature.worker(execNr);
     if (!worker) {
       registerWarning(expressionContext, AFN, TRI_ERROR_HTTP_NOT_FOUND);
       return AqlValue(AqlValueHintEmptyArray());

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -683,14 +683,13 @@ void HeartbeatThread::getNewsFromAgencyForCoordinator() {
       ci.setFailedServers(failedServers);
       transaction::cluster::abortTransactionsWithFailedServers(ci);
 
-      std::shared_ptr<pregel::PregelFeature> prgl = pregel::PregelFeature::instance();
-      if (prgl) {
-        pregel::RecoveryManager* mngr = prgl->recoveryManager();
+      if (_server.hasFeature<pregel::PregelFeature>()) {
+        auto& pregel = _server.getFeature<pregel::PregelFeature>();
+        pregel::RecoveryManager* mngr = pregel.recoveryManager();
         if (mngr != nullptr) {
           mngr->updatedFailedServers(failedServers);
         }
       }
-
     } else {
       LOG_TOPIC("cd95f", WARN, Logger::HEARTBEAT)
           << "FailedServers is not an object. ignoring for now";

--- a/arangod/Pregel/AlgoRegistry.cpp
+++ b/arangod/Pregel/AlgoRegistry.cpp
@@ -85,12 +85,14 @@ IAlgorithm* AlgoRegistry::createAlgorithm(application_features::ApplicationServe
 template <typename V, typename E, typename M>
 /*static*/ std::shared_ptr<IWorker> AlgoRegistry::createWorker(TRI_vocbase_t& vocbase,
                                                                Algorithm<V, E, M>* algo,
-                                                               VPackSlice body) {
-  return std::make_shared<Worker<V, E, M>>(vocbase, algo, body);
+                                                               VPackSlice body,
+                                                               PregelFeature& feature) {
+  return std::make_shared<Worker<V, E, M>>(vocbase, algo, body, feature);
 }
 
 /*static*/ std::shared_ptr<IWorker> AlgoRegistry::createWorker(TRI_vocbase_t& vocbase,
-                                                               VPackSlice body) {
+                                                               VPackSlice body,
+                                                               PregelFeature& feature) {
   VPackSlice algoSlice = body.get(Utils::algorithmKey);
 
   if (!algoSlice.isString()) {
@@ -104,35 +106,35 @@ template <typename V, typename E, typename M>
 
   auto& server = vocbase.server();
   if (algorithm == "sssp") {
-    return createWorker(vocbase, new algos::SSSPAlgorithm(server, userParams), body);
+    return createWorker(vocbase, new algos::SSSPAlgorithm(server, userParams), body, feature);
   } else if (algorithm == "pagerank") {
-    return createWorker(vocbase, new algos::PageRank(server, userParams), body);
+    return createWorker(vocbase, new algos::PageRank(server, userParams), body, feature);
   } else if (algorithm == "recoveringpagerank") {
-    return createWorker(vocbase, new algos::RecoveringPageRank(server, userParams), body);
+    return createWorker(vocbase, new algos::RecoveringPageRank(server, userParams), body, feature);
   } else if (algorithm == "shortestpath") {
-    return createWorker(vocbase, new algos::ShortestPathAlgorithm(server, userParams), body);
+    return createWorker(vocbase, new algos::ShortestPathAlgorithm(server, userParams), body, feature);
   } else if (algorithm == "linerank") {
-    return createWorker(vocbase, new algos::LineRank(server, userParams), body);
+    return createWorker(vocbase, new algos::LineRank(server, userParams), body, feature);
   } else if (algorithm == "effectivecloseness") {
-    return createWorker(vocbase, new algos::EffectiveCloseness(server, userParams), body);
+    return createWorker(vocbase, new algos::EffectiveCloseness(server, userParams), body, feature);
   } else if (algorithm == "connectedcomponents") {
-    return createWorker(vocbase, new algos::ConnectedComponents(server, userParams), body);
+    return createWorker(vocbase, new algos::ConnectedComponents(server, userParams), body, feature);
   } else if (algorithm == "scc") {
-    return createWorker(vocbase, new algos::SCC(server, userParams), body);
+    return createWorker(vocbase, new algos::SCC(server, userParams), body, feature);
   } else if (algorithm == "asyncscc") {
-    return createWorker(vocbase, new algos::AsyncSCC(server, userParams), body);
+    return createWorker(vocbase, new algos::AsyncSCC(server, userParams), body, feature);
   } else if (algorithm == "hits") {
-    return createWorker(vocbase, new algos::HITS(server, userParams), body);
+    return createWorker(vocbase, new algos::HITS(server, userParams), body, feature);
   } else if (algorithm == "labelpropagation") {
-    return createWorker(vocbase, new algos::LabelPropagation(server, userParams), body);
+    return createWorker(vocbase, new algos::LabelPropagation(server, userParams), body, feature);
   } else if (algorithm == "slpa") {
-    return createWorker(vocbase, new algos::SLPA(server, userParams), body);
+    return createWorker(vocbase, new algos::SLPA(server, userParams), body, feature);
   } else if (algorithm == "dmid") {
-    return createWorker(vocbase, new algos::DMID(server, userParams), body);
+    return createWorker(vocbase, new algos::DMID(server, userParams), body, feature);
   } else if (algorithm == "wcc") {
-    return createWorker(vocbase, new algos::WCC(server, userParams), body);
+    return createWorker(vocbase, new algos::WCC(server, userParams), body, feature);
   } else if (algorithm == algos::accumulators::pregel_algorithm_name) {
-    return createWorker(vocbase, new algos::accumulators::ProgrammablePregelAlgorithm(server, userParams), body);
+    return createWorker(vocbase, new algos::accumulators::ProgrammablePregelAlgorithm(server, userParams), body, feature);
   }
 
   THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,

--- a/arangod/Pregel/AlgoRegistry.h
+++ b/arangod/Pregel/AlgoRegistry.h
@@ -32,15 +32,19 @@ struct TRI_vocbase_t;
 namespace arangodb {
 namespace pregel {
 
+class PregelFeature;
+
 struct AlgoRegistry {
   static IAlgorithm* createAlgorithm(application_features::ApplicationServer& server,
                                      std::string const& algorithm, VPackSlice userParams);
-  static std::shared_ptr<IWorker> createWorker(TRI_vocbase_t& vocbase, VPackSlice body);
+  static std::shared_ptr<IWorker> createWorker(TRI_vocbase_t& vocbase, VPackSlice body,
+                                               PregelFeature& feature);
 
  private:
   template <typename V, typename E, typename M>
   static std::shared_ptr<IWorker> createWorker(TRI_vocbase_t& vocbase,
-                                               Algorithm<V, E, M>* algo, VPackSlice body);
+                                               Algorithm<V, E, M>* algo, VPackSlice body,
+                                               PregelFeature& feature);
 };
 
 }  // namespace pregel

--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -64,8 +64,10 @@ Conductor::Conductor(uint64_t executionNumber, TRI_vocbase_t& vocbase,
                      std::vector<CollectionID> const& vertexCollections,
                      std::vector<CollectionID> const& edgeCollections,
                      std::unordered_map<std::string, std::vector<std::string>> const& edgeCollectionRestrictions,
-                     std::string const& algoName, VPackSlice const& config)
-    : _vocbaseGuard(vocbase),
+                     std::string const& algoName, VPackSlice const& config,
+                     PregelFeature& feature)
+    : _feature(feature),
+      _vocbaseGuard(vocbase),
       _executionNumber(executionNumber),
       _algorithm(AlgoRegistry::createAlgorithm(vocbase.server(), algoName, config)),
       _vertexCollections(vertexCollections),
@@ -149,6 +151,10 @@ void Conductor::start() {
 // only called by the conductor, is protected by the
 // mutex locked in finishedGlobalStep
 bool Conductor::_startGlobalStep() {
+  if (_feature.isStopping()) {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+  }
+
   _callbackMutex.assertLockedByCurrentThread();
   // send prepare GSS notice
   VPackBuilder b;
@@ -372,7 +378,7 @@ VPackBuilder Conductor::finishedWorkerStep(VPackSlice const& data) {
   Scheduler* scheduler = SchedulerFeature::SCHEDULER;
   // don't block the response for workers waiting on this callback
   // this should allow workers to go into the IDLE state
-  bool queued = scheduler->queue(RequestLane::INTERNAL_LOW, [this] {
+  bool queued = scheduler->queue(RequestLane::INTERNAL_LOW, [this, self = shared_from_this()] {
     MUTEX_LOCKER(guard, _callbackMutex);
 
     if (_state == ExecutionState::RUNNING) {
@@ -492,13 +498,12 @@ void Conductor::startRecovery() {
   // let's wait for a final state in the cluster
   bool queued = false;
   std::tie(queued, _workHandle) = SchedulerFeature::SCHEDULER->queueDelay(
-      RequestLane::CLUSTER_AQL, std::chrono::seconds(2), [this](bool cancelled) {
+      RequestLane::CLUSTER_AQL, std::chrono::seconds(2), [this, self = shared_from_this()](bool cancelled) {
         if (cancelled || _state != ExecutionState::RECOVERING) {
           return;  // seems like we are canceled
         }
         std::vector<ServerID> goodServers;
-        auto res =
-            PregelFeature::instance()->recoveryManager()->filterGoodServers(_dbServers, goodServers);
+        auto res = _feature.recoveryManager()->filterGoodServers(_dbServers, goodServers);
         if (res != TRI_ERROR_NO_ERROR) {
           LOG_TOPIC("3d08b", ERR, Logger::PREGEL)
               << "Recovery proceedings failed";
@@ -689,11 +694,10 @@ ErrorCode Conductor::_initializeWorkers(std::string const& suffix, VPackSlice ad
     // hack for single server
     if (ServerState::instance()->getRole() == ServerState::ROLE_SINGLE) {
       TRI_ASSERT(vertexMap.size() == 1);
-      std::shared_ptr<PregelFeature> feature = PregelFeature::instance();
-      if (!feature) {
+      if (_feature.isStopping()) {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
       }
-      std::shared_ptr<IWorker> worker = feature->worker(_executionNumber);
+      std::shared_ptr<IWorker> worker = _feature.worker(_executionNumber);
 
       if (worker) {
         THROW_ARANGO_EXCEPTION_MESSAGE(
@@ -701,11 +705,11 @@ ErrorCode Conductor::_initializeWorkers(std::string const& suffix, VPackSlice ad
             "a worker with this execution number already exists.");
       }
 
-      auto created = AlgoRegistry::createWorker(_vocbaseGuard.database(), b.slice());
+      auto created = AlgoRegistry::createWorker(_vocbaseGuard.database(), b.slice(), _feature);
 
       TRI_ASSERT(created.get() != nullptr);
-      feature->addWorker(std::move(created), _executionNumber);
-      worker = feature->worker(_executionNumber);
+      _feature.addWorker(std::move(created), _executionNumber);
+      worker = _feature.worker(_executionNumber);
       TRI_ASSERT(worker);
       worker->setupWorker();
 
@@ -751,12 +755,8 @@ ErrorCode Conductor::_finalizeWorkers() {
     _masterContext->postApplication();
   }
 
-  std::shared_ptr<PregelFeature> feature = PregelFeature::instance();
-  if (!feature) {
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
-  }
   // stop monitoring shards
-  RecoveryManager* mngr = feature->recoveryManager();
+  RecoveryManager* mngr = _feature.recoveryManager();
   if (mngr) {
     mngr->stopMonitoring(this);
   }
@@ -825,11 +825,8 @@ void Conductor::finishedWorkerFinalize(VPackSlice data) {
     auto* scheduler = SchedulerFeature::SCHEDULER;
     if (scheduler) {
       uint64_t exe = _executionNumber;
-      bool queued = scheduler->queue(RequestLane::CLUSTER_AQL, [exe] {
-        auto pf = PregelFeature::instance();
-        if (pf) {
-          pf->cleanupConductor(exe);
-        }
+      bool queued = scheduler->queue(RequestLane::CLUSTER_AQL, [this, exe, self = shared_from_this()] {
+        _feature.cleanupConductor(exe);
       });
       if (!queued) {
         LOG_TOPIC("038da", ERR, Logger::PREGEL)
@@ -909,26 +906,19 @@ ErrorCode Conductor::_sendToAllDBServers(std::string const& path, VPackBuilder c
   if (ServerState::instance()->isRunningInCluster() == false) {
     if (handle) {
       VPackBuilder response;
-
-      PregelFeature::handleWorkerRequest(_vocbaseGuard.database(), path,
-                                         message.slice(), response);
+      _feature.handleWorkerRequest(_vocbaseGuard.database(), path, message.slice(), response);
       handle(response.slice());
     } else {
       TRI_ASSERT(SchedulerFeature::SCHEDULER != nullptr);
       uint64_t exe = _executionNumber;
       Scheduler* scheduler = SchedulerFeature::SCHEDULER;
-      bool queued = scheduler->queue(RequestLane::INTERNAL_LOW, [path, message, exe] {
-        auto pf = PregelFeature::instance();
-        if (!pf) {
-          return;
-        }
-        auto conductor = pf->conductor(exe);
-        if (conductor) {
-          TRI_vocbase_t& vocbase = conductor->_vocbaseGuard.database();
-          VPackBuilder response;
-          PregelFeature::handleWorkerRequest(vocbase, path, message.slice(), response);
-        }
-      });
+      bool queued =
+          scheduler->queue(RequestLane::INTERNAL_LOW, [this, path, message, exe,
+                                                       self = shared_from_this()] {
+            TRI_vocbase_t& vocbase = _vocbaseGuard.database();
+            VPackBuilder response;
+            _feature.handleWorkerRequest(vocbase, path, message.slice(), response);
+          });
       if (!queued) {
         return TRI_ERROR_QUEUE_FULL;
       }

--- a/arangod/Pregel/Conductor.h
+++ b/arangod/Pregel/Conductor.h
@@ -29,8 +29,8 @@
 #include "Basics/asio_ns.h"
 #include "Basics/system-functions.h"
 #include "Cluster/ClusterInfo.h"
-#include "Pregel/Statistics.h"
 #include "Pregel/Reports.h"
+#include "Pregel/Statistics.h"
 #include "Scheduler/Scheduler.h"
 #include "Utils/DatabaseGuard.h"
 
@@ -58,10 +58,11 @@ struct Error {
   std::string message;
 };
 
-class Conductor {
+class Conductor : public std::enable_shared_from_this<Conductor> {
   friend class PregelFeature;
 
   ExecutionState _state = ExecutionState::DEFAULT;
+  PregelFeature& _feature;
   const DatabaseGuard _vocbaseGuard;
   const uint64_t _executionNumber;
   VPackBuilder _userParams;
@@ -82,8 +83,7 @@ class Conductor {
   std::unique_ptr<AggregatorHandler> _aggregators;
   std::unique_ptr<MasterContext> _masterContext;
   /// tracks the servers which responded, only used for stages where we expect
-  /// an
-  /// unique response, not necessarily during the async mode
+  /// an unique response, not necessarily during the async mode
   std::set<ServerID> _respondedServers;
   uint64_t _globalSuperstep = 0;
   /// adjustable maximum gss for some algorithms
@@ -130,7 +130,8 @@ class Conductor {
             std::vector<CollectionID> const& vertexCollections,
             std::vector<CollectionID> const& edgeCollections,
             std::unordered_map<std::string, std::vector<std::string>> const& edgeCollectionRestrictions,
-            std::string const& algoName, VPackSlice const& userConfig);
+            std::string const& algoName, VPackSlice const& userConfig,
+            PregelFeature& feature);
 
   ~Conductor();
 

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -70,8 +70,6 @@ struct NonDeleter {
   void operator()(arangodb::pregel::PregelFeature*) {}
 };
 
-std::shared_ptr<arangodb::pregel::PregelFeature> instance;
-
 }  // namespace
 
 using namespace arangodb;
@@ -83,13 +81,9 @@ std::pair<Result, uint64_t> PregelFeature::startExecution(
     std::vector<std::string> const& edgeCollections, 
     std::unordered_map<std::string, std::vector<std::string>> const& edgeCollectionRestrictions,
     VPackSlice const& params) {
-
-  // make sure no one removes the PregelFeature while in use
-  std::shared_ptr<PregelFeature> instance = ::instance;
-
-  if (!instance) {
-    return std::make_pair(Result{TRI_ERROR_INTERNAL,
-                                 "pregel system not ready"}, 0);
+  if (isStopping()) {
+    return std::make_pair(Result{TRI_ERROR_SHUTTING_DOWN,
+                                 "pregel system not available"}, 0);
   }
 
   ServerState* ss = ServerState::instance();
@@ -208,13 +202,13 @@ std::pair<Result, uint64_t> PregelFeature::startExecution(
     }
   }
 
-  uint64_t en = instance->createExecutionNumber();
+  uint64_t en = createExecutionNumber();
   auto c = std::make_shared<pregel::Conductor>(en, vocbase, vertexCollections,
                                                edgeColls, edgeCollectionRestrictions,
-                                               algorithm, params);
-  instance->addConductor(std::move(c), en);
-  TRI_ASSERT(instance->conductor(en));
-  instance->conductor(en)->start();
+                                               algorithm, params, *this);
+  addConductor(std::move(c), en);
+  TRI_ASSERT(conductor(en));
+  conductor(en)->start();
 
   return std::make_pair(Result{}, en);
 }
@@ -230,13 +224,9 @@ PregelFeature::PregelFeature(application_features::ApplicationServer& server)
 }
 
 PregelFeature::~PregelFeature() {
-  if (_recoveryManager) {
-    _recoveryManager.reset();
-  }
-  cleanupAll();
+  TRI_ASSERT(_conductors.empty());
+  TRI_ASSERT(_workers.empty());
 }
-
-std::shared_ptr<PregelFeature> PregelFeature::instance() { return ::instance; }
 
 size_t PregelFeature::availableParallelism() {
   const size_t procNum = NumberOfCores::getValue();
@@ -259,18 +249,49 @@ void PregelFeature::start() {
 }
 
 void PregelFeature::beginShutdown() {
-  cleanupAll();
+  TRI_ASSERT(isStopping());
+  
+  MUTEX_LOCKER(guard, _mutex);
+  // cancel all conductors and workers
+  for (auto& it : _conductors) {
+    it.second.second->cancel();
+  }
+  for (auto it : _workers) {
+    it.second.second->cancelGlobalStep(VPackSlice());
+  }
 }
 
 void PregelFeature::stop() {}
 
 void PregelFeature::unprepare() {
-  ::instance.reset();
+  MUTEX_LOCKER(guard, _mutex);
+  decltype(_conductors) cs = std::move(_conductors);
+  decltype(_workers) ws = std::move(_workers);
+  guard.unlock();
+
+  // all pending tasks should have been finished by now, and all references
+  // to conductors and workers been dropped!
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  for (auto& it : cs) {
+    TRI_ASSERT(it.second.second.use_count() == 1);
+  }
+  
+  for (auto it : _workers) {
+    TRI_ASSERT(it.second.second.use_count() == 1);
+  }
+#endif
+}
+
+bool PregelFeature::isStopping() const noexcept {
+  return server().isStopping();
 }
 
 void PregelFeature::addConductor(std::shared_ptr<Conductor>&& c, uint64_t executionNumber) {
+  if (isStopping()) {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+  }
+  
   std::string user = ExecContext::current().user();
-
   MUTEX_LOCKER(guard, _mutex);
   _conductors.try_emplace(executionNumber,
                       std::move(user), std::move(c));
@@ -283,8 +304,11 @@ std::shared_ptr<Conductor> PregelFeature::conductor(uint64_t executionNumber) {
 }
 
 void PregelFeature::addWorker(std::shared_ptr<IWorker>&& w, uint64_t executionNumber) {
+  if (isStopping()) {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+  }
+  
   std::string user = ExecContext::current().user();
-
   MUTEX_LOCKER(guard, _mutex);
   _workers.try_emplace(executionNumber,
                    std::move(user), std::move(w));
@@ -302,17 +326,10 @@ void PregelFeature::cleanupConductor(uint64_t executionNumber) {
 }
 
 void PregelFeature::cleanupWorker(uint64_t executionNumber) {
-  // make sure no one removes the PregelFeature while in use
-  std::shared_ptr<PregelFeature> instance = ::instance;
-
-  if (!instance) {
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
-  }
-
   // unmapping etc might need a few seconds
   TRI_ASSERT(SchedulerFeature::SCHEDULER != nullptr);
   Scheduler* scheduler = SchedulerFeature::SCHEDULER;
-  bool queued = scheduler->queue(RequestLane::INTERNAL_LOW, [this, executionNumber, instance] {
+  bool queued = scheduler->queue(RequestLane::INTERNAL_LOW, [this, executionNumber] {
     MUTEX_LOCKER(guard, _mutex);
     _workers.erase(executionNumber);
   });
@@ -322,31 +339,12 @@ void PregelFeature::cleanupWorker(uint64_t executionNumber) {
   }
 }
 
-void PregelFeature::cleanupAll() {
-  MUTEX_LOCKER(guard, _mutex);
-  decltype(_conductors) cs = std::move(_conductors);
-  decltype(_workers) ws = std::move(_workers);
-  guard.unlock();
-
-  // cleanup all workers & conductors without holding the lock    
-  cs.clear();
-  for (auto it : ws) {
-    it.second.second->cancelGlobalStep(VPackSlice());
-  }
-}
-
-/* static */ void PregelFeature::handleConductorRequest(TRI_vocbase_t& vocbase,
-                                                        std::string const& path,
-                                                        VPackSlice const& body,
-                                                        VPackBuilder& outBuilder) {
-  if (vocbase.server().isStopping()) {
+void PregelFeature::handleConductorRequest(TRI_vocbase_t& vocbase,
+                                           std::string const& path,
+                                           VPackSlice const& body,
+                                           VPackBuilder& outBuilder) {
+  if (isStopping()) {
     return;  // shutdown ongoing
-  }
-
-  // make sure no one removes the PregelFeature while in use
-  std::shared_ptr<PregelFeature> instance = ::instance;
-  if (!instance) {
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
   }
 
   VPackSlice sExecutionNum = body.get(Utils::executionNumberKey);
@@ -359,7 +357,7 @@ void PregelFeature::cleanupAll() {
   } else if (sExecutionNum.isString()) {
     exeNum = basics::StringUtils::uint64(sExecutionNum.copyString());
   }
-  std::shared_ptr<Conductor> co = instance->conductor(exeNum);
+  std::shared_ptr<Conductor> co = conductor(exeNum);
   if (!co) {
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_CURSOR_NOT_FOUND, "Conductor not found, invalid execution number: " + std::to_string(exeNum));
@@ -376,18 +374,12 @@ void PregelFeature::cleanupAll() {
   }
 }
 
-/*static*/ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
-                                                   std::string const& path,
-                                                   VPackSlice const& body,
-                                                   VPackBuilder& outBuilder) {
-  if (vocbase.server().isStopping() && path != Utils::finalizeExecutionPath) {
+void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
+                                        std::string const& path,
+                                        VPackSlice const& body,
+                                        VPackBuilder& outBuilder) {
+  if (isStopping() && path != Utils::finalizeExecutionPath) {
     return;  // shutdown ongoing
-  }
-
-  // make sure no one removes the PregelFeature while in use
-  std::shared_ptr<PregelFeature> instance = ::instance;
-  if (!instance) {
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
   }
 
   VPackSlice sExecutionNum = body.get(Utils::executionNumberKey);
@@ -398,7 +390,7 @@ void PregelFeature::cleanupAll() {
   }
 
   uint64_t exeNum = sExecutionNum.getUInt();
-  std::shared_ptr<IWorker> w = instance->worker(exeNum);
+  std::shared_ptr<IWorker> w = worker(exeNum);
 
   // create a new worker instance if necessary
   if (path == Utils::startExecutionPath) {
@@ -408,17 +400,16 @@ void PregelFeature::cleanupAll() {
           "Worker with this execution number already exists.");
     }
 
-    instance->addWorker(AlgoRegistry::createWorker(vocbase, body), exeNum);
-    instance->worker(exeNum)->setupWorker();  // will call conductor
+    addWorker(AlgoRegistry::createWorker(vocbase, body, *this), exeNum);
+    worker(exeNum)->setupWorker();  // will call conductor
 
     return;
   } else if (path == Utils::startRecoveryPath) {
     if (!w) {
-      instance->addWorker(AlgoRegistry::createWorker(vocbase, body), exeNum);
+      addWorker(AlgoRegistry::createWorker(vocbase, body, *this), exeNum);
     }
 
-    instance->worker(exeNum)->startRecovery(body);
-
+    worker(exeNum)->startRecovery(body);
     return;
   } else if (!w) {
     // any other call should have a working worker instance
@@ -438,8 +429,8 @@ void PregelFeature::cleanupAll() {
   } else if (path == Utils::cancelGSSPath) {
     w->cancelGlobalStep(body);
   } else if (path == Utils::finalizeExecutionPath) {
-    w->finalizeExecution(body, [exeNum, instance]() {
-      instance->cleanupWorker(exeNum);
+    w->finalizeExecution(body, [this, exeNum]() {
+      cleanupWorker(exeNum);
     });
   } else if (path == Utils::continueRecoveryPath) {
     w->compensateStep(body);

--- a/arangod/Pregel/Worker.h
+++ b/arangod/Pregel/Worker.h
@@ -43,6 +43,8 @@ namespace arangodb {
 class RestPregelHandler;
 
 namespace pregel {
+  
+class PregelFeature;
 
 class IWorker : public std::enable_shared_from_this<IWorker> {
  public:
@@ -88,7 +90,8 @@ class Worker : public IWorker {
     DONE         // after calling finished
   };
 
-  WorkerState _state = WorkerState::DEFAULT;
+  PregelFeature& _feature;
+  std::atomic<WorkerState> _state = WorkerState::DEFAULT;
   WorkerConfig _config;
   uint64_t _expectedGSS = 0;
   uint32_t _messageBatchSize = 500;
@@ -146,7 +149,7 @@ class Worker : public IWorker {
                                   std::function<void(VPackSlice slice)> handle);
 
  public:
-  Worker(TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algorithm, VPackSlice params);
+  Worker(TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algorithm, VPackSlice params, PregelFeature& feature);
   ~Worker();
 
   // ====== called by rest handler =====

--- a/arangod/RestHandler/RestControlPregelHandler.h
+++ b/arangod/RestHandler/RestControlPregelHandler.h
@@ -26,6 +26,10 @@
 #include "RestHandler/RestVocbaseBaseHandler.h"
 
 namespace arangodb {
+
+namespace pregel {
+  class PregelFeature;
+}
 class RestControlPregelHandler : public arangodb::RestVocbaseBaseHandler {
  public:
   RestControlPregelHandler(application_features::ApplicationServer&,
@@ -43,6 +47,8 @@ class RestControlPregelHandler : public arangodb::RestVocbaseBaseHandler {
   void startExecution();
   void getExecutionStatus();
   void cancelExecution();
+
+  pregel::PregelFeature& _pregel;
 };
 }  // namespace arangodb
 

--- a/arangod/RestHandler/RestPregelHandler.cpp
+++ b/arangod/RestHandler/RestPregelHandler.cpp
@@ -39,7 +39,7 @@ using namespace arangodb::pregel;
 
 RestPregelHandler::RestPregelHandler(application_features::ApplicationServer& server,
                                      GeneralRequest* request, GeneralResponse* response)
-    : RestVocbaseBaseHandler(server, request, response) {}
+    : RestVocbaseBaseHandler(server, request, response), _pregel(server.getFeature<PregelFeature>()) {}
 
 RestStatus RestPregelHandler::execute() {
   try {
@@ -61,10 +61,10 @@ RestStatus RestPregelHandler::execute() {
       generateError(rest::ResponseCode::BAD, TRI_ERROR_NOT_IMPLEMENTED,
                     "you are missing a prefix");
     } else if (suffix[0] == Utils::conductorPrefix) {
-      PregelFeature::handleConductorRequest(_vocbase, suffix[1], body, response);
+      _pregel.handleConductorRequest(_vocbase, suffix[1], body, response);
       generateResult(rest::ResponseCode::OK, response.slice());
     } else if (suffix[0] == Utils::workerPrefix) {
-      PregelFeature::handleWorkerRequest(_vocbase, suffix[1], body, response);
+      _pregel.handleWorkerRequest(_vocbase, suffix[1], body, response);
 
       generateResult(rest::ResponseCode::OK, response.slice());
     } else {

--- a/arangod/RestHandler/RestPregelHandler.h
+++ b/arangod/RestHandler/RestPregelHandler.h
@@ -26,6 +26,10 @@
 #include "RestHandler/RestVocbaseBaseHandler.h"
 
 namespace arangodb {
+  
+namespace pregel {
+  class PregelFeature;
+}
 class RestPregelHandler : public arangodb::RestVocbaseBaseHandler {
  public:
   explicit RestPregelHandler(application_features::ApplicationServer&,
@@ -35,6 +39,9 @@ class RestPregelHandler : public arangodb::RestVocbaseBaseHandler {
   RestStatus execute() override;
   char const* name() const override { return "Pregel Rest Handler"; }
   RequestLane lane() const override final { return RequestLane::CLIENT_SLOW; }
+  
+ private:
+  pregel::PregelFeature& _pregel;
 };
 }  // namespace arangodb
 

--- a/arangod/V8Server/v8-collection.cpp
+++ b/arangod/V8Server/v8-collection.cpp
@@ -1660,7 +1660,8 @@ static void JS_PregelStart(v8::FunctionCallbackInfo<v8::Value> const& args) {
   }
 
   auto& vocbase = GetContextVocBase(isolate);
-  auto res = pregel::PregelFeature::startExecution(vocbase, algorithm, paramVertices,
+  auto& pregel = vocbase.server().getFeature<arangodb::pregel::PregelFeature>();
+  auto res = pregel.startExecution(vocbase, algorithm, paramVertices,
                                                    paramEdges, paramEdgeCollectionRestrictions,
                                                    paramBuilder.slice());
   if (res.first.fail()) {
@@ -1684,13 +1685,14 @@ static void JS_PregelStatus(v8::FunctionCallbackInfo<v8::Value> const& args) {
     TRI_V8_THROW_EXCEPTION_USAGE("_pregelStatus(<executionNum>]");
   }
 
-  std::shared_ptr<pregel::PregelFeature> feature = pregel::PregelFeature::instance();
-  if (feature == nullptr) {
+  auto& vocbase = GetContextVocBase(isolate);
+  if (!vocbase.server().hasFeature<arangodb::pregel::PregelFeature>()) {
     TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_FAILED, "pregel is not enabled");
   }
+  auto& pregel = vocbase.server().getFeature<arangodb::pregel::PregelFeature>();
 
   uint64_t executionNum = TRI_ObjectToUInt64(isolate, args[0], true);
-  auto c = feature->conductor(executionNum);
+  auto c = pregel.conductor(executionNum);
   if (!c) {
     TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_CURSOR_NOT_FOUND,
                                    "Execution number is invalid");
@@ -1712,13 +1714,14 @@ static void JS_PregelCancel(v8::FunctionCallbackInfo<v8::Value> const& args) {
     TRI_V8_THROW_EXCEPTION_USAGE("_pregelCancel(<executionNum>)");
   }
 
-  std::shared_ptr<pregel::PregelFeature> feature = pregel::PregelFeature::instance();
-  if (feature == nullptr) {
+  auto& vocbase = GetContextVocBase(isolate);
+  if (!vocbase.server().hasFeature<arangodb::pregel::PregelFeature>()) {
     TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_FAILED, "pregel is not enabled");
   }
+  auto& pregel = vocbase.server().getFeature<arangodb::pregel::PregelFeature>();
 
   uint64_t executionNum = TRI_ObjectToUInt64(isolate, args[0], true);
-  auto c = feature->conductor(executionNum);
+  auto c = pregel.conductor(executionNum);
   if (!c) {
     TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_CURSOR_NOT_FOUND,
                                    "Execution number is invalid");
@@ -1745,14 +1748,15 @@ static void JS_PregelAQLResult(v8::FunctionCallbackInfo<v8::Value> const& args) 
     withId = TRI_ObjectToBoolean(isolate, args[1]);
   }
 
-  std::shared_ptr<pregel::PregelFeature> feature = pregel::PregelFeature::instance();
-  if (feature == nullptr) {
+  auto& vocbase = GetContextVocBase(isolate);
+  if (!vocbase.server().hasFeature<arangodb::pregel::PregelFeature>()) {
     TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_FAILED, "pregel is not enabled");
   }
+  auto& pregel = vocbase.server().getFeature<arangodb::pregel::PregelFeature>();
 
   uint64_t executionNum = TRI_ObjectToUInt64(isolate, args[0], true);
   if (ServerState::instance()->isSingleServerOrCoordinator()) {
-    auto c = feature->conductor(executionNum);
+    auto c = pregel.conductor(executionNum);
     if (!c) {
       TRI_V8_THROW_EXCEPTION_USAGE("Execution number is invalid");
     }


### PR DESCRIPTION
### Scope & Purpose

Fixes pregel lifetime management. Previously shutting down the server while a pregel job was still running could result in a segfault or a shutdown hanger.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

Needs to be discussed whether this should be backported to 3.8.

- [ ] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *shell_client*.
