### PR TITLE
Use `optimize_filters_for_hits` for documents CF

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Adjust interal RocksDB setting `optimize_filters_for_hits` for Documents
+  column family, setting it from `false` to `true`. This should reduce memory
+  and disk space requirements for the bottom-most .sst files of the documents
+  column family.
+
 * Upgrade VelocyPack library to latest version.
 
 * Slightly improve the explain output of SingleRemoteOperationNodes.

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -717,6 +717,12 @@ rocksdb::ColumnFamilyOptions RocksDBOptionFeature::columnFamilyOptions(
       break;
 
     case RocksDBColumnFamilyManager::Family::Documents:
+      // in the documents column family, it is totally unexpected to not
+      // find a document by local document id. that means even in the lowest
+      // levels we expect to find the document when looking it up.
+      options.optimize_filters_for_hits = true;
+      [[fallthrough]];
+
     case RocksDBColumnFamilyManager::Family::PrimaryIndex:
     case RocksDBColumnFamilyManager::Family::GeoIndex:
     case RocksDBColumnFamilyManager::Family::FulltextIndex:


### PR DESCRIPTION
### Scope & Purpose

* Adjust interal RocksDB setting `optimize_filters_for_hits` for Documents
  column family, setting it from `false` to `true`. This should reduce memory
  and disk space requirements for the bottom-most .sst files of the documents
  column family.

This PR only changes the value of an internal option. There is no need for end-user documentation or backports.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

