### PR TITLE
[CINFRA-113] LCI not displayed properly

### DIFF
--- a/arangod/Replication2/ReplicatedLog/LogStatus.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogStatus.cpp
@@ -88,6 +88,7 @@ auto LeaderStatus::fromVelocyPack(velocypack::Slice slice) -> LeaderStatus {
   LeaderStatus status;
   status.term = slice.get(StaticStrings::Term).extract<LogTerm>();
   status.local = LogStatistics::fromVelocyPack(slice.get("local"));
+  status.largestCommonIndex = slice.get("largestCommonIndex").extract<LogIndex>();
   status.commitLagMS = std::chrono::duration<double, std::milli>{
       slice.get("commitLagMS").extract<double>()};
   for (auto [key, value] : VPackObjectIterator(slice.get(StaticStrings::Follower))) {


### PR DESCRIPTION
### Scope & Purpose

LCI was not forwarded correctly because deserializer missing field. [CINFRA-113](https://arangodb.atlassian.net/browse/CINFRA-113)

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*