### PR TITLE
[CINFRA-128] Spearhead.term to big

### DIFF
--- a/arangod/Replication2/ReplicatedLog/LogFollower.h
+++ b/arangod/Replication2/ReplicatedLog/LogFollower.h
@@ -44,14 +44,15 @@ namespace arangodb::replication2::replicated_log {
 /**
  * @brief Follower instance of a replicated log.
  */
-class LogFollower final : public ILogFollower,
-                          public std::enable_shared_from_this<LogFollower> {
+class LogFollower : public ILogFollower,
+                    public std::enable_shared_from_this<LogFollower> {
  public:
   ~LogFollower() override;
-  LogFollower(LoggerContext const&,
-              std::shared_ptr<ReplicatedLogMetrics> logMetrics,
-              ParticipantId id, std::unique_ptr<LogCore> logCore, LogTerm term,
-              std::optional<ParticipantId> leaderId, InMemoryLog inMemoryLog);
+  static auto construct(LoggerContext const&,
+                        std::shared_ptr<ReplicatedLogMetrics> logMetrics,
+                        ParticipantId id, std::unique_ptr<LogCore> logCore,
+                        LogTerm term, std::optional<ParticipantId> leaderId)
+      -> std::shared_ptr<LogFollower>;
 
   // follower only
   [[nodiscard]] auto appendEntries(AppendEntriesRequest)
@@ -81,6 +82,11 @@ class LogFollower final : public ILogFollower,
   auto waitForLeaderAcked() -> WaitForFuture override;
 
  private:
+  LogFollower(LoggerContext const&,
+              std::shared_ptr<ReplicatedLogMetrics> logMetrics,
+              ParticipantId id, std::unique_ptr<LogCore> logCore, LogTerm term,
+              std::optional<ParticipantId> leaderId, InMemoryLog inMemoryLog);
+
   struct GuardedFollowerData {
     GuardedFollowerData() = delete;
     GuardedFollowerData(LogFollower const& self,

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -333,7 +333,7 @@ auto replicated_log::LogLeader::construct(
     LOG_CTX("8ed2f", FATAL, logContext)
         << "Failed to construct log leader. Current term is " << term
         << " but spearhead is already at " << lastIndex.term;
-    FATAL_ERROR_EXIT(); // This must never happen in production
+    FATAL_ERROR_EXIT();  // This must never happen in production
   }
 
   // Note that although we add an entry to establish our leadership

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -329,7 +329,12 @@ auto replicated_log::LogLeader::construct(
   // if this assertion triggers there is an entry present in the log
   // that has the current term. Did create a different leader with the same term
   // in your test?
-  TRI_ASSERT(lastIndex.term != term);
+  if (lastIndex.term >= term) {
+    LOG_CTX("8ed2f", FATAL, logContext)
+        << "Failed to construct log leader. Current term is " << term
+        << " but spearhead is already at " << lastIndex.term;
+    FATAL_ERROR_EXIT(); // This must never happen in production
+  }
 
   // Note that although we add an entry to establish our leadership
   // we do still want to use the unchanged lastIndex to initialize

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLog.cpp
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLog.cpp
@@ -112,10 +112,10 @@ auto replicated_log::ReplicatedLog::becomeFollower(
     LOG_CTX("1ed24", DEBUG, _logContext)
         << "becoming follower in term " << term << " with leader "
         << leaderId.value_or("<none>");
-    auto log = InMemoryLog::loadFromLogCore(*logCore);
-    auto follower = std::make_shared<LogFollower>(
-        _logContext, _metrics, std::move(id), std::move(logCore), term,
-        std::move(leaderId), log);
+
+    auto follower =
+        LogFollower::construct(_logContext, _metrics, std::move(id),
+                               std::move(logCore), term, std::move(leaderId));
     _participant = std::static_pointer_cast<ILogParticipant>(follower);
     _metrics->replicatedLogStartedFollowingNumber->operator++();
     return std::make_tuple(follower, std::move(deferred));

--- a/tests/Replication2/Mocks/FakeReplicatedLog.h
+++ b/tests/Replication2/Mocks/FakeReplicatedLog.h
@@ -49,11 +49,9 @@ struct DelayedFollowerLog : replicated_log::AbstractFollower,
                      std::unique_ptr<replicated_log::LogCore> logCore,
                      LogTerm term, ParticipantId leaderId)
       : DelayedFollowerLog([&] {
-          auto inMemoryLog =
-              replicated_log::InMemoryLog::loadFromLogCore(*logCore);
-          return std::make_shared<replicated_log::LogFollower>(
+          return replicated_log::LogFollower::construct(
               logContext, std::move(logMetricsMock), id, std::move(logCore),
-              term, std::move(leaderId), std::move(inMemoryLog));
+              term, std::move(leaderId));
         }()) {}
 
   auto appendEntries(replicated_log::AppendEntriesRequest req)


### PR DESCRIPTION
### Scope & Purpose
Instead of an assertion it is now a fatal error if the spearheads term is bigger than the current term. If this happens in production there is no way to continue. https://arangodb.atlassian.net/browse/CINFRA-128

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [x] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
