### PR TITLE
add back "doSoftLockOnly" attribute for shard sync protocol

### DIFF
--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -447,6 +447,7 @@ arangodb::Result SynchronizeShard::getReadLock(
     body.add(TTL, VPackValue(timeout));
     body.add("serverId", VPackValue(arangodb::ServerState::instance()->getId()));
     body.add(StaticStrings::RebootId, VPackValue(ServerState::instance()->getRebootId().value()));
+    body.add(StaticStrings::ReplicationSoftLockOnly, VPackValue(soft));
     // the following attribute was added in 3.7.16, 3.8.3 and higher:
     // with this, the follower indicates to the leader that it is 
     // capable of handling following term ids correctly.


### PR DESCRIPTION
### Scope & Purpose

Add back "doSoftLockOnly" attribute for shard sync protocol.
This attribute was previously always present when the follower sent its request to the leader, but it was unintentionally removed during the development of 3.7.16. the change has not been released in any version.
No other version was affected.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
