### PR TITLE
Fix BTS-450: RandomGenerator caught assertion during a value generati…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fix BTS-450: RandomGenerator caught assertion during a value generation within
+  `dump_maskings` testsuite. Ensure correct conversion between 64 and 32bit.
 
 * Fix BTS-409: return error 1948 when a negative edge was detected during or was
   used as default weight in a SHORTEST_PATH or a K_SHOTRTEST_PAHS traversal.

--- a/lib/Random/RandomGenerator.cpp
+++ b/lib/Random/RandomGenerator.cpp
@@ -102,7 +102,10 @@ int32_t RandomDevice::random(int32_t left, int32_t right) {
 
   TRI_ASSERT(right > left);
   int64_t r = static_cast<int64_t>(right) - static_cast<int64_t>(left) + 1;
-  TRI_ASSERT(r >= 0 && r <= UINT32_MAX);
+
+  // r must be at least 2, because right > left
+  // r must be strictly less UINT32_MAX, because we checked MIN & MAX
+  TRI_ASSERT(r > 1 && r < UINT32_MAX);
   uint32_t range = static_cast<uint32_t>(r);
 
   switch (range) {
@@ -201,10 +204,10 @@ int32_t RandomDevice::other(int32_t left, uint32_t range) {
 
   r %= range;
 
-  int32_t result = left + static_cast<int32_t>(r);
-  TRI_ASSERT(result >= left);
+  int64_t result = static_cast<int64_t>(left) + static_cast<int64_t>(r);
+  TRI_ASSERT(result >= static_cast<int64_t>(left>);
   TRI_ASSERT(result < left + static_cast<int64_t>(range));
-  return result;
+  return static_cast<int32_t>(result);
 }
 
 // -----------------------------------------------------------------------------

--- a/lib/Random/RandomGenerator.cpp
+++ b/lib/Random/RandomGenerator.cpp
@@ -206,7 +206,8 @@ int32_t RandomDevice::other(int32_t left, uint32_t range) {
 
   int64_t result = static_cast<int64_t>(left) + static_cast<int64_t>(r);
   TRI_ASSERT(result >= static_cast<int64_t>(left));
-  TRI_ASSERT(result < left + static_cast<int64_t>(range));
+  TRI_ASSERT(result < static_cast<int64_t>(left) + static_cast<int64_t>(range));
+  TRI_ASSERT(result <= static_cast<int64_t>(INT32_MAX));
   return static_cast<int32_t>(result);
 }
 

--- a/lib/Random/RandomGenerator.cpp
+++ b/lib/Random/RandomGenerator.cpp
@@ -205,7 +205,7 @@ int32_t RandomDevice::other(int32_t left, uint32_t range) {
   r %= range;
 
   int64_t result = static_cast<int64_t>(left) + static_cast<int64_t>(r);
-  TRI_ASSERT(result >= static_cast<int64_t>(left>);
+  TRI_ASSERT(result >= static_cast<int64_t>(left));
   TRI_ASSERT(result < left + static_cast<int64_t>(range));
   return static_cast<int32_t>(result);
 }


### PR DESCRIPTION
…on within `dump_maskings` testsuite. Ensure correct conversion between 64 and 32bit.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers - **mandatory**)*

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.8: https://github.com/arangodb/arangodb/pull/14286, 3.7: https://github.com/arangodb/arangodb/pull/14287, 3.6: https://github.com/arangodb/arangodb/pull/14288

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such asdump_masking
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:

### Documentation

> All new features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the CHANGELOG so that
> support, end users, and other developers have a concise overview. 

- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
