### PR TITLE
Improvements for WAL tailing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 v3.7.16 (XXXX-XX-XX)
 --------------------
 
+* Properly clean up replication client entries for tailing from WAL so that 
+  archived WAL files are not retained for an unnecessary long time period.
+
+* Added metrics `rocksdb_wal_sequence_lower_bound`, 
+  `rocksdb_archived_wal_files`, `rocskdb_prunable_wal_files` and 
+  `rocksdb_wal_pruning_active` to allow inspection of WAL file pruning from 
+  the outside.
+
 * Fixed BTS-582: ArangoDB client EXE package for Windows has incorrect metadata.
 
 * Fixed BTS-575: Windows EXE installer doesn't replace service during upgrade in

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -1572,6 +1572,27 @@ Result TailingSyncer::runContinuousSync() {
               ", open transactions: " + StringUtils::itoa(_ongoingTransactions.size()) +
               ", parallel: " + (_workInParallel ? "yes" : "no"));
 
+  // when we leave this method, we must unregister ourselves from the leader,
+  // otherwise the leader may keep WAL logs around for us for too long
+  auto unregister = scopeGuard([&]() noexcept {
+    if (ServerState::instance()->isRunningInCluster()) {
+      try {
+        _state.connection.lease([&](httpclient::SimpleHttpClient* client) {
+          std::unique_ptr<httpclient::SimpleHttpResult> response;
+          std::string const url = tailingBaseUrl("tail") +
+                                  "serverId=" + _state.localServerIdString +
+                                  "&syncerId=" + syncerId().toString();
+          // simply send the request, but don't care about the response. if it
+          // fails, there is not much we can do from here.
+          response.reset(client->request(rest::RequestType::DELETE_REQ, url, nullptr, 0));
+        });
+      } catch (...) {
+        // this must be exception-safe, but if an exception occurs, there is not
+        // much we can do
+      }
+    }
+  });
+
   // the shared status will wait in its destructor until all posted
   // requests have been completed/canceled!
   auto self = shared_from_this();
@@ -1803,7 +1824,7 @@ void TailingSyncer::fetchMasterLog(std::shared_ptr<Syncer::JobSynchronizer> shar
                                    TRI_voc_tick_t fetchTick, TRI_voc_tick_t lastScannedTick,
                                    TRI_voc_tick_t firstRegularTick) {
   try {
-    std::string const url =
+    std::string url =
         tailingBaseUrl("tail") +
         "chunkSize=" + StringUtils::itoa(_state.applier._chunkSize) +
         "&barrier=" + StringUtils::itoa(_state.barrier.id) +
@@ -1814,6 +1835,12 @@ void TailingSyncer::fetchMasterLog(std::shared_ptr<Syncer::JobSynchronizer> shar
         "&serverId=" + _state.localServerIdString +
         "&includeSystem=" + (_state.applier._includeSystem ? "true" : "false") +
         "&includeFoxxQueues=" + (_state.applier._includeFoxxQueues ? "true" : "false");
+
+    if (syncerId().value > 0) {
+      // we must only send the syncerId along if it is != 0, otherwise we will
+      // trigger an error on the leader
+      url += "&syncerId=" + syncerId().toString();
+    }
     
     // send request
     setProgress(std::string("fetching master log from tick ") + StringUtils::itoa(fetchTick) +

--- a/arangod/Replication/utilities.h
+++ b/arangod/Replication/utilities.h
@@ -165,7 +165,8 @@ struct MasterInfo {
 };
 
 struct BatchInfo {
-  static constexpr double DefaultTimeout = 7200.0;
+  static constexpr double DefaultTimeout = 3600.0;
+  static constexpr double DefaultTimeoutForTailing = 1800.0;
 
   /// @brief dump batch id
   uint64_t id{0};

--- a/arangod/RestHandler/RestWalAccessHandler.cpp
+++ b/arangod/RestHandler/RestWalAccessHandler.cpp
@@ -185,7 +185,8 @@ RestStatus RestWalAccessHandler::execute() {
   } else if (suffixes[0] == "lastTick" && _request->requestType() == RequestType::GET) {
     handleCommandLastTick(wal);
   } else if (suffixes[0] == "tail" && (_request->requestType() == RequestType::GET ||
-                                       _request->requestType() == RequestType::PUT)) {
+                                       _request->requestType() == RequestType::PUT ||
+                                       _request->requestType() == RequestType::DELETE_REQ)) {
     handleCommandTail(wal);
   } else if (suffixes[0] == "open-transactions" &&
              _request->requestType() == RequestType::GET) {
@@ -238,6 +239,21 @@ void RestWalAccessHandler::handleCommandLastTick(WalAccess const* wal) {
 }
 
 void RestWalAccessHandler::handleCommandTail(WalAccess const* wal) {
+  // check for serverId
+  ServerId const clientId{StringUtils::uint64(_request->value("serverId"))};
+  SyncerId const syncerId = SyncerId::fromRequest(*_request);
+  std::string const clientInfo = _request->value("clientInfo");
+
+  if (_request->requestType() == arangodb::rest::RequestType::DELETE_REQ) {
+    // this is a notification that tailing has come to an end, so we
+    // can unregister the client from the list of tracked clients
+    server().getFeature<DatabaseFeature>().enumerateDatabases([&](TRI_vocbase_t& vocbase) -> void {
+      vocbase.replicationClients().untrack(syncerId, clientId, clientInfo);
+    });
+    generateOk(rest::ResponseCode::OK, VPackSlice::emptyObjectSlice());
+    return;
+  }
+
   // track the number of parallel invocations of the tailing API
   auto& rf = _vocbase.server().getFeature<ReplicationFeature>();
   // this may throw when too many threads are going into tailing
@@ -251,11 +267,6 @@ void RestWalAccessHandler::handleCommandTail(WalAccess const* wal) {
   if (!parseFilter(filter)) {
     return;
   }
-
-  // check for serverId
-  ServerId const clientId{StringUtils::uint64(_request->value("serverId"))};
-  SyncerId const syncerId = SyncerId::fromRequest(*_request);
-  std::string const clientInfo = _request->value("clientInfo");
 
   // check if a barrier id was specified in request
   TRI_voc_tid_t barrierId =
@@ -362,7 +373,7 @@ void RestWalAccessHandler::handleCommandTail(WalAccess const* wal) {
 
   DatabaseFeature::DATABASE->enumerateDatabases([&](TRI_vocbase_t& vocbase) -> void {
     vocbase.replicationClients().track(syncerId, clientId, clientInfo, filter.tickStart,
-                                       replutils::BatchInfo::DefaultTimeout);
+                                       replutils::BatchInfo::DefaultTimeoutForTailing);
   });
 }
 

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -210,7 +210,16 @@ RocksDBEngine::RocksDBEngine(application_features::ApplicationServer& server)
       _useReleasedTick(false),
       _debugLogging(false),
       _useEdgeCache(true),
-      _runningCompactions(0) {
+      _dbExisted(false),
+      _runningCompactions(0),
+      _metricsWalSequenceLowerBound(server.getFeature<arangodb::MetricsFeature>().gauge(
+          "rocksdb_wal_sequence_lower_bound", uint64_t(0), "RocksDB WAL sequence number until which background thread has caught up")),
+      _metricsArchivedWalFiles(server.getFeature<arangodb::MetricsFeature>().gauge(
+          "rocksdb_archived_wal_files", uint64_t(0), "Number of archived RocksDB WAL files")),
+      _metricsPrunableWalFiles(server.getFeature<arangodb::MetricsFeature>().gauge(
+          "rocksdb_prunable_wal_files", uint64_t(0), "Number of prunable RocksDB WAL files")),
+      _metricsWalPruningActive(server.getFeature<arangodb::MetricsFeature>().gauge(
+          "rocksdb_wal_pruning_active", uint64_t(0), "Whether or not RocksDB WAL file pruning is active")) {
 
   startsAfter<BasicFeaturePhaseServer>();
   // inherits order from StorageEngine but requires "RocksDBOption" that is used
@@ -818,6 +827,8 @@ void RocksDBEngine::start() {
 
   // will crash the process if version does not match
   arangodb::rocksdbStartupVersionCheck(_db, dbExisted);
+  
+  _dbExisted = dbExisted;
 
   // only enable logger after RocksDB start
   if (logger != nullptr) {
@@ -1870,6 +1881,32 @@ std::vector<std::shared_ptr<RocksDBRecoveryHelper>> const& RocksDBEngine::recove
   return _recoveryHelpers;
 }
 
+void RocksDBEngine::determineWalFilesInitial() {
+  WRITE_LOCKER(lock, _walFileLock);
+  // Retrieve the sorted list of all wal files with earliest file first
+  rocksdb::VectorLogPtr files;
+  auto status = _db->GetSortedWalFiles(files);
+  if (!status.ok()) {
+    LOG_TOPIC("078ee", WARN, Logger::ENGINES)
+        << "could not get WAL files: " << status.ToString();
+    return;
+  }
+
+  size_t archivedFiles = 0;
+  for (size_t current = 0; current < files.size(); current++) {
+    auto const& f = files[current].get();
+
+    if (f->Type() != rocksdb::WalFileType::kArchivedLogFile) {
+      // we are only interested in files of the archive
+      continue;
+    }
+
+    ++archivedFiles;
+  }
+  _metricsWalSequenceLowerBound.operator=(_settingsManager->earliestSeqNeeded());
+  _metricsArchivedWalFiles.operator=(archivedFiles);
+}
+
 void RocksDBEngine::determinePrunableWalFiles(TRI_voc_tick_t minTickExternal) {
   WRITE_LOCKER(lock, _walFileLock);
   TRI_voc_tick_t minTickToKeep =
@@ -1877,15 +1914,20 @@ void RocksDBEngine::determinePrunableWalFiles(TRI_voc_tick_t minTickExternal) {
                                 : std::numeric_limits<TRI_voc_tick_t>::max(),
                minTickExternal);
 
+  LOG_TOPIC("4673c", TRACE, Logger::ENGINES)
+      << "determining prunable WAL files, minTickToKeep: " << minTickToKeep 
+      << ", minTickExternal: " << minTickExternal;
+
   // Retrieve the sorted list of all wal files with earliest file first
   rocksdb::VectorLogPtr files;
   auto status = _db->GetSortedWalFiles(files);
   if (!status.ok()) {
-    LOG_TOPIC("078ef", INFO, Logger::ENGINES)
+    LOG_TOPIC("078ef", WARN, Logger::ENGINES)
         << "could not get WAL files: " << status.ToString();
     return;
   }
 
+  size_t archivedFiles = 0;
   uint64_t totalArchiveSize = 0;
   for (size_t current = 0; current < files.size(); current++) {
     auto const& f = files[current].get();
@@ -1894,6 +1936,8 @@ void RocksDBEngine::determinePrunableWalFiles(TRI_voc_tick_t minTickExternal) {
       // we are only interested in files of the archive
       continue;
     }
+
+    ++archivedFiles;
 
     // determine the size of the archive only if it there is a cap on the
     // archive size otherwise we can save the underlying file access
@@ -1923,62 +1967,67 @@ void RocksDBEngine::determinePrunableWalFiles(TRI_voc_tick_t minTickExternal) {
     }
   }
 
-  if (_maxWalArchiveSizeLimit == 0) {
-    // size of the archive is not restricted. done!
-    return;
-  }
+  LOG_TOPIC("01e20", TRACE, Logger::ENGINES)
+      << "found " << files.size() << " WAL file(s), with " 
+      << archivedFiles << " files in the archive, " 
+      << "number of prunable files: " << _prunableWalFiles.size();
 
-  // print current archive size
-  LOG_TOPIC("8d71b", TRACE, Logger::ENGINES)
-      << "total size of the RocksDB WAL file archive: " << totalArchiveSize;
+  if (_maxWalArchiveSizeLimit > 0 &&
+      totalArchiveSize <= _maxWalArchiveSizeLimit) {
+    // size of the archive is restricted.
 
-  if (totalArchiveSize <= _maxWalArchiveSizeLimit) {
-    // archive is smaller than allowed. all good
-    return;
-  }
+    // print current archive size
+    LOG_TOPIC("8d71b", TRACE, Logger::ENGINES)
+        << "total size of the RocksDB WAL file archive: " << totalArchiveSize;
 
-  // we got more archived files than configured. time for purging some files!
-  for (size_t current = 0; current < files.size(); current++) {
-    auto const& f = files[current].get();
+    // we got more archived files than configured. time for purging some files!
+    for (size_t current = 0; current < files.size(); current++) {
+      auto const& f = files[current].get();
 
-    if (f->Type() != rocksdb::WalFileType::kArchivedLogFile) {
-      continue;
-    }
-
-    // force pruning
-    bool doPrint = false;
-    auto [it, emplaced] = _prunableWalFiles.try_emplace(f->PathName(), -1.0);
-    if (emplaced) {
-      doPrint = true;
-      // using an expiration time of -1.0 indicates the file is subject to
-      // deletion because the archive outgrew the maximum allowed size
-    } else {
-      // file already in list. now set its expiration time to the past
-      // so we are sure it will get deleted
-
-      // using an expiration time of -1.0 indicates the file is subject to
-      // deletion because the archive outgrew the maximum allowed size
-      if ((*it).second > 0.0) {
-        doPrint = true;
+      if (f->Type() != rocksdb::WalFileType::kArchivedLogFile) {
+        continue;
       }
-      (*it).second = -1.0;
-    }
 
-    if (doPrint) {
-      LOG_TOPIC("d9793", WARN, Logger::ENGINES)
-          << "forcing removal of RocksDB WAL file '" << f->PathName() << "' with start sequence "
-          << f->StartSequence() << " because of overflowing archive. configured maximum archive size is "
-          << _maxWalArchiveSizeLimit << ", actual archive size is: " << totalArchiveSize;
-    }
+      // force pruning
+      bool doPrint = false;
+      auto [it, emplaced] = _prunableWalFiles.try_emplace(f->PathName(), -1.0);
+      if (emplaced) {
+        doPrint = true;
+        // using an expiration time of -1.0 indicates the file is subject to
+        // deletion because the archive outgrew the maximum allowed size
+      } else {
+        // file already in list. now set its expiration time to the past
+        // so we are sure it will get deleted
 
-    TRI_ASSERT(totalArchiveSize >= f->SizeFileBytes());
-    totalArchiveSize -= f->SizeFileBytes();
+        // using an expiration time of -1.0 indicates the file is subject to
+        // deletion because the archive outgrew the maximum allowed size
+        if ((*it).second > 0.0) {
+          doPrint = true;
+        }
+        (*it).second = -1.0;
+      }
 
-    if (totalArchiveSize <= _maxWalArchiveSizeLimit) {
-      // got enough files to remove
-      break;
+      if (doPrint) {
+        LOG_TOPIC("d9793", WARN, Logger::ENGINES)
+            << "forcing removal of RocksDB WAL file '" << f->PathName() << "' with start sequence "
+            << f->StartSequence() << " because of overflowing archive. configured maximum archive size is "
+            << _maxWalArchiveSizeLimit << ", actual archive size is: " << totalArchiveSize;
+      }
+
+      TRI_ASSERT(totalArchiveSize >= f->SizeFileBytes());
+      totalArchiveSize -= f->SizeFileBytes();
+
+      if (totalArchiveSize <= _maxWalArchiveSizeLimit) {
+        // got enough files to remove
+        break;
+      }
     }
   }
+
+  _metricsWalSequenceLowerBound.operator=(_settingsManager->earliestSeqNeeded());
+  _metricsArchivedWalFiles.operator=(archivedFiles);
+  _metricsPrunableWalFiles.operator=(_prunableWalFiles.size());
+  _metricsWalPruningActive.operator=(1);
 }
 
 RocksDBFilePurgePreventer RocksDBEngine::disallowPurging() noexcept {
@@ -1997,6 +2046,9 @@ void RocksDBEngine::pruneWalFiles() {
   RocksDBFilePurgeEnabler purgeEnabler(rocksutils::globalRocksEngine()->startPurging());
 
   WRITE_LOCKER(lock, _walFileLock);
+
+  // used for logging later
+  size_t const initialSize = _prunableWalFiles.size();
 
   // go through the map of WAL files that we have already and check if they are
   // "expired"
@@ -2035,6 +2087,10 @@ void RocksDBEngine::pruneWalFiles() {
       if (s.ok() || s.IsInvalidArgument()) {
         it = _prunableWalFiles.erase(it);
         continue;
+      } else {
+        LOG_TOPIC("83162", WARN, Logger::ENGINES) 
+          << "attempt to prune RocksDB WAL file '" << (*it).first
+          << "' failed with error: " << rocksutils::convertStatus(s).errorMessage();
       }
     }
 
@@ -2042,6 +2098,12 @@ void RocksDBEngine::pruneWalFiles() {
     // endless loop
     ++it;
   }
+
+  _metricsPrunableWalFiles.operator=(_prunableWalFiles.size());
+
+  LOG_TOPIC("82a4c", TRACE, Logger::ENGINES) 
+      << "prune WAL files started with " << initialSize << " prunable WAL files, "
+      << "current number of prunable WAL files: " << _prunableWalFiles.size();
 }
 
 Result RocksDBEngine::dropDatabase(TRI_voc_tick_t id) {

--- a/arangosh/Dump/DumpFeature.cpp
+++ b/arangosh/Dump/DumpFeature.cpp
@@ -56,9 +56,10 @@
 
 namespace {
 
-/// @brief fake client id we will send to the server. the server keeps
+/// @brief fake client and syncer ids we will send to the server. the server keeps
 /// track of all connected clients
 static std::string clientId;
+static std::string syncerId;
 
 /// @brief name of the feature to report to application server
 constexpr auto FeatureName = "Dump";
@@ -169,7 +170,7 @@ std::pair<arangodb::Result, uint64_t> startBatch(arangodb::httpclient::SimpleHtt
   using arangodb::basics::VelocyPackHelper;
   using arangodb::basics::StringUtils::uint64;
 
-  std::string url = "/_api/replication/batch?serverId=" + clientId;
+  std::string url = "/_api/replication/batch?serverId=" + clientId + "&syncerId=" + syncerId;
   std::string const body = "{\"ttl\":600}";
   if (!DBserver.empty()) {
     url += "&DBserver=" + DBserver;
@@ -206,7 +207,7 @@ void extendBatch(arangodb::httpclient::SimpleHttpClient& client,
   TRI_ASSERT(batchId > 0);
 
   std::string url = "/_api/replication/batch/" + itoa(batchId) +
-                    "?serverId=" + clientId;
+                    "?serverId=" + clientId + "&syncerId=" + syncerId;
   std::string const body = "{\"ttl\":600}";
   if (!DBserver.empty()) {
     url += "&DBserver=" + DBserver;
@@ -1187,6 +1188,7 @@ void DumpFeature::start() {
   // in the future, if we are sure the server is an ArangoDB 3.5 or
   // higher
   ::clientId = std::to_string(RandomGenerator::interval(static_cast<uint64_t>(0x0000FFFFFFFFFFFFULL)));
+  ::syncerId = std::to_string(RandomGenerator::interval(static_cast<uint64_t>(0xFFFFFFFFFFFFFFFFULL)));
 
   double const start = TRI_microtime();
 

--- a/tests/Maintenance/MaintenanceTest.cpp
+++ b/tests/Maintenance/MaintenanceTest.cpp
@@ -505,10 +505,8 @@ class MaintenanceTestActionPhaseOne : public SharedMaintenanceTest {
 
   std::map<std::string, Node> localNodes;
 
-  arangodb::RocksDBEngine engine;  // arbitrary implementation that has index types registered
+  std::unique_ptr<arangodb::RocksDBEngine> engine;  // arbitrary implementation that has index types registered
   arangodb::StorageEngine* origStorageEngine;
-
-
 
 
   MaintenanceTestActionPhaseOne()
@@ -521,12 +519,12 @@ class MaintenanceTestActionPhaseOne : public SharedMaintenanceTest {
         localNodes{{dbsIds[shortNames[0]], createNode(dbs0Str)},
                    {dbsIds[shortNames[1]], createNode(dbs1Str)},
                    {dbsIds[shortNames[2]], createNode(dbs2Str)}},
-        engine(as),
         origStorageEngine(arangodb::EngineSelectorFeature::ENGINE) {
     as.addFeature<arangodb::MetricsFeature>();
     as.addFeature<arangodb::application_features::GreetingsFeaturePhase>(false);
 
-    arangodb::EngineSelectorFeature::ENGINE = &engine;
+    engine = std::make_unique<arangodb::RocksDBEngine>(as);
+    arangodb::EngineSelectorFeature::ENGINE = engine.get();
   }
 
   ~MaintenanceTestActionPhaseOne() {


### PR DESCRIPTION
### Scope & Purpose

* Properly clean up replication client entries for tailing from WAL so that
  archived WAL files are not retained for an unnecessary long time period.

* Added metrics `rocksdb_wal_sequence_lower_bound`,
  `rocksdb_archived_wal_files`, `rocskdb_prunable_wal_files` and
  `rocksdb_wal_pruning_active` to allow inspection of WAL file pruning from
  the outside.

This is a backport of selected changes from https://github.com/arangodb/arangodb/pull/14816

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
