### PR TITLE
Fix BTS-548 array index wrong optimization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.7.15 (XXXX-XX-XX)
 --------------------
 
+* Fixed a bug for array indexes on update of documents. See BTS-548.
+
 * Updated OpenSSL to 1.1.1l and OpenLDAP to 2.4.59.
 
 * (EE only) Bug-fix: If you created a ArangoSearch view on Satellite-Collections

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -921,6 +921,15 @@ namespace {
 
       if (begin->shouldExpand &&
           first.isArray() && second.isArray()) {
+        if (first.length() != second.length()) {
+          // Nonequal length, so there is a difference!
+          // We have to play this carefully here. It is possible that the
+          // set of values found is the same, but we must err on the side
+          // of caution in this case and use the slow path. Note in
+          // particular that the following code returns `true`, if one
+          // of the arrays is empty, which is not correct!
+          return false;
+        }
         auto next = begin + 1;
         VPackArrayIterator it1(first), it2(second);
         while (it1.valid() && it2.valid()) {

--- a/tests/js/server/shell/shell-array-index-noncluster.js
+++ b/tests/js/server/shell/shell-array-index-noncluster.js
@@ -275,7 +275,75 @@ function arraySkiplistIndexSuite () {
       catch (err) {
         assertEqual(errors.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code, err.errorNum);
       }
-    }
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test: Test update of an array index where entries are removed:
+////////////////////////////////////////////////////////////////////////////////
+
+    testPersistentArrayIndexUpdates : function () {
+      collection.ensureIndex({type:"persistent", fields: ["a[*].b"], unique: true});
+
+      let meta = collection.insert({a: [{b:"xyz"}]});
+
+      try {
+        collection.insert({a: [{b:"xyz"}]});
+        fail();
+      }
+      catch (err) {
+        assertEqual(errors.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code, err.errorNum);
+      }
+
+      collection.update(meta._key, {a: []});
+
+      let meta2 = collection.insert({a: [{b:"xyz"}]});  // must work again
+
+      try {
+        collection.insert({a: [{b:"xyz"}]});
+        fail();
+      }
+      catch (err) {
+        assertEqual(errors.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code, err.errorNum);
+      }
+
+      collection.replace(meta2._key, {a: []});
+
+      collection.insert({a: [{b:"xyz"}]});  // must work again
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test: Test update of an array index where entries are changed:
+////////////////////////////////////////////////////////////////////////////////
+
+    testPersistentArrayIndexUpdates2 : function () {
+      collection.ensureIndex({type:"persistent", fields: ["a[*].b"], unique: true});
+
+      let meta = collection.insert({a: [{b:"xyz"}]});
+
+      try {
+        collection.insert({a: [{b:"xyz"}]});
+        fail();
+      }
+      catch (err) {
+        assertEqual(errors.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code, err.errorNum);
+      }
+
+      collection.update(meta._key, {a: [{b:"123"}]});
+
+      let meta2 = collection.insert({a: [{b:"xyz"}]});  // must work again
+
+      try {
+        collection.insert({a: [{b:"xyz"}]});
+        fail();
+      }
+      catch (err) {
+        assertEqual(errors.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code, err.errorNum);
+      }
+
+      collection.replace(meta2._key, {a: [{b:"456"}]});
+
+      collection.insert({a: [{b:"xyz"}]});  // must work again
+    },
 
   };
 }


### PR DESCRIPTION
This fixes BTS-548, see details there. Longer story short: if there is an array index and there is a document update or replace, then we had a shortcut which bypasses the array index update if none of the indexed attributes has changed. In the array
case the change of an array to an empty array was not recognized and thus the index was not updated.

 - Fix attributesEqual for update/replace array index changes.
 - CHANGELOG.

Scope & Purpose

(Please describe the changes in this PR for reviewers - mandatory)

[*] Bugfix (requires CHANGELOG entry)
[*] CHANGELOG entry made

Backports:

No backports required
[*] Backports required for: 3.7, 3.8

Related Information

(Please reference tickets / specification / other PRs etc)

[*] GitHub issue / Jira ticket number: BTS-548

Testing & Verification

(Please pick either of the following options)

[*] The behavior in this PR was manually tested
[*] This PR adds tests that were used to verify all changes:

    [*] Added new integration tests (e.g. in shell_server / shell_server_aql)

