### PR TITLE
do not pass VPack slices as const references

### DIFF
--- a/arangod/StorageEngine/PhysicalCollection.cpp
+++ b/arangod/StorageEngine/PhysicalCollection.cpp
@@ -194,7 +194,7 @@ RevisionId PhysicalCollection::newRevisionId() const {
 /// @brief merge two objects for update, oldValue must have correctly set
 /// _key and _id attributes
 Result PhysicalCollection::mergeObjectsForUpdate(
-    transaction::Methods*, VPackSlice const& oldValue, VPackSlice const& newValue,
+    transaction::Methods*, VPackSlice oldValue, VPackSlice newValue,
     bool isEdgeCollection, bool mergeObjects, bool keepNull, VPackBuilder& b,
     bool isRestore, RevisionId& revisionId) const {
   b.openObject();
@@ -350,7 +350,7 @@ Result PhysicalCollection::mergeObjectsForUpdate(
 
 /// @brief new object for insert, computes the hash of the key
 Result PhysicalCollection::newObjectForInsert(transaction::Methods*,
-                                              VPackSlice const& value, bool isEdgeCollection,
+                                              VPackSlice value, bool isEdgeCollection,
                                               VPackBuilder& builder, bool isRestore,
                                               RevisionId& revisionId) const {
   builder.openObject();
@@ -455,7 +455,7 @@ Result PhysicalCollection::newObjectForInsert(transaction::Methods*,
 }
 
 /// @brief new object for remove, must have _key set
-void PhysicalCollection::newObjectForRemove(transaction::Methods*, VPackSlice const& oldValue,
+void PhysicalCollection::newObjectForRemove(transaction::Methods*, VPackSlice oldValue,
                                             VPackBuilder& builder, bool isRestore,
                                             RevisionId& revisionId) const {
   // create an object consisting of _key and _rev (in this order)
@@ -478,8 +478,8 @@ void PhysicalCollection::newObjectForRemove(transaction::Methods*, VPackSlice co
 /// @brief new object for replace, oldValue must have _key and _id correctly
 /// set
 Result PhysicalCollection::newObjectForReplace(transaction::Methods*,
-                                               VPackSlice const& oldValue,
-                                               VPackSlice const& newValue, bool isEdgeCollection,
+                                               VPackSlice oldValue,
+                                               VPackSlice newValue, bool isEdgeCollection,
                                                VPackBuilder& builder, bool isRestore,
                                                RevisionId& revisionId) const {
   builder.openObject();

--- a/arangod/StorageEngine/PhysicalCollection.h
+++ b/arangod/StorageEngine/PhysicalCollection.h
@@ -206,7 +206,7 @@ class PhysicalCollection {
                         ManagedDocumentResult& previous, OperationOptions& options);
 
   /// @brief new object for insert, value must have _key set correctly.
-  Result newObjectForInsert(transaction::Methods* trx, velocypack::Slice const& value,
+  Result newObjectForInsert(transaction::Methods* trx, velocypack::Slice value,
                             bool isEdgeCollection, velocypack::Builder& builder,
                             bool isRestore, RevisionId& revisionId) const;
 
@@ -233,20 +233,20 @@ class PhysicalCollection {
   bool isValidEdgeAttribute(velocypack::Slice const& slice) const;
 
   /// @brief new object for remove, must have _key set
-  void newObjectForRemove(transaction::Methods* trx, velocypack::Slice const& oldValue,
+  void newObjectForRemove(transaction::Methods* trx, velocypack::Slice oldValue,
                           velocypack::Builder& builder, bool isRestore,
                           RevisionId& revisionId) const;
 
   /// @brief merge two objects for update
-  Result mergeObjectsForUpdate(transaction::Methods* trx, velocypack::Slice const& oldValue,
-                               velocypack::Slice const& newValue,
+  Result mergeObjectsForUpdate(transaction::Methods* trx, velocypack::Slice oldValue,
+                               velocypack::Slice newValue,
                                bool isEdgeCollection, bool mergeObjects,
                                bool keepNull, velocypack::Builder& builder,
                                bool isRestore, RevisionId& revisionId) const;
 
   /// @brief new object for replace
-  Result newObjectForReplace(transaction::Methods* trx, velocypack::Slice const& oldValue,
-                             velocypack::Slice const& newValue,
+  Result newObjectForReplace(transaction::Methods* trx, velocypack::Slice oldValue,
+                             velocypack::Slice newValue,
                              bool isEdgeCollection, velocypack::Builder& builder,
                              bool isRestore, RevisionId& revisionId) const;
 


### PR DESCRIPTION
### Scope & Purpose

  VPack slices only contain a single pointer data member, so they can be
  passed around by value. It is not necessary to pass them by reference.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
