### PR TITLE
Metrics names in snippets fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.8.0 (XXXX-XX-XX)
 -------------------
 
+* Added check to utils/generateAllMetricsDocumentation.py to check that
+  the file name and the value of the name attribute are the same in the
+  metrics documentation snippets. Correct a few such names.
+
 * Updated arangosync to 2.3.0.
 
 * Fix BTS-456, BTS-457: Make geo intersection between point and rectangle

--- a/Documentation/Metrics/arangodb_agency_append_hist.yaml
+++ b/Documentation/Metrics/arangodb_agency_append_hist.yaml
@@ -1,4 +1,4 @@
-name: arangodb_agency_append_hist_total
+name: arangodb_agency_append_hist
 introducedIn: "3.7.1"
 help: |
   Agency RAFT follower append time histogram

--- a/Documentation/Metrics/arangodb_connection_pool_connections_current.yaml
+++ b/Documentation/Metrics/arangodb_connection_pool_connections_current.yaml
@@ -1,4 +1,4 @@
-name: arangodb_connection_connections_current
+name: arangodb_connection_pool_connections_current
 renamedFrom: arangodb_connection_connections_current
 introducedIn: "3.8.0"
 help: |

--- a/Documentation/Metrics/arangodb_connection_pool_leases_successful_total.yaml
+++ b/Documentation/Metrics/arangodb_connection_pool_leases_successful_total.yaml
@@ -1,4 +1,4 @@
-name: arangodb_connection_leases_successful_total
+name: arangodb_connection_pool_leases_successful_total
 renamedFrom: arangodb_connection_leases_successful
 introducedIn: "3.8.0"
 help: |

--- a/utils/generateAllMetricsDocumentation.py
+++ b/utils/generateAllMetricsDocumentation.py
@@ -154,6 +154,10 @@ for i, metric in enumerate(METRICSLIST):
                         print(f"YAML file '{filename}' has an unknown category "
                               f"'{y['category']}', please fix.")
                         bad = True
+                    if not bad:
+                        if y["name"] != metric:
+                            print(f"YAML file '{filename}' has an attribute name '" + y["name"] + "' which does not match the file name.")
+                            bad = True
 
     if bad:
         MISSING = True

--- a/utils/makeDashboards.py
+++ b/utils/makeDashboards.py
@@ -325,7 +325,7 @@ for c in CATEGORYNAMES:
                         panel["legend"] = {"show": False}
                         panel["targets"] = [\
                             {"expr": "histogram_quantile(0.95, sum(rate(" + \
-                             met["name"] + "_bucket[60s])) by (le))", \
+                             met["name"] + "_bucket[3m])) by (le))", \
                              "format": "heatmap", \
                              "legendFormat": ""}]
                         POSX, POSY = incxy(POSX, POSY)
@@ -334,7 +334,7 @@ for c in CATEGORYNAMES:
                         panel["title"] = panel["title"] + " (count of events per second)"
                         panel["type"] = "graph"
                         panel["targets"] = [\
-                            {"expr": "rate(" + met["name"] + "_count[60s])", \
+                            {"expr": "rate(" + met["name"] + "_count[3m])", \
                              "legendFormat": "{{instance}}:{{shortname}}"}]
                         POSX, POSY = incxy(POSX, POSY)
                         PANELS.append(panel)
@@ -342,8 +342,8 @@ for c in CATEGORYNAMES:
                         panel["title"] = panel["title"] + " (average per second)"
                         panel["type"] = "graph"
                         panel["targets"] = [\
-                            {"expr": "rate(" + met["name"] + "_sum[60s])" + \
-                                      " / rate(" + met["name"] + "_count[60s])", \
+                            {"expr": "rate(" + met["name"] + "_sum[3m])" + \
+                                      " / rate(" + met["name"] + "_count[3m])", \
                               "legendFormat": "{{instance}}:{{shortname}}"}]
                         POSX, POSY = incxy(POSX, POSY)
                         PANELS.append(panel)


### PR DESCRIPTION
This adds a test to the utils/generateAllMetricsDocumentation.py script
to check if the value in the name attribute of a documentation snippet
matches the file name.

Also corrects a few mistakes which went unnoticed.

Also fixes the averaging time for histogram metrics from 60s to 3m (which is necessary for k8s deployments).
