### PR TITLE
Parallel multi-shard INSERTs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Allow an INSERT operation for a multi-shard collection to execute in 
+  parallel on different DB servers.
 
 * Fix BTS-409: return error 1948 when a negative edge was detected during or was
   used as default weight in a SHORTEST_PATH or a K_SHOTRTEST_PAHS traversal.

--- a/arangod/Aql/BlocksWithClients.cpp
+++ b/arangod/Aql/BlocksWithClients.cpp
@@ -90,8 +90,7 @@ BlocksWithClientsImpl<Executor>::BlocksWithClientsImpl(ExecutionEngine* engine,
       _registerInfos(std::move(registerInfos)),
       _executorInfos(std::move(executorInfos)),
       _executor{_executorInfos},
-      _clientBlockData{},
-      _wasShutdown(false) {
+      _clientBlockData{} {
   _shardIdMap.reserve(_nrClients);
   auto const& shardIds = _executorInfos.clientIds();
   for (size_t i = 0; i < _nrClients; i++) {

--- a/arangod/Aql/BlocksWithClients.h
+++ b/arangod/Aql/BlocksWithClients.h
@@ -190,8 +190,6 @@ class BlocksWithClientsImpl : public ExecutionBlock, public BlocksWithClients {
   /// @brief A map of clientId to the data this client should receive.
   ///        This map will be filled as the execution progresses.
   std::unordered_map<std::string, typename Executor::ClientBlockData> _clientBlockData;
-
-  bool _wasShutdown;
 };
 
 }  // namespace aql

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -383,7 +383,8 @@ ExecutionBlockImpl<Executor>::execute(AqlCallStack const& stack) {
     // store only the first failure we got
     _firstFailure = {TRI_ERROR_INTERNAL, ex.what()};
     LOG_QUERY("2bbd5", DEBUG) << printBlockInfo() << " local statemachine failed with exception: " << ex.what();
-    throw;
+    // Rewire the error, to be consistent with potentially next caller.
+    THROW_ARANGO_EXCEPTION(_firstFailure);
   }
 }
 

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -373,18 +373,16 @@ ExecutionBlockImpl<Executor>::execute(AqlCallStack const& stack) {
     traceExecuteEnd(res);
     return res;
   } catch (basics::Exception const& ex) {
-    if (_firstFailure.ok()) {
-      // store only the first failure we got
-      _firstFailure = {ex.code(), ex.what()};
-      LOG_QUERY("7289a", DEBUG) << printBlockInfo() << " local statemachine failed with exception: " << ex.what();
-    }
+    TRI_ASSERT(_firstFailure.ok());
+    // store only the first failure we got
+    _firstFailure = {ex.code(), ex.what()};
+    LOG_QUERY("7289a", DEBUG) << printBlockInfo() << " local statemachine failed with exception: " << ex.what();
     throw;
   } catch (std::exception const& ex) {
-    if (_firstFailure.ok()) {
-      // store only the first failure we got
-      _firstFailure = {TRI_ERROR_INTERNAL, ex.what()};
-      LOG_QUERY("2bbd5", DEBUG) << printBlockInfo() << " local statemachine failed with exception: " << ex.what();
-    }
+    TRI_ASSERT(_firstFailure.ok());
+    // store only the first failure we got
+    _firstFailure = {TRI_ERROR_INTERNAL, ex.what()};
+    LOG_QUERY("2bbd5", DEBUG) << printBlockInfo() << " local statemachine failed with exception: " << ex.what();
     throw;
   }
 }

--- a/arangod/Aql/ExecutionBlockImpl.h
+++ b/arangod/Aql/ExecutionBlockImpl.h
@@ -394,6 +394,8 @@ class ExecutionBlockImpl final : public ExecutionBlock {
   
   std::shared_ptr<PrefetchTask> _prefetchTask;
   
+  Result _firstFailure;
+  
   bool _hasMemoizedCall{false};
 
   // Only used in passthrough variant.

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -7410,10 +7410,14 @@ struct ParallelizableFinder final
     : public WalkerWorker<ExecutionNode, WalkerUniqueness::NonUnique> {
   bool const _parallelizeWrites;
   bool _isParallelizable;
+  bool _seenDistribute;
+  uint32_t _numRemotes;
 
   explicit ParallelizableFinder(bool parallelizeWrites)
       : _parallelizeWrites(parallelizeWrites),
-        _isParallelizable(true) {}
+        _isParallelizable(true),
+        _seenDistribute(false),
+        _numRemotes(0) {}
 
   ~ParallelizableFinder() = default;
 
@@ -7423,10 +7427,29 @@ struct ParallelizableFinder final
 
   bool before(ExecutionNode* node) override final {
     if (node->getType() == ExecutionNode::SCATTER ||
-        node->getType() == ExecutionNode::GATHER ||
-        node->getType() == ExecutionNode::DISTRIBUTE) {
+        node->getType() == ExecutionNode::GATHER) {
       _isParallelizable = false;
       return true;  // true to abort the whole walking process
+    }
+    if (node->getType() == ExecutionNode::DISTRIBUTE) {
+      if (_seenDistribute) {
+        // if we find 2 DISTRIBUTE nodes in the plan, we give up
+        _isParallelizable = false;
+        return true;
+      }
+      // node that we have seen a DISTRIBUTE node
+      _seenDistribute = true;
+    }
+    if (node->getType() == ExecutionNode::REMOTE) {
+      // plan walking starts at a GATHER node, so we expect to see
+      // at least one REMOTE node.
+      // if we find another one, it is ok if that REMOTE node refers
+      // to a DISTRIBUTE node (checked above). if it refers to another
+      // GATHER node somewhere, we also abort above.
+      if (++_numRemotes > 2) {
+        _isParallelizable = false;
+        return true;
+      }
     }
 
     if (node->getType() == ExecutionNode::TRAVERSAL ||
@@ -7446,6 +7469,7 @@ struct ParallelizableFinder final
         (!_parallelizeWrites ||
          (node->getType() != ExecutionNode::REMOVE &&
           node->getType() != ExecutionNode::REPLACE &&
+          node->getType() != ExecutionNode::INSERT &&
           node->getType() != ExecutionNode::UPDATE))) {
       _isParallelizable = false;
       return true;  // true to abort the whole walking process
@@ -7790,10 +7814,10 @@ void arangodb::aql::parallelizeGatherRule(Optimizer* opt,
   ::arangodb::containers::SmallVector<ExecutionNode*> nodes{a};
   plan->findNodesOfType(nodes, EN::GATHER, true);
 
-  if (nodes.size() == 1 && !plan->contains(EN::DISTRIBUTE) && !plan->contains(EN::SCATTER)) {
+  if (nodes.size() == 1 && !plan->contains(EN::SCATTER)) {
+    GatherNode* gn = ExecutionNode::castTo<GatherNode*>(nodes[0]);
     TRI_vocbase_t& vocbase = plan->getAst()->query().vocbase();
     bool parallelizeWrites = vocbase.server().getFeature<OptimizerRulesFeature>().parallelizeGatherWrites();
-    GatherNode* gn = ExecutionNode::castTo<GatherNode*>(nodes[0]);
 
     if (!gn->isInSubquery() && isParallelizable(gn, parallelizeWrites)) {
       // find all graph nodes and make sure that they all are using satellite

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -7438,7 +7438,7 @@ struct ParallelizableFinder final
         _isParallelizable = false;
         return true;
       }
-      // node that we have seen a DISTRIBUTE node.
+      // note that we have seen a DISTRIBUTE node.
       // note that a single DISTRIBUTE node should be safe if it
       // itself does not reach out to other snippets.
       // The reason it should be safe is that the DISTRIBUTE will

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -7437,7 +7437,14 @@ struct ParallelizableFinder final
         _isParallelizable = false;
         return true;
       }
-      // node that we have seen a DISTRIBUTE node
+      // node that we have seen a DISTRIBUTE node.
+      // note that a single DISTRIBUTE node should be safe if it
+      // itself does not reach out to other snippets.
+      // The reason it should be safe is that the DISTRIBUTE will
+      // be executed under the snippet's mutex, so any real parallelism
+      // on the same DISTRIBUTE node is prevented. if multiple
+      // DB ervers are queuing for the same DISTRIBUTE node, this may
+      // lead to some contention, but should work eventually.
       _seenDistribute = true;
     }
     if (node->getType() == ExecutionNode::REMOTE) {

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -7433,7 +7433,8 @@ struct ParallelizableFinder final
     }
     if (node->getType() == ExecutionNode::DISTRIBUTE) {
       if (_seenDistribute) {
-        // if we find 2 DISTRIBUTE nodes in the plan, we give up
+        // if we find 2 DISTRIBUTE nodes in the plan, or a DISTRIBUTE
+        // at an unexpected place, we give up
         _isParallelizable = false;
         return true;
       }
@@ -7453,7 +7454,7 @@ struct ParallelizableFinder final
       // if we find another one, it is ok if that REMOTE node refers
       // to a DISTRIBUTE node (checked above). if it refers to another
       // GATHER node somewhere, we also abort above.
-      if (++_numRemotes > 2) {
+      if (++_numRemotes > 2 || _seenDistribute) {
         _isParallelizable = false;
         return true;
       }

--- a/arangod/Aql/QueryRegistry.cpp
+++ b/arangod/Aql/QueryRegistry.cpp
@@ -115,14 +115,14 @@ void QueryRegistry::insertQuery(std::unique_ptr<ClusterQuery> query, double ttl,
 
 /// @brief open
 void* QueryRegistry::openEngine(EngineId id, EngineType type) {
-  LOG_TOPIC("8c204", DEBUG, arangodb::Logger::AQL) << "Opening engine with id " << id;
+  LOG_TOPIC("8c204", DEBUG, arangodb::Logger::AQL) << "trying to open engine with id " << id;
   // std::cout << "Taking out query with ID " << id << std::endl;
   WRITE_LOCKER(writeLocker, _lock);
   
   auto it = _engines.find(id);
   if (it == _engines.end()) {
     LOG_TOPIC("c3ae4", DEBUG, arangodb::Logger::AQL)
-    << "Found no engine with id " << id;
+      << "Found no engine with id " << id;
     return nullptr;
   }
   
@@ -130,7 +130,7 @@ void* QueryRegistry::openEngine(EngineId id, EngineType type) {
   
   if (ei._type != type) {
     LOG_TOPIC("c3af5", DEBUG, arangodb::Logger::AQL)
-    << "Engine with id " << id << " has other type";
+      << "Engine with id " << id << " has other type";
     return nullptr;
   }
   
@@ -151,9 +151,11 @@ void* QueryRegistry::openEngine(EngineId id, EngineType type) {
     // now that we made it return the true value, the assertion is triggered.
     // TODO: need to sort this out.
     // TRI_ASSERT(ei._queryInfo->_numOpen == 1 || !ei._queryInfo->_query->isModificationQuery());
-    LOG_TOPIC("b1cfd", TRACE, arangodb::Logger::AQL) << "opening engine " << id << ", query id: " << ei._queryInfo->_query->id() << ", numOpen: " << ei._queryInfo->_numOpen;
+    LOG_TOPIC("b1cfd", TRACE, arangodb::Logger::AQL) 
+      << "opening engine " << id << ", query id: " << ei._queryInfo->_query->id() << ", numOpen: " << ei._queryInfo->_numOpen;
   } else {
-    LOG_TOPIC("50eff", TRACE, arangodb::Logger::AQL) << "opening engine " << id << ", no query";
+    LOG_TOPIC("50eff", TRACE, arangodb::Logger::AQL) 
+      << "opening engine " << id << ", no query";
   }
 
   return ei._engine;

--- a/tests/js/server/aql/aql-optimizer-rule-parallelize-gather-cluster.js
+++ b/tests/js/server/aql/aql-optimizer-rule-parallelize-gather-cluster.js
@@ -77,8 +77,10 @@ function optimizerRuleTestSuite () {
 
     testRuleNoEffect : function () {
       let queries = [  
+        "FOR doc IN " + cn + " INSERT {} IN " + cn,
+        "FOR doc1 IN " + cn + " FOR doc2 IN " + cn + " INSERT {} IN " + cn,
         "FOR doc IN " + cn + " LIMIT 10 UPDATE doc WITH {} IN " + cn,
-        "FOR i IN 1..1000 INSERT {} IN " + cn,
+        "FOR doc1 IN " + cn + " FOR doc2 IN " + cn + " RETURN 1",
         "FOR doc1 IN " + cn + " FOR doc2 IN " + cn + " FILTER doc1._key == doc2._key RETURN doc1",
         "FOR doc1 IN " + cn + " FOR doc2 IN " + cn + " FOR doc3 IN " + cn + " FILTER doc1._key == doc2._key FILTER doc2._key == doc3._key RETURN doc1",
         "FOR i IN 1..100 LET sub = (FOR doc IN " + cn + " FILTER doc.value == i RETURN doc) RETURN sub",
@@ -99,6 +101,8 @@ function optimizerRuleTestSuite () {
 
     testRuleHasEffect : function () {
       let queries = [ 
+        "FOR i IN 1..1000 FOR j IN 1..100 INSERT {} IN " + cn,
+        "LET top = (FOR i IN 1..10 COLLECT AGGREGATE m = MAX(i) RETURN m)[0] FOR i IN 1..top INSERT {} IN " + cn,
         "FOR doc IN " + cn + " RETURN doc",
         "FOR doc IN " + cn + " LIMIT 1000 RETURN doc",
         "FOR doc IN " + cn + " LIMIT 1000, 1000 RETURN doc",
@@ -110,6 +114,7 @@ function optimizerRuleTestSuite () {
 
       if (require("internal").options()["query.parallelize-gather-writes"]) {
         queries.concat([
+          "FOR i IN 1..1000 INSERT {} IN " + cn,
           "FOR doc IN " + cn + " REMOVE doc IN " + cn,
           "FOR doc IN " + cn + " REMOVE doc._key IN " + cn,
           "FOR doc IN " + cn + " REPLACE doc WITH {} IN " + cn,

--- a/tests/js/server/aql/aql-optimizer-rule-parallelize-gather-cluster.js
+++ b/tests/js/server/aql/aql-optimizer-rule-parallelize-gather-cluster.js
@@ -129,7 +129,7 @@ function optimizerRuleTestSuite () {
       }
 
       queries.forEach(function(query) {
-        let result = AQL_EXPLAIN(query,);
+        let result = AQL_EXPLAIN(query);
         assertNotEqual(-1, result.plan.rules.indexOf(ruleName), query);
       });
     },


### PR DESCRIPTION
### Scope & Purpose

Partly addresses https://arangodb.atlassian.net/browse/BTS-439.

Allow an INSERT operation for a multi-shard collection to execute in
parallel on different DB servers.
Previously INSERTs for a multi-shard collection were executed
sequentially on each DB servers. This could lead to slow execution time,
a large memory usage (DISTRIBUTE has to buffer data for all other DB
servers in memory until the DB servers asks for them) and also query
timeouts.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (shell_server_aql)
