### PR TITLE
Docs: List possible execution state strings for GET /_api/query/current

### DIFF
--- a/Documentation/DocuBlocks/Rest/AQL/GetApiQueryCurrent.md
+++ b/Documentation/DocuBlocks/Rest/AQL/GetApiQueryCurrent.md
@@ -23,7 +23,18 @@ database. Each query is a JSON object with the following attributes:
 - *runTime*: the query's run time up to the point the list of queries was
   queried
 
-- *state*: the query's current execution state (as a string)
+- *state*: the query's current execution state (as a string). One of:
+  - `"initializing"`
+  - `"parsing"`
+  - `"optimizing ast"`
+  - `"loading collections"`
+  - `"instantiating plan"`
+  - `"optimizing plan"`
+  - `"executing"`
+  - `"finalizing"`
+  - `"finished"`
+  - `"killed"`
+  - `"invalid"`
 
 - *stream*: whether or not the query uses a streaming cursor
 


### PR DESCRIPTION
Backport of #14223 