### PR TITLE
Fixed python imports to work with 3.10 (#15502)

### DIFF
--- a/3rdParty/V8/gyp/common.py
+++ b/3rdParty/V8/gyp/common.py
@@ -4,7 +4,6 @@
 
 from __future__ import print_function
 
-import collections
 import errno
 import filecmp
 import os
@@ -13,6 +12,10 @@ import re
 import tempfile
 import sys
 
+try:
+  from collections.abc import MutableSet
+except ImportError:
+  from collections import MutableSet
 
 # A minimal memoizing decorator. It'll blow up if the args aren't immutable, among other "problems".
 class memoize(object):
@@ -479,7 +482,7 @@ def uniquer(seq, idfun=None):
 
 
 # Based on http://code.activestate.com/recipes/576694/.
-class OrderedSet(collections.MutableSet):
+class OrderedSet(MutableSet):
   def __init__(self, iterable=None):
     self.end = end = []
     end += [None, end, end]         # sentinel node for doubly linked list

--- a/3rdParty/V8/gyp/msvs_emulation.py
+++ b/3rdParty/V8/gyp/msvs_emulation.py
@@ -16,8 +16,13 @@ import sys
 import time
 import hashlib
 import traceback
-from collections import Iterable, OrderedDict
+from collections import OrderedDict
 from tempfile import gettempdir
+
+try:
+  from collections.abc import Iterable
+except ImportError:
+  from collections import Iterable
 
 from gyp import DebugOutput, DEBUG_GENERAL
 from gyp.common import EnsureDirExists, WriteOnDiff, memoize

--- a/3rdParty/V8/gypfiles/standalone.gypi
+++ b/3rdParty/V8/gypfiles/standalone.gypi
@@ -402,15 +402,15 @@
       ['host_clang==1', {
         'conditions':[
           ['OS=="android"', {
-            'host_ld': '<!(<(PYTHON_EXECUTABLE)  -c "import distutils.spawn; print(distutils.spawn.find_executable(\\"ld\\"))")',
-            'host_ranlib': '<!(<(PYTHON_EXECUTABLE)  -c "import distutils.spawn; print(distutils.spawn.find_executable(\\"ranlib\\"))")',
+            'host_ld': '<!(<(PYTHON_EXECUTABLE)  -c "import shutil; print(shutil.which(\\"ld\\"))")',
+            'host_ranlib': '<!(<(PYTHON_EXECUTABLE)  -c "import shutil; print(shutil.which(\\"ranlib\\"))")',
           }],
         ],
         'host_cc': '<(clang_dir)/bin/clang',
         'host_cxx': '<(clang_dir)/bin/clang++',
       }, {
-        'host_cc': '<!(<(PYTHON_EXECUTABLE)  -c "import distutils.spawn; print(distutils.spawn.find_executable(\\"gcc\\"))")',
-        'host_cxx': '<!(<(PYTHON_EXECUTABLE)  -c "import distutils.spawn; print(distutils.spawn.find_executable(\\"g++\\"))")',
+        'host_cc': '<!(<(PYTHON_EXECUTABLE)  -c "import shutil; print(shutil.which(\\"gcc\\"))")',
+        'host_cxx': '<!(<(PYTHON_EXECUTABLE)  -c "import shutil; print(shutil.which(\\"g++\\"))")',
       }],
     ],
     # Default ARM variable settings.
@@ -1369,8 +1369,8 @@
       # Set default ARM cross tools on linux.  These can be overridden
       # using CC,CXX,CC.host and CXX.host environment variables.
       'make_global_settings': [
-        ['CC', '<!(<(PYTHON_EXECUTABLE)  -c "import distutils.spawn; print(distutils.spawn.find_executable(\\"arm-linux-gnueabihf-gcc\\"))")'],
-        ['CXX', '<!(<(PYTHON_EXECUTABLE)  -c "import distutils.spawn; print(distutils.spawn.find_executable(\\"arm-linux-gnueabihf-g++\\"))")'],
+        ['CC', '<!(<(PYTHON_EXECUTABLE)  -c "import shutil; print(shutil.which(\\"arm-linux-gnueabihf-gcc\\"))")'],
+        ['CXX', '<!(<(PYTHON_EXECUTABLE)  -c "import shutil; print(shutil.which(\\"arm-linux-gnueabihf-g++\\"))")'],
         ['CC.host', '<(host_cc)'],
         ['CXX.host', '<(host_cxx)'],
       ],

--- a/3rdParty/V8/v7.9.317/third_party/jinja2/tests.py
+++ b/3rdParty/V8/v7.9.317/third_party/jinja2/tests.py
@@ -10,10 +10,14 @@
 """
 import operator
 import re
-from collections import Mapping
 from jinja2.runtime import Undefined
 from jinja2._compat import text_type, string_types, integer_types
 import decimal
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 number_re = re.compile(r'^-?\d+(\.\d+)?$')
 regex_type = type(number_re)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,7 +498,7 @@ get_filename_component(PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}" REALPATH)
 
 set($ENV{PYTHON_EXECUTABLE} ${PYTHON_EXECUTABLE})
 execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import shutil.which"
+    COMMAND ${PYTHON_EXECUTABLE} -c "from shutil import which"
     RESULT_VARIABLE EXIT_CODE
     OUTPUT_QUIET
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,12 +498,12 @@ get_filename_component(PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}" REALPATH)
 
 set($ENV{PYTHON_EXECUTABLE} ${PYTHON_EXECUTABLE})
 execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import distutils.spawn"
+    COMMAND ${PYTHON_EXECUTABLE} -c "import shutil.which"
     RESULT_VARIABLE EXIT_CODE
     OUTPUT_QUIET
     )
 if (NOT "${EXIT_CODE}" EQUAL "0")
-  message(FATAL_ERROR "python distutils package is required! ")
+  message(FATAL_ERROR "python shutil.which package is required! ")
 endif()
 
 # FIXME the build containers seem to have a


### PR DESCRIPTION
backport of https://github.com/arangodb/arangodb/pull/15502 and https://github.com/arangodb/arangodb/pull/15552