### PR TITLE
[BTS-565] 3.9 Timeout without Deadlock

### DIFF
--- a/tests/js/client/communication/test-communication.js
+++ b/tests/js/client/communication/test-communication.js
@@ -89,7 +89,7 @@ const runShell = function (args, prefix) {
     'server.database': arango.getDatabaseName(),
     'server.username': arango.connectedUser(),
     'server.password': '',
-    'server.request-timeout': '10',
+    'server.request-timeout': '30',
     'log.foreground-tty': 'false',
     'log.output': 'file://' + prefix + '.log'
   };


### PR DESCRIPTION
### Scope & Purpose

This increases the test timeout to 30s to detect a deadlock.