### PR TITLE
experiment to check if SyncWAL works on Windows

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Honor the value of startup option `--rocksdb.sync-interval` on Windows, too.
+  Previously, the value was ignored and WAL syncing on Windows was using a
+  different code paths than on the other supported platforms. Now syncing is
+  unified across all platforms, and they all call RocksDB's `SyncWAL()`.
+
 * Updated ArangoDB Starter to 0.15.1-preview-4.
 
 * APM-132: Clean up collection statuses

--- a/arangod/RocksDBEngine/Methods/RocksDBTrxBaseMethods.cpp
+++ b/arangod/RocksDBEngine/Methods/RocksDBTrxBaseMethods.cpp
@@ -376,7 +376,7 @@ arangodb::Result RocksDBTrxBaseMethods::doCommit() {
   _state->commitCollections(_lastWrittenOperationTick);
   cleanupCollTrx.cancel();
 
-  // wait for sync if required, for all other platforms but Windows
+  // wait for sync if required
   if (_state->waitForSync()) {
     auto& selector = _state->vocbase().server().getFeature<EngineSelectorFeature>();
     auto& engine = selector.engine<RocksDBEngine>();

--- a/arangod/RocksDBEngine/Methods/RocksDBTrxBaseMethods.cpp
+++ b/arangod/RocksDBEngine/Methods/RocksDBTrxBaseMethods.cpp
@@ -348,17 +348,6 @@ arangodb::Result RocksDBTrxBaseMethods::doCommit() {
   // if we fail during commit, make sure we remove blockers, etc.
   auto cleanupCollTrx = scopeGuard([this]() { _state->cleanupCollections(); });
 
-#ifdef _WIN32
-  // set wait for sync flag if required
-  // we do this only for Windows here, because all other platforms use the
-  // RocksDB SyncThread to do the syncing
-  if (_state->waitForSync()) {
-    rocksdb::WriteOptions wo;
-    wo.sync = true;
-    _rocksTransaction->SetWriteOptions(wo);
-  }
-#endif
-
   // total number of sequence ID consuming records
   uint64_t numOps = _rocksTransaction->GetNumPuts() +
                     _rocksTransaction->GetNumDeletes() +
@@ -387,7 +376,6 @@ arangodb::Result RocksDBTrxBaseMethods::doCommit() {
   _state->commitCollections(_lastWrittenOperationTick);
   cleanupCollTrx.cancel();
 
-#ifndef _WIN32
   // wait for sync if required, for all other platforms but Windows
   if (_state->waitForSync()) {
     auto& selector = _state->vocbase().server().getFeature<EngineSelectorFeature>();
@@ -402,7 +390,6 @@ arangodb::Result RocksDBTrxBaseMethods::doCommit() {
       return RocksDBSyncThread::sync(engine.db()->GetBaseDB());
     }
   }
-#endif
 
   return Result();
 }

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -184,12 +184,7 @@ RocksDBEngine::RocksDBEngine(application_features::ApplicationServer& server)
       _pruneWaitTimeInitial(180.0),
       _maxWalArchiveSizeLimit(0),
       _releasedTick(0),
-#ifdef _WIN32
-      // background syncing is not supported on Windows
-      _syncInterval(0),
-#else
       _syncInterval(100),
-#endif
       _syncDelayThreshold(5000),
       _requiredDiskFreePercentage(0.01),
       _requiredDiskFreeBytes(16 * 1024 * 1024),
@@ -409,14 +404,6 @@ void RocksDBEngine::validateOptions(std::shared_ptr<options::ProgramOptions> opt
           << "auto-adjusting value of --rocksdb.sync-delay-threshold to " << _syncDelayThreshold << " ms";
     }
   }
-
-#ifdef _WIN32
-  if (_syncInterval > 0) {
-    LOG_TOPIC("68301", WARN, arangodb::Logger::CONFIG)
-        << "automatic syncing of RocksDB WAL via background thread is not "
-        << " supported on this platform";
-  }
-#endif
 
   if (_pruneWaitTimeInitial < 10) {
     LOG_TOPIC("a9667", WARN, arangodb::Logger::ENGINES)

--- a/arangod/RocksDBEngine/RocksDBSyncThread.cpp
+++ b/arangod/RocksDBEngine/RocksDBSyncThread.cpp
@@ -75,9 +75,6 @@ Result RocksDBSyncThread::syncWal() {
 }
 
 Result RocksDBSyncThread::sync(rocksdb::DB* db) {
-  // if called on Windows, we would get the following error from RocksDB:
-  // > Not implemented: SyncWAL() is not supported for this implementation of
-  // WAL file
   LOG_TOPIC("a3978", TRACE, Logger::ENGINES) << "syncing RocksDB WAL";
 
   rocksdb::Status status = db->SyncWAL();

--- a/arangod/RocksDBEngine/RocksDBSyncThread.cpp
+++ b/arangod/RocksDBEngine/RocksDBSyncThread.cpp
@@ -75,7 +75,6 @@ Result RocksDBSyncThread::syncWal() {
 }
 
 Result RocksDBSyncThread::sync(rocksdb::DB* db) {
-#ifndef _WIN32
   // if called on Windows, we would get the following error from RocksDB:
   // > Not implemented: SyncWAL() is not supported for this implementation of
   // WAL file
@@ -85,7 +84,6 @@ Result RocksDBSyncThread::sync(rocksdb::DB* db) {
   if (!status.ok()) {
     return rocksutils::convertStatus(status);
   }
-#endif
   return Result();
 }
 


### PR DESCRIPTION
### Scope & Purpose

Enable RocksDB SyncWAL() calls on Windows as well.
Previously they were disabled for Windows but enabled for all other platforms. For Windows, there was a workaround. The reason for not calling SyncWAL() on Windows previously was that RocksDB reported the operation as unsupported.

Tested manually on Windows that it now works.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
