### PR TITLE
[CINFRA-129] Rename max{...} to threshold{...}

### DIFF
--- a/arangod/Replication2/ReplicatedLog/LogCommon.h
+++ b/arangod/Replication2/ReplicatedLog/LogCommon.h
@@ -331,14 +331,14 @@ struct LogConfig {
 // These settings are initialised by the ReplicatedLogFeature based on command line arguments
 struct ReplicatedLogGlobalSettings {
  public:
-  static inline constexpr std::size_t defaultMaxNetworkBatchSize{1024 * 1024};
-  static inline constexpr std::size_t minNetworkBatchSize{1024 * 1024};
+  static inline constexpr std::size_t defaultThresholdNetworkBatchSize{1024 * 1024};
+  static inline constexpr std::size_t minThresholdNetworkBatchSize{1024 * 1024};
 
-  static inline constexpr std::size_t defaultMaxRocksDBWriteBatchSize{1024 * 1024};
-  static inline constexpr std::size_t minRocksDBWriteBatchSize{1024 * 1024};
+  static inline constexpr std::size_t defaultThresholdRocksDBWriteBatchSize{1024 * 1024};
+  static inline constexpr std::size_t minThresholdRocksDBWriteBatchSize{1024 * 1024};
 
-  std::size_t _maxNetworkBatchSize{defaultMaxNetworkBatchSize};
-  std::size_t _maxRocksDBWriteBatchSize{defaultMaxRocksDBWriteBatchSize};
+  std::size_t _thresholdNetworkBatchSize{defaultThresholdNetworkBatchSize};
+  std::size_t _thresholdRocksDBWriteBatchSize{defaultThresholdRocksDBWriteBatchSize};
 };
 
 

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -609,7 +609,7 @@ auto replicated_log::LogLeader::GuardedLeaderData::createAppendEntriesRequest(
       transientEntries.push_back(InMemoryLogEntry(*entry));
       sizeCounter += entry->entry().approxByteSize();
 
-      if (sizeCounter >= _self._options->_maxNetworkBatchSize) {
+      if (sizeCounter >= _self._options->_thresholdNetworkBatchSize) {
         break;
       }
     }

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLogFeature.cpp
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLogFeature.cpp
@@ -67,6 +67,7 @@ void ReplicatedLogFeature::prepare() {
 }
 
 void ReplicatedLogFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
+#if defined(ARANGODB_ENABLE_MAINTAINER_MODE)
   options->addSection("replicatedlog", "Options for replicated logs");
 
   options->addOption("--replicatedlog.threshold-network-batch-size",
@@ -77,6 +78,7 @@ void ReplicatedLogFeature::collectOptions(std::shared_ptr<ProgramOptions> option
                      "write a batch of log updates to RocksDB early "
                      "when threshold (in bytes) is exceeded",
                      new SizeTParameter(&_options->_thresholdRocksDBWriteBatchSize));
+#endif
 }
 
 void ReplicatedLogFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLogFeature.cpp
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLogFeature.cpp
@@ -69,25 +69,29 @@ void ReplicatedLogFeature::prepare() {
 void ReplicatedLogFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addSection("replicatedlog", "Options for replicated logs");
 
-  options->addOption("--replicatedlog.max-network-batch-size", "",
-                     new SizeTParameter(&_options->_maxNetworkBatchSize));
-  options->addOption("--replicatedlog.max-rocksdb-write-batch-size", "",
-                     new SizeTParameter(&_options->_maxRocksDBWriteBatchSize));
+  options->addOption("--replicatedlog.threshold-network-batch-size",
+                     "send a batch of log updates early when threshold "
+                     "(in bytes) is exceeded",
+                     new SizeTParameter(&_options->_thresholdNetworkBatchSize));
+  options->addOption("--replicatedlog.threshold-rocksdb-write-batch-size",
+                     "write a batch of log updates to RocksDB early "
+                     "when threshold (in bytes) is exceeded",
+                     new SizeTParameter(&_options->_thresholdRocksDBWriteBatchSize));
 }
 
 void ReplicatedLogFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
-  if (_options->_maxNetworkBatchSize < ReplicatedLogGlobalSettings::minNetworkBatchSize) {
+  if (_options->_thresholdNetworkBatchSize < ReplicatedLogGlobalSettings::minThresholdNetworkBatchSize) {
     LOG_TOPIC("e83c3", FATAL, arangodb::Logger::REPLICATION2)
-        << "Invalid value for `--max-network-batch-size`. The value must be at "
+        << "Invalid value for `--threshold-network-batch-size`. The value must be at "
            "least "
-        << ReplicatedLogGlobalSettings::minNetworkBatchSize;
+        << ReplicatedLogGlobalSettings::minThresholdNetworkBatchSize;
     FATAL_ERROR_EXIT();
   }
-  if (_options->_maxRocksDBWriteBatchSize < ReplicatedLogGlobalSettings::minRocksDBWriteBatchSize) {
+  if (_options->_thresholdRocksDBWriteBatchSize < ReplicatedLogGlobalSettings::minThresholdRocksDBWriteBatchSize) {
     LOG_TOPIC("e83c4", FATAL, arangodb::Logger::REPLICATION2)
-        << "Invalid value for `--max-rocksdb-write-batch-size`. The value must be at "
+        << "Invalid value for `--threshold-rocksdb-write-batch-size`. The value must be at "
            "least "
-        << ReplicatedLogGlobalSettings::minRocksDBWriteBatchSize;
+        << ReplicatedLogGlobalSettings::minThresholdRocksDBWriteBatchSize;
     FATAL_ERROR_EXIT();
   }
 }

--- a/arangod/RocksDBEngine/RocksDBPersistedLog.cpp
+++ b/arangod/RocksDBEngine/RocksDBPersistedLog.cpp
@@ -201,7 +201,7 @@ void RocksDBLogPersistor::runPersistorWorker(Lane& lane) noexcept {
         // persisted log already has some entries that are not yet confirmed
         // (which may be overwritten later). This could still be improved upon a
         // little by reporting up to which entry was written successfully.
-        while (wb.GetDataSize() < _options->_maxRocksDBWriteBatchSize &&
+        while (wb.GetDataSize() < _options->_thresholdRocksDBWriteBatchSize &&
                nextReqToWrite != std::end(pendingRequests)) {
           if (auto res = nextReqToWrite->execute(wb); res.fail()) {
             return res;

--- a/tests/Replication2/ReplicatedLog/AppendEntriesBatchTest.cpp
+++ b/tests/Replication2/ReplicatedLog/AppendEntriesBatchTest.cpp
@@ -76,7 +76,7 @@ TEST_P(AppendEntriesBatchTest, test_with_sized_batches) {
     auto currentSize = size_t{0};
     while (auto log = it->next()) {
       currentSize += log->approxByteSize();
-      if (currentSize >= _optionsMock->_maxNetworkBatchSize) {
+      if (currentSize >= _optionsMock->_thresholdNetworkBatchSize) {
         numRequests += 1;
         currentSize = 0;
       }


### PR DESCRIPTION
The naming was misleading, as it  did not reflect the maximum size of
a batch that is sent, but a threshold that triggers sending of a batch
of log updates.

We also disable the command line options for `ReplicatedLog` when not building in maintainer mode to not cause confusion with documentation building, or accidentally offering unfinished options to users of released versions.

### Scope & Purpose
- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:
