### PR TITLE
ES-1006 Correcting documentation for server admin

### DIFF
--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_server_mode.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_server_mode.md
@@ -10,7 +10,7 @@ a field `mode` with the value `readonly` or `default`. In a read-only server
 all write operations will fail with an error code of `1004` (_ERROR_READ_ONLY_).
 Creating or dropping of databases and collections will also fail with error code `11` (_ERROR_FORBIDDEN_).
 
-This is *not* a public API so it requires authentication.
+This API requires authentication.
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_server_mode.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_server_mode.md
@@ -10,7 +10,7 @@ a field `mode` with the value `readonly` or `default`. In a read-only server
 all write operations will fail with an error code of `1004` (_ERROR_READ_ONLY_).
 Creating or dropping of databases and collections will also fail with error code `11` (_ERROR_FORBIDDEN_).
 
-This is a public API so it does *not* require authentication.
+This is *not* a public API so it requires authentication.
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_server_tls.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_server_tls.md
@@ -28,7 +28,7 @@ has a subset of the following attributes (whatever is appropriate):
     but not `clientCA`), this field is present and contains a
     JSON string with the SHA256 of the private key.
 
-This is a protected API and can only be executed with superuser rights.
+This is a public API so it does not require authentication.
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_server_tls.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_server_tls.md
@@ -28,7 +28,7 @@ has a subset of the following attributes (whatever is appropriate):
     but not `clientCA`), this field is present and contains a
     JSON string with the SHA256 of the private key.
 
-This is a public API so it does not require authentication.
+This is a public API so it does *not* require authentication.
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_server_tls.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_server_tls.md
@@ -28,7 +28,7 @@ has a subset of the following attributes (whatever is appropriate):
     but not `clientCA`), this field is present and contains a
     JSON string with the SHA256 of the private key.
 
-This is a public API so it does *not* require authentication.
+This API requires authentication.
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_server_tls.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_server_tls.md
@@ -28,7 +28,7 @@ has a subset of the following attributes (whatever is appropriate):
     but not `clientCA`), this field is present and contains a
     JSON string with the SHA256 of the private key.
 
-This is a public API so it does *not* require authentication.
+This is a protected API and can only be executed with superuser rights.
 
 @RESTRETURNCODES
 


### PR DESCRIPTION
### Scope & Purpose

Corrected documentation for admin server to reflect that the end point is protected.


#### Backports:


- [ ] Backport for 3.8: *[PR for 3.8](https://github.com/arangodb/arangodb/pull/15251)*
- [ ] Backport for 3.7: *[PR for 3.7](https://github.com/arangodb/arangodb/pull/15250)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools

Link to Jenkins PR run:

### Documentation

> All new features should be accompanied by corresponding documentation. 
> Bugs and features should furthermore be documented in the CHANGELOG so that
> support, end users, and other developers have a concise overview. 

- [ ] Added entry to *Release Notes* 
- [ ] Added a new section in the *Manual* 
- [ ] Added a new section in the *HTTP API* 
- [ ] Added *Swagger examples* for the HTTP API  
- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries

### External contributors / CLA Note 

Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
