### PR TITLE
fix non-deterministic dropping of followers during tests

### DIFF
--- a/js/client/modules/@arangodb/process-utils.js
+++ b/js/client/modules/@arangodb/process-utils.js
@@ -2081,9 +2081,13 @@ function startInstanceAgency (instanceInfo, protocol, options, addArgs, rootDir)
     usedPorts.push(port);
     instanceArgs['server.endpoint'] = protocol + '://127.0.0.1:' + port;
     instanceArgs['agency.my-address'] = protocol + '://127.0.0.1:' + port;
-    instanceArgs['agency.supervision-grace-period'] = '10.0';
-    instanceArgs['agency.supervision-frequency'] = '1.0';
 
+    if (!instanceArgs.hasOwnProperty("agency.supervision-grace-period")) {
+      instanceArgs['agency.supervision-grace-period'] = '10.0';
+    }
+    if (!instanceArgs.hasOwnProperty("agency.supervision-frequency")) {
+      instanceArgs['agency.supervision-frequency'] = '1.0';
+    }
     if (i === N - 1) {
       let l = [];
       instanceInfo.arangods.forEach(arangod => {

--- a/js/client/modules/@arangodb/testsuites/aql.js
+++ b/js/client/modules/@arangodb/testsuites/aql.js
@@ -67,7 +67,11 @@ function shellClient (options) {
 
   testCases = tu.splitBuckets(options, testCases);
 
-  return tu.performTests(ensureServers(options, 3), testCases, 'shell_client', tu.runInLocalArangosh);
+  // increase timeouts after which servers count as BAD/FAILED.
+  // we want this to ensure that in an overload situation we do not
+  // get random failedLeader / failedFollower jobs during our tests.
+  let moreOptions = { "agency.supervision-ok-threshold" : "15", "agency.supervision-grace-period" : "30" };
+  return tu.performTests(ensureServers(options, 3), testCases, 'shell_client', tu.runInLocalArangosh, moreOptions);
 }
 
 // //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/15144

Fix non-deterministic dropping of followers during tests

This change increases the supervision grace period from 10 seconds to a higher value when running the `shell_client` tests. it seems that 10 seconds is not enough on overloaded servers, so that we randomly get failedLeader jobs during the tests, which can lead to spurious dropping of followers. this is a problem because some tests assume that during the tests no followers are getting dropped.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
