### PR TITLE
[3.8] more consistent rocksdb throttle in compating

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.8.6 (XXXX-XX-XX)
 -------------------
 
+* In an attempt to make the performance of the RocksDB throttle much
+  more consistent and predictable the default compaction slow down
+  trigger is lowered to 128kB.
+
 * Fixed issue #15501: Regression when using "exclusive" query option?
   This fixes a regression in AQL query execution when exclusive locks are used
   for a query and the query also uses the DOCUMENT() AQL function. In this case,

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -144,7 +144,7 @@ RocksDBOptionFeature::RocksDBOptionFeature(application_features::ApplicationServ
       _level0CompactionTrigger(2),
       _level0SlowdownTrigger(16),
       _level0StopTrigger(256),
-      _pendingCompactionBytesSlowdownTrigger(8 * 1073741824ull),
+      _pendingCompactionBytesSlowdownTrigger(128 * 1024ull),
       _pendingCompactionBytesStopTrigger(16 * 1073741824ull),
       _recycleLogFileNum(rocksDBDefaults.recycle_log_file_num),
       _enforceBlockCacheSizeLimit(false),

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -988,6 +988,7 @@ Future<OperationResult> transaction::Methods::insertLocal(std::string const& cna
         case FollowerInfo::WriteState::FORBIDDEN:
           // We cannot fulfill minimum replication Factor. Reject write.
           return OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options);
+        case FollowerInfo::WriteState::UNAVAILABLE:
         case FollowerInfo::WriteState::STARTUP:
           return OperationResult(TRI_ERROR_CLUSTER_BACKEND_UNAVAILABLE, options);
         default:
@@ -1289,6 +1290,7 @@ Future<OperationResult> transaction::Methods::modifyLocal(std::string const& col
         case FollowerInfo::WriteState::FORBIDDEN:
           // We cannot fulfill minimum replication Factor. Reject write.
           return OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options);
+        case FollowerInfo::WriteState::UNAVAILABLE:
         case FollowerInfo::WriteState::STARTUP:
           return OperationResult(TRI_ERROR_CLUSTER_BACKEND_UNAVAILABLE, options);
         default:
@@ -1509,6 +1511,7 @@ Future<OperationResult> transaction::Methods::removeLocal(std::string const& col
         case FollowerInfo::WriteState::FORBIDDEN:
           // We cannot fulfill minimum replication Factor. Reject write.
           return OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options);
+        case FollowerInfo::WriteState::UNAVAILABLE:
         case FollowerInfo::WriteState::STARTUP:
           return OperationResult(TRI_ERROR_CLUSTER_BACKEND_UNAVAILABLE, options);
         default:
@@ -1755,6 +1758,7 @@ Future<OperationResult> transaction::Methods::truncateLocal(std::string const& c
         case FollowerInfo::WriteState::FORBIDDEN:
           // We cannot fulfill minimum replication Factor. Reject write.
           return OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options);
+        case FollowerInfo::WriteState::UNAVAILABLE:
         case FollowerInfo::WriteState::STARTUP:
           return OperationResult(TRI_ERROR_CLUSTER_BACKEND_UNAVAILABLE, options);
         default:

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -988,7 +988,6 @@ Future<OperationResult> transaction::Methods::insertLocal(std::string const& cna
         case FollowerInfo::WriteState::FORBIDDEN:
           // We cannot fulfill minimum replication Factor. Reject write.
           return OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options);
-        case FollowerInfo::WriteState::UNAVAILABLE:
         case FollowerInfo::WriteState::STARTUP:
           return OperationResult(TRI_ERROR_CLUSTER_BACKEND_UNAVAILABLE, options);
         default:
@@ -1290,7 +1289,6 @@ Future<OperationResult> transaction::Methods::modifyLocal(std::string const& col
         case FollowerInfo::WriteState::FORBIDDEN:
           // We cannot fulfill minimum replication Factor. Reject write.
           return OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options);
-        case FollowerInfo::WriteState::UNAVAILABLE:
         case FollowerInfo::WriteState::STARTUP:
           return OperationResult(TRI_ERROR_CLUSTER_BACKEND_UNAVAILABLE, options);
         default:
@@ -1511,7 +1509,6 @@ Future<OperationResult> transaction::Methods::removeLocal(std::string const& col
         case FollowerInfo::WriteState::FORBIDDEN:
           // We cannot fulfill minimum replication Factor. Reject write.
           return OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options);
-        case FollowerInfo::WriteState::UNAVAILABLE:
         case FollowerInfo::WriteState::STARTUP:
           return OperationResult(TRI_ERROR_CLUSTER_BACKEND_UNAVAILABLE, options);
         default:
@@ -1758,7 +1755,6 @@ Future<OperationResult> transaction::Methods::truncateLocal(std::string const& c
         case FollowerInfo::WriteState::FORBIDDEN:
           // We cannot fulfill minimum replication Factor. Reject write.
           return OperationResult(TRI_ERROR_ARANGO_READ_ONLY, options);
-        case FollowerInfo::WriteState::UNAVAILABLE:
         case FollowerInfo::WriteState::STARTUP:
           return OperationResult(TRI_ERROR_CLUSTER_BACKEND_UNAVAILABLE, options);
         default:


### PR DESCRIPTION
### Scope & Purpose

*Consistent RocksDB throttling, when compactions are pending*. The RocksDB throttle is only effective when RocksDB goes into "stall", otherwise it is ignored. Therefore this setting prevents oscillations between "full speed writing" leading to compaction debt, and complete RocksDB stops.

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [X] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

