### PR TITLE
Change query out of memory error message

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.7.16 (XXXX-XX-XX)
 --------------------
 
-* Change error message for queries that use too much memory from "resource
-  limit exceeded" to "query would use more memory than allowed".
+* Change error message for queries that use too much memory from "resource limit
+  exceeded" to "query would use more memory than allowed".
 
 * arangorestore: Fix the order (regarding distributeShardsLike) in which
   collections are being created during restore, which could result in an error

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.7.16 (XXXX-XX-XX)
 --------------------
 
+* Change error message for queries that use too much memory from "resource
+  limit exceeded" to "query would use more memory than allowed".
+
 * arangorestore: Fix the order (regarding distributeShardsLike) in which
   collections are being created during restore, which could result in an error
   and make manual intervention necessary.

--- a/lib/Basics/ResourceUsage.h
+++ b/lib/Basics/ResourceUsage.h
@@ -67,7 +67,8 @@ struct ResourceMonitor final {
 
     if (max > 0 && ADB_UNLIKELY(current > max)) {
       currentResources.memoryUsage.fetch_sub(value, std::memory_order_relaxed);
-      THROW_ARANGO_EXCEPTION(TRI_ERROR_RESOURCE_LIMIT);
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_RESOURCE_LIMIT, "query would use more memory than allowed");
     }
     
     size_t peak = currentResources.peakMemoryUsage.load(std::memory_order_relaxed);


### PR DESCRIPTION
### Scope & Purpose

DEVSUP-898: Change error message for queries that use too much memory from "resource limit exceeded" to "query would use more memory than allowed".

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] Backport for 3.9: *(Please link PR)*
- [ ] Backport for 3.8: *(Please link PR)*
- [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/DEVSUP-898

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
