### PR TITLE
generate procdump on forcefull shutdown regardless whether we previously

### DIFF
--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -643,8 +643,10 @@ function makeArgsArangod (options, appDir, role, tmpDir) {
 }
 
 function killWithCoreDump (options, instanceInfo) {
-  if (platform.substr(0, 3) === 'win' && !options.disableMonitor) {
-    crashUtils.stopProcdump (options, instanceInfo, true);
+  if (platform.substr(0, 3) === 'win') {
+    if (!options.disableMonitor) {
+      crashUtils.stopProcdump (options, instanceInfo, true);
+    }
     crashUtils.runProcdump (options, instanceInfo, instanceInfo.rootDir, instanceInfo.pid, true);
   }
   instanceInfo.exitStatus = killExternal(instanceInfo.pid, abortSignal);


### PR DESCRIPTION
### Scope & Purpose

generate procdump on forcefull shutdown regardless whether we previously had a procdump running or its disabled

- [x] :fire: test infrastructural fix

#### Backports:

- [x] Backport for 3.9: *(Please link PR)*
- [x] Backport for 3.8: *(Please link PR)*
- [x] Backport for 3.7: *(Please link PR)*

