### PR TITLE
Fix wrong assertion in fuerte

### DIFF
--- a/3rdParty/fuerte/FuerteH1TCP.tla
+++ b/3rdParty/fuerte/FuerteH1TCP.tla
@@ -124,7 +124,7 @@ process(fuerte = "fuertethread") {
       or connectDone:    \* VERIFIED
         if (/\ Len(iocontext) >= 1
             /\ Head(iocontext) \in {"connect", "connectBAD"}) {
-          assert state \in {"Connecting", "Created", "Closed"};
+          assert state \in {"Connecting", "Closed"};
           alarm := "off";
           if (Head(iocontext) = "connect" /\ state = "Connecting") {
             assert active;
@@ -259,7 +259,7 @@ process(cancel = "cancelthread") {
 
 }
 *)
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-925ea62a5ed7f2fd7841f2836c7d799c
+\* BEGIN TRANSLATION - the hash of the PCal code: PCal-925ea62a5ed7f2fd7841f2836c7d799c (chksum(pcal) = "c5aa3da3" /\ chksum(tla) = "af7613cb")
 VARIABLES state, active, queueSize, alarm, asyncRunning, iocontext, reading, 
           writing, pc, stack
 
@@ -464,12 +464,12 @@ activate == /\ pc["fuertethread"] = "activate"
 connectDone == /\ pc["fuertethread"] = "connectDone"
                /\ IF /\ Len(iocontext) >= 1
                      /\ Head(iocontext) \in {"connect", "connectBAD"}
-                     THEN /\ Assert(state \in {"Connecting", "Created", "Closed"}, 
-                                    "Failure of assertion at line 127, column 11.")
+                     THEN /\ Assert(state \in {"Connecting", "Closed"}, 
+                                    "Failure of assertion at line 128, column 11.")
                           /\ alarm' = "off"
                           /\ IF Head(iocontext) = "connect" /\ state = "Connecting"
                                 THEN /\ Assert(active, 
-                                               "Failure of assertion at line 130, column 13.")
+                                               "Failure of assertion at line 131, column 13.")
                                      /\ iocontext' = Tail(iocontext)
                                      /\ state' = "Connected"
                                      /\ stack' = [stack EXCEPT !["fuertethread"] = << [ procedure |->  "asyncWriteNextRequest",
@@ -492,7 +492,7 @@ writeDone == /\ pc["fuertethread"] = "writeDone"
                    /\ Head(iocontext) \in {"write", "writeBAD"}
                    THEN /\ Assert(/\ state \in {"Connected", "Closed"}
                                   /\ writing, 
-                                  "Failure of assertion at line 145, column 11.")
+                                  "Failure of assertion at line 146, column 11.")
                         /\ writing' = FALSE
                         /\ IF Head(iocontext) = "write" /\ state = "Connected"
                               THEN /\ iocontext' = Tail(iocontext)
@@ -517,7 +517,7 @@ readDone == /\ pc["fuertethread"] = "readDone"
             /\ IF /\ Len(iocontext) >= 1
                   /\ Head(iocontext) \in {"read", "readBAD"}
                   THEN /\ Assert(state \in {"Connected", "Closed"}, 
-                                 "Failure of assertion at line 163, column 11.")
+                                 "Failure of assertion at line 164, column 11.")
                        /\ alarm' = "off"
                        /\ reading' = FALSE
                        /\ IF Head(iocontext) = "read" /\ state = "Connected"
@@ -714,6 +714,6 @@ NoSleepingBarber == /\ NothingForgottenOnQueue
 
 =============================================================================
 \* Modification History
-\* Last modified Fri Aug 21 16:03:16 CEST 2020 by neunhoef
+\* Last modified Thu Aug 19 14:45:44 CEST 2021 by neunhoef
 \* Last modified Wed Jul 22 12:06:32 CEST 2020 by simon
 \* Created Mi 22. Apr 22:46:19 CEST 2020 by neunhoef

--- a/3rdParty/fuerte/src/H1Connection.cpp
+++ b/3rdParty/fuerte/src/H1Connection.cpp
@@ -201,8 +201,10 @@ void H1Connection<ST>::finishConnect() {
   } else {
     FUERTE_LOG_ERROR << "finishConnect: found state other than 'Connecting': "
                      << static_cast<int>(exp);
-    FUERTE_ASSERT(false);
-    // If this happens, we probably have a sleeping barber
+    FUERTE_ASSERT(exp == Connection::State::Closed);
+    // If this happens, then the connection has been shut down before
+    // it could be fully connected, but the completion handler of the
+    // connect call was still scheduled. No more work to do.
   }
 }
 

--- a/3rdParty/fuerte/src/H1Connection.cpp
+++ b/3rdParty/fuerte/src/H1Connection.cpp
@@ -194,9 +194,9 @@ void H1Connection<ST>::finishConnect() {
   // If it has already gone off, we might have a completion handler
   // already posted on the iocontext. However, this will not touch anything
   // if we have first set the state to `Connected`.
-  FUERTE_ASSERT(this->_active.load());
   auto exp = Connection::State::Connecting;
   if (this->_state.compare_exchange_strong(exp, Connection::State::Connected)) {
+    FUERTE_ASSERT(this->_active.load());
     this->asyncWriteNextRequest();  // starts writing if queue non-empty
   } else {
     FUERTE_LOG_ERROR << "finishConnect: found state other than 'Connecting': "

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.8.1 (XXXX-XX-XX)
 -------------------
 
+* Fix wrong assertion in fuerte and move it to where the TLA+ model says
+  it should be. This fixes a unit test failure occurring on newer Macs
+  with a certain clang version.
+
 * When creating Pregel memory-mapped files, create them with O_TMPFILE attribute
   on Linux so that files are guaranteed to vanish even if a process dies.
 


### PR DESCRIPTION
Some newer Macs with a newer clang compiler have run into an assertion
in fuerte. As it turns out, the TLA+ model was predicting this. The
actual code simply has the assertion in the wrong place. This PR
should fix this.

 - Move assertion to the right place where the model has it.
 - CHANGELOG.

Scope & Purpose

(Please describe the changes in this PR for reviewers - mandatory)

    [*] Bugfix (requires CHANGELOG entry)

Backports:

    [*] Backports required for: 3.7 and 3.8, this is the 3.8 backport

Related Information

(Please reference tickets / specification / other PRs etc)

    [*] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-552

Testing & Verification

(Please pick either of the following options)

    [*] This change was suggested by our TLA+ model.
    [*] This change is already covered by existing tests, such as unit
    tests on newer macs with newer clang

