### PR TITLE
Backport rocksdb diskspace bugfix

### DIFF
--- a/3rdParty/rocksdb/6.8/env/fs_posix.cc
+++ b/3rdParty/rocksdb/6.8/env/fs_posix.cc
@@ -832,7 +832,17 @@ class PosixFileSystem : public FileSystem {
       return IOError("While doing statvfs", fname, errno);
     }
 
-    *free_space = ((uint64_t)sbuf.f_bsize * sbuf.f_bfree);
+    // sbuf.bfree is total free space available to root
+    // sbuf.bavail is total free space available to unprivileged user
+    //  sbuf.bavail <= sbuf.bfree ... pick correct based upon effective user id
+    if (geteuid()) {
+      // non-zero user is unprivileged, or -1 if error.  take more conservative
+      // size
+      *free_space = ((uint64_t)sbuf.f_bsize * sbuf.f_bavail);
+    } else {
+      // root user can access all disk space
+      *free_space = ((uint64_t)sbuf.f_bsize * sbuf.f_bfree);
+    }
     return IOStatus::OK();
   }
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Backport bugfix from upstream rocksdb repository for calculating the
+  free disk space for the database directory. Before the bugfix, rocksdb
+  could overestimate the amount of free space when the arangod process
+  was run as non-privileged users.
+
 * Add soft coordinator shutdown: This is a new option `soft=true` for the
   DELETE /_admin/shutdown API. Has only meaning for coordinators, otherwise
   ignored. A number of things are allowed to finish but no new things are

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -479,6 +479,17 @@ void RocksDBEngine::start() {
       FATAL_ERROR_EXIT();
     }
   }
+  
+  uint64_t totalSpace;
+  uint64_t freeSpace;
+  if (TRI_GetDiskSpaceInfo(_path, totalSpace, freeSpace).ok() && totalSpace != 0) {
+    LOG_TOPIC("b71b9", DEBUG, arangodb::Logger::ENGINES)
+      << "total disk space for database directory mount: " 
+      << basics::StringUtils::formatSize(totalSpace)
+      << ", free disk space for database directory mount: " 
+      << basics::StringUtils::formatSize(freeSpace)
+      << " (" << (100.0 * double(freeSpace) / double(totalSpace)) << "% free)";
+  }
 
   // options imported set by RocksDBOptionFeature
   auto const& opts = server().getFeature<arangodb::RocksDBOptionFeature>();


### PR DESCRIPTION
### Scope & Purpose

* Backport bugfix from upstream rocksdb repository for calculating the free disk space for the database directory (rocksdb PR 8370). Before the bugfix, rocksdb could overestimate the amount of free disk space when the arangod process was run as non-privileged users.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*: https://github.com/arangodb/arangodb/pull/14353, *3.7*: https://github.com/arangodb/arangodb/pull/14354

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
