### PR TITLE
remove internal `_constAstNode` from `Variable` struct

### DIFF
--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -2388,8 +2388,7 @@ void Ast::validateAndOptimize(transaction::Methods& trx) {
       TRI_ASSERT(node->numMembers() == 2);
       Variable const* variable =
           static_cast<Variable const*>(node->getMember(0)->getData());
-      AstNode const* expression = node->getMember(1);
-      AstNode const* source = expression;
+      AstNode const* source = node->getMember(1);
       // recursively process assignments so we can track LET a = b LET c = b
 
       while (source->type == NODE_TYPE_REFERENCE) {

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -62,6 +62,21 @@ namespace StringUtils = arangodb::basics::StringUtils;
 
 namespace {
 
+struct ValidateAndOptimizeContext {
+  explicit ValidateAndOptimizeContext(transaction::Methods& t) : trx(t) {}
+
+  std::unordered_set<std::string> writeCollectionsSeen;
+  std::unordered_map<Variable const*, AstNode const*> variableDefinitions;
+  AqlFunctionsInternalCache aqlFunctionsInternalCache;
+  transaction::Methods& trx;
+  int64_t stopOptimizationRequests = 0;
+  int64_t nestingLevel = 0;     // only used for subqueries
+  int64_t filterDepth = -1;     // -1 = not in filter
+  uint64_t recursionDepth = 0;  // current depth of the tree we walk
+  bool hasSeenAnyWriteNode = false;
+  bool hasSeenWriteNodeInCurrentScope = false;
+};
+
 auto doNothingVisitor = [](AstNode const*) {};
 
 [[noreturn]] void throwFormattedError(arangodb::aql::QueryContext& query,
@@ -425,26 +440,6 @@ AstNode* Ast::createNodeLet(AstNode const* variable,
 
   node->addMember(variable);
   node->addMember(expression);
-
-  return node;
-}
-
-/// @brief create an AST let node, with an IF condition
-AstNode* Ast::createNodeLet(char const* variableName, size_t nameLength,
-                            AstNode const* expression,
-                            AstNode const* condition) {
-  if (variableName == nullptr) {
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_OUT_OF_MEMORY);
-  }
-
-  AstNode* node = createNode(NODE_TYPE_LET);
-  node->reserve(3);
-
-  AstNode* variable =
-      createNodeVariable(std::string_view(variableName, nameLength), true);
-  node->addMember(variable);
-  node->addMember(expression);
-  node->addMember(condition);
 
   return node;
 }
@@ -2151,22 +2146,7 @@ size_t Ast::extractParallelism(AstNode const* optionsNode) {
 /// bind parameter injection. merging this pass with the regular AST
 /// optimizations saves one extra pass over the AST
 void Ast::validateAndOptimize(transaction::Methods& trx) {
-  struct TraversalContext {
-    TraversalContext(transaction::Methods& t) : trx(t) {}
-
-    std::unordered_set<std::string> writeCollectionsSeen;
-    std::unordered_map<Variable const*, AstNode const*> variableDefinitions;
-    AqlFunctionsInternalCache aqlFunctionsInternalCache;
-    transaction::Methods& trx;
-    int64_t stopOptimizationRequests = 0;
-    int64_t nestingLevel = 0;     // only used for subqueries
-    int64_t filterDepth = -1;     // -1 = not in filter
-    uint64_t recursionDepth = 0;  // current depth of the tree we walk
-    bool hasSeenAnyWriteNode = false;
-    bool hasSeenWriteNodeInCurrentScope = false;
-  };
-
-  TraversalContext context(trx);
+  ::ValidateAndOptimizeContext context(trx);
 
   auto preVisitor = [&](AstNode const* node) -> bool {
     auto ctx = &context;
@@ -2189,7 +2169,7 @@ void Ast::validateAndOptimize(transaction::Methods& trx) {
 
       if (func->hasFlag(Function::Flags::NoEval)) {
         // NOOPT will turn all function optimizations off
-        ++(ctx->stopOptimizationRequests);
+        ++ctx->stopOptimizationRequests;
       }
       if (node->willUseV8()) {
         setWillUseV8();
@@ -2380,7 +2360,21 @@ void Ast::validateAndOptimize(transaction::Methods& trx) {
     // reference to a variable, may be able to insert the variable value
     // directly
     if (node->type == NODE_TYPE_REFERENCE) {
-      return this->optimizeReference(node);
+      // this may be a reference to a variable name, not a reference to the
+      // result this can be happen for variables that are specified in the
+      // COLLECT...KEEP clause.
+      if (!node->hasFlag(FLAG_KEEP_VARIABLENAME)) {
+        // look up the definition for the variable
+        auto it = ctx->variableDefinitions.find(
+            static_cast<Variable*>(node->getData()));
+        if (it != ctx->variableDefinitions.end() &&
+            (*it).second->isConstant()) {
+          // if the definition is a constant, return the const value
+          return const_cast<AstNode*>((*it).second);
+        }
+      }
+      // optimization not allowed
+      return node;
     }
 
     // indexed access, e.g. a[0] or a['foo']
@@ -2394,20 +2388,21 @@ void Ast::validateAndOptimize(transaction::Methods& trx) {
       TRI_ASSERT(node->numMembers() == 2);
       Variable const* variable =
           static_cast<Variable const*>(node->getMember(0)->getData());
-      AstNode const* definition = node->getMember(1);
+      AstNode const* expression = node->getMember(1);
+      AstNode const* source = expression;
       // recursively process assignments so we can track LET a = b LET c = b
 
-      while (definition->type == NODE_TYPE_REFERENCE) {
+      while (source->type == NODE_TYPE_REFERENCE) {
         auto it = ctx->variableDefinitions.find(
-            static_cast<Variable const*>(definition->getData()));
+            static_cast<Variable const*>(source->getData()));
         if (it == ctx->variableDefinitions.end()) {
           break;
         }
-        definition = (*it).second;
+        source = (*it).second;
       }
 
-      ctx->variableDefinitions.try_emplace(variable, definition);
-      return this->optimizeLet(node);
+      ctx->variableDefinitions.try_emplace(variable, source);
+      return node;
     }
 
     // FILTER
@@ -3638,33 +3633,6 @@ AstNode* Ast::optimizeFunctionCall(
   return nodeFromVPack(materializer.slice(a, false), true);
 }
 
-/// @brief optimizes a reference to a variable
-/// references are replaced with constants if possible
-AstNode* Ast::optimizeReference(AstNode* node) {
-  TRI_ASSERT(node != nullptr);
-  TRI_ASSERT(node->type == NODE_TYPE_REFERENCE);
-
-  auto variable = static_cast<Variable*>(node->getData());
-
-  if (variable == nullptr) {
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_OUT_OF_MEMORY);
-  }
-
-  // constant propagation
-  if (variable->getConstAstNode() == nullptr) {
-    return node;
-  }
-
-  if (node->hasFlag(FLAG_KEEP_VARIABLENAME)) {
-    // this is a reference to a variable name, not a reference to the result
-    // this can be happen for variables that are specified in the COLLECT...KEEP
-    // clause
-    return node;
-  }
-
-  return variable->getConstAstNode();
-}
-
 /// @brief optimizes indexed access, e.g. a[0] or a['foo']
 AstNode* Ast::optimizeIndexedAccess(AstNode* node) {
   TRI_ASSERT(node != nullptr);
@@ -3690,33 +3658,6 @@ AstNode* Ast::optimizeIndexedAccess(AstNode* node) {
   }
 
   // can't optimize when we get here
-  return node;
-}
-
-/// @brief optimizes the LET statement
-AstNode* Ast::optimizeLet(AstNode* node) {
-  TRI_ASSERT(node != nullptr);
-  TRI_ASSERT(node->type == NODE_TYPE_LET);
-  TRI_ASSERT(node->numMembers() >= 2);
-
-  AstNode* variable = node->getMember(0);
-  AstNode* expression = node->getMember(1);
-
-  bool const hasCondition = (node->numMembers() > 2);
-
-  auto v = static_cast<Variable*>(variable->getData());
-  TRI_ASSERT(v != nullptr);
-
-  if (!hasCondition && expression->isConstant()) {
-    // if the expression assigned to the LET variable is constant, we'll store
-    // a pointer to the const value in the variable
-    // further optimizations can then use this pointer and optimize further,
-    // e.g.
-    // LET a = 1 LET b = a + 1, c = b + a can be optimized to LET a = 1 LET b =
-    // 2 LET c = 4
-    v->setConstAstNode(expression);
-  }
-
   return node;
 }
 

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -184,9 +184,6 @@ class Ast {
   /// @brief create an AST let node, without creating a variable
   AstNode* createNodeLet(AstNode const*, AstNode const*);
 
-  /// @brief create an AST let node, with an IF condition
-  AstNode* createNodeLet(char const*, size_t, AstNode const*, AstNode const*);
-
   /// @brief create an AST filter node
   AstNode* createNodeFilter(AstNode const*);
 
@@ -551,14 +548,8 @@ class Ast {
   AstNode* optimizeFunctionCall(transaction::Methods&,
                                 AqlFunctionsInternalCache&, AstNode*);
 
-  /// @brief optimizes a reference to a variable
-  AstNode* optimizeReference(AstNode*);
-
   /// @brief optimizes indexed access, e.g. a[0] or a['foo']
   AstNode* optimizeIndexedAccess(AstNode*);
-
-  /// @brief optimizes the LET statement
-  AstNode* optimizeLet(AstNode*);
 
   /// @brief optimizes the FILTER statement
   AstNode* optimizeFilter(AstNode*);

--- a/arangod/Aql/Variable.h
+++ b/arangod/Aql/Variable.h
@@ -69,14 +69,6 @@ struct Variable {
 
   Variable* clone() const;
 
-  /// @brief registers a constant value for the variable
-  /// this constant value is used for constant propagation while creating the
-  /// AST
-  void setConstAstNode(AstNode* node) { _constAstNode = node; }
-
-  /// @brief returns a constant value registered for this variable
-  AstNode* getConstAstNode() const { return _constAstNode; }
-
   /// @brief whether or not the variable is user-defined
   bool isUserDefined() const;
 
@@ -122,14 +114,9 @@ struct Variable {
   bool isDataFromCollection;
 
  private:
-  /// @brief constant variable value (points to another AstNode)
-  /// Used for constant propagation while creating the AST.
-  AstNode* _constAstNode{nullptr};
-
-  // TODO - we have two kinds of const values here; this should be cleaned up!
-  /// @brief for const variables, this stores the constant value determined
-  /// while initializing the plan. Note: the variable takes ownership of this
-  /// value and destroys it
+  // for const variables, this stores the constant value determined
+  // while initializing the plan. Note: the variable takes ownership of this
+  // value and destroys it
   AqlValue _constantValue;
 };
 }  // namespace aql


### PR DESCRIPTION
### Scope & Purpose

the `_constAstNode` member in `Variable` was used before to track
the constant value of a variable in an AQL query. For example, in
`LET a = 1`, the `a` variable contained a `_constAstNode` pointer
to the AstNode containing `1`. This pointer was checked during
AST optimization and used for constant propagation, and remained
unused afterwards.
As we are tracking variable definitions during AST optimization in
a map anyway, this PR now removes the `_constAstNode` member from
`Variable` and simply relies on this map. This also allowed removal
of a few methods in `Ast` that became unused.

This is an internal change and should have no user-visible impact.
Thus also no CHANGELOG entry.
No backports are planned.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*
