### PR TITLE
Extend Windows minidump with referenced memory regions.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.8.3 (XXXX-XX-XX)
 -------------------
 
+* Extend Windows minidumps with memory regions referenced from CPU registers or
+  the stack to provide more contextual information in case of crashes.
+
 * Fix issues during rolling upgrades from 3.8.0 to 3.8.x (x >= 1) and from 3.7.x
   (x <= 12) to 3.8.3. The problem was that older versions did not handle
   following term ids that are sent from newer versions during synchronous

--- a/lib/Basics/CrashHandler.cpp
+++ b/lib/Basics/CrashHandler.cpp
@@ -628,7 +628,7 @@ void createMiniDump(EXCEPTION_POINTERS* pointers) {
   };
 
   if (MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hFile,
-                        MINIDUMP_TYPE(MiniDumpNormal | MiniDumpWithProcessThreadData | MiniDumpWithDataSegs),
+                        MINIDUMP_TYPE(MiniDumpNormal | MiniDumpWithProcessThreadData | MiniDumpWithDataSegs | MiniDumpIgnoreInaccessibleMemory),
                         pointers ? &exceptionInfo : nullptr, nullptr,
                         pointers ? &callbackInfo : nullptr)) {
     char* p = &buffer[0];


### PR DESCRIPTION
### Scope & Purpose

Extend Windows minidumps with memory regions referenced from CPU registers or the stack to provide more contextual information in case of crashes.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
