### PR TITLE
[Search-183] Fix strange test failed

### DIFF
--- a/tests/IResearch/IResearchLinkTest.cpp
+++ b/tests/IResearch/IResearchLinkTest.cpp
@@ -2277,7 +2277,6 @@ TEST_F(IResearchLinkMetricsTest, TimeCommit) {
     EXPECT_TRUE(0 < indexSize0);
 
     remove(1, 10000);
-    auto [commitTime1, cleanupTime1, consolidationTime1] = l->avgTime();
     auto [numFiles1, indexSize1] = numFiles();
     EXPECT_TRUE(0 < numFiles1);
     EXPECT_TRUE(numFiles1 < numFiles0);
@@ -2285,8 +2284,6 @@ TEST_F(IResearchLinkMetricsTest, TimeCommit) {
     EXPECT_TRUE(indexSize1 < indexSize0);
 
     remove(10000, 10100);
-    auto [commitTime2, cleanupTime2, consolidationTime2] = l->avgTime();
-    EXPECT_TRUE(cleanupTime2 <= cleanupTime1);
     auto [numFiles2, indexSize2] = numFiles();
     EXPECT_TRUE(0 < numFiles2);
     EXPECT_TRUE(numFiles2 < numFiles1);


### PR DESCRIPTION
### Scope & Purpose

This assertion checked that the `сleanup` after the second removes, which removes 100 times fewer documents than the first, works faster or the same. Apparently, sometimes this isn't true, locally it isn't reproduced for me. So I just removed this statement

- [x] :hankey: Bugfix (requires CHANGELOG entry)

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] This change is already covered by existing tests, such as *(please describe tests)*.
