### PR TITLE
[3.8] debug logging for rocksdb stall events only

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.8.6 (XXXX-XX-XX)
 -------------------
 
+* As we are now in constant stall regime, stall onset and warnings are
+  demoted to DEBUG.
+
 * Fixed BTS-621: Fixed rare case of segfault in cluster during database recovery
   if DBServer is in upgrade mode in the same time.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.8.6 (XXXX-XX-XX)
 -------------------
 
-* As we are now in constant stall regime, stall onset and warnings are
-  demoted to DEBUG.
+* As we are now in constant stall regime, stall onset and warnings are demoted
+  to DEBUG.
 
 * Fixed BTS-621: Fixed rare case of segfault in cluster during database recovery
   if DBServer is in upgrade mode in the same time.

--- a/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
@@ -46,7 +46,7 @@ void RocksDBMetricsListener::OnStallConditionsChanged(const rocksdb::WriteStallI
 
   if (info.condition.cur == rocksdb::WriteStallCondition::kDelayed) {
     _writeStalls.count();
-    LOG_TOPIC("9123c", WARN, Logger::ENGINES)
+    LOG_TOPIC("9123c", DEBUG, Logger::ENGINES)
         << "rocksdb is slowing incoming writes to column family '"
         << info.cf_name << "' to let background writes catch up";
   } else if (info.condition.cur == rocksdb::WriteStallCondition::kStopped) {
@@ -56,9 +56,15 @@ void RocksDBMetricsListener::OnStallConditionsChanged(const rocksdb::WriteStallI
         << info.cf_name << "' to let background writes catch up";
   } else {
     TRI_ASSERT(info.condition.cur == rocksdb::WriteStallCondition::kNormal);
-    LOG_TOPIC("9123e", INFO, Logger::ENGINES)
-        << "rocksdb is resuming normal writes for column family '"
+    if (info.condition.prev == rocksdb::WriteStallCondition::kStopped) {
+      LOG_TOPIC("9123e", INFO, Logger::ENGINES)
+        << "rocksdb is resuming normal writes from stop for column family '"
         << info.cf_name << "'";
+    } else {
+      LOG_TOPIC("9123f", INFO, Logger::ENGINES)
+        << "rocksdb is resuming normal writes from stall for column family '"
+        << info.cf_name << "'";
+    }
   }
 }
 

--- a/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
@@ -61,7 +61,7 @@ void RocksDBMetricsListener::OnStallConditionsChanged(const rocksdb::WriteStallI
         << "rocksdb is resuming normal writes from stop for column family '"
         << info.cf_name << "'";
     } else {
-      LOG_TOPIC("9123f", INFO, Logger::ENGINES)
+      LOG_TOPIC("9123f", DEBUG, Logger::ENGINES)
         << "rocksdb is resuming normal writes from stall for column family '"
         << info.cf_name << "'";
     }


### PR DESCRIPTION
### Scope & Purpose

*As we are contantly in stall regime, stall related log messages are demoted to `DEBUG`*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [X] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

