### PR TITLE
Throw an exception when a negative edge weight is detected.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.8.0 (XXXX-XX-XX)
 -------------------
 
+* Return error 1948 when a negative edge was detected during a weighted traversal
+  or was used as default weight.
+
 * Fixed BTS-403: Hot restores must also clear relevant `Current` keys. The
   overriding of the `Plan` entries needs to be reflected in `Current` to avoid
   conflicts in maintenance jobs.

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -255,6 +255,11 @@ std::unique_ptr<graph::BaseOptions> createTraversalOptions(Ast* ast,
           }
         } else if (name == "defaultWeight" && value->isNumericValue()) {
           options->defaultWeight = value->getDoubleValue();
+          if (options->defaultWeight < 0.) {
+            THROW_ARANGO_EXCEPTION_MESSAGE(
+                TRI_ERROR_GRAPH_NEGATIVE_EDGE_WEIGHT,
+                "negative default weight not allowed");
+          }
         } else if (name == "weightAttribute" && value->isStringValue()) {
           options->weightAttribute = value->getString();
         } else if (name == "parallelism") {

--- a/arangod/Graph/TraverserOptions.cpp
+++ b/arangod/Graph/TraverserOptions.cpp
@@ -143,6 +143,10 @@ TraverserOptions::TraverserOptions(arangodb::aql::QueryContext& query,
 
   weightAttribute = VPackHelper::getStringValue(obj, "weightAttribute", "");
   defaultWeight = VPackHelper::getNumericValue<double>(obj, "defaultWeight", 1);
+  if (defaultWeight < 0.) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_GRAPH_NEGATIVE_EDGE_WEIGHT,
+                                   "negative default weight not allowed");
+  }
 
   VPackSlice read = obj.get("vertexCollections");
   if (read.isString()) {
@@ -300,6 +304,10 @@ TraverserOptions::TraverserOptions(arangodb::aql::QueryContext& query, VPackSlic
 
   weightAttribute = VPackHelper::getStringValue(info, "weightAttribute", "");
   defaultWeight = VPackHelper::getNumericValue<double>(info, "defaultWeight", 1);
+  if (defaultWeight < 0.) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_GRAPH_NEGATIVE_EDGE_WEIGHT,
+                                   "negative default weight not allowed");
+  }
 
   read = info.get("vertexCollections");
   if (read.isString()) {
@@ -823,8 +831,14 @@ void TraverserOptions::activatePrune(std::vector<aql::Variable const*> vars,
 
 double TraverserOptions::weightEdge(VPackSlice edge) const {
   TRI_ASSERT(mode == Order::WEIGHTED);
-  return arangodb::basics::VelocyPackHelper::getNumericValue<double>(edge, weightAttribute,
-                                                                     defaultWeight);
+  const auto weight =
+      arangodb::basics::VelocyPackHelper::getNumericValue<double>(edge, weightAttribute,
+                                                                  defaultWeight);
+  if (weight < 0.) {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_GRAPH_NEGATIVE_EDGE_WEIGHT);
+  }
+
+  return weight;
 }
 
 bool TraverserOptions::hasWeightAttribute() const {

--- a/js/common/bootstrap/errors.js
+++ b/js/common/bootstrap/errors.js
@@ -277,6 +277,7 @@
     "ERROR_GRAPH_COLLECTION_IS_INITIAL" : { "code" : 1945, "message" : "initial collection is not allowed to be removed manually" },
     "ERROR_GRAPH_NO_INITIAL_COLLECTION" : { "code" : 1946, "message" : "no valid initial collection found" },
     "ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED" : { "code" : 1947, "message" : "referenced vertex collection is not part of the graph" },
+    "ERROR_GRAPH_NEGATIVE_EDGE_WEIGHT" : { "code" : 1948, "message" : "negative edge weight found" },
     "ERROR_SESSION_UNKNOWN"        : { "code" : 1950, "message" : "unknown session" },
     "ERROR_SESSION_EXPIRED"        : { "code" : 1951, "message" : "session expired" },
     "ERROR_SIMPLE_CLIENT_UNKNOWN_ERROR" : { "code" : 2000, "message" : "unknown client error" },

--- a/lib/Basics/error-registry.h
+++ b/lib/Basics/error-registry.h
@@ -16,7 +16,7 @@ struct elsa<ErrorCode> {
 #include <frozen/unordered_map.h>
 
 namespace arangodb::error {
-constexpr static frozen::unordered_map<ErrorCode, const char*, 353> ErrorMessages = {
+constexpr static frozen::unordered_map<ErrorCode, const char*, 354> ErrorMessages = {
     {TRI_ERROR_NO_ERROR,  // 0
       "no error"},
     {TRI_ERROR_FAILED,  // 1
@@ -555,6 +555,8 @@ constexpr static frozen::unordered_map<ErrorCode, const char*, 353> ErrorMessage
       "no valid initial collection found"},
     {TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED,  // 1947
       "referenced vertex collection is not part of the graph"},
+    {TRI_ERROR_GRAPH_NEGATIVE_EDGE_WEIGHT,  // 1948
+      "negative edge weight found"},
     {TRI_ERROR_SESSION_UNKNOWN,  // 1950
       "unknown session"},
     {TRI_ERROR_SESSION_EXPIRED,  // 1951

--- a/lib/Basics/errors.dat
+++ b/lib/Basics/errors.dat
@@ -373,6 +373,7 @@ ERROR_GRAPH_EDGE_DEFINITION_IS_DOCUMENT,1944,"edge definition collection is a do
 ERROR_GRAPH_COLLECTION_IS_INITIAL,1945,"initial collection is not allowed to be removed manually","the collection is used as the initial collection of this graph and is not allowed to be removed manually."
 ERROR_GRAPH_NO_INITIAL_COLLECTION,1946,"no valid initial collection found","during the graph creation process no collection could be selected as the needed initial collection. Happens if a distributeShardsLike or replicationFactor mismatch was found."
 ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED,1947,"referenced vertex collection is not part of the graph","the _from or _to collection specified for the edge refers to a vertex collection which is not used in any edge definition of the graph."
+ERROR_GRAPH_NEGATIVE_EDGE_WEIGHT,1948,"negative edge weight found","a negative edge weight was found during a weighted graph traversal or shortest path query"
 
 ################################################################################
 ## Session errors

--- a/lib/Basics/voc-errors.h
+++ b/lib/Basics/voc-errors.h
@@ -1466,6 +1466,12 @@ constexpr auto TRI_ERROR_GRAPH_NO_INITIAL_COLLECTION                            
 /// collection which is not used in any edge definition of the graph.
 constexpr auto TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED             = ErrorCode{1947};
 
+/// 1948: ERROR_GRAPH_NEGATIVE_EDGE_WEIGHT
+/// "negative edge weight found"
+/// a negative edge weight was found during a weighted graph traversal or
+/// shortest path query
+constexpr auto TRI_ERROR_GRAPH_NEGATIVE_EDGE_WEIGHT                              = ErrorCode{1948};
+
 /// 1950: ERROR_SESSION_UNKNOWN
 /// "unknown session"
 /// Will be raised when an invalid/unknown session id is passed to the server.

--- a/tests/js/server/aql/aql-graph-weighted-traversal.js
+++ b/tests/js/server/aql/aql-graph-weighted-traversal.js
@@ -1,10 +1,11 @@
 /*jshint globalstrict:false, strict:false, sub: true, maxlen: 500 */
-/*global assertEqual, assertTrue, assertFalse */
+/*global assertEqual, assertTrue, assertFalse, fail */
 
 const jsunity = require("jsunity");
 const db = require("@arangodb").db;
 const gm = require("@arangodb/general-graph");
 const _ = require("underscore");
+const internal = require('internal');
 
 /*
 
@@ -176,5 +177,74 @@ function WeightedTraveralsTestSuite() {
   };
 }
 
+
+function WeightedTraveralsErrorTestSuite() {
+
+  const graphName = "UnitTestGraph";
+  const vName = "UnitTestVertices";
+  const eName = "UnitTestEdges";
+
+  function createGraph () {
+    gm._create(graphName, [gm._relation(eName, vName, vName)], [], {});
+
+    const vertexes = [
+      { _key: "1", value: 1 },
+      { _key: "2", value: 1 },
+    ];
+
+    const edges = [
+      { _from: `${vName}/1`, _to: `${vName}/2`, weight: -1 },
+    ];
+
+    db[vName].insert(vertexes);
+    db[eName].insert(edges);
+  }
+
+
+  return {
+    setUpAll: function () {
+      createGraph();
+    },
+
+    tearDownAll: function () {
+      gm._drop(graphName, true);
+    },
+
+    testShortestPathNegativeDefaultEdgeWeight: function () {
+      const query = `
+        FOR v, e, p IN 0..10 OUTBOUND "${vName}/1" GRAPH "${graphName}"
+          OPTIONS {order: "weighted", defaultWeight: @weight, uniqueVertices: "global"}
+          LIMIT 1
+          RETURN {path: p.vertices[*]._key, weight: p.weights[-1]}
+      `;
+
+      try {
+        db._query({query, bindVars: {weight: -1}});
+        fail();
+      } catch (err) {
+        assertEqual(err.errorNum, internal.errors.ERROR_GRAPH_NEGATIVE_EDGE_WEIGHT.code);
+      }
+    },
+
+    testShortestPathNegativeEdgeWeight: function () {
+      const query = `
+        FOR v, e, p IN 0..10 OUTBOUND "${vName}/1" GRAPH "${graphName}"
+          OPTIONS {order: "weighted", weightAttribute: "weight", uniqueVertices: "global"}
+          LIMIT 1
+          RETURN {path: p.vertices[*]._key, weight: p.weights[-1]}
+      `;
+
+      try {
+        db._query(query);
+        fail();
+      } catch (err) {
+        assertEqual(err.errorNum, internal.errors.ERROR_GRAPH_NEGATIVE_EDGE_WEIGHT.code);
+      }
+    },
+  };
+}
+
+
 jsunity.run(WeightedTraveralsTestSuite);
+jsunity.run(WeightedTraveralsErrorTestSuite);
 return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

A negative edge weight can crash the server in a weighted traversal.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *(please describe tests)*.
- [x] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [x] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
