### PR TITLE
rename "storedTree" attribute to just "stored".

### DIFF
--- a/arangod/RocksDBEngine/RocksDBV8Functions.cpp
+++ b/arangod/RocksDBEngine/RocksDBV8Functions.cpp
@@ -265,10 +265,10 @@ static void JS_CollectionRevisionTreeVerification(v8::FunctionCallbackInfo<v8::V
   { 
     VPackObjectBuilder guard(&builder);
     if (storedTree != nullptr) {
-      builder.add(VPackValue("storedTree"));
+      builder.add(VPackValue("stored"));
       storedTree->serialize(builder);
     } else {
-      builder.add("storedTree", VPackValue(false));
+      builder.add("stored", VPackValue(false));
     }
     if (computedTree != nullptr) {
       builder.add(VPackValue("computed"));


### PR DESCRIPTION
### Scope & Purpose

For consistency, rename "storedTree" attribute to just "stored". 
This affects a not-yet-published API, so there is intentionally no changelog entry for it.
The same change for devel is contained in https://github.com/arangodb/arangodb/pull/14220.
We don't need any backports to 3.7 or earlier.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
