### PR TITLE
reintroduce --cluster.index-create-timeout for testing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,9 +15,11 @@ devel
 * Do not block a scheduler thread on the coordinator while an index is being 
   created. Instead, start a background thread for the actual index 
   fill-up work. The original thread can then be relinquished until the index
-  is completely filled or index creation has failed. This also allows
-  obsoleting the startup option `--cluster.index-create-timeout`, which from
-  now on is ignored when set.
+  is completely filled or index creation has failed. 
+  The default index creation timeout on coordinators has also been 
+  extended from 1 hour to 4 days, but it is still configurable via the
+  startup parameter `--cluster.index-create-timeout` in case this is
+  necessary.
 
 * Fix wrong assertion in fuerte and move it to where the TLA+ model says
   it should be. This fixes a unit test failure occurring on newer Macs

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -115,11 +115,6 @@ void ClusterFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
 
   options->addObsoleteOption("--cluster.agency-prefix", "agency prefix", false);
   
-  options->addObsoleteOption("--cluster.index-create-timeout",
-      "amount of time (in seconds) the coordinator will wait for an index to "
-      "be created before giving up", true);
-
-
   options->addOption(
       "--cluster.require-persisted-id",
       "if set to true, then the instance will only start if a UUID file is "
@@ -221,6 +216,15 @@ void ClusterFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
       arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents,
                                    arangodb::options::Flags::OnCoordinator,
                                    arangodb::options::Flags::OnDBServer,
+                                   arangodb::options::Flags::Hidden));
+
+  options->addOption(
+      "--cluster.index-create-timeout",
+      "amount of time (in seconds) the coordinator will wait for an index to "
+      "be created before giving up",
+      new DoubleParameter(&_indexCreationTimeout),
+      arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents,
+                                   arangodb::options::Flags::OnCoordinator,
                                    arangodb::options::Flags::Hidden));
 
   options

--- a/arangod/Cluster/ClusterFeature.h
+++ b/arangod/Cluster/ClusterFeature.h
@@ -86,7 +86,7 @@ class ClusterFeature : public application_features::ApplicationFeature {
   bool forceOneShard() const { return _forceOneShard; }
   /// @brief index creation timeout in seconds. note: this used to be
   /// a configurable parameter in previous versions, but is now hard-coded.
-  double indexCreationTimeout() const noexcept { return 72.0 * 3600.0; }
+  double indexCreationTimeout() const { return _indexCreationTimeout; }
 
   std::shared_ptr<HeartbeatThread> heartbeatThread();
 
@@ -170,6 +170,8 @@ class ClusterFeature : public application_features::ApplicationFeature {
   bool _unregisterOnShutdown = false;
   bool _enableCluster = false;
   bool _requirePersistedId = false;
+  /// @brief coordinator timeout for index creation. defaults to 4 days
+  double _indexCreationTimeout = 72.0 * 3600.0;
   std::unique_ptr<ClusterInfo> _clusterInfo;
   std::shared_ptr<HeartbeatThread> _heartbeatThread;
   std::unique_ptr<AgencyCache> _agencyCache;


### PR DESCRIPTION
### Scope & Purpose

Reintroduce `--cluster.index-create-timeout` startup option, because we want the timeout to be configurable for arangosync testing. The option was obsoleted and the timeout was set to a hard-coded value in a recent PR. We now make it configurable again so we can set it to very small timeouts for testing.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*: https://github.com/arangodb/arangodb/pull/14679, *3.7*: https://github.com/arangodb/arangodb/pull/14680, *3.6*: https://github.com/arangodb/arangodb/pull/14681

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
