### PR TITLE
improve shell-aql-query-setup-timeout test

### DIFF
--- a/tests/js/client/shell/shell-aql-query-setup-timeout.js
+++ b/tests/js/client/shell/shell-aql-query-setup-timeout.js
@@ -2,7 +2,7 @@
 /* global fail, assertEqual, assertTrue, assertFalse, arango */
 
 // //////////////////////////////////////////////////////////////////////////////
-// / @brief dropping followers while replicating
+// / @brief timeouts during query setup
 // /
 // / DISCLAIMER
 // /
@@ -71,8 +71,10 @@ function aqlQuerySetupTimeout() {
 
       try {
         db._query("FOR i IN 1..1000 INSERT {} INTO " + cn);
+        fail();
       } catch (e) {
-        assertEqual(e.errorNum, ERRORS.ERROR_CLUSTER_TIMEOUT.code);
+        assertTrue(e.errorNum === ERRORS.ERROR_CLUSTER_TIMEOUT.code ||
+                   e.errorNum === ERRORS.ERROR_CLUSTER_CONNECTION_LOST.code);
       }
 
       assertEqual(0, c.count());


### PR DESCRIPTION
### Scope & Purpose

Improve shell-aql-query-setup-timeout test
- added a missing `fail()`
- allow 2 different errors codes (both are possible)

This PR only makes a change to the test, so there is intentionally no CHANGELOG entry for it.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
