### PR TITLE
Adjust rocksdb throttle frequency default value

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,18 @@
 devel
 -----
 
+* Change default value for `--rocksdb.throttle-frequency` to 5000 (i.e. 5 
+  seconds) from previous default value 60000 (60 seconds). This makes the
+  throttling kick in sooner than before, which can help evening out load peaks
+  and prevent server overwhelm.
+
 * Improve some RocksDB-related error messages during server startup.
 
 * Added startup options to adjust previously hard-coded parameters for the 
   RocksDB throttle:
   - `--rocksdb.throttle-frequency`: frequency for write-throttle calculations
-    (in milliseconds, default value is 60000, i.e. 60 seconds).
+    (in milliseconds, default value is 60000, i.e. 60 seconds). Note: this
+    default value was changed by a later commit.
   - `--rocksdb.throttle-slots`: number of historic measures to use for throttle
     value calculation (default value is 63).
   - `--rocksdb.throttle-scaling-factor`: adaptiveness scaling factor for write-
@@ -22,7 +28,8 @@ devel
   All these options will only have an effect if `--rocksdb.throttle` is enabled
   (which is the default). The configuration options introduced here use the
   previously hard-coded settings as their default values, so there should not be
-  a change in behavior if the options are not adjusted.
+  a change in behavior if the options are not adjusted. (Note: a later commit
+  changed the default value for `--rocksdb.throttle-frequency`).
 
 * Raised minimal macOS supported version to 10.15 (Catalina).
 

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -580,7 +580,7 @@ class RocksDBEngine final : public StorageEngine {
   size_t _runningCompactions;
 
   // frequency for throttle in milliseconds
-  uint64_t _throttleFrequency = 60 * 1000; 
+  uint64_t _throttleFrequency = 5 * 1000; 
 
   // number of historic data slots to keep around for throttle
   uint64_t _throttleSlots = 63;


### PR DESCRIPTION
### Scope & Purpose

* Change default value for `--rocksdb.throttle-frequency` to 5000 (i.e. 5 seconds) from previous default value 60000 (60 seconds). This makes the throttling kick in sooner than before, which can help evening out load peaks and prevent server overwhelm.

Docs PR: https://github.com/arangodb/docs/pull/844

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/15327
- [x] Backport for 3.8: TO BE DISCUSSED

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/844

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
