### PR TITLE
[3.8] correctly report shutdown as shard leader

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,9 @@
 v3.8.0 (XXXX-XX-XX)
 -------------------
 
-* Fixes BTS-416. During shutdown, a Shard leader wrongly reported that
-  it could not drop a shard follower instead of correctly indicating
-  the shutdown as reason.
+* Fixes BTS-416. During shutdown, a Shard leader wrongly reported that it could
+  not drop a shard follower instead of correctly indicating the shutdown as the
+  reason.
 
 * Fixes pregel lifetime management. Previously shutting down the server while a
   pregel job was still running could result in a segfault or a shutdown hanger.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,13 @@
 v3.8.0 (XXXX-XX-XX)
 -------------------
 
+* Fixes BTS-416. During shutdown, a Shard leader wrongly reported that
+  it could not drop a shard follower instead of correctly indicating
+  the shutdown as reason.   
+
 * Fixes pregel lifetime management. Previously shutting down the server while a
   pregel job was still running could result in a segfault or a shutdown hanger.
-  
+
 * Improve error reporting for Merkle tree operations and improve memory usage
   for unused trees by hibernating them. In addition, add some backoff to shard
   synchronization in case there are repeated sync failures for the same shard.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@ v3.8.0 (XXXX-XX-XX)
 
 * Fixes BTS-416. During shutdown, a Shard leader wrongly reported that
   it could not drop a shard follower instead of correctly indicating
-  the shutdown as reason.   
+  the shutdown as reason.
 
 * Fixes pregel lifetime management. Previously shutting down the server while a
   pregel job was still running could result in a segfault or a shutdown hanger.

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2518,7 +2518,7 @@ Future<Result> Methods::replicateOperations(
             << "follower " << follower << " for shard "
             << collection->vocbase().name() << "/" << collection->name()
             << " stopped as we're shutting down";
-          return Result(TRI_ERROR_SHUTTING_DOWN);
+          THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
         }
       }
     }

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -1939,7 +1939,7 @@ Future<OperationResult> transaction::Methods::truncateLocal(std::string const& c
               }
             }
           } else {
-            LOG_TOPIC("cb953", DEBUG, Logger::REPLICATION)
+            LOG_TOPIC("cb953", INFO, Logger::REPLICATION)
               << "truncateLocal: shutting down and not replicating " << (*followers)[i]
               << " for shard " << collection->vocbase().name() << "/" << collection->name()
               << ": " << res.errorMessage();
@@ -2513,7 +2513,7 @@ Future<Result> Methods::replicateOperations(
             }
           }
         } else {
-          LOG_TOPIC("8921e", DEBUG, Logger::REPLICATION)
+          LOG_TOPIC("8921e", INFO, Logger::REPLICATION)
             << "synchronous replication of " << opName << " operation: "
             << "follower " << follower << " for shard "
             << collection->vocbase().name() << "/" << collection->name()

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2450,7 +2450,7 @@ Future<Result> Methods::replicateOperations(
           replicationWorked = !found;
         } else {
 
-          if (!vocbase().server().isStopping) {
+          if (!vocbase().server().isStopping()) {
             auto r = resp.combinedResult();
             bool followerRefused = (r.errorNumber() == TRI_ERROR_CLUSTER_SHARD_LEADER_REFUSES_REPLICATION);
             didRefuse = didRefuse || followerRefused;

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -1907,35 +1907,43 @@ Future<OperationResult> transaction::Methods::truncateLocal(std::string const& c
             (responses[i].get().statusCode() == fuerte::StatusAccepted ||
              responses[i].get().statusCode() == fuerte::StatusOK);
         if (!replicationWorked) {
-          auto const& followerInfo = collection->followers();
-          LOG_TOPIC("0e2e0", WARN, Logger::REPLICATION)
+          if (!vocbase().server().isStopping()) {
+            auto const& followerInfo = collection->followers();
+            LOG_TOPIC("0e2e0", WARN, Logger::REPLICATION)
               << "truncateLocal: dropping follower " << (*followers)[i]
               << " for shard " << collection->vocbase().name() << "/" << collectionName
               << ": " << responses[i].get().combinedResult().errorMessage();
-          res = followerInfo->remove((*followers)[i]);
-          if (res.ok()) {
-            _state->removeKnownServer((*followers)[i]);
-          } else {
-            LOG_TOPIC("359bc", WARN, Logger::REPLICATION)
+            res = followerInfo->remove((*followers)[i]);
+            if (res.ok()) {
+              _state->removeKnownServer((*followers)[i]);
+            } else {
+              LOG_TOPIC("359bc", WARN, Logger::REPLICATION)
                 << "truncateLocal: could not drop follower " << (*followers)[i]
                 << " for shard " << collection->vocbase().name() << "/" << collection->name()
                 << ": " << res.errorMessage();
-            // Note: it is safe here to exit the loop early. We are losing the leadership here.
-            // No matter what happens next, the Current entry in the agency is rewritten and
-            // thus replication is restarted from the new leader. There is no need to keep
-            // trying to drop followers at this point.
-            if (res.is(TRI_ERROR_CLUSTER_NOT_LEADER)) {
-              // In this case, we know that we are not or no longer
-              // the leader for this shard. Therefore we need to
-              // send a code which let's the coordinator retry.
-              THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_SHARD_LEADER_RESIGNED);
-            } else {
-              // In this case, some other error occurred and we
-              // most likely are still the proper leader, so
-              // the error needs to be reported and the local
-              // transaction must be rolled back.
-              THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_COULD_NOT_DROP_FOLLOWER);
+              // Note: it is safe here to exit the loop early. We are losing the leadership here.
+              // No matter what happens next, the Current entry in the agency is rewritten and
+              // thus replication is restarted from the new leader. There is no need to keep
+              // trying to drop followers at this point.
+              if (res.is(TRI_ERROR_CLUSTER_NOT_LEADER)) {
+                // In this case, we know that we are not or no longer
+                // the leader for this shard. Therefore we need to
+                // send a code which let's the coordinator retry.
+                THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_SHARD_LEADER_RESIGNED);
+              } else {
+                // In this case, some other error occurred and we
+                // most likely are still the proper leader, so
+                // the error needs to be reported and the local
+                // transaction must be rolled back.
+                THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_COULD_NOT_DROP_FOLLOWER);
+              }
             }
+          } else {
+            LOG_TOPIC("cb953", DEBUG, Logger::REPLICATION)
+              << "truncateLocal: shutting down and not replicating " << (*followers)[i]
+              << " for shard " << collection->vocbase().name() << "/" << collection->name()
+              << ": " << res.errorMessage();
+            THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
           }
         }
       }
@@ -2449,28 +2457,18 @@ Future<Result> Methods::replicateOperations(
           resp.response().header.metaByKey(StaticStrings::ErrorCodes, found);
           replicationWorked = !found;
         } else {
+          auto r = resp.combinedResult();
+          bool followerRefused = (r.errorNumber() == TRI_ERROR_CLUSTER_SHARD_LEADER_REFUSES_REPLICATION);
+          didRefuse = didRefuse || followerRefused;
 
-          if (!vocbase().server().isStopping()) {
-            auto r = resp.combinedResult();
-            bool followerRefused = (r.errorNumber() == TRI_ERROR_CLUSTER_SHARD_LEADER_REFUSES_REPLICATION);
-            didRefuse = didRefuse || followerRefused;
+          if (followerRefused) {
+            vocbase().server().getFeature<arangodb::ClusterFeature>().followersRefusedCounter()++;
 
-            if (followerRefused) {
-              vocbase().server().getFeature<arangodb::ClusterFeature>().followersRefusedCounter()++;
-
-              LOG_TOPIC("3032c", WARN, Logger::REPLICATION)
-                << "synchronous replication of " << opName << " operation: "
-                << "follower " << follower << " for shard "
-                << collection->vocbase().name() << "/" << collection->name()
-                << " refused the operation: " << r.errorMessage();
-            }
-          } else {
-            LOG_TOPIC("8921e", DEBUG, Logger::REPLICATION)
+            LOG_TOPIC("3032c", WARN, Logger::REPLICATION)
               << "synchronous replication of " << opName << " operation: "
               << "follower " << follower << " for shard "
               << collection->vocbase().name() << "/" << collection->name()
-              << " stopped as we're shutting down: " << r.errorMessage();
-            return Result(TRI_ERROR_SHUTTING_DOWN)
+              << " refused the operation: " << r.errorMessage();
           }
         }
       }
@@ -2480,42 +2478,51 @@ Future<Result> Methods::replicateOperations(
       }
 
       if (!replicationWorked) {
-        LOG_TOPIC("12d8c", WARN, Logger::REPLICATION)
+        if (!vocbase().server().isStopping()) {
+          LOG_TOPIC("12d8c", WARN, Logger::REPLICATION)
             << "synchronous replication of " << opName << " operation: "
             << ": dropping follower " << follower << " for shard "
             << collection->vocbase().name() << "/" << collection->name()
             << ": " << resp.combinedResult().errorMessage();
 
-        Result res = collection->followers()->remove(follower);
-        if (res.ok()) {
-          // simon: follower cannot be re-added without lock on collection
-          _state->removeKnownServer(follower);
-        } else {
-          LOG_TOPIC("db473", ERR, Logger::REPLICATION)
-            << "synchronous replication of " << opName << " operation: "
-            << "could not drop follower " << follower << " for shard "
-            << collection->vocbase().name() << "/" << collection->name()
-            << ": " << res.errorMessage();
-          // Note: it is safe here to exit the loop early. We are losing the leadership here.
-          // No matter what happens next, the Current entry in the agency is rewritten and
-          // thus replication is restarted from the new leader. There is no need to keep
-          // trying to drop followers at this point.
-          if (res.is(TRI_ERROR_CLUSTER_NOT_LEADER)) {
-            // In this case, we know that we are not or no longer
-            // the leader for this shard. Therefore we need to
-            // send a code which let's the coordinator retry.
-            THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_SHARD_LEADER_RESIGNED);
+          Result res = collection->followers()->remove(follower);
+          if (res.ok()) {
+            // simon: follower cannot be re-added without lock on collection
+            _state->removeKnownServer(follower);
           } else {
-            // In this case, some other error occurred and we
-            // most likely are still the proper leader, so
-            // the error needs to be reported and the local
-            // transaction must be rolled back.
-            THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_COULD_NOT_DROP_FOLLOWER);
+            LOG_TOPIC("db473", ERR, Logger::REPLICATION)
+              << "synchronous replication of " << opName << " operation: "
+              << "could not drop follower " << follower << " for shard "
+              << collection->vocbase().name() << "/" << collection->name()
+              << ": " << res.errorMessage();
+            // Note: it is safe here to exit the loop early. We are losing the leadership here.
+            // No matter what happens next, the Current entry in the agency is rewritten and
+            // thus replication is restarted from the new leader. There is no need to keep
+            // trying to drop followers at this point.
+            if (res.is(TRI_ERROR_CLUSTER_NOT_LEADER)) {
+              // In this case, we know that we are not or no longer
+              // the leader for this shard. Therefore we need to
+              // send a code which let's the coordinator retry.
+              THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_SHARD_LEADER_RESIGNED);
+            } else {
+              // In this case, some other error occurred and we
+              // most likely are still the proper leader, so
+              // the error needs to be reported and the local
+              // transaction must be rolled back.
+              THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_COULD_NOT_DROP_FOLLOWER);
+            }
           }
+        } else {
+          LOG_TOPIC("8921e", DEBUG, Logger::REPLICATION)
+            << "synchronous replication of " << opName << " operation: "
+            << "follower " << follower << " for shard "
+            << collection->vocbase().name() << "/" << collection->name()
+            << " stopped as we're shutting down";
+          return Result(TRI_ERROR_SHUTTING_DOWN);
         }
       }
     }
-
+    
     if (didRefuse) {  // case (1), caller may abort this transaction
       return Result(TRI_ERROR_CLUSTER_SHARD_LEADER_RESIGNED);
     }


### PR DESCRIPTION
### Scope & Purpose

*Fixes BTS-416, where a shard leader instead of correctly reporting shutdown, claimed that it couldn't dropa shard follower resulting to 500 error towards client*

- [X] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [X] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:
https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/15444/

### Documentation

> All new features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the CHANGELOG so that
> support, end users, and other developers have a concise overview. 

- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
