### PR TITLE
Refactor/improve prepend in path results

### DIFF
--- a/arangod/Graph/Enumerators/OneSidedEnumerator.h
+++ b/arangod/Graph/Enumerators/OneSidedEnumerator.h
@@ -31,7 +31,7 @@
 #include "Aql/TraversalStats.h"
 #include "Graph/Enumerators/OneSidedEnumeratorInterface.h"
 #include "Graph/Options/OneSidedEnumeratorOptions.h"
-#include "Graph/PathManagement/SingleProviderPathResult.h"
+#include "Graph/PathManagement/SingleSidedPathResult.h"
 #include "Transaction/Methods.h"
 
 #include <set>
@@ -59,7 +59,7 @@ class OneSidedEnumerator : public TraversalEnumerator {
   using Provider = typename Configuration::Provider;
   using Store = typename Configuration::Store;
 
-  using ResultPathType = SingleProviderPathResult<Provider, Store, Step>;
+  using ResultPathType = SingleSidedPathResult<Provider, Store, Step>;
 
  private:
   using VertexRef = arangodb::velocypack::HashedStringRef;

--- a/arangod/Graph/PathManagement/PathStoreTracer.cpp
+++ b/arangod/Graph/PathManagement/PathStoreTracer.cpp
@@ -28,7 +28,7 @@
 #include "Logger/LogMacros.h"
 
 #include "Graph/PathManagement/PathStore.h"
-#include "Graph/PathManagement/SingleProviderPathResult.h"
+#include "Graph/PathManagement/SingleSidedPathResult.h"
 #include "Graph/Providers/ClusterProvider.h"
 #include "Graph/Providers/ProviderTracer.h"
 #include "Graph/Providers/SingleServerProvider.h"

--- a/arangod/Graph/PathManagement/PathValidator.cpp
+++ b/arangod/Graph/PathManagement/PathValidator.cpp
@@ -30,7 +30,7 @@
 #include "Graph/Providers/ClusterProvider.h"
 #include "Graph/Providers/ProviderTracer.h"
 #include "Graph/Providers/SingleServerProvider.h"
-#include "Graph/PathManagement/SingleProviderPathResult.h"
+#include "Graph/PathManagement/SingleSidedPathResult.h"
 #include "Graph/Steps/SingleServerProviderStep.h"
 #include "Graph/Types/ValidationResult.h"
 
@@ -250,7 +250,7 @@ auto PathValidator<ProviderType, PathStore, vertexUniqueness, edgeUniqueness>::
       if (std::is_same_v<ProviderType,
                          SingleServerProvider<SingleServerProviderStep>>) {
         using ResultPathType =
-            SingleProviderPathResult<ProviderType, PathStore, Step>;
+            SingleSidedPathResult<ProviderType, PathStore, Step>;
         std::unique_ptr<PathResultInterface> currentPath =
             std::make_unique<ResultPathType>(step, _provider, _store);
         currentPath->toVelocyPack(pathBuilder);

--- a/arangod/Graph/PathManagement/PathValidatorTracer.cpp
+++ b/arangod/Graph/PathManagement/PathValidatorTracer.cpp
@@ -30,7 +30,7 @@
 #include "Graph/Providers/ClusterProvider.h"
 #include "Graph/Providers/ProviderTracer.h"
 #include "Graph/Providers/SingleServerProvider.h"
-#include "Graph/PathManagement/SingleProviderPathResult.h"
+#include "Graph/PathManagement/SingleSidedPathResult.h"
 #include "Graph/Steps/SingleServerProviderStep.h"
 #include "Graph/Types/ValidationResult.h"
 

--- a/arangod/Graph/PathManagement/SingleProviderPathResult.cpp
+++ b/arangod/Graph/PathManagement/SingleProviderPathResult.cpp
@@ -22,7 +22,7 @@
 /// @author Heiko Kernbach
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "SingleProviderPathResult.h"
+#include "SingleSidedPathResult.h"
 #include "Basics/StaticStrings.h"
 
 #include "Graph/PathManagement/PathStore.h"
@@ -47,51 +47,48 @@ class SmartGraphStep;
 }  // namespace arangodb::graph::enterprise
 
 template<class ProviderType, class PathStoreType, class Step>
-SingleProviderPathResult<ProviderType, PathStoreType,
-                         Step>::SingleProviderPathResult(Step step,
-                                                         ProviderType& provider,
-                                                         PathStoreType& store)
+SingleSidedPathResult<ProviderType, PathStoreType, Step>::SingleSidedPathResult(
+    Step step, ProviderType& provider, PathStoreType& store)
     : _step(std::move(step)), _provider(provider), _store(store) {}
 
 template<class ProviderType, class PathStoreType, class Step>
-auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::clear()
-    -> void {
+auto SingleSidedPathResult<ProviderType, PathStoreType, Step>::clear() -> void {
   _vertices.clear();
   _edges.clear();
 }
 
 template<class ProviderType, class PathStoreType, class Step>
-auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::appendVertex(
+auto SingleSidedPathResult<ProviderType, PathStoreType, Step>::appendVertex(
     typename Step::Vertex v) -> void {
   _vertices.push_back(std::move(v));
 }
 
 template<class ProviderType, class PathStoreType, class Step>
-auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::prependVertex(
+auto SingleSidedPathResult<ProviderType, PathStoreType, Step>::prependVertex(
     typename Step::Vertex v) -> void {
   _vertices.insert(_vertices.begin(), std::move(v));
 }
 
 template<class ProviderType, class PathStoreType, class Step>
-auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::prependWeight(
+auto SingleSidedPathResult<ProviderType, PathStoreType, Step>::prependWeight(
     double weight) -> void {
   _weights.insert(_weights.begin(), weight);
 }
 
 template<class ProviderType, class PathStoreType, class Step>
-auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::appendEdge(
+auto SingleSidedPathResult<ProviderType, PathStoreType, Step>::appendEdge(
     typename Step::Edge e) -> void {
   _edges.push_back(std::move(e));
 }
 
 template<class ProviderType, class PathStoreType, class Step>
-auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::prependEdge(
+auto SingleSidedPathResult<ProviderType, PathStoreType, Step>::prependEdge(
     typename Step::Edge e) -> void {
   _edges.insert(_edges.begin(), std::move(e));
 }
 
 template<class ProviderType, class PathStoreType, class Step>
-auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::populatePath()
+auto SingleSidedPathResult<ProviderType, PathStoreType, Step>::populatePath()
     -> void {
   _store.visitReversePath(_step, [&](Step const& s) -> bool {
     prependVertex(s.getVertex());
@@ -106,7 +103,7 @@ auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::populatePath()
 }
 
 template<class ProviderType, class PathStoreType, class Step>
-auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::
+auto SingleSidedPathResult<ProviderType, PathStoreType, Step>::
     verticesToVelocyPack(arangodb::velocypack::Builder& builder) -> void {
   TRI_ASSERT(builder.isOpenObject());
   {
@@ -120,7 +117,7 @@ auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::
 }
 
 template<class ProviderType, class PathStoreType, class Step>
-auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::
+auto SingleSidedPathResult<ProviderType, PathStoreType, Step>::
     edgesToVelocyPack(arangodb::velocypack::Builder& builder) -> void {
   TRI_ASSERT(builder.isOpenObject());
   {
@@ -134,7 +131,7 @@ auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::
 }
 
 template<class ProviderType, class PathStoreType, class Step>
-auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::
+auto SingleSidedPathResult<ProviderType, PathStoreType, Step>::
     weightsToVelocyPack(velocypack::Builder& builder) -> void {
   TRI_ASSERT(builder.isOpenObject());
   {
@@ -148,7 +145,7 @@ auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::
 }
 
 template<class ProviderType, class PathStoreType, class Step>
-auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::toVelocyPack(
+auto SingleSidedPathResult<ProviderType, PathStoreType, Step>::toVelocyPack(
     arangodb::velocypack::Builder& builder) -> void {
   if (_vertices.empty()) {
     populatePath();
@@ -160,14 +157,14 @@ auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::toVelocyPack(
 }
 
 template<class ProviderType, class PathStoreType, class Step>
-auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::
+auto SingleSidedPathResult<ProviderType, PathStoreType, Step>::
     lastVertexToVelocyPack(arangodb::velocypack::Builder& builder) -> void {
   TRI_ASSERT(!_step.getVertex().getID().empty());
   _provider.addVertexToBuilder(_step.getVertex(), builder);
 }
 
 template<class ProviderType, class PathStoreType, class Step>
-auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::
+auto SingleSidedPathResult<ProviderType, PathStoreType, Step>::
     lastEdgeToVelocyPack(arangodb::velocypack::Builder& builder) -> void {
   if (_step.isFirst()) {
     builder.add(VPackSlice::nullSlice());
@@ -178,20 +175,20 @@ auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::
 }
 
 template<class ProviderType, class PathStoreType, class Step>
-auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::isEmpty()
-    const -> bool {
+auto SingleSidedPathResult<ProviderType, PathStoreType, Step>::isEmpty() const
+    -> bool {
   return false;
 }
 
 /* SingleServerProvider Section */
 using SingleServerProviderStep = ::arangodb::graph::SingleServerProviderStep;
 
-template class ::arangodb::graph::SingleProviderPathResult<
+template class ::arangodb::graph::SingleSidedPathResult<
     ::arangodb::graph::SingleServerProvider<SingleServerProviderStep>,
     ::arangodb::graph::PathStore<SingleServerProviderStep>,
     SingleServerProviderStep>;
 
-template class ::arangodb::graph::SingleProviderPathResult<
+template class ::arangodb::graph::SingleSidedPathResult<
     ::arangodb::graph::ProviderTracer<
         ::arangodb::graph::SingleServerProvider<SingleServerProviderStep>>,
     ::arangodb::graph::PathStoreTracer<
@@ -199,12 +196,12 @@ template class ::arangodb::graph::SingleProviderPathResult<
     SingleServerProviderStep>;
 
 #ifdef USE_ENTERPRISE
-template class ::arangodb::graph::SingleProviderPathResult<
+template class ::arangodb::graph::SingleSidedPathResult<
     ::arangodb::graph::SingleServerProvider<enterprise::SmartGraphStep>,
     ::arangodb::graph::PathStore<enterprise::SmartGraphStep>,
     enterprise::SmartGraphStep>;
 
-template class ::arangodb::graph::SingleProviderPathResult<
+template class ::arangodb::graph::SingleSidedPathResult<
     ::arangodb::graph::ProviderTracer<
         ::arangodb::graph::SingleServerProvider<enterprise::SmartGraphStep>>,
     ::arangodb::graph::PathStoreTracer<
@@ -214,12 +211,12 @@ template class ::arangodb::graph::SingleProviderPathResult<
 
 // TODO: check if cluster is needed here
 /* ClusterProvider Section */
-template class ::arangodb::graph::SingleProviderPathResult<
+template class ::arangodb::graph::SingleSidedPathResult<
     ::arangodb::graph::ClusterProvider<ClusterProviderStep>,
     ::arangodb::graph::PathStore<::arangodb::graph::ClusterProviderStep>,
     ::arangodb::graph::ClusterProviderStep>;
 
-template class ::arangodb::graph::SingleProviderPathResult<
+template class ::arangodb::graph::SingleSidedPathResult<
     ::arangodb::graph::ProviderTracer<
         ::arangodb::graph::ClusterProvider<ClusterProviderStep>>,
     ::arangodb::graph::PathStoreTracer<

--- a/arangod/Graph/PathManagement/SingleSidedPathResult.h
+++ b/arangod/Graph/PathManagement/SingleSidedPathResult.h
@@ -43,10 +43,10 @@ class Builder;
 namespace graph {
 
 template<class ProviderType, class PathStoreType, class Step>
-class SingleProviderPathResult : public PathResultInterface {
+class SingleSidedPathResult : public PathResultInterface {
  public:
-  SingleProviderPathResult(Step step, ProviderType& provider,
-                           PathStoreType& store);
+  SingleSidedPathResult(Step step, ProviderType& provider,
+                        PathStoreType& store);
   auto clear() -> void;
 
   // Writing the full path to VelocyPack

--- a/arangod/Graph/Steps/ClusterProviderStep.h
+++ b/arangod/Graph/Steps/ClusterProviderStep.h
@@ -12,7 +12,7 @@ class ClusterProvider;
 class ClusterProviderStep
     : public arangodb::graph::BaseStep<ClusterProviderStep> {
  public:
-  using EdgeType = EdgeType;
+  using EdgeType = ::arangodb::graph::EdgeType;
   friend ClusterProvider<ClusterProviderStep>;
 
   class Vertex {

--- a/tests/Graph/GraphMockProviderInstances.cpp
+++ b/tests/Graph/GraphMockProviderInstances.cpp
@@ -43,11 +43,11 @@ using namespace ::arangodb::tests::graph;
 template class ::arangodb::graph::PathResult<MockGraphProvider,
                                              MockGraphProvider::Step>;
 
-template class ::arangodb::graph::SingleProviderPathResult<
+template class ::arangodb::graph::SingleSidedPathResult<
     MockGraphProvider, PathStore<MockGraphProvider::Step>,
     MockGraphProvider::Step>;
 
-template class ::arangodb::graph::SingleProviderPathResult<
+template class ::arangodb::graph::SingleSidedPathResult<
     MockGraphProvider, PathStoreTracer<PathStore<MockGraphProvider::Step>>,
     MockGraphProvider::Step>;
 


### PR DESCRIPTION
### Scope & Purpose

In PathResult, splitted vector `_vertices` into `_sourceVertices` and `_targetVertices` to avoid pushing new vertices of a path at the beginning of the vector. PathResult now inherits from PathResultInterface. Renamed SingleServerProviderPathResult to SigleSidedPathResult

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement (not measured)
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

