### PR TITLE
[BTS-580] Trim password field from payload in arangorestore error messages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fix BTS-580: Trimmed the password field from the payload in the client 
+  requests when displaying error messages in arangorestore, because they 
+  displayed the password as plain text. 
+
 * Refactored unit tests with the `grey` keyword, which is for skipping certain 
   tests. A test file that did not perform any test, but only had a function to 
   sleep, was removed. Two test files were renamed so they would not be skipped.

--- a/lib/SimpleHttpClient/HttpResponseChecker.cpp
+++ b/lib/SimpleHttpClient/HttpResponseChecker.cpp
@@ -26,38 +26,103 @@
 
 #include "Basics/StaticStrings.h"
 
+#include <velocypack/Builder.h>
+#include <velocypack/Iterator.h>
+#include <velocypack/Parser.h>
+#include <velocypack/velocypack-aliases.h>
+
 using namespace arangodb;
+
+/// @brief Trim the payload so it doesn't have the password field with the password in plain text
+void HttpResponseChecker::trimPayload(VPackSlice input, VPackBuilder& output) {
+  using namespace velocypack;
+  if (input.isObject()) {
+    output.openObject();
+    ObjectIterator it(input);
+    while (it.valid()) {
+      if (it.key().stringView() != "passwd") {
+        output.add(it.key());
+        trimPayload(it.value(), output);
+      }
+      it.next();
+    }
+    output.close();
+  } else if (input.isArray()) {
+    output.openArray();
+    VPackArrayIterator it(input);
+    while (it.valid()) {
+      trimPayload(it.value(), output);
+      it.next();
+    }
+    output.close();
+  } else {
+    output.add(input);
+  }
+}
 
 /// @brief Check for error in http response
 Result HttpResponseChecker::check(std::string const& clientErrorMsg, httpclient::SimpleHttpResult const* const response,
-                                  std::string const& actionMsg, std::string const& requestPayload) {
+                                  std::string const& actionMsg, std::string_view requestPayload, PayloadType type) {
+  if (response != nullptr && !response->wasHttpError() && response->isComplete()) {
+    return {TRI_ERROR_NO_ERROR};
+  }
+  // here we will trim the payload to remove every field that contains the password in plain text, e.g. "passwd" field,
+  // and we don't have a way to trim it with velocypack, so we have to parse the JSON and rebuild it without the "passwd" fields.
+  std::string msgBody;
+  if (!requestPayload.empty()) {
+    VPackBuilder output;
+    if (type == PayloadType::JSON) {
+      try {
+        auto payloadVPack = VPackParser::fromJson(requestPayload.data(), requestPayload.size());
+        trimPayload(payloadVPack->slice(), output);
+        msgBody = output.toJson();
+      } catch (...) {
+        msgBody = requestPayload;
+      }
+    } else if (type == PayloadType::VPACK){
+      trimPayload(VPackSlice(reinterpret_cast<uint8_t const*>(requestPayload.data())), output);
+      msgBody = output.toJson();
+    } else {
+      msgBody = requestPayload;
+    }
+  }
+  constexpr size_t maxMsgBodySize = 4096; // max amount of bytes in msg body to truncate
+                                   // if too big to display
+  if (msgBody.size() > maxMsgBodySize) { //truncate error message
+    msgBody.resize(maxMsgBodySize);
+    msgBody.append("...");
+  }
   using basics::StringUtils::itoa;
   if (response == nullptr || !response->isComplete()) {
     return {TRI_ERROR_INTERNAL,
-            "got invalid response from server " + (clientErrorMsg.empty() ? "" : ": '" + clientErrorMsg + "'") +
+            "got invalid response from server " +
+                (clientErrorMsg.empty() ? "" : ": '" + clientErrorMsg + "'") +
                 (actionMsg.empty() ? "" : " while executing " + actionMsg) +
-                (requestPayload.empty() ? "" : " with this requestPayload: '" + requestPayload + "'")};
+                (msgBody.empty() ? "" : " with this requestPayload: '" + msgBody + "'")};
   }
-  if (response->wasHttpError()) {
-    auto errorNum = static_cast<int>(TRI_ERROR_INTERNAL);
-    std::string errorMsg = response->getHttpReturnMessage();
-    try {
-      std::shared_ptr<velocypack::Builder> bodyBuilder(response->getBodyVelocyPack());
-      velocypack::Slice error = bodyBuilder->slice();
-      if (!error.isNone() && error.hasKey(StaticStrings::ErrorMessage)) {
-        errorNum = error.get(StaticStrings::ErrorNum).getNumericValue<int>();
-        errorMsg = error.get(StaticStrings::ErrorMessage).copyString();
-      }
-    } catch (...) {
-      errorMsg = response->getHttpReturnMessage();
-      errorNum = response->getHttpReturnCode();
+  auto errorNum = static_cast<int>(TRI_ERROR_INTERNAL);
+  std::string errorMsg = response->getHttpReturnMessage();
+  try {
+    std::shared_ptr<velocypack::Builder> bodyBuilder(response->getBodyVelocyPack());
+    velocypack::Slice error = bodyBuilder->slice();
+    if (!error.isNone() && error.hasKey(StaticStrings::ErrorMessage)) {
+      errorNum = error.get(StaticStrings::ErrorNum).getNumericValue<int>();
+      errorMsg = error.get(StaticStrings::ErrorMessage).copyString();
     }
-
-    auto err = ErrorCode{errorNum};
-    return {err, "got invalid response from server: HTTP " +
-                     itoa(response->getHttpReturnCode()) + ": '" + errorMsg + "'" +
-                     (actionMsg.empty() ? "" : " while executing " + actionMsg) +
-                     (requestPayload.empty() ? "" : " with this requestPayload: '" + requestPayload + "'")};
+  } catch (...) {
+    errorMsg = response->getHttpReturnMessage();
+    errorNum = response->getHttpReturnCode();
   }
-  return {TRI_ERROR_NO_ERROR};
+
+  auto err = ErrorCode{errorNum};
+  return {err, "got invalid response from server: HTTP " +
+                   itoa(response->getHttpReturnCode()) + ": '" + errorMsg + "'" +
+                   (actionMsg.empty() ? "" : " while executing " + actionMsg) +
+                   (msgBody.empty() ? "" : " with this requestPayload: '" + msgBody + "'")};
+}
+
+/// @brief Check for error in http response
+Result HttpResponseChecker::check(std::string const& clientErrorMsg,
+                                  httpclient::SimpleHttpResult const* const response) {
+  return check(clientErrorMsg, response, "", "", PayloadType::JSON);
 }

--- a/lib/SimpleHttpClient/HttpResponseChecker.h
+++ b/lib/SimpleHttpClient/HttpResponseChecker.h
@@ -24,14 +24,19 @@
 #pragma once
 #include "Basics/Result.h"
 #include "SimpleHttpClient/SimpleHttpResult.h"
+#include <string_view>
 
 
 namespace arangodb {
 class HttpResponseChecker {
  public:
   HttpResponseChecker() = delete;
+  enum class PayloadType {JSON, VPACK, JSONL};
+  static arangodb::Result check(std::string const& clientErrorMsg, arangodb::httpclient::SimpleHttpResult const* const response);
   static arangodb::Result check(std::string const& clientErrorMsg, arangodb::httpclient::SimpleHttpResult const* const response,
-                                std::string const& actionMsg = "", std::string const& requestPayload = "");
+                                std::string const& actionMsg, std::string_view requestPayload, PayloadType type);
+ private:
+  static void trimPayload(VPackSlice input, VPackBuilder& output);
 };
 
 }

--- a/tests/SimpleHttpClient/HttpResponseCheckerTest.cpp
+++ b/tests/SimpleHttpClient/HttpResponseCheckerTest.cpp
@@ -28,7 +28,6 @@
 #include "SimpleHttpClient/HttpResponseChecker.h"
 #include "SimpleHttpClient/SimpleHttpResult.h"
 
-
 using namespace arangodb;
 using namespace arangodb::httpclient;
 using namespace arangodb::velocypack;
@@ -47,7 +46,7 @@ TEST(HttpResponseCheckerTest, testEmptyWithClientErrorMsg) {
 TEST(HttpResponseCheckerTest, testErrorResponse) {
   std::unique_ptr<httpclient::SimpleHttpResult> response = std::make_unique<httpclient::SimpleHttpResult>();
   response->setResultType(httpclient::SimpleHttpResult::resultTypes{arangodb::httpclient::SimpleHttpResult::COULD_NOT_CONNECT});
-  auto check = HttpResponseChecker::check("", response.get(), "Http request");
+  auto check = HttpResponseChecker::check("", response.get(), "Http request",  "{\"abc123\":\"foo\"}", HttpResponseChecker::PayloadType::JSON);
   EXPECT_EQ(check.errorNumber(), TRI_ERROR_INTERNAL);
   EXPECT_NE(check.errorMessage().find("Http request"), std::string::npos);
 }
@@ -159,9 +158,10 @@ TEST(HttpResponseCheckerTest, testErrorResponseHtml) {
   response->setResultType(httpclient::SimpleHttpResult::resultTypes{arangodb::httpclient::SimpleHttpResult::COMPLETE});
   response->setHttpReturnMessage("NOT FOUND");
   response->setHttpReturnCode(404);
-  auto check = HttpResponseChecker::check("", response.get(), "foo bar", "abc123");
+  auto check = HttpResponseChecker::check("", response.get(), "foo bar", "{\"abc123\":\"foo\"}", HttpResponseChecker::PayloadType::JSON);
   EXPECT_EQ(check.errorNumber(), ErrorCode{response->getHttpReturnCode()});
   EXPECT_NE(check.errorMessage().find(response->getHttpReturnMessage()), std::string::npos);
+  EXPECT_NE(check.errorMessage().find("{\"abc123\":\"foo\"}"), std::string::npos);
   EXPECT_NE(check.errorMessage().find("foo bar"), std::string::npos);
   EXPECT_NE(check.errorMessage().find("abc123"), std::string::npos);
 }

--- a/tests/js/client/communication/test-communication.js
+++ b/tests/js/client/communication/test-communication.js
@@ -87,7 +87,7 @@ const runShell = function (args, prefix) {
     'server.database': arango.getDatabaseName(),
     'server.username': arango.connectedUser(),
     'server.password': '',
-    'server.request-timeout': '10',
+    'server.request-timeout': '30',
     'log.foreground-tty': 'false',
     'log.output': 'file://' + prefix + '.log'
   };


### PR DESCRIPTION
### Scope & Purpose

This PR fixes the error messages on the client requests of arangorestore displaying passwords in plain text, trimming the json fields from the payload that display the password.
The server code still has to be changed and would require some extra thought into it.
Examples of error messages displaying the password in plain text, as in the ticket https://arangodb.atlassian.net/browse/BTS-580:
```
2021-09-13T15:45:52Z [4120] ERROR [7a35f] {restore} Could not create database '😀': got invalid response from server: HTTP 400: 'database name invalid' while executing creating database' with this payload: '{"name":"😀","options":{"replicationFactor":1},"users":[{"username":"root","passwd":"hustensaft"}]}'
2021-09-13T15:45:52Z [4120] ERROR [cb69f] {restore} got invalid response from server: HTTP 400: 'database name invalid' while executing creating database' with this payload: '{"name":"😀","options":{"replicationFactor":1},"users":[{"username":"root","passwd":"hustensaft"}]}'
```

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

No backports required.

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-622
- [ ] Design document: 

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new C++ **Unit tests** Obs.: actually edits an existing test
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
