### PR TITLE
experimental: try a container growth factor of 1.5x

### DIFF
--- a/lib/Containers/Helpers.h
+++ b/lib/Containers/Helpers.h
@@ -33,8 +33,8 @@ namespace arangodb::containers {
 struct Helpers {
 /// @brief calculate capacity for the container for at least one more 
 /// element.
-/// if this would exceed the container's capacity, use a factor-of-2
-/// growth strategy to calculate the capacity.
+/// if this would exceed the container's capacity, use a growth factor of
+/// 1.5 to calculate the new capacity.
 template<typename T>
 static std::size_t nextCapacity(T const& container, std::size_t initialCapacity) {
   std::size_t capacity;
@@ -42,10 +42,11 @@ static std::size_t nextCapacity(T const& container, std::size_t initialCapacity)
     // reserve some initial space
     capacity = std::max(std::size_t(1), initialCapacity);
   } else {
+    // minimum is that we have room for at least one more element.
     capacity = container.size() + 1;
-    // allocate with power of 2 growth
     if (capacity > container.capacity()) {
-      capacity *= 2;
+      // grow with a growth factor of 1.5
+      capacity = (container.size() * 3) / 2;
     }
   }
   TRI_ASSERT(capacity > container.size());
@@ -53,8 +54,8 @@ static std::size_t nextCapacity(T const& container, std::size_t initialCapacity)
 }
 
 /// @brief reserve space for at least one more element in the container.
-/// if this would exceed the container's capacity, use a factor-of-2
-/// growth strategy to grow the container's memory.
+/// if this would exceed the container's capacity, use a growth factor of
+/// 1.5 to grow the container's memory.
 template<typename T>
 static void reserveSpace(T& container, std::size_t initialCapacity) {
   std::size_t capacity = nextCapacity(container, initialCapacity);


### PR DESCRIPTION
### Scope & Purpose

As suggest by @goedderz in https://github.com/arangodb/arangodb/pull/14803#discussion_r713709584:

Experimental: try a container growth factor of 1.5x instead of 2x. We will have to see if this has an impact in our regular performance tests.
If this does not have any measurable or a negative effect on performance, we can simply revert the changes in this PR.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
