### PR TITLE
optimized description of satelliteCollections entry during graph crea…

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/graphManagementView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/graphManagementView.js
@@ -983,7 +983,7 @@
               'New Satellite collections',
               hybridSatelliteCollections,
               'Insert vertex collections here which are being used in new edge definitions (fromCollections, toCollections).' +
-              'Those defined collections will be created as satellite collections, and therefore will be replicated to all database servers.',
+              'Those defined collections will be created as SatelliteCollections, and therefore will be replicated to all DB-Servers.',
               'New Satellite Collections',
               false,
               false,

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/graphManagementView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/graphManagementView.js
@@ -1159,7 +1159,7 @@
             'Satellite collections',
             hybridSatelliteCollections,
             'Insert vertex collections here which are being used in your edge definitions (fromCollections, toCollections).' +
-            'Those defined collections will be created as satellite collections, and therefore will be replicated to all database servers.',
+            'Those defined collections will be created as SatelliteCollections, and therefore will be replicated to all DB-Servers.',
             'Satellite Collections',
             false,
             false,

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/graphManagementView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/graphManagementView.js
@@ -358,7 +358,8 @@
       var i;
       for (i = 0; i < this.counter; i++) {
         $('#newEdgeDefinitions' + i).select2({
-          tags: self.eCollList
+          tags: self.eCollList,
+          maximumSelectionSize: 1
         });
         $('#newEdgeDefinitions' + i).select2('data', self.cachedNewEdgeDefinitions);
         $('#newEdgeDefinitions' + i).attr('disabled', self.cachedNewEdgeDefinitionsState);
@@ -388,7 +389,8 @@
 
       for (i = 0; i < self.counter; i++) {
         $('#newEdgeDefinitions' + i).select2({
-          tags: []
+          tags: [],
+          maximumSelectionSize: 1
         });
         self.cachedNewEdgeDefinitions = $('#newEdgeDefinitions' + i).select2('data');
         self.cachedNewEdgeDefinitionsState = $('#newEdgeDefinitions' + i).attr('disabled');
@@ -980,7 +982,8 @@
               'new-hybridSatelliteCollections',
               'New Satellite collections',
               hybridSatelliteCollections,
-              'Collections that are part of the graph used in an newly created edge definition and should be created as satellite collections.',
+              'Insert vertex collections here which are being used in new edge definitions (fromCollections, toCollections).' +
+              'Those defined collections will be created as satellite collections, and therefore will be replicated to all database servers.',
               'New Satellite Collections',
               false,
               false,
@@ -1155,7 +1158,8 @@
             'hybridSatelliteCollections',
             'Satellite collections',
             hybridSatelliteCollections,
-            'Collections that are part of a graph used in an edge definition and should be created as satellite collections.',
+            'Insert vertex collections here which are being used in your edge definitions (fromCollections, toCollections).' +
+            'Those defined collections will be created as satellite collections, and therefore will be replicated to all database servers.',
             'Satellite Collections',
             false,
             false,


### PR DESCRIPTION
### Scope & Purpose

I. Optimized description of satelliteCollections entry during Hybrid SmartGraph creation and Hybrid SmartGraph edit.
II. Also fixed a bug where it has been possible to provide multiple entries into `Edge definitions*:` input box. This should not be possible and is invalid input. Fixed here as well. 

- [x] :hankey: Bugfix (does not require changelog - as not released yet)
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/15141

#### Related Information

Only discussed in Slack. No Ticket.


### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*