### PR TITLE
make iterator usage safer after intermediate commits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+v3.8.1 (XXXX-XX-XX)
+-------------------
+
+* Fix internal iterator states after intermediate commits in write
+  transactions.
+
+
 v3.8.0 (XXXX-XX-XX)
 -------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,8 @@ v3.8.1 (XXXX-XX-XX)
 -------------------
 
 * Fix internal iterator states after intermediate commits in write
-  transactions.
+  transactions. Iterators could point to invalid data after an
+  intermediate commit, producing undefined behavior.
 
 
 v3.8.0 (XXXX-XX-XX)

--- a/arangod/RocksDBEngine/CMakeLists.txt
+++ b/arangod/RocksDBEngine/CMakeLists.txt
@@ -59,6 +59,7 @@ set(ROCKSDB_SOURCES
   RocksDBEngine/RocksDBIndex.cpp
   RocksDBEngine/RocksDBIndexFactory.cpp
   RocksDBEngine/RocksDBIterators.cpp
+  RocksDBEngine/RocksDBIteratorStateTracker.cpp
   RocksDBEngine/RocksDBKey.cpp
   RocksDBEngine/RocksDBKeyBounds.cpp
   RocksDBEngine/RocksDBLogValue.cpp

--- a/arangod/RocksDBEngine/RocksDBFulltextIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBFulltextIndex.cpp
@@ -463,6 +463,9 @@ Result RocksDBFulltextIndex::applyQueryToken(transaction::Methods* trx,
   rocksdb::ReadOptions ro = mthds->iteratorReadOptions();
   ro.iterate_upper_bound = &end;
   std::unique_ptr<rocksdb::Iterator> iter = mthds->NewIterator(ro, _cf);
+  if (iter == nullptr) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "invalid iterator in RocksDBFullTextIndex");
+  }
 
   // set is used to perform an intersection with the result set
   std::set<LocalDocumentId> intersect;

--- a/arangod/RocksDBEngine/RocksDBIteratorStateTracker.cpp
+++ b/arangod/RocksDBEngine/RocksDBIteratorStateTracker.cpp
@@ -1,0 +1,93 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#include "RocksDBIteratorStateTracker.h"
+
+#include "Basics/debugging.h"
+#include "RocksDBEngine/RocksDBTransactionState.h"
+#include "StorageEngine/TransactionState.h"
+#include "Transaction/Methods.h"
+
+#include <rocksdb/slice.h>
+
+namespace arangodb {
+
+RocksDBIteratorStateTracker::RocksDBIteratorStateTracker(transaction::Methods* trx)
+    : _trx(trx),
+      _intermediateCommitId(currentIntermediateCommitId()) {
+  TRI_ASSERT(_trx != nullptr);
+  TransactionState* state = _trx->state();
+  TRI_ASSERT(state != nullptr);
+  if (static_cast<RocksDBTransactionState*>(state)->isReadOnlyTransaction()) {
+    // turn ourselves off for read-only transactions, for performance reasons
+    deactivate();
+  }
+}
+
+RocksDBIteratorStateTracker::~RocksDBIteratorStateTracker() = default;
+
+bool RocksDBIteratorStateTracker::isActive() const noexcept {
+  return _trx != nullptr;
+}
+  
+void RocksDBIteratorStateTracker::trackKey(rocksdb::Slice key) {
+  if (isActive()) {
+    // track last intermediate commit id
+    _intermediateCommitId = currentIntermediateCommitId();
+  
+    // track last iterator key
+    _key.clear();
+    _key.append(key.data(), key.size());
+  }
+}
+
+void RocksDBIteratorStateTracker::reset() {
+  if (isActive()) {
+    _intermediateCommitId = currentIntermediateCommitId();
+    _key.clear();
+  }
+}
+
+bool RocksDBIteratorStateTracker::mustRebuildIterator() const {
+  return isActive() && currentIntermediateCommitId() != _intermediateCommitId;
+}
+
+rocksdb::Slice RocksDBIteratorStateTracker::key() const {
+  TRI_ASSERT(mustRebuildIterator());
+  TRI_ASSERT(_key.size() > 0);
+  return rocksdb::Slice(reinterpret_cast<char const*>(_key.data()), _key.size());
+}
+
+uint64_t RocksDBIteratorStateTracker::currentIntermediateCommitId() const {
+  TRI_ASSERT(isActive());
+  TransactionState* state = _trx->state();
+  TRI_ASSERT(state != nullptr);
+  return static_cast<RocksDBTransactionState*>(state)->intermediateCommitId();
+}
+
+void RocksDBIteratorStateTracker::deactivate() {
+  // we simply unset _trx here and check it everywhere using isActive().
+  // that way we don't have to store an extra boolean flag somewhere
+  _trx = nullptr;
+}
+
+}  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBIteratorStateTracker.h
+++ b/arangod/RocksDBEngine/RocksDBIteratorStateTracker.h
@@ -1,0 +1,82 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef ARANGOD_ROCKSDB_ENGINE_ROCKSDB_ITERATOR_STATE_TRACKER_H
+#define ARANGOD_ROCKSDB_ENGINE_ROCKSDB_ITERATOR_STATE_TRACKER_H 1
+
+#include <velocypack/Buffer.h>
+
+namespace rocksdb {
+class Slice;
+}
+
+namespace arangodb {
+namespace transaction {
+class Methods;
+}
+
+/// @brief last state (last looked-at-key, transaction state) used by a
+/// RocksDB iterator. the purpose of the state tracker is to find out if an
+/// existing RocksDB Iterator needs to be rebuilt after an intermediate
+/// commit. Intermediate commits tamper with the rocksdb::Transaction's
+/// internals, which can also affect Iterators handed out by this transaction.
+/// the only safe way to continue working with such Iterators is to recreate
+/// and reposition them.
+class RocksDBIteratorStateTracker {
+ public:
+  RocksDBIteratorStateTracker(RocksDBIteratorStateTracker const&) = delete;
+  RocksDBIteratorStateTracker& operator=(RocksDBIteratorStateTracker const&) = delete;
+
+  explicit RocksDBIteratorStateTracker(transaction::Methods* trx);
+  ~RocksDBIteratorStateTracker();
+
+  /// @brief whether or not tracking is active. as tracking can have a minimal
+  /// performance overhead, it is turned off where not needed (read-only transactions)
+  bool isActive() const noexcept;
+
+  /// @brief track last seen key by a RocksDB Iterator
+  void trackKey(rocksdb::Slice key);
+  
+  /// @brief reset our state tracking (i.e. forget about last seen key)
+  void reset();
+
+  /// @brief whether or not existing rocksdb::Iterators should be rebuilt
+  bool mustRebuildIterator() const;
+
+  /// @brief last tracked key
+  rocksdb::Slice key() const;
+
+ private:
+  /// @brief return the transaction's current intermediate commit id
+  uint64_t currentIntermediateCommitId() const;
+
+  /// @brief deactivate the tracking
+  void deactivate();
+
+ private:
+  transaction::Methods* _trx;
+  arangodb::velocypack::Buffer<uint8_t> _key;
+  uint64_t _intermediateCommitId;
+};
+
+}  // namespace arangodb
+#endif

--- a/arangod/RocksDBEngine/RocksDBIterators.cpp
+++ b/arangod/RocksDBEngine/RocksDBIterators.cpp
@@ -62,7 +62,19 @@ RocksDBAllIndexIterator::RocksDBAllIndexIterator(LogicalCollection* col,
 bool RocksDBAllIndexIterator::outOfRange() const {
   TRI_ASSERT(_trx->state()->isRunning());
   TRI_ASSERT(_iterator != nullptr);
-  return _isWriteTransaction && _cmp->Compare(_iterator->key(), _bounds.end()) > 0;
+  // we can effectively disable the out-of-range checks for read-only
+  // transactions, as our Iterator is a snapshot-based iterator with a 
+  // configured iterate_upper_bound/iterate_lower_bound value. 
+  // this makes RocksDB filter out non-matching keys automatically.
+  // however, for a write transaction our Iterator is a rocksdb BaseDeltaIterator,
+  // which will merge the values from a snapshot iterator and the changes in
+  // the current transaction. here rocksdb will only apply the bounds checks
+  // for the base iterator (from the snapshot), but not for the delta iterator
+  // (from the current transaction), so we still have to carry out the checks
+  // ourselves.
+
+  // note: this is always a forward iterator
+  return _isWriteTransaction && _cmp->Compare(_iterator->key(), _upperBound) > 0;
 }
 
 bool RocksDBAllIndexIterator::nextImpl(LocalDocumentIdCallback const& cb, size_t limit) {
@@ -83,9 +95,7 @@ bool RocksDBAllIndexIterator::nextImpl(LocalDocumentIdCallback const& cb, size_t
   TRI_ASSERT(limit > 0);
 
   do {
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     TRI_ASSERT(_bounds.objectId() == RocksDBKey::objectId(_iterator->key()));
-#endif
 
     cb(RocksDBKey::documentId(_iterator->key()));
     --limit;
@@ -370,7 +380,7 @@ RocksDBGenericIterator::RocksDBGenericIterator(rocksdb::TransactionDB* db,
       _options(options),
       _iterator(db->NewIterator(_options, _bounds.columnFamily())),
       _cmp(_bounds.columnFamily()->GetComparator()) {
-  reset();
+  seek(_bounds.start());
 }
 
 bool RocksDBGenericIterator::hasMore() const {
@@ -379,24 +389,6 @@ bool RocksDBGenericIterator::hasMore() const {
 
 bool RocksDBGenericIterator::outOfRange() const {
   return _cmp->Compare(_iterator->key(), _bounds.end()) > 0;
-}
-
-bool RocksDBGenericIterator::reset() {
-  return seek(_bounds.start());
-}
-
-bool RocksDBGenericIterator::skip(uint64_t count, uint64_t& skipped) {
-  bool hasMore = _iterator->Valid();
-  while (count > 0 && hasMore) {
-    hasMore = next(
-        [&count, &skipped](rocksdb::Slice const&, rocksdb::Slice const&) {
-          --count;
-          ++skipped;
-          return true;
-        },
-        count /*gets copied*/);
-  }
-  return hasMore;
 }
 
 bool RocksDBGenericIterator::seek(rocksdb::Slice const& key) {
@@ -418,9 +410,7 @@ bool RocksDBGenericIterator::next(GenericCallback const& cb, size_t limit) {
   }
 
   while (limit > 0 && hasMore()) {
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     TRI_ASSERT(_bounds.objectId() == RocksDBKey::objectId(_iterator->key()));
-#endif
 
     if (!cb(_iterator->key(), _iterator->value())) {
       // stop iteration

--- a/arangod/RocksDBEngine/RocksDBIterators.cpp
+++ b/arangod/RocksDBEngine/RocksDBIterators.cpp
@@ -46,27 +46,12 @@ constexpr bool AnyIteratorFillBlockCache = false;
 RocksDBAllIndexIterator::RocksDBAllIndexIterator(LogicalCollection* col,
                                                  transaction::Methods* trx) 
     : IndexIterator(col, trx),
+      _iteratorStateTracker(trx),
       _bounds(static_cast<RocksDBMetaCollection*>(col->getPhysical())->bounds()),
       _upperBound(_bounds.end()),
       _cmp(_bounds.columnFamily()->GetComparator()),
-      _mustSeek(true) {
-  // acquire rocksdb transaction
-  auto* mthds = RocksDBTransactionState::toMethods(trx);
-
-  rocksdb::ReadOptions ro = mthds->iteratorReadOptions();
-  TRI_ASSERT(ro.snapshot != nullptr);
-  TRI_ASSERT(ro.prefix_same_as_start);
-  ro.fill_cache = AllIteratorFillBlockCache;
-  ro.verify_checksums = false;  // TODO evaluate
-  ro.iterate_upper_bound = &_upperBound;
-  // options.readahead_size = 4 * 1024 * 1024;
-
-  _iterator = mthds->NewIterator(ro, _bounds.columnFamily());
-  TRI_ASSERT(_iterator != nullptr);
-  if (_iterator == nullptr) {
-    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "invalid iterator in RocksDBAllIndexIterator");
-  }
-
+      _mustSeek(true),
+      _isWriteTransaction(_iteratorStateTracker.isActive()) {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   rocksdb::ColumnFamilyDescriptor desc;
   _bounds.columnFamily()->GetDescriptor(&desc);
@@ -74,21 +59,16 @@ RocksDBAllIndexIterator::RocksDBAllIndexIterator(LogicalCollection* col,
 #endif
 }
 
-void RocksDBAllIndexIterator::seekIfRequired() {
-  if (_mustSeek) {
-    _iterator->Seek(_bounds.start());
-    _mustSeek = false;
-  }
-}
-
 bool RocksDBAllIndexIterator::outOfRange() const {
   TRI_ASSERT(_trx->state()->isRunning());
-  return _cmp->Compare(_iterator->key(), _bounds.end()) > 0;
+  TRI_ASSERT(_iterator != nullptr);
+  return _isWriteTransaction && _cmp->Compare(_iterator->key(), _bounds.end()) > 0;
 }
 
 bool RocksDBAllIndexIterator::nextImpl(LocalDocumentIdCallback const& cb, size_t limit) {
+  ensureIterator();
   TRI_ASSERT(_trx->state()->isRunning());
-  seekIfRequired();
+  TRI_ASSERT(_iterator != nullptr);
 
   if (limit == 0 || ADB_UNLIKELY(!_iterator->Valid()) || outOfRange()) {
     // No limit no data, or we are actually done. The last call should have
@@ -96,12 +76,13 @@ bool RocksDBAllIndexIterator::nextImpl(LocalDocumentIdCallback const& cb, size_t
     TRI_ASSERT(limit > 0);  // Someone called with limit == 0. Api broken
     // validate that Iterator is in a good shape and hasn't failed
     arangodb::rocksutils::checkIteratorStatus(_iterator.get());
+    _iteratorStateTracker.reset();
     return false;
   }
 
   TRI_ASSERT(limit > 0);
 
-  while (limit > 0) {
+  do {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     TRI_ASSERT(_bounds.objectId() == RocksDBKey::objectId(_iterator->key()));
 #endif
@@ -113,19 +94,25 @@ bool RocksDBAllIndexIterator::nextImpl(LocalDocumentIdCallback const& cb, size_t
     if (ADB_UNLIKELY(!_iterator->Valid())) {
       // validate that Iterator is in a good shape and hasn't failed
       arangodb::rocksutils::checkIteratorStatus(_iterator.get());
+      _iteratorStateTracker.reset();
       return false;
     } else if (outOfRange()) {
+      _iteratorStateTracker.reset();
       return false;
     }
-  }
 
-  return true;
+    if (limit == 0) {
+      _iteratorStateTracker.trackKey(_iterator->key());
+      return true;
+    }
+  } while (true);
 }
 
 bool RocksDBAllIndexIterator::nextDocumentImpl(IndexIterator::DocumentCallback const& cb,
                                                size_t limit) {
+  ensureIterator();
   TRI_ASSERT(_trx->state()->isRunning());
-  seekIfRequired();
+  TRI_ASSERT(_iterator != nullptr);
 
   if (limit == 0 || !_iterator->Valid() || outOfRange()) {
     // No limit no data, or we are actually done. The last call should have
@@ -133,10 +120,13 @@ bool RocksDBAllIndexIterator::nextDocumentImpl(IndexIterator::DocumentCallback c
     TRI_ASSERT(limit > 0);  // Someone called with limit == 0. Api broken
     // validate that Iterator is in a good shape and hasn't failed
     arangodb::rocksutils::checkIteratorStatus(_iterator.get());
+    _iteratorStateTracker.reset();
     return false;
   }
 
-  while (limit > 0) {
+  TRI_ASSERT(limit > 0);
+
+  do {
     cb(RocksDBKey::documentId(_iterator->key()), VPackSlice(reinterpret_cast<uint8_t const*>(_iterator->value().data())));
     --limit;
     _iterator->Next();
@@ -144,23 +134,41 @@ bool RocksDBAllIndexIterator::nextDocumentImpl(IndexIterator::DocumentCallback c
     if (ADB_UNLIKELY(!_iterator->Valid())) {
       // validate that Iterator is in a good shape and hasn't failed
       arangodb::rocksutils::checkIteratorStatus(_iterator.get());
+      _iteratorStateTracker.reset();
       return false;
     } else if (outOfRange()) {
+      _iteratorStateTracker.reset();
       return false;
     }
-  }
-
-  return true;
+    
+    if (limit == 0) {
+      _iteratorStateTracker.trackKey(_iterator->key());
+      return true;
+    }
+  } while (true);
 }
 
 void RocksDBAllIndexIterator::skipImpl(uint64_t count, uint64_t& skipped) {
+  ensureIterator();
   TRI_ASSERT(_trx->state()->isRunning());
-  seekIfRequired();
+  TRI_ASSERT(_iterator != nullptr);
 
-  while (count > 0 && _iterator->Valid()) {
-    --count;
-    ++skipped;
-    _iterator->Next();
+  if (_iterator->Valid() && !outOfRange() && count > 0) {
+    do {
+      --count;
+      ++skipped;
+      _iterator->Next();
+
+      if (!_iterator->Valid() || outOfRange()) {
+        _iteratorStateTracker.reset();
+        break;
+      }
+
+      if (count == 0) {
+        _iteratorStateTracker.trackKey(_iterator->key());
+        return;
+      }
+    } while (true);
   }
     
   // validate that Iterator is in a good shape and hasn't failed
@@ -170,6 +178,42 @@ void RocksDBAllIndexIterator::skipImpl(uint64_t count, uint64_t& skipped) {
 void RocksDBAllIndexIterator::resetImpl() {
   TRI_ASSERT(_trx->state()->isRunning());
   _mustSeek = true;
+}
+
+void RocksDBAllIndexIterator::ensureIterator() {
+  if (_iteratorStateTracker.mustRebuildIterator()) {
+    _iterator.reset();
+  }
+
+  if (_iterator == nullptr) {
+    // acquire rocksdb transaction
+    auto* mthds = RocksDBTransactionState::toMethods(_trx);
+
+    rocksdb::ReadOptions ro = mthds->iteratorReadOptions();
+    TRI_ASSERT(ro.snapshot != nullptr);
+    TRI_ASSERT(ro.prefix_same_as_start);
+    ro.fill_cache = AllIteratorFillBlockCache;
+    ro.verify_checksums = false;  // TODO evaluate
+    ro.iterate_upper_bound = &_upperBound;
+    // options.readahead_size = 4 * 1024 * 1024;
+
+    _iterator = mthds->NewIterator(ro, _bounds.columnFamily());
+    TRI_ASSERT(_iterator != nullptr);
+    if (_iterator == nullptr) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "invalid iterator in RocksDBAllIndexIterator");
+    }
+  }
+
+  TRI_ASSERT(_iterator != nullptr);
+  if (_mustSeek) {
+    _iterator->Seek(_bounds.start());
+    _mustSeek = false;
+  } else if (_iteratorStateTracker.mustRebuildIterator()) {
+    _iterator->Seek(_iteratorStateTracker.key());
+  }
+  _iteratorStateTracker.reset();
+  TRI_ASSERT(!_mustSeek);
+  TRI_ASSERT(!_iteratorStateTracker.mustRebuildIterator());;
 }
 
 // ================ Any Iterator ================

--- a/arangod/RocksDBEngine/RocksDBIterators.h
+++ b/arangod/RocksDBEngine/RocksDBIterators.h
@@ -31,6 +31,7 @@
 
 #include "Indexes/Index.h"
 #include "Indexes/IndexIterator.h"
+#include "RocksDBEngine/RocksDBIteratorStateTracker.h"
 #include "RocksDBEngine/RocksDBKeyBounds.h"
 
 namespace rocksdb {
@@ -59,15 +60,16 @@ class RocksDBAllIndexIterator final : public IndexIterator {
 
  private:
   bool outOfRange() const;
-  void seekIfRequired();
+  void ensureIterator();
 
- private:
+  RocksDBIteratorStateTracker _iteratorStateTracker;
   RocksDBKeyBounds const _bounds;
   rocksdb::Slice _upperBound;  // used for iterate_upper_bound
   std::unique_ptr<rocksdb::Iterator> _iterator;
   rocksdb::Comparator const* _cmp;
   // we use _mustSeek to save repeated seeks for the same start key
   bool _mustSeek;
+  bool const _isWriteTransaction;
 };
 
 class RocksDBAnyIndexIterator final : public IndexIterator {

--- a/arangod/RocksDBEngine/RocksDBIterators.h
+++ b/arangod/RocksDBEngine/RocksDBIterators.h
@@ -52,6 +52,9 @@ class RocksDBAllIndexIterator final : public IndexIterator {
   ~RocksDBAllIndexIterator() = default;
 
   char const* typeName() const override { return "all-index-iterator"; }
+  
+  /// @brief index does not support rearming
+  bool canRearm() const override { return false; }
 
   bool nextImpl(LocalDocumentIdCallback const& cb, size_t limit) override;
   bool nextDocumentImpl(DocumentCallback const& cb, size_t limit) override;
@@ -64,7 +67,7 @@ class RocksDBAllIndexIterator final : public IndexIterator {
 
   RocksDBIteratorStateTracker _iteratorStateTracker;
   RocksDBKeyBounds const _bounds;
-  rocksdb::Slice _upperBound;  // used for iterate_upper_bound
+  rocksdb::Slice const _upperBound;  // used for iterate_upper_bound
   std::unique_ptr<rocksdb::Iterator> _iterator;
   rocksdb::Comparator const* _cmp;
   // we use _mustSeek to save repeated seeks for the same start key
@@ -102,6 +105,8 @@ class RocksDBAnyIndexIterator final : public IndexIterator {
 /// @brief return false to stop iteration
 typedef std::function<bool(rocksdb::Slice const& key, rocksdb::Slice const& value)> GenericCallback;
 
+/// @brief a forward-only iterator over the primary index, only reading from the
+/// database, not taking into account changes done in the current transaction
 class RocksDBGenericIterator {
  public:
   RocksDBGenericIterator(rocksdb::TransactionDB* db, rocksdb::ReadOptions& options,
@@ -114,10 +119,7 @@ class RocksDBGenericIterator {
   //  @param limit - number of documents the callback should be applied to
   bool next(GenericCallback const& cb, size_t limit);
 
-  // documents to skip, skipped documents
-  bool skip(uint64_t count, uint64_t& skipped);
   bool seek(rocksdb::Slice const& key);
-  bool reset();
   bool hasMore() const;
 
   // return bounds
@@ -126,7 +128,6 @@ class RocksDBGenericIterator {
  private:
   bool outOfRange() const;
 
- private:
   RocksDBKeyBounds const _bounds;
   rocksdb::ReadOptions const _options;
   std::unique_ptr<rocksdb::Iterator> _iterator;

--- a/arangod/RocksDBEngine/RocksDBMethods.h
+++ b/arangod/RocksDBEngine/RocksDBMethods.h
@@ -129,7 +129,7 @@ class RocksDBTrxMethods : public RocksDBMethods {
  public:
   explicit RocksDBTrxMethods(RocksDBTransactionState* state);
 
-  virtual bool isIndexingDisabled() const override{ return _indexingDisabled; }
+  virtual bool isIndexingDisabled() const override { return _indexingDisabled; }
 
   /// @brief returns true if indexing was disabled by this call
   bool DisableIndexing() override;
@@ -156,6 +156,7 @@ class RocksDBTrxMethods : public RocksDBMethods {
   rocksdb::Status RollbackToSavePoint() override;
   void PopSavePoint() override;
 
+ private:
   bool _indexingDisabled;
 };
 

--- a/arangod/RocksDBEngine/RocksDBReplicationIterator.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationIterator.cpp
@@ -42,7 +42,8 @@ RocksDBRevisionReplicationIterator::RocksDBRevisionReplicationIterator(
     : RevisionReplicationIterator(collection),
       _readOptions(),
       _bounds(RocksDBKeyBounds::CollectionDocuments(
-          static_cast<RocksDBCollection*>(collection.getPhysical())->objectId())) {
+          static_cast<RocksDBCollection*>(collection.getPhysical())->objectId())),
+      _rangeBound(_bounds.end()) {
   auto& selector = collection.vocbase().server().getFeature<EngineSelectorFeature>();
   RocksDBEngine& engine = *static_cast<RocksDBEngine*>(&selector.engine());
   rocksdb::TransactionDB* db = engine.db();
@@ -54,6 +55,7 @@ RocksDBRevisionReplicationIterator::RocksDBRevisionReplicationIterator(
   _readOptions.verify_checksums = false;
   _readOptions.fill_cache = false;
   _readOptions.prefix_same_as_start = true;
+  _readOptions.iterate_upper_bound = &_rangeBound;
 
   rocksdb::ColumnFamilyHandle* cf = _bounds.columnFamily();
   _cmp = cf->GetComparator();
@@ -71,13 +73,15 @@ RocksDBRevisionReplicationIterator::RocksDBRevisionReplicationIterator(
     : RevisionReplicationIterator(collection),
       _readOptions(),
       _bounds(RocksDBKeyBounds::CollectionDocuments(
-          static_cast<RocksDBCollection*>(collection.getPhysical())->objectId())) {
+          static_cast<RocksDBCollection*>(collection.getPhysical())->objectId())),
+      _rangeBound(_bounds.end()) {
   RocksDBMethods* methods = RocksDBTransactionState::toMethods(&trx);
   _readOptions = methods->iteratorReadOptions();
 
   _readOptions.verify_checksums = false;
   _readOptions.fill_cache = false;
   _readOptions.prefix_same_as_start = true;
+  _readOptions.iterate_upper_bound = &_rangeBound;
 
   rocksdb::ColumnFamilyHandle* cf = _bounds.columnFamily();
   _cmp = cf->GetComparator();

--- a/arangod/RocksDBEngine/RocksDBReplicationIterator.h
+++ b/arangod/RocksDBEngine/RocksDBReplicationIterator.h
@@ -26,12 +26,21 @@
 
 #include <rocksdb/iterator.h>
 #include <rocksdb/options.h>
-#include <rocksdb/snapshot.h>
+#include <rocksdb/slice.h>
 
 #include "RocksDBEngine/RocksDBKeyBounds.h"
 #include "StorageEngine/ReplicationIterator.h"
+#include "VocBase/Identifiers/RevisionId.h"
+
+namespace rocksdb {
+class Snaspshot;
+}
 
 namespace arangodb {
+namespace transaction {
+class Methods;
+}
+
 class LogicalCollection;
 
 class RocksDBRevisionReplicationIterator : public RevisionReplicationIterator {
@@ -51,7 +60,8 @@ class RocksDBRevisionReplicationIterator : public RevisionReplicationIterator {
  private:
   std::unique_ptr<rocksdb::Iterator> _iter;
   rocksdb::ReadOptions _readOptions;
-  RocksDBKeyBounds _bounds;
+  RocksDBKeyBounds const _bounds;
+  rocksdb::Slice const _rangeBound;
   rocksdb::Comparator const* _cmp;
 };
 

--- a/arangod/RocksDBEngine/RocksDBTransactionState.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.cpp
@@ -70,6 +70,7 @@ RocksDBTransactionState::RocksDBTransactionState(TRI_vocbase_t& vocbase, Transac
       _readSnapshot(nullptr),
       _rocksReadOptions(),
       _cacheTx(nullptr),
+      _intermediateCommitId(0),
       _numCommits(0),
       _numInserts(0),
       _numUpdates(0),
@@ -633,6 +634,8 @@ Result RocksDBTransactionState::triggerIntermediateCommit(bool& hasPerformedInte
   }
 
   hasPerformedIntermediateCommit = true;
+
+  ++_intermediateCommitId;
   ++statistics()._intermediateCommits;
 
   TRI_IF_FAILURE("FailAfterIntermediateCommit") {

--- a/arangod/RocksDBEngine/RocksDBTransactionState.h
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.h
@@ -79,6 +79,9 @@ class RocksDBTransactionState final : public TransactionState {
 
   /// @brief abort a transaction
   Result abortTransaction(transaction::Methods* trx) override;
+  
+  /// @brief a counter value that gets increase after every intermediate commit
+  uint64_t intermediateCommitId() const { return _intermediateCommitId; } 
 
   /// @brief number of commits, including intermediate commits
   uint64_t numCommits() const override { return _numCommits; }
@@ -206,6 +209,10 @@ class RocksDBTransactionState final : public TransactionState {
 
   /// @brief cache transaction to unblock banished keys
   cache::Transaction* _cacheTx;
+  
+  /// @brief a counter value that gets increase after every intermediate commit
+  uint64_t _intermediateCommitId;
+
   /// @brief wrapper to use outside this class to access rocksdb
   std::unique_ptr<RocksDBMethods> _rocksMethods;
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/14346

When a transaction triggers an intermediate commit, this may affect rocksdb::Iterator objects used by the transaction. These may become silently invalidated if they point to nodes in the committed transaction's `WriteBatchWithIndex`'s index (i.e. the SkipList). 
This change tries to rebuild any such iterators after an intermediate commit, by tracking the last key an iterator was pointing at when leaving iterator-related code.
When re-entering iterator code, there is a check if an intermediate commit has happened in the meantime, and if so, the iterator will be rebuilt from scratch and will seek back to the last tracked key. This seems to be the only safe way to make sure the previous iterator does not point to any data that is now invalid after the previous transaction committed.

For read-only transactions, this behavior is turned off, i.e. there should be no overhead. For write-transactions, there will be (hopefully) neglible overhead, because the last seen key is copied to already allocated memory only when iterator-related code is left. Tracking keys will only happen for every 1,000 keys or so.
The PR also removes superfluous out-of-bounds checks for read-only transactions, which could even see a small speedup due to the changes.

We should add a lot more tests for these changes and the behavior. In our normal tests, intermediate commits are not happening frequently.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *shell_server_aql, shell_client*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools