### PR TITLE
Extend Windows minidump with referenced memory regions.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Extend Windows minidumps with memory regions referenced from CPU registers or
+  the stack to provide more contextual information in case of crashes.
+
 * Add option to content-transfer encode gzip Foxx replies.
 
 * Simplify internal request compression/decompression handling code.

--- a/lib/Basics/CrashHandler.cpp
+++ b/lib/Basics/CrashHandler.cpp
@@ -492,6 +492,16 @@ void crashHandlerSignalHandler(int signal, siginfo_t* info, void* ucontext) {
 static std::string miniDumpDirectory = "C:\\temp";
 static std::mutex miniDumpLock;
 
+// TODO - ATM if these are put inside the function MSVC complains that they
+// are not captured in the lambda, but a lamba with captures cannot convert
+// to a function pointer. Since these are constexpr is should not be necessary
+// to capture them, and with C++20 enabled MSVC no longer complains.
+// So once we have upgraded to C++20 these should be move into the function.
+constexpr DWORD64 blockSize = 1024;  // 1kb
+constexpr DWORD64 maxStackAddrs = 2048;
+constexpr DWORD maxNumAddrs = 160000;
+constexpr DWORD numRegs = 16;
+
 void createMiniDump(EXCEPTION_POINTERS* pointers) {
   // we have to serialize calls to MiniDumpWriteDump
   std::lock_guard<std::mutex> lock(miniDumpLock);
@@ -525,10 +535,106 @@ void createMiniDump(EXCEPTION_POINTERS* pointers) {
   exceptionInfo.ThreadId = GetCurrentThreadId();
   exceptionInfo.ExceptionPointers = pointers;
   exceptionInfo.ClientPointers = FALSE;
+  
+  // We try to gather some additional information from referenced memory
+  // In total we gather up to 16000 memory blocks of 1kb each.
+  // We consider only addresses that reference some memory block that can
+  // actually be read (-> !IsBadReadPtr).
+
+  // we want to have enough addresses to cover all 16 registers plus all indirections and all
+  // maxStackAddrs stack addresses
+  static_assert(maxNumAddrs > maxStackAddrs + numRegs * (blockSize / sizeof(void*)));
+  
+  DWORD64 addrs[maxNumAddrs];
+  DWORD numAddrs = 0;
+
+  if (pointers) {
+    auto addAddr = [&addrs, &numAddrs](DWORD64 reg) {
+      auto base = reg & ~(blockSize - 1);
+      if (base == 0 || IsBadReadPtr((void*)base, blockSize) || numAddrs >= maxNumAddrs) {
+        return;
+      }
+      for (DWORD i = 0; i < numAddrs; ++i) {
+        if (addrs[i] == base) {
+          return;
+        }
+      }
+      addrs[numAddrs++] = base;
+    };
+
+    // we take the values of all general purpose registers
+    auto& ctx = *pointers->ContextRecord;
+    addAddr(ctx.Rax);
+    addAddr(ctx.Rcx);
+    addAddr(ctx.Rdx);
+    addAddr(ctx.Rbx);
+    addAddr(ctx.Rsp);
+    addAddr(ctx.Rbp);
+    addAddr(ctx.Rsi);
+    addAddr(ctx.Rdi);
+    addAddr(ctx.R8);
+    addAddr(ctx.R9);
+    addAddr(ctx.R10);
+    addAddr(ctx.R11);
+    addAddr(ctx.R12);
+    addAddr(ctx.R13);
+    addAddr(ctx.R14);
+    addAddr(ctx.R15);
+    TRI_ASSERT(numAddrs <= numRegs);
+
+    // Take the first 2048 pointers from the stack and add them to the address list.
+    // We use the thread information block (TIB) to get the base address of the stack
+    // to handle the (unlikely) cases where the stack has less than 2048 items.
+    auto* tib = (PNT_TIB)NtCurrentTeb();
+    auto numStackAddrs = std::min(((DWORD64)tib->StackBase - ctx.Rsp) / sizeof(void*), maxStackAddrs);
+    void** p = (void**)ctx.Rsp;
+    for (DWORD64 i = 0; i < numStackAddrs; ++i) {
+      addAddr((DWORD64)p[i]);
+    }
+
+    // Now we take all the addresses we gathered so far and add all indirect addresses,
+    // i.e., we take each 1024 byte block and add all 128 potential addresses from that
+    // block (as long as we don't exceed our limit).
+    // That way can follow at least one level of indirection when analyzing the dump.
+    DWORD idx = numAddrs;
+    do {
+      --idx;
+      void** p = (void**)addrs[idx];
+      for (DWORD i = 0; i < blockSize / sizeof(void*) && numAddrs < maxNumAddrs; ++i) {
+        auto base = (DWORD64)p[i] & ~(blockSize - 1);
+        if (base != 0) {
+          addrs[numAddrs++] = base;
+        }
+      }
+    } while (idx != 0 && numAddrs < maxNumAddrs);
+  }
+
+  struct CallbackParam {
+    DWORD64* addrs;
+    DWORD idx;
+    DWORD numAddrs;
+  };
+  CallbackParam param{addrs, 0, numAddrs};
+
+  auto callback = [](PVOID callbackParam, PMINIDUMP_CALLBACK_INPUT callbackInput, PMINIDUMP_CALLBACK_OUTPUT callbackOutput) -> BOOL {
+    auto* param = static_cast<CallbackParam*>(callbackParam);
+    if (callbackInput->CallbackType == MemoryCallback && param->idx < param->numAddrs) {
+      callbackOutput->MemoryBase = param->addrs[param->idx];
+      callbackOutput->MemorySize = blockSize;
+      ++param->idx;
+    }
+    return TRUE;
+  };
+  
+  MINIDUMP_CALLBACK_INFORMATION callbackInfo{
+    callback,
+    &param
+  };
 
   if (MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hFile,
                         MINIDUMP_TYPE(MiniDumpNormal | MiniDumpWithProcessThreadData | MiniDumpWithDataSegs),
-                        pointers ? &exceptionInfo : nullptr, nullptr, nullptr)) {
+                        pointers ? &exceptionInfo : nullptr, nullptr,
+                        pointers ? &callbackInfo : nullptr)) {
     char* p = &buffer[0];
     appendNullTerminatedString("Wrote minidump: ", p);
     appendNullTerminatedString(filename, p);

--- a/lib/Basics/CrashHandler.cpp
+++ b/lib/Basics/CrashHandler.cpp
@@ -632,7 +632,7 @@ void createMiniDump(EXCEPTION_POINTERS* pointers) {
   };
 
   if (MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hFile,
-                        MINIDUMP_TYPE(MiniDumpNormal | MiniDumpWithProcessThreadData | MiniDumpWithDataSegs),
+                        MINIDUMP_TYPE(MiniDumpNormal | MiniDumpWithProcessThreadData | MiniDumpWithDataSegs | MiniDumpIgnoreInaccessibleMemory),
                         pointers ? &exceptionInfo : nullptr, nullptr,
                         pointers ? &callbackInfo : nullptr)) {
     char* p = &buffer[0];


### PR DESCRIPTION
### Scope & Purpose

Extend Windows minidumps with memory regions referenced from CPU registers or the stack to provide more contextual information in case of crashes.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backport for 3.9: #15114
- [x] Backport for 3.8: #15115

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
