### PR TITLE
Fix usage of -std=c++latest vs. -std=c++20 in MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -604,9 +604,7 @@ if (CMAKE_COMPILER_IS_GNUCC)
   set(BASE_C_FLAGS "${BASE_C_FLAGS}")
 endif ()
 
-if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG OR APPLE)
-  set(BASE_CXX_FLAGS "${BASE_CXX_FLAGS} -std=c++20")
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   # MSVC2018.1 - MSVC2018.7 does not correctly support alignas()
   if (MSVC_VERSION VERSION_LESS 1915)
     message(FATAL_ERROR "ArangoDB doesn't support MSVC less than 2017 update 15.8!")
@@ -619,10 +617,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   elseif (MSVC_VERSION VERSION_GREATER_EQUAL 1920 AND MSVC_VERSION VERSION_LESS 1924)
     message(FATAL_ERROR "ArangoDB requires at least MSVC 2019 update 16.4!")
   endif()
-  # We need to use c++latest instead of c++20 because <format>, <ranges>, and the formatting part of <chrono> will
-  # remain restricted to /std:c++latest due to WG21's upcoming changes.
-  # For more details on this see https://github.com/microsoft/STL/issues/1814#issuecomment-845572895
-  set(BASE_CXX_FLAGS "${BASE_CXX_FLAGS} -std:c++latest")
 endif()
 
 if (CMAKE_COMPILER_IS_CLANG)
@@ -646,6 +640,13 @@ endif ()
 # need c++20
 # XXX this should really be set on a per target level using cmake compile_features capabilties
 set(CMAKE_CXX_STANDARD 20)
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  # We need to use c++latest instead of c++20 because <format>, <ranges>, and the formatting part of <chrono> will
+  # remain restricted to /std:c++latest due to WG21's upcoming changes.
+  # For more details on this see https://github.com/microsoft/STL/issues/1814#issuecomment-845572895")
+  set(CMAKE_CXX20_STANDARD_COMPILE_OPTION "-std:c++latest")
+  set(CMAKE_CXX20_EXTENSION_COMPILE_OPTION "-std:c++latest")
+endif ()
 
 # need threads
 find_package(Threads REQUIRED)


### PR DESCRIPTION
### Scope & Purpose

Currently our cmake files, for MSVC, set `-std=c++latest` via `CMAKE_CXX_FLAGS`. However, as we provide `set(CMAKE_CXX_STANDARD 20)`, cmake itself passes `-std=c++20`, possibly overriding the former.

- [X] :hammer: Refactoring/simplification

#### Backports:

None.

#### Related Information

https://github.com/arangodb/arangodb/pull/15171

### Testing & Verification

- [X] This change is a trivial rework / code cleanup without any test coverage.