### PR TITLE
potential bugfix for BTS-451

### DIFF
--- a/arangod/Cluster/MaintenanceFeature.cpp
+++ b/arangod/Cluster/MaintenanceFeature.cpp
@@ -89,6 +89,10 @@ MaintenanceFeature::MaintenanceFeature(application_features::ApplicationServer& 
   requiresElevatedPrivileges(false);
 }
 
+MaintenanceFeature::~MaintenanceFeature() {
+  stop();
+}
+
 void MaintenanceFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addSection("server", "Server features");
 

--- a/arangod/Cluster/MaintenanceFeature.h
+++ b/arangod/Cluster/MaintenanceFeature.h
@@ -424,11 +424,11 @@ class MaintenanceFeature : public application_features::ApplicationFeature {
   /// @brief condition variable to motivate workers to find new action
   arangodb::basics::ConditionVariable _actionRegistryCond;
 
-  /// @brief list of background workers
-  std::vector<std::unique_ptr<maintenance::MaintenanceWorker>> _activeWorkers;
-
   /// @brief condition variable to indicate thread completion
   arangodb::basics::ConditionVariable _workerCompletion;
+
+  /// @brief list of background workers
+  std::vector<std::unique_ptr<maintenance::MaintenanceWorker>> _activeWorkers;
 
   /// Errors are managed through raiseIndexError / removeIndexError and
   /// raiseShardError / renoveShardError. According locks must be held in said

--- a/arangod/Cluster/MaintenanceFeature.h
+++ b/arangod/Cluster/MaintenanceFeature.h
@@ -54,7 +54,7 @@ class MaintenanceFeature : public application_features::ApplicationFeature {
  public:
   explicit MaintenanceFeature(application_features::ApplicationServer&);
 
-  virtual ~MaintenanceFeature() = default;
+  virtual ~MaintenanceFeature();
 
   struct errors_t {
     std::map<std::string, std::map<std::string, std::shared_ptr<VPackBuffer<uint8_t>>>> indexes;

--- a/tests/Maintenance/MaintenanceFeatureTest.cpp
+++ b/tests/Maintenance/MaintenanceFeatureTest.cpp
@@ -421,7 +421,13 @@ TEST(MaintenanceFeatureTestThreaded, populate_action_queue_and_validate) {
   as.addFeature<TestMaintenanceFeature, arangodb::MaintenanceFeature>();
   TestMaintenanceFeature& tf = *dynamic_cast<TestMaintenanceFeature*>(
       &as.getFeature<arangodb::MaintenanceFeature>());
+  
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
+  
+  auto threadGuard = arangodb::scopeGuard([&]() {
+    as.beginShutdown();
+    th.join();
+  });
 
   //
   // 1. load up the queue without threads running
@@ -485,12 +491,6 @@ TEST(MaintenanceFeatureTestThreaded, populate_action_queue_and_validate) {
 #if 0  // for debugging
     std::cout << tf.toVelocyPack().toJson() << std::endl;
 #endif
-
-  //
-  // 6. bring down the ApplicationServer, i.e. clean up
-  as.beginShutdown();
-
-  th.join();
 }
 
 TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_preaction) {
@@ -509,6 +509,7 @@ TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_preaction) {
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
 
   auto threadGuard = arangodb::scopeGuard([&]() {
+    as.beginShutdown();
     th.join();
   });
 
@@ -550,10 +551,6 @@ TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_preaction) {
 #if 0  // for debugging
     std::cout << tf.toVelocyPack().toJson() << std::endl;
 #endif
-
-  //
-  // 6. bring down the ApplicationServer, i.e. clean up
-  as.beginShutdown();
 }
 
 TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_postaction) {
@@ -572,6 +569,7 @@ TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_postaction) {
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
   
   auto threadGuard = arangodb::scopeGuard([&]() {
+    as.beginShutdown();
     th.join();
   });
 
@@ -614,10 +612,6 @@ TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_postaction) {
 #if 0  // for debugging
     std::cout << tf.toVelocyPack().toJson() << std::endl;
 #endif
-
-  //
-  // 6. bring down the ApplicationServer, i.e. clean up
-  as.beginShutdown();
 }
 
 TEST(MaintenanceFeatureTestThreaded, priority_queue_should_be_able_to_process_fast_tracked_action) {
@@ -637,6 +631,7 @@ TEST(MaintenanceFeatureTestThreaded, priority_queue_should_be_able_to_process_fa
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
   
   auto threadGuard = arangodb::scopeGuard([&]() {
+    as.beginShutdown();
     th.join();
   });
 
@@ -668,10 +663,6 @@ TEST(MaintenanceFeatureTestThreaded, priority_queue_should_be_able_to_process_fa
 #if 0  // for debugging
     std::cout << tf.toVelocyPack().toJson() << std::endl;
 #endif
-
-  //
-  // 4. bring down the ApplicationServer, i.e. clean up
-  as.beginShutdown();
 }
 
 TEST(MaintenanceFeatureTestThreaded, action_delete) {
@@ -690,6 +681,7 @@ TEST(MaintenanceFeatureTestThreaded, action_delete) {
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
   
   auto threadGuard = arangodb::scopeGuard([&]() {
+    as.beginShutdown();
     th.join();
   });
 
@@ -732,8 +724,4 @@ TEST(MaintenanceFeatureTestThreaded, action_delete) {
 #if 0  // for debugging
     std::cout << tf.toVelocyPack().toJson() << std::endl;
 #endif
-
-  //
-  // 6. bring down the ApplicationServer, i.e. clean up
-  as.beginShutdown();
 }

--- a/tests/Maintenance/MaintenanceFeatureTest.cpp
+++ b/tests/Maintenance/MaintenanceFeatureTest.cpp
@@ -33,6 +33,7 @@
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "ApplicationFeatures/GreetingsFeaturePhase.h"
 #include "Basics/Result.h"
+#include "Basics/ScopeGuard.h"
 #include "Cluster/Action.h"
 #include "Cluster/Maintenance.h"
 #include "Cluster/MaintenanceFeature.h"
@@ -504,7 +505,12 @@ TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_preaction) {
   as.addFeature<TestMaintenanceFeature, arangodb::MaintenanceFeature>();
   TestMaintenanceFeature& tf = *dynamic_cast<TestMaintenanceFeature*>(
       &as.getFeature<arangodb::MaintenanceFeature>());
+  
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
+
+  auto threadGuard = arangodb::scopeGuard([&]() {
+    th.join();
+  });
 
   //
   // 1. load up the queue without threads running
@@ -548,7 +554,6 @@ TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_preaction) {
   //
   // 6. bring down the ApplicationServer, i.e. clean up
   as.beginShutdown();
-  th.join();
 }
 
 TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_postaction) {
@@ -563,7 +568,12 @@ TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_postaction) {
   as.addFeature<TestMaintenanceFeature, arangodb::MaintenanceFeature>();
   TestMaintenanceFeature& tf = *dynamic_cast<TestMaintenanceFeature*>(
       &as.getFeature<arangodb::MaintenanceFeature>());
+  
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
+  
+  auto threadGuard = arangodb::scopeGuard([&]() {
+    th.join();
+  });
 
   //
   // 1. load up the queue without threads running
@@ -608,7 +618,6 @@ TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_postaction) {
   //
   // 6. bring down the ApplicationServer, i.e. clean up
   as.beginShutdown();
-  th.join();
 }
 
 TEST(MaintenanceFeatureTestThreaded, priority_queue_should_be_able_to_process_fast_tracked_action) {
@@ -624,7 +633,12 @@ TEST(MaintenanceFeatureTestThreaded, priority_queue_should_be_able_to_process_fa
   as.addFeature<TestMaintenanceFeature, arangodb::MaintenanceFeature>();
   TestMaintenanceFeature& tf = *dynamic_cast<TestMaintenanceFeature*>(
       &as.getFeature<arangodb::MaintenanceFeature>());
+  
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
+  
+  auto threadGuard = arangodb::scopeGuard([&]() {
+    th.join();
+  });
 
   //
   // 1. load up the queue without threads running
@@ -658,7 +672,6 @@ TEST(MaintenanceFeatureTestThreaded, priority_queue_should_be_able_to_process_fa
   //
   // 4. bring down the ApplicationServer, i.e. clean up
   as.beginShutdown();
-  th.join();
 }
 
 TEST(MaintenanceFeatureTestThreaded, action_delete) {
@@ -673,7 +686,12 @@ TEST(MaintenanceFeatureTestThreaded, action_delete) {
   as.addFeature<TestMaintenanceFeature, arangodb::MaintenanceFeature>();
   TestMaintenanceFeature& tf = *dynamic_cast<TestMaintenanceFeature*>(
       &as.getFeature<arangodb::MaintenanceFeature>());
+  
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
+  
+  auto threadGuard = arangodb::scopeGuard([&]() {
+    th.join();
+  });
 
   //
   // 1. load up the queue without threads running
@@ -718,5 +736,4 @@ TEST(MaintenanceFeatureTestThreaded, action_delete) {
   //
   // 6. bring down the ApplicationServer, i.e. clean up
   as.beginShutdown();
-  th.join();
 }


### PR DESCRIPTION
### Scope & Purpose

Make sure threads are properly joined before exiting test scopes.
This is a potential bugfix for BTS-451: https://arangodb.atlassian.net/browse/BTS-451
This change only affects a test, so no CHANGELOG entry added.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] This change is already covered by existing tests, such as *gtest*.
