### PR TITLE
make AQL modification operations blocking again

### DIFF
--- a/arangod/Aql/SimpleModifier.cpp
+++ b/arangod/Aql/SimpleModifier.cpp
@@ -173,6 +173,13 @@ ExecutionState SimpleModifier<ModifierCompletion, Enable>::transact(transaction:
 
   auto result = _completion.transact(trx, _accumulator.closeAndGetContents());
 
+  // we are currently waiting here for the `result` future to get
+  // ready before we continue. this makes the AQL modification
+  // operations blocking as in previous versions of ArangoDB.
+  // TODO: fix this and make it truly non-blocking (requires to
+  // fix some lifecycle issues for AQL queries first).
+  result.wait();
+
   if (result.isReady()) {
     _results = std::move(result.get());
     return ExecutionState::DONE;


### PR DESCRIPTION
### Scope & Purpose

This is an interim solution so everything works safely when we branch off 3.9. the proper solution is to keep the modification operations truly asynchronously, but this requires some lifecycle fix for AQL queries first. The latter will be addressed when there is time next.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *shell_server_aql, chaos*.
