### PR TITLE
Fixed issue #14720

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fixed issue #14720: Bulk import ignores onDuplicate in 3.8.0.
+  The "onDuplicate" attribute was ignored by the `/_api/import` REST API when
+  not specifying the "type" URL parameter.
+
 * Updated OpenSSL to 1.1.1l and OpenLDAP to 2.4.59.
 
 * APM-70: allow PRUNE condition to be stored in a variable.

--- a/arangod/RestHandler/RestImportHandler.cpp
+++ b/arangod/RestHandler/RestImportHandler.cpp
@@ -628,8 +628,8 @@ bool RestImportHandler::createFromKeyValueList() {
   bool const complete = _request->parsedValue("complete", false);
   bool const overwrite = _request->parsedValue("overwrite", false);
   _ignoreMissing = _request->parsedValue("ignoreMissing", false);
-  OperationOptions opOptions(_context);
-  opOptions.waitForSync = _request->parsedValue("waitForSync", false);
+  OperationOptions opOptions = buildOperationOptions();
+  opOptions.waitForSync = _request->parsedValue(StaticStrings::WaitForSyncString, false);
 
   // extract the collection name
   bool found;


### PR DESCRIPTION
### Scope & Purpose

devel port of https://github.com/arangodb/arangodb/pull/14772

* Fixed issue #14720: Bulk import ignores onDuplicate in 3.8.0.
  The "onDuplicate" attribute was ignored by the `/_api/import` REST API when
  not specifying the "type" URL parameter.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for 3.8: https://github.com/arangodb/arangodb/pull/14772

#### Related Information

- [x] GitHub issue / Jira ticket number: https://github.com/arangodb/arangodb/issues/14720

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in http_server)
