### PR TITLE
BTS-501

### DIFF
--- a/tests/IResearch/IResearchFeatureTest.cpp
+++ b/tests/IResearch/IResearchFeatureTest.cpp
@@ -1462,7 +1462,7 @@ TEST_F(IResearchFeatureTest, test_options_threads_set_zero) {
   opts->processingResult().touch("arangosearch.threads");
 
   uint32_t const expectedNumThreads = std::max(
-      1U, std::min(8U, (uint32_t(arangodb::NumberOfCores::getValue()) / 8)));
+      1U, std::min(4U, (uint32_t(arangodb::NumberOfCores::getValue()) / 8)));
   feature.validateOptions(opts);
   ASSERT_EQ(0, *threads->ptr);
   ASSERT_EQ(0, *threadsLimit->ptr);


### PR DESCRIPTION
### Scope & Purpose

Fix test for case with more than 32 cores. As for the default thread count computation there is an upper limit of 4 threads per task.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

