### PR TITLE
Build/add zlib dependency

### DIFF
--- a/3rdParty/V8/gypfiles/standalone.gypi
+++ b/3rdParty/V8/gypfiles/standalone.gypi
@@ -402,15 +402,15 @@
       ['host_clang==1', {
         'conditions':[
           ['OS=="android"', {
-            'host_ld': '<!(<(PYTHON_EXECUTABLE)  -c "import distutils.spawn; print(distutils.spawn.find_executable(\\"ld\\"))")',
-            'host_ranlib': '<!(<(PYTHON_EXECUTABLE)  -c "import distutils.spawn; print(distutils.spawn.find_executable(\\"ranlib\\"))")',
+            'host_ld': '<!(<(PYTHON_EXECUTABLE)  -c "import shutil; print(shutil.which(\\"ld\\"))")',
+            'host_ranlib': '<!(<(PYTHON_EXECUTABLE)  -c "import shutil; print(shutil.which(\\"ranlib\\"))")',
           }],
         ],
         'host_cc': '<(clang_dir)/bin/clang',
         'host_cxx': '<(clang_dir)/bin/clang++',
       }, {
-        'host_cc': '<!(<(PYTHON_EXECUTABLE)  -c "import distutils.spawn; print(distutils.spawn.find_executable(\\"gcc\\"))")',
-        'host_cxx': '<!(<(PYTHON_EXECUTABLE)  -c "import distutils.spawn; print(distutils.spawn.find_executable(\\"g++\\"))")',
+        'host_cc': '<!(<(PYTHON_EXECUTABLE)  -c "import shutil; print(shutil.which(\\"gcc\\"))")',
+        'host_cxx': '<!(<(PYTHON_EXECUTABLE)  -c "import shutil; print(shutil.which(\\"g++\\"))")',
       }],
     ],
     # Default ARM variable settings.
@@ -1369,8 +1369,8 @@
       # Set default ARM cross tools on linux.  These can be overridden
       # using CC,CXX,CC.host and CXX.host environment variables.
       'make_global_settings': [
-        ['CC', '<!(<(PYTHON_EXECUTABLE)  -c "import distutils.spawn; print(distutils.spawn.find_executable(\\"arm-linux-gnueabihf-gcc\\"))")'],
-        ['CXX', '<!(<(PYTHON_EXECUTABLE)  -c "import distutils.spawn; print(distutils.spawn.find_executable(\\"arm-linux-gnueabihf-g++\\"))")'],
+        ['CC', '<!(<(PYTHON_EXECUTABLE)  -c "import shutil; print(shutil.which(\\"arm-linux-gnueabihf-gcc\\"))")'],
+        ['CXX', '<!(<(PYTHON_EXECUTABLE)  -c "import shutil; print(shutil.which(\\"arm-linux-gnueabihf-g++\\"))")'],
         ['CC.host', '<(host_cc)'],
         ['CXX.host', '<(host_cxx)'],
       ],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,12 +534,12 @@ get_filename_component(PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}" REALPATH)
 
 set($ENV{PYTHON_EXECUTABLE} ${PYTHON_EXECUTABLE})
 execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import distutils.spawn"
+    COMMAND ${PYTHON_EXECUTABLE} -c "import shutil.which"
     RESULT_VARIABLE EXIT_CODE
     OUTPUT_QUIET
     )
 if (NOT "${EXIT_CODE}" EQUAL "0")
-  message(FATAL_ERROR "python distutils package is required! ")
+  message(FATAL_ERROR "python shutil.which package is required! ")
 endif()
 
 # FIXME the build containers seem to have a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,7 +534,7 @@ get_filename_component(PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}" REALPATH)
 
 set($ENV{PYTHON_EXECUTABLE} ${PYTHON_EXECUTABLE})
 execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import shutil.which"
+    COMMAND ${PYTHON_EXECUTABLE} -c "from shutil import which"
     RESULT_VARIABLE EXIT_CODE
     OUTPUT_QUIET
     )

--- a/tests/rb/HttpInterface/Gemfile
+++ b/tests/rb/HttpInterface/Gemfile
@@ -3,3 +3,4 @@ source :rubygems
 gem "persistent_httparty"
 gem "rspec", "~> 2.14.0"
 gem "rspec-core", "~> 2.14.0"
+gem "zlib", "~> 2.1.1"

--- a/tests/rb/HttpInterface/Gemfile
+++ b/tests/rb/HttpInterface/Gemfile
@@ -3,4 +3,3 @@ source :rubygems
 gem "persistent_httparty"
 gem "rspec", "~> 2.14.0"
 gem "rspec-core", "~> 2.14.0"
-gem "zlib", "~> 2.1.1"


### PR DESCRIPTION
### Scope & Purpose

the integration test `api-http-spec.rb` uses zlib, but our bundle doesn't demand it so far. 