### PR TITLE
fixed issue #14592: IS_NULL(@x) isn't recognized as a constant expression

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.8.1 (XXXX-XX-XX)
 -------------------
 
+* Fixed issue #14592:  IS_NULL(@x) isn't recognized as a constant expression.
+
 * Fixed various problems in GEO_INTERSECTS: wrong results, not implemented cases
   and numerically unstable behaviour. In particular, the case of the
   intersection of two polygons in which one is an S2LngLatRect is fixed

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -3463,8 +3463,9 @@ AstNode* Ast::optimizeFunctionCall(transaction::Methods& trx,
     auto args = node->getMember(0);
     if (args->numMembers() == 1) {
       // replace IS_NULL(x) function call with `x == null`
-      return createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_EQ,
-                                      args->getMemberUnchecked(0), createNodeValueNull());
+      return this->optimizeBinaryOperatorRelational(trx, aqlFunctionsInternalCache, 
+                                                    createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_EQ,
+                                                                             args->getMemberUnchecked(0), createNodeValueNull()));
     }
 #if 0
   } else if (func->name == "LIKE") {

--- a/tests/js/server/aql/aql-queries-simple.js
+++ b/tests/js/server/aql/aql-queries-simple.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global assertEqual, AQL_EXECUTE */
+/*global assertEqual, assertTrue, assertFalse, AQL_EXECUTE, AQL_EXPLAIN */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief tests for query language, simple queries
@@ -1333,6 +1333,35 @@ function ahuacatlQuerySimpleTestSuite () {
       
         assertQueryError(errors.ERROR_QUERY_ARRAY_EXPECTED.code, "LET a = NOOPT(@value) FOR x IN a RETURN 1", { value }); 
       });
+    },
+
+    testIsNullConversion : function() {
+      let q = `RETURN IS_NULL(42)`; 
+      let nodes = AQL_EXPLAIN(q).plan.nodes.filter((n) => n.type === 'CalculationNode');
+      assertEqual(1, nodes.length);
+      let expr = nodes[0].expression;
+      assertEqual("value", expr.type);
+      assertFalse(expr.value);
+      
+      q = `RETURN IS_NULL(null)`; 
+      nodes = AQL_EXPLAIN(q).plan.nodes.filter((n) => n.type === 'CalculationNode');
+      assertEqual(1, nodes.length);
+      expr = nodes[0].expression;
+      assertEqual("value", expr.type);
+      assertTrue(expr.value);
+      
+      q = `RETURN IS_NULL(@value)`; 
+      nodes = AQL_EXPLAIN(q, {value: 42}).plan.nodes.filter((n) => n.type === 'CalculationNode');
+      assertEqual(1, nodes.length);
+      expr = nodes[0].expression;
+      assertEqual("value", expr.type);
+      assertFalse(expr.value);
+      
+      nodes = AQL_EXPLAIN(q, {value: null}).plan.nodes.filter((n) => n.type === 'CalculationNode');
+      assertEqual(1, nodes.length);
+      expr = nodes[0].expression;
+      assertEqual("value", expr.type);
+      assertTrue(expr.value);
     },
 
   };


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/14603
Bugfix for issue #14592 

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.7*

#### Related Information

- [x] GitHub issue / Jira ticket number: https://github.com/arangodb/arangodb/issues/14592

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (shell_server_aql)
