### PR TITLE
enable interprocedural optimizations for velocypack library

### DIFF
--- a/3rdParty/velocypack/CMakeLists.txt
+++ b/3rdParty/velocypack/CMakeLists.txt
@@ -1,6 +1,6 @@
 # -*- mode: CMAKE; -*-
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.9)
 project(velocypack CXX C)
 
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "target C++ standard")
@@ -8,6 +8,29 @@ message(STATUS "Require C++${CMAKE_CXX_STANDARD}")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
+
+set(UseIPO "AUTO" CACHE STRING "Use interprocedural optimization: ON, OFF or AUTO")
+set_property(CACHE UseIPO PROPERTY STRINGS AUTO ON OFF)
+
+# Determine value if IPO_ENABLED from USE_IPO and CMAKE_BUILD_TYPE
+set(IPO_ENABLED False)
+if (UseIPO STREQUAL "AUTO")
+  if (CMAKE_BUILD_TYPE STREQUAL "Release"
+      OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"
+      OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+    set(IPO_ENABLED True)
+  else()
+    set(IPO_ENABLED False)
+  endif ()
+elseif (UseIPO)
+  set(IPO_ENABLED True)
+else()
+  set(IPO_ENABLED False)
+endif()
+
+if (IPO_ENABLED)
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION True)
+endif()
 
 option(BuildVelocyPackExamples "Build examples" ON)
 option(Maintainer "Build maintainer tools" OFF)
@@ -19,8 +42,9 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()
 
-message(STATUS "Build mode: ${CMAKE_BUILD_TYPE}")
-message(STATUS "Install base directory: ${CMAKE_INSTALL_PREFIX}")
+message(STATUS "VelocyPack build mode: ${CMAKE_BUILD_TYPE}")
+message(STATUS "VelocyPack interprocedural optimizations: ${IPO_ENABLED}")
+message(STATUS "VelocyPack install base directory: ${CMAKE_INSTALL_PREFIX}")
 set(VELOCYPACK_VERSION "0.1.33" CACHE STRING "VelocyPack version")
 set(VELOCYPACK_DISPLAY_NAME "Velocypack")
 set(VELOCYPACK_URL_INFO_ABOUT "https://github.com/arangodb/velocypack")
@@ -68,9 +92,9 @@ elseif(HashType STREQUAL "fasthash")
     list(APPEND VELOCY_SOURCE src/fasthash.cpp)
     add_definitions("-DVELOCYPACK_FASTHASH=1")
 else()
-    message(FATAL_ERROR "invalid HashType value. supported values: xxhash, fasthash")
+    message(FATAL_ERROR "VelocyPack invalid HashType value. supported values: xxhash, fasthash")
 endif()
-message(STATUS "Building with hash type: ${HashType}")
+message(STATUS "VelocyPack Building with hash type: ${HashType}")
 
 add_library(velocypack STATIC ${VELOCY_SOURCE})
 target_include_directories(velocypack PRIVATE src)

--- a/3rdParty/velocypack/examples/CMakeLists.txt
+++ b/3rdParty/velocypack/examples/CMakeLists.txt
@@ -1,5 +1,8 @@
 # options
-message(STATUS "Building examples: ${BuildVelocyPackExamples}")
+  
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION False)
+
+message(STATUS "VelocyPack building examples: ${BuildVelocyPackExamples}")
 if(BuildVelocyPackExamples)
     set(Examples
         exampleAliases

--- a/3rdParty/velocypack/tests/CMakeLists.txt
+++ b/3rdParty/velocypack/tests/CMakeLists.txt
@@ -1,14 +1,16 @@
 # -*- mode: CMAKE; -*-
 
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION False)
+
 # options
 option(BuildTests "Build test suite" OFF)
-message(STATUS "Building test suite: ${BuildTests}")
+message(STATUS "VelocyPack building test suite: ${BuildTests}")
 
 option(BuildLargeTests "Build large tests" OFF)
-message(STATUS "Building large tests: ${BuildLargeTests}")
+message(STATUS "VelocyPack building large tests: ${BuildLargeTests}")
 
 option(BuildAsmTest "Build assembler test code" OFF)
-message(STATUS "Building assembler test suite: ${BuildAsmTest}")
+message(STATUS "VelocyPack building assembler test suite: ${BuildAsmTest}")
 
 set(Tests
     testsAliases

--- a/3rdParty/velocypack/tools/CMakeLists.txt
+++ b/3rdParty/velocypack/tools/CMakeLists.txt
@@ -1,11 +1,13 @@
 # -*- mode: CMAKE; -*-
 
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION False)
+
 # options
 option(BuildBench "Build bench performance test suite" OFF)
-message(STATUS "Building bench performance test suite: ${BuildBench}")
+message(STATUS "VelocyPack building bench performance test suite: ${BuildBench}")
 
 option(BuildTools "Build support programs and tools" ON)
-message(STATUS "Building support programs and tools: ${BuildTools}")
+message(STATUS "VelocyPack building support programs and tools: ${BuildTools}")
 
 # build json-to-vpack.cpp
 if(BuildTools)


### PR DESCRIPTION
### Scope & Purpose

Enable interprocedure optimizations / link-time optimizations for the VelocyPack library.
All changes in this PR are reflected in the following PR for arangodb/velocypack as well: https://github.com/arangodb/velocypack/pull/102

The overhead on build/links times seems minimal, at least when I tried this locally. This is probably because VelocyPack is a small library, and many things are implemented in header files already.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
