### PR TITLE
add a suppression for UBSan

### DIFF
--- a/lib/Logger/LogContext.h
+++ b/lib/Logger/LogContext.h
@@ -515,6 +515,10 @@ inline LogContext::ValueBuilder<> LogContext::makeValue() noexcept {
   return ValueBuilder<std::tuple<>>({});
 }
 
+// the following attribute suppresses an UBSan false positive that reports
+// a nullptr access to the LogContext object here. it seems UBSan has issues
+// with thread-locals
+__attribute__((no_sanitize("null")))
 inline LogContext& LogContext::current() noexcept {
   return _threadControlBlock._logContext;
 }


### PR DESCRIPTION
### Scope & Purpose

Add a suppression for UBSan that removes a false positive from being reported at server startup.
This affects only the `LogContext` object, which has been added in 3.10/devel only. So no backports are needed.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*