### PR TITLE
bts 542: huge memory use agent

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Append physical compaction of log collection to every Raft log
+  compaction (BTS-542).
+
 * Fixed issue BTS-536 "Upgrading without rest-server is aborted by error".
   Now stating `--server.rest-server false` does not require the additional
   `--console` argument for upgrading a server.

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -314,7 +314,7 @@ index_t State::logNonBlocking(index_t idx, velocypack::Slice const& slice,
                               term_t term, uint64_t millis, std::string const& clientId,
                               bool leading, bool reconfiguration) {
   _logLock.assertLockedByCurrentThread();
-  
+
   // verbose logging for all agency operations
   // there are two different log levels in use here for the AGENCYSTORE topic
   // - DEBUG: will log writes only on the leader
@@ -338,7 +338,7 @@ index_t State::logNonBlocking(index_t idx, velocypack::Slice const& slice,
       << "RAFT member fails to persist log entries!";
     FATAL_ERROR_EXIT();
   }
-  
+
   auto byteSize = slice.byteSize();
   auto buf = std::make_shared<Buffer<uint8_t>>(byteSize);
   buf->append(slice.begin(), byteSize);
@@ -361,7 +361,7 @@ void State::logEmplaceBackNoLock(log_t&& l) {
       FATAL_ERROR_EXIT();
     }
   }
-  
+
   try {
     _log_size += l.entry->byteSize();
     _log.emplace_back(std::forward<log_t>(l));  // log to RAM or die
@@ -386,7 +386,7 @@ index_t State::logFollower(query_t const& transactions) {
   // Check whether we have got a snapshot in the first position:
   bool gotSnapshot = slices.length() > 0 && slices[0].isObject() &&
                      !slices[0].get("readDB").isNone();
-  
+
   MUTEX_LOCKER(logLock, _logLock);
 
   // In case of a snapshot, there are three possibilities:
@@ -592,7 +592,7 @@ void State::logEraseNoLock(
       }
     }
   }
-  
+
   _clientIdLookupCount -= numRemoved;
 
   _log.erase(rbegin, rend);
@@ -876,7 +876,7 @@ bool State::loadPersisted() {
   loadOrPersistConfiguration();
 
   ensureCollection("election", false);
-  
+
   if (checkCollection("log") && checkCollection("compact")) {
     index_t lastCompactionIndex = loadCompacted();
     if (loadRemaining(lastCompactionIndex)) {
@@ -911,7 +911,7 @@ bool State::loadPersisted() {
 bool State::loadLastCompactedSnapshot(Store& store, index_t& index, term_t& term) {
   std::string const aql("FOR c IN compact SORT c._key DESC LIMIT 1 RETURN c");
 
-  TRI_ASSERT(nullptr != _vocbase);  
+  TRI_ASSERT(nullptr != _vocbase);
   arangodb::aql::Query query(transaction::StandaloneContext::Create(*_vocbase),
                              aql::QueryString(aql), nullptr);
 
@@ -924,7 +924,7 @@ bool State::loadLastCompactedSnapshot(Store& store, index_t& index, term_t& term
   VPackSlice result = queryResult.data->slice();
   // AQL results are guaranteed to be arrays
   TRI_ASSERT(result.isArray());
-    
+
   // Default: No compaction snapshot yet
   index = 0;
   term = 0;
@@ -968,7 +968,7 @@ index_t State::loadCompacted() {
   if (result.length()) {
     // Result can only have length 0 or 1.
     VPackSlice ii = result[0];
-    
+
     MUTEX_LOCKER(logLock, _logLock);
     _agent->setPersistedState(ii);
     try {
@@ -1206,7 +1206,7 @@ bool State::loadRemaining(index_t cind) {
       }
     }
   }
-  
+
   return !_log.empty() && match;
 }
 
@@ -1327,13 +1327,17 @@ bool State::compactPersisted(index_t cind, index_t keep) {
   index_t cut = cind - keep;
 
   auto bindVars = std::make_shared<VPackBuilder>();
+  auto cutStr = stringify(cut);
   bindVars->openObject();
-  bindVars->add("key", VPackValue(stringify(cut)));
+  bindVars->add("key", VPackValue(cutStr));
   bindVars->close();
 
   std::string const aql("FOR l IN log FILTER l._key < @key REMOVE l IN log");
 
   TRI_ASSERT(nullptr != _vocbase);  // this check was previously in the Query constructor
+
+  LOG_TOPIC("a8123", DEBUG, Logger::AGENCY) << "Removing log entries with keys lower than " << cutStr;
+
   arangodb::aql::Query query(transaction::StandaloneContext::Create(*_vocbase),
                              aql::QueryString(aql), bindVars);
 
@@ -1341,6 +1345,19 @@ bool State::compactPersisted(index_t cind, index_t keep) {
 
   if (queryResult.result.fail()) {
     THROW_ARANGO_EXCEPTION(queryResult.result);
+  }
+
+  LOG_TOPIC("a8123", DEBUG, Logger::AGENCY) << "Compacting log collection";
+  try {
+    auto col = _vocbase->lookupCollection("log");
+    if (col == nullptr) {
+      LOG_TOPIC("d131f", FATAL, Logger::AGENCY) << "Failed to find log collection in agency.";
+      FATAL_ERROR_EXIT();
+    } else {
+      col->compact();
+    }
+  } catch (const std::exception& e) {
+    LOG_TOPIC("d13f1", WARN, Logger::AGENCY) << "Failed to compact agent's physical log collection.";
   }
 
   return true;
@@ -1397,7 +1414,7 @@ bool State::persistCompactionSnapshot(index_t cind, arangodb::consensus::term_t 
       std::shared_ptr<transaction::Context>(
         std::shared_ptr<transaction::Context>(), &ctx),
       "compact", AccessMode::Type::WRITE);
-  
+
     Result res = trx.begin();
 
     if (!res.ok()) {
@@ -1472,7 +1489,7 @@ bool State::storeLogFromSnapshot(Store& snapshot, index_t index, term_t term) {
   _clientIdLookupTable.clear();
   _clientIdLookupCount = 0;
   _cur = index;
-  
+
   // This empty log should soon be rectified!
   return true;
 }
@@ -1526,8 +1543,8 @@ query_t State::allLogs() const {
   std::string const comp("FOR c IN compact SORT c._key RETURN c");
   std::string const logs("FOR l IN log SORT l._key RETURN l");
 
-  TRI_ASSERT(nullptr != _vocbase); 
-  
+  TRI_ASSERT(nullptr != _vocbase);
+
   MUTEX_LOCKER(mutexLocker, _logLock);
 
   arangodb::aql::Query compq(transaction::StandaloneContext::Create(*_vocbase),
@@ -1738,7 +1755,7 @@ uint64_t State::toVelocyPack(index_t lastIndex, VPackBuilder& builder) const {
 
   auto copyWithoutId = [&](VPackSlice slice, VPackBuilder& builder) {
     // Need to remove custom attribute in _id:
-    { 
+    {
       VPackObjectBuilder guard(&builder);
       for (auto const& p : VPackObjectIterator(slice)) {
         if (!p.key.isEqualString(StaticStrings::IdString)) {
@@ -1802,7 +1819,7 @@ uint64_t State::toVelocyPack(index_t lastIndex, VPackBuilder& builder) const {
 /// @brief dump the entire in-memory state to velocypack.
 /// should be used for testing only
 void State::toVelocyPack(velocypack::Builder& builder) const {
-  MUTEX_LOCKER(mutexLocker, _logLock); 
+  MUTEX_LOCKER(mutexLocker, _logLock);
 
   builder.openObject();
   builder.add("current", VPackValue(_cur));

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -1357,7 +1357,7 @@ bool State::compactPersisted(index_t cind, index_t keep) {
       col->compact();
     }
   } catch (const std::exception& e) {
-    LOG_TOPIC("d13f1", WARN, Logger::AGENCY) << "Failed to compact agent's physical log collection.";
+    LOG_TOPIC("d13f1", WARN, Logger::AGENCY) << "Failed to compact agent's physical log collection: " << e.what();
   }
 
   return true;

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -1347,7 +1347,7 @@ bool State::compactPersisted(index_t cind, index_t keep) {
     THROW_ARANGO_EXCEPTION(queryResult.result);
   }
 
-  LOG_TOPIC("a8123", DEBUG, Logger::AGENCY) << "Compacting log collection";
+  LOG_TOPIC("a8132", DEBUG, Logger::AGENCY) << "Compacting log collection";
   try {
     auto col = _vocbase->lookupCollection("log");
     if (col == nullptr) {


### PR DESCRIPTION
### Scope & Purpose

*Append physical compaction of log collection to every Raft log compaction (BTS-542).*

- [X] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [X] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [ ] Backports required for: *[3.8](https://github.com/arangodb/arangodb/pull/14615), 3.7*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [X] This change is a trivial rework / code cleanup without any test coverage.
- [X] The behavior in this PR was *manually tested*
- [X] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:
https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/16548/

### Documentation

> All new features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the CHANGELOG so that
> support, end users, and other developers have a concise overview. 

- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
