### PR TITLE
Avoid NO_INDEXING inc sync

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.7.16 (XXXX-XX-XX)
 --------------------
 
+* Improved sync protocol to commit after each chunk and get rid of
+  potentially dangereous NO_INDEXING optimization.
+
 * Fixed an issue in old incremental sync protocol with document keys that
   contained special characters (`%`). These keys could be send unencoded in the
   incremental sync protocol, leading to wrong key ranges being transfered

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.7.16 (XXXX-XX-XX)
 --------------------
 
-* Improved sync protocol to commit after each chunk and get rid of
-  potentially dangereous NO_INDEXING optimization.
+* Improved sync protocol to commit after each chunk and get rid of the
+  potentially dangerous NO_INDEXING optimization.
 
 * Fixed an issue in old incremental sync protocol with document keys that
   contained special characters (`%`). These keys could be send unencoded in the

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -1194,11 +1194,11 @@ Result DatabaseInitialSyncer::handleCollection(VPackSlice const& parameters,
   // -------------------------------------------------------------------------------------
 
   if (phase == PHASE_DROP_CREATE) {
-    auto* col = resolveCollection(vocbase(), parameters).get();
+    auto col = resolveCollection(vocbase(), parameters);
 
     if (col == nullptr) {
       // not found...
-      col = vocbase().lookupCollection(masterName).get();
+      col = vocbase().lookupCollection(masterName);
 
       if (col != nullptr && (col->name() != masterName ||
                              (!masterUuid.empty() && col->guid() != masterUuid))) {
@@ -1289,9 +1289,10 @@ Result DatabaseInitialSyncer::handleCollection(VPackSlice const& parameters,
 
         // collection is already present
         _config.progress.set("checking/changing parameters of " + collectionMsg);
-        return changeCollection(col, parameters);
+        return changeCollection(col.get(), parameters);
       }
     }
+    // When we get here, col is a nullptr anyway!
 
     std::string msg = "creating " + collectionMsg;
     if (_config.applier._skipCreateDrop) {
@@ -1304,7 +1305,8 @@ Result DatabaseInitialSyncer::handleCollection(VPackSlice const& parameters,
     LOG_TOPIC("7093d", DEBUG, Logger::REPLICATION)
         << "Dump is creating collection " << parameters.toJson();
 
-    auto r = createCollection(vocbase(), parameters, &col);
+    LogicalCollection* col2 = nullptr;
+    auto r = createCollection(vocbase(), parameters, &col2);
 
     if (r.fail()) {
       return Result(r.errorNumber(), std::string("unable to create ") + collectionMsg +
@@ -1321,7 +1323,8 @@ Result DatabaseInitialSyncer::handleCollection(VPackSlice const& parameters,
   else if (phase == PHASE_DUMP) {
     _config.progress.set("dumping data for " + collectionMsg);
 
-    auto* col = resolveCollection(vocbase(), parameters).get();
+    std::shared_ptr<LogicalCollection> col
+        = resolveCollection(vocbase(), parameters);
 
     if (col == nullptr) {
       return Result(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
@@ -1331,8 +1334,8 @@ Result DatabaseInitialSyncer::handleCollection(VPackSlice const& parameters,
 
     std::string const& masterColl = !masterUuid.empty() ? masterUuid : itoa(masterCid);
     auto res = incremental && hasDocuments(*col)
-                   ? fetchCollectionSync(col, masterColl, _config.master.lastLogTick)
-                   : fetchCollectionDump(col, masterColl, _config.master.lastLogTick);
+                   ? fetchCollectionSync(col.get(), masterColl, _config.master.lastLogTick)
+                   : fetchCollectionDump(col.get(), masterColl, _config.master.lastLogTick);
 
     if (!res.ok()) {
       return res;

--- a/arangod/Replication/Syncer.cpp
+++ b/arangod/Replication/Syncer.cpp
@@ -745,7 +745,7 @@ Result Syncer::dropCollection(VPackSlice const& slice, bool reportError) {
     return Result(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
   }
 
-  auto* col = resolveCollection(*vocbase, slice).get();
+  auto col = resolveCollection(*vocbase, slice);
 
   if (col == nullptr) {
     if (reportError) {

--- a/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
+++ b/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
@@ -661,25 +661,24 @@ Result handleSyncKeysRocksDB(DatabaseInitialSyncer& syncer,
       return Result(TRI_ERROR_REPLICATION_APPLIER_STOPPED);
     }
 
-    SingleCollectionTransaction trx(transaction::StandaloneContext::Create(
-                                        syncer.vocbase()),
-                                    *col, AccessMode::Type::EXCLUSIVE);
+    // Create on heap since we want to do controlled commits for each chunk:
+    std::unique_ptr<SingleCollectionTransaction> trx;
 
-    // turn on intermediate commits as the number of operations can be huge here
-    trx.addHint(transaction::Hints::Hint::INTERMEDIATE_COMMITS);
-    // TODO: check if we need to remove the below line!
-    trx.addHint(transaction::Hints::Hint::NO_INDEXING);
+    auto startTrx = [&]() -> Result {
+      trx = std::make_unique<SingleCollectionTransaction>(
+          transaction::StandaloneContext::Create(syncer.vocbase()),
+            *col, AccessMode::Type::EXCLUSIVE);
+      return trx->begin();
+    };
 
-    Result res = trx.begin();
-
+    Result res = startTrx();
     if (!res.ok()) {
       return Result(res.errorNumber(),
                     std::string("unable to start transaction: ") + res.errorMessage());
     }
 
     // We do not take responsibility for the index.
-    // The LogicalCollection is protected by trx.
-    // Neither it nor its indexes can be invalidated
+    // The LogicalCollection is protected by the shared_ptr.
 
     RocksDBCollection* physical = static_cast<RocksDBCollection*>(col->getPhysical());
     size_t currentChunkId = 0;
@@ -750,7 +749,7 @@ Result handleSyncKeysRocksDB(DatabaseInitialSyncer& syncer,
             tempBuilder.add(VPackValue(docKey));
 
             ManagedDocumentResult previous;
-            auto r = physical->remove(trx, tempBuilder.slice(), previous, options);
+            auto r = physical->remove(*trx, tempBuilder.slice(), previous, options);
 
             if (r.fail() && r.isNot(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND)) {
               // ignore not found, we remove conflicting docs ahead of time
@@ -805,7 +804,7 @@ Result handleSyncKeysRocksDB(DatabaseInitialSyncer& syncer,
           TRI_ASSERT(!rangeUnequal || nextChunk);  // A => B
           if (nextChunk) {  // we are out of range, see next chunk
             if (rangeUnequal && currentChunkId < numChunks) {
-              Result res = syncChunkRocksDB(syncer, &trx, stats, keysId,
+              Result res = syncChunkRocksDB(syncer, trx.get(), stats, keysId,
                                             currentChunkId, lowKey, highKey, markers);
               if (!res.ok()) {
                 THROW_ARANGO_EXCEPTION(res);
@@ -823,7 +822,7 @@ Result handleSyncKeysRocksDB(DatabaseInitialSyncer& syncer,
         };  // compare chunk - end
 
     uint64_t documentsFound = 0;
-    auto iterator = createPrimaryIndexIterator(&trx, col);
+    auto iterator = createPrimaryIndexIterator(trx.get(), col);
     iterator.next(
         [&](rocksdb::Slice const& rocksKey, rocksdb::Slice const& rocksValue) {
           ++documentsFound;
@@ -832,7 +831,7 @@ Result handleSyncKeysRocksDB(DatabaseInitialSyncer& syncer,
           if (!RocksDBValue::revisionId(rocksValue, docRev)) {
             // for collections that do not have the revisionId in the value
             auto documentId = RocksDBValue::documentId(rocksValue);  // we want probably to do this instead
-            col->readDocumentWithCallback(&trx, documentId,
+            col->readDocumentWithCallback(trx.get(), documentId,
                                           [&docRev](LocalDocumentId const&, VPackSlice doc) {
                                             docRev = TRI_ExtractRevisionId(doc);
                                             return true;
@@ -845,7 +844,7 @@ Result handleSyncKeysRocksDB(DatabaseInitialSyncer& syncer,
 
     // we might have missed chunks, if the keys don't exist at all locally
     while (currentChunkId < numChunks) {
-      Result res = syncChunkRocksDB(syncer, &trx, stats, keysId, currentChunkId,
+      Result res = syncChunkRocksDB(syncer, trx.get(), stats, keysId, currentChunkId,
                                     lowKey, highKey, markers);
       if (!res.ok()) {
         THROW_ARANGO_EXCEPTION(res);
@@ -853,6 +852,14 @@ Result handleSyncKeysRocksDB(DatabaseInitialSyncer& syncer,
       currentChunkId++;
       if (currentChunkId < numChunks) {
         resetChunk();
+        res = trx->commit();
+        if (res.fail()) {
+          THROW_ARANGO_EXCEPTION(res);
+        }
+        res = startTrx();
+        if (res.fail()) {
+          THROW_ARANGO_EXCEPTION(res);
+        }
       }
     }
 
@@ -861,7 +868,7 @@ Result handleSyncKeysRocksDB(DatabaseInitialSyncer& syncer,
           documentsFound + stats.numDocsInserted -
           (stats.numDocsRemoved - numberDocumentsRemovedBeforeStart);
       uint64_t numberDocumentsDueToCounter =
-          col->numberDocuments(&trx, transaction::CountType::Normal);
+          col->numberDocuments(trx.get(), transaction::CountType::Normal);
       syncer.setProgress(
           std::string("number of remaining documents in collection '") +
           col->name() + "': " + std::to_string(numberDocumentsAfterSync) +
@@ -880,12 +887,12 @@ Result handleSyncKeysRocksDB(DatabaseInitialSyncer& syncer,
         int64_t diff = static_cast<int64_t>(numberDocumentsAfterSync) -
                        static_cast<int64_t>(numberDocumentsDueToCounter);
         auto seq = rocksutils::latestSequenceNumber();
-        static_cast<RocksDBCollection*>(trx.documentCollection()->getPhysical())
+        static_cast<RocksDBCollection*>(trx->documentCollection()->getPhysical())
             ->meta().adjustNumberDocuments(seq, /*revId*/0, diff);
       }
     }
 
-    res = trx.commit();
+    res = trx->commit();
 
     if (res.fail()) {
       return res;


### PR DESCRIPTION
This PR aims to get rid of the NO_INDEXING hint during initial shard
synchronization. To avoid performance losses, we will commit the
transaction after each chunk (5000 documents).

This PR also fixes some unsafe uses of LogicalCollection pointers.

- In handleSyncKeysRocksDB commit after each chunk.
- CHANGELOG.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers)*

- [*] :hankey: Bugfix 
- [*] :book: CHANGELOG entry made
- [*] :muscle: The behavior in this PR was *manually tested*

#### Backports:

- [*] Backports required for: This will be forward ported to 3.8, 3.9
      and devel.

#### Related Information

*(Please reference tickets / specification etc)*

- [*] GitHub issue / Jira ticket number: This is a followup work to
      https://github.com/arangodb/arangodb/pull/15117

### Testing & Verification

*(Please pick either of the following options)*

- [*] This change is a trivial rework / code cleanup without any test coverage.
- [*] This change is already covered by existing tests, such as
       - all tests doing replication and incremental sync protocol

