### PR TITLE
New RocksDB tuning for pending compactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,7 +22,7 @@ v3.8.5 (XXXX-XX-XX)
   data ingestion or lead to cluster internal timeouts.
 
 * Added startup options to adjust previously hard-coded parameters for RocksDB's
-  behaviour:
+  behavior:
 
   - `--rocksdb.pending-compactions-bytes-slowdown-trigger` controls RocksDB's
     setting `soft_pending_compaction_bytes_limit`, which controls how many

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,16 @@
 v3.8.5 (XXXX-XX-XX)
 -------------------
 
+* Added startup options to adjust previously hard-coded parameters for
+  RocksDB's behaviour:
+
+  - `--rocksdb.pending-compactions-bytes-slowdown-trigger` controls RocksDB's
+    setting `soft_pending_compaction_bytes_limit`, which controls how many
+    pending compaction bytes RocksDB tolerates before it slows down writes.
+  - `--rocksdb.pending-compactions-bytes-stop-trigger` controls RocksDB's
+    setting `hard_pending_compaction_bytes_limit`, which controls how many
+    pending compaction bytes RocksDB tolerates before it stops writes entirely.
+
 * Added startup options to adjust previously hard-coded parameters for the
   RocksDB throttle:
   - `--rocksdb.throttle-frequency`: frequency for write-throttle calculations

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,8 @@ v3.8.5 (XXXX-XX-XX)
   - `--rocksdb.pending-compactions-bytes-stop-trigger` controls RocksDB's
     setting `hard_pending_compaction_bytes_limit`, which controls how many
     pending compaction bytes RocksDB tolerates before it stops writes entirely.
+  - `--rocksdb.throttle-lower-bound-bps`, which controls a lower bound for the
+    bandwidth restriction on RocksDB writes the throttle imposes
 
 * Added startup options to adjust previously hard-coded parameters for the
   RocksDB throttle:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,18 +8,19 @@ v3.8.5 (XXXX-XX-XX)
   - `--rocksdb.level0-stop-trigger` has been increased from 36 to 256
   - `--rocksdb.max-background-jobs` has been increased to the number of cores
     and is no longer limited to 8
-  - `--rocksdb.enabled-pipelined-write` is now `true` by default instead of `false`
+  - `--rocksdb.enabled-pipelined-write` is now `true` by default instead of
+    `false`
   - `--rocksdb.throttle-frequency` has been decreased from 60000ms down to
     1000ms per iteration, which makes the RocksDB throttle react much quicker
-  - `--rocksdb.pending-compactions-slowdown-trigger` has been decreased from
-    64 GB down to 8 GB
-  - `--rocksdb.pending-compactions-stop-trigger` has been decreased from
-    256 GB down to 16 GB
+  - `--rocksdb.pending-compactions-slowdown-trigger` has been decreased from 64
+    GB down to 8 GB
+  - `--rocksdb.pending-compactions-stop-trigger` has been decreased from 256 GB
+    down to 16 GB
   - `--rocksdb.max-subcompactions` has been increased from 1 to 2
   - `--rocksdb.throttle-slots` has been increased from 63 to 120
-  Combined, these changes help ArangoDB/RocksDB to react quicker to a backlog
-  of background jobs and thus to prevent catastrophic stops which abort
-  data ingestion or lead to cluster internal timeouts.
+  Combined, these changes help ArangoDB/RocksDB to react quicker to a backlog of
+  background jobs and thus to prevent catastrophic stops which abort data
+  ingestion or lead to cluster internal timeouts.
 
 * Added startup options to adjust previously hard-coded parameters for RocksDB's
   behavior:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,26 @@
 v3.8.5 (XXXX-XX-XX)
 -------------------
 
+* Changed various default values for RocksDB to tune operations for different
+  typical scenarios like gp2 type volumes and gp3 type volumes and locally
+  attached SSDs with RAID0:
+  - `--rocksdb.level0-slowdown-trigger` has been decreased from 20 to 16
+  - `--rocksdb.level0-stop-trigger` has been increased from 36 to 256
+  - `--rocksdb.max-background-jobs` has been increased to the number of cores
+    and is no longer limited to 8
+  - `--rocksdb.enabled-pipelined-write` is now `true` by default instead of `false`
+  - `--rocksdb.throttle-frequency` has been decreased from 60000ms down to
+    1000ms per iteration, which makes the RocksDB throttle react much quicker
+  - `--rocksdb.pending-compactions-slowdown-trigger` has been decreased from
+    64 GB down to 8 GB
+  - `--rocksdb.pending-compactions-stop-trigger` has been decreased from
+    256 GB down to 16 GB
+  - `--rocksdb.max-subcompactions` has been increased from 1 to 2
+  - `--rocksdb.throttle-slots` has been increased from 63 to 120
+  Combined, these changes help ArangoDB/RocksDB to react quicker to a backlog
+  of background jobs and thus to prevent catastrophic stops which abort
+  data ingestion or lead to cluster internal timeouts.
+
 * Added startup options to adjust previously hard-coded parameters for RocksDB's
   behaviour:
 

--- a/arangod/RocksDBEngine/Listeners/RocksDBThrottle.h
+++ b/arangod/RocksDBEngine/Listeners/RocksDBThrottle.h
@@ -70,7 +70,8 @@ namespace arangodb {
 class RocksDBThrottle : public rocksdb::EventListener {
  public:
   RocksDBThrottle(uint64_t numSlots, uint64_t frequency, uint64_t scalingFactor, 
-                  uint64_t maxWriteRate, uint64_t slowdownWritesTrigger);
+                  uint64_t maxWriteRate, uint64_t slowdownWritesTrigger,
+                  uint64_t lowerBoundBps);
   virtual ~RocksDBThrottle();
 
   void OnFlushBegin(rocksdb::DB* db, const rocksdb::FlushJobInfo& flush_job_info) override;
@@ -153,6 +154,7 @@ class RocksDBThrottle : public rocksdb::EventListener {
   uint64_t const _scalingFactor;
   uint64_t const _maxWriteRate;
   uint64_t const _slowdownWritesTrigger;
+  uint64_t const _lowerBoundThrottleBps;
 };
 
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -650,6 +650,13 @@ void RocksDBEngine::start() {
   // Maximum number of level-0 files.  We stop writes at this point.
   _options.level0_stop_writes_trigger = static_cast<int>(opts._level0StopTrigger);
 
+  // Soft limit on pending compaction bytes. We start slowing down writes
+  // at this point.
+  _options.soft_pending_compaction_bytes_limit = opts._pendingCompactionBytesSlowdownTrigger;
+
+  // Maximum number of pending compaction bytes. We stop writes at this point.
+  _options.hard_pending_compaction_bytes_limit = opts._pendingCompactionBytesStopTrigger;
+
   _options.recycle_log_file_num = opts._recycleLogFileNum;
   _options.compaction_readahead_size = static_cast<size_t>(opts._compactionReadaheadSize);
 

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -403,6 +403,12 @@ void RocksDBEngine::collectOptions(std::shared_ptr<options::ProgramOptions> opti
                      arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
                      .setIntroducedIn(30805);
 
+  options->addOption("--rocksdb.throttle-lower-bound-bps", "lower bound for throttle's "
+                     "write bandwidth in bytes per second",
+                     new UInt64Parameter(&_throttleLowerBoundBps),
+                     arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
+                     .setIntroducedIn(30805);
+
 #ifdef USE_ENTERPRISE
   options->addOption("--rocksdb.create-sha-files",
                      "enable generation of sha256 files for each .sst file",
@@ -747,7 +753,7 @@ void RocksDBEngine::start() {
 
   if (_useThrottle) {
     _throttleListener = std::make_shared<RocksDBThrottle>(_throttleSlots, _throttleFrequency, _throttleScalingFactor,
-                                                          _throttleMaxWriteRate, _throttleSlowdownWritesTrigger);
+                                                          _throttleMaxWriteRate, _throttleSlowdownWritesTrigger, _throttleLowerBoundBps);
     _options.listeners.push_back(_throttleListener);
   }
 

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -594,6 +594,8 @@ class RocksDBEngine final : public StorageEngine {
   // trigger point where level-0 file is considered "too many pending"
   // (from original Google leveldb db/dbformat.h)
   uint64_t _throttleSlowdownWritesTrigger = 8;
+  // Lower bound for computed write bandwidth of throttle:
+  uint64_t _throttleLowerBoundBps = 10 * 1024 * 1024;
   
   Gauge<uint64_t>& _metricsWalSequenceLowerBound;
   Gauge<uint64_t>& _metricsArchivedWalFiles;

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -578,11 +578,11 @@ class RocksDBEngine final : public StorageEngine {
   /// @brief number of currently running compaction jobs
   size_t _runningCompactions;
 
-  // frequency for throttle in milliseconds
-  uint64_t _throttleFrequency = 60 * 1000; 
+  // frequency for throttle in milliseconds between iterations
+  uint64_t _throttleFrequency = 1000; 
 
   // number of historic data slots to keep around for throttle
-  uint64_t _throttleSlots = 63;
+  uint64_t _throttleSlots = 120;
   // adaptiveness factor for throttle
   // following is a heuristic value, determined by trial and error.
   // its job is slow down the rate of change in the current throttle.

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -144,6 +144,8 @@ RocksDBOptionFeature::RocksDBOptionFeature(application_features::ApplicationServ
       _level0CompactionTrigger(2),
       _level0SlowdownTrigger(rocksDBDefaults.level0_slowdown_writes_trigger),
       _level0StopTrigger(rocksDBDefaults.level0_stop_writes_trigger),
+      _pendingCompactionBytesSlowdownTrigger(rocksDBDefaults.soft_pending_compaction_bytes_limit),
+      _pendingCompactionBytesStopTrigger(rocksDBDefaults.hard_pending_compaction_bytes_limit),
       _recycleLogFileNum(rocksDBDefaults.recycle_log_file_num),
       _enforceBlockCacheSizeLimit(false),
       _cacheIndexAndFilterBlocks(rocksDBTableOptionsDefaults.cache_index_and_filter_blocks),
@@ -359,8 +361,14 @@ void RocksDBOptionFeature::collectOptions(std::shared_ptr<ProgramOptions> option
                      new Int64Parameter(&_level0SlowdownTrigger));
 
   options->addOption("--rocksdb.level0-stop-trigger",
-                     "number of level-0 files that triggers a full write stall",
+                     "number of level-0 files that triggers a full write stop",
                      new Int64Parameter(&_level0StopTrigger));
+  options->addOption("--rocksdb.pending-compactions-slowdown-trigger",
+                     "number of pending compaction bytes that triggers a write slowdown",
+                     new UInt64Parameter(&_pendingCompactionBytesSlowdownTrigger));
+  options->addOption("--rocksdb.pending-compactions-stop-trigger",
+                     "number of pending compaction bytes that triggers a full write stop",
+                     new UInt64Parameter(&_pendingCompactionBytesStopTrigger));
 
   options->addOption(
       "--rocksdb.num-threads-priority-high",

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -130,7 +130,7 @@ RocksDBOptionFeature::RocksDBOptionFeature(application_features::ApplicationServ
       _maxBytesForLevelBase(rocksDBDefaults.max_bytes_for_level_base),
       _maxBytesForLevelMultiplier(rocksDBDefaults.max_bytes_for_level_multiplier),
       _maxBackgroundJobs(rocksDBDefaults.max_background_jobs),
-      _maxSubcompactions(rocksDBDefaults.max_subcompactions),
+      _maxSubcompactions(2),
       _numThreadsHigh(0),
       _numThreadsLow(0),
       _targetFileSizeBase(rocksDBDefaults.target_file_size_base),
@@ -142,10 +142,10 @@ RocksDBOptionFeature::RocksDBOptionFeature(application_features::ApplicationServ
                    static_cast<decltype(rocksDBTableOptionsDefaults.block_size)>(16 * 1024))),
       _compactionReadaheadSize(2 * 1024 * 1024),  // rocksDBDefaults.compaction_readahead_size
       _level0CompactionTrigger(2),
-      _level0SlowdownTrigger(rocksDBDefaults.level0_slowdown_writes_trigger),
-      _level0StopTrigger(rocksDBDefaults.level0_stop_writes_trigger),
-      _pendingCompactionBytesSlowdownTrigger(rocksDBDefaults.soft_pending_compaction_bytes_limit),
-      _pendingCompactionBytesStopTrigger(rocksDBDefaults.hard_pending_compaction_bytes_limit),
+      _level0SlowdownTrigger(16),
+      _level0StopTrigger(256),
+      _pendingCompactionBytesSlowdownTrigger(8 * 1073741824ull),
+      _pendingCompactionBytesStopTrigger(16 * 1073741824ull),
       _recycleLogFileNum(rocksDBDefaults.recycle_log_file_num),
       _enforceBlockCacheSizeLimit(false),
       _cacheIndexAndFilterBlocks(rocksDBTableOptionsDefaults.cache_index_and_filter_blocks),
@@ -155,7 +155,7 @@ RocksDBOptionFeature::RocksDBOptionFeature(application_features::ApplicationServ
           rocksDBTableOptionsDefaults.pin_l0_filter_and_index_blocks_in_cache),
       _pinTopLevelIndexAndFilter(rocksDBTableOptionsDefaults.pin_top_level_index_and_filter),
       _blockAlignDataBlocks(rocksDBTableOptionsDefaults.block_align),
-      _enablePipelinedWrite(rocksDBDefaults.enable_pipelined_write),
+      _enablePipelinedWrite(true),
       _optimizeFiltersForHits(rocksDBDefaults.optimize_filters_for_hits),
       _useDirectReads(rocksDBDefaults.use_direct_reads),
       _useDirectIoForFlushAndCompaction(rocksDBDefaults.use_direct_io_for_flush_and_compaction),
@@ -172,16 +172,7 @@ RocksDBOptionFeature::RocksDBOptionFeature(application_features::ApplicationServ
       _minWriteBufferNumberToMergeTouched(false) {
   // setting the number of background jobs to
   _maxBackgroundJobs = static_cast<int32_t>(
-      std::max(static_cast<size_t>(2), std::min(NumberOfCores::getValue(), static_cast<size_t>(8))));
-#ifdef _WIN32
-  // Windows code does not (yet) support lowering thread priority of
-  //  compactions.  Therefore it is possible for rocksdb to use all
-  //  CPU time on compactions.  Essential network communications can be lost.
-  //  Save one CPU for ArangoDB network and other activities.
-  if (2 < _maxBackgroundJobs) {
-    --_maxBackgroundJobs;
-  }  // if
-#endif
+      std::max(static_cast<size_t>(2), NumberOfCores::getValue()));
 
   if (_totalWriteBufferSize == 0) {
     // unlimited write buffer size... now set to some fraction of physical RAM

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -363,12 +363,24 @@ void RocksDBOptionFeature::collectOptions(std::shared_ptr<ProgramOptions> option
   options->addOption("--rocksdb.level0-stop-trigger",
                      "number of level-0 files that triggers a full write stop",
                      new Int64Parameter(&_level0StopTrigger));
-  options->addOption("--rocksdb.pending-compactions-slowdown-trigger",
-                     "number of pending compaction bytes that triggers a write slowdown",
-                     new UInt64Parameter(&_pendingCompactionBytesSlowdownTrigger));
-  options->addOption("--rocksdb.pending-compactions-stop-trigger",
-                     "number of pending compaction bytes that triggers a full write stop",
-                     new UInt64Parameter(&_pendingCompactionBytesStopTrigger));
+  options
+      ->addOption(
+          "--rocksdb.pending-compactions-slowdown-trigger",
+          "number of pending compaction bytes that triggers a write slowdown",
+          new UInt64Parameter(&_pendingCompactionBytesSlowdownTrigger),
+          arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents,
+                                       arangodb::options::Flags::OnDBServer,
+                                       arangodb::options::Flags::OnSingle))
+      .setIntroducedIn(30805);
+  options
+      ->addOption(
+          "--rocksdb.pending-compactions-stop-trigger",
+          "number of pending compaction bytes that triggers a full write stop",
+          new UInt64Parameter(&_pendingCompactionBytesStopTrigger),
+          arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents,
+                                       arangodb::options::Flags::OnDBServer,
+                                       arangodb::options::Flags::OnSingle))
+      .setIntroducedIn(30805);
 
   options->addOption(
       "--rocksdb.num-threads-priority-high",

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.h
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.h
@@ -89,6 +89,8 @@ class RocksDBOptionFeature final : public application_features::ApplicationFeatu
   int64_t _level0CompactionTrigger;
   int64_t _level0SlowdownTrigger;
   int64_t _level0StopTrigger;
+  uint64_t _pendingCompactionBytesSlowdownTrigger;
+  uint64_t _pendingCompactionBytesStopTrigger;
   bool _recycleLogFileNum;
   bool _enforceBlockCacheSizeLimit;
   bool _cacheIndexAndFilterBlocks;


### PR DESCRIPTION
Changed various default values for RocksDB to tune operations for different
  typical scenarios like gp2 type volumes and gp3 type volumes and locally
  attached SSDs with RAID0:
  - `--rocksdb.level0-slowdown-trigger` has been decreased from 20 to 16
  - `--rocksdb.level0-stop-trigger` has been increased from 36 to 256
  - `--rocksdb.max-background-jobs` has been increased to the number of cores
    and is no longer limited to 8
  - `--rocksdb.enabled-pipelined-write` is now `true` by default instead of `false`
  - `--rocksdb.throttle-frequency` has been decreased from 60000ms down to
    1000ms per iteration, which makes the RocksDB throttle react much quicker
  - `--rocksdb.pending-compactions-slowdown-trigger` has been decreased from
    64 GB down to 8 GB
  - `--rocksdb.pending-compactions-stop-trigger` has been decreased from
    256 GB down to 16 GB
  - `--rocksdb.throttle-slots` has been increased from 63 to 120
  Combined, these changes help ArangoDB/RocksDB to react quicker to a backlog
  of background jobs and thus to prevent catastrophic stops which abort
  data ingestion or lead to cluster internal timeouts.

Adjust default value for startup option `--rocksdb.max-subcompactions` from 1
  to 2. This allows compactions jobs to be broken up into disjoint ranges which
  can be processed in parallel.

Added startup options to adjust previously hard-coded parameters for
RocksDB's behaviour:

  - `--rocksdb.pending-compactions-bytes-slowdown-trigger` controls RocksDB's
    setting `soft_pending_compaction_bytes_limit`, which controls how many
    pending compaction bytes RocksDB tolerates before it slows down writes.
  - `--rocksdb.pending-compactions-bytes-stop-trigger` controls RocksDB's
    setting `hard_pending_compaction_bytes_limit`, which controls how many
    pending compaction bytes RocksDB tolerates before it stops writes entirely.

This is the forward port to 3.9Changed various default values for RocksDB to tune operations for different
  typical scenarios like gp2 type volumes and gp3 type volumes and locally
  attached SSDs with RAID0:
  - `--rocksdb.level0-slowdown-trigger` has been decreased from 20 to 16
  - `--rocksdb.level0-stop-trigger` has been increased from 36 to 256
  - `--rocksdb.max-background-jobs` has been increased to the number of cores
    and is no longer limited to 8
  - `--rocksdb.enabled-pipelined-write` is now `true` by default instead of `false`
  - `--rocksdb.throttle-frequency` has been decreased from 60000ms down to
    1000ms per iteration, which makes the RocksDB throttle react much quicker
  - `--rocksdb.pending-compactions-slowdown-trigger` has been decreased from
    64 GB down to 8 GB
  - `--rocksdb.pending-compactions-stop-trigger` has been decreased from
    256 GB down to 16 GB
  - `--rocksdb.throttle-slots` has been increased from 63 to 120
  Combined, these changes help ArangoDB/RocksDB to react quicker to a backlog
  of background jobs and thus to prevent catastrophic stops which abort
  data ingestion or lead to cluster internal timeouts.

Adjust default value for startup option `--rocksdb.max-subcompactions` from 1
  to 2. This allows compactions jobs to be broken up into disjoint ranges which
  can be processed in parallel.

Added startup options to adjust previously hard-coded parameters for
RocksDB's behaviour:

  - `--rocksdb.pending-compactions-bytes-slowdown-trigger` controls RocksDB's
    setting `soft_pending_compaction_bytes_limit`, which controls how many
    pending compaction bytes RocksDB tolerates before it slows down writes.
  - `--rocksdb.pending-compactions-bytes-stop-trigger` controls RocksDB's
    setting `hard_pending_compaction_bytes_limit`, which controls how many
    pending compaction bytes RocksDB tolerates before it stops writes entirely.

This needs forward ports to 3.9 and devel.

Testing:

  - this was manually tested, the defaults have not been touched


Testing:

  - this was manually tested, the defaults have not been touched
