### PR TITLE
Refuse to concat a char.

### DIFF
--- a/arangod/Replication2/ReplicatedLog/LogCommon.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogCommon.cpp
@@ -332,7 +332,7 @@ auto replication2::intersect(LogRange a, LogRange b) noexcept -> LogRange {
 }
 
 auto replication2::to_string(LogRange const& r) -> std::string {
-  return basics::StringUtils::concatT('[', r.from, ", ", r.to, ')');
+  return basics::StringUtils::concatT("[", r.from, ", ", r.to, ")");
 }
 
 auto LogRange::end() const noexcept -> LogRange::Iterator {

--- a/lib/Basics/StringUtils.h
+++ b/lib/Basics/StringUtils.h
@@ -545,6 +545,11 @@ auto joinImplStr(std::string_view delim, Args&&... args) -> std::string {
 /// or via `to_string`.
 template<typename... Args>
 auto concatT(Args&&... args) -> std::string {
+  static_assert(
+      (!std::is_same_v<std::decay_t<Args>, char> && ...),
+      "passing a `char` does not what you expect. Pass it as literal string"
+      "of length one. If you want to print the numeric value, cast "
+      "it to an int instead.");
   return detail::concatImplStr(detail::toStringOrView(args)...);
 }
 
@@ -554,6 +559,11 @@ auto concatT(Args&&... args) -> std::string {
 /// or via `to_string`.
 template<typename... Args>
 auto joinT(std::string_view delim, Args&&... args) -> std::string {
+  static_assert(
+      (!std::is_same_v<std::decay_t<Args>, char> && ...),
+      "passing a `char` does not what you expect. Pass it as literal string"
+      "of length one. If you want to print the numeric value, cast "
+      "it to an int instead.");
   return detail::joinImplStr(delim, detail::toStringOrView(args)...);
 }
 

--- a/tests/Basics/StringUtilsTest.cpp
+++ b/tests/Basics/StringUtilsTest.cpp
@@ -436,7 +436,7 @@ TEST_F(StringUtilsTest, concatT) {
   EXPECT_EQ("42", StringUtils::concatT(42));
   EXPECT_EQ("2.500000", StringUtils::concatT(2.5));
   EXPECT_EQ("hello, world", StringUtils::concatT("hello", ", ", "world"));
-  EXPECT_EQ("45", StringUtils::concatT(static_cast<int>('/')));
+  EXPECT_EQ("47", StringUtils::concatT(static_cast<int>('/')));
   EXPECT_EQ("cstr 42 stdstr view",
             StringUtils::concatT("cstr ", 42, " stdstr "s, "view"sv));
 }

--- a/tests/Basics/StringUtilsTest.cpp
+++ b/tests/Basics/StringUtilsTest.cpp
@@ -436,6 +436,7 @@ TEST_F(StringUtilsTest, concatT) {
   EXPECT_EQ("42", StringUtils::concatT(42));
   EXPECT_EQ("2.500000", StringUtils::concatT(2.5));
   EXPECT_EQ("hello, world", StringUtils::concatT("hello", ", ", "world"));
+  EXPECT_EQ("45", StringUtils::concatT(static_cast<int>('/')));
   EXPECT_EQ("cstr 42 stdstr view",
             StringUtils::concatT("cstr ", 42, " stdstr "s, "view"sv));
 }


### PR DESCRIPTION
### Scope & Purpose

If you write something like
```cpp
basics::StringUtils::concatT(curServersKnown, '/', serverId);
```
it **does** not what you think it does. The reason is, that for a `char` type, `concatT` will (like for all numerical data types) call `std::to_string`. Hence the above results in something like
```cpp
"/Current/ServersKnown45PRMR-XXXXX"
```
I had to debug that and I never want to do it again. After this change `concatT` refuses to compile using a `char` as parameter.
Same applies to `joinT`.

Instead use
```cpp
basics::StringUtils::concatT(curServersKnown, "/", serverId);
```
or
```cpp
basics::StringUtils::concatT("The value is: ", static_cast<int>(myCharVariable));
```