### PR TITLE
reintroduce disabled shard synchronisation cancellation check

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Reintroduce shard synchronization cancellation check that was disabled
+  before.
+
 * Fix potential access to dangling reference in cancellation of shard
   synchronization.
 

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -587,8 +587,9 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
         return tailingSyncer->inheritFromInitialSyncer(syncer);
       });
 
-  auto& agencyCache = job.feature().server().getFeature<ClusterFeature>().agencyCache();
-  
+  auto& agencyCache =
+      job.feature().server().getFeature<ClusterFeature>().agencyCache();
+
   syncer->setCancellationCheckCallback([=, &agencyCache]() -> bool {
     // Will return true if the SynchronizeShard job should be aborted.
     std::string path = "Plan/Collections/" + database + "/" +
@@ -618,7 +619,6 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
         << " because we are not planned as a follower anymore";
     return true;
   });
-  */
 
   SyncerId syncerId{syncer->syncerId()};
 

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -587,11 +587,10 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
         return tailingSyncer->inheritFromInitialSyncer(syncer);
       });
 
-  /*
-  syncer->setAbortionCheckCallback([&]() -> bool {
+  auto& agencyCache = job.feature().server().getFeature<ClusterFeature>().agencyCache();
+  
+  syncer->setCancellationCheckCallback([=, &agencyCache]() -> bool {
     // Will return true if the SynchronizeShard job should be aborted.
-    auto& agencyCache =
-        job.feature().server().getFeature<ClusterFeature>().agencyCache();
     std::string path = "Plan/Collections/" + database + "/" +
                        std::to_string(col->planId().id()) + "/shards/" +
                        col->name();
@@ -600,15 +599,13 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
 
     if (!builder.isEmpty()) {
       VPackSlice plan = builder.slice();
-      if (plan.isArray()) {
-        if (plan.length() >= 2) {
-          if (plan[0].isString() && plan[0].isEqualString(leaderId)) {
-            std::string myself = arangodb::ServerState::instance()->getId();
-            for (size_t i = 1; i < plan.length(); ++i) {
-              if (plan[i].isString() && plan[i].isEqualString(myself)) {
-                // do not abort the synchronization
-                return false;
-              }
+      if (plan.isArray() && plan.length() >= 2) {
+        if (plan[0].isString() && plan[0].isEqualString(leaderId)) {
+          std::string myself = arangodb::ServerState::instance()->getId();
+          for (size_t i = 1; i < plan.length(); ++i) {
+            if (plan[i].isString() && plan[i].isEqualString(myself)) {
+              // do not abort the synchronization
+              return false;
             }
           }
         }

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -390,7 +390,7 @@ DatabaseInitialSyncer::DatabaseInitialSyncer(
       _config{_state.applier, _batch,        _state.connection,
               false,          _state.leader, _progress,
               _state,         vocbase},
-      _lastAbortionCheck(std::chrono::steady_clock::now()),
+      _lastCancellationCheck(std::chrono::steady_clock::now()),
       _isClusterRole(ServerState::instance()->isClusterRole()),
       _quickKeysNumDocsLimit(
           vocbase.server().getFeature<ReplicationFeature>().quickKeysLimit()) {
@@ -571,19 +571,26 @@ bool DatabaseInitialSyncer::isAborted() const {
       return true;
     }
   }
-
-  if (_checkAbortion) {
+  
+  if (_checkCancellation) {
     // execute custom check for abortion only every few seconds, in case
     // it is expensive
+    constexpr auto checkFrequency = std::chrono::seconds(5);
+
     auto now = std::chrono::steady_clock::now();
-    if (now - _lastAbortionCheck >= std::chrono::seconds(5)) {
-      _lastAbortionCheck = now;
-      if (_checkAbortion()) {
+    TRI_IF_FAILURE("Replication::forceCheckCancellation") {
+      // always force the cancellation check!
+      _lastCancellationCheck = now - checkFrequency;
+    }
+
+    if (now - _lastCancellationCheck >= checkFrequency) {
+      _lastCancellationCheck = now;
+      if (_checkCancellation()) {
         return true;
       }
     }
   }
-
+  
   return Syncer::isAborted();
 }
 
@@ -1021,9 +1028,19 @@ Result DatabaseInitialSyncer::fetchCollectionDump(
       // request to the scheduler, which can run it asynchronously
       sharedStatus->request([this, self, baseUrl, sharedStatus, coll,
                              leaderColl, batch, fromTick, chunkSize]() {
+        TRI_IF_FAILURE("Replication::forceCheckCancellation") {
+          // we intentionally sleep here for a while, so the next call gets executed
+          // after the scheduling thread has thrown its TRI_ERROR_INTERNAL exception
+          // for our failure point
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
         fetchDumpChunk(sharedStatus, baseUrl, coll, leaderColl, batch + 1,
                        fromTick, chunkSize);
       });
+      TRI_IF_FAILURE("Replication::forceCheckCancellation") {
+        // forcefully abort replication once we have scheduled the job
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_INTERNAL);
+      }
     }
 
     SingleCollectionTransaction trx(

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -571,7 +571,7 @@ bool DatabaseInitialSyncer::isAborted() const {
       return true;
     }
   }
-  
+
   if (_checkCancellation) {
     // execute custom check for abortion only every few seconds, in case
     // it is expensive
@@ -590,7 +590,7 @@ bool DatabaseInitialSyncer::isAborted() const {
       }
     }
   }
-  
+
   return Syncer::isAborted();
 }
 
@@ -1029,9 +1029,9 @@ Result DatabaseInitialSyncer::fetchCollectionDump(
       sharedStatus->request([this, self, baseUrl, sharedStatus, coll,
                              leaderColl, batch, fromTick, chunkSize]() {
         TRI_IF_FAILURE("Replication::forceCheckCancellation") {
-          // we intentionally sleep here for a while, so the next call gets executed
-          // after the scheduling thread has thrown its TRI_ERROR_INTERNAL exception
-          // for our failure point
+          // we intentionally sleep here for a while, so the next call gets
+          // executed after the scheduling thread has thrown its
+          // TRI_ERROR_INTERNAL exception for our failure point
           std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
         fetchDumpChunk(sharedStatus, baseUrl, coll, leaderColl, batch + 1,

--- a/arangod/Replication/DatabaseInitialSyncer.h
+++ b/arangod/Replication/DatabaseInitialSyncer.h
@@ -168,8 +168,8 @@ class DatabaseInitialSyncer : public InitialSyncer {
     _onSuccess = cb;
   }
 
-  void setAbortionCheckCallback(std::function<bool()> const& cb) {
-    _checkAbortion = cb;
+  void setCancellationCheckCallback(std::function<bool()> const& cb) {
+    _checkCancellation = cb;
   }
 
  private:
@@ -278,11 +278,11 @@ class DatabaseInitialSyncer : public InitialSyncer {
   // custom callback executed when synchronization was completed successfully
   std::function<Result(DatabaseInitialSyncer&)> _onSuccess;
 
-  // custom callback to check if the sync should be aborted
-  std::function<bool()> _checkAbortion;
+  // custom callback to check if the sync should be cancelled
+  std::function<bool()> _checkCancellation;
 
-  // point in time when we last executed the _checkAbortion callback
-  mutable std::chrono::steady_clock::time_point _lastAbortionCheck;
+  // point in time when we last executed the _checkCancellation callback
+  mutable std::chrono::steady_clock::time_point _lastCancellationCheck;
 
   /// @brief whether or not we are a coordinator/dbserver
   bool const _isClusterRole;


### PR DESCRIPTION
### Scope & Purpose

Reintroduce shard synchronization cancellation check after it was previously disabled.
This PR reintroduces periodic checks during shard synchronization, so that the synchronization on followers is cancelled when the leader is marked as failed by the supervision.
The feature was introduced before in 3.8.5 but had a flaw, so we disabled it there.

The PR contains a new test that triggers the previously problematic code section, which led to issues in the previous version of the cancellation check.
Established that the new code works by running
```
for i in `seq 1 10`; do scripts/unittest shell_client --test tests/js/client/shell/shell-abort-replication-cluster.js  --cluster true; if [[ "x$?" != "x0" ]]; then echo "error!"; break; fi; done
```
No backports for 3.7 are needed, because it doesn't have the cancellation check.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for devel: this PR
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/15683
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/15681
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 