### PR TITLE
remove unused `_allowPartialIndex` attribute

### DIFF
--- a/arangod/RocksDBEngine/RocksDBVPackIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.h
@@ -235,9 +235,6 @@ class RocksDBVPackIndex : public RocksDBIndex {
   /// @brief whether or not array indexes will de-duplicate their input values
   bool _deduplicate;
 
-  /// @brief whether or not partial indexing is allowed
-  bool _allowPartialIndex;
-
   /// @brief whether or not we want to have estimates
   bool _estimates;
 


### PR DESCRIPTION
### Scope & Purpose

Remove unused `_allowPartialIndex` attribute, make `_format` instance variable const.
This is an internal code cleanup. It doesn't change behavior or adds new functionality. No documentation needed. No backports are planned.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

