### PR TITLE
Feature/maintenance mode duration selection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* When enabling the cluster supervision maintenance mode via the web UI, there
+  is now the possibility to select a duration for the maintenance mode.
+  Previous versions of ArangoDB always enabled the maintenance mode for one
+  hour, without allowing any choice here.
+
 * Fixed SEARCH-261: Fix possible race between file creation and directory
   cleaner (ArangoSearch).
 

--- a/Documentation/DocuBlocks/Rest/Cluster/put_cluster_maintenance.md
+++ b/Documentation/DocuBlocks/Rest/Cluster/put_cluster_maintenance.md
@@ -14,10 +14,10 @@ To enable the maintenance mode the request body must contain the string `"on"`
 maintenance mode for 60 minutes, i.e. the supervision maintenance will reactivate itself
 after 60 minutes.
 
-To enable the maintenance mode the request body must contain the string `"on"`
-(Please note it _must_ be lowercase as well as include the quotes). This will enable the
-maintenance mode for 60 minutes, i.e. the supervision maintenance will reactivate itself
-after 60 minutes.
+Since ArangoDB 3.8.3 it is possible to enable the maintenance mode for a different 
+duration than 60 minutes, it is possible to send the desired duration value (in seconds) 
+as a string in the request body. For example, sending `"7200"`
+(including the quotes) will enable the maintenance mode for 7200 seconds, i.e. 2 hours.
 
 To disable the maintenance mode the request body must contain the string `"off"` 
 (Please note it _must_ be lowercase as well as include the quotes).

--- a/Documentation/DocuBlocks/Rest/Cluster/put_cluster_maintenance.md
+++ b/Documentation/DocuBlocks/Rest/Cluster/put_cluster_maintenance.md
@@ -5,12 +5,21 @@
 @RESTHEADER{PUT /_admin/cluster/maintenance, Enable or disable the supervision maintenance mode}
 
 @RESTDESCRIPTION
-This API allows you to temporarily enable the supervision maintenance mode. Be aware that no
+This API allows to temporarily enable the supervision maintenance mode. Please be aware that no
 automatic failovers of any kind will take place while the maintenance mode is enabled.
-The _cluster_ supervision reactivates itself automatically _60 minutes_ after disabling it.
+The cluster supervision reactivates itself automatically at some point after disabling it.
 
-To enable the maintenance mode the request body must contain the string `"on"`. To disable it, send the string
-`"off"` (Please note it _must_ be lowercase as well as include the quotes).
+To enable the maintenance mode the request body must contain the string `"on"`
+(Please note it _must_ be lowercase as well as include the quotes). This will enable the
+maintenance mode for 60 minutes, i.e. the supervision maintenance will reactivate itself
+after 60 minutes.
+
+To enable the maintenance mode for a different duration than 60 minutes, it is possible to send
+the desired duration value (in seconds) as the request body. For example, sending `"7200"`
+(including the quotes) will enable the maintenance mode for 7200 seconds, i.e. 2 hours.
+
+To disable the maintenance mode the request body must contain the string `"off"` 
+(Please note it _must_ be lowercase as well as include the quotes).
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Cluster/put_cluster_maintenance.md
+++ b/Documentation/DocuBlocks/Rest/Cluster/put_cluster_maintenance.md
@@ -14,9 +14,10 @@ To enable the maintenance mode the request body must contain the string `"on"`
 maintenance mode for 60 minutes, i.e. the supervision maintenance will reactivate itself
 after 60 minutes.
 
-To enable the maintenance mode for a different duration than 60 minutes, it is possible to send
-the desired duration value (in seconds) as the request body. For example, sending `"7200"`
-(including the quotes) will enable the maintenance mode for 7200 seconds, i.e. 2 hours.
+To enable the maintenance mode the request body must contain the string `"on"`
+(Please note it _must_ be lowercase as well as include the quotes). This will enable the
+maintenance mode for 60 minutes, i.e. the supervision maintenance will reactivate itself
+after 60 minutes.
 
 To disable the maintenance mode the request body must contain the string `"off"` 
 (Please note it _must_ be lowercase as well as include the quotes).

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -966,7 +966,7 @@ void Supervision::reportStatus(std::string const& status) {
     }
   }
 
-  // Importatnt! No reporting in transient for Maintenance mode.
+  // Important! No reporting in transient for Maintenance mode.
   if (status != "Maintenance") {
     transient(_agent, *report);
   }

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -37,6 +37,7 @@
 #include "Agency/TransactionBuilder.h"
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/ResultT.h"
+#include "Basics/NumberUtils.h"
 #include "Cluster/AgencyCache.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterHelpers.h"
@@ -1308,33 +1309,30 @@ RestStatus RestAdminClusterHandler::handleGetMaintenance() {
 }
 
 RestAdminClusterHandler::FutureVoid RestAdminClusterHandler::waitForSupervisionState(
-    bool state, clock::time_point startTime) {
-  if (startTime == clock::time_point()) {
-    startTime = clock::now();
-  }
-
+    bool state, std::string const& reactivationTime, clock::time_point startTime) {
   return SchedulerFeature::SCHEDULER->delay(1s)
       .thenValue([](auto) {
         return AsyncAgencyComm().getValues(
             arangodb::cluster::paths::root()->arango()->supervision()->state()->mode());
       })
-      .thenValue([this, state, startTime](AgencyReadResult&& result) {
+      .thenValue([this, state, startTime, reactivationTime](AgencyReadResult&& result) {
         auto waitFor = state ? "Maintenance" : "Normal";
         if (result.ok() && result.statusCode() == fuerte::StatusOK) {
           if (!result.value().isEqualString(waitFor)) {
             if ((clock::now() - startTime) < 120.0s) {
               // wait again
-              return waitForSupervisionState(state, startTime);
+              return waitForSupervisionState(state, reactivationTime, startTime);
             }
 
             generateError(rest::ResponseCode::REQUEST_TIMEOUT,
-                          TRI_ERROR_HTTP_GATEWAY_TIMEOUT, std::string{"timed out while waiting for supervision to go into maintenance mode"});
+                          TRI_ERROR_HTTP_GATEWAY_TIMEOUT, std::string{"timed out while waiting for supervision maintenance mode change"});
           } else {
-            auto msg = state ? "Cluster supervision deactivated. It will be "
-                               "reactivated automatically in 60 minutes unless "
+            auto msg = state ? std::string("Cluster supervision deactivated. It will be "
+                               "reactivated automatically on ") + reactivationTime + " unless "
                                "this call is repeated until then."
-                             : "Cluster supervision reactivated.";
+                             : std::string("Cluster supervision reactivated.");
             VPackBuilder builder;
+            VPackBuffer<uint8_t> body;
             {
               VPackObjectBuilder obj(&builder);
               builder.add("warning", VPackValue(msg));
@@ -1349,16 +1347,23 @@ RestAdminClusterHandler::FutureVoid RestAdminClusterHandler::waitForSupervisionS
       });
 }
 
-RestStatus RestAdminClusterHandler::setMaintenance(bool wantToActivate) {
+RestStatus RestAdminClusterHandler::setMaintenance(bool wantToActivate, uint64_t timeout) {
+  // we don't need a timeout when disabling the maintenance
+  TRI_ASSERT(wantToActivate || timeout == 0);
+
   auto maintenancePath =
       arangodb::cluster::paths::root()->arango()->supervision()->maintenance();
 
+  // (stringified) timepoint at which maintenance will reactivate itself
+  std::string reactivationTime;
+  if (wantToActivate) {
+    reactivationTime = timepointToString(
+              std::chrono::system_clock::now() + std::chrono::seconds(timeout));
+  }
+
   auto sendTransaction = [&] {
     if (wantToActivate) {
-      constexpr int timeout = 3600; // 1 hour
-      return AsyncAgencyComm().setValue(60s, maintenancePath,
-          VPackValue(timepointToString(
-              std::chrono::system_clock::now() + std::chrono::seconds(timeout))), 3600);
+      return AsyncAgencyComm().setValue(60s, maintenancePath, VPackValue(reactivationTime), timeout);
     } else {
       return AsyncAgencyComm().deleteKey(60s, maintenancePath);
     }
@@ -1368,9 +1373,9 @@ RestStatus RestAdminClusterHandler::setMaintenance(bool wantToActivate) {
 
   return waitForFuture(
       sendTransaction()
-          .thenValue([this, wantToActivate](AsyncAgencyCommResult&& result) {
+          .thenValue([this, wantToActivate, reactivationTime](AsyncAgencyCommResult&& result) {
             if (result.ok() && result.statusCode() == 200) {
-              return waitForSupervisionState(wantToActivate);
+              return waitForSupervisionState(wantToActivate, reactivationTime, std::chrono::steady_clock::now());
             } else {
               generateError(result.asResult());
             }
@@ -1400,10 +1405,28 @@ RestStatus RestAdminClusterHandler::handlePutMaintenance() {
 
   if (body.isString()) {
     if (body.isEqualString("on")) {
-      return setMaintenance(true);
+      // supervision maintenance will turn itself off automatically
+      // after one hour by default
+      constexpr uint64_t timeout = 3600; // 1 hour
+      return setMaintenance(true, timeout);
     } else if (body.isEqualString("off")) {
-      return setMaintenance(false);
+      // timeout doesn't matter for turning off the supervision
+      return setMaintenance(false, /*timeout*/ 0);
+    } else {
+      // user sent a stringified timeout value, so lets honor this
+      VPackValueLength l;
+      char const* p = body.getString(l);
+      bool valid = false;
+      uint64_t timeout = NumberUtils::atoi_positive<uint64_t>(p, p + l, valid);
+      if (valid) {
+        return setMaintenance(true, timeout);
+      }
+      // otherwise fall-through to error
     }
+  } else if (body.isNumber()) {
+    // user sent a numeric timeout value, so lets honor this
+    uint64_t timeout = body.getNumber<uint64_t>();
+    return setMaintenance(true, timeout);
   }
 
   generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,

--- a/arangod/RestHandler/RestAdminClusterHandler.h
+++ b/arangod/RestHandler/RestAdminClusterHandler.h
@@ -29,6 +29,7 @@
 
 #include <velocypack/Slice.h>
 
+#include <cstdint>
 #include <map>
 #include <utility>
 
@@ -68,7 +69,9 @@ class RestAdminClusterHandler : public RestVocbaseBaseHandler {
   RestStatus handleNumberOfServers();
   RestStatus handleMaintenance();
 
-  RestStatus setMaintenance(bool state);
+  // timeout can be used to set an arbitrary timeout for the maintenance
+  // duration. it will be ignored if "state" is not true. 
+  RestStatus setMaintenance(bool state, uint64_t timeout);
   RestStatus handlePutMaintenance();
   RestStatus handleGetMaintenance();
 
@@ -126,7 +129,8 @@ class RestAdminClusterHandler : public RestVocbaseBaseHandler {
   typedef futures::Future<futures::Unit> FutureVoid;
 
   FutureVoid waitForSupervisionState(bool state,
-                                     clock::time_point startTime = clock::time_point());
+                                     std::string const& reactivationTime,
+                                     clock::time_point startTime);
 
   struct RemoveServerContext {
     size_t tries;

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/maintenanceView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/maintenanceView.js
@@ -86,7 +86,7 @@
       let info = `<blockquote>
         Modifies the cluster supervision maintenance mode. Be aware that no automatic failovers of any
         kind will take place while the maintenance mode is enabled. The cluster supervision reactivates
-        itself automatically 60 minutes after disabling it, in case it is not manually prolonged.<blockquote>
+        itself automatically after the selected duration in case it is not manually prolonged.<blockquote>
       `;
 
       tableContent.push(
@@ -96,23 +96,42 @@
           info
         )
       );
-
-      if (mode === 'off') {
-        buttons.push(
-          window.modalView.createSuccessButton(
-            title,
-            self.confirmChangeMaintenance.bind(this, mode)
+         
+      if (mode !== 'off') {
+        // when enabling maintenance mode, add a selectbox with some useful
+        // maintenance durations for the user to pick from. we don't need this
+        // when turning the maintenance off.
+        tableContent.push(
+          window.modalView.createSelectEntry(
+            'maintenance-duration',
+            'Maintenance duration',
+            3600,
+            'The duration that the supervision maintenance will be enabled.',
+            [{value: 600, label: '10 minutes'}, {value: 1200, label: '20 minutes'},
+             {value: 1800, label: '30 minutes'}, {value: 2700, label: '45 minutes'},
+             {value: 3600, label: '1 hour'}, {value: 5400, label: '1.5 hours'},
+             {value: 7200, label: '2 hours'}, {value: 10800, label: '3 hours'},
+             {value: 14400, label: '4 hours'}, {value: 18000, label: '5 hours'},
+             {value: 36000, label: '10 hours'}, {value: 86400, label: '24 hours'},
+            ]
           )
         );
-      } else {
+        
         buttons.push(
           window.modalView.createNotificationButton(
             title,
             self.confirmChangeMaintenance.bind(this, mode)
           )
         );
+      } else {
+        // disable maintenance mode
+        buttons.push(
+          window.modalView.createSuccessButton(
+            title,
+            self.confirmChangeMaintenance.bind(this, mode)
+          )
+        );
       }
-
 
       window.modalView.show(
         'modalTable.ejs',
@@ -125,6 +144,10 @@
     confirmChangeMaintenance: function (mode) {
       let self = this;
       let data = mode;
+
+      if (mode !== 'off') {
+        data = $('#maintenance-duration').val();
+      }
 
       $.ajax({
         type: 'PUT',

--- a/tests/js/client/shell/shell-supervision-maintenance-cluster.js
+++ b/tests/js/client/shell/shell-supervision-maintenance-cluster.js
@@ -1,0 +1,170 @@
+/*jshint globalstrict:false, strict:false, maxlen : 4000 */
+/* global arango, assertTrue, assertFalse, assertMatch, assertEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief tests for supervision maintenance API
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+const jsunity = require('jsunity');
+
+function numberOfServersSuite () {
+  const url = "/_admin/cluster/maintenance";
+  const re = /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)/;
+
+  return {
+    tearDown : function () {
+      // turn off supervision maintenance mode again
+      arango.PUT(url, '"off"');
+    },
+
+    testGetSupervisionDisabled : function () {
+      let result = arango.GET(url);
+      assertFalse(result.error);
+      assertEqual("Normal", result.result);
+    },
+    
+    testGetSupervisionEnabled : function () {
+      // default maintenance period is 1 hour
+      let result = arango.PUT(url, '"on"');
+      assertFalse(result.error);
+
+      result = arango.GET(url);
+      assertFalse(result.error);
+      assertEqual("Maintenance", result.result);
+    },
+    
+    testSetSupervisionEnabledWrongData : function () {
+      let result = arango.PUT(url, '"piff!"');
+      assertTrue(result.error);
+      assertEqual(400, result.code);
+      
+      result = arango.GET(url);
+      assertFalse(result.error);
+      assertEqual("Normal", result.result);
+    },
+    
+    testSetSupervisionEnabledDefaultTimeout : function () {
+      const now = Date.now();
+      // default maintenance period is 1 hour
+      let result = arango.PUT(url, '"on"');
+      assertFalse(result.error);
+      // we expect the reactivation date to be returned
+      assertMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/, result.warning);
+
+      let match = result.warning.match(re);
+      assertTrue(Array.isArray(match));
+
+      let reactivationTime = match[0];
+      assertMatch(re, reactivationTime);
+
+      const reactivate = Date.parse(reactivationTime);
+
+      // difference between dates should be at least one hour
+      // we subtract one second because the returned datetime string does not
+      // have millisecond precision
+      assertTrue(reactivate - now >= (3600 * 1000) - 1000, { now, reactivate });
+
+      result = arango.GET(url);
+      assertFalse(result.error);
+      assertEqual("Maintenance", result.result);
+    },
+    
+    testSetSupervisionEnabled30MinutesTimeout : function () {
+      const now = Date.now();
+      let result = arango.PUT(url, '"1800"');
+      assertFalse(result.error);
+      // we expect the reactivation date to be returned
+      assertMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/, result.warning);
+
+      let match = result.warning.match(re);
+      assertTrue(Array.isArray(match));
+
+      let reactivationTime = match[0];
+      assertMatch(re, reactivationTime);
+
+      const reactivate = Date.parse(reactivationTime);
+
+      // we subtract one second because the returned datetime string does not
+      // have millisecond precision
+      assertTrue(reactivate - now >= (1800 * 1000) - 1000, { now, reactivate });
+
+      result = arango.GET(url);
+      assertFalse(result.error);
+      assertEqual("Maintenance", result.result);
+    },
+    
+    testSetSupervisionEnabled5HoursTimeout : function () {
+      const now = Date.now();
+      let result = arango.PUT(url, '"18000"');
+      assertFalse(result.error);
+      // we expect the reactivation date to be returned
+      assertMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/, result.warning);
+
+      let match = result.warning.match(re);
+      assertTrue(Array.isArray(match));
+
+      let reactivationTime = match[0];
+      assertMatch(re, reactivationTime);
+
+      const reactivate = Date.parse(reactivationTime);
+      
+      // we subtract one second because the returned datetime string does not
+      // have millisecond precision
+      assertTrue(reactivate - now >= (18000 * 1000) - 1000, { now, reactivate });
+
+      result = arango.GET(url);
+      assertFalse(result.error);
+      assertEqual("Maintenance", result.result);
+    },
+    
+    testSetSupervisionEnabledNumericTimeout : function () {
+      const now = Date.now();
+      let result = arango.PUT(url, '666');
+      assertFalse(result.error);
+      // we expect the reactivation date to be returned
+      assertMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/, result.warning);
+
+      let match = result.warning.match(re);
+      assertTrue(Array.isArray(match));
+
+      let reactivationTime = match[0];
+      assertMatch(re, reactivationTime);
+
+      const reactivate = Date.parse(reactivationTime);
+
+      // we subtract one second because the returned datetime string does not
+      // have millisecond precision
+      assertTrue(reactivate - now >= (666 * 1000) - 1000, { now, reactivate });
+
+      result = arango.GET(url);
+      assertFalse(result.error);
+      assertEqual("Maintenance", result.result);
+    },
+
+  };
+}
+
+jsunity.run(numberOfServersSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

When enabling the cluster supervision maintenance mode via the web UI, there is now the possibility to select a duration for the maintenance mode. Previous versions of ArangoDB always enabled the maintenance mode for one hour, without allowing any choice here.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/15061
- [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/15060

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_client)
