### PR TITLE
add hex parameter to stopwords analyzer

### DIFF
--- a/tests/js/common/aql/aql-view-arangosearch-feature.js
+++ b/tests/js/common/aql/aql-view-arangosearch-feature.js
@@ -1836,7 +1836,28 @@ function iResearchFeatureAqlTestSuite () {
       try { analyzers.remove(analyzerName, true); } catch(e) {}
       {
         analyzers.save(analyzerName,"stopwords",
-                        {stopwords:["QWE", "qwe", "qqq"]}, ["position", "frequency"]);
+                        {stopwords:["QWE", "qwe", "qqq", "abcd"]}, ["position", "frequency"]);
+        try {
+          let result = db._query(
+            "RETURN TOKENS(['QWE', 'qqq', 'aaa', 'qWe', 'abcd'], '" + analyzerName + "' )",
+            null,
+            { }
+          ).toArray();
+          assertEqual(1, result.length);
+          assertEqual(5, result[0].length);
+          assertEqual([ ], result[0][0]);
+          assertEqual([ ], result[0][1]);
+          assertEqual([ "aaa" ], result[0][2]);
+          assertEqual([ "qWe" ], result[0][3]);
+          assertEqual([ ], result[0][4]);
+        } finally {
+          analyzers.remove(analyzerName, true);
+        }
+      }
+      try { analyzers.remove(analyzerName, true); } catch(e) {}
+      {
+        analyzers.save(analyzerName,"stopwords",
+                        {stopwords:["515745", "717765", "717171"], hex:true}, ["position", "frequency"]);
         try {
           let result = db._query(
             "RETURN TOKENS(['QWE', 'qqq', 'aaa', 'qWe'], '" + analyzerName + "' )",


### PR DESCRIPTION
### Scope & Purpose

Add hex parameter to stopwords analyzer to clarify processing of stopword tokens

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [x] Backports required for: 3.8

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [x] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [x] There are tests in an external testing repository: iresearch
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Related docs PR https://github.com/arangodb/docs/pull/711
