### PR TITLE
improve usage of `__has_include`

### DIFF
--- a/lib/Basics/Mutex.h
+++ b/lib/Basics/Mutex.h
@@ -25,8 +25,10 @@
 #ifndef ARANGODB_BASICS_MUTEX_H
 #define ARANGODB_BASICS_MUTEX_H 1
 
+#if defined __has_include
 #if __has_include(<pthread.h>)
 #include <pthread.h>
+#endif
 #endif
 
 #include "Basics/operating-system.h"

--- a/lib/Basics/Mutex.h
+++ b/lib/Basics/Mutex.h
@@ -25,8 +25,8 @@
 #ifndef ARANGODB_BASICS_MUTEX_H
 #define ARANGODB_BASICS_MUTEX_H 1
 
-// cppcheck-suppress preprocessorErrorDirective
 #if defined __has_include
+// cppcheck-suppress preprocessorErrorDirective
 #if __has_include(<pthread.h>)
 #include <pthread.h>
 #endif

--- a/lib/Basics/Mutex.h
+++ b/lib/Basics/Mutex.h
@@ -25,6 +25,7 @@
 #ifndef ARANGODB_BASICS_MUTEX_H
 #define ARANGODB_BASICS_MUTEX_H 1
 
+// cppcheck-suppress preprocessorErrorDirective
 #if defined __has_include
 #if __has_include(<pthread.h>)
 #include <pthread.h>


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/14851

Improve portability of `__has_include` macro, as advertised in gcc docs:
https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005finclude.html

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required.

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
