### PR TITLE
Replace death test by a normal test

### DIFF
--- a/lib/Basics/Guarded.h
+++ b/lib/Basics/Guarded.h
@@ -119,7 +119,7 @@ auto MutexGuard<T, L>::get() const noexcept -> T& {
 
 template <class T, class L>
 auto MutexGuard<T, L>::operator->() const noexcept -> T* {
-  return std::addressof(get());
+  return _value.get();
 }
 
 template <class T, class L>


### PR DESCRIPTION
### Scope & Purpose

Replace a death test by a normal test.

- [X] :hammer: Refactoring/simplification

#### Backports:

- [X] Backport for 3.9: https://github.com/arangodb/arangodb/pull/14995

#### Related Information

- [X] Jira ticket number: https://arangodb.atlassian.net/browse/BTS-598
