### PR TITLE
Deduplicate TestAnalyzer and TestAttribute

### DIFF
--- a/tests/IResearch/CMakeLists.txt
+++ b/tests/IResearch/CMakeLists.txt
@@ -57,6 +57,7 @@ set(ARANGODB_IRESEARCH_TESTS_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/IResearchQueryTraversal-test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/IResearchRocksDBRecoveryHelper-test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/IResearchPrimaryKeyReuse-test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/IResearchTestCommon.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/IResearchView-test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/IResearchViewCoordinator-test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/IResearchViewDBServer-test.cpp

--- a/tests/IResearch/IResearchAnalyzerFeature-test.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeature-test.cpp
@@ -30,6 +30,7 @@
 #include "index/norm.hpp"
 #include "utils/utf8_path.hpp"
 
+#include "IResearch/IResearchTestCommon.h"
 #include "IResearch/RestHandlerMock.h"
 #include "IResearch/common.h"
 #include "Mocks/LogLevels.h"
@@ -116,14 +117,6 @@ struct TestIndex : public arangodb::Index {
   void unload() override {}
 };
 
-struct TestAttribute : public irs::attribute {
-  static constexpr irs::string_ref type_name() noexcept {
-    return "TestAttribute";
-  }
-};
-
-REGISTER_ATTRIBUTE(TestAttribute);  // required to open reader on segments with analized fields
-
 class ReNormalizingAnalyzer : public irs::analysis::analyzer {
  public:
   static constexpr irs::string_ref type_name() noexcept {
@@ -182,82 +175,6 @@ class ReNormalizingAnalyzer : public irs::analysis::analyzer {
 
 REGISTER_ANALYZER_VPACK(ReNormalizingAnalyzer, ReNormalizingAnalyzer::make,
                         ReNormalizingAnalyzer::normalize);
-
-class TestAnalyzer : public irs::analysis::analyzer {
- public:
-  static constexpr irs::string_ref type_name() noexcept {
-    return "TestAnalyzer";
-  }
-
-  TestAnalyzer() : irs::analysis::analyzer(irs::type<TestAnalyzer>::get()) { }
-  virtual irs::attribute* get_mutable(irs::type_info::type_id type) noexcept override {
-    if (type == irs::type<TestAttribute>::id()) {
-      return &_attr;
-    }
-    if (type == irs::type<irs::increment>::id()) {
-      return &_increment;
-    }
-    if (type == irs::type<irs::term_attribute>::id()) {
-      return &_term;
-    }
-    return nullptr;
-  }
-
-  static ptr make(irs::string_ref const& args) {
-    auto slice = arangodb::iresearch::slice(args);
-    if (slice.isNull()) throw std::exception();
-    if (slice.isNone()) return nullptr;
-    PTR_NAMED(TestAnalyzer, ptr);
-    return ptr;
-  }
-
-  static bool normalize(irs::string_ref const& args, std::string& definition) {
-    // same validation as for make,
-    // as normalize usually called to sanitize data before make
-    auto slice = arangodb::iresearch::slice(args);
-    if (slice.isNull()) throw std::exception();
-    if (slice.isNone()) return false;
-
-    arangodb::velocypack::Builder builder;
-    if (slice.isString()) {
-      VPackObjectBuilder scope(&builder);
-      arangodb::iresearch::addStringRef(builder, "args",
-                                        arangodb::iresearch::getStringRef(slice));
-    } else if (slice.isObject() && slice.hasKey("args") && slice.get("args").isString()) {
-      VPackObjectBuilder scope(&builder);
-      arangodb::iresearch::addStringRef(builder, "args",
-                                        arangodb::iresearch::getStringRef(slice.get("args")));
-    } else {
-      return false;
-    }
-
-    definition = builder.buffer()->toString();
-
-    return true;
-  }
-
-  virtual bool next() override {
-    if (_data.empty()) return false;
-
-    _term.value = irs::bytes_ref(_data.c_str(), 1);
-    _data = irs::bytes_ref(_data.c_str() + 1, _data.size() - 1);
-    return true;
-  }
-
-  virtual bool reset(irs::string_ref const& data) override {
-    _data = irs::ref_cast<irs::byte_type>(data);
-    return true;
-  }
-
- private:
-  irs::bytes_ref _data;
-  irs::increment _increment;
-  irs::term_attribute _term;
-  TestAttribute _attr;
-};
-
-REGISTER_ANALYZER_VPACK(TestAnalyzer, TestAnalyzer::make, TestAnalyzer::normalize);
-
 
 class TestTokensTypedAnalyzer : public irs::analysis::analyzer {
  public:

--- a/tests/IResearch/IResearchTestCommon.cpp
+++ b/tests/IResearch/IResearchTestCommon.cpp
@@ -1,0 +1,95 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2021-2021 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#include "IResearchTestCommon.h"
+
+#include "IResearch/VelocyPackHelper.h"
+
+#include <analysis/analyzers.hpp>
+#include <velocypack/Builder.h>
+#include <velocypack/velocypack-aliases.h>
+
+TestAnalyzer::TestAnalyzer()
+    : irs::analysis::analyzer(irs::type<TestAnalyzer>::get()) { }
+
+bool TestAnalyzer::reset(const iresearch::string_ref& data) {
+  _data = irs::ref_cast<irs::byte_type>(data);
+  return true;
+}
+
+bool TestAnalyzer::next() {
+  if (_data.empty()) return false;
+
+  _term.value = irs::bytes_ref(_data.c_str(), 1);
+  _data = irs::bytes_ref(_data.c_str() + 1, _data.size() - 1);
+  return true;
+}
+
+bool TestAnalyzer::normalize(const iresearch::string_ref& args, std::string& definition) {
+  // same validation as for make,
+  // as normalize usually called to sanitize data before make
+  auto slice = arangodb::iresearch::slice(args);
+  if (slice.isNull()) throw std::exception();
+  if (slice.isNone()) return false;
+
+  arangodb::velocypack::Builder builder;
+  if (slice.isString()) {
+    VPackObjectBuilder scope(&builder);
+    arangodb::iresearch::addStringRef(builder, "args",
+        arangodb::iresearch::getStringRef(slice));
+  } else if (slice.isObject() && slice.hasKey("args") && slice.get("args").isString()) {
+    VPackObjectBuilder scope(&builder);
+    arangodb::iresearch::addStringRef(builder, "args",
+        arangodb::iresearch::getStringRef(slice.get("args")));
+  } else {
+    return false;
+  }
+
+  definition = builder.buffer()->toString();
+
+  return true;
+}
+
+auto TestAnalyzer::make(const iresearch::string_ref& args) -> ptr {
+  auto slice = arangodb::iresearch::slice(args);
+  if (slice.isNull()) throw std::exception();
+  if (slice.isNone()) return nullptr;
+  PTR_NAMED(TestAnalyzer, ptr);
+  return ptr;
+}
+
+irs::attribute* TestAnalyzer::get_mutable(irs::type_info::type_id type) noexcept {
+  if (type == irs::type<TestAttribute>::id()) {
+    return &_attr;
+  }
+  if (type == irs::type<irs::increment>::id()) {
+    return &_increment;
+  }
+  if (type == irs::type<irs::term_attribute>::id()) {
+    return &_term;
+  }
+  return nullptr;
+}
+
+REGISTER_ATTRIBUTE(TestAttribute);  // required to open reader on segments with analyzed fields
+
+REGISTER_ANALYZER_VPACK(TestAnalyzer, TestAnalyzer::make, TestAnalyzer::normalize);

--- a/tests/IResearch/IResearchTestCommon.h
+++ b/tests/IResearch/IResearchTestCommon.h
@@ -1,0 +1,58 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2021-2021 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <analysis/analyzer.hpp>
+#include <analysis/token_attributes.hpp>
+#include <utils/attributes.hpp>
+
+struct TestAttribute : public irs::attribute {
+  static constexpr irs::string_ref type_name() noexcept {
+    return "TestAttribute";
+  }
+};
+
+class TestAnalyzer : public irs::analysis::analyzer {
+ public:
+  static constexpr irs::string_ref type_name() noexcept {
+    return "TestAnalyzer";
+  }
+
+  TestAnalyzer();
+
+  irs::attribute* get_mutable(irs::type_info::type_id type) noexcept override;
+
+  static ptr make(irs::string_ref const& args);
+
+  static bool normalize(irs::string_ref const& args, std::string& definition);
+
+  bool next() override;
+
+  bool reset(irs::string_ref const& data) override;
+
+ private:
+  irs::bytes_ref _data;
+  irs::increment _increment{};
+  irs::term_attribute _term{};
+  TestAttribute _attr;
+};


### PR DESCRIPTION
### Scope & Purpose

Currently, the following warning happens during initialization of arangodbtests:

```
WARN: [...]/arangodb/3rdParty/iresearch/core/utils/attributes.cpp:88 type name collision detected while registering attribute, ignoring: type 'TestAttribute' from [...]/arangodb/tests/IResearch/IResearchView-test.cpp:153, previously from [...]/arangodb/tests/IResearch/IResearchAnalyzerFeature-test.cpp:124
WARN: [...]/arangodb/3rdParty/iresearch/core/analysis/analyzers.cpp:262 type name collision detected while registering analyzer, ignoring: type 'TestAnalyzer' from [...]/arangodb/tests/IResearch/IResearchView-test.cpp:229, previously from [...]/arangodb/tests/IResearch/IResearchAnalyzerFeature-test.cpp:258
```

This PR moves the duplicate analyzer and attribute into a separate file.

- [X] :hammer: Refactoring/simplification

#### Backports:

- [X] No backports required

### Testing & Verification

- [X] This change is a trivial rework / code cleanup without any test coverage.