### PR TITLE
cancel ongoing RocksDB compactions on shutdown (#15331)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,9 @@
 v3.9.0 (XXXX-XX-XX)
 -------------------
 
-* Updated Enterprise license behaviour: now there will be a one hour period for
+* Cancel ongoing RocksDB compactions on server shutdown.
+
+* Updated Enterprise license behavior: now there will be a one hour period for
   a new deployment to provide the license. After that period, the read-only mode
   will be enforced.
 

--- a/arangod/RocksDBEngine/RocksDBCommon.cpp
+++ b/arangod/RocksDBEngine/RocksDBCommon.cpp
@@ -242,8 +242,10 @@ Result removeLargeRange(rocksdb::DB* db, RocksDBKeyBounds const& bounds,
   }
 }
 
-Result compactAll(rocksdb::DB* db, bool changeLevel, bool compactBottomMostLevel) {
+Result compactAll(rocksdb::DB* db, bool changeLevel, bool compactBottomMostLevel,
+                  std::atomic<bool>* canceled) {
   rocksdb::CompactRangeOptions options;
+  options.canceled = canceled;
   options.change_level = changeLevel;
   options.bottommost_level_compaction = compactBottomMostLevel ?
       rocksdb::BottommostLevelCompaction::kForceOptimized : 

--- a/arangod/RocksDBEngine/RocksDBCommon.h
+++ b/arangod/RocksDBEngine/RocksDBCommon.h
@@ -40,6 +40,8 @@
 #include <rocksdb/status.h>
 #include <rocksdb/utilities/transaction_db.h>
 
+#include <atomic>
+
 namespace rocksdb {
 class Comparator;
 class ColumnFamilyHandle;
@@ -83,7 +85,8 @@ Result removeLargeRange(rocksdb::DB* db, RocksDBKeyBounds const& bounds,
 /// @brief compacts the entire key range of the database.
 /// warning: may cause a full rewrite of the entire database, which will
 /// take long for large databases - use with care!
-Result compactAll(rocksdb::DB* db, bool changeLevel, bool compactBottomMostLeve);
+Result compactAll(rocksdb::DB* db, bool changeLevel, bool compactBottomMostLevel,
+                  std::atomic<bool>* canceled = nullptr);
 
 // optional switch to std::function to reduce amount of includes and
 // to avoid template


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/15331

Cancel ongoing RocksDB compactions on server shutdown.
This is an attempt to fix hangs in threads that are waiting in RocksDB compactions during the server shutdown.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
