### PR TITLE
increase locking timeout

### DIFF
--- a/tests/IResearch/Containers-test.cpp
+++ b/tests/IResearch/Containers-test.cpp
@@ -91,7 +91,7 @@ TEST(ContainersTest, testResourceMutex) {
     EXPECT_FALSE(reset);
     lock.unlock();
     auto result1 = cond.wait_for(cond_lock, std::chrono::milliseconds(50));
-    int nTryCount = 3;
+    int nTryCount = 100;
     while (std::cv_status::timeout == result1 && nTryCount--) {
       result1 = cond.wait_for(cond_lock, std::chrono::milliseconds(50));
     }


### PR DESCRIPTION
### Scope & Purpose

Increase to 5 secs  locking timeout in tests as Mac VM nodes still fails from time to time on this lock.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as Container-test
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:


