### PR TITLE
[3.8] Disable COMDAT folding.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,6 @@
 v3.8.4 (XXXX-XX-XX)
 -------------------
 
-* Disable COMDAT folding (aka Identical Code Folding) on Windows, because it
-  can break a program that depends on unique addresses for functions or
-  read-only data members (which apparently we do at the moment).
-
 * Simplify the tagging of EnumerateCollectionNodes and IndexNodes with the
   "read-own-writes" flag. Previously the tagging only happened after all query
   optimizations were completed, making the tag unavailable to the optimizer.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.8.4 (XXXX-XX-XX)
 -------------------
 
+* Disable COMDAT folding (aka Identical Code Folding) on Windows, because it
+  can break a program that depends on unique addresses for functions or
+  read-only data members (which apparently we do at the moment).
+
 * Simplify the tagging of EnumerateCollectionNodes and IndexNodes with the
   "read-own-writes" flag. Previously the tagging only happened after all query
   optimizations were completed, making the tag unavailable to the optimizer.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,6 +620,11 @@ if (MSVC)
   set(CMAKE_EXE_LINKER_FLAGS
     "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:CONSOLE /SAFESEH:NO /MACHINE:x64 /ignore:4099 ${BASE_LD_FLAGS}"
   )
+  # We currently need to disable ICF because unfortunately we have some code
+  # that depends on unique addresses for functions or read-only data members.
+  set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL     "/DEBUG /OPT:REF /OPT:NOICF")
+  set(CMAKE_EXE_LINKER_FLAGS_RELEASE        "/OPT:REF /OPT:NOICF")
+  set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "/DEBUG /OPT:REF /OPT:NOICF")
 else ()
   set(CMAKE_EXE_LINKER_FLAGS
     "${CMAKE_EXE_LINKER_FLAGS} ${BASE_LD_FLAGS}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -622,9 +622,9 @@ if (MSVC)
   )
   # We currently need to disable ICF because unfortunately we have some code
   # that depends on unique addresses for functions or read-only data members.
-  set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL     "/DEBUG /OPT:REF /OPT:NOICF")
-  set(CMAKE_EXE_LINKER_FLAGS_RELEASE        "/OPT:REF /OPT:NOICF")
-  set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "/DEBUG /OPT:REF /OPT:NOICF")
+  set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL     "/DEBUG /OPT:NOICF")
+  set(CMAKE_EXE_LINKER_FLAGS_RELEASE        "/OPT:NOICF")
+  set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "/DEBUG /OPT:NOICF")
 else ()
   set(CMAKE_EXE_LINKER_FLAGS
     "${CMAKE_EXE_LINKER_FLAGS} ${BASE_LD_FLAGS}"


### PR DESCRIPTION
### Scope & Purpose

Backport for #15213 and #15219

Disable COMDAT folding (aka Identical Code Folding) on Windows, because it can break a program that depends on unique addresses for functions or read-only data members (which apparently we do).

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :book: CHANGELOG entry made
