### PR TITLE
Fix counts and size sum in hotbackup META files APM-409

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+v3.7.18 (XXXX-XX-XX)
+--------------------
+
+* Fix counts and file size sum in hotbackup META files. Do no longer count
+  directories.
+
+
 v3.7.17 (2022-01-25)
 --------------------
 

--- a/arangod/StorageEngine/HotBackupCommon.h
+++ b/arangod/StorageEngine/HotBackupCommon.h
@@ -54,6 +54,7 @@ struct BackupMeta {
   bool _potentiallyInconsistent;
   bool _isAvailable;
   unsigned int _nrPiecesPresent;
+  bool _countIncludesFilesOnly;
 
   static constexpr const char *ID = "id";
   static constexpr const char *VERSION = "version";
@@ -66,6 +67,8 @@ struct BackupMeta {
   static constexpr const char *POTENTIALLYINCONSISTENT = "potentiallyInconsistent";
   static constexpr const char *AVAILABLE = "available";
   static constexpr const char *NRPIECESPRESENT = "nrPiecesPresent";
+  static constexpr const char *COUNTINCLUDESFILESONLY =
+      "countIncludesFilesOnly";
 
 
   void toVelocyPack(VPackBuilder &builder) const {
@@ -92,6 +95,7 @@ struct BackupMeta {
         builder.add(NRPIECESPRESENT, VPackValue(_nrPiecesPresent));
       }
       builder.add(POTENTIALLYINCONSISTENT, VPackValue(_potentiallyInconsistent));
+      builder.add(COUNTINCLUDESFILESONLY, VPackValue(_countIncludesFilesOnly));
     }
   }
 
@@ -121,6 +125,8 @@ struct BackupMeta {
       meta._isAvailable = basics::VelocyPackHelper::getBooleanValue(slice, AVAILABLE, true);
       meta._nrPiecesPresent = basics::VelocyPackHelper::getNumericValue<unsigned int>(
           slice, NRPIECESPRESENT, 1);
+      meta._countIncludesFilesOnly = basics::VelocyPackHelper::getBooleanValue(
+          slice, COUNTINCLUDESFILESONLY, false);
       return meta;
     } catch (std::exception const& e) {
       return ResultT<BackupMeta>::error(TRI_ERROR_BAD_PARAMETER, e.what());
@@ -132,7 +138,7 @@ struct BackupMeta {
              size_t nrFiles, unsigned int nrDBServers, std::string const& serverId, bool potentiallyInconsistent) :
     _id(id), _version(version), _datetime(datetime), _userSecretHashes(hashes),
     _sizeInBytes(sizeInBytes), _nrFiles(nrFiles), _nrDBServers(nrDBServers),
-    _serverId(serverId), _potentiallyInconsistent(potentiallyInconsistent),_isAvailable(true), _nrPiecesPresent(1) {}
+    _serverId(serverId), _potentiallyInconsistent(potentiallyInconsistent),_isAvailable(true), _nrPiecesPresent(1), _countIncludesFilesOnly(true) {}
 
 private:
   BackupMeta() {}


### PR DESCRIPTION
This is a small bug fix to get the counts and file size sum in hotbackup
META files correct. The problem was that due to a bug in the accounting
directories have been counted, rendering the sums incorrect. This PR
is accompanied by an enterprise PR and together they fix the sums and
add a new filed to recognize new style META files.

- Get counts in hotbackup META files right.
- CHANGELOG.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] **integration tests**, see enterprise repo
  - [x] **release test automation** also has a test now
- [x] :book: CHANGELOG entry made
- [x] Backports
  - [x] This is the backport for 3.7 for: https://github.com/arangodb/arangodb/pull/15757

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/889
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/APM-409
      This is the first quick step towards fulfilling this ticket.





