### PR TITLE
Fixed a potential use-after-free on Windows.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fix GitHub issue #15084. Fixed a potential use-after-free on Windows for
+  queries that used the NeighborsEnumerator (though other PathEnumerators
+  might have been affected as well).
+
 * BTS-624: The `move-calculations-up` optimization rule is now also applied to
   subqueries, when they don't have dependencies on the outer nodes, don't have
   modification nodes and don't read their own writes. This fixed the execution

--- a/arangod/Cluster/ClusterTraverser.cpp
+++ b/arangod/Cluster/ClusterTraverser.cpp
@@ -90,6 +90,7 @@ void ClusterTraverser::clear() {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   TRI_ASSERT(!_vertexGetter->pointsIntoTraverserCache());
 #endif
+  _enumerator->clear();
   traverserCache()->clear();
 }
 

--- a/arangod/Graph/BreadthFirstEnumerator.cpp
+++ b/arangod/Graph/BreadthFirstEnumerator.cpp
@@ -56,9 +56,7 @@ BreadthFirstEnumerator::~BreadthFirstEnumerator() {
   _opts->resourceMonitor().decreaseMemoryUsage(_schreier.capacity() * pathStepSize());
 }
 
-void BreadthFirstEnumerator::setStartVertex(arangodb::velocypack::StringRef startVertex) {
-  PathEnumerator::setStartVertex(startVertex);
-
+void BreadthFirstEnumerator::clear() {
   _schreier.clear();
   _schreierIndex = 0;
   _lastReturned = 0;
@@ -66,7 +64,13 @@ void BreadthFirstEnumerator::setStartVertex(arangodb::velocypack::StringRef star
   _toSearch.clear();
   _currentDepth = 0;
   _toSearchPos = 0;
+}
 
+void BreadthFirstEnumerator::setStartVertex(arangodb::velocypack::StringRef startVertex) {
+  PathEnumerator::setStartVertex(startVertex);
+  
+  clear();
+  
   growStorage();
   _schreier.emplace_back(startVertex);
   _toSearch.emplace_back(NextStep(0));

--- a/arangod/Graph/BreadthFirstEnumerator.h
+++ b/arangod/Graph/BreadthFirstEnumerator.h
@@ -105,6 +105,8 @@ class BreadthFirstEnumerator final : public arangodb::traverser::PathEnumerator 
 
   ~BreadthFirstEnumerator();
 
+  void clear() final;
+
   void setStartVertex(arangodb::velocypack::StringRef startVertex) override;
 
   /// @brief Get the next Path element from the traversal.

--- a/arangod/Graph/NeighborsEnumerator.cpp
+++ b/arangod/Graph/NeighborsEnumerator.cpp
@@ -43,15 +43,19 @@ NeighborsEnumerator::NeighborsEnumerator(Traverser* traverser, TraverserOptions*
   TRI_ASSERT(!opts->hasDepthLookupInfo());
 }
 
-void NeighborsEnumerator::setStartVertex(arangodb::velocypack::StringRef startVertex) {
-  PathEnumerator::setStartVertex(startVertex);
-
+void NeighborsEnumerator::clear() {
   _allFound.clear();
   _currentDepth.clear();
   _lastDepth.clear();
   _iterator = _currentDepth.end();
   _toPrune.clear();
   _searchDepth = 0;
+}
+
+void NeighborsEnumerator::setStartVertex(arangodb::velocypack::StringRef startVertex) {
+  PathEnumerator::setStartVertex(startVertex);
+
+  clear();
 
   _allFound.emplace(startVertex);
   _currentDepth.insert(startVertex);

--- a/arangod/Graph/NeighborsEnumerator.h
+++ b/arangod/Graph/NeighborsEnumerator.h
@@ -48,6 +48,8 @@ class NeighborsEnumerator final : public arangodb::traverser::PathEnumerator {
 
   ~NeighborsEnumerator() = default;
 
+  void clear() final;
+
   void setStartVertex(arangodb::velocypack::StringRef startVertex) override;
 
   /// @brief Get the next Path element from the traversal.

--- a/arangod/Graph/PathEnumerator.h
+++ b/arangod/Graph/PathEnumerator.h
@@ -119,6 +119,8 @@ class PathEnumerator {
 
   virtual ~PathEnumerator();
 
+  virtual void clear() = 0;
+
   /// @brief set start vertex and reset
   /// note that the caller *must* guarantee that the string data pointed to by
   /// startVertex remains valid even after the call to reset()!!
@@ -172,6 +174,8 @@ class DepthFirstEnumerator final : public PathEnumerator {
   DepthFirstEnumerator(Traverser* traverser, TraverserOptions* opts);
 
   ~DepthFirstEnumerator();
+
+  void clear() override {}
 
   /// @brief set start vertex and reset
   void setStartVertex(arangodb::velocypack::StringRef startVertex) override;

--- a/arangod/Graph/SingleServerTraverser.cpp
+++ b/arangod/Graph/SingleServerTraverser.cpp
@@ -77,6 +77,7 @@ void SingleServerTraverser::clear() {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   TRI_ASSERT(!_vertexGetter->pointsIntoTraverserCache());
 #endif
+  _enumerator->clear();
   traverserCache()->clear();
 }
 

--- a/arangod/Graph/WeightedEnumerator.cpp
+++ b/arangod/Graph/WeightedEnumerator.cpp
@@ -57,14 +57,15 @@ WeightedEnumerator::WeightedEnumerator(Traverser* traverser, TraverserOptions* o
   _schreier.reserve(32);
 }
 
-void WeightedEnumerator::setStartVertex(arangodb::velocypack::StringRef startVertex) {
-  PathEnumerator::setStartVertex(startVertex);
-
+void WeightedEnumerator::clear() {
   _schreier.clear();
   _schreierIndex = 0;
   _lastReturned = 0;
   _queue.clear();
+}
 
+void WeightedEnumerator::setStartVertex(arangodb::velocypack::StringRef startVertex) {
+  PathEnumerator::setStartVertex(startVertex);
   _schreier.emplace_back(startVertex);
 }
 

--- a/arangod/Graph/WeightedEnumerator.h
+++ b/arangod/Graph/WeightedEnumerator.h
@@ -128,6 +128,8 @@ class WeightedEnumerator final : public arangodb::traverser::PathEnumerator {
 
   ~WeightedEnumerator() = default;
 
+  void clear() final;
+
   void setStartVertex(arangodb::velocypack::StringRef startVertex) override;
 
   /// @brief Get the next Path element from the traversal.

--- a/tests/Aql/TraversalExecutorTest.cpp
+++ b/tests/Aql/TraversalExecutorTest.cpp
@@ -141,13 +141,17 @@ class GraphEnumerator : public PathEnumerator {
 
   ~GraphEnumerator() = default;
 
-  void setStartVertex(arangodb::velocypack::StringRef startVertex) override {
-    PathEnumerator::setStartVertex(startVertex);
-
+  void clear() override {
     _idx = 0;
     _depth = 0;
     _currentDepth.clear();
     _nextDepth.clear();
+  }
+
+  void setStartVertex(arangodb::velocypack::StringRef startVertex) override {
+    PathEnumerator::setStartVertex(startVertex);
+
+    clear();
     _nextDepth.emplace_back(startVertex);
   }
 


### PR DESCRIPTION
### Scope & Purpose

Fix GitHub issue #15084.

Enterprise companion: https://github.com/arangodb/enterprise/pull/821

Fixed a potential use-after-free on Windows for queries that used the NeighborsEnumerator (though other PathEnumerators might have been affected as well).

The reason was that in some cases the MSVC STL unordered_map/unordered_set calculates hashes in `clear`, but the stringHeap that stored the strings which were reference by the stringRefs in the unordered_set was cleared before the set.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backport for 3.9: *#15267*
- [x] Backport for 3.8: *#15265*
- [x] Backport for 3.7: *#15268*

#### Related Information

- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/821
- [x] GitHub issue: #15084

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
