### PR TITLE
Fix missing rename of _thresholdNetworkBatchSize.

### DIFF
--- a/tests/Replication2/ReplicatedLog/AppendEntriesBatchTest.cpp
+++ b/tests/Replication2/ReplicatedLog/AppendEntriesBatchTest.cpp
@@ -84,7 +84,7 @@ TEST_P(AppendEntriesBatchTest, test_with_sized_batches) {
     {
       // Add first entry in term
       currentSize += PersistingLogEntry{LogTerm{5}, LogIndex{1}, std::nullopt}.approxByteSize();
-      if (currentSize >= _optionsMock->_maxNetworkBatchSize) {
+      if (currentSize >= _optionsMock->_thresholdNetworkBatchSize) {
         numRequests += 1;
         currentSize = 0;
       }


### PR DESCRIPTION
### Scope & Purpose

Fix missing rename of _thresholdNetworkBatchSize.
