### PR TITLE
add `inBackground` flag for indexes

### DIFF
--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index.md
@@ -73,6 +73,9 @@ The *estimates* attribute is optional and defaults to *true* if not set. It will
 have no effect on indexes other than *persistent* (with *hash* and *skiplist*
 being mere aliases for *persistent* nowadays).
 
+The optional attribute **inBackground** can be set to *true* to create the index
+in the background, which will not write-lock the underlying collection for
+as long as if the index is built in the foreground.
 @RESTRETURNCODES
 
 @RESTRETURNCODE{200}

--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index_fulltext.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index_fulltext.md
@@ -21,6 +21,11 @@ Minimum character length of words to index. Will default
 to a server-defined value if unspecified. It is thus recommended to set
 this value explicitly when creating the index.
 
+@RESTBODYPARAM{inBackground,boolean,optional,}
+The optional attribute **inBackground** can be set to *true* to create the index
+in the background, which will not write-lock the underlying collection for
+as long as if the index is built in the foreground. The default value is *false*.
+
 @RESTDESCRIPTION
 Creates a fulltext index for the collection *collection-name*, if
 it does not already exist. The call expects an object containing the index

--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index_geo.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index_geo.md
@@ -27,11 +27,16 @@ the attribute *latitude* and of the attribute *longitude* must a
 double. All documents, which do not have the attribute paths or which
 values are not suitable, are ignored.
 
-@RESTBODYPARAM{geoJson,string,required,string}
+@RESTBODYPARAM{geoJson,string,optional,string}
 If a geo-spatial index on a *location* is constructed
 and *geoJson* is *true*, then the order within the array is longitude
 followed by latitude. This corresponds to the format described in
 http://geojson.org/geojson-spec.html#positions
+
+@RESTBODYPARAM{inBackground,boolean,optional,}
+The optional attribute **inBackground** can be set to *true* to create the index
+in the background, which will not write-lock the underlying collection for
+as long as if the index is built in the foreground. The default value is *false*.
 
 @RESTDESCRIPTION
 Creates a geo-spatial index in the collection *collection-name*, if

--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index_hash.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index_hash.md
@@ -15,14 +15,19 @@ must be equal to *"hash"*.
 @RESTBODYPARAM{fields,array,required,string}
 an array of attribute paths.
 
-@RESTBODYPARAM{unique,boolean,required,}
+@RESTBODYPARAM{unique,boolean,optional,}
 if *true*, then create a unique index.
 
-@RESTBODYPARAM{sparse,boolean,required,}
+@RESTBODYPARAM{sparse,boolean,optional,}
 if *true*, then create a sparse index.
 
 @RESTBODYPARAM{deduplicate,boolean,optional,}
 if *false*, the deduplication of array values is turned off.
+
+@RESTBODYPARAM{inBackground,boolean,optional,}
+The optional attribute **inBackground** can be set to *true* to create the index
+in the background, which will not write-lock the underlying collection for
+as long as if the index is built in the foreground. The default value is *false*.
 
 @RESTDESCRIPTION
 Creates a hash index for the collection *collection-name* if it

--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index_persistent.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index_persistent.md
@@ -43,6 +43,11 @@ The *estimates* attribute is optional and defaults to *true* if not set. It will
 have no effect on indexes other than *persistent* (with *hash* and *skiplist*
 being mere aliases for *persistent* nowadays).
 
+@RESTBODYPARAM{inBackground,boolean,optional,}
+The optional attribute **inBackground** can be set to *true* to create the index
+in the background, which will not write-lock the underlying collection for
+as long as if the index is built in the foreground. The default value is *false*.
+
 @RESTDESCRIPTION
 
 Creates a persistent index for the collection *collection-name*, if

--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index_skiplist.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index_skiplist.md
@@ -15,14 +15,19 @@ must be equal to *"skiplist"*.
 @RESTBODYPARAM{fields,array,required,string}
 an array of attribute paths.
 
-@RESTBODYPARAM{unique,boolean,required,}
+@RESTBODYPARAM{unique,boolean,optional,}
 if *true*, then create a unique index.
 
-@RESTBODYPARAM{sparse,boolean,required,}
+@RESTBODYPARAM{sparse,boolean,optional,}
 if *true*, then create a sparse index.
 
 @RESTBODYPARAM{deduplicate,boolean,optional,}
 if *false*, the deduplication of array values is turned off.
+
+@RESTBODYPARAM{inBackground,boolean,optional,}
+The optional attribute **inBackground** can be set to *true* to create the index
+in the background, which will not write-lock the underlying collection for
+as long as if the index is built in the foreground. The default value is *false*.
 
 @RESTDESCRIPTION
 

--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index_ttl.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index_ttl.md
@@ -21,6 +21,11 @@ attribute after which the documents count as expired. Can be set to `0` to let
 documents expire as soon as the server time passes the point in time stored in
 the document attribute, or to a higher number to delay the expiration.
 
+@RESTBODYPARAM{inBackground,boolean,optional,}
+The optional attribute **inBackground** can be set to *true* to create the index
+in the background, which will not write-lock the underlying collection for
+as long as if the index is built in the foreground. The default value is *false*.
+
 @RESTDESCRIPTION
 Creates a TTL index for the collection *collection-name* if it
 does not already exist. The call expects an object containing the index

--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index_zkd.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index_zkd.md
@@ -15,8 +15,13 @@ must be equal to *"zkd"*.
 @RESTBODYPARAM{fields,array,required,string}
 an array of attribute names used for each dimension. Array expansions are not allowed.
 
-@RESTBODYPARAM{unique,boolean,required,}
+@RESTBODYPARAM{unique,boolean,optional,}
 if *true*, then create a unique index.
+
+@RESTBODYPARAM{inBackground,boolean,optional,}
+The optional attribute **inBackground** can be set to *true* to create the index
+in the background, which will not write-lock the underlying collection for
+as long as if the index is built in the foreground. The default value is *false*.
 
 @RESTBODYPARAM{fieldValueTypes,string,required,string}
 must be equal to *"double"*. Currently only doubles are supported as values.


### PR DESCRIPTION
### Scope & Purpose

This is an addition to the documentation, so that a missing `inBackground` option for indexes is added.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.8*

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
