### PR TITLE
Bug fix/replicated logs missing column family

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Add ReplicatedLogs column family.
+
 * Add optimization rule for AqlAnalyzer 
 
 * Append physical compaction of log collection to every Raft log

--- a/arangod/RocksDBEngine/RocksDBColumnFamilyManager.h
+++ b/arangod/RocksDBEngine/RocksDBColumnFamilyManager.h
@@ -55,7 +55,7 @@ struct RocksDBColumnFamilyManager {
     External   // for display to users
   };
 
-  static constexpr size_t minNumberOfColumnFamilies = 8;
+  static constexpr size_t minNumberOfColumnFamilies = 7;
   static constexpr size_t numberOfColumnFamilies = 8;
 
   static void initialize();


### PR DESCRIPTION
### Scope & Purpose

If the column family `ReplicatedLogs` is missing, we silently create it.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required
