### PR TITLE
added various startup options for throttle configuration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,29 @@
+v3.8.4.1 (XXXX-XX-XX)
+---------------------
+
+* Added startup options to adjust previously hard-coded parameters for the 
+  RocksDB throttle:
+  - `--rocksdb.throttle-frequency`: frequency for write-throttle calculations
+    (in milliseconds, default value is 60000, i.e. 60 seconds).
+  - `--rocksdb.throttle-slots`: number of historic measures to use for throttle
+    value calculation (default value is 63).
+  - `--rocksdb.throttle-scaling-factor`: adaptiveness scaling factor for write-
+    throttle calculations (default value is 17). There is normally no need to
+    change this value.
+  - `--rocksdb.throttle-max-write-rate`: maximum write rate enforced by the
+    throttle (in bytes per second, default value is 0, meaning "unlimited").
+    The actual write rate will be the minimum of this value and the value the
+    throttle calculation produces.
+  - `--rocksdb.throttle-slow-down-writes-trigger`: number of level 0 files whose
+    payload is not considered in throttle calculations when penalizing the 
+    presence of L0 files. There is normally no need to change this value.
+
+  All these options will only have an effect if `--rocksdb.throttle` is enabled
+  (which is the default). The configuration options introduced here use the
+  previously hard-coded settings as their default values, so there should not be
+  a change in behavior if the options are not adjusted.
+
+
 v3.8.4 (2021-11-30)
 -------------------
 

--- a/arangod/RocksDBEngine/Listeners/RocksDBThrottle.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBThrottle.cpp
@@ -105,13 +105,22 @@ thread_local sPriorityInfo gThreadPriority = {false, 0, 0};
 thread_local std::chrono::steady_clock::time_point flushStart = std::chrono::steady_clock::time_point{};
 
 // Setup the object, clearing variables, but do no real work
-RocksDBThrottle::RocksDBThrottle()
+RocksDBThrottle::RocksDBThrottle(uint64_t numSlots, uint64_t frequency, uint64_t scalingFactor,
+                                 uint64_t maxWriteRate, uint64_t slowdownWritesTrigger)
     : _internalRocksDB(nullptr),
       _throttleState(ThrottleState::NotStarted),
       _replaceIdx(2),
       _throttleBps(0),
-      _firstThrottle(true) {
-  memset(&_throttleData, 0, sizeof(_throttleData));
+      _firstThrottle(true),
+      _numSlots(numSlots),
+      _frequency(frequency),
+      _scalingFactor(scalingFactor),
+      _maxWriteRate(maxWriteRate == 0 ? std::numeric_limits<uint64_t>::max() : maxWriteRate), 
+      _slowdownWritesTrigger(slowdownWritesTrigger) {
+      
+  TRI_ASSERT(_scalingFactor != 0);
+  _throttleData = std::make_unique<std::vector<ThrottleData_t>>();
+  _throttleData->resize(numSlots);
 }
 
 // Shutdown the background thread only if it was ever started
@@ -224,6 +233,7 @@ void RocksDBThrottle::startup(rocksdb::DB* db) {
 
 void RocksDBThrottle::SetThrottleWriteRate(std::chrono::microseconds Micros,
                                            uint64_t Keys, uint64_t Bytes, bool IsLevel0) {
+  TRI_ASSERT(Micros.count() >= 0);
   // throw out anything smaller than 32Mbytes ... be better if this
   //  was calculated against write_buffer_size, but that varies by column family
   if ((64 << 19) < Bytes) {
@@ -232,10 +242,12 @@ void RocksDBThrottle::SetThrottleWriteRate(std::chrono::microseconds Micros,
     // index 0 for level 0 compactions, index 1 for all others
     unsigned target_idx = (IsLevel0 ? 0 : 1);
 
-    _throttleData[target_idx]._micros += Micros;
-    _throttleData[target_idx]._keys += Keys;
-    _throttleData[target_idx]._bytes += Bytes;
-    _throttleData[target_idx]._compactions += 1;
+    auto& throttleData = *_throttleData;
+
+    throttleData[target_idx]._micros += Micros;
+    throttleData[target_idx]._keys += Keys;
+    throttleData[target_idx]._bytes += Bytes;
+    throttleData[target_idx]._compactions += 1;
 
     // attempt to override throttle changes by rocksdb ... hammer this often
     //  (note that _threadMutex IS HELD)
@@ -273,7 +285,7 @@ void RocksDBThrottle::ThreadLoop() {
     } 
 
     ++_replaceIdx;
-    if (THROTTLE_INTERVALS == _replaceIdx) {
+    if (_numSlots == _replaceIdx) {
       _replaceIdx = 2;
     }
 
@@ -282,7 +294,7 @@ void RocksDBThrottle::ThreadLoop() {
 
     if (_throttleState.load(std::memory_order_relaxed) == ThrottleState::Running) {  
       // test in case of race at shutdown
-      _threadCondvar.wait(THROTTLE_SECONDS * 1000000);
+      _threadCondvar.wait(std::chrono::microseconds(_frequency * 1000));
     } 
   }
 
@@ -293,44 +305,40 @@ void RocksDBThrottle::ThreadLoop() {
 // Routine to actually perform the throttle calculation,
 //  now is external routing from ThreadLoop() to easy unit test
 void RocksDBThrottle::RecalculateThrottle() {
-  unsigned loop;
-  std::chrono::microseconds tot_micros;
-  uint64_t tot_bytes, tot_keys, tot_compact, adjustment_bytes;
-  int64_t new_throttle, compaction_backlog, temp_rate;
+  std::chrono::microseconds tot_micros{0};
+  uint64_t tot_bytes = 0;
+  uint64_t tot_keys = 0;
+  uint64_t tot_compact = 0;
   bool no_data;
 
-  tot_micros *= 0;
-  tot_keys = 0;
-  tot_bytes = 0;
-  tot_compact = 0;
-  temp_rate = 0;
-
-  compaction_backlog = ComputeBacklog();
+  int64_t compaction_backlog = ComputeBacklog();
+  TRI_ASSERT(_throttleData != nullptr);
+  auto& throttleData = *_throttleData;
 
   {
     MUTEX_LOCKER(mutexLocker, _threadMutex);
-
-    _throttleData[_replaceIdx] = _throttleData[1];
-    memset(&_throttleData[1], 0, sizeof(_throttleData[1]));
+    
+    throttleData[_replaceIdx] = throttleData[1];
+    throttleData[1] = ThrottleData_t{};
 
     // this could be faster by keeping running totals and
     //  subtracting [_replaceIdx] before copying [0] into it,
     //  then adding new [_replaceIdx].  But that needs more
     //  time for testing.
-    for (loop = 2; loop < THROTTLE_INTERVALS; ++loop) {
-      tot_micros += _throttleData[loop]._micros;
-      tot_keys += _throttleData[loop]._keys;
-      tot_bytes += _throttleData[loop]._bytes;
-      tot_compact += _throttleData[loop]._compactions;
+    for (uint64_t loop = 2; loop < _numSlots; ++loop) {
+      tot_micros += throttleData[loop]._micros;
+      tot_keys += throttleData[loop]._keys;
+      tot_bytes += throttleData[loop]._bytes;
+      tot_compact += throttleData[loop]._compactions;
     }  // for
 
     // flag to skip throttle changes if zero data available
-    no_data = (0 == tot_bytes && 0 == _throttleData[0]._bytes);
+    no_data = (0 == tot_bytes && 0 == throttleData[0]._bytes);
   }  // unique_lock
 
   // reduce bytes by 10% for each excess level_0 files and/or excess write
   // buffers
-  adjustment_bytes = (tot_bytes * compaction_backlog) / 10;
+  uint64_t adjustment_bytes = (tot_bytes * compaction_backlog) / 10;
   if (adjustment_bytes < tot_bytes) {
     tot_bytes -= adjustment_bytes;
   } else {
@@ -342,9 +350,10 @@ void RocksDBThrottle::RecalculateThrottle() {
   if (!no_data) {
     MUTEX_LOCKER(mutexLocker, _threadMutex);
 
+    int64_t new_throttle;
     // non-level0 data available?
     if (0 != tot_bytes && 0 != tot_micros.count()) {
-      // average bytes per secon for level 1+ compactions
+      // average bytes per second for level 1+ compactions
       //  (adjust bytes upward by 1000000 since dividing by microseconds,
       //   yields integer bytes per second)
       new_throttle = ((tot_bytes * 1000000) / tot_micros.count());
@@ -353,44 +362,49 @@ void RocksDBThrottle::RecalculateThrottle() {
     // attempt to most recent level0
     //  (only use most recent level0 until level1+ data becomes available,
     //   useful on restart of heavily loaded server)
-    else if (0 != _throttleData[0]._bytes && 0 != _throttleData[0]._micros.count()) {
+    else if (0 != throttleData[0]._bytes && 0 != throttleData[0]._micros.count()) {
       new_throttle =
-          (_throttleData[0]._bytes * 1000000) / _throttleData[0]._micros.count();
+          (throttleData[0]._bytes * 1000000) / throttleData[0]._micros.count();
     }  // else if
     else {
       new_throttle = 1;
     }  // else
 
-    if (0 == new_throttle) new_throttle = 1;  // throttle must have an effect
+    if (0 == new_throttle) {
+      new_throttle = 1;  // throttle must have an effect
+    }
 
     // change the throttle slowly
     //  (+1 & +2 keep throttle moving toward goal when difference new and
-    //   old is less than THROTTLE_SCALING)
+    //   old is less than _scalingFactor)
     if (!_firstThrottle) {
-      temp_rate = _throttleBps;
+      int64_t temp_rate = _throttleBps.load(std::memory_order_relaxed);
 
-      if (temp_rate < new_throttle)
-        temp_rate += (new_throttle - temp_rate) / THROTTLE_SCALING + 1;
-      else
-        temp_rate -= (temp_rate - new_throttle) / THROTTLE_SCALING + 2;
+      if (temp_rate < new_throttle) {
+        temp_rate += (new_throttle - temp_rate) / _scalingFactor + 1;
+      } else {
+        temp_rate -= (temp_rate - new_throttle) / _scalingFactor + 2;
+      }
 
       // +2 can make this go negative
-      if (temp_rate < 1) temp_rate = 1;  // throttle must always have an effect
+      if (temp_rate < 1) {
+        temp_rate = 1;  // throttle must always have an effect
+      }
 
       LOG_TOPIC("46d4a", DEBUG, arangodb::Logger::ENGINES)
-          << "RecalculateThrottle(): old " << _throttleBps << ", new " << temp_rate;
+          << "RecalculateThrottle(): old " << _throttleBps << ", new " << temp_rate << ", cap: " << _maxWriteRate;
 
-      _throttleBps = temp_rate;
-
+      _throttleBps = std::min(static_cast<uint64_t>(temp_rate), _maxWriteRate);
+      
       // prepare for next interval
-      memset(&_throttleData[0], 0, sizeof(_throttleData[0]));
+      throttleData[0] = ThrottleData_t{};
     } else if (1 < new_throttle) {
       // never had a valid throttle, and have first hint now
-      _throttleBps = new_throttle;
+      _throttleBps = std::min(static_cast<uint64_t>(new_throttle), _maxWriteRate);
 
       LOG_TOPIC("e0bbb", DEBUG, arangodb::Logger::ENGINES)
           << "RecalculateThrottle(): first " << _throttleBps;
-
+        
       _firstThrottle = false;
     }  // else if
 
@@ -399,7 +413,6 @@ void RocksDBThrottle::RecalculateThrottle() {
     //  Add back only if this becomes a pluggable WriteController with
     //  access to db mutex.
     // SetThrottle();
-
   }  // !no_data && unlock _threadMutex
 
 }  // RocksDBThrottle::RecalculateThrottle
@@ -470,7 +483,7 @@ int64_t RocksDBThrottle::ComputeBacklog() {
   }  // else
 
   // loop through column families to obtain family specific counts
-  for (auto& cf : _families) {
+  for (auto const& cf : _families) {
     property_name = rocksdb::DB::Properties::kNumFilesAtLevelPrefix;
     property_name.append("0");
     ret_flag = _internalRocksDB->GetProperty(cf, property_name, &ret_string);
@@ -480,8 +493,8 @@ int64_t RocksDBThrottle::ComputeBacklog() {
       temp = 0;
     }  // else
 
-    if (kL0_SlowdownWritesTrigger <= temp) {
-      temp -= (kL0_SlowdownWritesTrigger - 1);
+    if (static_cast<int>(_slowdownWritesTrigger) <= temp) {
+      temp -= (static_cast<int>(_slowdownWritesTrigger) - 1);
     } else {
       temp = 0;
     }  // else
@@ -508,7 +521,7 @@ int64_t RocksDBThrottle::ComputeBacklog() {
 ///  it is performing.  The routine is called HEAVILY.
 void RocksDBThrottle::AdjustThreadPriority(int Adjustment) {
 #ifndef _WIN32
-  // initialize thread infor if this the first time the thread has ever called
+  // initialize thread info if this the first time the thread has ever called
   if (!gThreadPriority._baseSet) {
     pid_t tid = syscall(SYS_gettid);
     if (-1 != (int)tid) {
@@ -523,7 +536,7 @@ void RocksDBThrottle::AdjustThreadPriority(int Adjustment) {
     }    // if
   }      // if
 
-  // only change priorities if we
+  // only change priorities if we succeeded
   if (gThreadPriority._baseSet && (gThreadPriority._basePriority + Adjustment) !=
                                       gThreadPriority._currentPriority) {
     pid_t tid;

--- a/arangod/RocksDBEngine/Listeners/RocksDBThrottle.h
+++ b/arangod/RocksDBEngine/Listeners/RocksDBThrottle.h
@@ -38,6 +38,8 @@
 
 #include <chrono>
 #include <future>
+#include <memory>
+#include <vector>
 
 #include "Basics/Common.h"
 #include "Basics/ConditionVariable.h"
@@ -67,7 +69,8 @@ namespace arangodb {
 
 class RocksDBThrottle : public rocksdb::EventListener {
  public:
-  RocksDBThrottle();
+  RocksDBThrottle(uint64_t numSlots, uint64_t frequency, uint64_t scalingFactor, 
+                  uint64_t maxWriteRate, uint64_t slowdownWritesTrigger);
   virtual ~RocksDBThrottle();
 
   void OnFlushBegin(rocksdb::DB* db, const rocksdb::FlushJobInfo& flush_job_info) override;
@@ -100,26 +103,13 @@ class RocksDBThrottle : public rocksdb::EventListener {
 
   void RecalculateThrottle();
 
-  // I am unable to figure out static initialization of std::chrono::seconds,
-  //  using old school unsigned.
-  static constexpr unsigned THROTTLE_SECONDS = 60;
-  static constexpr unsigned THROTTLE_INTERVALS = 63;
-
-  // following is a heuristic value, determined by trial and error.
-  //  its job is slow down the rate of change in the current throttle.
-  //  do not want sudden changes in one or two intervals to swing
-  //  the throttle value wildly.  Goal is a nice, even throttle value.
-  static constexpr unsigned THROTTLE_SCALING = 17;
-
-  // trigger point where level-0 file is considered "too many pending"
-  //  (from original Google leveldb db/dbformat.h)
-  static constexpr int64_t kL0_SlowdownWritesTrigger = 8;
-
   struct ThrottleData_t {
-    std::chrono::microseconds _micros;
-    uint64_t _keys;
-    uint64_t _bytes;
-    uint64_t _compactions;
+    std::chrono::microseconds _micros{};
+    uint64_t _keys = 0;
+    uint64_t _bytes = 0;
+    uint64_t _compactions = 0;
+
+    ThrottleData_t() noexcept = default;
   };
 
   rocksdb::DBImpl* _internalRocksDB;
@@ -143,11 +133,11 @@ class RocksDBThrottle : public rocksdb::EventListener {
   basics::ConditionVariable _threadCondvar;
 
   // this array stores compaction statistics used in throttle calculation.
-  //  Index 0 of this array accumulates the current minute's compaction data for
-  //  level 0. Index 1 accumulates accumulates current minute's compaction
+  //  Index 0 of this array accumulates the current interval's compaction data for
+  //  level 0. Index 1 accumulates accumulates current intervals's compaction
   //  statistics for all other levels.  Remaining intervals contain
-  //  most recent interval statistics for last hour.
-  ThrottleData_t _throttleData[THROTTLE_INTERVALS];
+  //  most recent interval statistics for the total time period.
+  std::unique_ptr<std::vector<ThrottleData_t>> _throttleData;
   size_t _replaceIdx;
 
   std::atomic<uint64_t> _throttleBps;
@@ -156,7 +146,14 @@ class RocksDBThrottle : public rocksdb::EventListener {
   std::unique_ptr<WriteControllerToken> _delayToken;
   std::vector<rocksdb::ColumnFamilyHandle*> _families;
 
-};  // class RocksDBThrottle
+ private:
+  uint64_t const _numSlots;
+  // frequency in milliseconds
+  uint64_t const _frequency; 
+  uint64_t const _scalingFactor;
+  uint64_t const _maxWriteRate;
+  uint64_t const _slowdownWritesTrigger;
+};
 
 }  // namespace arangodb
 

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -366,6 +366,32 @@ void RocksDBEngine::collectOptions(std::shared_ptr<options::ProgramOptions> opti
   options->addOption("--rocksdb.throttle", "enable write-throttling",
                      new BooleanParameter(&_useThrottle),
                      arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle));
+  
+  options->addOption("--rocksdb.throttle-slots", "number of historic metrics to use for throttle value calculation",
+                     new UInt64Parameter(&_throttleSlots),
+                     arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
+                     .setIntroducedIn(30805);
+  
+  options->addOption("--rocksdb.throttle-frequency", "frequency for write-throttle calculations (in milliseconds)",
+                     new UInt64Parameter(&_throttleFrequency),
+                     arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
+                     .setIntroducedIn(30805);
+  
+  options->addOption("--rocksdb.throttle-scaling-factor", "adaptiveness scaling factor for write-throttle calculations",
+                     new UInt64Parameter(&_throttleScalingFactor),
+                     arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
+                     .setIntroducedIn(30805);
+  
+  options->addOption("--rocksdb.throttle-max-write-rate", "maximum write rate enforced by throttle (in bytes per second, 0 = unlimited)",
+                     new UInt64Parameter(&_throttleMaxWriteRate),
+                     arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
+                     .setIntroducedIn(30805);
+  
+  options->addOption("--rocksdb.throttle-slow-down-writes-trigger", "number of level 0 files whose payload "
+                     "is not considered in throttle calculations when penalizing the presence of L0 files",
+                     new UInt64Parameter(&_throttleSlowdownWritesTrigger),
+                     arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
+                     .setIntroducedIn(30805);
 
 #ifdef USE_ENTERPRISE
   options->addOption("--rocksdb.create-sha-files",
@@ -402,6 +428,20 @@ void RocksDBEngine::validateOptions(std::shared_ptr<options::ProgramOptions> opt
 #ifdef USE_ENTERPRISE
   validateEnterpriseOptions(options);
 #endif
+
+  if (_throttleSlots == 0) {
+    LOG_TOPIC("76e1b", FATAL, arangodb::Logger::CONFIG)
+        << "invalid value for --rocksdb.throttle-slots";
+    FATAL_ERROR_EXIT();
+  }
+
+  if (_throttleScalingFactor == 0) {
+    _throttleScalingFactor = 1;
+  }
+
+  if (_throttleSlots < 8) {
+    _throttleSlots = 8;
+  }
 
   if (_requiredDiskFreePercentage < 0.0 || _requiredDiskFreePercentage > 1.0) {
     LOG_TOPIC("e4697", FATAL, arangodb::Logger::CONFIG)
@@ -689,7 +729,8 @@ void RocksDBEngine::start() {
   _options.bloom_locality = 1;
 
   if (_useThrottle) {
-    _throttleListener = std::make_shared<RocksDBThrottle>();
+    _throttleListener = std::make_shared<RocksDBThrottle>(_throttleSlots, _throttleFrequency, _throttleScalingFactor,
+                                                          _throttleMaxWriteRate, _throttleSlowdownWritesTrigger);
     _options.listeners.push_back(_throttleListener);
   }
 

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -571,6 +571,23 @@ class RocksDBEngine final : public StorageEngine {
   std::deque<RocksDBKeyBounds> _pendingCompactions;
   /// @brief number of currently running compaction jobs
   size_t _runningCompactions;
+
+  // frequency for throttle in milliseconds
+  uint64_t _throttleFrequency = 60 * 1000; 
+
+  // number of historic data slots to keep around for throttle
+  uint64_t _throttleSlots = 63;
+  // adaptiveness factor for throttle
+  // following is a heuristic value, determined by trial and error.
+  // its job is slow down the rate of change in the current throttle.
+  // we do not want sudden changes in one or two intervals to swing
+  // the throttle value wildly. the goal is a nice, even throttle value.
+  uint64_t _throttleScalingFactor = 17;
+  // max write rate enforced by throttle
+  uint64_t _throttleMaxWriteRate = 0;
+  // trigger point where level-0 file is considered "too many pending"
+  // (from original Google leveldb db/dbformat.h)
+  uint64_t _throttleSlowdownWritesTrigger = 8;
   
   Gauge<uint64_t>& _metricsWalSequenceLowerBound;
   Gauge<uint64_t>& _metricsArchivedWalFiles;


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/15317
Docs PR: https://github.com/arangodb/docs/pull/841

Added startup options to adjust previously hard-coded parameters for the RocksDB throttle:
- `--rocksdb.throttle-frequency`: frequency for write-throttle calculations (in milliseconds, default value is 60000, i.e. 60 seconds).
- `--rocksdb.throttle-slots`: number of historic measures to use for throttle value calculation (default value is 63).
- `--rocksdb.throttle-scaling-factor`: adaptiveness scaling factor for write-throttle calculations (default value is 17). There is normally no need to change this value.
- `--rocksdb.throttle-slow-down-writes-trigger`: number of level 0 files whose payload is not considered in throttle calculations when penalizing the presence of L0 files. There is normally no need to change this value.
- `--rocksdb.throttle-max-write-rate`: maximum write rate enforced by the throttle (in bytes per second, default value is 0, meaning "unlimited"). The actual write rate will be the minimum of this value and the value the throttle calculation produces.

All these options will only have an effect if `--rocksdb.throttle` is enabled (which is the default). The configuration options introduced here use the previously hard-coded settings as their default values, so there should not be a change in behavior if the options are not adjusted.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/841

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
