### PR TITLE
Make names for analyzers and attributes unique

### DIFF
--- a/tests/IResearch/IResearchAnalyzerFeature-test.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeature-test.cpp
@@ -118,7 +118,7 @@ struct TestIndex : public arangodb::Index {
 
 struct TestAttribute : public irs::attribute {
   static constexpr irs::string_ref type_name() noexcept {
-    return "TestAttribute";
+    return "TestAttributeAnalyzerFeature";
   }
 };
 
@@ -186,7 +186,7 @@ REGISTER_ANALYZER_VPACK(ReNormalizingAnalyzer, ReNormalizingAnalyzer::make,
 class TestAnalyzer : public irs::analysis::analyzer {
  public:
   static constexpr irs::string_ref type_name() noexcept {
-    return "TestAnalyzer";
+    return "TestAnalyzerAnalyzerFeature";
   }
 
   TestAnalyzer() : irs::analysis::analyzer(irs::type<TestAnalyzer>::get()) { }

--- a/tests/IResearch/IResearchView-test.cpp
+++ b/tests/IResearch/IResearchView-test.cpp
@@ -146,7 +146,7 @@ REGISTER_SCORER_TEXT(DocIdScorer, DocIdScorer::make);
 
 struct TestAttribute : public irs::attribute {
   static constexpr irs::string_ref type_name() noexcept {
-    return "TestAttribute";
+    return "TestAttributeView";
   }
 };
 
@@ -155,7 +155,7 @@ REGISTER_ATTRIBUTE(TestAttribute);  // required to open reader on segments with 
 class TestAnalyzer : public irs::analysis::analyzer {
  public:
   static constexpr irs::string_ref type_name() noexcept {
-    return "TestAnalyzer";
+    return "TestAnalyzerView";
   }
 
   TestAnalyzer() : irs::analysis::analyzer(irs::type<TestAnalyzer>::get()) { }


### PR DESCRIPTION
### Scope & Purpose

Currently, the following warning happens during initialization of arangodbtests:

```
WARN: [...]/arangodb/3rdParty/iresearch/core/utils/attributes.cpp:88 type name collision detected while registering attribute, ignoring: type 'TestAttribute' from [...]/arangodb/tests/IResearch/IResearchView-test.cpp:153, previously from [...]/arangodb/tests/IResearch/IResearchAnalyzerFeature-test.cpp:124
WARN: [...]/arangodb/3rdParty/iresearch/core/analysis/analyzers.cpp:262 type name collision detected while registering analyzer, ignoring: type 'TestAnalyzer' from [...]/arangodb/tests/IResearch/IResearchView-test.cpp:229, previously from [...]/arangodb/tests/IResearch/IResearchAnalyzerFeature-test.cpp:258
```

This changes a few constants to get rid of these name collisions.

- [X] :hammer: Refactoring/simplification

#### Backports:

- [X] No backports required

### Testing & Verification

- [X] This change is a trivial rework / code cleanup without any test coverage.