### PR TITLE
do not copy generated log message string

### DIFF
--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -420,7 +420,7 @@ std::string const& Logger::translateLogLevel(LogLevel level) noexcept {
 }
 
 void Logger::log(char const* logid, char const* function, char const* file, int line,
-                 LogLevel level, size_t topicId, std::string const& message) try {
+                 LogLevel level, size_t topicId, std::string_view message) try {
   TRI_ASSERT(logid != nullptr);
 
   // we only determine our pid once, as currentProcessId() will
@@ -559,14 +559,14 @@ void Logger::log(char const* logid, char const* function, char const* file, int 
       // sure that the dynamic text part is truncated and not the
       // entries JSON thing
       size_t maxMessageLength = defaultLogGroup().maxLogEntryLength();
-      // cut of prologue, the quotes ('"' --- ' '") and the final '}'
+      // cut off prologue, the quotes ('"' --- ' '") and the final '}'
       if (maxMessageLength >= out.size() + 3) {
         maxMessageLength -= out.size() + 3;
       }
       if (maxMessageLength > message.size()) {
         maxMessageLength = message.size();
       }
-      dumper.appendString(message.c_str(), maxMessageLength);
+      dumper.appendString(message.data(), maxMessageLength);
   
       // this tells the logger to not shrink our (potentially already
       // shrunk) message once more - if it would shrink the message again,

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -59,6 +59,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -298,7 +299,7 @@ class Logger {
   static std::string const& translateLogLevel(LogLevel) noexcept;
 
   static void log(char const* logid, char const* function, char const* file, int line,
-                  LogLevel level, size_t topicId, std::string const& message);
+                  LogLevel level, size_t topicId, std::string_view message);
 
   static void append(LogGroup&, std::unique_ptr<LogMessage>& msg,
                      bool forceDirect,

--- a/lib/Logger/LoggerStream.cpp
+++ b/lib/Logger/LoggerStream.cpp
@@ -153,9 +153,7 @@ LoggerStream::~LoggerStream() {
 #endif
     
   try {
-    // TODO: with c++20, we can get a view on the stream's underlying buffer,
-    // without copying it
-    Logger::log(_logid, _function, _file, _line, _level, _topicId, _out.str());
+    Logger::log(_logid, _function, _file, _line, _level, _topicId, _out.view());
   } catch (...) {
     try {
       // logging the error may fail as well, and we should never throw in the


### PR DESCRIPTION
### Scope & Purpose

Do not copy generated log message string

When a log message is put together in an output stream, earlier versions of C++ had no means of accessing the data from the ostream in a read-only fashion without copying it. With c++20 it is now possible to get a read-only view on the ostream's contents, without having to copy it.
We can use this to avoid making a copy of the ostream content's for every log message 😊

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
