### PR TITLE
Bugfixes for old incremental sync protocol

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.7.16 (XXXX-XX-XX)
 --------------------
 
+* Fixed an issue in old incremental sync protocol with document keys that 
+  contained special characters (`%`). These keys could be send unencoded in
+  the incremental sync protocol, leading to wrong key ranges being transfered
+  between leader and follower, and thus causing follow-up errors and preventing
+  getting in sync.
+
 * Fixed SEARCH-261: Fix possible race between file creation and directory
   cleaner (ArangoSearch).
 

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -2198,8 +2198,7 @@ Result RocksDBCollection::removeDocument(arangodb::transaction::Methods* trx,
   }
 
   if (res.ok()) {
-    RocksDBTransactionState::toState(trx)->trackRemove(_logicalCollection.id(),
-                                                       documentId.id());
+    RocksDBTransactionState::toState(trx)->trackRemove(_logicalCollection.id(), revisionId);
   }
 
   return res;

--- a/arangod/RocksDBEngine/RocksDBCollection.h
+++ b/arangod/RocksDBEngine/RocksDBCollection.h
@@ -164,20 +164,24 @@ class RocksDBCollection final : public RocksDBMetaCollection {
                                   RocksDBSavePoint& savepoint,
                                   LocalDocumentId const& documentId,
                                   arangodb::velocypack::Slice const& doc,
-                                  OperationOptions& options) const;
+                                  OperationOptions& options,
+                                  TRI_voc_rid_t revisionId) const;
 
   arangodb::Result removeDocument(arangodb::transaction::Methods* trx,
+                                  RocksDBSavePoint& savepoint,
                                   LocalDocumentId const& documentId,
                                   arangodb::velocypack::Slice const& doc,
-                                  OperationOptions& options) const;
+                                  OperationOptions& options,
+                                  TRI_voc_rid_t revisionId) const;
 
-  arangodb::Result updateDocument(transaction::Methods* trx, 
+  arangodb::Result modifyDocument(transaction::Methods* trx, 
                                   RocksDBSavePoint& savepoint,
                                   LocalDocumentId const& oldDocumentId,
                                   arangodb::velocypack::Slice const& oldDoc,
                                   LocalDocumentId const& newDocumentId,
                                   arangodb::velocypack::Slice const& newDoc,
-                                  OperationOptions& options) const;
+                                  OperationOptions& options,
+                                  TRI_voc_rid_t revisionId) const;
 
   /// @brief lookup document in cache and / or rocksdb
   /// @param readCache attempt to read from cache

--- a/arangod/RocksDBEngine/RocksDBMethods.h
+++ b/arangod/RocksDBEngine/RocksDBMethods.h
@@ -85,6 +85,7 @@ class RocksDBMethods {
 
   virtual void SetSavePoint() = 0;
   virtual rocksdb::Status RollbackToSavePoint() = 0;
+  virtual rocksdb::Status RollbackToWriteBatchSavePoint() = 0;
   virtual void PopSavePoint() = 0;
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
@@ -118,6 +119,9 @@ class RocksDBReadOnlyMethods final : public RocksDBMethods {
 
   void SetSavePoint() override {}
   rocksdb::Status RollbackToSavePoint() override {
+    return rocksdb::Status::OK();
+  }
+  rocksdb::Status RollbackToWriteBatchSavePoint() override {
     return rocksdb::Status::OK();
   }
   void PopSavePoint() override {}
@@ -156,6 +160,7 @@ class RocksDBTrxMethods : public RocksDBMethods {
 
   void SetSavePoint() override;
   rocksdb::Status RollbackToSavePoint() override;
+  rocksdb::Status RollbackToWriteBatchSavePoint() override;
   void PopSavePoint() override;
 
   bool _indexingDisabled;
@@ -187,6 +192,9 @@ class RocksDBBatchedMethods final : public RocksDBMethods {
   rocksdb::Status RollbackToSavePoint() override {
     return rocksdb::Status::OK();
   }
+  rocksdb::Status RollbackToWriteBatchSavePoint() override {
+    return rocksdb::Status::OK();
+  }
   void PopSavePoint() override {}
 
  private:
@@ -216,6 +224,9 @@ class RocksDBBatchedWithIndexMethods final : public RocksDBMethods {
 
   void SetSavePoint() override {}
   rocksdb::Status RollbackToSavePoint() override {
+    return rocksdb::Status::OK();
+  }
+  rocksdb::Status RollbackToWriteBatchSavePoint() override {
     return rocksdb::Status::OK();
   }
   void PopSavePoint() override {}

--- a/arangod/RocksDBEngine/RocksDBSavePoint.cpp
+++ b/arangod/RocksDBEngine/RocksDBSavePoint.cpp
@@ -1,7 +1,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2021 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -17,10 +18,11 @@
 ///
 /// Copyright holder is ArangoDB GmbH, Cologne, Germany
 ///
-/// @author Simon Grätzer
+/// @author Jan Steemann
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "RocksDBSavePoint.h"
+#include "Basics/Exceptions.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
@@ -31,17 +33,28 @@
 
 namespace arangodb {
 
-RocksDBSavePoint::RocksDBSavePoint(transaction::Methods* trx,
+RocksDBSavePoint::RocksDBSavePoint(RocksDBTransactionState* state,
+                                   transaction::Methods* trx,
                                    TRI_voc_document_operation_e operationType)
-    : _trx(trx),
+    : _state(state),
+      _trx(trx),
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+      _numCommitsAtStart(0),
+#endif
       _operationType(operationType),
-      _handled(_trx->isSingleOperationTransaction()) {
+      _handled(_trx->isSingleOperationTransaction()),
+      _tainted(false) {
+  TRI_ASSERT(_state != nullptr);
   TRI_ASSERT(trx != nullptr);
+
   if (!_handled) {
     auto mthds = RocksDBTransactionState::toMethods(_trx);
     // only create a savepoint when necessary
     mthds->SetSavePoint();
   }
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  _numCommitsAtStart = _state->numCommits();
+#endif
 }
 
 RocksDBSavePoint::~RocksDBSavePoint() {
@@ -60,43 +73,79 @@ RocksDBSavePoint::~RocksDBSavePoint() {
   }
 }
 
-void RocksDBSavePoint::cancel() {
-  // unconditionally cancel the savepoint
-  if (!_handled) {
-    auto mthds = RocksDBTransactionState::toMethods(_trx);
-    mthds->PopSavePoint();
-  
-    // this will prevent the rollback call in the destructor
-    _handled = true;
-  }
+void RocksDBSavePoint::prepareOperation(TRI_voc_cid_t cid, TRI_voc_rid_t rid) {
+  TRI_ASSERT(!_tainted);
+
+  _state->prepareOperation(cid, rid, _operationType);
 }
 
-void RocksDBSavePoint::finish(bool hasPerformedIntermediateCommit) {
-  if (!_handled && !hasPerformedIntermediateCommit) {
-    // pop the savepoint from the transaction in order to
-    // save some memory for transactions with many operations
-    // this is only safe to do when we have a created a savepoint
-    // when creating the guard, and when there hasn't been an
-    // intermediate commit in the transaction
-    // when there has been an intermediate commit, we must
-    // leave the savepoint alone, because it belonged to another
-    // transaction, and the current transaction will not have any
-    // savepoint
-    auto mthds = RocksDBTransactionState::toMethods(_trx);
-    mthds->PopSavePoint();
+/// @brief acknowledges the current savepoint, so there
+/// will be no rollback when the destructor is called
+Result RocksDBSavePoint::finish(TRI_voc_cid_t cid, TRI_voc_rid_t rid) {
+  bool hasPerformedIntermediateCommit = false;
+  Result res = basics::catchToResult([&]() -> Result {
+    return _state->addOperation(cid, rid, _operationType, hasPerformedIntermediateCommit);
+  });
+
+  if (!_handled) {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    TRI_ASSERT(_numCommitsAtStart + (hasPerformedIntermediateCommit ? 1 : 0) == _state->numCommits());
+#endif
+
+    if (res.ok()) {
+      if (!hasPerformedIntermediateCommit) {
+        // pop the savepoint from the transaction in order to
+        // save some memory for transactions with many operations
+        // this is only safe to do when we have a created a savepoint
+        // when creating the guard, and when there hasn't been an
+        // intermediate commit in the transaction
+        // when there has been an intermediate commit, we must
+        // leave the savepoint alone, because it belonged to another
+        // transaction, and the current transaction will not have any
+        // savepoint
+        auto mthds = RocksDBTransactionState::toMethods(_trx);
+        mthds->PopSavePoint();
+      }
+    
+      // this will prevent the rollback call in the destructor
+      _handled = true;
+    } else {
+      TRI_ASSERT(res.fail());
+      if (hasPerformedIntermediateCommit) {
+        // very rare case reached only during testing
+        _handled = true;
+      }
+    }
   }
 
-  // this will prevent the rollback call in the destructor
-  _handled = true;
+  return res;
 }
 
 void RocksDBSavePoint::rollback() {
   TRI_ASSERT(!_handled);
   auto mthds = RocksDBTransactionState::toMethods(_trx);
-  mthds->RollbackToSavePoint();
 
-  auto state = RocksDBTransactionState::toState(_trx);
-  state->rollbackOperation(_operationType);
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  TRI_ASSERT(_numCommitsAtStart == _state->numCommits());
+#endif
+
+  rocksdb::Status s;
+  if (_tainted) {
+    // we have written at least one Put or Delete operation after
+    // we created the savepoint. because that has modified the
+    // WBWI, we need to do a full rebuild
+    s = mthds->RollbackToSavePoint();
+  } else {
+    // we have written only LogData values since we created the
+    // savepoint. we can get away by rolling back the WBWI's
+    // underlying WriteBatch only. this is a lot faster (simple
+    // std::string::resize instead of a full rebuild of the WBWI
+    // from the WriteBatch)
+    s = mthds->RollbackToWriteBatchSavePoint();
+  }  
+  TRI_ASSERT(s.ok());
+
+  _state->rollbackOperation(_operationType);
 
   _handled = true;  // in order to not roll back again by accident
 }

--- a/arangod/RocksDBEngine/RocksDBSavePoint.h
+++ b/arangod/RocksDBEngine/RocksDBSavePoint.h
@@ -1,7 +1,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2021 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -17,40 +18,58 @@
 ///
 /// Copyright holder is ArangoDB GmbH, Cologne, Germany
 ///
-/// @author Simon Grätzer
+/// @author Jan Steemann
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef ARANGOD_ROCKSDB_ROCKSDB_SAVEPOINT_H
 #define ARANGOD_ROCKSDB_ROCKSDB_SAVEPOINT_H 1
 
+#include "Basics/Result.h"
+#include "RocksDBEngine/RocksDBCommon.h"
 #include "VocBase/voc-types.h"
 
 namespace arangodb {
+class RocksDBTransactionState;
+
 namespace transaction {
 class Methods;
 }
 
 class RocksDBSavePoint {
  public:
-  RocksDBSavePoint(transaction::Methods* trx, TRI_voc_document_operation_e operationType);
-  ~RocksDBSavePoint();
-  
-  /// @brief unconditionally cancel the savepoint
-  void cancel();
+  RocksDBSavePoint(RocksDBTransactionState* state,
+                   transaction::Methods* trx, 
+                   TRI_voc_document_operation_e operationType);
 
+  ~RocksDBSavePoint();
+
+  void prepareOperation(TRI_voc_cid_t cid, TRI_voc_rid_t rid);
+  
   /// @brief acknowledges the current savepoint, so there
   /// will be no rollback when the destructor is called
-  /// if an intermediate commit was performed, pass a value of
-  /// true, false otherwise
-  void finish(bool hasPerformedIntermediateCommit);
+  [[nodiscard]] Result finish(TRI_voc_cid_t cid, TRI_voc_rid_t rid);
+  
+  TRI_voc_document_operation_e operationType() const {
+    return _operationType;
+  }
 
+  /// @brief this is going to be called if at least one Put or Delete
+  /// has made it into the underyling WBWI. if so, on rollback we must
+  /// perform a full rebuild
+  void tainted() { _tainted = true; }
+  
  private:
   void rollback();
 
  private:
+  RocksDBTransactionState* _state;
   transaction::Methods* _trx;
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  uint64_t _numCommitsAtStart;
+#endif
   TRI_voc_document_operation_e const _operationType;
   bool _handled;
+  bool _tainted;
 };
 
 }  // namespace arangodb

--- a/tests/js/common/shell/shell-collection.js
+++ b/tests/js/common/shell/shell-collection.js
@@ -238,7 +238,7 @@ function CollectionSuite () {
 
       c1.truncate({ compact: false });
       var r5 = c1.revision();
-      assertEqual(-1, testHelper.compareStringIds(r5, r4));
+      assertEqual(1, testHelper.compareStringIds(r5, r4));
 
       // unload
       c1.unload();

--- a/tests/js/server/replication/ongoing/global/replication-ongoing-global.js
+++ b/tests/js/server/replication/ongoing/global/replication-ongoing-global.js
@@ -153,10 +153,10 @@ const compare = function (masterFunc, masterFunc2, slaveFuncOngoing, slaveFuncFi
       console.topic('replication=debug', 'waiting for slave to catch up');
       printed = true;
     }
-    internal.wait(0.5, false);
+    internal.wait(0.25, false);
   }
 
-  internal.wait(1.0, false);
+  internal.wait(0.1, false);
   db._flushCache();
   slaveFuncFinal(state);
 };

--- a/tests/js/server/replication/static/replication-static.js
+++ b/tests/js/server/replication/static/replication-static.js
@@ -156,7 +156,7 @@ const compare = function (masterFunc, slaveFunc, applierConfiguration) {
       console.debug('waiting for slave to catch up');
       printed = true;
     }
-    internal.wait(0.5, false);
+    internal.wait(0.2, false);
   }
 
   db._flushCache();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/15120 (plus additional changes)

* Fixed an issue in old incremental sync protocol with document keys that
  contained special characters (`%`). These keys could be send unencoded in
  the incremental sync protocol, leading to wrong key ranges being transfered
  between leader and follower, and thus causing follow-up errors and preventing
  getting in sync.

* Additionally, this PR improves the behavior of savepoints during
  incremental sync: previously, if during a preflight check it was found
  that a document cannot be inserted/updated, some LogData leftovers for
  the document may have remained in the WriteBatchWithIndex. These will
  have made it into WAL when the overall transaction was committed. This
  was probably harmless, but is now cleaned up.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (replication_sync, replication_ongoing)
