### PR TITLE
enable assertion in QueryContext::collections()

### DIFF
--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -1480,7 +1480,9 @@ aql::ExecutionState Query::cleanupTrxAndEngines(ErrorCode errorCode) {
     }
     bool usingSystemCollection = false;
     // Ignore queries on System collections, we do not want them to hit failure points
-    collections().visit([&usingSystemCollection](std::string const&, Collection& col) -> bool {
+    // note that we must call the _const_ version of collections() here, because the non-const
+    // version will trigger an assertion failure if the query is already executing!
+    const_cast<Query const*>(this)->collections().visit([&usingSystemCollection](std::string const&, Collection const& col) -> bool {
       if (col.getCollection()->system()) {
         usingSystemCollection = true;
         return false;

--- a/arangod/Aql/QueryContext.cpp
+++ b/arangod/Aql/QueryContext.cpp
@@ -76,15 +76,20 @@ QueryContext::~QueryContext() {
 }
 
 Collections& QueryContext::collections() {
-#ifndef ARANGODB_USE_GOOGLE_TESTS
   TRI_ASSERT(_execState != QueryExecutionState::ValueType::EXECUTION);
-#endif
   return _collections;
 }
 
 Collections const& QueryContext::collections() const {
   return _collections;
 }
+
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+  // same as "collections()", but without assertion about query execution state
+Collections& QueryContext::collectionsForTest() {
+  return _collections;
+}
+#endif
 
 /// @brief return the names of collections used in the query
 std::vector<std::string> QueryContext::collectionNames() const {

--- a/arangod/Aql/QueryContext.h
+++ b/arangod/Aql/QueryContext.h
@@ -79,6 +79,11 @@ class QueryContext {
   Collections& collections();
   Collections const& collections() const;
 
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+  // same as "collections()", but without assertion about query execution state
+  Collections& collectionsForTest();
+#endif
+
   /// @brief return the names of collections used in the query
   std::vector<std::string> collectionNames() const;
 

--- a/arangod/Aql/QueryContext.h
+++ b/arangod/Aql/QueryContext.h
@@ -79,11 +79,6 @@ class QueryContext {
   Collections& collections();
   Collections const& collections() const;
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
-  // same as "collections()", but without assertion about query execution state
-  Collections& collectionsForTest();
-#endif
-
   /// @brief return the names of collections used in the query
   std::vector<std::string> collectionNames() const;
 
@@ -152,9 +147,6 @@ class QueryContext {
   /// @brief current resources and limits used by query
   arangodb::ResourceMonitor _resourceMonitor;
 
-  /// @brief registers/unregisters query base ovehead
-  arangodb::ResourceUsageScope _baseOverHeadTracker;
-  
   TRI_voc_tick_t const _queryId;
   
   /// @brief thread-safe query warnings collector

--- a/tests/Aql/AqlSharedExecutionBlockImplTest.cpp
+++ b/tests/Aql/AqlSharedExecutionBlockImplTest.cpp
@@ -94,7 +94,11 @@ class AqlSharedExecutionBlockImplTest : public ::testing::Test {
           auto collection = server.getSystemDatabase().createCollection(info->slice());
           //"Failed to create collection";
           TRI_ASSERT(collection.get() != nullptr);
-          auto& collections = query.collections();
+          // we cannot call collections() here, because that would trigger an assertion
+          // error because we are adding collections to the query after the start. as
+          // a workaround, we call collectionsForTest, which returns the mutable list
+          // of collections without the assertion
+          auto& collections = query.collectionsForTest();
           auto col = collections.add(collectionName, AccessMode::Type::WRITE,
                                      Collection::Hint::Shard);
           TRI_ASSERT(col != nullptr);  // failed to add collection
@@ -256,7 +260,7 @@ class AqlSharedExecutionBlockImplTest : public ::testing::Test {
                                               std::move(execInfos)};
     }
     if constexpr (std::is_same_v<ExecutorType, InsertExecutor>) {
-      auto const& collections = fakedQuery->collections();
+      auto const& collections = fakedQuery->collectionsForTest();
       auto col = collections.get(collectionName);
       TRI_ASSERT(col != nullptr);  // failed to add collection
       OperationOptions opts{};

--- a/tests/Aql/AqlSharedExecutionBlockImplTest.cpp
+++ b/tests/Aql/AqlSharedExecutionBlockImplTest.cpp
@@ -94,11 +94,7 @@ class AqlSharedExecutionBlockImplTest : public ::testing::Test {
           auto collection = server.getSystemDatabase().createCollection(info->slice());
           //"Failed to create collection";
           TRI_ASSERT(collection.get() != nullptr);
-          // we cannot call collections() here, because that would trigger an assertion
-          // error because we are adding collections to the query after the start. as
-          // a workaround, we call collectionsForTest, which returns the mutable list
-          // of collections without the assertion
-          auto& collections = query.collectionsForTest();
+          auto& collections = query.collections();
           auto col = collections.add(collectionName, AccessMode::Type::WRITE,
                                      Collection::Hint::Shard);
           TRI_ASSERT(col != nullptr);  // failed to add collection
@@ -260,7 +256,7 @@ class AqlSharedExecutionBlockImplTest : public ::testing::Test {
                                               std::move(execInfos)};
     }
     if constexpr (std::is_same_v<ExecutorType, InsertExecutor>) {
-      auto const& collections = fakedQuery->collectionsForTest();
+      auto const& collections = fakedQuery->collections();
       auto col = collections.get(collectionName);
       TRI_ASSERT(col != nullptr);  // failed to add collection
       OperationOptions opts{};

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -34,6 +34,7 @@
 #include "Basics/Thread.h"
 #include "Basics/icu-helper.h"
 #include "Cluster/ServerState.h"
+#include "ClusterEngine/ClusterEngine.h"
 #include "Logger/LogAppender.h"
 #include "Logger/Logger.h"
 #include "Random/RandomGenerator.h"
@@ -137,6 +138,10 @@ int main(int argc, char* argv[]) {
   // so we do it here in a central place
   arangodb::ServerState::instance()->setRebootId(arangodb::RebootId{1}); 
   IcuInitializer::setup(ARGV0);
+  
+  // enable mocking globally - not awesome, but helps to prevent runtime
+  // assertions in queries
+  arangodb::ClusterEngine::Mocking = true;
 
   // Run tests in subthread such that it has a larger stack size in libmusl,
   // the stack size for subthreads has been reconfigured in the


### PR DESCRIPTION
### Scope & Purpose

Enable an assertion in `QueryContext::collections()` that was previously enabled only when not compiling with Google tests enabled.
The assertion is valid and is now globally enabled, except when running unittest from gtest.
This is an internal change (for testing) without any user-visible change, thus there is no CHANGELOG entry for it.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *gtest, shell_server_aql, shell_client*.
