### PR TITLE
ensure consistency for `db.<collection>.figures(true)` count results

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.9.0 (XXXX-XX-XX)
 -------------------
 
+* Make `db.<collection>.figures(true)` operate on the same snapshot when 
+  counting the number of documents in the documents column family and the
+  indexes. This ensures consistency for the results of a single figures result.
+
 * Upgraded bundled version of RocksDB to 6.27.
 
 * Improved sync protocol to commit after each chunk and get rid of potentially

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.9.0 (XXXX-XX-XX)
 -------------------
 
-* Make `db.<collection>.figures(true)` operate on the same snapshot when 
+* Make `db.<collection>.figures(true)` operate on the same snapshot when
   counting the number of documents in the documents column family and the
   indexes. This ensures consistency for the results of a single figures result.
 

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -1281,7 +1281,7 @@ bool RocksDBCollection::hasDocuments() {
   RocksDBEngine& engine =
       _logicalCollection.vocbase().server().getFeature<EngineSelectorFeature>().engine<RocksDBEngine>();
   RocksDBKeyBounds bounds = RocksDBKeyBounds::CollectionDocuments(objectId());
-  return rocksutils::hasKeys(engine.db(), bounds, true);
+  return rocksutils::hasKeys(engine.db(), bounds, /*snapshot*/ nullptr, true);
 }
 
 /// @brief return engine-specific figures
@@ -1320,15 +1320,21 @@ void RocksDBCollection::figuresSpecific(bool details, arangodb::velocypack::Buil
 
   if (details) {
     // engine-specific stuff here
+    RocksDBFilePurgePreventer purgePreventer(engine.disallowPurging());
+
     rocksdb::DB* rootDB = db->GetRootDB();
+      
+    // acquire a snapshot
+    rocksdb::Snapshot const* snapshot = db->GetSnapshot();
+     
+    try {
+      builder.add("engine", VPackValue(VPackValueType::Object));
 
-    builder.add("engine", VPackValue(VPackValueType::Object));
+      builder.add("documents",
+                  VPackValue(rocksutils::countKeyRange(
+                      rootDB, RocksDBKeyBounds::CollectionDocuments(objectId()), snapshot, true)));
+      builder.add("indexes", VPackValue(VPackValueType::Array));
 
-    builder.add("documents",
-                VPackValue(rocksutils::countKeyRange(
-                    rootDB, RocksDBKeyBounds::CollectionDocuments(objectId()), true)));
-    builder.add("indexes", VPackValue(VPackValueType::Array));
-    {
       RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
       for (auto it : _indexes) {
         auto type = it->type();
@@ -1346,28 +1352,28 @@ void RocksDBCollection::figuresSpecific(bool details, arangodb::velocypack::Buil
         size_t count = 0;
         switch (type) {
           case Index::TRI_IDX_TYPE_PRIMARY_INDEX:
-            count = rocksutils::countKeyRange(db, RocksDBKeyBounds::PrimaryIndex(rix->objectId()), true);
+            count = rocksutils::countKeyRange(db, RocksDBKeyBounds::PrimaryIndex(rix->objectId()), snapshot, true);
             break;
           case Index::TRI_IDX_TYPE_GEO_INDEX:
           case Index::TRI_IDX_TYPE_GEO1_INDEX:
           case Index::TRI_IDX_TYPE_GEO2_INDEX:
-            count = rocksutils::countKeyRange(db, RocksDBKeyBounds::GeoIndex(rix->objectId()), true);
+            count = rocksutils::countKeyRange(db, RocksDBKeyBounds::GeoIndex(rix->objectId()), snapshot, true);
             break;
           case Index::TRI_IDX_TYPE_HASH_INDEX:
           case Index::TRI_IDX_TYPE_SKIPLIST_INDEX:
           case Index::TRI_IDX_TYPE_TTL_INDEX:
           case Index::TRI_IDX_TYPE_PERSISTENT_INDEX:
             if (it->unique()) {
-              count = rocksutils::countKeyRange(db, RocksDBKeyBounds::UniqueVPackIndex(rix->objectId(), false), true);
+              count = rocksutils::countKeyRange(db, RocksDBKeyBounds::UniqueVPackIndex(rix->objectId(), false), snapshot, true);
             } else {
-              count = rocksutils::countKeyRange(db, RocksDBKeyBounds::VPackIndex(rix->objectId(), false), true);
+              count = rocksutils::countKeyRange(db, RocksDBKeyBounds::VPackIndex(rix->objectId(), false), snapshot, true);
             }
             break;
           case Index::TRI_IDX_TYPE_EDGE_INDEX:
-            count = rocksutils::countKeyRange(db, RocksDBKeyBounds::EdgeIndex(rix->objectId()), false);
+            count = rocksutils::countKeyRange(db, RocksDBKeyBounds::EdgeIndex(rix->objectId()), snapshot, false);
             break;
           case Index::TRI_IDX_TYPE_FULLTEXT_INDEX:
-            count = rocksutils::countKeyRange(db, RocksDBKeyBounds::FulltextIndex(rix->objectId()), true);
+            count = rocksutils::countKeyRange(db, RocksDBKeyBounds::FulltextIndex(rix->objectId()), snapshot, true);
             break;
           default:
             // we should not get here
@@ -1377,6 +1383,12 @@ void RocksDBCollection::figuresSpecific(bool details, arangodb::velocypack::Buil
         builder.add("count", VPackValue(count));
         builder.close();
       }
+        
+      db->ReleaseSnapshot(snapshot);
+    } catch (...) {
+      // always free the snapshot
+      db->ReleaseSnapshot(snapshot);
+      throw;
     }
     builder.close(); // "indexes" array
     builder.close(); // "engine" object

--- a/arangod/RocksDBEngine/RocksDBCommon.cpp
+++ b/arangod/RocksDBEngine/RocksDBCommon.cpp
@@ -83,14 +83,17 @@ std::size_t countKeys(rocksdb::DB* db, rocksdb::ColumnFamilyHandle* cf) {
 
 /// @brief iterate over all keys in range and count them
 std::size_t countKeyRange(rocksdb::DB* db, RocksDBKeyBounds const& bounds,
-                          bool prefix_same_as_start) {
+                          rocksdb::Snapshot const* snapshot,
+                          bool prefixSameAsStart) {
+  // note: snapshot may be a nullptr!
   rocksdb::Slice lower(bounds.start());
   rocksdb::Slice upper(bounds.end());
 
   rocksdb::ReadOptions readOptions;
-  readOptions.prefix_same_as_start = prefix_same_as_start;
+  readOptions.snapshot = snapshot;
+  readOptions.prefix_same_as_start = prefixSameAsStart;
   readOptions.iterate_upper_bound = &upper;
-  readOptions.total_order_seek = !prefix_same_as_start;
+  readOptions.total_order_seek = !prefixSameAsStart;
   readOptions.verify_checksums = false;
   readOptions.fill_cache = false;
 
@@ -108,14 +111,18 @@ std::size_t countKeyRange(rocksdb::DB* db, RocksDBKeyBounds const& bounds,
 }
 
 /// @brief whether or not the specified range has keys
-bool hasKeys(rocksdb::DB* db, RocksDBKeyBounds const& bounds, bool prefix_same_as_start) {
+bool hasKeys(rocksdb::DB* db, RocksDBKeyBounds const& bounds, 
+             rocksdb::Snapshot const* snapshot,
+             bool prefixSameAsStart) {
+  // note: snapshot may be a nullptr!
   rocksdb::Slice lower(bounds.start());
   rocksdb::Slice upper(bounds.end());
 
   rocksdb::ReadOptions readOptions;
-  readOptions.prefix_same_as_start = prefix_same_as_start;
+  readOptions.snapshot = snapshot;
+  readOptions.prefix_same_as_start = prefixSameAsStart;
   readOptions.iterate_upper_bound = &upper;
-  readOptions.total_order_seek = !prefix_same_as_start;
+  readOptions.total_order_seek = !prefixSameAsStart;
   readOptions.verify_checksums = false;
   readOptions.fill_cache = false;
 

--- a/arangod/RocksDBEngine/RocksDBCommon.h
+++ b/arangod/RocksDBEngine/RocksDBCommon.h
@@ -46,6 +46,7 @@ class ColumnFamilyHandle;
 class DB;
 class Iterator;
 struct ReadOptions;
+class Snapshot;
 class TransactionDB;
 }  // namespace rocksdb
 
@@ -67,10 +68,12 @@ void checkIteratorStatus(rocksdb::Iterator const* iterator);
 std::size_t countKeys(rocksdb::DB*, rocksdb::ColumnFamilyHandle* cf);
 
 /// @brief iterate over all keys in range and count them
-std::size_t countKeyRange(rocksdb::DB*, RocksDBKeyBounds const&, bool prefix_same_as_start);
+std::size_t countKeyRange(rocksdb::DB*, RocksDBKeyBounds const&, 
+                          rocksdb::Snapshot const* snapshot, bool prefixSameAsStart);
 
 /// @brief whether or not the specified range has keys
-bool hasKeys(rocksdb::DB*, RocksDBKeyBounds const&, bool prefix_same_as_start);
+bool hasKeys(rocksdb::DB*, RocksDBKeyBounds const&, 
+             rocksdb::Snapshot const* snapshot, bool prefixSameAsStart);
 
 /// @brief helper method to remove large ranges of data
 /// Should mainly be used to implement the drop() call

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -1772,7 +1772,7 @@ arangodb::Result RocksDBEngine::dropCollection(TRI_vocbase_t& vocbase,
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // check if documents have been deleted
-  size_t numDocs = rocksutils::countKeyRange(_db, bounds, true);
+  size_t numDocs = rocksutils::countKeyRange(_db, bounds, nullptr, true);
 
   if (numDocs > 0) {
     std::string errorMsg(
@@ -2391,7 +2391,7 @@ Result RocksDBEngine::dropDatabase(TRI_voc_tick_t id) {
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
         // check if documents have been deleted
-        numDocsLeft += rocksutils::countKeyRange(db, bounds, prefixSameAsStart);
+        numDocsLeft += rocksutils::countKeyRange(db, bounds, /*snapshot*/ nullptr, prefixSameAsStart);
 #endif
       }
     }
@@ -2423,7 +2423,7 @@ Result RocksDBEngine::dropDatabase(TRI_voc_tick_t id) {
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     // check if documents have been deleted
-    numDocsLeft += rocksutils::countKeyRange(db, bounds, true);
+    numDocsLeft += rocksutils::countKeyRange(db, bounds, /*snapshot*/ nullptr, true);
 #endif
   });
 

--- a/arangod/RocksDBEngine/RocksDBIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndex.cpp
@@ -233,7 +233,7 @@ Result RocksDBIndex::drop() {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // check if documents have been deleted
   size_t numDocs =
-      rocksutils::countKeyRange(engine.db(), this->getBounds(), prefixSameAsStart);
+      rocksutils::countKeyRange(engine.db(), this->getBounds(), nullptr, prefixSameAsStart);
   if (numDocs > 0) {
     std::string errorMsg(
         "deletion check in index drop failed - not all documents in the index "

--- a/arangod/RocksDBEngine/RocksDBV8Functions.cpp
+++ b/arangod/RocksDBEngine/RocksDBV8Functions.cpp
@@ -243,7 +243,7 @@ static void JS_CollectionRevisionTreeVerification(v8::FunctionCallbackInfo<v8::V
     RocksDBEngine& engine = server.getFeature<EngineSelectorFeature>().engine<RocksDBEngine>();
     RocksDBReplicationManager* manager = engine.replicationManager();
     double ttl = 3600;
-    // the "17" is a magic number number. we just need any client id to proceed.
+    // the "17" is a magic number. we just need any client id to proceed.
     RocksDBReplicationContext* ctx 
       = manager->createContext(engine, ttl, SyncerId{17}, ServerId{17}, "");
     if (ctx == nullptr) {


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/15148

* Make `db.<collection>.figures(true)` operate on the same snapshot when
  counting the number of documents in the documents column family and the
  indexes. This ensures consistency for the results of a single figures result.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/15200
- [x] Backport for 3.7: https://github.com/arangodb/arangodb/pull/15201

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
