### PR TITLE
Fix potential segfault in tcp/ssl socket handling.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,10 @@
 v3.7.13 (XXXX-XX-XX)
 --------------------
 
-* Fix potential segfault in tcp/ssl socket handling.
+* Fixed potential segfault in tcp/ssl socket handling (potentially fixes issue
+  #14431).
 
-* Fix display of running and slow queries in web UI when there are multiple
+* Fixed display of running and slow queries in web UI when there are multiple
   coordinators. Previously, the display order of queries was undefined, which
   could lead to queries from one coordinator being display on top once and then
   the queries from another. That made using this UI harder than necessary.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.7.13 (XXXX-XX-XX)
 --------------------
 
+* Fix potential segfault in tcp/ssl socket handling.
+
 * Fix display of running and slow queries in web UI when there are multiple
   coordinators. Previously, the display order of queries was undefined, which
   could lead to queries from one coordinator being display on top once and then
@@ -27,7 +29,7 @@ v3.7.13 (XXXX-XX-XX)
   The actual bug happened when comparing the usefulness of the candidate
   indexes, when figuring out that even though the selectivity estimate for index
   1 could not be used, but that there existed a prefix index of index 1 (index
-  2). The selecivity estimate of this index was taken _without_ checking that
+  2). The selectivity estimate of this index was taken _without_ checking that
   prefix index actually satisfied the FILTER condition fully.
   The prefix index' selectivity estimate must only be used if it fully satisfies
   the FILTER condition, which was not the case here.

--- a/arangod/GeneralServer/AcceptorTcp.cpp
+++ b/arangod/GeneralServer/AcceptorTcp.cpp
@@ -125,15 +125,11 @@ void AcceptorTcp<T>::open() {
 
 template <SocketType T>
 void AcceptorTcp<T>::close() {
-  if (_asioSocket) {
-    _asioSocket->timer.cancel();
-  }
   if (_open) {
     _open = false;  // make sure the _open flag is `false` before we
                     // cancel/close the acceptor, since otherwise the
                     // handleError method will restart async_accept.
     _acceptor.close();
-    _asioSocket.reset();
   }
 }
 
@@ -144,14 +140,12 @@ void AcceptorTcp<T>::cancel() {
 
 template <>
 void AcceptorTcp<SocketType::Tcp>::asyncAccept() {
-  // In most cases _asioSocket will be nullptr here, however, if
-  // the async_accept returns with an error, then an old _asioSocket
-  // is already set. Therefore, we do no longer assert here that
-  // _asioSocket is nullptr.
   TRI_ASSERT(_endpoint->encryption() == Endpoint::EncryptionType::NONE);
 
-  _asioSocket.reset(new AsioSocket<SocketType::Tcp>(_server.selectIoContext()));
-  auto handler = [this](asio_ns::error_code const& ec) {
+  auto asioSocket = std::make_unique<AsioSocket<SocketType::Tcp>>(_server.selectIoContext());
+  auto& socket = asioSocket->socket;
+  auto& peer = asioSocket->peer;
+  auto handler = [this, asioSocket = std::move(asioSocket)](asio_ns::error_code const& ec) mutable {
     if (ec) {
       handleError(ec);
       return;
@@ -165,22 +159,21 @@ void AcceptorTcp<SocketType::Tcp>::asyncAccept() {
     info.serverAddress = _endpoint->host();
     info.serverPort = _endpoint->port();
 
-    std::unique_ptr<AsioSocket<SocketType::Tcp>> as = std::move(_asioSocket);
-    info.clientAddress = as->peer.address().to_string();
-    info.clientPort = as->peer.port();
+    info.clientAddress = asioSocket->peer.address().to_string();
+    info.clientPort = asioSocket->peer.port();
 
     LOG_TOPIC("853aa", DEBUG, arangodb::Logger::COMMUNICATION)
         << "accepted connection from " << info.clientAddress << ":" << info.clientPort;
 
     auto commTask =
         std::make_shared<HttpCommTask<SocketType::Tcp>>(_server, std::move(info),
-                                                        std::move(as));
+                                                        std::move(asioSocket));
     _server.registerTask(std::move(commTask));
     this->asyncAccept();
   };
 
   // cppcheck-suppress accessMoved
-  _acceptor.async_accept(_asioSocket->socket, _asioSocket->peer, std::move(handler));
+  _acceptor.async_accept(socket, peer, std::move(handler));
 }
 
 template <>
@@ -255,29 +248,26 @@ void AcceptorTcp<SocketType::Ssl>::performHandshake(std::unique_ptr<AsioSocket<S
 
 template <>
 void AcceptorTcp<SocketType::Ssl>::asyncAccept() {
-  // In most cases _asioSocket will be nullptr here, however, if
-  // the async_accept returns with an error, then an old _asioSocket
-  // is already set. Therefore, we do no longer assert here that
-  // _asioSocket is nullptr.
   TRI_ASSERT(_endpoint->encryption() == Endpoint::EncryptionType::SSL);
 
   // select the io context for this socket
   auto& ctx = _server.selectIoContext();
 
-  _asioSocket = std::make_unique<AsioSocket<SocketType::Ssl>>(ctx, _server.sslContexts());
-  auto handler = [this](asio_ns::error_code const& ec) {
+  auto asioSocket = std::make_unique<AsioSocket<SocketType::Ssl>>(ctx, _server.sslContexts());
+  auto& socket = asioSocket->socket.lowest_layer();
+  auto& peer =  asioSocket->peer;
+  auto handler = [this, asioSocket = std::move(asioSocket)](asio_ns::error_code const& ec) mutable {
     if (ec) {
       handleError(ec);
       return;
     }
 
-    performHandshake(std::move(_asioSocket));
+    performHandshake(std::move(asioSocket));
     this->asyncAccept();
   };
 
   // cppcheck-suppress accessMoved
-  _acceptor.async_accept(_asioSocket->socket.lowest_layer(), _asioSocket->peer,
-                         std::move(handler));
+  _acceptor.async_accept(socket, peer, std::move(handler));
 }
 }  // namespace rest
 }  // namespace arangodb

--- a/arangod/GeneralServer/AcceptorTcp.h
+++ b/arangod/GeneralServer/AcceptorTcp.h
@@ -46,7 +46,6 @@ class AcceptorTcp final : public Acceptor {
 
  private:
   asio_ns::ip::tcp::acceptor _acceptor;
-  std::unique_ptr<AsioSocket<T>> _asioSocket;
 };
 }  // namespace rest
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required (devel and 3.8 already have this fix)

#### Related Information

Potentially fixes this issue: https://github.com/arangodb/arangodb/issues/14431

### Testing & Verification

I first fixed this issued in https://github.com/arangodb/arangodb/pull/14029/commits/da1e761c7443c34204ea7e1e5be66d3babb454aa after TSan reported a data race. From the race, I figured that it would be possible to cause a segfault, but unfortunately I was never able to trigger any. Thus there is not additional test to cover this.

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
