### PR TITLE
fuse CMake options for maintainers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -758,12 +758,14 @@ endif (ASM_OPTIMIZATIONS)
 ################################################################################
 
 option(USE_MAINTAINER_MODE
-  "whether we want to have assertions and other development features"
+  "whether we want to have assertions, unit tests, failure tests and other development features"
   OFF
 )
 
 if (USE_MAINTAINER_MODE)
   add_definitions("-DARANGODB_ENABLE_MAINTAINER_MODE=1")
+
+  # use fortified string and memory functions
   if (CMAKE_COMPILER_IS_GNUCC AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_definitions("-D_FORTIFY_SOURCE=2")
   endif()
@@ -776,27 +778,9 @@ if (USE_MAINTAINER_MODE)
   find_program(AWK_EXECUTABLE awk)
 endif ()
 
-option(USE_GOOGLE_TESTS "Compile C++ unit tests" ON)
-if (USE_GOOGLE_TESTS)
-  add_definitions("-DARANGODB_USE_GOOGLE_TESTS=1")
-endif()
-
 include(debugInformation)
 find_program(READELF_EXECUTABLE readelf)
 detect_binary_id_type(CMAKE_DEBUG_FILENAMES_SHA_SUM)
-
-################################################################################
-## FAILURE TESTS
-################################################################################
-
-option(USE_FAILURE_TESTS
-  "whether we want to have failure tests compiled in"
-  OFF
-)
-
-if (USE_FAILURE_TESTS)
-  add_definitions("-DARANGODB_ENABLE_FAILURE_TESTS=1")
-endif ()
 
 ################################################################################
 ## INTERPROCEDURAL OPTIMIZATION (LINK TIME OPTIMIZATION)
@@ -817,18 +801,14 @@ if (USE_IPO STREQUAL "AUTO")
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91375.
   # So this check may be removed later as soon as we use fixed gcc versions.
   # - Tobias, 2019-08-08
-  if (NOT USE_GOOGLE_TESTS AND
+  if (NOT USE_MAINTAINER_MODE AND
     (CMAKE_BUILD_TYPE STREQUAL "Release"
     OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"
     OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel"))
     set(IPO_ENABLED True)
-  else()
-    set(IPO_ENABLED False)
   endif ()
 elseif (USE_IPO)
   set(IPO_ENABLED True)
-else()
-  set(IPO_ENABLED False)
 endif()
 
 message(STATUS "IPO_ENABLED: ${IPO_ENABLED}")
@@ -1380,7 +1360,7 @@ add_subdirectory(arangosh)
 add_subdirectory(arangod)
 
 
-if (USE_GOOGLE_TESTS)
+if (USE_MAINTAINER_MODE)
   add_subdirectory(tests)
 endif ()
 
@@ -1421,7 +1401,7 @@ if (NOT USE_PRECOMPILED_V8)
   add_dependencies(arangoimport  v8_build)
   add_dependencies(arangorestore v8_build)
   add_dependencies(arangosh      v8_build)
-  if (USE_GOOGLE_TESTS)
+  if (USE_MAINTAINER_MODE)
     add_dependencies(arangodbtests v8_build)
   endif ()
 endif ()

--- a/README_maintainers.md
+++ b/README_maintainers.md
@@ -717,7 +717,7 @@ Controlling the place where the test-data is stored:
 (Linux/Mac case. On Windows `TMP` or `TEMP` - as returned by `GetTempPathW` are the way to go)
 
 Note that the `arangodbtests` executable is not compiled and shipped for
-production releases (`-DUSE_GOOGLE_TESTS=off`).
+production releases (`-DUSE_MAINTAINER_MODE=off`).
 
 Run all tests:
 

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -549,7 +549,7 @@ JOB_STATUS MoveShard::pendingLeader() {
                      } else {
                        LOG_TOPIC("edfc7", WARN, Logger::SUPERVISION)
                          << "missing current entry for " << _shard << " or a clone, we'll be back";
-#ifndef ARANGODB_USE_GOOGLE_TESTS
+#ifndef ARANGODB_ENABLE_MAINTAINER_MODE
                        TRI_ASSERT(false);
 #endif
                      }

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -104,7 +104,7 @@ bool State::persist(index_t index, term_t term, uint64_t millis,
                     arangodb::velocypack::Slice const& entry,
                     std::string const& clientId) const {
 
-  TRI_IF_FAILURE("State::persist") {
+  ARANGODB_IF_FAILURE("State::persist") {
     return true;
   }
 
@@ -155,7 +155,7 @@ bool State::persist(index_t index, term_t term, uint64_t millis,
 bool State::persistConf(index_t index, term_t term, uint64_t millis,
                         arangodb::velocypack::Slice const& entry,
                         std::string const& clientId) const {
-  TRI_IF_FAILURE("State::persistConf") {
+  ARANGODB_IF_FAILURE("State::persistConf") {
     return true;
   }
 
@@ -1223,7 +1223,7 @@ index_t State::lastCompactionAt() const { return _lastCompactionAt; }
 
 /// Log compaction
 bool State::compact(index_t cind, index_t keep) {
-  TRI_IF_FAILURE("State::compact") {
+  ARANGODB_IF_FAILURE("State::compact") {
     return true;
   }
 
@@ -1373,7 +1373,7 @@ bool State::removeObsolete(index_t cind) {
 /// Persist a compaction snapshot
 bool State::persistCompactionSnapshot(index_t cind, arangodb::consensus::term_t term,
                                       arangodb::consensus::Store& snapshot) {
-  TRI_IF_FAILURE("State::persistCompactionSnapshot") {
+  ARANGODB_IF_FAILURE("State::persistCompactionSnapshot") {
     return true;
   }
 

--- a/arangod/Aql/AqlItemBlockManager.cpp
+++ b/arangod/Aql/AqlItemBlockManager.cpp
@@ -152,13 +152,13 @@ arangodb::ResourceMonitor& AqlItemBlockManager::resourceMonitor() const noexcept
   return _resourceMonitor;
 }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 void AqlItemBlockManager::deleteBlock(AqlItemBlock* block) {
   delete block;
 }
 #endif
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 uint32_t AqlItemBlockManager::getBucketId(size_t targetSize) noexcept {
   return Bucket::getId(targetSize);
 }

--- a/arangod/Aql/AqlItemBlockManager.h
+++ b/arangod/Aql/AqlItemBlockManager.h
@@ -70,7 +70,7 @@ class AqlItemBlockManager {
     return _constValueBlock;
   }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // Only used for the mocks in the catch tests. Other code should always use
   // SharedAqlItemBlockPtr which in turn call returnBlock()!
   static void deleteBlock(AqlItemBlock* block);
@@ -78,7 +78,7 @@ class AqlItemBlockManager {
   static uint32_t getBucketId(size_t targetSize) noexcept;
 #endif
 
-#ifndef ARANGODB_USE_GOOGLE_TESTS
+#ifndef ARANGODB_ENABLE_MAINTAINER_MODE
  protected:
 #else
   // make returnBlock public for tests so it can be mocked

--- a/arangod/Aql/BlocksWithClients.cpp
+++ b/arangod/Aql/BlocksWithClients.cpp
@@ -250,7 +250,7 @@ auto BlocksWithClientsImpl<Executor>::fetchMore(AqlCallStack stack) -> Execution
   // we cannot get it back.
   TRI_ASSERT(skipped.getSkipCount() == 0);
 
-  TRI_IF_FAILURE("ExecutionBlock::getBlock") {
+  ARANGODB_IF_FAILURE("ExecutionBlock::getBlock") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 

--- a/arangod/Aql/CalculationExecutor.cpp
+++ b/arangod/Aql/CalculationExecutor.cpp
@@ -87,7 +87,7 @@ template <CalculationType calculationType>
 std::tuple<ExecutorState, typename CalculationExecutor<calculationType>::Stats, AqlCall>
 CalculationExecutor<calculationType>::produceRows(AqlItemBlockInputRange& inputRange,
                                                   OutputAqlItemRow& output) {
-  TRI_IF_FAILURE("CalculationExecutor::produceRows") {
+  ARANGODB_IF_FAILURE("CalculationExecutor::produceRows") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
   ExecutorState state = ExecutorState::HASMORE;
@@ -153,10 +153,10 @@ void CalculationExecutor<CalculationType::Reference>::doEvaluation(InputAqlItemR
   auto const& inRegs = _infos.getExpInRegs();
   TRI_ASSERT(inRegs.size() == 1);
 
-  TRI_IF_FAILURE("CalculationBlock::executeExpression") {
+  ARANGODB_IF_FAILURE("CalculationBlock::executeExpression") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
-  TRI_IF_FAILURE("CalculationBlock::fillBlockWithReference") {
+  ARANGODB_IF_FAILURE("CalculationBlock::fillBlockWithReference") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -177,7 +177,7 @@ void CalculationExecutor<CalculationType::Condition>::doEvaluation(InputAqlItemR
   AqlValue a = _infos.getExpression().execute(&ctx, mustDestroy);
   AqlValueGuard guard(a, mustDestroy);
 
-  TRI_IF_FAILURE("CalculationBlock::executeExpression") {
+  ARANGODB_IF_FAILURE("CalculationBlock::executeExpression") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -210,7 +210,7 @@ void CalculationExecutor<CalculationType::V8Condition>::doEvaluation(InputAqlIte
   AqlValue a = _infos.getExpression().execute(&ctx, mustDestroy);
   AqlValueGuard guard(a, mustDestroy);
 
-  TRI_IF_FAILURE("CalculationBlock::executeExpression") {
+  ARANGODB_IF_FAILURE("CalculationBlock::executeExpression") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 

--- a/arangod/Aql/ClusterQuery.cpp
+++ b/arangod/Aql/ClusterQuery.cpp
@@ -104,7 +104,7 @@ void ClusterQuery::prepareClusterQuery(VPackSlice querySlice,
     _trx->state()->acceptAnalyzersRevision(analyzersRevision);
   }
   
-  TRI_IF_FAILURE("Query::setupLockTimeout") {
+  ARANGODB_IF_FAILURE("Query::setupLockTimeout") {
     if (RandomGenerator::interval(uint32_t(100)) >= 95) {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_LOCK_TIMEOUT);
     }

--- a/arangod/Aql/ConditionFinder.cpp
+++ b/arangod/Aql/ConditionFinder.cpp
@@ -87,7 +87,7 @@ bool ConditionFinder::before(ExecutionNode* en) {
       if (_sorts.empty()) {
         for (auto& it : ExecutionNode::castTo<SortNode const*>(en)->elements()) {
           _sorts.emplace_back(it.var, it.ascending);
-          TRI_IF_FAILURE("ConditionFinder::sortNode") {
+          ARANGODB_IF_FAILURE("ConditionFinder::sortNode") {
             THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
           }
         }
@@ -99,7 +99,7 @@ bool ConditionFinder::before(ExecutionNode* en) {
       _variableDefinitions.try_emplace(
           ExecutionNode::castTo<CalculationNode const*>(en)->outVariable()->id,
           ExecutionNode::castTo<CalculationNode const*>(en)->expression()->node());
-      TRI_IF_FAILURE("ConditionFinder::variableDefinition") {
+      ARANGODB_IF_FAILURE("ConditionFinder::variableDefinition") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
       break;
@@ -149,7 +149,7 @@ bool ConditionFinder::before(ExecutionNode* en) {
         // will clear out usedIndexes
         IndexIteratorOptions opts;
         opts.ascending = !descending;
-        TRI_IF_FAILURE("ConditionFinder::insertIndexNode") {
+        ARANGODB_IF_FAILURE("ConditionFinder::insertIndexNode") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
 
@@ -227,7 +227,7 @@ bool ConditionFinder::handleFilterCondition(ExecutionNode* en,
 
   // normalize the condition
   condition->normalize(_plan);
-  TRI_IF_FAILURE("ConditionFinder::normalizePlan") {
+  ARANGODB_IF_FAILURE("ConditionFinder::normalizePlan") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 

--- a/arangod/Aql/ConstrainedSortExecutor.cpp
+++ b/arangod/Aql/ConstrainedSortExecutor.cpp
@@ -95,7 +95,7 @@ void ConstrainedSortExecutor::pushRow(InputAqlItemRow const& input) {
   }
 
   TRI_ASSERT(dRow < _infos.limit());
-  TRI_IF_FAILURE("SortBlock::doSortingInner") {
+  ARANGODB_IF_FAILURE("SortBlock::doSortingInner") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -184,7 +184,7 @@ bool ConstrainedSortExecutor::doneSkipping() const noexcept {
 
 ExecutorState ConstrainedSortExecutor::consumeInput(AqlItemBlockInputRange& inputRange) {
   while (inputRange.hasDataRow()) {
-    TRI_IF_FAILURE("SortBlock::doSorting") {
+    ARANGODB_IF_FAILURE("SortBlock::doSorting") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
 

--- a/arangod/Aql/CountCollectExecutor.cpp
+++ b/arangod/Aql/CountCollectExecutor.cpp
@@ -50,7 +50,7 @@ CountCollectExecutor::CountCollectExecutor(Fetcher&, Infos& infos)
 auto CountCollectExecutor::produceRows(AqlItemBlockInputRange& inputRange,
                                        OutputAqlItemRow& output)
     -> std::tuple<ExecutorState, Stats, AqlCall> {
-  TRI_IF_FAILURE("CountCollectExecutor::produceRows") {
+  ARANGODB_IF_FAILURE("CountCollectExecutor::produceRows") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
   // skipped > 0 -> done
@@ -76,7 +76,7 @@ auto CountCollectExecutor::produceRows(AqlItemBlockInputRange& inputRange,
 
 auto CountCollectExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange, AqlCall& call)
     -> std::tuple<ExecutorState, Stats, size_t, AqlCall> {
-  TRI_IF_FAILURE("CountCollectExecutor::produceRows") {
+  ARANGODB_IF_FAILURE("CountCollectExecutor::produceRows") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
   // skipped > 0 -> done

--- a/arangod/Aql/DependencyProxy.cpp
+++ b/arangod/Aql/DependencyProxy.cpp
@@ -78,7 +78,7 @@ DependencyProxy<blockPassthrough>::executeForDependency(size_t dependency,
     std::tie(state, skipped, block) =
         upstreamBlockForDependency(dependency).execute(stack);
   }
-  TRI_IF_FAILURE("ExecutionBlock::getBlock") {
+  ARANGODB_IF_FAILURE("ExecutionBlock::getBlock") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 

--- a/arangod/Aql/DistinctCollectExecutor.cpp
+++ b/arangod/Aql/DistinctCollectExecutor.cpp
@@ -101,7 +101,7 @@ const DistinctCollectExecutor::Infos& DistinctCollectExecutor::infos() const noe
 auto DistinctCollectExecutor::produceRows(AqlItemBlockInputRange& inputRange,
                                           OutputAqlItemRow& output)
     -> std::tuple<ExecutorState, Stats, AqlCall> {
-  TRI_IF_FAILURE("DistinctCollectExecutor::produceRows") {
+  ARANGODB_IF_FAILURE("DistinctCollectExecutor::produceRows") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -148,7 +148,7 @@ auto DistinctCollectExecutor::produceRows(AqlItemBlockInputRange& inputRange,
 
 auto DistinctCollectExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange, AqlCall& call)
     -> std::tuple<ExecutorState, Stats, size_t, AqlCall> {
-  TRI_IF_FAILURE("DistinctCollectExecutor::skipRowsRange") {
+  ARANGODB_IF_FAILURE("DistinctCollectExecutor::skipRowsRange") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 

--- a/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
+++ b/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
@@ -460,13 +460,13 @@ Result EngineInfoContainerDBServerServerBased::buildEngines(
   options.timeout = network::Timeout(SETUP_TIMEOUT);
   options.skipScheduler = true;  // hack to speed up future.get()
   
-  TRI_IF_FAILURE("Query::setupTimeout") {
+  ARANGODB_IF_FAILURE("Query::setupTimeout") {
     options.timeout = network::Timeout(0.01 + (double) RandomGenerator::interval(uint32_t(10)));
   }
   
-  TRI_IF_FAILURE("Query::setupTimeoutFailSequence") {
+  ARANGODB_IF_FAILURE("Query::setupTimeoutFailSequence") {
     double t = 0.5;
-    TRI_IF_FAILURE("Query::setupTimeoutFailSequenceRandom") {
+    ARANGODB_IF_FAILURE("Query::setupTimeoutFailSequenceRandom") {
       if (RandomGenerator::interval(uint32_t(100)) >= 95) {
         t = 3.0;
       }

--- a/arangod/Aql/EnumerateCollectionExecutor.cpp
+++ b/arangod/Aql/EnumerateCollectionExecutor.cpp
@@ -230,7 +230,7 @@ void EnumerateCollectionExecutor::initializeNewRow(AqlItemBlockInputRange& input
 
 std::tuple<ExecutorState, EnumerateCollectionStats, AqlCall> EnumerateCollectionExecutor::produceRows(
     AqlItemBlockInputRange& inputRange, OutputAqlItemRow& output) {
-  TRI_IF_FAILURE("EnumerateCollectionExecutor::produceRows") {
+  ARANGODB_IF_FAILURE("EnumerateCollectionExecutor::produceRows") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -282,7 +282,7 @@ std::tuple<ExecutorState, EnumerateCollectionStats, AqlCall> EnumerateCollection
       stats.incrFiltered(_documentProducingFunctionContext.getAndResetNumFiltered());
     }
 
-    TRI_IF_FAILURE("EnumerateCollectionBlock::moreDocuments") {
+    ARANGODB_IF_FAILURE("EnumerateCollectionBlock::moreDocuments") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
   }

--- a/arangod/Aql/EnumerateListExecutor.cpp
+++ b/arangod/Aql/EnumerateListExecutor.cpp
@@ -95,7 +95,7 @@ void EnumerateListExecutor::processArrayElement(OutputAqlItemRow& output) {
   AqlValue innerValue = getAqlValue(inputList, _inputArrayPosition, mustDestroy);
   AqlValueGuard guard(innerValue, mustDestroy);
 
-  TRI_IF_FAILURE("EnumerateListBlock::getSome") {
+  ARANGODB_IF_FAILURE("EnumerateListBlock::getSome") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -192,7 +192,7 @@ void EnumerateListExecutor::initialize() {
 /// @brief create an AqlValue from the inVariable using the current _index
 AqlValue EnumerateListExecutor::getAqlValue(AqlValue const& inVarReg,
                                             size_t const& pos, bool& mustDestroy) {
-  TRI_IF_FAILURE("EnumerateListBlock::getAqlValue") {
+  ARANGODB_IF_FAILURE("EnumerateListBlock::getAqlValue") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 

--- a/arangod/Aql/ExecutionBlock.cpp
+++ b/arangod/Aql/ExecutionBlock.cpp
@@ -70,7 +70,7 @@ std::string const& stateToString(aql::ExecutionState state) {
 
 }  // namespace
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 size_t ExecutionBlock::DefaultBatchSize = ExecutionBlock::ProductionDefaultBatchSize;
 #endif
 

--- a/arangod/Aql/ExecutionBlock.h
+++ b/arangod/Aql/ExecutionBlock.h
@@ -59,7 +59,7 @@ class ExecutionBlock {
   /// @brief batch size value
   static constexpr size_t ProductionDefaultBatchSize = 1000;
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // when we compile the tests, we want to make the batch size adjustable
   static size_t DefaultBatchSize;
   static void setDefaultBatchSize(size_t value) { DefaultBatchSize = value; }

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -140,7 +140,7 @@ CREATE_HAS_MEMBER_CHECK(expectedNumberOfRows, hasExpectedNumberOfRows);
 CREATE_HAS_MEMBER_CHECK(skipRowsRange, hasSkipRowsRange);
 CREATE_HAS_MEMBER_CHECK(expectedNumberOfRowsNew, hasExpectedNumberOfRowsNew);
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 // Forward declaration of Test Executors.
 // only used as long as isNewStyleExecutor is required.
 namespace arangodb::aql {
@@ -333,13 +333,13 @@ ExecutionBlockImpl<Executor>::execute(AqlCallStack const& stack) {
   }
   traceExecuteBegin(stack);
   // silence tests -- we need to introduce new failure tests for fetchers
-  TRI_IF_FAILURE("ExecutionBlock::getOrSkipSome1") {
+  ARANGODB_IF_FAILURE("ExecutionBlock::getOrSkipSome1") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
-  TRI_IF_FAILURE("ExecutionBlock::getOrSkipSome2") {
+  ARANGODB_IF_FAILURE("ExecutionBlock::getOrSkipSome2") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
-  TRI_IF_FAILURE("ExecutionBlock::getOrSkipSome3") {
+  ARANGODB_IF_FAILURE("ExecutionBlock::getOrSkipSome3") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
   
@@ -608,7 +608,7 @@ static SkipRowsRangeVariant constexpr skipRowsType() {
               IdExecutor<SingleRowFetcher<BlockPassthrough::Enable>>, IdExecutor<ConstFetcher>, HashedCollectExecutor,
               AccuWindowExecutor, WindowExecutor, IndexExecutor, EnumerateCollectionExecutor, DistinctCollectExecutor,
               ConstrainedSortExecutor, CountCollectExecutor,
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
               TestLambdaSkipExecutor,
 #endif
               ModificationExecutor<AllRowsFetcher, InsertModifier>,
@@ -1866,7 +1866,7 @@ auto ExecutionBlockImpl<Executor>::countShadowRowProduced(AqlCallStack& stack, s
   }
 }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 // This is a helper method to inject a prepared
 // input range in the tests. It should simulate
 // an ongoing query in a specific state.

--- a/arangod/Aql/ExecutionBlockImpl.h
+++ b/arangod/Aql/ExecutionBlockImpl.h
@@ -214,7 +214,7 @@ class ExecutionBlockImpl final : public ExecutionBlock {
   template <class exec = Executor, typename = std::enable_if_t<std::is_same_v<exec, IdExecutor<SingleRowFetcher<BlockPassthrough::Enable>>>>>
   [[nodiscard]] RegisterId getOutputRegisterId() const noexcept;
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // This is a helper method to inject a prepared
   // input range in the tests. It should simulate
   // an ongoing query in a specific state.

--- a/arangod/Aql/ExecutionEngine.cpp
+++ b/arangod/Aql/ExecutionEngine.cpp
@@ -566,13 +566,13 @@ auto ExecutionEngine::execute(AqlCallStack const& stack)
     THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
   }
 
-  TRI_IF_FAILURE("ExecutionEngine::directKillBeforeAQLQueryExecute") {
+  ARANGODB_IF_FAILURE("ExecutionEngine::directKillBeforeAQLQueryExecute") {
     _query.debugKillQuery();
   }
 
   auto const res = _root->execute(stack);
 
-  TRI_IF_FAILURE("ExecutionEngine::directKillAfterAQLQueryExecute") {
+  ARANGODB_IF_FAILURE("ExecutionEngine::directKillAfterAQLQueryExecute") {
     _query.debugKillQuery();
   }
 

--- a/arangod/Aql/ExecutionEngine.h
+++ b/arangod/Aql/ExecutionEngine.h
@@ -145,7 +145,7 @@ class ExecutionEngine {
                                     std::map<aql::ExecutionNodeId, aql::ExecutionNodeId>& aliases);
 #endif
   
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   std::vector<std::unique_ptr<ExecutionBlock>> const& blocksForTesting() const {
     return _blocks;
   }

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -2293,7 +2293,7 @@ void ExecutionPlan::unlinkNode(ExecutionNode* node, bool allowUnlinkingRoot) {
   }
 
   auto dep = node->getDependencies();  // Intentionally copy the vector!
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   for (auto const& it : dep) {
     TRI_ASSERT(it != nullptr);
   }

--- a/arangod/Aql/FilterExecutor.cpp
+++ b/arangod/Aql/FilterExecutor.cpp
@@ -73,7 +73,7 @@ auto FilterExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange, AqlCall& 
 
 auto FilterExecutor::produceRows(AqlItemBlockInputRange& inputRange, OutputAqlItemRow& output)
     -> std::tuple<ExecutorState, Stats, AqlCall> {
-  TRI_IF_FAILURE("FilterExecutor::produceRows") {
+  ARANGODB_IF_FAILURE("FilterExecutor::produceRows") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
   FilterStats stats{};

--- a/arangod/Aql/Function.cpp
+++ b/arangod/Aql/Function.cpp
@@ -60,7 +60,7 @@ Function::Function(std::string const& name, char const* arguments,
   TRI_ASSERT(!hasFlag(Flags::CanRunOnDBServerCluster) || hasFlag(Flags::CanRunOnDBServerOneShard));
 }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 // constructor to create a function stub. only used from tests
 Function::Function(std::string const& name, FunctionImplementation implementation) 
     : name(name), 

--- a/arangod/Aql/Function.h
+++ b/arangod/Aql/Function.h
@@ -101,7 +101,7 @@ struct Function {
            std::underlying_type<Flags>::type flags,
            FunctionImplementation implementation);
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   Function(std::string const& name,
            FunctionImplementation implementation);
 #endif

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -5352,7 +5352,7 @@ AqlValue Functions::Union(ExpressionContext* expressionContext, AstNode const&,
       return AqlValue(AqlValueHintNull());
     }
 
-    TRI_IF_FAILURE("AqlFunctions::OutOfMemory1") {
+    ARANGODB_IF_FAILURE("AqlFunctions::OutOfMemory1") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
 
@@ -5362,13 +5362,13 @@ AqlValue Functions::Union(ExpressionContext* expressionContext, AstNode const&,
     // this passes ownership for the JSON contents into result
     for (VPackSlice it : VPackArrayIterator(slice)) {
       builder->add(it);
-      TRI_IF_FAILURE("AqlFunctions::OutOfMemory2") {
+      ARANGODB_IF_FAILURE("AqlFunctions::OutOfMemory2") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
     }
   }
   builder->close();
-  TRI_IF_FAILURE("AqlFunctions::OutOfMemory3") {
+  ARANGODB_IF_FAILURE("AqlFunctions::OutOfMemory3") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -5406,7 +5406,7 @@ AqlValue Functions::UnionDistinct(ExpressionContext* expressionContext,
     for (VPackSlice v : VPackArrayIterator(slice)) {
       v = v.resolveExternal();
       if (values.find(v) == values.end()) {
-        TRI_IF_FAILURE("AqlFunctions::OutOfMemory1") {
+        ARANGODB_IF_FAILURE("AqlFunctions::OutOfMemory1") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
 
@@ -5415,7 +5415,7 @@ AqlValue Functions::UnionDistinct(ExpressionContext* expressionContext,
     }
   }
 
-  TRI_IF_FAILURE("AqlFunctions::OutOfMemory2") {
+  ARANGODB_IF_FAILURE("AqlFunctions::OutOfMemory2") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -5426,7 +5426,7 @@ AqlValue Functions::UnionDistinct(ExpressionContext* expressionContext,
   }
   builder->close();
 
-  TRI_IF_FAILURE("AqlFunctions::OutOfMemory3") {
+  ARANGODB_IF_FAILURE("AqlFunctions::OutOfMemory3") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -5465,7 +5465,7 @@ AqlValue Functions::Intersection(ExpressionContext* expressionContext,
       if (i == 0) {
         // round one
 
-        TRI_IF_FAILURE("AqlFunctions::OutOfMemory1") {
+        ARANGODB_IF_FAILURE("AqlFunctions::OutOfMemory1") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
 
@@ -5485,7 +5485,7 @@ AqlValue Functions::Intersection(ExpressionContext* expressionContext,
     }
   }
 
-  TRI_IF_FAILURE("AqlFunctions::OutOfMemory2") {
+  ARANGODB_IF_FAILURE("AqlFunctions::OutOfMemory2") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -5498,7 +5498,7 @@ AqlValue Functions::Intersection(ExpressionContext* expressionContext,
   }
   builder->close();
 
-  TRI_IF_FAILURE("AqlFunctions::OutOfMemory3") {
+  ARANGODB_IF_FAILURE("AqlFunctions::OutOfMemory3") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
   return AqlValue(builder->slice(), builder->size());
@@ -5594,7 +5594,7 @@ AqlValue Functions::Outersection(ExpressionContext* expressionContext,
     }
   }
 
-  TRI_IF_FAILURE("AqlFunctions::OutOfMemory2") {
+  ARANGODB_IF_FAILURE("AqlFunctions::OutOfMemory2") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -5607,7 +5607,7 @@ AqlValue Functions::Outersection(ExpressionContext* expressionContext,
   }
   builder->close();
 
-  TRI_IF_FAILURE("AqlFunctions::OutOfMemory3") {
+  ARANGODB_IF_FAILURE("AqlFunctions::OutOfMemory3") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
   return AqlValue(builder->slice(), builder->size());

--- a/arangod/Aql/HashedCollectExecutor.cpp
+++ b/arangod/Aql/HashedCollectExecutor.cpp
@@ -230,7 +230,7 @@ auto HashedCollectExecutor::returnState() const -> ExecutorState {
 auto HashedCollectExecutor::produceRows(AqlItemBlockInputRange& inputRange,
                                         OutputAqlItemRow& output)
     -> std::tuple<ExecutorState, NoStats, AqlCall> {
-  TRI_IF_FAILURE("HashedCollectExecutor::produceRows") {
+  ARANGODB_IF_FAILURE("HashedCollectExecutor::produceRows") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
   if (!_isInitialized) {

--- a/arangod/Aql/IdExecutor.cpp
+++ b/arangod/Aql/IdExecutor.cpp
@@ -82,7 +82,7 @@ auto IdExecutor<UsedFetcher>::produceRows(AqlItemBlockInputRange& inputRange,
   CountStats stats;
   if (inputRange.hasDataRow()) {
     TRI_ASSERT(!output.isFull());
-    TRI_IF_FAILURE("SingletonBlock::getOrSkipSome") {
+    ARANGODB_IF_FAILURE("SingletonBlock::getOrSkipSome") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
     auto const& [state, inputRow] = inputRange.peekDataRow();
@@ -91,7 +91,7 @@ auto IdExecutor<UsedFetcher>::produceRows(AqlItemBlockInputRange& inputRange,
 
     output.fastForwardAllRows(inputRow, rows);
 
-    TRI_IF_FAILURE("SingletonBlock::getOrSkipSomeSet") {
+    ARANGODB_IF_FAILURE("SingletonBlock::getOrSkipSomeSet") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
   }

--- a/arangod/Aql/IndexExecutor.cpp
+++ b/arangod/Aql/IndexExecutor.cpp
@@ -408,7 +408,7 @@ bool IndexExecutor::CursorReader::readIndex(OutputAqlItemRow& output) {
   // Then initIndexes is read again and so on. This is to avoid reading the
   // entire index when we only want a small number of documents.
   TRI_ASSERT(_cursor->hasMore());
-  TRI_IF_FAILURE("IndexBlock::readIndex") {
+  ARANGODB_IF_FAILURE("IndexBlock::readIndex") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
   switch (_type) {
@@ -568,13 +568,13 @@ void IndexExecutor::initIndexes(InputAqlItemRow& input) {
       v8::HandleScope scope(isolate);  // do not delete this!
 
       executeExpressions(input);
-      TRI_IF_FAILURE("IndexBlock::executeV8") {
+      ARANGODB_IF_FAILURE("IndexBlock::executeV8") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
     } else {
       // no V8 context required!
       executeExpressions(input);
-      TRI_IF_FAILURE("IndexBlock::executeExpression") {
+      ARANGODB_IF_FAILURE("IndexBlock::executeExpression") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
     }
@@ -709,7 +709,7 @@ bool IndexExecutor::needsUniquenessCheck() const noexcept {
 
 auto IndexExecutor::produceRows(AqlItemBlockInputRange& inputRange, OutputAqlItemRow& output)
     -> std::tuple<ExecutorState, Stats, AqlCall> {
-  TRI_IF_FAILURE("IndexExecutor::produceRows") {
+  ARANGODB_IF_FAILURE("IndexExecutor::produceRows") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
   IndexStats stats{};
@@ -802,7 +802,7 @@ auto IndexExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange, AqlCall& c
   // happen, because with multiple indexes, the FILTER is not removed and thus
   // skipSome is not called on the IndexExecutor.
   TRI_ASSERT(_infos.getIndexes().size() <= 1);
-  TRI_IF_FAILURE("IndexExecutor::skipRows") {
+  ARANGODB_IF_FAILURE("IndexExecutor::skipRows") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 

--- a/arangod/Aql/IndexNode.cpp
+++ b/arangod/Aql/IndexNode.cpp
@@ -276,7 +276,7 @@ void IndexNode::initializeOnce(bool& hasV8Expression, std::vector<Variable const
     // all new AstNodes are registered with the Ast in the Query
     auto e = std::make_unique<Expression>(_plan->getAst(), a);
 
-    TRI_IF_FAILURE("IndexBlock::initialize") {
+    ARANGODB_IF_FAILURE("IndexBlock::initialize") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
 
@@ -323,7 +323,7 @@ void IndexNode::initializeOnce(bool& hasV8Expression, std::vector<Variable const
           idx.emplace_back(k);
           instantiateExpression(child, std::move(idx));
 
-          TRI_IF_FAILURE("IndexBlock::initializeExpressions") {
+          ARANGODB_IF_FAILURE("IndexBlock::initializeExpressions") {
             THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
           }
         }
@@ -359,7 +359,7 @@ void IndexNode::initializeOnce(bool& hasV8Expression, std::vector<Variable const
               rhs = makeUnique(rhs);
             }
             instantiateExpression(rhs, {i, j, 1});
-            TRI_IF_FAILURE("IndexBlock::initializeExpressions") {
+            ARANGODB_IF_FAILURE("IndexBlock::initializeExpressions") {
               THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
             }
           }
@@ -372,7 +372,7 @@ void IndexNode::initializeOnce(bool& hasV8Expression, std::vector<Variable const
             instFCallArgExpressions(lhs, {i, j, 0});
           } else if (!lhs->isConstant()) {
             instantiateExpression(lhs, {i, j, 0});
-            TRI_IF_FAILURE("IndexBlock::initializeExpressions") {
+            ARANGODB_IF_FAILURE("IndexBlock::initializeExpressions") {
               THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
             }
           }

--- a/arangod/Aql/InputAqlItemRow.cpp
+++ b/arangod/Aql/InputAqlItemRow.cpp
@@ -172,7 +172,7 @@ bool InputAqlItemRow::isSameBlockAndIndex(InputAqlItemRow const& other) const no
   return this->_block == other._block && this->_baseIndex == other._baseIndex;
 }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 bool InputAqlItemRow::equates(InputAqlItemRow const& other,
                               velocypack::Options const* const options) const noexcept {
   if (!isInitialized() || !other.isInitialized()) {

--- a/arangod/Aql/InputAqlItemRow.h
+++ b/arangod/Aql/InputAqlItemRow.h
@@ -92,7 +92,7 @@ class InputAqlItemRow {
   // the _same_ index.
   [[nodiscard]] bool isSameBlockAndIndex(InputAqlItemRow const& other) const noexcept;
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // This checks whether the rows are equivalent, in the sense that they hold
   // the same number of registers and their entry-AqlValues compare equal.
   // In maintainer mode, it also asserts that the number of registers of the

--- a/arangod/Aql/ModificationExecutor.cpp
+++ b/arangod/Aql/ModificationExecutor.cpp
@@ -165,7 +165,7 @@ template <typename FetcherType, typename ModifierType>
     return {input.upstreamState(), stats, upstreamCall};
   }
 
-  TRI_IF_FAILURE("ModificationBlock::getSome") {
+  ARANGODB_IF_FAILURE("ModificationBlock::getSome") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -210,7 +210,7 @@ template <typename FetcherType, typename ModifierType>
 
   auto stats = ModificationStats{};
 
-  TRI_IF_FAILURE("ModificationBlock::getSome") {
+  ARANGODB_IF_FAILURE("ModificationBlock::getSome") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 

--- a/arangod/Aql/MultiDependencySingleRowFetcher.cpp
+++ b/arangod/Aql/MultiDependencySingleRowFetcher.cpp
@@ -294,7 +294,7 @@ auto MultiDependencySingleRowFetcher::resetDidReturnSubquerySkips(size_t shadowR
   }
 }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 auto MultiDependencySingleRowFetcher::initialize(size_t subqueryDepth) -> void {
   initializeReports(subqueryDepth);
 }

--- a/arangod/Aql/MultiDependencySingleRowFetcher.h
+++ b/arangod/Aql/MultiDependencySingleRowFetcher.h
@@ -130,7 +130,7 @@ class MultiDependencySingleRowFetcher {
   void reportSubqueryFullCounts(size_t subqueryDepth,
                                 std::vector<size_t> const& skippedInDependency);
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   auto initialize(size_t subqueryDepth) -> void;
 #endif
 

--- a/arangod/Aql/MutexExecutor.cpp
+++ b/arangod/Aql/MutexExecutor.cpp
@@ -55,7 +55,7 @@ auto MutexExecutor::distributeBlock(SharedAqlItemBlockPtr const& block, SkipResu
                                     std::unordered_map<std::string, ClientBlockData>& blockMap)
     -> void {
 
-  TRI_IF_FAILURE("MutexExecutor::distributeBlock") {
+  ARANGODB_IF_FAILURE("MutexExecutor::distributeBlock") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 

--- a/arangod/Aql/Optimizer.cpp
+++ b/arangod/Aql/Optimizer.cpp
@@ -306,7 +306,7 @@ void Optimizer::createPlans(std::unique_ptr<ExecutionPlan> plan,
           continue;
         }
 
-        TRI_IF_FAILURE("Optimizer::createPlansOom") {
+        ARANGODB_IF_FAILURE("Optimizer::createPlansOom") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
 

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -5558,7 +5558,7 @@ void arangodb::aql::replaceOrWithInRule(Optimizer* opt, std::unique_ptr<Executio
     if (newRoot != root) {
       auto expr = std::make_unique<Expression>(plan->getAst(), newRoot);
 
-      TRI_IF_FAILURE("OptimizerRules::replaceOrWithInRuleOom") {
+      ARANGODB_IF_FAILURE("OptimizerRules::replaceOrWithInRuleOom") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
 

--- a/arangod/Aql/OutputAqlItemRow.cpp
+++ b/arangod/Aql/OutputAqlItemRow.cpp
@@ -476,10 +476,10 @@ void OutputAqlItemRow::doCopyOrMoveValue(ItemRowType& sourceRow, RegisterId item
       AqlValue clonedValue = value.clone();
       AqlValueGuard guard(clonedValue, true);
 
-      TRI_IF_FAILURE("OutputAqlItemRow::copyRow") {
+      ARANGODB_IF_FAILURE("OutputAqlItemRow::copyRow") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
-      TRI_IF_FAILURE("ExecutionBlock::inheritRegisters") {
+      ARANGODB_IF_FAILURE("ExecutionBlock::inheritRegisters") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
 
@@ -492,10 +492,10 @@ void OutputAqlItemRow::doCopyOrMoveValue(ItemRowType& sourceRow, RegisterId item
     if (!stolenValue.isEmpty()) {
       AqlValueGuard guard(stolenValue, true);
 
-      TRI_IF_FAILURE("OutputAqlItemRow::copyRow") {
+      ARANGODB_IF_FAILURE("OutputAqlItemRow::copyRow") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
-      TRI_IF_FAILURE("ExecutionBlock::inheritRegisters") {
+      ARANGODB_IF_FAILURE("ExecutionBlock::inheritRegisters") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
 

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -686,7 +686,7 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
         }
 
         if (!_queryOptions.silent && resultRegister.isValid()) {
-          TRI_IF_FAILURE("Query::executeV8directKillBeforeQueryResultIsGettingHandled") {
+          ARANGODB_IF_FAILURE("Query::executeV8directKillBeforeQueryResultIsGettingHandled") {
             debugKillQuery();
           }
           size_t memoryUsage = 0;
@@ -719,7 +719,7 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
           _resourceMonitor.increaseMemoryUsage(memoryUsage);
           _resultMemoryUsage += memoryUsage;
 
-          TRI_IF_FAILURE("Query::executeV8directKillAfterQueryResultIsGettingHandled") {
+          ARANGODB_IF_FAILURE("Query::executeV8directKillAfterQueryResultIsGettingHandled") {
             debugKillQuery();
           }
         }
@@ -1219,7 +1219,7 @@ transaction::Methods& Query::trxForOptimization() {
   return *_trx;
 }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 void Query::initForTests() {
   this->init(/*createProfile*/ false);
   initTrxForTests();
@@ -1356,7 +1356,7 @@ aql::ExecutionState Query::cleanupTrxAndEngines(ErrorCode errorCode) {
 
   enterState(QueryExecutionState::ValueType::FINALIZATION);
 
-  TRI_IF_FAILURE("Query::directKillBeforeQueryWillBeFinalized") {
+  ARANGODB_IF_FAILURE("Query::directKillBeforeQueryWillBeFinalized") {
     debugKillQuery();
   }
 
@@ -1384,7 +1384,7 @@ aql::ExecutionState Query::cleanupTrxAndEngines(ErrorCode errorCode) {
     if (commitResult.get().fail()) {
       THROW_ARANGO_EXCEPTION(std::move(commitResult).get());
     }
-    TRI_IF_FAILURE("Query::finalize_before_done") {
+    ARANGODB_IF_FAILURE("Query::finalize_before_done") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
     // We succeeded with commit. Let us cancel the guard
@@ -1392,7 +1392,7 @@ aql::ExecutionState Query::cleanupTrxAndEngines(ErrorCode errorCode) {
     guard.cancel();
   }
 
-  TRI_IF_FAILURE("Query::directKillAfterQueryWillBeFinalized") {
+  ARANGODB_IF_FAILURE("Query::directKillAfterQueryWillBeFinalized") {
     debugKillQuery();
   }
 
@@ -1409,7 +1409,7 @@ aql::ExecutionState Query::cleanupTrxAndEngines(ErrorCode errorCode) {
   TRI_ASSERT(ServerState::instance()->isCoordinator());
   TRI_ASSERT(_sharedState);
   try {
-    TRI_IF_FAILURE("Query::finalize_error_on_finish_db_servers") {
+    ARANGODB_IF_FAILURE("Query::finalize_error_on_finish_db_servers") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_INTERNAL_AQL);
     }
     ::finishDBServerParts(*this, errorCode).thenValue([ss = _sharedState, this](Result r) {
@@ -1421,7 +1421,7 @@ aql::ExecutionState Query::cleanupTrxAndEngines(ErrorCode errorCode) {
       });
     });
 
-    TRI_IF_FAILURE("Query::directKillAfterDBServerFinishRequests") {
+    ARANGODB_IF_FAILURE("Query::directKillAfterDBServerFinishRequests") {
       debugKillQuery();
     }
 
@@ -1474,7 +1474,7 @@ aql::ExecutionState Query::cleanupTrxAndEngines(ErrorCode errorCode) {
 }
 
   void Query::debugKillQuery() {
-#ifndef ARANGODB_ENABLE_FAILURE_TESTS
+#ifndef ARANGODB_ENABLE_MAINTAINER_MODE
     TRI_ASSERT(false);
     return;
 #else

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -188,7 +188,7 @@ class Query : public QueryContext {
   
   virtual transaction::Methods& trxForOptimization() override;
   
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   ExecutionPlan* plan() const {
     if (_plans.size() == 1) {
       return _plans[0].get();
@@ -341,7 +341,7 @@ class Query : public QueryContext {
   /// @brief user that started the query
   std::string _user;
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // Intentionally initialized here to not
   // be present in production constructors
   // Indicator if a query was already killed

--- a/arangod/Aql/QueryCursor.cpp
+++ b/arangod/Aql/QueryCursor.cpp
@@ -152,7 +152,7 @@ QueryStreamCursor::QueryStreamCursor(std::unique_ptr<arangodb::aql::Query> q,
       _queryResultPos(0),
       _finalization(false) {
   _query->prepareQuery(SerializationFormat::SHADOWROWS);
-  TRI_IF_FAILURE("QueryStreamCursor::directKillAfterPrepare") {
+  ARANGODB_IF_FAILURE("QueryStreamCursor::directKillAfterPrepare") {
     debugKillQuery();
   }
   // In all the following ASSERTs it is valid (though unlikely) that the query is already killed
@@ -162,7 +162,7 @@ QueryStreamCursor::QueryStreamCursor(std::unique_ptr<arangodb::aql::Query> q,
   _ctx = _query->newTrxContext();
   
   transaction::Methods trx(_ctx);
-  TRI_IF_FAILURE("QueryStreamCursor::directKillAfterTrxSetup") {
+  ARANGODB_IF_FAILURE("QueryStreamCursor::directKillAfterTrxSetup") {
     debugKillQuery();
   }
   TRI_ASSERT(trx.status() == transaction::Status::RUNNING || _query->killed());
@@ -204,7 +204,7 @@ void QueryStreamCursor::kill() {
 }
 
 void QueryStreamCursor::debugKillQuery() {
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if (_query) {
     _query->debugKillQuery();
   }
@@ -212,13 +212,13 @@ void QueryStreamCursor::debugKillQuery() {
 }
 
 std::pair<ExecutionState, Result> QueryStreamCursor::dump(VPackBuilder& builder) {
-  TRI_IF_FAILURE("QueryCursor::directKillBeforeQueryIsGettingDumped") {
+  ARANGODB_IF_FAILURE("QueryCursor::directKillBeforeQueryIsGettingDumped") {
     debugKillQuery();
   }
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   TRI_DEFER(
-    TRI_IF_FAILURE("QueryCursor::directKillAfterQueryIsGettingDumped") {
+    ARANGODB_IF_FAILURE("QueryCursor::directKillAfterQueryIsGettingDumped") {
       debugKillQuery();
     }
   )
@@ -270,12 +270,12 @@ std::pair<ExecutionState, Result> QueryStreamCursor::dump(VPackBuilder& builder)
 }
 
 Result QueryStreamCursor::dumpSync(VPackBuilder& builder) {
-  TRI_IF_FAILURE("QueryCursor::directKillBeforeQueryIsGettingDumpedSynced") {
+  ARANGODB_IF_FAILURE("QueryCursor::directKillBeforeQueryIsGettingDumpedSynced") {
     debugKillQuery();
   }
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   TRI_DEFER(
-    TRI_IF_FAILURE("QueryCursor::directKillAfterQueryIsGettingDumpedSynced") {
+    ARANGODB_IF_FAILURE("QueryCursor::directKillAfterQueryIsGettingDumpedSynced") {
       debugKillQuery();
     }
   )

--- a/arangod/Aql/QueryList.cpp
+++ b/arangod/Aql/QueryList.cpp
@@ -126,7 +126,7 @@ bool QueryList::insert(Query* query) {
   try {
     WRITE_LOCKER(writeLocker, _lock);
 
-    TRI_IF_FAILURE("QueryList::insert") {
+    ARANGODB_IF_FAILURE("QueryList::insert") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
 
@@ -183,7 +183,7 @@ void QueryList::remove(Query* query) {
   if (elapsed >= threshold && threshold >= 0.0) {
     // yes.
     try {
-      TRI_IF_FAILURE("QueryList::remove") {
+      ARANGODB_IF_FAILURE("QueryList::remove") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
   

--- a/arangod/Aql/QueryProfile.cpp
+++ b/arangod/Aql/QueryProfile.cpp
@@ -59,7 +59,7 @@ void QueryProfile::registerInQueryList() {
   if (queryList) {
     _tracked = queryList->insert(_query);
 
-    TRI_IF_FAILURE("QueryProfile::directKillAfterQueryGotRegistered") {
+    ARANGODB_IF_FAILURE("QueryProfile::directKillAfterQueryGotRegistered") {
       _query->debugKillQuery();
     }
   }

--- a/arangod/Aql/QueryRegistry.cpp
+++ b/arangod/Aql/QueryRegistry.cpp
@@ -64,7 +64,7 @@ void QueryRegistry::insertQuery(std::unique_ptr<ClusterQuery> query, double ttl,
 
   QueryId qId = query->id();
 
-  TRI_IF_FAILURE("QueryRegistryInsertException1") { 
+  ARANGODB_IF_FAILURE("QueryRegistryInsertException1") { 
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -72,7 +72,7 @@ void QueryRegistry::insertQuery(std::unique_ptr<ClusterQuery> query, double ttl,
   auto p = std::make_unique<QueryInfo>(std::move(query), ttl, std::move(guard));
   TRI_ASSERT(p->_expires != 0);
 
-  TRI_IF_FAILURE("QueryRegistryInsertException2") { 
+  ARANGODB_IF_FAILURE("QueryRegistryInsertException2") { 
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -542,7 +542,7 @@ QueryRegistry::QueryInfo::QueryInfo(ErrorCode errorCode, double ttl)
 
 QueryRegistry::QueryInfo::~QueryInfo() = default;
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 bool QueryRegistry::queryIsRegistered(std::string const& dbName, QueryId id) {
   READ_LOCKER(readLocker, _lock);
 

--- a/arangod/Aql/QueryRegistry.h
+++ b/arangod/Aql/QueryRegistry.h
@@ -124,7 +124,7 @@ class QueryRegistry {
   /// @brief return the default TTL value
   TEST_VIRTUAL double defaultTTL() const { return _defaultTTL; }
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   bool queryIsRegistered(std::string const& dbName, QueryId id);
 #endif
 

--- a/arangod/Aql/RemoteExecutor.cpp
+++ b/arangod/Aql/RemoteExecutor.cpp
@@ -84,13 +84,13 @@ ExecutionBlockImpl<RemoteExecutor>::ExecutionBlockImpl(
 
 std::pair<ExecutionState, SharedAqlItemBlockPtr> ExecutionBlockImpl<RemoteExecutor>::getSomeWithoutTrace(size_t atMost) {
   // silence tests -- we need to introduce new failure tests for fetchers
-  TRI_IF_FAILURE("ExecutionBlock::getOrSkipSome1") {
+  ARANGODB_IF_FAILURE("ExecutionBlock::getOrSkipSome1") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
-  TRI_IF_FAILURE("ExecutionBlock::getOrSkipSome2") {
+  ARANGODB_IF_FAILURE("ExecutionBlock::getOrSkipSome2") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
-  TRI_IF_FAILURE("ExecutionBlock::getOrSkipSome3") {
+  ARANGODB_IF_FAILURE("ExecutionBlock::getOrSkipSome3") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -329,13 +329,13 @@ auto ExecutionBlockImpl<RemoteExecutor>::execute(AqlCallStack const& stack)
 auto ExecutionBlockImpl<RemoteExecutor>::executeWithoutTrace(AqlCallStack const& stack)
     -> std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> {
   // silence tests -- we need to introduce new failure tests for fetchers
-  TRI_IF_FAILURE("ExecutionBlock::getOrSkipSome1") {
+  ARANGODB_IF_FAILURE("ExecutionBlock::getOrSkipSome1") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
-  TRI_IF_FAILURE("ExecutionBlock::getOrSkipSome2") {
+  ARANGODB_IF_FAILURE("ExecutionBlock::getOrSkipSome2") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
-  TRI_IF_FAILURE("ExecutionBlock::getOrSkipSome3") {
+  ARANGODB_IF_FAILURE("ExecutionBlock::getOrSkipSome3") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -110,15 +110,15 @@ void RestAqlHandler::setupClusterQuery() {
     return;
   }
   
-  TRI_IF_FAILURE("Query::setupTimeout") {
+  ARANGODB_IF_FAILURE("Query::setupTimeout") {
     // intentionally delay the request
     std::this_thread::sleep_for(std::chrono::milliseconds(RandomGenerator::interval(uint32_t(2000))));
   }
   
-  TRI_IF_FAILURE("Query::setupTimeoutFailSequence") {
+  ARANGODB_IF_FAILURE("Query::setupTimeoutFailSequence") {
     // simulate lock timeout during query setup
     uint32_t r = 100;
-    TRI_IF_FAILURE("Query::setupTimeoutFailSequenceRandom") {
+    ARANGODB_IF_FAILURE("Query::setupTimeoutFailSequenceRandom") {
       r = RandomGenerator::interval(uint32_t(100));
     }
     if (r >= 96) {
@@ -661,7 +661,7 @@ RestStatus RestAqlHandler::handleUseQuery(std::string const& operation,
   // this is because the request may contain additional data
   if ((operation == "getSome" || operation == "skipSome") &&
       !_engine->initializeCursorCalled()) {
-    TRI_IF_FAILURE("RestAqlHandler::getSome") {
+    ARANGODB_IF_FAILURE("RestAqlHandler::getSome") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
     auto res = _engine->initializeCursor(nullptr, 0);
@@ -688,7 +688,7 @@ RestStatus RestAqlHandler::handleUseQuery(std::string const& operation,
       generateError(std::move(maybeExecuteCall).result());
       return RestStatus::DONE;
     }
-    TRI_IF_FAILURE("RestAqlHandler::getSome") {
+    ARANGODB_IF_FAILURE("RestAqlHandler::getSome") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
     auto& executeCall = maybeExecuteCall.get();
@@ -717,7 +717,7 @@ RestStatus RestAqlHandler::handleUseQuery(std::string const& operation,
     result.toVelocyPack(answerBuilder, &_engine->getQuery().vpackOptions());
     answerBuilder.add(StaticStrings::Code, VPackValue(TRI_ERROR_NO_ERROR));
   } else if (operation == "getSome") {
-    TRI_IF_FAILURE("RestAqlHandler::getSome") {
+    ARANGODB_IF_FAILURE("RestAqlHandler::getSome") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
     auto atMost = VelocyPackHelper::getNumericValue<size_t>(querySlice, "atMost",

--- a/arangod/Aql/ReturnExecutor.cpp
+++ b/arangod/Aql/ReturnExecutor.cpp
@@ -49,7 +49,7 @@ ReturnExecutor::~ReturnExecutor() = default;
 
 auto ReturnExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange, AqlCall& call)
     -> std::tuple<ExecutorState, Stats, size_t, AqlCall> {
-  TRI_IF_FAILURE("ReturnExecutor::produceRows") {
+  ARANGODB_IF_FAILURE("ReturnExecutor::produceRows") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -71,7 +71,7 @@ auto ReturnExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange, AqlCall& 
 
 auto ReturnExecutor::produceRows(AqlItemBlockInputRange& inputRange, OutputAqlItemRow& output)
     -> std::tuple<ExecutorState, Stats, AqlCall> {
-  TRI_IF_FAILURE("ReturnExecutor::produceRows") {
+  ARANGODB_IF_FAILURE("ReturnExecutor::produceRows") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -83,7 +83,7 @@ auto ReturnExecutor::produceRows(AqlItemBlockInputRange& inputRange, OutputAqlIt
     // REMARK: it is called `getInputRegisterId` here but FilterExecutor calls it `getInputRegister`.
     AqlValue val = input.stealValue(_infos.getInputRegisterId());
     AqlValueGuard guard(val, true);
-    TRI_IF_FAILURE("ReturnBlock::getSome") {
+    ARANGODB_IF_FAILURE("ReturnBlock::getSome") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
     output.moveValueInto(_infos.getOutputRegisterId(), input, guard);

--- a/arangod/Aql/ShadowAqlItemRow.cpp
+++ b/arangod/Aql/ShadowAqlItemRow.cpp
@@ -91,7 +91,7 @@ bool ShadowAqlItemRow::isSameBlockAndIndex(ShadowAqlItemRow const& other) const 
     return this->_block == other._block && this->_baseIndex == other._baseIndex;
 }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 bool ShadowAqlItemRow::equates(ShadowAqlItemRow const& other,
                                velocypack::Options const* options) const noexcept {
   if (!isInitialized() || !other.isInitialized()) {

--- a/arangod/Aql/ShadowAqlItemRow.h
+++ b/arangod/Aql/ShadowAqlItemRow.h
@@ -108,7 +108,7 @@ class ShadowAqlItemRow {
   // the same row in the same block.
   [[nodiscard]] bool isSameBlockAndIndex(ShadowAqlItemRow const& other) const noexcept;
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // This checks whether the rows are equivalent, in the sense that they hold
   // the same number of registers and their entry-AqlValues compare equal,
   // plus their shadow-depth is the same.

--- a/arangod/Aql/SingleRemoteModificationExecutor.cpp
+++ b/arangod/Aql/SingleRemoteModificationExecutor.cpp
@@ -256,7 +256,7 @@ auto SingleRemoteModificationExecutor<Modifier>::doSingleRemoteModificationOutpu
     output.moveValueInto(_info._outputNewRegisterId, input, guard);
   }
 
-  TRI_IF_FAILURE("SingleRemoteModificationOperationBlock::moreDocuments") {
+  ARANGODB_IF_FAILURE("SingleRemoteModificationOperationBlock::moreDocuments") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 }

--- a/arangod/Aql/SortExecutor.cpp
+++ b/arangod/Aql/SortExecutor.cpp
@@ -192,7 +192,7 @@ std::tuple<ExecutorState, NoStats, AqlCall> SortExecutor::produceRows(
 }
 
 void SortExecutor::doSorting() {
-  TRI_IF_FAILURE("SortBlock::doSorting") {
+  ARANGODB_IF_FAILURE("SortBlock::doSorting") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
   

--- a/arangod/Aql/SortedCollectExecutor.cpp
+++ b/arangod/Aql/SortedCollectExecutor.cpp
@@ -162,7 +162,7 @@ void SortedCollectExecutor::CollectGroup::addLine(InputAqlItemRow const& input) 
     }
     ++j;
   }
-  TRI_IF_FAILURE("SortedCollectBlock::getOrSkipSome") {
+  ARANGODB_IF_FAILURE("SortedCollectBlock::getOrSkipSome") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
   if (infos.getCollectRegister().value() != RegisterId::maxRegisterId) {
@@ -184,7 +184,7 @@ void SortedCollectExecutor::CollectGroup::addLine(InputAqlItemRow const& input) 
       _builder.close();
     }
   }
-  TRI_IF_FAILURE("CollectGroup::addValues") {
+  ARANGODB_IF_FAILURE("CollectGroup::addValues") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 }
@@ -303,7 +303,7 @@ void SortedCollectExecutor::CollectGroup::writeToOutput(OutputAqlItemRow& output
 auto SortedCollectExecutor::produceRows(AqlItemBlockInputRange& inputRange,
                                         OutputAqlItemRow& output)
     -> std::tuple<ExecutorState, Stats, AqlCall> {
-  TRI_IF_FAILURE("SortedCollectExecutor::produceRows") {
+  ARANGODB_IF_FAILURE("SortedCollectExecutor::produceRows") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -335,11 +335,11 @@ auto SortedCollectExecutor::produceRows(AqlItemBlockInputRange& inputRange,
       break;
     }
 
-    TRI_IF_FAILURE("SortedCollectBlock::getOrSkipSomeOuter") {
+    ARANGODB_IF_FAILURE("SortedCollectBlock::getOrSkipSomeOuter") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
 
-    TRI_IF_FAILURE("SortedCollectBlock::hasMore") {
+    ARANGODB_IF_FAILURE("SortedCollectBlock::hasMore") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
 
@@ -395,7 +395,7 @@ auto SortedCollectExecutor::produceRows(AqlItemBlockInputRange& inputRange,
 
 auto SortedCollectExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange, AqlCall& clientCall)
     -> std::tuple<ExecutorState, Stats, size_t, AqlCall> {
-  TRI_IF_FAILURE("SortedCollectExecutor::skipRowsRange") {
+  ARANGODB_IF_FAILURE("SortedCollectExecutor::skipRowsRange") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 

--- a/arangod/Aql/TraversalConditionFinder.cpp
+++ b/arangod/Aql/TraversalConditionFinder.cpp
@@ -560,7 +560,7 @@ bool TraversalConditionFinder::before(ExecutionNode* en) {
       if (_filterVariables.find(outVar->id) != _filterVariables.end()) {
         // This calculationNode is directly part of a filter condition
         // So we have to iterate through it.
-        TRI_IF_FAILURE("ConditionFinder::variableDefinition") {
+        ARANGODB_IF_FAILURE("ConditionFinder::variableDefinition") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
         _condition->andCombine(calcNode->expression()->node());
@@ -584,7 +584,7 @@ bool TraversalConditionFinder::before(ExecutionNode* en) {
 
       _condition->normalize();
 
-      TRI_IF_FAILURE("ConditionFinder::normalizePlan") {
+      ARANGODB_IF_FAILURE("ConditionFinder::normalizePlan") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
 

--- a/arangod/Auth/UserManager.cpp
+++ b/arangod/Auth/UserManager.cpp
@@ -129,7 +129,7 @@ static auth::UserMap ParseUsers(VPackSlice const& slice) {
 }
 
 static std::shared_ptr<VPackBuilder> QueryAllUsers(application_features::ApplicationServer& server) {
-  TRI_IF_FAILURE("QueryAllUsers") {
+  ARANGODB_IF_FAILURE("QueryAllUsers") {
     // simulates the case that the _users collection is not yet available
     THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
   }
@@ -211,7 +211,7 @@ void auth::UserManager::loadFromDB() {
     return;
   }
 
-  TRI_IF_FAILURE("UserManager::performDBLookup") {
+  ARANGODB_IF_FAILURE("UserManager::performDBLookup") {
     // Used in GTest. It is used to identify
     // if the UserManager would have updated it's
     // cache in a specific situation.
@@ -818,7 +818,7 @@ auth::Level auth::UserManager::collectionAuthLevel(std::string const& user,
   return level;
 }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 /// Only used for testing
 void auth::UserManager::setAuthInfo(auth::UserMap const& newMap) {
   MUTEX_LOCKER(guard, _loadFromDBLock);      // must be first

--- a/arangod/Auth/UserManager.h
+++ b/arangod/Auth/UserManager.h
@@ -133,7 +133,7 @@ class UserManager {
   auth::Level collectionAuthLevel(std::string const& username, std::string const& dbname,
                                   std::string const& coll, bool configured = false);
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   /// Overwrite internally cached permissions, only use
   /// for testing purposes
   void setAuthInfo(auth::UserMap const& userEntryMap);

--- a/arangod/Cluster/AgencyCache.cpp
+++ b/arangod/Cluster/AgencyCache.cpp
@@ -49,7 +49,7 @@ AgencyCache::AgencyCache(application_features::ApplicationServer& server,
     _callbacksCount(
       _server.getFeature<MetricsFeature>().add(arangodb_agency_cache_callback_number{})) {
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   TRI_ASSERT(_shutdownCode == TRI_ERROR_NO_ERROR || _shutdownCode == TRI_ERROR_SHUTTING_DOWN);
 #else
   TRI_ASSERT(_shutdownCode == TRI_ERROR_SHUTTING_DOWN);

--- a/arangod/Cluster/AgencyCache.h
+++ b/arangod/Cluster/AgencyCache.h
@@ -102,14 +102,14 @@ class AgencyCache final : public arangodb::Thread {
   /// @brief Cache has these path? Paths are absolute
   std::vector<bool> has(std::vector<std::string> const& paths) const;
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   /// @brief Used exclusively in unit tests!
   ///        Do not use for production code under any circumstances
   std::pair<std::vector<consensus::apply_ret_t>, consensus::index_t> applyTestTransaction(
     consensus::query_t const& trx);
 #endif
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   /// @brief Used exclusively in unit tests
   consensus::Store& store();
 #endif

--- a/arangod/Cluster/ClusterCollectionCreationInfo.cpp
+++ b/arangod/Cluster/ClusterCollectionCreationInfo.cpp
@@ -55,7 +55,7 @@ ClusterCollectionCreationInfo::ClusterCollectionCreationInfo(
 // tries to get away without other servers by initially adding only 0
 // shard collections (non-smart). We do not want to loose these test.
 // So we will loose this assertion for now.
-#ifndef ARANGODB_USE_GOOGLE_TESTS
+#ifndef ARANGODB_ENABLE_MAINTAINER_MODE
     TRI_ASSERT(basics::VelocyPackHelper::getBooleanValue(json, StaticStrings::IsSmart,
                                                                    false));
 #endif

--- a/arangod/Cluster/ClusterFeature.h
+++ b/arangod/Cluster/ClusterFeature.h
@@ -136,7 +136,7 @@ class ClusterFeature : public application_features::ApplicationFeature {
   /// note: this may be called multiple times during shutdown
   void waitForSyncersToStop();
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   void setSyncerShutdownCode(ErrorCode code) { _syncerShutdownCode = code; }
 #endif
 

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -402,7 +402,7 @@ ClusterInfo::ClusterInfo(application_features::ApplicationServer& server,
   _uniqid._backgroundJobIsRunning = false;
   // Actual loading into caches is postponed until necessary
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   TRI_ASSERT(_syncerShutdownCode == TRI_ERROR_NO_ERROR || _syncerShutdownCode == TRI_ERROR_SHUTTING_DOWN);
 #else
   TRI_ASSERT(_syncerShutdownCode == TRI_ERROR_SHUTTING_DOWN);
@@ -1160,7 +1160,7 @@ void ClusterInfo::loadPlan() {
         << analyzerSlice.toJson();
     }
   }
-  TRI_IF_FAILURE("AlwaysSwapAnalyzersRevision") {
+  ARANGODB_IF_FAILURE("AlwaysSwapAnalyzersRevision") {
     swapAnalyzers = true;
   }
 
@@ -3062,7 +3062,7 @@ Result ClusterInfo::createCollectionsCoordinator(
     }
   }
 
-  TRI_IF_FAILURE("ClusterInfo::createCollectionsCoordinator") {
+  ARANGODB_IF_FAILURE("ClusterInfo::createCollectionsCoordinator") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -3124,7 +3124,7 @@ Result ClusterInfo::createCollectionsCoordinator(
           << "createCollectionCoordinator, isBuilding removed, waiting for new "
              "Plan...";
 
-      TRI_IF_FAILURE("ClusterInfo::createCollectionsCoordinatorRemoveIsBuilding") {
+      ARANGODB_IF_FAILURE("ClusterInfo::createCollectionsCoordinatorRemoveIsBuilding") {
         res.set(rest::ResponseCode::PRECONDITION_FAILED, "Failed to mark collection ready");
       }
 
@@ -3822,7 +3822,7 @@ std::pair<Result, AnalyzersRevision::Revision> ClusterInfo::startModifyingAnalyz
 /// is a timeout.
 ////////////////////////////////////////////////////////////////////////////////
 Result ClusterInfo::finishModifyingAnalyzerCoordinator(DatabaseID const& databaseID, bool restore) {
-  TRI_IF_FAILURE("FinishModifyingAnalyzerCoordinator") {
+  ARANGODB_IF_FAILURE("FinishModifyingAnalyzerCoordinator") {
     return Result(TRI_ERROR_DEBUG);
   }
 
@@ -4854,7 +4854,7 @@ std::unordered_map<ServerID, RebootId> ClusterInfo::rebootIds() const {
 ////////////////////////////////////////////////////////////////////////////////
 
 std::string ClusterInfo::getServerEndpoint(ServerID const& serverID) {
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if (serverID == "debug-follower") {
     return "tcp://127.0.0.1:3000";
   }
@@ -4905,7 +4905,7 @@ std::string ClusterInfo::getServerEndpoint(ServerID const& serverID) {
 ////////////////////////////////////////////////////////////////////////////////
 
 std::string ClusterInfo::getServerAdvertisedEndpoint(ServerID const& serverID) {
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if (serverID == "debug-follower") {
     return "tcp://127.0.0.1:3000";
   }
@@ -5358,7 +5358,7 @@ std::unordered_map<ShardID, ServerID> ClusterInfo::getResponsibleServers(
 ////////////////////////////////////////////////////////////////////////////////
 
 std::shared_ptr<std::vector<ShardID>> ClusterInfo::getShardList(CollectionID const& collectionID) {
-  TRI_IF_FAILURE("ClusterInfo::failedToGetShardList") {
+  ARANGODB_IF_FAILURE("ClusterInfo::failedToGetShardList") {
     // Simulate no results
     return std::make_shared<std::vector<ShardID>>();
   }
@@ -5503,7 +5503,7 @@ void ClusterInfo::setFailedServers(std::vector<std::string> const& failedServers
   _failedServers = failedServers;
 }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 void ClusterInfo::setServers(std::unordered_map<ServerID, std::string> servers) {
   WRITE_LOCKER(readLocker, _serversProt.lock);
   _servers = std::move(servers);

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -325,7 +325,7 @@ class AnalyzerModificationTransaction {
   static std::atomic<int32_t> _pendingAnalyzerOperationsCount;
 };
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 class ClusterInfo {
 #else
 class ClusterInfo final {
@@ -907,7 +907,7 @@ class ClusterInfo final {
 
   void setFailedServers(std::vector<std::string> const& failedServers);
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   void setServers(std::unordered_map<ServerID, std::string> servers);
 
   void setServerAliases(std::unordered_map<ServerID, std::string> aliases);

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -754,7 +754,7 @@ bool shardKeysChanged(LogicalCollection const& collection, VPackSlice const& old
     // expecting two objects. everything else is an error
     return true;
   }
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if (collection.vocbase().name() == "sync-replication-test") {
     return false;
   }

--- a/arangod/Cluster/ClusterTrxMethods.cpp
+++ b/arangod/Cluster/ClusterTrxMethods.cpp
@@ -64,7 +64,7 @@ void buildTransactionBody(TransactionState& state, ServerID const& server,
         return true;
       }
       if (!state.isCoordinator()) {
-        TRI_IF_FAILURE("buildTransactionBodyEmpty") {
+        ARANGODB_IF_FAILURE("buildTransactionBodyEmpty") {
           return true;  // continue
         }
 

--- a/arangod/Cluster/CreateDatabase.cpp
+++ b/arangod/Cluster/CreateDatabase.cpp
@@ -70,7 +70,7 @@ bool CreateDatabase::first() {
 
   LOG_TOPIC("953b1", INFO, Logger::MAINTENANCE) << "CreateDatabase: creating database " << database;
 
-  TRI_IF_FAILURE("CreateDatabase::first") {
+  ARANGODB_IF_FAILURE("CreateDatabase::first") {
     // simulate DB creation failure
     result(TRI_ERROR_DEBUG);
     _feature.storeDBError(database, result());

--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -119,7 +119,7 @@ VPackSlice planShardEntry(arangodb::LogicalCollection const& col, VPackSlice pla
 ////////////////////////////////////////////////////////////////////////////////
 
 Result FollowerInfo::add(ServerID const& sid) {
-  TRI_IF_FAILURE("FollowerInfo::add") {
+  ARANGODB_IF_FAILURE("FollowerInfo::add") {
     return {TRI_ERROR_CLUSTER_AGENCY_COMMUNICATION_FAILED,
             "unable to add follower"};
   }
@@ -183,7 +183,7 @@ Result FollowerInfo::add(ServerID const& sid) {
 ////////////////////////////////////////////////////////////////////////////////
 
 Result FollowerInfo::remove(ServerID const& sid) {
-  TRI_IF_FAILURE("FollowerInfo::remove") {
+  ARANGODB_IF_FAILURE("FollowerInfo::remove") {
     return {TRI_ERROR_CLUSTER_AGENCY_COMMUNICATION_FAILED,
             "unable to remove follower"};
   }

--- a/arangod/Cluster/RebootTracker.cpp
+++ b/arangod/Cluster/RebootTracker.cpp
@@ -58,7 +58,7 @@ RebootTracker::RebootTracker(RebootTracker::SchedulerPointer scheduler)
   // SchedulerFeature. Thus this dies. However, we will be able to fix that at
   // a central place later, as there is some refactoring going on there. Then
   // this #ifdef can be removed.
-#ifndef ARANGODB_USE_GOOGLE_TESTS
+#ifndef ARANGODB_ENABLE_MAINTAINER_MODE
   TRI_ASSERT(_scheduler != nullptr);
 #endif
 }

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -758,7 +758,7 @@ bool SynchronizeShard::first() {
         << failuresInRow << " failures in a row. delaying next sync by " 
         << sleepTime << " s";
   
-    TRI_IF_FAILURE("SynchronizeShard::noSleepOnSyncError") {
+    ARANGODB_IF_FAILURE("SynchronizeShard::noSleepOnSyncError") {
       sleepTime = 0.0;
     }
 
@@ -1251,7 +1251,7 @@ Result SynchronizeShard::catchupWithExclusiveLock(
   res = addShardFollower(pool, ep, getDatabase(), getShard(), lockJobId, clientId,
                          syncerId, _clientInfoString, 60.0);
 
-  TRI_IF_FAILURE("SynchronizeShard::wrongChecksum") {
+  ARANGODB_IF_FAILURE("SynchronizeShard::wrongChecksum") {
     res.reset(TRI_ERROR_REPLICATION_WRONG_CHECKSUM);
   }
 

--- a/arangod/Cluster/UpdateCollection.cpp
+++ b/arangod/Cluster/UpdateCollection.cpp
@@ -103,7 +103,7 @@ bool UpdateCollection::first() {
       // from the local list of followers. Will be reported
       // to Current in due course.
       if (!followersToDrop.empty()) {
-        TRI_IF_FAILURE("Maintenance::doNotRemoveUnPlannedFollowers") {
+        ARANGODB_IF_FAILURE("Maintenance::doNotRemoveUnPlannedFollowers") {
           LOG_TOPIC("de342", ERR, Logger::MAINTENANCE)
               << "Skipping check for followers not in Plan because of failure "
                  "point.";

--- a/arangod/ClusterEngine/ClusterCollection.cpp
+++ b/arangod/ClusterEngine/ClusterCollection.cpp
@@ -68,7 +68,7 @@ ClusterCollection::ClusterCollection(LogicalCollection& collection, ClusterEngin
   if (_engineType == ClusterEngineType::RocksDBEngine) {
     return;
   }
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if (_engineType == ClusterEngineType::MockEngine) {
     return;
   }
@@ -115,7 +115,7 @@ Result ClusterCollection::updateProperties(VPackSlice const& slice, bool doSync)
     if (!validators.isNone()) {
       merge.add(StaticStrings::Schema, validators);
     }
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   } else if (_engineType == ClusterEngineType::MockEngine) {
     // do nothing
 #endif
@@ -157,7 +157,7 @@ void ClusterCollection::getPropertiesVPack(velocypack::Builder& result) const {
   if (_engineType == ClusterEngineType::RocksDBEngine) {
     result.add(StaticStrings::CacheEnabled,
                VPackValue(Helper::getBooleanValue(_info.slice(), StaticStrings::CacheEnabled, false)));
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   } else if (_engineType == ClusterEngineType::MockEngine) {
     // do nothing
 #endif

--- a/arangod/ClusterEngine/ClusterEngine.cpp
+++ b/arangod/ClusterEngine/ClusterEngine.cpp
@@ -54,7 +54,7 @@ using namespace arangodb::application_features;
 std::string const ClusterEngine::EngineName("Cluster");
 std::string const ClusterEngine::FeatureName("ClusterEngine");
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 // fall back to the using the mock storage engine
 bool ClusterEngine::Mocking = false;
 #endif
@@ -79,7 +79,7 @@ bool ClusterEngine::isRocksDB() const {
 }
 
 bool ClusterEngine::isMock() const {
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   return ClusterEngine::Mocking ||
          (_actualEngine && _actualEngine->name() == "Mock");
 #else
@@ -92,7 +92,7 @@ HealthData ClusterEngine::healthCheck() {
 }
 
 ClusterEngineType ClusterEngine::engineType() const {
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if (isMock()) {
     return ClusterEngineType::MockEngine;
   }
@@ -277,7 +277,7 @@ Result ClusterEngine::compactAll(bool changeLevel, bool compactBottomMostLevel) 
 void ClusterEngine::addOptimizerRules(aql::OptimizerRulesFeature& feature) {
   if (engineType() == ClusterEngineType::RocksDBEngine) {
     RocksDBOptimizerRules::registerResources(feature);
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   } else if (engineType() == ClusterEngineType::MockEngine) {
     // do nothing
 #endif

--- a/arangod/ClusterEngine/ClusterEngine.h
+++ b/arangod/ClusterEngine/ClusterEngine.h
@@ -218,7 +218,7 @@ class ClusterEngine final : public StorageEngine {
   static std::string const FeatureName;
 
   // mock mode
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   static bool Mocking;
 #else
   static constexpr bool Mocking = false;

--- a/arangod/ClusterEngine/ClusterIndex.cpp
+++ b/arangod/ClusterEngine/ClusterIndex.cpp
@@ -141,7 +141,7 @@ bool ClusterIndex::hasSelectivityEstimate() const {
             (_indexType == Index::TRI_IDX_TYPE_HASH_INDEX ||
              _indexType == Index::TRI_IDX_TYPE_SKIPLIST_INDEX ||
              _indexType == Index::TRI_IDX_TYPE_PERSISTENT_INDEX));
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   } else if (_engineType == ClusterEngineType::MockEngine) {
     return false;
 #endif
@@ -179,7 +179,7 @@ bool ClusterIndex::isSorted() const {
            _indexType == Index::TRI_IDX_TYPE_PERSISTENT_INDEX ||
            _indexType == Index::TRI_IDX_TYPE_TTL_INDEX ||
            _indexType == Index::TRI_IDX_TYPE_FULLTEXT_INDEX;
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   } else if (_engineType == ClusterEngineType::MockEngine) {
     return false;
 #endif
@@ -364,7 +364,7 @@ aql::AstNode* ClusterIndex::specializeCondition(aql::AstNode* node,
       break;
   }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if (_engineType == ClusterEngineType::MockEngine) {
     return node;
   }

--- a/arangod/ClusterEngine/ClusterTransactionState.cpp
+++ b/arangod/ClusterEngine/ClusterTransactionState.cpp
@@ -119,7 +119,7 @@ Result ClusterTransactionState::commitTransaction(transaction::Methods* activeTr
       << "committing " << AccessMode::typeString(_type) << " transaction";
 
   TRI_ASSERT(_status == transaction::Status::RUNNING);
-  TRI_IF_FAILURE("TransactionWriteCommitMarker") {
+  ARANGODB_IF_FAILURE("TransactionWriteCommitMarker") {
     return Result(TRI_ERROR_DEBUG);
   }
 

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -380,7 +380,7 @@ void CommTask::executeRequest(std::unique_ptr<GeneralRequest> request,
       ok = handleRequestAsync(std::move(handler));
     }
 
-    TRI_IF_FAILURE("queueFull") {
+    ARANGODB_IF_FAILURE("queueFull") {
       ok = false;
       jobId = 0;
     }

--- a/arangod/GeneralServer/GeneralServerFeature.cpp
+++ b/arangod/GeneralServer/GeneralServerFeature.cpp
@@ -574,7 +574,7 @@ void GeneralServerFeature::defineHandlers() {
   _handlerFactory->addHandler("/_admin/supervisionState",
                               RestHandlerCreator<arangodb::RestSupervisionStateHandler>::createNoData);
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // This handler is to activate SYS_DEBUG_FAILAT on DB servers
   _handlerFactory->addPrefixHandler("/_admin/debug",
                                     RestHandlerCreator<arangodb::RestDebugHandler>::createNoData);

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -250,7 +250,7 @@ bool HttpCommTask<T>::readCallback(asio_ns::error_code ec) {
       do {
         size_t datasize = end - data;
 
-        TRI_IF_FAILURE("HttpCommTask<T>::readCallback_in_small_chunks") {
+        ARANGODB_IF_FAILURE("HttpCommTask<T>::readCallback_in_small_chunks") {
           // we had an issue that URLs were cut off because the url data was handed
           // in in multiple buffers.
           // To cover this case, we simulate that data fed to the parser in small chunks.

--- a/arangod/Graph/AttributeWeightShortestPathFinder.cpp
+++ b/arangod/Graph/AttributeWeightShortestPathFinder.cpp
@@ -223,7 +223,7 @@ bool AttributeWeightShortestPathFinder::shortestPath(arangodb::velocypack::Slice
     backwardSearcher = std::make_unique<Searcher>(this, backward, forward, target, true);
   }
 
-  TRI_IF_FAILURE("TraversalOOMInitialize") {
+  ARANGODB_IF_FAILURE("TraversalOOMInitialize") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -297,7 +297,7 @@ bool AttributeWeightShortestPathFinder::shortestPath(arangodb::velocypack::Slice
     s = backward._pq.find(s->_predecessor);
   }
 
-  TRI_IF_FAILURE("TraversalOOMPath") {
+  ARANGODB_IF_FAILURE("TraversalOOMPath") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 

--- a/arangod/Graph/ConstantWeightShortestPathFinder.cpp
+++ b/arangod/Graph/ConstantWeightShortestPathFinder.cpp
@@ -98,7 +98,7 @@ bool ConstantWeightShortestPathFinder::shortestPath(
   _leftClosure.emplace_back(start);
   _rightClosure.emplace_back(end);
 
-  TRI_IF_FAILURE("TraversalOOMInitialize") {
+  ARANGODB_IF_FAILURE("TraversalOOMInitialize") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -180,7 +180,7 @@ void ConstantWeightShortestPathFinder::fillResult(arangodb::velocypack::StringRe
     it = _rightFound.find(next);
   }
 
-  TRI_IF_FAILURE("TraversalOOMPath") {
+  ARANGODB_IF_FAILURE("TraversalOOMPath") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
   _options.fetchVerticesCoordinator(result._vertices);

--- a/arangod/Graph/KShortestPathsFinder.cpp
+++ b/arangod/Graph/KShortestPathsFinder.cpp
@@ -87,7 +87,7 @@ bool KShortestPathsFinder::startKShortestPathsTraversal(
   clear();
   _traversalDone = false;
 
-  TRI_IF_FAILURE("Travefalse") { THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG); }
+  ARANGODB_IF_FAILURE("Travefalse") { THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG); }
 
   return true;
 }
@@ -305,7 +305,7 @@ void KShortestPathsFinder::reconstructPath(Ball const& left, Ball const& right,
     result._weights.emplace_back(startToJoin + (joinToEnd - it->_weight));
   }
 
-  TRI_IF_FAILURE("TraversalOOMPath") {
+  ARANGODB_IF_FAILURE("TraversalOOMPath") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -421,7 +421,7 @@ bool KShortestPathsFinder::getNextPath(Path& result) {
     _shortestPaths.emplace_back(result);
     _options.fetchVerticesCoordinator(result._vertices);
 
-    TRI_IF_FAILURE("TraversalOOMPath") {
+    ARANGODB_IF_FAILURE("TraversalOOMPath") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
   } else {
@@ -431,7 +431,7 @@ bool KShortestPathsFinder::getNextPath(Path& result) {
   return !_traversalDone;
 }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 bool KShortestPathsFinder::getNextPathShortestPathResult(ShortestPathResult& result) {
   _tempPath.clear();
 

--- a/arangod/Graph/KShortestPathsFinder.h
+++ b/arangod/Graph/KShortestPathsFinder.h
@@ -258,7 +258,7 @@ class KShortestPathsFinder : public ShortestPathFinder {
   // get the next available path as a ShortestPathResult
   // TODO: this is only here to not break catch-tests and needs a cleaner solution.
   //       probably by making ShortestPathResult versatile enough and using that
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   bool getNextPathShortestPathResult(ShortestPathResult& path);
 #endif
   // get the next available path as a Path

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -1162,7 +1162,7 @@ getAnalyzerMeta(irs::analysis::analyzer const* analyzer) noexcept {
              &GeoPointAnalyzer::store };
   }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if ("iresearch-vpack-analyzer" == type().name()) {
     return { AnalyzerValueType::Array | AnalyzerValueType::Object,
              AnalyzerValueType::String,
@@ -2781,7 +2781,7 @@ Result IResearchAnalyzerFeature::removeFromCollection(irs::string_ref const& nam
 }
 
 Result IResearchAnalyzerFeature::finalizeRemove(irs::string_ref const& name, irs::string_ref const& vocbase) {
-  TRI_IF_FAILURE("FinalizeAnalyzerRemove") {
+  ARANGODB_IF_FAILURE("FinalizeAnalyzerRemove") {
     return Result(TRI_ERROR_DEBUG);
   }
 
@@ -2946,7 +2946,7 @@ Result IResearchAnalyzerFeature::remove(
         return result.result;
       }
 
-      TRI_IF_FAILURE("UpdateAnalyzerForRemove") {
+      ARANGODB_IF_FAILURE("UpdateAnalyzerForRemove") {
         return Result(TRI_ERROR_DEBUG);
       }
 
@@ -3045,7 +3045,7 @@ void IResearchAnalyzerFeature::stop() {
 }
 
 Result IResearchAnalyzerFeature::storeAnalyzer(AnalyzerPool& pool) {
-  TRI_IF_FAILURE("FailStoreAnalyzer") {
+  ARANGODB_IF_FAILURE("FailStoreAnalyzer") {
     return Result(TRI_ERROR_DEBUG);
   }
 

--- a/arangod/IResearch/IResearchCompression.cpp
+++ b/arangod/IResearch/IResearchCompression.cpp
@@ -24,7 +24,7 @@
 #include "IResearchCompression.h"
 #include "Basics/debugging.h"
 #include <utils/lz4compression.hpp>
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 #include "../tests/IResearch/IResearchTestCompressor.h"
 #endif
 
@@ -47,7 +47,7 @@ irs::string_ref columnCompressionToString(irs::type_info::type_id type) noexcept
 
 irs::type_info::type_id columnCompressionFromString(irs::string_ref const& c) noexcept {
   TRI_ASSERT(!c.null());
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if (c == "test") {
     return irs::type<irs::compression::mock::test_compressor>::id();
   }

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -366,7 +366,7 @@ bool upgradeArangoSearchLinkCollectionName(TRI_vocbase_t& vocbase,
                     << clusterCollectionName << "' for link " << indexPtr->id().id()
                     << ": " << res.errorMessage();;
                 }
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
               } else if (selector.engineName() != "Mock") { // for unit tests just ignore write to storage
 #else
               } else {
@@ -768,11 +768,11 @@ class IResearchAsync{
   }
 
   ThreadPool& get(ThreadGroup id)
-#ifndef ARANGODB_ENABLE_FAILURE_TESTS
+#ifndef ARANGODB_ENABLE_MAINTAINER_MODE
   noexcept
 #endif
   {
-    TRI_IF_FAILURE("IResearchFeature::testGroupAccess") {
+    ARANGODB_IF_FAILURE("IResearchFeature::testGroupAccess") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
 
@@ -1018,19 +1018,19 @@ bool IResearchFeature::queue(
     std::chrono::steady_clock::duration delay,
     std::function<void()>&& fn) {
   try {
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
-    TRI_IF_FAILURE("IResearchFeature::queue") {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    ARANGODB_IF_FAILURE("IResearchFeature::queue") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
 
     switch (id) {
       case ThreadGroup::_0:
-        TRI_IF_FAILURE("IResearchFeature::queueGroup0") {
+        ARANGODB_IF_FAILURE("IResearchFeature::queueGroup0") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
         break;
       case ThreadGroup::_1:
-        TRI_IF_FAILURE("IResearchFeature::queueGroup1") {
+        ARANGODB_IF_FAILURE("IResearchFeature::queueGroup1") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
         break;

--- a/arangod/IResearch/IResearchLink.cpp
+++ b/arangod/IResearch/IResearchLink.cpp
@@ -379,7 +379,7 @@ void CommitTask::operator()() {
 
   // reload RuntimeState
   {
-    TRI_IF_FAILURE("IResearchCommitTask::lockDataStore") {
+    ARANGODB_IF_FAILURE("IResearchCommitTask::lockDataStore") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
 
@@ -401,7 +401,7 @@ void CommitTask::operator()() {
     return;
   }
 
-  TRI_IF_FAILURE("IResearchCommitTask::commitUnsafe") {
+  ARANGODB_IF_FAILURE("IResearchCommitTask::commitUnsafe") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -419,7 +419,7 @@ void CommitTask::operator()() {
       if (cleanupIntervalStep && cleanupIntervalCount++ > cleanupIntervalStep) { // if enabled
         cleanupIntervalCount = 0;
 
-        TRI_IF_FAILURE("IResearchCommitTask::cleanupUnsafe") {
+        ARANGODB_IF_FAILURE("IResearchCommitTask::cleanupUnsafe") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
 
@@ -519,7 +519,7 @@ void ConsolidationTask::operator()() {
 
   // reload RuntimeState
   {
-    TRI_IF_FAILURE("IResearchConsolidationTask::lockDataStore") {
+    ARANGODB_IF_FAILURE("IResearchConsolidationTask::lockDataStore") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
 
@@ -550,7 +550,7 @@ void ConsolidationTask::operator()() {
     schedule(consolidationIntervalMsec);
   }
 
-  TRI_IF_FAILURE("IResearchConsolidationTask::consolidateUnsafe") {
+  ARANGODB_IF_FAILURE("IResearchConsolidationTask::consolidateUnsafe") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -668,7 +668,7 @@ void IResearchLink::afterTruncate(TRI_voc_tick_t tick,
                                   transaction::Methods* trx) {
   auto lock = _asyncSelf->lock();  // '_dataStore' can be asynchronously modified
 
-  TRI_IF_FAILURE("ArangoSearchTruncateFailure") {
+  ARANGODB_IF_FAILURE("ArangoSearchTruncateFailure") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -1566,7 +1566,7 @@ Result IResearchLink::insert(
     }
   };
 
-  TRI_IF_FAILURE("ArangoSearch::BlockInsertsWithoutIndexCreationHint") {
+  ARANGODB_IF_FAILURE("ArangoSearch::BlockInsertsWithoutIndexCreationHint") {
     if (!state.hasHint(transaction::Hints::Hint::INDEX_CREATION)) {
       return Result(TRI_ERROR_DEBUG);
     }
@@ -1576,7 +1576,7 @@ Result IResearchLink::insert(
     auto lock = _asyncSelf->lock();
     auto ctx = _dataStore._writer->documents();
 
-    TRI_IF_FAILURE("ArangoSearch::MisreportCreationInsertAsFailed") {
+    ARANGODB_IF_FAILURE("ArangoSearch::MisreportCreationInsertAsFailed") {
       auto res = insertImpl(ctx); // we need insert to succeed, so  we have things to cleanup in storage
       if (res.fail()) {
         return res;

--- a/arangod/IResearch/IResearchLinkCoordinator.cpp
+++ b/arangod/IResearch/IResearchLinkCoordinator.cpp
@@ -44,7 +44,7 @@
 namespace {
 
 arangodb::ClusterEngineType getEngineType(arangodb::application_features::ApplicationServer& server) {
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // during the unit tests there is a mock storage engine which cannot be casted
   // to a ClusterEngine at all. the only sensible way to find out the engine type is 
   // to try a dynamic_cast here and assume the MockEngine if the cast goes wrong

--- a/arangod/Indexes/Index.cpp
+++ b/arangod/Indexes/Index.cpp
@@ -917,7 +917,7 @@ void Index::expandInSearchValues(VPackSlice const base, VPackBuilder& result) co
     std::vector<size_t> positions(n, 0);
     bool done = false;
     while (!done) {
-      TRI_IF_FAILURE("Index::permutationIN") {
+      ARANGODB_IF_FAILURE("Index::permutationIN") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
       VPackArrayBuilder guard(&result);

--- a/arangod/Indexes/SimpleAttributeEqualityMatcher.cpp
+++ b/arangod/Indexes/SimpleAttributeEqualityMatcher.cpp
@@ -267,7 +267,7 @@ arangodb::aql::AstNode* SimpleAttributeEqualityMatcher::specializeAll(
                           reference, nonNullAttributes, false) ||
           accessFitsIndex(index, op->getMember(1), op->getMember(0), op,
                           reference, nonNullAttributes, false)) {
-        TRI_IF_FAILURE("SimpleAttributeMatcher::specializeAllChildrenEQ") {
+        ARANGODB_IF_FAILURE("SimpleAttributeMatcher::specializeAllChildrenEQ") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
         if (_found.size() == _attributes.size()) {
@@ -279,7 +279,7 @@ arangodb::aql::AstNode* SimpleAttributeEqualityMatcher::specializeAll(
       TRI_ASSERT(op->numMembers() == 2);
       if (accessFitsIndex(index, op->getMember(0), op->getMember(1), op,
                           reference, nonNullAttributes, false)) {
-        TRI_IF_FAILURE("SimpleAttributeMatcher::specializeAllChildrenIN") {
+        ARANGODB_IF_FAILURE("SimpleAttributeMatcher::specializeAllChildrenIN") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
         if (_found.size() == _attributes.size()) {
@@ -479,7 +479,7 @@ bool SimpleAttributeEqualityMatcher::accessFitsIndex(
     if (match) {
       // mark ith attribute as being covered
       _found.try_emplace(i, op);
-      TRI_IF_FAILURE("SimpleAttributeMatcher::accessFitsIndex") {
+      ARANGODB_IF_FAILURE("SimpleAttributeMatcher::accessFitsIndex") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
       return true;

--- a/arangod/Indexes/SortedIndexAttributeMatcher.cpp
+++ b/arangod/Indexes/SortedIndexAttributeMatcher.cpp
@@ -185,13 +185,13 @@ bool SortedIndexAttributeMatcher::accessFitsIndex(
     if (match) {
       // mark ith attribute as being covered
       found[i].emplace_back(op);
-      TRI_IF_FAILURE("PersistentIndex::accessFitsIndex") {
+      ARANGODB_IF_FAILURE("PersistentIndex::accessFitsIndex") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
-      TRI_IF_FAILURE("SkiplistIndex::accessFitsIndex") {
+      ARANGODB_IF_FAILURE("SkiplistIndex::accessFitsIndex") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
-      TRI_IF_FAILURE("HashIndex::accessFitsIndex") {
+      ARANGODB_IF_FAILURE("HashIndex::accessFitsIndex") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
 
@@ -259,7 +259,7 @@ Index::FilterCosts SortedIndexAttributeMatcher::supportsFilterCondition(
     arangodb::aql::Variable const* reference, size_t itemsInIndex) {
   // mmfiles failure point compat
   if (idx->type() == Index::TRI_IDX_TYPE_HASH_INDEX) {
-    TRI_IF_FAILURE("SimpleAttributeMatcher::accessFitsIndex") {
+    ARANGODB_IF_FAILURE("SimpleAttributeMatcher::accessFitsIndex") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
   }
@@ -470,10 +470,10 @@ arangodb::aql::AstNode* SortedIndexAttributeMatcher::specializeCondition(
     arangodb::aql::Variable const* reference) {
   // mmfiles failure compat
   if (idx->type() == Index::TRI_IDX_TYPE_HASH_INDEX) {
-    TRI_IF_FAILURE("SimpleAttributeMatcher::specializeAllChildrenEQ") {
+    ARANGODB_IF_FAILURE("SimpleAttributeMatcher::specializeAllChildrenEQ") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
-    TRI_IF_FAILURE("SimpleAttributeMatcher::specializeAllChildrenIN") {
+    ARANGODB_IF_FAILURE("SimpleAttributeMatcher::specializeAllChildrenIN") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
   }

--- a/arangod/Network/ConnectionPool.h
+++ b/arangod/Network/ConnectionPool.h
@@ -50,7 +50,7 @@ namespace network {
 class ConnectionPtr;
 
 /// @brief simple connection pool managing fuerte connections
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 class ConnectionPool {
 #else
 class ConnectionPool final {

--- a/arangod/Network/Methods.cpp
+++ b/arangod/Network/Methods.cpp
@@ -81,7 +81,7 @@ arangodb::fuerte::Response& Response::response() const {
   return *_response;
 }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 /// @brief inject a different response - only use this from tests!
 void Response::setResponse(std::unique_ptr<arangodb::fuerte::Response> response) {
   _response = std::move(response);

--- a/arangod/Network/Methods.h
+++ b/arangod/Network/Methods.h
@@ -71,7 +71,7 @@ struct Response {
   /// there is no valid response!
   arangodb::fuerte::Response& response() const;
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   /// @brief inject a different response - only use this from tests!
   void setResponse(std::unique_ptr<arangodb::fuerte::Response> response);
 #endif

--- a/arangod/Network/NetworkFeature.cpp
+++ b/arangod/Network/NetworkFeature.cpp
@@ -263,7 +263,7 @@ arangodb::network::ConnectionPool* NetworkFeature::pool() const {
   return _poolPtr.load(std::memory_order_relaxed);
 }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 void NetworkFeature::setPoolTesting(arangodb::network::ConnectionPool* pool) {
   _poolPtr.store(pool, std::memory_order_release);
 }

--- a/arangod/Network/NetworkFeature.h
+++ b/arangod/Network/NetworkFeature.h
@@ -60,7 +60,7 @@ class NetworkFeature final : public application_features::ApplicationFeature {
   /// @brief global connection pool
   arangodb::network::ConnectionPool* pool() const;
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   void setPoolTesting(arangodb::network::ConnectionPool* pool);
 #endif
 

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -368,7 +368,7 @@ DatabaseInitialSyncer::DatabaseInitialSyncer(TRI_vocbase_t& vocbase,
       _quickKeysNumDocsLimit(vocbase.server().getFeature<ReplicationFeature>().quickKeysLimit()) {
   _state.vocbases.try_emplace(vocbase.name(), vocbase);
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   adjustQuickKeysNumDocsLimit();
 #endif
   if (configuration._database.empty()) {
@@ -1155,7 +1155,7 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByKeys(arangodb::LogicalCollect
     
   uint64_t ndocs = c.getNumber<uint64_t>();
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if (ndocs > _quickKeysNumDocsLimit && slice.hasKey("id")) {
     LOG_TOPIC("6e1b3", ERR, Logger::REPLICATION)
         << "client: DatabaseInitialSyncer::run - expected only document count for quick call";
@@ -1382,7 +1382,7 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(arangodb::LogicalCo
   });
   std::unique_ptr<arangodb::SingleCollectionTransaction> trx;
   transaction::Options options;
-  TRI_IF_FAILURE("IncrementalReplicationFrequentIntermediateCommit") {
+  ARANGODB_IF_FAILURE("IncrementalReplicationFrequentIntermediateCommit") {
     options.intermediateCommitCount = 1000;
   }
   try {
@@ -2199,10 +2199,10 @@ Result DatabaseInitialSyncer::batchFinish() {
   return _config.batch.finish(_config.connection, _config.progress, _config.state.syncerId);
 }
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 /// @brief patch quickKeysNumDocsLimit for testing
 void DatabaseInitialSyncer::adjustQuickKeysNumDocsLimit() {
-  TRI_IF_FAILURE("RocksDBRestReplicationHandler::quickKeysNumDocsLimit100") {
+  ARANGODB_IF_FAILURE("RocksDBRestReplicationHandler::quickKeysNumDocsLimit100") {
     _quickKeysNumDocsLimit = 100;
   }
 }

--- a/arangod/Replication/DatabaseInitialSyncer.h
+++ b/arangod/Replication/DatabaseInitialSyncer.h
@@ -255,7 +255,7 @@ class DatabaseInitialSyncer : public InitialSyncer {
   bool const _isClusterRole;
   uint64_t _quickKeysNumDocsLimit;
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   void adjustQuickKeysNumDocsLimit();
 #endif
 };

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -441,7 +441,7 @@ RestAdminClusterHandler::FutureVoid RestAdminClusterHandler::tryDeleteServer(
                     resetResponse(rest::ResponseCode::OK);
                     return futures::makeFuture();
                   } else if (result.statusCode() == fuerte::StatusPreconditionFailed) {
-                    TRI_IF_FAILURE("removeServer::noRetry") {
+                    ARANGODB_IF_FAILURE("removeServer::noRetry") {
                       generateError(result.asResult());
                       return futures::makeFuture();
                     }
@@ -453,7 +453,7 @@ RestAdminClusterHandler::FutureVoid RestAdminClusterHandler::tryDeleteServer(
               });
         }
                     
-        TRI_IF_FAILURE("removeServer::noRetry") {
+        ARANGODB_IF_FAILURE("removeServer::noRetry") {
           generateError(Result(TRI_ERROR_HTTP_PRECONDITION_FAILED));
           return futures::makeFuture();
         }

--- a/arangod/RestHandler/RestCursorHandler.cpp
+++ b/arangod/RestHandler/RestCursorHandler.cpp
@@ -429,7 +429,7 @@ void RestCursorHandler::registerQuery(std::unique_ptr<arangodb::aql::Query> quer
 ////////////////////////////////////////////////////////////////////////////////
 
 void RestCursorHandler::unregisterQuery() {
-  TRI_IF_FAILURE("RestCursorHandler::directKillBeforeQueryResultIsGettingHandled") {
+  ARANGODB_IF_FAILURE("RestCursorHandler::directKillBeforeQueryResultIsGettingHandled") {
     _query->debugKillQuery();
   }
   MUTEX_LOCKER(mutexLocker, _queryLock);

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -174,7 +174,7 @@ RestStatus RestDocumentHandler::insertDocument() {
   extractStringParameter(StaticStrings::IsSynchronousReplicationString,
                          opOptions.isSynchronousReplicationFrom);
 
-  TRI_IF_FAILURE("delayed_synchronous_replication_request_processing") {
+  ARANGODB_IF_FAILURE("delayed_synchronous_replication_request_processing") {
     if (!opOptions.isSynchronousReplicationFrom.empty()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(RandomGenerator::interval(uint32_t(2000))));
     }
@@ -450,7 +450,7 @@ RestStatus RestDocumentHandler::modifyDocument(bool isPatch) {
   extractStringParameter(StaticStrings::IsSynchronousReplicationString,
                          opOptions.isSynchronousReplicationFrom);
 
-  TRI_IF_FAILURE("delayed_synchronous_replication_request_processing") {
+  ARANGODB_IF_FAILURE("delayed_synchronous_replication_request_processing") {
     if (!opOptions.isSynchronousReplicationFrom.empty()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(RandomGenerator::interval(uint32_t(2000))));
     }
@@ -601,7 +601,7 @@ RestStatus RestDocumentHandler::removeDocument() {
   extractStringParameter(StaticStrings::IsSynchronousReplicationString,
                          opOptions.isSynchronousReplicationFrom);
 
-  TRI_IF_FAILURE("delayed_synchronous_replication_request_processing") {
+  ARANGODB_IF_FAILURE("delayed_synchronous_replication_request_processing") {
     if (!opOptions.isSynchronousReplicationFrom.empty()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(RandomGenerator::interval(uint32_t(2000))));
     }

--- a/arangod/RestServer/BootstrapFeature.cpp
+++ b/arangod/RestServer/BootstrapFeature.cpp
@@ -88,7 +88,7 @@ BootstrapFeature::BootstrapFeature(application_features::ApplicationServer& serv
 }
 
 bool BootstrapFeature::isReady() const {
-  TRI_IF_FAILURE("BootstrapFeature_not_ready") {
+  ARANGODB_IF_FAILURE("BootstrapFeature_not_ready") {
     return false;
   }
   return _isReady;

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -522,10 +522,10 @@ void DatabaseFeature::unprepare() {
 
   _databaseManager.reset();
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // This is to avoid heap use after free errors in the iresearch tests, because
   // the destruction a callback uses a database.
-  // I don't know if this is safe to do, thus I enclosed it in ARANGODB_USE_GOOGLE_TESTS
+  // I don't know if this is safe to do, thus I enclosed it in ARANGODB_ENABLE_MAINTAINER_MODE
   // to prevent accidentally breaking anything. However,
   // TODO Find out if this is okay and may be merged (maybe without the #ifdef),
   // or if this has to be done differently in the tests instead. The errors may

--- a/arangod/RestServer/DatabaseFeature.h
+++ b/arangod/RestServer/DatabaseFeature.h
@@ -80,7 +80,7 @@ class DatabaseFeature : public application_features::ApplicationFeature {
   void prepare() override final;
 
   // used by catch tests
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   inline ErrorCode loadDatabases(velocypack::Slice const& databases) {
     return iterateDatabases(databases);
   }

--- a/arangod/RestServer/FlushFeature.cpp
+++ b/arangod/RestServer/FlushFeature.cpp
@@ -109,7 +109,7 @@ arangodb::Result FlushFeature::releaseUnusedTicks(size_t& count, TRI_voc_tick_t&
 
   TRI_ASSERT(minTick <= engine.currentTick());
 
-  TRI_IF_FAILURE("FlushCrashBeforeSyncingMinTick") {
+  ARANGODB_IF_FAILURE("FlushCrashBeforeSyncingMinTick") {
     TRI_TerminateDebugging("crashing before syncing min tick");
   }
 
@@ -117,13 +117,13 @@ arangodb::Result FlushFeature::releaseUnusedTicks(size_t& count, TRI_voc_tick_t&
   // engine supports it
   //   engine->waitForSyncTick(minTick);
   
-  TRI_IF_FAILURE("FlushCrashAfterSyncingMinTick") {
+  ARANGODB_IF_FAILURE("FlushCrashAfterSyncingMinTick") {
     TRI_TerminateDebugging("crashing after syncing min tick");
   }
 
   engine.releaseTick(minTick);
 
-  TRI_IF_FAILURE("FlushCrashAfterReleasingMinTick") {
+  ARANGODB_IF_FAILURE("FlushCrashAfterReleasingMinTick") {
     TRI_TerminateDebugging("crashing after releasing min tick");
   }
 

--- a/arangod/RestServer/QueryRegistryFeature.cpp
+++ b/arangod/RestServer/QueryRegistryFeature.cpp
@@ -401,7 +401,7 @@ void QueryRegistryFeature::prepare() {
   // prepare gauge value
   _globalQueryMemoryLimit = _queryGlobalMemoryLimit;
   
-#ifndef ARANGODB_USE_GOOGLE_TESTS
+#ifndef ARANGODB_ENABLE_MAINTAINER_MODE
   // we are now intentionally not printing this message during testing,
   // because otherwise it would be printed a *lot* of times
   // note that options() can be a nullptr during unit testing

--- a/arangod/RocksDBEngine/Methods/RocksDBTrxBaseMethods.cpp
+++ b/arangod/RocksDBEngine/Methods/RocksDBTrxBaseMethods.cpp
@@ -114,7 +114,7 @@ rocksdb::SequenceNumber RocksDBTrxBaseMethods::GetSequenceNumber() const noexcep
 /// @brief add an operation for a transaction collection
 Result RocksDBTrxBaseMethods::addOperation(DataSourceId cid, RevisionId revisionId,
                                            TRI_voc_document_operation_e operationType) {
-  TRI_IF_FAILURE("addOperationSizeError") {
+  ARANGODB_IF_FAILURE("addOperationSizeError") {
     return Result(TRI_ERROR_RESOURCE_LIMIT);
   }
 
@@ -334,7 +334,7 @@ arangodb::Result RocksDBTrxBaseMethods::doCommit() {
 
   _state->prepareCollections();
 
-  TRI_IF_FAILURE("TransactionChaos::randomSync") {
+  ARANGODB_IF_FAILURE("TransactionChaos::randomSync") {
     if (RandomGenerator::interval(uint32_t(1000)) > 950) {
       auto& selector = _state->vocbase().server().getFeature<EngineSelectorFeature>();
       auto& engine = selector.engine<RocksDBEngine>();

--- a/arangod/RocksDBEngine/Methods/RocksDBTrxMethods.cpp
+++ b/arangod/RocksDBEngine/Methods/RocksDBTrxMethods.cpp
@@ -139,10 +139,10 @@ void RocksDBTrxMethods::createTransaction() {
 Result RocksDBTrxMethods::triggerIntermediateCommit(bool& hasPerformedIntermediateCommit) {
   TRI_ASSERT(!hasPerformedIntermediateCommit);
 
-  TRI_IF_FAILURE("FailBeforeIntermediateCommit") {
+  ARANGODB_IF_FAILURE("FailBeforeIntermediateCommit") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
-  TRI_IF_FAILURE("SegfaultBeforeIntermediateCommit") {
+  ARANGODB_IF_FAILURE("SegfaultBeforeIntermediateCommit") {
     TRI_TerminateDebugging("SegfaultBeforeIntermediateCommit");
   }
 
@@ -167,10 +167,10 @@ Result RocksDBTrxMethods::triggerIntermediateCommit(bool& hasPerformedIntermedia
   _numRemoves = 0;
   _numLogdata = 0;
 
-  TRI_IF_FAILURE("FailAfterIntermediateCommit") {
+  ARANGODB_IF_FAILURE("FailAfterIntermediateCommit") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
-  TRI_IF_FAILURE("SegfaultAfterIntermediateCommit") {
+  ARANGODB_IF_FAILURE("SegfaultAfterIntermediateCommit") {
     TRI_TerminateDebugging("SegfaultAfterIntermediateCommit");
   }
 
@@ -184,7 +184,7 @@ Result RocksDBTrxMethods::triggerIntermediateCommit(bool& hasPerformedIntermedia
 Result RocksDBTrxMethods::checkIntermediateCommit(uint64_t newSize, bool& hasPerformedIntermediateCommit) {
   hasPerformedIntermediateCommit = false;
     
-  TRI_IF_FAILURE("noIntermediateCommits") {
+  ARANGODB_IF_FAILURE("noIntermediateCommits") {
     return TRI_ERROR_NO_ERROR;
   }
 

--- a/arangod/RocksDBEngine/RocksDBBackgroundThread.cpp
+++ b/arangod/RocksDBEngine/RocksDBBackgroundThread.cpp
@@ -61,7 +61,7 @@ void RocksDBBackgroundThread::run() {
       continue;
     }
 
-    TRI_IF_FAILURE("RocksDBBackgroundThread::run") { continue; }
+    ARANGODB_IF_FAILURE("RocksDBBackgroundThread::run") { continue; }
 
     try {
       if (!isStopping()) {

--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
@@ -188,7 +188,7 @@ static arangodb::Result fillIndex(rocksdb::DB* rootDB, RocksDBIndex& ridx, Rocks
     THROW_ARANGO_EXCEPTION(res);
   }
 
-  TRI_IF_FAILURE("RocksDBBuilderIndex::fillIndex") { FATAL_ERROR_EXIT(); }
+  ARANGODB_IF_FAILURE("RocksDBBuilderIndex::fillIndex") { FATAL_ERROR_EXIT(); }
 
   uint64_t numDocsWritten = 0;
   RocksDBTransactionCollection* trxColl = trx.resolveTrxCollection();

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -689,7 +689,7 @@ Result RocksDBCollection::truncate(transaction::Methods& trx, OperationOptions& 
     // no savepoint needed here
     TRI_ASSERT(!state->hasOperations());  // not allowed
 
-    TRI_IF_FAILURE("RocksDBRemoveLargeRangeOn") {
+    ARANGODB_IF_FAILURE("RocksDBRemoveLargeRangeOn") {
       return Result(TRI_ERROR_DEBUG);
     }
 
@@ -699,7 +699,7 @@ Result RocksDBCollection::truncate(transaction::Methods& trx, OperationOptions& 
                                 .engine<RocksDBEngine>();
     rocksdb::DB* db = engine.db()->GetRootDB();
 
-    TRI_IF_FAILURE("RocksDBCollection::truncate::forceSync") {
+    ARANGODB_IF_FAILURE("RocksDBCollection::truncate::forceSync") {
       engine.settingsManager()->sync(false);
     }
 
@@ -765,7 +765,7 @@ Result RocksDBCollection::truncate(transaction::Methods& trx, OperationOptions& 
     return {};
   }
 
-  TRI_IF_FAILURE("RocksDBRemoveLargeRangeOff") {
+  ARANGODB_IF_FAILURE("RocksDBRemoveLargeRangeOff") {
     return {TRI_ERROR_DEBUG};
   }
 
@@ -840,8 +840,8 @@ Result RocksDBCollection::truncate(transaction::Methods& trx, OperationOptions& 
   }
 #endif
 
-  TRI_IF_FAILURE("FailAfterAllCommits") { return Result(TRI_ERROR_DEBUG); }
-  TRI_IF_FAILURE("SegfaultAfterAllCommits") {
+  ARANGODB_IF_FAILURE("FailAfterAllCommits") { return Result(TRI_ERROR_DEBUG); }
+  ARANGODB_IF_FAILURE("SegfaultAfterAllCommits") {
     TRI_TerminateDebugging("SegfaultAfterAllCommits");
   }
   return {};
@@ -889,7 +889,7 @@ bool RocksDBCollection::lookupRevision(transaction::Methods* trx, VPackSlice con
 Result RocksDBCollection::read(transaction::Methods* trx,
                                arangodb::velocypack::StringRef const& key,
                                IndexIterator::DocumentCallback const& cb) const {
-  TRI_IF_FAILURE("LogicalCollection::read") { return Result(TRI_ERROR_DEBUG); }
+  ARANGODB_IF_FAILURE("LogicalCollection::read") { return Result(TRI_ERROR_DEBUG); }
 
   ::ReadTimeTracker timeTracker(_statistics._rocksdb_read_sec, _statistics);
 
@@ -1425,13 +1425,13 @@ Result RocksDBCollection::insertDocument(arangodb::transaction::Methods* trx,
   }
 #endif
 
-  TRI_IF_FAILURE("RocksDBCollection::insertFail1") {
+  ARANGODB_IF_FAILURE("RocksDBCollection::insertFail1") {
     if (RandomGenerator::interval(uint32_t(1000)) >= 995) {
       return res.reset(TRI_ERROR_DEBUG);
     }
   }
   
-  TRI_IF_FAILURE("RocksDBCollection::insertFail1Always") {
+  ARANGODB_IF_FAILURE("RocksDBCollection::insertFail1Always") {
     return res.reset(TRI_ERROR_DEBUG);
   }
   
@@ -1458,13 +1458,13 @@ Result RocksDBCollection::insertDocument(arangodb::transaction::Methods* trx,
     RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
 
     for (auto it = _indexes.begin(); it != _indexes.end(); ++it) {
-      TRI_IF_FAILURE("RocksDBCollection::insertFail2") {
+      ARANGODB_IF_FAILURE("RocksDBCollection::insertFail2") {
         if (it == _indexes.begin() && RandomGenerator::interval(uint32_t(1000)) >= 995) {
           return res.reset(TRI_ERROR_DEBUG);
         }
       }
       
-      TRI_IF_FAILURE("RocksDBCollection::insertFail2Always") {
+      ARANGODB_IF_FAILURE("RocksDBCollection::insertFail2Always") {
         return res.reset(TRI_ERROR_DEBUG);
       }
 
@@ -1527,13 +1527,13 @@ Result RocksDBCollection::removeDocument(arangodb::transaction::Methods* trx,
   }
 #endif
   
-  TRI_IF_FAILURE("RocksDBCollection::removeFail1") {
+  ARANGODB_IF_FAILURE("RocksDBCollection::removeFail1") {
     if (RandomGenerator::interval(uint32_t(1000)) >= 995) {
       return res.reset(TRI_ERROR_DEBUG);
     }
   }
   
-  TRI_IF_FAILURE("RocksDBCollection::removeFail1Always") {
+  ARANGODB_IF_FAILURE("RocksDBCollection::removeFail1Always") {
     return res.reset(TRI_ERROR_DEBUG);
   }
 
@@ -1560,12 +1560,12 @@ Result RocksDBCollection::removeDocument(arangodb::transaction::Methods* trx,
     RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
 
     for (auto it = _indexes.begin(); it != _indexes.end(); it++) {
-      TRI_IF_FAILURE("RocksDBCollection::removeFail2") {
+      ARANGODB_IF_FAILURE("RocksDBCollection::removeFail2") {
         if (it == _indexes.begin() && RandomGenerator::interval(uint32_t(1000)) >= 995) {
           return res.reset(TRI_ERROR_DEBUG);
         }
       }
-      TRI_IF_FAILURE("RocksDBCollection::removeFail2Always") {
+      ARANGODB_IF_FAILURE("RocksDBCollection::removeFail2Always") {
         return res.reset(TRI_ERROR_DEBUG);
       }
 
@@ -1645,13 +1645,13 @@ Result RocksDBCollection::modifyDocument(transaction::Methods* trx,
   TRI_ASSERT(key->containsLocalDocumentId(oldDocumentId));
   invalidateCacheEntry(key.ref());
   
-  TRI_IF_FAILURE("RocksDBCollection::modifyFail1") {
+  ARANGODB_IF_FAILURE("RocksDBCollection::modifyFail1") {
     if (RandomGenerator::interval(uint32_t(1000)) >= 995) {
       return res.reset(TRI_ERROR_DEBUG);
     }
   }
   
-  TRI_IF_FAILURE("RocksDBCollection::modifyFail1Always") {
+  ARANGODB_IF_FAILURE("RocksDBCollection::modifyFail1Always") {
     return res.reset(TRI_ERROR_DEBUG);
   }
 
@@ -1673,13 +1673,13 @@ Result RocksDBCollection::modifyDocument(transaction::Methods* trx,
   // can only restore the previous state via a full rebuild
   savepoint.tainted();
   
-  TRI_IF_FAILURE("RocksDBCollection::modifyFail2") {
+  ARANGODB_IF_FAILURE("RocksDBCollection::modifyFail2") {
     if (RandomGenerator::interval(uint32_t(1000)) >= 995) {
       return res.reset(TRI_ERROR_DEBUG);
     }
   }
   
-  TRI_IF_FAILURE("RocksDBCollection::modifyFail2Always") {
+  ARANGODB_IF_FAILURE("RocksDBCollection::modifyFail2Always") {
     return res.reset(TRI_ERROR_DEBUG);
   }
 
@@ -1704,13 +1704,13 @@ Result RocksDBCollection::modifyDocument(transaction::Methods* trx,
     RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
 
     for (auto it = _indexes.begin(); it != _indexes.end(); it++) {
-      TRI_IF_FAILURE("RocksDBCollection::modifyFail3") {
+      ARANGODB_IF_FAILURE("RocksDBCollection::modifyFail3") {
         if (it == _indexes.begin() && RandomGenerator::interval(uint32_t(1000)) >= 995) {
           return res.reset(TRI_ERROR_DEBUG);
         }
       }
 
-      TRI_IF_FAILURE("RocksDBCollection::modifyFail3Always") {
+      ARANGODB_IF_FAILURE("RocksDBCollection::modifyFail3Always") {
         return res.reset(TRI_ERROR_DEBUG);
       }
 

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
@@ -850,7 +850,7 @@ void RocksDBEdgeIndex::fillLookupValue(VPackBuilder& keys,
   TRI_ASSERT(keys.isEmpty());
   keys.openArray(/*unindexed*/true);
   handleValNode(&keys, value);
-  TRI_IF_FAILURE("EdgeIndex::noIterator") {
+  ARANGODB_IF_FAILURE("EdgeIndex::noIterator") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
   keys.close();
@@ -866,12 +866,12 @@ void RocksDBEdgeIndex::fillInLookupValues(transaction::Methods* trx, VPackBuilde
   size_t const n = values->numMembers();
   for (size_t i = 0; i < n; ++i) {
     handleValNode(&keys, values->getMemberUnchecked(i));
-    TRI_IF_FAILURE("EdgeIndex::iteratorValNodes") {
+    ARANGODB_IF_FAILURE("EdgeIndex::iteratorValNodes") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
   }
 
-  TRI_IF_FAILURE("EdgeIndex::noIterator") {
+  ARANGODB_IF_FAILURE("EdgeIndex::noIterator") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
   keys.close();
@@ -887,7 +887,7 @@ void RocksDBEdgeIndex::handleValNode(VPackBuilder* keys,
   keys->add(VPackValuePair(valNode->getStringValue(),
                            valNode->getStringLength(), VPackValueType::String));
 
-  TRI_IF_FAILURE("EdgeIndex::collectKeys") {
+  ARANGODB_IF_FAILURE("EdgeIndex::collectKeys") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 }

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2774,7 +2774,7 @@ HealthData RocksDBEngine::healthCheck() {
   // capacity at the same time, which could be expensive.
   MUTEX_LOCKER(guard, _healthMutex);
   
-  TRI_IF_FAILURE("RocksDBEngine::healthCheck") {
+  ARANGODB_IF_FAILURE("RocksDBEngine::healthCheck") {
     _healthData.res.reset(TRI_ERROR_DEBUG, "peng! 💥");
     return _healthData;
   }

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -253,7 +253,7 @@ uint64_t RocksDBMetaCollection::recalculateCounts() {
   }
   
   int64_t adjustment = count - snapNumberOfDocuments;
-  TRI_IF_FAILURE("disableCountAdjustment") {
+  ARANGODB_IF_FAILURE("disableCountAdjustment") {
     adjustment = 0;
   }
   if (adjustment != 0) {
@@ -529,11 +529,11 @@ rocksdb::SequenceNumber RocksDBMetaCollection::serializeRevisionTree(
     bool beenTooLong = 30 < std::chrono::duration_cast<std::chrono::seconds>(
                                 std::chrono::steady_clock::now() - _revisionTreeSerializedTime)
                                 .count();
-    TRI_IF_FAILURE("RocksDBMetaCollection::forceSerialization") {
+    ARANGODB_IF_FAILURE("RocksDBMetaCollection::forceSerialization") {
       coinFlip = true;
     }
 
-    TRI_IF_FAILURE("RocksDBMetaCollection::serializeRevisionTree") {
+    ARANGODB_IF_FAILURE("RocksDBMetaCollection::serializeRevisionTree") {
       return _revisionTreeSerializedSeq;
     }
     if (force || neverDone || coinFlip || beenTooLong) {  // ...but only write the tree out sometimes
@@ -614,7 +614,7 @@ std::unique_ptr<containers::RevisionTree> RocksDBMetaCollection::buildTreeFromIt
   return newTree;
 }
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 void RocksDBMetaCollection::corruptRevisionTree(uint64_t count, uint64_t hash) {
   if (!_logicalCollection.useSyncByRevision()) {
     return;
@@ -842,7 +842,7 @@ void RocksDBMetaCollection::bufferUpdates(rocksdb::SequenceNumber seq,
     return;
   }
         
-  TRI_IF_FAILURE("TransactionChaos::randomSleep") {
+  ARANGODB_IF_FAILURE("TransactionChaos::randomSleep") {
     std::this_thread::sleep_for(std::chrono::milliseconds(RandomGenerator::interval(uint32_t(5))));
   }
 
@@ -912,7 +912,7 @@ void RocksDBMetaCollection::applyUpdates(rocksdb::SequenceNumber commitSeq) {
   TRI_ASSERT(_logicalCollection.useSyncByRevision());
   TRI_ASSERT(_revisionTree || haveBufferedOperations());
 
-  TRI_IF_FAILURE("applyUpdates::forceHibernation1") {
+  ARANGODB_IF_FAILURE("applyUpdates::forceHibernation1") {
     if (_revisionTree != nullptr) {
       _revisionTree->hibernate(/*force*/ true);
     }
@@ -934,7 +934,7 @@ void RocksDBMetaCollection::applyUpdates(rocksdb::SequenceNumber commitSeq) {
       }
     };
   
-    TRI_IF_FAILURE("TransactionChaos::randomSleep") {
+    ARANGODB_IF_FAILURE("TransactionChaos::randomSleep") {
       std::this_thread::sleep_for(std::chrono::milliseconds(RandomGenerator::interval(uint32_t(5))));
     }
 
@@ -1008,7 +1008,7 @@ void RocksDBMetaCollection::applyUpdates(rocksdb::SequenceNumber commitSeq) {
       // no inserts or removals left to apply, drop out of loop
       if (!applyInserts && !applyRemovals) {
         // we have applied all changes up to including commitSeq
-        TRI_IF_FAILURE("TransactionChaos::randomSleep") {
+        ARANGODB_IF_FAILURE("TransactionChaos::randomSleep") {
           std::this_thread::sleep_for(std::chrono::milliseconds(RandomGenerator::interval(uint32_t(5))));
         }
         bumpSequence(commitSeq);
@@ -1030,7 +1030,7 @@ void RocksDBMetaCollection::applyUpdates(rocksdb::SequenceNumber commitSeq) {
         // release the mutex while we modify the tree. this is safe (see above)
         guard.unlock();
 
-        TRI_IF_FAILURE("RevisionTree::applyInserts") {
+        ARANGODB_IF_FAILURE("RevisionTree::applyInserts") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
         
@@ -1054,7 +1054,7 @@ void RocksDBMetaCollection::applyUpdates(rocksdb::SequenceNumber commitSeq) {
           throw;
         }
     
-        TRI_IF_FAILURE("TransactionChaos::randomSleep") {
+        ARANGODB_IF_FAILURE("TransactionChaos::randomSleep") {
           std::this_thread::sleep_for(std::chrono::milliseconds(RandomGenerator::interval(uint32_t(5))));
         }
 
@@ -1075,7 +1075,7 @@ void RocksDBMetaCollection::applyUpdates(rocksdb::SequenceNumber commitSeq) {
         
         TRI_ASSERT(removeIt->first > _revisionTreeApplied.load());
         
-        TRI_IF_FAILURE("RevisionTree::applyRemoves") {
+        ARANGODB_IF_FAILURE("RevisionTree::applyRemoves") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
 
@@ -1097,7 +1097,7 @@ void RocksDBMetaCollection::applyUpdates(rocksdb::SequenceNumber commitSeq) {
           throw;
         }
     
-        TRI_IF_FAILURE("TransactionChaos::randomSleep") {
+        ARANGODB_IF_FAILURE("TransactionChaos::randomSleep") {
           std::this_thread::sleep_for(std::chrono::milliseconds(RandomGenerator::interval(uint32_t(5))));
         }
 
@@ -1119,7 +1119,7 @@ void RocksDBMetaCollection::applyUpdates(rocksdb::SequenceNumber commitSeq) {
     THROW_ARANGO_EXCEPTION(res);
   }
   
-  TRI_IF_FAILURE("applyUpdates::forceHibernation2") {
+  ARANGODB_IF_FAILURE("applyUpdates::forceHibernation2") {
     if (_revisionTree != nullptr) {
       _revisionTree->hibernate(/*force*/ true);
     }
@@ -1392,7 +1392,7 @@ void RocksDBMetaCollection::RevisionTreeAccessor::checkConsistency() const {
   return _tree->checkConsistency();
 }
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 void RocksDBMetaCollection::RevisionTreeAccessor::corrupt(uint64_t count, uint64_t hash) {
   ensureTree();
   _tree->corrupt(count, hash);

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.h
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.h
@@ -122,7 +122,7 @@ class RocksDBMetaCollection : public PhysicalCollection {
 
   std::unique_ptr<containers::RevisionTree> buildTreeFromIterator(RevisionReplicationIterator& it) const;
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   void corruptRevisionTree(std::uint64_t count, std::uint64_t hash);
 #endif
   
@@ -192,7 +192,7 @@ class RocksDBMetaCollection : public PhysicalCollection {
     // compressed representation
     void hibernate(bool force);
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     void corrupt(std::uint64_t count, std::uint64_t hash);
 #endif
 

--- a/arangod/RocksDBEngine/RocksDBMetadata.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetadata.cpp
@@ -300,12 +300,12 @@ Result RocksDBMetadata::serializeMeta(rocksdb::WriteBatch& batch,
 
   const rocksdb::SequenceNumber maxCommitSeq = committableSeq(appliedSeq);
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // simulate another transaction coming along and trying to commit while
   // we are serializing
   RocksDBBlockerGuard blocker(&coll);
   
-  TRI_IF_FAILURE("TransactionChaos::blockerOnSync") {
+  ARANGODB_IF_FAILURE("TransactionChaos::blockerOnSync") {
     blocker.placeBlocker();
   }
 #endif
@@ -314,7 +314,7 @@ Result RocksDBMetadata::serializeMeta(rocksdb::WriteBatch& batch,
   TRI_ASSERT(maxCommitSeq != UINT64_MAX);
   TRI_ASSERT(maxCommitSeq > 0);
   
-  TRI_IF_FAILURE("TransactionChaos::randomSleep") {
+  ARANGODB_IF_FAILURE("TransactionChaos::randomSleep") {
     std::this_thread::sleep_for(std::chrono::milliseconds(RandomGenerator::interval(uint32_t(5))));
   }
     

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
@@ -117,7 +117,7 @@ class RocksDBPrimaryIndexEqIterator final : public IndexIterator {
     _key->clear();
     _index->handleValNode(_trx, _key.get(), aap.value, !_allowCoveringIndexOptimization);
 
-    TRI_IF_FAILURE("PrimaryIndex::noIterator") {
+    ARANGODB_IF_FAILURE("PrimaryIndex::noIterator") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
 
@@ -1000,7 +1000,7 @@ std::unique_ptr<IndexIterator> RocksDBPrimaryIndex::createEqIterator(
   // handle the sole element
   handleValNode(trx, key.get(), valNode, isId);
 
-  TRI_IF_FAILURE("PrimaryIndex::noIterator") {
+  ARANGODB_IF_FAILURE("PrimaryIndex::noIterator") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
@@ -1027,7 +1027,7 @@ void RocksDBPrimaryIndex::fillInLookupValues(transaction::Methods* trx, VPackBui
   if (ascending) {
     for (size_t i = 0; i < n; ++i) {
       handleValNode(trx, &keys, values->getMemberUnchecked(i), isId);
-      TRI_IF_FAILURE("PrimaryIndex::iteratorValNodes") {
+      ARANGODB_IF_FAILURE("PrimaryIndex::iteratorValNodes") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
     }
@@ -1036,13 +1036,13 @@ void RocksDBPrimaryIndex::fillInLookupValues(transaction::Methods* trx, VPackBui
     while (i > 0) {
       --i;
       handleValNode(trx, &keys, values->getMemberUnchecked(i), isId);
-      TRI_IF_FAILURE("PrimaryIndex::iteratorValNodes") {
+      ARANGODB_IF_FAILURE("PrimaryIndex::iteratorValNodes") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
     }
   }
 
-  TRI_IF_FAILURE("PrimaryIndex::noIterator") {
+  ARANGODB_IF_FAILURE("PrimaryIndex::noIterator") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 

--- a/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
@@ -64,7 +64,7 @@ RocksDBRestReplicationHandler::RocksDBRestReplicationHandler(
       _manager(
           server.getFeature<EngineSelectorFeature>().engine<RocksDBEngine>().replicationManager()),
       _quickKeysNumDocsLimit(server.getFeature<ReplicationFeature>().quickKeysLimit())  {
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   adjustQuickKeysNumDocsLimit();
 #endif
 
@@ -838,10 +838,10 @@ void RocksDBRestReplicationHandler::handleCommandDump() {
   }
 }
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 /// @brief patch quickKeysNumDocsLimit for testing
 void RocksDBRestReplicationHandler::adjustQuickKeysNumDocsLimit() {
-  TRI_IF_FAILURE("RocksDBRestReplicationHandler::quickKeysNumDocsLimit100") {
+  ARANGODB_IF_FAILURE("RocksDBRestReplicationHandler::quickKeysNumDocsLimit100") {
     _quickKeysNumDocsLimit = 100;
   }
 }

--- a/arangod/RocksDBEngine/RocksDBRestReplicationHandler.h
+++ b/arangod/RocksDBEngine/RocksDBRestReplicationHandler.h
@@ -80,7 +80,7 @@ class RocksDBRestReplicationHandler : public RestReplicationHandler {
   RocksDBReplicationManager* _manager;
   uint64_t _quickKeysNumDocsLimit;
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   void adjustQuickKeysNumDocsLimit();
 #endif  
 };

--- a/arangod/RocksDBEngine/RocksDBSettingsManager.cpp
+++ b/arangod/RocksDBEngine/RocksDBSettingsManager.cpp
@@ -136,7 +136,7 @@ bool RocksDBSettingsManager::lockForSync(bool force) {
 
 /// Thread-Safe force sync
 Result RocksDBSettingsManager::sync(bool force) {
-  TRI_IF_FAILURE("RocksDBSettingsManagerSync") { return Result(); }
+  ARANGODB_IF_FAILURE("RocksDBSettingsManagerSync") { return Result(); }
   if (!_db) {
     return Result();
   }

--- a/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
@@ -169,7 +169,7 @@ void RocksDBTransactionCollection::prepareTransaction(TransactionId trxId, uint6
   TRI_ASSERT(_collection != nullptr);
   if (hasOperations() || !_trackedOperations.empty() || !_trackedIndexOperations.empty()) {
   
-    TRI_IF_FAILURE("TransactionChaos::randomSleep") {
+    ARANGODB_IF_FAILURE("TransactionChaos::randomSleep") {
       std::this_thread::sleep_for(std::chrono::milliseconds(RandomGenerator::interval(uint32_t(5))));
     }
 
@@ -188,7 +188,7 @@ void RocksDBTransactionCollection::abortCommit(TransactionId trxId) {
 }
 
 void RocksDBTransactionCollection::commitCounts(TransactionId trxId, uint64_t commitSeq) {
-  TRI_IF_FAILURE("DisableCommitCounts") {
+  ARANGODB_IF_FAILURE("DisableCommitCounts") {
     return;
   }
   TRI_ASSERT(_collection != nullptr);
@@ -199,10 +199,10 @@ void RocksDBTransactionCollection::commitCounts(TransactionId trxId, uint64_t co
   if (hasOperations()) {
     TRI_ASSERT(_revision.isSet() && commitSeq != 0);
       
-    TRI_IF_FAILURE("RocksDBCommitCounts") {
+    ARANGODB_IF_FAILURE("RocksDBCommitCounts") {
       adj = 0;
     }
-    TRI_IF_FAILURE("RocksDBCommitCountsRandom") {
+    ARANGODB_IF_FAILURE("RocksDBCommitCountsRandom") {
       if (RandomGenerator::interval(uint16_t(100)) >= 50) {
         adj = 0;
       }

--- a/arangod/RocksDBEngine/RocksDBTransactionState.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.cpp
@@ -255,7 +255,7 @@ Result RocksDBTransactionState::commitTransaction(transaction::Methods* activeTr
 
   TRI_ASSERT(_status == transaction::Status::RUNNING);
   TRI_ASSERT(activeTrx->isMainTransaction());
-  TRI_IF_FAILURE("TransactionWriteCommitMarker") {
+  ARANGODB_IF_FAILURE("TransactionWriteCommitMarker") {
     return Result(TRI_ERROR_DEBUG);
   }
 

--- a/arangod/RocksDBEngine/RocksDBV8Functions.cpp
+++ b/arangod/RocksDBEngine/RocksDBV8Functions.cpp
@@ -198,7 +198,7 @@ static void JS_WaitForEstimatorSync(v8::FunctionCallbackInfo<v8::Value> const& a
   TRI_V8_TRY_CATCH_END
 }
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 static void JS_CollectionRevisionTreeCorrupt(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
@@ -338,7 +338,7 @@ static void JS_CollectionRevisionTreeSummary(v8::FunctionCallbackInfo<v8::Value>
   TRI_V8_TRY_CATCH_END
 }
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 static void JS_CollectionRevisionTreePendingUpdates(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
@@ -380,7 +380,7 @@ void RocksDBV8Functions::registerResources() {
   TRI_AddMethodVocbase(isolate, rt,
                        TRI_V8_ASCII_STRING(isolate, "_revisionTreeSummary"),
                        JS_CollectionRevisionTreeSummary);
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   TRI_AddMethodVocbase(isolate, rt,
                        TRI_V8_ASCII_STRING(isolate, "_revisionTreePendingUpdates"),
                        JS_CollectionRevisionTreePendingUpdates);

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -442,7 +442,7 @@ ErrorCode RocksDBVPackIndex::fillElement(
     return TRI_ERROR_INTERNAL;
   }
 
-  TRI_IF_FAILURE("FillElementIllegalSlice") { return TRI_ERROR_INTERNAL; }
+  ARANGODB_IF_FAILURE("FillElementIllegalSlice") { return TRI_ERROR_INTERNAL; }
 
   TRI_ASSERT(leased.isEmpty());
   if (!_useExpansion) {
@@ -469,8 +469,8 @@ ErrorCode RocksDBVPackIndex::fillElement(
     }
     leased.close();
 
-    TRI_IF_FAILURE("FillElementOOM") { return TRI_ERROR_OUT_OF_MEMORY; }
-    TRI_IF_FAILURE("FillElementOOM2") {
+    ARANGODB_IF_FAILURE("FillElementOOM") { return TRI_ERROR_OUT_OF_MEMORY; }
+    ARANGODB_IF_FAILURE("FillElementOOM2") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_OUT_OF_MEMORY);
     }
 
@@ -991,7 +991,7 @@ Result RocksDBVPackIndex::update(transaction::Methods& trx, RocksDBMethods* mthd
 Result RocksDBVPackIndex::remove(transaction::Methods& trx, RocksDBMethods* mthds,
                                  LocalDocumentId const& documentId,
                                  velocypack::Slice doc) {
-  TRI_IF_FAILURE("BreakHashIndexRemove") {
+  ARANGODB_IF_FAILURE("BreakHashIndexRemove") {
     if (type() == arangodb::Index::IndexType::TRI_IDX_TYPE_HASH_INDEX) {
       // intentionally  break index removal
       return Result(TRI_ERROR_INTERNAL, "BreakHashIndexRemove failure point triggered");
@@ -1219,13 +1219,13 @@ std::unique_ptr<IndexIterator> RocksDBVPackIndex::iteratorForCondition(
     // We only use this index for sort. Empty searchValue
     VPackArrayBuilder guard(&searchValues);
 
-    TRI_IF_FAILURE("PersistentIndex::noSortIterator") {
+    ARANGODB_IF_FAILURE("PersistentIndex::noSortIterator") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
-    TRI_IF_FAILURE("SkiplistIndex::noSortIterator") {
+    ARANGODB_IF_FAILURE("SkiplistIndex::noSortIterator") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
-    TRI_IF_FAILURE("HashIndex::noSortIterator") {
+    ARANGODB_IF_FAILURE("HashIndex::noSortIterator") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
   } else {
@@ -1284,26 +1284,26 @@ std::unique_ptr<IndexIterator> RocksDBVPackIndex::iteratorForCondition(
       if (comp->type == arangodb::aql::NODE_TYPE_OPERATOR_BINARY_EQ) {
         searchValues.openObject();
         searchValues.add(VPackValue(StaticStrings::IndexEq));
-        TRI_IF_FAILURE("PersistentIndex::permutationEQ") {
+        ARANGODB_IF_FAILURE("PersistentIndex::permutationEQ") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
-        TRI_IF_FAILURE("SkiplistIndex::permutationEQ") {
+        ARANGODB_IF_FAILURE("SkiplistIndex::permutationEQ") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
-        TRI_IF_FAILURE("HashIndex::permutationEQ") {
+        ARANGODB_IF_FAILURE("HashIndex::permutationEQ") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
       } else if (comp->type == arangodb::aql::NODE_TYPE_OPERATOR_BINARY_IN) {
         if (isAttributeExpanded(usedFields)) {
           searchValues.openObject();
           searchValues.add(VPackValue(StaticStrings::IndexEq));
-          TRI_IF_FAILURE("PersistentIndex::permutationArrayIN") {
+          ARANGODB_IF_FAILURE("PersistentIndex::permutationArrayIN") {
             THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
           }
-          TRI_IF_FAILURE("SkiplistIndex::permutationArrayIN") {
+          ARANGODB_IF_FAILURE("SkiplistIndex::permutationArrayIN") {
             THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
           }
-          TRI_IF_FAILURE("HashIndex::permutationArrayIN") {
+          ARANGODB_IF_FAILURE("HashIndex::permutationArrayIN") {
             THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
           }
         } else {
@@ -1380,13 +1380,13 @@ std::unique_ptr<IndexIterator> RocksDBVPackIndex::iteratorForCondition(
   }
   searchValues.close();
 
-  TRI_IF_FAILURE("PersistentIndex::noIterator") {
+  ARANGODB_IF_FAILURE("PersistentIndex::noIterator") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
-  TRI_IF_FAILURE("SkiplistIndex::noIterator") {
+  ARANGODB_IF_FAILURE("SkiplistIndex::noIterator") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
-  TRI_IF_FAILURE("HashIndex::noIterator") {
+  ARANGODB_IF_FAILURE("HashIndex::noIterator") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 

--- a/arangod/StorageEngine/EngineSelectorFeature.cpp
+++ b/arangod/StorageEngine/EngineSelectorFeature.cpp
@@ -82,7 +82,7 @@ void EngineSelectorFeature::collectOptions(std::shared_ptr<ProgramOptions> optio
 }
 
 void EngineSelectorFeature::prepare() {
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if (_selected.load()) {
     // already set in the test code
     return;
@@ -280,7 +280,7 @@ bool EngineSelectorFeature::isRocksDB() {
   return engineName() == RocksDBEngine::EngineName;
 }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 void EngineSelectorFeature::setEngineTesting(StorageEngine* input) {
   TRI_ASSERT((input == nullptr) != (_engine == nullptr));
   _selected.store(input != nullptr);

--- a/arangod/StorageEngine/EngineSelectorFeature.h
+++ b/arangod/StorageEngine/EngineSelectorFeature.h
@@ -58,7 +58,7 @@ class EngineSelectorFeature final : public application_features::ApplicationFeat
   /// the underlying engine is the RocksDB engine.
   bool isRocksDB();
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   void setEngineTesting(StorageEngine*);
 #endif
 

--- a/arangod/StorageEngine/PhysicalCollection.cpp
+++ b/arangod/StorageEngine/PhysicalCollection.cpp
@@ -423,7 +423,7 @@ Result PhysicalCollection::newObjectForInsert(transaction::Methods*,
 
   // _rev
   bool handled = false;
-  TRI_IF_FAILURE("Insert::useRev") {
+  ARANGODB_IF_FAILURE("Insert::useRev") {
     isRestore = true;
   }
   if (isRestore) {
@@ -673,7 +673,7 @@ bool PhysicalCollection::IndexOrder::operator()(const std::shared_ptr<Index>& le
   // of index operations. Hash index placed always AFTER reversable indexes
   // could be broken by unique constraint violation or by intentional failpoint.
   // And this will make possible to deterministically trigger index reversals
-  TRI_IF_FAILURE("HashIndexAlwaysLast") {
+  ARANGODB_IF_FAILURE("HashIndexAlwaysLast") {
     if (left->type() != right->type()) {
       if (right->type() == arangodb::Index::IndexType::TRI_IDX_TYPE_HASH_INDEX) {
         return true;

--- a/arangod/StorageEngine/TransactionState.cpp
+++ b/arangod/StorageEngine/TransactionState.cpp
@@ -62,7 +62,7 @@ TransactionState::TransactionState(TRI_vocbase_t& vocbase, TransactionId tid,
       _registeredTransaction(false) {
 
   // patch intermediateCommitCount for testing
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   transaction::Options::adjustIntermediateCommitCount(_options);
 #endif
 }
@@ -130,8 +130,8 @@ TransactionState::Cookie::ptr TransactionState::cookie(void const* key,
 /// @brief add a collection to a transaction
 Result TransactionState::addCollection(DataSourceId cid, std::string const& cname,
                                        AccessMode::Type accessType, bool lockUsage) {
-#if defined(ARANGODB_ENABLE_MAINTAINER_MODE) && defined(ARANGODB_ENABLE_FAILURE_TESTS)
-  TRI_IF_FAILURE(("WaitOnLock::" + cname).c_str()) {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  ARANGODB_IF_FAILURE(("WaitOnLock::" + cname).c_str()) {
     auto& raceController = basics::DebugRaceController::sharedInstance();
     if (!raceController.didTrigger()) {
       raceController.waitForOthers(2, _id, vocbase().server());
@@ -424,7 +424,7 @@ void TransactionState::clearQueryCache() {
   }
 }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 // reset the internal Transaction ID to none.
 // Only used in the Transaction Mock for internal reasons.
 void TransactionState::resetTransactionId() {

--- a/arangod/StorageEngine/TransactionState.h
+++ b/arangod/StorageEngine/TransactionState.h
@@ -260,7 +260,7 @@ class TransactionState {
   /// the transaction
   void clearQueryCache();
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // reset the internal Transaction ID to none.
   // Only used in the Transaction Mock for internal reasons.
   void resetTransactionId();

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -144,7 +144,7 @@ uint64_t Manager::getActiveTransactionCount() {
 
   auto role = ServerState::instance()->getRole();
   if ((ServerState::isSingleServer(role) || ServerState::isCoordinator(role))) {
-    TRI_IF_FAILURE("lowStreamingIdleTimeout") { return 5.0; }
+    ARANGODB_IF_FAILURE("lowStreamingIdleTimeout") { return 5.0; }
 
     return feature.streamingIdleTimeout();
   }
@@ -712,7 +712,7 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(TransactionId tid
     return nullptr;
   }
 
-  TRI_IF_FAILURE("leaseManagedTrxFail") { return nullptr; }
+  ARANGODB_IF_FAILURE("leaseManagedTrxFail") { return nullptr; }
 
   auto const role = ServerState::instance()->getRole();
   std::chrono::steady_clock::time_point endTime;
@@ -859,7 +859,7 @@ void Manager::returnManagedTrx(TransactionId tid, bool isSideUser) noexcept {
   // call updateTransaction, which then will try to acquire the same
   // write lock
 
-  TRI_IF_FAILURE("returnManagedTrxForceSoftAbort") { isSoftAborted = true; }
+  ARANGODB_IF_FAILURE("returnManagedTrxForceSoftAbort") { isSoftAborted = true; }
 
   if (isSoftAborted) {
     TRI_ASSERT(!isSideUser);

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -510,7 +510,7 @@ Result transaction::Methods::begin() {
 
 /// @brief commit / finish the transaction
 Future<Result> transaction::Methods::commitAsync() {
-  TRI_IF_FAILURE("TransactionCommitFail") { return Result(TRI_ERROR_DEBUG); }
+  ARANGODB_IF_FAILURE("TransactionCommitFail") { return Result(TRI_ERROR_DEBUG); }
 
   if (_state == nullptr || _state->status() != transaction::Status::RUNNING) {
     // transaction not created or not running
@@ -1051,7 +1051,7 @@ Future<OperationResult> transaction::Methods::insertLocal(std::string const& cna
     // resigned in the meantime but still gets an insert request from
     // a coordinator who does not know this yet. That is, the test sets
     // the failure point on all servers, including the current leader.
-    TRI_IF_FAILURE("documents::insertLeaderRefusal") {
+    ARANGODB_IF_FAILURE("documents::insertLeaderRefusal") {
       if (value.isObject() && value.hasKey("ThisIsTheRetryOnLeaderRefusalTest")) {
         return OperationResult(TRI_ERROR_CLUSTER_SHARD_LEADER_RESIGNED, options);
       }
@@ -2477,11 +2477,11 @@ Future<Result> Methods::replicateOperations(
   }
 
   reqOpts.timeout = network::Timeout(chooseTimeoutForReplication(count, payload->size()));
-  TRI_IF_FAILURE("replicateOperations_randomize_timeout") {
+  ARANGODB_IF_FAILURE("replicateOperations_randomize_timeout") {
     reqOpts.timeout = network::Timeout((double) RandomGenerator::interval(uint32_t(60)));
   }
     
-  TRI_IF_FAILURE("replicateOperationsDropFollowerBeforeSending") {
+  ARANGODB_IF_FAILURE("replicateOperationsDropFollowerBeforeSending") {
     // drop all our followers, intentionally
     for (auto const& f : *followerList) {
       Result res = collection->followers()->remove(f);
@@ -2575,7 +2575,7 @@ Future<Result> Methods::replicateOperations(
         replicationFailureReason = "no response from follower";
       }
 
-      TRI_IF_FAILURE("replicateOperationsDropFollower") {
+      ARANGODB_IF_FAILURE("replicateOperationsDropFollower") {
         replicationFailureReason = "intentional debug error";
       }
 

--- a/arangod/Transaction/Options.cpp
+++ b/arangod/Transaction/Options.cpp
@@ -66,7 +66,7 @@ Options::Options()
     );
   }
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // patch intermediateCommitCount for testing
   adjustIntermediateCommitCount(*this);
 #endif
@@ -143,7 +143,7 @@ void Options::fromVelocyPack(arangodb::velocypack::Slice const& slice) {
   // we are intentionally *not* reading allowImplicitCollectionForWrite here.
   // this is an internal option only used in replication
   
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // patch intermediateCommitCount for testing
   adjustIntermediateCommitCount(*this);
 #endif
@@ -179,16 +179,16 @@ void Options::toVelocyPack(arangodb::velocypack::Builder& builder) const {
   }
 }
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 /// @brief patch intermediateCommitCount for testing
 /*static*/ void Options::adjustIntermediateCommitCount(Options& options) {
-  TRI_IF_FAILURE("TransactionState::intermediateCommitCount100") {
+  ARANGODB_IF_FAILURE("TransactionState::intermediateCommitCount100") {
     options.intermediateCommitCount = 100;
   }
-  TRI_IF_FAILURE("TransactionState::intermediateCommitCount1000") {
+  ARANGODB_IF_FAILURE("TransactionState::intermediateCommitCount1000") {
     options.intermediateCommitCount = 1000;
   }
-  TRI_IF_FAILURE("TransactionState::intermediateCommitCount10000") {
+  ARANGODB_IF_FAILURE("TransactionState::intermediateCommitCount10000") {
     options.intermediateCommitCount = 10000;
   }
 }

--- a/arangod/Transaction/Options.h
+++ b/arangod/Transaction/Options.h
@@ -52,7 +52,7 @@ struct Options {
   /// @brief add the options to an opened vpack builder
   void toVelocyPack(arangodb::velocypack::Builder&) const;
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   /// @brief patch intermediateCommitCount for testing
   static void adjustIntermediateCommitCount(Options& options);
 #endif

--- a/arangod/Utils/CursorRepository.cpp
+++ b/arangod/Utils/CursorRepository.cpp
@@ -130,7 +130,7 @@ Cursor* CursorRepository::addCursor(std::unique_ptr<Cursor> cursor) {
     _cursors.emplace(id, std::make_pair(cursor.get(), std::move(user)));
   }
 
-  TRI_IF_FAILURE(
+  ARANGODB_IF_FAILURE(
       "CursorRepository::directKillStreamQueryAfterCursorIsBeingCreated") {
     cursor->debugKillQuery();
   }

--- a/arangod/Utils/FlushThread.cpp
+++ b/arangod/Utils/FlushThread.cpp
@@ -62,7 +62,7 @@ void FlushThread::run() {
 
   while (!isStopping()) {
     try {
-      TRI_IF_FAILURE("FlushThreadDisableAll") {
+      ARANGODB_IF_FAILURE("FlushThreadDisableAll") {
         CONDITION_LOCKER(guard, _condition);
         guard.wait(_flushInterval);
 

--- a/arangod/V8Server/v8-actions.cpp
+++ b/arangod/V8Server/v8-actions.cpp
@@ -1508,7 +1508,7 @@ void TRI_InitV8Actions(v8::Isolate* isolate) {
 /// Below Debugging Functions. Only compiled in maintainer mode.
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 static ErrorCode clusterSendToAllServers(v8::Isolate* isolate, std::string const& dbname,
                                          std::string const& path,  // Note: Has to be properly encoded!
                                          arangodb::rest::RequestType const& method,
@@ -1563,7 +1563,7 @@ static ErrorCode clusterSendToAllServers(v8::Isolate* isolate, std::string const
 /// intentionally cause a segmentation violation
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 static void JS_DebugTerminate(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
@@ -1592,7 +1592,7 @@ static void JS_DebugTerminate(v8::FunctionCallbackInfo<v8::Value> const& args) {
 /// Set a point for an intentional system failure
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 static void JS_DebugSetFailAt(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
@@ -1635,7 +1635,7 @@ static void JS_DebugSetFailAt(v8::FunctionCallbackInfo<v8::Value> const& args) {
 /// Checks if a specific intentional failure point is set
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 static void JS_DebugShouldFailAt(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
@@ -1667,7 +1667,7 @@ static void JS_DebugShouldFailAt(v8::FunctionCallbackInfo<v8::Value> const& args
 /// Remove a point for an intentional system failure
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 static void JS_DebugRemoveFailAt(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
@@ -1721,7 +1721,7 @@ static void JS_DebugClearFailAt(v8::FunctionCallbackInfo<v8::Value> const& args)
   }
 
 // if failure testing is not enabled, this is a no-op
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   TRI_ClearFailurePointsDebugging();
 
   if (ServerState::instance()->isCoordinator()) {
@@ -1872,7 +1872,7 @@ void TRI_InitV8ServerUtils(v8::Isolate* isolate) {
                                                    "SYS_DEBUG_CLEAR_FAILAT"),
                                JS_DebugClearFailAt);
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   TRI_AddGlobalFunctionVocbase(
       isolate, TRI_V8_ASCII_STRING(isolate, "SYS_DEBUG_TERMINATE"), JS_DebugTerminate);
   TRI_AddGlobalFunctionVocbase(isolate,

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -172,7 +172,7 @@ LogicalCollection::LogicalCollection(TRI_vocbase_t& vocbase, VPackSlice const& i
       _physical(vocbase.server().getFeature<EngineSelectorFeature>().engine().createPhysicalCollection(
           *this, info)) {
 
-  TRI_IF_FAILURE("disableRevisionsAsDocumentIds") {
+  ARANGODB_IF_FAILURE("disableRevisionsAsDocumentIds") {
     _usesRevisionsAsDocumentIds.store(false);
     _syncByRevision.store(false);
   }
@@ -1097,7 +1097,7 @@ void LogicalCollection::deferDropCollection(std::function<bool(LogicalCollection
 ////////////////////////////////////////////////////////////////////////////////
 
 Result LogicalCollection::truncate(transaction::Methods& trx, OperationOptions& options) {
-  TRI_IF_FAILURE("LogicalCollection::truncate") {
+  ARANGODB_IF_FAILURE("LogicalCollection::truncate") {
     return Result(TRI_ERROR_DEBUG);
   }
 
@@ -1113,7 +1113,7 @@ void LogicalCollection::compact() { getPhysical()->compact(); }
 
 Result LogicalCollection::insert(transaction::Methods* trx, VPackSlice const slice,
                                  ManagedDocumentResult& result, OperationOptions& options) {
-  TRI_IF_FAILURE("LogicalCollection::insert") {
+  ARANGODB_IF_FAILURE("LogicalCollection::insert") {
     return Result(TRI_ERROR_DEBUG);
   }
   return getPhysical()->insert(trx, slice, result, options);
@@ -1123,7 +1123,7 @@ Result LogicalCollection::insert(transaction::Methods* trx, VPackSlice const sli
 Result LogicalCollection::update(transaction::Methods* trx, VPackSlice newSlice,
                                  ManagedDocumentResult& result, OperationOptions& options,
                                  ManagedDocumentResult& previous) {
-  TRI_IF_FAILURE("LogicalCollection::update") {
+  ARANGODB_IF_FAILURE("LogicalCollection::update") {
     return Result(TRI_ERROR_DEBUG);
   }
 
@@ -1138,7 +1138,7 @@ Result LogicalCollection::update(transaction::Methods* trx, VPackSlice newSlice,
 Result LogicalCollection::replace(transaction::Methods* trx, VPackSlice newSlice,
                                   ManagedDocumentResult& result, OperationOptions& options,
                                   ManagedDocumentResult& previous) {
-  TRI_IF_FAILURE("LogicalCollection::replace") {
+  ARANGODB_IF_FAILURE("LogicalCollection::replace") {
     return Result(TRI_ERROR_DEBUG);
   }
   if (!newSlice.isObject()) {
@@ -1152,7 +1152,7 @@ Result LogicalCollection::replace(transaction::Methods* trx, VPackSlice newSlice
 Result LogicalCollection::remove(transaction::Methods& trx,
                                  velocypack::Slice const slice, OperationOptions& options,
                                  ManagedDocumentResult& previous) {
-  TRI_IF_FAILURE("LogicalCollection::remove") {
+  ARANGODB_IF_FAILURE("LogicalCollection::remove") {
     return Result(TRI_ERROR_DEBUG);
   }
   return getPhysical()->remove(trx, slice, previous, options);

--- a/arangod/VocBase/Methods/UpgradeTasks.cpp
+++ b/arangod/VocBase/Methods/UpgradeTasks.cpp
@@ -195,7 +195,7 @@ Result createSystemCollections(TRI_vocbase_t& vocbase,
   systemCollections.push_back(StaticStrings::AppBundlesCollection);
   systemCollections.push_back(StaticStrings::FrontendCollection);
 
-  TRI_IF_FAILURE("UpgradeTasks::CreateCollectionsExistsGraphAqlFunctions") {
+  ARANGODB_IF_FAILURE("UpgradeTasks::CreateCollectionsExistsGraphAqlFunctions") {
     VPackBuilder testOptions;
     std::vector<std::shared_ptr<VPackBuffer<uint8_t>>> testBuffers;
     std::vector<CollectionCreationInfo> testSystemCollectionsToCreate;
@@ -416,14 +416,14 @@ bool UpgradeTasks::createSystemCollectionsAndIndices(TRI_vocbase_t& vocbase,
     return false;
   }
 
-  TRI_IF_FAILURE("UpgradeTasks::HideDatabaseUntilCreationIsFinished") {
+  ARANGODB_IF_FAILURE("UpgradeTasks::HideDatabaseUntilCreationIsFinished") {
     // just trigger a sleep here. The client test will create the db async
     // and directly fetch the state of creation. The DB is not allowed to be
     // visible to the outside world.
     std::this_thread::sleep_for(std::chrono::milliseconds(5000));
   }
 
-  TRI_IF_FAILURE("UpgradeTasks::FatalExitDuringDatabaseCreation") {
+  ARANGODB_IF_FAILURE("UpgradeTasks::FatalExitDuringDatabaseCreation") {
     FATAL_ERROR_EXIT();
   }
 

--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -1044,7 +1044,7 @@ Result RestoreFeature::RestoreJob::sendRestoreData(arangodb::httpclient::SimpleH
       MUTEX_LOCKER(locker, sharedState->mutex);
       TRI_ASSERT(!sharedState->readOffsets.empty());
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
       if (options.failOnUpdateContinueFile) {
         auto it = sharedState->readOffsets.find(readOffset);
         TRI_ASSERT(it != sharedState->readOffsets.end());
@@ -1599,7 +1599,7 @@ void RestoreFeature::collectOptions(std::shared_ptr<options::ProgramOptions> opt
                      new BooleanParameter(&_options.useEnvelope))
                      .setIntroducedIn(30800);
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   options->addOption("--fail-after-update-continue-file", "",
                      new BooleanParameter(&_options.failOnUpdateContinueFile),
                      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden));

--- a/arangosh/Restore/RestoreFeature.h
+++ b/arangosh/Restore/RestoreFeature.h
@@ -105,7 +105,7 @@ class RestoreFeature final : public application_features::ApplicationFeature {
     bool overwrite{true};
     bool useEnvelope{true};
     bool continueRestore{false};
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     bool failOnUpdateContinueFile{false};
 #endif
     bool cleanupDuplicateAttributes{false};

--- a/lib/ApplicationFeatures/GreetingsFeature.cpp
+++ b/lib/ApplicationFeatures/GreetingsFeature.cpp
@@ -51,7 +51,7 @@ void GreetingsFeature::prepare() {
   constexpr bool warn = true;
 #else
   // catch-tests on (enables TEST_VIRTUAL)
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   constexpr bool warn = true;
 #else
   // neither maintainer mode nor catch tests

--- a/lib/Basics/Common.h
+++ b/lib/Basics/Common.h
@@ -44,7 +44,7 @@
 #undef DEBUG
 #endif
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 #define TEST_VIRTUAL virtual
 #else
 #define TEST_VIRTUAL
@@ -53,5 +53,7 @@
 #ifdef sleep
 #undef sleep
 #endif
+/// @brief sleep should not be used directly. 
+/// one should use std::this_thread::sleep_for() instead.
 #define sleep ERROR_USE_std_this_thread_sleep_for
 

--- a/lib/Basics/debugging.cpp
+++ b/lib/Basics/debugging.cpp
@@ -47,7 +47,7 @@
 
 using namespace arangodb;
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 
 namespace {
 /// @brief custom comparer for failure points. this allows an implicit

--- a/lib/Basics/debugging.h
+++ b/lib/Basics/debugging.h
@@ -38,57 +38,61 @@
 #endif
 #endif
 
-/// @brief macro TRI_IF_FAILURE
+/// @brief macro ARANGODB_IF_FAILURE
 /// this macro can be used in maintainer mode to make the server fail at
 /// certain locations in the C code. The points at which a failure is actually
 /// triggered can be defined at runtime using TRI_AddFailurePointDebugging().
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 
-#define TRI_IF_FAILURE(what) if (TRI_ShouldFailDebugging(what))
+#define ARANGODB_IF_FAILURE(what) if (TRI_ShouldFailDebugging(what))
 
 #else
 
-#define TRI_IF_FAILURE(what) if (false)
+#define ARANGODB_IF_FAILURE(what) if (false)
 
 #endif
 
+/// @brief TRI_IF_FAILURE should not be used anymore. 
+/// one should use ARANGODB_IF_FAILURE instead.
+#define TRI_IF_FAILURE(what) ERROR_USE_ARANGODB_IF_FAILURE_INSTEAD
+
 /// @brief intentionally cause a segmentation violation or other failures
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 void TRI_TerminateDebugging(char const* value);
 #else
 inline void TRI_TerminateDebugging(char const*) {}
 #endif
 
 /// @brief check whether we should fail at a failure point
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 bool TRI_ShouldFailDebugging(char const* value);
 #else
 inline constexpr bool TRI_ShouldFailDebugging(char const*) { return false; }
 #endif
 
 /// @brief add a failure point
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 void TRI_AddFailurePointDebugging(char const* value);
 #else
 inline void TRI_AddFailurePointDebugging(char const*) {}
 #endif
 
 /// @brief remove a failure point
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 void TRI_RemoveFailurePointDebugging(char const* value);
 #else
 inline void TRI_RemoveFailurePointDebugging(char const*) {}
 #endif
 
 /// @brief clear all failure points
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 void TRI_ClearFailurePointsDebugging();
 #else
 inline void TRI_ClearFailurePointsDebugging() {}
 #endif
 
 /// @brief returns whether failure point debugging can be used
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 inline constexpr bool TRI_CanUseFailurePointsDebugging() { return true; }
 #else
 inline constexpr bool TRI_CanUseFailurePointsDebugging() { return false; }
@@ -226,4 +230,3 @@ enable_if_t<is_container<T>::value, std::ostream&> operator<<(std::ostream& o, T
 #endif  // #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 
 #endif  // #ifndef TRI_ASSERT
-

--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -2543,7 +2543,7 @@ int TRI_CreateDatafile(std::string const& filename, size_t maximalSize) {
   int fd = TRI_CREATE(filename.c_str(), O_CREAT | O_EXCL | O_RDWR | TRI_O_CLOEXEC | TRI_NOATIME,
                       S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
 
-  TRI_IF_FAILURE("CreateDatafile1") {
+  ARANGODB_IF_FAILURE("CreateDatafile1") {
     // intentionally fail
     TRI_CLOSE(fd);
     fd = -1;
@@ -2594,7 +2594,7 @@ int TRI_CreateDatafile(std::string const& filename, size_t maximalSize) {
 
       ssize_t writeResult = TRI_WRITE(fd, &nullBuffer[0], static_cast<TRI_write_t>(writeSize));
 
-      TRI_IF_FAILURE("CreateDatafile2") {
+      ARANGODB_IF_FAILURE("CreateDatafile2") {
         // intentionally fail
         writeResult = -1;
         errno = ENOSPC;

--- a/lib/Containers/MerkleTree.cpp
+++ b/lib/Containers/MerkleTree.cpp
@@ -57,7 +57,7 @@
 
 #include "Logger/LogMacros.h"
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 #include "Random/RandomGenerator.h"
 #endif
 
@@ -712,7 +712,7 @@ void MerkleTree<Hasher, BranchingBits>::checkConsistency() const {
   checkInternalConsistency();
 }
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 // intentionally corrupts the tree. used for testing only
 template <typename Hasher, std::uint64_t const BranchingBits>
 void MerkleTree<Hasher, BranchingBits>::corrupt(std::uint64_t count, std::uint64_t hash) {
@@ -939,16 +939,16 @@ void MerkleTree<Hasher, BranchingBits>::serializeBinary(std::string& output,
   }
 
   // the following format modifiers are only used for testing via JavaScript
-  TRI_IF_FAILURE("MerkleTree::serializeUncompressed") {
+  ARANGODB_IF_FAILURE("MerkleTree::serializeUncompressed") {
     format = BinaryFormat::Uncompressed;
   }
-  TRI_IF_FAILURE("MerkleTree::serializeOnlyPopulated") {
+  ARANGODB_IF_FAILURE("MerkleTree::serializeOnlyPopulated") {
     format = BinaryFormat::OnlyPopulated;
   }
-  TRI_IF_FAILURE("MerkleTree::serializeSnappy") {
+  ARANGODB_IF_FAILURE("MerkleTree::serializeSnappy") {
     format = BinaryFormat::CompressedSnappyFull;
   }
-  TRI_IF_FAILURE("MerkleTree::serializeSnappyLazy") {
+  ARANGODB_IF_FAILURE("MerkleTree::serializeSnappyLazy") {
     format = BinaryFormat::CompressedSnappyLazy;
   }
 
@@ -1606,7 +1606,7 @@ std::pair<std::uint64_t, std::uint64_t> MerkleTree<Hasher, BranchingBits>::chunk
 
 template <typename Hasher, std::uint64_t const BranchingBits>
 void MerkleTree<Hasher, BranchingBits>::checkInternalConsistency() const {
-  TRI_IF_FAILURE("MerkleTree::skipConsistencyCheck") {
+  ARANGODB_IF_FAILURE("MerkleTree::skipConsistencyCheck") {
     return;
   }
 

--- a/lib/Containers/MerkleTree.h
+++ b/lib/Containers/MerkleTree.h
@@ -422,7 +422,7 @@ class MerkleTree : public MerkleTreeBase {
   
   std::uint64_t numberOfShards() const noexcept;
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // intentionally corrupts the tree. used for testing only
   void corrupt(std::uint64_t count, std::uint64_t hash);
 #endif

--- a/lib/Logger/LogAppenderFile.cpp
+++ b/lib/Logger/LogAppenderFile.cpp
@@ -292,7 +292,7 @@ void LogAppenderFile::closeAll() {
   _openAppenders.clear();
 }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 std::vector<std::tuple<int, std::string, LogAppenderFile*>> LogAppenderFile::getAppenders() {
   std::vector<std::tuple<int, std::string, LogAppenderFile*>> result;
 

--- a/lib/Logger/LogAppenderFile.h
+++ b/lib/Logger/LogAppenderFile.h
@@ -96,7 +96,7 @@ class LogAppenderFile : public LogAppenderStream {
   static void reopenAll();
   static void closeAll();
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   static std::vector<std::tuple<int, std::string, LogAppenderFile*>> getAppenders();
 
   static void setAppenders(std::vector<std::tuple<int, std::string, LogAppenderFile*>> const& fds);

--- a/lib/Logger/LogThread.cpp
+++ b/lib/Logger/LogThread.cpp
@@ -41,7 +41,7 @@ LogThread::~LogThread() {
 bool LogThread::log(LogGroup& group, std::unique_ptr<LogMessage>& message) {
   TRI_ASSERT(message != nullptr);
 
-  TRI_IF_FAILURE("LogThread::log") {
+  ARANGODB_IF_FAILURE("LogThread::log") {
     // simulate a successful logging, but actually don't log anything
     return true;
   }

--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -703,7 +703,7 @@ void Logger::append(LogGroup& group,
     if (!handled) {
       TRI_ASSERT(msg != nullptr);
 
-      TRI_IF_FAILURE("Logger::append") {
+      ARANGODB_IF_FAILURE("Logger::append") {
         // cut off all logging
         return;
       }

--- a/lib/Random/RandomGenerator.cpp
+++ b/lib/Random/RandomGenerator.cpp
@@ -590,7 +590,7 @@ uint64_t RandomGenerator::interval(uint64_t right) {
   return value;
 }
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 int32_t RandomGenerator::random(int32_t left, int32_t right) {
   ensureDeviceIsInitialized();
   return _device->random(left, right);

--- a/lib/Random/RandomGenerator.h
+++ b/lib/Random/RandomGenerator.h
@@ -90,7 +90,7 @@ class RandomGenerator {
   static uint64_t interval(uint64_t);
   
   // exposed only for testing
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   static int32_t random(int32_t left, int32_t right);
 #endif
 

--- a/lib/Rest/GeneralRequest.h
+++ b/lib/Rest/GeneralRequest.h
@@ -158,7 +158,7 @@ class GeneralRequest {
 
   void addSuffix(std::string part);
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   void clearSuffixes() {
     _suffixes.clear();
   }

--- a/lib/Rest/Version.cpp
+++ b/lib/Rest/Version.cpp
@@ -227,7 +227,7 @@ void Version::initialize() {
   Values["maintainer-mode"] = "false";
 #endif
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   Values["failure-tests"] = "true";
 #else
   Values["failure-tests"] = "false";

--- a/lib/SimpleHttpClient/ConnectionCache.h
+++ b/lib/SimpleHttpClient/ConnectionCache.h
@@ -87,7 +87,7 @@ class ConnectionCache {
   /// this is currently used only for testing
   void release(std::unique_ptr<GeneralClientConnection> connection, bool force = false);
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   std::unordered_map<std::string, std::vector<std::unique_ptr<GeneralClientConnection>>> const& connections() const { 
     return  _connections;
   }

--- a/tests/Aql/BlockCollector.cpp
+++ b/tests/Aql/BlockCollector.cpp
@@ -71,7 +71,7 @@ SharedAqlItemBlockPtr BlockCollector::steal() {
   TRI_ASSERT(_totalSize > 0);
   SharedAqlItemBlockPtr result{nullptr};
 
-  TRI_IF_FAILURE("BlockCollector::getOrSkipSomeConcatenate") {
+  ARANGODB_IF_FAILURE("BlockCollector::getOrSkipSomeConcatenate") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 

--- a/tests/Aql/TestEmptyExecutorHelper.cpp
+++ b/tests/Aql/TestEmptyExecutorHelper.cpp
@@ -41,7 +41,7 @@ using namespace arangodb::aql;
 TestEmptyExecutorHelper::TestEmptyExecutorHelper(Fetcher&, Infos&) {}
 
 std::pair<ExecutionState, FilterStats> TestEmptyExecutorHelper::produceRows(OutputAqlItemRow& output) {
-  TRI_IF_FAILURE("TestEmptyExecutorHelper::produceRows") {
+  ARANGODB_IF_FAILURE("TestEmptyExecutorHelper::produceRows") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
   ExecutionState state = ExecutionState::DONE;

--- a/tests/Auth/UserManagerClusterTest.cpp
+++ b/tests/Auth/UserManagerClusterTest.cpp
@@ -75,7 +75,7 @@ class UserManagerClusterTest : public ::testing::Test {
   }
 };
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 TEST_F(UserManagerClusterTest, regression_forgotten_update) {
   /* The following order of events did lead to a missing update:
    * 1. um->triggerLocalReload();

--- a/tests/Containers/MerkleTreeTest.cpp
+++ b/tests/Containers/MerkleTreeTest.cpp
@@ -972,7 +972,7 @@ TEST(MerkleTreeTest, test_check_consistency) {
   // must not throw
   tree.checkConsistency();
  
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   tree.corrupt(42, 23);
 
   // must throw

--- a/tests/IResearch/IResearchFeature-test.cpp
+++ b/tests/IResearch/IResearchFeature-test.cpp
@@ -2097,7 +2097,7 @@ TEST_F(IResearchFeatureTest, test_async_schedule_task_resize_pool) {
   EXPECT_TRUE(100ms < diff);
 }
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 TEST_F(IResearchFeatureTest, test_fail_to_submit_task) {
   {
     auto cleanup = arangodb::scopeGuard(TRI_ClearFailurePointsDebugging);

--- a/tests/IResearch/IResearchLink-test.cpp
+++ b/tests/IResearch/IResearchLink-test.cpp
@@ -1620,7 +1620,7 @@ TEST_F(IResearchLinkTest, test_maintenance_consolidation) {
                 feature.stats(ThreadGroup::_1));
     }
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     // ensure consolidation is rescheduled after exception
     {
       auto clearFailurePoints = arangodb::scopeGuard(TRI_ClearFailurePointsDebugging);
@@ -1808,7 +1808,7 @@ TEST_F(IResearchLinkTest, test_maintenance_commit) {
                 feature.stats(ThreadGroup::_0));
     }
 
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     // ensure commit is rescheduled after exception
     {
       auto clearFailurePoints = arangodb::scopeGuard(TRI_ClearFailurePointsDebugging);

--- a/tests/Mocks/StorageEngineMock.cpp
+++ b/tests/Mocks/StorageEngineMock.cpp
@@ -90,7 +90,7 @@ void handleValNode(VPackBuilder* keys, arangodb::aql::AstNode const* valNode) {
                            valNode->getStringLength(), VPackValueType::String));
   keys->close();
 
-  TRI_IF_FAILURE("EdgeIndex::collectKeys") {
+  ARANGODB_IF_FAILURE("EdgeIndex::collectKeys") {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 }
@@ -331,7 +331,7 @@ class EdgeIndexMock final : public arangodb::Index {
     keys->openArray();
 
     handleValNode(keys.get(), valNode);
-    TRI_IF_FAILURE("EdgeIndex::noIterator") {
+    ARANGODB_IF_FAILURE("EdgeIndex::noIterator") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
     keys->close();
@@ -356,12 +356,12 @@ class EdgeIndexMock final : public arangodb::Index {
     size_t const n = valNode->numMembers();
     for (size_t i = 0; i < n; ++i) {
       handleValNode(keys.get(), valNode->getMemberUnchecked(i));
-      TRI_IF_FAILURE("EdgeIndex::iteratorValNodes") {
+      ARANGODB_IF_FAILURE("EdgeIndex::iteratorValNodes") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
     }
 
-    TRI_IF_FAILURE("EdgeIndex::noIterator") {
+    ARANGODB_IF_FAILURE("EdgeIndex::noIterator") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
     keys->close();

--- a/tests/js/server/replication/sync/replication-sync-malarkey.js
+++ b/tests/js/server/replication/sync/replication-sync-malarkey.js
@@ -1139,7 +1139,7 @@ function ReplicationIncrementalMalarkeyNewFormatIntermediateCommits() {
 
 let res = arango.GET("/_admin/debug/failat");
 if (res === true) {
-  // tests only work when compiled with -DUSE_FAILURE_TESTS
+  // tests only work when compiled with -DUSE_MAINTAINER_MODE
   jsunity.run(ReplicationIncrementalMalarkeyOldFormat);
   jsunity.run(ReplicationIncrementalMalarkeyNewFormat);
   jsunity.run(ReplicationIncrementalMalarkeyNewFormatIntermediateCommits);


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/726

This change fuses the 3 separate options `USE_MAINTAINER_MODE`, `USE_FAILURE_TESTS` and `USE_GOOGLE_TESTS`.
Now `USE_MAINTAINER_MODE` rules them all and enables both assertions, failure tests and the compilation of C++ unit tests.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/726

### Testing & Verification

- [x] This change is already covered by existing tests, such as *all*.
