### PR TITLE
remember exception in ExecutionBlock

### DIFF
--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -332,16 +332,42 @@ ExecutionBlockImpl<Executor>::execute(AqlCallStack stack) {
   TRI_IF_FAILURE("ExecutionBlock::getOrSkipSome3") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
-  initOnce();
-  auto res = executeWithoutTrace(std::move(stack));
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-  auto const& [state, skipped, block] = res;
-  if (block != nullptr) {
-    block->validateShadowRowConsistency();
+
+  // check if this block failed already.
+  if (_firstFailure.fail()) {
+    // if so, just return the stored error.
+    // we need to do this because if a block fails with
+    // an exception, it is in an invalid state, and all
+    // subsequent calls into it may behave badly.
+    THROW_ARANGO_EXCEPTION(_firstFailure);
   }
+
+  try {
+    initOnce();
+    auto res = executeWithoutTrace(stack);
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    auto const& [state, skipped, block] = res;
+    if (block != nullptr) {
+      block->validateShadowRowConsistency();
+    }
 #endif
-  traceExecuteEnd(res);
-  return res;
+    traceExecuteEnd(res);
+    return res;
+  } catch (basics::Exception const& ex) {
+    if (_firstFailure.ok()) {
+      // store only the first failure we got
+      _firstFailure = {ex.code(), ex.what()};
+      LOG_QUERY("7289a", DEBUG) << printBlockInfo() << " local statemachine failed with exception: " << ex.what();
+    }
+    throw;
+  } catch (std::exception const& ex) {
+    if (_firstFailure.ok()) {
+      // store only the first failure we got
+      _firstFailure = {TRI_ERROR_INTERNAL, ex.what()};
+      LOG_QUERY("2bbd5", DEBUG) << printBlockInfo() << " local statemachine failed with exception: " << ex.what();
+    }
+    throw;
+  }
 }
 
 // Work around GCC bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -354,19 +354,18 @@ ExecutionBlockImpl<Executor>::execute(AqlCallStack stack) {
     traceExecuteEnd(res);
     return res;
   } catch (basics::Exception const& ex) {
-    if (_firstFailure.ok()) {
-      // store only the first failure we got
-      _firstFailure = {ex.code(), ex.what()};
-      LOG_QUERY("7289a", DEBUG) << printBlockInfo() << " local statemachine failed with exception: " << ex.what();
-    }
+    TRI_ASSERT(_firstFailure.ok());
+    // store only the first failure we got
+    _firstFailure = {ex.code(), ex.what()};
+    LOG_QUERY("7289a", DEBUG) << printBlockInfo() << " local statemachine failed with exception: " << ex.what();
     throw;
   } catch (std::exception const& ex) {
-    if (_firstFailure.ok()) {
-      // store only the first failure we got
-      _firstFailure = {TRI_ERROR_INTERNAL, ex.what()};
-      LOG_QUERY("2bbd5", DEBUG) << printBlockInfo() << " local statemachine failed with exception: " << ex.what();
-    }
-    throw;
+    TRI_ASSERT(_firstFailure.ok());
+    // store only the first failure we got
+    _firstFailure = {TRI_ERROR_INTERNAL, ex.what()};
+    LOG_QUERY("2bbd5", DEBUG) << printBlockInfo() << " local statemachine failed with exception: " << ex.what();
+    // Rewire the error, to be consistent with potentially next caller.
+    THROW_ARANGO_EXCEPTION(_firstFailure);
   }
 }
 

--- a/arangod/Aql/ExecutionBlockImpl.h
+++ b/arangod/Aql/ExecutionBlockImpl.h
@@ -336,6 +336,8 @@ class ExecutionBlockImpl final : public ExecutionBlock {
 
   AqlCallStack _stackBeforeWaiting;
   
+  Result _firstFailure;
+  
   bool _hasMemoizedCall{false};
 
   // Only used in passthrough variant.


### PR DESCRIPTION
### Scope & Purpose

Remember exception in ExecutionBlock and return it on next invocation.
normally any exception returned by an ExecutionBlock is directly handled
by the block's caller.
However, if the same block is asked semi-concurrently (only protected by
the RestAqlHandler's lease), then there can still be other requests in
flight that wait to enter the block. if an exception escapes the block,
it may be left in an invalid state, so we have to prevent other threads
from entering it afterwards and continue with that invalid state.

This is fixed in devel via https://github.com/arangodb/arangodb/pull/14267

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
