### PR TITLE
Bug fix/avoid cpp17 deprecations

### DIFF
--- a/3rdParty/fakeit-gtest/fakeit.hpp
+++ b/3rdParty/fakeit-gtest/fakeit.hpp
@@ -8371,7 +8371,7 @@ namespace fakeit {
 
             virtual ~StubbingChange() THROWS {
 
-                if (std::uncaught_exception()) {
+                if (std::uncaught_exceptions()) {
                     return;
                 }
 
@@ -8631,7 +8631,7 @@ namespace fakeit {
         friend class SequenceVerificationProgress;
 
         ~SequenceVerificationExpectation() THROWS {
-            if (std::uncaught_exception()) {
+            if (std::uncaught_exceptions()) {
                 return;
             }
             VerifyExpectation(_fakeit);
@@ -8993,7 +8993,7 @@ namespace fakeit {
             friend class VerifyNoOtherInvocationsVerificationProgress;
 
             ~VerifyNoOtherInvocationsExpectation() THROWS {
-                if (std::uncaught_exception()) {
+                if (std::uncaught_exceptions()) {
                     return;
                 }
 

--- a/3rdParty/immer/v0.6.2/extra/guile/scm/detail/invoke.hpp
+++ b/3rdParty/immer/v0.6.2/extra/guile/scm/detail/invoke.hpp
@@ -20,7 +20,7 @@ namespace detail {
 template <typename Functor, typename... Args>
 std::enable_if_t<
     std::is_member_pointer<std::decay_t<Functor>>::value,
-    std::result_of_t<Functor&&(Args&&...)>>
+    std::invoke_result_t<Functor&&, Args&&...>>
 invoke(Functor&& f, Args&&... args)
 {
     return std::mem_fn(f)(std::forward<Args>(args)...);
@@ -29,7 +29,7 @@ invoke(Functor&& f, Args&&... args)
 template <typename Functor, typename... Args>
 std::enable_if_t<
     !std::is_member_pointer<std::decay_t<Functor>>::value,
-    std::result_of_t<Functor&&(Args&&...)>>
+    std::invoke_result_t<Functor&&, Args&&...>>
 invoke(Functor&& f, Args&&... args)
 {
     return std::forward<Functor>(f)(std::forward<Args>(args)...);

--- a/3rdParty/immer/v0.6.2/extra/guile/scm/detail/subr_wrapper.hpp
+++ b/3rdParty/immer/v0.6.2/extra/guile/scm/detail/subr_wrapper.hpp
@@ -97,7 +97,7 @@ template <typename Tag, typename Fn, typename... Args>
 auto subr_wrapper_aux(Fn fn, pack<Args...>)
 {
     return subr_wrapper_impl<Tag>(
-        fn, pack<std::result_of_t<Fn(Args...)>>{}, pack<Args...>{});
+        fn, pack<std::invoke_result_t<Fn, Args...>>{}, pack<Args...>{});
 }
 
 template <typename Tag, typename Fn>

--- a/3rdParty/immer/v0.6.2/tools/include/nonius.h++
+++ b/3rdParty/immer/v0.6.2/tools/include/nonius.h++
@@ -658,13 +658,13 @@ namespace nonius {
                 return {};
             }
         };
-        template <typename Sig>
-        using ResultOf = typename std::invoke_result<Sig>::type;
+        template <typename Fun, typename... Args>
+        using ResultOf = typename std::invoke_result<Fun, Args...>::type;
 
         // invoke and not return void :(
         template <typename Fun, typename... Args>
-        CompleteType<ResultOf<Fun(Args...)>> complete_invoke(Fun&& fun, Args&&... args) {
-            return complete_invoker<ResultOf<Fun(Args...)>>::invoke(std::forward<Fun>(fun), std::forward<Args>(args)...);
+        CompleteType<ResultOf<Fun, Args...>> complete_invoke(Fun&& fun, Args&&... args) {
+            return complete_invoker<ResultOf<Fun, Args...>>::invoke(std::forward<Fun>(fun), std::forward<Args>(args)...);
         }
     } // namespace detail
 } // namespace nonius
@@ -922,8 +922,8 @@ namespace nonius {
         Result result;
         int iterations;
     };
-    template <typename Clock, typename Sig>
-    using TimingOf = timing<Duration<Clock>, detail::CompleteType<detail::ResultOf<Sig>>>;
+    template <typename Clock, typename Fun, typename... Args>
+    using TimingOf = timing<Duration<Clock>, detail::CompleteType<detail::ResultOf<Fun, Args...>>>;
 } // namespace nonius
 
 #include <utility>
@@ -931,7 +931,7 @@ namespace nonius {
 namespace nonius {
     namespace detail {
         template <typename Clock, typename Fun, typename... Args>
-        TimingOf<Clock, Fun(Args...)> measure(Fun&& fun, Args&&... args) {
+        TimingOf<Clock, Fun, Args...> measure(Fun&& fun, Args&&... args) {
             auto start = Clock::now();
             auto&& r = detail::complete_invoke(fun, std::forward<Args>(args)...);
             auto end = Clock::now();
@@ -947,11 +947,11 @@ namespace nonius {
 namespace nonius {
     namespace detail {
         template <typename Clock, typename Fun>
-        TimingOf<Clock, Fun(int)> measure_one(Fun&& fun, int iters, const parameters&, std::false_type) {
+        TimingOf<Clock, Fun, int> measure_one(Fun&& fun, int iters, const parameters&, std::false_type) {
             return detail::measure<Clock>(fun, iters);
         }
         template <typename Clock, typename Fun>
-        TimingOf<Clock, Fun(chronometer)> measure_one(Fun&& fun, int iters, const parameters& params, std::true_type) {
+        TimingOf<Clock, Fun, chronometer> measure_one(Fun&& fun, int iters, const parameters& params, std::true_type) {
             detail::chronometer_model<Clock> meter;
             auto&& result = detail::complete_invoke(fun, chronometer(meter, iters, params));
 
@@ -968,7 +968,7 @@ namespace nonius {
         };
 
         template <typename Clock, typename Fun>
-        TimingOf<Clock, Fun(run_for_at_least_argument_t<Clock, Fun>)> run_for_at_least(const parameters& params, Duration<Clock> how_long, int seed, Fun&& fun) {
+        TimingOf<Clock, Fun, run_for_at_least_argument_t<Clock, Fun>> run_for_at_least(const parameters& params, Duration<Clock> how_long, int seed, Fun&& fun) {
             auto iters = seed;
             while(iters < (1 << 30)) {
                 auto&& timing = measure_one<Clock>(fun, iters, params, detail::is_callable<Fun(chronometer)>());

--- a/3rdParty/immer/v0.6.2/tools/include/nonius.h++
+++ b/3rdParty/immer/v0.6.2/tools/include/nonius.h++
@@ -659,7 +659,7 @@ namespace nonius {
             }
         };
         template <typename Sig>
-        using ResultOf = typename std::result_of<Sig>::type;
+        using ResultOf = typename std::invoke_result<Sig>::type;
 
         // invoke and not return void :(
         template <typename Fun, typename... Args>

--- a/3rdParty/iresearch/external/absl/absl/container/internal/btree.h
+++ b/3rdParty/iresearch/external/absl/absl/container/internal/btree.h
@@ -78,7 +78,7 @@ namespace container_internal {
 // comparator.
 template <typename Compare, typename T>
 using btree_is_key_compare_to =
-    std::is_convertible<iresearch_absl::result_of_t<Compare(const T &, const T &)>,
+    std::is_convertible<iresearch_absl::result_of_t<Compare, const T &, const T &>,
                         iresearch_absl::weak_ordering>;
 
 struct StringBtreeDefaultLess {
@@ -1868,7 +1868,7 @@ constexpr bool btree<P>::static_assert_validation() {
 
   // Verify that key_compare returns an iresearch_absl::{weak,strong}_ordering or bool.
   using compare_result_type =
-      iresearch_absl::result_of_t<key_compare(key_type, key_type)>;
+      iresearch_absl::result_of_t<key_compare, key_type, key_type>;
   static_assert(
       std::is_same<compare_result_type, bool>::value ||
           std::is_convertible<compare_result_type, iresearch_absl::weak_ordering>::value,

--- a/3rdParty/iresearch/external/absl/absl/meta/type_traits.h
+++ b/3rdParty/iresearch/external/absl/absl/meta/type_traits.h
@@ -610,8 +610,8 @@ using common_type_t = typename std::common_type<T...>::type;
 template <typename T>
 using underlying_type_t = typename std::underlying_type<T>::type;
 
-template <typename T>
-using result_of_t = typename std::result_of<T>::type;
+template <class F, class... Args>
+using result_of_t = typename std::invoke_result<F, Args...>::type;
 
 namespace type_traits_internal {
 // In MSVC we can't probe std::hash or stdext::hash because it triggers a

--- a/3rdParty/iresearch/external/absl/absl/types/compare.h
+++ b/3rdParty/iresearch/external/absl/absl/types/compare.h
@@ -574,8 +574,8 @@ constexpr iresearch_absl::weak_ordering compare_result_as_ordering(
 
 template <
     typename Compare, typename K, typename LK,
-    iresearch_absl::enable_if_t<!std::is_same<bool, iresearch_absl::result_of_t<Compare(
-                                              const K &, const LK &)>>::value,
+    iresearch_absl::enable_if_t<!std::is_same<bool, iresearch_absl::result_of_t<Compare,
+                                              const K &, const LK &>>::value,
                       int> = 0>
 constexpr iresearch_absl::weak_ordering do_three_way_comparison(const Compare &compare,
                                                       const K &x, const LK &y) {

--- a/3rdParty/iresearch/external/absl/absl/types/internal/variant.h
+++ b/3rdParty/iresearch/external/absl/absl/types/internal/variant.h
@@ -894,7 +894,7 @@ struct ContainsVariantNPos
 
 template <class Op, class... QualifiedVariants>
 using RawVisitResult =
-    iresearch_absl::result_of_t<Op(VariantAccessResult<0, QualifiedVariants>...)>;
+    iresearch_absl::result_of_t<Op, VariantAccessResult<0, QualifiedVariants>...>;
 
 // NOTE: The spec requires that all return-paths yield the same type and is not
 // SFINAE-friendly, so we can deduce the return type by examining the first
@@ -905,7 +905,7 @@ using RawVisitResult =
 template <class Op, class... QualifiedVariants>
 struct VisitResultImpl {
   using type =
-      iresearch_absl::result_of_t<Op(VariantAccessResult<0, QualifiedVariants>...)>;
+      iresearch_absl::result_of_t<Op, VariantAccessResult<0, QualifiedVariants>...>;
 };
 
 // Done in two steps intentionally so that we don't cause substitution to fail.
@@ -927,8 +927,8 @@ struct PerformVisitation {
                            index_sequence<TupIs...>, SizeT<Is>...) const {
     static_assert(
         std::is_same<ReturnType,
-                     iresearch_absl::result_of_t<Op(VariantAccessResult<
-                                          Is, QualifiedVariants>...)>>::value,
+                     iresearch_absl::result_of_t<Op, VariantAccessResult<
+                                          Is, QualifiedVariants>...>>::value,
         "All visitation overloads must have the same return type.");
     return iresearch_absl::base_internal::invoke(
         iresearch_absl::forward<Op>(op),

--- a/3rdParty/iresearch/external/openfst/fst/memory.h
+++ b/3rdParty/iresearch/external/openfst/fst/memory.h
@@ -324,11 +324,11 @@ class PoolAllocator {
   using Allocator = std::allocator<T>;
   using size_type = typename Allocator::size_type;
   using difference_type = typename Allocator::difference_type;
-  using pointer = typename Allocator::pointer;
-  using const_pointer = typename Allocator::const_pointer;
-  using reference = typename Allocator::reference;
-  using const_reference = typename Allocator::const_reference;
   using value_type = typename Allocator::value_type;
+  using pointer = value_type*;
+  using const_pointer = value_type const*;
+  using reference = value_type&;
+  using const_reference = value_type const&;
 
   template <typename U>
   struct rebind {

--- a/3rdParty/s2geometry/dfefe0c/CMakeLists.txt
+++ b/3rdParty/s2geometry/dfefe0c/CMakeLists.txt
@@ -58,7 +58,7 @@ if (APPLE)
     set(CMAKE_MACOSX_RPATH TRUE)
 endif()
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # No compiler-specific extensions, i.e. -std=c++11, not -std=gnu++11.
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/3rdParty/s2geometry/dfefe0c/src/s2/third_party/absl/container/inlined_vector.h
+++ b/3rdParty/s2geometry/dfefe0c/src/s2/third_party/absl/container/inlined_vector.h
@@ -72,10 +72,10 @@ class InlinedVector {
  public:
   using allocator_type = A;
   using value_type = typename allocator_type::value_type;
-  using pointer = typename allocator_type::pointer;
-  using const_pointer = typename allocator_type::const_pointer;
-  using reference = typename allocator_type::reference;
-  using const_reference = typename allocator_type::const_reference;
+  using pointer = value_type*;
+  using const_pointer = value_type const*;
+  using reference = value_type&;
+  using const_reference = value_type const&;
   using size_type = typename allocator_type::size_type;
   using difference_type = typename allocator_type::difference_type;
   using iterator = pointer;

--- a/3rdParty/s2geometry/dfefe0c/src/s2/third_party/absl/meta/type_traits.h
+++ b/3rdParty/s2geometry/dfefe0c/src/s2/third_party/absl/meta/type_traits.h
@@ -347,8 +347,8 @@ using common_type_t = typename std::common_type<T...>::type;
 template <typename T>
 using underlying_type_t = typename std::underlying_type<T>::type;
 
-template <typename T>
-using result_of_t = typename std::result_of<T>::type;
+template <class F, class... Args>
+using result_of_t = typename std::invoke_result_t<F, Args...>;
 
 namespace type_traits_internal {
 template <typename Key, typename = size_t>

--- a/3rdParty/s2geometry/dfefe0c/src/s2/util/gtl/btree.h
+++ b/3rdParty/s2geometry/dfefe0c/src/s2/util/gtl/btree.h
@@ -1446,7 +1446,7 @@ class btree {
 
   // Verify that key_compare returns an int or bool, as appropriate
   // depending on the value of is_key_compare_to.
-  static_assert(std::is_same<absl::result_of_t<key_compare(key_type, key_type)>,
+  static_assert(std::is_same<absl::result_of_t<key_compare, key_type, key_type>,
                              absl::conditional_t<is_key_compare_to::value, int,
                                                  bool>>::value,
                 "key comparison function must return bool");

--- a/lib/Futures/Future.h
+++ b/lib/Futures/Future.h
@@ -79,7 +79,7 @@ struct ArgType<> {
 template <typename F, typename... Args>
 struct argResult {
   using ArgList = ArgType<Args...>;
-  using Result = typename std::result_of<F(Args...)>::type;
+  using Result = typename std::invoke_result<F, Args...>::type;
 };
 
 template <typename T, typename F>
@@ -98,7 +98,7 @@ struct valueCallableResult {
   typedef Future<typename ReturnsFuture::inner> FutureT;
 };
 
-template <class F, typename R = typename std::result_of<F()>::type>
+template <class F, typename R = typename std::invoke_result<F>::type>
 typename std::enable_if<!std::is_same<R, void>::value, Try<R>>::type makeTryWith(F&& func) noexcept {
   try {
     return Try<R>(std::in_place, func());
@@ -107,7 +107,7 @@ typename std::enable_if<!std::is_same<R, void>::value, Try<R>>::type makeTryWith
   }
 }
 
-template <class F, typename R = typename std::result_of<F()>::type>
+template <class F, typename R = typename std::invoke_result<F>::type>
 typename std::enable_if<std::is_same<R, void>::value, Try<Unit>>::type makeTryWith(F&& func) noexcept {
   try {
     func();
@@ -449,14 +449,14 @@ class Future {
   /// Variant: function returns void and accepts Try<T>&&
   /// When this Future has completed, execute func which is a function that
   /// can be called with either `T&&` or `Try<T>&&`.
-  template <typename F, typename R = typename std::result_of<F && (Try<T> &&)>::type>
+  template <typename F, typename R = typename std::invoke_result<F&&, Try<T>&&>::type>
   typename std::enable_if<std::is_same<R, void>::value>::type thenFinal(F&& fn) {
     getState().setCallback(std::forward<detail::decay_t<F>>(fn));
   }
 
   /// Set an error continuation for this Future where the continuation can
   /// be called with a known exception type and returns a `T`
-  template <typename ExceptionType, typename F, typename R = std::result_of_t<F(ExceptionType)>>
+  template <typename ExceptionType, typename F, typename R = std::invoke_result_t<F, ExceptionType>>
   typename std::enable_if<!isFuture<R>::value, Future<typename lift_unit<R>::type>>::type thenError(
       F&& func) && {
     typedef typename lift_unit<R>::type B;
@@ -486,7 +486,7 @@ class Future {
 
   /// Set an error continuation for this Future where the continuation can
   /// be called with a known exception type and returns a `Future<T>`
-  template <typename ExceptionType, typename F, typename R = std::result_of_t<F(ExceptionType)>>
+  template <typename ExceptionType, typename F, typename R = std::invoke_result_t<F, ExceptionType>>
   typename std::enable_if<isFuture<R>::value, Future<typename isFuture<R>::inner>>::type thenError(F&& fn) && {
     typedef typename isFuture<R>::inner B;
     typedef std::decay_t<ExceptionType> ET;

--- a/lib/Futures/Try.h
+++ b/lib/Futures/Try.h
@@ -391,7 +391,7 @@ class Try<void> {
   std::exception_ptr _exception;
 };
 
-template <class F, typename R = typename std::result_of<F()>::type>
+template <class F, typename R = typename std::invoke_result<F>::type>
 typename std::enable_if<!std::is_same<R, void>::value, Try<R>>::type makeTryWith(F&& func) noexcept {
   try {
     return Try<R>(std::in_place, func());
@@ -400,7 +400,7 @@ typename std::enable_if<!std::is_same<R, void>::value, Try<R>>::type makeTryWith
   }
 }
 
-template <class F, typename R = typename std::result_of<F()>::type>
+template <class F, typename R = typename std::invoke_result<F>::type>
 typename std::enable_if<std::is_same<R, void>::value, Try<void>>::type makeTryWith(F&& func) noexcept {
   try {
     func();

--- a/lib/Futures/Utilities.h
+++ b/lib/Futures/Utilities.h
@@ -63,7 +63,7 @@ typename std::enable_if<std::is_base_of<std::exception, E>::value, Future<T>>::t
 }
 
 // makeFutureWith(Future<T>()) -> Future<T>
-template <typename F, typename R = std::result_of_t<F()>>
+template <typename F, typename R = std::invoke_result_t<F>>
 typename std::enable_if<isFuture<R>::value, R>::type makeFutureWith(F&& func) {
   using InnerType = typename isFuture<R>::inner;
   try {
@@ -75,7 +75,7 @@ typename std::enable_if<isFuture<R>::value, R>::type makeFutureWith(F&& func) {
 
 // makeFutureWith(T()) -> Future<T>
 // makeFutureWith(void()) -> Future<Unit>
-template <typename F, typename R = std::result_of_t<F()>>
+template <typename F, typename R = std::invoke_result_t<F>>
 typename std::enable_if<!isFuture<R>::value, Future<R>>::type makeFutureWith(F&& func) {
   return makeFuture<R>(
       makeTryWith([&func]() mutable { return std::forward<F>(func)(); }));


### PR DESCRIPTION
### Scope & Purpose

Fix various places where STL features have been used that have been deprecated in C++17 and removed in C++20.

- [x] :hammer: Refactoring/simplification

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
