### PR TITLE
workaround for assertion failure

### DIFF
--- a/arangod/RocksDBEngine/RocksDBWalAccess.cpp
+++ b/arangod/RocksDBEngine/RocksDBWalAccess.cpp
@@ -777,6 +777,95 @@ class MyWALDumper final : public rocksdb::WriteBatch::Handler, public WalAccessC
 #endif
 };
 
+/// @brief helper function to print WAL contents. this is only used for
+/// debugging
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+void RocksDBWalAccess::printWal(Filter const& filter, size_t chunkSize, 
+                                MarkerCallback const& func) const {
+  rocksdb::TransactionDB* db = _engine.db();
+
+  if (chunkSize < 16384) {  // we need to have some sensible minimum
+    chunkSize = 16384;
+  }
+
+  // pre 3.4 breaking up write batches is not supported
+  size_t maxTrxChunkSize = filter.tickLastScanned > 0 ? chunkSize : SIZE_MAX;
+
+  MyWALDumper dumper(_engine, filter, func, maxTrxChunkSize);
+  const uint64_t since = dumper.safeBeginTick();
+  TRI_ASSERT(since <= filter.tickStart);
+  TRI_ASSERT(since <= filter.tickEnd);
+
+  uint64_t firstTick = UINT64_MAX;   // first tick to actually print (exclusive)
+  uint64_t lastScannedTick = since;  // last (begin) tick of batch we looked at
+  uint64_t latestTick = db->GetLatestSequenceNumber();
+
+  std::unique_ptr<rocksdb::TransactionLogIterator> iterator;  
+  rocksdb::TransactionLogIterator::ReadOptions ro(false);
+  rocksdb::Status s = db->GetUpdatesSince(since, &iterator, ro);
+  TRI_ASSERT(s.ok());
+
+  // we need to check if the builder is bigger than the chunksize,
+  // only after we printed a full WriteBatch. Otherwise a client might
+  // never read the full writebatch
+  LOG_TOPIC("caefa", WARN, Logger::ENGINES)
+      << "WAL tailing call. Scan since: " << since << ", tick start: " << filter.tickStart
+      << ", tick end: " << filter.tickEnd << ", chunk size: " << chunkSize << ", latesttick: " << latestTick;
+  while (iterator->Valid() && lastScannedTick <= filter.tickEnd) {
+    rocksdb::BatchResult batch = iterator->GetBatch();
+    // record the first tick we are actually considering
+    if (firstTick == UINT64_MAX) {
+      firstTick = batch.sequence;
+    }
+
+    if (batch.sequence > filter.tickEnd) {
+      break;  // cancel out
+    }
+
+    LOG_TOPIC("a9d9c", WARN, Logger::REPLICATION) 
+        << "found batch-seq: " << batch.sequence << ", count: " 
+        << batch.writeBatchPtr->Count() 
+        << ", last scanned: " << lastScannedTick;
+    lastScannedTick = batch.sequence;  // start of the batch
+    TRI_ASSERT(lastScannedTick <= db->GetLatestSequenceNumber());
+
+    if (batch.sequence < since) {
+      iterator->Next();  // skip
+      continue;
+    }
+
+    dumper.startNewBatch(batch.sequence);
+    s = batch.writeBatchPtr->Iterate(&dumper);
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    if (batch.writeBatchPtr->Count() == 0) {
+      // there can be completely empty write batches. in case we encounter
+      // some, we cannot assume the tick gets increased next time
+      dumper.disableTickCheck();
+    }
+#endif
+    TRI_ASSERT(s.ok());
+
+    uint64_t batchEndSeq = dumper.endBatch();        // end tick of the batch
+    TRI_ASSERT(batchEndSeq >= lastScannedTick);
+
+    if (dumper.responseSize() >= chunkSize) {  // break if response gets big
+      LOG_TOPIC("205d3", WARN, Logger::REPLICATION) << "reached maximum result size. finishing tailing";
+      break;
+    }
+    // we need to set this here again, to avoid re-scanning WriteBatches
+    lastScannedTick = batchEndSeq;  // do not remove, tailing take forever
+    TRI_ASSERT(lastScannedTick <= db->GetLatestSequenceNumber());
+
+    iterator->Next();
+  }
+
+  latestTick = db->GetLatestSequenceNumber();
+
+  LOG_TOPIC("5b5a1", WARN, Logger::REPLICATION) 
+      << "lastScannedTick: " << lastScannedTick << ", latestTick: " << latestTick;
+}
+#endif
+
 // iterates over WAL starting at 'from' and returns up to 'chunkSize' documents
 // from the corresponding database
 WalAccessResult RocksDBWalAccess::tail(Filter const& filter, size_t chunkSize,
@@ -805,19 +894,19 @@ WalAccessResult RocksDBWalAccess::tail(Filter const& filter, size_t chunkSize,
   // prevent purging of WAL files while we are in here
   RocksDBFilePurgePreventer purgePreventer(_engine.disallowPurging());
 
-  std::unique_ptr<rocksdb::TransactionLogIterator> iterator;  // reader();
+  std::unique_ptr<rocksdb::TransactionLogIterator> iterator;  
   // no need verifying the WAL contents
   rocksdb::TransactionLogIterator::ReadOptions ro(false);
   rocksdb::Status s = db->GetUpdatesSince(since, &iterator, ro);
   if (!s.ok()) {
     Result r = convertStatus(s, rocksutils::StatusHint::wal);
-    return WalAccessResult(r.errorNumber(), filter.tickStart == latestTick, 0, 0, latestTick);
+    return WalAccessResult(r.errorNumber(), filter.tickStart == latestTick, 0, /*lastScannedTick*/ 0, latestTick);
   }
 
   // we need to check if the builder is bigger than the chunksize,
   // only after we printed a full WriteBatch. Otherwise a client might
   // never read the full writebatch
-  LOG_TOPIC("caefa", DEBUG, Logger::ENGINES)
+  LOG_TOPIC("caefb", DEBUG, Logger::ENGINES)
       << "WAL tailing call. Scan since: " << since << ", tick start: " << filter.tickStart
       << ", tick end: " << filter.tickEnd << ", chunk size: " << chunkSize;
   while (iterator->Valid() && lastScannedTick <= filter.tickEnd) {
@@ -833,6 +922,14 @@ WalAccessResult RocksDBWalAccess::tail(Filter const& filter, size_t chunkSize,
 
     // LOG_TOPIC("1eccb", TRACE, Logger::REPLICATION) << "found batch-seq: " << batch.sequence;
     lastScannedTick = batch.sequence;  // start of the batch
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    if (lastScannedTick > db->GetLatestSequenceNumber()) {
+      // this is an unexpected condition. in this case we print the WAL for
+      // debug purposes and error out
+      printWal(filter, chunkSize, func);
+    }
+#endif
+    TRI_ASSERT(lastScannedTick <= db->GetLatestSequenceNumber());
 
     if (batch.sequence < since) {
       // LOG_TOPIC("a5e56", TRACE, Logger::REPLICATION) << "skipping batch from " << batch.sequence << " to " << (batch.sequence + batch.writeBatchPtr->Count());
@@ -863,6 +960,14 @@ WalAccessResult RocksDBWalAccess::tail(Filter const& filter, size_t chunkSize,
     }
     // we need to set this here again, to avoid re-scanning WriteBatches
     lastScannedTick = batchEndSeq;  // do not remove, tailing take forever
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    if (lastScannedTick > db->GetLatestSequenceNumber()) {
+      // this is an unexpected condition. in this case we print the WAL for
+      // debug purposes and error out
+      printWal(filter, chunkSize, func);
+    }
+#endif
+    TRI_ASSERT(lastScannedTick <= db->GetLatestSequenceNumber());
 
     iterator->Next();
   }
@@ -871,15 +976,15 @@ WalAccessResult RocksDBWalAccess::tail(Filter const& filter, size_t chunkSize,
   // while scanning the WAL
   latestTick = db->GetLatestSequenceNumber();
 
-  if (lastScannedTick > latestTick) {
-    // it is possible to get here if we call WAL tailing with a too high
-    // sequence number. in this case lastScannedTick is higher than the
-    // current tick, and we need to reset it to avoid assertions further
-    // down the road
-    TRI_ASSERT(since > latestTick);
-    TRI_ASSERT(firstTick == UINT64_MAX);
-    lastScannedTick = latestTick;
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  if (s.ok() && lastScannedTick > latestTick) {
+    // this is an unexpected condition. in this case we print the WAL for
+    // debug purposes and error out
+    printWal(filter, chunkSize, func);
   }
+#endif
+
+  TRI_ASSERT(!s.ok() || lastScannedTick <= latestTick);
 
   WalAccessResult result(TRI_ERROR_NO_ERROR, firstTick <= filter.tickStart,
                          lastWrittenTick, lastScannedTick, latestTick);

--- a/arangod/RocksDBEngine/RocksDBWalAccess.h
+++ b/arangod/RocksDBEngine/RocksDBWalAccess.h
@@ -57,6 +57,13 @@ class RocksDBWalAccess final : public WalAccess {
                        MarkerCallback const&) const override;
 
  private:
+  /// @brief helper function to print WAL contents. this is only used for
+  /// debugging
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  void printWal(WalAccess::Filter const& filter, size_t chunkSize,
+                MarkerCallback const&) const;
+#endif
+
   RocksDBEngine& _engine;
 };
 }  // namespace arangodb

--- a/tests/js/server/replication/static/replication-static.js
+++ b/tests/js/server/replication/static/replication-static.js
@@ -1959,6 +1959,32 @@ function BaseTestConfig () {
         }
       );
     },
+    
+    testTailingWithTooHighSequenceNumber: function () {
+      connectToMaster();
+
+      const dbPrefix = db._name() === '_system' ? '' : '/_db/' + db._name();
+
+      const {lastTick: snapshotTick, id: replicationContextId} = arango.POST(`${dbPrefix}/_api/replication/batch?syncerId=123`, {ttl: 120});
+
+      const callWailTail = (tick) => {
+        const result = arango.GET_RAW(`${dbPrefix}/_api/wal/tail?from=${tick}&syncerId=123`);
+        assertFalse(result.error, `Expected call to succeed, but got ${JSON.stringify(result)}`);
+        assertEqual(204, result.code, `Unexpected response ${JSON.stringify(result)}`);
+        return result;
+      };
+
+      try {
+        // use a too high sequence number
+        let result = callWailTail(snapshotTick * 100000);
+        assertEqual("false", result.headers["x-arango-replication-checkmore"]);
+        assertEqual("0", result.headers["x-arango-replication-lastincluded"]);
+        let lastScanned = result.headers["x-arango-replication-lastscanned"];
+        assertTrue(lastScanned === "0" || lastScanned === result.headers["x-arango-replication-lasttick"]);
+      } finally {
+        arango.DELETE(`${dbPrefix}/_api/replication/batch/${replicationContextId}`);
+      }
+    },
 
     // /////////////////////////////////////////////////////////////////////////////
     //  @brief Check that different syncer IDs and their WAL ticks are tracked


### PR DESCRIPTION
### Scope & Purpose

In contrast to what the branch name indicates, this is actually not (yet) a bugfix. The PR adds more assertions to the WAL tailing and a helper function to print write batch sequence numbers in maintainer mode. This can be used to debug the assertion failure reported in BTS-564

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-564

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
