### PR TITLE
make "numberOfCores" and "physicalMemory" available to agency

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,14 +1,17 @@
 devel
 -----
 
+* Make per-server values "numberOfCores" and "physicalMemory" available to
+  agency to improve quality of potential future shard rebalancing algorithms.
+
 * Unify the result structure of `db._version(true)` calls for arangosh and
   server console. Previously such a call in the server console would return
   a different structure that only consisted of the `details` subobject.
   This is now unified so that the result structure in the server console is
   consistent with arangosh, but strictly speaking this is a breaking change.
 
-* Set a limit for ArangoSearch segment size to 256MB during recovery to avoid OOM kill in rare 
-  cases.
+* Set a limit for ArangoSearch segment size to 256MB during recovery to avoid 
+  OOM kill in rare cases.
 
 * Updated arangosync to 2.7.0.
 

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -36,6 +36,8 @@
 #include "Agency/TimeString.h"
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/FileUtils.h"
+#include "Basics/NumberOfCores.h"
+#include "Basics/PhysicalMemory.h"
 #include "Basics/ReadLocker.h"
 #include "Basics/ResultT.h"
 #include "Basics/StringUtils.h"
@@ -917,6 +919,8 @@ bool ServerState::registerAtAgencyPhase2(AgencyComm& comm, bool const hadPersist
       builder.add("endpoint", VPackValue(_myEndpoint));
       builder.add("advertisedEndpoint", VPackValue(_advertisedEndpoint));
       builder.add("host", VPackValue(getHost()));
+      builder.add("physicalMemory", VPackValue(PhysicalMemory::getValue()));
+      builder.add("numberOfCores", VPackValue(NumberOfCores::getValue()));
       builder.add("version", VPackValue(rest::Version::getNumericServerVersion()));
       builder.add("versionString", VPackValue(rest::Version::getServerVersion()));
       builder.add("engine",


### PR DESCRIPTION
### Scope & Purpose

Make "numberOfCores" and "physicalMemory" available to agency, for any potential future shard rebalancing algorithms.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
