### PR TITLE
[devel] fix: clang-format workflow

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -2,7 +2,12 @@ name: clang-format
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ devel, "3.9" ]
+    branches: [ devel ]
+    paths:
+      - "arangod/**"
+      - "client-tools/**"
+      - "lib/**"
+      - "tests/**"
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -11,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Get changed files within arangod, client-tools (arangosh), lib, & tests
-        run: echo "CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }}..${{ github.sha }} -- arangod/ client-tools/ arangosh/ lib/ tests/ | grep -e .cpp$ -e .hpp$ -e .cc$ -e .c$ -e .h$ | xargs)" >> $GITHUB_ENV
+        run: echo "CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }}..${{ github.sha }} -- arangod/ client-tools/ lib/ tests/ | grep -e .cpp$ -e .hpp$ -e .cc$ -e .c$ -e .h$ | xargs)" >> $GITHUB_ENV
       - name: Echo changed files
         run: echo $CHANGED_FILES
       - name: arangodb-clang-format

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,5 +1,8 @@
 name: clang-format
-on: push
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ devel, "3.9" ]
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -8,7 +11,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Get changed files within arangod, client-tools (arangosh), lib, & tests
-        run: echo "CHANGED_FILES=$(git diff --name-only ${{ github.event.before }}..${{ github.event.after }} -- arangod/ client-tools/ arangosh/ lib/ tests/ | grep -e .cpp -e .hpp -e .cc -e .c -e .h | sed -z 's/\n/\ /g')" >> $GITHUB_ENV
+        run: echo "CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }}..${{ github.sha }} -- arangod/ client-tools/ arangosh/ lib/ tests/ | grep -e .cpp$ -e .hpp$ -e .cc$ -e .c$ -e .h$ | xargs)" >> $GITHUB_ENV
       - name: Echo changed files
         run: echo $CHANGED_FILES
       - name: arangodb-clang-format


### PR DESCRIPTION
* Addresses cases of [false-positives](https://github.com/arangodb/arangodb/runs/4650363227?check_suite_focus=true) and [false-negatives](https://github.com/arangodb/arangodb/runs/4650724350?check_suite_focus=true)
* Minor cleanup to the `git diff` command
* Action now only triggers on Pull Requests that point to `devel`, and that modify files within within `arangod`, `client-tools`, `lib`, or `tests`
* Add `workflow_dispatch` event to allow this Action to be triggered manually from the [Actions](https://github.com/arangodb/arangodb/actions) menu