### PR TITLE
[CINFRA-237] fix graceful leader replacement

### DIFF
--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.cpp
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.cpp
@@ -304,6 +304,8 @@ auto agency::to_string(LogCurrentSupervisionError error) noexcept
   switch (error) {
     case LogCurrentSupervisionError::TARGET_LEADER_INVALID:
       return "the leader selected in target is invalid";
+    case LogCurrentSupervisionError::TARGET_LEADER_EXCLUDED:
+      return "the leader selected in target is excluded";
   }
   LOG_TOPIC("7eee2", FATAL, arangodb::Logger::REPLICATION2)
       << "Invalid LogCurrentSupervisionError "

--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
@@ -137,7 +137,10 @@ auto to_string(LogCurrentSupervisionElection::Outcome) noexcept
 auto toVelocyPack(LogCurrentSupervisionElection::Outcome, VPackBuilder&)
     -> void;
 
-enum class LogCurrentSupervisionError { TARGET_LEADER_INVALID };
+enum class LogCurrentSupervisionError {
+  TARGET_LEADER_INVALID,
+  TARGET_LEADER_EXCLUDED
+};
 
 auto to_string(LogCurrentSupervisionError) noexcept -> std::string_view;
 auto toVelocyPack(LogCurrentSupervisionError, VPackBuilder&) -> void;

--- a/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
+++ b/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
@@ -396,9 +396,8 @@ const replicatedLogSuite = function () {
       setReplicatedLogLeaderTarget(database, logId, newLeader);
 
       // nothing should happen (supervision should not elect leader)
-      waitFor(replicatedLogLeaderElectionFailed(database, logId, term, {
-        [newLeader]: 3,
-      }));
+      const errorCode = 1; // TARGET_LEADER_EXCLUDED
+      waitFor(replicatedLogSupervisionError(database, logId, errorCode));
 
       replicatedLogUpdateTargetParticipants(database, logId, {
         [newLeader]: {excluded: false},
@@ -467,7 +466,6 @@ const replicatedLogSuite = function () {
     // This tests replaces the leader in Target with a new server that has the
     // excluded flag set. It then waits for the replicated log to converge and
     // then removes the excluded flag.
-    /* TODO reenable this test
     testReplaceLeaderWithNewFollower: function () {
       const {logId, servers, term, leader, followers} = createReplicatedLogAndWaitForLeader(database);
 
@@ -496,12 +494,10 @@ const replicatedLogSuite = function () {
       // we expect to have a new leader and the new follower
       waitFor(replicatedLogLeaderEstablished(database, logId, term + 1, [...followers, newServer]));
     },
-    */
 
     // This test replaces the old leader in target with a new server that is excluded
     // and additionally requests that this new server shall become the leader.
     // It expects the supervision to fail and then removes the excluded flag.
-    /* TODO reenable this test
     testChangeLeaderToNewFollower: function () {
       const {logId, servers, term, leader, followers} = createReplicatedLogAndWaitForLeader(database);
 
@@ -537,7 +533,6 @@ const replicatedLogSuite = function () {
       }));
       waitFor(replicatedLogIsReady(database, logId, term + 1, [...followers, newServer], newServer));
     },
-    */
 
     // This tests requests a non-server as leader and expects the
     // supervision to fail


### PR DESCRIPTION
### Scope & Purpose

The log supervision tests were unstable because of an incorrect implementation of graceful leader change; we now select a new leader from the set of participants and dictate leadership again.

Also changes some tests to do what they say on the tin and wait for events correctly.

Does not fix error-reporting yet.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket: https://arangodb.atlassian.net/jira/software/projects/CINFRA/boards/60?selectedIssue=CINFRA-237
- [ ] Design document: 

