### PR TITLE
Fixed potential UB in edge cache migration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,8 +2,8 @@ v3.7.16 (XXXX-XX-XX)
 --------------------
 
 * Fixed potential undefined behavior in edge cache during cache migration tasks.
-  There was a short window of time in which an already freed Table could be
-  used by concurrently running edge lookups.
+  There was a short window of time in which an already freed Table could be used
+  by concurrently running edge lookups.
 
 * Change error message for queries that use too much memory from "resource limit
   exceeded" to "query would use more memory than allowed".

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.7.16 (XXXX-XX-XX)
 --------------------
 
+* Fixed potential undefined behavior in edge cache during cache migration tasks.
+  There was a short window of time in which an already freed Table could be
+  used by concurrently running edge lookups.
+
 * Change error message for queries that use too much memory from "resource limit
   exceeded" to "query would use more memory than allowed".
 

--- a/arangod/Cache/Cache.cpp
+++ b/arangod/Cache/Cache.cpp
@@ -65,16 +65,16 @@ Cache::Cache(ConstructionGuard guard, Manager* manager, std::uint64_t id,
       _manager(manager),
       _id(id),
       _metadata(std::move(metadata)),
-      _tableShrdPtr(std::move(table)),
-      _table(_tableShrdPtr.get()),
+      _table(std::move(table)),
       _bucketClearer(bucketClearer(&_metadata)),
       _slotsPerBucket(slotsPerBucket),
       _insertsTotal(),
       _insertEvictions(),
       _migrateRequestTime(std::chrono::steady_clock::now().time_since_epoch().count()),
       _resizeRequestTime(std::chrono::steady_clock::now().time_since_epoch().count()) {
-  _tableShrdPtr->setTypeSpecifics(_bucketClearer, _slotsPerBucket);
-  _tableShrdPtr->enable();
+  TRI_ASSERT(_table != nullptr);
+  _table->setTypeSpecifics(_bucketClearer, _slotsPerBucket);
+  _table->enable();
   if (_enableWindowedStats) {
     try {
       _findStats.reset(new StatBuffer(_findStatsCapacity));
@@ -231,7 +231,7 @@ void Cache::requestMigrate(std::uint32_t requestedLogSize) {
   SpinLocker taskGuard(SpinLocker::Mode::Write, _taskLock);
   if (std::chrono::steady_clock::now().time_since_epoch().count() >
       _migrateRequestTime.load()) {
-    cache::Table* table = _table.load(std::memory_order_relaxed);
+    std::shared_ptr<cache::Table> table = std::atomic_load_explicit(&_table, std::memory_order_relaxed);
     TRI_ASSERT(table != nullptr);
 
     bool ok = false;
@@ -246,7 +246,7 @@ void Cache::requestMigrate(std::uint32_t requestedLogSize) {
   }
 }
 
-void Cache::freeValue(CachedValue* value) {
+void Cache::freeValue(CachedValue* value) noexcept {
   while (!value->isFreeable()) {
     std::this_thread::yield();
   }
@@ -260,7 +260,7 @@ bool Cache::reclaimMemory(std::uint64_t size) {
   return (_metadata.softUsageLimit >= _metadata.usage);
 }
 
-std::uint32_t Cache::hashKey(void const* key, std::size_t keySize) const {
+std::uint32_t Cache::hashKey(void const* key, std::size_t keySize) const noexcept {
   return (std::max)(static_cast<std::uint32_t>(1), fasthash32(key, keySize, 0xdeadbeefUL));
 }
 
@@ -302,7 +302,7 @@ bool Cache::reportInsert(bool hadEviction) {
     if (total > 0 && total > evictions &&
         ((static_cast<double>(evictions) / static_cast<double>(total)) > _evictionRateThreshold)) {
       shouldMigrate = true;
-      cache::Table* table = _table.load(std::memory_order_relaxed);
+      std::shared_ptr<cache::Table> table = std::atomic_load_explicit(&_table, std::memory_order_relaxed);
       TRI_ASSERT(table != nullptr);
       table->signalEvictions();
     }
@@ -316,7 +316,8 @@ bool Cache::reportInsert(bool hadEviction) {
 Metadata& Cache::metadata() { return _metadata; }
 
 std::shared_ptr<Table> Cache::table() const {
-  return std::atomic_load(&_tableShrdPtr);
+  // TODO: check if std::atomic_load_explicitt(&_table, std::memory_order_relaxed); works here!
+  return std::atomic_load(&_table);
 }
 
 void Cache::shutdown() {
@@ -337,23 +338,23 @@ void Cache::shutdown() {
       std::this_thread::sleep_for(std::chrono::microseconds(10));
     }
 
-    cache::Table* table = _table.load(std::memory_order_relaxed);
+    std::shared_ptr<cache::Table> table = std::atomic_load_explicit(&_table, std::memory_order_relaxed);
     if (table != nullptr) {
-      std::shared_ptr<Table> extra = table->setAuxiliary(std::shared_ptr<Table>(nullptr));
+      std::shared_ptr<Table> extra = table->setAuxiliary(std::shared_ptr<Table>());
       if (extra) {
         extra->clear();
         _manager->reclaimTable(extra);
       }
       table->clear();
+      _manager->reclaimTable(table);
     }
 
-    _manager->reclaimTable(std::atomic_load(&_tableShrdPtr));
     {
       SpinLocker metaGuard(SpinLocker::Mode::Write, _metadata.lock());
       _metadata.changeTable(0);
     }
     _manager->unregisterCache(_id);
-    _table.store(nullptr, std::memory_order_relaxed);
+    std::atomic_store_explicit(&_table, std::shared_ptr<cache::Table>(), std::memory_order_relaxed);
   }
 }
 
@@ -414,7 +415,7 @@ bool Cache::migrate(std::shared_ptr<Table> newTable) {
   newTable->setTypeSpecifics(_bucketClearer, _slotsPerBucket);
   newTable->enable();
 
-  cache::Table* table = _table.load(std::memory_order_relaxed);
+  std::shared_ptr<cache::Table> table = std::atomic_load_explicit(&_table, std::memory_order_relaxed);
   TRI_ASSERT(table != nullptr);
   table->setAuxiliary(newTable);
 
@@ -427,13 +428,13 @@ bool Cache::migrate(std::shared_ptr<Table> newTable) {
   std::shared_ptr<Table> oldTable;
   {
     SpinLocker taskGuard(SpinLocker::Mode::Write, _taskLock);
-    _table.store(newTable.get(), std::memory_order_relaxed);
-    oldTable = std::atomic_exchange(&_tableShrdPtr, newTable);
-    std::shared_ptr<Table> confirm =
-        oldTable->setAuxiliary(std::shared_ptr<Table>(nullptr));
+    oldTable = std::atomic_load(&_table);
+    std::atomic_store_explicit(&_table, newTable, std::memory_order_relaxed);
+    oldTable->setAuxiliary(std::shared_ptr<Table>());
   }
 
   // clear out old table and release it
+  TRI_ASSERT(oldTable != nullptr);
   oldTable->clear();
   _manager->reclaimTable(oldTable);
 

--- a/arangod/Cache/Cache.cpp
+++ b/arangod/Cache/Cache.cpp
@@ -353,7 +353,7 @@ void Cache::shutdown() {
       _metadata.changeTable(0);
     }
     _manager->unregisterCache(_id);
-    std::atomic_store_explicit(&_table, std::shared_ptr<cache::Table>(), std::memory_order_relaxed);
+    std::atomic_store_explicit(&_table, std::shared_ptr<cache::Table>(), std::memory_order_release);
   }
 }
 
@@ -428,7 +428,7 @@ bool Cache::migrate(std::shared_ptr<Table> newTable) {
   {
     SpinLocker taskGuard(SpinLocker::Mode::Write, _taskLock);
     oldTable = this->table();
-    std::atomic_store_explicit(&_table, newTable, std::memory_order_relaxed);
+    std::atomic_store_explicit(&_table, newTable, std::memory_order_release);
     oldTable->setAuxiliary(std::shared_ptr<Table>());
   }
 

--- a/arangod/Cache/Cache.h
+++ b/arangod/Cache/Cache.h
@@ -164,10 +164,8 @@ class Cache : public std::enable_shared_from_this<Cache> {
   std::uint64_t _id;
   Metadata _metadata;
 
-  // manage the actual table
-  std::shared_ptr<Table> _tableShrdPtr;
-  /// keep a pointer to the current table, which can be atomically set
-  std::atomic<Table*> _table;
+  // manage the actual table - note: MUST be used only with atomic_load and atomic_store!
+  std::shared_ptr<Table> _table;
 
   Table::BucketClearer _bucketClearer;
   std::size_t _slotsPerBucket;
@@ -196,10 +194,10 @@ class Cache : public std::enable_shared_from_this<Cache> {
   void requestGrow();
   void requestMigrate(std::uint32_t requestedLogSize = 0);
 
-  static void freeValue(CachedValue* value);
+  static void freeValue(CachedValue* value) noexcept;
   bool reclaimMemory(std::uint64_t size);
 
-  std::uint32_t hashKey(void const* key, std::size_t keySize) const;
+  std::uint32_t hashKey(void const* key, std::size_t keySize) const noexcept;
   void recordStat(Stat stat);
 
   bool reportInsert(bool hadEviction);

--- a/arangod/Cache/Cache.h
+++ b/arangod/Cache/Cache.h
@@ -149,7 +149,6 @@ class Cache : public std::enable_shared_from_this<Cache> {
   static constexpr std::uint64_t triesFast = 200;
   static constexpr std::uint64_t triesSlow = 10000;
 
- protected:
   basics::ReadWriteSpinLock _taskLock;
   std::atomic<bool> _shutdown;
 
@@ -164,6 +163,7 @@ class Cache : public std::enable_shared_from_this<Cache> {
   std::uint64_t _id;
   Metadata _metadata;
 
+ private:
   // manage the actual table - note: MUST be used only with atomic_load and atomic_store!
   std::shared_ptr<Table> _table;
 

--- a/arangod/Cache/Manager.h
+++ b/arangod/Cache/Manager.h
@@ -198,7 +198,7 @@ class Manager {
 
   // actual tables to lease out
 
-  std::array<std::stack<std::shared_ptr<Table>>, 32> _tables;
+  std::array<std::stack<std::shared_ptr<Table>, std::vector<std::shared_ptr<Table>>>, 32> _tables;
 
   // global statistics
   std::uint64_t _globalSoftLimit;

--- a/arangod/Cache/ManagerTasks.cpp
+++ b/arangod/Cache/ManagerTasks.cpp
@@ -31,62 +31,94 @@ namespace arangodb::cache {
 
 FreeMemoryTask::FreeMemoryTask(Manager::TaskEnvironment environment,
                                Manager& manager, std::shared_ptr<Cache> cache)
-    : _environment(environment), _manager(manager), _cache(cache) {}
+    : _environment(environment), _manager(manager), _cache(std::move(cache)) {}
 
 FreeMemoryTask::~FreeMemoryTask() = default;
 
 bool FreeMemoryTask::dispatch() {
   _manager.prepareTask(_environment);
-  return _manager.post([self = shared_from_this()]() -> void { self->run(); });
+  try {
+    if (_manager.post([self = shared_from_this()]() -> void { self->run(); })) {
+      return true;
+    }
+    _manager.unprepareTask(_environment);
+    return false;
+  } catch (std::exception const&) {
+    _manager.unprepareTask(_environment);
+    throw;
+  }
 }
 
 void FreeMemoryTask::run() {
-  using basics::SpinLocker;
+  try {
+    using basics::SpinLocker;
 
-  bool ran = _cache->freeMemory();
+    bool ran = _cache->freeMemory();
 
-  if (ran) {
-    std::uint64_t reclaimed = 0;
-    SpinLocker guard(SpinLocker::Mode::Write, _manager._lock);
-    Metadata& metadata = _cache->metadata();
-    {
-      SpinLocker metaGuard(SpinLocker::Mode::Write, metadata.lock());
-      reclaimed = metadata.hardUsageLimit - metadata.softUsageLimit;
-      metadata.adjustLimits(metadata.softUsageLimit, metadata.softUsageLimit);
-      metadata.toggleResizing();
+    if (ran) {
+      std::uint64_t reclaimed = 0;
+      SpinLocker guard(SpinLocker::Mode::Write, _manager._lock);
+      Metadata& metadata = _cache->metadata();
+      {
+        SpinLocker metaGuard(SpinLocker::Mode::Write, metadata.lock());
+        TRI_ASSERT(metaGuard.isLocked());
+        reclaimed = metadata.hardUsageLimit - metadata.softUsageLimit;
+        metadata.adjustLimits(metadata.softUsageLimit, metadata.softUsageLimit);
+        metadata.toggleResizing();
+      }
+      _manager._globalAllocation -= reclaimed;
     }
-    _manager._globalAllocation -= reclaimed;
-  }
 
-  _manager.unprepareTask(_environment);
+    _manager.unprepareTask(_environment);
+  } catch (std::exception const&) {
+    // always count down at the end
+    _manager.unprepareTask(_environment);
+    throw;
+  }
 }
 
 MigrateTask::MigrateTask(Manager::TaskEnvironment environment, Manager& manager,
                          std::shared_ptr<Cache> cache, std::shared_ptr<Table> table)
-    : _environment(environment), _manager(manager), _cache(cache), _table(table) {}
+    : _environment(environment), _manager(manager), 
+      _cache(std::move(cache)), _table(std::move(table)) {}
 
 MigrateTask::~MigrateTask() = default;
 
 bool MigrateTask::dispatch() {
   _manager.prepareTask(_environment);
-  return _manager.post([self = shared_from_this()]() -> void { self->run(); });
+  try {
+    if (_manager.post([self = shared_from_this()]() -> void { self->run(); })) {
+      return true;
+    }
+    _manager.unprepareTask(_environment);
+    return false;
+  } catch (std::exception const&) {
+    _manager.unprepareTask(_environment);
+    throw;
+  }
 }
 
 void MigrateTask::run() {
-  using basics::SpinLocker;
+  try {
+    using basics::SpinLocker;
 
-  // do the actual migration
-  bool ran = _cache->migrate(_table);
+    // do the actual migration
+    bool ran = _cache->migrate(_table);
 
-  if (!ran) {
-    Metadata& metadata = _cache->metadata();
-    {
-      SpinLocker metaGuard(SpinLocker::Mode::Write, metadata.lock());
-      metadata.toggleMigrating();
+    if (!ran) {
+      Metadata& metadata = _cache->metadata();
+      {
+        SpinLocker metaGuard(SpinLocker::Mode::Write, metadata.lock());
+        TRI_ASSERT(metaGuard.isLocked());
+        metadata.toggleMigrating();
+      }
+      _manager.reclaimTable(_table);
     }
-    _manager.reclaimTable(_table);
+    _manager.unprepareTask(_environment);
+  } catch (std::exception const&) {
+    // always count down at the end
+    _manager.unprepareTask(_environment);
+    throw;
   }
-
-  _manager.unprepareTask(_environment);
 }
 }

--- a/arangod/Cache/PlainCache.cpp
+++ b/arangod/Cache/PlainCache.cpp
@@ -231,7 +231,7 @@ std::uint64_t PlainCache::freeMemoryFrom(std::uint32_t hash) {
     }
   }
 
-  std::shared_ptr<cache::Table> table = std::atomic_load_explicit(&_table, std::memory_order_relaxed);
+  std::shared_ptr<cache::Table> table = this->table();
   if (table) {
     std::int32_t size = table->idealSize();
     if (maybeMigrate) {
@@ -245,7 +245,7 @@ std::uint64_t PlainCache::freeMemoryFrom(std::uint32_t hash) {
 void PlainCache::migrateBucket(void* sourcePtr, std::unique_ptr<Table::Subtable> targets,
                                std::shared_ptr<Table> newTable) {
   // lock current bucket
-  std::shared_ptr<Table> table = std::atomic_load(&_table);
+  std::shared_ptr<Table> table = this->table();
 
   Table::BucketLocker sourceGuard(sourcePtr, table.get(), Cache::triesGuarantee);
   PlainBucket& source = sourceGuard.bucket<PlainBucket>();
@@ -299,7 +299,7 @@ std::pair<Result, Table::BucketLocker> PlainCache::getBucket(std::uint32_t hash,
   Result status;
   Table::BucketLocker guard;
 
-  std::shared_ptr<Table> table = std::atomic_load_explicit(&_table, std::memory_order_relaxed);
+  std::shared_ptr<Table> table = this->table();
   if (isShutdown() || table == nullptr) {
     status.reset(TRI_ERROR_SHUTTING_DOWN);
     return std::make_pair(std::move(status), std::move(guard));

--- a/arangod/Cache/Table.h
+++ b/arangod/Cache/Table.h
@@ -104,7 +104,7 @@ class Table : public std::enable_shared_from_this<Table> {
   struct Subtable {
     Subtable(std::shared_ptr<Table> source, GenericBucket* buckets,
              std::uint64_t size, std::uint32_t mask, std::uint32_t shift);
-    void* fetchBucket(std::uint32_t hash);
+    void* fetchBucket(std::uint32_t hash) noexcept;
 
     std::vector<BucketLocker> lockAllBuckets();
 
@@ -114,9 +114,9 @@ class Table : public std::enable_shared_from_this<Table> {
    private:
     std::shared_ptr<Table> _source;
     GenericBucket* _buckets;
-    std::uint64_t _size;
-    std::uint32_t _mask;
-    std::uint32_t _shift;
+    std::uint64_t const _size;
+    std::uint32_t const _mask;
+    std::uint32_t const _shift;
   };
 
  public:
@@ -210,7 +210,12 @@ class Table : public std::enable_shared_from_this<Table> {
   /// value will be true, and the cache should request migration to a larger
   /// table.
   //////////////////////////////////////////////////////////////////////////////
-  bool slotFilled();
+  bool slotFilled() noexcept;
+  
+  //////////////////////////////////////////////////////////////////////////////
+  /// @brief Report that multiple slots were filled
+  //////////////////////////////////////////////////////////////////////////////
+  void slotsFilled(std::uint64_t numSlots) noexcept;
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Report that a slot was emptied.
@@ -219,7 +224,12 @@ class Table : public std::enable_shared_from_this<Table> {
   /// return value will be true, and the cache should request migration to a
   /// smaller table.
   //////////////////////////////////////////////////////////////////////////////
-  bool slotEmptied();
+  bool slotEmptied() noexcept;
+  
+  //////////////////////////////////////////////////////////////////////////////
+  /// @brief Report that multiple slots were emptied
+  //////////////////////////////////////////////////////////////////////////////
+  void slotsEmptied(std::uint64_t numSlots) noexcept;
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Report that there have been too many evictions.

--- a/arangod/Cache/TransactionalCache.cpp
+++ b/arangod/Cache/TransactionalCache.cpp
@@ -278,7 +278,7 @@ uint64_t TransactionalCache::freeMemoryFrom(std::uint32_t hash) {
     }
   }
 
-  std::shared_ptr<cache::Table> table = std::atomic_load_explicit(&_table, std::memory_order_relaxed);
+  std::shared_ptr<cache::Table> table = this->table();
   if (table) {
     std::int32_t size = table->idealSize();
     if (maybeMigrate) {
@@ -295,7 +295,7 @@ void TransactionalCache::migrateBucket(void* sourcePtr,
   std::uint64_t term = _manager->_transactions.term();
 
   // lock current bucket
-  std::shared_ptr<Table> table = std::atomic_load(&_table);
+  std::shared_ptr<Table> table = this->table();
 
   Table::BucketLocker sourceGuard(sourcePtr, table.get(), Cache::triesGuarantee);
   TransactionalBucket& source = sourceGuard.bucket<TransactionalBucket>();
@@ -399,7 +399,7 @@ std::tuple<Result, Table::BucketLocker> TransactionalCache::getBucket(
   Result status;
   Table::BucketLocker guard;
 
-  std::shared_ptr<Table> table = std::atomic_load_explicit(&_table, std::memory_order_relaxed);
+  std::shared_ptr<Table> table = this->table();
   if (isShutdown() || table == nullptr) {
     status.reset(TRI_ERROR_SHUTTING_DOWN);
     return std::make_tuple(std::move(status), std::move(guard));

--- a/arangod/Cache/TransactionalCache.cpp
+++ b/arangod/Cache/TransactionalCache.cpp
@@ -49,9 +49,7 @@ Finding TransactionalCache::find(void const* key, std::uint32_t keySize) {
   Finding result;
   std::uint32_t hash = hashKey(key, keySize);
 
-  Result status;
-  Table::BucketLocker guard;
-  std::tie(status, guard) = getBucket(hash, Cache::triesFast, false);
+  auto [status, guard] = getBucket(hash, Cache::triesFast, false);
   if (status.fail()) {
     result.reportError(status);
     return result;
@@ -121,6 +119,7 @@ Result TransactionalCache::insert(CachedValue* value) {
           }
           bucket.insert(hash, value);
           if (!eviction) {
+            TRI_ASSERT(source != nullptr);
             maybeMigrate = source->slotFilled();
           }
           maybeMigrate |= reportInsert(eviction);
@@ -135,6 +134,7 @@ Result TransactionalCache::insert(CachedValue* value) {
   }
 
   if (maybeMigrate) {
+    TRI_ASSERT(source != nullptr);
     requestMigrate(source->idealSize());  // let function do the hard work
   }
 
@@ -168,11 +168,13 @@ Result TransactionalCache::remove(void const* key, std::uint32_t keySize) {
       }
 
       freeValue(candidate);
+      TRI_ASSERT(source != nullptr);
       maybeMigrate = source->slotEmptied();
     }
   }
 
   if (maybeMigrate) {
+    TRI_ASSERT(source != nullptr);
     requestMigrate(source->idealSize());
   }
 
@@ -207,11 +209,13 @@ Result TransactionalCache::blacklist(void const* key, std::uint32_t keySize) {
       }
 
       freeValue(candidate);
+      TRI_ASSERT(source != nullptr);
       maybeMigrate = source->slotEmptied();
     }
   }
 
   if (maybeMigrate) {
+    TRI_ASSERT(source != nullptr);
     requestMigrate(source->idealSize());
   }
 
@@ -274,7 +278,7 @@ uint64_t TransactionalCache::freeMemoryFrom(std::uint32_t hash) {
     }
   }
 
-  cache::Table* table = _table.load(std::memory_order_relaxed);
+  std::shared_ptr<cache::Table> table = std::atomic_load_explicit(&_table, std::memory_order_relaxed);
   if (table) {
     std::int32_t size = table->idealSize();
     if (maybeMigrate) {
@@ -291,7 +295,9 @@ void TransactionalCache::migrateBucket(void* sourcePtr,
   std::uint64_t term = _manager->_transactions.term();
 
   // lock current bucket
-  Table::BucketLocker sourceGuard(sourcePtr, _table.load(), Cache::triesGuarantee);
+  std::shared_ptr<Table> table = std::atomic_load(&_table);
+
+  Table::BucketLocker sourceGuard(sourcePtr, table.get(), Cache::triesGuarantee);
   TransactionalBucket& source = sourceGuard.bucket<TransactionalBucket>();
   term = std::max(term, source._blacklistTerm);
 
@@ -320,6 +326,8 @@ void TransactionalCache::migrateBucket(void* sourcePtr,
         return true;
       });
     } else {
+      std::uint64_t totalSize = 0;
+      std::uint64_t emptied = 0;
       for (std::size_t j = 0; j < TransactionalBucket::slotsBlacklist; j++) {
         std::uint32_t hash = source._blacklistHashes[j];
         if (hash != 0) {
@@ -329,12 +337,14 @@ void TransactionalCache::migrateBucket(void* sourcePtr,
           if (candidate != nullptr) {
             std::uint64_t size = candidate->size();
             freeValue(candidate);
-            reclaimMemory(size);
-            newTable->slotEmptied();
+            totalSize += size;
+            ++emptied;
           }
           source._blacklistHashes[j] = 0;
         }
       }
+      reclaimMemory(totalSize);
+      newTable->slotsEmptied(emptied);
     }
 
     // migrate actual values
@@ -389,7 +399,7 @@ std::tuple<Result, Table::BucketLocker> TransactionalCache::getBucket(
   Result status;
   Table::BucketLocker guard;
 
-  Table* table = _table.load(std::memory_order_relaxed);
+  std::shared_ptr<Table> table = std::atomic_load_explicit(&_table, std::memory_order_relaxed);
   if (isShutdown() || table == nullptr) {
     status.reset(TRI_ERROR_SHUTTING_DOWN);
     return std::make_tuple(std::move(status), std::move(guard));

--- a/tests/Cache/BucketState.cpp
+++ b/tests/Cache/BucketState.cpp
@@ -39,9 +39,9 @@ TEST(CacheBucketStateTest, test_lock_methods) {
 
   std::uint32_t outsideBucketState = 0;
 
-  auto cb1 = [&outsideBucketState]() -> void { outsideBucketState = 1; };
+  auto cb1 = [&outsideBucketState]() noexcept -> void { outsideBucketState = 1; };
 
-  auto cb2 = [&outsideBucketState]() -> void { outsideBucketState = 2; };
+  auto cb2 = [&outsideBucketState]() noexcept -> void { outsideBucketState = 2; };
 
   // check lock without contention
   ASSERT_FALSE(state.isLocked());


### PR DESCRIPTION
### Scope & Purpose

* Fixed potential undefined behavior in edge cache during cache migration tasks.
  There was a short window of time in which an already freed Table could be
  used by concurrently running edge lookups.

The bug can happen when using the edge cache and at the same time a migration task for the same cache is executed.
This requires that concurrent cache access(es) and a cache migration happen for the same edge collection/shard's edge cache at the same time. And still then it is a matter of luck/misfortune because there is only a small window of time in which a raw pointer to the cache's Table is used and dereferenced, while the migration task deletes this very same Table.
A migration to a larger cache is kicked off when after a cache insert the cache goes above 25% fill grade. A migration is also kicked off on a remove if the cache goes to a fill grade less than 4%.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *gtest*.

Additionally tested via setting a local cluster with the edge cache limited to 4 MB (`--cache.size 4000000`) and running the following script repeatedly:
```bash 
scripts/startLocalCluster.sh -d 3 -a 1 # starts cluster on port 8530
colls=3
for i in `seq 1 $colls`; do 
  echo "cn = \"testi$i\"; try { c = db._createEdgeCollection(cn, { numberOfShards: 40, replicationFactor: 1 }); } catch (err) { c = db._collection(cn); } docs = []; for (i = 0; i < 1000000; ++i) { docs.push({ _from: \"v1/testi\" + Math.floor(Math.random() * 100000), _to: \"v2/testi\" + Math.floor(Math.random() * 1000000) }); if (docs.length === 5000) { print(i); c.insert(docs); docs = []; } }" | build/bin/arangosh --server.endpoint tcp://127.0.0.1:8530 & 
done
sleep 4
for i in `seq 1 $(($colls * 2))`; do 
  echo "cn = \"testi\" + (($i % $colls) + 1); c = db._collection(cn); while (true) { docs = []; for (i = 0; i < 10000; ++i) { docs.push(\"v1/testi\" + Math.floor(Math.random() * 100000)); } db._query('FOR doc IN @@cn FILTER doc._from IN @docs RETURN doc', { '@cn': cn, docs }, { silent: true }); }" | build/bin/arangosh --server.endpoint tcp://127.0.0.1:8530 & 
done
for i in `seq 1 $(($colls * 2))`; do 
  echo "cn = \"testi\" + (($i % $colls) + 1); c = db._collection(cn); while (true) { docs = []; for (i = 0; i < 10000; ++i) { docs.push(\"v2/testi\" + Math.floor(Math.random() * 1000000)); } db._query('FOR doc IN @@cn FILTER doc._to IN @docs RETURN doc', { '@cn': cn, docs }, { silent: true }); }" | build/bin/arangosh --server.endpoint tcp://127.0.0.1:8530 & 
done
```