### PR TITLE
fix cpp-check found issue

### DIFF
--- a/lib/SimpleHttpClient/SimpleHttpClient.cpp
+++ b/lib/SimpleHttpClient/SimpleHttpClient.cpp
@@ -893,7 +893,7 @@ void SimpleHttpClient::processChunkedHeader() {
   }
 
   // empty lines are an error
-  if (line[0] == '\r' || line.empty()) {
+  if (line.empty() || line[0] == '\r') {
     setErrorMessage("found invalid Content-Length", true);
     // reset connection
     this->close();


### PR DESCRIPTION
### Scope & Purpose

Fix an issue found by Cppcheck. Container contents was accessed before emptiness were checked. Check was inversed.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

#### Backports:

- [ ] Backport for 3.9: *(Please link PR)*
- [ ] Backport for 3.8: *(Please link PR)*
- [ ] Backport for 3.7: *(Please link PR)*

### Testing & Verification


- [x] This change is a trivial rework / code cleanup without any test coverage.
- [ ] The behavior in this PR was *manually tested*
- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
- [ ] This PR adds tests that were used to verify all changes:
  - [ ] Added new C++ **Unit tests**
  - [ ] Added new **integration tests** (e.g. in shell_server / shell_server_aql)
  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
- [ ] There are tests in an external testing repository:
- [ ] I ensured this code runs with ASan / TSan or other static verification tools
