### PR TITLE
reintroduce --cluster.index-create-timeout for testing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,11 +8,10 @@ v3.6.16 (XXXX-XX-XX)
 * Do not block a scheduler thread on the coordinator while an index is being
   created. Instead, start a background thread for the actual index fill-up work.
   The original thread can then be relinquished until the index is completely
-  filled or index creation has failed. 
-  The default index creation timeout on coordinators has also been 
-  extended from 1 hour to 4 days, but it is still configurable via the
-  startup parameter `--cluster.index-create-timeout` in case this is
-  necessary.
+  filled or index creation has failed.
+  The default index creation timeout on coordinators has also been extended from
+  1 hour to 4 days, but it is still configurable via the startup parameter
+  `--cluster.index-create-timeout` in case this is necessary.
 
 * Make `--javascript.copy-installation` also copy the `node_modules`
   subdirectory. This is required so we have a full copy of the JavaScript

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,9 +8,11 @@ v3.6.16 (XXXX-XX-XX)
 * Do not block a scheduler thread on the coordinator while an index is being
   created. Instead, start a background thread for the actual index fill-up work.
   The original thread can then be relinquished until the index is completely
-  filled or index creation has failed. This also allows obsoleting the startup
-  option `--cluster.index-create-timeout`, which from now on is ignored when
-  set.
+  filled or index creation has failed. 
+  The default index creation timeout on coordinators has also been 
+  extended from 1 hour to 4 days, but it is still configurable via the
+  startup parameter `--cluster.index-create-timeout` in case this is
+  necessary.
 
 * Make `--javascript.copy-installation` also copy the `node_modules`
   subdirectory. This is required so we have a full copy of the JavaScript

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -167,9 +167,7 @@ void ClusterFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
       "amount of time (in seconds) the coordinator will wait for an index to "
       "be created before giving up",
       new DoubleParameter(&_indexCreationTimeout),
-      arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents,
-                                   arangodb::options::Flags::OnCoordinator,
-                                   arangodb::options::Flags::Hidden));
+      arangodb::options::makeFlags(arangodb::options::Flags::Hidden));
 }
 
 void ClusterFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -93,9 +93,6 @@ void ClusterFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                              "path to log directory for the cluster", true);
   options->addObsoleteOption("--cluster.arangod-path",
                              "path to the arangod for the cluster", true);
-  options->addObsoleteOption("--cluster.index-create-timeout",
-      "amount of time (in seconds) the coordinator will wait for an index to "
-      "be created before giving up", true);
 
   options->addOption(
       "--cluster.require-persisted-id",
@@ -164,6 +161,15 @@ void ClusterFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
       "active coordinator will wait for all replicas to create collection",
       new BooleanParameter(&_createWaitsForSyncReplication),
       arangodb::options::makeFlags(arangodb::options::Flags::Hidden));
+  
+  options->addOption(
+      "--cluster.index-create-timeout",
+      "amount of time (in seconds) the coordinator will wait for an index to "
+      "be created before giving up",
+      new DoubleParameter(&_indexCreationTimeout),
+      arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents,
+                                   arangodb::options::Flags::OnCoordinator,
+                                   arangodb::options::Flags::Hidden));
 }
 
 void ClusterFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {

--- a/arangod/Cluster/ClusterFeature.h
+++ b/arangod/Cluster/ClusterFeature.h
@@ -81,7 +81,7 @@ class ClusterFeature : public application_features::ApplicationFeature {
   bool forceOneShard() const { return _forceOneShard; }
   /// @brief index creation timeout in seconds. note: this used to be
   /// a configurable parameter in previous versions, but is now hard-coded.
-  double indexCreationTimeout() const noexcept { return 72.0 * 3600.0; }
+  double indexCreationTimeout() const { return _indexCreationTimeout; }
 
   std::shared_ptr<HeartbeatThread> heartbeatThread();
 
@@ -125,6 +125,8 @@ class ClusterFeature : public application_features::ApplicationFeature {
   bool _unregisterOnShutdown = false;
   bool _enableCluster = false;
   bool _requirePersistedId = false;
+  /// @brief coordinator timeout for index creation. defaults to 4 days
+  double _indexCreationTimeout = 72.0 * 3600.0;
   std::unique_ptr<ClusterInfo> _clusterInfo;
   std::shared_ptr<HeartbeatThread> _heartbeatThread;
   uint64_t _heartbeatInterval = 0;


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/14678

Reintroduce `--cluster.index-create-timeout` startup option, because we want the timeout to be configurable for arangosync testing. The option was obsoleted and the timeout was set to a hard-coded value in a recent PR. We now make it configurable again so we can set it to very small timeouts for testing.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
