### PR TITLE
add a test for disabled statistics

### DIFF
--- a/arangod/RestServer/MetricsFeature.cpp
+++ b/arangod/RestServer/MetricsFeature.cpp
@@ -454,7 +454,6 @@ void MetricsFeature::validateOptions(std::shared_ptr<ProgramOptions>) {
 }
 
 void MetricsFeature::toPrometheus(std::string& result, bool v2) const {
-
   // minimize reallocs
   result.reserve(32768);
 

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -562,12 +562,13 @@ void StatisticsFeature::collectOptions(std::shared_ptr<ProgramOptions> options) 
   options->addOldOption("server.disable-statistics", "server.statistics");
 
   options->addOption("--server.statistics",
-                     "turn statistics gathering on or off",
+                     "turn statistics gathering and APIs on or off",
                      new BooleanParameter(&_statistics));
 
   options->addOption("--server.statistics-history",
                      "turn storing statistics in database on or off",
-                     new BooleanParameter(&_statisticsHistory))
+                     new BooleanParameter(&_statisticsHistory),
+                     arangodb::options::makeDefaultFlags(arangodb::options::Flags::Dynamic))
                      .setIntroducedIn(30409)
                      .setIntroducedIn(30501);
 
@@ -633,9 +634,9 @@ void StatisticsFeature::start() {
     _statisticsHistory = false;
   }
 
-  _statisticsWorker = std::make_unique<StatisticsWorker>(*vocbase);
-
   if (_statisticsHistory) {
+    _statisticsWorker = std::make_unique<StatisticsWorker>(*vocbase);
+
     if (!_statisticsWorker->start()) {
       LOG_TOPIC("6ecdc", FATAL, arangodb::Logger::STATISTICS)
         << "could not start statistics worker";
@@ -653,7 +654,7 @@ void StatisticsFeature::stop() {
     }
   }
 
-  if (_statisticsHistory && _statisticsWorker != nullptr) {
+  if (_statisticsWorker != nullptr) {
     _statisticsWorker->beginShutdown();
 
     while (_statisticsWorker->isRunning()) {
@@ -783,18 +784,18 @@ void StatisticsFeature::toPrometheus(std::string& result, double const& now, boo
     // _clientStatistics()
     appendMetric(result, std::to_string(connectionStats.httpConnections.get()), "clientHttpConnections", v2);
     appendHistogram(result, connectionStats.connectionTime, "connectionTime", {"0.01", "1.0", "60.0", "+Inf"}, v2);
-  appendHistogram(result, requestStats.totalTime, "totalTime",
-                  {"0.01", "0.05", "0.1", "0.2", "0.5", "1.0", "5.0", "15.0",
-                   "30.0", "+Inf"}, v2);
-  appendHistogram(result, requestStats.requestTime, "requestTime",
-                  {"0.01", "0.05", "0.1", "0.2", "0.5", "1.0", "5.0", "15.0",
-                   "30.0", "+Inf"}, v2);
-  appendHistogram(result, requestStats.queueTime, "queueTime",
-                  {"0.01", "0.05", "0.1", "0.2", "0.5", "1.0", "5.0", "15.0",
-                   "30.0", "+Inf"}, v2);
-  appendHistogram(result, requestStats.ioTime, "ioTime",
-                  {"0.01", "0.05", "0.1", "0.2", "0.5", "1.0", "5.0", "15.0",
-                   "30.0", "+Inf"}, v2);
+    appendHistogram(result, requestStats.totalTime, "totalTime",
+                    {"0.01", "0.05", "0.1", "0.2", "0.5", "1.0", "5.0", "15.0",
+                     "30.0", "+Inf"}, v2);
+    appendHistogram(result, requestStats.requestTime, "requestTime",
+                    {"0.01", "0.05", "0.1", "0.2", "0.5", "1.0", "5.0", "15.0",
+                     "30.0", "+Inf"}, v2);
+    appendHistogram(result, requestStats.queueTime, "queueTime",
+                    {"0.01", "0.05", "0.1", "0.2", "0.5", "1.0", "5.0", "15.0",
+                     "30.0", "+Inf"}, v2);
+    appendHistogram(result, requestStats.ioTime, "ioTime",
+                    {"0.01", "0.05", "0.1", "0.2", "0.5", "1.0", "5.0", "15.0",
+                     "30.0", "+Inf"}, v2);
     appendHistogram(result, requestStats.bytesSent, "bytesSent", {"250", "1000", "2000", "5000", "10000", "+Inf"}, v2);
     appendHistogram(result, requestStats.bytesReceived, "bytesReceived", {"250", "1000", "2000", "5000", "10000", "+Inf"}, v2);
 

--- a/tests/js/client/server_parameters/test-statistics-enabled-false.js
+++ b/tests/js/client/server_parameters/test-statistics-enabled-false.js
@@ -1,0 +1,88 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertTrue, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for security-related server options
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'server.statistics': "false",
+    'server.export-metrics-api': "true",
+  };
+}
+
+const jsunity = require('jsunity');
+
+function testSuite() {
+  return {
+    testGetAdminStatistics : function() {
+      let res = arango.GET("/_admin/statistics");
+      assertTrue(res.error);
+      assertEqual(404, res.code);
+    },
+    
+    testGetAdminStatisticsDescription : function() {
+      let res = arango.GET("/_admin/statistics-description");
+      assertTrue(res.error);
+      assertEqual(404, res.code);
+    },
+    
+    testGetMetrics : function() {
+      let metrics = {};
+      String(arango.GET("/_admin/metrics"))
+        .split("\n")
+        .filter((line) => line.match(/^[^#]/))
+        .filter((line) => line.match(/^arangodb_/))
+        .forEach((line) => {
+          let name = line.replace(/[ \{].*$/g, '');
+          let value = Number(line.replace(/^.+ (\d+)$/, '$1'));
+          metrics[name] = value;
+        });
+
+      const expected = [
+        "arangodb_process_statistics_minor_page_faults",
+        "arangodb_process_statistics_major_page_faults",
+        "arangodb_process_statistics_user_time",
+        "arangodb_process_statistics_system_time",
+        "arangodb_process_statistics_number_of_threads",
+        "arangodb_process_statistics_resident_set_size",
+        "arangodb_process_statistics_resident_set_size_percent",
+        "arangodb_process_statistics_virtual_memory_size",
+        "arangodb_server_statistics_physical_memory",
+        "arangodb_server_statistics_server_uptime",
+      ];
+
+      expected.forEach((name) => {
+        assertTrue(metrics.hasOwnProperty(name));
+        assertEqual("number", typeof metrics[name]);
+      });
+    },
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Adds a test to devel that is introduced to 3.7 via #14702.
In addition, does a micro cleanup in the StatisticsFeature.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (server_parameters)
