### PR TITLE
fix potentially dangling references

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix potential access to dangling reference in cancellation of shard
+  synchronization.
+
 * Limited module resolution in arangosh to the path from which arangosh is invoked.
 
 * Fixed BTS-621 Fixed rare case of segfault in cluster during database recovery if DBServer is

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -587,6 +587,7 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
         return tailingSyncer->inheritFromInitialSyncer(syncer);
       });
 
+  /*
   syncer->setAbortionCheckCallback([&]() -> bool {
     // Will return true if the SynchronizeShard job should be aborted.
     auto& agencyCache =
@@ -620,6 +621,7 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
         << " because we are not planned as a follower anymore";
     return true;
   });
+  */
 
   SyncerId syncerId{syncer->syncerId()};
 


### PR DESCRIPTION
### Scope & Purpose

Fix potentially dangling references in cancellation check of shard synchronization.
It is possible that some of the objects passed to the cancellation check lambda by reference are outlived by the cancellation check itself. This can cause undefined behavior when accessing these objects in the cancellation check lambda later.

This PR disables the extra cancellation check for shard synchronization, which was introduced in 3.8.5. The behavior for shard synchronization cancellation with this PR will be the same as in 3.8.4. The cancellation check will be fixed and reactivated with a follow-up PR.

This does not need to be backported to 3.7 as 3.7 did not get the cancellation check changes.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for devel: this PR
  - [x] Backport for 3.9.0: https://github.com/arangodb/arangodb/pull/15676
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/15675
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/15674
  - [x] Backport for 3.8.5: https://github.com/arangodb/arangodb/pull/15677
  - [ ] Backport for 3.7: not affected

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 