### PR TITLE
Improve SIGHUP handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 devel
 -----
+
+* Avoid multiple parallel SIGHUP requests to be handled at the same time.
+  Now collapse multiple incoming SIGHUP requests into a single one, which can
+  be executed race-free.
+
 * Support JSON schema objects for documenting Foxx endpoints.
 
 * Sorted out various geo problems:

--- a/arangod/Scheduler/SchedulerFeature.cpp
+++ b/arangod/Scheduler/SchedulerFeature.cpp
@@ -23,6 +23,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <limits>
 #include <thread>
 
 #include "SchedulerFeature.h"
@@ -65,6 +66,17 @@ size_t defaultNumberOfThreads() {
   }
   return result;
 }
+
+// atomic flag to track shutdown requests
+std::atomic<bool> receivedShutdownRequest{false};
+
+#ifndef _WIN32
+// id of process that will not be used to send SIGHUP requests
+constexpr pid_t processIdUnspecified{std::numeric_limits<pid_t>::min()};
+
+// id of process that requested a log rotation via SIGHUP
+std::atomic<pid_t> processIdRequestingLogRotate{processIdUnspecified};
+#endif
 
 }  // namespace
 
@@ -373,15 +385,12 @@ bool CtrlHandler(DWORD eventType) {
     return true;
   }
 
-  static bool seen = false;
-
-  if (!seen) {
+  if (!::receivedShutdownRequest.exchange(true)) {
     LOG_TOPIC("3278a", INFO, arangodb::Logger::FIXME)
         << shutdownMessage << ", beginning shut down sequence";
 
     application_features::ApplicationServer::CTRL_C.store(true);
 
-    seen = true;
     return true;
   }
 
@@ -399,15 +408,10 @@ bool CtrlHandler(DWORD eventType) {
 
 extern "C" void c_exit_handler(int signal, siginfo_t* info, void*) {
   if (signal == SIGQUIT || signal == SIGTERM || signal == SIGINT) {
-    static std::atomic<bool> seen{false};
-
-    if (!seen.exchange(true)) {
-      std::string sender =
-          info ? std::to_string(info->si_pid) : std::string("unknown");
+    if (!::receivedShutdownRequest.exchange(true)) {
       LOG_TOPIC("b4133", INFO, arangodb::Logger::FIXME)
-          << signals::name(signal) << " received (sender pid " << sender
-          << "), beginning shut down sequence";
-
+          << signals::name(signal) << " received (sender pid "
+          << (info ? info->si_pid : 0) << "), beginning shut down sequence";
       application_features::ApplicationServer::CTRL_C.store(true);
     } else {
       LOG_TOPIC("11ca3", FATAL, arangodb::Logger::FIXME)
@@ -420,15 +424,37 @@ extern "C" void c_exit_handler(int signal, siginfo_t* info, void*) {
 }
 
 extern "C" void c_hangup_handler(int signal, siginfo_t* info, void*) {
-  if (signal == SIGHUP) {
-    std::string sender =
-        info ? std::to_string(info->si_pid) : std::string("unknown");
-    LOG_TOPIC("33eae", INFO, arangodb::Logger::FIXME)
-        << "hangup received, about to reopen logfile (sender pid " << sender
-        << ")";
-    LogAppender::reopen();
-    LOG_TOPIC("23db2", INFO, arangodb::Logger::FIXME)
-        << "hangup received, reopened logfile";
+  TRI_ASSERT(signal == SIGHUP);
+
+  // id of process that issued the SIGHUP
+  pid_t processIdRequesting = info ? info->si_pid : 0;
+  // the expected process id that we want to see
+  pid_t processIdExpected = ::processIdUnspecified;
+
+  // only set log rotate request if we don't have one queued already. this
+  // prevents duplicate execution of log rotate requests.
+  // if the CAS fails, it doesn't matter, because it means that a log rotate
+  // request was already queued
+  ::processIdRequestingLogRotate.compare_exchange_strong(processIdExpected,
+                                                         processIdRequesting);
+
+  bool queued = SchedulerFeature::SCHEDULER->tryBoundedQueue(
+      RequestLane::CLIENT_SLOW, [processIdRequesting]() {
+        try {
+          LOG_TOPIC("33eae", INFO, arangodb::Logger::FIXME)
+              << "hangup received, about to reopen logfile (sender pid "
+              << processIdRequesting << ")";
+          LogAppender::reopen();
+          LOG_TOPIC("23db2", INFO, arangodb::Logger::FIXME)
+              << "hangup received, reopened logfile";
+        } catch (...) {
+          // cannot do much if log rotate request goes wrong
+        }
+        ::processIdRequestingLogRotate.store(::processIdUnspecified);
+      });
+  if (!queued) {
+    // in case we couldn't queue the log rotate request, just give up
+    ::processIdRequestingLogRotate.store(::processIdUnspecified);
   }
 }
 #endif
@@ -445,7 +471,7 @@ void SchedulerFeature::buildHangupHandler() {
 
   if (res < 0) {
     LOG_TOPIC("b7ed0", ERR, arangodb::Logger::FIXME)
-        << "cannot initialize signal handlers for hang up";
+        << "cannot initialize signal handler for hang up";
   }
 #endif
 }

--- a/arangod/Scheduler/SchedulerFeature.h
+++ b/arangod/Scheduler/SchedulerFeature.h
@@ -28,6 +28,9 @@
 #include "Scheduler/SupervisedScheduler.h"
 #include "RestServer/arangod.h"
 
+#include <functional>
+#include <memory>
+
 namespace arangodb {
 
 class SchedulerFeature final : public ArangodFeature {
@@ -46,7 +49,16 @@ class SchedulerFeature final : public ArangodFeature {
   void stop() override final;
   void unprepare() override final;
 
+  // -------------------------------------------------------------------------
+  // UNRELATED SECTION STARTS HERE: Signals and other things crept into Sched
+  // -------------------------------------------------------------------------
+  void buildControlCHandler();
+  void buildHangupHandler();
+
  private:
+  void signalStuffInit();
+  void signalStuffDeinit();
+
   uint64_t _nrMinimalThreads = 4;
   uint64_t _nrMaximalThreads = 0;
   uint64_t _queueSize = 4096;
@@ -58,23 +70,11 @@ class SchedulerFeature final : public ArangodFeature {
 
   std::unique_ptr<Scheduler> _scheduler;
 
-  // -------------------------------------------------------------------------
-  // UNRELATED SECTION STARTS HERE: Signals and other things crept into Sched
-  // -------------------------------------------------------------------------
-
- public:
-  void buildControlCHandler();
-  void buildHangupHandler();
-
- private:
-  void signalStuffInit();
-  void signalStuffDeinit();
-
-  std::function<void(const asio_ns::error_code&, int)> _signalHandler;
-  std::function<void(const asio_ns::error_code&, int)> _exitHandler;
+  std::function<void(asio_ns::error_code const&, int)> _signalHandler;
+  std::function<void(asio_ns::error_code const&, int)> _exitHandler;
   std::shared_ptr<asio_ns::signal_set> _exitSignals;
 
-  std::function<void(const asio_ns::error_code&, int)> _hangupHandler;
+  std::function<void(asio_ns::error_code const&, int)> _hangupHandler;
   std::shared_ptr<asio_ns::signal_set> _hangupSignals;
 };
 

--- a/arangod/Scheduler/SupervisedScheduler.cpp
+++ b/arangod/Scheduler/SupervisedScheduler.cpp
@@ -493,7 +493,7 @@ void SupervisedScheduler::runWorker() {
   std::shared_ptr<WorkerState> state;
 
   {
-    std::lock_guard<std::mutex> guard1(_mutex);
+    std::lock_guard<std::mutex> guard(_mutex);
     id =
         _numWorkers++;  // increase the number of workers here, to obtain the id
     // copy shared_ptr with worker state

--- a/lib/Basics/signals.cpp
+++ b/lib/Basics/signals.cpp
@@ -33,12 +33,11 @@
 #endif
 #include <sys/types.h>
 
-namespace arangodb {
-namespace signals {
+namespace arangodb::signals {
 
 #ifndef _WIN32
 /// @brief find out what impact a signal will have to the process we send it.
-SignalType signalType(int signal) {
+SignalType signalType(int signal) noexcept {
   // Some platforms don't have these. To keep our table clean
   // we just define them here:
 #ifndef SIGPOLL
@@ -125,7 +124,7 @@ SignalType signalType(int signal) {
 #endif
 
 /// @brief whether or not the signal is deadly
-bool isDeadly(int signal) {
+bool isDeadly(int signal) noexcept {
 #ifndef _WIN32
   switch (signalType(signal)) {
     case SignalType::term:
@@ -149,7 +148,7 @@ bool isDeadly(int signal) {
 }
 
 /// @brief return the name for a signal
-char const* name(int signal) {
+std::string_view name(int signal) noexcept {
   if (signal >= 128) {
     signal -= 128;
   }
@@ -261,5 +260,4 @@ void unmaskAllSignals() {
 #endif
 }
 
-}  // namespace signals
-}  // namespace arangodb
+}  // namespace arangodb::signals

--- a/lib/Basics/signals.h
+++ b/lib/Basics/signals.h
@@ -23,26 +23,26 @@
 
 #pragma once
 
-namespace arangodb {
-namespace signals {
+#include <string_view>
+
+namespace arangodb::signals {
 
 enum class SignalType { term, core, cont, ign, logrotate, stop, user };
 
 /// @brief find out what impact a signal will have to the process we send it.
 #ifndef _WIN32
-SignalType signalType(int signal);
+SignalType signalType(int signal) noexcept;
 #endif
 
 /// @brief whether or not the signal is deadly
-bool isDeadly(int signal);
+bool isDeadly(int signal) noexcept;
 
 /// @brief return the name for a signal
-char const* name(int signal);
+std::string_view name(int signal) noexcept;
 
 void maskAllSignals();
 void maskAllSignalsServer();
 void maskAllSignalsClient();
 void unmaskAllSignals();
 
-}  // namespace signals
-}  // namespace arangodb
+}  // namespace arangodb::signals


### PR DESCRIPTION
### Scope & Purpose

* Avoid multiple parallel SIGHUP requests to be handled at the same time.
  Now collapse multiple incoming SIGHUP requests into a single one, which can
  be executed race-free.

Backports may follow later if so decided.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 