### PR TITLE
we must return v8::Undefined, the way its now the object will be invalid on the place of the function invocation

### DIFF
--- a/arangosh/Shell/V8ClientConnection.cpp
+++ b/arangosh/Shell/V8ClientConnection.cpp
@@ -1877,8 +1877,8 @@ v8::Local<v8::Value> parseReplyBodyToV8(fu::Response const& response,
       err += ex.what();
       TRI_CreateErrorObject(isolate, TRI_ERROR_HTTP_CORRUPTED_JSON, err, true);
     }
-  } 
-  return v8::Local<v8::Value>();
+  }
+  return v8::Undefined(isolate);
 }
 
 v8::Local<v8::Value> translateResultBodyToV8(fu::Response const& response,


### PR DESCRIPTION
### Scope & Purpose

The current implementation will crash arangosh while trying to do error handling.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: 3.8 https://github.com/arangodb/arangodb/pull/14957 , 3.9 https://github.com/arangodb/arangodb/pull/14958

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
