### PR TITLE
[3.7] Fixed a potential use-after-free on Windows.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.7.17 (XXXX-XX-XX)
 --------------------
 
+* Fix GitHub issue #15084. Fixed a potential use-after-free on Windows for
+  queries that used the NeighborsEnumerator (though other PathEnumerators
+  might have been affected as well).
+  
 * Make `db.<collection>.figures(true)` operate on the same snapshot when
   counting the number of documents in the documents column family and the
   indexes. This ensures consistency for the results of a single figures result.

--- a/arangod/Cluster/ClusterTraverser.cpp
+++ b/arangod/Cluster/ClusterTraverser.cpp
@@ -93,6 +93,7 @@ void ClusterTraverser::clear() {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   TRI_ASSERT(!_vertexGetter->pointsIntoTraverserCache());
 #endif
+  _enumerator->clear();
   traverserCache()->clear();
 }
 

--- a/arangod/Graph/BreadthFirstEnumerator.cpp
+++ b/arangod/Graph/BreadthFirstEnumerator.cpp
@@ -55,9 +55,7 @@ BreadthFirstEnumerator::~BreadthFirstEnumerator() {
   _opts->resourceMonitor().decreaseMemoryUsage(_schreier.capacity() * pathStepSize());
 }
 
-void BreadthFirstEnumerator::setStartVertex(arangodb::velocypack::StringRef startVertex) {
-  PathEnumerator::setStartVertex(startVertex);
-  
+void BreadthFirstEnumerator::clear() {
   _schreier.clear();
   _schreierIndex = 0;
   _lastReturned = 0;
@@ -65,7 +63,13 @@ void BreadthFirstEnumerator::setStartVertex(arangodb::velocypack::StringRef star
   _toSearch.clear();
   _currentDepth = 0;
   _toSearchPos = 0;
+}
 
+void BreadthFirstEnumerator::setStartVertex(arangodb::velocypack::StringRef startVertex) {
+  PathEnumerator::setStartVertex(startVertex);
+  
+  clear();
+  
   growStorage();
   _schreier.emplace_back(startVertex);
   _toSearch.emplace_back(NextStep(0));

--- a/arangod/Graph/BreadthFirstEnumerator.h
+++ b/arangod/Graph/BreadthFirstEnumerator.h
@@ -105,7 +105,9 @@ class BreadthFirstEnumerator final : public arangodb::traverser::PathEnumerator 
                          arangodb::traverser::TraverserOptions* opts);
 
   ~BreadthFirstEnumerator();
-  
+
+  void clear() final;
+
   void setStartVertex(arangodb::velocypack::StringRef startVertex) override;
 
   /// @brief Get the next Path element from the traversal.

--- a/arangod/Graph/NeighborsEnumerator.cpp
+++ b/arangod/Graph/NeighborsEnumerator.cpp
@@ -43,15 +43,19 @@ NeighborsEnumerator::NeighborsEnumerator(Traverser* traverser, TraverserOptions*
   TRI_ASSERT(!opts->hasDepthLookupInfo());
 }
 
-void NeighborsEnumerator::setStartVertex(arangodb::velocypack::StringRef startVertex) {
-  PathEnumerator::setStartVertex(startVertex);
-
+void NeighborsEnumerator::clear() {
   _allFound.clear();
   _currentDepth.clear();
   _lastDepth.clear();
   _iterator = _currentDepth.end();
   _toPrune.clear();
   _searchDepth = 0;
+}
+
+void NeighborsEnumerator::setStartVertex(arangodb::velocypack::StringRef startVertex) {
+  PathEnumerator::setStartVertex(startVertex);
+
+  clear();
 
   _allFound.insert(startVertex);
   _currentDepth.insert(startVertex);

--- a/arangod/Graph/NeighborsEnumerator.h
+++ b/arangod/Graph/NeighborsEnumerator.h
@@ -48,6 +48,8 @@ class NeighborsEnumerator final : public arangodb::traverser::PathEnumerator {
 
   ~NeighborsEnumerator() = default;
 
+  void clear() final;
+
   void setStartVertex(arangodb::velocypack::StringRef startVertex) override;
 
   /// @brief Get the next Path element from the traversal.

--- a/arangod/Graph/PathEnumerator.h
+++ b/arangod/Graph/PathEnumerator.h
@@ -119,6 +119,8 @@ class PathEnumerator {
 
   virtual ~PathEnumerator();
 
+  virtual void clear() = 0;
+
   /// @brief set start vertex and reset
   /// note that the caller *must* guarantee that the string data pointed to by
   /// startVertex remains valid even after the call to reset()!!
@@ -166,6 +168,8 @@ class DepthFirstEnumerator final : public PathEnumerator {
   DepthFirstEnumerator(Traverser* traverser, TraverserOptions* opts);
 
   ~DepthFirstEnumerator();
+
+  void clear() override {}
 
   /// @brief set start vertex and reset
   void setStartVertex(arangodb::velocypack::StringRef startVertex) override;

--- a/arangod/Graph/SingleServerTraverser.cpp
+++ b/arangod/Graph/SingleServerTraverser.cpp
@@ -71,6 +71,7 @@ void SingleServerTraverser::clear() {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   TRI_ASSERT(!_vertexGetter->pointsIntoTraverserCache());
 #endif
+  _enumerator->clear();
   traverserCache()->clear();
 }
 

--- a/tests/Aql/TraversalExecutorTest.cpp
+++ b/tests/Aql/TraversalExecutorTest.cpp
@@ -138,16 +138,21 @@ class GraphEnumerator : public PathEnumerator {
         _depth(0) {}
 
   ~GraphEnumerator() = default;
-
-  void setStartVertex(arangodb::velocypack::StringRef startVertex) override {
-    PathEnumerator::setStartVertex(startVertex);
-
+  
+  void clear() override {
     _idx = 0;
     _depth = 0;
     _currentDepth.clear();
     _nextDepth.clear();
+  }
+
+  void setStartVertex(arangodb::velocypack::StringRef startVertex) override {
+    PathEnumerator::setStartVertex(startVertex);
+
+    clear();
     _nextDepth.emplace_back(startVertex);
   }
+
 
   bool next() override {
     ++_idx;


### PR DESCRIPTION
### Scope & Purpose

Fix GitHub issue #15084.

Enterprise companion: https://github.com/arangodb/enterprise/pull/824

Fixed a potential use-after-free on Windows for queries that used the NeighborsEnumerator (though other PathEnumerators might have been affected as well).

The reason was that in some cases the MSVC STL unordered_map/unordered_set calculates hashes in `clear`, but the stringHeap that stored the strings which were reference by the stringRefs in the unordered_set was cleared before the set.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] devel port: *#15266*
- [x] Backport for 3.9: *#15267*
- [x] Backport for 3.8: *#15265*

#### Related Information

- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/824
- [x] GitHub issue: #15084

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
