### PR TITLE
disable a test that only works with failure points enabled

### DIFF
--- a/tests/js/common/shell/test-kill-queries.js
+++ b/tests/js/common/shell/test-kill-queries.js
@@ -277,7 +277,8 @@ function QueryKillSuite() {
   return GenericQueryKillSuite();
 }
 
-jsunity.run(QueryKillSuite);
+if (internal.debugCanUseFailAt()) {
+  jsunity.run(QueryKillSuite);
+}
 
 return jsunity.done();
-


### PR DESCRIPTION
### Scope & Purpose

Disable a test that only works with failure points enabled.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *shell_server*, *shell_client*.
