### PR TITLE
properly throw an exception in case an invalid state is encountered

### DIFF
--- a/arangod/Cache/Table.cpp
+++ b/arangod/Cache/Table.cpp
@@ -296,7 +296,8 @@ void Table::setTypeSpecifics(BucketClearer clearer, std::size_t slotsPerBucket) 
 void Table::clear() {
   disable();
   if (_auxiliary.get() != nullptr) {
-    throw;
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_INTERNAL, "unexpected auxiliary state");
   }
   for (std::uint64_t i = 0; i < _size; i++) {
     _bucketClearer(&(_buckets[i]));


### PR DESCRIPTION
### Scope & Purpose

Properly throw an exception in case an invalid state is encounteredin TableCache::clear(). The previous implementation just used `throw;`, which is not valid here.
This is a trivial code improvement for an issue that we have never seen happening anywhere.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*: https://github.com/arangodb/arangodb/pull/14850

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
