### PR TITLE
use more sensible values for timeouts/renewals

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/footerView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/footerView.js
@@ -56,11 +56,23 @@
           // only try to renew token if we are still online
           return;
         }
+        
+        var frac = (frontendConfig.sessionTimeout >= 1800) ? 0.95 : 0.8;
+        // threshold for renewal: once session is x% over
+        var renewalThreshold = frontendConfig.sessionTimeout * frac;
 
         var now = Date.now() / 1000;
         var lastActivity = arangoHelper.lastActivity();
 
-        if (lastActivity > 0 && (now - lastActivity) > 90 * 60) {
+        // seconds in which the last user activity counts as significant
+        var lastSignificantActivityTimePeriod = 90 * 60;
+
+        // if this is more than the renewal threshold, limit it
+        if (lastSignificantActivityTimePeriod > renewalThreshold * 0.95) {
+          lastSignificantActivityTimePeriod = renewalThreshold * 0.95;
+        }
+
+        if (lastActivity > 0 && (now - lastActivity) > lastSignificantActivityTimePeriod) {
           // don't make an attempt to renew the token if last 
           // user activity is longer than 90 minutes ago
           return;
@@ -68,8 +80,7 @@
 
         // to save some superfluous HTTP requests to the server, 
         // try to renew only if session time is x% or more over
-        var frac = (frontendConfig.sessionTimeout >= 1800) ? 0.95 : 0.8;
-        if (now - self.lastTokenRenewal < frontendConfig.sessionTimeout * frac) {
+        if (now - self.lastTokenRenewal < renewalThreshold) {
           return;
         }
 


### PR DESCRIPTION
### Scope & Purpose

Use slightly more sensible internal timeout values (e.g. an adaptive timeout) for determining the "last significant" user action. Inspired by @Simran-B.
This slightly improves a new feature in 3.9, so intentionally no CHANGELOG for it (there is one for the original feature, APM-79).

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
