### PR TITLE
Feature 3.8/shard sync improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,16 @@
 v3.8.3 (XXXX-XX-XX)
 -------------------
+    
+* Close a potential gap during shard synchronization when moving from the
+  initial sync step to the WAL tailing step. In this small gap the leader 
+  could purge some of the WAL files that would be required by the following
+  WAL tailing step. This was possible because at the end of the initial sync
+  step, the snapshot on the leader is released, and there is a small window
+  of time before the follower will issue its first WAL tailing request.
+    
+* Improve Shards overview in web UI: the number of currently syncing shards is
+  now displayed per collection. Additionally, shards on failed servers are now
+  displayed in a different color.
 
 * When enabling the cluster supervision maintenance mode via the web UI, there
   is now the possibility to select a duration for the maintenance mode.

--- a/arangod/Cluster/SynchronizeShard.h
+++ b/arangod/Cluster/SynchronizeShard.h
@@ -32,6 +32,7 @@
 #include "VocBase/voc-types.h"
 
 #include <chrono>
+#include <functional>
 #include <memory>
 
 namespace arangodb {
@@ -54,11 +55,8 @@ class SynchronizeShard : public ActionBase, public ShardDefinition {
   bool first() override final;
 
   void setState(ActionState state) override final;
-
+  
   std::string const& clientInfoString() const;
-
-  arangodb::replutils::LeaderInfo const& leaderInfo() const;
-  void setLeaderInfo(arangodb::replutils::LeaderInfo const& leaderInfo);
 
  private:
   arangodb::Result getReadLock(network::ConnectionPool* pool,
@@ -95,8 +93,6 @@ class SynchronizeShard : public ActionBase, public ShardDefinition {
   /// @brief Short, informative description of the replication client, passed to the server
   std::string _clientInfoString;
 
-  /// @brief information about the leader, reused across multiple replication steps
-  arangodb::replutils::LeaderInfo _leaderInfo;
   uint64_t _followingTermId;
 
   /// @brief maximum tick until which we need to run WAL tailing for. 0 means "no restriction"

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -728,7 +728,7 @@ void DatabaseInitialSyncer::fetchDumpChunk(std::shared_ptr<Syncer::JobSynchroniz
       url += "&flush=false";
     } else {
       // only flush WAL once
-      url += "&flush=true&flushWait=180";
+      url += "&flush=true";
       _config.flushed = true;
     }
 
@@ -942,9 +942,9 @@ Result DatabaseInitialSyncer::fetchCollectionDump(arangodb::LogicalCollection* c
     _config.progress.set(
         std::string("fetched leader collection dump for collection '") +
         coll->name() + "', type: " + typeString + ", id: " + leaderColl +
-        ", batch " + itoa(batch) + ", markers processed: " + itoa(cumulativeStats.numDumpDocuments) +
-        ", bytes received: " + itoa(cumulativeStats.numDumpBytesReceived) +
-        ", apply time: " + std::to_string(applyTime) + " s");
+        ", batch " + itoa(batch) + ", markers processed so far: " + itoa(cumulativeStats.numDumpDocuments) +
+        ", bytes received so far: " + itoa(cumulativeStats.numDumpBytesReceived) +
+        ", apply time for batch: " + std::to_string(applyTime) + " s");
 
     if (!res.ok()) {
       return res;

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -231,7 +231,7 @@ arangodb::Result fetchRevisions(arangodb::transaction::Methods& trx,
                             config.leader.endpoint, url, ": ", r.errorMessage()));
     }
 
-    VPackSlice const docs = responseBuilder->slice();
+    VPackSlice docs = responseBuilder->slice();
     if (!docs.isArray()) {
       return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                     concatT("got invalid response from leader at ",
@@ -249,14 +249,14 @@ arangodb::Result fetchRevisions(arangodb::transaction::Methods& trx,
                           ": response document entry is not an object");
       }
 
-      VPackSlice const keySlice = leaderDoc.get(arangodb::StaticStrings::KeyString);
+      VPackSlice keySlice = leaderDoc.get(arangodb::StaticStrings::KeyString);
       if (!keySlice.isString()) {
         return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                       std::string("got invalid response from leader at ") +
                           state.leader.endpoint + ": document key is invalid");
       }
 
-      VPackSlice const revSlice = leaderDoc.get(arangodb::StaticStrings::RevString);
+      VPackSlice revSlice = leaderDoc.get(arangodb::StaticStrings::RevString);
       if (!revSlice.isString()) {
         return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
                       std::string("got invalid response from leader at ") +
@@ -279,7 +279,9 @@ arangodb::Result fetchRevisions(arangodb::transaction::Methods& trx,
           options.indexOperationMode = arangodb::IndexOperationMode::normal;
         }
 
+        double tInsert = TRI_microtime();
         Result res = physical->insert(&trx, leaderDoc, mdr, options);
+        stats.waitedForInsertions += TRI_microtime() - tInsert;
 
         options.indexOperationMode = arangodb::IndexOperationMode::internal;
 
@@ -1631,8 +1633,7 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(arangodb::LogicalCo
       }
       toRemove.clear();
 
-      res = ::fetchRevisions(*trx, _config, _state, *coll, leaderColl, toFetch,
-                             /*removed,*/ stats);
+      res = ::fetchRevisions(*trx, _config, _state, *coll, leaderColl, toFetch, stats);
       if (res.fail()) {
         return res;
       }

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -492,6 +492,10 @@ Result DatabaseInitialSyncer::runWithInventory(bool incremental, VPackSlice dbIn
         << Logger::FIXED(TRI_microtime() - startTime, 6) << " s. status: "
         << (r.errorMessage().empty() ? "all good" : r.errorMessage());
 
+    if (_onSuccess) {
+      r = _onSuccess(*this);
+    }
+
     return r;
   } catch (arangodb::basics::Exception const& ex) {
     return Result(ex.code(), ex.what());

--- a/arangod/Replication/DatabaseInitialSyncer.h
+++ b/arangod/Replication/DatabaseInitialSyncer.h
@@ -157,6 +157,10 @@ class DatabaseInitialSyncer : public InitialSyncer {
   
   /// @brief return information about the leader
   replutils::LeaderInfo leaderInfo() const;
+  
+  void setOnSuccessCallback(std::function<Result(DatabaseInitialSyncer&)> const& cb) {
+    _onSuccess = cb;
+  }
 
  private:
   enum class FormatHint {
@@ -251,6 +255,8 @@ class DatabaseInitialSyncer : public InitialSyncer {
   Result batchFinish();
 
   Configuration _config;
+  
+  std::function<Result(DatabaseInitialSyncer&)> _onSuccess;
 
   /// @brief whether or not we are a coordinator/dbserver
   bool const _isClusterRole;

--- a/arangod/Replication/DatabaseTailingSyncer.cpp
+++ b/arangod/Replication/DatabaseTailingSyncer.cpp
@@ -182,6 +182,9 @@ void DatabaseTailingSyncer::unregisterFromLeader() {
         std::string const url = tailingBaseUrl("tail") +
                                 "serverId=" + _state.localServerIdString +
                                 "&syncerId=" + syncerId().toString();
+        LOG_TOPIC("22640", DEBUG, Logger::REPLICATION) 
+            << "unregistering tailing syncer from leader, url: " << url;
+
         // simply send the request, but don't care about the response. if it
         // fails, there is not much we can do from here.
         response.reset(client->request(rest::RequestType::DELETE_REQ, url, nullptr, 0));

--- a/arangod/Replication/DatabaseTailingSyncer.h
+++ b/arangod/Replication/DatabaseTailingSyncer.h
@@ -35,6 +35,7 @@
 struct TRI_vocbase_t;
 
 namespace arangodb {
+class DatabaseInitialSyncer;
 class DatabaseReplicationApplier;
 
 class DatabaseTailingSyncer : public TailingSyncer {
@@ -61,8 +62,7 @@ class DatabaseTailingSyncer : public TailingSyncer {
   
   /// @brief finalize the synchronization of a collection by tailing the WAL
   /// and filtering on the collection name until no more data is available
-  Result syncCollectionFinalize(arangodb::replutils::LeaderInfo const& leaderInfo,
-                                std::string const& collectionName, 
+  Result syncCollectionFinalize(std::string const& collectionName, 
                                 TRI_voc_tick_t fromTick,
                                 TRI_voc_tick_t toTick, 
                                 std::string const& context);
@@ -77,16 +77,16 @@ class DatabaseTailingSyncer : public TailingSyncer {
   /// by getting an exclusive lock on the leader and use
   /// `syncCollectionFinalize` to finish off the rest.
   /// Internally, both use `syncCollectionCatchupInternal`.
-  Result syncCollectionCatchup(arangodb::replutils::LeaderInfo const& leaderInfo,
-                               std::string const& collectionName, TRI_voc_tick_t fromTick,
+  Result syncCollectionCatchup(std::string const& collectionName, TRI_voc_tick_t fromTick,
                                double timeout, TRI_voc_tick_t& until, bool& didTimeout, 
                                std::string const& context);
   
+  Result inheritFromInitialSyncer(DatabaseInitialSyncer const& syncer);
+  Result registerOnLeader();
   void unregisterFromLeader();
 
  protected:
-  Result syncCollectionCatchupInternal(arangodb::replutils::LeaderInfo const& leaderInfo, 
-                                       std::string const& collectionName,
+  Result syncCollectionCatchupInternal(std::string const& collectionName,
                                        double timeout, bool hard,
                                        TRI_voc_tick_t& until, bool& didTimeout, 
                                        std::string const& context);

--- a/arangod/Replication/GlobalTailingSyncer.cpp
+++ b/arangod/Replication/GlobalTailingSyncer.cpp
@@ -79,18 +79,13 @@ Result GlobalTailingSyncer::saveApplierState() {
   return  _applier->persistStateResult(false);
 }
 
-bool GlobalTailingSyncer::skipMarker(VPackSlice const& slice) {
+bool GlobalTailingSyncer::skipMarker(VPackSlice slice) {
   // we do not have a "cname" attribute in the marker...
   // now check for a globally unique id attribute ("cuid")
   // if its present, then we will use our local cuid -> collection name
   // translation table
-  VPackSlice const name = slice.get("cuid");
+  VPackSlice name = slice.get("cuid");
   if (!name.isString()) {
-    return false;
-  }
-
-  if (_state.leader.version() < 30300) {
-    // globallyUniqueId only exists in 3.3 and higher
     return false;
   }
 

--- a/arangod/Replication/GlobalTailingSyncer.h
+++ b/arangod/Replication/GlobalTailingSyncer.h
@@ -58,7 +58,7 @@ class GlobalTailingSyncer : public TailingSyncer {
   /// @brief save the current applier state
   Result saveApplierState() override;
 
-  bool skipMarker(arangodb::velocypack::Slice const& slice) override;
+  bool skipMarker(arangodb::velocypack::Slice slice) override;
 
  private:
   /// @brief translation between globallyUniqueId and collection name

--- a/arangod/Replication/ReplicationClients.cpp
+++ b/arangod/Replication/ReplicationClients.cpp
@@ -209,6 +209,8 @@ void ReplicationClientsProgressTracker::garbageCollect(double thresholdStamp) {
       ++it;
     }
   }
+
+  LOG_DEVEL << "PROGRESSTRACKER HAS " << _clients.size() << " CLIENTS LEFT";
 }
 
 /// @brief return the lowest lastServedTick value for all clients

--- a/arangod/Replication/ReplicationClients.cpp
+++ b/arangod/Replication/ReplicationClients.cpp
@@ -211,9 +211,10 @@ void ReplicationClientsProgressTracker::garbageCollect(double thresholdStamp) {
   }
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  LOG_TOPIC("239fb", DEBUG, Logger::REPLICATION)
+      << "replication progress tracker has " << _clients.size() << " clients left";
+
   if (!_clients.empty()) {
-    LOG_TOPIC("239fb", TRACE, Logger::REPLICATION)
-        << "replication progress tracker has " << _clients.size() << " left";
     for (auto const& it : _clients) {
       ReplicationClientProgress const& value = it.second;
 

--- a/arangod/Replication/ReplicationClients.cpp
+++ b/arangod/Replication/ReplicationClients.cpp
@@ -210,19 +210,23 @@ void ReplicationClientsProgressTracker::garbageCollect(double thresholdStamp) {
     }
   }
 
-  LOG_DEVEL << "PROGRESSTRACKER HAS " << _clients.size() << " CLIENTS LEFT";
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if (!_clients.empty()) {
+    LOG_TOPIC("239fb", TRACE, Logger::REPLICATION)
+        << "replication progress tracker has " << _clients.size() << " left";
     for (auto const& it : _clients) {
       ReplicationClientProgress const& value = it.second;
 
-      LOG_DEVEL 
-          << "- server: " << value.clientId.id() 
+      LOG_TOPIC("81d72", TRACE, Logger::REPLICATION)
+          << "replication progress tracker entry: "
+          << "server: " << value.clientId.id() 
           << ", syncer: " << value.syncerId.toString() 
-          << ", lastServed:" << value.lastServedTick 
+          << ", lastServed: " << value.lastServedTick 
           << ", lastSeen: " << value.lastSeenStamp 
           << ", expire: " << value.expireStamp;
     }
   }
+#endif
 }
 
 /// @brief return the lowest lastServedTick value for all clients

--- a/arangod/Replication/ReplicationClients.cpp
+++ b/arangod/Replication/ReplicationClients.cpp
@@ -211,6 +211,18 @@ void ReplicationClientsProgressTracker::garbageCollect(double thresholdStamp) {
   }
 
   LOG_DEVEL << "PROGRESSTRACKER HAS " << _clients.size() << " CLIENTS LEFT";
+  if (!_clients.empty()) {
+    for (auto const& it : _clients) {
+      ReplicationClientProgress const& value = it.second;
+
+      LOG_DEVEL 
+          << "- server: " << value.clientId.id() 
+          << ", syncer: " << value.syncerId.toString() 
+          << ", lastServed:" << value.lastServedTick 
+          << ", lastSeen: " << value.lastSeenStamp 
+          << ", expire: " << value.expireStamp;
+    }
+  }
 }
 
 /// @brief return the lowest lastServedTick value for all clients

--- a/arangod/Replication/Syncer.cpp
+++ b/arangod/Replication/Syncer.cpp
@@ -467,7 +467,10 @@ SyncerId newSyncerId() {
 }
 
 Syncer::SyncerState::SyncerState(Syncer* syncer, ReplicationApplierConfiguration const& configuration)
-    : syncerId{newSyncerId()}, applier{configuration}, connection{syncer, configuration}, leader{configuration} {}
+    : syncerId{newSyncerId()}, 
+      applier{configuration}, 
+      connection{syncer, configuration}, 
+      leader{configuration} {}
 
 Syncer::Syncer(ReplicationApplierConfiguration const& configuration)
     : _state{this, configuration} {

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -212,7 +212,7 @@ bool TailingSyncer::hasMultipleOngoingTransactions() const {
 #endif
 
 /// @brief whether or not a marker should be skipped
-bool TailingSyncer::skipMarker(TRI_voc_tick_t firstRegularTick, VPackSlice const& slice,
+bool TailingSyncer::skipMarker(TRI_voc_tick_t firstRegularTick, VPackSlice slice,
                                TRI_voc_tick_t actualMarkerTick, TRI_replication_operation_e type) {
   TRI_ASSERT(slice.isObject());
 
@@ -239,10 +239,10 @@ bool TailingSyncer::skipMarker(TRI_voc_tick_t firstRegularTick, VPackSlice const
         }
       }
     }
-  }
-
-  if (tooOld) {
-    return true;
+  
+    if (tooOld) {
+      return true;
+    }
   }
 
   // the transient applier state is just used for one shard / collection
@@ -255,7 +255,7 @@ bool TailingSyncer::skipMarker(TRI_voc_tick_t firstRegularTick, VPackSlice const
     return false;
   }
 
-  VPackSlice const name = slice.get(::cnameRef);
+  VPackSlice name = slice.get(::cnameRef);
   if (name.isString()) {
     return isExcludedCollection(name.copyString());
   }

--- a/arangod/Replication/TailingSyncer.h
+++ b/arangod/Replication/TailingSyncer.h
@@ -92,7 +92,7 @@ class TailingSyncer : public Syncer {
 #endif
 
   /// @brief whether or not a collection should be excluded
-  bool skipMarker(TRI_voc_tick_t firstRegulaTick, arangodb::velocypack::Slice const& slice,
+  bool skipMarker(TRI_voc_tick_t firstRegulaTick, arangodb::velocypack::Slice slice,
                   TRI_voc_tick_t actualMarkerTick, TRI_replication_operation_e type);
 
   /// @brief whether or not a collection should be excluded
@@ -180,7 +180,7 @@ class TailingSyncer : public Syncer {
                                                     char const* type);
 
  protected:
-  virtual bool skipMarker(arangodb::velocypack::Slice const& slice) = 0;
+  virtual bool skipMarker(arangodb::velocypack::Slice slice) = 0;
 
   /// @brief pointer to the applier
   ReplicationApplier* _applier;

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -2641,7 +2641,7 @@ void RestReplicationHandler::handleCommandHoldReadLockCollection() {
 
   if (body.hasKey(StaticStrings::RebootId)) {
     if (body.get(StaticStrings::RebootId).isInteger()) {
-      if (body.hasKey("serverId") && body.get("serverId").isString()) {
+      if (body.get("serverId").isString()) {
         rebootId = RebootId(body.get(StaticStrings::RebootId).getNumber<uint64_t>());
         serverId = body.get("serverId").copyString();
       } else {
@@ -2733,6 +2733,13 @@ void RestReplicationHandler::handleCommandHoldReadLockCollection() {
       b.add(StaticStrings::FollowingTermId,
             VPackValue(col->followers()->newFollowingTermId(serverId)));
     }
+
+    // also return the _current_ last log sequence number. this may be higher
+    // than the tick of the transaction created above, but it still can be
+    // used by a follower as an upper bound until which to tail the WAL _at most_.
+    TRI_ASSERT(server().hasFeature<EngineSelectorFeature>());
+    StorageEngine& engine = server().getFeature<EngineSelectorFeature>().engine();
+    b.add("lastLogTick", VPackValue(engine.currentTick()));
   }
 
   LOG_TOPIC("61a9d", DEBUG, Logger::REPLICATION)

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -1549,6 +1549,12 @@ void RocksDBEngine::processCompactions() {
       // found something to do, now steal the item from the queue
       bounds = std::move(_pendingCompactions.front());
       _pendingCompactions.pop_front();
+      
+      if (server().isStopping()) {
+        // if we are stopping, it is ok to not process but lose any pending
+        // compactions
+        return;
+      }
       // set it to running already, so that concurrent callers of this method
       // will not kick off additional jobs
       ++_runningCompactions;
@@ -3081,16 +3087,19 @@ void RocksDBEngine::waitForCompactionJobsToFinish() {
   int iterations = 0;
 
   do {
+    size_t numRunning;
     {
       READ_LOCKER(locker, _pendingCompactionsLock);
-      if (_runningCompactions == 0) {
-        return;
-      }
+      numRunning =  _runningCompactions;
+    }
+    if (numRunning == 0) {
+      return;
     }
       
     // print this only every few seconds
     if (iterations++ % 200 == 0) {
-      LOG_TOPIC("9cbfd", INFO, Logger::ENGINES) << "waiting for compaction jobs to finish...";
+      LOG_TOPIC("9cbfd", INFO, Logger::ENGINES) 
+          << "waiting for " << numRunning << " compaction job(s) to finish...";
     }
     // unfortunately there is not much we can do except waiting for
     // RocksDB's compaction job(s) to finish.

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/routers/router.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/routers/router.js
@@ -106,6 +106,12 @@
             this.loggerView.logTopicView.remove();
           }
         }
+      
+        if (this.lastRoute === '#shards') {
+          if (this.shardsView) {
+            this.shardsView.remove();
+          }
+        }
 
         // react unmounting
         ReactDOM.unmountComponentAtNode(document.getElementById("content"));

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/templates/shardsView.ejs
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/templates/shardsView.ejs
@@ -19,16 +19,6 @@
   <% var collectionName; %>
   <% var first = 0; %>
 
-  <%
-  var collectionInSync = function (name) {
-    var result = false;
-    if (_.isEqual(collections[name].Current, collections[name].Plan)) {
-      return true;
-    }
-    return result;
-  };
-  %>
-
   <% _.each(collections, function(collection, name) { %>
   <div class="sectionShard" id="<%= name %>">
     <% collectionName = name %>
@@ -40,19 +30,38 @@
       <div class="sectionHeader pure-g">
         <% } %>
 
+        <% var collectionExpanded = (visible.indexOf(name) !== -1); %>
+        <% var collectionInSync = (_.isEqual(collections[name].Current, collections[name].Plan)); %>
+        <% 
+           var numShards = 0;
+           var outOfSyncShards = 0;
+           _.each(collection.Plan, function(shard, name) { 
+             numShards++;
+             var foundOutOfSync = false;
+             _.each(shard.followers, function(s) { 
+               if (collections[collectionName].Current[name].followers.indexOf(s) === -1) { 
+                 foundOutOfSync = true;
+               }
+             });
+             if (foundOutOfSync) {
+               outOfSyncShards++;
+             }
+           });
+        %>
+
         <div class="pure-u-22-24">
           <div class="title" style="position: relative; top: -4px;">
-            <% var numShards = Object.keys(collection.Plan).length; %>
-            <%= name %> (<%= numShards + ' shard' + (numShards !== 1 ? 's' : '') %>)
+            <%= name %> (<%= numShards + ' shard' + (numShards !== 1 ? 's' : '') %><%= (outOfSyncShards > 0 ? " - " + outOfSyncShards + " syncing..." : "") %>)
           </div>
         </div>
+
         <div class="pure-u-2-24 shardSyncIcons">
-          <% if (visible.indexOf(name) !== -1) { %>
+          <% if (collectionExpanded) { %>
             <i style="margin-left: 10px; color: #fff;" class="fa fa-arrow-down"></i>
           <% } else { %>
             <i style="margin-left: 10px; color: #fff;" class="fa fa-arrow-right"></i>
           <% } %>
-          <% if (collectionInSync(name)) { %>
+          <% if (collectionInSync) { %>
             <i style="margin-left: 10px;" class="fa fa-check-circle"></i>
           <% } else { %>
             <i style="margin-left: 10px;" class="fa fa-times-circle"></i>
@@ -60,7 +69,7 @@
         </div>
       </div>
 
-      <% if (visible.indexOf(name) !== -1) { %>
+      <% if (collectionExpanded) { %>
       <div class="sectionShardContent">
         <% } else { %>
         <div class="sectionShardContent" style="display: none">
@@ -74,7 +83,7 @@
             </div>
           </div>
 
-          <% var counter = 0; var shardClass; %>
+          <% var shardClass; %>
           <% _.each(collection.Plan, function(shard, name) { %>
             <div class="pure-g pure-table pure-table-body">
 
@@ -92,14 +101,15 @@
                 <div class="<%= genClass1 %> left"><%= name %></div>
                 <div class="shardLeader <%= genClass1 %> positive left"><span><%= shard.leader %></span></div>
 
-                <% var found = null; %>
-                <% _.each(shard.followers, function(db) { %>
-                  <% if (db === shard.leader) { %>
-                    <% found = true; %>
+                <% var foundLeader = false; %>
+                <% _.each(shard.followers, function(s) { %>
+                  <% if (s === shard.leader) { %>
+                    <% foundLeader = true; %>
                   <% } %>
                 <% }); %>
 
-                <% if (found) { %>
+                <% var shardsNotInSync = 0; %>
+                <% if (foundLeader) { %>
                   <div class="<%= genClass2 %> mid"><i class="fa fa-circle-o-notch fa-spin"></i></div>
                 <% } else { %>
                   <% if (shard.followers.length === 0) { %>
@@ -109,31 +119,27 @@
                     <% var counter2 = 0; %>
                     <% var shardCssClass = 'inSync'; %>
 
-                    <% var shardsNotInSync = 0; %>
-                    <% _.each(shard.followers, function(db) { %>
-
-                      <% if (collections[collectionName].Current[name].followers.indexOf(db) > -1) { %>
+                    <% _.each(shard.followers, function(s) { %>
+                      <% if (collections[collectionName].Current[name].followers.indexOf(s) > -1) { %>
                         <% shardCssClass = 'inSync'; %>
                       <% } else { %>
                         <% shardCssClass = 'notInSync'; %>
                         <% shardsNotInSync++; %>
                       <% } %>
-
-                      <% if (shard.followers.length === 1) { %>
-                        <% string += '<span class="' + shardCssClass + '">' + db + '</span> '; %>
-                      <% } else { %>
-                        <% if (counter2 === 0) { %>
-                          <% string += '<span class="' + shardCssClass + '">' + db + '</span>'; counter2++; %>
-                        <% } else { %>
-                          <% string += ", " + '<span class="' + shardCssClass + '">' + db + '</span>'; %>
-                        <% } %>
+                      <% if (serversFailed[s]) { %>
+                        <% shardCssClass = 'failed'; %>
                       <% } %>
+
+                      <% if (counter2++ > 0) { %>
+                        <% string += ', '; %>
+                      <% } %>
+                      <% string += '<span class="' + shardCssClass + '">' + s + '</span>'; %>
                     <% }); %>
 
                     <div class="shardFollowers <%= genClass2 %> left"><%= string %></div>
                   <% } %>
 
-                  <% if (collectionInSync(collectionName)) { %>
+                  <% if (collectionInSync) { %>
                     <div class="<%= genClass1 %> left progressWrapper"><i class="fa fa-check-circle"></i></div>
                   <% } else { %>
                     <% if (shardsNotInSync > 0) { %>
@@ -149,7 +155,6 @@
               </div>
             </div>
 
-            <% counter++; %>
           <% }); %>
         </div>
 

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/shardsView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/shardsView.js
@@ -430,9 +430,18 @@
         ordered[key] = collections[key];
       });
 
+      var serversFailed = {};
+      var healthData = window.App.lastHealthCheckResult;
+      if (healthData && healthData.Health) {
+        Object.keys(healthData.Health).forEach(function(id) {
+          serversFailed[healthData.Health[id].ShortName] = healthData.Health[id].Status === 'FAILED';
+        });
+      }
+        
       this.$el.html(this.template.render({
         collections: ordered,
-        visible: this.visibleCollections
+        visible: this.visibleCollections,
+        serversFailed: serversFailed,
       }));
 
       // if we have only one collection to show, automatically open the entry

--- a/js/apps/system/_admin/aardvark/APP/frontend/scss/_shards.scss
+++ b/js/apps/system/_admin/aardvark/APP/frontend/scss/_shards.scss
@@ -17,6 +17,10 @@
   .notInSync {
     color: $c-warning;
   }
+
+  .failed {
+    color: $c-negative;
+  }
 }
 
 .sectionShard {


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/15085

* Close a potential gap during shard synchronization when moving from the
  initial sync step to the WAL tailing step. In this small gap the leader 
  could purge some of the WAL files that would be required by the following
  WAL tailing step. This was possible because at the end of the initial sync
  step, the snapshot on the leader is released, and there is a small window
  of time before the follower will issue its first WAL tailing request.

* Improve Shards overview in web UI: the number of currently syncing shards is
  now displayed per collection. Additionally, shards on failed servers are now
  displayed in a different color.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [ ] Backport for 3.7: *(Please link PR)*

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
