### PR TITLE
remove eslint from package.json

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fixed ES-867: remove eslint from the package.json and package-lock.json files
+  exported in the packages. ESLINT itself was not part of these packages. However,
+  the package file mentioned it.
+
 * Fix BTS-450: RandomGenerator caught assertion during a value generation within
   `dump_maskings` testsuite. Ensure correct conversion between 64 and 32bit.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1450,3 +1450,15 @@ message(STATUS "building for git revision: ${ARANGODB_BUILD_REPOSITORY}")
 
 add_custom_target(arangodb
         DEPENDS arangod arangosh arangodump arangoexport arangoimport arangorestore)
+
+################################################################################
+## node modules
+################################################################################
+
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/js/node/package.json PACKAGE_JSON)
+string(REGEX REPLACE "[ \t]*\"eslint\"[^,]*," "" OUT_PACKAGE_JSON ${PACKAGE_JSON})
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/js/node/package.json-no-eslint ${OUT_PACKAGE_JSON})
+
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/js/node/package-lock.json PACKAGE_LOCK_JSON)
+string(REGEX REPLACE "\n    \"eslint\": {.*\n    },\n\    \"expect.js\"" "\n    \"expect.js\"" OUT_PACKAGE_LOCK_JSON ${PACKAGE_LOCK_JSON})
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/js/node/package-lock.json-no-eslint ${OUT_PACKAGE_LOCK_JSON})

--- a/cmake/InstallArangoDBJSClient.cmake
+++ b/cmake/InstallArangoDBJSClient.cmake
@@ -31,11 +31,24 @@ if (USE_ENTERPRISE)
   )
 endif ()
 
-# For the node modules we need all files:
+# For the node modules we need almost all files:
 install(
   DIRECTORY ${ARANGODB_SOURCE_DIR}/js/node
   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR_ARANGO}/${ARANGODB_JS_VERSION}
   REGEX "^.*/eslint"                                       EXCLUDE
   REGEX "^.*/.npmignore"                                   EXCLUDE
   REGEX "^.*/.bin"                                         EXCLUDE
+  REGEX "^.*/package.*json"                                EXCLUDE
+)
+
+install(
+  FILES ${PROJECT_BINARY_DIR}/js/node/package.json-no-eslint
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR_ARANGO}/${ARANGODB_JS_VERSION}/node
+  RENAME package.json
+)
+
+install(
+  FILES ${PROJECT_BINARY_DIR}/js/node/package-lock.json-no-eslint
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR_ARANGO}/${ARANGODB_JS_VERSION}/node
+  RENAME package-lock.json
 )


### PR DESCRIPTION
### Scope & Purpose

Forward port of https://github.com/arangodb/arangodb/pull/14261

`eslint` was still mentioned in the package.json and package-lock.json of build packages. However, eslint was not distributed in the package. Removed these entries when installing.
This also fixes security warnings by package scanners.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.8: https://github.com/arangodb/arangodb/pull/14290, 3.7: https://github.com/arangodb/arangodb/pull/14261

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
