### PR TITLE
do not use -n on echo, this might not be supported and is not necessary (3.6)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.6.16 (XXXX-XX-XX)
 --------------------
 
+* Fix BTS-453: Download of a HotBackup from remote source doesn't work on macOS.
+
 * Updated arangosync to 1.7.0.
 
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/enterprise/pull/689
Enterprise companion PR: https://github.com/arangodb/enterprise/pull/718

BTS-453: "echo -n" does not work reliably. It strongly depends on the log-in shell.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/718
- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-453

### Testing & Verification

- [x] This change is already covered by existing tests, such as *hot_backup*.
