### PR TITLE
Fix for memory leaks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fix some memory leaks after adding optimization rule for AqlAnalyzer.
+
 * Fix internal iterator states after intermediate commits in write
   transactions. Iterators could point to invalid data after an
   intermediate commit, producing undefined behavior.

--- a/arangod/IResearch/IResearchAqlAnalyzer.cpp
+++ b/arangod/IResearch/IResearchAqlAnalyzer.cpp
@@ -556,9 +556,11 @@ void resetFromExpression(AqlAnalyzer* analyzer) {
 
   // put calculated value in _queryResults
   analyzer->_queryResults->destroyValue(0,0);
-  bool mustDestroy = false;
-  AqlValue& out = const_cast<AqlValue&>(analyzer->_queryResults->getValueReference(0,0));
-  out = e->execute(&ctx, mustDestroy);
+  bool mustDestroy = true;
+
+  AqlValue value;
+  value = e->execute(&ctx, mustDestroy);
+  analyzer->_queryResults->setValue(0,0, value);
 
   analyzer->_engineResultRegister = 0;
 }

--- a/arangod/IResearch/IResearchAqlAnalyzer.cpp
+++ b/arangod/IResearch/IResearchAqlAnalyzer.cpp
@@ -558,9 +558,7 @@ void resetFromExpression(AqlAnalyzer* analyzer) {
   analyzer->_queryResults->destroyValue(0,0);
   bool mustDestroy = true;
 
-  AqlValue value;
-  value = e->execute(&ctx, mustDestroy);
-  analyzer->_queryResults->setValue(0,0, value);
+  analyzer->_queryResults->setValue(0,0, e->execute(&ctx, mustDestroy));
 
   analyzer->_engineResultRegister = 0;
 }


### PR DESCRIPTION
### Scope & Purpose
This PR aimed to eliminate some memory leaks after changes in https://github.com/arangodb/arangodb/pull/14585

*(Please describe the changes in this PR for reviewers - **mandatory**)*

- [X] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [X] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-550
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:

### Documentation

> All new features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the CHANGELOG so that
> support, end users, and other developers have a concise overview. 

- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
