### PR TITLE
Fix duplicate log id in ExecutionBlockImpl

### DIFF
--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -1411,7 +1411,7 @@ ExecutionBlockImpl<Executor>::executeWithoutTrace(AqlCallStack const& callStack)
         TRI_ASSERT(ctx.clientCall.getLimit() > 0);
         TRI_ASSERT(ctx.clientCall.getSkipCount() == 0);
 
-        LOG_QUERY("1f786", DEBUG) << printTypeInfo() << " call produceRows " << ctx.clientCall;
+        LOG_QUERY("1f787", DEBUG) << printTypeInfo() << " call produceRows " << ctx.clientCall;
         if (outputIsFull()) {
           // We need to be able to write data
           // But maybe the existing block is full here

--- a/utils/checkLogIds.py
+++ b/utils/checkLogIds.py
@@ -18,7 +18,7 @@ def is_good(status):
     return status in (Status.OK, Status.OK_REPLACED)
 
 import re
-g_log_topic_pattern = re.compile(r'(?P<macro>LOG_(TOPIC(_IF)?|TRX))\((?P<param>[^),]*),(?P<rest>.*)')
+g_log_topic_pattern = re.compile(r'(?P<macro>LOG_(TOPIC(_IF)?|TRX|QUERY))\((?P<param>[^),]*),(?P<rest>.*)')
 
 import hashlib
 g_hash_algorithm = hashlib.md5()


### PR DESCRIPTION
### Scope & Purpose

Fix a duplicate log id, and adapt the corresponding script to check these kind of log macros.

Necessary so https://github.com/arangodb/oskar/pull/331 can be merged.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [X] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [X] Backport required for **3.8**: https://github.com/arangodb/arangodb/pull/14523
- [X] Backport required for **3.7**: https://github.com/arangodb/arangodb/pull/14524

#### Related Information

- Oskar PR: https://github.com/arangodb/arangodb/pull/14523

### Testing & Verification

- [X] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
