### PR TITLE
[CINFRA-191] softWriteConcern defaults to writeConcern

### DIFF
--- a/arangod/Replication2/ReplicatedLog/LogCommon.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogCommon.cpp
@@ -277,8 +277,11 @@ auto replication2::operator<<(std::ostream& os, TermIndexPair pair)
 LogConfig::LogConfig(VPackSlice slice) {
   waitForSync = slice.get(StaticStrings::WaitForSyncString).extract<bool>();
   writeConcern = slice.get(StaticStrings::WriteConcern).extract<std::size_t>();
-  softWriteConcern =
-      slice.get(StaticStrings::SoftWriteConcern).extract<std::size_t>();
+  if (auto sw = slice.get(StaticStrings::SoftWriteConcern); !sw.isNone()) {
+    softWriteConcern = sw.extract<std::size_t>();
+  } else {
+    softWriteConcern = writeConcern;
+  }
   replicationFactor =
       slice.get(StaticStrings::ReplicationFactor).extract<std::size_t>();
 }

--- a/tests/Replication2/Serialization/LogCommonTest.cpp
+++ b/tests/Replication2/Serialization/LogCommonTest.cpp
@@ -102,4 +102,13 @@ TEST(LogCommonTest, log_config) {
   auto jsonSlice = velocypack::Slice(jsonBuffer->data());
   EXPECT_TRUE(VelocyPackHelper::equal(jsonSlice, slice, true))
       << "expected " << jsonSlice.toJson() << " found " << slice.toJson();
+
+  jsonBuffer = R"({
+    "writeConcern": 2,
+    "replicationFactor": 3,
+    "waitForSync": false
+  })"_vpack;
+  jsonSlice = velocypack::Slice(jsonBuffer->data());
+  logConfig = LogConfig{jsonSlice};
+  EXPECT_EQ(logConfig.softWriteConcern, logConfig.writeConcern);
 }


### PR DESCRIPTION
### Scope & Purpose

softWriteConcern default to writeConcern if it is not found during de-serialization.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [ ] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as `LogCommonTest.cpp`.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
