### PR TITLE
fixed issue BTS-422

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,18 @@
 v3.8.0 (XXXX-XX-XX)
 -------------------
 
+* Fixed BTS-422: SingleRemoteModification in AQL behaves different.
+
+  This disables the optimizer rule `optimize-cluster-single-document-operations`
+  for array inputs, e.g.
+  
+      INSERT [...] INTO collection
+      REMOVE [...] IN collection
+
+  For the cases, the optimization is not pulled off, and the normal insert/
+  update/replace/remove behavior is executed, which will fail because of an
+  array being used as input.
+
 * Fixes SEARCH-7: inconsistent BM25 scoring for LEVENSHTEIN_MATCH function.
 
 * Rename two metrics with previously Prometheus-incompatible names:

--- a/arangod/Aql/OptimizerRulesCluster.cpp
+++ b/arangod/Aql/OptimizerRulesCluster.cpp
@@ -320,6 +320,27 @@ bool substituteClusterSingleDocumentOperationsNoIndex(Optimizer* opt, ExecutionP
         keyVar = updateReplaceNode->inKeyVariable();
       }
     }
+    
+    auto isArrayInput = [&](Variable const* variable) {
+      if (variable == nullptr) {
+        return false;
+      }
+
+      ExecutionNode* setter = plan->getVarSetBy(variable->id);
+      if (setter != nullptr && setter->getType() == EN::CALCULATION) {
+        CalculationNode const* calc = ExecutionNode::castTo<CalculationNode*>(setter);
+        AstNode const* expr = calc->expression()->node();
+        if (expr->isArray()) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    if (isArrayInput(keyVar) || isArrayInput(update)) {
+      // cannot handle arrays as inputs here
+      continue;
+    }
 
     ExecutionNode* cursor = node;
     CalculationNode* calc = nullptr;

--- a/tests/js/server/aql/aql-optimizer-optimize-cluster-single-document-operations.js
+++ b/tests/js/server/aql/aql-optimizer-optimize-cluster-single-document-operations.js
@@ -491,6 +491,34 @@ function optimizerClusterSingleDocumentTestSuite () {
         "FOR one IN @@cn1 FILTER one._key == 'a' REMOVE 'foo' IN @@cn1",
         "FOR one IN @@cn1 FILTER one._key == 'a' REMOVE 'foo' IN " + cn2,
         "FOR one IN @@cn1 FILTER one._key == 'a' REMOVE one IN " + cn2,
+
+        "INSERT [] INTO @@cn1",
+        "INSERT [ {} ] INTO @@cn1",
+        "INSERT [{ foo: 1 }] INTO @@cn1",
+        "INSERT [] INTO @@cn1 RETURN NEW",
+        "INSERT [ {} ] INTO @@cn1 RETURN NEW",
+        "INSERT [{ foo: 2 }] INTO @@cn1 RETURN NEW",
+
+        "UPDATE [] IN @@cn1",
+        "UPDATE [ {} ] IN @@cn1",
+        "UPDATE [{ foo: 3 }] IN @@cn1",
+        "UPDATE [] IN @@cn1 RETURN OLD",
+        "UPDATE [ {} ] IN @@cn1 RETURN OLD",
+        "UPDATE [{ foo: 4 }] IN @@cn1 RETURN OLD",
+        
+        "REPLACE [] IN @@cn1",
+        "REPLACE [ {} ] IN @@cn1",
+        "REPLACE [{ foo: 3 }] IN @@cn1",
+        "REPLACE [] IN @@cn1 RETURN OLD",
+        "REPLACE [ {} ] IN @@cn1 RETURN OLD",
+        "REPLACE [{ foo: 4 }] IN @@cn1 RETURN OLD",
+
+        "REMOVE [] IN @@cn1",
+        "REMOVE [ {} ] IN @@cn1",
+        "REMOVE [{ foo: 3 }] IN @@cn1",
+        "REMOVE [] IN @@cn1 RETURN OLD",
+        "REMOVE [ {} ] IN @@cn1 RETURN OLD",
+        "REMOVE [{ foo: 4 }] IN @@cn1 RETURN OLD",
       ];
 
       queries.forEach(function(query) {


### PR DESCRIPTION
### Scope & Purpose

https://arangodb.atlassian.net/browse/BTS-422
Backport of https://github.com/arangodb/arangodb/pull/14215

* Fixed BTS-422: SingleRemoteModification in AQL behaves different.

  This disables the optimizer rule `optimize-cluster-single-document-operations`
  for array inputs, e.g.

      INSERT [...] INTO collection
      REMOVE [...] IN collection

  For the cases, the optimization is not pulled off, and the normal insert/
  update/replace/remove behavior is executed, which will fail because of an
  array being used as input.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.7*: https://github.com/arangodb/arangodb/pull/14217

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (shell_server_aql)
