### PR TITLE
[3.6] Disable replication2_client test in oskar.

### DIFF
--- a/UnitTests/OskarTestSuitesBlockList
+++ b/UnitTests/OskarTestSuitesBlockList
@@ -15,3 +15,4 @@ dump_jwt
 dump_no_envelope
 dump_with_crashes
 chaos
+replication2_client


### PR DESCRIPTION
### Scope & Purpose

Disable replication2_client test in oskar.