### PR TITLE
Fix cluster-internal network protocol to HTTP/1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 devel
 -----
 
+* Fix cluster-internal network protocol to HTTP/1 for now. Any other protocol
+  selected via the startup option `--network.protocol` will automatically be
+  switched to HTTP/1. The startup option `--network.protocol` is now deprecated
+  and hidden by default. It will be removed in a future version of arangod.
+  The rationale for this change is to move towards a single protocol for 
+  cluster-internal communication instead of 3 different ones.
+
 * (EE only) Bug-fix: If you created a ArangoSearch view on Satellite-
   Collections only and then join with a collection only having a single
   shard the cluster-one-shard-rule was falsely applied and could lead to

--- a/arangod/Network/NetworkFeature.cpp
+++ b/arangod/Network/NetworkFeature.cpp
@@ -133,9 +133,12 @@ void NetworkFeature::collectOptions(std::shared_ptr<options::ProgramOptions> opt
   std::unordered_set<std::string> protos = {
       "", "http", "http2", "h2", "vst"};
 
+  // starting with 3.9, we will hard-code the protocol for cluster-internal communication
   options->addOption("--network.protocol", "network protocol to use for cluster-internal communication",
-                     new DiscreteValuesParameter<StringParameter>(&_protocol, protos))
-                     .setIntroducedIn(30700);
+                     new DiscreteValuesParameter<StringParameter>(&_protocol, protos),
+                     options::makeDefaultFlags(options::Flags::Hidden))
+                     .setIntroducedIn(30700)
+                     .setDeprecatedIn(30900);
 
   options
       ->addOption("--network.max-requests-in-flight",
@@ -182,6 +185,11 @@ void NetworkFeature::prepare() {
   config.clusterInfo = ci;
   config.name = "ClusterComm";
 
+  // using an internal network protocol other than HTTP/1 is
+  // not supported since 3.9. the protocol is always hard-coded
+  // to HTTP/1 from now on. 
+  // note: we plan to upgrade the internal protocol to HTTP/2 at 
+  // some point in the future
   config.protocol = fuerte::ProtocolType::Http;
   if (_protocol == "http" || _protocol == "h1") {
     config.protocol = fuerte::ProtocolType::Http;
@@ -189,6 +197,13 @@ void NetworkFeature::prepare() {
     config.protocol = fuerte::ProtocolType::Http2;
   } else if (_protocol == "vst") {
     config.protocol = fuerte::ProtocolType::Vst;
+  }
+
+  if (config.protocol != fuerte::ProtocolType::Http) {
+    LOG_TOPIC("6d221", WARN, Logger::CONFIG)
+        << "using `--network.protocol` is deprecated. "
+        << "the network protocol for cluster-internal requests is hard-coded to HTTP/1 in this version";
+    config.protocol = fuerte::ProtocolType::Http;
   }
 
   _pool = std::make_unique<network::ConnectionPool>(config);


### PR DESCRIPTION
### Scope & Purpose

* Fix cluster-internal network protocol to HTTP/1 for now. Any other protocol
  selected via the startup option `--network.protocol` will automatically be
  switched to HTTP/1. The startup option `--network.protocol` is now deprecated
  and hidden by default. It will be removed in a future version of arangod.
  The rationale for this change is to move towards a single protocol for
  cluster-internal communication instead of 3 different ones.
  Note: we may move to a different protocol in the future, but this will then
  be an internal-only change.

Docs PR: https://github.com/arangodb/docs/pull/761

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/761

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
