### PR TITLE
Fix /_admin/cluster/health if one agent gone

### DIFF
--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -1689,7 +1689,7 @@ RestStatus RestAdminClusterHandler::handleHealth() {
               std::string memberName = member.key.copyString();
 
               auto future =
-                  network::sendRequestRetry(pool, endpoint, fuerte::RestVerb::Get,
+                  network::sendRequest(pool, endpoint, fuerte::RestVerb::Get,
                                        "/_api/agency/config", VPackBuffer<uint8_t>())
                       .then([endpoint = std::move(endpoint), memberName = std::move(memberName)](
                                 futures::Try<network::Response>&& resp) mutable {


### PR DESCRIPTION
This is a rather trivial bug fix which addreses BTS-584.

It fixes a regression on /_admin/cluster/health if an agent is off line,
since the health endpoint retried for too long to reach the agent before
giving up.

This is a trivial fix which is covered by QA tests.
