### PR TITLE
disable RTTI for snappy compilation

### DIFF
--- a/3rdParty/README_maintainers.md
+++ b/3rdParty/README_maintainers.md
@@ -104,17 +104,6 @@ http://s2geometry.io/
 Compression library
 https://github.com/google/snappy
 
-The original Snappy code disables RTTI. This prevents the code from linking with
-ArangoDB, so we need to comment the section in Snappy's CMakeLists.txt that disables
-RTTI unconditionally.
-
-     # Disable RTTI.
-    -string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-    -set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
-    +# note: we need cannot disable RTTI because otherwise it won't link on Linux
-    +# string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-    +# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
-
 ## snowball
 
 http://snowball.tartarus.org/ stemming for IResearch. We use the latest provided cmake which we maintain.

--- a/3rdParty/snappy/snappy-1.1.9/CMakeLists.txt
+++ b/3rdParty/snappy/snappy-1.1.9/CMakeLists.txt
@@ -78,9 +78,8 @@ else(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
 
   # Disable RTTI.
-  # note: we need cannot disable RTTI because otherwise it won't link on Linux
-  # string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+  string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 
 # BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to make

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Disable RTTI when compiling Snappy. RTTI used to be disabled previously,
+  up until some Merkle tree improvement PR was merged about one month ago, 
+  which turned on RTTI for compiling Snappy.
+
 * (EE only) Bug-fix: If you created a ArangoSearch view on Satellite-
   Collections only and then join with a collection only having a single
   shard the cluster-one-shard-rule was falsely applied and could lead to

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -1505,55 +1505,54 @@ aql::ExecutionState Query::cleanupTrxAndEngines(ErrorCode errorCode) {
   }
 }
 
-  void Query::debugKillQuery() {
+void Query::debugKillQuery() {
 #ifndef ARANGODB_ENABLE_FAILURE_TESTS
-    TRI_ASSERT(false);
-    return;
+  TRI_ASSERT(false);
 #else
-    if (_wasDebugKilled) {
-      return;
-    }
-    bool usingSystemCollection = false;
-    // Ignore queries on System collections, we do not want them to hit failure points
-    // note that we must call the _const_ version of collections() here, because the non-const
-    // version will trigger an assertion failure if the query is already executing!
-    const_cast<Query const*>(this)->collections().visit([&usingSystemCollection](std::string const&, Collection const& col) -> bool {
+  if (_wasDebugKilled) {
+    return;
+  }
+  bool usingSystemCollection = false;
+  // Ignore queries on System collections, we do not want them to hit failure points
+  // note that we must call the _const_ version of collections() here, because the non-const
+  // version will trigger an assertion failure if the query is already executing!
+  const_cast<Query const*>(this)->collections().visit([&usingSystemCollection](std::string const&, Collection const& col) -> bool {
       if (col.getCollection()->system()) {
-        usingSystemCollection = true;
-        return false;
+      usingSystemCollection = true;
+      return false;
       }
       return true;
-    });
+      });
 
-    if (usingSystemCollection) {
-      return;
-    }
+  if (usingSystemCollection) {
+    return;
+  }
 
-    _wasDebugKilled = true;
-    // A query can only be killed under certain circumstances.
-    // We assert here that one of those is true.
-    // a) Query is in the list of current queries, this can be requested by the user and the query can be killed by user
-    // b) Query is in the query registry. In this case the query registry can hit a timeout, which triggers the kill
-    // c) The query id has been handed out to the user (stream query only)
-    bool isStreaming = queryOptions().stream;
-    bool isInList = false;
-    bool isInRegistry = false;
-    auto const& queryList = vocbase().queryList();
-    if (queryList->enabled()) {
-      auto const& current = queryList->listCurrent();
-      for (auto const& it : current) {
-        if (it.id == _queryId) {
-          isInList = true;
-          break;
-        }
+  _wasDebugKilled = true;
+  // A query can only be killed under certain circumstances.
+  // We assert here that one of those is true.
+  // a) Query is in the list of current queries, this can be requested by the user and the query can be killed by user
+  // b) Query is in the query registry. In this case the query registry can hit a timeout, which triggers the kill
+  // c) The query id has been handed out to the user (stream query only)
+  bool isStreaming = queryOptions().stream;
+  bool isInList = false;
+  bool isInRegistry = false;
+  auto const& queryList = vocbase().queryList();
+  if (queryList->enabled()) {
+    auto const& current = queryList->listCurrent();
+    for (auto const& it : current) {
+      if (it.id == _queryId) {
+        isInList = true;
+        break;
       }
     }
-
-    QueryRegistry* registry = QueryRegistryFeature::registry();
-    if (registry != nullptr) {
-      isInRegistry = registry->queryIsRegistered(vocbase().name(), _queryId);
-    }
-    TRI_ASSERT(isInList || isStreaming || isInRegistry || _execState == QueryExecutionState::ValueType::FINALIZATION);
-    kill();
-#endif
   }
+
+  QueryRegistry* registry = QueryRegistryFeature::registry();
+  if (registry != nullptr) {
+    isInRegistry = registry->queryIsRegistered(vocbase().name(), _queryId);
+  }
+  TRI_ASSERT(isInList || isStreaming || isInRegistry || _execState == QueryExecutionState::ValueType::FINALIZATION);
+  kill();
+#endif
+}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -208,7 +208,7 @@ add_library(arango STATIC
   ${ADDITIONAL_LIB_ARANGO_SOURCES}
 )
 
-# The following is necessary to compile MerkleTree.cp without RTTI
+# The following is necessary to compile MerkleTree.cpp without RTTI.
 # RTTI needs to be disabled because the file contains a class that
 # is derived from some Snappy base class, which itself is compiled
 # with -fno-rtti. Mixing RTTI code and non-RTTI code can cause 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -151,6 +151,7 @@ add_library(arango STATIC
   Basics/tri-strings.cpp
   Basics/tri-zip.cpp
   Containers/MerkleTree.cpp
+  Containers/MerkleTreeHelpers.cpp
   Containers/ImmerMemoryPolicy.h
   Endpoint/Endpoint.cpp
   Endpoint/EndpointIp.cpp
@@ -211,19 +212,19 @@ add_library(arango STATIC
 # The following is necessary to compile MerkleTree.cpp without RTTI.
 # RTTI needs to be disabled because the file contains a class that
 # is derived from some Snappy base class, which itself is compiled
-# with -fno-rtti. Mixing RTTI code and non-RTTI code can cause 
+# with -fno-rtti. Mixing RTTI code and non-RTTI code can cause
 # problems during linking. Here is what "man g++" has to say:
-#     Mixing code compiled with -frtti with that compiled with 
-#     -fno-rtti may not work. For example, programs may fail to 
+#     Mixing code compiled with -frtti with that compiled with
+#     -fno-rtti may not work. For example, programs may fail to
 #     link if a class compiled with -fno-rtti is used as a
 #     base for a class compiled with -frtti.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   set_source_files_properties(
-    Containers/MerkleTree.cpp
+    Containers/MerkleTreeHelpers.cpp
     PROPERTIES COMPILE_FLAGS "/GR-")
 else()
   set_source_files_properties(
-    Containers/MerkleTree.cpp
+    Containers/MerkleTreeHelpers.cpp
     PROPERTIES COMPILE_FLAGS "-fno-rtti")
 endif()
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -208,6 +208,26 @@ add_library(arango STATIC
   ${ADDITIONAL_LIB_ARANGO_SOURCES}
 )
 
+# The following is necessary to compile MerkleTree.cp without RTTI
+# RTTI needs to be disabled because the file contains a class that
+# is derived from some Snappy base class, which itself is compiled
+# with -fno-rtti. Mixing RTTI code and non-RTTI code can cause 
+# problems during linking. Here is what "man g++" has to say:
+#     Mixing code compiled with -frtti with that compiled with 
+#     -fno-rtti may not work. For example, programs may fail to 
+#     link if a class compiled with -fno-rtti is used as a
+#     base for a class compiled with -frtti.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  set_source_files_properties(
+    Containers/MerkleTree.cpp
+    PROPERTIES COMPILE_FLAGS "/GR-")
+else()
+  set_source_files_properties(
+    Containers/MerkleTree.cpp
+    PROPERTIES COMPILE_FLAGS "-fno-rtti")
+endif()
+
+
 target_link_libraries(arango
   s2
   boost_system

--- a/lib/Containers/MerkleTree.cpp
+++ b/lib/Containers/MerkleTree.cpp
@@ -29,17 +29,16 @@
 #include <limits>
 #include <memory>
 #include <mutex>
-#include <queue>
+//#include <queue>
 #include <shared_mutex>
 #include <stdexcept>
 #include <string>
 #include <string_view>
-#include <type_traits>
+//#include <type_traits>
 #include <utility>
 #include <vector>
 
 #include <snappy.h>
-#include <snappy-sinksource.h>
 
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
@@ -54,6 +53,7 @@
 #include "Basics/StringUtils.h"
 #include "Basics/debugging.h"
 #include "Basics/hashes.h"
+#include "Containers/MerkleTreeHelpers.h"
 
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
 #include "Random/RandomGenerator.h"
@@ -70,86 +70,6 @@ template<typename T> T readUInt(char const*& p) noexcept {
   memcpy(&value, p, sizeof(T));
   p += sizeof(T);
   return arangodb::basics::littleToHost<T>(value);
-};
-
-/// @brief an empty shard that is reused when serializing empty shards
-struct EmptyShard {
-  EmptyShard()
-    : buffer(arangodb::containers::MerkleTreeBase::Data::buildShard(arangodb::containers::MerkleTreeBase::ShardSize)) {}
-
-  char* data() const { return reinterpret_cast<char*>(buffer.get()); }
-
-  arangodb::containers::MerkleTreeBase::Data::ShardType buffer;
-};
-
-/// @brief an empty shard that is reused when serializing empty shards
-EmptyShard const emptyShard;
-
-
-class SnappyStringAppendSink : public snappy::Sink {
- public:
-  explicit SnappyStringAppendSink(std::string& output) 
-      : output(output) {}
-
-  void Append(const char* bytes, size_t n) override {
-    output.append(bytes, n);
-  }
-
- private:
-  std::string& output;
-};
-  
-/// @brief helper class for compressing a Merkle tree using Snappy
-class MerkleTreeSnappySource : public snappy::Source {
- public:
-  explicit MerkleTreeSnappySource(std::uint64_t numberOfShards, 
-                                  std::uint64_t allocationSize,
-                                  arangodb::containers::MerkleTreeBase::Data const& data)
-      : numberOfShards(numberOfShards),
-        data(data), 
-        bytesRead(0),
-        bytesLeftToRead(allocationSize) {}
-  
-  size_t Available() const override {
-    return bytesLeftToRead;
-  }
-  
-  char const* Peek(size_t* len) override {
-    if (bytesRead < arangodb::containers::MerkleTreeBase::MetaSize) {
-      TRI_ASSERT(bytesRead == 0);
-      *len = arangodb::containers::MerkleTreeBase::MetaSize;
-      return reinterpret_cast<char const*>(&data.meta);
-    }
-    
-    TRI_ASSERT(bytesRead >= arangodb::containers::MerkleTreeBase::MetaSize);
-    std::uint64_t shard = (bytesRead - arangodb::containers::MerkleTreeBase::MetaSize) / arangodb::containers::MerkleTreeBase::ShardSize;
-    std::uint64_t offsetInShard = (bytesRead - arangodb::containers::MerkleTreeBase::MetaSize) % arangodb::containers::MerkleTreeBase::ShardSize;
-
-    if (shard < numberOfShards) {
-      *len = arangodb::containers::MerkleTreeBase::ShardSize - offsetInShard;
-      if (shard >= data.shards.size() || data.shards[shard] == nullptr) {
-        // for compressing empty shards, we use the static EmptyShard object,
-        // which consists of one shard that is completely empty
-        return emptyShard.data() + offsetInShard;
-      }
-      return reinterpret_cast<char const*>(data.shards[shard].get()) + offsetInShard;
-    }
-    // no more data
-    *len = 0;
-    return "";
-  }
-
-  void Skip(size_t n) override {
-    bytesRead += n;
-    TRI_ASSERT(n <= bytesLeftToRead);
-    bytesLeftToRead -= n;
-  }
-   
- private:
-  std::uint64_t const numberOfShards;
-  arangodb::containers::MerkleTreeBase::Data const& data;
-  std::uint64_t bytesRead;
-  std::uint64_t bytesLeftToRead;
 };
 
 }  // namespace
@@ -963,8 +883,8 @@ void MerkleTree<Hasher, BranchingBits>::serializeBinary(std::string& output,
     }
     case BinaryFormat::CompressedSnappyFull: {
       output.reserve(16384);
-      ::MerkleTreeSnappySource source(numberOfShards(), allocationSize(meta().depth), _data);
-      ::SnappyStringAppendSink sink(output);
+      arangodb::containers::helpers::MerkleTreeSnappySource source(numberOfShards(), allocationSize(meta().depth), _data);
+      arangodb::containers::helpers::SnappyStringAppendSink sink(output);
       snappy::Compress(&source, &sink);
       break;
     }
@@ -988,7 +908,7 @@ void MerkleTree<Hasher, BranchingBits>::serializeBinary(std::string& output,
       }
 
       TRI_ASSERT(output.size() == MetaSize - sizeof(Meta::Padding) + sizeof(uint32_t) + numberOfShards() * sizeof(uint32_t));
-      ::SnappyStringAppendSink sink(output);
+      arangodb::containers::helpers::SnappyStringAppendSink sink(output);
       for (std::uint64_t i = 0; i < numberOfShards(); ++i) {
         size_t compressedLength = 0;
         bool shardSet = (_data.shards.size() > i && _data.shards[i] != nullptr);

--- a/lib/Containers/MerkleTree.cpp
+++ b/lib/Containers/MerkleTree.cpp
@@ -55,8 +55,6 @@
 #include "Basics/debugging.h"
 #include "Basics/hashes.h"
 
-#include "Logger/LogMacros.h"
-
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
 #include "Random/RandomGenerator.h"
 #endif

--- a/lib/Containers/MerkleTreeHelpers.cpp
+++ b/lib/Containers/MerkleTreeHelpers.cpp
@@ -1,0 +1,99 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2021 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Dan Larkin-York
+////////////////////////////////////////////////////////////////////////////////
+
+#include <cstddef>
+#include <cstring>
+#include <string>
+
+#include "MerkleTreeHelpers.h"
+#include "Basics/debugging.h"
+
+namespace {
+/// @brief an empty shard that is reused when serializing empty shards
+struct EmptyShard {
+  EmptyShard()
+    : buffer(arangodb::containers::MerkleTreeBase::Data::buildShard(arangodb::containers::MerkleTreeBase::ShardSize)) {}
+
+  char* data() const { return reinterpret_cast<char*>(buffer.get()); }
+
+  arangodb::containers::MerkleTreeBase::Data::ShardType buffer;
+};
+
+} // namespace
+
+/// @brief an empty shard that is reused when serializing empty shards
+EmptyShard const emptyShard;
+
+namespace arangodb::containers::helpers {
+
+SnappyStringAppendSink::SnappyStringAppendSink(std::string& output) 
+    : output(output) {}
+
+void SnappyStringAppendSink::Append(const char* bytes, size_t n) {
+  output.append(bytes, n);
+}
+
+MerkleTreeSnappySource::MerkleTreeSnappySource(std::uint64_t numberOfShards, 
+                                               std::uint64_t allocationSize,
+                                               arangodb::containers::MerkleTreeBase::Data const& data)
+    : numberOfShards(numberOfShards),
+      data(data), 
+      bytesRead(0),
+      bytesLeftToRead(allocationSize) {}
+  
+size_t MerkleTreeSnappySource::Available() const {
+  return bytesLeftToRead;
+}
+  
+char const* MerkleTreeSnappySource::Peek(size_t* len) {
+  if (bytesRead < arangodb::containers::MerkleTreeBase::MetaSize) {
+    TRI_ASSERT(bytesRead == 0);
+    *len = arangodb::containers::MerkleTreeBase::MetaSize;
+    return reinterpret_cast<char const*>(&data.meta);
+  }
+    
+  TRI_ASSERT(bytesRead >= arangodb::containers::MerkleTreeBase::MetaSize);
+  std::uint64_t shard = (bytesRead - arangodb::containers::MerkleTreeBase::MetaSize) / arangodb::containers::MerkleTreeBase::ShardSize;
+  std::uint64_t offsetInShard = (bytesRead - arangodb::containers::MerkleTreeBase::MetaSize) % arangodb::containers::MerkleTreeBase::ShardSize;
+
+  if (shard < numberOfShards) {
+    *len = arangodb::containers::MerkleTreeBase::ShardSize - offsetInShard;
+    if (shard >= data.shards.size() || data.shards[shard] == nullptr) {
+      // for compressing empty shards, we use the static EmptyShard object,
+      // which consists of one shard that is completely empty
+      return ::emptyShard.data() + offsetInShard;
+    }
+    return reinterpret_cast<char const*>(data.shards[shard].get()) + offsetInShard;
+  }
+  // no more data
+  *len = 0;
+  return "";
+}
+
+void MerkleTreeSnappySource::Skip(size_t n) {
+  bytesRead += n;
+  TRI_ASSERT(n <= bytesLeftToRead);
+  bytesLeftToRead -= n;
+}
+
+}  // namespace

--- a/lib/Containers/MerkleTreeHelpers.h
+++ b/lib/Containers/MerkleTreeHelpers.h
@@ -1,0 +1,66 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2021 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Dan Larkin-York
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include <snappy-sinksource.h>
+
+#include "MerkleTree.h"
+
+namespace arangodb::containers::helpers {
+
+class SnappyStringAppendSink : public snappy::Sink {
+ public:
+  explicit SnappyStringAppendSink(std::string& output);
+
+  void Append(const char* bytes, size_t n) override;
+
+ private:
+  std::string& output;
+};
+
+/// @brief helper class for compressing a Merkle tree using Snappy
+class MerkleTreeSnappySource : public snappy::Source {
+ public:
+  explicit MerkleTreeSnappySource(std::uint64_t numberOfShards, 
+                                  std::uint64_t allocationSize,
+                                  arangodb::containers::MerkleTreeBase::Data const& data);
+  
+  size_t Available() const override;
+  
+  char const* Peek(size_t* len) override;
+
+  void Skip(size_t n) override;
+   
+ private:
+  std::uint64_t const numberOfShards;
+  arangodb::containers::MerkleTreeBase::Data const& data;
+  std::uint64_t bytesRead;
+  std::uint64_t bytesLeftToRead;
+};
+
+}  // namespace


### PR DESCRIPTION
### Scope & Purpose

This restores the compilation of Snappy to how it was done before commit 573f7ebfdd0f5856970b2ea93555175d5ee9743b. That commit disabled the hack in Snappy that turns of RTTI in its CMakeLists.txt.
The reason for enabling RTTI for Snappy compilation in that previous commit was that we were deriving from two Snappy source files, which are supposed to be used as interfaces. However, g++ cannot link files which have base classes compiled without RTTI and derived classes that use RTTI. That's why RTTI was enabled for the Snappy files in that commit.
That required changes to the original Snappy CMakeLists.txt, and may have had an adverse impact on performance (still to be proven by our performance tests). Now, instead of turning RTTI on for Snappy, we turn it back off and in addition we turn off RTTI for the one file that derives from Snappy's interfaces. So we have to use some source-file specific compile hack in CMakeLists.txt to turn RTTI off for one of our own files.
This is hopefully less intrusive than turning RTTI off for Snappy and having to maintain a patch for Snappy's CMakeLists.txt long-term.

This doesn't need to be backported because the commit above was only in devel/3.9.

Testing if this works is basically done by compilers on all platforms. If this has a positive impact on performance we will see soon after merging by observing the trends in our performance tests.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*