### PR TITLE
output database directory of instance for better reference

### DIFF
--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -2057,7 +2057,10 @@ function launchFinalize(options, instanceInfo, startTime) {
     } else {
       ports.push('port ' + port);
     }
-    processInfo.push('  [' + arangod.role + '] up with pid ' + arangod.pid + ' on port ' + port);
+    processInfo.push('  [' + arangod.role +
+                     '] up with pid ' + arangod.pid +
+                     ' on port ' + port +
+                     ' - ' + arangod.args['database.directory']);
   });
 
   print(Date() + ' sniffing template:\n  tcpdump -ni lo -s0 -w /tmp/out.pcap ' + ports.join(' or ') + '\n');


### PR DESCRIPTION
### Scope & Purpose

Improve tests by outputting base directory belonging to ports in overview

```
  [agent] up with pid 1771231 on port 23287 - /tmp/arangosh_wq3Hhk/shell_client/agency/data0
  [agent] up with pid 1771232 on port 4699 - /tmp/arangosh_wq3Hhk/shell_client/agency/data1
  [agent] up with pid 1771233 on port 20088 - /tmp/arangosh_wq3Hhk/shell_client/agency/data2
  [dbserver] up with pid 1771436 on port 6045 - /tmp/arangosh_wq3Hhk/shell_client/dbserver0/data
  [dbserver] up with pid 1771437 on port 20867 - /tmp/arangosh_wq3Hhk/shell_client/dbserver1/data
  [dbserver] up with pid 1771438 on port 3926 - /tmp/arangosh_wq3Hhk/shell_client/dbserver2/data
  [coordinator] up with pid 1771440 on port 8583 - /tmp/arangosh_wq3Hhk/shell_client/coordinator0/data
  [coordinator] up with pid 1771442 on port 16944 - /tmp/arangosh_wq3Hhk/shell_client/coordinator1/data
```
