### PR TITLE
Avoid NO_INDEXING inc sync

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@ v3.8.4 (XXXX-XX-XX)
   in the response with a value "(non-representable type none)".
 
 * Improved sync protocol to commit after each chunk and get rid of
-  potentially dangereous NO_INDEXING optimization.
+  potentially dangerous NO_INDEXING optimization.
 
 
 v3.8.3 (2021-11-17)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,12 @@
 v3.8.4 (XXXX-XX-XX)
 -------------------
 
+* Improved sync protocol to commit after each chunk and get rid of
+  potentially dangerous NO_INDEXING optimization.
+
 * Do not expose "parallelism" key in responses to Pregel control job requests
   when parallelism is not set. This avoids returning a "parallelism" attribute
   in the response with a value "(non-representable type none)".
-
-* Improved sync protocol to commit after each chunk and get rid of
-  potentially dangerous NO_INDEXING optimization.
 
 
 v3.8.3 (2021-11-17)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,9 @@ v3.8.4 (XXXX-XX-XX)
   when parallelism is not set. This avoids returning a "parallelism" attribute
   in the response with a value "(non-representable type none)".
 
+* Improved sync protocol to commit after each chunk and get rid of
+  potentially dangereous NO_INDEXING optimization.
+
 
 v3.8.3 (2021-11-17)
 -------------------

--- a/arangod/Replication/Syncer.cpp
+++ b/arangod/Replication/Syncer.cpp
@@ -745,7 +745,7 @@ Result Syncer::dropCollection(VPackSlice const& slice, bool reportError) {
     return Result(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
   }
 
-  auto* col = resolveCollection(*vocbase, slice).get();
+  auto col = resolveCollection(*vocbase, slice);
 
   if (col == nullptr) {
     if (reportError) {


### PR DESCRIPTION
This PR aims to get rid of the NO_INDEXING hint during initial shard
synchronization. To avoid performance losses, we will commit the
transaction after each chunk (5000 documents).

This PR also fixes some unsafe uses of LogicalCollection pointers.

 -  In handleSyncKeysRocksDB commit after each chunk.
 -  CHANGELOG.

Scope & Purpose

(Please describe the changes in this PR for reviewers)

    [*] Bugfix
    [*] CHANGELOG entry made
    [*] The behavior in this PR was manually tested

Backports:

    [*] Backports required for: This will be forward ported to 3.8, 3.9
        and devel.

Related Information

(Please reference tickets / specification etc)

    [*] GitHub issue / Jira ticket number: This is a followup work to

        Bugfixes for old incremental sync protocol #15117

Testing & Verification

(Please pick either of the following options)

    [*] This change is a trivial rework / code cleanup without any test coverage.
    [*] This change is already covered by existing tests, such as
         - all tests doing replication and incremental sync protocol

