### PR TITLE
Hide help text fragment about VST connection strings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Hide help text fragment about VST connection strings in client tools that
+  do not support VST.
+
 * Added REST API endpoint `/_admin/debug/failat/all` to retrieve the list
   of currently enabled failure points. This API is available only if 
   failure testing is enabled, but not in production.

--- a/arangosh/Shell/ClientFeature.cpp
+++ b/arangosh/Shell/ClientFeature.cpp
@@ -30,6 +30,7 @@
 #include "Basics/StaticStrings.h"
 #include "Basics/Utf8Helper.h"
 #include "Basics/application-exit.h"
+#include "Basics/files.h"
 #include "Endpoint/Endpoint.h"
 #include "Logger/Logger.h"
 #include "ProgramOptions/ProgramOptions.h"
@@ -62,19 +63,17 @@ ClientFeature::ClientFeature(application_features::ApplicationServer& server,
       _maxPacketSize(1024 * 1024 * 1024),
       _sslProtocol(TLS_V12),
       _retries(DEFAULT_RETRIES),
+#if _WIN32
+      _codePage(65001),  // default to UTF8
+      _originalCodePage(UINT16_MAX),
+#endif
+      _allowJwtSecret(allowJwtSecret),
       _authentication(true),
       _askJwtSecret(false),
-      _allowJwtSecret(allowJwtSecret),
       _warn(false),
       _warnConnect(true),
       _haveServerPassword(false),
-      _forceJson(false)
-#if _WIN32
-      ,
-      _codePage(65001),  // default to UTF8
-      _originalCodePage(UINT16_MAX)
-#endif
-{
+      _forceJson(false) {
   setOptional(true);
   requiresElevatedPrivileges(false);
   startsAfter<CommunicationFeaturePhase>();
@@ -95,11 +94,26 @@ void ClientFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addOption("--server.username", "username to use when connecting",
                      new StringParameter(&_username));
 
+  bool isArangosh = false;
+  { 
+    std::string basename = TRI_Basename(options->progname());
+    isArangosh = basename == "arangosh" || basename == "arangosh.exe";
+  }
+
+  char const* endpointHelp;
+  if (isArangosh) {
+    endpointHelp = "endpoint to connect to. Use 'none' to start without a server. "
+                   "Use http+ssl:// or vst+ssl:// as schema to connect to an SSL-secured "
+                   "server endpoint, otherwise http+tcp://, vst+tcp:// or unix://";
+  } else {
+    endpointHelp = "endpoint to connect to. Use 'none' to start without a server. "
+                   "Use http+ssl:// as schema to connect to an SSL-secured "
+                   "server endpoint, otherwise http+tcp:// or unix://";
+  }
+
   options->addOption(
       "--server.endpoint",
-      "endpoint to connect to. Use 'none' to start without a server. "
-      "Use http+ssl:// or vst+ssl:// as schema to connect to an SSL-secured "
-      "server endpoint, otherwise http+tcp://, vst+tcp:// or unix://",
+      endpointHelp,
       new StringParameter(&_endpoint));
 
   options->addOption("--server.password",
@@ -108,11 +122,14 @@ void ClientFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                      "for a password",
                      new StringParameter(&_password));
 
-  options->addOption("--server.force-json",
-                     "force to not use VelocyPack for easier debugging",
-                     new BooleanParameter(&_forceJson),
-                     arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden))
-    .setIntroducedIn(30600);
+  if (isArangosh) {
+    // this option is only available in arangosh
+    options->addOption("--server.force-json",
+                       "force to not use VelocyPack for easier debugging",
+                       new BooleanParameter(&_forceJson),
+                       arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden))
+      .setIntroducedIn(30600);
+  }
 
   if (_allowJwtSecret) {
     // currently the option is only present for arangosh, but none

--- a/arangosh/Shell/ClientFeature.h
+++ b/arangosh/Shell/ClientFeature.h
@@ -123,19 +123,19 @@ class ClientFeature final : public HttpEndpointProvider {
   uint64_t _sslProtocol;
 
   size_t _retries;
-  bool _authentication;
-  bool _askJwtSecret;
-
-  bool _allowJwtSecret;
-  bool _warn;
-  bool _warnConnect;
-  bool _haveServerPassword;
-  bool _forceJson;
 
 #if _WIN32
   uint16_t _codePage;
   uint16_t _originalCodePage;
 #endif
+
+  bool const _allowJwtSecret;
+  bool _authentication;
+  bool _askJwtSecret;
+  bool _warn;
+  bool _warnConnect;
+  bool _haveServerPassword;
+  bool _forceJson;
 };
 
 }  // namespace arangodb

--- a/lib/ProgramOptions/ProgramOptions.h
+++ b/lib/ProgramOptions/ProgramOptions.h
@@ -95,6 +95,8 @@ class ProgramOptions {
   ProgramOptions(char const* progname, std::string const& usage,
                  std::string const& more, char const* binaryPath);
 
+  std::string progname() const { return _progname; }
+
   // sets a value translator
   void setTranslator(std::function<std::string(std::string const&, char const*)> const& translator);
 


### PR DESCRIPTION
### Scope & Purpose

Hide help text fragment about VST connection strings in client tools that do not support VST.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
