### PR TITLE
add missing initialization to OperationOptions flag

### DIFF
--- a/arangod/Utils/OperationOptions.cpp
+++ b/arangod/Utils/OperationOptions.cpp
@@ -42,6 +42,7 @@ OperationOptions::OperationOptions()
       isRestore(false),
       checkUniqueConstraintsInPreflight(false),
       truncateCompact(true),
+      documentCallFromAql(false),
       _context(nullptr) {}
 
 OperationOptions::OperationOptions(ExecContext const& context)


### PR DESCRIPTION
### Scope & Purpose

Add proper initialization to `OperationOptions` flag `documentCallFromAql`.
This was missing before. No CHANGELOG entry added, because the flag was only recently backported to 3.8 and was not yet released.
Note: this does not need any backport to 3.7 because the option does not exist there, and forward port to devel because in devel the variable is properly initialized.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [x] I ensured this code runs with ASan / TSan or other static verification tools
