### PR TITLE
Shard synchronization improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Improve error reporting for Merkle tree operations and improve memory usage
+  for unused trees by hibernating them. In addition, add some backoff to shard
+  synchronization in case there are repeated sync failures for the same shard.
+
 * Updated bundled version of Snappy library to 1.1.9.
 
 * Fixed various issues (mainly data races) reported by ThreadSanitizer.

--- a/arangod/Cluster/ActionBase.cpp
+++ b/arangod/Cluster/ActionBase.cpp
@@ -112,6 +112,7 @@ ActionDescription const& ActionBase::describe() const { return _description; }
 MaintenanceFeature& ActionBase::feature() const { return _feature; }
 
 VPackSlice const ActionBase::properties() const {
+  TRI_ASSERT(_description.properties() != nullptr);
   return _description.properties()->slice();
 }
 

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -851,10 +851,9 @@ AgencyCache& ClusterFeature::agencyCache() {
 
 
 void ClusterFeature::allocateMembers() {
-  _agencyCallbackRegistry.reset(new AgencyCallbackRegistry(server(), agencyCallbacksPath()));
+  _agencyCallbackRegistry = std::make_unique<AgencyCallbackRegistry>(server(), agencyCallbacksPath());
   _clusterInfo = std::make_unique<ClusterInfo>(server(), _agencyCallbackRegistry.get(), _syncerShutdownCode);
-  _agencyCache =
-    std::make_unique<AgencyCache>(server(), *_agencyCallbackRegistry, _syncerShutdownCode);
+  _agencyCache = std::make_unique<AgencyCache>(server(), *_agencyCallbackRegistry, _syncerShutdownCode);
 }
 
 void ClusterFeature::addDirty(std::unordered_set<std::string> const& databases, bool callNotify) {
@@ -872,7 +871,7 @@ void ClusterFeature::addDirty(std::unordered_set<std::string> const& databases, 
   }
 }
 
-void ClusterFeature::addDirty(std::unordered_map<std::string,std::shared_ptr<VPackBuilder>> const& databases) {
+void ClusterFeature::addDirty(std::unordered_map<std::string, std::shared_ptr<VPackBuilder>> const& databases) {
   if (databases.size() > 0) {
     MUTEX_LOCKER(guard, _dirtyLock);
     bool addedAny = false;

--- a/arangod/Cluster/DropCollection.cpp
+++ b/arangod/Cluster/DropCollection.cpp
@@ -80,6 +80,11 @@ bool DropCollection::first() {
         LOG_TOPIC("03e2f", DEBUG, Logger::MAINTENANCE)
           << "Dropping local collection " + shard;
         result(Collections::drop(*coll, false, 2.5));
+
+        // it is safe here to clear our replication failure statistics even
+        // if the collection could not be dropped. the drop attempt alone
+        // should be reason enough to zero our stats
+        _feature.removeReplicationError(vocbase.name(), shard);
       } else {
         std::stringstream error;
 

--- a/arangod/Cluster/DropDatabase.cpp
+++ b/arangod/Cluster/DropDatabase.cpp
@@ -78,6 +78,8 @@ bool DropDatabase::first() {
                                      << " failed: " << res.errorMessage();
       return false;
     }
+    _feature.removeDBError(database);
+    _feature.removeReplicationError(database);
   } catch (std::exception const& e) {
     std::stringstream error;
     error << "action " << _description << " failed with exception " << e.what();

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -826,6 +826,8 @@ arangodb::Result arangodb::maintenance::executePlan(
     if (!action->isRunEvenIfDuplicate()) {
       feature.addAction(std::move(action), false);
     } else {
+      TRI_ASSERT(action->has(SHARD));
+
       std::string shardName = action->get(SHARD);
       bool ok = feature.lockShard(shardName, action);
       TRI_ASSERT(ok);
@@ -1611,7 +1613,7 @@ void arangodb::maintenance::syncReplicatedShardsWithLeaders(
         if (indexOf(cservers, serverId) > 0) {
           continue;
         }
-
+       
         std::string leader = pservers[0].copyString();
         std::shared_ptr<ActionDescription> description = std::make_shared<ActionDescription>(
           std::map<std::string, std::string>{

--- a/arangod/Cluster/MaintenanceFeature.cpp
+++ b/arangod/Cluster/MaintenanceFeature.cpp
@@ -860,6 +860,83 @@ arangodb::Result MaintenanceFeature::storeIndexError(
   return Result();
 }
 
+/// @brief remove all replication errors for all shards of the database
+void MaintenanceFeature::removeReplicationError(std::string const& database) {
+  MUTEX_LOCKER(guard, _replLock);
+  _replErrors.erase(database);
+}
+
+/// @brief remove all replication errors for the shard in the database
+void MaintenanceFeature::removeReplicationError(std::string const& database, std::string const& shard) {
+  MUTEX_LOCKER(guard, _replLock);
+  
+  auto it = _replErrors.find(database);
+  if (it == _replErrors.end()) {
+    return;
+  }
+
+  (*it).second.erase(shard);
+}
+
+/// @brief store a replication error for the shard in the database.
+/// we currently don't store the exact error for simplicity reasons.
+/// all we do here is to store a _timestamp_ of the last x errors per
+/// shard, so that we can calculate the number of errors in a given
+/// time period.
+void MaintenanceFeature::storeReplicationError(
+    std::string const& database, std::string const& shard) {
+
+  auto now = std::chrono::steady_clock::now();
+
+  MUTEX_LOCKER(guard, _replLock);
+  // this may create the new entries on-the-fly
+  auto& bucket = _replErrors[database][shard];
+  size_t n = bucket.size();
+
+  // clean up existing bucket data while we are already on it
+  bucket.erase(std::remove_if(bucket.begin(), bucket.end(), [&](auto const& value) {
+    if (n >= maxReplicationErrorsPerShard ||
+        value < now - maxReplicationErrorsPerShardAge) {
+      // too many values. delete the first x OR entry too old
+      --n;
+      return true;
+    } 
+    // keep all the rest
+    return false;
+  }), bucket.end());
+
+  TRI_ASSERT(bucket.size() == n);
+  bucket.emplace_back(now);
+  TRI_ASSERT(bucket.size() <= maxReplicationErrorsPerShard);
+}
+
+/// @brief return the number of replication errors for a particular shard.
+/// note: we will return only those errors which happened not longer than
+/// maxReplicationErrorsPerShardAge  ago
+size_t MaintenanceFeature::replicationErrors(std::string const& database,   
+                                             std::string const& shard) const {
+  auto since = std::chrono::steady_clock::now() - maxReplicationErrorsPerShardAge;
+
+  MUTEX_LOCKER(guard, _replLock);
+
+  auto it = _replErrors.find(database);
+  if (it == _replErrors.end()) {
+    // no errors recorded for database, 
+    return 0;
+  }
+
+  auto it2 = (*it).second.find(shard);
+  if (it2 == (*it).second.end()) {
+    // no errors recorded for shard
+    return 0;
+  }
+  
+  auto& bucket = (*it2).second;
+  return std::count_if(bucket.begin(), bucket.end(), [&](auto const& value) {
+    return value >= since;
+  });
+}
+
 template <typename T>
 std::ostream& operator<<(std::ostream& os, std::set<T> const& st) {
   size_t j = 0;

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -665,6 +665,72 @@ bool SynchronizeShard::first() {
   std::string planId = _description.get(COLLECTION);
   std::string const& shard = getShard();
   std::string leader = _description.get(THE_LEADER);
+ 
+  size_t failuresInRow = feature().replicationErrors(database, shard);
+  
+  // from this many number of failures in a row, we will step on the brake
+  constexpr size_t delayThreshold = 4;
+
+  TRI_IF_FAILURE("SynchronizeShard::maxReplicationErrors") {
+    // simulate we have got lots of failures
+    failuresInRow = MaintenanceFeature::maxReplicationErrorsPerShard;
+  }
+  
+  TRI_IF_FAILURE("SynchronizeShard::someReplicationErrors") {
+    // simulate we have got some failures
+    failuresInRow = delayThreshold;
+  }
+
+  
+  if (failuresInRow >= MaintenanceFeature::maxReplicationErrorsPerShard) { 
+    auto& df = _feature.server().getFeature<DatabaseFeature>();
+    DatabaseGuard guard(df, database);
+    auto vocbase = &guard.database();
+    
+    auto collection = vocbase->lookupCollection(shard);
+    if (collection != nullptr) {
+      LOG_TOPIC("7a2cf", WARN, Logger::MAINTENANCE)
+          << "SynchronizeShard: synchronizing shard '" << database << "/" << shard
+          << "' for central '" << database << "/" << planId << "' encountered "
+          << failuresInRow << " failures in a row. now dropping follower shard for "
+          << "a full rebuild";
+
+      // remove all recorded failures, so in next run we can start with a clean state
+      _feature.removeReplicationError(getDatabase(), getShard());
+
+      // drop shard (💥)
+      methods::Collections::drop(*collection, false, 3.0); 
+      result(TRI_ERROR_REPLICATION_WRONG_CHECKSUM);
+      return false;
+    }
+  }
+
+  if (failuresInRow >= delayThreshold) {
+    // shard synchronization has failed several times in a row.
+    // now step on the brake a bit. this blocks our maintenance thread, but currently
+    // there seems to be no better way to delay the execution of maintenance tasks.
+    double sleepTime = 2.0 + 0.1 * (failuresInRow * (failuresInRow + 1) / 2);
+
+    sleepTime = std::min<double>(sleepTime, 15.0);
+    
+    LOG_TOPIC("40376", INFO, Logger::MAINTENANCE)
+        << "SynchronizeShard: synchronizing shard '" << database << "/" << shard
+        << "' for central '" << database << "/" << planId << "' encountered "
+        << failuresInRow << " failures in a row. delaying next sync by " 
+        << sleepTime << " s";
+
+    while (sleepTime > 0.0) {
+      if (feature().server().isStopping()) {
+        result(TRI_ERROR_SHUTTING_DOWN);
+        return false;
+      }
+       
+      constexpr double sleepPerRound = 0.5;
+      // sleep only for up to 0.5 seconds at a time so we can react quickly to shutdown
+      std::this_thread::sleep_for(std::chrono::duration<double>(std::min(sleepTime, sleepPerRound)));
+      sleepTime -= sleepPerRound;
+    }
+  }
 
   LOG_TOPIC("fa651", DEBUG, Logger::MAINTENANCE)
       << "SynchronizeShard: synchronizing shard '" << database << "/" << shard
@@ -1170,8 +1236,8 @@ Result SynchronizeShard::catchupWithExclusiveLock(
       // no change happened due to recalculation. now try recounting on leader too.
       // this is last resort and should not happen often!
       LOG_TOPIC("3dc64", INFO, Logger::MAINTENANCE) 
-         << "recalculating collection count on leader for "
-         << getDatabase() << "/" << getShard();
+          << "recalculating collection count on leader for "
+          << getDatabase() << "/" << getShard();
 
       VPackBuffer<uint8_t> buffer;
       VPackBuilder tmp(buffer);
@@ -1179,15 +1245,40 @@ Result SynchronizeShard::catchupWithExclusiveLock(
 
       network::RequestOptions options;
       options.database = getDatabase();
-      options.timeout = network::Timeout(600.0);  // this can be slow!!!
+      options.timeout = network::Timeout(900.0);  // this can be slow!!!
       options.skipScheduler = true;  // hack to speed up future.get()
 
       std::string const url = "/_api/collection/" + collection.name() + "/recalculateCount";
 
-      auto response = network::sendRequest(pool, ep, fuerte::RestVerb::Put,
-                                           url, std::move(buffer), options)
-                          .get();
-      auto result = response.combinedResult();
+      // send out the request
+      auto future = network::sendRequest(pool, ep, fuerte::RestVerb::Put,
+                                         url, std::move(buffer), options);
+        
+      // while the request is pending, rebuild the revision tree for our local collection
+      {
+        LOG_TOPIC("04c25", INFO, Logger::MAINTENANCE) 
+            << "rebuilding revision tree on follower for shard " 
+            << getDatabase() << "/" << getShard();
+    
+        double start = TRI_microtime();
+        Result result = collection.getPhysical()->rebuildRevisionTree();
+        
+        if (result.fail()) {
+          LOG_TOPIC("92233", WARN, Logger::MAINTENANCE) 
+              << "unable to rebuild revision tree on follower for shard " 
+              << getDatabase() << "/" << getShard() << ": " << result.errorMessage();
+          // still go on...
+        }
+
+        LOG_TOPIC("1c9e7", INFO, Logger::MAINTENANCE) 
+            << "rebuilt revision tree on follower for shard " 
+            << getDatabase() << "/" << getShard() << ": " << result.errorMessage() 
+            << ", took: " << (TRI_microtime() - start) << "s";
+      }
+
+      network::Response const& r = future.get();
+
+      Result result = r.combinedResult();
 
       if (result.fail()) {
         auto const errorMessage = StringUtils::concatT(
@@ -1198,7 +1289,7 @@ Result SynchronizeShard::catchupWithExclusiveLock(
         LOG_TOPIC("22e0b", WARN, Logger::MAINTENANCE) << errorMessage;
         return arangodb::Result(result.errorNumber(), std::move(errorMessage));
       } else {
-        auto const resultSlice = response.slice();
+        auto const resultSlice = r.slice();
         if (VPackSlice c = resultSlice.get("count"); c.isNumber()) {
           LOG_TOPIC("bc26d", DEBUG, Logger::MAINTENANCE) << "leader's shard count response is " << c.getNumber<uint64_t>();
         }
@@ -1239,6 +1330,13 @@ void SynchronizeShard::setState(ActionState state) {
     if (COMPLETE == state) {
       LOG_TOPIC("50827", INFO, Logger::MAINTENANCE)
         << "SynchronizeShard: synchronization completed for shard " << getDatabase() << "/" << getShard();
+    
+      // because we succeeded now, we can wipe out all past failures
+      _feature.removeReplicationError(getDatabase(), getShard());
+    } else {
+      TRI_ASSERT(FAILED == state);
+      // increase failure counter for this shard
+      _feature.storeReplicationError(getDatabase(), getShard());
     }
 
     // Acquire current version from agency and wait for it to have been dealt

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -1418,8 +1418,7 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(arangodb::LogicalCo
 
   // diff with local tree
   //std::pair<std::size_t, std::size_t> fullRange = treeLeader->range();
-  std::unique_ptr<containers::RevisionTree> treeLocal =
-      physical->revisionTree(*trx);
+  auto treeLocal = physical->revisionTree(*trx);
   if (!treeLocal) {
     // local collection does not support syncing by revision, fall back to keys
     guard.fire();

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1379,8 +1379,9 @@ Result RestReplicationHandler::processRestoreData(std::string const& colName) {
   }
 #endif
 
-  bool const generateNewRevisionIds =
-      !_request->parsedValue(StaticStrings::PreserveRevisionIds, false);
+  // always regenerate revision ids on restore, so that we cannot run into
+  // any trouble with non-conforming revision-id ranges
+  constexpr bool generateNewRevisionIds = true;
 
   ExecContextSuperuserScope escope(
       ExecContext::current().isSuperuser() ||

--- a/arangod/RocksDBEngine/RocksDBBackgroundThread.cpp
+++ b/arangod/RocksDBEngine/RocksDBBackgroundThread.cpp
@@ -73,9 +73,13 @@ void RocksDBBackgroundThread::run() {
         }
 
         double end = TRI_microtime();
-        if ((end - start) > 0.75) {
+        if (end - start > 5.0) {
           LOG_TOPIC("3ad54", WARN, Logger::ENGINES)
               << "slow background settings sync: " << Logger::FIXED(end - start, 6)
+              << " s";
+        } else {
+          LOG_TOPIC("dd9ea", DEBUG, Logger::ENGINES)
+              << "slow background settings sync took: " << Logger::FIXED(end - start, 6)
               << " s";
         }
       }

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -920,7 +920,9 @@ void RocksDBEngine::stop() {
     if (_settingsManager) {
       try {
         _settingsManager->sync(true);
-      } catch (...) {
+      } catch (std::exception const& ex) {
+        LOG_TOPIC("0582f", WARN, Logger::ENGINES)
+          << "caught exception while shutting down RocksDB engine: " << ex.what();
       }
     }
 

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -918,7 +918,10 @@ void RocksDBEngine::stop() {
     _backgroundThread->beginShutdown();
 
     if (_settingsManager) {
-      _settingsManager->sync(true);
+      try {
+        _settingsManager->sync(true);
+      } catch (...) {
+      }
     }
 
     // wait until background thread stops

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -333,31 +333,39 @@ void RocksDBMetaCollection::setRevisionTree(std::unique_ptr<containers::Revision
                                             uint64_t seq) {
   TRI_ASSERT(_logicalCollection.useSyncByRevision());
   TRI_ASSERT(_logicalCollection.syncByRevision());
-  TRI_ASSERT(tree);
+  TRI_ASSERT(tree != nullptr);
+  TRI_ASSERT(tree->maxDepth() == revisionTreeDepth);
+  
   std::unique_lock<std::mutex> guard(_revisionTreeLock);
-  _revisionTree = std::move(tree);
+  _revisionTree = std::make_unique<RevisionTreeAccessor>(std::move(tree), _logicalCollection);
   _revisionTreeApplied.store(seq);
   _revisionTreeCreationSeq = seq;
   _revisionTreeSerializedSeq = seq;
 }
 
-std::unique_ptr<containers::RevisionTree> RocksDBMetaCollection::revisionTree(transaction::Methods& trx) {
+std::unique_ptr<containers::RevisionTree> RocksDBMetaCollection::revisionTree(
+    std::function<std::unique_ptr<containers::RevisionTree>(std::unique_ptr<containers::RevisionTree>)> const& callback) {
   if (!_logicalCollection.useSyncByRevision()) {
     return nullptr;
   }
 
-  // first apply any updates that can be safely applied
   RocksDBEngine& engine =
       _logicalCollection.vocbase().server().getFeature<EngineSelectorFeature>().engine<RocksDBEngine>();
   rocksdb::DB* db = engine.db()->GetRootDB();
+
+  // first apply any updates that can be safely applied
   rocksdb::SequenceNumber safeSeq = meta().committableSeq(db->GetLatestSequenceNumber());
 
   std::unique_lock<std::mutex> guard(_revisionTreeLock);
+
   if (!_revisionTree && !haveBufferedOperations()) {
-    return allocateEmptyRevisionTree();  // collection empty
+    // we only need to return an empty tree here.
+    return allocateEmptyRevisionTree(revisionTreeDepth); 
   }
 
   applyUpdates(safeSeq);
+  TRI_ASSERT(_revisionTree != nullptr);
+  TRI_ASSERT(_revisionTree->maxDepth() == revisionTreeDepth);
 
   // now clone the tree so we can apply all updates consistent with our ongoing trx
   auto tree = _revisionTree->clone();
@@ -365,7 +373,11 @@ std::unique_ptr<containers::RevisionTree> RocksDBMetaCollection::revisionTree(tr
     return nullptr;
   }
 
-  {
+  return callback(std::move(tree));
+}
+
+std::unique_ptr<containers::RevisionTree> RocksDBMetaCollection::revisionTree(transaction::Methods& trx) {
+  return revisionTree([this, &trx](std::unique_ptr<containers::RevisionTree> tree) -> std::unique_ptr<containers::RevisionTree> {
     // apply any which are buffered and older than our ongoing transaction start
     rocksdb::SequenceNumber trxSeq = RocksDBTransactionState::toState(&trx)->beginSeq();
     TRI_ASSERT(trxSeq != 0);
@@ -373,45 +385,23 @@ std::unique_ptr<containers::RevisionTree> RocksDBMetaCollection::revisionTree(tr
     if (res.fail()) {
       return nullptr;
     }
-  }
 
-  {
     // now peek at updates buffered inside transaction and apply those too
     auto operations = RocksDBTransactionState::toState(&trx)->trackedOperations(
         _logicalCollection.id());
+        
     tree->insert(operations.inserts);
     tree->remove(operations.removals);
-  }
 
-  return tree;
+    return tree;
+  });
 }
 
 std::unique_ptr<containers::RevisionTree> RocksDBMetaCollection::revisionTree(uint64_t batchId) {
-  if (!_logicalCollection.useSyncByRevision()) {
-    return nullptr;
-  }
+  return revisionTree([this, batchId](std::unique_ptr<containers::RevisionTree> tree) -> std::unique_ptr<containers::RevisionTree> {
+    RocksDBEngine& engine =
+        _logicalCollection.vocbase().server().getFeature<EngineSelectorFeature>().engine<RocksDBEngine>();
 
-  EngineSelectorFeature& selector =
-      _logicalCollection.vocbase().server().getFeature<EngineSelectorFeature>();
-  // first apply any updates that can be safely applied
-  RocksDBEngine& engine = selector.engine<RocksDBEngine>();
-  rocksdb::DB* db = engine.db()->GetRootDB();
-  rocksdb::SequenceNumber safeSeq = meta().committableSeq(db->GetLatestSequenceNumber());
-
-  std::unique_lock<std::mutex> guard(_revisionTreeLock);
-  if (!_revisionTree && !haveBufferedOperations()) {
-    return allocateEmptyRevisionTree();  // collection empty
-  }
-
-  applyUpdates(safeSeq);
-
-  // now clone the tree so we can apply all updates consistent with our ongoing trx
-  auto tree = _revisionTree->clone();
-  if (!tree) {
-    return nullptr;
-  }
-
-  {
     // apply any which are buffered and older than our ongoing transaction start
     RocksDBReplicationManager* manager = engine.replicationManager();
     RocksDBReplicationContext* ctx = batchId == 0 ? nullptr : manager->find(batchId);
@@ -425,9 +415,9 @@ std::unique_ptr<containers::RevisionTree> RocksDBMetaCollection::revisionTree(ui
     if (res.fail()) {
       return nullptr;
     }
-  }
 
-  return tree;
+    return tree;
+  });
 }
 
 bool RocksDBMetaCollection::needToPersistRevisionTree(rocksdb::SequenceNumber maxCommitSeq) const {
@@ -466,9 +456,10 @@ bool RocksDBMetaCollection::needToPersistRevisionTree(rocksdb::SequenceNumber ma
 }
 
 rocksdb::SequenceNumber RocksDBMetaCollection::lastSerializedRevisionTree(rocksdb::SequenceNumber maxCommitSeq) {
+  rocksdb::SequenceNumber seq = maxCommitSeq;
+
   // first update so we don't under-report
   std::unique_lock<std::mutex> guard(_revisionBufferLock);
-  rocksdb::SequenceNumber seq = maxCommitSeq;
 
   // limit to before any pending buffered updates
 
@@ -501,11 +492,17 @@ rocksdb::SequenceNumber RocksDBMetaCollection::lastSerializedRevisionTree(rocksd
 rocksdb::SequenceNumber RocksDBMetaCollection::serializeRevisionTree(
     std::string& output, rocksdb::SequenceNumber commitSeq, bool force) {
   std::unique_lock<std::mutex> guard(_revisionTreeLock);
+
   if (_logicalCollection.useSyncByRevision()) {
     if (!_revisionTree && !haveBufferedOperations()) {  // empty collection
       return commitSeq;
     }
     applyUpdates(commitSeq);  // always apply updates...
+ 
+    // applyUpdates will make sure we will have a valid tree
+    TRI_ASSERT(_revisionTree != nullptr);
+    TRI_ASSERT(_revisionTree->maxDepth() == revisionTreeDepth);
+
     bool neverDone = _revisionTreeSerializedSeq == _revisionTreeCreationSeq;
     bool coinFlip = RandomGenerator::interval(static_cast<uint32_t>(5)) == 0;
     bool beenTooLong = 30 < std::chrono::duration_cast<std::chrono::seconds>(
@@ -515,7 +512,7 @@ rocksdb::SequenceNumber RocksDBMetaCollection::serializeRevisionTree(
       return _revisionTreeSerializedSeq;
     }
     if (force || neverDone || coinFlip || beenTooLong) {  // ...but only write the tree out sometimes
-      _revisionTree->serializeBinary(output, true);
+      _revisionTree->serializeBinary(output);
       _revisionTreeSerializedSeq = commitSeq;
       _revisionTreeSerializedTime = std::chrono::steady_clock::now();
     }
@@ -527,56 +524,84 @@ rocksdb::SequenceNumber RocksDBMetaCollection::serializeRevisionTree(
   return commitSeq;
 }
 
+ResultT<std::pair<std::unique_ptr<containers::RevisionTree>, rocksdb::SequenceNumber>> RocksDBMetaCollection::revisionTreeFromCollection() {
+  auto ctxt = transaction::StandaloneContext::Create(_logicalCollection.vocbase());
+  SingleCollectionTransaction trx(ctxt, _logicalCollection, AccessMode::Type::READ);
+
+  Result res = trx.begin();
+  if (res.fail()) {
+    LOG_TOPIC("d1e53", WARN, arangodb::Logger::ENGINES)
+        << "failed to begin transaction to rebuild revision tree "
+           "for collection '"
+        << _logicalCollection.id().id() << "'";
+    return res;
+  }
+
+  auto* state = RocksDBTransactionState::toState(&trx);
+
+  auto iter = getReplicationIterator(ReplicationIterator::Ordering::Revision, trx);
+  if (!iter) {
+    LOG_TOPIC("d1e54", WARN, arangodb::Logger::ENGINES)
+        << "failed to retrieve replication iterator to rebuild revision tree "
+           "for collection '"
+        << _logicalCollection.id().id() << "'";
+    return Result(TRI_ERROR_INTERNAL);
+  }
+  RevisionReplicationIterator& it =
+      *static_cast<RevisionReplicationIterator*>(iter.get());
+  
+  std::vector<std::uint64_t> revisions;
+  revisions.resize(1024);
+  
+  auto newTree = allocateEmptyRevisionTree(revisionTreeDepth);
+  
+  while (it.hasMore()) {
+    revisions.emplace_back(it.revision().id());
+    if (revisions.size() >= 4096) {  // arbitrary batch size
+      newTree->insert(revisions);
+      revisions.clear();
+    
+      if (_logicalCollection.vocbase().server().isStopping()) {
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+      }
+    }
+    it.next();
+  }
+  if (!revisions.empty()) {
+    newTree->insert(revisions);
+  }
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  newTree->checkConsistency();
+#endif
+
+  return std::make_pair(std::move(newTree), state->beginSeq());
+}
+
 Result RocksDBMetaCollection::rebuildRevisionTree() {
   return basics::catchToResult([this]() -> Result {
     std::unique_lock<std::mutex> guard(_revisionTreeLock);
-    auto ctxt = transaction::StandaloneContext::Create(_logicalCollection.vocbase());
-    SingleCollectionTransaction trx(ctxt, _logicalCollection, AccessMode::Type::READ);
-    Result res = trx.begin();
-    if (res.fail()) {
-      LOG_TOPIC("d1e53", WARN, arangodb::Logger::ENGINES)
-          << "failed to begin transaction to rebuild revision tree "
-             "for collection '"
-          << _logicalCollection.id().id() << "'";
-      return res;
+    
+    auto result = revisionTreeFromCollection();
+    if (result.fail()) {
+      return result.result(); 
     }
-    auto* state = RocksDBTransactionState::toState(&trx);
 
-    std::vector<std::uint64_t> revisions;
-    auto iter = getReplicationIterator(ReplicationIterator::Ordering::Revision, trx);
-    if (!iter) {
-      LOG_TOPIC("d1e54", WARN, arangodb::Logger::ENGINES)
-          << "failed to retrieve replication iterator to rebuild revision tree "
-             "for collection '"
-          << _logicalCollection.id().id() << "'";
-      return Result(TRI_ERROR_INTERNAL);
-    }
-    RevisionReplicationIterator& it =
-        *static_cast<RevisionReplicationIterator*>(iter.get());
-    auto newTree = allocateEmptyRevisionTree();
-    while (it.hasMore()) {
-      revisions.emplace_back(it.revision().id());
-      if (revisions.size() >= 5000) {  // arbitrary batch size
-        newTree->insert(revisions);
-        revisions.clear();
-      }
-      it.next();
-    }
-    if (!revisions.empty()) {
-      newTree->insert(revisions);
-    }
-    _revisionTree = std::move(newTree);
-    _revisionTreeApplied = state->beginSeq();
-    _revisionTreeCreationSeq = state->beginSeq();
-    _revisionTreeSerializedSeq = state->beginSeq();
-    return Result();
+    auto&& [newTree, beginSeq] = result.get();
+
+    _revisionTree = std::make_unique<RevisionTreeAccessor>(std::move(newTree), _logicalCollection);
+    _revisionTreeApplied = beginSeq;
+    _revisionTreeCreationSeq = beginSeq;
+    _revisionTreeSerializedSeq = beginSeq;
+  
+    return {};
   });
 }
 
 void RocksDBMetaCollection::rebuildRevisionTree(std::unique_ptr<rocksdb::Iterator>& iter) {
-  std::unique_lock<std::mutex> guard(_revisionTreeLock);
+  auto newTree = allocateEmptyRevisionTree(revisionTreeDepth);
 
-  _revisionTree = allocateEmptyRevisionTree();
+  std::unique_lock<std::mutex> guard(_revisionTreeLock);
 
   // okay, we are in recovery and can't open a transaction, so we need to
   // read the raw RocksDB data; on the plus side, we are in recovery, so we
@@ -592,40 +617,75 @@ void RocksDBMetaCollection::rebuildRevisionTree(std::unique_ptr<rocksdb::Iterato
   ro.iterate_upper_bound = &end;
   ro.fill_cache = false;
 
-  std::vector<std::uint64_t> revisions;
   auto& selector =
       _logicalCollection.vocbase().server().getFeature<EngineSelectorFeature>();
   auto& engine = selector.engine<RocksDBEngine>();
   auto* db = engine.db();
+  
+  std::vector<std::uint64_t> revisions;
+  revisions.reserve(1024);
+  
   for (iter->Seek(documentBounds.start());
        iter->Valid() && cmp->Compare(iter->key(), end) < 0; iter->Next()) {
     LocalDocumentId const docId = RocksDBKey::documentId(iter->key());
     revisions.emplace_back(docId.id());
-    if (revisions.size() >= 5000) {  // arbitrary batch size
-      _revisionTree->insert(revisions);
+    if (revisions.size() >= 4096) {  // arbitrary batch size
+      newTree->insert(revisions);
       revisions.clear();
+        
+      if (_logicalCollection.vocbase().server().isStopping()) {
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+      }
     }
   }
   if (!revisions.empty()) {
-    _revisionTree->insert(revisions);
+    newTree->insert(revisions);
   }
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    newTree->checkConsistency();
+#endif
+
   rocksdb::SequenceNumber seq = db->GetLatestSequenceNumber();
+  _revisionTree = std::make_unique<RevisionTreeAccessor>(std::move(newTree), _logicalCollection);
   _revisionTreeApplied.store(seq);
   _revisionTreeCreationSeq = seq;
   _revisionTreeSerializedSeq = seq;
 }
 
-void RocksDBMetaCollection::revisionTreeSummary(VPackBuilder& builder) {
+void RocksDBMetaCollection::revisionTreeSummary(VPackBuilder& builder, bool fromCollection) {
   if (!_logicalCollection.useSyncByRevision()) {
     return;
   }
 
-  std::unique_lock<std::mutex> guard(_revisionTreeLock);
-  if (_revisionTree) {
-    VPackObjectBuilder obj(&builder);
-    obj->add(StaticStrings::RevisionTreeCount, VPackValue(_revisionTree->count()));
-    obj->add(StaticStrings::RevisionTreeHash, VPackValue(_revisionTree->rootValue()));
+  uint64_t count = 0;
+  uint64_t hash = 0;
+
+  if (fromCollection) {
+    // rebuild a temporary tree from the collection
+    auto result = revisionTreeFromCollection();
+
+    if (result.fail()) {
+      THROW_ARANGO_EXCEPTION(result.result());
+    }
+
+    auto&& [tree, beginSeq] = result.get();
+
+    count = tree->count();
+    hash = tree->rootValue();
+  } else {
+    // use existing revision tree
+    std::unique_lock<std::mutex> guard(_revisionTreeLock);
+
+    if (_revisionTree != nullptr) {
+      count = _revisionTree->count();
+      hash = _revisionTree->rootValue();
+    }
   }
+  
+  VPackObjectBuilder obj(&builder);
+  obj->add(StaticStrings::RevisionTreeCount, VPackValue(count));
+  obj->add(StaticStrings::RevisionTreeHash, VPackValue(hash));
 }
 
 void RocksDBMetaCollection::placeRevisionTreeBlocker(TransactionId transactionId) {
@@ -657,6 +717,7 @@ void RocksDBMetaCollection::bufferUpdates(rocksdb::SequenceNumber seq,
     return;
   }
 
+
   TRI_ASSERT(!inserts.empty() || !removals.empty());
 
   std::unique_lock<std::mutex> guard(_revisionBufferLock);
@@ -683,41 +744,45 @@ Result RocksDBMetaCollection::bufferTruncate(rocksdb::SequenceNumber seq) {
   return res;
 }
 
+void RocksDBMetaCollection::hibernateRevisionTree() {
+  std::unique_lock<std::mutex> guard(_revisionTreeLock);
+
+  if (_revisionTree && !haveBufferedOperations()) {
+    _revisionTree->hibernate();
+  }
+}
+
 void RocksDBMetaCollection::applyUpdates(rocksdb::SequenceNumber commitSeq) {
-  if (!_logicalCollection.useSyncByRevision()) {
-    return;
-  }
+  // should have _revisionTreeLock held outside
+    
+  TRI_ASSERT(_logicalCollection.useSyncByRevision());
+  TRI_ASSERT(_revisionTree || haveBufferedOperations());
 
-  if (!_revisionTree && !haveBufferedOperations()) {
-    return;  // collection empty
-  }
-
-  bool haveTree = ensureRevisionTree();
-  if (!haveTree) {
-    return;
-  }
+  // make sure we will have a _revisionTree ready after this
+  ensureRevisionTree();
+  TRI_ASSERT(_revisionTree != nullptr);
+  TRI_ASSERT(_revisionTree->maxDepth() == revisionTreeDepth);
 
   Result res = basics::catchVoidToResult([&]() -> void {
-    decltype(_revisionInsertBuffers)::const_iterator insertIt;
-    decltype(_revisionRemovalBuffers)::const_iterator removeIt;
-    {
-      std::unique_lock<std::mutex> guard(_revisionBufferLock);
-      insertIt = _revisionInsertBuffers.begin();
-      removeIt = _revisionRemovalBuffers.begin();
-    }
+    std::unique_lock<std::mutex> guard(_revisionBufferLock);
 
+    auto insertIt = _revisionInsertBuffers.begin();
+    auto removeIt = _revisionRemovalBuffers.begin();
+
+    auto it = _revisionTruncateBuffer.begin();  // sorted ASC
+    
     {
+      // check for a truncate marker
       rocksdb::SequenceNumber ignoreSeq = 0;  // truncate will increase this sequence
       bool foundTruncate = false;
-      // check for a truncate marker
-      std::unique_lock<std::mutex> guard(_revisionBufferLock);
-      auto it = _revisionTruncateBuffer.begin();  // sorted ASC
+
       while (it != _revisionTruncateBuffer.end() && *it <= commitSeq) {
         ignoreSeq = *it;
         TRI_ASSERT(ignoreSeq != 0);
         foundTruncate = true;
         it = _revisionTruncateBuffer.erase(it);
       }
+
       if (foundTruncate) {
         TRI_ASSERT(ignoreSeq <= commitSeq);
         while (insertIt != _revisionInsertBuffers.end() && insertIt->first <= ignoreSeq) {
@@ -726,56 +791,115 @@ void RocksDBMetaCollection::applyUpdates(rocksdb::SequenceNumber commitSeq) {
         while (removeIt != _revisionRemovalBuffers.end() && removeIt->first <= ignoreSeq) {
           removeIt = _revisionRemovalBuffers.erase(removeIt);
         }
-        _revisionTree->clear();  // clear out any revision structure, now empty
+      
+        TRI_ASSERT(insertIt == _revisionInsertBuffers.begin() || insertIt == _revisionInsertBuffers.end());
+        TRI_ASSERT(removeIt == _revisionRemovalBuffers.begin() || removeIt == _revisionRemovalBuffers.end());
+
+        // we can clear the revision tree without holding the mutex here
+        guard.unlock();
+        // clear out any revision structure, now empty
+        _revisionTree->clear();
+
+        guard.lock();
       }
     }
 
+    // still holding the mutex here
+
     while (true) {
-      std::vector<std::uint64_t> inserts;
-      std::vector<std::uint64_t> removals;
-      // find out if we have buffers to apply
-      {
-        bool haveInserts = insertIt != _revisionInsertBuffers.end() &&
-                           insertIt->first <= commitSeq;
-        bool haveRemovals = removeIt != _revisionRemovalBuffers.end() &&
-                            removeIt->first <= commitSeq;
+      // find out if we still have buffers to apply
+      TRI_ASSERT(insertIt == _revisionInsertBuffers.begin() || insertIt == _revisionInsertBuffers.end());
+      TRI_ASSERT(removeIt == _revisionRemovalBuffers.begin() || removeIt == _revisionRemovalBuffers.end());
 
-        bool applyInserts =
+      bool haveInserts = insertIt != _revisionInsertBuffers.end() &&
+                         insertIt->first <= commitSeq;
+      bool haveRemovals = removeIt != _revisionRemovalBuffers.end() &&
+                          removeIt->first <= commitSeq;
+
+      bool applyInserts =
             haveInserts && (!haveRemovals || removeIt->first >= insertIt->first);
-        bool applyRemovals = haveRemovals && !applyInserts;
-
-        // check for inserts
-        if (applyInserts) {
-          std::unique_lock<std::mutex> guard(_revisionBufferLock);
-          inserts = std::move(insertIt->second);
-          insertIt = _revisionInsertBuffers.erase(insertIt);
-        }
-        // check for removals
-        if (applyRemovals) {
-          std::unique_lock<std::mutex> guard(_revisionBufferLock);
-          removals = std::move(removeIt->second);
-          removeIt = _revisionRemovalBuffers.erase(removeIt);
-        }
-      }
-
+      bool applyRemovals = haveRemovals && !applyInserts;
+  
       // no inserts or removals left to apply, drop out of loop
-      if (inserts.empty() && removals.empty()) {
+      if (!applyInserts && !applyRemovals) {
         break;
       }
+     
+      // another concurrent thread may insert new elements into _revisionInsertBuffers or 
+      // _revisionRemovalBuffers while we are here.
+      // it is safe for us to access the elements pointed to by insertIt and removeIt here 
+      // without holding the lock on these containers though, because of std::multimap's
+      // iterator invalidation rules:
+      // - emplace / insert: No iterators or references are invalidated.
+      // - erase: References and iterators to the erased elements are invalidated. Other references and iterators are not affected.
+      
+      // check for inserts
+      if (applyInserts) {
+        TRI_ASSERT(!applyRemovals);
+      
+        // release the mutex while we modify the tree. this is safe (see above)
+        guard.unlock();
 
-      // apply inserts
-      if (!inserts.empty()) {
-        _revisionTree->insert(inserts);
-        inserts.clear();
+        TRI_IF_FAILURE("RevisionTree::applyInserts") {
+          THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
+        }
+
+        // apply inserts, without holding the lock
+        // if this throws we will not have modified _revisionInsertBuffers
+        try {
+          _revisionTree->insert(insertIt->second);
+        } catch (std::exception const& ex) {
+          // it is pretty bad if this fails, so we want to see it in our tests
+          // and not overlook it.
+          LOG_TOPIC("27811", ERR, Logger::ENGINES)
+              << "unable to apply revision tree updates for " 
+              << _logicalCollection.vocbase().name() << "/" << _logicalCollection.name() 
+              << ": " << ex.what();
+          TRI_ASSERT(false);
+          throw;
+        }
+
+        // move iterator forward, we need the mutex for this
+        guard.lock();
+        insertIt = _revisionInsertBuffers.erase(insertIt);
       }
 
-      // apply removals
-      if (!removals.empty()) {
-        _revisionTree->remove(removals);
-        removals.clear();
+      // check for removals
+      if (applyRemovals) {
+        TRI_ASSERT(!applyInserts);
+        
+        // release the mutex while we modify the tree. this is safe (see above)
+        guard.unlock();
+        
+        TRI_IF_FAILURE("RevisionTree::applyRemoves") {
+          THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
+        }
+
+        // apply removals, without holding the lock
+        // if this throws we will not have modified _revisionRemovalBuffers
+        try {
+          _revisionTree->remove(removeIt->second);
+        } catch (...) {
+          // this should never fail
+          TRI_ASSERT(false);
+          throw;
+        }
+
+        // move iterator forward, we need the mutex for this
+        guard.lock();
+        removeIt = _revisionRemovalBuffers.erase(removeIt);
       }
     }
   });
+
+  if (res.fail()) {
+    LOG_TOPIC("fdfa7", ERR, Logger::ENGINES)
+        << "unable to apply revision tree updates for " 
+        << _logicalCollection.vocbase().name() << "/" << _logicalCollection.name() 
+        << ": " << res.errorMessage();
+    return;
+  }
+  
   rocksdb::SequenceNumber applied = _revisionTreeApplied.load();
   while (commitSeq > applied) {
     _revisionTreeApplied.compare_exchange_strong(applied, commitSeq);
@@ -785,7 +909,7 @@ void RocksDBMetaCollection::applyUpdates(rocksdb::SequenceNumber commitSeq) {
 Result RocksDBMetaCollection::applyUpdatesForTransaction(containers::RevisionTree& tree,
                                                          rocksdb::SequenceNumber commitSeq) const {
   if (!_logicalCollection.useSyncByRevision()) {
-    return Result();
+    return {};
   }
 
   Result res = basics::catchVoidToResult([&]() -> void {
@@ -930,9 +1054,7 @@ ErrorCode RocksDBMetaCollection::doLock(double timeout, AccessMode::Type mode) {
 }
 
 bool RocksDBMetaCollection::haveBufferedOperations() const {
-  if (!_logicalCollection.useSyncByRevision()) {
-    return false;
-  }
+  TRI_ASSERT(_logicalCollection.useSyncByRevision());
 
   std::unique_lock<std::mutex> guard(_revisionBufferLock);
 
@@ -954,81 +1076,178 @@ bool RocksDBMetaCollection::haveBufferedOperations() const {
   return false;
 }
 
-std::size_t RocksDBMetaCollection::revisionTreeDepth() const {
-  std::size_t const treeCount = _revisionTree ? _revisionTree->count() : 0;
-  std::size_t bufferInserts = 0;
-  std::size_t bufferRemovals = 0;
-  {
-    std::unique_lock<std::mutex> guard(_revisionBufferLock);
-
-    rocksdb::SequenceNumber ignoreSeq = 0;
-    if (!_revisionTruncateBuffer.empty()) {
-      auto it = _revisionTruncateBuffer.rbegin();
-      if (it != _revisionTruncateBuffer.rend()) {
-        ignoreSeq = *it;
-      }
-    }
-
-    for (auto& pair : _revisionInsertBuffers) {
-      if (pair.first <= ignoreSeq) {
-        continue;
-      }
-
-      bufferInserts += pair.second.size();
-    }
-
-    for (auto& pair : _revisionRemovalBuffers) {
-      if (pair.first <= ignoreSeq) {
-        continue;
-      }
-
-      bufferRemovals += pair.second.size();
-    }
-  }
-
-  constexpr std::size_t minDepth = 3;
-  constexpr std::size_t maxDepth = 6;
-  std::size_t const treeDepth = _revisionTree ? _revisionTree->maxDepth() : minDepth;
-
-  if (treeDepth < maxDepth && bufferInserts > bufferRemovals) {
-    std::size_t const count = treeCount + bufferInserts - bufferRemovals;
-    std::size_t targetDepth = treeDepth;
-    while (targetDepth < maxDepth &&
-           count > 8 * containers::RevisionTree::nodeCountAtDepth(targetDepth)) {
-      ++targetDepth;
-    }
-    return targetDepth;
-  }
-
-  return treeDepth;
-}
-
-std::unique_ptr<containers::RevisionTree> RocksDBMetaCollection::allocateEmptyRevisionTree() const {
+std::unique_ptr<containers::RevisionTree> RocksDBMetaCollection::allocateEmptyRevisionTree(std::size_t depth) const {
   // should have _revisionTreeLock held outside
-  return std::make_unique<containers::RevisionTree>(
-      revisionTreeDepth(), _logicalCollection.minRevision().id());
+  return std::make_unique<containers::RevisionTree>(depth, _logicalCollection.minRevision().id());
 }
 
-bool RocksDBMetaCollection::ensureRevisionTree() {
-  try {
-    if (_revisionTree) {
-      std::size_t targetDepth = revisionTreeDepth();
-      if (_revisionTree->maxDepth() < targetDepth) {
-        // grow tree
-        auto newTree = _revisionTree->cloneWithDepth(targetDepth);
-        _revisionTree = std::move(newTree);
-      }
-      return true;
-    }
+void RocksDBMetaCollection::ensureRevisionTree() {
+  // should have _revisionTreeLock held outside
+  if (_revisionTree == nullptr) {
     auto& selector =
         _logicalCollection.vocbase().server().getFeature<EngineSelectorFeature>();
     auto& engine = selector.engine<RocksDBEngine>();
+
+    auto newTree = allocateEmptyRevisionTree(revisionTreeDepth);
+    TRI_ASSERT(newTree->maxDepth() == revisionTreeDepth);
+
+    _revisionTree = std::make_unique<RevisionTreeAccessor>(std::move(newTree), _logicalCollection);
     _revisionTreeCreationSeq = engine.db()->GetLatestSequenceNumber();
     _revisionTreeSerializedSeq = _revisionTreeCreationSeq;
-    _revisionTree = allocateEmptyRevisionTree();
-    return true;
-  } catch (...) {
-    _revisionTree.reset();  // should be unnecessary, but just in case
-    return false;
+  }
+
+  TRI_ASSERT(_revisionTree != nullptr);
+  TRI_ASSERT(_revisionTree->maxDepth() == revisionTreeDepth);
+}
+
+/// @brief construct from revision tree
+RocksDBMetaCollection::RevisionTreeAccessor::RevisionTreeAccessor(std::unique_ptr<containers::RevisionTree> tree,
+                                                                  LogicalCollection const& collection) 
+    : _tree(std::move(tree)),
+      _logicalCollection(collection),
+      _maxDepth(_tree->maxDepth()),
+      _hibernationRequests(0),
+      _compressible(true) {
+  TRI_ASSERT(_maxDepth == revisionTreeDepth);
+}
+
+void RocksDBMetaCollection::RevisionTreeAccessor::insert(std::vector<std::uint64_t> const& keys) {
+  ensureTree();
+  _tree->insert(keys);
+}
+
+void RocksDBMetaCollection::RevisionTreeAccessor::remove(std::vector<std::uint64_t> const& keys) {
+  ensureTree();
+  _tree->remove(keys);
+}
+
+void RocksDBMetaCollection::RevisionTreeAccessor::clear() {
+  ensureTree();
+  _tree->clear();
+  _compressible = true;
+}
+    
+std::unique_ptr<containers::RevisionTree> RocksDBMetaCollection::RevisionTreeAccessor::clone() const {
+  ensureTree();
+  return _tree->clone();
+}
+
+std::uint64_t RocksDBMetaCollection::RevisionTreeAccessor::count() const {
+  ensureTree();
+  return _tree->count();
+}
+
+std::uint64_t RocksDBMetaCollection::RevisionTreeAccessor::rootValue() const {
+  ensureTree();
+  return _tree->rootValue();
+}
+
+std::uint64_t RocksDBMetaCollection::RevisionTreeAccessor::maxDepth() const {
+  return _maxDepth;
+}
+
+void RocksDBMetaCollection::RevisionTreeAccessor::checkConsistency() const {
+  ensureTree();
+  return _tree->checkConsistency();
+}
+
+void RocksDBMetaCollection::RevisionTreeAccessor::hibernate() {
+  if (_tree == nullptr) {
+    // already compressed, nothing to do
+    TRI_ASSERT(!_compressed.empty());
+    return;
+  }
+
+  std::uint64_t count = _tree->count();
+
+  if (count >= 5'000'000) {
+    // we have so many values in the tree that compressibility
+    // will likely be bad
+    return;
+  }
+  
+  if (count >= 1'000'000 && !_compressible) {
+    // for whatever reason this collection is not well compressible
+    return;
+  }
+  
+  if (++_hibernationRequests < 10) {
+    // sit out the first few hibernation requests before we
+    // actually work (10 is just an arbitrary value here to avoid
+    // some pathologic hibernation/resurrection cycles, e.g. by
+    // the statistics collections)
+    return;
+  }
+
+  double start = TRI_microtime();
+  
+  _compressed.clear();
+  _tree->serializeBinary(_compressed, true);
+
+  TRI_ASSERT(!_compressed.empty());
+ 
+  LOG_TOPIC("45eae", DEBUG, Logger::REPLICATION) 
+      << "hibernating revision tree for "
+      << _logicalCollection.vocbase().name() << "/" << _logicalCollection.name()
+      << " with " << count << " entries and size " 
+      << _tree->byteSize() << ", hibernated size: " << _compressed.size() 
+      << ", hibernation took: " << (TRI_microtime() - start);;
+
+  // we would like to see at least 50% compressibility
+  if (_compressed.size() * 2 < _tree->byteSize()) {
+    // compression ratio ok.
+    // remove tree from memory. now we only have _compressed
+    _tree.reset();
+    _compressible = true;
+  } else {
+    // otherwise we'll keep the uncompressed tree, and will
+    // not try compressing again soon
+    _compressed.clear();
+    _compressed.shrink_to_fit();
+    _compressible = false;
   }
 }
+
+void RocksDBMetaCollection::RevisionTreeAccessor::serializeBinary(std::string& output) const {
+  if (_tree != nullptr) {
+    // compress tree into output
+    _tree->serializeBinary(output, true);
+  } else {
+    // append our already compressed state
+    output.append(_compressed);
+  }
+}
+
+// unfortunately we need to declare this method const although it can
+// modify internal (mutable) state
+void RocksDBMetaCollection::RevisionTreeAccessor::ensureTree() const {
+  if (_tree == nullptr) {
+    // build tree from compressed state
+    TRI_ASSERT(!_compressed.empty());
+
+    double start = TRI_microtime();
+
+    _tree = containers::RevisionTree::fromBuffer(std::string_view(_compressed));
+
+    if (_tree == nullptr) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "unable to uncompress tree");
+    }
+
+    // reset hibernation counter
+    _hibernationRequests = 0;
+
+    TRI_ASSERT(_tree->maxDepth() == _maxDepth);
+    
+    LOG_TOPIC("e9c29", DEBUG, Logger::REPLICATION) 
+        << "resurrected revision tree for " 
+        << _logicalCollection.vocbase().name() << "/" << _logicalCollection.name()
+        << " with " << _tree->count() << " entries. resurrection took: " 
+        << (TRI_microtime() - start);
+
+    // clear the compressed state and free the associated memory
+    _compressed.clear();
+    _compressed.shrink_to_fit();
+  }
+  TRI_ASSERT(_tree != nullptr);
+}
+

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.h
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.h
@@ -27,12 +27,15 @@
 
 #include "Basics/Common.h"
 #include "Basics/ReadWriteLock.h"
+#include "Basics/ResultT.h"
 #include "Containers/MerkleTree.h"
 #include "RocksDBEngine/RocksDBCommon.h"
 #include "RocksDBEngine/RocksDBMetadata.h"
 #include "StorageEngine/PhysicalCollection.h"
 #include "VocBase/AccessMode.h"
 #include "VocBase/LogicalCollection.h"
+
+#include <functional>
 
 namespace arangodb {
 
@@ -53,6 +56,7 @@ class RocksDBMetaCollection : public PhysicalCollection {
   uint64_t objectId() const { return _objectId.load(); }
 
   RocksDBMetadata& meta() { return _meta; }
+  RocksDBMetadata const& meta() const { return _meta; }
 
   RevisionId revision(arangodb::transaction::Methods* trx) const override final;
   uint64_t numberDocuments(transaction::Methods* trx) const override final;
@@ -85,7 +89,7 @@ class RocksDBMetaCollection : public PhysicalCollection {
   Result rebuildRevisionTree() override;
   void rebuildRevisionTree(std::unique_ptr<rocksdb::Iterator>& iter);
 
-  void revisionTreeSummary(VPackBuilder& builder);
+  void revisionTreeSummary(VPackBuilder& builder, bool fromCollection);
 
   void placeRevisionTreeBlocker(TransactionId transactionId) override;
   void removeRevisionTreeBlocker(TransactionId transactionId) override;
@@ -106,16 +110,19 @@ class RocksDBMetaCollection : public PhysicalCollection {
 
   Result bufferTruncate(rocksdb::SequenceNumber seq);
 
- public:
-  /// return bounds for all documents
+  /// @brief sends the collection's revision tree to hibernation
+  void hibernateRevisionTree();
+
+  /// @brief return bounds for all documents
   virtual RocksDBKeyBounds bounds() const = 0;
+  
+  /// @brief produce a revision tree from the documents in the collection
+  ResultT<std::pair<std::unique_ptr<containers::RevisionTree>, rocksdb::SequenceNumber>> revisionTreeFromCollection();
   
  protected:
   
   /// @brief track the usage of waitForSync option in an operation
   void trackWaitForSync(arangodb::transaction::Methods* trx, OperationOptions& options);
-
-  void applyUpdates(rocksdb::SequenceNumber commitSeq);
 
   Result applyUpdatesForTransaction(containers::RevisionTree& tree,
                                     rocksdb::SequenceNumber commitSeq) const;
@@ -123,9 +130,13 @@ class RocksDBMetaCollection : public PhysicalCollection {
  private:
   ErrorCode doLock(double timeout, AccessMode::Type mode);
   bool haveBufferedOperations() const;
-  std::size_t revisionTreeDepth() const;
-  std::unique_ptr<containers::RevisionTree> allocateEmptyRevisionTree() const;
-  bool ensureRevisionTree();
+  std::unique_ptr<containers::RevisionTree> allocateEmptyRevisionTree(std::size_t depth) const;
+  void applyUpdates(rocksdb::SequenceNumber commitSeq);
+  void ensureRevisionTree();
+
+  // helper function to build revision trees
+  std::unique_ptr<containers::RevisionTree> revisionTree(
+    std::function<std::unique_ptr<containers::RevisionTree>(std::unique_ptr<containers::RevisionTree>)> const& callback);
 
  protected:
   RocksDBMetadata _meta;     /// collection metadata
@@ -134,16 +145,80 @@ class RocksDBMetaCollection : public PhysicalCollection {
   /// @brief collection lock used for recalculation count values
   mutable std::mutex _recalculationLock;
 
+  /// @brief depth for all revision trees. 
+  /// depth is large from the beginning so that the trees are always
+  /// large enough to handle large collections and do not need resizing.
+  /// as the combined RAM usage for all such trees would be prohibitive,
+  /// we may hold some of the trees in memory only in a compressed variant.
+  static constexpr std::size_t revisionTreeDepth = 6;
+
  private:
   std::atomic<uint64_t> _objectId;  /// rocksdb-specific object id for collection
 
+  /// @brief helper class for accessing revision trees in a compressed or
+  /// uncompressed state. this class alone is not thread-safe. it must be
+  /// used with external synchronization
+  class RevisionTreeAccessor {
+   public:
+    RevisionTreeAccessor(RevisionTreeAccessor const&) = delete;
+    RevisionTreeAccessor& operator=(RevisionTreeAccessor const&) = delete;
+
+    explicit RevisionTreeAccessor(std::unique_ptr<containers::RevisionTree> tree,
+                                  LogicalCollection const& collection);
+
+    void insert(std::vector<std::uint64_t> const& keys);
+    void remove(std::vector<std::uint64_t> const& keys);
+    void clear();
+    std::unique_ptr<containers::RevisionTree> clone() const;
+    std::uint64_t count() const;
+    std::uint64_t rootValue() const;
+    std::uint64_t maxDepth() const;
+    void checkConsistency() const;
+    void serializeBinary(std::string& output) const;
+
+    // turn the full-blown revision tree into a potentially smaller
+    // compressed representation
+    void hibernate();
+
+   private:
+    /// @brief make sure we have a value in _tree. unfortunately we
+    /// need to declare this const although it can mutate the internal
+    /// state of _tree
+    void ensureTree() const;
+
+    /// @brief compressed representation of tree. we will either have
+    /// this attribute populated or _tree
+    std::string mutable _compressed;
+
+    /// @brief the actual tree. we will either have this populated or 
+    ///_compressed
+    std::unique_ptr<containers::RevisionTree> mutable _tree;
+
+    /// @brief collecion object, used only for context in log messages
+    LogicalCollection const& _logicalCollection;
+
+    /// @brief maxDepth of tree. supposed to never change
+    std::uint64_t const _maxDepth;
+  
+    /// @brief number of hibernation requests received (we may ignore the
+    /// first few ones)
+    std::uint32_t mutable _hibernationRequests;
+
+    /// @brief whether or not we should attempt to compress the tree
+    bool _compressible;
+  };
+
   /// @revision tree management for replication
-  std::unique_ptr<containers::RevisionTree> _revisionTree;
+  std::unique_ptr<RevisionTreeAccessor> _revisionTree;
   std::atomic<rocksdb::SequenceNumber> _revisionTreeApplied;
   rocksdb::SequenceNumber _revisionTreeCreationSeq;
   rocksdb::SequenceNumber _revisionTreeSerializedSeq;
   std::chrono::steady_clock::time_point _revisionTreeSerializedTime;
   mutable std::mutex _revisionTreeLock;
+
+  // if the types of these containers are changed to some other type, please check the new
+  // type's iterator invalidation rules first and if iterators are invalidated when new 
+  // elements get inserted
   std::multimap<rocksdb::SequenceNumber, std::vector<std::uint64_t>> _revisionInsertBuffers;
   std::multimap<rocksdb::SequenceNumber, std::vector<std::uint64_t>> _revisionRemovalBuffers;
   std::set<rocksdb::SequenceNumber> _revisionTruncateBuffer;

--- a/arangod/RocksDBEngine/RocksDBMetadata.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetadata.cpp
@@ -416,11 +416,13 @@ Result RocksDBMetadata::serializeMeta(rocksdb::WriteBatch& batch,
 
   // Step 4. store the revision tree
   if (rcoll->needToPersistRevisionTree(maxCommitSeq)) {
+    output.clear();
+      
+    rocksdb::SequenceNumber seq =
+        rcoll->serializeRevisionTree(output, maxCommitSeq, force);
+    appliedSeq = std::min(appliedSeq, seq);
+
     if (coll.useSyncByRevision()) {
-      output.clear();
-      rocksdb::SequenceNumber seq =
-          rcoll->serializeRevisionTree(output, maxCommitSeq, force);
-      appliedSeq = std::min(appliedSeq, seq);
       if (!output.empty()) {
         rocksutils::uint64ToPersistent(output, seq);
 
@@ -444,10 +446,6 @@ Result RocksDBMetadata::serializeMeta(rocksdb::WriteBatch& batch,
             << "collection with objectId '" << rcoll->objectId() << "'";
       }
     } else {
-      output.clear();
-      rocksdb::SequenceNumber seq =
-          rcoll->serializeRevisionTree(output, maxCommitSeq, force);
-      appliedSeq = std::min(appliedSeq, seq);
       TRI_ASSERT(output.empty());
       key.constructRevisionTreeValue(rcoll->objectId());
       rocksdb::Status s = batch.Delete(cf, key.string());
@@ -468,6 +466,12 @@ Result RocksDBMetadata::serializeMeta(rocksdb::WriteBatch& batch,
         << "collection with objectId '" << rcoll->objectId() << "'";
     rocksdb::SequenceNumber seq = rcoll->lastSerializedRevisionTree(maxCommitSeq);
     appliedSeq = std::min(appliedSeq, seq);
+        
+    if (coll.useSyncByRevision()) {
+      // set the tree to sleep (note: hibernation requests may be ignored if there
+      // is not yet a need to hibernate)
+      rcoll->hibernateRevisionTree();
+    }
   }
 
   return res;
@@ -577,38 +581,37 @@ Result RocksDBMetadata::deserializeMeta(rocksdb::DB* db, LogicalCollection& coll
   }
 
   // Step 4. load the revision tree
-  if (coll.useSyncByRevision()) {
-    key.constructRevisionTreeValue(rcoll->objectId());
-    s = db->Get(ro, cf, key.string(), &value);
-    if (!s.ok() && !s.IsNotFound()) {
-      LOG_TOPIC("92caa", TRACE, Logger::ENGINES)
-          << "[" << this << "] error while recovering revision tree for "
-          << "collection with objectId '" << rcoll->objectId()
-          << "': " << rocksutils::convertStatus(s).errorMessage();
-      return rocksutils::convertStatus(s);
-    } else if (s.IsNotFound()) {
-      // no tree, check if collection is non-empty
-      auto bounds = RocksDBKeyBounds::CollectionDocuments(rcoll->objectId());
-      auto cmp = RocksDBColumnFamilyManager::get(RocksDBColumnFamilyManager::Family::Documents)
-                     ->GetComparator();
-      std::unique_ptr<rocksdb::Iterator> it{
-          db->NewIterator(ro, RocksDBColumnFamilyManager::get(
-                                  RocksDBColumnFamilyManager::Family::Documents))};
-      it->Seek(bounds.start());
-      if (it->Valid() && cmp->Compare(it->key(), bounds.end()) < 0) {
-        LOG_TOPIC("ecdbc", WARN, Logger::ENGINES)
-            << "no revision tree found for collection with id '"
-            << coll.id().id() << "', rebuilding";
-        rcoll->rebuildRevisionTree(it);
-      } else {
-        LOG_TOPIC("ecdbe", DEBUG, Logger::ENGINES)
-            << "no revision tree found for collection with id '"
-            << coll.id().id() << "', but collection appears empty";
-      }
-    } else {
+  if (!coll.useSyncByRevision()) {
+    LOG_TOPIC("92ca9", TRACE, Logger::ENGINES)
+        << "[" << this << "] no need to recover revision tree for "
+        << "collection with objectId '" << rcoll->objectId() << "', "
+        << "it is not configured to sync by revision";
+    // nothing to do
+    return {};
+  }
+
+  // look for a persisted Merkle tree in RocksDB
+  key.constructRevisionTreeValue(rcoll->objectId());
+  s = db->Get(ro, cf, key.string(), &value);
+  if (!s.ok() && !s.IsNotFound()) {
+    LOG_TOPIC("92caa", TRACE, Logger::ENGINES)
+        << "[" << this << "] error while recovering revision tree for "
+        << "collection with objectId '" << rcoll->objectId()
+        << "': " << rocksutils::convertStatus(s).errorMessage();
+    return rocksutils::convertStatus(s);
+  } 
+
+  if (!s.IsNotFound()) {
+    // we do have a persisted tree.
+    TRI_ASSERT(value.size() > sizeof(uint64_t));
+
+    try {
       auto tree = containers::RevisionTree::fromBuffer(
           std::string_view(value.data(), value.size() - sizeof(uint64_t)));
+
       if (tree) {
+        tree->checkConsistency();
+
         uint64_t seq = rocksutils::uint64FromPersistent(
             value.data() + value.size() - sizeof(uint64_t));
         // we may have skipped writing out the tree because it hadn't changed,
@@ -616,28 +619,50 @@ Result RocksDBMetadata::deserializeMeta(rocksdb::DB* db, LogicalCollection& coll
         // seq anyway, so take the max
         rocksdb::SequenceNumber useSeq = std::max(globalSeq, seq);
         rcoll->setRevisionTree(std::move(tree), useSeq);
+
         LOG_TOPIC("92cab", TRACE, Logger::ENGINES)
             << "[" << this << "] recovered revision tree for "
             << "collection with objectId '" << rcoll->objectId() << "', "
             << "valid through " << useSeq;
-      } else {
-        LOG_TOPIC("dcd99", ERR, Logger::ENGINES)
-            << "unsupported revision tree format in collection "
-            << "with id '" << coll.id().id() << "', rebuilding";
-        std::unique_ptr<rocksdb::Iterator> it{
-            db->NewIterator(ro, RocksDBColumnFamilyManager::get(
-                                    RocksDBColumnFamilyManager::Family::Documents))};
-        rcoll->rebuildRevisionTree(it);
+
+        return {};
       }
+      
+      LOG_TOPIC("dcd99", WARN, Logger::ENGINES)
+          << "unsupported revision tree format for collection " << coll.name();
+
+      // we intentionally fall through to the tree rebuild process
+    } catch (std::exception const& ex) {
+      // error during tree processing.
+      // the tree is either invalid or some other exception happened
+      LOG_TOPIC("84247", WARN, Logger::ENGINES)
+          << "caught exception while loading revision tree in collection "
+          << coll.name() << ": " << ex.what();
     }
-  } else {
-    LOG_TOPIC("92ca9", TRACE, Logger::ENGINES)
-        << "[" << this << "] no need to recover revision tree for "
-        << "collection with objectId '" << rcoll->objectId() << "', "
-        << "it is not configured to sync by revision";
   }
 
-  return Result();
+  // no tree, or we read an invalid tree from persistence
+
+  // no tree, check if collection is non-empty
+  auto bounds = RocksDBKeyBounds::CollectionDocuments(rcoll->objectId());
+  auto cmp = RocksDBColumnFamilyManager::get(RocksDBColumnFamilyManager::Family::Documents)
+                 ->GetComparator();
+  std::unique_ptr<rocksdb::Iterator> it{
+      db->NewIterator(ro, RocksDBColumnFamilyManager::get(
+                              RocksDBColumnFamilyManager::Family::Documents))};
+  it->Seek(bounds.start());
+  if (it->Valid() && cmp->Compare(it->key(), bounds.end()) < 0) {
+    LOG_TOPIC("ecdbc", WARN, Logger::ENGINES)
+        << "no revision tree found for collection " << coll.name() 
+        << ", rebuilding from collection data";
+    rcoll->rebuildRevisionTree(it);
+  } else {
+    LOG_TOPIC("ecdbe", DEBUG, Logger::ENGINES)
+        << "no revision tree found for collection " << coll.name()
+        << ", but collection appears empty";
+  }
+
+  return {};
 }
 
 void RocksDBMetadata::loadInitialNumberDocuments() {

--- a/arangod/RocksDBEngine/RocksDBTypes.h
+++ b/arangod/RocksDBEngine/RocksDBTypes.h
@@ -52,7 +52,8 @@ enum class RocksDBEntryType : char {
   KeyGeneratorValue = '=',
   View = '>',
   GeoIndexValue = '?',
-  RevisionTreeValue = '@'
+  // RevisionTreeValue = '@', // pre-3.8 GA revision trees. do not use or reuse!
+  RevisionTreeValue = '/'
 };
 
 char const* rocksDBEntryTypeName(RocksDBEntryType);

--- a/arangod/RocksDBEngine/RocksDBV8Functions.cpp
+++ b/arangod/RocksDBEngine/RocksDBV8Functions.cpp
@@ -206,9 +206,14 @@ static void JS_CollectionRevisionTreeSummary(v8::FunctionCallbackInfo<v8::Value>
     TRI_V8_THROW_EXCEPTION_INTERNAL("cannot extract collection");
   }
 
+  bool fromCollection = false;
+  if (args.Length() > 0) {
+    TRI_ObjectToBoolean(isolate, args[0]);
+  }
+
   auto* physical = toRocksDBCollection(*collection);
   VPackBuilder builder;
-  physical->revisionTreeSummary(builder);
+  physical->revisionTreeSummary(builder, fromCollection);
 
   v8::Handle<v8::Value> result = TRI_VPackToV8(isolate, builder.slice());
   TRI_V8_RETURN(result);

--- a/arangod/VocBase/Identifiers/RevisionId.cpp
+++ b/arangod/VocBase/Identifiers/RevisionId.cpp
@@ -93,6 +93,14 @@ void RevisionId::toPersistent(std::string& buffer) const {
   rocksutils::uint64ToPersistent(buffer, id());
 }
 
+/// @brief create a revision id with a lower-bound HLC value
+RevisionId RevisionId::lowerBound() { 
+  // "2020-01-01T00:00:00.000Z" => 1577836800000 milliseconds since the epoch
+  RevisionId value{uint64_t(1577836800000) << 20ULL};
+  TRI_ASSERT(value.id() > ::TickLimit);
+  return value;
+}
+
 /// @brief create a revision id using an HLC value
 RevisionId RevisionId::create() { return RevisionId{TRI_HybridLogicalClock()}; }
 

--- a/arangod/VocBase/Identifiers/RevisionId.h
+++ b/arangod/VocBase/Identifiers/RevisionId.h
@@ -81,6 +81,9 @@ class RevisionId : public arangodb::basics::Identifier {
     return RevisionId{std::numeric_limits<std::uint64_t>::max()};
   }
 
+  /// @brief create a revision id with a lower-bound HLC value
+  static RevisionId lowerBound();
+
   /// @brief create a revision id using an HLC value
   static RevisionId create();
 

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -170,9 +170,11 @@ LogicalCollection::LogicalCollection(TRI_vocbase_t& vocbase, VPackSlice const& i
       _usesRevisionsAsDocumentIds(
           Helper::getBooleanValue(info, StaticStrings::UsesRevisionsAsDocumentIds, false)),
       _syncByRevision(determineSyncByRevision()),
-      _minRevision((system() || isSmartChild())
-                       ? RevisionId::none()
-                       : RevisionId::fromSlice(info.get(StaticStrings::MinRevision))),
+      _minRevision(isSmartChild() 
+                   ? RevisionId::none()
+                   : (system()
+                      ? RevisionId::lowerBound()
+                      : RevisionId::fromSlice(info.get(StaticStrings::MinRevision)))),
 #ifdef USE_ENTERPRISE
       _smartJoinAttribute(
           Helper::getStringValue(info, StaticStrings::SmartJoinAttribute, "")),

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -170,6 +170,8 @@ LogicalCollection::LogicalCollection(TRI_vocbase_t& vocbase, VPackSlice const& i
       _usesRevisionsAsDocumentIds(
           Helper::getBooleanValue(info, StaticStrings::UsesRevisionsAsDocumentIds, false)),
       _syncByRevision(determineSyncByRevision()),
+      // for info on how to determine the minRevisionId please refer to methods::Collections::create(),
+      // where there is a lengthier explanation.
       _minRevision(isSmartChild() 
                    ? RevisionId::none()
                    : (system()

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -297,7 +297,12 @@ Result Collections::create(TRI_vocbase_t& vocbase, OperationOptions const& optio
       bool isSmartChild =
           Helper::getBooleanValue(info.properties, StaticStrings::IsSmartChild, false);
       RevisionId minRev =
-          (isSystem || isSmartChild) ? RevisionId::none() : RevisionId::create();
+          (isSmartChild 
+           ? RevisionId::none()
+           : (isSystem
+              ? RevisionId::lowerBound()
+              : RevisionId::create()));
+
       helper.add(arangodb::StaticStrings::MinRevision,
                  arangodb::velocypack::Value(minRev.toString()));
     }

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -296,6 +296,22 @@ Result Collections::create(TRI_vocbase_t& vocbase, OperationOptions const& optio
                  arangodb::velocypack::Value(useRevs));
       bool isSmartChild =
           Helper::getBooleanValue(info.properties, StaticStrings::IsSmartChild, false);
+
+      // determine the minimum revision id for the collection.
+      // for smart edge collection children collections, the _rev values are determined
+      // via the agency's uniqid() function. they can be anything, so we need to assume
+      // 0 as the lower bound.
+      // for system collections, we can assume that there will be no data inserted with
+      // revisions older than lowerBound(), which is a HLC value from January 2020. We
+      // cannot assume a current revision id because that may cause trouble in replication.
+      // replication for some system collections may not drop and recreate them, but
+      // reuse the existing collections. this is done at least for the _users collection,
+      // which is not dropped by the replication. that means we must be careful to avoid
+      // min revisions on the follower to be higher than on the leader, and we cannot use
+      // a recent revision id. so for system collections, we simply use a 2020 HLC value,
+      // which should be good enough for all cases given that 3.8 is released in 2021.
+      // for all other collections (non-smart edge children, non-system collections) we
+      // can simply use a recent HLC value as min revision id.
       RevisionId minRev =
           (isSmartChild 
            ? RevisionId::none()

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -2419,7 +2419,7 @@ function inspectDump(filename, outfile) {
     let details = data.collections[collection];
     if (details.examples) {
       details.examples.forEach(function (example) {
-        print("db[" + JSON.stringify(collection) + "].insert(" + JSON.stringify(example) + ", {isRestore: true});");
+        print("db[" + JSON.stringify(collection) + "].insert(" + JSON.stringify(example) + ");");
       });
     }
     let missing = details.count;

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -66,7 +66,6 @@ std::string const StaticStrings::Namespace("namespace");
 std::string const StaticStrings::Prefix("prefix");
 std::string const StaticStrings::Overwrite("overwrite");
 std::string const StaticStrings::OverwriteMode("overwriteMode");
-std::string const StaticStrings::PreserveRevisionIds("preserveRevisionIds");
 std::string const StaticStrings::Compact("compact");
 
 // replication headers

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -69,7 +69,6 @@ class StaticStrings {
   static std::string const Prefix;
   static std::string const Overwrite;
   static std::string const OverwriteMode;
-  static std::string const PreserveRevisionIds;
   static std::string const Compact;
 
   // replication headers

--- a/lib/Basics/hashes.h
+++ b/lib/Basics/hashes.h
@@ -41,7 +41,7 @@ uint64_t TRI_FnvHashString(char const*);
 /// @brief computes a FNV hash for POD types
 template <typename T>
 std::enable_if_t<std::is_pod_v<T>, uint64_t> TRI_FnvHashPod(T input) {
-  return TRI_FnvHashPointer(&input, sizeof(T));
+  return TRI_FnvHashBlock(0xcbf29ce484222325ULL, &input, sizeof(T));
 }
 
 /// @brief computes a initial FNV for blocks

--- a/lib/Containers/MerkleTree.cpp
+++ b/lib/Containers/MerkleTree.cpp
@@ -44,18 +44,30 @@
 
 #include "MerkleTree.h"
 
+#include "Basics/Endian.h"
 #include "Basics/HybridLogicalClock.h"
 #include "Basics/NumberUtils.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/StringUtils.h"
 #include "Basics/debugging.h"
 #include "Basics/hashes.h"
-#include "Logger/LogMacros.h"
+
+// can turn this on for more aggressive and expensive consistency checks
+// #define PARANOID_TREE_CHECKS
 
 namespace {
 static constexpr std::uint8_t CurrentVersion = 0x01;
-static constexpr char CompressedCurrent = '1';
+static constexpr char CompressedSnappyCurrent = '1';
 static constexpr char UncompressedCurrent = '2';
+static constexpr char CompressedBottomMostCurrent = '3';
+
+template<typename T> T readUInt(char const*& p) noexcept {
+  T value;
+  memcpy(&value, p, sizeof(T));
+  p += sizeof(T);
+  return arangodb::basics::littleToHost<T>(value);
+};
+
 }  // namespace
 
 namespace arangodb {
@@ -65,18 +77,19 @@ std::uint64_t FnvHashProvider::hash(std::uint64_t input) const {
   return TRI_FnvHashPod(input);
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-bool MerkleTree<Hasher, BranchingBits, LockStripes>::Node::operator==(Node const& other) {
+template <typename Hasher, std::uint64_t const BranchingBits>
+bool MerkleTree<Hasher, BranchingBits>::Node::operator==(Node const& other) const noexcept{
   return ((this->count == other.count) && (this->hash == other.hash));
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-constexpr std::uint64_t MerkleTree<Hasher, BranchingBits, LockStripes>::nodeCountUpToDepth(
-    std::uint64_t maxDepth) {
+template <typename Hasher, std::uint64_t const BranchingBits>
+constexpr std::uint64_t MerkleTree<Hasher, BranchingBits>::nodeCountUpToDepth(
+    std::uint64_t maxDepth) noexcept {
   return ((static_cast<std::uint64_t>(1) << (BranchingBits * (maxDepth + 1))) - 1) /
          (BranchingFactor - 1);
 }
-class TestNodeCountUpToDepth : public MerkleTree<FnvHashProvider, 3, 64> {
+
+class TestNodeCountUpToDepth : public MerkleTree<FnvHashProvider, 3> {
   static_assert(nodeCountUpToDepth(0) == 1);
   static_assert(nodeCountUpToDepth(1) == 9);
   static_assert(nodeCountUpToDepth(2) == 73);
@@ -85,13 +98,13 @@ class TestNodeCountUpToDepth : public MerkleTree<FnvHashProvider, 3, 64> {
   static_assert(nodeCountUpToDepth(10) == 1227133513);
 };
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-constexpr std::uint64_t MerkleTree<Hasher, BranchingBits, LockStripes>::allocationSize(std::uint64_t maxDepth) {
+template <typename Hasher, std::uint64_t const BranchingBits>
+constexpr std::uint64_t MerkleTree<Hasher, BranchingBits>::allocationSize(std::uint64_t maxDepth) noexcept {
   return MetaSize + (NodeSize * nodeCountUpToDepth(maxDepth));
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-constexpr std::uint64_t MerkleTree<Hasher, BranchingBits, LockStripes>::log2ceil(std::uint64_t n) {
+template <typename Hasher, std::uint64_t const BranchingBits>
+constexpr std::uint64_t MerkleTree<Hasher, BranchingBits>::log2ceil(std::uint64_t n) noexcept {
   if (n > (std::numeric_limits<std::uint64_t>::max() / 2)) {
     return 8 * sizeof(std::uint64_t) - 1;
   }
@@ -100,7 +113,8 @@ constexpr std::uint64_t MerkleTree<Hasher, BranchingBits, LockStripes>::log2ceil
   }
   return i;
 }
-class TestLog2Ceil : public MerkleTree<FnvHashProvider, 3, 64> {
+
+class TestLog2Ceil : public MerkleTree<FnvHashProvider, 3> {
   static_assert(log2ceil(0) == 1);
   static_assert(log2ceil(1) == 1);
   static_assert(log2ceil(2) == 1);
@@ -116,8 +130,8 @@ class TestLog2Ceil : public MerkleTree<FnvHashProvider, 3, 64> {
                 8 * sizeof(std::uint64_t) - 1);
 };
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-constexpr std::uint64_t MerkleTree<Hasher, BranchingBits, LockStripes>::minimumFactorFor(
+template <typename Hasher, std::uint64_t const BranchingBits>
+constexpr std::uint64_t MerkleTree<Hasher, BranchingBits>::minimumFactorFor(
     std::uint64_t current, std::uint64_t target) {
   if (target < current) {
     throw std::invalid_argument("Was expecting target >= current.");
@@ -142,7 +156,7 @@ constexpr std::uint64_t MerkleTree<Hasher, BranchingBits, LockStripes>::minimumF
   return correctedFactor;
 }
 
-class TestMinimumFactorFor : public MerkleTree<FnvHashProvider, 3, 64> {
+class TestMinimumFactorFor : public MerkleTree<FnvHashProvider, 3> {
   static_assert(minimumFactorFor(1, 2) == 4);
   static_assert(minimumFactorFor(1, 4) == 8);
   static_assert(minimumFactorFor(1, 12) == 16);
@@ -161,35 +175,48 @@ class TestMinimumFactorFor : public MerkleTree<FnvHashProvider, 3, 64> {
   static_assert(minimumFactorFor(8192, 2147483600) == 262144);
 };
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-std::uint64_t MerkleTree<Hasher, BranchingBits, LockStripes>::defaultRange(std::uint64_t maxDepth) {
+template <typename Hasher, std::uint64_t const BranchingBits>
+std::uint64_t MerkleTree<Hasher, BranchingBits>::defaultRange(std::uint64_t maxDepth) {
   // start with 64 revisions per leaf; this is arbitrary, but the key is we want
   // to start with a relatively fine-grained tree so we can differentiate well,
   // but we don't want to go so small that we have to resize immediately
   return nodeCountAtDepth(maxDepth) * 64;
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-std::unique_ptr<MerkleTree<Hasher, BranchingBits, LockStripes>>
-MerkleTree<Hasher, BranchingBits, LockStripes>::fromBuffer(std::string_view buffer) {
-  bool compressed = false;
-  std::uint8_t version = static_cast<uint8_t>(buffer[buffer.size() - 1]);
-  if (version == 0x01) {
-    compressed = ::CompressedCurrent == buffer[buffer.size() - 2];
-  } else {
+template <typename Hasher, std::uint64_t const BranchingBits>
+std::unique_ptr<MerkleTree<Hasher, BranchingBits>>
+MerkleTree<Hasher, BranchingBits>::fromBuffer(std::string_view buffer) {
+  if (buffer.size() < sizeof(Meta) + 2) {
     throw std::invalid_argument(
-        "Buffer does not contain a properly versioned tree.");
+        "Input buffer is too small");
   }
 
-  std::string scratch;
-  if (compressed) {
-    snappy::Uncompress(buffer.data(), buffer.size() - 2, &scratch);
-    buffer = std::string_view(scratch);
-  } else {
-    buffer = std::string_view(buffer.data(), buffer.size() - 2);
-  }
+  TRI_ASSERT(buffer.size() > 2);
+  std::uint8_t version = static_cast<uint8_t>(buffer[buffer.size() - 1]);
 
-  if (buffer.size() < MetaSize) {
+  if (version != ::CurrentVersion) {
+    throw std::invalid_argument(
+        "Buffer does not contain a properly versioned tree");
+  }
+  
+  if (buffer[buffer.size() - 2] == ::CompressedBottomMostCurrent) {
+    // bottom-most level compressed data
+    return fromBottomMostCompressed(std::string_view(buffer.data(), buffer.size() - 2));
+  } else if (buffer[buffer.size() - 2] == ::CompressedSnappyCurrent) {
+    // Snappy-compressed data
+    return fromSnappyCompressed(std::string_view(buffer.data(), buffer.size() - 2));
+  } else if (buffer[buffer.size() - 2] == ::UncompressedCurrent) {
+    // uncompressed data
+    return fromUncompressed(std::string_view(buffer.data(), buffer.size() - 2));
+  } 
+  
+  throw std::invalid_argument("unknown tree serialization type");
+}
+
+template <typename Hasher, std::uint64_t const BranchingBits>
+std::unique_ptr<MerkleTree<Hasher, BranchingBits>>
+MerkleTree<Hasher, BranchingBits>::fromUncompressed(std::string_view buffer) {
+  if (buffer.size() < sizeof(Meta)) {
     // not enough space to even store the meta info, can't proceed
     return nullptr;
   }
@@ -200,14 +227,106 @@ MerkleTree<Hasher, BranchingBits, LockStripes>::fromBuffer(std::string_view buff
     return nullptr;
   }
 
-  return std::unique_ptr<MerkleTree<Hasher, BranchingBits, LockStripes>>(
-      new MerkleTree<Hasher, BranchingBits, LockStripes>(buffer));
+  return std::unique_ptr<MerkleTree<Hasher, BranchingBits>>(
+      new MerkleTree<Hasher, BranchingBits>(buffer));
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-std::unique_ptr<MerkleTree<Hasher, BranchingBits, LockStripes>>
-MerkleTree<Hasher, BranchingBits, LockStripes>::deserialize(velocypack::Slice slice) {
-  std::unique_ptr<MerkleTree<Hasher, BranchingBits, LockStripes>> tree{nullptr};
+template <typename Hasher, std::uint64_t const BranchingBits>
+std::unique_ptr<MerkleTree<Hasher, BranchingBits>>
+MerkleTree<Hasher, BranchingBits>::fromSnappyCompressed(std::string_view buffer) {
+  size_t length;
+  bool canUncompress = snappy::GetUncompressedLength(buffer.data(), buffer.size(), &length);
+  if (!canUncompress || length != allocationSize(6)) {
+    throw std::invalid_argument(
+        "Cannot determine size of Snappy-compressed data.");
+  }
+  
+  auto uncompressed = std::make_unique<uint8_t[]>(length);
+
+  if (!snappy::RawUncompress(buffer.data(), buffer.size(), reinterpret_cast<char*>(uncompressed.get()))) {
+    throw std::invalid_argument(
+        "Cannot uncompress Snappy-compressed data.");
+  }
+  
+  return std::unique_ptr<MerkleTree<Hasher, BranchingBits>>(
+      new MerkleTree<Hasher, BranchingBits>(std::move(uncompressed)));
+}
+
+template <typename Hasher, std::uint64_t const BranchingBits>
+std::unique_ptr<MerkleTree<Hasher, BranchingBits>>
+MerkleTree<Hasher, BranchingBits>::fromBottomMostCompressed(std::string_view buffer) {
+  char const* p = buffer.data();
+  char const* e = p + buffer.size();
+
+  if (p + 3 * sizeof(uint64_t) > e) {
+    throw std::invalid_argument("invalid compressed tree data");
+  }
+
+  std::uint64_t rangeMin = readUInt<uint64_t>(p);
+  std::uint64_t rangeMax = readUInt<uint64_t>(p);
+  std::uint64_t maxDepth = readUInt<uint64_t>(p);
+
+  auto tree = std::make_unique<MerkleTree<Hasher, BranchingBits>>(maxDepth,
+                                                                  rangeMin,
+                                                                  rangeMax);
+  if (tree == nullptr) {
+    throw std::invalid_argument("invalid compressed tree data");
+  }
+
+  std::uint64_t const offset = nodeCountUpToDepth(maxDepth - 1);
+
+  // rebuild bottom-most level
+  while (p + sizeof(uint32_t) + sizeof(uint64_t) + sizeof(uint64_t) <= e) {
+    // enough data to read
+    std::uint32_t pos = readUInt<uint32_t>(p);
+    std::uint64_t count = readUInt<uint64_t>(p);
+    std::uint64_t hash = readUInt<uint64_t>(p);
+
+    Node& node = tree->node(offset + pos);
+    node.count = count;
+    node.hash = hash;
+  }
+
+  if (p != e) {
+    throw std::invalid_argument("invalid compressed tree data with overflow values");
+  }
+  
+  // rebuild all levels above from bottom-most data
+  for (std::size_t d = maxDepth - 1; /*d >= 0*/; --d) {
+    std::uint64_t prevOffset = (d == 0 ? 0 : nodeCountUpToDepth(d - 1));
+    std::uint64_t ourOffset = nodeCountUpToDepth(d);
+    std::uint64_t const ourEnd = nodeCountUpToDepth(d + 1);
+
+    while (ourOffset < ourEnd) {
+      std::uint64_t count = 0;
+      std::uint64_t hash = 0;
+      for (std::size_t index = 0; index < (1 << BranchingBits); ++index) {
+        Node const& src = tree->node(ourOffset++);
+        count += src.count;
+        hash ^= src.hash;
+      }
+      Node& dst = tree->node(prevOffset);
+      dst.count = count;
+      dst.hash = hash;
+
+      ++prevOffset;
+    }
+    if (d == 0) { 
+      break;
+    }
+  }
+
+#ifdef PARANOID_TREE_CHECKS
+  tree->checkInternalConsistency();
+#endif
+
+  return tree;
+}
+
+template <typename Hasher, std::uint64_t const BranchingBits>
+std::unique_ptr<MerkleTree<Hasher, BranchingBits>>
+MerkleTree<Hasher, BranchingBits>::deserialize(velocypack::Slice slice) {
+  std::unique_ptr<MerkleTree<Hasher, BranchingBits>> tree;
 
   if (!slice.isObject()) {
     return tree;
@@ -256,7 +375,9 @@ MerkleTree<Hasher, BranchingBits, LockStripes>::deserialize(velocypack::Slice sl
   }
 
   // allocate the tree
-  tree.reset(new MerkleTree<Hasher, BranchingBits, LockStripes>(maxDepth, rangeMin, rangeMax));
+  TRI_ASSERT(rangeMin < rangeMax);
+
+  tree.reset(new MerkleTree<Hasher, BranchingBits>(maxDepth, rangeMin, rangeMax));
 
   std::uint64_t index = 0;
   for (velocypack::Slice nodeSlice : velocypack::ArrayIterator(nodes)) {
@@ -279,7 +400,6 @@ MerkleTree<Hasher, BranchingBits, LockStripes>::deserialize(velocypack::Slice sl
       return tree;
     }
 
-    std::unique_lock<std::mutex> guard(tree->lock(index));
     Node& node = tree->node(index);
     node.hash = hash;
     node.count = count;
@@ -290,30 +410,51 @@ MerkleTree<Hasher, BranchingBits, LockStripes>::deserialize(velocypack::Slice sl
   return tree;
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-MerkleTree<Hasher, BranchingBits, LockStripes>::MerkleTree(std::uint64_t maxDepth,
-                                                           std::uint64_t rangeMin,
-                                                           std::uint64_t rangeMax) {
+template <typename Hasher, std::uint64_t const BranchingBits>
+MerkleTree<Hasher, BranchingBits>::MerkleTree(std::uint64_t maxDepth,
+                                              std::uint64_t rangeMin,
+                                              std::uint64_t rangeMax) {
   if (maxDepth < 2) {
-    throw std::invalid_argument("Must specify a maxDepth >= 2.");
+    throw std::invalid_argument("Must specify a maxDepth >= 2");
   }
-  _buffer.reset(new uint8_t[allocationSize(maxDepth)]);
+ 
+  TRI_ASSERT(rangeMax == 0 || rangeMax > rangeMin);
 
   if (rangeMax == 0) {
+    // default value for rangeMax is 0
     rangeMax = rangeMin + defaultRange(maxDepth);
+    TRI_ASSERT(rangeMin < rangeMax);
   }
+
+  if (rangeMax <= rangeMin) {
+    throw std::invalid_argument("rangeMax must be larger than rangeMin");
+  }
+ 
   TRI_ASSERT(((rangeMax - rangeMin) / nodeCountAtDepth(maxDepth)) * nodeCountAtDepth(maxDepth) ==
              (rangeMax - rangeMin));
-  new (&meta()) Meta{rangeMin, rangeMax, maxDepth};
+  
+  // no lock necessary here
+  _buffer.reset(new uint8_t[allocationSize(maxDepth)]);
 
+  new (&meta()) Meta{rangeMin, rangeMax, maxDepth};
+  
   std::uint64_t const last = nodeCountUpToDepth(maxDepth);
   for (std::uint64_t i = 0; i < last; ++i) {
     new (&node(i)) Node{0, 0};
   }
+
+  TRI_ASSERT(this->node(0).count == 0);
+  TRI_ASSERT(this->node(0).hash == 0);
+
+#ifdef PARANOID_TREE_CHECKS
+  // checking an empty tree is overyl paranoid and only wastes
+  // cycles, so we only do it if absolutely necessary
+  checkInternalConsistency();
+#endif
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-MerkleTree<Hasher, BranchingBits, LockStripes>::~MerkleTree() {
+template <typename Hasher, std::uint64_t const BranchingBits>
+MerkleTree<Hasher, BranchingBits>::~MerkleTree() {
   std::unique_lock<std::shared_mutex> guard(_bufferLock);
 
   if (!_buffer) {
@@ -328,9 +469,9 @@ MerkleTree<Hasher, BranchingBits, LockStripes>::~MerkleTree() {
   meta().~Meta();
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-MerkleTree<Hasher, BranchingBits, LockStripes>& MerkleTree<Hasher, BranchingBits, LockStripes>::
-operator=(std::unique_ptr<MerkleTree<Hasher, BranchingBits, LockStripes>>&& other) {
+template <typename Hasher, std::uint64_t const BranchingBits>
+MerkleTree<Hasher, BranchingBits>& MerkleTree<Hasher, BranchingBits>::
+operator=(std::unique_ptr<MerkleTree<Hasher, BranchingBits>>&& other) {
   if (!other) {
     return *this;
   }
@@ -350,67 +491,40 @@ operator=(std::unique_ptr<MerkleTree<Hasher, BranchingBits, LockStripes>>&& othe
   return *this;
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-std::uint64_t MerkleTree<Hasher, BranchingBits, LockStripes>::count() const {
+template <typename Hasher, std::uint64_t const BranchingBits>
+std::uint64_t MerkleTree<Hasher, BranchingBits>::count() const {
   std::shared_lock<std::shared_mutex> guard(_bufferLock);
-  std::unique_lock<std::mutex> lock(this->lock(0));
   return node(0).count;
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-std::uint64_t MerkleTree<Hasher, BranchingBits, LockStripes>::rootValue() const {
+template <typename Hasher, std::uint64_t const BranchingBits>
+std::uint64_t MerkleTree<Hasher, BranchingBits>::rootValue() const {
   std::shared_lock<std::shared_mutex> guard(_bufferLock);
-  std::unique_lock<std::mutex> lock(this->lock(0));
   return node(0).hash;
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-std::pair<std::uint64_t, std::uint64_t> MerkleTree<Hasher, BranchingBits, LockStripes>::range() const {
+template <typename Hasher, std::uint64_t const BranchingBits>
+std::pair<std::uint64_t, std::uint64_t> MerkleTree<Hasher, BranchingBits>::range() const {
   std::shared_lock<std::shared_mutex> guard(_bufferLock);
   return {meta().rangeMin, meta().rangeMax};
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-std::uint64_t MerkleTree<Hasher, BranchingBits, LockStripes>::maxDepth() const {
+template <typename Hasher, std::uint64_t const BranchingBits>
+std::uint64_t MerkleTree<Hasher, BranchingBits>::maxDepth() const {
   std::shared_lock<std::shared_mutex> guard(_bufferLock);
   return meta().maxDepth;
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-void MerkleTree<Hasher, BranchingBits, LockStripes>::insert(std::uint64_t key) {
+template <typename Hasher, std::uint64_t const BranchingBits>
+std::uint64_t MerkleTree<Hasher, BranchingBits>::byteSize() const {
   std::shared_lock<std::shared_mutex> guard(_bufferLock);
-  if (key < meta().rangeMin) {
-    throw std::out_of_range("Cannot insert, key " + std::to_string(key) +
-                            " less than range minimum " +
-                            std::to_string(meta().rangeMin) + ".");
-  }
-
-  if (key >= meta().rangeMax) {
-    // unlock so we can get exclusive access to grow the range
-    guard.unlock();
-    grow(key, "insertSingle");
-    guard.lock();
-  }
-
-  modify(key, /* isInsert */ true);
+  return allocationSize(meta().maxDepth);
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-void MerkleTree<Hasher, BranchingBits, LockStripes>::insert(std::vector<std::uint64_t> const& keys) {
-  if (keys.empty()) {
-    return;
-  }
-
-  std::vector<std::uint64_t> sortedKeys = keys;
-  std::sort(sortedKeys.begin(), sortedKeys.end());
-
-  std::uint64_t minKey = sortedKeys[0];
-  std::uint64_t maxKey = sortedKeys[sortedKeys.size() - 1];
-
-  // instead of locking for each individual key, just get an exclusive lock
-  // and batch insert
-  std::unique_lock<std::shared_mutex> guard(_bufferLock);
-
+template <typename Hasher, std::uint64_t const BranchingBits>
+void MerkleTree<Hasher, BranchingBits>::checkInsertMinMax(std::unique_lock<std::shared_mutex>& guard,
+                                                          std::uint64_t minKey,
+                                                          std::uint64_t maxKey) {
   if (minKey < meta().rangeMin) {
     throw std::out_of_range("Cannot insert, key " + std::to_string(minKey) +
                             " less than range minimum " +
@@ -420,26 +534,65 @@ void MerkleTree<Hasher, BranchingBits, LockStripes>::insert(std::vector<std::uin
   if (maxKey >= meta().rangeMax) {
     // unlock so we can get exclusive access to grow the range
     guard.unlock();
-    grow(maxKey, "insertBatch");
+    grow(maxKey);
     guard.lock();
   }
-
-  modify(sortedKeys, true);
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-void MerkleTree<Hasher, BranchingBits, LockStripes>::remove(std::uint64_t key) {
-  std::shared_lock<std::shared_mutex> guard(_bufferLock);
+template <typename Hasher, std::uint64_t const BranchingBits>
+void MerkleTree<Hasher, BranchingBits>::insert(std::uint64_t key) {
+  std::unique_lock<std::shared_mutex> guard(_bufferLock);
+
+  // may throw if key < rangeMin, or grow the tree if key >= rangeMax
+  checkInsertMinMax(guard, key, key);
+
+  modify(key, /*isInsert*/ true);
+}
+
+template <typename Hasher, std::uint64_t const BranchingBits>
+void MerkleTree<Hasher, BranchingBits>::insert(std::vector<std::uint64_t> const& keys) {
+  if (keys.size() == 1) {
+    // optimization for a single key
+    return this->insert(keys[0]);
+  }
+  
+  if (ADB_UNLIKELY(keys.empty())) {
+    return;
+  }
+
+  std::vector<std::uint64_t> sortedKeys = keys;
+  std::sort(sortedKeys.begin(), sortedKeys.end());
+
+  std::uint64_t minKey = sortedKeys[0];
+  std::uint64_t maxKey = sortedKeys[sortedKeys.size() - 1];
+
+  std::unique_lock<std::shared_mutex> guard(_bufferLock);
+  
+  // may throw if minKey < rangeMin, or grow the tree if maxKey >= rangeMax
+  checkInsertMinMax(guard, minKey, maxKey);
+
+  modify(sortedKeys, /*isInsert*/ true);
+}
+
+template <typename Hasher, std::uint64_t const BranchingBits>
+void MerkleTree<Hasher, BranchingBits>::remove(std::uint64_t key) {
+  std::unique_lock<std::shared_mutex> guard(_bufferLock);
+
   if (key < meta().rangeMin || key >= meta().rangeMax) {
     throw std::out_of_range("Cannot remove, key out of current range.");
   }
 
-  modify(key, /* isInsert */ false);
+  modify(key, /*isInsert*/ false);
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-void MerkleTree<Hasher, BranchingBits, LockStripes>::remove(std::vector<std::uint64_t> const& keys) {
-  if (keys.empty()) {
+template <typename Hasher, std::uint64_t const BranchingBits>
+void MerkleTree<Hasher, BranchingBits>::remove(std::vector<std::uint64_t> const& keys) {
+  if (keys.size() == 1) {
+    // optimization for a single key
+    return remove(keys[0]);
+  }
+
+  if (ADB_UNLIKELY(keys.empty())) {
     return;
   }
 
@@ -455,46 +608,69 @@ void MerkleTree<Hasher, BranchingBits, LockStripes>::remove(std::vector<std::uin
     throw std::out_of_range("Cannot remove, key out of current range.");
   }
 
-  modify(sortedKeys, false);
+  modify(sortedKeys, /*isInsert*/ false);
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-void MerkleTree<Hasher, BranchingBits, LockStripes>::clear() {
+template <typename Hasher, std::uint64_t const BranchingBits>
+void MerkleTree<Hasher, BranchingBits>::clear() {
   std::unique_lock<std::shared_mutex> guard(_bufferLock);
+
   std::uint64_t const last = nodeCountUpToDepth(meta().maxDepth);
   for (std::uint64_t i = 0; i < last; ++i) {
     new (&node(i)) Node{0, 0};
   }
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-std::unique_ptr<MerkleTree<Hasher, BranchingBits, LockStripes>>
-MerkleTree<Hasher, BranchingBits, LockStripes>::clone() {
+template <typename Hasher, std::uint64_t const BranchingBits>
+void MerkleTree<Hasher, BranchingBits>::checkConsistency() const {
   std::shared_lock<std::shared_mutex> guard(_bufferLock);
-  return std::unique_ptr<MerkleTree<Hasher, BranchingBits, LockStripes>>(
-      new MerkleTree<Hasher, BranchingBits, LockStripes>(*this));
+
+  checkInternalConsistency();
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-std::unique_ptr<MerkleTree<Hasher, BranchingBits, LockStripes>>
-MerkleTree<Hasher, BranchingBits, LockStripes>::cloneWithDepth(std::uint64_t newDepth) const {
+template <typename Hasher, std::uint64_t const BranchingBits>
+std::unique_ptr<MerkleTree<Hasher, BranchingBits>> MerkleTree<Hasher, BranchingBits>::clone() {
+  // acquire the read-lock here to protect ourselves from concurrent modifications
   std::shared_lock<std::shared_mutex> guard(_bufferLock);
 
+  return std::unique_ptr<MerkleTree<Hasher, BranchingBits>>(
+      new MerkleTree<Hasher, BranchingBits>(*this));
+}
+
+template <typename Hasher, std::uint64_t const BranchingBits>
+std::unique_ptr<MerkleTree<Hasher, BranchingBits>>
+MerkleTree<Hasher, BranchingBits>::cloneWithDepth(std::uint64_t newDepth) const {
+  // arangod does not call this method! That is, because it is rather dangerous:
+  // To grow the depth, it has to modify `rangeMax` by multiplying `rangeMax-rangeMin` by
+  // the `branchingFactor`. This can quickly lead to integer overflow! Do not use without
+  // knowing exactly what you are doing!
+
+  // acquire the read-lock here to protect ourselves from concurrent modifications
+  std::shared_lock<std::shared_mutex> guard(_bufferLock);
+  
+  TRI_ASSERT(meta().rangeMin < meta().rangeMax);
+
   if (newDepth == meta().maxDepth) {
-    return std::unique_ptr<MerkleTree<Hasher, BranchingBits, LockStripes>>(
-        new MerkleTree<Hasher, BranchingBits, LockStripes>(*this));
+    // exact copy
+    return std::unique_ptr<MerkleTree<Hasher, BranchingBits>>(
+        new MerkleTree<Hasher, BranchingBits>(*this));
   }
 
   if (newDepth < meta().maxDepth) {
-    std::unique_ptr<MerkleTree<Hasher, BranchingBits, LockStripes>> newTree =
-        std::make_unique<MerkleTree<Hasher, BranchingBits, LockStripes>>(newDepth,
-                                                                         meta().rangeMin,
-                                                                         meta().rangeMax);
+    // shrinking
+    std::unique_ptr<MerkleTree<Hasher, BranchingBits>> newTree =
+        std::make_unique<MerkleTree<Hasher, BranchingBits>>(newDepth,
+                                                            meta().rangeMin,
+                                                            meta().rangeMax);
     for (std::uint64_t index = 0; index < nodeCountUpToDepth(newDepth); ++index) {
-      Node& n = this->node(index);
+      Node const& n = this->node(index);
       Node& m = newTree->node(index);
       m = n;
     }
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    newTree->checkInternalConsistency();
+#endif
     return newTree;
   }
 
@@ -504,36 +680,46 @@ MerkleTree<Hasher, BranchingBits, LockStripes>::cloneWithDepth(std::uint64_t new
   // than a couple levels at a time.
   std::uint64_t newRangeMax =
       meta().rangeMin + ((meta().rangeMax - meta().rangeMin) * BranchingFactor);
-  std::unique_ptr<MerkleTree<Hasher, BranchingBits, LockStripes>> newTree =
-      std::make_unique<MerkleTree<Hasher, BranchingBits, LockStripes>>(newDepth,
-                                                                       meta().rangeMin,
-                                                                       newRangeMax);
+ 
+  TRI_ASSERT(newRangeMax > meta().rangeMin);
+  TRI_ASSERT(newRangeMax > meta().rangeMax);
+
+  auto newTree = 
+      std::make_unique<MerkleTree<Hasher, BranchingBits>>(newDepth,
+                                                          meta().rangeMin,
+                                                          newRangeMax);
+  
   {
     for (std::uint64_t d = 0; d <= meta().maxDepth; ++d) {
       // copy each cell into the same index at the next level of the deeper tree
       std::uint64_t const offset = (d == 0 ? 0 : nodeCountUpToDepth(d - 1));
       std::uint64_t const offsetNew = nodeCountUpToDepth(d);
       for (std::uint64_t i = 0; i < nodeCountAtDepth(d); ++i) {
-        Node& n = this->node(offset + i);
+        Node const& n = this->node(offset + i);
         Node& m = newTree->node(offsetNew + i);
         m = n;
       }
-      // now copy the root into the root, special case
-      Node& n = this->node(0);
-      Node& m = newTree->node(0);
-      m = n;
     }
+      
+    // now copy the root into the root, special case
+    Node const& n = this->node(0);
+    Node& m = newTree->node(0);
+    m = n;
   }
 
   if (newDepth == meta().maxDepth + 1) {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    newTree->checkInternalConsistency();
+#endif
     return newTree;
   }
+
   return newTree->cloneWithDepth(newDepth);
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-std::vector<std::pair<std::uint64_t, std::uint64_t>> MerkleTree<Hasher, BranchingBits, LockStripes>::diff(
-    MerkleTree<Hasher, BranchingBits, LockStripes>& other) {
+template <typename Hasher, std::uint64_t const BranchingBits>
+std::vector<std::pair<std::uint64_t, std::uint64_t>> MerkleTree<Hasher, BranchingBits>::diff(
+    MerkleTree<Hasher, BranchingBits>& other) {
   std::shared_lock<std::shared_mutex> guard1(_bufferLock);
   std::shared_lock<std::shared_mutex> guard2(other._bufferLock);
 
@@ -545,12 +731,12 @@ std::vector<std::pair<std::uint64_t, std::uint64_t>> MerkleTree<Hasher, Branchin
     if (this->meta().rangeMax < other.meta().rangeMax) {
       // grow this to match other range
       guard1.unlock();
-      this->grow(other.meta().rangeMax - 1, "diffOurs");
+      this->grow(other.meta().rangeMax - 1);
       guard1.lock();
     } else {
       // grow other to match this range
       guard2.unlock();
-      other.grow(this->meta().rangeMax - 1, "diffOther");
+      other.grow(this->meta().rangeMax - 1);
       guard2.lock();
     }
     // loop to repeat check to make sure someone else didn't grow while we
@@ -593,17 +779,31 @@ std::vector<std::pair<std::uint64_t, std::uint64_t>> MerkleTree<Hasher, Branchin
   return result;
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-std::string MerkleTree<Hasher, BranchingBits, LockStripes>::toString() const {
+template <typename Hasher, std::uint64_t const BranchingBits>
+std::string MerkleTree<Hasher, BranchingBits>::toString(bool full) const {
+  std::string output;
+
   std::shared_lock<std::shared_mutex> guard(_bufferLock);
-  std::string output("{");
+
+  if (full) {
+    output.append("Merkle-tree ");
+    output.append("- maxDepth: ");
+    output.append(std::to_string(meta().maxDepth));
+    output.append(", rangeMin: ");
+    output.append(std::to_string(meta().rangeMin));
+    output.append(", rangeMax: ");
+    output.append(std::to_string(meta().rangeMax));
+    output.append(", count: ");
+    output.append(std::to_string(count()));
+    output.append(" ");
+  }
+  output.append("{");
   for (std::uint64_t depth = 0; depth <= meta().maxDepth; ++depth) {
     output.append(std::to_string(depth));
     output.append(": [");
     for (std::uint64_t chunk = 0; chunk < nodeCountAtDepth(depth); ++chunk) {
       std::uint64_t index = this->index(chunk, depth);
-      std::unique_lock<std::mutex> guard(this->lock(index));
-      Node& node = this->node(index);
+      Node const& node = this->node(index);
       output.append("[");
       output.append(std::to_string(node.count));
       output.append(",");
@@ -616,10 +816,11 @@ std::string MerkleTree<Hasher, BranchingBits, LockStripes>::toString() const {
   return output;
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-void MerkleTree<Hasher, BranchingBits, LockStripes>::serialize(velocypack::Builder& output,
-                                                               std::uint64_t maxDepth) const {
-  std::unique_lock<std::shared_mutex> guard(_bufferLock);
+template <typename Hasher, std::uint64_t const BranchingBits>
+void MerkleTree<Hasher, BranchingBits>::serialize(velocypack::Builder& output,
+                                                  std::uint64_t maxDepth) const {
+  std::shared_lock<std::shared_mutex> guard(_bufferLock);
+
   TRI_ASSERT(output.isEmpty());
   char ridBuffer[arangodb::basics::maxUInt64StringSize];
   std::uint64_t depth = std::min(maxDepth, meta().maxDepth);
@@ -635,40 +836,46 @@ void MerkleTree<Hasher, BranchingBits, LockStripes>::serialize(velocypack::Build
   velocypack::ArrayBuilder nodeArrayGuard(&output, StaticStrings::RevisionTreeNodes);
   for (std::uint64_t index = 0; index < nodeCountUpToDepth(depth); ++index) {
     velocypack::ObjectBuilder nodeGuard(&output);
-    std::unique_lock<std::mutex> guard(this->lock(index));
-    Node& node = this->node(index);
+    Node const& node = this->node(index);
     output.add(StaticStrings::RevisionTreeHash,
                basics::HybridLogicalClock::encodeTimeStampToValuePair(node.hash, ridBuffer));
     output.add(StaticStrings::RevisionTreeCount, velocypack::Value(node.count));
   }
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-void MerkleTree<Hasher, BranchingBits, LockStripes>::serializeBinary(std::string& output,
-                                                                     bool compress) const {
-  std::unique_lock<std::shared_mutex> guard(_bufferLock);
+template <typename Hasher, std::uint64_t const BranchingBits>
+void MerkleTree<Hasher, BranchingBits>::serializeBinary(std::string& output,
+                                                        bool compress) const {
+  std::shared_lock<std::shared_mutex> guard(_bufferLock);
+
   TRI_ASSERT(output.empty());
+    
   if (compress) {
-    snappy::Compress(reinterpret_cast<char*>(_buffer.get()),
-                     allocationSize(meta().maxDepth), &output);
-    output.push_back(::CompressedCurrent);
+    if (this->node(0).count <= 15'000) {
+      // 15'000 is an arbitrary cutoff value for when to move from
+      // bottom-most level compression to full tree compression with Snappy
+      storeBottomMostCompressed(output);
+      output.push_back(::CompressedBottomMostCurrent);
+    } else {
+      snappy::Compress(reinterpret_cast<char*>(_buffer.get()),
+                       allocationSize(meta().maxDepth), &output);
+      output.push_back(::CompressedSnappyCurrent);
+    }
   } else {
     output.append(reinterpret_cast<char*>(_buffer.get()), allocationSize(meta().maxDepth));
     output.push_back(::UncompressedCurrent);
   }
+
   output.push_back(static_cast<char>(::CurrentVersion));
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
+template <typename Hasher, std::uint64_t const BranchingBits>
 std::vector<std::pair<std::uint64_t, std::uint64_t>>
-MerkleTree<Hasher, BranchingBits, LockStripes>::partitionKeys(std::uint64_t count) {
+MerkleTree<Hasher, BranchingBits>::partitionKeys(std::uint64_t count) const {
   std::vector<std::pair<std::uint64_t, std::uint64_t>> result;
+
   std::shared_lock<std::shared_mutex> guard(_bufferLock);
-  std::uint64_t remaining = 0;
-  {
-    std::unique_lock<std::mutex> lock(this->lock(0));
-    remaining = node(0).count;
-  }
+  std::uint64_t remaining = node(0).count;
 
   if (count <= 1 || remaining == 0) {
     // special cases, just return full range
@@ -683,13 +890,12 @@ MerkleTree<Hasher, BranchingBits, LockStripes>::partitionKeys(std::uint64_t coun
   std::uint64_t rangeCount = 0;
   for (std::uint64_t chunk = 0; chunk < nodeCountAtDepth(depth); ++chunk) {
     if (result.size() == count - 1) {
-      // if we are generating the last partion, just fast forward to the last
+      // if we are generating the last partition, just fast forward to the last
       // chunk, put everything in
       chunk = nodeCountAtDepth(depth) - 1;
     }
     std::uint64_t index = offset + chunk;
-    std::unique_lock<std::mutex> guard(this->lock(index));
-    Node& node = this->node(index);
+    Node const& node = this->node(index);
     rangeCount += node.count;
     if (rangeCount >= targetCount || chunk == nodeCountAtDepth(depth) - 1) {
       auto [_, rangeEnd] = chunkRange(chunk, depth);
@@ -711,51 +917,83 @@ MerkleTree<Hasher, BranchingBits, LockStripes>::partitionKeys(std::uint64_t coun
   return result;
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-MerkleTree<Hasher, BranchingBits, LockStripes>::MerkleTree(std::string_view buffer)
+template <typename Hasher, std::uint64_t const BranchingBits>
+MerkleTree<Hasher, BranchingBits>::MerkleTree(std::string_view buffer)
     : _buffer(new uint8_t[buffer.size()]) {
+  if (buffer.size() < allocationSize(/*minDepth*/ 2)) {
+    throw std::invalid_argument("Invalid (too small) buffer size for tree");
+  }
+  
+  // no lock necessary here, as no other thread can see us yet
   std::memcpy(_buffer.get(), buffer.data(), buffer.size());
+
+  if (buffer.size() != allocationSize(meta().maxDepth)) {
+    throw std::invalid_argument("Unexpected buffer size for tree");
+  }
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-MerkleTree<Hasher, BranchingBits, LockStripes>::MerkleTree(
-    MerkleTree<Hasher, BranchingBits, LockStripes> const& other)
+  template <typename Hasher, std::uint64_t const BranchingBits>
+MerkleTree<Hasher, BranchingBits>::MerkleTree(std::unique_ptr<uint8_t[]> buffer)
+    : _buffer(std::move(buffer)) {}
+
+template <typename Hasher, std::uint64_t const BranchingBits>
+MerkleTree<Hasher, BranchingBits>::MerkleTree(MerkleTree<Hasher, BranchingBits> const& other)
     : _buffer(new uint8_t[allocationSize(other.meta().maxDepth)]) {
+  // this is a protected constructor, and we get here only via clone() or cloneWithDepth().
+  // in this case  other  is already properly locked
+
+  // no lock necessary here for ourselves, as no other thread can see us yet
   new (&meta()) Meta{other.meta().rangeMin, other.meta().rangeMax, other.meta().maxDepth};
 
   std::uint64_t const last = nodeCountUpToDepth(meta().maxDepth);
   for (std::uint64_t i = 0; i < last; ++i) {
-    std::unique_lock<std::mutex> nodeGuard(other.lock(i));
-    new (&this->node(i)) Node{other.node(i).hash, other.node(i).count};
+    new (&this->node(i)) Node{other.node(i).count, other.node(i).hash};
   }
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  TRI_ASSERT(meta().maxDepth == other.meta().maxDepth);
+  TRI_ASSERT(meta().rangeMin == other.meta().rangeMin);
+  TRI_ASSERT(meta().rangeMax == other.meta().rangeMax);
+  
+#ifdef PARANOID_TREE_CHECKS
+  checkInternalConsistency();
+
+  for (std::uint64_t i = 0; i < last; ++i) {
+    TRI_ASSERT(this->node(i) == other.node(i));
+  }
+#endif
+#endif
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-typename MerkleTree<Hasher, BranchingBits, LockStripes>::Meta&
-MerkleTree<Hasher, BranchingBits, LockStripes>::meta() const {
+template <typename Hasher, std::uint64_t const BranchingBits>
+typename MerkleTree<Hasher, BranchingBits>::Meta&
+MerkleTree<Hasher, BranchingBits>::meta() const noexcept {
   // not thread-safe, lock buffer from outside
   TRI_ASSERT(_buffer);
   return *reinterpret_cast<Meta*>(_buffer.get());
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-typename MerkleTree<Hasher, BranchingBits, LockStripes>::Node&
-MerkleTree<Hasher, BranchingBits, LockStripes>::node(std::uint64_t index) const {
+template <typename Hasher, std::uint64_t const BranchingBits>
+typename MerkleTree<Hasher, BranchingBits>::Node&
+MerkleTree<Hasher, BranchingBits>::node(std::uint64_t index) noexcept {
   // not thread-safe, lock buffer from outside
   TRI_ASSERT(index < nodeCountUpToDepth(meta().maxDepth));
   uint8_t* ptr = _buffer.get() + MetaSize + (NodeSize * index);
   return *reinterpret_cast<Node*>(ptr);
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-std::mutex& MerkleTree<Hasher, BranchingBits, LockStripes>::lock(std::uint64_t index) const {
-  Hasher h;
-  return _nodeLocks[h.hash(index) % LockStripes];
+template <typename Hasher, std::uint64_t const BranchingBits>
+typename MerkleTree<Hasher, BranchingBits>::Node const&
+MerkleTree<Hasher, BranchingBits>::node(std::uint64_t index) const noexcept {
+  // not thread-safe, lock buffer from outside
+  TRI_ASSERT(index < nodeCountUpToDepth(meta().maxDepth));
+  uint8_t const* ptr = _buffer.get() + MetaSize + (NodeSize * index);
+  return *reinterpret_cast<Node const*>(ptr);
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-std::uint64_t MerkleTree<Hasher, BranchingBits, LockStripes>::index(std::uint64_t key,
-                                                                    std::uint64_t depth) const {
+template <typename Hasher, std::uint64_t const BranchingBits>
+std::uint64_t MerkleTree<Hasher, BranchingBits>::index(std::uint64_t key,
+                                                       std::uint64_t depth) const noexcept {
   // not thread-safe, lock buffer from outside
   TRI_ASSERT(depth <= meta().maxDepth);
   TRI_ASSERT(key >= meta().rangeMin);
@@ -775,33 +1013,35 @@ std::uint64_t MerkleTree<Hasher, BranchingBits, LockStripes>::index(std::uint64_
   return chunk + nodeCountUpToDepth(depth - 1);
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-void MerkleTree<Hasher, BranchingBits, LockStripes>::modify(std::uint64_t key, bool isInsert) {
+template <typename Hasher, std::uint64_t const BranchingBits>
+void MerkleTree<Hasher, BranchingBits>::modify(std::uint64_t key, bool isInsert) {
   // not thread-safe, shared-lock buffer from outside
   Hasher h;
   std::uint64_t const value = h.hash(key);
   for (std::uint64_t depth = 0; depth <= meta().maxDepth; ++depth) {
-    bool success = modifyLocal(depth, key, value, isInsert, true);
-    if (!success) {
+    bool success = modifyLocal(depth, key, value, isInsert);
+    if (ADB_UNLIKELY(!success)) {
       // roll back the changes we already made, using best effort
       for (std::uint64_t d = 0; d < depth; ++d) {
-        [[maybe_unused]] bool rolledBack = modifyLocal(d, key, value, !isInsert, true);
+        [[maybe_unused]] bool rolledBack = modifyLocal(d, key, value, !isInsert);
       }
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+      checkInternalConsistency();
+#endif
       throw std::invalid_argument("Tried to remove key that is not present.");
     }
   }
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-void MerkleTree<Hasher, BranchingBits, LockStripes>::modify(std::vector<std::uint64_t> const& keys,
-                                                            bool isInsert) {
+template <typename Hasher, std::uint64_t const BranchingBits>
+void MerkleTree<Hasher, BranchingBits>::modify(std::vector<std::uint64_t> const& keys,
+                                               bool isInsert) {
   // not thread-safe, unique-lock buffer from outside
   Hasher h;
-  bool success = true;
-  for (std::uint64_t depth = 0; depth <= meta().maxDepth && success; ++depth) {
+  for (std::uint64_t depth = 0; depth <= meta().maxDepth; ++depth) {
     for (std::uint64_t key : keys) {
-      success = modifyLocal(depth, key, h.hash(key), isInsert, false);
-      if (!success) {
+      bool success = modifyLocal(depth, key, h.hash(key), isInsert);
+      if (ADB_UNLIKELY(!success)) {
         // roll back the changes we already made, using best effort
         for (std::uint64_t d = 0; d <= depth; ++d) {
           for (std::uint64_t k : keys) {
@@ -810,32 +1050,29 @@ void MerkleTree<Hasher, BranchingBits, LockStripes>::modify(std::vector<std::uin
               break;
             }
             [[maybe_unused]] bool rolledBack =
-                modifyLocal(d, k, h.hash(k), !isInsert, false);
+                modifyLocal(d, k, h.hash(k), !isInsert);
           }
         }
-        break;
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+        checkInternalConsistency();
+#endif
+        throw std::invalid_argument("Tried to remove key that is not present.");
       }
     }
   }
-  if (!success) {
-    throw std::invalid_argument("Tried to remove key that is not present.");
-  }
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-bool MerkleTree<Hasher, BranchingBits, LockStripes>::modifyLocal(
-    std::uint64_t depth, std::uint64_t key, std::uint64_t value, bool isInsert, bool doLock) {
+template <typename Hasher, std::uint64_t const BranchingBits>
+bool MerkleTree<Hasher, BranchingBits>::modifyLocal(
+    std::uint64_t depth, std::uint64_t key, std::uint64_t value, bool isInsert) {
   // only use via modify
   std::uint64_t index = this->index(key, depth);
   Node& node = this->node(index);
-  std::unique_lock<std::mutex> lock(this->lock(index), std::defer_lock);
-  if (doLock) {
-    lock.lock();
-  }
+  
   if (isInsert) {
     ++node.count;
   } else {
-    if (node.count == 0) {
+    if (ADB_UNLIKELY(node.count == 0)) {
       return false;
     }
     --node.count;
@@ -845,72 +1082,86 @@ bool MerkleTree<Hasher, BranchingBits, LockStripes>::modifyLocal(
   return true;
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-void MerkleTree<Hasher, BranchingBits, LockStripes>::grow(std::uint64_t key, char const* context) {
-  // context is here for debugging only
-  TRI_ASSERT(context != nullptr);
-
-  std::unique_lock<std::shared_mutex> guard(_bufferLock);
-  // no need to lock nodes as we have an exclusive lock on the buffer
-
-  std::uint64_t rangeMin = meta().rangeMin;
-  std::uint64_t rangeMax = meta().rangeMax;
-  if (key < rangeMax) {
-    // someone else resized already while we were waiting for the lock
-    return;
-  }
-
-  std::uint64_t factor = 0;
-  try {
-    factor = minimumFactorFor(rangeMax - rangeMin, key - rangeMin);
-  } catch (...) {
-    LOG_TOPIC("15384", WARN, Logger::ENGINES)
-        << "invalid tree grow command. key: " << key 
-        << ", rangeMin: " << rangeMin
-        << ", rangeMax: " << rangeMax
-        << ", maxDepth: " << meta().maxDepth
-        << ", context: " << context;
-    throw;
-  }
-
-  TRI_ASSERT(factor != 0);
-
+template <typename Hasher, std::uint64_t const BranchingBits>
+void MerkleTree<Hasher, BranchingBits>::leftCombine(std::uint64_t factor) noexcept {
+  // not fully thread-safe, lock nodes from outside
   for (std::uint64_t depth = 1; depth <= meta().maxDepth; ++depth) {
     // iterate over all nodes and left-combine, (skipping the first, identity)
     std::uint64_t offset = nodeCountUpToDepth(depth - 1);
     for (std::uint64_t index = 1; index < nodeCountAtDepth(depth); ++index) {
       Node& src = this->node(offset + index);
       Node& dst = this->node(offset + (index / factor));
+
+      TRI_ASSERT(&src != &dst);
       dst.count += src.count;
       dst.hash ^= src.hash;
       src = Node{0, 0};
     }
   }
-
-  meta().rangeMax = rangeMin + ((rangeMax - rangeMin) * factor);
-  TRI_ASSERT(key < meta().rangeMax);
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-bool MerkleTree<Hasher, BranchingBits, LockStripes>::equalAtIndex(
-    MerkleTree<Hasher, BranchingBits, LockStripes> const& other, std::uint64_t index) const {
-  // not fully thread-safe, lock buffer from outside
-  std::unique_lock<std::mutex> lock1(this->lock(index));
-  std::unique_lock<std::mutex> lock2(other.lock(index));
+template <typename Hasher, std::uint64_t const BranchingBits>
+void MerkleTree<Hasher, BranchingBits>::grow(std::uint64_t key) {
+  std::unique_lock<std::shared_mutex> guard(_bufferLock);
+
+  std::uint64_t rangeMin = meta().rangeMin;
+  std::uint64_t rangeMax = meta().rangeMax;
+
+  TRI_ASSERT(rangeMin < rangeMax);
+
+  if (key < rangeMax) {
+    // someone else resized already while we were waiting for the lock
+    return;
+  }
+
+  std::uint64_t factor = minimumFactorFor(rangeMax - rangeMin, key - rangeMin);
+  TRI_ASSERT(factor != 0);
+  TRI_ASSERT(NumberUtils::isPowerOf2(factor));
+  
+  if (!NumberUtils::isPowerOf2(factor)) {
+    throw std::invalid_argument("Expecting factor to be power of 2");
+  }
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  std::uint64_t count = this->node(0).count;
+#endif 
+
+  leftCombine(factor);
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  TRI_ASSERT(count == this->node(0).count);
+#endif 
+
+  meta().rangeMax = rangeMin + ((rangeMax - rangeMin) * factor);
+
+  TRI_ASSERT(meta().rangeMin < meta().rangeMax);
+  TRI_ASSERT(key < meta().rangeMax);
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+#ifdef PARANOID_TREE_CHECKS
+  checkInternalConsistency();
+#endif
+#endif
+}
+
+template <typename Hasher, std::uint64_t const BranchingBits>
+bool MerkleTree<Hasher, BranchingBits>::equalAtIndex(
+    MerkleTree<Hasher, BranchingBits> const& other, std::uint64_t index) const noexcept {
+  // not fully thread-safe, lock nodes from outside
   return (this->node(index) == other.node(index));
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-bool MerkleTree<Hasher, BranchingBits, LockStripes>::childrenAreLeaves(std::uint64_t index) {
+template <typename Hasher, std::uint64_t const BranchingBits>
+bool MerkleTree<Hasher, BranchingBits>::childrenAreLeaves(std::uint64_t index) const noexcept {
   // not thread-safe, lock buffer from outside
   std::uint64_t maxDepth = meta().maxDepth;
   return index >= nodeCountUpToDepth(maxDepth - 2) &&
          index < nodeCountUpToDepth(maxDepth - 1);
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
-std::pair<std::uint64_t, std::uint64_t> MerkleTree<Hasher, BranchingBits, LockStripes>::chunkRange(
-    std::uint64_t chunk, std::uint64_t depth) {
+template <typename Hasher, std::uint64_t const BranchingBits>
+std::pair<std::uint64_t, std::uint64_t> MerkleTree<Hasher, BranchingBits>::chunkRange(
+    std::uint64_t chunk, std::uint64_t depth) const {
   // not thread-safe, lock buffer from outside
   std::uint64_t rangeMin = meta().rangeMin;
   std::uint64_t rangeMax = meta().rangeMax;
@@ -920,15 +1171,112 @@ std::pair<std::uint64_t, std::uint64_t> MerkleTree<Hasher, BranchingBits, LockSt
                         rangeMin + (chunkSizeAtDepth * (chunk + 1)) - 1);
 }
 
-template <typename Hasher, std::uint64_t const BranchingBits, std::uint64_t const LockStripes>
+template <typename Hasher, std::uint64_t const BranchingBits>
+void MerkleTree<Hasher, BranchingBits>::checkInternalConsistency() const {
+  // not thread-safe, lock buffer from outside
+  if (!_buffer) {
+    return;
+  }
+
+  // validate meta data
+  std::uint64_t maxDepth = meta().maxDepth;
+  std::uint64_t rangeMin = meta().rangeMin;
+  std::uint64_t rangeMax = meta().rangeMax;
+  
+  if (maxDepth < 2) {
+    throw std::invalid_argument("Invalid tree maxDepth");
+  }
+
+  if (rangeMin >= rangeMax) { // || rangeMin == 0) {
+    throw std::invalid_argument("Invalid tree rangeMin / rangeMax");
+  }
+  if (!NumberUtils::isPowerOf2(rangeMax - rangeMin)) {
+    throw std::invalid_argument("Expecting difference between min and max to be power of 2");
+  }
+
+  std::uint64_t previousCount = this->node(0).count;
+  std::uint64_t previousHash = this->node(0).hash;
+
+  for (std::uint64_t d = 1; d <= maxDepth; ++d) {
+    std::uint64_t const offset = nodeCountUpToDepth(d - 1);
+    std::uint64_t count = 0;
+    std::uint64_t hash = 0;
+
+    for (std::uint64_t i = 0; i < nodeCountAtDepth(d); ++i) {
+      Node const& n = this->node(offset + i);
+      count += n.count;
+      hash ^= n.hash;
+
+      TRI_ASSERT(n.count != 0 || n.hash == 0);
+    }
+
+    if (count != previousCount) {
+      throw std::invalid_argument("Inconsistent count values in tree");
+    }
+    previousCount = count;
+    
+    if (hash != previousHash) {
+      throw std::invalid_argument("Inconsistent hash values in tree");
+    }
+  }
+}
+
+template <typename Hasher, std::uint64_t const BranchingBits>
+void MerkleTree<Hasher, BranchingBits>::storeBottomMostCompressed(std::string& output) const {
+  // make a minimum allocation that will be enough for the meta data and a 
+  // few notes. if we need more space, the string can grow as needed
+  TRI_ASSERT(output.empty());
+  output.reserve(64);
+
+  // rangeMin / rangeMax / maxDepth
+  {
+    uint64_t value = basics::hostToLittle(meta().rangeMin);
+    output.append(reinterpret_cast<const char*>(&value), sizeof(uint64_t));
+    
+    value = basics::hostToLittle(meta().rangeMax);
+    output.append(reinterpret_cast<const char*>(&value), sizeof(uint64_t));
+    
+    value = basics::hostToLittle(meta().maxDepth);
+    output.append(reinterpret_cast<const char*>(&value), sizeof(uint64_t));
+  }
+  
+  std::uint64_t maxDepth = meta().maxDepth;
+  std::uint64_t offset = nodeCountUpToDepth(maxDepth - 1);
+  for (std::uint64_t index = 0; index < nodeCountAtDepth(maxDepth); ++index) {
+    Node const& src = this->node(offset + index);
+    TRI_ASSERT(src.count > 0 || src.hash == 0);
+
+    // serialize only the non-zero buckets
+    if (src.count > 0) {
+      // index
+      {
+        uint32_t value = basics::hostToLittle(static_cast<uint32_t>(index));
+        output.append(reinterpret_cast<const char*>(&value), sizeof(uint32_t));
+      }
+      // count / hash
+      {
+        uint64_t value = basics::hostToLittle(src.count);
+        output.append(reinterpret_cast<const char*>(&value), sizeof(uint64_t));
+        
+        value = basics::hostToLittle(src.hash);
+        output.append(reinterpret_cast<const char*>(&value), sizeof(uint64_t));
+      }
+    }
+  }
+
+  TRI_ASSERT(output.size() >= 3 * sizeof(uint64_t));
+  TRI_ASSERT((output.size() - 3 * sizeof(uint64_t)) % (sizeof(uint32_t) + 2 * sizeof(uint64_t)) == 0);
+}
+
+template <typename Hasher, std::uint64_t const BranchingBits>
 std::ostream& operator<<(std::ostream& stream,
-                         MerkleTree<Hasher, BranchingBits, LockStripes> const& tree) {
-  return stream << tree.toString();
+                         MerkleTree<Hasher, BranchingBits> const& tree) {
+  return stream << tree.toString(true);
 }
 
 /// INSTANTIATIONS
-template class MerkleTree<FnvHashProvider, 3, 64>;
-template std::ostream& operator<<(std::ostream& stream, MerkleTree<FnvHashProvider, 3, 64> const&);
+template class MerkleTree<FnvHashProvider, 3>;
+template std::ostream& operator<<(std::ostream& stream, MerkleTree<FnvHashProvider, 3> const&);
 
 }  // namespace containers
 }  // namespace arangodb

--- a/tests/Containers/MerkleTreeTest.cpp
+++ b/tests/Containers/MerkleTreeTest.cpp
@@ -48,8 +48,8 @@ std::vector<std::uint64_t> permutation(std::uint64_t n) {
 }
 
 bool diffAsExpected(
-    ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64>& t1,
-    ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64>& t2,
+    ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>& t1,
+    ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>& t2,
     std::vector<std::pair<std::uint64_t, std::uint64_t>>& expected) {
   std::vector<std::pair<std::uint64_t, std::uint64_t>> d1 = t1.diff(t2);
   std::vector<std::pair<std::uint64_t, std::uint64_t>> d2 = t2.diff(t1);
@@ -74,7 +74,7 @@ bool diffAsExpected(
 }
 
 bool partitionAsExpected(
-    ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64>& tree,
+    ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>& tree,
     std::uint64_t count, std::vector<std::pair<std::uint64_t, std::uint64_t>> expected) {
   std::vector<std::pair<std::uint64_t, std::uint64_t>> partitions =
       tree.partitionKeys(count);
@@ -93,7 +93,7 @@ bool partitionAsExpected(
 }  // namespace
 
 class TestNodeCountAtDepth
-    : public arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64> {
+    : public arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> {
   static_assert(nodeCountAtDepth(0) == 1);
   static_assert(nodeCountAtDepth(1) == 8);
   static_assert(nodeCountAtDepth(2) == 64);
@@ -103,11 +103,11 @@ class TestNodeCountAtDepth
 };
 
 class InternalMerkleTreeTest
-    : public ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64>,
+    : public ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>,
       public ::testing::Test {
  public:
   InternalMerkleTreeTest()
-      : MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64>(2, 0, 64) {}
+      : MerkleTree<::arangodb::containers::FnvHashProvider, 3>(2, 0, 64) {}
 };
 
 TEST_F(InternalMerkleTreeTest, test_childrenAreLeaves) {
@@ -395,20 +395,20 @@ TEST_F(InternalMerkleTreeTest, test_partition) {
        {55, 56}, {57, 58}, {59, 60}, {61, 62}}));
 
   // now let's make the distribution more uneven and see how things go
-  this->grow(511, "test");
+  this->grow(511);
 
   ASSERT_TRUE(::partitionAsExpected(*this, 3, {{0, 23}, {24, 47}, {48, 511}}));
   ASSERT_TRUE(::partitionAsExpected(*this, 4, {{0, 15}, {16, 31}, {32, 47}, {48, 511}}));
 
   // lump it all in one cell
-  this->grow(4095, "test");
+  this->grow(4095);
 
   ASSERT_TRUE(::partitionAsExpected(*this, 4, {{0, 63}}));
 }
 
 TEST(MerkleTreeTest, test_diff_equal) {
-  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64> t1(2, 0, 64);
-  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64> t2(2, 0, 64);
+  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t1(2, 0, 64);
+  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t2(2, 0, 64);
 
   std::vector<std::pair<std::uint64_t, std::uint64_t>> expected;  // empty
   ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
@@ -429,8 +429,8 @@ TEST(MerkleTreeTest, test_diff_equal) {
 }
 
 TEST(MerkleTreeTest, test_diff_one_empty) {
-  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64> t1(2, 0, 64);
-  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64> t2(2, 0, 64);
+  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t1(2, 0, 64);
+  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t2(2, 0, 64);
 
   std::vector<std::pair<std::uint64_t, std::uint64_t>> expected;
   ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
@@ -468,8 +468,8 @@ TEST(MerkleTreeTest, test_diff_one_empty) {
 }
 
 TEST(MerkleTreeTest, test_diff_misc) {
-  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64> t1(2, 0, 64);
-  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64> t2(2, 0, 64);
+  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t1(2, 0, 64);
+  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t2(2, 0, 64);
 
   std::vector<std::pair<std::uint64_t, std::uint64_t>> expected;
   ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
@@ -497,7 +497,7 @@ TEST(MerkleTreeTest, test_diff_misc) {
 }
 
 TEST(MerkleTreeTest, test_serializeBinary) {
-  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64> t1(2, 0, 64);
+  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t1(2, 0, 64);
 
   for (std::uint64_t i = 0; i < 32; ++i) {
     t1.insert(2 * i);
@@ -505,15 +505,15 @@ TEST(MerkleTreeTest, test_serializeBinary) {
 
   std::string t1s;
   t1.serializeBinary(t1s, true);
-  std::unique_ptr<::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64>> t2 =
-      ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64>::fromBuffer(t1s);
+  std::unique_ptr<::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>> t2 =
+      ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>::fromBuffer(t1s);
   ASSERT_NE(t2, nullptr);
   ASSERT_TRUE(t1.diff(*t2).empty());
   ASSERT_TRUE(t2->diff(t1).empty());
 }
 
 TEST(MerkleTreeTest, test_serializePortable) {
-  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64> t1(2, 0, 64);
+  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t1(2, 0, 64);
 
   for (std::uint64_t i = 0; i < 32; ++i) {
     t1.insert(2 * i);
@@ -521,8 +521,8 @@ TEST(MerkleTreeTest, test_serializePortable) {
 
   ::arangodb::velocypack::Builder t1s;
   t1.serialize(t1s);
-  std::unique_ptr<::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64>> t2 =
-      ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64>::deserialize(
+  std::unique_ptr<::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>> t2 =
+      ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>::deserialize(
           t1s.slice());
   ASSERT_NE(t2, nullptr);
   ASSERT_TRUE(t1.diff(*t2).empty());
@@ -530,8 +530,8 @@ TEST(MerkleTreeTest, test_serializePortable) {
 }
 
 TEST(MerkleTreeTest, test_deepen) {
-  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64> t1(2, 0, 64);
-  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3, 64> t2(2, 0, 64);
+  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t1(2, 0, 64);
+  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t2(2, 0, 64);
 
   std::vector<std::pair<std::uint64_t, std::uint64_t>> expected;  // empty
   ASSERT_TRUE(::diffAsExpected(t1, t2, expected));

--- a/tests/js/server/recovery/check-warnings.js
+++ b/tests/js/server/recovery/check-warnings.js
@@ -78,7 +78,7 @@ function recoverySuite () {
         }
         if (internal.env["isAsan"] === "true" && line.match(/\[3ad54\].*=+/)) {
           // intentionally ignore "slow background settings sync: " in case of ASan
-          return false
+          return false;
         }
 
         return true;


### PR DESCRIPTION
### Scope & Purpose

Improve error reporting for Merkle tree operations, and improve robustness of the trees.
In addition reduce memory usage for unused trees by hibernating them.
This also adds a backoff procedure in case there are repeated synchronization failures for the same shard. If there are too many failures in a row, it will finally drop the follower shard, so it can be completely rebuilt from the leader data.

Additional tests for replication and tree operations will follow separately.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: https://github.com/arangodb/arangodb/pull/14163

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *recovery, replication, shell_client*.

Additional tests will follow in a separate PR.