### PR TITLE
BTS-450: RandomGenerator caught assertion during a value generation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+v3.8.0 (XXXX-XX-XX)
+-------------------
+
+* Fix BTS-450: RandomGenerator caught assertion during a value generation within
+  `dump_maskings` testsuite. Ensure correct conversion between 64 and 32bit.
+
+
 v3.8.0-rc.1 (2021-05-26)
 ------------------------
 

--- a/lib/Random/RandomGenerator.cpp
+++ b/lib/Random/RandomGenerator.cpp
@@ -102,7 +102,10 @@ int32_t RandomDevice::random(int32_t left, int32_t right) {
 
   TRI_ASSERT(right > left);
   int64_t r = static_cast<int64_t>(right) - static_cast<int64_t>(left) + 1;
-  TRI_ASSERT(r >= 0 && r <= UINT32_MAX);
+
+  // r must be at least 2, because right > left
+  // r must be strictly less UINT32_MAX, because we checked MIN & MAX
+  TRI_ASSERT(r > 1 && r < UINT32_MAX);
   uint32_t range = static_cast<uint32_t>(r);
 
   switch (range) {
@@ -201,10 +204,11 @@ int32_t RandomDevice::other(int32_t left, uint32_t range) {
 
   r %= range;
 
-  int32_t result = left + static_cast<int32_t>(r);
-  TRI_ASSERT(result >= left);
-  TRI_ASSERT(result < left + static_cast<int64_t>(range));
-  return result;
+  int64_t result = static_cast<int64_t>(left) + static_cast<int64_t>(r);
+  TRI_ASSERT(result >= static_cast<int64_t>(left));
+  TRI_ASSERT(result < static_cast<int64_t>(left) + static_cast<int64_t>(range));
+  TRI_ASSERT(result <= static_cast<int64_t>(INT32_MAX));
+  return static_cast<int32_t>(result);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/14272/

BTS-450: RandomGenerator caught assertion during a value generation within `dump_maskings` testsuite. Ensure correct conversion between 64 and 32bit.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.7*: https://github.com/arangodb/arangodb/pull/14287, *3.6*: https://github.com/arangodb/arangodb/pull/14288

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
