### PR TITLE
[3.8] Make all synchronous transaction methods set skipScheduler for network requests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.8.2 (XXXX-XX-XX)
 -------------------
 
+* Prevent some possible deadlocks under high load regarding transactions and
+  document operations, and also improve performance slightly.
+
 * Fixed BTS-562: reduce-extraction-to-projection optimization returns null for
   one attribute if nested attributes are named the same.
 

--- a/arangod/Cluster/ClusterMethods.h
+++ b/arangod/Cluster/ClusterMethods.h
@@ -34,6 +34,7 @@
 #include "Network/types.h"
 #include "Rest/CommonDefines.h"
 #include "Rest/GeneralResponse.h"
+#include "Transaction/MethodsApi.h"
 #include "Utils/OperationResult.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/voc-types.h"
@@ -120,7 +121,8 @@ futures::Future<OperationResult> figuresOnCoordinator(ClusterFeature&,
 
 futures::Future<OperationResult> countOnCoordinator(transaction::Methods& trx,
                                                     std::string const& collname,
-                                                    OperationOptions const& options);
+                                                    OperationOptions const& options,
+                                                    arangodb::transaction::MethodsApi api);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief gets the selectivity estimates from DBservers
@@ -136,17 +138,16 @@ Result selectivityEstimatesOnCoordinator(ClusterFeature&, std::string const& dbn
 ////////////////////////////////////////////////////////////////////////////////
 
 futures::Future<OperationResult> createDocumentOnCoordinator(
-    transaction::Methods const& trx, LogicalCollection&, VPackSlice const slice,
-    OperationOptions const& options);
+    transaction::Methods const& trx, LogicalCollection& coll, VPackSlice slice,
+    OperationOptions const& options, transaction::MethodsApi api);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief remove a document in a coordinator
 ////////////////////////////////////////////////////////////////////////////////
 
-futures::Future<OperationResult> removeDocumentOnCoordinator(transaction::Methods& trx,
-                                                             LogicalCollection&,
-                                                             VPackSlice const slice,
-                                                             OperationOptions const& options);
+futures::Future<OperationResult> removeDocumentOnCoordinator(
+    transaction::Methods& trx, LogicalCollection& coll, VPackSlice slice,
+    OperationOptions const& options, transaction::MethodsApi api);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief get a document in a coordinator
@@ -154,7 +155,8 @@ futures::Future<OperationResult> removeDocumentOnCoordinator(transaction::Method
 
 futures::Future<OperationResult> getDocumentOnCoordinator(transaction::Methods& trx,
                                                           LogicalCollection&, VPackSlice slice,
-                                                          OperationOptions const& options);
+                                                          OperationOptions const& options,
+                                                          transaction::MethodsApi api);
 
 /// @brief fetch edges from TraverserEngines
 ///        Contacts all TraverserEngines placed
@@ -211,14 +213,16 @@ void fetchVerticesFromEngines(
 
 futures::Future<OperationResult> modifyDocumentOnCoordinator(
     transaction::Methods& trx, LogicalCollection& coll,
-    arangodb::velocypack::Slice const& slice, OperationOptions const& options, bool isPatch);
+    arangodb::velocypack::Slice const& slice, OperationOptions const& options,
+    bool isPatch, transaction::MethodsApi api);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief truncate a cluster collection on a coordinator
 ////////////////////////////////////////////////////////////////////////////////
 
 futures::Future<OperationResult> truncateCollectionOnCoordinator(
-    transaction::Methods& trx, std::string const& collname, OperationOptions const& options);
+    transaction::Methods& trx, std::string const& collname,
+    OperationOptions const& options, transaction::MethodsApi api);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief flush Wal on all DBservers

--- a/arangod/Cluster/ClusterTrxMethods.cpp
+++ b/arangod/Cluster/ClusterTrxMethods.cpp
@@ -38,6 +38,7 @@
 #include "Transaction/Context.h"
 #include "Transaction/Helpers.h"
 #include "Transaction/Methods.h"
+#include "Transaction/MethodsApi.h"
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Slice.h>
@@ -132,7 +133,8 @@ void buildTransactionBody(TransactionState& state, ServerID const& server,
 
 /// @brief lazily begin a transaction on subordinate servers
 Future<network::Response> beginTransactionRequest(TransactionState& state,
-                                                  ServerID const& server) {
+                                                  ServerID const& server,
+                                                  transaction::MethodsApi api) {
   TransactionId tid = state.id().child();
   TRI_ASSERT(!tid.isLegacyTransactionId());
 
@@ -142,6 +144,7 @@ Future<network::Response> beginTransactionRequest(TransactionState& state,
 
   network::RequestOptions reqOpts;
   reqOpts.database = state.vocbase().name();
+  reqOpts.skipScheduler = api == transaction::MethodsApi::Synchronous;
 
   auto* pool = state.vocbase().server().getFeature<NetworkFeature>().pool();
   network::Headers headers;
@@ -202,7 +205,8 @@ Result checkTransactionResult(TransactionId desiredTid, transaction::Status desS
 }
 
 Future<Result> commitAbortTransaction(arangodb::TransactionState* state,
-                                      transaction::Status status) {
+                                      transaction::Status status,
+                                      transaction::MethodsApi api) {
   TRI_ASSERT(state->isRunning());
 
   if (state->knownServers().empty()) {
@@ -218,6 +222,7 @@ Future<Result> commitAbortTransaction(arangodb::TransactionState* state,
 
   network::RequestOptions reqOpts;
   reqOpts.database = state->vocbase().name();
+  reqOpts.skipScheduler = api == transaction::MethodsApi::Synchronous;
 
   TransactionId tidPlus = state->id().child();
   std::string const path = "/_api/transaction/" + std::to_string(tidPlus.id());
@@ -315,10 +320,11 @@ Future<Result> commitAbortTransaction(arangodb::TransactionState* state,
       });
 }
 
-Future<Result> commitAbortTransaction(transaction::Methods& trx, transaction::Status status) {
+Future<Result> commitAbortTransaction(transaction::Methods& trx, transaction::Status status,
+                                      transaction::MethodsApi api) {
   arangodb::TransactionState* state = trx.state();
   TRI_ASSERT(trx.isMainTransaction());
-  return commitAbortTransaction(state, status);
+  return commitAbortTransaction(state, status, api);
 }
 
 }  // namespace
@@ -332,8 +338,9 @@ bool IsServerIdLessThan::operator()(ServerID const& lhs, ServerID const& rhs) co
 }
 
 /// @brief begin a transaction on all leaders
-Future<Result> beginTransactionOnLeaders(TransactionState& state,
-                                         ClusterTrxMethods::SortedServersSet const& leaders) {
+Future<Result> beginTransactionOnLeaders(TransactionState& state, ClusterTrxMethods::SortedServersSet const& leaders,
+    // everything in this function is done synchronously, so the `api` parameter is currently unused.
+    [[maybe_unused]] transaction::MethodsApi api) {
   TRI_ASSERT(state.isCoordinator());
   TRI_ASSERT(!state.hasHint(transaction::Hints::Hint::SINGLE_OPERATION));
   Result res;
@@ -361,7 +368,8 @@ Future<Result> beginTransactionOnLeaders(TransactionState& state,
       if (state.knowsServer(leader)) {
         continue;  // already sent a begin transaction there
       }
-      requests.emplace_back(::beginTransactionRequest(state, leader));
+      requests.emplace_back(
+          ::beginTransactionRequest(state, leader, transaction::MethodsApi::Synchronous));
     }
 
     if (requests.empty()) {
@@ -413,8 +421,9 @@ Future<Result> beginTransactionOnLeaders(TransactionState& state,
 
     // abortTransaction on knownServers() and wait for them
     if (!state.knownServers().empty()) {
-      Result resetRes =
-          commitAbortTransaction(&state, transaction::Status::ABORTED).get();
+      Result resetRes = commitAbortTransaction(&state, transaction::Status::ABORTED,
+                                               transaction::MethodsApi::Synchronous)
+                            .get();
       if (resetRes.fail()) {
         // return here if cleanup failed - this needs to be a success
         return resetRes;
@@ -438,7 +447,7 @@ Future<Result> beginTransactionOnLeaders(TransactionState& state,
       serverBefore = leader;
 #endif
 
-      auto resp = ::beginTransactionRequest(state, leader);
+      auto resp = ::beginTransactionRequest(state, leader, transaction::MethodsApi::Synchronous);
       auto const& resolvedResponse = resp.get();
       if (resolvedResponse.fail()) {
         return resolvedResponse.combinedResult();
@@ -452,13 +461,13 @@ Future<Result> beginTransactionOnLeaders(TransactionState& state,
 }
 
 /// @brief commit a transaction on a subordinate
-Future<Result> commitTransaction(transaction::Methods& trx) {
-  return commitAbortTransaction(trx, transaction::Status::COMMITTED);
+Future<Result> commitTransaction(transaction::Methods& trx, transaction::MethodsApi api) {
+  return commitAbortTransaction(trx, transaction::Status::COMMITTED, api);
 }
 
 /// @brief commit a transaction on a subordinate
-Future<Result> abortTransaction(transaction::Methods& trx) {
-  return commitAbortTransaction(trx, transaction::Status::ABORTED);
+Future<Result> abortTransaction(transaction::Methods& trx, transaction::MethodsApi api) {
+  return commitAbortTransaction(trx, transaction::Status::ABORTED, api);
 }
 
 /// @brief set the transaction ID header

--- a/arangod/Cluster/ClusterTrxMethods.h
+++ b/arangod/Cluster/ClusterTrxMethods.h
@@ -26,6 +26,7 @@
 
 #include "Basics/Common.h"
 #include "Futures/Future.h"
+#include "Transaction/MethodsApi.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/voc-types.h"
 
@@ -47,14 +48,17 @@ struct IsServerIdLessThan {
 using SortedServersSet = std::set<ServerID, IsServerIdLessThan>;
 
 /// @brief begin a transaction on all followers
-Future<arangodb::Result> beginTransactionOnLeaders(TransactionState&,
-                                                   SortedServersSet const& leaders);
+Future<Result> beginTransactionOnLeaders(TransactionState&,
+                                         ClusterTrxMethods::SortedServersSet const& leaders,
+                                         transaction::MethodsApi api);
 
 /// @brief commit a transaction on a subordinate
-Future<arangodb::Result> commitTransaction(transaction::Methods& trx);
+Future<arangodb::Result> commitTransaction(transaction::Methods& trx,
+                                           transaction::MethodsApi api);
 
 /// @brief commit a transaction on a subordinate
-Future<arangodb::Result> abortTransaction(transaction::Methods& trx);
+Future<arangodb::Result> abortTransaction(transaction::Methods& trx,
+                                          transaction::MethodsApi api);
 
 /// @brief add the transaction ID header for servers
 template <typename MapT>

--- a/arangod/ClusterEngine/ClusterTransactionState.cpp
+++ b/arangod/ClusterEngine/ClusterTransactionState.cpp
@@ -102,7 +102,9 @@ Result ClusterTransactionState::beginTransaction(transaction::Hints hints) {
     // if there is only one server we may defer the lazy locking
     // until the first actual operation (should save one request)
     if (leaders.size() > 1) {
-      res = ClusterTrxMethods::beginTransactionOnLeaders(*this, leaders).get();
+      res = ClusterTrxMethods::beginTransactionOnLeaders(*this, leaders,
+                                                         transaction::MethodsApi::Synchronous)
+                .get();
       if (res.fail()) {  // something is wrong
         return res;
       }

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -508,94 +508,31 @@ Result transaction::Methods::begin() {
   return Result();
 }
 
+Result Methods::commit() {
+  return commitInternal(MethodsApi::Synchronous).get();
+}
+
 /// @brief commit / finish the transaction
 Future<Result> transaction::Methods::commitAsync() {
-  TRI_IF_FAILURE("TransactionCommitFail") { return Result(TRI_ERROR_DEBUG); }
+  return commitInternal(MethodsApi::Asynchronous);
+}
 
-  if (_state == nullptr || _state->status() != transaction::Status::RUNNING) {
-    // transaction not created or not running
-    return Result(TRI_ERROR_TRANSACTION_INTERNAL,
-                  "transaction not running on commit");
-  }
-
-  if (!_state->isReadOnlyTransaction()) {
-    auto const& exec = ExecContext::current();
-    bool cancelRW = ServerState::readOnly() && !exec.isSuperuser();
-    if (exec.isCanceled() || cancelRW) {
-      return Result(TRI_ERROR_ARANGO_READ_ONLY, "server is in read-only mode");
-    }
-  }
-
-  if (!_mainTransaction) {
-    return futures::makeFuture(Result());
-  }
-
-  auto f = futures::makeFuture(Result());
-  if (_state->isRunningInCluster()) {
-    // first commit transaction on subordinate servers
-    f = ClusterTrxMethods::commitTransaction(*this);
-  }
-
-  return std::move(f).thenValue([this](Result res) -> Result {
-    if (res.fail()) {  // do not commit locally
-      LOG_TOPIC("5743a", WARN, Logger::TRANSACTIONS)
-          << "failed to commit on subordinates: '" << res.errorMessage() << "'";
-      return res;
-    }
-
-    res = _state->commitTransaction(this);
-    if (res.ok()) {
-      applyStatusChangeCallbacks(*this, Status::COMMITTED);
-    }
-
-    return res;
-  });
+Result Methods::abort() {
+  return abortInternal(MethodsApi::Synchronous).get();
 }
 
 /// @brief abort the transaction
 Future<Result> transaction::Methods::abortAsync() {
-  if (_state == nullptr || _state->status() != transaction::Status::RUNNING) {
-    // transaction not created or not running
-    return Result(TRI_ERROR_TRANSACTION_INTERNAL,
-                  "transaction not running on abort");
-  }
+  return abortInternal(MethodsApi::Asynchronous);
+}
 
-  if (!_mainTransaction) {
-    return futures::makeFuture(Result());
-  }
-
-  auto f = futures::makeFuture(Result());
-  if (_state->isRunningInCluster()) {
-    // first commit transaction on subordinate servers
-    f = ClusterTrxMethods::abortTransaction(*this);
-  }
-
-  return std::move(f).thenValue([this](Result res) -> Result {
-    if (res.fail()) {  // do not commit locally
-      LOG_TOPIC("d89a8", WARN, Logger::TRANSACTIONS)
-          << "failed to abort on subordinates: " << res.errorMessage();
-    }  // abort locally anyway
-
-    res = _state->abortTransaction(this);
-    if (res.ok()) {
-      applyStatusChangeCallbacks(*this, Status::ABORTED);
-    }
-
-    return res;
-  });
+Result Methods::finish(Result const& res) {
+  return finishInternal(res, MethodsApi::Synchronous).get();
 }
 
 /// @brief finish a transaction (commit or abort), based on the previous state
 Future<Result> transaction::Methods::finishAsync(Result const& res) {
-  if (res.ok()) {
-    // there was no previous error, so we'll commit
-    return this->commitAsync();
-  }
-
-  // there was a previous error, so we'll abort
-  return this->abortAsync().thenValue([res](Result ignore) {
-    return res;  // return original error
-  });
+  return finishInternal(res, MethodsApi::Asynchronous);
 }
 
 /// @brief return the transaction id
@@ -758,7 +695,9 @@ Result transaction::Methods::documentFastPath(std::string const& collectionName,
   }
 
   if (_state->isCoordinator()) {
-    OperationResult opRes = documentCoordinator(collectionName, value, options).get();
+    OperationResult opRes =
+        documentCoordinator(collectionName, value, options, MethodsApi::Synchronous)
+            .get();
     if (!opRes.fail()) {
       result.add(opRes.slice());
     }
@@ -833,33 +772,23 @@ Future<OperationResult> addTracking(Future<OperationResult>&& f, F&& func) {
 }
 }
 
+OperationResult Methods::document(std::string const& collectionName,
+                                  VPackSlice value,
+                                  OperationOptions const& options) {
+  return documentInternal(collectionName, value, options, MethodsApi::Synchronous).get();
+}
+
 /// @brief return one or multiple documents from a collection
 Future<OperationResult> transaction::Methods::documentAsync(std::string const& cname,
                                                             VPackSlice value,
-                                                            OperationOptions& options) {
-  TRI_ASSERT(_state->status() == transaction::Status::RUNNING);
-
-  if (!value.isObject() && !value.isArray()) {
-    // must provide a document object or an array of documents
-    events::ReadDocument(vocbase().name(), cname, value, options,
-                         TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
-  }
-
-  if (_state->isCoordinator()) {
-    return addTracking(documentCoordinator(cname, value, options),
-                       [=](OperationResult&& opRes) {
-      events::ReadDocument(vocbase().name(), cname, value, opRes.options, opRes.errorNumber());
-      return std::move(opRes);
-    });
-  }
-  return documentLocal(cname, value, options);
+                                                            OperationOptions const& options) {
+  return documentInternal(cname, value, options, MethodsApi::Asynchronous);
 }
 
 /// @brief read one or multiple documents in a collection, coordinator
 #ifndef USE_ENTERPRISE
 Future<OperationResult> transaction::Methods::documentCoordinator(
-    std::string const& collectionName, VPackSlice value, OperationOptions const& options) {
+    std::string const& collectionName, VPackSlice value, OperationOptions const& options, MethodsApi api) {
   if (!value.isArray()) {
     arangodb::velocypack::StringRef key(transaction::helpers::extractKeyPart(value));
     if (key.empty()) {
@@ -872,7 +801,7 @@ Future<OperationResult> transaction::Methods::documentCoordinator(
     return futures::makeFuture(OperationResult(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, options));
   }
 
-  return arangodb::getDocumentOnCoordinator(*this, *colptr, value, options);
+  return arangodb::getDocumentOnCoordinator(*this, *colptr, value, options, api);
 }
 #endif
 
@@ -956,39 +885,19 @@ Future<OperationResult> transaction::Methods::documentLocal(std::string const& c
                                              options, countErrorCodes));
 }
 
+
+OperationResult Methods::insert(std::string const& cname, VPackSlice value,
+                                OperationOptions const& options) {
+  return insertInternal(cname, value, options, MethodsApi::Synchronous).get();
+}
+
 /// @brief create one or multiple documents in a collection
 /// the single-document variant of this operation will either succeed or,
 /// if it fails, clean up after itself
 Future<OperationResult> transaction::Methods::insertAsync(std::string const& cname,
                                                           VPackSlice value,
                                                           OperationOptions const& options) {
-  TRI_ASSERT(_state->status() == transaction::Status::RUNNING);
-
-  if (!value.isObject() && !value.isArray()) {
-    // must provide a document object or an array of documents
-    events::CreateDocument(vocbase().name(), cname, value, options,
-                           TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
-  }
-  if (value.isArray() && value.length() == 0) {
-    events::CreateDocument(vocbase().name(), cname, value, options, TRI_ERROR_NO_ERROR);
-    return emptyResult(options);
-  }
-
-  auto f = Future<OperationResult>::makeEmpty();
-  if (_state->isCoordinator()) {
-    f = insertCoordinator(cname, value, options);
-  } else {
-    OperationOptions optionsCopy = options;
-    f = insertLocal(cname, value, optionsCopy);
-  }
-
-  return addTracking(std::move(f), [=](OperationResult&& opRes) {
-    events::CreateDocument(vocbase().name(), cname,
-                           (opRes.ok() && opRes.options.returnNew) ? opRes.slice() : value,
-                           opRes.options, opRes.errorNumber());
-    return std::move(opRes);
-  });
+  return insertInternal(cname, value, options, MethodsApi::Asynchronous);
 }
 
 /// @brief create one or multiple documents in a collection, coordinator
@@ -997,12 +906,13 @@ Future<OperationResult> transaction::Methods::insertAsync(std::string const& cna
 #ifndef USE_ENTERPRISE
 Future<OperationResult> transaction::Methods::insertCoordinator(std::string const& collectionName,
                                                                 VPackSlice value,
-                                                                OperationOptions const& options) {
+                                                                OperationOptions const& options,
+                                                                MethodsApi api) {
   auto colptr = resolver()->getCollectionStructCluster(collectionName);
   if (colptr == nullptr) {
     return futures::makeFuture(OperationResult(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, options));
   }
-  return arangodb::createDocumentOnCoordinator(*this, *colptr, value, options);
+  return arangodb::createDocumentOnCoordinator(*this, *colptr, value, options, api);
 }
 #endif
 
@@ -1280,38 +1190,18 @@ Future<OperationResult> transaction::Methods::insertLocal(std::string const& cna
                                              options, std::move(errorCounter)));
 }
 
+OperationResult Methods::update(std::string const& cname, VPackSlice updateValue,
+                                OperationOptions const& options) {
+  return updateInternal(cname, updateValue, options, MethodsApi::Synchronous).get();
+}
+
 /// @brief update/patch one or multiple documents in a collection
 /// the single-document variant of this operation will either succeed or,
 /// if it fails, clean up after itself
 Future<OperationResult> transaction::Methods::updateAsync(std::string const& cname,
                                                           VPackSlice newValue,
                                                           OperationOptions const& options) {
-  TRI_ASSERT(_state->status() == transaction::Status::RUNNING);
-
-  if (!newValue.isObject() && !newValue.isArray()) {
-    // must provide a document object or an array of documents
-    events::ModifyDocument(vocbase().name(), cname, newValue, options,
-                           TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
-  }
-  if (newValue.isArray() && newValue.length() == 0) {
-    events::ModifyDocument(vocbase().name(), cname, newValue, options,
-                           TRI_ERROR_NO_ERROR);
-    return emptyResult(options);
-  }
-
-  auto f = Future<OperationResult>::makeEmpty();
-  if (_state->isCoordinator()) {
-    f = modifyCoordinator(cname, newValue, options, TRI_VOC_DOCUMENT_OPERATION_UPDATE);
-  } else {
-    OperationOptions optionsCopy = options;
-    f = modifyLocal(cname, newValue, optionsCopy, TRI_VOC_DOCUMENT_OPERATION_UPDATE);
-  }
-  return addTracking(std::move(f), [=](OperationResult&& opRes) {
-    events::ModifyDocument(vocbase().name(), cname, newValue, opRes.options,
-                           opRes.errorNumber());
-    return std::move(opRes);
-  });
+  return updateInternal(cname, newValue, options, MethodsApi::Asynchronous);
 }
 
 /// @brief update one or multiple documents in a collection, coordinator
@@ -1319,8 +1209,8 @@ Future<OperationResult> transaction::Methods::updateAsync(std::string const& cna
 /// if it fails, clean up after itself
 #ifndef USE_ENTERPRISE
 Future<OperationResult> transaction::Methods::modifyCoordinator(
-    std::string const& cname, VPackSlice newValue,
-    OperationOptions const& options, TRI_voc_document_operation_e operation) {
+    std::string const& cname, VPackSlice newValue, OperationOptions const& options,
+    TRI_voc_document_operation_e operation, MethodsApi api) {
   if (!newValue.isArray()) {
     arangodb::velocypack::StringRef key(transaction::helpers::extractKeyPart(newValue));
     if (key.empty()) {
@@ -1334,9 +1224,14 @@ Future<OperationResult> transaction::Methods::modifyCoordinator(
   }
 
   const bool isPatch = (TRI_VOC_DOCUMENT_OPERATION_UPDATE == operation);
-  return arangodb::modifyDocumentOnCoordinator(*this, *colptr, newValue, options, isPatch);
+  return arangodb::modifyDocumentOnCoordinator(*this, *colptr, newValue, options, isPatch, api);
 }
 #endif
+
+OperationResult Methods::replace(std::string const& cname, VPackSlice replaceValue,
+                                 OperationOptions const& options) {
+  return replaceInternal(cname, replaceValue, options, MethodsApi::Synchronous).get();
+}
 
 /// @brief replace one or multiple documents in a collection
 /// the single-document variant of this operation will either succeed or,
@@ -1344,32 +1239,7 @@ Future<OperationResult> transaction::Methods::modifyCoordinator(
 Future<OperationResult> transaction::Methods::replaceAsync(std::string const& cname,
                                               VPackSlice newValue,
                                               OperationOptions const& options) {
-  TRI_ASSERT(_state->status() == transaction::Status::RUNNING);
-
-  if (!newValue.isObject() && !newValue.isArray()) {
-    // must provide a document object or an array of documents
-    events::ReplaceDocument(vocbase().name(), cname, newValue, options,
-                            TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
-  }
-  if (newValue.isArray() && newValue.length() == 0) {
-    events::ReplaceDocument(vocbase().name(), cname, newValue, options,
-                            TRI_ERROR_NO_ERROR);
-    return futures::makeFuture(emptyResult(options));
-  }
-
-  auto f = Future<OperationResult>::makeEmpty();
-  if (_state->isCoordinator()) {
-    f = modifyCoordinator(cname, newValue, options, TRI_VOC_DOCUMENT_OPERATION_REPLACE);
-  } else {
-    OperationOptions optionsCopy = options;
-    f = modifyLocal(cname, newValue, optionsCopy, TRI_VOC_DOCUMENT_OPERATION_REPLACE);
-  }
-  return addTracking(std::move(f), [=](OperationResult&& opRes) {
-    events::ReplaceDocument(vocbase().name(), cname, newValue, opRes.options,
-                            opRes.errorNumber());
-    return std::move(opRes);
-  });
+  return replaceInternal(cname, newValue, options, MethodsApi::Asynchronous);
 }
 
 /// @brief replace one or multiple documents in a collection, local
@@ -1555,37 +1425,18 @@ Future<OperationResult> transaction::Methods::modifyLocal(std::string const& col
                          std::move(options), std::move(errorCounter));
 }
 
+OperationResult Methods::remove(std::string const& collectionName,
+                                VPackSlice value, OperationOptions const& options) {
+  return removeInternal(collectionName, value, options, MethodsApi::Synchronous).get();
+}
+
 /// @brief remove one or multiple documents in a collection
 /// the single-document variant of this operation will either succeed or,
 /// if it fails, clean up after itself
 Future<OperationResult> transaction::Methods::removeAsync(std::string const& cname,
                                                           VPackSlice value,
                                                           OperationOptions const& options) {
-  TRI_ASSERT(_state->status() == transaction::Status::RUNNING);
-
-  if (!value.isObject() && !value.isArray() && !value.isString()) {
-    // must provide a document object or an array of documents
-    events::DeleteDocument(vocbase().name(), cname, value, options,
-                           TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
-  }
-  if (value.isArray() && value.length() == 0) {
-    events::DeleteDocument(vocbase().name(), cname, value, options, TRI_ERROR_NO_ERROR);
-    return emptyResult(options);
-  }
-
-  auto f = Future<OperationResult>::makeEmpty();
-  if (_state->isCoordinator()) {
-    f = removeCoordinator(cname, value, options);
-  } else {
-    OperationOptions optionsCopy = options;
-    f = removeLocal(cname, value, optionsCopy);
-  }
-  return addTracking(std::move(f), [=](OperationResult&& opRes) {
-    events::DeleteDocument(vocbase().name(), cname, value, opRes.options,
-                           opRes.errorNumber());
-    return std::move(opRes);
-  });
+  return removeInternal(cname, value, options, MethodsApi::Asynchronous);
 }
 
 /// @brief remove one or multiple documents in a collection, coordinator
@@ -1594,12 +1445,13 @@ Future<OperationResult> transaction::Methods::removeAsync(std::string const& cna
 #ifndef USE_ENTERPRISE
 Future<OperationResult> transaction::Methods::removeCoordinator(std::string const& cname,
                                                                 VPackSlice value,
-                                                                OperationOptions const& options) {
+                                                                OperationOptions const& options,
+                                                                MethodsApi api) {
   auto colptr = resolver()->getCollectionStructCluster(cname);
   if (colptr == nullptr) {
     return futures::makeFuture(OperationResult(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, options));
   }
-  return arangodb::removeDocumentOnCoordinator(*this, *colptr, value, options);
+  return arangodb::removeDocumentOnCoordinator(*this, *colptr, value, options, api);
 }
 #endif
 
@@ -1824,28 +1676,23 @@ OperationResult transaction::Methods::allLocal(std::string const& collectionName
   return OperationResult(Result(), resultBuilder.steal(), options);
 }
 
+OperationResult Methods::truncate(std::string const& collectionName,
+                                  OperationOptions const& options) {
+  return truncateInternal(collectionName, options, MethodsApi::Synchronous).get();
+}
+
 /// @brief remove all documents in a collection
 Future<OperationResult> transaction::Methods::truncateAsync(std::string const& collectionName,
                                                             OperationOptions const& options) {
-  TRI_ASSERT(_state->status() == transaction::Status::RUNNING);
-
-  OperationOptions optionsCopy = options;
-  auto cb = [this, collectionName](OperationResult res) {
-    events::TruncateCollection(vocbase().name(), collectionName, res);
-    return res;
-  };
-
-  if (_state->isCoordinator()) {
-    return truncateCoordinator(collectionName, optionsCopy).thenValue(cb);
-  }
-  return truncateLocal(collectionName, optionsCopy).thenValue(cb);
+  return truncateInternal(collectionName, options, MethodsApi::Asynchronous);
 }
 
 /// @brief remove all documents in a collection, coordinator
 #ifndef USE_ENTERPRISE
 Future<OperationResult> transaction::Methods::truncateCoordinator(std::string const& collectionName,
-                                                                  OperationOptions& options) {
-  return arangodb::truncateCollectionOnCoordinator(*this, collectionName, options);
+                                                                  OperationOptions& options,
+                                                                  MethodsApi api) {
+  return arangodb::truncateCollectionOnCoordinator(*this, collectionName, options, api);
 }
 #endif
 
@@ -2016,44 +1863,37 @@ Future<OperationResult> transaction::Methods::truncateLocal(std::string const& c
   return futures::makeFuture(OperationResult(res, options));
 }
 
+OperationResult Methods::count(std::string const& collectionName,
+                               CountType type, OperationOptions const& options) {
+  return countInternal(collectionName, type, options, MethodsApi::Synchronous).get();
+}
+
 /// @brief count the number of documents in a collection
 futures::Future<OperationResult> transaction::Methods::countAsync(
     std::string const& collectionName, transaction::CountType type,
     OperationOptions const& options) {
-  TRI_ASSERT(_state->status() == transaction::Status::RUNNING);
-
-  if (_state->isCoordinator()) {
-    return countCoordinator(collectionName, type, options);
-  }
-
-  if (type == CountType::Detailed) {
-    // we are a single-server... we cannot provide detailed per-shard counts,
-    // so just downgrade the request to a normal request
-    type = CountType::Normal;
-  }
-
-  return futures::makeFuture(countLocal(collectionName, type, options));
+  return countInternal(collectionName, type, options, MethodsApi::Asynchronous);
 }
 
 #ifndef USE_ENTERPRISE
 /// @brief count the number of documents in a collection
 futures::Future<OperationResult> transaction::Methods::countCoordinator(
     std::string const& collectionName, transaction::CountType type,
-    OperationOptions const& options) {
+    OperationOptions const& options, MethodsApi api) {
   // First determine the collection ID from the name:
   auto colptr = resolver()->getCollectionStructCluster(collectionName);
   if (colptr == nullptr) {
     return futures::makeFuture(OperationResult(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, options));
   }
 
-  return countCoordinatorHelper(colptr, collectionName, type, options);
+  return countCoordinatorHelper(colptr, collectionName, type, options, api);
 }
 
 #endif
 
 futures::Future<OperationResult> transaction::Methods::countCoordinatorHelper(
     std::shared_ptr<LogicalCollection> const& collinfo, std::string const& collectionName,
-    transaction::CountType type, OperationOptions const& options) {
+    transaction::CountType type, OperationOptions const& options, MethodsApi api) {
   TRI_ASSERT(collinfo != nullptr);
   auto& cache = collinfo->countCache();
 
@@ -2067,7 +1907,7 @@ futures::Future<OperationResult> transaction::Methods::countCoordinatorHelper(
 
   if (documents == CountCache::NotPopulated) {
     // no cache hit, or detailed results requested
-    return arangodb::countOnCoordinator(*this, collectionName, options)
+    return arangodb::countOnCoordinator(*this, collectionName, options, api)
         .thenValue([&cache, type, options](OperationResult&& res) -> OperationResult {
           if (res.fail()) {
             return std::move(res);
@@ -2634,6 +2474,268 @@ Future<Result> Methods::replicateOperations(
     return Result();
   };
   return futures::collectAll(std::move(futures)).thenValue(std::move(cb));
+}
+
+Future<Result> Methods::commitInternal(MethodsApi api) {
+  TRI_IF_FAILURE("TransactionCommitFail") { return Result(TRI_ERROR_DEBUG); }
+
+  if (_state == nullptr || _state->status() != transaction::Status::RUNNING) {
+    // transaction not created or not running
+    return Result(TRI_ERROR_TRANSACTION_INTERNAL,
+                  "transaction not running on commit");
+  }
+
+  if (!_state->isReadOnlyTransaction()) {
+    auto const& exec = ExecContext::current();
+    bool cancelRW = ServerState::readOnly() && !exec.isSuperuser();
+    if (exec.isCanceled() || cancelRW) {
+      return Result(TRI_ERROR_ARANGO_READ_ONLY, "server is in read-only mode");
+    }
+  }
+
+  if (!_mainTransaction) {
+    return futures::makeFuture(Result());
+  }
+
+  auto f = futures::makeFuture(Result());
+  if (_state->isRunningInCluster()) {
+    // first commit transaction on subordinate servers
+    f = ClusterTrxMethods::commitTransaction(*this, api);
+  }
+
+  return std::move(f).thenValue([this](Result res) -> Result {
+    if (res.fail()) {  // do not commit locally
+      LOG_TOPIC("5743a", WARN, Logger::TRANSACTIONS)
+          << "failed to commit on subordinates: '" << res.errorMessage() << "'";
+      return res;
+    }
+
+    res = _state->commitTransaction(this);
+    if (res.ok()) {
+      applyStatusChangeCallbacks(*this, Status::COMMITTED);
+    }
+
+    return res;
+  });
+}
+
+Future<Result> Methods::abortInternal(MethodsApi api) {
+  if (_state == nullptr || _state->status() != transaction::Status::RUNNING) {
+    // transaction not created or not running
+    return Result(TRI_ERROR_TRANSACTION_INTERNAL,
+                  "transaction not running on abort");
+  }
+
+  if (!_mainTransaction) {
+    return futures::makeFuture(Result());
+  }
+
+  auto f = futures::makeFuture(Result());
+  if (_state->isRunningInCluster()) {
+    // first commit transaction on subordinate servers
+    f = ClusterTrxMethods::abortTransaction(*this, api);
+  }
+
+  return std::move(f).thenValue([this](Result res) -> Result {
+    if (res.fail()) {  // do not commit locally
+      LOG_TOPIC("d89a8", WARN, Logger::TRANSACTIONS)
+          << "failed to abort on subordinates: " << res.errorMessage();
+    }  // abort locally anyway
+
+    res = _state->abortTransaction(this);
+    if (res.ok()) {
+      applyStatusChangeCallbacks(*this, Status::ABORTED);
+    }
+
+    return res;
+  });
+}
+
+Future<Result> Methods::finishInternal(Result const& res, MethodsApi api) {
+  if (res.ok()) {
+    // there was no previous error, so we'll commit
+    return this->commitInternal(api);
+  }
+
+  // there was a previous error, so we'll abort
+  return this->abortInternal(api).thenValue([res](Result const& ignore) {
+    return res;  // return original error
+  });
+}
+
+Future<OperationResult> Methods::documentInternal(std::string const& cname, VPackSlice value,
+                                                  OperationOptions const& options, MethodsApi api) {
+  TRI_ASSERT(_state->status() == transaction::Status::RUNNING);
+
+  if (!value.isObject() && !value.isArray()) {
+    // must provide a document object or an array of documents
+    events::ReadDocument(vocbase().name(), cname, value, options,
+                         TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
+  }
+
+  if (_state->isCoordinator()) {
+    return addTracking(documentCoordinator(cname, value, options, api),
+                       [=](OperationResult&& opRes) {
+                         events::ReadDocument(vocbase().name(), cname, value,
+                                              opRes.options, opRes.errorNumber());
+                         return std::move(opRes);
+                       });
+  }
+  return documentLocal(cname, value, options);
+}
+
+Future<OperationResult> Methods::insertInternal(std::string const& cname, VPackSlice value,
+                                                OperationOptions const& options, MethodsApi api) {
+  TRI_ASSERT(_state->status() == transaction::Status::RUNNING);
+
+  if (!value.isObject() && !value.isArray()) {
+    // must provide a document object or an array of documents
+    events::CreateDocument(vocbase().name(), cname, value, options,
+                           TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
+  }
+  if (value.isArray() && value.length() == 0) {
+    events::CreateDocument(vocbase().name(), cname, value, options, TRI_ERROR_NO_ERROR);
+    return emptyResult(options);
+  }
+
+  auto f = Future<OperationResult>::makeEmpty();
+  if (_state->isCoordinator()) {
+    f = insertCoordinator(cname, value, options, api);
+  } else {
+    OperationOptions optionsCopy = options;
+    f = insertLocal(cname, value, optionsCopy);
+  }
+
+  return addTracking(std::move(f), [=](OperationResult&& opRes) {
+    events::CreateDocument(vocbase().name(), cname,
+                           (opRes.ok() && opRes.options.returnNew) ? opRes.slice() : value,
+                           opRes.options, opRes.errorNumber());
+    return std::move(opRes);
+  });
+}
+
+Future<OperationResult> Methods::updateInternal(std::string const& cname, VPackSlice newValue,
+                                                OperationOptions const& options, MethodsApi api) {
+  TRI_ASSERT(_state->status() == transaction::Status::RUNNING);
+
+  if (!newValue.isObject() && !newValue.isArray()) {
+    // must provide a document object or an array of documents
+    events::ModifyDocument(vocbase().name(), cname, newValue, options,
+                           TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
+  }
+  if (newValue.isArray() && newValue.length() == 0) {
+    events::ModifyDocument(vocbase().name(), cname, newValue, options, TRI_ERROR_NO_ERROR);
+    return emptyResult(options);
+  }
+
+  auto f = Future<OperationResult>::makeEmpty();
+  if (_state->isCoordinator()) {
+    f = modifyCoordinator(cname, newValue, options, TRI_VOC_DOCUMENT_OPERATION_UPDATE, api);
+  } else {
+    OperationOptions optionsCopy = options;
+    f = modifyLocal(cname, newValue, optionsCopy, TRI_VOC_DOCUMENT_OPERATION_UPDATE);
+  }
+  return addTracking(std::move(f), [=](OperationResult&& opRes) {
+    events::ModifyDocument(vocbase().name(), cname, newValue, opRes.options,
+                           opRes.errorNumber());
+    return std::move(opRes);
+  });
+}
+
+Future<OperationResult> Methods::replaceInternal(std::string const& cname, VPackSlice newValue,
+                                                 OperationOptions const& options, MethodsApi api) {
+  TRI_ASSERT(_state->status() == transaction::Status::RUNNING);
+
+  if (!newValue.isObject() && !newValue.isArray()) {
+    // must provide a document object or an array of documents
+    events::ReplaceDocument(vocbase().name(), cname, newValue, options,
+                            TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
+  }
+  if (newValue.isArray() && newValue.length() == 0) {
+    events::ReplaceDocument(vocbase().name(), cname, newValue, options, TRI_ERROR_NO_ERROR);
+    return futures::makeFuture(emptyResult(options));
+  }
+
+  auto f = Future<OperationResult>::makeEmpty();
+  if (_state->isCoordinator()) {
+    f = modifyCoordinator(cname, newValue, options, TRI_VOC_DOCUMENT_OPERATION_REPLACE, api);
+  } else {
+    OperationOptions optionsCopy = options;
+    f = modifyLocal(cname, newValue, optionsCopy, TRI_VOC_DOCUMENT_OPERATION_REPLACE);
+  }
+  return addTracking(std::move(f), [=](OperationResult&& opRes) {
+    events::ReplaceDocument(vocbase().name(), cname, newValue, opRes.options,
+                            opRes.errorNumber());
+    return std::move(opRes);
+  });
+}
+
+Future<OperationResult> Methods::removeInternal(std::string const& cname, VPackSlice value,
+                                                OperationOptions const& options, MethodsApi api) {
+  TRI_ASSERT(_state->status() == transaction::Status::RUNNING);
+
+  if (!value.isObject() && !value.isArray() && !value.isString()) {
+    // must provide a document object or an array of documents
+    events::DeleteDocument(vocbase().name(), cname, value, options,
+                           TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);
+  }
+  if (value.isArray() && value.length() == 0) {
+    events::DeleteDocument(vocbase().name(), cname, value, options, TRI_ERROR_NO_ERROR);
+    return emptyResult(options);
+  }
+
+  auto f = Future<OperationResult>::makeEmpty();
+  if (_state->isCoordinator()) {
+    f = removeCoordinator(cname, value, options, api);
+  } else {
+    OperationOptions optionsCopy = options;
+    f = removeLocal(cname, value, optionsCopy);
+  }
+  return addTracking(std::move(f), [=](OperationResult&& opRes) {
+    events::DeleteDocument(vocbase().name(), cname, value, opRes.options,
+                           opRes.errorNumber());
+    return std::move(opRes);
+  });
+}
+
+Future<OperationResult> Methods::truncateInternal(std::string const& collectionName,
+                                                  OperationOptions const& options, MethodsApi api) {
+  TRI_ASSERT(_state->status() == transaction::Status::RUNNING);
+
+  OperationOptions optionsCopy = options;
+  auto cb = [this, collectionName](OperationResult res) {
+    events::TruncateCollection(vocbase().name(), collectionName, res);
+    return res;
+  };
+
+  if (_state->isCoordinator()) {
+    return truncateCoordinator(collectionName, optionsCopy, api).thenValue(cb);
+  }
+  return truncateLocal(collectionName, optionsCopy).thenValue(cb);
+}
+
+futures::Future<OperationResult> Methods::countInternal(std::string const& collectionName,
+                                                        CountType type,
+                                                        OperationOptions const& options,
+                                                        MethodsApi api) {
+  TRI_ASSERT(_state->status() == transaction::Status::RUNNING);
+
+  if (_state->isCoordinator()) {
+    return countCoordinator(collectionName, type, options, api);
+  }
+
+  if (type == CountType::Detailed) {
+    // we are a single-server... we cannot provide detailed per-shard counts,
+    // so just downgrade the request to a normal request
+    type = CountType::Normal;
+  }
+
+  return futures::makeFuture(countLocal(collectionName, type, options));
 }
 
 #ifndef USE_ENTERPRISE

--- a/arangod/Transaction/Methods.h
+++ b/arangod/Transaction/Methods.h
@@ -34,6 +34,7 @@
 #include "Rest/CommonDefines.h"
 #include "Transaction/CountCache.h"
 #include "Transaction/Hints.h"
+#include "Transaction/MethodsApi.h"
 #include "Transaction/Options.h"
 #include "Transaction/Status.h"
 #include "Utils/OperationResult.h"
@@ -89,21 +90,15 @@ namespace transaction {
 
 class Methods {
  public:
-
   template<typename T>
   using Future = futures::Future<T>;
   using IndexHandle = std::shared_ptr<arangodb::Index>; // legacy
   using VPackSlice = arangodb::velocypack::Slice;
 
-  /// @brief transaction::Methods
- private:
   Methods() = delete;
   Methods(Methods const&) = delete;
-
   Methods& operator=(Methods const&) = delete;
 
- public:
-  
   /// @brief create the transaction
   explicit Methods(std::shared_ptr<transaction::Context> const& ctx,
                    transaction::Options const& options = transaction::Options());
@@ -204,17 +199,17 @@ class Methods {
   Result begin();
 
   /// @deprecated use async variant
-  Result commit() { return commitAsync().get(); }
+  Result commit();
   /// @brief commit / finish the transaction
   Future<Result> commitAsync();
 
   /// @deprecated use async variant
-  Result abort() { return abortAsync().get(); }
+  Result abort();
   /// @brief abort the transaction
   Future<Result> abortAsync();
 
   /// @deprecated use async variant
-  Result finish(Result const& res) { return finishAsync(res).get(); }
+  Result finish(Result const& res);
 
   /// @brief finish a transaction (commit or abort), based on the previous state
   Future<Result> finishAsync(Result const& res);
@@ -273,47 +268,37 @@ class Methods {
 
   /// @brief return one or multiple documents from a collection
   /// @deprecated use async variant
-  ENTERPRISE_VIRT OperationResult document(std::string const& collectionName,
-                                           VPackSlice value,
-                                           OperationOptions& options) {
-    return documentAsync(collectionName, value, options).get();
-  }
+  [[deprecated]] OperationResult document(std::string const& collectionName, VPackSlice value,
+                                          OperationOptions const& options);
 
   /// @brief return one or multiple documents from a collection
-  Future<OperationResult> documentAsync(std::string const& collectionName,
-                                        VPackSlice value, OperationOptions& options);
+  Future<OperationResult> documentAsync(std::string const& cname,
+                                        VPackSlice value,
+                                        OperationOptions const& options);
 
   /// @deprecated use async variant
-  OperationResult insert(std::string const& cname,
-                         VPackSlice value,
-                         OperationOptions const& options) {
-    return this->insertAsync(cname, value, options).get();
-  }
+  [[deprecated]] OperationResult insert(std::string const& cname, VPackSlice value,
+                                        OperationOptions const& options);
 
   /// @brief create one or multiple documents in a collection
   /// The single-document variant of this operation will either succeed or,
   /// if it fails, clean up after itself
-  Future<OperationResult> insertAsync(std::string const& collectionName,
-                                      VPackSlice value,
+  Future<OperationResult> insertAsync(std::string const& collectionName, VPackSlice value,
                                       OperationOptions const& options);
-  
+
   /// @deprecated use async variant
-  OperationResult update(std::string const& cname, VPackSlice updateValue,
-                         OperationOptions const& options) {
-    return this->updateAsync(cname, updateValue, options).get();
-  }
+  [[deprecated]] OperationResult update(std::string const& cname, VPackSlice updateValue,
+                                        OperationOptions const& options);
 
   /// @brief update/patch one or multiple documents in a collection.
   /// The single-document variant of this operation will either succeed or,
   /// if it fails, clean up after itself
   Future<OperationResult> updateAsync(std::string const& collectionName, VPackSlice updateValue,
                                       OperationOptions const& options);
-  
+
   /// @deprecated use async variant
-  OperationResult replace(std::string const& cname, VPackSlice replaceValue,
-                         OperationOptions const& options) {
-    return this->replaceAsync(cname, replaceValue, options).get();
-  }
+  [[deprecated]] OperationResult replace(std::string const& cname, VPackSlice replaceValue,
+                                         OperationOptions const& options);
 
   /// @brief replace one or multiple documents in a collection.
   /// The single-document variant of this operation will either succeed or,
@@ -322,40 +307,34 @@ class Methods {
                                        OperationOptions const& options);
 
   /// @deprecated use async variant
-  OperationResult remove(std::string const& collectionName,
-                         VPackSlice value, OperationOptions const& options) {
-    return removeAsync(collectionName, value, options).get();
-  }
+  [[deprecated]] OperationResult remove(std::string const& collectionName, VPackSlice value,
+                                        OperationOptions const& options);
 
   /// @brief remove one or multiple documents in a collection
   /// the single-document variant of this operation will either succeed or,
   /// if it fails, clean up after itself
-  Future<OperationResult> removeAsync(std::string const& collectionName,
-                                      VPackSlice value, OperationOptions const& options);
+  Future<OperationResult> removeAsync(std::string const& collectionName, VPackSlice value,
+                                      OperationOptions const& options);
 
   /// @brief fetches all documents in a collection
   ENTERPRISE_VIRT OperationResult all(std::string const& collectionName, uint64_t skip,
                                       uint64_t limit, OperationOptions const& options);
 
   /// @brief deprecated use async variant
-  OperationResult truncate(std::string const& collectionName, OperationOptions const& options) {
-    return this->truncateAsync(collectionName, options).get();
-  }
+  [[deprecated]] OperationResult truncate(std::string const& collectionName,
+                                          OperationOptions const& options);
 
   /// @brief remove all documents in a collection
   Future<OperationResult> truncateAsync(std::string const& collectionName,
                                         OperationOptions const& options);
 
   /// deprecated, use async variant
-  virtual OperationResult count(std::string const& collectionName,
-                                CountType type, OperationOptions const& options) {
-    return countAsync(collectionName, type, options).get();
-  }
+  [[deprecated]] OperationResult count(std::string const& collectionName, CountType type,
+                                       OperationOptions const& options);
 
   /// @brief count the number of documents in a collection
-  virtual futures::Future<OperationResult> countAsync(std::string const& collectionName,
-                                                      CountType type,
-                                                      OperationOptions const& options);
+  futures::Future<OperationResult> countAsync(std::string const& collectionName, CountType type,
+                                              OperationOptions const& options);
 
   /// @brief factory for IndexIterator objects from AQL
   /// note: the caller must have read-locked the underlying collection when
@@ -412,16 +391,17 @@ class Methods {
                              RevisionId oldRid, ManagedDocumentResult const* oldDoc,
                              ManagedDocumentResult const* newDoc);
 
-  Future<OperationResult> documentCoordinator(std::string const& collectionName,
-                                              VPackSlice value,
-                                              OperationOptions const& options);
+  futures::Future<OperationResult> documentCoordinator(std::string const& collectionName,
+                                                       VPackSlice const value,
+                                                       OperationOptions const& options,
+                                                       MethodsApi api);
 
   Future<OperationResult> documentLocal(std::string const& collectionName,
                                         VPackSlice value, OperationOptions const& options);
 
   Future<OperationResult> insertCoordinator(std::string const& collectionName,
-                                            VPackSlice value,
-                                            OperationOptions const& options);
+                                            VPackSlice value, OperationOptions const& options,
+                                            MethodsApi api);
 
   Future<OperationResult> insertLocal(std::string const& collectionName,
                                       VPackSlice value, OperationOptions& options);
@@ -429,7 +409,8 @@ class Methods {
   Future<OperationResult> modifyCoordinator(std::string const& collectionName,
                                             VPackSlice newValue,
                                             OperationOptions const& options,
-                                            TRI_voc_document_operation_e operation);
+                                            TRI_voc_document_operation_e operation,
+                                            MethodsApi api);
 
   Future<OperationResult> modifyLocal(std::string const& collectionName,
                                       VPackSlice newValue,
@@ -437,8 +418,8 @@ class Methods {
                                       TRI_voc_document_operation_e operation);
 
   Future<OperationResult> removeCoordinator(std::string const& collectionName,
-                                            VPackSlice value,
-                                            OperationOptions const& options);
+                                            VPackSlice value, OperationOptions const& options,
+                                            transaction::MethodsApi api);
 
   Future<OperationResult> removeLocal(std::string const& collectionName,
                                       VPackSlice value,
@@ -456,12 +437,38 @@ class Methods {
   OperationResult anyLocal(std::string const& collectionName, OperationOptions const& options);
 
   Future<OperationResult> truncateCoordinator(std::string const& collectionName,
-                                              OperationOptions& options);
+                                              OperationOptions& options, MethodsApi api);
 
   Future<OperationResult> truncateLocal(std::string const& collectionName,
                                         OperationOptions& options);
 
  protected:
+
+  // The internal methods distinguish between the synchronous and asynchronous
+  // APIs via an additional parameter, so `skipScheduler` can be set for network
+  // requests.
+  auto commitInternal(MethodsApi api) -> Future<Result>;
+  auto abortInternal(MethodsApi api) -> Future<Result>;
+  auto finishInternal(Result const& res, MethodsApi api) -> Future<Result>;
+  // is virtual for IgnoreNoAccessMethods
+  ENTERPRISE_VIRT auto documentInternal(std::string const& cname, VPackSlice value,
+                                        OperationOptions const& options, MethodsApi api)
+      -> Future<OperationResult>;
+  auto insertInternal(std::string const& collectionName, VPackSlice value,
+                      OperationOptions const& options, MethodsApi api) -> Future<OperationResult>;
+  auto updateInternal(std::string const& collectionName, VPackSlice updateValue,
+                      OperationOptions const& options, MethodsApi api) -> Future<OperationResult>;
+  auto replaceInternal(std::string const& collectionName, VPackSlice replaceValue,
+                       OperationOptions const& options, MethodsApi api) -> Future<OperationResult>;
+  auto removeInternal(std::string const& collectionName, VPackSlice value,
+                      OperationOptions const& options, MethodsApi api) -> Future<OperationResult>;
+  auto truncateInternal(std::string const& collectionName, OperationOptions const& options,
+                        MethodsApi api) -> Future<OperationResult>;
+  // is virtual for IgnoreNoAccessMethods
+  ENTERPRISE_VIRT auto countInternal(std::string const& collectionName, CountType type,
+                                     OperationOptions const& options, MethodsApi api)
+      -> futures::Future<OperationResult>;
+
   /// @brief return the transaction collection for a document collection
   TransactionCollection* trxCollection(DataSourceId cid,
                                        AccessMode::Type type = AccessMode::Type::READ) const;
@@ -471,11 +478,12 @@ class Methods {
 
   futures::Future<OperationResult> countCoordinator(std::string const& collectionName,
                                                     CountType type,
-                                                    OperationOptions const& options);
+                                                    OperationOptions const& options,
+                                                    MethodsApi api);
 
   futures::Future<OperationResult> countCoordinatorHelper(
       std::shared_ptr<LogicalCollection> const& collinfo, std::string const& collectionName,
-      CountType type, OperationOptions const& options);
+      CountType type, OperationOptions const& options, MethodsApi api);
 
   OperationResult countLocal(std::string const& collectionName, CountType type,
                              OperationOptions const& options);
@@ -505,7 +513,6 @@ class Methods {
       std::unordered_set<size_t> const& excludePositions,
       FollowerInfo& followerInfo);
 
- private:
   /// @brief transaction hints
   transaction::Hints _localHints;
 

--- a/arangod/Transaction/MethodsApi.h
+++ b/arangod/Transaction/MethodsApi.h
@@ -1,0 +1,30 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2021-2021 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+namespace arangodb::transaction {
+enum class MethodsApi {
+  Asynchronous,
+  Synchronous
+};
+}


### PR DESCRIPTION
Backport of #14810.

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/764