### PR TITLE
Added MutexGuard::unlock(), fixed tryLockedGuard, added tests

### DIFF
--- a/lib/Basics/Guarded.h
+++ b/lib/Basics/Guarded.h
@@ -91,6 +91,9 @@ class MutexGuard {
   auto get() const noexcept -> T&;
   auto operator->() const noexcept -> T*;
 
+  // @brief Unlocks and releases the mutex, and releases the value.
+  //        The guard is unusable after this, and the value inaccessible from
+  //        the guard.
   void unlock() noexcept(noexcept(std::declval<L>().unlock()));
 
  private:

--- a/lib/Basics/Guarded.h
+++ b/lib/Basics/Guarded.h
@@ -30,6 +30,7 @@
 #include <mutex>
 #include <optional>
 #include <stdexcept>
+#include <utility>
 #include <variant>
 
 /**
@@ -90,6 +91,8 @@ class MutexGuard {
   auto get() const noexcept -> T&;
   auto operator->() const noexcept -> T*;
 
+  void unlock() noexcept(noexcept(std::declval<L>().unlock()));
+
  private:
   struct nop {
     void operator()(T*) {}
@@ -114,6 +117,15 @@ auto MutexGuard<T, L>::get() const noexcept -> T& {
 template <class T, class L>
 auto MutexGuard<T, L>::operator->() const noexcept -> T* {
   return std::addressof(get());
+}
+
+template <class T, class L>
+void MutexGuard<T, L>::unlock() noexcept(noexcept(std::declval<L>().unlock())) {
+  static_assert(noexcept(_value.reset()));
+  static_assert(noexcept(_mutexLock.release()));
+  _value.reset();
+  _mutexLock.unlock();
+  _mutexLock.release();
 }
 
 template <class T, class M = std::mutex, template <class> class L = std::unique_lock>
@@ -249,7 +261,7 @@ auto Guarded<T, M, L>::getLockedGuard() const -> MutexGuard<T const, L<M>> {
 
 template <class T, class M, template <class> class L>
 auto Guarded<T, M, L>::tryLockedGuard() -> std::optional<MutexGuard<T, L<M>>> {
-  auto lock = lock_type(_mutex, std::try_lock);
+  auto lock = lock_type(_mutex, std::try_to_lock);
 
   if (lock.owns_lock()) {
     return MutexGuard(_value, std::move(lock));
@@ -261,7 +273,7 @@ auto Guarded<T, M, L>::tryLockedGuard() -> std::optional<MutexGuard<T, L<M>>> {
 template <class T, class M, template <class> class L>
 auto Guarded<T, M, L>::tryLockedGuard() const
     -> std::optional<MutexGuard<T const, L<M>>> {
-  auto lock = lock_type(_mutex, std::try_lock);
+  auto lock = lock_type(_mutex, std::try_to_lock);
 
   if (lock.owns_lock()) {
     return MutexGuard(_value, std::move(lock));

--- a/tests/Basics/GuardedTest.cpp
+++ b/tests/Basics/GuardedTest.cpp
@@ -22,6 +22,8 @@
 
 #include "gtest/gtest.h"
 
+#include <Mocks/Death_Test.h>
+
 #include "Basics/Guarded.h"
 #include "Basics/Mutex.h"
 #include "Basics/MutexLocker.h"
@@ -51,7 +53,11 @@ class GuardedTest : public ::testing::Test {
   using Guarded = Guarded<V, Mutex, Lock>;
 };
 
+template <typename T>
+class GuardedDeathTest : public GuardedTest<T> {};
+
 TYPED_TEST_CASE_P(GuardedTest);
+TYPED_TEST_CASE_P(GuardedDeathTest);
 
 // Test helper that acquires a lock;
 // then executes a callback that tries to acquire the same lock;
@@ -160,6 +166,46 @@ TYPED_TEST_P(GuardedTest, test_guard_waits_for_access) {
   testWaitForLock<GuardedType>(acquireGuard);
 }
 
+TYPED_TEST_P(GuardedTest, test_guard_unlock_releases_mutex) {
+  auto guardedObj = typename TestFixture::template Guarded<UnderGuard>{1};
+  EXPECT_EQ(1, guardedObj.copy().val);
+  auto guard = guardedObj.getLockedGuard();
+  EXPECT_EQ(1, guard.get().val);
+  guard.get().val = 2;
+  EXPECT_EQ(2, guard.get().val);
+  guard.unlock();
+
+  auto threadStarted = std::atomic<bool>{false};
+  auto couldAcquireLock = std::atomic<bool>{false};
+  auto thr = std::thread([&] {
+    threadStarted.store(true, std::memory_order_release);
+    guardedObj.doUnderLock([&](auto&&) {
+      couldAcquireLock.store(true, std::memory_order_release);
+    });
+  });
+
+  EXPECT_EQ(2, guardedObj.copy().val);
+  while (!threadStarted.load(std::memory_order_acquire)) {
+    // busy wait
+  }
+  // wait generously for the thread to try to get the lock and do something
+  std::this_thread::sleep_for(std::chrono::milliseconds{1});
+  EXPECT_TRUE(couldAcquireLock.load(std::memory_order_acquire));
+  thr.join();
+}
+
+TYPED_TEST_P(GuardedDeathTest, test_guard_unlock_releases_value) {
+  auto guardedObj = typename TestFixture::template Guarded<UnderGuard>{1};
+  EXPECT_EQ(1, guardedObj.copy().val);
+  auto guard = guardedObj.getLockedGuard();
+  EXPECT_EQ(1, guard.get().val);
+  guard.get().val = 2;
+  EXPECT_EQ(2, guard.get().val);
+  guard.unlock();
+
+  ASSERT_DEATH_CORE_FREE({ ASSERT_NE(2, guard.get().val); }, "");
+}
+
 TYPED_TEST_P(GuardedTest, test_do_allows_access) {
   auto guardedObj = typename TestFixture::template Guarded<UnderGuard>{1};
   {
@@ -252,6 +298,32 @@ TYPED_TEST_P(GuardedTest, test_try_allows_access) {
   }
 }
 
+TYPED_TEST_P(GuardedTest, test_try_guard_allows_access) {
+  auto guardedObj = typename TestFixture::template Guarded<UnderGuard>{1};
+  {
+    // try is allowed to spuriously fail for no reason. But we expect it to
+    // succeed at some point when noone holds the lock.
+    bool didExecute = false;
+    while (!didExecute) {
+      if (auto guard = guardedObj.tryLockedGuard()) {
+        EXPECT_EQ(1, guard->get().val);
+        guard->get().val = 2;
+        didExecute = true;
+        EXPECT_EQ(2, guard->get().val);
+      }
+
+      {
+        auto guard = guardedObj.getLockedGuard();
+        if (didExecute) {
+          EXPECT_EQ(guard->val, 2);
+        } else {
+          EXPECT_EQ(guard->val, 1);
+        }
+      }
+    }
+  }
+}
+
 TYPED_TEST_P(GuardedTest, test_try_fails_access) {
   auto guardedObj = typename TestFixture::template Guarded<UnderGuard>{1};
   {
@@ -279,11 +351,40 @@ TYPED_TEST_P(GuardedTest, test_try_fails_access) {
   }
 }
 
-REGISTER_TYPED_TEST_CASE_P(GuardedTest, test_copy_allows_access, test_copy_waits_for_access,
-                           test_assign_allows_access, test_assign_waits_for_access,
-                           test_guard_allows_access, test_guard_waits_for_access,
+TYPED_TEST_P(GuardedTest, test_try_guard_fails_access) {
+  auto guardedObj = typename TestFixture::template Guarded<UnderGuard>{1};
+  {
+    auto guard = guardedObj.getLockedGuard();
+    bool threadStarted = false;
+    bool threadFinished = false;
+    auto thr = std::thread([&] {
+      threadStarted = true;
+      bool didExecute = false;
+      if (auto guard = guardedObj.tryLockedGuard()) {
+        EXPECT_EQ(1, guard->get().val);
+        guard->get().val = 2;
+        didExecute = true;
+        EXPECT_EQ(2, guard->get().val);
+      }
+      EXPECT_FALSE(didExecute);
+      threadFinished = true;
+    });
+    thr.join();
+    EXPECT_TRUE(threadStarted);
+    EXPECT_TRUE(threadFinished);
+    EXPECT_EQ(guard->val, 1);
+  }
+}
+
+REGISTER_TYPED_TEST_CASE_P(GuardedTest, test_copy_allows_access,
+                           test_copy_waits_for_access, test_assign_allows_access,
+                           test_assign_waits_for_access, test_guard_allows_access,
+                           test_guard_waits_for_access, test_guard_unlock_releases_mutex,
                            test_do_allows_access, test_do_waits_for_access,
-                           test_try_allows_access, test_try_fails_access);
+                           test_try_allows_access, test_try_guard_allows_access,
+                           test_try_fails_access, test_try_guard_fails_access);
+
+REGISTER_TYPED_TEST_CASE_P(GuardedDeathTest, test_guard_unlock_releases_value);
 
 template <template <typename> typename T>
 struct ParamT {
@@ -297,5 +398,6 @@ using TestedTypes =
                      std::pair<arangodb::Mutex, ParamT<std::unique_lock>>>;
 
 INSTANTIATE_TYPED_TEST_CASE_P(GuardedTestInstantiation, GuardedTest, TestedTypes);
+INSTANTIATE_TYPED_TEST_CASE_P(GuardedDeathTestInstantiation, GuardedDeathTest, TestedTypes);
 
 }  // namespace arangodb::tests

--- a/tests/Mocks/Death_Test.h
+++ b/tests/Mocks/Death_Test.h
@@ -30,8 +30,7 @@
 /// So this thin macro wraps around the GTEST :: EXPECT_DEATH macro and disables coredumps
 /// only within the expected forked process
 
-#ifndef ARANGODB_TESTS_MOCKS_DEATH_TEST_CHANGER_H
-#define ARANGODB_TESTS_MOCKS_DEATH_TEST_CHANGER_H 1
+#pragma once
 
 #ifndef _WIN32
 
@@ -39,13 +38,24 @@
 
 // Enabled on Linux and Mac
 
+inline void disableCoredump() {
+  auto core_limit = rlimit{};
+  core_limit.rlim_cur = 0;
+  core_limit.rlim_max = 0;
+  setrlimit(RLIMIT_CORE, &core_limit);
+}
+
 #define EXPECT_DEATH_CORE_FREE(func, assertion) \
   EXPECT_DEATH(                                 \
       [&]() {                                   \
-        rlimit core_limit;                      \
-        core_limit.rlim_cur = 0;                \
-        core_limit.rlim_max = 0;                \
-        setrlimit(RLIMIT_CORE, &core_limit);    \
+        disableCoredump();                      \
+        func;                                   \
+      }(),                                      \
+      assertion)
+#define ASSERT_DEATH_CORE_FREE(func, assertion) \
+  ASSERT_DEATH(                                 \
+      [&]() {                                   \
+        disableCoredump();                      \
         func;                                   \
       }(),                                      \
       assertion)
@@ -57,7 +67,5 @@
 // please feel free to fix it here.
 
 #define EXPECT_DEATH_CORE_FREE(func, assertion) EXPECT_TRUE(true)
-
-#endif
 
 #endif

--- a/tests/Mocks/Death_Test.h
+++ b/tests/Mocks/Death_Test.h
@@ -67,6 +67,6 @@ inline void disableCoredump() {
 // please feel free to fix it here.
 
 #define EXPECT_DEATH_CORE_FREE(func, assertion) EXPECT_TRUE(true)
-#define ASSERT_DEATH_CORE_FREE(func, assertion) EXPECT_TRUE(true)
+#define ASSERT_DEATH_CORE_FREE(func, assertion) ASSERT_TRUE(true)
 
 #endif

--- a/tests/Mocks/Death_Test.h
+++ b/tests/Mocks/Death_Test.h
@@ -67,5 +67,6 @@ inline void disableCoredump() {
 // please feel free to fix it here.
 
 #define EXPECT_DEATH_CORE_FREE(func, assertion) EXPECT_TRUE(true)
+#define ASSERT_DEATH_CORE_FREE(func, assertion) EXPECT_TRUE(true)
 
 #endif


### PR DESCRIPTION
### Scope & Purpose

Added an `unlock` method to `MutexGuard`, fixed the `tryLockedGuard` implementation, and added tests for both.

- [X] :hammer: Refactoring/simplification

#### Backports:

- [X] No backports required

### Testing & Verification

- [X] This PR adds tests that were used to verify all changes:
  - [X] Added new C++ **Unit tests**
