### PR TITLE
[BTS-596] Fixing CppCheck warnings.

### DIFF
--- a/arangod/Replication2/Streams/StreamInformationBlock.tpp
+++ b/arangod/Replication2/Streams/StreamInformationBlock.tpp
@@ -107,31 +107,31 @@ auto StreamInformationBlock<stream_descriptor<Id, Type, Tags>>::getIteratorRange
 
   struct Iterator : TypedLogRangeIterator<StreamEntryView<Type>> {
     ContainerType _log;
-    ContainerIterator current;
-    LogIndex start, stop;
+    ContainerIterator _current;
+    LogIndex _start, _stop;
 
     auto next() -> std::optional<StreamEntryView<Type>> override {
-      if (current != std::end(_log) && current->first < stop) {
-        auto view = std::make_pair(current->first, std::cref(current->second));
-        ++current;
+      if (_current != std::end(_log) && _current->first < _stop) {
+        auto view = std::make_pair(_current->first, std::cref(_current->second));
+        ++_current;
         return view;
       }
       return std::nullopt;
     }
     [[nodiscard]] auto range() const noexcept -> LogRange override {
-      return {start, stop};
+      return {_start, _stop};
     }
 
     explicit Iterator(ContainerType log, LogIndex start, LogIndex stop)
         : _log(std::move(log)),
-          current(std::lower_bound(std::begin(_log), std::end(_log), start,
+          _current(std::lower_bound(std::begin(_log), std::end(_log), start,
                                    [](StreamEntry<Type> const& left, LogIndex index) {
                                      return left.first < index;
                                    })),
           // cppcheck-suppress 	selfInitialization
-          start(start),
+          _start(start),
           // cppcheck-suppress 	selfInitialization
-          stop(stop) {}
+          _stop(stop) {}
   };
   return std::make_unique<Iterator>(std::move(log), start, stop);
 }


### PR DESCRIPTION
### Scope & Purpose
Rename variables to work around false positive in CppCheck.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required