### PR TITLE
TRI_ASSERT Log Stream

### DIFF
--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -481,7 +481,8 @@ auto replicated_log::LogLeader::GuardedLeaderData::updateCommitIndexLeader(
       << "updating commit index to " << newIndex << "with quorum " << quorum->quorum;
   auto oldIndex = _commitIndex;
 
-  TRI_ASSERT(_commitIndex < newIndex);
+  TRI_ASSERT(_commitIndex < newIndex)
+      << "_commitIndex == " << _commitIndex << ", newIndex == " << newIndex;
   _commitIndex = newIndex;
   _lastQuorum = quorum;
 

--- a/lib/Basics/CrashHandler.cpp
+++ b/lib/Basics/CrashHandler.cpp
@@ -584,7 +584,7 @@ void CrashHandler::crash(char const* context) {
 }
 
 /// @brief logs an assertion failure and crashes the program
-void CrashHandler::assertionFailure(char const* file, int line, char const* func, char const* context) {
+void CrashHandler::assertionFailure(char const* file, int line, char const* func, char const* context, const char *message) {
   // assemble an "assertion failured in file:line: message" string
   char buffer[4096];
   memset(&buffer[0], 0, sizeof(buffer));
@@ -601,6 +601,10 @@ void CrashHandler::assertionFailure(char const* file, int line, char const* func
   }
   appendNullTerminatedString(": ", p);
   appendNullTerminatedString(context, 256, p);
+  if (message != nullptr) {
+    appendNullTerminatedString(" - ", p);
+    appendNullTerminatedString(message, p);
+  }
 
   crash(&buffer[0]);
 }

--- a/lib/Basics/CrashHandler.h
+++ b/lib/Basics/CrashHandler.h
@@ -33,7 +33,7 @@ class CrashHandler {
   [[noreturn]] static void crash(char const* context);
 
   /// @brief logs an assertion failure and crashes the program
-  [[noreturn]] static void assertionFailure(char const* file, int line, char const* func, char const* context);
+  [[noreturn]] static void assertionFailure(char const* file, int line, char const* func, char const* context, const char* message);
 
   /// @brief set flag to kill process hard using SIGKILL, in order to circumvent core
   /// file generation etc.


### PR DESCRIPTION
### Scope & Purpose

Allow to print additional information in case an assertion fails:
```
  TRI_ASSERT(_commitIndex < newIndex)
      << "_commitIndex == " << _commitIndex << ", newIndex == " << newIndex;
```
Will produce the following output:
```
assertion failed in /work/ArangoDB/arangod/Replication2/ReplicatedLogs/LogLeader.cpp:667 [LogLeader::checkCommitIndex]: _commitIndex < newIndex ; _commitIndex = 12, newIndex == 8
```

I made sure that no string is build if the the condition is satisfied or the maintainer mode is disabled. [See more.](https://godbolt.org/z/85cbfjavG)


- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

I will add tests to ensure, that this also works with types that have a custom `operator<<`.