### PR TITLE
prevent stealing of values from Aql const registers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.8.2 (XXXX-XX-XX)
 -------------------
 
+* Prevent stealing of values from AQL const value registers. This fixes an
+  issue for queries that produce constant results (known at query compile time)
+  when the queries are executed directly on a DB server in a cluster (which is
+  not supported, but may happen for troubleshooting).
+
 * Fix active failover, so that the new host actually has working
   foxx services. (BTS-558)
 

--- a/arangod/Aql/InputAqlItemRow.cpp
+++ b/arangod/Aql/InputAqlItemRow.cpp
@@ -157,6 +157,11 @@ AqlValue InputAqlItemRow::stealValue(RegisterId registerId) {
   TRI_ASSERT(registerId.isConstRegister() || registerId < getNumRegisters());
   AqlValue const& a = block().getValueReference(_baseIndex, registerId);
   if (!a.isEmpty() && a.requiresDestruction()) {
+    if (registerId.isConstRegister()) {
+      // we cannot steal the value of a const register!
+      return a.clone();
+    }
+
     // Now no one is responsible for AqlValue a
     block().steal(a);
   }


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/14798

Prevent stealing of values from AQL const registers. These values must stay constant until the end of the query.
This fixes an issue for queries that produce constant results (known at query compile time) when the queries are executed directly on a DB server in a cluster (which is not supported, but may happen for troubleshooting).

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (shell_client)
- [x] I ensured this code runs with ASan / TSan or other static verification tools
