### PR TITLE
[ES-1025] Fix performance regression caused by different hash calculation.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.8.5 (XXXX-XX-XX)
 -------------------
 
+* Fixed ES-1025: fixed a performance regression caused by different hash
+  calculation for primitive types like `uint64_t` and new the `Identifier`
+  wrapper and derived types.
+
 * APM-78: Added startup security option `--foxx.allow-install-from-remote` to
   allow installing Foxx apps from remote URLs other than Github. The option is
   turned on by default to ensure backwards compatibility with previous version,

--- a/lib/Basics/Identifier.cpp
+++ b/lib/Basics/Identifier.cpp
@@ -31,31 +31,33 @@ namespace arangodb::basics {
 
 Identifier::BaseType Identifier::id() const noexcept { return _id; }
 
-Identifier::BaseType const* Identifier::data() const noexcept { return &_id; }
+Identifier::BaseType const* Identifier::data() const noexcept {
+  return &_id;
+}
 
 Identifier::operator bool() const noexcept { return _id != 0; }
 
-bool Identifier::operator==(Identifier const& other) const {
+bool Identifier::operator==(Identifier const& other) const noexcept {
   return _id == other._id;
 }
 
-bool Identifier::operator!=(Identifier const& other) const {
+bool Identifier::operator!=(Identifier const& other) const noexcept {
   return !(operator==(other));
 }
 
-bool Identifier::operator<(Identifier const& other) const {
+bool Identifier::operator<(Identifier const& other) const noexcept {
   return _id < other._id;
 }
 
-bool Identifier::operator<=(Identifier const& other) const {
+bool Identifier::operator<=(Identifier const& other) const noexcept {
   return _id <= other._id;
 }
 
-bool Identifier::operator>(Identifier const& other) const {
+bool Identifier::operator>(Identifier const& other) const noexcept {
   return _id > other._id;
 }
 
-bool Identifier::operator>=(Identifier const& other) const {
+bool Identifier::operator>=(Identifier const& other) const noexcept {
   return _id >= other._id;
 }
 

--- a/lib/Basics/Identifier.h
+++ b/lib/Basics/Identifier.h
@@ -54,22 +54,22 @@ class Identifier {
   explicit operator bool() const noexcept;
 
   /// @brief check if two identifiers are equal
-  bool operator==(Identifier const& other) const;
+  bool operator==(Identifier const& other) const noexcept;
 
   /// @brief check if two identifiers are equal
-  bool operator!=(Identifier const& other) const;
+  bool operator!=(Identifier const& other) const noexcept;
 
   /// @brief check if this identifier is less than another
-  bool operator<(Identifier const& other) const;
+  bool operator<(Identifier const& other) const noexcept;
 
   /// @brief check if this identifier is at most another
-  bool operator<=(Identifier const& other) const;
+  bool operator<=(Identifier const& other) const noexcept;
 
   /// @brief check if this identifier is greater than another
-  bool operator>(Identifier const& other) const;
+  bool operator>(Identifier const& other) const noexcept;
 
   /// @brief check if this identifier is at least another
-  bool operator>=(Identifier const& other) const;
+  bool operator>=(Identifier const& other) const noexcept;
 
  private:
   BaseType _id;
@@ -87,18 +87,18 @@ std::ostream& operator<<(std::ostream& s, arangodb::basics::Identifier const& i)
   template <>                                                 \
   struct hash<T> {                                            \
     inline size_t operator()(T const& value) const noexcept { \
-      return value.id();                                      \
+      return std::hash<typename T::BaseType>{}(value.id());   \
     }                                                         \
   };                                                          \
   }  // namespace std
 DECLARE_HASH_FOR_IDENTIFIER(arangodb::basics::Identifier)
 
-#define DECLARE_EQUAL_FOR_IDENTIFIER(T)                                      \
-  namespace std {                                                            \
-  template <>                                                                \
-  struct equal_to<T> {                                                       \
-    bool operator()(T const& lhs, T const& rhs) const { return lhs == rhs; } \
-  };                                                                         \
+#define DECLARE_EQUAL_FOR_IDENTIFIER(T)                                                \
+  namespace std {                                                                      \
+  template <>                                                                          \
+  struct equal_to<T> {                                                                 \
+    bool operator()(T const& lhs, T const& rhs) const  noexcept { return lhs == rhs; } \
+  };                                                                                   \
   }  // namespace std
 DECLARE_EQUAL_FOR_IDENTIFIER(arangodb::basics::Identifier)
 


### PR DESCRIPTION
### Scope & Purpose

Fixes a performance regression caused by different hash calculation for primitive types like `uint64_t` and new the `Identifier` wrapper and derived types.

- [x] :hankey: Bugfix (requires CHANGELOG entry)
- [x] :book: CHANGELOG entry made

#### Backports:

- [x] Backport for devel: #15463
- [x] Backport for 3.9 #15462

#### Related Information

- [x] Jira ticket number: https://arangodb.atlassian.net/browse/ES-1025

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [x] The behavior in this PR was *manually tested*