### PR TITLE
make AQL modification operations async

### DIFF
--- a/arangod/Aql/ClusterNodes.cpp
+++ b/arangod/Aql/ClusterNodes.cpp
@@ -612,6 +612,7 @@ std::unique_ptr<ExecutionBlock> SingleRemoteOperationNode::createBlock(
                                            std::move(writableOutputRegisters));
 
   auto executorInfos = SingleRemoteModificationInfos(
+      &engine,
       in, outputNew, outputOld, out, _plan->getAst()->query(), std::move(options),
       collection(), ConsultAqlWriteFilter(_options.consultAqlWriteFilter),
       IgnoreErrors(_options.ignoreErrors),

--- a/arangod/Aql/InsertModifier.cpp
+++ b/arangod/Aql/InsertModifier.cpp
@@ -50,6 +50,6 @@ ModifierOperationType InsertModifierCompletion::accumulate(ModificationExecutorA
   }
 }
 
-OperationResult InsertModifierCompletion::transact(transaction::Methods& trx, VPackSlice const& data) {
-  return trx.insert(_infos._aqlCollection->name(), data, _infos._options);
+futures::Future<OperationResult> InsertModifierCompletion::transact(transaction::Methods& trx, VPackSlice const& data) {
+  return trx.insertAsync(_infos._aqlCollection->name(), data, _infos._options);
 }

--- a/arangod/Aql/InsertModifier.h
+++ b/arangod/Aql/InsertModifier.h
@@ -27,6 +27,7 @@
 #include "Aql/ModificationExecutor.h"
 #include "Aql/ModificationExecutorAccumulator.h"
 #include "Aql/ModificationExecutorInfos.h"
+#include "Futures/Future.h"
 
 namespace arangodb {
 namespace aql {
@@ -41,7 +42,7 @@ class InsertModifierCompletion {
 
   ModifierOperationType accumulate(ModificationExecutorAccumulator& accu,
                                    InputAqlItemRow& row);
-  OperationResult transact(transaction::Methods& trx, VPackSlice const& data);
+  futures::Future<OperationResult> transact(transaction::Methods& trx, VPackSlice const& data);
 
  private:
   ModificationExecutorInfos& _infos;

--- a/arangod/Aql/ModificationExecutorInfos.cpp
+++ b/arangod/Aql/ModificationExecutorInfos.cpp
@@ -32,13 +32,15 @@ using namespace arangodb;
 using namespace arangodb::aql;
 
 ModificationExecutorInfos::ModificationExecutorInfos(
+    ExecutionEngine* engine,
     RegisterId input1RegisterId, RegisterId input2RegisterId, RegisterId input3RegisterId,
     RegisterId outputNewRegisterId, RegisterId outputOldRegisterId,
     RegisterId outputRegisterId, arangodb::aql::QueryContext& query, OperationOptions options,
     aql::Collection const* aqlCollection, ProducesResults producesResults,
     ConsultAqlWriteFilter consultAqlWriteFilter, IgnoreErrors ignoreErrors,
     DoCount doCount, IsReplace isReplace, IgnoreDocumentNotFound ignoreDocumentNotFound)
-    : _query(query),
+    : _engine(engine), 
+      _query(query),
       _options(options),
       _aqlCollection(aqlCollection),
       _producesResults(ProducesResults(producesResults._value || !_options.silent)),

--- a/arangod/Aql/ModificationExecutorInfos.h
+++ b/arangod/Aql/ModificationExecutorInfos.h
@@ -37,6 +37,7 @@
 namespace arangodb {
 namespace aql {
 
+class ExecutionEngine;
 class QueryContext;
 
 struct BoolWrapper {
@@ -65,7 +66,8 @@ struct IgnoreDocumentNotFound : BoolWrapper {
 };
 
 struct ModificationExecutorInfos {
-  ModificationExecutorInfos(RegisterId input1RegisterId, RegisterId input2RegisterId,
+  ModificationExecutorInfos(ExecutionEngine* engine, 
+                            RegisterId input1RegisterId, RegisterId input2RegisterId,
                             RegisterId input3RegisterId, RegisterId outputNewRegisterId,
                             RegisterId outputOldRegisterId, RegisterId outputRegisterId,
                             arangodb::aql::QueryContext& query, OperationOptions options,
@@ -79,7 +81,10 @@ struct ModificationExecutorInfos {
   ModificationExecutorInfos(ModificationExecutorInfos const&) = delete;
   ~ModificationExecutorInfos() = default;
 
+  ExecutionEngine* engine() const { return _engine; }
+
   /// @brief the variable produced by Return
+  arangodb::aql::ExecutionEngine* _engine;
   arangodb::aql::QueryContext& _query;
   OperationOptions _options;
   aql::Collection const* _aqlCollection;

--- a/arangod/Aql/ModificationNodes.cpp
+++ b/arangod/Aql/ModificationNodes.cpp
@@ -151,6 +151,7 @@ std::unique_ptr<ExecutionBlock> RemoveNode::createBlock(
   auto registerInfos = createRegisterInfos(std::move(readableInputRegisters), std::move(writableOutputRegisters));
 
   auto executorInfos = ModificationExecutorInfos(
+      &engine,
       inDocRegister, RegisterPlan::MaxRegisterId, RegisterPlan::MaxRegisterId,
       outputNew, outputOld, RegisterPlan::MaxRegisterId /*output*/,
       _plan->getAst()->query(), std::move(options), collection(),
@@ -243,6 +244,7 @@ std::unique_ptr<ExecutionBlock> InsertNode::createBlock(
   auto registerInfos = createRegisterInfos(std::move(readableInputRegisters), std::move(writableOutputRegisters));
 
   ModificationExecutorInfos infos(
+      &engine,
       inputRegister, RegisterPlan::MaxRegisterId, RegisterPlan::MaxRegisterId,
       outputNew, outputOld, RegisterPlan::MaxRegisterId /*output*/,
       _plan->getAst()->query(), std::move(options), collection(),
@@ -358,6 +360,7 @@ std::unique_ptr<ExecutionBlock> UpdateNode::createBlock(
       ModificationExecutorHelpers::convertOptions(_options, _outVariableNew, _outVariableOld);
 
   auto executorInfos = ModificationExecutorInfos(
+      &engine,
       inDocRegister, inKeyRegister, RegisterPlan::MaxRegisterId, outputNew, outputOld,
       RegisterPlan::MaxRegisterId /*output*/, _plan->getAst()->query(),
       std::move(options), collection(), ProducesResults(producesResults()),
@@ -445,6 +448,7 @@ std::unique_ptr<ExecutionBlock> ReplaceNode::createBlock(
       ModificationExecutorHelpers::convertOptions(_options, _outVariableNew, _outVariableOld);
 
   auto executorInfos = ModificationExecutorInfos(
+      &engine,
       inDocRegister, inKeyRegister, RegisterPlan::MaxRegisterId, outputNew, outputOld,
       RegisterPlan::MaxRegisterId /*output*/, _plan->getAst()->query(),
       std::move(options), collection(), ProducesResults(producesResults()),
@@ -555,6 +559,7 @@ std::unique_ptr<ExecutionBlock> UpsertNode::createBlock(
       ModificationExecutorHelpers::convertOptions(_options, _outVariableNew, _outVariableOld);
 
   auto executorInfos = ModificationExecutorInfos(
+      &engine,
       inDoc, insert, update, outputNew, outputOld,
       RegisterPlan::MaxRegisterId /*output*/, _plan->getAst()->query(),
       std::move(options), collection(), ProducesResults(producesResults()),

--- a/arangod/Aql/RemoveModifier.cpp
+++ b/arangod/Aql/RemoveModifier.cpp
@@ -73,6 +73,6 @@ ModifierOperationType RemoveModifierCompletion::accumulate(ModificationExecutorA
   }
 }
 
-OperationResult RemoveModifierCompletion::transact(transaction::Methods& trx, VPackSlice const& data) {
-  return trx.remove(_infos._aqlCollection->name(), data, _infos._options);
+futures::Future<OperationResult> RemoveModifierCompletion::transact(transaction::Methods& trx, VPackSlice const& data) {
+  return trx.removeAsync(_infos._aqlCollection->name(), data, _infos._options);
 }

--- a/arangod/Aql/RemoveModifier.h
+++ b/arangod/Aql/RemoveModifier.h
@@ -27,6 +27,7 @@
 #include "Aql/ModificationExecutor.h"
 #include "Aql/ModificationExecutorAccumulator.h"
 #include "Aql/ModificationExecutorInfos.h"
+#include "Futures/Future.h"
 
 #include <velocypack/Builder.h>
 
@@ -42,7 +43,7 @@ class RemoveModifierCompletion {
 
   ModifierOperationType accumulate(ModificationExecutorAccumulator& accu,
                                    InputAqlItemRow& row);
-  OperationResult transact(transaction::Methods& trx, VPackSlice const& data);
+  futures::Future<OperationResult> transact(transaction::Methods& trx, VPackSlice const& data);
 
  private:
   ModificationExecutorInfos& _infos;

--- a/arangod/Aql/SingleRemoteModificationExecutor.h
+++ b/arangod/Aql/SingleRemoteModificationExecutor.h
@@ -35,9 +35,11 @@
 
 namespace arangodb {
 namespace aql {
+class ExecutionEngine;
 
 struct SingleRemoteModificationInfos : ModificationExecutorInfos {
-  SingleRemoteModificationInfos(RegisterId inputRegister, RegisterId outputNewRegisterId,
+  SingleRemoteModificationInfos(ExecutionEngine* engine,
+                                RegisterId inputRegister, RegisterId outputNewRegisterId,
                                 RegisterId outputOldRegisterId, RegisterId outputRegisterId,
                                 arangodb::aql::QueryContext& query, OperationOptions options,
                                 aql::Collection const* aqlCollection,
@@ -45,7 +47,7 @@ struct SingleRemoteModificationInfos : ModificationExecutorInfos {
                                 IgnoreErrors ignoreErrors,
                                 IgnoreDocumentNotFound ignoreDocumentNotFound,
                                 std::string key, bool hasParent, bool replaceIndex)
-      : ModificationExecutorInfos(inputRegister, RegisterPlan::MaxRegisterId,
+      : ModificationExecutorInfos(engine, inputRegister, RegisterPlan::MaxRegisterId,
                                   RegisterPlan::MaxRegisterId, outputNewRegisterId,
                                   outputOldRegisterId, outputRegisterId, query,
                                   std::move(options), aqlCollection,

--- a/arangod/Aql/UpdateReplaceModifier.cpp
+++ b/arangod/Aql/UpdateReplaceModifier.cpp
@@ -107,10 +107,10 @@ ModifierOperationType UpdateReplaceModifierCompletion::accumulate(
   }
 }
 
-OperationResult UpdateReplaceModifierCompletion::transact(transaction::Methods& trx, VPackSlice const data) {
+futures::Future<OperationResult> UpdateReplaceModifierCompletion::transact(transaction::Methods& trx, VPackSlice const data) {
   if (_infos._isReplace) {
-    return trx.replace(_infos._aqlCollection->name(), data, _infos._options);
+    return trx.replaceAsync(_infos._aqlCollection->name(), data, _infos._options);
   } else {
-    return trx.update(_infos._aqlCollection->name(), data, _infos._options);
+    return trx.updateAsync(_infos._aqlCollection->name(), data, _infos._options);
   }
 }

--- a/arangod/Aql/UpdateReplaceModifier.h
+++ b/arangod/Aql/UpdateReplaceModifier.h
@@ -27,6 +27,7 @@
 #include "Aql/ModificationExecutor.h"
 #include "Aql/ModificationExecutorAccumulator.h"
 #include "Aql/ModificationExecutorInfos.h"
+#include "Futures/Future.h"
 
 #include <velocypack/Builder.h>
 
@@ -43,7 +44,7 @@ class UpdateReplaceModifierCompletion {
 
   ModifierOperationType accumulate(ModificationExecutorAccumulator& accu,
                                    InputAqlItemRow& row);
-  OperationResult transact(transaction::Methods& trx, VPackSlice const data);
+  futures::Future<OperationResult> transact(transaction::Methods& trx, VPackSlice const data);
 
  private:
   ModificationExecutorInfos& _infos;

--- a/tests/js/server/aql/aql-modify-subqueries.js
+++ b/tests/js/server/aql/aql-modify-subqueries.js
@@ -1623,7 +1623,6 @@ function ahuacatlModifySuite () {
         c2.truncate({ compact: false });
       }
     },
-
   };
 }
 
@@ -1746,6 +1745,14 @@ function ahuacatlModifySkipSuite () {
 
       assertEqual(1000, db[cn].count());
     },
+
+    testSubqueryFullCount : function () {
+      const query = "LET sub = NOOPT(FOR doc IN " + cn + " REMOVE doc IN " + cn + " RETURN OLD) COLLECT WITH COUNT INTO l RETURN l"; 
+      let result = AQL_EXECUTE(query, null, { optimizer: { rules: ["-all"] } });
+      assertEqual(1, result.json.length);
+      assertEqual(1, result.json[0]);
+    },
+
   };
 }
 


### PR DESCRIPTION
### Scope & Purpose

This PR makes the AQL modification operations INSERT, UPDATE, REPLACE, REMOVE return futures so they become non-blocking. UPSERT is currently still blocking, but this will be addressed soon.

Async operations work for `produceRows` already in single server and cluster mode, but `skipRowsRange` does not yet work in cluster mode.

This still needs to be sorted out. After that, UPSERT needs to be made async.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
