### PR TITLE
Improve usability of hidden options:

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 devel
 -----
+
+* Improve usability of hidden options: `--help` mentions that these exist
+  and how to display them.
+
 * Fix DEVSUP-753: now it is safe to call visit on exhausted disjunction
   iterator.
 

--- a/lib/ProgramOptions/ProgramOptions.cpp
+++ b/lib/ProgramOptions/ProgramOptions.cpp
@@ -98,22 +98,48 @@ void ProgramOptions::printUsage() const {
 // hidden
 void ProgramOptions::printHelp(std::string const& search) const {
   bool const colors = (isatty(STDOUT_FILENO) != 0);
-  printUsage();
-
   TRI_TerminalSize ts = TRI_DefaultTerminalSize();
   size_t const tw = ts.columns;
   size_t const ow = optionsWidth();
 
+  std::string normalized = search;
+  if (normalized == "uncommon" || normalized == "hidden") {
+    normalized = ".";
+  }
+
+  bool showHidden = normalized == ".";
+
+  printUsage();
+
+  if (!showHidden) {
+    std::cout << "Common options (excluding hidden options) are:" << std::endl;
+    std::cout << std::endl;
+  }
+
   for (auto const& it : _sections) {
-    if (search == it.second.name ||
-        ((search == "*" || search == ".") && !it.second.obsolete)) {
-      it.second.printHelp(search, tw, ow, colors);
+    if (normalized == it.second.name ||
+        ((normalized == "*" || showHidden) && !it.second.obsolete)) {
+      it.second.printHelp(normalized, tw, ow, colors);
     }
   }
 
-  if (search == "*") {
+  if (normalized == "*") {
     printSectionsHelp();
   }
+  
+  std::cout << std::endl;
+  if (!showHidden) {
+    char const* colorStart = "";
+    char const* colorEnd = "";
+
+    if (isatty(STDOUT_FILENO)) {
+      colorStart = ShellColorsFeature::SHELL_COLOR_BRIGHT;
+      colorEnd = ShellColorsFeature::SHELL_COLOR_RESET;
+    }
+    std::cout << "More uncommon options are not shown by default. " 
+              << "To show these options, use  " << colorStart << "--help-uncommon" << colorEnd << std::endl;
+  }
+  std::cout << std::endl;
 }
 
 // prints the names for all section help options


### PR DESCRIPTION
### Scope & Purpose

Improve usability of hidden options:
`--help` mentions that these exist and how to display them.

This is a usability improvement.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
