### PR TITLE
Fix wrong expect in iresearch link metrics test

### DIFF
--- a/tests/IResearch/IResearchLinkTest.cpp
+++ b/tests/IResearch/IResearchLinkTest.cpp
@@ -2406,13 +2406,11 @@ TEST_F(IResearchLinkMetricsTest, TimeCommit) {
     timeMs = insert(1, 10000, 0);
     auto [commitTime1, cleanupTime1, consolidationTime1] = l->avgTime();
     EXPECT_LT(0, commitTime1);
-    EXPECT_EQ(0, cleanupTime1);
-    EXPECT_LE(commitTime1, timeMs);
+    EXPECT_LE(commitTime1 + cleanupTime1, timeMs);
     timeMs += insert(10000, 10100, 1);
     auto [commitTime2, cleanupTime2, consolidationTime2] = l->avgTime();
     EXPECT_LT(0, commitTime2);
-    EXPECT_EQ(0, cleanupTime1);
-    EXPECT_LE(commitTime2, timeMs / 2.0);
+    EXPECT_LE(commitTime2 + cleanupTime2, timeMs / 2.0);
   }
   {
     auto [numFiles0, indexSize0] = numFiles();


### PR DESCRIPTION
### Scope & Purpose

I couldn't expect that cleanup time with nothing to clean should be less than 1 ms

- [x] :hankey: Bugfix (requires CHANGELOG entry)

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [x] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
