### PR TITLE
verify that replicationFactor >= writeConcern

### DIFF
--- a/arangod/Sharding/ShardingInfo.cpp
+++ b/arangod/Sharding/ShardingInfo.cpp
@@ -617,6 +617,13 @@ Result ShardingInfo::validateShardsAndReplicationFactor(
                     cl.clusterInfo().getCurrentDBServers().size()) {
               return Result(TRI_ERROR_CLUSTER_INSUFFICIENT_DBSERVERS);
             }
+
+            if (replicationFactorSlice.isNumber() &&
+                writeConcern > replicationFactorSlice.getNumber<int64_t>()) {
+              return Result(
+                  TRI_ERROR_BAD_PARAMETER,
+                  "writeConcern must not be higher than replicationFactor");
+            }
           }
         }
       }

--- a/tests/js/common/shell/01_shell-database.js
+++ b/tests/js/common/shell/01_shell-database.js
@@ -571,6 +571,92 @@ function DatabaseSuite () {
     },
 
 ////////////////////////////////////////////////////////////////////////////////
+/// @brief test _createDatabase function
+////////////////////////////////////////////////////////////////////////////////
+
+    testCreateDatabaseReplicationFactorGreaterWriteConcern : function () {
+      if (!internal.isCluster()) {
+        return;
+      }
+
+      try {
+        internal.db._dropDatabase("UnitTestsDatabase");
+      } catch (err) {
+      }
+
+      [
+        [1, 2],
+        [1, 3],
+        [2, 3],
+      ].forEach((data) => {
+        let [replicationFactor, writeConcern] = data;
+        try {
+          internal.db._createDatabase("UnitTestsDatabase", { replicationFactor, writeConcern });
+          fail();
+        } catch (err) {
+          assertEqual(ERRORS.ERROR_BAD_PARAMETER.code, err.errorNum);
+        } finally {
+          try {
+            internal.db._dropDatabase("UnitTestsDatabase");
+          } catch (err) {
+          }
+        }
+      });
+    },
+    
+    testCreateDatabaseReplicationFactorGreaterDBServers : function () {
+      if (!internal.isCluster()) {
+        return;
+      }
+
+      try {
+        internal.db._dropDatabase("UnitTestsDatabase");
+      } catch (err) {
+      }
+
+      try {
+        internal.db._createDatabase("UnitTestsDatabase", { replicationFactor: 10, writeConcern: 10 });
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_CLUSTER_INSUFFICIENT_DBSERVERS.code, err.errorNum);
+      } finally {
+        try {
+          internal.db._dropDatabase("UnitTestsDatabase");
+        } catch (err) {
+        }
+      }
+    },
+
+    testCreateDatabaseReplicationFactorWriteConcernPairs : function () {
+      if (!internal.isCluster()) {
+        return;
+      }
+
+      try {
+        internal.db._dropDatabase("UnitTestsDatabase");
+      } catch (err) {
+      }
+
+      [
+        [1, 1],
+        [2, 1],
+        [2, 2],
+        [3, 1],
+        [3, 2],
+      ].forEach((data) => {
+        let [replicationFactor, writeConcern] = data;
+        try {
+          internal.db._createDatabase("UnitTestsDatabase", { replicationFactor, writeConcern });
+        } finally {
+          try {
+            internal.db._dropDatabase("UnitTestsDatabase");
+          } catch (err) {
+          }
+        }
+      });
+    },
+
+////////////////////////////////////////////////////////////////////////////////
 /// @brief test _useDatabase function
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
### Scope & Purpose

Verify that replicationFactor is >= writeConcern when creating databases.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [x] The behavior in this PR was *manually tested*
- [x] This PR adds tests that were used to verify all changes:
  - [x] Added new **integration tests** (shell_server)
