### PR TITLE
Docs: Unbreak example generation

### DIFF
--- a/js/client/bootstrap/modules/internal.js
+++ b/js/client/bootstrap/modules/internal.js
@@ -355,6 +355,9 @@
 
       // append body
       if (response.body !== undefined) {
+        if (Buffer.isBuffer(response.body)) {
+          response.body = response.body.toString();
+        }
         let splitted = response.body.split(/\r\n|\r|\n/);
         if (splitted.length > 0) {
           splitted.forEach(function (line) {
@@ -402,6 +405,10 @@
 
       appendHeaders(appender, response.headers);
       appender('\n');
+
+      if (Buffer.isBuffer(response.body)) {
+        response.body = response.body.toString();
+      }
 
       var splitted = response.body.split("\n");
       splitted.forEach(function(line) {

--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -1752,7 +1752,7 @@ function checkClusterAlive(options, instanceInfo, addArgs) {
           print('================= Coordinator log file start =================');
           print(coordinatorLogFile);
           print('--------------------------------------------------------------');
-          print(fs.readFileSync(coordinatorLogFile));
+          print(fs.readFileSync(coordinatorLogFile, 'utf8'));
           print('================= Coordinator log file end ===================');
         }
       } else {

--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -1732,6 +1732,7 @@ function checkClusterAlive(options, instanceInfo, addArgs) {
 
 
   let count = 0;
+  let coordinatorTickles = 0;
   while (true) {
     ++count;
 
@@ -1745,6 +1746,15 @@ function checkClusterAlive(options, instanceInfo, addArgs) {
       let url = arangod.url;
       if (arangod.role === "coordinator") {
         url += '/_admin/aardvark/index.html';
+        coordinatorTickles++;
+        if (coordinatorTickles == 10) {
+          let coordinatorLogFile = arangod.args['log.file'];
+          print('================= Coordinator log file start =================');
+          print(coordinatorLogFile);
+          print('--------------------------------------------------------------');
+          print(fs.readFileSync(coordinatorLogFile));
+          print('================= Coordinator log file end ===================');
+        }
       } else {
         url += '/_api/version';
       }

--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -1747,7 +1747,7 @@ function checkClusterAlive(options, instanceInfo, addArgs) {
       if (arangod.role === "coordinator") {
         url += '/_admin/aardvark/index.html';
         coordinatorTickles++;
-        if (coordinatorTickles == 10) {
+        if (coordinatorTickles === 10) {
           let coordinatorLogFile = arangod.args['log.file'];
           print('================= Coordinator log file start =================');
           print(coordinatorLogFile);

--- a/utils/generateExamples.js
+++ b/utils/generateExamples.js
@@ -34,7 +34,7 @@ const optionsDefaults = {
   'coreDirectory': '/var/tmp',
   'dbServers': 2,
   'duration': 10,
-  'extraArgs': { 'extraArgs:log.level': 'info', 'extraArgs:log.force-direct': true },
+  'extraArgs': { 'log.level': 'info', 'log.force-direct': true },
   'extremeVerbosity': true, /// TODO false,
   'force': true,
   'getSockStat': false,

--- a/utils/generateExamples.js
+++ b/utils/generateExamples.js
@@ -34,7 +34,7 @@ const optionsDefaults = {
   'coreDirectory': '/var/tmp',
   'dbServers': 2,
   'duration': 10,
-  'extraArgs': {},
+  'extraArgs': { 'extraArgs:log.level': 'info', 'extraArgs:log.force-direct': true },
   'extremeVerbosity': true, /// TODO false,
   'force': true,
   'getSockStat': false,


### PR DESCRIPTION
DO NOT MERGE, the concrete problems with example generation are fixed by
- https://github.com/arangodb/oskar/pull/320
- https://github.com/arangodb/arangodb/pull/14179
- https://github.com/arangodb/arangodb/pull/14180

What is still needed:
- Expose the server logs in Jenkins by adding them as build artifacts. Problem: the path is dynamic (temp folder). How can that be solved?

- Fix cluster health check to not wait for 10 minutes if a node fails to start with an error. Willi mentioned this:

  > maybe we should pull out that to the options?
  ```
  // Didn't startup in 10 minutes? kill it, give up.
  if (count > 1200) {
  ```
  