### PR TITLE
fix BTS-536 "Upgrading without rest-server is aborted by error".

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fixed issue BTS-536 "Upgrading without rest-server is aborted by error".
+  Now stating `--server.rest-server false` does not require the additional
+  `--console` argument for upgrading a server.
+
 * Fixed various problems in GEO_INTERSECTS: wrong results, not implemented
   cases and numerically unstable behaviour. In particular, the case of
   the intersection of two polygons in which one is an S2LngLatRect

--- a/arangod/RestServer/ServerFeature.cpp
+++ b/arangod/RestServer/ServerFeature.cpp
@@ -144,8 +144,10 @@ void ServerFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
         << "'--javascript.script'";
     FATAL_ERROR_EXIT();
   }
+  
+  DatabaseFeature& db = server().getFeature<DatabaseFeature>();
 
-  if (_operationMode == OperationMode::MODE_SERVER && !_restServer) {
+  if (_operationMode == OperationMode::MODE_SERVER && !_restServer && db.upgrade()) {
     LOG_TOPIC("8daab", FATAL, arangodb::Logger::FIXME)
         << "need at least '--console', '--javascript.unit-tests' or"
         << "'--javascript.script if rest-server is disabled";

--- a/arangod/RestServer/ServerFeature.cpp
+++ b/arangod/RestServer/ServerFeature.cpp
@@ -147,7 +147,7 @@ void ServerFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
   
   DatabaseFeature& db = server().getFeature<DatabaseFeature>();
 
-  if (_operationMode == OperationMode::MODE_SERVER && !_restServer && db.upgrade()) {
+  if (_operationMode == OperationMode::MODE_SERVER && !_restServer && !db.upgrade()) {
     LOG_TOPIC("8daab", FATAL, arangodb::Logger::FIXME)
         << "need at least '--console', '--javascript.unit-tests' or"
         << "'--javascript.script if rest-server is disabled";


### PR DESCRIPTION
### Scope & Purpose

Bugfix for https://arangodb.atlassian.net/browse/BTS-536

Now stating `--server.rest-server false` does not require the additional `--console` argument for upgrading a server.

Starting with `--server.rest-server false --database.auto-upgrade true` now works and does not require the extra `--console` argument. Previously the startup was just aborted with an error message.

I couldn't find a good way to test this with the `server_parameters` test suite. This test suite assumes a running server after starting up with arbitrary startup options. But here we won't have a running server after startup. So I tested the changes manually for single server and coordinator.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for *3.8*: https://github.com/arangodb/arangodb/pull/14607

#### Related Information

- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-536

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
