### PR TITLE
add more tests for random generator

### DIFF
--- a/lib/Random/RandomGenerator.cpp
+++ b/lib/Random/RandomGenerator.cpp
@@ -590,6 +590,13 @@ uint64_t RandomGenerator::interval(uint64_t right) {
   return value;
 }
 
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+int32_t RandomGenerator::random(int32_t left, int32_t right) {
+  ensureDeviceIsInitialized();
+  return _device->random(left, right);
+}
+#endif
+
 void RandomGenerator::seed(uint64_t seed) {
   ensureDeviceIsInitialized();
   if (RandomDeviceMersenne* dev = dynamic_cast<RandomDeviceMersenne*>(_device.get())) {

--- a/lib/Random/RandomGenerator.h
+++ b/lib/Random/RandomGenerator.h
@@ -47,11 +47,11 @@ class RandomDevice {
   int32_t interval(int32_t left, int32_t right);
   uint32_t interval(uint32_t left, uint32_t right);
 
- public:
   static unsigned long seed();
 
- private:
   int32_t random(int32_t left, int32_t right);
+
+ private:
   int32_t power2(int32_t left, uint32_t right);
   int32_t other(int32_t left, uint32_t right);
 };
@@ -88,6 +88,11 @@ class RandomGenerator {
   static uint16_t interval(uint16_t);
   static uint32_t interval(uint32_t);
   static uint64_t interval(uint64_t);
+  
+  // exposed only for testing
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+  static int32_t random(int32_t left, int32_t right);
+#endif
 
  private:
   static RandomType _type;

--- a/tests/Basics/RandomTest.cpp
+++ b/tests/Basics/RandomTest.cpp
@@ -30,6 +30,143 @@
 
 using namespace arangodb;
 
+TEST(RandomGeneratorTest, test_RandomGeneratorTest_interval_uint16_brute) {
+  RandomGenerator::initialize(RandomGenerator::RandomType::MERSENNE);
+  RandomGenerator::ensureDeviceIsInitialized();
+  RandomGenerator::seed(0xdeadbeef);
+  
+  constexpr uint16_t bounds[] = { 1, 2, 4, 1023, 1024, 65535 };
+  for (uint16_t bound : bounds) {
+    for (int i = 0; i < 10000; ++i) {
+      uint16_t value = RandomGenerator::interval(bound);
+      ASSERT_LE(value, bound);
+    }
+  }
+}
+
+TEST(RandomGeneratorTest, test_RandomGeneratorTest_interval_uint32_brute) {
+  RandomGenerator::initialize(RandomGenerator::RandomType::MERSENNE);
+  RandomGenerator::ensureDeviceIsInitialized();
+  RandomGenerator::seed(0xdeadbeef);
+  
+  constexpr uint32_t bounds[] = { 1, 2, 4, 1023, 1024, 65535, 65536, 4294967295ULL };
+  for (uint32_t bound : bounds) {
+    for (int i = 0; i < 10000; ++i) {
+      uint32_t value = RandomGenerator::interval(bound);
+      ASSERT_LE(value, bound);
+    }
+  }
+}
+
+TEST(RandomGeneratorTest, test_RandomGeneratorTest_interval_uint64_brute) {
+  RandomGenerator::initialize(RandomGenerator::RandomType::MERSENNE);
+  RandomGenerator::ensureDeviceIsInitialized();
+  RandomGenerator::seed(0xdeadbeef);
+  
+  constexpr uint64_t bounds[] = { 1, 2, 4, 1023, 1024, 65535, 65536, 4294967295ULL, 4294967296ULL, 18446744073709551615ULL };
+  for (uint64_t bound : bounds) {
+    for (int i = 0; i < 10000; ++i) {
+      uint64_t value = RandomGenerator::interval(bound);
+      ASSERT_LE(value, bound);
+    }
+  }
+}
+
+TEST(RandomGeneratorTest, test_RandomGeneratorTest_ranges_int16_brute) {
+  RandomGenerator::initialize(RandomGenerator::RandomType::MERSENNE);
+  RandomGenerator::ensureDeviceIsInitialized();
+  RandomGenerator::seed(0xdeadbeef);
+  
+  constexpr std::pair<int16_t, int16_t> bounds[] = { 
+    {0, 0}, {0, 1}, {0, 2}, {0, 1023}, {0, 1024}, {0, 32760}, {0, 32767},
+    {1, 1}, {1, 2}, {1, 1023}, {1, 1024}, {1, 32766}, {1, 32767},
+    {10, 10}, {10, 11}, {10, 32766}, {10, 32767},
+    {1024, 32760}, {1024, 32766}, {1024, 32767},
+    {32760, 32761}, {32760, 32765}, {32760, 32766}, {32760, 32767},
+    {32766, 32766}, {32766, 32767},
+    {32767, 32767},
+  };
+  for (auto [lower, upper] : bounds) {
+    for (int i = 0; i < 10000; ++i) {
+      int16_t value = RandomGenerator::interval(lower, upper);
+      ASSERT_GE(value, lower);
+      ASSERT_LE(value, upper);
+    }
+  }
+}
+
+TEST(RandomGeneratorTest, test_RandomGeneratorTest_ranges_int32_brute) {
+  RandomGenerator::initialize(RandomGenerator::RandomType::MERSENNE);
+  RandomGenerator::ensureDeviceIsInitialized();
+  RandomGenerator::seed(0xdeadbeef);
+  
+  constexpr std::pair<int32_t, int32_t> bounds[] = { 
+    {0, 0}, {0, 1}, {0, 2}, {0, 1023}, {0, 1024}, {0, 65534}, {0, 65535}, {0, 2147483647},
+    {1, 1}, {1, 2}, {1, 1023}, {1, 1024}, {1, 65534}, {1, 65535}, {1, 2147483647},
+    {10, 10}, {10, 11}, {10, 65534}, {10, 65535}, {10, 2147483647},
+    {1024, 65534}, {1024, 65535}, {1024, 2147483647},
+    {65530, 65534}, {65530, 65535}, {65530, 2147483647},
+    {2147483640, 2147483640}, {2147483640, 2147483641}, {2147483640, 2147483642}, {2147483640, 2147483646}, {2147483640, 2147483647},
+    {2147483646, 2147483646}, {2147483646, 2147483647},
+    {2147483647, 2147483647},
+  };
+  for (auto [lower, upper] : bounds) {
+    for (int i = 0; i < 10000; ++i) {
+      int32_t value = RandomGenerator::interval(lower, upper);
+      ASSERT_GE(value, lower);
+      ASSERT_LE(value, upper);
+    }
+  }
+}
+
+TEST(RandomGeneratorTest, test_RandomGeneratorTest_ranges_int64_brute) {
+  RandomGenerator::initialize(RandomGenerator::RandomType::MERSENNE);
+  RandomGenerator::ensureDeviceIsInitialized();
+  RandomGenerator::seed(0xdeadbeef);
+  
+  constexpr std::pair<int64_t, int64_t> bounds[] = { 
+    {0, 0}, {0, 1}, {0, 2}, {0, 1023}, {0, 1024}, {0, 65534}, {0, 65535}, {0, 2147483647}, {0, 9223372036854775807LL},
+    {1, 1}, {1, 2}, {1, 1023}, {1, 1024}, {1, 65534}, {1, 65535}, {1, 2147483647}, {1, 9223372036854775807LL},
+    {10, 10}, {10, 11}, {10, 65534}, {10, 65535}, {10, 9223372036854775807LL},
+    {2147483640, 2147483640}, {2147483640, 2147483641}, {2147483640, 2147483642}, {2147483640, 2147483646}, {2147483640, 2147483647}, {2147483640, 9223372036854775807LL},
+    {9223372036854775800LL, 9223372036854775800LL}, {9223372036854775800LL, 9223372036854775806LL}, {9223372036854775800LL, 9223372036854775807LL},
+    {9223372036854775806LL, 9223372036854775806LL}, {9223372036854775806LL, 9223372036854775807LL},
+    {9223372036854775807LL, 9223372036854775807LL},
+  };
+  for (auto [lower, upper] : bounds) {
+    for (int i = 0; i < 10000; ++i) {
+      int64_t value = RandomGenerator::interval(lower, upper);
+      ASSERT_GE(value, lower);
+      ASSERT_LE(value, upper);
+    }
+  }
+}
+
+TEST(RandomGeneratorTest, test_RandomGeneratorTest_random_int32_brute) {
+  RandomGenerator::initialize(RandomGenerator::RandomType::MERSENNE);
+  RandomGenerator::ensureDeviceIsInitialized();
+  RandomGenerator::seed(0xdeadbeef);
+  
+  constexpr std::pair<int32_t, int32_t> bounds[] = { 
+    {0, 0}, {0, 1}, {0, 2}, {0, 1023}, {0, 1024}, {0, 65534}, {0, 65535}, {0, 2147483646}, {0, 2147483647},
+    {1, 1}, {1, 2}, {1, 1023}, {1, 1024}, {1, 65534}, {1, 65535}, {1, 2147483646}, {1, 2147483647},
+    {10, 10}, {10, 11}, {10, 65534}, {10, 65535}, {10, 2147483647},
+    {1024, 65534}, {1024, 65535}, {1024, 2147483647},
+    {65530, 65534}, {65530, 65535}, {65530, 2000000000}, {65530, 2147483600}, {65535, 2147483600}, {65536, 2147483600},
+    {2000000000, 2147483640}, {2000000000, 2147483641}, {2000000000, 2147483642}, {2000000000, 2147483646}, {2000000000, 2147483647},
+    {2147483640, 2147483640}, {2147483640, 2147483641}, {2147483640, 2147483642}, {2147483640, 2147483646}, {2147483640, 2147483647},
+    {2147483646, 2147483646}, {2147483646, 2147483647},
+    {2147483647, 2147483647},
+  };
+  for (auto [lower, upper] : bounds) {
+    for (int i = 0; i < 10000; ++i) {
+      int32_t value = RandomGenerator::random(lower, upper);
+      ASSERT_GE(value, lower);
+      ASSERT_LE(value, upper);
+    }
+  }
+}
+
 TEST(RandomGeneratorTest, test_RandomGeneratorMersenne_ranges_int64) {
   RandomGenerator::initialize(RandomGenerator::RandomType::MERSENNE);
   RandomGenerator::ensureDeviceIsInitialized();


### PR DESCRIPTION
### Scope & Purpose

Add extra tests for random number generator functionality.
This only adds tests and exposes one existing rng function for testing.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for 3.8: https://github.com/arangodb/arangodb/pull/14307, 3.7: https://github.com/arangodb/arangodb/pull/14308, 3.6: https://github.com/arangodb/arangodb/pull/14310

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new C++ **Unit tests**
