### PR TITLE
simplify PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,61 +1,28 @@
 ### Scope & Purpose
 
-*(Please describe the changes in this PR for reviewers)*
+*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*
 
-- [ ] :hankey: Bugfix 
-- [ ] :pizza: New feature 
-- [ ] :hammer: Refactoring 
+- [ ] :hankey: Bugfix
+- [ ] :pizza: New feature
+- [ ] :fire: Performance improvement
+- [ ] :hammer: Refactoring/simplification
+
+### Checklist
+
+- [ ] Tests
+  - [ ] **Regression tests**
+  - [ ] C++ **Unit tests**
+  - [ ] **integration tests**
+  - [ ] **resilience tests**
 - [ ] :book: CHANGELOG entry made
-- [ ] :muscle: The behavior in this PR was *manually tested*
-- [ ] :computer: The behavior change can be verified via automatic tests
-
-#### Backports:
-
-- [ ] No backports required
-- [ ] Backports required for: *(Please specify versions)*
+- [ ] :books: documentation written (release notes, API changes, ...)
 
 #### Related Information
 
-*(Please reference tickets / specification etc)*
+*(Please reference tickets / specification / other PRs etc)*
 
 - [ ] Docs PR: 
 - [ ] Enterprise PR:
-- [ ] GitHub issue / Jira ticket number:
+- [ ] GitHub issue / Jira ticket:
 - [ ] Design document: 
 
-### Testing & Verification
-
-*(Please pick either of the following options)*
-
-- [ ] This change is a trivial rework / code cleanup without any test coverage.
-- [ ] This change is already covered by existing tests, such as *(please describe tests)*.
-- [ ] This PR adds tests that were used to verify all changes:
-  - [ ] Added **Regression Tests**
-  - [ ] Added new C++ **Unit Tests**
-  - [ ] Added new **integration tests** (i.e. in shell_server / shell_server_aql)
-  - [ ] Added new **resilience tests** (only if the feature is impacted by failovers)
-
-Additionally:
-
-- [ ] There are tests in an external testing repository:
-- [ ] I ensured this code runs with ASan / TSan or other static verification tools
-
-*(Include link to Jenkins run etc)*
-
-### Documentation
-
-> All new Features should be accompanied by corresponding documentation. 
-> Bugs and features should furthermore be documented in the changelog so that
-> developers and users have a concise overview. 
-
-- [ ] Added a *Changelog Entry* (referencing the corresponding public or internal issue number)
-- [ ] Added entry to *Release Notes* 
-- [ ] Added a new section in the *Manual* 
-- [ ] Added a new section in the *HTTP API* 
-- [ ] Added *Swagger examples* for the HTTP API  
-- [ ] Updated license information in *LICENSES-OTHER-COMPONENTS.md* for 3rd party libraries
-
-### External contributors / CLA Note 
-
-Please note that for legal reasons we require you to sign the [Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
-before we can accept your pull requests.


### PR DESCRIPTION
### Scope & Purpose

This PR simplifies the PULL_REQUEST_TEMPLATE.md in several ways, making it slightly easier to fill out.
The documentation section has been removed, because it was never filled out. The CLA section was removed because there is now the CLA bot. The testing section has been streamlined.

The PR is meant as a basis for discussion with other developers.

- [ ] :hankey: Bugfix (requires CHANGELOG entry)
- [ ] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
- [ ] :book: CHANGELOG entry made

### Testing & Verification

- [x] This change is a trivial rework / code cleanup without any test coverage.
