### PR TITLE
Fix issues with following term ids during rolling upgrade

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Fix issues during rolling upgrades from 3.8.0 to 3.8.x (x >= 1) and from
+  3.7.x (x <= 12) to 3.8.3. The problem was that older versions did not handle
+  following term ids that are sent from newer versions during synchronous
+  replication operations.
+
 * Close a potential gap during shard synchronization when moving from the
   initial sync step to the WAL tailing step. In this small gap the leader 
   could purge some of the WAL files that would be required by the following

--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -551,6 +551,11 @@ VPackBuilder FollowerInfo::newShardEntry(VPackSlice oldValue) const {
   return newValue;
 }
 
+void FollowerInfo::setFollowingTermId(ServerID const& s, uint64_t value) {
+  WRITE_LOCKER(guard, _dataLock);
+  _followingTermId[s] = value;
+}
+
 uint64_t FollowerInfo::newFollowingTermId(ServerID const& s) noexcept {
   WRITE_LOCKER(guard, _dataLock);
   uint64_t i = 0;

--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -150,6 +150,12 @@ class FollowerInfo {
   Result remove(ServerID const& s);
 
   //////////////////////////////////////////////////////////////////////////////
+  /// @brief explicitly set the following term id for a follower.
+  /// this should only be used for special cases during upgrading or testing.
+  //////////////////////////////////////////////////////////////////////////////
+  void setFollowingTermId(ServerID const& s, uint64_t value);
+
+  //////////////////////////////////////////////////////////////////////////////
   /// @brief for each run of the "get-in-sync" protocol we generate a
   /// random number to identify this "following term". This is created
   /// when the follower fetches the exclusive lock to finally get in sync

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -449,7 +449,17 @@ arangodb::Result SynchronizeShard::getReadLock(
     body.add(TTL, VPackValue(timeout));
     body.add("serverId", VPackValue(arangodb::ServerState::instance()->getId()));
     body.add(StaticStrings::RebootId, VPackValue(ServerState::instance()->getRebootId().value()));
-    body.add(StaticStrings::ReplicationSoftLockOnly, VPackValue(soft)); 
+    body.add(StaticStrings::ReplicationSoftLockOnly, VPackValue(soft));
+    // the following attribute was added in 3.8.3:
+    // with this, the follower indicates to the leader that it is 
+    // capable of handling following term ids correctly.
+    bool sendWantFollowingTerm = true;
+    TRI_IF_FAILURE("SynchronizeShard::dontSendWantFollowingTerm") {
+      sendWantFollowingTerm = false;
+    }
+    if (sendWantFollowingTerm) {
+      body.add("wantFollowingTerm", VPackValue(true));
+    }
   }
   auto buf = body.steal();
 

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -2734,8 +2734,20 @@ void RestReplicationHandler::handleCommandHoldReadLockCollection() {
     VPackObjectBuilder bb(&b);
     b.add(StaticStrings::Error, VPackValue(false));
     if (!serverId.empty()) {
-      b.add(StaticStrings::FollowingTermId,
-            VPackValue(col->followers()->newFollowingTermId(serverId)));
+      // check if the follower sent us the "wantFollowingTerm" attribute.
+      // followers >= 3.8.3 will send this to indicate that they know how
+      // to handle following term ids safely
+      bool wantFollowingTerm = VelocyPackHelper::getBooleanValue(body, "wantFollowingTerm", false);
+      if (wantFollowingTerm) {
+        b.add(StaticStrings::FollowingTermId,
+              VPackValue(col->followers()->newFollowingTermId(serverId)));
+      } else {
+        // a client < 3.8.3 does not know how to handle following term ids
+        // safely. in this case we set the follower's term id to 0, so it
+        // will be ignored on followers < 3.8.3
+        col->followers()->setFollowingTermId(serverId, 0);
+        b.add(StaticStrings::FollowingTermId, VPackValue(0));
+      }
     }
 
     // also return the _current_ last log sequence number. this may be higher

--- a/tests/js/client/shell/shell-following-term-id-cluster.js
+++ b/tests/js/client/shell/shell-following-term-id-cluster.js
@@ -30,6 +30,7 @@ let jsunity = require('jsunity');
 let internal = require('internal');
 let arangodb = require('@arangodb');
 let db = arangodb.db;
+let { getMetric, debugCanUseFailAt, debugRemoveFailAt, debugSetFailAt, debugClearFailAt, waitForShardsInSync } = require('@arangodb/test-helper');
 
 function createCollectionWithKnownLeaderAndFollower(cn) {
   db._create(cn, {numberOfShards:1, replicationFactor:2});
@@ -64,20 +65,19 @@ function switchConnectionToFollower(collInfo) {
 function followingTermIdSuite() {
   'use strict';
   const cn = 'UnitTestsFollowingTermId';
-  let collInfo = {};
 
   return {
 
     setUp: function () {
       db._drop(cn);
-      collInfo = createCollectionWithKnownLeaderAndFollower(cn);
     },
 
     tearDown: function () {
       db._drop(cn);
     },
     
-    testFollowingTermIdSuite: function() {
+    testFollowingTermIdHandling: function() {
+      let collInfo = createCollectionWithKnownLeaderAndFollower(cn);
       // We have a shard whose leader and follower is known to us.
       
       // Let's insert some documents:
@@ -92,7 +92,7 @@ function followingTermIdSuite() {
       switchConnectionToFollower(collInfo);
       assertEqual(100, db._collection(collInfo.shard).count());
 
-      // Try to insert a document with the leaderId:
+      // Try to insert a document with only the leaderId:
       let res = arango.POST(`/_api/document/${collInfo.shard}?isSynchronousReplication=${collInfo.idMap[collInfo.leader]}`, {Hallo:101});
       assertTrue(res.error);
       assertEqual(406, res.code);
@@ -110,6 +110,125 @@ function followingTermIdSuite() {
       assertEqual(101, db._collection(collInfo.shard).count());
 
       switchConnectionToCoordinator(collInfo);
+    },
+    
+    testFollowingTermIdHandlingMixedMode: function() {
+      let collInfo = createCollectionWithKnownLeaderAndFollower(cn);
+
+      let followerEndpoint = collInfo.endpointMap[collInfo.follower];
+      let leaderEndpoint = collInfo.endpointMap[collInfo.leader];
+
+      if (!debugCanUseFailAt(followerEndpoint)) {
+        // test only works if we can use failure points
+        return;
+      }
+
+      // We have a shard whose leader and follower is known to us.
+      // now set failure points on the follower to get the shard out
+      // of sync
+      try {
+        switchConnectionToFollower(collInfo);
+        // this failure point makes a follower refuse every operation sent by the leader
+        // via synchronous replication
+        debugSetFailAt(followerEndpoint, "synchronousReplication::refuseOnFollower");
+        // this failure point makes the follower not send the "wantFollowingTermId" as part
+        // of the synchronization protocol
+        debugSetFailAt(followerEndpoint, "synchronousReplication::dontSendWantFollowingTerm");
+        
+        let droppedFollowersBefore = getMetric(leaderEndpoint, "arangodb_dropped_followers_total");
+     
+        switchConnectionToCoordinator(collInfo);
+        let c = db._collection(cn);
+        // this will drop the follower
+        c.insert({});
+        
+        let droppedFollowersAfter = getMetric(leaderEndpoint, "arangodb_dropped_followers_total");
+        assertTrue(droppedFollowersAfter > droppedFollowersBefore, { droppedFollowersBefore, droppedFollowersAfter });
+        
+        switchConnectionToFollower(collInfo);
+        debugRemoveFailAt(followerEndpoint, "synchronousReplication::refuseOnFollower");
+
+        // wait for everything to get back into sync
+        switchConnectionToCoordinator(collInfo);
+        assertEqual(1, db._collection(cn).count());
+        waitForShardsInSync(cn, 120); 
+
+        switchConnectionToFollower(collInfo);
+        assertEqual(1, db._collection(collInfo.shard).count());
+        
+        switchConnectionToLeader(collInfo);
+        assertEqual(1, db._collection(collInfo.shard).count());
+        
+      } finally {
+        switchConnectionToFollower(collInfo);
+        debugClearFailAt(followerEndpoint);
+
+        switchConnectionToCoordinator(collInfo);
+      }
+    },
+    
+    testFollowingTermIdIsSet: function() {
+      let collInfo = createCollectionWithKnownLeaderAndFollower(cn);
+
+      let followerEndpoint = collInfo.endpointMap[collInfo.follower];
+      let leaderEndpoint = collInfo.endpointMap[collInfo.leader];
+
+      if (!debugCanUseFailAt(followerEndpoint)) {
+        // test only works if we can use failure points
+        return;
+      }
+
+      // We have a shard whose leader and follower is known to us.
+      // now set failure points on the follower to get the shard out
+      // of sync
+      try {
+        switchConnectionToFollower(collInfo);
+
+        // this failure point makes a follower refuse every operation sent by the leader
+        // via synchronous replication
+        debugSetFailAt(followerEndpoint, "synchronousReplication::refuseOnFollower");
+        // this failure point makes the follower reject all synchronous replication requests
+        // that do not have a following term id
+        debugSetFailAt(followerEndpoint, "synchronousReplication::expectFollowingTerm");
+        
+        let droppedFollowersBefore = getMetric(leaderEndpoint, "arangodb_dropped_followers_total");
+     
+        switchConnectionToCoordinator(collInfo);
+        let c = db._collection(cn);
+        // this will drop the follower
+        c.insert({});
+        
+        let droppedFollowersAfter = getMetric(leaderEndpoint, "arangodb_dropped_followers_total");
+        assertTrue(droppedFollowersAfter > droppedFollowersBefore, { droppedFollowersBefore, droppedFollowersAfter });
+        
+        switchConnectionToFollower(collInfo);
+        debugRemoveFailAt(followerEndpoint, "synchronousReplication::refuseOnFollower");
+
+        // wait for everything to get back into sync
+        switchConnectionToCoordinator(collInfo);
+        assertEqual(1, db._collection(cn).count());
+        waitForShardsInSync(cn, 120); 
+
+        switchConnectionToFollower(collInfo);
+        assertEqual(1, db._collection(collInfo.shard).count());
+        
+        switchConnectionToLeader(collInfo);
+        assertEqual(1, db._collection(collInfo.shard).count());
+        
+
+        droppedFollowersBefore = getMetric(leaderEndpoint, "arangodb_dropped_followers_total");
+        // the following insert should not drop any followers
+        switchConnectionToCoordinator(collInfo);
+        c.insert({});
+        
+        droppedFollowersAfter = getMetric(leaderEndpoint, "arangodb_dropped_followers_total");
+        assertEqual(droppedFollowersAfter, droppedFollowersBefore);
+        
+      } finally {
+        switchConnectionToFollower(collInfo);
+        debugClearFailAt(followerEndpoint);
+        switchConnectionToCoordinator(collInfo);
+      }
     },
     
   };


### PR DESCRIPTION
### Scope & Purpose

* Fix issues during rolling upgrades from 3.8.0 to 3.8.x (x >= 1) and from
  3.7.x (x <= 12) to 3.8.3. The problem was that older versions did not handle
  following term ids that are sent from newer versions during synchronous
  replication operations.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/15099
- [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/15098
- [x] Backport for 3.7: https://github.com/arangodb/arangodb/pull/15100

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (e.g. in shell_client)
