### PR TITLE
unify method used in cursor readAll - GORDO-1210

### DIFF
--- a/arangod/Graph/Cursors/RefactoredSingleServerEdgeCursor.cpp
+++ b/arangod/Graph/Cursors/RefactoredSingleServerEdgeCursor.cpp
@@ -183,7 +183,7 @@ void RefactoredSingleServerEdgeCursor::readAll(SingleServerProvider& provider,
       provider.insertEdgeIntoResult(edgeToken, tmpBuilder);
       edge = tmpBuilder.slice();
     }
-    return evaluateExpression(expression, edge);
+    return evaluateEdgeExpression(expression, edge);
   };
 
   auto evaluateLookupInfos = [&](EdgeDocumentToken const& edgeToken,
@@ -270,8 +270,8 @@ void RefactoredSingleServerEdgeCursor::readAll(SingleServerProvider& provider,
   }
 }
 
-bool RefactoredSingleServerEdgeCursor::evaluateExpression(arangodb::aql::Expression* expression,
-                                                          VPackSlice value) {
+bool RefactoredSingleServerEdgeCursor::evaluateEdgeExpression(arangodb::aql::Expression* expression,
+                                                              VPackSlice value) {
   if (expression == nullptr) {
     return true;
   }

--- a/arangod/Graph/Cursors/RefactoredSingleServerEdgeCursor.cpp
+++ b/arangod/Graph/Cursors/RefactoredSingleServerEdgeCursor.cpp
@@ -215,7 +215,9 @@ void RefactoredSingleServerEdgeCursor::readAll(SingleServerProvider& provider,
     auto& cursor = _lookupInfo[_currentCursor].cursor();
     LogicalCollection* collection = cursor.collection();
     auto cid = collection->id();
-    if (cursor.hasExtra()) {
+    bool hasExtra = cursor.hasExtra();
+
+    if (hasExtra) {
       cursor.allExtra([&](LocalDocumentId const& token, VPackSlice edge) {
         stats.addScannedIndex(1);
 #ifdef USE_ENTERPRISE

--- a/arangod/Graph/Cursors/RefactoredSingleServerEdgeCursor.h
+++ b/arangod/Graph/Cursors/RefactoredSingleServerEdgeCursor.h
@@ -112,7 +112,7 @@ class RefactoredSingleServerEdgeCursor {
 
   void rearm(VertexType vertex, uint64_t depth);
 
-  bool evaluateExpression(arangodb::aql::Expression* expression, VPackSlice value);
+  bool evaluateEdgeExpression(arangodb::aql::Expression* expression, VPackSlice value);
 };
 }  // namespace graph
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
@@ -111,7 +111,12 @@ class RocksDBEdgeIndexLookupIterator final : public IndexIterator {
 
   char const* typeName() const override { return "edge-index-iterator"; }
 
-  bool hasExtra() const override { return true; }
+  bool hasExtra() const override {
+    TRI_IF_FAILURE("RocksDBEdgeIndex::disableHasExtra") {
+      return false;
+    }
+    return true;
+  }
 
   /// @brief we provide a method to provide the index attribute values
   /// while scanning the index

--- a/js/server/modules/@arangodb/testutils/aql-graph-traversal-generic-tests.js
+++ b/js/server/modules/@arangodb/testutils/aql-graph-traversal-generic-tests.js
@@ -2647,8 +2647,11 @@ function testCompleteGraphDfsUniqueVerticesPathD3(testGraph) {
 
 function testCompleteGraphDfsUniqueVerticesPathD3NotHasExtra(testGraph) {
   internal.debugSetFailAt("RocksDBEdgeIndex::disableHasExtra");
-  completeGraphDfsUniqueVerticesPathD3Helper(testGraph);
-  internal.debugRemoveFailAt("RocksDBEdgeIndex::disableHasExtra");
+  try {
+    completeGraphDfsUniqueVerticesPathD3Helper(testGraph);
+  } finally {
+    internal.debugRemoveFailAt("RocksDBEdgeIndex::disableHasExtra");
+  }
 }
 
 function testCompleteGraphDfsUniqueVerticesUniqueEdgesPathD2(testGraph) {

--- a/js/server/modules/@arangodb/testutils/aql-graph-traversal-generic-tests.js
+++ b/js/server/modules/@arangodb/testutils/aql-graph-traversal-generic-tests.js
@@ -2567,7 +2567,7 @@ function testCompleteGraphDfsUniqueEdgesPathD2(testGraph) {
   checkResIsValidDfsOf(expectedPathsAsTree, actualPaths);
 }
 
-function testCompleteGraphDfsUniqueVerticesPathD3(testGraph) {
+function completeGraphDfsUniqueVerticesPathD3Helper(testGraph) {
   assertTrue(testGraph.name().startsWith(protoGraphs.completeGraph.name()));
   const query = aql`
         FOR v, e, p IN 0..3 OUTBOUND ${testGraph.vertex('A')} GRAPH ${testGraph.name()} OPTIONS {uniqueVertices: "path"}
@@ -2639,6 +2639,16 @@ function testCompleteGraphDfsUniqueVerticesPathD3(testGraph) {
   const actualPaths = res.toArray();
 
   checkResIsValidDfsOf(expectedPathsAsTree, actualPaths);
+}
+
+function testCompleteGraphDfsUniqueVerticesPathD3(testGraph) {
+  completeGraphDfsUniqueVerticesPathD3Helper(testGraph);
+}
+
+function testCompleteGraphDfsUniqueVerticesPathD3NotHasExtra(testGraph) {
+  internal.debugSetFailAt("RocksDBEdgeIndex::disableHasExtra");
+  completeGraphDfsUniqueVerticesPathD3Helper(testGraph);
+  internal.debugRemoveFailAt("RocksDBEdgeIndex::disableHasExtra");
 }
 
 function testCompleteGraphDfsUniqueVerticesUniqueEdgesPathD2(testGraph) {
@@ -5871,6 +5881,7 @@ const testsByGraph = {
     testCompleteGraphDfsUniqueVerticesPathD1,
     testCompleteGraphDfsUniqueVerticesPathD2,
     testCompleteGraphDfsUniqueVerticesPathD3,
+    testCompleteGraphDfsUniqueVerticesPathD3NotHasExtra,
     testCompleteGraphDfsUniqueEdgesPathD1,
     testCompleteGraphDfsUniqueEdgesPathD2,
     testCompleteGraphDfsUniqueVerticesUniqueEdgesPathD2,


### PR DESCRIPTION
Use lambda helper method to remove duplicate code usage and unify readAll(getExtra vs !getExtra)
- Also added a test. 