### PR TITLE
Allow active failover failover

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fixed a problem with active failover, where a failover could take 5 mins
+  because the follower was caught in a bad state during replication.
+
 * Added check to utils/generateAllMetricsDocumentation.py to check that
   the file name and the value of the name attribute are the same in the
   metrics documentation snippets. Correct a few such names.

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -1073,7 +1073,14 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
 
       double waitTime = TRI_microtime() - startTime;
 
-      if (response != nullptr && response->isComplete()) {
+      if (response == nullptr || response->getHttpReturnCode() == 0) {
+        // No connection could be established. This is a showstopper:
+        return Result(TRI_ERROR_REPLICATION_NO_RESPONSE,
+                      std::string("could not connect to ") +
+                      _config.master.endpoint);
+      }
+
+      if (response->isComplete()) {
         if (response->hasContentLength()) {
           stats.numSyncBytesReceived += response->getContentLength();
         }


### PR DESCRIPTION
This is a try to fix too long retry behaviour in initial sync to allow
an active failover setup to actually fail over quickly.

This is WIP.
