### PR TITLE
fix potential issue during cluster index creation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.8.1 (XXXX-XX-XX)
 -------------------
 
-* Fix a potential multi-threading issue in index creation on coordinators,
-  when an agency callback was triggered at the same time the method
+* Fix a potential multi-threading issue in index creation on coordinators, when
+  an agency callback was triggered at the same time the method
   `ensureIndexCoordinatorInner` was left.
 
 * Append physical compaction of log collection to every Raft log compaction

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.8.1 (XXXX-XX-XX)
 -------------------
 
+* Fix a potential multi-threading issue in index creation on coordinators,
+  when an agency callback was triggered at the same time the method
+  `ensureIndexCoordinatorInner` was left.
+
 * Append physical compaction of log collection to every Raft log compaction
   (BTS-542).
 

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -6087,7 +6087,7 @@ CollectionWatcher::CollectionWatcher(AgencyCallbackRegistry* agencyCallbackRegis
       [self = weak_from_this()](VPackSlice const& result) {
         auto watcher = self.lock();
         if (result.isNone() && watcher) {
-          _present.store(false);
+          watcher->_present.store(false);
         }
         return true;
       },

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -66,7 +66,7 @@ struct ClusterCollectionCreationInfo;
 // make sure a collection is still in Plan
 // we are only going from *assuming* that it is present
 // to it being changed to not present.
-class CollectionWatcher {
+class CollectionWatcher : public std::enable_shared_from_this<CollectionWatcher> {
  public:
   CollectionWatcher(CollectionWatcher const&) = delete;
   CollectionWatcher(AgencyCallbackRegistry* agencyCallbackRegistry, LogicalCollection const& collection);


### PR DESCRIPTION
### Scope & Purpose

Fix a potential multi-threading issue in index creation on coordinators, when an agency callback was triggered at the same time the method `ensureIndexCoordinatorInner` was left.

Found this randomly by checking the results of another Jenkins job:
https://jenkins.arangodb.biz/job/arangodb-matrix-pr-linux/17920/EDITION=community,STORAGE_ENGINE=mmfiles,TEST_SUITE=cluster,limit=linux&&(test%7C%7Cbuild)%7C%7Cgce/artifact/testfailures.txt

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for 3.6: https://github.com/arangodb/arangodb/pull/14689, 3.7: https://github.com/arangodb/arangodb/pull/14690

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
