### PR TITLE
go python3; handle bindvalue errors accordingly.

### DIFF
--- a/utils/generateExamples.js
+++ b/utils/generateExamples.js
@@ -136,7 +136,7 @@ function findFreePort() {
 }
 
 function main(argv) {
-  let thePython = 'python';
+  let thePython = 'python3';
   if (fs.exists('build/CMakeCache.txt')) {
     let CMakeCache = fs.readFileSync('build/CMakeCache.txt');
     thePython = CMakeCache.toString().match(/^PYTHON_EXECUTABLE:FILEPATH=(.*)$/m)[1];

--- a/utils/generateExamples.py
+++ b/utils/generateExamples.py
@@ -532,7 +532,7 @@ def generateAQL(testName):
             json.loads(value[AQLBV])
         except json.decoder.JSONDecodeError as ex:
             bv_parse_error = '''
-  allErrors += '\\nRUN FAILED TO JSON PARSE BIND VALUES: {testName},\\nError: {err}\\nUnparseable JSON:\\n {no_json}';
+  allErrors += '\\nRUN FAILED TO JSON PARSE BIND VALUES IN EXAMPLE {testName},\\nError: {err}\\nUnparseable JSON:\\n {no_json}';
 '''.format(**{
     "testName": testName,
     "err": ex.msg,

--- a/utils/generateExamples.py
+++ b/utils/generateExamples.py
@@ -532,7 +532,7 @@ def generateAQL(testName):
             json.loads(value[AQLBV])
         except json.decoder.JSONDecodeError as ex:
             bv_parse_error = '''
-  allErrors += '\\nRUN FAILED TO JSON PARSE BIND VALUES IN EXAMPLE {testName},\\nError: {err}\\nUnparseable JSON:\\n {no_json}';
+  allErrors += '\\nRUN FAILED TO JSON PARSE BIND VALUES IN EXAMPLE {testName}\\nError: {err}\\nUnparseable JSON:\\n {no_json}';
 '''.format(**{
     "testName": testName,
     "err": ex.msg,

--- a/utils/generateExamples.py
+++ b/utils/generateExamples.py
@@ -532,9 +532,10 @@ def generateAQL(testName):
             json.loads(value[AQLBV])
         except json.decoder.JSONDecodeError as ex:
             bv_parse_error = '''
-  allErrors += '\\nRUN FAILED TO JSON PARSE BIND VALUES IN EXAMPLE {testName}\\nError: {err}\\nUnparseable JSON:\\n {no_json}';
+  allErrors += '\\nRUN FAILED TO JSON PARSE BIND VALUES IN EXAMPLE {testName} in {filename}\\nError: {err}\\nUnparseable JSON:\\n {no_json}';
 '''.format(**{
     "testName": testName,
+    "filename": MapSourceFiles[testName],
     "err": ex.msg,
     "no_json": value[AQLBV].encode('unicode_escape').decode("utf-8").replace("'", "\\'")
 })

--- a/utils/generateExamples.py
+++ b/utils/generateExamples.py
@@ -532,7 +532,7 @@ def generateAQL(testName):
             json.loads(value[AQLBV])
         except json.decoder.JSONDecodeError as ex:
             bv_parse_error = '''
-  allErrors += '\\nRUN FAILED TO JSON PARSE BIND VALUES: {testName}, {err}\\nUnparseable JSON: {no_json}';
+  allErrors += '\\nRUN FAILED TO JSON PARSE BIND VALUES: {testName},\\nError: {err}\\nUnparseable JSON:\\n {no_json}';
 '''.format(**{
     "testName": testName,
     "err": ex.msg,

--- a/utils/generateSwagger.sh
+++ b/utils/generateSwagger.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-exec python \
+exec python3 \
   `pwd`/utils/generateSwagger.py \
   `pwd` \
   `pwd`/js/apps/system/_admin/aardvark/APP/api-docs \


### PR DESCRIPTION
### Scope & Purpose

Documentation: handle syntax errors in bind-values accordingly and give better errormessages to the user.

an example of such an error output looks like this:
```
[0.003465414047241211s] done with  working_with_date_time

RUN FAILED TO JSON PARSE BIND VALUES: COMBINING_GRAPH_02_show_geo, Expecting property name enclosed in double quotes
Unparseable JSON: {bonn: [7.0998, 50.7340],
radius: 400000
}
```
#### backports
 - 3.9 https://github.com/arangodb/arangodb/pull/15368
 - 3.8 https://github.com/arangodb/arangodb/pull/15369
 - 3.7 https://github.com/arangodb/arangodb/pull/15370
