### PR TITLE
Docs: `--log.line-number` also logs function name

### DIFF
--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -196,8 +196,8 @@ void LoggerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden));
 
   options->addOption("--log.line-number",
-                     "log function name, file name and line number of the source file "
-                     "in the format `[func@FileName.cpp:123]`",
+                     "include the function name, file name and line number of the source code "
+                     "that issues the log message. Format: `[func@FileName.cpp:123]`",
                      new BooleanParameter(&_lineNumber),
                      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden));
 

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -195,7 +195,7 @@ void LoggerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                      new StringParameter(&_file),
                      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden));
 
-  options->addOption("--log.line-number", "append line number and file name",
+  options->addOption("--log.line-number", "append source file name, line number and function name",
                      new BooleanParameter(&_lineNumber),
                      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden));
 

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -195,7 +195,9 @@ void LoggerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                      new StringParameter(&_file),
                      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden));
 
-  options->addOption("--log.line-number", "append source file name, line number and function name",
+  options->addOption("--log.line-number",
+                     "log function name, file name and line number of the source file "
+                     "in the format `[func@FileName.cpp:123]`",
                      new BooleanParameter(&_lineNumber),
                      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden));
 


### PR DESCRIPTION
### Scope & Purpose

According to https://github.com/arangodb/docs/pull/474/files#diff-836e267255d7145a3792f742141791ed7d3a393116990126ea0b9811bb2d2e84R277 the source function name is also logged

#### Backports:

- [x] Backports required for: 3.6, 3.7, 3.8

#### Related Information

The startup option is actually `--log.line-number`.

- [x] Docs PR: https://github.com/arangodb/docs/pull/707
- [x] Docs update: https://github.com/arangodb/docs/commit/1593737b6eade1d9562c969931793c1b981dd594