### PR TITLE
BTS-707: rename "hardened" option value

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* BTS-707: rename "hardened" option value for `--server.support-info-api`
+  startup option to "admin".
+
 * When creating a new database the value of the write concern has to be smaller
   or equal to the replication factor. Otherwise an error message will be displayed
   and no database will be created.

--- a/arangod/GeneralServer/GeneralServerFeature.cpp
+++ b/arangod/GeneralServer/GeneralServerFeature.cpp
@@ -148,7 +148,7 @@ GeneralServerFeature::GeneralServerFeature(
       _returnQueueTimeHeader(true),
       _permanentRootRedirect(true),
       _redirectRootTo("/_admin/aardvark/index.html"),
-      _supportInfoApiPolicy("hardened"),
+      _supportInfoApiPolicy("admin"),
       _numIoThreads(0),
       _requestBodySizeHttp1(server.getFeature<metrics::MetricsFeature>().add(
           arangodb_request_body_size_http1{})),
@@ -195,7 +195,7 @@ void GeneralServerFeature::collectOptions(
                   new DiscreteValuesParameter<StringParameter>(
                       &_supportInfoApiPolicy,
                       std::unordered_set<std::string>{"disabled", "jwt",
-                                                      "hardened", "public"}))
+                                                      "admin", "public"}))
       .setIntroducedIn(30900);
 
   options->addSection("http", "HTTP server features");

--- a/arangod/RestHandler/RestSupportInfoHandler.cpp
+++ b/arangod/RestHandler/RestSupportInfoHandler.cpp
@@ -90,21 +90,10 @@ RestStatus RestSupportInfoHandler::execute() {
     }
   }
 
-  if (apiPolicy == "hardened") {
-    ServerSecurityFeature& security =
-        server().getFeature<ServerSecurityFeature>();
-    if (!security.canAccessHardenedApi()) {
-      // superuser can still access API even if hardened
-      if (!ExecContext::current().isSuperuser()) {
-        generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                      "insufficent permissions");
-        return RestStatus::DONE;
-      }
-    } else if (!ExecContext::current().isAdminUser()) {
-      generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                    "insufficent permissions");
-      return RestStatus::DONE;
-    }
+  if (apiPolicy == "admin" && !ExecContext::current().isAdminUser()) {
+    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
+                  "insufficent permissions");
+    return RestStatus::DONE;
   }
 
   if (_request->databaseName() != StaticStrings::SystemDatabase) {

--- a/tests/js/client/server_permissions/test-support-info-api-admin-noncluster.js
+++ b/tests/js/client/server_permissions/test-support-info-api-admin-noncluster.js
@@ -35,9 +35,8 @@ const jwtSecret = 'abc123';
 
 if (getOptions === true) {
   return {
-    'server.harden': 'false',
     'server.authentication': 'true',
-    'server.support-info-api': "hardened",
+    'server.support-info-api': "admin",
     'server.jwt-secret': jwtSecret,
     'runSetup': true
   };
@@ -76,7 +75,7 @@ function testSuite() {
         auth: {
           username: "test_rw",
           password: "testi"
-        },
+        }
       });
       assertEqual(200, res.status);
       assertTrue(res.json.hasOwnProperty("deployment"));
@@ -88,7 +87,7 @@ function testSuite() {
         auth: {
           username: "test_ro",
           password: "testi"
-        },
+        }
       });
       assertEqual(403, res.status);
     },

--- a/tests/js/client/server_permissions/test-support-info-api-admin-off-noncluster.js
+++ b/tests/js/client/server_permissions/test-support-info-api-admin-off-noncluster.js
@@ -35,9 +35,8 @@ const jwtSecret = 'abc123';
 
 if (getOptions === true) {
   return {
-    'server.harden': 'true',
     'server.authentication': 'true',
-    'server.support-info-api': "hardened",
+    'server.support-info-api': "admin",
     'server.jwt-secret': jwtSecret,
     'runSetup': true
   };
@@ -76,7 +75,7 @@ function testSuite() {
         auth: {
           username: "test_rw",
           password: "testi"
-        }
+        },
       });
       assertEqual(200, res.status);
       assertTrue(res.json.hasOwnProperty("deployment"));
@@ -88,7 +87,7 @@ function testSuite() {
         auth: {
           username: "test_ro",
           password: "testi"
-        }
+        },
       });
       assertEqual(403, res.status);
     },


### PR DESCRIPTION
### Scope & Purpose

BTS-707: rename "hardened" option value for `--server.support-info-api` startup option to "admin".
Docs PR: https://github.com/arangodb/docs/pull/863

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/15460

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/863

### Testing & Verification

- [x] This change is already covered by existing tests, such as *server_permissions*.
