### PR TITLE
fix non-deterministic dropping of followers during tests

### DIFF
--- a/js/client/modules/@arangodb/testsuites/aql.js
+++ b/js/client/modules/@arangodb/testsuites/aql.js
@@ -79,7 +79,11 @@ function shellClient (options) {
 
   var opts = ensureServers(options, 3);
   opts = ensureCoordinators(opts, 2);
-  let rc = tu.performTests(opts, testCases, 'shell_client', tu.runInLocalArangosh);
+  // increase timeouts after which servers count as BAD/FAILED.
+  // we want this to ensure that in an overload situation we do not
+  // get random failedLeader / failedFollower jobs during our tests.
+  let moreOptions = { "agency.supervision-ok-threshold" : "15", "agency.supervision-grace-period" : "30" };
+  let rc = tu.performTests(opts, testCases, 'shell_client', tu.runInLocalArangosh, moreOptions);
   options.cleanup = options.cleanup && opts.cleanup;
   return rc;
 }

--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -2222,8 +2222,12 @@ function startInstanceAgency (instanceInfo, protocol, options, addArgs, rootDir)
     usedPorts.push(port);
     instanceArgs['server.endpoint'] = protocol + '://127.0.0.1:' + port;
     instanceArgs['agency.my-address'] = protocol + '://127.0.0.1:' + port;
-    instanceArgs['agency.supervision-grace-period'] = '10.0';
-    instanceArgs['agency.supervision-frequency'] = '1.0';
+    if (!instanceArgs.hasOwnProperty("agency.supervision-grace-period")) {
+      instanceArgs['agency.supervision-grace-period'] = '10.0';
+    }
+    if (!instanceArgs.hasOwnProperty("agency.supervision-frequency")) {
+      instanceArgs['agency.supervision-frequency'] = '1.0';
+    }
     if (options.encryptionAtRest) {
       instanceArgs['rocksdb.encryption-keyfile'] = instanceInfo.restKeyFile;
     }

--- a/tests/js/client/shell/shell-promtool-cluster.js
+++ b/tests/js/client/shell/shell-promtool-cluster.js
@@ -223,7 +223,7 @@ function promtoolClusterSuite() {
       try {
         let metricsUrl = metricsUrlPath + "?serverId=" + serverId;
         let res = arango.GET_RAW(metricsUrl);
-        assertEqual(503, res.code);
+        assertTrue(res.code === 500 || res.code === 503);
         //Do not validate response body because errorNum and errorMessage can differ depending on whether there was an open connection
         //between coordinator and db server when the later stopped responding. This cannot be reproduced consistently in the test.
         //        let body = res.parsedBody;


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/15144

Fix non-deterministic dropping of followers during tests

This change increases the supervision grace period from 10 seconds to a higher value when running the `shell_client` tests. it seems that 10 seconds is not enough on overloaded servers, so that we randomly get failedLeader jobs during the tests, which can lead to spurious dropping of followers. this is a problem because some tests assume that during the tests no followers are getting dropped.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [x] Backport for 3.7: https://github.com/arangodb/arangodb/pull/15145

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
