### PR TITLE
Added more detail to time consumption and data amount parsed log

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Added more detail to the log messages that display the total time consumption
+  and total amount of data parsed for the client tools arangodump and 
+  arangorestore. 
+
 * Fixed minDepth handling of weighted Traversals. When using a minDepth of 3, also paths of length
   2 have been returned, on all locally executed variants (SingleServer, OneShard, DisjointSmart).
 

--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -1273,14 +1273,15 @@ void DumpFeature::start() {
     if (_options.dumpData) {
       LOG_TOPIC("66c0e", INFO, Logger::DUMP)
           << "Processed " << _stats.totalCollections.load()
-          << " collection(s) in " << Logger::FIXED(totalTime, 6) << " s,"
-          << " wrote " << formatSize(_stats.totalWritten.load())
-          << " into datafiles, sent " << _stats.totalBatches.load()
-          << " batch(es)";
+          << " collection(s) from " << databases.size() << " databases in "
+          << Logger::FIXED(totalTime, 6) << " s total time. Wrote "
+          << formatSize(_stats.totalWritten.load()) << " into datafiles, sent "
+          << _stats.totalBatches.load() << " batch(es) in total.";
     } else {
       LOG_TOPIC("aaa17", INFO, Logger::DUMP)
           << "Processed " << _stats.totalCollections.load()
-          << " collection(s) in " << Logger::FIXED(totalTime, 6) << " s";
+          << " collection(s) from " << databases.size() << " databases in "
+          << Logger::FIXED(totalTime, 6) << " s total time.";
     }
   }
 }

--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -1273,14 +1273,14 @@ void DumpFeature::start() {
     if (_options.dumpData) {
       LOG_TOPIC("66c0e", INFO, Logger::DUMP)
           << "Processed " << _stats.totalCollections.load()
-          << " collection(s) from " << databases.size() << " databases in "
+          << " collection(s) from " << databases.size() << " database(s) in "
           << Logger::FIXED(totalTime, 6) << " s total time. Wrote "
           << formatSize(_stats.totalWritten.load()) << " into datafiles, sent "
           << _stats.totalBatches.load() << " batch(es) in total.";
     } else {
       LOG_TOPIC("aaa17", INFO, Logger::DUMP)
           << "Processed " << _stats.totalCollections.load()
-          << " collection(s) from " << databases.size() << " databases in "
+          << " collection(s) from " << databases.size() << " database(s) in "
           << Logger::FIXED(totalTime, 6) << " s total time.";
     }
   }

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -2191,15 +2191,17 @@ void RestoreFeature::start() {
 
     if (_options.importData) {
       LOG_TOPIC("a66e1", INFO, Logger::RESTORE)
-          << "Processed " << _stats.restoredCollections << " collection(s) in "
-          << Logger::FIXED(totalTime, 6) << " s, "
-          << "read " << formatSize(_stats.totalRead) << " from datafiles, "
+          << "Processed " << _stats.restoredCollections
+          << " collection(s) from " << databases.size() << " databases in "
+          << Logger::FIXED(totalTime, 6) << " s total time. Read "
+          << formatSize(_stats.totalRead) << " from datafiles, "
           << "sent " << _stats.totalBatches << " data batch(es) of "
-          << formatSize(_stats.totalSent) << " total size";
+          << formatSize(_stats.totalSent) << " total size.";
     } else if (_options.importStructure) {
       LOG_TOPIC("147ca", INFO, Logger::RESTORE)
-          << "Processed " << _stats.restoredCollections << " collection(s) in "
-          << Logger::FIXED(totalTime, 6) << " s";
+          << "Processed " << _stats.restoredCollections
+          << " collection(s) from " << databases.size() << " databases in "
+          << Logger::FIXED(totalTime, 6) << " s total time.";
     }
   }
 }

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -2192,7 +2192,7 @@ void RestoreFeature::start() {
     if (_options.importData) {
       LOG_TOPIC("a66e1", INFO, Logger::RESTORE)
           << "Processed " << _stats.restoredCollections
-          << " collection(s) from " << databases.size() << " databases in "
+          << " collection(s) from " << databases.size() << " database(s) in "
           << Logger::FIXED(totalTime, 6) << " s total time. Read "
           << formatSize(_stats.totalRead) << " from datafiles, "
           << "sent " << _stats.totalBatches << " data batch(es) of "
@@ -2200,7 +2200,7 @@ void RestoreFeature::start() {
     } else if (_options.importStructure) {
       LOG_TOPIC("147ca", INFO, Logger::RESTORE)
           << "Processed " << _stats.restoredCollections
-          << " collection(s) from " << databases.size() << " databases in "
+          << " collection(s) from " << databases.size() << " database(s) in "
           << Logger::FIXED(totalTime, 6) << " s total time.";
     }
   }


### PR DESCRIPTION
### Scope & Purpose

This PR adds more detail to the log messages that display the total time consumption and total amount of data parsed for the client tools arangodump and arangorestore. 

- [ ] :hankey: Bugfix
- [x] :pizza: New feature (Obs.: don't know how to classify this)
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
No backports required.

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

