### PR TITLE
[CINFRA-249] Replicated Maintenance Actions Fast Track

### DIFF
--- a/arangod/Cluster/UpdateReplicatedLogAction.cpp
+++ b/arangod/Cluster/UpdateReplicatedLogAction.cpp
@@ -120,4 +120,6 @@ bool arangodb::maintenance::UpdateReplicatedLogAction::first() {
 arangodb::maintenance::UpdateReplicatedLogAction::UpdateReplicatedLogAction(
     arangodb::MaintenanceFeature& mf,
     arangodb::maintenance::ActionDescription const& desc)
-    : ActionBase(mf, desc) {}
+    : ActionBase(mf, desc) {
+  _labels.emplace(FAST_TRACK);
+}

--- a/arangod/Cluster/UpdateReplicatedStateAction.cpp
+++ b/arangod/Cluster/UpdateReplicatedStateAction.cpp
@@ -114,4 +114,6 @@ bool arangodb::maintenance::UpdateReplicatedStateAction::first() {
 arangodb::maintenance::UpdateReplicatedStateAction::UpdateReplicatedStateAction(
     arangodb::MaintenanceFeature& mf,
     arangodb::maintenance::ActionDescription const& desc)
-    : ActionBase(mf, desc) {}
+    : ActionBase(mf, desc) {
+  _labels.emplace(FAST_TRACK);
+}

--- a/js/server/modules/@arangodb/testutils/replicated-logs-helper.js
+++ b/js/server/modules/@arangodb/testutils/replicated-logs-helper.js
@@ -29,7 +29,7 @@ const request = require('@arangodb/request');
 const arangodb = require('@arangodb');
 const ArangoError = arangodb.ArangoError;
 
-const waitFor = function (checkFn, maxTries = 100) {
+const waitFor = function (checkFn, maxTries = 240) {
   let count = 0;
   let result = null;
   while (count < maxTries) {
@@ -37,12 +37,14 @@ const waitFor = function (checkFn, maxTries = 100) {
     if (result === true || result === undefined) {
       return result;
     }
-    console.log(result);
     if (!(result instanceof Error)) {
       throw Error("expected error");
     }
     count += 1;
-    wait(0.5);
+    if (count % 10 === 0) {
+      console.log(result);
+    }
+    wait(0.5); // 240 * .5s = 2 minutes
   }
   throw result;
 };


### PR DESCRIPTION
### Scope & Purpose
This PR tries to fix a timeout in Jenkins:
1. Put the Replicated Log/State actions on the fast track. Otherwise it can happen that they are executed after SynchronizeShard actions. This leads to timeouts in the test.
2. Increase the test timeout to two minutes. Jenkins is not a realtime system.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
