### PR TITLE
try to improve unstable fillBlockCache test

### DIFF
--- a/js/client/modules/@arangodb/testutils/block-cache-test-helper.js
+++ b/js/client/modules/@arangodb/testutils/block-cache-test-helper.js
@@ -55,7 +55,11 @@ exports.testDbQuery = function(cn, fillBlockCache) {
     // allow for some other background things to be run, thus add 1MB of leeway
     assertTrue(newValue <= oldValue + 1000 * 1000, { oldValue, newValue });
   }
-  
+
+  /*
+   * for some reason the block cache usage is not 100% deterministic after here.
+   * it is probably due to some other unrelated queries running or some RocksDB
+   * internals
   result = db._query("FOR doc IN @@collection RETURN doc.value1", { "@collection": cn }, { fillBlockCache }).toArray();
   assertEqual(250 * 1000, result.length);
 
@@ -65,6 +69,7 @@ exports.testDbQuery = function(cn, fillBlockCache) {
     // On Windows, the block cache usage in newValue2 is a lot higher here.
     assertTrue(newValue2 <= newValue + 1000 * 1000, { newValue, newValue2 });
   }
+  */
 };
 
 exports.testHttpApi = function(cn, fillBlockCache) {


### PR DESCRIPTION
### Scope & Purpose

For unknown reasons, the block cache usage values returned by the engine stats in this test seem to be unstable, even in single server on Linux. 
There is potentially some other, yet unknown action, that populates parts of the RocksDB block cache.
Being unable to reproduce the issue locally, this is an attempt to cut a part of the test in exchange for test stability.

This is a test-only modification, so it is intentionally missing a CHANGELOG entry.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*: if approved, should be merged into https://github.com/arangodb/arangodb/pull/14256

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *server_parameters*.
