### PR TITLE
Better corruption visibility

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Improve visibility in case of potential data corruption between primary
+  index and actual document store in documents column family.
+
 * Changed "arangosh" directory name to "client-tools", because the directory 
   contains the code for all client tools and not just arangosh.
 

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -209,6 +209,22 @@ struct TruncateTimeTracker : public TimeTracker {
   }
 };
 
+void reportPrimaryIndexInconsistency(
+    arangodb::Result const& res,
+    arangodb::velocypack::StringRef const& key,
+    arangodb::LocalDocumentId const& rev) {
+
+  if (res.is(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND)) {
+    // Scandal! A primary index entry is pointing to nowhere! Let's report
+    // this to the authorities immediately:
+    LOG_TOPIC("42536", ERR, arangodb::Logger::ENGINES)
+        << "Found primary index entry for which there is no actual "
+           "document: _key=" << key << ", _rev=" << rev.id()
+        << ", ";
+    TRI_ASSERT(false);
+  }
+}
+
 }  // namespace
 
 namespace arangodb {
@@ -917,11 +933,12 @@ Result RocksDBCollection::read(transaction::Methods* trx,
 
   rocksdb::PinnableSlice ps;
   Result res;
+  LocalDocumentId documentId;
   do {
-    LocalDocumentId const documentId = primaryIndex()->lookupKey(trx, key, readOwnWrites);
+    documentId = primaryIndex()->lookupKey(trx, key, readOwnWrites);
     if (!documentId.isSet()) {
       res.reset(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND);
-      break;
+      return res;
     }  // else found
 
     res = lookupDocumentVPack(trx, documentId, ps, /*readCache*/true, /*fillCache*/true, readOwnWrites);
@@ -930,6 +947,7 @@ Result RocksDBCollection::read(transaction::Methods* trx,
     }
   } while (res.is(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND) &&
            RocksDBTransactionState::toState(trx)->ensureSnapshot());
+  ::reportPrimaryIndexInconsistency(res, key, documentId);
   return res;
 }
 
@@ -1054,7 +1072,7 @@ Result RocksDBCollection::replace(transaction::Methods* trx,
   ::WriteTimeTracker timeTracker(_statistics._rocksdb_replace_sec, _statistics, options);
   return performUpdateOrReplace(trx, newSlice, resultMdr, options, previousMdr, false);
 }
-                                  
+
 Result RocksDBCollection::performUpdateOrReplace(transaction::Methods* trx,
                                                  velocypack::Slice newSlice,
                                                  ManagedDocumentResult& resultMdr, OperationOptions& options,
@@ -1088,6 +1106,7 @@ Result RocksDBCollection::performUpdateOrReplace(transaction::Methods* trx,
   res = lookupDocumentVPack(trx, oldDocumentId, previousPS,
     /*readCache*/ true, /*fillCache*/ false, ReadOwnWrites::yes);
   if (res.fail()) {
+    ::reportPrimaryIndexInconsistency(res, keyStr, oldDocumentId);
     return res;
   }
 
@@ -1212,7 +1231,9 @@ Result RocksDBCollection::remove(transaction::Methods& trx, velocypack::Slice sl
     expectedId = RevisionId::fromSlice(slice);
   }
 
-  return remove(trx, documentId, expectedId, previousMdr, options);
+  Result res = remove(trx, documentId, expectedId, previousMdr, options);
+  ::reportPrimaryIndexInconsistency(res, keyStr, documentId);
+  return res;
 }
 
 Result RocksDBCollection::remove(transaction::Methods& trx, LocalDocumentId documentId,

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -219,8 +219,7 @@ void reportPrimaryIndexInconsistency(
     // this to the authorities immediately:
     LOG_TOPIC("42536", ERR, arangodb::Logger::ENGINES)
         << "Found primary index entry for which there is no actual "
-           "document: _key=" << key << ", _rev=" << rev.id()
-        << ", ";
+           "document: _key=" << key << ", _rev=" << rev.id();
     TRI_ASSERT(false);
   }
 }


### PR DESCRIPTION
Whenever we find a document in the primary index, but then fail to
locate the actual document in the documents column family, we write
an ERROR into the log. In maintainer mode, we trigger an assertion
failure.

- Report inconsistency between primary index and actual documents better.
- CHANGELOG.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers - **mandatory**)*

- [*] Minor visibility improvements in case of data corruption
- [*] :book: CHANGELOG entry made

#### Backports:

- [*] Backport for 3.9: *(Please link PR)*
- [*] Backport for 3.8: *(Please link PR)*
- [*] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-653

### Testing & Verification

*(Please pick either of the following options)*

- [*] This change is a trivial rework / code cleanup without any test coverage.

