### PR TITLE
Added (gauge) metric "rocksdb_read_only"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 devel
 -----
 
+* APM-107: Added metric "rocksdb_read_only" to determine whether RocksDB is
+  currently in read-only mode due to a background error. The metric will have
+  a value of "1" if RocksDB is in read-only mode and "0" if RocksDB is in 
+  normal operations mode. If the metric value is "1" it means all writes into
+  RocksDB will fail, so inspecting the logfiles and acting on the actual error
+  situation is required.
+
 * Updated ArangoDB Starter to 0.15.1-preview-3.
 
 * Added garbage collection for finished and failed Pregel conductors.

--- a/Documentation/Metrics/rocksdb_read_only.yaml
+++ b/Documentation/Metrics/rocksdb_read_only.yaml
@@ -1,0 +1,31 @@
+name: rocksdb_read_only
+introducedIn: "3.8.1"
+help: |
+  RocksDB metric "background-errors"
+unit: number
+type: gauge
+category: RocksDB
+complexity: simple
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  This metric indicates whether RocksDB currently is in read-only
+  mode, due to a background error. If RocksDB is in read-only mode,
+  this metric will have a value of "1". When in read-only mode, all
+  writes into RocksDB will fail. When RocksDB is in normal operations
+  mode, this metric will have a value of "0".
+troubleshoot: |
+  If this value is non-zero, it means that all write operations in
+  RocksDB will fail until the RocksDB background error is resolved.
+  The arangod server logfile should show more details about the exact
+  errors that are happening, so logs should be inspected first.
+  RocksDB can set a background error when some I/O operation fails. 
+  This is often due to disk space usage issues, so often either freeing 
+  disk space or increasing the disk capacity will help.
+  Under some conditions, RocksDB can automatically resume from the 
+  background error and go back into normal operations. However, if the
+  background error happens during certain RocksDB operations, it can
+  resume operations automatically, so the instance will need a manual
+  restart after the error condition is removed.

--- a/Documentation/Metrics/rocksdb_read_only.yaml
+++ b/Documentation/Metrics/rocksdb_read_only.yaml
@@ -26,6 +26,6 @@ troubleshoot: |
   disk space or increasing the disk capacity will help.
   Under some conditions, RocksDB can automatically resume from the 
   background error and go back into normal operations. However, if the
-  background error happens during certain RocksDB operations, it can
+  background error happens during certain RocksDB operations, it cannot
   resume operations automatically, so the instance will need a manual
   restart after the error condition is removed.

--- a/arangod/RocksDBEngine/Listeners/RocksDBBackgroundErrorListener.h
+++ b/arangod/RocksDBEngine/Listeners/RocksDBBackgroundErrorListener.h
@@ -37,6 +37,8 @@ class RocksDBBackgroundErrorListener : public rocksdb::EventListener {
 
   void OnBackgroundError(rocksdb::BackgroundErrorReason reason, rocksdb::Status* error) override;
 
+  void OnErrorRecoveryCompleted(rocksdb::Status /* old_bg_error */) override;
+
   bool called() const { return _called.load(std::memory_order_relaxed); }
 
  private:

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2406,6 +2406,7 @@ DECLARE_GAUGE(rocksdb_total_disk_space, uint64_t, "rocksdb_total_disk_space");
 DECLARE_GAUGE(rocksdb_total_inodes, uint64_t, "rocksdb_total_inodes");
 DECLARE_GAUGE(rocksdb_total_sst_files_size, uint64_t, "rocksdb_total_sst_files_size");
 DECLARE_GAUGE(rocksdb_engine_throttle_bps, uint64_t, "rocksdb_engine_throttle_bps");
+DECLARE_GAUGE(rocksdb_read_only, uint64_t, "rocksdb_read_only");
 
 void RocksDBEngine::getStatistics(std::string& result, bool v2) const {
   VPackBuilder stats;
@@ -2616,6 +2617,10 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder, bool v2) const {
       builder.add("rocksdb.free-inodes", VPackValue(VPackValueType::Null));
       builder.add("rocksdb.total-inodes", VPackValue(VPackValueType::Null));
     }
+  }
+
+  if (_errorListener) {
+    builder.add("rocksdb.read-only", VPackValue(_errorListener->called() ? 1 : 0));
   }
 
   builder.close();


### PR DESCRIPTION
### Scope & Purpose

* APM-107: Added metric "rocksdb_read_only" to determine whether RocksDB is currently in read-only mode due to a background error. The metric will have a value of "1" if RocksDB is in read-only mode and "0" if RocksDB is in normal operations mode. If the metric value is "1" it means all writes into RocksDB will fail, so inspecting the logfiles and acting on the actual error situation is required.

PR was tested manually by starting arangod using a space-constrained tmpfs directory, and writing data into it until RocksDB went into read-only mode. While doing that, metrics were retrieved periodically so check if the "rocksdb_read_only" metric flipped from "0" to "1".
Also verified manually that it goes back to "0" if RocksDB is able to resume normal operations.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*: https://github.com/arangodb/arangodb/pull/14468, *3.7*: https://github.com/arangodb/arangodb/pull/14469

#### Related Information

- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/APM-107

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
