### PR TITLE
improve Pregel log messages by giving them more context

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Improve log messages for Pregel runs by giving them more context.
+
 * Add ReplicatedLogs column family.
 
 * Add optimization rule for AqlAnalyzer.

--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -57,6 +57,8 @@ using namespace arangodb;
 using namespace arangodb::pregel;
 using namespace arangodb::basics;
 
+#define LOG_PREGEL(id, level) LOG_TOPIC(id, level, Logger::PREGEL) << "[job " << _executionNumber << "] " 
+
 const char* arangodb::pregel::ExecutionStateNames[8] = {
     "none",     "running",  "storing",    "done",
     "canceled", "in error", "recovering", "fatal error"};
@@ -102,27 +104,30 @@ Conductor::Conductor(uint64_t executionNumber, TRI_vocbase_t& vocbase,
                                    "Algorithm not found");
   }
   _masterContext.reset(_algorithm->masterContext(config));
-  _aggregators.reset(new AggregatorHandler(_algorithm.get()));
+  _aggregators = std::make_unique<AggregatorHandler>(_algorithm.get());
 
   _maxSuperstep = VelocyPackHelper::getNumericValue(config, "maxGSS", _maxSuperstep);
   // configure the async mode as off by default
   VPackSlice async = _userParams.slice().get("async");
   _asyncMode = _algorithm->supportsAsyncMode() && async.isBool() && async.getBoolean();
-  if (_asyncMode) {
-    LOG_TOPIC("1b1c2", DEBUG, Logger::PREGEL) << "Running in async mode";
-  }
   _useMemoryMaps = VelocyPackHelper::getBooleanValue(_userParams.slice(), Utils::useMemoryMapsKey,
                                                      _useMemoryMaps);
   VPackSlice storeSlice = config.get("store");
   _storeResults = !storeSlice.isBool() || storeSlice.getBool();
-  if (!_storeResults) {
-    LOG_TOPIC("f3817", DEBUG, Logger::PREGEL) << "Will keep results in-memory";
-  }
   
   // time-to-live for finished/failed Pregel jobs before garbage collection.
   // default timeout is 10 minutes for each conductor
   uint64_t ttl = 600;
   _ttl = std::chrono::seconds(VelocyPackHelper::getNumericValue(config, "ttl", ttl));
+
+  LOG_PREGEL("00f5f", INFO)
+      << "Starting " << _algorithm->name() 
+      << " in database '" << vocbase.name()
+      << "', ttl: " << _ttl.count() << "s"
+      << ", async: " << (_asyncMode ? "yes" : "no")
+      << ", memory mapping: " << (_useMemoryMaps ? "yes" : "no")
+      << ", store: " << (_storeResults ? "yes" : "no")
+      << ", config: " << _userParams.slice().toJson();
 }
 
 Conductor::~Conductor() {
@@ -145,12 +150,12 @@ void Conductor::start() {
   _globalSuperstep = 0;
   updateState(ExecutionState::RUNNING);
 
-  LOG_TOPIC("3a255", DEBUG, Logger::PREGEL)
+  LOG_PREGEL("3a255", DEBUG)
       << "Telling workers to load the data";
   auto res = _initializeWorkers(Utils::startExecutionPath, VPackSlice());
   if (res != TRI_ERROR_NO_ERROR) {
     updateState(ExecutionState::CANCELED);
-    LOG_TOPIC("30171", ERR, Logger::PREGEL)
+    LOG_PREGEL("30171", ERR)
         << "Not all DBServers started the execution";
   }
 }
@@ -195,7 +200,7 @@ bool Conductor::_startGlobalStep() {
 
     if (res != TRI_ERROR_NO_ERROR) {
       updateState(ExecutionState::IN_ERROR);
-      LOG_TOPIC("04189", ERR, Logger::PREGEL)
+      LOG_PREGEL("04189", ERR)
           << "Seems there is at least one worker out of order";
       // the recovery mechanisms should take care of this
       return false;
@@ -215,7 +220,7 @@ bool Conductor::_startGlobalStep() {
     _masterContext->postGlobalSuperstepMessage(messagesFromWorkers.slice());
     proceed = _masterContext->postGlobalSuperstep();
     if (!proceed) {
-      LOG_TOPIC("0aa8e", DEBUG, Logger::PREGEL)
+      LOG_PREGEL("0aa8e", DEBUG)
           << "Master context ended execution";
     }
     if (proceed) {
@@ -247,7 +252,7 @@ bool Conductor::_startGlobalStep() {
     } else {  // just stop the timer
       updateState(_inErrorAbort ? ExecutionState::FATAL_ERROR : ExecutionState::DONE);
       _endTimeSecs = TRI_microtime();
-      LOG_TOPIC("9e82c", INFO, Logger::PREGEL)
+      LOG_PREGEL("9e82c", INFO)
           << "Done, execution took: " << totalRuntimeSecs() << " s";
     }
     return false;
@@ -282,7 +287,7 @@ bool Conductor::_startGlobalStep() {
 
   b.close();
 
-  LOG_TOPIC("d98de", DEBUG, Logger::PREGEL) << b.toString();
+  LOG_PREGEL("d98de", DEBUG) << b.slice().toJson();
 
   _stepStartTimeSecs = TRI_microtime();
 
@@ -290,11 +295,11 @@ bool Conductor::_startGlobalStep() {
   auto res = _sendToAllDBServers(Utils::startGSSPath, b);  // call me maybe
   if (res != TRI_ERROR_NO_ERROR) {
     updateState(ExecutionState::IN_ERROR);
-    LOG_TOPIC("f34bb", ERR, Logger::PREGEL)
+    LOG_PREGEL("f34bb", ERR)
         << "Conductor could not start GSS " << _globalSuperstep;
     // the recovery mechanisms should take care od this
   } else {
-    LOG_TOPIC("411a5", DEBUG, Logger::PREGEL) << "Conductor started new gss " << _globalSuperstep;
+    LOG_PREGEL("411a5", DEBUG) << "Conductor started new gss " << _globalSuperstep;
   }
   return res == TRI_ERROR_NO_ERROR;
 }
@@ -304,7 +309,7 @@ void Conductor::finishedWorkerStartup(VPackSlice const& data) {
   MUTEX_LOCKER(guard, _callbackMutex);
   _ensureUniqueResponse(data);
   if (_state != ExecutionState::RUNNING) {
-    LOG_TOPIC("10f48", WARN, Logger::PREGEL)
+    LOG_PREGEL("10f48", WARN)
         << "We are not in a state where we expect a response";
     return;
   }
@@ -315,7 +320,7 @@ void Conductor::finishedWorkerStartup(VPackSlice const& data) {
     return;
   }
 
-  LOG_TOPIC("76631", INFO, Logger::PREGEL)
+  LOG_PREGEL("76631", INFO)
       << "Running Pregel " << _algorithm->name() << " with "
       << _totalVerticesCount << " vertices, " << _totalEdgesCount << " edges";
   if (_masterContext) {
@@ -340,7 +345,7 @@ VPackBuilder Conductor::finishedWorkerStep(VPackSlice const& data) {
   uint64_t gss = data.get(Utils::globalSuperstepKey).getUInt();
   if (gss != _globalSuperstep ||
       !(_state == ExecutionState::RUNNING || _state == ExecutionState::CANCELED)) {
-    LOG_TOPIC("dc904", WARN, Logger::PREGEL)
+    LOG_PREGEL("dc904", WARN)
         << "Conductor did received a callback from the wrong superstep";
     return VPackBuilder();
   }
@@ -375,7 +380,7 @@ VPackBuilder Conductor::finishedWorkerStep(VPackSlice const& data) {
     return response;
   }
 
-  LOG_TOPIC("39385", DEBUG, Logger::PREGEL)
+  LOG_PREGEL("39385", DEBUG)
       << "Finished gss " << _globalSuperstep << " in "
       << (TRI_microtime() - _stepStartTimeSecs) << "s";
   //_statistics.debugOutput();
@@ -391,16 +396,16 @@ VPackBuilder Conductor::finishedWorkerStep(VPackSlice const& data) {
     if (_state == ExecutionState::RUNNING) {
       _startGlobalStep();  // trigger next superstep
     } else if (_state == ExecutionState::CANCELED) {
-      LOG_TOPIC("dd721", WARN, Logger::PREGEL)
+      LOG_PREGEL("dd721", WARN)
           << "Execution was canceled, results will be discarded.";
       _finalizeWorkers();  // tells workers to store / discard results
     } else {  // this prop shouldn't occur unless we are recovering or in error
-      LOG_TOPIC("923db", WARN, Logger::PREGEL)
+      LOG_PREGEL("923db", WARN)
           << "No further action taken after receiving all responses";
     }
   });
   if (!queued) {
-    LOG_TOPIC("038db", ERR, Logger::PREGEL)
+    LOG_PREGEL("038db", ERR)
         << "No thread available to queue response, canceling execution";
     cancel();
   }
@@ -411,7 +416,7 @@ void Conductor::finishedRecoveryStep(VPackSlice const& data) {
   MUTEX_LOCKER(guard, _callbackMutex);
   _ensureUniqueResponse(data);
   if (_state != ExecutionState::RECOVERING) {
-    LOG_TOPIC("23d8b", WARN, Logger::PREGEL)
+    LOG_PREGEL("23d8b", WARN)
         << "We are not in a state where we expect a recovery response";
     return;
   }
@@ -445,7 +450,7 @@ void Conductor::finishedRecoveryStep(VPackSlice const& data) {
     res = _sendToAllDBServers(Utils::continueRecoveryPath, b);
 
   } else {
-    LOG_TOPIC("6ecf2", INFO, Logger::PREGEL)
+    LOG_PREGEL("6ecf2", INFO)
         << "Recovery finished. Proceeding normally";
 
     // build the message, works for all cases
@@ -462,7 +467,7 @@ void Conductor::finishedRecoveryStep(VPackSlice const& data) {
   }
   if (res != TRI_ERROR_NO_ERROR) {
     cancelNoLock();
-    LOG_TOPIC("7f97e", INFO, Logger::PREGEL) << "Recovery failed";
+    LOG_PREGEL("7f97e", INFO) << "Recovery failed";
   }
 }
 
@@ -478,7 +483,7 @@ void Conductor::cancelNoLock() {
       [this]() -> bool { return (_finalizeWorkers() != TRI_ERROR_QUEUE_FULL); },
       Logger::PREGEL, "cancel worker execution");
   if (!ok) {
-    LOG_TOPIC("f8b3c", ERR, Logger::PREGEL)
+    LOG_PREGEL("f8b3c", ERR)
         << "Failed to cancel worker execution for five minutes, giving up.";
   }
   _workHandle.reset();
@@ -489,7 +494,7 @@ void Conductor::startRecovery() {
   if (_state != ExecutionState::RUNNING && _state != ExecutionState::IN_ERROR) {
     return;  // maybe we are already in recovery mode
   } else if (_algorithm->supportsCompensation() == false) {
-    LOG_TOPIC("12e0e", ERR, Logger::PREGEL)
+    LOG_PREGEL("12e0e", ERR)
         << "Algorithm does not support recovery";
     cancelNoLock();
     return;
@@ -512,7 +517,7 @@ void Conductor::startRecovery() {
         std::vector<ServerID> goodServers;
         auto res = _feature.recoveryManager()->filterGoodServers(_dbServers, goodServers);
         if (res != TRI_ERROR_NO_ERROR) {
-          LOG_TOPIC("3d08b", ERR, Logger::PREGEL)
+          LOG_PREGEL("3d08b", ERR)
               << "Recovery proceedings failed";
           cancelNoLock();
           return;
@@ -549,11 +554,11 @@ void Conductor::startRecovery() {
         res = _initializeWorkers(Utils::startRecoveryPath, additionalKeys.slice());
         if (res != TRI_ERROR_NO_ERROR) {
           cancelNoLock();
-          LOG_TOPIC("fefc6", ERR, Logger::PREGEL) << "Compensation failed";
+          LOG_PREGEL("fefc6", ERR) << "Compensation failed";
         }
       });
   if (!queued) {
-    LOG_TOPIC("92a8d", ERR, Logger::PREGEL)
+    LOG_PREGEL("92a8d", ERR)
         << "No thread available to queue recovery, may be in dirty state.";
   }
 }
@@ -730,19 +735,19 @@ ErrorCode Conductor::_initializeWorkers(std::string const& suffix, VPackSlice ad
                                                   fuerte::RestVerb::Post, path,
                                                   std::move(buffer), reqOpts));
 
-      LOG_TOPIC("6ae66", DEBUG, Logger::PREGEL) << "Initializing Server " << server;
+      LOG_PREGEL("6ae66", DEBUG) << "Initializing Server " << server;
     }
   }
 
   size_t nrGood = 0;
   futures::collectAll(responses)
-      .thenValue([&nrGood](auto const& results) {
+      .thenValue([&nrGood, this](auto const& results) {
         for (auto const& tryRes : results) {
           network::Response const& r = tryRes.get();  // throws exceptions upwards
           if (r.ok() && r.statusCode() < 400) {
             nrGood++;
           } else {
-            LOG_TOPIC("6ae67", ERR, Logger::PREGEL)
+            LOG_PREGEL("6ae67", ERR)
                 << "received error from worker: '"
                 << (r.ok() ? r.slice().toJson() : fuerte::to_string(r.error)) << "'";
           }
@@ -768,7 +773,7 @@ ErrorCode Conductor::_finalizeWorkers() {
     mngr->stopMonitoring(this);
   }
 
-  LOG_TOPIC("fc187", DEBUG, Logger::PREGEL) << "Finalizing workers";
+  LOG_PREGEL("fc187", DEBUG) << "Finalizing workers";
   VPackBuilder b;
   b.openObject();
   b.add(Utils::executionNumberKey, VPackValue(_executionNumber));
@@ -819,13 +824,13 @@ void Conductor::finishedWorkerFinalize(VPackSlice data) {
     _storeTimeSecs = TRI_microtime() - _finalizationStartTimeSecs;
   }
 
-  LOG_TOPIC("063b5", INFO, Logger::PREGEL) << "Done. We did " << _globalSuperstep << " rounds";
-  LOG_TOPIC("3cfa8", INFO, Logger::PREGEL)
-      << "Startup Time: " << _computationStartTimeSecs - _startTimeSecs << "s";
-  LOG_TOPIC("d43cb", INFO, Logger::PREGEL) << "Computation time: " << compTime << "s";
-  LOG_TOPIC_IF("74e05", INFO, Logger::PREGEL, didStore) << "Storage time: " << _storeTimeSecs << "s";
-  LOG_TOPIC("06f03", INFO, Logger::PREGEL) << "Overall: " << totalRuntimeSecs() << "s";
-  LOG_TOPIC("03f2e", DEBUG, Logger::PREGEL) << "Stats: " << debugOut.toString();
+  LOG_PREGEL("063b5", INFO) 
+      << "Done. We did " << _globalSuperstep << " rounds"
+      << ". Startup time: " << _computationStartTimeSecs - _startTimeSecs << "s"
+      << ", computation time: " << compTime << "s"
+      << (didStore ? (", storage time: " + std::to_string(_storeTimeSecs) + "s") : "")
+      << ", overall: " << totalRuntimeSecs() << "s"
+      << ", stats: " << debugOut.slice().toJson();
 
   // always try to cleanup
   if (_state == ExecutionState::CANCELED) {
@@ -836,7 +841,7 @@ void Conductor::finishedWorkerFinalize(VPackSlice data) {
         _feature.cleanupConductor(exe);
       });
       if (!queued) {
-        LOG_TOPIC("038da", ERR, Logger::PREGEL)
+        LOG_PREGEL("038da", ERR)
             << "No thread available to queue cleanup, canceling execution";
         cancel();
       }
@@ -963,7 +968,7 @@ ErrorCode Conductor::_sendToAllDBServers(std::string const& path, VPackBuilder c
   }
 
   if (_dbServers.empty()) {
-    LOG_TOPIC("a14fa", WARN, Logger::PREGEL) << "No servers registered";
+    LOG_PREGEL("a14fa", WARN) << "No servers registered";
     return TRI_ERROR_FAILED;
   }
 
@@ -1011,7 +1016,7 @@ void Conductor::_ensureUniqueResponse(VPackSlice body) {
   // check if this the only time we received this
   ServerID sender = body.get(Utils::senderKey).copyString();
   if (_respondedServers.find(sender) != _respondedServers.end()) {
-    LOG_TOPIC("c38b8", ERR, Logger::PREGEL) << "Received response already from " << sender;
+    LOG_PREGEL("c38b8", ERR) << "Received response already from " << sender;
     THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_CONFLICT);
   }
   _respondedServers.insert(sender);

--- a/arangod/Pregel/GraphStore.cpp
+++ b/arangod/Pregel/GraphStore.cpp
@@ -61,6 +61,8 @@
 using namespace arangodb;
 using namespace arangodb::pregel;
 
+#define LOG_PREGEL(id, level) LOG_TOPIC(id, level, Logger::PREGEL) << "[job " << _executionNumber << "] " 
+
 namespace {
 static constexpr size_t minStringChunkSize = 16 * 1024 * sizeof(char);
 static constexpr size_t maxStringChunkSize = 32 * 1024 * 1024 * sizeof(char);
@@ -87,8 +89,9 @@ size_t stringChunkSize(size_t /*numberOfChunks*/, uint64_t numVerticesLeft, bool
 } // namespace
 
 template <typename V, typename E>
-GraphStore<V, E>::GraphStore(TRI_vocbase_t& vb, GraphFormat<V, E>* graphFormat)
+GraphStore<V, E>::GraphStore(TRI_vocbase_t& vb, uint64_t executionNumber, GraphFormat<V, E>* graphFormat)
     : _vocbaseGuard(vb),
+      _executionNumber(executionNumber),
       _graphFormat(graphFormat),
       _config(nullptr),
       _vertexIdRangeStart(0),
@@ -105,7 +108,7 @@ void GraphStore<V, E>::loadShards(WorkerConfig* config, std::function<void()> co
   _config = config;
   TRI_ASSERT(_runningThreads == 0);
 
-  LOG_TOPIC("27f1e", DEBUG, Logger::PREGEL)
+  LOG_PREGEL("27f1e", DEBUG)
       << "Using up to " << _config->parallelism()
       << " threads to load data. memory-mapping is turned "
       << (config->useMemoryMaps() ? "on" : "off");
@@ -168,7 +171,7 @@ void GraphStore<V, E>::loadShards(WorkerConfig* config, std::function<void()> co
         auto task =
             std::make_shared<basics::LambdaTask>(queue, [this, vertexShard, edges]() -> Result {
               if (_vocbaseGuard.database().server().isStopping()) {
-                LOG_TOPIC("4355b", WARN, Logger::PREGEL)
+                LOG_PREGEL("4355b", WARN)
                     << "Aborting graph loading";
                 return {TRI_ERROR_SHUTTING_DOWN};
               }
@@ -176,26 +179,26 @@ void GraphStore<V, E>::loadShards(WorkerConfig* config, std::function<void()> co
                 loadVertices(vertexShard, edges);
                 return Result();
               } catch (basics::Exception const& ex) {
-                LOG_TOPIC("8682a", WARN, Logger::PREGEL)
+                LOG_PREGEL("8682a", WARN)
                     << "caught exception while loading pregel graph: " << ex.what();
                 return Result(ex.code(), ex.what());
               } catch (std::exception const& ex) {
-                LOG_TOPIC("c87c9", WARN, Logger::PREGEL)
+                LOG_PREGEL("c87c9", WARN)
                     << "caught exception while loading pregel graph: " << ex.what();
                 return Result(TRI_ERROR_INTERNAL, ex.what());
               } catch (...) {
-                LOG_TOPIC("c7240", WARN, Logger::PREGEL)
+                LOG_PREGEL("c7240", WARN)
                     << "caught unknown exception while loading pregel graph";
                 return Result(TRI_ERROR_INTERNAL, "unknown exception while loading pregel graph");
               }
             });
         queue->enqueue(task);
       } catch (basics::Exception const& ex) {
-        LOG_TOPIC("3f283", WARN, Logger::PREGEL)
+        LOG_PREGEL("3f283", WARN)
             << "unhandled exception while "
             << "loading pregel graph: " << ex.what();
       } catch (...) {
-        LOG_TOPIC("3f282", WARN, Logger::PREGEL) << "unhandled exception while "
+        LOG_PREGEL("3f282", WARN) << "unhandled exception while "
                                                  << "loading pregel graph";
       }
     }
@@ -302,8 +305,8 @@ std::unique_ptr<TypedBuffer<M>> createBuffer(WorkerConfig const& config, size_t 
 template <typename V, typename E>
 void GraphStore<V, E>::loadVertices(ShardID const& vertexShard,
                                     std::vector<ShardID> const& edgeShards) {
-  LOG_TOPIC("24837", DEBUG, Logger::PREGEL)
-    << "Pregel worker: loading from vertex shard " << vertexShard << ", edge shards: " << edgeShards;
+  LOG_PREGEL("24837", DEBUG)
+    << "Loading from vertex shard " << vertexShard << ", edge shards: " << edgeShards;
 
   transaction::Options trxOpts;
   trxOpts.waitForSync = false;
@@ -326,7 +329,7 @@ void GraphStore<V, E>::loadVertices(ShardID const& vertexShard,
   uint64_t const vertexIdRangeStart = determineVertexIdRangeStart(numVertices);
   uint64_t vertexIdRange = vertexIdRangeStart;
 
-  LOG_TOPIC("7c31f", DEBUG, Logger::PREGEL) << "Shard '" << vertexShard << "' has "
+  LOG_PREGEL("7c31f", DEBUG) << "Shard '" << vertexShard << "' has "
     << numVertices << " vertices. id range: ["
     << vertexIdRangeStart << ", " << (vertexIdRangeStart + numVertices) << ")";
 
@@ -393,10 +396,12 @@ void GraphStore<V, E>::loadVertices(ShardID const& vertexShard,
 
   _localVertexCount += numVertices;
 
+  double lastLogStamp = TRI_microtime();
+
   constexpr uint64_t batchSize = 10000;
   while (cursor->nextDocument(cb, batchSize)) {
     if (_vocbaseGuard.database().server().isStopping()) {
-      LOG_TOPIC("4355a", WARN, Logger::PREGEL) << "Aborting graph loading";
+      LOG_PREGEL("4355a", WARN) << "Aborting graph loading";
       break;
     }
 
@@ -405,8 +410,15 @@ void GraphStore<V, E>::loadVertices(ShardID const& vertexShard,
     } else {
       numVertices -= batchSize;
     }
-    LOG_TOPIC("b9ed9", DEBUG, Logger::PREGEL) << "Shard '" << vertexShard << "', "
-      << numVertices << " remaining vertices";
+
+    // log only every 10 seconds
+    double now = TRI_microtime();
+    if (now - lastLogStamp >= 10.0) {
+      lastLogStamp = now;
+      LOG_PREGEL("b9ed9", DEBUG) 
+          << "Shard '" << vertexShard << "', "
+          << numVertices << " left to load";
+    }
     segmentSize = std::min<size_t>(numVertices, vertexSegmentSize());
   }
 
@@ -419,7 +431,7 @@ void GraphStore<V, E>::loadVertices(ShardID const& vertexShard,
   ::moveAppend(edges, _edges);
   ::moveAppend(eKeys, _edgeKeys);
 
-  LOG_TOPIC("6d389", DEBUG, Logger::PREGEL)
+  LOG_PREGEL("6d389", DEBUG)
       << "Pregel worker: done loading from vertex shard " << vertexShard;
 }
 
@@ -475,7 +487,7 @@ void GraphStore<V, E>::loadEdges(transaction::Methods& trx, Vertex<V, E>& vertex
       auto res = Utils::resolveShard(ci, _config, collectionName,
                                      StaticStrings::KeyString, key, responsibleShard);
       if (res != TRI_ERROR_NO_ERROR) {
-        LOG_TOPIC("b80ba", ERR, Logger::PREGEL)
+        LOG_PREGEL("b80ba", ERR)
           << "Could not resolve target shard of edge '" << key
           << "', collection: " << collectionName
           << ": " << TRI_errno_string(res);
@@ -489,7 +501,7 @@ void GraphStore<V, E>::loadEdges(transaction::Methods& trx, Vertex<V, E>& vertex
     }
 
     if (edge->_targetShard == InvalidPregelShard) {
-      LOG_TOPIC("1f413", ERR, Logger::PREGEL)
+      LOG_PREGEL("1f413", ERR)
           << "Could not resolve target shard of edge";
       return TRI_ERROR_CLUSTER_BACKEND_UNAVAILABLE;
     }
@@ -547,7 +559,8 @@ uint64_t GraphStore<V, E>::determineVertexIdRangeStart(uint64_t numVertices) {
 /// Should not dead-lock unless we have to wait really long for other threads
 template <typename V, typename E>
 void GraphStore<V, E>::storeVertices(std::vector<ShardID> const& globalShards,
-                                     RangeIterator<Vertex<V, E>>& it) {
+                                     RangeIterator<Vertex<V, E>>& it,
+                                     size_t threadNumber) {
   // transaction on one shard
   OperationOptions options;
   options.silent = true;
@@ -560,7 +573,8 @@ void GraphStore<V, E>::storeVertices(std::vector<ShardID> const& globalShards,
   Result res;
 
   VPackBuilder builder;
-  size_t numDocs = 0;
+  uint64_t numDocs = 0;
+  double lastLogStamp = TRI_microtime();
 
   auto commitTransaction = [&]() {
     if (trx) {
@@ -583,7 +597,7 @@ void GraphStore<V, E>::storeVertices(std::vector<ShardID> const& globalShards,
         THROW_ARANGO_EXCEPTION(opRes.result);
       }
       if (opRes.is(TRI_ERROR_ARANGO_CONFLICT)) {
-        LOG_TOPIC("4e632", WARN, Logger::PREGEL) << "conflict while storing " << builder.toJson();
+        LOG_PREGEL("4e632", WARN) << "conflict while storing " << builder.toJson();
       }
 
       res = trx->finish(res);
@@ -592,11 +606,19 @@ void GraphStore<V, E>::storeVertices(std::vector<ShardID> const& globalShards,
       }
 
       if (_vocbaseGuard.database().server().isStopping()) {
-        LOG_TOPIC("73ec2", WARN, Logger::PREGEL) << "Storing data was canceled prematurely";
+        LOG_PREGEL("73ec2", WARN) << "Storing data was canceled prematurely";
         THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
       }
 
       numDocs = 0;
+  
+      // log only every 10 seconds
+      double now = TRI_microtime();
+      if (now - lastLogStamp >= 10.0) {
+        lastLogStamp = now;
+        LOG_PREGEL("24837", DEBUG)
+            << "Worker thread " << threadNumber << ", " << it.size() << " vertices left to store";
+      }
     }
 
     builder.clear();
@@ -627,9 +649,6 @@ void GraphStore<V, E>::storeVertices(std::vector<ShardID> const& globalShards,
     VPackStringRef const key = it->key();
     V const& data = it->data();
 
-    // This loop will fill a buffer of vertices until we run into a new
-    // collection
-    // or there are no more vertices for to store (or the buffer is full)
     builder.openObject(true);
     builder.add(StaticStrings::KeyString,
                 VPackValuePair(key.data(), key.size(), VPackValueType::String));
@@ -665,8 +684,9 @@ void GraphStore<V, E>::storeResults(WorkerConfig* config, std::function<void()> 
 
   _runningThreads.store(numThreads, std::memory_order_relaxed);
   size_t const numT = numThreads;
-  LOG_TOPIC("f3fd9", DEBUG, Logger::PREGEL) << "Storing vertex data using " <<
-    numT << " threads";
+  LOG_PREGEL("f3fd9", DEBUG) 
+      << "Storing vertex data (" << numSegments << " vertices) using " 
+      << numT << " threads";
 
   for (size_t i = 0; i < numT; ++i) {
     bool queued = SchedulerFeature::SCHEDULER->queue(RequestLane::INTERNAL_LOW, [=] {
@@ -676,18 +696,18 @@ void GraphStore<V, E>::storeResults(WorkerConfig* config, std::function<void()> 
 
       try {
         RangeIterator<Vertex<V, E>> it = vertexIterator(startI, endI);
-        storeVertices(_config->globalShardIDs(), it);
+        storeVertices(_config->globalShardIDs(), it, i);
         // TODO can't just write edges with SmartGraphs
       } catch (std::exception const& e) {
-        LOG_TOPIC("e22c8", ERR, Logger::PREGEL) << "Storing vertex data failed: " << e.what();
+        LOG_PREGEL("e22c8", ERR) << "Storing vertex data failed: " << e.what();
       } catch (...) {
-        LOG_TOPIC("51b87", ERR, Logger::PREGEL) << "Storing vertex data failed";
+        LOG_PREGEL("51b87", ERR) << "Storing vertex data failed";
       }
 
       uint32_t numRunning = _runningThreads.fetch_sub(1, std::memory_order_relaxed);
       TRI_ASSERT(numRunning > 0);
       if (numRunning - 1 == 0) {
-        LOG_TOPIC("b5a21", DEBUG, Logger::PREGEL)
+        LOG_PREGEL("b5a21", DEBUG)
             << "Storing data took " << (TRI_microtime() - now) << "s";
         cb();
       }

--- a/arangod/Pregel/GraphStore.h
+++ b/arangod/Pregel/GraphStore.h
@@ -64,7 +64,8 @@ struct GraphFormat;
 template <typename V, typename E>
 class GraphStore final {
  public:
-  GraphStore(TRI_vocbase_t& vocbase, GraphFormat<V, E>* graphFormat);
+  GraphStore(TRI_vocbase_t& vocbase, uint64_t executionNumber,
+             GraphFormat<V, E>* graphFormat);
 
   uint64_t numberVertexSegments() const {
     return _vertices.size();
@@ -101,7 +102,8 @@ class GraphStore final {
                  uint64_t numVertices, traverser::EdgeCollectionInfo& info);
 
   void storeVertices(std::vector<ShardID> const& globalShards,
-                     RangeIterator<Vertex<V,E>>& it);
+                     RangeIterator<Vertex<V,E>>& it,
+                     size_t threadNumber);
 
   uint64_t determineVertexIdRangeStart(uint64_t numVertices);
 
@@ -115,6 +117,7 @@ class GraphStore final {
 
  private:
   DatabaseGuard _vocbaseGuard;
+  uint64_t const _executionNumber;
   const std::unique_ptr<GraphFormat<V, E>> _graphFormat;
   WorkerConfig* _config = nullptr;
 

--- a/arangod/Pregel/Iterators.h
+++ b/arangod/Pregel/Iterators.h
@@ -132,8 +132,10 @@ class RangeIterator {
     return *this;
   }
 
-//  iterator begin() { return RangeIterator(_buffers.begin(), _begin, _end); }
-//  const_iterator begin() const { return RangeIterator(_buffers.begin(), _begin, _end); }
+  size_t size() const noexcept {
+    return _size;
+  }
+
   bool hasMore() const noexcept {
     return _size > 0;
   }

--- a/arangod/Pregel/Worker.cpp
+++ b/arangod/Pregel/Worker.cpp
@@ -41,6 +41,8 @@ using namespace arangodb;
 using namespace arangodb::basics;
 using namespace arangodb::pregel;
 
+#define LOG_PREGEL(id, level) LOG_TOPIC(id, level, Logger::PREGEL) << "[job " << _config.executionNumber() << "] " 
+
 #define MY_READ_LOCKER(obj, lock)                                              \
   ReadLocker<ReadWriteLock> obj(&lock, arangodb::basics::LockerType::BLOCKING, \
                                 true, __FILE__, __LINE__)
@@ -65,9 +67,9 @@ Worker<V, E, M>::Worker(TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algo,
   _workerContext.reset(algo->workerContext(userParams));
   _messageFormat.reset(algo->messageFormat());
   _messageCombiner.reset(algo->messageCombiner());
-  _conductorAggregators.reset(new AggregatorHandler(algo));
-  _workerAggregators.reset(new AggregatorHandler(algo));
-  _graphStore.reset(new GraphStore<V, E>(vocbase, _algorithm->inputFormat()));
+  _conductorAggregators = std::make_unique<AggregatorHandler>(algo);
+  _workerAggregators = std::make_unique<AggregatorHandler>(algo);
+  _graphStore = std::make_unique<GraphStore<V, E>>(vocbase, _config.executionNumber(), _algorithm->inputFormat());
 
   if (_config.asynchronousMode()) {
     _messageBatchSize = _algorithm->messageBatchSize(_config, _messageStats);
@@ -152,11 +154,11 @@ void Worker<V, E, M>::setupWorker() {
     try {
       _graphStore->loadShards(&_config, cb);
     } catch (std::exception const& ex) {
-      LOG_TOPIC("a47c4", WARN, Logger::PREGEL)
+      LOG_PREGEL("a47c4", WARN)
           << "caught exception in loadShards: " << ex.what();
       throw;
     } catch (...) {
-      LOG_TOPIC("e932d", WARN, Logger::PREGEL)
+      LOG_PREGEL("e932d", WARN)
           << "caught unknown exception in loadShards";
       throw;
     }
@@ -173,13 +175,13 @@ void Worker<V, E, M>::prepareGlobalStep(VPackSlice const& data, VPackBuilder& re
   // Lock to prevent malicous activity
   MUTEX_LOCKER(guard, _commandMutex);
   if (_state != WorkerState::IDLE) {
-    LOG_TOPIC("b8506", ERR, Logger::PREGEL)
+    LOG_PREGEL("b8506", ERR)
         << "Cannot prepare a gss when the worker is not idle";
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_INTERNAL, "Cannot prepare a gss when the worker is not idle");
   }
   _state = WorkerState::PREPARING;  // stop any running step
-  LOG_TOPIC("f16f2", DEBUG, Logger::PREGEL) << "Received prepare GSS: " << data.toJson();
+  LOG_PREGEL("f16f2", DEBUG) << "Received prepare GSS: " << data.toJson();
   VPackSlice gssSlice = data.get(Utils::globalSuperstepKey);
   if (!gssSlice.isInteger()) {
     THROW_ARANGO_EXCEPTION_FORMAT(TRI_ERROR_BAD_PARAMETER,
@@ -261,7 +263,7 @@ void Worker<V, E, M>::receivedMessages(VPackSlice const& data) {
     MY_READ_LOCKER(guard, _cacheRWLock);
     _writeCacheNextGSS->parseMessages(data);
   } else {
-    LOG_TOPIC("ecd34", ERR, Logger::PREGEL)
+    LOG_PREGEL("ecd34", ERR)
         << "Expected: " << _config._globalSuperstep << "Got: " << gss;
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
                                    "Superstep out of sync");
@@ -279,7 +281,7 @@ void Worker<V, E, M>::startGlobalStep(VPackSlice const& data) {
         TRI_ERROR_INTERNAL,
         "Cannot start a gss when the worker is not prepared");
   }
-  LOG_TOPIC("d5e44", DEBUG, Logger::PREGEL) << "Starting GSS: " << data.toJson();
+  LOG_PREGEL("d5e44", DEBUG) << "Starting GSS: " << data.toJson();
   VPackSlice gssSlice = data.get(Utils::globalSuperstepKey);
   const uint64_t gss = (uint64_t)gssSlice.getUInt();
   if (gss != _config.globalSuperstep()) {
@@ -303,7 +305,7 @@ void Worker<V, E, M>::startGlobalStep(VPackSlice const& data) {
     _workerContext->preGlobalSuperstepMasterMessage(data.get(Utils::masterToWorkerMessagesKey));
   }
 
-  LOG_TOPIC("39e20", DEBUG, Logger::PREGEL) << "Worker starts new gss: " << gss;
+  LOG_PREGEL("39e20", DEBUG) << "Worker starts new gss: " << gss;
   _startProcessing();  // sets _state = COMPUTING;
 }
 
@@ -338,7 +340,7 @@ void Worker<V, E, M>::_startProcessing() {
   for (size_t i = 0; i < numT; i++) {
     bool queued = scheduler->queue(RequestLane::INTERNAL_LOW, [self, this, i, numT, numSegments] {
       if (_state != WorkerState::COMPUTING) {
-        LOG_TOPIC("f0e3d", WARN, Logger::PREGEL)
+        LOG_PREGEL("f0e3d", WARN)
             << "Execution aborted prematurely.";
         return;
       }
@@ -361,7 +363,7 @@ void Worker<V, E, M>::_startProcessing() {
   }
 
   // TRI_ASSERT(_runningThreads == i);
-  LOG_TOPIC("425c3", DEBUG, Logger::PREGEL) << "Using " << numT << " Threads";
+  LOG_PREGEL("425c3", DEBUG) << "Starting processing using " << numT << " threads";
 }
 
 template <typename V, typename E, typename M>
@@ -423,7 +425,7 @@ bool Worker<V, E, M>::_processVertices(size_t threadId,
   // ==================== send messages to other shards ====================
   outCache->flushMessages();
   if (ADB_UNLIKELY(!_writeCache)) {  // ~Worker was called
-    LOG_TOPIC("ee2ab", WARN, Logger::PREGEL)
+    LOG_PREGEL("ee2ab", WARN)
         << "Execution aborted prematurely.";
     return false;
   }
@@ -508,11 +510,11 @@ void Worker<V, E, M>::_finishedProcessing() {
       _messageBatchSize = s > 1000 ? (uint32_t)s : 1000;
     }
     _messageStats.resetTracking();
-    LOG_TOPIC("13dbf", DEBUG, Logger::PREGEL) << "Batch size: " << _messageBatchSize;
+    LOG_PREGEL("13dbf", DEBUG) << "Message batch size: " << _messageBatchSize;
   }
 
   if (_config.asynchronousMode()) {
-    LOG_TOPIC("56a27", DEBUG, Logger::PREGEL) << "Finished LSS: " << package.toJson();
+    LOG_PREGEL("56a27", DEBUG) << "Finished LSS: " << package.toJson();
 
     // if the conductor is unreachable or has send data (try to) proceed
     _callConductorWithResponse(Utils::finishedWorkerStepPath, package, [this](VPackSlice response) {
@@ -528,7 +530,7 @@ void Worker<V, E, M>::_finishedProcessing() {
 
   } else {  // no answer expected
     _callConductor(Utils::finishedWorkerStepPath, package);
-    LOG_TOPIC("2de5b", DEBUG, Logger::PREGEL) << "Finished GSS: " << package.toJson();
+    LOG_PREGEL("2de5b", DEBUG) << "Finished GSS: " << package.toJson();
   }
 }
 
@@ -581,7 +583,7 @@ void Worker<V, E, M>::finalizeExecution(VPackSlice const& body, std::function<vo
   // Lock to prevent malicious activity
   MUTEX_LOCKER(guard, _commandMutex);
   if (_state == WorkerState::DONE) {
-    LOG_TOPIC("4067a", DEBUG, Logger::PREGEL) << "removing worker";
+    LOG_PREGEL("4067a", DEBUG) << "removing worker";
     cb();
     return;
   }
@@ -602,12 +604,12 @@ void Worker<V, E, M>::finalizeExecution(VPackSlice const& body, std::function<vo
   _state = WorkerState::DONE;
   VPackSlice store = body.get(Utils::storeResultsKey);
   if (store.isBool() && store.getBool() == true) {
-    LOG_TOPIC("91264", DEBUG, Logger::PREGEL) << "Storing results";
+    LOG_PREGEL("91264", DEBUG) << "Storing results";
     // tell graphstore to remove read locks
     _graphStore->_reports = &this->_reports;
     _graphStore->storeResults(&_config, std::move(cleanup));
   } else {
-    LOG_TOPIC("b3f35", WARN, Logger::PREGEL) << "Discarding results";
+    LOG_PREGEL("b3f35", WARN) << "Discarding results";
     cleanup();
   }
 }
@@ -649,7 +651,7 @@ void Worker<V, E, M>::aqlResult(VPackBuilder& b, bool withId) const {
     // bool store =
     if (auto res = _graphStore->graphFormat()->buildVertexDocumentWithResult(b, &data);
         res.fail()) {
-      LOG_TOPIC("37fde", ERR, Logger::PREGEL)
+      LOG_PREGEL("37fde", ERR)
           << "failed to build vertex document: " << res.error().toString();
       THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_AIR_EXECUTION_ERROR, res.error().toString());
     }
@@ -664,7 +666,7 @@ void Worker<V, E, M>::startRecovery(VPackSlice const& data) {
   MUTEX_LOCKER(guard, _commandMutex);
   VPackSlice method = data.get(Utils::recoveryMethodKey);
   if (method.compareString(Utils::compensate) != 0) {
-    LOG_TOPIC("742c5", ERR, Logger::PREGEL) << "Unsupported operation";
+    LOG_PREGEL("742c5", ERR) << "Unsupported operation";
     return;
   }
   // else if (method.compareString(Utils::rollback) == 0)
@@ -701,7 +703,7 @@ void Worker<V, E, M>::compensateStep(VPackSlice const& data) {
   Scheduler* scheduler = SchedulerFeature::SCHEDULER;
   bool queued = scheduler->queue(RequestLane::INTERNAL_LOW, [self = shared_from_this(), this] {
     if (_state != WorkerState::RECOVERING) {
-      LOG_TOPIC("554e2", WARN, Logger::PREGEL)
+      LOG_PREGEL("554e2", WARN)
           << "Compensation aborted prematurely.";
       return;
     }
@@ -712,7 +714,7 @@ void Worker<V, E, M>::compensateStep(VPackSlice const& data) {
     _initializeVertexContext(vCompensate.get());
     if (!vCompensate) {
       _state = WorkerState::DONE;
-      LOG_TOPIC("938d2", WARN, Logger::PREGEL)
+      LOG_PREGEL("938d2", WARN)
           << "Compensation aborted prematurely.";
       return;
     }
@@ -725,7 +727,7 @@ void Worker<V, E, M>::compensateStep(VPackSlice const& data) {
       vCompensate->compensate(i > _preRecoveryTotal);
       i++;
       if (_state != WorkerState::RECOVERING) {
-        LOG_TOPIC("e9011", WARN, Logger::PREGEL)
+        LOG_PREGEL("e9011", WARN)
             << "Execution aborted prematurely.";
         break;
       }
@@ -749,7 +751,7 @@ template <typename V, typename E, typename M>
 void Worker<V, E, M>::finalizeRecovery(VPackSlice const& data) {
   MUTEX_LOCKER(guard, _commandMutex);
   if (_state != WorkerState::RECOVERING) {
-    LOG_TOPIC("22e42", WARN, Logger::PREGEL)
+    LOG_PREGEL("22e42", WARN)
         << "Compensation aborted prematurely.";
     return;
   }
@@ -757,7 +759,7 @@ void Worker<V, E, M>::finalizeRecovery(VPackSlice const& data) {
   _expectedGSS = data.get(Utils::globalSuperstepKey).getUInt();
   _messageStats.resetTracking();
   _state = WorkerState::IDLE;
-  LOG_TOPIC("17f3c", INFO, Logger::PREGEL) << "Recovery finished";
+  LOG_PREGEL("17f3c", INFO) << "Recovery finished";
 }
 
 template <typename V, typename E, typename M>
@@ -795,7 +797,7 @@ template <typename V, typename E, typename M>
 void Worker<V, E, M>::_callConductorWithResponse(std::string const& path,
                                                  VPackBuilder const& message,
                                                  std::function<void(VPackSlice slice)> handle) {
-  LOG_TOPIC("6d349", TRACE, Logger::PREGEL) << "Calling the conductor";
+  LOG_PREGEL("6d349", TRACE) << "Calling the conductor";
   if (ServerState::instance()->isRunningInCluster() == false) {
     VPackBuilder response;
     _feature.handleConductorRequest(*_config.vocbase(), path, message.slice(), response);


### PR DESCRIPTION
### Scope & Purpose

Improve log messages for Pregel by passing the execution number around in most log messages.
Also log a clear INFO message at the start of each run with the relevant settings.
For data storage, also introduce a logging for the progress (remaining vertices to store).

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.8: https://github.com/arangodb/arangodb/pull/14632, 3.7: https://github.com/arangodb/arangodb/pull/14633

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
