### PR TITLE
search for the servers assert log messages, and print them, add them to testfailures.txt

### DIFF
--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -468,7 +468,7 @@ function readAssertLogLines (logPath) {
           const line = buf.asciiSlice(lineStart, j);
           lineStart = j + 1;
 
-          // scan for asesrts from the crash dumper
+          // scan for asserts from the crash dumper
           if ((line.search('a7902') !== -1) ||
               (line.search('c962b') !== -1) ||
               (line.search('308c3') !== -1)) {

--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -469,9 +469,7 @@ function readAssertLogLines (logPath) {
           lineStart = j + 1;
 
           // scan for asserts from the crash dumper
-          if ((line.search('a7902') !== -1) ||
-              (line.search('c962b') !== -1) ||
-              (line.search('308c3') !== -1)) {
+          if (line.search('{crash}') !== -1) {
             if (!IS_A_TTY) {
               // else the server has already printed these:
               print("ERROR: " + line);

--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -56,6 +56,7 @@ const GREEN = internal.COLORS.COLOR_GREEN;
 const RED = internal.COLORS.COLOR_RED;
 const RESET = internal.COLORS.COLOR_RESET;
 // const YELLOW = internal.COLORS.COLOR_YELLOW;
+const IS_A_TTY = RED.length !== 0;
 
 const platform = internal.platform;
 
@@ -63,6 +64,7 @@ const abortSignal = 6;
 const termSignal = 15;
 
 let tcpdump;
+let assertLines = [];
 
 class ConfigBuilder {
   constructor(type) {
@@ -444,6 +446,42 @@ function readImportantLogLines (logPath) {
   }
 
   return importantLines;
+}
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief scans the log files for assert lines
+// //////////////////////////////////////////////////////////////////////////////
+
+function readAssertLogLines (logPath) {
+  const list = fs.list(logPath);
+
+  for (let i = 0; i < list.length; i++) {
+    let fnLines = [];
+
+    if (list[i].slice(0, 3) === 'log') {
+      const buf = fs.readBuffer(fs.join(logPath, list[i]));
+      let lineStart = 0;
+      let maxBuffer = buf.length;
+
+      for (let j = 0; j < maxBuffer; j++) {
+        if (buf[j] === 10) { // \n
+          const line = buf.asciiSlice(lineStart, j);
+          lineStart = j + 1;
+
+          // scan for asesrts from the crash dumper
+          if ((line.search('a7902') !== -1) ||
+              (line.search('c962b') !== -1) ||
+              (line.search('308c3') !== -1)) {
+            if (!IS_A_TTY) {
+              // else the server has already printed these:
+              print("ERROR: " + line);
+            }
+            assertLines.push(line);
+          }
+        }
+      }
+    }
+  }
 }
 
 // //////////////////////////////////////////////////////////////////////////////
@@ -1668,6 +1706,9 @@ function shutdownInstance (instanceInfo, options, forceTerminate) {
       }
     });
   }
+  instanceInfo.arangods.forEach(arangod => {
+    readAssertLogLines(arangod.rootDir);
+  });
   if (tcpdump !== undefined) {
     print(CYAN + "Stopping tcpdump" + RESET);
     killExternal(tcpdump.pid);
@@ -2384,6 +2425,12 @@ function reStartInstance(options, instanceInfo, moreArgs) {
 }
 
 function aggregateFatalErrors(currentTest) {
+  if (assertLines.length > 0) {
+    assertLines.forEach(line => {
+      rp.addFailRunsMessage(currentTest, line);
+    });
+    assertLines = [];
+  }
   if (serverCrashedLocal) {
     rp.addFailRunsMessage(currentTest, serverFailMessagesLocal);
     serverFailMessagesLocal = "";

--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -989,7 +989,12 @@ function dumpAllResults(options, results) {
 
 
 function addFailRunsMessage(testcase, message) {
-  failedRuns[testcase] = message;
+  if (!failedRuns.hasOwnProperty(testcase)) {
+    failedRuns[testcase] = '';
+  } else if (failedRuns[testcase].length > 0) {
+    failedRuns[testcase] += '\n';
+  }
+  failedRuns[testcase] += message;
 }
 
 function yamlDumpResults(options, results) {


### PR DESCRIPTION
### Scope & Purpose

This PR improves the testinfrastructure to fetch probably happening asserts in running server instances into the test summary.

#### Backports:

- [x] No backports required - this is a feature to aid developers.

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
In future test errors caused by server asserts will look like this in `testfailures.txt`:
```
* Test "shell_server_aql"
    [FAILED]  tests/js/server/aql/aql-traversal-grinder.js

      "test" failed: server unavailable for testing. Connection closed by remote


   Suites failed: 2 Tests Failed: 0

 [shell_server_aql] :     2021-06-01T15:09:00Z [1226204] C FATAL [a7902] {crash} p^_^R% ArangoDB 3.9.0-devel enterprise [linux], thread 5 [SchedWorker] caught unexpected signal 6 (SIGABRT): assertion failed in /home/willi/src/devel4/enterprise/Enterprise/Cluster/SmartWeightedPathEnumerator.cpp:248 [operator()]: !vertexSlice.isString() - image base address: 0x000056136224c000
    2021-06-01T15:09:00Z [1226204] C INFO [c962b] {crash} Backtrace of thread 5 [SchedWorker]
    2021-06-01T15:09:00Z [1226204] C INFO [308c3] {crash} frame  1 [+0x0000000001fbd3d7] arangodb::CrashHandler::crash(char const*) (+0x17)
    2021-06-01T15:09:00Z [1226204] C INFO [308c3] {crash} frame  2 [+0x0000000001fbd585] arangodb::CrashHandler::assertionFailure(char const*, int, char const*, char const*) (+0xf5)
    2021-06-01T15:09:00Z [1226204] C INFO [308c3] {crash} frame  3 [+0x0000000000f23dee] arangodb::traverser::SmartWeightedPathEnumerator::processAnswers() (+0x18ce)
    2021-06-01T15:09:00Z [1226204] C INFO [308c3] {crash} frame  4 [+0x0000000000f24166] arangodb::traverser::SmartWeightedPathEnumerator::next() (+0x26)
    2021-06-01T15:09:00Z [1226204] C INFO [308c3] {crash} frame  5 [+0x0000000000ecf84c] arangodb::traverser::Traverser::next() (+0x1c)
    2021-06-01T15:09:00Z [1226204] C INFO [308c3] {crash} frame  6 [+0x0000000000de935f] arangodb::aql::TraversalExecutor::doOutput(arangodb::aql::OutputAqlItemRow&) (+0x8f)
```
Link to Jenkins PR run:

