### PR TITLE
improve usage of `__has_include`

### DIFF
--- a/lib/Basics/Mutex.h
+++ b/lib/Basics/Mutex.h
@@ -24,8 +24,10 @@
 
 #pragma once
 
+#if defined __has_include
 #if __has_include(<pthread.h>)
 #include <pthread.h>
+#endif
 #endif
 
 #include "Basics/operating-system.h"

--- a/lib/Basics/Mutex.h
+++ b/lib/Basics/Mutex.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #if defined __has_include
+// cppcheck-suppress preprocessorErrorDirective
 #if __has_include(<pthread.h>)
 #include <pthread.h>
 #endif


### PR DESCRIPTION
### Scope & Purpose

Improve portability of `__has_include` macro, as advertised in gcc docs:
https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005finclude.html

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*: https://github.com/arangodb/arangodb/pull/14852

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
