### PR TITLE
Avoid acquisition of recursive read lock on server shutdown

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Avoid the acquisition of a recursive read lock on server shutdown, which
+  could in theory lead to shutdown hangs at least if a concurrent thread is
+  trying to modify the list of collections (very unlikely and never observed
+  until now).
+
 * Fixed display of unicode characters in Windows console.
 
 * Fixed issue BTS-531 "Error happens during EXE package installation if

--- a/arangod/Replication/GlobalInitialSyncer.cpp
+++ b/arangod/Replication/GlobalInitialSyncer.cpp
@@ -305,8 +305,7 @@ Result GlobalInitialSyncer::updateServerInventory(VPackSlice const& leaderDataba
             if (!collection->system()) {  // we will not drop system collections here
               toDrop.emplace_back(collection);
             }
-          },
-          false);
+          });
 
       for (auto const& collection : toDrop) {
         try {

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -484,14 +484,13 @@ void DatabaseFeature::stop() {
 #endif
     vocbase->stop();
 
-    vocbase->processCollections(
+    vocbase->processCollectionsOnShutdown(
         [](LogicalCollection* collection) {
           // no one else must modify the collection's status while we are in
           // here
           collection->executeWhileStatusWriteLocked(
               [collection]() { collection->close(); });
-        },
-        true);
+        });
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     // i am here for debugging only.

--- a/arangod/VocBase/vocbase.h
+++ b/arangod/VocBase/vocbase.h
@@ -286,8 +286,9 @@ struct TRI_vocbase_t {
   /// @brief returns all known collections
   std::vector<std::shared_ptr<arangodb::LogicalCollection>> collections(bool includeDeleted);
 
-  void processCollections(std::function<void(arangodb::LogicalCollection*)> const& cb,
-                          bool includeDeleted);
+  void processCollectionsOnShutdown(std::function<void(arangodb::LogicalCollection*)> const& cb);
+
+  void processCollections(std::function<void(arangodb::LogicalCollection*)> const& cb);
 
   /// @brief returns names of all known collections
   std::vector<std::string> collectionNames();


### PR DESCRIPTION
### Scope & Purpose

Devel port of https://github.com/arangodb/arangodb/pull/14791
Enterprise companion PR: https://github.com/arangodb/enterprise/pull/761

* Avoid the acquisition of a recursive read lock on server shutdown, which
  could in theory lead to shutdown hangs at least if a concurrent thread is
  trying to modify the list of collections (very unlikely and never observed
  until now).

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for *3.8*: https://github.com/arangodb/arangodb/pull/14791

#### Related Information

- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/761

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
