### PR TITLE
Bug fix 3.8/bts 750

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 v3.8.6 (XXXX-XX-XX)
 -------------------
 
+* Fixed BTS-750: Fixed the issue restricted to cluster mode in which queries 
+  containing the keywords UPDATE or REPLACE together with the keyword WITH and
+  the same key value would result in an error. For example: 
+  `UPDATE 'key1' WITH {_key: 'key1'} IN Collection`
+  because the same key used to update was provided in the object to update the
+  document with.
+
 * Fixed issue #15501: Regression when using "exclusive" query option?
   This fixes a regression in AQL query execution when exclusive locks are used
   for a query and the query also uses the DOCUMENT() AQL function. In this case,

--- a/arangod/Aql/OptimizerRulesCluster.cpp
+++ b/arangod/Aql/OptimizerRulesCluster.cpp
@@ -272,12 +272,12 @@ bool substituteClusterSingleDocumentOperationsIndex(Optimizer* opt, ExecutionPla
         plan->unlinkNode(indexNode);
         modified = true;
       } else if (::parentIsReturnOrConstCalc(node)) {
-        ExecutionNode* singleOperationNode = plan->registerNode(
-            new SingleRemoteOperationNode(plan, plan->nextId(), EN::INDEX, true,
-                                          key, indexNode->collection(),
-                                          ModificationOptions{}, nullptr /*in*/,
-                                          indexNode->outVariable() /*out*/,
-                                          nullptr /*old*/, nullptr /*new*/));
+        ExecutionNode* singleOperationNode =
+            plan->createNode<SingleRemoteOperationNode>(
+                plan, plan->nextId(), EN::INDEX, true, key,
+                indexNode->collection(), ModificationOptions{}, nullptr /*in*/,
+                indexNode->outVariable() /*out*/, nullptr /*old*/,
+                nullptr /*new*/);
         ::replaceNode(plan, indexNode, singleOperationNode);
         modified = true;
       }
@@ -409,16 +409,20 @@ bool substituteClusterSingleDocumentOperationsNoIndex(Optimizer* opt, ExecutionP
       continue;
     }
 
-    ExecutionNode* singleOperationNode = plan->registerNode(
-        new SingleRemoteOperationNode(plan, plan->nextId(), depType, false, key,
-                                      mod->collection(), mod->getOptions(), update /*in*/,
-                                      nullptr, mod->getOutVariableOld(),
-                                      mod->getOutVariableNew()));
+    ExecutionNode* singleOperationNode =
+        plan->createNode<SingleRemoteOperationNode>(
+            plan, plan->nextId(), depType, false, key, mod->collection(),
+            mod->getOptions(), update /*in*/, nullptr, mod->getOutVariableOld(),
+            mod->getOutVariableNew());
 
     ::replaceNode(plan, mod, singleOperationNode);
 
     if (calc) {
-      plan->unlinkNode(calc);
+      plan->clearVarUsageComputed();
+      plan->findVarUsage();
+      if (!calc->isVarUsedLater(calc->outVariable())) {
+        plan->unlinkNode(calc);
+      }
     }
     modified = true;
   }  // for node : nodes

--- a/arangod/Aql/RegisterPlan.cpp
+++ b/arangod/Aql/RegisterPlan.cpp
@@ -173,13 +173,16 @@ void RegisterPlanWalkerT<T>::after(T* en) {
 
           if (it2 == plan->varInfo.end()) {
             // report an error here to prevent crashing
-            THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
-                                           std::string("missing variable #") +
-                                               std::to_string(v->id) + " (" +
-                                               v->name + ") for node #" +
-                                               std::to_string(en->id().id()) +
-                                               " (" + en->getTypeString() +
-                                               ") while planning registers");
+            THROW_ARANGO_EXCEPTION_MESSAGE(
+                TRI_ERROR_INTERNAL,
+                std::string("missing variable ") +
+                    ((!v->name.empty() && v->name[0] >= '0' &&
+                      v->name[0] <= '9')
+                         ? "#"
+                         : "") +
+                    v->name + " (id " + std::to_string(v->id) + ") for node #" +
+                    std::to_string(en->id().id()) + " (" + en->getTypeString() +
+                    ") while planning registers");
           }
         }
       }

--- a/arangod/Aql/SingleRemoteModificationExecutor.cpp
+++ b/arangod/Aql/SingleRemoteModificationExecutor.cpp
@@ -32,8 +32,6 @@
 #include "Cluster/ServerState.h"
 #include "VocBase/LogicalCollection.h"
 
-#include "Logger/LogMacros.h"
-
 #include <algorithm>
 
 using namespace arangodb;

--- a/arangod/Aql/SingleRemoteModificationExecutor.cpp
+++ b/arangod/Aql/SingleRemoteModificationExecutor.cpp
@@ -28,12 +28,11 @@
 #include "Aql/OutputAqlItemRow.h"
 #include "Aql/SingleRowFetcher.h"
 #include "Aql/QueryContext.h"
-#include "Basics/Common.h"
 #include "Basics/StaticStrings.h"
-#include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
-#include "Transaction/Methods.h"
 #include "VocBase/LogicalCollection.h"
+
+#include "Logger/LogMacros.h"
 
 #include <algorithm>
 
@@ -49,8 +48,7 @@ std::unique_ptr<VPackBuilder> merge(VPackSlice document, std::string const& key,
     TRI_SanitizeObject(document, *builder);
     VPackSlice keyInBody = document.get(StaticStrings::KeyString);
 
-    if (keyInBody.isNone() || keyInBody.isNull() ||
-        (keyInBody.isString() && keyInBody.copyString() != key) ||
+    if (keyInBody.isNone() || keyInBody.isNull() || keyInBody.isString() ||
         ((revision.isSet()) && (RevisionId::fromSlice(document) != revision))) {
       // We need to rewrite the document with the given revision and key:
       builder->add(StaticStrings::KeyString, VPackValue(key));

--- a/tests/js/server/aql/aql-optimizer-rule-optimize-cluster-single-document-operations.js
+++ b/tests/js/server/aql/aql-optimizer-rule-optimize-cluster-single-document-operations.js
@@ -31,7 +31,6 @@ const internal = require("internal");
 const errors = internal.errors;
 const db = require("@arangodb").db;
 const helper = require("@arangodb/aql-helper");
-const assertQueryError = helper.assertQueryError;
 
 function optimizerClusterSingleDocumentTestSuite () {
   var ruleName = "optimize-cluster-single-document-operations";
@@ -107,6 +106,8 @@ function optimizerClusterSingleDocumentTestSuite () {
       let doFullTest = set[3]; // Do advanced checking
       let setupFunction = set[4]; // this resets the setup
       let errorCode = set[5]; // expected error code
+      let returnKey = set[6];
+      let returnValue = set[7];
       const queryInfo = "count: " + count + " query info: " + JSON.stringify(set);
 
       var result = AQL_EXPLAIN(queryString, {}, thisRuleEnabled); // explain - only
@@ -120,6 +121,9 @@ function optimizerClusterSingleDocumentTestSuite () {
         try {
           r1 = AQL_EXECUTE(queryString, {}, thisRuleDisabled);
           assertEqual(0, errorCode, "we have no error in the original, but the tests expects an exception: " + queryInfo);
+          if (typeof returnKey !== 'undefined') {
+            assertEqual(r1["json"][0][returnKey], returnValue);
+          }
         } catch (y) {
           assertTrue(errorCode.hasOwnProperty('code'), "original plan throws, but we don't expect an exception" + JSON.stringify(y) + queryInfo);
           assertEqual(y.errorNum, errorCode.code, "match other error code - got: " + JSON.stringify(y) + queryInfo);
@@ -130,6 +134,9 @@ function optimizerClusterSingleDocumentTestSuite () {
         try {
           r2 = AQL_EXECUTE(queryString, {}, thisRuleEnabled);
           assertEqual(0, errorCode, "we have no error in our plan, but the tests expects an exception" + queryInfo);
+          if (typeof returnKey !== 'undefined') {
+            assertEqual(r1["json"][0][returnKey], returnValue);
+          }
         } catch (x) {
           assertTrue(errorCode.hasOwnProperty('code'), "our plan throws, but we don't expect an exception" + JSON.stringify(x) + queryInfo);
           assertEqual(x.errorNum, errorCode.code, "match our error code" + JSON.stringify(x) + queryInfo);
@@ -342,9 +349,13 @@ function optimizerClusterSingleDocumentTestSuite () {
         [ "UPDATE {_key: '1'} WITH {foo: 'bar4a'} IN " + cn1 + " OPTIONS {} RETURN [OLD, NEW]", 2, 2, true, setupC1, 0],        
         [ "UPDATE {_key: '1'} WITH {foo: 'bar5a'} IN " + cn1 + " OPTIONS {} RETURN { old: OLD, new: NEW }", 2, 2, true, setupC1, 0],
         [ "UPDATE {_key: '1'} INTO " + cn1 + " RETURN OLD._key", 0, 2, true, s, 0],
+        [ "UPDATE {_key: '1'} WITH {_key: '1', name: 'test1'} IN " + cn1 + " OPTIONS {} RETURN NEW", 1, 1, true, setupC1, 0, "name", "test1"],
         [ `FOR doc IN ${cn1} FILTER doc._key == '1' UPDATE doc INTO ${cn1} OPTIONS {} RETURN NEW`, 4, 3, true, s, 0],
         [ `FOR doc IN ${cn1} FILTER doc._key == '1' UPDATE doc WITH {foo: 'bar'} INTO ${cn1} OPTIONS {} RETURN [OLD, NEW]`, 8, 2, true, setupC1, 0],
+        [ `FOR doc IN ${cn1} FILTER doc._key == '1' UPDATE doc WITH {_key: '1', name: 'test1'} INTO ${cn1} OPTIONS {} RETURN NEW`, 8, 1, true, setupC1, 0, "name", "test1"],
+        [ `FOR doc IN ${cn1} FILTER doc._key == '1' UPDATE '1' WITH {_key: '1', name: 'test1'} INTO ${cn1} OPTIONS {} RETURN NEW`, 10, 5, true, setupC1, 0, "name", "test1"],
         [ `FOR doc IN ${cn1} FILTER doc._key == '${notHereDoc}' UPDATE doc WITH {foo: 'bar'} INTO ${cn1} OPTIONS {} RETURN [OLD, NEW]`, 8, 2, true, setupC1, 0],
+        [ `LET a = 123 FOR doc IN ${cn1} FILTER doc._key == '1' UPDATE '1' WITH {_key: '1', name: 'test1'} INTO ${cn1} OPTIONS {} RETURN NEW`, 11, 5, true, setupC1, 0, "name", "test1"],
         [ `LET a = { a: 123 } FOR doc IN ${cn1} FILTER doc._key == '1' UPDATE doc INTO ${cn1} OPTIONS {} RETURN { NEW: NEW, a: a }`, 6, 4, true, s, 0],
         [ `LET a = { a: 123 } FOR doc IN ${cn1} FILTER doc._key == '1' UPDATE doc WITH {foo: 'bar'} INTO ${cn1} OPTIONS {} RETURN [OLD, NEW, a]`, 9, 2, true, setupC1, 0],
         [ `LET a = { a: 123 } FOR doc IN ${cn1} FILTER doc._key == '1' UPDATE doc INTO ${cn1} OPTIONS {} RETURN [ NEW, a ]`, 6, 4, true, s, 0],
@@ -364,6 +375,8 @@ function optimizerClusterSingleDocumentTestSuite () {
         [ "move-calculations-up", "remove-unnecessary-calculations", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "optimize-cluster-single-document-operations" ],
         [ "move-calculations-up", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "optimize-cluster-single-document-operations" ],
         [ "move-calculations-up", "remove-unnecessary-calculations", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "optimize-cluster-single-document-operations" ],
+        [ "move-calculations-up", "move-calculations-up-2", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "distribute-in-cluster", "scatter-in-cluster", "remove-unnecessary-remote-scatter", "restrict-to-single-shard" ],
+        [ "move-calculations-up", "remove-unnecessary-calculations", "move-calculations-up-2", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "distribute-in-cluster", "scatter-in-cluster", "remove-unnecessary-remote-scatter", "restrict-to-single-shard" ],
       ];
 
       var expectedNodes = [
@@ -371,7 +384,8 @@ function optimizerClusterSingleDocumentTestSuite () {
         [ "SingletonNode", "CalculationNode", "SingleRemoteOperationNode", "ReturnNode" ],
         [ "SingletonNode", "CalculationNode", "SingleRemoteOperationNode", "CalculationNode", "ReturnNode" ],
         [ "SingletonNode", "SingleRemoteOperationNode", "ReturnNode" ],
-        [ "SingletonNode", "SingleRemoteOperationNode", "CalculationNode", "ReturnNode" ]
+        [ "SingletonNode", "SingleRemoteOperationNode", "CalculationNode", "ReturnNode" ],
+        [ "SingletonNode", "CalculationNode", "CalculationNode", "IndexNode", "RemoteNode", "GatherNode", "CalculationNode", "DistributeNode", "RemoteNode", "UpdateNode", "RemoteNode", "GatherNode", "ReturnNode" ]
 
       ];
 
@@ -397,9 +411,14 @@ function optimizerClusterSingleDocumentTestSuite () {
         [ "REPLACE {_key: '1'} WITH {foo: 'bar4a'} IN " + cn1 + " OPTIONS {} RETURN [OLD, NEW]", 2, 2, true, setupC1, 0],   
         [ "REPLACE {_key: '1', boom: true } IN   " + cn1 + " OPTIONS {} RETURN [OLD, NEW]", 3, 2, true, setupC1, 0],
         [ "REPLACE {_key: '1'} WITH {foo: 'bar5a'} IN " + cn1 + " OPTIONS {} RETURN { old: OLD, new: NEW }", 2, 2, true, setupC1, 0],
+        [ "REPLACE {_key: '1'} WITH {_key: '1', name: 'test1'} IN " + cn1 + " OPTIONS {} RETURN NEW", 1, 1, true, setupC1, 0, "name", "test1"],
         [ `FOR doc IN ${cn1} FILTER doc._key == '1' REPLACE doc WITH {foo: 'bar'} INTO ${cn1} OPTIONS {} RETURN [OLD, NEW]`, 8, 2, true, setupC1, 0],
         [ `FOR doc IN ${cn1} FILTER doc._key == '1' REPLACE doc INTO ${cn1} OPTIONS {} RETURN NEW`, 4, 3, true, setupC1, 0],
+        [ `FOR doc IN ${cn1} FILTER doc._key == '1' REPLACE doc WITH {_key: '1', name: 'test1'} INTO ${cn1} OPTIONS {} RETURN NEW`, 8, 1, true, setupC1, 0, "name", "test1"],
+        [ `FOR doc IN ${cn1} FILTER doc._key == '1' REPLACE '1' WITH {_key: '1', name: 'test1'} INTO ${cn1} OPTIONS {} RETURN NEW`, 11, 5, true, setupC1, 0, "name", "test1"],
 
+
+        [ `LET a = 123 FOR doc IN ${cn1} FILTER doc._key == '1' REPLACE '1' WITH {_key: '1', name: 'test1'} INTO ${cn1} OPTIONS {} RETURN NEW`, 12, 5, true, setupC1, 0, "name", "test1"],
         [ `LET a = 123 FOR doc IN ${cn1} FILTER doc._key == '-1' REPLACE doc WITH {foo: 'bar'} INTO ${cn1} OPTIONS {} RETURN [OLD, NEW, a]`, 9, 2, true, setupC1, 0 ],
         
         [ `LET a = 123 FOR doc IN ${cn1} FILTER doc._key ==  '1' REPLACE doc WITH {foo: 'bar'} INTO ${cn1} OPTIONS {} RETURN [OLD, NEW, a]`, 9, 2, true, setupC1, 0],
@@ -420,15 +439,18 @@ function optimizerClusterSingleDocumentTestSuite () {
         [ "move-calculations-up", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "optimize-cluster-single-document-operations" ],
         [ "move-calculations-up", "remove-unnecessary-calculations", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "optimize-cluster-single-document-operations" ],
         [ "move-calculations-up", "move-calculations-up-2", "remove-data-modification-out-variables", "optimize-cluster-single-document-operations" ],
+        [ "move-calculations-up", "move-calculations-up-2", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "distribute-in-cluster", "scatter-in-cluster", "remove-unnecessary-remote-scatter", "restrict-to-single-shard" ],
+        [ "move-calculations-up", "remove-unnecessary-calculations", "move-calculations-up-2", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "distribute-in-cluster", "scatter-in-cluster", "remove-unnecessary-remote-scatter", "restrict-to-single-shard" ],
       ];
-      
+
       var expectedNodes = [
         [ "SingletonNode", "CalculationNode", "SingleRemoteOperationNode" ],
         [ "SingletonNode", "CalculationNode", "SingleRemoteOperationNode", "ReturnNode" ],
         [ "SingletonNode", "CalculationNode", "SingleRemoteOperationNode", "CalculationNode", "ReturnNode"],
         [ "SingletonNode", "SingleRemoteOperationNode", "ReturnNode" ],
-        [ "SingletonNode", "SingleRemoteOperationNode", "CalculationNode", "ReturnNode" ]
-  ];
+        [ "SingletonNode", "SingleRemoteOperationNode", "CalculationNode", "ReturnNode" ],
+        [ "SingletonNode", "CalculationNode", "CalculationNode", "IndexNode", "RemoteNode", "GatherNode", "CalculationNode", "DistributeNode", "RemoteNode", "ReplaceNode", "RemoteNode", "GatherNode", "ReturnNode" ],
+      ];
 
       runTestSet(queries, expectedRules, expectedNodes);
     },

--- a/tests/js/server/aql/aql-optimizer-rule-optimize-cluster-single-document-operations.js
+++ b/tests/js/server/aql/aql-optimizer-rule-optimize-cluster-single-document-operations.js
@@ -375,8 +375,8 @@ function optimizerClusterSingleDocumentTestSuite () {
         [ "move-calculations-up", "remove-unnecessary-calculations", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "optimize-cluster-single-document-operations" ],
         [ "move-calculations-up", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "optimize-cluster-single-document-operations" ],
         [ "move-calculations-up", "remove-unnecessary-calculations", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "optimize-cluster-single-document-operations" ],
-        [ "move-calculations-up", "move-calculations-up-2", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "distribute-in-cluster", "scatter-in-cluster", "remove-unnecessary-remote-scatter", "restrict-to-single-shard" ],
-        [ "move-calculations-up", "remove-unnecessary-calculations", "move-calculations-up-2", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "distribute-in-cluster", "scatter-in-cluster", "remove-unnecessary-remote-scatter", "restrict-to-single-shard" ],
+        [ "move-calculations-up", "move-calculations-up-2", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "patch-update-statements", "distribute-in-cluster", "scatter-in-cluster", "remove-unnecessary-remote-scatter", "restrict-to-single-shard" ],
+        [ "move-calculations-up", "remove-unnecessary-calculations", "move-calculations-up-2", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "patch-update-statements", "distribute-in-cluster", "scatter-in-cluster", "remove-unnecessary-remote-scatter", "restrict-to-single-shard" ],
       ];
 
       var expectedNodes = [
@@ -439,8 +439,8 @@ function optimizerClusterSingleDocumentTestSuite () {
         [ "move-calculations-up", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "optimize-cluster-single-document-operations" ],
         [ "move-calculations-up", "remove-unnecessary-calculations", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "optimize-cluster-single-document-operations" ],
         [ "move-calculations-up", "move-calculations-up-2", "remove-data-modification-out-variables", "optimize-cluster-single-document-operations" ],
-        [ "move-calculations-up", "move-calculations-up-2", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "distribute-in-cluster", "scatter-in-cluster", "remove-unnecessary-remote-scatter", "restrict-to-single-shard" ],
-        [ "move-calculations-up", "remove-unnecessary-calculations", "move-calculations-up-2", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "distribute-in-cluster", "scatter-in-cluster", "remove-unnecessary-remote-scatter", "restrict-to-single-shard" ],
+        [ "move-calculations-up", "move-calculations-up-2", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "patch-update-statements", "distribute-in-cluster", "scatter-in-cluster", "remove-unnecessary-remote-scatter", "restrict-to-single-shard" ],
+        [ "move-calculations-up", "remove-unnecessary-calculations", "move-calculations-up-2", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "patch-update-statements", "distribute-in-cluster", "scatter-in-cluster", "remove-unnecessary-remote-scatter", "restrict-to-single-shard" ],
       ];
 
       var expectedNodes = [

--- a/tests/js/server/aql/aql-optimizer-rule-optimize-cluster-single-document-operations.js
+++ b/tests/js/server/aql/aql-optimizer-rule-optimize-cluster-single-document-operations.js
@@ -350,12 +350,19 @@ function optimizerClusterSingleDocumentTestSuite () {
         [ "UPDATE {_key: '1'} WITH {foo: 'bar5a'} IN " + cn1 + " OPTIONS {} RETURN { old: OLD, new: NEW }", 2, 2, true, setupC1, 0],
         [ "UPDATE {_key: '1'} INTO " + cn1 + " RETURN OLD._key", 0, 2, true, s, 0],
         [ "UPDATE {_key: '1'} WITH {_key: '1', name: 'test1'} IN " + cn1 + " OPTIONS {} RETURN NEW", 1, 1, true, setupC1, 0, "name", "test1"],
+        [ "UPDATE {_key: '1'} WITH {_key: '2'} IN " + cn1 + " OPTIONS {} RETURN NEW", 1, 1, true, setupC1, 0],
+        [ "UPDATE {_key: '1'} WITH {_key: '1'} IN " + cn1 + " OPTIONS {} RETURN NEW", 12, 1, true, setupC1, 0],
+        [ "UPDATE '1' WITH {_key: '2'} IN " + cn1 + " OPTIONS {} RETURN OLD", 1, 1, true, setupC1, 0],
+        [ "UPDATE '1' WITH {_key: '1'} IN " + cn1 + " OPTIONS {} RETURN OLD", 1, 1, true, setupC1, 0],
+        [ "UPDATE '1' WITH {_key: '1', name: 'test1'} IN " + cn1 + " OPTIONS {} RETURN NEW", 1, 1, true, setupC1, 0, "name", "test1"],
         [ `FOR doc IN ${cn1} FILTER doc._key == '1' UPDATE doc INTO ${cn1} OPTIONS {} RETURN NEW`, 4, 3, true, s, 0],
         [ `FOR doc IN ${cn1} FILTER doc._key == '1' UPDATE doc WITH {foo: 'bar'} INTO ${cn1} OPTIONS {} RETURN [OLD, NEW]`, 8, 2, true, setupC1, 0],
         [ `FOR doc IN ${cn1} FILTER doc._key == '1' UPDATE doc WITH {_key: '1', name: 'test1'} INTO ${cn1} OPTIONS {} RETURN NEW`, 8, 1, true, setupC1, 0, "name", "test1"],
         [ `FOR doc IN ${cn1} FILTER doc._key == '1' UPDATE '1' WITH {_key: '1', name: 'test1'} INTO ${cn1} OPTIONS {} RETURN NEW`, 10, 5, true, setupC1, 0, "name", "test1"],
+        [ `FOR doc IN ${cn1} FILTER doc._key == '1' UPDATE '1' WITH {_key: '1'} INTO ${cn1} OPTIONS {} RETURN NEW`, 10, 5, true, setupC1, 0],
         [ `FOR doc IN ${cn1} FILTER doc._key == '${notHereDoc}' UPDATE doc WITH {foo: 'bar'} INTO ${cn1} OPTIONS {} RETURN [OLD, NEW]`, 8, 2, true, setupC1, 0],
         [ `LET a = 123 FOR doc IN ${cn1} FILTER doc._key == '1' UPDATE '1' WITH {_key: '1', name: 'test1'} INTO ${cn1} OPTIONS {} RETURN NEW`, 11, 5, true, setupC1, 0, "name", "test1"],
+        [ `LET a = 123 FOR doc IN ${cn1} FILTER doc._key == '1' UPDATE '1' WITH {_key: '1'} INTO ${cn1} OPTIONS {} RETURN NEW`, 11, 5, true, setupC1, 0],
         [ `LET a = { a: 123 } FOR doc IN ${cn1} FILTER doc._key == '1' UPDATE doc INTO ${cn1} OPTIONS {} RETURN { NEW: NEW, a: a }`, 6, 4, true, s, 0],
         [ `LET a = { a: 123 } FOR doc IN ${cn1} FILTER doc._key == '1' UPDATE doc WITH {foo: 'bar'} INTO ${cn1} OPTIONS {} RETURN [OLD, NEW, a]`, 9, 2, true, setupC1, 0],
         [ `LET a = { a: 123 } FOR doc IN ${cn1} FILTER doc._key == '1' UPDATE doc INTO ${cn1} OPTIONS {} RETURN [ NEW, a ]`, 6, 4, true, s, 0],
@@ -377,6 +384,7 @@ function optimizerClusterSingleDocumentTestSuite () {
         [ "move-calculations-up", "remove-unnecessary-calculations", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "optimize-cluster-single-document-operations" ],
         [ "move-calculations-up", "move-calculations-up-2", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "patch-update-statements", "distribute-in-cluster", "scatter-in-cluster", "remove-unnecessary-remote-scatter", "restrict-to-single-shard" ],
         [ "move-calculations-up", "remove-unnecessary-calculations", "move-calculations-up-2", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "patch-update-statements", "distribute-in-cluster", "scatter-in-cluster", "remove-unnecessary-remote-scatter", "restrict-to-single-shard" ],
+        [ "move-calculations-up", "remove-redundant-calculations", "remove-unnecessary-calculations", "remove-data-modification-out-variables", "optimize-cluster-single-document-operations" ],
       ];
 
       var expectedNodes = [
@@ -412,12 +420,19 @@ function optimizerClusterSingleDocumentTestSuite () {
         [ "REPLACE {_key: '1', boom: true } IN   " + cn1 + " OPTIONS {} RETURN [OLD, NEW]", 3, 2, true, setupC1, 0],
         [ "REPLACE {_key: '1'} WITH {foo: 'bar5a'} IN " + cn1 + " OPTIONS {} RETURN { old: OLD, new: NEW }", 2, 2, true, setupC1, 0],
         [ "REPLACE {_key: '1'} WITH {_key: '1', name: 'test1'} IN " + cn1 + " OPTIONS {} RETURN NEW", 1, 1, true, setupC1, 0, "name", "test1"],
+        [ "REPLACE {_key: '1'} WITH {_key: '2'} IN " + cn1 + " OPTIONS {} RETURN NEW", 1, 1, true, setupC1, 0],
+        [ "REPLACE {_key: '1'} WITH {_key: '1'} IN " + cn1 + " OPTIONS {} RETURN NEW", 13, 1, true, setupC1, 0],
+        [ "REPLACE '1' WITH {_key: '1', name: 'test1'} IN " + cn1 + " OPTIONS {} RETURN NEW", 1, 1, true, setupC1, 0, "name", "test1"],
+        [ "REPLACE '1' WITH {_key: '2'} IN " + cn1 + " OPTIONS {} RETURN OLD", 1, 1, true, setupC1, 0],
+        [ "REPLACE '1' WITH {_key: '1'} IN " + cn1 + " OPTIONS {} RETURN OLD", 1, 1, true, setupC1, 0],
+
         [ `FOR doc IN ${cn1} FILTER doc._key == '1' REPLACE doc WITH {foo: 'bar'} INTO ${cn1} OPTIONS {} RETURN [OLD, NEW]`, 8, 2, true, setupC1, 0],
         [ `FOR doc IN ${cn1} FILTER doc._key == '1' REPLACE doc INTO ${cn1} OPTIONS {} RETURN NEW`, 4, 3, true, setupC1, 0],
         [ `FOR doc IN ${cn1} FILTER doc._key == '1' REPLACE doc WITH {_key: '1', name: 'test1'} INTO ${cn1} OPTIONS {} RETURN NEW`, 8, 1, true, setupC1, 0, "name", "test1"],
         [ `FOR doc IN ${cn1} FILTER doc._key == '1' REPLACE '1' WITH {_key: '1', name: 'test1'} INTO ${cn1} OPTIONS {} RETURN NEW`, 11, 5, true, setupC1, 0, "name", "test1"],
+        [ `FOR doc IN ${cn1} FILTER doc._key == '1' REPLACE '1' WITH {_key: '1'} INTO ${cn1} OPTIONS {} RETURN NEW`, 11, 5, true, setupC1, 0],
 
-
+        [ `LET a = 123 FOR doc IN ${cn1} FILTER doc._key == '1' REPLACE '1' WITH {_key: '1'} INTO ${cn1} OPTIONS {} RETURN NEW`, 12, 5, true, setupC1, 0],
         [ `LET a = 123 FOR doc IN ${cn1} FILTER doc._key == '1' REPLACE '1' WITH {_key: '1', name: 'test1'} INTO ${cn1} OPTIONS {} RETURN NEW`, 12, 5, true, setupC1, 0, "name", "test1"],
         [ `LET a = 123 FOR doc IN ${cn1} FILTER doc._key == '-1' REPLACE doc WITH {foo: 'bar'} INTO ${cn1} OPTIONS {} RETURN [OLD, NEW, a]`, 9, 2, true, setupC1, 0 ],
         
@@ -441,6 +456,7 @@ function optimizerClusterSingleDocumentTestSuite () {
         [ "move-calculations-up", "move-calculations-up-2", "remove-data-modification-out-variables", "optimize-cluster-single-document-operations" ],
         [ "move-calculations-up", "move-calculations-up-2", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "patch-update-statements", "distribute-in-cluster", "scatter-in-cluster", "remove-unnecessary-remote-scatter", "restrict-to-single-shard" ],
         [ "move-calculations-up", "remove-unnecessary-calculations", "move-calculations-up-2", "remove-data-modification-out-variables", "use-indexes", "remove-filter-covered-by-index", "remove-unnecessary-calculations-2", "patch-update-statements", "distribute-in-cluster", "scatter-in-cluster", "remove-unnecessary-remote-scatter", "restrict-to-single-shard" ],
+        [ "move-calculations-up", "remove-redundant-calculations", "remove-unnecessary-calculations", "remove-data-modification-out-variables", "optimize-cluster-single-document-operations" ],
       ];
 
       var expectedNodes = [


### PR DESCRIPTION
### Scope & Purpose

Fixed the issue restricted to cluster mode in which queries containing the keywords UPDATE or REPLACE together with the keyword WITH and the same key value would result in an error. For example: 
`UPDATE 'key1' WITH {_key: 'key1'} IN Collection`
because the same key used to update was provided in the object to update the document with. 

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
 3.8 backport.

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-750
- [ ] Design document: 

