### PR TITLE
Enable pipelined write for RocksDB

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Change default value of startup option `--rocksdb.enable-pipelined-write`
+  from false to true.
+
 * When enabling the cluster supervision maintenance mode via the web UI, there
   is now the possibility to select a duration for the maintenance mode.
   Previous versions of ArangoDB always enabled the maintenance mode for one

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -513,7 +513,7 @@ void RocksDBEngine::start() {
   transactionOptions.transaction_lock_timeout = opts._transactionLockTimeout;
 
   _options.allow_fallocate = opts._allowFAllocate;
-  _options.enable_pipelined_write = opts._enablePipelinedWrite;
+  _options.enable_pipelined_write = true; // default value in RocksDB is actually _false_
   _options.write_buffer_size = static_cast<size_t>(opts._writeBufferSize);
   _options.max_write_buffer_number = static_cast<int>(opts._maxWriteBufferNumber);
   // The following setting deserves an explanation: We found that if we leave the


### PR DESCRIPTION
### Scope & Purpose

Enable pipelined write for RocksDB

* Change default value of startup option `--rocksdb.enable-pipelined-write`
  from false to true.

This is a test to see if setting the options improves write throughput in parallel setups. As all devel versions also undergo continous performance tests, we can also check if setting the option has adverse effects for single-threaded performance tests.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/808
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
