### PR TITLE
improve usability of --version for arangobackup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.9.0 (XXXX-XX-XX)
 -------------------
 
+* Make the `--version` and `--version-json` commands usable in arangobackup
+  when no positional argument (operation type) was specified. Previously,
+  arangobackup insisted on specifying the operation type alongside the
+  `--version` or `--version-json` commands.
+
 * Fixed an issue in old incremental sync protocol with document keys that
   contained special characters (`%`). These keys could be send unencoded in the
   incremental sync protocol, leading to wrong key ranges being transfered

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.9.0 (XXXX-XX-XX)
 -------------------
 
-* Make the `--version` and `--version-json` commands usable in arangobackup
-  when no positional argument (operation type) was specified. Previously,
+* Make the `--version` and `--version-json` commands usable in arangobackup when
+  no positional argument (operation type) was specified. Previously,
   arangobackup insisted on specifying the operation type alongside the
   `--version` or `--version-json` commands.
 

--- a/arangosh/Backup/BackupFeature.cpp
+++ b/arangosh/Backup/BackupFeature.cpp
@@ -656,7 +656,7 @@ BackupFeature::BackupFeature(application_features::ApplicationServer& server, in
   requiresElevatedPrivileges(false);
   setOptional(false);
   startsAfter<ClientFeature>();
-};
+}
 
 std::string BackupFeature::featureName() { return ::FeatureName; }
 
@@ -771,9 +771,16 @@ void BackupFeature::validateOptions(std::shared_ptr<options::ProgramOptions> opt
   using namespace arangodb::application_features;
 
   auto const& positionals = options->processingResult()._positionals;
+
+  if (options->processingResult().touched("--version") ||
+      options->processingResult().touched("--version-json")) {
+    // skip validation of options when --version* command is specified
+    return;
+  }
+
   auto& client = server().getFeature<HttpEndpointProvider, ClientFeature>();
 
-  if (client.databaseName() != "_system") {
+  if (client.databaseName() != StaticStrings::SystemDatabase) {
     LOG_TOPIC("6b53c", FATAL, Logger::BACKUP)
       << "hot backups are global and must be performed on the _system database with super user privileges";
     FATAL_ERROR_EXIT();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/15149

* Make the `--version` and `--version-json` commands usable in arangobackup
  when no positional argument (operation type) was specified. Previously,
  arangobackup insisted on specifying the operation type alongside the
  `--version` or `--version-json` commands.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
