### PR TITLE
[CINFRA-192] Made LogFollower LostLogCore errors more visible in gtests, to avoid …

### DIFF
--- a/arangod/Replication2/ReplicatedLog/LogFollower.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogFollower.cpp
@@ -64,7 +64,23 @@ auto LogFollower::appendEntriesPreFlightChecks(GuardedFollowerData const& data,
                                                AppendEntriesRequest const& req) const noexcept
     -> std::optional<AppendEntriesResult> {
   if (data._logCore == nullptr) {
-    LOG_CTX("d290d", DEBUG, _loggerContext)
+    // Note that a `ReplicatedLog` instance, when destroyed, will resign its
+    // participant. This is intentional and has been thoroughly discussed to be
+    // the preferable behavior in production, so no LogCore can ever be "lost"
+    // but still working in the background. It is expected to be unproblematic,
+    // as the ReplicatedLogs are the entries in the central log registry in the
+    // vocbase.
+    // It is an easy pitfall in the tests, however, as it's easy to drop the
+    // shared_ptr to the ReplicatedLog, and keep only the one to the participant.
+    // In that case, the participant looses its LogCore, which is hard to find
+    // out. Thus we increase the log level for this message to make this more
+    // visible.
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+#define LOST_LOG_CORE_LOGLEVEL WARN
+#else
+#define LOST_LOG_CORE_LOGLEVEL DEBUG
+#endif
+    LOG_CTX("d290d", LOST_LOG_CORE_LOGLEVEL, _loggerContext)
         << "reject append entries - log core gone";
     return AppendEntriesResult::withRejection(_currentTerm, req.messageId,
                                               {AppendEntriesErrorReason::ErrorType::kLostLogCore});


### PR DESCRIPTION
…pitfalls

### Scope & Purpose

- [X] :hammer: Refactoring/simplification

#### Backports:

None.

### Testing & Verification

- [X] This change is a trivial rework / code cleanup without any test coverage.