### PR TITLE
Changed flag name from --concurrency to --threads

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Changed arangobench concurrency flag name from `--concurrency` to `--threads`.
+
 * APM-217: deprecate the usage of fulltext indexes.
 
 * Improve visibility in case of potential data corruption between primary

--- a/client-tools/Benchmark/BenchFeature.h
+++ b/client-tools/Benchmark/BenchFeature.h
@@ -59,7 +59,7 @@ class BenchFeature final : public application_features::ApplicationFeature {
   void start() override final;
 
   bool async() const { return _async; }
-  uint64_t concurrency() const { return _concurrency; }
+  uint64_t threadCount() const { return _threadCount; }
   uint64_t operations() const { return _operations; }
   uint64_t batchSize() const { return _batchSize; }
   bool keepAlive() const { return _keepAlive; }
@@ -89,7 +89,7 @@ class BenchFeature final : public application_features::ApplicationFeature {
   void setupHistogram(std::stringstream& pp);
   void updateStatsValues(std::stringstream& pp, VPackBuilder& builder, std::vector<std::unique_ptr<arangodb::arangobench::BenchmarkThread>> const&  threads, arangodb::arangobench::BenchmarkStats& totalStats);
 
-  uint64_t _concurrency;
+  uint64_t _threadCount;
   uint64_t _operations;
   uint64_t _realOperations;
   uint64_t _batchSize;

--- a/js/client/modules/@arangodb/testsuites/arangobench.js
+++ b/js/client/modules/@arangodb/testsuites/arangobench.js
@@ -58,68 +58,68 @@ const testPaths = {
 const benchTodos = [{
   'histogram.generate': true,
   'requests': '10000',
-  'concurrency': '2',
+  'threads': '2',
   'test-case': 'version',
   'keep-alive': 'false'
 }, {
   'histogram.generate': true,
   'requests': '10000',
-  'concurrency': '2',
+  'threads': '2',
   'test-case': 'version',
   'async': 'true'
 }, {
   'histogram.generate': true,
   'requests': '20000',
-  'concurrency': '1',
+  'threads': '1',
   'test-case': 'version',
   'async': 'true'
 }, {
   'histogram.generate': true,
   'requests': '1000',
-  'concurrency': '2',
+  'threads': '2',
   'test-case': 'version',
   'batch-size': '16'
 }, {
   'histogram.generate': true,
   'requests': '100',
-  'concurrency': '1',
+  'threads': '1',
   'test-case': 'version',
   'batch-size': '0'
 }, {
   'histogram.generate': true,
   'requests': '100',
-  'concurrency': '2',
+  'threads': '2',
   'test-case': 'document',
   'batch-size': '10',
   'complexity': '1'
 }, {
   'histogram.generate': true,
   'requests': '2000',
-  'concurrency': '2',
+  'threads': '2',
   'test-case': 'crud',
   'complexity': '1'
 }, {
   'histogram.generate': true,
   'requests': '4000',
-  'concurrency': '2',
+  'threads': '2',
   'test-case': 'crud-append',
   'complexity': '4'
 }, {
   'histogram.generate': true,
   'requests': '4000',
-  'concurrency': '2',
+  'threads': '2',
   'test-case': 'edge',
   'complexity': '4'
 }, {
   'histogram.generate': true,
   'requests': '5000',
-  'concurrency': '2',
+  'threads': '2',
   'test-case': 'persistent-index',
   'complexity': '1'
 },{
   'histogram.generate': true,
   'requests': '1',
-  'concurrency': '1',
+  'threads': '1',
   'test-case': 'version',
   'keep-alive': 'true',
   'server.database': 'arangobench_testdb',
@@ -127,7 +127,7 @@ const benchTodos = [{
 },{
   'histogram.generate': true,
   'requests': '100',
-  'concurrency': '1',
+  'threads': '1',
   'test-case': 'custom-query',
   'custom-query': 'RETURN 1',
   'keep-alive': 'true',
@@ -137,7 +137,7 @@ const benchTodos = [{
 },{
   'histogram.generate': true,
   'requests': '100',
-  'concurrency': '1',
+  'threads': '1',
   'test-case': 'version',
   'keep-alive': 'true',
   // test with Unicode database name


### PR DESCRIPTION
### Scope & Purpose

In arangobench, the concurrency flag is called `--concurrency`, but, in the other tools, it is called `--threads`, so this PR changes arangobench flag name to `--threads` to be in accordance with the other tools.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

No backports needed

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/828
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ x] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [x] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
