### PR TITLE
Fix index range calculation for queries where both bounds are expressed using the same operator.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.8.0 (XXXX-XX-XX)
 -------------------
 
+* Fixes BTS-417. In some cases an index did not consider both bounds (lower and
+  upper) for a close range scan if both bounds are expressed using the same
+  operator, e.g., `FILTER doc.beginDate >= lb AND ub >= doc.beginDate`.
+
 * Fixes BTS-416. During shutdown, a Shard leader wrongly reported that it could
   not drop a shard follower instead of correctly indicating the shutdown as the
   reason.

--- a/arangod/Indexes/SortedIndexAttributeMatcher.cpp
+++ b/arangod/Indexes/SortedIndexAttributeMatcher.cpp
@@ -481,19 +481,25 @@ arangodb::aql::AstNode* SortedIndexAttributeMatcher::specializeCondition(
               });
 
     ::arangodb::containers::HashSet<int> operatorsFound;
-    for (auto& it : nodes) {
+    for (auto const& it : nodes) {
       if (it->type == arangodb::aql::NODE_TYPE_OPERATOR_BINARY_NE) {
         // ignore all != operators here
         continue;
       }
 
+      arangodb::aql::AstNodeType type = it->type;
+      if (arangodb::aql::Ast::IsReversibleOperator(type) &&
+          it->getMember(1)->isAttributeAccessForVariable(reference, false)) {
+        type = arangodb::aql::Ast::ReverseOperator(type); 
+      }
+
       // do not let duplicate or related operators pass
-      if (isDuplicateOperator(it, operatorsFound)) {
+      if (isDuplicateOperator(type, operatorsFound)) {
         continue;
       }
 
       TRI_ASSERT(it->type != arangodb::aql::NODE_TYPE_OPERATOR_BINARY_NE);
-      operatorsFound.emplace(static_cast<int>(it->type));
+      operatorsFound.emplace(static_cast<int>(type));
       children.emplace_back(it);
     }
   }
@@ -512,9 +518,8 @@ arangodb::aql::AstNode* SortedIndexAttributeMatcher::specializeCondition(
 }
 
 bool SortedIndexAttributeMatcher::isDuplicateOperator(
-    arangodb::aql::AstNode const* node,
+    arangodb::aql::AstNodeType type,
     ::arangodb::containers::HashSet<int> const& operatorsFound) {
-  auto type = node->type;
   if (operatorsFound.find(static_cast<int>(type)) != operatorsFound.end()) {
     // duplicate operator
     return true;

--- a/arangod/Indexes/SortedIndexAttributeMatcher.h
+++ b/arangod/Indexes/SortedIndexAttributeMatcher.h
@@ -31,6 +31,7 @@
 namespace arangodb {
 namespace aql {
 class Ast;
+enum AstNodeType : uint32_t;
 struct AstNode;
 class SortCondition;
 struct Variable;
@@ -93,7 +94,7 @@ bool accessFitsIndex(
     std::unordered_map<size_t, std::vector<arangodb::aql::AstNode const*>>& found,
     std::unordered_set<std::string>& nonNullAttributes, bool isExecution);
 
-bool isDuplicateOperator(arangodb::aql::AstNode const* node,
+bool isDuplicateOperator(arangodb::aql::AstNodeType type,
                          ::arangodb::containers::HashSet<int> const& operatorsFound);
 };  // namespace SortedIndexAttributeMatcher
 

--- a/tests/js/server/aql/aql-index-choice.js
+++ b/tests/js/server/aql/aql-index-choice.js
@@ -564,6 +564,105 @@ function BaseTestConfig () {
         assertEqual("sorted", collectNode.collectOptions.method);
       });
     },
+    
+    testSingleFilterUpperAndLowerBound: function() {
+      db[cn].ensureIndex({ type: "persistent", fields: ["uid"] });
+      [
+        `
+          FOR doc IN ${cn}
+            LET lowerBound = 1
+            LET upperBound = 100
+            FILTER doc.uid >= lowerBound AND doc.uid <= upperBound
+            RETURN doc
+        `,
+        `
+          FOR doc IN ${cn}
+            LET lowerBound = 1
+            LET upperBound = 100
+            FILTER lowerBound <= doc.uid AND upperBound >= doc.uid
+            RETURN doc
+        `,
+        `
+          FOR src IN [{uid: 123}, {uid: 124}]
+            LET upperBound = src.uid + 100
+            FOR dst IN ${cn}
+              FILTER dst.uid >= src.uid AND dst.uid <= upperBound
+              RETURN { src, dst }
+        `
+      ].forEach((q) => {
+        const nodes = AQL_EXPLAIN(q, {},
+          { optimizer: { rules: ["-interchange-adjacent-enumerations", "-move-filters-into-enumerate"] }}).plan.nodes;
+        assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
+        const indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
+        assertEqual(1, indexNode.condition.subNodes.length);
+        assertEqual("n-ary and", indexNode.condition.subNodes[0].type);
+        // index covers both conditions
+        assertEqual(2, indexNode.condition.subNodes[0].subNodes.length);
+        // since the index covers all conditions, the filter should be completely removed
+        assertEqual(0, nodes.filter((n) => n.type === 'FilterNode').length);
+      });
+    },
+    
+    testSingleFilterUpperAndLowerBoundWithRedunantCondition: function() {
+      db[cn].ensureIndex({ type: "persistent", fields: ["uid"] });
+      // generate the cross product of the given arrays
+      const product = (...a) => a.reduce((a, b) => a.flatMap(d => b.map(e => [d, e].flat())));
+      // generate a list of all permutations of the given array
+      const perm = a => a.length
+        ? a.reduce((r, v, i) => [...r, ...perm([...a.slice(0, i), ...a.slice(i + 1)]).map(x => [v, ...x])], [])
+        : [[]]
+        
+      // lowerBound = 10
+      // upperBound = 100
+      const lowerBound = ["doc.uid >= lowerBound", "lowerBound <= doc.uid"];
+      const upperBound = ["doc.uid <= upperBound", "upperBound >= doc.uid"];
+      const bounds = product(lowerBound, upperBound);
+      [
+        // TODO - the commented cases currently do not work correctly.
+        // The optimizer picks the wrong (weaker) bound and keeps an additional filter for
+        // the stronger bound. The problem is Condition::optimize which does not properly
+        // handle these scenarios, but this needs to be fixed in a separate PR.
+        [["doc.uid > 5", "5 < doc.uid"], ">=", 10, "<=", 100],
+        [["doc.uid >= 5", "5 <= doc.uid"], ">=", 10, "<=", 100],
+        [["doc.uid > 42", "42 < doc.uid"], ">", 42, "<=", 100],
+        //[["doc.uid >= 42", "42 <= doc.uid"], ">=", 42, "<=", 100],
+        [["doc.uid < 42", "42 > doc.uid"], ">=", 10, "<", 42],
+        //[["doc.uid <= 42", "42 >= doc.uid"], ">=", 10, "<=", 42],
+        //[["doc.uid < 1234", "1234 > doc.uid"], ">=", 10, "<=", 100],
+        //[["doc.uid <= 1234", "1234 >= doc.uid"], ">=", 10, "<=", 100],
+        [["doc.uid != 5"], ">=", 10, "<=", 100],
+        [["doc.uid != 1234"], ">=", 10, "<=", 100],
+        [product(["doc.uid > 20", "20 < doc.uid"],  ["doc.uid < 90", "90 > doc.uid"]), ">", 20, "<", 90],
+        //[product(["doc.uid >= 20", "20 <= doc.uid"],  ["doc.uid <= 90", "90 >= doc.uid"]), ">=", 20, "<=", 90],
+      ].forEach(([filters, lbOp, lb, ubOp, ub]) => {
+        product(bounds, filters)
+          .map(list => perm(list.flat()))
+          .flat(1)
+          .forEach(filter => {
+            const q = `
+                FOR doc IN ${cn}
+                  LET lowerBound = 10
+                  LET upperBound = 100
+                  FILTER ${filter.join(" AND ")}
+                  RETURN doc
+              `;
+            const nodes = AQL_EXPLAIN(q, {}, { optimizer: { rules: ["-move-filters-into-enumerate"] }}).plan.nodes;
+            assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
+            const indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
+            assertEqual(1, indexNode.condition.subNodes.length);
+            assertEqual("n-ary and", indexNode.condition.subNodes[0].type);
+            // index covers both conditions, so both conditions should be present in the index node
+            assertEqual(2, indexNode.condition.subNodes[0].subNodes.length);
+            const conds = indexNode.condition.subNodes[0].subNodes;
+            assertEqual("compare " + lbOp, conds[0].type);
+            assertEqual(lb, conds[0].subNodes[1].value);
+            assertEqual("compare " + ubOp, conds[1].type);
+            assertEqual(ub, conds[1].subNodes[1].value);
+            // since the index covers all conditions, the filter should be completely removed
+            assertEqual(0, nodes.filter((n) => n.type === 'FilterNode').length);
+          });
+      });
+    },
   };
 }
 

--- a/tests/js/server/aql/aql-index-choice.js
+++ b/tests/js/server/aql/aql-index-choice.js
@@ -610,7 +610,7 @@ function BaseTestConfig () {
       // generate a list of all permutations of the given array
       const perm = a => a.length
         ? a.reduce((r, v, i) => [...r, ...perm([...a.slice(0, i), ...a.slice(i + 1)]).map(x => [v, ...x])], [])
-        : [[]]
+        : [[]];
         
       // lowerBound = 10
       // upperBound = 100


### PR DESCRIPTION
### Scope & Purpose

Fixes BTS-417

In some cases an index did not consider both bounds (lower and upper) for a close range scan if both bounds are expressed using the same operator, e.g., `FILTER doc.beginDate >= lb AND ub >= doc.beginDate`.

The newly added tests revealed yet another issue with the condition optimization in case of redundant conditions which result in suboptimal range calculation with an additional filter. But that needs to be fixed in a separate PR.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.7, devel  (#14196, #14195)

#### Related Information

- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-417

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** shell_server_aql