### PR TITLE
[3.9] fix: clang-format git diff filter

### DIFF
--- a/.githooks/pre-commit-linux
+++ b/.githooks/pre-commit-linux
@@ -11,7 +11,7 @@ adb_path="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/../.." &> /dev/null && p
 echo "ArangoDB directory: $adb_path"
 cd "$adb_path"
 
-community_diff=$(git diff HEAD --diff-filter=ACMR --name-only -- '*.cpp' '*.hpp' '*.cc' '*.c' '*.h')
+community_diff=$(git diff HEAD --diff-filter=ACMRT --name-only -- '*.cpp' '*.hpp' '*.cc' '*.c' '*.h')
 if ! [[ -z "${community_diff// }" ]]; then
   docker run --rm -u "$(id -u):$(id -g)" --mount type=bind,source="$adb_path",target=/usr/src/arangodb arangodb/clang-format:1.0 "$community_diff"
 fi

--- a/.githooks/pre-commit-macos
+++ b/.githooks/pre-commit-macos
@@ -11,7 +11,7 @@ adb_path="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/../.." &> /dev/null && p
 echo "ArangoDB directory: $adb_path"
 cd "$adb_path"
 
-community_diff=$(git diff HEAD --diff-filter=ACMR --name-only -- '*.cpp' '*.hpp' '*.cc' '*.c' '*.h')
+community_diff=$(git diff HEAD --diff-filter=ACMRT --name-only -- '*.cpp' '*.hpp' '*.cc' '*.c' '*.h')
 if ! [[ -z "${community_diff// }" ]]; then
   docker run --rm -u "$(id -u):$(id -g)" --mount type=bind,source="$adb_path",target=/usr/src/arangodb arangodb/clang-format:1.0 "$community_diff"
 fi

--- a/.githooks/pre-commit-windows
+++ b/.githooks/pre-commit-windows
@@ -11,7 +11,7 @@ adb_path="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/../.." &> /dev/null && p
 echo "ArangoDB directory: $adb_path"
 cd "$adb_path"
 
-community_diff=$(git diff HEAD --diff-filter=ACMR --name-only -- '*.cpp' '*.hpp' '*.cc' '*.c' '*.h')
+community_diff=$(git diff HEAD --diff-filter=ACMRT --name-only -- '*.cpp' '*.hpp' '*.cc' '*.c' '*.h')
 if ! [[ -z "${community_diff// }" ]]; then
   docker run --rm --mount type=bind,source="$adb_path",target=/usr/src/arangodb arangodb/clang-format:1.0 "$community_diff"
 fi

--- a/scripts/clang-format-linux.sh
+++ b/scripts/clang-format-linux.sh
@@ -10,12 +10,12 @@ echo "ArangoDB directory: $adb_path"
 echo "Enterprise directory: $adb_path/$ent_dir"
 
 cd "$adb_path"
-community_diff=$(git diff HEAD --diff-filter=ACMR --name-only -- '*.cpp' '*.hpp' '*.cc' '*.c' '*.h')
+community_diff=$(git diff HEAD --diff-filter=ACMRT --name-only -- '*.cpp' '*.hpp' '*.cc' '*.c' '*.h')
 
 if [ -d "$adb_path/$ent_dir" ]
 then
    cd "$adb_path/$ent_dir"
-   enterprise_diff=$(git diff HEAD --diff-filter=ACMR --name-only -- '*.cpp' '*.hpp' '*.cc' '*.c' '*.h' | sed "s,^,$ent_dir/,")
+   enterprise_diff=$(git diff HEAD --diff-filter=ACMRT --name-only -- '*.cpp' '*.hpp' '*.cc' '*.c' '*.h' | sed "s,^,$ent_dir/,")
 fi
 
 cd "$adb_path"

--- a/scripts/clang-format-macos.sh
+++ b/scripts/clang-format-macos.sh
@@ -10,12 +10,12 @@ echo "ArangoDB directory: $adb_path"
 echo "Enterprise directory: $adb_path/$ent_dir"
 
 cd "$adb_path"
-community_diff=$(git diff HEAD --diff-filter=ACMR --name-only -- '*.cpp' '*.hpp' '*.cc' '*.c' '*.h')
+community_diff=$(git diff HEAD --diff-filter=ACMRT --name-only -- '*.cpp' '*.hpp' '*.cc' '*.c' '*.h')
 
 if [ -d "$adb_path/$ent_dir" ]
 then
    cd "$adb_path/$ent_dir"
-   enterprise_diff=$(git diff HEAD --diff-filter=ACMR --name-only -- '*.cpp' '*.hpp' '*.cc' '*.c' '*.h' | sed "s,^,$ent_dir/,")
+   enterprise_diff=$(git diff HEAD --diff-filter=ACMRT --name-only -- '*.cpp' '*.hpp' '*.cc' '*.c' '*.h' | sed "s,^,$ent_dir/,")
 fi
 
 cd "$adb_path"

--- a/scripts/clang-format-windows.sh
+++ b/scripts/clang-format-windows.sh
@@ -10,12 +10,12 @@ echo "ArangoDB directory: $adb_path"
 echo "Enterprise directory: $adb_path/$ent_dir"
 
 cd "$adb_path"
-community_diff=$(git diff HEAD --diff-filter=ACMR --name-only -- '*.cpp' '*.hpp' '*.cc' '*.c' '*.h')
+community_diff=$(git diff HEAD --diff-filter=ACMRT --name-only -- '*.cpp' '*.hpp' '*.cc' '*.c' '*.h')
 
 if [ -d "$adb_path/$ent_dir" ]
 then
    cd "$adb_path/$ent_dir"
-   enterprise_diff=$(git diff HEAD --diff-filter=ACMR --name-only -- '*.cpp' '*.hpp' '*.cc' '*.c' '*.h' | sed "s,^,$ent_dir/,")
+   enterprise_diff=$(git diff HEAD --diff-filter=ACMRT --name-only -- '*.cpp' '*.hpp' '*.cc' '*.c' '*.h' | sed "s,^,$ent_dir/,")
 fi
 
 cd "$adb_path"


### PR DESCRIPTION
Copy of #15442 for `3.9`

* adds the [T] value to the `--diff-filter` flag, to stay consistent with the [current clang-format action implementation](https://github.com/arangodb/arangodb/blob/3.9/.github/workflows/clang-format.yml#L19)

[Link]( https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203) to `--diff-filter` documentation