### PR TITLE
Improve startup file copying of JavaScript files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 devel
 -----
 
+* Make `--javascript.copy-installation` also copy the `node_modules` sub
+  directory. This is required so we have a full copy of the JavaScript
+  dependencies and not one that excludes some infrequently changed modules.
+  In addition, file copying now intentionally excludes .map files as they
+  are not needed. 
+
 * Slightly increase internal AQL query and transaction timeout on DB servers 
   from 3 to 5 minutes.
   Previously, queries and transactions on DB servers could expire quicker,

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -444,6 +444,13 @@ bool copyDirectoryRecursive(std::string const& source, std::string const& target
                             std::function<TRI_copy_recursive_e(std::string const&)> const& filter,
                             std::string& error) {
   bool rc_bool = true;
+  
+  // these strings will be recycled over and over
+  std::string dst = target + TRI_DIR_SEPARATOR_STR;
+  size_t const dstPrefixLength = dst.size();
+  std::string src = source + TRI_DIR_SEPARATOR_STR;
+  size_t const srcPrefixLength = src.size();
+
 
 #ifdef TRI_HAVE_WIN32_LIST_FILES
   struct _wfinddata_t oneItem;
@@ -475,12 +482,6 @@ bool copyDirectoryRecursive(std::string const& source, std::string const& target
   }
 
   struct dirent* oneItem = nullptr;
-
-  // these strings will be recycled over and over
-  std::string dst = target + TRI_DIR_SEPARATOR_STR;
-  size_t dstPrefixLength = dst.size();
-  std::string src = source + TRI_DIR_SEPARATOR_STR;
-  size_t srcPrefixLength = src.size();
 
   // do not use readdir_r() here anymore as it is not safe and deprecated
   // in newer versions of libc:

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -64,7 +64,49 @@
 namespace {
 std::function<bool(std::string const&)> const passAllFilter =
     [](std::string const&) { return false; };
+
+enum class StatResultType {
+  Error, // in case it cannot be determined
+  Directory,
+  SymLink,
+  File,
+  Other // potentially file
+};
+
+StatResultType statResultType(TRI_stat_t const& stbuf) {
+#ifdef _WIN32
+  if ((stbuf.st_mode & S_IFMT) == S_IFDIR) {
+    return StatResultType::Directory;
+  }
+#else
+  if (S_ISDIR(stbuf.st_mode)) {
+    return StatResultType::Directory;
+  }
+#endif
+
+#ifndef TRI_HAVE_WIN32_SYMBOLIC_LINK
+  if (S_ISLNK(stbuf.st_mode)) {
+    return StatResultType::SymLink;
+  }
+#endif
+  
+  if ((stbuf.st_mode & S_IFMT) == S_IFREG) {
+    return StatResultType::File;
+  }
+    
+  return StatResultType::Other;
 }
+
+StatResultType statResultType(std::string const& path) {
+  TRI_stat_t stbuf;
+  int res = TRI_STAT(path.c_str(), &stbuf);
+  if (res != 0) {
+    return StatResultType::Error;
+  }
+  return statResultType(stbuf);
+}
+
+} // namespace
 
 namespace arangodb {
 namespace basics {
@@ -401,12 +443,8 @@ bool copyRecursive(std::string const& source, std::string const& target,
 bool copyDirectoryRecursive(std::string const& source, std::string const& target,
                             std::function<TRI_copy_recursive_e(std::string const&)> const& filter,
                             std::string& error) {
-  char* fn = nullptr;
   bool rc_bool = true;
 
-  auto isSubDirectory = [](std::string const& name) -> bool {
-    return isDirectory(name);
-  };
 #ifdef TRI_HAVE_WIN32_LIST_FILES
   struct _wfinddata_t oneItem;
   intptr_t handle;
@@ -427,7 +465,7 @@ bool copyDirectoryRecursive(std::string const& source, std::string const& target
     rcs.clear();
     icu::UnicodeString d((wchar_t*)oneItem.name, static_cast<int32_t>(wcslen(oneItem.name)));
     d.toUTF8String<std::string>(rcs);
-    fn = (char*)rcs.c_str();
+    char const* fn = (char*)rcs.c_str();
 #else
   DIR* filedir = opendir(source.c_str());
 
@@ -438,6 +476,12 @@ bool copyDirectoryRecursive(std::string const& source, std::string const& target
 
   struct dirent* oneItem = nullptr;
 
+  // these strings will be recycled over and over
+  std::string dst = target + TRI_DIR_SEPARATOR_STR;
+  size_t dstPrefixLength = dst.size();
+  std::string src = source + TRI_DIR_SEPARATOR_STR;
+  size_t srcPrefixLength = src.size();
+
   // do not use readdir_r() here anymore as it is not safe and deprecated
   // in newer versions of libc:
   // http://man7.org/linux/man-pages/man3/readdir_r.3.html
@@ -445,7 +489,7 @@ bool copyDirectoryRecursive(std::string const& source, std::string const& target
   // to be thread-safe in reality, and newer versions of POSIX may require its
   // thread-safety formally, and in addition obsolete readdir_r() altogether
   while ((oneItem = (readdir(filedir))) != nullptr && rc_bool) {
-    fn = oneItem->d_name;
+    char const* fn = oneItem->d_name;
 #endif
 
     // Now iterate over the items.
@@ -453,49 +497,71 @@ bool copyDirectoryRecursive(std::string const& source, std::string const& target
     if (!strcmp(fn, ".") || !strcmp(fn, "..")) {
       continue;
     }
-    std::string dst = target + TRI_DIR_SEPARATOR_STR + fn;
-    std::string src = source + TRI_DIR_SEPARATOR_STR + fn;
 
-    switch (filter(src)) {
-      case TRI_COPY_IGNORE:
-        break;
+    // add current filename to prefix
+    src.resize(srcPrefixLength);
+    TRI_ASSERT(src.back() == TRI_DIR_SEPARATOR_CHAR);
+    src.append(fn);
+    
+    auto filterResult = filter(src);
 
-      case TRI_COPY_COPY:
-        // Handle subdirectories:
-        if (isSubDirectory(src)) {
-          long systemError;
-          auto rc = TRI_CreateDirectory(dst.c_str(), systemError, error);
-          if (rc != TRI_ERROR_NO_ERROR && rc != TRI_ERROR_FILE_EXISTS) {
-            rc_bool = false;
-            break;
-          }
-          if (!copyDirectoryRecursive(src, dst, filter, error)) {
-            rc_bool = false;
-            break;
-          }
-          if (!TRI_CopyAttributes(src, dst, error)) {
-            rc_bool = false;
-            break;
-          }
+    if (filterResult != TRI_COPY_IGNORE) {
+      // prepare dst filename
+      dst.resize(dstPrefixLength);
+      TRI_ASSERT(dst.back() == TRI_DIR_SEPARATOR_CHAR);
+      dst.append(fn);
+ 
+      // figure out the type of the directory entry.
+      StatResultType type = StatResultType::Error;
+      TRI_stat_t stbuf;
+      int res = TRI_STAT(src.c_str(), &stbuf);
+      if (res == 0) {
+        type = ::statResultType(stbuf);
+      }
+
+      switch (filterResult) {
+        case TRI_COPY_IGNORE:
+          TRI_ASSERT(false);
+          break;
+
+        case TRI_COPY_COPY:
+          // Handle subdirectories:
+          if (type == StatResultType::Directory) {
+            long systemError;
+            auto rc = TRI_CreateDirectory(dst.c_str(), systemError, error);
+            if (rc != TRI_ERROR_NO_ERROR && rc != TRI_ERROR_FILE_EXISTS) {
+              rc_bool = false;
+              break;
+            }
+            if (!copyDirectoryRecursive(src, dst, filter, error)) {
+              rc_bool = false;
+              break;
+            }
+            if (!TRI_CopyAttributes(src, dst, error)) {
+              rc_bool = false;
+              break;
+            }
+          } else if (type == StatResultType::SymLink) {
+            if (!TRI_CopySymlink(src, dst, error)) {
+              rc_bool = false;
+            }
+          } else {
 #ifndef _WIN32
-        } else if (isSymbolicLink(src)) {
-          if (!TRI_CopySymlink(src, dst, error)) {
-            rc_bool = false;
-          }
+            rc_bool = TRI_CopyFile(src, dst, error);
+#else
+            // optimized version that reuses the already retrieved stat data
+            rc_bool = TRI_CopyFile(src, dst, error, &stbuf);
 #endif
-        } else {
-          if (!TRI_CopyFile(src, dst, error)) {
-            rc_bool = false;
           }
-        }
-        break;
+          break;
 
-      case TRI_COPY_LINK:
-        if (!TRI_CreateHardlink(src, dst, error)) {
-          rc_bool = false;
-        } // if
-        break;
-    } // switch
+        case TRI_COPY_LINK:
+          if (!TRI_CreateHardlink(src, dst, error)) {
+            rc_bool = false;
+          } // if
+          break;
+      } // switch
+    }
 #ifdef TRI_HAVE_WIN32_LIST_FILES
   } while (_wfindnext(handle, &oneItem) != -1 && rc_bool);
 
@@ -578,48 +644,19 @@ std::vector<std::string> listFiles(std::string const& directory) {
 }
 
 bool isDirectory(std::string const& path) {
-  TRI_stat_t stbuf;
-  int res = TRI_STAT(path.c_str(), &stbuf);
-
-#ifdef _WIN32
-  return (res == 0) && ((stbuf.st_mode & S_IFMT) == S_IFDIR);
-#else
-  return (res == 0) && S_ISDIR(stbuf.st_mode);
-#endif
+  return ::statResultType(path) == ::StatResultType::Directory;
 }
 
 bool isSymbolicLink(std::string const& path) {
-#ifdef TRI_HAVE_WIN32_SYMBOLIC_LINK
-
-  // .....................................................................
-  // TODO: On the NTFS file system, there are the following file links:
-  // hard links -
-  // junctions -
-  // symbolic links -
-  // .....................................................................
-  return false;
-
-#else
-
-  struct stat stbuf;
-  int res = TRI_STAT(path.c_str(), &stbuf);
-
-  return (res == 0) && S_ISLNK(stbuf.st_mode);
-
-#endif
+  return ::statResultType(path) == ::StatResultType::SymLink;
 }
 
 bool isRegularFile(std::string const& path) {
-  TRI_stat_t stbuf;
-  int res = TRI_STAT(path.c_str(), &stbuf);
-  return (res == 0) && ((stbuf.st_mode & S_IFMT) == S_IFREG);
+  return ::statResultType(path) == ::StatResultType::File;
 }
 
 bool exists(std::string const& path) {
-  TRI_stat_t stbuf;
-  int res = TRI_STAT(path.c_str(), &stbuf);
-
-  return res == 0;
+  return ::statResultType(path) != ::StatResultType::Error;
 }
 
 off_t size(std::string const& path) {

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -547,7 +547,7 @@ bool copyDirectoryRecursive(std::string const& source, std::string const& target
               rc_bool = false;
             }
           } else {
-#ifndef _WIN32
+#ifdef _WIN32
             rc_bool = TRI_CopyFile(src, dst, error);
 #else
             // optimized version that reuses the already retrieved stat data

--- a/lib/Basics/files.h
+++ b/lib/Basics/files.h
@@ -42,6 +42,8 @@
 #include "Enterprise/Encryption/EncryptionFeature.h"
 #endif
 
+struct stat;
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief returns the size of a file
 ///
@@ -351,7 +353,13 @@ ErrorCode TRI_GetTempName(char const* directory, std::string& result, bool creat
 /// @brief copies a file from source to dest.
 ////////////////////////////////////////////////////////////////////////////////
 
+#ifdef _WIN32
 bool TRI_CopyFile(std::string const& src, std::string const& dst, std::string& error);
+#else
+// this API allows passing already retrieved stat info to the copy routine, in
+// order to avoid extra stat calls
+bool TRI_CopyFile(std::string const& src, std::string const& dst, std::string& error, struct stat* statbuf = nullptr);
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief copies the file Attributes from source to dest.

--- a/lib/Basics/operating-system.h
+++ b/lib/Basics/operating-system.h
@@ -187,8 +187,8 @@
 #define TRI_DUP ::dup
 #define TRI_RMDIR ::rmdir
 #define TRI_STAT ::stat
-#define TRI_STAT_ATIME_SEC(statbuf) statbuf.st_atimespec.tv_sec
-#define TRI_STAT_MTIME_SEC(statbuf) statbuf.st_mtimespec.tv_sec
+#define TRI_STAT_ATIME_SEC(statbuf) (statbuf).st_atimespec.tv_sec
+#define TRI_STAT_MTIME_SEC(statbuf) (statbuf).st_mtimespec.tv_sec
 #define TRI_UNLINK ::unlink
 #define TRI_WRITE ::write
 #define TRI_FDOPEN(a, b) ::fdopen((a), (b))
@@ -333,8 +333,8 @@
 #define TRI_DUP ::dup
 #define TRI_RMDIR ::rmdir
 #define TRI_STAT ::stat
-#define TRI_STAT_ATIME_SEC(statbuf) statbuf.st_atimespec.tv_sec
-#define TRI_STAT_MTIME_SEC(statbuf) statbuf.st_mtimespec.tv_sec
+#define TRI_STAT_ATIME_SEC(statbuf) (statbuf).st_atimespec.tv_sec
+#define TRI_STAT_MTIME_SEC(statbuf) (statbuf).st_mtimespec.tv_sec
 #define TRI_UNLINK ::unlink
 #define TRI_WRITE ::write
 #define TRI_FDOPEN(a, b) ::fdopen((a), (b))
@@ -492,8 +492,8 @@
 #define TRI_DUP ::dup
 #define TRI_RMDIR ::rmdir
 #define TRI_STAT ::stat
-#define TRI_STAT_ATIME_SEC(statbuf) statbuf.st_atim.tv_sec
-#define TRI_STAT_MTIME_SEC(statbuf) statbuf.st_mtim.tv_sec
+#define TRI_STAT_ATIME_SEC(statbuf) (statbuf).st_atim.tv_sec
+#define TRI_STAT_MTIME_SEC(statbuf) (statbuf).st_mtim.tv_sec
 #define TRI_UNLINK ::unlink
 #define TRI_WRITE ::write
 #define TRI_FDOPEN(a, b) ::fdopen((a), (b))

--- a/tests/js/client/server_parameters/test-copy-installation.js
+++ b/tests/js/client/server_parameters/test-copy-installation.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/* global getOptions, assertEqual, arango */
+/* global getOptions, assertEqual, assertTrue, assertFalse, arango */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test for security-related server options
@@ -34,7 +34,10 @@ if (getOptions === true) {
     'javascript.allow-admin-execute': 'true',
   };
 }
-var jsunity = require('jsunity');
+
+const db = require("@arangodb").db;
+const fs = require("fs");
+const jsunity = require('jsunity');
 
 function testSuite() {
   const errors = require('@arangodb').errors;
@@ -44,12 +47,15 @@ function testSuite() {
     tearDown: function() {},
 
     testCanExecuteAction : function() {
-      // this test just does something, and it doesn't really matter
-      // the key thing in this test is to get the server started using
-      // the `--javascript.copy-installation true` setting without failing
-      let data = "return 'test!'";
-      let result = arango.POST("/_admin/execute", data);
-      assertEqual("test!", result);
+      // fetch server-side database directory name
+      let data = "return require('@arangodb').db._path();";
+      let dbPath = arango.POST("/_admin/execute", data);
+      let jsPath = fs.join(dbPath, "js");
+      assertTrue(fs.exists(jsPath));
+      assertTrue(fs.exists(fs.join(jsPath, "node")));
+      assertTrue(fs.exists(fs.join(jsPath, "node", "node_modules")));
+      assertTrue(fs.exists(fs.join(jsPath, "node", "node_modules", "lodash")));
+      assertFalse(fs.exists(fs.join(jsPath, "node", "eslint")));
     },
     
   };


### PR DESCRIPTION
### Scope & Purpose

Partial fix of BTS-516 (https://arangodb.atlassian.net/browse/BTS-516)

Improve startup file copying of JavaScript files

* Make `--javascript.copy-installation` also copy the `node_modules` sub directory. This is required so we have a full copy of the JavaScript dependencies and not one that excludes some infrequently changed modules. In addition, file copying now intentionally excludes .map files as they are not needed.

* Revive unused code for file copying on Linux using `splice()`. This can have performance advantages compared to other copying implementations. 

* The file copying routine in `--javascript.copy-installation` was also optimized to significantly do less stat calls, and the file/directory filtering code was also sped up.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.8, 3.7, 3.6 (partial backports)

#### Related Information

- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-516

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *server_parameters*.
- [x] I ensured this code runs with ASan / TSan or other static verification tools

