### PR TITLE
add integration for another long existing example

### DIFF
--- a/js/common/modules/@arangodb/examples/examples.js
+++ b/js/common/modules/@arangodb/examples/examples.js
@@ -27,6 +27,7 @@
 
 let db = require("internal").db;
 let examples = require("@arangodb/graph-examples/example-graph.js");
+let user_examples = require("@arangodb/examples/example-users.js");
 
 exports.Examples = {
   'traversalGraph': {
@@ -141,6 +142,20 @@ exports.Examples = {
     removeDS: function() {
       try {
         db._drop("observations");
+      } catch (e) {}
+    }
+  },
+  'usersDataset': {
+    createDS: function() {
+      let u = user_examples.createUsers('users');
+      let r = user_examples.createRegions('regions');
+      user_examples.createLocations('locations', u);
+    },
+    removeDS: function() {
+      try {
+        db._drop("users");
+        db._drop("regions");
+        db._drop("locations");
       } catch (e) {}
     }
   }


### PR DESCRIPTION
### Scope & Purpose

`@arangodb/examples/example-users.js` has been existing for very long in our source. connect it to the general example documentation facility.

#### Backports
- 3.9: https://github.com/arangodb/arangodb/pull/15358
- 3.8: https://github.com/arangodb/arangodb/pull/15359
- 3.7: https://github.com/arangodb/arangodb/pull/15360

#### Related Information

This would enable using it in the documentation.

- [x] Docs PR:  none so far.
