### PR TITLE
Disable an optimizer rule in exclusive lock mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 devel
 -----
+  
+* Disable optimizer rule "optimize-cluster-single-document-operations" when a
+  collection is accessed in exclusive mode, because the optimized query would
+  use a slightly different mode of locking then.
 
 * Fixed BTS-712: Collation analyzer now always produces valid UTF-8 sequence.
 

--- a/arangod/Aql/OptimizerRulesCluster.cpp
+++ b/arangod/Aql/OptimizerRulesCluster.cpp
@@ -232,6 +232,12 @@ bool substituteClusterSingleDocumentOperationsIndex(Optimizer* opt,
           continue;
         }
 
+        if (mod->getOptions().exclusive) {
+          // exclusive lock used. this is not supported by the
+          // SingleRemoteOperationNode
+          continue;
+        }
+
         auto parentType = parentModification->getType();
         Variable const* update = nullptr;
         Variable const* keyVar = nullptr;
@@ -310,6 +316,12 @@ bool substituteClusterSingleDocumentOperationsNoIndex(
     }
 
     if (!::parentIsReturnOrConstCalc(node)) {
+      continue;
+    }
+
+    if (mod->getOptions().exclusive) {
+      // exclusive lock used. this is not supported by the
+      // SingleRemoteOperationNode
       continue;
     }
 

--- a/tests/js/server/aql/aql-optimizer-rule-optimize-cluster-single-document-operations.js
+++ b/tests/js/server/aql/aql-optimizer-rule-optimize-cluster-single-document-operations.js
@@ -4,8 +4,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief tests for single operation nodes in cluster
 ///
-/// @file
-///
 /// DISCLAIMER
 ///
 /// Copyright 2010-2012 triagens GmbH, Cologne, Germany
@@ -28,16 +26,12 @@
 /// @author Copyright 2018, ArangoDB GmbH, Cologne, Germany
 ////////////////////////////////////////////////////////////////////////////////
 
-var jsunity = require("jsunity");
-var internal = require("internal");
-var errors = internal.errors;
-var db = require("@arangodb").db;
-var helper = require("@arangodb/aql-helper");
-var assertQueryError = helper.assertQueryError;
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test suite
-////////////////////////////////////////////////////////////////////////////////
+const jsunity = require("jsunity");
+const internal = require("internal");
+const errors = internal.errors;
+const db = require("@arangodb").db;
+const helper = require("@arangodb/aql-helper");
+const assertQueryError = helper.assertQueryError;
 
 function optimizerClusterSingleDocumentTestSuite () {
   var ruleName = "optimize-cluster-single-document-operations";
@@ -498,6 +492,7 @@ function optimizerClusterSingleDocumentTestSuite () {
         "INSERT [] INTO @@cn1 RETURN NEW",
         "INSERT [ {} ] INTO @@cn1 RETURN NEW",
         "INSERT [{ foo: 2 }] INTO @@cn1 RETURN NEW",
+        "INSERT {} INTO @@cn1 OPTIONS { exclusive: true }",
 
         "UPDATE [] IN @@cn1",
         "UPDATE [ {} ] IN @@cn1",
@@ -505,6 +500,7 @@ function optimizerClusterSingleDocumentTestSuite () {
         "UPDATE [] IN @@cn1 RETURN OLD",
         "UPDATE [ {} ] IN @@cn1 RETURN OLD",
         "UPDATE [{ foo: 4 }] IN @@cn1 RETURN OLD",
+        "UPDATE 'foo' WITH { two: 1 } INTO @@cn1 OPTIONS { exclusive: true }",
         
         "REPLACE [] IN @@cn1",
         "REPLACE [ {} ] IN @@cn1",
@@ -512,6 +508,7 @@ function optimizerClusterSingleDocumentTestSuite () {
         "REPLACE [] IN @@cn1 RETURN OLD",
         "REPLACE [ {} ] IN @@cn1 RETURN OLD",
         "REPLACE [{ foo: 4 }] IN @@cn1 RETURN OLD",
+        "REPLACE { _key: 'abc' } WITH { two: 1 } INTO @@cn1 OPTIONS { exclusive: true }",
 
         "REMOVE [] IN @@cn1",
         "REMOVE [ {} ] IN @@cn1",
@@ -519,6 +516,7 @@ function optimizerClusterSingleDocumentTestSuite () {
         "REMOVE [] IN @@cn1 RETURN OLD",
         "REMOVE [ {} ] IN @@cn1 RETURN OLD",
         "REMOVE [{ foo: 4 }] IN @@cn1 RETURN OLD",
+        "REMOVE { _key: 'abc' } INTO @@cn1 OPTIONS { exclusive: true }",
       ];
 
       queries.forEach(function(query) {
@@ -534,12 +532,17 @@ function optimizerClusterSingleDocumentTestSuite () {
         "FOR one IN @@cn1 FILTER one._key == 'a' REPLACE one WITH { two: 1 } IN @@cn1",
         "FOR one IN @@cn1 FILTER one._key == 'a' REMOVE one IN @@cn1",
         "INSERT {} INTO @@cn1",
+        "INSERT {} INTO @@cn1 OPTIONS { exclusive: false }",
         "INSERT { _key: 'abc' } INTO @@cn1",
         "INSERT { two: 1 } INTO @@cn1",
         "UPDATE 'foo' WITH { two: 1 } INTO @@cn1",
+        "UPDATE 'foo' WITH { two: 1 } INTO @@cn1 OPTIONS { exclusive: false }",
         "UPDATE { _key: 'abc' } WITH { two: 1 } INTO @@cn1",
+        "REPLACE { _key: 'abc' } WITH { two: 1 } INTO @@cn1",
+        "REPLACE { _key: 'abc' } WITH { two: 1 } INTO @@cn1 OPTIONS { exclusive: false }",
         "REMOVE 'abc' INTO @@cn1",
         "REMOVE { _key: 'abc' } INTO @@cn1",
+        "REMOVE { _key: 'abc' } INTO @@cn1 OPTIONS { exclusive: false }",
       ];
 
       queries.forEach(function(query) {
@@ -550,6 +553,6 @@ function optimizerClusterSingleDocumentTestSuite () {
 
   };
 }
-jsunity.run(optimizerClusterSingleDocumentTestSuite);
 
+jsunity.run(optimizerClusterSingleDocumentTestSuite);
 return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

* Disable optimizer rule "optimize-cluster-single-document-operations" when a
  collection is accessed in exclusive mode, because the optimized query would
  use a slightly different mode of locking then.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/15558
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/15559
