### PR TITLE
fix metrics names

### DIFF
--- a/Documentation/Metrics/arangodb_aql_global_query_memory_limit_reached_total.yaml
+++ b/Documentation/Metrics/arangodb_aql_global_query_memory_limit_reached_total.yaml
@@ -1,4 +1,4 @@
-name: arangodb_aql_global_query_memory_limit_reached
+name: arangodb_aql_global_query_memory_limit_reached_total
 introducedIn: "3.8.0"
 help: |
   Number of times the global query memory limit threshold was reached.

--- a/Documentation/Metrics/arangodb_aql_local_query_memory_limit_reached_total.yaml
+++ b/Documentation/Metrics/arangodb_aql_local_query_memory_limit_reached_total.yaml
@@ -1,4 +1,4 @@
-name: arangodb_aql_local_query_memory_limit_reached
+name: arangodb_aql_local_query_memory_limit_reached_total
 introducedIn: "3.8.0"
 help: |
   Number of times a local query memory limit threshold was reached.

--- a/arangod/RestServer/QueryRegistryFeature.cpp
+++ b/arangod/RestServer/QueryRegistryFeature.cpp
@@ -144,9 +144,9 @@ DECLARE_GAUGE(
         std::to_string(ResourceMonitor::chunkSize) + " bytes steps");
 DECLARE_GAUGE(arangodb_aql_global_memory_limit, uint64_t,
               "Total memory limit for all AQL queries combined [bytes]");
-DECLARE_COUNTER(arangodb_aql_global_query_memory_limit_reached,
+DECLARE_COUNTER(arangodb_aql_global_query_memory_limit_reached_total,
                 "Number of global AQL query memory limit violations");
-DECLARE_COUNTER(arangodb_aql_local_query_memory_limit_reached,
+DECLARE_COUNTER(arangodb_aql_local_query_memory_limit_reached_total,
                 "Number of local AQL query memory limit violations");
 
 QueryRegistryFeature::QueryRegistryFeature(application_features::ApplicationServer& server)
@@ -194,9 +194,9 @@ QueryRegistryFeature::QueryRegistryFeature(application_features::ApplicationServ
       _globalQueryMemoryLimit(
         server.getFeature<arangodb::MetricsFeature>().add(arangodb_aql_global_memory_limit{})),
       _globalQueryMemoryLimitReached(
-        server.getFeature<arangodb::MetricsFeature>().add(arangodb_aql_global_query_memory_limit_reached{})),
+        server.getFeature<arangodb::MetricsFeature>().add(arangodb_aql_global_query_memory_limit_reached_total{})),
       _localQueryMemoryLimitReached(
-        server.getFeature<arangodb::MetricsFeature>().add(arangodb_aql_local_query_memory_limit_reached{})) {
+        server.getFeature<arangodb::MetricsFeature>().add(arangodb_aql_local_query_memory_limit_reached_total{})) {
   setOptional(false);
   startsAfter<V8FeaturePhase>();
 

--- a/tests/js/client/server_parameters/test-global-memory-limit.js
+++ b/tests/js/client/server_parameters/test-global-memory-limit.js
@@ -77,7 +77,7 @@ function testSuite() {
       // now give it a second to make sure it has allocated _some_ memory
       require("internal").sleep(1.0);
 
-      const previousValue = getMetric("arangodb_aql_global_query_memory_limit_reached");
+      const previousValue = getMetric("arangodb_aql_global_query_memory_limit_reached_total");
       try {
         // we expect this query here to violate the global memory limit, because some memory is already
         // allocated by the other, sleeping query
@@ -91,7 +91,7 @@ function testSuite() {
         queries.kill(current[0].id);
       }
       
-      const currentValue = getMetric("arangodb_aql_global_query_memory_limit_reached");
+      const currentValue = getMetric("arangodb_aql_global_query_memory_limit_reached_total");
       assertTrue(currentValue > previousValue);
     },
     

--- a/tests/js/client/server_parameters/test-memory-limit.js
+++ b/tests/js/client/server_parameters/test-memory-limit.js
@@ -55,7 +55,7 @@ function testSuite() {
     },
     
     testQueryAboveLimit: function() {
-      const previousValue = getMetric("arangodb_aql_local_query_memory_limit_reached");
+      const previousValue = getMetric("arangodb_aql_local_query_memory_limit_reached_total");
       try {
         // we expect this query here to violate the memory limit
         db._query("LET testi = (FOR i IN 1..10000 FOR j IN 1..100 RETURN CONCAT('testmann-der-fuxxx', i, j)) RETURN testi");
@@ -65,7 +65,7 @@ function testSuite() {
         assertNotMatch(/global/, err.errorMessage);
       }
       
-      const currentValue = getMetric("arangodb_aql_local_query_memory_limit_reached");
+      const currentValue = getMetric("arangodb_aql_local_query_memory_limit_reached_total");
       assertTrue(currentValue > previousValue);
     },
     


### PR DESCRIPTION
### Scope & Purpose

Rename some metrics that were introduced in 3.8 so that they have Prometheus-compatible names.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*: https://github.com/arangodb/arangodb/pull/14199

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *server_parameters*.
