### PR TITLE
[3.8] timely update of database servers in cluster cache

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.8.1 (XXXX-XX-XX)
 -------------------
 
+* Timely update of database server list on health check fixes BTS-505.
+
 * Updated JavaScript dependencies, including breaking changes to non-public
   modules. We recommend always bundling your own copy of third-party modules,
   even ones listed as public.

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -271,14 +271,15 @@ void HeartbeatThread::run() {
       return true;
     };
     std::vector<std::string> const serverAgencyPaths{
-      "Current/ServersRegistered", "Target/MapUniqueToShortID", "Current/ServersKnown",
-      "Current/ServersKnown/" + ServerState::instance()->getId()};
+      "Current/ServersRegistered", "Target/MapUniqueToShortID", "Current/ServersKnown", "Supervision/Health",
+      "Current/ServersKnown/" + ServerState::instance()->getId(), ""};
     for (auto const& path : serverAgencyPaths) {
       serverCallbacks.try_emplace(path, std::make_shared<AgencyCallback>(_server, path, upsrv, true, false));
     }
     std::function<bool(VPackSlice const& result)> upcrd = [self = shared_from_this()] (VPackSlice const& result) {
       LOG_TOPIC("2f09e", DEBUG, Logger::HEARTBEAT) << "Updating cluster's cache of current coordinators";
       self->server().getFeature<ClusterFeature>().clusterInfo().loadCurrentCoordinators();
+      self->server().getFeature<ClusterFeature>().clusterInfo().loadCurrentDBServers();
       return true;
     };
     std::string const path = "Current/Coordinators";

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -272,7 +272,7 @@ void HeartbeatThread::run() {
     };
     std::vector<std::string> const serverAgencyPaths{
       "Current/ServersRegistered", "Target/MapUniqueToShortID", "Current/ServersKnown", "Supervision/Health",
-      "Current/ServersKnown/" + ServerState::instance()->getId(), ""};
+      "Current/ServersKnown/" + ServerState::instance()->getId()};
     for (auto const& path : serverAgencyPaths) {
       serverCallbacks.try_emplace(path, std::make_shared<AgencyCallback>(_server, path, upsrv, true, false));
     }


### PR DESCRIPTION
…te of cluster info

### Scope & Purpose

*Allow timely update of database server lists of isolated database servers.* **Fixes BTS-505**

- [X] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [X] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [X] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [X] This change is a trivial rework / code cleanup without any test coverage.
- [X] The behavior in this PR was *manually tested*
- [X] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run: https://jenkins.arangodb.biz/job/arangodb-matrix-pr/16437/

### Documentation

> All new features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the CHANGELOG so that
> support, end users, and other developers have a concise overview. 

- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
