### PR TITLE
Fix DEVSUP-799

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,9 @@
 v3.7.13 (XXXX-XX-XX)
 --------------------
 
-* Fixed DEVSUP-799: unique vertex getter may point to invalid memory after
-  being resetted, resulting in undefined behavior for traversals returning
-  unique vertices from inner FOR loops.
+* Fixed DEVSUP-799: unique vertex getter may point to invalid memory after being
+  resetted, resulting in undefined behavior for traversals returning unique
+  vertices from inner FOR loops.
 
 * Fixed ES-863: reloading of users within the Cluster.
   If a Coordinator is asked to reload its users (e.g. by the UserManager in

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.7.13 (XXXX-XX-XX)
 --------------------
 
+* Fixed DEVSUP-799: unique vertex getter may point to invalid memory after
+  being resetted, resulting in undefined behavior for traversals returning
+  unique vertices from inner FOR loops.
+
 * Fixed ES-863: reloading of users within the Cluster.
   If a Coordinator is asked to reload its users (e.g. by the UserManager in
   Foxx, it is also possible to do via API, but this is internal and on purpose

--- a/arangod/Cluster/ClusterTraverser.cpp
+++ b/arangod/Cluster/ClusterTraverser.cpp
@@ -90,7 +90,9 @@ void ClusterTraverser::clear() {
   _vertices.clear();
   _verticesToFetch.clear();
 
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   TRI_ASSERT(!_vertexGetter->pointsIntoTraverserCache());
+#endif
   traverserCache()->clear();
 }
 

--- a/arangod/Cluster/ClusterTraverser.cpp
+++ b/arangod/Cluster/ClusterTraverser.cpp
@@ -86,6 +86,7 @@ void ClusterTraverser::setStartVertex(std::string const& vid) {
 }
 
 void ClusterTraverser::clear() {
+  _vertexGetter->clear();
   traverserCache()->clear();
 
   _vertices.clear();

--- a/arangod/Cluster/ClusterTraverser.cpp
+++ b/arangod/Cluster/ClusterTraverser.cpp
@@ -87,10 +87,11 @@ void ClusterTraverser::setStartVertex(std::string const& vid) {
 
 void ClusterTraverser::clear() {
   _vertexGetter->clear();
-  traverserCache()->clear();
-
   _vertices.clear();
   _verticesToFetch.clear();
+
+  TRI_ASSERT(!_vertexGetter->pointsIntoTraverserCache());
+  traverserCache()->clear();
 }
 
 bool ClusterTraverser::getVertex(VPackSlice edge, arangodb::traverser::EnumeratedPath& path) {

--- a/arangod/Graph/SingleServerTraverser.cpp
+++ b/arangod/Graph/SingleServerTraverser.cpp
@@ -68,8 +68,9 @@ void SingleServerTraverser::setStartVertex(std::string const& vid) {
 
 void SingleServerTraverser::clear() {
   _vertexGetter->clear();
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   TRI_ASSERT(!_vertexGetter->pointsIntoTraverserCache());
-
+#endif
   traverserCache()->clear();
 }
 

--- a/arangod/Graph/SingleServerTraverser.cpp
+++ b/arangod/Graph/SingleServerTraverser.cpp
@@ -68,6 +68,8 @@ void SingleServerTraverser::setStartVertex(std::string const& vid) {
 
 void SingleServerTraverser::clear() {
   _vertexGetter->clear();
+  TRI_ASSERT(!_vertexGetter->pointsIntoTraverserCache());
+
   traverserCache()->clear();
 }
 

--- a/arangod/Graph/SingleServerTraverser.cpp
+++ b/arangod/Graph/SingleServerTraverser.cpp
@@ -67,6 +67,7 @@ void SingleServerTraverser::setStartVertex(std::string const& vid) {
 }
 
 void SingleServerTraverser::clear() {
+  _vertexGetter->clear();
   traverserCache()->clear();
 }
 

--- a/arangod/Graph/Traverser.cpp
+++ b/arangod/Graph/Traverser.cpp
@@ -74,6 +74,9 @@ bool Traverser::VertexGetter::getSingleVertex(arangodb::velocypack::Slice edge,
 
 void Traverser::VertexGetter::reset(arangodb::velocypack::StringRef const&) {}
 
+// nothing to do
+void Traverser::VertexGetter::clear() {}
+
 bool Traverser::UniqueVertexGetter::getVertex(VPackSlice edge,
                                               arangodb::traverser::EnumeratedPath& path) {
   // getSingleVertex will populate s and register the underlying character data 
@@ -116,6 +119,13 @@ bool Traverser::UniqueVertexGetter::getSingleVertex(arangodb::velocypack::Slice 
   result = _traverser->traverserCache()->persistString(s);
   _returnedVertices.emplace(result);
   return true;
+}
+
+void Traverser::UniqueVertexGetter::clear() {
+  // we must make sure that we clear _returnedVertices, not only for
+  // correctness, but also because it may point into memory that is
+  // going to be freed after this call.
+  _returnedVertices.clear();
 }
 
 void Traverser::UniqueVertexGetter::reset(arangodb::velocypack::StringRef const& startVertex) {

--- a/arangod/Graph/Traverser.cpp
+++ b/arangod/Graph/Traverser.cpp
@@ -77,6 +77,12 @@ void Traverser::VertexGetter::reset(arangodb::velocypack::StringRef const&) {}
 // nothing to do
 void Traverser::VertexGetter::clear() {}
 
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+bool Traverser::VertexGetter::pointsIntoTraverserCache() const noexcept {
+  return false;
+}
+#endif
+
 bool Traverser::UniqueVertexGetter::getVertex(VPackSlice edge,
                                               arangodb::traverser::EnumeratedPath& path) {
   // getSingleVertex will populate s and register the underlying character data 
@@ -127,6 +133,12 @@ void Traverser::UniqueVertexGetter::clear() {
   // going to be freed after this call.
   _returnedVertices.clear();
 }
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+bool Traverser::UniqueVertexGetter::pointsIntoTraverserCache() const noexcept {
+  return !_returnedVertices.empty();
+}
+#endif
 
 void Traverser::UniqueVertexGetter::reset(arangodb::velocypack::StringRef const& startVertex) {
   _returnedVertices.clear();

--- a/arangod/Graph/Traverser.h
+++ b/arangod/Graph/Traverser.h
@@ -143,6 +143,10 @@ class Traverser {
 
     virtual void clear();
 
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    virtual bool pointsIntoTraverserCache() const noexcept;
+#endif
+
    protected:
     Traverser* _traverser;
   };
@@ -167,6 +171,10 @@ class Traverser {
     void reset(arangodb::velocypack::StringRef const&) override;
 
     void clear() override;
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    bool pointsIntoTraverserCache() const noexcept override;
+#endif
 
    private:
     std::unordered_set<arangodb::velocypack::StringRef> _returnedVertices;

--- a/arangod/Graph/Traverser.h
+++ b/arangod/Graph/Traverser.h
@@ -141,6 +141,8 @@ class Traverser {
 
     virtual void reset(arangodb::velocypack::StringRef const&);
 
+    virtual void clear();
+
    protected:
     Traverser* _traverser;
   };
@@ -163,6 +165,8 @@ class Traverser {
                          uint64_t, arangodb::velocypack::StringRef&) override;
 
     void reset(arangodb::velocypack::StringRef const&) override;
+
+    void clear() override;
 
    private:
     std::unordered_set<arangodb::velocypack::StringRef> _returnedVertices;

--- a/arangod/Graph/TraverserCache.cpp
+++ b/arangod/Graph/TraverserCache.cpp
@@ -86,9 +86,9 @@ TraverserCache::~TraverserCache() {
 void TraverserCache::clear() {
   _query.resourceMonitor().decreaseMemoryUsage(_persistedStrings.size() * ::costPerPersistedString);
 
-  _stringHeap.clear();
   _persistedStrings.clear();
   _mmdr.clear();
+  _stringHeap.clear();
 }
 
 VPackSlice TraverserCache::lookupToken(EdgeDocumentToken const& idToken) {

--- a/tests/js/server/aql/aql-graph-traverser.js
+++ b/tests/js/server/aql/aql-graph-traverser.js
@@ -3301,6 +3301,44 @@ function subQuerySuite() {
       cleanup();
     },
 
+    testUniqueVertexGetterMemoryIssue: function () {
+      // test case: UniqueVertexGetter keeps track of which vertices
+      // were already visited. the vertex id tracked pointed to memory
+      // which was allocated only temporarily and that became invalid
+      // once TraverserCache::clear() got called.
+      let query = `WITH ${vn} FOR i IN 1..3 FOR v, e, p IN 1..3 OUTBOUND '${vertex.A}' ${en} OPTIONS { uniqueVertices: 'global', bfs: true } SORT v._key RETURN v._key`;
+      let result = db._query(query).toArray();
+      assertEqual([ 
+        "B", "B", "B", 
+        "B1", "B1", "B1", 
+        "B2", "B2", "B2", 
+        "B3", "B3", "B3", 
+        "B4", "B4", "B4", 
+        "B5", "B5", "B5", 
+        "C", "C", "C", 
+        "C1", "C1", "C1", 
+        "C2", "C2", "C2", 
+        "C3", "C3", "C3", 
+        "C4", "C4", "C4", 
+        "C5", "C5", "C5", 
+        "D", "D", "D", 
+        "D1", "D1", "D1", 
+        "D2", "D2", "D2", 
+        "D3", "D3", "D3", 
+        "D4", "D4", "D4", 
+        "D5", "D5", "D5" 
+      ], result);
+      
+      // while we are here, try a different query as well
+      query = `WITH ${vn} FOR i IN 1..3 LET sub = (FOR v, e, p IN 1..3 OUTBOUND '${vertex.A}' ${en} OPTIONS { uniqueVertices: 'global', bfs: true } SORT v._key RETURN v._key) RETURN sub`;
+      result = db._query(query).toArray();
+      assertEqual([ 
+        [ "B", "B1", "B2", "B3", "B4", "B5", "C", "C1", "C2", "C3", "C4", "C5", "D", "D1", "D2", "D3", "D4", "D5" ], 
+        [ "B", "B1", "B2", "B3", "B4", "B5", "C", "C1", "C2", "C3", "C4", "C5", "D", "D1", "D2", "D3", "D4", "D5" ], 
+        [ "B", "B1", "B2", "B3", "B4", "B5", "C", "C1", "C2", "C3", "C4", "C5", "D", "D1", "D2", "D3", "D4", "D5" ] 
+      ], result);
+    },
+
     // The test is that the traversal in subquery has more then LIMIT many
     // results. In case of a bug the cursor of the traversal is reused for the second
     // iteration as well and does not reset.


### PR DESCRIPTION
### Scope & Purpose

* Fixed DEVSUP-799: unique vertex getter may point to invalid memory after
  being resetted, resulting in undefined behavior for traversals returning
  unique vertices from inner FOR loops.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.6*: https://github.com/arangodb/arangodb/pull/14402

#### Related Information

- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/DEVSUP-799

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (shell_server_aql)
- [x] I ensured this code runs with ASan / TSan or other static verification tools
