### PR TITLE
New RocksDB tuning for pending compactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,9 @@ devel
   - `--rocksdb.pending-compactions-stop-trigger` has been decreased from
     256 GB down to 16 GB
   - `--rocksdb.throttle-slots` has been increased from 63 to 120
+  - `--rocksdb.encryption-hardware-acceleration` is now `true` by default,
+    which helps performance and should not create any problems, since we
+    require sandybridge anyway.
   Combined, these changes help ArangoDB/RocksDB to react quicker to a backlog
   of background jobs and thus to prevent catastrophic stops which abort
   data ingestion or lead to cluster internal timeouts.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,37 @@
 devel
 -----
 
+* Changed various default values for RocksDB to tune operations for different
+  typical scenarios like gp2 type volumes and gp3 type volumes and locally
+  attached SSDs with RAID0:
+  - `--rocksdb.level0-slowdown-trigger` has been decreased from 20 to 16
+  - `--rocksdb.level0-stop-trigger` has been increased from 36 to 256
+  - `--rocksdb.max-background-jobs` has been increased to the number of cores
+    and is no longer limited to 8
+  - `--rocksdb.enabled-pipelined-write` is now `true` by default instead of `false`
+  - `--rocksdb.throttle-frequency` has been decreased from 60000ms down to
+    1000ms per iteration, which makes the RocksDB throttle react much quicker
+  - `--rocksdb.pending-compactions-slowdown-trigger` has been decreased from
+    64 GB down to 8 GB
+  - `--rocksdb.pending-compactions-stop-trigger` has been decreased from
+    256 GB down to 16 GB
+  - `--rocksdb.throttle-slots` has been increased from 63 to 120
+  Combined, these changes help ArangoDB/RocksDB to react quicker to a backlog
+  of background jobs and thus to prevent catastrophic stops which abort
+  data ingestion or lead to cluster internal timeouts.
+
+* Added startup options to adjust previously hard-coded parameters for RocksDB's
+  behavior:
+
+  - `--rocksdb.pending-compactions-bytes-slowdown-trigger` controls RocksDB's
+    setting `soft_pending_compaction_bytes_limit`, which controls how many
+    pending compaction bytes RocksDB tolerates before it slows down writes.
+  - `--rocksdb.pending-compactions-bytes-stop-trigger` controls RocksDB's
+    setting `hard_pending_compaction_bytes_limit`, which controls how many
+    pending compaction bytes RocksDB tolerates before it stops writes entirely.
+  - `--rocksdb.throttle-lower-bound-bps`, which controls a lower bound for the
+    bandwidth restriction on RocksDB writes the throttle imposes.
+
 * Fixed PRESUPP-439: In arangoimport, for CSV and TSV files, it could happen 
   that a buffer containing only the header would be sent to the server, and 
   also batches would contain the documents equivalent to the csv rows in them, 

--- a/arangod/RocksDBEngine/Listeners/RocksDBThrottle.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBThrottle.cpp
@@ -61,7 +61,8 @@ thread_local std::chrono::steady_clock::time_point flushStart = std::chrono::ste
 
 // Setup the object, clearing variables, but do no real work
 RocksDBThrottle::RocksDBThrottle(uint64_t numSlots, uint64_t frequency, uint64_t scalingFactor,
-                                 uint64_t maxWriteRate, uint64_t slowdownWritesTrigger)
+                                 uint64_t maxWriteRate, uint64_t slowdownWritesTrigger,
+                                 uint64_t lowerBoundBps)
     : _internalRocksDB(nullptr),
       _throttleState(ThrottleState::NotStarted),
       _replaceIdx(2),
@@ -71,7 +72,8 @@ RocksDBThrottle::RocksDBThrottle(uint64_t numSlots, uint64_t frequency, uint64_t
       _frequency(frequency),
       _scalingFactor(scalingFactor),
       _maxWriteRate(maxWriteRate == 0 ? std::numeric_limits<uint64_t>::max() : maxWriteRate), 
-      _slowdownWritesTrigger(slowdownWritesTrigger) {
+      _slowdownWritesTrigger(slowdownWritesTrigger),
+      _lowerBoundThrottleBps(lowerBoundBps) {
       
   TRI_ASSERT(_scalingFactor != 0);
   _throttleData = std::make_unique<std::vector<ThrottleData_t>>();
@@ -332,15 +334,19 @@ void RocksDBThrottle::RecalculateThrottle() {
       }
 
       LOG_TOPIC("46d4a", DEBUG, arangodb::Logger::ENGINES)
-          << "RecalculateThrottle(): old " << _throttleBps << ", new " << temp_rate << ", cap: " << _maxWriteRate;
+          << "RecalculateThrottle(): old " << _throttleBps << ", new " << temp_rate
+          << ", cap: " << _maxWriteRate << ", lower bound: " << _lowerBoundThrottleBps;
 
-      _throttleBps = std::min(static_cast<uint64_t>(temp_rate), _maxWriteRate);
-      
+      _throttleBps = std::max(_lowerBoundThrottleBps,
+                              std::min(static_cast<uint64_t>(temp_rate), _maxWriteRate));
+
       // prepare for next interval
       throttleData[0] = ThrottleData_t{};
     } else if (1 < new_throttle) {
       // never had a valid throttle, and have first hint now
-      _throttleBps = std::min(static_cast<uint64_t>(new_throttle), _maxWriteRate);
+      _throttleBps =
+          std::max(_lowerBoundThrottleBps,
+                   std::min(static_cast<uint64_t>(new_throttle), _maxWriteRate));
 
       LOG_TOPIC("e0bbb", DEBUG, arangodb::Logger::ENGINES)
           << "RecalculateThrottle(): first " << _throttleBps;

--- a/arangod/RocksDBEngine/Listeners/RocksDBThrottle.h
+++ b/arangod/RocksDBEngine/Listeners/RocksDBThrottle.h
@@ -68,7 +68,8 @@ namespace arangodb {
 class RocksDBThrottle : public rocksdb::EventListener {
  public:
   RocksDBThrottle(uint64_t numSlots, uint64_t frequency, uint64_t scalingFactor, 
-                  uint64_t maxWriteRate, uint64_t slowdownWritesTrigger);
+                  uint64_t maxWriteRate, uint64_t slowdownWritesTrigger,
+                  uint64_t lowerBoundBps);
   virtual ~RocksDBThrottle();
 
   void OnFlushBegin(rocksdb::DB* db, const rocksdb::FlushJobInfo& flush_job_info) override;
@@ -149,6 +150,7 @@ class RocksDBThrottle : public rocksdb::EventListener {
   uint64_t const _scalingFactor;
   uint64_t const _maxWriteRate;
   uint64_t const _slowdownWritesTrigger;
+  uint64_t const _lowerBoundThrottleBps;
 }; 
 
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -405,6 +405,12 @@ void RocksDBEngine::collectOptions(std::shared_ptr<options::ProgramOptions> opti
                      arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
                      .setIntroducedIn(30805);
 
+  options->addOption("--rocksdb.throttle-lower-bound-bps", "lower bound for throttle's "
+                     "write bandwidth in bytes per second",
+                     new UInt64Parameter(&_throttleLowerBoundBps),
+                     arangodb::options::makeFlags(arangodb::options::Flags::DefaultNoComponents, arangodb::options::Flags::OnDBServer, arangodb::options::Flags::OnSingle, arangodb::options::Flags::Hidden))
+                     .setIntroducedIn(30805);
+
 #ifdef USE_ENTERPRISE
   options->addOption("--rocksdb.create-sha-files",
                      "enable generation of sha256 files for each .sst file",
@@ -643,6 +649,13 @@ void RocksDBEngine::start() {
   // Maximum number of level-0 files.  We stop writes at this point.
   _options.level0_stop_writes_trigger = static_cast<int>(opts._level0StopTrigger);
 
+  // Soft limit on pending compaction bytes. We start slowing down writes
+  // at this point.
+  _options.soft_pending_compaction_bytes_limit = opts._pendingCompactionBytesSlowdownTrigger;
+
+  // Maximum number of pending compaction bytes. We stop writes at this point.
+  _options.hard_pending_compaction_bytes_limit = opts._pendingCompactionBytesStopTrigger;
+
   _options.recycle_log_file_num = opts._recycleLogFileNum;
   _options.compaction_readahead_size = static_cast<size_t>(opts._compactionReadaheadSize);
 
@@ -742,7 +755,7 @@ void RocksDBEngine::start() {
 
   if (_useThrottle) {
     _throttleListener = std::make_shared<RocksDBThrottle>(_throttleSlots, _throttleFrequency, _throttleScalingFactor,
-                                                          _throttleMaxWriteRate, _throttleSlowdownWritesTrigger);
+                                                          _throttleMaxWriteRate, _throttleSlowdownWritesTrigger, _throttleLowerBoundBps);
     _options.listeners.push_back(_throttleListener);
   }
 

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -579,11 +579,11 @@ class RocksDBEngine final : public StorageEngine {
   /// @brief number of currently running compaction jobs
   size_t _runningCompactions;
 
-  // frequency for throttle in milliseconds
-  uint64_t _throttleFrequency = 60 * 1000; 
+  // frequency for throttle in milliseconds between iterations
+  uint64_t _throttleFrequency = 1000; 
 
   // number of historic data slots to keep around for throttle
-  uint64_t _throttleSlots = 63;
+  uint64_t _throttleSlots = 120;
   // adaptiveness factor for throttle
   // following is a heuristic value, determined by trial and error.
   // its job is slow down the rate of change in the current throttle.
@@ -595,6 +595,8 @@ class RocksDBEngine final : public StorageEngine {
   // trigger point where level-0 file is considered "too many pending"
   // (from original Google leveldb db/dbformat.h)
   uint64_t _throttleSlowdownWritesTrigger = 8;
+  // Lower bound for computed write bandwidth of throttle:
+  uint64_t _throttleLowerBoundBps = 10 * 1024 * 1024;
   
   metrics::Gauge<uint64_t>& _metricsWalSequenceLowerBound;
   metrics::Gauge<uint64_t>& _metricsArchivedWalFiles;

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.h
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.h
@@ -88,6 +88,8 @@ class RocksDBOptionFeature final : public application_features::ApplicationFeatu
   int64_t _level0CompactionTrigger;
   int64_t _level0SlowdownTrigger;
   int64_t _level0StopTrigger;
+  uint64_t _pendingCompactionBytesSlowdownTrigger;
+  uint64_t _pendingCompactionBytesStopTrigger;
   bool _recycleLogFileNum;
   bool _enforceBlockCacheSizeLimit;
   bool _cacheIndexAndFilterBlocks;


### PR DESCRIPTION
Changed various default values for RocksDB to tune operations for different
  typical scenarios like gp2 type volumes and gp3 type volumes and locally
  attached SSDs with RAID0:
  - `--rocksdb.level0-slowdown-trigger` has been decreased from 20 to 16
  - `--rocksdb.level0-stop-trigger` has been increased from 36 to 256
  - `--rocksdb.max-background-jobs` has been increased to the number of cores
    and is no longer limited to 8
  - `--rocksdb.enabled-pipelined-write` is now `true` by default instead of `false`
  - `--rocksdb.throttle-frequency` has been decreased from 60000ms down to
    1000ms per iteration, which makes the RocksDB throttle react much quicker
  - `--rocksdb.pending-compactions-slowdown-trigger` has been decreased from
    64 GB down to 8 GB
  - `--rocksdb.pending-compactions-stop-trigger` has been decreased from
    256 GB down to 16 GB
  - `--rocksdb.throttle-slots` has been increased from 63 to 120
  Combined, these changes help ArangoDB/RocksDB to react quicker to a backlog
  of background jobs and thus to prevent catastrophic stops which abort
  data ingestion or lead to cluster internal timeouts.

Adjust default value for startup option `--rocksdb.max-subcompactions` from 1
  to 2. This allows compactions jobs to be broken up into disjoint ranges which
  can be processed in parallel.

Added startup options to adjust previously hard-coded parameters for
RocksDB's behaviour:

  - `--rocksdb.pending-compactions-bytes-slowdown-trigger` controls RocksDB's
    setting `soft_pending_compaction_bytes_limit`, which controls how many
    pending compaction bytes RocksDB tolerates before it slows down writes.
  - `--rocksdb.pending-compactions-bytes-stop-trigger` controls RocksDB's
    setting `hard_pending_compaction_bytes_limit`, which controls how many
    pending compaction bytes RocksDB tolerates before it stops writes entirely.

This is the forward port to devel. 

Testing:

  - this was manually tested, the defaults have not been touched


