### PR TITLE
fixes warnings about potentially uninitialized vars with g++11

### DIFF
--- a/arangod/Aql/LateMaterializedOptimizerRulesCommon.h
+++ b/arangod/Aql/LateMaterializedOptimizerRulesCommon.h
@@ -42,18 +42,18 @@ namespace latematerialized {
 
 struct AstAndFieldData {
   // ast node
-  AstNode* parentNode;
-  size_t childNumber;
+  AstNode* parentNode{nullptr};
+  size_t childNumber{0};
 
   // index data
-  std::vector<arangodb::basics::AttributeName> const* field;
-  size_t fieldNumber;
+  std::vector<arangodb::basics::AttributeName> const* field{nullptr};
+  size_t fieldNumber{0};
 
   std::vector<std::string> postfix;
 };
 
 struct AstAndColumnFieldData : AstAndFieldData {
-  ptrdiff_t columnNumber;
+  ptrdiff_t columnNumber{0};
 };
 
 template<typename T>


### PR DESCRIPTION
### Scope & Purpose

See PR title. Some member variables are not properly initialized.
g++-11 can warn about those.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
