### PR TITLE
Use lower defaultMaxNodesPerCallstack for Mac.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Reduce default value for max-nodes-per-callstack to 200 for OSX, because on
+  OSX worker threads have a stack size of only 512kb.
+
 * Make `--javascript.copy-installation` also copy the `node_modules` sub
   directory. This is required so we have a full copy of the JavaScript
   dependencies and not one that excludes some infrequently changed modules.

--- a/arangod/Aql/QueryOptions.cpp
+++ b/arangod/Aql/QueryOptions.cpp
@@ -38,7 +38,13 @@ using namespace arangodb::aql;
 
 size_t QueryOptions::defaultMemoryLimit = 0;
 size_t QueryOptions::defaultMaxNumberOfPlans = 128;
+#ifdef __APPLE__
+// On OSX the default stack size for worker threads (non-main thread) is 512kb
+// which is rather low, so we have to use a lower default
+size_t QueryOptions::defaultMaxNodesPerCallstack = 200;
+#else
 size_t QueryOptions::defaultMaxNodesPerCallstack = 250;
+#endif
 double QueryOptions::defaultMaxRuntime = 0.0;
 double QueryOptions::defaultTtl;
 bool QueryOptions::defaultFailOnWarning = false;


### PR DESCRIPTION
### Scope & Purpose

On OSX the default stack size for worker threads (non-main thread) is 512kb which is rather low, so we have to use a lower default for the max. number of nodes per callstack,

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested* by @mchacki 
