### PR TITLE
make scripts/startLocalCluster.sh start slightly faster

### DIFF
--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -1048,15 +1048,15 @@ bool AgencyComm::ensureStructureInitialized() {
       break;
     }
 
+    // we can get here if a competing process tries to initialize
+    // the agency structures as well
     LOG_TOPIC("63f7b", INFO, Logger::AGENCYCOMM)
         << "Initializing agency failed. We'll try again soon";
-    // We should really have exclusive access, here, this is strange!
-    std::this_thread::sleep_for(std::chrono::seconds(1));
 
     LOG_TOPIC("9d265", TRACE, Logger::AGENCYCOMM)
         << "Waiting for agency to get initialized";
 
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
   }
 
   return true;

--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -82,7 +82,7 @@ fi
 
 SFRE=1.0
 COMP=500
-KEEP=2000
+KEEP=50000
 if [ -z "$ONGOING_PORTS" ] ; then
   CO_BASE=$(( $PORT_OFFSET + 8530 ))
   DB_BASE=$(( $PORT_OFFSET + 8629 ))
@@ -297,19 +297,25 @@ done
 
 testServer() {
     PORT=$1
+    COUNTER=0
     while true ; do
         if [ -z "$AUTHORIZATION_HEADER" ]; then
           ${CURL}//$ADDRESS:$PORT/_api/version > /dev/null 2>&1
         else
           ${CURL}//$ADDRESS:$PORT/_api/version -H "$AUTHORIZATION_HEADER" > /dev/null 2>&1
         fi
-        if [ "$?" != "0" ] ; then
-            echo Server on port $PORT does not answer yet.
+        if [ "x$?" != "x0" ] ; then
+            COUNTER=$(($COUNTER + 1))
+            if [ "x$COUNTER" = "x4" ]; then
+              # only print every now and then
+              echo Server on port $PORT does not answer yet.
+              COUNTER=0
+            fi;
         else
             echo Server on port $PORT is ready for business.
             break
         fi
-        sleep 1
+        sleep 0.25
     done
 }
 


### PR DESCRIPTION
### Scope & Purpose

* make scripts/startLocalCluster.sh start slightly faster by checking for available servers every 1/4 seconds.
* additionally, set the agency's compaction-keep-size to 50000, up from previously 2000. this allows better debugging of local clusters.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
