### PR TITLE
fix compile warning about unused function

### DIFF
--- a/arangod/Replication2/ReplicatedLog/PersistedLog.h
+++ b/arangod/Replication2/ReplicatedLog/PersistedLog.h
@@ -19,8 +19,8 @@
 ///
 /// @author Lars Maier
 ////////////////////////////////////////////////////////////////////////////////
-#ifndef ARANGODB3_PERSISTEDLOG_H
-#define ARANGODB3_PERSISTEDLOG_H
+
+#pragma once
 
 #include "Replication2/ReplicatedLog/LogCommon.h"
 
@@ -57,5 +57,3 @@ struct PersistedLog {
 };
 
 }  // namespace arangodb::replication2
-
-#endif  // ARANGODB3_PERSISTEDLOG_H

--- a/arangod/RestHandler/RestLogHandler.h
+++ b/arangod/RestHandler/RestLogHandler.h
@@ -20,8 +20,8 @@
 ///
 /// @author Lars Maier
 ////////////////////////////////////////////////////////////////////////////////
-#ifndef ARANGODB3_RESTLOGHANDLER_H
-#define ARANGODB3_RESTLOGHANDLER_H
+
+#pragma once
 
 #include "Basics/Common.h"
 #include "RestHandler/RestVocbaseBaseHandler.h"
@@ -69,4 +69,3 @@ class RestLogHandler : public RestVocbaseBaseHandler {
 
 };
 }  // namespace arangodb
-#endif  // ARANGODB3_RESTLOGHANDLER_H

--- a/arangod/RocksDBEngine/RocksDBPersistedLog.h
+++ b/arangod/RocksDBEngine/RocksDBPersistedLog.h
@@ -19,8 +19,8 @@
 ///
 /// @author Lars Maier
 ////////////////////////////////////////////////////////////////////////////////
-#ifndef ARANGODB3_ROCKSDBPERSISTEDLOG_H
-#define ARANGODB3_ROCKSDBPERSISTEDLOG_H
+
+#pragma once
 
 #include <rocksdb/db.h>
 
@@ -117,5 +117,3 @@ class RocksDBPersistedLog : public replication2::replicated_log::PersistedLog,
 };
 
 }  // namespace arangodb
-
-#endif  // ARANGODB3_ROCKSDBPERSISTEDLOG_H

--- a/arangod/RocksDBEngine/RocksDBZkdIndex.h
+++ b/arangod/RocksDBEngine/RocksDBZkdIndex.h
@@ -22,8 +22,7 @@
 /// @author Lars Maier
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef ARANGOD_ROCKSDB_ZKD_INDEX_H
-#define ARANGOD_ROCKSDB_ZKD_INDEX_H
+#pragma once
 
 #include "RocksDBEngine/RocksDBIndex.h"
 
@@ -113,5 +112,3 @@ auto specializeCondition(arangodb::Index const* index, arangodb::aql::AstNode* c
 }
 
 }
-
-#endif  // ARANGOD_ROCKSDB_ZKD_INDEX_H

--- a/arangosh/Restore/RestoreFeature.cpp
+++ b/arangosh/Restore/RestoreFeature.cpp
@@ -162,53 +162,6 @@ uint64_t getNumberOfShards(arangodb::RestoreFeature::Options const& options,
   return result;
 }
 
-/// @brief Sort collections for proper recreation order
-bool sortCollectionsForCreation(VPackBuilder const& l, VPackBuilder const& r) {
-  VPackSlice const left = l.slice().get("parameters");
-  VPackSlice const right = r.slice().get("parameters");
-
-  std::string leftName =
-      arangodb::basics::VelocyPackHelper::getStringValue(left, "name", "");
-  std::string rightName =
-      arangodb::basics::VelocyPackHelper::getStringValue(right, "name", "");
-
-  // First we sort by shard distribution.
-  // We first have to create the collections which have no dependencies.
-  // NB: Dependency graph has depth at most 1, no need to manage complex DAG
-  VPackSlice leftDist = left.get(arangodb::StaticStrings::DistributeShardsLike);
-  VPackSlice rightDist = right.get(arangodb::StaticStrings::DistributeShardsLike);
-  if (leftDist.isNone() && rightDist.isString() &&
-      rightDist.copyString() == leftName) {
-    return true;
-  }
-  if (rightDist.isNone() && leftDist.isString() &&
-      leftDist.copyString() == rightName) {
-    return false;
-  }
-
-  // Next we sort by collection type so that vertex collections are recreated
-  // before edge, etc.
-  int leftType =
-      arangodb::basics::VelocyPackHelper::getNumericValue<int>(left, "type", 0);
-  int rightType =
-      arangodb::basics::VelocyPackHelper::getNumericValue<int>(right, "type", 0);
-  if (leftType != rightType) {
-    return leftType < rightType;
-  }
-
-  // Finally, sort by name so we have stable, reproducible results
-  // Sort system collections first
-  if (!leftName.empty() && leftName[0] == '_' &&
-      !rightName.empty() && rightName[0] != '_') {
-    return true;
-  }
-  if (!leftName.empty() && leftName[0] != '_' &&
-      !rightName.empty() && rightName[0] == '_') {
-    return false;
-  }
-  return strcasecmp(leftName.c_str(), rightName.c_str()) < 0;
-}
-
 void makeAttributesUnique(arangodb::velocypack::Builder& builder,
                           arangodb::velocypack::Slice slice) {
   if (slice.isObject()) {

--- a/lib/Basics/EncodingUtils.h
+++ b/lib/Basics/EncodingUtils.h
@@ -22,8 +22,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #pragma once
-#ifndef ARANGOD_BASICS_ENCODING_UTILS_H
-#define ARANGOD_BASICS_ENCODING_UTILS_H 1
 
 #include <velocypack/Buffer.h>
 
@@ -38,5 +36,3 @@ bool gzipDeflate(uint8_t* compressed, size_t compressedLength,
 
 }  // namespace encoding
 }  // namespace arangodb
-
-#endif

--- a/lib/Basics/exitcodes.h
+++ b/lib/Basics/exitcodes.h
@@ -1,5 +1,4 @@
-#ifndef ARANGODB_BASICS_EXIT_CODES_H
-#define ARANGODB_BASICS_EXIT_CODES_H 1
+#pragma once
 
 #include "Basics/error.h"
 
@@ -100,6 +99,4 @@ constexpr int TRI_EXIT_TZDATA_INITIALIZATION_FAILED                             
 /// Will be returned if i.e. ulimit is too restrictive
 constexpr int TRI_EXIT_RESOURCES_TOO_LOW                                        = 28;
 
-
-#endif
 

--- a/lib/Rest/CommonDefines.h
+++ b/lib/Rest/CommonDefines.h
@@ -22,8 +22,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #pragma once
-#ifndef ARANGODB_REST_COMMON_DEFINES_H
-#define ARANGODB_REST_COMMON_DEFINES_H 1
 
 #include <ostream>
 #include <string>
@@ -253,4 +251,3 @@ inline std::ostream& operator<<(std::ostream& ostream, ResponseCode responseCode
 }
 }  // namespace rest
 }  // namespace arangodb
-#endif

--- a/lib/SimpleHttpClient/ConnectionCache.h
+++ b/lib/SimpleHttpClient/ConnectionCache.h
@@ -21,8 +21,7 @@
 /// @author Jan Steemann
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef ARANGODB_SIMPLE_HTTP_CLIENT_CONNECTION_CACHE_H
-#define ARANGODB_SIMPLE_HTTP_CLIENT_CONNECTION_CACHE_H 1
+#pragma once
 
 #include "Basics/Mutex.h"
 
@@ -108,5 +107,3 @@ class ConnectionCache {
 
 }  // namespace httpclient
 }  // namespace arangodb
-
-#endif

--- a/utils/generateExitCodesFiles.py
+++ b/utils/generateExitCodesFiles.py
@@ -112,8 +112,7 @@ def genCHeaderFile(errors):
   wiki = "/// Exit codes and meanings\n"\
        + "/// The following codes might be returned when exiting ArangoDB:\n"
 
-  header =   "#ifndef ARANGODB_BASICS_EXIT_CODES_H\n"\
-           + "#define ARANGODB_BASICS_EXIT_CODES_H 1\n"\
+  header =   "#pragma once\n"\
            + "\n"\
            + "#include \"Basics/error.h\"\n"\
            + "\n"\
@@ -130,8 +129,6 @@ def genCHeaderFile(errors):
            + "\n"
 
   header = header\
-         + "\n"\
-         + "#endif\n"\
          + "\n"
 
   return header


### PR DESCRIPTION
### Scope & Purpose

Remove an unused function from the RestoreFeature, and replace a left include guard leftovers with `#pragma once`s.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
