### PR TITLE
Search-183

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,5 @@ perf*
 callgrind*
 
 Documentation/Metrics/allMetrics.yaml
+
+cmake-build*/

--- a/Documentation/Metrics/arangodb_arangosearch_cleanup_time.yaml
+++ b/Documentation/Metrics/arangodb_arangosearch_cleanup_time.yaml
@@ -1,0 +1,13 @@
+name: arangodb_arangosearch_cleanup_time
+introducedIn: "3.10.0"
+help: |
+  Average time of few last cleanups.
+unit: ms
+type: gauge
+category: Disk
+complexity: advanced
+exposedBy:
+  - dbserver
+  - single
+description: |
+  Average time of few last cleanups.

--- a/Documentation/Metrics/arangodb_arangosearch_commit_time.yaml
+++ b/Documentation/Metrics/arangodb_arangosearch_commit_time.yaml
@@ -1,0 +1,13 @@
+name: arangodb_arangosearch_commit_time
+introducedIn: "3.10.0"
+help: |
+  Average time of few last commits.
+unit: ms
+type: gauge
+category: Disk
+complexity: advanced
+exposedBy:
+  - dbserver
+  - single
+description: |
+  Average time of few last commits.

--- a/Documentation/Metrics/arangodb_arangosearch_consolidation_time.yaml
+++ b/Documentation/Metrics/arangodb_arangosearch_consolidation_time.yaml
@@ -1,0 +1,13 @@
+name: arangodb_arangosearch_consolidation_time
+introducedIn: "3.10.0"
+help: |
+  Average time of few last consolidations.
+unit: ms
+type: gauge
+category: Disk
+complexity: advanced
+exposedBy:
+  - dbserver
+  - single
+description: |
+  Average time of few last consolidations.

--- a/Documentation/Metrics/arangodb_arangosearch_index_size.yaml
+++ b/Documentation/Metrics/arangodb_arangosearch_index_size.yaml
@@ -1,0 +1,13 @@
+name: arangodb_arangosearch_index_size
+introducedIn: "3.10.0"
+help: |
+  Size of the index in bytes for current snapshot.
+unit: number
+type: gauge
+category: Disk
+complexity: advanced
+exposedBy:
+  - dbserver
+  - single
+description: |
+  Size of the index in bytes for current snapshot.

--- a/Documentation/Metrics/arangodb_arangosearch_num_buffered_docs.yaml
+++ b/Documentation/Metrics/arangodb_arangosearch_num_buffered_docs.yaml
@@ -1,0 +1,13 @@
+name: arangodb_arangosearch_num_buffered_docs
+introducedIn: "3.10.0"
+help: |
+  Number of buffered documents for current snapshot.
+unit: number
+type: gauge
+category: Disk
+complexity: advanced
+exposedBy:
+  - dbserver
+  - single
+description: |
+  Number of buffered documents for current snapshot.

--- a/Documentation/Metrics/arangodb_arangosearch_num_docs.yaml
+++ b/Documentation/Metrics/arangodb_arangosearch_num_docs.yaml
@@ -1,0 +1,13 @@
+name: arangodb_arangosearch_num_docs
+introducedIn: "3.10.0"
+help: |
+  Number of documents for current snapshot.
+unit: number
+type: gauge
+category: Disk
+complexity: advanced
+exposedBy:
+  - dbserver
+  - single
+description: |
+  Number of documents for current snapshot.

--- a/Documentation/Metrics/arangodb_arangosearch_num_failed_cleanups.yaml
+++ b/Documentation/Metrics/arangodb_arangosearch_num_failed_cleanups.yaml
@@ -1,0 +1,13 @@
+name: arangodb_arangosearch_num_failed_cleanups
+introducedIn: "3.10.0"
+help: |
+  Number of failed cleanups.
+unit: number
+type: gauge
+category: Disk
+complexity: advanced
+exposedBy:
+  - dbserver
+  - single
+description: |
+  Number of failed cleanups.

--- a/Documentation/Metrics/arangodb_arangosearch_num_failed_commits.yaml
+++ b/Documentation/Metrics/arangodb_arangosearch_num_failed_commits.yaml
@@ -1,0 +1,13 @@
+name: arangodb_arangosearch_num_failed_commits
+introducedIn: "3.10.0"
+help: |
+  Number of failed commits.
+unit: number
+type: gauge
+category: Disk
+complexity: advanced
+exposedBy:
+  - dbserver
+  - single
+description: |
+  Number of failed commits.

--- a/Documentation/Metrics/arangodb_arangosearch_num_failed_consolidations.yaml
+++ b/Documentation/Metrics/arangodb_arangosearch_num_failed_consolidations.yaml
@@ -1,0 +1,13 @@
+name: arangodb_arangosearch_num_failed_consolidations
+introducedIn: "3.10.0"
+help: |
+  Number of failed consolidations.
+unit: number
+type: gauge
+category: Disk
+complexity: advanced
+exposedBy:
+  - dbserver
+  - single
+description: |
+  Number of failed consolidations.

--- a/Documentation/Metrics/arangodb_arangosearch_num_files.yaml
+++ b/Documentation/Metrics/arangodb_arangosearch_num_files.yaml
@@ -1,0 +1,13 @@
+name: arangodb_arangosearch_num_files
+introducedIn: "3.10.0"
+help: |
+  Number of files for current snapshot.
+unit: number
+type: gauge
+category: Disk
+complexity: advanced
+exposedBy:
+  - dbserver
+  - single
+description: |
+  Number of files for current snapshot.

--- a/Documentation/Metrics/arangodb_arangosearch_num_live_docs.yaml
+++ b/Documentation/Metrics/arangodb_arangosearch_num_live_docs.yaml
@@ -1,0 +1,13 @@
+name: arangodb_arangosearch_num_live_docs
+introducedIn: "3.10.0"
+help: |
+  Number of live documents for current snapshot.
+unit: number
+type: gauge
+category: Disk
+complexity: advanced
+exposedBy:
+  - dbserver
+  - single
+description: |
+  Number of live documents for current snapshot.

--- a/Documentation/Metrics/arangodb_arangosearch_num_segments.yaml
+++ b/Documentation/Metrics/arangodb_arangosearch_num_segments.yaml
@@ -1,0 +1,13 @@
+name: arangodb_arangosearch_num_segments
+introducedIn: "3.10.0"
+help: |
+  Number of segments for current snapshot.
+unit: number
+type: gauge
+category: Disk
+complexity: advanced
+exposedBy:
+  - dbserver
+  - single
+description: |
+  Number of segments for current snapshot.

--- a/arangod/IResearch/IResearchLink.cpp
+++ b/arangod/IResearch/IResearchLink.cpp
@@ -26,11 +26,11 @@
 #include <store/mmap_directory.hpp>
 #include <store/store_utils.hpp>
 #include <utils/encryption.hpp>
-#include <utils/singleton.hpp>
 #include <utils/file_utils.hpp>
+#include <utils/singleton.hpp>
 
-#include "IResearchLink.h"
 #include "IResearchDocument.h"
+#include "IResearchLink.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/QueryCache.h"
@@ -70,13 +70,11 @@ using namespace arangodb::iresearch;
 ////////////////////////////////////////////////////////////////////////////////
 struct LinkTrxState final : public TransactionState::Cookie {
   irs::index_writer::documents_context _ctx;
-  AsyncValue<IResearchLink>::Value _linkLock; // prevent data-store deallocation (lock @ AsyncSelf)
+  AsyncValue<IResearchLink>::Value _linkLock;  // prevent data-store deallocation (lock @ AsyncSelf)
   PrimaryKeyFilterContainer _removals;  // list of document removals
 
-  LinkTrxState(AsyncValue<IResearchLink>::Value&& linkLock,
-               irs::index_writer& writer) noexcept
-      : _ctx(writer.documents()),
-        _linkLock(std::move(linkLock)) {
+  LinkTrxState(AsyncValue<IResearchLink>::Value&& linkLock, irs::index_writer& writer) noexcept
+      : _ctx(writer.documents()), _linkLock(std::move(linkLock)) {
     TRI_ASSERT(_linkLock.ownsLock());
   }
 
@@ -114,12 +112,10 @@ struct LinkTrxState final : public TransactionState::Cookie {
 /// @brief inserts ArangoDB document into an IResearch data store
 ////////////////////////////////////////////////////////////////////////////////
 inline Result insertDocument(irs::index_writer::documents_context& ctx,
-                             transaction::Methods const& trx,
-                             FieldIterator& body,
+                             transaction::Methods const& trx, FieldIterator& body,
                              velocypack::Slice const& document,
                              LocalDocumentId const& documentId,
-                             IResearchLinkMeta const& meta,
-                             IndexId id) {
+                             IResearchLinkMeta const& meta, IndexId id) {
   body.reset(document, meta);  // reset reusable container to doc
 
   if (!body.valid()) {
@@ -149,7 +145,7 @@ inline Result insertDocument(irs::index_writer::documents_context& ctx,
       }
 
       VPackSlice slice;
-    } field; // SortedField
+    } field;  // SortedField
 
     for (auto& sortField : meta._sort.fields()) {
       field.slice = get(document, sortField, VPackSlice::nullSlice());
@@ -189,8 +185,7 @@ inline Result insertDocument(irs::index_writer::documents_context& ctx,
 class IResearchFlushSubscription final : public FlushSubscription {
  public:
   explicit IResearchFlushSubscription(TRI_voc_tick_t tick = 0) noexcept
-    : _tick(tick) {
-  }
+      : _tick(tick) {}
 
   /// @brief earliest tick that can be released
   TRI_voc_tick_t tick() const noexcept override final {
@@ -207,9 +202,9 @@ class IResearchFlushSubscription final : public FlushSubscription {
 
 bool readTick(irs::bytes_ref const& payload, TRI_voc_tick_t& tick) noexcept {
   static_assert(
-    // cppcheck-suppress duplicateExpression
-    sizeof(uint64_t) == sizeof(TRI_voc_tick_t),
-    "sizeof(uint64_t) != sizeof(TRI_voc_tick_t)");
+      // cppcheck-suppress duplicateExpression
+      sizeof(uint64_t) == sizeof(TRI_voc_tick_t),
+      "sizeof(uint64_t) != sizeof(TRI_voc_tick_t)");
 
   if (payload.size() != sizeof(uint64_t)) {
     return false;
@@ -222,15 +217,12 @@ bool readTick(irs::bytes_ref const& payload, TRI_voc_tick_t& tick) noexcept {
 }
 
 struct ThreadGroupStats : std::tuple<size_t, size_t, size_t> {
-  explicit ThreadGroupStats(
-      std::tuple<size_t, size_t, size_t> const& stats)
-    : std::tuple<size_t, size_t, size_t>(stats) {
-  }
+  explicit ThreadGroupStats(std::tuple<size_t, size_t, size_t> const& stats)
+      : std::tuple<size_t, size_t, size_t>(stats) {}
 };
 
 std::ostream& operator<<(std::ostream& out, ThreadGroupStats const& stats) {
-  out << "Active=" << std::get<0>(stats)
-      << ", Pending=" << std::get<1>(stats)
+  out << "Active=" << std::get<0>(stats) << ", Pending=" << std::get<1>(stats)
       << ", Threads=" << std::get<2>(stats);
   return out;
 }
@@ -239,17 +231,16 @@ std::ostream& operator<<(std::ostream& out, ThreadGroupStats const& stats) {
 /// @struct Task
 /// @brief base class for asynchronous maintenance tasks
 ////////////////////////////////////////////////////////////////////////////////
-template<typename T>
+template <typename T>
 struct Task {
   void schedule(std::chrono::milliseconds delay) const {
     LOG_TOPIC("eb0da", TRACE, arangodb::iresearch::TOPIC)
-        << "scheduled a " << T::typeName()
-        << " task for arangosearch link '" << id
-        << "', delay '" << delay.count() << "'";
+        << "scheduled a " << T::typeName() << " task for arangosearch link '"
+        << id << "', delay '" << delay.count() << "'";
 
     LOG_TOPIC("eb0d2", TRACE, arangodb::iresearch::TOPIC)
-        << T::typeName() << " pool: "
-        << ThreadGroupStats(async->stats(T::threadGroup()));
+        << T::typeName()
+        << " pool: " << ThreadGroupStats(async->stats(T::threadGroup()));
 
     if (!link->terminationRequested()) {
       async->queue(T::threadGroup(), delay, static_cast<const T&>(*this));
@@ -260,7 +251,7 @@ struct Task {
   IResearchFeature* async;
   IResearchLink::AsyncLinkPtr link;
   IndexId id;
-}; // Task
+};  // Task
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief total number of loaded links
@@ -293,9 +284,7 @@ struct CommitTask : Task<CommitTask> {
     return ThreadGroup::_0;
   }
 
-  static constexpr const char* typeName() noexcept {
-    return "commit";
-  }
+  static constexpr const char* typeName() noexcept { return "commit"; }
 
   void operator()();
   void finalize(IResearchLink* link, IResearchLink::CommitResult code);
@@ -304,11 +293,9 @@ struct CommitTask : Task<CommitTask> {
   std::chrono::milliseconds commitIntervalMsec{};
   std::chrono::milliseconds consolidationIntervalMsec{};
   size_t cleanupIntervalStep{};
-}; // CommitTask
+};  // CommitTask
 
-void CommitTask::finalize(
-    IResearchLink* link,
-    IResearchLink::CommitResult code) {
+void CommitTask::finalize(IResearchLink* link, IResearchLink::CommitResult code) {
   constexpr size_t MAX_NON_EMPTY_COMMITS = 10;
   constexpr size_t MAX_PENDING_CONSOLIDATIONS = 3;
 
@@ -330,7 +317,7 @@ void CommitTask::finalize(
     state->nonEmptyCommits = 0;
     ++state->noopCommitCount;
 
-    for (auto count = state->pendingCommits.load(); count < 1; ) {
+    for (auto count = state->pendingCommits.load(); count < 1;) {
       if (state->pendingCommits.compare_exchange_weak(count, 1)) {
         schedule(commitIntervalMsec);
         break;
@@ -386,8 +373,8 @@ void CommitTask::operator()() {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
 
-    TRI_ASSERT(linkPtr->_dataStore); // must be valid if _asyncSelf->get() is valid
-    READ_LOCKER(lock, linkPtr->_dataStore._mutex); // '_meta' can be asynchronously modified
+    TRI_ASSERT(linkPtr->_dataStore);  // must be valid if _asyncSelf->get() is valid
+    READ_LOCKER(lock, linkPtr->_dataStore._mutex);  // '_meta' can be asynchronously modified
     auto& meta = linkPtr->_dataStore._meta;
 
     commitIntervalMsec = std::chrono::milliseconds(meta._commitIntervalMsec);
@@ -399,8 +386,8 @@ void CommitTask::operator()() {
     reschedule.cancel();
 
     LOG_TOPIC("eba4a", DEBUG, iresearch::TOPIC)
-        << "sync is disabled for the link '" << id
-        << "', runId '" << size_t(&runId) << "'";
+        << "sync is disabled for the link '" << id << "', runId '"
+        << size_t(&runId) << "'";
     return;
   }
 
@@ -408,53 +395,58 @@ void CommitTask::operator()() {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
-  auto const syncStart = std::chrono::steady_clock::now(); // FIXME: add sync durations to metrics
-  auto res = linkPtr->commitUnsafe(false, &code); // run commit ('_asyncSelf' locked by async task)
+  auto const syncStart =
+      std::chrono::steady_clock::now();  // FIXME: add sync durations to metrics
+  auto res = linkPtr->commitUnsafe(false, &code);  // run commit ('_asyncSelf' locked by async task)
 
   if (res.ok()) {
     LOG_TOPIC("7e323", TRACE, iresearch::TOPIC)
-        << "successful sync of arangosearch link '" << id
-        << "', run id '" << size_t(&runId) << "', took: " << 
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-          std::chrono::steady_clock::now() - syncStart).count()
+        << "successful sync of arangosearch link '" << id << "', run id '"
+        << size_t(&runId) << "', took: "
+        << std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - syncStart)
+               .count()
         << "ms";
     if (code == IResearchLink::CommitResult::DONE) {
-      if (cleanupIntervalStep && cleanupIntervalCount++ > cleanupIntervalStep) { // if enabled
+      if (cleanupIntervalStep && cleanupIntervalCount++ > cleanupIntervalStep) {  // if enabled
         cleanupIntervalCount = 0;
 
         TRI_IF_FAILURE("IResearchCommitTask::cleanupUnsafe") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
 
-        auto const cleanupStart = std::chrono::steady_clock::now(); // FIXME: add cleanup durations to metrics
-        res = linkPtr->cleanupUnsafe(); // run cleanup ('_asyncSelf' locked by async task)
+        auto const cleanupStart =
+            std::chrono::steady_clock::now();  // FIXME: add cleanup durations to metrics
+        res = linkPtr->cleanupUnsafe();  // run cleanup ('_asyncSelf' locked by async task)
 
         if (res.ok()) {
           LOG_TOPIC("7e821", TRACE, iresearch::TOPIC)
               << "successful cleanup of arangosearch link '" << id
-              << "', run id '" << size_t(&runId) << "', took: " << 
-              std::chrono::duration_cast<std::chrono::milliseconds>(
-                std::chrono::steady_clock::now() - cleanupStart).count()
+              << "', run id '" << size_t(&runId) << "', took: "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(
+                     std::chrono::steady_clock::now() - cleanupStart)
+                     .count()
               << "ms";
         } else {
           LOG_TOPIC("130de", WARN, iresearch::TOPIC)
-              << "error after running for " <<
-              std::chrono::duration_cast<std::chrono::milliseconds>(
-                std::chrono::steady_clock::now() - cleanupStart).count()
+              << "error after running for "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(
+                     std::chrono::steady_clock::now() - cleanupStart)
+                     .count()
               << "ms while cleaning up arangosearch link '" << id
-              << "', run id '" << size_t(&runId)
-              << "': " << res.errorNumber() << " " << res.errorMessage();
+              << "', run id '" << size_t(&runId) << "': " << res.errorNumber()
+              << " " << res.errorMessage();
         }
       }
     }
   } else {
     LOG_TOPIC("8377b", WARN, iresearch::TOPIC)
-        << "error after running for " <<
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-          std::chrono::steady_clock::now() - syncStart).count()
-        << "ms while committing arangosearch link '" << linkPtr->id()
-        << "', run id '" << size_t(&runId)
-        << "': " << res.errorNumber() << " " << res.errorMessage();
+        << "error after running for "
+        << std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - syncStart)
+               .count()
+        << "ms while committing arangosearch link '" << linkPtr->id() << "', run id '"
+        << size_t(&runId) << "': " << res.errorNumber() << " " << res.errorMessage();
   }
 }
 
@@ -468,16 +460,14 @@ struct ConsolidationTask : Task<ConsolidationTask> {
     return ThreadGroup::_1;
   }
 
-  static constexpr const char* typeName() noexcept {
-    return "consolidation";
-  }
+  static constexpr const char* typeName() noexcept { return "consolidation"; }
 
   void operator()();
 
   irs::merge_writer::flush_progress_t progress;
   IResearchViewMeta::ConsolidationPolicy consolidationPolicy;
   std::chrono::milliseconds consolidationIntervalMsec{};
-}; // ConsolidationTask
+};  // ConsolidationTask
 
 void ConsolidationTask::operator()() {
   const char runId = 0;
@@ -528,21 +518,21 @@ void ConsolidationTask::operator()() {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
 
-    TRI_ASSERT(linkPtr->_dataStore); // must be valid if _asyncSelf->get() is valid
-    READ_LOCKER(lock, linkPtr->_dataStore._mutex); // '_meta' can be asynchronously modified
+    TRI_ASSERT(linkPtr->_dataStore);  // must be valid if _asyncSelf->get() is valid
+    READ_LOCKER(lock, linkPtr->_dataStore._mutex);  // '_meta' can be asynchronously modified
     auto& meta = linkPtr->_dataStore._meta;
 
     consolidationPolicy = meta._consolidationPolicy;
     consolidationIntervalMsec = std::chrono::milliseconds(meta._consolidationIntervalMsec);
   }
 
-  if (std::chrono::milliseconds::zero() == consolidationIntervalMsec // disabled via interval
-      || !consolidationPolicy.policy()) { // disabled via policy
+  if (std::chrono::milliseconds::zero() == consolidationIntervalMsec  // disabled via interval
+      || !consolidationPolicy.policy()) {  // disabled via policy
     reschedule.cancel();
 
     LOG_TOPIC("eba3a", DEBUG, iresearch::TOPIC)
-        << "consolidation is disabled for the link '" << id
-        << "', runId '" << size_t(&runId) << "'";
+        << "consolidation is disabled for the link '" << id << "', runId '"
+        << size_t(&runId) << "'";
     return;
   }
 
@@ -560,30 +550,34 @@ void ConsolidationTask::operator()() {
   }
 
   // run consolidation ('_asyncSelf' locked by async task)
-  auto const consolidationStart = std::chrono::steady_clock::now(); // FIXME: add consolidation durations to metrics
+  auto const consolidationStart =
+      std::chrono::steady_clock::now();  // FIXME: add consolidation durations to metrics
   bool emptyConsolidation = false;
-  auto const res = linkPtr->consolidateUnsafe(consolidationPolicy, progress, emptyConsolidation);
+  auto const res =
+      linkPtr->consolidateUnsafe(consolidationPolicy, progress, emptyConsolidation);
 
   if (res.ok()) {
     if (emptyConsolidation) {
       ++state->noopConsolidationCount;
     } else {
-       state->noopConsolidationCount = 0;
+      state->noopConsolidationCount = 0;
     }
     LOG_TOPIC("7e828", TRACE, iresearch::TOPIC)
         << "successful consolidation of arangosearch link '" << linkPtr->id()
-        << "', run id '" << size_t(&runId) << "', took: " << 
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-          std::chrono::steady_clock::now() - consolidationStart).count()
+        << "', run id '" << size_t(&runId) << "', took: "
+        << std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - consolidationStart)
+               .count()
         << "ms";
   } else {
     LOG_TOPIC("bce4f", DEBUG, iresearch::TOPIC)
-        << "error after running for " <<
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-          std::chrono::steady_clock::now() - consolidationStart).count()
+        << "error after running for "
+        << std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - consolidationStart)
+               .count()
         << "ms while consolidating arangosearch link '" << linkPtr->id()
-        << "', run id '" << size_t(&runId)
-        << "': " << res.errorNumber() << " " << res.errorMessage();
+        << "', run id '" << size_t(&runId) << "': " << res.errorNumber() << " "
+        << res.errorMessage();
   }
 }
 
@@ -591,19 +585,15 @@ void ConsolidationTask::operator()() {
 // --SECTION--                                                     IResearchLink
 // -----------------------------------------------------------------------------
 
-
-AsyncLinkHandle::AsyncLinkHandle(IResearchLink* link)
-  : _link(link) {
+AsyncLinkHandle::AsyncLinkHandle(IResearchLink* link) : _link(link) {
   ++LinksCount;
 }
 
-AsyncLinkHandle::~AsyncLinkHandle() {
-  --LinksCount;
-}
+AsyncLinkHandle::~AsyncLinkHandle() { --LinksCount; }
 
 void AsyncLinkHandle::reset() {
-  _asyncTerminate.store(true); // mark long-running async jobs for terminatation
-  _link.reset(); // the data-store is being deallocated, link use is no longer valid (wait for all the view users to finish)
+  _asyncTerminate.store(true);  // mark long-running async jobs for terminatation
+  _link.reset();  // the data-store is being deallocated, link use is no longer valid (wait for all the view users to finish)
 }
 
 IResearchLink::IResearchLink(IndexId iid, LogicalCollection& collection)
@@ -618,7 +608,7 @@ IResearchLink::IResearchLink(IndexId iid, LogicalCollection& collection)
   auto* key = this;
 
   // initialize transaction callback
-  _trxCallback = [key](transaction::Methods& trx, transaction::Status status)->void {
+  _trxCallback = [key](transaction::Methods& trx, transaction::Status status) -> void {
     auto* state = trx.state();
     TRI_ASSERT(state != nullptr);
 
@@ -637,7 +627,7 @@ IResearchLink::IResearchLink(IndexId iid, LogicalCollection& collection)
       auto& ctx = static_cast<LinkTrxState&>(*prev);
 #endif
 
-      if (transaction::Status::COMMITTED != status) { // rollback
+      if (transaction::Status::COMMITTED != status) {  // rollback
         ctx.reset();
       } else {
         ctx._ctx.tick(state->lastOperationTick());
@@ -652,7 +642,8 @@ IResearchLink::~IResearchLink() {
   Result res;
   try {
     res = unload();  // disassociate from view if it has not been done yet
-  } catch (...) { }
+  } catch (...) {
+  }
 
   if (!res.ok()) {
     LOG_TOPIC("2b41f", ERR, iresearch::TOPIC)
@@ -669,8 +660,7 @@ bool IResearchLink::operator==(IResearchLinkMeta const& meta) const noexcept {
   return _meta == meta;
 }
 
-void IResearchLink::afterTruncate(TRI_voc_tick_t tick,
-                                  transaction::Methods* trx) {
+void IResearchLink::afterTruncate(TRI_voc_tick_t tick, transaction::Methods* trx) {
   auto lock = _asyncSelf->lock();  // '_dataStore' can be asynchronously modified
 
   TRI_IF_FAILURE("ArangoSearchTruncateFailure") {
@@ -700,23 +690,24 @@ void IResearchLink::afterTruncate(TRI_voc_tick_t tick,
 #endif
 
     if (ctx) {
-      ctx->reset(); // throw away all pending operations as clear will overwrite them all
-      state.cookie(key, nullptr); // force active segment release to allow commit go and avoid deadlock in clear
+      ctx->reset();  // throw away all pending operations as clear will overwrite them all
+      state.cookie(key, nullptr);  // force active segment release to allow commit go and avoid deadlock in clear
     }
   }
 
   auto const lastCommittedTick = _lastCommittedTick;
   bool recoverCommittedTick = true;
 
-  auto lastCommittedTickGuard = irs::make_finally([lastCommittedTick, this, &recoverCommittedTick]()->void {
-      if (recoverCommittedTick) {
-        _lastCommittedTick = lastCommittedTick;
-      }
-    });
+  auto lastCommittedTickGuard =
+      irs::make_finally([lastCommittedTick, this, &recoverCommittedTick]() -> void {
+        if (recoverCommittedTick) {
+          _lastCommittedTick = lastCommittedTick;
+        }
+      });
 
   try {
     _dataStore._writer->clear(tick);
-    recoverCommittedTick = false; //_lastCommittedTick now updated and data is written to storage
+    recoverCommittedTick = false;  //_lastCommittedTick now updated and data is written to storage
 
     // get new reader
     auto reader = _dataStore._reader.reopen();
@@ -724,8 +715,8 @@ void IResearchLink::afterTruncate(TRI_voc_tick_t tick,
     if (!reader) {
       // nothing more to do
       LOG_TOPIC("1c2c1", WARN, iresearch::TOPIC)
-        << "failed to update snapshot after truncate "
-        << ", reuse the existing snapshot for arangosearch link '" << id() << "'";
+          << "failed to update snapshot after truncate "
+          << ", reuse the existing snapshot for arangosearch link '" << id() << "'";
       return;
     }
 
@@ -756,7 +747,7 @@ void IResearchLink::afterTruncate(TRI_voc_tick_t tick,
 ////////////////////////////////////////////////////////////////////////////////
 Result IResearchLink::cleanupUnsafe() {
   // NOTE: assumes that '_asyncSelf' is read-locked (for use with async tasks)
-  TRI_ASSERT(_dataStore); // must be valid if _asyncSelf->get() is valid
+  TRI_ASSERT(_dataStore);  // must be valid if _asyncSelf->get() is valid
 
   try {
     irs::directory_utils::remove_all_unreferenced(*(_dataStore._directory));
@@ -774,7 +765,7 @@ Result IResearchLink::cleanupUnsafe() {
 }
 
 Result IResearchLink::commit(bool wait /*= true*/) {
-  auto lock = _asyncSelf->lock(); // '_dataStore' can be asynchronously modified
+  auto lock = _asyncSelf->lock();  // '_dataStore' can be asynchronously modified
 
   if (!_asyncSelf.get()) {
     // the current link is no longer valid (checked after ReadLock acquisition)
@@ -794,7 +785,7 @@ Result IResearchLink::commit(bool wait /*= true*/) {
 ////////////////////////////////////////////////////////////////////////////////
 Result IResearchLink::commitUnsafe(bool wait, CommitResult* code) {
   // NOTE: assumes that '_asyncSelf' is read-locked (for use with async tasks)
-  TRI_ASSERT(_dataStore); // must be valid if _asyncSelf->get() is valid
+  TRI_ASSERT(_dataStore);  // must be valid if _asyncSelf->get() is valid
 
   auto subscription = std::atomic_load(&_flushSubscription);
 
@@ -832,9 +823,7 @@ Result IResearchLink::commitUnsafe(bool wait, CommitResult* code) {
 
     try {
       // _lastCommittedTick is being updated in '_before_commit'
-      *code = _dataStore._writer->commit()
-        ? CommitResult::DONE
-        : CommitResult::NO_CHANGES;
+      *code = _dataStore._writer->commit() ? CommitResult::DONE : CommitResult::NO_CHANGES;
     } catch (...) {
       // restore last committed tick in case of any error
       _lastCommittedTick = lastCommittedTick;
@@ -859,7 +848,8 @@ Result IResearchLink::commitUnsafe(bool wait, CommitResult* code) {
       // nothing more to do
       LOG_TOPIC("37bcf", WARN, iresearch::TOPIC)
           << "failed to update snapshot after commit, reuse "
-             "the existing snapshot for arangosearch link '" << id() << "'";
+             "the existing snapshot for arangosearch link '"
+          << id() << "'";
 
       return {};
     }
@@ -875,15 +865,14 @@ Result IResearchLink::commitUnsafe(bool wait, CommitResult* code) {
     aql::QueryCache::instance()->invalidate(&(_collection.vocbase()), _viewGuid);
 
     LOG_TOPIC("7e328", DEBUG, iresearch::TOPIC)
-        << "successful sync of arangosearch link '" << id()
-        << "', segments '" << reader->size()
-        << "', docs count '" << reader->docs_count()
+        << "successful sync of arangosearch link '" << id() << "', segments '"
+        << reader->size() << "', docs count '" << reader->docs_count()
         << "', live docs count '" << reader->docs_count()
         << "', live docs count '" << reader->live_docs_count()
         << "', last operation tick '" << _lastCommittedTick << "'";
   } catch (basics::Exception const& e) {
     return {e.code(), "caught exception while committing arangosearch link '" +
-                       std::to_string(id().id()) + "': " + e.what()};
+                          std::to_string(id().id()) + "': " + e.what()};
   } catch (std::exception const& e) {
     return {TRI_ERROR_INTERNAL,
             "caught exception while committing arangosearch link '" +
@@ -891,7 +880,7 @@ Result IResearchLink::commitUnsafe(bool wait, CommitResult* code) {
   } catch (...) {
     return {TRI_ERROR_INTERNAL,
             "caught exception while committing arangosearch link '" +
-                std::to_string(id().id()) };
+                std::to_string(id().id())};
   }
 
   return {};
@@ -900,10 +889,9 @@ Result IResearchLink::commitUnsafe(bool wait, CommitResult* code) {
 ////////////////////////////////////////////////////////////////////////////////
 /// @note assumes that '_asyncSelf' is read-locked (for use with async tasks)
 ////////////////////////////////////////////////////////////////////////////////
-Result IResearchLink::consolidateUnsafe(
-    IResearchViewMeta::ConsolidationPolicy const& policy,
-    irs::merge_writer::flush_progress_t const& progress,
-    bool& emptyConsolidation) {
+Result IResearchLink::consolidateUnsafe(IResearchViewMeta::ConsolidationPolicy const& policy,
+                                        irs::merge_writer::flush_progress_t const& progress,
+                                        bool& emptyConsolidation) {
   emptyConsolidation = false;
 
   if (!policy.policy()) {
@@ -915,7 +903,7 @@ Result IResearchLink::consolidateUnsafe(
   }
 
   // NOTE: assumes that '_asyncSelf' is read-locked (for use with async tasks)
-  TRI_ASSERT(_dataStore); // must be valid if _asyncSelf->get() is valid
+  TRI_ASSERT(_dataStore);  // must be valid if _asyncSelf->get() is valid
 
   try {
     auto const res = _dataStore._writer->consolidate(policy.policy(), nullptr, progress);
@@ -967,12 +955,12 @@ Result IResearchLink::drop() {
           << "unable to find arangosearch view '" << _viewGuid
           << "' while dropping arangosearch link '" << _id.id() << "'";
     } else {
-      view->unlink(_collection.id()); // unlink before reset() to release lock in view (if any)
+      view->unlink(_collection.id());  // unlink before reset() to release lock in view (if any)
     }
   }
 
-  std::atomic_store(&_flushSubscription, {}); // reset together with '_asyncSelf'
-  _asyncSelf->reset(); // the data-store is being deallocated, link use is no longer valid (wait for all the view users to finish)
+  std::atomic_store(&_flushSubscription, {});  // reset together with '_asyncSelf'
+  _asyncSelf->reset();  // the data-store is being deallocated, link use is no longer valid (wait for all the view users to finish)
 
   try {
     if (_dataStore) {
@@ -982,8 +970,8 @@ Result IResearchLink::drop() {
     bool exists;
 
     // remove persisted data store directory if present
-    if (!irs::file_utils::exists_directory(exists, _dataStore._path.c_str())
-        || (exists && !irs::file_utils::remove(_dataStore._path.c_str()))) {
+    if (!irs::file_utils::exists_directory(exists, _dataStore._path.c_str()) ||
+        (exists && !irs::file_utils::remove(_dataStore._path.c_str()))) {
       return {TRI_ERROR_INTERNAL, "failed to remove arangosearch link '" +
                                       std::to_string(id().id()) + "'"};
     }
@@ -1004,15 +992,14 @@ Result IResearchLink::drop() {
 }
 
 bool IResearchLink::hasSelectivityEstimate() const {
-  return false; // selectivity can only be determined per query since multiple fields are indexed
+  return false;  // selectivity can only be determined per query since multiple fields are indexed
 }
 
-Result IResearchLink::init(
-    velocypack::Slice const& definition,
-    InitCallback const& initCallback /* = { }*/ ) {
+Result IResearchLink::init(velocypack::Slice const& definition,
+                           InitCallback const& initCallback /* = { }*/) {
   // disassociate from view if it has not been done yet
   if (!unload().ok()) {
-    return { TRI_ERROR_INTERNAL, "failed to unload link" };
+    return {TRI_ERROR_INTERNAL, "failed to unload link"};
   }
 
   std::string error;
@@ -1021,13 +1008,11 @@ Result IResearchLink::init(
   // definition should already be normalized and analyzers created if required
   if (!meta.init(_collection.vocbase().server(), definition, true, error,
                  _collection.vocbase().name())) {
-    return {
-      TRI_ERROR_BAD_PARAMETER,
-      "error parsing view link parameters from json: " + error
-    };
+    return {TRI_ERROR_BAD_PARAMETER,
+            "error parsing view link parameters from json: " + error};
   }
 
-  if (!definition.isObject() // not object
+  if (!definition.isObject()  // not object
       || !definition.get(StaticStrings::ViewIdField).isString()) {
     return {TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
             "error finding view for link '" + std::to_string(_id.id()) + "'"};
@@ -1038,10 +1023,9 @@ Result IResearchLink::init(
   bool const sorted = !meta._sort.empty();
   auto const& storedValuesColumns = meta._storedValues.columns();
   TRI_ASSERT(meta._sortCompression);
-  auto const primarySortCompression = meta._sortCompression
-      ? meta._sortCompression
-      : getDefaultCompression();
-  if (ServerState::instance()->isCoordinator()) { // coordinator link
+  auto const primarySortCompression =
+      meta._sortCompression ? meta._sortCompression : getDefaultCompression();
+  if (ServerState::instance()->isCoordinator()) {  // coordinator link
     if (!vocbase.server().hasFeature<ClusterFeature>()) {
       return {
           TRI_ERROR_INTERNAL,
@@ -1068,10 +1052,11 @@ Result IResearchLink::init(
                     std::to_string(_id.id()) + "'"};
       }
 
-      viewId = view->guid(); // ensue that this is a GUID (required by operator==(IResearchView))
-      std::swap(const_cast<IResearchLinkMeta&>(_meta), meta); // required for IResearchViewCoordinator which calls IResearchLink::properties(...)
+      viewId = view->guid();  // ensue that this is a GUID (required by operator==(IResearchView))
+      std::swap(const_cast<IResearchLinkMeta&>(_meta),
+                meta);  // required for IResearchViewCoordinator which calls IResearchLink::properties(...)
 
-      auto revert = irs::make_finally([this, &meta]()->void { // revert '_meta'
+      auto revert = irs::make_finally([this, &meta]() -> void {  // revert '_meta'
         std::swap(const_cast<IResearchLinkMeta&>(_meta), meta);
       });
       auto res = view->link(*this);
@@ -1080,7 +1065,7 @@ Result IResearchLink::init(
         return res;
       }
     }
-  } else if (ServerState::instance()->isDBServer()) { // db-server link
+  } else if (ServerState::instance()->isDBServer()) {  // db-server link
     if (!vocbase.server().hasFeature<ClusterFeature>()) {
       return {
           TRI_ERROR_INTERNAL,
@@ -1091,40 +1076,44 @@ Result IResearchLink::init(
       auto& ci = vocbase.server().getFeature<ClusterFeature>().clusterInfo();
 
       // cluster-wide link
-      auto clusterWideLink = _collection.id() == _collection.planId() && _collection.isAStub();
+      auto clusterWideLink =
+          _collection.id() == _collection.planId() && _collection.isAStub();
 
       // upgrade step for old link definition without collection name
       // this could be received from  agency while shard of the collection was moved (or added)
       // to the server.
       // New links already has collection name set, but here we must get this name on our own
       if (meta._collectionName.empty()) {
-        if (clusterWideLink) {// could set directly
-          LOG_TOPIC("86ecd", TRACE, iresearch::TOPIC) << "Setting collection name '" << _collection.name() << "' for new link '"
-            << this->id().id() << "'";
+        if (clusterWideLink) {  // could set directly
+          LOG_TOPIC("86ecd", TRACE, iresearch::TOPIC)
+              << "Setting collection name '" << _collection.name()
+              << "' for new link '" << this->id().id() << "'";
           meta._collectionName = _collection.name();
         } else {
           meta._collectionName = ci.getCollectionNameForShard(_collection.name());
-          LOG_TOPIC("86ece", TRACE, iresearch::TOPIC) << "Setting collection name '" << meta._collectionName << "' for new link '"
-            << this->id().id() << "'";
+          LOG_TOPIC("86ece", TRACE, iresearch::TOPIC)
+              << "Setting collection name '" << meta._collectionName
+              << "' for new link '" << this->id().id() << "'";
         }
         if (ADB_UNLIKELY(meta._collectionName.empty())) {
-          LOG_TOPIC("67da6", WARN, iresearch::TOPIC) << "Failed to init collection name for the link '"
-            << this->id().id() << "'. Link will not index '_id' attribute. Please recreate the link if this is necessary!";
+          LOG_TOPIC("67da6", WARN, iresearch::TOPIC)
+              << "Failed to init collection name for the link '"
+              << this->id().id() << "'. Link will not index '_id' attribute. Please recreate the link if this is necessary!";
         }
 
-  #ifdef USE_ENTERPRISE
+#ifdef USE_ENTERPRISE
         // enterprise name is not used in _id so should not be here!
         if (ADB_LIKELY(!meta._collectionName.empty())) {
           arangodb::ClusterMethods::realNameFromSmartName(meta._collectionName);
         }
-  #endif
+#endif
       }
 
       if (!clusterWideLink) {
         // prepare data-store which can then update options
         // via the IResearchView::link(...) call
-        auto const res = initDataStore(initCallback, meta._version,
-                                       sorted, storedValuesColumns, primarySortCompression);
+        auto const res = initDataStore(initCallback, meta._version, sorted,
+                                       storedValuesColumns, primarySortCompression);
 
         if (!res.ok()) {
           return res;
@@ -1137,7 +1126,7 @@ Result IResearchLink::init(
       // if there is no logicalView present yet then skip this step
       if (logicalView) {
         if (iresearch::DATA_SOURCE_TYPE != logicalView->type()) {
-          unload(); // unlock the data store directory
+          unload();  // unlock the data store directory
           return {TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
                   "error finding view: '" + viewId + "' for link '" +
                       std::to_string(_id.id()) + "' : no such view"};
@@ -1146,26 +1135,27 @@ Result IResearchLink::init(
         auto* view = LogicalView::cast<IResearchView>(logicalView.get());
 
         if (!view) {
-          unload(); // unlock the data store directory
+          unload();  // unlock the data store directory
           return {TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
                   "error finding view: '" + viewId + "' for link '" +
                       std::to_string(_id.id()) + "'"};
         }
 
-        viewId = view->guid(); // ensue that this is a GUID (required by operator==(IResearchView))
+        viewId = view->guid();  // ensue that this is a GUID (required by operator==(IResearchView))
 
-        if (clusterWideLink) { // cluster cluster-wide link
+        if (clusterWideLink) {  // cluster cluster-wide link
           auto shardIds = _collection.shardIds();
 
-          // go through all shard IDs of the collection and try to link any links
-          // missing links will be populated when they are created in the
+          // go through all shard IDs of the collection and try to link any
+          // links missing links will be populated when they are created in the
           // per-shard collection
           if (shardIds) {
             for (auto& entry : *shardIds) {
-              auto collection = vocbase.lookupCollection(entry.first); // per-shard collections are always in 'vocbase'
+              auto collection = vocbase.lookupCollection(
+                  entry.first);  // per-shard collections are always in 'vocbase'
 
               if (!collection) {
-                continue; // missing collection should be created after Plan becomes Current
+                continue;  // missing collection should be created after Plan becomes Current
               }
 
               auto link = IResearchLinkHelper::find(*collection, *view);
@@ -1179,25 +1169,25 @@ Result IResearchLink::init(
               }
             }
           }
-        } else { // cluster per-shard link
+        } else {  // cluster per-shard link
           auto res = view->link(_asyncSelf);
 
           if (!res.ok()) {
-            unload(); // unlock the data store directory
+            unload();  // unlock the data store directory
 
             return res;
           }
         }
       }
     } else {
-      LOG_TOPIC("67dd6", DEBUG, iresearch::TOPIC) << "Skipped link '"
-        << this->id().id() << "' due to disabled cluster features.";
+      LOG_TOPIC("67dd6", DEBUG, iresearch::TOPIC)
+          << "Skipped link '" << this->id().id() << "' due to disabled cluster features.";
     }
   } else if (ServerState::instance()->isSingleServer()) {  // single-server link
     // prepare data-store which can then update options
     // via the IResearchView::link(...) call
-    auto const res = initDataStore(initCallback, meta._version,
-                                   sorted, storedValuesColumns, primarySortCompression);
+    auto const res = initDataStore(initCallback, meta._version, sorted,
+                                   storedValuesColumns, primarySortCompression);
 
     if (!res.ok()) {
       return res;
@@ -1208,7 +1198,7 @@ Result IResearchLink::init(
     // if there is no logicalView present yet then skip this step
     if (logicalView) {
       if (iresearch::DATA_SOURCE_TYPE != logicalView->type()) {
-        unload(); // unlock the data store directory
+        unload();  // unlock the data store directory
 
         return {TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
                 "error finding view: '" + viewId + "' for link '" +
@@ -1218,19 +1208,19 @@ Result IResearchLink::init(
       auto* view = LogicalView::cast<IResearchView>(logicalView.get());
 
       if (!view) {
-        unload(); // unlock the data store directory
+        unload();  // unlock the data store directory
 
         return {TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
                 "error finding view: '" + viewId + "' for link '" +
                     std::to_string(_id.id()) + "'"};
       }
 
-      viewId = view->guid(); // ensue that this is a GUID (required by operator==(IResearchView))
+      viewId = view->guid();  // ensue that this is a GUID (required by operator==(IResearchView))
 
       auto res = view->link(_asyncSelf);
 
       if (!res.ok()) {
-        unload(); // unlock the directory
+        unload();  // unlock the directory
 
         return res;
       }
@@ -1244,14 +1234,12 @@ Result IResearchLink::init(
   return {};
 }
 
-Result IResearchLink::initDataStore(
-    InitCallback const& initCallback,
-    uint32_t version,
-    bool sorted,
-    std::vector<IResearchViewStoredValues::StoredColumn> const& storedColumns,
-    irs::type_info::type_id primarySortCompression) {
-  std::atomic_store(&_flushSubscription, {}); // reset together with '_asyncSelf'
-  _asyncSelf->reset(); // the data-store is being deallocated, link use is no longer valid (wait for all the view users to finish)
+Result IResearchLink::initDataStore(InitCallback const& initCallback,
+                                    uint32_t version, bool sorted,
+                                    std::vector<IResearchViewStoredValues::StoredColumn> const& storedColumns,
+                                    irs::type_info::type_id primarySortCompression) {
+  std::atomic_store(&_flushSubscription, {});  // reset together with '_asyncSelf'
+  _asyncSelf->reset();  // the data-store is being deallocated, link use is no longer valid (wait for all the view users to finish)
 
   auto& server = _collection.vocbase().server();
   if (!server.hasFeature<DatabasePathFeature>()) {
@@ -1274,7 +1262,7 @@ Result IResearchLink::initDataStore(
   if (!format) {
     return {TRI_ERROR_INTERNAL,
             "failed to get data store codec '"s + formatId.data() +
-             "' while initializing link '" + std::to_string(_id.id()) + "'"};
+                "' while initializing link '" + std::to_string(_id.id()) + "'"};
   }
 
   _engine = &server.getFeature<EngineSelectorFeature>().engine();
@@ -1285,18 +1273,19 @@ Result IResearchLink::initDataStore(
 
   // must manually ensure that the data store directory exists (since not using
   // a lockfile)
-  if (irs::file_utils::exists_directory(pathExists, _dataStore._path.c_str())
-      && !pathExists
-      && !irs::file_utils::mkdir(_dataStore._path.c_str(), true)) {
+  if (irs::file_utils::exists_directory(pathExists, _dataStore._path.c_str()) &&
+      !pathExists && !irs::file_utils::mkdir(_dataStore._path.c_str(), true)) {
     return {TRI_ERROR_CANNOT_CREATE_DIRECTORY,
             "failed to create data store directory with path '" +
                 _dataStore._path.string() + "' while initializing link '" +
                 std::to_string(_id.id()) + "'"};
   }
   if (initCallback) {
-    _dataStore._directory = std::make_unique<irs::mmap_directory>(_dataStore._path.u8string(), initCallback());
+    _dataStore._directory =
+        std::make_unique<irs::mmap_directory>(_dataStore._path.u8string(), initCallback());
   } else {
-    _dataStore._directory = std::make_unique<irs::mmap_directory>(_dataStore._path.u8string());
+    _dataStore._directory =
+        std::make_unique<irs::mmap_directory>(_dataStore._path.u8string());
   }
 
   if (!_dataStore._directory) {
@@ -1306,17 +1295,15 @@ Result IResearchLink::initDataStore(
                 std::to_string(_id.id()) + "'"};
   }
 
-  
-
   switch (_engine->recoveryState()) {
-    case RecoveryState::BEFORE: // link is being opened before recovery
-    case RecoveryState::DONE: { // link is being created after recovery
-      _dataStore._inRecovery = true; // will be adjusted in post-recovery callback
+    case RecoveryState::BEFORE:       // link is being opened before recovery
+    case RecoveryState::DONE: {       // link is being created after recovery
+      _dataStore._inRecovery = true;  // will be adjusted in post-recovery callback
       _dataStore._recoveryTick = _engine->recoveryTick();
       break;
     }
 
-    case RecoveryState::IN_PROGRESS: { // link is being created during recovery
+    case RecoveryState::IN_PROGRESS: {  // link is being created during recovery
       // both MMFiles and RocksDB will fill out link based on
       // actual data in linked collections, we can treat recovery as done
       _createdInRecovery = true;
@@ -1350,10 +1337,9 @@ Result IResearchLink::initDataStore(
   _lastCommittedTick = _dataStore._recoveryTick;
   _flushSubscription.reset(new IResearchFlushSubscription(_dataStore._recoveryTick));
 
-
   irs::index_writer::init_options options;
-  options.lock_repository = false; // do not lock index, ArangoDB has its own lock
-  options.comparator = sorted ? &_comparer : nullptr; // set comparator if requested
+  options.lock_repository = false;  // do not lock index, ArangoDB has its own lock
+  options.comparator = sorted ? &_comparer : nullptr;  // set comparator if requested
   options.features[irs::type<irs::granularity_prefix>::id()] = nullptr;
   if (LinkVersion(version) < LinkVersion::MAX) {
     options.features[irs::type<irs::norm>::id()] = &irs::norm::compute;
@@ -1362,8 +1348,8 @@ Result IResearchLink::initDataStore(
   }
   // initialize commit callback
   options.meta_payload_provider = [this](uint64_t tick, irs::bstring& out) {
-    _lastCommittedTick = std::max(_lastCommittedTick, TRI_voc_tick_t(tick)); // update last tick
-    tick = irs::numeric_utils::hton64(uint64_t(_lastCommittedTick)); // convert to BE
+    _lastCommittedTick = std::max(_lastCommittedTick, TRI_voc_tick_t(tick));  // update last tick
+    tick = irs::numeric_utils::hton64(uint64_t(_lastCommittedTick));  // convert to BE
 
     out.append(reinterpret_cast<irs::byte_type const*>(&tick), sizeof(uint64_t));
 
@@ -1384,27 +1370,27 @@ Result IResearchLink::initDataStore(
   }
   // setup columnstore compression/encryption if requested by storage engine
   auto const encrypt = (nullptr != _dataStore._directory->attributes().encryption());
-  options.column_info =
-    [encrypt, comprMap = std::move(compressionMap), primarySortCompression](
-        const irs::string_ref& name) -> irs::column_info {
-      if (name.null()) {
-        return { primarySortCompression(), {}, encrypt };
-      }
-      auto compress = comprMap.find(static_cast<std::string>(name)); // FIXME: remove cast after C++20
-      if (compress != comprMap.end()) {
-        // do not waste resources to encrypt primary key column
-        return { compress->second(), {}, encrypt && (DocumentPrimaryKey::PK() != name) };
-      } else {
-        return { getDefaultCompression()(), {}, encrypt && (DocumentPrimaryKey::PK() != name) };
-      }
-    };
+  options.column_info = [encrypt, comprMap = std::move(compressionMap),
+                         primarySortCompression](const irs::string_ref& name) -> irs::column_info {
+    if (name.null()) {
+      return {primarySortCompression(), {}, encrypt};
+    }
+    auto compress = comprMap.find(static_cast<std::string>(name));  // FIXME: remove cast after C++20
+    if (compress != comprMap.end()) {
+      // do not waste resources to encrypt primary key column
+      return {compress->second(), {}, encrypt && (DocumentPrimaryKey::PK() != name)};
+    } else {
+      return {getDefaultCompression()(), {}, encrypt && (DocumentPrimaryKey::PK() != name)};
+    }
+  };
 
   auto openFlags = irs::OM_APPEND;
   if (!_dataStore._reader) {
     openFlags |= irs::OM_CREATE;
   }
 
-  _dataStore._writer = irs::index_writer::make(*(_dataStore._directory), format, openFlags, options);
+  _dataStore._writer =
+      irs::index_writer::make(*(_dataStore._directory), format, openFlags, options);
 
   if (!_dataStore._writer) {
     return {TRI_ERROR_INTERNAL,
@@ -1414,7 +1400,7 @@ Result IResearchLink::initDataStore(
   }
 
   if (!_dataStore._reader) {
-    _dataStore._writer->commit(); // initialize 'store'
+    _dataStore._writer->commit();  // initialize 'store'
     _dataStore._reader = irs::directory_reader::open(*(_dataStore._directory));
   }
 
@@ -1438,10 +1424,10 @@ Result IResearchLink::initDataStore(
       << "' is initialized with recovery tick '" << _dataStore._recoveryTick << "'";
 
   // reset data store meta, will be updated at runtime via properties(...)
-  _dataStore._meta._cleanupIntervalStep = 0; // 0 == disable
-  _dataStore._meta._commitIntervalMsec = 0; // 0 == disable
-  _dataStore._meta._consolidationIntervalMsec = 0; // 0 == disable
-  _dataStore._meta._consolidationPolicy = IResearchViewMeta::ConsolidationPolicy(); // disable
+  _dataStore._meta._cleanupIntervalStep = 0;        // 0 == disable
+  _dataStore._meta._commitIntervalMsec = 0;         // 0 == disable
+  _dataStore._meta._consolidationIntervalMsec = 0;  // 0 == disable
+  _dataStore._meta._consolidationPolicy = IResearchViewMeta::ConsolidationPolicy();  // disable
   _dataStore._meta._writebufferActive = options.segment_count_max;
   _dataStore._meta._writebufferIdle = options.segment_pool_size;
   _dataStore._meta._writebufferSizeMax = options.segment_memory_max;
@@ -1454,7 +1440,7 @@ Result IResearchLink::initDataStore(
   // ...........................................................................
 
   if (!server.hasFeature<DatabaseFeature>()) {
-    return {}; // nothing more to do
+    return {};  // nothing more to do
   }
   auto& dbFeature = server.getFeature<DatabaseFeature>();
 
@@ -1530,7 +1516,7 @@ void IResearchLink::scheduleConsolidation(std::chrono::milliseconds delay) {
   task.async = _asyncFeature;
   task.id = id();
   task.state = _maintenanceState;
-  task.progress = [link = _asyncSelf.get()](){
+  task.progress = [link = _asyncSelf.get()]() {
     return !link->terminationRequested();
   };
 
@@ -1538,10 +1524,8 @@ void IResearchLink::scheduleConsolidation(std::chrono::milliseconds delay) {
   task.schedule(delay);
 }
 
-Result IResearchLink::insert(
-    transaction::Methods& trx,
-    LocalDocumentId const& documentId,
-    velocypack::Slice const doc) {
+Result IResearchLink::insert(transaction::Methods& trx, LocalDocumentId const& documentId,
+                             velocypack::Slice const doc) {
   TRI_ASSERT(_engine);
   TRI_ASSERT(trx.state());
 
@@ -1549,14 +1533,14 @@ Result IResearchLink::insert(
 
   if (_dataStore._inRecovery && _engine->recoveryTick() <= _dataStore._recoveryTick) {
     LOG_TOPIC("7c228", TRACE, iresearch::TOPIC)
-      << "skipping 'insert', operation tick '" << _engine->recoveryTick()
-      << "', recovery tick '" << _dataStore._recoveryTick << "'";
+        << "skipping 'insert', operation tick '" << _engine->recoveryTick()
+        << "', recovery tick '" << _dataStore._recoveryTick << "'";
 
     return {};
   }
 
-  auto insertImpl = [this, &trx, &doc, &documentId](
-                        irs::index_writer::documents_context& ctx) -> Result {
+  auto insertImpl = [this, &trx, &doc,
+                     &documentId](irs::index_writer::documents_context& ctx) -> Result {
     try {
       FieldIterator body(trx, _meta._collectionName, _id);
 
@@ -1593,7 +1577,7 @@ Result IResearchLink::insert(
     auto ctx = _dataStore._writer->documents();
 
     TRI_IF_FAILURE("ArangoSearch::MisreportCreationInsertAsFailed") {
-      auto res = insertImpl(ctx); // we need insert to succeed, so  we have things to cleanup in storage
+      auto res = insertImpl(ctx);  // we need insert to succeed, so  we have things to cleanup in storage
       if (res.fail()) {
         return res;
       }
@@ -1622,16 +1606,16 @@ Result IResearchLink::insert(
                   std::to_string(id().id()) + "'"};
     }
 
-    TRI_ASSERT(_dataStore); // must be valid if _asyncSelf->get() is valid
+    TRI_ASSERT(_dataStore);  // must be valid if _asyncSelf->get() is valid
 
-//FIXME try to preserve optimization
-//    // optimization for single-document insert-only transactions
-//    if (trx.isSingleOperationTransaction() // only for single-docuemnt transactions
-//        && !_dataStore._inRecovery) {
-//      auto ctx = _dataStore._writer->documents();
-//
-//      return insertImpl(ctx);
-//    }
+    // FIXME try to preserve optimization
+    //     // optimization for single-document insert-only transactions
+    //     if (trx.isSingleOperationTransaction() // only for single-docuemnt transactions
+    //         && !_dataStore._inRecovery) {
+    //       auto ctx = _dataStore._writer->documents();
+    //
+    //       return insertImpl(ctx);
+    //     }
 
     auto ptr = std::make_unique<LinkTrxState>(std::move(lock), *(_dataStore._writer));
 
@@ -1652,11 +1636,11 @@ Result IResearchLink::insert(
 }
 
 bool IResearchLink::isHidden() const {
-  return !ServerState::instance()->isDBServer(); // hide links unless we are on a DBServer
+  return !ServerState::instance()->isDBServer();  // hide links unless we are on a DBServer
 }
 
 bool IResearchLink::isSorted() const {
-  return false; // IResearch does not provide a fixed default sort order
+  return false;  // IResearch does not provide a fixed default sort order
 }
 
 void IResearchLink::load() {
@@ -1665,7 +1649,7 @@ void IResearchLink::load() {
 
 bool IResearchLink::matchesDefinition(VPackSlice const& slice) const {
   if (!slice.isObject() || !slice.hasKey(StaticStrings::ViewIdField)) {
-    return false; // slice has no view identifier field
+    return false;  // slice has no view identifier field
   }
 
   auto viewId = slice.get(StaticStrings::ViewIdField);
@@ -1673,7 +1657,7 @@ bool IResearchLink::matchesDefinition(VPackSlice const& slice) const {
   // NOTE: below will not match if 'viewId' is 'id' or 'name',
   //       but ViewIdField should always contain GUID
   if (!viewId.isString() || !viewId.isEqualString(_viewGuid)) {
-    return false; // IResearch View identifiers of current object and slice do not match
+    return false;  // IResearch View identifiers of current object and slice do not match
   }
 
   IResearchLinkMeta other;
@@ -1684,9 +1668,7 @@ bool IResearchLink::matchesDefinition(VPackSlice const& slice) const {
          && _meta == other;
 }
 
-Result IResearchLink::properties(
-    velocypack::Builder& builder,
-    bool forPersistence) const {
+Result IResearchLink::properties(velocypack::Builder& builder, bool forPersistence) const {
   if (!builder.isOpenObject()  // not an open object
       || !_meta.json(_collection.vocbase().server(), builder, forPersistence,
                      nullptr, &(_collection.vocbase()))) {
@@ -1695,9 +1677,8 @@ Result IResearchLink::properties(
 
   builder.add(arangodb::StaticStrings::IndexId,
               velocypack::Value(std::to_string(_id.id())));
-  builder.add(
-    arangodb::StaticStrings::IndexType,
-    velocypack::Value(IResearchLinkHelper::type()));
+  builder.add(arangodb::StaticStrings::IndexType,
+              velocypack::Value(IResearchLinkHelper::type()));
   builder.add(StaticStrings::ViewIdField, velocypack::Value(_viewGuid));
 
   return {};
@@ -1718,7 +1699,7 @@ Result IResearchLink::properties(IResearchViewMeta const& meta) {
   TRI_ASSERT(_dataStore);  // must be valid if _asyncSelf->get() is valid
 
   {
-    WRITE_LOCKER(lock, _dataStore._mutex); // '_meta' can be asynchronously modified
+    WRITE_LOCKER(lock, _dataStore._mutex);  // '_meta' can be asynchronously modified
     _dataStore._meta = meta;
   }
 
@@ -1742,10 +1723,8 @@ Result IResearchLink::properties(IResearchViewMeta const& meta) {
   return {};
 }
 
-Result IResearchLink::remove(
-    transaction::Methods& trx,
-    LocalDocumentId const& documentId,
-    velocypack::Slice const /*doc*/) {
+Result IResearchLink::remove(transaction::Methods& trx, LocalDocumentId const& documentId,
+                             velocypack::Slice const /*doc*/) {
   TRI_ASSERT(_engine);
   TRI_ASSERT(trx.state());
 
@@ -1755,8 +1734,8 @@ Result IResearchLink::remove(
 
   if (_dataStore._inRecovery && _engine->recoveryTick() <= _dataStore._recoveryTick) {
     LOG_TOPIC("7d228", TRACE, iresearch::TOPIC)
-      << "skipping 'removal', operation tick '" << _engine->recoveryTick()
-      << "', recovery tick '" << _dataStore._recoveryTick << "'";
+        << "skipping 'removal', operation tick '" << _engine->recoveryTick()
+        << "', recovery tick '" << _dataStore._recoveryTick << "'";
 
     return {};
   }
@@ -1785,10 +1764,10 @@ Result IResearchLink::remove(
                   std::to_string(documentId.id()) + "'"};
     }
 
-    TRI_ASSERT(_dataStore); // must be valid if _asyncSelf->get() is valid
+    TRI_ASSERT(_dataStore);  // must be valid if _asyncSelf->get() is valid
 
-    auto ptr = irs::memory::make_unique<LinkTrxState>(
-      std::move(lock), *(_dataStore._writer));
+    auto ptr = irs::memory::make_unique<LinkTrxState>(std::move(lock),
+                                                      *(_dataStore._writer));
 
     ctx = ptr.get();
     state.cookie(key, std::move(ptr));
@@ -1870,8 +1849,8 @@ bool IResearchLink::setCollectionName(irs::string_ref name) noexcept {
     return true;
   }
   LOG_TOPIC_IF("5573c", ERR, iresearch::TOPIC, name != _meta._collectionName)
-        << "Collection name mismatch for arangosearch link '" << id() << "'."
-        << " Meta name '" << _meta._collectionName << "' setting name '" << name << "'";
+      << "Collection name mismatch for arangosearch link '" << id() << "'."
+      << " Meta name '" << _meta._collectionName << "' setting name '" << name << "'";
   TRI_ASSERT(name == _meta._collectionName);
   return false;
 }
@@ -1880,13 +1859,13 @@ Result IResearchLink::unload() {
   // this code is used by the MMFilesEngine
   // if the collection is in the process of being removed then drop it from the view
   // FIXME TODO remove once LogicalCollection::drop(...) will drop its indexes explicitly
-  if (_collection.deleted() // collection deleted
+  if (_collection.deleted()  // collection deleted
       || TRI_vocbase_col_status_e::TRI_VOC_COL_STATUS_DELETED == _collection.status()) {
     return drop();
   }
 
-  std::atomic_store(&_flushSubscription, {}); // reset together with '_asyncSelf'
-  _asyncSelf->reset(); // the data-store is being deallocated, link use is no longer valid (wait for all the view users to finish)
+  std::atomic_store(&_flushSubscription, {});  // reset together with '_asyncSelf'
+  _asyncSelf->reset();  // the data-store is being deallocated, link use is no longer valid (wait for all the view users to finish)
 
   try {
     if (_dataStore) {
@@ -1947,7 +1926,7 @@ IResearchLink::Stats IResearchLink::stats() const {
     stats.numSegments = reader->size();
     stats.docsCount = reader->docs_count();
     stats.liveDocsCount = reader->live_docs_count();
-    stats.numFiles = 1; // +1 for segments file
+    stats.numFiles = 1;  // +1 for segments file
 
     auto visitor = [&stats](std::string const& /*name*/,
                             irs::segment_meta const& segment) noexcept {

--- a/arangod/IResearch/IResearchLink.cpp
+++ b/arangod/IResearch/IResearchLink.cpp
@@ -424,33 +424,32 @@ void CommitTask::operator()() {
     LOG_TOPIC("7e323", TRACE, iresearch::TOPIC)
         << "successful sync of arangosearch link '" << id << "', run id '"
         << size_t(&runId) << '\'';
-    if (code == IResearchLink::CommitResult::DONE) {
-      if (cleanupIntervalStep && cleanupIntervalCount++ > cleanupIntervalStep) {  // if enabled
-        cleanupIntervalCount = 0;
-
-        TRI_IF_FAILURE("IResearchCommitTask::cleanupUnsafe") {
-          THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
-        }
-
-        res = linkPtr->cleanupUnsafe();  // run cleanup ('_asyncSelf' locked by async task)
-
-        if (res.ok()) {
-          LOG_TOPIC("7e821", TRACE, iresearch::TOPIC)
-              << "successful cleanup of arangosearch link '" << id
-              << "', run id '" << size_t(&runId) << '\'';
-        } else {
-          LOG_TOPIC("130de", WARN, iresearch::TOPIC)
-              << "error after cleaning up arangosearch link '" << id
-              << "', run id '" << size_t(&runId) << "': " << res.errorNumber()
-              << " " << res.errorMessage();
-        }
-      }
-    }
   } else {
     LOG_TOPIC("8377b", WARN, iresearch::TOPIC)
         << "error after committing arangosearch link '" << linkPtr->id()
         << "', run id '" << size_t(&runId) << "': " << res.errorNumber() << " "
         << res.errorMessage();
+  }
+
+  if (cleanupIntervalStep && ++cleanupIntervalCount >= cleanupIntervalStep) {  // if enabled
+    cleanupIntervalCount = 0;
+
+    TRI_IF_FAILURE("IResearchCommitTask::cleanupUnsafe") {
+      THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
+    }
+
+    res = linkPtr->cleanupUnsafe();  // run cleanup ('_asyncSelf' locked by async task)
+
+    if (res.ok()) {
+      LOG_TOPIC("7e821", TRACE, iresearch::TOPIC)
+          << "successful cleanup of arangosearch link '" << id << "', run id '"
+          << size_t(&runId) << '\'';
+    } else {
+      LOG_TOPIC("130de", WARN, iresearch::TOPIC)
+          << "error after cleaning up arangosearch link '" << id
+          << "', run id '" << size_t(&runId) << "': " << res.errorNumber()
+          << " " << res.errorMessage();
+    }
   }
 }
 

--- a/arangod/IResearch/IResearchLink.h
+++ b/arangod/IResearch/IResearchLink.h
@@ -416,6 +416,21 @@ class IResearchLink {
   //////////////////////////////////////////////////////////////////////////////
   void removeStats();
 
+  //////////////////////////////////////////////////////////////////////////////
+  /// @brief Add statistic about failed commit
+  //////////////////////////////////////////////////////////////////////////////
+  void wasFailedCommit();
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// @brief Add statistic about failed cleanup
+  //////////////////////////////////////////////////////////////////////////////
+  void wasFailedCleanup();
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// @brief Add statistic about failed consolidation
+  //////////////////////////////////////////////////////////////////////////////
+  void wasFailedConsolidation();
+
   StorageEngine* _engine;
   VPackComparer _comparer;
   IResearchFeature* _asyncFeature;  // the feature where async jobs were registered (nullptr == no jobs registered)
@@ -432,6 +447,12 @@ class IResearchLink {
   std::string const _viewGuid;  // the identifier of the desired view (read-only, set via init())
   bool _createdInRecovery;  // link was created based on recovery marker
   GuardMetric<LinkStats>* _linkStats;
+  Gauge<uint64_t>* _numFailedCommits;
+  Gauge<uint64_t>* _numFailedCleanups;
+  Gauge<uint64_t>* _numFailedConsolidations;
+  Gauge<uint64_t>* _allCommitTimeMs;
+  Gauge<uint64_t>* _allCleanupTimeMs;
+  Gauge<uint64_t>* _allConsolidationTimeMs;
 };
 
 irs::utf8_path getPersistedPath(DatabasePathFeature const& dbPathFeature,

--- a/arangod/IResearch/IResearchLink.h
+++ b/arangod/IResearch/IResearchLink.h
@@ -29,10 +29,10 @@
 #include "store/directory.hpp"
 #include "utils/utf8_path.hpp"
 
-#include "Indexes/Index.h"
 #include "IResearch/IResearchLinkMeta.h"
 #include "IResearch/IResearchVPackComparer.h"
 #include "IResearch/IResearchViewMeta.h"
+#include "Indexes/Index.h"
 #include "RestServer/DatabasePathFeature.h"
 #include "Transaction/Status.h"
 #include "Utils/OperationOptions.h"
@@ -72,8 +72,8 @@ class AsyncLinkHandle {
   void reset();
 
   AsyncValue<IResearchLink> _link;
-  std::atomic<bool> _asyncTerminate{false}; // trigger termination of long-running async jobs
-}; // AsyncLinkHandle
+  std::atomic<bool> _asyncTerminate{false};  // trigger termination of long-running async jobs
+};                                           // AsyncLinkHandle
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief common base class for functionality required to link an ArangoDB
@@ -91,14 +91,12 @@ class IResearchLink {
   class Snapshot {
    public:
     Snapshot() = default;
-    Snapshot(AsyncValue<IResearchLink>::Value&& lock,
-             irs::directory_reader&& reader) noexcept
+    Snapshot(AsyncValue<IResearchLink>::Value&& lock, irs::directory_reader&& reader) noexcept
         : _lock(std::move(lock)), _reader(std::move(reader)) {
       TRI_ASSERT(_lock.ownsLock());
     }
     Snapshot(Snapshot&& rhs) noexcept
-      : _lock(std::move(rhs._lock)),
-        _reader(std::move(rhs._reader)) {
+        : _lock(std::move(rhs._lock)), _reader(std::move(rhs._reader)) {
       TRI_ASSERT(_lock.ownsLock());
     }
     Snapshot& operator=(Snapshot&& rhs) noexcept {
@@ -109,12 +107,10 @@ class IResearchLink {
       TRI_ASSERT(_lock.ownsLock());
       return *this;
     }
-    operator irs::directory_reader const&() const noexcept {
-      return _reader;
-    }
+    operator irs::directory_reader const&() const noexcept { return _reader; }
 
    private:
-    AsyncValue<IResearchLink>::Value _lock; // lock preventing data store dealocation
+    AsyncValue<IResearchLink>::Value _lock;  // lock preventing data store dealocation
     irs::directory_reader _reader;
   };
 
@@ -137,7 +133,7 @@ class IResearchLink {
   }
 
   void afterTruncate(TRI_voc_tick_t tick,
-                     transaction::Methods* trx); // arangodb::Index override
+                     transaction::Methods* trx);  // arangodb::Index override
 
   bool canBeDropped() const {
     // valid for a link to be dropped from an ArangoSearch view
@@ -148,9 +144,7 @@ class IResearchLink {
   /// @return the associated collection
   /// @note arangodb::Index override
   //////////////////////////////////////////////////////////////////////////////
-  LogicalCollection& collection() const noexcept {
-    return _collection;
-  }
+  LogicalCollection& collection() const noexcept { return _collection; }
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief mark the current data store state as the latest valid state
@@ -164,7 +158,7 @@ class IResearchLink {
   ////////////////////////////////////////////////////////////////////////////////
   Result drop();
 
-  bool hasSelectivityEstimate() const; // arangodb::Index override
+  bool hasSelectivityEstimate() const;  // arangodb::Index override
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief the identifier for this link
@@ -175,12 +169,11 @@ class IResearchLink {
   /// @brief insert an ArangoDB document into an iResearch View using '_meta' params
   /// @note arangodb::Index override
   ////////////////////////////////////////////////////////////////////////////////
-  Result insert(transaction::Methods& trx,
-                LocalDocumentId const& documentId,
+  Result insert(transaction::Methods& trx, LocalDocumentId const& documentId,
                 velocypack::Slice const doc);
 
   bool isHidden() const;  // arangodb::Index override
-  bool isSorted() const; // arangodb::Index override
+  bool isSorted() const;  // arangodb::Index override
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief called when the iResearch Link is loaded into memory
@@ -217,8 +210,7 @@ class IResearchLink {
   /// @brief remove an ArangoDB document from an iResearch View
   /// @note arangodb::Index override
   ////////////////////////////////////////////////////////////////////////////////
-  Result remove(transaction::Methods& trx,
-                LocalDocumentId const& documentId,
+  Result remove(transaction::Methods& trx, LocalDocumentId const& documentId,
                 velocypack::Slice const doc);
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -261,8 +253,7 @@ class IResearchLink {
   /// @brief initialize from the specified definition used in make(...)
   /// @return success
   ////////////////////////////////////////////////////////////////////////////////
-  Result init(velocypack::Slice const& definition,
-              InitCallback const& initCallback = {});
+  Result init(velocypack::Slice const& definition, InitCallback const& initCallback = {});
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @return arangosearch internal format identifier
@@ -277,7 +268,7 @@ class IResearchLink {
   /// @brief sets the _collectionName in Link meta. Used in cluster only to store
   /// linked collection name (as shard name differs from the cluster-wide collection name)
   /// @param name  collectioName to set. Should match existing value of  the _collectionName
-  /// if it is not empty. 
+  /// if it is not empty.
   /// @return true if name not existed in link before and was actually set by this call,
   /// false otherwise
   bool setCollectionName(irs::string_ref name) noexcept;
@@ -287,12 +278,12 @@ class IResearchLink {
   /// @brief index stats
   //////////////////////////////////////////////////////////////////////////////
   struct Stats {
-    size_t docsCount{};       // total number of documents
-    size_t liveDocsCount{};   // number of live documents
-    size_t numBufferedDocs{}; // number of buffered docs
-    size_t indexSize{};       // size of the index in bytes
-    size_t numSegments{};     // number of segments
-    size_t numFiles{};        // number of files
+    size_t docsCount{};        // total number of documents
+    size_t liveDocsCount{};    // number of live documents
+    size_t numBufferedDocs{};  // number of buffered docs
+    size_t indexSize{};        // size of the index in bytes
+    size_t numSegments{};      // number of segments
+    size_t numFiles{};         // number of files
   };
 
  protected:
@@ -339,24 +330,24 @@ class IResearchLink {
     /// @brief commit is done
     ////////////////////////////////////////////////////////////////////////////
     DONE
-  }; // CommitResult
+  };  // CommitResult
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief the underlying iresearch data store
   //////////////////////////////////////////////////////////////////////////////
   struct DataStore {
-    IResearchViewMeta _meta; // runtime meta for a data store (not persisted)
+    IResearchViewMeta _meta;  // runtime meta for a data store (not persisted)
     irs::directory::ptr _directory;
-    basics::ReadWriteLock _mutex; // for use with member '_meta'
+    basics::ReadWriteLock _mutex;  // for use with member '_meta'
     irs::utf8_path _path;
     irs::directory_reader _reader;
     irs::index_writer::ptr _writer;
-    TRI_voc_tick_t _recoveryTick{ 0 }; // the tick at which data store was recovered
-    std::atomic<bool> _inRecovery{ false }; // data store is in recovery
+    TRI_voc_tick_t _recoveryTick{0};  // the tick at which data store was recovered
+    std::atomic<bool> _inRecovery{false};  // data store is in recovery
     operator bool() const noexcept { return _directory && _writer; }
 
-    void resetDataStore() noexcept { // reset all underlying readers to release file handles 
-      _reader.reset(); 
+    void resetDataStore() noexcept {  // reset all underlying readers to release file handles
+      _reader.reset();
       _writer.reset();
       _directory.reset();
     }
@@ -379,20 +370,16 @@ class IResearchLink {
   /// @brief run segment consolidation on the data store
   /// @note assumes that '_asyncSelf' is read-locked (for use with async tasks)
   //////////////////////////////////////////////////////////////////////////////
-  Result consolidateUnsafe(
-    IResearchViewMeta::ConsolidationPolicy const& policy,
-    irs::merge_writer::flush_progress_t const& progress,
-    bool& emptyConsolidation);
+  Result consolidateUnsafe(IResearchViewMeta::ConsolidationPolicy const& policy,
+                           irs::merge_writer::flush_progress_t const& progress,
+                           bool& emptyConsolidation);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief initialize the data store with a new or from an existing directory
   //////////////////////////////////////////////////////////////////////////////
-  Result initDataStore(
-    InitCallback const& initCallback,
-    uint32_t version,
-    bool sorted,
-    std::vector<IResearchViewStoredValues::StoredColumn> const& storedColumns,
-    irs::type_info::type_id primarySortCompression);
+  Result initDataStore(InitCallback const& initCallback, uint32_t version, bool sorted,
+                       std::vector<IResearchViewStoredValues::StoredColumn> const& storedColumns,
+                       irs::type_info::type_id primarySortCompression);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief schedule a commit job
@@ -406,24 +393,23 @@ class IResearchLink {
 
   StorageEngine* _engine;
   VPackComparer _comparer;
-  IResearchFeature* _asyncFeature; // the feature where async jobs were registered (nullptr == no jobs registered)
-  AsyncLinkPtr _asyncSelf; // 'this' for the lifetime of the link (for use with asynchronous calls)
-  LogicalCollection& _collection; // the linked collection
-  DataStore _dataStore; // the iresearch data store, protected by _asyncSelf->mutex()
+  IResearchFeature* _asyncFeature;  // the feature where async jobs were registered (nullptr == no jobs registered)
+  AsyncLinkPtr _asyncSelf;  // 'this' for the lifetime of the link (for use with asynchronous calls)
+  LogicalCollection& _collection;  // the linked collection
+  DataStore _dataStore;  // the iresearch data store, protected by _asyncSelf->mutex()
   std::shared_ptr<FlushSubscription> _flushSubscription;
   std::shared_ptr<MaintenanceState> _maintenanceState;
-  IndexId const _id;                 // the index identifier
-  TRI_voc_tick_t _lastCommittedTick; // protected by _commitMutex
-  IResearchLinkMeta const _meta; // how this collection should be indexed (read-only, set via init())
-  std::mutex _commitMutex; // prevents data store sequential commits
-  std::function<void(transaction::Methods& trx, transaction::Status status)> _trxCallback; // for insert(...)/remove(...)
-  std::string const _viewGuid; // the identifier of the desired view (read-only, set via init())
-  bool _createdInRecovery; // link was created based on recovery marker
-};  // IResearchLink
+  IndexId const _id;                  // the index identifier
+  TRI_voc_tick_t _lastCommittedTick;  // protected by _commitMutex
+  IResearchLinkMeta const _meta;  // how this collection should be indexed (read-only, set via init())
+  std::mutex _commitMutex;  // prevents data store sequential commits
+  std::function<void(transaction::Methods& trx, transaction::Status status)> _trxCallback;  // for insert(...)/remove(...)
+  std::string const _viewGuid;  // the identifier of the desired view (read-only, set via init())
+  bool _createdInRecovery;  // link was created based on recovery marker
+};                          // IResearchLink
 
 irs::utf8_path getPersistedPath(DatabasePathFeature const& dbPathFeature,
                                 iresearch::IResearchLink const& link);
 
 }  // namespace iresearch
 }  // namespace arangodb
-

--- a/arangod/IResearch/IResearchLink.h
+++ b/arangod/IResearch/IResearchLink.h
@@ -59,7 +59,9 @@ class AsyncLinkHandle final {
   bool empty() const { return _link.empty(); }
   auto lock() { return _link.lock(); }
   auto try_lock() noexcept { return _link.try_lock(); }
-  bool terminationRequested() const noexcept { return _asyncTerminate.load(); }
+  bool terminationRequested() const noexcept {
+    return _asyncTerminate.load(std::memory_order_seq_cst);
+  }
 
   AsyncLinkHandle(AsyncLinkHandle const&) = delete;
   AsyncLinkHandle(AsyncLinkHandle&&) = delete;
@@ -72,7 +74,7 @@ class AsyncLinkHandle final {
   void reset();
 
   AsyncValue<IResearchLink> _link;
-  std::atomic<bool> _asyncTerminate{false};  // trigger termination of long-running async jobs
+  std::atomic_bool _asyncTerminate{false};  // trigger termination of long-running async jobs
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -351,7 +353,7 @@ class IResearchLink {
     irs::directory_reader _reader;
     irs::index_writer::ptr _writer;
     TRI_voc_tick_t _recoveryTick{0};  // the tick at which data store was recovered
-    std::atomic<bool> _inRecovery{false};  // data store is in recovery
+    std::atomic_bool _inRecovery{false};  // data store is in recovery
     explicit operator bool() const noexcept { return _directory && _writer; }
 
     void resetDataStore() noexcept {  // reset all underlying readers to release file handles

--- a/arangod/IResearch/IResearchLink.h
+++ b/arangod/IResearch/IResearchLink.h
@@ -60,7 +60,7 @@ class AsyncLinkHandle final {
   auto lock() { return _link.lock(); }
   auto try_lock() noexcept { return _link.try_lock(); }
   bool terminationRequested() const noexcept {
-    return _asyncTerminate.load(std::memory_order_seq_cst);
+    return _asyncTerminate.load(std::memory_order_acquire);
   }
 
   AsyncLinkHandle(AsyncLinkHandle const&) = delete;

--- a/arangod/IResearch/IResearchLink.h
+++ b/arangod/IResearch/IResearchLink.h
@@ -50,9 +50,9 @@ class IResearchView;
 class IResearchLink;
 
 ////////////////////////////////////////////////////////////////////////////////
-/// @brief IResarchLink handle to use with asynchronous tasks
+/// @brief IResearchLink handle to use with asynchronous tasks
 ////////////////////////////////////////////////////////////////////////////////
-class AsyncLinkHandle {
+class AsyncLinkHandle final {
  public:
   explicit AsyncLinkHandle(IResearchLink* link);
   ~AsyncLinkHandle();
@@ -61,19 +61,19 @@ class AsyncLinkHandle {
   auto try_lock() noexcept { return _link.try_lock(); }
   bool terminationRequested() const noexcept { return _asyncTerminate.load(); }
 
- private:
-  friend class IResearchLink;
-
   AsyncLinkHandle(AsyncLinkHandle const&) = delete;
   AsyncLinkHandle(AsyncLinkHandle&&) = delete;
   AsyncLinkHandle& operator=(AsyncLinkHandle const&) = delete;
   AsyncLinkHandle& operator=(AsyncLinkHandle&&) = delete;
 
+ private:
+  friend class IResearchLink;
+
   void reset();
 
   AsyncValue<IResearchLink> _link;
   std::atomic<bool> _asyncTerminate{false};  // trigger termination of long-running async jobs
-};                                           // AsyncLinkHandle
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief common base class for functionality required to link an ArangoDB
@@ -81,6 +81,11 @@ class AsyncLinkHandle {
 ////////////////////////////////////////////////////////////////////////////////
 class IResearchLink {
  public:
+  IResearchLink(IResearchLink const&) = delete;
+  IResearchLink(IResearchLink&&) = delete;
+  IResearchLink& operator=(IResearchLink const&) = delete;
+  IResearchLink& operator=(IResearchLink&&) = delete;
+
   using AsyncLinkPtr = std::shared_ptr<AsyncLinkHandle>;
   using InitCallback = std::function<irs::directory_attributes()>;
 
@@ -88,15 +93,19 @@ class IResearchLink {
   /// @brief a snapshot representation of the data-store
   ///        locked to prevent data store deallocation
   //////////////////////////////////////////////////////////////////////////////
+  // TODO Refactor irs::directory_reader ctor, now it doesn't have move
   class Snapshot {
    public:
+    Snapshot(Snapshot const&) = delete;
+    Snapshot& operator=(Snapshot const&) = delete;
     Snapshot() = default;
+    ~Snapshot() = default;
     Snapshot(AsyncValue<IResearchLink>::Value&& lock, irs::directory_reader&& reader) noexcept
-        : _lock(std::move(lock)), _reader(std::move(reader)) {
+        : _lock{std::move(lock)}, _reader{std::move(reader)} {
       TRI_ASSERT(_lock.ownsLock());
     }
     Snapshot(Snapshot&& rhs) noexcept
-        : _lock(std::move(rhs._lock)), _reader(std::move(rhs._reader)) {
+        : _lock{std::move(rhs._lock)}, _reader{std::move(rhs._reader)} {
       TRI_ASSERT(_lock.ownsLock());
     }
     Snapshot& operator=(Snapshot&& rhs) noexcept {
@@ -107,10 +116,12 @@ class IResearchLink {
       TRI_ASSERT(_lock.ownsLock());
       return *this;
     }
-    operator irs::directory_reader const&() const noexcept { return _reader; }
+    irs::directory_reader const& getDirectoryReader() const noexcept {
+      return _reader;
+    }
 
    private:
-    AsyncValue<IResearchLink>::Value _lock;  // lock preventing data store dealocation
+    AsyncValue<IResearchLink>::Value _lock;  // lock preventing data store deallocation
     irs::directory_reader _reader;
   };
 
@@ -135,7 +146,7 @@ class IResearchLink {
   void afterTruncate(TRI_voc_tick_t tick,
                      transaction::Methods* trx);  // arangodb::Index override
 
-  bool canBeDropped() const {
+  static bool canBeDropped() {
     // valid for a link to be dropped from an ArangoSearch view
     return true;
   };
@@ -158,7 +169,7 @@ class IResearchLink {
   ////////////////////////////////////////////////////////////////////////////////
   Result drop();
 
-  bool hasSelectivityEstimate() const;  // arangodb::Index override
+  static bool hasSelectivityEstimate();  // arangodb::Index override
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief the identifier for this link
@@ -169,11 +180,10 @@ class IResearchLink {
   /// @brief insert an ArangoDB document into an iResearch View using '_meta' params
   /// @note arangodb::Index override
   ////////////////////////////////////////////////////////////////////////////////
-  Result insert(transaction::Methods& trx, LocalDocumentId const& documentId,
-                velocypack::Slice const doc);
+  Result insert(transaction::Methods& trx, LocalDocumentId documentId, velocypack::Slice doc);
 
-  bool isHidden() const;  // arangodb::Index override
-  bool isSorted() const;  // arangodb::Index override
+  static bool isHidden();  // arangodb::Index override
+  static bool isSorted();  // arangodb::Index override
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief called when the iResearch Link is loaded into memory
@@ -186,7 +196,7 @@ class IResearchLink {
   ///        definition is the same as this link
   /// @note arangodb::Index override
   ////////////////////////////////////////////////////////////////////////////////
-  bool matchesDefinition(velocypack::Slice const& slice) const;
+  bool matchesDefinition(velocypack::Slice slice) const;
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief amount of memory in bytes occupied by this iResearch Link
@@ -201,7 +211,7 @@ class IResearchLink {
   Result properties(velocypack::Builder& builder, bool forPersistence) const;
 
   //////////////////////////////////////////////////////////////////////////////
-  /// @brief update runtine data processing properties (not persisted)
+  /// @brief update runtime data processing properties (not persisted)
   /// @return success
   //////////////////////////////////////////////////////////////////////////////
   Result properties(IResearchViewMeta const& meta);
@@ -210,8 +220,7 @@ class IResearchLink {
   /// @brief remove an ArangoDB document from an iResearch View
   /// @note arangodb::Index override
   ////////////////////////////////////////////////////////////////////////////////
-  Result remove(transaction::Methods& trx, LocalDocumentId const& documentId,
-                velocypack::Slice const doc);
+  Result remove(transaction::Methods& trx, LocalDocumentId documentId, velocypack::Slice doc);
 
   ///////////////////////////////////////////////////////////////////////////////
   /// @brief 'this' for the lifetime of the link data-store
@@ -222,7 +231,7 @@ class IResearchLink {
   //////////////////////////////////////////////////////////////////////////////
   /// @return pointer to an index reader containing the data store current
   ///         record snapshot
-  ///         (nullptr == no data store snapshot availabe, e.g. error)
+  ///         (nullptr == no data store snapshot available, e.g. error)
   //////////////////////////////////////////////////////////////////////////////
   Snapshot snapshot() const;
 
@@ -230,13 +239,13 @@ class IResearchLink {
   /// @brief ArangoSearch Link index type enum value
   /// @note arangodb::Index override
   ////////////////////////////////////////////////////////////////////////////////
-  Index::IndexType type() const;
+  static Index::IndexType type();
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief ArangoSearch Link index type string value
   /// @note arangodb::Index override
   ////////////////////////////////////////////////////////////////////////////////
-  char const* typeName() const;
+  static char const* typeName();
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief called when the iResearch Link is unloaded from memory
@@ -267,7 +276,7 @@ class IResearchLink {
 
   /// @brief sets the _collectionName in Link meta. Used in cluster only to store
   /// linked collection name (as shard name differs from the cluster-wide collection name)
-  /// @param name  collectioName to set. Should match existing value of  the _collectionName
+  /// @param name collection to set. Should match existing value of the _collectionName
   /// if it is not empty.
   /// @return true if name not existed in link before and was actually set by this call,
   /// false otherwise
@@ -286,7 +295,6 @@ class IResearchLink {
     size_t numFiles{};         // number of files
   };
 
- protected:
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief construct an uninitialized IResearch link, must call init(...)
   /// after
@@ -330,7 +338,7 @@ class IResearchLink {
     /// @brief commit is done
     ////////////////////////////////////////////////////////////////////////////
     DONE
-  };  // CommitResult
+  };
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief the underlying iresearch data store
@@ -344,7 +352,7 @@ class IResearchLink {
     irs::index_writer::ptr _writer;
     TRI_voc_tick_t _recoveryTick{0};  // the tick at which data store was recovered
     std::atomic<bool> _inRecovery{false};  // data store is in recovery
-    operator bool() const noexcept { return _directory && _writer; }
+    explicit operator bool() const noexcept { return _directory && _writer; }
 
     void resetDataStore() noexcept {  // reset all underlying readers to release file handles
       _reader.reset();
@@ -406,7 +414,7 @@ class IResearchLink {
   std::function<void(transaction::Methods& trx, transaction::Status status)> _trxCallback;  // for insert(...)/remove(...)
   std::string const _viewGuid;  // the identifier of the desired view (read-only, set via init())
   bool _createdInRecovery;  // link was created based on recovery marker
-};                          // IResearchLink
+};
 
 irs::utf8_path getPersistedPath(DatabasePathFeature const& dbPathFeature,
                                 iresearch::IResearchLink const& link);

--- a/arangod/IResearch/IResearchLink.h
+++ b/arangod/IResearch/IResearchLink.h
@@ -340,6 +340,12 @@ class IResearchLink {
   std::tuple<uint64_t, uint64_t, uint64_t> avgTime() const;
 
  private:
+  ////////////////////////////////////////////////////////////////////////////////
+  /// @brief get index stats for current snapshot
+  /// @note Unsafe, can only be called as in the stats()
+  ////////////////////////////////////////////////////////////////////////////////
+  LinkStats statsUnsafe() const;
+
   friend struct CommitTask;
   friend struct ConsolidationTask;
 

--- a/arangod/IResearch/IResearchLink.h
+++ b/arangod/IResearch/IResearchLink.h
@@ -288,12 +288,12 @@ class IResearchLink {
   /// @brief index stats
   //////////////////////////////////////////////////////////////////////////////
   struct Stats {
-    size_t numBufferedDocs{};  // number of buffered docs
-    size_t numDocs{};          // number of documents
-    size_t numLiveDocs{};      // number of live documents
-    size_t numSegments{};      // number of segments
-    size_t numFiles{};         // number of files
-    size_t indexSize{};        // size of the index in bytes
+    uint64_t numBufferedDocs{};
+    uint64_t numDocs{};
+    uint64_t numLiveDocs{};
+    uint64_t numSegments{};
+    uint64_t numFiles{};
+    uint64_t indexSize{};
   };
 
   const std::string& getViewId() const noexcept;
@@ -302,8 +302,12 @@ class IResearchLink {
   std::string getCollectionName() const;
 
   struct LinkStats : Stats {
-    void toPrometheus(std::string& result, const std::string& globals,
-                      const std::string& labels) const;
+    void needName() const;
+    void toPrometheus(std::string& result, std::string_view globals,
+                      std::string_view labels) const;
+
+   private:
+    mutable bool _needName{false};
   };
 
  protected:

--- a/arangod/IResearch/IResearchView.cpp
+++ b/arangod/IResearch/IResearchView.cpp
@@ -115,7 +115,7 @@ class ViewTrxState final : public arangodb::TransactionState::Cookie,
 
 void ViewTrxState::add(arangodb::DataSourceId cid,
                        arangodb::iresearch::IResearchLink::Snapshot&& snapshot) {
-  auto& reader = static_cast<irs::index_reader const&>(snapshot);
+  auto& reader = snapshot.getDirectoryReader();
   for (auto& entry : reader) {
     _subReaders.emplace_back(std::piecewise_construct, std::forward_as_tuple(cid),
                              std::forward_as_tuple(&entry));
@@ -876,7 +876,7 @@ IResearchView::Snapshot const* IResearchView::snapshot(
         snapshot = link->snapshot();
       }
 
-      if (!static_cast<irs::directory_reader const&>(snapshot)) {
+      if (!snapshot.getDirectoryReader()) {
         LOG_TOPIC("e76eb", ERR, arangodb::iresearch::TOPIC)
             << "failed to get snaphot of arangosearch link in collection '"
             << cid << "' for arangosearch view '" << name() << "', skipping it";

--- a/arangod/RestServer/Metrics.h
+++ b/arangod/RestServer/Metrics.h
@@ -46,6 +46,12 @@ class Metric {
   std::string const& name() const;
   std::string const& labels() const;
   virtual std::string type() const = 0;
+  virtual void toPrometheusBegin(std::string& result, std::string_view name) const {
+    result.append("# HELP ").append(name).append(" ").append(help()).append(
+        "\n");
+    result.append("# TYPE ").append(name).append(" ").append(type()).append(
+        "\n");
+  }
   virtual void toPrometheus(std::string& result, std::string const& globals, std::string const& alternativeName = std::string()) const = 0;
   void header(std::string& result) const;
  protected:
@@ -205,6 +211,10 @@ class GuardMetric final : public Metric {
 
   std::string type() const final { return "untyped"; }
 
+  void toPrometheusBegin(std::string& result, std::string_view name) const final {
+    std::lock_guard guard{_m};
+    _metric.needName();
+  }
   void toPrometheus(std::string& result, std::string const& globals,
                     std::string const&) const final {
     load().toPrometheus(result, globals, labels());

--- a/arangod/RestServer/Metrics.h
+++ b/arangod/RestServer/Metrics.h
@@ -169,7 +169,11 @@ template<typename T> class Gauge : public Metric {
     _g.store(t, std::memory_order_relaxed);
     return *this;
   }
-  
+
+  void store(T value, std::memory_order mo) noexcept {
+    return _g.store(value, mo);
+  }
+
   T load(std::memory_order mo = std::memory_order_relaxed) const noexcept { return _g.load(mo); }
   
   void toPrometheus(std::string& result, std::string const& globalLabels, std::string const& alternativeName) const override {

--- a/arangod/RestServer/MetricsFeature.cpp
+++ b/arangod/RestServer/MetricsFeature.cpp
@@ -560,6 +560,14 @@ ServerStatistics& MetricsFeature::serverStatistics() noexcept {
   return *_serverStatistics;
 }
 
+Metric* MetricsFeature::get(const metrics_key& key) {
+  auto it = _registry.find(key);
+  if (it == _registry.end()) {
+    return nullptr;
+  }
+  return it->second.get();
+}
+
 metrics_key::metrics_key(std::string const& name, std::initializer_list<std::string> const& il) : name(name) {
   TRI_ASSERT(il.size() < 2);
   if (il.size() == 1) {

--- a/arangod/RestServer/MetricsFeature.cpp
+++ b/arangod/RestServer/MetricsFeature.cpp
@@ -534,8 +534,7 @@ void MetricsFeature::toPrometheus(std::string& result, bool v2) const {
         continue;
       }
       if (lastType != name) {
-        result += "# HELP " + name + " " + i.second->help() + "\n";
-        result += "# TYPE " + name + " " + i.second->type() + "\n";
+        i.second->toPrometheusBegin(result, name);
         lastType = name;
       }
       i.second->toPrometheus(result, _globalLabelsStr, alternativeName);

--- a/arangod/RestServer/MetricsFeature.h
+++ b/arangod/RestServer/MetricsFeature.h
@@ -188,6 +188,11 @@ class MetricsFeature final : public application_features::ApplicationFeature {
   }
 
   template <typename MetricBuilder>
+  bool remove(MetricBuilder&& builder) {
+    return doRemove(builder);
+  }
+
+  template <typename MetricBuilder>
   auto addShared(MetricBuilder&& builder)
       -> std::shared_ptr<typename MetricBuilder::metric_t> {
     return std::static_pointer_cast<typename MetricBuilder::metric_t>(doAdd(builder));
@@ -199,7 +204,7 @@ class MetricsFeature final : public application_features::ApplicationFeature {
 
  private:
   auto doAdd(metrics::Builder& builder) -> std::shared_ptr<::Metric>;
-
+  bool doRemove(const metrics::Builder& builder);
 
   registry_type _registry;
 

--- a/arangod/RestServer/MetricsFeature.h
+++ b/arangod/RestServer/MetricsFeature.h
@@ -36,19 +36,20 @@
     x() { _name = #x; _help = help; } \
     }
 
-#define DECLARE_GAUGE(x, type, help)    \
+#define DECLARE_GAUGE(x, type, help)                    \
   struct x : arangodb::metrics::GaugeBuilder<x, type> { \
-    x() { _name = #x; _help = help; } \
-    }
-    
+    static constexpr std::string_view kName = #x;       \
+    x() {                                               \
+      _name = #x;                                       \
+      _help = help;                                     \
+    }                                                   \
+  }
+
 #define DECLARE_LEGACY_GAUGE(x, type, help) DECLARE_GAUGE(x, type, help)
 
-#define DECLARE_GUARD_METRIC(x, type, help)                   \
+#define DECLARE_GUARD_METRIC(x, type)                         \
   struct x : arangodb::metrics::GuardMetricBuilder<x, type> { \
-    x() {                                                     \
-      _name = #x;                                             \
-      _help = help;                                           \
-    }                                                         \
+    x() { _name = #x; }                                       \
   }
 
 #define DECLARE_HISTOGRAM(x, scale, help)                   \

--- a/arangod/RestServer/MetricsFeature.h
+++ b/arangod/RestServer/MetricsFeature.h
@@ -187,6 +187,8 @@ class MetricsFeature final : public application_features::ApplicationFeature {
     return static_cast<typename MetricBuilder::metric_t&>(*doAdd(builder));
   }
 
+  Metric* get(const metrics_key& key);
+
   template <typename MetricBuilder>
   bool remove(MetricBuilder&& builder) {
     return doRemove(builder);

--- a/arangod/VocBase/Identifiers/LocalDocumentId.cpp
+++ b/arangod/VocBase/Identifiers/LocalDocumentId.cpp
@@ -27,7 +27,7 @@
 
 namespace arangodb {
 
-LocalDocumentId::LocalDocumentId(RevisionId const& id) noexcept
+LocalDocumentId::LocalDocumentId(RevisionId id) noexcept
     : Identifier(id.id()) {}
 
 bool LocalDocumentId::isSet() const noexcept { return id() != 0; }
@@ -40,11 +40,11 @@ LocalDocumentId LocalDocumentId::create() {
 }
 
 /// @brief create a document id from an existing revision id
-LocalDocumentId LocalDocumentId::create(RevisionId const& rid) {
+LocalDocumentId LocalDocumentId::create(RevisionId rid) {
   return LocalDocumentId{rid.id()};
 }
 
-void LocalDocumentId::track(LocalDocumentId const& id) {
+void LocalDocumentId::track(LocalDocumentId id) {
   TRI_HybridLogicalClock(id.id());
 }
 

--- a/arangod/VocBase/Identifiers/LocalDocumentId.h
+++ b/arangod/VocBase/Identifiers/LocalDocumentId.h
@@ -32,11 +32,11 @@ class RevisionId;
 
 /// @brief a LocalDocumentId is an identifier for storing and retrieving
 /// documents using a uint64_t value.
-class LocalDocumentId : public basics::Identifier {
+class LocalDocumentId final : public basics::Identifier {
  public:
   constexpr LocalDocumentId() noexcept : Identifier() {}
   constexpr explicit LocalDocumentId(BaseType id) noexcept : Identifier(id) {}
-  explicit LocalDocumentId(RevisionId const& id) noexcept;
+  explicit LocalDocumentId(RevisionId id) noexcept;
 
   /// @brief whether or not the id is set (not 0)
   bool isSet() const noexcept;
@@ -57,10 +57,10 @@ class LocalDocumentId : public basics::Identifier {
   }
 
   /// @brief create a document id from an existing revision id
-  static LocalDocumentId create(RevisionId const& rid);
+  static LocalDocumentId create(RevisionId rid);
 
   /// @brief use to track an existing value in recovery to ensure no duplicates
-  static void track(LocalDocumentId const& id);
+  static void track(LocalDocumentId id);
 };
 
 // LocalDocumentId should not be bigger than the BaseType

--- a/arangod/VocBase/Identifiers/RevisionId.cpp
+++ b/arangod/VocBase/Identifiers/RevisionId.cpp
@@ -45,7 +45,7 @@ constexpr static arangodb::RevisionId::BaseType TickLimit =
 
 namespace arangodb {
 
-RevisionId::RevisionId(LocalDocumentId const& id) : Identifier(id.id()) {}
+RevisionId::RevisionId(LocalDocumentId id) : Identifier(id.id()) {}
 
 bool RevisionId::isSet() const noexcept { return id() != 0; }
 

--- a/arangod/VocBase/Identifiers/RevisionId.h
+++ b/arangod/VocBase/Identifiers/RevisionId.h
@@ -35,11 +35,11 @@ class ClusterInfo;
 class LocalDocumentId;
 
 /// @brief server id type
-class RevisionId : public arangodb::basics::Identifier {
+class RevisionId final : public arangodb::basics::Identifier {
  public:
   constexpr RevisionId() noexcept : Identifier() {}
   constexpr explicit RevisionId(BaseType id) noexcept : Identifier(id) {}
-  explicit RevisionId(LocalDocumentId const& id);
+  explicit RevisionId(LocalDocumentId id);
 
   /// @brief whether or not the id is set (not 0)
   bool isSet() const noexcept;
@@ -104,7 +104,7 @@ class RevisionId : public arangodb::basics::Identifier {
 
   /// @brief extract revision from slice; expects either an integer or string,
   /// or an object with a string or integer _rev attribute
-  static RevisionId fromSlice(velocypack::Slice const slice);
+  static RevisionId fromSlice(velocypack::Slice slice);
 
   /// @brief extract revision from persistent storage (proper endianness)
   static RevisionId fromPersistent(char const* data);

--- a/tests/IResearch/IResearchQueryNoMaterializationTest.cpp
+++ b/tests/IResearch/IResearchQueryNoMaterializationTest.cpp
@@ -466,7 +466,8 @@ TEST_P(IResearchQueryNoMaterializationTest, testStoredValuesRecord) {
     EXPECT_TRUE(trx.begin().ok());
     auto link = arangodb::iresearch::IResearchLinkHelper::find(*logicalCollection, *view);
     ASSERT_TRUE(link);
-    irs::directory_reader const snapshotReader = link->snapshot();
+    auto const snapshot = link->snapshot();
+    auto const& snapshotReader = snapshot.getDirectoryReader();
     std::string const columns[] = {arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + std::string("_id"),
                                    arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + std::string("foo"),
                                    arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + std::string("foo") +
@@ -612,7 +613,8 @@ TEST_P(IResearchQueryNoMaterializationTest, testStoredValuesRecordWithCompressio
     EXPECT_TRUE(trx.begin().ok());
     auto link = arangodb::iresearch::IResearchLinkHelper::find(*logicalCollection, *view);
     ASSERT_TRUE(link);
-    irs::directory_reader const snapshotReader = link->snapshot();
+    auto const snapshot = link->snapshot();
+    auto const& snapshotReader = snapshot.getDirectoryReader();
     std::string const columns[] = { arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + std::string("_id"),
                                    arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + std::string("foo"),
                                    arangodb::iresearch::IResearchViewStoredValues::FIELDS_DELIMITER + std::string("foo") +


### PR DESCRIPTION
### Scope & Purpose

Add metrics for IResearchLink
And small refactoring

Based on this PR: https://github.com/arangodb/arangodb/pull/14532

<details><summary> 
<b>Example of usage (Single Server):</b>
</summary>

```
$ curl --header 'accept: application/json' --dump - http://localhost:8529/_admin/metrics | grep arangosearch
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 65129  100 65129    0 # HELP arangodb_arangosearch_cleanup_time Some average time of last cleanups in microseconds
   # TYPE arangodb_arangosearch_cleanup_time gauge
 0arangodb_arangosearch_cleanup_time{role="SINGLE",viewId="hFAEF893B47B8/252",collId="205",shardName="",dbName="1"} 0
  arangodb_arangosearch_cleanup_time{role="SINGLE",viewId="hFAEF893B47B8/252",collId="211",shardName="",dbName="1"} 0
11# HELP arangodb_arangosearch_commit_time Some average time of last commits in microseconds
.7# TYPE arangodb_arangosearch_commit_time gauge
M arangodb_arangosearch_commit_time{role="SINGLE",viewId="hFAEF893B47B8/252",collId="205",shardName="",dbName="1"} 15
  arangodb_arangosearch_commit_time{role="SINGLE",viewId="hFAEF893B47B8/252",collId="211",shardName="",dbName="1"} 20
   # HELP arangodb_arangosearch_consolidation_time Some average time of last consolidations in microseconds
0 # TYPE arangodb_arangosearch_consolidation_time gauge
--arangodb_arangosearch_consolidation_time{role="SINGLE",viewId="hFAEF893B47B8/252",collId="205",shardName="",dbName="1"} 0
:-arangodb_arangosearch_consolidation_time{role="SINGLE",viewId="hFAEF893B47B8/252",collId="211",shardName="",dbName="1"} 0
-:# HELP arangodb_arangosearch_link_stats Stats of documents in link
--# TYPE arangodb_arangosearch_link_stats guard_metric
 -arangodb_arangosearch_num_buffered_docs{ role="SINGLE", viewId="hFAEF893B47B8/252",collId="205",shardName="",dbName="1"} 0
-arangodb_arangosearch_num_docs{ role="SINGLE", viewId="hFAEF893B47B8/252",collId="205",shardName="",dbName="1"} 100
:-arangodb_arangosearch_num_live_docs{ role="SINGLE", viewId="hFAEF893B47B8/252",collId="205",shardName="",dbName="1"} 100
-:arangodb_arangosearch_num_segments{ role="SINGLE", viewId="hFAEF893B47B8/252",collId="205",shardName="",dbName="1"} 1
--arangodb_arangosearch_num_files{ role="SINGLE", viewId="hFAEF893B47B8/252",collId="205",shardName="",dbName="1"} 7
 -arangodb_arangosearch_index_size{ role="SINGLE", viewId="hFAEF893B47B8/252",collId="205",shardName="",dbName="1"} 5321
-:arangodb_arangosearch_num_buffered_docs{ role="SINGLE", viewId="hFAEF893B47B8/252",collId="211",shardName="",dbName="1"} 0
--arangodb_arangosearch_num_docs{ role="SINGLE", viewId="hFAEF893B47B8/252",collId="211",shardName="",dbName="1"} 100
:arangodb_arangosearch_num_live_docs{ role="SINGLE", viewId="hFAEF893B47B8/252",collId="211",shardName="",dbName="1"} 100
--arangodb_arangosearch_num_segments{ role="SINGLE", viewId="hFAEF893B47B8/252",collId="211",shardName="",dbName="1"} 1
 1arangodb_arangosearch_num_files{ role="SINGLE", viewId="hFAEF893B47B8/252",collId="211",shardName="",dbName="1"} 7
2.arangodb_arangosearch_index_size{ role="SINGLE", viewId="hFAEF893B47B8/252",collId="211",shardName="",dbName="1"} 5345
4M# HELP arangodb_arangosearch_num_failed_cleanups Number of failed cleanups

# TYPE arangodb_arangosearch_num_failed_cleanups gauge
arangodb_arangosearch_num_failed_cleanups{role="SINGLE",viewId="hFAEF893B47B8/252",collId="205",shardName="",dbName="1"} 0
arangodb_arangosearch_num_failed_cleanups{role="SINGLE",viewId="hFAEF893B47B8/252",collId="211",shardName="",dbName="1"} 0
# HELP arangodb_arangosearch_num_failed_commits Number of failed commits
# TYPE arangodb_arangosearch_num_failed_commits gauge
arangodb_arangosearch_num_failed_commits{role="SINGLE",viewId="hFAEF893B47B8/252",collId="205",shardName="",dbName="1"} 0
arangodb_arangosearch_num_failed_commits{role="SINGLE",viewId="hFAEF893B47B8/252",collId="211",shardName="",dbName="1"} 0
# HELP arangodb_arangosearch_num_failed_consolidations Number of failed consolidations
# TYPE arangodb_arangosearch_num_failed_consolidations gauge
arangodb_arangosearch_num_failed_consolidations{role="SINGLE",viewId="hFAEF893B47B8/252",collId="205",shardName="",dbName="1"} 0
arangodb_arangosearch_num_failed_consolidations{role="SINGLE",viewId="hFAEF893B47B8/252",collId="211",shardName="",dbName="1"} 0
```

</details>

<details><summary> 
<b>Example of usage (Cluster):</b>
</summary>

```
$ scripts/startLocalCluster.sh -B ./cmake-build-debug-llvm -a 3 -c 3 -d 3
$ curl --header 'accept: application/json' --dump - http://localhost:8629/_admin/metrics | grep arangosearch
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  105k  1# HELP arangodb_arangosearch_cleanup_time Some average time of last cleanups in microseconds
00# TYPE arangodb_arangosearch_cleanup_time gauge
  arangodb_arangosearch_cleanup_time{role="PRIMARY",shortname="DBServer0002",viewId="c6010050/",collId="foo1",shardName="s6010037",dbName="1"} 0
10arangodb_arangosearch_cleanup_time{role="PRIMARY",shortname="DBServer0002",viewId="c6010050/",collId="foo2",shardName="s6010045",dbName="1"} 0
5# HELP arangodb_arangosearch_commit_time Some average time of last commits in microseconds
k # TYPE arangodb_arangosearch_commit_time gauge
  arangodb_arangosearch_commit_time{role="PRIMARY",shortname="DBServer0002",viewId="c6010050/",collId="foo1",shardName="s6010037",dbName="1"} 50
 arangodb_arangosearch_commit_time{role="PRIMARY",shortname="DBServer0002",viewId="c6010050/",collId="foo2",shardName="s6010045",dbName="1"} 39
0# HELP arangodb_arangosearch_consolidation_time Some average time of last consolidations in microseconds
  # TYPE arangodb_arangosearch_consolidation_time gauge
   arangodb_arangosearch_consolidation_time{role="PRIMARY",shortname="DBServer0002",viewId="c6010050/",collId="foo1",shardName="s6010037",dbName="1"} 0
0 arangodb_arangosearch_consolidation_time{role="PRIMARY",shortname="DBServer0002",viewId="c6010050/",collId="foo2",shardName="s6010045",dbName="1"} 0
 2# HELP arangodb_arangosearch_link_stats Stats of documents in link
8.# TYPE arangodb_arangosearch_link_stats guard_metric
7Marangodb_arangosearch_num_buffered_docs{ role="PRIMARY",shortname="DBServer0002", viewId="c6010050/",collId="foo1",shardName="s6010037",dbName="1"} 0
  arangodb_arangosearch_num_docs{ role="PRIMARY",shortname="DBServer0002", viewId="c6010050/",collId="foo1",shardName="s6010037",dbName="1"} 1000
 arangodb_arangosearch_num_live_docs{ role="PRIMARY",shortname="DBServer0002", viewId="c6010050/",collId="foo1",shardName="s6010037",dbName="1"} 1000
  arangodb_arangosearch_num_segments{ role="PRIMARY",shortname="DBServer0002", viewId="c6010050/",collId="foo1",shardName="s6010037",dbName="1"} 1
 0 arangodb_arangosearch_num_files{ role="PRIMARY",shortname="DBServer0002", viewId="c6010050/",collId="foo1",shardName="s6010037",dbName="1"} 7
--arangodb_arangosearch_index_size{ role="PRIMARY",shortname="DBServer0002", viewId="c6010050/",collId="foo1",shardName="s6010037",dbName="1"} 60416
:-arangodb_arangosearch_num_buffered_docs{ role="PRIMARY",shortname="DBServer0002", viewId="c6010050/",collId="foo2",shardName="s6010045",dbName="1"} 0
-:arangodb_arangosearch_num_docs{ role="PRIMARY",shortname="DBServer0002", viewId="c6010050/",collId="foo2",shardName="s6010045",dbName="1"} 1000
--arangodb_arangosearch_num_live_docs{ role="PRIMARY",shortname="DBServer0002", viewId="c6010050/",collId="foo2",shardName="s6010045",dbName="1"} 1000
 arangodb_arangosearch_num_segments{ role="PRIMARY",shortname="DBServer0002", viewId="c6010050/",collId="foo2",shardName="s6010045",dbName="1"} 1
--arangodb_arangosearch_num_files{ role="PRIMARY",shortname="DBServer0002", viewId="c6010050/",collId="foo2",shardName="s6010045",dbName="1"} 7
:arangodb_arangosearch_index_size{ role="PRIMARY",shortname="DBServer0002", viewId="c6010050/",collId="foo2",shardName="s6010045",dbName="1"} 60452
--# HELP arangodb_arangosearch_num_failed_cleanups Number of failed cleanups
:-# TYPE arangodb_arangosearch_num_failed_cleanups gauge
-arangodb_arangosearch_num_failed_cleanups{role="PRIMARY",shortname="DBServer0002",viewId="c6010050/",collId="foo1",shardName="s6010037",dbName="1"} 0
 arangodb_arangosearch_num_failed_cleanups{role="PRIMARY",shortname="DBServer0002",viewId="c6010050/",collId="foo2",shardName="s6010045",dbName="1"} 0
-# HELP arangodb_arangosearch_num_failed_commits Number of failed commits
-# TYPE arangodb_arangosearch_num_failed_commits gauge
:-arangodb_arangosearch_num_failed_commits{role="PRIMARY",shortname="DBServer0002",viewId="c6010050/",collId="foo1",shardName="s6010037",dbName="1"} 0
-:arangodb_arangosearch_num_failed_commits{role="PRIMARY",shortname="DBServer0002",viewId="c6010050/",collId="foo2",shardName="s6010045",dbName="1"} 0
--# HELP arangodb_arangosearch_num_failed_consolidations Number of failed consolidations
 3# TYPE arangodb_arangosearch_num_failed_consolidations gauge
4.arangodb_arangosearch_num_failed_consolidations{role="PRIMARY",shortname="DBServer0002",viewId="c6010050/",collId="foo1",shardName="s6010037",dbName="1"} 0
3Marangodb_arangosearch_num_failed_consolidations{role="PRIMARY",shortname="DBServer0002",viewId="c6010050/",collId="foo2",shardName="s6010045",dbName="1"} 0
```

</details>

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] Backport for 3.9: *(Please link PR)*
- [ ] Backport for 3.8: *(Please link PR)*
- [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [x] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:

### Documentation

> All new features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the CHANGELOG so that
> support, end users, and other developers have a concise overview. 

- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
