### PR TITLE
Fix duplicate log id

### DIFF
--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -506,7 +506,7 @@ auto replicated_log::LogLeader::GuardedLeaderData::updateCommitIndexLeader(
   } catch (...) {
     // If those promises are not fulfilled we can not continue.
     // Note that the move constructor of std::multi_map is not noexcept.
-    LOG_CTX("e7a4d", FATAL, _self._logContext)
+    LOG_CTX("c0bbb", FATAL, _self._logContext)
         << "failed to fulfill replication promises due to exception; system "
            "can not continue";
     FATAL_ERROR_EXIT();


### PR DESCRIPTION
### Scope & Purpose

Fix a duplicate log id. Not caught by oskar because a necessary PR isn't merged yet. No CHANGELOG required, it was introduced in devel only.

- [X] :hankey: Bugfix

#### Backports:

- [X] No backports required

#### Related Information

Introduced in: https://github.com/arangodb/arangodb/pull/14486
Oskar PR that adds the necessary check: https://github.com/arangodb/oskar/pull/327

### Testing & Verification

- [X] This change is already covered by existing tests, such as https://github.com/arangodb/oskar/pull/327.

Link to Jenkins PR run:

https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/16566/

Used with this oskar branch: https://github.com/arangodb/oskar/pull/327
