### PR TITLE
Remove fixPrototypeChain agency migration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Remove old fixPrototypeChain agency migration, which was introduced in 3.2
+  and is no longer necessary. This will make it impossible to upgrade
+  directly from a version < 3.2 to a version >= 3.9, provided one has
+  a chain of `distributeShardsLike` collections.
+
 * Improve log messages for Pregel runs by giving them more context.
 
 * Add ReplicatedLogs column family.


### PR DESCRIPTION
- Remove fixPrototypeChain code.
- CHANGELOG.

This agency migration code was introduced with 3.2.1, as far as I see.
It handled the case that somebody might have three collections A, B and
C, with B having `distributeShardsLike` set to `"A"`, and C having
`distributeShardsLike` set to `"B"`, by migrating this to set C also
to have `distributeShardsLike` set to `"A"`.

This migration was broken by a recent fix in `devel` (not in 3.8),
therefore no backports are necessary and no customers are in danger.

Note that this makes it impossible to upgrade directly from a version
< 3.2 to a version >= 3.9, if one has such a `distributeShardsLike`
chain as described above.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers - **mandatory**)*

- [*] :hankey: Bugfix (requires CHANGELOG entry)
- [*] :book: CHANGELOG entry made

#### Backports:

- [*] No backports required

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] GitHub issue / Jira ticket number:
      https://arangodb.atlassian.net/browse/BTS-546

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [*] The behavior in this PR was *manually tested*
- [*] This change is already covered by existing tests, such as release
      test automation.

