### PR TITLE
Protocol specific metrics

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.8.1 (XXXX-XX-XX)
 -------------------
 
+* Added protocol specific metrics: histogram about request body size, total
+  number of HTTP/2 connections and total number of VST connections.
+
 * Append physical compaction of log collection to every Raft log compaction
   (BTS-542).
 

--- a/Documentation/Metrics/arangodb_http2_connections_total.yaml
+++ b/Documentation/Metrics/arangodb_http2_connections_total.yaml
@@ -1,0 +1,17 @@
+name: arangodb_http2_connections_total
+introducedIn: "3.7.15"
+help: |
+  Total number of HTTP/2 connections accepted.
+unit: number
+type: counter
+category: Connectivity
+complexity: medium
+exposedBy:
+  - coordinator
+  - dbserver
+  - agent
+  - single
+description: |
+  Total number of connections accepted for HTTP/2, this can be upgraded
+  connections from HTTP/1.1 or connections negotiated to be HTTP/2 during
+  the TLS handshake.

--- a/Documentation/Metrics/arangodb_request_body_size_http1.yaml
+++ b/Documentation/Metrics/arangodb_request_body_size_http1.yaml
@@ -1,0 +1,16 @@
+name: arangodb_request_body_size_http1
+introducedIn: "3.7.15"
+help: |
+  Body size in bytes for HTTP/1.1 requests.
+unit: bytes
+type: histogram
+category: Statistics
+complexity: medium
+exposedBy:
+  - coordinator
+  - dbserver
+  - agent
+  - single
+description: |
+  Histogram of the body sizes of the received HTTP/1.1 requests in bytes.
+  Note that this does not account for the header.

--- a/Documentation/Metrics/arangodb_request_body_size_http2.yaml
+++ b/Documentation/Metrics/arangodb_request_body_size_http2.yaml
@@ -1,0 +1,16 @@
+name: arangodb_request_body_size_http2
+introducedIn: "3.7.15"
+help: |
+  Body size in bytes for HTTP/2 requests.
+unit: bytes
+type: histogram
+category: Statistics
+complexity: medium
+exposedBy:
+  - coordinator
+  - dbserver
+  - agent
+  - single
+description: |
+  Histogram of the body sizes of the received HTTP/2 requests in bytes.
+  Note that this does not account for the header.

--- a/Documentation/Metrics/arangodb_request_body_size_vst.yaml
+++ b/Documentation/Metrics/arangodb_request_body_size_vst.yaml
@@ -1,0 +1,16 @@
+name: arangodb_request_body_size_vst
+introducedIn: "3.7.15"
+help: |
+  Body size in bytes for VST requests.
+unit: bytes
+type: histogram
+category: Statistics
+complexity: medium
+exposedBy:
+  - coordinator
+  - dbserver
+  - agent
+  - single
+description: |
+  Histogram of the body sizes of the received VST requests in bytes.
+  Note that this does include the binary header.

--- a/Documentation/Metrics/arangodb_vst_connections_total.yaml
+++ b/Documentation/Metrics/arangodb_vst_connections_total.yaml
@@ -1,0 +1,16 @@
+name: arangodb_vst_connections_total
+introducedIn: "3.7.15"
+help: |
+  Total number of VST connections accepted.
+unit: number
+type: counter
+category: Connectivity
+complexity: medium
+exposedBy:
+  - coordinator
+  - dbserver
+  - agent
+  - single
+description: |
+  Total number of connections accepted for VST, this are upgraded
+  connections from HTTP/1.1.

--- a/arangod/GeneralServer/GeneralCommTask.h
+++ b/arangod/GeneralServer/GeneralCommTask.h
@@ -66,7 +66,7 @@ class GeneralCommTask : public CommTask {
     
   std::unique_ptr<AsioSocket<T>> _protocol;
           
-  GeneralServerFeature const& _generalServerFeature;
+  GeneralServerFeature& _generalServerFeature;
   
   bool _reading;
   bool _writing;

--- a/arangod/GeneralServer/GeneralServerFeature.cpp
+++ b/arangod/GeneralServer/GeneralServerFeature.cpp
@@ -121,13 +121,38 @@ namespace arangodb {
 
 static uint64_t const _maxIoThreads = 64;
 
+struct RequestBodySizeScale {
+  static log_scale_t<uint64_t> scale() { return { 2, 64, 65536, 10 }; }
+};
+
+DECLARE_HISTOGRAM(arangodb_request_body_size_http1, RequestBodySizeScale,
+    "Body size of HTTP/1.1 requests");
+DECLARE_HISTOGRAM(arangodb_request_body_size_http2, RequestBodySizeScale,
+    "Body size of HTTP/2 requests");
+DECLARE_HISTOGRAM(arangodb_request_body_size_vst, RequestBodySizeScale,
+    "Body size of VST requests");
+DECLARE_COUNTER(arangodb_http2_connections_total,
+    "Total number of HTTP/2 connections");
+DECLARE_COUNTER(arangodb_vst_connections_total,
+    "Total number of VST connections");
+
 GeneralServerFeature::GeneralServerFeature(application_features::ApplicationServer& server)
     : ApplicationFeature(server, "GeneralServer"),
       _allowMethodOverride(false),
       _proxyCheck(true),
       _permanentRootRedirect(true),
       _redirectRootTo("/_admin/aardvark/index.html"),
-      _numIoThreads(0) {
+      _numIoThreads(0),
+      _requestBodySizeHttp1(
+          server.getFeature<MetricsFeature>().add(arangodb_request_body_size_http1{})),
+      _requestBodySizeHttp2(
+          server.getFeature<MetricsFeature>().add(arangodb_request_body_size_http2{})),
+      _requestBodySizeVst(
+          server.getFeature<MetricsFeature>().add(arangodb_request_body_size_vst{})),
+      _http2Connections(
+          server.getFeature<MetricsFeature>().add(arangodb_http2_connections_total{})),
+      _vstConnections(
+          server.getFeature<MetricsFeature>().add(arangodb_vst_connections_total{})) {
   setOptional(true);
   startsAfter<application_features::AqlFeaturePhase>();
 

--- a/arangod/GeneralServer/GeneralServerFeature.h
+++ b/arangod/GeneralServer/GeneralServerFeature.h
@@ -28,6 +28,7 @@
 #include "GeneralServer/AsyncJobManager.h"
 #include "GeneralServer/GeneralServer.h"
 #include "GeneralServer/RestHandlerFactory.h"
+#include "RestServer/Metrics.h"
 
 namespace arangodb {
 class RestServerThread;
@@ -57,6 +58,26 @@ class GeneralServerFeature final : public application_features::ApplicationFeatu
   rest::RestHandlerFactory& handlerFactory();
   rest::AsyncJobManager& jobManager();
 
+  void countHttp1Request(uint64_t bodySize) {
+    _requestBodySizeHttp1.count(bodySize);
+  }
+
+  void countHttp2Request(uint64_t bodySize) {
+    _requestBodySizeHttp2.count(bodySize);
+  }
+
+  void countVstRequest(uint64_t bodySize) {
+    _requestBodySizeVst.count(bodySize);
+  }
+
+  void countHttp2Connection() {
+    _http2Connections.count();
+  }
+
+  void countVstConnection() {
+    _vstConnections.count();
+  }
+
  private:
 
   void buildServers();
@@ -74,6 +95,13 @@ class GeneralServerFeature final : public application_features::ApplicationFeatu
   std::unique_ptr<rest::AsyncJobManager> _jobManager;
   std::vector<std::unique_ptr<rest::GeneralServer>> _servers;
   uint64_t _numIoThreads;
+
+  // Some metrics about
+  Histogram<log_scale_t<uint64_t>>& _requestBodySizeHttp1;
+  Histogram<log_scale_t<uint64_t>>& _requestBodySizeHttp2;
+  Histogram<log_scale_t<uint64_t>>& _requestBodySizeVst;
+  Counter& _http2Connections;
+  Counter& _vstConnections;
 };
 
 }  // namespace arangodb

--- a/arangod/GeneralServer/H2CommTask.cpp
+++ b/arangod/GeneralServer/H2CommTask.cpp
@@ -209,6 +209,7 @@ H2CommTask<T>::H2CommTask(GeneralServer& server, ConnectionInfo info,
                           std::unique_ptr<AsioSocket<T>> so)
     : GeneralCommTask<T>(server, std::move(info), std::move(so)) {
   this->_connectionStatistics.SET_HTTP();
+  this->_generalServerFeature.countHttp2Connection();
   initNgHttp2Session();
 }
 
@@ -493,6 +494,7 @@ void H2CommTask<T>::processStream(H2CommTask<T>::Stream& stream) {
         << HttpRequest::translateMethod(req->requestType()) << "\",\"" << url(req.get()) << "\"";
 
     VPackStringRef body = req->rawPayload();
+    this->_generalServerFeature.countHttp2Request(body.size());
     if (!body.empty() && Logger::isEnabled(LogLevel::TRACE, Logger::REQUESTS) &&
         Logger::logRequestParameters()) {
       LOG_TOPIC("b6dc3", TRACE, Logger::REQUESTS)

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -446,6 +446,7 @@ void HttpCommTask<T>::processRequest() {
         << HttpRequest::translateMethod(_request->requestType()) << "\",\"" << url() << "\"";
 
     VPackStringRef body = _request->rawPayload();
+    this->_generalServerFeature.countHttp1Request(body.size());
     if (!body.empty() && Logger::isEnabled(LogLevel::TRACE, Logger::REQUESTS) &&
         Logger::logRequestParameters()) {
       LOG_TOPIC("b9e76", TRACE, Logger::REQUESTS)

--- a/arangod/GeneralServer/VstCommTask.cpp
+++ b/arangod/GeneralServer/VstCommTask.cpp
@@ -65,6 +65,7 @@ VstCommTask<T>::VstCommTask(GeneralServer& server, ConnectionInfo info,
   // arbitrary initial reserve value to save a few memory allocations
   // in the most common cases.
   _writeQueue.reserve(32);
+  this->_generalServerFeature.countVstConnection();
 }
 
 template <SocketType T>
@@ -275,6 +276,8 @@ void VstCommTask<T>::processMessage(velocypack::Buffer<uint8_t> buffer, uint64_t
   RequestStatistics::Item const& stat = this->statistics(messageId);
   stat.SET_READ_END();
   stat.ADD_RECEIVED_BYTES(buffer.size());
+
+  this->_generalServerFeature.countVstRequest(buffer.size());
 
   // handle request types
   if (mt == fu::MessageType::Authentication) {  // auth

--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -775,7 +775,7 @@ function getMemProfSnapshot(instanceInfo, options, counter) {
       }
 
       let fnMetrics = fs.join(arangod.rootDir, `${arangod.role}_${arangod.pid}_${counter}_.metrics`);
-      let metricsReply = download(arangod.url + '/_admin/metrics', opts);
+      let metricsReply = download(arangod.url + '/_admin/metrics/v2', opts);
       if (metricsReply.code === 200) {
         fs.write(fnMetrics, metricsReply.body);
         print(CYAN + Date() + ` Saved ${fnMetrics}` + RESET);

--- a/js/server/modules/@arangodb/test-helper.js
+++ b/js/server/modules/@arangodb/test-helper.js
@@ -113,7 +113,7 @@ exports.getChecksum = function (endpoint, name) {
 exports.getMetric = function (endpoint, name) {
 
   let res = request.get({
-    url: endpoint + '/_admin/metrics',
+    url: endpoint + '/_admin/metrics/v2',
   });
   let re = new RegExp("^" + name);
   let matches = res.body.split('\n').filter((line) => !line.match(/^#/)).filter((line) => line.match(re));

--- a/tests/js/client/communication/test-communication.js
+++ b/tests/js/client/communication/test-communication.js
@@ -43,7 +43,7 @@ let { debugCanUseFailAt,
     } = require('@arangodb/test-helper');
 
 const getMetric = (name) => {
-  let res = arango.GET_RAW("/_admin/metrics");
+  let res = arango.GET_RAW("/_admin/metrics/v2");
   let re = new RegExp("^" + name + "({[^}]*})?");
   let matches = res.body.split('\n').filter((line) => !line.match(/^#/)).filter((line) => line.match(re));
   if (!matches.length) {

--- a/tests/js/client/server_parameters/test-export-document-metrics-off-noncluster.js
+++ b/tests/js/client/server_parameters/test-export-document-metrics-off-noncluster.js
@@ -37,7 +37,7 @@ const jsunity = require('jsunity');
 function testSuite() {
   return {
     testMetricsUnavailable : function() {
-      let res = arango.GET_RAW(`/_admin/metrics`);
+      let res = arango.GET_RAW(`/_admin/metrics/v2`);
 
       let lines = res.body.split(/\n/);
       assertEqual(0, lines.filter((line) => line.match(/^arangodb_document_read_time/) ).length);

--- a/tests/js/client/server_parameters/test-export-document-metrics-on-noncluster.js
+++ b/tests/js/client/server_parameters/test-export-document-metrics-on-noncluster.js
@@ -36,7 +36,7 @@ const jsunity = require('jsunity');
 
 function testSuite() {
   let getMetrics = function() {
-    let res = arango.GET_RAW(`/_admin/metrics`);
+    let res = arango.GET_RAW(`/_admin/metrics/v2`);
     let lines = res.body.split(/\n/);
     return lines;
   };

--- a/tests/js/client/shell/shell-check-metrics-move-noncluster.js
+++ b/tests/js/client/shell/shell-check-metrics-move-noncluster.js
@@ -95,14 +95,12 @@ function checkMetricsMoveSuite() {
     testConnectionCountByProtocol: function () {
       let http2ConnCount = getMetric("arangodb_http2_connections_total");
       let vstConnCount = getMetric("arangodb_vst_connections_total");
-      let allConnCount = getMetric("arangodb_client_connection_statistics_connection_time_count");
       // I have not found a reliable way to trigger a new connection from
       // `arangosh`. `arango.reconnect` does not work since it is caching
       // connections and the request timeout is not honoured for HTTP/2
       // and VST by fuerte. The idle timeout runs into an assertion failure.
       // Therefore, we must be content here to check that the connection
       // count is non-zero for the currently underlying protocol:
-      //assertNotEqual(0, allConnCount);
       if (arango.protocol() === "http2") {
         assertNotEqual(0, http2ConnCount);
       } else if (arango.protocol() === "vst") {

--- a/tests/js/client/shell/shell-check-metrics-move-noncluster.js
+++ b/tests/js/client/shell/shell-check-metrics-move-noncluster.js
@@ -42,6 +42,10 @@ function checkMetricsMoveSuite() {
   return {
     
     testByProtocol: function () {
+      // Note that this test is "-noncluster", since in the cluster
+      // all sorts of requests constantly arrive and we can never be
+      // sure that nothing happens. In a single server, this is OK,
+      // only our own requests should arrive at the server.
       let http1ReqCount = getMetric("arangodb_request_body_size_http1_count");
       let http1ReqSum = getMetric("arangodb_request_body_size_http1_sum");
       let http2ReqCount = getMetric("arangodb_request_body_size_http2_count");

--- a/tests/js/client/shell/shell-check-metrics-move-noncluster.js
+++ b/tests/js/client/shell/shell-check-metrics-move-noncluster.js
@@ -1,0 +1,112 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global assertEqual, assertTrue, assertNotEqual, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2021 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / @author Max Neunhoeffer
+// //////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require('jsunity');
+
+function getMetric(name) {
+  let res = arango.GET_RAW( '/_admin/metrics/v2');
+  if (res.code !== 200) {
+    throw "error fetching metric";
+  }
+  let re = new RegExp("^" + name);
+  let matches = res.body.split('\n').filter((line) => !line.match(/^#/)).filter((line) => line.match(re));
+  if (!matches.length) {
+    throw "Metric " + name + " not found";
+  }
+  return Number(matches[0].replace(/^.* (\d+)$/, '$1'));
+}
+
+function checkMetricsMoveSuite() {
+  'use strict';
+
+  return {
+    
+    testByProtocol: function () {
+      let http1ReqCount = getMetric("arangodb_request_body_size_http1_count");
+      let http1ReqSum = getMetric("arangodb_request_body_size_http1_sum");
+      let http2ReqCount = getMetric("arangodb_request_body_size_http2_count");
+      let http2ReqSum = getMetric("arangodb_request_body_size_http2_sum");
+      let vstReqCount = getMetric("arangodb_request_body_size_vst_count");
+      let vstReqSum = getMetric("arangodb_request_body_size_vst_sum");
+      // Do a few requests:
+      for (let i = 0; i < 10; ++i) {
+        let res = arango.GET_RAW("/_api/version");
+        assertEqual(200, res.code);
+      }
+      // Note that GET requests do not have bodies, so they do not move
+      // the sum of the histogram. So let's do a PUT just for good measure:
+      let logging = arango.GET("/_admin/log/level");
+      let res = arango.PUT_RAW("/_admin/log/level", logging);
+      assertEqual(200, res.code);
+      // And get the values again:
+      let http1ReqCount2 = getMetric("arangodb_request_body_size_http1_count");
+      let http1ReqSum2 = getMetric("arangodb_request_body_size_http1_sum");
+      let http2ReqCount2 = getMetric("arangodb_request_body_size_http2_count");
+      let http2ReqSum2 = getMetric("arangodb_request_body_size_http2_sum");
+      let vstReqCount2 = getMetric("arangodb_request_body_size_vst_count");
+      let vstReqSum2 = getMetric("arangodb_request_body_size_vst_sum");
+      if (arango.protocol() === "vst") {
+        assertNotEqual(vstReqCount, vstReqCount2);
+        assertNotEqual(vstReqSum, vstReqSum2);
+      } else {
+        assertEqual(vstReqCount, vstReqCount2);
+        assertEqual(vstReqSum, vstReqSum2);
+      }
+      if (arango.protocol() === "http") {
+        assertNotEqual(http1ReqCount, http1ReqCount2);
+        assertNotEqual(http1ReqSum, http1ReqSum2);
+      } else {
+        assertEqual(http1ReqCount, http1ReqCount2);
+        assertEqual(http1ReqSum, http1ReqSum2);
+      }
+      if (arango.protocol() === "http2") {
+        assertNotEqual(http2ReqCount, http2ReqCount2);
+        assertNotEqual(http2ReqSum, http2ReqSum2);
+      } else {
+        assertEqual(http2ReqCount, http2ReqCount2);
+        assertEqual(http2ReqSum, http2ReqSum2);
+      }
+    },
+
+    testConnectionCountByProtocol: function () {
+      let http2ConnCount = getMetric("arangodb_http2_connections_total");
+      let vstConnCount = getMetric("arangodb_vst_connections_total");
+      let allConnCount = getMetric("arangodb_client_connection_statistics_connection_time_count");
+      // I have not found a reliable way to trigger a new connection from
+      // `arangosh`. `arango.reconnect` does not work since it is caching
+      // connections and the request timeout is not honoured for HTTP/2
+      // and VST by fuerte. The idle timeout runs into an assertion failure.
+      // Therefore, we must be content here to check that the connection
+      // count is non-zero for the currently underlying protocol:
+      //assertNotEqual(0, allConnCount);
+      if (arango.protocol() === "http2") {
+        assertNotEqual(0, http2ConnCount);
+      } else if (arango.protocol() === "vst") {
+        assertNotEqual(0, vstConnCount);
+      }
+    },
+  };
+}
+
+jsunity.run(checkMetricsMoveSuite);
+return jsunity.done();

--- a/tests/js/client/shell/shell-process-metrics-cluster.js
+++ b/tests/js/client/shell/shell-process-metrics-cluster.js
@@ -49,7 +49,7 @@ function getEndpointsByType(type) {
 
 function getMetric(endpoint, name) {
   let res = request.get({
-    url: endpoint + '/_admin/metrics',
+    url: endpoint + '/_admin/metrics/v2',
   });
   let re = new RegExp("^" + name);
   let matches = res.body.split('\n').filter((line) => !line.match(/^#/)).filter((line) => line.match(re));


### PR DESCRIPTION
Add protocol specific metrics.

This adds histograms about the body sizes of requests, distinguishing
HTTP/2, VST and HTTP/1.1 requests.

Also: Adds metrics about total number of accepted HTTP/2 and VST
connections.

Also: Switches metrics tests to /_admin/metrics/v2 in more tests.
Scope & Purpose

(Please describe the changes in this PR for reviewers - mandatory)

    [*] New feature (requires CHANGELOG entry, feature documentation and release notes)

Backports:

    [*] This is the backport for 3.8

Testing & Verification

(Please pick either of the following options)

    [*] The behavior in this PR was manually tested
    [*] There are new JS tests to test the metrics.

Documentation

    All new features should be accompanied by corresponding documentation.
    Bugs and features should furthermore be documented in the CHANGELOG so that
    support, end users, and other developers have a concise overview.

    [*] Added a new section in the Manual (metrics, auto-generated)

