### PR TITLE
Removed an invalid assertion in `removeDocument`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.8.4 (XXXX-XX-XX)
 -------------------
 
+* Removed an invalid assertion that could be triggered during chaos testing in
+  maintainer mode.
+
 * Do not expose "parallelism" key in responses to Pregel control job requests
   when parallelism is not set. This avoids returning a "parallelism" attribute
   in the response with a value "(non-representable type none)".

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -1554,14 +1554,6 @@ Result RocksDBCollection::insertDocument(arangodb::transaction::Methods* trx,
 
   // disable indexing in this transaction if we are allowed to
   IndexingDisabler disabler(mthds, state->isSingleOperation());
- 
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-  if (performPreflightChecks) {
-    rocksdb::PinnableSlice val;
-    rocksdb::Status s = mthds->Get(RocksDBColumnFamilyManager::get(RocksDBColumnFamilyManager::Family::Documents), key->string(), &val, ReadOwnWrites::yes);
-    TRI_ASSERT(s.IsNotFound() || !s.ok());
-  }
-#endif
 
   TRI_IF_FAILURE("RocksDBCollection::insertFail1") {
     if (RandomGenerator::interval(uint32_t(1000)) >= 995) {
@@ -1651,14 +1643,6 @@ Result RocksDBCollection::removeDocument(arangodb::transaction::Methods* trx,
   // disable indexing in this transaction if we are allowed to
   IndexingDisabler disabler(mthds, trx->isSingleOperationTransaction());
 
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-  {
-    rocksdb::PinnableSlice val;
-    rocksdb::Status s = mthds->Get(RocksDBColumnFamilyManager::get(RocksDBColumnFamilyManager::Family::Documents), key->string(), &val, ReadOwnWrites::yes);
-    TRI_ASSERT(s.ok());
-  }
-#endif
-  
   TRI_IF_FAILURE("RocksDBCollection::removeFail1") {
     if (RandomGenerator::interval(uint32_t(1000)) >= 995) {
       return res.reset(TRI_ERROR_DEBUG);


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/15177

Removed an invalid assertion in `removeDocument` that assertion could be triggered during chaos testing in maintainer mode.
The assertion is invalid under the following circumstances:
* `removeDocument` is called by `truncate`
* the `truncate` has created an iterator for the collection's documents in which the document still existed
* another concurrent thread removed a document from the snapshot
* the thread that performs the truncate does an intermediate commit

Then the thread that performs truncate will be unable to find the document in the database that still exists in the snapshot. Thus the assertion will fire.

This fixes https://arangodb.atlassian.net/browse/BTS-601

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Related Information

- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-601

### Testing & Verification

- [x] This change is already covered by existing tests, such as *chaos*.
