### PR TITLE
Small change on creation scripts for metrics

### DIFF
--- a/utils/makeDashboards.py
+++ b/utils/makeDashboards.py
@@ -310,7 +310,7 @@ for c in CATEGORYNAMES:
                     if met["type"] == "counter":
                         panel["type"] = "graph"
                         panel["targets"] = [{"expr": "rate(" + met["name"] + \
-                                                     "[1m])", \
+                                                     "[3m])", \
                             "legendFormat": "{{instance}}:{{shortname}}"}]
                         POSX, POSY = incxy(POSX, POSY)
                         PANELS.append(panel)


### PR DESCRIPTION
This change is necessary for metrics on k8s. For counters, the
averaging period is changed from 1 minute to 3 minutes, since on k8s
scraping is done less frequently.
