### PR TITLE
delete test since  test for gzip transfer encoding /_api/version

### DIFF
--- a/tests/rb/HttpInterface/api-http-spec.rb
+++ b/tests/rb/HttpInterface/api-http-spec.rb
@@ -191,62 +191,6 @@ describe ArangoDB do
       end
     end
 
-################################################################################
-## checking GZIP requests
-################################################################################
-
-    context "gzip requests" do
-      it "checks handling of a request, with gzip support" do
-        require 'uri'
-        require 'net/http'
-
-        # only run the following test when using SSL
-        if not ArangoDB.base_uri =~ /^https:/
-          uri = URI.parse(ArangoDB.base_uri + "/_db/_system/_admin/aardvark/index.html")
-          http = Net::HTTP.new(uri.host, uri.port)
-
-          request = Net::HTTP::Get.new(uri.request_uri)
-          request["Accept-Encoding"] = "gzip"
-          response = http.request(request)
-
-          # check content encoding
-          response['content-encoding'].should eq('gzip')
-        end
-      end
-
-      it "checks handling of an request, without gzip support" do
-        cmd = "/_admin/aardvark/index.html"
-        doc = ArangoDB.log_get("admin-interface-get", cmd, :headers => { "Accept-Encoding" => "" }, :format => :plain)
-
-        # check response code
-        doc.code.should eq(200)
-        # check content encoding
-        doc.headers['Content-Encoding'].should be nil
-      end
-    end
-
-################################################################################
-## checking GZIP requests
-################################################################################
-
-    context "deflate requests" do
-      it "checks handling of a request, with deflate support" do
-        require 'uri'
-        require 'net/http'
-        require 'zlib'
-
-        cmd = "/_api/version"
-        deflatedVersion = ArangoDB.log_get("version-deflate-get", cmd, :headers => { "Accept-Encoding" => "deflate" }, :format => :plain)
-        version = ArangoDB.log_get("version-get", cmd, :headers => { "Accept-Encoding" => "" }, :format => :plain)
-
-        # check content encoding
-        deflatedVersion.headers['Content-Encoding'].should eq('deflate')
-
-        # compare both responses
-        inflatedVersionStr = Zlib::inflate deflatedVersion.body
-        version.body.should eq(inflatedVersionStr)
-      end
-    end
 
 ################################################################################
 ## checking CORS requests


### PR DESCRIPTION
### Scope & Purpose
via ruby since we've got the more thorough shell-foxx-api-spec.js doing that now.

- [x] :hammer: Refactoring/simplification
