### PR TITLE
Fix numeric overflow in WINDOW cost estimtation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix numeric overflow in AQL WINDOW node cost estimation if the number of
+  preceding rows was set to `unbounded`.
+
 * Updated ArangoDB Starter to 0.15.1-preview-3.
 
 * Added garbage collection for finished and failed Pregel conductors.

--- a/arangod/Aql/WindowNode.cpp
+++ b/arangod/Aql/WindowNode.cpp
@@ -492,8 +492,14 @@ CostEstimate WindowNode::estimateCost() const {
   // we never return more rows than above
   CostEstimate estimate = _dependencies.at(0)->getCost();
   if (_rangeVariable == nullptr) {
-    int64_t numRows = 1 + _bounds.numPrecedingRows() + _bounds.numFollowingRows();
-    estimate.estimatedCost += double(numRows * numRows) * _aggregateVariables.size();
+    uint64_t numRows = 1;
+    if ( _bounds.unboundedPreceding()) {
+      numRows += estimate.estimatedNrItems;
+    } else {
+      numRows += std::min<uint64_t>(estimate.estimatedNrItems, _bounds.numPrecedingRows());
+    }
+    numRows += _bounds.numFollowingRows();
+    estimate.estimatedCost += double(numRows) * double(numRows) * _aggregateVariables.size();
   } else {  // guestimate
     estimate.estimatedCost += 4 * _aggregateVariables.size();
   }


### PR DESCRIPTION
### Scope & Purpose

Fix numeric overflow in AQL WINDOW node cost estimation if the number of preceding rows was set to `unbounded`. This error was detected by UBSan.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for 3.8: https://github.com/arangodb/arangodb/pull/14465

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [x] I ensured this code runs with ASan / TSan or other static verification tools
