### PR TITLE
Fixed BTS-562

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fixed BTS-562: reduce-extraction-to-projection optimization returns null for 
+  one attribute if nested attributes are named the same.
+
 * Add `--datatype` startup option to arangoimport, in order to hard-code the
   datatype (null/boolean/number/string) for certain attributes in the CSV/TSV import.
   For example, given the following input file:

--- a/arangod/Aql/AttributeNamePath.cpp
+++ b/arangod/Aql/AttributeNamePath.cpp
@@ -133,9 +133,10 @@ AttributeNamePath& AttributeNamePath::shortenTo(size_t length) {
   size_t numEqual = 0;
   size_t commonLength = std::min(lhs.size(), rhs.size());
   for (size_t i = 0; i < commonLength; ++i) {
-    if (lhs[i] == rhs[i]) {
-      ++numEqual;
+    if (lhs[i] != rhs[i]) {
+      break;
     }
+    ++numEqual;
   }
   return numEqual;
 }


### PR DESCRIPTION
### Scope & Purpose

https://arangodb.atlassian.net/browse/BTS-562

* Fixed BTS-562: reduce-extraction-to-projection optimization returns null for
  one attribute if nested attributes are named the same.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*: https://github.com/arangodb/arangodb/pull/14801

#### Related Information

- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-562, https://github.com/arangodb/arangodb/issues/14672, https://github.com/arangodb/arangodb/issues/14790

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (shell_server_aql)
