### PR TITLE
Docs: List possible execution state strings for GET /_api/query/current

### DIFF
--- a/Documentation/DocuBlocks/Rest/AQL/GetApiQueryCurrent.md
+++ b/Documentation/DocuBlocks/Rest/AQL/GetApiQueryCurrent.md
@@ -23,7 +23,18 @@ database. Each query is a JSON object with the following attributes:
 - *runTime*: the query's run time up to the point the list of queries was
   queried
 
-- *state*: the query's current execution state (as a string)
+- *state*: the query's current execution state (as a string):
+  - `"initializing"`
+  - `"parsing"`
+  - `"optimizing ast"`
+  - `"loading collections"`
+  - `"instantiating plan"`
+  - `"optimizing plan"`
+  - `"executing"`
+  - `"finalizing"`
+  - `"finished"`
+  - `"killed"`
+  - `"invalid"`
 
 - *stream*: whether or not the query uses a streaming cursor
 

--- a/Documentation/DocuBlocks/Rest/AQL/GetApiQueryCurrent.md
+++ b/Documentation/DocuBlocks/Rest/AQL/GetApiQueryCurrent.md
@@ -23,7 +23,7 @@ database. Each query is a JSON object with the following attributes:
 - *runTime*: the query's run time up to the point the list of queries was
   queried
 
-- *state*: the query's current execution state (as a string):
+- *state*: the query's current execution state (as a string). One of:
   - `"initializing"`
   - `"parsing"`
   - `"optimizing ast"`


### PR DESCRIPTION
Backports required: 3.7, 3.8

https://github.com/arangodb/arangodb/blob/fbb60b75b7dcf182f1f12c1f7003fa875180901f/arangod/Aql/QueryExecutionState.cpp#L33-L46