### PR TITLE
suppress intentional failures for cppcheck tests

### DIFF
--- a/lib/Basics/debugging.cpp
+++ b/lib/Basics/debugging.cpp
@@ -99,6 +99,7 @@ void TRI_TerminateDebugging(char const* message) {
     // the program but continues.
     auto f = []() noexcept {
       // intentionally crashes the program!
+      // cppcheck-suppress *
       return std::string(nullptr);
     };
     f();
@@ -107,7 +108,9 @@ void TRI_TerminateDebugging(char const* message) {
   } else if (s == "CRASH-HANDLER-TEST-SEGFAULT") {
     std::unique_ptr<int> x;
     // intentionally crashes the program!
+    // cppcheck-suppress *
     int a = *x;
+    // cppcheck-suppress *
     *x = 2;
     TRI_ASSERT(a == 1);
   } else if (s == "CRASH-HANDLER-TEST-ASSERT") {


### PR DESCRIPTION
### Scope & Purpose

Suppress cppcheck errors for code that intentionally causes errors/crashes (during debugging in maintainer mode).

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
