### PR TITLE
remove redundant implementation of debugClearFailAt

### DIFF
--- a/js/client/modules/@arangodb/test-helper.js
+++ b/js/client/modules/@arangodb/test-helper.js
@@ -129,21 +129,6 @@ exports.debugClearFailAt = function (endpoint) {
   }
 };
 
-
-exports.debugClearFailAt = function (endpoint) {
-  const primaryEndpoint = arango.getEndpoint();
-  try {
-    reconnectRetry(endpoint, db._name(), "root", "");
-    let res = arango.DELETE_RAW('/_admin/debug/failat');
-    if (res.code !== 200) {
-      throw "Error removing failure points";
-    }
-    return true;
-  } finally {
-    reconnectRetry(primaryEndpoint, "_system", "root", "");
-  }
-};
-
 exports.getChecksum = function (endpoint, name) {
   const primaryEndpoint = arango.getEndpoint();
   try {


### PR DESCRIPTION
### Scope & Purpose

This only cleans up helper code used during testing. It does not cause any behavior changes.
3.9 and devel do not need this cleanup.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
