### PR TITLE
Bugfixes for old incremental sync protocol

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.8.3 (XXXX-XX-XX)
 -------------------
 
+* Fixed an issue in old incremental sync protocol with document keys that
+  contained special characters (`%`). These keys could be send unencoded in
+  the incremental sync protocol, leading to wrong key ranges being transfered
+  between leader and follower, and thus causing follow-up errors and preventing
+  getting in sync.
+
 * Fix issues during rolling upgrades from 3.8.0 to 3.8.x (x >= 1) and from 3.7.x
   (x <= 12) to 3.8.3. The problem was that older versions did not handle
   following term ids that are sent from newer versions during synchronous

--- a/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
+++ b/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
@@ -200,7 +200,7 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
   {
     std::string const url =
         baseUrl + "/" + keysId + "?type=keys&chunk=" + std::to_string(chunkId) +
-        "&chunkSize=" + std::to_string(chunkSize) + "&low=" + lowString;
+        "&chunkSize=" + std::to_string(chunkSize) + "&low=" + basics::StringUtils::encodeURIComponent(lowString);
 
     syncer.setProgress(std::string("fetching keys chunk ") +
                        std::to_string(chunkId) + " from " + url);
@@ -258,6 +258,9 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
                       " Chunk: " + std::to_string(chunkId));
   }
   TRI_ASSERT(numKeys > 0);
+  
+  // this will be very verbose, so intentionally not active
+  // LOG_TOPIC("3c002", TRACE, Logger::REPLICATION) << "received chunk: " << responseBody.toJson();
 
   // state for RocksDBCollection insert/replace/remove
   ManagedDocumentResult mdr, previous;
@@ -388,17 +391,17 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
   }();
 
 
-  LOG_TOPIC("48f94", TRACE, Logger::REPLICATION)
-      << "will refetch " << toFetch.size() << " documents for this chunk";
-
   keyBuilder->clear();
   keyBuilder->openArray(false);
   for (auto const& it : toFetch) {
     keyBuilder->add(VPackValue(it));
   }
   keyBuilder->close();
-
+  
   std::string const keyJsonString(keyBuilder->slice().toJson());
+  // this will be very verbose, so intentionally not active
+  // LOG_TOPIC("48f94", TRACE, Logger::REPLICATION)
+  //     << "will refetch " << toFetch.size() << " documents for this chunk: " << keyJsonString;
 
   size_t offsetInChunk = 0;
   while (true) {
@@ -407,7 +410,7 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
     {
       std::string const url =
           baseUrl + "/" + keysId + "?type=docs&chunk=" + std::to_string(chunkId) +
-          "&chunkSize=" + std::to_string(chunkSize) + "&low=" + lowString +
+          "&chunkSize=" + std::to_string(chunkSize) + "&low=" + basics::StringUtils::encodeURIComponent(lowString) +
           "&offset=" + std::to_string(offsetInChunk);
 
       syncer.setProgress(std::string("fetching documents chunk ") +
@@ -449,6 +452,10 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
                         "got invalid response from leader at ",
                         syncer._state.leader.endpoint, ": ", r.errorMessage()));
     }
+  
+    // this will be very verbose, so intentionally not active
+    // LOG_TOPIC("e7ddf", TRACE, Logger::REPLICATION)
+    //     << "received documents chunk: " << slice.toJson();
 
     VPackSlice const slice = docsBuilder->slice();
     if (!slice.isArray()) {
@@ -542,7 +549,11 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
         }
         
         options.indexOperationMode = arangodb::IndexOperationMode::internal;
-        
+
+        // this will be very verbose, so intentionally not active
+        // LOG_TOPIC("8cbd1", TRACE, Logger::REPLICATION)
+        //    << "handled document key '" << keySlice.copyString() << "', mustInsert: " << mustInsert << ", res: " << res.errorMessage();
+ 
         if (res.ok()) {
           // all good, we can exit the retry loop now!
           break;
@@ -569,7 +580,7 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
       }
     }
     stats.waitedForInsertions += TRI_microtime() - t;
-
+      
     if (foundLength >= toFetch.size()) {
       break;
     }
@@ -686,9 +697,10 @@ Result handleSyncKeysRocksDB(DatabaseInitialSyncer& syncer,
                                         syncer.vocbase()),
                                     *col, AccessMode::Type::EXCLUSIVE);
 
-    trx.addHint(transaction::Hints::Hint::NO_INDEXING);
     // turn on intermediate commits as the number of operations can be huge here
     trx.addHint(transaction::Hints::Hint::INTERMEDIATE_COMMITS);
+    // TODO: check if we need to remove the below line!
+    trx.addHint(transaction::Hints::Hint::NO_INDEXING);
 
     Result res = trx.begin();
 

--- a/tests/js/server/replication/ongoing/global/replication-ongoing-global.js
+++ b/tests/js/server/replication/ongoing/global/replication-ongoing-global.js
@@ -152,10 +152,10 @@ const compare = function (leaderFunc, leaderFunc2, followerFuncOngoing, follower
       console.topic('replication=debug', 'waiting for follower to catch up');
       printed = true;
     }
-    internal.wait(0.5, false);
+    internal.wait(0.25, false);
   }
 
-  internal.wait(1.0, false);
+  internal.wait(0.1, false);
   db._flushCache();
   followerFuncFinal(state);
 };

--- a/tests/js/server/replication/ongoing/replication-ongoing.js
+++ b/tests/js/server/replication/ongoing/replication-ongoing.js
@@ -152,10 +152,10 @@ const compare = function (leaderFunc, leaderFunc2, followerFuncOngoing, follower
       console.topic('replication=debug', 'waiting for follower to catch up');
       printed = true;
     }
-    internal.wait(0.5, false);
+    internal.wait(0.25, false);
   }
 
-  internal.wait(1.0, false);
+  internal.wait(0.1, false);
   db._flushCache();
 
   try {
@@ -164,6 +164,23 @@ const compare = function (leaderFunc, leaderFunc2, followerFuncOngoing, follower
     console.warn("caught error. debug information: syncResult:", syncResult, "loggerState:", loggerState, "followerState:", followerState.state);
     throw err;
   }
+};
+
+const checkCountConsistency = function(cn, expected) {
+  let check = function() {
+    db._flushCache();
+    let c = db[cn];
+    let figures = c.figures(true).engine;
+
+    assertEqual(expected, c.count());
+    assertEqual(expected, c.toArray().length);
+    assertEqual(expected, figures.documents);
+    assertEqual("primary", figures.indexes[0].type);
+    assertEqual(expected, figures.indexes[0].count);
+    figures.indexes.forEach((idx) => {
+      assertEqual(expected, idx.count);
+    });
+  };
 };
 
 // //////////////////////////////////////////////////////////////////////////////
@@ -184,9 +201,11 @@ function BaseTestConfig () {
 
         function (state) {
           db._create(cn);
+          let docs = [];
           for (let i = 0; i < 1000; ++i) {
-            db._collection(cn).insert({ _key: "test" + i });
+            docs.push({ _key: "test" + i });
           }
+          db._collection(cn).insert(docs);
           internal.wal.flush(true, true);
         },
 
@@ -233,6 +252,8 @@ function BaseTestConfig () {
           assertTrue(s.totalFetchTime > 0);
           assertTrue(s.totalApplyTime > 0);
           assertTrue(s.averageApplyTime > 0);
+  
+          checkCountConsistency(cn, 1000);
         }
       );
     },
@@ -347,7 +368,70 @@ function BaseTestConfig () {
         }
       );
     },
+    
+    testInsertRemoveInsert: function () {
+      connectToLeader();
 
+      compare(
+        function (state) {
+          db._create(cn);
+        },
+        function (state) {
+          for (let i = 0; i < 1000; ++i) {
+            db._collection(cn).insert({ _key: "test" + i, value: i });
+            db._collection(cn).update("test" + i, { value: i + 1 });
+            db._collection(cn).remove("test" + i);
+            db._collection(cn).insert({ _key: "test" + i, value: 42 + i });
+          }
+          internal.wal.flush(true, true);
+        },
+
+        function (state) {
+          return true;
+        },
+
+        function (state) {
+          checkCountConsistency(cn, 1000);
+        }
+      );
+    },
+    
+    testInsertRemoveTransaction: function () {
+      connectToLeader();
+
+      compare(
+        function (state) {
+          db._create(cn);
+        },
+        function (state) {
+          const opts = {
+            collections: {
+              write: [cn]
+            }
+          };
+          const trx = internal.db._createTransaction(opts);
+
+          const tc = trx.collection(cn);
+          for (let i = 0; i < 1000; ++i) {
+            tc.insert({ _key: "test" + i, value: i });
+            tc.update("test" + i, { value: i + 1 });
+            tc.remove("test" + i);
+            tc.insert({ _key: "test" + i, value: 42 + i });
+          }
+          trx.commit();
+          internal.wal.flush(true, true);
+        },
+
+        function (state) {
+          return true;
+        },
+
+        function (state) {
+          checkCountConsistency(cn, 1000);
+        }
+      );
+    },
+    
     // //////////////////////////////////////////////////////////////////////////////
     // / @brief test duplicate _key issue and replacement
     // //////////////////////////////////////////////////////////////////////////////
@@ -386,6 +470,7 @@ function BaseTestConfig () {
         function (state) {
           // leader document version must have one
           assertEqual('leader', db[cn].document('boom').who);
+          checkCountConsistency(cn, 1);
         }
       );
     },
@@ -409,7 +494,7 @@ function BaseTestConfig () {
             action: function(params) {
               let db = require("internal").db;
               db[params.cn].insert({ _key: "meow", foo: "bar" });
-              db[params.cn].insert({ _key: "boom", who: "leader" });
+              db[params.cn].insert({ _key: "boom", who: "leader" }, {waitForSync: true});
             },
             params: { cn }
           });
@@ -424,6 +509,7 @@ function BaseTestConfig () {
           assertEqual("bar", db[cn].document("meow").foo);
           // leader document version must have won
           assertEqual("leader", db[cn].document("boom").who);
+          checkCountConsistency(cn, 2);
         }
       );
     },
@@ -469,6 +555,7 @@ function BaseTestConfig () {
           }));
           assertEqual('leader', db[cn].toArray()[0]._key);
           assertEqual('one', db[cn].toArray()[0].value);
+          checkCountConsistency(cn, 1);
         }
       );
     },
@@ -518,6 +605,7 @@ function BaseTestConfig () {
           });
           assertEqual("leader", docs[0]._key);
           assertEqual("one", docs[0].value);
+          checkCountConsistency(cn, 3);
         }
       );
     },

--- a/tests/js/server/replication/sync/replication-sync-malarkey.js
+++ b/tests/js/server/replication/sync/replication-sync-malarkey.js
@@ -36,6 +36,7 @@ const leaderEndpoint = arango.getEndpoint();
 const followerEndpoint = ARGUMENTS[ARGUMENTS.length - 1];
 const errors = require("internal").errors;
 const { deriveTestSuite, compareStringIds } = require('@arangodb/test-helper');
+const _ = require('lodash');
 
 const cn = 'UnitTestsReplication';
 
@@ -69,11 +70,12 @@ function BaseTestConfig () {
       let c = db[cn];
       let figures = c.figures(true).engine;
 
-      assertEqual(expected, c.count());
-      assertEqual(expected, c.toArray().length);
-      assertEqual(expected, figures.documents);
+      assertEqual(expected, c.count(), figures);
+      assertEqual(expected, c.toArray().length, figures);
+      assertEqual(expected, figures.documents, figures);
+      assertEqual("primary", figures.indexes[0].type, figures);
       figures.indexes.forEach((idx) => {
-        assertEqual(expected, idx.count);
+        assertEqual(expected, idx.count, figures);
       });
     };
 
@@ -184,9 +186,260 @@ function BaseTestConfig () {
      
       checkCountConsistency(cn, 2);
     },
+
+    testIndexConflicts: function () {
+      let c = db._create(cn);
+      c.ensureIndex({ type: "persistent", fields: ["value"], unique: true });
+
+      // create connection on follower too
+      connectToFollower();
+      db._flushCache();
+
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+      });
+
+      let docs = [];
+      for (let i = 0; i < 10000; ++i) {
+        docs.push({ _key: "test" + i, value: 9999 - i });
+      }
+      c.insert(docs);
+
+      connectToLeader();
+      docs = [];
+      for (let i = 0; i < 10000; ++i) {
+        docs.push({ _key: "test" + i, value: i });
+      }
+      c.insert(docs);
+      
+      connectToFollower();
+
+      // sync all documents
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      checkCountConsistency(cn, 10000);
+    },
+    
+    testMoreOnLeader: function () {
+      let c = db._create(cn);
+
+      // create connection on follower too
+      connectToFollower();
+      db._flushCache();
+
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+      });
+
+      let docs = [];
+      for (let i = 19; i < 10000; i += 111) {
+        docs.push({ _key: "test" + i, value: "follower-" + i });
+      }
+      c.insert(docs);
+
+      connectToLeader();
+      docs = [];
+      for (let i = 0; i < 10000; ++i) {
+        docs.push({ _key: "test" + i, value: "leader-" + i });
+      }
+      c.insert(docs);
+      
+      connectToFollower();
+
+      // sync all documents
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      checkCountConsistency(cn, 10000);
+    },
+    
+    testMoreOnFollower: function () {
+      let c = db._create(cn);
+
+      // create connection on follower too
+      connectToFollower();
+      db._flushCache();
+
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+      });
+
+      let docs = [];
+      for (let i = 0; i < 10000; ++i) {
+        docs.push({ _key: "test" + i, value: "follower-" + i });
+      }
+      c.insert(docs);
+
+      connectToLeader();
+      docs = [];
+      for (let i = 19; i < 10000; i += 111) {
+        docs.push({ _key: "test" + i, value: "leader-" + i });
+      }
+      c.insert(docs);
+      
+      connectToFollower();
+
+      // sync all documents
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      checkCountConsistency(cn, 90);
+    },
+    
+    testDifferentDocuments: function () {
+      let c = db._create(cn);
+
+      // create connection on follower too
+      connectToFollower();
+      db._flushCache();
+
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+      });
+
+      let docs = [];
+      for (let i = 0; i < 10000; ++i) {
+        docs.push({ _key: "test" + i, value: "follower-" + i });
+      }
+      c.insert(docs);
+
+      connectToLeader();
+      docs = [];
+      for (let i = 0; i < 10000; ++i) {
+        docs.push({ _key: "test" + i, value: "leader-" + i });
+      }
+      c.insert(docs);
+      
+      connectToFollower();
+
+      // sync all documents
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      checkCountConsistency(cn, 10000);
+    },
+    
+    testLargeDocuments: function () {
+      let c = db._create(cn);
+
+      // create connection on follower too
+      connectToFollower();
+      db._flushCache();
+
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+      });
+      // insert 1 document, so that the incremental sync gets triggered
+      c.insert({ _key: "testi" });
+      assertEqual(1, c.count());
+
+      connectToLeader();
+      let payload = Array(512).join("x");
+      let doc = {};
+      for (let i = 0; i < 100; ++i) {
+        doc["test" + i] = payload;
+      }
+      let docs = [];
+      for (let i = 0; i < 100; ++i) {
+        docs.push(doc);
+      }
+      for (let i = 0; i < 10000; ++i) {
+        c.insert(docs);
+        i += docs.length;
+      }
+      assertEqual(10000, c.count());
+      
+      connectToFollower();
+
+      // sync all documents
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      checkCountConsistency(cn, 10000);
+    },
+    
+    testLargeDocumentsWithEvilKeys: function () {
+      let c = db._create(cn);
+
+      // create connection on follower too
+      connectToFollower();
+      db._flushCache();
+
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+      });
+      // insert documents with evil keys
+      let docs = [];
+      for (let i = 0; i < 100; ++i) {
+        docs.push({ _key: "testi$!%20%44+abc=" + i });
+      }
+      c.insert(docs);
+      assertEqual(100, c.count());
+
+      connectToLeader();
+      let payload = Array(512).join("x");
+      let doc = {};
+      for (let i = 0; i < 100; ++i) {
+        doc["test" + i] = payload;
+      }
+      docs = [];
+      for (let i = 0; i < 10000; ++i) {
+        doc._key = "testi$!%20%44+abc=" + i;
+        docs.push(_.clone(doc));
+        if (docs.length === 100) {
+          c.insert(docs);
+          docs = [];
+        }
+      }
+      assertEqual(10000, c.count());
+      
+      connectToFollower();
+
+      // sync all documents
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      checkCountConsistency(cn, 10000);
+    },
+    
     
     testInsertRemoveInsertRemove: function () {
       let c = db._create(cn);
+      // create connection on follower too
+      connectToFollower();
+      db._flushCache();
+
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+      });
+
+      connectToLeader();
+      db._flushCache();
       let rev1 = c.insert({ _key: "a" })._rev;
       c.remove("a");
       let rev2 = c.insert({ _rev: rev1, _key: "a" }, { isRestore: true })._rev;
@@ -196,7 +449,6 @@ function BaseTestConfig () {
 
       connectToFollower();
       db._flushCache();
-      c = db._create(cn);
       
       rev1 = c.insert({ _rev: rev1, _key: "a" }, { isRestore: true })._rev;
       assertEqual(rev1, c.document("a")._rev);
@@ -217,6 +469,15 @@ function BaseTestConfig () {
     
     testInsertRemoveInsertRemoveInsert: function () {
       let c = db._create(cn);
+      connectToFollower();
+      db._flushCache();
+
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+      });
+
+      connectToLeader();
+      db._flushCache();
       let rev1 = c.insert({ _key: "a" })._rev;
       c.remove("a");
       let rev2 = c.insert({ _rev: rev1, _key: "a" }, { isRestore: true })._rev;
@@ -228,7 +489,6 @@ function BaseTestConfig () {
 
       connectToFollower();
       db._flushCache();
-      c = db._create(cn);
       
       assertEqual(rev1, c.insert({ _rev: rev1, _key: "a" }, { isRestore: true })._rev);
       assertEqual(rev1, c.document("a")._rev);
@@ -249,21 +509,33 @@ function BaseTestConfig () {
       checkCountConsistency(cn, 1);
     },
 
-    testSecondaryIndexConflicts: function () {
+    testSecondaryIndexConflictsDocuments: function () {
       let c = db._create(cn);
       c.ensureIndex({ type: "hash", fields: ["value"], unique: true });
 
-      let rev1 = c.insert({ _key: "a", value: 1 })._rev;
-      let rev2 = c.insert({ _key: "b", value: 2 })._rev;
-      let rev3 = c.insert({ _key: "c", value: 3 })._rev;
-      
       connectToFollower();
       db._flushCache();
-      c = db._create(cn);
-      c.ensureIndex({ type: "hash", fields: ["value"], unique: true });
+
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+      });
+
+      connectToLeader();
+      db._flushCache();
+
+      c.insert({ _key: "a", value: 1 });
+      c.insert({ _key: "b", value: 2 });
+      c.insert({ _key: "c", value: 3 });
       
-      assertEqual(rev1, c.insert({ _rev: rev1, _key: "b", value: 3 }, { isRestore: true })._rev);
-      assertEqual(rev3, c.insert({ _rev: rev3, _key: "c", value: 2 }, { isRestore: true })._rev);
+      assertEqual(1, c.document("a").value);
+      assertEqual(2, c.document("b").value);
+      assertEqual(3, c.document("c").value);
+
+      connectToFollower();
+     
+      assertEqual(2, c.indexes().length);
+      c.insert({ _key: "b", value: 3 });
+      c.insert({ _key: "c", value: 2 });
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
@@ -273,14 +545,14 @@ function BaseTestConfig () {
 
       db._flushCache();
       c = db._collection(cn);
-      
-      assertEqual(rev1, c.document("a")._rev);
-      assertEqual(rev2, c.document("b")._rev);
-      assertEqual(rev3, c.document("c")._rev);
+     
+      assertEqual(1, c.document("a").value);
+      assertEqual(2, c.document("b").value);
+      assertEqual(3, c.document("c").value);
      
       checkCountConsistency(cn, 3);
     },
-
+    
     // create different state on follower
     testDowngradeManyRevisions: function () {
       let c = db._create(cn);
@@ -1122,13 +1394,13 @@ function ReplicationIncrementalMalarkeyNewFormatIntermediateCommits() {
       connectToFollower();
       // clear all failure points
       clearFailurePoints();
-      setFailurePoint("TransactionState::intermediateCommitCount10000");
+      setFailurePoint("TransactionState::intermediateCommitCount1000");
       db._drop(cn);
 
       connectToLeader();
       // clear all failure points
       clearFailurePoints();
-      setFailurePoint("TransactionState::intermediateCommitCount10000");
+      setFailurePoint("TransactionState::intermediateCommitCount1000");
       db._drop(cn);
     },
   };


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/15120

* Fixed an issue in old incremental sync protocol with document keys that
  contained special characters (`%`). These keys could be send unencoded in
  the incremental sync protocol, leading to wrong key ranges being transfered
  between leader and follower, and thus causing follow-up errors and preventing
  getting in sync.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backport for 3.7: https://github.com/arangodb/arangodb/pull/15117

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (replication_sync, replication_ongoing)