### PR TITLE
Fix URL request parsing.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fix URL request parsing in case data is handed in in small chunks.
+  Previously the URL could be cut off if the chunk size was smaller than
+  the URL size.
+ 
 * Backport bugfix from upstream rocksdb repository for calculating the
   free disk space for the database directory. Before the bugfix, rocksdb
   could overestimate the amount of free space when the arangod process

--- a/arangod/GeneralServer/HttpCommTask.h
+++ b/arangod/GeneralServer/HttpCommTask.h
@@ -86,6 +86,7 @@ class HttpCommTask final : public GeneralCommTask<T> {
   std::string _lastHeaderField;
   std::string _lastHeaderValue;
   std::string _origin;  // value of the HTTP origin header the client sent
+  std::string _url;
   std::unique_ptr<HttpRequest> _request;
   std::unique_ptr<basics::StringBuffer> _response;
   bool _lastHeaderWasValue;

--- a/tests/js/client/shell/shell-request.js
+++ b/tests/js/client/shell/shell-request.js
@@ -34,14 +34,16 @@ var request = require('@arangodb/request');
 var url = require('url');
 var querystring = require('querystring');
 var qs = require('qs');
+const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
+const internal = require("internal");
 
+'use strict';
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test suite
 ////////////////////////////////////////////////////////////////////////////////
 
-function RequestSuite () {
-  'use strict';
+function BaseRequestSuite () {
   var buildUrl = function (append, base) {
     base = base === false ? '' : '/_admin/echo';
     append = append || '';
@@ -395,12 +397,33 @@ function RequestSuite () {
   };
 }
 
+function RequestSuite () {
+  let suite = {};
+  deriveTestSuite(BaseRequestSuite(), suite, '');
+  return suite;
+}
+
+function RequestSuiteWithSmallChunks () {
+  let suite = {
+    setUpAll: function() {
+      internal.debugSetFailAt("HttpCommTask<T>::readCallback_in_small_chunks");
+    },
+    
+    tearDownAll: function() {
+      internal.debugClearFailAt();
+    },
+  };
+
+  deriveTestSuite(BaseRequestSuite(), suite, '_SmallChunks');
+  return suite;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief executes the test suite
 ////////////////////////////////////////////////////////////////////////////////
 
 jsunity.run(RequestSuite);
+jsunity.run(RequestSuiteWithSmallChunks);
 
 return jsunity.done();
 


### PR DESCRIPTION
### Scope & Purpose

Fix URL request parsing in case data is handed in in small chunks. Previously the URL could be cut off if the chunk size was smaller than the URL size.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.6, 3.7, 3.8

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** in shell_client_aql
