### PR TITLE
remove a workaround that was accidentially committed

### DIFF
--- a/arangod/GeneralServer/AcceptorTcp.cpp
+++ b/arangod/GeneralServer/AcceptorTcp.cpp
@@ -175,7 +175,7 @@ void AcceptorTcp<SocketType::Tcp>::asyncAccept() {
   };
 
   // cppcheck-suppress accessMoved
-  _acceptor.async_accept(socket, peer, std::move(handler)); //withLogContext(std::move(handler)));
+  _acceptor.async_accept(socket, peer, withLogContext(std::move(handler)));
 }
 
 template <>
@@ -269,7 +269,7 @@ void AcceptorTcp<SocketType::Ssl>::asyncAccept() {
   };
 
   // cppcheck-suppress accessMoved
-  _acceptor.async_accept(socket, peer, std::move(handler)); //withLogContext(std::move(handler)));
+  _acceptor.async_accept(socket, peer, withLogContext(std::move(handler)));
 }
 }  // namespace rest
 }  // namespace arangodb

--- a/arangod/GeneralServer/AcceptorUnixDomain.cpp
+++ b/arangod/GeneralServer/AcceptorUnixDomain.cpp
@@ -94,7 +94,7 @@ void AcceptorUnixDomain::asyncAccept() {
   };
 
   // cppcheck-suppress accessMoved
-  _acceptor.async_accept(socket, peer, std::move(handler));
+  _acceptor.async_accept(socket, peer, withLogContext(std::move(handler)));
 }
 
 void AcceptorUnixDomain::close() {


### PR DESCRIPTION
### Scope & Purpose

Remove a workaround that allowed compilation with g++-11 a while ago.
The workaround is not necessary anymore, as the compile issue was properly fixed via commit 6c9531a480a33dff7c84934104da11de1fd8fffe.
This is an internal change. No previous version was affected.
Verified that this version compiles with g++-10 and g++-11.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
