### PR TITLE
APM-217: deprecate the usage of fulltext indexes.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* APM-217: deprecate the usage of fulltext indexes.
+
 * Changed "arangosh" directory name to "client-tools", because the directory 
   contains the code for all client tools and not just arangosh.
 

--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index.md
@@ -43,7 +43,7 @@ create a non-unique index.
 the *unique* attribute with these types may lead to an error:
 
 - geo indexes
-- fulltext indexes
+- fulltext indexes (deprecated from ArangoDB 3.10 onwards)
 
 **Note**: Unique indexes on non-shard keys are not supported in a
 cluster.

--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index_fulltext.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index_fulltext.md
@@ -4,6 +4,11 @@
 
 @RESTHEADER{POST /_api/index#fulltext, Create fulltext index, createIndex#fulltext}
 
+@HINTS
+{% hint 'warning' %}
+The fulltext index type is deprecated from version 3.10 onwards.
+{% endhint %}
+
 @RESTQUERYPARAMETERS
 
 @RESTQUERYPARAM{collection,string,required}


### PR DESCRIPTION
### Scope & Purpose

https://arangodb.atlassian.net/browse/APM-217

APM-217: deprecate the usage of fulltext indexes.
This is a documentation-only PR.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/825

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
