### PR TITLE
Allow make to find its jobserver again

### DIFF
--- a/3rdParty/V8/CMakeLists.txt
+++ b/3rdParty/V8/CMakeLists.txt
@@ -439,7 +439,7 @@ message(${V8_GYP_ARGS})
     CONFIGURE_COMMAND
       ${PYTHON_EXECUTABLE} ${GYP_MAIN} ${V8_GYP_ARGS}
     BUILD_COMMAND
-      ${MAKE} ${V8_COMPILE_TARGETS} ${V8_COMPILE_ARGS}
+      $(MAKE) ${V8_COMPILE_TARGETS} ${V8_COMPILE_ARGS}
     STEP_TARGETS
       v8_libbase v8_libplatform icui18n icuuc v8_base v8_libsampler v8_init v8_initializers v8_nosnapshot mksnapshot v8_snapshot
     INSTALL_COMMAND

--- a/3rdParty/jemalloc/CMakeLists.txt
+++ b/3rdParty/jemalloc/CMakeLists.txt
@@ -56,11 +56,11 @@ if (LINUX OR DARWIN)
                   --with-version=${JEMALLOC_VERSION}-0-g0
 		  ${JEMALLOC_PROF}
     BUILD_COMMAND
-      ${MAKE} build_lib_static
+      $(MAKE) build_lib_static
     BUILD_IN_SOURCE
       1
     INSTALL_COMMAND
-      ${MAKE} install_include
+      $(MAKE) install_include
            && ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/lib
            && ${CMAKE_COMMAND} -E copy ${JEMALLOC_BINARY_DIR}/lib/libjemalloc.a ${CMAKE_CURRENT_BINARY_DIR}/lib
     STEP_TARGETS

--- a/3rdParty/libunwind/CMakeLists.txt
+++ b/3rdParty/libunwind/CMakeLists.txt
@@ -42,11 +42,11 @@ if (LINUX)
                   --prefix=${CMAKE_CURRENT_BINARY_DIR}
                   --disable-shared --enable-static --disable-tests --disable-documentation --disable-per-thread-cache --disable-coredump --disable-ptrace --disable-setjmp --disable-debug --disable-zlibdebuginfo --disable-minidebuginfo --disable-cxx-exceptions
     BUILD_COMMAND
-      ${MAKE} 
+      $(MAKE)
     BUILD_IN_SOURCE
       1
     INSTALL_COMMAND
-      ${MAKE} install prefix=${CMAKE_CURRENT_BINARY_DIR} DESTDIR=${CMAKE_CURRENT_BINARY_DIR}
+      $(MAKE) install prefix=${CMAKE_CURRENT_BINARY_DIR} DESTDIR=${CMAKE_CURRENT_BINARY_DIR}
     STEP_TARGETS
       ${LIBUNWIND_LIB} libunwind
   )


### PR DESCRIPTION
### Scope & Purpose

This reverts a change from #14164, which inadvertently prevented make from finding its job server, e.g.:

```
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
```

We can later find out the reason and how to make it work for ninja as well, this is just to make builds work in parallel again for those three libraries.

- [X] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [X] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

### Testing & Verification

- [X] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
