### PR TITLE
fix compilation with glibc 2.34

### DIFF
--- a/3rdParty/boost/1.71.0/boost/thread/pthread/thread_data.hpp
+++ b/3rdParty/boost/1.71.0/boost/thread/pthread/thread_data.hpp
@@ -57,7 +57,7 @@ namespace boost
 #else
           std::size_t page_size = ::sysconf( _SC_PAGESIZE);
 #endif
-#if PTHREAD_STACK_MIN > 0
+#ifdef PTHREAD_STACK_MIN
           if (size<PTHREAD_STACK_MIN) size=PTHREAD_STACK_MIN;
 #endif
           size = ((size+page_size-1)/page_size)*page_size;


### PR DESCRIPTION
### Scope & Purpose

Fix compilation with glibc version 2.34. That version of glibc changes the definition of `PTHREAD_STACK_MIN` from a constant value to a function call.
Change taken from upstream boost version: https://github.com/boostorg/thread/commit/74fb0a26099bc51d717f5f154b37231ce7df3e98#diff-ef2dff427736336b6cfc1b3e54c68a8c8321d7b1a69c551a6e6191afc7d783ee

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] No backports required

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
