### PR TITLE
added test for addOperation returning an error

### DIFF
--- a/arangod/RocksDBEngine/RocksDBTransactionState.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.cpp
@@ -543,6 +543,10 @@ void RocksDBTransactionState::rollbackOperation(TRI_voc_document_operation_e ope
 Result RocksDBTransactionState::addOperation(DataSourceId cid, RevisionId revisionId,
                                              TRI_voc_document_operation_e operationType,
                                              bool& hasPerformedIntermediateCommit) {
+  TRI_IF_FAILURE("addOperationSizeError") {
+    return Result(TRI_ERROR_RESOURCE_LIMIT);
+  }
+
   size_t currentSize = _rocksTransaction->GetWriteBatch()->GetWriteBatch()->GetDataSize();
   if (currentSize > _options.maxTransactionSize) {
     // we hit the transaction size limit

--- a/tests/js/server/shell/shell-collection-failures-noncluster.js
+++ b/tests/js/server/shell/shell-collection-failures-noncluster.js
@@ -48,6 +48,27 @@ function DocumentOperationsFailuresSuite() {
       internal.debugClearFailAt();
       db._drop(cn);
     },
+    
+    testInsertSizeLimit: function () {
+      let c = db._create(cn);
+
+      internal.debugSetFailAt("addOperationSizeError");
+
+      try {
+        c.insert({ _key: "testi" });
+        fail();
+      } catch (e) {
+        // Validate that we died with debug
+        assertEqual(e.errorNum, ERRORS.ERROR_RESOURCE_LIMIT.code);
+      }
+
+      assertEqual(0, c.count());
+    
+      internal.debugClearFailAt();
+
+      c.insert({ _key: "testi" });
+      assertEqual(1, c.count());
+    },
 
     testInsertFailure1: function () {
       let c = db._create(cn);
@@ -89,6 +110,28 @@ function DocumentOperationsFailuresSuite() {
 
       c.insert({ _key: "testi" });
       assertEqual(1, c.count());
+    },
+    
+    testRemoveSizeLimit: function () {
+      let c = db._create(cn);
+      c.insert({ _key: "testi" });
+
+      internal.debugSetFailAt("addOperationSizeError");
+
+      try {
+        c.remove("testi");
+        fail();
+      } catch (e) {
+        // Validate that we died with debug
+        assertEqual(e.errorNum, ERRORS.ERROR_RESOURCE_LIMIT.code);
+      }
+
+      assertEqual(1, c.count());
+    
+      internal.debugClearFailAt();
+
+      c.remove("testi");
+      assertEqual(0, c.count());
     },
     
     testRemoveFailure1: function () {
@@ -133,6 +176,30 @@ function DocumentOperationsFailuresSuite() {
 
       c.remove("testi");
       assertEqual(0, c.count());
+    },
+    
+    testModifySizeLimit: function () {
+      let c = db._create(cn);
+      c.insert({ _key: "testi", value: 1 });
+
+      internal.debugSetFailAt("addOperationSizeError");
+
+      try {
+        c.update("testi", { value: 2 });
+        fail();
+      } catch (e) {
+        // Validate that we died with debug
+        assertEqual(e.errorNum, ERRORS.ERROR_RESOURCE_LIMIT.code);
+      }
+
+      assertEqual(1, c.count());
+      assertEqual(1, c.document("testi").value);
+    
+      internal.debugClearFailAt();
+
+      c.update("testi", { value: 3 });
+      assertEqual(1, c.count());
+      assertEqual(3, c.document("testi").value);
     },
     
     testModifyFailure1: function () {


### PR DESCRIPTION
### Scope & Purpose

Add a failure point and a test for `addOperation` returning an error

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [x] Backports required for: *3.8*, *3.7* (already included in shard synchronization bugfix PRs)

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (shell_server)
