### PR TITLE
Add some explicit captures for this

### DIFF
--- a/3rdParty/fuerte/src/AsioSockets.h
+++ b/3rdParty/fuerte/src/AsioSockets.h
@@ -130,7 +130,7 @@ struct Socket<fuerte::SocketType::Ssl> {
     bool verify = config._verifyHost;
     resolveConnect(
         config, resolver, socket.next_layer(),
-        [=, done(std::forward<F>(done))](auto const& ec) mutable {
+        [=, this, done(std::forward<F>(done))](auto const& ec) mutable {
           if (ec) {
             done(ec);
             return;

--- a/3rdParty/fuerte/src/GeneralConnection.h
+++ b/3rdParty/fuerte/src/GeneralConnection.h
@@ -195,7 +195,7 @@ class GeneralConnection : public fuerte::Connection {
 
     abortRequests(err, /*now*/ Clock::time_point::max());
 
-    _proto.shutdown([=, self(shared_from_this())](auto const& ec) {
+    _proto.shutdown([=, this, self(shared_from_this())](auto const& ec) {
       terminateActivity(err);
       onFailure(err, msg);
     });  // Close socket
@@ -455,7 +455,7 @@ struct MultiConnection : public GeneralConnection<ST, RT> {
     // expires_after cancels pending ops
     this->_proto.timer.expires_at(tp);
     this->_proto.timer.async_wait(
-        [=, self = Connection::weak_from_this()](auto const& ec) {
+        [=, this, self = Connection::weak_from_this()](auto const& ec) {
           std::shared_ptr<Connection> s;
           if (ec || !(s = self.lock())) {  // was canceled / deallocated
             return;


### PR DESCRIPTION
### Scope & Purpose

Implicit `this` captures are deprecated as of c++20, so better remove them before things break.
### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as all of them.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
