### PR TITLE
potential bugfix for BTS-451

### DIFF
--- a/arangod/Cluster/MaintenanceFeature.cpp
+++ b/arangod/Cluster/MaintenanceFeature.cpp
@@ -131,6 +131,10 @@ MaintenanceFeature::MaintenanceFeature(application_features::ApplicationServer& 
   requiresElevatedPrivileges(false);
 }
 
+MaintenanceFeature::~MaintenanceFeature() {
+  stop();
+}
+
 void MaintenanceFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addSection("server", "Server features");
 

--- a/arangod/Cluster/MaintenanceFeature.h
+++ b/arangod/Cluster/MaintenanceFeature.h
@@ -58,7 +58,7 @@ class MaintenanceFeature : public application_features::ApplicationFeature {
  public:
   explicit MaintenanceFeature(application_features::ApplicationServer&);
 
-  virtual ~MaintenanceFeature() = default;
+  virtual ~MaintenanceFeature();
 
   struct errors_t {
     std::map<std::string, std::map<std::string, std::shared_ptr<VPackBuffer<uint8_t>>>> indexes;
@@ -452,11 +452,11 @@ class MaintenanceFeature : public application_features::ApplicationFeature {
   /// @brief condition variable to motivate workers to find new action
   arangodb::basics::ConditionVariable _actionRegistryCond;
 
-  /// @brief list of background workers
-  std::vector<std::unique_ptr<maintenance::MaintenanceWorker>> _activeWorkers;
-
   /// @brief condition variable to indicate thread completion
   arangodb::basics::ConditionVariable _workerCompletion;
+
+  /// @brief list of background workers
+  std::vector<std::unique_ptr<maintenance::MaintenanceWorker>> _activeWorkers;
 
   /// Errors are managed through raiseIndexError / removeIndexError and
   /// raiseShardError / renoveShardError. According locks must be held in said

--- a/tests/Maintenance/MaintenanceFeatureTest.cpp
+++ b/tests/Maintenance/MaintenanceFeatureTest.cpp
@@ -422,6 +422,7 @@ TEST(MaintenanceFeatureTestThreaded, populate_action_queue_and_validate) {
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
   
   auto threadGuard = arangodb::scopeGuard([&]() {
+    as.beginShutdown();
     th.join();
   });
 
@@ -487,10 +488,6 @@ TEST(MaintenanceFeatureTestThreaded, populate_action_queue_and_validate) {
 #if 0  // for debugging
     std::cout << tf.toVelocyPack().toJson() << std::endl;
 #endif
-
-  //
-  // 6. bring down the ApplicationServer, i.e. clean up
-  as.beginShutdown();
 }
 
 TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_preaction) {
@@ -509,6 +506,7 @@ TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_preaction) {
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
 
   auto threadGuard = arangodb::scopeGuard([&]() {
+    as.beginShutdown();
     th.join();
   });
 
@@ -550,10 +548,6 @@ TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_preaction) {
 #if 0  // for debugging
     std::cout << tf.toVelocyPack().toJson() << std::endl;
 #endif
-
-  //
-  // 6. bring down the ApplicationServer, i.e. clean up
-  as.beginShutdown();
 }
 
 TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_postaction) {
@@ -572,6 +566,7 @@ TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_postaction) {
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
   
   auto threadGuard = arangodb::scopeGuard([&]() {
+    as.beginShutdown();
     th.join();
   });
 
@@ -614,10 +609,6 @@ TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_postaction) {
 #if 0  // for debugging
     std::cout << tf.toVelocyPack().toJson() << std::endl;
 #endif
-
-  //
-  // 6. bring down the ApplicationServer, i.e. clean up
-  as.beginShutdown();
 }
 
 TEST(MaintenanceFeatureTestThreaded, priority_queue_should_be_able_to_process_fast_tracked_action) {
@@ -637,6 +628,7 @@ TEST(MaintenanceFeatureTestThreaded, priority_queue_should_be_able_to_process_fa
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
   
   auto threadGuard = arangodb::scopeGuard([&]() {
+    as.beginShutdown();
     th.join();
   });
 
@@ -668,10 +660,6 @@ TEST(MaintenanceFeatureTestThreaded, priority_queue_should_be_able_to_process_fa
 #if 0  // for debugging
     std::cout << tf.toVelocyPack().toJson() << std::endl;
 #endif
-
-  //
-  // 4. bring down the ApplicationServer, i.e. clean up
-  as.beginShutdown();
 }
 
 TEST(MaintenanceFeatureTestThreaded, action_delete) {
@@ -690,6 +678,7 @@ TEST(MaintenanceFeatureTestThreaded, action_delete) {
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
   
   auto threadGuard = arangodb::scopeGuard([&]() {
+    as.beginShutdown();
     th.join();
   });
 
@@ -732,8 +721,4 @@ TEST(MaintenanceFeatureTestThreaded, action_delete) {
 #if 0  // for debugging
     std::cout << tf.toVelocyPack().toJson() << std::endl;
 #endif
-
-  //
-  // 6. bring down the ApplicationServer, i.e. clean up
-  as.beginShutdown();
 }

--- a/tests/Maintenance/MaintenanceFeatureTest.cpp
+++ b/tests/Maintenance/MaintenanceFeatureTest.cpp
@@ -30,6 +30,7 @@
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "ApplicationFeatures/GreetingsFeaturePhase.h"
 #include "Basics/Result.h"
+#include "Basics/ScopeGuard.h"
 #include "Cluster/Action.h"
 #include "Cluster/Maintenance.h"
 #include "Cluster/MaintenanceFeature.h"
@@ -501,7 +502,12 @@ TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_preaction) {
   as.addFeature<TestMaintenanceFeature, arangodb::MaintenanceFeature>();
   TestMaintenanceFeature& tf = *dynamic_cast<TestMaintenanceFeature*>(
       &as.getFeature<arangodb::MaintenanceFeature>());
+  
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
+
+  auto threadGuard = arangodb::scopeGuard([&]() {
+    th.join();
+  });
 
   //
   // 1. load up the queue without threads running
@@ -545,7 +551,6 @@ TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_preaction) {
   //
   // 6. bring down the ApplicationServer, i.e. clean up
   as.beginShutdown();
-  th.join();
 }
 
 TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_postaction) {
@@ -560,7 +565,12 @@ TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_postaction) {
   as.addFeature<TestMaintenanceFeature, arangodb::MaintenanceFeature>();
   TestMaintenanceFeature& tf = *dynamic_cast<TestMaintenanceFeature*>(
       &as.getFeature<arangodb::MaintenanceFeature>());
+  
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
+  
+  auto threadGuard = arangodb::scopeGuard([&]() {
+    th.join();
+  });
 
   //
   // 1. load up the queue without threads running
@@ -605,7 +615,6 @@ TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_postaction) {
   //
   // 6. bring down the ApplicationServer, i.e. clean up
   as.beginShutdown();
-  th.join();
 }
 
 TEST(MaintenanceFeatureTestThreaded, priority_queue_should_be_able_to_process_fast_tracked_action) {
@@ -621,7 +630,12 @@ TEST(MaintenanceFeatureTestThreaded, priority_queue_should_be_able_to_process_fa
   as.addFeature<TestMaintenanceFeature, arangodb::MaintenanceFeature>();
   TestMaintenanceFeature& tf = *dynamic_cast<TestMaintenanceFeature*>(
       &as.getFeature<arangodb::MaintenanceFeature>());
+  
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
+  
+  auto threadGuard = arangodb::scopeGuard([&]() {
+    th.join();
+  });
 
   //
   // 1. load up the queue without threads running
@@ -655,7 +669,6 @@ TEST(MaintenanceFeatureTestThreaded, priority_queue_should_be_able_to_process_fa
   //
   // 4. bring down the ApplicationServer, i.e. clean up
   as.beginShutdown();
-  th.join();
 }
 
 TEST(MaintenanceFeatureTestThreaded, action_delete) {
@@ -670,7 +683,12 @@ TEST(MaintenanceFeatureTestThreaded, action_delete) {
   as.addFeature<TestMaintenanceFeature, arangodb::MaintenanceFeature>();
   TestMaintenanceFeature& tf = *dynamic_cast<TestMaintenanceFeature*>(
       &as.getFeature<arangodb::MaintenanceFeature>());
+  
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
+  
+  auto threadGuard = arangodb::scopeGuard([&]() {
+    th.join();
+  });
 
   //
   // 1. load up the queue without threads running
@@ -715,5 +733,4 @@ TEST(MaintenanceFeatureTestThreaded, action_delete) {
   //
   // 6. bring down the ApplicationServer, i.e. clean up
   as.beginShutdown();
-  th.join();
 }

--- a/tests/Maintenance/MaintenanceFeatureTest.cpp
+++ b/tests/Maintenance/MaintenanceFeatureTest.cpp
@@ -418,7 +418,12 @@ TEST(MaintenanceFeatureTestThreaded, populate_action_queue_and_validate) {
   as.addFeature<TestMaintenanceFeature, arangodb::MaintenanceFeature>();
   TestMaintenanceFeature& tf = *dynamic_cast<TestMaintenanceFeature*>(
       &as.getFeature<arangodb::MaintenanceFeature>());
+  
   std::thread th(&arangodb::application_features::ApplicationServer::run, &as, 0, nullptr);
+  
+  auto threadGuard = arangodb::scopeGuard([&]() {
+    th.join();
+  });
 
   //
   // 1. load up the queue without threads running
@@ -486,8 +491,6 @@ TEST(MaintenanceFeatureTestThreaded, populate_action_queue_and_validate) {
   //
   // 6. bring down the ApplicationServer, i.e. clean up
   as.beginShutdown();
-
-  th.join();
 }
 
 TEST(MaintenanceFeatureTestThreaded, action_that_generates_a_preaction) {


### PR DESCRIPTION
### Scope & Purpose

Make sure threads are properly joined before exiting test scopes.
This is a potential bugfix for BTS-451: https://arangodb.atlassian.net/browse/BTS-451
This change only affects a test, so no CHANGELOG entry added.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for 3.7: https://github.com/arangodb/arangodb/pull/14274

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] This change is already covered by existing tests, such as *gtest*.
