### PR TITLE
styleguide: clang-format documentation

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1,3 +1,39 @@
+# ArangoDB Clang-Format
+
+ArangoDB uses `clang-format` to lint the codebase of [arangodb/arangodb](https://github.com/arangodb/arangodb) & [arangodb/enterprise](https://github.com/arangodb/enterprise).
+
+You are expected to format your local changes via clang-format. Here are your options:
+
+1. Lint with a **pre-commit git hook** (OS dependant)
+    * pre-requisites
+        * Docker
+        * Git 2.9+
+    * how-to (one-time setup)
+        * `cd arangodb`
+        * `git config core.hooksPath .git/hooks`
+        * `cp .githooks/pre-commit-[linux, macos, windows] .git/hooks/pre-commit`
+        * `cd enterprise`
+        * `git config core.hooksPath .git/hooks`
+        * `cp .githooks/pre-commit-[linux, macos, windows] .git/hooks/pre-commit`
+2. Lint with a **local shell script** (OS dependant)
+    * pre-requisites
+        * Docker
+    * how-to (must run manually)
+        * `cd arangodb`
+        * `./scripts/clang-format-[linux, macos, windows].sh`
+
+3. Lint with a **codebase-wide format script** (not recommended unless absolutely necessary)
+    * pre-requisites
+        * Docker
+    * how-to
+        * See [pull/15417#comment](https://github.com/arangodb/arangodb/pull/15417#issuecomment-1001211838) 
+
+4. Lint with your **custom clang-format setup**
+    * This would be up to you to configure, if you do not want to rely on Docker and/or already have a way of automatically linting your changes via clang-format. We still highly encourage that you use `clang-format 12` or higher.
+
+Once your changes are pushed, a [Github Action CI](https://github.com/arangodb/clang-format-action) will be triggered to validate that your changes comply to the [established clang-format standard](https://github.com/arangodb/arangodb/blob/devel/.clang-format). Should you be missing any format specifications, your push’s CI will fail.
+
+
 # ArangoDB coding guidelines
 
 This document is mostly derived from [Google C++ Style

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -10,14 +10,15 @@ You are expected to format your local changes via clang-format. Here are your op
         * Git 2.9+
     * how-to (one-time setup)
         * `cd arangodb`
-        * `git config core.hooksPath .git/hooks`
         * `cp .githooks/pre-commit-[linux, macos, windows] .git/hooks/pre-commit`
+        * `git config core.hooksPath .git/hooks`
         * `cd enterprise`
-        * `git config core.hooksPath .git/hooks`
         * `cp .githooks/pre-commit-[linux, macos, windows] .git/hooks/pre-commit`
+        * `git config core.hooksPath .git/hooks`
 2. Lint with a **local shell script** (OS dependant)
     * pre-requisites
         * Docker
+        * Your local changes have been added with `git add`
     * how-to (must run manually)
         * `cd arangodb`
         * `./scripts/clang-format-[linux, macos, windows].sh`

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -32,7 +32,7 @@ You are expected to format your local changes via clang-format. Here are your op
         * `docker run --rm -u "$(id -u):$(id -g)" --mount type=bind,source="$(pwd)",target=/usr/src/arangodb arangodb/clang-format:1.0 "$files"`
     * how-to (Windows)
         * The [dir](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/dir) command should be able to replace the `find` logic seen above. Please use the same file extension matches.
-        * `docker run --rm --mount type=bind,source="YOUR/PATH/TO/ARANGODB",target=/usr/src/arangodb arangodb/clang-format:1.0 "YOUR LIST OF FILES"`
+        * `docker run --rm --mount type=bind,source=${pwd},target=/usr/src/arangodb arangodb/clang-format:1.0 "YOUR LIST OF FILES"`
 
 4. Lint with your **custom clang-format setup**
     * This would be up to you to configure, if you do not want to rely on Docker and/or already have a way of automatically linting your changes via clang-format. We still highly encourage that you use `clang-format 12` or higher.

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -26,8 +26,13 @@ You are expected to format your local changes via clang-format. Here are your op
 3. Lint with a **codebase-wide format script** (not recommended unless absolutely necessary)
     * pre-requisites
         * Docker
-    * how-to
-        * See [pull/15417#comment](https://github.com/arangodb/arangodb/pull/15417#issuecomment-1001211838) 
+    * how-to (MacOS / Linux)
+        * `cd arangodb`
+        * `files=$(find arangod client-tools arangosh lib tests enterprise/Enterprise enterprise/tests -type f -name "*.cpp" -o -name "*.hpp" -o -name "*.cc" -o -name "*.c" -o -name "*.h")`
+        * `docker run --rm -u "$(id -u):$(id -g)" --mount type=bind,source="$(pwd)",target=/usr/src/arangodb arangodb/clang-format:1.0 "$files"`
+    * how-to (Windows)
+        * The [dir](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/dir) command should be able to replace the `find` logic seen above. Please use the same file extension matches.
+        * `docker run --rm --mount type=bind,source="YOUR/PATH/TO/ARANGODB",target=/usr/src/arangodb arangodb/clang-format:1.0 "YOUR LIST OF FILES"`
 
 4. Lint with your **custom clang-format setup**
     * This would be up to you to configure, if you do not want to rely on Docker and/or already have a way of automatically linting your changes via clang-format. We still highly encourage that you use `clang-format 12` or higher.


### PR DESCRIPTION
* taken from its [confluence page](https://arangodb.atlassian.net/wiki/spaces/DEV/pages/1780908145/Linting+with+Clang+Format).



