### PR TITLE
Use C++20 likely/unlikely instead of macro

### DIFF
--- a/3rdParty/fuerte/src/debugging.h
+++ b/3rdParty/fuerte/src/debugging.h
@@ -25,21 +25,6 @@
 
 #include <fuerte/FuerteLogger.h>
 
-#ifndef ADB_LIKELY
-
-// likely/unlikely branch indicator
-// macro definitions similar to the ones at
-// https://kernelnewbies.org/FAQ/LikelyUnlikely
-#if defined(__GNUC__) || defined(__GNUG__)
-#define ADB_LIKELY(v) __builtin_expect(!!(v), 1)
-#define ADB_UNLIKELY(v) __builtin_expect(!!(v), 0)
-#else
-#define ADB_LIKELY(v) v
-#define ADB_UNLIKELY(v) v
-#endif
-
-#endif  // ADB_LIKELY
-
 /// @brief assert
 #ifndef FUERTE_ASSERT
 
@@ -47,7 +32,7 @@
 
 #define FUERTE_ASSERT(expr)                                                 \
   do {                                                                      \
-    if (!(ADB_LIKELY(expr))) {                                              \
+    if (!(expr)) [[unlikely]] {                                             \
       std::cout << "broken assert (" << #expr << ") in " << __FILE__ << ":" \
                 << __LINE__ << std::endl;                                   \
       std::abort();                                                         \

--- a/arangod/Agency/Node.h
+++ b/arangod/Agency/Node.h
@@ -353,7 +353,7 @@ class Node final {
 
   template<typename T>
   auto getNumberUnlessExpiredWithDefault() -> T {
-    if (ADB_LIKELY(!lifetimeExpired())) {
+    if (!lifetimeExpired()) [[likely]] {
       try {
         return this->slice().getNumber<T>();
       } catch (...) {

--- a/arangod/Aql/AqlCall.cpp
+++ b/arangod/Aql/AqlCall.cpp
@@ -40,7 +40,7 @@ using namespace arangodb;
 using namespace arangodb::aql;
 
 auto AqlCall::fromVelocyPack(velocypack::Slice slice) -> ResultT<AqlCall> {
-  if (ADB_UNLIKELY(!slice.isObject())) {
+  if (!slice.isObject()) [[unlikely]] {
     using namespace std::string_literals;
     return Result(TRI_ERROR_TYPE_ERROR,
                   "When deserializating AqlCall: Expected object, got "s +
@@ -93,7 +93,7 @@ auto AqlCall::fromVelocyPack(velocypack::Slice slice) -> ResultT<AqlCall> {
     if (slice.isNull()) {
       return {std::nullopt};
     }
-    if (ADB_UNLIKELY(!slice.isString())) {
+    if (!slice.isString()) [[unlikely]] {
       auto message = std::string{
           "When deserializating AqlCall: When reading limitType: "
           "Unexpected type "};
@@ -116,7 +116,7 @@ auto AqlCall::fromVelocyPack(velocypack::Slice slice) -> ResultT<AqlCall> {
   };
 
   auto const readFullCount = [](velocypack::Slice slice) -> ResultT<bool> {
-    if (ADB_UNLIKELY(!slice.isBool())) {
+    if (!slice.isBool()) [[unlikely]] {
       auto message = std::string{
           "When deserializating AqlCall: When reading fullCount: "
           "Unexpected type "};
@@ -147,15 +147,15 @@ auto AqlCall::fromVelocyPack(velocypack::Slice slice) -> ResultT<AqlCall> {
 
   for (auto const it : velocypack::ObjectIterator(slice)) {
     auto const keySlice = it.key;
-    if (ADB_UNLIKELY(!keySlice.isString())) {
+    if (!keySlice.isString()) [[unlikely]] {
       return Result(TRI_ERROR_TYPE_ERROR,
                     "When deserializating AqlCall: Key is not a string");
     }
     auto const key = keySlice.stringView();
 
     if (auto propIt = expectedPropertiesFound.find(key);
-        ADB_LIKELY(propIt != expectedPropertiesFound.end())) {
-      if (ADB_UNLIKELY(propIt->second)) {
+        propIt != expectedPropertiesFound.end()) [[likely]] {
+      if (propIt->second) [[unlikely]] {
         return Result(
             TRI_ERROR_TYPE_ERROR,
             "When deserializating AqlCall: Encountered duplicate key");
@@ -197,7 +197,7 @@ auto AqlCall::fromVelocyPack(velocypack::Slice slice) -> ResultT<AqlCall> {
   }
 
   for (auto const& it : expectedPropertiesFound) {
-    if (ADB_UNLIKELY(!it.second)) {
+    if (!it.second) [[unlikely]] {
       auto message = std::string{"When deserializating AqlCall: missing key "};
       message += it.first;
       return Result(TRI_ERROR_TYPE_ERROR, std::move(message));
@@ -215,7 +215,7 @@ auto AqlCall::fromVelocyPack(velocypack::Slice slice) -> ResultT<AqlCall> {
         call.hardLimit = limit;
         break;
     }
-  } else if (ADB_UNLIKELY(!std::holds_alternative<Infinity>(limit))) {
+  } else if (!std::holds_alternative<Infinity>(limit)) [[unlikely]] {
     return Result(
         TRI_ERROR_TYPE_ERROR,
         "When deserializating AqlCall: limit set, but limitType is missing.");

--- a/arangod/Aql/AqlCallList.cpp
+++ b/arangod/Aql/AqlCallList.cpp
@@ -115,7 +115,7 @@ void AqlCallList::createEquivalentFetchAllRowsCall() {
 }
 
 auto AqlCallList::fromVelocyPack(VPackSlice slice) -> ResultT<AqlCallList> {
-  if (ADB_UNLIKELY(!slice.isObject())) {
+  if (!slice.isObject()) [[unlikely]] {
     using namespace std::string_literals;
     return Result(TRI_ERROR_TYPE_ERROR,
                   "When deserializating AqlCallList: Expected object, got "s +
@@ -128,7 +128,7 @@ auto AqlCallList::fromVelocyPack(VPackSlice slice) -> ResultT<AqlCallList> {
 
   auto const readSpecific =
       [](velocypack::Slice slice) -> ResultT<std::vector<AqlCall>> {
-    if (ADB_UNLIKELY(!slice.isArray())) {
+    if (!slice.isArray()) [[unlikely]] {
       auto message = std::string{"When deserializating AqlCall: When reading " +
                                  StaticStrings::AqlCallListSpecific +
                                  ": "
@@ -140,7 +140,7 @@ auto AqlCallList::fromVelocyPack(VPackSlice slice) -> ResultT<AqlCallList> {
     res.reserve(slice.length());
     for (VPackSlice const c : VPackArrayIterator(slice)) {
       auto maybeAqlCall = AqlCall::fromVelocyPack(c);
-      if (ADB_UNLIKELY(maybeAqlCall.fail())) {
+      if (maybeAqlCall.fail()) [[unlikely]] {
         auto message = std::string{"When deserializing AqlCallList: entry "};
         message += std::to_string(res.size());
         message += ": ";
@@ -154,7 +154,7 @@ auto AqlCallList::fromVelocyPack(VPackSlice slice) -> ResultT<AqlCallList> {
 
   auto const readDefault =
       [](velocypack::Slice slice) -> ResultT<std::optional<AqlCall>> {
-    if (ADB_UNLIKELY(!slice.isObject() && !slice.isNull())) {
+    if (!slice.isObject() && !slice.isNull()) [[unlikely]] {
       auto message =
           std::string{"When deserializating AqlCallList: When reading " +
                       StaticStrings::AqlCallListDefault +
@@ -167,7 +167,7 @@ auto AqlCallList::fromVelocyPack(VPackSlice slice) -> ResultT<AqlCallList> {
       return {std::nullopt};
     }
     auto maybeAqlCall = AqlCall::fromVelocyPack(slice);
-    if (ADB_UNLIKELY(maybeAqlCall.fail())) {
+    if (maybeAqlCall.fail()) [[unlikely]] {
       auto message = std::string{"When deserializing AqlCallList: default "};
       message += maybeAqlCall.errorMessage();
       return Result(TRI_ERROR_TYPE_ERROR, std::move(message));
@@ -179,15 +179,15 @@ auto AqlCallList::fromVelocyPack(VPackSlice slice) -> ResultT<AqlCallList> {
 
   for (auto const it : velocypack::ObjectIterator(slice)) {
     auto const keySlice = it.key;
-    if (ADB_UNLIKELY(!keySlice.isString())) {
+    if (!keySlice.isString()) [[unlikely]] {
       return Result(TRI_ERROR_TYPE_ERROR,
                     "When deserializating AqlCallList: Key is not a string");
     }
     auto const key = getStringView(keySlice);
 
     if (auto propIt = expectedPropertiesFound.find(key);
-        ADB_LIKELY(propIt != expectedPropertiesFound.end())) {
-      if (ADB_UNLIKELY(propIt->second)) {
+        propIt != expectedPropertiesFound.end()) [[likely]] {
+      if (propIt->second) [[unlikely]] {
         return Result(
             TRI_ERROR_TYPE_ERROR,
             "When deserializating AqlCallList: Encountered duplicate key");
@@ -218,7 +218,7 @@ auto AqlCallList::fromVelocyPack(VPackSlice slice) -> ResultT<AqlCallList> {
   }
 
   for (auto const& it : expectedPropertiesFound) {
-    if (ADB_UNLIKELY(!it.second)) {
+    if (!it.second) [[unlikely]] {
       auto message = std::string{"When deserializating AqlCall: missing key "};
       message += it.first;
       return Result(TRI_ERROR_TYPE_ERROR, std::move(message));

--- a/arangod/Aql/AqlCallStack.cpp
+++ b/arangod/Aql/AqlCallStack.cpp
@@ -84,13 +84,13 @@ void AqlCallStack::pushCall(AqlCallList const& call) {
 
 auto AqlCallStack::fromVelocyPack(velocypack::Slice const slice)
     -> ResultT<AqlCallStack> {
-  if (ADB_UNLIKELY(!slice.isArray())) {
+  if (!slice.isArray()) [[unlikely]] {
     using namespace std::string_literals;
     return Result(TRI_ERROR_TYPE_ERROR,
                   "When deserializing AqlCallStack: expected array, got "s +
                       slice.typeName());
   }
-  if (ADB_UNLIKELY(slice.isEmptyArray())) {
+  if (slice.isEmptyArray()) [[unlikely]] {
     return Result(TRI_ERROR_TYPE_ERROR,
                   "When deserializing AqlCallStack: stack is empty");
   }
@@ -101,7 +101,7 @@ auto AqlCallStack::fromVelocyPack(velocypack::Slice const slice)
   for (auto const entry : VPackArrayIterator(slice)) {
     auto maybeAqlCall = AqlCallList::fromVelocyPack(entry);
 
-    if (ADB_UNLIKELY(maybeAqlCall.fail())) {
+    if (maybeAqlCall.fail()) [[unlikely]] {
       auto message = std::string{"When deserializing AqlCallStack: entry "};
       message += std::to_string(i);
       message += ": ";

--- a/arangod/Aql/AqlExecuteResult.cpp
+++ b/arangod/Aql/AqlExecuteResult.cpp
@@ -108,7 +108,7 @@ void AqlExecuteResult::toVelocyPack(
 auto AqlExecuteResult::fromVelocyPack(velocypack::Slice const slice,
                                       AqlItemBlockManager& itemBlockManager)
     -> ResultT<AqlExecuteResult> {
-  if (ADB_UNLIKELY(!slice.isObject())) {
+  if (!slice.isObject()) [[unlikely]] {
     using namespace std::string_literals;
     return Result(
         TRI_ERROR_TYPE_ERROR,
@@ -127,7 +127,7 @@ auto AqlExecuteResult::fromVelocyPack(velocypack::Slice const slice,
 
   auto const readState =
       [](velocypack::Slice slice) -> ResultT<ExecutionState> {
-    if (ADB_UNLIKELY(!slice.isString())) {
+    if (!slice.isString()) [[unlikely]] {
       auto message = std::string{
           "When deserializing AqlExecuteResult: When reading state: "
           "Unexpected type "};
@@ -161,15 +161,15 @@ auto AqlExecuteResult::fromVelocyPack(velocypack::Slice const slice,
 
   for (auto const it : velocypack::ObjectIterator(slice)) {
     auto const keySlice = it.key;
-    if (ADB_UNLIKELY(!keySlice.isString())) {
+    if (!keySlice.isString()) [[unlikely]] {
       return Result(TRI_ERROR_TYPE_ERROR,
                     "When deserializing AqlExecuteResult: Key is not a string");
     }
     auto const key = getStringView(keySlice);
 
     if (auto propIt = expectedPropertiesFound.find(key);
-        ADB_LIKELY(propIt != expectedPropertiesFound.end())) {
-      if (ADB_UNLIKELY(propIt->second)) {
+        propIt != expectedPropertiesFound.end()) [[likely]] {
+      if (propIt->second) [[unlikely]] {
         return Result(TRI_ERROR_TYPE_ERROR,
                       "When deserializing AqlExecuteResult: "
                       "Encountered duplicate key");
@@ -208,7 +208,7 @@ auto AqlExecuteResult::fromVelocyPack(velocypack::Slice const slice,
   }
 
   for (auto const& it : expectedPropertiesFound) {
-    if (ADB_UNLIKELY(!it.second)) {
+    if (!it.second) [[unlikely]] {
       auto message =
           std::string{"When deserializing AqlExecuteResult: missing key "};
       message += it.first;

--- a/arangod/Aql/AqlItemBlock.cpp
+++ b/arangod/Aql/AqlItemBlock.cpp
@@ -362,7 +362,7 @@ void AqlItemBlock::shrink(size_t numRows) {
     return;
   }
 
-  if (ADB_UNLIKELY(numRows > _numRows)) {
+  if (numRows > _numRows) [[unlikely]] {
     // cannot use shrink() to increase the size of the block
     std::string errorMessage("cannot use shrink() to increase block");
     errorMessage.append(". numRows: ");
@@ -1062,7 +1062,7 @@ void AqlItemBlock::eraseAll() {
 
   size_t totalUsed = 0;
   for (auto const& it : _valueCount) {
-    if (ADB_LIKELY(it.second.refCount > 0)) {
+    if (it.second.refCount > 0) [[likely]] {
       totalUsed += it.second.memoryUsage;
     }
   }
@@ -1267,7 +1267,7 @@ bool AqlItemBlock::ShadowRows::is(size_t row) const noexcept {
 
 size_t AqlItemBlock::ShadowRows::getDepth(size_t row) const noexcept {
   TRI_ASSERT(_depths.size() > row);
-  if (ADB_UNLIKELY(_depths.size() <= row)) {
+  if (_depths.size() <= row) [[unlikely]] {
     // should not happen
     return 0;
   }
@@ -1301,14 +1301,13 @@ void AqlItemBlock::ShadowRows::resize(size_t numRows) {
 
 void AqlItemBlock::ShadowRows::make(size_t row, size_t depth) {
   TRI_ASSERT(row < _numRows);
-  if (ADB_UNLIKELY(depth >=
-                   std::numeric_limits<decltype(_depths)::value_type>::max() -
-                       1U)) {
+  if (depth >= std::numeric_limits<decltype(_depths)::value_type>::max() - 1U)
+      [[unlikely]] {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
                                    "invalid subquery depth");
   }
-  if (ADB_UNLIKELY(
-          row > std::numeric_limits<decltype(_indexes)::value_type>::max())) {
+  if (row > std::numeric_limits<decltype(_indexes)::value_type>::max())
+      [[unlikely]] {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
                                    "invalid subquery row");
   }

--- a/arangod/Aql/AqlItemBlock.h
+++ b/arangod/Aql/AqlItemBlock.h
@@ -96,7 +96,7 @@ class AqlItemBlock {
       // This case will be very rare and likely will cause a lot of other
       // issues upfront. If we get such huge value, we count it as using
       // 4 GB of memory and ignore the rest.
-      if (ADB_UNLIKELY(value > std::numeric_limits<uint32_t>::max())) {
+      if (value > std::numeric_limits<uint32_t>::max()) [[unlikely]] {
         memoryUsage = std::numeric_limits<uint32_t>::max();
       } else {
         memoryUsage = static_cast<uint32_t>(value);

--- a/arangod/Aql/AqlItemBlockManager.cpp
+++ b/arangod/Aql/AqlItemBlockManager.cpp
@@ -203,7 +203,7 @@ uint32_t AqlItemBlockManager::Bucket::getId(size_t targetSize) noexcept {
     return 0;
   }
 
-  if (ADB_UNLIKELY(targetSize >= (1ULL << numBuckets))) {
+  if (targetSize >= (1ULL << numBuckets)) [[unlikely]] {
     return (numBuckets - 1);
   }
 

--- a/arangod/Aql/AqlItemMatrix.cpp
+++ b/arangod/Aql/AqlItemMatrix.cpp
@@ -295,7 +295,7 @@ auto AqlItemMatrix::RowIterator::hasMore() const noexcept -> bool {
   TRI_ASSERT((_matrix != nullptr && _blockIndex < _matrix->numberOfBlocks()) ||
              _rowIndex == 0);
   // If _blockIndex is valid, _rowIndex must be, too.
-  return ADB_LIKELY(_matrix != nullptr) &&
+  return ADB_LIKELY_DEPRECATED(_matrix != nullptr) &&
          _blockIndex < _matrix->numberOfBlocks();
 }
 
@@ -347,9 +347,10 @@ AqlItemMatrix::RowIterator::operator bool() const noexcept { return hasMore(); }
 
 bool aql::operator==(AqlItemMatrix::RowIterator const& a,
                      AqlItemMatrix::RowIterator const& b) {
-  return ADB_LIKELY(a._matrix == b._matrix) &&
-         (ADB_UNLIKELY(a._matrix == nullptr /* => b._matrix == nullptr */) ||
-          (ADB_LIKELY(a._blockIndex == b._blockIndex) &&
+  return ADB_LIKELY_DEPRECATED(a._matrix == b._matrix) &&
+         (ADB_UNLIKELY_DEPRECATED(a._matrix ==
+                                  nullptr /* => b._matrix == nullptr */) ||
+          (ADB_LIKELY_DEPRECATED(a._blockIndex == b._blockIndex) &&
            a._rowIndex == b._rowIndex));
 }
 

--- a/arangod/Aql/AqlItemMatrix.cpp
+++ b/arangod/Aql/AqlItemMatrix.cpp
@@ -120,15 +120,14 @@ void AqlItemMatrix::addBlock(SharedAqlItemBlockPtr blockPtr) {
 
   TRI_ASSERT(blockPtr->numRegisters() == getNumRegisters());
   // Test if we have more than uint32_t many blocks
-  if (ADB_UNLIKELY(_blocks.size() == std::numeric_limits<uint32_t>::max())) {
+  if (_blocks.size() == std::numeric_limits<uint32_t>::max()) [[unlikely]] {
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_RESOURCE_LIMIT,
         "Reaching the limit of AqlItems to SORT, please consider using a "
         "limit after sorting.");
   }
   // Test if we have more than uint32_t many rows within a block
-  if (ADB_UNLIKELY(blockPtr->numRows() >
-                   std::numeric_limits<uint32_t>::max())) {
+  if (blockPtr->numRows() > std::numeric_limits<uint32_t>::max()) [[unlikely]] {
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_RESOURCE_LIMIT,
         "Reaching the limit of AqlItems to SORT, please consider lowering "

--- a/arangod/Aql/AqlValue.cpp
+++ b/arangod/Aql/AqlValue.cpp
@@ -875,9 +875,9 @@ int64_t AqlValue::toInt64() const {
       return basics::littleToHost(
           _data.longNumberMeta.data.intLittleEndian.val);
     case VPACK_INLINE_UINT64:
-      if (ADB_UNLIKELY(
-              _data.longNumberMeta.data.uintLittleEndian.val >
-              static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))) {
+      if (_data.longNumberMeta.data.uintLittleEndian.val >
+          static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
+          [[unlikely]] {
         throw velocypack::Exception(velocypack::Exception::NumberOutOfRange);
       }
       return basics::littleToHost(
@@ -887,8 +887,8 @@ int64_t AqlValue::toInt64() const {
       auto const hostVal =
           basics::littleToHost(_data.longNumberMeta.data.uintLittleEndian.val);
       memcpy(&val, &hostVal, sizeof(val));
-      if (ADB_UNLIKELY(
-              val > static_cast<double>(std::numeric_limits<int64_t>::max()))) {
+      if (val > static_cast<double>(std::numeric_limits<int64_t>::max()))
+          [[unlikely]] {
         throw velocypack::Exception(velocypack::Exception::NumberOutOfRange);
       }
       return static_cast<int64_t>(val);
@@ -998,7 +998,7 @@ void AqlValue::setManagedSliceData(MemoryOriginType mot,
                                    arangodb::velocypack::ValueLength length) {
   TRI_ASSERT(length > 0);
   TRI_ASSERT(mot == MemoryOriginType::New || mot == MemoryOriginType::Malloc);
-  if (ADB_UNLIKELY(length > 0x0000ffffffffffffULL)) {
+  if (length > 0x0000ffffffffffffULL) [[unlikely]] {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_OUT_OF_MEMORY,
                                    "invalid AqlValue length");
   }
@@ -1407,7 +1407,7 @@ AqlValue::AqlValue(AqlValueHintDouble v) noexcept {
     // a "real" double
     _data.longNumberMeta.data.slice.slice[0] = 0x1b;
     // unify +0.0 and -0.0 to +0.0
-    if (ADB_UNLIKELY(value == -0.0)) {
+    if (value == -0.0) [[unlikely]] {
       value = 0.0;
     }
     uint64_t uintVal;

--- a/arangod/Aql/BlocksWithClients.cpp
+++ b/arangod/Aql/BlocksWithClients.cpp
@@ -178,7 +178,7 @@ auto BlocksWithClientsImpl<Executor>::executeWithoutTraceForClient(
     AqlCallStack stack, std::string const& clientId)
     -> std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr> {
   TRI_ASSERT(!clientId.empty());
-  if (ADB_UNLIKELY(clientId.empty())) {
+  if (clientId.empty()) [[unlikely]] {
     // Security bailout to avoid UB
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
                                    "got empty distribution id");
@@ -186,7 +186,7 @@ auto BlocksWithClientsImpl<Executor>::executeWithoutTraceForClient(
 
   auto it = _clientBlockData.find(clientId);
   TRI_ASSERT(it != _clientBlockData.end());
-  if (ADB_UNLIKELY(it == _clientBlockData.end())) {
+  if (it == _clientBlockData.end()) [[unlikely]] {
     // Security bailout to avoid UB
     std::string message("AQL: unknown distribution id ");
     message.append(clientId);

--- a/arangod/Aql/DistributeExecutor.cpp
+++ b/arangod/Aql/DistributeExecutor.cpp
@@ -154,7 +154,7 @@ auto DistributeExecutor::distributeBlock(
           if (!client.empty()) {
             // We can only have clients we are prepared for
             TRI_ASSERT(blockMap.find(client) != blockMap.end());
-            if (ADB_UNLIKELY(blockMap.find(client) == blockMap.end())) {
+            if (blockMap.find(client) == blockMap.end()) [[unlikely]] {
               THROW_ARANGO_EXCEPTION_MESSAGE(
                   TRI_ERROR_INTERNAL, std::string("unexpected client id '") +
                                           client + "' found in blockMap");

--- a/arangod/Aql/DocumentProducingHelper.cpp
+++ b/arangod/Aql/DocumentProducingHelper.cpp
@@ -302,7 +302,7 @@ bool DocumentProducingFunctionContext::checkFilter(
 
 bool DocumentProducingFunctionContext::checkFilter(ExpressionContext& ctx) {
   _killCheckCounter = (_killCheckCounter + 1) % 1024;
-  if (ADB_UNLIKELY(_killCheckCounter == 0 && _query.killed())) {
+  if (_killCheckCounter == 0 && _query.killed()) [[unlikely]] {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
   }
 

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -545,7 +545,7 @@ bool parameterToTimePoint(ExpressionContext* expressionContext,
 
   if (value.isNumber()) {
     int64_t v = value.toInt64();
-    if (ADB_UNLIKELY(v < -62167219200000 || v > 253402300799999)) {
+    if (v < -62167219200000 || v > 253402300799999) [[unlikely]] {
       // check if value is between "0000-01-01T00:00:00.000Z" and
       // "9999-12-31T23:59:59.999Z" -62167219200000: "0000-01-01T00:00:00.000Z"
       // 253402300799999: "9999-12-31T23:59:59.999Z"
@@ -1644,7 +1644,7 @@ AqlValue NgramSimilarityHelper(char const* AFN, ExpressionContext* ctx,
   }
 
   auto const& attribute = extractFunctionParameterValue(args, 0);
-  if (ADB_UNLIKELY(!attribute.isString())) {
+  if (!attribute.isString()) [[unlikely]] {
     arangodb::aql::registerInvalidArgumentWarning(ctx, AFN);
     return arangodb::aql::AqlValue{arangodb::aql::AqlValueHintNull{}};
   }
@@ -1652,20 +1652,20 @@ AqlValue NgramSimilarityHelper(char const* AFN, ExpressionContext* ctx,
       arangodb::iresearch::getStringRef(attribute.slice());
 
   auto const& target = extractFunctionParameterValue(args, 1);
-  if (ADB_UNLIKELY(!target.isString())) {
+  if (!target.isString()) [[unlikely]] {
     arangodb::aql::registerInvalidArgumentWarning(ctx, AFN);
     return arangodb::aql::AqlValue{arangodb::aql::AqlValueHintNull{}};
   }
   auto const targetValue = arangodb::iresearch::getStringRef(target.slice());
 
   auto const& ngramSize = extractFunctionParameterValue(args, 2);
-  if (ADB_UNLIKELY(!ngramSize.isNumber())) {
+  if (!ngramSize.isNumber()) [[unlikely]] {
     arangodb::aql::registerInvalidArgumentWarning(ctx, AFN);
     return arangodb::aql::AqlValue{arangodb::aql::AqlValueHintNull{}};
   }
   auto const ngramSizeValue = ngramSize.toInt64();
 
-  if (ADB_UNLIKELY(ngramSizeValue < 1)) {
+  if (ngramSizeValue < 1) [[unlikely]] {
     arangodb::aql::registerWarning(
         ctx, AFN,
         arangodb::Result{TRI_ERROR_BAD_PARAMETER,
@@ -1720,14 +1720,14 @@ AqlValue Functions::NgramMatch(ExpressionContext* ctx, AstNode const&,
   }
 
   auto const& attribute = extractFunctionParameterValue(args, 0);
-  if (ADB_UNLIKELY(!attribute.isString())) {
+  if (!attribute.isString()) [[unlikely]] {
     arangodb::aql::registerInvalidArgumentWarning(ctx, AFN);
     return arangodb::aql::AqlValue{arangodb::aql::AqlValueHintNull{}};
   }
   auto const attributeValue = iresearch::getStringRef(attribute.slice());
 
   auto const& target = extractFunctionParameterValue(args, 1);
-  if (ADB_UNLIKELY(!target.isString())) {
+  if (!target.isString()) [[unlikely]] {
     arangodb::aql::registerInvalidArgumentWarning(ctx, AFN);
     return arangodb::aql::AqlValue{arangodb::aql::AqlValueHintNull{}};
   }
@@ -1739,7 +1739,7 @@ AqlValue Functions::NgramMatch(ExpressionContext* ctx, AstNode const&,
   if (argc > 3) {  // 4 args given. 3rd is threshold
     auto const& thresholdArg = extractFunctionParameterValue(args, 2);
     analyzerPosition = 3;
-    if (ADB_UNLIKELY(!thresholdArg.isNumber())) {
+    if (!thresholdArg.isNumber()) [[unlikely]] {
       arangodb::aql::registerInvalidArgumentWarning(ctx, AFN);
       return arangodb::aql::AqlValue{arangodb::aql::AqlValueHintNull{}};
     }
@@ -1754,7 +1754,7 @@ AqlValue Functions::NgramMatch(ExpressionContext* ctx, AstNode const&,
 
   auto const& analyzerArg =
       extractFunctionParameterValue(args, analyzerPosition);
-  if (ADB_UNLIKELY(!analyzerArg.isString())) {
+  if (!analyzerArg.isString()) [[unlikely]] {
     arangodb::aql::registerInvalidArgumentWarning(ctx, AFN);
     return arangodb::aql::AqlValue{arangodb::aql::AqlValueHintNull{}};
   }
@@ -1830,7 +1830,7 @@ AqlValue Functions::LevenshteinMatch(ExpressionContext* ctx,
 
   auto const& maxDistance = extractFunctionParameterValue(args, 2);
 
-  if (ADB_UNLIKELY(!maxDistance.isNumber())) {
+  if (!maxDistance.isNumber()) [[unlikely]] {
     arangodb::aql::registerInvalidArgumentWarning(ctx, AFN);
     return arangodb::aql::AqlValue{arangodb::aql::AqlValueHintNull{}};
   }
@@ -1841,7 +1841,7 @@ AqlValue Functions::LevenshteinMatch(ExpressionContext* ctx,
   if (args.size() > 3) {
     auto const& withTranspositions = extractFunctionParameterValue(args, 3);
 
-    if (ADB_UNLIKELY(!withTranspositions.isBoolean())) {
+    if (!withTranspositions.isBoolean()) [[unlikely]] {
       registerInvalidArgumentWarning(ctx, AFN);
       return AqlValue{AqlValueHintNull{}};
     }
@@ -1872,7 +1872,7 @@ AqlValue Functions::LevenshteinMatch(ExpressionContext* ctx,
       static_cast<irs::byte_type>(unsignedMaxDistanceValue),
       withTranspositionsValue);
 
-  if (ADB_UNLIKELY(!description)) {
+  if (!description) [[unlikely]] {
     registerInvalidArgumentWarning(ctx, AFN);
     return AqlValue{AqlValueHintNull{}};
   }
@@ -1911,12 +1911,12 @@ AqlValue Functions::InRange(ExpressionContext* ctx, AstNode const&,
   auto const& includeLowerVal = extractFunctionParameterValue(args, 3);
   auto const& includeUpperVal = extractFunctionParameterValue(args, 4);
 
-  if (ADB_UNLIKELY(!includeLowerVal.isBoolean())) {
+  if (!includeLowerVal.isBoolean()) [[unlikely]] {
     arangodb::aql::registerInvalidArgumentWarning(ctx, AFN);
     return arangodb::aql::AqlValue{arangodb::aql::AqlValueHintNull{}};
   }
 
-  if (ADB_UNLIKELY(!includeUpperVal.isBoolean())) {
+  if (!includeUpperVal.isBoolean()) [[unlikely]] {
     arangodb::aql::registerInvalidArgumentWarning(ctx, AFN);
     return arangodb::aql::AqlValue{arangodb::aql::AqlValueHintNull{}};
   }
@@ -5666,7 +5666,7 @@ AqlValue Functions::Jaccard(ExpressionContext* ctx, AstNode const&,
 
   AqlValue const& lhs = extractFunctionParameterValue(args, 0);
 
-  if (ADB_UNLIKELY(!lhs.isArray())) {
+  if (!lhs.isArray()) [[unlikely]] {
     // not an array
     registerWarning(ctx, AFN, TRI_ERROR_QUERY_ARRAY_EXPECTED);
     return AqlValue(AqlValueHintNull());
@@ -5674,7 +5674,7 @@ AqlValue Functions::Jaccard(ExpressionContext* ctx, AstNode const&,
 
   AqlValue const& rhs = extractFunctionParameterValue(args, 1);
 
-  if (ADB_UNLIKELY(!rhs.isArray())) {
+  if (!rhs.isArray()) [[unlikely]] {
     // not an array
     registerWarning(ctx, AFN, TRI_ERROR_QUERY_ARRAY_EXPECTED);
     return AqlValue(AqlValueHintNull());

--- a/arangod/Aql/IndexExecutor.cpp
+++ b/arangod/Aql/IndexExecutor.cpp
@@ -97,8 +97,8 @@ IndexIterator::CoveringCallback getCallback(
     auto indexId = index->id();
     TRI_ASSERT(indexId == outNonMaterializedIndRegs.first &&
                indexId == outNonMaterializedIndVars.first);
-    if (ADB_UNLIKELY(indexId != outNonMaterializedIndRegs.first ||
-                     indexId != outNonMaterializedIndVars.first)) {
+    if (indexId != outNonMaterializedIndRegs.first ||
+        indexId != outNonMaterializedIndVars.first) [[unlikely]] {
       return false;
     }
 
@@ -114,14 +114,14 @@ IndexIterator::CoveringCallback getCallback(
         auto const& fc = *reinterpret_cast<filterContext const*>(ctx);
         auto const it = fc.outNonMaterializedIndVars.second.find(var);
         TRI_ASSERT(fc.outNonMaterializedIndVars.second.cend() != it);
-        if (ADB_UNLIKELY(fc.outNonMaterializedIndVars.second.cend() == it)) {
+        if (fc.outNonMaterializedIndVars.second.cend() == it) [[unlikely]] {
           return AqlValue();
         }
         velocypack::Slice s;
         // hash/skiplist/persistent
         if (fc.covering.isArray()) {
           TRI_ASSERT(it->second < fc.covering.length());
-          if (ADB_UNLIKELY(it->second >= fc.covering.length())) {
+          if (it->second >= fc.covering.length()) [[unlikely]] {
             return AqlValue();
           }
           s = fc.covering.at(it->second);
@@ -153,7 +153,7 @@ IndexIterator::CoveringCallback getCallback(
     if (covering.isArray()) {
       for (auto const& indReg : outNonMaterializedIndRegs.second) {
         TRI_ASSERT(indReg.first < covering.length());
-        if (ADB_UNLIKELY(indReg.first >= covering.length())) {
+        if (indReg.first >= covering.length()) [[unlikely]] {
           return false;
         }
         auto s = covering.at(indReg.first);
@@ -165,7 +165,7 @@ IndexIterator::CoveringCallback getCallback(
     } else {  // primary/edge
       auto indReg = outNonMaterializedIndRegs.second.cbegin();
       TRI_ASSERT(indReg != outNonMaterializedIndRegs.second.cend());
-      if (ADB_UNLIKELY(indReg == outNonMaterializedIndRegs.second.cend())) {
+      if (indReg == outNonMaterializedIndRegs.second.cend()) [[unlikely]] {
         return false;
       }
       AqlValue v(covering.value());

--- a/arangod/Aql/LimitExecutor.cpp
+++ b/arangod/Aql/LimitExecutor.cpp
@@ -200,8 +200,8 @@ auto LimitExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange,
     -> std::tuple<ExecutorState, Stats, size_t, AqlCall> {
   auto upstreamCall = calculateUpstreamCall(call);
 
-  if (ADB_UNLIKELY(inputRange.skippedInFlight() < upstreamCall.getOffset() &&
-                   inputRange.hasDataRow())) {
+  if (inputRange.skippedInFlight() < upstreamCall.getOffset() &&
+      inputRange.hasDataRow()) [[unlikely]] {
     static_assert(
         Properties::allowsBlockPassthrough == BlockPassthrough::Enable,
         "For LIMIT with passthrough to work, there must no input "

--- a/arangod/Aql/ModificationExecutor.cpp
+++ b/arangod/Aql/ModificationExecutor.cpp
@@ -387,7 +387,7 @@ auto ModificationExecutor<FetcherType, ModifierType>::RangeHandler::
     upstreamState(typename FetcherType::DataRange& input) const noexcept
     -> ExecutorState {
   if constexpr (inputIsMatrix) {
-    if (ADB_UNLIKELY(!_iterator.isInitialized())) {
+    if (!_iterator.isInitialized()) [[unlikely]] {
       // As long as the iterator isn't initialized, we need to pass the upstream
       // state. In particular if the input is completely empty, we need to
       // return DONE.

--- a/arangod/Aql/Optimizer.cpp
+++ b/arangod/Aql/Optimizer.cpp
@@ -228,7 +228,7 @@ void Optimizer::addPlanInternal(std::unique_ptr<ExecutionPlan> plan,
 
 void Optimizer::initializeRules(ExecutionPlan* plan,
                                 QueryOptions const& queryOptions) {
-  if (ADB_LIKELY(_rules.empty())) {
+  if (_rules.empty()) [[likely]] {
     auto const& rules = OptimizerRulesFeature::rules();
     _rules.reserve(rules.size());
 

--- a/arangod/Aql/OutputAqlItemRow.cpp
+++ b/arangod/Aql/OutputAqlItemRow.cpp
@@ -489,16 +489,15 @@ void OutputAqlItemRow::doCopyOrMoveRow(ItemRowType& sourceRow,
       if (ignoreMissing && itemId.value() >= sourceRow.getNumRegisters()) {
         continue;
       }
-      if (ADB_LIKELY(!_allowSourceRowUninitialized ||
-                     sourceRow.isInitialized())) {
+      if (!_allowSourceRowUninitialized || sourceRow.isInitialized())
+          [[likely]] {
         doCopyOrMoveValue<ItemRowType, copyOrMove>(sourceRow, itemId);
       }
     }
     adjustShadowRowDepth(sourceRow);
   } else {
     TRI_ASSERT(_baseIndex > 0);
-    if (ADB_LIKELY(!_allowSourceRowUninitialized ||
-                   sourceRow.isInitialized())) {
+    if (!_allowSourceRowUninitialized || sourceRow.isInitialized()) [[likely]] {
       block().referenceValuesFromRow(_baseIndex, regsToKeep, _lastBaseIndex);
     }
   }

--- a/arangod/Aql/RemoteExecutor.cpp
+++ b/arangod/Aql/RemoteExecutor.cpp
@@ -410,7 +410,7 @@ auto ExecutionBlockImpl<RemoteExecutor>::deserializeExecuteCallResultBody(
              VelocyPackHelper::getNumericValue<ErrorCode>(
                  slice, StaticStrings::Code, TRI_ERROR_INTERNAL));
 
-  if (ADB_UNLIKELY(!slice.isObject())) {
+  if (!slice.isObject()) [[unlikely]] {
     using namespace std::string_literals;
     return Result{TRI_ERROR_TYPE_ERROR,
                   "When parsing execute result: expected object, got "s +

--- a/arangod/Aql/SharedQueryState.cpp
+++ b/arangod/Aql/SharedQueryState.cpp
@@ -126,7 +126,7 @@ void SharedQueryState::queueHandler() {
   }
 
   auto scheduler = SchedulerFeature::SCHEDULER;
-  if (ADB_UNLIKELY(scheduler == nullptr)) {
+  if (scheduler == nullptr) [[unlikely]] {
     // We are shutting down
     return;
   }

--- a/arangod/Aql/ShortestPathExecutor.cpp
+++ b/arangod/Aql/ShortestPathExecutor.cpp
@@ -120,7 +120,7 @@ static std::string typeToString(ShortestPathExecutorInfos::OutputName type) {
 RegisterId ShortestPathExecutorInfos::findRegisterChecked(
     OutputName type) const {
   auto const& it = _registerMapping.find(type);
-  if (ADB_UNLIKELY(it == _registerMapping.end())) {
+  if (it == _registerMapping.end()) [[unlikely]] {
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_INTERNAL,
         "Logic error: requested unused register type " + typeToString(type));

--- a/arangod/Aql/TraversalExecutor.cpp
+++ b/arangod/Aql/TraversalExecutor.cpp
@@ -99,7 +99,7 @@ static std::string typeToString(TraversalExecutorInfos::OutputName type) {
 
 RegisterId TraversalExecutorInfos::findRegisterChecked(OutputName type) const {
   auto const& it = _registerMapping.find(type);
-  if (ADB_UNLIKELY(it == _registerMapping.end())) {
+  if (it == _registerMapping.end()) [[unlikely]] {
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_INTERNAL,
         "Logic error: requested unused register type " + typeToString(type));

--- a/arangod/Aql/WindowNode.cpp
+++ b/arangod/Aql/WindowNode.cpp
@@ -169,7 +169,7 @@ bool parameterToTimePoint(AqlValue const& value, QueryWarnings& warnings,
                           tp_sys_clock_ms& tp) {
   if (value.isNumber()) {
     int64_t v = value.toInt64();
-    if (ADB_UNLIKELY(v < -62167219200000 || v > 253402300799999)) {
+    if (v < -62167219200000 || v > 253402300799999) [[unlikely]] {
       // check if value is between "0000-01-01T00:00:00.000Z" and
       // "9999-12-31T23:59:59.999Z" -62167219200000: "0000-01-01T00:00:00.000Z"
       // 253402300799999: "9999-12-31T23:59:59.999Z"

--- a/arangod/Cluster/Action.cpp
+++ b/arangod/Cluster/Action.cpp
@@ -136,7 +136,7 @@ void Action::create(MaintenanceFeature& feature,
                     ActionDescription const& description) {
   auto factory = factories.find(description.name());
 
-  if (ADB_UNLIKELY(factory == factories.end())) {
+  if (factory == factories.end()) [[unlikely]] {
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_INTERNAL, "invalid action type: " + description.name());
   }

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -2356,7 +2356,7 @@ void fetchVerticesFromEngines(
     bool cached = false;
     for (auto pair : VPackObjectIterator(resSlice, /*sequential*/ true)) {
       arangodb::velocypack::HashedStringRef key(pair.key);
-      if (ADB_UNLIKELY(vertexIds.erase(key) == 0)) {
+      if (vertexIds.erase(key) == 0) [[unlikely]] {
         // We either found the same vertex twice,
         // or found a vertex we did not request.
         // Anyways something somewhere went seriously wrong

--- a/arangod/GeneralServer/H2CommTask.cpp
+++ b/arangod/GeneralServer/H2CommTask.cpp
@@ -659,7 +659,7 @@ void H2CommTask<T>::sendResponse(std::unique_ptr<GeneralResponse> res,
   // streams)
   unsigned retries = 512;
   try {
-    while (ADB_UNLIKELY(!_responses.push(tmp) && --retries > 0)) {
+    while (ADB_UNLIKELY_DEPRECATED(!_responses.push(tmp) && --retries > 0)) {
       std::this_thread::yield();
     }
   } catch (...) {

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -272,7 +272,7 @@ bool HttpCommTask<T>::readCallback(asio_ns::error_code ec) {
         }
         nparsed += datasize;
         data += datasize;
-      } while (ADB_UNLIKELY(data < end));
+      } while (ADB_UNLIKELY_DEPRECATED(data < end));
     }
 
     TRI_ASSERT(nparsed < std::numeric_limits<size_t>::max());

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -457,7 +457,7 @@ void HttpCommTask<T>::doProcessRequest() {
   }
 
   // we may have gotten an H2 Upgrade request
-  if (ADB_UNLIKELY(_parser.upgrade)) {
+  if (_parser.upgrade) [[unlikely]] {
     LOG_TOPIC("5a660", INFO, Logger::REQUESTS)
         << "detected an 'Upgrade' header";
     bool found;

--- a/arangod/GeneralServer/VstCommTask.cpp
+++ b/arangod/GeneralServer/VstCommTask.cpp
@@ -423,7 +423,8 @@ void VstCommTask<T>::sendResponse(std::unique_ptr<GeneralResponse> baseRes,
   // streams)
   unsigned retries = 512;
   try {
-    while (ADB_UNLIKELY(!_writeQueue.push(resItem.get()) && --retries > 0)) {
+    while (ADB_UNLIKELY_DEPRECATED(!_writeQueue.push(resItem.get()) &&
+                                   --retries > 0)) {
       std::this_thread::yield();
       --retries;
     }

--- a/arangod/Graph/Cache/RefactoredTraverserCache.cpp
+++ b/arangod/Graph/Cache/RefactoredTraverserCache.cpp
@@ -104,7 +104,7 @@ bool RefactoredTraverserCache::appendEdge(EdgeDocumentToken const& idToken,
                                           bool onlyId, ResultType& result) {
   auto col = _trx->vocbase().lookupCollection(idToken.cid());
 
-  if (ADB_UNLIKELY(col == nullptr)) {
+  if (col == nullptr) [[unlikely]] {
     // collection gone... should not happen
     LOG_TOPIC("c4d78", ERR, arangodb::Logger::GRAPHS)
         << "Could not extract indexed edge document. collection not found";
@@ -132,7 +132,7 @@ bool RefactoredTraverserCache::appendEdge(EdgeDocumentToken const& idToken,
               },
               ReadOwnWrites::no)
           .ok();
-  if (ADB_UNLIKELY(!res)) {
+  if (!res) [[unlikely]] {
     // We already had this token, inconsistent state. Return NULL in Production
     LOG_TOPIC("daac5", ERR, arangodb::Logger::GRAPHS)
         << "Could not extract indexed edge document, return 'null' instead. "

--- a/arangod/Graph/Enumerators/TwoSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/TwoSidedEnumerator.cpp
@@ -419,13 +419,13 @@ void TwoSidedEnumerator<QueueType, PathStoreType, ProviderType,
   while (_results.empty() && !searchDone()) {
     _resultsFetched = false;
     if (_searchLeft) {
-      if (ADB_UNLIKELY(_left.doneWithDepth())) {
+      if (_left.doneWithDepth()) [[unlikely]] {
         startNextDepth();
       } else {
         _left.computeNeighbourhoodOfNextVertex(_right, _results);
       }
     } else {
-      if (ADB_UNLIKELY(_right.doneWithDepth())) {
+      if (_right.doneWithDepth()) [[unlikely]] {
         startNextDepth();
       } else {
         _right.computeNeighbourhoodOfNextVertex(_left, _results);

--- a/arangod/Graph/Providers/ClusterProvider.cpp
+++ b/arangod/Graph/Providers/ClusterProvider.cpp
@@ -429,7 +429,7 @@ auto ClusterProvider::expand(Step const& step, size_t previous,
   auto const relations = _vertexConnectedEdges.find(vertex.getID());
   TRI_ASSERT(relations != _vertexConnectedEdges.end());
 
-  if (ADB_LIKELY(relations != _vertexConnectedEdges.end())) {
+  if (relations != _vertexConnectedEdges.end()) [[likely]] {
     for (auto const& relation : relations->second) {
       bool const fetched = _vertexConnectedEdges.contains(relation.second);
       callback(Step{relation.second, relation.first, previous, fetched});

--- a/arangod/IResearch/ExpressionFilter.cpp
+++ b/arangod/IResearch/ExpressionFilter.cpp
@@ -145,7 +145,7 @@ class NondeterministicExpressionQuery final : public irs::filter::prepared {
   virtual irs::doc_iterator::ptr execute(
       const irs::sub_reader& rdr, const irs::order::prepared& order,
       const irs::attribute_provider* ctx) const override {
-    if (ADB_UNLIKELY(!ctx)) {
+    if (!ctx) [[unlikely]] {
       // no context provided
       return irs::doc_iterator::empty();
     }
@@ -183,7 +183,7 @@ class DeterministicExpressionQuery final : public irs::filter::prepared {
   virtual irs::doc_iterator::ptr execute(
       const irs::sub_reader& segment, const irs::order::prepared& order,
       const irs::attribute_provider* ctx) const override {
-    if (ADB_UNLIKELY(!ctx)) {
+    if (!ctx) [[unlikely]] {
       // no context provided
       return irs::doc_iterator::empty();
     }

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -145,7 +145,7 @@ bool normalize(std::string& out, irs::string_ref const& type,
 aql::AqlValue aqlFnTokens(aql::ExpressionContext* expressionContext,
                           aql::AstNode const&,
                           aql::VPackFunctionParameters const& args) {
-  if (ADB_UNLIKELY(args.empty() || args.size() > 2)) {
+  if (args.empty() || args.size() > 2) [[unlikely]] {
     irs::string_ref const message =
         "invalid arguments count while computing result for function 'TOKENS'";
     LOG_TOPIC("740fd", WARN, arangodb::iresearch::TOPIC) << message;
@@ -202,7 +202,7 @@ aql::AqlValue aqlFnTokens(aql::ExpressionContext* expressionContext,
   auto* token = irs::get<irs::term_attribute>(*analyzer);
   auto* vpack_token = irs::get<VPackTermAttribute>(*analyzer);
 
-  if (ADB_UNLIKELY(!token && !vpack_token)) {
+  if (!token && !vpack_token) [[unlikely]] {
     auto const message =
         "failure to retrieve values from arangosearch analyzer name '"s +
         static_cast<std::string>(name) +
@@ -230,7 +230,7 @@ aql::AqlValue aqlFnTokens(aql::ExpressionContext* expressionContext,
       if (!numeric_analyzer) {
         numeric_analyzer = std::make_unique<irs::numeric_token_stream>();
         numeric_token = irs::get<irs::term_attribute>(*numeric_analyzer);
-        if (ADB_UNLIKELY(!numeric_token)) {
+        if (!numeric_token) [[unlikely]] {
           auto const message =
               "failure to retrieve values from arangosearch numeric analyzer "
               "while computing result for function 'TOKENS'";
@@ -422,8 +422,8 @@ bool equalAnalyzer(AnalyzerPool const& pool, irs::string_ref const& type,
   // #9652) To make sure properties really differ, let`s re-normalize and
   // re-check
   std::string reNormalizedProperties;
-  if (ADB_UNLIKELY(!::normalize(reNormalizedProperties, pool.type(),
-                                pool.properties()))) {
+  if (!::normalize(reNormalizedProperties, pool.type(), pool.properties()))
+      [[unlikely]] {
     // failed to re-normalize definition - strange. It was already normalized
     // once. Some bug in load/store?
     TRI_ASSERT(FALSE);
@@ -505,7 +505,7 @@ Result visitAnalyzers(TRI_vocbase_t& vocbase,
       }
 
       auto shards = collection->shardIds();
-      if (ADB_UNLIKELY(!shards)) {
+      if (!shards) [[unlikely]] {
         TRI_ASSERT(FALSE);
         return {};  // treat missing collection as if there are no analyzers
       }
@@ -1447,7 +1447,7 @@ Result IResearchAnalyzerFeature::emplace(EmplaceResult& result,
         auto cached = _lastLoad.find(static_cast<std::string>(
             split.first));  // FIXME: remove cast after C++20
         TRI_ASSERT(cached != _lastLoad.end());
-        if (ADB_LIKELY(cached != _lastLoad.end())) {
+        if (cached != _lastLoad.end()) [[likely]] {
           cached->second =
               transaction->buildingRevision();  // as we already "updated cache"
                                                 // to this revision
@@ -1691,7 +1691,7 @@ Result IResearchAnalyzerFeature::bulkEmplace(TRI_vocbase_t& vocbase,
         }
       }
     }
-    if (ADB_UNLIKELY(inserted.empty())) {
+    if (inserted.empty()) [[unlikely]] {
       // nothing changed. So nothing to commit;
       return {};
     }
@@ -1703,7 +1703,7 @@ Result IResearchAnalyzerFeature::bulkEmplace(TRI_vocbase_t& vocbase,
       }
       auto cached = _lastLoad.find(vocbase.name());
       TRI_ASSERT(cached != _lastLoad.end());
-      if (ADB_LIKELY(cached != _lastLoad.end())) {
+      if (cached != _lastLoad.end()) [[likely]] {
         cached->second =
             transaction->buildingRevision();  // as we already "updated cache"
                                               // to this revision
@@ -2735,7 +2735,7 @@ Result IResearchAnalyzerFeature::remove(irs::string_ref const& name,
       auto cached = _lastLoad.find(static_cast<std::string>(
           split.first));  // FIXME: remove cast after C++20
       TRI_ASSERT(cached != _lastLoad.end());
-      if (ADB_LIKELY(cached != _lastLoad.end())) {
+      if (cached != _lastLoad.end()) [[likely]] {
         // we are hodling writelock so nobody should be able reload analyzers
         // and update cache.
         TRI_ASSERT(cached->second <
@@ -2997,7 +2997,7 @@ bool IResearchAnalyzerFeature::visit(
 }
 
 void IResearchAnalyzerFeature::cleanupAnalyzers(irs::string_ref database) {
-  if (ADB_UNLIKELY(database.empty())) {
+  if (database.empty()) [[unlikely]] {
     TRI_ASSERT(FALSE);
     return;
   }

--- a/arangod/IResearch/IResearchCompression.cpp
+++ b/arangod/IResearch/IResearchCompression.cpp
@@ -33,7 +33,7 @@ namespace iresearch {
 
 irs::string_ref columnCompressionToString(
     irs::type_info::type_id type) noexcept {
-  if (ADB_UNLIKELY(type == nullptr)) {
+  if (type == nullptr) [[unlikely]] {
     TRI_ASSERT(false);
     return irs::string_ref::EMPTY;
   }

--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -1066,7 +1066,7 @@ Result IResearchDataStore::initDataStore(
   // as values provided may be temporary
   std::map<std::string, irs::type_info::type_id> compressionMap;
   for (auto const& c : storedColumns) {
-    if (ADB_LIKELY(c.compression != nullptr)) {
+    if (c.compression != nullptr) [[likely]] {
       compressionMap.emplace(c.name, c.compression);
     } else {
       TRI_ASSERT(false);

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -193,7 +193,7 @@ aql::AqlValue minMatchFunc(aql::ExpressionContext* ctx, aql::AstNode const&,
 
   TRI_ASSERT(args.size() > 1);  // ensured by function signature
   auto& minMatchValue = args.back();
-  if (ADB_UNLIKELY(!minMatchValue.isNumber())) {
+  if (!minMatchValue.isNumber()) [[unlikely]] {
     return errorAqlValue(ctx, AFN);
   }
 

--- a/arangod/IResearch/IResearchFilterFactory.cpp
+++ b/arangod/IResearch/IResearchFilterFactory.cpp
@@ -3288,7 +3288,7 @@ Result processPhraseArgObjectType(char const* funcName,
                                   irs::analysis::analyzer* analyzer = nullptr) {
   TRI_ASSERT(object.isObject());
   VPackObjectIterator itr(object);
-  if (ADB_LIKELY(itr.valid())) {
+  if (itr.valid()) [[likely]] {
     auto key = itr.key();
     auto value = itr.value();
     if (!key.isString()) {

--- a/arangod/IResearch/IResearchInvertedIndex.cpp
+++ b/arangod/IResearch/IResearchInvertedIndex.cpp
@@ -245,13 +245,13 @@ struct CoveringValue {
     // FIXME: this is cheap. Keep it here?
     auto extraValuesReader = column.empty() ? rdr.sort() : rdr.column(column);
     // FIXME: this is expensive - move it to get and do lazily?
-    if (ADB_LIKELY(extraValuesReader)) {
+    if (extraValuesReader) [[likely]] {
       itr = extraValuesReader->iterator(false);
       TRI_ASSERT(itr);
-      if (ADB_LIKELY(itr)) {
+      if (itr) [[likely]] {
         value = irs::get<irs::payload>(*itr);
         TRI_ASSERT(value);
-        if (ADB_UNLIKELY(!value)) {
+        if (!value) [[unlikely]] {
           value = &NoPayload;
         }
       }
@@ -271,10 +271,10 @@ struct CoveringValue {
       VPackSlice slice(value->value.c_str());
       TRI_ASSERT(slice.byteSize() <= totalSize);
       while (i < index) {
-        if (ADB_LIKELY(size < totalSize)) {
+        if (size < totalSize) [[likely]] {
           size += slice.byteSize();
           TRI_ASSERT(size <= totalSize);
-          if (ADB_UNLIKELY(size > totalSize)) {
+          if (size > totalSize) [[unlikely]] {
             slice = VPackSlice::noneSlice();
             break;
           }
@@ -428,7 +428,7 @@ class IResearchInvertedIndexIteratorBase : public IndexIterator {
                  arangodb::aql::Variable const*,
                  IndexIteratorOptions const&) override {
     TRI_ASSERT(node);
-    if (ADB_LIKELY(node)) {
+    if (node) [[likely]] {
       reset();
       resetFilter(node);
       return true;
@@ -493,8 +493,8 @@ class IResearchInvertedIndexIteratorBase : public IndexIterator {
       } else {
         TRI_ASSERT(static_cast<int64_t>(condition->numMembers()) >
                    _mutableConditionIdx);
-        if (ADB_UNLIKELY(static_cast<int64_t>(condition->numMembers()) <=
-                         _mutableConditionIdx)) {
+        if (static_cast<int64_t>(condition->numMembers()) <=
+            _mutableConditionIdx) [[unlikely]] {
           arangodb::velocypack::Builder builder;
           condition->toVelocyPack(builder, true);
           THROW_ARANGO_EXCEPTION_MESSAGE(
@@ -560,7 +560,7 @@ class IResearchInvertedIndexIteratorBase : public IndexIterator {
     }
     _filter = root.prepare(*_reader, _order, irs::no_boost(), nullptr);
     TRI_ASSERT(_filter);
-    if (ADB_UNLIKELY(!_filter)) {
+    if (!_filter) [[unlikely]] {
       if (condition) {
         arangodb::velocypack::Builder builder;
         condition->toVelocyPack(builder, true);
@@ -653,7 +653,7 @@ class IResearchInvertedIndexIterator final
         // skip-next-covering mixture of the calls
         _pkDocItr = ::pkColumn(segmentReader);
         _pkValue = irs::get<irs::payload>(*_pkDocItr);
-        if (ADB_UNLIKELY(!_pkValue)) {
+        if (!_pkValue) [[unlikely]] {
           _pkValue = &NoPayload;
         }
         _projections.reset(segmentReader);
@@ -837,9 +837,9 @@ class IResearchInvertedIndexMergeIterator final
       TRI_ASSERT(doc);
       pkDocItr = ::pkColumn(segment);
       TRI_ASSERT(pkDocItr);
-      if (ADB_LIKELY(pkDocItr)) {
+      if (pkDocItr) [[likely]] {
         pkValue = irs::get<irs::payload>(*pkDocItr);
-        if (ADB_UNLIKELY(!pkValue)) {
+        if (!pkValue) [[unlikely]] {
           pkValue = &NoPayload;
         }
       }

--- a/arangod/IResearch/IResearchInvertedIndexMeta.cpp
+++ b/arangod/IResearch/IResearchInvertedIndexMeta.cpp
@@ -331,7 +331,7 @@ bool IResearchInvertedIndexMeta::init(
                 analyzer = *it;
                 found = static_cast<bool>(analyzer);
 
-                if (ADB_UNLIKELY(!found)) {
+                if (!found) [[unlikely]] {
                   TRI_ASSERT(false);               // should not happen
                   _analyzerDefinitions.erase(it);  // remove null analyzer
                 }
@@ -515,7 +515,7 @@ bool IResearchInvertedIndexMeta::matchesFieldsDefinition(
     TRI_ASSERT(fieldSlice.isObject());  // We expect only normalized definitions
                                         // here. Otherwise we will need vocbase
                                         // to properly match analyzers.
-    if (ADB_UNLIKELY(!fieldSlice.isObject())) {
+    if (!fieldSlice.isObject()) [[unlikely]] {
       return false;
     }
 
@@ -525,7 +525,7 @@ bool IResearchInvertedIndexMeta::matchesFieldsDefinition(
         name.isString() &&     // We expect only normalized definitions here.
         analyzer.isString());  // Otherwise we will need vocbase to properly
                                // match analyzers.
-    if (ADB_UNLIKELY(!name.isString() || !analyzer.isString())) {
+    if (!name.isString() || !analyzer.isString()) [[unlikely]] {
       return false;
     }
 

--- a/arangod/IResearch/IResearchLink.cpp
+++ b/arangod/IResearch/IResearchLink.cpp
@@ -306,7 +306,7 @@ Result IResearchLink::init(velocypack::Slice definition,
               << "Setting collection name '" << meta._collectionName
               << "' for new link '" << this->id().id() << "'";
         }
-        if (ADB_UNLIKELY(meta._collectionName.empty())) {
+        if (meta._collectionName.empty()) [[unlikely]] {
           LOG_TOPIC("67da6", WARN, TOPIC)
               << "Failed to init collection name for the link '"
               << this->id().id()
@@ -316,7 +316,7 @@ Result IResearchLink::init(velocypack::Slice definition,
 
 #ifdef USE_ENTERPRISE
         // enterprise name is not used in _id so should not be here!
-        if (ADB_LIKELY(!meta._collectionName.empty())) {
+        if (!meta._collectionName.empty()) [[likely]] {
           ClusterMethods::realNameFromSmartName(meta._collectionName);
         }
 #endif

--- a/arangod/IResearch/IResearchLinkHelper.cpp
+++ b/arangod/IResearch/IResearchLinkHelper.cpp
@@ -861,7 +861,7 @@ namespace iresearch {
         const auto& currentVocbase = vocbase.name();
         for (const auto& analyzer : meta._analyzerDefinitions) {
           TRI_ASSERT(analyzer);  // should be checked in meta init
-          if (ADB_UNLIKELY(!analyzer)) {
+          if (!analyzer) [[unlikely]] {
             continue;
           }
           auto* pool = analyzer.get();

--- a/arangod/IResearch/IResearchLinkMeta.cpp
+++ b/arangod/IResearch/IResearchLinkMeta.cpp
@@ -204,7 +204,7 @@ bool FieldMeta::init(
           analyzer = *it;
           found = static_cast<bool>(analyzer);
 
-          if (ADB_UNLIKELY(!found)) {
+          if (!found) [[unlikely]] {
             TRI_ASSERT(false);              // should not happen
             referencedAnalyzers.erase(it);  // remove null analyzer
           }

--- a/arangod/IResearch/IResearchViewMeta.cpp
+++ b/arangod/IResearch/IResearchViewMeta.cpp
@@ -599,7 +599,7 @@ bool IResearchViewMeta::init(velocypack::Slice slice, std::string& errorField,
         _primarySortCompression =
             columnCompressionFromString(field.copyString());
       }
-      if (ADB_UNLIKELY(nullptr == _primarySortCompression)) {
+      if (nullptr == _primarySortCompression) [[unlikely]] {
         errorField += ".primarySortCompression";
         return false;
       }

--- a/arangod/IResearch/IResearchViewStoredValues.cpp
+++ b/arangod/IResearch/IResearchViewStoredValues.cpp
@@ -64,7 +64,7 @@ bool IResearchViewStoredValues::toVelocyPack(
     irs::string_ref encodedCompression =
         columnCompressionToString(column.compression);
     TRI_ASSERT(!encodedCompression.null());
-    if (ADB_LIKELY(!encodedCompression.null())) {
+    if (!encodedCompression.null()) [[likely]] {
       addStringRef(builder, COMPRESSION_COLUMN_PARAM, encodedCompression);
     }
   }
@@ -176,14 +176,14 @@ bool IResearchViewStoredValues::fromVelocyPack(velocypack::Slice slice,
     for (auto columnSlice : VPackArrayIterator(slice)) {
       ++idx;
       if (columnSlice.isObject()) {
-        if (ADB_LIKELY(columnSlice.hasKey(FIELD_COLUMN_PARAM))) {
+        if (columnSlice.hasKey(FIELD_COLUMN_PARAM)) [[likely]] {
           auto compression = getDefaultCompression();
           if (columnSlice.hasKey(COMPRESSION_COLUMN_PARAM)) {
             auto compressionKey = columnSlice.get(COMPRESSION_COLUMN_PARAM);
-            if (ADB_LIKELY(compressionKey.isString())) {
+            if (compressionKey.isString()) [[likely]] {
               auto decodedCompression = columnCompressionFromString(
                   iresearch::getStringRef(compressionKey));
-              if (ADB_LIKELY(decodedCompression != nullptr)) {
+              if (decodedCompression != nullptr) [[likely]] {
                 compression = decodedCompression;
               } else {
                 errorField =

--- a/arangod/Network/Methods.cpp
+++ b/arangod/Network/Methods.cpp
@@ -372,7 +372,7 @@ class RequestsState final : public std::enable_shared_from_this<RequestsState> {
   // scheduler requests that are due
   void startRequest() {
     TRI_ASSERT(_tmp_req != nullptr);
-    if (ADB_UNLIKELY(!_pool)) {
+    if (!_pool) [[unlikely]] {
       LOG_TOPIC("5949f", ERR, Logger::COMMUNICATION)
           << "connection pool unavailable";
       _tmp_err = Error::ConnectionCanceled;
@@ -581,7 +581,7 @@ class RequestsState final : public std::enable_shared_from_this<RequestsState> {
         << "'";
 
     auto* sch = SchedulerFeature::SCHEDULER;
-    if (ADB_UNLIKELY(sch == nullptr)) {
+    if (sch == nullptr) [[unlikely]] {
       _promise.setValue(Response{std::move(_destination),
                                  fuerte::Error::ConnectionCanceled, nullptr,
                                  nullptr});

--- a/arangod/Pregel/Worker.cpp
+++ b/arangod/Pregel/Worker.cpp
@@ -429,7 +429,7 @@ bool Worker<V, E, M>::_processVertices(
   }
   // ==================== send messages to other shards ====================
   outCache->flushMessages();
-  if (ADB_UNLIKELY(!_writeCache)) {  // ~Worker was called
+  if (!_writeCache) [[unlikely]] {  // ~Worker was called
     LOG_PREGEL("ee2ab", WARN) << "Execution aborted prematurely.";
     return false;
   }

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -609,7 +609,7 @@ void DatabaseInitialSyncer::setProgress(std::string const& msg) {
 Result DatabaseInitialSyncer::parseCollectionDumpMarker(
     transaction::Methods& trx, LogicalCollection* coll, VPackSlice marker,
     FormatHint& hint) {
-  if (!ADB_LIKELY(marker.isObject())) {
+  if (!marker.isObject()) [[unlikely]] {
     return TRI_ERROR_REPLICATION_INVALID_RESPONSE;
   }
 
@@ -646,7 +646,7 @@ Result DatabaseInitialSyncer::parseCollectionDumpMarker(
     doc = marker;
   }
 
-  if (!ADB_LIKELY(doc.isObject())) {
+  if (!doc.isObject()) [[unlikely]] {
     return TRI_ERROR_REPLICATION_INVALID_RESPONSE;
   }
 

--- a/arangod/Replication2/ReplicatedLog/Algorithms.cpp
+++ b/arangod/Replication2/ReplicatedLog/Algorithms.cpp
@@ -162,9 +162,8 @@ auto checkCurrentTerm(
     if (numberOfAvailableParticipants >=
         requiredNumberOfAvailableParticipants) {
       auto const numParticipants = newLeaderSet.size();
-      if (ADB_UNLIKELY(numParticipants == 0 ||
-                       numParticipants >
-                           std::numeric_limits<uint16_t>::max())) {
+      if (numParticipants == 0 ||
+          numParticipants > std::numeric_limits<uint16_t>::max()) [[unlikely]] {
         abortOrThrow(
             TRI_ERROR_NUMERIC_OVERFLOW,
             basics::StringUtils::concatT(

--- a/arangod/Replication2/ReplicatedLog/LogCore.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogCore.cpp
@@ -38,7 +38,7 @@ using namespace arangodb::replication2::replicated_log;
 
 replicated_log::LogCore::LogCore(std::shared_ptr<PersistedLog> persistedLog)
     : _persistedLog(std::move(persistedLog)) {
-  if (ADB_UNLIKELY(_persistedLog == nullptr)) {
+  if (_persistedLog == nullptr) [[unlikely]] {
     TRI_ASSERT(false);
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
                                    "When instantiating ReplicatedLog: "

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -293,7 +293,7 @@ auto replicated_log::LogLeader::construct(
     std::shared_ptr<ReplicatedLogMetrics> logMetrics,
     std::shared_ptr<ReplicatedLogGlobalSettings const> options)
     -> std::shared_ptr<LogLeader> {
-  if (ADB_UNLIKELY(logCore == nullptr)) {
+  if (logCore == nullptr) [[unlikely]] {
     auto followerIds = std::vector<std::string>{};
     std::transform(followers.begin(), followers.end(),
                    std::back_inserter(followerIds),

--- a/arangod/Replication2/ReplicatedState/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedState/Supervision.cpp
@@ -193,8 +193,8 @@ auto tryLeadershipElection(Log const& log, ParticipantsHealth const& health)
   // uint16_t::max participants at the moment)
   //
   // TODO: should this really be throwing or just erroring?
-  if (ADB_UNLIKELY(numElectible == 0 ||
-                   numElectible > std::numeric_limits<uint16_t>::max())) {
+  if (numElectible == 0 || numElectible > std::numeric_limits<uint16_t>::max())
+      [[unlikely]] {
     abortOrThrow(TRI_ERROR_NUMERIC_OVERFLOW,
                  basics::StringUtils::concatT(
                      "Number of participants electible for leadership out "

--- a/arangod/RocksDBEngine/Methods/RocksDBTrxBaseMethods.cpp
+++ b/arangod/RocksDBEngine/Methods/RocksDBTrxBaseMethods.cpp
@@ -381,7 +381,7 @@ arangodb::Result RocksDBTrxBaseMethods::doCommit() {
   TRI_ASSERT(postCommitSeq != 0);
   TRI_ASSERT(postCommitSeq >= previousSeqNo);
 
-  if (ADB_LIKELY(numOps > 0)) {
+  if (numOps > 0) [[likely]] {
     // we now need to add 1 for each write operation carried out in the trx
     // to get to the transaction's last operation's seqno
     postCommitSeq += numOps - 1;  // add to get to the next batch

--- a/arangod/RocksDBEngine/RocksDBComparator.cpp
+++ b/arangod/RocksDBEngine/RocksDBComparator.cpp
@@ -79,8 +79,7 @@ int RocksDBVPackComparator::compareIndexValues(
     return r;
   }
 
-  if (ADB_UNLIKELY(lhs.size() == objectIDLength ||
-                   rhs.size() == objectIDLength)) {
+  if (lhs.size() == objectIDLength || rhs.size() == objectIDLength) [[likely]] {
     if (lhs.size() == rhs.size()) {
       return 0;
     }

--- a/arangod/RocksDBEngine/RocksDBIterators.cpp
+++ b/arangod/RocksDBEngine/RocksDBIterators.cpp
@@ -85,7 +85,8 @@ bool RocksDBAllIndexIterator::nextImpl(LocalDocumentIdCallback const& cb,
   TRI_ASSERT(_trx->state()->isRunning());
   TRI_ASSERT(_iterator != nullptr);
 
-  if (limit == 0 || ADB_UNLIKELY(!_iterator->Valid()) || outOfRange()) {
+  if (limit == 0 || ADB_UNLIKELY_DEPRECATED(!_iterator->Valid()) ||
+      outOfRange()) {
     // No limit no data, or we are actually done. The last call should have
     // returned false
     TRI_ASSERT(limit > 0);  // Someone called with limit == 0. Api broken

--- a/arangod/RocksDBEngine/RocksDBIterators.cpp
+++ b/arangod/RocksDBEngine/RocksDBIterators.cpp
@@ -103,7 +103,7 @@ bool RocksDBAllIndexIterator::nextImpl(LocalDocumentIdCallback const& cb,
     --limit;
     _iterator->Next();
 
-    if (ADB_UNLIKELY(!_iterator->Valid())) {
+    if (!_iterator->Valid()) [[unlikely]] {
       // validate that Iterator is in a good shape and hasn't failed
       arangodb::rocksutils::checkIteratorStatus(_iterator.get());
       return false;
@@ -140,7 +140,7 @@ bool RocksDBAllIndexIterator::nextDocumentImpl(
     --limit;
     _iterator->Next();
 
-    if (ADB_UNLIKELY(!_iterator->Valid())) {
+    if (!_iterator->Valid()) [[unlikely]] {
       // validate that Iterator is in a good shape and hasn't failed
       arangodb::rocksutils::checkIteratorStatus(_iterator.get());
       return false;

--- a/arangod/RocksDBEngine/RocksDBMetadata.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetadata.cpp
@@ -191,10 +191,10 @@ void RocksDBMetadata::removeBlocker(TransactionId trxId) noexcept try {
   WRITE_LOCKER(locker, _blockerLock);
   auto it = _blockers.find(trxId);
 
-  if (ADB_LIKELY(_blockers.end() != it)) {
+  if (_blockers.end() != it) [[likely]] {
     auto cross = _blockersBySeq.find(std::make_pair(it->second, it->first));
     TRI_ASSERT(_blockersBySeq.end() != cross);
-    if (ADB_LIKELY(_blockersBySeq.end() != cross)) {
+    if (_blockersBySeq.end() != cross) [[likely]] {
       _blockersBySeq.erase(cross);
     }
     _blockers.erase(it);

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
@@ -360,7 +360,7 @@ class RocksDBPrimaryIndexRangeIterator final : public IndexIterator {
         _iterator->Next();
       }
 
-      if (ADB_UNLIKELY(!_iterator->Valid())) {
+      if (!_iterator->Valid()) [[unlikely]] {
         // validate that Iterator is in a good shape and hasn't failed
         arangodb::rocksutils::checkIteratorStatus(_iterator.get());
         return false;
@@ -408,7 +408,7 @@ class RocksDBPrimaryIndexRangeIterator final : public IndexIterator {
         _iterator->Next();
       }
 
-      if (ADB_UNLIKELY(!_iterator->Valid())) {
+      if (!_iterator->Valid()) [[unlikely]] {
         // validate that Iterator is in a good shape and hasn't failed
         arangodb::rocksutils::checkIteratorStatus(_iterator.get());
         return false;

--- a/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
@@ -231,13 +231,13 @@ void RocksDBTransactionCollection::commitCounts(TransactionId trxId,
   // Update the index estimates.
   for (auto& pair : _trackedIndexOperations) {
     auto idx = _collection->lookupIndex(pair.first);
-    if (ADB_UNLIKELY(idx == nullptr)) {
+    if (idx == nullptr) [[unlikely]] {
       TRI_ASSERT(false);  // Index reported estimates, but does not exist
       continue;
     }
     auto ridx = static_cast<RocksDBIndex*>(idx.get());
     auto est = ridx->estimator();
-    if (ADB_LIKELY(est != nullptr)) {
+    if (est != nullptr) [[likely]] {
       est->bufferUpdates(commitSeq, std::move(pair.second.inserts),
                          std::move(pair.second.removals));
     } else {

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -1259,7 +1259,7 @@ std::unique_ptr<IndexIterator> RocksDBVPackIndex::lookup(
   TRI_ASSERT(searchValues.isArray());
   TRI_ASSERT(searchValues.length() <= _fields.size());
 
-  if (ADB_UNLIKELY(searchValues.length() == 0)) {
+  if (searchValues.length() == 0) [[unlikely]] {
     // full range search
     RocksDBKeyBounds bounds =
         _unique ? RocksDBKeyBounds::UniqueVPackIndex(objectId(), reverse)

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -281,7 +281,7 @@ bool transaction::Methods::removeStatusChangeCallback(
     auto it = std::find(statusChangeCallbacks->begin(),
                         statusChangeCallbacks->end(), callback);
     TRI_ASSERT(it != statusChangeCallbacks->end());
-    if (ADB_LIKELY(it != statusChangeCallbacks->end())) {
+    if (it != statusChangeCallbacks->end()) [[likely]] {
       statusChangeCallbacks->erase(it);
     }
   }
@@ -333,7 +333,7 @@ transaction::Methods::Methods(std::shared_ptr<transaction::Context> const& ctx,
                               transaction::Options const& options)
     : _state(nullptr), _transactionContext(ctx), _mainTransaction(false) {
   TRI_ASSERT(_transactionContext != nullptr);
-  if (ADB_UNLIKELY(_transactionContext == nullptr)) {
+  if (_transactionContext == nullptr) [[unlikely]] {
     // in production, we must not go on with undefined behavior, so we bail out
     // here with an exception as last resort
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
@@ -2227,7 +2227,7 @@ std::unique_ptr<IndexIterator> transaction::Methods::indexScan(
     ReadOwnWrites readOwnWrites) {
   // For now we assume indexId is the iid part of the index.
 
-  if (ADB_UNLIKELY(_state->isCoordinator())) {
+  if (_state->isCoordinator()) [[unlikely]] {
     // The index scan is only available on DBServers and Single Server.
     THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_ONLY_ON_DBSERVER);
   }

--- a/arangod/V8Server/v8-vocbase.cpp
+++ b/arangod/V8Server/v8-vocbase.cpp
@@ -780,7 +780,7 @@ static void JS_ExecuteAqlJson(v8::FunctionCallbackInfo<v8::Value> const& args) {
 
   QueryAnalyzerRevisions analyzersRevision;
   auto revisionRes = analyzersRevision.fromVelocyPack(queryBuilder.slice());
-  if (ADB_UNLIKELY(revisionRes.fail())) {
+  if (revisionRes.fail()) [[unlikely]] {
     TRI_V8_THROW_EXCEPTION(revisionRes);
   }
 

--- a/arangod/VocBase/KeyGenerator.cpp
+++ b/arangod/VocBase/KeyGenerator.cpp
@@ -230,7 +230,7 @@ class TraditionalKeyGenerator : public KeyGenerator {
   std::string generate() override final {
     uint64_t tick = generateValue();
 
-    if (ADB_UNLIKELY(tick == 0)) {
+    if (tick == 0) [[unlikely]] {
       // unlikely case we have run out of keys
       // returning an empty string will trigger an error on the call site
       return std::string();
@@ -300,7 +300,7 @@ class TraditionalKeyGeneratorSingle final : public TraditionalKeyGenerator {
   uint64_t generateValue() override {
     uint64_t tick = TRI_NewTickServer();
 
-    if (ADB_UNLIKELY(tick == UINT64_MAX)) {
+    if (tick == UINT64_MAX) [[unlikely]] {
       // out of keys
       return 0;
     }
@@ -308,7 +308,7 @@ class TraditionalKeyGeneratorSingle final : public TraditionalKeyGenerator {
     // keep track of last assigned value, and make sure the value
     // we hand out is always higher than it
     auto lastValue = _lastValue.load(std::memory_order_relaxed);
-    if (ADB_UNLIKELY(lastValue >= UINT64_MAX - 1ULL)) {
+    if (lastValue >= UINT64_MAX - 1ULL) [[unlikely]] {
       // oops, out of keys!
       return 0;
     }
@@ -379,14 +379,14 @@ class PaddedKeyGenerator : public KeyGenerator {
   std::string generate() override {
     uint64_t tick = generateValue();
 
-    if (ADB_UNLIKELY(tick == 0 || tick == UINT64_MAX)) {
+    if (tick == 0 || tick == UINT64_MAX) [[unlikely]] {
       // unlikely case we have run out of keys
       // returning an empty string will trigger an error on the call site
       return std::string();
     }
 
     auto lastValue = _lastValue.load(std::memory_order_relaxed);
-    if (ADB_UNLIKELY(lastValue >= UINT64_MAX - 1ULL)) {
+    if (lastValue >= UINT64_MAX - 1ULL) [[unlikely]] {
       // oops, out of keys!
       return std::string();
     }

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -1084,7 +1084,7 @@ static Result DropVocbaseColCoordinator(arangodb::LogicalCollection* collection,
       << "error while dropping collection: '" << collName << "' error: '"
       << res.errorMessage() << "'";
 
-  if (ADB_LIKELY(!keepUserRights)) {
+  if (!keepUserRights) [[likely]] {
     auth::UserManager* um = AuthenticationFeature::instance()->userManager();
 
     if (res.ok() && um != nullptr) {

--- a/lib/Basics/GlobalResourceMonitor.cpp
+++ b/lib/Basics/GlobalResourceMonitor.cpp
@@ -83,7 +83,7 @@ bool GlobalResourceMonitor::increaseMemoryUsage(std::int64_t value) noexcept {
     std::int64_t next;
     do {
       next = cur + value;
-      if (ADB_UNLIKELY(next > _limit)) {
+      if (next > _limit) [[unlikely]] {
         return false;
       }
     } while (

--- a/lib/Basics/Guarded.h
+++ b/lib/Basics/Guarded.h
@@ -108,7 +108,7 @@ class MutexGuard {
 template<class T, class L>
 MutexGuard<T, L>::MutexGuard(T& value, L mutexLock)
     : _value(&value), _mutexLock(std::move(mutexLock)) {
-  if (ADB_UNLIKELY(!_mutexLock.owns_lock())) {
+  if (!_mutexLock.owns_lock()) [[unlikely]] {
     throw std::invalid_argument("Lock not owned");
   }
 }

--- a/lib/Basics/NumberUtils.h
+++ b/lib/Basics/NumberUtils.h
@@ -87,7 +87,7 @@ inline T atoi_positive_unchecked(char const* p, char const* e) noexcept {
 // this function will not modify errno.
 template<typename T>
 inline T atoi_unchecked(char const* p, char const* e) noexcept {
-  if (ADB_UNLIKELY(p == e)) {
+  if (p == e) [[unlikely]] {
     return T();
   }
 
@@ -97,7 +97,7 @@ inline T atoi_unchecked(char const* p, char const* e) noexcept {
     }
     return atoi_negative_unchecked<T>(++p, e);
   }
-  if (ADB_UNLIKELY(*p == '+')) {
+  if (*p == '+') [[unlikely]] {
     ++p;
   }
 
@@ -115,7 +115,7 @@ inline T atoi_unchecked(char const* p, char const* e) noexcept {
 // this function will not modify errno.
 template<typename T>
 inline T atoi_negative(char const* p, char const* e, bool& valid) noexcept {
-  if (ADB_UNLIKELY(p == e)) {
+  if (p == e) [[unlikely]] {
     valid = false;
     return T();
   }
@@ -127,14 +127,14 @@ inline T atoi_negative(char const* p, char const* e, bool& valid) noexcept {
   do {
     char c = *p;
     // we expect only '0' to '9'. everything else is unexpected
-    if (ADB_UNLIKELY(c < '0' || c > '9')) {
+    if (c < '0' || c > '9') [[unlikely]] {
       valid = false;
       return result;
     }
 
     c -= '0';
     // we expect the bulk of values to not hit the bounds restrictions
-    if (ADB_UNLIKELY(result < cutoff || (result == cutoff && c > cutlim))) {
+    if (result < cutoff || (result == cutoff && c > cutlim)) [[unlikely]] {
       valid = false;
       return result;
     }
@@ -157,7 +157,7 @@ inline T atoi_negative(char const* p, char const* e, bool& valid) noexcept {
 // this function will not modify errno.
 template<typename T>
 inline T atoi_positive(char const* p, char const* e, bool& valid) noexcept {
-  if (ADB_UNLIKELY(p == e)) {
+  if (p == e) [[unlikely]] {
     valid = false;
     return T();
   }
@@ -170,14 +170,14 @@ inline T atoi_positive(char const* p, char const* e, bool& valid) noexcept {
     char c = *p;
 
     // we expect only '0' to '9'. everything else is unexpected
-    if (ADB_UNLIKELY(c < '0' || c > '9')) {
+    if (c < '0' || c > '9') [[unlikely]] {
       valid = false;
       return result;
     }
 
     c -= '0';
     // we expect the bulk of values to not hit the bounds restrictions
-    if (ADB_UNLIKELY(result > cutoff || (result == cutoff && c > cutlim))) {
+    if (result > cutoff || (result == cutoff && c > cutlim)) [[unlikely]] {
       valid = false;
       return result;
     }
@@ -203,7 +203,7 @@ inline T atoi_positive(char const* p, char const* e, bool& valid) noexcept {
 template<typename T>
 inline typename std::enable_if<std::is_signed<T>::value, T>::type atoi(
     char const* p, char const* e, bool& valid) noexcept {
-  if (ADB_UNLIKELY(p == e)) {
+  if (p == e) [[unlikely]] {
     valid = false;
     return T();
   }
@@ -211,7 +211,7 @@ inline typename std::enable_if<std::is_signed<T>::value, T>::type atoi(
   if (*p == '-') {
     return atoi_negative<T>(++p, e, valid);
   }
-  if (ADB_UNLIKELY(*p == '+')) {
+  if (*p == '+') [[unlikely]] {
     ++p;
   }
 
@@ -221,7 +221,7 @@ inline typename std::enable_if<std::is_signed<T>::value, T>::type atoi(
 template<typename T>
 inline typename std::enable_if<std::is_unsigned<T>::value, T>::type atoi(
     char const* p, char const* e, bool& valid) noexcept {
-  if (ADB_UNLIKELY(p == e)) {
+  if (p == e) [[unlikely]] {
     valid = false;
     return T();
   }
@@ -230,7 +230,7 @@ inline typename std::enable_if<std::is_unsigned<T>::value, T>::type atoi(
     valid = false;
     return T();
   }
-  if (ADB_UNLIKELY(*p == '+')) {
+  if (*p == '+') [[unlikely]] {
     ++p;
   }
 

--- a/lib/Basics/ResourceUsage.cpp
+++ b/lib/Basics/ResourceUsage.cpp
@@ -129,7 +129,7 @@ void ResourceMonitor::increaseMemoryUsage(std::uint64_t value) {
     // or we have piled up changes by lots of small allocations so far. time for
     // some memory expensive checks now...
 
-    if (_limit > 0 && ADB_UNLIKELY(current > _limit)) {
+    if (_limit > 0 && current > _limit) [[unlikely]] {
       // we would use more memory than dictated by the instance's own limit.
       // because we will throw an exception directly afterwards, we now need to
       // revert the change that we already made to the instance's own counter.

--- a/lib/Basics/Utf8Helper.cpp
+++ b/lib/Basics/Utf8Helper.cpp
@@ -120,7 +120,7 @@ int Utf8Helper::compareUtf8(char const* left, size_t leftLength,
   int result =
       _coll->compareUTF8(icu::StringPiece(left, (int32_t)leftLength),
                          icu::StringPiece(right, (int32_t)rightLength), status);
-  if (ADB_UNLIKELY(U_FAILURE(status))) {
+  if (U_FAILURE(status)) [[unlikely]] {
     TRI_ASSERT(false);
     return (strncmp(left, right,
                     leftLength < rightLength ? leftLength : rightLength));

--- a/lib/Basics/VelocyPackHelper.cpp
+++ b/lib/Basics/VelocyPackHelper.cpp
@@ -321,7 +321,7 @@ bool VelocyPackHelper::VPackEqual::operator()(VPackSlice const& lhs,
 static inline int8_t TypeWeight(VPackSlice& slice) {
 again:
   int8_t w = ::typeWeights[slice.head()];
-  if (ADB_UNLIKELY(w == -50)) {
+  if (w == -50) [[unlikely]] {
     slice = slice.resolveExternal();
     goto again;
   }

--- a/lib/Basics/datetime.cpp
+++ b/lib/Basics/datetime.cpp
@@ -520,7 +520,7 @@ bool parseDateTime(std::string_view dateTime, ParsedDateTime& result) {
   if (length == 0 || result.year > 9999) {
     return false;
   }
-  if (ADB_UNLIKELY(length > 4)) {
+  if (length > 4) [[unlikely]] {
     // we must have at least 4 digits for the year, however, we
     // allow any amount of leading zeroes
     size_t i = 0;

--- a/lib/Basics/debugging.h
+++ b/lib/Basics/debugging.h
@@ -272,7 +272,7 @@ struct AssertionLogger {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 
 #define TRI_ASSERT(expr) /*GCOVR_EXCL_LINE*/                                  \
-  (ADB_LIKELY(expr))                                                          \
+  (ADB_LIKELY_DEPRECATED(expr))                                               \
       ? (void)nullptr                                                         \
       : ::arangodb::debug::AssertionLogger{__FILE__, __LINE__,                \
                                            ARANGODB_PRETTY_FUNCTION, #expr} & \

--- a/lib/Basics/system-compiler.h
+++ b/lib/Basics/system-compiler.h
@@ -58,11 +58,11 @@
 // macro definitions similar to the ones at
 // https://kernelnewbies.org/FAQ/LikelyUnlikely
 #if defined(__GNUC__) || defined(__GNUG__)
-#define ADB_LIKELY(v) __builtin_expect(!!(v), 1)
-#define ADB_UNLIKELY(v) __builtin_expect(!!(v), 0)
+#define ADB_LIKELY_DEPRECATED(v) __builtin_expect(!!(v), 1)
+#define ADB_UNLIKELY_DEPRECATED(v) __builtin_expect(!!(v), 0)
 #else
-#define ADB_LIKELY(v) v
-#define ADB_UNLIKELY(v) v
+#define ADB_LIKELY_DEPRECATED(v) v
+#define ADB_UNLIKELY_DEPRECATED(v) v
 #endif
 
 // sizetint_t

--- a/lib/Containers/MerkleTree.cpp
+++ b/lib/Containers/MerkleTree.cpp
@@ -611,7 +611,7 @@ void MerkleTree<Hasher, BranchingBits>::insert(
     return this->insert(keys[0]);
   }
 
-  if (ADB_UNLIKELY(keys.empty())) {
+  if (keys.empty()) [[unlikely]] {
     return;
   }
 
@@ -648,7 +648,7 @@ void MerkleTree<Hasher, BranchingBits>::remove(
     return remove(keys[0]);
   }
 
-  if (ADB_UNLIKELY(keys.empty())) {
+  if (keys.empty()) [[unlikely]] {
     return;
   }
 
@@ -1278,7 +1278,7 @@ void MerkleTree<Hasher, BranchingBits>::modify(std::uint64_t key,
 
   // adjust bucket node
   bool success = modifyLocal(key, value, isInsert);
-  if (ADB_UNLIKELY(!success)) {
+  if (!success) [[unlikely]] {
     throw std::invalid_argument("Tried to remove key that is not present.");
   }
 
@@ -1296,7 +1296,7 @@ void MerkleTree<Hasher, BranchingBits>::modify(
   for (std::uint64_t key : keys) {
     std::uint64_t value = h.hash(key);
     bool success = modifyLocal(key, value, isInsert);
-    if (ADB_UNLIKELY(!success)) {
+    if (!success) [[unlikely]] {
       // roll back the changes we already made, using best effort
       for (std::uint64_t k : keys) {
         if (k == key) {
@@ -1324,7 +1324,7 @@ bool MerkleTree<Hasher, BranchingBits>::modifyLocal(Node& node,
   if (isInsert) {
     node.count += count;
   } else {
-    if (ADB_UNLIKELY(node.count < count)) {
+    if (node.count < count) [[unlikely]] {
       return false;
     }
     node.count -= count;

--- a/lib/Futures/Try.h
+++ b/lib/Futures/Try.h
@@ -130,9 +130,9 @@ class Try {
   }
 
   ~Try() {
-    if (ADB_LIKELY(_content == Content::Value)) {
+    if (_content == Content::Value) [[likely]] {
       _value.~T();
-    } else if (ADB_UNLIKELY(_content == Content::Exception)) {
+    } else if (_content == Content::Exception) [[unlikely]] {
       _exception.~exception_ptr();
     }
   }
@@ -289,9 +289,9 @@ class Try {
   void destroy() noexcept {
     auto old = _content;
     _content = Content::None;
-    if (ADB_LIKELY(old == Content::Value)) {
+    if (old == Content::Value) [[likely]] {
       _value.~T();
-    } else if (ADB_UNLIKELY(old == Content::Exception)) {
+    } else if (old == Content::Exception) [[unlikely]] {
       _exception.~exception_ptr();
     }
   }

--- a/lib/Rest/VstResponse.cpp
+++ b/lib/Rest/VstResponse.cpp
@@ -123,7 +123,7 @@ void VstResponse::addPayload(VPackBuffer<uint8_t>&& buffer,
   }
 
   auto handleBuffer = [this, options](VPackBuffer<uint8_t>&& buff) {
-    if (ADB_UNLIKELY(_contentType == rest::ContentType::JSON)) {
+    if (_contentType == rest::ContentType::JSON) [[unlikely]] {
       // simon: usually we escape unicode char sequences,
       // but JSON over VST is not consumed by node.js or browsers
       velocypack::ByteBufferSinkImpl<uint8_t> sink(&_payload);

--- a/lib/V8/v8-globals.h
+++ b/lib/V8/v8-globals.h
@@ -88,7 +88,7 @@ static inline v8::Local<v8::String> v8Utf8StringFactory(v8::Isolate* isolate,
 static inline v8::Local<v8::String> v8Utf8StringFactory(v8::Isolate* isolate,
                                                         void const* ptr,
                                                         std::size_t length) {
-  if (ADB_UNLIKELY(length > (unsigned int)std::numeric_limits<int>::max())) {
+  if (length > (unsigned int)std::numeric_limits<int>::max()) [[unlikely]] {
     throw std::overflow_error("string length out of range");
   }
   return v8Utf8StringFactory(isolate, ptr, static_cast<int>(length));


### PR DESCRIPTION
### Scope & Purpose

Use C++20 likely/unlikely standard attributes instead of compiler-dependent ADB_ macros

https://github.com/arangodb/enterprise/pull/872

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

