### PR TITLE
BTS-598: try to work around crash in tests with ASan

### DIFF
--- a/tests/Basics/GuardedTest.cpp
+++ b/tests/Basics/GuardedTest.cpp
@@ -204,7 +204,6 @@ TYPED_TEST_P(GuardedDeathTest, test_guard_unlock_releases_value) {
   EXPECT_EQ(2, guard.get().val);
   guard.unlock();
 
-  ASSERT_DEATH_CORE_FREE({ ASSERT_NE(2, guard.get().val); }, "");
   // stunt to find out whether we are compiling with ASan enabled...
   // we do this to avoid getting a mysterious SIGSEGV during testing.
   // more details can be found in BTS-598


### PR DESCRIPTION
### Scope & Purpose

BTS-598: Try to work around SIGSEGV in ASan tests.
Works for me when I execute the test locally under ASan. We have to verify this in Jenkins as well.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backports required for: *3.9*

#### Related Information

- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-598

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [x] I ensured this code runs with ASan / TSan or other static verification tools
