### PR TITLE
Add DocuBlocks for /_admin/license endpoint (#14892)

### DIFF
--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_license.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_license.md
@@ -1,0 +1,52 @@
+
+@startDocuBlock get_admin_license
+@brief Get license information
+
+@RESTHEADER{GET /_admin/license, Return information about the current license, getLicense}
+
+@RESTDESCRIPTION
+View the license information and status of an Enterprise Edition instance.
+Can be called on single servers, Coordinators, and DB-Servers.
+
+@RESTRETURNCODES
+
+@RESTRETURNCODE{200}
+
+@RESTREPLYBODY{features,object,required,license_features}
+
+@RESTSTRUCT{expires,license_features,number,required,}
+The `expires` key lists the expiry date as Unix timestamp (seconds since
+January 1st, 1970 UTC).
+
+@RESTREPLYBODY{license,string,required,}
+The encrypted license key in base64 encoding.
+
+@RESTREPLYBODY{version,number,required,}
+The license version number.
+
+@RESTREPLYBODY{status,string,required,}
+The `status` key allows you to confirm the state of the installed license on a
+glance. The possible values are as follows:
+
+- `good`: The license is valid for more than 2 weeks.
+- `expiring`: The license is valid for less than 2 weeks.
+- `expired`: The license has expired. In this situation, no new
+  Enterprise Edition features can be utilized.
+- `read-only`: The license is expired over 2 weeks. The instance is now
+  restricted to read-only mode.
+
+@EXAMPLES
+
+@EXAMPLE_ARANGOSH_RUN{RestAdminLicenseGet_cluster}
+    var assertTypeOf = require("jsunity").jsUnity.assertions.assertTypeOf;
+    var url = "/_admin/license";
+    var response = logCurlRequest('GET', url);
+
+    assert(response.code === 200);
+    var body = JSON.parse(response.body);
+    assertTypeOf("string", body.license);
+
+    logJsonResponse(response);
+@END_EXAMPLE_ARANGOSH_RUN
+
+@endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Administration/put_admin_license.md
+++ b/Documentation/DocuBlocks/Rest/Administration/put_admin_license.md
@@ -1,0 +1,48 @@
+
+@startDocuBlock put_admin_license
+@brief Set a new license
+
+@RESTHEADER{PUT /_admin/license, Set a new license, putLicense}
+
+@RESTQUERYPARAMETERS
+
+@RESTQUERYPARAM{force,boolean,optional}
+Set to `true` to change the license even if it expires sooner than the current one.
+
+@RESTDESCRIPTION
+Set a new license for an Enterprise Edition instance.
+Can be called on single servers, Coordinators, and DB-Servers.
+
+**Examples**
+
+```
+shell> curl -XPUT http://localhost:8529/_admin/license -d '"<license-string>"'
+```
+
+Server response in case of success:
+
+```json
+{
+  "result": {
+    "error": false,
+    "code": 201
+  }
+}
+```
+
+Server response if the new license expires sooner than the current one (requires
+`?force=true` to update the license anyway):
+
+```json
+{
+  "code": 400,
+  "error": true,
+  "errorMessage": "This license expires sooner than the existing. You may override this by specifying force=true with invocation.",
+  "errorNum": 9007
+}
+```
+
+In case of a different error related to an expired or invalid license, please
+contact ArangoDB sales.
+
+@endDocuBlock


### PR DESCRIPTION
Related: https://github.com/arangodb/docs/pull/790

It's currently not possible to add a working example of setting a new license successfully (no demo license key). Kaveh looks into it. Meanwhile, we need to put the examples in the description text.

**Backport of https://github.com/arangodb/arangodb/pull/14892**