### PR TITLE
Allow startup of arangod with an existing database

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Allow startup of arangod with an existing database directory that was missing
+  the ZkdIndex column family.
+
 * Added ArangoSearch condition optimization: STARTS_WITH is merged 
   with LEVENSHTEIN_MATCH if used in the same AND node and field name and prefix
   matches.

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -747,7 +747,7 @@ void RocksDBEngine::start() {
       auto const replicatedLogsName = RocksDBColumnFamilyManager::name(
           RocksDBColumnFamilyManager::Family::ReplicatedLogs);
       auto const zkdIndexName = RocksDBColumnFamilyManager::name(
-          RocksDBColumnFamilyManager::Family::ReplicatedLogs);
+          RocksDBColumnFamilyManager::Family::ZkdIndex);
 
       for (auto const& it : cfFamilies) {
         auto it2 = std::find(existingColumnFamilies.begin(),


### PR DESCRIPTION
### Scope & Purpose

Allow startup of arangod with an existing database directory that was missing the ZkdIndex column family.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
