### PR TITLE
[CINFRA-20] Added support for waitForSync per entry.

### DIFF
--- a/arangod/Replication2/ReplicatedLog/InMemoryLog.cpp
+++ b/arangod/Replication2/ReplicatedLog/InMemoryLog.cpp
@@ -213,6 +213,14 @@ auto replicated_log::InMemoryLog::getIteratorFrom(LogIndex fromIdx) const
   return std::make_unique<ReplicatedLogIterator>(std::move(log));
 }
 
+auto replicated_log::InMemoryLog::getMemtryIteratorFrom(LogIndex fromIdx) const
+    -> std::unique_ptr<TypedLogIterator<InMemoryLogEntry>> {
+  // if we want to have read from log entry 1 onwards, we have to drop
+  // no entries, because log entry 0 does not exist.
+  auto log = _log.drop(fromIdx.saturatedDecrement(_first.value).value);
+  return std::make_unique<InMemoryLogIterator>(std::move(log));
+}
+
 auto replicated_log::InMemoryLog::getInternalIteratorFrom(LogIndex fromIdx) const
     -> std::unique_ptr<PersistedLogIterator> {
   // if we want to have read from log entry 1 onwards, we have to drop

--- a/arangod/Replication2/ReplicatedLog/InMemoryLog.h
+++ b/arangod/Replication2/ReplicatedLog/InMemoryLog.h
@@ -110,6 +110,8 @@ struct InMemoryLog {
 
   [[nodiscard]] auto getIteratorFrom(LogIndex fromIdx) const -> std::unique_ptr<LogIterator>;
   [[nodiscard]] auto getInternalIteratorFrom(LogIndex fromIdx) const -> std::unique_ptr<PersistedLogIterator>;
+  [[nodiscard]] auto getMemtryIteratorFrom(LogIndex fromIdx) const
+      -> std::unique_ptr<TypedLogIterator<InMemoryLogEntry>>;
   // get an iterator for range [from, to).
   [[nodiscard]] auto getIteratorRange(LogIndex fromIdx, LogIndex toIdx) const
       -> std::unique_ptr<LogRangeIterator>;

--- a/arangod/Replication2/ReplicatedLog/LogCommon.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogCommon.cpp
@@ -133,8 +133,8 @@ PersistingLogEntry::PersistingLogEntry(LogIndex index, velocypack::Slice persist
   }
 }
 
-InMemoryLogEntry::InMemoryLogEntry(PersistingLogEntry entry)
-    : _logEntry(std::move(entry)) {}
+InMemoryLogEntry::InMemoryLogEntry(PersistingLogEntry entry, bool waitForSync)
+    : _waitForSync(waitForSync), _logEntry(std::move(entry)) {}
 
 void InMemoryLogEntry::setInsertTp(clock::time_point tp) noexcept {
   _insertTp = tp;

--- a/arangod/Replication2/ReplicatedLog/LogCommon.h
+++ b/arangod/Replication2/ReplicatedLog/LogCommon.h
@@ -232,13 +232,15 @@ class InMemoryLogEntry {
  public:
   using clock = std::chrono::steady_clock;
 
-  explicit InMemoryLogEntry(PersistingLogEntry entry);
+  explicit InMemoryLogEntry(PersistingLogEntry entry, bool waitForSync = false);
 
   [[nodiscard]] auto insertTp() const noexcept -> clock::time_point;
   void setInsertTp(clock::time_point) noexcept;
   [[nodiscard]] auto entry() const noexcept -> PersistingLogEntry const&;
+  [[nodiscard]] bool getWaitForSync() const noexcept { return _waitForSync; }
 
  private:
+  bool _waitForSync;
   // Immutable box that allows sharing, i.e. cheap copying.
   ::immer::box<PersistingLogEntry, ::arangodb::immer::arango_memory_policy> _logEntry;
   // Timepoint at which the insert was started (not the point in time where it

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -449,7 +449,7 @@ auto replicated_log::LogLeader::insert(LogPayload payload, [[maybe_unused]] bool
     auto const index = leaderData._inMemoryLog.getNextIndex();
     auto const payloadSize = payload.byteSize();
     auto logEntry =
-        InMemoryLogEntry(PersistingLogEntry(_currentTerm, index, std::move(payload)));
+        InMemoryLogEntry(PersistingLogEntry(_currentTerm, index, std::move(payload)), waitForSync);
     logEntry.setInsertTp(insertTp);
     leaderData._inMemoryLog.appendInPlace(_logContext, std::move(logEntry));
     _logMetrics->replicatedLogInsertsBytes->count(payloadSize);
@@ -616,7 +616,8 @@ auto replicated_log::LogLeader::GuardedLeaderData::createAppendEntriesRequest(
     auto it = getInternalLogIterator(follower.lastAckedEntry.index + 1);
     auto transientEntries = decltype(req.entries)::transient_type{};
     while (auto entry = it->next()) {
-      transientEntries.push_back(InMemoryLogEntry(*std::move(entry)));
+      req.waitForSync |= entry->getWaitForSync();
+      transientEntries.push_back(InMemoryLogEntry(*entry));
       if (transientEntries.size() >= 1000) {
         break;
       }
@@ -727,10 +728,10 @@ auto replicated_log::LogLeader::GuardedLeaderData::handleAppendEntriesResponse(
 }
 
 auto replicated_log::LogLeader::GuardedLeaderData::getInternalLogIterator(LogIndex firstIdx) const
-    -> std::unique_ptr<PersistedLogIterator> {
+    -> std::unique_ptr<TypedLogIterator<InMemoryLogEntry>> {
   auto const endIdx = _inMemoryLog.getLastTermIndexPair().index + 1;
   TRI_ASSERT(firstIdx <= endIdx);
-  return _inMemoryLog.getInternalIteratorFrom(firstIdx);
+  return _inMemoryLog.getMemtryIteratorFrom(firstIdx);
 }
 
 auto replicated_log::LogLeader::GuardedLeaderData::getCommittedLogIterator(LogIndex firstIndex) const

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -245,7 +245,7 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>, public ILogPar
         -> ResolvedPromiseSet;
 
     [[nodiscard]] auto getInternalLogIterator(LogIndex firstIdx) const
-        -> std::unique_ptr<PersistedLogIterator>;
+        -> std::unique_ptr<TypedLogIterator<InMemoryLogEntry>>;
 
     [[nodiscard]] auto getCommittedLogIterator(LogIndex firstIndex) const
         -> std::unique_ptr<LogRangeIterator>;

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLogIterator.h
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLogIterator.h
@@ -101,4 +101,28 @@ class InMemoryPersistedLogIterator : public PersistedLogIterator {
   log_type::const_iterator _end;
 };
 
+class InMemoryLogIterator : public TypedLogIterator<InMemoryLogEntry> {
+ public:
+  using log_type = ::immer::flex_vector<InMemoryLogEntry, arangodb::immer::arango_memory_policy>;
+
+  explicit InMemoryLogIterator(log_type container)
+      : _container(std::move(container)),
+        _begin(_container.begin()),
+        _end(_container.end()) {}
+
+  auto next() -> std::optional<InMemoryLogEntry> override {
+    if (_begin != _end) {
+      auto const& it = *_begin;
+      ++_begin;
+      return it;
+    }
+    return std::nullopt;
+  }
+
+ private:
+  log_type _container;
+  log_type::const_iterator _begin;
+  log_type::const_iterator _end;
+};
+
 }  // namespace arangodb::replication2::replicated_log

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -327,7 +327,10 @@ set(ARANGODB_REPLICATION2_TEST_SOURCES
   Replication2/Streams/TestLogSpecification.h
   Replication2/Streams/MultiplexerConcurrencyTest.cpp
   Replication2/Mocks/AsyncFollower.cpp
-  Replication2/Mocks/AsyncFollower.h)
+  Replication2/Mocks/AsyncFollower.h
+  Replication2/Mocks/FakeFollower.h
+  Replication2/ReplicatedLog/WaitForSyncTest.cpp
+  )
 
 if (LINUX)
   # add "-fno-var-tracking" to the compiler flags

--- a/tests/Replication2/Mocks/FakeFollower.h
+++ b/tests/Replication2/Mocks/FakeFollower.h
@@ -1,0 +1,71 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2021-2021 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Lars Maier
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Replication2/ReplicatedLog/ILogParticipant.h"
+#include "Replication2/ReplicatedLog/LogFollower.h"
+#include "Replication2/ReplicatedLog/ReplicatedLog.h"
+#include "Replication2/ReplicatedLog/types.h"
+
+namespace arangodb::replication2::test {
+
+struct FakeFollower : AbstractFollower {
+  FakeFollower(ParticipantId id) : participantId(std::move(id)) {}
+
+  [[nodiscard]] auto getParticipantId() const noexcept -> ParticipantId const& override {
+    return participantId;
+  };
+
+  virtual auto appendEntries(AppendEntriesRequest request)
+      -> futures::Future<AppendEntriesResult> override {
+    return requests.emplace_back(std::move(request)).promise.getFuture();
+  }
+
+  void resolveRequest(AppendEntriesResult result) {
+    requests.front().promise.setValue(std::move(result));
+    requests.pop_front();
+  }
+
+  template <typename E>
+  void resolveRequestWithException(E&& e) {
+    requests.front().promise.setException(std::forward<E>(e));
+    requests.pop_front();
+  }
+
+  auto currentRequest() const -> AppendEntriesRequest const& {
+    return requests.front().request;
+  }
+
+  auto hasPendingRequests() const -> bool { return !requests.empty(); }
+
+  struct AsyncRequest {
+    explicit AsyncRequest(AppendEntriesRequest request)
+        : request(std::move(request)) {}
+    AppendEntriesRequest request;
+    futures::Promise<AppendEntriesResult> promise;
+  };
+
+  std::deque<AsyncRequest> requests;
+  ParticipantId participantId;
+};
+}  // namespace arangodb::replication2::test

--- a/tests/Replication2/ReplicatedLog/LeaderAppendEntriesTest.cpp
+++ b/tests/Replication2/ReplicatedLog/LeaderAppendEntriesTest.cpp
@@ -28,6 +28,8 @@
 #include "Replication2/ReplicatedLog/ReplicatedLog.h"
 #include "Replication2/ReplicatedLog/types.h"
 
+#include "Replication2/Mocks/FakeFollower.h"
+
 using namespace arangodb;
 using namespace arangodb::replication2;
 using namespace arangodb::replication2::replicated_log;
@@ -35,47 +37,6 @@ using namespace arangodb::replication2::test;
 
 struct LeaderAppendEntriesTest : ReplicatedLogTest {};
 
-struct FakeFollower : AbstractFollower {
-  FakeFollower(ParticipantId id) : participantId(std::move(id)) {}
-
-  [[nodiscard]] auto getParticipantId() const noexcept -> ParticipantId const& override {
-    return participantId;
-  };
-
-  virtual auto appendEntries(AppendEntriesRequest request)
-      -> futures::Future<AppendEntriesResult> override {
-    return requests.emplace_back(std::move(request)).promise.getFuture();
-  }
-
-  void resolveRequest(AppendEntriesResult result) {
-    requests.front().promise.setValue(std::move(result));
-    requests.pop_front();
-  }
-
-  template<typename E>
-  void resolveRequestWithException(E&& e) {
-    requests.front().promise.setException(std::forward<E>(e));
-    requests.pop_front();
-  }
-
-  auto currentRequest() const -> AppendEntriesRequest const& {
-    return requests.front().request;
-  }
-
-  auto hasPendingRequests() const -> bool {
-    return !requests.empty();
-  }
-
-  struct AsyncRequest {
-    explicit AsyncRequest(AppendEntriesRequest request)
-        : request(std::move(request)) {}
-    AppendEntriesRequest request;
-    futures::Promise<AppendEntriesResult> promise;
-  };
-
-  std::deque<AsyncRequest> requests;
-  ParticipantId participantId;
-};
 
 TEST_F(LeaderAppendEntriesTest, simple_append_entries) {
   auto leaderLog = makeReplicatedLog(LogId{1});

--- a/tests/Replication2/ReplicatedLog/WaitForSyncTest.cpp
+++ b/tests/Replication2/ReplicatedLog/WaitForSyncTest.cpp
@@ -1,0 +1,126 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2021-2021 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Lars Maier
+////////////////////////////////////////////////////////////////////////////////
+
+#include "TestHelper.h"
+
+#include "Basics/voc-errors.h"
+
+#include "Replication2/ReplicatedLog/LogFollower.h"
+#include "Replication2/ReplicatedLog/ReplicatedLog.h"
+#include "Replication2/ReplicatedLog/types.h"
+
+#include "Replication2/Mocks/FakeFollower.h"
+
+using namespace arangodb;
+using namespace arangodb::replication2;
+using namespace arangodb::replication2::replicated_log;
+using namespace arangodb::replication2::test;
+
+struct WaitForSyncTest : ReplicatedLogTest {};
+
+
+TEST_F(WaitForSyncTest, no_wait_for_sync) {
+  auto const waitForSync = false;
+  auto const term = LogTerm{4};
+
+  auto leaderLog = makeReplicatedLog(LogId{1});
+  auto follower = std::make_shared<FakeFollower>("follower");
+  auto leader = leaderLog->becomeLeader(LogConfig(2, waitForSync), "leader", term, {follower});
+
+  auto const firstIdx =
+      leader->insert(LogPayload::createFromString("first entry"));
+  // Note that the leader inserts an empty log entry in becomeLeader already
+  ASSERT_EQ(firstIdx, LogIndex{2});
+
+  leader->triggerAsyncReplication();
+  ASSERT_TRUE(follower->hasPendingRequests());
+  {
+    auto req = follower->currentRequest();
+    EXPECT_EQ(req.messageId, MessageId{1});
+    EXPECT_FALSE(req.waitForSync);
+  }
+
+  {
+    auto result = AppendEntriesResult{term, TRI_ERROR_NO_ERROR,
+                                      AppendEntriesErrorReason::NONE,
+                                      follower->currentRequest().messageId};
+    follower->resolveRequest(std::move(result));
+  }
+}
+
+TEST_F(WaitForSyncTest, global_wait_for_sync) {
+  auto const waitForSync = true;
+  auto const term = LogTerm{4};
+
+  auto leaderLog = makeReplicatedLog(LogId{1});
+  auto follower = std::make_shared<FakeFollower>("follower");
+  auto leader = leaderLog->becomeLeader(LogConfig(2, waitForSync), "leader", term, {follower});
+
+  auto const firstIdx =
+      leader->insert(LogPayload::createFromString("first entry"));
+  // Note that the leader inserts an empty log entry in becomeLeader already
+  ASSERT_EQ(firstIdx, LogIndex{2});
+
+  leader->triggerAsyncReplication();
+  ASSERT_TRUE(follower->hasPendingRequests());
+  {
+    auto req = follower->currentRequest();
+    EXPECT_EQ(req.messageId, MessageId{1});
+    EXPECT_TRUE(req.waitForSync);
+  }
+
+  {
+    auto result = AppendEntriesResult{term, TRI_ERROR_NO_ERROR,
+                                      AppendEntriesErrorReason::NONE,
+                                      follower->currentRequest().messageId};
+    follower->resolveRequest(std::move(result));
+  }
+}
+
+TEST_F(WaitForSyncTest, per_entry_wait_for_sync) {
+  auto const waitForSync = false;
+  auto const term = LogTerm{4};
+
+  auto leaderLog = makeReplicatedLog(LogId{1});
+  auto follower = std::make_shared<FakeFollower>("follower");
+  auto leader = leaderLog->becomeLeader(LogConfig(2, waitForSync), "leader", term, {follower});
+
+  auto const firstIdx =
+      leader->insert(LogPayload::createFromString("first entry"), true);
+  // Note that the leader inserts an empty log entry in becomeLeader already
+  ASSERT_EQ(firstIdx, LogIndex{2});
+
+  leader->triggerAsyncReplication();
+  ASSERT_TRUE(follower->hasPendingRequests());
+  {
+    auto req = follower->currentRequest();
+    EXPECT_EQ(req.messageId, MessageId{1});
+    EXPECT_TRUE(req.waitForSync);
+  }
+
+  {
+    auto result = AppendEntriesResult{term, TRI_ERROR_NO_ERROR,
+                                      AppendEntriesErrorReason::NONE,
+                                      follower->currentRequest().messageId};
+    follower->resolveRequest(std::move(result));
+  }
+}

--- a/tests/Replication2/ReplicatedLog/WaitForSyncTest.cpp
+++ b/tests/Replication2/ReplicatedLog/WaitForSyncTest.cpp
@@ -51,7 +51,6 @@ TEST_F(WaitForSyncTest, no_wait_for_sync) {
   // Note that the leader inserts an empty log entry in becomeLeader already
   ASSERT_EQ(firstIdx, LogIndex{2});
 
-  leader->triggerAsyncReplication();
   ASSERT_TRUE(follower->hasPendingRequests());
   {
     auto req = follower->currentRequest();
@@ -80,7 +79,6 @@ TEST_F(WaitForSyncTest, global_wait_for_sync) {
   // Note that the leader inserts an empty log entry in becomeLeader already
   ASSERT_EQ(firstIdx, LogIndex{2});
 
-  leader->triggerAsyncReplication();
   ASSERT_TRUE(follower->hasPendingRequests());
   {
     auto req = follower->currentRequest();
@@ -109,7 +107,6 @@ TEST_F(WaitForSyncTest, per_entry_wait_for_sync) {
   // Note that the leader inserts an empty log entry in becomeLeader already
   ASSERT_EQ(firstIdx, LogIndex{2});
 
-  leader->triggerAsyncReplication();
   ASSERT_TRUE(follower->hasPendingRequests());
   {
     auto req = follower->currentRequest();


### PR DESCRIPTION
### Scope & Purpose

This PR adds support for the waitForSync flag that is specified on a per entry basis. [Ticket](https://arangodb.atlassian.net/browse/CINFRA-20).

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*
