### PR TITLE
enable assertion in QueryContext::collections()

### DIFF
--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -1483,7 +1483,9 @@ aql::ExecutionState Query::cleanupTrxAndEngines(ErrorCode errorCode) {
     }
     bool usingSystemCollection = false;
     // Ignore queries on System collections, we do not want them to hit failure points
-    collections().visit([&usingSystemCollection](std::string const&, Collection& col) -> bool {
+    // note that we must call the _const_ version of collections() here, because the non-const
+    // version will trigger an assertion failure if the query is already executing!
+    const_cast<Query const*>(this)->collections().visit([&usingSystemCollection](std::string const&, Collection const& col) -> bool {
       if (col.getCollection()->system()) {
         usingSystemCollection = true;
         return false;

--- a/arangod/Aql/QueryContext.cpp
+++ b/arangod/Aql/QueryContext.cpp
@@ -32,6 +32,7 @@
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/system-functions.h"
 #include "Cluster/ServerState.h"
+#include "ClusterEngine/ClusterEngine.h"
 #include "Graph/Graph.h"
 #include "Graph/GraphManager.h"
 #include "Logger/LogMacros.h"
@@ -53,7 +54,6 @@ using namespace arangodb::aql;
 /// @brief creates a query
 QueryContext::QueryContext(TRI_vocbase_t& vocbase, QueryId id)
     : _resourceMonitor(GlobalResourceMonitor::instance()),
-      _baseOverHeadTracker(_resourceMonitor, baseMemoryUsage),
       _queryId(id ? id : TRI_NewServerSpecificTick()),
       _collections(&vocbase),
       _vocbase(vocbase),
@@ -76,9 +76,7 @@ QueryContext::~QueryContext() {
 }
 
 Collections& QueryContext::collections() {
-#ifndef ARANGODB_USE_GOOGLE_TESTS
-  TRI_ASSERT(_execState != QueryExecutionState::ValueType::EXECUTION);
-#endif
+  TRI_ASSERT(_execState != QueryExecutionState::ValueType::EXECUTION || ClusterEngine::Mocking);
   return _collections;
 }
 

--- a/arangod/Aql/QueryContext.h
+++ b/arangod/Aql/QueryContext.h
@@ -146,9 +146,6 @@ class QueryContext {
   /// @brief current resources and limits used by query
   arangodb::ResourceMonitor _resourceMonitor;
 
-  /// @brief registers/unregisters query base ovehead
-  arangodb::ResourceUsageScope _baseOverHeadTracker;
-  
   TRI_voc_tick_t const _queryId;
   
   /// @brief thread-safe query warnings collector

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -408,10 +408,6 @@ std::unique_ptr<arangodb::aql::Query> MockAqlServer::createFakeQuery(
   callback(*query);
   query->prepareQuery(aql::SerializationFormat::SHADOWROWS);
 
-  //  auto engine =
-  //      std::make_unique<aql::ExecutionEngine>(*query, aql::SerializationFormat::SHADOWROWS);
-  //  query->setEngine(std::move(engine));
-
   return query;
 }
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -34,6 +34,7 @@
 #include "Basics/Thread.h"
 #include "Basics/icu-helper.h"
 #include "Cluster/ServerState.h"
+#include "ClusterEngine/ClusterEngine.h"
 #include "Logger/LogAppender.h"
 #include "Logger/Logger.h"
 #include "Random/RandomGenerator.h"
@@ -132,6 +133,10 @@ int main(int argc, char* argv[]) {
   // so we do it here in a central place
   arangodb::ServerState::instance()->setRebootId(arangodb::RebootId{1}); 
   IcuInitializer::setup(ARGV0);
+
+  // enable mocking globally - not awesome, but helps to prevent runtime
+  // assertions in queries
+  arangodb::ClusterEngine::Mocking = true;
 
   // Run tests in subthread such that it has a larger stack size in libmusl,
   // the stack size for subthreads has been reconfigured in the


### PR DESCRIPTION
### Scope & Purpose

devel port of https://github.com/arangodb/arangodb/pull/14447

Enable an assertion in `QueryContext::collections()` that was previously enabled only when not compiling with Google tests enabled.
The assertion is valid and is now globally enabled, except when running unittest from gtest.
This is an internal change (for testing) without any user-visible change, thus there is no CHANGELOG entry for it.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for 3.8: https://github.com/arangodb/arangodb/pull/14447

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *gtest, shell_server_aql, shell_client*.
