### PR TITLE
Add observationsSampleDataset for docs

### DIFF
--- a/js/common/modules/@arangodb/examples/examples.js
+++ b/js/common/modules/@arangodb/examples/examples.js
@@ -122,5 +122,26 @@ exports.Examples = {
         db._drop("relations");
       } catch (e) {}
     }
+  },
+  'observationsSampleDataset': {
+    createDS: function() {
+      db._create("observations");
+      db.observations.save([
+        { "time": "07:00:00", "subject": "st113", "val": 10 },
+        { "time": "07:15:00", "subject": "st113", "val": 9 },
+        { "time": "07:30:00", "subject": "st113", "val": 25 },
+        { "time": "07:45:00", "subject": "st113", "val": 20 },
+        { "time": "07:00:00", "subject": "xh458", "val": 0 },
+        { "time": "07:15:00", "subject": "xh458", "val": 10 },
+        { "time": "07:30:00", "subject": "xh458", "val": 5 },
+        { "time": "07:45:00", "subject": "xh458", "val": 30 },
+        { "time": "08:00:00", "subject": "xh458", "val": 25 },
+      ]);
+    },
+    removeDS: function() {
+      try {
+        db._drop("observations");
+      } catch (e) {}
+    }
   }
 };

--- a/js/common/modules/@arangodb/examples/examples.js
+++ b/js/common/modules/@arangodb/examples/examples.js
@@ -127,15 +127,15 @@ exports.Examples = {
     createDS: function() {
       db._create("observations");
       db.observations.save([
-        { "time": "07:00:00", "subject": "st113", "val": 10 },
-        { "time": "07:15:00", "subject": "st113", "val": 9 },
-        { "time": "07:30:00", "subject": "st113", "val": 25 },
-        { "time": "07:45:00", "subject": "st113", "val": 20 },
-        { "time": "07:00:00", "subject": "xh458", "val": 0 },
-        { "time": "07:15:00", "subject": "xh458", "val": 10 },
-        { "time": "07:30:00", "subject": "xh458", "val": 5 },
-        { "time": "07:45:00", "subject": "xh458", "val": 30 },
-        { "time": "08:00:00", "subject": "xh458", "val": 25 },
+        { "time": "2021-05-25 07:00:00", "subject": "st113", "val": 10 },
+        { "time": "2021-05-25 07:15:00", "subject": "st113", "val": 9 },
+        { "time": "2021-05-25 07:30:00", "subject": "st113", "val": 25 },
+        { "time": "2021-05-25 07:45:00", "subject": "st113", "val": 20 },
+        { "time": "2021-05-25 07:00:00", "subject": "xh458", "val": 0 },
+        { "time": "2021-05-25 07:15:00", "subject": "xh458", "val": 10 },
+        { "time": "2021-05-25 07:30:00", "subject": "xh458", "val": 5 },
+        { "time": "2021-05-25 07:45:00", "subject": "xh458", "val": 30 },
+        { "time": "2021-05-25 08:00:00", "subject": "xh458", "val": 25 },
       ]);
     },
     removeDS: function() {


### PR DESCRIPTION
### Scope & Purpose

Add a tiny dataset to be used for WINDOW aggregation queries in the documentation.

- Add more data points? -> Good enough, easy to understand with just a few data points
- Convert `time` to actual ISO datetime string to enable `WINDOW DATE_TIMESTAMP(t.time) WITH { ... }`? (the current example query does not make sense) -> Converted to ISO compatible string, but still requires cast to numeric timestamp - not sure how performant that is on large datasets, but it's easier to follow

#### Backports:

- [x] Backports required for: 3.8

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/695
- [x] Jira ticket number: https://arangodb.atlassian.net/browse/BTS-401

