### PR TITLE
BTS-734 hotbackup upload can miss files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.7.17 (XXXX-XX-XX)
 --------------------
 
+* Fixed a bug that hotbackup upload could miss files (fixes BTS-734).
+
 * BTS-590: When creating a new database in Web UI the value of the write concern
   has to be smaller or equal to the replication factor. Otherwise an error
   message will be displayed and no database will be created.

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/databaseView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/databaseView.js
@@ -1,6 +1,6 @@
 /* jshint browser: true */
 /* jshint unused: false */
-/* global window, Backbone, $, arangoHelper, templateEngine, Joi, frontendConfig */
+/* global window, Backbone, $, arangoHelper, templateEngine, Joi, frontendConfig, _ */
 (function () {
   'use strict';
 

--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -922,6 +922,9 @@ TRI_read_return_t TRI_ReadPointer(int fd, char* buffer, size_t length) {
     TRI_read_return_t n = TRI_READ(fd, ptr, static_cast<TRI_read_t>(remainLength));
 
     if (n < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
       TRI_set_errno(TRI_ERROR_SYS_ERROR);
       LOG_TOPIC("c9c0c", ERR, arangodb::Logger::FIXME) << "cannot read: " << TRI_LAST_ERROR_STR;
       return n; // always negative

--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -257,6 +257,8 @@ start() {
         --log.force-direct false \
         --log.thread true \
         --log.level $LOG_LEVEL_CLUSTER \
+        --log.level=rocksdb=debug \
+        --rocksdb.enable-statistics=true \
         --javascript.allow-admin-execute true \
         $STORAGE_ENGINE \
         $AUTHENTICATION \

--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -257,8 +257,6 @@ start() {
         --log.force-direct false \
         --log.thread true \
         --log.level $LOG_LEVEL_CLUSTER \
-        --log.level=rocksdb=debug \
-        --rocksdb.enable-statistics=true \
         --javascript.allow-admin-execute true \
         $STORAGE_ENGINE \
         $AUTHENTICATION \


### PR DESCRIPTION
It was observed that sometimes hotbackup upload can miss some files
during the upload, rendering the uploaded backups corrupt.

The reason is that the files of the backup are listed by an rclone
subprocess and after a recent change we sometimes truncate the output
of this file listing and therefore do not upload some files in the
backup.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers - **mandatory**)*

- [*] :hankey: Bugfix (requires CHANGELOG entry)
- [*] :book: CHANGELOG entry made

#### Backports:

This is the backport for 3.7.

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] GitHub issue / Jira ticket number: https://arangodb.atlassian.net/browse/BTS-734
- [*] This is accompanied by a PR in the enterprise repository: https://github.com/arangodb/enterprise/pull/858

### Testing & Verification

*(Please pick either of the following options)*

- [*] This change is a trivial rework / code cleanup without any test coverage.
- [*] The behavior in this PR was *manually tested*
- [*] We cannot ourself reproduce the problem but it is clear that it
      exists and we have evidence that it has happened to some customer.
      We currently do not know under what circumstances the bug is
      triggered and therefore we cannot provide a testing scenario.




