### PR TITLE
Avoid NO_INDEXING inc sync

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.9.0 (XXXX-XX-XX)
 -------------------
 
+* Improved sync protocol to commit after each chunk and get rid of
+  potentially dangereous NO_INDEXING optimization.
+
 * APM-187: The "Rebalance Shards" button now is displayed in a new tab, and it
   is displayed for any database in cluster mode. There is also a new flag for
   arangod, `--cluster.max-number-of-move-shards` (default = 10), which limits
@@ -116,7 +119,6 @@ v3.9.0 (XXXX-XX-XX)
 
 * Fixed SEARCH-260: Fix invalid sorting order of stored features in presence of
   primary sort (ArangoSearch).
-
 
 * Change error message for queries that use too much memory from "resource limit
   exceeded" to "query would use more memory than allowed".

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ v3.9.0 (XXXX-XX-XX)
 -------------------
 
 * Improved sync protocol to commit after each chunk and get rid of
-  potentially dangereous NO_INDEXING optimization.
+  potentially dangerous NO_INDEXING optimization.
 
 * APM-187: The "Rebalance Shards" button now is displayed in a new tab, and it
   is displayed for any database in cluster mode. There is also a new flag for

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -1785,11 +1785,11 @@ Result DatabaseInitialSyncer::handleCollection(VPackSlice const& parameters,
   // -------------------------------------------------------------------------------------
 
   if (phase == PHASE_DROP_CREATE) {
-    auto* col = resolveCollection(vocbase(), parameters).get();
+    auto col = resolveCollection(vocbase(), parameters);
 
     if (col == nullptr) {
       // not found...
-      col = vocbase().lookupCollection(leaderName).get();
+      col = vocbase().lookupCollection(leaderName);
 
       if (col != nullptr && (col->name() != leaderName ||
                              (!leaderUuid.empty() && col->guid() != leaderUuid))) {
@@ -1878,9 +1878,10 @@ Result DatabaseInitialSyncer::handleCollection(VPackSlice const& parameters,
 
         // collection is already present
         _config.progress.set("checking/changing parameters of " + collectionMsg);
-        return changeCollection(col, parameters);
+        return changeCollection(col.get(), parameters);
       }
     }
+    // When we get here, col is a nullptr anyway!
 
     std::string msg = "creating " + collectionMsg;
     if (_config.applier._skipCreateDrop) {
@@ -1893,7 +1894,8 @@ Result DatabaseInitialSyncer::handleCollection(VPackSlice const& parameters,
     LOG_TOPIC("7093d", DEBUG, Logger::REPLICATION)
         << "Dump is creating collection " << parameters.toJson();
 
-    auto r = createCollection(vocbase(), parameters, &col);
+    LogicalCollection* col2 = nullptr;
+    auto r = createCollection(vocbase(), parameters, &col2);
 
     if (r.fail()) {
       return Result(r.errorNumber(), concatT("unable to create ", collectionMsg,
@@ -1910,7 +1912,8 @@ Result DatabaseInitialSyncer::handleCollection(VPackSlice const& parameters,
   else if (phase == PHASE_DUMP) {
     _config.progress.set("dumping data for " + collectionMsg);
 
-    auto* col = resolveCollection(vocbase(), parameters).get();
+    std::shared_ptr<LogicalCollection> col
+        = resolveCollection(vocbase(), parameters);
 
     if (col == nullptr) {
       return Result(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
@@ -1921,8 +1924,8 @@ Result DatabaseInitialSyncer::handleCollection(VPackSlice const& parameters,
     std::string const& leaderColl =
         !leaderUuid.empty() ? leaderUuid : itoa(leaderCid.id());
     auto res = incremental && hasDocuments(*col)
-                   ? fetchCollectionSync(col, leaderColl, _config.leader.lastLogTick)
-                   : fetchCollectionDump(col, leaderColl, _config.leader.lastLogTick);
+                   ? fetchCollectionSync(col.get(), leaderColl, _config.leader.lastLogTick)
+                   : fetchCollectionDump(col.get(), leaderColl, _config.leader.lastLogTick);
 
     if (!res.ok()) {
       return res;

--- a/arangod/Replication/Syncer.cpp
+++ b/arangod/Replication/Syncer.cpp
@@ -725,7 +725,7 @@ Result Syncer::dropCollection(VPackSlice const& slice, bool reportError) {
     return Result(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
   }
 
-  auto* col = resolveCollection(*vocbase, slice).get();
+  auto col = resolveCollection(*vocbase, slice);
 
   if (col == nullptr) {
     if (reportError) {

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -380,7 +380,7 @@ Result TailingSyncer::processDocument(TRI_replication_operation_e type,
     return Result(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
   }
 
-  auto* coll = resolveCollection(*vocbase, slice).get();
+  auto coll = resolveCollection(*vocbase, slice);
 
   if (coll == nullptr) {
     return Result(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
@@ -455,7 +455,7 @@ Result TailingSyncer::processDocument(TRI_replication_operation_e type,
 
     trx->addCollectionAtRuntime(coll->id(), coll->name(), AccessMode::Type::EXCLUSIVE);
     std::string conflictingDocumentKey;
-    Result r = applyCollectionDumpMarker(*trx, coll, type, applySlice, conflictingDocumentKey);
+    Result r = applyCollectionDumpMarker(*trx, coll.get(), type, applySlice, conflictingDocumentKey);
     TRI_ASSERT(!r.is(TRI_ERROR_ARANGO_TRY_AGAIN));
 
     if (r.errorNumber() == TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED && isSystem) {
@@ -491,7 +491,7 @@ Result TailingSyncer::processDocument(TRI_replication_operation_e type,
 
       // intentionally ignore the return code here, as the operation will be followed
       // by yet another insert/replace
-      removeSingleDocument(coll, conflictDocumentKey);
+      removeSingleDocument(coll.get(), conflictDocumentKey);
       conflictDocumentKey.clear();
     }
     
@@ -514,7 +514,7 @@ Result TailingSyncer::processDocument(TRI_replication_operation_e type,
                         "unable to create replication transaction: ", res.errorMessage()));
     }
 
-    res = applyCollectionDumpMarker(trx, coll, type, applySlice, conflictDocumentKey);
+    res = applyCollectionDumpMarker(trx, coll.get(), type, applySlice, conflictDocumentKey);
 
     TRI_ASSERT(res.is(TRI_ERROR_ARANGO_TRY_AGAIN) == !conflictDocumentKey.empty());
 
@@ -723,16 +723,16 @@ Result TailingSyncer::renameCollection(VPackSlice const& slice) {
     return Result(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
   }
 
-  arangodb::LogicalCollection* col = nullptr;
+  std::shared_ptr<arangodb::LogicalCollection> col;
 
   if (slice.hasKey("cuid")) {
-    col = resolveCollection(*vocbase, slice).get();
+    col = resolveCollection(*vocbase, slice);
 
     if (col == nullptr) {
       return Result(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, "unknown cuid");
     }
   } else if (collection.hasKey("oldName")) {
-    col = vocbase->lookupCollection(collection.get("oldName").copyString()).get();
+    col = vocbase->lookupCollection(collection.get("oldName").copyString());
 
     if (col == nullptr) {
       return Result(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
@@ -812,7 +812,7 @@ Result TailingSyncer::truncateCollection(arangodb::velocypack::Slice const& slic
   if (vocbase == nullptr) {
     return Result(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
   }
-  auto* col = resolveCollection(*vocbase, slice).get();
+  auto col = resolveCollection(*vocbase, slice);
   if (col == nullptr) {
     return Result(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
   }


### PR DESCRIPTION
This PR aims to get rid of the NO_INDEXING hint during initial shard
synchronization. To avoid performance losses, we will commit the
transaction after each chunk (5000 documents).

This PR also fixes some unsafe uses of LogicalCollection pointers.

 - In handleSyncKeysRocksDB commit after each chunk.
 - CHANGELOG.

Scope & Purpose

(Please describe the changes in this PR for reviewers)

 - [*] Bugfix
 - [*] CHANGELOG entry made
 - [*] The behavior in this PR was manually tested

Backports:

 - [*] Backports required for: This is a forward port to 3.9 from 3.7.

Related Information

(Please reference tickets / specification etc)

 - [*] GitHub issue / Jira ticket number: This is a followup work to
       Bugfixes for old incremental sync protocol #15117

Testing & Verification

(Please pick either of the following options)

 - [*] This change is a trivial rework / code cleanup without any test coverage.
 - [*] This change is already covered by existing tests, such as
        - all tests doing replication and incremental sync protocol

