### PR TITLE
BTS-446 Cluster machines fail to integrate on OSX jenkins runs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@ devel
 * Fix BTS-409: return error 1948 when a negative edge was detected during or was
   used as default weight in a SHORTEST_PATH or a K_SHOTRTEST_PAHS traversal.
 
-* Fix BTS-446: When finding not yet fully initialised agency, do not
+* Fix BTS-446: When finding a not yet fully initialized agency, do not
   immediately fatal exit. Keep trying for (very generous) 5
   minutes.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,10 @@ devel
 * Fix BTS-409: return error 1948 when a negative edge was detected during or was
   used as default weight in a SHORTEST_PATH or a K_SHOTRTEST_PAHS traversal.
 
+* Fix BTS-446: When finding not yet fully initialised agency, do not
+  immediately fatal exit. Keep trying for (very generous) 5
+  minutes.
+
 * Removed unused documentation snippets (non-Rest DocuBlocks) as well as the
   documentation about the long deprecated features Simple Queries and
 	JavaScript-based graph traversal. Also removed the descriptions of the

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -659,10 +659,25 @@ bool ServerState::checkIfAgencyInitialized(AgencyComm& comm,
 //////////////////////////////////////////////////////////////////////////////
 
 bool ServerState::registerAtAgencyPhase1(AgencyComm& comm, ServerState::RoleEnum const& role) {
-  // if the agency is not initialized, there is no point in continuing.
-  if (!checkIfAgencyInitialized(comm, role)) {
-    return false;
-  }
+
+  // if the agency is not initialized, we'll give the bunch a little time to get their
+  // act together before calling it a day.
+
+  using namespace std::chrono;
+  using clock = steady_clock;
+  auto registrationTimeout = clock::now() + seconds(300);
+  auto backoff = milliseconds(75);
+  do {
+    if (checkIfAgencyInitialized(comm, role)) {
+      break;
+    } else if (clock::now() >= registrationTimeout) {
+      return false;
+    }
+    std::this_thread::sleep_for(backoff);
+    if (backoff < seconds(1)) {
+      backoff += backoff;
+    }
+  } while (!_server.isStopping());
 
   std::string const agencyListKey = roleToAgencyListKey(role);
   std::string const latestIdKey = "Latest" + roleToAgencyKey(role) + "Id";


### PR DESCRIPTION
### Scope & Purpose

*Fix BTS-466. Sporadically breaking cluster starts in jenkins on OSX, where the agency is being bootstrapped by a fellow member but the initialisation has not finished yet.*

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [X] Backports required for:  *[3.8](https://github.com/arangodb/arangodb/pull/14280)* *[3.7](https://github.com/arangodb/arangodb/pull/14282)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:

### Documentation

> All new features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the CHANGELOG so that
> support, end users, and other developers have a concise overview. 

- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
