### PR TITLE
catch AQL-Errors for better error messages

### DIFF
--- a/utils/generateExamples.py
+++ b/utils/generateExamples.py
@@ -573,11 +573,19 @@ def generateAQL(testName):
   output += "\\n@R\\n";
 
   if (explainAql) {
-    const explainResult =  require('@arangodb/aql/explainer').explain({bindVars:bv, query:query}, {}, false);
-    ansiAppender(explainResult);
+    try {
+      const explainResult =  require('@arangodb/aql/explainer').explain({bindVars:bv, query:query}, {}, false);
+      ansiAppender(explainResult);
+    } catch (err) {
+      allErrors += '\nRUN FAILED: ' + testName + ', ' + err + '\n' + err.stack + '\n';
+    }
   } else {
-    const result = db._query(query, bv).toArray();
-    jsonAppender(JSON.stringify(result, null, 2));
+    try {
+      const result = db._query(query, bv).toArray();
+      jsonAppender(JSON.stringify(result, null, 2));
+    } catch (err) {
+      allErrors += '\nRUN FAILED: ' + testName + ', ' + err + '\n' + err.stack + '\n';
+    }
   }
 
   if (ds !== '') {

--- a/utils/generateExamples.py
+++ b/utils/generateExamples.py
@@ -577,14 +577,14 @@ def generateAQL(testName):
       const explainResult =  require('@arangodb/aql/explainer').explain({bindVars:bv, query:query}, {}, false);
       ansiAppender(explainResult);
     } catch (err) {
-      allErrors += '\nRUN FAILED: ' + testName + ', ' + err + '\n' + err.stack + '\n';
+      allErrors += '\\nRUN FAILED: ' + testName + ', ' + err + '\\n' + err.stack + '\\n';
     }
   } else {
     try {
       const result = db._query(query, bv).toArray();
       jsonAppender(JSON.stringify(result, null, 2));
     } catch (err) {
-      allErrors += '\nRUN FAILED: ' + testName + ', ' + err + '\n' + err.stack + '\n';
+      allErrors += '\\nRUN FAILED: ' + testName + ', ' + err + '\\n' + err.stack + '\\n';
     }
   }
 


### PR DESCRIPTION
### Scope & Purpose

AQL-Examples may fail. Catch these errors and produce better error messages.

#### Backports:

- [x] Backport for 3.9: *(Please link PR)*
- [x] Backport for 3.8: *(Please link PR)*
- [x] Backport for 3.7: *(Please link PR)*

#### Related Information


- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket number:
- [ ] Design document: 

### Testing & Verification
this testrun should show a proper errormessage now:
 https://jenkins.arangodb.biz/view/Documentation/job/arangodb-ANY-examples/1391/
The error handling is copied from the code used for the other docublocks:
https://github.com/arangodb/arangodb/blob/devel/Documentation/Scripts/exampleHeader.js#L219