### PR TITLE
Fix ArangoAgency::version()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fix ArangoAgency::version(), which always returned an empty string instead
+  of the agency's correctly reported version. This also fixes the agency
+  version in the startup log messages of the cluster.
+
 * Add following term ids, which prevents old synchronous replication requests
   to be accepted after a follower was dropped and has gotten in sync again.
   This makes the chaos tests which delay synchronous replication requests

--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -622,8 +622,14 @@ std::string AgencyComm::version() {
                        AgencyCommHelper::CONNECTION_OPTIONS._requestTimeout,
                        "/_api/version", VPackSlice::noneSlice());
 
-  if (result.successful() && result.slice().isString()) {
-    return result.slice().copyString();
+  if (result.successful()) {
+    VPackSlice r = result.slice();
+    if (r.isObject()) {
+      r = r.get("version");
+    }
+    if (r.isString()) {
+      return r.copyString();
+    }
   }
 
   return "";

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -623,7 +623,7 @@ void ClusterFeature::start() {
       << (_forceOneShard ? " with one-shard mode" : "")
       << ". Agency version: " << version << ", Agency endpoints: " << endpoints
       << ", server id: '" << myId << "', internal endpoint / address: " << _myEndpoint
-      << "', advertised endpoint: " << _myAdvertisedEndpoint << ", role: " << role;
+      << "', advertised endpoint: " << _myAdvertisedEndpoint << ", role: " << ServerState::roleToString(role);
 
   auto [acb, idx] = _agencyCache->read(
     std::vector<std::string>{AgencyCommHelper::path("Sync/HeartbeatIntervalMs")});

--- a/tests/js/server/shell/shell-cluster-agency.js
+++ b/tests/js/server/shell/shell-cluster-agency.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/*global fail, assertFalse, assertTrue, assertEqual, ArangoAgency */
+/*global fail, assertFalse, assertTrue, assertEqual, assertMatch, ArangoAgency */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test the agency communication layer
@@ -64,6 +64,11 @@ function AgencySuite () {
       }
       catch (err) {
       }
+    },
+    
+    testVersion : function () {
+      let result = agency.version();
+      assertMatch(/^\d\.\d/, result);
     },
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose

* Fix ArangoAgency::version(), which always returned an empty string instead
  of the agency's correctly reported version. This also fixes the agency
  version in the startup log messages of the cluster.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
