### PR TITLE
fix some non-deterministic tests

### DIFF
--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -727,11 +727,14 @@ void RocksDBMetaCollection::revisionTreePendingUpdates(VPackBuilder& builder) {
     }
   }
   
-  std::unique_lock<std::mutex> guard(_revisionBufferLock);
+  uint64_t inserts, removes, truncates;
+  {
+    std::unique_lock<std::mutex> guard(_revisionBufferLock);
 
-  uint64_t inserts = _revisionInsertBuffers.size();
-  uint64_t removes = _revisionRemovalBuffers.size();
-  uint64_t truncates = _revisionTruncateBuffer.size();
+    inserts = _revisionInsertBuffers.size();
+    removes = _revisionRemovalBuffers.size();
+    truncates = _revisionTruncateBuffer.size();
+  }
   
   obj->add("inserts", VPackValue(inserts));
   obj->add("removes", VPackValue(removes));

--- a/tests/js/server/recovery/revision-trees-compression-format-bottommost.js
+++ b/tests/js/server/recovery/revision-trees-compression-format-bottommost.js
@@ -111,7 +111,7 @@ function recoverySuite () {
       internal.waitForEstimatorSync(); // make sure estimates are consistent
     },
 
-    testRevisionTreeHibernation: function() {
+    testRevisionTreeCompression: function() {
       internal.debugSetFailAt("MerkleTree::serializeBottomMost");
 
       const c1 = db._collection(colName1);
@@ -129,18 +129,21 @@ function recoverySuite () {
       const c4 = db._collection(colName4);
       assertEqual(c4._revisionTreeSummary().count, c4.count());
       assertEqual(c4._revisionTreeSummary().count, 1);
-      
+     
+      // it depends a bit on luck how compressible the trees actually are.
+      // the reason is that _rev values and thus rangeMax in the trees are
+      // dynamic.
       let summary = db[colName1]._revisionTreeSummary();
-      assertTrue(summary.byteSize < 5000, summary);
+      assertTrue(summary.byteSize < 15000, summary);
       
       summary = db[colName2]._revisionTreeSummary();
-      assertTrue(summary.byteSize < 5000, summary);
+      assertTrue(summary.byteSize < 15000, summary);
       
       summary = db[colName3]._revisionTreeSummary();
-      assertTrue(summary.byteSize < 200000, summary);
+      assertTrue(summary.byteSize < 700000, summary);
       
       summary = db[colName4]._revisionTreeSummary();
-      assertTrue(summary.byteSize < 100, summary);
+      assertTrue(summary.byteSize < 500, summary);
     },
 
   };

--- a/tests/js/server/recovery/revision-trees-compression-format-snappy.js
+++ b/tests/js/server/recovery/revision-trees-compression-format-snappy.js
@@ -111,7 +111,7 @@ function recoverySuite () {
       internal.waitForEstimatorSync(); // make sure estimates are consistent
     },
 
-    testRevisionTreeHibernation: function() {
+    testRevisionTreeCompression: function() {
       internal.debugSetFailAt("MerkleTree::serializeSnappy");
 
       const c1 = db._collection(colName1);
@@ -133,8 +133,10 @@ function recoverySuite () {
       [colName1, colName2, colName3, colName4].forEach((cn) => {
         let summary = db[cn]._revisionTreeSummary();
         // yes, the compression is that bad!
-        assertTrue(summary.byteSize > 200000, summary);
-        assertTrue(summary.byteSize < 500000, summary);
+        // how good/bad the compression is depends a bit on luck, as the _rev
+        // values in the tree are dynamic and also the tree's rangeMax.
+        assertTrue(summary.byteSize > 150000, summary);
+        assertTrue(summary.byteSize < 1000000, summary);
       });
     },
 

--- a/tests/js/server/recovery/revision-trees-compression-format-uncompressed.js
+++ b/tests/js/server/recovery/revision-trees-compression-format-uncompressed.js
@@ -111,7 +111,7 @@ function recoverySuite () {
       internal.waitForEstimatorSync(); // make sure estimates are consistent
     },
 
-    testRevisionTreeHibernation: function() {
+    testRevisionTreeCompression: function() {
       internal.debugSetFailAt("MerkleTree::serializeUncompressed");
 
       const c1 = db._collection(colName1);


### PR DESCRIPTION
### Scope & Purpose

Extend the ranges considered valid for compressed revision tree sizes in tests.
The actuall compressed sizes depend on the the _rev values, and thus the rangeMax value used by the tree. This has a large influence on compressibility.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.8: https://github.com/arangodb/arangodb/pull/14169

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *recovery*.
