### PR TITLE
Following term id for 3.7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.7.13 (XXXX-XX-XX)
 --------------------
 
+* Add following term ids, which prevents old synchronous replication requests
+  to be accepted after a follower was dropped and has gotten in sync again.
+  This makes the chaos tests which delay synchronous replication requests
+  more reliable and prevent inconsistent shard replicas under bad network
+  conditions.
+
 * Fix display of running and slow queries in web UI when there are multiple
   coordinators. Previously, the display order of queries was undefined, which
   could lead to queries from one coordinator being display on top once and then

--- a/arangod/Cluster/CreateCollection.cpp
+++ b/arangod/Cluster/CreateCollection.cpp
@@ -168,7 +168,7 @@ bool CreateCollection::first() {
         std::vector<std::string> noFollowers;
         col->followers()->takeOverLeadership(noFollowers, nullptr);
       } else {
-        col->followers()->setTheLeader(leader);
+        col->followers()->setTheLeader(LEADER_NOT_YET_KNOWN);
       }
     }
 

--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -31,6 +31,7 @@
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
+#include "Random/RandomGenerator.h"
 #include "VocBase/LogicalCollection.h"
 
 #include "Basics/ScopeGuard.h"
@@ -502,4 +503,37 @@ VPackBuilder FollowerInfo::newShardEntry(VPackSlice oldValue) const {
     injectFollowerInfoInternal(newValue);
   }
   return newValue;
+}
+
+uint64_t FollowerInfo::newFollowingTermId(ServerID const& s) noexcept {
+  WRITE_LOCKER(guard, _dataLock);
+  uint64_t i = 0;
+  uint64_t prev = 0;
+  auto it = _followingTermId.find(s);
+  if (it != _followingTermId.end()) {
+    prev = it->second;
+  }
+  // We want the random number to be non-zero and different from a previous one:
+  do {
+    i = RandomGenerator::interval(UINT64_MAX);
+  } while (i == 0 || i == prev);
+  try {
+    _followingTermId[s] = i;
+  } catch(std::bad_alloc const&) {
+    i = 1;   // I assume here that I do not get bad_alloc if the key is
+             // already in the map, since it then only has to overwrite
+             // an integer, if the key is not in the map, we default to 1.
+  }
+  return i;
+}
+
+uint64_t FollowerInfo::getFollowingTermId(ServerID const& s) const noexcept {
+  READ_LOCKER(guard, _dataLock);
+  // Note that we assume that find() does not throw!
+  auto it = _followingTermId.find(s);
+  if (it == _followingTermId.end()) {
+    // If not found, we use the default from above:
+    return 1;
+  }
+  return it->second;
 }

--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -55,6 +55,20 @@ class FollowerInfo {
   // soon as we can guarantee at least so many followers locally.
   std::shared_ptr<std::vector<ServerID> const> _failoverCandidates;
 
+  // The following map holds a random number for each follower, this
+  // random number is given and sent to the follower when it gets in sync
+  // (actually, when it acquires the exclusive lock to get in sync), and is
+  // then subsequently sent alongside every synchronous replication
+  // request. If the number does not match, the follower will refuse the
+  // replication request. This is to ensure that replication requests cannot
+  // be delayed into the "next" leader/follower relationship.
+  // And here is the proof that this works: The exclusive lock divides the
+  // write operations between "before" and "after". The id is changed
+  // when the exclusive lock is established. Therefore, it is OK for the
+  // replication requests to send along the "current" id, directly
+  // from this map.
+  std::unordered_map<ServerID, uint64_t> _followingTermId;
+
   // The agencyMutex is used to synchronise access to the agency.
   // the _dataLock is used to sync the access to local data.
   // The _canWriteLock is used to protect flag if we do have enough followers
@@ -133,6 +147,28 @@ class FollowerInfo {
   //////////////////////////////////////////////////////////////////////////////
 
   Result remove(ServerID const& s);
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// @brief for each run of the "get-in-sync" protocol we generate a
+  /// random number to identify this "following term". This is created
+  /// when the follower fetches the exclusive lock to finally get in sync
+  /// and is stored in _followingTermId, so that it can be forwarded with
+  /// each synchronous replication request. The follower can then decline
+  /// the replication in case it is not "in the same term".
+  //////////////////////////////////////////////////////////////////////////////
+
+  uint64_t newFollowingTermId(ServerID const& s) noexcept;
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// @brief for each run of the "get-in-sync" protocol we generate a
+  /// random number to identify this "following term". This is created
+  /// when the follower fetches the exclusive lock to finally get in sync
+  /// and is stored in _followingTermId, so that it can be forwarded with
+  /// each synchronous replication request. The follower can then decline
+  /// the replication in case it is not "in the same term".
+  //////////////////////////////////////////////////////////////////////////////
+
+  uint64_t getFollowingTermId(ServerID const& s) const noexcept;
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief clear follower list, no changes in agency necesary

--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -247,7 +247,7 @@ class FollowerInfo {
         // We know that we still do not have enough followers
         LOG_TOPIC("d7306", ERR, Logger::REPLICATION)
             << "Shard " << _docColl->name() << " is temporarily in read-only mode, since we have less than writeConcern ("
-            << basics::StringUtils::itoa(_docColl->writeConcern())
+            << _docColl->writeConcern()
             << ") replicas in sync.";
         return false;
       }

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -317,7 +317,6 @@ void handlePlanShard(uint64_t planIndex, VPackSlice const& cprops, VPackSlice co
             {DATABASE, dbname},
             {COLLECTION, colname},
             {SHARD, shname},
-            {THE_LEADER, std::string()},
             {LOCAL_LEADER, std::string(localLeader)},
             {OLD_CURRENT_COUNTER, "0"},  // legacy, no longer used
             {PLAN_RAFT_INDEX, std::to_string(planIndex)}},

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -89,8 +89,36 @@ std::string const TTL("ttl");
 
 using namespace std::chrono;
 
+// Overview over the code in this file:
+// The main method being called is "first", it does:
+// first:
+//  - wait until leader has created shard
+//  - lookup local shard
+//  - call `replicationSynchronize`
+//  - call `catchupWithReadLock`
+//  - call `catchupWithExclusiveLock`
+// replicationSynchronize:
+//  - set local shard to follow leader (without a following term id)
+//  - use a `DatabaseInitialSyncer` to synchronize to a certain state,
+//    (configure leaderId for it to go through)
+// catchupWithReadLock:
+//  - start a read lock on leader
+//  - keep configuration for shard to follow the leader without term id
+//  - call `replicationSynchronizeCatchup` (WAL tailing, configure leaderId
+//    for it to go through)
+//  - cancel read lock on leader
+// catchupWithExclusiveLock:
+//  - start an exclusive lock on leader, acquire unique following term id
+//  - set local shard to follower leader (with new following term id)
+//  - call `replicationSynchronizeFinalize` (WAL tailing)
+//  - do a final check by comparing counts on leader and follower
+//  - add us as official follower on the leader
+//  - release exclusive lock on leader
+//
+
 SynchronizeShard::SynchronizeShard(MaintenanceFeature& feature, ActionDescription const& desc)
-  : ActionBase(feature, desc) {
+  : ActionBase(feature, desc),
+    _followingTermId(0) {
   std::stringstream error;
 
   if (!desc.has(COLLECTION)) {
@@ -454,7 +482,7 @@ arangodb::Result SynchronizeShard::getReadLock(
   // nullptr only happens during controlled shutdown
   if (pool == nullptr) {
     return arangodb::Result(TRI_ERROR_SHUTTING_DOWN,
-                            "cancelReadLockOnLeader: Shutting down");
+                            "getReadLock: Shutting down");
   }
 
   VPackBuilder body;
@@ -481,6 +509,16 @@ arangodb::Result SynchronizeShard::getReadLock(
 
   if (res.ok()) {
     // Habemus clausum, we have a lock
+    if (!soft) {
+      // Now store the random followingTermId:
+      VPackSlice body = response.response->slice();
+      if (body.isObject()) {
+        VPackSlice followingTermIdSlice = body.get(StaticStrings::FollowingTermId);
+        if (followingTermIdSlice.isNumber()) {
+          _followingTermId = followingTermIdSlice.getNumber<uint64_t>();
+        }
+      }
+    }
     return arangodb::Result();
   }
 
@@ -570,6 +608,7 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
     syncer.reset(new DatabaseInitialSyncer(vocbase, configuration));
 
     if (!leaderId.empty()) {
+      // In this phase we use the normal leader ID without following term id:
       syncer->setLeaderId(leaderId);
     }
   } else if (applierType == APPLIER_GLOBAL) {
@@ -649,6 +688,8 @@ static arangodb::Result replicationSynchronizeCatchup(
   DatabaseTailingSyncer syncer(guard.database(), configuration, fromTick, true, 0);
 
   if (!leaderId.empty()) {
+    // In this phase we still use the normal leaderId without a following
+    // term id:
     syncer.setLeaderId(leaderId);
   }
 
@@ -666,17 +707,17 @@ static arangodb::Result replicationSynchronizeCatchup(
 
   if (r.fail()) {
     LOG_TOPIC("fa2ab", ERR, Logger::REPLICATION)
-        << "syncCollectionFinalize failed: " << r.errorMessage();
+        << "syncCollectionCatchup failed: " << r.errorMessage();
   }
 
   return r;
 }
 
 static arangodb::Result replicationSynchronizeFinalize(application_features::ApplicationServer& server,
-                                                       VPackSlice const& conf) {
+                                                       VPackSlice const& conf,
+                                                       std::string const& leaderId) {
   auto const database = conf.get(DATABASE).copyString();
   auto const collection = conf.get(COLLECTION).copyString();
-  auto const leaderId = conf.get(LEADER_ID).copyString();
   auto const fromTick = conf.get("from").getNumber<uint64_t>();
     
   ReplicationApplierConfiguration configuration =
@@ -917,6 +958,10 @@ bool SynchronizeShard::first() {
 
       auto details = std::make_shared<VPackBuilder>();
 
+      // Configure the shard to follow the leader without any following
+      // term id:
+      collection->followers()->setTheLeader(leader);
+
       ResultT<SyncerId> syncRes =
           replicationSynchronize(collection, config.slice(), _clientInfoString,
                                  APPLIER_DATABASE, details);
@@ -1145,6 +1190,19 @@ Result SynchronizeShard::catchupWithExclusiveLock(
       }
     });
 
+  // Now we have got a unique id for this following term and have stored it
+  // in _followingTermId, so we can use it to set the leader:
+
+  // This is necessary to accept replications from the leader which can
+  // happen as soon as we are in sync.
+  std::string leaderIdWithTerm{leader};
+  if (_followingTermId != 0) {
+    leaderIdWithTerm += "_";
+    leaderIdWithTerm += basics::StringUtils::itoa(_followingTermId);
+  }
+  // If _followingTermid is 0, then this is a leader before the update, 
+  // we tolerate this and simply use its ID without a term in this case.
+  collection.followers()->setTheLeader(leaderIdWithTerm);
   LOG_TOPIC("d76cb", DEBUG, Logger::MAINTENANCE) << "lockJobId: " << lockJobId;
 
   builder.clear();
@@ -1153,13 +1211,13 @@ Result SynchronizeShard::catchupWithExclusiveLock(
     builder.add(ENDPOINT, VPackValue(ep));
     builder.add(DATABASE, VPackValue(database));
     builder.add(COLLECTION, VPackValue(shard));
-    builder.add(LEADER_ID, VPackValue(leader));
+    builder.add(LEADER_ID, VPackValue(leaderIdWithTerm));
     builder.add("from", VPackValue(lastLogTick));
     builder.add("requestTimeout", VPackValue(600.0));
     builder.add("connectTimeout", VPackValue(60.0));
   }
 
-  res = replicationSynchronizeFinalize(feature().server(), builder.slice());
+  res = replicationSynchronizeFinalize(feature().server(), builder.slice(), leaderIdWithTerm);
 
   if (!res.ok()) {
     std::string errorMessage(
@@ -1168,10 +1226,6 @@ Result SynchronizeShard::catchupWithExclusiveLock(
     return {TRI_ERROR_INTERNAL, errorMessage};
   }
       
-  // This is necessary to accept replications from the leader which can
-  // happen as soon as we are in sync.
-  collection.followers()->setTheLeader(leader);
-
   NetworkFeature& nf = _feature.server().getFeature<NetworkFeature>();
   network::ConnectionPool* pool = nf.pool();
   res = addShardFollower(pool, ep, database, shard, lockJobId, clientId,

--- a/arangod/Cluster/SynchronizeShard.h
+++ b/arangod/Cluster/SynchronizeShard.h
@@ -77,6 +77,8 @@ class SynchronizeShard : public ActionBase {
 
   /// @brief Short, informative description of the replication client, passed to the server
   std::string _clientInfoString;
+
+  uint64_t _followingTermId;
 };
 
 }  // namespace maintenance

--- a/arangod/Cluster/TakeoverShardLeadership.cpp
+++ b/arangod/Cluster/TakeoverShardLeadership.cpp
@@ -89,11 +89,6 @@ TakeoverShardLeadership::TakeoverShardLeadership(MaintenanceFeature& feature,
   }
   TRI_ASSERT(desc.has(SHARD));
 
-  if (!desc.has(THE_LEADER)) {
-    error << "leader must be specified. ";
-  }
-  TRI_ASSERT(desc.has(THE_LEADER));
-
   if (!desc.has(LOCAL_LEADER)) {
     error << "local leader must be specified. ";
   }
@@ -115,22 +110,13 @@ static void sendLeaderChangeRequests(network::ConnectionPool* pool,
                                      std::vector<ServerID> const& currentServers,
                                      std::shared_ptr<std::vector<ServerID>>& realInsyncFollowers,
                                      std::string const& databaseName,
-                                     ShardID const& shardID, std::string const& oldLeader) {
+                                     LogicalCollection& shard, std::string const& oldLeader) {
   if (pool == nullptr) {
     // nullptr happens only during controlled shutdown
     return;
   }
 
   std::string const& sid = ServerState::instance()->getId();
-
-  VPackBufferUInt8 buffer;
-  VPackBuilder bodyBuilder(buffer);
-  {
-    VPackObjectBuilder ob(&bodyBuilder);
-    bodyBuilder.add("leaderId", VPackValue(sid));
-    bodyBuilder.add("oldLeaderId", VPackValue(oldLeader));
-    bodyBuilder.add("shard", VPackValue(shardID));
-  }
 
   network::RequestOptions options;
   options.database = databaseName;
@@ -146,6 +132,17 @@ static void sendLeaderChangeRequests(network::ConnectionPool* pool,
     if (srv == sid) {
       continue;  // ignore ourself
     }
+    uint64_t followingTermId = shard.followers()->newFollowingTermId(srv);
+    VPackBufferUInt8 buffer;
+    VPackBuilder bodyBuilder(buffer);
+    {
+      VPackObjectBuilder ob(&bodyBuilder);
+      bodyBuilder.add("leaderId", VPackValue(sid));
+      bodyBuilder.add("oldLeaderId", VPackValue(oldLeader));
+      bodyBuilder.add("shard", VPackValue(shard.name()));
+      bodyBuilder.add(StaticStrings::FollowingTermId, VPackValue(followingTermId));
+    }
+
     LOG_TOPIC("42516", DEBUG, Logger::MAINTENANCE)
         << "Sending " << bodyBuilder.toJson() << " to " << srv;
     auto f = network::sendRequest(pool, "server:" + srv, fuerte::RestVerb::Put,
@@ -168,77 +165,53 @@ static void sendLeaderChangeRequests(network::ConnectionPool* pool,
 }
 
 static void handleLeadership(uint64_t planIndex, LogicalCollection& collection,
-                             std::string const& localLeader, std::string const& plannedLeader,
+                             std::string const& localLeader,
                              std::string const& databaseName,
                              MaintenanceFeature& feature) {
   auto& followers = collection.followers();
 
-  if (plannedLeader.empty()) {   // Planned to lead
-    if (!localLeader.empty()) {  // We were not leader, assume leadership
-      LOG_TOPIC("5632f", DEBUG, Logger::MAINTENANCE)
-      << "handling leadership of shard '" << databaseName << "/"
-      << collection.name() << ": becoming leader";
+  if (!localLeader.empty()) {  // We were not leader, assume leadership
+    LOG_TOPIC("5632f", DEBUG, Logger::MAINTENANCE)
+    << "handling leadership of shard '" << databaseName << "/"
+    << collection.name() << ": becoming leader";
 
-      auto& ci = collection.vocbase().server().getFeature<ClusterFeature>().clusterInfo();
-      // This will block the thread until our ClusterInfo cache fetched a
-      // Current version in background thread which is at least as new as the
-      // Plan which brought us here. This is important for the assertion
-      // below where we check that we are in the list of failoverCandidates!
-      ci.waitForCurrent(planIndex);
-      auto currentInfo =
-          ci.getCollectionCurrent(databaseName, std::to_string(collection.planId()));
-      if (currentInfo == nullptr) {
-        // Collection has been dropped we cannot continue here.
-        return;
-      }
-      TRI_ASSERT(currentInfo != nullptr);
-      std::vector<ServerID> currentServers = currentInfo->servers(collection.name());
-      std::shared_ptr<std::vector<ServerID>> realInsyncFollowers;
-
-      if (currentServers.size() > 0) {
-        std::string& oldLeader = currentServers.at(0);
-        // Check if the old leader has resigned and stopped all write
-        // (if so, we can assume that all servers are still in sync)
-        if (oldLeader.at(0) == '_') {
-          // remove the underscore from the list as it is useless anyway
-          oldLeader = oldLeader.substr(1);
-
-          // Update all follower and tell them that we are the leader now
-          NetworkFeature& nf =
-              collection.vocbase().server().getFeature<NetworkFeature>();
-          network::ConnectionPool* pool = nf.pool();
-          sendLeaderChangeRequests(pool, currentServers, realInsyncFollowers,
-                                   databaseName, collection.name(), oldLeader);
-        }
-      }
-
-      std::vector<ServerID> failoverCandidates =
-          currentInfo->failoverCandidates(collection.name());
-      followers->takeOverLeadership(failoverCandidates, realInsyncFollowers);
-      transaction::cluster::abortFollowerTransactionsOnShard(collection.id());
+    auto& ci = collection.vocbase().server().getFeature<ClusterFeature>().clusterInfo();
+    // This will block the thread until our ClusterInfo cache fetched a
+    // Current version in background thread which is at least as new as the
+    // Plan which brought us here. This is important for the assertion
+    // below where we check that we are in the list of failoverCandidates!
+    ci.waitForCurrent(planIndex);
+    auto currentInfo =
+        ci.getCollectionCurrent(databaseName, std::to_string(collection.planId()));
+    if (currentInfo == nullptr) {
+      // Collection has been dropped we cannot continue here.
+      return;
     }
-  } else {  // Planned to follow
-    if (localLeader.empty() || localLeader == LEADER_NOT_YET_KNOWN) {
-      // Note that the following does not delete the follower list
-      // and that this is crucial, because in the planned leader
-      // resign case, updateCurrentForCollections will report the
-      // resignation together with the old in-sync list to the
-      // agency. If this list would be empty, then the supervision
-      // would be very angry with us!
+    TRI_ASSERT(currentInfo != nullptr);
+    std::vector<ServerID> currentServers = currentInfo->servers(collection.name());
+    std::shared_ptr<std::vector<ServerID>> realInsyncFollowers;
 
-      LOG_TOPIC("5632e", DEBUG, Logger::MAINTENANCE)
-          << "handling leadership of shard '" << databaseName << "/"
-          << collection.name() << ": following " << plannedLeader;
+    if (currentServers.size() > 0) {
+      std::string& oldLeader = currentServers.at(0);
+      // Check if the old leader has resigned and stopped all write
+      // (if so, we can assume that all servers are still in sync)
+      if (oldLeader.at(0) == '_') {
+        // remove the underscore from the list as it is useless anyway
+        oldLeader = oldLeader.substr(1);
 
-      followers->setTheLeader(plannedLeader);
-      transaction::cluster::abortLeaderTransactionsOnShard(collection.id());
+        // Update all follower and tell them that we are the leader now
+        NetworkFeature& nf =
+            collection.vocbase().server().getFeature<NetworkFeature>();
+        network::ConnectionPool* pool = nf.pool();
+        sendLeaderChangeRequests(pool, currentServers, realInsyncFollowers,
+                                 databaseName, collection, oldLeader);
+      }
     }
-    // Note that if we have been a follower to some leader
-    // we do not immediately adjust the leader here, even if
-    // the planned leader differs from what we have set locally.
-    // The setting must only be adjusted once we have
-    // synchronized with the new leader and negotiated
-    // a leader/follower relationship!
+
+    std::vector<ServerID> failoverCandidates =
+        currentInfo->failoverCandidates(collection.name());
+    followers->takeOverLeadership(failoverCandidates, realInsyncFollowers);
+    transaction::cluster::abortFollowerTransactionsOnShard(collection.id());
   }
 }
 
@@ -246,7 +219,6 @@ bool TakeoverShardLeadership::first() {
   std::string const& database = _description.get(DATABASE);
   std::string const& collection = _description.get(COLLECTION);
   std::string const& shard = _description.get(SHARD);
-  std::string const& plannedLeader = _description.get(THE_LEADER);
   std::string const& localLeader = _description.get(LOCAL_LEADER);
   std::string const& planRaftIndex = _description.get(PLAN_RAFT_INDEX);
   uint64_t planIndex = basics::StringUtils::uint64(planRaftIndex);
@@ -266,7 +238,7 @@ bool TakeoverShardLeadership::first() {
       // resignation case is not handled here, since then
       // ourselves does not appear in shards[shard] but only
       // "_" + ourselves.
-      handleLeadership(planIndex, *coll, localLeader, plannedLeader, vocbase.name(),
+      handleLeadership(planIndex, *coll, localLeader, vocbase.name(),
                        feature());
     } else {
       std::stringstream error;

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -2665,6 +2665,10 @@ void RestReplicationHandler::handleCommandSetTheLeader() {
   VPackSlice const leaderIdSlice = body.get("leaderId");
   VPackSlice const oldLeaderIdSlice = body.get("oldLeaderId");
   VPackSlice const shard = body.get("shard");
+  VPackSlice const followingTermId = body.get(StaticStrings::FollowingTermId);
+  // Note that we tolerate if followingTermId is not present or not a number
+  // for upgrade scenarios. If the new leader does not send it, it will also
+  // not send it in the option IsSynchronousReplication.
   if (!leaderIdSlice.isString() || !shard.isString() || !oldLeaderIdSlice.isString()) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "'leaderId' and 'shard' attributes must be strings");
@@ -2698,7 +2702,12 @@ void RestReplicationHandler::handleCommandSetTheLeader() {
       return;
     }
 
-    col->followers()->setTheLeader(leaderId);
+    if (followingTermId.isNumber()) {
+      col->followers()->setTheLeader(leaderId + "_" +
+          StringUtils::itoa(followingTermId.getNumber<uint64_t>()));
+    } else {
+      col->followers()->setTheLeader(leaderId);
+    }
   }
 
   VPackBuilder b;
@@ -2829,6 +2838,10 @@ void RestReplicationHandler::handleCommandHoldReadLockCollection() {
   {
     VPackObjectBuilder bb(&b);
     b.add(StaticStrings::Error, VPackValue(false));
+    if (!serverId.empty()) {
+      b.add(StaticStrings::FollowingTermId,
+            VPackValue(col->followers()->newFollowingTermId(serverId)));
+    }
   }
 
   LOG_TOPIC("61a9d", DEBUG, Logger::REPLICATION)

--- a/arangod/Transaction/Methods.h
+++ b/arangod/Transaction/Methods.h
@@ -28,6 +28,7 @@
 #include "Basics/Common.h"
 #include "Basics/Exceptions.h"
 #include "Basics/Result.h"
+#include "Cluster/FollowerInfo.h"
 #include "Futures/Future.h"
 #include "Rest/CommonDefines.h"
 #include "Transaction/CountCache.h"
@@ -498,7 +499,8 @@ class Methods {
       std::shared_ptr<const std::vector<std::string>> const& followers,
       OperationOptions const& options, VPackSlice value, TRI_voc_document_operation_e operation,
       std::shared_ptr<velocypack::Buffer<uint8_t>> const& ops,
-      std::unordered_set<size_t> const& excludePositions);
+      std::unordered_set<size_t> const& excludePositions,
+      FollowerInfo& followerInfo);
 
  private:
   /// @brief transaction hints

--- a/arangod/Transaction/Methods.h
+++ b/arangod/Transaction/Methods.h
@@ -28,7 +28,6 @@
 #include "Basics/Common.h"
 #include "Basics/Exceptions.h"
 #include "Basics/Result.h"
-#include "Cluster/FollowerInfo.h"
 #include "Futures/Future.h"
 #include "Rest/CommonDefines.h"
 #include "Transaction/CountCache.h"
@@ -82,6 +81,7 @@ struct Options;
 /// @brief forward declarations
 class ClusterFeature;
 class CollectionNameResolver;
+class FollowerInfo;
 class Index;
 class LocalDocumentId;
 class ManagedDocumentResult;

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -306,6 +306,7 @@ std::string const StaticStrings::RevisionTreeRangeMin("rangeMin");
 std::string const StaticStrings::RevisionTreeRanges("ranges");
 std::string const StaticStrings::RevisionTreeResume("resume");
 std::string const StaticStrings::RevisionTreeVersion("version");
+std::string const StaticStrings::FollowingTermId("followingTermId");
 
 // Generic attribute names
 std::string const StaticStrings::AttrCoordinator("coordinator");

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -284,6 +284,7 @@ class StaticStrings {
   static std::string const RevisionTreeRanges;
   static std::string const RevisionTreeResume;
   static std::string const RevisionTreeVersion;
+  static std::string const FollowingTermId;
 
   // generic attribute names
   static std::string const AttrCoordinator;

--- a/tests/Maintenance/MaintenanceTest.cpp
+++ b/tests/Maintenance/MaintenanceTest.cpp
@@ -733,7 +733,6 @@ class MaintenanceTestActionPhaseOne : public SharedMaintenanceTest {
     ASSERT_TRUE(action.has(DATABASE));
     ASSERT_TRUE(action.has(COLLECTION));
     ASSERT_TRUE(action.has(SHARD));
-    ASSERT_TRUE(action.has(THE_LEADER));
     ASSERT_TRUE(action.has(LOCAL_LEADER));
     ASSERT_TRUE(action.has(PLAN_RAFT_INDEX));
     ASSERT_EQ(action.get(DATABASE), dbName);
@@ -1190,7 +1189,6 @@ TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_self_local_other) {
       auto shardName = action->get(SHARD);
       auto removed = relevantShards.erase(shardName);
       EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
-      EXPECT_EQ(action->get(THE_LEADER), "");
       EXPECT_EQ(action->get(LOCAL_LEADER), unusedServer());
     }
   }
@@ -1284,7 +1282,6 @@ TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_self_local_resigned)
       auto shardName = action->get(SHARD);
       auto removed = relevantShards.erase(shardName);
       EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
-      EXPECT_EQ(action->get(THE_LEADER), "");
       EXPECT_EQ(action->get(LOCAL_LEADER), ResignShardLeadership::LeaderNotYetKnownString);
     }
   }
@@ -1374,7 +1371,6 @@ TEST_F(MaintenanceTestActionPhaseOne, leader_behaviour_plan_self_local_reboot) {
       auto shardName = action->get(SHARD);
       auto removed = relevantShards.erase(shardName);
       EXPECT_EQ(removed, 1) << "We created a JOB for a shard we do not expect " << shardName;
-      EXPECT_EQ(action->get(THE_LEADER), "");
       EXPECT_EQ(action->get(LOCAL_LEADER), LEADER_NOT_YET_KNOWN);
     }
   }

--- a/tests/js/client/shell/shell-following-term-id-cluster.js
+++ b/tests/js/client/shell/shell-following-term-id-cluster.js
@@ -1,0 +1,119 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global fail, assertEqual, assertTrue, assertFalse, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief Test following term id behaviour.
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2021 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Max Neunhoeffer
+// //////////////////////////////////////////////////////////////////////////////
+
+const _ = require('lodash');
+let jsunity = require('jsunity');
+let internal = require('internal');
+let arangodb = require('@arangodb');
+let db = arangodb.db;
+
+function createCollectionWithKnownLeaderAndFollower(cn) {
+  db._create(cn, {numberOfShards:1, replicationFactor:2});
+  // Get dbserver names first:
+  let health = arango.GET("/_admin/cluster/health").Health;
+  let endpointMap = {};
+  let idMap = {};
+  for (let sid in health) {
+    endpointMap[health[sid].ShortName] = health[sid].Endpoint;
+    idMap[health[sid].ShortName] = sid;
+  }
+  let plan = arango.GET("/_admin/cluster/shardDistribution").results[cn].Plan;
+  let shard = Object.keys(plan)[0];
+  let coordinator = "Coordinator0001";
+  let leader = plan[shard].leader;
+  let follower = plan[shard].followers[0];
+  return { endpointMap, idMap, coordinator, leader, follower, shard };
+}
+
+function switchConnectionToCoordinator(collInfo) {
+  arango.reconnect(collInfo.endpointMap[collInfo.coordinator], "_system", "root", "");
+}
+
+function switchConnectionToLeader(collInfo) {
+  arango.reconnect(collInfo.endpointMap[collInfo.leader], "_system", "root", "");
+}
+
+function switchConnectionToFollower(collInfo) {
+  arango.reconnect(collInfo.endpointMap[collInfo.follower], "_system", "root", "");
+}
+
+function followingTermIdSuite() {
+  'use strict';
+  const cn = 'UnitTestsFollowingTermId';
+  let collInfo = {};
+
+  return {
+
+    setUp: function () {
+      db._drop(cn);
+      collInfo = createCollectionWithKnownLeaderAndFollower(cn);
+    },
+
+    tearDown: function () {
+      db._drop(cn);
+    },
+    
+    testFollowingTermIdSuite: function() {
+      // We have a shard whose leader and follower is known to us.
+      
+      // Let's insert some documents:
+      let c = db._collection(cn);
+      for (let i = 0; i < 100; ++i) {
+        c.insert({Hallo:i});
+      }
+
+      // Now check that both leader and follower have 100 documents:
+      switchConnectionToLeader(collInfo);
+      assertEqual(100, db._collection(collInfo.shard).count());
+      switchConnectionToFollower(collInfo);
+      assertEqual(100, db._collection(collInfo.shard).count());
+
+      // Try to insert a document with the leaderId:
+      let res = arango.POST(`/_api/document/${collInfo.shard}?isSynchronousReplication=${collInfo.idMap[collInfo.leader]}`, {Hallo:101});
+      assertTrue(res.error);
+      assertEqual(406, res.code);
+      assertEqual(1490, res.errorNum);
+
+      switchConnectionToCoordinator(collInfo);
+      
+      // Now insert another document:
+      c.insert({Hallo:101});
+
+      // And check that both leader and follower have 101 documents:
+      switchConnectionToLeader(collInfo);
+      assertEqual(101, db._collection(collInfo.shard).count());
+      switchConnectionToFollower(collInfo);
+      assertEqual(101, db._collection(collInfo.shard).count());
+
+      switchConnectionToCoordinator(collInfo);
+    },
+    
+  };
+}
+
+jsunity.run(followingTermIdSuite);
+return jsunity.done();


### PR DESCRIPTION
Synchronous replication requests (for insert, replace, update, delete
and truncate operations) have been checked on the follower in so far,
that it was checked that they come from the correct leader (the one the
follower believes to be following). However, it can in rare cases happen
that a follower is dropped and a replication request from before the
dropping only hits the follower after it has gotten in sync again.
This is very bad since it can lead to inconsistent data on shard
replicas which are deemed to be "in sync" and thus equal.

This PR attacks this problem: Whenever a leader/follower relationship is
established, the leader invents a random number and sends it to the
follower together with the confirmation that it has aqcuired an
exclusive lock on the shard (one relative late step of the get-in-sync
protocol). The leader stores this number and sends it along with each
synchronous replication request. The follower stores this number, too,
and checks that a synchronous replication requests comes not only from
the right leader, but also from the right "term" and not from some
distant past term.

The method described is relatively straightforward, the implementation
follows exactly the plan outlined above. One caveat is that there is
also the case of controlled leadership handover. In this case, we need
to play the same game and establish a random number identifying the
term.

Note that these numbers are not persisted (not necessary!), therefore we
prefer to use random numbers as opposed to an ascending counter, since
then we could have a certain possibility to reach the same counter value
after a restart.
Scope & Purpose

(Please describe the changes in this PR for reviewers - mandatory)

    [*] hankey Bugfix (requires CHANGELOG entry)

Backports:

    No backports required
    [*] This is the 3.7 backport, original:
        https://github.com/arangodb/arangodb/pull/14405

Testing & Verification

(Please pick either of the following options)

    [*] The behavior in this PR was manually tested
    [*] This change is already covered by existing tests, such as all
    tests bringing shards in sync. The new chaos test which delays
    synchronous replication requests artificially.
    [*] This PR adds tests that were used to verify all changes:
        `tests/js/client/shell/shell-following-term-id-cluster.js`
