### PR TITLE
remove 2 occurences of VPackStringRef that slipped in

### DIFF
--- a/arangod/Replication2/ReplicatedLog/LogCommon.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogCommon.cpp
@@ -286,7 +286,7 @@ auto LogConfig::toVelocyPack(VPackBuilder& builder) const -> void {
   VPackObjectBuilder ob(&builder);
   builder.add(StaticStrings::WaitForSyncString, VPackValue(waitForSync));
   builder.add(StaticStrings::WriteConcern, VPackValue(writeConcern));
-  builder.add(VPackStringRef(StaticStrings::SoftWriteConcern), VPackValue(softWriteConcern));
+  builder.add(StaticStrings::SoftWriteConcern, VPackValue(softWriteConcern));
   builder.add(StaticStrings::ReplicationFactor, VPackValue(replicationFactor));
 }
 

--- a/arangod/Replication2/ReplicatedLog/types.cpp
+++ b/arangod/Replication2/ReplicatedLog/types.cpp
@@ -187,7 +187,7 @@ void replicated_log::AppendEntriesErrorReason::toVelocyPack(velocypack::Builder&
   builder.add(StaticStrings::Error, VPackValue(to_string(error)));
   builder.add(StaticStrings::ErrorMessage, VPackValue(getErrorMessage()));
   if (details) {
-    builder.add(VPackStringRef{kDetailsString}, VPackValue(details.value()));
+    builder.add(kDetailsString, VPackValue(details.value()));
   }
 }
 


### PR DESCRIPTION
### Scope & Purpose

Remove 2 occurences of VPackStringRef that slipped in

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
