### PR TITLE
fix issues in `importing` testsuite

### DIFF
--- a/js/client/modules/@arangodb/testsuites/importing.js
+++ b/js/client/modules/@arangodb/testsuites/importing.js
@@ -384,14 +384,16 @@ function importing (options) {
       result[impTodo.id] = pu.run.arangoImport(options, instanceInfo, impTodo, options.coreCheck);
       result[impTodo.id].failed = 0;
 
+      if (impTodo.expectFailure) {
+        // if status === false, we make true out of it
+        // if status === true, we make false out of it
+        result[impTodo.id].status = !result[impTodo.id].status;
+      }
+
       if (result[impTodo.id].status !== true && !options.force) {
-        if (impTodo.expectFailure) {
-          result[impTodo.id].status = true;
-        } else {
-          result[impTodo.id].failed = 1;
-          result.failed += 1;
-          throw new Error('cannot run import');
-        }
+        result[impTodo.id].failed = 1;
+        result.failed += 1;
+        throw new Error('cannot run import');
       }
     }
 

--- a/tests/js/server/import/import-setup.js
+++ b/tests/js/server/import/import-setup.js
@@ -100,6 +100,7 @@
   db.UnitTestsImportIgnore.ensureIndex({ type: "hash", fields: [ "value" ], unique: true });
   db._create("UnitTestsImportUniqueConstraints");
   db.UnitTestsImportUniqueConstraints.ensureIndex({ type: "hash", fields: [ "value" ], unique: true });
+  db._create("UnitTestsImportCsvMergeAttributes");
 })();
 
 return {


### PR DESCRIPTION
### Scope & Purpose

Fix issues in `importing` testsuite.
This prevents the `importing` testsuite to fail in nightly runs. This fixes only test code, so no CHANGELOG entry added.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *importing*.
