### PR TITLE
Feature/dual ldap tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 devel
 -----
 
+* added LDAP tests for fail-over or alternate LDAP servers. There are the
+  following test scenarios:
+ - two LDAP servers, each responsible for the same users. The second one
+   is a fail-over for the first one.
+ - two LDAP servers, responsbible for different users.
+
 * Fixed DEVSUP-764 (SEARCH-7): inconsistent BM25 scoring for LEVENSHTEIN_MATCH
   function.
 

--- a/tests/js/client/ldapfailover/auth-dualldap.js
+++ b/tests/js/client/ldapfailover/auth-dualldap.js
@@ -1,0 +1,236 @@
+/*jshint globalstrict:false, strict:false */
+/*global fail, assertTrue, assertEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test the authentication (dual ldap)
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2021 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Frank Celler
+/// @author Copyright 2021, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const arango = require("@arangodb").arango;
+const db = require("internal").db;
+const users = require("@arangodb/users");
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test suite
+////////////////////////////////////////////////////////////////////////////////
+
+function AuthSuite() {
+  'use strict';
+  var baseUrl = function () {
+    return arango.getEndpoint().replace(/^tcp:/, 'http:').replace(/^ssl:/, 'https:');
+  };
+
+  // hardcoded in testsuite
+  const jwtSecret = 'haxxmann';
+  const dbname = 'test';
+  const role1 = "role1";
+  const role2 = "adminrole";
+  const role3 = "bundeskanzlerin";
+  const roles = [role1, role2, role3];
+  
+  return {
+    setUpAll: function () {
+      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+
+      for (const role of roles) {
+        try {
+          users.remove(":role:" + role);
+        }
+        catch (err) {
+        }
+      }
+
+      try {
+        db._dropDatabase(dbname);
+      } catch (err) {
+      }
+    },
+
+    tearDownAll: function () {
+      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+
+      for (const role of roles) {
+        try {
+          users.remove(":role:" + role);
+        }
+        catch (err) {
+        }
+      }
+
+      try {
+        db._dropDatabase(dbname);
+      } catch (err) {
+      }
+    },
+    
+    testCreateRoles: function () {
+      for (const role of roles) {
+         const fr = ":role:" + role;
+         let r = users.save(fr, "password", true);
+         assertEqual(fr, r.user);
+      }
+
+      users.reload();
+
+      for (const role of roles) {
+         const fr = ":role:" + role;
+         assertTrue(users.exists(fr));
+      }
+    },
+
+    testDatabases: function () {
+      let r = db._createDatabase(dbname);
+      assertTrue(r);
+
+      users.grantDatabase(":role:" + role1, dbname, "rw");
+      users.grantDatabase(":role:" + role2, dbname, "rw");
+      users.grantDatabase(":role:" + role3, dbname, "rw");
+    },
+
+    testRole1: function () {
+      // both LDAP will answer for user1 resp. user2
+      const user1 = "user1";
+      const user2 = user1 + ",dc=arangodb";
+
+      // this will fail, as the PW is wrong
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user1, "");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will succeed as the PW is correct and LDAP1 is active and responsible
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user1, "abc");
+	assertTrue(true);
+      } catch (e) {
+	assertTrue(false);
+      }
+
+      // this will fail, as the PW is wrong
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user2, "");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will succeed as the PW is correct and LDAP2 is active and responsible
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user2, "abc");
+	assertTrue(true);
+      } catch (e) {
+	assertTrue(false);
+      }
+    },
+
+    testRole2: function () {
+      // only first LDAP will answer for user1
+      const user1 = "The Donald";
+      const user2 = user1 + ",dc=arangodb";
+
+      // this will fail, as the PW is wrong
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user1, "");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will succeed as the PW is correct and LDAP1 is active and responsible
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user1, "abc");
+	assertTrue(true);
+      } catch (e) {
+	assertTrue(false);
+      }
+
+      // this will fail, as the PW is wrong
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user2, "");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will fail as the PW is correct and LDAP2 is active and not responsible
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user2, "abc");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+    },
+
+    testRole3: function () {
+      // only second LDAP will answer for user2
+      const user1 = "Angela Merkel";
+      const user2 = user1 + ",dc=arangodb";
+
+      // this will fail, as the PW is wrong
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user1, "");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will fail as the PW is correct and LDAP1 is active and not responsible
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user1, "abc");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will fail, as the PW is wrong
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user2, "");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will succeed as the PW is correct and LDAP2 is active and responsible
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user2, "abc");
+	assertTrue(true);
+      } catch (e) {
+	assertTrue(false);
+      }
+    }
+  };
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief executes the test suite
+////////////////////////////////////////////////////////////////////////////////
+
+jsunity.run(AuthSuite);
+
+return jsunity.done();

--- a/tests/js/client/ldapfailover/auth-firstldap.js
+++ b/tests/js/client/ldapfailover/auth-firstldap.js
@@ -1,0 +1,236 @@
+/*jshint globalstrict:false, strict:false */
+/*global fail, assertTrue, assertEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test the authentication (dual ldap)
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2021 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Frank Celler
+/// @author Copyright 2021, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const arango = require("@arangodb").arango;
+const db = require("internal").db;
+const users = require("@arangodb/users");
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test suite
+////////////////////////////////////////////////////////////////////////////////
+
+function AuthSuite() {
+  'use strict';
+  var baseUrl = function () {
+    return arango.getEndpoint().replace(/^tcp:/, 'http:').replace(/^ssl:/, 'https:');
+  };
+
+  // hardcoded in testsuite
+  const jwtSecret = 'haxxmann';
+  const dbname = 'test';
+  const role1 = "role1";
+  const role2 = "adminrole";
+  const role3 = "bundeskanzlerin";
+  const roles = [role1, role2, role3];
+  
+  return {
+    setUpAll: function () {
+      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+
+      for (const role of roles) {
+        try {
+          users.remove(":role:" + role);
+        }
+        catch (err) {
+        }
+      }
+
+      try {
+        db._dropDatabase(dbname);
+      } catch (err) {
+      }
+    },
+
+    tearDownAll: function () {
+      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+
+      for (const role of roles) {
+        try {
+          users.remove(":role:" + role);
+        }
+        catch (err) {
+        }
+      }
+
+      try {
+        db._dropDatabase(dbname);
+      } catch (err) {
+      }
+    },
+    
+    testCreateRoles: function () {
+      for (const role of roles) {
+         const fr = ":role:" + role;
+         let r = users.save(fr, "password", true);
+         assertEqual(fr, r.user);
+      }
+
+      users.reload();
+
+      for (const role of roles) {
+         const fr = ":role:" + role;
+         assertTrue(users.exists(fr));
+      }
+    },
+
+    testDatabases: function () {
+      let r = db._createDatabase(dbname);
+      assertTrue(r);
+
+      users.grantDatabase(":role:" + role1, dbname, "rw");
+      users.grantDatabase(":role:" + role2, dbname, "rw");
+      users.grantDatabase(":role:" + role3, dbname, "rw");
+    },
+
+    testRole1: function () {
+      // both LDAP will answer for user1 resp. user2
+      const user1 = "user1";
+      const user2 = user1 + ",dc=arangodb";
+
+      // this will fail, as the PW is wrong
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user1, "");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will succeed as the PW is correct and LDAP1 is active and responsible
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user1, "abc");
+	assertTrue(true);
+      } catch (e) {
+	assertTrue(false);
+      }
+
+      // this will fail, as the PW is wrong
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user2, "");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will fail as the PW is correct and LDAP2 is not active
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user2, "abc");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+    },
+
+    testRole2: function () {
+      // only first LDAP will answer for user1
+      const user1 = "The Donald";
+      const user2 = user1 + ",dc=arangodb";
+
+      // this will fail, as the PW is wrong
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user1, "");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will succeed as the PW is correct and LDAP1 is active and responsible
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user1, "abc");
+	assertTrue(true);
+      } catch (e) {
+	assertTrue(false);
+      }
+
+      // this will fail, as the PW is wrong
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user2, "");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will fail as the PW is correct and LDAP2 is not active
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user2, "abc");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+    },
+
+    testRole3: function () {
+      // only second LDAP will answer for user2
+      const user1 = "Angela Merkel";
+      const user2 = user1 + ",dc=arangodb";
+
+      // this will fail, as the PW is wrong
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user1, "");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will fail as the PW is correct and LDAP1 is active and not responsible
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user1, "abc");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will fail, as the PW is wrong
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user2, "");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will fail as the PW is correct and LDAP2 is not active
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user2, "abc");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+    }
+  };
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief executes the test suite
+////////////////////////////////////////////////////////////////////////////////
+
+jsunity.run(AuthSuite);
+
+return jsunity.done();

--- a/tests/js/client/ldapfailover/auth-secondldap.js
+++ b/tests/js/client/ldapfailover/auth-secondldap.js
@@ -1,0 +1,236 @@
+/*jshint globalstrict:false, strict:false */
+/*global fail, assertTrue, assertEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test the authentication (dual ldap)
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2021 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Frank Celler
+/// @author Copyright 2021, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const arango = require("@arangodb").arango;
+const db = require("internal").db;
+const users = require("@arangodb/users");
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test suite
+////////////////////////////////////////////////////////////////////////////////
+
+function AuthSuite() {
+  'use strict';
+  var baseUrl = function () {
+    return arango.getEndpoint().replace(/^tcp:/, 'http:').replace(/^ssl:/, 'https:');
+  };
+
+  // hardcoded in testsuite
+  const jwtSecret = 'haxxmann';
+  const dbname = 'test';
+  const role1 = "role1";
+  const role2 = "adminrole";
+  const role3 = "bundeskanzlerin";
+  const roles = [role1, role2, role3];
+  
+  return {
+    setUpAll: function () {
+      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+
+      for (const role of roles) {
+        try {
+          users.remove(":role:" + role);
+        }
+        catch (err) {
+        }
+      }
+
+      try {
+        db._dropDatabase(dbname);
+      } catch (err) {
+      }
+    },
+
+    tearDownAll: function () {
+      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+
+      for (const role of roles) {
+        try {
+          users.remove(":role:" + role);
+        }
+        catch (err) {
+        }
+      }
+
+      try {
+        db._dropDatabase(dbname);
+      } catch (err) {
+      }
+    },
+    
+    testCreateRoles: function () {
+      for (const role of roles) {
+         const fr = ":role:" + role;
+         let r = users.save(fr, "password", true);
+         assertEqual(fr, r.user);
+      }
+
+      users.reload();
+
+      for (const role of roles) {
+         const fr = ":role:" + role;
+         assertTrue(users.exists(fr));
+      }
+    },
+
+    testDatabases: function () {
+      let r = db._createDatabase(dbname);
+      assertTrue(r);
+
+      users.grantDatabase(":role:" + role1, dbname, "rw");
+      users.grantDatabase(":role:" + role2, dbname, "rw");
+      users.grantDatabase(":role:" + role3, dbname, "rw");
+    },
+
+    testRole1: function () {
+      // both LDAP will answer for user1 resp. user2
+      const user1 = "user1";
+      const user2 = user1 + ",dc=arangodb";
+
+      // this will fail, as the PW is wrong
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user1, "");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will fail as the PW is correct and LDAP1 is not active
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user1, "abc");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will fail, as the PW is wrong
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user2, "");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will succeed as the PW is correct and LDAP2 is active and responsible
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user2, "abc");
+	assertTrue(true);
+      } catch (e) {
+	assertTrue(false);
+      }
+    },
+
+    testRole2: function () {
+      // only first LDAP will answer for user1
+      const user1 = "The Donald";
+      const user2 = user1 + ",dc=arangodb";
+
+      // this will fail, as the PW is wrong
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user1, "");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will fail as the PW is correct and LDAP1 is not active
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user1, "abc");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will fail, as the PW is wrong
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user2, "");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will fail as the PW is correct and LDAP2 is active and not responsible
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user2, "abc");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+    },
+
+    testRole3: function () {
+      // only second LDAP will answer for user2
+      const user1 = "Angela Merkel";
+      const user2 = user1 + ",dc=arangodb";
+
+      // this will fail, as the PW is wrong
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user1, "");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will fail as the PW is correct and LDAP1 is not active
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user1, "abc");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will fail, as the PW is wrong
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user2, "");
+	assertTrue(false);
+      } catch (e) {
+        assertEqual(10, e.errorNum);
+      }
+
+      // this will succeed as the PW is correct and LDAP2 is active and responsible
+      try {
+        arango.reconnect(arango.getEndpoint(), dbname, user2, "abc");
+	assertTrue(true);
+      } catch (e) {
+	assertTrue(false);
+      }
+    }
+  };
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief executes the test suite
+////////////////////////////////////////////////////////////////////////////////
+
+jsunity.run(AuthSuite);
+
+return jsunity.done();

--- a/tests/js/client/ldapfailover/responsible1
+++ b/tests/js/client/ldapfailover/responsible1
@@ -1,0 +1,2 @@
+user1
+The Donald

--- a/tests/js/client/ldapfailover/responsible2
+++ b/tests/js/client/ldapfailover/responsible2
@@ -1,0 +1,2 @@
+user1,dc=arangodb
+Angela Merkel,dc=arangodb


### PR DESCRIPTION
### Scope & Purpose

This will add the three test scenarios:

* two active ldap servers
* first ldap server active, second ldap server not reachable
* second ldap server not reachable, second ldap server active

The fourth scenario, only one ldap, is tests be the existing tests.
 
This requires a PR for oskar (https://github.com/arangodb/oskar/pull/319) which starts two LDAP servers as docker containers.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification: tests added
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.6, 3.7, 3.8

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [x] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [x] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:

### Documentation

> All new features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the CHANGELOG so that
> support, end users, and other developers have a concise overview. 

- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
