### PR TITLE
[CINFRA-239] Detailed global status

### DIFF
--- a/arangod/Agency/AsyncAgencyComm.cpp
+++ b/arangod/Agency/AsyncAgencyComm.cpp
@@ -562,8 +562,11 @@ const char* AGENCY_URL_WRITE = "/_api/agency/write";
 const char* AGENCY_URL_POLL = "/_api/agency/poll";
 
 AsyncAgencyComm::FutureResult AsyncAgencyComm::getValues(
-    std::string const& path) const {
-  return sendTransaction(120s, AgencyReadTransaction(path));
+    std::string const& path, std::optional<network::Timeout> timeout) const {
+  if (!timeout.has_value()) {
+    timeout = 120s;
+  }
+  return sendTransaction(*timeout, AgencyReadTransaction(path));
 }
 
 AsyncAgencyComm::FutureResult AsyncAgencyComm::poll(network::Timeout timeout,
@@ -572,8 +575,12 @@ AsyncAgencyComm::FutureResult AsyncAgencyComm::poll(network::Timeout timeout,
 }
 
 AsyncAgencyComm::FutureReadResult AsyncAgencyComm::getValues(
-    std::shared_ptr<arangodb::cluster::paths::Path const> const& path) const {
-  return sendTransaction(120s, AgencyReadTransaction(path->str()))
+    std::shared_ptr<arangodb::cluster::paths::Path const> const& path,
+    std::optional<network::Timeout> timeout) const {
+  if (!timeout.has_value()) {
+    timeout = 120s;
+  }
+  return sendTransaction(*timeout, AgencyReadTransaction(path->str()))
       .thenValue([path = path](AsyncAgencyCommResult&& result) mutable {
         if (result.ok() && result.statusCode() == fuerte::StatusOK) {
           return futures::makeFuture(

--- a/arangod/Agency/AsyncAgencyComm.cpp
+++ b/arangod/Agency/AsyncAgencyComm.cpp
@@ -458,7 +458,6 @@ AsyncAgencyComm::FutureResult AsyncAgencyComm::sendWithFailover(
 
   fuerte::StringMap params;
   std::string url = fuerte::extractPathParameters(urlIn, params);
-
   return agencyAsyncSend(
              _manager,
              RequestMeta({timeout, method, type, url, std::move(clientIds),
@@ -563,10 +562,7 @@ const char* AGENCY_URL_POLL = "/_api/agency/poll";
 
 AsyncAgencyComm::FutureResult AsyncAgencyComm::getValues(
     std::string const& path, std::optional<network::Timeout> timeout) const {
-  if (!timeout.has_value()) {
-    timeout = 120s;
-  }
-  return sendTransaction(*timeout, AgencyReadTransaction(path));
+  return sendTransaction(timeout.value_or(120s), AgencyReadTransaction(path));
 }
 
 AsyncAgencyComm::FutureResult AsyncAgencyComm::poll(network::Timeout timeout,
@@ -577,10 +573,8 @@ AsyncAgencyComm::FutureResult AsyncAgencyComm::poll(network::Timeout timeout,
 AsyncAgencyComm::FutureReadResult AsyncAgencyComm::getValues(
     std::shared_ptr<arangodb::cluster::paths::Path const> const& path,
     std::optional<network::Timeout> timeout) const {
-  if (!timeout.has_value()) {
-    timeout = 120s;
-  }
-  return sendTransaction(*timeout, AgencyReadTransaction(path->str()))
+  return sendTransaction(timeout.value_or(120s),
+                         AgencyReadTransaction(path->str()))
       .thenValue([path = path](AsyncAgencyCommResult&& result) mutable {
         if (result.ok() && result.statusCode() == fuerte::StatusOK) {
           return futures::makeFuture(

--- a/arangod/Agency/AsyncAgencyComm.h
+++ b/arangod/Agency/AsyncAgencyComm.h
@@ -193,9 +193,12 @@ class AsyncAgencyComm final {
   using FutureResult = arangodb::futures::Future<AsyncAgencyCommResult>;
   using FutureReadResult = arangodb::futures::Future<AgencyReadResult>;
 
-  [[nodiscard]] FutureResult getValues(std::string const& path) const;
+  [[nodiscard]] FutureResult getValues(
+      std::string const& path,
+      std::optional<network::Timeout> timeout = {}) const;
   [[nodiscard]] FutureReadResult getValues(
-      std::shared_ptr<arangodb::cluster::paths::Path const> const& path) const;
+      std::shared_ptr<arangodb::cluster::paths::Path const> const& path,
+      std::optional<network::Timeout> timeout = {}) const;
   [[nodiscard]] FutureResult poll(network::Timeout timeout,
                                   uint64_t index) const;
 

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -6743,6 +6743,26 @@ void ClusterInfo::triggerWaiting(
   }
 }
 
+auto arangodb::ClusterInfo::getReplicatedLogPlanSpecification(
+    DatabaseID const& database, replication2::LogId id) const
+    -> ResultT<
+        std::shared_ptr<replication2::agency::LogPlanSpecification const>> {
+  READ_LOCKER(readLocker, _planProt.lock);
+
+  auto it = _newStuffByDatabase.find(database);
+  if (it == std::end(_newStuffByDatabase)) {
+    return {TRI_ERROR_ARANGO_DATABASE_NOT_FOUND};
+  }
+
+  auto it2 = it->second->replicatedLogs.find(id);
+  if (it2 == std::end(it->second->replicatedLogs)) {
+    return {TRI_ERROR_REPLICATION_REPLICATED_LOG_NOT_FOUND};
+  }
+
+  TRI_ASSERT(it2->second != nullptr);
+  return it2->second;
+}
+
 AnalyzerModificationTransaction::AnalyzerModificationTransaction(
     DatabaseID const& database, ClusterInfo* ci, bool cleanup)
     : _clusterInfo(ci), _database(database), _cleanupTransaction(cleanup) {

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -975,6 +975,15 @@ class ClusterInfo final {
   auto getReplicatedLogLeader(DatabaseID const& database,
                               replication2::LogId) const -> ResultT<ServerID>;
 
+  auto getReplicatedLogParticipants(DatabaseID const& database,
+                                    replication2::LogId) const
+      -> ResultT<std::vector<ServerID>>;
+
+  auto getReplicatedLogPlanSpecification(DatabaseID const& database,
+                                         replication2::LogId) const
+      -> ResultT<
+          std::shared_ptr<replication2::agency::LogPlanSpecification const>>;
+
   /**
    * @brief Lock agency's hot backup with TTL 60 seconds
    *

--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -474,13 +474,12 @@ struct ReplicatedLogMethodsCoordinator final
     AsyncAgencyComm ac;
     using Status = GlobalStatus::SupervisionStatus;
     // TODO move this into the agency methods
-    // TODO reduce timeout to 5s
     auto f = ac.getValues(arangodb::cluster::paths::aliases::current()
                               ->replicatedLogs()
                               ->database(vocbase.name())
                               ->log(id)
                               ->supervision(),
-                          2 * std::chrono::seconds{});
+                          std::chrono::seconds{5});
     return std::move(f).then([self = shared_from_this()](
                                  futures::Try<AgencyReadResult>&& tryResult) {
       auto result =
@@ -514,6 +513,7 @@ struct ReplicatedLogMethodsCoordinator final
     auto path = basics::StringUtils::joinT("/", "_api/log", id, "local-status");
     network::RequestOptions opts;
     opts.database = vocbase.name();
+    opts.timeout = std::chrono::seconds{5};
     return network::sendRequest(pool, "server:" + participant,
                                 fuerte::RestVerb::Get, path, {}, opts)
         .then([self = shared_from_this(), participant](

--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -479,7 +479,8 @@ struct ReplicatedLogMethodsCoordinator final
                               ->replicatedLogs()
                               ->database(vocbase.name())
                               ->log(id)
-                              ->supervision());
+                              ->supervision(),
+                          2 * std::chrono::seconds{});
     return std::move(f).then([self = shared_from_this()](
                                  futures::Try<AgencyReadResult>&& tryResult) {
       auto result =

--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -515,7 +515,7 @@ struct ReplicatedLogMethodsCoordinator final
     opts.database = vocbase.name();
     return network::sendRequest(pool, "server:" + participant,
                                 fuerte::RestVerb::Get, path, {}, opts)
-        .then([self = shared_from_this(), id, participant](
+        .then([self = shared_from_this(), participant](
                   futures::Try<network::Response>&& tryResult) mutable {
           auto result = basics::catchToResultT(
               [&] { return std::move(tryResult.get()); });

--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -516,7 +516,7 @@ struct ReplicatedLogMethodsCoordinator final
     opts.timeout = std::chrono::seconds{5};
     return network::sendRequest(pool, "server:" + participant,
                                 fuerte::RestVerb::Get, path, {}, opts)
-        .then([self = shared_from_this(), participant](
+        .then([](
                   futures::Try<network::Response>&& tryResult) mutable {
           auto result = basics::catchToResultT(
               [&] { return std::move(tryResult.get()); });
@@ -562,7 +562,7 @@ struct ReplicatedLogMethodsCoordinator final
     auto af = readSupervisionStatus(spec->id);
     return futures::collect(std::move(af), std::move(psf))
         .thenValue(
-            [self = shared_from_this(), spec, source](auto&& pairResult) {
+            [spec, source](auto&& pairResult) {
               auto& [agency, participantResults] = pairResult;
 
               auto leader = std::optional<ParticipantId>{};

--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -39,6 +39,7 @@
 #include "VocBase/vocbase.h"
 
 #include "Methods.h"
+#include "Agency/AsyncAgencyComm.h"
 
 using namespace arangodb;
 using namespace arangodb::replication2;
@@ -175,6 +176,7 @@ struct VPackLogIterator final : PersistedLogIterator {
   VPackArrayIterator iter;
   VPackArrayIterator end;
 };
+
 }  // namespace
 
 struct ReplicatedLogMethodsCoordinator final
@@ -219,42 +221,22 @@ struct ReplicatedLogMethodsCoordinator final
 
   auto getGlobalStatus(LogId id) const
       -> futures::Future<replication2::replicated_log::GlobalStatus> override {
-    auto path = basics::StringUtils::joinT("/", "_api/log", id, "local-status");
-    network::RequestOptions opts;
-    opts.database = vocbase.name();
-
-    auto leader = clusterInfo.getReplicatedLogLeader(opts.database, id);
-    if (leader.fail()) {
-      if (leader.is(TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED)) {
-        return GlobalStatus{
-            replication2::agency::methods::getCurrentSupervision(vocbase, id),
-            {},
-            std::nullopt};
-      } else {
-        THROW_ARANGO_EXCEPTION(leader.result());
-      }
-    }
-    auto leaderId = std::move(*leader);
-
-    return network::sendRequest(pool, "server:" + leaderId,
-                                fuerte::RestVerb::Get, path, {}, opts)
-        .thenValue([self = shared_from_this(), id,
-                    leaderId](network::Response&& resp) mutable {
-          if (resp.fail() || !fuerte::statusIsSuccess(resp.statusCode())) {
-            THROW_ARANGO_EXCEPTION(resp.combinedResult());
+    // 1. Determine which source to use for gathering information
+    // 2. Query information from all sources
+    auto source = GlobalStatus::SpecificationSource::kLocalCache;
+    auto futureSpec = loadLogSpecification(vocbase.name(), id, source);
+    return std::move(futureSpec)
+        .thenValue([self = shared_from_this(), source](
+                       ResultT<std::shared_ptr<
+                           replication2::agency::LogPlanSpecification const>>
+                           result) {
+          if (result.fail()) {
+            THROW_ARANGO_EXCEPTION(result.result());
           }
 
-          auto supervision =
-              replication2::agency::methods::getCurrentSupervision(
-                  self->vocbase, id);
-          auto leaderStatus =
-              replication2::replicated_log::LogStatus::fromVelocyPack(
-                  resp.slice().get("result"));
-          auto participants = std::unordered_map<ParticipantId, LogStatus>{
-              {leaderId, std::move(leaderStatus)}};
-          return GlobalStatus{.supervision = std::move(supervision),
-                              .participants = std::move(participants),
-                              .leaderId = std::move(leaderId)};
+          auto const& spec = result.get();
+          TRI_ASSERT(spec != nullptr);
+          return self->collectGlobalStatusUsingSpec(spec, source);
         });
   }
 
@@ -472,6 +454,137 @@ struct ReplicatedLogMethodsCoordinator final
     }
 
     return *leader;
+  }
+
+  auto loadLogSpecification(DatabaseID const& database, replication2::LogId id,
+                            GlobalStatus::SpecificationSource source) const
+      -> futures::Future<ResultT<std::shared_ptr<
+          arangodb::replication2::agency::LogPlanSpecification const>>> {
+    if (source == GlobalStatus::SpecificationSource::kLocalCache) {
+      return clusterInfo.getReplicatedLogPlanSpecification(database, id);
+    } else {
+      return ResultT<std::shared_ptr<
+          arangodb::replication2::agency::LogPlanSpecification const>>::
+          error(TRI_ERROR_NOT_IMPLEMENTED);
+    }
+  }
+
+  auto readSupervisionStatus(replication2::LogId id) const
+      -> futures::Future<GlobalStatus::SupervisionStatus> {
+    AsyncAgencyComm ac;
+    using Status = GlobalStatus::SupervisionStatus;
+    // TODO move this into the agency methods
+    // TODO reduce timeout to 5s
+    auto f = ac.getValues(arangodb::cluster::paths::aliases::current()
+                              ->replicatedLogs()
+                              ->database(vocbase.name())
+                              ->log(id)
+                              ->supervision());
+    return std::move(f).then([self = shared_from_this()](
+                                 futures::Try<AgencyReadResult>&& tryResult) {
+      auto result =
+          basics::catchToResultT([&] { return std::move(tryResult.get()); });
+
+      auto const statusFromResult = [](Result const& res) {
+        return Status{
+            .connection = {.error = res.errorNumber(),
+                           .errorMessage = std::string{res.errorMessage()}},
+            .response = std::nullopt};
+      };
+
+      if (result.fail()) {
+        return statusFromResult(result.result());
+      }
+      auto& read = result.get();
+      auto status = statusFromResult(read.asResult());
+      if (read.ok() && !read.value().isNone()) {
+        status.response.emplace(arangodb::replication2::agency::from_velocypack,
+                                read.value());
+      }
+
+      return status;
+    });
+  }
+
+  auto queryParticipantsStatus(replication2::LogId id,
+                               replication2::ParticipantId const& participant)
+      const -> futures::Future<GlobalStatus::ParticipantStatus> {
+    using Status = GlobalStatus::ParticipantStatus;
+    auto path = basics::StringUtils::joinT("/", "_api/log", id, "local-status");
+    network::RequestOptions opts;
+    opts.database = vocbase.name();
+    return network::sendRequest(pool, "server:" + participant,
+                                fuerte::RestVerb::Get, path, {}, opts)
+        .then([self = shared_from_this(), id, participant](
+                  futures::Try<network::Response>&& tryResult) mutable {
+          auto result = basics::catchToResultT(
+              [&] { return std::move(tryResult.get()); });
+
+          auto const statusFromResult = [](Result const& res) {
+            return Status{
+                .connection = {.error = res.errorNumber(),
+                               .errorMessage = std::string{res.errorMessage()}},
+                .response = std::nullopt};
+          };
+
+          if (result.fail()) {
+            return statusFromResult(result.result());
+          }
+
+          auto& response = result.get();
+          auto status = statusFromResult(response.combinedResult());
+          if (response.combinedResult().ok()) {
+            status.response = GlobalStatus::ParticipantStatus::Response{
+                .value =
+                    replication2::replicated_log::LogStatus::fromVelocyPack(
+                        response.slice().get("result"))};
+          }
+          return status;
+        });
+  }
+
+  auto collectGlobalStatusUsingSpec(
+      std::shared_ptr<replication2::agency::LogPlanSpecification const> spec,
+      GlobalStatus::SpecificationSource source) const
+      -> futures::Future<GlobalStatus> {
+    // send of a request to all participants
+
+    auto psf = std::invoke([&] {
+      auto const& participants = spec->participantsConfig.participants;
+      std::vector<futures::Future<GlobalStatus::ParticipantStatus>> pfs;
+      pfs.reserve(participants.size());
+      for (auto const& [id, flags] : participants) {
+        pfs.emplace_back(queryParticipantsStatus(spec->id, id));
+      }
+      return futures::collectAll(pfs);
+    });
+    auto af = readSupervisionStatus(spec->id);
+    return futures::collect(std::move(af), std::move(psf))
+        .thenValue(
+            [self = shared_from_this(), spec, source](auto&& pairResult) {
+              auto& [agency, participantResults] = pairResult;
+
+              auto leader = std::optional<ParticipantId>{};
+              if (spec->currentTerm && spec->currentTerm->leader) {
+                leader = spec->currentTerm->leader->serverId;
+              }
+              auto participantsMap =
+                  std::unordered_map<ParticipantId,
+                                     GlobalStatus::ParticipantStatus>{};
+
+              auto const& participants = spec->participantsConfig.participants;
+              std::size_t idx = 0;
+              for (auto const& [id, flags] : participants) {
+                auto& result = participantResults.at(idx++);
+                participantsMap[id] = std::move(result.get());
+              }
+
+              return GlobalStatus{
+                  .supervision = agency,
+                  .participants = participantsMap,
+                  .specification = {.source = source, .plan = *spec},
+                  .leaderId = std::move(leader)};
+            });
   }
 
   TRI_vocbase_t& vocbase;

--- a/tests/Replication2/Serialization/LogStatusTest.cpp
+++ b/tests/Replication2/Serialization/LogStatusTest.cpp
@@ -264,16 +264,20 @@ TEST(LogStatusTest, global_status) {
 
   auto participants = std::unordered_map<ParticipantId, LogStatus>{
       {"LeaderId", LogStatus{UnconfiguredStatus{}}}};
-  auto status =
-      GlobalStatus{{{}, supervision},
-                   {{"LeaderId",
-                     GlobalStatus::ParticipantStatus{
-                         .connection = {},
-                         .response =
-                             GlobalStatus::ParticipantStatus::Response{
-                                 .value = LogStatus{UnconfiguredStatus{}}}}}},
-                   {},
-                   "LeaderId"};
+
+  GlobalStatus::SupervisionStatus supervisionStatus{.connection = {},
+                                                    .response = supervision};
+  std::unordered_map<ParticipantId, GlobalStatus::ParticipantStatus>
+      globalStatusParticipants{
+          {"LeaderId",
+           GlobalStatus::ParticipantStatus{
+               .connection = {},
+               .response = GlobalStatus::ParticipantStatus::Response{
+                   .value = LogStatus{UnconfiguredStatus{}}}}}};
+  GlobalStatus status{.supervision = std::move(supervisionStatus),
+                      .participants = std::move(globalStatusParticipants),
+                      .specification = {},
+                      .leaderId = "LeaderId"};
 
   VPackBuilder builder;
   status.toVelocyPack(builder);

--- a/tests/Replication2/Serialization/LogStatusTest.cpp
+++ b/tests/Replication2/Serialization/LogStatusTest.cpp
@@ -265,15 +265,19 @@ TEST(LogStatusTest, global_status) {
   auto participants = std::unordered_map<ParticipantId, LogStatus>{
       {"LeaderId", LogStatus{UnconfiguredStatus{}}}};
 
-  GlobalStatus::SupervisionStatus supervisionStatus{.connection = {},
-                                                    .response = supervision};
+  GlobalStatus::SupervisionStatus supervisionStatus{
+      .connection = {}, .response = std::move(supervision)};
   std::unordered_map<ParticipantId, GlobalStatus::ParticipantStatus>
-      globalStatusParticipants{
-          {"LeaderId",
-           GlobalStatus::ParticipantStatus{
-               .connection = {},
-               .response = GlobalStatus::ParticipantStatus::Response{
-                   .value = LogStatus{UnconfiguredStatus{}}}}}};
+      globalStatusParticipants;
+  {
+    LogStatus responseValue = LogStatus{UnconfiguredStatus{}};
+    GlobalStatus::ParticipantStatus::Response response{
+        .value = std::move(responseValue)};
+    GlobalStatus::ParticipantStatus participantStatus{
+        .connection = {}, .response = std::move(response)};
+    globalStatusParticipants[ParticipantId("LeaderId")] =
+        std::move(participantStatus);
+  }
   GlobalStatus status{.supervision = std::move(supervisionStatus),
                       .participants = std::move(globalStatusParticipants),
                       .specification = {},

--- a/tests/Replication2/Serialization/LogStatusTest.cpp
+++ b/tests/Replication2/Serialization/LogStatusTest.cpp
@@ -264,8 +264,16 @@ TEST(LogStatusTest, global_status) {
 
   auto participants = std::unordered_map<ParticipantId, LogStatus>{
       {"LeaderId", LogStatus{UnconfiguredStatus{}}}};
-  auto status = GlobalStatus{
-      supervision, {{"LeaderId", LogStatus{UnconfiguredStatus{}}}}, "LeaderId"};
+  auto status =
+      GlobalStatus{{{}, supervision},
+                   {{"LeaderId",
+                     GlobalStatus::ParticipantStatus{
+                         .connection = {},
+                         .response =
+                             GlobalStatus::ParticipantStatus::Response{
+                                 .value = LogStatus{UnconfiguredStatus{}}}}}},
+                   {},
+                   "LeaderId"};
 
   VPackBuilder builder;
   status.toVelocyPack(builder);
@@ -273,17 +281,27 @@ TEST(LogStatusTest, global_status) {
 
   auto jsonBuffer = R"({
     "supervision": {
-      "election": {
-        "term": 1,
-        "participantsRequired": 2,
-        "participantsAvailable": 0,
-        "details": {}
+      "connection":{"errorCode":0},
+      "response": {
+        "election": {
+          "term": 1,
+          "participantsRequired": 2,
+          "participantsAvailable": 0,
+          "details": {}
+        }
       }
     },
     "participants": {
       "LeaderId": {
-        "role": "unconfigured"
+        "connection":{"errorCode":0},
+        "response":{
+          "role": "unconfigured"
+        }
       }
+    },
+    "specification":{
+      "plan":{"id":0,"participantsConfig":{"generation":0,"participants":{}}},
+      "source": "LocalCache"
     },
     "leaderId": "LeaderId"
   })"_vpack;

--- a/tests/js/common/shell/shell-replicated-logs-cluster.js
+++ b/tests/js/common/shell/shell-replicated-logs-cluster.js
@@ -31,8 +31,6 @@ const db = arangodb.db;
 const ERRORS = arangodb.errors;
 const database = "replication2_test_db";
 
-let { getServersByType } = require('@arangodb/test-helper');
-
 const getLeaderStatus = function(id) {
   let status = db._replicatedLog(id).status();
   const leaderId = status.leaderId;
@@ -44,11 +42,11 @@ const getLeaderStatus = function(id) {
     console.info(`participants status not available for replicated log ${id}`);
     return null;
   }
-  if (status.participants[leaderId].role !== "leader") {
+  if (status.participants[leaderId].response.role !== "leader") {
     console.info(`leader not available for replicated log ${id}`);
     return null;
   }
-  return status.participants[leaderId];
+  return status.participants[leaderId].response;
 };
 
 const waitForLeader = function (id) {

--- a/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
+++ b/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
@@ -53,7 +53,7 @@ const waitForReplicatedLogAvailable = function (id) {
       let status = db._replicatedLog(id).status();
       const leaderId = status.leaderId;
       if (leaderId !== undefined && status.participants !== undefined &&
-          status.participants[leaderId].role === "leader") {
+          status.participants[leaderId].connection.errorCode === 0 && status.participants[leaderId].response.role === "leader") {
         break;
       }
       console.info("replicated log not yet available");
@@ -593,7 +593,12 @@ const replicatedLogSuite = function () {
           return Error('Designated leader does not report as leader');
         }
 
-        if (!_.isEqual(globalStatus.participants[leader], localStatus)) {
+        const leaderData = globalStatus.participants[leader];
+        if (leaderData.connection.errorCode !== 0) {
+          return Error(`Connection to leader failed: ${leaderData.connection.errorCode} ${leaderData.connection.errorMessage}`);
+        }
+
+        if (!_.isEqual(leaderData.response, localStatus)) {
           return Error("Copy of local status does not yet match actual local status, " +
               `found = ${JSON.stringify(globalStatus.participants[leader])}; expected = ${JSON.stringify(localStatus)}`);
         }
@@ -618,7 +623,12 @@ const replicatedLogSuite = function () {
         const {current} = readReplicatedLogAgency(database, logId);
         const election = current.supervision.election;
 
-        if (!_.isEqual(election, globalStatus.supervision.election)) {
+        const supervisionData = globalStatus.supervision;
+        if (supervisionData.connection.errorCode !== 0) {
+          return Error(`Connection to supervision failed: ${supervisionData.connection.errorCode} ${supervisionData.connection.errorMessage}`);
+        }
+
+        if (!_.isEqual(election, supervisionData.response.election)) {
           return Error('Coordinator not reporting latest state from supervision' +
               `found = ${globalStatus.supervision.election}; expected = ${election}`);
         }


### PR DESCRIPTION
### Scope & Purpose

This PR add more information to the replicated log global status.
- It connects to the agency and queries for `Current/ReplicatedLogs/<db>/<logid>/supervision`.
- It connects to all participants and collects their local log status.
- It uses the local known plan for that. The plan used to gather information is added to the response as well.

## Scope

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**