### PR TITLE
[CINFRA-181] Rest API default limits

### DIFF
--- a/arangod/Replication2/Methods.h
+++ b/arangod/Replication2/Methods.h
@@ -51,6 +51,8 @@ struct WaitForResult;
  * request to the leader.
  */
 struct ReplicatedLogMethods {
+  static constexpr auto kDefaultLimit = std::size_t{10};
+
   virtual ~ReplicatedLogMethods() = default;
   virtual auto createReplicatedLog(agency::LogPlanSpecification const& spec) const
       -> futures::Future<Result> = 0;

--- a/js/client/modules/@arangodb/replicated-logs.js
+++ b/js/client/modules/@arangodb/replicated-logs.js
@@ -33,6 +33,8 @@ function ArangoReplicatedLog(database, id) {
 
 exports.ArangoReplicatedLog = ArangoReplicatedLog;
 
+ArangoReplicatedLog.prototype.defaultLimit = 10;
+
 ArangoReplicatedLog.prototype.id = function () {
   return this._id;
 };
@@ -69,25 +71,25 @@ ArangoReplicatedLog.prototype.status = function() {
   return requestResult.result;
 };
 
-ArangoReplicatedLog.prototype.head = function(limit = 100) {
+ArangoReplicatedLog.prototype.head = function(limit = this.defaultLimit) {
   let requestResult = this._database._connection.GET(this._baseurl() + `/head?limit=${limit}`);
   arangosh.checkRequestResult(requestResult);
   return requestResult.result;
 };
 
-ArangoReplicatedLog.prototype.tail = function(limit = 100) {
+ArangoReplicatedLog.prototype.tail = function(limit = this.defaultLimit) {
   let requestResult = this._database._connection.GET(this._baseurl() + `/tail?limit=${limit}`);
   arangosh.checkRequestResult(requestResult);
   return requestResult.result;
 };
 
-ArangoReplicatedLog.prototype.slice = function(start, stop) {
+ArangoReplicatedLog.prototype.slice = function(start = 0, stop = start + this.defaultLimit + 1) {
   let requestResult = this._database._connection.GET(this._baseurl() + `/slice?start=${start}&stop=${stop}`);
   arangosh.checkRequestResult(requestResult);
   return requestResult.result;
 };
 
-ArangoReplicatedLog.prototype.poll = function(first, limit = 100) {
+ArangoReplicatedLog.prototype.poll = function(first = 0, limit = this.defaultLimit) {
   let requestResult = this._database._connection.GET(this._baseurl() + `/poll?first=${first}&limit=${limit}`);
   arangosh.checkRequestResult(requestResult);
   return requestResult.result;

--- a/js/client/modules/@arangodb/replicated-logs.js
+++ b/js/client/modules/@arangodb/replicated-logs.js
@@ -33,8 +33,6 @@ function ArangoReplicatedLog(database, id) {
 
 exports.ArangoReplicatedLog = ArangoReplicatedLog;
 
-ArangoReplicatedLog.prototype.defaultLimit = 10;
-
 ArangoReplicatedLog.prototype.id = function () {
   return this._id;
 };
@@ -71,26 +69,54 @@ ArangoReplicatedLog.prototype.status = function() {
   return requestResult.result;
 };
 
-ArangoReplicatedLog.prototype.head = function(limit = this.defaultLimit) {
-  let requestResult = this._database._connection.GET(this._baseurl() + `/head?limit=${limit}`);
+ArangoReplicatedLog.prototype.head = function(limit) {
+  let query = '/head';
+  if (limit !== undefined) {
+    query += `?limit=${limit}`;
+  }
+  let requestResult = this._database._connection.GET(this._baseurl() + query);
   arangosh.checkRequestResult(requestResult);
   return requestResult.result;
 };
 
-ArangoReplicatedLog.prototype.tail = function(limit = this.defaultLimit) {
-  let requestResult = this._database._connection.GET(this._baseurl() + `/tail?limit=${limit}`);
+ArangoReplicatedLog.prototype.tail = function(limit) {
+  let query = '/tail';
+  if (limit !== undefined) {
+    query += `?limit=${limit}`;
+  }
+  let requestResult = this._database._connection.GET(this._baseurl() + query);
   arangosh.checkRequestResult(requestResult);
   return requestResult.result;
 };
 
-ArangoReplicatedLog.prototype.slice = function(start = 0, stop = start + this.defaultLimit + 1) {
-  let requestResult = this._database._connection.GET(this._baseurl() + `/slice?start=${start}&stop=${stop}`);
+ArangoReplicatedLog.prototype.slice = function(start, stop) {
+  let query = '/slice?';
+  if (start !== undefined) {
+    query += `start=${start}`;
+  }
+  if (stop !== undefined) {
+    if (start !== undefined) {
+      query += `&`;
+    }
+    query += `stop=${stop}`;
+  }
+  let requestResult = this._database._connection.GET(this._baseurl() + query);
   arangosh.checkRequestResult(requestResult);
   return requestResult.result;
 };
 
-ArangoReplicatedLog.prototype.poll = function(first = 0, limit = this.defaultLimit) {
-  let requestResult = this._database._connection.GET(this._baseurl() + `/poll?first=${first}&limit=${limit}`);
+ArangoReplicatedLog.prototype.poll = function(first, limit) {
+  let query = '/poll?';
+  if (first !== undefined) {
+    query += `first=${first}`;
+  }
+  if (limit !== undefined) {
+    if (first !== undefined) {
+      query += `&`;
+    }
+    query += `limit=${limit}`;
+  }
+  let requestResult = this._database._connection.GET(this._baseurl() + query);
   arangosh.checkRequestResult(requestResult);
   return requestResult.result;
 };

--- a/tests/js/common/shell/shell-replicated-logs-cluster.js
+++ b/tests/js/common/shell/shell-replicated-logs-cluster.js
@@ -139,12 +139,18 @@ function ReplicatedLogsWriteSuite () {
         assertTrue(next > index);
         index = next;
       }
-      let head = log.head(11);  // skip first entry
+      let head = log.head();
+      assertEqual(head.length, 10);
+      assertEqual(head[9].logIndex, 10);
+      head = log.head(11);  // skip first entry
       assertEqual(head.length, 11);
       for (let i = 0; i < 10; i++) {
         assertEqual(head[i+1].payload.foo, i);
       }
-      let tail = log.tail(10);
+      let tail = log.tail();
+      assertEqual(tail.length, 10);
+      assertEqual(tail[9].logIndex, 101);
+      tail = log.tail(10);
       assertEqual(tail.length, 10);
       for (let i = 0; i < 10; i++) {
         assertEqual(tail[i].payload.foo, 100 + i - 10);
@@ -159,7 +165,11 @@ function ReplicatedLogsWriteSuite () {
         assertTrue(next > index);
         index = next;
       }
-      let s = log.slice(50, 60);
+      let s = log.slice();
+      assertEqual(s.length, 10);
+      assertEqual(s[0].logIndex, 1);
+      assertEqual(s[9].logIndex, 10);
+      s = log.slice(50, 60);
       assertEqual(s.length, 10);
       for (let i = 0; i < 10; i++) {
         assertEqual(s[i].logIndex, 50 + i);
@@ -194,7 +204,11 @@ function ReplicatedLogsWriteSuite () {
         assertTrue(next > index);
         index = next;
       }
-      let s = log.poll(50, 10);
+      let s = log.poll();
+      assertEqual(s.length, 9);
+      assertEqual(s[0].logIndex, 1);
+      assertEqual(s[8].logIndex, 9);
+      s = log.poll(50, 10);
       assertEqual(s.length, 10);
       for (let i = 0; i < 10; i++) {
         assertEqual(s[i].logIndex, 50 + i);


### PR DESCRIPTION
### Scope & Purpose

This pull requests sets the following default values for some of the methods:
- head?limit=10
- tail?limit=10
- slice?start=0&end=11
- poll?first=0&limit=10

Constants are used instead of hardcoded values.
Some tests were modified to ensure consistency between the V8 implementation and the HTTP client.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as replication2 tests.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools