### PR TITLE
Harden velocypack validator after fuzz testing

### DIFF
--- a/3rdParty/velocypack/include/velocypack/Slice.h
+++ b/3rdParty/velocypack/include/velocypack/Slice.h
@@ -1197,8 +1197,13 @@ class Slice {
   uint8_t tagsOffset(uint8_t const* start) const noexcept {
     uint8_t ret = 0;
 
-    while(SliceStaticData::TypeMap[*start] == ValueType::Tagged) {
+    while (SliceStaticData::TypeMap[*start] == ValueType::Tagged) {
       uint8_t offset = tagOffset(start);
+      VELOCYPACK_ASSERT(offset != 0);
+      if (VELOCYPACK_UNLIKELY(offset == 0)) {
+        // prevent endless loop
+        break;
+      }
       ret += offset;
       start += offset;
     }
@@ -1272,6 +1277,9 @@ class Slice {
 
       case ValueType::Tagged: {
         uint8_t offset = tagsOffset(start);
+        if (VELOCYPACK_UNLIKELY(offset == 0)) {
+          throw Exception(Exception::InternalError, "Invalid tag data in byteSize()");
+        }
         return byteSize(start + offset) + offset;
       }
 

--- a/3rdParty/velocypack/tests/testsValidator.cpp
+++ b/3rdParty/velocypack/tests/testsValidator.cpp
@@ -1830,6 +1830,34 @@ TEST(ValidatorTest, ArrayCompactNrItemsWrong3) {
   ASSERT_VELOCYPACK_EXCEPTION(validator.validate(value.c_str(), value.size()), Exception::ValidatorInvalidLength);
 }
 
+TEST(ValidatorTest, ArrayCompactNrItemsExceedsBytesize) {
+  std::string const value("\x13\x06\x42\x40\x40\x02", 6);
+
+  Validator validator;
+  ASSERT_VELOCYPACK_EXCEPTION(validator.validate(value.c_str(), value.size()), Exception::ValidatorInvalidLength);
+}
+
+TEST(ValidatorTest, ArrayCompactMemberExceedsBytesize1) {
+  std::string const value("\x13\x06\x43\x40\x40\x02", 6);
+
+  Validator validator;
+  ASSERT_VELOCYPACK_EXCEPTION(validator.validate(value.c_str(), value.size()), Exception::ValidatorInvalidLength);
+}
+
+TEST(ValidatorTest, ArrayCompactMemberExceedsBytesize2) {
+  std::string const value("\x13\x06\x44\x40\x40\x02", 6);
+
+  Validator validator;
+  ASSERT_VELOCYPACK_EXCEPTION(validator.validate(value.c_str(), value.size()), Exception::ValidatorInvalidLength);
+}
+
+TEST(ValidatorTest, ArrayCompactMemberExceedsBytesize3) {
+  std::string const value("\x13\x06\x45\x40\x40\x02", 6);
+
+  Validator validator;
+  ASSERT_VELOCYPACK_EXCEPTION(validator.validate(value.c_str(), value.size()), Exception::ValidatorInvalidLength);
+}
+
 TEST(ValidatorTest, ArrayCompactManyEntries) {
   Builder b;
   b.openArray(true);


### PR DESCRIPTION
### Scope & Purpose

Harden velocypack validator after fuzz testing.
Changes are from upstream https://github.com/arangodb/velocypack/pull/111

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/15661
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/15662
  - [x] Backport for 3.7: https://github.com/arangodb/arangodb/pull/15663

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

