### PR TITLE
Fix operator<< lookup

### DIFF
--- a/arangod/Cluster/ClusterTypes.cpp
+++ b/arangod/Cluster/ClusterTypes.cpp
@@ -28,16 +28,15 @@
 
 #include <iostream>
 
+namespace arangodb {
+
 std::ostream& operator<<(std::ostream& o, arangodb::RebootId const& r) {
   return r.print(o);
 }
 
-std::ostream& operator<<(std::ostream& o, 
-  arangodb::QueryAnalyzerRevisions const& r) {
+std::ostream& operator<<(std::ostream& o, arangodb::QueryAnalyzerRevisions const& r) {
   return r.print(o);
 }
-
-namespace arangodb {
 
 void QueryAnalyzerRevisions::toVelocyPack(VPackBuilder& builder) const {
   VPackObjectBuilder scope(&builder, StaticStrings::ArangoSearchAnalyzersRevision);

--- a/arangod/Cluster/ClusterTypes.h
+++ b/arangod/Cluster/ClusterTypes.h
@@ -174,8 +174,7 @@ struct QueryAnalyzerRevisions {
   AnalyzersRevision::Revision systemDbRevision{ AnalyzersRevision::MIN};
 };
 
-}  // namespace arangodb
-
 std::ostream& operator<<(std::ostream& o, arangodb::RebootId const& r);
 std::ostream& operator<<(std::ostream& o, arangodb::QueryAnalyzerRevisions const& r);
 
+}  // namespace arangodb

--- a/arangod/Cluster/RebootTracker.cpp
+++ b/arangod/Cluster/RebootTracker.cpp
@@ -27,6 +27,7 @@
 #include "Basics/MutexLocker.h"
 #include "Basics/ScopeGuard.h"
 #include "Basics/StaticStrings.h"
+#include "Cluster/ClusterTypes.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Scheduler/Scheduler.h"
@@ -64,16 +65,9 @@ RebootTracker::RebootTracker(RebootTracker::SchedulerPointer scheduler)
 
 void RebootTracker::updateServerState(std::unordered_map<ServerID, RebootId> const& state) {
   MUTEX_LOCKER(guard, _mutex);
-    
-  // FIXME: can't get this log message to compile in some build environments...
-  // ostreaming _rebootIds causes a compiler failure because operator<< is not visible
-  // here anymore for some reason, which is very likely due to a changed order of include
-  // files or some other change in declaration order.
-  // leaving the log message here because it can be compiled in some environments and
-  // maybe someone can fix it in the future
-  //
-  // LOG_TOPIC("77a6e", DEBUG, Logger::CLUSTER)
-  //     << "updating reboot server state from " << _rebootIds << " to " << state;
+
+  LOG_TOPIC("77a6e", DEBUG, Logger::CLUSTER)
+      << "updating reboot server state from " << _rebootIds << " to " << state;
 
   // Call cb for each iterator.
   auto for_each_iter = [](auto begin, auto end, auto cb) {

--- a/arangod/Transaction/Status.cpp
+++ b/arangod/Transaction/Status.cpp
@@ -28,6 +28,7 @@
 
 namespace arangodb {
 namespace transaction {
+
 Status statusFromString(char const* str, size_t len) {
   if (len == 9 && memcmp(str, "undefined", len) == 0) {
     return Status::UNDEFINED;
@@ -44,10 +45,11 @@ Status statusFromString(char const* str, size_t len) {
   TRI_ASSERT(false);
   return Status::UNDEFINED;
 }
-}  // namespace transaction
-}  // namespace arangodb
 
 std::ostream& operator<<(std::ostream& stream, arangodb::transaction::Status const& s) {
   stream << arangodb::transaction::statusString(s);
   return stream;
 }
+
+}  // namespace transaction
+}  // namespace arangodb

--- a/arangod/Transaction/Status.h
+++ b/arangod/Transaction/Status.h
@@ -62,8 +62,9 @@ static inline char const* statusString(Status status) {
 
 Status statusFromString(char const* str, size_t len);
 
+std::ostream& operator<<(std::ostream& stream, arangodb::transaction::Status const& s);
+
 }  // namespace transaction
 }  // namespace arangodb
 
-std::ostream& operator<<(std::ostream& stream, arangodb::transaction::Status const& s);
 

--- a/lib/Basics/AttributeNameParser.cpp
+++ b/lib/Basics/AttributeNameParser.cpp
@@ -195,7 +195,8 @@ bool arangodb::basics::TRI_AttributeNamesHaveExpansion(std::vector<AttributeName
 /// @brief append the attribute name to an output stream
 ////////////////////////////////////////////////////////////////////////////////
 
-std::ostream& operator<<(std::ostream& stream, arangodb::basics::AttributeName const& name) {
+std::ostream& arangodb::basics::operator<<(std::ostream& stream,
+                                           arangodb::basics::AttributeName const& name) {
   stream << name.name;
   if (name.shouldExpand) {
     stream << "[*]";
@@ -207,8 +208,8 @@ std::ostream& operator<<(std::ostream& stream, arangodb::basics::AttributeName c
 /// @brief append the attribute names to an output stream
 ////////////////////////////////////////////////////////////////////////////////
 
-std::ostream& operator<<(std::ostream& stream,
-                         std::vector<arangodb::basics::AttributeName> const& attributes) {
+std::ostream& arangodb::basics::operator<<(std::ostream& stream,
+                                           std::vector<arangodb::basics::AttributeName> const& attributes) {
   size_t const n = attributes.size();
   for (size_t i = 0; i < n; ++i) {
     if (i > 0) {

--- a/lib/Basics/AttributeNameParser.h
+++ b/lib/Basics/AttributeNameParser.h
@@ -133,6 +133,9 @@ void TRI_AttributeNamesToString(std::vector<AttributeName> const& input,
 
 bool TRI_AttributeNamesHaveExpansion(std::vector<AttributeName> const& input);
 
+std::ostream& operator<<(std::ostream&, arangodb::basics::AttributeName const&);
+std::ostream& operator<<(std::ostream&, std::vector<arangodb::basics::AttributeName> const&);
+
 }  // namespace basics
 }  // namespace arangodb
 
@@ -166,7 +169,4 @@ struct equal_to<std::vector<arangodb::basics::AttributeName>> {
 };
 
 } // namespace std
-
-std::ostream& operator<<(std::ostream&, arangodb::basics::AttributeName const&);
-std::ostream& operator<<(std::ostream&, std::vector<arangodb::basics::AttributeName> const&);
 

--- a/lib/Basics/Identifier.cpp
+++ b/lib/Basics/Identifier.cpp
@@ -59,8 +59,8 @@ bool Identifier::operator>=(Identifier const& other) const {
   return _id >= other._id;
 }
 
-}  // namespace arangodb::basics
-
 std::ostream& operator<<(std::ostream& s, arangodb::basics::Identifier const& i) {
   return s << std::to_string(i.id());
 }
+
+}  // namespace arangodb::basics

--- a/lib/Basics/Identifier.h
+++ b/lib/Basics/Identifier.h
@@ -77,9 +77,11 @@ class Identifier {
 // Identifier should not be bigger than the BaseType
 static_assert(sizeof(Identifier) == sizeof(Identifier::BaseType),
               "invalid size of Identifier");
-}  // namespace arangodb::basics
 
 std::ostream& operator<<(std::ostream& s, arangodb::basics::Identifier const& i);
+
+}  // namespace arangodb::basics
+
 
 #define DECLARE_HASH_FOR_IDENTIFIER(T)                        \
   namespace std {                                             \

--- a/lib/Basics/Result.cpp
+++ b/lib/Basics/Result.cpp
@@ -150,7 +150,7 @@ auto Result::errorMessage() && noexcept -> std::string {
   }
 }
 
-auto operator<<(std::ostream& out, arangodb::Result const& result) -> std::ostream& {
+auto arangodb::operator<<(std::ostream& out, arangodb::Result const& result) -> std::ostream& {
   VPackBuilder dump;
   {
     VPackObjectBuilder b(&dump);

--- a/lib/Basics/Result.h
+++ b/lib/Basics/Result.h
@@ -173,11 +173,10 @@ class Result final {
   std::unique_ptr<arangodb::result::Error> _error = nullptr;
 };
 
-}  // namespace arangodb
-
 /**
  * @brief  Print to output stream
  * @return Said output stream
  */
 auto operator<<(std::ostream& out, arangodb::Result const& result) -> std::ostream&;
 
+}  // namespace arangodb

--- a/lib/Basics/debugging.h
+++ b/lib/Basics/debugging.h
@@ -126,6 +126,8 @@ struct is_associative {
 
 }  // namespace container_traits
 
+namespace arangodb {
+
 template <class T>
 struct remove_cvref {
   typedef std::remove_cv_t<std::remove_reference_t<T>> type;
@@ -196,6 +198,8 @@ enable_if_t<is_container<T>::value, std::ostream&> operator<<(std::ostream& o, T
   o << " " << conpar<is_associative<T>::value>::close;
   return o;
 }
+
+}  // namespace arangodb
 
 /// @brief assert
 #ifndef TRI_ASSERT


### PR DESCRIPTION
### Scope & Purpose

Many of our `operator<<`s were defined in `::`. This prevented other operators being put in appropriate namespaces, because then the operators in `::` could no longer be found in namespaces containing such `operator<<`s.

This PR cleans that up a little.

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/676

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [X] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

### Testing & Verification

- [X] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
