### PR TITLE
Fixed code to be compatible with gcc-11.1

### DIFF
--- a/3rdParty/iresearch/external/unicorn/unicorn/utility.hpp
+++ b/3rdParty/iresearch/external/unicorn/unicorn/utility.hpp
@@ -54,6 +54,7 @@
 #include <istream>
 #include <iterator>
 #include <limits>
+#include <memory>
 #include <mutex>
 #include <new>
 #include <optional>

--- a/3rdParty/velocypack/include/velocypack/Slice.h
+++ b/3rdParty/velocypack/include/velocypack/Slice.h
@@ -25,18 +25,19 @@
 #ifndef VELOCYPACK_SLICE_H
 #define VELOCYPACK_SLICE_H 1
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
-#include <string>
-#include <vector>
+#include <functional>
 #include <initializer_list>
 #include <iosfwd>
 #include <iterator>
-#include <algorithm>
-#include <functional>
-#include <tuple>
+#include <limits>
+#include <string>
 #include <string_view>
+#include <tuple>
 #include <type_traits>
+#include <vector>
 
 #include "velocypack/velocypack-common.h"
 #include "velocypack/Exception.h"

--- a/arangod/Cluster/TraverserEngine.cpp
+++ b/arangod/Cluster/TraverserEngine.cpp
@@ -29,6 +29,7 @@
 #include "Basics/Exceptions.h"
 #include "Basics/Result.h"
 #include "Graph/EdgeCursor.h"
+#include "Graph/EdgeDocumentToken.h"
 #include "Graph/ShortestPathOptions.h"
 #include "Graph/TraverserCache.h"
 #include "Graph/TraverserOptions.h"

--- a/arangosh/Utils/ProgressTracker.h
+++ b/arangosh/Utils/ProgressTracker.h
@@ -28,6 +28,7 @@
 #include "Basics/VelocyPackHelper.h"
 
 #include <atomic>
+#include <mutex>
 #include <shared_mutex>
 #include <string>
 #include <unordered_map>

--- a/lib/Basics/StringHeap.h
+++ b/lib/Basics/StringHeap.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <vector>
 
 #include "Basics/Common.h"

--- a/tests/IResearch/IResearchTestCompressor.h
+++ b/tests/IResearch/IResearchTestCompressor.h
@@ -42,7 +42,7 @@ namespace iresearch {
 namespace compression {
 namespace mock {
 struct test_compressor {
-  class test_compressor_compressor final : public compressor {
+  class test_compressor_compressor final : public ::iresearch::compression::compressor {
    public:
     virtual bytes_ref compress(byte_type* src, size_t size, bstring& out) override {
       return test_compressor::functions().compress_mock ?
@@ -50,7 +50,7 @@ struct test_compressor {
     }
   };
 
-  class test_compressor_decompressor final : public decompressor {
+  class test_compressor_decompressor final : public ::iresearch::compression::decompressor {
    public:
     virtual bytes_ref decompress(const byte_type* src, size_t src_size,
                                  byte_type* dst, size_t dst_size) override {


### PR DESCRIPTION
### Scope & Purpose

# I do not intend to change the compiler used for releases to gcc-11.1. Please read below.

I use Arch Linux. Thus my default system compiler is now gcc-11.1. I made some adjustments to make ArangoDB compile on Arch Linux. I explained all changes below. Almost all of them are adding **missing** includes.

- `lib/Basics/StringHeap.h` uses `std::size_t` but does not include `cstddef`.
- `3rdParty/iresearch/external/unicorn/unicorn/utility.hpp` uses `std::shared_ptr` but does not include `memory`.
- `arangosh/Utils/ProgressTracker.h` uses `std::unique_lock` but does not include `mutex`.

   - See https://gcc.gnu.org/gcc-11/porting_to.html#header-dep-changes:
 >  The following headers are used less widely in libstdc++ and may need to be included explicitly when compiled with GCC 11:
 >
 >    <limits> (for std::numeric_limits)
 >    <memory> (for std::unique_ptr, std::shared_ptr etc.)
 >    <utility> (for std::pair, std::tuple_size, std::index_sequence etc.)
 >    <thread> (for members of namespace std::this_thread.)


- `tests/IResearch/IResearchTestCompressor.h` changes meaning of `compressor`/`decompressor`. After declaration of static functions the unqualified name lookup does not return the same thing as before. (see https://godbolt.org/z/xjMPsWard)

- `arangod/Cluster/TraverserEngine.cpp` uses `EdgeDocumentToken` but does not include `Graph/EdgeDocumentToken.h`. It is only forward
declared and `std::function` requires all parameter types to be complete when invoked.
