### PR TITLE
Added documentation for backport for PR 15095

### DIFF
--- a/Documentation/DocuBlocks/Rest/Cursors/post_api_cursor.md
+++ b/Documentation/DocuBlocks/Rest/Cursors/post_api_cursor.md
@@ -235,6 +235,16 @@ accessed in the query.
 @RESTRETURNCODE{405}
 The server will respond with *HTTP 405* if an unsupported HTTP method is used.
 
+@RESTRETURNCODE{410}
+The server will respond with *HTTP 410* if a server which will process the query
+or is the leader for a shard which is used in the query stops responding, but 
+the connection has not been closed.
+
+@RESTRETURNCODE{503}
+The server will respond with *HTTP 503* if a server which will process the query
+or is the leader for a shard which is used in the query is down, either for 
+going through a restart, a failure or connectivity issues.
+
 @EXAMPLES
 
 Execute a query and extract the result in a single go

--- a/Documentation/DocuBlocks/Rest/Cursors/post_api_cursor.md
+++ b/Documentation/DocuBlocks/Rest/Cursors/post_api_cursor.md
@@ -241,7 +241,7 @@ or is the leader for a shard which is used in the query stops responding, but
 the connection has not been closed.
 
 @RESTRETURNCODE{503}
-The server will respond with *HTTP 503* if a server which will process the query
+The server will respond with *HTTP 503* if a server which processes the query
 or is the leader for a shard which is used in the query is down, either for 
 going through a restart, a failure or connectivity issues.
 

--- a/Documentation/DocuBlocks/Rest/Cursors/post_api_cursor.md
+++ b/Documentation/DocuBlocks/Rest/Cursors/post_api_cursor.md
@@ -236,7 +236,7 @@ accessed in the query.
 The server will respond with *HTTP 405* if an unsupported HTTP method is used.
 
 @RESTRETURNCODE{410}
-The server will respond with *HTTP 410* if a server which will process the query
+The server will respond with *HTTP 410* if a server which processes the query
 or is the leader for a shard which is used in the query stops responding, but 
 the connection has not been closed.
 

--- a/Documentation/DocuBlocks/Rest/Cursors/post_api_cursor_identifier.md
+++ b/Documentation/DocuBlocks/Rest/Cursors/post_api_cursor_identifier.md
@@ -35,6 +35,17 @@ If the cursor identifier is omitted, the server will respond with *HTTP 404*.
 If no cursor with the specified identifier can be found, the server will respond
 with *HTTP 404*.
 
+@RESTRETURNCODE{410}
+The server will respond with *HTTP 410* if a server which will process the query
+or is the leader for a shard which is used in the query stops responding, but 
+the connection has not been closed.
+
+@RESTRETURNCODE{503}
+The server will respond with *HTTP 503* if a server which will process the query
+or is the leader for a shard which is used in the query is down, either for 
+going through a restart, a failure or connectivity issues.
+
+
 @EXAMPLES
 
 Valid request for next batch

--- a/Documentation/DocuBlocks/Rest/Cursors/post_api_cursor_identifier.md
+++ b/Documentation/DocuBlocks/Rest/Cursors/post_api_cursor_identifier.md
@@ -41,7 +41,7 @@ or is the leader for a shard which is used in the query stops responding, but
 the connection has not been closed.
 
 @RESTRETURNCODE{503}
-The server will respond with *HTTP 503* if a server which will process the query
+The server will respond with *HTTP 503* if a server which processes the query
 or is the leader for a shard which is used in the query is down, either for 
 going through a restart, a failure or connectivity issues.
 

--- a/Documentation/DocuBlocks/Rest/Cursors/post_api_cursor_identifier.md
+++ b/Documentation/DocuBlocks/Rest/Cursors/post_api_cursor_identifier.md
@@ -36,7 +36,7 @@ If no cursor with the specified identifier can be found, the server will respond
 with *HTTP 404*.
 
 @RESTRETURNCODE{410}
-The server will respond with *HTTP 410* if a server which will process the query
+The server will respond with *HTTP 410* if a server which processes the query
 or is the leader for a shard which is used in the query stops responding, but 
 the connection has not been closed.
 

--- a/Documentation/DocuBlocks/Rest/Cursors/put_api_cursor_identifier.md
+++ b/Documentation/DocuBlocks/Rest/Cursors/put_api_cursor_identifier.md
@@ -41,6 +41,17 @@ If the cursor identifier is omitted, the server will respond with *HTTP 404*.
 If no cursor with the specified identifier can be found, the server will respond
 with *HTTP 404*.
 
+@RESTRETURNCODE{410}
+The server will respond with *HTTP 410* if a server which will process the query
+or is the leader for a shard which is used in the query stops responding, but 
+the connection has not been closed.
+
+@RESTRETURNCODE{503}
+The server will respond with *HTTP 503* if a server which will process the query
+or is the leader for a shard which is used in the query is down, either for 
+going through a restart, a failure or connectivity issues.
+
+
 @EXAMPLES
 
 Valid request for next batch

--- a/Documentation/DocuBlocks/Rest/Cursors/put_api_cursor_identifier.md
+++ b/Documentation/DocuBlocks/Rest/Cursors/put_api_cursor_identifier.md
@@ -42,7 +42,7 @@ If no cursor with the specified identifier can be found, the server will respond
 with *HTTP 404*.
 
 @RESTRETURNCODE{410}
-The server will respond with *HTTP 410* if a server which will process the query
+The server will respond with *HTTP 410* if a server which processes the query
 or is the leader for a shard which is used in the query stops responding, but 
 the connection has not been closed.
 


### PR DESCRIPTION
### Scope & Purpose

Backport for https://github.com/arangodb/arangodb/pull/15095.
Documentation for https://arangodb.atlassian.net/browse/APM-185 and https://arangodb.atlassian.net/browse/APM-68. 
During the execution of a query in a cluster, for methods POST and PUT, there are cases in which there are 2 other  HTTP return codes: 410 and 503. 

The server will respond with HTTP 410 if a server which will process the query
or is the leader for a shard which is used in the query stops responding, but 
the connection has not been closed.

The server will respond with HTTP 503 if a server which will process the query
or is the leader for a shard which is used in the query is down, either for 
going through a restart, a failure or connectivity issues.

Obs.: for DELETE, this can be the case as well, must find an example in which these codes are returned.

#### Backports:

Backport for https://github.com/arangodb/arangodb/pull/15095

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/APM-185 and https://arangodb.atlassian.net/browse/APM-68
- [ ] Design document: 

### Testing & Verification

No tests required. 

