### PR TITLE
reintroduce disabled shard synchronisation cancellation check

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.8.6 (XXXX-XX-XX)
 -------------------
 
+* Reintroduce shard synchronization cancellation check that was disabled in
+  3.8.5.
+
 * Fix potential access to dangling reference in cancellation of shard
   synchronization.
 

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1914,7 +1914,6 @@ void Supervision::cleanupHotbackupTransferJobs() {
   arangodb::consensus::cleanupHotbackupTransferJobsFunctional(
       snapshot(), envelope);
   if (envelope->size() > 0) {
-    LOG_DEVEL << "Sending transaction to agency: " << envelope->toJson();
     write_ret_t res = singleWriteTransaction(_agent, *envelope, false);
 
     if (!res.accepted || (res.indices.size() == 1 && res.indices[0] == 0)) {

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -585,10 +585,11 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
     // this saves an HTTP roundtrip to the leader when initializing the WAL tailing.
     return tailingSyncer->inheritFromInitialSyncer(syncer);
   });
+ 
+  auto& agencyCache = job.feature().server().getFeature<ClusterFeature>().agencyCache();
   
-  syncer->setAbortionCheckCallback([&]() -> bool {
+  syncer->setCancellationCheckCallback([=, &agencyCache]() -> bool {
     // Will return true if the SynchronizeShard job should be aborted.
-    auto& agencyCache = job.feature().server().getFeature<ClusterFeature>().agencyCache();
     std::string path = "Plan/Collections/" + database + "/" +
           std::to_string(col->planId().id()) + "/shards/" + col->name();
     VPackBuilder builder;
@@ -596,15 +597,13 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
 
     if (!builder.isEmpty()) {
       VPackSlice plan = builder.slice();
-      if (plan.isArray()) {
-        if (plan.length() >= 2) {
-          if (plan[0].isString() && plan[0].isEqualString(leaderId)) {
-            std::string myself = arangodb::ServerState::instance()->getId();
-            for (size_t i = 1; i < plan.length(); ++i) {
-              if (plan[i].isString() && plan[i].isEqualString(myself)) {
-                // do not abort the synchronization
-                return false;
-              }
+      if (plan.isArray() && plan.length() >= 2) {
+        if (plan[0].isString() && plan[0].isEqualString(leaderId)) {
+          std::string myself = arangodb::ServerState::instance()->getId();
+          for (size_t i = 1; i < plan.length(); ++i) {
+            if (plan[i].isString() && plan[i].isEqualString(myself)) {
+              // do not abort the synchronization
+              return false;
             }
           }
         }

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -368,7 +368,7 @@ DatabaseInitialSyncer::DatabaseInitialSyncer(TRI_vocbase_t& vocbase,
                                              ReplicationApplierConfiguration const& configuration)
     : InitialSyncer(configuration, [this](std::string const& msg) -> void { setProgress(msg); }),
       _config{_state.applier, _batch, _state.connection, false, _state.leader, _progress, _state, vocbase},
-      _lastAbortionCheck(std::chrono::steady_clock::now()),
+      _lastCancellationCheck(std::chrono::steady_clock::now()),
       _isClusterRole(ServerState::instance()->isClusterRole()),
       _quickKeysNumDocsLimit(vocbase.server().getFeature<ReplicationFeature>().quickKeysLimit()) {
   _state.vocbases.try_emplace(vocbase.name(), vocbase);
@@ -541,19 +541,26 @@ bool DatabaseInitialSyncer::isAborted() const {
       return true;
     }
   }
-
-  if (_checkAbortion) {
+  
+  if (_checkCancellation) {
     // execute custom check for abortion only every few seconds, in case
     // it is expensive
+    constexpr auto checkFrequency = std::chrono::seconds(5);
+
     auto now = std::chrono::steady_clock::now();
-    if (now - _lastAbortionCheck >= std::chrono::seconds(5)) {
-      _lastAbortionCheck = now;
-      if (_checkAbortion()) {
+    TRI_IF_FAILURE("Replication::forceCheckCancellation") {
+      // always force the cancellation check!
+      _lastCancellationCheck = now - checkFrequency;
+    }
+
+    if (now - _lastCancellationCheck >= checkFrequency) {
+      _lastCancellationCheck = now;
+      if (_checkCancellation()) {
         return true;
       }
     }
   }
-
+  
   return Syncer::isAborted();
 }
 
@@ -922,9 +929,19 @@ Result DatabaseInitialSyncer::fetchCollectionDump(arangodb::LogicalCollection* c
       // request to the scheduler, which can run it asynchronously
       sharedStatus->request([this, self, baseUrl,
                              sharedStatus, coll, leaderColl, batch, fromTick, chunkSize]() {
+        TRI_IF_FAILURE("Replication::forceCheckCancellation") {
+          // we intentionally sleep here for a while, so the next call gets executed
+          // after the scheduling thread has thrown its TRI_ERROR_INTERNAL exception
+          // for our failure point
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
         fetchDumpChunk(sharedStatus, baseUrl, coll, leaderColl,
                        batch + 1, fromTick, chunkSize);
       });
+      TRI_IF_FAILURE("Replication::forceCheckCancellation") {
+        // forcefully abort replication once we have scheduled the job
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_INTERNAL);
+      }
     }
 
     SingleCollectionTransaction trx(transaction::StandaloneContext::Create(vocbase()),

--- a/arangod/Replication/DatabaseInitialSyncer.h
+++ b/arangod/Replication/DatabaseInitialSyncer.h
@@ -163,8 +163,8 @@ class DatabaseInitialSyncer : public InitialSyncer {
     _onSuccess = cb;
   }
   
-  void setAbortionCheckCallback(std::function<bool()> const& cb) {
-    _checkAbortion = cb;
+  void setCancellationCheckCallback(std::function<bool()> const& cb) {
+    _checkCancellation = cb;
   }
 
  private:
@@ -264,11 +264,11 @@ class DatabaseInitialSyncer : public InitialSyncer {
   // custom callback executed when synchronization was completed successfully
   std::function<Result(DatabaseInitialSyncer&)> _onSuccess;
 
-  // custom callback to check if the sync should be aborted
-  std::function<bool()> _checkAbortion;
+  // custom callback to check if the sync should be cancelled
+  std::function<bool()> _checkCancellation;
 
-  // point in time when we last executed the _checkAbortion callback
-  mutable std::chrono::steady_clock::time_point _lastAbortionCheck;
+  // point in time when we last executed the _checkCancellation callback
+  mutable std::chrono::steady_clock::time_point _lastCancellationCheck;
 
   /// @brief whether or not we are a coordinator/dbserver
   bool const _isClusterRole;


### PR DESCRIPTION
### Scope & Purpose

Reintroduce shard synchronization cancellation check after it was previously disabled.
This PR reintroduces periodic checks during shard synchronization, so that the synchronization on followers is cancelled when the leader is marked as failed by the supervision.
The feature was introduced before in 3.8.5 but had a flaw, so we disabled it there.

The PR contains a new test that triggers the previously problematic code section, which led to issues in the previous version of the cancellation check.
Established that the new code works by running
```
for i in `seq 1 10`; do scripts/unittest shell_client --test tests/js/client/shell/shell-abort-replication-cluster.js  --cluster true; if [[ "x$?" != "x0" ]]; then echo "error!"; break; fi; done
```
No backports for 3.7 are needed, because it doesn't have the cancellation check.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for devel: https://github.com/arangodb/arangodb/pull/15684
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/15683
  - [x] Backport for 3.8: this PR
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

