### PR TITLE
Avoid acquisition of recursive read lock on server shutdown

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.8.2 (XXXX-XX-XX)
 -------------------
 
+* Avoid the acquisition of a recursive read lock on server shutdown, which
+  could in theory lead to shutdown hangs at least if a concurrent thread is
+  trying to modify the list of collections (very unlikely and never observed
+  until now).
+
 * Fix active failover, so that the new host actually has working
   foxx services. (BTS-558)
 

--- a/arangod/Replication/GlobalInitialSyncer.cpp
+++ b/arangod/Replication/GlobalInitialSyncer.cpp
@@ -303,8 +303,7 @@ Result GlobalInitialSyncer::updateServerInventory(VPackSlice const& leaderDataba
             if (!collection->system()) {  // we will not drop system collections here
               toDrop.emplace_back(collection);
             }
-          },
-          false);
+          });
 
       for (auto const& collection : toDrop) {
         try {

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -487,14 +487,13 @@ void DatabaseFeature::stop() {
 #endif
     vocbase->stop();
 
-    vocbase->processCollections(
+    vocbase->processCollectionsOnShutdown(
         [](LogicalCollection* collection) {
           // no one else must modify the collection's status while we are in
           // here
           collection->executeWhileStatusWriteLocked(
               [collection]() { collection->close(); });
-        },
-        true);
+        });
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     // i am here for debugging only.

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -1736,33 +1736,34 @@ std::vector<std::shared_ptr<arangodb::LogicalView>> TRI_vocbase_t::views() {
   return views;
 }
 
-void TRI_vocbase_t::processCollections(std::function<void(LogicalCollection*)> const& cb,
-                                       bool includeDeleted) {
+void TRI_vocbase_t::processCollectionsOnShutdown(std::function<void(LogicalCollection*)> const& cb) {
+  RECURSIVE_WRITE_LOCKER(_dataSourceLock, _dataSourceLockWriteOwner);
+
+  for (auto const& it : _collections) {
+    cb(it.get());
+  }
+}
+
+void TRI_vocbase_t::processCollections(std::function<void(LogicalCollection*)> const& cb) {
   RECURSIVE_READ_LOCKER(_dataSourceLock, _dataSourceLockWriteOwner);
 
-  if (includeDeleted) {
-    for (auto const& it : _collections) {
-      cb(it.get());
-    }
-  } else {
-    for (auto& entry : _dataSourceById) {
-      TRI_ASSERT(entry.second);
+  for (auto& entry : _dataSourceById) {
+    TRI_ASSERT(entry.second);
 
-      if (entry.second->category() != LogicalCollection::category()) {
-        continue;
-      }
+    if (entry.second->category() != LogicalCollection::category()) {
+      continue;
+    }
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-      auto collection =
-          std::dynamic_pointer_cast<arangodb::LogicalCollection>(entry.second);
-      TRI_ASSERT(collection);
+    auto collection =
+        std::dynamic_pointer_cast<arangodb::LogicalCollection>(entry.second);
+    TRI_ASSERT(collection);
 #else
-      auto collection =
-          std::static_pointer_cast<arangodb::LogicalCollection>(entry.second);
+    auto collection =
+        std::static_pointer_cast<arangodb::LogicalCollection>(entry.second);
 #endif
 
-      cb(collection.get());
-    }
+    cb(collection.get());
   }
 }
 

--- a/arangod/VocBase/vocbase.h
+++ b/arangod/VocBase/vocbase.h
@@ -252,8 +252,9 @@ struct TRI_vocbase_t {
   /// @brief returns all known collections
   std::vector<std::shared_ptr<arangodb::LogicalCollection>> collections(bool includeDeleted);
 
-  void processCollections(std::function<void(arangodb::LogicalCollection*)> const& cb,
-                          bool includeDeleted);
+  void processCollectionsOnShutdown(std::function<void(arangodb::LogicalCollection*)> const& cb);
+
+  void processCollections(std::function<void(arangodb::LogicalCollection*)> const& cb);
 
   /// @brief returns names of all known collections
   std::vector<std::string> collectionNames();


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/760

* Avoid the acquisition of a recursive read lock on server shutdown, which
  could in theory lead to shutdown hangs at least if a concurrent thread is
  trying to modify the list of collections (very unlikely and never observed
  until now).

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

#### Related Information

- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/760

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
