### PR TITLE
remove non-portable thread priority adjustment code

### DIFF
--- a/arangod/RocksDBEngine/Listeners/RocksDBThrottle.h
+++ b/arangod/RocksDBEngine/Listeners/RocksDBThrottle.h
@@ -81,8 +81,6 @@ class RocksDBThrottle : public rocksdb::EventListener {
     _families = Families;
   }
 
-  static void AdjustThreadPriority(int Adjustment);
-
   void stopThread();
 
   uint64_t GetThrottle() const { return _throttleBps; }


### PR DESCRIPTION
### Scope & Purpose

Removed non-portable thread priority adjustment code that worked opposite to what the code comments described.
It seems to have _lowered_ the priority of flush/compaction threads instead of raising it. 
Plus, raising the priority would only have been successful under some adjustments to the setup/environment, which are and were not part of our recommended setup. 

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
