### PR TITLE
fix compile warning about potentially unused variable

### DIFF
--- a/arangod/RocksDBEngine/Listeners/RocksDBShaCalculator.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBShaCalculator.cpp
@@ -315,7 +315,7 @@ void RocksDBShaCalculatorThread::checkMissingShaFiles(std::string const& pathnam
         // creation event.
         std::string tempPath = basics::FileUtils::buildFilename(pathname, *iter);
         int64_t now = ::time(nullptr);
-        int64_t modTime;
+        int64_t modTime = 0;
         auto r = TRI_MTimeFile(tempPath.c_str(), &modTime);
         if (r == TRI_ERROR_NO_ERROR && (now - modTime) >= requireAge) {
           LOG_TOPIC("d6c86", DEBUG, arangodb::Logger::ENGINES)


### PR DESCRIPTION
### Scope & Purpose

Fix a compile warning about a potentially uninitialized variable with clang 12.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
