### PR TITLE
[CINFRA] First Term write-concern replication-factor confusion

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Algorithms.cpp
+++ b/arangod/Replication2/ReplicatedLog/Algorithms.cpp
@@ -66,7 +66,7 @@ auto createFirstTerm(DatabaseID const& database, LogPlanSpecification const& spe
   LogPlanTermSpecification newTermSpec;
   newTermSpec.term = LogTerm{1};
   newTermSpec.config = spec.targetConfig;
-  for (std::size_t i = 0; i < spec.targetConfig.writeConcern; i++) {
+  for (std::size_t i = 0; i < spec.targetConfig.replicationFactor; i++) {
     newTermSpec.participants.emplace(ParticipantId{participants[i]},
                                      LogPlanTermSpecification::Participant{});
   }

--- a/tests/Replication2/ReplicatedLog/CheckLogsTest.cpp
+++ b/tests/Replication2/ReplicatedLog/CheckLogsTest.cpp
@@ -274,6 +274,29 @@ TEST_F(CheckLogsAlgorithmTest, check_constitute_first_term) {
   EXPECT_TRUE(e.participants.find("C") != e.participants.end());
 }
 
+TEST_F(CheckLogsAlgorithmTest, check_constitute_first_term_r3_wc2) {
+
+  auto participants = ParticipantInfo{
+      {"A", ParticipantRecord{RebootId{1}, true}},
+      {"B", ParticipantRecord{RebootId{1}, true}},
+      {"C", ParticipantRecord{RebootId{1}, true}},
+  };
+
+  auto spec = makePlanSpecification(LogId{1});
+  spec.targetConfig.writeConcern = 2;
+  spec.targetConfig.replicationFactor = 3;
+  auto current = makeLogCurrent();
+
+  auto v = checkReplicatedLog("db", spec, current, participants);
+  auto& e = std::get<agency::LogPlanTermSpecification>(v);
+  EXPECT_EQ(e.term, LogTerm{1});
+  EXPECT_EQ(e.config, spec.targetConfig);
+  EXPECT_EQ(e.participants.size(), 3);
+  EXPECT_TRUE(e.participants.find("B") != e.participants.end());
+  EXPECT_TRUE(e.participants.find("C") != e.participants.end());
+  EXPECT_TRUE(e.participants.find("A") != e.participants.end());
+}
+
 TEST_F(CheckLogsAlgorithmTest, check_constitute_first_term_not_enough_participants) {
   auto participants = ParticipantInfo{
       {"A", ParticipantRecord{RebootId{1}, false}},


### PR DESCRIPTION
### Scope & Purpose
Before this fix the supervision would only select writeConcern many servers, instead of replicationFactor many.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required
- [ ] Backports required for: *(Please specify versions and link PRs)*
