### PR TITLE
make test more robust

### DIFF
--- a/tests/Containers/MerkleTreeTest.cpp
+++ b/tests/Containers/MerkleTreeTest.cpp
@@ -1312,7 +1312,7 @@ TEST(MerkleTreeTest, test_to_string) {
   std::string s = t1.toString(false);
   ASSERT_LE(1100, s.size());
   s = t1.toString(true);
-  ASSERT_LE(1300, s.size());
+  ASSERT_LE(1250, s.size());
 }
 
 TEST(MerkleTreeTest, test_diff_one_side_empty_random_data_shifted) {


### PR DESCRIPTION
### Scope & Purpose

Make assertion about generated string size less strict in a test that relies on random values being inserted.
This is a test-only bugfix, so it does not have a CHANGELOG entry.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *gtest*.
