### PR TITLE
Change internal RocksDB checksum function to XXH3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Change internal RocksDB checksum function from crc32c to XXH3 for new files.
+
 * Improve some RocksDB-related error messages during server startup.
 
 * Added startup options to adjust previously hard-coded parameters for the 

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -704,6 +704,7 @@ void RocksDBEngine::start() {
   // use slightly space-optimized format version 3
   tableOptions.format_version = 3;
   tableOptions.block_align = opts._blockAlignDataBlocks;
+  tableOptions.checksum = static_cast<rocksdb::ChecksumType>(rocksdb::kXXH3);
 
   _options.table_factory.reset(rocksdb::NewBlockBasedTableFactory(tableOptions));
 


### PR DESCRIPTION
### Scope & Purpose

Change RocksDB internal checksum function to XXH3 from crc32c. This only affects new .sst files that are being written.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
