### PR TITLE
fix UB in DistributeExecutor

### DIFF
--- a/arangod/Aql/DistributeExecutor.cpp
+++ b/arangod/Aql/DistributeExecutor.cpp
@@ -125,24 +125,37 @@ auto DistributeExecutor::distributeBlock(SharedAqlItemBlockPtr const& block, Ski
           choosenMap[key].emplace_back(i);
         }
       } else {
-        auto input = extractInput(block, i);
-        if (!input.isNone()) {
-          // NONE is ignored.
-          // Object is processd
-          // All others throw.
-          TRI_ASSERT(input.isObject());
-          if (_infos.shouldDistributeToAll(input)) {
-            // This input should be added to all clients
-            for (auto const& [key, value] : blockMap) {
-              choosenMap[key].emplace_back(i);
+        // check first input register
+        AqlValue val = InputAqlItemRow{block, i}.getValue(_infos.registerId());
+
+        VPackSlice input = val.slice();  // will throw when wrong type
+        if (input.isNone()) {
+          continue;
+        }
+
+        if (!input.isObject()) {
+          THROW_ARANGO_EXCEPTION_MESSAGE(
+              TRI_ERROR_INTERNAL, "DistributeExecutor requires an object as input");
+        }
+        // NONE is ignored.
+        // Object is processd
+        // All others throw.
+        TRI_ASSERT(input.isObject());
+        if (_infos.shouldDistributeToAll(input)) {
+          // This input should be added to all clients
+          for (auto const& [key, value] : blockMap) {
+            choosenMap[key].emplace_back(i);
+          }
+        } else {
+          auto client = getClient(input);
+          if (!client.empty()) {
+            // We can only have clients we are prepared for
+            TRI_ASSERT(blockMap.find(client) != blockMap.end());
+            if (ADB_UNLIKELY(blockMap.find(client) == blockMap.end())) {
+              THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, 
+                  std::string("unexpected client id '") + client + "' found in blockMap");
             }
-          } else {
-            auto client = getClient(input);
-            if (!client.empty()) {
-              // We can only have clients we are prepared for
-              TRI_ASSERT(blockMap.find(client) != blockMap.end());
-              choosenMap[client].emplace_back(i);
-            }
+            choosenMap[client].emplace_back(i);
           }
         }
       }
@@ -166,23 +179,6 @@ auto DistributeExecutor::distributeBlock(SharedAqlItemBlockPtr const& block, Ski
       target.addBlock(skipped, nullptr, {});
     }
   }
-}
-
-auto DistributeExecutor::extractInput(SharedAqlItemBlockPtr const& block,
-                                      size_t rowIndex) const -> VPackSlice {
-  // check first input register
-  AqlValue val = InputAqlItemRow{block, rowIndex}.getValue(_infos.registerId());
-
-  VPackSlice input = val.slice();  // will throw when wrong type
-  if (input.isNone()) {
-    return input;
-  }
-
-  if (!input.isObject()) {
-    THROW_ARANGO_EXCEPTION_MESSAGE(
-        TRI_ERROR_INTERNAL, "DistributeExecutor requires an object as input");
-  }
-  return input;
 }
 
 auto DistributeExecutor::getClient(VPackSlice input) const -> std::string {

--- a/arangod/Aql/DistributeExecutor.h
+++ b/arangod/Aql/DistributeExecutor.h
@@ -97,15 +97,8 @@ class DistributeExecutor {
                        std::unordered_map<std::string, ClientBlockData>& blockMap) -> void;
 
  private:
-  /**
-   * @brief Compute which client needs to get this row
-   * @param block The input block
-   * @param rowIndex
-   * @return std::string Identifier used by the client
-   */
   auto getClient(velocypack::Slice input) const -> std::string;
 
- private:
   DistributeExecutorInfos const& _infos;
 
   // a reusable Builder object for building _key values

--- a/arangod/Aql/DistributeExecutor.h
+++ b/arangod/Aql/DistributeExecutor.h
@@ -103,8 +103,6 @@ class DistributeExecutor {
    * @param rowIndex
    * @return std::string Identifier used by the client
    */
-  auto extractInput(SharedAqlItemBlockPtr const& block, size_t rowIndex) const
-      -> velocypack::Slice;
   auto getClient(velocypack::Slice input) const -> std::string;
 
  private:


### PR DESCRIPTION
### Scope & Purpose

Fix UB in DistributeExecutor.
The `extractInput` method created an AqlValue on the stack, and returned a VPackSlice that may have pointed into it. This slice may have random contents after leaving the method, when the stack was cleaned up and the AqlValue overwritten with other data.
This only affects devel, but no previous versions.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
