### PR TITLE
avoid deadlock in agency

### DIFF
--- a/arangod/Agency/Inception.h
+++ b/arangod/Agency/Inception.h
@@ -75,8 +75,8 @@ class Inception : public Thread {
   Agent& _agent;                            //< @brief The agent
   arangodb::basics::ConditionVariable _cv;  //< @brief For proper shutdown
   std::unordered_map<std::string, size_t>
-      _acked;                      //< @brief acknowledged config version
-  mutable arangodb::Mutex _vLock;  //< @brieg Guard _acked
+      _acked;                        //< @brief acknowledged config version
+  mutable arangodb::Mutex _ackLock;  //< @brieg Guard _acked
 };
 
 }  // namespace consensus


### PR DESCRIPTION
### Scope & Purpose

Avoid a deadlock in agency, when Inception::gossip() acquired a mutex, then could call Agent under the mutex, and Agent could finally could call Inception::signalConditionVar(), which would try to acquire the mutex again.

It is yet unclear if this needs to be backported.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

