### PR TITLE
deprecate several extra arangobench testcases

### DIFF
--- a/arangosh/Benchmark/testcases/RandomShapesTest.h
+++ b/arangosh/Benchmark/testcases/RandomShapesTest.h
@@ -81,7 +81,7 @@ namespace arangodb::arangobench {
     }
 
     bool isDeprecated() const noexcept override {
-      return false;
+      return true;
     }
 
     uint32_t _randomValue;

--- a/arangosh/Benchmark/testcases/ShapesAppendTest.h
+++ b/arangosh/Benchmark/testcases/ShapesAppendTest.h
@@ -74,7 +74,7 @@ namespace arangodb::arangobench {
     }
 
     bool isDeprecated() const noexcept override {
-      return false;
+      return true;
     }
 
   };

--- a/arangosh/Benchmark/testcases/ShapesTest.h
+++ b/arangosh/Benchmark/testcases/ShapesTest.h
@@ -75,7 +75,7 @@ namespace arangodb::arangobench {
     }
 
     bool isDeprecated() const noexcept override {
-      return false;
+      return true;
     }
 
   };

--- a/arangosh/Benchmark/testcases/StreamCursorTest.h
+++ b/arangosh/Benchmark/testcases/StreamCursorTest.h
@@ -79,7 +79,7 @@ namespace arangodb::arangobench {
     }
 
     bool isDeprecated() const noexcept override {
-      return false;
+      return true;
     }
 
   };

--- a/arangosh/Benchmark/testcases/TransactionMultiCollectionTest.h
+++ b/arangosh/Benchmark/testcases/TransactionMultiCollectionTest.h
@@ -80,7 +80,7 @@ namespace arangodb::arangobench {
     }
 
     bool isDeprecated() const noexcept override {
-      return false;
+      return true;
     }
 
     std::string _c1;

--- a/arangosh/Benchmark/testcases/TransactionMultiTest.h
+++ b/arangosh/Benchmark/testcases/TransactionMultiTest.h
@@ -82,7 +82,7 @@ namespace arangodb::arangobench {
     }
 
     bool isDeprecated() const noexcept override {
-      return false;
+      return true;
     }
 
     std::string _c1;


### PR DESCRIPTION
### Scope & Purpose

Deprecate several other arangobench test cases which are pretty outdated and serve no apparent purpose from the end user perspective.
CHANGELOG entry is missing intentionally, as this is a very minor change.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/764

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *arangobench*.
