### PR TITLE
Fix a potential deadlock in QueryList introduced in #15515

### DIFF
--- a/arangod/Aql/QueryList.cpp
+++ b/arangod/Aql/QueryList.cpp
@@ -130,8 +130,7 @@ bool QueryList::insert(Query& query) {
     }
 
     // return whether or not insertion worked
-    bool inserted =
-        _current.insert({query.id(), query.shared_from_this()}).second;
+    bool inserted = _current.insert({query.id(), &query}).second;
     _queryRegistryFeature.trackQueryStart();
     return inserted;
   } catch (...) {
@@ -277,11 +276,7 @@ Result QueryList::kill(TRI_voc_tick_t id) {
     return {TRI_ERROR_QUERY_NOT_FOUND, "query ID not found in query list"};
   }
 
-  auto query = it->second.lock();
-  if (query) {
-    // if we cannot lock the query, it is already beeing destroyed
-    killQuery(*query, maxLength, false);
-  }
+  killQuery(*it->second, maxLength, false);
 
   return Result();
 }
@@ -297,13 +292,13 @@ uint64_t QueryList::kill(std::function<bool(Query&)> const& filter,
   READ_LOCKER(readLocker, _lock);
 
   for (auto& it : _current) {
-    auto query = it.second.lock();
+    Query& query = *(it.second);
 
-    if (query == nullptr || !filter(*query)) {
+    if (!filter(query)) {
       continue;
     }
 
-    killQuery(*query, maxLength, silent);
+    killQuery(query, maxLength, silent);
     ++killed;
   }
 
@@ -328,10 +323,9 @@ std::vector<QueryEntryCopy> QueryList::listCurrent() {
     result.reserve(_current.size());
 
     for (auto const& it : _current) {
-      auto query = it.second.lock();
-      if (query == nullptr) {
-        continue;
-      }
+      Query const* query = it.second;
+
+      TRI_ASSERT(query != nullptr);
 
       // elapsed time since query start
       double const elapsed = elapsedSince(query->startTime());

--- a/arangod/Aql/QueryList.h
+++ b/arangod/Aql/QueryList.h
@@ -242,7 +242,7 @@ class QueryList {
   arangodb::basics::ReadWriteLock _lock;
 
   /// @brief list of current queries, protected by _lock
-  std::unordered_map<TRI_voc_tick_t, std::weak_ptr<Query>> _current;
+  std::unordered_map<TRI_voc_tick_t, Query*> _current;
 
   /// @brief list of slow queries, protected by _lock
   std::list<QueryEntryCopy> _slow;


### PR DESCRIPTION
### Scope & Purpose

devel fix will be part of #15514; other backports are not necessary because the faulty change was not backported to 3.8.

The problem was that when the QueryList acquires the shared_ptr, it can happen that once it drops that reference, it has to call the destructor (because this was the _last_ reference), which would then try to remove the query from the QueryList. For that we need to acquire the write lock, but since we are calling from some QueryList function that already holds the read lock, this results in a dead lock.

- [x] :hankey: Bugfix
