### PR TITLE
Change query out of memory error message

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Change error message for queries that use too much memory from "resource
+  limit exceeded" to "query would use more memory than allowed".
+
 * Single server license output checking fixed.
 
 * Added enterprise license feature visibility for arangosh.

--- a/lib/Basics/ResourceUsage.cpp
+++ b/lib/Basics/ResourceUsage.cpp
@@ -133,7 +133,8 @@ void ResourceMonitor::increaseMemoryUsage(std::uint64_t value) {
       // track local limit violation
       _global.trackLocalViolation();
       // now we can safely signal an exception
-      THROW_ARANGO_EXCEPTION(TRI_ERROR_RESOURCE_LIMIT);
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_RESOURCE_LIMIT, "query would use more memory than allowed");
     }
 
     // instance's own memory usage counter has been updated successfully once we got here.


### PR DESCRIPTION
### Scope & Purpose

DEVSUP-898: Change error message for queries that use too much memory from "resource limit exceeded" to "query would use more memory than allowed".

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] Backport for 3.9: https://github.com/arangodb/arangodb/pull/15024
- [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/15023
- [x] Backport for 3.7: https://github.com/arangodb/arangodb/pull/15022

#### Related Information

- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/DEVSUP-898

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
