### PR TITLE
prefer using absl::flat_hash_map

### DIFF
--- a/arangod/Aql/AqlItemBlock.h
+++ b/arangod/Aql/AqlItemBlock.h
@@ -25,6 +25,7 @@
 
 #include "Aql/AqlValue.h"
 #include "Basics/ResourceUsage.h"
+#include "Containers/FlatHashMap.h"
 #include "Containers/SmallVector.h"
 
 #include <limits>
@@ -33,7 +34,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include <absl/container/flat_hash_map.h>
 
 namespace arangodb {
 namespace aql {
@@ -360,7 +360,7 @@ class AqlItemBlock {
   /// count with valueCount.
   /// note: only AqlValues that point to dynamically allocated memory
   /// should be added to this map. Other types (VPACK_INLINE) are not supported.
-  ::iresearch_absl::flat_hash_map<void const*, ValueInfo> _valueCount;
+  containers::FlatHashMap<void const*, ValueInfo> _valueCount;
 
   /// @brief _numRows, number of rows
   size_t _numRows = 0;

--- a/arangod/Aql/HashedCollectExecutor.h
+++ b/arangod/Aql/HashedCollectExecutor.h
@@ -33,9 +33,11 @@
 #include "Aql/RegisterInfos.h"
 #include "Aql/Stats.h"
 #include "Aql/types.h"
+#include "Aql/AqlValueGroup.h"
+
+#include "Containers/FlatHashMap.h"
 
 #include <memory>
-#include <unordered_map>
 
 namespace arangodb {
 struct ResourceMonitor;
@@ -166,7 +168,7 @@ class HashedCollectExecutor {
   using GroupKeyType = HashedAqlValueGroup;
   using GroupValueType = std::unique_ptr<ValueAggregators>;
   using GroupMapType =
-      std::unordered_map<GroupKeyType, GroupValueType, AqlValueGroupHash, AqlValueGroupEqual>;
+      containers::FlatHashMap<GroupKeyType, GroupValueType, AqlValueGroupHash, AqlValueGroupEqual>;
 
   Infos const& infos() const noexcept;
 

--- a/lib/Containers/FlatHashMap.h
+++ b/lib/Containers/FlatHashMap.h
@@ -23,15 +23,17 @@
 
 #pragma once
 
-#include <absl/container/flat_hash_set.h>
+#include <absl/container/flat_hash_map.h>
 
 namespace arangodb {
 namespace containers {
 
-template <typename T, typename Hash = ::iresearch_absl::container_internal::hash_default_hash<T>,
+template <typename T,
+          typename V,
+          typename Hash = ::iresearch_absl::container_internal::hash_default_hash<T>,
           typename Eq = ::iresearch_absl::container_internal::hash_default_eq<T>,
           typename Allocator = std::allocator<T>>
-using FlatHashSet = ::iresearch_absl::flat_hash_set<T, Hash, Eq, Allocator>;
+using FlatHashMap = ::iresearch_absl::flat_hash_map<T, V, Hash, Eq, Allocator>;
 
 }
 }


### PR DESCRIPTION
### Scope & Purpose

Prefer using absl::flat_hash_map<...> instead of std::unordered_map<...> where applicable. It's always faster.
https://martin.ankerl.com/2019/04/01/hashmap-benchmarks-01-overview/

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] Backport for 3.9: *(Please link PR)*
- [ ] Backport for 3.8: *(Please link PR)*
- [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:

### Documentation

> All new features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the CHANGELOG so that
> support, end users, and other developers have a concise overview. 

- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
