### PR TITLE
do not clobber replication failure if a success callback is set

### DIFF
--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -492,7 +492,7 @@ Result DatabaseInitialSyncer::runWithInventory(bool incremental, VPackSlice dbIn
         << Logger::FIXED(TRI_microtime() - startTime, 6) << " s. status: "
         << (r.errorMessage().empty() ? "all good" : r.errorMessage());
 
-    if (_onSuccess) {
+    if (r.ok() && _onSuccess) {
       r = _onSuccess(*this);
     }
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/15137

do not clobber replication failure if a success callback is set

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/15135

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
