### PR TITLE
Fix creation of satellite graphs with a `numberOfShards` value != 1.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.7.17 (XXXX-XX-XX)
 --------------------
 
+* Fix creation of satellite graphs with a `numberOfShards` value != 1.
+
 * Fixed a bug that hotbackup upload could miss files (fixes BTS-734).
 
 * BTS-590: When creating a new database in Web UI the value of the write concern


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/862

Fix the creation of satellite graphs with a `numberOfShards` value != 1. 
This combination is invalid and is now rejected properly on the server side.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [x] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/859
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: