### PR TITLE
fix potential issue during cluster index creation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fix a potential multi-threading issue in index creation on coordinators,
+  when an agency callback was triggered at the same time the method
+  `ensureIndexCoordinatorInner` was left.
+
 * Add pseudo log topic "all" to set the log levels for all log topics at
   once. For example, this can be used when starting a server with trace or
   debug logging enabled for all log topics, e.g.

--- a/Documentation/Metrics/rocksdb_read_only.yaml
+++ b/Documentation/Metrics/rocksdb_read_only.yaml
@@ -1,7 +1,7 @@
 name: rocksdb_read_only
 introducedIn: "3.8.1"
 help: |
-  RocksDB metric "background-errors"
+  RocksDB metric "background-errors".
 unit: number
 type: gauge
 category: RocksDB

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -6167,7 +6167,7 @@ CollectionWatcher::CollectionWatcher(AgencyCallbackRegistry* agencyCallbackRegis
       [self = weak_from_this()](VPackSlice const& result) {
         auto watcher = self.lock();
         if (result.isNone() && watcher) {
-          _present.store(false);
+          watcher->_present.store(false);
         }
         return true;
       },

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -4336,7 +4336,7 @@ Result ClusterInfo::ensureIndexCoordinatorInner(LogicalCollection const& collect
   // This object watches whether the collection is still present in Plan
   // It assumes that the collection *is* present and only changes state
   // if the collection disappears
-  CollectionWatcher collectionWatcher(_agencyCallbackRegistry, collection);
+  auto collectionWatcher = std::make_shared<CollectionWatcher>(_agencyCallbackRegistry, collection);
 
   if (!result.successful()) {
     if (result.httpCode() == rest::ResponseCode::PRECONDITION_FAILED) {
@@ -4437,7 +4437,7 @@ Result ClusterInfo::ensureIndexCoordinatorInner(LogicalCollection const& collect
           }
         }
 
-        if (!collectionWatcher.isPresent()) {
+        if (!collectionWatcher->isPresent()) {
           return Result(TRI_ERROR_ARANGO_INDEX_CREATION_FAILED,
                         "Collection " + collectionID +
                             " has gone from database " + databaseName +
@@ -4524,7 +4524,7 @@ Result ClusterInfo::ensureIndexCoordinatorInner(LogicalCollection const& collect
         // when we wanted to roll back the index creation.
       }
 
-      if (!collectionWatcher.isPresent()) {
+      if (!collectionWatcher->isPresent()) {
         return Result(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
                       "collection " + collectionID +
                           "appears to have been dropped from database " +
@@ -6164,8 +6164,9 @@ CollectionWatcher::CollectionWatcher(AgencyCallbackRegistry* agencyCallbackRegis
 
   _agencyCallback = std::make_shared<AgencyCallback>(
       collection.vocbase().server(), where,
-      [this](VPackSlice const& result) {
-        if (result.isNone()) {
+      [self = weak_from_this()](VPackSlice const& result) {
+        auto watcher = self.lock();
+        if (result.isNone() && watcher) {
           _present.store(false);
         }
         return true;

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -72,7 +72,7 @@ struct ClusterCollectionCreationInfo;
 // make sure a collection is still in Plan
 // we are only going from *assuming* that it is present
 // to it being changed to not present.
-class CollectionWatcher {
+class CollectionWatcher : public std::enable_shared_from_this<CollectionWatcher> {
  public:
   CollectionWatcher(CollectionWatcher const&) = delete;
   CollectionWatcher(AgencyCallbackRegistry* agencyCallbackRegistry, LogicalCollection const& collection);


### PR DESCRIPTION
### Scope & Purpose

Fix a potential multi-threading issue in index creation on coordinators, when an agency callback was triggered at the same time the method `ensureIndexCoordinatorInner` was left.

Found this randomly by checking the results of another Jenkins job:
https://jenkins.arangodb.biz/job/arangodb-matrix-pr-linux/17920/EDITION=community,STORAGE_ENGINE=mmfiles,TEST_SUITE=cluster,limit=linux&&(test%7C%7Cbuild)%7C%7Cgce/artifact/testfailures.txt

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for 3.6: https://github.com/arangodb/arangodb/pull/14689, 3.7: https://github.com/arangodb/arangodb/pull/14690, 3.8: https://github.com/arangodb/arangodb/pull/14691

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
