### PR TITLE
BTS-519: avoid holding 2 mutexes at the same time

### DIFF
--- a/arangod/Pregel/Conductor.h
+++ b/arangod/Pregel/Conductor.h
@@ -151,6 +151,8 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   }
 
   bool canBeGarbageCollected() const;
+  
+  uint64_t executionNumber() const { return _executionNumber; }
 
  private:
   void cancelNoLock();


### PR DESCRIPTION
### Scope & Purpose

BTS-519: https://arangodb.atlassian.net/browse/BTS-519

This change avoids holding the _mutex of PregelFeature while calling into each Conductor for velocypackification. The velocypackification of a Conductor requires holding the Conductor's _callbackMutex as well, and we prefer holding only one mutex at a time.

There don't need to be backports for this, as the fix for code changes that are only present in devel.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-519

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *shell_server*.
- [x] I ensured this code runs with ASan / TSan or other static verification tools
