### PR TITLE
remove duplicate code, arangod/GeneralServer/GeneralServerFeature.cpp already has these.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* remove the not anymore supported --server.default-api-compatibility option
+
 * Fixed SEARCH-261: Fix possible race between file creation and directory
   cleaner (ArangoSearch).
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 devel
 -----
 
-* remove the not anymore supported --server.default-api-compatibility option
+* Remove unsupported `--server.default-api-compatibility` startup option.
 
 * Fixed SEARCH-261: Fix possible race between file creation and directory
   cleaner (ArangoSearch).

--- a/arangod/GeneralServer/AuthenticationFeature.cpp
+++ b/arangod/GeneralServer/AuthenticationFeature.cpp
@@ -74,13 +74,6 @@ void AuthenticationFeature::collectOptions(std::shared_ptr<ProgramOptions> optio
                         "server.authentication-unix-sockets");
   options->addOldOption("server.authenticate-system-only",
                         "server.authentication-system-only");
-  options->addOldOption("server.allow-method-override",
-                        "http.allow-method-override");
-  options->addOldOption("server.hide-product-header",
-                        "http.hide-product-header");
-  options->addOldOption("server.keep-alive-timeout", "http.keep-alive-timeout");
-  options->addOldOption("server.default-api-compatibility", "");
-  options->addOldOption("no-server", "server.rest-server");
 
   options->addOption("--server.authentication",
                      "enable authentication for ALL client requests",

--- a/arangod/GeneralServer/GeneralServerFeature.cpp
+++ b/arangod/GeneralServer/GeneralServerFeature.cpp
@@ -176,7 +176,6 @@ void GeneralServerFeature::collectOptions(std::shared_ptr<ProgramOptions> option
   options->addOldOption("server.hide-product-header",
                         "http.hide-product-header");
   options->addOldOption("server.keep-alive-timeout", "http.keep-alive-timeout");
-  options->addOldOption("server.default-api-compatibility", "");
   options->addOldOption("no-server", "server.rest-server");
 
   options->addOption("--server.io-threads",


### PR DESCRIPTION
### Scope & Purpose

cleanup duplicate code. See https://github.com/arangodb/arangodb/blob/devel/arangod/GeneralServer/GeneralServerFeature.cpp#L174 for the remaining place.

- [x] :hammer: Refactoring/simplification


### Testing & Verification

*(Please pick either of the following options)*

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
```
./bin/arangod --server.allow-method-override true  --server.hide-product-header false --server.keep-alive-timeout 10 --no-server false  /tmp/blarg
```
However, 
```
./bin/arangod --server.default-api-compatibility true /tmp/blarg 
Error while processing command-line options for arangod:
  unknown option '--'

Did you mean one of these?
  --gid     switch to group-id after reading config files
  --hund    make ArangoDB bark on startup
  --log     the global or topic-specific log level
  --uid     switch to user-id after reading config files

Use --help or --help-all to get an overview of available options
```
is probably bad behaviour because of bad error messages, maybe it should be removed alltogether?