### PR TITLE
--cluster.max-number-of-move-shards introduced in 3.9.0

### DIFF
--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -275,7 +275,7 @@ void ClusterFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                   arangodb::options::makeFlags(
                       arangodb::options::Flags::DefaultNoComponents,
                       arangodb::options::Flags::OnCoordinator))
-      .setIntroducedIn(31000);
+      .setIntroducedIn(30900);
 }
 
 void ClusterFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {


### PR DESCRIPTION
was backported via #15155