### PR TITLE
Fix issues with following term ids during rolling upgrade

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.7.16 (XXXX-XX-XX)
 --------------------
 
+* Fix issues during rolling upgrades from 3.8.0 to 3.8.x (x >= 1) and from
+  3.7.x (x <= 12) to 3.8.3. The problem was that older versions did not handle
+  following term ids that are sent from newer versions during synchronous
+  replication operations.
+
 * Fixed SEARCH-261: Fix possible race between file creation and directory
   cleaner (ArangoSearch).
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.7.16 (XXXX-XX-XX)
 --------------------
 
-* Fix issues during rolling upgrades from 3.8.0 to 3.8.x (x >= 1) and from
-  3.7.x (x <= 12) to 3.8.3. The problem was that older versions did not handle
+* Fix issues during rolling upgrades from 3.8.0 to 3.8.x (x >= 1) and from 3.7.x
+  (x <= 12) to 3.8.3. The problem was that older versions did not handle
   following term ids that are sent from newer versions during synchronous
   replication operations.
 

--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -505,6 +505,11 @@ VPackBuilder FollowerInfo::newShardEntry(VPackSlice oldValue) const {
   return newValue;
 }
 
+void FollowerInfo::setFollowingTermId(ServerID const& s, uint64_t value) {
+  WRITE_LOCKER(guard, _dataLock);
+  _followingTermId[s] = value;
+}
+
 uint64_t FollowerInfo::newFollowingTermId(ServerID const& s) noexcept {
   WRITE_LOCKER(guard, _dataLock);
   uint64_t i = 0;

--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -149,6 +149,12 @@ class FollowerInfo {
   Result remove(ServerID const& s);
 
   //////////////////////////////////////////////////////////////////////////////
+  /// @brief explicitly set the following term id for a follower.
+  /// this should only be used for special cases during upgrading or testing.
+  //////////////////////////////////////////////////////////////////////////////
+  void setFollowingTermId(ServerID const& s, uint64_t value);
+
+  //////////////////////////////////////////////////////////////////////////////
   /// @brief for each run of the "get-in-sync" protocol we generate a
   /// random number to identify this "following term". This is created
   /// when the follower fetches the exclusive lock to finally get in sync

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -1097,7 +1097,17 @@ Future<OperationResult> transaction::Methods::insertLocal(std::string const& cna
       if (options.isSynchronousReplicationFrom.empty()) {
         return OperationResult(TRI_ERROR_CLUSTER_SHARD_LEADER_RESIGNED, options);
       }
-      if (options.isSynchronousReplicationFrom != theLeader) {
+      bool sendRefusal = (options.isSynchronousReplicationFrom != theLeader);
+      TRI_IF_FAILURE("synchronousReplication::refuseOnFollower") {
+        sendRefusal = true;
+      }
+      TRI_IF_FAILURE("synchronousReplication::expectFollowingTerm") {
+        // expect a following term id or send a refusal
+        if (!options.isRestore) {
+          sendRefusal |= (options.isSynchronousReplicationFrom.find('_') == std::string::npos);
+        }
+      }
+      if (sendRefusal) {
         return OperationResult(TRI_ERROR_CLUSTER_SHARD_FOLLOWER_REFUSES_OPERATION, options);
       }
     }
@@ -1420,7 +1430,17 @@ Future<OperationResult> transaction::Methods::modifyLocal(std::string const& col
       if (options.isSynchronousReplicationFrom.empty()) {
         return OperationResult(TRI_ERROR_CLUSTER_SHARD_LEADER_RESIGNED);
       }
-      if (options.isSynchronousReplicationFrom != theLeader) {
+      bool sendRefusal = (options.isSynchronousReplicationFrom != theLeader);
+      TRI_IF_FAILURE("synchronousReplication::refuseOnFollower") {
+        sendRefusal = true;
+      }
+      TRI_IF_FAILURE("synchronousReplication::expectFollowingTerm") {
+        // expect a following term id or send a refusal
+        if (!options.isRestore) {
+          sendRefusal |= (options.isSynchronousReplicationFrom.find('_') == std::string::npos);
+        }
+      }
+      if (sendRefusal) {
         return OperationResult(TRI_ERROR_CLUSTER_SHARD_FOLLOWER_REFUSES_OPERATION);
       }
     }
@@ -1645,7 +1665,17 @@ Future<OperationResult> transaction::Methods::removeLocal(std::string const& col
       if (options.isSynchronousReplicationFrom.empty()) {
         return OperationResult(TRI_ERROR_CLUSTER_SHARD_LEADER_RESIGNED);
       }
-      if (options.isSynchronousReplicationFrom != theLeader) {
+      bool sendRefusal = (options.isSynchronousReplicationFrom != theLeader);
+      TRI_IF_FAILURE("synchronousReplication::refuseOnFollower") {
+        sendRefusal = true;
+      }
+      TRI_IF_FAILURE("synchronousReplication::expectFollowingTerm") {
+        // expect a following term id or send a refusal
+        if (!options.isRestore) {
+          sendRefusal |= (options.isSynchronousReplicationFrom.find('_') == std::string::npos);
+        }
+      }
+      if (sendRefusal) {
         return OperationResult(TRI_ERROR_CLUSTER_SHARD_FOLLOWER_REFUSES_OPERATION);
       }
     }
@@ -1879,7 +1909,17 @@ Future<OperationResult> transaction::Methods::truncateLocal(std::string const& c
       if (options.isSynchronousReplicationFrom.empty()) {
         return futures::makeFuture(OperationResult(TRI_ERROR_CLUSTER_SHARD_LEADER_RESIGNED));
       }
-      if (options.isSynchronousReplicationFrom != theLeader) {
+      bool sendRefusal = (options.isSynchronousReplicationFrom != theLeader);
+      TRI_IF_FAILURE("synchronousReplication::refuseOnFollower") {
+        sendRefusal = true;
+      }
+      TRI_IF_FAILURE("synchronousReplication::expectFollowingTerm") {
+        // expect a following term id or send a refusal
+        if (!options.isRestore) {
+          sendRefusal |= (options.isSynchronousReplicationFrom.find('_') == std::string::npos);
+        }
+      }
+      if (sendRefusal) {
         return futures::makeFuture(
             OperationResult(TRI_ERROR_CLUSTER_SHARD_FOLLOWER_REFUSES_OPERATION));
       }
@@ -1923,10 +1963,21 @@ Future<OperationResult> transaction::Methods::truncateLocal(std::string const& c
       reqOpts.param(StaticStrings::Compact, (options.truncateCompact ? "true" : "false"));
 
       for (auto const& f : *followers) {
-        reqOpts.param(StaticStrings::IsSynchronousReplicationString,
-            ServerState::instance()->getId() + "_" +
-            basics::StringUtils::itoa(
-              collection->followers()->getFollowingTermId(f)));
+        // check following term id for the follower: 
+        // if it is 0, it means that the follower cannot handle following
+        // term ids safely, so we only pass the leader id string to id but
+        // no following term. this happens for followers < 3.8.3
+        // if the following term id is != 0, we will pass it on along with
+        // the leader id string, in format "LEADER_FOLLOWINGTERMID"
+        uint64_t followingTermId = collection->followers()->getFollowingTermId(f);
+        if (followingTermId == 0) {
+          reqOpts.param(StaticStrings::IsSynchronousReplicationString,
+                        ServerState::instance()->getId());
+        } else {
+          reqOpts.param(StaticStrings::IsSynchronousReplicationString,
+              ServerState::instance()->getId() + "_" +
+              basics::StringUtils::itoa(followingTermId));
+        }
         // reqOpts is copied deep in sendRequestRetry, so we are OK to
         // change it in the loop!
         network::Headers headers;
@@ -2492,10 +2543,21 @@ Future<Result> Methods::replicateOperations(
 
   auto* pool = vocbase().server().getFeature<NetworkFeature>().pool();
   for (auto const& f : *followerList) {
-    reqOpts.param(StaticStrings::IsSynchronousReplicationString,
-        ServerState::instance()->getId() + "_" +
-        basics::StringUtils::itoa(
-          collection->followers()->getFollowingTermId(f)));
+    // check following term id for the follower: 
+    // if it is 0, it means that the follower cannot handle following
+    // term ids safely, so we only pass the leader id string to id but
+    // no following term. this happens for followers < 3.8.3
+    // if the following term id is != 0, we will pass it on along with
+    // the leader id string, in format "LEADER_FOLLOWINGTERMID"
+    uint64_t followingTermId = collection->followers()->getFollowingTermId(f);
+    if (followingTermId == 0) {
+      reqOpts.param(StaticStrings::IsSynchronousReplicationString,
+                    ServerState::instance()->getId());
+    } else {
+      reqOpts.param(StaticStrings::IsSynchronousReplicationString,
+          ServerState::instance()->getId() + "_" +
+          basics::StringUtils::itoa(followingTermId));
+    }
     // reqOpts is copied deep in sendRequestRetry, so we are OK to
     // change it in the loop!
     network::Headers headers;

--- a/js/client/modules/@arangodb/test-helper.js
+++ b/js/client/modules/@arangodb/test-helper.js
@@ -164,7 +164,7 @@ exports.getMetric = function (endpoint, name) {
   const primaryEndpoint = arango.getEndpoint();
   try {
     reconnectRetry(endpoint, db._name(), "root", "");
-    let res = arango.GET_RAW( '/_admin/metrics/v2');
+    let res = arango.GET_RAW( '/_admin/metrics');
     if (res.code !== 200) {
       throw "error fetching metric";
     }


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/15101

* Fix issues during rolling upgrades from 3.8.0 to 3.8.x (x >= 1) and from
  3.7.x (x <= 12) to 3.8.3. The problem was that older versions did not handle
  following term ids that are sent from newer versions during synchronous
  replication operations.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_client)
