### PR TITLE
Make background calculation of SHA hashes less intrusive

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,18 @@ v3.8.2 (XXXX-XX-XX)
 * Fixed counting of all read transaction as aborted. Added a new metric to count
   read transactions.
 
+* Make background calculation of SHA hashes for RocksDB .sst files less
+  intrusive. The previous implementation frequently iterated over all files
+  in the database directory to check if it needed to ad-hoc calculate the
+  SHA hashes for .sst files it previously missed. The procedure it used 
+  was to iterate over all files in the database directory and check if there
+  were matching pairs of .sst files and .sha files. This was expensive,
+  because a full directory iteration was performed and a lot of temporary
+  strings were created for filenames and used in comparisons. This was
+  especially expensive for larger deployments with lots of .sst files.
+  The expensive iteration of files in the directory is now happening less
+  frequently, and will not be as expensive as before if it runs.
+
 * Fix windows installer PATH manipulation issue by replaceng the NSIS plugin
   (BTS-176).
 

--- a/arangod/RocksDBEngine/Listeners/RocksDBShaCalculator.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBShaCalculator.cpp
@@ -363,7 +363,7 @@ RocksDBShaCalculator::RocksDBShaCalculator(application_features::ApplicationServ
 RocksDBShaCalculator::~RocksDBShaCalculator() {
   // when we get here the background thread should have been stopped
   // already.
-  TRI_ASSERT(!_shaThread.isRunning());
+  TRI_ASSERT(!_shaThread.hasStarted() || !_shaThread.isRunning());
   waitForShutdown();
 }
   
@@ -374,7 +374,7 @@ void RocksDBShaCalculator::waitForShutdown() {
   _shaThread.signalLoop();
 
   CONDITION_LOCKER(locker, _threadDone);
-  if (_shaThread.isRunning()) {
+  if (_shaThread.hasStarted() && _shaThread.isRunning()) {
     _threadDone.wait();
   }
   // now we are sure the SHA thread is not running anymore

--- a/arangod/RocksDBEngine/Listeners/RocksDBShaCalculator.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBShaCalculator.cpp
@@ -36,51 +36,92 @@
 #include "RestServer/DatabasePathFeature.h"
 
 namespace arangodb {
+  
+RocksDBShaCalculatorThread::RocksDBShaCalculatorThread(application_features::ApplicationServer& server,
+                                                       std::string const& name)
+    : Thread(server, name) {}
 
 // must call Thread::shutdown() in order to properly shutdown
 RocksDBShaCalculatorThread::~RocksDBShaCalculatorThread() { shutdown(); }
+  
+template <typename T>
+bool RocksDBShaCalculatorThread::isSstFilename(T const& filename) const {
+  // length of  ".sst" is 4, but the actual filename should be something 
+  // like xxxxxx.sst
+  return filename.size() >= 4 && 
+         (filename.compare(filename.size() - 4, 4, ".sst") == 0);
+}
 
 void RocksDBShaCalculatorThread::run() {
+  try {
+    // do an initial check over the entire directory first
+    checkMissingShaFiles(getRocksDBPath(), 0);
+        
+    MUTEX_LOCKER(mutexLock, _pendingMutex);
+    _lastFullCheck = std::chrono::steady_clock::now();
+  } catch (...) {
+  }
+
   while (!isStopping()) {
     try {
-      {
-        MUTEX_LOCKER(mutexLock, _pendingMutex);
+      MUTEX_LOCKER(mutexLock, _pendingMutex);
+        
+      // first check if we need to calculate any SHA values for
+      // new sst files
+      while (!_pendingCalculations.empty()) {
+        std::string nextFile = _pendingCalculations.back();
+        _pendingCalculations.pop_back();
 
-        while (!_pendingQueue.empty()) {
-          actionNeeded_t next(_pendingQueue.front());
-          _pendingQueue.pop();
+        // check if a SHA calculation was requested for an sst file, 
+        // but the file is already deleted by now
+        if (_pendingDeletions.find(nextFile) == _pendingDeletions.end()) {
+          // .sst file should still exist
 
+          // continue without holding the mutex, so RocksDB can register
+          // additional operations while we move on
           mutexLock.unlock();
-          switch (next._action) {
-            case actionNeeded_t::CALC_SHA:
-              shaCalcFile(next._path);
-              break;
 
-            case actionNeeded_t::DELETE_ACTION:
-              deleteFile(next._path);
-              break;
-
-            default:
-              LOG_TOPIC("7c75c", ERR, arangodb::Logger::ENGINES)
-                  << "RocksDBShaCalculatorThread::run encountered unknown "
-                     "action";
-              TRI_ASSERT(false);
-              break;
-          }
+          auto [ok, hash] = shaCalcFile(nextFile);
+        
           mutexLock.lock();
+        
+          if (ok) {
+            // store the calculated hash value for later
+            TRI_ASSERT(nextFile != TRI_Basename(nextFile));
+            _calculatedHashes[TRI_Basename(nextFile)] = std::move(hash);
+          }
         }
       }
 
-      // we could find files that subsequently post to _pendingQueue ... no worries.
-      checkMissingShaFiles(getRocksDBPath(), 5 * 60);
-      // need not to be written to in the past 5 minutes!
+      // we are still holding the mutex here
+      if (!_pendingDeletions.empty()) {
+        mutexLock.unlock();
+
+        deleteObsoleteFiles();
+          
+        mutexLock.lock();
+      }
+
+      bool runFullCheck = false;
+      auto now = std::chrono::steady_clock::now();
+
+      if (now >= _lastFullCheck + std::chrono::minutes(5)) {
+        _lastFullCheck = now;
+        runFullCheck = true;
+      }
+
+      mutexLock.unlock();
+
+      if (runFullCheck) {
+        // we could find files that subsequently post to _pendingOperations ... no worries.
+        checkMissingShaFiles(getRocksDBPath(), 3 * 60);
+        // need not to be written to in the past 3 minutes!
+      }
 
       // no need for fast retry, hotbackups do not happen often
-      {
-        CONDITION_LOCKER(condLock, _loopingCondvar);
-        if (!isStopping()) {
-          condLock.wait(std::chrono::minutes(5));
-        }
+      CONDITION_LOCKER(condLock, _loopingCondvar);
+      if (!isStopping()) {
+        condLock.wait(std::chrono::seconds(30));
       }
     } catch (std::exception const& ex) {
       LOG_TOPIC("a27a1", ERR, arangodb::Logger::ENGINES)
@@ -93,98 +134,105 @@ void RocksDBShaCalculatorThread::run() {
 }
 
 void RocksDBShaCalculatorThread::queueShaCalcFile(std::string const& pathName) {
-  {
-    MUTEX_LOCKER(lock, _pendingMutex);
-    _pendingQueue.emplace(actionNeeded_t{actionNeeded_t::CALC_SHA, pathName});
+  if (isSstFilename(pathName)) {
+    {
+      MUTEX_LOCKER(lock, _pendingMutex);
+      _pendingCalculations.emplace_back(pathName);
+    }
+
+    signalLoop();
   }
-  signalLoop();
 }
 
 void RocksDBShaCalculatorThread::queueDeleteFile(std::string const& pathName) {
-  {
-    MUTEX_LOCKER(lock, _pendingMutex);
-    _pendingQueue.emplace(actionNeeded_t{actionNeeded_t::DELETE_ACTION, pathName});
+  if (isSstFilename(pathName)) {
+    {
+      MUTEX_LOCKER(lock, _pendingMutex);
+      _pendingDeletions.emplace(pathName);
+    }
+    signalLoop();
   }
-
-  signalLoop();
 }
 
 void RocksDBShaCalculatorThread::signalLoop() {
-  {
-    CONDITION_LOCKER(lock, _loopingCondvar);
-    lock.signal();
-  }
+  CONDITION_LOCKER(lock, _loopingCondvar);
+  lock.signal();
 }
 
-bool RocksDBShaCalculatorThread::shaCalcFile(std::string const& filename) {
-  bool good = false;
-
-  if (4 < filename.size() && 0 == filename.substr(filename.size() - 4).compare(".sst")) {
-    TRI_SHA256Functor sha;
-    LOG_TOPIC("af088", DEBUG, arangodb::Logger::ENGINES)
-        << "shaCalcFile: computing " << filename;
-    good = TRI_ProcessFile(filename.c_str(), std::ref(sha));
-
-    if (good) {
-      std::string newfile = filename.substr(0, filename.size() - 4);
-      newfile += ".sha.";
-      newfile += sha.finalize();
-      newfile += ".hash";
-      LOG_TOPIC("80257", DEBUG, arangodb::Logger::ENGINES)
-          << "shaCalcFile: done " << filename << " result: " << newfile;
-      auto ret_val = TRI_WriteFile(newfile.c_str(), "", 0);
-      if (TRI_ERROR_NO_ERROR != ret_val) {
-        good = false;
-        LOG_TOPIC("8f7ef", DEBUG, arangodb::Logger::ENGINES)
-            << "shaCalcFile: TRI_WriteFile failed with " << ret_val << " for " << newfile;
-      }
-    } else {
-      LOG_TOPIC("7f3fd", DEBUG, arangodb::Logger::ENGINES)
-          << "shaCalcFile:  TRI_ProcessFile failed for " << filename;
+std::pair<bool, std::string> RocksDBShaCalculatorThread::shaCalcFile(std::string const& filename) {
+  LOG_TOPIC("af088", DEBUG, arangodb::Logger::ENGINES)
+      << "shaCalcFile: computing " << filename;
+ 
+  TRI_SHA256Functor sha;
+  if (TRI_ProcessFile(filename.c_str(), std::ref(sha))) {
+    std::string hash = sha.finalize();
+    std::string newfile = filename.substr(0, filename.size() - 4);
+    newfile += ".sha.";
+    newfile += hash;
+    newfile += ".hash";
+    LOG_TOPIC("80257", DEBUG, arangodb::Logger::ENGINES)
+        << "shaCalcFile: done " << filename << " result: " << newfile;
+    auto res = TRI_WriteFile(newfile.c_str(), "", 0);
+    if (res == TRI_ERROR_NO_ERROR) {
+      return {true, std::move(hash) }; 
     }
-  }
 
-  return good;
-}
-
-bool RocksDBShaCalculatorThread::deleteFile(std::string const& filename) {
-  bool good = false, found = false;
-
-  // need filename without ".sst" for matching to ".sha." file
-  std::string basename = TRI_Basename(filename.c_str());
-  if (4 < basename.size() && 0 == basename.substr(basename.size() - 4).compare(".sst")) {
-    basename = basename.substr(0, basename.size() - 4);
+    LOG_TOPIC("8f7ef", DEBUG, arangodb::Logger::ENGINES)
+        << "shaCalcFile: TRI_WriteFile failed with " << res << " for " << newfile;
   } else {
-    // abort looking
-    found = true;
+    LOG_TOPIC("7f3fd", DEBUG, arangodb::Logger::ENGINES)
+        << "shaCalcFile:  TRI_ProcessFile failed for " << filename;
   }
+    
+  return {false, ""};
+}
 
-  if (!found) {
-    std::string dirname = TRI_Dirname(filename);
-    std::vector<std::string> filelist = TRI_FilesDirectory(dirname.c_str());
+void RocksDBShaCalculatorThread::deleteObsoleteFiles() {
+  std::string const dirname = getRocksDBPath();
+  std::string scratch;
+    
+  MUTEX_LOCKER(mutexLock, _pendingMutex);
 
-    // future thought: are there faster ways to find matching .sha. file?
-    for (auto const& it : filelist) {
-      // sha256 is 64 characters long.  ".sha." is added 5.  So 69 characters is minimum length
-      if (69 < it.size() && 0 == it.compare(0, basename.size(), basename) &&
-          0 == it.substr(basename.size(), 5).compare(".sha.")) {
-        std::string deletefile = basics::FileUtils::buildFilename(dirname, it);
-        auto ret_val = TRI_UnlinkFile(deletefile.c_str());
-        good = (TRI_ERROR_NO_ERROR == ret_val);
-        if (!good) {
-          LOG_TOPIC("acb34", DEBUG, arangodb::Logger::ENGINES)
-              << "deleteCalcFile:  TRI_UnlinkFile failed with " << ret_val
-              << " for " << deletefile;
-        } else {
-          LOG_TOPIC("e0a0d", DEBUG, arangodb::Logger::ENGINES)
-              << "deleteCalcFile:  TRI_UnlinkFile succeeded for " << deletefile;
-        }
-        break;
+  while (!_pendingDeletions.empty()) {
+    auto const& it = *_pendingDeletions.begin();
+    // ".sst" is 4 characters
+    TRI_ASSERT(isSstFilename(it));
+    TRI_ASSERT(it.size() > 4);
+      
+    scratch.clear();
+
+    auto it2 = _calculatedHashes.find(TRI_Basename(it));
+    if (it2 != _calculatedHashes.end()) {
+      // file names look like
+      //   046440.sha.0dd3cc9fb90f6a32dd95ef721f7437ada30da588114a882284022123af414e8a.hash
+      scratch.append(it.data(), it.size() - 4); // append without .sst
+      TRI_ASSERT(!isSstFilename(scratch));
+      scratch.append(".sha.");
+      scratch.append((*it2).second);
+      scratch.append(".hash");
+  
+      _calculatedHashes.erase(it2);
+    }
+    
+    _pendingDeletions.erase(_pendingDeletions.begin());
+
+    if (!scratch.empty()) {
+      // we will remove this file from disk
+      mutexLock.unlock();
+
+      auto res = TRI_UnlinkFile(scratch.c_str());
+      if (res == TRI_ERROR_NO_ERROR) {
+        LOG_TOPIC("e0a0d", DEBUG, arangodb::Logger::ENGINES)
+            << "deleteCalcFile:  TRI_UnlinkFile succeeded for " << scratch;
+      } else {
+        LOG_TOPIC("acb34", DEBUG, arangodb::Logger::ENGINES)
+            << "deleteCalcFile:  TRI_UnlinkFile failed with " << res
+            << " for " << scratch;
       }
+
+      mutexLock.lock();
     }
   }
-
-  return good;
 }
 
 /// @brief Wrapper for getFeature<DatabasePathFeature> to simplify
@@ -206,65 +254,109 @@ void RocksDBShaCalculatorThread::checkMissingShaFiles(std::string const& pathnam
   // sorting will put xxxxxx.sha.yyy just before xxxxxx.sst
   std::sort(filelist.begin(), filelist.end());
 
-  std::string temppath, tempname;
+  std::string tempname;
+      
   for (auto iter = filelist.begin(); filelist.end() != iter; ++iter) {
+    if (iter->size() < 5) {
+      // filename is too short and does not matter
+      continue;
+    }
+      
+    TRI_ASSERT(*iter == TRI_Basename(*iter));
+
     // cppcheck-suppress derefInvalidIteratorRedundantCheck
     std::string::size_type shaIdx = iter->find(".sha.");
     if (std::string::npos != shaIdx) {
       // two cases: 1. its .sst follows so skip both, 2. no matching .sst, so delete
+      tempname = iter->substr(0, shaIdx);
+      tempname += ".sst";
+      TRI_ASSERT(tempname == TRI_Basename(tempname));
+
       bool match = false;
       // cppcheck-suppress derefInvalidIteratorRedundantCheck
       auto next = iter + 1;
       // cppcheck-suppress derefInvalidIteratorRedundantCheck
       if (filelist.end() != next) {
-        tempname = iter->substr(0, shaIdx);
-        tempname += ".sst";
         if (0 == next->compare(tempname)) {
+          TRI_ASSERT(iter->size() >= shaIdx + 64);
+          std::string hash = iter->substr(shaIdx + /*.sha.*/ 5, 64);
+
+          // update our hashes table, in case we missed this file
+          {
+            MUTEX_LOCKER(mutexLock, _pendingMutex);
+            _calculatedHashes[tempname] = std::move(hash);
+          }
+
           match = true;
           iter = next;
         }
       }
 
       if (!match) {
-        temppath = basics::FileUtils::buildFilename(pathname, *iter);
+        std::string tempPath = basics::FileUtils::buildFilename(pathname, *iter);
         LOG_TOPIC("4eac9", DEBUG, arangodb::Logger::ENGINES)
             << "checkMissingShaFiles:"
                " Deleting file "
-            << temppath;
-        TRI_UnlinkFile(temppath.c_str());
+            << tempPath;
+        TRI_UnlinkFile(tempPath.c_str());
+          
+        // remove from our calculated hashes map
+        MUTEX_LOCKER(mutexLock, _pendingMutex);
+        _calculatedHashes.erase(tempname);
       }
-    } else if (0 == iter->substr(iter->size() - 4).compare(".sst")) {
-      // reaching this point means no .sha. preceeded, now check the
-      // modification time, if younger than 5 mins, just leave it, otherwise,
-      // we create a sha file. This is to ensure that sha files are eventually
-      // generated if somebody switches on backup after the fact. However,
-      // normally, the shas should only be computed when the sst file has
-      // been fully written, which can only be guaranteed if we got a
-      // creation event.
-      temppath = basics::FileUtils::buildFilename(pathname, *iter);
-      int64_t now = ::time(nullptr);
-      int64_t modTime;
-      auto r = TRI_MTimeFile(temppath.c_str(), &modTime);
-      if (r == TRI_ERROR_NO_ERROR && (now - modTime) >= requireAge) {
-        LOG_TOPIC("d6c86", DEBUG, arangodb::Logger::ENGINES)
-            << "checkMissingShaFiles:"
-               " Computing checksum for "
-            << temppath;
-        shaCalcFile(temppath);
-      } else {
-        LOG_TOPIC("7f70f", DEBUG, arangodb::Logger::ENGINES)
-            << "checkMissingShaFiles:"
-               " Not computing checksum for "
-            << temppath << " since it is too young";
+    } else if (iter->size() > 4 &&
+               iter->compare(iter->size() - 4, 4, ".sst") == 0) {
+      // we only get here if we found an .sst find but no .sha file directly
+      // in front of it!
+      MUTEX_LOCKER(mutexLock, _pendingMutex);
+
+      auto it2 = _calculatedHashes.find(*iter);
+      if (it2 == _calculatedHashes.end()) {
+        // not yet calculated
+        mutexLock.unlock();
+
+        // reaching this point means no .sha. preceeded, now check the
+        // modification time, if younger than a few mins, just leave it, otherwise,
+        // we create a sha file. This is to ensure that sha files are eventually
+        // generated if somebody switches on backup after the fact. However,
+        // normally, the shas should only be computed when the sst file has
+        // been fully written, which can only be guaranteed if we got a
+        // creation event.
+        std::string tempPath = basics::FileUtils::buildFilename(pathname, *iter);
+        int64_t now = ::time(nullptr);
+        int64_t modTime;
+        auto r = TRI_MTimeFile(tempPath.c_str(), &modTime);
+        if (r == TRI_ERROR_NO_ERROR && (now - modTime) >= requireAge) {
+          LOG_TOPIC("d6c86", DEBUG, arangodb::Logger::ENGINES)
+              << "checkMissingShaFiles:"
+                 " Computing checksum for "
+              << tempPath;
+
+          // calculate hash value and generate .hash file
+          auto [ok, hash] = shaCalcFile(tempPath);
+          
+          if (ok) {
+            MUTEX_LOCKER(mutexLock, _pendingMutex);
+            _calculatedHashes[*iter] = std::move(hash);
+          }
+        } else {
+          LOG_TOPIC("7f70f", DEBUG, arangodb::Logger::ENGINES)
+              << "checkMissingShaFiles:"
+                 " Not computing checksum for "
+              << tempPath << " since it is too young";
+        }
       }
     }
   }
 }
 
 /// @brief Setup the object, clearing variables, but do no real work
-RocksDBShaCalculator::RocksDBShaCalculator(application_features::ApplicationServer& server)
+RocksDBShaCalculator::RocksDBShaCalculator(application_features::ApplicationServer& server,
+                                           bool startThread)
     : _shaThread(server, "Sha256Thread") {
-  _shaThread.start(&_threadDone);
+  if (startThread) {
+    _shaThread.start(&_threadDone);
+  }
 }
 
 /// @brief Shutdown the background thread only if it was ever started
@@ -280,6 +372,7 @@ void RocksDBShaCalculator::waitForShutdown() {
   _shaThread.beginShutdown();
   
   _shaThread.signalLoop();
+
   CONDITION_LOCKER(locker, _threadDone);
   if (_shaThread.isRunning()) {
     _threadDone.wait();
@@ -301,6 +394,10 @@ void RocksDBShaCalculator::OnCompactionCompleted(rocksdb::DB* db,
   for (auto const& filename : ci.output_files) {
     _shaThread.queueShaCalcFile(filename);
   }
+}
+
+void RocksDBShaCalculator::checkMissingShaFiles(std::string const& pathname, int64_t requireAge) {
+  _shaThread.checkMissingShaFiles(pathname, requireAge);
 }
 
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/Listeners/RocksDBShaCalculator.h
+++ b/arangod/RocksDBEngine/Listeners/RocksDBShaCalculator.h
@@ -24,63 +24,78 @@
 #ifndef ARANGO_ROCKSDB_ENGINE_LISTENERS_ROCKSDB_SHA_CALCULATOR_H
 #define ARANGO_ROCKSDB_ENGINE_LISTENERS_ROCKSDB_SHA_CALCULATOR_H 1
 
-#include <atomic>
-#include <queue>
+#include <chrono>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 // public rocksdb headers
 #include <rocksdb/listener.h>
 
+#include "Basics/Common.h"
 #include "Basics/ConditionVariable.h"
 #include "Basics/Mutex.h"
 #include "Basics/Thread.h"
 
 namespace arangodb {
+namespace application_features {
+class ApplicationServer;
+}
 
 class RocksDBShaCalculatorThread : public arangodb::Thread {
  public:
   explicit RocksDBShaCalculatorThread(application_features::ApplicationServer& server,
-                                      std::string const& name)
-      : Thread(server, name) {}
+                                      std::string const& name);
+
   ~RocksDBShaCalculatorThread();
 
+  /// @brief called by RocksDB when a new .sst file is created
   void queueShaCalcFile(std::string const& pathName);
 
+  /// @brief called by RocksDB when it deletes an .sst
   void queueDeleteFile(std::string const& pathName);
 
+  // return [success, hash]
+  static std::pair<bool, std::string> shaCalcFile(std::string const& filename);
+
+  void checkMissingShaFiles(std::string const& pathname, int64_t requireAge);
+  
   void signalLoop();
-
-  static bool shaCalcFile(std::string const& filename);
-
-  static bool deleteFile(std::string const& filename);
-
-  static void checkMissingShaFiles(std::string const& pathname, int64_t requireAge);
 
  protected:
   void run() override;
+  
+  void deleteObsoleteFiles();
 
-  struct actionNeeded_t {
-    enum { CALC_SHA, DELETE_ACTION } _action;
-    std::string _path;
-  };
+  template <typename T>
+  bool isSstFilename(T const& filename) const;
+  
+  /// @brief The following wrapper routine simplifies unit testing
+  TEST_VIRTUAL std::string getRocksDBPath();
 
   basics::ConditionVariable _loopingCondvar;
 
   Mutex _pendingMutex;
-  std::queue<actionNeeded_t> _pendingQueue;
+  /// @brief use vectors to buffer all pending operations. this
+  /// will mean that we do not necessarily process the operations
+  /// in incoming order (LIFO), but rather in FIFO order. However,
+  /// the processing order is not important here
+  std::vector<std::string> _pendingCalculations;
+  std::unordered_set<std::string> _pendingDeletions;
 
-  ////////////////////////////////////////////////////////////////////////////////
-  /// @brief The following wrapper routines simplify unit testing
-  ////////////////////////////////////////////////////////////////////////////////
-  virtual std::string getRocksDBPath();
+  /// @brief already calculated and memoized hash values
+  std::unordered_map<std::string, std::string> _calculatedHashes;
+
+  /// @brief time point when we ran the last full check over the
+  /// entire directory
+  std::chrono::time_point<std::chrono::steady_clock> _lastFullCheck;
 };
 
-////////////////////////////////////////////////////////////////////////////////
-///
-///
-////////////////////////////////////////////////////////////////////////////////
 class RocksDBShaCalculator : public rocksdb::EventListener {
  public:
-  explicit RocksDBShaCalculator(application_features::ApplicationServer&);
+  explicit RocksDBShaCalculator(application_features::ApplicationServer&, bool startThread);
   virtual ~RocksDBShaCalculator();
 
   void OnFlushCompleted(rocksdb::DB* db, const rocksdb::FlushJobInfo& flush_job_info) override;
@@ -88,6 +103,8 @@ class RocksDBShaCalculator : public rocksdb::EventListener {
   void OnTableFileDeleted(const rocksdb::TableFileDeletionInfo& /*info*/) override;
 
   void OnCompactionCompleted(rocksdb::DB* db, const rocksdb::CompactionJobInfo& ci) override;
+  
+  void checkMissingShaFiles(std::string const& pathname, int64_t requireAge);
 
   void beginShutdown() { _shaThread.beginShutdown(); }
 

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -389,6 +389,8 @@ class RocksDBEngine final : public StorageEngine {
   static arangodb::Result registerRecoveryHelper(std::shared_ptr<RocksDBRecoveryHelper> helper);
   static std::vector<std::shared_ptr<RocksDBRecoveryHelper>> const& recoveryHelpers();
 
+  void checkMissingShaFiles(std::string const& pathname, int64_t requireAge);
+
  private:
   void shutdownRocksDBInstance() noexcept;
   void waitForCompactionJobsToFinish();

--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -817,7 +817,7 @@ std::vector<std::string> TRI_FilesDirectory(char const* path) {
   while (de != nullptr) {
     if (strcmp(de->d_name, ".") != 0 && strcmp(de->d_name, "..") != 0) {
       // may throw
-      result.emplace_back(std::string(de->d_name));
+      result.emplace_back(de->d_name);
     }
 
     de = readdir(d);
@@ -1081,23 +1081,14 @@ bool TRI_ProcessFile(char const* filename,
     return false;
   }
   
-  TRI_string_buffer_t result;
-  TRI_InitStringBuffer(&result, false);
-
-  auto guard = scopeGuard([&fd, &result]() {
+  auto guard = scopeGuard([&fd]() noexcept {
     TRI_CLOSE(fd);
-    TRI_DestroyStringBuffer(&result);
   });
 
-  auto res = TRI_ReserveStringBuffer(&result, READBUFFER_SIZE);
-
-  if (res != TRI_ERROR_NO_ERROR) {
-    return false;
-  }
+  char buffer[4096];
 
   while (true) {
-    TRI_ASSERT(TRI_CapacityStringBuffer(&result) >= READBUFFER_SIZE);
-    TRI_read_return_t n = TRI_READ(fd, (void*) TRI_BeginStringBuffer(&result), READBUFFER_SIZE);
+    TRI_read_return_t n = TRI_READ(fd, &buffer[0], sizeof(buffer));
 
     if (n == 0) {
       return true;
@@ -1108,7 +1099,7 @@ bool TRI_ProcessFile(char const* filename,
       return false;
     }
 
-    if (!reader(result._buffer, n)) {
+    if (!reader(&buffer[0], n)) {
       return false;
     }
   }
@@ -1704,7 +1695,7 @@ std::string TRI_BinaryName(char const* argv0) {
 std::string TRI_LocateBinaryPath(char const* argv0) {
 #if _WIN32
   wchar_t buff[4096];
-  int res = GetModuleFileNameW(NULL, buff, sizeof(buff));
+  int res = GetModuleFileNameW(nullptr, buff, sizeof(buff));
 
   if (res != 0) {
     buff[4095] = '\0';
@@ -2092,33 +2083,21 @@ std::string TRI_HomeDirectory() {
 ////////////////////////////////////////////////////////////////////////////////
 
 ErrorCode TRI_Crc32File(char const* path, uint32_t* crc) {
-  FILE* fin;
-  void* buffer;
-  auto res = TRI_ERROR_NO_ERROR;
-
-  *crc = TRI_InitialCrc32();
-
-  constexpr size_t bufferSize = 4096;
-  buffer = TRI_Allocate(bufferSize);
-
-  if (buffer == nullptr) {
-    return TRI_ERROR_OUT_OF_MEMORY;
-  }
-
-  fin = TRI_FOPEN(path, "rb");
+  FILE* fin = TRI_FOPEN(path, "rb");
 
   if (fin == nullptr) {
-    TRI_Free(buffer);
-
     return TRI_ERROR_FILE_NOT_FOUND;
   }
 
-  res = TRI_ERROR_NO_ERROR;
+  char buffer[4096];
+  
+  auto res = TRI_ERROR_NO_ERROR;
+  *crc = TRI_InitialCrc32();
 
   while (true) {
-    size_t sizeRead = fread(buffer, 1, bufferSize, fin);
+    size_t sizeRead = fread(&buffer[0], 1, sizeof(buffer), fin);
 
-    if (sizeRead < bufferSize) {
+    if (sizeRead < sizeof(buffer)) {
       if (feof(fin) == 0) {
         res = TRI_ERROR_FAILED;
         break;
@@ -2126,13 +2105,11 @@ ErrorCode TRI_Crc32File(char const* path, uint32_t* crc) {
     }
 
     if (sizeRead > 0) {
-      *crc = TRI_BlockCrc32(*crc, static_cast<char const*>(buffer), sizeRead);
+      *crc = TRI_BlockCrc32(*crc, &buffer[0], sizeRead);
     } else /* if (sizeRead <= 0) */ {
       break;
     }
   }
-
-  TRI_Free(buffer);
 
   if (0 != fclose(fin)) {
     res = TRI_set_errno(TRI_ERROR_SYS_ERROR);
@@ -2652,7 +2629,7 @@ TRI_SHA256Functor::~TRI_SHA256Functor() {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
   EVP_MD_CTX_free(_context);
 #else
-    EVP_MD_CTX_destroy(_context);
+  EVP_MD_CTX_destroy(_context);
 #endif
 }
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/14893

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/770

Make background calculation of SHA hashes less intrusive

* Make background calculation of SHA hashes for RocksDB .sst files less
  intrusive. The previous implementation frequently iterated over all files
  in the database directory to check if it needed to ad-hoc calculate the
  SHA hashes for .sst files it previously missed. The procedure it used
  was to iterate over all files in the database directory and check if there
  were matching pairs of .sst files and .sha files. This was expensive,
  because a full directory iteration was performed and a lot of temporary
  strings were created for filenames and used in comparisons. This was
  especially expensive for larger deployments with lots of .sst files.
  The expensive iteration of files in the directory is now happening less
  frequently, and will not be as expensive as before if it runs.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *gtest*, *hot_backup*.
