### PR TITLE
Fixed issues with old incremental sync protocol

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+v3.7.13.1 (XXXX-XX-XX)
+----------------------
+
+* Fixed an issue in old incremental sync protocol with document keys that
+  contained special characters (`%`). These keys could be send unencoded in
+  the incremental sync protocol, leading to wrong key ranges being transfered
+  between leader and follower, and thus causing follow-up errors and preventing
+  getting in sync.
+
+
 v3.7.13 (2021-07-20)
 --------------------
 

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -1468,7 +1468,7 @@ ExecutionBlockImpl<Executor>::executeWithoutTrace(AqlCallStack stack) {
         TRI_ASSERT(clientCall.getLimit() > 0);
         TRI_ASSERT(clientCall.getSkipCount() == 0);
 
-        LOG_QUERY("1f786", DEBUG) << printTypeInfo() << " call produceRows " << clientCall;
+        LOG_QUERY("1f787", DEBUG) << printTypeInfo() << " call produceRows " << clientCall;
         if (outputIsFull()) {
           // We need to be able to write data
           // But maybe the existing block is full here

--- a/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
+++ b/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
@@ -200,7 +200,7 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
   {
     std::string const url =
         baseUrl + "/" + keysId + "?type=keys&chunk=" + std::to_string(chunkId) +
-        "&chunkSize=" + std::to_string(chunkSize) + "&low=" + lowString;
+        "&chunkSize=" + std::to_string(chunkSize) + "&low=" + basics::StringUtils::encodeURIComponent(lowString);
 
     syncer.setProgress(std::string("fetching keys chunk ") +
                        std::to_string(chunkId) + " from " + url);
@@ -400,7 +400,7 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer, SingleCollectionTransacti
     {
       std::string const url =
           baseUrl + "/" + keysId + "?type=docs&chunk=" + std::to_string(chunkId) +
-          "&chunkSize=" + std::to_string(chunkSize) + "&low=" + lowString +
+          "&chunkSize=" + std::to_string(chunkSize) + "&low=" + basics::StringUtils::encodeURIComponent(lowString) +
           "&offset=" + std::to_string(offsetInChunk);
 
       syncer.setProgress(std::string("fetching documents chunk ") +

--- a/tests/js/server/replication/sync/replication-sync-malarkey.js
+++ b/tests/js/server/replication/sync/replication-sync-malarkey.js
@@ -36,6 +36,7 @@ const leaderEndpoint = arango.getEndpoint();
 const followerEndpoint = ARGUMENTS[ARGUMENTS.length - 1];
 const errors = require("internal").errors;
 const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
+const _ = require('lodash');
 
 const cn = 'UnitTestsReplication';
 
@@ -248,6 +249,54 @@ function BaseTestConfig () {
       assertEqual(rev3, c.document("c")._rev);
      
       checkCountConsistency(cn, 3);
+    },
+
+    testLargeDocumentsWithEvilKeys: function () {
+      let c = db._create(cn);
+
+      // create connection on follower too
+      connectToFollower();
+      db._flushCache();
+
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+      });
+      // insert documents with evil keys
+      let docs = [];
+      for (let i = 0; i < 100; ++i) {
+        docs.push({ _key: "testi$!%20%44+abc=" + i });
+      }
+      c.insert(docs);
+      assertEqual(100, c.count());
+
+      connectToLeader();
+      let payload = Array(512).join("x");
+      let doc = {};
+      for (let i = 0; i < 100; ++i) {
+        doc["test" + i] = payload;
+      }
+      docs = [];
+      for (let i = 0; i < 10000; ++i) {
+        doc._key = "testi$!%20%44+abc=" + i;
+        docs.push(_.clone(doc));
+        if (docs.length === 100) {
+          c.insert(docs);
+          docs = [];
+        }
+      }
+      assertEqual(10000, c.count());
+
+      connectToFollower();
+
+      // sync all documents
+      replication.syncCollection(cn, {
+        endpoint: leaderEndpoint,
+        verbose: true,
+        incremental: true
+      });
+
+      db._flushCache();
+      checkCountConsistency(cn, 10000);
     },
 
     // create different state on follower

--- a/utils/checkLogIds.py
+++ b/utils/checkLogIds.py
@@ -18,7 +18,7 @@ def is_good(status):
     return status in (Status.OK, Status.OK_REPLACED)
 
 import re
-g_log_topic_pattern = re.compile(r'(?P<macro>LOG_(TOPIC(_IF)?|TRX))\((?P<param>[^),]*),(?P<rest>.*)')
+g_log_topic_pattern = re.compile(r'(?P<macro>LOG_(TOPIC(_IF)?|TRX|QUERY))\((?P<param>[^),]*),(?P<rest>.*)')
 
 import hashlib
 g_hash_algorithm = hashlib.md5()


### PR DESCRIPTION
### Scope & Purpose

* Fixed an issue in old incremental sync protocol with document keys that
  contained special characters (`%`). These keys could be send unencoded in
  the incremental sync protocol, leading to wrong key ranges being transfered
  between leader and follower, and thus causing follow-up errors and preventing
  getting in sync.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (replication_sync)
