### PR TITLE
Refactor LogContext to produce less moves/copies

### DIFF
--- a/lib/Logger/LogContext.h
+++ b/lib/Logger/LogContext.h
@@ -307,7 +307,7 @@ struct LogContext::ValueBuilder<LogContext::KeyValue<K, V>, Base, Depth> {
  private:
   using ValueTypesT = typename Base::ValueTypesT::template With<
       std::decay_t<std::remove_reference_t<V>>>;
-  using KeysT = typename Base::Keys::template With<K>;
+  using KeysT = typename Base::KeysT::template With<K>;
 
   template<class F>
   auto passValues(F&& func) && {

--- a/lib/Logger/LogContext.h
+++ b/lib/Logger/LogContext.h
@@ -83,6 +83,12 @@ class LogContext {
 
   struct Values;
 
+  template<const char K[], class V>
+  struct KeyValue {
+    static constexpr const char* Key = K;
+    using Value = V;
+  };
+
   /// @brief helper class to create value tuples with the following syntax:
   ///   LogContext::makeValue().with<Key1>(value1).with<Key2>(value2)
   /// The keys must be compile time constant char pointers; the values can
@@ -92,7 +98,7 @@ class LogContext {
   /// `ScopedValue`, or you can call `share()` to create a reusable
   /// `std::shared_ptr<Values>` which can be stored in a member and used for
   /// different `ScopedValues`.
-  template<class Vals = std::tuple<>, const char... Keys[]>
+  template<class KV = void, class Base = void, std::size_t Depth = 0>
   struct ValueBuilder;
 
   /// @brief sets the given LogContext as the thread's current context for the
@@ -144,8 +150,8 @@ class LogContext {
     /// only revert to this function if you cannot use `ScopedValue`.
     static EntryPtr pushValues(std::shared_ptr<Values>);
 
-    template<class Vals, const char... Keys[]>
-    static EntryPtr pushValues(ValueBuilder<Vals, Keys...>&&);
+    template<class KV, class Base, std::size_t Depth>
+    static EntryPtr pushValues(ValueBuilder<KV, Base, Depth>&&);
 
     /// @brief removes the previously added entry from the LogContext.
     /// Note: it is important that entries are popped in the inverse order in
@@ -153,12 +159,25 @@ class LogContext {
     static void popEntry(EntryPtr&) noexcept;
 
    private:
-    template<class V>
-    static EntryPtr pushImpl(V&& v);
+    template<class T, class... Args>
+    static EntryPtr appendEntry(Args&&... args);
   };
 
  private:
   struct ThreadControlBlock;
+
+  template<const char... Ks[]>
+  struct Keys {
+    template<const char K[]>
+    using With = Keys<Ks..., K>;
+  };
+
+  template<class... Vs>
+  struct ValueTypes {
+    template<class V>
+    using With = ValueTypes<Vs..., V>;
+    using Tuple = std::tuple<Vs...>;
+  };
 
   static ThreadControlBlock& controlBlock() noexcept {
     return _threadControlBlock;
@@ -166,7 +185,7 @@ class LogContext {
 
   struct EntryCache;
 
-  template<class Vals, const char... Keys[]>
+  template<class Vals, class Keys>
   struct ValuesImpl;
 
   template<class Vals>
@@ -226,22 +245,101 @@ struct LogContext::OverloadVisitor : GenericVisitor<OverloadVisitor<Overloads>>,
   }
 };
 
-template<class Vals, const char... Keys[]>
-struct LogContext::ValueBuilder {
+template<>
+struct LogContext::ValueBuilder<void, void, 0> {
   template<const char Key[], class Value>
-  auto with(Value v) && {
-    auto vals = std::tuple_cat(std::move(_vals),
-                               std::make_tuple(std::forward<Value>(v)));
-    return ValueBuilder<decltype(vals), Keys..., Key>(std::move(vals));
+  auto with(Value&& v) && {
+    return ValueBuilder<KeyValue<Key, Value>, void, 1>(std::forward<Value>(v));
+  }
+};
+
+template<const char K[], class V>
+struct LogContext::ValueBuilder<LogContext::KeyValue<K, V>, void, 1> {
+  template<const char Key[], class Value>
+  auto with(Value&& v) && {
+    return ValueBuilder<KeyValue<Key, Value>, ValueBuilder, 2>(
+        *this, std::forward<Value>(v));
   }
   std::shared_ptr<Values> share() && {
-    return std::make_shared<ValuesImpl<Vals, Keys...>>(std::move(_vals));
+    return std::make_shared<ValuesImpl<ValueTypes, Keys>>(std::move(_value));
   }
 
  private:
+  using ValueTypes = ValueTypes<std::decay_t<std::remove_reference_t<V>>>;
+  using Keys = Keys<K>;
+
+  template<std::size_t Idx>
+  V&& value() {
+    static_assert(Idx == 0);
+    return std::forward<V>(_value);
+  }
+  template<std::size_t Idx>
+  static constexpr const char* key() {
+    static_assert(Idx == 0);
+    return K;
+  }
+  template<class F>
+  auto passValues(F&& func) && {
+    return std::forward<F>(func)(std::forward<V>(_value));
+  }
+
   friend class LogContext;
-  ValueBuilder(Vals vals) : _vals(std::move(vals)) {}
-  Vals _vals;
+  template<class VV>
+  ValueBuilder(VV&& v) : _value(std::forward<VV>(v)) {}
+  V&& _value;
+};
+
+template<const char K[], class V, class Base, std::size_t Depth>
+struct LogContext::ValueBuilder<LogContext::KeyValue<K, V>, Base, Depth> {
+  template<const char Key[], class Value>
+  auto with(Value&& v) && {
+    return ValueBuilder<KeyValue<Key, Value>, ValueBuilder, Depth + 1>(
+        *this, std::forward<Value>(v));
+  }
+  std::shared_ptr<Values> share() && {
+    return std::move(*this).passValues([]<class... Args>(Args && ... args) {
+      return std::make_shared<
+          ValuesImpl<typename ValueBuilder::ValueTypes, Keys>>(
+          std::forward<Args>(args)...);
+    });
+  }
+
+ private:
+  using ValueTypes = typename Base::ValueTypes::template With<
+      std::decay_t<std::remove_reference_t<V>>>;
+  using Keys = typename Base::Keys::template With<K>;
+
+  template<class F>
+  auto passValues(F&& func) && {
+    return [ this, &func ]<std::size_t... I>(std::index_sequence<I...>) {
+      return std::forward<F>(func)(this->template value<I>()...);
+    }
+    (std::make_index_sequence<Depth>{});
+  }
+
+  template<std::size_t Idx>
+  auto&& value() {
+    static_assert(Idx < Depth);
+    if constexpr (Idx + 1 == Depth) {
+      return std::forward<V>(_value);
+    } else {
+      return _base.template value<Idx>();
+    }
+  }
+  template<std::size_t Idx>
+  static constexpr const char* key() {
+    static_assert(Idx < Depth);
+    if constexpr (Idx + 1 == Depth) {
+      return K;
+    } else {
+      return Base::template key<Idx>();
+    }
+  }
+  friend class LogContext;
+  template<class VV>
+  ValueBuilder(Base& base, VV&& v) : _base(base), _value(std::forward<VV>(v)) {}
+  Base& _base;
+  V&& _value;
 };
 
 struct LogContext::Values {
@@ -249,11 +347,13 @@ struct LogContext::Values {
   virtual void visit(Visitor const&) const = 0;
 };
 
-template<class Vals, const char... Keys[]>
-struct LogContext::ValuesImpl final : Values {
-  explicit ValuesImpl(Vals vals) : _values(std::move(vals)) {}
+template<class Vals, const char... KeyValues[]>
+struct LogContext::ValuesImpl<Vals, LogContext::Keys<KeyValues...>> final
+    : Values {
+  template<class... V>
+  explicit ValuesImpl(V&&... v) : _values(std::forward<V>(v)...) {}
   void visit(Visitor const& visitor) const override {
-    doVisit<0, Keys...>(visitor);
+    doVisit<0, KeyValues...>(visitor);
   }
   ValuesImpl const* operator->() const { return this; }
 
@@ -261,7 +361,7 @@ struct LogContext::ValuesImpl final : Values {
   template<std::size_t Idx, const char K[], const char... Ks[]>
   void doVisit(Visitor const& visitor) const {
     visitor.visit(K, toVisitorType(std::get<Idx>(_values)));
-    if constexpr (Idx + 1 < std::tuple_size<Vals>{}()) {
+    if constexpr (Idx + 1 < std::tuple_size<typename Vals::Tuple>{}()) {
       doVisit<Idx + 1, Ks...>(visitor);
     }
   }
@@ -286,7 +386,7 @@ struct LogContext::ValuesImpl final : Values {
     }
   }
 
-  Vals _values;
+  typename Vals::Tuple _values;
 };
 
 struct LogContext::Entry {
@@ -366,7 +466,9 @@ struct LogContext::EntryPtr {
 
 template<class Vals>
 struct LogContext::EntryImpl final : Entry {
-  explicit EntryImpl(Vals&& v) : _values(std::move(v)) {}
+  //explicit EntryImpl(Vals&& v) : _values(std::move(v)) {}
+  template<class... Args>
+  explicit EntryImpl(Args&&... args) : _values(std::forward<Args>(args)...) {}
   void visit(Visitor const& visitor) const override { _values->visit(visitor); }
   void release(EntryCache& cache) noexcept override;
 
@@ -409,18 +511,18 @@ struct LogContext::EntryCache {
     return ::operator new(MinEntryCacheSize);
   }
 
-  template<class T, class Arg>
-  std::unique_ptr<Entry> makeEntry(Arg&& arg) {
+  template<class T, class... Args>
+  std::unique_ptr<Entry> makeEntry(Args&&... args) {
     void* p = sizeof(T) <= MinEntryCacheSize ? popFromCache()
                                              : ::operator new(sizeof(T));
-    auto* e = new (p) T(std::forward<Arg>(arg));
+    auto* e = new (p) T(std::forward<Args>(args)...);
     return std::unique_ptr<Entry>(e);
   }
 
   static inline constexpr char dummy[] =
       "dummy";  // only needed to calculate MinEntryCacheSize with MSVC
   static constexpr std::size_t MinEntryCacheSize =
-      sizeof(EntryImpl<ValuesImpl<std::tuple<std::string>, dummy>>);
+      sizeof(EntryImpl<ValuesImpl<ValueTypes<std::string>, Keys<dummy>>>);
 
  private:
   static constexpr std::size_t MaxCachedEntries = 128;
@@ -435,10 +537,6 @@ struct LogContext::ThreadControlBlock {
   ThreadControlBlock& operator=(ThreadControlBlock const&) = delete;
   ThreadControlBlock& operator=(ThreadControlBlock&&) = delete;
 
-  template<class Vals, const char... Keys[]>
-  LogContext::Entry* push(LogContext::ValueBuilder<Vals, Keys...>&& v);
-  LogContext::Entry* push(std::shared_ptr<LogContext::Values> v);
-
   void pop(LogContext::Entry* entry) noexcept;
 
  private:
@@ -449,13 +547,17 @@ struct LogContext::ThreadControlBlock {
 
 struct LogContext::Accessor::ScopedValue {
   explicit ScopedValue(std::shared_ptr<LogContext::Values> v) {
-    appendEntry(std::move(v));
+    appendEntry<std::shared_ptr<LogContext::Values>>(std::move(v));
   }
 
-  template<class Vals, const char... Keys[]>
-  explicit ScopedValue(ValueBuilder<Vals, Keys...>&& v) {
-    using V = ValuesImpl<Vals, Keys...>;
-    appendEntry(V(std::move(v._vals)));
+  template<class KV, class Base, std::size_t Depth>
+  explicit ScopedValue(ValueBuilder<KV, Base, Depth>&& v) {
+    std::move(v).passValues([this]<class... Args>(Args && ... args) {
+      this->appendEntry<
+          ValuesImpl<typename ValueBuilder<KV, Base, Depth>::ValueTypes,
+                     typename ValueBuilder<KV, Base, Depth>::Keys>>(
+          std::forward<Args>(args)...);
+    });
   }
 
   ScopedValue(ScopedValue const&) = delete;
@@ -469,10 +571,11 @@ struct LogContext::Accessor::ScopedValue {
   }
 
  private:
-  template<class V>
-  void appendEntry(V&& v) {
+  template<class T, class... Args>
+  void appendEntry(Args&&... args) {
     auto& local = LogContext::controlBlock();
-    auto e = local._entryCache.makeEntry<EntryImpl<V>>(std::forward<V>(v));
+    auto e =
+        local._entryCache.makeEntry<EntryImpl<T>>(std::forward<Args>(args)...);
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     _oldTail = e.get();
 #endif
@@ -531,20 +634,6 @@ inline void LogContext::ThreadControlBlock::pop(Entry* entry) noexcept {
   _logContext.popTail(_entryCache);
 }
 
-template<class Vals, const char... Keys[]>
-inline LogContext::Entry* LogContext::ThreadControlBlock::push(
-    ValueBuilder<Vals, Keys...>&& v) {
-  using V = ValuesImpl<Vals, Keys...>;
-  return _logContext.pushEntry(
-      _entryCache.makeEntry<EntryImpl<V>>(V(std::move(v._vals))));
-}
-
-inline LogContext::Entry* LogContext::ThreadControlBlock::push(
-    std::shared_ptr<Values> v) {
-  return _logContext.pushEntry(
-      _entryCache.makeEntry<EntryImpl<std::shared_ptr<Values>>>(std::move(v)));
-}
-
 // LogContext
 
 inline LogContext::~LogContext() {
@@ -595,7 +684,7 @@ inline LogContext& LogContext::operator=(LogContext&& r) noexcept {
 }
 
 inline LogContext::ValueBuilder<> LogContext::makeValue() noexcept {
-  return ValueBuilder<std::tuple<>>({});
+  return ValueBuilder<>();
 }
 
 // the following attribute suppresses an UBSan false positive that reports
@@ -604,27 +693,31 @@ inline LogContext::ValueBuilder<> LogContext::makeValue() noexcept {
 #ifndef _MSC_VER
 __attribute__((no_sanitize("null")))
 #endif
-inline LogContext&
-LogContext::current() noexcept {
+inline LogContext& LogContext::current() noexcept {
   return _threadControlBlock._logContext;
 }
 
 inline LogContext::EntryPtr LogContext::Current::pushValues(
     std::shared_ptr<Values> values) {
-  return pushImpl(std::move(values));
+  return appendEntry<std::shared_ptr<LogContext::Values>>(std::move(values));
 }
 
-template<class Vals, const char... Keys[]>
+template<class KV, class Base, std::size_t Depth>
 inline LogContext::EntryPtr LogContext::Current::pushValues(
-    ValueBuilder<Vals, Keys...>&& v) {
-  using V = ValuesImpl<Vals, Keys...>;
-  return pushImpl(V(std::move(v._vals)));
+    ValueBuilder<KV, Base, Depth>&& v) {
+  return std::move(v).passValues([]<class... Args>(Args && ... args) {
+      return Current::appendEntry<
+          ValuesImpl<typename ValueBuilder<KV, Base, Depth>::ValueTypes,
+                     typename ValueBuilder<KV, Base, Depth>::Keys>>(
+          std::forward<Args>(args)...);
+    });
 }
 
-template<class V>
-inline LogContext::EntryPtr LogContext::Current::pushImpl(V&& v) {
+template<class T, class... Args>
+inline LogContext::EntryPtr LogContext::Current::appendEntry(Args&&... args) {
   auto& local = LogContext::controlBlock();
-  auto e = local._entryCache.makeEntry<EntryImpl<V>>(std::forward<V>(v));
+  auto e =
+      local._entryCache.makeEntry<EntryImpl<T>>(std::forward<Args>(args)...);
   EntryPtr result(e.get());
   local._logContext.pushEntry(std::move(e));
   return result;

--- a/lib/Logger/LogContext.h
+++ b/lib/Logger/LogContext.h
@@ -261,12 +261,12 @@ struct LogContext::ValueBuilder<LogContext::KeyValue<K, V>, void, 1> {
         *this, std::forward<Value>(v));
   }
   std::shared_ptr<Values> share() && {
-    return std::make_shared<ValuesImpl<ValueTypes, Keys>>(std::move(_value));
+    return std::make_shared<ValuesImpl<ValueTypesT, KeysT>>(std::move(_value));
   }
 
  private:
-  using ValueTypes = ValueTypes<std::decay_t<std::remove_reference_t<V>>>;
-  using Keys = Keys<K>;
+  using ValueTypesT = ValueTypes<std::decay_t<std::remove_reference_t<V>>>;
+  using KeysT = Keys<K>;
 
   template<std::size_t Idx>
   V&& value() {
@@ -299,15 +299,15 @@ struct LogContext::ValueBuilder<LogContext::KeyValue<K, V>, Base, Depth> {
   std::shared_ptr<Values> share() && {
     return std::move(*this).passValues([]<class... Args>(Args && ... args) {
       return std::make_shared<
-          ValuesImpl<typename ValueBuilder::ValueTypes, Keys>>(
+          ValuesImpl<ValueTypesT, KeysT>>(
           std::forward<Args>(args)...);
     });
   }
 
  private:
-  using ValueTypes = typename Base::ValueTypes::template With<
+  using ValueTypesT = typename Base::ValueTypesT::template With<
       std::decay_t<std::remove_reference_t<V>>>;
-  using Keys = typename Base::Keys::template With<K>;
+  using KeysT = typename Base::Keys::template With<K>;
 
   template<class F>
   auto passValues(F&& func) && {
@@ -554,8 +554,8 @@ struct LogContext::Accessor::ScopedValue {
   explicit ScopedValue(ValueBuilder<KV, Base, Depth>&& v) {
     std::move(v).passValues([this]<class... Args>(Args && ... args) {
       this->appendEntry<
-          ValuesImpl<typename ValueBuilder<KV, Base, Depth>::ValueTypes,
-                     typename ValueBuilder<KV, Base, Depth>::Keys>>(
+          ValuesImpl<typename ValueBuilder<KV, Base, Depth>::ValueTypesT,
+                     typename ValueBuilder<KV, Base, Depth>::KeysT>>(
           std::forward<Args>(args)...);
     });
   }
@@ -707,8 +707,8 @@ inline LogContext::EntryPtr LogContext::Current::pushValues(
     ValueBuilder<KV, Base, Depth>&& v) {
   return std::move(v).passValues([]<class... Args>(Args && ... args) {
       return Current::appendEntry<
-          ValuesImpl<typename ValueBuilder<KV, Base, Depth>::ValueTypes,
-                     typename ValueBuilder<KV, Base, Depth>::Keys>>(
+          ValuesImpl<typename ValueBuilder<KV, Base, Depth>::ValueTypesT,
+                     typename ValueBuilder<KV, Base, Depth>::KeysT>>(
           std::forward<Args>(args)...);
     });
 }


### PR DESCRIPTION
### Scope & Purpose

Previously chained `with<key>(value)` calls resulted in a quadratic number of moves/copies.

- [x] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [x] C++ **Unit tests**
