### PR TITLE
Docs: `--log.line-number` also logs function name (#14326)

### DIFF
--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -165,7 +165,9 @@ void LoggerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                      new StringParameter(&_file),
                      arangodb::options::makeFlags(arangodb::options::Flags::Hidden));
 
-  options->addOption("--log.line-number", "append line number and file name",
+  options->addOption("--log.line-number",
+                     "include the function name, file name and line number of the source code "
+                     "that issues the log message. Format: `[func@FileName.cpp:123]`",
                      new BooleanParameter(&_lineNumber),
                      arangodb::options::makeFlags(arangodb::options::Flags::Hidden));
 


### PR DESCRIPTION
Backport of #14326