### PR TITLE
Fixing immer gcc x.1 compilation issues.

### DIFF
--- a/3rdParty/immer/v0.6.2/immer/detail/combine_standard_layout.hpp
+++ b/3rdParty/immer/v0.6.2/immer/detail/combine_standard_layout.hpp
@@ -10,7 +10,7 @@
 
 #include <type_traits>
 
-#if __GNUC__ == 7 || __GNUC_MINOR__ == 1
+#if __GNUC__ == 7 &&  __GNUC_MINOR__ == 1
 #define IMMER_BROKEN_STANDARD_LAYOUT_DETECTION 1
 #define immer_offsetof(st, m) ((std::size_t) &(((st*)0)->m))
 #else


### PR DESCRIPTION
### Scope & Purpose
Fix a compilation issue with `immer` that affects all gcc x.1 versions.
