### PR TITLE
[CINFRA-207] Wait for server to recover after test suspend

### DIFF
--- a/js/server/modules/@arangodb/testutils/replicated-logs-helper.js
+++ b/js/server/modules/@arangodb/testutils/replicated-logs-helper.js
@@ -80,6 +80,9 @@ const createTermSpecification = function (term, servers, config, leader) {
     return spec;
 };
 
+const getServerHealth = function (serverId) {
+    return readAgencyValueAt(`Supervision/Health/${serverId}/Status`);
+};
 
 const dbservers = (function () {
     return global.ArangoClusterInfo.getDBServers().map((x) => x.serverId);
@@ -184,6 +187,42 @@ const continueServer = function (serverId) {
     }
 };
 
+const allServersHealthy = function () {
+    return function () {
+        for (const server of dbservers) {
+            const health = getServerHealth(server);
+            if (health !== "GOOD") {
+                return Error(`${server} is ${health}`);
+            }
+        }
+
+        return true;
+    };
+};
+
+const checkServerHealth = function (serverId, value) {
+    return function () {
+        return value === getServerHealth(serverId);
+    };
+};
+
+const serverHealthy = (serverId) => checkServerHealth(serverId, "GOOD");
+const serverFailed = (serverId) => checkServerHealth(serverId, "FAILED");
+
+const waitForServersHealth = function () {
+    waitFor(allServersHealthy());
+};
+
+const continueServerWaitOk = function (serverId) {
+    continueServer(serverId);
+    waitFor(serverHealthy(serverId));
+};
+
+const stopServerWaitFailed = function (serverId) {
+    continueServer(serverId);
+    waitFor(serverFailed(serverId));
+};
+
 const nextUniqueLogId = function() {
     return parseInt(global.ArangoClusterInfo.uniqid());
 };
@@ -212,3 +251,6 @@ exports.continueServer = continueServer;
 exports.nextUniqueLogId = nextUniqueLogId;
 exports.registerAgencyTestBegin = registerAgencyTestBegin;
 exports.registerAgencyTestEnd = registerAgencyTestEnd;
+exports.waitForServersHealth = waitForServersHealth;
+exports.continueServerWaitOk = continueServerWaitOk;
+exports.stopServerWaitFailed = stopServerWaitFailed;

--- a/js/server/modules/@arangodb/testutils/replicated-logs-helper.js
+++ b/js/server/modules/@arangodb/testutils/replicated-logs-helper.js
@@ -209,10 +209,6 @@ const checkServerHealth = function (serverId, value) {
 const serverHealthy = (serverId) => checkServerHealth(serverId, "GOOD");
 const serverFailed = (serverId) => checkServerHealth(serverId, "FAILED");
 
-const waitForServersHealth = function () {
-    waitFor(allServersHealthy());
-};
-
 const continueServerWaitOk = function (serverId) {
     continueServer(serverId);
     waitFor(serverHealthy(serverId));
@@ -251,6 +247,6 @@ exports.continueServer = continueServer;
 exports.nextUniqueLogId = nextUniqueLogId;
 exports.registerAgencyTestBegin = registerAgencyTestBegin;
 exports.registerAgencyTestEnd = registerAgencyTestEnd;
-exports.waitForServersHealth = waitForServersHealth;
+exports.allServersHealthy = allServersHealthy;
 exports.continueServerWaitOk = continueServerWaitOk;
 exports.stopServerWaitFailed = stopServerWaitFailed;

--- a/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
+++ b/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
@@ -37,7 +37,7 @@ const {
     replicatedLogDeletePlan,
     createTermSpecification,
     replicatedLogIsReady,
-    dbservers, waitForServersHealth,
+    dbservers, allServersHealthy,
     nextUniqueLogId,
     registerAgencyTestBegin, registerAgencyTestEnd,
 } = helper;
@@ -153,7 +153,7 @@ const replicatedLogSuite = function () {
         setUpAll, tearDownAll,
         setUp: registerAgencyTestBegin,
         tearDown: function (test) {
-            waitForServersHealth();
+            waitFor(allServersHealthy());
             registerAgencyTestEnd(test);
         },
 

--- a/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
+++ b/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
@@ -37,7 +37,7 @@ const {
     replicatedLogDeletePlan,
     createTermSpecification,
     replicatedLogIsReady,
-    dbservers,
+    dbservers, waitForServersHealth,
     nextUniqueLogId,
     registerAgencyTestBegin, registerAgencyTestEnd,
 } = helper;
@@ -152,7 +152,10 @@ const replicatedLogSuite = function () {
     return {
         setUpAll, tearDownAll,
         setUp: registerAgencyTestBegin,
-        tearDown: registerAgencyTestEnd,
+        tearDown: function (test) {
+            waitForServersHealth();
+            registerAgencyTestEnd(test);
+        },
 
         testCheckSimpleFailover: function () {
             const logId = nextUniqueLogId();
@@ -214,6 +217,8 @@ const replicatedLogSuite = function () {
             waitFor(replicatedLogIsReady(database, logId, term + 2, [servers[1], servers[2]], servers[2]));
 
             replicatedLogDeletePlan(database, logId);
+
+            continueServer(leader);
         },
     };
 };


### PR DESCRIPTION
### Scope & Purpose
After a test suspended a server,we should wait for the server to recover in the supervision. Otherwise it might not be ready for the second test. When it comes back it changes it's reboot id and thus the next test will fail.