### PR TITLE
Removed unused function declaration

### DIFF
--- a/arangod/IResearch/IResearchFilterFactory.cpp
+++ b/arangod/IResearch/IResearchFilterFactory.cpp
@@ -512,14 +512,6 @@ FORCE_INLINE void appendExpression(irs::boolean_filter& filter,
   exprFilter.boost(filterCtx.boost);
 }
 
-FORCE_INLINE void appendExpression(irs::boolean_filter& filter,
-                                   std::shared_ptr<aql::AstNode>&& node,
-                                   QueryContext const& ctx, FilterContext const& filterCtx) {
-  auto& exprFilter = filter.add<arangodb::iresearch::ByExpression>();
-  exprFilter.init(*ctx.plan, *ctx.ast, std::move(node));
-  exprFilter.boost(filterCtx.boost);
-}
-
 Result byTerm(irs::by_term* filter, std::string&& name,
               ScopedAqlValue const& value, QueryContext const& /*ctx*/,
               FilterContext const& filterCtx) {


### PR DESCRIPTION
### Scope & Purpose
By compiling with clang 11, found through a warning that a function overload declaration of appendExpression was not being used.
```
/arangodb/arangodb_clang/arangod/IResearch/IResearchFilterFactory.cpp:515:19: warning: unused function 'appendExpression' [-Wunused-function]
FORCE_INLINE void appendExpression(irs::boolean_filter& filter,
```

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*