### PR TITLE
Fix cmake for arangodb-iresearch target

### DIFF
--- a/tests/IResearch/CMakeLists.txt
+++ b/tests/IResearch/CMakeLists.txt
@@ -100,7 +100,6 @@ target_include_directories(arangodbtests-iresearch PRIVATE
   ${PROJECT_SOURCE_DIR}/arangod
   ${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}
   ${PROJECT_SOURCE_DIR}/tests
-  ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 # add these includes as system includes because otherwise

--- a/tests/IResearch/CMakeLists.txt
+++ b/tests/IResearch/CMakeLists.txt
@@ -97,7 +97,10 @@ target_link_libraries(arangodbtests-iresearch
 )
 
 target_include_directories(arangodbtests-iresearch PRIVATE
-  ${INCLUDE_DIRECTORIES}
+  ${PROJECT_SOURCE_DIR}/arangod
+  ${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}
+  ${PROJECT_SOURCE_DIR}/tests
+  ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 # add these includes as system includes because otherwise


### PR DESCRIPTION
### Scope & Purpose

PR #15151 adjusted arangodbtests but iresearch-arangodbtests target also needs same adjustments as includes were changed.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
