### PR TITLE
debug logging for rocksdb stall events only

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* As we are now in constant stall regime, stall onset and warnings are
+  demoted to DEBUG.
+
 * Allow early pruning (moving a FILTER condition into an IndexNode or
   EnumerateCollectionNode) in more cases than before. Previously, early
   pruning was only possible if the FILTER condition referred to exactly one

--- a/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
@@ -69,7 +69,7 @@ void RocksDBMetricsListener::OnStallConditionsChanged(
           << "rocksdb is resuming normal writes from stop for column family '"
           << info.cf_name << "'";
     } else {
-      LOG_TOPIC("9123f", INFO, Logger::ENGINES)
+      LOG_TOPIC("9123f", DEBUG, Logger::ENGINES)
           << "rocksdb is resuming normal writes from stall for column family '"
           << info.cf_name << "'";
     }

--- a/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
@@ -66,12 +66,12 @@ void RocksDBMetricsListener::OnStallConditionsChanged(
     TRI_ASSERT(info.condition.cur == rocksdb::WriteStallCondition::kNormal);
     if (info.condition.prev == rocksdb::WriteStallCondition::kStopped) {
       LOG_TOPIC("9123e", INFO, Logger::ENGINES)
-        << "rocksdb is resuming normal writes from stop for column family '"
-        << info.cf_name << "'";
+          << "rocksdb is resuming normal writes from stop for column family '"
+          << info.cf_name << "'";
     } else {
       LOG_TOPIC("9123f", INFO, Logger::ENGINES)
-        << "rocksdb is resuming normal writes from stall for column family '"
-        << info.cf_name << "'";
+          << "rocksdb is resuming normal writes from stall for column family '"
+          << info.cf_name << "'";
     }
   }
 }

--- a/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
@@ -54,7 +54,7 @@ void RocksDBMetricsListener::OnStallConditionsChanged(
 
   if (info.condition.cur == rocksdb::WriteStallCondition::kDelayed) {
     _writeStalls.count();
-    LOG_TOPIC("9123c", WARN, Logger::ENGINES)
+    LOG_TOPIC("9123c", DEBUG, Logger::ENGINES)
         << "rocksdb is slowing incoming writes to column family '"
         << info.cf_name << "' to let background writes catch up";
   } else if (info.condition.cur == rocksdb::WriteStallCondition::kStopped) {
@@ -64,9 +64,14 @@ void RocksDBMetricsListener::OnStallConditionsChanged(
         << info.cf_name << "' to let background writes catch up";
   } else {
     TRI_ASSERT(info.condition.cur == rocksdb::WriteStallCondition::kNormal);
-    LOG_TOPIC("9123e", INFO, Logger::ENGINES)
-        << "rocksdb is resuming normal writes for column family '"
-        << info.cf_name << "'";
+    if ()
+      LOG_TOPIC("9123e",
+                (info.condition.prev == rocksdb::WriteStallCondition::kStopped)
+                    ? INFO
+                    : DEBUG,
+                Logger::ENGINES)
+          << "rocksdb is resuming normal writes for column family '"
+          << info.cf_name << "'";
   }
 }
 

--- a/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
@@ -64,14 +64,15 @@ void RocksDBMetricsListener::OnStallConditionsChanged(
         << info.cf_name << "' to let background writes catch up";
   } else {
     TRI_ASSERT(info.condition.cur == rocksdb::WriteStallCondition::kNormal);
-    if ()
-      LOG_TOPIC("9123e",
-                (info.condition.prev == rocksdb::WriteStallCondition::kStopped)
-                    ? INFO
-                    : DEBUG,
-                Logger::ENGINES)
-          << "rocksdb is resuming normal writes for column family '"
-          << info.cf_name << "'";
+    if (info.condition.prev == rocksdb::WriteStallCondition::kStopped) {
+      LOG_TOPIC("9123e", INFO, Logger::ENGINES)
+        << "rocksdb is resuming normal writes from stop for column family '"
+        << info.cf_name << "'";
+    } else {
+      LOG_TOPIC("9123f", INFO, Logger::ENGINES)
+        << "rocksdb is resuming normal writes from stall for column family '"
+        << info.cf_name << "'";
+    }
   }
 }
 


### PR DESCRIPTION
### Scope & Purpose

*As we are contantly in stall regime, stall related log messages are demoted to `DEBUG`*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [X] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [X] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *https://github.com/arangodb/arangodb/pull/15745*
  - [ ] Backport for 3.8: *https://github.com/arangodb/arangodb/pull/15744*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

