### PR TITLE
Allow to compile with python 3.10

### DIFF
--- a/3rdParty/V8/gyp/common.py
+++ b/3rdParty/V8/gyp/common.py
@@ -4,7 +4,6 @@
 
 from __future__ import print_function
 
-import collections
 import errno
 import filecmp
 import os
@@ -13,6 +12,10 @@ import re
 import tempfile
 import sys
 
+try:
+  from collections.abc import MutableSet
+except ImportError:
+  from collections import MutableSet
 
 # A minimal memoizing decorator. It'll blow up if the args aren't immutable, among other "problems".
 class memoize(object):
@@ -479,7 +482,7 @@ def uniquer(seq, idfun=None):
 
 
 # Based on http://code.activestate.com/recipes/576694/.
-class OrderedSet(collections.MutableSet):
+class OrderedSet(MutableSet):
   def __init__(self, iterable=None):
     self.end = end = []
     end += [None, end, end]         # sentinel node for doubly linked list

--- a/3rdParty/V8/gyp/msvs_emulation.py
+++ b/3rdParty/V8/gyp/msvs_emulation.py
@@ -16,8 +16,13 @@ import sys
 import time
 import hashlib
 import traceback
-from collections import Iterable, OrderedDict
+from collections import OrderedDict
 from tempfile import gettempdir
+
+try:
+  from collections.abc import Iterable
+except ImportError:
+  from collections import Iterable
 
 from gyp import DebugOutput, DEBUG_GENERAL
 from gyp.common import EnsureDirExists, WriteOnDiff, memoize

--- a/3rdParty/V8/v7.9.317/third_party/jinja2/tests.py
+++ b/3rdParty/V8/v7.9.317/third_party/jinja2/tests.py
@@ -10,10 +10,14 @@
 """
 import operator
 import re
-from collections import Mapping
 from jinja2.runtime import Undefined
 from jinja2._compat import text_type, string_types, integer_types
 import decimal
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 number_re = re.compile(r'^-?\d+(\.\d+)?$')
 regex_type = type(number_re)


### PR DESCRIPTION
### Scope & Purpose

Allow to compile with python 3.10.

#### Related Information

- [X] GitHub issue: https://github.com/arangodb/arangodb/issues/15448

### Testing & Verification

- [X] This change is a trivial rework / code cleanup without any test coverage.
