### PR TITLE
Fix BTS-442

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ devel
 -----
 
 * Fix BTS-442: a query with fullCount on a sharded collection hangs
-  indefinitely when LIMIT is less then number of available documents.
+  indefinitely when LIMIT is less than number of available documents.
 
 * Fix BTS-409: return error 1948 when a negative edge was detected during or was
   used as default weight in a SHORTEST_PATH or a K_SHOTRTEST_PAHS traversal.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fix BTS-442: a query with fullCount on a sharded collection hangs
+  indefinitely when LIMIT is less then number of available documents.
 
 * Fix BTS-409: return error 1948 when a negative edge was detected during or was
   used as default weight in a SHORTEST_PATH or a K_SHOTRTEST_PAHS traversal.

--- a/arangod/Aql/ParallelUnsortedGatherExecutor.cpp
+++ b/arangod/Aql/ParallelUnsortedGatherExecutor.cpp
@@ -131,6 +131,7 @@ auto ParallelUnsortedGatherExecutor::skipRowsRange(typename Fetcher::DataRange& 
         // By guarantee we will only see data, if
         // we are past the offset phase.
         TRI_ASSERT(call.getOffset() == 0);
+        call.didSkip(range.countAndSkipAllRemainingDataRows());
       } else {
         if (call.getOffset() > 0) {
           call.didSkip(range.skip(call.getOffset()));

--- a/tests/js/server/aql/aql-skipping-cluster.js
+++ b/tests/js/server/aql/aql-skipping-cluster.js
@@ -70,6 +70,16 @@ function aqlSkippingClusterTestsuite () {
         assertEqual(i, n);
       }
     },
+
+    testSkipWithFullCount: function () {
+      const query = 'FOR doc IN @@col LIMIT 2 RETURN doc';
+      const bind = {'@col': colName};
+      for (let i = 0; i < 10; ++i) {
+        col.insert({});
+      }
+      const res = db._query(query, bind, {'fullCount': true});
+      assertEqual(2, res.toArray().length);
+    },
   };
 }
 

--- a/tests/js/server/aql/aql-skipping-cluster.js
+++ b/tests/js/server/aql/aql-skipping-cluster.js
@@ -71,6 +71,11 @@ function aqlSkippingClusterTestsuite () {
       }
     },
 
+    /**
+     * Regression test for PR https://github.com/arangodb/arangodb/pull/14268
+     * A query with LIMIT and fullCount on a sharded collection would hang indefinitely
+     * if the LIMIT is less then number of available documents.
+     */
     testSkipWithFullCount: function () {
       const query = 'FOR doc IN @@col LIMIT 2 RETURN doc';
       const bind = {'@col': colName};


### PR DESCRIPTION
### Scope & Purpose

Fix BTS-442: a query with fullCount on a sharded collection hangs indefinitely when LIMIT is less then number of available documents.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.8, 3.7 (#14269, #14270)

#### Related Information

- [x] GitHub issue: https://github.com/arangodb/arangodb/issues/14214
- [x] Jira ticket number: https://arangodb.atlassian.net/browse/BTS-442

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** in shell_server_aql
