### PR TITLE
Added memory usage tracking for revision trees

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@ v3.9.0 (XXXX-XX-XX)
   - `arangodb_revision_tree_memory_usage`: total memory usage (in bytes) by
     all active revision trees
 
-* Added metric `rocskdb_wal_sequence_number` to track the current tip of the
+* Added metric `rocskdb_wal_sequence` to track the current tip of the
   WAL's sequence number.
 
 * Upgraded bundled version of RocksDB to 6.27.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,10 @@ v3.9.0 (XXXX-XX-XX)
 * Added metric `rocksdb_wal_sequence` to track the current tip of the WAL's
   sequence number.
 
+
+v3.9.0-alpha.1 (2021-11-30)
+---------------------------
+
 * Cleanup and properly fail hotbackup upload and download jobs if a dbserver
   fails or is restarted during the transfer. This gets rid of upload and
   download blockages in these circumstances.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@ v3.9.0 (XXXX-XX-XX)
   - `arangodb_revision_tree_memory_usage`: total memory usage (in bytes) by
     all active revision trees
 
-* Added metric `rocskdb_wal_sequence` to track the current tip of the
+* Added metric `rocksdb_wal_sequence` to track the current tip of the
   WAL's sequence number.
 
 * Upgraded bundled version of RocksDB to 6.27.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,17 @@
 v3.9.0 (XXXX-XX-XX)
 -------------------
 
+* Added the following metrics for revision trees:
+  - `arangodb_revision_tree_hibernations_total`: number of times a revision
+    tree was compressed in RAM and set to hibernation
+  - `arangodb_revision_tree_resurrections_total`: number of times a revision
+    tree was resurrected from hibernation and uncompressed in RAM
+  - `arangodb_revision_tree_memory_usage`: total memory usage (in bytes) by
+    all active revision trees
+
+* Added metric `rocskdb_wal_sequence_number` to track the current tip of the
+  WAL's sequence number.
+
 * Upgraded bundled version of RocksDB to 6.27.
 
 * Improved sync protocol to commit after each chunk and get rid of potentially

--- a/Documentation/Metrics/arangodb_revision_tree_hibernations_total.yaml
+++ b/Documentation/Metrics/arangodb_revision_tree_hibernations_total.yaml
@@ -1,5 +1,5 @@
 name: arangodb_revision_tree_hibernations_total
-introducedIn: "3.8.4"
+introducedIn: "3.8.5"
 help: |
   Number of revision tree hibernations.
 unit: number

--- a/Documentation/Metrics/arangodb_revision_tree_hibernations_total.yaml
+++ b/Documentation/Metrics/arangodb_revision_tree_hibernations_total.yaml
@@ -1,0 +1,24 @@
+name: arangodb_revision_tree_hibernations_total
+introducedIn: "3.8.4"
+help: |
+  Number of revision tree hibernations.
+unit: number
+type: counter
+category: Replication
+complexity: advanced
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  The revision trees of collections/shards are normally present
+  in RAM in an uncompressed state. However, to reduce the memory
+  usage of keeping all revision trees in RAM at the same time, 
+  revision trees can be put into "hibernation" mode. Any inactive
+  revision tree will automatically be hibernated by ArangoDB after
+  a while. For the hibernation step, a revision tree will be 
+  compressed in RAM, and only the compressed version is then kept.
+  Later accesses of a compressed revision tree require uncompressing
+  the tree again. 
+  This metric is increased whenever a revision tree is hibernated.
+  This can happened many times during the lifetime of a revision tree.

--- a/Documentation/Metrics/arangodb_revision_tree_memory_usage.yaml
+++ b/Documentation/Metrics/arangodb_revision_tree_memory_usage.yaml
@@ -1,0 +1,25 @@
+name: arangodb_revision_tree_memory_usage
+introducedIn: "3.8.4"
+help: |
+  Total memory usage of all revision trees (both hibernated and uncompressed).
+unit: bytes
+type: gauge
+category: Replication
+complexity: simple
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  Total memory usage of all revision trees for collections/shards.
+  The revision trees of collections/shards are normally present
+  in RAM in an uncompressed state. However, to reduce the memory
+  usage of keeping all revision trees in RAM at the same time, 
+  revision trees can be put into "hibernation" mode. Any inactive
+  revision tree will automatically be hibernated by ArangoDB after
+  a while. For the hibernation step, a revision tree will be 
+  compressed in RAM, and only the compressed version is then kept.
+  Later accesses of a compressed revision tree require uncompressing
+  the tree again. 
+  This metrics reports the total memory usage of all revision trees,
+  including both the hibernated and uncompressed forms).

--- a/Documentation/Metrics/arangodb_revision_tree_memory_usage.yaml
+++ b/Documentation/Metrics/arangodb_revision_tree_memory_usage.yaml
@@ -1,5 +1,5 @@
 name: arangodb_revision_tree_memory_usage
-introducedIn: "3.8.4"
+introducedIn: "3.8.5"
 help: |
   Total memory usage of all revision trees (both hibernated and uncompressed).
 unit: bytes

--- a/Documentation/Metrics/arangodb_revision_tree_resurrections_total.yaml
+++ b/Documentation/Metrics/arangodb_revision_tree_resurrections_total.yaml
@@ -1,0 +1,25 @@
+name: arangodb_revision_tree_resurrections_total
+introducedIn: "3.8.4"
+help: |
+  Number of revision tree resurrections.
+unit: number
+type: counter
+category: Replication
+complexity: advanced
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  The revision trees of collections/shards are normally present
+  in RAM in an uncompressed state. However, to reduce the memory
+  usage of keeping all revision trees in RAM at the same time, 
+  revision trees can be put into "hibernation" mode. Any inactive
+  revision tree will automatically be hibernated by ArangoDB after
+  a while. For the hibernation step, a revision tree will be 
+  compressed in RAM, and only the compressed version is then kept.
+  Later accesses of a compressed revision tree require uncompressing
+  the tree again. 
+  This metric is increased whenever a revision tree is restored from
+  its hibernated state back into an uncompressed form in RAM.
+  This can happened many times during the lifetime of a revision tree.

--- a/Documentation/Metrics/arangodb_revision_tree_resurrections_total.yaml
+++ b/Documentation/Metrics/arangodb_revision_tree_resurrections_total.yaml
@@ -1,5 +1,5 @@
 name: arangodb_revision_tree_resurrections_total
-introducedIn: "3.8.4"
+introducedIn: "3.8.5"
 help: |
   Number of revision tree resurrections.
 unit: number

--- a/Documentation/Metrics/rocksdb_wal_sequence.yaml
+++ b/Documentation/Metrics/rocksdb_wal_sequence.yaml
@@ -1,4 +1,4 @@
-name: rocksdb_wal_sequence_number
+name: rocksdb_wal_sequence
 introducedIn: "3.8.5"
 help: |
   Current RocksDB WAL sequence number.

--- a/Documentation/Metrics/rocksdb_wal_sequence_number.yaml
+++ b/Documentation/Metrics/rocksdb_wal_sequence_number.yaml
@@ -1,0 +1,15 @@
+name: rocksdb_wal_sequence_number
+introducedIn: "3.8.4"
+help: |
+  Current RocksDB WAL sequence number.
+unit: number
+type: gauge
+category: RocksDB
+complexity: high
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  This metric exposes the current RocksDB WAL sequence number. Any
+  write operations into the database will increase the sequence number.

--- a/Documentation/Metrics/rocksdb_wal_sequence_number.yaml
+++ b/Documentation/Metrics/rocksdb_wal_sequence_number.yaml
@@ -1,5 +1,5 @@
 name: rocksdb_wal_sequence_number
-introducedIn: "3.8.4"
+introducedIn: "3.8.5"
 help: |
   Current RocksDB WAL sequence number.
 unit: number

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -1037,13 +1037,13 @@ void RocksDBEngine::trackRevisionTreeResurrection() noexcept {
   ++_metricsTreeResurrections;
 }
   
-void RocksDBEngine::trackRevisionTreeMemoryIncrease(std::size_t value) noexcept {
+void RocksDBEngine::trackRevisionTreeMemoryIncrease(std::uint64_t value) noexcept {
   if (value != 0) {
     _metricsTreeMemoryUsage += value;
   }
 }
 
-void RocksDBEngine::trackRevisionTreeMemoryDecrease(std::size_t value) noexcept {
+void RocksDBEngine::trackRevisionTreeMemoryDecrease(std::uint64_t value) noexcept {
   if (value != 0) {
     [[maybe_unused]] auto old = _metricsTreeMemoryUsage.fetch_sub(value);
     TRI_ASSERT(old >= value);

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -121,7 +121,7 @@ using namespace arangodb::options;
 
 namespace arangodb {
 
-DECLARE_GAUGE(rocksdb_wal_sequence_number, uint64_t, "Current RocksDB WAL sequence number");
+DECLARE_GAUGE(rocksdb_wal_sequence, uint64_t, "Current RocksDB WAL sequence");
 DECLARE_GAUGE(rocksdb_wal_sequence_lower_bound, uint64_t, "RocksDB WAL sequence number until which background thread has caught up");
 DECLARE_GAUGE(rocksdb_archived_wal_files, uint64_t, "Number of archived RocksDB WAL files");
 DECLARE_GAUGE(rocksdb_prunable_wal_files, uint64_t, "Number of prunable RocksDB WAL files");
@@ -215,8 +215,6 @@ RocksDBEngine::RocksDBEngine(application_features::ApplicationServer& server)
       _dbExisted(false),
       _runningRebuilds(0),
       _runningCompactions(0),
-      _metricsWalSequenceNumber(server.getFeature<arangodb::MetricsFeature>().add(
-          rocksdb_wal_sequence_number{})),
       _metricsWalSequenceLowerBound(server.getFeature<arangodb::MetricsFeature>().add(
           rocksdb_wal_sequence_lower_bound{})),
       _metricsArchivedWalFiles(server.getFeature<arangodb::MetricsFeature>().add(
@@ -2923,8 +2921,9 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder, bool v2) const {
   if (_errorListener) {
     builder.add("rocksdb.read-only", VPackValue(_errorListener->called() ? 1 : 0));
   }
-  
-  builder.add("rocksdb.wal-sequence-number", VPackValue(_db->GetLatestSequenceNumber()));
+
+  auto sequenceNumber = _db->GetLatestSequenceNumber();
+  builder.add("rocksdb.wal-sequence", VPackValue(sequenceNumber));
 
   builder.close();
 }

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -121,12 +121,16 @@ using namespace arangodb::options;
 
 namespace arangodb {
 
+DECLARE_GAUGE(rocksdb_wal_sequence_number, uint64_t, "Current RocksDB WAL sequence number");
 DECLARE_GAUGE(rocksdb_wal_sequence_lower_bound, uint64_t, "RocksDB WAL sequence number until which background thread has caught up");
 DECLARE_GAUGE(rocksdb_archived_wal_files, uint64_t, "Number of archived RocksDB WAL files");
 DECLARE_GAUGE(rocksdb_prunable_wal_files, uint64_t, "Number of prunable RocksDB WAL files");
 DECLARE_GAUGE(rocksdb_wal_pruning_active, uint64_t, "Whether or not RocksDB WAL file pruning is active");
+DECLARE_GAUGE(arangodb_revision_tree_memory_usage, uint64_t, "Total memory consumed by all revision trees");
 DECLARE_COUNTER(arangodb_revision_tree_rebuilds_success_total, "Number of successful revision tree rebuilds");
 DECLARE_COUNTER(arangodb_revision_tree_rebuilds_failure_total, "Number of failed revision tree rebuilds");
+DECLARE_COUNTER(arangodb_revision_tree_hibernations_total, "Number of revision tree hibernations");
+DECLARE_COUNTER(arangodb_revision_tree_resurrections_total, "Number of revision tree resurrections");
           
 std::string const RocksDBEngine::EngineName("rocksdb");
 std::string const RocksDBEngine::FeatureName("RocksDBEngine");
@@ -211,6 +215,8 @@ RocksDBEngine::RocksDBEngine(application_features::ApplicationServer& server)
       _dbExisted(false),
       _runningRebuilds(0),
       _runningCompactions(0),
+      _metricsWalSequenceNumber(server.getFeature<arangodb::MetricsFeature>().add(
+          rocksdb_wal_sequence_number{})),
       _metricsWalSequenceLowerBound(server.getFeature<arangodb::MetricsFeature>().add(
           rocksdb_wal_sequence_lower_bound{})),
       _metricsArchivedWalFiles(server.getFeature<arangodb::MetricsFeature>().add(
@@ -219,10 +225,16 @@ RocksDBEngine::RocksDBEngine(application_features::ApplicationServer& server)
           rocksdb_prunable_wal_files{})),
       _metricsWalPruningActive(server.getFeature<arangodb::MetricsFeature>().add(
           rocksdb_wal_pruning_active{})),
+      _metricsTreeMemoryUsage(server.getFeature<arangodb::MetricsFeature>().add(
+          arangodb_revision_tree_memory_usage{})),
       _metricsTreeRebuildsSuccess(server.getFeature<arangodb::MetricsFeature>().add(
           arangodb_revision_tree_rebuilds_success_total{})),
       _metricsTreeRebuildsFailure(server.getFeature<arangodb::MetricsFeature>().add(
-          arangodb_revision_tree_rebuilds_failure_total{})) {
+          arangodb_revision_tree_rebuilds_failure_total{})),
+      _metricsTreeHibernations(server.getFeature<arangodb::MetricsFeature>().add(
+          arangodb_revision_tree_hibernations_total{})),
+      _metricsTreeResurrections(server.getFeature<arangodb::MetricsFeature>().add(
+          arangodb_revision_tree_resurrections_total{})) {
 
   server.addFeature<RocksDBOptionFeature>();
 
@@ -235,7 +247,7 @@ RocksDBEngine::RocksDBEngine(application_features::ApplicationServer& server)
 }
 
 RocksDBEngine::~RocksDBEngine() { shutdownRocksDBInstance(); }
-
+  
 /// shuts down the RocksDB instance. this is called from unprepare
 /// and the dtor
 void RocksDBEngine::shutdownRocksDBInstance() noexcept {
@@ -1015,6 +1027,27 @@ void RocksDBEngine::unprepare() {
   TRI_ASSERT(isEnabled());
   waitForCompactionJobsToFinish();
   shutdownRocksDBInstance();
+}
+
+void RocksDBEngine::trackRevisionTreeHibernation() noexcept {
+  ++_metricsTreeHibernations;
+}
+
+void RocksDBEngine::trackRevisionTreeResurrection() noexcept {
+  ++_metricsTreeResurrections;
+}
+  
+void RocksDBEngine::trackRevisionTreeMemoryIncrease(std::size_t value) noexcept {
+  if (value != 0) {
+    _metricsTreeMemoryUsage += value;
+  }
+}
+
+void RocksDBEngine::trackRevisionTreeMemoryDecrease(std::size_t value) noexcept {
+  if (value != 0) {
+    [[maybe_unused]] auto old = _metricsTreeMemoryUsage.fetch_sub(value);
+    TRI_ASSERT(old >= value);
+  }
 }
   
 bool RocksDBEngine::hasBackgroundError() const {
@@ -2890,6 +2923,8 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder, bool v2) const {
   if (_errorListener) {
     builder.add("rocksdb.read-only", VPackValue(_errorListener->called() ? 1 : 0));
   }
+  
+  builder.add("rocksdb.wal-sequence-number", VPackValue(_db->GetLatestSequenceNumber()));
 
   builder.close();
 }

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -336,6 +336,12 @@ class RocksDBEngine final : public StorageEngine {
   /// so don't call it from other features during their start() if they are
   /// earlier in the startup sequence
   bool dbExisted() const noexcept { return _dbExisted; }
+
+  void trackRevisionTreeHibernation() noexcept;
+  void trackRevisionTreeResurrection() noexcept;
+  
+  void trackRevisionTreeMemoryIncrease(std::size_t value) noexcept;
+  void trackRevisionTreeMemoryDecrease(std::size_t value) noexcept;
   
 #ifdef USE_ENTERPRISE
   bool encryptionKeyRotationEnabled() const;
@@ -581,12 +587,16 @@ class RocksDBEngine final : public StorageEngine {
   /// @brief number of currently running compaction jobs
   size_t _runningCompactions;
   
+  Gauge<uint64_t>& _metricsWalSequenceNumber;
   Gauge<uint64_t>& _metricsWalSequenceLowerBound;
   Gauge<uint64_t>& _metricsArchivedWalFiles;
   Gauge<uint64_t>& _metricsPrunableWalFiles;
   Gauge<uint64_t>& _metricsWalPruningActive;
+  Gauge<uint64_t>& _metricsTreeMemoryUsage;
   Counter& _metricsTreeRebuildsSuccess;
   Counter& _metricsTreeRebuildsFailure;
+  Counter& _metricsTreeHibernations;
+  Counter& _metricsTreeResurrections;
   
   // @brief persistor for replicated logs
   std::shared_ptr<RocksDBLogPersistor> _logPersistor;

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -587,7 +587,6 @@ class RocksDBEngine final : public StorageEngine {
   /// @brief number of currently running compaction jobs
   size_t _runningCompactions;
   
-  Gauge<uint64_t>& _metricsWalSequenceNumber;
   Gauge<uint64_t>& _metricsWalSequenceLowerBound;
   Gauge<uint64_t>& _metricsArchivedWalFiles;
   Gauge<uint64_t>& _metricsPrunableWalFiles;

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -340,8 +340,8 @@ class RocksDBEngine final : public StorageEngine {
   void trackRevisionTreeHibernation() noexcept;
   void trackRevisionTreeResurrection() noexcept;
   
-  void trackRevisionTreeMemoryIncrease(std::size_t value) noexcept;
-  void trackRevisionTreeMemoryDecrease(std::size_t value) noexcept;
+  void trackRevisionTreeMemoryIncrease(std::uint64_t value) noexcept;
+  void trackRevisionTreeMemoryDecrease(std::uint64_t value) noexcept;
   
 #ifdef USE_ENTERPRISE
   bool encryptionKeyRotationEnabled() const;

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -1761,8 +1761,8 @@ void RocksDBMetaCollection::RevisionTreeAccessor::hibernate(bool force) {
       return;
     }
   
-    if (oldMemoryUsage <= 64) {
-      // tree uses so little memory that it won't be worth to compress it
+    if (oldMemoryUsage == 0) {
+      // tree is empty so it won't be worth to compress it
       return;
     }
     

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -385,6 +385,7 @@ std::unique_ptr<containers::RevisionTree> RocksDBMetaCollection::revisionTree(tr
     auto const& operations = RocksDBTransactionState::toState(&trx)->trackedOperations(
         _logicalCollection.id());
         
+    // this revision tree exists only temporarily, so we do not track its memory usage
     tree->insert(operations.inserts);
     tree->remove(operations.removals);
   
@@ -429,7 +430,10 @@ std::unique_ptr<containers::RevisionTree> RocksDBMetaCollection::computeRevision
 
   RevisionReplicationIterator& it =
       *static_cast<RevisionReplicationIterator*>(iter.get());
-  
+ 
+  // the tree may only be there temporarily, so we intentionally do
+  // not track its memory usage here, but rather at some indirect call sites
+  // only.
   return buildTreeFromIterator(it);
 }
 
@@ -768,6 +772,9 @@ RocksDBMetaCollection::revisionTreeFromCollection(bool checkForBlockers) {
   RevisionReplicationIterator& it =
       *static_cast<RevisionReplicationIterator*>(iter.get());
   
+  // the tree may only be there temporarily, so we intentionally do
+  // not track its memory usage here, but rather at some indirect call sites
+  // only.
   auto newTree = buildTreeFromIterator(it);
   return std::make_pair(std::move(newTree), state->beginSeq());
 }
@@ -952,7 +959,7 @@ Result RocksDBMetaCollection::rebuildRevisionTree() {
       TRI_ASSERT(_revisionTreeApplied <= beginSeq);
       TRI_ASSERT(_revisionTreeSerializedSeq <= beginSeq);
 
-      // establish the new tree
+      // establish the new tree. this will also track the memory usage of the tree
       _revisionTree = std::make_unique<RevisionTreeAccessor>(std::move(newTree), _logicalCollection);
       _revisionTreeApplied = beginSeq;
       _revisionTreeCreationSeq = beginSeq;
@@ -1043,6 +1050,8 @@ void RocksDBMetaCollection::revisionTreeSummary(VPackBuilder& builder, bool from
   if (fromCollection) {
     // rebuild a temporary tree from the collection
     auto result = revisionTreeFromCollection(false);
+    // the tree is only there temporarily, so we intentionally do
+    // not track its memory usage!
 
     if (result.fail()) {
       THROW_ARANGO_EXCEPTION(result.result());
@@ -1234,6 +1243,8 @@ void RocksDBMetaCollection::applyUpdates(rocksdb::SequenceNumber commitSeq,
   if (!_revisionTreeCanBeSerialized) {
     return;
   }
+
+  auto oldMemoryUsage = _revisionTree->memoryUsage();
   
   Result res = basics::catchVoidToResult([&]() -> void {
     // bump sequence number upwards
@@ -1401,6 +1412,18 @@ void RocksDBMetaCollection::applyUpdates(rocksdb::SequenceNumber commitSeq,
       }
     }
   });
+
+  // if memory usage changed, track the adjustment
+  auto newMemoryUsage = _revisionTree->memoryUsage();
+  if (oldMemoryUsage != newMemoryUsage) {
+    auto& engine =
+        _logicalCollection.vocbase().server().getFeature<EngineSelectorFeature>().engine<RocksDBEngine>();
+    if (oldMemoryUsage > newMemoryUsage) {
+      engine.trackRevisionTreeMemoryDecrease(oldMemoryUsage - newMemoryUsage);
+    } else {
+      engine.trackRevisionTreeMemoryIncrease(newMemoryUsage - oldMemoryUsage);
+    }
+  }
 
   if (res.fail()) {
     LOG_TOPIC("fdfa7", ERR, Logger::ENGINES)
@@ -1619,6 +1642,16 @@ RocksDBMetaCollection::RevisionTreeAccessor::RevisionTreeAccessor(std::unique_pt
       _hibernationRequests(0),
       _compressible(true) {
   TRI_ASSERT(_depth == revisionTreeDepth);
+        
+  auto& engine = _logicalCollection.vocbase().server().getFeature<EngineSelectorFeature>().engine<RocksDBEngine>();
+  engine.trackRevisionTreeMemoryIncrease(_tree->memoryUsage());
+}
+
+RocksDBMetaCollection::RevisionTreeAccessor::~RevisionTreeAccessor() {
+  if (_tree != nullptr) {
+    auto& engine = _logicalCollection.vocbase().server().getFeature<EngineSelectorFeature>().engine<RocksDBEngine>();
+    engine.trackRevisionTreeMemoryDecrease(_tree->memoryUsage());
+  }
 }
 
 void RocksDBMetaCollection::RevisionTreeAccessor::insert(std::vector<std::uint64_t> const& keys) {
@@ -1633,7 +1666,12 @@ void RocksDBMetaCollection::RevisionTreeAccessor::remove(std::vector<std::uint64
 
 void RocksDBMetaCollection::RevisionTreeAccessor::clear() {
   ensureTree();
+  
+  auto& engine = _logicalCollection.vocbase().server().getFeature<EngineSelectorFeature>().engine<RocksDBEngine>();
+  engine.trackRevisionTreeMemoryDecrease(_tree->memoryUsage() + _compressed.size());
+
   _tree->clear();
+  _compressed.clear();
   _compressible = true;
 }
     
@@ -1666,6 +1704,11 @@ std::uint64_t RocksDBMetaCollection::RevisionTreeAccessor::depth() const {
   return _depth;
 }
 
+std::size_t RocksDBMetaCollection::RevisionTreeAccessor::memoryUsage() const {
+  ensureTree();
+  return _tree->memoryUsage();
+}
+
 void RocksDBMetaCollection::RevisionTreeAccessor::checkConsistency() const {
   ensureTree();
   return _tree->checkConsistency();
@@ -1674,7 +1717,15 @@ void RocksDBMetaCollection::RevisionTreeAccessor::checkConsistency() const {
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
 void RocksDBMetaCollection::RevisionTreeAccessor::corrupt(uint64_t count, uint64_t hash) {
   ensureTree();
+
+  // track memory usage differences
+  auto oldMemoryUsage = _tree->memoryUsage();
+  // corrupt will _insert_ intentionally broken data into the tree. it does not _remove_ data 
   _tree->corrupt(count, hash);
+  
+  RocksDBEngine& engine =
+      _logicalCollection.vocbase().server().getFeature<EngineSelectorFeature>().engine<RocksDBEngine>();
+  engine.trackRevisionTreeMemoryIncrease(_tree->memoryUsage() - oldMemoryUsage);
 }
 #endif
 
@@ -1684,8 +1735,11 @@ void RocksDBMetaCollection::RevisionTreeAccessor::hibernate(bool force) {
     TRI_ASSERT(!_compressed.empty());
     return;
   }
+  
+  TRI_ASSERT(_compressed.empty());
 
   std::uint64_t count = _tree->count();
+  auto oldMemoryUsage = _tree->memoryUsage();
 
   if (!force) {
     if (count >= 5'000'000) {
@@ -1696,6 +1750,11 @@ void RocksDBMetaCollection::RevisionTreeAccessor::hibernate(bool force) {
     
     if (count >= 1'000'000 && !_compressible) {
       // for whatever reason this collection is not well compressible
+      return;
+    }
+  
+    if (oldMemoryUsage <= 64) {
+      // tree uses so little memory that it won't be worth to compress it
       return;
     }
     
@@ -1709,12 +1768,12 @@ void RocksDBMetaCollection::RevisionTreeAccessor::hibernate(bool force) {
   }
 
   double start = TRI_microtime();
-  
+ 
   _compressed.clear();
   _tree->serializeBinary(_compressed, arangodb::containers::MerkleTreeBase::BinaryFormat::Optimal);
 
   TRI_ASSERT(!_compressed.empty());
- 
+  
   LOG_TOPIC("45eae", DEBUG, Logger::REPLICATION) 
       << "hibernating revision tree for "
       << _logicalCollection.vocbase().name() << "/" << _logicalCollection.name()
@@ -1726,6 +1785,11 @@ void RocksDBMetaCollection::RevisionTreeAccessor::hibernate(bool force) {
   if (_compressed.size() * 2 < _tree->byteSize()) {
     // compression ratio ok.
     // remove tree from memory. now we only have _compressed
+    RocksDBEngine& engine =
+        _logicalCollection.vocbase().server().getFeature<EngineSelectorFeature>().engine<RocksDBEngine>();
+    engine.trackRevisionTreeHibernation();
+    engine.trackRevisionTreeMemoryIncrease(_compressed.size());
+    engine.trackRevisionTreeMemoryDecrease(oldMemoryUsage);
     _tree.reset();
     _compressible = true;
   } else {
@@ -1761,6 +1825,12 @@ void RocksDBMetaCollection::RevisionTreeAccessor::ensureTree() const {
     if (_tree == nullptr) {
       THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "unable to uncompress tree");
     }
+  
+    RocksDBEngine& engine =
+        _logicalCollection.vocbase().server().getFeature<EngineSelectorFeature>().engine<RocksDBEngine>();
+    engine.trackRevisionTreeResurrection();
+    engine.trackRevisionTreeMemoryIncrease(_tree->memoryUsage());
+    engine.trackRevisionTreeMemoryDecrease(_compressed.size());
 
     // reset hibernation counter
     _hibernationRequests = 0;

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.h
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.h
@@ -187,6 +187,8 @@ class RocksDBMetaCollection : public PhysicalCollection {
 
     explicit RevisionTreeAccessor(std::unique_ptr<containers::RevisionTree> tree,
                                   LogicalCollection const& collection);
+    
+    ~RevisionTreeAccessor();
 
     void insert(std::vector<std::uint64_t> const& keys);
     void remove(std::vector<std::uint64_t> const& keys);
@@ -195,6 +197,7 @@ class RocksDBMetaCollection : public PhysicalCollection {
     std::uint64_t count() const;
     std::uint64_t rootValue() const;
     std::uint64_t depth() const;
+    std::size_t memoryUsage() const;
 
     // potentially expensive! only call when necessary
     std::uint64_t compressedSize() const;

--- a/lib/Containers/MerkleTree.h
+++ b/lib/Containers/MerkleTree.h
@@ -116,9 +116,11 @@ class MerkleTreeBase {
 
     Meta meta;
     std::vector<ShardType> shards;
+    std::size_t memoryUsage = 0;
   
     void clear() {
       shards.clear();
+      memoryUsage = 0;
       meta.summary = { 0, 0 };
     }
 
@@ -290,6 +292,8 @@ class MerkleTree : public MerkleTreeBase {
    * @param other Input tree, intended assignment
    */
   MerkleTree& operator=(std::unique_ptr<MerkleTree<Hasher, BranchingBits>>&& other);
+  
+  std::size_t memoryUsage() const;
 
   /**
    * @brief Returns the number of hashed keys contained in the tree

--- a/lib/Containers/MerkleTree.h
+++ b/lib/Containers/MerkleTree.h
@@ -293,7 +293,7 @@ class MerkleTree : public MerkleTreeBase {
    */
   MerkleTree& operator=(std::unique_ptr<MerkleTree<Hasher, BranchingBits>>&& other);
   
-  std::size_t memoryUsage() const;
+  std::uint64_t memoryUsage() const;
 
   /**
    * @brief Returns the number of hashed keys contained in the tree

--- a/tests/Containers/MerkleTreeTest.cpp
+++ b/tests/Containers/MerkleTreeTest.cpp
@@ -120,47 +120,47 @@ class InternalMerkleTreeTest
 
 TEST_F(InternalMerkleTreeTest, test_chunkRange) {
   auto r = chunkRange(0, 0);
-  ASSERT_EQ(r.first, 0);
-  ASSERT_EQ(r.second, 63);
+  EXPECT_EQ(r.first, 0);
+  EXPECT_EQ(r.second, 63);
 
   for (std::uint64_t chunk = 0; chunk < 8; ++chunk) {
     auto r = chunkRange(chunk, 1);
-    ASSERT_EQ(r.first, chunk * 8);
-    ASSERT_EQ(r.second, ((chunk + 1) * 8) - 1);
+    EXPECT_EQ(r.first, chunk * 8);
+    EXPECT_EQ(r.second, ((chunk + 1) * 8) - 1);
   }
 
   for (std::uint64_t chunk = 0; chunk < 64; ++chunk) {
     auto r = chunkRange(chunk, 2);
-    ASSERT_EQ(r.first, chunk);
-    ASSERT_EQ(r.second, chunk);
+    EXPECT_EQ(r.first, chunk);
+    EXPECT_EQ(r.second, chunk);
   }
 }
 
 TEST_F(InternalMerkleTreeTest, test_index) {
   std::pair<std::uint64_t, std::uint64_t> range = this->range();
-  ASSERT_EQ(range.first, 0);
-  ASSERT_EQ(range.second, 64);
+  EXPECT_EQ(range.first, 0);
+  EXPECT_EQ(range.second, 64);
 
   // check boundaries at level 2
   for (std::uint64_t chunk = 0; chunk < 64; ++chunk) {
     std::uint64_t left = chunk;  // only one value per chunk
-    ASSERT_EQ(index(left), chunk);
+    EXPECT_EQ(index(left), chunk);
   }
 }
 
 TEST_F(InternalMerkleTreeTest, test_modify) {
   std::pair<std::uint64_t, std::uint64_t> range = this->range();
-  ASSERT_EQ(range.first, 0);
-  ASSERT_EQ(range.second, 64);
+  EXPECT_EQ(range.first, 0);
+  EXPECT_EQ(range.second, 64);
 
-  ASSERT_EQ(count(), 0);
+  EXPECT_EQ(count(), 0);
   // check that an attempt to remove will fail if it's empty
-  ASSERT_THROW(modify(0, false), std::invalid_argument);
-  ASSERT_EQ(count(), 0);
+  EXPECT_THROW(modify(0, false), std::invalid_argument);
+  EXPECT_EQ(count(), 0);
 
   // insert a single value
   modify(0, true);
-  ASSERT_EQ(count(), 1);
+  EXPECT_EQ(count(), 1);
 
   // build set of indexes that should be touched
   std::set<std::uint64_t> indices0{ this->index(0) };
@@ -173,13 +173,13 @@ TEST_F(InternalMerkleTreeTest, test_modify) {
     std::uint64_t expectedHash = inSet0 ? hasher.hash(0) : 0;
 
     InternalMerkleTreeTest::Node& node = this->node(index);
-    ASSERT_EQ(node.count, expectedCount);
-    ASSERT_EQ(node.hash, expectedHash);
+    EXPECT_EQ(node.count, expectedCount);
+    EXPECT_EQ(node.hash, expectedHash);
   }
 
   // insert another value, minimal overlap
   modify(63, true);
-  ASSERT_EQ(count(), 2);
+  EXPECT_EQ(count(), 2);
 
   // build set of indexes that should be touched
   std::set<std::uint64_t> indices63{ this->index(63) };
@@ -195,13 +195,13 @@ TEST_F(InternalMerkleTreeTest, test_modify) {
     }
 
     InternalMerkleTreeTest::Node& node = this->node(index);
-    ASSERT_EQ(node.count, expectedCount);
-    ASSERT_EQ(node.hash, expectedHash);
+    EXPECT_EQ(node.count, expectedCount);
+    EXPECT_EQ(node.hash, expectedHash);
   }
 
   // insert another value, more overlap
   modify(1, true);
-  ASSERT_EQ(count(), 3);
+  EXPECT_EQ(count(), 3);
 
   // build set of indexes that should be touched
   std::set<std::uint64_t> indices1{ this->index(1) };
@@ -221,13 +221,13 @@ TEST_F(InternalMerkleTreeTest, test_modify) {
     }
 
     InternalMerkleTreeTest::Node& node = this->node(index);
-    ASSERT_EQ(node.count, expectedCount);
-    ASSERT_EQ(node.hash, expectedHash);
+    EXPECT_EQ(node.count, expectedCount);
+    EXPECT_EQ(node.hash, expectedHash);
   }
 
   // remove a value, minimal overlap
   modify(63, false);
-  ASSERT_EQ(count(), 2);
+  EXPECT_EQ(count(), 2);
 
   // check that it sets everything it should, and nothing it shouldn't
   for (std::uint64_t index = 0; index < 64; ++index) {
@@ -240,13 +240,13 @@ TEST_F(InternalMerkleTreeTest, test_modify) {
     }
 
     InternalMerkleTreeTest::Node& node = this->node(index);
-    ASSERT_EQ(node.count, expectedCount);
-    ASSERT_EQ(node.hash, expectedHash);
+    EXPECT_EQ(node.count, expectedCount);
+    EXPECT_EQ(node.hash, expectedHash);
   }
 
   // remove a value, maximal overlap
   modify(1, false);
-  ASSERT_EQ(count(), 1);
+  EXPECT_EQ(count(), 1);
 
   // check that it sets everything it should, and nothing it shouldn't
   for (std::uint64_t index = 0; index < 64; ++index) {
@@ -255,34 +255,34 @@ TEST_F(InternalMerkleTreeTest, test_modify) {
     std::uint64_t expectedHash = inSet0 ? hasher.hash(0) : 0;
 
     InternalMerkleTreeTest::Node& node = this->node(index);
-    ASSERT_EQ(node.count, expectedCount);
-    ASSERT_EQ(node.hash, expectedHash);
+    EXPECT_EQ(node.count, expectedCount);
+    EXPECT_EQ(node.hash, expectedHash);
   }
 
   // remove a value, maximal overlap
   modify(0, false);
-  ASSERT_EQ(count(), 0);
+  EXPECT_EQ(count(), 0);
 
   // check that it sets everything it should, and nothing it shouldn't
   for (std::uint64_t index = 0; index < 64; ++index) {
     InternalMerkleTreeTest::Node& node = this->node(index);
-    ASSERT_EQ(node.count, 0);
-    ASSERT_EQ(node.hash, 0);
+    EXPECT_EQ(node.count, 0);
+    EXPECT_EQ(node.hash, 0);
   }
 }
 
 TEST_F(InternalMerkleTreeTest, test_grow) {
   std::pair<std::uint64_t, std::uint64_t> range = this->range();
-  ASSERT_EQ(range.first, 0);
-  ASSERT_EQ(range.second, 64);
+  EXPECT_EQ(range.first, 0);
+  EXPECT_EQ(range.second, 64);
 
   // fill the tree, but not enough that it grows
   for (std::uint64_t i = 0; i < 64; ++i) {
     insert(i);
   }
   range = this->range();
-  ASSERT_EQ(range.first, 0);
-  ASSERT_EQ(range.second, 64);
+  EXPECT_EQ(range.first, 0);
+  EXPECT_EQ(range.second, 64);
 
   ::arangodb::containers::FnvHashProvider hasher;
   // check that tree state is as expected prior to growing
@@ -297,13 +297,13 @@ TEST_F(InternalMerkleTreeTest, test_grow) {
     }
     for (std::uint64_t i = 0; i < 64; ++i) {
       Node& node = this->node(this->index(static_cast<std::uint64_t>(i)));
-      ASSERT_EQ(node.count, 1);
-      ASSERT_EQ(node.hash, hash2[i]);
+      EXPECT_EQ(node.count, 1);
+      EXPECT_EQ(node.hash, hash2[i]);
     }
     {
       Node const& node = this->meta().summary;
-      ASSERT_EQ(node.count, 64);
-      ASSERT_EQ(node.hash, hash0);
+      EXPECT_EQ(node.count, 64);
+      EXPECT_EQ(node.hash, hash0);
     }
   }
 
@@ -312,8 +312,8 @@ TEST_F(InternalMerkleTreeTest, test_grow) {
     insert(i);
   }
   range = this->range();
-  ASSERT_EQ(range.first, 0);
-  ASSERT_EQ(range.second, 128);
+  EXPECT_EQ(range.first, 0);
+  EXPECT_EQ(range.second, 128);
 
   // check that tree state is as expected after growing
   {
@@ -327,31 +327,31 @@ TEST_F(InternalMerkleTreeTest, test_grow) {
     }
     for (std::uint64_t i = 0; i < 64; ++i) {
       Node const& node = this->node(i);
-      ASSERT_EQ(node.count, 2);
-      ASSERT_EQ(node.hash, hash2[i]);
+      EXPECT_EQ(node.count, 2);
+      EXPECT_EQ(node.hash, hash2[i]);
     }
     {
       Node const& node = this->meta().summary;
-      ASSERT_EQ(node.count, 128);
-      ASSERT_EQ(node.hash, hash0);
+      EXPECT_EQ(node.count, 128);
+      EXPECT_EQ(node.hash, hash0);
     }
   }
 }
 
 TEST_F(InternalMerkleTreeTest, test_partition) {
-  ASSERT_TRUE(::partitionAsExpected(*this, 0, {{0, 64}}));
+  EXPECT_TRUE(::partitionAsExpected(*this, 0, {{0, 64}}));
 
   for (std::uint64_t i = 0; i < 32; ++i) {
     this->insert(2 * i);
   }
 
-  ASSERT_TRUE(::partitionAsExpected(*this, 0, {{0, 64}}));
-  ASSERT_TRUE(::partitionAsExpected(*this, 1, {{0, 64}}));
-  ASSERT_TRUE(::partitionAsExpected(*this, 2, {{0, 30}, {31, 63}}));
-  ASSERT_TRUE(::partitionAsExpected(*this, 3, {{0, 18}, {19, 40}, {41, 63}}));
-  ASSERT_TRUE(::partitionAsExpected(*this, 4, {{0, 14}, {15, 30}, {31, 46}, {47, 63}}));
+  EXPECT_TRUE(::partitionAsExpected(*this, 0, {{0, 64}}));
+  EXPECT_TRUE(::partitionAsExpected(*this, 1, {{0, 64}}));
+  EXPECT_TRUE(::partitionAsExpected(*this, 2, {{0, 30}, {31, 63}}));
+  EXPECT_TRUE(::partitionAsExpected(*this, 3, {{0, 18}, {19, 40}, {41, 63}}));
+  EXPECT_TRUE(::partitionAsExpected(*this, 4, {{0, 14}, {15, 30}, {31, 46}, {47, 63}}));
   ///
-  ASSERT_TRUE(::partitionAsExpected(
+  EXPECT_TRUE(::partitionAsExpected(
       *this, 42,
       {{0, 0},   {1, 2},   {3, 4},   {5, 6},   {7, 8},   {9, 10},  {11, 12},
        {13, 14}, {15, 16}, {17, 18}, {19, 20}, {21, 22}, {23, 24}, {25, 26},
@@ -362,67 +362,96 @@ TEST_F(InternalMerkleTreeTest, test_partition) {
   // now let's make the distribution more uneven and see how things go
   this->growRight(511);
 
-  ASSERT_TRUE(::partitionAsExpected(*this, 3, {{0, 23}, {24, 47}, {48, 511}}));
-  ASSERT_TRUE(::partitionAsExpected(*this, 4, {{0, 15}, {16, 31}, {32, 47}, {48, 511}}));
+  EXPECT_TRUE(::partitionAsExpected(*this, 3, {{0, 23}, {24, 47}, {48, 511}}));
+  EXPECT_TRUE(::partitionAsExpected(*this, 4, {{0, 15}, {16, 31}, {32, 47}, {48, 511}}));
 
   // lump it all in one cell
   this->growRight(4095);
 
-  ASSERT_TRUE(::partitionAsExpected(*this, 4, {{0, 63}}));
+  EXPECT_TRUE(::partitionAsExpected(*this, 4, {{0, 63}}));
 }
 
 TEST(MerkleTreeTest, test_allocation_size) {
   {
     ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t(2, 0, 64);
-    ASSERT_EQ(t.allocationSize(2), t.MetaSize + 64 * t.NodeSize);
+    EXPECT_EQ(t.allocationSize(2), t.MetaSize + 64 * t.NodeSize);
   }
   
   {
     ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t(3, 0, 512);
-    ASSERT_EQ(t.allocationSize(3), t.MetaSize + 512 * t.NodeSize);
+    EXPECT_EQ(t.allocationSize(3), t.MetaSize + 512 * t.NodeSize);
   }
   
   {
     ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t(4, 0, 4096);
-    ASSERT_EQ(t.allocationSize(4), t.MetaSize + 4096 * t.NodeSize);
+    EXPECT_EQ(t.allocationSize(4), t.MetaSize + 4096 * t.NodeSize);
   }
   
   {
     ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t(5, 0, 32768);
-    ASSERT_EQ(t.allocationSize(5), t.MetaSize + 32768 * t.NodeSize);
+    EXPECT_EQ(t.allocationSize(5), t.MetaSize + 32768 * t.NodeSize);
   }
  
   {
     ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t(6, 0, 1ULL << 18);
-    ASSERT_EQ(t.allocationSize(6), t.MetaSize + 262144 * t.NodeSize);
+    EXPECT_EQ(t.allocationSize(6), t.MetaSize + 262144 * t.NodeSize);
   }
 }
 
 TEST(MerkleTreeTest, test_number_of_shards) {
   {
     ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t1(2, 0, 64);
-    ASSERT_EQ(1, t1.numberOfShards());
+    EXPECT_EQ(1, t1.numberOfShards());
   }
  
   {
     ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t1(3, 0, 512);
-    ASSERT_EQ(1, t1.numberOfShards());
+    EXPECT_EQ(1, t1.numberOfShards());
   }
   
   {
     ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t1(4, 0, 4096);
-    ASSERT_EQ(1, t1.numberOfShards());
+    EXPECT_EQ(1, t1.numberOfShards());
   }
   
   {
     ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t1(5, 0, 32768);
-    ASSERT_EQ(8, t1.numberOfShards());
+    EXPECT_EQ(8, t1.numberOfShards());
   }
  
   {
     ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t2(6, 0, 1ULL << 18);
-    ASSERT_EQ(64, t2.numberOfShards());
+    EXPECT_EQ(64, t2.numberOfShards());
   }
+}
+
+TEST(MerkleTreeTest, test_stats) {
+  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t(3, 0, 512);
+ 
+  // tree empty
+  EXPECT_EQ(3, t.depth());
+  EXPECT_EQ(0, t.count());
+  EXPECT_EQ(0, t.rootValue());
+  EXPECT_EQ(8256, t.byteSize());
+  EXPECT_EQ(0, t.memoryUsage());
+
+  for (std::uint64_t i = 0; i < 100'000; ++i) {
+    t.insert((8 * i) + 1);
+  }
+  
+  // populated with some values
+  EXPECT_EQ(3, t.depth());
+  EXPECT_EQ(100000, t.count());
+  EXPECT_EQ(1167003112264018688ULL, t.rootValue());
+  EXPECT_EQ(8256, t.byteSize());
+  EXPECT_EQ(65536, t.memoryUsage());
+
+  t.clear();
+  EXPECT_EQ(3, t.depth());
+  EXPECT_EQ(0, t.count());
+  EXPECT_EQ(0, t.rootValue());
+  EXPECT_EQ(8256, t.byteSize());
+  EXPECT_EQ(0, t.memoryUsage());
 }
 
 TEST(MerkleTreeTest, test_diff_equal) {
@@ -430,20 +459,20 @@ TEST(MerkleTreeTest, test_diff_equal) {
   ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t2(2, 0, 64);
 
   std::vector<std::pair<std::uint64_t, std::uint64_t>> expected;  // empty
-  ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
+  EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
 
   std::vector<std::uint64_t> order = ::permutation(64);
   for (std::uint64_t i : order) {
     t1.insert(i);
     t2.insert(i);
-    ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
+    EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
   }
 
   order = ::permutation(64);
   for (std::uint64_t i : order) {
     t1.remove(i);
     t2.remove(i);
-    ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
+    EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
   }
 }
 
@@ -451,21 +480,45 @@ TEST(MerkleTreeTest, test_diff_one_empty) {
   ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t1(2, 0, 64);
   ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t2(2, 0, 64);
 
+  EXPECT_EQ(2, t1.depth());
+  EXPECT_EQ(0, t1.count());
+  EXPECT_EQ(0, t1.rootValue());
+  EXPECT_EQ(1088, t1.byteSize());
+  EXPECT_EQ(0, t1.memoryUsage());
+
+  EXPECT_EQ(2, t1.depth());
+  EXPECT_EQ(0, t2.count());
+  EXPECT_EQ(0, t2.rootValue());
+  EXPECT_EQ(1088, t2.byteSize());
+  EXPECT_EQ(0, t2.memoryUsage());
+
   std::vector<std::pair<std::uint64_t, std::uint64_t>> expected;
-  ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
+  EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
 
   for (std::uint64_t i = 0; i < 8; ++i) {
     t1.insert(8 * i);
     expected.emplace_back(std::make_pair(8 * i, 8 * i));
-    ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
+    EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
   }
+  
+  EXPECT_EQ(2, t1.depth());
+  EXPECT_EQ(8, t1.count());
+  EXPECT_EQ(119171121494394880ULL, t1.rootValue());
+  EXPECT_EQ(1088, t1.byteSize());
+  EXPECT_EQ(65536, t1.memoryUsage());
 
   expected.clear();
   for (std::uint64_t i = 0; i < 8; ++i) {
     t1.insert((8 * i) + 1);
     expected.emplace_back(std::make_pair(8 * i, (8 * i) + 1));
   }
-  ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
+  EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
+  
+  EXPECT_EQ(2, t1.depth());
+  EXPECT_EQ(16, t1.count());
+  EXPECT_EQ(150767561592393728ULL, t1.rootValue());
+  EXPECT_EQ(1088, t1.byteSize());
+  EXPECT_EQ(65536, t1.memoryUsage());
 
   expected.clear();
   for (std::uint64_t i = 0; i < 8; ++i) {
@@ -473,7 +526,13 @@ TEST(MerkleTreeTest, test_diff_one_empty) {
     t1.insert((8 * i) + 3);
     expected.emplace_back(std::make_pair(8 * i, (8 * i) + 3));
   }
-  ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
+  EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
+  
+  EXPECT_EQ(2, t1.depth());
+  EXPECT_EQ(32, t1.count());
+  EXPECT_EQ(13554546285411683328ULL, t1.rootValue());
+  EXPECT_EQ(1088, t1.byteSize());
+  EXPECT_EQ(65536, t1.memoryUsage());
 
   expected.clear();
   for (std::uint64_t i = 0; i < 8; ++i) {
@@ -483,28 +542,40 @@ TEST(MerkleTreeTest, test_diff_one_empty) {
     t1.insert((8 * i) + 7);
   }
   expected.emplace_back(std::make_pair(0, 63));
-  ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
+  EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
 }
 
 TEST(MerkleTreeTest, test_diff_misc) {
   ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t1(2, 0, 64);
   ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t2(2, 0, 64);
+  
+  EXPECT_EQ(2, t1.depth());
+  EXPECT_EQ(0, t1.count());
+  EXPECT_EQ(0, t1.rootValue());
+  EXPECT_EQ(1088, t1.byteSize());
+  EXPECT_EQ(0, t1.memoryUsage());
+
+  EXPECT_EQ(2, t1.depth());
+  EXPECT_EQ(0, t2.count());
+  EXPECT_EQ(0, t2.rootValue());
+  EXPECT_EQ(1088, t2.byteSize());
+  EXPECT_EQ(0, t2.memoryUsage());
 
   std::vector<std::pair<std::uint64_t, std::uint64_t>> expected;
-  ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
+  EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
 
   for (std::uint64_t i = 0; i < 32; ++i) {
     t1.insert(2 * i);
     expected.emplace_back(std::make_pair(2 * i, 2 * i));
   }
-  ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
+  EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
 
   expected.clear();
   for (std::uint64_t i = 0; i < 32; ++i) {
     t2.insert((2 * i) + 1);
   }
   expected.emplace_back(std::make_pair(0, 63));
-  ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
+  EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
 
   expected.clear();
   for (std::uint64_t i = 0; i < 16; ++i) {
@@ -512,7 +583,7 @@ TEST(MerkleTreeTest, test_diff_misc) {
     expected.emplace_back(std::make_pair(2 * i, 2 * i));
   }
   expected.emplace_back(std::make_pair(32, 63));
-  ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
+  EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
 }
 
 TEST(MerkleTreeTest, test_serializeBinarySnappyFullSmall) {
@@ -524,18 +595,18 @@ TEST(MerkleTreeTest, test_serializeBinarySnappyFullSmall) {
 
   std::string t1s;
   t1.serializeBinary(t1s, arangodb::containers::MerkleTreeBase::BinaryFormat::CompressedSnappyFull);
-  ASSERT_EQ(520, t1s.size());
+  EXPECT_EQ(520, t1s.size());
 
   std::unique_ptr<::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>> t2 =
       ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>::fromBuffer(t1s);
-  ASSERT_NE(t2, nullptr);
-  ASSERT_TRUE(t1.diff(*t2).empty());
-  ASSERT_TRUE(t2->diff(t1).empty());
+  EXPECT_NE(t2, nullptr);
+  EXPECT_TRUE(t1.diff(*t2).empty());
+  EXPECT_TRUE(t2->diff(t1).empty());
 }
 
 TEST(MerkleTreeTest, test_serializeBinarySnappyFullLarge) {
   ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t1(6, 0, 1ULL << 18);
-
+  
   std::vector<std::uint64_t> keys;
   for (std::uint64_t i = 10'000'000; i < 60'000'000; i += 5) {
     keys.emplace_back(i);
@@ -544,17 +615,17 @@ TEST(MerkleTreeTest, test_serializeBinarySnappyFullLarge) {
       keys.clear();
     }
   }
-  ASSERT_EQ(10'000'000, t1.count());
+  EXPECT_EQ(10'000'000, t1.count());
 
   std::string t1s;
   t1.serializeBinary(t1s, arangodb::containers::MerkleTreeBase::BinaryFormat::CompressedSnappyFull);
-  ASSERT_EQ(2143871, t1s.size());
+  EXPECT_EQ(2143871, t1s.size());
 
   std::unique_ptr<::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>> t2 =
       ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>::fromBuffer(t1s);
-  ASSERT_NE(t2, nullptr);
-  ASSERT_TRUE(t1.diff(*t2).empty());
-  ASSERT_TRUE(t2->diff(t1).empty());
+  EXPECT_NE(t2, nullptr);
+  EXPECT_TRUE(t1.diff(*t2).empty());
+  EXPECT_TRUE(t2->diff(t1).empty());
 }
 
 TEST(MerkleTreeTest, test_serializeBinarySnappyLazySmall) {
@@ -566,13 +637,13 @@ TEST(MerkleTreeTest, test_serializeBinarySnappyLazySmall) {
 
   std::string t1s;
   t1.serializeBinary(t1s, arangodb::containers::MerkleTreeBase::BinaryFormat::CompressedSnappyLazy);
-  ASSERT_EQ(548, t1s.size());
+  EXPECT_EQ(548, t1s.size());
 
   std::unique_ptr<::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>> t2 =
       ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>::fromBuffer(t1s);
-  ASSERT_NE(t2, nullptr);
-  ASSERT_TRUE(t1.diff(*t2).empty());
-  ASSERT_TRUE(t2->diff(t1).empty());
+  EXPECT_NE(t2, nullptr);
+  EXPECT_TRUE(t1.diff(*t2).empty());
+  EXPECT_TRUE(t2->diff(t1).empty());
 }
 
 TEST(MerkleTreeTest, test_serializeBinarySnappyLazyLarge) {
@@ -586,17 +657,17 @@ TEST(MerkleTreeTest, test_serializeBinarySnappyLazyLarge) {
       keys.clear();
     }
   }
-  ASSERT_EQ(10'000'000, t1.count());
+  EXPECT_EQ(10'000'000, t1.count());
 
   std::string t1s;
   t1.serializeBinary(t1s, arangodb::containers::MerkleTreeBase::BinaryFormat::CompressedSnappyLazy);
-  ASSERT_EQ(2116630, t1s.size());
+  EXPECT_EQ(2116630, t1s.size());
 
   std::unique_ptr<::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>> t2 =
       ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>::fromBuffer(t1s);
-  ASSERT_NE(t2, nullptr);
-  ASSERT_TRUE(t1.diff(*t2).empty());
-  ASSERT_TRUE(t2->diff(t1).empty());
+  EXPECT_NE(t2, nullptr);
+  EXPECT_TRUE(t1.diff(*t2).empty());
+  EXPECT_TRUE(t2->diff(t1).empty());
 }
 
 TEST(MerkleTreeTest, test_serializeBinaryOnlyPopulatedSmall) {
@@ -608,13 +679,13 @@ TEST(MerkleTreeTest, test_serializeBinaryOnlyPopulatedSmall) {
 
   std::string t1s;
   t1.serializeBinary(t1s, arangodb::containers::MerkleTreeBase::BinaryFormat::OnlyPopulated);
-  ASSERT_EQ(690, t1s.size());
+  EXPECT_EQ(690, t1s.size());
 
   std::unique_ptr<::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>> t2 =
       ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>::fromBuffer(t1s);
-  ASSERT_NE(t2, nullptr);
-  ASSERT_TRUE(t1.diff(*t2).empty());
-  ASSERT_TRUE(t2->diff(t1).empty());
+  EXPECT_NE(t2, nullptr);
+  EXPECT_TRUE(t1.diff(*t2).empty());
+  EXPECT_TRUE(t2->diff(t1).empty());
 }
 
 TEST(MerkleTreeTest, test_serializeBinaryOnlyPopulatedLarge) {
@@ -628,17 +699,17 @@ TEST(MerkleTreeTest, test_serializeBinaryOnlyPopulatedLarge) {
       keys.clear();
     }
   }
-  ASSERT_EQ(10'000'000, t1.count());
+  EXPECT_EQ(10'000'000, t1.count());
 
   std::string t1s;
   t1.serializeBinary(t1s, arangodb::containers::MerkleTreeBase::BinaryFormat::OnlyPopulated);
-  ASSERT_EQ(3906310, t1s.size());
+  EXPECT_EQ(3906310, t1s.size());
 
   std::unique_ptr<::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>> t2 =
       ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>::fromBuffer(t1s);
-  ASSERT_NE(t2, nullptr);
-  ASSERT_TRUE(t1.diff(*t2).empty());
-  ASSERT_TRUE(t2->diff(t1).empty());
+  EXPECT_NE(t2, nullptr);
+  EXPECT_TRUE(t1.diff(*t2).empty());
+  EXPECT_TRUE(t2->diff(t1).empty());
 }
 
 TEST(MerkleTreeTest, test_serializeBinaryUncompressedSmall) {
@@ -650,13 +721,13 @@ TEST(MerkleTreeTest, test_serializeBinaryUncompressedSmall) {
 
   std::string t1s;
   t1.serializeBinary(t1s, arangodb::containers::MerkleTreeBase::BinaryFormat::Uncompressed);
-  ASSERT_EQ(1090, t1s.size());
+  EXPECT_EQ(1090, t1s.size());
 
   std::unique_ptr<::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>> t2 =
       ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>::fromBuffer(t1s);
-  ASSERT_NE(t2, nullptr);
-  ASSERT_TRUE(t1.diff(*t2).empty());
-  ASSERT_TRUE(t2->diff(t1).empty());
+  EXPECT_NE(t2, nullptr);
+  EXPECT_TRUE(t1.diff(*t2).empty());
+  EXPECT_TRUE(t2->diff(t1).empty());
 }
 
 TEST(MerkleTreeTest, test_serializeBinaryUncompressedLarge) {
@@ -670,17 +741,17 @@ TEST(MerkleTreeTest, test_serializeBinaryUncompressedLarge) {
       keys.clear();
     }
   }
-  ASSERT_EQ(10'000'000, t1.count());
+  EXPECT_EQ(10'000'000, t1.count());
 
   std::string t1s;
   t1.serializeBinary(t1s, arangodb::containers::MerkleTreeBase::BinaryFormat::Uncompressed);
-  ASSERT_EQ(4194370, t1s.size());
+  EXPECT_EQ(4194370, t1s.size());
 
   std::unique_ptr<::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>> t2 =
       ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>::fromBuffer(t1s);
-  ASSERT_NE(t2, nullptr);
-  ASSERT_TRUE(t1.diff(*t2).empty());
-  ASSERT_TRUE(t2->diff(t1).empty());
+  EXPECT_NE(t2, nullptr);
+  EXPECT_TRUE(t1.diff(*t2).empty());
+  EXPECT_TRUE(t2->diff(t1).empty());
 }
 
 TEST(MerkleTreeTest, test_serializePortableSmall) {
@@ -693,29 +764,29 @@ TEST(MerkleTreeTest, test_serializePortableSmall) {
   ::arangodb::velocypack::Builder t1s;
   t1.serialize(t1s, false);
 
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeVersion).isNumber());
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeMaxDepth).isNumber());
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeRangeMax).isString());
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeRangeMin).isString());
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeInitialRangeMin).isString());
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeCount).isNumber());
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeHash).isNumber());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeVersion).isNumber());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeMaxDepth).isNumber());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeRangeMax).isString());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeRangeMin).isString());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeInitialRangeMin).isString());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeCount).isNumber());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeHash).isNumber());
   
-  ASSERT_EQ(2, t1s.slice().get(StaticStrings::RevisionTreeMaxDepth).getNumber<int>());
-  ASSERT_EQ(32, t1s.slice().get(StaticStrings::RevisionTreeCount).getNumber<int>());
+  EXPECT_EQ(2, t1s.slice().get(StaticStrings::RevisionTreeMaxDepth).getNumber<int>());
+  EXPECT_EQ(32, t1s.slice().get(StaticStrings::RevisionTreeCount).getNumber<int>());
 
   std::unique_ptr<::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>> t2 =
       ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>::deserialize(
           t1s.slice());
-  ASSERT_NE(t2, nullptr);
+  EXPECT_NE(t2, nullptr);
 
-  ASSERT_EQ(2, t2->depth());
-  ASSERT_EQ(32, t2->count());
-  ASSERT_EQ(t1.range(), t2->range());
-  ASSERT_EQ(t1.rootValue(), t2->rootValue());
+  EXPECT_EQ(2, t2->depth());
+  EXPECT_EQ(32, t2->count());
+  EXPECT_EQ(t1.range(), t2->range());
+  EXPECT_EQ(t1.rootValue(), t2->rootValue());
 
-  ASSERT_TRUE(t1.diff(*t2).empty());
-  ASSERT_TRUE(t2->diff(t1).empty());
+  EXPECT_TRUE(t1.diff(*t2).empty());
+  EXPECT_TRUE(t2->diff(t1).empty());
 }
 
 TEST(MerkleTreeTest, test_serializePortableLarge) {
@@ -729,44 +800,44 @@ TEST(MerkleTreeTest, test_serializePortableLarge) {
       keys.clear();
     }
   }
-  ASSERT_EQ(10'000'000, t1.count());
+  EXPECT_EQ(10'000'000, t1.count());
 
   ::arangodb::velocypack::Builder t1s;
   t1.serialize(t1s, false);
 
-  ASSERT_GT(t1s.slice().byteSize(), 7'000'000);
-  ASSERT_LT(t1s.slice().byteSize(), 8'000'000);
+  EXPECT_GT(t1s.slice().byteSize(), 7'000'000);
+  EXPECT_LT(t1s.slice().byteSize(), 8'000'000);
   
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeVersion).isNumber());
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeMaxDepth).isNumber());
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeRangeMax).isString());
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeRangeMin).isString());
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeInitialRangeMin).isString());
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeCount).isNumber());
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeHash).isNumber());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeVersion).isNumber());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeMaxDepth).isNumber());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeRangeMax).isString());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeRangeMin).isString());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeInitialRangeMin).isString());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeCount).isNumber());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeHash).isNumber());
   
-  ASSERT_EQ(6, t1s.slice().get(StaticStrings::RevisionTreeMaxDepth).getNumber<int>());
-  ASSERT_EQ(10'000'000, t1s.slice().get(StaticStrings::RevisionTreeCount).getNumber<int>());
-  ASSERT_EQ(t1.nodeCountAtDepth(6), t1s.slice().get(StaticStrings::RevisionTreeNodes).length());
+  EXPECT_EQ(6, t1s.slice().get(StaticStrings::RevisionTreeMaxDepth).getNumber<int>());
+  EXPECT_EQ(10'000'000, t1s.slice().get(StaticStrings::RevisionTreeCount).getNumber<int>());
+  EXPECT_EQ(t1.nodeCountAtDepth(6), t1s.slice().get(StaticStrings::RevisionTreeNodes).length());
   
   for (auto it : arangodb::velocypack::ArrayIterator(t1s.slice().get(StaticStrings::RevisionTreeNodes))) {
-    ASSERT_TRUE(it.isObject());
-    ASSERT_TRUE(it.hasKey(StaticStrings::RevisionTreeHash));
-    ASSERT_TRUE(it.hasKey(StaticStrings::RevisionTreeCount));
+    EXPECT_TRUE(it.isObject());
+    EXPECT_TRUE(it.hasKey(StaticStrings::RevisionTreeHash));
+    EXPECT_TRUE(it.hasKey(StaticStrings::RevisionTreeCount));
   }
 
   std::unique_ptr<::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>> t2 =
       ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>::deserialize(
           t1s.slice());
-  ASSERT_NE(t2, nullptr);
+  EXPECT_NE(t2, nullptr);
   
-  ASSERT_EQ(6, t2->depth());
-  ASSERT_EQ(10'000'000, t2->count());
-  ASSERT_EQ(t1.range(), t2->range());
-  ASSERT_EQ(t1.rootValue(), t2->rootValue());
+  EXPECT_EQ(6, t2->depth());
+  EXPECT_EQ(10'000'000, t2->count());
+  EXPECT_EQ(t1.range(), t2->range());
+  EXPECT_EQ(t1.rootValue(), t2->rootValue());
 
-  ASSERT_TRUE(t1.diff(*t2).empty());
-  ASSERT_TRUE(t2->diff(t1).empty());
+  EXPECT_TRUE(t1.diff(*t2).empty());
+  EXPECT_TRUE(t2->diff(t1).empty());
 }
 
 TEST(MerkleTreeTest, test_serializePortableLargeOnlyPopulated) {
@@ -780,30 +851,30 @@ TEST(MerkleTreeTest, test_serializePortableLargeOnlyPopulated) {
       keys.clear();
     }
   }
-  ASSERT_EQ(10'000'000, t1.count());
+  EXPECT_EQ(10'000'000, t1.count());
 
   ::arangodb::velocypack::Builder t1s;
   t1.serialize(t1s, true);
  
-  ASSERT_GT(t1s.slice().byteSize(), 6'000'000);
-  ASSERT_LT(t1s.slice().byteSize(), 7'000'000);
+  EXPECT_GT(t1s.slice().byteSize(), 6'000'000);
+  EXPECT_LT(t1s.slice().byteSize(), 7'000'000);
   
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeVersion).isNumber());
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeMaxDepth).isNumber());
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeRangeMax).isString());
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeRangeMin).isString());
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeInitialRangeMin).isString());
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeCount).isNumber());
-  ASSERT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeHash).isNumber());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeVersion).isNumber());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeMaxDepth).isNumber());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeRangeMax).isString());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeRangeMin).isString());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeInitialRangeMin).isString());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeCount).isNumber());
+  EXPECT_TRUE(t1s.slice().get(StaticStrings::RevisionTreeHash).isNumber());
   
-  ASSERT_EQ(6, t1s.slice().get(StaticStrings::RevisionTreeMaxDepth).getNumber<int>());
-  ASSERT_EQ(10'000'000, t1s.slice().get(StaticStrings::RevisionTreeCount).getNumber<int>());
-  ASSERT_GE(t1.nodeCountAtDepth(6), t1s.slice().get(StaticStrings::RevisionTreeNodes).length());
+  EXPECT_EQ(6, t1s.slice().get(StaticStrings::RevisionTreeMaxDepth).getNumber<int>());
+  EXPECT_EQ(10'000'000, t1s.slice().get(StaticStrings::RevisionTreeCount).getNumber<int>());
+  EXPECT_GE(t1.nodeCountAtDepth(6), t1s.slice().get(StaticStrings::RevisionTreeNodes).length());
  
   size_t populated = 0;
   size_t empty = 0;
   for (auto it : arangodb::velocypack::ArrayIterator(t1s.slice().get(StaticStrings::RevisionTreeNodes))) {
-    ASSERT_TRUE(it.isObject());
+    EXPECT_TRUE(it.isObject());
 
     if (it.hasKey(StaticStrings::RevisionTreeHash)) {
       ++populated;
@@ -812,23 +883,23 @@ TEST(MerkleTreeTest, test_serializePortableLargeOnlyPopulated) {
     }
   }
 
-  ASSERT_GT(empty, 0);
-  ASSERT_GT(populated, 0);
+  EXPECT_GT(empty, 0);
+  EXPECT_GT(populated, 0);
 
-  ASSERT_GE(t1.nodeCountAtDepth(6), empty + populated);
+  EXPECT_GE(t1.nodeCountAtDepth(6), empty + populated);
 
   std::unique_ptr<::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>> t2 =
       ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>::deserialize(
           t1s.slice());
-  ASSERT_NE(t2, nullptr);
+  EXPECT_NE(t2, nullptr);
   
-  ASSERT_EQ(6, t2->depth());
-  ASSERT_EQ(10'000'000, t2->count());
-  ASSERT_EQ(t1.range(), t2->range());
-  ASSERT_EQ(t1.rootValue(), t2->rootValue());
+  EXPECT_EQ(6, t2->depth());
+  EXPECT_EQ(10'000'000, t2->count());
+  EXPECT_EQ(t1.range(), t2->range());
+  EXPECT_EQ(t1.rootValue(), t2->rootValue());
 
-  ASSERT_TRUE(t1.diff(*t2).empty());
-  ASSERT_TRUE(t2->diff(t1).empty());
+  EXPECT_TRUE(t1.diff(*t2).empty());
+  EXPECT_TRUE(t2->diff(t1).empty());
 }
 
 TEST(MerkleTreeTest, test_tree_based_on_2021_hlcs) {
@@ -837,35 +908,37 @@ TEST(MerkleTreeTest, test_tree_based_on_2021_hlcs) {
 
   ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> tree(6, rangeMin);
   
-  ASSERT_EQ(6, tree.depth());
-  ASSERT_EQ(0, tree.count());
-  ASSERT_EQ(0, tree.rootValue());
+  EXPECT_EQ(6, tree.depth());
+  EXPECT_EQ(0, tree.count());
+  EXPECT_EQ(0, tree.rootValue());
   
   auto [left, right] = tree.range();
-  ASSERT_EQ(rangeMin, left);
-  ASSERT_EQ(rangeMax, right);
+  EXPECT_EQ(rangeMin, left);
+  EXPECT_EQ(rangeMax, right);
 
   for (std::uint64_t i = rangeMin; i < rangeMin + 10000; ++i) {
     tree.insert(i);
   }
   
-  ASSERT_EQ(6, tree.depth());
-  ASSERT_EQ(10000, tree.count());
-  ASSERT_EQ(4298149919775466880ULL, tree.rootValue());
+  EXPECT_EQ(6, tree.depth());
+  EXPECT_EQ(10000, tree.count());
+  EXPECT_EQ(4298149919775466880ULL, tree.rootValue());
+  EXPECT_EQ(65536, tree.memoryUsage());
   std::tie(left, right) = tree.range();
-  ASSERT_EQ(rangeMin, left);
-  ASSERT_EQ(rangeMax, right);
+  EXPECT_EQ(rangeMin, left);
+  EXPECT_EQ(rangeMax, right);
   
   for (std::uint64_t i = rangeMin; i < rangeMin + 10000; ++i) {
     tree.remove(i);
   }
   
-  ASSERT_EQ(6, tree.depth());
-  ASSERT_EQ(0, tree.count());
-  ASSERT_EQ(0, tree.rootValue());
+  EXPECT_EQ(6, tree.depth());
+  EXPECT_EQ(0, tree.count());
+  EXPECT_EQ(0, tree.rootValue());
+  EXPECT_EQ(65536, tree.memoryUsage());
   std::tie(left, right) = tree.range();
-  ASSERT_EQ(rangeMin, left);
-  ASSERT_EQ(rangeMax, right);
+  EXPECT_EQ(rangeMin, left);
+  EXPECT_EQ(rangeMax, right);
 
   // increase the pace
   constexpr std::uint64_t n = 10'000'000;
@@ -881,12 +954,13 @@ TEST(MerkleTreeTest, test_tree_based_on_2021_hlcs) {
     tree.insert(revisions);
   }
   
-  ASSERT_EQ(6, tree.depth());
-  ASSERT_EQ(10'000'000, tree.count());
-  ASSERT_EQ(9116977756596679424ULL, tree.rootValue());
+  EXPECT_EQ(6, tree.depth());
+  EXPECT_EQ(10'000'000, tree.count());
+  EXPECT_EQ(9116977756596679424ULL, tree.rootValue());
+  EXPECT_EQ(2555904, tree.memoryUsage());
   std::tie(left, right) = tree.range();
-  ASSERT_EQ(rangeMin, left);
-  ASSERT_EQ(rangeMax, right);
+  EXPECT_EQ(rangeMin, left);
+  EXPECT_EQ(rangeMax, right);
   
   for (std::uint64_t i = rangeMin; i < rangeMin + n; i += batchSize) {
     revisions.clear();
@@ -896,12 +970,13 @@ TEST(MerkleTreeTest, test_tree_based_on_2021_hlcs) {
     tree.remove(revisions);
   }
   
-  ASSERT_EQ(6, tree.depth());
-  ASSERT_EQ(0, tree.count());
-  ASSERT_EQ(0, tree.rootValue());
+  EXPECT_EQ(6, tree.depth());
+  EXPECT_EQ(0, tree.count());
+  EXPECT_EQ(0, tree.rootValue());
+  EXPECT_EQ(2555904, tree.memoryUsage());
   std::tie(left, right) = tree.range();
-  ASSERT_EQ(rangeMin, left);
-  ASSERT_EQ(rangeMax, right);
+  EXPECT_EQ(rangeMin, left);
+  EXPECT_EQ(rangeMax, right);
 }
 
 TEST(MerkleTreeTest, test_large_steps) {
@@ -910,13 +985,14 @@ TEST(MerkleTreeTest, test_large_steps) {
   
   ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> tree(6, rangeMin);
   
-  ASSERT_EQ(6, tree.depth());
-  ASSERT_EQ(0, tree.count());
-  ASSERT_EQ(0, tree.rootValue());
+  EXPECT_EQ(6, tree.depth());
+  EXPECT_EQ(0, tree.count());
+  EXPECT_EQ(0, tree.rootValue());
+  EXPECT_EQ(0, tree.memoryUsage());
   
   auto [left, right] = tree.range();
-  ASSERT_EQ(rangeMin, left);
-  ASSERT_EQ(rangeMax, right);
+  EXPECT_EQ(rangeMin, left);
+  EXPECT_EQ(rangeMax, right);
 
   constexpr std::uint64_t n = 100'000'000'000;
   constexpr std::uint64_t step = 10'000;
@@ -925,9 +1001,10 @@ TEST(MerkleTreeTest, test_large_steps) {
     tree.insert(i);
   }
   
-  ASSERT_EQ(6, tree.depth());
+  EXPECT_EQ(6, tree.depth());
   EXPECT_EQ(10'000'000, tree.count());
   EXPECT_EQ(7036974261486883938ULL, tree.rootValue());
+  EXPECT_EQ(4194304, tree.memoryUsage());
   std::tie(left, right) = tree.range();
   rangeMax = 1609459337438953472ULL;
   EXPECT_EQ(rangeMin, left);
@@ -937,12 +1014,55 @@ TEST(MerkleTreeTest, test_large_steps) {
     tree.remove(i);
   }
   
-  ASSERT_EQ(6, tree.depth());
-  ASSERT_EQ(0, tree.count());
-  ASSERT_EQ(0, tree.rootValue());
+  EXPECT_EQ(6, tree.depth());
+  EXPECT_EQ(0, tree.count());
+  EXPECT_EQ(0, tree.rootValue());
+  EXPECT_EQ(4194304, tree.memoryUsage());
   std::tie(left, right) = tree.range();
-  ASSERT_EQ(rangeMin, left);
-  ASSERT_EQ(rangeMax, right);
+  EXPECT_EQ(rangeMin, left);
+  EXPECT_EQ(rangeMax, right);
+}
+
+TEST(MerkleTreeTest, test_clear) {
+  uint64_t rangeMin = uint64_t(1609459200000000000ULL);
+  uint64_t rangeMax = uint64_t(1609459200016777216ULL);
+  
+  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> tree(6, rangeMin);
+  
+  EXPECT_EQ(6, tree.depth());
+  EXPECT_EQ(0, tree.count());
+  EXPECT_EQ(0, tree.rootValue());
+  EXPECT_EQ(0, tree.memoryUsage());
+  
+  auto [left, right] = tree.range();
+  EXPECT_EQ(rangeMin, left);
+  EXPECT_EQ(rangeMax, right);
+
+  constexpr std::uint64_t n = 100'000'000'000;
+  constexpr std::uint64_t step = 50'000;
+
+  for (std::uint64_t i = rangeMin; i < rangeMin + n; i += step) {
+    tree.insert(i);
+  }
+  
+  EXPECT_EQ(6, tree.depth());
+  EXPECT_EQ(2'000'000, tree.count());
+  EXPECT_EQ(12929699950823344265ULL, tree.rootValue());
+  EXPECT_EQ(4194304, tree.memoryUsage());
+  std::tie(left, right) = tree.range();
+  rangeMax = 1609459337438953472ULL;
+  EXPECT_EQ(rangeMin, left);
+  EXPECT_EQ(rangeMax, right);
+ 
+  tree.clear();
+  
+  EXPECT_EQ(6, tree.depth());
+  EXPECT_EQ(0, tree.count());
+  EXPECT_EQ(0, tree.rootValue());
+  EXPECT_EQ(0, tree.memoryUsage());
+  std::tie(left, right) = tree.range();
+  EXPECT_EQ(rangeMin, left);
+  EXPECT_EQ(rangeMax, right);
 }
 
 TEST(MerkleTreeTest, test_check_consistency) {
@@ -951,16 +1071,16 @@ TEST(MerkleTreeTest, test_check_consistency) {
   
   ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> tree(6, rangeMin);
   
-  ASSERT_EQ(6, tree.depth());
-  ASSERT_EQ(0, tree.count());
-  ASSERT_EQ(0, tree.rootValue());
+  EXPECT_EQ(6, tree.depth());
+  EXPECT_EQ(0, tree.count());
+  EXPECT_EQ(0, tree.rootValue());
   
   // must not throw
   tree.checkConsistency();
   
   auto [left, right] = tree.range();
-  ASSERT_EQ(rangeMin, left);
-  ASSERT_EQ(rangeMax, right);
+  EXPECT_EQ(rangeMin, left);
+  EXPECT_EQ(rangeMax, right);
 
   constexpr std::uint64_t n = 100'000'000'000;
   constexpr std::uint64_t step = 10'000;
@@ -978,7 +1098,7 @@ TEST(MerkleTreeTest, test_check_consistency) {
   // must throw
   try {
     tree.checkConsistency();
-    ASSERT_TRUE(false);
+    EXPECT_TRUE(false);
   } catch (std::invalid_argument const&) {
   }
 #endif
@@ -999,21 +1119,21 @@ class MerkleTreeGrowTests
 };
 
 TEST_F(MerkleTreeGrowTests, test_grow_left_simple) {
-  ASSERT_EQ(rangeMin + initWidth, rangeMax);
+  EXPECT_EQ(rangeMin + initWidth, rangeMax);
 
   arangodb::containers::FnvHashProvider hasher;
 
-  ASSERT_EQ(6, depth());
-  ASSERT_EQ(0, count());
-  ASSERT_EQ(0, rootValue());
+  EXPECT_EQ(6, depth());
+  EXPECT_EQ(0, count());
+  EXPECT_EQ(0, rootValue());
   
   insert(rangeMin);
   insert(rangeMin + bucketWidth);
   insert(rangeMin + 47 * bucketWidth);
 
-  ASSERT_EQ(6, depth());
-  ASSERT_EQ(3, count());
-  ASSERT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth) ^
+  EXPECT_EQ(6, depth());
+  EXPECT_EQ(3, count());
+  EXPECT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth) ^
             hasher.hash(rangeMin + 47 * bucketWidth), rootValue());
 
   // Now grow to the left:
@@ -1022,35 +1142,35 @@ TEST_F(MerkleTreeGrowTests, test_grow_left_simple) {
   // Must not throw:
   checkConsistency();
 
-  ASSERT_EQ(6, depth());
-  ASSERT_EQ(4, count());
-  ASSERT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth) ^
+  EXPECT_EQ(6, depth());
+  EXPECT_EQ(4, count());
+  EXPECT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth) ^
             hasher.hash(rangeMin + 47 * bucketWidth) ^
             hasher.hash(rangeMin - 1), rootValue());
-  ASSERT_EQ(rangeMin - initWidth, range().first);
-  ASSERT_EQ(rangeMax, range().second);
+  EXPECT_EQ(rangeMin - initWidth, range().first);
+  EXPECT_EQ(rangeMax, range().second);
 
   // Now check the bottommost buckets:
   Node& n = node(index(rangeMin));
-  ASSERT_EQ(2, n.count);
-  ASSERT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth),
+  EXPECT_EQ(2, n.count);
+  EXPECT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth),
             n.hash);
   Node& n2 = node(index(rangeMin - 1));
-  ASSERT_EQ(1, n2.count);
-  ASSERT_EQ(hasher.hash(rangeMin - 1), n2.hash);
+  EXPECT_EQ(1, n2.count);
+  EXPECT_EQ(hasher.hash(rangeMin - 1), n2.hash);
   Node& n3 = node(index(rangeMin + 47 * bucketWidth));
-  ASSERT_EQ(1, n3.count);
-  ASSERT_EQ(hasher.hash(rangeMin + 47 * bucketWidth), n3.hash);
+  EXPECT_EQ(1, n3.count);
+  EXPECT_EQ(hasher.hash(rangeMin + 47 * bucketWidth), n3.hash);
 }
 
 TEST_F(MerkleTreeGrowTests, test_grow_left_with_shift) {
-  ASSERT_EQ(rangeMin + initWidth, rangeMax);
+  EXPECT_EQ(rangeMin + initWidth, rangeMax);
 
   arangodb::containers::FnvHashProvider hasher;
 
-  ASSERT_EQ(6, depth());
-  ASSERT_EQ(0, count());
-  ASSERT_EQ(0, rootValue());
+  EXPECT_EQ(6, depth());
+  EXPECT_EQ(0, count());
+  EXPECT_EQ(0, rootValue());
   
   // We grow once to the left, so that initialRangeMin - rangeMin is 2^24.
   // Then we grow to the right until the width is 2^(18+24) = 2^42.
@@ -1064,25 +1184,25 @@ TEST_F(MerkleTreeGrowTests, test_grow_left_with_shift) {
     rangeMax = range().second;
   }
 
-  ASSERT_EQ(6, depth());
-  ASSERT_EQ(0, count());
-  ASSERT_EQ(0, rootValue());
-  ASSERT_EQ(rangeMin - initWidth, range().first);
+  EXPECT_EQ(6, depth());
+  EXPECT_EQ(0, count());
+  EXPECT_EQ(0, rootValue());
+  EXPECT_EQ(rangeMin - initWidth, range().first);
   rangeMin = range().first;
   rangeMax = range().second;
-  ASSERT_EQ(rangeMin + (1ULL << 42), rangeMax);
+  EXPECT_EQ(rangeMin + (1ULL << 42), rangeMax);
   bucketWidth = (range().second - range().first) >> 18;
-  ASSERT_EQ(1ULL << 24, bucketWidth);
+  EXPECT_EQ(1ULL << 24, bucketWidth);
 
   insert(rangeMin);
   insert(rangeMin + bucketWidth);
   insert(rangeMin + 47 * bucketWidth);
 
-  ASSERT_EQ(6, depth());
-  ASSERT_EQ(3, count());
-  ASSERT_EQ(rangeMin, range().first);
-  ASSERT_EQ(rangeMax, range().second);
-  ASSERT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth) ^
+  EXPECT_EQ(6, depth());
+  EXPECT_EQ(3, count());
+  EXPECT_EQ(rangeMin, range().first);
+  EXPECT_EQ(rangeMax, range().second);
+  EXPECT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth) ^
             hasher.hash(rangeMin + 47 * bucketWidth), rootValue());
 
   // Now grow to the left:
@@ -1091,42 +1211,42 @@ TEST_F(MerkleTreeGrowTests, test_grow_left_with_shift) {
   // Must not throw:
   checkConsistency();
 
-  ASSERT_EQ(6, depth());
-  ASSERT_EQ(4, count());
-  ASSERT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth) ^
+  EXPECT_EQ(6, depth());
+  EXPECT_EQ(4, count());
+  EXPECT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth) ^
             hasher.hash(rangeMin + 47 * bucketWidth) ^
             hasher.hash(rangeMin - 1), rootValue());
-  ASSERT_EQ(rangeMin - (rangeMax - rangeMin) + bucketWidth, range().first);
-  ASSERT_EQ(rangeMax + bucketWidth, range().second);
+  EXPECT_EQ(rangeMin - (rangeMax - rangeMin) + bucketWidth, range().first);
+  EXPECT_EQ(rangeMax + bucketWidth, range().second);
 
   // Now check the bottommost buckets:
   Node& n = node(index(rangeMin));
-  ASSERT_EQ(2, n.count);
-  ASSERT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin - 1), n.hash);
+  EXPECT_EQ(2, n.count);
+  EXPECT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin - 1), n.hash);
   Node& n2 = node(index(rangeMin + bucketWidth));
-  ASSERT_EQ(1, n2.count);
-  ASSERT_EQ(hasher.hash(rangeMin + bucketWidth), n2.hash);
+  EXPECT_EQ(1, n2.count);
+  EXPECT_EQ(hasher.hash(rangeMin + bucketWidth), n2.hash);
   Node& n3 = node(index(rangeMin + 47 * bucketWidth));
-  ASSERT_EQ(1, n3.count);
-  ASSERT_EQ(hasher.hash(rangeMin + 47 * bucketWidth), n3.hash);
+  EXPECT_EQ(1, n3.count);
+  EXPECT_EQ(hasher.hash(rangeMin + 47 * bucketWidth), n3.hash);
 }
 
 TEST_F(MerkleTreeGrowTests, test_grow_right_simple) {
-  ASSERT_EQ(rangeMin + initWidth, rangeMax);
+  EXPECT_EQ(rangeMin + initWidth, rangeMax);
 
   arangodb::containers::FnvHashProvider hasher;
 
-  ASSERT_EQ(6, depth());
-  ASSERT_EQ(0, count());
-  ASSERT_EQ(0, rootValue());
+  EXPECT_EQ(6, depth());
+  EXPECT_EQ(0, count());
+  EXPECT_EQ(0, rootValue());
   
   insert(rangeMin);
   insert(rangeMin + bucketWidth);
   insert(rangeMin + 47 * bucketWidth);
 
-  ASSERT_EQ(6, depth());
-  ASSERT_EQ(3, count());
-  ASSERT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth) ^
+  EXPECT_EQ(6, depth());
+  EXPECT_EQ(3, count());
+  EXPECT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth) ^
             hasher.hash(rangeMin + 47 * bucketWidth), rootValue());
 
   // Now grow to the right:
@@ -1135,35 +1255,35 @@ TEST_F(MerkleTreeGrowTests, test_grow_right_simple) {
   // Must not throw:
   checkConsistency();
 
-  ASSERT_EQ(6, depth());
-  ASSERT_EQ(4, count());
-  ASSERT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth) ^
+  EXPECT_EQ(6, depth());
+  EXPECT_EQ(4, count());
+  EXPECT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth) ^
             hasher.hash(rangeMin + 47 * bucketWidth) ^
             hasher.hash(rangeMax + 42), rootValue());
-  ASSERT_EQ(rangeMin, range().first);
-  ASSERT_EQ(rangeMax + initWidth, range().second);
+  EXPECT_EQ(rangeMin, range().first);
+  EXPECT_EQ(rangeMax + initWidth, range().second);
 
   // Now check the bottommost buckets:
   Node& n = node(index(rangeMin));
-  ASSERT_EQ(2, n.count);
-  ASSERT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth),
+  EXPECT_EQ(2, n.count);
+  EXPECT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth),
             n.hash);
   Node& n2 = node(index(rangeMax + 42));
-  ASSERT_EQ(1, n2.count);
-  ASSERT_EQ(hasher.hash(rangeMax + 42), n2.hash);
+  EXPECT_EQ(1, n2.count);
+  EXPECT_EQ(hasher.hash(rangeMax + 42), n2.hash);
   Node& n3 = node(index(rangeMin + 47 * bucketWidth));
-  ASSERT_EQ(1, n3.count);
-  ASSERT_EQ(hasher.hash(rangeMin + 47 * bucketWidth), n3.hash);
+  EXPECT_EQ(1, n3.count);
+  EXPECT_EQ(hasher.hash(rangeMin + 47 * bucketWidth), n3.hash);
 }
 
 TEST_F(MerkleTreeGrowTests, test_grow_right_with_shift) {
-  ASSERT_EQ(rangeMin + initWidth, rangeMax);
+  EXPECT_EQ(rangeMin + initWidth, rangeMax);
 
   arangodb::containers::FnvHashProvider hasher;
 
-  ASSERT_EQ(6, depth());
-  ASSERT_EQ(0, count());
-  ASSERT_EQ(0, rootValue());
+  EXPECT_EQ(6, depth());
+  EXPECT_EQ(0, count());
+  EXPECT_EQ(0, rootValue());
   
   // We grow once to the left, so that initialRangeMin - rangeMin is 2^24.
   // Then we grow to the right until the width is 2^(18+24) = 2^42.
@@ -1177,25 +1297,25 @@ TEST_F(MerkleTreeGrowTests, test_grow_right_with_shift) {
     rangeMax = range().second;
   }
 
-  ASSERT_EQ(6, depth());
-  ASSERT_EQ(0, count());
-  ASSERT_EQ(0, rootValue());
-  ASSERT_EQ(rangeMin - initWidth, range().first);
+  EXPECT_EQ(6, depth());
+  EXPECT_EQ(0, count());
+  EXPECT_EQ(0, rootValue());
+  EXPECT_EQ(rangeMin - initWidth, range().first);
   rangeMin = range().first;
   rangeMax = range().second;
-  ASSERT_EQ(rangeMin + (1ULL << 42), rangeMax);
+  EXPECT_EQ(rangeMin + (1ULL << 42), rangeMax);
   bucketWidth = (range().second - range().first) >> 18;
-  ASSERT_EQ(1ULL << 24, bucketWidth);
+  EXPECT_EQ(1ULL << 24, bucketWidth);
 
   insert(rangeMin);
   insert(rangeMin + bucketWidth);
   insert(rangeMin + 47 * bucketWidth);
 
-  ASSERT_EQ(6, depth());
-  ASSERT_EQ(3, count());
-  ASSERT_EQ(rangeMin, range().first);
-  ASSERT_EQ(rangeMax, range().second);
-  ASSERT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth) ^
+  EXPECT_EQ(6, depth());
+  EXPECT_EQ(3, count());
+  EXPECT_EQ(rangeMin, range().first);
+  EXPECT_EQ(rangeMax, range().second);
+  EXPECT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth) ^
             hasher.hash(rangeMin + 47 * bucketWidth), rootValue());
 
   // Now grow to the right:
@@ -1204,27 +1324,27 @@ TEST_F(MerkleTreeGrowTests, test_grow_right_with_shift) {
   // Must not throw:
   checkConsistency();
 
-  ASSERT_EQ(6, depth());
-  ASSERT_EQ(4, count());
-  ASSERT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth) ^
+  EXPECT_EQ(6, depth());
+  EXPECT_EQ(4, count());
+  EXPECT_EQ(hasher.hash(rangeMin) ^ hasher.hash(rangeMin + bucketWidth) ^
             hasher.hash(rangeMin + 47 * bucketWidth) ^
             hasher.hash(rangeMax), rootValue());
-  ASSERT_EQ(rangeMin - bucketWidth, range().first);
-  ASSERT_EQ(rangeMax + (rangeMax - rangeMin) - bucketWidth, range().second);
+  EXPECT_EQ(rangeMin - bucketWidth, range().first);
+  EXPECT_EQ(rangeMax + (rangeMax - rangeMin) - bucketWidth, range().second);
 
   // Now check the bottommost buckets:
   Node& n = node(index(rangeMin));
-  ASSERT_EQ(1, n.count);
-  ASSERT_EQ(hasher.hash(rangeMin), n.hash);
+  EXPECT_EQ(1, n.count);
+  EXPECT_EQ(hasher.hash(rangeMin), n.hash);
   Node& n2 = node(index(rangeMin + bucketWidth));
-  ASSERT_EQ(1, n2.count);
-  ASSERT_EQ(hasher.hash(rangeMin + bucketWidth), n2.hash);
+  EXPECT_EQ(1, n2.count);
+  EXPECT_EQ(hasher.hash(rangeMin + bucketWidth), n2.hash);
   Node& n3 = node(index(rangeMin + 47 * bucketWidth));
-  ASSERT_EQ(1, n3.count);
-  ASSERT_EQ(hasher.hash(rangeMin + 47 * bucketWidth), n3.hash);
+  EXPECT_EQ(1, n3.count);
+  EXPECT_EQ(hasher.hash(rangeMin + 47 * bucketWidth), n3.hash);
   Node& n4 = node(index(rangeMax));
-  ASSERT_EQ(1, n4.count);
-  ASSERT_EQ(hasher.hash(rangeMax), n4.hash);
+  EXPECT_EQ(1, n4.count);
+  EXPECT_EQ(hasher.hash(rangeMax), n4.hash);
 }
 
 TEST(MerkleTreeTest, test_diff_with_shift_1) {
@@ -1234,7 +1354,7 @@ TEST(MerkleTreeTest, test_diff_with_shift_1) {
   ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t2(6, M + 16, M + W + 16, M + 16);   // four buckets further right
 
   std::vector<std::pair<std::uint64_t, std::uint64_t>> expected;
-  ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
+  EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
 
   // Now insert something into t1 left of tree 2 as well as in the overlap:
   t1.insert(M);      // first bucket in t1
@@ -1243,7 +1363,7 @@ TEST(MerkleTreeTest, test_diff_with_shift_1) {
   expected.emplace_back(std::pair(M+8, M+11));
   t1.insert(M + 16); // fifth bucket in t1, first bucket in t2
   expected.emplace_back(std::pair(M+16, M+19));
-  ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
+  EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
   t1.clear();
   expected.clear();
 
@@ -1254,7 +1374,7 @@ TEST(MerkleTreeTest, test_diff_with_shift_1) {
   t1.insert(M + 12); // fourth bucket in t1
   t1.insert(M + 16); // fifth bucket in t1, first bucket in t2
   expected.emplace_back(std::pair(M, M+19));
-  ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
+  EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
   t1.clear();
   expected.clear();
 
@@ -1265,7 +1385,7 @@ TEST(MerkleTreeTest, test_diff_with_shift_1) {
   expected.emplace_back(std::pair(M + W, M + W + 3));
   t2.insert(M + W + 8);      // not in t1, second last bucket in t2
   expected.emplace_back(std::pair(M + W + 8, M + W + 11));
-  ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
+  EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
   t2.clear();
   expected.clear();
   
@@ -1276,7 +1396,7 @@ TEST(MerkleTreeTest, test_diff_with_shift_1) {
   t2.insert(M + W + 4);      // not in t1, third last bucket in t2
   t2.insert(M + W + 8);      // not in t1, second last bucket in t2
   expected.emplace_back(std::pair(M + W - 8, M + W + 11));
-  ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
+  EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
   t2.clear();
   expected.clear();
 
@@ -1295,7 +1415,7 @@ TEST(MerkleTreeTest, test_diff_with_shift_1) {
   t2.insert(M + W);
   t2.insert(M + W + 5);
   expected.emplace_back(std::pair(M + W, M + W + 7));
-  ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
+  EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
 }
 
 TEST(MerkleTreeTest, test_diff_empty_random_data_shifted) {
@@ -1330,8 +1450,8 @@ TEST(MerkleTreeTest, test_diff_empty_random_data_shifted) {
   auto t2c = t2.clone();
 
   std::vector<std::pair<std::uint64_t, std::uint64_t>> expected;
-  ASSERT_TRUE(::diffAsExpected(t1, t2, expected));
-  ASSERT_TRUE(::diffAsExpected(t2, t1, expected));
+  EXPECT_TRUE(::diffAsExpected(t1, t2, expected));
+  EXPECT_TRUE(::diffAsExpected(t2, t1, expected));
 }
 
 TEST(MerkleTreeTest, test_clone_compare_clean) {
@@ -1356,7 +1476,7 @@ TEST(MerkleTreeTest, test_clone_compare_clean) {
 
   // And compare the two:
   std::vector<std::pair<std::uint64_t, std::uint64_t>> expected;
-  ASSERT_TRUE(::diffAsExpected(t1, *t2, expected));
+  EXPECT_TRUE(::diffAsExpected(t1, *t2, expected));
 
   // And compare bitwise:
   auto format = arangodb::containers::MerkleTreeBase::BinaryFormat::Uncompressed;
@@ -1364,28 +1484,28 @@ TEST(MerkleTreeTest, test_clone_compare_clean) {
   t1.serializeBinary(s1, format);
   std::string s2;
   t2->serializeBinary(s2, format);
-  ASSERT_EQ(s1, s2);
+  EXPECT_EQ(s1, s2);
   
   format = arangodb::containers::MerkleTreeBase::BinaryFormat::OnlyPopulated;
   s1.clear();
   t1.serializeBinary(s1, format);
   s2.clear();
   t2->serializeBinary(s2, format);
-  ASSERT_EQ(s1, s2);
+  EXPECT_EQ(s1, s2);
 
   format = arangodb::containers::MerkleTreeBase::BinaryFormat::CompressedSnappyFull;
   s1.clear();
   t1.serializeBinary(s1, format);
   s2.clear();
   t2->serializeBinary(s2, format);
-  ASSERT_EQ(s1, s2);
+  EXPECT_EQ(s1, s2);
   
   format = arangodb::containers::MerkleTreeBase::BinaryFormat::CompressedSnappyLazy;
   s1.clear();
   t1.serializeBinary(s1, format);
   s2.clear();
   t2->serializeBinary(s2, format);
-  ASSERT_EQ(s1, s2);
+  EXPECT_EQ(s1, s2);
 
   // Now use operator=
   ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t3(6, M, M + W, M + 16);
@@ -1397,28 +1517,28 @@ TEST(MerkleTreeTest, test_clone_compare_clean) {
   t1.serializeBinary(s1, format);
   s2.clear();
   t3.serializeBinary(s2, format);
-  ASSERT_EQ(s1, s2);
+  EXPECT_EQ(s1, s2);
 
   format = arangodb::containers::MerkleTreeBase::BinaryFormat::OnlyPopulated;
   s1.clear();
   t1.serializeBinary(s1, format);
   s2.clear();
   t3.serializeBinary(s2, format);
-  ASSERT_EQ(s1, s2);
+  EXPECT_EQ(s1, s2);
   
   format = arangodb::containers::MerkleTreeBase::BinaryFormat::CompressedSnappyFull;
   s1.clear();
   t1.serializeBinary(s1, format);
   s2.clear();
   t3.serializeBinary(s2, format);
-  ASSERT_EQ(s1, s2);
+  EXPECT_EQ(s1, s2);
 
   format = arangodb::containers::MerkleTreeBase::BinaryFormat::CompressedSnappyLazy;
   s1.clear();
   t1.serializeBinary(s1, format);
   s2.clear();
   t3.serializeBinary(s2, format);
-  ASSERT_EQ(s1, s2);
+  EXPECT_EQ(s1, s2);
 }
 
 TEST(MerkleTreeTest, test_clone_compare_clean_large) {
@@ -1443,7 +1563,7 @@ TEST(MerkleTreeTest, test_clone_compare_clean_large) {
 
   // And compare the two:
   std::vector<std::pair<std::uint64_t, std::uint64_t>> expected;
-  ASSERT_TRUE(::diffAsExpected(t1, *t2, expected));
+  EXPECT_TRUE(::diffAsExpected(t1, *t2, expected));
 
   // And compare bitwise:
   auto format = arangodb::containers::MerkleTreeBase::BinaryFormat::Uncompressed;
@@ -1451,28 +1571,28 @@ TEST(MerkleTreeTest, test_clone_compare_clean_large) {
   t1.serializeBinary(s1, format);
   std::string s2;
   t2->serializeBinary(s2, format);
-  ASSERT_EQ(s1, s2);
+  EXPECT_EQ(s1, s2);
   
   format = arangodb::containers::MerkleTreeBase::BinaryFormat::OnlyPopulated;
   s1.clear();
   t1.serializeBinary(s1, format);
   s2.clear();
   t2->serializeBinary(s2, format);
-  ASSERT_EQ(s1, s2);
+  EXPECT_EQ(s1, s2);
   
   format = arangodb::containers::MerkleTreeBase::BinaryFormat::CompressedSnappyFull;
   s1.clear();
   t1.serializeBinary(s1, format);
   s2.clear();
   t2->serializeBinary(s2, format);
-  ASSERT_EQ(s1, s2);
+  EXPECT_EQ(s1, s2);
 
   format = arangodb::containers::MerkleTreeBase::BinaryFormat::CompressedSnappyLazy;
   s1.clear();
   t1.serializeBinary(s1, format);
   s2.clear();
   t2->serializeBinary(s2, format);
-  ASSERT_EQ(s1, s2);
+  EXPECT_EQ(s1, s2);
 
   // Now use operator=
   ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t3(6, M, M + W, M + 16);
@@ -1484,28 +1604,28 @@ TEST(MerkleTreeTest, test_clone_compare_clean_large) {
   t1.serializeBinary(s1, format);
   s2.clear();
   t3.serializeBinary(s2, format);
-  ASSERT_EQ(s1, s2);
+  EXPECT_EQ(s1, s2);
   
   format = arangodb::containers::MerkleTreeBase::BinaryFormat::OnlyPopulated;
   s1.clear();
   t1.serializeBinary(s1, format);
   s2.clear();
   t3.serializeBinary(s2, format);
-  ASSERT_EQ(s1, s2);
+  EXPECT_EQ(s1, s2);
   
   format = arangodb::containers::MerkleTreeBase::BinaryFormat::CompressedSnappyFull;
   s1.clear();
   t1.serializeBinary(s1, format);
   s2.clear();
   t3.serializeBinary(s2, format);
-  ASSERT_EQ(s1, s2);
+  EXPECT_EQ(s1, s2);
 
   format = arangodb::containers::MerkleTreeBase::BinaryFormat::CompressedSnappyLazy;
   s1.clear();
   t1.serializeBinary(s1, format);
   s2.clear();
   t3.serializeBinary(s2, format);
-  ASSERT_EQ(s1, s2);
+  EXPECT_EQ(s1, s2);
 }
 
 TEST(MerkleTreeTest, test_to_string) {
@@ -1526,9 +1646,9 @@ TEST(MerkleTreeTest, test_to_string) {
   // the exact size of the response is unclear here, due to the pseudo-random
   // inserts
   std::string s = t1.toString(false);
-  ASSERT_LE(800, s.size());
+  EXPECT_LE(800, s.size());
   s = t1.toString(true);
-  ASSERT_LE(950, s.size());
+  EXPECT_LE(950, s.size());
 }
 
 TEST(MerkleTreeTest, test_diff_one_side_empty_random_data_shifted) {
@@ -1562,10 +1682,10 @@ TEST(MerkleTreeTest, test_diff_one_side_empty_random_data_shifted) {
   std::vector<std::pair<std::uint64_t, std::uint64_t>> d2 = t2c->diff(*t1c);
 
   // Now do a check of the result, first, the two should be the same:
-  ASSERT_EQ(d1.size(), d2.size());
+  EXPECT_EQ(d1.size(), d2.size());
   for (size_t i = 0; i < d1.size(); ++i) {
-    ASSERT_EQ(d1[i].first, d2[i].first);
-    ASSERT_EQ(d1[i].second, d2[i].second);
+    EXPECT_EQ(d1[i].first, d2[i].first);
+    EXPECT_EQ(d1[i].second, d2[i].second);
   }
 
   // Now check that each of the intervals contains at least one entry
@@ -1574,8 +1694,8 @@ TEST(MerkleTreeTest, test_diff_one_side_empty_random_data_shifted) {
   size_t posi = 0;  // position in intervals
   while (pos < sorted.size() && posi < d1.size()) {
     // Next key in the sorted list must be in next interval:
-    ASSERT_LE(d1[posi].first, sorted[pos]);
-    ASSERT_LE(sorted[pos], d1[posi].second);
+    EXPECT_LE(d1[posi].first, sorted[pos]);
+    EXPECT_LE(sorted[pos], d1[posi].second);
     // Now skip all points in the sorted list in that interval:
     while (pos < sorted.size() &&
            d1[posi].first <= sorted[pos] && sorted[pos] <= d1[posi].second) {
@@ -1584,8 +1704,8 @@ TEST(MerkleTreeTest, test_diff_one_side_empty_random_data_shifted) {
     // Now skip this interval:
     ++posi;
   }
-  ASSERT_EQ(pos, sorted.size());  // All points should be consumed
-  ASSERT_EQ(posi, d1.size());     // All intervals should be consumed
+  EXPECT_EQ(pos, sorted.size());  // All points should be consumed
+  EXPECT_EQ(posi, d1.size());     // All intervals should be consumed
 }
 
 TEST(MerkleTreeTest, overflow_underflow) {
@@ -1593,18 +1713,18 @@ TEST(MerkleTreeTest, overflow_underflow) {
   ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t(6, 0, M, 0);
   try {
     t.insert(M);   // must throw because of overflow
-    ASSERT_TRUE(false);
+    EXPECT_TRUE(false);
   } catch (std::out_of_range const& exc) {
     std::string msg{exc.what()};
-    ASSERT_TRUE(msg.find("overflow") != std::string::npos);
+    EXPECT_TRUE(msg.find("overflow") != std::string::npos);
   }
   ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3> t2(6, 1, M + 1, 1);
   try {
     t2.insert(0);   // must throw because of underflow
-    ASSERT_TRUE(false);
+    EXPECT_TRUE(false);
   } catch (std::out_of_range const& exc) {
     std::string msg{exc.what()};
-    ASSERT_TRUE(msg.find("underflow") != std::string::npos);
+    EXPECT_TRUE(msg.find("underflow") != std::string::npos);
   }
 };
 
@@ -1623,13 +1743,13 @@ class MerkleTreeSpecialGrowTests
 };
 
 TEST_F(MerkleTreeSpecialGrowTests, test_grow_right_simple) {
-  ASSERT_EQ(rangeMin + initWidth, rangeMax);
+  EXPECT_EQ(rangeMin + initWidth, rangeMax);
 
   arangodb::containers::FnvHashProvider hasher;
 
-  ASSERT_EQ(6, depth());
-  ASSERT_EQ(0, count());
-  ASSERT_EQ(0, rootValue());
+  EXPECT_EQ(6, depth());
+  EXPECT_EQ(0, count());
+  EXPECT_EQ(0, rootValue());
 
   // There are 2^18 buckets, and initWidth is 2^24, so 2^6=64 values
   // per bucket. We put something in bucket 1, but nothing in buckets

--- a/tests/js/client/shell/shell-promtool-cluster.js
+++ b/tests/js/client/shell/shell-promtool-cluster.js
@@ -121,8 +121,15 @@ function validateMetrics(metrics) {
     let command = promtoolPath + ' check metrics < "' + input + '" > "' + output + '" 2>&1';
     // pipe contents of temp file into promtool
     let actualRc = internal.executeExternalAndWait('sh', ['-c', command]);
+
+    // provide more context about what exactly went wrong
+    let help = "";
+    try {
+      help = metrics + "\n\n" + String(fs.readFileSync(output));
+    } catch (err) {}
+
     assertTrue(actualRc.hasOwnProperty('exit'));
-    assertEqual(0, actualRc.exit);
+    assertEqual(0, actualRc.exit, help);
 
     let promtoolResult = fs.readFileSync(output).toString();
     // no errors found means an empty result file
@@ -214,7 +221,7 @@ function promtoolClusterSuite() {
       expect(res).to.have.property('statusCode', 404);
       expect(res.json.errorNum).to.equal(errors.ERROR_HTTP_BAD_PARAMETER.code);
     },
-    testServerDoesntResponse: function () {
+    testServerDoesntRespond: function () {
       //query metrics from coordinator, supplying id of a server, that is shut down
       let dbServer = dbServers[0];
       let serverId = getServerId(dbServer);


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/15225

Added memory usage tracking for revision trees

* Added the following metrics for revision trees:
  - `arangodb_revision_tree_hibernations_total`: number of times a revision tree was compressed in RAM and set to hibernation
  - `arangodb_revision_tree_resurrections_total`: number of times a revision tree was resurrected from hibernation and uncompressed in RAM
  - `arangodb_revision_tree_memory_usage`: total memory usage (in bytes) by all active revision trees

* Added metric `rocskdb_wal_sequence` to track the current tip of the WAL's sequence number.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/15237

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *gtest*.
  - [x] Added new **integration tests** (gtest)
