### PR TITLE
fix potential issue during cluster index creation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.6.16 (XXXX-XX-XX)
 --------------------
 
+* Fix a potential multi-threading issue in index creation on coordinators,
+  when an agency callback was triggered at the same time the method
+  `ensureIndexCoordinatorInner` was left.
+
 * Preselect "create index in background" option when creating indexes in the web
   UI. The "create index in background" option can be less intrusive because it
   allows other write operations on the collection to proceed.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.6.16 (XXXX-XX-XX)
 --------------------
 
-* Fix a potential multi-threading issue in index creation on coordinators,
-  when an agency callback was triggered at the same time the method
+* Fix a potential multi-threading issue in index creation on coordinators, when
+  an agency callback was triggered at the same time the method
   `ensureIndexCoordinatorInner` was left.
 
 * Preselect "create index in background" option when creating indexes in the web

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -3235,7 +3235,7 @@ Result ClusterInfo::ensureIndexCoordinatorInner(LogicalCollection const& collect
   // This object watches whether the collection is still present in Plan
   // It assumes that the collection *is* present and only changes state
   // if the collection disappears
-  CollectionWatcher collectionWatcher(_agencyCallbackRegistry, collection);
+  auto collectionWatcher = std::make_shared<CollectionWatcher>(_agencyCallbackRegistry, collection);
 
   if (!result.successful()) {
     if (result.httpCode() == (int)arangodb::rest::ResponseCode::PRECONDITION_FAILED) {
@@ -3341,7 +3341,7 @@ Result ClusterInfo::ensureIndexCoordinatorInner(LogicalCollection const& collect
 
         loadPlan();
 
-        if (!collectionWatcher.isPresent()) {
+        if (!collectionWatcher->isPresent()) {
           return Result(TRI_ERROR_ARANGO_INDEX_CREATION_FAILED,
                         "Collection " + collectionID +
                             " has gone from database " + databaseName +
@@ -3423,7 +3423,7 @@ Result ClusterInfo::ensureIndexCoordinatorInner(LogicalCollection const& collect
         // when we wanted to roll back the index creation.
       }
 
-      if (!collectionWatcher.isPresent()) {
+      if (!collectionWatcher->isPresent()) {
         return Result(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
                       "collection " + collectionID +
                           " appears to have been dropped from database " +
@@ -4906,7 +4906,7 @@ VPackSlice PlanCollectionReader::indexes() {
 
 CollectionWatcher::~CollectionWatcher() {
   _agencyCallbackRegistry->unregisterCallback(_agencyCallback);
-};
+}
 
 // -----------------------------------------------------------------------------
 // --SECTION--                                                       END-OF-FILE


### PR DESCRIPTION
### Scope & Purpose

Fix a potential multi-threading issue in index creation on coordinators, when an agency callback was triggered at the same time the method `ensureIndexCoordinatorInner` was left.

Found this randomly by checking the results of another Jenkins job:
https://jenkins.arangodb.biz/job/arangodb-matrix-pr-linux/17920/EDITION=community,STORAGE_ENGINE=mmfiles,TEST_SUITE=cluster,limit=linux&&(test%7C%7Cbuild)%7C%7Cgce/artifact/testfailures.txt

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
