### PR TITLE
willi

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Retain backwards-compatibility for client tools when more than one
+  endpoint is specified but the tool only supports a single endpoint.
+
 * Fixed BTS-602 by not starting license feature is upgrade mode.
 
 * APM-173: Now, arangobench, arangodump and arangorestore support multiple 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,6 @@
 devel
 -----
 
-* Retain backwards-compatibility for client tools when more than one
-  endpoint is specified but the tool only supports a single endpoint.
-
 * Fixed BTS-602 by not starting license feature is upgrade mode.
 
 * APM-173: Now, arangobench, arangodump and arangorestore support multiple 


### PR DESCRIPTION
### Scope & Purpose

Retain backwards-compatibility for client tools when more than one endpoint is specified but the tool only supports a single endpoint. This affects 3.9 only.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
