### PR TITLE
added various startup options for throttle configuration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,23 @@
 v3.8.5 (XXXX-XX-XX)
 -------------------
 
+* Added startup options to adjust previously hard-coded parameters for the 
+  RocksDB throttle:
+  - `--rocksdb.throttle-frequency`: frequency for write-throttle calculations
+    (in milliseconds, default value is 60000, i.e. 60 seconds)
+  - `--rocksdb.throttle-slots`: number of historic measures to use for throttle
+    value calculation (default value is 63)
+  - `--rocksdb.throttle-scaling-factor`: adaptiveness scaling factor for write-
+    throttle calculations (default value is 17)
+  - `--rocksdb.throttle-max-write-rate`: maximum write rate enforced by the
+    throttle (in bytes per second, default value is 0, meaning "unlimited").
+    The actual write rate will be the minimum of this value and the value the
+    throttle calculation produces.
+  All these options will only have an effect if `--rocksdb.throttle` is enabled
+  (which is the default). The configuration options introduced here use the
+  previously hard-coded settings as their default values, so there should not be
+  a change in behavior if the options are not adjusted.
+
 * Improve visibility in case of potential data corruption between primary index
   and actual document store in documents column family.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,7 +16,7 @@ v3.8.5 (XXXX-XX-XX)
     throttle calculation produces.
   - `--rocksdb.throttle-slow-down-writes-trigger`: number of level 0 files whose
     payload is not considered in throttle calculations when penalizing the 
-    presence of L0 files.
+    presence of L0 files. There is normally no need to change this value.
   All these options will only have an effect if `--rocksdb.throttle` is enabled
   (which is the default). The configuration options introduced here use the
   previously hard-coded settings as their default values, so there should not be

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,15 +4,19 @@ v3.8.5 (XXXX-XX-XX)
 * Added startup options to adjust previously hard-coded parameters for the 
   RocksDB throttle:
   - `--rocksdb.throttle-frequency`: frequency for write-throttle calculations
-    (in milliseconds, default value is 60000, i.e. 60 seconds)
+    (in milliseconds, default value is 60000, i.e. 60 seconds).
   - `--rocksdb.throttle-slots`: number of historic measures to use for throttle
-    value calculation (default value is 63)
+    value calculation (default value is 63).
   - `--rocksdb.throttle-scaling-factor`: adaptiveness scaling factor for write-
-    throttle calculations (default value is 17)
+    throttle calculations (default value is 17). There is normally no need to
+    change this value.
   - `--rocksdb.throttle-max-write-rate`: maximum write rate enforced by the
     throttle (in bytes per second, default value is 0, meaning "unlimited").
     The actual write rate will be the minimum of this value and the value the
     throttle calculation produces.
+  - `--rocksdb.throttle-slow-down-writes-trigger`: number of level 0 files whose
+    payload is not considered in throttle calculations when penalizing the 
+    presence of L0 files.
   All these options will only have an effect if `--rocksdb.throttle` is enabled
   (which is the default). The configuration options introduced here use the
   previously hard-coded settings as their default values, so there should not be

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.8.5 (XXXX-XX-XX)
 -------------------
 
-* Added startup options to adjust previously hard-coded parameters for the 
+* Added startup options to adjust previously hard-coded parameters for the
   RocksDB throttle:
   - `--rocksdb.throttle-frequency`: frequency for write-throttle calculations
     (in milliseconds, default value is 60000, i.e. 60 seconds).
@@ -15,8 +15,9 @@ v3.8.5 (XXXX-XX-XX)
     The actual write rate will be the minimum of this value and the value the
     throttle calculation produces.
   - `--rocksdb.throttle-slow-down-writes-trigger`: number of level 0 files whose
-    payload is not considered in throttle calculations when penalizing the 
+    payload is not considered in throttle calculations when penalizing the
     presence of L0 files. There is normally no need to change this value.
+
   All these options will only have an effect if `--rocksdb.throttle` is enabled
   (which is the default). The configuration options introduced here use the
   previously hard-coded settings as their default values, so there should not be

--- a/arangod/RocksDBEngine/Listeners/RocksDBThrottle.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBThrottle.cpp
@@ -353,7 +353,7 @@ void RocksDBThrottle::RecalculateThrottle() {
     int64_t new_throttle;
     // non-level0 data available?
     if (0 != tot_bytes && 0 != tot_micros.count()) {
-      // average bytes per secon for level 1+ compactions
+      // average bytes per second for level 1+ compactions
       //  (adjust bytes upward by 1000000 since dividing by microseconds,
       //   yields integer bytes per second)
       new_throttle = ((tot_bytes * 1000000) / tot_micros.count());
@@ -521,7 +521,7 @@ int64_t RocksDBThrottle::ComputeBacklog() {
 ///  it is performing.  The routine is called HEAVILY.
 void RocksDBThrottle::AdjustThreadPriority(int Adjustment) {
 #ifndef _WIN32
-  // initialize thread infor if this the first time the thread has ever called
+  // initialize thread info if this the first time the thread has ever called
   if (!gThreadPriority._baseSet) {
     pid_t tid = syscall(SYS_gettid);
     if (-1 != (int)tid) {
@@ -536,7 +536,7 @@ void RocksDBThrottle::AdjustThreadPriority(int Adjustment) {
     }    // if
   }      // if
 
-  // only change priorities if we
+  // only change priorities if we succeeded
   if (gThreadPriority._baseSet && (gThreadPriority._basePriority + Adjustment) !=
                                       gThreadPriority._currentPriority) {
     pid_t tid;

--- a/arangod/RocksDBEngine/Listeners/RocksDBThrottle.h
+++ b/arangod/RocksDBEngine/Listeners/RocksDBThrottle.h
@@ -38,6 +38,8 @@
 
 #include <chrono>
 #include <future>
+#include <memory>
+#include <vector>
 
 #include "Basics/Common.h"
 #include "Basics/ConditionVariable.h"
@@ -67,7 +69,8 @@ namespace arangodb {
 
 class RocksDBThrottle : public rocksdb::EventListener {
  public:
-  RocksDBThrottle();
+  RocksDBThrottle(uint64_t numSlots, uint64_t frequency, uint64_t scalingFactor, 
+                  uint64_t maxWriteRate, uint64_t slowdownWritesTrigger);
   virtual ~RocksDBThrottle();
 
   void OnFlushBegin(rocksdb::DB* db, const rocksdb::FlushJobInfo& flush_job_info) override;
@@ -100,26 +103,13 @@ class RocksDBThrottle : public rocksdb::EventListener {
 
   void RecalculateThrottle();
 
-  // I am unable to figure out static initialization of std::chrono::seconds,
-  //  using old school unsigned.
-  static constexpr unsigned THROTTLE_SECONDS = 60;
-  static constexpr unsigned THROTTLE_INTERVALS = 63;
-
-  // following is a heuristic value, determined by trial and error.
-  //  its job is slow down the rate of change in the current throttle.
-  //  do not want sudden changes in one or two intervals to swing
-  //  the throttle value wildly.  Goal is a nice, even throttle value.
-  static constexpr unsigned THROTTLE_SCALING = 17;
-
-  // trigger point where level-0 file is considered "too many pending"
-  //  (from original Google leveldb db/dbformat.h)
-  static constexpr int64_t kL0_SlowdownWritesTrigger = 8;
-
   struct ThrottleData_t {
-    std::chrono::microseconds _micros;
-    uint64_t _keys;
-    uint64_t _bytes;
-    uint64_t _compactions;
+    std::chrono::microseconds _micros{};
+    uint64_t _keys = 0;
+    uint64_t _bytes = 0;
+    uint64_t _compactions = 0;
+
+    ThrottleData_t() noexcept = default;
   };
 
   rocksdb::DBImpl* _internalRocksDB;
@@ -143,11 +133,11 @@ class RocksDBThrottle : public rocksdb::EventListener {
   basics::ConditionVariable _threadCondvar;
 
   // this array stores compaction statistics used in throttle calculation.
-  //  Index 0 of this array accumulates the current minute's compaction data for
-  //  level 0. Index 1 accumulates accumulates current minute's compaction
+  //  Index 0 of this array accumulates the current interval's compaction data for
+  //  level 0. Index 1 accumulates accumulates current intervals's compaction
   //  statistics for all other levels.  Remaining intervals contain
-  //  most recent interval statistics for last hour.
-  ThrottleData_t _throttleData[THROTTLE_INTERVALS];
+  //  most recent interval statistics for the total time period.
+  std::unique_ptr<std::vector<ThrottleData_t>> _throttleData;
   size_t _replaceIdx;
 
   std::atomic<uint64_t> _throttleBps;
@@ -156,7 +146,14 @@ class RocksDBThrottle : public rocksdb::EventListener {
   std::unique_ptr<WriteControllerToken> _delayToken;
   std::vector<rocksdb::ColumnFamilyHandle*> _families;
 
-};  // class RocksDBThrottle
+ private:
+  uint64_t const _numSlots;
+  // frequency in milliseconds
+  uint64_t const _frequency; 
+  uint64_t const _scalingFactor;
+  uint64_t const _maxWriteRate;
+  uint64_t const _slowdownWritesTrigger;
+};
 
 }  // namespace arangodb
 

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -377,7 +377,7 @@ void RocksDBEngine::collectOptions(std::shared_ptr<options::ProgramOptions> opti
                      new BooleanParameter(&_useThrottle),
                      arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle));
   
-  options->addOption("--rocksdb.throttle-slots", "number of historic slots to use for throttle calculation",
+  options->addOption("--rocksdb.throttle-slots", "number of historic metrics to use for throttle value calculation",
                      new UInt64Parameter(&_throttleSlots),
                      arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
                      .setIntroducedIn(30805);
@@ -397,7 +397,7 @@ void RocksDBEngine::collectOptions(std::shared_ptr<options::ProgramOptions> opti
                      arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
                      .setIntroducedIn(30805);
   
-  options->addOption("--rocksdb.throttle-slow-down-writes-tigger", "number of level 0 files that are considered as 'too many pending'",
+  options->addOption("--rocksdb.throttle-slow-down-writes-trigger", "number of level 0 files that are considered as 'too many pending'",
                      new UInt64Parameter(&_throttleSlowdownWritesTrigger),
                      arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
                      .setIntroducedIn(30805);

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -397,7 +397,8 @@ void RocksDBEngine::collectOptions(std::shared_ptr<options::ProgramOptions> opti
                      arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
                      .setIntroducedIn(30805);
   
-  options->addOption("--rocksdb.throttle-slow-down-writes-trigger", "number of level 0 files that are considered as 'too many pending'",
+  options->addOption("--rocksdb.throttle-slow-down-writes-trigger", "number of level 0 files whose payload "
+                     "is not considered in throttle calculations when penalizing the presence of L0 files",
                      new UInt64Parameter(&_throttleSlowdownWritesTrigger),
                      arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
                      .setIntroducedIn(30805);

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -376,6 +376,31 @@ void RocksDBEngine::collectOptions(std::shared_ptr<options::ProgramOptions> opti
   options->addOption("--rocksdb.throttle", "enable write-throttling",
                      new BooleanParameter(&_useThrottle),
                      arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle));
+  
+  options->addOption("--rocksdb.throttle-slots", "number of historic slots to use for throttle calculation",
+                     new UInt64Parameter(&_throttleSlots),
+                     arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
+                     .setIntroducedIn(30805);
+  
+  options->addOption("--rocksdb.throttle-frequency", "frequency for write-throttle calculations (in milliseconds)",
+                     new UInt64Parameter(&_throttleFrequency),
+                     arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
+                     .setIntroducedIn(30805);
+  
+  options->addOption("--rocksdb.throttle-scaling-factor", "adaptiveness scaling factor for write-throttle calculations",
+                     new UInt64Parameter(&_throttleScalingFactor),
+                     arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
+                     .setIntroducedIn(30805);
+  
+  options->addOption("--rocksdb.throttle-max-write-rate", "maximum write rate enforced by throttle (in bytes, 0 = unlimited)",
+                     new UInt64Parameter(&_throttleMaxWriteRate),
+                     arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
+                     .setIntroducedIn(30805);
+  
+  options->addOption("--rocksdb.throttle-slow-down-writes-tigger", "number of level 0 files that are considered as 'too many pending'",
+                     new UInt64Parameter(&_throttleSlowdownWritesTrigger),
+                     arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
+                     .setIntroducedIn(30805);
 
 #ifdef USE_ENTERPRISE
   options->addOption("--rocksdb.create-sha-files",
@@ -412,6 +437,20 @@ void RocksDBEngine::validateOptions(std::shared_ptr<options::ProgramOptions> opt
 #ifdef USE_ENTERPRISE
   validateEnterpriseOptions(options);
 #endif
+
+  if (_throttleSlots == 0) {
+    LOG_TOPIC("76e1b", FATAL, arangodb::Logger::CONFIG)
+        << "invalid value for --rocksdb.throttle-slots";
+    FATAL_ERROR_EXIT();
+  }
+
+  if (_throttleScalingFactor == 0) {
+    _throttleScalingFactor = 1;
+  }
+
+  if (_throttleSlots < 8) {
+    _throttleSlots = 8;
+  }
 
   if (_requiredDiskFreePercentage < 0.0 || _requiredDiskFreePercentage > 1.0) {
     LOG_TOPIC("e4697", FATAL, arangodb::Logger::CONFIG)
@@ -699,7 +738,8 @@ void RocksDBEngine::start() {
   _options.bloom_locality = 1;
 
   if (_useThrottle) {
-    _throttleListener = std::make_shared<RocksDBThrottle>();
+    _throttleListener = std::make_shared<RocksDBThrottle>(_throttleSlots, _throttleFrequency, _throttleScalingFactor,
+                                                          _throttleMaxWriteRate, _throttleSlowdownWritesTrigger);
     _options.listeners.push_back(_throttleListener);
   }
 

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -392,7 +392,7 @@ void RocksDBEngine::collectOptions(std::shared_ptr<options::ProgramOptions> opti
                      arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
                      .setIntroducedIn(30805);
   
-  options->addOption("--rocksdb.throttle-max-write-rate", "maximum write rate enforced by throttle (in bytes, 0 = unlimited)",
+  options->addOption("--rocksdb.throttle-max-write-rate", "maximum write rate enforced by throttle (in bytes per second, 0 = unlimited)",
                      new UInt64Parameter(&_throttleMaxWriteRate),
                      arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
                      .setIntroducedIn(30805);

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -577,6 +577,23 @@ class RocksDBEngine final : public StorageEngine {
   std::deque<RocksDBKeyBounds> _pendingCompactions;
   /// @brief number of currently running compaction jobs
   size_t _runningCompactions;
+
+  // frequency for throttle in milliseconds
+  uint64_t _throttleFrequency = 60 * 1000; 
+
+  // number of historic data slots to keep around for throttle
+  uint64_t _throttleSlots = 63;
+  // adaptiveness factor for throttle
+  // following is a heuristic value, determined by trial and error.
+  //  its job is slow down the rate of change in the current throttle.
+  //  do not want sudden changes in one or two intervals to swing
+  //  the throttle value wildly.  Goal is a nice, even throttle value.
+  uint64_t _throttleScalingFactor = 17;
+  // max write rate enforced by throttle
+  uint64_t _throttleMaxWriteRate = 0;
+  // trigger point where level-0 file is considered "too many pending"
+  // (from original Google leveldb db/dbformat.h)
+  uint64_t _throttleSlowdownWritesTrigger = 8;
   
   Gauge<uint64_t>& _metricsWalSequenceLowerBound;
   Gauge<uint64_t>& _metricsArchivedWalFiles;

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -585,9 +585,9 @@ class RocksDBEngine final : public StorageEngine {
   uint64_t _throttleSlots = 63;
   // adaptiveness factor for throttle
   // following is a heuristic value, determined by trial and error.
-  //  its job is slow down the rate of change in the current throttle.
-  //  do not want sudden changes in one or two intervals to swing
-  //  the throttle value wildly.  Goal is a nice, even throttle value.
+  // its job is slow down the rate of change in the current throttle.
+  // we do not want sudden changes in one or two intervals to swing
+  // the throttle value wildly. the goal is a nice, even throttle value.
   uint64_t _throttleScalingFactor = 17;
   // max write rate enforced by throttle
   uint64_t _throttleMaxWriteRate = 0;


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/15317
Docs PR: https://github.com/arangodb/docs/pull/841

Added startup options to adjust previously hard-coded parameters for the RocksDB throttle:
- `--rocksdb.throttle-frequency`: frequency for write-throttle calculations (in milliseconds, default value is 60000, i.e. 60 seconds).
- `--rocksdb.throttle-slots`: number of historic measures to use for throttle value calculation (default value is 63).
- `--rocksdb.throttle-scaling-factor`: adaptiveness scaling factor for write-throttle calculations (default value is 17). There is normally no need to change this value.
- `--rocksdb.throttle-slow-down-writes-trigger`: number of level 0 files whose payload is not considered in throttle calculations when penalizing the presence of L0 files. There is normally no need to change this value.
- `--rocksdb.throttle-max-write-rate`: maximum write rate enforced by the throttle (in bytes per second, default value is 0, meaning "unlimited"). The actual write rate will be the minimum of this value and the value the throttle calculation produces.

All these options will only have an effect if `--rocksdb.throttle` is enabled (which is the default). The configuration options introduced here use the previously hard-coded settings as their default values, so there should not be a change in behavior if the options are not adjusted.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/841

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
