### PR TITLE
Fix potential memleak in Pregel conductor garbage collection.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fix potential memleak in Pregel conductor garbage collection.
+
 * Updated ArangoDB Starter to 0.15.1-preview-3.
 
 * Added garbage collection for finished and failed Pregel conductors.

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -297,9 +297,7 @@ void PregelFeature::unprepare() {
   
   MUTEX_LOCKER(guard, _mutex);
   decltype(_conductors) cs = std::move(_conductors);
-  _conductors.clear();
   decltype(_workers) ws = std::move(_workers);
-  _workers.clear();
   guard.unlock();
 
   // all pending tasks should have been finished by now, and all references

--- a/arangod/Scheduler/Scheduler.h
+++ b/arangod/Scheduler/Scheduler.h
@@ -154,27 +154,27 @@ class Scheduler {
   [[nodiscard]] virtual bool queueItem(RequestLane lane, std::unique_ptr<WorkItemBase> item) = 0;
 
  public:
-    // delay Future returns a future that will be fulfilled after the given duration
-    // requires scheduler
-    // If d is zero, the future is fulfilled immediately. Throws a logic error
-    // if delay was cancelled.
-    futures::Future<futures::Unit> delay(clock::duration d) {
-      if (d == clock::duration::zero()) {
-        return futures::makeFuture();
-      }
-
-      futures::Promise<bool> p;
-      futures::Future<bool> f = p.getFuture();
-
-      auto item = queueDelay(RequestLane::DELAYED_FUTURE, d,
-        [pr = std::move(p)](bool cancelled) mutable { pr.setValue(cancelled); });
-
-      return std::move(f).thenValue([item = std::move(item)](bool cancelled) {
-        if (cancelled) {
-          throw std::logic_error("delay was cancelled");
-        }
-      });
+  // delay Future returns a future that will be fulfilled after the given duration
+  // requires scheduler
+  // If d is zero, the future is fulfilled immediately. Throws a logic error
+  // if delay was cancelled.
+  futures::Future<futures::Unit> delay(clock::duration d) {
+    if (d == clock::duration::zero()) {
+      return futures::makeFuture();
     }
+
+    futures::Promise<bool> p;
+    futures::Future<bool> f = p.getFuture();
+
+    auto item = queueDelay(RequestLane::DELAYED_FUTURE, d,
+      [pr = std::move(p)](bool cancelled) mutable { pr.setValue(cancelled); });
+
+    return std::move(f).thenValue([item = std::move(item)](bool cancelled) {
+      if (cancelled) {
+        throw std::logic_error("delay was cancelled");
+      }
+    });
+  }
 
   // ---------------------------------------------------------------------------
   // CronThread and delayed tasks


### PR DESCRIPTION
### Scope & Purpose

Fixes a potential memleaks with Pregel conductors, as shown by the nightly ASan tests.
This PR also moves the usages of the `_gcHandle` under the mutex because there is a potential race condition when accessing it.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *shell_server*, *shell_client*.
- [x] I ensured this code runs with ASan / TSan or other static verification tools
