### PR TITLE
cut yet some more code from the fillBlockCache test

### DIFF
--- a/js/client/modules/@arangodb/testutils/block-cache-test-helper.js
+++ b/js/client/modules/@arangodb/testutils/block-cache-test-helper.js
@@ -84,6 +84,10 @@ exports.testHttpApi = function(cn, fillBlockCache) {
     assertTrue(newValue <= oldValue + 1000 * 1000, { oldValue, newValue });
   }
   
+  /*
+   * for some reason the block cache usage is not 100% deterministic after here.
+   * it is probably due to some other unrelated queries running or some RocksDB
+   * internals
   arango.POST("/_api/cursor", { query: "FOR doc IN @@collection RETURN doc.value1", bindVars: { "@collection": cn }, options: { fillBlockCache } });
   
   if (internal.platform.substr(0, 3) !== 'win') {
@@ -93,4 +97,5 @@ exports.testHttpApi = function(cn, fillBlockCache) {
     // allow for some other background things to be run, thus add 1MB of leeway
     assertTrue(newValue2 <= newValue + 1000 * 1000, { newValue, newValue2 });
   }
+  */
 };


### PR DESCRIPTION
### Scope & Purpose

Test case reduction following up to https://github.com/arangodb/arangodb/pull/14284

For unknown reasons, the block cache usage values returned by the engine stats in this test seem to be unstable, even in single server on Linux.
There is potentially some other, yet unknown action, that populates parts of the RocksDB block cache.
Being unable to reproduce the issue locally, this is an attempt to cut a part of the test in exchange for test stability.

This is a test-only modification, so it is intentionally missing a CHANGELOG entry.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*: https://github.com/arangodb/arangodb/pull/14256

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
