### PR TITLE
[BTS-535] Fix waiting for Current/Version for TakeoverShardLeadership

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix BTS-535: TakeoverShardLeadership waits properly for Current data in
+  ClusterInfo. This avoids a fake warning and fake test failure.
+
 * Fix GitHub issue #15084. Fixed a potential use-after-free on Windows for
   queries that used the NeighborsEnumerator (though other PathEnumerators
   might have been affected as well).

--- a/arangod/Cluster/TakeoverShardLeadership.cpp
+++ b/arangod/Cluster/TakeoverShardLeadership.cpp
@@ -183,7 +183,7 @@ static void handleLeadership(uint64_t planIndex, LogicalCollection& collection,
     // the assertion below where we check that we are in the list of
     // failoverCandidates!
     uint64_t currVersion = 0;
-    while (true) {
+    while (collection.vocbase().server()) {
       VPackBuilder builder;
       uint64_t raftIndex = agencyCache.get(builder, "Current/Version");
       if (!builder.isEmpty()) {


### PR DESCRIPTION
This fixes BTS-535.

When a shard leader takes over its leadership it has to make sure that
it is a FailoverCandidate. This check needs an up-to-date version of
the information in `Current` and this has to have made its way through
the agency cache to the ClusterInfo cache.

This PR fixes the waiting condition to avoid test instabilities.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers - **mandatory**)*

- [*] :hankey: Bugfix (requires CHANGELOG entry)
- [*] :book: CHANGELOG entry made

#### Backports:

 - not decided yet

- [*] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-535

### Testing & Verification

*(Please pick either of the following options)*

- [*] This change is a trivial rework / code cleanup without any test coverage.
- [*] The behavior in this PR was *manually tested*
- [*] This change is already covered by existing tests, such as
  `scripts/unittest resilience_failover --test tests/js/server/resilience/failover/resilience-synchronous-repl-cluster.js --cluster true`

