### PR TITLE
[3.7] Disable COMDAT folding.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,6 @@
 v3.7.16 (XXXX-XX-XX)
 --------------------
 
-* Disable COMDAT folding (aka Identical Code Folding) on Windows, because it
-  can break a program that depends on unique addresses for functions or
-  read-only data members (which apparently we do at the moment).
-
 * Improvements for getting-in-sync:
   Reuse the same DatabaseTailingSyncer instance for both the catchup (soft lock)
   and the exclusive (hard lock) phase. This allows the syncer to use the same

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.7.16 (XXXX-XX-XX)
 --------------------
 
+* Disable COMDAT folding (aka Identical Code Folding) on Windows, because it
+  can break a program that depends on unique addresses for functions or
+  read-only data members (which apparently we do at the moment).
+
 * Improvements for getting-in-sync:
   Reuse the same DatabaseTailingSyncer instance for both the catchup (soft lock)
   and the exclusive (hard lock) phase. This allows the syncer to use the same

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -634,6 +634,11 @@ else ()
   set(CMAKE_EXE_LINKER_FLAGS
     "${CMAKE_EXE_LINKER_FLAGS} ${BASE_LD_FLAGS}"
   )
+  # We currently need to disable ICF because unfortunately we have some code
+  # that depends on unique addresses for functions or read-only data members.
+  set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL     "/DEBUG /OPT:REF /OPT:NOICF")
+  set(CMAKE_EXE_LINKER_FLAGS_RELEASE        "/OPT:REF /OPT:NOICF")
+  set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "/DEBUG /OPT:REF /OPT:NOICF")
 endif ()
 
 # broken clock_gettime on MacOSX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -636,9 +636,9 @@ else ()
   )
   # We currently need to disable ICF because unfortunately we have some code
   # that depends on unique addresses for functions or read-only data members.
-  set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL     "/DEBUG /OPT:REF /OPT:NOICF")
-  set(CMAKE_EXE_LINKER_FLAGS_RELEASE        "/OPT:REF /OPT:NOICF")
-  set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "/DEBUG /OPT:REF /OPT:NOICF")
+  set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL     "/DEBUG /OPT:NOICF")
+  set(CMAKE_EXE_LINKER_FLAGS_RELEASE        "/OPT:NOICF")
+  set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "/DEBUG /OPT:NOICF")
 endif ()
 
 # broken clock_gettime on MacOSX


### PR DESCRIPTION
### Scope & Purpose

Backport for #15213 and #15219

Disable COMDAT folding (aka Identical Code Folding) on Windows, because it can break a program that depends on unique addresses for functions or read-only data members (which apparently we do).

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :book: CHANGELOG entry made
