### PR TITLE
abort shard synchronization in case the follower becomes undesired

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.8.5 (XXXX-XX-XX)
 -------------------
 
+* Allow initial, full dump shard synchronization to abort prematurely if it 
+  turns out that the follower was removed from the plan as a follower (e.g. if 
+  there are enough other in-sync followers).
+
 * Set the limit for ArangoSearch segment size to 256MB during recovery to avoid
   OOM kill in rare cases.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.8.5 (XXXX-XX-XX)
 -------------------
 
-* Allow initial, full dump shard synchronization to abort prematurely if it 
-  turns out that the follower was removed from the plan as a follower (e.g. if 
+* Allow initial, full dump shard synchronization to abort prematurely if it
+  turns out that the follower was removed from the plan as a follower (e.g. if
   there are enough other in-sync followers).
 
 * Set the limit for ArangoSearch segment size to 256MB during recovery to avoid

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -32,6 +32,7 @@
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/debugging.h"
 #include "Cluster/ActionDescription.h"
+#include "Cluster/AgencyCache.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/FollowerInfo.h"
@@ -583,6 +584,38 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
     // store leader info for later, so that the next phases don't need to acquire it again.
     // this saves an HTTP roundtrip to the leader when initializing the WAL tailing.
     return tailingSyncer->inheritFromInitialSyncer(syncer);
+  });
+  
+  syncer->setAbortionCheckCallback([&]() -> bool {
+    // Will return true if the SynchronizeShard job should be aborted.
+    auto& agencyCache = job.feature().server().getFeature<ClusterFeature>().agencyCache();
+    std::string path = "Plan/Collections/" + database + "/" +
+          std::to_string(col->planId().id()) + "/shards/" + col->name();
+    VPackBuilder builder;
+    agencyCache.get(builder, path);
+
+    if (!builder.isEmpty()) {
+      VPackSlice plan = builder.slice();
+      if (plan.isArray()) {
+        if (plan.length() >= 2) {
+          if (plan[0].isString() && plan[0].isEqualString(leaderId)) {
+            std::string myself = arangodb::ServerState::instance()->getId();
+            for (size_t i = 1; i < plan.length(); ++i) {
+              if (plan[i].isString() && plan[i].isEqualString(myself)) {
+                // do not abort the synchronization
+                return false;
+              }
+            }
+          }
+        }
+      }
+    }
+    
+    // abort synchronization
+    LOG_TOPIC("f6dbc", INFO, Logger::REPLICATION)
+        << "aborting initial sync for " << database << "/" << col->name()
+        << " because we are not planned as a follower anymore";
+    return true;
   });
 
   SyncerId syncerId{syncer->syncerId()};

--- a/arangod/Replication/DatabaseInitialSyncer.h
+++ b/arangod/Replication/DatabaseInitialSyncer.h
@@ -32,6 +32,7 @@
 #include "Replication/utilities.h"
 #include "Utils/SingleCollectionTransaction.h"
 
+#include <chrono>
 #include <memory>
 
 struct TRI_vocbase_t;
@@ -161,6 +162,10 @@ class DatabaseInitialSyncer : public InitialSyncer {
   void setOnSuccessCallback(std::function<Result(DatabaseInitialSyncer&)> const& cb) {
     _onSuccess = cb;
   }
+  
+  void setAbortionCheckCallback(std::function<bool()> const& cb) {
+    _checkAbortion = cb;
+  }
 
  private:
   enum class FormatHint {
@@ -256,7 +261,14 @@ class DatabaseInitialSyncer : public InitialSyncer {
 
   Configuration _config;
   
+  // custom callback executed when synchronization was completed successfully
   std::function<Result(DatabaseInitialSyncer&)> _onSuccess;
+
+  // custom callback to check if the sync should be aborted
+  std::function<bool()> _checkAbortion;
+
+  // point in time when we last executed the _checkAbortion callback
+  mutable std::chrono::steady_clock::time_point _lastAbortionCheck;
 
   /// @brief whether or not we are a coordinator/dbserver
   bool const _isClusterRole;


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/15363

Allow initial, full dump shard synchronization to abort prematurely if it turns out that the follower was removed from the plan as a follower (e.g. if there are enough other in-sync followers).

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
