### PR TITLE
Remove hacks trying to detect tool paths, which do not always work

### DIFF
--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -240,6 +240,7 @@ let ARANGOIMPORT_BIN;
 let ARANGORESTORE_BIN;
 let ARANGOEXPORT_BIN;
 let ARANGOSH_BIN;
+let ARANGO_SECURE_INSTALLATION_BIN;
 let CONFIG_ARANGODB_DIR;
 let CONFIG_RELATIVE_DIR;
 let CONFIG_DIR;
@@ -327,6 +328,7 @@ function setupBinaries (builddir, buildType, configDir) {
   ARANGORESTORE_BIN = fs.join(BIN_DIR, 'arangorestore' + executableExt);
   ARANGOEXPORT_BIN = fs.join(BIN_DIR, 'arangoexport' + executableExt);
   ARANGOSH_BIN = fs.join(BIN_DIR, 'arangosh' + executableExt);
+  ARANGO_SECURE_INSTALLATION_BIN = fs.join(BIN_DIR, 'arango-secure-installation' + executableExt);
 
   CONFIG_ARANGODB_DIR = fs.join(builddir, 'etc', 'arangodb3');
   if (!fs.exists(CONFIG_ARANGODB_DIR)) {
@@ -2528,9 +2530,15 @@ exports.getCleanupDBDirectories = getCleanupDBDirectories;
 
 exports.makeAuthorizationHeaders = makeAuthorizationHeaders;
 exports.dumpAgency = dumpAgency;
-Object.defineProperty(exports, 'ARANGOEXPORT_BIN', {get: () => ARANGOEXPORT_BIN});
+Object.defineProperty(exports, 'ARANGOBACKUP_BIN', {get: () => ARANGOBACKUP_BIN});
+Object.defineProperty(exports, 'ARANGOBENCH_BIN', {get: () => ARANGOBENCH_BIN});
+Object.defineProperty(exports, 'ARANGODUMP_BIN', {get: () => ARANGODUMP_BIN});
 Object.defineProperty(exports, 'ARANGOD_BIN', {get: () => ARANGOD_BIN});
+Object.defineProperty(exports, 'ARANGOEXPORT_BIN', {get: () => ARANGOEXPORT_BIN});
+Object.defineProperty(exports, 'ARANGOIMPORT_BIN', {get: () => ARANGOIMPORT_BIN});
+Object.defineProperty(exports, 'ARANGORESTORE_BIN', {get: () => ARANGORESTORE_BIN});
 Object.defineProperty(exports, 'ARANGOSH_BIN', {get: () => ARANGOSH_BIN});
+Object.defineProperty(exports, 'ARANGO_SECURE_INSTALLATION_BIN', {get: () => ARANGO_SECURE_INSTALLATION_BIN});
 Object.defineProperty(exports, 'CONFIG_DIR', {get: () => CONFIG_DIR});
 Object.defineProperty(exports, 'TOP_DIR', {get: () => TOP_DIR});
 Object.defineProperty(exports, 'LOGS_DIR', {get: () => LOGS_DIR});

--- a/tests/js/client/communication/test-communication.js
+++ b/tests/js/client/communication/test-communication.js
@@ -63,9 +63,7 @@ const endpointToURL = (endpoint) => {
   return 'http' + endpoint.substr(pos);
 };
 
-// detect the path of arangosh. quite hacky, but works
-const arangosh = fs.join(global.ARANGOSH_PATH, 'arangosh' + pu.executableExt);
-
+const arangosh = pu.ARANGOSH_BIN;
 
 const debug = function (text) {
   console.warn(text);

--- a/tests/js/client/communication/test-kill.js
+++ b/tests/js/client/communication/test-kill.js
@@ -41,8 +41,7 @@ function KillSuite () {
   // generate a random collection name
   const cn = "UnitTests" + require("@arangodb/crypto").md5(internal.genRandomAlphaNumbers(32));
   
-  // detect the path of arangosh. quite hacky, but works
-  const arangosh = fs.join(global.ARANGOSH_PATH, 'arangosh' + pu.executableExt);
+  const arangosh = pu.ARANGOSH_BIN;
 
   assertTrue(fs.isFile(arangosh), "arangosh executable not found!");
 

--- a/tests/js/client/shell/shell-arango-secure-installation-noncluster.js
+++ b/tests/js/client/shell/shell-arango-secure-installation-noncluster.js
@@ -35,8 +35,7 @@ function arangoSecureInstallationSuite () {
 
   let oldPasswd;
 
-  // detect the path of arango-secure-installation. quite hacky, but works
-  const arangoSecureInstallation = fs.join(global.ARANGOSH_PATH, 'arango-secure-installation' + pu.executableExt);
+  const arangoSecureInstallation = pu.ARANGO_SECURE_INSTALLATION_BIN;
 
   assertTrue(fs.isFile(arangoSecureInstallation), "arango-secure-installation not found!");
 

--- a/tests/js/client/shell/shell-dump-integration.js
+++ b/tests/js/client/shell/shell-dump-integration.js
@@ -44,8 +44,7 @@ function checkDumpJsonFile (dbName, path, id) {
 function dumpIntegrationSuite () {
   'use strict';
   const cn = 'UnitTestsDump';
-  // detect the path of arangodump. quite hacky, but works
-  const arangodump = fs.join(global.ARANGOSH_PATH, 'arangodump' + pu.executableExt);
+  const arangodump = pu.ARANGODUMP_BIN;
 
   assertTrue(fs.isFile(arangodump), "arangodump not found!");
 

--- a/tests/js/client/shell/shell-restore-integration.js
+++ b/tests/js/client/shell/shell-restore-integration.js
@@ -71,8 +71,7 @@ function createDumpJsonFile (path, databaseName, id) {
 function restoreIntegrationSuite () {
   'use strict';
   const cn = 'UnitTestsRestore';
-  // detect the path of arangorestore. quite hacky, but works
-  const arangorestore = fs.join(global.ARANGOSH_PATH, 'arangorestore' + pu.executableExt);
+  const arangorestore = pu.ARANGORESTORE_BIN;
 
   assertTrue(fs.isFile(arangorestore), "arangorestore not found!");
 


### PR DESCRIPTION
### Scope & Purpose

This change only applies to the JavaScript test suites.

In some places, instead of using the path supplied with `--build` to detect the paths to a tool (like `arangorestore`), the path of the directory `arangosh` is in was used instead. Apart from being inconsistent, this isn't generally true. `scripts/unittest` prefers to take the path for arangosh from the environment variable `ARANGOSH`, and tries certain fixed fallbacks otherwise (starting with `build/bin/arangosh`, and finally to executing a `find` command which will return the first executable named `arangosh` it can find 🙄). However, at no place the build directory specified by `--build` is used. Thus, if the build directory isn't called `build`, usually the wrong binaries will be used.

- [X] :hankey: Bugfix (test suite only)

#### Related information:

- [X] Enterprise PR: https://github.com/arangodb/enterprise/pull/786

#### Backports:

- [ ] Backport for 3.9: *(Please link PR)*
- [ ] Backport for 3.8: *(Please link PR)*
- [ ] Backport for 3.7: *(Please link PR)*

### Testing & Verification

- [X] This change is already covered by existing tests, such as *(please describe tests)*.