### PR TITLE
Fix handling of empty WAL files with encryption at rest

### DIFF
--- a/3rdParty/rocksdb/6.8/env/env_encryption.cc
+++ b/3rdParty/rocksdb/6.8/env/env_encryption.cc
@@ -902,18 +902,18 @@ Status CTREncryptionProvider::CreateCipherStream(
   Slice iv;
   decodeCTRParameters(prefix.data(), blockSize, initialCounter, iv);
 
-  // If the prefix is smaller than twice the block size, we would below read a
-  // very large chunk of the file (and very likely read over the bounds)
-  if (prefix.size() < 2 * blockSize) {
-    return Status::Corruption("Unable to read from file " + fname +
-                              ": read attempt would read beyond file bounds");
-  }
-  
-  assert(prefix.size() >= 2 * blockSize);
-
   // Decrypt the encrypted part of the prefix, starting from block 2 (block 0, 1 with initial counter & IV are unencrypted)
   CTRCipherStream cipherStream(cipher_, iv.data(), initialCounter);
-  auto status = cipherStream.Decrypt(0, (char*)prefix.data() + (2 * blockSize), prefix.size() - (2 * blockSize));
+  Status status;
+  if (!prefix.empty()) {
+    // If the prefix is smaller than twice the block size, we would below read a
+    // very large chunk of the file (and very likely read over the bounds)
+    if (prefix.size() < 2 * blockSize) {
+      return Status::Corruption("Unable to read from file " + fname +
+                                ": read attempt would read beyond file bounds");
+    }
+    status = cipherStream.Decrypt(0, (char*)prefix.data() + (2 * blockSize), prefix.size() - (2 * blockSize));
+  }
   if (!status.ok()) {
     return status;
   }

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 v3.7.13 (XXXX-XX-XX)
 --------------------
 
+* Fix startup issues with encryption-at-rest enabled when there were empty
+  (0 byte) RocksDB WAL files present. Such empty files caused RocksDB to
+  abort the startup, reporting corruption. However, empty WAL files are 
+  possible in case of server crashes etc. Now, if a WAL file is completely
+  empty, there will be no attempt to read the encryption meta data from it,
+  so the startup succeeds.
+
 * Fixed potential segfault in tcp/ssl socket handling (potentially fixes issue
   #14431).
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,11 @@
 v3.7.13 (XXXX-XX-XX)
 --------------------
 
-* Fix startup issues with encryption-at-rest enabled when there were empty
-  (0 byte) RocksDB WAL files present. Such empty files caused RocksDB to
-  abort the startup, reporting corruption. However, empty WAL files are 
-  possible in case of server crashes etc. Now, if a WAL file is completely
-  empty, there will be no attempt to read the encryption meta data from it,
-  so the startup succeeds.
+* Fix startup issues with encryption-at-rest enabled when there were empty (0
+  byte) RocksDB WAL files present. Such empty files caused RocksDB to abort the
+  startup, reporting corruption. However, empty WAL files are possible in case
+  of server crashes etc. Now, if a WAL file is completely empty, there will be
+  no attempt to read the encryption meta data from it, so the startup succeeds.
 
 * Fixes a bug in the maintenance's error-handling code. A shard error would
   result in log messages like

--- a/tests/js/server/recovery/empty-journal.js
+++ b/tests/js/server/recovery/empty-journal.js
@@ -1,0 +1,108 @@
+/* jshint globalstrict:false, strict:false, unused: false */
+/* global assertNotNull */
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief tests for empty journal files
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2010-2012 triagens GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// / @author Copyright 2013, triAGENS GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+const db = require('@arangodb').db;
+const internal = require('internal');
+const fs = require('fs');
+const jsunity = require('jsunity');
+
+function runSetup () {
+  'use strict';
+  internal.debugClearFailAt();
+
+  let c = db._create('UnitTestsRecovery');
+  let walfiles = () => {
+    return db._currentWalFiles().map(function(f) {
+      // strip off leading `/` or `/archive/` if it exists
+      let p = f.split('/');
+      return p[p.length - 1];
+    });
+  };
+
+  let docs = [];
+  let payload = Array(1024).join("XuxU");
+  for (let i = 0; i < 1000; ++i) {
+    docs.push({ value: i, payload });
+  }
+
+  let initial = walfiles();
+  
+  while (true) {
+    c.insert(docs);
+    let now = walfiles();
+    if (now.length > initial.length) {
+      // filter out the original files
+      let remain = now.filter((f) => {
+        return initial.indexOf(f) === -1;
+      });
+
+      if (remain.length > 0) {
+        // ok, we found a WAL file to destroy!
+        let fn = fs.join(db._path(), 'engine-rocksdb', 'journals', remain[0]);
+        // remove file and replace it with an empty one!
+        require("console").warn("intentionally truncating log file " + fn);
+        fs.remove(fn);
+        fs.writeFileSync(fn, "");
+        
+        // crash
+        internal.debugTerminate('crashing server');
+      }
+    }
+  }
+}
+
+function recoverySuite () {
+  'use strict';
+  jsunity.jsUnity.attachAssertions();
+
+  return {
+    // //////////////////////////////////////////////////////////////////////////////
+    // / @brief test that we can still start
+    // //////////////////////////////////////////////////////////////////////////////
+
+    testRestart: function () {
+      // assert that initial collection exists.
+      // as we manually wiped one of the WAL files, 
+      // we cannot know how much data is still in it.
+      // all we require is a successful restart here
+      let c = db._collection('UnitTestsRecovery');
+      assertNotNull(c);
+    }
+
+  };
+}
+
+function main (argv) {
+  'use strict';
+  if (argv[1] === 'setup') {
+    runSetup();
+    return 0;
+  } else {
+    jsunity.run(recoverySuite);
+    return jsunity.writeDone().status ? 0 : 1;
+  }
+}


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/14477

* Fix startup issues with encryption-at-rest enabled when there were empty
  (0 byte) RocksDB WAL files present. Such empty files caused RocksDB to
  abort the startup, reporting corruption. However, empty WAL files are
  possible in case of server crashes etc. Now, if a WAL file is completely
  empty, there will be no attempt to read the encryption meta data from it,
  so the startup succeeds.

A PR for facebook/rocksdb will be opened seperately: https://github.com/facebook/rocksdb/pull/8499

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (recovery)
