### PR TITLE
small code cleanup

### DIFF
--- a/arangod/Agency/AddFollower.cpp
+++ b/arangod/Agency/AddFollower.cpp
@@ -271,8 +271,7 @@ bool AddFollower::start(bool&) {
       } catch (std::exception const& e) {
         // Just in case, this is never going to happen, since when _jb is
         // set, then the current job is stored under ToDo.
-        LOG_TOPIC("15c37", WARN, Logger::SUPERVISION)
-            << e.what() << ": " << __FILE__ << ":" << __LINE__;
+        LOG_TOPIC("15c37", WARN, Logger::SUPERVISION) << e.what();
         return false;
       }
     }

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -35,6 +35,7 @@
 #include "Basics/ConditionLocker.h"
 #include "Basics/ReadLocker.h"
 #include "Basics/ScopeGuard.h"
+#include "Basics/StaticStrings.h"
 #include "Basics/StringUtils.h"
 #include "Basics/WriteLocker.h"
 #include "Basics/application-exit.h"
@@ -557,8 +558,7 @@ priv_rpc_ret_t Agent::recvAppendEntriesRPC(term_t term,
     }
   } catch (std::exception const& e) {
     LOG_TOPIC("bedb8", DEBUG, Logger::AGENCY)
-        << "Exception during log append: " << __FILE__ << __LINE__ << " "
-        << e.what();
+        << "Exception during log append: " << e.what();
   }
 
   {
@@ -2077,12 +2077,11 @@ void Agent::setPersistedState(VPackSlice compaction) {
     CONDITION_LOCKER(guard, _waitForCV);
     _readDB = compaction;
     _commitIndex = arangodb::basics::StringUtils::uint64(
-        compaction.get("_key").copyString());
+        compaction.get(StaticStrings::KeyString).copyString());
     _local_index = _commitIndex.load(std::memory_order_relaxed);
     _waitForCV.broadcast();
   } catch (std::exception const& e) {
-    LOG_TOPIC("70844", ERR, Logger::AGENCY)
-        << e.what() << " " << __FILE__ << __LINE__;
+    LOG_TOPIC("70844", ERR, Logger::AGENCY) << e.what();
   }
 }
 
@@ -2182,8 +2181,7 @@ query_t Agent::gossip(VPackSlice slice, bool isCallback, size_t version) {
       try {
         _config.eraseGossipPeer(endpoint);
       } catch (std::exception const& e) {
-        LOG_TOPIC("58f08", ERR, Logger::AGENCY)
-            << __FILE__ << ":" << __LINE__ << " " << e.what();
+        LOG_TOPIC("58f08", ERR, Logger::AGENCY) << e.what();
       }
     }
 

--- a/arangod/Agency/CleanOutServer.cpp
+++ b/arangod/Agency/CleanOutServer.cpp
@@ -304,8 +304,7 @@ bool CleanOutServer::start(bool& aborts) {
       } catch (std::exception const& e) {
         // Just in case, this is never going to happen, since when _jb is
         // set, then the current job is stored under ToDo.
-        LOG_TOPIC("7b79a", WARN, Logger::SUPERVISION)
-            << e.what() << ": " << __FILE__ << ":" << __LINE__;
+        LOG_TOPIC("7b79a", WARN, Logger::SUPERVISION) << e.what();
         return false;
       }
     }

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -393,8 +393,7 @@ bool MoveShard::start(bool&) {
       } catch (std::exception const& e) {
         // Just in case, this is never going to happen, since when _jb is
         // set, then the current job is stored under ToDo.
-        LOG_TOPIC("34af0", WARN, Logger::SUPERVISION)
-            << e.what() << ": " << __FILE__ << ":" << __LINE__;
+        LOG_TOPIC("34af0", WARN, Logger::SUPERVISION) << e.what();
         return false;
       }
     }

--- a/arangod/Agency/Node.cpp
+++ b/arangod/Agency/Node.cpp
@@ -966,8 +966,7 @@ void Node::toBuilder(Builder& builder, bool showHidden) const {
     }
 
   } catch (std::exception const& e) {
-    LOG_TOPIC("44d99", ERR, Logger::AGENCY)
-        << e.what() << " " << __FILE__ << __LINE__;
+    LOG_TOPIC("44d99", ERR, Logger::AGENCY) << e.what();
   }
 }
 

--- a/arangod/Agency/RemoveFollower.cpp
+++ b/arangod/Agency/RemoveFollower.cpp
@@ -380,8 +380,7 @@ bool RemoveFollower::start(bool&) {
       } catch (std::exception const& e) {
         // Just in case, this is never going to happen, since when _jb is
         // set, then the current job is stored under ToDo.
-        LOG_TOPIC("95927", WARN, Logger::SUPERVISION)
-            << e.what() << ": " << __FILE__ << ":" << __LINE__;
+        LOG_TOPIC("95927", WARN, Logger::SUPERVISION) << e.what();
         return false;
       }
     }

--- a/arangod/Agency/ResignLeadership.cpp
+++ b/arangod/Agency/ResignLeadership.cpp
@@ -298,8 +298,7 @@ bool ResignLeadership::start(bool& aborts) {
       } catch (std::exception const& e) {
         // Just in case, this is never going to happen, since when _jb is
         // set, then the current job is stored under ToDo.
-        LOG_TOPIC("deadc", WARN, Logger::SUPERVISION)
-            << e.what() << ": " << __FILE__ << ":" << __LINE__;
+        LOG_TOPIC("deadc", WARN, Logger::SUPERVISION) << e.what();
         return false;
       }
     }

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -576,8 +576,7 @@ size_t State::removeConflicts(VPackSlice transactions, bool gotSnapshot) {
       }
     }
   } catch (std::exception const& e) {
-    LOG_TOPIC("9e1df", DEBUG, Logger::AGENCY)
-        << e.what() << " " << __FILE__ << __LINE__;
+    LOG_TOPIC("9e1df", DEBUG, Logger::AGENCY) << e.what();
   }
 
   return ndups;
@@ -960,8 +959,7 @@ bool State::loadLastCompactedSnapshot(Store& store, index_t& index,
       index = extractIndexFromKey(ii);
       term = ii.get("term").getNumber<uint64_t>();
     } catch (std::exception const& e) {
-      LOG_TOPIC("8ef2a", ERR, Logger::AGENCY)
-          << e.what() << " " << __FILE__ << __LINE__;
+      LOG_TOPIC("8ef2a", ERR, Logger::AGENCY) << e.what();
       return false;
     }
   }
@@ -1006,8 +1004,7 @@ index_t State::loadCompacted() {
       _nextCompactionAfter = _cur + _agent->config().compactionStepSize();
     } catch (std::exception const& e) {
       _cur = 0;
-      LOG_TOPIC("bc330", ERR, Logger::AGENCY)
-          << e.what() << " " << __FILE__ << __LINE__;
+      LOG_TOPIC("bc330", ERR, Logger::AGENCY) << e.what();
     }
   }
 

--- a/arangod/Agency/Store.cpp
+++ b/arangod/Agency/Store.cpp
@@ -180,8 +180,7 @@ std::vector<apply_ret_t> Store::applyTransactions(
       }
 
     } catch (std::exception const& e) {  // Catch any errors
-      LOG_TOPIC("8264b", ERR, Logger::AGENCY)
-          << __FILE__ << ":" << __LINE__ << " " << e.what();
+      LOG_TOPIC("8264b", ERR, Logger::AGENCY) << e.what();
       success.push_back(UNKNOWN_ERROR);
     }
 

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1147,8 +1147,7 @@ void Supervision::run() {
                   LOG_TOPIC("675fc", TRACE, Logger::SUPERVISION)
                       << "Finished doChecks";
                 } catch (std::exception const& e) {
-                  LOG_TOPIC("e0869", ERR, Logger::SUPERVISION)
-                      << e.what() << " " << __FILE__ << " " << __LINE__;
+                  LOG_TOPIC("e0869", ERR, Logger::SUPERVISION) << e.what();
                 } catch (...) {
                   LOG_TOPIC("ac4c4", ERR, Logger::SUPERVISION)
                       << "Supervision::doChecks() generated an uncaught "
@@ -2387,7 +2386,7 @@ void Supervision::restoreBrokenAnalyzersRevision(
 
 void Supervision::resourceCreatorLost(
     std::shared_ptr<Node> const& resource,
-    std::function<void(const ResourceCreatorLostEvent&)> const& action) {
+    std::function<void(ResourceCreatorLostEvent const&)> const& action) {
   //  check if the coordinator exists and its reboot is the same as specified
   auto rebootID = resource->hasAsUInt(StaticStrings::AttrCoordinatorRebootId);
   auto coordinatorID = resource->hasAsString(StaticStrings::AttrCoordinator);
@@ -2414,7 +2413,7 @@ void Supervision::resourceCreatorLost(
 
 void Supervision::ifResourceCreatorLost(
     std::shared_ptr<Node> const& resource,
-    std::function<void(const ResourceCreatorLostEvent&)> const& action) {
+    std::function<void(ResourceCreatorLostEvent const&)> const& action) {
   // check if isBuilding is set and it is true
   auto isBuilding = resource->hasAsBool(StaticStrings::AttrIsBuilding);
   if (isBuilding && isBuilding.value()) {
@@ -3040,8 +3039,7 @@ void Supervision::getUniqueIds() {
       _jobId = _jobIdMax - n;
     } catch (std::exception const& e) {
       LOG_TOPIC("4da4b", ERR, Logger::SUPERVISION)
-          << "Failed to acquire job IDs from agency: " << e.what() << __FILE__
-          << " " << __LINE__;
+          << "Failed to acquire job IDs from agency: " << e.what();
     }
   }
 }

--- a/arangod/Agency/Supervision.h
+++ b/arangod/Agency/Supervision.h
@@ -35,6 +35,10 @@
 #include "Metrics/Fwd.h"
 
 namespace arangodb {
+namespace velocypack {
+class Slice;
+}
+
 namespace consensus {
 
 class Agent;
@@ -79,7 +83,7 @@ class Supervision : public arangodb::Thread {
 
   template<TASKS T>
   class Task {
-    explicit Task(const VPackSlice& config) {}
+    explicit Task(VPackSlice const& config) {}
     ServerID _serverID;
     std::string _endpoint;
   };
@@ -204,7 +208,7 @@ class Supervision : public arangodb::Thread {
   // @brief Action is called if resource should be deleted
   void resourceCreatorLost(
       std::shared_ptr<Node> const& resource,
-      std::function<void(const ResourceCreatorLostEvent&)> const& action);
+      std::function<void(ResourceCreatorLostEvent const&)> const& action);
 
   /// @brief Check for inconsistencies in replication factor vs dbs entries
   void enforceReplication();

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -4615,7 +4615,7 @@ Result ClusterInfo::ensureIndexCoordinatorInner(
           VPackObjectBuilder o(&finishedPlanIndex);
           for (auto const& entry :
                VPackObjectIterator(newIndexBuilder.slice())) {
-            auto const key = entry.key.copyString();
+            auto const key = entry.key.stringView();
             if (key != StaticStrings::IndexIsBuilding &&
                 key != "isNewlyCreated") {
               finishedPlanIndex.add(entry.key.copyString(), entry.value);

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -1085,8 +1085,7 @@ arangodb::Result arangodb::maintenance::phaseOne(
                            feature, report, shardActionMap, localLogs);
     } catch (std::exception const& e) {
       LOG_TOPIC("55938", ERR, Logger::MAINTENANCE)
-          << "Error executing plan: " << e.what() << ". " << __FILE__ << ":"
-          << __LINE__;
+          << "Error executing plan: " << e.what();
     }
   }
 

--- a/tests/Agency/CleanUpLostCollectionTest.cpp
+++ b/tests/Agency/CleanUpLostCollectionTest.cpp
@@ -43,8 +43,6 @@ const std::string COLLECTION = "collection";
 const std::string SHARD = "s99";
 const std::string SHARD_LEADER = "leader";
 const std::string SHARD_FOLLOWER1 = "follower1";
-const std::string FREE_SERVER = "free";
-const std::string FREE_SERVER2 = "free2";
 
 using namespace arangodb;
 using namespace arangodb::basics;
@@ -74,24 +72,6 @@ Node createRootNode() {
   Node root("ROOT");
   root.handle<SET>(builder.slice());
   return root;
-}
-
-VPackBuilder createJob(std::string const& collection, std::string const& from,
-                       std::string const& to) {
-  VPackBuilder builder;
-  {
-    VPackObjectBuilder b(&builder);
-    builder.add("jobId", VPackValue("1"));
-    builder.add("creator", VPackValue("unittest"));
-    builder.add("type", VPackValue("moveShard"));
-    builder.add("database", VPackValue(DATABASE));
-    builder.add("collection", VPackValue(collection));
-    builder.add("shard", VPackValue(SHARD));
-    builder.add("fromServer", VPackValue(from));
-    builder.add("toServer", VPackValue(to));
-    builder.add("isLeader", VPackValue(from == SHARD_LEADER));
-  }
-  return builder;
 }
 
 class CleanUpLostCollectionTest : public ::testing::Test {


### PR DESCRIPTION
### Scope & Purpose

Internal code cleanup by removing obsolete `__FILE__` and `__LINE__` mentions from error messages. These are obsolete because each log message has a unique log id anyway.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
