### PR TITLE
add cleanup

### DIFF
--- a/tests/js/server/aql/aql-inverted-index.js
+++ b/tests/js/server/aql/aql-inverted-index.js
@@ -92,6 +92,7 @@ function optimizerRuleInvertedIndexTestSuite() {
     },
     tearDownAll: function () {
       col.drop();
+      try { analyzers.remove("my_geo", true); } catch (e) {}
     },
     testIndexNotHinted: function () {
       const query = aql`

--- a/tests/js/server/aql/aql-iresearch-view-executor-regression.js
+++ b/tests/js/server/aql/aql-iresearch-view-executor-regression.js
@@ -99,8 +99,6 @@ const tearDownAll = () => {
   try {
     analyzers.remove(analyzerName, true);
   } catch (e) {}
-
-  assertEqual(0, db._analyzers.count(), db._analyzers.toArray());
 };
 
 function IResearchViewEnumerationRegressionTest() {


### PR DESCRIPTION
### Scope & Purpose

 + Add missing cleanup for the inverted index test. 
 + Removes asserton from tearDownAll of another test as assertions are not intened to be used in the tearDown and broke testing frameworks. Also there are plenty of tests in the aql-view-arangosearch-feature.js that checks proper analyzer add/remove

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

