### PR TITLE
[CINFRA-163] Improve replicated state test

### DIFF
--- a/tests/Replication2/ReplicatedState/ReplicatedStateTest.cpp
+++ b/tests/Replication2/ReplicatedState/ReplicatedStateTest.cpp
@@ -96,9 +96,7 @@ TEST_F(ReplicatedStateTest, recreate_follower_on_new_term) {
 
   // create a leader in term 2
   leader = leaderLog->becomeLeader(LogConfig(2, 2, 2, false), "leader", LogTerm{2}, {follower});
-  mux = streams::LogMultiplexer<ReplicatedStateStreamSpec<MyState>>::construct(leader);
-  inputStream = mux->getStreamById<1>();
-  inputStream->insert({.key = "hello", .value = "world"});
+  leader->triggerAsyncReplication();
 
   while (follower->hasPendingAppendEntries()) {
     follower->runAsyncAppendEntries();


### PR DESCRIPTION
### Scope & Purpose

The modified test now checks if entries survive after a follower is recreated.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
