### PR TITLE
Fixing clang-13 linker error when building tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(fuertetest
     arango
     arango_v8server
     arango_v8
+    arangoserver
     ${MSVC_LIBS}
     ${OPENSSL_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}


### PR DESCRIPTION
### Scope & Purpose

When compiling with clang-13 on Ubuntu 20.04 I got some linking errors during fuertetest linking.
This is due to a missing dependency. Example of one such error:
```
ld.lld: error: undefined symbol: arangodb::ServerState::instance()
>>> referenced by RocksDBIndex.cpp:178 (/home/apetenchea/work/branches/arangodb-clang/arangod/RocksDBEngine/RocksDBIndex.cpp:178)
```
The fix is to add **arangoserver** as a dependency to **fuertetest**.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
