### PR TITLE
Hotbackup blockage after DBServer restart

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,10 @@ v3.9.0 (XXXX-XX-XX)
 * Removed an invalid assertion that could be triggered during chaos testing in
   maintainer mode.
 
+* Cleanup and properly fail hotbackup upload and download jobs if a dbserver
+  fails or is restarted during the transfer. This gets rid of upload and download
+  blockages in these circumstances.
+
 * Simplify the tagging of EnumerateCollectionNodes and IndexNodes with the
   "read-own-writes" flag. Previously the tagging only happened after all query
   optimizations were completed, making the tag unavailable to the optimizer.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.9.0 (XXXX-XX-XX)
 -------------------
 
+* Cleanup and properly fail hotbackup upload and download jobs if a dbserver
+  fails or is restarted during the transfer. This gets rid of upload and download
+  blockages in these circumstances.
+
 * Upgraded bundled version of RocksDB to 6.27.
 
 * Improved sync protocol to commit after each chunk and get rid of potentially
@@ -8,10 +12,6 @@ v3.9.0 (XXXX-XX-XX)
 
 * Removed an invalid assertion that could be triggered during chaos testing in
   maintainer mode.
-
-* Cleanup and properly fail hotbackup upload and download jobs if a dbserver
-  fails or is restarted during the transfer. This gets rid of upload and download
-  blockages in these circumstances.
 
 * Simplify the tagging of EnumerateCollectionNodes and IndexNodes with the
   "read-own-writes" flag. Previously the tagging only happened after all query

--- a/arangod/Agency/AgencyStrings.h
+++ b/arangod/Agency/AgencyStrings.h
@@ -53,7 +53,7 @@ constexpr char const* PLAN_DATABASES = "Plan/Databases/";
 constexpr char const* PLAN_VIEWS = "Plan/Views/";
 constexpr char const* PLAN_ANALYZERS = "Plan/Analyzers/";
 
-constexpr char const* HOTBACKUP_TRANSFER_LOCKS = "/Target/Hotbackup/Transfers/";
+constexpr char const* HOTBACKUP_TRANSFER_LOCKS = "/Target/HotBackup/Transfers/";
 constexpr char const* HOTBACKUP_TRANSFER_JOBS = "/Target/HotBackup/TransferJobs/";
 constexpr char const* HOTBACKUP_KEY = "/Target/HotBackup/Create";
 

--- a/arangod/Agency/AgencyStrings.h
+++ b/arangod/Agency/AgencyStrings.h
@@ -53,6 +53,8 @@ constexpr char const* PLAN_DATABASES = "Plan/Databases/";
 constexpr char const* PLAN_VIEWS = "Plan/Views/";
 constexpr char const* PLAN_ANALYZERS = "Plan/Analyzers/";
 
+constexpr char const* HOTBACKUP_TRANSFER_LOCKS = "/Target/Hotbackup/Transfers/";
+constexpr char const* HOTBACKUP_TRANSFER_JOBS = "/Target/HotBackup/TransferJobs/";
 constexpr char const* HOTBACKUP_KEY = "/Target/HotBackup/Create";
 
 constexpr char const* PREC_IS_READ_LOCKED = "is-read-locked";

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1212,12 +1212,17 @@ bool Supervision::isShuttingDown() {
   return false;
 }
 
+std::string Supervision::serverHealthFunctional(Node const& snapshot,
+    std::string const& serverName) {
+  std::string const serverStatus(healthPrefix + serverName + "/Status");
+  return (snapshot.has(serverStatus)) ? snapshot.hasAsString(serverStatus).value()
+                                      : std::string();
+}
+
 // Guarded by caller
 std::string Supervision::serverHealth(std::string const& serverName) {
   _lock.assertLockedByCurrentThread();
-  std::string const serverStatus(healthPrefix + serverName + "/Status");
-  return (snapshot().has(serverStatus)) ? snapshot().hasAsString(serverStatus).value()
-                                        : std::string();
+  return Supervision::serverHealthFunctional(snapshot(), serverName);
 }
 
 // Guarded by caller
@@ -1662,6 +1667,10 @@ bool Supervision::handleJobs() {
       << "Begin cleanupHotbackupTransferJobs";
   cleanupHotbackupTransferJobs();
 
+  LOG_TOPIC("0892d", TRACE, Logger::SUPERVISION)
+      << "Begin failBrokenHotbackupTransferJobs";
+  failBrokenHotbackupTransferJobs();
+
   return true;
 }
 
@@ -1729,7 +1738,7 @@ void arangodb::consensus::cleanupHotbackupTransferJobsFunctional(
   // /Target/HotBackup/TransferJobs according to their time stamp.
   // We keep at most 100 transfer jobs which are completed.
   constexpr uint64_t maximalNumberTransferJobs = 100;
-  constexpr char const* prefix = "/Target/HotBackup/TransferJobs/";
+  constexpr char const* prefix = HOTBACKUP_TRANSFER_JOBS;
 
   auto static const noJobs = Node::Children{};
   auto const jobs = snapshot.hasAsChildren(prefix).value_or(noJobs).get();
@@ -1791,6 +1800,72 @@ void arangodb::consensus::cleanupHotbackupTransferJobsFunctional(
   }
 }
 
+// Guarded by caller
+void arangodb::consensus::failBrokenHotbackupTransferJobsFunctional(
+    Node const& snapshot,
+    std::shared_ptr<VPackBuilder> envelope) {
+  // This observes the hotbackup transfer jobs and declares those as failed
+  // whose responsible dbservers have crashed or have been shut down.
+  VPackArrayBuilder guard(envelope.get());
+  constexpr char const* prefix = HOTBACKUP_TRANSFER_JOBS;
+  auto const& jobs = snapshot.hasAsChildren(prefix);
+  if (jobs) {
+    for (auto const& p : jobs.value().get()) {
+      auto const& dbservers = p.second->hasAsChildren("DBServers");
+      if (!dbservers) {
+        continue;
+      }
+      for (auto const& pp : dbservers.value().get()) {
+        auto const& status = pp.second->hasAsString("Status");
+        if (!status) {
+          // Should not happen, just be cautious
+          continue;
+        }
+        if (status.value().compare("COMPLETED") == 0 ||
+            status.value().compare("FAILED") == 0 ||
+            status.value().compare("CANCELLED") == 0 ) {
+          // Nothing to do
+          continue;
+        }
+        bool found = false;
+        auto const& rebootId = pp.second->hasAsUInt(StaticStrings::RebootId);
+        auto const& lockLocation = pp.second->hasAsString(StaticStrings::LockLocation);
+        if (rebootId && lockLocation) {
+          if (!Supervision::verifyServerRebootID(
+                snapshot, pp.first, rebootId.value(), found)) {
+            // Cancel job, set status to FAILED and release lock:
+            VPackArrayBuilder guard(envelope.get());
+            // Action part:
+            {
+              VPackObjectBuilder guard2(envelope.get());
+              envelope->add(VPackValue(
+                    prefix + p.first + "/DBServers/" + pp.first + "/Status"));
+              {
+                VPackObjectBuilder guard(envelope.get());
+                envelope->add("op", VPackValue("set"));
+                envelope->add("new", VPackValue("FAILED"));
+              }
+              envelope->add(VPackValue(std::string(HOTBACKUP_TRANSFER_LOCKS) + lockLocation.value()));
+              {
+                VPackObjectBuilder guard(envelope.get());
+                envelope->add("op", VPackValue("delete"));
+              }
+            }
+            // Precondition part: status is unchanged
+            // This guards us against the case that a DBserver has finished a job and
+            // was then shut down since we last renewed our snapshot.
+            {
+              VPackObjectBuilder guard2(envelope.get());
+              envelope->add(prefix + p.first + "/DBServers/" + pp.first + "/Status",
+                  VPackValue(status.value()));
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 void Supervision::cleanupHotbackupTransferJobs() {
   _lock.assertLockedByCurrentThread();
 
@@ -1806,6 +1881,40 @@ void Supervision::cleanupHotbackupTransferJobs() {
 
     if (!res.accepted || (res.indices.size() == 1 && res.indices[0] == 0)) {
       LOG_TOPIC("1232b", INFO, Logger::SUPERVISION) << "Failed to remove old transfer jobs: " << envelope->toJson();
+    }
+  }
+}
+
+void Supervision::failBrokenHotbackupTransferJobs() {
+  _lock.assertLockedByCurrentThread();
+
+  auto envelope = std::make_shared<VPackBuilder>();
+  arangodb::consensus::failBrokenHotbackupTransferJobsFunctional(
+      snapshot(), envelope);
+  if (envelope->slice().length() > 0) {
+    trans_ret_t res = generalTransaction(_agent, *envelope);
+
+    bool good = true;
+    VPackSlice resSlice = res.result->slice();
+    if (res.accepted) {
+      if (!resSlice.isArray()) {
+        good = false;
+      } else {
+        for (size_t i = 0; i < resSlice.length(); ++i) {
+          if (!resSlice[i].isNumber()) {
+            good = false;
+          } else {
+            uint64_t j = resSlice[i].getNumber<uint64_t>();
+            if (j == 0) {
+              good = false;
+            }
+          }
+        }
+      }
+    }
+    if (!good) {
+      LOG_TOPIC("1232c", INFO, Logger::SUPERVISION) << "Failed to fail bad transfer jobs: " << envelope->toJson()
+        << ", response: " << (res.accepted ? resSlice.toJson() : std::string());
     }
   }
 }
@@ -1902,12 +2011,13 @@ void Supervision::workJobs() {
   }
 }
 
-bool Supervision::verifyServerRebootID(std::string const& serverID,
-                                            uint64_t wantedRebootID, bool& serverFound) {
-  // check if the coordinator exists in health
-  std::string const& health = serverHealth(serverID);
+bool Supervision::verifyServerRebootID(Node const& snapshot,
+                                       std::string const& serverID,
+                                       uint64_t wantedRebootID, bool& serverFound) {
+  // check if the server exists in health
+  std::string const& health = serverHealthFunctional(snapshot, serverID);
   LOG_TOPIC("44432", DEBUG, Logger::SUPERVISION)
-      << "verifyServerRebootID: coordinatorID=" << serverID << " health=" << health;
+      << "verifyServerRebootID: serverID=" << serverID << " health=" << health;
 
   // if the server is not found, health is an empty string
   serverFound = !health.empty();
@@ -1917,9 +2027,9 @@ bool Supervision::verifyServerRebootID(std::string const& serverID,
 
   // now lookup reboot id
   std::optional<uint64_t> rebootID =
-      snapshot().hasAsUInt(curServersKnown + serverID + "/" + StaticStrings::RebootId);
+      snapshot.hasAsUInt(curServersKnown + serverID + "/" + StaticStrings::RebootId);
   LOG_TOPIC("54326", DEBUG, Logger::SUPERVISION)
-      << "verifyCoordinatorRebootID: rebootId=" << rebootID.value_or(0)
+      << "verifyServerRebootID: rebootId=" << rebootID.value_or(0)
       << " bool=" << rebootID.has_value();
   return rebootID && *rebootID == wantedRebootID;
 }
@@ -2115,7 +2225,7 @@ void Supervision::resourceCreatorLost(
 
 
   if (rebootID && coordinatorID) {
-    keepResource = Supervision::verifyServerRebootID(*coordinatorID, *rebootID, coordinatorFound);
+    keepResource = Supervision::verifyServerRebootID(snapshot(), *coordinatorID, *rebootID, coordinatorFound);
     // incomplete data, should not happen
   } else {
     //          v---- Please note this awesome log-id

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1772,7 +1772,7 @@ void arangodb::consensus::cleanupHotbackupTransferJobsFunctional(
     if (!completed) {
       continue;
     }
-    auto created = p.second->hasAsString("timestamp");
+    auto created = p.second->hasAsString("Timestamp");
     if (created) {
       v.emplace_back(p.first, *created);
     } else {

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1758,18 +1758,23 @@ void arangodb::consensus::cleanupHotbackupTransferJobsFunctional(
     if (!dbservers) {
       continue;
     }
+    // Now check if everything is completed or failed, or if the job
+    // has no status information whatsoever:
     bool completed = true;
+    bool hasStatus = false;
     for (auto const& pp : dbservers->get()) {
       auto const& status = pp.second->hasAsString("Status");
       if (!status) {
         completed = false;
       } else {
-        if (status->compare("COMPLETED") != 0) {
+        hasStatus = true;
+        if (status->compare("COMPLETED") != 0 ||
+            status->compare("FAILED") != 0) {
           completed = false;
         }
       }
     }
-    if (!completed) {
+    if ((!completed && hasStatus) || !hasStatus) {
       continue;
     }
     auto created = p.second->hasAsString("Timestamp");

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1768,20 +1768,19 @@ void arangodb::consensus::cleanupHotbackupTransferJobsFunctional(
         completed = false;
       } else {
         hasStatus = true;
-        if (status->compare("COMPLETED") != 0 ||
+        if (status->compare("COMPLETED") != 0 &&
             status->compare("FAILED") != 0) {
           completed = false;
         }
       }
     }
-    if ((!completed && hasStatus) || !hasStatus) {
-      continue;
-    }
-    auto created = p.second->hasAsString("Timestamp");
-    if (created) {
-      v.emplace_back(p.first, *created);
-    } else {
-      v.emplace_back(p.first, "1970");  // will be sorted very early
+    if (completed || !hasStatus) {
+      auto created = p.second->hasAsString("Timestamp");
+      if (created) {
+        v.emplace_back(p.first, *created);
+      } else {
+        v.emplace_back(p.first, "1970");  // will be sorted very early
+      }
     }
   }
   std::sort(v.begin(), v.end(), [](keyDate const& a, keyDate const& b) -> bool {

--- a/arangod/Agency/Supervision.h
+++ b/arangod/Agency/Supervision.h
@@ -46,7 +46,7 @@ struct check_t {
 // This is the functional version which actually does the work, it is
 // called by the private method Supervision::enforceReplication and the
 // unit tests:
-void enforceReplicationFunctional(Node const& snapshot, 
+void enforceReplicationFunctional(Node const& snapshot,
                                   uint64_t& jobId,
                                   std::shared_ptr<VPackBuilder> envelope);
 
@@ -54,7 +54,14 @@ void enforceReplicationFunctional(Node const& snapshot,
 // called by the private method Supervision::cleanupHotbackupTransferJobs
 // and the unit tests:
 void cleanupHotbackupTransferJobsFunctional(
-    Node const& snapshot, 
+    Node const& snapshot,
+    std::shared_ptr<VPackBuilder> envelope);
+
+// This is the second functional version which actually does the work, it is
+// called by the private method Supervision::cleanupHotbackupTransferJobs
+// and the unit tests:
+void failBrokenHotbackupTransferJobsFunctional(
+    Node const& snapshot,
     std::shared_ptr<VPackBuilder> envelope);
 
 class Supervision : public arangodb::Thread {
@@ -142,6 +149,13 @@ class Supervision : public arangodb::Thread {
     _agencyPrefix = prefix;
   }
 
+  static std::string serverHealthFunctional(Node const& snapshot,
+                                            std::string const&);
+
+  static bool verifyServerRebootID(Node const& snapshot,
+                                   std::string const& serverID,
+                                   uint64_t wantedRebootID, bool& serverFound);
+
  private:
 
   /// @brief get reference to the spearhead snapshot
@@ -214,6 +228,9 @@ class Supervision : public arangodb::Thread {
   /// @brief Cleanup old hotbackup transfer jobs
   void cleanupHotbackupTransferJobs();
 
+  /// @brief Fail hotbackup transfer jobs when dbservers have failed
+  void failBrokenHotbackupTransferJobs();
+
   // @brief these servers have gone for too long without any responsibility
   //        and this are safely removable and so they are
   void cleanupExpiredServers(Node const&, Node const&);
@@ -258,8 +275,6 @@ class Supervision : public arangodb::Thread {
 
   bool handleJobs();
   void handleShutdown();
-  bool verifyServerRebootID(std::string const& serverID,
-                                 uint64_t wantedRebootID, bool& serverFound);
   void deleteBrokenDatabase(std::string const& database, std::string const& coordinatorID,
                             uint64_t rebootID, bool coordinatorFound);
   void deleteBrokenCollection(std::string const& database, std::string const& collection,

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -205,6 +205,7 @@ std::string const StaticStrings::HLCHeader("x-arango-hlc");
 std::string const StaticStrings::KeepAlive("Keep-Alive");
 std::string const StaticStrings::LeaderEndpoint("x-arango-endpoint");
 std::string const StaticStrings::Location("location");
+std::string const StaticStrings::LockLocation("lockLocation");
 std::string const StaticStrings::NoSniff("nosniff");
 std::string const StaticStrings::Origin("origin");
 std::string const StaticStrings::PotentialDirtyRead(

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -191,6 +191,7 @@ class StaticStrings {
   static std::string const KeepAlive;
   static std::string const LeaderEndpoint;
   static std::string const Location;
+  static std::string const LockLocation;
   static std::string const NoSniff;
   static std::string const Origin;
   static std::string const PotentialDirtyRead;

--- a/tests/Agency/SupervisionTest.cpp
+++ b/tests/Agency/SupervisionTest.cpp
@@ -480,6 +480,39 @@ TEST_F(SupervisionTestClass, cleanup_hotback_transfer_jobs) {
   }
 }
 
+TEST_F(SupervisionTestClass, cleanup_hotback_transfer_jobs_empty) {
+  for (size_t i = 0; i < 200; ++i) {
+    char const* job =
+          R"=(
+{
+  "DBServers": {
+    "PRMR-b9b08faa-6286-4745-9c37-15e85b3a7d27": {
+    },
+    "PRMR-a0b13c71-2472-4985-bc48-ffa091d26e03": {
+    }
+  },
+  "BackupId": "2021-02-25T12.38.11Z_c5656558-54ac-42bd-8851-08969d1a53f0",
+)=";
+    std::string st = std::string(job)
+        + "\"Timestamp\": \"" + std::to_string(1900 + i)
+        + "-02-25T12:38:29Z\"\n}";
+    _snapshot("/Target/HotBackup/TransferJobs/" + std::to_string(1000000 + i))
+      = createNode(st.c_str());
+  }
+  std::shared_ptr<VPackBuilder> envelope = runCleanupHotbackupTransferJobs(
+      _snapshot);
+  VPackSlice content = envelope->slice();
+  EXPECT_EQ(content.length(), 100);
+  // We expect the first 100 jobs to be deleted:
+  for (size_t i = 0; i < 100; ++i) {
+    std::string jobId = "/Target/HotBackup/TransferJobs/" + std::to_string(1000000 + i);
+    VPackSlice guck = content.get(jobId);
+    EXPECT_TRUE(guck.isObject());
+    EXPECT_TRUE(guck.hasKey("op"));
+    EXPECT_EQ(guck.get("op").copyString(), "delete");
+  }
+}
+
 TEST_F(SupervisionTestClass, fail_hotbackup_transfer_jobs) {
   // We put in three transfer jobs. One of the DBServers is healthy
   // and its rebootId has not changed ==> nothing ought to be done.

--- a/tests/Agency/SupervisionTest.cpp
+++ b/tests/Agency/SupervisionTest.cpp
@@ -469,3 +469,140 @@ TEST_F(SupervisionTestClass, cleanup_hotback_transfer_jobs) {
   EXPECT_EQ(content.length(), 100);
 }
 
+TEST_F(SupervisionTestClass, fail_hotbackup_transfer_jobs) {
+  // We put in three transfer jobs. One of the DBServers is healthy
+  // and its rebootId has not changed ==> nothing ought to be done.
+  // For the other ones either the dbserver is FAILED or its rebootId
+  // has changed, in this case we want the job aborted and the lock
+  // removed.
+  _snapshot("/Target/HotBackup/TransferJobs/" + std::to_string(1234567))
+      = createNode(R"=(
+{
+  "Timestamp": "2021-02-25T12:38:29Z",
+  "DBServers": {
+    "PRMR-b9b08faa-6286-4745-9c37-15e85b3a7d27": {
+      "Progress": {
+        "Total": 5,
+        "Time": "2021-02-25T12:38:29Z",
+        "Done": 4
+      },
+      "rebootId": 1,
+      "lockLocation": "Upload/local:/tmp/backups/2021-11-26T09.21.00Z_c95725ed-7572-4dac-bc8d-ea786d05f833/PRMR-b9b08faa-6286-4745-9c37-15e85b3a7d27",
+      "Status": "RUNNING"
+    },
+    "PRMR-fe142532-2536-426f-23aa-123534feb253": {
+      "Progress": {
+        "Total": 5,
+        "Time": "2021-02-25T12:38:29Z",
+        "Done": 2
+      },
+      "rebootId": 1,
+      "lockLocation": "Upload/local:/tmp/backups/2021-11-26T09.21.00Z_c95725ed-7572-4dac-bc8d-ea786d05f833/PRMR-fe142532-2536-426f-23aa-123534feb253",
+      "Status": "RUNNING"
+    },
+    "PRMR-a0b13c71-2472-4985-bc48-ffa091d26e03": {
+      "Progress": {
+        "Total": 5,
+        "Time": "2021-02-25T12:38:29Z",
+        "Done": 3
+      },
+      "rebootId": 1,
+      "lockLocation": "Upload/local:/tmp/backups/2021-11-26T09.21.00Z_c95725ed-7572-4dac-bc8d-ea786d05f833/PRMR-a0b13c71-2472-4985-bc48-ffa091d26e03",
+      "Status": "RUNNING"
+    }
+  },
+  "BackupId": "2021-02-25T12.38.11Z_c5656558-54ac-42bd-8851-08969d1a53f0"
+}
+        )=");
+  _snapshot("/Current/ServersKnown")
+      = createNode(R"=(
+{
+  "PRMR-b9b08faa-6286-4745-9c37-15e85b3a7d27": {
+    "rebootId": 1
+  },
+  "PRMR-fe142532-2536-426f-23aa-123534feb253": {
+    "rebootId": 1
+  },
+  "PRMR-a0b13c71-2472-4985-bc48-ffa091d26e03": {
+    "rebootId": 2
+  }
+}
+        )=");
+  _snapshot("/Supervision/Health")
+      = createNode(R"=(
+{
+  "PRMR-b9b08faa-6286-4745-9c37-15e85b3a7d27": {
+    "ShortName": "DBServer0001",
+    "Endpoint": "tcp://[::1]:8629",
+    "Host": "1a00546e9ae740aeadf30f0090f43b8d",
+    "SyncStatus": "SERVING",
+    "Status": "GOOD",
+    "Version": "3.8.4",
+    "Engine": "rocksdb",
+    "Timestamp": "2021-11-26T11:05:22Z",
+    "SyncTime": "2021-11-26T11:05:22Z",
+    "LastAckedTime": "2021-11-26T11:05:22Z"
+  },
+  "PRMR-fe142532-2536-426f-23aa-123534feb253": {
+    "ShortName": "DBServer0002",
+    "Endpoint": "tcp://[::1]:8630",
+    "Host": "1a00546e9ae740aeadf30f0090f43b8d",
+    "SyncStatus": "SERVING",
+    "Status": "FAILED",
+    "Version": "3.8.4",
+    "Engine": "rocksdb",
+    "Timestamp": "2021-11-26T11:05:22Z",
+    "SyncTime": "2021-11-26T11:05:22Z",
+    "LastAckedTime": "2021-11-26T11:05:22Z"
+  },
+  "PRMR-a0b13c71-2472-4985-bc48-ffa091d26e03": {
+    "ShortName": "DBServer0003",
+    "Endpoint": "tcp://[::1]:8631",
+    "Host": "1a00546e9ae740aeadf30f0090f43b8d",
+    "SyncStatus": "SERVING",
+    "Status": "GOOD",
+    "Version": "3.8.4",
+    "Engine": "rocksdb",
+    "Timestamp": "2021-11-26T11:05:22Z",
+    "SyncTime": "2021-11-26T11:05:22Z",
+    "LastAckedTime": "2021-11-26T11:05:22Z"
+  }
+}
+        )=");
+  auto envelope = std::make_shared<VPackBuilder>();
+  arangodb::consensus::failBrokenHotbackupTransferJobsFunctional(
+    _snapshot, envelope);
+  VPackSlice content = envelope->slice();
+  EXPECT_TRUE(content.isArray());
+  EXPECT_EQ(content.length(), 2);  // two transactions
+
+  VPackSlice trx = content[0];
+  EXPECT_TRUE(trx.isArray());
+  EXPECT_EQ(trx.length(), 2);  // with precondition
+  VPackSlice action = trx[0];
+  VPackSlice guck = action.get("/Target/HotBackup/TransferJobs/1234567/DBServers/PRMR-fe142532-2536-426f-23aa-123534feb253/Status");
+  EXPECT_TRUE(guck.isObject());
+  EXPECT_EQ(guck.length(), 2);
+  EXPECT_EQ(guck["op"].copyString(), "set");
+  EXPECT_EQ(guck["new"].copyString(), "FAILED");
+  guck = action.get("/Target/Hotbackup/Transfers/Upload/local:/tmp/backups/2021-11-26T09.21.00Z_c95725ed-7572-4dac-bc8d-ea786d05f833/PRMR-fe142532-2536-426f-23aa-123534feb253");
+  EXPECT_TRUE(guck.isObject());
+  EXPECT_EQ(guck["op"].copyString(), "delete");
+  VPackSlice precond = trx[1];
+  guck = precond.get("/Target/HotBackup/TransferJobs/1234567/DBServers/PRMR-fe142532-2536-426f-23aa-123534feb253/Status");
+  EXPECT_EQ(guck.copyString(), "RUNNING");
+
+  trx = content[1];
+  action = trx[0];
+  guck = action.get("/Target/HotBackup/TransferJobs/1234567/DBServers/PRMR-a0b13c71-2472-4985-bc48-ffa091d26e03/Status");
+  EXPECT_TRUE(guck.isObject());
+  EXPECT_EQ(guck["op"].copyString(), "set");
+  EXPECT_EQ(guck["new"].copyString(), "FAILED");
+  guck = action.get("/Target/Hotbackup/Transfers/Upload/local:/tmp/backups/2021-11-26T09.21.00Z_c95725ed-7572-4dac-bc8d-ea786d05f833/PRMR-a0b13c71-2472-4985-bc48-ffa091d26e03");
+  EXPECT_TRUE(guck.isObject());
+  EXPECT_EQ(guck["op"].copyString(), "delete");
+  precond = trx[1];
+  guck = precond.get("/Target/HotBackup/TransferJobs/1234567/DBServers/PRMR-a0b13c71-2472-4985-bc48-ffa091d26e03/Status");
+  EXPECT_EQ(guck.copyString(), "RUNNING");
+}
+

--- a/tests/Agency/SupervisionTest.cpp
+++ b/tests/Agency/SupervisionTest.cpp
@@ -585,7 +585,7 @@ TEST_F(SupervisionTestClass, fail_hotbackup_transfer_jobs) {
   EXPECT_EQ(guck.length(), 2);
   EXPECT_EQ(guck["op"].copyString(), "set");
   EXPECT_EQ(guck["new"].copyString(), "FAILED");
-  guck = action.get("/Target/Hotbackup/Transfers/Upload/local:/tmp/backups/2021-11-26T09.21.00Z_c95725ed-7572-4dac-bc8d-ea786d05f833/PRMR-fe142532-2536-426f-23aa-123534feb253");
+  guck = action.get("/Target/HotBackup/Transfers/Upload/local:/tmp/backups/2021-11-26T09.21.00Z_c95725ed-7572-4dac-bc8d-ea786d05f833/PRMR-fe142532-2536-426f-23aa-123534feb253");
   EXPECT_TRUE(guck.isObject());
   EXPECT_EQ(guck["op"].copyString(), "delete");
   VPackSlice precond = trx[1];
@@ -598,7 +598,7 @@ TEST_F(SupervisionTestClass, fail_hotbackup_transfer_jobs) {
   EXPECT_TRUE(guck.isObject());
   EXPECT_EQ(guck["op"].copyString(), "set");
   EXPECT_EQ(guck["new"].copyString(), "FAILED");
-  guck = action.get("/Target/Hotbackup/Transfers/Upload/local:/tmp/backups/2021-11-26T09.21.00Z_c95725ed-7572-4dac-bc8d-ea786d05f833/PRMR-a0b13c71-2472-4985-bc48-ffa091d26e03");
+  guck = action.get("/Target/HotBackup/Transfers/Upload/local:/tmp/backups/2021-11-26T09.21.00Z_c95725ed-7572-4dac-bc8d-ea786d05f833/PRMR-a0b13c71-2472-4985-bc48-ffa091d26e03");
   EXPECT_TRUE(guck.isObject());
   EXPECT_EQ(guck["op"].copyString(), "delete");
   precond = trx[1];

--- a/tests/Agency/SupervisionTest.cpp
+++ b/tests/Agency/SupervisionTest.cpp
@@ -475,7 +475,7 @@ TEST_F(SupervisionTestClass, fail_hotbackup_transfer_jobs) {
   // For the other ones either the dbserver is FAILED or its rebootId
   // has changed, in this case we want the job aborted and the lock
   // removed.
-  _snapshot("/Target/HotBackup/TransferJobs/" + std::to_string(1234567))
+  _snapshot.getOrCreate("/Target/HotBackup/TransferJobs/" + std::to_string(1234567))
       = createNode(R"=(
 {
   "Timestamp": "2021-02-25T12:38:29Z",
@@ -514,7 +514,7 @@ TEST_F(SupervisionTestClass, fail_hotbackup_transfer_jobs) {
   "BackupId": "2021-02-25T12.38.11Z_c5656558-54ac-42bd-8851-08969d1a53f0"
 }
         )=");
-  _snapshot("/Current/ServersKnown")
+  _snapshot.getOrCreate("/Current/ServersKnown")
       = createNode(R"=(
 {
   "PRMR-b9b08faa-6286-4745-9c37-15e85b3a7d27": {
@@ -528,7 +528,7 @@ TEST_F(SupervisionTestClass, fail_hotbackup_transfer_jobs) {
   }
 }
         )=");
-  _snapshot("/Supervision/Health")
+  _snapshot.getOrCreate("/Supervision/Health")
       = createNode(R"=(
 {
   "PRMR-b9b08faa-6286-4745-9c37-15e85b3a7d27": {

--- a/tests/Agency/SupervisionTest.cpp
+++ b/tests/Agency/SupervisionTest.cpp
@@ -496,7 +496,7 @@ TEST_F(SupervisionTestClass, cleanup_hotback_transfer_jobs_empty) {
     std::string st = std::string(job)
         + "\"Timestamp\": \"" + std::to_string(1900 + i)
         + "-02-25T12:38:29Z\"\n}";
-    _snapshot("/Target/HotBackup/TransferJobs/" + std::to_string(1000000 + i))
+    _snapshot.getOrCreate("/Target/HotBackup/TransferJobs/" + std::to_string(1000000 + i))
       = createNode(st.c_str());
   }
   std::shared_ptr<VPackBuilder> envelope = runCleanupHotbackupTransferJobs(


### PR DESCRIPTION
This is a forward-port from 3.8 of https://github.com/arangodb/arangodb/pull/15230

Add proper cleanup if a dbserver is restarted, shut down or crashes
during a hotbackup upload or download job. In this case we need to
detect this in the Supervision by looking at the rebootId, report
the upload or download job for this DBServer as failed, and clear the
lock for this operation and its destination.

The problem was that no rebootId was saved with the job, no cleanup
routine existed and the destination lock could remain, which would
prevent successful retries by the operator in production.
Scope & Purpose

(Please describe the changes in this PR for reviewers - mandatory)

    [*] hankey Bugfix (requires CHANGELOG entry)
    [*] book CHANGELOG entry made

Backports:

    [*] this is the forward port from 3.8 for 3.9

Related Information

(Please reference tickets / specification / other PRs etc)

    [*] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-652

Testing & Verification

(Please pick either of the following options)

    [*] The behavior in this PR was manually tested
    [*] This PR adds tests that were used to verify all changes:
        [*] Added new C++ Unit tests

