### PR TITLE
attempt to pacify clang-1100

### DIFF
--- a/arangod/Graph/Enumerators/TwoSidedEnumerator.h
+++ b/arangod/Graph/Enumerators/TwoSidedEnumerator.h
@@ -121,7 +121,9 @@ class TwoSidedEnumerator {
                      TwoSidedEnumeratorOptions&& options,
                      arangodb::ResourceMonitor& resourceMonitor);
   TwoSidedEnumerator(TwoSidedEnumerator const& other) = delete;
-  TwoSidedEnumerator(TwoSidedEnumerator&& other) noexcept = default;
+  TwoSidedEnumerator& operator=(TwoSidedEnumerator const& other) = delete;
+  TwoSidedEnumerator(TwoSidedEnumerator&& other) = delete;
+  TwoSidedEnumerator& operator=(TwoSidedEnumerator&& other) = delete;
 
   ~TwoSidedEnumerator();
 


### PR DESCRIPTION
### Scope & Purpose

Devel port of https://github.com/arangodb/arangodb/pull/14553

Attempt to pacify specific clang compiler version. This is just a workaround and may not fix the problem.

- [x] :hankey: Bugfix (requires CHANGELOG entry)

#### Backports:

- [x] Backports required for 3.8: https://github.com/arangodb/arangodb/pull/14553

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
