### PR TITLE
[CINFRA-257] Test Error due to Plan update

### DIFF
--- a/tests/js/server/replication2/replication2-replicated-log-entry-cluster.js
+++ b/tests/js/server/replication2/replication2-replicated-log-entry-cluster.js
@@ -87,6 +87,8 @@ const replicatedLogEntrySuite = function () {
 
   return {
     setUpAll, tearDownAll,
+    setUp: lh.registerAgencyTestBegin,
+    tearDown: lh.registerAgencyTestEnd,
 
     testCheckFirstIndexOfTermEntry: function () {
       const {logId, leader, servers} = lh.createReplicatedLog(database, targetConfig);
@@ -107,11 +109,11 @@ const replicatedLogEntrySuite = function () {
     },
 
     testCheckUpdateParticipantsConfig: function () {
-      const {logId, leader, servers, followers} = lh.createReplicatedLog(database, targetConfig);
+      const {logId, servers, followers} = lh.createReplicatedLog(database, targetConfig);
       waitForReplicatedLogAvailable(logId);
       const follower = _.sample(followers);
 
-      lh.replicatedLogUpdatePlanParticipantsConfigParticipants(database, logId, {
+      lh.replicatedLogUpdateTargetParticipants(database, logId, {
         [follower]: {forced: true},
       });
       lh.waitFor(lh.replicatedLogParticipantsFlag(database, logId, {


### PR DESCRIPTION
### Scope & Purpose

The test in question updated plan, instead of Target. This introduced a race, between the test finishing and the supervision detecting the difference between Target and Plan. If the supervision is faster, the test will see 3 log entries instead of two.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
