### PR TITLE
Improve revision tree sync performance

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.8.3 (XXXX-XX-XX)
 -------------------
 
+* Improve performance of getting-in-sync protocol when using revision trees
+  (for collections created with 3.8). The protocol optimization allows skipping
+  the unused parts of the revision trees in the data transfer, which can
+  substantially reduce the amount of data to be transfered for small and medium
+  collections when trying to get back into sync.
+
 * Change error message for queries that use too much memory from "resource limit
   exceeded" to "query would use more memory than allowed".
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,9 @@
 v3.8.3 (XXXX-XX-XX)
 -------------------
 
-* Improve performance of getting-in-sync protocol when using revision trees
-  (for collections created with 3.8). The protocol optimization allows skipping
-  the unused parts of the revision trees in the data transfer, which can
+* Improve performance of getting-in-sync protocol when using revision trees (for
+  collections created with 3.8). The protocol optimization allows skipping the
+  unused parts of the revision trees in the data transfer, which can
   substantially reduce the amount of data to be transfered for small and medium
   collections when trying to get back into sync.
 

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -1291,6 +1291,7 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(arangodb::LogicalCo
   {
     std::string url = baseUrl + "/" + RestReplicationHandler::Tree +
                       "?collection=" + urlEncode(leaderColl) +
+                      "&onlyPopulated=true" + 
                       "&to=" + std::to_string(maxTick) +
                       "&serverId=" + _state.localServerIdString +
                       "&batchId=" + std::to_string(_config.batch.id);

--- a/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
@@ -851,6 +851,10 @@ void RocksDBRestReplicationHandler::handleCommandRevisionTree() {
   // shall we do a verification?
   bool withVerification = _request->parsedValue("verification", false);
 
+  // return only populated nodes in the tree (can make the result a lot
+  // smaller and thus improve efficiency)
+  bool onlyPopulated = _request->parsedValue("onlyPopulated", false);
+
   auto tree = ctx.collection->getPhysical()->revisionTree(ctx.batchId);
    
   {
@@ -881,13 +885,13 @@ void RocksDBRestReplicationHandler::handleCommandRevisionTree() {
 
     VPackObjectBuilder guard(&result);
     result.add(VPackValue("computed"));
-    tree2->serialize(result);
+    tree2->serialize(result, onlyPopulated);
     result.add(VPackValue("stored"));
-    tree->serialize(result);
+    tree->serialize(result, onlyPopulated);
     auto diff = tree->diff(*tree2);
     result.add("equal", VPackValue(diff.empty()));
   } else {
-    tree->serialize(result);
+    tree->serialize(result, onlyPopulated);
   }
 
   generateResult(rest::ResponseCode::OK, std::move(buffer));

--- a/arangod/RocksDBEngine/RocksDBV8Functions.cpp
+++ b/arangod/RocksDBEngine/RocksDBV8Functions.cpp
@@ -266,13 +266,13 @@ static void JS_CollectionRevisionTreeVerification(v8::FunctionCallbackInfo<v8::V
     VPackObjectBuilder guard(&builder);
     if (storedTree != nullptr) {
       builder.add(VPackValue("stored"));
-      storedTree->serialize(builder);
+      storedTree->serialize(builder, /*onlyPopulated*/ false);
     } else {
       builder.add("stored", VPackValue(false));
     }
     if (computedTree != nullptr) {
       builder.add(VPackValue("computed"));
-      computedTree->serialize(builder);
+      computedTree->serialize(builder, /*onlyPopulated*/ false);
     } else {
       builder.add("computed", VPackValue(false));
     }

--- a/lib/Containers/MerkleTree.h
+++ b/lib/Containers/MerkleTree.h
@@ -323,10 +323,9 @@ class MerkleTree {
    * @brief Serialize the tree for transport or storage in portable format
    *
    * @param output    VPackBuilder for output
-   * @param depth     Maximum depth to serialize
+   * @param onlyPopulated  Only return populated buckets
    */
-  void serialize(velocypack::Builder& output,
-                 std::uint64_t depth = std::numeric_limits<std::uint64_t>::max()) const;
+  void serialize(velocypack::Builder& output, bool onlyPopulated) const;
 
   /**
    * @brief Provides a partition of the keyspace

--- a/tests/js/server/recovery/revision-trees-sync.js
+++ b/tests/js/server/recovery/revision-trees-sync.js
@@ -1,0 +1,143 @@
+/* jshint globalstrict:false, strict:false, unused : false */
+/* global assertEqual, assertFalse, assertTrue */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief tests for dump/reload
+// /
+// / @file
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2010-2012 triagens GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// / @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+const db = require('@arangodb').db;
+const internal = require('internal');
+const jsunity = require('jsunity');
+
+const colName1 = 'UnitTestsRecovery1';
+const colName2 = 'UnitTestsRecovery2';
+const colName3 = 'UnitTestsRecovery3';
+
+function runSetup () {
+  'use strict';
+  internal.debugClearFailAt();
+
+  db._drop(colName1);
+  var c = db._create(colName1), i;
+  c.ensureHashIndex('value');
+
+  for (i = 0; i < 1000; ++i) {
+    c.save({ _key: "test_" + i });
+  }
+
+  db._drop(colName2);
+  c = db._create(colName2);
+
+  for (i = 0; i < 1000; ++i) {
+    c.save({ _key: "test_" + i });
+  }
+  for (i = 0; i < 500; ++i) {
+    c.remove({ _key: "test_" + i });
+  }
+
+  db._drop(colName3);
+  c = db._create(colName3);
+
+  for (i = 0; i < 1000; ++i) {
+    c.save({ _key: "test_" + i });
+  }
+  c.truncate();
+
+  db._drop('test');
+  c = db._create('test');
+  c.save({ _key: 'crashme' }, true);
+
+  let haveUpdates;
+  while (true) {
+    haveUpdates = false;
+    [colName1, colName2, colName3].forEach((cn) => {
+      let updates = db[cn]._revisionTreePendingUpdates();
+      if (!updates.hasOwnProperty('inserts')) {
+        // no revision tree yet
+        haveUpdates = true;
+        return;
+      }
+      haveUpdates |= updates.inserts > 0;
+      haveUpdates |= updates.removes > 0;
+      haveUpdates |= updates.truncates > 0;
+    });
+    if (!haveUpdates) {
+      break;
+    }
+    internal.wait(0.25);
+  }
+
+  internal.waitForEstimatorSync(); 
+  internal.sleep(2);
+
+  internal.debugTerminate('crashing server');
+}
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief test suite
+// //////////////////////////////////////////////////////////////////////////////
+
+function recoverySuite () {
+  'use strict';
+  jsunity.jsUnity.attachAssertions();
+
+  return {
+    setUp: function () {
+      internal.waitForEstimatorSync(); // make sure estimates are consistent
+    },
+    tearDown: function () {},
+
+    testRevisionTreeCounts: function() {
+      const c1 = db._collection(colName1);
+      assertEqual(c1._revisionTreeSummary().count, c1.count());
+      assertEqual(c1._revisionTreeSummary().count, 1000);
+
+      const c2 = db._collection(colName2);
+      assertEqual(c2._revisionTreeSummary().count, c2.count());
+      assertEqual(c2._revisionTreeSummary().count, 500);
+
+      const c3 = db._collection(colName3);
+      assertEqual(c3._revisionTreeSummary().count, c3.count());
+      assertEqual(c3._revisionTreeSummary().count, 0);
+    },
+
+  };
+}
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief executes the test suite
+// //////////////////////////////////////////////////////////////////////////////
+
+function main (argv) {
+  'use strict';
+  if (argv[1] === 'setup') {
+    runSetup();
+    return 0;
+  } else {
+    jsunity.run(recoverySuite);
+    return jsunity.writeDone().status ? 0 : 1;
+  }
+}


### PR DESCRIPTION
### Scope & Purpose

* Improve performance of getting-in-sync protocol when using revision trees
  (for collections created with 3.8). The protocol optimization allows skipping
  the unused parts of the revision trees in the data transfer, which can
  substantially reduce the amount of data to be transfered for small and medium
  collections when trying to get back into sync.

This optimization is already contained in 3.9 and 3.10.
It is opt-in, so it is downwards-compatible to 3.8.x (x <= 2)

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *gtest, recovery*.
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new C++ **Unit tests**
