### PR TITLE
Soft coordinator shutdown documentation

### DIFF
--- a/Documentation/DocuBlocks/Rest/Administration/delete_api_shutdown.md
+++ b/Documentation/DocuBlocks/Rest/Administration/delete_api_shutdown.md
@@ -29,6 +29,9 @@ The following types of operations are tracked:
 Note that the latter two are tracked but not prevented from being
 started, to allow for finishing operations.
 
+This query parameter was introduced in 3.7.12, 3.8.1 and all versions
+greater or equal than 3.9.
+
 @RESTDESCRIPTION
 This call initiates a clean shutdown sequence. Requires administrive privileges.
 

--- a/Documentation/DocuBlocks/Rest/Administration/delete_api_shutdown.md
+++ b/Documentation/DocuBlocks/Rest/Administration/delete_api_shutdown.md
@@ -4,8 +4,33 @@
 
 @RESTHEADER{DELETE /_admin/shutdown, Initiate shutdown sequence, RestShutdownHandler}
 
+@RESTQUERYPARAMETERS
+
+@RESTQUERYPARAM{soft,boolean,optional}
+If set to `true`, this initiates a soft shutdown. This is only available
+on coordinators. When issued, the coordinator tracks a number of ongoing
+operations, waits until all have finished, and then shuts itself down
+normally. In the meantime, new operations of these types are no longer
+accepted and a 503 response is sent instead. However, further requests
+to finish the ongoing operations are allowed. This feature can be used
+to make restart operations of coordinators less intrusive for clients.
+
+The following types of operations are tracked:
+
+ - AQL cursors (in particular streaming cursors)
+ - Transactions (in particular streaming transactions)
+ - Pregel runs (conducted by this coordinator)
+ - Ongoing asynchronous requests (using the `x-arango-async: store` HTTP header
+ - Finished asynchronous requests, whose result has not yet been
+   collected
+ - Queued low priority requests (most normal requests)
+ - Ongoing low priority requests
+
+Note that the latter two are tracked but not prevented from being
+started, to allow for finishing operations.
+
 @RESTDESCRIPTION
-This call initiates a clean shutdown sequence. Requires administrive privileges
+This call initiates a clean shutdown sequence. Requires administrive privileges.
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Administration/delete_api_shutdown.md
+++ b/Documentation/DocuBlocks/Rest/Administration/delete_api_shutdown.md
@@ -7,19 +7,21 @@
 @RESTQUERYPARAMETERS
 
 @RESTQUERYPARAM{soft,boolean,optional}
+<small>Introduced in: v3.7.12, v3.8.1, v3.9.0</small>
+
 If set to `true`, this initiates a soft shutdown. This is only available
-on coordinators. When issued, the coordinator tracks a number of ongoing
+on Coordinators. When issued, the Coordinator tracks a number of ongoing
 operations, waits until all have finished, and then shuts itself down
 normally. In the meantime, new operations of these types are no longer
 accepted and a 503 response is sent instead. However, further requests
 to finish the ongoing operations are allowed. This feature can be used
-to make restart operations of coordinators less intrusive for clients.
+to make restart operations of Coordinators less intrusive for clients.
 
 The following types of operations are tracked:
 
  - AQL cursors (in particular streaming cursors)
- - Transactions (in particular streaming transactions)
- - Pregel runs (conducted by this coordinator)
+ - Transactions (in particular stream transactions)
+ - Pregel runs (conducted by this Coordinator)
  - Ongoing asynchronous requests (using the `x-arango-async: store` HTTP header
  - Finished asynchronous requests, whose result has not yet been
    collected
@@ -28,9 +30,6 @@ The following types of operations are tracked:
 
 Note that the latter two are tracked but not prevented from being
 started, to allow for finishing operations.
-
-This query parameter was introduced in 3.7.12, 3.8.1 and all versions
-greater or equal than 3.9.
 
 @RESTDESCRIPTION
 This call initiates a clean shutdown sequence. Requires administrive privileges.

--- a/Documentation/DocuBlocks/Rest/Administration/get_api_shutdown.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_api_shutdown.md
@@ -40,6 +40,9 @@ Once all numbers have gone to 0, the flag `allClear` is set and the
 coordinator shuts down automatically. This API is not available on
 DBServers and Agents.
 
+This API call was introduced in 3.7.12, 3.8.1 and all versions greater
+or equal to 3.9.
+
 @RESTRETURNCODES
 
 @RESTRETURNCODE{200}

--- a/Documentation/DocuBlocks/Rest/Administration/get_api_shutdown.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_api_shutdown.md
@@ -42,6 +42,10 @@ Once all numbers have gone to 0, the flag `allClear` is set and the
 Coordinator shuts down automatically. This API is not available on
 DB-Servers and Agents.
 
+@RESTRETURNCODES
+
+@RESTRETURNCODE{200}
+Returned in all cases.
 
 @RESTREPLYBODY{softShutdownOngoing,boolean,required,}
 Whether a soft shutdown of the Coordinator is in progress.
@@ -69,10 +73,5 @@ Number of ongoing low priority requests.
 
 @RESTREPLYBODY{allClear,boolean,required,}
 Whether all active operations finished.
-
-@RESTRETURNCODES
-
-@RESTRETURNCODE{200}
-is returned in all cases, the above JSON object is in the body.
 
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Administration/get_api_shutdown.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_api_shutdown.md
@@ -5,13 +5,15 @@
 @RESTHEADER{GET /_admin/shutdown, Query progress of soft shutdown process, RestShutdownHandler}
 
 @RESTDESCRIPTION
-This call reports progress about a soft coordinator shutdown (see
+<small>Introduced in: v3.7.12, v3.8.1, v3.9.0</small>
+
+This call reports progress about a soft Coordinator shutdown (see
 documentation of `DELETE /_admin/shutdown?soft=true`). 
 In this case, the following types of operations are tracked:
 
  - AQL cursors (in particular streaming cursors)
- - Transactions (in particular streaming transactions)
- - Pregel runs (conducted by this coordinator)
+ - Transactions (in particular stream transactions)
+ - Pregel runs (conducted by this Coordinator)
  - Ongoing asynchronous requests (using the `x-arango-async: store` HTTP header
  - Finished asynchronous requests, whose result has not yet been
    collected
@@ -37,11 +39,36 @@ of the various types:
 ```
 
 Once all numbers have gone to 0, the flag `allClear` is set and the
-coordinator shuts down automatically. This API is not available on
-DBServers and Agents.
+Coordinator shuts down automatically. This API is not available on
+DB-Servers and Agents.
 
-This API call was introduced in 3.7.12, 3.8.1 and all versions greater
-or equal to 3.9.
+
+@RESTREPLYBODY{softShutdownOngoing,boolean,required,}
+Whether a soft shutdown of the Coordinator is in progress.
+
+@RESTREPLYBODY{AQLcursors,number,required,}
+Number of AQL cursors that are still active.
+
+@RESTREPLYBODY{transactions,number,required,}
+Number of ongoing transactions.
+
+@RESTREPLYBODY{pendingJobs,number,required,}
+Number of ongoing asynchronous requests.
+
+@RESTREPLYBODY{doneJobs,number,required,}
+Number of finished asynchronous requests, whose result has not yet been collected.
+
+@RESTREPLYBODY{pregelConductors,number,required,}
+Number of ongoing Pregel jobs.
+
+@RESTREPLYBODY{lowPrioOngoingRequests,number,required,}
+Number of queued low priority requests.
+
+@RESTREPLYBODY{lowPrioQueuedRequests,number,required,}
+Number of ongoing low priority requests.
+
+@RESTREPLYBODY{allClear,boolean,required,}
+Whether all active operations finished.
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Administration/get_api_shutdown.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_api_shutdown.md
@@ -1,0 +1,48 @@
+
+@startDocuBlock get_api_shutdown
+@brief initiates the shutdown sequence
+
+@RESTHEADER{GET /_admin/shutdown, Query progress of soft shutdown process, RestShutdownHandler}
+
+@RESTDESCRIPTION
+This call reports progress about a soft coordinator shutdown (see
+documentation of `DELETE /_admin/shutdown?soft=true`. 
+In this case, the following types of operations are tracked:
+
+ - AQL cursors (in particular streaming cursors)
+ - Transactions (in particular streaming transactions)
+ - Pregel runs (conducted by this coordinator)
+ - Ongoing asynchronous requests (using the `x-arango-async: store` HTTP header
+ - Finished asynchronous requests, whose result has not yet been
+   collected
+ - Queued low priority requests (most normal requests)
+ - Ongoing low priority requests
+
+This call returns a JSON object of the following shape, indicating the
+fact that a soft shutdown is ongoing and the number of active operations
+of the various types:
+
+```json
+{
+  "softShutdownOngoing" : true,
+  "AQLcursors" : 0,
+  "transactions" : 1,
+  "pendingJobs" : 1,
+  "doneJobs" : 0,
+  "pregelConductors" : 0,
+  "lowPrioOngoingRequests" : 1,
+  "lowPrioQueuedRequests" : 0,
+  "allClear" : false
+}
+```
+
+Once all numbers have gone to 0, the flag `allClear` is set and the
+coordinator shuts down automatically. This API is not available on
+DBServers and Agents.
+
+@RESTRETURNCODES
+
+@RESTRETURNCODE{200}
+is returned in all cases, the above JSON object is in the body.
+
+@endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Administration/get_api_shutdown.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_api_shutdown.md
@@ -6,7 +6,7 @@
 
 @RESTDESCRIPTION
 This call reports progress about a soft coordinator shutdown (see
-documentation of `DELETE /_admin/shutdown?soft=true`. 
+documentation of `DELETE /_admin/shutdown?soft=true`). 
 In this case, the following types of operations are tracked:
 
  - AQL cursors (in particular streaming cursors)

--- a/Documentation/DocuBlocks/Rest/Administration/get_api_shutdown.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_api_shutdown.md
@@ -1,8 +1,8 @@
 
 @startDocuBlock get_api_shutdown
-@brief initiates the shutdown sequence
+@brief query progress of soft shutdown process
 
-@RESTHEADER{GET /_admin/shutdown, Query progress of soft shutdown process, RestShutdownHandler}
+@RESTHEADER{GET /_admin/shutdown, Query progress of soft shutdown process, RestGetShutdownHandler}
 
 @RESTDESCRIPTION
 <small>Introduced in: v3.7.12, v3.8.1, v3.9.0</small>
@@ -20,32 +20,14 @@ In this case, the following types of operations are tracked:
  - Queued low priority requests (most normal requests)
  - Ongoing low priority requests
 
-This call returns a JSON object of the following shape, indicating the
-fact that a soft shutdown is ongoing and the number of active operations
-of the various types:
-
-```json
-{
-  "softShutdownOngoing" : true,
-  "AQLcursors" : 0,
-  "transactions" : 1,
-  "pendingJobs" : 1,
-  "doneJobs" : 0,
-  "pregelConductors" : 0,
-  "lowPrioOngoingRequests" : 1,
-  "lowPrioQueuedRequests" : 0,
-  "allClear" : false
-}
-```
-
-Once all numbers have gone to 0, the flag `allClear` is set and the
-Coordinator shuts down automatically. This API is not available on
-DB-Servers and Agents.
+This API is not available on DB-Servers and Agents.
 
 @RESTRETURNCODES
 
 @RESTRETURNCODE{200}
-Returned in all cases.
+The response indicates the fact that a soft shutdown is ongoing and the
+number of active operations of the various types. Once all numbers have gone
+to 0, the flag `allClear` is set and the Coordinator shuts down automatically.
 
 @RESTREPLYBODY{softShutdownOngoing,boolean,required,}
 Whether a soft shutdown of the Coordinator is in progress.

--- a/Documentation/DocuBlocks/Rest/Administration/get_api_shutdown.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_api_shutdown.md
@@ -8,7 +8,7 @@
 <small>Introduced in: v3.7.12, v3.8.1, v3.9.0</small>
 
 This call reports progress about a soft Coordinator shutdown (see
-documentation of `DELETE /_admin/shutdown?soft=true`). 
+documentation of `DELETE /_admin/shutdown?soft=true`).
 In this case, the following types of operations are tracked:
 
  - AQL cursors (in particular streaming cursors)
@@ -20,7 +20,7 @@ In this case, the following types of operations are tracked:
  - Queued low priority requests (most normal requests)
  - Ongoing low priority requests
 
-This API is not available on DB-Servers and Agents.
+This API is only available on Coordinators.
 
 @RESTRETURNCODES
 


### PR DESCRIPTION
This only adds documentation for the soft coordinator shutdown feature
into docublocks.
