### PR TITLE
cancel ongoing RocksDB compactions on shutdown

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Cancel ongoing RocksDB compactions on server shutdown.
+
 * Improve some RocksDB-related error messages during server startup.
 
 * Added startup options to adjust previously hard-coded parameters for the 

--- a/arangod/RocksDBEngine/RocksDBCommon.cpp
+++ b/arangod/RocksDBEngine/RocksDBCommon.cpp
@@ -241,8 +241,10 @@ Result removeLargeRange(rocksdb::DB* db, RocksDBKeyBounds const& bounds,
   }
 }
 
-Result compactAll(rocksdb::DB* db, bool changeLevel, bool compactBottomMostLevel) {
+Result compactAll(rocksdb::DB* db, bool changeLevel, bool compactBottomMostLevel,
+                  std::atomic<bool>* canceled) {
   rocksdb::CompactRangeOptions options;
+  options.canceled = canceled;
   options.change_level = changeLevel;
   options.bottommost_level_compaction = compactBottomMostLevel ?
       rocksdb::BottommostLevelCompaction::kForceOptimized : 

--- a/arangod/RocksDBEngine/RocksDBCommon.h
+++ b/arangod/RocksDBEngine/RocksDBCommon.h
@@ -40,6 +40,8 @@
 #include <rocksdb/status.h>
 #include <rocksdb/utilities/transaction_db.h>
 
+#include <atomic>
+
 namespace rocksdb {
 class Comparator;
 class ColumnFamilyHandle;
@@ -83,7 +85,8 @@ Result removeLargeRange(rocksdb::DB* db, RocksDBKeyBounds const& bounds,
 /// @brief compacts the entire key range of the database.
 /// warning: may cause a full rewrite of the entire database, which will
 /// take long for large databases - use with care!
-Result compactAll(rocksdb::DB* db, bool changeLevel, bool compactBottomMostLeve);
+Result compactAll(rocksdb::DB* db, bool changeLevel, bool compactBottomMostLevel,
+                  std::atomic<bool>* canceled = nullptr);
 
 // optional switch to std::function to reduce amount of includes and
 // to avoid template

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2006,7 +2006,8 @@ Result RocksDBEngine::changeView(TRI_vocbase_t& vocbase,
 }
 
 Result RocksDBEngine::compactAll(bool changeLevel, bool compactBottomMostLevel) {
-  return rocksutils::compactAll(_db->GetRootDB(), changeLevel, compactBottomMostLevel);
+  return rocksutils::compactAll(_db->GetRootDB(), changeLevel, compactBottomMostLevel, 
+                                &::cancelCompactions);
 }
 
 /// @brief Add engine-specific optimizer rules


### PR DESCRIPTION
### Scope & Purpose

Cancel ongoing RocksDB compactions on server shutdown.
This is an attempt to fix hangs in threads that are waiting in RocksDB compactions during the server shutdown.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backport for 3.9: TO BE DEFINED

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
