### PR TITLE
fix a spuriously failing replication test

### DIFF
--- a/tests/js/server/replication/ongoing/replication-ongoing.js
+++ b/tests/js/server/replication/ongoing/replication-ongoing.js
@@ -444,12 +444,12 @@ function BaseTestConfig () {
           db[cn].insert({
             _key: 'boom',
             who: 'slave'
-          });
+          }, {waitForSync: true});
           connectToMaster();
           db[cn].insert({
             _key: 'boom',
             who: 'master'
-          });
+          }, {waitForSync: true});
         },
 
         function (state) {


### PR DESCRIPTION
### Scope & Purpose

This is a test-only change.
Fix a spuriously failing replication test that is due to us not waiting for `waitForSync`.
This should fix the error
```
* Test "replication_ongoing"
    [FAILED]  tests/js/server/replication/ongoing/replication-ongoing.js

      "testPrimaryKeyConflict_ReplOther" failed: Error: at assertion #2: assertEqual: (slave) is not equal to (master)
```
Fixes for this have been done in 3.8, 3.9 and devel already.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *replication_ongoing*.
