### PR TITLE
Fix missing rows in unsorted gather

### DIFF
--- a/arangod/Aql/ConstFetcher.cpp
+++ b/arangod/Aql/ConstFetcher.cpp
@@ -82,9 +82,10 @@ auto ConstFetcher::execute(AqlCallStack& stack)
         }
       }
       TRI_ASSERT(fromShadowRow < toShadowRow);
+      TRI_ASSERT(sliceIndexes.size() == 1);
       // We cannot go past the first shadowRow
-      sliceIndexes.emplace_back(fromShadowRow, toShadowRow);
       sliceIndexes[0].second = fromShadowRow;
+      sliceIndexes.emplace_back(fromShadowRow, toShadowRow);
     }
   }
   // Number of data rows we have left
@@ -109,7 +110,7 @@ auto ConstFetcher::execute(AqlCallStack& stack)
     }
     {
       // Produce the next rows
-      // Adjost from and rowsLeft
+      // Adjust to and rowsLeft
       // Note: canProduce can be 0
       size_t canProduce = (std::min)(call.getLimit(), rowsLeft);
       to = from + canProduce;
@@ -198,7 +199,7 @@ auto ConstFetcher::execute(AqlCallStack& stack)
 }
 
 void ConstFetcher::injectBlock(SharedAqlItemBlockPtr block, SkipResult skipped) {
-  // If this assert triggers, we have injected a block adn skip pair
+  // If this assert triggers, we have injected a block and skip pair
   // that has not yet been fetched.
   TRI_ASSERT(_skipped.nothingSkipped());
   _currentBlock = block;

--- a/arangod/Aql/ExecutionBlock.cpp
+++ b/arangod/Aql/ExecutionBlock.cpp
@@ -185,20 +185,22 @@ void ExecutionBlock::traceExecuteEnd(std::tuple<ExecutionState, SkipResult, Shar
           << " skipped=" << skipped.getSkipCount() << " produced=" << rows
           << " shadowRows=" << shadowRows
           << (clientId.empty() ? "" : " clientId=" + clientId);
-      ;
 
       if (_profileLevel >= ProfileLevel::TraceTwo) {
-        if (block == nullptr) {
-          LOG_QUERY("9b3f4", INFO)
-              << "execute type=" << node->getTypeString() << " result: nullptr";
-        } else {
-          auto const* opts = &_engine->getQuery().vpackOptions();
-          VPackBuilder builder;
-          block->toSimpleVPack(opts, builder);
-          LOG_QUERY("f12f9", INFO)
-              << "execute type=" << node->getTypeString()
-              << " result: " << VPackDumper::toString(builder.slice(), opts);
-        }
+        auto const resultString = std::invoke([&, &block = block]() -> std::string {
+          if (block == nullptr) {
+            return "nullptr";
+          } else {
+            auto const* opts = &_engine->getQuery().vpackOptions();
+            VPackBuilder builder;
+            block->toSimpleVPack(opts, builder);
+            return VPackDumper::toString(builder.slice(), opts);
+          }
+        });
+        LOG_QUERY("f12f9", INFO)
+            << "execute type=" << node->getTypeString() << " id=" << node->id()
+            << (clientId.empty() ? "" : " clientId=" + clientId)
+            << " result: " << resultString;
       }
     }
   }

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -1748,7 +1748,7 @@ ExecutionBlockImpl<Executor>::executeWithoutTrace(AqlCallStack const& callStack)
           // we do not have any input for this executor on the current depth.
           // We have skipped over the full subquery execution, so claim it is
           // DONE for now. It will be resetted after this shadowRow. If one
-          // of the next SubqueryRuns is not skipepd over.
+          // of the next SubqueryRuns is not skipped over.
           localExecutorState = ExecutorState::DONE;
           _execState = ExecState::SHADOWROWS;
           // The following line is in particular for the UnsortedGatherExecutor,

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -1751,6 +1751,22 @@ ExecutionBlockImpl<Executor>::executeWithoutTrace(AqlCallStack const& callStack)
           // of the next SubqueryRuns is not skipepd over.
           localExecutorState = ExecutorState::DONE;
           _execState = ExecState::SHADOWROWS;
+          // The following line is in particular for the UnsortedGatherExecutor,
+          // which implies we're using a MultiDependencyRowFetcher.
+          // Imagine the following situation:
+          // In case the last subquery ended, at least for one dependency, on an
+          // item block-boundary. But the next row in this dependency - and thus,
+          // all other dependencies - is a non-relevant shadow row. Then the
+          // executor will have been called by now, possibly multiple times,
+          // until all dependencies have some input and thus arrived at this
+          // particular shadow row. So now the condition of this if-branch is
+          // true.
+          // The outcome of this is that the executor is no longer in a freshly
+          // initialized state, but may have progressed over one or more
+          // dependencies already.
+          // Without the following reset, these dependencies would thus be
+          // ignored in the next subquery iteration.
+          resetExecutor();
         } else {
           _execState = ExecState::CHECKCALL;
         }

--- a/arangod/Aql/ExecutionBlockImpl.h
+++ b/arangod/Aql/ExecutionBlockImpl.h
@@ -285,7 +285,7 @@ class ExecutionBlockImpl final : public ExecutionBlock {
   // position of the callStack as "skipped".
   // as soon as we reach a place where there is no skip
   // ordered in the outer shadow rows, this call
-  // will fall back to shadowRowForwardning.
+  // will fall back to shadowRowForwarding.
   [[nodiscard]] auto sideEffectShadowRowForwarding(AqlCallStack& stack,
                                                    SkipResult& skipResult) -> ExecState;
 

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -378,7 +378,7 @@ RestStatus RestAqlHandler::useQuery(std::string const& operation, std::string co
 
   if (_engine->getQuery().queryOptions().profile >= ProfileLevel::TraceOne) {
     LOG_TOPIC("1bf67", INFO, Logger::QUERIES)
-        << "[query#" << idString << "] remote request received: " << operation
+        << "[query#" << _engine->getQuery().id() << "] remote request received: " << operation
         << " registryId=" << idString;
   }
 

--- a/arangod/Aql/UnsortedGatherExecutor.cpp
+++ b/arangod/Aql/UnsortedGatherExecutor.cpp
@@ -87,6 +87,7 @@ auto UnsortedGatherExecutor::produceRows(typename Fetcher::DataRange& input,
     auto callSet = AqlCallSet{};
     callSet.calls.emplace_back(
         AqlCallSet::DepCallPair{currentDependency(), AqlCallList{output.getClientCall()}});
+    TRI_ASSERT(input.upstreamState(currentDependency()) != ExecutorState::DONE);
     return {input.upstreamState(currentDependency()), Stats{}, callSet};
   }
 }

--- a/arangod/Aql/UnsortedGatherExecutor.cpp
+++ b/arangod/Aql/UnsortedGatherExecutor.cpp
@@ -87,7 +87,6 @@ auto UnsortedGatherExecutor::produceRows(typename Fetcher::DataRange& input,
     auto callSet = AqlCallSet{};
     callSet.calls.emplace_back(
         AqlCallSet::DepCallPair{currentDependency(), AqlCallList{output.getClientCall()}});
-    TRI_ASSERT(input.upstreamState(currentDependency()) != ExecutorState::DONE);
     return {input.upstreamState(currentDependency()), Stats{}, callSet};
   }
 }

--- a/tests/js/server/aql/aql-gather-block-cluster.js
+++ b/tests/js/server/aql/aql-gather-block-cluster.js
@@ -795,7 +795,7 @@ function gatherBlockTestSuite () {
       assertEqual(expected, actual, query);
     },
 
-    // This is a regression test. TODO Add link to PR
+    // This is a regression test, see https://github.com/arangodb/arangodb/pull/14837.
     // An UnsortedGather would get confused if an input block started with a non-relevant shadow row,
     // which let it skip some dependencies and thus miss some rows.
     testGatherOnShadowRowBoundary : function () {


### PR DESCRIPTION
### Scope & Purpose

There were certain situations in which an unsorted gather could miss some documents, because it accidentally skipped some dependencies.

In detail, this happened when the input blocks began with a non-relevant shadow row. In that case, the UnsortedGatherExecutor was called repeatedly until all inputs had blocks, and stayed on the named non-relevant shadow row. Then, the ExecutionBlockImpl would forward the shadow rows, but not reset the UnsortedGatherExecutor. Leaving it in a state where it already marked all but the last dependency as finished. Therefore missing possible rows in those dependencies.

This PR fixes this by just adding a single line that resets the executor, exactly when all dependencies have fetched some input and the ExecutionBlockImpl can proceed by forwarding the non-relevant shadow row.

- [X] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] Backports required for 3.8: *TODO*
- [ ] Backports required for 3.7: *TODO*

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [X] The behavior in this PR was *manually tested*
- [X] This change is already covered by existing tests, such as *shell_server_aql* and the unit tests.
- [X] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests** *TODO*
  - [X] Added new **integration tests** (regression test in *shell_server_aql*)
