### PR TITLE
Bug fix/non recursive plan handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 devel
 -----
+* Adapt various places related to handling of execution plans non-recursive
+  in order to avoid stack overflows. This allows us now to execute much larger
+  queries.
 
 * Updated ArangoDB Starter to 0.15.1-preview-3.
 

--- a/arangod/Aql/ClusterNodes.cpp
+++ b/arangod/Aql/ClusterNodes.cpp
@@ -302,7 +302,7 @@ std::unique_ptr<ExecutionBlock> DistributeNode::createBlock(
                                                                   std::move(infos));
 }
 
-/// @brief doToVelocyPack, for DistributedNode
+/// @brief doToVelocyPack, for DistributeNode
 void DistributeNode::doToVelocyPack(VPackBuilder& builder, unsigned flags) const {
   // call base class method
   ScatterNode::doToVelocyPack(builder, flags);

--- a/arangod/Aql/ClusterNodes.cpp
+++ b/arangod/Aql/ClusterNodes.cpp
@@ -153,18 +153,14 @@ std::unique_ptr<ExecutionBlock> RemoteNode::createBlock(
                                                               queryId());
 }
 
-/// @brief toVelocyPack, for RemoteNode
-void RemoteNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                    std::unordered_set<ExecutionNode const*>& seen) const {
+/// @brief doToVelocyPack, for RemoteNode
+void RemoteNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   // call base class method
-  DistributeConsumerNode::toVelocyPackHelperInternal(nodes, flags, seen);
+  DistributeConsumerNode::doToVelocyPack(nodes, flags);
 
   nodes.add("database", VPackValue(_vocbase->name()));
   nodes.add("server", VPackValue(_server));
   nodes.add("queryId", VPackValue(_queryId));
-
-  // And close it:
-  nodes.close();
 }
 
 /// @brief estimateCost
@@ -202,16 +198,10 @@ std::unique_ptr<ExecutionBlock> ScatterNode::createBlock(
                                                                std::move(executorInfos));
 }
 
-/// @brief toVelocyPack, for ScatterNode
-void ScatterNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                     std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
-
+/// @brief doToVelocyPack, for ScatterNode
+void ScatterNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   // serialize clients
   writeClientsToVelocyPack(nodes);
-  // And close it:
-  nodes.close();
 }
 
 bool ScatterNode::readClientsFromVelocyPack(VPackSlice base) {
@@ -312,23 +302,15 @@ std::unique_ptr<ExecutionBlock> DistributeNode::createBlock(
                                                                   std::move(infos));
 }
 
-/// @brief toVelocyPack, for DistributedNode
-void DistributeNode::toVelocyPackHelper(VPackBuilder& builder, unsigned flags,
-                                        std::unordered_set<ExecutionNode const*>& seen) const {
+/// @brief doToVelocyPack, for DistributedNode
+void DistributeNode::doToVelocyPack(VPackBuilder& builder, unsigned flags) const {
   // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(builder, flags, seen);
-
+  ScatterNode::doToVelocyPack(builder, flags);
   // add collection information
   CollectionAccessingNode::toVelocyPack(builder, flags);
 
-  // serialize clients
-  writeClientsToVelocyPack(builder);
-
   builder.add(VPackValue("variable"));
-  _variable->toVelocyPack(builder);;
-
-  // And close it:
-  builder.close();
+  _variable->toVelocyPack(builder);
 }
 
 void DistributeNode::replaceVariables(std::unordered_map<VariableId, Variable const*> const& replacements) {
@@ -435,12 +417,8 @@ GatherNode::GatherNode(ExecutionPlan* plan, ExecutionNodeId id,
       _parallelism(parallelism),
       _limit(0) {}
 
-/// @brief toVelocyPack, for GatherNode
-void GatherNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                    std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
-
+/// @brief doToVelocyPack, for GatherNode
+void GatherNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   nodes.add("parallelism", VPackValue(toString(_parallelism)));
 
   if (_elements.empty()) {
@@ -467,9 +445,6 @@ void GatherNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
       }
     }
   }
-
-  // And close it:
-  nodes.close();
 }
 
 /// @brief creates corresponding ExecutionBlock
@@ -656,11 +631,8 @@ std::unique_ptr<ExecutionBlock> SingleRemoteOperationNode::createBlock(
   }
 }
 
-/// @brief toVelocyPack, for SingleRemoteOperationNode
-void SingleRemoteOperationNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                                   std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
+/// @brief doToVelocyPack, for SingleRemoteOperationNode
+void SingleRemoteOperationNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   CollectionAccessingNode::toVelocyPackHelperPrimaryIndex(nodes);
 
   // add collection information
@@ -702,9 +674,6 @@ void SingleRemoteOperationNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned
 
   nodes.add("projections", VPackValue(VPackValueType::Array));
   // TODO: support projections?
-  nodes.close();
-
-  // And close it:
   nodes.close();
 }
 

--- a/arangod/Aql/ClusterNodes.h
+++ b/arangod/Aql/ClusterNodes.h
@@ -72,10 +72,6 @@ class RemoteNode final : public DistributeConsumerNode {
   /// @brief return the type of the node
   NodeType getType() const override final { return REMOTE; }
 
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
-
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
       ExecutionEngine& engine,
@@ -112,6 +108,10 @@ class RemoteNode final : public DistributeConsumerNode {
     _queryId = arangodb::basics::StringUtils::itoa(queryId);
   }
 
+ protected:
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override final;
+  
  private:
   /// @brief the underlying database
   TRI_vocbase_t* _vocbase;
@@ -136,10 +136,6 @@ class ScatterNode : public ExecutionNode {
 
   /// @brief return the type of the node
   NodeType getType() const override { return SCATTER; }
-
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override;
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
@@ -176,6 +172,9 @@ class ScatterNode : public ExecutionNode {
   void setScatterType(ScatterType targetType) { _type = targetType; }
 
  protected:
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override;
+  
   void writeClientsToVelocyPack(velocypack::Builder& builder) const;
   bool readClientsFromVelocyPack(velocypack::Slice base);
 
@@ -205,10 +204,6 @@ class DistributeNode final : public ScatterNode, public CollectionAccessingNode 
   /// @brief return the type of the node
   NodeType getType() const override final { return DISTRIBUTE; }
 
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
-
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
       ExecutionEngine& engine,
@@ -231,6 +226,10 @@ class DistributeNode final : public ScatterNode, public CollectionAccessingNode 
   void setVariable(Variable const* var) noexcept { _variable = var; }
   
   ExecutionNodeId getTargetNodeId() const noexcept { return _targetNodeId; }
+
+ protected:
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override final;
 
  private:
   /// @brief the variable we must inspect to know where to distribute
@@ -274,10 +273,6 @@ class GatherNode final : public ExecutionNode {
   /// @brief return the type of the node
   NodeType getType() const override final { return GATHER; }
 
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
-
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
                        bool withProperties) const override final {
@@ -319,6 +314,10 @@ class GatherNode final : public ExecutionNode {
   Parallelism parallelism() const noexcept {
     return _parallelism;
   }
+
+ protected: 
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override final;
 
  private:
   /// @brief the underlying database
@@ -364,10 +363,6 @@ class SingleRemoteOperationNode final : public ExecutionNode, public CollectionA
   /// @brief return the type of the node
   NodeType getType() const override final { return REMOTESINGLE; }
 
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
-
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
       ExecutionEngine& engine,
@@ -395,6 +390,10 @@ class SingleRemoteOperationNode final : public ExecutionNode, public CollectionA
   CostEstimate estimateCost() const override final;
 
   std::string const& key() const { return _key; }
+
+ protected: 
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override final;
 
  private:
   // whether we replaced an index node

--- a/arangod/Aql/CollectNode.cpp
+++ b/arangod/Aql/CollectNode.cpp
@@ -85,12 +85,8 @@ CollectNode::CollectNode(
 
 CollectNode::~CollectNode() = default;
 
-/// @brief toVelocyPack, for CollectNode
-void CollectNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                     std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
-
+/// @brief doToVelocyPack, for CollectNode
+void CollectNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   // group variables
   nodes.add(VPackValue("groups"));
   {
@@ -148,9 +144,6 @@ void CollectNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
   nodes.add("specialized", VPackValue(_specialized));
   nodes.add(VPackValue("collectOptions"));
   _options.toVelocyPack(nodes);
-
-  // And close it:
-  nodes.close();
 }
 
 void CollectNode::calcExpressionRegister(arangodb::aql::RegisterId& expressionRegister,

--- a/arangod/Aql/CollectNode.h
+++ b/arangod/Aql/CollectNode.h
@@ -87,10 +87,6 @@ class CollectNode : public ExecutionNode {
   /// @brief getOptions
   CollectOptions& getOptions();
 
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
-
   /// @brief calculate the expression register
   void calcExpressionRegister(RegisterId& expressionRegister,
                               RegIdSet& writeableOutputRegisters) const;
@@ -186,6 +182,10 @@ class CollectNode : public ExecutionNode {
 
   static void calculateAccessibleUserVariables(ExecutionNode const& node,
                                                std::vector<Variable const*>& userVariables);
+
+ protected:
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override final;
 
  private:
   /// @brief options for the aggregation

--- a/arangod/Aql/DistributeConsumerNode.cpp
+++ b/arangod/Aql/DistributeConsumerNode.cpp
@@ -41,18 +41,7 @@ DistributeConsumerNode::DistributeConsumerNode(ExecutionPlan* plan,
       _isResponsibleForInitializeCursor(
           base.get("isResponsibleForInitializeCursor").getBoolean()) {}
 
-void DistributeConsumerNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                                std::unordered_set<ExecutionNode const*>& seen) const {
-  // Local variant
-  toVelocyPackHelperInternal(nodes, flags, seen);
-  // And close it:
-  nodes.close();
-}
-
-void DistributeConsumerNode::toVelocyPackHelperInternal(
-    VPackBuilder& nodes, unsigned flags, std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
+void DistributeConsumerNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   nodes.add("distributeId", VPackValue(_distributeId));
   nodes.add("isResponsibleForInitializeCursor", VPackValue(_isResponsibleForInitializeCursor));
 }

--- a/arangod/Aql/DistributeConsumerNode.h
+++ b/arangod/Aql/DistributeConsumerNode.h
@@ -48,10 +48,6 @@ class DistributeConsumerNode : public ExecutionNode {
   /// @brief return the type of the node
   NodeType getType() const override { return DISTRIBUTE_CONSUMER; }
 
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override;
-
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
       ExecutionEngine& engine,
@@ -92,8 +88,8 @@ class DistributeConsumerNode : public ExecutionNode {
   }
 
  protected:
-  void toVelocyPackHelperInternal(arangodb::velocypack::Builder& nodes, unsigned flags,
-                                  std::unordered_set<ExecutionNode const*>& seen) const;
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override;
 
  private:
   /// @brief our own distributeId. If it is set, we will fetch only ata for

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -525,9 +525,9 @@ void ExecutionNode::allToVelocyPack(VPackBuilder& builder, unsigned flags) const
   struct NodeSerializer : WalkerWorker<ExecutionNode, WalkerUniqueness::Unique> {
     NodeSerializer(VPackBuilder& builder, unsigned flags)
         : builder(builder), flags(flags) {}
-    virtual void after(ExecutionNode* n) {
+    void after(ExecutionNode* n) override {
       n->toVelocyPack(builder, flags);
-    };
+    }
     VPackBuilder& builder;
     unsigned flags;
   } nodeSerializer{builder, flags};

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -516,20 +516,24 @@ ExecutionNode::ExecutionNode(ExecutionPlan& plan, ExecutionNode const& other)
   other.cloneWithoutRegisteringAndDependencies(plan, *this, false);
 }
 
-/// @brief toVelocyPack, export an ExecutionNode to VelocyPack
-void ExecutionNode::toVelocyPack(VPackBuilder& builder, unsigned flags,
-                                 bool keepTopLevelOpen) const {
-  // default value is to NOT keep top level open
-  builder.openObject();
-  builder.add(VPackValue("nodes"));
-  {
-    std::unordered_set<ExecutionNode const*> seen;
-    VPackArrayBuilder guard(&builder);
-    toVelocyPackHelper(builder, flags, seen);
-  }
-  if (!keepTopLevelOpen) {
-    builder.close();
-  }
+/// @brief exports this ExecutionNode with all its dependencies to VelocyPack.
+/// This function implicitly creates an array and serializes all nodes top-down,
+/// i.e., the upmost dependency will be the first, and this node will be the
+/// last in the array.
+void ExecutionNode::allToVelocyPack(VPackBuilder& builder, unsigned flags) const {
+
+  struct NodeSerializer : WalkerWorker<ExecutionNode, WalkerUniqueness::Unique> {
+    NodeSerializer(VPackBuilder& builder, unsigned flags)
+        : builder(builder), flags(flags) {}
+    virtual void after(ExecutionNode* n) {
+      n->toVelocyPack(builder, flags);
+    };
+    VPackBuilder& builder;
+    unsigned flags;
+  } nodeSerializer{builder, flags};
+
+  VPackArrayBuilder guard(&builder);
+  const_cast<ExecutionNode*>(this)->walk(nodeSerializer);
 }
 
 /// @brief execution Node clone utility to be called by derived classes
@@ -807,167 +811,146 @@ ExecutionNode const* ExecutionNode::getLoop() const {
   return nullptr;
 }
 
-/// @brief toVelocyPackHelper, for a generic node
-/// Note: The input nodes has to be an Array Element that is still Open.
-///       At the end of this function the current-nodes Object is OPEN and
-///       has to be closed. The initial caller of toVelocyPackHelper
-///       has to close the array.
-void ExecutionNode::toVelocyPackHelperGeneric(VPackBuilder& nodes, unsigned flags,
-                                              std::unordered_set<ExecutionNode const*>& seen) const {
-  TRI_ASSERT(nodes.isOpenArray());
-  // We are not allowed to call if this node is already seen.
-  TRI_ASSERT(seen.find(this) == seen.end());
-  size_t const n = _dependencies.size();
-  for (size_t i = 0; i < n; i++) {
-    ExecutionNode const* dep = _dependencies[i];
-    if (seen.find(dep) == seen.end()) {
-      // Only toVelocypack those that have not been seen
-      dep->toVelocyPackHelper(nodes, flags, seen);
-    }
-    // every dependency needs to be in this list!
-    TRI_ASSERT(seen.find(dep) != seen.end());
-  }
-  // If this assert triggers we have created a loop.
-  // There is a dependency path that leads back to this node
-  TRI_ASSERT(seen.find(this) == seen.end());
-  seen.emplace(this);
-  nodes.openObject();
-  nodes.add("type", VPackValue(getTypeString()));
+/// @brief serialize this ExecutionNode to VelocyPack
+/// Note: The builder has to be an Array Element that is still Open.
+void ExecutionNode::toVelocyPack(arangodb::velocypack::Builder& builder, unsigned flags) const {
+  TRI_ASSERT(builder.isOpenArray());
+  VPackObjectBuilder objectGuard(&builder);
+
+  builder.add("type", VPackValue(getTypeString()));
   if (flags & ExecutionNode::SERIALIZE_DETAILS) {
-    nodes.add("typeID", VPackValue(static_cast<int>(getType())));
+    builder.add("typeID", VPackValue(static_cast<int>(getType())));
   }
-  nodes.add(VPackValue("dependencies"));  // Open Key
   {
-    VPackArrayBuilder guard(&nodes);
+    VPackArrayBuilder guard(&builder, "dependencies");
     for (auto const& it : _dependencies) {
-      nodes.add(VPackValue(it->id().id()));
+      builder.add(VPackValue(it->id().id()));
     }
   }
-  nodes.add("id", VPackValue(id().id()));
+  builder.add("id", VPackValue(id().id()));
   if (flags & ExecutionNode::SERIALIZE_PARENTS) {
-    nodes.add(VPackValue("parents"));  // Open Key
-    VPackArrayBuilder guard(&nodes);
+    VPackArrayBuilder guard(&builder, "parents");
     for (auto const& it : _parents) {
-      nodes.add(VPackValue(it->id().id()));
+      builder.add(VPackValue(it->id().id()));
     }
   }
   if (flags & ExecutionNode::SERIALIZE_ESTIMATES) {
     CostEstimate estimate = getCost();
-    nodes.add("estimatedCost", VPackValue(estimate.estimatedCost));
-    nodes.add("estimatedNrItems", VPackValue(estimate.estimatedNrItems));
+    builder.add("estimatedCost", VPackValue(estimate.estimatedCost));
+    builder.add("estimatedNrItems", VPackValue(estimate.estimatedNrItems));
   }
 
   // SERIALIZE_REGISTER_INFORMATION => SERIALIZE_DETAILS
   TRI_ASSERT(!ExecutionNode::SERIALIZE_REGISTER_INFORMATION || ExecutionNode::SERIALIZE_DETAILS);
   if (flags & (ExecutionNode::SERIALIZE_DETAILS | ExecutionNode::SERIALIZE_REGISTER_INFORMATION)) {
-    nodes.add("depth", VPackValue(_depth));
+    builder.add("depth", VPackValue(_depth));
 
     if (_registerPlan) {
-      _registerPlan->toVelocyPack(nodes);
+      _registerPlan->toVelocyPack(builder);
     } else {
-      RegisterPlan::toVelocyPackEmpty(nodes);
+      RegisterPlan::toVelocyPackEmpty(builder);
     }
 
-    nodes.add(VPackValue("regsToClear"));
     {
-      VPackArrayBuilder guard(&nodes);
+      VPackArrayBuilder guard(&builder, "regsToClear");
       for (auto const& oneRegisterID : _regsToClear) {
         TRI_ASSERT(oneRegisterID.isRegularRegister());
-        nodes.add(VPackValue(oneRegisterID.value()));
+        builder.add(VPackValue(oneRegisterID.value()));
       }
     }
 
-    nodes.add(VPackValue("varsUsedLaterStack"));
+    builder.add(VPackValue("varsUsedLaterStack"));
     {
-      VPackArrayBuilder guard(&nodes);
+      VPackArrayBuilder guard(&builder);
       TRI_ASSERT(!_varsUsedLaterStack.empty());
       for (auto const& stackEntry : _varsUsedLaterStack) {
-        VPackArrayBuilder stackEntryGuard(&nodes);
+        VPackArrayBuilder stackEntryGuard(&builder);
         for (auto const& oneVar : stackEntry) {
-          oneVar->toVelocyPack(nodes);
+          oneVar->toVelocyPack(builder);
         }
       }
     }
 
-    nodes.add(VPackValue("regsToKeepStack"));
+    builder.add(VPackValue("regsToKeepStack"));
     {
-      VPackArrayBuilder guard(&nodes);
+      VPackArrayBuilder guard(&builder);
       for (auto const& stackEntry : getRegsToKeepStack()) {
-        VPackArrayBuilder stackEntryGuard(&nodes);
+        VPackArrayBuilder stackEntryGuard(&builder);
         for (auto const& reg : stackEntry) {
           TRI_ASSERT(reg.isRegularRegister());
-          nodes.add(VPackValue(reg.value()));
+          builder.add(VPackValue(reg.value()));
         }
       }
     }
 
-    nodes.add(VPackValue("varsValidStack"));
+    builder.add(VPackValue("varsValidStack"));
     {
-      VPackArrayBuilder guard(&nodes);
+      VPackArrayBuilder guard(&builder);
       TRI_ASSERT(!_varsValidStack.empty());
       for (auto const& stackEntry : _varsValidStack) {
-        VPackArrayBuilder stackEntryGuard(&nodes);
+        VPackArrayBuilder stackEntryGuard(&builder);
         for (auto const& oneVar : stackEntry) {
-          oneVar->toVelocyPack(nodes);
+          oneVar->toVelocyPack(builder);
         }
       }
     }
 
     if (flags & ExecutionNode::SERIALIZE_REGISTER_INFORMATION) {
-      nodes.add(VPackValue("unusedRegsStack"));
+      builder.add(VPackValue("unusedRegsStack"));
       auto const& unusedRegsStack = _registerPlan->unusedRegsByNode.at(id());
       {
-        VPackArrayBuilder guard(&nodes);
+        VPackArrayBuilder guard(&builder);
         TRI_ASSERT(!unusedRegsStack.empty());
         for (auto const& stackEntry : unusedRegsStack) {
-          VPackArrayBuilder stackEntryGuard(&nodes);
+          VPackArrayBuilder stackEntryGuard(&builder);
           for (auto const& reg : stackEntry) {
             TRI_ASSERT(reg.isRegularRegister());
-            nodes.add(VPackValue(reg.value()));
+            builder.add(VPackValue(reg.value()));
           }
         }
       }
 
-      nodes.add(VPackValue("regVarMapStack"));
+      builder.add(VPackValue("regVarMapStack"));
       auto const& regVarMapStack = _registerPlan->regVarMapStackByNode.at(id());
       {
-        VPackArrayBuilder guard(&nodes);
+        VPackArrayBuilder guard(&builder);
         TRI_ASSERT(!regVarMapStack.empty());
         for (auto const& stackEntry : regVarMapStack) {
-          VPackObjectBuilder stackEntryGuard(&nodes);
+          VPackObjectBuilder stackEntryGuard(&builder);
           for (auto const& reg : stackEntry) {
             using std::to_string;
-            nodes.add(VPackValue(to_string(reg.first.value())));
-            reg.second->toVelocyPack(nodes);
+            builder.add(VPackValue(to_string(reg.first.value())));
+            reg.second->toVelocyPack(builder);
           }
         }
       }
 
-      nodes.add(VPackValue("varsSetHere"));
+      builder.add(VPackValue("varsSetHere"));
       {
-        VPackArrayBuilder guard(&nodes);
+        VPackArrayBuilder guard(&builder);
         auto const& varsSetHere = getVariablesSetHere();
         for (auto const& oneVar : varsSetHere) {
-          oneVar->toVelocyPack(nodes);
+          oneVar->toVelocyPack(builder);
         }
       }
 
-      nodes.add(VPackValue("varsUsedHere"));
+      builder.add(VPackValue("varsUsedHere"));
       {
-        VPackArrayBuilder guard(&nodes);
+        VPackArrayBuilder guard(&builder);
         auto varsUsedHere = VarSet{};
         getVariablesUsedHere(varsUsedHere);
         for (auto const& oneVar : varsUsedHere) {
-          oneVar->toVelocyPack(nodes);
+          oneVar->toVelocyPack(builder);
         }
       }
     }
 
-    nodes.add("isInSplicedSubquery", VPackValue(_isInSplicedSubquery));
-    nodes.add("isAsyncPrefetchEnabled", VPackValue(_isAsyncPrefetchEnabled));
-    nodes.add("isCallstackSplitEnabled", VPackValue(_isCallstackSplitEnabled));
+    builder.add("isInSplicedSubquery", VPackValue(_isInSplicedSubquery));
+    builder.add("isAsyncPrefetchEnabled", VPackValue(_isAsyncPrefetchEnabled));
+    builder.add("isCallstackSplitEnabled", VPackValue(_isCallstackSplitEnabled));
   }
-  TRI_ASSERT(nodes.isOpenObject());
+  TRI_ASSERT(builder.isOpenObject());
+  doToVelocyPack(builder, flags);
 }
 
 /// @brief static analysis debugger
@@ -1521,13 +1504,9 @@ std::unique_ptr<ExecutionBlock> SingletonNode::createBlock(
   return res;
 }
 
-/// @brief toVelocyPack, for SingletonNode
-void SingletonNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                       std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
-  // This node has no own information.
-  nodes.close();
+/// @brief doToVelocyPack, for SingletonNode
+void SingletonNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
+  // nothing to do here!
 }
 
 /// @brief the cost of a singleton is 1, it produces one item only
@@ -1554,12 +1533,8 @@ EnumerateCollectionNode::EnumerateCollectionNode(ExecutionPlan* plan,
       _random(base.get("random").getBoolean()),
       _hint(base) {}
 
-/// @brief toVelocyPack, for EnumerateCollectionNode
-void EnumerateCollectionNode::toVelocyPackHelper(VPackBuilder& builder, unsigned flags,
-                                                 std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(builder, flags, seen);
-
+/// @brief doToVelocyPack, for EnumerateCollectionNode
+void EnumerateCollectionNode::doToVelocyPack(VPackBuilder& builder, unsigned flags) const {
   builder.add("random", VPackValue(_random));
 
   _hint.toVelocyPack(builder);
@@ -1569,9 +1544,6 @@ void EnumerateCollectionNode::toVelocyPackHelper(VPackBuilder& builder, unsigned
 
   // add collection information
   CollectionAccessingNode::toVelocyPack(builder, flags);
-
-  // And close it:
-  builder.close();
 }
 
 /// @brief creates corresponding ExecutionBlock
@@ -1658,19 +1630,13 @@ EnumerateListNode::EnumerateListNode(ExecutionPlan* plan,
       _inVariable(Variable::varFromVPack(plan->getAst(), base, "inVariable")),
       _outVariable(Variable::varFromVPack(plan->getAst(), base, "outVariable")) {}
 
-/// @brief toVelocyPack, for EnumerateListNode
-void EnumerateListNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                           std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
+/// @brief doToVelocyPack, for EnumerateListNode
+void EnumerateListNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   nodes.add(VPackValue("inVariable"));
   _inVariable->toVelocyPack(nodes);
 
   nodes.add(VPackValue("outVariable"));
   _outVariable->toVelocyPack(nodes);
-
-  // And close it:
-  nodes.close();
 }
 
 /// @brief creates corresponding ExecutionBlock
@@ -1806,17 +1772,11 @@ std::unique_ptr<ExecutionBlock> LimitNode::createBlock(
                                                              std::move(executorInfos));
 }
 
-// @brief toVelocyPack, for LimitNode
-void LimitNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                   std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
+// @brief doToVelocyPack, for LimitNode
+void LimitNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   nodes.add("offset", VPackValue(_offset));
   nodes.add("limit", VPackValue(_limit));
   nodes.add("fullCount", VPackValue(_fullCount));
-
-  // And close it:
-  nodes.close();
 }
 
 /// @brief estimateCost
@@ -1881,11 +1841,8 @@ CalculationNode::CalculationNode(ExecutionPlan* plan, ExecutionNodeId id,
 
 CalculationNode::~CalculationNode() = default;
 
-/// @brief toVelocyPack, for CalculationNode
-void CalculationNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                         std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
+/// @brief doToVelocyPack, for CalculationNode
+void CalculationNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   nodes.add(VPackValue("expression"));
   _expression->toVelocyPack(nodes, flags);
 
@@ -1943,9 +1900,6 @@ void CalculationNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
       nodes.close();
     }
   }
-
-  // And close it
-  nodes.close();
 }
 
 /// @brief creates corresponding ExecutionBlock
@@ -2077,21 +2031,10 @@ SubqueryNode::SubqueryNode(ExecutionPlan* plan, arangodb::velocypack::Slice cons
       _subquery(nullptr),
       _outVariable(Variable::varFromVPack(plan->getAst(), base, "outVariable")) {}
 
-/// @brief toVelocyPack, for SubqueryNode
-void SubqueryNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                      std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
-
-  nodes.add(VPackValue("subquery"));
-  _subquery->toVelocyPack(nodes, flags, /*keepTopLevelOpen*/ false);
-  nodes.add(VPackValue("outVariable"));
-  _outVariable->toVelocyPack(nodes);
-
-  nodes.add("isConst", VPackValue(const_cast<SubqueryNode*>(this)->isConst()));
-
-  // And add it:
-  nodes.close();
+/// @brief doToVelocyPack, for SubqueryNode
+void SubqueryNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
+  // since we have spliced subqueries this should never be called!
+  TRI_ASSERT(false);
 }
 
 /// @brief invalidate the cost estimation for the node and its dependencies
@@ -2335,17 +2278,10 @@ FilterNode::FilterNode(ExecutionPlan* plan, arangodb::velocypack::Slice const& b
     : ExecutionNode(plan, base),
       _inVariable(Variable::varFromVPack(plan->getAst(), base, "inVariable")) {}
 
-/// @brief toVelocyPack, for FilterNode
-void FilterNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                    std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
-
+/// @brief doToVelocyPack, for FilterNode
+void FilterNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   nodes.add(VPackValue("inVariable"));
   _inVariable->toVelocyPack(nodes);
-
-  // And close it:
-  nodes.close();
 }
 
 /// @brief creates corresponding ExecutionBlock
@@ -2416,18 +2352,11 @@ ReturnNode::ReturnNode(ExecutionPlan* plan, arangodb::velocypack::Slice const& b
       _inVariable(Variable::varFromVPack(plan->getAst(), base, "inVariable")),
       _count(VelocyPackHelper::getBooleanValue(base, "count", false)) {}
 
-/// @brief toVelocyPack, for ReturnNode
-void ReturnNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                    std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
-
+/// @brief doToVelocyPack, for ReturnNode
+void ReturnNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   nodes.add(VPackValue("inVariable"));
   _inVariable->toVelocyPack(nodes);
   nodes.add("count", VPackValue(_count));
-
-  // And close it:
-  nodes.close();
 }
 
 /// @brief creates corresponding ExecutionBlock
@@ -2522,14 +2451,9 @@ Variable const* ReturnNode::inVariable() const { return _inVariable; }
 
 void ReturnNode::inVariable(Variable const* v) { _inVariable = v; }
 
-/// @brief toVelocyPack, for NoResultsNode
-void NoResultsNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                       std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
-
-  // And close it
-  nodes.close();
+/// @brief doToVelocyPack, for NoResultsNode
+void NoResultsNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
+  // nothing to do here!
 }
 
 /// @brief creates corresponding ExecutionBlock
@@ -2635,14 +2559,9 @@ SortInformation::Match SortInformation::isCoveredBy(SortInformation const& other
   return allEqual;
 }
 
-/// @brief toVelocyPack, for AsyncNode
-void AsyncNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                   std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
-
-  // And close it
-  nodes.close();
+/// @brief doToVelocyPack, for AsyncNode
+void AsyncNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
+  // nothing to do here!
 }
 
 /// @brief creates corresponding ExecutionBlock
@@ -2703,11 +2622,7 @@ MaterializeNode::MaterializeNode(ExecutionPlan* plan, arangodb::velocypack::Slic
       _outVariable(aql::Variable::varFromVPack(plan->getAst(), base,
                                                MATERIALIZE_NODE_OUT_VARIABLE_PARAM)) {}
 
-void MaterializeNode::toVelocyPackHelper(arangodb::velocypack::Builder& nodes, unsigned flags,
-                                         std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  aql::ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
-
+void MaterializeNode::doToVelocyPack(arangodb::velocypack::Builder& nodes, unsigned flags) const {
   nodes.add(VPackValue(MATERIALIZE_NODE_IN_NM_DOC_PARAM));
   _inNonMaterializedDocId->toVelocyPack(nodes);
 
@@ -2748,16 +2663,12 @@ MaterializeMultiNode::MaterializeMultiNode(ExecutionPlan* plan,
       _inNonMaterializedColPtr(aql::Variable::varFromVPack(plan->getAst(), base, MATERIALIZE_NODE_IN_NM_COL_PARAM,
                                                            true)) {}
 
-void MaterializeMultiNode::toVelocyPackHelper(arangodb::velocypack::Builder& nodes,
-                                              unsigned flags,
-                                              std::unordered_set<ExecutionNode const*>& seen) const {
+void MaterializeMultiNode::doToVelocyPack(arangodb::velocypack::Builder& nodes, unsigned flags) const {
   // call base class method
-  MaterializeNode::toVelocyPackHelper(nodes, flags, seen);
+  MaterializeNode::doToVelocyPack(nodes, flags);
 
   nodes.add(VPackValue(MATERIALIZE_NODE_IN_NM_COL_PARAM));
   _inNonMaterializedColPtr->toVelocyPack(nodes);
-
-  nodes.close();
 }
 
 std::unique_ptr<ExecutionBlock> MaterializeMultiNode::createBlock(
@@ -2837,16 +2748,12 @@ MaterializeSingleNode::MaterializeSingleNode(ExecutionPlan* plan,
                                              arangodb::velocypack::Slice const& base)
     : MaterializeNode(plan, base), CollectionAccessingNode(plan, base) {}
 
-void MaterializeSingleNode::toVelocyPackHelper(arangodb::velocypack::Builder& nodes,
-                                               unsigned flags,
-                                               std::unordered_set<ExecutionNode const*>& seen) const {
+void MaterializeSingleNode::doToVelocyPack(arangodb::velocypack::Builder& nodes, unsigned flags) const {
   // call base class method
-  MaterializeNode::toVelocyPackHelper(nodes, flags, seen);
+  MaterializeNode::doToVelocyPack(nodes, flags);
 
   // add collection information
   CollectionAccessingNode::toVelocyPack(nodes, flags);
-
-  nodes.close();
 }
 
 std::unique_ptr<ExecutionBlock> MaterializeSingleNode::createBlock(

--- a/arangod/Aql/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode.h
@@ -369,6 +369,9 @@ class ExecutionNode {
   /// include addition information of the register plan for explain
   static constexpr unsigned SERIALIZE_REGISTER_INFORMATION = 1 << 4;
 
+  /// @brief serialize this ExecutionNode to VelocyPack
+  void toVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const;
+
   /// @brief exports this ExecutionNode with all its dependencies to VelocyPack.
   /// This function implicitly creates an array and serializes all nodes top-down,
   /// i.e., the upmost dependency will be the first, and this node will be the last
@@ -486,9 +489,6 @@ class ExecutionNode {
   auto getRegsToKeepStack() const -> RegIdSetStack;
 
  protected:
-  /// @brief serialize this ExecutionNode to VelocyPack
-  void toVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const;
-
   /// @brief serialize this ExecutionNode to VelocyPack.
   /// This function is called as part of `toVelocyPack` and must be overriden in
   /// order to serialize type specific information.

--- a/arangod/Aql/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode.h
@@ -574,6 +574,9 @@ class ExecutionNode {
  public:
   /// @brief used as "type traits" for ExecutionNodes and derived classes
   static constexpr bool IsExecutionNode = true;
+
+private:
+  bool doWalk(WalkerWorkerBase<ExecutionNode>& worker, bool subQueryFirst);
 };
 
 /// @brief class SingletonNode

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -499,10 +499,12 @@ void ExecutionPlan::toVelocyPack(VPackBuilder& builder, Ast* ast, bool verbose,
   if (explainRegisterPlan == ExplainRegisterPlan::Yes) {
     flags |= ExecutionNode::SERIALIZE_REGISTER_INFORMATION;
   }
-  // keeps top level of built object open
-  _root->toVelocyPack(builder, flags, true);
+  builder.openObject();
+  builder.add(VPackValue("nodes"));
 
-  TRI_ASSERT(!builder.isClosed());
+  _root->allToVelocyPack(builder, flags);
+
+  TRI_ASSERT(builder.isOpenObject());
 
   // set up rules
   builder.add(VPackValue("rules"));

--- a/arangod/Aql/GraphNode.cpp
+++ b/arangod/Aql/GraphNode.cpp
@@ -514,11 +514,7 @@ std::string const& GraphNode::collectionToShardName(std::string const& collName)
   return found->second;
 }
 
-void GraphNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                   std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
-
+void GraphNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   // Vocbase
   nodes.add("database", VPackValue(_vocbase->name()));
 

--- a/arangod/Aql/GraphNode.h
+++ b/arangod/Aql/GraphNode.h
@@ -110,9 +110,6 @@ class GraphNode : public ExecutionNode {
  public:
   ~GraphNode() override = default;
 
-  void toVelocyPackHelper(arangodb::velocypack::Builder& nodes, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override;
-
   /// @brief the cost of a graph node
   CostEstimate estimateCost() const override;
 
@@ -198,8 +195,10 @@ class GraphNode : public ExecutionNode {
     _collectionToShard[coll] = shard;
   }
 
- public:
   graph::Graph const* graph() const noexcept;
+
+ protected:  
+  void doToVelocyPack(arangodb::velocypack::Builder& nodes, unsigned flags) const override;
 
  private:
   void addEdgeCollection(aql::Collections const& collections, std::string const& name, TRI_edge_direction_e dir);

--- a/arangod/Aql/IResearchViewNode.cpp
+++ b/arangod/Aql/IResearchViewNode.cpp
@@ -1162,12 +1162,8 @@ std::pair<bool, bool> IResearchViewNode::volatility(bool force /*=false*/) const
                         irs::check_bit<1>(_volatilityMask));  // sort
 }
 
-/// @brief toVelocyPack, for EnumerateViewNode
-void IResearchViewNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                           std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  aql::ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
-
+/// @brief doToVelocyPack, for EnumerateViewNode
+void IResearchViewNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   // system info
   nodes.add(NODE_DATABASE_PARAM, VPackValue(_vocbase.name()));
   // need 'view' field to correctly print view name in JS explanation
@@ -1264,8 +1260,6 @@ void IResearchViewNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
     }
     nodes.add(NODE_PRIMARY_SORT_BUCKETS_PARAM, VPackValue(_sort.second));
   }
-
-  nodes.close();
 }
 
 std::vector<std::reference_wrapper<aql::Collection const>> IResearchViewNode::collections() const {

--- a/arangod/Aql/IResearchViewNode.h
+++ b/arangod/Aql/IResearchViewNode.h
@@ -102,10 +102,6 @@ class IResearchViewNode final : public arangodb::aql::ExecutionNode {
   /// @brief return the type of the node
   NodeType getType() const override final { return ENUMERATE_IRESEARCH_VIEW; }
 
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
-
   /// @brief clone ExecutionNode recursively
   aql::ExecutionNode* clone(aql::ExecutionPlan* plan, bool withDependencies,
                             bool withProperties) const override final;
@@ -270,6 +266,9 @@ class IResearchViewNode final : public arangodb::aql::ExecutionNode {
 
   OptimizationState& state() noexcept { return _optState; }
 
+ protected:
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned) const override final;
 
  private:
   /// @brief the database

--- a/arangod/Aql/IndexNode.cpp
+++ b/arangod/Aql/IndexNode.cpp
@@ -185,12 +185,8 @@ void IndexNode::setProjections(arangodb::aql::Projections projections) {
   dn->projections().determineIndexSupport(this->collection()->id(), _indexes);
 }
 
-/// @brief toVelocyPack, for IndexNode
-void IndexNode::toVelocyPackHelper(VPackBuilder& builder, unsigned flags,
-                                   std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(builder, flags, seen);
-
+/// @brief doToVelocyPack, for IndexNode
+void IndexNode::doToVelocyPack(VPackBuilder& builder, unsigned flags) const {
   // add outvariable and projections
   DocumentProducingNode::toVelocyPack(builder, flags);
 
@@ -240,9 +236,6 @@ void IndexNode::toVelocyPackHelper(VPackBuilder& builder, unsigned flags,
       builder.add("field", VPackValue(fieldName));  // for explainer.js
     }
   }
-
-  // And close it:
-  builder.close();
 }
 
 /// @brief adds a UNIQUE() to a dynamic IN condition

--- a/arangod/Aql/IndexNode.h
+++ b/arangod/Aql/IndexNode.h
@@ -91,10 +91,6 @@ class IndexNode : public ExecutionNode, public DocumentProducingNode, public Col
   bool needsGatherNodeSort() const;
   void needsGatherNodeSort(bool value);
 
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
-
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
       ExecutionEngine& engine,
@@ -142,6 +138,10 @@ class IndexNode : public ExecutionNode, public DocumentProducingNode, public Col
                            IndexVarsInfo const& indexVariables);
 
   void setProjections(arangodb::aql::Projections projections);
+
+ protected:
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override final;
 
  private:
   void initializeOnce(bool& hasV8Expression, std::vector<Variable const*>& inVars,

--- a/arangod/Aql/KShortestPathsNode.cpp
+++ b/arangod/Aql/KShortestPathsNode.cpp
@@ -269,10 +269,8 @@ void KShortestPathsNode::setStartInVariable(Variable const* inVariable) {
   _startVertexId = "";
 }
 
-void KShortestPathsNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                            std::unordered_set<ExecutionNode const*>& seen) const {
-  GraphNode::toVelocyPackHelper(nodes, flags, seen);  // call base class method
-
+void KShortestPathsNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
+  GraphNode::doToVelocyPack(nodes, flags);  // call base class method
   nodes.add(StaticStrings::GraphQueryShortestPathType,
             VPackValue(arangodb::graph::ShortestPathType::toString(_shortestPathType)));
 
@@ -305,9 +303,6 @@ void KShortestPathsNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
   TRI_ASSERT(_toCondition != nullptr);
   nodes.add(VPackValue("toCondition"));
   _toCondition->toVelocyPack(nodes, flags);
-
-  // And close it:
-  nodes.close();
 }
 
 /// @brief creates corresponding ExecutionBlock

--- a/arangod/Aql/KShortestPathsNode.h
+++ b/arangod/Aql/KShortestPathsNode.h
@@ -80,10 +80,6 @@ class KShortestPathsNode : public virtual GraphNode {
   /// @brief return the type of the node
   NodeType getType() const override final { return K_SHORTEST_PATHS; }
 
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
-
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
       ExecutionEngine& engine,
@@ -150,6 +146,10 @@ class KShortestPathsNode : public virtual GraphNode {
   /// @brief Overrides GraphNode::options() with a more specific return type
   ///  (casts graph::BaseOptions* into graph::ShortestPathOptions*)
   auto options() const -> graph::ShortestPathOptions*;
+
+ protected:
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override final;
 
  private:
   void kShortestPathsCloneHelper(ExecutionPlan& plan, KShortestPathsNode& c,

--- a/arangod/Aql/ModificationNodes.h
+++ b/arangod/Aql/ModificationNodes.h
@@ -59,10 +59,6 @@ class ModificationNode : public ExecutionNode, public CollectionAccessingNode {
 
   ModificationNode(ExecutionPlan*, arangodb::velocypack::Slice const& slice);
 
-  /// @brief export to VelocyPack
-  virtual void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                                  std::unordered_set<ExecutionNode const*>& seen) const override;
-
  public:
   /// @brief estimateCost
   /// Note that all the modifying nodes use this estimateCost method which is
@@ -128,6 +124,9 @@ class ModificationNode : public ExecutionNode, public CollectionAccessingNode {
   void disableStatistics() { _countStats = false; }
 
  protected:
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override;
+
   void cloneCommon(ModificationNode*) const;
 
  protected:
@@ -167,10 +166,6 @@ class RemoveNode : public ModificationNode {
   /// @brief return the type of the node
   NodeType getType() const override final { return REMOVE; }
 
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
-
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
       ExecutionEngine& engine,
@@ -190,6 +185,10 @@ class RemoveNode : public ModificationNode {
   void setInVariable(Variable const* var) { _inVariable = var; }
 
   Variable const* inVariable() const { return _inVariable; }
+
+ protected:
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override final;
 
  private:
   /// @brief input variable
@@ -216,10 +215,6 @@ class InsertNode : public ModificationNode {
   /// @brief return the type of the node
   NodeType getType() const override final { return INSERT; }
 
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
-
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
       ExecutionEngine& engine,
@@ -239,6 +234,10 @@ class InsertNode : public ModificationNode {
   Variable const* inVariable() const { return _inVariable; }
 
   void setInVariable(Variable const* var) { _inVariable = var; }
+
+ protected:
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override final;
 
  private:
   /// @brief input variable
@@ -263,10 +262,6 @@ class UpdateReplaceNode : public ModificationNode {
 
   UpdateReplaceNode(ExecutionPlan*, arangodb::velocypack::Slice const&);
 
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override;
-
   /// @brief getVariablesUsedHere, modifying the set in-place
   void getVariablesUsedHere(VarSet& vars) const override final {
     vars.emplace(_inDocVariable);
@@ -289,6 +284,9 @@ class UpdateReplaceNode : public ModificationNode {
   Variable const* inDocVariable() const { return _inDocVariable; }
 
  protected:
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override;
+
   /// @brief input variable for documents
   Variable const* _inDocVariable;
 
@@ -314,10 +312,6 @@ class UpdateNode : public UpdateReplaceNode {
 
   /// @brief return the type of the node
   NodeType getType() const override final { return UPDATE; }
-
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
@@ -347,10 +341,6 @@ class ReplaceNode : public UpdateReplaceNode {
 
   /// @brief return the type of the node
   NodeType getType() const override final { return REPLACE; }
-
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
@@ -390,10 +380,6 @@ class UpsertNode : public ModificationNode {
   /// @brief return the type of the node
   NodeType getType() const override final { return UPSERT; }
 
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
-
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
       ExecutionEngine& engine,
@@ -423,6 +409,10 @@ class UpsertNode : public ModificationNode {
   void setUpdateVariable(Variable const* var) { _updateVariable = var; }
 
   void setIsReplace(bool var) { _isReplace = var; }
+
+ protected:
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override final;
 
  private:
   /// @brief input variable for the search document

--- a/arangod/Aql/MutexNode.cpp
+++ b/arangod/Aql/MutexNode.cpp
@@ -56,21 +56,12 @@ ExecutionNode* MutexNode::clone(ExecutionPlan* plan, bool withDependencies,
                      withDependencies, withProperties);
 }
 
-/// @brief toVelocyPack, for MutexNode
-void MutexNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                   std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
-  
-  {
-    VPackArrayBuilder arrayScope(&nodes, "clients");
-    for (auto const& client : _clients) {
-      nodes.add(VPackValue(client));
-    }
+/// @brief doToVelocyPack, for MutexNode
+void MutexNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
+  VPackArrayBuilder arrayScope(&nodes, "clients");
+  for (auto const& client : _clients) {
+    nodes.add(VPackValue(client));
   }
-
-  // And close it
-  nodes.close();
 }
 
 /// @brief creates corresponding ExecutionBlock

--- a/arangod/Aql/MutexNode.h
+++ b/arangod/Aql/MutexNode.h
@@ -43,10 +43,6 @@ class MutexNode : public ExecutionNode {
   /// @brief return the type of the node
   NodeType getType() const override final;
 
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
-
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
       ExecutionEngine& engine,
@@ -60,7 +56,11 @@ class MutexNode : public ExecutionNode {
   CostEstimate estimateCost() const override final;
 
   void addClient(DistributeConsumerNode const* client);
-  
+
+ protected:
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override final;
+
  private:
   std::vector<std::string> _clients;
 };

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -4207,7 +4207,7 @@ void arangodb::aql::collectInClusterRule(Optimizer* opt, std::unique_ptr<Executi
 
       bool eligible = true;
       for (auto const& it : current->getVariablesSetHere()) {
-        if (std::find(used.begin(), used.end(), it) != used.end()) {
+        if (used.contains(it)) {
           eligible = false;
           break;
         }

--- a/arangod/Aql/QuerySnippet.cpp
+++ b/arangod/Aql/QuerySnippet.cpp
@@ -506,8 +506,12 @@ void QuerySnippet::serializeIntoBuilder(
       cloneWorker.process();
     }
 
-    const unsigned flags = ExecutionNode::SERIALIZE_DETAILS;
-    internalGather->toVelocyPack(infoBuilder, flags, false);
+    {
+      VPackObjectBuilder guard(&infoBuilder);
+      infoBuilder.add(VPackValue("nodes"));
+      const unsigned flags = ExecutionNode::SERIALIZE_DETAILS;
+      internalGather->allToVelocyPack(infoBuilder, flags);
+    }
 
     // Clean up plan for next run
     //
@@ -532,8 +536,10 @@ void QuerySnippet::serializeIntoBuilder(
       TRI_ASSERT(remoteParent->getDependencies()[0] == _remoteNode);
     }
   } else {
+    VPackObjectBuilder guard(&infoBuilder);
+    infoBuilder.add(VPackValue("nodes"));
     const unsigned flags = ExecutionNode::SERIALIZE_DETAILS;
-    _nodes.front()->toVelocyPack(infoBuilder, flags, false);
+    _nodes.front()->allToVelocyPack(infoBuilder, flags);
   }
 
   if (_remoteNode != nullptr) {

--- a/arangod/Aql/RegisterPlan.cpp
+++ b/arangod/Aql/RegisterPlan.cpp
@@ -139,8 +139,7 @@ void RegisterPlanWalkerT<T>::after(T* en) {
              varsSetHere.end();
     };
     auto isUsedLater = [&](Variable const* var) {
-      return std::find(varsUsedLater.begin(), varsUsedLater.end(), var) !=
-             varsUsedLater.end();
+      return varsUsedLater.contains(var);
     };
 
     // items are pushed for each SubqueryStartNode and popped for
@@ -562,8 +561,7 @@ auto RegisterPlanT<T>::calcRegsToKeep(VarSetStack const& varsUsedLaterStack,
       auto reg = variableToRegisterId(var);
       TRI_ASSERT(reg.isRegularRegister());
 
-      bool isUsedLater = std::find(varsUsedLater.begin(), varsUsedLater.end(), var) !=
-                         varsUsedLater.end();
+      bool isUsedLater = varsUsedLater.contains(var);
       if (isUsedLater) {
         bool isSetHere = std::find(varsSetHere.begin(), varsSetHere.end(), var) !=
                          varsSetHere.end();

--- a/arangod/Aql/ShortestPathNode.cpp
+++ b/arangod/Aql/ShortestPathNode.cpp
@@ -218,9 +218,8 @@ void ShortestPathNode::setStartInVariable(Variable const* inVariable) {
   _startVertexId = "";
 }
 
-void ShortestPathNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                          std::unordered_set<ExecutionNode const*>& seen) const {
-  GraphNode::toVelocyPackHelper(nodes, flags, seen);  // call base class method
+void ShortestPathNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
+  GraphNode::doToVelocyPack(nodes, flags);  // call base class method
   // In variables
   if (usesStartInVariable()) {
     nodes.add(VPackValue("startInVariable"));
@@ -244,9 +243,6 @@ void ShortestPathNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
   TRI_ASSERT(_toCondition != nullptr);
   nodes.add(VPackValue("toCondition"));
   _toCondition->toVelocyPack(nodes, flags);
-
-  // And close it:
-  nodes.close();
 }
 
 /// @brief creates corresponding ExecutionBlock

--- a/arangod/Aql/ShortestPathNode.h
+++ b/arangod/Aql/ShortestPathNode.h
@@ -73,10 +73,6 @@ class ShortestPathNode : public virtual GraphNode {
   /// @brief return the type of the node
   NodeType getType() const override final { return SHORTEST_PATH; }
 
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
-
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
       ExecutionEngine& engine,
@@ -120,6 +116,10 @@ class ShortestPathNode : public virtual GraphNode {
   /// @brief Overrides GraphNode::options() with a more specific return type
   ///  (casts graph::BaseOptions* into graph::ShortestPathOptions*)
   auto options() const -> graph::ShortestPathOptions*;
+
+ protected:
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override final;
 
  private:
   void shortestPathCloneHelper(ExecutionPlan& plan, ShortestPathNode& c,

--- a/arangod/Aql/SortNode.cpp
+++ b/arangod/Aql/SortNode.cpp
@@ -67,12 +67,8 @@ SortNode::SortNode(ExecutionPlan* plan, arangodb::velocypack::Slice const& base,
       _stable(stable),
       _limit(VelocyPackHelper::getNumericValue<size_t>(base, "limit", 0)) {}
 
-/// @brief toVelocyPack, for SortNode
-void SortNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                  std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
-
+/// @brief doToVelocyPack, for SortNode
+void SortNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   nodes.add(VPackValue("elements"));
   {
     VPackArrayBuilder guard(&nodes);
@@ -93,9 +89,6 @@ void SortNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
   nodes.add("stable", VPackValue(_stable));
   nodes.add("limit", VPackValue(_limit));
   nodes.add("strategy", VPackValue(sorterTypeName(sorterType())));
-
-  // And close it:
-  nodes.close();
 }
 
 class SortNodeFindMyExpressions

--- a/arangod/Aql/SortNode.h
+++ b/arangod/Aql/SortNode.h
@@ -72,10 +72,6 @@ class SortNode : public ExecutionNode {
   /// @brief whether or not the sort is stable
   inline bool isStable() const { return _stable; }
 
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
-
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
       ExecutionEngine& engine,
@@ -127,6 +123,10 @@ class SortNode : public ExecutionNode {
   /// this node is left in plan only in sake of GatherNode 
   /// to properly handle merging.
   bool _reinsertInCluster;
+
+ protected:
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override final;
 
  private:
   /// @brief pairs, consisting of variable and sort direction

--- a/arangod/Aql/SubqueryEndExecutionNode.cpp
+++ b/arangod/Aql/SubqueryEndExecutionNode.cpp
@@ -65,10 +65,7 @@ SubqueryEndNode::SubqueryEndNode(ExecutionPlan* plan, ExecutionNodeId id,
   TRI_ASSERT(_outVariable != nullptr);
 }
 
-void SubqueryEndNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                         std::unordered_set<ExecutionNode const*>& seen) const {
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
-
+void SubqueryEndNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   nodes.add(VPackValue("outVariable"));
   _outVariable->toVelocyPack(nodes);
 
@@ -76,8 +73,6 @@ void SubqueryEndNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
     nodes.add(VPackValue("inVariable"));
     _inVariable->toVelocyPack(nodes);
   }
-
-  nodes.close();
 }
 
 std::unique_ptr<ExecutionBlock> SubqueryEndNode::createBlock(

--- a/arangod/Aql/SubqueryEndExecutionNode.h
+++ b/arangod/Aql/SubqueryEndExecutionNode.h
@@ -47,9 +47,6 @@ class SubqueryEndNode : public ExecutionNode {
 
   Variable const* outVariable() const { return _outVariable; }
 
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
-
   std::unique_ptr<ExecutionBlock> createBlock(
       ExecutionEngine& engine,
       std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const override;
@@ -75,6 +72,9 @@ class SubqueryEndNode : public ExecutionNode {
   // noone should ever ask this node whether it is a modification
   // node
   bool isModificationNode() const override;
+
+ protected:
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override final;
 
  private:
   Variable const* _inVariable;

--- a/arangod/Aql/SubqueryStartExecutionNode.cpp
+++ b/arangod/Aql/SubqueryStartExecutionNode.cpp
@@ -60,15 +60,12 @@ CostEstimate SubqueryStartNode::estimateCost() const {
   return estimate;
 }
 
-void SubqueryStartNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                           std::unordered_set<ExecutionNode const*>& seen) const {
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
+void SubqueryStartNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   // We need this for the Explainer
   if (_subqueryOutVariable != nullptr) {
     nodes.add(VPackValue("subqueryOutVariable"));
     _subqueryOutVariable->toVelocyPack(nodes);
   }
-  nodes.close();
 }
 
 std::unique_ptr<ExecutionBlock> SubqueryStartNode::createBlock(

--- a/arangod/Aql/SubqueryStartExecutionNode.h
+++ b/arangod/Aql/SubqueryStartExecutionNode.h
@@ -45,9 +45,6 @@ class SubqueryStartNode : public ExecutionNode {
 
   NodeType getType() const override final { return SUBQUERY_START; }
 
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
-
   std::unique_ptr<ExecutionBlock> createBlock(
       ExecutionEngine& engine,
       std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const override;
@@ -56,6 +53,9 @@ class SubqueryStartNode : public ExecutionNode {
                        bool withProperties) const override final;
 
   bool isEqualTo(ExecutionNode const& other) const override final;
+
+ protected:
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override final;
 
  private:
   /// @brief This is only required for Explain output.

--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -426,10 +426,9 @@ bool TraversalNode::allDirectionsEqual() const {
   return true;
 }
 
-void TraversalNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                       std::unordered_set<ExecutionNode const*>& seen) const {
+void TraversalNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   // call base class method
-  GraphNode::toVelocyPackHelper(nodes, flags, seen);
+  GraphNode::doToVelocyPack(nodes, flags);
   // In variable
   if (usesInVariable()) {
     nodes.add(VPackValue("inVariable"));
@@ -535,9 +534,6 @@ void TraversalNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
       }
     }
   }
-
-  // And close it:
-  nodes.close();
 }
 
 /// @brief creates corresponding ExecutionBlock

--- a/arangod/Aql/TraversalNode.h
+++ b/arangod/Aql/TraversalNode.h
@@ -106,10 +106,6 @@ class TraversalNode : public virtual GraphNode {
   /// @brief return the type of the node
   NodeType getType() const override final { return TRAVERSAL; }
 
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
-
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
       ExecutionEngine& engine,
@@ -200,6 +196,10 @@ class TraversalNode : public virtual GraphNode {
   /// @brief Overrides GraphNode::options() with a more specific return type
   ///  (casts graph::BaseOptions* into traverser::TraverserOptions*)
   auto options() const -> traverser::TraverserOptions*;
+
+ protected:
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override final;
 
  private:
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE

--- a/arangod/Aql/WindowNode.cpp
+++ b/arangod/Aql/WindowNode.cpp
@@ -329,12 +329,8 @@ WindowNode::WindowNode(ExecutionPlan* plan, arangodb::velocypack::Slice const& b
 
 WindowNode::~WindowNode() = default;
 
-/// @brief toVelocyPack, for CollectNode
-void WindowNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
-                                    std::unordered_set<ExecutionNode const*>& seen) const {
-  // call base class method
-  ExecutionNode::toVelocyPackHelperGeneric(nodes, flags, seen);
-
+/// @brief doToVelocyPack, for CollectNode
+void WindowNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   if (_rangeVariable) {
     nodes.add(VPackValue("rangeVariable"));
     _rangeVariable->toVelocyPack(nodes);
@@ -355,9 +351,6 @@ void WindowNode::toVelocyPackHelper(VPackBuilder& nodes, unsigned flags,
   }
 
   _bounds.toVelocyPack(nodes);
-
-  // And close it:
-  nodes.close();
 }
 
 void WindowNode::calcAggregateRegisters(std::vector<std::pair<RegisterId, RegisterId>>& aggregateRegisters,

--- a/arangod/Aql/WindowNode.h
+++ b/arangod/Aql/WindowNode.h
@@ -113,10 +113,6 @@ class WindowNode : public ExecutionNode {
   /// @brief return the type of the node
   NodeType getType() const override final;
 
-  /// @brief export to VelocyPack
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override final;
-
   /// @brief calculate the aggregate registers
   void calcAggregateRegisters(std::vector<std::pair<RegisterId, RegisterId>>& aggregateRegisters,
                               RegIdSet& readableInputRegisters,
@@ -148,6 +144,10 @@ class WindowNode : public ExecutionNode {
 
   // does this WINDOW need to look at rows following the current one
   bool needsFollowingRows() const;
+
+ protected:
+  /// @brief export to VelocyPack
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override final;
 
  private:
   WindowBounds _bounds;

--- a/tests/Aql/ExecutionNodeTest.cpp
+++ b/tests/Aql/ExecutionNodeTest.cpp
@@ -58,19 +58,14 @@ TEST_F(ExecutionNodeTest, start_node_velocypack_roundtrip) {
   VPackBuilder builder;
 
   std::unique_ptr<SubqueryStartNode> node, nodeFromVPack;
-  std::unordered_set<ExecutionNode const*> seen{};
 
   node = std::make_unique<SubqueryStartNode>(&plan, ExecutionNodeId{0}, nullptr);
   node->setVarsUsedLater({{}});
   node->setVarsValid({{}});
   node->setRegsToKeep({{}});
 
-  builder.openArray();
-  node->toVelocyPackHelper(builder, ExecutionNode::SERIALIZE_DETAILS, seen);
-  builder.close();
-  EXPECT_NE(seen.find(node.get()), seen.end())
-      << "The node has not been added into the seen list";
-
+  node->allToVelocyPack(builder, ExecutionNode::SERIALIZE_DETAILS);
+  
   nodeFromVPack = std::make_unique<SubqueryStartNode>(&plan, builder.slice()[0]);
 
   ASSERT_TRUE(node->isEqualTo(*nodeFromVPack));
@@ -91,19 +86,13 @@ TEST_F(ExecutionNodeTest, end_node_velocypack_roundtrip_no_invariable) {
   Variable outvar("name", 1, false);
 
   std::unique_ptr<SubqueryEndNode> node, nodeFromVPack;
-  std::unordered_set<ExecutionNode const*> seen{};
 
   node = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{0}, nullptr, &outvar);
   node->setVarsUsedLater({{}});
   node->setVarsValid({{}});
   node->setRegsToKeep({{}});
 
-  builder.openArray();
-  node->toVelocyPackHelper(builder, ExecutionNode::SERIALIZE_DETAILS, seen);
-  builder.close();
-
-  EXPECT_NE(seen.find(node.get()), seen.end())
-      << "The node has not been added into the seen list";
+  node->allToVelocyPack(builder, ExecutionNode::SERIALIZE_DETAILS);
 
   nodeFromVPack = std::make_unique<SubqueryEndNode>(&plan, builder.slice()[0]);
 
@@ -117,19 +106,13 @@ TEST_F(ExecutionNodeTest, end_node_velocypack_roundtrip_invariable) {
   Variable invar("otherName", 2, false);
 
   std::unique_ptr<SubqueryEndNode> node, nodeFromVPack;
-  std::unordered_set<ExecutionNode const*> seen{};
 
   node = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{0}, &invar, &outvar);
   node->setVarsUsedLater({{}});
   node->setVarsValid({{}});
   node->setRegsToKeep({{}});
 
-  builder.openArray();
-  node->toVelocyPackHelper(builder, ExecutionNode::SERIALIZE_DETAILS, seen);
-  builder.close();
-
-  EXPECT_NE(seen.find(node.get()), seen.end())
-      << "The node has not been added into the seen list";
+  node->allToVelocyPack(builder, ExecutionNode::SERIALIZE_DETAILS);
 
   nodeFromVPack = std::make_unique<SubqueryEndNode>(&plan, builder.slice()[0]);
 

--- a/tests/Aql/IndexNodeTest.cpp
+++ b/tests/Aql/IndexNodeTest.cpp
@@ -482,17 +482,16 @@ TEST_F(IndexNodeTest, constructIndexNode) {
 
     // deserialization
     arangodb::aql::IndexNode indNode(
-      const_cast<arangodb::aql::ExecutionPlan*>(query.plan()),
-      createJson->slice());
+      const_cast<arangodb::aql::ExecutionPlan*>(query.plan()), createJson->slice());
     ASSERT_TRUE(indNode.isLateMaterialized());
 
     // serialization and deserialization
     {
       VPackBuilder builder;
-      indNode.allToVelocyPack(builder, arangodb::aql::ExecutionNode::SERIALIZE_DETAILS);
+      static_cast<arangodb::aql::ExecutionNode&>(indNode).toVelocyPack(builder, arangodb::aql::ExecutionNode::SERIALIZE_DETAILS);
 
       arangodb::aql::IndexNode indNodeDeserialized(
-        const_cast<arangodb::aql::ExecutionPlan*>(query.plan()), createJson->slice());
+        const_cast<arangodb::aql::ExecutionPlan*>(query.plan()), builder.slice());
       ASSERT_TRUE(indNodeDeserialized.isLateMaterialized());
     }
 

--- a/tests/Aql/IndexNodeTest.cpp
+++ b/tests/Aql/IndexNodeTest.cpp
@@ -489,11 +489,7 @@ TEST_F(IndexNodeTest, constructIndexNode) {
     // serialization and deserialization
     {
       VPackBuilder builder;
-      std::unordered_set<arangodb::aql::ExecutionNode const*> seen;
-      {
-        VPackArrayBuilder guard(&builder);
-        indNode.toVelocyPackHelper(builder, arangodb::aql::ExecutionNode::SERIALIZE_DETAILS, seen);
-      }
+      indNode.allToVelocyPack(builder, arangodb::aql::ExecutionNode::SERIALIZE_DETAILS);
 
       arangodb::aql::IndexNode indNodeDeserialized(
         const_cast<arangodb::aql::ExecutionPlan*>(query.plan()), createJson->slice());

--- a/tests/Aql/MockTypedNode.cpp
+++ b/tests/Aql/MockTypedNode.cpp
@@ -50,8 +50,7 @@ std::unique_ptr<::arangodb::aql::ExecutionBlock> MockTypedNode::createBlock(
   THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
 }
 
-void MockTypedNode::toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                                       std::unordered_set<ExecutionNode const*>& seen) const {
+void MockTypedNode::doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const {
   THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
 }
 

--- a/tests/Aql/MockTypedNode.h
+++ b/tests/Aql/MockTypedNode.h
@@ -41,8 +41,7 @@ class MockTypedNode : public ::arangodb::aql::ExecutionNode {
 
   // Necessary overrides, all not implemented:
 
-  void toVelocyPackHelper(arangodb::velocypack::Builder&, unsigned flags,
-                          std::unordered_set<ExecutionNode const*>& seen) const override;
+  void doToVelocyPack(arangodb::velocypack::Builder&, unsigned flags) const override;
 
   std::unique_ptr<::arangodb::aql::ExecutionBlock> createBlock(
       ::arangodb::aql::ExecutionEngine& engine,

--- a/tests/IResearch/IResearchViewNode-test.cpp
+++ b/tests/IResearch/IResearchViewNode-test.cpp
@@ -2148,15 +2148,9 @@ TEST_F(IResearchViewNodeTest, serialize) {
 
     arangodb::velocypack::Builder builder;
     unsigned flags = arangodb::aql::ExecutionNode::SERIALIZE_DETAILS;
-    node.allToVelocyPack(builder, flags);  // object with array of objects
+    node.toVelocyPack(builder, flags);  // object with array of objects
 
-    auto const slice = builder.slice();
-    EXPECT_TRUE(slice.isObject());
-    auto const nodesSlice = slice.get("nodes");
-    EXPECT_TRUE(nodesSlice.isArray());
-    arangodb::velocypack::ArrayIterator it(nodesSlice);
-    EXPECT_EQ(1, it.size());
-    auto nodeSlice = it.value();
+    auto nodeSlice = builder.slice();
 
     // constructor
     {
@@ -2238,15 +2232,9 @@ TEST_F(IResearchViewNodeTest, serialize) {
 
     arangodb::velocypack::Builder builder;
     unsigned flags = arangodb::aql::ExecutionNode::SERIALIZE_DETAILS;
-    node.allToVelocyPack(builder, flags);  // object with array of objects
+    node.toVelocyPack(builder, flags);  // object with array of objects
 
-    auto const slice = builder.slice();
-    EXPECT_TRUE(slice.isObject());
-    auto const nodesSlice = slice.get("nodes");
-    EXPECT_TRUE(nodesSlice.isArray());
-    arangodb::velocypack::ArrayIterator it(nodesSlice);
-    ASSERT_EQ(1, it.size());
-    auto nodeSlice = it.value();
+    auto nodeSlice = builder.slice();
 
     // constructor
     {
@@ -2316,15 +2304,9 @@ TEST_F(IResearchViewNodeTest, serialize) {
 
     arangodb::velocypack::Builder builder;
     unsigned flags = arangodb::aql::ExecutionNode::SERIALIZE_DETAILS;
-    node.allToVelocyPack(builder, flags);  // object with array of objects
+    node.toVelocyPack(builder, flags);  // object with array of objects
 
-    auto const slice = builder.slice();
-    EXPECT_TRUE(slice.isObject());
-    auto const nodesSlice = slice.get("nodes");
-    EXPECT_TRUE(nodesSlice.isArray());
-    arangodb::velocypack::ArrayIterator it(nodesSlice);
-    ASSERT_EQ(1, it.size());
-    auto nodeSlice = it.value();
+    auto nodeSlice = builder.slice();
 
     // constructor
     {
@@ -2417,15 +2399,9 @@ TEST_F(IResearchViewNodeTest, serialize) {
 
     arangodb::velocypack::Builder builder;
     unsigned flags = arangodb::aql::ExecutionNode::SERIALIZE_DETAILS;
-    node.allToVelocyPack(builder, flags);  // object with array of objects
+    node.toVelocyPack(builder, flags);  // object with array of objects
 
-    auto const slice = builder.slice();
-    EXPECT_TRUE(slice.isObject());
-    auto const nodesSlice = slice.get("nodes");
-    EXPECT_TRUE(nodesSlice.isArray());
-    arangodb::velocypack::ArrayIterator it(nodesSlice);
-    ASSERT_EQ(1, it.size());
-    auto nodeSlice = it.value();
+    auto nodeSlice = builder.slice();
 
     // constructor
     {
@@ -2473,15 +2449,9 @@ TEST_F(IResearchViewNodeTest, serialize) {
 
     arangodb::velocypack::Builder builder;
     unsigned flags = arangodb::aql::ExecutionNode::SERIALIZE_DETAILS;
-    node.allToVelocyPack(builder, flags);  // object with array of objects
+    node.toVelocyPack(builder, flags);  // object with array of objects
 
-    auto const slice = builder.slice();
-    EXPECT_TRUE(slice.isObject());
-    auto const nodesSlice = slice.get("nodes");
-    EXPECT_TRUE(nodesSlice.isArray());
-    arangodb::velocypack::ArrayIterator it(nodesSlice);
-    ASSERT_EQ(1, it.size());
-    auto nodeSlice = it.value();
+    auto nodeSlice = builder.slice();
 
     // constructor
     {
@@ -2545,15 +2515,9 @@ TEST_F(IResearchViewNodeTest, serializeSortedView) {
 
     arangodb::velocypack::Builder builder;
     unsigned flags = arangodb::aql::ExecutionNode::SERIALIZE_DETAILS;
-    node.allToVelocyPack(builder, flags);  // object with array of objects
+    node.toVelocyPack(builder, flags);  // object with array of objects
 
-    auto const slice = builder.slice();
-    EXPECT_TRUE(slice.isObject());
-    auto const nodesSlice = slice.get("nodes");
-    EXPECT_TRUE(nodesSlice.isArray());
-    arangodb::velocypack::ArrayIterator it(nodesSlice);
-    EXPECT_EQ(1, it.size());
-    auto nodeSlice = it.value();
+    auto nodeSlice = builder.slice();
 
     // constructor
     {
@@ -2634,15 +2598,9 @@ TEST_F(IResearchViewNodeTest, serializeSortedView) {
 
     arangodb::velocypack::Builder builder;
     unsigned flags = arangodb::aql::ExecutionNode::SERIALIZE_DETAILS;
-    node.allToVelocyPack(builder, flags);  // object with array of objects
+    node.toVelocyPack(builder, flags);  // object with array of objects
 
-    auto const slice = builder.slice();
-    EXPECT_TRUE(slice.isObject());
-    auto const nodesSlice = slice.get("nodes");
-    EXPECT_TRUE(nodesSlice.isArray());
-    arangodb::velocypack::ArrayIterator it(nodesSlice);
-    EXPECT_EQ(1, it.size());
-    auto nodeSlice = it.value();
+    auto nodeSlice = builder.slice();
 
     // constructor
     {
@@ -2714,15 +2672,9 @@ TEST_F(IResearchViewNodeTest, serializeSortedView) {
 
     arangodb::velocypack::Builder builder;
     unsigned flags = arangodb::aql::ExecutionNode::SERIALIZE_DETAILS;
-    node.allToVelocyPack(builder, flags);  // object with array of objects
+    node.toVelocyPack(builder, flags);  // object with array of objects
 
-    auto const slice = builder.slice();
-    EXPECT_TRUE(slice.isObject());
-    auto const nodesSlice = slice.get("nodes");
-    EXPECT_TRUE(nodesSlice.isArray());
-    arangodb::velocypack::ArrayIterator it(nodesSlice);
-    ASSERT_EQ(1, it.size());
-    auto nodeSlice = it.value();
+    auto nodeSlice = builder.slice();
 
     // constructor
     {

--- a/tests/IResearch/IResearchViewNode-test.cpp
+++ b/tests/IResearch/IResearchViewNode-test.cpp
@@ -2148,7 +2148,7 @@ TEST_F(IResearchViewNodeTest, serialize) {
 
     arangodb::velocypack::Builder builder;
     unsigned flags = arangodb::aql::ExecutionNode::SERIALIZE_DETAILS;
-    node.toVelocyPack(builder, flags, false);  // object with array of objects
+    node.allToVelocyPack(builder, flags);  // object with array of objects
 
     auto const slice = builder.slice();
     EXPECT_TRUE(slice.isObject());
@@ -2238,7 +2238,7 @@ TEST_F(IResearchViewNodeTest, serialize) {
 
     arangodb::velocypack::Builder builder;
     unsigned flags = arangodb::aql::ExecutionNode::SERIALIZE_DETAILS;
-    node.toVelocyPack(builder, flags, false);  // object with array of objects
+    node.allToVelocyPack(builder, flags);  // object with array of objects
 
     auto const slice = builder.slice();
     EXPECT_TRUE(slice.isObject());
@@ -2316,7 +2316,7 @@ TEST_F(IResearchViewNodeTest, serialize) {
 
     arangodb::velocypack::Builder builder;
     unsigned flags = arangodb::aql::ExecutionNode::SERIALIZE_DETAILS;
-    node.toVelocyPack(builder, flags, false);  // object with array of objects
+    node.allToVelocyPack(builder, flags);  // object with array of objects
 
     auto const slice = builder.slice();
     EXPECT_TRUE(slice.isObject());
@@ -2417,7 +2417,7 @@ TEST_F(IResearchViewNodeTest, serialize) {
 
     arangodb::velocypack::Builder builder;
     unsigned flags = arangodb::aql::ExecutionNode::SERIALIZE_DETAILS;
-    node.toVelocyPack(builder, flags, false);  // object with array of objects
+    node.allToVelocyPack(builder, flags);  // object with array of objects
 
     auto const slice = builder.slice();
     EXPECT_TRUE(slice.isObject());
@@ -2473,7 +2473,7 @@ TEST_F(IResearchViewNodeTest, serialize) {
 
     arangodb::velocypack::Builder builder;
     unsigned flags = arangodb::aql::ExecutionNode::SERIALIZE_DETAILS;
-    node.toVelocyPack(builder, flags, false);  // object with array of objects
+    node.allToVelocyPack(builder, flags);  // object with array of objects
 
     auto const slice = builder.slice();
     EXPECT_TRUE(slice.isObject());
@@ -2545,7 +2545,7 @@ TEST_F(IResearchViewNodeTest, serializeSortedView) {
 
     arangodb::velocypack::Builder builder;
     unsigned flags = arangodb::aql::ExecutionNode::SERIALIZE_DETAILS;
-    node.toVelocyPack(builder, flags, false);  // object with array of objects
+    node.allToVelocyPack(builder, flags);  // object with array of objects
 
     auto const slice = builder.slice();
     EXPECT_TRUE(slice.isObject());
@@ -2634,7 +2634,7 @@ TEST_F(IResearchViewNodeTest, serializeSortedView) {
 
     arangodb::velocypack::Builder builder;
     unsigned flags = arangodb::aql::ExecutionNode::SERIALIZE_DETAILS;
-    node.toVelocyPack(builder, flags, false);  // object with array of objects
+    node.allToVelocyPack(builder, flags);  // object with array of objects
 
     auto const slice = builder.slice();
     EXPECT_TRUE(slice.isObject());
@@ -2714,7 +2714,7 @@ TEST_F(IResearchViewNodeTest, serializeSortedView) {
 
     arangodb::velocypack::Builder builder;
     unsigned flags = arangodb::aql::ExecutionNode::SERIALIZE_DETAILS;
-    node.toVelocyPack(builder, flags, false);  // object with array of objects
+    node.allToVelocyPack(builder, flags);  // object with array of objects
 
     auto const slice = builder.slice();
     EXPECT_TRUE(slice.isObject());

--- a/tests/js/server/aql/aql-queries-simple.js
+++ b/tests/js/server/aql/aql-queries-simple.js
@@ -1336,30 +1336,25 @@ function ahuacatlQuerySimpleTestSuite () {
     },
 
     testLargeQuery : function() {
-      let q = "";
-      const cnt = 990;
-      for (let i = 0; i < cnt; ++i) {
-        q += `LET v${i} = NOOPT(1)\n`;
-      }
-      q += "RETURN v0";
+      let q = "LET v0 = NOOPT(1)";
+      const cnt = 2000;
       for (let i = 1; i < cnt; ++i) {
-        q += ` + v${i}`;
+        q += `LET v${i} = NOOPT(v${i- 1} + 1)\n`;
       }
+      q += `RETURN v${cnt - 1}`;
       assertEqual([cnt], AQL_EXECUTE(q, {}, {optimizer: {rules: ['-all']}}).json);
     },
     
     testLargeSubQuery : function() {
       const _ = require('lodash');
       let q = "FOR i IN 0..9 LET x = (\n";
-      const cnt = 900;
-      for (let i = 0; i < cnt; ++i) {
-        q += `LET v${i} = NOOPT(1)\n`;
-      }
-      q += "RETURN i + v0";
+      q += "LET v0 = NOOPT(1)\n";
+      const cnt = 2000;
       for (let i = 1; i < cnt; ++i) {
-        q += ` + v${i}`;
+        q += `LET v${i} = NOOPT(v${i- 1} + 1)\n`;
       }
-      q += ")[0]\nRETURN x";
+      q += `RETURN v${cnt - 1})[0]\n`;
+      q += "RETURN i + x";
       const expected = _.range(cnt, cnt + 10);
       assertEqual(expected, AQL_EXECUTE(q, {}, {optimizer: {rules: ['-all']}}).json);
     },


### PR DESCRIPTION
### Scope & Purpose

Adapt various places to make handling of execution plans non-recursive in order to avoid stack overflows.

Before these changes, on my Windows machine (which has a default stack size of 1MB) I could handle queries with up to 1000 nodes. After these changes, I can run queries with up to 7000 nodes. More than that is still not possible, because `ExecutionBlock::initializeCursor` is still recursive and larger queries will again run into a stack overflow.

I made some basic tests that showed that performance of the non-recursive version is slightly better than before. In order to test this, I created some huge queries with thousands of variables, which revealed a performance issue in RegisterPlan where `std::find` was used on a `HashSet` which could be changed to a simple `HashSet::contains`, so this PR also massively improves register planning performance for large queries.

One thing I noted is that the detailed query plan required by `_explain` grows quadratic in the number of variables. This is because each node has the `varInfoList` and `varsUsedLaterStack` lists, both of which grow linear with the number of variables in the query. While this can probably be improved, it is not critical. However, it means that even though we can _execute_ such large queries, they can effectively not be `_explain`ed.

In order to prevent stack overflows and issues with the size explosion in `_explain`, we should limit the number of query nodes, and also the expression depths in calculation nodes. But this should be discussed and implemented in a separate PR.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Jira ticket number: https://arangodb.atlassian.net/browse/APM-77

### Testing & Verification

During development I had test code in place to ensure that the old and new implementation behave identically (e.g., that `walk` visits all nodes in the exact same order, etc.).

I have adapted some tests to use an even larger number of nodes than before (previously these numbers would have resulted in a crash).

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
