### PR TITLE
[3.9] debug logging for rocksdb stall events only

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.9.1 (XXXX-XX-XX)
 -------------------
 
+* As we are now in constant stall regime, stall onset and warnings are
+  demoted to DEBUG.
+
 * Shorten the license grace period to the documented 3 hours.
 
 * Replaced internal JS dependency xmldom with @xmldom/xmldom.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.9.1 (XXXX-XX-XX)
 -------------------
 
-* As we are now in constant stall regime, stall onset and warnings are
-  demoted to DEBUG.
+* As we are now in constant stall regime, stall onset and warnings are demoted
+  to DEBUG.
 
 * Shorten the license grace period to the documented 3 hours.
 

--- a/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
@@ -65,12 +65,12 @@ void RocksDBMetricsListener::OnStallConditionsChanged(
     TRI_ASSERT(info.condition.cur == rocksdb::WriteStallCondition::kNormal);
     if (info.condition.prev == rocksdb::WriteStallCondition::kStopped) {
       LOG_TOPIC("9123e", INFO, Logger::ENGINES)
-        << "rocksdb is resuming normal writes from stop for column family '"
-        << info.cf_name << "'";
+          << "rocksdb is resuming normal writes from stop for column family '"
+          << info.cf_name << "'";
     } else {
       LOG_TOPIC("9123f", INFO, Logger::ENGINES)
-        << "rocksdb is resuming normal writes from stall for column family '"
-        << info.cf_name << "'";
+          << "rocksdb is resuming normal writes from stall for column family '"
+          << info.cf_name << "'";
     }
   }
 }

--- a/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
@@ -68,7 +68,7 @@ void RocksDBMetricsListener::OnStallConditionsChanged(
           << "rocksdb is resuming normal writes from stop for column family '"
           << info.cf_name << "'";
     } else {
-      LOG_TOPIC("9123f", INFO, Logger::ENGINES)
+      LOG_TOPIC("9123f", DEBUG, Logger::ENGINES)
           << "rocksdb is resuming normal writes from stall for column family '"
           << info.cf_name << "'";
     }

--- a/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
@@ -53,7 +53,7 @@ void RocksDBMetricsListener::OnStallConditionsChanged(
 
   if (info.condition.cur == rocksdb::WriteStallCondition::kDelayed) {
     _writeStalls.count();
-    LOG_TOPIC("9123c", WARN, Logger::ENGINES)
+    LOG_TOPIC("9123c", DEBUG, Logger::ENGINES)
         << "rocksdb is slowing incoming writes to column family '"
         << info.cf_name << "' to let background writes catch up";
   } else if (info.condition.cur == rocksdb::WriteStallCondition::kStopped) {
@@ -63,9 +63,15 @@ void RocksDBMetricsListener::OnStallConditionsChanged(
         << info.cf_name << "' to let background writes catch up";
   } else {
     TRI_ASSERT(info.condition.cur == rocksdb::WriteStallCondition::kNormal);
-    LOG_TOPIC("9123e", INFO, Logger::ENGINES)
-        << "rocksdb is resuming normal writes for column family '"
+    if (info.condition.prev == rocksdb::WriteStallCondition::kStopped) {
+      LOG_TOPIC("9123e", INFO, Logger::ENGINES)
+        << "rocksdb is resuming normal writes from stop for column family '"
         << info.cf_name << "'";
+    } else {
+      LOG_TOPIC("9123f", INFO, Logger::ENGINES)
+        << "rocksdb is resuming normal writes from stall for column family '"
+        << info.cf_name << "'";
+    }
   }
 }
 


### PR DESCRIPTION
### Scope & Purpose

*As we are contantly in stall regime, stall related log messages are demoted to `DEBUG`*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [X] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [X] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

