### PR TITLE
fix a g++-9 compile warning for a potentially uninitialized var

### DIFF
--- a/lib/V8/v8-utils.cpp
+++ b/lib/V8/v8-utils.cpp
@@ -2456,7 +2456,7 @@ static void JS_MTime(v8::FunctionCallbackInfo<v8::Value> const& args) {
                                    std::string("not allowed to read files in this path: ") + filename);
   }
 
-  int64_t mtime;
+  int64_t mtime = 0;
   auto res = TRI_MTimeFile(filename.c_str(), &mtime);
 
   if (res != TRI_ERROR_NO_ERROR) {


### PR DESCRIPTION
### Scope & Purpose

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
